### PR TITLE
fix(client): prevent line chart tooltip from triggering page scrollbar

### DIFF
--- a/client/src/shared/components/LineChart/LineChart.tsx
+++ b/client/src/shared/components/LineChart/LineChart.tsx
@@ -551,7 +551,7 @@ const LineChart = ({
   );
 
   return (
-    <div ref={chartRef} className="min-h-100 flex-1 [&_*]:!outline-none" data-testid="line-chart">
+    <div ref={chartRef} className="min-h-100 flex-1 overflow-x-clip [&_*]:!outline-none" data-testid="line-chart">
       <ChartWrapper className="mb-10 h-full w-full">
         {chartData?.length ? (
           <RechartsLineChart


### PR DESCRIPTION
## Summary
- Recharts' tooltip wrapper is sized to the 269px tooltip content and positioned at the cursor. Our inner `transform` clamps the visible tooltip inside the chart, but the wrapper's bounding box still overflowed the chart's right edge — producing a horizontal page scrollbar when hovering the half-width efficiency panel.
- Clip the chart's outer container on the X axis so the phantom wrapper width no longer widens the page. Y axis stays visible so tooltips can still escape above the chart (the reason `allowEscapeViewBox.y` is set).

Fixes #82

## Test plan
- [x] `vitest` — shared LineChart + EfficiencyPanel suites green
- [ ] Manual: hover the efficiency graph near its right edge, confirm no horizontal scrollbar
- [ ] Manual: hover other chart panels, confirm tooltips still display and can escape above the chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)