### PR TITLE
Add Fleet activity E2E tests

### DIFF
--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -2,6 +2,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { test as base } from "@playwright/test";
 import { CommonSteps } from "../helpers/commonSteps";
+import { ActivityPage } from "../pages/activity";
 import { AddMinersPage } from "../pages/addMiners";
 import { AuthPage } from "../pages/auth";
 import { LoginModalComponent } from "../pages/components/loginModal";
@@ -20,6 +21,7 @@ import { SettingsSecurityPage } from "../pages/settingsSecurity";
 import { SettingsTeamPage } from "../pages/settingsTeam";
 
 type PageFixtures = {
+  activityPage: ActivityPage;
   authPage: AuthPage;
   homePage: HomePage;
   minersPage: MinersPage;
@@ -40,6 +42,9 @@ type PageFixtures = {
 };
 
 export const test = base.extend<PageFixtures>({
+  activityPage: async ({ page, isMobile }, use) => {
+    await use(new ActivityPage(page, isMobile));
+  },
   authPage: async ({ page, isMobile }, use) => {
     await use(new AuthPage(page, isMobile));
   },

--- a/client/e2eTests/protoFleet/pages/activity.ts
+++ b/client/e2eTests/protoFleet/pages/activity.ts
@@ -1,0 +1,97 @@
+import { expect, type Locator } from "@playwright/test";
+import { BasePage } from "./base";
+
+export class ActivityPage extends BasePage {
+  async validateActivityPageOpened() {
+    await expect(this.page).toHaveURL(/.*\/activity/);
+    await this.validateTitle("Activity");
+  }
+
+  async waitForActivityListToLoad() {
+    const rows = this.page.getByTestId("list-row");
+    const emptyState = this.page.getByText("No activity to display.");
+    const noResults = this.page.getByText("No results", { exact: true });
+
+    await this.validateActivityPageOpened();
+
+    if ((await emptyState.isVisible().catch(() => false)) || (await noResults.isVisible().catch(() => false))) {
+      return;
+    }
+
+    await expect(rows.first()).toBeVisible();
+  }
+
+  async searchActivity(searchText: string) {
+    const input = this.page.locator("#activity-search");
+    await input.fill(searchText);
+  }
+
+  async clearSearchWithEscape() {
+    const input = this.page.locator("#activity-search");
+    await input.press("Escape");
+  }
+
+  async selectTypeFilter(optionLabel: string) {
+    await this.selectDropdownFilter("Type", optionLabel);
+  }
+
+  async selectUserFilter(optionLabel: string) {
+    await this.selectDropdownFilter("Users", optionLabel);
+  }
+
+  async validateNoResultsVisible() {
+    await expect(this.page.getByText("No results", { exact: true })).toBeVisible();
+    await expect(this.page.getByTestId("clear-all-filters-button")).toBeVisible();
+  }
+
+  async clearAllFilters() {
+    await this.page.getByTestId("clear-all-filters-button").click();
+  }
+
+  async validateSearchInputValue(expectedValue: string) {
+    await expect(this.page.locator("#activity-search")).toHaveValue(expectedValue);
+  }
+
+  async validateLatestActivityDescription(description: string) {
+    await expect(this.latestActivityRow()).toContainText(description);
+  }
+
+  async validateLatestActivityUser(username: string) {
+    await expect(this.latestActivityRow().getByTestId("user")).toHaveText(username);
+  }
+
+  async validateLatestActivityScope(scopeText: string) {
+    await expect(this.latestActivityRow().getByTestId("scope")).toContainText(scopeText);
+  }
+
+  async validateLatestActivityMarkedFailed() {
+    await expect(this.latestActivityRow().getByText("Failed", { exact: true })).toBeVisible();
+  }
+
+  async validateLatestActivityNotMarkedFailed() {
+    await expect(this.latestActivityRow().getByText("Failed", { exact: true })).toHaveCount(0);
+  }
+
+  async validateActivityDescriptionVisible(description: string) {
+    await expect(this.activityRowByDescription(description)).toBeVisible();
+  }
+
+  private latestActivityRow(): Locator {
+    return this.page.getByTestId("list-row").first();
+  }
+
+  private activityRowByDescription(description: string): Locator {
+    return this.page.getByTestId("list-row").filter({
+      has: this.page.getByTestId("type").getByText(description, { exact: false }),
+    });
+  }
+
+  private async selectDropdownFilter(title: string, optionLabel: string) {
+    await this.page.getByTestId(`filter-dropdown-${title}`).click();
+    const popover = this.page.getByTestId("dropdown-filter-popover");
+    await expect(popover).toBeVisible();
+    await popover.getByText(optionLabel, { exact: true }).click();
+    await popover.getByRole("button", { name: "Apply", exact: true }).click();
+    await expect(popover).toBeHidden();
+  }
+}

--- a/client/e2eTests/protoFleet/pages/activity.ts
+++ b/client/e2eTests/protoFleet/pages/activity.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator } from "@playwright/test";
+import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
 import { BasePage } from "./base";
 
 export class ActivityPage extends BasePage {
@@ -8,27 +9,28 @@ export class ActivityPage extends BasePage {
   }
 
   async waitForActivityListToLoad() {
-    const rows = this.page.getByTestId("list-row");
-    const emptyState = this.page.getByText("No activity to display.");
-    const noResults = this.page.getByText("No results", { exact: true });
-
     await this.validateActivityPageOpened();
+    await expect(async () => {
+      const initialState = await this.getVisibleActivityListState();
+      expect(initialState).not.toBe("loading");
 
-    if ((await emptyState.isVisible().catch(() => false)) || (await noResults.isVisible().catch(() => false))) {
-      return;
-    }
+      await new Promise((resolve) => setTimeout(resolve, DEFAULT_INTERVAL));
 
-    await expect(rows.first()).toBeVisible();
+      const settledState = await this.getVisibleActivityListState();
+      expect(settledState).toBe(initialState);
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [100, DEFAULT_INTERVAL] });
   }
 
   async searchActivity(searchText: string) {
     const input = this.page.locator("#activity-search");
     await input.fill(searchText);
+    await this.waitForActivityListToLoad();
   }
 
   async clearSearchWithEscape() {
     const input = this.page.locator("#activity-search");
     await input.press("Escape");
+    await this.waitForActivityListToLoad();
   }
 
   async selectTypeFilter(optionLabel: string) {
@@ -46,6 +48,7 @@ export class ActivityPage extends BasePage {
 
   async clearAllFilters() {
     await this.page.getByTestId("clear-all-filters-button").click();
+    await this.waitForActivityListToLoad();
   }
 
   async validateSearchInputValue(expectedValue: string) {
@@ -93,5 +96,33 @@ export class ActivityPage extends BasePage {
     await popover.getByText(optionLabel, { exact: true }).click();
     await popover.getByRole("button", { name: "Apply", exact: true }).click();
     await expect(popover).toBeHidden();
+    await this.waitForActivityListToLoad();
+  }
+
+  private async getVisibleActivityListState(): Promise<string> {
+    const rows = this.page.getByTestId("list-row");
+    const emptyState = this.page.getByText("No activity to display.");
+    const noResults = this.page.getByText("No results", { exact: true });
+
+    if (await noResults.isVisible().catch(() => false)) {
+      return "no-results";
+    }
+
+    if (await emptyState.isVisible().catch(() => false)) {
+      return "empty";
+    }
+
+    const rowCount = await rows.count();
+    if (
+      rowCount > 0 &&
+      (await rows
+        .first()
+        .isVisible()
+        .catch(() => false))
+    ) {
+      return `rows:${rowCount}`;
+    }
+
+    return "loading";
   }
 }

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -130,6 +130,12 @@ export class BasePage {
     await expect(this.page).toHaveURL(/.*\/racks/);
   }
 
+  async navigateToActivityPage() {
+    await this.clickNavigationMenuIfMobile();
+    await this.page.getByTestId("navigation-menu").locator('a[href="/activity"]').click();
+    await expect(this.page).toHaveURL(/.*\/activity/);
+  }
+
   async navigateToSettingsPage() {
     await this.clickNavigationMenuIfMobile();
     await this.clickExpandSettingsIfMobile();

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -138,6 +138,17 @@ export class MinersPage extends BasePage {
     await this.page.getByTestId("actions-menu-button").click();
   }
 
+  async clickBlinkLEDsButton() {
+    const quickAction = this.page.getByTestId("actions-menu-quick-action-blink-leds");
+    if (await quickAction.isVisible().catch(() => false)) {
+      await quickAction.click();
+      return;
+    }
+
+    await this.clickActionsMenuButton();
+    await this.page.getByText("Blink LEDs", { exact: true }).click();
+  }
+
   async validateActionBarMinerCount(expectedCount: number) {
     await expect(this.page.getByTestId("action-bar")).toBeVisible();
     if (expectedCount === 1) {

--- a/client/e2eTests/protoFleet/spec/activity.spec.ts
+++ b/client/e2eTests/protoFleet/spec/activity.spec.ts
@@ -1,0 +1,167 @@
+/* eslint-disable playwright/expect-expect */
+import { testConfig } from "../config/test.config";
+import { test } from "../fixtures/pageFixtures";
+import { CommonSteps } from "../helpers/commonSteps";
+import { generateRandomText } from "../helpers/testDataHelper";
+import { AuthPage } from "../pages/auth";
+import { MinersPage } from "../pages/miners";
+import { SettingsSchedulesPage } from "../pages/settingsSchedules";
+
+const SCHEDULE_PREFIX = "activity_schedule_e2e";
+
+test.describe("Proto Fleet - Activity", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test.afterEach("CLEANUP: Delete schedules created during activity tests", async ({ browser }, testInfo) => {
+    const isMobile = testInfo.project.use?.isMobile ?? false;
+    const viewport = testInfo.project.use?.viewport;
+    const context = await browser.newContext({ baseURL: testConfig.baseUrl, viewport });
+
+    try {
+      const page = await context.newPage();
+      await page.goto("/");
+
+      const authPage = new AuthPage(page, isMobile);
+      const minersPage = new MinersPage(page, isMobile);
+      const settingsSchedulesPage = new SettingsSchedulesPage(page, isMobile);
+      const commonSteps = new CommonSteps(authPage, minersPage);
+
+      await commonSteps.loginAsAdmin();
+      await settingsSchedulesPage.navigateToSchedulesSettings();
+      await settingsSchedulesPage.deleteSchedulesByPrefix(SCHEDULE_PREFIX);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("Blink LEDs bulk action is visible in Activity with the right miner count", async ({
+    activityPage,
+    commonSteps,
+    minersPage,
+  }) => {
+    await commonSteps.loginAsAdmin();
+    await commonSteps.goToMinersPage();
+
+    await test.step("Filter Proto miners as a workaround", async () => {
+      await minersPage.filterRigMiners();
+    });
+
+    await test.step("Select three miners and trigger Blink LEDs", async () => {
+      await minersPage.clickMinerCheckboxByIndex(0);
+      await minersPage.validateActionBarMinerCount(1);
+      await minersPage.clickMinerCheckboxByIndex(1);
+      await minersPage.validateActionBarMinerCount(2);
+      await minersPage.clickMinerCheckboxByIndex(2);
+      await minersPage.validateActionBarMinerCount(3);
+
+      await minersPage.clickBlinkLEDsButton();
+    });
+
+    await test.step("Validate Blink LEDs toasts", async () => {
+      await minersPage.validateTextInToastGroup("Blinking LEDs");
+      await minersPage.validateTextInToastGroup("Blinked LEDs");
+    });
+
+    await test.step("Open Activity and filter by user", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.selectUserFilter(testConfig.users.admin.username);
+    });
+
+    await test.step("Validate the latest activity row", async () => {
+      await activityPage.validateLatestActivityDescription("Blink LEDs");
+      await activityPage.validateLatestActivityScope("3 miners");
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityNotMarkedFailed();
+    });
+  });
+
+  test("Search, no-results, and clear-filters work for schedule activity", async ({
+    activityPage,
+    commonSteps,
+    settingsSchedulesPage,
+  }) => {
+    const scheduleName = generateRandomText(SCHEDULE_PREFIX);
+
+    await commonSteps.loginAsAdmin();
+
+    await test.step("Open schedules settings", async () => {
+      await settingsSchedulesPage.navigateToSchedulesSettings();
+      await settingsSchedulesPage.validateSchedulesPageOpened();
+    });
+
+    await test.step("Create a uniquely named schedule", async () => {
+      await settingsSchedulesPage.clickAddSchedule();
+      await settingsSchedulesPage.inputScheduleName(scheduleName);
+      await settingsSchedulesPage.selectStartDate(1);
+      await settingsSchedulesPage.openMinersTargetSelector();
+      await settingsSchedulesPage.waitForMinerSelectionModalToLoad();
+      await settingsSchedulesPage.selectFirstMiners(1);
+      await settingsSchedulesPage.confirmMinerSelection();
+      await settingsSchedulesPage.clickSaveSchedule();
+    });
+
+    await test.step("Validate the schedule was created", async () => {
+      await settingsSchedulesPage.validateScheduleVisible(scheduleName);
+    });
+
+    await test.step("Open Activity and search for the created schedule", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.searchActivity(scheduleName);
+    });
+
+    await test.step("Validate the searched schedule activity row", async () => {
+      await activityPage.validateActivityDescriptionVisible(`Created schedule: ${scheduleName}`);
+    });
+
+    await test.step("Filter Activity by type and validate the same row", async () => {
+      await activityPage.selectTypeFilter("Create schedule");
+      await activityPage.validateActivityDescriptionVisible(`Created schedule: ${scheduleName}`);
+    });
+
+    await test.step("Search for a missing activity entry", async () => {
+      await activityPage.searchActivity("missing-activity-entry");
+      await activityPage.validateNoResultsVisible();
+    });
+
+    await test.step("Clear filters and validate results return", async () => {
+      await activityPage.clearAllFilters();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.validateSearchInputValue("");
+      await activityPage.validateActivityDescriptionVisible(`Created schedule: ${scheduleName}`);
+    });
+  });
+});
+
+test.describe("Proto Fleet - Activity Login", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("Login activity is visible for the signed-in admin", async ({ authPage, activityPage }) => {
+    await test.step("Log in as admin", async () => {
+      await authPage.inputUsername(testConfig.users.admin.username);
+      await authPage.inputPassword(testConfig.users.admin.password);
+      await authPage.clickLogin();
+      await authPage.validateLoggedIn();
+    });
+
+    await test.step("Open Activity and filter to login events", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.selectTypeFilter("Login");
+      await activityPage.selectUserFilter(testConfig.users.admin.username);
+    });
+
+    await test.step("Validate the latest login row", async () => {
+      await activityPage.validateLatestActivityDescription("Login");
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityNotMarkedFailed();
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- added a ProtoFleet Activity page object and fixture wiring
- added Activity E2E coverage for login activity, Blink LEDs activity, and schedule search/filter behavior
- reused existing Fleet helpers and filtered Blink LEDs to Proto rig miners for stable supported-action coverage

## Why
The Activity screen did not have end-to-end coverage for core user-visible audit flows after the repo move.

## Validation
- `npx eslint e2eTests/protoFleet/spec/activity.spec.ts`
- `npx playwright test spec/activity.spec.ts --project=desktop --no-deps`
- `npx playwright test spec/activity.spec.ts --project=mobile --no-deps`