### PR TITLE
Use Heading/200 (20px) for modal title bar text

### DIFF
--- a/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
+++ b/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
@@ -177,7 +177,7 @@ const FullScreenTwoPaneModal = ({
           <div className="sticky top-0 z-10 mb-6 bg-surface-base px-6 pt-4 pb-4 phone:mb-0 tablet:mb-0 laptop:static desktop:static">
             <Header
               title={title}
-              titleSize="text-heading-300"
+              titleSize="text-heading-200"
               stackButtonsOnPhone={false}
               iconAriaLabel={closeAriaLabel}
               icon={<Dismiss className={isBusy ? "cursor-default text-text-primary-30" : "cursor-pointer"} />}

--- a/client/src/shared/components/Modal/Modal.tsx
+++ b/client/src/shared/components/Modal/Modal.tsx
@@ -170,7 +170,7 @@ const Modal = ({
             >
               <Header
                 title={showTitleInHeader ? title : undefined}
-                titleSize="text-heading-300"
+                titleSize="text-heading-200"
                 {...headerIconProps}
                 buttonSize={buttonSize}
                 buttonsWrapperClassName={hasPhoneFooterButtons ? "phone:hidden" : undefined}


### PR DESCRIPTION
## Summary
- Modal and FullScreenTwoPaneModal headers were using `text-heading-300`; design calls for `text-heading-200` (20px).
- Two-line change: swap the `titleSize` prop on both `Header` usages.

## Test plan
- [ ] Open any modal with a title — verify title renders at 20px (Heading/200).
- [ ] Open a FullScreenTwoPaneModal — verify title renders at 20px.