### PR TITLE
ci: cache golangci-lint analysis to speed up lint runs [3/3]

### DIFF
--- a/.github/actions/go-cache-setup/action.yml
+++ b/.github/actions/go-cache-setup/action.yml
@@ -1,5 +1,5 @@
 name: Configure Go Cache
-description: Setup Go build and module caching for workspace
+description: Setup Go build, module, and golangci-lint caching for workspace
 
 runs:
   using: "composite"
@@ -14,3 +14,11 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-go-workspace-
           ${{ runner.os }}-${{ runner.arch }}-go-
+
+    - name: Configure golangci-lint cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.cache/golangci-lint
+        key: ${{ runner.os }}-${{ runner.arch }}-golangci-${{ hashFiles('**/.golangci.yaml', '**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-golangci-


### PR DESCRIPTION
## Summary
Part 3 of a 3-PR CI speedup series, rounding out the server-side checks. Adds `~/.cache/golangci-lint` to the shared `go-cache-setup` composite action so every lint-driven job benefits.

![Cache all the things](https://media2.giphy.com/media/xTkcEQACH24SMPxIQg/giphy.gif)

## What changed
[.github/actions/go-cache-setup/action.yml](.github/actions/go-cache-setup/action.yml) now also caches `~/.cache/golangci-lint`, keyed on the linter config (`.golangci.yaml`) and `go.sum`. Any job that uses this composite action (Server Checks, Generated Code, E2E, plugin checks) picks it up automatically.

## Why not more?
The original plan called out three sub-items for Wave 3, but investigating showed:

- **~~Drop duplicate format check~~**: In golangci-lint v2, `golangci-lint fmt` and `golangci-lint run` are separate commands \u2014 `run` does **not** invoke formatters. Removing the `fmt --diff` step would silently drop format enforcement. Leaving it alone.
- **~~Split unit vs integration tests~~**: Low marginal value (~30-60s) and risks misclassifying tests without a thorough audit. Worth revisiting only if Server Checks becomes the critical path after the E2E PRs land.

So Wave 3 is a one-file change: just the cache.

## Expected impact
- Warm-cache lint runs save ~30-60s. Not on the PR critical path today (E2E dominates), but will matter once Waves 1+2 land and Server Checks (currently 5m 32s) moves closer to becoming the gate.
- Benefits apply to every workflow that reuses `go-cache-setup`, not just Server Checks.

## Test plan
- [ ] Open this PR, confirm the new cache step appears in Server Checks, Generated Code Check, and one plugin-check job.
- [ ] On second run (cache warm), confirm `just lint` runs faster vs a main-branch baseline.
- [ ] Confirm no other step regresses (this is purely additive).

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)