### PR TITLE
Updated github paths from `btc-mining` to `block`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/btc-mining/proto-fleet" target="_blank" rel="noopener noreferrer">
+  <a href="https://github.com/block/proto-fleet" target="_blank" rel="noopener noreferrer">
     <img width="64" src="docs/logo.svg" alt="Proto logo">
   </a>
 </p>
@@ -17,14 +17,14 @@
   <a href="LICENSE">
     <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Proto Fleet is released under the Apache 2.0 license." />
   </a>
-  <a href="https://github.com/btc-mining/proto-fleet/actions/workflows/protofleet-client-checks.yml">
-    <img src="https://github.com/btc-mining/proto-fleet/actions/workflows/protofleet-client-checks.yml/badge.svg" alt="Client checks status." />
+  <a href="https://github.com/block/proto-fleet/actions/workflows/protofleet-client-checks.yml">
+    <img src="https://github.com/block/proto-fleet/actions/workflows/protofleet-client-checks.yml/badge.svg" alt="Client checks status." />
   </a>
-  <a href="https://github.com/btc-mining/proto-fleet/actions/workflows/protofleet-server-checks.yml">
-    <img src="https://github.com/btc-mining/proto-fleet/actions/workflows/protofleet-server-checks.yml/badge.svg" alt="Server checks status." />
+  <a href="https://github.com/block/proto-fleet/actions/workflows/protofleet-server-checks.yml">
+    <img src="https://github.com/block/proto-fleet/actions/workflows/protofleet-server-checks.yml/badge.svg" alt="Server checks status." />
   </a>
-  <a href="https://github.com/btc-mining/proto-fleet/actions/workflows/protofleet-e2e-tests.yml">
-    <img src="https://github.com/btc-mining/proto-fleet/actions/workflows/protofleet-e2e-tests.yml/badge.svg" alt="E2E tests status." />
+  <a href="https://github.com/block/proto-fleet/actions/workflows/protofleet-e2e-tests.yml">
+    <img src="https://github.com/block/proto-fleet/actions/workflows/protofleet-e2e-tests.yml/badge.svg" alt="E2E tests status." />
   </a>
 </p>
 

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -14,7 +14,7 @@ Before running the install script:
 ## Installing Proto Fleet
 
 ```bash
-bash <(curl -fsSL https://github.com/btc-mining/proto-fleet/releases/latest/download/install.sh)
+bash <(curl -fsSL https://github.com/block/proto-fleet/releases/latest/download/install.sh)
 ```
 
 The `install.sh` script sets up the Proto Fleet server components.
@@ -33,10 +33,10 @@ Examples:
 
 ```bash
 # Install the latest version
-bash <(curl -fsSL https://github.com/btc-mining/proto-fleet/releases/latest/download/install.sh)
+bash <(curl -fsSL https://github.com/block/proto-fleet/releases/latest/download/install.sh)
 
 # Install a specific version
-bash <(curl -fsSL https://github.com/btc-mining/proto-fleet/releases/latest/download/install.sh) v0.1.0-beta-5
+bash <(curl -fsSL https://github.com/block/proto-fleet/releases/latest/download/install.sh) v0.1.0-beta-5
 ```
 
 The script will:
@@ -49,13 +49,13 @@ The script will:
 ## Uninstalling Proto Fleet
 
 ```bash
-bash <(curl -fsSL https://github.com/btc-mining/proto-fleet/releases/latest/download/uninstall.sh)
+bash <(curl -fsSL https://github.com/block/proto-fleet/releases/latest/download/uninstall.sh)
 ```
 
 If Proto Fleet was installed in a non-default location, pass it explicitly:
 
 ```bash
-bash <(curl -fsSL https://github.com/btc-mining/proto-fleet/releases/latest/download/uninstall.sh) --deployment-path /path/to/install/root
+bash <(curl -fsSL https://github.com/block/proto-fleet/releases/latest/download/uninstall.sh) --deployment-path /path/to/install/root
 ```
 
 ### SSL/TLS Configuration

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -67,7 +67,7 @@ EOF
 resolve_latest_version() {
   local latest_release_url effective_url curl_stderr
 
-  latest_release_url="https://github.com/btc-mining/proto-fleet/releases/latest"
+  latest_release_url="https://github.com/block/proto-fleet/releases/latest"
   echo "🛰  Determining latest version from ${latest_release_url}" >&2
 
   curl_stderr=$(mktemp)

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -123,7 +123,7 @@ fi
 
 check_page_size
 
-GITHUB_RELEASES_URL="https://github.com/btc-mining/proto-fleet/releases"
+GITHUB_RELEASES_URL="https://github.com/block/proto-fleet/releases"
 
 # determine version and tarball name
 if [[ -n "${1:-}" && "${1:-}" != "latest" ]]; then


### PR DESCRIPTION
## Summary
- Updated the repo and deployment READMEs to link to **this** repo instead of the old `btc-mining` repo

## Test plan
- No functional changes