### PR TITLE
ci(e2e): prebuild client and plugins once per PR gate [1/3]

### DIFF
--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -37,8 +37,74 @@ jobs:
           echo "Detected specs: ${SPEC_FILES}"
           echo "Projects to run: ${PROJECTS}"
 
-  e2e-tests:
+  build:
+    name: Build client and plugins
     needs: detect-specs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Hermit
+        uses: ./.github/actions/hermit-setup
+
+      - name: Configure Go cache
+        uses: ./.github/actions/go-cache-setup
+
+      - name: Cache Node modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            client/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('client/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install client dependencies
+        working-directory: client
+        run: npm ci
+
+      - name: Build ProtoFleet
+        working-directory: client
+        run: |
+          # Skip lint in CI to avoid import order issues from merged main branch
+          npm run build:protoFleet
+
+      - name: Build plugins for CI (Linux AMD64)
+        run: |
+          # CI runners use linux/amd64, not arm64
+          # CGO_ENABLED=0 creates static binaries that work in Alpine (musl libc)
+          echo "Syncing Go workspace..."
+          go work sync
+          echo "Building static plugins for Linux AMD64..."
+          mkdir -p server/plugins
+          (cd plugin/proto && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../server/plugins/proto-plugin .)
+          (cd plugin/antminer && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../server/plugins/antminer-plugin .)
+          chmod +x server/plugins/proto-plugin server/plugins/antminer-plugin
+          echo "Plugins built successfully"
+
+      - name: Upload client build
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: protofleet-client-dist
+          path: client/dist
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload plugins
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: protofleet-plugins
+          path: server/plugins
+          if-no-files-found: error
+          retention-days: 1
+
+  e2e-tests:
+    needs: [detect-specs, build]
     timeout-minutes: 40
     runs-on: ubuntu-latest
     permissions:
@@ -67,21 +133,6 @@ jobs:
         with:
           preinstall: "false"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Cache Docker layers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-e2e-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-e2e-
-            ${{ runner.os }}-buildx-
-
-      - name: Configure Go cache
-        uses: ./.github/actions/go-cache-setup
-
       - name: Cache Node modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -100,24 +151,20 @@ jobs:
         working-directory: client/e2eTests/protoFleet
         run: npx playwright install --with-deps chromium
 
-      - name: Build ProtoFleet
-        working-directory: client
-        run: |
-          # Skip lint in CI to avoid import order issues from merged main branch
-          npm run build:protoFleet
+      - name: Download prebuilt client
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: protofleet-client-dist
+          path: client/dist
 
-      - name: Build plugins for CI (Linux AMD64)
-        run: |
-          # CI runners use linux/amd64, not arm64
-          # CGO_ENABLED=0 creates static binaries that work in Alpine (musl libc)
-          echo "Syncing Go workspace..."
-          go work sync
-          echo "Building static plugins for Linux AMD64..."
-          mkdir -p server/plugins
-          (cd plugin/proto && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../server/plugins/proto-plugin .)
-          (cd plugin/antminer && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../server/plugins/antminer-plugin .)
-          chmod +x server/plugins/proto-plugin server/plugins/antminer-plugin
-          echo "Plugins built successfully"
+      - name: Download prebuilt plugins
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: protofleet-plugins
+          path: server/plugins
+
+      - name: Make plugins executable
+        run: chmod +x server/plugins/proto-plugin server/plugins/antminer-plugin
 
       - name: Start services (TimeScaleDB + Backend + Simulators)
         working-directory: server


### PR DESCRIPTION
## Summary
- Part 1 of a 3-PR CI speedup series
- Adds a `build` job that compiles the ProtoFleet client (`npm run build:protoFleet`) and both Go plugins once, uploads them as artifacts, and gates the 32-shard matrix on it.
- Each E2E shard now downloads the artifacts instead of rebuilding, shaving an estimated **2-3 minutes off every shard** (critical-path savings, since the slowest shard is the PR-gate bottleneck).

![Prebuild cached plugins](https://media1.giphy.com/media/l1KsqYTQd6bCXXQOA/giphy.gif)

## What changed
| Before | After |
|---|---|
| Each of 32 shards: `npm ci` + `npm run build:protoFleet` + `go work sync` + build both plugins | One `build` job does it; shards `download-artifact` |

`npm ci` and Playwright browser install still run per shard because `vite preview` (which serves `client/dist`) needs node and browsers.

The existing `/tmp/.buildx-cache` cache step was dead code (docker-compose wasn't wired to consume it) so it's removed from the shard path.

## Tradeoffs
- One extra serial dependency before the matrix fans out (~2-4 min for the build job). Net-net still a win because that cost replaces ~2-3 min × 32 shards.
- Artifacts retention: 1 day (only needed for the life of the workflow run).

## Follow-ups not in this PR
- Docker image pre-bake / cache for `fleet-api` and `timescaledb` (needs buildx-to-compose wiring — separate investigation).
- Playwright setup project + `storageState` to remove per-test login — next PR in the series.

## Test plan
- [ ] Open this PR, confirm `Build client and plugins` job runs once and the matrix picks up its artifacts.
- [ ] Spot-check one shard log: it should no longer run `npm run build:protoFleet` or the plugin build, but should download both artifacts.
- [ ] Confirm `vite preview` serves the downloaded `client/dist` (frontend reachable at :5173).
- [ ] Confirm `docker compose up` finds `server/plugins/*` and services start.
- [ ] Measure one matrix shard's duration and compare against a recent main-branch run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)