### PR TITLE
fix(installer): don't report success when containers fail to start

### DIFF
--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -590,37 +590,45 @@ echo "Stopping any running services..."
 docker compose -f "$COMPOSE_FILE" down
 
 echo "Starting services..."
-docker compose -f "$COMPOSE_FILE" up -d
-
-# ----------------------------------------------------------------------------
-# Docker Cleanup
-# ----------------------------------------------------------------------------
-
-# Remove dangling images and build cache left behind by previous deployments.
-echo "Cleaning up old Docker images and build cache..."
-docker image prune -f 2>/dev/null || true
-docker builder prune -f 2>/dev/null || true
+if ! docker compose -f "$COMPOSE_FILE" up -d; then
+    echo "Error: docker compose up failed. Check logs with: docker compose -f $COMPOSE_FILE logs"
+    exit 1
+fi
 
 # ----------------------------------------------------------------------------
 # Final Status Check
 # ----------------------------------------------------------------------------
 
-# Check if docker compose was successful
-if [ $? -eq 0 ]; then
-    echo "--------------------------------------------------------------"
-    echo "Proto Fleet is now running!"
+# `up -d` can exit 0 while containers stay in Created (e.g. port conflicts under host networking).
+sleep 3
+not_running=$(docker compose -f "$COMPOSE_FILE" ps --format '{{.Name}} {{.State}}' \
+    | awk '$2 != "running" {print $1}')
+if [ -n "$not_running" ]; then
+    echo "Error: these services failed to reach running state:"
+    echo "$not_running" | sed 's/^/  - /'
     echo ""
-    echo "Access URLs:"
-    protocol="http"
-    [ "$PROTOCOL_MODE" == "https" ] && protocol="https"
-    echo "  Local:  ${protocol}://localhost"
-    for ip in $(get_local_ips); do
-        echo "  LAN:    ${protocol}://$ip"
-    done
-    echo "--------------------------------------------------------------"
-else
-    echo "Error: Failed to start services. Check docker compose logs for details."
+    echo "Check logs with: docker compose -f $COMPOSE_FILE logs"
     exit 1
 fi
+
+# ----------------------------------------------------------------------------
+# Docker Cleanup
+# ----------------------------------------------------------------------------
+
+echo "Cleaning up old Docker images and build cache..."
+docker image prune -f 2>/dev/null || true
+docker builder prune -f 2>/dev/null || true
+
+echo "--------------------------------------------------------------"
+echo "Proto Fleet is now running!"
+echo ""
+echo "Access URLs:"
+protocol="http"
+[ "$PROTOCOL_MODE" == "https" ] && protocol="https"
+echo "  Local:  ${protocol}://localhost"
+for ip in $(get_local_ips); do
+    echo "  LAN:    ${protocol}://$ip"
+done
+echo "--------------------------------------------------------------"
 
 exit 0

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -590,24 +590,12 @@ echo "Stopping any running services..."
 docker compose -f "$COMPOSE_FILE" down
 
 echo "Starting services..."
-if ! docker compose -f "$COMPOSE_FILE" up -d; then
-    echo "Error: docker compose up failed. Check logs with: docker compose -f $COMPOSE_FILE logs"
-    exit 1
-fi
-
-# ----------------------------------------------------------------------------
-# Final Status Check
-# ----------------------------------------------------------------------------
-
-# `up -d` can exit 0 while containers stay in Created (e.g. port conflicts under host networking).
-sleep 3
-not_running=$(docker compose -f "$COMPOSE_FILE" ps --format '{{.Name}} {{.State}}' \
-    | awk '$2 != "running" {print $1}')
-if [ -n "$not_running" ]; then
-    echo "Error: these services failed to reach running state:"
-    echo "$not_running" | sed 's/^/  - /'
-    echo ""
-    echo "Check logs with: docker compose -f $COMPOSE_FILE logs"
+# --wait blocks until every service is running (or healthy, when a healthcheck is defined).
+# Without it, `up -d` can exit 0 while containers stay in Created (e.g. port conflicts under
+# host networking), producing a false "Proto Fleet is now running!" banner.
+if ! docker compose -f "$COMPOSE_FILE" up -d --wait --wait-timeout 60; then
+    echo "Error: services failed to reach running state."
+    echo "Check logs with: docker compose -f \"$COMPOSE_FILE\" logs"
     exit 1
 fi
 

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -593,7 +593,7 @@ echo "Starting services..."
 # --wait blocks until every service is running (or healthy, when a healthcheck is defined).
 # Without it, `up -d` can exit 0 while containers stay in Created (e.g. port conflicts under
 # host networking), producing a false "Proto Fleet is now running!" banner.
-if ! docker compose -f "$COMPOSE_FILE" up -d --wait --wait-timeout 60; then
+if ! docker compose -f "$COMPOSE_FILE" up -d --wait --wait-timeout 300; then
     echo "Error: services failed to reach running state."
     echo "Check logs with: docker compose -f \"$COMPOSE_FILE\" logs"
     exit 1

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -327,6 +327,14 @@ if ! docker compose version &> /dev/null; then
     fi
 fi
 
+# The post-start readiness check below relies on `--wait` (Compose v2.1.0+).
+# Fail fast here, before `docker compose down` takes an existing stack offline.
+if ! docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
+    echo "Error: your docker compose does not support --wait (requires Compose v2.1.0+)."
+    echo "Please upgrade Docker Compose: https://docs.docker.com/compose/install/"
+    exit 1
+fi
+
 # ----------------------------------------------------------------------------
 # Database Volume Management Function
 # ----------------------------------------------------------------------------

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -327,13 +327,17 @@ if ! docker compose version &> /dev/null; then
     fi
 fi
 
-# The post-start readiness check below relies on `--wait` (Compose v2.1.0+).
-# Fail fast here, before `docker compose down` takes an existing stack offline.
-if ! docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
-    echo "Error: your docker compose does not support --wait (requires Compose v2.1.0+)."
-    echo "Please upgrade Docker Compose: https://docs.docker.com/compose/install/"
-    exit 1
-fi
+# The post-start readiness check below uses both `--wait` and `--wait-timeout`
+# (Compose v2.17.0+). Fail fast here, before `docker compose down` takes an
+# existing stack offline.
+compose_up_help=$(docker compose up --help 2>&1 || true)
+for flag in --wait --wait-timeout; do
+    if ! grep -qE -- "(^|[[:space:]])${flag}([[:space:]]|$)" <<<"$compose_up_help"; then
+        echo "Error: your docker compose does not support ${flag}."
+        echo "run-fleet.sh requires Compose v2.17.0+. Upgrade: https://docs.docker.com/compose/install/"
+        exit 1
+    fi
+done
 
 # ----------------------------------------------------------------------------
 # Database Volume Management Function


### PR DESCRIPTION
## Summary

- The installer's success check read `$?` after `docker image prune ... || true` / `docker builder prune ... || true`, which always returns 0. So `run-fleet.sh` printed "Proto Fleet is now running!" even when `docker compose up -d` silently left containers in `Created` state (e.g. port 80/4000/5432 was already bound on the host and `network_mode: host` couldn't claim it).
- Check `docker compose up -d` directly via `if ! ...; then exit 1; fi`, then verify every service reached state `running` by parsing `docker compose ps`. Fail loudly with the list of stuck services and a hint to `docker compose logs`.
- Move the `docker image prune` / `docker builder prune` cleanup after the success check so their exit codes can no longer mask failures.


## Repro (before the fix)

1. Run anything that holds port 4000 or 5432 on the host (e.g. `just dev` from this repo).
2. Run `bash <(curl -fsSL https://fleet.proto.xyz/install.sh)`.
3. Observe: installer prints "Proto Fleet is now running!" with `http://localhost` as the access URL, but `curl http://localhost/` returns connection refused and `docker ps -a --filter name=deployment` shows the three containers stuck in `Created`.

## Test plan

- [ ] With port 4000 held (e.g. `just dev` running), run `run-fleet.sh` and confirm it now exits non-zero with a message listing the stuck services (no "Proto Fleet is now running!" banner).
- [ ] Happy path: stop anything holding 4000/5432, re-run `run-fleet.sh`, confirm containers come up and the access-URLs banner still prints.
- [ ] `bash -n deployment-files/run-fleet.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)