### PR TITLE
ci(e2e): prebuild+cache docker images and fix node cache collision

### DIFF
--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -109,6 +109,12 @@ jobs:
         working-directory: server
         run: |
           mkdir -p /tmp/docker-images
+          # `--ignore-buildable` pulls only services with `image:` and no
+          # `build:` (otel-collector, jaeger). `docker save` below otherwise
+          # fails on a cold runner because those images don't exist locally.
+          echo "::group::docker compose pull"
+          docker compose pull --ignore-buildable
+          echo "::endgroup::"
           echo "::group::docker compose build"
           docker compose build
           echo "::endgroup::"

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -55,8 +55,12 @@ jobs:
       - name: Configure Go cache
         uses: ./.github/actions/go-cache-setup
 
-      - name: Cache Node modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      # Restore-only: the E2E shard job saves this key with an additional
+      # `~/.cache/ms-playwright` path. Cache keys are immutable, so if this job
+      # saved first it would permanently lock the shards out of caching their
+      # Playwright browsers. Restore here, save there.
+      - name: Restore Node modules cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             client/node_modules
@@ -275,8 +279,10 @@ jobs:
         with:
           preinstall: "false"
 
-      - name: Cache Node modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      # Restore-only: see the build job for rationale — the E2E shard owns the
+      # shared node cache key so it can include the Playwright browser cache.
+      - name: Restore Node modules cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             client/node_modules

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -99,7 +99,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/docker-images
-          key: ${{ runner.os }}-protofleet-e2e-docker-${{ hashFiles('server/Dockerfile', 'server/docker-compose*.yaml', 'server/go.sum', 'server/go.mod', 'server/**/*.go', 'server/fake-antminer/**', 'server/fake-proto-rig/**', 'server/timescaledb/**') }}
+          # `schedule` salts run_id so daily runs always rebuild against
+          # current base images. `server/**` because the Dockerfile does
+          # `COPY server/ ./` (e.g. go:embed migrations).
+          key: ${{ runner.os }}-protofleet-e2e-docker-${{ github.event_name == 'schedule' && format('schedule-{0}', github.run_id) || hashFiles('server/**') }}
 
       - name: Build E2E Docker images
         if: steps.docker-image-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -91,6 +91,37 @@ jobs:
           chmod +x server/plugins/proto-plugin server/plugins/antminer-plugin
           echo "Plugins built successfully"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      # Cache the docker-compose service images (fleet-api, timescaledb, 6x
+      # fake-antminer, 2x fake-proto-rig, ...) between CI runs. Keyed on the
+      # sources that actually change image contents; when the key matches,
+      # `docker load` is all the shards need and they skip the ~3-5 min
+      # per-shard `docker compose build` that was the Wave 1 critical-path
+      # regression.
+      - name: Restore Docker image cache
+        id: docker-image-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/docker-images
+          key: ${{ runner.os }}-protofleet-e2e-docker-${{ hashFiles('server/Dockerfile', 'server/docker-compose*.yaml', 'server/go.sum', 'server/go.mod', 'server/**/*.go', 'server/fake-antminer/**', 'server/fake-proto-rig/**', 'server/timescaledb/**') }}
+
+      - name: Build E2E Docker images
+        if: steps.docker-image-cache.outputs.cache-hit != 'true'
+        working-directory: server
+        run: |
+          mkdir -p /tmp/docker-images
+          echo "::group::docker compose build"
+          docker compose build
+          echo "::endgroup::"
+          echo "::group::Save images to compressed tarball"
+          mapfile -t images < <(docker compose config --images | sort -u)
+          printf '  - %s\n' "${images[@]}"
+          docker save "${images[@]}" | gzip > /tmp/docker-images/e2e-images.tar.gz
+          ls -lh /tmp/docker-images/
+          echo "::endgroup::"
+
       - name: Upload client build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -104,6 +135,14 @@ jobs:
         with:
           name: protofleet-plugins
           path: server/plugins
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Docker images
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: protofleet-e2e-docker-images
+          path: /tmp/docker-images/e2e-images.tar.gz
           if-no-files-found: error
           retention-days: 1
 
@@ -170,9 +209,22 @@ jobs:
       - name: Make plugins executable
         run: chmod +x server/plugins/proto-plugin server/plugins/antminer-plugin
 
+      - name: Download prebuilt Docker images
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: protofleet-e2e-docker-images
+          path: /tmp/docker-images
+
+      - name: Load Docker images
+        run: |
+          gunzip < /tmp/docker-images/e2e-images.tar.gz | docker load
+
       - name: Start services (TimeScaleDB + Backend + Simulators)
         working-directory: server
-        run: docker compose up -d
+        # --no-build: images were loaded from the prebuilt tarball. Fail loudly
+        # if any service image is missing instead of silently falling back to
+        # a per-shard rebuild (the very cost this change is eliminating).
+        run: docker compose up -d --no-build
 
       - name: Start frontend
         working-directory: client

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -78,31 +78,25 @@ jobs:
           # Skip lint in CI to avoid import order issues from merged main branch
           npm run build:protoFleet
 
-      - name: Build plugins for CI (Linux AMD64)
-        run: |
-          # CI runners use linux/amd64, not arm64
-          # CGO_ENABLED=0 creates static binaries that work in Alpine (musl libc)
-          echo "Syncing Go workspace..."
-          go work sync
-          echo "Building static plugins for Linux AMD64..."
-          mkdir -p server/plugins
-          (cd plugin/proto && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../server/plugins/proto-plugin .)
-          (cd plugin/antminer && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../server/plugins/antminer-plugin .)
-          chmod +x server/plugins/proto-plugin server/plugins/antminer-plugin
-          echo "Plugins built successfully"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      # Docker cache is computed before the plugin build so the gitignored
+      # `server/plugins/*` binaries (not a Docker build input) don't enter
+      # the hash and spuriously bust the cache.
+      #
+      # Scheduled runs skip restore + save so they rebuild against fresh
+      # upstream base images without polluting the cache namespace with
+      # one-off entries that would evict other workflow caches.
       - name: Restore Docker image cache
         id: docker-image-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: github.event_name != 'schedule'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/docker-images
-          # `schedule` salts run_id so daily runs always rebuild against
-          # current base images. `server/**` because the Dockerfile does
-          # `COPY server/ ./` (e.g. go:embed migrations).
-          key: ${{ runner.os }}-protofleet-e2e-docker-${{ github.event_name == 'schedule' && format('schedule-{0}', github.run_id) || hashFiles('server/**') }}
+          # `server/**` because the Dockerfile does `COPY server/ ./`
+          # (e.g. go:embed migrations).
+          key: ${{ runner.os }}-protofleet-e2e-docker-${{ hashFiles('server/**') }}
 
       - name: Build E2E Docker images
         if: steps.docker-image-cache.outputs.cache-hit != 'true'
@@ -115,8 +109,10 @@ jobs:
           echo "::group::docker compose pull"
           docker compose pull --ignore-buildable
           echo "::endgroup::"
+          # `--pull` forces fresh upstream base images on rebuild so a stale
+          # cache miss key doesn't serve stale FROM layers.
           echo "::group::docker compose build"
-          docker compose build
+          docker compose build --pull
           echo "::endgroup::"
           echo "::group::Save images to compressed tarball"
           mapfile -t images < <(docker compose config --images | sort -u)
@@ -124,6 +120,26 @@ jobs:
           docker save "${images[@]}" | gzip > /tmp/docker-images/e2e-images.tar.gz
           ls -lh /tmp/docker-images/
           echo "::endgroup::"
+
+      - name: Save Docker image cache
+        if: github.event_name != 'schedule' && steps.docker-image-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/docker-images
+          key: ${{ runner.os }}-protofleet-e2e-docker-${{ hashFiles('server/**') }}
+
+      - name: Build plugins for CI (Linux AMD64)
+        run: |
+          # CI runners use linux/amd64, not arm64
+          # CGO_ENABLED=0 creates static binaries that work in Alpine (musl libc)
+          echo "Syncing Go workspace..."
+          go work sync
+          echo "Building static plugins for Linux AMD64..."
+          mkdir -p server/plugins
+          (cd plugin/proto && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../server/plugins/proto-plugin .)
+          (cd plugin/antminer && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../server/plugins/antminer-plugin .)
+          chmod +x server/plugins/proto-plugin server/plugins/antminer-plugin
+          echo "Plugins built successfully"
 
       - name: Upload client build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -94,12 +94,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      # Cache the docker-compose service images (fleet-api, timescaledb, 6x
-      # fake-antminer, 2x fake-proto-rig, ...) between CI runs. Keyed on the
-      # sources that actually change image contents; when the key matches,
-      # `docker load` is all the shards need and they skip the ~3-5 min
-      # per-shard `docker compose build` that was the Wave 1 critical-path
-      # regression.
       - name: Restore Docker image cache
         id: docker-image-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -221,9 +215,8 @@ jobs:
 
       - name: Start services (TimeScaleDB + Backend + Simulators)
         working-directory: server
-        # --no-build: images were loaded from the prebuilt tarball. Fail loudly
-        # if any service image is missing instead of silently falling back to
-        # a per-shard rebuild (the very cost this change is eliminating).
+        # --no-build: fail loudly on a missing image rather than falling back
+        # to a per-shard rebuild (the cost this change is eliminating).
         run: docker compose up -d --no-build
 
       - name: Start frontend


### PR DESCRIPTION
## Summary

Two related E2E CI follow-ups to [#43](https://github.com/block/proto-fleet/pull/43):

### 1. Prebuild and cache docker-compose images

Wave 1 moved the client and plugin builds into a shared job, but each e2e shard was still running `docker compose up -d` against raw build contexts \u2014 rebuilding `fleet-api`, `timescaledb`, 6\u00d7 `fake-antminer`, and 2\u00d7 `fake-proto-rig` from scratch every time. On shards that lost the Docker layer-cache lottery that added 3\u20135 min (the `teamAccounts mobile` shard on [#43](https://github.com/block/proto-fleet/pull/43) spent 3m 5s compiling `fake-antminer-hw-errors` alone).

Moved into the `build` job:

- Restore a cross-run image tarball via `actions/cache`, keyed on every input that changes image contents (`Dockerfile`, `go.sum`/`go.mod`, `server/**/*.go`, fake-miner contexts, `timescaledb/**`, compose files).
- On cache miss, `docker compose build` \u2192 enumerate images via `docker compose config --images` \u2192 `docker save | gzip` to `/tmp/docker-images/e2e-images.tar.gz`.
- Upload as the `protofleet-e2e-docker-images` artifact (retention 1 day).

Each shard now:

- Downloads the tarball, `docker load`s it.
- Runs `docker compose up -d --no-build`. The `--no-build` is intentional \u2014 if tags ever mismatch we'd rather see a loud failure than a silent 3\u20135 min rebuild.

Expected impact: warm-cache runs, the `build` job restores the tarball and skips compose build entirely; cold-cache runs pay one compose build (in `build`) instead of ~32 in parallel shards.

### 2. Non-Playwright node cache jobs become restore-only

Fixes a cache-key collision introduced in [#43](https://github.com/block/proto-fleet/pull/43). The `build` and `merge-reports` jobs shared the cache key `${{ runner.os }}-node-${{ hashFiles('client/package-lock.json') }}` with the E2E shard but cached a smaller path set. Cache entries are **immutable per key**, so whichever job saved first won; if `build` or `merge-reports` saved first, shards could never upload a cache that included `~/.cache/ms-playwright` \u2014 Playwright browsers got re-downloaded on every shard run.

Switched the two non-Playwright jobs to `actions/cache/restore` (restore-only). The E2E shard remains the sole writer and keeps saving the full `client/node_modules + ~/.cache/ms-playwright` pair.

![stay in your lane](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMHVseTNwczhoeDI3d2M0OWZxdjliZzM5bW0zeHlua2VzdW9vMmp2ZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oKIPxQH6bg2q4ka88/200.gif)

## Test plan

**Image cache**
- [ ] First CI run after this merges: confirm the `build` job logs `docker compose build` (cache miss) and uploads `protofleet-e2e-docker-images`.
- [ ] Spot-check one shard: it should log `Load Docker images` (no build) and `docker compose up -d --no-build` should succeed.
- [ ] Subsequent run with no server/Dockerfile/compose changes: confirm the `build` job logs `Cache restored from key: ...` and skips the build step entirely.
- [ ] Compare slowest-shard duration vs a recent main run; previously the teamAccounts-mobile outlier was 12m 35s, expected closer to ~7\u20138 min.
- [ ] Confirm `--no-build` surfaces a clear error if the artifact/tarball is ever missing (i.e. no silent fallback to per-shard rebuild).

**Node cache restore-only**
- [ ] Confirm the `build` job logs \"Cache restored from key: ...\" but does **not** log a save action.
- [ ] Confirm the `e2e-tests` shard job still saves both paths (`client/node_modules` and `~/.cache/ms-playwright`).
- [ ] On a subsequent PR run, confirm the `build` job restores the cache saved by a prior shard.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)