### PR TITLE
ci: speed up contract tests

### DIFF
--- a/.github/workflows/protofleet-contract-checks.yml
+++ b/.github/workflows/protofleet-contract-checks.yml
@@ -41,5 +41,8 @@ jobs:
       - name: Configure Go cache
         uses: ./.github/actions/go-cache-setup
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build plugins and run contract tests
         run: just test-contract

--- a/.github/workflows/protofleet-contract-checks.yml
+++ b/.github/workflows/protofleet-contract-checks.yml
@@ -44,5 +44,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      # buildx's type=gha cache backend reads ACTIONS_RUNTIME_TOKEN and
+      # ACTIONS_CACHE_URL (aka ACTIONS_RESULTS_URL) from the environment. These
+      # aren't exposed to plain `run:` steps by default, so export them here.
+      - name: Expose GitHub Actions runtime to buildx
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+
       - name: Build plugins and run contract tests
         run: just test-contract

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ plugin/asicrs/target/
 
 server/plugins/*
 
+# Compiled contract-test binary (built by `just test-contract`)
+tests/plugin-contract/bin/
+
 # Generated nginx config (copied from nginx.http.conf or nginx.https.conf by run-fleet.sh)
 deployment-files/client/nginx.conf
 

--- a/justfile
+++ b/justfile
@@ -76,30 +76,59 @@ test-contract: _asicrs-build
   GO_VERSION=$(grep '^go ' tests/plugin-contract/go.mod | awk '{print $2}')
   IMAGE="golang:${GO_VERSION}-alpine"
 
-  # Build Go plugins once (shared via volume mount)
-  docker run --rm \
-    -v "$(pwd)":/work \
-    -w /work \
-    -e GOFLAGS=-buildvcs=false \
-    "$IMAGE" \
-    sh -c '\
-      mkdir -p server/plugins && \
-      (cd plugin/proto && go build -o ../../server/plugins/proto-plugin .) && \
-      (cd plugin/antminer && go build -o ../../server/plugins/antminer-plugin .) \
-    '
+  # Share the host Go build + module cache with every container so the
+  # actions/cache restore on CI (and the local dev cache) isn't wasted.
+  mkdir -p "${HOME}/.cache/go-build" "${HOME}/go/pkg/mod"
+  DOCKER_RUN=(
+    docker run --rm
+    -v "$(pwd):/work"
+    -v "${HOME}/.cache/go-build:/gocache"
+    -v "${HOME}/go/pkg/mod:/gomodcache"
+    --user "$(id -u):$(id -g)"
+    -e GOCACHE=/gocache
+    -e GOMODCACHE=/gomodcache
+    -e GOFLAGS=-buildvcs=false
+    -e HOME=/tmp
+    -w /work
+  )
+
+  # Build Go plugins and compile the contract-test binary in a single container
+  # so the three test runs below only need to execute it, not recompile it.
+  mkdir -p tests/plugin-contract/bin
+  "${DOCKER_RUN[@]}" "$IMAGE" sh -c '
+    mkdir -p server/plugins && \
+    (cd plugin/proto && go build -o ../../server/plugins/proto-plugin .) && \
+    (cd plugin/antminer && go build -o ../../server/plugins/antminer-plugin .) && \
+    (cd tests/plugin-contract && go test -c -o bin/miners.test ./miners/)
+  '
 
   # Run each test suite in its own container (isolated network namespace)
-  # so mocks binding port 4028/80 don't conflict between suites.
-  FAILED=0
+  # so mocks binding port 4028/80 don't conflict between suites. Since the
+  # containers are network-isolated, run them in parallel and stream logs
+  # after each one finishes so output isn't interleaved mid-test.
+  declare -a PIDS NAMES LOGS
   for test in TestAntminerStock TestAntminerVNish TestWhatsMinerStock; do
-    echo "=== Running ${test} ==="
-    docker run --rm \
-      -v "$(pwd)":/work \
-      -w /work \
-      -e GOFLAGS=-buildvcs=false \
-      "$IMAGE" \
-      go test -v -count=1 -timeout=2m -run "^${test}$" ./tests/plugin-contract/miners/ \
-    || FAILED=1
+    LOG=$(mktemp)
+    echo "=== Launching ${test} (log: ${LOG}) ==="
+    # cd into the miners package so the tests' relative testdata paths (../testdata/...) resolve.
+    "${DOCKER_RUN[@]}" "$IMAGE" sh -c \
+      "cd tests/plugin-contract/miners && ../bin/miners.test -test.v -test.timeout=2m -test.run '^${test}\$'" \
+      >"$LOG" 2>&1 &
+    PIDS+=("$!")
+    NAMES+=("$test")
+    LOGS+=("$LOG")
+  done
+
+  FAILED=0
+  for i in "${!PIDS[@]}"; do
+    if wait "${PIDS[$i]}"; then
+      echo "=== PASSED: ${NAMES[$i]} ==="
+    else
+      echo "=== FAILED: ${NAMES[$i]} ==="
+      FAILED=1
+    fi
+    cat "${LOGS[$i]}"
+    rm -f "${LOGS[$i]}"
   done
 
   if [ "$FAILED" -ne 0 ]; then
@@ -316,7 +345,13 @@ _asicrs-build:
   fi
   echo "Building asicrs plugin..."
   mkdir -p server/plugins
+  CACHE_ARGS=()
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    CACHE_ARGS+=(--cache-from 'type=gha,scope=asicrs-native')
+    CACHE_ARGS+=(--cache-to 'type=gha,mode=max,scope=asicrs-native')
+  fi
   docker buildx build \
+    ${CACHE_ARGS[@]+"${CACHE_ARGS[@]}"} \
     --file plugin/asicrs/Dockerfile.build \
     --output type=local,dest=server/plugins \
     .

--- a/justfile
+++ b/justfile
@@ -103,32 +103,17 @@ test-contract: _asicrs-build
   '
 
   # Run each test suite in its own container (isolated network namespace)
-  # so mocks binding port 4028/80 don't conflict between suites. Since the
-  # containers are network-isolated, run them in parallel and stream logs
-  # after each one finishes so output isn't interleaved mid-test.
-  declare -a PIDS NAMES LOGS
+  # so mocks binding port 4028/80 don't conflict between suites. Keep the
+  # loop sequential: the asicrs harness rewrites a shared config file next
+  # to the plugin binary, and parallel containers bind-mounting the same
+  # /work would race on server/plugins/asicrs-config.yaml.
+  FAILED=0
   for test in TestAntminerStock TestAntminerVNish TestWhatsMinerStock; do
-    LOG=$(mktemp)
-    echo "=== Launching ${test} (log: ${LOG}) ==="
+    echo "=== Running ${test} ==="
     # cd into the miners package so the tests' relative testdata paths (../testdata/...) resolve.
     "${DOCKER_RUN[@]}" "$IMAGE" sh -c \
       "cd tests/plugin-contract/miners && ../bin/miners.test -test.v -test.timeout=2m -test.run '^${test}\$'" \
-      >"$LOG" 2>&1 &
-    PIDS+=("$!")
-    NAMES+=("$test")
-    LOGS+=("$LOG")
-  done
-
-  FAILED=0
-  for i in "${!PIDS[@]}"; do
-    if wait "${PIDS[$i]}"; then
-      echo "=== PASSED: ${NAMES[$i]} ==="
-    else
-      echo "=== FAILED: ${NAMES[$i]} ==="
-      FAILED=1
-    fi
-    cat "${LOGS[$i]}"
-    rm -f "${LOGS[$i]}"
+    || FAILED=1
   done
 
   if [ "$FAILED" -ne 0 ]; then

--- a/justfile
+++ b/justfile
@@ -76,31 +76,33 @@ test-contract: _asicrs-build
   GO_VERSION=$(grep '^go ' tests/plugin-contract/go.mod | awk '{print $2}')
   IMAGE="golang:${GO_VERSION}-alpine"
 
-  # Share the host Go build + module cache with every container so the
-  # actions/cache restore on CI (and the local dev cache) isn't wasted.
-  mkdir -p "${HOME}/.cache/go-build" "${HOME}/go/pkg/mod"
-  DOCKER_RUN=(
+  DOCKER_COMMON=(
     docker run --rm
     -v "$(pwd):/work"
-    -v "${HOME}/.cache/go-build:/gocache"
-    -v "${HOME}/go/pkg/mod:/gomodcache"
     --user "$(id -u):$(id -g)"
-    -e GOCACHE=/gocache
-    -e GOMODCACHE=/gomodcache
     -e GOFLAGS=-buildvcs=false
     -e HOME=/tmp
     -w /work
   )
 
   # Build Go plugins and compile the contract-test binary in a single container
-  # so the three test runs below only need to execute it, not recompile it.
-  mkdir -p tests/plugin-contract/bin
-  "${DOCKER_RUN[@]}" "$IMAGE" sh -c '
-    mkdir -p server/plugins && \
-    (cd plugin/proto && go build -o ../../server/plugins/proto-plugin .) && \
-    (cd plugin/antminer && go build -o ../../server/plugins/antminer-plugin .) && \
-    (cd tests/plugin-contract && go test -c -o bin/miners.test ./miners/)
-  '
+  # so the three test runs below only need to execute the binary, not recompile
+  # it. Only this builder container mounts the host Go caches, so the
+  # actions/cache restore on CI (and the local dev cache) isn't wasted; the
+  # test-execution containers below don't need it and shouldn't have write
+  # access to the host's global Go caches.
+  mkdir -p "${HOME}/.cache/go-build" "${HOME}/go/pkg/mod" tests/plugin-contract/bin
+  "${DOCKER_COMMON[@]}" \
+    -v "${HOME}/.cache/go-build:/gocache" \
+    -v "${HOME}/go/pkg/mod:/gomodcache" \
+    -e GOCACHE=/gocache \
+    -e GOMODCACHE=/gomodcache \
+    "$IMAGE" sh -c '
+      mkdir -p server/plugins && \
+      (cd plugin/proto && go build -o ../../server/plugins/proto-plugin .) && \
+      (cd plugin/antminer && go build -o ../../server/plugins/antminer-plugin .) && \
+      (cd tests/plugin-contract && go test -c -o bin/miners.test ./miners/)
+    '
 
   # Run each test suite in its own container (isolated network namespace)
   # so mocks binding port 4028/80 don't conflict between suites. Keep the
@@ -111,7 +113,7 @@ test-contract: _asicrs-build
   for test in TestAntminerStock TestAntminerVNish TestWhatsMinerStock; do
     echo "=== Running ${test} ==="
     # cd into the miners package so the tests' relative testdata paths (../testdata/...) resolve.
-    "${DOCKER_RUN[@]}" "$IMAGE" sh -c \
+    "${DOCKER_COMMON[@]}" "$IMAGE" sh -c \
       "cd tests/plugin-contract/miners && ../bin/miners.test -test.v -test.timeout=2m -test.run '^${test}\$'" \
     || FAILED=1
   done


### PR DESCRIPTION
## Summary

The **Contract Tests** job consistently takes ~13–14 min (e.g. 13m42s on [run 24802916993](https://github.com/block/proto-fleet/actions/runs/24802916993)) because every container in `just test-contract` re-downloads modules and recompiles from scratch — the host `actions/cache` restore is never plumbed into the containers. This PR pipes the cache through, collapses four cold Go environments into one, and caches the asicrs Rust build layers.

![speed](https://media.giphy.com/media/dcKWFKCzjdozxwZASo/giphy.gif)

### Changes
- **`test-contract`**: mount host `GOCACHE`/`GOMODCACHE` into every `docker run` and run as the host UID so the `actions/cache` restore is actually reused and written files stay runner-owned.
- **`test-contract`**: compile the contract-test binary once with `go test -c`, then execute it for each suite — removes three redundant compile passes. Suites still run sequentially because the asicrs harness rewrites `server/plugins/asicrs-config.yaml` next to the binary and parallel containers bind-mounting `/work` would race on that file.
- **`_asicrs-build`**: add `--cache-from`/`--cache-to type=gha,scope=asicrs-native` when running in CI, so the Rust build layers are cached across runs.
- **workflow**: add `docker/setup-buildx-action` so the GHA cache backend has a container-based builder to talk to.
- **`.gitignore`**: ignore `tests/plugin-contract/bin/` (the compiled contract-test binary).

## Test plan

- [ ] First CI run primes the caches — expect roughly baseline (~13 min) duration and confirm it completes.
- [ ] Second CI run on this branch: compare job duration against the ~13–14 min baseline; expect a meaningful drop (target: several minutes).
- [ ] Inspect the `Build plugins and run contract tests` step log: no `go: downloading ...` lines inside containers on cache hits.
- [ ] All three suites still pass: `TestAntminerStock`, `TestAntminerVNish`, `TestWhatsMinerStock`.
- [ ] Local: `just test-contract` still works on a dev machine (macOS + Docker Desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)