### PR TITLE
Use standard 640px width for miner status modal

### DIFF
--- a/client/src/shared/components/StatusModal/StatusModal.tsx
+++ b/client/src/shared/components/StatusModal/StatusModal.tsx
@@ -44,7 +44,6 @@ export function StatusModal<TComponentAddress = any>({
         onIconClick={showBack ? componentData.onNavigateBack : undefined}
         onDismiss={componentData.onDismiss}
         open={open}
-        size="large"
       >
         <ComponentStatusModalContent {...componentData.props} />
       </Modal>
@@ -54,7 +53,7 @@ export function StatusModal<TComponentAddress = any>({
   // Fall back to miner status view
   const minerData = getMinerStatus();
   return (
-    <Modal title={minerData.title} buttons={minerData.buttons} onDismiss={minerData.onDismiss} open={open} size="large">
+    <Modal title={minerData.title} buttons={minerData.buttons} onDismiss={minerData.onDismiss} open={open}>
       <MinerStatusModalContent {...minerData.props} />
     </Modal>
   );


### PR DESCRIPTION
## Summary
- `StatusModal` was forcing `size="large"` on both the component and miner status `Modal`s.
- Drops the override so miner status falls back to the default 640px width, matching other status modals.

## Test plan
- [ ] Open a miner status modal — verify it renders at 640px wide.
- [ ] Open a component status modal — verify it also renders at 640px wide.