### PR TITLE
WIP: Add dashboard E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/pages/home.ts
+++ b/client/e2eTests/protoFleet/pages/home.ts
@@ -85,14 +85,21 @@ export class HomePage extends BasePage {
   }
 
   async getSelectedDuration(durations: readonly string[]) {
+    const selectedDurations: string[] = [];
+
     for (const duration of durations) {
       const className = await this.getDurationButton(duration).getAttribute("class");
       if (className?.includes("bg-core-primary-fill")) {
-        return duration;
+        selectedDurations.push(duration);
       }
     }
 
-    return null;
+    expect(
+      selectedDurations,
+      `Expected exactly one selected duration, but found ${selectedDurations.length}: ${selectedDurations.join(", ") || "none"}`,
+    ).toHaveLength(1);
+
+    return selectedDurations[0];
   }
 
   async clickControlBoardsLink() {

--- a/client/e2eTests/protoFleet/pages/home.ts
+++ b/client/e2eTests/protoFleet/pages/home.ts
@@ -56,6 +56,14 @@ export class HomePage extends BasePage {
     await expect(this.page.getByRole("button", { name: "Authenticate" })).toBeHidden();
   }
 
+  async validateConfigurePoolsButtonNotVisible() {
+    await expect(this.page.getByRole("button", { name: "Configure" })).toHaveCount(0);
+  }
+
+  async validateSetupTaskCardNotVisible(title: string) {
+    await expect(this.page.getByText(title, { exact: true })).toHaveCount(0);
+  }
+
   async validateDashboardSectionVisible(title: string) {
     await expect(this.page.getByText(title, { exact: true }).first()).toBeVisible();
   }

--- a/client/e2eTests/protoFleet/pages/home.ts
+++ b/client/e2eTests/protoFleet/pages/home.ts
@@ -2,6 +2,14 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class HomePage extends BasePage {
+  private getDurationButton(duration: string) {
+    return this.page.getByRole("button", { name: duration, exact: true });
+  }
+
+  private getDashboardPanelHeading(title: string) {
+    return this.page.getByRole("heading", { name: title, exact: true }).first();
+  }
+
   private getOverviewIssueCard(title: string) {
     return this.page
       .locator(`//*[self::a or self::div][contains(@class,'rounded-xl')][.//*[normalize-space(text())='${title}']]`)
@@ -46,6 +54,37 @@ export class HomePage extends BasePage {
 
   async validateAuthenticateMinersButtonNotVisible() {
     await expect(this.page.getByRole("button", { name: "Authenticate" })).toBeHidden();
+  }
+
+  async validateDashboardSectionVisible(title: string) {
+    await expect(this.page.getByText(title, { exact: true }).first()).toBeVisible();
+  }
+
+  async validateDashboardPanelVisible(title: string) {
+    await expect(this.getDashboardPanelHeading(title)).toBeVisible();
+  }
+
+  async validateDashboardPerformanceDisclaimerVisible() {
+    await this.validateTextIsVisible("Some devices do not make all data available to Proto Fleet.");
+  }
+
+  async clickDurationButton(duration: string) {
+    await this.getDurationButton(duration).click();
+  }
+
+  async validateDurationSelected(duration: string) {
+    await expect(this.getDurationButton(duration)).toHaveClass(/bg-core-primary-fill/);
+  }
+
+  async getSelectedDuration(durations: readonly string[]) {
+    for (const duration of durations) {
+      const className = await this.getDurationButton(duration).getAttribute("class");
+      if (className?.includes("bg-core-primary-fill")) {
+        return duration;
+      }
+    }
+
+    return null;
   }
 
   async clickControlBoardsLink() {

--- a/client/e2eTests/protoFleet/spec/dashboard.spec.ts
+++ b/client/e2eTests/protoFleet/spec/dashboard.spec.ts
@@ -1,0 +1,70 @@
+/* eslint-disable playwright/expect-expect */
+import { test } from "../fixtures/pageFixtures";
+
+const FLEET_DURATIONS = ["1h", "24h", "7d", "30d", "90d", "1y"] as const;
+const DURATION_SWITCH_TARGETS = ["7d", "30d"] as const;
+
+test.describe("Proto Fleet - Dashboard", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("Dashboard renders the paired fleet shell", async ({ homePage, commonSteps }) => {
+    await commonSteps.loginAsAdmin();
+
+    await test.step("Validate dashboard sections are visible", async () => {
+      await homePage.validateHomePageOpened();
+      await homePage.validateDashboardSectionVisible("Overview");
+      await homePage.validateDashboardSectionVisible("Performance");
+    });
+
+    await test.step("Validate dashboard panels are visible", async () => {
+      await homePage.validateDashboardPanelVisible("Hashrate");
+      await homePage.validateDashboardPanelVisible("Uptime");
+      await homePage.validateDashboardPanelVisible("Temperature");
+      await homePage.validateDashboardPanelVisible("Power");
+      await homePage.validateDashboardPanelVisible("Efficiency");
+    });
+
+    await test.step("Validate setup prompt is not shown for the prepared fleet", async () => {
+      await homePage.validateCompleteSetupTitleNotVisible();
+      await homePage.validateAuthenticateMinersButtonNotVisible();
+      await homePage.validateDashboardPerformanceDisclaimerVisible();
+    });
+  });
+
+  test("Dashboard duration selection persists after refresh", async ({ homePage, commonSteps }) => {
+    await commonSteps.loginAsAdmin();
+
+    let currentDuration: string | null = null;
+    let targetDuration = "7d";
+
+    await test.step("Choose a different dashboard duration", async () => {
+      currentDuration = await homePage.getSelectedDuration(FLEET_DURATIONS);
+      targetDuration =
+        DURATION_SWITCH_TARGETS.find((duration) => duration !== currentDuration) ?? DURATION_SWITCH_TARGETS[0];
+
+      await homePage.clickDurationButton(targetDuration);
+      await homePage.validateDurationSelected(targetDuration);
+    });
+
+    await test.step("Validate dashboard still renders after changing duration", async () => {
+      await homePage.validateDashboardPanelVisible("Hashrate");
+      await homePage.validateDashboardPanelVisible("Uptime");
+      await homePage.validateDashboardPanelVisible("Temperature");
+      await homePage.validateDashboardPanelVisible("Power");
+      await homePage.validateDashboardPanelVisible("Efficiency");
+    });
+
+    await test.step("Refresh and validate duration persistence", async () => {
+      await homePage.reloadPage();
+      await homePage.validateHomePageOpened();
+      await homePage.validateDurationSelected(targetDuration);
+      await homePage.validateDashboardPanelVisible("Hashrate");
+      await homePage.validateDashboardPanelVisible("Uptime");
+      await homePage.validateDashboardPanelVisible("Temperature");
+      await homePage.validateDashboardPanelVisible("Power");
+      await homePage.validateDashboardPanelVisible("Efficiency");
+    });
+  });
+});

--- a/client/e2eTests/protoFleet/spec/dashboard.spec.ts
+++ b/client/e2eTests/protoFleet/spec/dashboard.spec.ts
@@ -4,6 +4,10 @@ import { test } from "../fixtures/pageFixtures";
 const FLEET_DURATIONS = ["1h", "24h", "7d", "30d", "90d", "1y"] as const;
 const DURATION_SWITCH_TARGETS = ["7d", "30d"] as const;
 
+function getDurationSwitchTarget(currentDuration: string) {
+  return currentDuration === DURATION_SWITCH_TARGETS[0] ? DURATION_SWITCH_TARGETS[1] : DURATION_SWITCH_TARGETS[0];
+}
+
 test.describe("Proto Fleet - Dashboard", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
@@ -39,14 +43,14 @@ test.describe("Proto Fleet - Dashboard", () => {
   test("Dashboard duration selection persists after refresh", async ({ homePage, commonSteps }) => {
     await commonSteps.loginAsAdmin();
 
-    let currentDuration: string | null = null;
+    let currentDuration = "";
     let targetDuration = "7d";
 
     await test.step("Choose a different dashboard duration", async () => {
       currentDuration = await homePage.getSelectedDuration(FLEET_DURATIONS);
-      targetDuration =
-        DURATION_SWITCH_TARGETS.find((duration) => duration !== currentDuration) ?? DURATION_SWITCH_TARGETS[0];
+      targetDuration = getDurationSwitchTarget(currentDuration);
 
+      test.expect(targetDuration).not.toBe(currentDuration);
       await homePage.clickDurationButton(targetDuration);
       await homePage.validateDurationSelected(targetDuration);
     });
@@ -78,14 +82,14 @@ test.describe("Proto Fleet - Dashboard", () => {
   }) => {
     await commonSteps.loginAsAdmin();
 
-    let currentDuration: string | null = null;
+    let currentDuration = "";
     let targetDuration = "7d";
 
     await test.step("Choose a different dashboard duration", async () => {
       currentDuration = await homePage.getSelectedDuration(FLEET_DURATIONS);
-      targetDuration =
-        DURATION_SWITCH_TARGETS.find((duration) => duration !== currentDuration) ?? DURATION_SWITCH_TARGETS[0];
+      targetDuration = getDurationSwitchTarget(currentDuration);
 
+      test.expect(targetDuration).not.toBe(currentDuration);
       await homePage.clickDurationButton(targetDuration);
       await homePage.validateDurationSelected(targetDuration);
     });

--- a/client/e2eTests/protoFleet/spec/dashboard.spec.ts
+++ b/client/e2eTests/protoFleet/spec/dashboard.spec.ts
@@ -28,7 +28,10 @@ test.describe("Proto Fleet - Dashboard", () => {
 
     await test.step("Validate setup prompt is not shown for the prepared fleet", async () => {
       await homePage.validateCompleteSetupTitleNotVisible();
+      await homePage.validateSetupTaskCardNotVisible("Authenticate miners");
+      await homePage.validateSetupTaskCardNotVisible("Configure pools");
       await homePage.validateAuthenticateMinersButtonNotVisible();
+      await homePage.validateConfigurePoolsButtonNotVisible();
       await homePage.validateDashboardPerformanceDisclaimerVisible();
     });
   });
@@ -60,6 +63,45 @@ test.describe("Proto Fleet - Dashboard", () => {
       await homePage.reloadPage();
       await homePage.validateHomePageOpened();
       await homePage.validateDurationSelected(targetDuration);
+      await homePage.validateDashboardPanelVisible("Hashrate");
+      await homePage.validateDashboardPanelVisible("Uptime");
+      await homePage.validateDashboardPanelVisible("Temperature");
+      await homePage.validateDashboardPanelVisible("Power");
+      await homePage.validateDashboardPanelVisible("Efficiency");
+    });
+  });
+
+  test("Dashboard duration selection persists after issue-card navigation", async ({
+    homePage,
+    minersPage,
+    commonSteps,
+  }) => {
+    await commonSteps.loginAsAdmin();
+
+    let currentDuration: string | null = null;
+    let targetDuration = "7d";
+
+    await test.step("Choose a different dashboard duration", async () => {
+      currentDuration = await homePage.getSelectedDuration(FLEET_DURATIONS);
+      targetDuration =
+        DURATION_SWITCH_TARGETS.find((duration) => duration !== currentDuration) ?? DURATION_SWITCH_TARGETS[0];
+
+      await homePage.clickDurationButton(targetDuration);
+      await homePage.validateDurationSelected(targetDuration);
+    });
+
+    await test.step("Navigate to miners from the Control Boards issue card", async () => {
+      await homePage.clickControlBoardsLink();
+      await minersPage.validateMinersPageOpened();
+      await minersPage.validateActiveFilter("Control board issue");
+    });
+
+    await test.step("Return home and validate dashboard state", async () => {
+      await minersPage.navigateToHomePage();
+      await homePage.validateHomePageOpened();
+      await homePage.validateDurationSelected(targetDuration);
+      await homePage.validateDashboardSectionVisible("Overview");
+      await homePage.validateDashboardSectionVisible("Performance");
       await homePage.validateDashboardPanelVisible("Hashrate");
       await homePage.validateDashboardPanelVisible("Uptime");
       await homePage.validateDashboardPanelVisible("Temperature");


### PR DESCRIPTION
## What changed
Adds Proto Fleet dashboard E2E coverage for the paired-fleet shell and duration persistence after refresh.

## Validation
- npx eslint e2eTests/protoFleet/pages/home.ts e2eTests/protoFleet/spec/dashboard.spec.ts
- npx playwright test spec/dashboard.spec.ts --project=desktop --no-deps
- npx playwright test spec/dashboard.spec.ts --project=mobile --no-deps