### PR TITLE
feat: config from yaml & flag prefixes

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -85,6 +85,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b h1:slYM766cy2nI3BwyRiyQj/Ud48djTMtMebDqepE95rw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
+github.com/alecthomas/kong-yaml v0.2.0 h1:iiVVqVttmOsHKawlaW/TljPsjaEv1O4ODx6dloSA58Y=
+github.com/alecthomas/kong-yaml v0.2.0/go.mod h1:vMvOIy+wpB49MCZ0TA3KMts38Mu9YfRP03Q1StN69/g=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=

--- a/server/README.md
+++ b/server/README.md
@@ -174,6 +174,22 @@ Scale replicas with: `docker compose up --scale fake-proto-rig=10`
 
 The service is configured using environment variables or command-line flags. See `internal/domain/config.go`. For local development, create a `.env` file in this directory.
 
+At startup, `fleetd` also loads `/etc/fleetd/config.yaml` if that file exists. The YAML file can use nested groups that mirror the config sections, for example:
+
+```yaml
+auth:
+  client:
+    secret-key: "replace-me"
+    expiration-period: "1h"
+  miner-token-expiration-period: "30m"
+encrypt:
+  service-master-key: "replace-me"
+http:
+  address: "0.0.0.0:4000"
+```
+
+Command-line flags override values from the YAML file.
+
 ## API Testing
 
 ## Error Query Service (Testing/Development Only)

--- a/server/cmd/fleetd/config.go
+++ b/server/cmd/fleetd/config.go
@@ -28,21 +28,21 @@ type HTTPConfig struct {
 	PprofAddr         string        `help:"Address to listen for pprof debug server, e.g. 127.0.0.1:6060 (empty disables it; use a non-loopback address only if you intentionally want remote access)" default:"" env:"PPROF_ADDR"`
 }
 type Config struct {
-	DB             db.Config              `embed:"" prefix:"db" envprefix:"DB_"`
-	Log            logging.Config         `embed:"" prefix:"logging" envprefix:"LOG_"`
-	HTTP           HTTPConfig             `embed:"" prefix:"http" envprefix:"HTTP_"`
-	Auth           token.Config           `embed:"" prefix:"auth" envprefix:"AUTH_"`
-	Session        session.Config         `embed:"" prefix:"session" envprefix:"SESSION_"`
-	Pools          pools.Config           `embed:"" prefix:"pools" envprefix:"POOLS_"`
-	Encrypt        encrypt.Config         `embed:"" prefix:"encrypt" envprefix:"ENCRYPT_"`
-	Command        command.Config         `embed:"" prefix:"fleet_command" envprefix:"FLEET_COMMAND_"`
-	Queue          queue.Config           `embed:"" prefix:"fleet_queue" envprefix:"FLEET_QUEUE_"`
-	TimescaleDB    timescaledb.Config     `embed:"" prefix:"timescaledb" envprefix:"TIMESCALEDB_"`
-	Telemetry      telemetry.Config       `embed:"" prefix:"telemetry" envprefix:"TELEMETRY_"`
-	Scheduler      scheduler.Config       `embed:"" prefix:"scheduler" envprefix:"SCHEDULER_"`
-	Plugins        plugins.Config         `embed:"" prefix:"plugins" envprefix:"PLUGINS_"`
-	IPScanner      ipscanner.Config       `embed:"" prefix:"ipscanner" envprefix:"IPSCANNER_"`
-	Diagnostics    diagnostics.Config     `embed:"" prefix:"diagnostics" envprefix:"DIAGNOSTICS_"`
-	Files          files.Config           `embed:"" prefix:"files" envprefix:"FILES_"`
-	FleetTelemetry fleet_telemetry.Config `embed:"" prefix:"fleet_telemetry" envprefix:"FLEET_TELEMETRY_"`
+	DB             db.Config              `embed:"" prefix:"db-" envprefix:"DB_"`
+	Log            logging.Config         `embed:"" prefix:"logging-" envprefix:"LOG_"`
+	HTTP           HTTPConfig             `embed:"" prefix:"http-" envprefix:"HTTP_"`
+	Auth           token.Config           `embed:"" prefix:"auth-" envprefix:"AUTH_"`
+	Session        session.Config         `embed:"" prefix:"session-" envprefix:"SESSION_"`
+	Pools          pools.Config           `embed:"" prefix:"pools-" envprefix:"POOLS_"`
+	Encrypt        encrypt.Config         `embed:"" prefix:"encrypt-" envprefix:"ENCRYPT_"`
+	Command        command.Config         `embed:"" prefix:"fleet-command-" envprefix:"FLEET_COMMAND_"`
+	Queue          queue.Config           `embed:"" prefix:"fleet-queue-" envprefix:"FLEET_QUEUE_"`
+	TimescaleDB    timescaledb.Config     `embed:"" prefix:"timescaledb-" envprefix:"TIMESCALEDB_"`
+	Telemetry      telemetry.Config       `embed:"" prefix:"telemetry-" envprefix:"TELEMETRY_"`
+	Scheduler      scheduler.Config       `embed:"" prefix:"scheduler-" envprefix:"SCHEDULER_"`
+	Plugins        plugins.Config         `embed:"" prefix:"plugins-" envprefix:"PLUGINS_"`
+	IPScanner      ipscanner.Config       `embed:"" prefix:"ipscanner-" envprefix:"IPSCANNER_"`
+	Diagnostics    diagnostics.Config     `embed:"" prefix:"diagnostics-" envprefix:"DIAGNOSTICS_"`
+	Files          files.Config           `embed:"" prefix:"files-" envprefix:"FILES_"`
+	FleetTelemetry fleet_telemetry.Config `embed:"" prefix:"fleet-telemetry-" envprefix:"FLEET_TELEMETRY_"`
 }

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -28,6 +28,7 @@ import (
 	"connectrpc.com/grpcreflect"
 	"connectrpc.com/validate"
 	"github.com/alecthomas/kong"
+	kongyaml "github.com/alecthomas/kong-yaml"
 	"github.com/block/proto-fleet/server/internal/infrastructure/encrypt"
 	fleet_telemetry "github.com/block/proto-fleet/server/internal/infrastructure/fleet-telemetry"
 	"github.com/block/proto-fleet/server/internal/infrastructure/logging"
@@ -98,7 +99,11 @@ var version = "dev"
 func main() {
 	config := &Config{}
 
-	_ = kong.Parse(config, kong.Name("fleetd"))
+	_ = kong.Parse(
+		config,
+		kong.Name("fleetd"),
+		kong.Configuration(kongyaml.Loader, "/etc/fleetd/config.yaml"),
+	)
 
 	logging.InitLogger(config.Log)
 

--- a/server/cmd/fleetd/main_test.go
+++ b/server/cmd/fleetd/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kong"
+	kongyaml "github.com/alecthomas/kong-yaml"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFleetdLoadsConfigFromYAML(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeFleetdConfigFile(t, `
+auth:
+  client:
+    expiration-period: "1h"
+    secret-key: "test-client-secret"
+  miner-token-expiration-period: "30m"
+db:
+  address: "db.internal:5432"
+encrypt:
+  service-master-key: "test-master-key"
+http:
+  address: "0.0.0.0:9090"
+  suppress-cors: true
+logging:
+  json: true
+`)
+
+	config := &Config{}
+	parser, err := kong.New(
+		config,
+		kong.Name("fleetd"),
+		kong.Configuration(kongyaml.Loader, configPath),
+	)
+	require.NoError(t, err)
+
+	_, err = parser.Parse(nil)
+	require.NoError(t, err)
+	require.Equal(t, "0.0.0.0:9090", config.HTTP.Address)
+	require.True(t, config.HTTP.SuppressCors)
+	require.Equal(t, "db.internal:5432", config.DB.Address)
+	require.True(t, config.Log.JSON)
+	require.Equal(t, "test-client-secret", config.Auth.ClientToken.SecretKey)
+	require.Equal(t, time.Hour, config.Auth.ClientToken.ExpirationPeriod)
+	require.Equal(t, 30*time.Minute, config.Auth.MinerTokenExpirationPeriod)
+	require.Equal(t, "test-master-key", config.Encrypt.ServiceMasterKey)
+}
+
+func TestFleetdFlagsOverrideYAMLConfig(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeFleetdConfigFile(t, `
+auth:
+  client:
+    expiration-period: "1h"
+    secret-key: "test-client-secret"
+  miner-token-expiration-period: "30m"
+encrypt:
+  service-master-key: "test-master-key"
+http:
+  address: "0.0.0.0:9090"
+logging:
+  json: true
+`)
+
+	config := &Config{}
+	parser, err := kong.New(
+		config,
+		kong.Name("fleetd"),
+		kong.Configuration(kongyaml.Loader, configPath),
+	)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{
+		"--http-address=127.0.0.1:8081",
+		"--logging-json=false",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:8081", config.HTTP.Address)
+	require.False(t, config.Log.JSON)
+}
+
+func writeFleetdConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "fleetd.yaml")
+	err := os.WriteFile(configPath, []byte(contents), 0o600)
+	require.NoError(t, err)
+
+	return configPath
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Ullaakut/nmap/v3 v3.1.0
 	github.com/alecthomas/assert/v2 v2.11.0
 	github.com/alecthomas/kong v1.15.0
+	github.com/alecthomas/kong-yaml v0.2.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -22,6 +22,8 @@ github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8v
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.15.0 h1:BVJstKbpO73zKpmIu+m/aLRrNmWwxXPIGTNin9VmLVI=
 github.com/alecthomas/kong v1.15.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
+github.com/alecthomas/kong-yaml v0.2.0 h1:iiVVqVttmOsHKawlaW/TljPsjaEv1O4ODx6dloSA58Y=
+github.com/alecthomas/kong-yaml v0.2.0/go.mod h1:vMvOIy+wpB49MCZ0TA3KMts38Mu9YfRP03Q1StN69/g=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=

--- a/server/internal/domain/token/config.go
+++ b/server/internal/domain/token/config.go
@@ -10,6 +10,6 @@ type AuthTokenConfig struct {
 }
 
 type Config struct {
-	ClientToken                AuthTokenConfig `embed:"" prefix:"client" envprefix:"CLIENT_"`
+	ClientToken                AuthTokenConfig `embed:"" prefix:"client-" envprefix:"CLIENT_"`
 	MinerTokenExpirationPeriod time.Duration   `help:"Expiration period duration for the miner auth JWT" env:"MINER_EXPIRATION_PERIOD" required:""`
 }


### PR DESCRIPTION
Currently our command line argument and config parsing is not that clean:
```
Flags:
  -h, --help                                                    Show context-sensitive help.
      --dbname="fleet"                                          Name of the database ($DB_NAME)
      --dbusername="fleet"                                      Username to database ($DB_USERNAME)
      --dbpassword=STRING                                       Password to database ($DB_PASSWORD)
      --dbaddress="127.0.0.1:5432"                              Address of the database, including port ($DB_ADDRESS)
      --dbssl-mode="disable"                                    PostgreSQL SSL mode ($DB_SSL_MODE)
...
      --httpaddress="127.0.0.1:8080"                            Address to listen on ($HTTP_LISTEN_ADDRESS)
      --httpread-header-timeout=3s                              Read header timeout ($HTTP_READ_HEADER_TIMEOUT)
      --httpsuppress-cors                                       Suppress CORS ($HTTP_SUPPRESS_CORS)
...
      --fleet_commandmax-workers=500                            Max number of worker threads running at the same time ($FLEET_COMMAND_MAX_WORKERS).
      --fleet_commandmaster-polling-interval=1s                 Interval in which the master polls the batch status check ($FLEET_COMMAND_MASTER_POLLING_INTERVAL).
      --fleet_commandworker-execution-timeout=30s               Limit for a single worker thread runtime ($FLEET_COMMAND_WORKER_EXECUTION_TIMEOUT).
```

More importantly, one can't edit these without changing the docker-compose file written by the installer. Meaning the config get cleared every install.

This PR introduces a new location purely for configuration (`/etc/fleetd/config.yaml`) and a cleaning up of the flag formats above:

```yaml
# /etc/fleetd/config.yaml
http:
  address: "0.0.0.0:9090"
logging:
  json: true
```

```
Flags:
  -h, --help                                                     Show context-sensitive help.
      --db-name="fleet"                                          Name of the database ($DB_NAME)
      --db-username="fleet"                                      Username to database ($DB_USERNAME)
      --db-password=STRING                                       Password to database ($DB_PASSWORD)
      --db-address="127.0.0.1:5432"                              Address of the database, including port ($DB_ADDRESS)
      --db-ssl-mode="disable"                                    PostgreSQL SSL mode ($DB_SSL_MODE)
...
      --http-address="127.0.0.1:8080"                            Address to listen on ($HTTP_LISTEN_ADDRESS)
      --http-read-header-timeout=3s                              Read header timeout ($HTTP_READ_HEADER_TIMEOUT)
      --http-suppress-cors                                       Suppress CORS ($HTTP_SUPPRESS_CORS)
...
      --fleet-command-max-workers=500                            Max number of worker threads running at the same time ($FLEET_COMMAND_MAX_WORKERS).
      --fleet-command-master-polling-interval=1s                 Interval in which the master polls the batch status check ($FLEET_COMMAND_MASTER_POLLING_INTERVAL).
      --fleet-command-worker-execution-timeout=30s               Limit for a single worker thread runtime ($FLEET_COMMAND_WORKER_EXECUTION_TIMEOUT).
```