### PR TITLE
Fix ProtoOS tests after repo change

### DIFF
--- a/client/e2eTests/protoOS/pages/onboarding.ts
+++ b/client/e2eTests/protoOS/pages/onboarding.ts
@@ -55,4 +55,14 @@ export class WelcomePage extends BasePage {
   async closeDefaultPoolWarning() {
     await this.page.getByTestId("warn-default-pool-callout").getByRole("button").click();
   }
+
+  async confirmAirCoolingIfPrompted() {
+    const dialogTitle = this.page.getByText("No fans detected");
+    if (!(await dialogTitle.isVisible())) {
+      return;
+    }
+
+    await this.clickButton("Use air cooling");
+    await expect(dialogTitle).toBeHidden();
+  }
 }

--- a/client/e2eTests/protoOS/spec/00-onboarding.spec.ts
+++ b/client/e2eTests/protoOS/spec/00-onboarding.spec.ts
@@ -67,10 +67,10 @@ test.describe("Onboarding", () => {
       await welcomePage.validateTitle("Continue without a backup pool?");
       await welcomePage.validateButtonIsVisible("Add a backup pool");
       await welcomePage.clickButton("Continue without backup");
+      await welcomePage.confirmAirCoolingIfPrompted();
     });
 
     await test.step("Your miner is ready", async () => {
-      await welcomePage.validateTitle("Configuring your miner");
       await welcomePage.validateTitle("Your miner is ready");
       await welcomePage.validateTextIsVisible("Testing your mining pool connections");
       await welcomePage.clickButton("Continue");


### PR DESCRIPTION
## What changed
- handle the new no-fans onboarding dialog in the ProtoOS Playwright onboarding page object
- stop requiring the transient "Configuring your miner" title before asserting the stable ready state

## Why
After the repo change, the mobile ProtoOS setup flow could surface a "No fans detected" dialog. The onboarding spec did not handle that branch, so setup never completed and later mobile pools/power tests failed downstream.

## Validation
- npx playwright test --project=mobile spec/00-onboarding.spec.ts spec/pools.spec.ts spec/power.spec.ts
- npx eslint e2eTests/protoOS/pages/onboarding.ts e2eTests/protoOS/spec/00-onboarding.spec.ts