### PR TITLE
fix: only restart fleet on rebuild & ignore paths

### DIFF
--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -17,6 +17,11 @@ services:
             - testing/
             - "**/*.http"
             - "**/*.md"
+            - "**/*.yaml"
+            - "**/*.yml"
+            - "**/*.json"
+            - "**/*.sh"
+            - "**/Dockerfile"
     environment:
       AUTH_CLIENT_SECRET_KEY: "${AUTH_CLIENT_SECRET_KEY:-00000000000000000000000000000000000000000000}"
       AUTH_CLIENT_EXPIRATION_PERIOD: "168h" # Override to 168h for development

--- a/server/justfile
+++ b/server/justfile
@@ -19,7 +19,7 @@ install:
 
 # run local server in docker compose with watch enabled
 dev: _build-plugins-docker start
-  docker compose up --watch fleet-api --remove-orphans
+  docker compose up --watch fleet-api --remove-orphans --no-deps
 
 # start services in docker compose
 start:


### PR DESCRIPTION
Earlier `timescaledb` would stop whenever a rebuild of the go server started.
This prevents that case and also ignores more files that would cause unnecessary rebuilds.