### PR TITLE
perf(client): split useBatchOperations into actions-only hook (#32)

### DIFF
--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -36,7 +36,9 @@ export class MinersPage extends BasePage {
 
   async validateMinersAdded(minerCount: number = 5) {
     const rows = this.page.getByTestId("list-body").locator("tr");
-    expect(await rows.count()).toBeGreaterThanOrEqual(minerCount);
+    await expect
+      .poll(() => rows.count(), { timeout: PROLONGED_TIMEOUT, intervals: [DEFAULT_INTERVAL] })
+      .toBeGreaterThanOrEqual(minerCount);
   }
 
   private async filterMinersByModel(minerType: string) {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkWorkerNameModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkWorkerNameModal.test.tsx
@@ -92,7 +92,7 @@ vi.mock("@/protoFleet/api/useMinerCommand", () => ({
 }));
 
 vi.mock("@/protoFleet/features/fleetManagement/hooks/useBatchOperations", () => ({
-  useBatchOperations: vi.fn(() => ({
+  useBatchActions: vi.fn(() => ({
     startBatchOperation: mockStartBatchOperation,
     completeBatchOperation: mockCompleteBatchOperation,
   })),

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkWorkerNameModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkWorkerNameModal.tsx
@@ -51,7 +51,7 @@ import {
 import { useMinerCommand } from "@/protoFleet/api/useMinerCommand";
 import useUpdateWorkerNames from "@/protoFleet/api/useUpdateWorkerNames";
 import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
-import { useBatchOperations } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
+import { useBatchActions } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 import {
   applyFleetSelectablePairingStatuses,
   isFleetSelectablePairingStatus,
@@ -345,7 +345,7 @@ const BulkWorkerNameModal = ({
   getWorkerNameCredentials,
   onDismiss,
 }: BulkWorkerNameModalProps) => {
-  const { startBatchOperation, completeBatchOperation } = useBatchOperations();
+  const { startBatchOperation, completeBatchOperation } = useBatchActions();
   const preferences = useBulkWorkerNamePreferences();
   const setBulkWorkerNamePreferences = useSetBulkWorkerNamePreferences();
   const { handleAuthErrors } = useAuthErrors();

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
@@ -13,7 +13,7 @@ const {
   mockBulkWorkerNameModal,
   mockWithCapabilityCheck,
   mockPoolSelectionPageWrapper,
-  mockUseBatchOperations,
+  mockUseBatchActions,
   mockUseMinerActions,
   mockUseWindowDimensions,
 } = vi.hoisted(() => {
@@ -51,7 +51,7 @@ const {
         onDismiss: () => void;
       }) => null,
     ),
-    mockUseBatchOperations: vi.fn(() => ({
+    mockUseBatchActions: vi.fn(() => ({
       startBatchOperation: vi.fn(),
       completeBatchOperation: vi.fn(),
       removeDevicesFromBatch: vi.fn(),
@@ -188,7 +188,7 @@ vi.mock("./useMinerActions", () => ({
 }));
 
 vi.mock("@/protoFleet/features/fleetManagement/hooks/useBatchOperations", () => ({
-  useBatchOperations: mockUseBatchOperations,
+  useBatchActions: mockUseBatchActions,
 }));
 
 // Mock Popover

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -18,7 +18,7 @@ import type {
   MinerStateSnapshot,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import AuthenticateFleetModal from "@/protoFleet/features/auth/components/AuthenticateFleetModal";
-import { useBatchOperations } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
+import { useBatchActions } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 import { ChevronDown, Edit, MiningPools } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -66,7 +66,7 @@ const MinerActionsMenu = ({
   onActionStart,
   onActionComplete,
 }: MinerActionsMenuProps) => {
-  const { startBatchOperation, completeBatchOperation, removeDevicesFromBatch } = useBatchOperations();
+  const { startBatchOperation, completeBatchOperation, removeDevicesFromBatch } = useBatchActions();
   const [showBulkRenameModal, setShowBulkRenameModal] = useState(false);
   const [showBulkWorkerNameModal, setShowBulkWorkerNameModal] = useState(false);
   const [showWorkerNameAuthenticateModal, setShowWorkerNameAuthenticateModal] = useState(false);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.tsx
@@ -25,7 +25,7 @@ import type { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telem
 import { useMinerCommand } from "@/protoFleet/api/useMinerCommand";
 import useUpdateWorkerNames from "@/protoFleet/api/useUpdateWorkerNames";
 import AuthenticateFleetModal from "@/protoFleet/features/auth/components/AuthenticateFleetModal";
-import { useBatchOperations } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
+import { useBatchActions } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 import { ArrowRight, Edit, Ellipsis, MiningPools } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -68,7 +68,7 @@ const SingleMinerActionsMenu = ({
   onRefetchMiners,
   onWorkerNameUpdated,
 }: SingleMinerActionsMenuProps) => {
-  const { startBatchOperation, completeBatchOperation, removeDevicesFromBatch } = useBatchOperations();
+  const { startBatchOperation, completeBatchOperation, removeDevicesFromBatch } = useBatchActions();
   const { streamCommandBatchUpdates } = useMinerCommand();
   const { updateSingleWorkerName } = useUpdateWorkerNames();
   const selectedMiners = useMemo(() => [{ deviceIdentifier, deviceStatus }], [deviceIdentifier, deviceStatus]);

--- a/client/src/protoFleet/features/fleetManagement/hooks/useBatchOperations.ts
+++ b/client/src/protoFleet/features/fleetManagement/hooks/useBatchOperations.ts
@@ -12,25 +12,41 @@ import {
 export type { BatchOperation, BatchOperationInput } from "@/protoFleet/store/slices/batchSlice";
 
 /**
- * Manages ephemeral batch operation state for the fleet page.
- * Tracks in-progress operations (firmware updates, reboots, etc.) so
- * MinerStatus can show an in-progress state while an action is running.
- *
- * State is stored in the Zustand batch slice so it survives route navigation
- * (e.g., rebooting from Groups page then navigating to Miners page).
+ * Action-only view over the batch slice. Selects stable action callbacks from
+ * the store without subscribing to `batchStateVersion`, so consumers that only
+ * dispatch (e.g. per-row action menus) don't re-render on every batch mutation.
  */
-export function useBatchOperations() {
+export function useBatchActions() {
   const startBatchOperation = useStartBatchOperation();
   const completeBatchOperation = useCompleteBatchOperation();
   const removeDevicesFromBatch = useRemoveDevicesFromBatch();
   const cleanupStaleBatches = useCleanupStaleBatches();
-  const batchStateVersion = useBatchStateVersion();
 
   return {
     startBatchOperation,
     completeBatchOperation,
     removeDevicesFromBatch,
     cleanupStaleBatches,
+  };
+}
+
+/**
+ * Manages ephemeral batch operation state for the fleet page.
+ * Tracks in-progress operations (firmware updates, reboots, etc.) so
+ * MinerStatus can show an in-progress state while an action is running.
+ *
+ * State is stored in the Zustand batch slice so it survives route navigation
+ * (e.g., rebooting from Groups page then navigating to Miners page).
+ *
+ * Subscribes to `batchStateVersion` — use `useBatchActions` instead if you
+ * only need the action callbacks.
+ */
+export function useBatchOperations() {
+  const actions = useBatchActions();
+  const batchStateVersion = useBatchStateVersion();
+
+  return {
+    ...actions,
     /** Reads directly from the store — always returns fresh data. */
     getAllBatches,
     /** Reads directly from the store — always returns fresh data. */

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
@@ -25,7 +25,7 @@ import {
   UpdateMinerPasswordModal,
 } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity";
 import { useMinerActions } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions";
-import { useBatchOperations } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
+import { useBatchActions } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 import { ArrowRight, Edit, Ellipsis } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { type ButtonVariant, sizes, variants } from "@/shared/components/Button";
@@ -81,7 +81,7 @@ const DeviceSetActionsMenuInner = ({
   actionActiveRef,
 }: DeviceSetActionsMenuProps) => {
   const { triggerRef, setPopoverRenderMode } = usePopover();
-  const batchOps = useBatchOperations();
+  const batchOps = useBatchActions();
   const [isOpen, setIsOpen] = useState(false);
 
   // Lazy-fetched member IDs for table context (when deviceSetId is provided but memberDeviceIds aren't)


### PR DESCRIPTION
## Summary

Closes #32. Adds `useBatchActions()` that returns only the batch action callbacks without subscribing to `batchStateVersion`. Per-row consumers (`SingleMinerActionsMenu`, `MinerActionsMenu`, `BulkWorkerNameModal`, `DeviceSetActionsMenu`) now avoid re-rendering on every batch mutation. `Fleet.tsx` keeps the full `useBatchOperations` since it needs `batchStateVersion` to reconcile batch state against miner state.

## Test plan
- [x] `bin/just lint` clean
- [x] `npx tsc --noEmit` clean
- [x] Related vitest suites pass (113 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)