### PR TITLE
ci(e2e): share admin auth via Playwright setup project [2/3]

### DIFF
--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -148,8 +148,9 @@ jobs:
           rm -rf blob-report playwright-report test-results
           mkdir -p blob-report
 
-          # The Playwright `setup` project (onboarding + pools + auth storageState)
-          # runs automatically before the target via project `dependencies`.
+          # The viewport-matched setup project (setup-${{ matrix.project }}:
+          # onboarding + pools + auth storageState) runs automatically before
+          # the target via project `dependencies`.
           PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${{ matrix.project }}-${{ steps.artifact.outputs.spec_name }}.zip" \
           PWTEST_BLOB_DO_NOT_REMOVE=1 \
           npx playwright test --project=${{ matrix.project }} --reporter=blob "spec/${{ matrix.spec }}"

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -144,32 +144,15 @@ jobs:
         working-directory: client/e2eTests/protoFleet
         env:
           CI: true
-          SETUP_SPECS_JSON: ${{ needs.detect-specs.outputs.setup_specs }}
         run: |
-          run_spec() {
-            local spec_path="$1"
-            local spec_slug
-            spec_slug=$(echo "${spec_path}" | sed 's/\.spec\.ts$//' | sed 's/[^a-zA-Z0-9]/-/g')
-
-            echo "Running spec: ${spec_path} on project: ${{ matrix.project }}"
-            PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${{ matrix.project }}-${{ steps.artifact.outputs.spec_name }}-${spec_slug}.zip" \
-            PWTEST_BLOB_DO_NOT_REMOVE=1 \
-            npx playwright test --project=${{ matrix.project }} --reporter=blob "spec/${spec_path}"
-          }
-
           rm -rf blob-report playwright-report test-results
           mkdir -p blob-report
 
-          mapfile -t setup_specs < <(printf '%s' "${SETUP_SPECS_JSON}" | jq -r '.[]')
-          if [ "${#setup_specs[@]}" -gt 0 ]; then
-            echo "Running setup specs before target spec:"
-            printf ' - %s\n' "${setup_specs[@]}"
-            for spec in "${setup_specs[@]}"; do
-              run_spec "${spec}"
-            done
-          fi
-
-          run_spec "${{ matrix.spec }}"
+          # The Playwright `setup` project (onboarding + pools + auth storageState)
+          # runs automatically before the target via project `dependencies`.
+          PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${{ matrix.project }}-${{ steps.artifact.outputs.spec_name }}.zip" \
+          PWTEST_BLOB_DO_NOT_REMOVE=1 \
+          npx playwright test --project=${{ matrix.project }} --reporter=blob "spec/${{ matrix.spec }}"
 
           echo "Blob reports created:"
           find blob-report -maxdepth 2 -type f -print | sort || true

--- a/client/e2eTests/protoFleet/globalSetup.ts
+++ b/client/e2eTests/protoFleet/globalSetup.ts
@@ -1,25 +1,6 @@
-/**
- * Enforce explicit --project selection so only one `setup-*` project runs
- * against the backend at a time.
- *
- * The numbered setup specs (00-onboarding, 01-miningPools, 02-saveAuthState)
- * create the admin user, add miners, and configure pools against a fresh
- * backend — they are not idempotent. `setup-desktop` and `setup-mobile` each
- * perform that flow under their own viewport, and the `desktop` / `mobile`
- * target projects depend on their viewport-matched setup.
- *
- * With per-shard `--project=desktop` or `--project=mobile` invocations
- * (what CI does), only one setup project is scheduled per run and the
- * design is safe. A plain `npx playwright test` with no --project flag
- * would schedule both setup projects against the same backend; the second
- * setup to reach onboarding collides with the admin user already created
- * by the first.
- *
- * Fail loudly at startup with a message pointing at the right invocation
- * rather than letting the collision show up as a confusing mid-suite
- * failure. `--ui` and `--list` opt out: `--ui` lets the developer pick a
- * project interactively, and `--list` is discovery-only (no backend).
- */
+// The numbered setup specs are not idempotent, so `setup-desktop` and
+// `setup-mobile` cannot run against the same backend in one invocation.
+// Require --project to keep a bare `npx playwright test` from scheduling both.
 export default async function globalSetup(): Promise<void> {
   const argv = process.argv.slice(2);
   const hasProjectFlag = argv.some(
@@ -28,7 +9,6 @@ export default async function globalSetup(): Promise<void> {
       arg === "-p" ||
       arg.startsWith("--project=") ||
       arg.startsWith("-p=") ||
-      // handle the space-separated form (prev arg is the flag)
       (i > 0 && (argv[i - 1] === "--project" || argv[i - 1] === "-p")),
   );
 

--- a/client/e2eTests/protoFleet/globalSetup.ts
+++ b/client/e2eTests/protoFleet/globalSetup.ts
@@ -1,24 +1,38 @@
 // The numbered setup specs are not idempotent, so `setup-desktop` and
 // `setup-mobile` cannot run against the same backend in one invocation.
-// Require --project to keep a bare `npx playwright test` from scheduling both.
+// Require exactly one --project to keep a bare `npx playwright test` (or
+// multiple --project flags) from scheduling both setup projects at once.
 export default async function globalSetup(): Promise<void> {
   const argv = process.argv.slice(2);
-  const hasProjectFlag = argv.some(
-    (arg, i) =>
-      arg === "--project" ||
-      arg === "-p" ||
-      arg.startsWith("--project=") ||
-      arg.startsWith("-p=") ||
-      (i > 0 && (argv[i - 1] === "--project" || argv[i - 1] === "-p")),
-  );
 
-  const hasUiOrListOptOut = argv.includes("--ui") || argv.includes("--list");
+  // --list is a dry-run: Playwright enumerates tests without touching the
+  // backend, so the single-project invariant does not apply.
+  if (argv.includes("--list")) {
+    return;
+  }
 
-  if (!hasProjectFlag && !hasUiOrListOptOut) {
+  const projects: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if ((a === "--project" || a === "-p") && argv[i + 1]) {
+      projects.push(argv[i + 1]);
+      i++;
+    } else if (a.startsWith("--project=")) {
+      projects.push(a.slice("--project=".length));
+    } else if (a.startsWith("-p=")) {
+      projects.push(a.slice("-p=".length));
+    }
+  }
+
+  if (projects.length !== 1) {
     throw new Error(
       [
         "",
-        "Proto Fleet e2e tests require an explicit --project flag.",
+        "Proto Fleet e2e tests require exactly one --project flag.",
+        "",
+        projects.length === 0
+          ? "No --project was provided."
+          : `Received ${projects.length} projects: ${projects.join(", ")}.`,
         "",
         "The numbered setup specs (00-onboarding, 01-miningPools,",
         "02-saveAuthState) are not idempotent: running both setup-desktop",

--- a/client/e2eTests/protoFleet/globalSetup.ts
+++ b/client/e2eTests/protoFleet/globalSetup.ts
@@ -1,0 +1,56 @@
+/**
+ * Enforce explicit --project selection so only one `setup-*` project runs
+ * against the backend at a time.
+ *
+ * The numbered setup specs (00-onboarding, 01-miningPools, 02-saveAuthState)
+ * create the admin user, add miners, and configure pools against a fresh
+ * backend — they are not idempotent. `setup-desktop` and `setup-mobile` each
+ * perform that flow under their own viewport, and the `desktop` / `mobile`
+ * target projects depend on their viewport-matched setup.
+ *
+ * With per-shard `--project=desktop` or `--project=mobile` invocations
+ * (what CI does), only one setup project is scheduled per run and the
+ * design is safe. A plain `npx playwright test` with no --project flag
+ * would schedule both setup projects against the same backend; the second
+ * setup to reach onboarding collides with the admin user already created
+ * by the first.
+ *
+ * Fail loudly at startup with a message pointing at the right invocation
+ * rather than letting the collision show up as a confusing mid-suite
+ * failure. `--ui` and `--list` opt out: `--ui` lets the developer pick a
+ * project interactively, and `--list` is discovery-only (no backend).
+ */
+export default async function globalSetup(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const hasProjectFlag = argv.some(
+    (arg, i) =>
+      arg === "--project" ||
+      arg === "-p" ||
+      arg.startsWith("--project=") ||
+      arg.startsWith("-p=") ||
+      // handle the space-separated form (prev arg is the flag)
+      (i > 0 && (argv[i - 1] === "--project" || argv[i - 1] === "-p")),
+  );
+
+  const hasUiOrListOptOut = argv.includes("--ui") || argv.includes("--list");
+
+  if (!hasProjectFlag && !hasUiOrListOptOut) {
+    throw new Error(
+      [
+        "",
+        "Proto Fleet e2e tests require an explicit --project flag.",
+        "",
+        "The numbered setup specs (00-onboarding, 01-miningPools,",
+        "02-saveAuthState) are not idempotent: running both setup-desktop",
+        "and setup-mobile against the same backend would collide on",
+        "admin onboarding. Pick a single target project:",
+        "",
+        "  npx playwright test --project=desktop [spec/...]",
+        "  npx playwright test --project=mobile  [spec/...]",
+        "",
+        "The CI workflow already does this per matrix shard.",
+        "",
+      ].join("\n"),
+    );
+  }
+}

--- a/client/e2eTests/protoFleet/helpers/commonSteps.ts
+++ b/client/e2eTests/protoFleet/helpers/commonSteps.ts
@@ -11,11 +11,12 @@ export class CommonSteps {
 
   async loginAsAdmin() {
     await test.step("Login as admin", async () => {
-      // The setup project captures the admin session into storageState, so most
-      // tests start already authenticated. Skip the login flow when the auth
-      // form isn't on screen.
+      // With storageState preloaded by the setup project, tests usually start
+      // authenticated. Probe for the post-login marker first and only fall
+      // through to the full login flow when it isn't visible (e.g. auth spec,
+      // post-logout paths, or storageState opt-outs).
       // eslint-disable-next-line playwright/no-conditional-in-test
-      if (!(await this.authPage.isLoginFormVisible())) {
+      if (await this.authPage.isAlreadyLoggedIn()) {
         return;
       }
       await this.authPage.inputUsername(testConfig.users.admin.username);

--- a/client/e2eTests/protoFleet/helpers/commonSteps.ts
+++ b/client/e2eTests/protoFleet/helpers/commonSteps.ts
@@ -11,10 +11,6 @@ export class CommonSteps {
 
   async loginAsAdmin() {
     await test.step("Login as admin", async () => {
-      // With storageState preloaded by the setup project, tests usually start
-      // authenticated. Probe for the post-login marker first and only fall
-      // through to the full login flow when it isn't visible (e.g. auth spec,
-      // post-logout paths, or storageState opt-outs).
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (await this.authPage.isAlreadyLoggedIn()) {
         return;

--- a/client/e2eTests/protoFleet/helpers/commonSteps.ts
+++ b/client/e2eTests/protoFleet/helpers/commonSteps.ts
@@ -11,6 +11,12 @@ export class CommonSteps {
 
   async loginAsAdmin() {
     await test.step("Login as admin", async () => {
+      // The setup project captures the admin session into storageState, so most
+      // tests start already authenticated. Skip the login flow when the auth
+      // form isn't on screen.
+      if (!(await this.authPage.isLoginFormVisible())) {
+        return;
+      }
       await this.authPage.inputUsername(testConfig.users.admin.username);
       await this.authPage.inputPassword(testConfig.users.admin.password);
       await this.authPage.clickLogin();

--- a/client/e2eTests/protoFleet/helpers/commonSteps.ts
+++ b/client/e2eTests/protoFleet/helpers/commonSteps.ts
@@ -14,6 +14,7 @@ export class CommonSteps {
       // The setup project captures the admin session into storageState, so most
       // tests start already authenticated. Skip the login flow when the auth
       // form isn't on screen.
+      // eslint-disable-next-line playwright/no-conditional-in-test
       if (!(await this.authPage.isLoginFormVisible())) {
         return;
       }

--- a/client/e2eTests/protoFleet/pages/auth.ts
+++ b/client/e2eTests/protoFleet/pages/auth.ts
@@ -2,9 +2,11 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class AuthPage extends BasePage {
-  async isLoginFormVisible(timeoutMs = 2000): Promise<boolean> {
+  async isAlreadyLoggedIn(timeoutMs = 5000): Promise<boolean> {
+    // Probe for the post-login marker (mobile menu button or desktop logout
+    // button) to decide whether the full login flow can be skipped.
     try {
-      await this.page.locator(`//input[@id='username']`).waitFor({ state: "visible", timeout: timeoutMs });
+      await this.validateLoggedIn(timeoutMs);
       return true;
     } catch {
       return false;

--- a/client/e2eTests/protoFleet/pages/auth.ts
+++ b/client/e2eTests/protoFleet/pages/auth.ts
@@ -3,12 +3,6 @@ import { BasePage } from "./base";
 
 export class AuthPage extends BasePage {
   async isAlreadyLoggedIn(timeoutMs = 5000): Promise<boolean> {
-    // Wait for the page to settle into either the authenticated UI (mobile
-    // menu button or desktop logout button) or the login form. Return true
-    // only after positively confirming the authenticated state. Any other
-    // locator failure (e.g. selector rename, browser crash) is re-thrown so
-    // auth regressions surface here rather than as a secondary failure
-    // inside the login flow.
     const loggedInMarker = this.isMobile
       ? this.page.getByTestId("navigation-menu-button")
       : this.page.getByTestId("logout-button");
@@ -17,9 +11,8 @@ export class AuthPage extends BasePage {
     try {
       await expect(loggedInMarker.or(loginForm)).toBeVisible({ timeout: timeoutMs });
     } catch (err) {
-      // Only swallow Playwright timeouts (page hasn't settled into either
-      // state) so the caller can fall through to the full login flow which
-      // has its own assertion.
+      // Only swallow timeouts so selector regressions propagate instead of
+      // silently falling through to the login flow.
       if (err instanceof Error && /Timeout/i.test(err.message)) {
         return false;
       }

--- a/client/e2eTests/protoFleet/pages/auth.ts
+++ b/client/e2eTests/protoFleet/pages/auth.ts
@@ -3,14 +3,30 @@ import { BasePage } from "./base";
 
 export class AuthPage extends BasePage {
   async isAlreadyLoggedIn(timeoutMs = 5000): Promise<boolean> {
-    // Probe for the post-login marker (mobile menu button or desktop logout
-    // button) to decide whether the full login flow can be skipped.
+    // Wait for the page to settle into either the authenticated UI (mobile
+    // menu button or desktop logout button) or the login form. Return true
+    // only after positively confirming the authenticated state. Any other
+    // locator failure (e.g. selector rename, browser crash) is re-thrown so
+    // auth regressions surface here rather than as a secondary failure
+    // inside the login flow.
+    const loggedInMarker = this.isMobile
+      ? this.page.getByTestId("navigation-menu-button")
+      : this.page.getByTestId("logout-button");
+    const loginForm = this.page.locator(`//input[@id='username']`);
+
     try {
-      await this.validateLoggedIn(timeoutMs);
-      return true;
-    } catch {
-      return false;
+      await expect(loggedInMarker.or(loginForm)).toBeVisible({ timeout: timeoutMs });
+    } catch (err) {
+      // Only swallow Playwright timeouts (page hasn't settled into either
+      // state) so the caller can fall through to the full login flow which
+      // has its own assertion.
+      if (err instanceof Error && /Timeout/i.test(err.message)) {
+        return false;
+      }
+      throw err;
     }
+
+    return await loggedInMarker.isVisible();
   }
 
   async inputUsername(username: string) {

--- a/client/e2eTests/protoFleet/pages/auth.ts
+++ b/client/e2eTests/protoFleet/pages/auth.ts
@@ -2,6 +2,15 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class AuthPage extends BasePage {
+  async isLoginFormVisible(timeoutMs = 2000): Promise<boolean> {
+    try {
+      await this.page.locator(`//input[@id='username']`).waitFor({ state: "visible", timeout: timeoutMs });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async inputUsername(username: string) {
     await this.page.locator(`//input[@id='username']`).fill(username);
   }

--- a/client/e2eTests/protoFleet/playwright.config.ts
+++ b/client/e2eTests/protoFleet/playwright.config.ts
@@ -56,10 +56,12 @@ export default defineConfig({
 
   // E.g.:  npx playwright test --project=desktop
   projects: [
-    // Setup project seeds backend state (onboarding, pools) and captures the
-    // admin auth storageState. Always runs before target specs via `dependencies`.
+    // Setup projects seed backend state (onboarding, pools) and capture the
+    // admin auth storageState. Split per viewport so the mobile matrix also
+    // exercises the mobile onboarding/pool-setup UI rather than inheriting
+    // desktop-driven state.
     {
-      name: "setup",
+      name: "setup-desktop",
       testMatch: SETUP_FILE_GLOB,
       use: {
         viewport: { width: 1600, height: 900 },
@@ -67,10 +69,18 @@ export default defineConfig({
       },
     },
     {
+      name: "setup-mobile",
+      testMatch: SETUP_FILE_GLOB,
+      use: {
+        viewport: { width: 393, height: 852 },
+        isMobile: true,
+      },
+    },
+    {
       name: "desktop",
       testMatch: /.*\.spec\.ts$/,
       testIgnore: SETUP_FILE_GLOB,
-      dependencies: ["setup"],
+      dependencies: ["setup-desktop"],
       use: {
         viewport: { width: 1600, height: 900 },
         isMobile: false,
@@ -82,7 +92,7 @@ export default defineConfig({
       name: "mobile",
       testMatch: /.*\.spec\.ts$/,
       testIgnore: SETUP_FILE_GLOB,
-      dependencies: ["setup"],
+      dependencies: ["setup-mobile"],
       use: {
         viewport: { width: 393, height: 852 },
         isMobile: true,

--- a/client/e2eTests/protoFleet/playwright.config.ts
+++ b/client/e2eTests/protoFleet/playwright.config.ts
@@ -1,9 +1,11 @@
-import path from "path";
 import { defineConfig } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
 import { testConfig } from "./config/test.config";
 
-const adminStorageState = path.join(__dirname, "playwright", ".auth", "admin.json");
-const SETUP_FILE_PATTERN = /^[0-9]{2}-.*\.spec\.ts$/;
+const configDir = path.dirname(fileURLToPath(import.meta.url));
+const adminStorageState = path.join(configDir, "playwright", ".auth", "admin.json");
+const SETUP_FILE_GLOB = "**/[0-9][0-9]-*.spec.ts";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -58,7 +60,7 @@ export default defineConfig({
     // admin auth storageState. Always runs before target specs via `dependencies`.
     {
       name: "setup",
-      testMatch: SETUP_FILE_PATTERN,
+      testMatch: SETUP_FILE_GLOB,
       use: {
         viewport: { width: 1600, height: 900 },
         isMobile: false,
@@ -67,7 +69,7 @@ export default defineConfig({
     {
       name: "desktop",
       testMatch: /.*\.spec\.ts$/,
-      testIgnore: SETUP_FILE_PATTERN,
+      testIgnore: SETUP_FILE_GLOB,
       dependencies: ["setup"],
       use: {
         viewport: { width: 1600, height: 900 },
@@ -79,7 +81,7 @@ export default defineConfig({
     {
       name: "mobile",
       testMatch: /.*\.spec\.ts$/,
-      testIgnore: SETUP_FILE_PATTERN,
+      testIgnore: SETUP_FILE_GLOB,
       dependencies: ["setup"],
       use: {
         viewport: { width: 393, height: 852 },

--- a/client/e2eTests/protoFleet/playwright.config.ts
+++ b/client/e2eTests/protoFleet/playwright.config.ts
@@ -13,9 +13,6 @@ const SETUP_FILE_GLOB = "**/[0-9][0-9]-*.spec.ts";
 
 export default defineConfig({
   testDir: "./spec",
-  // Guard against bare `npx playwright test` invocations. See globalSetup.ts
-  // for the rationale: the setup-desktop and setup-mobile projects are not
-  // safe to run against a shared backend at the same time.
   globalSetup: "./globalSetup.ts",
   /* Run tests in serial order (one at a time) */
   fullyParallel: false,
@@ -60,10 +57,6 @@ export default defineConfig({
 
   // E.g.:  npx playwright test --project=desktop
   projects: [
-    // Setup projects seed backend state (onboarding, pools) and capture the
-    // admin auth storageState. Split per viewport so the mobile matrix also
-    // exercises the mobile onboarding/pool-setup UI rather than inheriting
-    // desktop-driven state.
     {
       name: "setup-desktop",
       testMatch: SETUP_FILE_GLOB,

--- a/client/e2eTests/protoFleet/playwright.config.ts
+++ b/client/e2eTests/protoFleet/playwright.config.ts
@@ -1,5 +1,9 @@
+import path from "path";
 import { defineConfig } from "@playwright/test";
 import { testConfig } from "./config/test.config";
+
+const adminStorageState = path.join(__dirname, "playwright", ".auth", "admin.json");
+const SETUP_FILE_PATTERN = /^[0-9]{2}-.*\.spec\.ts$/;
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -50,21 +54,37 @@ export default defineConfig({
 
   // E.g.:  npx playwright test --project=desktop
   projects: [
+    // Setup project seeds backend state (onboarding, pools) and captures the
+    // admin auth storageState. Always runs before target specs via `dependencies`.
     {
-      name: "desktop",
-      testMatch: /.*\.spec\.ts/,
+      name: "setup",
+      testMatch: SETUP_FILE_PATTERN,
       use: {
         viewport: { width: 1600, height: 900 },
         isMobile: false,
       },
     },
+    {
+      name: "desktop",
+      testMatch: /.*\.spec\.ts$/,
+      testIgnore: SETUP_FILE_PATTERN,
+      dependencies: ["setup"],
+      use: {
+        viewport: { width: 1600, height: 900 },
+        isMobile: false,
+        storageState: adminStorageState,
+      },
+    },
     // Resolution of the iPhone 14 Pro / 15 Pro / 16
     {
       name: "mobile",
-      testMatch: /.*\.spec\.ts/,
+      testMatch: /.*\.spec\.ts$/,
+      testIgnore: SETUP_FILE_PATTERN,
+      dependencies: ["setup"],
       use: {
         viewport: { width: 393, height: 852 },
         isMobile: true,
+        storageState: adminStorageState,
       },
     },
   ],

--- a/client/e2eTests/protoFleet/playwright.config.ts
+++ b/client/e2eTests/protoFleet/playwright.config.ts
@@ -13,6 +13,10 @@ const SETUP_FILE_GLOB = "**/[0-9][0-9]-*.spec.ts";
 
 export default defineConfig({
   testDir: "./spec",
+  // Guard against bare `npx playwright test` invocations. See globalSetup.ts
+  // for the rationale: the setup-desktop and setup-mobile projects are not
+  // safe to run against a shared backend at the same time.
+  globalSetup: "./globalSetup.ts",
   /* Run tests in serial order (one at a time) */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
+++ b/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
@@ -1,0 +1,17 @@
+/* eslint-disable playwright/expect-expect */
+import path from "path";
+import { testConfig } from "../config/test.config";
+import { test } from "../fixtures/pageFixtures";
+
+export const adminStorageStatePath = path.join(__dirname, "..", "playwright", ".auth", "admin.json");
+
+test("save admin auth storage state @setup", async ({ page, authPage }) => {
+  await page.goto("/");
+
+  await authPage.inputUsername(testConfig.users.admin.username);
+  await authPage.inputPassword(testConfig.users.admin.password);
+  await authPage.clickLogin();
+  await authPage.validateLoggedIn();
+
+  await page.context().storageState({ path: adminStorageStatePath });
+});

--- a/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
+++ b/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable playwright/expect-expect */
+import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 import { testConfig } from "../config/test.config";
@@ -15,5 +16,7 @@ test("save admin auth storage state @setup", async ({ page, authPage }) => {
   await authPage.clickLogin();
   await authPage.validateLoggedIn();
 
+  // playwright/.auth/ is gitignored and absent on fresh checkouts.
+  await fs.mkdir(path.dirname(adminStorageStatePath), { recursive: true });
   await page.context().storageState({ path: adminStorageStatePath });
 });

--- a/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
+++ b/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
@@ -1,9 +1,11 @@
 /* eslint-disable playwright/expect-expect */
 import path from "path";
+import { fileURLToPath } from "url";
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 
-export const adminStorageStatePath = path.join(__dirname, "..", "playwright", ".auth", "admin.json");
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const adminStorageStatePath = path.join(specDir, "..", "playwright", ".auth", "admin.json");
 
 test("save admin auth storage state @setup", async ({ page, authPage }) => {
   await page.goto("/");

--- a/client/e2eTests/protoFleet/spec/auth.spec.ts
+++ b/client/e2eTests/protoFleet/spec/auth.spec.ts
@@ -3,8 +3,7 @@ import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 
 test.describe("Proto Fleet - Authentication", () => {
-  // Auth spec validates the login flow itself, so opt out of the admin
-  // storageState applied to other projects.
+  // Validates the login flow itself, so opt out of the preloaded admin storageState.
   test.use({ storageState: { cookies: [], origins: [] } });
 
   test.beforeEach(async ({ page }) => {

--- a/client/e2eTests/protoFleet/spec/auth.spec.ts
+++ b/client/e2eTests/protoFleet/spec/auth.spec.ts
@@ -3,6 +3,10 @@ import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 
 test.describe("Proto Fleet - Authentication", () => {
+  // Auth spec validates the login flow itself, so opt out of the admin
+  // storageState applied to other projects.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
   });

--- a/client/e2eTests/protoFleet/spec/navigation.spec.ts
+++ b/client/e2eTests/protoFleet/spec/navigation.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable playwright/expect-expect */
-import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 
 test.describe("Navigation", () => {
@@ -55,13 +54,8 @@ test.describe("Navigation", () => {
     });
   });
 
-  test("Navigate between main pages and settings sub-pages", async ({ authPage, settingsPage }) => {
-    await test.step("Log in as admin user", async () => {
-      await authPage.inputUsername(testConfig.users.admin.username);
-      await authPage.inputPassword(testConfig.users.admin.password);
-      await authPage.clickLogin();
-      await authPage.validateLoggedIn();
-    });
+  test("Navigate between main pages and settings sub-pages", async ({ authPage, commonSteps, settingsPage }) => {
+    await commonSteps.loginAsAdmin();
 
     await test.step("Navigate from Home to Settings page", async () => {
       await authPage.navigateToSettingsPage();

--- a/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
@@ -7,6 +7,10 @@ import { SettingsPage } from "../pages/settings";
 import { SettingsSecurityPage } from "../pages/settingsSecurity";
 
 test.describe("Proto Fleet - Security Settings", () => {
+  // Tests here change admin credentials and log back in with them; opt out of
+  // the preloaded admin storageState so each test starts from a clean session.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
   });

--- a/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
@@ -84,13 +84,8 @@ test.describe("Proto Fleet - Security Settings", () => {
   const newUsername = generateRandomUsername();
   const newPassword = generateRandomText("A1!");
 
-  test("Update admin username and password", async ({ authPage, settingsPage, settingsSecurityPage }) => {
-    await test.step("Log in as admin", async () => {
-      await authPage.inputUsername(username);
-      await authPage.inputPassword(password);
-      await authPage.clickLogin();
-      await authPage.validateLoggedIn();
-    });
+  test("Update admin username and password", async ({ authPage, commonSteps, settingsPage, settingsSecurityPage }) => {
+    await commonSteps.loginAsAdmin();
 
     await test.step("Navigate to Security Settings", async () => {
       await settingsPage.navigateToSecuritySettings();

--- a/client/e2eTests/protoFleet/spec/teamAccounts.spec.ts
+++ b/client/e2eTests/protoFleet/spec/teamAccounts.spec.ts
@@ -9,6 +9,10 @@ import { SettingsPage } from "../pages/settings";
 import { SettingsTeamPage } from "../pages/settingsTeam";
 
 test.describe("Proto Fleet - Team Accounts", () => {
+  // Tests here exercise logout + re-login as different users; opt out of the
+  // preloaded admin storageState so each test starts from a clean session.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
   });


### PR DESCRIPTION
## Summary
Part 2 of a 3-PR CI speedup series. Replaces the per-shard shell loop over setup specs with Playwright's native project `dependencies` + `storageState`, so most target tests start already authenticated instead of running the login flow in every single `it()`.

## What changed
- **Two viewport-matched setup projects** in [playwright.config.ts](client/e2eTests/protoFleet/playwright.config.ts): `setup-desktop` and `setup-mobile` each run `spec/00-*`, `spec/01-*`, and the new `02-saveAuthState.spec.ts` under their own viewport. `desktop` and `mobile` target projects declare `dependencies: ['setup-desktop']` / `dependencies: ['setup-mobile']` respectively.
- **New [02-saveAuthState.spec.ts](client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts)** signs in as admin once and writes `playwright/.auth/admin.json` (already gitignored; `fs.mkdir` ensures the directory exists on fresh checkouts).
- **`desktop` / `mobile`** projects load that file via `use.storageState`, so most target tests boot pre-authenticated.
- **`commonSteps.loginAsAdmin()` is idempotent** via a new `authPage.isAlreadyLoggedIn()` helper that waits for either the authed UI marker or the login form to appear, then returns `true` only when positively confirming the authed state. Only Playwright timeouts are swallowed; other errors propagate.
- **Specs that manipulate sessions opt out of `storageState`**: `auth.spec.ts` validates login itself; `teamAccounts.spec.ts` and `securitySettings.spec.ts` exercise `authPage.logout()` + re-login flows that would otherwise leave later tests holding a revoked cookie while the UI still shows authed chrome.
- **`globalSetup.ts`** enforces exactly one `--project` flag (throws with guidance otherwise). This keeps a bare `npx playwright test` or multi-project invocation from scheduling both setup projects against the same backend; the numbered setup specs are not idempotent on shared state. `--list` is exempted (dry-run, no backend).
- **CI workflow** drops the shell loop that ran setup specs one-by-one. Each shard now runs a single `npx playwright test --project=${{ matrix.project }}` call and Playwright handles setup ordering via `dependencies`.

## Expected impact
- ~30s saved per target test that skips the login flow. `minersSleepWake.spec.ts mobile` (critical path, 3 tests) should drop ~90s just from this.
- Plus one-time savings of 2 extra browser cold starts per shard (setup specs used to be separate Playwright invocations).
- Combined with #43 (prebuild artifacts), total estimated critical-path reduction is ~4-5 minutes.

## Test plan
- [ ] Local: `cd client/e2eTests/protoFleet && E2E_TARGET=fake npx playwright test --project=desktop spec/minersSleepWake.spec.ts` — confirm the setup project runs first, target spec skips login step, all tests pass.
- [ ] Local: `npx playwright test --project=desktop spec/auth.spec.ts` — confirm `auth.spec.ts` still sees the login form (storageState opted out).
- [ ] Local: `npx playwright test` (no project), `npx playwright test --project=desktop --project=mobile` — both should fail at globalSetup with the guidance message.
- [ ] CI: Open PR, confirm each shard does one Playwright invocation and the blob report still merges correctly.
- [ ] CI: Check `minersSleepWake.spec.ts mobile` runtime vs main.

Stacking note: #43 is merged; this PR targets `main` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)