### PR TITLE
fix: add 16px left padding after first-column divider in lists

### DIFF
--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -500,7 +500,7 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
             <div
               className={clsx(
                 allowWrap ? "overflow-hidden" : "truncate overflow-hidden",
-                tdPaddingClassList,
+                columnIndex === 1 && stickyFirstColumn ? "py-3 pr-2 pl-4 phone:pl-2" : tdPaddingClassList,
                 applyColumnWidthsToCells ? "box-border w-full" : columnWidthClass,
                 {
                   "opacity-50": rowDisabled && !isExempt,
@@ -1258,7 +1258,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
                 <th
                   scope="col"
                   className={clsx(
-                    "pl-2",
+                    idx === 1 && stickyFirstColumn ? "pl-4 phone:pl-2" : "pl-2",
                     thClassList,
                     idx === 0 && stickyFirstColumn && (itemSelectable ? secondStickyClasses : firstStickyClasses),
                     idx === 0 && stickyFirstColumn && columnShadowBaseClassList,


### PR DESCRIPTION
## Summary
- Column immediately after the first-column divider now renders with 16px (pl-4) left padding on tablet+ where the divider is visible, reverting to 8px (pl-2) on phone where the divider is hidden.
- Applied in the shared `List` component so both the Racks and Miners tables benefit.

Closes #27

## Test plan
- [x] `vitest run List.test.tsx` — 86/86 pass
- [x] `just lint` / `just format` clean
- [x] Verified in Storybook at desktop (16px gap) and phone (8px gap, no divider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)