### PR TITLE
refactor: abstract null state component and simplify settings empty states

### DIFF
--- a/client/src/protoFleet/components/NullState.tsx
+++ b/client/src/protoFleet/components/NullState.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import clsx from "clsx";
+
+import Header from "@/shared/components/Header";
+
+interface NullStateProps {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+  testId?: string;
+}
+
+const NullState = ({ icon, title, description, action, className, testId }: NullStateProps) => (
+  <div className={clsx("flex h-full flex-col justify-center p-6 sm:p-10", className)} data-testid={testId}>
+    <div className="flex h-full w-full flex-col justify-center rounded-xl bg-core-primary-5 px-6 py-10 sm:px-20 sm:py-10">
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4">
+          {icon && (
+            <div className="bg-core-surface-5 flex h-10 w-10 items-center justify-center rounded-lg">{icon}</div>
+          )}
+          <Header title={title} titleSize="text-display-200" description={description} />
+        </div>
+        {action && <div>{action}</div>}
+      </div>
+    </div>
+  </div>
+);
+
+export default NullState;

--- a/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
@@ -10,6 +10,7 @@ import {
   useIssueFilter,
 } from "@/protoFleet/components/DeviceSetList";
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
+import NullState from "@/protoFleet/components/NullState";
 import GroupModal from "@/protoFleet/features/groupManagement/components/GroupModal";
 import GroupNameCell from "@/protoFleet/features/groupManagement/components/GroupsTable/GroupNameCell";
 import { useDeviceSetListState } from "@/protoFleet/hooks/useDeviceSetListState";
@@ -17,7 +18,6 @@ import { useDeviceSetListState } from "@/protoFleet/hooks/useDeviceSetListState"
 import { Alert, DismissTiny, Groups } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
-import Header from "@/shared/components/Header";
 import DropdownFilter from "@/shared/components/List/Filters/DropdownFilter";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 
@@ -138,23 +138,16 @@ const GroupsPage = () => {
   return (
     <>
       {!hasGroups ? (
-        <div className="flex h-full flex-col justify-center p-6 sm:p-10">
-          <div className="flex h-full w-full flex-col justify-center rounded-xl bg-surface-5 px-6 py-10 sm:px-20 sm:py-10 dark:bg-surface-base">
-            <div className="flex flex-col gap-6">
-              <div className="flex flex-col gap-4">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-core-primary-5">
-                  <Groups width="w-5" />
-                </div>
-                <Header title="Groups" titleSize="text-display-200" description="Organize your miners into groups." />
-              </div>
-              <div>
-                <Button variant="primary" onClick={() => setShowGroupModal(true)}>
-                  Add group
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <NullState
+          icon={<Groups width="w-5" />}
+          title="Groups"
+          description="Organize your miners into groups."
+          action={
+            <Button variant="primary" onClick={() => setShowGroupModal(true)}>
+              Add group
+            </Button>
+          }
+        />
       ) : (
         <>
           <div className="sticky left-0 z-3 px-10 pt-10 phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6">

--- a/client/src/protoFleet/features/onboarding/components/Miners/Miners.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/Miners.tsx
@@ -5,6 +5,7 @@ import FoundMinersModal from "./FoundMinersModal";
 import { MinerDiscoveryMode } from "./types";
 import ValidationErrorDialog from "./ValidationErrorDialog";
 import { Device } from "@/protoFleet/api/generated/pairing/v1/pairing_pb";
+import NullState from "@/protoFleet/components/NullState";
 import { Dismiss, LogoAlt } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Dialog from "@/shared/components/Dialog";
@@ -178,27 +179,20 @@ const Miners = ({
   }
 
   return (
-    <div className="h-[calc(100vh-theme(spacing.1)*15)] p-6 sm:p-10">
+    <div className="h-[calc(100vh-theme(spacing.1)*15)]">
       <Dialog open={pairingPending} title="Pairing the found miners" subtitle="This may take a few seconds" loading />
 
       {mode === "onboarding" && (
-        <div className="flex h-full w-full items-center rounded-xl bg-landing-page p-6 sm:p-20">
-          <div className="flex flex-col gap-12">
-            <div className="flex flex-col gap-4">
-              <LogoAlt width="w-[48px]" />
-              <Header
-                title="Let's setup your fleet."
-                titleSize="text-display-200"
-                description="Add miners to your fleet to get started."
-              />
-            </div>
-            <div>
-              <Button variant="primary" onClick={() => setShowModal(true)}>
-                Get started
-              </Button>
-            </div>
-          </div>
-        </div>
+        <NullState
+          icon={<LogoAlt width="w-5" />}
+          title="Let's setup your fleet."
+          description="Add miners to your fleet to get started."
+          action={
+            <Button variant="primary" onClick={() => setShowModal(true)}>
+              Get started
+            </Button>
+          }
+        />
       )}
 
       <PageOverlay open={mode === "pairing" || showModal} zIndex="z-50">

--- a/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
@@ -6,6 +6,7 @@ import type { DeviceSetColumn } from "@/protoFleet/components/DeviceSetList";
 import { DEFAULT_PAGE_SIZE, DeviceSetList, issueOptions, useIssueFilter } from "@/protoFleet/components/DeviceSetList";
 import { getNextSortFromSelection, RACK_SORT_OPTIONS } from "@/protoFleet/components/DeviceSetList/sortConfig";
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
+import NullState from "@/protoFleet/components/NullState";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import {
   AssignMinersModal,
@@ -20,7 +21,6 @@ import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 import { Alert, ChevronDown, DismissTiny, Racks } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
-import Header from "@/shared/components/Header";
 import DropdownFilter from "@/shared/components/List/Filters/DropdownFilter";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import SegmentedControl from "@/shared/components/SegmentedControl";
@@ -268,26 +268,17 @@ const RacksPage = () => {
 
   if (!hasRacks) {
     return (
-      <div className="flex h-full flex-col justify-center p-6 sm:p-10">
-        <div className="flex h-full w-full flex-col justify-center rounded-xl bg-surface-5 px-6 py-10 sm:px-20 sm:py-10 dark:bg-surface-base">
-          <div className="flex flex-col gap-6">
-            <div className="flex flex-col gap-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-core-primary-5">
-                <Racks width="w-5" />
-              </div>
-              <Header
-                title="You haven't set up any racks"
-                titleSize="text-display-200"
-                description="Add a rack and assign miners to rack positions to get started."
-              />
-            </div>
-            <div>
-              <Button variant="primary" onClick={() => setShowRackSettingsModal(true)}>
-                Add rack
-              </Button>
-            </div>
-          </div>
-        </div>
+      <>
+        <NullState
+          icon={<Racks width="w-5" />}
+          title="You haven't set up any racks"
+          description="Add a rack and assign miners to rack positions to get started."
+          action={
+            <Button variant="primary" onClick={() => setShowRackSettingsModal(true)}>
+              Add rack
+            </Button>
+          }
+        />
         {showRackSettingsModal && (
           <RackSettingsModal
             show={showRackSettingsModal}
@@ -307,7 +298,7 @@ const RacksPage = () => {
             onDelete={assignMinersRackId ? handleDeleteRack : undefined}
           />
         )}
-      </div>
+      </>
     );
   }
 

--- a/client/src/protoFleet/features/settings/components/MiningPools.test.tsx
+++ b/client/src/protoFleet/features/settings/components/MiningPools.test.tsx
@@ -60,7 +60,7 @@ describe("MiningPools", () => {
       expect(spinner).toBeInTheDocument();
 
       // Should not show empty state or table content
-      expect(screen.queryByText("Add a pool to start assigning your miners.")).not.toBeInTheDocument();
+      expect(screen.queryByText(/No pools yet/)).not.toBeInTheDocument();
     });
   });
 
@@ -69,7 +69,7 @@ describe("MiningPools", () => {
       render(<MiningPools />);
 
       expect(screen.getAllByText("Pools").length).toBeGreaterThan(0);
-      expect(screen.getByText("Add a pool to start assigning your miners.")).toBeInTheDocument();
+      expect(screen.getByText(/No pools yet/)).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /add pool/i })).toBeInTheDocument();
     });
 

--- a/client/src/protoFleet/features/settings/components/MiningPools.tsx
+++ b/client/src/protoFleet/features/settings/components/MiningPools.tsx
@@ -1,5 +1,4 @@
 import { type RefObject, useCallback, useMemo, useState } from "react";
-import clsx from "clsx";
 import { create } from "@bufbuild/protobuf";
 
 import {
@@ -431,47 +430,6 @@ const MiningPools = () => {
     );
   }
 
-  // Empty state - no pools configured
-  if (pools.length === 0) {
-    return (
-      <>
-        <div
-          className={clsx("flex items-center rounded-xl bg-landing-page p-6 sm:p-20", {
-            "h-full": !isPhone && !isTablet,
-            "flex-1": isPhone || isTablet,
-          })}
-        >
-          <div className="flex flex-col gap-6">
-            <Header
-              title="Pools"
-              subtitle="Add a pool to start assigning your miners."
-              titleSize="text-heading-400"
-              subtitleSize="text-400"
-              subtitleClassName="mt-1"
-              className="items-center"
-            />
-            <Button variant={variants.primary} className="w-fit" onClick={() => setShowAddPoolModal(true)}>
-              Add pool
-            </Button>
-          </div>
-        </div>
-        <PoolModal
-          open={showAddPoolModal}
-          onChangePools={setPoolsInfo}
-          onDismiss={() => setShowAddPoolModal(false)}
-          poolIndex={0}
-          pools={poolsInfo}
-          isTestingConnection={validatePoolPending}
-          testConnection={validatePool}
-          onSave={handleSavePool}
-          usernameHelperText={fleetUsernameHelperText}
-          disallowUsernameSeparator
-        />
-      </>
-    );
-  }
-
-  // Show pools list when pools exist
   return (
     <>
       <div className="flex flex-col gap-6">
@@ -513,16 +471,22 @@ const MiningPools = () => {
 
           {/* Table body */}
           <div>
-            {pools.map((pool) => (
-              <PoolRowInner
-                key={pool.poolId.toString()}
-                pool={pool}
-                onEdit={handleEditPool}
-                onTestConnection={handleTestConnection}
-                onDelete={handleDeletePool}
-                connectionStatus={connectionStatuses[pool.poolId.toString()] || "idle"}
-              />
-            ))}
+            {pools.length === 0 ? (
+              <div className="py-10 text-center text-text-primary-50">
+                No pools yet. Add a pool to start assigning your miners.
+              </div>
+            ) : (
+              pools.map((pool) => (
+                <PoolRowInner
+                  key={pool.poolId.toString()}
+                  pool={pool}
+                  onEdit={handleEditPool}
+                  onTestConnection={handleTestConnection}
+                  onDelete={handleDeletePool}
+                  connectionStatus={connectionStatuses[pool.poolId.toString()] || "idle"}
+                />
+              ))
+            )}
           </div>
         </div>
       </div>

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
@@ -87,22 +87,19 @@ describe("SchedulesPage", () => {
 
     render(<SchedulesPage />);
 
-    expect(screen.queryByText("Configure schedules to automate actions for your miners.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/No schedules yet/)).not.toBeInTheDocument();
 
     deferred.resolve(undefined);
 
-    await waitFor(() =>
-      expect(screen.getByText("Configure schedules to automate actions for your miners.")).toBeVisible(),
-    );
+    await waitFor(() => expect(screen.getByText(/No schedules yet/)).toBeVisible());
   });
 
   it("renders the empty schedules state when no schedules exist", async () => {
     render(<SchedulesPage />);
 
     await waitFor(() => expect(screen.getAllByText("Schedules")).toHaveLength(1));
-    expect(screen.getByText("Configure schedules to automate actions for your miners.")).toBeVisible();
+    expect(screen.getByText(/No schedules yet/)).toBeVisible();
     expect(screen.getByRole("button", { name: "Add a schedule" })).toBeEnabled();
-    expect(screen.queryByRole("columnheader", { name: "Name" })).not.toBeInTheDocument();
     expect(mockScheduleModal).not.toHaveBeenCalled();
   });
 

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import clsx from "clsx";
 
 import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
 import { useScheduleApiContext } from "@/protoFleet/api/ScheduleApiContext";
@@ -30,7 +29,6 @@ import type { ActiveFilters } from "@/shared/components/List/Filters/types";
 import type { ListAction, SortDirection } from "@/shared/components/List/types";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
-import { useWindowDimensions } from "@/shared/hooks/useWindowDimensions";
 
 const defaultActiveFilters: ActiveFilters = {
   buttonFilters: ["all"],
@@ -49,7 +47,6 @@ const SchedulesPage = () => {
     deleteSchedule,
     reorderSchedules,
   } = useScheduleApiContext();
-  const { isPhone, isTablet } = useWindowDimensions();
   const [activeFilters, setActiveFilters] = useState<ActiveFilters>(defaultActiveFilters);
   const [currentSort, setCurrentSort] = useState<{ field: ScheduleColumn; direction: SortDirection }>();
   const [hasCompletedInitialLoad, setHasCompletedInitialLoad] = useState(false);
@@ -204,13 +201,15 @@ const SchedulesPage = () => {
     />
   ) : null;
 
-  const emptyStateRow = (
+  const emptyStateRow = filtersActive ? (
     <div className="flex flex-col items-center justify-center gap-1 py-12 text-center">
       <p className="text-heading-200 text-text-primary">No schedules match those filters</p>
       <p className="text-300 text-text-primary-70">
         Try clearing one or more filters to see the rest of your schedules.
       </p>
     </div>
+  ) : (
+    <div className="py-10 text-center text-text-primary-50">No schedules yet. {SCHEDULE_EMPTY_STATE_DESCRIPTION}</div>
   );
 
   if (isLoading || !hasCompletedInitialLoad) {
@@ -218,37 +217,6 @@ const SchedulesPage = () => {
       <div className="flex justify-center py-20">
         <ProgressCircular indeterminate />
       </div>
-    );
-  }
-
-  if (schedules.length === 0) {
-    return (
-      <>
-        <div
-          className={clsx("flex items-center rounded-xl bg-landing-page p-6 sm:p-20", {
-            "h-full": !isPhone && !isTablet,
-            "flex-1": isPhone || isTablet,
-          })}
-        >
-          <div className="flex flex-col gap-6">
-            <Header
-              title="Schedules"
-              subtitle={SCHEDULE_EMPTY_STATE_DESCRIPTION}
-              titleSize="text-heading-400"
-              subtitleSize="text-400"
-              subtitleClassName="mt-1"
-              className="items-center"
-            />
-            <Button
-              variant={variants.primary}
-              className="w-fit"
-              text="Add a schedule"
-              onClick={handleOpenCreateModal}
-            />
-          </div>
-        </div>
-        {scheduleModal}
-      </>
     );
   }
 
@@ -283,7 +251,7 @@ const SchedulesPage = () => {
         filters={scheduleFilters}
         filterItem={matchesScheduleFilters}
         onFilterChange={setActiveFilters}
-        emptyStateRow={filtersActive ? emptyStateRow : undefined}
+        emptyStateRow={emptyStateRow}
         sortableColumns={SORTABLE_COLUMNS}
         currentSort={currentSort}
         onSort={handleSort}


### PR DESCRIPTION
## Summary
- Adds a shared `NullState` component and uses it in GroupsPage, RacksPage, and the Miners onboarding screen so the three full-page empty states are now visually consistent.
- Removes the full-page empty states from Settings → Pools and Settings → Schedules; the page header and table are now always rendered, with an inline empty-row message matching the API keys pattern.
- Updates MiningPools and SchedulesPage tests to reflect the new empty-state copy and markup.

## Test plan
- [ ] Verify Groups, Racks, and the Miners onboarding screen render the shared null state when no entities exist
- [ ] Verify Settings → Pools renders the header, "Add pool" button, and inline "No pools yet" message when empty
- [ ] Verify Settings → Schedules renders the header, "Add a schedule" button, List, and inline "No schedules yet" message when empty
- [ ] Confirm filter-empty-state in Schedules still shows the "No schedules match those filters" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)