### PR TITLE
fix(client): hide no-pools callout on the Pools settings null state

### DIFF
--- a/client/src/protoOS/components/App/App.test.tsx
+++ b/client/src/protoOS/components/App/App.test.tsx
@@ -94,7 +94,9 @@ vi.mock("@/protoOS/components/NavigationMenu", () => ({
 }));
 
 vi.mock("@/protoOS/components/NoPoolsCallout", () => ({
-  default: () => null,
+  default: ({ arePoolsConfigured }: { arePoolsConfigured: boolean }) => (
+    <div data-testid="no-pools-callout" data-pools-configured={String(arePoolsConfigured)} />
+  ),
 }));
 
 vi.mock("@/protoOS/components/Power", () => ({
@@ -298,5 +300,43 @@ describe("App auth gating", () => {
     onDismiss();
 
     expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("hides the no-pools callout on the mining pools null state page", () => {
+    // The Pools page renders its own null state when no pools are configured
+    // ("Add up to 3 pools for your miner."). Surfacing the global "No mining
+    // pools configured" banner on top of it duplicates the empty-state
+    // message and CTA, so the App-level callout must defer to the page.
+    mocks.useLocation.mockReturnValue({ pathname: "/settings/mining-pools", state: null });
+    mocks.usePoolsInfoStore.mockReturnValue([]);
+
+    render(<App title="App" />);
+
+    expect(screen.queryByTestId("no-pools-callout")).not.toBeInTheDocument();
+  });
+
+  it("still shows the no-pools callout on other pages when no pools are configured", () => {
+    mocks.useLocation.mockReturnValue({ pathname: "/settings/general", state: null });
+    mocks.usePoolsInfoStore.mockReturnValue([]);
+
+    render(<App title="App" />);
+
+    const callout = screen.getByTestId("no-pools-callout");
+    expect(callout).toBeInTheDocument();
+    expect(callout).toHaveAttribute("data-pools-configured", "false");
+  });
+
+  it("shows the no-pools callout on the mining pools page when configured pools are all offline", () => {
+    // When pools ARE configured but every one is dead, the Pools page renders
+    // its normal edit UI rather than the null state — the lost-connection
+    // banner is still relevant context, so it should remain visible there.
+    mocks.useLocation.mockReturnValue({ pathname: "/settings/mining-pools", state: null });
+    mocks.usePoolsInfoStore.mockReturnValue([{ status: "Dead", url: "stratum+tcp://primary.example:3333" }]);
+
+    render(<App title="App" />);
+
+    const callout = screen.getByTestId("no-pools-callout");
+    expect(callout).toBeInTheDocument();
+    expect(callout).toHaveAttribute("data-pools-configured", "true");
   });
 });

--- a/client/src/protoOS/components/App/App.tsx
+++ b/client/src/protoOS/components/App/App.tsx
@@ -14,6 +14,7 @@ import DefaultContentLayout from "@/protoOS/components/ContentLayout/DefaultCont
 import { ContentLayoutProps } from "@/protoOS/components/ContentLayout/types";
 import { navigationMenuTypes } from "@/protoOS/components/NavigationMenu";
 import NoPoolsCallout from "@/protoOS/components/NoPoolsCallout";
+import { getNoPoolsCalloutState } from "@/protoOS/components/NoPoolsCallout/utility";
 import { WarnWakeDialog } from "@/protoOS/components/Power";
 import LoginModal from "@/protoOS/features/auth/components/LoginModal";
 import { isAuthRequiredPath } from "@/protoOS/routeAuth";
@@ -228,12 +229,15 @@ const App = ({
   const wakeDialog = useWakeDialog();
   const poolsInfo = usePoolsInfoStore();
 
-  const noPoolsLive = useMemo(
-    () => poolsInfo !== undefined && !poolsInfo?.find((pool) => /alive|active/i.test(pool?.status ?? "")),
-    [poolsInfo],
+  // Suppress the global "No mining pools configured" banner on the Pools
+  // page when it's already in its own null state — otherwise the user sees
+  // the same empty-state message and CTA twice.
+  const { arePoolsConfigured, shouldShowNoPoolsCallout } = useMemo(
+    () => getNoPoolsCalloutState(poolsInfo, pathname),
+    [poolsInfo, pathname],
   );
 
-  const hasVisibleCallout = isWarmingUp || isSleeping || noPoolsLive;
+  const hasVisibleCallout = isWarmingUp || isSleeping || shouldShowNoPoolsCallout;
 
   // ============================================================================
   // DERIVED FLAGS
@@ -381,7 +385,9 @@ const App = ({
           <AppLayout title={title} ContentLayout={ContentLayout} type={navigationMenuTypes.app}>
             {calloutTopSpacing && hasVisibleCallout ? <div className="pt-14 phone:pt-6 tablet:pt-6" /> : null}
             {isWarmingUp ? <WarmingUpCallout /> : <WakeCallout afterWake={afterWake} onWake={handleWake} />}
-            {noPoolsLive && !isWarmingUp ? <NoPoolsCallout arePoolsConfigured={!!poolsInfo?.[0]?.url} /> : null}
+            {shouldShowNoPoolsCallout && !isWarmingUp ? (
+              <NoPoolsCallout arePoolsConfigured={arePoolsConfigured} />
+            ) : null}
             {!isWarmingUp && !isSleeping && errors.errors?.length && !hideErrors ? <ErrorCallout /> : null}
             {children}
           </AppLayout>

--- a/client/src/protoOS/components/NoPoolsCallout/utility.test.ts
+++ b/client/src/protoOS/components/NoPoolsCallout/utility.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { getNoPoolsCalloutState } from "./utility";
+
+describe("NoPoolsCallout utility", () => {
+  it("does not show the callout while pool data is still loading", () => {
+    expect(getNoPoolsCalloutState(undefined, "/settings/general")).toEqual({
+      arePoolsConfigured: false,
+      noPoolsLive: false,
+      shouldShowNoPoolsCallout: false,
+    });
+  });
+
+  it("does not show the callout when a pool is live", () => {
+    expect(getNoPoolsCalloutState([{ status: "Dead" }, { status: "Active" }], "/settings/general")).toEqual({
+      arePoolsConfigured: false,
+      noPoolsLive: false,
+      shouldShowNoPoolsCallout: false,
+    });
+  });
+
+  it.each([
+    "/settings/mining-pools",
+    "/settings/mining-pools/",
+    "/miners/miner-1/settings/mining-pools",
+    "/miners/miner-1/settings/mining-pools/",
+    "/miners/miner%2F1/settings/mining-pools/",
+    "/SETTINGS/MINING-POOLS",
+  ])("hides the callout on the mining pools null state for %s", (pathname) => {
+    expect(getNoPoolsCalloutState([], pathname)).toEqual({
+      arePoolsConfigured: false,
+      noPoolsLive: true,
+      shouldShowNoPoolsCallout: false,
+    });
+  });
+
+  it.each(["/settings/mining-pools/extra", "/onboarding/mining-pool", "/groups/1/settings/mining-pools"])(
+    "shows the callout on non-mining-pools null state path %s",
+    (pathname) => {
+      expect(getNoPoolsCalloutState([], pathname)).toEqual({
+        arePoolsConfigured: false,
+        noPoolsLive: true,
+        shouldShowNoPoolsCallout: true,
+      });
+    },
+  );
+
+  it("shows the callout on the mining pools page when configured pools are inactive", () => {
+    expect(
+      getNoPoolsCalloutState(
+        [{ status: "Dead" }, { status: "Dead", url: "stratum+tcp://backup.example:3333" }],
+        "/miners/miner-1/settings/mining-pools",
+      ),
+    ).toEqual({
+      arePoolsConfigured: true,
+      noPoolsLive: true,
+      shouldShowNoPoolsCallout: true,
+    });
+  });
+});

--- a/client/src/protoOS/components/NoPoolsCallout/utility.ts
+++ b/client/src/protoOS/components/NoPoolsCallout/utility.ts
@@ -1,9 +1,15 @@
+import { matchPath } from "react-router-dom";
+
 import type { Pool } from "@/protoOS/api/generatedApi";
+import { settingsRouteMetadata } from "@/protoOS/routeAuth";
 
 type PoolCalloutInfo = Pick<Pool, "status" | "url">;
 
 const livePoolStatusPattern = /alive|active/i;
-const miningPoolsPathPattern = /^\/(?:miners\/[^/]+\/)?settings\/mining-pools$/i;
+const miningPoolsRoutePatterns = [
+  `/settings/${settingsRouteMetadata.miningPools.path}`,
+  `/miners/:id/settings/${settingsRouteMetadata.miningPools.path}`,
+];
 
 const normalizePathname = (pathname: string) => {
   const normalized = pathname.trim().replace(/\/+$/, "");
@@ -22,7 +28,13 @@ const hasConfiguredPools = (poolsInfo?: readonly PoolCalloutInfo[]) => {
   return poolsInfo?.some((pool) => !!pool?.url) ?? false;
 };
 
-const isMiningPoolsPath = (pathname: string) => miningPoolsPathPattern.test(normalizePathname(pathname));
+const isMiningPoolsPath = (pathname: string) => {
+  const normalizedPathname = normalizePathname(pathname);
+
+  return miningPoolsRoutePatterns.some((path) =>
+    matchPath({ path, caseSensitive: false, end: true }, normalizedPathname),
+  );
+};
 
 export const getNoPoolsCalloutState = (poolsInfo: readonly PoolCalloutInfo[] | undefined, pathname: string) => {
   const arePoolsConfigured = hasConfiguredPools(poolsInfo);

--- a/client/src/protoOS/components/NoPoolsCallout/utility.ts
+++ b/client/src/protoOS/components/NoPoolsCallout/utility.ts
@@ -1,0 +1,36 @@
+import type { Pool } from "@/protoOS/api/generatedApi";
+
+type PoolCalloutInfo = Pick<Pool, "status" | "url">;
+
+const livePoolStatusPattern = /alive|active/i;
+const miningPoolsPathPattern = /^\/(?:miners\/[^/]+\/)?settings\/mining-pools$/i;
+
+const normalizePathname = (pathname: string) => {
+  const normalized = pathname.trim().replace(/\/+$/, "");
+  return normalized || "/";
+};
+
+const isPoolLive = (pool?: PoolCalloutInfo) => livePoolStatusPattern.test(pool?.status ?? "");
+
+const hasLivePool = (poolsInfo?: readonly PoolCalloutInfo[]) => poolsInfo?.some(isPoolLive) ?? false;
+
+const hasNoLivePools = (poolsInfo?: readonly PoolCalloutInfo[]) => {
+  return poolsInfo !== undefined && !hasLivePool(poolsInfo);
+};
+
+const hasConfiguredPools = (poolsInfo?: readonly PoolCalloutInfo[]) => {
+  return poolsInfo?.some((pool) => !!pool?.url) ?? false;
+};
+
+const isMiningPoolsPath = (pathname: string) => miningPoolsPathPattern.test(normalizePathname(pathname));
+
+export const getNoPoolsCalloutState = (poolsInfo: readonly PoolCalloutInfo[] | undefined, pathname: string) => {
+  const arePoolsConfigured = hasConfiguredPools(poolsInfo);
+  const noPoolsLive = hasNoLivePools(poolsInfo);
+
+  return {
+    arePoolsConfigured,
+    noPoolsLive,
+    shouldShowNoPoolsCallout: noPoolsLive && !(isMiningPoolsPath(pathname) && !arePoolsConfigured),
+  };
+};

--- a/client/src/protoOS/features/kpis/components/KpiLayout/KpiLayout.tsx
+++ b/client/src/protoOS/features/kpis/components/KpiLayout/KpiLayout.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { useTelemetry, useTimeSeries } from "@/protoOS/api";
 import { HashboardFieldType, MinerFieldType } from "@/protoOS/api/generatedApi";
 import NoPoolsCallout from "@/protoOS/components/NoPoolsCallout";
+import { getNoPoolsCalloutState } from "@/protoOS/components/NoPoolsCallout/utility";
 import TabMenu from "@/protoOS/features/kpis/components/TabMenu";
 import { usePoolsInfo } from "@/protoOS/store";
 import { useDuration, useSetDuration } from "@/protoOS/store";
@@ -13,6 +14,7 @@ const KpiLayout = () => {
   const poolsInfo = usePoolsInfo();
   const duration = useDuration();
   const setDuration = useSetDuration();
+  const { pathname } = useLocation();
 
   // Get latest miner level telemetry fo tabnav summary
   useTelemetry({ level: ["miner"] });
@@ -45,18 +47,15 @@ const KpiLayout = () => {
     poll: true,
   });
 
-  const noPoolsLive = useMemo(() => {
-    return (
-      poolsInfo !== undefined &&
-      // TODO: remove alive when cgminer is removed
-      !poolsInfo?.find((pool) => /alive|active/i.test(pool?.status ?? ""))
-    );
-  }, [poolsInfo]);
+  const { arePoolsConfigured, shouldShowNoPoolsCallout } = useMemo(
+    () => getNoPoolsCalloutState(poolsInfo, pathname),
+    [poolsInfo, pathname],
+  );
 
   return (
     <ErrorBoundary>
       <div className="p-14 phone:p-6 tablet:p-10">
-        {noPoolsLive ? <NoPoolsCallout arePoolsConfigured={!!poolsInfo?.[0]?.url} /> : null}
+        {shouldShowNoPoolsCallout ? <NoPoolsCallout arePoolsConfigured={arePoolsConfigured} /> : null}
 
         <div className="relative flex h-[calc(100vh-theme(spacing.36))] min-h-[800px] flex-col phone:min-h-[1000px]">
           <div className="flex items-center pb-6">


### PR DESCRIPTION
## Summary

- Fixes #94. In Proto OS, the global "No mining pools configured." alert banner stacks on top of the Pools settings page when no pools are configured — the page already shows its own null-state card with the same CTA, so the banner duplicates the empty-state prompt.
- Centralized the visibility logic in a new pathname-aware helper (`getNoPoolsCalloutState`) and routed both layout-level consumers (`App`, `KpiLayout`) through it. The helper now derives the Pools settings match from `settingsRouteMetadata.miningPools.path` via `matchPath`, including the embedded `/miners/:id/...` route, so it stays aligned with router changes. The banner is suppressed only when the Pools page is in its null state; if pools are configured but every one is offline, the banner stays (that's a real connectivity error, not a null state).

## Test plan

- [x] `npx vitest run src/protoOS/components/App/App.test.tsx src/protoOS/components/NoPoolsCallout/utility.test.ts` — added a utility-level matrix and three App-level integration tests; 29/29 passing.
- [x] `npx tsc --noEmit` from `client/`.
- [x] `npx prettier --check` on the touched files.
- [x] `npx eslint --max-warnings 0` on the touched files.
- [ ] Manual check on a Proto OS device: with no pools configured, navigate to **Settings → Pools** and confirm only the page's own null state is shown; navigate to any other page and confirm the global banner still appears.
- [ ] Manual check on the Pools page with at least one configured-but-offline pool — banner should still surface there.

Made with [Cursor](https://cursor.com)