### PR TITLE
Reduce health bar segment spacing to 1px in racks/groups list pages

### DIFF
--- a/client/src/protoFleet/components/DeviceSetList/deviceSetColConfig.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/deviceSetColConfig.tsx
@@ -104,7 +104,7 @@ const createDeviceSetColConfig = ({
 
       return (
         <div className="w-34">
-          <CompositionBar segments={segments} height={6} colorMap={HEALTH_COLOR_MAP} />
+          <CompositionBar segments={segments} height={6} gap={0.25} colorMap={HEALTH_COLOR_MAP} />
         </div>
       );
     },

--- a/client/src/shared/components/CompositionBar/constants.ts
+++ b/client/src/shared/components/CompositionBar/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_GAP = 1;
  */
 export const GAP_CLASS_MAP: Record<number, string> = {
   0: "gap-0",
+  0.25: "gap-[1px]",
   1: "gap-1",
   2: "gap-2",
   3: "gap-3",

--- a/client/src/shared/components/CompositionBar/types.ts
+++ b/client/src/shared/components/CompositionBar/types.ts
@@ -25,7 +25,7 @@ export interface CompositionBarProps {
   className?: string;
   /** Height of the bar in pixels (default: 8) */
   height?: number;
-  /** Gap between segments (default: 2) - uses Tailwind gap classes (0-12) */
+  /** Gap between segments (default: 1) - uses Tailwind gap classes (0, 0.25 for 1px, 1-8) */
   gap?: number;
   /** Optional custom color mappings for status values */
   colorMap?: Partial<Record<Status, string>>;


### PR DESCRIPTION
## Summary

Reduces the spacing between segments in the mini health bar shown in the health column of racks and groups list pages from `gap-1` (4px) to `gap-[1px]` (1px).

## Changes

- **`CompositionBar/constants.ts`** — Added `0.25: "gap-[1px]"` entry to `GAP_CLASS_MAP` for 1px gap support
- **`CompositionBar/types.ts`** — Updated `gap` prop docs to document the new option
- **`deviceSetColConfig.tsx`** — Pass `gap={0.25}` to `CompositionBar` in the health column
- **`CompositionBar.test.tsx`** — Updated gap tests to match current implementation

The dashboard's larger FleetHealth bar is unaffected (keeps the default gap).