### PR TITLE
chore(lint): adopt react-hooks/preserve-manual-memoization (#53)

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -63,7 +63,6 @@ export default [
       "react-hooks/set-state-in-effect": "off",
       "react-hooks/refs": "off",
       "react-hooks/immutability": "off",
-      "react-hooks/preserve-manual-memoization": "off",
       "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -58,8 +58,8 @@ export default [
     rules: {
       ...reactHooks.configs.recommended.rules,
       // React Compiler rules added to the `recommended` preset in
-      // eslint-plugin-react-hooks 7.1. Disabled for now; see follow-up issue
-      // for adopting them incrementally.
+      // eslint-plugin-react-hooks 7.1. The rules listed below remain
+      // disabled and are being adopted incrementally via follow-up issues.
       "react-hooks/set-state-in-effect": "off",
       "react-hooks/refs": "off",
       "react-hooks/immutability": "off",

--- a/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.tsx
+++ b/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.tsx
@@ -118,21 +118,22 @@ const AuthenticateMiners = ({
 
   const handleBulkChange = useCallback(
     (value: string, id: string) => {
-      setBulkCredentials({ ...bulkCredentials, [id]: value.trim() });
+      setBulkCredentials((prev) => ({ ...prev, [id]: value.trim() }));
     },
-    [bulkCredentials],
+    [setBulkCredentials],
   );
 
   const handleMinerChange = useCallback(
     (deviceIdentifier: string, key: string, value: string) => {
-      const newValue = { ...credentials };
-      newValue[deviceIdentifier] = {
-        ...(credentials[deviceIdentifier] || {}),
-        [key]: value.trim(),
-      };
-      setCredentials(newValue);
+      setCredentials((prev) => ({
+        ...prev,
+        [deviceIdentifier]: {
+          ...(prev[deviceIdentifier] || {}),
+          [key]: value.trim(),
+        },
+      }));
     },
-    [credentials],
+    [setCredentials],
   );
 
   const [showMiners, setShowMiners] = useState(false);
@@ -439,6 +440,9 @@ const AuthenticateMiners = ({
     handleAuthenticationComplete,
     onClose,
     pair,
+    setHasMissingCredentials,
+    setAuthenticateLoading,
+    setMinerErrors,
   ]);
 
   return (


### PR DESCRIPTION
## Summary
- Closes #53. Adopts the React Compiler `react-hooks/preserve-manual-memoization` rule so the compiler can optimize `AuthenticateMiners`.
- Converted `handleBulkChange` and `handleMinerChange` to functional setState so their closures no longer capture the state value, only the stable setter.
- Added the missing setters (`setHasMissingCredentials`, `setAuthenticateLoading`, `setMinerErrors`) to `authenticateMiners`' deps array and removed the rule override in `client/eslint.config.js`.

## Test plan
- [x] `npm run lint` passes with the rule enabled
- [ ] Manually verify bulk + per-miner credential entry still works in the Authenticate miners modal