### PR TITLE
Fix login modal layout regression in ResizeablePanel

### DIFF
--- a/client/src/protoOS/features/auth/components/LoginModal/ResizeablePanel.tsx
+++ b/client/src/protoOS/features/auth/components/LoginModal/ResizeablePanel.tsx
@@ -26,7 +26,7 @@ const ResizeablePanel = ({ children, resizeOn, className }: Props) => {
           exit={{ opacity: 0, transition: { duration: 0.2, ease: easeGentle } }}
           transition={{ duration: 0.5, delay: 0.1 }}
         >
-          <div ref={ref} className={clsx("absolute", className)}>
+          <div ref={ref} className={clsx("absolute inset-x-0", className)}>
             {children}
           </div>
         </motion.div>


### PR DESCRIPTION
## Summary
- The absolutely-positioned inner div in `ResizeablePanel` lost its horizontal stretch, causing children to collapse to intrinsic width.
- Adds `inset-x-0` back alongside `absolute` so children fill the panel.

## Test plan
- [ ] Open the Log in modal — verify the form fills the panel width and resizes correctly when toggling between login / forgot-password views.