### PR TITLE
chore(client): enforce ternary for conditional rendering (#33)

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -73,6 +73,7 @@ export default [
         },
       ],
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "react/jsx-no-leaked-render": ["error", { validStrategies: ["ternary"] }],
       quotes: ["error", "double"],
       "no-console": ["error", { allow: ["warn", "error"] }],
       "import-x/no-unresolved": "off",

--- a/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
@@ -114,7 +114,7 @@ const DeviceSetList = ({
         emptyStateRow={emptyStateRow}
       />
 
-      {shouldRenderPagination && (
+      {shouldRenderPagination ? (
         <div className="sticky left-0 flex flex-col items-center gap-4 py-6">
           <span className="text-300 text-text-primary">
             Showing {firstItemIndex}–{lastItemIndex} of {total} {itemName.plural}
@@ -138,7 +138,7 @@ const DeviceSetList = ({
             />
           </div>
         </div>
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/protoFleet/components/DeviceSetList/StatCell.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/StatCell.tsx
@@ -25,18 +25,19 @@ const InfoTooltip = ({ heading, body }: { heading: string; body: string }) => {
       >
         <Info className="shrink-0 cursor-default text-text-primary-30" />
       </button>
-      {isVisible &&
-        createPortal(
-          <div
-            role="tooltip"
-            className="fixed z-50 w-80 rounded-lg bg-surface-base p-4 shadow-200"
-            style={floatingStyle}
-          >
-            <div className="text-300 text-text-primary-50">{heading}</div>
-            <div className="text-300 text-text-primary">{body}</div>
-          </div>,
-          document.body,
-        )}
+      {isVisible
+        ? createPortal(
+            <div
+              role="tooltip"
+              className="fixed z-50 w-80 rounded-lg bg-surface-base p-4 shadow-200"
+              style={floatingStyle}
+            >
+              <div className="text-300 text-text-primary-50">{heading}</div>
+              <div className="text-300 text-text-primary">{body}</div>
+            </div>,
+            document.body,
+          )
+        : null}
     </>
   );
 };

--- a/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.tsx
+++ b/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.tsx
@@ -138,9 +138,9 @@ export function FileProcessingStatus({ state, fileName, fileSize, uploadProgress
       <div className="flex flex-col">
         <div className="text-300 text-text-primary">{fileName}</div>
         <div className="text-text-secondary text-200">
-          {state === "hashing" && "Computing checksum..."}
-          {state === "checking" && "Checking server..."}
-          {state === "uploading" && `${uploadProgress}% uploaded · ${formatFileSize(fileSize)}`}
+          {state === "hashing" ? "Computing checksum..." : null}
+          {state === "checking" ? "Checking server..." : null}
+          {state === "uploading" ? `${uploadProgress}% uploaded · ${formatFileSize(fileSize)}` : null}
         </div>
       </div>
     </div>

--- a/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
+++ b/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
@@ -71,7 +71,7 @@ const OverflowActionSheet = ({ overflowButtons, onClose }: { overflowButtons: Bu
           </Row>
         ))}
 
-        {dangerItems.length > 0 && nonDangerItems.length > 0 && <Divider />}
+        {dangerItems.length > 0 && nonDangerItems.length > 0 ? <Divider /> : null}
 
         {dangerItems.map((button, index) => (
           <Row
@@ -214,7 +214,7 @@ const FullScreenTwoPaneModal = ({
         </div>
       )}
 
-      {showOverflowSheet && <OverflowActionSheet overflowButtons={overflowButtons} onClose={closeSheet} />}
+      {showOverflowSheet ? <OverflowActionSheet overflowButtons={overflowButtons} onClose={closeSheet} /> : null}
     </Modal>
   );
 };

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -377,9 +377,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
             overflowContainer
             stickyBgColor="bg-surface-elevated-base"
             footerContent={
-              !isLoading &&
-              totalMiners !== undefined &&
-              totalMiners > 0 && (
+              !isLoading && totalMiners !== undefined && totalMiners > 0 ? (
                 <div className="flex flex-col items-center gap-4 py-6">
                   <span className="text-300 text-text-primary">
                     Showing {currentPage * PAGE_SIZE + 1}–{currentPage * PAGE_SIZE + currentPageItems.length} of{" "}
@@ -404,11 +402,11 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
                     />
                   </div>
                 </div>
-              )
+              ) : null
             }
           />
         </div>
-        {showSelectAllFooter && totalMiners !== undefined && !singleSelect && (
+        {showSelectAllFooter && totalMiners !== undefined && !singleSelect ? (
           <div className="shrink-0">
             <ModalSelectAllFooter
               label={allSelected ? `All ${totalMiners} miners selected` : `${selectedItems.length} miners selected`}
@@ -425,7 +423,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
               }}
             />
           </div>
-        )}
+        ) : null}
       </div>
     );
   },

--- a/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
+++ b/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
@@ -73,7 +73,7 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
       )}
     >
       <div className="flex flex-col items-start gap-1">
-        {homeItem && homeItem.path && (
+        {homeItem && homeItem.path ? (
           <div
             className={clsx(
               "flex h-15 w-full items-start px-3 py-3 laptop:h-13 laptop:items-center laptop:!pb-0 desktop:h-13 desktop:items-center desktop:!pb-0",
@@ -99,7 +99,7 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
               )}
             </Link>
           </div>
-        )}
+        ) : null}
 
         <ul data-testid="navigation-menu" className="flex w-full flex-col items-start gap-1 px-3">
           {items.map((item, idx) => {
@@ -134,11 +134,11 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
                         })
                       : item.label}
                   </div>
-                  {item.icon && (
+                  {item.icon ? (
                     <span className="ml-3 text-emphasis-300 whitespace-nowrap text-text-primary-70 laptop:hidden laptop:group-hover/nav:inline desktop:inline">
                       {item.label}
                     </span>
-                  )}
+                  ) : null}
                 </Link>
               </li>
             ) : null;
@@ -146,86 +146,82 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
 
           {/* On mobile/tablet: show expandable Settings menu */}
           {(isPhone || isTablet) &&
-            settingsItem &&
-            secondaryNavItems.filter((nav) => nav.parent === "/settings").length > 0 && (
-              <>
-                <li className="w-full">
-                  <button
-                    onClick={() => setSettingsManuallyToggled(!settingsManuallyToggled)}
-                    onMouseEnter={() => handleSettingsHover(true)}
-                    onMouseLeave={() => handleSettingsHover(false)}
-                    aria-expanded={isSettingsExpanded}
-                    aria-controls="settings-submenu"
-                    aria-label="Settings menu toggle"
-                    className={clsx(
-                      "group flex w-full items-center justify-start rounded-lg px-2 py-1 text-text-primary",
-                      "hover:cursor-pointer hover:bg-core-primary-5",
-                    )}
-                  >
-                    {settingsItem.icon &&
-                      createElement(settingsItem.icon, {
+          settingsItem &&
+          secondaryNavItems.filter((nav) => nav.parent === "/settings").length > 0 ? (
+            <>
+              <li className="w-full">
+                <button
+                  onClick={() => setSettingsManuallyToggled(!settingsManuallyToggled)}
+                  onMouseEnter={() => handleSettingsHover(true)}
+                  onMouseLeave={() => handleSettingsHover(false)}
+                  aria-expanded={isSettingsExpanded}
+                  aria-controls="settings-submenu"
+                  aria-label="Settings menu toggle"
+                  className={clsx(
+                    "group flex w-full items-center justify-start rounded-lg px-2 py-1 text-text-primary",
+                    "hover:cursor-pointer hover:bg-core-primary-5",
+                  )}
+                >
+                  {settingsItem.icon
+                    ? createElement(settingsItem.icon, {
                         className: "transition-transform duration-200 ease-gentle group-hover:scale-105",
                         width: "w-5",
-                      })}
-                    <span className="ml-2 flex-1 text-left text-emphasis-300 text-text-primary-70">
-                      {settingsItem.label}
-                    </span>
-                    {(showSettingsHover || isSettingsExpanded) && (
-                      /*
-                       * Show MorphingPlusMinus icon when either hovered or expanded.
-                       * - When hovering and not expanded, show plus (indicates expandable).
-                       * - When expanded, show minus (indicates collapsible).
-                       */
-                      <MorphingPlusMinus condition={showSettingsHover && !isSettingsExpanded} />
-                    )}
-                  </button>
-                </li>
+                      })
+                    : null}
+                  <span className="ml-2 flex-1 text-left text-emphasis-300 text-text-primary-70">
+                    {settingsItem.label}
+                  </span>
+                  {showSettingsHover || isSettingsExpanded ? (
+                    <MorphingPlusMinus condition={showSettingsHover ? !isSettingsExpanded : false} />
+                  ) : null}
+                </button>
+              </li>
 
-                {/* Show secondary nav items when expanded */}
-                <AnimatePresence>
-                  {isSettingsExpanded && (
-                    <motion.div
-                      id="settings-submenu"
-                      data-testid="secondary-nav"
-                      initial={{ opacity: 0, y: -12 }}
-                      animate={{
-                        opacity: 1,
-                        y: 0,
-                        transition: { duration: 0.3, ease: easeGentle },
-                      }}
-                      exit={{
-                        opacity: 0,
-                        y: -12,
-                        transition: { duration: 0.3, ease: easeGentle },
-                      }}
-                      className="flex w-full flex-col gap-3"
-                    >
-                      {secondaryNavItems
-                        .filter((nav) => nav.parent === "/settings")
-                        .filter((nav) => !nav.allowedRoles || nav.allowedRoles.includes(currentRole))
-                        .map((nav) => (
-                          <li key={nav.path} className="w-full">
-                            <Link
-                              to={nav.path}
-                              onClick={() => closeMenu?.()}
-                              aria-current={isCurrentPath(nav.path) ? "page" : undefined}
-                              className={clsx(
-                                "block rounded-lg px-9 py-1 text-emphasis-300 text-text-primary-70",
-                                "hover:cursor-pointer hover:bg-core-primary-5",
-                                {
-                                  "bg-core-primary-5": isCurrentPath(nav.path),
-                                },
-                              )}
-                            >
-                              {nav.label}
-                            </Link>
-                          </li>
-                        ))}
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </>
-            )}
+              {/* Show secondary nav items when expanded */}
+              <AnimatePresence>
+                {isSettingsExpanded ? (
+                  <motion.div
+                    id="settings-submenu"
+                    data-testid="secondary-nav"
+                    initial={{ opacity: 0, y: -12 }}
+                    animate={{
+                      opacity: 1,
+                      y: 0,
+                      transition: { duration: 0.3, ease: easeGentle },
+                    }}
+                    exit={{
+                      opacity: 0,
+                      y: -12,
+                      transition: { duration: 0.3, ease: easeGentle },
+                    }}
+                    className="flex w-full flex-col gap-3"
+                  >
+                    {secondaryNavItems
+                      .filter((nav) => nav.parent === "/settings")
+                      .filter((nav) => !nav.allowedRoles || nav.allowedRoles.includes(currentRole))
+                      .map((nav) => (
+                        <li key={nav.path} className="w-full">
+                          <Link
+                            to={nav.path}
+                            onClick={() => closeMenu?.()}
+                            aria-current={isCurrentPath(nav.path) ? "page" : undefined}
+                            className={clsx(
+                              "block rounded-lg px-9 py-1 text-emphasis-300 text-text-primary-70",
+                              "hover:cursor-pointer hover:bg-core-primary-5",
+                              {
+                                "bg-core-primary-5": isCurrentPath(nav.path),
+                              },
+                            )}
+                          >
+                            {nav.label}
+                          </Link>
+                        </li>
+                      ))}
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+            </>
+          ) : null}
         </ul>
       </div>
       <div className="px-3 pb-3">

--- a/client/src/protoFleet/components/NoFilterResultsEmptyState.tsx
+++ b/client/src/protoFleet/components/NoFilterResultsEmptyState.tsx
@@ -8,10 +8,10 @@ interface NoFilterResultsEmptyStateProps {
 const NoFilterResultsEmptyState = ({ hasActiveFilters = false, onClearFilters }: NoFilterResultsEmptyStateProps) => (
   <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
     <div className="text-heading-200 text-text-primary">No results</div>
-    {hasActiveFilters && (
+    {hasActiveFilters ? (
       <>
         <p className="mt-1 text-400 text-text-primary-70">Try adjusting or clearing your filters.</p>
-        {onClearFilters && (
+        {onClearFilters ? (
           <Button
             className="mt-6"
             variant={variants.secondary}
@@ -21,9 +21,9 @@ const NoFilterResultsEmptyState = ({ hasActiveFilters = false, onClearFilters }:
           >
             Clear all filters
           </Button>
-        )}
+        ) : null}
       </>
-    )}
+    ) : null}
   </div>
 );
 

--- a/client/src/protoFleet/components/NullState.tsx
+++ b/client/src/protoFleet/components/NullState.tsx
@@ -17,12 +17,12 @@ const NullState = ({ icon, title, description, action, className, testId }: Null
     <div className="flex h-full w-full flex-col justify-center rounded-xl bg-core-primary-5 px-6 py-10 sm:px-20 sm:py-10">
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-4">
-          {icon && (
+          {icon ? (
             <div className="bg-core-surface-5 flex h-10 w-10 items-center justify-center rounded-lg">{icon}</div>
-          )}
+          ) : null}
           <Header title={title} titleSize="text-display-200" description={description} />
         </div>
-        {action && <div>{action}</div>}
+        {action ? <div>{action}</div> : null}
       </div>
     </div>
   </div>

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -67,7 +67,7 @@ const PageHeader = ({ isMenuOpen, openMenu, schedulePillData }: PageHeaderProps)
       <div className="flex h-12 items-center laptop:h-15 desktop:h-15">
         <div className="flex grow items-center px-4">
           <div className="flex grow items-center">
-            {(isPhone || isTablet) && (
+            {isPhone || isTablet ? (
               <Pause
                 ariaExpanded={isMenuOpen}
                 ariaLabel="Open navigation menu"
@@ -75,17 +75,17 @@ const PageHeader = ({ isMenuOpen, openMenu, schedulePillData }: PageHeaderProps)
                 onClick={openMenu}
                 testId="navigation-menu-button"
               />
-            )}
+            ) : null}
             <LocationSelector />
           </div>
-          {!isPhone && headerWidgetEnabled && <HeaderWidgets {...headerWidgetsProps} />}
+          {!isPhone && headerWidgetEnabled ? <HeaderWidgets {...headerWidgetsProps} /> : null}
         </div>
       </div>
-      {showPhoneWidgets && (
+      {showPhoneWidgets ? (
         <div className={clsx("flex h-[57px] items-center", bgClass)}>
           <HeaderWidgets className="ml-5" {...headerWidgetsProps} />
         </div>
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/protoFleet/features/activity/components/ActivityFilters.tsx
+++ b/client/src/protoFleet/features/activity/components/ActivityFilters.tsx
@@ -63,7 +63,7 @@ const ActivityFilters = ({
           onKeyDown={handleClearSearch}
         />
       </div>
-      {typeOptions.length > 0 && (
+      {typeOptions.length > 0 ? (
         <DropdownFilter
           title="Type"
           options={typeOptions}
@@ -71,8 +71,8 @@ const ActivityFilters = ({
           onSelect={onTypesChange}
           withButtons
         />
-      )}
-      {scopeOptions.length > 0 && (
+      ) : null}
+      {scopeOptions.length > 0 ? (
         <DropdownFilter
           title="Scope"
           options={scopeOptions}
@@ -80,8 +80,8 @@ const ActivityFilters = ({
           onSelect={onScopesChange}
           withButtons
         />
-      )}
-      {userOptions.length > 0 && (
+      ) : null}
+      {userOptions.length > 0 ? (
         <DropdownFilter
           title="Users"
           options={userOptions}
@@ -89,7 +89,7 @@ const ActivityFilters = ({
           onSelect={onUsersChange}
           withButtons
         />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/protoFleet/features/activity/components/ActivityTable.tsx
+++ b/client/src/protoFleet/features/activity/components/ActivityTable.tsx
@@ -41,7 +41,7 @@ const ActivityTable = ({ activities, totalCount, noDataElement }: ActivityTableP
                 <Icon width="w-4" />
               </div>
               <span className="min-w-0 break-words">{entry.description}</span>
-              {isFailed && <span className="text-intent-critical shrink-0 text-200">Failed</span>}
+              {isFailed ? <span className="text-intent-critical shrink-0 text-200">Failed</span> : null}
             </div>
           );
         },

--- a/client/src/protoFleet/features/activity/pages/ActivityPage.tsx
+++ b/client/src/protoFleet/features/activity/pages/ActivityPage.tsx
@@ -146,7 +146,7 @@ const ActivityPage = () => {
             onScopesChange={setSelectedScopes}
             onUsersChange={setSelectedUsers}
           />
-          {activeFilterPills.length > 0 && (
+          {activeFilterPills.length > 0 ? (
             <div className="flex flex-wrap gap-2">
               {activeFilterPills.map((pill) => (
                 <Button
@@ -160,7 +160,7 @@ const ActivityPage = () => {
                 </Button>
               ))}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
 
@@ -180,7 +180,7 @@ const ActivityPage = () => {
             ) : undefined
           }
         />
-        {hasMore && (
+        {hasMore ? (
           <div className="flex justify-center py-6">
             <Button
               variant={variants.secondary}
@@ -192,7 +192,7 @@ const ActivityPage = () => {
               Load more
             </Button>
           </div>
-        )}
+        ) : null}
       </div>
     </>
   );

--- a/client/src/protoFleet/features/auth/components/AuthenticateFleetModal/AuthenticateFleetModal.stories.tsx
+++ b/client/src/protoFleet/features/auth/components/AuthenticateFleetModal/AuthenticateFleetModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <AuthenticateFleetModal
         open={open}
         onAuthenticated={(username, password) => {
@@ -39,13 +39,13 @@ export const SecurityPurpose = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <AuthenticateFleetModal
         open={open}
         purpose="security"
@@ -67,13 +67,13 @@ export const PoolPurpose = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <AuthenticateFleetModal
         open={open}
         purpose="pool"

--- a/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.stories.tsx
+++ b/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <AuthenticateMiners
         open={open}
         onClose={() => {

--- a/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.tsx
+++ b/client/src/protoFleet/features/auth/components/AuthenticateMiners/AuthenticateMiners.tsx
@@ -200,10 +200,11 @@ const AuthenticateMiners = ({
             initValue={credentials[item.deviceIdentifier]?.username ?? bulkCredentials.username}
             hideLabelOnFocus
             disabled={
-              authenticateLoading &&
-              (bulkCredentials.username !== "" ||
-                (credentials[item.deviceIdentifier] !== undefined &&
-                  credentials[item.deviceIdentifier].username !== ""))
+              authenticateLoading
+                ? bulkCredentials.username !== "" ||
+                  (credentials[item.deviceIdentifier] !== undefined &&
+                    credentials[item.deviceIdentifier].username !== "")
+                : false
             }
             error={minerErrors.find((id) => id === item.deviceIdentifier) !== undefined}
             onChange={handleMinerChange.bind(this, item.deviceIdentifier, ids.username)}
@@ -221,10 +222,11 @@ const AuthenticateMiners = ({
             initValue={credentials[item.deviceIdentifier]?.password ?? bulkCredentials.password}
             hideLabelOnFocus
             disabled={
-              authenticateLoading &&
-              (bulkCredentials.password !== "" ||
-                (credentials[item.deviceIdentifier] !== undefined &&
-                  credentials[item.deviceIdentifier].password !== ""))
+              authenticateLoading
+                ? bulkCredentials.password !== "" ||
+                  (credentials[item.deviceIdentifier] !== undefined &&
+                    credentials[item.deviceIdentifier].password !== "")
+                : false
             }
             error={minerErrors.find((id) => id === item.deviceIdentifier) !== undefined}
             onChange={handleMinerChange.bind(this, item.deviceIdentifier, ids.password)}
@@ -480,7 +482,7 @@ const AuthenticateMiners = ({
           : undefined
       }
     >
-      {errorMessage !== null && (
+      {errorMessage !== null ? (
         <Callout
           className="mt-6"
           intent={intents.information}
@@ -492,7 +494,7 @@ const AuthenticateMiners = ({
             setMinerErrors([]);
           }}
         />
-      )}
+      ) : null}
       <div className="mt-6 rounded-2xl bg-surface-5 p-6 dark:bg-core-primary-5">
         <div className="flex w-full flex-col gap-4">
           <div>
@@ -505,7 +507,7 @@ const AuthenticateMiners = ({
             id={ids.username}
             label="Miner username"
             initValue={bulkCredentials.username}
-            disabled={authenticateLoading && bulkCredentials.username !== ""}
+            disabled={authenticateLoading ? bulkCredentials.username !== "" : false}
             error={hasMissingCredentials && !bulkCredentials.username ? "Missing username" : undefined}
             onChange={handleBulkChange}
             autoFocus
@@ -515,13 +517,13 @@ const AuthenticateMiners = ({
             label="Miner password"
             type="password"
             initValue={bulkCredentials.password}
-            disabled={authenticateLoading && bulkCredentials.password !== ""}
+            disabled={authenticateLoading ? bulkCredentials.password !== "" : false}
             error={hasMissingCredentials && !bulkCredentials.password ? "Missing password" : undefined}
             onChange={handleBulkChange}
           />
         </div>
       </div>
-      {showMiners && (
+      {showMiners ? (
         <>
           <div className="mt-2">
             <List<UnauthenticatedMiner, UnauthenticatedMiner["deviceIdentifier"]>
@@ -548,7 +550,7 @@ const AuthenticateMiners = ({
             onSelectNone={() => setSelectedMiners([])}
           />
         </>
-      )}
+      ) : null}
     </Modal>
   );
 };

--- a/client/src/protoFleet/features/auth/components/UpdatePasswordForm.tsx
+++ b/client/src/protoFleet/features/auth/components/UpdatePasswordForm.tsx
@@ -101,12 +101,12 @@ export const UpdatePasswordForm = ({
                 />
               </div>
 
-              {showWeakPasswordWarning && !isSubmitting && (
+              {showWeakPasswordWarning && !isSubmitting ? (
                 <WeakPasswordWarning
                   onReturn={() => setShowWeakPasswordWarning(false)}
                   onContinue={() => handleSubmit(true)}
                 />
-              )}
+              ) : null}
 
               <Button onClick={() => handleSubmit(false)} variant="primary" disabled={isSubmitting}>
                 {isSubmitting ? "Updating..." : "Continue"}

--- a/client/src/protoFleet/features/dashboard/components/ChartWidget/ChartWidget.tsx
+++ b/client/src/protoFleet/features/dashboard/components/ChartWidget/ChartWidget.tsx
@@ -30,7 +30,7 @@ const ChartWidget = ({
   return (
     <div className={clsx("rounded-xl bg-surface-base p-10 dark:bg-core-primary-5 phone:p-6", className)}>
       <div className={statsPadding}>
-        {statsArray.length > 0 && (
+        {statsArray.length > 0 ? (
           <Stats
             stats={statsArray}
             size={statsSize}
@@ -38,7 +38,7 @@ const ChartWidget = ({
             gap={statsGap}
             padding="" // let our parent handle padding
           />
-        )}
+        ) : null}
       </div>
       <div className="flex w-full">{children}</div>
     </div>

--- a/client/src/protoFleet/features/dashboard/components/SegmentedMetricPanel/SegmentedMetricPanel.tsx
+++ b/client/src/protoFleet/features/dashboard/components/SegmentedMetricPanel/SegmentedMetricPanel.tsx
@@ -159,7 +159,7 @@ export const SegmentedMetricPanel = ({
                   xAxisTickInterval={getXAxisTickInterval(hours, isMultiDay)}
                   yAxisTickCount={4}
                   barWidth={barWidth}
-                  showDateLabel={isMultiDay && processedChartData.length > 1}
+                  showDateLabel={isMultiDay ? processedChartData.length > 1 : false}
                   useDateFormat={shouldUseDateFormat(hours)}
                   lastTickOverride={!isMultiDay && hours < 24 ? "live" : undefined}
                 />

--- a/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/FleetPoolActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/FleetPoolActionsMenu.tsx
@@ -51,7 +51,7 @@ const FleetPoolActionsMenuInner = ({ onTestConnection, onRemove, poolId }: Fleet
           setIsOpen((prev) => !prev);
         }}
       />
-      {isOpen && (
+      {isOpen ? (
         <Popover
           className="!space-y-0 px-4 pt-2 pb-1"
           position={positions["bottom right"]}
@@ -78,7 +78,7 @@ const FleetPoolActionsMenuInner = ({ onTestConnection, onRemove, poolId }: Fleet
             Remove
           </Row>
         </Popover>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/PoolSelectionModal/PoolSelectionModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/PoolSelectionModal/PoolSelectionModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <PoolSelectionModal
         open={open}
         onDismiss={() => {

--- a/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/PoolSelectionPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage/PoolSelectionPage.tsx
@@ -402,14 +402,14 @@ const PoolSelectionPage = ({
             />
 
             {/* Duplicate pools warning */}
-            {hasDuplicatePools && (
+            {hasDuplicatePools ? (
               <Callout
                 intent={intents.warning}
                 prefixIcon={<Alert />}
                 title="Duplicate pool configuration detected"
                 subtitle="Two or more pools have the same URL and username. Please remove or change the duplicate pools before assigning."
               />
-            )}
+            ) : null}
 
             {/* Pool list */}
             {isLoadingInitialState ? (
@@ -449,7 +449,7 @@ const PoolSelectionPage = ({
                   </SortableContext>
                 </DndContext>
 
-                {canAddMorePools && (
+                {canAddMorePools ? (
                   <div className="flex">
                     <Button
                       text="Add another pool"
@@ -459,7 +459,7 @@ const PoolSelectionPage = ({
                       testId="add-another-pool-button"
                     />
                   </div>
-                )}
+                ) : null}
               </div>
             )}
           </div>
@@ -467,7 +467,7 @@ const PoolSelectionPage = ({
       </div>
 
       <PoolSelectionModal
-        open={isVisible && showSelectionModal}
+        open={isVisible ? showSelectionModal : false}
         onDismiss={() => {
           setShowSelectionModal(false);
           setEditingPoolIndex(null);

--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
@@ -33,7 +33,7 @@ const ActionItem = <ActionType,>({ action, onAction }: ActionItemProps<ActionTyp
           {action.title}
         </Row>
       </div>
-      {action.showGroupDivider && <Divider dividerStyle="thick" />}
+      {action.showGroupDivider ? <Divider dividerStyle="thick" /> : null}
     </>
   );
 };

--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsWidget.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsWidget.tsx
@@ -108,9 +108,9 @@ const BulkActionsWidget = <ActionType extends Key>({
       >
         {buttonTitle}
       </Button>
-      {isOpen && renderPopover(handleAction)}
+      {isOpen ? renderPopover(handleAction) : null}
       <UnsupportedMinersModal
-        open={!!onUnsupportedMinersDismiss && (unsupportedMinersInfo?.visible ?? false)}
+        open={onUnsupportedMinersDismiss ? (unsupportedMinersInfo?.visible ?? false) : false}
         unsupportedGroups={unsupportedMinersInfo?.unsupportedGroups ?? []}
         totalUnsupportedCount={unsupportedMinersInfo?.totalUnsupportedCount ?? 0}
         noneSupported={unsupportedMinersInfo?.noneSupported ?? false}

--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/UnsupportedMinersModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/UnsupportedMinersModal.stories.tsx
@@ -27,13 +27,13 @@ export const WithSomeSupported = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <UnsupportedMinersModal
         open={open}
         unsupportedGroups={mockGroups}
@@ -57,13 +57,13 @@ export const NoneSupported = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <UnsupportedMinersModal
         open={open}
         unsupportedGroups={mockGroups}
@@ -92,13 +92,13 @@ export const SingleMiner = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <UnsupportedMinersModal
         open={open}
         unsupportedGroups={singleGroup}

--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/UnsupportedMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/UnsupportedMinersModal.tsx
@@ -31,7 +31,7 @@ const UnsupportedMinersModal = ({
   return (
     <>
       <Dialog
-        open={open && noneSupported}
+        open={open ? noneSupported : false}
         title="Action not supported"
         subtitle={`This action is not supported by the connected ${minerText} firmware.`}
         subtitleSize="text-300"
@@ -48,7 +48,7 @@ const UnsupportedMinersModal = ({
         testId="action-not-supported-dialog"
       />
       <Modal
-        open={open && !noneSupported}
+        open={open ? !noneSupported : false}
         onDismiss={onDismiss}
         buttons={[
           {
@@ -81,7 +81,7 @@ const UnsupportedMinersModal = ({
                 {group.count} {group.count === 1 ? "miner" : "miners"}
               </div>
             </Row>
-            {index < unsupportedGroups.length - 1 && <Divider />}
+            {index < unsupportedGroups.length - 1 ? <Divider /> : null}
           </Fragment>
         ))}
       </Modal>

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -200,14 +200,14 @@ const Fleet = () => {
 
   return (
     <>
-      {(!unfilteredCountLoaded || totalUnfilteredMiners > 0 || totalMiners > 0) && (
+      {!unfilteredCountLoaded || totalUnfilteredMiners > 0 || totalMiners > 0 ? (
         <CompleteSetup
           className="sticky left-0 mb-10 max-w-full px-10 pt-10 phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6"
           lastPairingCompletedAt={lastPairingCompletedAt}
           onRefetchMiners={refetchAll}
           onPairingCompleted={notifyPairingCompleted}
         />
-      )}
+      ) : null}
       <ErrorBoundary>
         <MinerList
           title="Miners"
@@ -249,7 +249,7 @@ const Fleet = () => {
         />
       </ErrorBoundary>
 
-      {showAddMinersModal && (
+      {showAddMinersModal ? (
         <Miners
           mode="pairing"
           onExit={handleAddMinersClose}
@@ -257,7 +257,7 @@ const Fleet = () => {
           onPairingCompleted={notifyPairingCompleted}
           onRefetchMiners={refetchAll}
         />
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/AddToGroupModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/AddToGroupModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <AddToGroupModal
         open={open}
         selectedMiners={["miner-1", "miner-2", "miner-3"]}
@@ -38,13 +38,13 @@ export const SingleMiner = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <AddToGroupModal
         open={open}
         selectedMiners={["miner-1"]}
@@ -64,13 +64,13 @@ export const AllMinersSelected = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <AddToGroupModal
         open={open}
         selectedMiners={[]}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/CoolingModeModal/CoolingModeModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/CoolingModeModal/CoolingModeModal.stories.tsx
@@ -23,9 +23,9 @@ const StoryWrapper = ({ infoMessage, minerCount = 1 }: { infoMessage?: string; m
 
   return (
     <div>
-      {infoMessage && (
+      {infoMessage ? (
         <div className="mb-4 rounded-lg bg-intent-info-10 p-4 text-300 text-text-primary">{infoMessage}</div>
-      )}
+      ) : null}
       <CoolingModeModal
         minerCount={minerCount}
         onConfirm={(coolingMode) => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <FirmwareUpdateModal
         open={open}
         onConfirm={(firmwareFileId) => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -111,13 +111,13 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
     <Modal open={open} title="Add firmware payload" onDismiss={handleDismiss} buttons={buttons} divider={false}>
       <div className="text-text-secondary mt-2 text-300">Upload the firmware payload file to update your miners.</div>
       <div className="mt-6 flex flex-col gap-4">
-        {showLoadingSpinner && (
+        {showLoadingSpinner ? (
           <div className="flex items-center justify-center p-8">
             <ProgressCircular indeterminate size={24} />
           </div>
-        )}
+        ) : null}
 
-        {hasExistingFiles && (
+        {hasExistingFiles ? (
           <div className="flex flex-col gap-2">
             <div className="text-300 text-text-primary">Select an existing firmware file</div>
             <div
@@ -147,7 +147,9 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
                       selectedExistingFileId === f.id ? "border-border-focus" : "border-border-20",
                     )}
                   >
-                    {selectedExistingFileId === f.id && <div className="h-2 w-2 rounded-full bg-core-primary-fill" />}
+                    {selectedExistingFileId === f.id ? (
+                      <div className="h-2 w-2 rounded-full bg-core-primary-fill" />
+                    ) : null}
                   </div>
                   <div className="flex min-w-0 flex-col">
                     <div className="truncate text-300 text-text-primary">{f.filename}</div>
@@ -159,7 +161,7 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
               ))}
             </div>
 
-            {serverConfig && (
+            {serverConfig ? (
               <div className="flex items-center gap-3 py-2">
                 <div className="h-px flex-1 bg-border-5" />
                 <Button
@@ -170,28 +172,28 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
                 />
                 <div className="h-px flex-1 bg-border-5" />
               </div>
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
 
-        {uploadState === "error" && errorMessage && <FileErrorStatus message={errorMessage} onRetry={retry} />}
+        {uploadState === "error" && errorMessage ? <FileErrorStatus message={errorMessage} onRetry={retry} /> : null}
 
-        {uploadState === "idle" && serverConfig && (!hasExistingFiles || showUploadZone) && (
+        {uploadState === "idle" && serverConfig && (!hasExistingFiles || showUploadZone) ? (
           <FileDropZone extensions={serverConfig.allowedExtensions} onFileSelect={handleUploadFileSelect} />
-        )}
+        ) : null}
 
-        {isProcessing && uploadFile && (
+        {isProcessing && uploadFile ? (
           <FileProcessingStatus
             state={uploadState as "hashing" | "checking" | "uploading"}
             fileName={uploadFile.name}
             fileSize={uploadFile.size}
             uploadProgress={uploadProgress}
           />
-        )}
+        ) : null}
 
-        {uploadState === "ready" && uploadFile && !selectedExistingFileId && (
+        {uploadState === "ready" && uploadFile && !selectedExistingFileId ? (
           <FileReadyStatus fileName={uploadFile.name} fileSize={uploadFile.size} />
-        )}
+        ) : null}
       </div>
     </Modal>
   );

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManagePowerModal/ManagePowerModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManagePowerModal/ManagePowerModal.stories.tsx
@@ -23,9 +23,9 @@ const StoryWrapper = ({ infoMessage }: { infoMessage?: string }) => {
 
   return (
     <div>
-      {infoMessage && (
+      {infoMessage ? (
         <div className="mb-4 rounded-lg bg-intent-info-10 p-4 text-300 text-text-primary">{infoMessage}</div>
-      )}
+      ) : null}
       <ManagePowerModal
         onConfirm={(performanceMode) => {
           action("onConfirm")(performanceMode);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/ManageSecurityModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/ManageSecurityModal.tsx
@@ -114,7 +114,7 @@ const ManageSecurityModal = ({ open, minerGroups, onUpdateGroup, onDismiss, onDo
                 >
                   <div className="text-emphasis-300 text-text-primary">{group.name}</div>
                 </Row>
-                {index < sortedGroups.length - 1 && <Divider />}
+                {index < sortedGroups.length - 1 ? <Divider /> : null}
               </div>
             ))}
           </div>

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <UpdateMinerPasswordModal
         open={open}
         hasThirdPartyMiners={false}
@@ -40,13 +40,13 @@ export const WithThirdPartyMiners = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <UpdateMinerPasswordModal
         open={open}
         hasThirdPartyMiners={true}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.tsx
@@ -149,12 +149,12 @@ const UpdateMinerPasswordModal = ({
             type="password"
             onChange={(value) => setNewPassword(value)}
           />
-          {!hasThirdPartyMiners && (
+          {!hasThirdPartyMiners ? (
             <div className="flex items-center justify-between gap-5">
               <div className="text-200 text-text-primary-50">Password strength</div>
               <PasswordStrengthMeter score={score} onSetScore={setScore} password={newPassword} />
             </div>
-          )}
+          ) : null}
         </div>
 
         <Input

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -261,7 +261,7 @@ const MinerActionsMenu = ({
         />
       </div>
       <PoolSelectionPageWrapper
-        open={showPoolSelectionPage && !!fleetCredentials}
+        open={showPoolSelectionPage ? !!fleetCredentials : false}
         selectedMiners={poolMiners}
         selectionMode={selectionMode}
         poolNeededCount={poolFilteredDeviceIds ? poolFilteredDeviceIds.length : totalCount}
@@ -272,17 +272,17 @@ const MinerActionsMenu = ({
         onDismiss={handleCancel}
       />
       <ManagePowerModal
-        open={currentAction === performanceActions.managePower && showManagePowerModal}
+        open={currentAction === performanceActions.managePower ? showManagePowerModal : false}
         onConfirm={handleManagePowerConfirm}
         onDismiss={handleManagePowerDismiss}
       />
       <FirmwareUpdateModal
-        open={currentAction === deviceActions.firmwareUpdate && showFirmwareUpdateModal}
+        open={currentAction === deviceActions.firmwareUpdate ? showFirmwareUpdateModal : false}
         onConfirm={handleFirmwareUpdateConfirm}
         onDismiss={handleFirmwareUpdateDismiss}
       />
       <CoolingModeModal
-        open={currentAction === settingsActions.coolingMode && showCoolingModeModal}
+        open={currentAction === settingsActions.coolingMode ? showCoolingModeModal : false}
         minerCount={coolingModeCount}
         initialCoolingMode={currentCoolingMode}
         onConfirm={handleCoolingModeConfirm}
@@ -318,7 +318,7 @@ const MinerActionsMenu = ({
         onDismiss={handlePasswordDismiss}
       />
       <AddToGroupModal
-        open={currentAction === groupActions.addToGroup && showAddToGroupModal}
+        open={currentAction === groupActions.addToGroup ? showAddToGroupModal : false}
         onDismiss={handleAddToGroupDismiss}
         selectedMiners={selectedMiners}
         selectionMode={selectionMode}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameMinerDialog.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameMinerDialog.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <RenameMinerDialog
         open={open}
         deviceIdentifier="device-abc-123"

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.tsx
@@ -578,7 +578,7 @@ const SingleMinerActionsMenuInner = ({
         testId="single-miner-actions-menu-button"
         onClick={() => setIsOpen((prev) => !prev)}
       />
-      {isOpen && (
+      {isOpen ? (
         <Popover
           className="!space-y-0 !rounded-2xl px-0 pt-2 pb-1"
           position={positions["bottom right"]}
@@ -600,11 +600,11 @@ const SingleMinerActionsMenuInner = ({
                   {action.title}
                 </Row>
               </div>
-              {action.showGroupDivider && <Divider dividerStyle="thick" />}
+              {action.showGroupDivider ? <Divider dividerStyle="thick" /> : null}
             </Fragment>
           ))}
         </Popover>
-      )}
+      ) : null}
       <UnsupportedMinersModal
         open={unsupportedMinersInfo.visible}
         unsupportedGroups={unsupportedMinersInfo.unsupportedGroups}
@@ -630,7 +630,7 @@ const SingleMinerActionsMenuInner = ({
           );
         })}
       <PoolSelectionPageWrapper
-        open={showPoolSelectionPage && !!fleetCredentials}
+        open={showPoolSelectionPage ? !!fleetCredentials : false}
         selectedMiners={selectedMiners}
         selectionMode="subset"
         userUsername={fleetCredentials?.username}
@@ -641,7 +641,7 @@ const SingleMinerActionsMenuInner = ({
       />
       <RenameMinerDialog
         key={showRenameDialog ? deviceIdentifier : "closed"}
-        open={currentAction === settingsActions.rename && showRenameDialog}
+        open={currentAction === settingsActions.rename ? showRenameDialog : false}
         deviceIdentifier={deviceIdentifier}
         currentMinerName={minerName}
         onConfirm={handleRenameConfirm}
@@ -655,17 +655,17 @@ const SingleMinerActionsMenuInner = ({
         onDismiss={handleUpdateWorkerNameDismiss}
       />
       <ManagePowerModal
-        open={currentAction === performanceActions.managePower && showManagePowerModal}
+        open={currentAction === performanceActions.managePower ? showManagePowerModal : false}
         onConfirm={handleManagePowerConfirm}
         onDismiss={handleManagePowerDismiss}
       />
       <FirmwareUpdateModal
-        open={currentAction === deviceActions.firmwareUpdate && showFirmwareUpdateModal}
+        open={currentAction === deviceActions.firmwareUpdate ? showFirmwareUpdateModal : false}
         onConfirm={handleFirmwareUpdateConfirm}
         onDismiss={handleFirmwareUpdateDismiss}
       />
       <CoolingModeModal
-        open={currentAction === settingsActions.coolingMode && showCoolingModeModal}
+        open={currentAction === settingsActions.coolingMode ? showCoolingModeModal : false}
         minerCount={coolingModeCount}
         initialCoolingMode={currentCoolingMode}
         onConfirm={handleCoolingModeConfirm}
@@ -697,7 +697,7 @@ const SingleMinerActionsMenuInner = ({
         onDismiss={handlePasswordDismiss}
       />
       <AddToGroupModal
-        open={currentAction === groupActions.addToGroup && showAddToGroupModal}
+        open={currentAction === groupActions.addToGroup ? showAddToGroupModal : false}
         onDismiss={handleAddToGroupDismiss}
         selectedMiners={[deviceIdentifier]}
         selectionMode="subset"

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerGroups.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerGroups.tsx
@@ -56,33 +56,34 @@ const MinerGroups = ({ miner, availableGroups }: MinerGroupsProps) => {
   return (
     <span ref={triggerRef} className="cursor-default" onMouseEnter={open} onMouseLeave={closeWithDelay}>
       {groupLabels.length} groups
-      {isVisible &&
-        createPortal(
-          <div
-            className="fixed z-[9999] min-w-60 rounded-lg bg-surface-elevated-base px-3 py-2 shadow-lg"
-            style={floatingStyle}
-            onMouseEnter={open}
-            onMouseLeave={closeWithDelay}
-          >
-            <ul className="flex flex-col divide-y divide-border-5 whitespace-nowrap">
-              {groupLabels.map((label) => {
-                const link = getGroupLink(label);
-                return (
-                  <li key={label} className="py-2">
-                    {link ? (
-                      <Link to={link} className="text-300 hover:underline">
-                        {label}
-                      </Link>
-                    ) : (
-                      <span>{label}</span>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          </div>,
-          document.body,
-        )}
+      {isVisible
+        ? createPortal(
+            <div
+              className="fixed z-[9999] min-w-60 rounded-lg bg-surface-elevated-base px-3 py-2 shadow-lg"
+              style={floatingStyle}
+              onMouseEnter={open}
+              onMouseLeave={closeWithDelay}
+            >
+              <ul className="flex flex-col divide-y divide-border-5 whitespace-nowrap">
+                {groupLabels.map((label) => {
+                  const link = getGroupLink(label);
+                  return (
+                    <li key={label} className="py-2">
+                      {link ? (
+                        <Link to={link} className="text-300 hover:underline">
+                          {label}
+                        </Link>
+                      ) : (
+                        <span>{label}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>,
+            document.body,
+          )
+        : null}
     </span>
   );
 };

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -340,7 +340,7 @@ const ScopedMinerListBody = ({
         }
       />
 
-      {shouldRenderPagination && (
+      {shouldRenderPagination ? (
         <div
           className={clsx("sticky left-0 flex flex-col items-center gap-4 pt-6", {
             "pb-24": selectionMode !== "none",
@@ -370,7 +370,7 @@ const ScopedMinerListBody = ({
             />
           </div>
         </div>
-      )}
+      ) : null}
     </>
   );
 };
@@ -856,25 +856,25 @@ const MinerList = ({
         />
       ) : null}
 
-      {modalFlow.kind === "authenticate-miners" && (
+      {modalFlow.kind === "authenticate-miners" ? (
         <AuthenticateMiners
           open
           onClose={closeModalFlow}
           onRefetchMiners={onRefetchMiners}
           onPairingCompleted={onPairingCompleted}
         />
-      )}
+      ) : null}
 
-      {modalFlow.kind === "authenticate-fleet" && (
+      {modalFlow.kind === "authenticate-fleet" ? (
         <AuthenticateFleetModal
           open
           purpose="pool"
           onAuthenticated={handleFleetAuthenticated}
           onDismiss={closeModalFlow}
         />
-      )}
+      ) : null}
 
-      {modalFlow.kind === "pool-selection" && (
+      {modalFlow.kind === "pool-selection" ? (
         <PoolSelectionPageWrapper
           open
           selectedMiners={[
@@ -890,16 +890,16 @@ const MinerList = ({
           onError={closeModalFlow}
           onDismiss={closeModalFlow}
         />
-      )}
+      ) : null}
 
-      {modalFlow.kind === "status-modal" && (
+      {modalFlow.kind === "status-modal" ? (
         <ProtoFleetStatusModal
           open
           onClose={closeModalFlow}
           deviceId={modalFlow.deviceIdentifier}
           miner={miners[modalFlow.deviceIdentifier]}
         />
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerName.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerName.tsx
@@ -44,18 +44,15 @@ const MinerName = ({
       <div className="flex items-center gap-2">
         {isActionLoading ? (
           <ProgressCircular size={14} indeterminate />
-        ) : (
-          needsAttention &&
-          !needsAuthentication && (
-            <button
-              onClick={() => onOpenStatusFlow(deviceIdentifier)}
-              className="cursor-pointer transition-opacity hover:opacity-80"
-              aria-label="View issues"
-            >
-              <Alert width="w-4" className="text-red-500" />
-            </button>
-          )
-        )}
+        ) : needsAttention && !needsAuthentication ? (
+          <button
+            onClick={() => onOpenStatusFlow(deviceIdentifier)}
+            className="cursor-pointer transition-opacity hover:opacity-80"
+            aria-label="View issues"
+          >
+            <Alert width="w-4" className="text-red-500" />
+          </button>
+        ) : null}
         <SingleMinerActionsMenu
           deviceIdentifier={deviceIdentifier}
           minerUrl={miner.url || undefined}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/UnsupportedMetric.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/UnsupportedMetric.tsx
@@ -15,14 +15,14 @@ const UnsupportedMetric = ({ message }: UnsupportedMetricProps) => {
       <span ref={triggerRef} className="text-text-primary-50" onMouseEnter={show} onMouseLeave={hide}>
         N/A
       </span>
-      {isVisible && (
+      {isVisible ? (
         <span
           className="pointer-events-none fixed z-50 w-max max-w-xs rounded-lg bg-surface-elevated-base px-3 py-2 text-300 text-text-primary shadow-300 transition-opacity duration-200"
           style={floatingStyle}
         >
           {message}
         </span>
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
@@ -363,8 +363,8 @@ const DeviceSetActionsMenuInner = ({
           prefixIcon={<Ellipsis width={iconSizes.small} className="text-text-primary-70" />}
           onClick={handleOpen}
         />
-        {isOpen &&
-          (fetchingMembers || fetchingMiners ? (
+        {isOpen ? (
+          fetchingMembers || fetchingMiners ? (
             <div
               className={`popover-content absolute right-0 z-10 flex items-center justify-center rounded-2xl bg-surface-overlay p-6 shadow-elevation-200 ${popoverClassName ?? ""}`}
             >
@@ -378,7 +378,8 @@ const DeviceSetActionsMenuInner = ({
               position={positions["bottom right"]}
               className={popoverClassName ?? "!space-y-0 !rounded-2xl px-0 pt-2 pb-1"}
             />
-          ))}
+          )
+        ) : null}
       </div>
 
       <UnsupportedMinersModal
@@ -408,7 +409,7 @@ const DeviceSetActionsMenuInner = ({
 
       {/* Modal dialogs */}
       <PoolSelectionPageWrapper
-        open={showPoolSelectionPage && !!fleetCredentials}
+        open={showPoolSelectionPage ? !!fleetCredentials : false}
         selectedMiners={poolMiners}
         selectionMode={"subset" as SelectionMode}
         poolNeededCount={poolFilteredDeviceIds ? poolFilteredDeviceIds.length : memberDeviceIds.length}
@@ -419,12 +420,12 @@ const DeviceSetActionsMenuInner = ({
         onDismiss={handleCancel}
       />
       <ManagePowerModal
-        open={currentAction === performanceActions.managePower && showManagePowerModal}
+        open={currentAction === performanceActions.managePower ? showManagePowerModal : false}
         onConfirm={handleManagePowerConfirm}
         onDismiss={handleManagePowerDismiss}
       />
       <CoolingModeModal
-        open={currentAction === settingsActions.coolingMode && showCoolingModeModal}
+        open={currentAction === settingsActions.coolingMode ? showCoolingModeModal : false}
         minerCount={coolingModeCount}
         initialCoolingMode={currentCoolingMode}
         onConfirm={handleCoolingModeConfirm}

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection.tsx
@@ -162,7 +162,7 @@ function ChartPanel({
           duration={duration}
           referenceLines={referenceLines}
         />
-        {legendStats && (
+        {legendStats ? (
           <div className="flex items-center gap-6 px-2 pt-2 text-200 text-core-primary-50">
             <div className="flex items-center gap-2">
               <svg width="24" height="4">
@@ -211,7 +211,7 @@ function ChartPanel({
               <span>{legendStats.min}</span>
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     </ChartWidget>
   );

--- a/client/src/protoFleet/features/groupManagement/components/GroupModal.stories.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/GroupModal.stories.tsx
@@ -12,13 +12,13 @@ export const CreateNew = () => {
 
   return (
     <>
-      {!show && (
+      {!show ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setShow(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <GroupModal
         show={show}
         onDismiss={() => {

--- a/client/src/protoFleet/features/groupManagement/components/GroupModal.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/GroupModal.tsx
@@ -145,7 +145,7 @@ const GroupModal = ({ show, onDismiss, onSuccess, group }: GroupModalProps) => {
     <>
       <Modal
         onDismiss={onDismiss}
-        open={show && !showDeleteConfirm}
+        open={show ? !showDeleteConfirm : false}
         size="large"
         className="flex !h-[calc(100vh-(--spacing(32)))] max-h-[calc(100vh-(--spacing(32)))] flex-col !overflow-hidden"
         bodyClassName="flex flex-1 min-h-0 flex-col"
@@ -207,7 +207,7 @@ const GroupModal = ({ show, onDismiss, onSuccess, group }: GroupModalProps) => {
         </div>
       </Modal>
 
-      {showDeleteConfirm && group && (
+      {showDeleteConfirm && group ? (
         <Dialog
           title={`Delete "${group.label}"?`}
           subtitle="This action cannot be undone. The miners in this group will not be affected."
@@ -226,7 +226,7 @@ const GroupModal = ({ show, onDismiss, onSuccess, group }: GroupModalProps) => {
             },
           ]}
         />
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
@@ -314,7 +314,7 @@ const GroupOverviewPage = () => {
         </section>
       </div>
 
-      {showEditModal && group && (
+      {showEditModal && group ? (
         <GroupModal
           show
           group={group}
@@ -325,7 +325,7 @@ const GroupOverviewPage = () => {
             void refetchStats();
           }}
         />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
@@ -169,7 +169,7 @@ const GroupsPage = () => {
                   </Button>
                 </div>
               </div>
-              {activeFilterPills.length > 0 && (
+              {activeFilterPills.length > 0 ? (
                 <div className="flex flex-wrap gap-2">
                   {activeFilterPills.map((pill) => (
                     <Button
@@ -183,7 +183,7 @@ const GroupsPage = () => {
                     </Button>
                   ))}
                 </div>
-              )}
+              ) : null}
             </div>
           </div>
           {error ? (
@@ -218,18 +218,18 @@ const GroupsPage = () => {
         </>
       )}
 
-      {showGroupModal && (
+      {showGroupModal ? (
         <GroupModal show={showGroupModal} onDismiss={() => setShowGroupModal(false)} onSuccess={resetAndFetch} />
-      )}
+      ) : null}
 
-      {editGroup && (
+      {editGroup ? (
         <GroupModal
           show={!!editGroup}
           group={editGroup}
           onDismiss={() => setEditGroup(null)}
           onSuccess={resetAndFetch}
         />
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.stories.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.stories.tsx
@@ -30,15 +30,15 @@ const TaskCard = ({
         <div className="flex size-8 items-center justify-center rounded-lg bg-surface-5">{icon}</div>
         <div className="flex flex-col">
           <div className="text-emphasis-300">{title}</div>
-          {description && <div className="text-300">{description}</div>}
+          {description ? <div className="text-300">{description}</div> : null}
         </div>
       </div>
       <div className="flex justify-between gap-5">
-        {skippable && (
+        {skippable ? (
           <Button className="pl-0" variant="textOnly" onClick={onSkip} disabled={isLoading}>
             Skip
           </Button>
-        )}
+        ) : null}
         <Button
           onClick={onActionClick}
           variant={skippable ? "secondary" : "primary"}
@@ -75,7 +75,7 @@ const CompleteSetupStory = ({ poolNeededCount, authNeededCount, isLoading = fals
           <Button onClick={action("dismiss complete setup")} variant="secondary" prefixIcon={<div>×</div>}></Button>
         </div>
         <div className="grid gap-4 @lg:grid-cols-2 @3xl:grid-cols-3 @7xl:grid-cols-4">
-          {hasConfigurePoolCard && (
+          {hasConfigurePoolCard ? (
             <TaskCard
               icon={<MiningPools className="text-text-primary" />}
               title="Configure pools"
@@ -86,8 +86,8 @@ const CompleteSetupStory = ({ poolNeededCount, authNeededCount, isLoading = fals
               onSkip={action("skip configure pools")}
               isLoading={isLoading}
             />
-          )}
-          {hasAuthCard && (
+          ) : null}
+          {hasAuthCard ? (
             <TaskCard
               icon={<Alert className="text-text-critical" />}
               title="Authenticate miners"
@@ -95,7 +95,7 @@ const CompleteSetupStory = ({ poolNeededCount, authNeededCount, isLoading = fals
               actionText="Authenticate"
               onActionClick={action("authenticate miners")}
             />
-          )}
+          ) : null}
         </div>
       </div>
     </div>

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
@@ -41,15 +41,15 @@ const TaskCard = ({
         <div className="flex size-8 items-center justify-center rounded-lg bg-surface-5">{icon}</div>
         <div className="flex flex-col">
           <div className="text-emphasis-300">{title}</div>
-          {description && <div className="text-300">{description}</div>}
+          {description ? <div className="text-300">{description}</div> : null}
         </div>
       </div>
       <div className="flex justify-between gap-5">
-        {skippable && (
+        {skippable ? (
           <Button className="pl-0" variant="textOnly" onClick={onSkip} disabled={isLoading}>
             Skip
           </Button>
-        )}
+        ) : null}
         <Button
           onClick={onActionClick}
           variant={skippable ? "secondary" : "primary"}
@@ -400,7 +400,7 @@ const CompleteSetup = ({
 
   return (
     <>
-      {shouldShow && (
+      {shouldShow ? (
         <div className={className}>
           <div className="@container rounded-3xl bg-core-primary-5 p-6">
             <div className="mb-6 flex items-center justify-between gap-x-10">
@@ -414,7 +414,7 @@ const CompleteSetup = ({
             </div>
             <div className="grid gap-4 @lg:grid-cols-2 @3xl:grid-cols-3 @7xl:grid-cols-4">
               <AnimatePresence mode="popLayout">
-                {hasConfigurePoolCard && (
+                {hasConfigurePoolCard ? (
                   <motion.div
                     key="configure-pool-card"
                     layout
@@ -435,8 +435,8 @@ const CompleteSetup = ({
                       isLoading={isLoadingPoolNeeded || isPollingAfterPoolAssignment}
                     />
                   </motion.div>
-                )}
-                {hasAuthCard && (
+                ) : null}
+                {hasAuthCard ? (
                   <motion.div
                     key="auth-card"
                     layout
@@ -452,12 +452,12 @@ const CompleteSetup = ({
                       onPairingCompleted={onPairingCompleted}
                     />
                   </motion.div>
-                )}
+                ) : null}
               </AnimatePresence>
             </div>
           </div>
         </div>
-      )}
+      ) : null}
       <AuthenticateFleetModal
         open={showAuthModal}
         purpose="pool"
@@ -465,7 +465,7 @@ const CompleteSetup = ({
         onDismiss={handleAuthDismiss}
       />
       <PoolSelectionPageWrapper
-        open={showPoolSelectionModal && !!poolFleetCredentials}
+        open={showPoolSelectionModal ? !!poolFleetCredentials : false}
         selectionMode="all"
         poolNeededCount={poolNeededCount}
         filterCriteria={{

--- a/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.tsx
@@ -87,7 +87,7 @@ const CollapsibleSkeleton = ({ visible, showDivider }: { visible: boolean; showD
     >
       <div ref={contentRef}>
         <SkeletonMinerRows />
-        {showDivider && <Divider />}
+        {showDivider ? <Divider /> : null}
       </div>
     </div>
   );
@@ -175,7 +175,7 @@ const FoundMiners = ({ miners, deselectedMiners, isScanning, showSkeleton, class
                   {model.miners.filter((miner) => !deselectedMiners.includes(miner.deviceIdentifier)).length} miners
                 </div>
               </Row>
-              {modelEntries.length > index + 1 && <Divider />}
+              {modelEntries.length > index + 1 ? <Divider /> : null}
             </Fragment>
           ))}
         </div>

--- a/client/src/protoFleet/features/onboarding/components/Miners/FoundMinersModal.stories.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/FoundMinersModal.stories.tsx
@@ -56,13 +56,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <FoundMinersModal
         open={open}
         miners={mockMiners}

--- a/client/src/protoFleet/features/onboarding/components/Miners/Miners.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/Miners.tsx
@@ -182,7 +182,7 @@ const Miners = ({
     <div className="h-[calc(100vh-theme(spacing.1)*15)]">
       <Dialog open={pairingPending} title="Pairing the found miners" subtitle="This may take a few seconds" loading />
 
-      {mode === "onboarding" && (
+      {mode === "onboarding" ? (
         <NullState
           icon={<LogoAlt width="w-5" />}
           title="Let's setup your fleet."
@@ -193,7 +193,7 @@ const Miners = ({
             </Button>
           }
         />
-      )}
+      ) : null}
 
       <PageOverlay open={mode === "pairing" || showModal} zIndex="z-50">
         <div className="h-full w-full overflow-auto bg-surface-base p-6">
@@ -261,7 +261,7 @@ const Miners = ({
                   ]
             }
           />
-          {activeStep === "findMiners" && (
+          {activeStep === "findMiners" ? (
             <div className="mx-auto max-w-4xl">
               <Header
                 title="Miners"
@@ -305,7 +305,7 @@ const Miners = ({
                   </div>
                 </div>
 
-                {onForemanImport && (
+                {onForemanImport ? (
                   <div
                     className="flex flex-col gap-4 rounded-3xl bg-core-primary-5 p-6"
                     data-testid="section-import-foreman"
@@ -322,7 +322,7 @@ const Miners = ({
                       </Button>
                     </div>
                   </div>
-                )}
+                ) : null}
               </div>
 
               <div className="flex flex-col gap-4 rounded-3xl bg-core-primary-5 p-6" data-testid="section-search-by-ip">
@@ -363,8 +363,8 @@ const Miners = ({
                 </div>
               </div>
             </div>
-          )}
-          {activeStep === "pairing" && (
+          ) : null}
+          {activeStep === "pairing" ? (
             <div className="mx-auto max-w-4xl">
               <FoundMiners
                 miners={displayMiners}
@@ -373,7 +373,7 @@ const Miners = ({
                 isScanning={discoveryPending}
                 showSkeleton={showLoadingSkeleton}
               />
-              {displayMiners.length > 0 && (
+              {displayMiners.length > 0 ? (
                 <FoundMinersModal
                   open={showFoundMinersModal}
                   setDeselectedMiners={setDeselectedMiners}
@@ -384,9 +384,9 @@ const Miners = ({
                   models={Array.from(new Set(displayMiners.map((miner) => miner.model)))}
                   onDismiss={() => setShowFoundMinersModal(false)}
                 />
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </div>
       </PageOverlay>
 
@@ -432,7 +432,7 @@ const Miners = ({
       </Modal>
 
       <ValidationErrorDialog
-        open={showValidationErrorDialog && !!categorizedInvalidEntries}
+        open={showValidationErrorDialog ? !!categorizedInvalidEntries : false}
         invalidEntries={categorizedInvalidEntries ?? { ipAddresses: [], ipRanges: [], subnets: [] }}
         hasValidEntries={pendingValidTargets !== null}
         onBackToEditing={handleBackToEditing}

--- a/client/src/protoFleet/features/onboarding/components/Miners/ValidationErrorDialog.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/ValidationErrorDialog.tsx
@@ -51,24 +51,24 @@ const ValidationErrorDialog = ({
       ]}
     >
       <div className="flex flex-col gap-2 text-300 text-text-primary-70">
-        {hasIpAddresses && (
+        {hasIpAddresses ? (
           <div>
             <p className="font-medium text-text-primary">Invalid IP addresses</p>
             <p>{invalidEntries.ipAddresses.join(", ")}</p>
           </div>
-        )}
-        {hasIpRanges && (
+        ) : null}
+        {hasIpRanges ? (
           <div>
             <p className="font-medium text-text-primary">Invalid IP ranges</p>
             <p>{invalidEntries.ipRanges.join(", ")}</p>
           </div>
-        )}
-        {hasSubnets && (
+        ) : null}
+        {hasSubnets ? (
           <div>
             <p className="font-medium text-text-primary">Invalid subnet blocks</p>
             <p>{invalidEntries.subnets.join(", ")}</p>
           </div>
-        )}
+        ) : null}
       </div>
     </Dialog>
   );

--- a/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/AssignMinersModal.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/AssignMinersModal.tsx
@@ -534,7 +534,7 @@ export default function AssignMinersModal({
         }
       />
 
-      {showRackSettings && (
+      {showRackSettings ? (
         <RackSettingsModal
           show={showRackSettings}
           existingRacks={existingRacks}
@@ -542,9 +542,9 @@ export default function AssignMinersModal({
           onDismiss={() => setShowRackSettings(false)}
           onContinue={handleRackSettingsUpdate}
         />
-      )}
+      ) : null}
 
-      {showManageMiners && (
+      {showManageMiners ? (
         <ManageMinersModal
           show={showManageMiners}
           currentRackMiners={rackMiners}
@@ -553,9 +553,9 @@ export default function AssignMinersModal({
           onDismiss={() => setShowManageMiners(false)}
           onConfirm={handleManageMinersConfirm}
         />
-      )}
+      ) : null}
 
-      {showSearchMiners && (
+      {showSearchMiners ? (
         <SearchMinersModal
           show={showSearchMiners}
           currentRackLabel={initialRackSettings.label}
@@ -565,9 +565,9 @@ export default function AssignMinersModal({
           }}
           onConfirm={handleSearchMinerConfirm}
         />
-      )}
+      ) : null}
 
-      {showDeleteConfirm && onDelete && (
+      {showDeleteConfirm && onDelete ? (
         <Dialog
           title={`Delete "${rackSettings.label}"?`}
           subtitle="This action cannot be undone. The miners in this rack will not be affected."
@@ -594,7 +594,7 @@ export default function AssignMinersModal({
             },
           ]}
         />
-      )}
+      ) : null}
     </>
   );
 }

--- a/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/ManageMinersModal.stories.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/ManageMinersModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!show && (
+      {!show ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setShow(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <ManageMinersModal
         show={show}
         currentRackMiners={["miner-001", "miner-002"]}

--- a/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/MinersPane.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/MinersPane.tsx
@@ -125,37 +125,37 @@ function MinerRow({
             !isSelected && isAssigned && "bg-intent-success-fill",
           )}
         >
-          {isSelected && <ArrowRight width="w-3" className="text-white" />}
-          {!isSelected && isAssigned && <Checkmark width="w-4" className="text-white" />}
+          {isSelected ? <ArrowRight width="w-3" className="text-white" /> : null}
+          {!isSelected && isAssigned ? <Checkmark width="w-4" className="text-white" /> : null}
         </div>
       </div>
       <div className="min-w-0 flex-1">
         <div className="truncate text-300 text-text-primary" data-testid="rack-miner-name">
           {name || deviceId}
         </div>
-        {subtitleParts.length > 0 && (
+        {subtitleParts.length > 0 ? (
           <div className="truncate text-300 text-text-primary-50" data-testid="rack-miner-subtitle">
             {subtitleParts.join(", ")}
           </div>
-        )}
+        ) : null}
       </div>
 
-      {isSelected && (
+      {isSelected ? (
         <span className="shrink-0 text-200 text-text-primary">
           {slotAwaitingAssignment !== null
             ? `assign to slot ${String(slotAwaitingAssignment).padStart(2, "0")}`
             : "select rack position"}
         </span>
-      )}
+      ) : null}
 
-      {!isSelected && isAssigned && (
+      {!isSelected && isAssigned ? (
         <span
           className="shrink-0 text-300 font-medium text-text-primary tabular-nums"
           data-testid="rack-miner-position"
         >
           Position {String(assignedSlotNumber).padStart(2, "0")}
         </span>
-      )}
+      ) : null}
 
       <div className="relative shrink-0" ref={menuRef}>
         {isAssigned ? (
@@ -181,7 +181,7 @@ function MinerRow({
             >
               <Ellipsis width="w-4" />
             </button>
-            {showMenu && (
+            {showMenu ? (
               <>
                 <div
                   className="fixed inset-0 z-20"
@@ -213,7 +213,7 @@ function MinerRow({
                   </button>
                 </div>
               </>
-            )}
+            ) : null}
           </>
         )}
       </div>

--- a/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/RackPane.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/RackPane.tsx
@@ -150,14 +150,14 @@ function RackSlotCell({
       >
         <span className="font-medium text-text-primary-70">{String(slot.slotNumber).padStart(padWidth, "0")}</span>
       </button>
-      {isSelected && showPopover && (
+      {isSelected && showPopover ? (
         <SlotPopover
           selectFromListDisabled={!hasMiners}
           onSelectFromList={onSelectFromList}
           onSearchMiners={onSearchMiners}
           onDismiss={onPopoverDismiss}
         />
-      )}
+      ) : null}
     </div>
   );
 }
@@ -228,7 +228,7 @@ export default function RackPane({
                 assignedMinerId={slotAssignments[slot.key]}
                 isManualMode={assignmentMode === "manual"}
                 isSelected={selectedSlotKey === slot.key}
-                showPopover={showPopover && selectedSlotKey === slot.key}
+                showPopover={showPopover ? selectedSlotKey === slot.key : false}
                 hasMiners={hasMiners}
                 slotSize={slotSize}
                 padWidth={padWidth}

--- a/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/SearchMinersModal.stories.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/SearchMinersModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!show && (
+      {!show ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setShow(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <SearchMinersModal
         show={show}
         currentRackLabel="Rack A-01"

--- a/client/src/protoFleet/features/rackManagement/components/RackCard/MiniRackGrid.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/RackCard/MiniRackGrid.tsx
@@ -48,7 +48,7 @@ const MiniRackGrid = ({ cols, rows, slots }: MiniRackGridProps) => {
               })}
               style={{ width: slotSize, height: slotSize }}
             >
-              {hasDot && (
+              {hasDot ? (
                 <span
                   className={clsx("absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full", {
                     "bg-intent-critical-fill": status === "needsAttention",
@@ -56,7 +56,7 @@ const MiniRackGrid = ({ cols, rows, slots }: MiniRackGridProps) => {
                   })}
                   style={{ width: dotSize, height: dotSize }}
                 />
-              )}
+              ) : null}
             </div>
           );
         })}

--- a/client/src/protoFleet/features/rackManagement/components/RackCard/RackCard.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/RackCard/RackCard.tsx
@@ -68,11 +68,11 @@ const RackCard = ({
           <span data-testid="rack-card-label" className="text-300 text-emphasis-300">
             {label}
           </span>
-          {zone && (
+          {zone ? (
             <span data-testid="rack-card-zone" className="text-300 text-text-primary-50">
               {zone}
             </span>
-          )}
+          ) : null}
         </div>
 
         {/* Mini Rack Grid */}
@@ -96,7 +96,7 @@ const RackCard = ({
                 <span key={i} className="inline-flex items-center gap-1">
                   <span className={clsx("h-2 w-2 shrink-0 rounded-full", seg.color)} />
                   {seg.text}
-                  {i < statusSegments.length - 1 && ","}
+                  {i < statusSegments.length - 1 ? "," : null}
                 </span>
               ))}
             </span>

--- a/client/src/protoFleet/features/rackManagement/components/RackDetailGrid/RackDetailGrid.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/RackDetailGrid/RackDetailGrid.tsx
@@ -44,7 +44,7 @@ export default function RackDetailGrid({
 
   return (
     <div ref={measureRef} className="flex w-full justify-center">
-      {computedSlotSize > 0 && (
+      {computedSlotSize > 0 ? (
         <div
           data-testid="rack-detail-grid"
           className="grid"
@@ -58,7 +58,7 @@ export default function RackDetailGrid({
             <RackDetailSlot key={i} slot={slot} slotSize={computedSlotSize} onEmptySlotClick={onEmptySlotClick} />
           ))}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/client/src/protoFleet/features/rackManagement/components/RackDetailGrid/RackDetailSlot.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/RackDetailGrid/RackDetailSlot.tsx
@@ -66,7 +66,7 @@ export default function RackDetailSlot({ slot, slotSize = 64, onEmptySlotClick }
       )}
       style={{ width: slotSize, height: slotSize, gap: iconOnly ? 0 : 4 }}
     >
-      {dotColor && (
+      {dotColor ? (
         <span
           className="inline-block shrink-0 rounded-full"
           style={{
@@ -75,8 +75,8 @@ export default function RackDetailSlot({ slot, slotSize = 64, onEmptySlotClick }
             background: dotColor,
           }}
         />
-      )}
-      {!iconOnly && (
+      ) : null}
+      {!iconOnly ? (
         <span
           data-testid="rack-detail-slot-number"
           className={clsx("leading-none", state === "sleeping" ? "text-text-primary-30" : "text-text-primary-70")}
@@ -84,7 +84,7 @@ export default function RackDetailSlot({ slot, slotSize = 64, onEmptySlotClick }
         >
           {num}
         </span>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/client/src/protoFleet/features/rackManagement/components/RackSettingsModal.stories.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/RackSettingsModal.stories.tsx
@@ -12,13 +12,13 @@ export const CreateNew = () => {
 
   return (
     <>
-      {!show && (
+      {!show ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setShow(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <RackSettingsModal
         show={show}
         existingRacks={[]}

--- a/client/src/protoFleet/features/rackManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/RackSettingsModal.tsx
@@ -359,7 +359,7 @@ const RackSettingsModal = ({
               error={zoneError}
               autoComplete="off"
             />
-            {showZoneSuggestions && filteredSuggestions.length > 0 && (
+            {showZoneSuggestions && filteredSuggestions.length > 0 ? (
               <div
                 className="absolute top-full z-10 mt-1 w-full rounded-xl border border-border-5 bg-surface-elevated-base p-1.5 shadow-300"
                 onMouseEnter={() => {
@@ -386,7 +386,7 @@ const RackSettingsModal = ({
                   </button>
                 ))}
               </div>
-            )}
+            ) : null}
           </div>
 
           <Input
@@ -400,7 +400,7 @@ const RackSettingsModal = ({
             error={labelError}
           />
 
-          {rackTypes.length > 0 && (
+          {rackTypes.length > 0 ? (
             <Select
               id="rack-type-select"
               label="Rack type"
@@ -409,7 +409,7 @@ const RackSettingsModal = ({
               onChange={handleRackTypeChange}
               testId="rack-type-select"
             />
-          )}
+          ) : null}
 
           <div className="flex gap-3">
             <div className="flex-1">

--- a/client/src/protoFleet/features/rackManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/rackManagement/pages/RackOverviewPage.tsx
@@ -412,7 +412,7 @@ const RackOverviewPage = () => {
         </section>
       </div>
 
-      {showEditModal && rack && assignMinersFormData && (
+      {showEditModal && rack && assignMinersFormData ? (
         <AssignMinersModal
           show
           rackSettings={assignMinersFormData}
@@ -441,9 +441,9 @@ const RackOverviewPage = () => {
             })
           }
         />
-      )}
+      ) : null}
 
-      {searchMinerSlot && rack && (
+      {searchMinerSlot && rack ? (
         <SearchMinersModal
           show
           currentRackLabel={rack.label}
@@ -484,7 +484,7 @@ const RackOverviewPage = () => {
             });
           }}
         />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
@@ -279,15 +279,15 @@ const RacksPage = () => {
             </Button>
           }
         />
-        {showRackSettingsModal && (
+        {showRackSettingsModal ? (
           <RackSettingsModal
             show={showRackSettingsModal}
             existingRacks={racks}
             onDismiss={() => setShowRackSettingsModal(false)}
             onContinue={handleRackSettingsContinue}
           />
-        )}
-        {assignMinersFormData && (
+        ) : null}
+        {assignMinersFormData ? (
           <AssignMinersModal
             show={!!assignMinersFormData}
             rackSettings={assignMinersFormData}
@@ -297,7 +297,7 @@ const RacksPage = () => {
             onSave={handleAssignMinersSave}
             onDelete={assignMinersRackId ? handleDeleteRack : undefined}
           />
-        )}
+        ) : null}
       </>
     );
   }
@@ -354,7 +354,7 @@ const RacksPage = () => {
                 onSelect={handleIssuesChange}
                 withButtons
               />
-              {racksViewMode === "grid" && (
+              {racksViewMode === "grid" ? (
                 <DropdownFilter
                   title="Sort"
                   options={RACK_SORT_OPTIONS}
@@ -362,7 +362,7 @@ const RacksPage = () => {
                   onSelect={handleSortSelect}
                   showSelectAll={false}
                 />
-              )}
+              ) : null}
             </div>
             <Button variant={variants.secondary} size={sizes.compact} onClick={() => setShowRackSettingsModal(true)}>
               Add rack
@@ -384,7 +384,7 @@ const RacksPage = () => {
               onSelect={handleIssuesChange}
               withButtons
             />
-            {racksViewMode === "grid" && (
+            {racksViewMode === "grid" ? (
               <DropdownFilter
                 title="Sort"
                 options={RACK_SORT_OPTIONS}
@@ -392,9 +392,9 @@ const RacksPage = () => {
                 onSelect={handleSortSelect}
                 showSelectAll={false}
               />
-            )}
+            ) : null}
           </div>
-          {activeFilterPills.length > 0 && (
+          {activeFilterPills.length > 0 ? (
             <div className="flex flex-wrap gap-2">
               {activeFilterPills.map((pill) => (
                 <Button
@@ -408,7 +408,7 @@ const RacksPage = () => {
                 </Button>
               ))}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
       {error ? (
@@ -472,7 +472,7 @@ const RacksPage = () => {
               </div>
             </div>
           )}
-          {(shouldRenderGridPagination || (currentPage > 0 && racks.length === 0)) && (
+          {shouldRenderGridPagination || (currentPage > 0 && racks.length === 0) ? (
             <div className="sticky left-0 flex flex-col items-center gap-4 py-6">
               <span className="text-300 text-text-primary">
                 Showing {firstItemIndex}–{lastItemIndex} of {totalCount} racks
@@ -496,18 +496,18 @@ const RacksPage = () => {
                 />
               </div>
             </div>
-          )}
+          ) : null}
         </div>
       )}
-      {showRackSettingsModal && (
+      {showRackSettingsModal ? (
         <RackSettingsModal
           show={showRackSettingsModal}
           existingRacks={racks}
           onDismiss={() => setShowRackSettingsModal(false)}
           onContinue={handleRackSettingsContinue}
         />
-      )}
-      {assignMinersFormData && (
+      ) : null}
+      {assignMinersFormData ? (
         <AssignMinersModal
           show={!!assignMinersFormData}
           rackSettings={assignMinersFormData}
@@ -516,7 +516,7 @@ const RacksPage = () => {
           onDismiss={handleAssignMinersDismiss}
           onSave={handleAssignMinersSave}
         />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/protoFleet/features/settings/components/AddTeamMemberModal.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/AddTeamMemberModal.stories.tsx
@@ -64,9 +64,9 @@ const StoryWrapper = ({
 
   return (
     <div>
-      {infoMessage && (
+      {infoMessage ? (
         <div className="mb-4 rounded-lg bg-intent-info-10 p-4 text-300 text-text-primary">{infoMessage}</div>
-      )}
+      ) : null}
       <div className="fixed right-4 bottom-4 z-30 phone:right-2 phone:bottom-2">
         <ToasterComponent />
       </div>

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -322,8 +322,10 @@ const AuthenticationSettings = () => {
             divider={false}
             onDismiss={() => setShowModal(false)}
           >
-            {step === "authenticate" && <AuthenticateForm onChange={handlePasswordChange} apiError={authApiError} />}
-            {step === "updatePassword" && (
+            {step === "authenticate" ? (
+              <AuthenticateForm onChange={handlePasswordChange} apiError={authApiError} />
+            ) : null}
+            {step === "updatePassword" ? (
               <div className="flex flex-col gap-6">
                 <Header
                   title="Update password"
@@ -367,15 +369,15 @@ const AuthenticationSettings = () => {
                     />
                   </div>
                 </div>
-                {showWeakPasswordWarning && !isSubmitting && (
+                {showWeakPasswordWarning && !isSubmitting ? (
                   <WeakPasswordWarning
                     onReturn={() => setShowWeakPasswordWarning(false)}
                     onContinue={() => submitPasswordUpdate(true)}
                   />
-                )}
+                ) : null}
               </div>
-            )}
-            {step === "updateUsername" && (
+            ) : null}
+            {step === "updateUsername" ? (
               <div className="flex flex-col gap-6">
                 <Header
                   title="Update username"
@@ -406,7 +408,7 @@ const AuthenticationSettings = () => {
                   </div>
                 </div>
               </div>
-            )}
+            ) : null}
           </Modal>
         </div>
       </div>

--- a/client/src/protoFleet/features/settings/components/CreateApiKeyModal.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/CreateApiKeyModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <CreateApiKeyModal
         open={open}
         onSuccess={() => action("onSuccess")()}

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <FirmwareUploadDialog
         open={open}
         onSuccess={() => {

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -54,26 +54,26 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
         Add a firmware file to make it available for miner updates.
       </div>
       <div className="mt-6 flex flex-col gap-4">
-        {showLoadingSpinner && (
+        {showLoadingSpinner ? (
           <div className="flex items-center justify-center p-8">
             <ProgressCircular indeterminate size={24} />
           </div>
-        )}
+        ) : null}
 
-        {showDropZone && <FileDropZone extensions={serverConfig.allowedExtensions} onFileSelect={processFile} />}
+        {showDropZone ? <FileDropZone extensions={serverConfig.allowedExtensions} onFileSelect={processFile} /> : null}
 
-        {showProcessingStatus && (
+        {showProcessingStatus ? (
           <FileProcessingStatus
             state={state as "hashing" | "checking" | "uploading"}
             fileName={file.name}
             fileSize={file.size}
             uploadProgress={uploadProgress}
           />
-        )}
+        ) : null}
 
-        {showReadyStatus && <FileReadyStatus fileName={file.name} fileSize={file.size} />}
+        {showReadyStatus ? <FileReadyStatus fileName={file.name} fileSize={file.size} /> : null}
 
-        {showError && <FileErrorStatus message={errorMessage} onRetry={retry} />}
+        {showError ? <FileErrorStatus message={errorMessage} onRetry={retry} /> : null}
       </div>
     </Modal>
   );

--- a/client/src/protoFleet/features/settings/components/General.tsx
+++ b/client/src/protoFleet/features/settings/components/General.tsx
@@ -49,9 +49,9 @@ const General = () => {
                   textColor="text-intent-warning-fill"
                   text={convertToSentenceCase(theme)}
                 />
-                {showThemeSwitcher && (
+                {showThemeSwitcher ? (
                   <ThemeSwitcher onClickDone={() => setShowThemeSwitcher(false)} theme={theme} setTheme={setTheme} />
-                )}
+                ) : null}
               </Row>
               <Row className="flex justify-between" divider={false}>
                 <div className="text-300">Temperature</div>
@@ -62,13 +62,13 @@ const General = () => {
                   textColor="text-intent-warning-fill"
                   text={temperatureUnit === "C" ? "Celsius" : "Fahrenheit"}
                 />
-                {showTemperatureUnitsSwitcher && (
+                {showTemperatureUnitsSwitcher ? (
                   <TemperatureUnitsSwitcher
                     onClickDone={() => setShowTemperatureUnitsSwitcher(false)}
                     temperatureUnit={temperatureUnit}
                     setTemperatureUnit={setTemperatureUnit}
                   />
-                )}
+                ) : null}
               </Row>
             </div>
           </div>

--- a/client/src/protoFleet/features/settings/components/MiningPools.tsx
+++ b/client/src/protoFleet/features/settings/components/MiningPools.tsx
@@ -108,7 +108,7 @@ const PoolRowMenu = ({
       ariaExpanded={showMenu}
       prefixIcon={<Ellipsis />}
     />
-    {showMenu && (
+    {showMenu ? (
       <Popover
         position={positions["top left"]}
         size={popoverSizes.small}
@@ -149,7 +149,7 @@ const PoolRowMenu = ({
           </Row>
         </div>
       </Popover>
-    )}
+    ) : null}
   </div>
 );
 
@@ -175,7 +175,7 @@ const PoolRowDesktop = ({ pool, onEdit, onTestConnection, onDelete, connectionSt
       </div>
       <div className="flex flex-col justify-center py-3" data-testid="pool-url">
         <span className="break-all">{formattedUrl}</span>
-        {connectionStatus === "failed" && <span className="text-200 text-text-critical">Connection failed</span>}
+        {connectionStatus === "failed" ? <span className="text-200 text-text-critical">Connection failed</span> : null}
       </div>
       <div className="flex items-center justify-between gap-4 py-3" data-testid="pool-username">
         <span className="break-all">{formattedUsername}</span>
@@ -226,7 +226,7 @@ const PoolRowMobile = ({ pool, onEdit, onTestConnection, onDelete, connectionSta
             {formattedUrl}
           </div>
         )}
-        {connectionStatus === "failed" && <span className="text-200 text-text-critical">Connection failed</span>}
+        {connectionStatus === "failed" ? <span className="text-200 text-text-critical">Connection failed</span> : null}
       </div>
 
       {/* Right column: Username and ellipsis */}

--- a/client/src/protoFleet/features/settings/components/Schedules/GroupSelectionModal.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/GroupSelectionModal.tsx
@@ -104,7 +104,7 @@ const GroupSelectionModal = ({ open, selectedGroupIds, onDismiss, onSave }: Grou
             <label className="flex w-full cursor-pointer items-center gap-4">
               <Checkbox
                 checked={allSelected}
-                partiallyChecked={!allSelected && selectedGroupCount > 0}
+                partiallyChecked={!allSelected ? selectedGroupCount > 0 : false}
                 onChange={() =>
                   setDraftSelection(
                     allSelected ? new Set<string>() : new Set(groups.map((group) => group.id.toString())),

--- a/client/src/protoFleet/features/settings/components/Schedules/MinerSelectionModal.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/MinerSelectionModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <MinerSelectionModal
         open={open}
         selectedMinerIds={[]}
@@ -40,13 +40,13 @@ export const WithPreselected = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <MinerSelectionModal
         open={open}
         selectedMinerIds={["miner-001", "miner-002"]}

--- a/client/src/protoFleet/features/settings/components/Schedules/RackSelectionModal.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/RackSelectionModal.stories.tsx
@@ -12,13 +12,13 @@ export const Default = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <RackSelectionModal
         open={open}
         selectedRackIds={[]}
@@ -40,13 +40,13 @@ export const WithPreselected = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <RackSelectionModal
         open={open}
         selectedRackIds={["1", "3"]}

--- a/client/src/protoFleet/features/settings/components/Schedules/RackSelectionModal.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/RackSelectionModal.tsx
@@ -103,7 +103,7 @@ const RackSelectionModal = ({ open, selectedRackIds, onDismiss, onSave }: RackSe
             <label className="flex w-full cursor-pointer items-center gap-4">
               <Checkbox
                 checked={allSelected}
-                partiallyChecked={!allSelected && selectedRackCount > 0}
+                partiallyChecked={!allSelected ? selectedRackCount > 0 : false}
                 onChange={() =>
                   setDraftSelection(allSelected ? new Set<string>() : new Set(racks.map((rack) => rack.id.toString())))
                 }

--- a/client/src/protoFleet/features/settings/components/Team.tsx
+++ b/client/src/protoFleet/features/settings/components/Team.tsx
@@ -192,14 +192,14 @@ const Team = () => {
     <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <Header title="Team" titleSize="text-heading-300" />
-        {canAddTeamMembers && (
+        {canAddTeamMembers ? (
           <Button
             variant={variants.primary}
             size={sizes.compact}
             text="Add team member"
             onClick={() => setShowAddMemberModal(true)}
           />
-        )}
+        ) : null}
       </div>
 
       {isLoading ? (

--- a/client/src/protoOS/components/App/App.tsx
+++ b/client/src/protoOS/components/App/App.tsx
@@ -353,7 +353,7 @@ const App = ({
   // ============================================================================
   return (
     <ErrorBoundary>
-      {canAccessProtectedApi && <AuthenticatedShell reloadSystemInfo={reloadSystemInfo} />}
+      {canAccessProtectedApi ? <AuthenticatedShell reloadSystemInfo={reloadSystemInfo} /> : null}
 
       {/* Toaster - Fixed position, renders above everything */}
       <div className="fixed right-4 bottom-4 z-10 phone:right-2 phone:bottom-2">
@@ -361,7 +361,7 @@ const App = ({
       </div>
 
       {/* Login Modal - Layout agnostic */}
-      {showLoginModal && <LoginModal onDismiss={handleDismissLogin} onSuccess={handleSuccessLogin} />}
+      {showLoginModal ? <LoginModal onDismiss={handleDismissLogin} onSuccess={handleSuccessLogin} /> : null}
 
       {/* Wake Dialog - Layout agnostic */}
       <WarnWakeDialog open={wakeDialog.show} onClose={wakeDialog.onClose} onSubmit={wakeDialog.onConfirm} />
@@ -381,7 +381,7 @@ const App = ({
           <AppLayout title={title} ContentLayout={ContentLayout} type={navigationMenuTypes.app}>
             {calloutTopSpacing && hasVisibleCallout ? <div className="pt-14 phone:pt-6 tablet:pt-6" /> : null}
             {isWarmingUp ? <WarmingUpCallout /> : <WakeCallout afterWake={afterWake} onWake={handleWake} />}
-            {noPoolsLive && !isWarmingUp && <NoPoolsCallout arePoolsConfigured={!!poolsInfo?.[0]?.url} />}
+            {noPoolsLive && !isWarmingUp ? <NoPoolsCallout arePoolsConfigured={!!poolsInfo?.[0]?.url} /> : null}
             {!isWarmingUp && !isSleeping && errors.errors?.length && !hideErrors ? <ErrorCallout /> : null}
             {children}
           </AppLayout>

--- a/client/src/protoOS/components/App/ErrorCallout.tsx
+++ b/client/src/protoOS/components/App/ErrorCallout.tsx
@@ -31,7 +31,7 @@ const ErrorCallout = () => {
 
   return (
     <>
-      {hasIssues && !dismissed && (
+      {hasIssues && !dismissed ? (
         <div className="mb-10">
           <Callout
             buttonOnClick={() => setModalOpen(true)}
@@ -47,7 +47,7 @@ const ErrorCallout = () => {
             }}
           />
         </div>
-      )}
+      ) : null}
 
       <ProtoOSStatusModal open={isModalOpen} onClose={() => setModalOpen(false)} />
     </>

--- a/client/src/protoOS/components/App/WakeCallout.tsx
+++ b/client/src/protoOS/components/App/WakeCallout.tsx
@@ -55,7 +55,7 @@ const WakeCallout = ({ afterWake, onWake }: WakeCalloutProps) => {
 
   return (
     <>
-      {isSleeping && (
+      {isSleeping ? (
         <div className="mb-10">
           <Callout
             buttonOnClick={wakeMiner}
@@ -65,7 +65,7 @@ const WakeCallout = ({ afterWake, onWake }: WakeCalloutProps) => {
             title="This miner is asleep and is not hashing."
           />
         </div>
-      )}
+      ) : null}
       <WakingDialog open={shouldWake} />
 
       <FansDetectedDialog

--- a/client/src/protoOS/components/MiningPools/MiningPools.tsx
+++ b/client/src/protoOS/components/MiningPools/MiningPools.tsx
@@ -23,13 +23,13 @@ const MiningPools = ({ title, children, loading, onChange, pools }: MiningPoolsP
 
   return (
     <>
-      {hasConfiguredPools && (
+      {hasConfiguredPools ? (
         <ContentHeader
           title={title}
           subtitle="Add up to 3 pools in order of priority. If a pool fails or is removed, your miner switches to the next available pool automatically."
           testId="mining-pool-title"
         />
-      )}
+      ) : null}
       {children}
       {loading ? <ProgressCircular indeterminate /> : <Pools pools={pools} onChangePools={onChange} />}
     </>

--- a/client/src/protoOS/components/MiningPools/Pools.tsx
+++ b/client/src/protoOS/components/MiningPools/Pools.tsx
@@ -90,7 +90,7 @@ const PoolActionsMenuInner = ({ onEdit, onDelete, poolIndex, canDelete = true }:
           setIsOpen((prev) => !prev);
         }}
       />
-      {isOpen && (
+      {isOpen ? (
         <Popover
           className="!space-y-0 px-4 pt-2 pb-1"
           position={positions["bottom right"]}
@@ -117,7 +117,7 @@ const PoolActionsMenuInner = ({ onEdit, onDelete, poolIndex, canDelete = true }:
             Delete
           </Row>
         </Popover>
-      )}
+      ) : null}
     </div>
   );
 };
@@ -397,7 +397,7 @@ const Pools = ({ onChangePools, pools }: PoolsProps) => {
         </SortableContext>
       </DndContext>
 
-      {configuredPools.length < MAX_POOLS && (
+      {configuredPools.length < MAX_POOLS ? (
         <div className="mt-4">
           <Button
             text="Add another pool"
@@ -407,7 +407,7 @@ const Pools = ({ onChangePools, pools }: PoolsProps) => {
             testId="add-another-pool-button"
           />
         </div>
-      )}
+      ) : null}
 
       <BackupPoolModalWrapper
         open={currentPoolIndex !== null}

--- a/client/src/protoOS/components/NavigationMenu/InfoItem/IpAddressInfo/IpAddressInfo.tsx
+++ b/client/src/protoOS/components/NavigationMenu/InfoItem/IpAddressInfo/IpAddressInfo.tsx
@@ -9,7 +9,7 @@ const IpAddressInfo = ({ loading, value }: IpAddressInfoProps) => {
   return (
     <InfoItem
       label="IP Address"
-      loading={loading && !value}
+      loading={loading ? !value : false}
       value={value}
       divider={false}
       testId="ip-address-info-item"

--- a/client/src/protoOS/components/NavigationMenu/InfoItem/MinerNameInfo/MinerNameInfo.tsx
+++ b/client/src/protoOS/components/NavigationMenu/InfoItem/MinerNameInfo/MinerNameInfo.tsx
@@ -7,7 +7,13 @@ export interface MinerNameInfoProps {
 
 const MinerNameInfo = ({ loading, value }: MinerNameInfoProps) => {
   return (
-    <InfoItem label="Miner" loading={loading && !value} value={value} divider={false} testId="miner-name-info-item" />
+    <InfoItem
+      label="Miner"
+      loading={loading ? !value : false}
+      value={value}
+      divider={false}
+      testId="miner-name-info-item"
+    />
   );
 };
 

--- a/client/src/protoOS/components/NavigationMenu/InfoItem/VersionInfo/VersionInfo.tsx
+++ b/client/src/protoOS/components/NavigationMenu/InfoItem/VersionInfo/VersionInfo.tsx
@@ -9,7 +9,7 @@ const VersionInfo = ({ loading, value }: VersionInfoProps) => {
   return (
     <InfoItem
       label="Firmware Version"
-      loading={loading && !value}
+      loading={loading ? !value : false}
       value={value}
       divider={false}
       testId="version-info-item"

--- a/client/src/protoOS/components/NavigationMenu/Navigation.tsx
+++ b/client/src/protoOS/components/NavigationMenu/Navigation.tsx
@@ -73,8 +73,8 @@ const Navigation = ({ ipAddressInfo, macInfo, minerNameInfo, onItemClick, versio
           )}
         </div>
         <div className="px-3" data-testid="navigation">
-          {isApp && <AppNavigationItems pageName={pageName} onClick={handleClick} />}
-          {isOnboarding && <OnboardingNavigationItems pageName={pageName} onClick={handleClick} />}
+          {isApp ? <AppNavigationItems pageName={pageName} onClick={handleClick} /> : null}
+          {isOnboarding ? <OnboardingNavigationItems pageName={pageName} onClick={handleClick} /> : null}
         </div>
       </div>
 

--- a/client/src/protoOS/components/NavigationMenu/NavigationItems/AppNavigationItems.tsx
+++ b/client/src/protoOS/components/NavigationMenu/NavigationItems/AppNavigationItems.tsx
@@ -43,7 +43,7 @@ const AppNavigationItems = ({ onClick, pageName }: AppNavigationItemsProps) => {
       <NavigationItem
         suffixIcon={
           showAccordionExpand || showAccordionItems ? (
-            <MorphingPlusMinus condition={showAccordionExpand && !showAccordionItems} />
+            <MorphingPlusMinus condition={showAccordionExpand ? !showAccordionItems : false} />
           ) : undefined
         }
         text="Settings"
@@ -51,7 +51,7 @@ const AppNavigationItems = ({ onClick, pageName }: AppNavigationItemsProps) => {
         onHover={handleAccordionHover}
       />
       <AnimatePresence>
-        {showAccordionItems && (
+        {showAccordionItems ? (
           <motion.div
             initial={{ opacity: 0, y: -12 }}
             animate={{
@@ -101,7 +101,7 @@ const AppNavigationItems = ({ onClick, pageName }: AppNavigationItemsProps) => {
               isChildItem
             />
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
     </>
   );

--- a/client/src/protoOS/components/PageHeader/GlobalActions/GlobalActionsWidget.tsx
+++ b/client/src/protoOS/components/PageHeader/GlobalActions/GlobalActionsWidget.tsx
@@ -43,7 +43,7 @@ export const GlobalActionsWidget = ({ onBlinkLEDs, onDownloadLogs }: GlobalActio
       >
         <Ellipsis width={iconSizes.small} className="m-1" />
       </WidgetWrapper>
-      {isOpen && <GlobalActionsPopover onBlinkLEDs={handleBlinkButton} onDownloadLogs={handleDownloadButton} />}
+      {isOpen ? <GlobalActionsPopover onBlinkLEDs={handleBlinkButton} onDownloadLogs={handleDownloadButton} /> : null}
     </div>
   );
 };

--- a/client/src/protoOS/components/PageHeader/MinerStatus/MinerStatusWidget.tsx
+++ b/client/src/protoOS/components/PageHeader/MinerStatus/MinerStatusWidget.tsx
@@ -26,11 +26,11 @@ const MinerStatusWidget = ({ onClick, summary, circle }: MinerStatusWidgetProps)
           </div>
         ) : (
           <>
-            {circle && (
+            {circle ? (
               <div className="flex items-center">
                 <StatusCircle status={circle} variant={variants.simple} width={"w-2"} removeMargin={true} />
               </div>
-            )}
+            ) : null}
           </>
         )}
         {summary || "Status"}

--- a/client/src/protoOS/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoOS/components/PageHeader/PageHeader.tsx
@@ -41,13 +41,13 @@ const MobileHeader = ({ openMenu, title, customButtons }: PageHeaderProps) => {
       </div>
       {/* Bottom bar */
       /* If custom buttons are passed (Onboarding flow), dont render bottom bar*/}
-      {!customButtons && (
+      {!customButtons ? (
         <div className="scrollbar-hide flex w-full gap-2 overflow-auto px-4 pb-6">
           <FirmwareUpdateStatus />
           <PowerTarget />
           <PoolStatus />
         </div>
-      )}
+      ) : null}
     </div>
   );
 };
@@ -57,12 +57,12 @@ const DesktopHeader = ({ customButtons }: { customButtons: PageHeaderProps["cust
     <div className="flex w-full items-center justify-end gap-4 pl-60">
       <div className="flex grow justify-between space-x-3 self-center px-4 [scrollbar-width:none]">
         <div className="flex space-x-3 phone:flex-shrink-0">
-          {!customButtons && (
+          {!customButtons ? (
             <>
               <MinerStatus />
               <FirmwareUpdateStatus />
             </>
-          )}
+          ) : null}
         </div>
 
         <div className="flex space-x-3 phone:flex-shrink-0">

--- a/client/src/protoOS/components/PageHeader/PoolStatus/PoolInfoPopover.tsx
+++ b/client/src/protoOS/components/PageHeader/PoolStatus/PoolInfoPopover.tsx
@@ -36,7 +36,7 @@ const PoolInfoPopover = ({ isConnected, onClickViewPools, poolInfo, poolsInfo }:
       position={positions["bottom left"]}
       testId="pool-info-popover"
     >
-      {poolInfo?.url && cardTitle && (
+      {poolInfo?.url && cardTitle ? (
         <Card title={cardTitle} type={isConnected ? cardType.success : cardType.warning}>
           {isConnected ? (
             <PoolInfoRow
@@ -59,7 +59,7 @@ const PoolInfoPopover = ({ isConnected, onClickViewPools, poolInfo, poolsInfo }:
             </>
           )}
         </Card>
-      )}
+      ) : null}
     </Popover>
   );
 };

--- a/client/src/protoOS/components/PageHeader/PoolStatus/PoolStatus.tsx
+++ b/client/src/protoOS/components/PageHeader/PoolStatus/PoolStatus.tsx
@@ -65,14 +65,14 @@ const PoolStatus = ({ loading = false, onClickViewPools, poolsInfo, shouldShowPo
         isOpen={isPopoverOpen}
         onTogglePopover={() => setShowPopover((prev) => !prev)}
       />
-      {isPopoverOpen && (
+      {isPopoverOpen ? (
         <PoolInfoPopover
           onClickViewPools={handleClickViewPools}
           poolInfo={poolInfo}
           poolsInfo={poolsInfo}
           isConnected={isConnected}
         />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/protoOS/components/PageHeader/Power/PowerWidget.tsx
+++ b/client/src/protoOS/components/PageHeader/Power/PowerWidget.tsx
@@ -172,7 +172,9 @@ const PowerWidget = ({
       >
         <Power width={iconSizes.small} className="m-1 -translate-y-0.25" />
       </WidgetWrapper>
-      {isOpen && <PowerPopover onReboot={handleRebootButton} onSleep={handleSleepButton} onWake={handleWakeButton} />}
+      {isOpen ? (
+        <PowerPopover onReboot={handleRebootButton} onSleep={handleSleepButton} onWake={handleWakeButton} />
+      ) : null}
       <WarnRebootDialog open={warnReboot} onClose={() => setWarnReboot(false)} onSubmit={handleRebootConfirm} />
       <RebootingDialog open={shouldReboot} />
       <WarnSleepDialog open={warnSleep} onClose={() => setWarnSleep(false)} onSubmit={handleSleepConfirm} />

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
@@ -117,11 +117,15 @@ const PowerTarget = () => {
         }}
       >
         <div className="flex items-center">
-          {pending && <ProgressCircular className="mr-1" indeterminate dataTestId="mining-pool-spinner" size={12} />}
+          {pending ? (
+            <ProgressCircular className="mr-1" indeterminate dataTestId="mining-pool-spinner" size={12} />
+          ) : null}
           {chipText}
         </div>
       </WidgetWrapper>
-      {showPopover && <PowerTargetPopover onDismiss={() => setShowPopover(false)} onUpdateStart={handleUpdateStart} />}
+      {showPopover ? (
+        <PowerTargetPopover onDismiss={() => setShowPopover(false)} onUpdateStart={handleUpdateStart} />
+      ) : null}
     </div>
   );
 };

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
@@ -136,7 +136,7 @@ const PowerTargetPopover = ({ onDismiss, onUpdateStart }: PowerTargetPopoverProp
         }}
       />
 
-      {selectedPowerTargetMode === powerTargetModes.custom && (
+      {selectedPowerTargetMode === powerTargetModes.custom ? (
         <div className="space-y-2">
           <Input
             id={"power-target-input"}
@@ -155,7 +155,7 @@ const PowerTargetPopover = ({ onDismiss, onUpdateStart }: PowerTargetPopoverProp
               ${convertWtoKW(bounds?.min || 0)} kW and ${convertWtoKW(bounds?.max || 0)} kW.`}
           </p>
         </div>
-      )}
+      ) : null}
 
       <div className="flex gap-3">
         <Button text="Cancel" variant={variants.secondary} className="grow" size={sizes.base} onClick={onDismiss} />

--- a/client/src/protoOS/features/diagnostic/components/CardHeader/CardHeader.tsx
+++ b/client/src/protoOS/features/diagnostic/components/CardHeader/CardHeader.tsx
@@ -25,7 +25,7 @@ function CardHeader({
       </div>
       <div className="flex items-center gap-3">
         {componentIcon}
-        {onInfoIconClick && (
+        {onInfoIconClick ? (
           <button
             className="rounded-full border-0 bg-core-primary-5 p-1.5"
             onClick={onInfoIconClick}
@@ -33,7 +33,7 @@ function CardHeader({
           >
             <InfoInverted className="text-text-primary-70" width={iconSizes.small} />
           </button>
-        )}
+        ) : null}
         {actions}
       </div>
     </div>

--- a/client/src/protoOS/features/diagnostic/components/DiagnosticView/DiagnosticView.tsx
+++ b/client/src/protoOS/features/diagnostic/components/DiagnosticView/DiagnosticView.tsx
@@ -156,29 +156,29 @@ function DiagnosticView({ className }: DiagnosticViewProps) {
       </div>
 
       <div className="space-y-12">
-        {shouldShowComponent("fans") && (
+        {shouldShowComponent("fans") ? (
           <ErrorBoundary>
             <FansSection />
           </ErrorBoundary>
-        )}
+        ) : null}
 
-        {shouldShowComponent("hashboards") && (
+        {shouldShowComponent("hashboards") ? (
           <ErrorBoundary>
             <HashboardsSection />
           </ErrorBoundary>
-        )}
+        ) : null}
 
-        {shouldShowComponent("psus") && (
+        {shouldShowComponent("psus") ? (
           <ErrorBoundary>
             <PsusSection />
           </ErrorBoundary>
-        )}
+        ) : null}
 
-        {shouldShowComponent("controlBoard") && (
+        {shouldShowComponent("controlBoard") ? (
           <ErrorBoundary>
             <ControlBoardSection />
           </ErrorBoundary>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/AsicChart/AsicChartTooltip.tsx
+++ b/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/AsicChart/AsicChartTooltip.tsx
@@ -49,7 +49,7 @@ const AsicChartTooltip = ({
 
   return (
     <>
-      {payload.datetime && (
+      {payload.datetime ? (
         <div className="w-[180px] rounded-xl bg-surface-elevated-base/70 px-3 py-2 shadow-200 backdrop-blur-[7px]">
           {payload.temp_c !== undefined ? (
             <AsicPopoverRow
@@ -66,7 +66,7 @@ const AsicChartTooltip = ({
             />
           ) : null}
         </div>
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/AsicPopover.tsx
+++ b/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/AsicPopover.tsx
@@ -76,11 +76,9 @@ const AsicPopover = ({ asic, closePopover, closeIgnoreSelectors }: AsicPopoverPr
         ) : null}
         {hashrateData.length || temperatureData.length ? (
           <AsicChart hashrateData={hashrateData} temperatureData={temperatureData} />
-        ) : (
-          !isLoading && (
-            <div className="flex h-full items-center justify-center text-text-primary-50">No chart data available</div>
-          )
-        )}
+        ) : !isLoading ? (
+          <div className="flex h-full items-center justify-center text-text-primary-50">No chart data available</div>
+        ) : null}
       </div>
       <div>
         <AsicPopoverRow

--- a/client/src/protoOS/features/diagnostic/components/HashboardTemperature/HashboardSelector.tsx
+++ b/client/src/protoOS/features/diagnostic/components/HashboardTemperature/HashboardSelector.tsx
@@ -39,7 +39,7 @@ const HashboardSelector = ({ hashboardList, currentHashboard }: HashboardSelecto
         {currentHashboardName || <SkeletonBar className="w-25 text-heading-300" />}
       </Button>
 
-      {showPopover && (
+      {showPopover ? (
         <Popover className="!space-y-0 px-0 py-0">
           <div ref={popoverRef} className="px-6 py-2">
             {hashboardList.map((hashboard, index) => (
@@ -61,7 +61,7 @@ const HashboardSelector = ({ hashboardList, currentHashboard }: HashboardSelecto
             ))}
           </div>
         </Popover>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/protoOS/features/diagnostic/components/HashboardTemperature/HashboardTemperature.tsx
+++ b/client/src/protoOS/features/diagnostic/components/HashboardTemperature/HashboardTemperature.tsx
@@ -160,25 +160,25 @@ const HashboardTemperature = ({ serial }: HashboardTemperatureProps) => {
         />
       </div>
       <div className={`${containerPadX} pt-4`}>
-        {serial && (
+        {serial ? (
           <div className="before:w-ful relative flex items-center justify-between font-mono text-mono-text-50 text-text-primary-50 before:absolute before:top-[50%] before:left-0 before:h-[1px] before:w-full before:bg-border-5">
             <div className="relative bg-surface-base pr-4">
               Front
-              {hashboard?.inletTemp?.latest && (
+              {hashboard?.inletTemp?.latest ? (
                 <> {convertAndFormatMeasurement(hashboard.inletTemp.latest, temperatureUnit, false)}</>
-              )}
+              ) : null}
             </div>
             <div className="relative bg-surface-base px-4">{serial}</div>
             <div className="relative bg-surface-base pl-4">
               Rear
-              {hashboard?.outletTemp?.latest && (
+              {hashboard?.outletTemp?.latest ? (
                 <> {convertAndFormatMeasurement(hashboard.outletTemp.latest, temperatureUnit, false)}</>
-              )}
+              ) : null}
             </div>
           </div>
-        )}
+        ) : null}
       </div>
-      {serial && (
+      {serial ? (
         <div className="scrollbar-hide max-w-screen overflow-x-auto">
           <div className={`relative ${containerMarginX} mb-2 min-w-[800px]`}>
             <AsicMetricProvider selectedMetric={selectedMetric}>
@@ -186,13 +186,13 @@ const HashboardTemperature = ({ serial }: HashboardTemperatureProps) => {
             </AsicMetricProvider>
           </div>
         </div>
-      )}
+      ) : null}
       <div className={`${containerPadX} mb-5`}>
-        {hashboard?.board && (
+        {hashboard?.board ? (
           <div className="before:w-ful relative flex items-center justify-around font-mono text-mono-text-50 text-text-primary-50 before:absolute before:top-[50%] before:left-0 before:h-[1px] before:w-full before:bg-border-5">
             <div className="relative bg-surface-base px-4">{hashboard.board}</div>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/client/src/protoOS/features/diagnostic/components/HashboardTemperature/HashboardTemperatureWrapper.tsx
+++ b/client/src/protoOS/features/diagnostic/components/HashboardTemperature/HashboardTemperatureWrapper.tsx
@@ -3,7 +3,7 @@ import HashboardTemperature from "./HashboardTemperature";
 
 const HashboardTemperatureWrapper = () => {
   const { serial } = useParams<{ serial: string }>();
-  return <>{serial !== undefined && <HashboardTemperature serial={serial} />}</>;
+  return <>{serial !== undefined ? <HashboardTemperature serial={serial} /> : null}</>;
 };
 
 export default HashboardTemperatureWrapper;

--- a/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatus/FirmwareUpdateStatusWidget.tsx
+++ b/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatus/FirmwareUpdateStatusWidget.tsx
@@ -47,7 +47,7 @@ const FirmwareUpdateStatusWidget = ({
           <div className="flex items-center">
             <ProgressCircular indeterminate dataTestId="miner-status-spinner" size={12} />
           </div>
-          {updateStatus?.progress && <>{updateStatus.progress}%</>}
+          {updateStatus?.progress ? <>{updateStatus.progress}%</> : null}
         </div>
       ) : updateStatus?.status !== "installed" ? (
         <div className="flex items-center">

--- a/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatus/FirmwareUpdateStatusWidget.tsx
+++ b/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatus/FirmwareUpdateStatusWidget.tsx
@@ -47,7 +47,7 @@ const FirmwareUpdateStatusWidget = ({
           <div className="flex items-center">
             <ProgressCircular indeterminate dataTestId="miner-status-spinner" size={12} />
           </div>
-          {updateStatus?.progress ? <>{updateStatus.progress}%</> : null}
+          {updateStatus?.progress != null ? <>{updateStatus.progress}%</> : null}
         </div>
       ) : updateStatus?.status !== "installed" ? (
         <div className="flex items-center">

--- a/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatusModal/FirmwareUpdateStatusModal.tsx
+++ b/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatusModal/FirmwareUpdateStatusModal.tsx
@@ -222,26 +222,26 @@ const FirmwareUpdateStatusModal = ({
         rebootPending,
       })}
     >
-      {updateStatus && (
+      {updateStatus ? (
         <div className="space-y-2 text-sm">
           <div>{statusConfig.message ?? updateStatus.message}</div>
-          {updateStatus.current_version && (
+          {updateStatus.current_version ? (
             <div>
               <span className="font-medium">Current Version:</span> {updateStatus.current_version}
             </div>
-          )}
-          {updateStatus.new_version && (
+          ) : null}
+          {updateStatus.new_version ? (
             <div>
               <span className="font-medium">New Version:</span> {updateStatus.new_version}
             </div>
-          )}
-          {updateStatus.progress !== undefined && (
+          ) : null}
+          {updateStatus.progress !== undefined ? (
             <div>
               <span className="font-medium">Progress:</span> {updateStatus.progress}%
             </div>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
     </Dialog>
   );
 };

--- a/client/src/protoOS/features/kpis/components/HashboardSelector/HashboardSelector.tsx
+++ b/client/src/protoOS/features/kpis/components/HashboardSelector/HashboardSelector.tsx
@@ -142,7 +142,7 @@ const HashboardSelector = ({
         onClick={handleSummaryClick}
         testId="chart-filter-summary"
       />
-      {hashboardLines.length > 0 && (
+      {hashboardLines.length > 0 ? (
         <Button
           size={sizes.compact}
           variant={allHashboardsSelected ? variants.secondary : variants.ghost}
@@ -151,13 +151,13 @@ const HashboardSelector = ({
           onClick={handleAllHashboardsClick}
           testId="chart-filter-all-hashboards"
         />
-      )}
+      ) : null}
 
       {hashboardLines.map((serial) => (
         <HashboardSelectorItem
           key={serial}
           slot={useMinerStore.getState().hardware.getHashboard(serial)?.slot}
-          selected={isFilteredMode && activeChartLines.includes(serial)}
+          selected={isFilteredMode ? activeChartLines.includes(serial) : false}
           onClick={() => {
             handleHashboardClick(serial);
           }}

--- a/client/src/protoOS/features/kpis/components/KpiLayout/KpiLayout.tsx
+++ b/client/src/protoOS/features/kpis/components/KpiLayout/KpiLayout.tsx
@@ -56,7 +56,7 @@ const KpiLayout = () => {
   return (
     <ErrorBoundary>
       <div className="p-14 phone:p-6 tablet:p-10">
-        {noPoolsLive && <NoPoolsCallout arePoolsConfigured={!!poolsInfo?.[0]?.url} />}
+        {noPoolsLive ? <NoPoolsCallout arePoolsConfigured={!!poolsInfo?.[0]?.url} /> : null}
 
         <div className="relative flex h-[calc(100vh-theme(spacing.36))] min-h-[800px] flex-col phone:min-h-[1000px]">
           <div className="flex items-center pb-6">

--- a/client/src/protoOS/features/kpis/components/KpiLineChart/KpiLineChart.test.tsx
+++ b/client/src/protoOS/features/kpis/components/KpiLineChart/KpiLineChart.test.tsx
@@ -35,7 +35,7 @@ vi.mock("recharts", async () => {
     Line: ({ dataKey, activeDot, isAnimationActive }: any) => (
       <div data-testid={`line-${dataKey}`}>
         <span data-testid={`animation-${dataKey}`}>{String(isAnimationActive)}</span>
-        {activeDot && <div data-testid={`dot-${dataKey}`}>{activeDot}</div>}
+        {activeDot ? <div data-testid={`dot-${dataKey}`}>{activeDot}</div> : null}
       </div>
     ),
     XAxis: ({ tick }: any) => <div data-testid="x-axis">{tick}</div>,

--- a/client/src/protoOS/features/settings/components/Cooling/Cooling.tsx
+++ b/client/src/protoOS/features/settings/components/Cooling/Cooling.tsx
@@ -174,7 +174,7 @@ const Cooling = () => {
 
   return (
     <>
-      {showFansDetectedCallout && (
+      {showFansDetectedCallout ? (
         <div className="mb-10">
           <Callout
             intent={intents.danger}
@@ -183,7 +183,7 @@ const Cooling = () => {
             subtitle="Fans will not turn on while in immersion mode."
           />
         </div>
-      )}
+      ) : null}
       <h2 className="mb-10 text-heading-300">Cooling</h2>
       <div className="mb-10 flex flex-col gap-4">
         <SelectRow
@@ -240,7 +240,7 @@ const Cooling = () => {
         </div>
       </div>
 
-      {showImmersionModal && (
+      {showImmersionModal ? (
         <InfoModal
           onDismiss={handleImmersionCancel}
           buttons={[
@@ -252,9 +252,9 @@ const Cooling = () => {
             },
           ]}
         />
-      )}
+      ) : null}
 
-      {showLearnMoreModal && <InfoModal onDismiss={() => setShowLearnMoreModal(false)} />}
+      {showLearnMoreModal ? <InfoModal onDismiss={() => setShowLearnMoreModal(false)} /> : null}
 
       <EnteringSleepDialog open={showSleepDialog} />
     </>

--- a/client/src/protoOS/features/settings/components/Cooling/InfoModal.stories.tsx
+++ b/client/src/protoOS/features/settings/components/Cooling/InfoModal.stories.tsx
@@ -19,7 +19,7 @@ const InfoModalStory = ({ hasButtons }: InfoModalProps) => {
           <Button onClick={() => setShowModal(true)} text="Show Modal" variant={variants.primary} size={sizes.base} />
         </div>
       </div>
-      {showModal && (
+      {showModal ? (
         <InfoModalComponent
           onDismiss={() => setShowModal(false)}
           buttons={
@@ -34,7 +34,7 @@ const InfoModalStory = ({ hasButtons }: InfoModalProps) => {
               : undefined
           }
         />
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/protoOS/features/settings/components/General/General.tsx
+++ b/client/src/protoOS/features/settings/components/General/General.tsx
@@ -86,17 +86,17 @@ const General = () => {
     <>
       <h2 className="mb-10 text-heading-300">General</h2>
       <div className="mb-10 flex h-68 w-full items-center justify-center rounded-2xl bg-core-primary-5">
-        {isProtoRig && (
+        {isProtoRig ? (
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
             <Picture image={ProtoRigImage} alt={systemInfo?.product_name} />
             <div className="mt-2 text-center text-heading-100 text-text-primary-50">{systemInfo?.product_name}</div>
           </motion.div>
-        )}
+        ) : null}
       </div>
       <div className="mb-10">
         <div className="mb-2 flex items-center justify-between">
           <h3 className="text-heading-100">Details</h3>
-          {hasTag && (
+          {hasTag ? (
             <Button
               text="Edit"
               variant={variants.secondary}
@@ -104,7 +104,7 @@ const General = () => {
               onClick={handleMinerIdClick}
               testId="edit-details-button"
             />
-          )}
+          ) : null}
         </div>
         <Row className="flex justify-between">
           <h4 className="text-emphasis-300">Model</h4>
@@ -146,9 +146,9 @@ const General = () => {
             textColor="text-intent-warning-fill"
             text={convertToSentenceCase(theme)}
           />
-          {showThemeSwitcher && (
+          {showThemeSwitcher ? (
             <ThemeSwitcher onClickDone={() => setShowThemeSwitcher(false)} theme={theme} setTheme={setTheme} />
-          )}
+          ) : null}
         </Row>
         <Row className="flex justify-between">
           <h4 className="text-emphasis-300">Temperature</h4>
@@ -159,13 +159,13 @@ const General = () => {
             text={temperatureUnit === "C" ? "Celsius" : "Fahrenheit"}
             testId="temperature-button"
           />
-          {showTemperatureUnitsSwitcher && (
+          {showTemperatureUnitsSwitcher ? (
             <TemperatureUnitsSwitcher
               onClickDone={() => setShowTemperatureUnitsSwitcher(false)}
               temperatureUnit={temperatureUnit}
               setTemperatureUnit={setTemperatureUnit}
             />
-          )}
+          ) : null}
         </Row>
       </div>
       <MinerSystemTagEditModal

--- a/client/src/protoOS/features/settings/components/MiningPools/MiningPools.tsx
+++ b/client/src/protoOS/features/settings/components/MiningPools/MiningPools.tsx
@@ -202,7 +202,12 @@ const SettingsMiningPools = () => {
   );
 
   return (
-    <MiningPools title="Pools" onChange={onChangePools} pools={pools} loading={poolsInfoPending && !isStalePools}>
+    <MiningPools
+      title="Pools"
+      onChange={onChangePools}
+      pools={pools}
+      loading={poolsInfoPending ? !isStalePools : false}
+    >
       <DismissibleCalloutWrapper
         className={clsx({
           "mb-10!": createPoolsError?.error?.message !== undefined,

--- a/client/src/protoOS/pages/MinerLogs/LogBadges.tsx
+++ b/client/src/protoOS/pages/MinerLogs/LogBadges.tsx
@@ -19,7 +19,7 @@ const LogBadges = ({ className, count, label, onClick, selected }: LogBadgesProp
     >
       <div className="flex items-center px-2 py-[1px]">
         {count} {label}
-        {selected && <DismissTiny className="ml-2" />}
+        {selected ? <DismissTiny className="ml-2" /> : null}
       </div>
     </div>
   );

--- a/client/src/protoOS/pages/MinerLogs/Logs.tsx
+++ b/client/src/protoOS/pages/MinerLogs/Logs.tsx
@@ -245,7 +245,7 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
                   prefixIcon={isExporting ? <ProgressCircular indeterminate /> : undefined}
                   onClick={handleExportLogs}
                 />
-                {searchValue && (
+                {searchValue ? (
                   <Button
                     variant={variants.secondary}
                     size={sizes.compact}
@@ -253,7 +253,7 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
                     onClick={clearSearch}
                     className="rounded-full!"
                   />
-                )}
+                ) : null}
               </div>
             </div>
           </div>
@@ -278,7 +278,7 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
                     >
                       <div className="mr-10">{line}</div>
                       <div ref={index === filteredLogs.length - 1 ? messagesEndRef : undefined}>
-                        {log.timestamp && <>[{log.timestamp}] </>}
+                        {log.timestamp ? <>[{log.timestamp}] </> : null}
                         {log.message}
                       </div>
                     </div>

--- a/client/src/shared/assets/icons/FanIndicator.tsx
+++ b/client/src/shared/assets/icons/FanIndicator.tsx
@@ -26,13 +26,13 @@ const FanIndicator = ({ numFans = 6, fanPosition = 1 }: FanIndicatorProps) => {
                   "bg-text-primary": fanPosition === firstFanIndex + 1,
                 })}
               />
-              {secondFanIndex < numFans && (
+              {secondFanIndex < numFans ? (
                 <div
                   className={clsx("h-2 w-2 rounded-full bg-core-primary-20", {
                     "bg-text-primary": fanPosition === secondFanIndex + 1,
                   })}
                 />
-              )}
+              ) : null}
             </div>
           );
         })}

--- a/client/src/shared/assets/icons/FanIndicatorV2.tsx
+++ b/client/src/shared/assets/icons/FanIndicatorV2.tsx
@@ -31,13 +31,13 @@ const FanIndicatorV2 = ({ totalSlots: numFans = 6, position = 1 }: FanIndicatorP
                   "bg-text-primary": isFirstActive,
                 })}
               />
-              {secondFanIndex < numFans && (
+              {secondFanIndex < numFans ? (
                 <div
                   className={clsx("h-1.5 w-1.5 rounded-full bg-core-primary-20", {
                     "bg-text-primary": isSecondActive,
                   })}
                 />
-              )}
+              ) : null}
             </div>
           );
         })}

--- a/client/src/shared/assets/icons/HashboardIndicator.tsx
+++ b/client/src/shared/assets/icons/HashboardIndicator.tsx
@@ -42,7 +42,7 @@ const HashboardIndicator = ({
                 backgroundColor: color && activeHashboardSlot === slotIndex ? `var(${color})` : undefined,
               }}
             />
-            {renderDivider && <div className="h-4.5 w-[1px] bg-core-primary-20" />}
+            {renderDivider ? <div className="h-4.5 w-[1px] bg-core-primary-20" /> : null}
           </Fragment>
         );
       })}

--- a/client/src/shared/components/Animation/AnimatedDotsBackground.tsx
+++ b/client/src/shared/components/Animation/AnimatedDotsBackground.tsx
@@ -96,7 +96,7 @@ const AnimatedDotsBackground = ({
         }}
       >
         {dotProps.map((props, i) => (
-          <Dot key={i} connecting={connecting && props.connecting} delay={props.delay} />
+          <Dot key={i} connecting={connecting ? props.connecting : false} delay={props.delay} />
         ))}
       </div>
     </div>

--- a/client/src/shared/components/Button/Button.tsx
+++ b/client/src/shared/components/Button/Button.tsx
@@ -129,17 +129,17 @@ const Button = ({
       data-testid={testId}
     >
       {prefix}
-      {(text || children) && prefix && <div className={gap} />}
+      {(text || children) && prefix ? <div className={gap} /> : null}
       <div className="flex flex-col">
         <div className={clsx({ "mb-[2px] group-hover:mb-0": textOnly && textOnlyUnderlineOnHover })}>
           {text}
           {children}
         </div>
-        {textOnly && !disabledState && textOnlyUnderlineOnHover && (
+        {textOnly && !disabledState && textOnlyUnderlineOnHover ? (
           <div className={clsx("-mt-[2px] w-full opacity-20 group-hover:border-b-2", borderColor)} />
-        )}
+        ) : null}
       </div>
-      {(text || children) && suffixIcon && <div className={gap} />}
+      {(text || children) && suffixIcon ? <div className={gap} /> : null}
       {suffixIcon}
     </button>
   );

--- a/client/src/shared/components/ButtonGroup/ButtonGroup.tsx
+++ b/client/src/shared/components/ButtonGroup/ButtonGroup.tsx
@@ -81,7 +81,7 @@ const ButtonGroup = ({ buttons, className, size, sortButtons = true, variant }: 
             variant={textOnly ? variants.textOnly : button.variant}
             className={clsx({ grow: fill }, button.className)}
           />
-          {textOnly && index !== sortedButtons.length - 1 && <ButtonDivider />}
+          {textOnly && index !== sortedButtons.length - 1 ? <ButtonDivider /> : null}
         </Fragment>
       ))}
     </div>

--- a/client/src/shared/components/Callout/Callout.tsx
+++ b/client/src/shared/components/Callout/Callout.tsx
@@ -96,9 +96,9 @@ const Callout = ({
 
   return (
     <div className={clsx("rounded-xl shadow-100", className)} data-testid={testId}>
-      {header && /(information|success|warning|danger)/.test(intent) && (
+      {header && /(information|success|warning|danger)/.test(intent) ? (
         <div className={clsx("rounded-t-xl px-4 py-1 text-emphasis-300 text-text-contrast", bgColor)}>{header}</div>
-      )}
+      ) : null}
       <div className="flex rounded-xl bg-surface-elevated-base px-5 py-2.5 text-text-primary">
         <div
           className={clsx("mr-3", iconColor, {
@@ -111,9 +111,9 @@ const Callout = ({
         <div className="flex w-full items-center justify-between">
           <div>
             <div className="text-emphasis-300">{title}</div>
-            {subtitle && <div className="text-300 text-text-primary-70">{subtitle}</div>}
+            {subtitle ? <div className="text-300 text-text-primary-70">{subtitle}</div> : null}
           </div>
-          {buttons.length !== 0 && (
+          {buttons.length !== 0 ? (
             <div className="ml-4">
               <ButtonGroup
                 variant={groupVariants.rightAligned}
@@ -122,7 +122,7 @@ const Callout = ({
                 sortButtons={false}
               />
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     </div>

--- a/client/src/shared/components/Checkbox/Checkbox.tsx
+++ b/client/src/shared/components/Checkbox/Checkbox.tsx
@@ -26,7 +26,7 @@ const Checkbox = ({ onChange, checked, partiallyChecked = false, className = "",
           },
         )}
       />
-      {!disabled && (
+      {!disabled ? (
         <>
           {partiallyChecked ? (
             <PartialCheckmark
@@ -38,7 +38,7 @@ const Checkbox = ({ onChange, checked, partiallyChecked = false, className = "",
             <Checkmark className="pointer-events-none absolute top-0 hidden h-full w-full text-text-contrast peer-checked:block" />
           )}
         </>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/Chip/Chip.tsx
+++ b/client/src/shared/components/Chip/Chip.tsx
@@ -20,7 +20,7 @@ const Chip = ({ loading, prefixIcon, children, onClick }: ChipProps) => {
       onClick={() => onClick && onClick()}
     >
       {prefix}
-      {children && prefix && <span className="w-1" />}
+      {children && prefix ? <span className="w-1" /> : null}
       <span className="text-200">{children}</span>
     </div>
   );

--- a/client/src/shared/components/DatePicker/DatePicker.stories.tsx
+++ b/client/src/shared/components/DatePicker/DatePicker.stories.tsx
@@ -7,7 +7,7 @@ export const Single = () => {
   return (
     <div className="p-8">
       <DatePicker selectionMode="single" selectedDate={date} onSelectedDateChange={setDate} testId="single-picker" />
-      {date && <p className="mt-4 text-300 text-text-primary">Selected: {date.toLocaleDateString()}</p>}
+      {date ? <p className="mt-4 text-300 text-text-primary">Selected: {date.toLocaleDateString()}</p> : null}
     </div>
   );
 };
@@ -27,11 +27,11 @@ export const Range = () => {
         }}
         testId="range-picker"
       />
-      {start && end && (
+      {start && end ? (
         <p className="mt-4 text-300 text-text-primary">
           Range: {start.toLocaleDateString()} — {end.toLocaleDateString()}
         </p>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/DatePicker/DatePicker.tsx
+++ b/client/src/shared/components/DatePicker/DatePicker.tsx
@@ -339,7 +339,7 @@ const DatePickerContent = (props: DatePickerProps) => {
           }}
           disabled={disabled}
           aria-haspopup="dialog"
-          aria-expanded={open ? !disabled : undefined}
+          aria-expanded={disabled ? undefined : open}
           aria-invalid={hasError || undefined}
           aria-describedby={id && typeof error === "string" && error ? `${id}-error` : undefined}
           onBlur={() => {

--- a/client/src/shared/components/DatePicker/DatePicker.tsx
+++ b/client/src/shared/components/DatePicker/DatePicker.tsx
@@ -339,7 +339,7 @@ const DatePickerContent = (props: DatePickerProps) => {
           }}
           disabled={disabled}
           aria-haspopup="dialog"
-          aria-expanded={open && !disabled}
+          aria-expanded={open ? !disabled : undefined}
           aria-invalid={hasError || undefined}
           aria-describedby={id && typeof error === "string" && error ? `${id}-error` : undefined}
           onBlur={() => {
@@ -378,7 +378,7 @@ const DatePickerContent = (props: DatePickerProps) => {
       </div>
 
       {/* Dropdown panel */}
-      {open && !disabled && (
+      {open && !disabled ? (
         <Popover
           position={positions["bottom right"]}
           className="!w-auto !space-y-0"
@@ -388,7 +388,7 @@ const DatePickerContent = (props: DatePickerProps) => {
         >
           <div className="flex gap-4">
             {/* Preset menu */}
-            {displayMenu && (
+            {displayMenu ? (
               <PresetList
                 activePreset={activePreset}
                 timeframe={timeframe}
@@ -397,11 +397,11 @@ const DatePickerContent = (props: DatePickerProps) => {
                 onCustomPresetClick={handleCustomPresetClick}
                 testId={`${testId}-presets`}
               />
-            )}
+            ) : null}
 
             {/* Calendar + optional inputs */}
             <div className="flex flex-col">
-              {withInputs && (
+              {withInputs ? (
                 <DatePickerInput
                   selectionMode={selectionMode}
                   withInputs={withInputs}
@@ -413,7 +413,7 @@ const DatePickerContent = (props: DatePickerProps) => {
                   disabled={disabled}
                   testId={`${testId}-inputs`}
                 />
-              )}
+              ) : null}
               <Calendar
                 displayedYear={displayedYear}
                 displayedMonth={displayedMonth}
@@ -433,7 +433,7 @@ const DatePickerContent = (props: DatePickerProps) => {
             </div>
           </div>
         </Popover>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/DatePicker/DatePicker.tsx
+++ b/client/src/shared/components/DatePicker/DatePicker.tsx
@@ -339,7 +339,7 @@ const DatePickerContent = (props: DatePickerProps) => {
           }}
           disabled={disabled}
           aria-haspopup="dialog"
-          aria-expanded={disabled ? undefined : open}
+          aria-expanded={open ? !disabled : false}
           aria-invalid={hasError || undefined}
           aria-describedby={id && typeof error === "string" && error ? `${id}-error` : undefined}
           onBlur={() => {

--- a/client/src/shared/components/Dialog/Dialog.tsx
+++ b/client/src/shared/components/Dialog/Dialog.tsx
@@ -73,12 +73,12 @@ const Dialog = ({
       >
         <div className="p-6">
           <div className="flex flex-col gap-3">
-            {loading && (
+            {loading ? (
               <div className="flex w-10 items-center justify-center rounded-lg bg-surface-5 py-2.5">
                 <ProgressCircular indeterminate className="text-text-primary" />
               </div>
-            )}
-            {!loading && icon}
+            ) : null}
+            {!loading ? icon : null}
             <Header
               className={headerClassName}
               subtitleClassName={subtitleClassName}
@@ -88,11 +88,11 @@ const Dialog = ({
               subtitleSize={subtitleSize}
             />
           </div>
-          {children && <div className="mt-4">{children}</div>}
+          {children ? <div className="mt-4">{children}</div> : null}
         </div>
-        {buttons && buttons.length > 0 && (
+        {buttons && buttons.length > 0 ? (
           <ButtonGroup buttons={buttons} variant={buttonGroupVariant} className="rounded-b-3xl bg-surface-5 p-6" />
-        )}
+        ) : null}
       </motion.div>
     </PageOverlay>
   );

--- a/client/src/shared/components/ErrorBoundary/DefaultErrorFallback.tsx
+++ b/client/src/shared/components/ErrorBoundary/DefaultErrorFallback.tsx
@@ -48,12 +48,12 @@ export const DefaultErrorFallback = ({
           Retry
         </Button>
       ) : null}
-      {showStackTrace && error && (
+      {showStackTrace && error ? (
         <div className="flex flex-col gap-6 overflow-auto bg-zinc-900 p-6 text-yellow-400">
           <p className="text-mono-text-100">{error.message ?? "An unexpected error occurred"}</p>
           <StackTrace error={error} className="text-mono-text-100" />
         </div>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/Header/Header.tsx
+++ b/client/src/shared/components/Header/Header.tsx
@@ -81,7 +81,7 @@ const Header = ({
       )}
     >
       <div className={clsx("w-full", { "flex items-center": inline })}>
-        {icon && iconOnClick && (
+        {icon && iconOnClick ? (
           <Button
             ariaLabel={iconAriaLabel}
             textColor={iconTextColor}
@@ -92,8 +92,8 @@ const Header = ({
             className={iconButtonClassName}
             testId="header-icon-button"
           />
-        )}
-        {icon && !iconOnClick && icon}
+        ) : null}
+        {icon && !iconOnClick ? icon : null}
         <div
           className={clsx("text-text-primary", {
             "ml-4": (icon || iconOnClick) && inline,
@@ -101,13 +101,13 @@ const Header = ({
             "mb-1": subtitle && !compact,
           })}
         >
-          {eybrow && <div className="text-200 text-text-primary-70">{eybrow}</div>}
-          {title && (
+          {eybrow ? <div className="text-200 text-text-primary-70">{eybrow}</div> : null}
+          {title ? (
             <div className={titleSize} data-testid={testId}>
               {title}
             </div>
-          )}
-          {subtitle && (
+          ) : null}
+          {subtitle ? (
             <div
               className={clsx(
                 "text-text-primary-70",
@@ -119,20 +119,20 @@ const Header = ({
             >
               {subtitle}
             </div>
-          )}
-          {description && (
+          ) : null}
+          {description ? (
             <div className={clsx("mt-1 max-w-[600px] text-300 text-text-primary-70", descriptionClassName)}>
               {description}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
       {children}
-      {buttons && (
+      {buttons ? (
         <div className={clsx("ml-3", { "phone:ml-0 phone:w-full": stackButtonsOnPhone }, buttonsWrapperClassName)}>
           <ButtonGroup buttons={buttons} variant={groupVariants.rightAligned} size={buttonSize} />
         </div>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -212,7 +212,7 @@ const Input = ({
             setFocused(false);
           }}
         />
-        {units && valueWidth !== undefined && value && (
+        {units && valueWidth !== undefined && value ? (
           <span
             className={clsx(
               "pointer-events-none absolute bottom-0 left-0 flex items-center text-300 text-text-primary-70",
@@ -226,7 +226,7 @@ const Input = ({
           >
             {units}
           </span>
-        )}
+        ) : null}
         <label
           htmlFor={id}
           className={clsx(
@@ -249,11 +249,11 @@ const Input = ({
         >
           {label}
         </label>
-        {tooltip && (
+        {tooltip ? (
           <div className="absolute top-7 right-4 -translate-y-1/2 transform">
             <Tooltip header={tooltip.header} body={tooltip.body} position={positions["top left"]} />
           </div>
-        )}
+        ) : null}
         {dismiss && length(value) && !compact ? (
           <div
             className={clsx("absolute right-4", {
@@ -271,7 +271,7 @@ const Input = ({
             ))}
           </div>
         ) : undefined}
-        {(type === "password" || statusIcon !== undefined) && (
+        {type === "password" || statusIcon !== undefined ? (
           <div
             className={clsx("absolute", {
               "top-1": compact,
@@ -294,7 +294,7 @@ const Input = ({
               />
             )}
           </div>
-        )}
+        ) : null}
       </div>
       <div
         className={clsx(

--- a/client/src/shared/components/LineChart/Tooltip/Tooltip.tsx
+++ b/client/src/shared/components/LineChart/Tooltip/Tooltip.tsx
@@ -174,32 +174,32 @@ const ChartTooltip = ({
       style={tooltipStyle}
     >
       <div className="px-6" style={{ width: tooltipWidth + "px" }}>
-        {shouldShowAggregate && aggregateKey && (
+        {shouldShowAggregate && aggregateKey ? (
           <div
             className={clsx("flex space-x-2", {
               "pb-4": hasSegmentEntries,
             })}
           >
             <div>
-              {showAggregateContext && (
+              {showAggregateContext ? (
                 <div className="mb-1 text-200 text-text-primary-70">{aggregateLabel || aggregateKey}</div>
-              )}
+              ) : null}
               <div className="inline-flex items-center gap-2 text-heading-100 text-text-primary">
-                {showAggregateContext && (
+                {showAggregateContext ? (
                   <StatusCircle
                     testId={AGGREGATE_TOOLTIP_STATUS_CIRCLE_TEST_ID}
                     width="w-2"
                     status={statuses.warning}
                     variant={variants.simple}
                   />
-                )}
-                {aggregateDisplayValue} {units && <span>{units}</span>}
+                ) : null}
+                {aggregateDisplayValue} {units ? <span>{units}</span> : null}
               </div>
             </div>
           </div>
-        )}
+        ) : null}
 
-        {hasSegmentEntries && (
+        {hasSegmentEntries ? (
           <div>
             <div className="mb-1 text-200 text-text-primary-70">{segmentsLabel}</div>
             {segmentEntries.map(([key, value], idx) => {
@@ -215,7 +215,7 @@ const ChartTooltip = ({
               );
             })}
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/client/src/shared/components/LineChart/Tooltip/TooltipItem.tsx
+++ b/client/src/shared/components/LineChart/Tooltip/TooltipItem.tsx
@@ -22,11 +22,11 @@ const TooltipItem = ({ itemKey, value, units, icon: Icon, colorMap }: TooltipIte
         <div className="inline-flex items-center gap-2">
           <Circle style={{ backgroundColor: color }} width="w-2" />
           <div className="grow text-end text-300 text-text-primary">
-            {value} {units && <span>{units}</span>}
+            {value} {units ? <span>{units}</span> : null}
           </div>
         </div>
 
-        {Icon && <Icon itemKey={itemKey} />}
+        {Icon ? <Icon itemKey={itemKey} /> : null}
       </div>
     </>
   );

--- a/client/src/shared/components/List/Filters/ButtonFilter.tsx
+++ b/client/src/shared/components/List/Filters/ButtonFilter.tsx
@@ -28,10 +28,10 @@ const ButtonFilter = ({
       size={size}
       variant={isActive ? "accent" : "ghost"}
       onClick={() => setActiveFilter(filter)}
-      prefixIcon={status && <StatusCircle status={status} width="w-2" variant="simple" removeMargin={true} />}
+      prefixIcon={status ? <StatusCircle status={status} width="w-2" variant="simple" removeMargin={true} /> : null}
       testId={`filter-button-${filter}`}
     >
-      {title} {count !== undefined && <span className="opacity-50">{count}</span>}
+      {title} {count !== undefined ? <span className="opacity-50">{count}</span> : null}
     </Button>
   );
 };

--- a/client/src/shared/components/List/Filters/DropdownFilter.tsx
+++ b/client/src/shared/components/List/Filters/DropdownFilter.tsx
@@ -172,7 +172,7 @@ const FilterContent = ({
           {title}
         </Button>
 
-        {showPopover && (
+        {showPopover ? (
           <DropdownFilterPopover
             options={options}
             displaySelectedItems={displaySelectedItems}
@@ -188,7 +188,7 @@ const FilterContent = ({
             optionsMaxHeight={optionsMaxHeight}
             position={popoverPosition}
           />
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/client/src/shared/components/List/Filters/DropdownFilterPopover.tsx
+++ b/client/src/shared/components/List/Filters/DropdownFilterPopover.tsx
@@ -68,7 +68,7 @@ const DropdownFilterPopover = ({
         className="space-y-0 overflow-y-auto overscroll-contain"
         style={{ maxHeight: optionsMaxHeight }}
       >
-        {showSelectAll && (
+        {showSelectAll ? (
           <>
             <div
               className={clsx(
@@ -83,7 +83,7 @@ const DropdownFilterPopover = ({
             </div>
             <Divider className="px-0" />
           </>
-        )}
+        ) : null}
 
         {options.map((item, index) => (
           <div key={item.id}>
@@ -101,7 +101,7 @@ const DropdownFilterPopover = ({
               </div>
               <Checkbox className="shrink-0" checked={displaySelectedItems.includes(item.id)} />
             </div>
-            {index < options.length - 1 && <Divider className="px-0" />}
+            {index < options.length - 1 ? <Divider className="px-0" /> : null}
           </div>
         ))}
       </div>

--- a/client/src/shared/components/List/Filters/Filters.tsx
+++ b/client/src/shared/components/List/Filters/Filters.tsx
@@ -190,7 +190,7 @@ const Filters = <ItemType,>({
       </div>
 
       {/* Active dropdown filters row */}
-      {activeDropdownFilterItems.length > 0 && (
+      {activeDropdownFilterItems.length > 0 ? (
         <div className="flex flex-wrap gap-2">
           {activeDropdownFilterItems.map((item) => (
             <Button
@@ -205,7 +205,7 @@ const Filters = <ItemType,>({
             </Button>
           ))}
         </div>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -434,7 +434,7 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
       }
       tabIndex={onRowClick ? 0 : undefined}
     >
-      {itemSelectable && (
+      {itemSelectable ? (
         <td
           className={clsx(tdClassList, firstStickyClasses, "w-9", onRowClick && rowHoverOverlayClassList)}
           style={paddingCssVariables}
@@ -467,7 +467,7 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
             )}
           </div>
         </td>
-      )}
+      ) : null}
 
       {activeCols.map((row, columnIndex) => {
         const isExempt = columnsExemptFromDisabledStyling?.has(row) ?? false;
@@ -1123,19 +1123,20 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
     "tablet:left-[calc(var(--list-padding-tablet)+theme(spacing.9))]",
   );
 
-  const filtersElement = (filters?.length || headerControls) && (
-    <Filters<ListItem>
-      key={JSON.stringify(initialActiveFilters ?? null)}
-      className={clsx("gap-4 py-6", paddingClasses)}
-      filterItems={filters ?? []}
-      filterSize={filterSize}
-      items={items}
-      onFilter={isServerSideFiltering ? handleServerFiltering : handleClientFiltering}
-      isServerSide={isServerSideFiltering}
-      headerControls={headerControls}
-      initialActiveFilters={initialActiveFilters}
-    />
-  );
+  const filtersElement =
+    filters?.length || headerControls ? (
+      <Filters<ListItem>
+        key={JSON.stringify(initialActiveFilters ?? null)}
+        className={clsx("gap-4 py-6", paddingClasses)}
+        filterItems={filters ?? []}
+        filterSize={filterSize}
+        items={items}
+        onFilter={isServerSideFiltering ? handleServerFiltering : handleClientFiltering}
+        isServerSide={isServerSideFiltering}
+        headerControls={headerControls}
+        initialActiveFilters={initialActiveFilters}
+      />
+    ) : null;
 
   const visibleItemKeys = useMemo(
     () => filteredItems.map((item) => item[itemKey] as ItemKeyValueType),
@@ -1228,19 +1229,19 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
                 : "shadow-[0_4px_6px_0_rgba(0,0,0,0)]",
             )}
           >
-            {itemSelectable && (
+            {itemSelectable ? (
               <th scope="col" className={clsx(thClassList, firstStickyClasses, "w-9")} style={paddingCssVariables}>
-                {selectionType !== "radio" && (
+                {selectionType !== "radio" ? (
                   <div className="w-9 truncate overflow-hidden" data-testid="select-all-checkbox">
                     <Checkbox
                       checked={allSelected}
-                      partiallyChecked={visibleSelectedCount > 0 && !allSelected}
+                      partiallyChecked={visibleSelectedCount > 0 ? !allSelected : false}
                       onChange={(e) => handleSelectAll(e.target.checked)}
                     />
                   </div>
-                )}
+                ) : null}
               </th>
-            )}
+            ) : null}
 
             {activeCols.map((row, idx) => {
               const isSortable = sortableColumns?.has(row);
@@ -1310,43 +1311,43 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
                 </th>
               );
             })}
-            {actions.length > 0 && (
+            {actions.length > 0 ? (
               <th scope="col" className={thClassList}>
                 <div className="w-11 truncate overflow-hidden" />
               </th>
-            )}
+            ) : null}
           </tr>
         </thead>
         {rowDragEnabled ? (
           <SortableContext items={visibleItemKeys as UniqueIdentifier[]} strategy={verticalListSortingStrategy}>
             <tbody data-testid="list-body">
-              {filteredItems.length > 0
-                ? filteredItems.map(renderRow)
-                : emptyStateRow && (
-                    <tr data-testid="list-empty-row">
-                      <td colSpan={totalColumnCount}>{emptyStateRow}</td>
-                    </tr>
-                  )}
+              {filteredItems.length > 0 ? (
+                filteredItems.map(renderRow)
+              ) : emptyStateRow ? (
+                <tr data-testid="list-empty-row">
+                  <td colSpan={totalColumnCount}>{emptyStateRow}</td>
+                </tr>
+              ) : null}
             </tbody>
           </SortableContext>
         ) : (
           <tbody data-testid="list-body">
-            {filteredItems.length > 0
-              ? filteredItems.map(renderRow)
-              : emptyStateRow && (
-                  <tr data-testid="list-empty-row">
-                    <td colSpan={totalColumnCount}>{emptyStateRow}</td>
-                  </tr>
-                )}
+            {filteredItems.length > 0 ? (
+              filteredItems.map(renderRow)
+            ) : emptyStateRow ? (
+              <tr data-testid="list-empty-row">
+                <td colSpan={totalColumnCount}>{emptyStateRow}</td>
+              </tr>
+            ) : null}
           </tbody>
         )}
       </table>
       {footerContent}
-      {onLoadMore && hasMore && (
+      {onLoadMore && hasMore ? (
         <div ref={loadMoreTriggerRef} className="flex justify-center py-6">
-          {isLoadingMore && <ProgressCircular indeterminate />}
+          {isLoadingMore ? <ProgressCircular indeterminate /> : null}
         </div>
-      )}
+      ) : null}
       {/* eslint-disable-next-line react-hooks/refs -- ref object from useStickyState is passed to <div ref>; React writes .current during commit, not read during render */}
       <div ref={refs.vertical.end} />
     </>
@@ -1358,13 +1359,13 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
         {filtersElement}
       </div>
       <div style={paddingCssVariables}>
-        {!hideTotal && total !== undefined && (
+        {!hideTotal && total !== undefined ? (
           <div className="sticky left-0 flex">
             <div className={clsx("sticky left-0 pb-4 text-emphasis-300 text-text-primary-70", paddingClasses)}>
               {total} {total === 1 ? itemName.singular : itemName.plural}
             </div>
           </div>
-        )}
+        ) : null}
         <div className={clsx("flex flex-col", containerClassName)}>
           <div
             ref={setCombinedScrollRef}
@@ -1385,11 +1386,11 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
               noDataElement
             )}
           </div>
-          {renderActionBar && (
+          {renderActionBar ? (
             <div className="w-full">
               {renderActionBar(currentSelectedItems, clearSelection, currentSelectionMode, totalSelectable)}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     </>

--- a/client/src/shared/components/List/ListActions/ListActions.tsx
+++ b/client/src/shared/components/List/ListActions/ListActions.tsx
@@ -53,7 +53,7 @@ const ListActions = <ListItem,>({ item, actions, disabled = false }: ListActionP
       >
         <Ellipsis />
       </button>
-      {actionsVisible && !disabled && (
+      {actionsVisible && !disabled ? (
         <Popover
           className="!space-y-0 px-4 pt-2 pb-1"
           position={positions["bottom left"]}
@@ -89,7 +89,7 @@ const ListActions = <ListItem,>({ item, actions, disabled = false }: ListActionP
             },
           )}
         </Popover>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/MiningPools/PoolModal.stories.tsx
+++ b/client/src/shared/components/MiningPools/PoolModal.stories.tsx
@@ -15,13 +15,13 @@ export const AddPool = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <PoolModal
         open={open}
         pools={pools}
@@ -60,13 +60,13 @@ export const EditPool = () => {
 
   return (
     <>
-      {!open && (
+      {!open ? (
         <div className="flex h-screen items-center justify-center">
           <button onClick={() => setOpen(true)} className="bg-emphasis-300 rounded-lg px-4 py-2 text-surface-base">
             Show Modal
           </button>
         </div>
-      )}
+      ) : null}
       <PoolModal
         open={open}
         pools={pools}

--- a/client/src/shared/components/MiningPools/PoolModal.tsx
+++ b/client/src/shared/components/MiningPools/PoolModal.tsx
@@ -318,7 +318,7 @@ const PoolModal = ({
         testId="pool-save-error-callout"
       />
       <div className="space-y-4">
-        {!hidePoolName && (
+        {!hidePoolName ? (
           <Input
             id={`${poolInfoAttributes.name} ${poolIndex}`}
             label="Pool Name"
@@ -328,7 +328,7 @@ const PoolModal = ({
             error={poolNameError}
             autoFocus
           />
-        )}
+        ) : null}
         <Input
           id={`${poolInfoAttributes.url} ${poolIndex}`}
           label="Pool URL"
@@ -348,7 +348,7 @@ const PoolModal = ({
             testId={`${poolInfoAttributes.username}-${poolIndex}-input`}
             error={usernameError}
           />
-          {usernameHelperText && <div className="text-200 text-text-primary-70">{usernameHelperText}</div>}
+          {usernameHelperText ? <div className="text-200 text-text-primary-70">{usernameHelperText}</div> : null}
         </div>
         <Input
           id={`${poolInfoAttributes.password} ${poolIndex}`}

--- a/client/src/shared/components/MiningPools/PoolRow.tsx
+++ b/client/src/shared/components/MiningPools/PoolRow.tsx
@@ -58,28 +58,28 @@ const PoolRow = ({
   return (
     <Row className="flex items-center justify-between gap-3" testId="pool-row">
       <div className="flex min-w-0 items-center gap-3">
-        {priorityNumber !== undefined && (
+        {priorityNumber !== undefined ? (
           <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-surface-5 text-xs font-medium text-text-primary">
             {priorityNumber}
           </div>
-        )}
+        ) : null}
         {prefixElement}
         <div className="flex min-w-0 flex-col">
           <div className="truncate text-text-primary">{displayTitle}</div>
-          {(displaySubtitle || displaySubtitleExtra) && (
+          {displaySubtitle || displaySubtitleExtra ? (
             <div className="text-200 text-text-primary-70">
-              {displaySubtitle && (
+              {displaySubtitle ? (
                 <div className="truncate" data-testid={`pool-${poolIndex}-saved-url`}>
                   {displaySubtitle}
                 </div>
-              )}
-              {displaySubtitleExtra && (
+              ) : null}
+              {displaySubtitleExtra ? (
                 <div className="truncate" data-testid={`pool-${poolIndex}-saved-username`}>
                   {displaySubtitleExtra}
                 </div>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-2">

--- a/client/src/shared/components/Modal/Modal.stories.tsx
+++ b/client/src/shared/components/Modal/Modal.stories.tsx
@@ -27,7 +27,7 @@ export const Modal = ({ hasButtons, hasTitle, numberOfSecondaryButtons }: ModalP
           <Button onClick={() => setShowModal(true)} text="Show Modal" variant={variants.primary} size={sizes.base} />
         </div>
       </div>
-      {showModal && (
+      {showModal ? (
         <ModalComponent
           title={hasTitle ? "Title" : undefined}
           description="This is a description that stays in the content area."
@@ -47,7 +47,7 @@ export const Modal = ({ hasButtons, hasTitle, numberOfSecondaryButtons }: ModalP
         >
           <div>Description</div>
         </ModalComponent>
-      )}
+      ) : null}
     </>
   );
 };
@@ -84,7 +84,7 @@ export const Standard = () => {
           />
         </div>
       </div>
-      {showModal && (
+      {showModal ? (
         <ModalComponent
           title="Standard Modal"
           description="Form Content"
@@ -102,7 +102,7 @@ export const Standard = () => {
             <p>This modal is 640px max-width, the default size for forms and general content.</p>
           </div>
         </ModalComponent>
-      )}
+      ) : null}
     </>
   );
 };
@@ -124,7 +124,7 @@ export const Large = () => {
           />
         </div>
       </div>
-      {showModal && (
+      {showModal ? (
         <ModalComponent
           title="Large Modal"
           description="Data-Heavy Content"
@@ -145,7 +145,7 @@ export const Large = () => {
             </p>
           </div>
         </ModalComponent>
-      )}
+      ) : null}
     </>
   );
 };
@@ -167,7 +167,7 @@ export const Fullscreen = () => {
           />
         </div>
       </div>
-      {showModal && (
+      {showModal ? (
         <ModalComponent
           title="Fullscreen Modal"
           description="This modal takes up the full screen"
@@ -186,7 +186,7 @@ export const Fullscreen = () => {
             <p className="mt-2">It's useful for immersive experiences or when you need maximum space for content.</p>
           </div>
         </ModalComponent>
-      )}
+      ) : null}
     </>
   );
 };
@@ -208,7 +208,7 @@ export const LongContent = () => {
           />
         </div>
       </div>
-      {showModal && (
+      {showModal ? (
         <ModalComponent
           title="Scroll-Aware Title"
           description="Scroll down — the title collapses into the sticky header when it leaves the viewport."
@@ -231,7 +231,7 @@ export const LongContent = () => {
             ))}
           </div>
         </ModalComponent>
-      )}
+      ) : null}
     </>
   );
 };
@@ -253,7 +253,7 @@ export const NoHeader = () => {
           />
         </div>
       </div>
-      {showModal && (
+      {showModal ? (
         <ModalComponent
           showHeader={false}
           buttons={[
@@ -279,7 +279,7 @@ export const NoHeader = () => {
             <p className="mt-2">The modal can still be closed with Escape key or clicking outside.</p>
           </div>
         </ModalComponent>
-      )}
+      ) : null}
     </>
   );
 };

--- a/client/src/shared/components/Modal/Modal.tsx
+++ b/client/src/shared/components/Modal/Modal.tsx
@@ -158,7 +158,7 @@ const Modal = ({
           ref={modalRef}
           data-testid={testId}
         >
-          {showHeader && (
+          {showHeader ? (
             <div
               ref={headerRef}
               className={clsx("sticky top-0 z-10 bg-surface-elevated-base pt-6", { "phone:hidden": hideHeaderOnPhone })}
@@ -182,8 +182,8 @@ const Modal = ({
                 <div className={headerSpacingClassName} />
               )}
             </div>
-          )}
-          {title && !isFullscreen && (
+          ) : null}
+          {title && !isFullscreen ? (
             <>
               <div ref={sentinelRef} className="h-0 w-0" />
               <div
@@ -194,8 +194,8 @@ const Modal = ({
                 {title}
               </div>
             </>
-          )}
-          {description && <div className="mb-4 max-w-[600px] text-300 text-text-primary-70">{description}</div>}
+          ) : null}
+          {description ? <div className="mb-4 max-w-[600px] text-300 text-text-primary-70">{description}</div> : null}
           <div className={clsx("text-300 text-text-primary-70", bodyClassName)}>{children}</div>
           {hasPhoneFooterButtons ? (
             <div className="mt-6 hidden w-full gap-3 phone:flex">

--- a/client/src/shared/components/Modal/ModalSelectAllFooter.tsx
+++ b/client/src/shared/components/Modal/ModalSelectAllFooter.tsx
@@ -14,7 +14,7 @@ const ModalSelectAllFooter = ({ label, onSelectAll, onSelectNone }: ModalSelectA
       <div className="flex items-center justify-between pt-5">
         <div className="text-emphasis-300">{label}</div>
         <div className="flex items-center gap-2">
-          {onSelectAll && (
+          {onSelectAll ? (
             <Button
               className="py-1"
               size={sizes.textOnly}
@@ -25,8 +25,8 @@ const ModalSelectAllFooter = ({ label, onSelectAll, onSelectNone }: ModalSelectA
             >
               Select all
             </Button>
-          )}
-          {onSelectNone && (
+          ) : null}
+          {onSelectNone ? (
             <Button
               className="py-1"
               size={sizes.textOnly}
@@ -37,7 +37,7 @@ const ModalSelectAllFooter = ({ label, onSelectAll, onSelectNone }: ModalSelectA
             >
               Select none
             </Button>
-          )}
+          ) : null}
         </div>
       </div>
     </>

--- a/client/src/shared/components/OnboardingSettingUp/ConfiguringMiningPool.tsx
+++ b/client/src/shared/components/OnboardingSettingUp/ConfiguringMiningPool.tsx
@@ -31,7 +31,7 @@ const ConfiguringMiningPool = ({ onClickReconfigure, onClickRetry, status }: Con
         <div className="text-emphasis-300">
           {isError ? "Configuring your mining pool" : "Testing your mining pool connections"}
         </div>
-        {isError && (
+        {isError ? (
           <div className="text-200 text-text-primary-70">
             <div>We’re having trouble connecting to your mining pools.</div>
             <div>
@@ -42,9 +42,9 @@ const ConfiguringMiningPool = ({ onClickReconfigure, onClickRetry, status }: Con
               .
             </div>
           </div>
-        )}
+        ) : null}
       </div>
-      {isError && (
+      {isError ? (
         <div className="flex items-center">
           <Button
             variant={variants.primary}
@@ -53,7 +53,7 @@ const ConfiguringMiningPool = ({ onClickReconfigure, onClickRetry, status }: Con
             onClick={onClickReconfigure}
           />
         </div>
-      )}
+      ) : null}
     </Row>
   );
 };

--- a/client/src/shared/components/PageOverlay/PageOverlay.tsx
+++ b/client/src/shared/components/PageOverlay/PageOverlay.tsx
@@ -66,7 +66,7 @@ const PageOverlay = ({
 }: PageOverlayProps) => {
   return createPortal(
     <AnimatePresence>
-      {open && (
+      {open ? (
         <PageOverlayContent
           shouldPreventScroll={shouldPreventScroll}
           zIndex={zIndex}
@@ -75,7 +75,7 @@ const PageOverlay = ({
         >
           {children}
         </PageOverlayContent>
-      )}
+      ) : null}
     </AnimatePresence>,
     document.body,
   );

--- a/client/src/shared/components/Popover/Popover.stories.tsx
+++ b/client/src/shared/components/Popover/Popover.stories.tsx
@@ -22,7 +22,7 @@ export const Popover = ({ hasSubtitle, numberOfButtons }: PopoverProps) => {
   return (
     <div ref={triggerRef}>
       <button onClick={() => setShowPopover((prev) => !prev)}>Show Popover</button>
-      {showPopover && (
+      {showPopover ? (
         <PopoverComponent
           title="Title"
           subtitle={hasSubtitle ? "Subtitle" : undefined}
@@ -46,7 +46,7 @@ export const Popover = ({ hasSubtitle, numberOfButtons }: PopoverProps) => {
           }
           position="bottom right"
         />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/Popover/PopoverContent.tsx
+++ b/client/src/shared/components/Popover/PopoverContent.tsx
@@ -89,11 +89,11 @@ const PopoverContent = ({
       data-testid={testId}
       onClick={handleClick}
     >
-      {(title || subtitle) && (
+      {title || subtitle ? (
         <Header title={title} titleSize={titleSize} subtitle={subtitle} subtitleSize="text-300" />
-      )}
+      ) : null}
       {children}
-      {buttons && <ButtonGroup buttons={buttons} variant={buttonGroupVariant} size={sizes.base} />}
+      {buttons ? <ButtonGroup buttons={buttons} variant={buttonGroupVariant} size={sizes.base} /> : null}
     </div>
   );
 };

--- a/client/src/shared/components/Row/Row.tsx
+++ b/client/src/shared/components/Row/Row.tsx
@@ -40,7 +40,7 @@ const Row = ({
         data-testid={testId}
         {...(Element === "button" && { type: "button" })}
       >
-        {prefixIcon && <div>{prefixIcon}</div>}
+        {prefixIcon ? <div>{prefixIcon}</div> : null}
         <div
           className={clsx(
             "grow text-left",
@@ -53,15 +53,15 @@ const Row = ({
         >
           {children}
         </div>
-        {suffixIcon && <div className="m-4">{suffixIcon}</div>}
+        {suffixIcon ? <div className="m-4">{suffixIcon}</div> : null}
       </Element>
-      {divider && (
+      {divider ? (
         <Divider
           className={clsx("mt-[-1px]", {
             "px-4": onClick,
           })}
         />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/SegmentedBarChart/SegmentedBarChart.stories.tsx
+++ b/client/src/shared/components/SegmentedBarChart/SegmentedBarChart.stories.tsx
@@ -263,7 +263,7 @@ export const InteractiveSpacing: Story = {
                     opacity: 0.5,
                   }}
                 />
-                {i < data.length - 1 && (
+                {i < data.length - 1 ? (
                   <div
                     style={{
                       width: "4px",
@@ -274,7 +274,7 @@ export const InteractiveSpacing: Story = {
                       opacity: 0.5,
                     }}
                   />
-                )}
+                ) : null}
               </div>
             ))}
           </div>

--- a/client/src/shared/components/SegmentedBarChart/SegmentedBarChart.tsx
+++ b/client/src/shared/components/SegmentedBarChart/SegmentedBarChart.tsx
@@ -397,7 +397,7 @@ const SegmentedBarChart = ({
                   </div>
                 </div>
                 {/* Always render tick but control visibility (only for time ticks, not date labels) */}
-                {!showDateLabel && (
+                {!showDateLabel ? (
                   <div
                     className={clsx(
                       "x-axis-tick absolute top-full left-1/2 mt-3 -translate-x-1/2 text-center text-200 text-text-primary-50 transition-opacity",
@@ -413,24 +413,24 @@ const SegmentedBarChart = ({
                         ? formatDate(data.datetime)
                         : formatTime(data.datetime, hasMinutesInTicks)}
                   </div>
-                )}
+                ) : null}
               </div>
             );
           })}
           {/* Centered date label when showDateLabel is true */}
-          {showDateLabel && transformedData.length > 0 && (
+          {showDateLabel && transformedData.length > 0 ? (
             <div className="absolute top-full left-1/2 mt-3 -translate-x-1/2 text-center text-200 text-text-primary-50">
               {formatDate(transformedData[Math.floor(transformedData.length / 2)].datetime)}
-              {hoveredBar !== null && (
+              {hoveredBar !== null ? (
                 <span className="ml-1">at {formatTime(transformedData[hoveredBar].datetime, hasMinutesInTicks)}</span>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
 
       {/* Tooltip */}
-      {tooltipData && hoveredBar !== null && tooltipPosition && (
+      {tooltipData && hoveredBar !== null && tooltipPosition ? (
         <div
           ref={tooltipRef}
           className="pointer-events-none absolute z-10 rounded-xl bg-surface-elevated-base/70 pt-6 pb-4 shadow-200 backdrop-blur-[7px]"
@@ -445,7 +445,7 @@ const SegmentedBarChart = ({
             <div className="text-200 text-text-primary-70">{tooltipData.timeRange}</div>
 
             {/* Segments */}
-            {tooltipData.segments.length > 0 && (
+            {tooltipData.segments.length > 0 ? (
               <div>
                 {tooltipData.segments.map((segment) => (
                   <div key={segment.key} className="flex items-center gap-2 py-1">
@@ -460,22 +460,23 @@ const SegmentedBarChart = ({
                     {/* Combined text: value + units + label */}
                     <span className="text-300 text-text-primary">
                       {segment.value}
-                      {units &&
-                        (typeof units === "string"
+                      {units
+                        ? typeof units === "string"
                           ? ` ${units}`
-                          : ` ${segment.value === 1 ? units.singular : units.plural}`)}{" "}
+                          : ` ${segment.value === 1 ? units.singular : units.plural}`
+                        : null}{" "}
                       {segment.label.toLowerCase()}
                     </span>
                   </div>
                 ))}
               </div>
-            )}
+            ) : null}
 
             {/* No data message if no segments */}
-            {tooltipData.segments.length === 0 && <div className="text-200 text-text-primary-50">No miners</div>}
+            {tooltipData.segments.length === 0 ? <div className="text-200 text-text-primary-50">No miners</div> : null}
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/SelectRow/SelectRow.tsx
+++ b/client/src/shared/components/SelectRow/SelectRow.tsx
@@ -60,11 +60,11 @@ const SelectRow = ({
             <div className="text-emphasis-300">{text}</div>
           </div>
         </div>
-        {sideText && (
+        {sideText ? (
           <div className="ml-4">
             <div className="text-300">{sideText}</div>
           </div>
-        )}
+        ) : null}
         <div className="relative ml-4 flex">
           <input
             className={clsx("peer relative h-[20px] w-[20px] cursor-pointer appearance-none border border-border-20", {
@@ -97,7 +97,7 @@ const SelectRow = ({
           )}
         </div>
       </div>
-      {divider && <Divider className="mt-[-1px] px-4" />}
+      {divider ? <Divider className="mt-[-1px] px-4" /> : null}
     </>
   );
 };

--- a/client/src/shared/components/SelectRowList/SelectRow.tsx
+++ b/client/src/shared/components/SelectRowList/SelectRow.tsx
@@ -56,7 +56,7 @@ const SelectRow = ({
         {prefixIcon}
         <div className={clsx({ "ml-4": prefixIcon })}>
           <div className="text-emphasis-300">{text}</div>
-          {subtext && (
+          {subtext ? (
             <div
               className={clsx("text-200", {
                 "text-text-primary-70": !disabled,
@@ -65,11 +65,11 @@ const SelectRow = ({
             >
               {subtext}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
       <div className="flex items-center gap-4">
-        {sideText && <div className="text-right text-300">{sideText}</div>}
+        {sideText ? <div className="text-right text-300">{sideText}</div> : null}
         <div className="relative flex">
           <input
             className={clsx("peer relative h-[20px] w-[20px] appearance-none", {
@@ -82,7 +82,7 @@ const SelectRow = ({
             })}
             disabled={disabled}
             type={type}
-            checked={isSelected && !disabled}
+            checked={isSelected ? !disabled : false}
             onChange={handleChange}
           />
           <div

--- a/client/src/shared/components/SelectRowList/SelectRowList.stories.tsx
+++ b/client/src/shared/components/SelectRowList/SelectRowList.stories.tsx
@@ -61,22 +61,22 @@ const SelectRowListForStory = ({ disabled, hasPrefixIcon, hasSubtext, type }: Se
         {
           id: selectRows.one,
           isSelected: selected.includes(selectRows.one),
-          prefixIcon: hasPrefixIcon && (
+          prefixIcon: hasPrefixIcon ? (
             <IconWrapper>
               <BaseIcon />
             </IconWrapper>
-          ),
+          ) : null,
           text: "Select row",
         },
         {
           disabled,
           id: selectRows.two,
           isSelected: selected.includes(selectRows.two),
-          prefixIcon: hasPrefixIcon && (
+          prefixIcon: hasPrefixIcon ? (
             <IconWrapper>
               <BaseIcon />
             </IconWrapper>
-          ),
+          ) : null,
           subtext: hasSubtext ? "Select row subtitle text." : undefined,
           text: "Select row",
         },

--- a/client/src/shared/components/SelectRowList/SelectRowList.tsx
+++ b/client/src/shared/components/SelectRowList/SelectRowList.tsx
@@ -35,7 +35,7 @@ const SelectRowList = ({ className, onChange, selectRows, type }: SelectRowListP
               type={type}
             />
             {/* Add divider line after each row except the last */}
-            {index < selectRows.length - 1 && <div className="h-[0.5px] bg-border-10" />}
+            {index < selectRows.length - 1 ? <div className="h-[0.5px] bg-border-10" /> : null}
           </div>
         );
       })}

--- a/client/src/shared/components/Setup/Authentication.tsx
+++ b/client/src/shared/components/Setup/Authentication.tsx
@@ -240,12 +240,12 @@ const Authentication = ({
           onChange={handleChange}
           id="username"
           label={inputPrefix ? `${inputPrefix} username` : "Username"}
-          disabled={initUsername !== undefined && initUsername !== ""}
+          disabled={initUsername !== undefined ? initUsername !== "" : false}
           initValue={values.username}
           error={errors.username}
           autoFocus={!initUsername}
         />
-        {isUpdateMode && (
+        {isUpdateMode ? (
           <Input
             onChange={handleChange}
             id="currentPassword"
@@ -255,7 +255,7 @@ const Authentication = ({
             error={errors.currentPassword}
             autoFocus={!!initUsername}
           />
-        )}
+        ) : null}
         <div className="space-y-2">
           <Input
             onChange={handleChange}
@@ -264,7 +264,7 @@ const Authentication = ({
             type="password"
             initValue={values.password}
             error={errors.password}
-            autoFocus={!!initUsername && !isUpdateMode}
+            autoFocus={initUsername ? !isUpdateMode : false}
           />
           <div className="flex items-center justify-between gap-5">
             <div>
@@ -274,7 +274,7 @@ const Authentication = ({
           </div>
         </div>
       </div>
-      {requirePasswordConfirmation && (
+      {requirePasswordConfirmation ? (
         <Input
           onChange={handleChange}
           id="confirmPassword"
@@ -284,13 +284,13 @@ const Authentication = ({
           error={errors.confirmPassword}
           statusIcon={passwordsMatch ? <Success className="text-intent-success-fill" /> : undefined}
         />
-      )}
-      {showWeakPasswordWarning && !isSubmitting && (
+      ) : null}
+      {showWeakPasswordWarning && !isSubmitting ? (
         <WeakPasswordWarning
           onReturn={() => setShowWeakPasswordWarning(false)}
           onContinue={() => handleContinue(true)}
         />
-      )}
+      ) : null}
       <Button
         onClick={() => handleContinue(false)}
         className={buttonClassName}

--- a/client/src/shared/components/Setup/BootingUp.tsx
+++ b/client/src/shared/components/Setup/BootingUp.tsx
@@ -31,7 +31,7 @@ const BootingUp = ({ title }: BootingUpProps) => {
           >
             <ProgressCircular indeterminate />
           </motion.div>
-          {title && (
+          {title ? (
             <motion.p
               animate={{ y: ["-50%", "0%"], opacity: [0, 1] }}
               transition={{ duration: 1, ease: easeGentle }}
@@ -39,7 +39,7 @@ const BootingUp = ({ title }: BootingUpProps) => {
             >
               {title}
             </motion.p>
-          )}
+          ) : null}
         </div>
       </AnimatedDotsBackground>
     </div>

--- a/client/src/shared/components/Setup/OnboardingLayout/OnboardingLayout.tsx
+++ b/client/src/shared/components/Setup/OnboardingLayout/OnboardingLayout.tsx
@@ -23,7 +23,7 @@ const OnboardingLayout = ({ children, steps, currentStep }: OnboardingLayoutProp
     <div className="min-h-screen bg-surface-base">
       <SetupHeader />
       <div className="relative px-6 pt-6 tablet:flex tablet:flex-row">
-        {steps && currentStep && (
+        {steps && currentStep ? (
           <div className="absolute w-30 phone:relative phone:mb-4 tablet:relative">
             <ol className="flex flex-col gap-2 phone:flex-row">
               {Object.entries(steps).map(([key, step]) => (
@@ -45,7 +45,7 @@ const OnboardingLayout = ({ children, steps, currentStep }: OnboardingLayoutProp
               ))}
             </ol>
           </div>
-        )}
+        ) : null}
         <div className="mx-auto w-full max-w-xl tablet:max-w-160">{children}</div>
       </div>
     </div>

--- a/client/src/shared/components/Setup/WelcomeScreen.tsx
+++ b/client/src/shared/components/Setup/WelcomeScreen.tsx
@@ -85,7 +85,7 @@ const WelcomeFlow = ({
 
   return (
     <>
-      {!noMinersFound && (
+      {!noMinersFound ? (
         <div className="absolute top-1/2 left-1/2 z-10 flex h-[314px] w-[418px] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center gap-6 bg-surface-base p-5 backdrop-blur-2xl">
           <motion.div
             initial={{ opacity: 0.2, y: "50%" }}
@@ -97,7 +97,7 @@ const WelcomeFlow = ({
           </motion.div>
           <div className="grid h-[112px] duration-500">
             <AnimatePresence>
-              {!searching && (
+              {!searching ? (
                 <motion.div
                   initial={{ y: "-50%", opacity: 0 }}
                   animate={{ y: "0%", opacity: 1 }}
@@ -111,11 +111,11 @@ const WelcomeFlow = ({
                     Get started
                   </Button>
                 </motion.div>
-              )}
+              ) : null}
             </AnimatePresence>
             <AnimatePresence>
-              {searching &&
-                (ipAddress ? (
+              {searching ? (
+                ipAddress ? (
                   <motion.div
                     className="col-start-1 row-start-1 text-center"
                     initial={{ scale: 0, opacity: 0 }}
@@ -134,11 +134,12 @@ const WelcomeFlow = ({
                   >
                     <p className="text-text-primary-70">Searching your network for miners</p>
                   </motion.div>
-                ))}
+                )
+              ) : null}
             </AnimatePresence>
           </div>
         </div>
-      )}
+      ) : null}
       <Modal
         open={noMinersFound}
         title="No Proto miners found"

--- a/client/src/shared/components/Stat/Stat.tsx
+++ b/client/src/shared/components/Stat/Stat.tsx
@@ -47,7 +47,7 @@ const Stat = ({
         >
           {label}
         </div>
-        {subtitle && (
+        {subtitle ? (
           <div
             className={clsx(
               "flex items-center gap-2 text-heading-50 text-text-primary-50 transition-opacity duration-500",
@@ -57,9 +57,9 @@ const Stat = ({
             aria-label="Data reporting status"
           >
             <span>{subtitle}</span>
-            {tooltipContent && <Tooltip body={tooltipContent} position="bottom left" icon="info" />}
+            {tooltipContent ? <Tooltip body={tooltipContent} position="bottom left" icon="info" /> : null}
           </div>
-        )}
+        ) : null}
       </div>
       {value === undefined ? (
         <SkeletonBar
@@ -82,12 +82,12 @@ const Stat = ({
             size === "small" && "text-heading-100",
           )}
         >
-          <span className={valueClassName}>{getDisplayValue(value)}</span> {units && units}
+          <span className={valueClassName}>{getDisplayValue(value)}</span> {units ? units : null}
         </motion.div>
       )}
-      {icon && <div className="absolute top-0 right-0">{icon}</div>}
-      {text && <div className="mt-1 text-300 text-text-primary-70">{text}</div>}
-      {chartPercentage !== undefined && (
+      {icon ? <div className="absolute top-0 right-0">{icon}</div> : null}
+      {text ? <div className="mt-1 text-300 text-text-primary-70">{text}</div> : null}
+      {chartPercentage !== undefined ? (
         <div className="relative mt-2 h-[2px] w-full">
           <div className={clsx("absolute h-full w-full opacity-20", statusColors[chartStatus])}></div>
           <div
@@ -99,7 +99,7 @@ const Stat = ({
             data-testid="stat-chart"
           ></div>
         </div>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/src/shared/components/StatusModal/ComponentStatusModalContent.tsx
+++ b/client/src/shared/components/StatusModal/ComponentStatusModalContent.tsx
@@ -82,7 +82,7 @@ const ComponentStatusModalContent = ({
   return (
     <StatusModalLayout icon={icon} title={title} subtitle={subtitle} errors={layoutErrors}>
       {/* Performance metrics grid */}
-      {metrics && metrics.length > 0 && (
+      {metrics && metrics.length > 0 ? (
         <div
           className={clsx("grid gap-x-4 gap-y-6", metrics.length % 3 === 0 ? "grid-cols-3" : "grid-cols-2")}
           data-testid="status-modal-metrics"
@@ -91,10 +91,10 @@ const ComponentStatusModalContent = ({
             <LabeledValue key={`${metric.label}-${index}`} label={metric.label} value={metric.value} />
           ))}
         </div>
-      )}
+      ) : null}
 
       {/* Metadata section */}
-      {metadata && <ComponentMetadata metadata={metadata} />}
+      {metadata ? <ComponentMetadata metadata={metadata} /> : null}
     </StatusModalLayout>
   );
 };

--- a/client/src/shared/components/StatusModal/ErrorRow.tsx
+++ b/client/src/shared/components/StatusModal/ErrorRow.tsx
@@ -20,14 +20,14 @@ const ErrorRow = ({ icon, title, subtitle, onClick, divider = true }: ErrorRowPr
     <Row prefixIcon={icon} className="flex items-center justify-between text-emphasis-300" compact divider={divider}>
       <div className="min-w-0 flex-1 py-2 pr-2">
         <div className="text-emphasis-300 text-text-primary">{title}</div>
-        {subtitle && <div className="mt-0.5 text-200 text-text-primary-70">{subtitle}</div>}
+        {subtitle ? <div className="mt-0.5 text-200 text-text-primary-70">{subtitle}</div> : null}
       </div>
 
-      {onClick && (
+      {onClick ? (
         <div className="ml-2 shrink-0">
           <ChevronDown width={iconSizes.small} className="rotate-270 text-text-primary-70" />
         </div>
-      )}
+      ) : null}
     </Row>
   );
 

--- a/client/src/shared/components/StatusModal/StatusModal.test.tsx
+++ b/client/src/shared/components/StatusModal/StatusModal.test.tsx
@@ -20,11 +20,11 @@ vi.mock("@/shared/components/Modal", () => ({
     return (
       <div data-testid="modal">
         <div data-testid="modal-title">{title}</div>
-        {icon && (
+        {icon ? (
           <button data-testid="modal-icon" onClick={onIconClick}>
             {icon}
           </button>
-        )}
+        ) : null}
         <button data-testid="modal-dismiss" onClick={onDismiss}>
           Dismiss
         </button>

--- a/client/src/shared/components/StatusModal/StatusModalLayout.tsx
+++ b/client/src/shared/components/StatusModal/StatusModalLayout.tsx
@@ -48,11 +48,11 @@ const StatusModalLayout = ({
       <div className="mt-6 flex flex-col gap-2">
         {icon}
         <div className="text-heading-300 text-text-primary">{title}</div>
-        {subtitle && <div className="text-300 text-text-primary-50">{subtitle}</div>}
+        {subtitle ? <div className="text-300 text-text-primary-50">{subtitle}</div> : null}
       </div>
 
       {/* Divider and secondary title when miner is asleep with errors */}
-      {secondaryTitle && (
+      {secondaryTitle ? (
         <>
           <Divider />
           {/* Secondary section - identical structure to header section */}
@@ -61,13 +61,13 @@ const StatusModalLayout = ({
               <Alert />
             </DialogIcon>
             <div className="text-heading-300 text-text-primary">{secondaryTitle}</div>
-            {secondarySubtitle && <div className="text-300 text-text-primary-50">{secondarySubtitle}</div>}
+            {secondarySubtitle ? <div className="text-300 text-text-primary-50">{secondarySubtitle}</div> : null}
           </div>
         </>
-      )}
+      ) : null}
 
       {/* Error list section */}
-      {errors && errors.length > 0 && (
+      {errors && errors.length > 0 ? (
         <div>
           {/* Error rows */}
           <div className="flex flex-col">
@@ -83,7 +83,7 @@ const StatusModalLayout = ({
             ))}
           </div>
         </div>
-      )}
+      ) : null}
 
       {/* Additional content sections */}
       {children}

--- a/client/src/shared/components/StatusOverlay/StatusOverlay.tsx
+++ b/client/src/shared/components/StatusOverlay/StatusOverlay.tsx
@@ -37,7 +37,7 @@ const StatusOverlay = ({ text, icon = <LogoAlt width="w-16" /> }: StatusOverlayP
         >
           <ProgressCircular indeterminate />
         </motion.div>
-        {text && (
+        {text ? (
           <motion.p
             animate={{ y: ["-50%", "0%"], opacity: [0, 1] }}
             transition={{ duration: 1, ease: easeGentle }}
@@ -45,7 +45,7 @@ const StatusOverlay = ({ text, icon = <LogoAlt width="w-16" /> }: StatusOverlayP
           >
             {text}
           </motion.p>
-        )}
+        ) : null}
       </div>
     </>
   );

--- a/client/src/shared/components/Switch/Switch.tsx
+++ b/client/src/shared/components/Switch/Switch.tsx
@@ -10,7 +10,7 @@ type SwitchProps = {
 const Switch = ({ label, checked, setChecked, disabled = false }: SwitchProps) => {
   return (
     <label className="inline-flex cursor-pointer items-center gap-4 select-none">
-      {label && <span className="text-300">{label}</span>}
+      {label ? <span className="text-300">{label}</span> : null}
       <div className="relative inline-block">
         <input
           type="checkbox"

--- a/client/src/shared/components/Tooltip/Tooltip.tsx
+++ b/client/src/shared/components/Tooltip/Tooltip.tsx
@@ -32,7 +32,7 @@ const Tooltip = ({ header, body, position, icon = "question" }: TooltipProps) =>
           peerHover,
         )}
       >
-        {header && <div className="mb-1 text-heading-100 text-text-primary">{header}</div>}
+        {header ? <div className="mb-1 text-heading-100 text-text-primary">{header}</div> : null}
         <div className="text-300 text-text-primary-70">{body}</div>
       </div>
     </div>

--- a/client/src/shared/features/toaster/components/GroupedToaster/GroupedToast.tsx
+++ b/client/src/shared/features/toaster/components/GroupedToaster/GroupedToast.tsx
@@ -37,10 +37,10 @@ const GroupedToast = ({ message, onClose, status, progress, actions, ttl = defau
         {icon}
         <div className="flex flex-1 flex-col">
           <div className="text-emphasis-300 text-text-primary">{message}</div>
-          {progress !== undefined && <div className="text-200 text-text-primary-70">{progress}% complete</div>}
-          {status === STATUSES.queued && <div className="text-200 text-text-primary-70">Queued</div>}
+          {progress !== undefined ? <div className="text-200 text-text-primary-70">{progress}% complete</div> : null}
+          {status === STATUSES.queued ? <div className="text-200 text-text-primary-70">Queued</div> : null}
         </div>
-        {actions && actions.length > 0 && (
+        {actions && actions.length > 0 ? (
           <div className="shrink-0">
             {actions.map((action, i) => (
               <Button
@@ -53,7 +53,7 @@ const GroupedToast = ({ message, onClose, status, progress, actions, ttl = defau
               />
             ))}
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/client/src/shared/features/toaster/components/GroupedToaster/GroupedToaster.tsx
+++ b/client/src/shared/features/toaster/components/GroupedToaster/GroupedToaster.tsx
@@ -93,7 +93,7 @@ const GroupedToaster = ({ toasts }: GroupedToasterProps) => {
       onClick={() => !isExpanded && setIsExpanded(true)}
       data-testid="toaster-container"
     >
-      {(!isExpanded || toasts.length > 1) && (
+      {!isExpanded || toasts.length > 1 ? (
         <div
           className={clsx("cursor-pointer", {
             "pb-2": isExpanded,
@@ -104,7 +104,7 @@ const GroupedToaster = ({ toasts }: GroupedToasterProps) => {
           <div className="flex items-center">
             <div className="flex flex-row items-center">
               <AnimatePresence initial={false} mode="popLayout">
-                {!isExpanded && (
+                {!isExpanded ? (
                   <motion.div
                     initial={{ x: "-100%", opacity: 0 }}
                     animate={{ x: 0, opacity: 1 }}
@@ -122,7 +122,7 @@ const GroupedToaster = ({ toasts }: GroupedToasterProps) => {
                       <ProgressCircular indeterminate dataTestId="header-progress-circular" />
                     )}
                   </motion.div>
-                )}
+                ) : null}
               </AnimatePresence>
               <motion.div layout transition={{ duration: 0.3 }}>
                 <div className="flex flex-col">
@@ -140,9 +140,9 @@ const GroupedToaster = ({ toasts }: GroupedToasterProps) => {
             </div>
           </div>
         </div>
-      )}
+      ) : null}
       <ResizeablePanel className="w-full" resizeOn={isExpanded ? toasts.length : false}>
-        {isExpanded && (
+        {isExpanded ? (
           <>
             <div className="w-full divide-y divide-border-5">
               {toasts.map(({ message, status, id, progress, ttl, onClose, actions }) => (
@@ -166,7 +166,7 @@ const GroupedToaster = ({ toasts }: GroupedToasterProps) => {
               }}
             />
           </>
-        )}
+        ) : null}
       </ResizeablePanel>
     </div>
   );

--- a/client/src/shared/features/toaster/components/Toast/Toast.tsx
+++ b/client/src/shared/features/toaster/components/Toast/Toast.tsx
@@ -61,9 +61,9 @@ const Toast = ({ message, onClose, status, index, numToasts, ttl = defaultTtl }:
           )}
         >
           <div className="flex grow items-center space-x-3 transition-opacity duration-300">
-            {status === STATUSES.loading && <ProgressCircular indeterminate />}
-            {status === STATUSES.success && <Success className="text-intent-success-fill" />}
-            {status === STATUSES.error && <Alert className="text-intent-critical-fill" />}
+            {status === STATUSES.loading ? <ProgressCircular indeterminate /> : null}
+            {status === STATUSES.success ? <Success className="text-intent-success-fill" /> : null}
+            {status === STATUSES.error ? <Alert className="text-intent-critical-fill" /> : null}
             <div className="text-heading-100 text-text-primary">{message}</div>
           </div>
           <button onClick={onClose}>


### PR DESCRIPTION
## Summary
- Adds `react/jsx-no-leaked-render` ESLint rule with `validStrategies: ["ternary"]` to prevent falsy values (e.g. `0`) from short-circuit `&&` expressions leaking into rendered output.
- Scrubs the codebase, converting `{cond && <X/>}` to `{cond ? <X/> : null}` across 170 files. Closes #33.

## Test plan
- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 2023 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)