### PR TITLE
Add General Settings E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/README.md
+++ b/client/e2eTests/protoFleet/README.md
@@ -310,7 +310,7 @@ await responsePromise;
 
 ### Code Quality
 
-- Disable `playwright/expect-expect` ESLint rule only when page objects handle assertions
+- E2E spec files already disable `playwright/expect-expect` via the shared ESLint config when page objects handle assertions
 - Keep page objects focused on single pages or components
 - Reuse common functionality in `BasePage`
 

--- a/client/e2eTests/protoFleet/pages/settings.ts
+++ b/client/e2eTests/protoFleet/pages/settings.ts
@@ -6,6 +6,38 @@ export class SettingsPage extends BasePage {
     await this.page.locator('[data-testid="temperature-button"]').click();
   }
 
+  async clickThemeButton() {
+    const currentTheme = await this.getCurrentTheme();
+    await this.page.getByRole("button", { name: currentTheme, exact: true }).click();
+    await this.validateTitleInModal("Theme");
+  }
+
+  async selectTheme(theme: "System" | "Light" | "Dark") {
+    await this.page.getByTestId("modal").getByText(theme, { exact: true }).click();
+  }
+
+  async getCurrentTheme(): Promise<string> {
+    const themeButton = this.page
+      .getByRole("button", {
+        name: /^(System|Light|Dark)$/,
+      })
+      .first();
+    return await themeButton.innerText();
+  }
+
+  async validateCurrentTheme(theme: string) {
+    await expect(this.page.getByRole("button", { name: theme, exact: true }).first()).toBeVisible();
+  }
+
+  async validateBodyTheme(theme: "light" | "dark") {
+    await expect(this.page.locator("body")).toHaveAttribute("data-theme", theme);
+  }
+
+  async validateNetworkDetails(subnet: string, gateway: string) {
+    await expect(this.page.getByText(subnet, { exact: true })).toBeVisible();
+    await expect(this.page.getByText(gateway, { exact: true })).toBeVisible();
+  }
+
   async selectFahrenheit() {
     await this.page.getByTestId("fahrenheit-option").click();
   }

--- a/client/e2eTests/protoFleet/pages/settings.ts
+++ b/client/e2eTests/protoFleet/pages/settings.ts
@@ -1,6 +1,8 @@
 import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
+export type SettingsTheme = "System" | "Light" | "Dark";
+
 export class SettingsPage extends BasePage {
   async clickTemperatureButton() {
     await this.page.locator('[data-testid="temperature-button"]').click();
@@ -12,20 +14,26 @@ export class SettingsPage extends BasePage {
     await this.validateTitleInModal("Theme");
   }
 
-  async selectTheme(theme: "System" | "Light" | "Dark") {
+  async selectTheme(theme: SettingsTheme) {
     await this.page.getByTestId("modal").getByText(theme, { exact: true }).click();
   }
 
-  async getCurrentTheme(): Promise<string> {
+  async getCurrentTheme(): Promise<SettingsTheme> {
     const themeButton = this.page
       .getByRole("button", {
         name: /^(System|Light|Dark)$/,
       })
       .first();
-    return await themeButton.innerText();
+    const currentTheme = (await themeButton.innerText()).trim();
+
+    if (currentTheme === "System" || currentTheme === "Light" || currentTheme === "Dark") {
+      return currentTheme;
+    }
+
+    throw new Error(`Unexpected theme value: ${currentTheme}`);
   }
 
-  async validateCurrentTheme(theme: string) {
+  async validateCurrentTheme(theme: SettingsTheme) {
     await expect(this.page.getByRole("button", { name: theme, exact: true }).first()).toBeVisible();
   }
 

--- a/client/e2eTests/protoFleet/spec/00-onboarding.spec.ts
+++ b/client/e2eTests/protoFleet/spec/00-onboarding.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
 

--- a/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
+++ b/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { DEFAULT_INTERVAL, testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";

--- a/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
+++ b/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";

--- a/client/e2eTests/protoFleet/spec/activity.spec.ts
+++ b/client/e2eTests/protoFleet/spec/activity.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";

--- a/client/e2eTests/protoFleet/spec/addMinersValidation.spec.ts
+++ b/client/e2eTests/protoFleet/spec/addMinersValidation.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { expect, test } from "../fixtures/pageFixtures";
 
 test.describe("Proto Fleet - Add Miners Validation", () => {

--- a/client/e2eTests/protoFleet/spec/apiKeysSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/apiKeysSettings.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";

--- a/client/e2eTests/protoFleet/spec/auth.spec.ts
+++ b/client/e2eTests/protoFleet/spec/auth.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 

--- a/client/e2eTests/protoFleet/spec/generalSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/generalSettings.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";
@@ -39,6 +38,35 @@ test.describe("General Settings", () => {
     }
   });
 
+  test("Render network details from the fleet network info API", async ({
+    authPage,
+    settingsPage,
+    commonSteps,
+    page,
+  }) => {
+    await commonSteps.loginAsAdmin();
+
+    const networkInfoResponsePromise = page.waitForResponse((response) => response.url().includes("GetNetworkInfo"));
+
+    let subnet = "";
+    let gateway = "";
+
+    await test.step("Navigate to general settings and capture the network info response", async () => {
+      await authPage.navigateToSettingsPage();
+      const response = await networkInfoResponsePromise;
+      const body = await response.json();
+
+      subnet = body.networkInfo?.subnet ?? "";
+      gateway = body.networkInfo?.gateway ?? "";
+    });
+
+    await test.step("Validate network details are rendered", async () => {
+      test.expect(subnet).toBeTruthy();
+      test.expect(gateway).toBeTruthy();
+      await settingsPage.validateNetworkDetails(subnet, gateway);
+    });
+  });
+
   test("Set temperature format", async ({ authPage, settingsPage, minersPage, commonSteps }) => {
     await commonSteps.loginAsAdmin();
 
@@ -74,6 +102,50 @@ test.describe("General Settings", () => {
 
     await test.step("Verify miner temperature is displayed in Celsius", async () => {
       await minersPage.validateTemperatureUnitCelsius();
+    });
+  });
+
+  test("Theme preference persists after refresh", async ({ authPage, settingsPage, commonSteps }) => {
+    await commonSteps.loginAsAdmin();
+
+    let originalTheme = "";
+    let targetTheme: "Light" | "Dark" = "Dark";
+
+    const targetThemeByCurrentTheme: Record<string, "Light" | "Dark"> = {
+      Dark: "Light",
+      Light: "Dark",
+      System: "Dark",
+    };
+    const bodyThemeByTheme: Record<"Light" | "Dark", "light" | "dark"> = {
+      Light: "light",
+      Dark: "dark",
+    };
+
+    await test.step("Navigate to general settings and capture the current theme", async () => {
+      await authPage.navigateToSettingsPage();
+      originalTheme = await settingsPage.getCurrentTheme();
+      targetTheme = targetThemeByCurrentTheme[originalTheme] ?? "Dark";
+    });
+
+    await test.step("Change the theme to a deterministic value", async () => {
+      await settingsPage.clickThemeButton();
+      await settingsPage.selectTheme(targetTheme);
+      await settingsPage.clickDoneButton();
+      await settingsPage.validateCurrentTheme(targetTheme);
+      await settingsPage.validateBodyTheme(bodyThemeByTheme[targetTheme]);
+    });
+
+    await test.step("Refresh and validate theme persistence", async () => {
+      await settingsPage.reloadPage();
+      await settingsPage.validateCurrentTheme(targetTheme);
+      await settingsPage.validateBodyTheme(bodyThemeByTheme[targetTheme]);
+    });
+
+    await test.step("Restore the original theme", async () => {
+      await settingsPage.clickThemeButton();
+      await settingsPage.selectTheme(originalTheme as "System" | "Light" | "Dark");
+      await settingsPage.clickDoneButton();
+      await settingsPage.validateCurrentTheme(originalTheme);
     });
   });
 });

--- a/client/e2eTests/protoFleet/spec/generalSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/generalSettings.spec.ts
@@ -3,7 +3,7 @@ import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";
 import { AuthPage } from "../pages/auth";
 import { MinersPage } from "../pages/miners";
-import { SettingsPage } from "../pages/settings";
+import { SettingsPage, type SettingsTheme } from "../pages/settings";
 
 test.describe("General Settings", () => {
   test.beforeEach(async ({ page }) => {
@@ -108,10 +108,10 @@ test.describe("General Settings", () => {
   test("Theme preference persists after refresh", async ({ authPage, settingsPage, commonSteps }) => {
     await commonSteps.loginAsAdmin();
 
-    let originalTheme = "";
+    let originalTheme: SettingsTheme = "System";
     let targetTheme: "Light" | "Dark" = "Dark";
 
-    const targetThemeByCurrentTheme: Record<string, "Light" | "Dark"> = {
+    const targetThemeByCurrentTheme: Record<SettingsTheme, "Light" | "Dark"> = {
       Dark: "Light",
       Light: "Dark",
       System: "Dark",
@@ -143,7 +143,7 @@ test.describe("General Settings", () => {
 
     await test.step("Restore the original theme", async () => {
       await settingsPage.clickThemeButton();
-      await settingsPage.selectTheme(originalTheme as "System" | "Light" | "Dark");
+      await settingsPage.selectTheme(originalTheme);
       await settingsPage.clickDoneButton();
       await settingsPage.validateCurrentTheme(originalTheme);
     });

--- a/client/e2eTests/protoFleet/spec/groups.spec.ts
+++ b/client/e2eTests/protoFleet/spec/groups.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";

--- a/client/e2eTests/protoFleet/spec/minerIssues.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minerIssues.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { test } from "../fixtures/pageFixtures";
 import { IssueIcon } from "../helpers/testDataHelper";
 

--- a/client/e2eTests/protoFleet/spec/minersAddRemove.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersAddRemove.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";

--- a/client/e2eTests/protoFleet/spec/minersSleepWake.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersSleepWake.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { expect } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";

--- a/client/e2eTests/protoFleet/spec/navigation.spec.ts
+++ b/client/e2eTests/protoFleet/spec/navigation.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { test } from "../fixtures/pageFixtures";
 
 test.describe("Navigation", () => {

--- a/client/e2eTests/protoFleet/spec/schedulesSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/schedulesSettings.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";

--- a/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { generateRandomText, generateRandomUsername } from "../helpers/testDataHelper";

--- a/client/e2eTests/protoFleet/spec/teamAccounts.spec.ts
+++ b/client/e2eTests/protoFleet/spec/teamAccounts.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";

--- a/client/e2eTests/protoOS/spec/00-onboarding.spec.ts
+++ b/client/e2eTests/protoOS/spec/00-onboarding.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { generateRandomText } from "../helpers/testDataHelper";

--- a/client/e2eTests/protoOS/spec/dashboard.spec.ts
+++ b/client/e2eTests/protoOS/spec/dashboard.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { test } from "../fixtures/pageFixtures";
 
 test.describe("Home dashboard", () => {

--- a/client/e2eTests/protoOS/spec/diagnostics.spec.ts
+++ b/client/e2eTests/protoOS/spec/diagnostics.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { expect } from "@playwright/test";
 import { test } from "../fixtures/pageFixtures";
 

--- a/client/e2eTests/protoOS/spec/pools.spec.ts
+++ b/client/e2eTests/protoOS/spec/pools.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { generateRandomText } from "../helpers/testDataHelper";

--- a/client/e2eTests/protoOS/spec/power.spec.ts
+++ b/client/e2eTests/protoOS/spec/power.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { test } from "../fixtures/pageFixtures";
 
 test.describe("Power management", () => {

--- a/client/e2eTests/protoOS/spec/temperature.spec.ts
+++ b/client/e2eTests/protoOS/spec/temperature.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable playwright/expect-expect */
 import { test } from "../fixtures/pageFixtures";
 
 test.describe("Temperature unit switching", () => {

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -188,5 +188,11 @@ export default [
       "prettier/prettier": "error",
     },
   },
+  {
+    files: ["e2eTests/**/*.spec.ts"],
+    rules: {
+      "playwright/expect-expect": "off",
+    },
+  },
   eslintConfigPrettier,
 ];


### PR DESCRIPTION
## What changed
- add ProtoFleet General Settings E2E coverage for rendered network details
- add theme persistence coverage across reloads
- disable playwright/expect-expect for e2e spec files in the shared ESLint config and remove the redundant file-level disable from the touched spec

## Why
- General Settings only had temperature-format coverage before this
- the suite already relies heavily on page-object assertions, so the ESLint override makes the repo config match the existing spec style

## Validation
- ./node_modules/.bin/eslint eslint.config.js e2eTests/protoFleet/spec/generalSettings.spec.ts e2eTests/protoFleet/spec/minersActions.spec.ts e2eTests/protoOS/spec/00-onboarding.spec.ts
- npx playwright test spec/generalSettings.spec.ts --project=desktop --no-deps
- npx playwright test spec/generalSettings.spec.ts --project=mobile --no-deps