### PR TITLE
fix(client): stop authentication modal oscillating when reopening Edit pool

### DIFF
--- a/client/src/protoFleet/features/auth/components/AuthenticateFleetModal/AuthenticateFleetModal.tsx
+++ b/client/src/protoFleet/features/auth/components/AuthenticateFleetModal/AuthenticateFleetModal.tsx
@@ -77,15 +77,11 @@ const AuthenticateFleetModal = ({ open, purpose, onAuthenticated, onDismiss }: A
   );
 
   return (
-    <Modal
-      open={open}
-      title={title}
-      description="Contact your system administrator if you need access to edit settings."
-      onDismiss={onDismiss}
-      icon={null}
-      divider={false}
-      bodyClassName="-mt-2"
-    >
+    <Modal open={open} onDismiss={onDismiss} icon={null} divider={false} showHeader={false}>
+      <div className="mb-1 text-heading-300 text-text-primary">{title}</div>
+      <div className="mb-4 max-w-[600px] text-300 text-text-primary-70">
+        Contact your system administrator if you need access to edit settings.
+      </div>
       {errorMessage ? <Callout className="mb-4" intent="danger" prefixIcon={<Alert />} title={errorMessage} /> : null}
 
       <div className="flex flex-col gap-4" onKeyDown={handleKeyDown}>


### PR DESCRIPTION
## Summary

The fleet authentication modal oscillated up and down with a duplicated title when the user dismissed it and triggered **Edit pool** again. The same modal opened from **Edit worker name** was unaffected.

## Root cause

`Modal` renders a zero-height sentinel and watches it with an `IntersectionObserver` to decide whether to collapse the body title into the sticky header on scroll. The mechanism has a layout feedback loop: when the observer flips `isTitleCollapsed`, the header height changes, the sentinel shifts, and the observer flips it back.

Edit pool surfaced this because its `purpose` cycles through `null` on dismiss, which changes `Modal`'s `title` prop and re-fires the observer effect on each reopen. Edit worker name uses a hardcoded `purpose="workerNames"`, so `title` never changes and the observer effect never re-runs after first mount.

## Fix

Render the credential form's title and description as `Modal` children with `showHeader={false}`. With no `title` prop, `Modal`'s observer effect early-returns and no sentinel is rendered, so the credential form opts out of the title-collapse machinery entirely — no observer, nothing to oscillate.

This is a one-file change scoped to `AuthenticateFleetModal`.

## Follow-up opportunities

- **Consolidate auth modal instances.** `SingleMinerActionsMenu` and `MinerActionsMenu` each render a separate `<AuthenticateFleetModal purpose="workerNames">` alongside the shared pool/security instance. These can be consolidated into one shared instance by routing worker names through `useFleetAuthentication` / `startAuthentication`, removing duplicated state and JSX.
- **Fix `Modal`'s observer.** The latent `IntersectionObserver` layout feedback loop in `Modal` is left untouched here and can be addressed in a follow-up scoped to `Modal` itself.

## Test plan

- [x] `tsc --noEmit` clean
- [x] ESLint clean on changed file
- [x] `vitest` `MinerActionsMenu` / `useMinerActions` / `MinerList.modalFlow` suites green
- [x] Manual: select miners → Edit pool → Cancel → Edit pool again, modal opens cleanly without oscillating or duplicate title
- [ ] Manual: same flow for Manage security
- [ ] Manual: Edit worker name still works