### PR TITLE
fix: show Racks above Groups in sidebar nav

### DIFF
--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -28,14 +28,14 @@ export const primaryNavItems: NavItem[] = [
     icon: Fleet,
   },
   {
-    path: "/groups",
-    label: "Groups",
-    icon: Groups,
-  },
-  {
     path: "/racks",
     label: "Racks",
     icon: Racks,
+  },
+  {
+    path: "/groups",
+    label: "Groups",
+    icon: Groups,
   },
   {
     path: "/activity",


### PR DESCRIPTION
## Summary
- Swap order of Racks and Groups entries in `primaryNavItems` so the sidebar reads Home, Miners, Racks, Groups, Activity, Settings.

## Test plan
- [ ] Visual check sidebar order in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)