### PR TITLE
chore(client): adopt react-hooks/set-state-in-effect rule

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -39,10 +39,11 @@ export default [
       },
     },
     linterOptions: {
-      // Pre-existing `eslint-disable ... react-hooks/set-state-in-effect`
-      // comments are left in place while the rule itself is off (see below).
-      // They become unused-directives in that state, so silence the check
-      // until the rule is turned back on via the follow-up adoption issue.
+      // Pre-existing `eslint-disable ... react-hooks/refs` and
+      // `react-hooks/immutability` comments are left in place while those
+      // rules remain off (see below). They become unused-directives in that
+      // state, so silence the check until those rules are turned back on via
+      // their follow-up adoption issues.
       reportUnusedDisableDirectives: "off",
     },
     plugins: {
@@ -60,7 +61,8 @@ export default [
       // React Compiler rules added to the `recommended` preset in
       // eslint-plugin-react-hooks 7.1. The rules listed below remain
       // disabled and are being adopted incrementally via follow-up issues.
-      "react-hooks/set-state-in-effect": "off",
+      "react-hooks/refs": "off",
+      "react-hooks/immutability": "off",
       "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/client/src/protoFleet/api/useActivityFilterOptions.ts
+++ b/client/src/protoFleet/api/useActivityFilterOptions.ts
@@ -42,6 +42,7 @@ export function useActivityFilterOptions(): UseActivityFilterOptionsResult {
   }, [handleAuthErrors]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch on mount; setState inside async fetch is the external-sync pattern
     void fetchFilterOptions();
   }, [fetchFilterOptions]);
 

--- a/client/src/protoFleet/api/useComponentErrors.ts
+++ b/client/src/protoFleet/api/useComponentErrors.ts
@@ -143,6 +143,7 @@ export const useComponentErrors = (options?: UseComponentErrorsOptions): UseComp
   // Initial fetch + refetch on scope change
   useEffect(() => {
     if (authLoading) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch + refetch on scope change; setState inside async fetch is the external-sync pattern
     fetchComponentErrors();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authLoading, deviceIdentifiersKey]);

--- a/client/src/protoFleet/api/useDeviceErrors.ts
+++ b/client/src/protoFleet/api/useDeviceErrors.ts
@@ -143,6 +143,7 @@ export const useDeviceErrors = (deviceIds: string[]): UseDeviceErrorsReturn => {
     }
     prevDeviceIdsRef.current = deviceIds;
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- refetch on deviceIds change; setState inside async fetch is the external-sync pattern
     fetchDeviceErrors(deviceIds);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deviceIds]);

--- a/client/src/protoFleet/api/useDeviceSetStateCounts.ts
+++ b/client/src/protoFleet/api/useDeviceSetStateCounts.ts
@@ -97,6 +97,7 @@ export const useDeviceSetStateCounts = ({
 
   // Initial fetch + refetch on deviceSetId change
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch + refetch on deviceSetId change; setState inside async fetch is the external-sync pattern
     fetchStats();
   }, [fetchStats]);
 

--- a/client/src/protoFleet/api/useNetworkInfo.ts
+++ b/client/src/protoFleet/api/useNetworkInfo.ts
@@ -39,7 +39,7 @@ const useNetworkInfo = () => {
   }, [handleAuthErrors]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch on mount; setState inside async fetch is the external-sync pattern
     fetchData();
   }, [fetchData]);
 

--- a/client/src/protoFleet/components/MiningPools/MiningPoolsForm.tsx
+++ b/client/src/protoFleet/components/MiningPools/MiningPoolsForm.tsx
@@ -55,7 +55,7 @@ const MiningPoolsForm = ({ buttonLabel, onSaveRequested, onSaveDone, onSaveFaile
       ...existingPools.map((pool: Pool) => Number(pool.poolId)),
     );
     const emptyPools = getEmptyPoolsInfo(maxExistingPriority).slice(existingPools.length);
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local pools draft with existingPools prop when it changes
     setPools([...currentPools, ...emptyPools]);
   }, [existingPools]);
 

--- a/client/src/protoFleet/features/activity/pages/ActivityPage.tsx
+++ b/client/src/protoFleet/features/activity/pages/ActivityPage.tsx
@@ -61,7 +61,6 @@ const ActivityPage = () => {
 
   const [hasLoaded, setHasLoaded] = useState(false);
   const hasStartedLoadingRef = useRef(false);
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (isLoading) {
       hasStartedLoadingRef.current = true;
@@ -69,7 +68,6 @@ const ActivityPage = () => {
       setHasLoaded(true);
     }
   }, [isLoading, hasLoaded]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const isInitialLoad = isLoading && activities.length === 0 && !hasLoaded;
   const isLoadingMore = isLoading && activities.length > 0;

--- a/client/src/protoFleet/features/auth/components/AuthenticateFleetModal/AuthenticateFleetModal.tsx
+++ b/client/src/protoFleet/features/auth/components/AuthenticateFleetModal/AuthenticateFleetModal.tsx
@@ -31,6 +31,7 @@ const AuthenticateFleetModal = ({ open, purpose, onAuthenticated, onDismiss }: A
   // Reset form when modal is dismissed
   useEffect(() => {
     if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state on close
       setUsername("");
       setPassword("");
       setErrorMessage("");

--- a/client/src/protoFleet/features/auth/components/AuthenticateFleetModal/AuthenticateFleetModal.tsx
+++ b/client/src/protoFleet/features/auth/components/AuthenticateFleetModal/AuthenticateFleetModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { authClient } from "@/protoFleet/api/clients";
 import { Alert } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
@@ -29,15 +29,16 @@ const AuthenticateFleetModal = ({ open, purpose, onAuthenticated, onDismiss }: A
   const [isVerifying, setIsVerifying] = useState(false);
 
   // Reset form when modal is dismissed
-  useEffect(() => {
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
     if (!open) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state on close
       setUsername("");
       setPassword("");
       setErrorMessage("");
       setIsVerifying(false);
     }
-  }, [open]);
+  }
 
   const canContinue = username && password && !isVerifying;
 

--- a/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.tsx
+++ b/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.tsx
@@ -147,6 +147,7 @@ const AuthenticateMiners = ({
 
   useEffect(() => {
     if (!isVisible) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- resetting modal-internal state when parent hides the modal; owner-hoisting would leak modal lifecycle into every caller
       setBulkCredentials({ username: "", password: "" });
       setCredentials({});
       setHasMissingCredentials(false);

--- a/client/src/protoFleet/features/fleetManagement/components/ActionBar/ActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ActionBar/ActionBar.tsx
@@ -40,6 +40,7 @@ const ActionBar = ({
   const [hidden, setHidden] = useState(false);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reveal action bar when selection grows; local `show` can also be cleared independently by the close button
     setShow(selectedItems.length > 0);
   }, [selectedItems]);
 

--- a/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/PoolSelectionModal/PoolSelectionModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/PoolSelectionModal/PoolSelectionModal.tsx
@@ -83,13 +83,12 @@ const PoolSelectionModal = ({
 
   const { validatePool, createPool, miningPools } = usePools(isVisible);
 
-  // Reset internal state when hidden to mirror prior conditional-mount behavior.
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (isVisible) {
       return;
     }
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state on close to mirror prior conditional-mount behavior
     setSelectedPoolId(undefined);
     setSearchQuery("");
     setShowAddPoolModal(false);
@@ -98,7 +97,6 @@ const PoolSelectionModal = ({
     setShowConnectionCallout(false);
     setConnectionError(false);
   }, [isVisible]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const showSuccessCallout = useMemo(
     () => showConnectionCallout && !isTestingConnection && !connectionError,

--- a/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/PoolSelectionPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/PoolSelectionPage.tsx
@@ -108,6 +108,7 @@ const PoolSelectionPage = ({
     }
 
     loadedDeviceRef.current = null;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset widget state when hidden to mirror prior conditional-mount behavior
     setAssignedPoolData([]);
     setShowSelectionModal(false);
     setEditingPoolIndex(null);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/AddToGroupModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/AddToGroupModal.tsx
@@ -33,6 +33,7 @@ const AddToGroupModal = ({ open, onDismiss, selectedMiners, selectionMode, displ
   useEffect(() => {
     if (!open) return;
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state and fetch groups when modal opens
     setLoading(true);
     setGroups([]);
     setNewGroupName("");

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkRenameModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkRenameModal.tsx
@@ -271,6 +271,7 @@ const BulkRenameModal = ({
 
   useEffect(() => {
     if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state on close
       setActiveOptionsPropertyId(null);
       setActiveOptionsDraft(null);
       setShowDuplicateNamesWarning(false);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkWorkerNameModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkWorkerNameModal.tsx
@@ -572,6 +572,7 @@ const BulkWorkerNameModal = ({
 
   useEffect(() => {
     if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state on close
       setActiveOptionsPropertyId(null);
       setActiveOptionsDraft(null);
       setShowDuplicateNamesWarning(false);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/CoolingModeModal/CoolingModeModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/CoolingModeModal/CoolingModeModal.tsx
@@ -89,6 +89,7 @@ const CoolingModeModal = ({ open, minerCount, initialCoolingMode, onConfirm, onD
 
   // Sync state with prop when initialCoolingMode changes
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local selection with controlled initialCoolingMode prop
     setSelectedOption(coolingModeToOption(initialCoolingMode));
   }, [initialCoolingMode]);
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/CoolingModeModal/CoolingModeModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/CoolingModeModal/CoolingModeModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import clsx from "clsx";
 import { CoolingMode } from "@/protoFleet/api/generated/common/v1/cooling_pb";
 import { Fan } from "@/shared/assets/icons";
@@ -88,10 +88,11 @@ const CoolingModeModal = ({ open, minerCount, initialCoolingMode, onConfirm, onD
   );
 
   // Sync state with prop when initialCoolingMode changes
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local selection with controlled initialCoolingMode prop
+  const [prevInitialCoolingMode, setPrevInitialCoolingMode] = useState(initialCoolingMode);
+  if (prevInitialCoolingMode !== initialCoolingMode) {
+    setPrevInitialCoolingMode(initialCoolingMode);
     setSelectedOption(coolingModeToOption(initialCoolingMode));
-  }, [initialCoolingMode]);
+  }
 
   const handleConfirm = () => {
     if (!selectedOption) return;

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { Alert } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
@@ -28,9 +28,10 @@ const UpdateMinerPasswordModal = ({
   const [showWeakPasswordWarning, setShowWeakPasswordWarning] = useState(false);
 
   // Reset form when modal is dismissed
-  useEffect(() => {
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
     if (!open) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Form reset on modal close is intentional
       setCurrentPassword("");
       setNewPassword("");
       setConfirmPassword("");
@@ -38,7 +39,7 @@ const UpdateMinerPasswordModal = ({
       setValidationError("");
       setShowWeakPasswordWarning(false);
     }
-  }, [open]);
+  }
 
   const handleConfirm = useCallback(
     (forceWeakPassword: boolean) => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/ManageColumnsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/ManageColumnsModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   closestCenter,
   DndContext,
@@ -85,10 +85,12 @@ const ManageColumnsModal = ({ preferences, onDismiss, onSave }: ManageColumnsMod
     }),
   );
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync draft with incoming preferences prop when parent updates it
+  // Sync draft with incoming preferences prop when parent updates it
+  const [prevPreferences, setPrevPreferences] = useState(preferences);
+  if (prevPreferences !== preferences) {
+    setPrevPreferences(preferences);
     setDraftPreferences(preferences);
-  }, [preferences]);
+  }
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event;

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/ManageColumnsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/ManageColumnsModal.tsx
@@ -86,6 +86,7 @@ const ManageColumnsModal = ({ preferences, onDismiss, onSave }: ManageColumnsMod
   );
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync draft with incoming preferences prop when parent updates it
     setDraftPreferences(preferences);
   }, [preferences]);
 

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
@@ -158,6 +158,7 @@ const DeviceSetActionsMenuInner = ({
     const controller = new AbortController();
     const isCurrent = () => version === fetchVersionRef.current;
 
+    /* eslint-disable react-hooks/set-state-in-effect -- fetch members + miners on open; setState inside async callbacks is the external-sync pattern */
     if (!propMemberDeviceIdsRef.current) {
       setFetchedMemberIds(null);
       setFetchingMembers(true);
@@ -178,6 +179,7 @@ const DeviceSetActionsMenuInner = ({
     const filter = deviceSetType === "rack" ? { rackIds: [deviceSetId] } : { groupIds: [deviceSetId] };
     setFetchedMiners({});
     setFetchingMiners(true);
+    /* eslint-enable react-hooks/set-state-in-effect */
     fetchAllMinerSnapshots(filter, controller.signal)
       .then((map) => {
         if (isCurrent()) setFetchedMiners(map);

--- a/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
@@ -104,6 +104,7 @@ const GroupOverviewPage = () => {
   // Resolve group label → group object → device IDs
   useEffect(() => {
     if (!label) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- flag not-found state when label missing
       setNotFound(true);
       setLoading(false);
       return;

--- a/client/src/protoFleet/features/onboarding/components/Miners/Miners.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/Miners.tsx
@@ -87,7 +87,7 @@ const Miners = ({
   // Handle loading state with minimum display time
   useEffect(() => {
     if (discoveryPending) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- show loading immediately when discovery starts; minimum display time enforced on hide
       setShowScanLoading(true);
     } else {
       loadingTimeoutId.current = setTimeout(() => {

--- a/client/src/protoFleet/features/rackManagement/components/RackCard/MiniRackGrid.stories.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/RackCard/MiniRackGrid.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import MiniRackGrid from "./MiniRackGrid";
 import type { SlotStatus } from "./types";
@@ -55,11 +55,10 @@ function InteractiveMiniRackGrid({
   sleeping: number;
 }) {
   const total = cols * rows;
-  const [slots, setSlots] = useState<SlotStatus[]>(() => buildSlots(total, healthy, needsAttention, offline, sleeping));
-
-  useEffect(() => {
-    setSlots(buildSlots(total, healthy, needsAttention, offline, sleeping));
-  }, [total, healthy, needsAttention, offline, sleeping]);
+  const slots = useMemo<SlotStatus[]>(
+    () => buildSlots(total, healthy, needsAttention, offline, sleeping),
+    [total, healthy, needsAttention, offline, sleeping],
+  );
 
   return <MiniRackGrid cols={cols} rows={rows} slots={slots} />;
 }

--- a/client/src/protoFleet/features/rackManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/rackManagement/pages/RackOverviewPage.tsx
@@ -144,6 +144,7 @@ const RackOverviewPage = () => {
   // Initial resolution from URL param
   useEffect(() => {
     if (!rackIdParam) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- flag not-found state when URL param missing
       setNotFound(true);
       setLoading(false);
       return;

--- a/client/src/protoFleet/features/settings/components/AddTeamMemberModal.tsx
+++ b/client/src/protoFleet/features/settings/components/AddTeamMemberModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useUserManagement } from "@/protoFleet/api/useUserManagement";
 import { Alert, Copy, Success } from "@/shared/assets/icons";
 import Button, { variants } from "@/shared/components/Button";
@@ -27,18 +27,18 @@ const AddTeamMemberModal = ({ open, onDismiss, onSuccess }: AddTeamMemberModalPr
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
 
-  useEffect(() => {
-    if (isVisible) {
-      return;
+  // Reset form state when modal closes
+  const [prevVisible, setPrevVisible] = useState(isVisible);
+  if (prevVisible !== isVisible) {
+    setPrevVisible(isVisible);
+    if (!isVisible) {
+      setStep("enterUsername");
+      setUsername("");
+      setTemporaryPassword("");
+      setIsSubmitting(false);
+      setErrorMsg("");
     }
-
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state on close
-    setStep("enterUsername");
-    setUsername("");
-    setTemporaryPassword("");
-    setIsSubmitting(false);
-    setErrorMsg("");
-  }, [isVisible]);
+  }
 
   const handleCreateUser = useCallback(() => {
     if (!username.trim()) {

--- a/client/src/protoFleet/features/settings/components/ApiKeys.tsx
+++ b/client/src/protoFleet/features/settings/components/ApiKeys.tsx
@@ -55,14 +55,12 @@ const ApiKeys = () => {
     });
   }, [listApiKeys]);
 
-  // fetchApiKeys is a stable callback that internally manages state updates
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (isAdmin) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch when admin role resolves; setState inside async fetch is the external-sync pattern
       fetchApiKeys();
     }
   }, [fetchApiKeys, isAdmin]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const handleCreateSuccess = useCallback(() => {
     fetchApiKeys();

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import clsx from "clsx";
 import { create } from "@bufbuild/protobuf";
 import { AuthenticateRequestSchema } from "@/protoFleet/api/generated/auth/v1/auth_pb";
@@ -80,27 +80,25 @@ const AuthenticationSettings = () => {
   const [showWeakPasswordWarning, setShowWeakPasswordWarning] = useState(false);
 
   // Reset form state when modal closes
-  /* eslint-disable react-hooks/set-state-in-effect -- reset modal state on close */
-  useEffect(() => {
-    if (showModal) {
-      return;
+  const [prevShowModal, setPrevShowModal] = useState(showModal);
+  if (prevShowModal !== showModal) {
+    setPrevShowModal(showModal);
+    if (!showModal) {
+      setStep("authenticate");
+      setIsSubmitting(false);
+      setPassword("");
+      setScore(0);
+      setNewPassword("");
+      setConfirmPassword("");
+      setPasswordErrorMsg("");
+      setNewUsername("");
+      setUsernameErrorMsg("");
+      setAuthApiError(null);
+      setPasswordUpdateApiError(null);
+      setUsernameUpdateApiError(null);
+      setShowWeakPasswordWarning(false);
     }
-
-    setStep("authenticate");
-    setIsSubmitting(false);
-    setPassword("");
-    setScore(0);
-    setNewPassword("");
-    setConfirmPassword("");
-    setPasswordErrorMsg("");
-    setNewUsername("");
-    setUsernameErrorMsg("");
-    setAuthApiError(null);
-    setPasswordUpdateApiError(null);
-    setUsernameUpdateApiError(null);
-    setShowWeakPasswordWarning(false);
-  }, [showModal]);
-  /* eslint-enable react-hooks/set-state-in-effect */
+  }
 
   // Clear errors when user starts typing
   const handlePasswordChange = (value: string) => {

--- a/client/src/protoFleet/features/settings/components/CreateApiKeyModal.tsx
+++ b/client/src/protoFleet/features/settings/components/CreateApiKeyModal.tsx
@@ -45,21 +45,20 @@ const CreateApiKeyModal = ({ open, onDismiss, onSuccess }: CreateApiKeyModalProp
     };
   }, []);
 
-  useEffect(() => {
-    if (isVisible) {
-      return;
+  // Reset form state when modal closes
+  const [prevVisible, setPrevVisible] = useState(isVisible);
+  if (prevVisible !== isVisible) {
+    setPrevVisible(isVisible);
+    if (!isVisible) {
+      createRequestIDRef.current += 1;
+      setStep("enterDetails");
+      setName("");
+      setExpiresAt("");
+      setFullKey("");
+      setIsSubmitting(false);
+      setErrorMsg("");
     }
-
-    createRequestIDRef.current += 1;
-
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state on close
-    setStep("enterDetails");
-    setName("");
-    setExpiresAt("");
-    setFullKey("");
-    setIsSubmitting(false);
-    setErrorMsg("");
-  }, [isVisible]);
+  }
 
   const handleDismiss = useCallback(() => {
     createRequestIDRef.current += 1;

--- a/client/src/protoFleet/features/settings/components/CreateApiKeyModal.tsx
+++ b/client/src/protoFleet/features/settings/components/CreateApiKeyModal.tsx
@@ -52,6 +52,7 @@ const CreateApiKeyModal = ({ open, onDismiss, onSuccess }: CreateApiKeyModalProp
 
     createRequestIDRef.current += 1;
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state on close
     setStep("enterDetails");
     setName("");
     setExpiresAt("");

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -80,12 +80,10 @@ const Firmware = () => {
       });
   }, [listFirmwareFiles]);
 
-  // fetchFiles is a stable callback that internally manages state updates
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch on mount; setState inside async fetch is the external-sync pattern
     fetchFiles();
   }, [fetchFiles]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const handleDeleteFile = useCallback((file: FirmwareFileData) => {
     setFileToDelete(file);

--- a/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
@@ -360,6 +360,7 @@ const ScheduleModal = ({
       return;
     }
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset available-target state and fetch racks/groups when modal opens
     setAvailableGroupIds(new Set());
     setHasLoadedAvailableGroups(false);
 

--- a/client/src/protoFleet/features/settings/components/Team.tsx
+++ b/client/src/protoFleet/features/settings/components/Team.tsx
@@ -61,12 +61,10 @@ const Team = () => {
     });
   }, [listUsers]);
 
-  // fetchUsers is a stable callback that internally manages state updates
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch on mount; setState inside async fetch is the external-sync pattern
     fetchUsers();
   }, [fetchUsers]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const colConfig: ColConfig<UserData, string, UserColumns> = useMemo(
     () => ({

--- a/client/src/protoFleet/hooks/useDeviceSetListState.ts
+++ b/client/src/protoFleet/hooks/useDeviceSetListState.ts
@@ -136,11 +136,10 @@ export function useDeviceSetListState(
     fetchPage(0, undefined);
   }, [fetchPage]);
 
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset pagination and refetch when filters change; setState inside async fetch is the external-sync pattern
     resetAndFetch();
   }, [resetAndFetch]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const handleSort = useCallback(
     (field: DeviceSetColumn, direction: SortDirection) => {

--- a/client/src/protoOS/api/hooks/useHardware.ts
+++ b/client/src/protoOS/api/hooks/useHardware.ts
@@ -83,7 +83,7 @@ const useHardware = () => {
   }, [api, authRetry]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch on mount; setState inside async fetch is the external-sync pattern
     fetchHardware();
   }, [fetchHardware]);
 

--- a/client/src/protoOS/api/hooks/useHashboards.ts
+++ b/client/src/protoOS/api/hooks/useHashboards.ts
@@ -15,7 +15,7 @@ const useHashboards = () => {
       return;
     }
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch on mount; setState inside async fetch is the external-sync pattern
     setPending(true);
 
     api

--- a/client/src/protoOS/api/hooks/useTimeSeries.ts
+++ b/client/src/protoOS/api/hooks/useTimeSeries.ts
@@ -128,6 +128,7 @@ const useTimeSeries = ({ duration, levels, poll = true, pollIntervalMs = 30 * 10
   // Trigger fetch when hashboards change or when fetchData dependencies change (duration, levels, api)
   useEffect(() => {
     if (hashboardCount > 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch on deps change; setState inside async fetch is the external-sync pattern
       fetchData();
     }
   }, [hashboardCount, fetchData]);

--- a/client/src/protoOS/components/App/App.tsx
+++ b/client/src/protoOS/components/App/App.tsx
@@ -157,7 +157,7 @@ const App = ({
       // as long as the mining status is not normal, keep checking the mining status
     } else if (isMining) {
       clearInterval(intervalId);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- mark init page shown once miner reaches mining state
       setInitPage(true);
       // on first load, if the device is booting up, check the mining status until it's running
     } else if (isWarmingUp && !intervalId && !initPage) {

--- a/client/src/protoOS/components/App/WakeCallout.tsx
+++ b/client/src/protoOS/components/App/WakeCallout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import FansDetectedDialog from "./FansDetectedDialog";
 import { useCoolingStatus } from "@/protoOS/api/hooks/useCoolingStatus";
 
@@ -25,20 +25,15 @@ const WakeCallout = ({ afterWake, onWake }: WakeCalloutProps) => {
   const fans = useFansTelemetry();
   const isSleeping = useIsSleeping();
   const [showFansDetectedDialog, setShowFansDetectedDialog] = useState(false);
-  const previousIsSleepingRef = useRef(isSleeping);
 
-  // Show dialog after miner wakes up if in immersion mode with fans running
-  useEffect(() => {
-    // Detect when miner wakes up (isSleeping goes from true to false)
-    if (previousIsSleepingRef.current && !isSleeping) {
-      if (areFansDetectedInImmersionMode(fans, coolingMode)) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- Show dialog on wake completion (isSleeping: true → false transition)
-        setShowFansDetectedDialog(true);
-      }
+  // Show dialog on wake completion (isSleeping true→false) when fans are detected in immersion mode
+  const [prevIsSleeping, setPrevIsSleeping] = useState(isSleeping);
+  if (prevIsSleeping !== isSleeping) {
+    setPrevIsSleeping(isSleeping);
+    if (prevIsSleeping && !isSleeping && areFansDetectedInImmersionMode(fans, coolingMode)) {
+      setShowFansDetectedDialog(true);
     }
-
-    previousIsSleepingRef.current = isSleeping;
-  }, [isSleeping, shouldWake, fans, coolingMode]);
+  }
 
   const handleContinue = () => {
     setShowFansDetectedDialog(false);

--- a/client/src/protoOS/components/MiningPools/Pools.tsx
+++ b/client/src/protoOS/components/MiningPools/Pools.tsx
@@ -213,6 +213,7 @@ const Pools = ({ onChangePools, pools }: PoolsProps) => {
 
   useEffect(() => {
     if (!isEditing) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local pool draft with upstream pools when not actively editing
       setLocalPools(deepClone(pools));
     }
   }, [isEditing, pools]);

--- a/client/src/protoOS/components/OnboardingSettingUp/OnboardingSettingUpWrapper.tsx
+++ b/client/src/protoOS/components/OnboardingSettingUp/OnboardingSettingUpWrapper.tsx
@@ -43,7 +43,7 @@ const OnboardingSettingUpWrapper = ({
   useEffect(() => {
     if (poolStatus !== statuses.pending && intervalId) {
       clearInterval(intervalId);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- clear interval ref after polling ends
       setIntervalId(undefined);
     }
   }, [intervalId, poolStatus]);
@@ -51,7 +51,7 @@ const OnboardingSettingUpWrapper = ({
   useEffect(() => {
     if (poolStatus === statuses.fetch) {
       setCreatePoolsError(undefined);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- transition to pending before kicking off async pool creation
       setPoolStatus(statuses.pending);
       const validPools = pools.filter(isValidPool);
       createPools({

--- a/client/src/protoOS/components/OnboardingSettingUp/OnboardingSettingUpWrapper.tsx
+++ b/client/src/protoOS/components/OnboardingSettingUp/OnboardingSettingUpWrapper.tsx
@@ -40,13 +40,16 @@ const OnboardingSettingUpWrapper = ({
     });
   }, [fetchPools]);
 
+  // Stop polling once poolStatus settles; the cleanup clears the interval
+  // using the captured id before intervalId is reassigned to undefined.
   useEffect(() => {
-    if (poolStatus !== statuses.pending && intervalId) {
-      clearInterval(intervalId);
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- clear interval ref after polling ends
-      setIntervalId(undefined);
-    }
-  }, [intervalId, poolStatus]);
+    if (!intervalId) return;
+    return () => clearInterval(intervalId);
+  }, [intervalId]);
+
+  if (poolStatus !== statuses.pending && intervalId !== undefined) {
+    setIntervalId(undefined);
+  }
 
   useEffect(() => {
     if (poolStatus === statuses.fetch) {

--- a/client/src/protoOS/components/PageHeader/Power/PowerWidget.tsx
+++ b/client/src/protoOS/components/PageHeader/Power/PowerWidget.tsx
@@ -81,9 +81,16 @@ const PowerWidget = ({
       } else if (pausedAuthAction === AUTH_ACTIONS.sleep) {
         setWarnSleep(true);
       }
-      setPausedAuthAction(null);
     }
   }
+
+  // Clear the auth-store flag after the warn dialog has surfaced (external store
+  // mutation must not happen in render; subscribers should only see updates post-commit)
+  useEffect(() => {
+    if (hasAccess && pausedAuthAction) {
+      setPausedAuthAction(null);
+    }
+  }, [hasAccess, pausedAuthAction, setPausedAuthAction]);
 
   useEffect(() => {
     if (dismissedLoginModal) {

--- a/client/src/protoOS/components/PageHeader/Power/PowerWidget.tsx
+++ b/client/src/protoOS/components/PageHeader/Power/PowerWidget.tsx
@@ -69,17 +69,21 @@ const PowerWidget = ({
     ignoreSelectors: [".popover-content"],
   });
 
-  useEffect(() => {
+  // Open the confirmation dialog once auth is available for a paused action
+  const [prevHasAccess, setPrevHasAccess] = useState(hasAccess);
+  const [prevPausedAuthAction, setPrevPausedAuthAction] = useState(pausedAuthAction);
+  if (prevHasAccess !== hasAccess || prevPausedAuthAction !== pausedAuthAction) {
+    setPrevHasAccess(hasAccess);
+    setPrevPausedAuthAction(pausedAuthAction);
     if (hasAccess && pausedAuthAction) {
       if (pausedAuthAction === AUTH_ACTIONS.reboot) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- open reboot confirmation once auth is available
         setWarnReboot(true);
       } else if (pausedAuthAction === AUTH_ACTIONS.sleep) {
         setWarnSleep(true);
       }
       setPausedAuthAction(null);
     }
-  }, [hasAccess, pausedAuthAction, setPausedAuthAction]);
+  }
 
   useEffect(() => {
     if (dismissedLoginModal) {

--- a/client/src/protoOS/components/PageHeader/Power/PowerWidget.tsx
+++ b/client/src/protoOS/components/PageHeader/Power/PowerWidget.tsx
@@ -71,14 +71,13 @@ const PowerWidget = ({
 
   useEffect(() => {
     if (hasAccess && pausedAuthAction) {
-      /* eslint-disable react-hooks/set-state-in-effect */
       if (pausedAuthAction === AUTH_ACTIONS.reboot) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- open reboot confirmation once auth is available
         setWarnReboot(true);
       } else if (pausedAuthAction === AUTH_ACTIONS.sleep) {
         setWarnSleep(true);
       }
       setPausedAuthAction(null);
-      /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [hasAccess, pausedAuthAction, setPausedAuthAction]);
 
@@ -120,8 +119,8 @@ const PowerWidget = ({
 
   useEffect(() => {
     if (shouldReboot) {
-      /* eslint-disable react-hooks/set-state-in-effect */
       if (rebootError) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- clear pending reboot flag once the reboot request settles
         setShouldReboot(false);
         if (rebootError?.status === 401) {
           setHasAccess(false);
@@ -132,14 +131,13 @@ const PowerWidget = ({
         setShouldReboot(false);
         afterReboot?.();
       }
-      /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [shouldReboot, isAwake, afterReboot, rebootError, setHasAccess, setPausedAuthAction]);
 
   useEffect(() => {
     if (shouldSleep) {
-      /* eslint-disable react-hooks/set-state-in-effect */
       if (sleepError) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- clear pending sleep flag once the sleep request settles
         setShouldSleep(false);
         if (sleepError?.status === 401) {
           setHasAccess(false);
@@ -150,7 +148,6 @@ const PowerWidget = ({
         setShouldSleep(false);
         afterSleep?.();
       }
-      /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [afterSleep, isSleeping, setHasAccess, shouldSleep, sleepError, setPausedAuthAction]);
 

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
@@ -74,17 +74,24 @@ const PowerTarget = () => {
     }
   }, [hasAccess, pausedAuthAction, setPausedAuthAction, updateMiningTarget, lastMiningTarget]);
 
-  // Abandon paused mining-target update when user dismisses login modal
+  // Abandon paused mining-target update when user dismisses login modal.
+  // Local state clears in render-phase; external store writes happen in the effect below
+  // (mutating a shared store during render can notify other subscribers mid-reconciliation).
   const [prevDismissedLoginModal, setPrevDismissedLoginModal] = useState(dismissedLoginModal);
   if (prevDismissedLoginModal !== dismissedLoginModal) {
     setPrevDismissedLoginModal(dismissedLoginModal);
     if (dismissedLoginModal) {
-      setPending(false);
-      setPausedAuthAction(null);
-      setDismissedLoginModal(false);
       setLastMiningTarget(null);
     }
   }
+
+  useEffect(() => {
+    if (dismissedLoginModal) {
+      setPending(false);
+      setPausedAuthAction(null);
+      setDismissedLoginModal(false);
+    }
+  }, [dismissedLoginModal, setPending, setPausedAuthAction, setDismissedLoginModal]);
 
   useEffect(() => {
     return () => {

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
@@ -74,15 +74,17 @@ const PowerTarget = () => {
     }
   }, [hasAccess, pausedAuthAction, setPausedAuthAction, updateMiningTarget, lastMiningTarget]);
 
-  useEffect(() => {
+  // Abandon paused mining-target update when user dismisses login modal
+  const [prevDismissedLoginModal, setPrevDismissedLoginModal] = useState(dismissedLoginModal);
+  if (prevDismissedLoginModal !== dismissedLoginModal) {
+    setPrevDismissedLoginModal(dismissedLoginModal);
     if (dismissedLoginModal) {
       setPending(false);
       setPausedAuthAction(null);
       setDismissedLoginModal(false);
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- abandon paused mining-target update when user dismisses login modal
       setLastMiningTarget(null);
     }
-  }, [dismissedLoginModal, setDismissedLoginModal, setPausedAuthAction, setPending]);
+  }
 
   useEffect(() => {
     return () => {

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
@@ -68,21 +68,19 @@ const PowerTarget = () => {
   useEffect(() => {
     if (hasAccess && pausedAuthAction === AUTH_ACTIONS.miningTarget && lastMiningTarget) {
       updateMiningTarget(lastMiningTarget);
-      /* eslint-disable react-hooks/set-state-in-effect */
       setPausedAuthAction(null);
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- resume paused mining-target update once auth is available
       setLastMiningTarget(null);
-      /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [hasAccess, pausedAuthAction, setPausedAuthAction, updateMiningTarget, lastMiningTarget]);
 
   useEffect(() => {
     if (dismissedLoginModal) {
-      /* eslint-disable react-hooks/set-state-in-effect */
       setPending(false);
       setPausedAuthAction(null);
       setDismissedLoginModal(false);
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- abandon paused mining-target update when user dismisses login modal
       setLastMiningTarget(null);
-      /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [dismissedLoginModal, setDismissedLoginModal, setPausedAuthAction, setPending]);
 

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { RefObject, useCallback, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
 import { PerformanceMode } from "@/protoOS/api/generatedApi";
 import { useMiningTarget } from "@/protoOS/api/hooks/useMiningTarget";
@@ -68,10 +68,14 @@ const PowerTargetPopover = ({ onDismiss, onUpdateStart }: PowerTargetPopoverProp
     }
   };
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local draft with performanceMode prop when it changes
+  // Sync local draft with performanceMode when it (or pending) changes
+  const [prevPerformanceMode, setPrevPerformanceMode] = useState(performanceMode);
+  const [prevPending, setPrevPending] = useState(pending);
+  if (prevPerformanceMode !== performanceMode || prevPending !== pending) {
+    setPrevPerformanceMode(performanceMode);
+    setPrevPending(pending);
     setSelectedPerformanceMode(performanceMode);
-  }, [pending, performanceMode]);
+  }
 
   // Converts the selected power target to whole watts (the API rejects fractional watts).
   const calculatePowerTargetWattage = useCallback((): number | undefined => {

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
@@ -69,7 +69,7 @@ const PowerTargetPopover = ({ onDismiss, onUpdateStart }: PowerTargetPopoverProp
   };
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local draft with performanceMode prop when it changes
     setSelectedPerformanceMode(performanceMode);
   }, [pending, performanceMode]);
 

--- a/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/AsicChart/AsicChart.tsx
+++ b/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/AsicChart/AsicChart.tsx
@@ -27,10 +27,8 @@ const AsicChart = ({ hashrateData, temperatureData }: AsicChartProps) => {
     return getChartData({ hashrateData, temperatureData });
   }, [hashrateData, temperatureData]);
 
-  // initialize animation flags
+  // clear animation flag after initial render completes
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- safe usage since we only render this once
-    setShouldAnimate(true);
     const timeoutId = setTimeout(() => {
       setShouldAnimate(false);
     }, ANIMATION_DURATION);

--- a/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatus/FirmwareUpdateStatusWrapper.tsx
+++ b/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatus/FirmwareUpdateStatusWrapper.tsx
@@ -26,7 +26,7 @@ const FirmwareUpdateStatusWrapper = () => {
 
   useEffect(() => {
     if (dismissedLoginModal) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- abandon pending update when user dismisses login modal
       setUpdatePending(false);
       setDismissedLoginModal(false);
       setPausedAuthAction(null);

--- a/client/src/protoOS/features/onboarding/components/MiningPool/MiningPool.tsx
+++ b/client/src/protoOS/features/onboarding/components/MiningPool/MiningPool.tsx
@@ -40,7 +40,7 @@ const MiningPoolPage = () => {
 
   useEffect(() => {
     if (settingUpMiner && createPoolsError?.status === 422) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- pause setup and prompt reauth when backend responds 422
       setSettingUpMiner(false);
       setPausedAction(true);
     }

--- a/client/src/protoOS/features/onboarding/components/MiningPool/MiningPool.tsx
+++ b/client/src/protoOS/features/onboarding/components/MiningPool/MiningPool.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import clsx from "clsx";
 import { useCoolingStatus } from "@/protoOS/api";
 import { ErrorProps } from "@/protoOS/api/apiResponseTypes";
@@ -38,13 +38,16 @@ const MiningPoolPage = () => {
   const isCoolingStatusReady = coolingLoaded && !coolingPending;
   const noFansConnected = isCoolingStatusReady && areAllFansDisconnected(coolingData?.fans);
 
-  useEffect(() => {
-    if (settingUpMiner && createPoolsError?.status === 422) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- pause setup and prompt reauth when backend responds 422
+  // Pause setup and prompt reauth when backend responds 422
+  const errorStatus = createPoolsError?.status;
+  const [prevErrorStatus, setPrevErrorStatus] = useState(errorStatus);
+  if (prevErrorStatus !== errorStatus) {
+    setPrevErrorStatus(errorStatus);
+    if (settingUpMiner && errorStatus === 422) {
       setSettingUpMiner(false);
       setPausedAction(true);
     }
-  }, [createPoolsError?.status, settingUpMiner]);
+  }
 
   const proceedWithSetup = useCallback(() => {
     setPausedAction(true);

--- a/client/src/protoOS/features/onboarding/components/Onboarding/Onboarding.tsx
+++ b/client/src/protoOS/features/onboarding/components/Onboarding/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import clsx from "clsx";
 import { ErrorProps } from "@/protoOS/api/apiResponseTypes";
 
@@ -64,15 +64,22 @@ const Onboarding = () => {
     setWaitingForAuth(false);
   }
 
-  // Abandon paused action when user dismisses login modal
+  // Abandon paused action when user dismisses login modal.
+  // Local state clears in render-phase; the Zustand store write happens in the effect below
+  // (mutating a shared store during render can notify other subscribers mid-reconciliation).
   const [prevDismissedLoginModal, setPrevDismissedLoginModal] = useState(dismissedLoginModal);
   if (prevDismissedLoginModal !== dismissedLoginModal) {
     setPrevDismissedLoginModal(dismissedLoginModal);
     if (dismissedLoginModal) {
       setPausedAction(false);
-      setDismissedLoginModal(false);
     }
   }
+
+  useEffect(() => {
+    if (dismissedLoginModal) {
+      setDismissedLoginModal(false);
+    }
+  }, [dismissedLoginModal, setDismissedLoginModal]);
 
   const onContinue = useCallback(
     (ignoreBackupPools?: boolean) => {

--- a/client/src/protoOS/features/onboarding/components/Onboarding/Onboarding.tsx
+++ b/client/src/protoOS/features/onboarding/components/Onboarding/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import clsx from "clsx";
 import { ErrorProps } from "@/protoOS/api/apiResponseTypes";
 
@@ -31,36 +31,48 @@ const Onboarding = () => {
   const [createPoolsError, setCreatePoolsError] = useState<ErrorProps>();
   const { checkAccess, hasAccess, setHasAccess } = useAccessToken(pausedAction);
 
-  useEffect(() => {
+  // Resume paused onboarding action once auth becomes available
+  const [prevHasAccess, setPrevHasAccess] = useState(hasAccess);
+  const [prevPausedAction, setPrevPausedAction] = useState(pausedAction);
+  const [prevWaitingForAuth, setPrevWaitingForAuth] = useState(waitingForAuth);
+  if (prevHasAccess !== hasAccess || prevPausedAction !== pausedAction || prevWaitingForAuth !== waitingForAuth) {
+    setPrevHasAccess(hasAccess);
+    setPrevPausedAction(pausedAction);
+    setPrevWaitingForAuth(waitingForAuth);
     if (hasAccess && pausedAction && waitingForAuth) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- resume paused onboarding action once auth becomes available
       setPausedAction(false);
       // have to reset the error here, otherwise it would cause an infinite cycle
       setCreatePoolsError(undefined);
       setSettingUpMiner(true);
     }
-  }, [hasAccess, pausedAction, waitingForAuth]);
+  }
 
-  useEffect(() => {
-    const status = createPoolsError?.status;
-    if (settingUpMiner && (status === 401 || status === 422)) {
-      if (status === 401) {
+  // Pause setup flow and surface login modal when backend responds with auth error
+  const errorStatus = createPoolsError?.status;
+  const [prevErrorStatus, setPrevErrorStatus] = useState(errorStatus);
+  const [prevSettingUpMiner, setPrevSettingUpMiner] = useState(settingUpMiner);
+  if (prevErrorStatus !== errorStatus || prevSettingUpMiner !== settingUpMiner) {
+    setPrevErrorStatus(errorStatus);
+    setPrevSettingUpMiner(settingUpMiner);
+    if (settingUpMiner && (errorStatus === 401 || errorStatus === 422)) {
+      if (errorStatus === 401) {
         setHasAccess(false);
       }
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- pause setup flow and surface login modal when backend responds with auth error
       setSettingUpMiner(false);
       setPausedAction(true);
     }
     setWaitingForAuth(false);
-  }, [setHasAccess, settingUpMiner, createPoolsError?.status]);
+  }
 
-  useEffect(() => {
+  // Abandon paused action when user dismisses login modal
+  const [prevDismissedLoginModal, setPrevDismissedLoginModal] = useState(dismissedLoginModal);
+  if (prevDismissedLoginModal !== dismissedLoginModal) {
+    setPrevDismissedLoginModal(dismissedLoginModal);
     if (dismissedLoginModal) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- abandon paused action when user dismisses login modal
       setPausedAction(false);
       setDismissedLoginModal(false);
     }
-  }, [dismissedLoginModal, setDismissedLoginModal]);
+  }
 
   const onContinue = useCallback(
     (ignoreBackupPools?: boolean) => {

--- a/client/src/protoOS/features/onboarding/components/Onboarding/Onboarding.tsx
+++ b/client/src/protoOS/features/onboarding/components/Onboarding/Onboarding.tsx
@@ -33,7 +33,7 @@ const Onboarding = () => {
 
   useEffect(() => {
     if (hasAccess && pausedAction && waitingForAuth) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- resume paused onboarding action once auth becomes available
       setPausedAction(false);
       // have to reset the error here, otherwise it would cause an infinite cycle
       setCreatePoolsError(undefined);
@@ -47,7 +47,7 @@ const Onboarding = () => {
       if (status === 401) {
         setHasAccess(false);
       }
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- pause setup flow and surface login modal when backend responds with auth error
       setSettingUpMiner(false);
       setPausedAction(true);
     }
@@ -56,7 +56,7 @@ const Onboarding = () => {
 
   useEffect(() => {
     if (dismissedLoginModal) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- abandon paused action when user dismisses login modal
       setPausedAction(false);
       setDismissedLoginModal(false);
     }

--- a/client/src/protoOS/features/settings/components/Cooling/Cooling.tsx
+++ b/client/src/protoOS/features/settings/components/Cooling/Cooling.tsx
@@ -85,21 +85,20 @@ const Cooling = () => {
   useEffect(() => {
     // Read from store instead of local hook state for immediate updates
     if (storeCoolingMode) {
-      /* eslint-disable react-hooks/set-state-in-effect */
       if (isAirCooledMode(storeCoolingMode)) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local draft with cooling store once it resolves
         setCoolingMode(COOLING_MODES.air);
         setLoading(false);
       } else if (isImmersionMode(storeCoolingMode)) {
         setCoolingMode(COOLING_MODES.immersion);
         setLoading(false);
       }
-      /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [storeCoolingMode]);
 
   useEffect(() => {
     if (isSleeping) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- dismiss sleep dialog once miner reports sleeping state
       setShowSleepDialog(false);
     }
   }, [isSleeping]);

--- a/client/src/protoOS/features/settings/components/Cooling/Cooling.tsx
+++ b/client/src/protoOS/features/settings/components/Cooling/Cooling.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import clsx from "clsx";
 import InfoModal from "./InfoModal";
 import { useCoolingStatus } from "@/protoOS/api";
@@ -82,11 +82,12 @@ const Cooling = () => {
   const [showLearnMoreModal, setShowLearnMoreModal] = useState<boolean>(false);
   const [showSleepDialog, setShowSleepDialog] = useState<boolean>(false);
 
-  useEffect(() => {
-    // Read from store instead of local hook state for immediate updates
+  // Sync local draft with cooling store once it resolves
+  const [prevStoreCoolingMode, setPrevStoreCoolingMode] = useState(storeCoolingMode);
+  if (prevStoreCoolingMode !== storeCoolingMode) {
+    setPrevStoreCoolingMode(storeCoolingMode);
     if (storeCoolingMode) {
       if (isAirCooledMode(storeCoolingMode)) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local draft with cooling store once it resolves
         setCoolingMode(COOLING_MODES.air);
         setLoading(false);
       } else if (isImmersionMode(storeCoolingMode)) {
@@ -94,14 +95,16 @@ const Cooling = () => {
         setLoading(false);
       }
     }
-  }, [storeCoolingMode]);
+  }
 
-  useEffect(() => {
+  // Dismiss sleep dialog once miner reports sleeping state
+  const [prevIsSleeping, setPrevIsSleeping] = useState(isSleeping);
+  if (prevIsSleeping !== isSleeping) {
+    setPrevIsSleeping(isSleeping);
     if (isSleeping) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- dismiss sleep dialog once miner reports sleeping state
       setShowSleepDialog(false);
     }
-  }, [isSleeping]);
+  }
 
   const handleChange = useCallback(
     (id: string, confirmed = false) => {

--- a/client/src/protoOS/features/settings/components/General/General.tsx
+++ b/client/src/protoOS/features/settings/components/General/General.tsx
@@ -63,7 +63,7 @@ const General = () => {
   useEffect(() => {
     if (hasAccess && pausedAuthAction === AUTH_ACTIONS.systemTag) {
       setPausedAuthAction(null);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- open system-tag edit modal once auth resolves (same pattern as PowerTarget)
       setShowMinerSystemTagEditModal(true);
     }
   }, [hasAccess, pausedAuthAction, setPausedAuthAction]);

--- a/client/src/protoOS/features/settings/components/General/MinerSystemTagEditModal.tsx
+++ b/client/src/protoOS/features/settings/components/General/MinerSystemTagEditModal.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useState } from "react";
+import { FormEvent, useCallback, useState } from "react";
 import { useSystemTag } from "@/protoOS/api";
 import { variants } from "@/shared/components/Button";
 import Input from "@/shared/components/Input";
@@ -17,10 +17,12 @@ const MinerSystemTagEditModal = ({ open, currentTag, onDismiss, onSaved }: Miner
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { putSystemTag } = useSystemTag();
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local value with controlled currentTag prop
+  // Sync local value with controlled currentTag prop
+  const [prevCurrentTag, setPrevCurrentTag] = useState(currentTag);
+  if (prevCurrentTag !== currentTag) {
+    setPrevCurrentTag(currentTag);
     setValue(currentTag);
-  }, [currentTag]);
+  }
 
   const handleSave = useCallback(() => {
     const trimmed = value.trim();

--- a/client/src/protoOS/features/settings/components/General/MinerSystemTagEditModal.tsx
+++ b/client/src/protoOS/features/settings/components/General/MinerSystemTagEditModal.tsx
@@ -18,6 +18,7 @@ const MinerSystemTagEditModal = ({ open, currentTag, onDismiss, onSaved }: Miner
   const { putSystemTag } = useSystemTag();
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local value with controlled currentTag prop
     setValue(currentTag);
   }, [currentTag]);
 

--- a/client/src/protoOS/features/settings/components/MiningPools/MiningPools.tsx
+++ b/client/src/protoOS/features/settings/components/MiningPools/MiningPools.tsx
@@ -41,6 +41,7 @@ const SettingsMiningPools = () => {
           priority: pool?.priority || index,
         };
       });
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- sync local pools when upstream poolsInfo query resolves
       setPools(newPools);
       setPreviousPools(newPools);
     }
@@ -158,6 +159,7 @@ const SettingsMiningPools = () => {
 
   useEffect(() => {
     if (toastStatus === TOAST_STATUSES.loading && isStalePools && !poolsInfoPending) {
+      /* eslint-disable react-hooks/set-state-in-effect -- finalize toast status based on the outcome of a refetch after edit/create */
       if (poolsInfoError && !/failed to connect to cgminer/i.test(poolsInfoError)) {
         setToastStatus(TOAST_STATUSES.error);
         removeToast(toastId.current);
@@ -184,6 +186,7 @@ const SettingsMiningPools = () => {
         setIsStalePools(false);
         skipSuccessToastRef.current = false;
       }
+      /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [isStalePools, poolsInfo, poolsInfoPending, poolsInfoError, toastStatus]);
 

--- a/client/src/protoOS/hooks/useWakeMiner/useWakeMiner.ts
+++ b/client/src/protoOS/hooks/useWakeMiner/useWakeMiner.ts
@@ -79,7 +79,6 @@ export const useWakeMiner = ({ afterWake, onSuccess, onError }: UseWakeMinerProp
         intervalIdRef.current = undefined;
       }
       isWakingRef.current = false;
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setShouldWake(false);
       setPending(false);
       afterWakeRef.current?.();

--- a/client/src/protoOS/pages/MinerLogs/Logs.tsx
+++ b/client/src/protoOS/pages/MinerLogs/Logs.tsx
@@ -25,7 +25,6 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
   const [initPage, setInitPage] = useState(false);
   const [storedLogs, setStoredLogs] = useState<string[]>([]);
   const [logs, setLogs] = useState<LogInfo[]>([]);
-  const [filteredLogs, setFilteredLogs] = useState<LogInfo[]>([]);
   const [filterByLogType, setFilterByLogType] = useState<logType[]>([]);
   const [focusSearch, setFocusSearch] = useState(false);
   const [errorCount, setErrorCount] = useState(0);
@@ -41,6 +40,15 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
     onClickOutside: () => setFocusSearch(false),
   });
 
+  const filteredLogs = useMemo(() => {
+    if (!searchValue && !filterByLogType.length) return logs;
+    return logs.filter(
+      (log) =>
+        `${log.timestamp} ${log.message}`.toLowerCase().includes(searchValue.toLowerCase()) &&
+        (!filterByLogType.length || filterByLogType.includes(log.logType as logType)),
+    );
+  }, [searchValue, logs, filterByLogType]);
+
   useEffect(() => {
     if (filteredLogs.length) {
       // on first load of the logs, scroll to bottom
@@ -53,33 +61,17 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
         messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
       }
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- mark init page done on first paint with content so subsequent updates animate instead of jump
   }, [filteredLogs, initPage, isPinnedToBottom]);
 
-  const updateFilteredLogs = useCallback(() => {
-    let newLogs = logs;
-    if (searchValue || filterByLogType.length) {
-      const newFilteredLogs = logs.filter(
-        (log) =>
-          `${log.timestamp} ${log.message}`.toLowerCase().includes(searchValue.toLowerCase()) &&
-          (!filterByLogType.length || filterByLogType.includes(log.logType as logType)),
-      );
-      newLogs = newFilteredLogs;
-    }
-
-    setFilteredLogs(newLogs);
-  }, [searchValue, logs, filterByLogType]);
-
-  // when switching between filters reset the Init Page state so that the page
-  // doesnt animate a long scroll to the bottom with filter change
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset first-load scroll flag when filters/search change so we don't animate a long scroll
+  // Reset first-load scroll flag when filters/search change so we don't animate a long scroll
+  const [prevFilterByLogType, setPrevFilterByLogType] = useState(filterByLogType);
+  const [prevSearchValue, setPrevSearchValue] = useState(searchValue);
+  if (prevFilterByLogType !== filterByLogType || prevSearchValue !== searchValue) {
+    setPrevFilterByLogType(filterByLogType);
+    setPrevSearchValue(searchValue);
     setInitPage(false);
-  }, [filterByLogType, searchValue]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- recompute filteredLogs when logs/filter/search change
-    updateFilteredLogs();
-  }, [updateFilteredLogs]);
+  }
 
   const formatAndSetLogsData = useCallback(
     (logsDataToSet: string[]) => {
@@ -92,9 +84,8 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
 
       const formattedLogs = formatLogs(logsDataToSet);
       setLogs(formattedLogs);
-      updateFilteredLogs();
     },
-    [storedLogs, updateFilteredLogs],
+    [storedLogs],
   );
 
   useEffect(() => {

--- a/client/src/protoOS/pages/MinerLogs/Logs.tsx
+++ b/client/src/protoOS/pages/MinerLogs/Logs.tsx
@@ -72,10 +72,12 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
   // when switching between filters reset the Init Page state so that the page
   // doesnt animate a long scroll to the bottom with filter change
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset first-load scroll flag when filters/search change so we don't animate a long scroll
     setInitPage(false);
   }, [filterByLogType, searchValue]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- recompute filteredLogs when logs/filter/search change
     updateFilteredLogs();
   }, [updateFilteredLogs]);
 
@@ -103,6 +105,7 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
         : logsData.content;
 
       const combinedLogs = [...storedLogs, ...uniqueLogs];
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- ingest new logs when upstream logsData changes
       formatAndSetLogsData(combinedLogs);
     }
   }, [logsData, storedLogs, formatAndSetLogsData]);
@@ -180,6 +183,7 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
 
   useEffect(() => {
     window.addEventListener("scroll", handleScroll);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initialize isPinnedToBottom from current scroll position on mount
     handleScroll();
 
     return () => {

--- a/client/src/protoOS/store/hooks/useAuth.ts
+++ b/client/src/protoOS/store/hooks/useAuth.ts
@@ -203,7 +203,7 @@ export const useAccessToken = (shouldCheckAccess: boolean = true) => {
   ]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- re-run access check on dependency change; auth state updates are the effect's purpose
     checkAccess();
   }, [checkAccess]);
 

--- a/client/src/shared/components/DatePicker/DatePicker.tsx
+++ b/client/src/shared/components/DatePicker/DatePicker.tsx
@@ -109,7 +109,7 @@ const DatePickerContent = (props: DatePickerProps) => {
   // Disabled is an external control boundary, so close the panel before paint when it flips on.
   useLayoutEffect(() => {
     if (!disabled || !open) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- close panel before paint when `disabled` prop flips on mid-interaction
     closePicker();
   }, [disabled, open, closePicker]);
 

--- a/client/src/shared/components/DatePicker/DatePickerInput.tsx
+++ b/client/src/shared/components/DatePicker/DatePickerInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import clsx from "clsx";
 
 import { SelectionMode, WithInputs } from "./types";
@@ -41,20 +41,25 @@ const DatePickerInput = ({
   const [startValue, setStartValue] = useState(() => formatValue(selectedStartDate));
   const [endValue, setEndValue] = useState(() => formatValue(selectedEndDate));
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync input display with external date prop when parent updates it
-    setDateValue(formatValue(selectedDate));
-  }, [selectedDate, formatValue]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync input display with external date prop when parent updates it
-    setStartValue(formatValue(selectedStartDate));
-  }, [selectedStartDate, formatValue]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync input display with external date prop when parent updates it
-    setEndValue(formatValue(selectedEndDate));
-  }, [selectedEndDate, formatValue]);
+  // Sync input display with external date props when parent updates them
+  const formattedDate = formatValue(selectedDate);
+  const formattedStart = formatValue(selectedStartDate);
+  const formattedEnd = formatValue(selectedEndDate);
+  const [prevFormattedDate, setPrevFormattedDate] = useState(formattedDate);
+  const [prevFormattedStart, setPrevFormattedStart] = useState(formattedStart);
+  const [prevFormattedEnd, setPrevFormattedEnd] = useState(formattedEnd);
+  if (prevFormattedDate !== formattedDate) {
+    setPrevFormattedDate(formattedDate);
+    setDateValue(formattedDate);
+  }
+  if (prevFormattedStart !== formattedStart) {
+    setPrevFormattedStart(formattedStart);
+    setStartValue(formattedStart);
+  }
+  if (prevFormattedEnd !== formattedEnd) {
+    setPrevFormattedEnd(formattedEnd);
+    setEndValue(formattedEnd);
+  }
 
   const handleSingleBlur = useCallback(() => {
     const parsed = includeTime ? parseDateTime(dateValue) : parseDate(dateValue);

--- a/client/src/shared/components/DatePicker/DatePickerInput.tsx
+++ b/client/src/shared/components/DatePicker/DatePickerInput.tsx
@@ -42,14 +42,17 @@ const DatePickerInput = ({
   const [endValue, setEndValue] = useState(() => formatValue(selectedEndDate));
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync input display with external date prop when parent updates it
     setDateValue(formatValue(selectedDate));
   }, [selectedDate, formatValue]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync input display with external date prop when parent updates it
     setStartValue(formatValue(selectedStartDate));
   }, [selectedStartDate, formatValue]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync input display with external date prop when parent updates it
     setEndValue(formatValue(selectedEndDate));
   }, [selectedEndDate, formatValue]);
 

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -82,36 +82,39 @@ const Input = ({
   required,
 }: InputProps) => {
   const [value, setValue] = useState(initValue);
-  // keep the error state until the animation is finished
-  const [validationError, setValidationError] = useState(error);
+  const [prevInitValue, setPrevInitValue] = useState(initValue);
+  if (initValue !== prevInitValue) {
+    setPrevInitValue(initValue);
+    setValue(initValue);
+  }
 
   const [inputType, setInputType] = useState(type);
+  const [prevType, setPrevType] = useState(type);
+  if (type !== prevType) {
+    setPrevType(type);
+    setInputType(type);
+  }
+
+  // keep the error state until the animation is finished
+  const [validationError, setValidationError] = useState(error);
+  const [prevError, setPrevError] = useState(error);
+  if (error && error !== prevError) {
+    setPrevError(error);
+    setValidationError(error);
+  }
+
   const [focused, setFocused] = useState(false);
   const fallbackRef = useRef<HTMLInputElement>(null) as RefObject<HTMLInputElement>;
   const valueWidth = useValueWidth(value, inputRef || fallbackRef, units);
   const hasFloatingLabel = type === "date" || !!length(value) || focused;
 
   useEffect(() => {
-    setValue(initValue);
-  }, [initValue]);
-
-  useEffect(() => {
-    setInputType(type);
-  }, [type]);
-
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout>;
-    if (error) {
+    if (error) return;
+    const timeoutId = setTimeout(() => {
       setValidationError(error);
-    } else {
-      // clear the error after the animation
-      timeoutId = setTimeout(() => {
-        setValidationError(error);
-      }, 200);
-    }
-    return () => {
-      clearTimeout(timeoutId);
-    };
+      setPrevError(error);
+    }, 200);
+    return () => clearTimeout(timeoutId);
   }, [error]);
 
   // When a password input gains focus, React's re-render (from setFocused)

--- a/client/src/shared/components/List/Filters/DropdownFilter.tsx
+++ b/client/src/shared/components/List/Filters/DropdownFilter.tsx
@@ -50,10 +50,14 @@ const FilterContent = ({
   // Only use internal state when buttons are shown
   const [internalSelectedItems, setInternalSelectedItems] = useState<string[]>(externalSelectedItems);
 
-  // Sync internal selection draft with external prop when parent updates
-  const [prevExternalSelectedItems, setPrevExternalSelectedItems] = useState(externalSelectedItems);
-  if (withButtons && prevExternalSelectedItems !== externalSelectedItems) {
-    setPrevExternalSelectedItems(externalSelectedItems);
+  // Sync internal selection draft with external prop when parent updates.
+  // Compare by content — call sites pass `selectedOptions || []` which produces a
+  // fresh array on every render when the prop is undefined, so referential inequality
+  // would cycle forever.
+  const externalKey = externalSelectedItems.join("\u0000");
+  const [prevExternalKey, setPrevExternalKey] = useState(externalKey);
+  if (withButtons && prevExternalKey !== externalKey) {
+    setPrevExternalKey(externalKey);
     setInternalSelectedItems(externalSelectedItems);
   }
 

--- a/client/src/shared/components/List/Filters/DropdownFilter.tsx
+++ b/client/src/shared/components/List/Filters/DropdownFilter.tsx
@@ -50,13 +50,12 @@ const FilterContent = ({
   // Only use internal state when buttons are shown
   const [internalSelectedItems, setInternalSelectedItems] = useState<string[]>(externalSelectedItems);
 
-  // When buttons are shown, update internal state when external changes
-  useEffect(() => {
-    if (withButtons) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- sync internal selection draft with external prop when parent updates
-      setInternalSelectedItems(externalSelectedItems);
-    }
-  }, [externalSelectedItems, withButtons]);
+  // Sync internal selection draft with external prop when parent updates
+  const [prevExternalSelectedItems, setPrevExternalSelectedItems] = useState(externalSelectedItems);
+  if (withButtons && prevExternalSelectedItems !== externalSelectedItems) {
+    setPrevExternalSelectedItems(externalSelectedItems);
+    setInternalSelectedItems(externalSelectedItems);
+  }
 
   useEffect(() => {
     if (!showPopover || !triggerRef.current) {

--- a/client/src/shared/components/List/Filters/DropdownFilter.tsx
+++ b/client/src/shared/components/List/Filters/DropdownFilter.tsx
@@ -53,7 +53,7 @@ const FilterContent = ({
   // When buttons are shown, update internal state when external changes
   useEffect(() => {
     if (withButtons) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- sync internal selection draft with external prop when parent updates
       setInternalSelectedItems(externalSelectedItems);
     }
   }, [externalSelectedItems, withButtons]);

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -918,6 +918,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   useEffect(() => {
     if (isServerSideFiltering) {
       // Server-side filtering: items are already filtered by server
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- refresh filteredItems when parent items prop changes
       setFilteredItems(items);
     } else if (!shouldRenderFilters && filterItem) {
       // Client-side filtering without Filters component: apply filterItem directly
@@ -950,6 +951,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
         if (customSetSelectedItems) {
           customSetSelectedItems(allSelectableItemKeys);
         } else {
+          // eslint-disable-next-line react-hooks/set-state-in-effect -- ensure newly loaded items join existing "select all" selection
           setSelectedItems(allSelectableItemKeys);
         }
       }
@@ -1069,6 +1071,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
 
   useEffect(() => {
     if (!overflowContainer) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- clear overflow flag when overflowContainer mode is disabled
       setHasHorizontalOverflow(false);
       return;
     }

--- a/client/src/shared/components/MiningPools/PoolForm/PoolForm.tsx
+++ b/client/src/shared/components/MiningPools/PoolForm/PoolForm.tsx
@@ -46,9 +46,9 @@ const PoolForm = ({
 
   useEffect(() => {
     if (shouldTestConnection && !isTestingConnection) {
-      /* eslint-disable react-hooks/set-state-in-effect */
       setShouldTestConnection(false);
       if (!pools[poolIndex].url.trim()) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- surface validation error synchronously before dispatching the async test
         setValidationErrors({
           ...validationErrors,
           url: urlValidationErrors.required,
@@ -56,7 +56,6 @@ const PoolForm = ({
         return;
       }
       setError(false);
-      /* eslint-enable react-hooks/set-state-in-effect */
       testConnection({
         poolInfo: pools[poolIndex],
         onError: () => {

--- a/client/src/shared/components/MiningPools/PoolModal.tsx
+++ b/client/src/shared/components/MiningPools/PoolModal.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { ReactNode, useCallback, useMemo, useState } from "react";
 
 import { poolInfoAttributes } from "./constants";
 import { poolNameValidationErrors, urlValidationErrors } from "./PoolForm/constants";
@@ -89,10 +89,12 @@ const PoolModal = ({
     [draftPoolInfo, poolIndex, hidePoolName, usernameRequired],
   );
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync draft with incoming pools prop when parent updates it
+  // Sync draft with incoming pools prop when parent updates it
+  const [prevPools, setPrevPools] = useState(pools);
+  if (prevPools !== pools) {
+    setPrevPools(pools);
     setDraftPoolInfo(deepClone(pools));
-  }, [pools]);
+  }
 
   // Reset modal state when modal opens
   const [prevOpen, setPrevOpen] = useState(open);

--- a/client/src/shared/components/MiningPools/PoolModal.tsx
+++ b/client/src/shared/components/MiningPools/PoolModal.tsx
@@ -90,11 +90,13 @@ const PoolModal = ({
   );
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync draft with incoming pools prop when parent updates it
     setDraftPoolInfo(deepClone(pools));
   }, [pools]);
 
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state when modal opens
       setPoolNameError(undefined);
       setUrlError(undefined);
       setUsernameError(undefined);

--- a/client/src/shared/components/MiningPools/PoolModal.tsx
+++ b/client/src/shared/components/MiningPools/PoolModal.tsx
@@ -94,9 +94,11 @@ const PoolModal = ({
     setDraftPoolInfo(deepClone(pools));
   }, [pools]);
 
-  useEffect(() => {
+  // Reset modal state when modal opens
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
     if (open) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset modal state when modal opens
       setPoolNameError(undefined);
       setUrlError(undefined);
       setUsernameError(undefined);
@@ -106,7 +108,7 @@ const PoolModal = ({
       setIsPasswordSet(false);
       setSaveError(false);
     }
-  }, [open]);
+  }
 
   const onPoolChange = useCallback(
     (value: string, id: string) => {

--- a/client/src/shared/components/Search/Search.tsx
+++ b/client/src/shared/components/Search/Search.tsx
@@ -15,11 +15,12 @@ const id = "search";
 
 const Search = ({ className, compact, onChange, initValue, shouldFocus }: SearchProps) => {
   const [value, setValue] = useState(initValue);
-  const inputRef = useRef<HTMLInputElement>(null) as RefObject<HTMLInputElement>;
-
-  useEffect(() => {
+  const [prevInitValue, setPrevInitValue] = useState(initValue);
+  if (initValue !== prevInitValue) {
+    setPrevInitValue(initValue);
     setValue(initValue);
-  }, [initValue]);
+  }
+  const inputRef = useRef<HTMLInputElement>(null) as RefObject<HTMLInputElement>;
 
   const focusSearch = (event: KeyboardEvent) => {
     // event.metaKey - pressed Command key on Macs

--- a/client/src/shared/components/SelectRow/SelectRow.stories.tsx
+++ b/client/src/shared/components/SelectRow/SelectRow.stories.tsx
@@ -22,7 +22,7 @@ export const SelectRow = ({ hasPrefixIcon, hasSideText, type }: SelectRowProps) 
   const [selected, setSelected] = useState<number[]>([]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset selection when story control "type" changes
     setSelected([0]);
   }, [type]);
 

--- a/client/src/shared/components/SelectRowList/SelectRowList.stories.tsx
+++ b/client/src/shared/components/SelectRowList/SelectRowList.stories.tsx
@@ -31,7 +31,7 @@ const SelectRowListForStory = ({ disabled, hasPrefixIcon, hasSubtext, type }: Se
   const [selected, setSelected] = useState<SelectRow[]>([selectRows.one]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset selection when story control "type" changes
     setSelected([selectRows.one]);
   }, [type]);
 

--- a/client/src/shared/components/Textarea/Textarea.tsx
+++ b/client/src/shared/components/Textarea/Textarea.tsx
@@ -61,34 +61,30 @@ const Textarea = ({
   required,
 }: TextareaProps) => {
   const [value, setValue] = useState(initValue);
+  const [prevInitValue, setPrevInitValue] = useState(initValue);
+  if (initValue !== prevInitValue) {
+    setPrevInitValue(initValue);
+    setValue(initValue);
+  }
+
   // keep the error state until the animation is finished
   const [validationError, setValidationError] = useState(error);
+  const [prevError, setPrevError] = useState(error);
+  if (error && error !== prevError) {
+    setPrevError(error);
+    setValidationError(error);
+  }
 
   const [focused, setFocused] = useState(false);
   const fallbackRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    setValue(initValue);
-  }, [initValue]);
-
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-    if (error) {
+    if (error) return;
+    const timeoutId = setTimeout(() => {
       setValidationError(error);
-    } else {
-      // clear the error after the animation
-      timeoutId = setTimeout(() => {
-        setValidationError(error);
-      }, 200);
-    }
-
-    // Cleanup function to clear the timeout when the component unmounts or when dependencies change
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
+      setPrevError(error);
+    }, 200);
+    return () => clearTimeout(timeoutId);
   }, [error]);
 
   const handleChange = useCallback(

--- a/client/src/shared/features/toaster/components/Toast/Toast.tsx
+++ b/client/src/shared/features/toaster/components/Toast/Toast.tsx
@@ -43,6 +43,7 @@ const Toast = ({ message, onClose, status, index, numToasts, ttl = defaultTtl }:
       return;
     }
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- recompute stacked-toast transforms when toast position within the stack changes
     setScale(1 - (numToasts - index - 1) * 0.07);
     setYOffset((numToasts - index - 1) * -14);
     setHoverYOffset((numToasts - index - 1) * -55);

--- a/client/src/shared/features/toaster/components/Toast/Toast.tsx
+++ b/client/src/shared/features/toaster/components/Toast/Toast.tsx
@@ -1,5 +1,5 @@
 import { motion } from "motion/react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import clsx from "clsx";
 
 import { defaultTtl, STATUSES } from "../../constants";
@@ -18,13 +18,13 @@ const extraPaddingForHover = 15;
 const initialTranslateY = 20;
 
 const Toast = ({ message, onClose, status, index, numToasts, ttl = defaultTtl }: ToastProps) => {
-  const [yOffset, setYOffset] = useState<number>(0);
-  const [hoverYOffset, setHoverYOffset] = useState<number>(0);
-  const [scale, setScale] = useState<number>(1);
-
-  // If Toast is used outside of toaster and we
-  // dont have index or numToast we just assume its on top
-  const [onTop, setOnTop] = useState<boolean>(index == undefined || numToasts == undefined || index + 1 == numToasts);
+  // If Toast is used outside of toaster and we don't have index or numToasts
+  // we just assume it's on top with no stacking transform applied.
+  const stackOffset = index !== undefined && numToasts !== undefined ? numToasts - index - 1 : 0;
+  const scale = 1 - stackOffset * 0.07;
+  const yOffset = stackOffset * -14;
+  const hoverYOffset = stackOffset * -55;
+  const onTop = index == undefined || numToasts == undefined || index + 1 == numToasts;
 
   const easeGentle = useCssVariable("--ease-gentle", cubicBezierValues);
 
@@ -37,18 +37,6 @@ const Toast = ({ message, onClose, status, index, numToasts, ttl = defaultTtl }:
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ttl]);
-
-  useEffect(() => {
-    if (numToasts == undefined || index == undefined) {
-      return;
-    }
-
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- recompute stacked-toast transforms when toast position within the stack changes
-    setScale(1 - (numToasts - index - 1) * 0.07);
-    setYOffset((numToasts - index - 1) * -14);
-    setHoverYOffset((numToasts - index - 1) * -55);
-    setOnTop(index + 1 == numToasts);
-  }, [index, numToasts]);
 
   return (
     <motion.div

--- a/client/src/shared/hooks/useMeasure.ts
+++ b/client/src/shared/hooks/useMeasure.ts
@@ -116,7 +116,7 @@ function useMeasure<E extends Element = Element>(options: UseMeasureOptions = {}
 
   useLayoutEffect(() => {
     if (!element) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset measurements when element detaches so consumers don't read stale rects
       setContentRect(defaultState);
       setBoundingRect(defaultState);
       return;

--- a/client/src/shared/hooks/useMeasure.ts
+++ b/client/src/shared/hooks/useMeasure.ts
@@ -114,14 +114,18 @@ function useMeasure<E extends Element = Element>(options: UseMeasureOptions = {}
     setElement(node);
   }, []);
 
-  useLayoutEffect(() => {
+  // Reset measurements when element detaches so consumers don't read stale rects
+  const [prevElement, setPrevElement] = useState(element);
+  if (prevElement !== element) {
+    setPrevElement(element);
     if (!element) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset measurements when element detaches so consumers don't read stale rects
       setContentRect(defaultState);
       setBoundingRect(defaultState);
-      return;
     }
+  }
 
+  useLayoutEffect(() => {
+    if (!element) return;
     if (!hasRequiredAPIs()) {
       return;
     }
@@ -199,6 +203,7 @@ function useMeasure<E extends Element = Element>(options: UseMeasureOptions = {}
         right: initialBoundingRect.width,
       };
 
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- initial measurement must read post-layout DOM and be available to consumers before the ResizeObserver's async callback fires
       setBoundingRect(initialBoundingRect);
       setContentRect(initialContentRect);
     } catch (error) {

--- a/client/src/shared/hooks/useMeasure.ts
+++ b/client/src/shared/hooks/useMeasure.ts
@@ -114,16 +114,6 @@ function useMeasure<E extends Element = Element>(options: UseMeasureOptions = {}
     setElement(node);
   }, []);
 
-  // Reset measurements when element detaches so consumers don't read stale rects
-  const [prevElement, setPrevElement] = useState(element);
-  if (prevElement !== element) {
-    setPrevElement(element);
-    if (!element) {
-      setContentRect(defaultState);
-      setBoundingRect(defaultState);
-    }
-  }
-
   useLayoutEffect(() => {
     if (!element) return;
     if (!hasRequiredAPIs()) {


### PR DESCRIPTION
## Summary

Closes #50.

Enables `react-hooks/set-state-in-effect` in `client/eslint.config.js` and refactors every flagged site in the client. Per-commit structure:

- `9d83fd2` — enable rule
- `382b489` — modal reset via render-phase guard
- `530c1ae` — prop-derived sync via render-phase guard
- `60212e6` — auth-resume flows via render-phase guard
- `3c4425e` — poll interval cleanup via effect cleanup
- `baf9c34` — remaining render-phase guards + derived state (useMemo + effect drops)

## Breakdown

### Pattern 1: Render-phase guard

Replaced `useEffect(() => setY(x), [x])` with a previous-value comparison during render (React's "adjusting state on prop change" idiom). Covers prop-sync, modal open/close resets, auth/state transitions, and ref-based transition detectors.

| File |
| --- |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/CoolingModeModal/CoolingModeModal.tsx` |
| `client/src/protoFleet/features/fleetManagement/components/MinerList/ManageColumnsModal.tsx` |
| `client/src/protoFleet/features/auth/components/AuthenticateFleetModal/AuthenticateFleetModal.tsx` |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.tsx` |
| `client/src/protoFleet/features/settings/components/AddTeamMemberModal.tsx` |
| `client/src/protoFleet/features/settings/components/Auth.tsx` |
| `client/src/protoFleet/features/settings/components/CreateApiKeyModal.tsx` |
| `client/src/protoOS/components/App/WakeCallout.tsx` |
| `client/src/protoOS/components/PageHeader/Power/PowerWidget.tsx` |
| `client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx` |
| `client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx` |
| `client/src/protoOS/features/settings/components/Cooling/Cooling.tsx` |
| `client/src/protoOS/features/settings/components/General/MinerSystemTagEditModal.tsx` |
| `client/src/protoOS/features/onboarding/components/MiningPool/MiningPool.tsx` |
| `client/src/protoOS/features/onboarding/components/Onboarding/Onboarding.tsx` |
| `client/src/shared/components/DatePicker/DatePickerInput.tsx` |
| `client/src/shared/components/Input/Input.tsx` |
| `client/src/shared/components/List/Filters/DropdownFilter.tsx` |
| `client/src/shared/components/MiningPools/PoolModal.tsx` |
| `client/src/shared/components/Search/Search.tsx` |
| `client/src/shared/components/Textarea/Textarea.tsx` |
| `client/src/shared/hooks/useMeasure.ts` |

### Pattern 2: Derive in render (drop state + effect)

When the value is a pure function of props/state, dropped the state and effect entirely — compute inline or via `useMemo`.

| File |
| --- |
| `client/src/shared/features/toaster/components/Toast/Toast.tsx` |
| `client/src/protoOS/pages/MinerLogs/Logs.tsx` |

### Pattern 3: Effect cleanup for teardown

Keyed the effect on resource id, registered teardown in cleanup, and nulled the id via render-phase guard when watched state settled.

| File |
| --- |
| `client/src/protoOS/components/OnboardingSettingUp/OnboardingSettingUpWrapper.tsx` |

### Pattern 4: Targeted `eslint-disable` with reason

Effects where setState-in-effect is the correct shape (modal lifecycle, server-state coordination, one-shot init). Per-line disable with `-- <why>` justification across ~25 API hooks, modal/action components, and settings pages. Rule enablement lives in `client/eslint.config.js`.

## Test plan

- [ ] `npm run lint` (client) passes with rule enabled and no unused disable directives
- [ ] `tsc --noEmit` clean
- [ ] Spot-check modal open/close, onboarding pool setup, mining target adjust, wake-from-sleep, and date picker date sync in app