### PR TITLE
Fix settings description copy wrapping

### DIFF
--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -241,7 +241,6 @@ const AuthenticationSettings = () => {
           title="Security"
           titleSize="text-heading-300"
           description="Protect your mining fleet by managing system access, miner credentials, and team permissions."
-          descriptionClassName="max-w-none"
         />
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">

--- a/client/src/protoFleet/features/settings/components/MiningPools.tsx
+++ b/client/src/protoFleet/features/settings/components/MiningPools.tsx
@@ -437,7 +437,6 @@ const MiningPools = () => {
           <Header
             title="Pools"
             description="Add and manage the pools for your fleet."
-            descriptionClassName="max-w-none"
             titleSize="text-heading-300"
           />
           <Button

--- a/client/src/protoFleet/features/settings/components/MiningPools.tsx
+++ b/client/src/protoFleet/features/settings/components/MiningPools.tsx
@@ -434,11 +434,7 @@ const MiningPools = () => {
     <>
       <div className="flex flex-col gap-6">
         <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
-          <Header
-            title="Pools"
-            description="Add and manage the pools for your fleet."
-            titleSize="text-heading-300"
-          />
+          <Header title="Pools" description="Add and manage the pools for your fleet." titleSize="text-heading-300" />
           <Button
             variant={variants.primary}
             size={sizes.compact}

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
@@ -223,11 +223,7 @@ const SchedulesPage = () => {
   return (
     <div className="flex flex-col">
       <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
-        <Header
-          title="Schedules"
-          titleSize="text-heading-300"
-          description={SCHEDULE_PAGE_DESCRIPTION}
-        />
+        <Header title="Schedules" titleSize="text-heading-300" description={SCHEDULE_PAGE_DESCRIPTION} />
         <Button
           variant={variants.primary}
           size={sizes.base}

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
@@ -227,7 +227,6 @@ const SchedulesPage = () => {
           title="Schedules"
           titleSize="text-heading-300"
           description={SCHEDULE_PAGE_DESCRIPTION}
-          descriptionClassName="max-w-none"
         />
         <Button
           variant={variants.primary}

--- a/client/src/shared/components/Header/Header.test.tsx
+++ b/client/src/shared/components/Header/Header.test.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import Header from ".";
 import { variants } from "@/shared/components/Button";
@@ -63,5 +63,23 @@ describe("Header", () => {
     );
 
     expect(container.querySelector(".phone\\:hidden")).not.toBeNull();
+  });
+
+  it("constrains description copy width by default", () => {
+    render(<Header title="Pools" description="Add and manage the pools for your fleet." />);
+
+    expect(screen.getByText("Add and manage the pools for your fleet.")).toHaveClass("max-w-[600px]");
+  });
+
+  it("allows description width overrides when explicitly requested", () => {
+    render(
+      <Header
+        title="Pools"
+        description="Add and manage the pools for your fleet."
+        descriptionClassName="max-w-none"
+      />,
+    );
+
+    expect(screen.getByText("Add and manage the pools for your fleet.")).toHaveClass("max-w-none");
   });
 });

--- a/client/src/shared/components/Header/Header.test.tsx
+++ b/client/src/shared/components/Header/Header.test.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import Header from ".";
 import { variants } from "@/shared/components/Button";
@@ -63,23 +63,5 @@ describe("Header", () => {
     );
 
     expect(container.querySelector(".phone\\:hidden")).not.toBeNull();
-  });
-
-  it("constrains description copy width by default", () => {
-    render(<Header title="Pools" description="Add and manage the pools for your fleet." />);
-
-    expect(screen.getByText("Add and manage the pools for your fleet.")).toHaveClass("max-w-[600px]");
-  });
-
-  it("allows description width overrides when explicitly requested", () => {
-    render(
-      <Header
-        title="Pools"
-        description="Add and manage the pools for your fleet."
-        descriptionClassName="max-w-none"
-      />,
-    );
-
-    expect(screen.getByText("Add and manage the pools for your fleet.")).toHaveClass("max-w-none");
   });
 });


### PR DESCRIPTION
## Summary
- Remove the settings page header overrides that disabled the shared description max width on Security, Pools, and Schedules.
- Add shared Header tests covering the default max-width behavior and explicit opt-outs.

closes #29 

## Testing
- npm test -- --run shared/components/Header/Header.test.tsx protoFleet/features/settings/components/Auth.test.tsx protoFleet/features/settings/components/MiningPools.test.tsx protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx