### PR TITLE
docs(client): drop stale useBatchOperations reference in jsdoc

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -91,11 +91,11 @@ interface UseMinerActionsParams {
   currentFilter?: MinerListFilter;
   onActionStart?: () => void;
   onActionComplete?: () => void;
-  /** Start tracking a batch operation (from useBatchOperations) */
+  /** Start tracking a batch operation */
   startBatchOperation?: (batch: BatchOperationInput) => void;
-  /** Complete a batch operation (from useBatchOperations) */
+  /** Complete a batch operation */
   completeBatchOperation?: (batchIdentifier: string) => void;
-  /** Remove devices from a batch (from useBatchOperations) */
+  /** Remove devices from a batch */
   removeDevicesFromBatch?: (batchIdentifier: string, deviceIds: string[]) => void;
   /** The miners map — used for firmware model checks, unpair subtitle, and security grouping */
   miners?: Record<string, MinerStateSnapshot>;


### PR DESCRIPTION
## Summary
- Follow-up to #77 addressing @rongxin-liu's [review comment](https://github.com/block/proto-fleet/pull/77#pullrequestreview-4172745057).
- The JSDoc on `UseMinerActionsParams` still named `useBatchOperations` as the provider of the batch callbacks, but callers now pass them from `useBatchActions`. Dropped the parenthetical entirely since `useMinerActions` just receives these as props and doesn't care which hook produced them.

## Test plan
- [x] `just format` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)