### PR TITLE
chore(lint): adopt react-hooks/immutability rule (#52)

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -62,7 +62,6 @@ export default [
       // disabled and are being adopted incrementally via follow-up issues.
       "react-hooks/set-state-in-effect": "off",
       "react-hooks/refs": "off",
-      "react-hooks/immutability": "off",
       "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/client/src/protoFleet/api/useActivity.ts
+++ b/client/src/protoFleet/api/useActivity.ts
@@ -40,7 +40,6 @@ export function useActivity({ filter, pageSize = 50 }: UseActivityParams): UseAc
     async (currentFilter: ActivityFilter | undefined, token: string, append: boolean) => {
       const requestId = ++requestIdRef.current;
       setIsLoading(true);
-      isLoadingRef.current = true;
       setError(null);
 
       try {
@@ -62,9 +61,7 @@ export function useActivity({ filter, pageSize = 50 }: UseActivityParams): UseAc
         }
 
         setPageToken(nextPageToken);
-        pageTokenRef.current = nextPageToken;
         setHasMore(nextPageToken !== "");
-        hasMoreRef.current = nextPageToken !== "";
       } catch (err) {
         if (requestId !== requestIdRef.current) return;
         handleAuthErrors({
@@ -76,7 +73,6 @@ export function useActivity({ filter, pageSize = 50 }: UseActivityParams): UseAc
       } finally {
         if (requestId === requestIdRef.current) {
           setIsLoading(false);
-          isLoadingRef.current = false;
         }
       }
     },
@@ -119,9 +115,7 @@ export function useActivity({ filter, pageSize = 50 }: UseActivityParams): UseAc
     if (isLoadingRef.current) return;
     setActivities([]);
     setPageToken("");
-    pageTokenRef.current = "";
     setHasMore(false);
-    hasMoreRef.current = false;
     setTotalCount(0);
     fetchRef.current(filterRef.current, "", false);
   }, []);
@@ -147,9 +141,7 @@ export function useActivity({ filter, pageSize = 50 }: UseActivityParams): UseAc
 
     setActivities([]);
     setPageToken("");
-    pageTokenRef.current = "";
     setHasMore(false);
-    hasMoreRef.current = false;
     setTotalCount(0);
 
     void fetchRef.current(filter, "", false);

--- a/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.tsx
+++ b/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.tsx
@@ -82,19 +82,6 @@ const AuthenticateMiners = ({
     };
   }, []);
 
-  useEffect(() => {
-    if (!isVisible) {
-      setBulkCredentials({ username: "", password: "" });
-      setCredentials({});
-      setHasMissingCredentials(false);
-      setMinerErrors([]);
-      setAuthenticateLoading(false);
-      setShowMiners(false);
-      setShowPasswords(false);
-      hasInitializedSelectionRef.current = false;
-    }
-  }, [isVisible]);
-
   const [bulkCredentials, setBulkCredentials] = useState<Credentials>({
     username: "",
     password: "",
@@ -158,12 +145,27 @@ const AuthenticateMiners = ({
     dropdownFilters: {},
   });
 
+  useEffect(() => {
+    if (!isVisible) {
+      setBulkCredentials({ username: "", password: "" });
+      setCredentials({});
+      setHasMissingCredentials(false);
+      setMinerErrors([]);
+      setAuthenticateLoading(false);
+      setShowMiners(false);
+      setShowPasswords(false);
+      // eslint-disable-next-line react-hooks/immutability -- one-shot init guard reset on close; ref is local-only
+      hasInitializedSelectionRef.current = false;
+    }
+  }, [isVisible]);
+
   // Initialize selection to all miners only on first data load
   // After initial load, preserve user selection even when miner list updates
   useEffect(() => {
     const minerIds = Object.keys(minersByIdentifier);
     if (!hasInitializedSelectionRef.current && minerIds.length > 0) {
       setSelectedMiners(minerIds);
+      // eslint-disable-next-line react-hooks/immutability -- one-shot init guard; ref is local-only
       hasInitializedSelectionRef.current = true;
     }
   }, [minersByIdentifier]);

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -1049,6 +1049,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
       : "",
   );
 
+  /* eslint-disable react-hooks/immutability -- callback-ref combiner forwards node to caller's mutable ref (standard ref-forwarding pattern) */
   const setCombinedScrollRef = useCallback(
     (node: HTMLDivElement | null) => {
       internalScrollRef.current = node;
@@ -1064,6 +1065,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
     },
     [scrollRef],
   );
+  /* eslint-enable react-hooks/immutability */
 
   useEffect(() => {
     if (!overflowContainer) {


### PR DESCRIPTION
## Summary
- Adopts `react-hooks/immutability` from the React Compiler preset; removes the rule disable in `client/eslint.config.js`.
- Cleans 17 violations across `useActivity.ts`, `AuthenticateMiners.tsx`, `List.tsx`. In `useActivity.ts` the redundant imperative ref-syncs are gone (mirror effects already handle it, matching `useFleet.ts`); in `AuthenticateMiners.tsx` state declarations now precede the visibility-reset effect.
- Two one-shot init-guard refs and `List.tsx`'s callback-ref combiner use justified inline disables — the rule's intended escape hatch for local-only / ref-forwarding patterns.

## Test plan
- [ ] CI lint passes with rule on
- [ ] `useActivity.test.ts` and AuthenticateMiners tests pass
- [ ] Smoke: open Activity page (paginate / refresh), open AuthenticateMiners modal (close / reopen), confirm List scroll-ref forwarding still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)