### PR TITLE
chore: improve test setup stability

### DIFF
--- a/client/e2eTests/protoFleet/pages/addMiners.ts
+++ b/client/e2eTests/protoFleet/pages/addMiners.ts
@@ -67,8 +67,17 @@ export class AddMinersPage extends BasePage {
 
     await expect(async () => {
       const scanningButton = this.page.getByRole("button", { name: "Scanning", exact: true });
+      const rescanNetworkButton = this.page.getByRole("button", { name: "Rescan network", exact: true });
+
       expect(await scanningButton.isVisible().catch(() => false)).toBe(false);
-      await expect(this.page.getByRole("button", { name: "Rescan network", exact: true })).toBeVisible();
+      expect(await rescanNetworkButton.isVisible().catch(() => false)).toBe(true);
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
+  }
+
+  async waitForNetworkScanToStart() {
+    await expect(async () => {
+      const scanningButton = this.page.getByRole("button", { name: "Scanning", exact: true });
+      expect(await scanningButton.isVisible().catch(() => false)).toBe(true);
     }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
   }
 
@@ -91,16 +100,20 @@ export class AddMinersPage extends BasePage {
 
   async waitForExpectedNetworkMinerCount(expectedMinerCount: number, maxAttempts: number = 2) {
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-      await this.waitForNetworkScanToFinish();
-      const foundMinerCount = await this.getSelectedMinersCount();
+      if (attempt > 1) {
+        await this.waitForNetworkScanToStart();
+      }
 
-      if (foundMinerCount === expectedMinerCount) {
+      await this.waitForNetworkScanToFinish();
+      const selectedMinerCount = await this.getSelectedMinersCount();
+
+      if (selectedMinerCount === expectedMinerCount) {
         return;
       }
 
       if (attempt === maxAttempts) {
         throw new Error(
-          `Expected ${expectedMinerCount} miners after network scan, but found ${foundMinerCount} after ${maxAttempts} attempt(s).`,
+          `Expected ${expectedMinerCount} selected miners after network scan, but got ${selectedMinerCount} after ${maxAttempts} attempt(s).`,
         );
       }
 

--- a/client/e2eTests/protoFleet/pages/addMiners.ts
+++ b/client/e2eTests/protoFleet/pages/addMiners.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator } from "@playwright/test";
+import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
 import { PROTO_RIG_DISPLAY_NAME } from "../helpers/minerModels";
 import { BasePage } from "./base";
 
@@ -59,6 +60,52 @@ export class AddMinersPage extends BasePage {
   async waitForFoundMinersList() {
     const foundMinersList = this.page.getByTestId("found-miners-list");
     await expect(foundMinersList).toBeVisible();
+  }
+
+  async waitForNetworkScanToFinish() {
+    await this.waitForFoundMinersList();
+
+    await expect(async () => {
+      const scanningButton = this.page.getByRole("button", { name: "Scanning", exact: true });
+      expect(await scanningButton.isVisible().catch(() => false)).toBe(false);
+      await expect(this.page.getByRole("button", { name: "Rescan network", exact: true })).toBeVisible();
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
+  }
+
+  async getSelectedMinersCount(): Promise<number> {
+    const continueButton = this.page.getByRole("button", { name: /Continue with \d+ miner(s)?/ }).first();
+
+    if (!(await continueButton.isVisible().catch(() => false))) {
+      return 0;
+    }
+
+    const buttonText = (await continueButton.innerText()).trim();
+    const match = buttonText.match(/Continue with (\d+) miner(?:s)?/);
+
+    if (!match) {
+      throw new Error(`Could not parse selected miner count from button text: "${buttonText}"`);
+    }
+
+    return Number.parseInt(match[1], 10);
+  }
+
+  async waitForExpectedNetworkMinerCount(expectedMinerCount: number, maxAttempts: number = 2) {
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      await this.waitForNetworkScanToFinish();
+      const foundMinerCount = await this.getSelectedMinersCount();
+
+      if (foundMinerCount === expectedMinerCount) {
+        return;
+      }
+
+      if (attempt === maxAttempts) {
+        throw new Error(
+          `Expected ${expectedMinerCount} miners after network scan, but found ${foundMinerCount} after ${maxAttempts} attempt(s).`,
+        );
+      }
+
+      await this.page.getByRole("button", { name: "Rescan network", exact: true }).click();
+    }
   }
 
   async getFoundMinersCount(): Promise<number> {

--- a/client/e2eTests/protoFleet/spec/00-onboarding.spec.ts
+++ b/client/e2eTests/protoFleet/spec/00-onboarding.spec.ts
@@ -2,6 +2,8 @@
 import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
 
+const EXPECTED_FAKE_NETWORK_MINER_COUNT = 14;
+
 test.describe("Proto Fleet - Onboarding", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
@@ -93,7 +95,8 @@ test.describe("Proto Fleet - Onboarding", () => {
 
       await test.step("Find and add miners", async () => {
         await addMinersPage.clickFindMinersInNetwork();
-        await addMinersPage.clickContinueWithSelectedMiners();
+        await addMinersPage.waitForExpectedNetworkMinerCount(EXPECTED_FAKE_NETWORK_MINER_COUNT);
+        await addMinersPage.clickContinueWithXMiners(EXPECTED_FAKE_NETWORK_MINER_COUNT);
       });
 
       await commonSteps.goToMinersPage();

--- a/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
+++ b/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
@@ -118,18 +118,8 @@ test.describe("Mining Pools", () => {
       await newPoolModal.inputPoolUsername(poolUsername);
     });
 
-    await test.step("Test connection - expect failure", async () => {
-      await newPoolModal.clickTestConnection();
-      await newPoolModal.validateConnectionFailed();
-    });
-
     await test.step("Change URL to a valid one", async () => {
       await newPoolModal.inputPoolUrl(validPoolUrl);
-    });
-
-    await test.step("Test connection - expect success", async () => {
-      await newPoolModal.clickTestConnection();
-      await newPoolModal.validateConnectionSuccessful();
     });
 
     await test.step("Save and validate pool URL", async () => {
@@ -166,8 +156,6 @@ test.describe("Mining Pools", () => {
       await newPoolModal.inputPoolUrl(validPoolUrl);
       await newPoolModal.inputPoolUsername(generateRandomText("allMinerDefault"));
       // await newPoolModal.inputPoolUsername(validUsername); // use when DASH-1407 is fixed
-      await newPoolModal.clickTestConnection();
-      await newPoolModal.validateConnectionSuccessful();
       await newPoolModal.clickSaveNewPool();
       await editPoolPage.validateModalIsClosed();
       await editPoolPage.validatePoolByIndex(0, poolName, validPoolUrl);
@@ -242,8 +230,6 @@ test.describe("Mining Pools", () => {
       await newPoolModal.inputPoolName(newPoolName2);
       await newPoolModal.inputPoolUrl(validPoolUrl);
       await newPoolModal.inputPoolUsername(newPoolUsername2);
-      await newPoolModal.clickTestConnection();
-      await newPoolModal.validateConnectionSuccessful();
       await newPoolModal.clickSaveNewPool();
       await editPoolPage.validateModalIsClosed();
     });

--- a/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
+++ b/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
@@ -87,7 +87,6 @@ test.describe("Mining Pools", () => {
     }
   });
 
-  const invalidPoolUrl = "stratum+tcp://eu1.examplepool.com:3333";
   const validPoolUrl = "stratum+tcp://mine.ocean.xyz:3334";
   // When DASH-1407 is fixed, use a real wallet, so that real miners always have it configured
   // Also, removed the actual username for security reasons. Need to get from GH secrets
@@ -112,14 +111,10 @@ test.describe("Mining Pools", () => {
       await newPoolModal.validateEmptyPoolUrlError();
     });
 
-    await test.step("Configure mining pool with invalid URL", async () => {
+    await test.step("Configure mining pool", async () => {
       await newPoolModal.inputPoolName(settingsPoolName);
-      await newPoolModal.inputPoolUrl(invalidPoolUrl);
-      await newPoolModal.inputPoolUsername(poolUsername);
-    });
-
-    await test.step("Change URL to a valid one", async () => {
       await newPoolModal.inputPoolUrl(validPoolUrl);
+      await newPoolModal.inputPoolUsername(poolUsername);
     });
 
     await test.step("Save and validate pool URL", async () => {


### PR DESCRIPTION
## Summary
- wait for onboarding network scans to finish and retry one rescan if the fake env miner count is short
- remove flaky external pool connection validation from the setup mining pool flow
- tighten the rescan helper to wait for a real new scan cycle before rechecking miner count

## Testing
- not run in block/proto-fleet after cherry-picking
- originally verified in the source repo with eslint and targeted Playwright setup specs