### PR TITLE
Switch to mobile first breakpoints rather than range based

### DIFF
--- a/client/src/protoFleet/components/App/App.tsx
+++ b/client/src/protoFleet/components/App/App.tsx
@@ -109,7 +109,7 @@ const App = ({ children, fullscreen }: AppProps) => {
       <div
         className={clsx(
           "fixed right-4 z-60 transition-[bottom] duration-200 phone:right-2",
-          isActionBarVisible ? "bottom-24 phone:bottom-30 tablet:bottom-30" : "bottom-4 phone:bottom-2",
+          isActionBarVisible ? "bottom-24 phone:bottom-30" : "bottom-4 phone:bottom-2",
         )}
       >
         <Toaster />

--- a/client/src/protoFleet/components/App/App.tsx
+++ b/client/src/protoFleet/components/App/App.tsx
@@ -109,7 +109,7 @@ const App = ({ children, fullscreen }: AppProps) => {
       <div
         className={clsx(
           "fixed right-4 z-60 transition-[bottom] duration-200 phone:right-2",
-          isActionBarVisible ? "bottom-24 phone:bottom-30" : "bottom-4 phone:bottom-2",
+          isActionBarVisible ? "bottom-24 phone:bottom-30 tablet-only:bottom-30" : "bottom-4 phone:bottom-2",
         )}
       >
         <Toaster />

--- a/client/src/protoFleet/components/AppLayout/AppLayout.tsx
+++ b/client/src/protoFleet/components/AppLayout/AppLayout.tsx
@@ -26,21 +26,20 @@ const AppLayoutContent = ({ children }: Props) => {
 
   return (
     <div className={clsx("absolute top-0 right-0 bottom-0 left-0", bgClass)}>
-      <div className="fixed top-0 z-50 h-fit w-16 phone:w-0 tablet:w-0 desktop:w-50">
+      <div className="fixed top-0 z-50 h-fit w-0 laptop:w-16 desktop:w-50">
         <NavigationMenu items={primaryNavItems} isVisible={isMenuOpen} closeMenu={() => setIsMenuOpen(false)} />
       </div>
 
       <div
-        className={`fixed top-0 right-0 bottom-[calc(100vh-theme(spacing.1)*15)] left-16 z-40 desktop:left-50 ${bgClass} phone:bottom-[calc(100vh-theme(spacing.1)*12)] phone:left-0 tablet:bottom-[calc(100vh-theme(spacing.1)*12)] tablet:left-0`}
+        className={`fixed top-0 right-0 bottom-[calc(100vh-theme(spacing.1)*12)] left-0 z-40 laptop:bottom-[calc(100vh-theme(spacing.1)*15)] laptop:left-16 desktop:left-50 ${bgClass}`}
       >
         <PageHeader isMenuOpen={isMenuOpen} openMenu={() => setIsMenuOpen(true)} schedulePillData={schedulePillData} />
       </div>
 
       <div
         className={clsx(
-          "fixed top-[calc(theme(spacing.1)*15)] right-0 bottom-0 left-16 z-20 overflow-auto desktop:left-50",
+          "fixed top-[calc(theme(spacing.1)*12)] right-0 bottom-0 left-0 z-20 overflow-auto laptop:top-[calc(theme(spacing.1)*15)] laptop:left-16 desktop:left-50",
           bgClass,
-          "phone:left-0 tablet:top-[calc(theme(spacing.1)*12)] tablet:left-0",
           showPhoneWidgets ? "phone:top-[calc(theme(spacing.1)*12+57px)]" : "phone:top-[calc(theme(spacing.1)*12)]",
         )}
       >

--- a/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
+++ b/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
@@ -12,11 +12,11 @@ import { useClickOutsideDismiss } from "@/shared/hooks/useClickOutsideDismiss";
 import { useEscapeDismiss } from "@/shared/hooks/useEscapeDismiss";
 
 const defaultPaneContainerClassName =
-  "flex min-h-[calc(100dvh-200px)] w-full flex-1 flex-col laptop:grid laptop:min-h-0 laptop:grid-cols-2 laptop:px-10 desktop:px-10 desktop:grid desktop:min-h-0 desktop:grid-cols-2";
+  "flex min-h-[calc(100dvh-200px)] w-full flex-1 flex-col laptop:grid laptop:min-h-0 laptop:grid-cols-2 laptop:px-10";
 const defaultPrimaryPaneClassName =
-  "order-2 flex flex-col phone:pl-6 tablet:pl-6 laptop:order-1 laptop:min-h-0 laptop:overflow-y-auto laptop:pl-1 desktop:order-1 desktop:min-h-0 desktop:overflow-y-auto desktop:pl-1";
+  "order-2 flex flex-col pl-6 laptop:order-1 laptop:min-h-0 laptop:overflow-y-auto laptop:pl-1";
 const defaultSecondaryPaneClassName =
-  "order-1 flex flex-col self-stretch bg-surface-overlay phone:mb-6 phone:max-h-[50vh] phone:overflow-y-auto tablet:mb-6 tablet:max-h-[50vh] tablet:overflow-y-auto laptop:order-2 laptop:min-h-0 laptop:rounded-xl laptop:pl-6 desktop:order-2 desktop:min-h-0 desktop:rounded-xl desktop:pl-6";
+  "order-1 flex max-h-[50vh] flex-col self-stretch overflow-y-auto bg-surface-overlay mb-6 laptop:order-2 laptop:min-h-0 laptop:max-h-none laptop:rounded-xl laptop:pl-6";
 
 interface FullScreenTwoPaneModalProps {
   open: boolean;
@@ -174,11 +174,11 @@ const FullScreenTwoPaneModal = ({
       testId="full-screen-two-pane-modal"
       className="!p-0"
       bodyClassName={clsx(
-        "flex h-full min-h-0 w-full flex-col overflow-auto bg-surface-base pb-6 laptop:overflow-hidden desktop:overflow-hidden",
+        "flex h-full min-h-0 w-full flex-col overflow-auto bg-surface-base pb-6 laptop:overflow-hidden",
         className,
       )}
     >
-      <div className="sticky top-0 z-10 mb-6 bg-surface-base px-6 pt-6 pb-4 phone:mb-0 tablet:mb-0 laptop:static desktop:static">
+      <div className="sticky top-0 z-10 mb-0 bg-surface-base px-6 pt-6 pb-4 laptop:static laptop:mb-6">
         <Header
           title={title}
           titleSize="text-heading-200"
@@ -193,11 +193,11 @@ const FullScreenTwoPaneModal = ({
           iconTextColor={isBusy ? "text-text-primary-30" : "text-text-primary"}
           inline
           centerButton
-          buttonsWrapperClassName="hidden laptop:block desktop:block"
+          buttonsWrapperClassName="hidden laptop:block"
           buttons={buttons}
         >
           {/* Mobile buttons: ellipsis + primary CTA */}
-          <div className="ml-3 shrink-0 laptop:hidden desktop:hidden">
+          <div className="ml-3 shrink-0 laptop:hidden">
             <ButtonGroup buttons={mobileButtons} variant={groupVariants.rightAligned} size={sizes.base} />
           </div>
         </Header>

--- a/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
+++ b/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
@@ -16,7 +16,7 @@ const defaultPaneContainerClassName =
 const defaultPrimaryPaneClassName =
   "order-2 flex flex-col pl-6 laptop:order-1 laptop:min-h-0 laptop:overflow-y-auto laptop:pl-1";
 const defaultSecondaryPaneClassName =
-  "order-1 flex max-h-[50vh] flex-col self-stretch overflow-y-auto bg-surface-overlay mb-6 laptop:order-2 laptop:min-h-0 laptop:max-h-none laptop:rounded-xl laptop:pl-6";
+  "order-1 flex max-h-[50vh] flex-col self-stretch overflow-y-auto bg-surface-overlay mb-6 laptop:order-2 laptop:mb-0 laptop:min-h-0 laptop:max-h-none laptop:overflow-visible laptop:rounded-xl laptop:pl-6";
 
 interface FullScreenTwoPaneModalProps {
   open: boolean;

--- a/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
+++ b/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
@@ -62,25 +62,20 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
     <nav
       aria-label="Main"
       className={clsx(
-        "group/nav flex min-h-screen w-60 flex-col justify-between bg-surface-base text-text-primary-70",
+        "group/nav absolute top-0 left-0 z-30 flex min-h-screen w-60 flex-col justify-between bg-surface-base text-text-primary-70",
         "laptop:absolute laptop:top-0 laptop:left-0 laptop:z-50 laptop:w-16 laptop:overflow-hidden laptop:hover:w-50 laptop:hover:border-r laptop:hover:border-core-primary-10 laptop:hover:bg-surface-base laptop:hover:shadow-lg",
         bg === "surface-5" ? "laptop:bg-surface-5 laptop:dark:bg-surface-base" : "laptop:bg-surface-base",
         "desktop:w-50 desktop:overflow-hidden desktop:border-r desktop:border-core-primary-10",
         bg === "surface-5" ? "desktop:bg-surface-5 desktop:dark:bg-surface-base" : "desktop:bg-surface-base",
-        "tablet:absolute tablet:z-30",
-        "phone:absolute phone:z-30",
         className,
       )}
     >
       <div className="flex flex-col items-start gap-1">
         {homeItem && homeItem.path ? (
           <div
-            className={clsx(
-              "flex h-15 w-full items-start px-3 py-3 laptop:h-13 laptop:items-center laptop:!pb-0 desktop:h-13 desktop:items-center desktop:!pb-0",
-              {
-                "border-b border-border-5": isPhone || isTablet,
-              },
-            )}
+            className={clsx("flex h-15 w-full items-start px-3 py-3 laptop:h-13 laptop:items-center laptop:!pb-0", {
+              "border-b border-border-5": isPhone || isTablet,
+            })}
           >
             <Link
               to={homeItem.path}

--- a/client/src/protoFleet/components/NullState.tsx
+++ b/client/src/protoFleet/components/NullState.tsx
@@ -13,8 +13,8 @@ interface NullStateProps {
 }
 
 const NullState = ({ icon, title, description, action, className, testId }: NullStateProps) => (
-  <div className={clsx("flex h-full flex-col justify-center p-6 sm:p-10", className)} data-testid={testId}>
-    <div className="flex h-full w-full flex-col justify-center rounded-xl bg-core-primary-5 px-6 py-10 sm:px-20 sm:py-10">
+  <div className={clsx("flex h-full flex-col justify-center p-6 tablet:p-10", className)} data-testid={testId}>
+    <div className="flex h-full w-full flex-col justify-center rounded-xl bg-core-primary-5 px-6 py-10 tablet:px-20 tablet:py-10">
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-4">
           {icon ? (

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -64,7 +64,7 @@ const PageHeader = ({ isMenuOpen, openMenu, schedulePillData }: PageHeaderProps)
 
   return (
     <>
-      <div className="flex h-12 items-center laptop:h-15 desktop:h-15">
+      <div className="flex h-12 items-center laptop:h-15">
         <div className="flex grow items-center px-4">
           <div className="flex grow items-center">
             {isPhone || isTablet ? (

--- a/client/src/protoFleet/features/activity/pages/ActivityPage.tsx
+++ b/client/src/protoFleet/features/activity/pages/ActivityPage.tsx
@@ -59,17 +59,17 @@ const ActivityPage = () => {
   const { exportCsv, isExportingCsv } = useExportActivity();
   const { eventTypes, scopeTypes, users } = useActivityFilterOptions();
 
-  const [hasLoaded, setHasLoaded] = useState(false);
   const hasStartedLoadingRef = useRef(false);
+  const hasLoadedRef = useRef(false);
   useEffect(() => {
     if (isLoading) {
       hasStartedLoadingRef.current = true;
-    } else if (hasStartedLoadingRef.current && !hasLoaded) {
-      setHasLoaded(true);
+    } else if (hasStartedLoadingRef.current) {
+      hasLoadedRef.current = true;
     }
-  }, [isLoading, hasLoaded]);
+  }, [isLoading]);
 
-  const isInitialLoad = isLoading && activities.length === 0 && !hasLoaded;
+  const isInitialLoad = isLoading && activities.length === 0 && !hasLoadedRef.current;
   const isLoadingMore = isLoading && activities.length > 0;
 
   const hasActiveFilters =
@@ -119,7 +119,7 @@ const ActivityPage = () => {
 
   return (
     <>
-      <div className="sticky left-0 z-3 px-10 pt-10 phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6">
+      <div className="sticky left-0 z-3 px-6 pt-6 laptop:px-10 laptop:pt-10">
         <div className="flex items-center justify-between pb-4">
           <Header title="Activity" titleSize="text-heading-300" />
           <Button
@@ -165,10 +165,10 @@ const ActivityPage = () => {
       </div>
 
       {error ? (
-        <Callout className="mx-10 mb-4 phone:mx-6 tablet:mx-6" intent="danger" prefixIcon={<Alert />} title={error} />
+        <Callout className="mx-6 mb-4 laptop:mx-10" intent="danger" prefixIcon={<Alert />} title={error} />
       ) : null}
 
-      <div className="p-10 pt-0 phone:p-6 phone:pt-0 tablet:p-6 tablet:pt-0">
+      <div className="p-6 pt-0 laptop:p-10 laptop:pt-0">
         <ActivityTable
           activities={activities}
           noDataElement={

--- a/client/src/protoFleet/features/dashboard/components/SectionHeading/SectionHeading.tsx
+++ b/client/src/protoFleet/features/dashboard/components/SectionHeading/SectionHeading.tsx
@@ -9,7 +9,7 @@ type SectionHeadingProps = {
 
 const SectionHeading = ({ heading, children, className }: SectionHeadingProps) => {
   return (
-    <div className={clsx("flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between", className)}>
+    <div className={clsx("flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between", className)}>
       <div className="text-emphasis-400 text-text-primary">{heading}</div>
       {children ? <div className="flex items-center">{children}</div> : null}
     </div>

--- a/client/src/protoFleet/features/dashboard/components/SegmentedMetricPanel/SegmentedMetricPanel.tsx
+++ b/client/src/protoFleet/features/dashboard/components/SegmentedMetricPanel/SegmentedMetricPanel.tsx
@@ -130,13 +130,10 @@ export const SegmentedMetricPanel = ({
 
   return (
     <div
-      className={`flex w-full flex-row overflow-hidden rounded-xl bg-surface-base dark:bg-core-primary-5 phone:flex-col phone:gap-6 tablet:flex-col tablet:gap-6 ${className || ""}`}
+      className={`flex w-full flex-col gap-6 overflow-hidden rounded-xl bg-surface-base laptop:flex-row laptop:gap-0 dark:bg-core-primary-5 ${className || ""}`}
     >
       {/* Left Panel: ChartWidget with SegmentedBarChart(s) */}
-      <ChartWidget
-        stats={stat}
-        className="w-1/2 rounded-none! bg-transparent dark:bg-transparent phone:w-full tablet:w-full"
-      >
+      <ChartWidget stats={stat} className="w-full rounded-none! bg-transparent laptop:w-1/2 dark:bg-transparent">
         <div className={`w-full ${isMultiDay ? "flex flex-row" : ""}`}>
           {processedChartData.map((dayData, index) => {
             // Use pre-calculated width for this chart
@@ -170,7 +167,7 @@ export const SegmentedMetricPanel = ({
       </ChartWidget>
 
       {/* Right Panel: Current Values Breakdown */}
-      <StatusBreakdownPanel items={currentBreakdown} className="w-1/2 phone:w-full tablet:w-full" />
+      <StatusBreakdownPanel items={currentBreakdown} className="w-full laptop:w-1/2" />
     </div>
   );
 };

--- a/client/src/protoFleet/features/dashboard/components/StatusBreakdownPanel/StatusBreakdownPanel.tsx
+++ b/client/src/protoFleet/features/dashboard/components/StatusBreakdownPanel/StatusBreakdownPanel.tsx
@@ -26,7 +26,7 @@ export const StatusBreakdownPanel = ({ items, className }: StatusBreakdownPanelP
   return (
     <div
       className={clsx(
-        "flex flex-col justify-between space-y-3 bg-transparent p-10 dark:bg-transparent phone:gap-4 phone:p-6 phone:pt-0 tablet:gap-4 tablet:p-6 tablet:pt-0",
+        "flex flex-col justify-between space-y-3 bg-transparent p-6 pt-0 laptop:p-10 laptop:pt-0 dark:bg-transparent",
         className,
       )}
     >

--- a/client/src/protoFleet/features/dashboard/pages/Dashboard.tsx
+++ b/client/src/protoFleet/features/dashboard/pages/Dashboard.tsx
@@ -89,10 +89,10 @@ const Dashboard = () => {
     <div className="h-full">
       {devicePaired ? (
         <div className="flex flex-col">
-          <CompleteSetup className="p-10 phone:p-6 tablet:p-6" />
+          <CompleteSetup className="p-6 laptop:p-10" />
 
           {/* Overview Section */}
-          <section className="p-10 phone:p-6 tablet:p-6">
+          <section className="p-6 laptop:p-10">
             <SectionHeading heading="Overview" />
             <div className="mt-6 flex flex-col gap-1">
               <FleetHealth
@@ -114,24 +114,24 @@ const Dashboard = () => {
           {/* Performance Section */}
           <section className="pb-6">
             <div ref={refs.vertical.start} />
-            <div className="sticky top-0 z-2 bg-surface-5 px-10 pt-10 pb-6 dark:bg-surface-base phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6">
+            <div className="sticky top-0 z-2 bg-surface-5 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10 dark:bg-surface-base">
               <SectionHeading heading="Performance">
                 <DurationSelector duration={duration} durations={fleetDurations} onSelect={setDuration} />
               </SectionHeading>
             </div>
 
-            <div className="flex flex-col gap-1 px-10 phone:px-6 tablet:px-6">
+            <div className="flex flex-col gap-1 px-6 laptop:px-10">
               <HashratePanel duration={duration} metrics={hashrateMetrics} />
               <UptimePanel duration={duration} uptimeStatusCounts={uptimeStatusCounts} />
               <TemperaturePanel duration={duration} temperatureStatusCounts={temperatureStatusCounts} />
 
-              <div className="grid grid-cols-2 gap-1 phone:grid-cols-1 tablet:grid-cols-1">
+              <div className="grid grid-cols-1 gap-1 laptop:grid-cols-2">
                 <PowerPanel duration={duration} metrics={powerMetrics} totalMiners={totalMiners} />
                 <EfficiencyPanel duration={duration} metrics={efficiencyMetrics} totalMiners={totalMiners} />
               </div>
             </div>
 
-            <p className="px-10 pt-6 text-300 text-text-primary phone:px-6 tablet:px-6">
+            <p className="px-6 pt-6 text-300 text-text-primary laptop:px-10">
               Some devices do not make all data available to Proto Fleet.
             </p>
             {/* eslint-disable-next-line react-hooks/refs -- ref object from useStickyState is passed to <div ref>; React writes .current during commit, not read during render */}
@@ -139,7 +139,7 @@ const Dashboard = () => {
           </section>
 
           {/* Privacy Policy */}
-          <footer className="px-10 pt-20 pb-6 text-300 phone:px-5 tablet:px-5">
+          <footer className="px-5 pt-20 pb-6 text-300 laptop:px-10">
             <p className="text-text-primary">
               Powerful mining tools. Built for decentralization.{" "}
               <span className="text-text-primary-50">

--- a/client/src/protoFleet/features/fleetManagement/components/ActionBar/ActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ActionBar/ActionBar.tsx
@@ -61,8 +61,8 @@ const ActionBar = ({
   const actionsClassName = clsx(
     "ml-auto flex items-center justify-end gap-3",
     "phone:col-start-2 phone:row-start-2 phone:ml-0 phone:justify-end",
-    "tablet:col-start-2 tablet:row-start-2 tablet:ml-0 tablet:justify-end",
-    selectionControls ? "" : "phone:col-span-2 tablet:col-span-2",
+    "tablet-only:col-start-2 tablet-only:row-start-2 tablet-only:ml-0 tablet-only:justify-end",
+    selectionControls ? "" : "phone:col-span-2 tablet-only:col-span-2",
   );
 
   return (
@@ -76,8 +76,8 @@ const ActionBar = ({
       )}
       data-testid="action-bar"
     >
-      <div className="flex w-[calc(100%-theme(spacing.24))] items-center gap-2 rounded-2xl bg-black px-3 py-3 shadow-300 dark:bg-surface-elevated-base phone:grid phone:w-[calc(100%-theme(spacing.4))] phone:grid-cols-[minmax(0,1fr),auto] phone:gap-x-3 phone:gap-y-1 phone:py-2 tablet:grid tablet:w-[calc(100%-theme(spacing.12))] tablet:grid-cols-[minmax(0,1fr),auto] tablet:gap-x-3 tablet:gap-y-1 tablet:py-2">
-        <div className="flex min-w-0 items-center gap-2 phone:col-span-2 tablet:col-span-2">
+      <div className="flex w-[calc(100%-theme(spacing.24))] items-center gap-2 rounded-2xl bg-black px-3 py-3 shadow-300 dark:bg-surface-elevated-base phone:grid phone:w-[calc(100%-theme(spacing.4))] phone:grid-cols-[minmax(0,1fr),auto] phone:gap-x-3 phone:gap-y-1 phone:py-2 tablet-only:grid tablet-only:w-[calc(100%-theme(spacing.12))] tablet-only:grid-cols-[minmax(0,1fr),auto] tablet-only:gap-x-3 tablet-only:gap-y-1 tablet-only:py-2">
+        <div className="flex min-w-0 items-center gap-2 phone:col-span-2 tablet-only:col-span-2">
           <Button
             className="bg-grayscale-white-10! text-grayscale-white-90!"
             prefixIcon={<DismissTiny />}
@@ -89,7 +89,7 @@ const ActionBar = ({
           <div className="text-emphasis-300 text-grayscale-white-90">{selectionText}</div>
         </div>
         {selectionControls ? (
-          <div className="flex flex-wrap items-center gap-2 phone:row-start-2 phone:ml-10 tablet:row-start-2 tablet:ml-10">
+          <div className="flex flex-wrap items-center gap-2 phone:row-start-2 phone:ml-10 tablet-only:row-start-2 tablet-only:ml-10">
             {selectionControls}
           </div>
         ) : null}

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -202,7 +202,7 @@ const Fleet = () => {
     <>
       {!unfilteredCountLoaded || totalUnfilteredMiners > 0 || totalMiners > 0 ? (
         <CompleteSetup
-          className="sticky left-0 mb-10 max-w-full px-10 pt-10 phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6"
+          className="sticky left-0 mb-10 max-w-full px-6 pt-6 laptop:px-10 laptop:pt-10"
           lastPairingCompletedAt={lastPairingCompletedAt}
           onRefetchMiners={refetchAll}
           onPairingCompleted={notifyPairingCompleted}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkRenamePreviewPanel.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkRenamePreviewPanel.tsx
@@ -22,7 +22,7 @@ const BulkRenamePreviewPanel = ({
   return (
     <>
       <div
-        className="flex min-h-16 items-center justify-center px-6 py-4 laptop:hidden desktop:hidden"
+        className="flex min-h-16 items-center justify-center px-6 py-4 laptop:hidden"
         data-testid="bulk-rename-mobile-preview"
       >
         {isLoadingPreview ? (
@@ -41,7 +41,7 @@ const BulkRenamePreviewPanel = ({
       </div>
 
       <div
-        className="hidden flex-col items-center justify-center gap-6 px-16 pt-6 pb-4 laptop:flex laptop:flex-1 desktop:flex desktop:flex-1"
+        className="hidden flex-col items-center justify-center gap-6 px-16 pt-6 pb-4 laptop:flex laptop:flex-1"
         data-testid="bulk-rename-desktop-preview"
       >
         {isLoadingPreview ? (

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkRenamePropertyForm.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/BulkRenamePropertyForm.tsx
@@ -118,7 +118,7 @@ const BulkRenamePropertyForm = ({
   );
 
   return (
-    <section className="flex flex-col gap-10 pr-6 pb-6 laptop:pr-10 laptop:pb-10 desktop:pr-10 desktop:pb-10">
+    <section className="flex flex-col gap-10 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
       {leadingContent}
 
       <div className="flex flex-col gap-3">
@@ -145,7 +145,7 @@ const BulkRenamePropertyForm = ({
 
       <div className="flex flex-col gap-3">
         <h2 className="text-emphasis-300 text-text-primary">{separatorTitle}</h2>
-        <div className="flex flex-wrap gap-x-4 gap-y-0 laptop:gap-6 desktop:gap-6">
+        <div className="flex flex-wrap gap-x-4 gap-y-0 laptop:gap-6">
           {Object.entries(bulkRenameSeparators).map(([separatorId, separator]) => (
             <label key={separatorId} className="flex h-12 items-center">
               <div className="flex w-8 items-center" data-testid={`bulk-rename-separator-${separatorId}`}>

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameOptionsModals/CustomPropertyOptionsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameOptionsModals/CustomPropertyOptionsModal.tsx
@@ -121,7 +121,7 @@ const OpenCustomPropertyOptionsModal = ({
         />
 
         {isStringAndCounter ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-4 tablet:grid-cols-2">
             <Input
               id="custom-property-prefix"
               label="Prefix (optional)"

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameOptionsModals/QualifierOptionsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameOptionsModals/QualifierOptionsModal.tsx
@@ -57,7 +57,7 @@ const OpenQualifierOptionsModal = ({
       mobileSaveTestId="qualifier-options-save-button-mobile"
     >
       <RenameOptionsModalBody>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 tablet:grid-cols-2">
           <Input
             id="qualifier-property-prefix"
             label="Prefix (optional)"

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameOptionsModals/RenameOptionsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameOptionsModals/RenameOptionsModal.tsx
@@ -70,7 +70,7 @@ const RenameOptionsModal = ({
 );
 
 export const RenameOptionsModalBody = ({ children }: RenameOptionsModalSectionProps) => {
-  return <div className="mt-6 flex flex-col gap-6 lg:mt-10">{children}</div>;
+  return <div className="mt-6 flex flex-col gap-6 laptop:mt-10">{children}</div>;
 };
 
 export const RenameOptionsModalPreview = ({ children }: RenameOptionsModalSectionProps) => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -761,8 +761,8 @@ const MinerList = ({
   if (showNullState) {
     return (
       <div className="h-full bg-surface-base">
-        <div className="h-full p-6 sm:p-10">
-          <div className="flex h-full w-full items-center rounded-xl bg-landing-page p-6 sm:p-20">
+        <div className="h-full p-6 tablet:p-10">
+          <div className="flex h-full w-full items-center rounded-xl bg-landing-page p-6 tablet:p-20">
             <div className="flex flex-col gap-12">
               <div className="flex flex-col gap-4">
                 <LogoAlt width="w-[48px]" />
@@ -791,14 +791,11 @@ const MinerList = ({
 
   return (
     <>
-      <div
-        ref={topRef}
-        className="sticky left-0 pt-10 phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6 laptop:px-10 desktop:px-10"
-      >
+      <div ref={topRef} className="sticky left-0 px-6 pt-6 laptop:px-10 laptop:pt-10">
         <h2 className="text-heading-300">{title}</h2>
       </div>
 
-      <div className="sticky left-0 text-300 text-text-primary-70 phone:px-6 tablet:px-6 laptop:px-10 desktop:px-10">
+      <div className="sticky left-0 px-6 text-300 text-text-primary-70 laptop:px-10">
         {hasActiveFilters && totalUnfilteredMiners !== undefined && totalMiners !== totalUnfilteredMiners
           ? `${totalMiners} of ${totalUnfilteredMiners} miners`
           : `${totalMiners ?? 0} miners`}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
@@ -85,7 +85,7 @@ const MinerListActionBar = ({
 
   return (
     <ActionBar
-      className="fixed right-0 bottom-4 left-16 z-20 phone:left-0 tablet:left-0 desktop:left-50"
+      className="fixed right-0 bottom-4 left-0 z-20 laptop:left-16 desktop:left-50"
       selectedItems={selectedMiners}
       selectionMode={selectionMode}
       totalCount={totalCount}

--- a/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
@@ -174,7 +174,7 @@ const GroupOverviewPage = () => {
 
   if (notFound) {
     return (
-      <div className="p-10 phone:p-6 tablet:p-6">
+      <div className="p-6 laptop:p-10">
         <h1 className="text-heading-300 text-text-primary">Group not found</h1>
         <p className="mt-2 text-300 text-text-primary-50">No group with the label &ldquo;{label}&rdquo; exists.</p>
       </div>
@@ -183,7 +183,7 @@ const GroupOverviewPage = () => {
 
   if (resolveError) {
     return (
-      <div className="p-10 phone:p-6 tablet:p-6">
+      <div className="p-6 laptop:p-10">
         <h1 className="text-heading-300 text-text-primary">Error loading group</h1>
         <p className="mt-2 text-300 text-text-primary-50">{resolveError}</p>
       </div>
@@ -194,7 +194,7 @@ const GroupOverviewPage = () => {
     <div className="h-full">
       <div className="flex flex-col">
         {/* Header */}
-        <div className="p-10 pb-0 phone:p-6 phone:pb-0 tablet:p-6 tablet:pb-0">
+        <div className="p-6 pb-0 laptop:p-10 laptop:pb-0">
           <Header
             title={label}
             titleSize="text-heading-300"
@@ -224,7 +224,7 @@ const GroupOverviewPage = () => {
         </div>
 
         {/* Overview Section */}
-        <section className="p-10 phone:p-6 tablet:p-6">
+        <section className="p-6 laptop:p-10">
           <div className="flex flex-col gap-1">
             <FleetHealth
               title="Miners"
@@ -249,8 +249,8 @@ const GroupOverviewPage = () => {
         {/* Performance Section */}
         <section className="pb-6">
           <div ref={refs.vertical.start} />
-          <div className="sticky top-0 z-2 bg-surface-5 px-10 pt-10 pb-6 dark:bg-surface-base phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="sticky top-0 z-2 bg-surface-5 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10 dark:bg-surface-base">
+            <div className="flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between">
               <div className="text-heading-200 text-text-primary">Performance</div>
               <div className="flex items-center gap-6 text-200 text-core-primary-50">
                 <div className="flex items-center gap-2">
@@ -306,7 +306,7 @@ const GroupOverviewPage = () => {
             </div>
           </div>
 
-          <div className="px-10 phone:px-6 tablet:px-6">
+          <div className="px-6 laptop:px-10">
             <DeviceSetPerformanceSection duration={duration} metrics={metrics} />
           </div>
           {/* eslint-disable-next-line react-hooks/refs -- ref object from useStickyState is passed to <div ref>; React writes .current during commit, not read during render */}

--- a/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
@@ -150,7 +150,7 @@ const GroupsPage = () => {
         />
       ) : (
         <>
-          <div className="sticky left-0 z-3 px-10 pt-10 phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6">
+          <div className="sticky left-0 z-3 px-6 pt-6 laptop:px-10 laptop:pt-10">
             <h1 className="pb-4 text-heading-300 text-text-primary">Groups</h1>
             <div className="flex flex-col gap-2 pb-6">
               <div className="flex items-center justify-between gap-2">
@@ -187,14 +187,9 @@ const GroupsPage = () => {
             </div>
           </div>
           {error ? (
-            <Callout
-              className="mx-10 mb-4 phone:mx-6 tablet:mx-6"
-              intent="danger"
-              prefixIcon={<Alert />}
-              title={error}
-            />
+            <Callout className="mx-6 mb-4 laptop:mx-10" intent="danger" prefixIcon={<Alert />} title={error} />
           ) : null}
-          <div className="p-10 pt-0 phone:p-6 phone:pt-0 tablet:p-6 tablet:pt-0">
+          <div className="p-6 pt-0 laptop:p-10 laptop:pt-0">
             <DeviceSetList
               deviceSets={groups}
               statsMap={statsMap}

--- a/client/src/protoFleet/features/kpis/components/FleetErrors/FleetErrors.tsx
+++ b/client/src/protoFleet/features/kpis/components/FleetErrors/FleetErrors.tsx
@@ -24,7 +24,7 @@ const FleetErrors = ({
   const suffix = extraFilterParams ? `&${extraFilterParams}` : "";
   return (
     <div className={className}>
-      <div className="grid grid-cols-4 gap-1 phone:grid-cols-1 tablet:grid-cols-2">
+      <div className="grid grid-cols-1 gap-1 tablet:grid-cols-2 laptop:grid-cols-4">
         <ComponentErrors
           icon={<ControlBoard />}
           heading="Control Boards"

--- a/client/src/protoFleet/features/onboarding/components/Welcome/WelcomePage.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Welcome/WelcomePage.tsx
@@ -101,8 +101,8 @@ const WelcomePage = () => {
         </div>
       ) : (
         <div className="flex h-screen flex-1 bg-surface-base">
-          <div className="flex h-screen w-1/2 phone:w-full tablet:w-full">
-            <div className="mx-auto h-full py-10 phone:px-6 tablet:px-6">
+          <div className="flex h-screen w-full laptop:w-1/2">
+            <div className="mx-auto h-full px-6 py-10 laptop:px-0">
               <div className="flex h-full flex-col justify-center space-y-10">
                 <Logo className="text-text-primary" width="w-[86px]" />
 
@@ -133,7 +133,7 @@ const WelcomePage = () => {
               </div>
             </div>
           </div>
-          <div className="h-screen w-1/2 py-10 pr-10 phone:hidden tablet:hidden">
+          <div className="hidden h-screen w-1/2 py-10 pr-10 laptop:block">
             <div className="flex h-full flex-col justify-between rounded-3xl bg-landing-page">
               <div className="h-1/4 pt-10" />
               <div className="px-20">

--- a/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/MinersPane.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/AssignMinersModal/MinersPane.tsx
@@ -300,8 +300,8 @@ export default function MinersPane({
     <div className="flex flex-col gap-4 pt-4 pr-4 pb-4">
       <div className="flex flex-col gap-3">
         <h3 className="text-emphasis-300 text-text-primary">Assign miners</h3>
-        <div className="scrollbar-hide flex items-center gap-2 overflow-x-auto phone:w-[calc(100%+48px)] phone:-translate-x-6 tablet:w-[calc(100%+48px)] tablet:-translate-x-6">
-          <div className="flex shrink-0 items-center gap-1 phone:pl-6 tablet:pl-6">
+        <div className="scrollbar-hide flex items-center gap-2 overflow-x-auto phone:w-[calc(100%+48px)] phone:-translate-x-6 tablet-only:w-[calc(100%+48px)] tablet-only:-translate-x-6">
+          <div className="flex shrink-0 items-center gap-1 phone:pl-6 tablet-only:pl-6">
             {modeSegments.map((seg) => (
               <Button
                 key={seg.key}

--- a/client/src/protoFleet/features/rackManagement/components/RackHealthModule/RackHealthModule.tsx
+++ b/client/src/protoFleet/features/rackManagement/components/RackHealthModule/RackHealthModule.tsx
@@ -125,9 +125,9 @@ export const RackHealthModule = ({
   }, [hashingCount, sleepingCount, needsAttentionCount, offlineCount, rackFilterParam, navigate]);
 
   return (
-    <div className="flex w-full flex-row overflow-hidden rounded-xl bg-surface-base dark:bg-core-primary-5 phone:flex-col tablet:flex-col">
+    <div className="flex w-full flex-col overflow-hidden rounded-xl bg-surface-base laptop:flex-row dark:bg-core-primary-5">
       {/* Left Panel: Rack Grid */}
-      <div className="flex w-1/2 items-center justify-center p-10 phone:w-full phone:p-6 tablet:w-full tablet:p-6">
+      <div className="flex w-full items-center justify-center p-6 laptop:w-1/2 laptop:p-10">
         <RackDetailGrid
           rows={rows}
           cols={cols}
@@ -139,21 +139,21 @@ export const RackHealthModule = ({
 
       {/* Right Panel: Status Breakdown */}
       {isLoading ? (
-        <div className="flex w-1/2 flex-col justify-center gap-8 p-10 phone:w-full phone:p-6 phone:pt-0 tablet:w-full tablet:p-6 tablet:pt-0">
+        <div className="flex w-full flex-col justify-center gap-8 p-6 pt-0 laptop:w-1/2 laptop:p-10 laptop:pt-0">
           <SkeletonBar className="h-14 w-full" />
           <SkeletonBar className="h-14 w-full" />
           <SkeletonBar className="h-14 w-full" />
           <SkeletonBar className="h-14 w-full" />
         </div>
       ) : hasNoData ? (
-        <div className="flex w-1/2 flex-col justify-center gap-4 p-10 text-300 text-text-primary-50 phone:w-full phone:p-6 phone:pt-0 tablet:w-full tablet:p-6 tablet:pt-0">
+        <div className="flex w-full flex-col justify-center gap-4 p-6 pt-0 text-300 text-text-primary-50 laptop:w-1/2 laptop:p-10 laptop:pt-0">
           <span>Healthy: &mdash;</span>
           <span>Sleeping: &mdash;</span>
           <span>Needs Attention: &mdash;</span>
           <span>Offline: &mdash;</span>
         </div>
       ) : (
-        <StatusBreakdownPanel items={breakdownItems} className="w-1/2 phone:w-full tablet:w-full" />
+        <StatusBreakdownPanel items={breakdownItems} className="w-full laptop:w-1/2" />
       )}
     </div>
   );

--- a/client/src/protoFleet/features/rackManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/rackManagement/pages/RackOverviewPage.tsx
@@ -254,7 +254,7 @@ const RackOverviewPage = () => {
 
   if (notFound) {
     return (
-      <div className="p-10 phone:p-6 tablet:p-6">
+      <div className="p-6 laptop:p-10">
         <h1 className="text-heading-300 text-text-primary">Rack not found</h1>
         <p className="mt-2 text-300 text-text-primary-50">No rack with ID &ldquo;{rackIdParam}&rdquo; exists.</p>
       </div>
@@ -263,7 +263,7 @@ const RackOverviewPage = () => {
 
   if (resolveError) {
     return (
-      <div className="p-10 phone:p-6 tablet:p-6">
+      <div className="p-6 laptop:p-10">
         <h1 className="text-heading-300 text-text-primary">Error loading rack</h1>
         <p className="mt-2 text-300 text-text-primary-50">{resolveError}</p>
       </div>
@@ -274,7 +274,7 @@ const RackOverviewPage = () => {
     <div className="h-full">
       <div className="flex flex-col">
         {/* Header */}
-        <div className="p-10 pb-0 phone:p-6 phone:pb-0 tablet:p-6 tablet:pb-0">
+        <div className="p-6 pb-0 laptop:p-10 laptop:pb-0">
           <Header
             title={rack?.label ?? ""}
             titleSize="text-heading-300"
@@ -320,7 +320,7 @@ const RackOverviewPage = () => {
         </div>
 
         {/* Health Overview Section */}
-        <section className="p-10 phone:p-6 tablet:p-6">
+        <section className="p-6 laptop:p-10">
           <div className="flex flex-col gap-1">
             <RackHealthModule
               rows={rows}
@@ -347,8 +347,8 @@ const RackOverviewPage = () => {
         {/* Performance Section */}
         <section className="pb-6">
           <div ref={refs.vertical.start} />
-          <div className="sticky top-0 z-2 bg-surface-5 px-10 pt-10 pb-6 dark:bg-surface-base phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="sticky top-0 z-2 bg-surface-5 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10 dark:bg-surface-base">
+            <div className="flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between">
               <div className="text-heading-200 text-text-primary">Performance</div>
               <div className="flex items-center gap-6 text-200 text-core-primary-50">
                 <div className="flex items-center gap-2">
@@ -404,7 +404,7 @@ const RackOverviewPage = () => {
             </div>
           </div>
 
-          <div className="px-10 phone:px-6 tablet:px-6">
+          <div className="px-6 laptop:px-10">
             <DeviceSetPerformanceSection duration={duration} metrics={metrics} />
           </div>
           {/* eslint-disable-next-line react-hooks/refs -- ref object from useStickyState is passed to <div ref>; React writes .current during commit, not read during render */}

--- a/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
@@ -304,17 +304,17 @@ const RacksPage = () => {
 
   return (
     <div>
-      <div className="sticky left-0 z-3 px-10 pt-10 phone:px-6 phone:pt-6 tablet:px-6 tablet:pt-6">
+      <div className="sticky left-0 z-3 px-6 pt-6 laptop:px-10 laptop:pt-10">
         <h1 className="pb-4 text-heading-300 text-text-primary">Racks</h1>
         <div className="flex flex-col gap-2 pb-6">
           {/* Action button — full-width on tablet/phone */}
-          <div className="hidden phone:block tablet:block">
+          <div className="block laptop:hidden">
             <Button variant={variants.secondary} size={sizes.compact} onClick={() => setShowRackSettingsModal(true)}>
               Add rack
             </Button>
           </div>
           {/* View toggle — full width on tablet/phone */}
-          <div className="hidden phone:block tablet:block">
+          <div className="block laptop:hidden">
             <SegmentedControl
               key={`mobile-${racksViewMode}`}
               className="!w-full whitespace-nowrap [&>button]:flex-1"
@@ -328,7 +328,7 @@ const RacksPage = () => {
             />
           </div>
           {/* Desktop layout — single row with toggle + filters left, buttons right */}
-          <div className="flex items-center justify-between gap-2 phone:hidden tablet:hidden">
+          <div className="hidden items-center justify-between gap-2 laptop:flex">
             <div className="flex items-center gap-2">
               <SegmentedControl
                 key={`desktop-${racksViewMode}`}
@@ -369,7 +369,7 @@ const RacksPage = () => {
             </Button>
           </div>
           {/* Filters — shown separately on tablet/phone */}
-          <div className="hidden items-center gap-2 phone:flex tablet:flex">
+          <div className="flex items-center gap-2 laptop:hidden">
             <DropdownFilter
               title="Zone"
               options={allZones}
@@ -412,10 +412,10 @@ const RacksPage = () => {
         </div>
       </div>
       {error ? (
-        <Callout className="mx-10 mb-4 phone:mx-6 tablet:mx-6" intent="danger" prefixIcon={<Alert />} title={error} />
+        <Callout className="mx-6 mb-4 laptop:mx-10" intent="danger" prefixIcon={<Alert />} title={error} />
       ) : null}
       {racksViewMode === "list" ? (
-        <div className="overflow-x-auto p-10 pt-0 phone:p-6 phone:pt-0 tablet:p-6 tablet:pt-0">
+        <div className="overflow-x-auto p-6 pt-0 laptop:p-10 laptop:pt-0">
           <DeviceSetList
             deviceSets={racks}
             statsMap={statsMap}
@@ -437,7 +437,7 @@ const RacksPage = () => {
           />
         </div>
       ) : (
-        <div className="px-10 phone:px-6 tablet:px-6">
+        <div className="px-6 laptop:px-10">
           {isLoading && racks.length === 0 ? (
             <div className="flex items-center justify-center py-20">
               <ProgressCircular indeterminate />

--- a/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
@@ -663,10 +663,10 @@ const ScheduleModal = ({
           },
         ]}
         primaryPane={
-          <section className="flex flex-col gap-10 pr-6 pb-6 laptop:pr-10 laptop:pb-10 desktop:pr-10 desktop:pb-10">
+          <section className="flex flex-col gap-10 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
             <div className={sectionBodyClassName}>
               <div className={sectionTitleClassName}>Schedule details</div>
-              <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-4 tablet:grid-cols-2">
                 <Input
                   id="schedule-name"
                   label="Schedule name"
@@ -715,7 +715,7 @@ const ScheduleModal = ({
                 <>
                   <div
                     className={clsx("grid gap-4", {
-                      "md:grid-cols-2": values.frequency === "weekly" || values.frequency === "monthly",
+                      "tablet:grid-cols-2": values.frequency === "weekly" || values.frequency === "monthly",
                     })}
                   >
                     <Select
@@ -751,7 +751,7 @@ const ScheduleModal = ({
                     ) : null}
                   </div>
 
-                  <div className={clsx("grid gap-4", { "md:grid-cols-2": showPowerTargetWindow })}>
+                  <div className={clsx("grid gap-4", { "tablet:grid-cols-2": showPowerTargetWindow })}>
                     <Select
                       id="schedule-start-time"
                       label="Start time"
@@ -772,7 +772,7 @@ const ScheduleModal = ({
                     ) : null}
                   </div>
 
-                  <div className="grid gap-4 md:grid-cols-2">
+                  <div className="grid gap-4 tablet:grid-cols-2">
                     <DatePickerField
                       id="schedule-start-date"
                       label="Start date"
@@ -804,7 +804,7 @@ const ScheduleModal = ({
                   </div>
 
                   {values.endBehavior === "endDate" ? (
-                    <div className="grid gap-4 md:grid-cols-2">
+                    <div className="grid gap-4 tablet:grid-cols-2">
                       <DatePickerField
                         id="schedule-end-date"
                         label="End date"
@@ -826,7 +826,7 @@ const ScheduleModal = ({
                   ) : null}
                 </>
               ) : (
-                <div className="grid gap-4 md:grid-cols-2">
+                <div className="grid gap-4 tablet:grid-cols-2">
                   <DatePickerField
                     id="schedule-start-date"
                     label="Start date"
@@ -861,7 +861,7 @@ const ScheduleModal = ({
 
             <div className={sectionBodyClassName}>
               <div className={sectionTitleClassName}>Apply to</div>
-              <div className="grid gap-4 md:grid-cols-3">
+              <div className="grid gap-4 tablet:grid-cols-3">
                 <TargetSelectButton
                   label="Racks"
                   value={getTargetButtonLabel(validRackTargetCount, "rack")}

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulePreview.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulePreview.tsx
@@ -199,7 +199,7 @@ const SchedulePreview = ({ values, isEditMode = false }: SchedulePreviewProps) =
 
   return (
     <>
-      <div className="flex min-h-16 items-center justify-center px-6 py-4 laptop:hidden desktop:hidden">
+      <div className="flex min-h-16 items-center justify-center px-6 py-4 laptop:hidden">
         {!isReady ? (
           <div className="text-300 text-text-primary-50">Complete the schedule fields to preview the run.</div>
         ) : mobilePreviewRun ? (
@@ -211,7 +211,7 @@ const SchedulePreview = ({ values, isEditMode = false }: SchedulePreviewProps) =
         )}
       </div>
 
-      <div className="hidden flex-col justify-center px-16 pt-6 pb-4 laptop:flex laptop:flex-1 desktop:flex desktop:flex-1">
+      <div className="hidden flex-col justify-center px-16 pt-6 pb-4 laptop:flex laptop:flex-1">
         {!isReady ? (
           <div className="max-w-[420px] text-300 text-text-primary-70">
             Complete the date, time, and targeting fields to preview the schedule before saving.

--- a/client/src/protoOS/components/App/App.tsx
+++ b/client/src/protoOS/components/App/App.tsx
@@ -383,7 +383,7 @@ const App = ({
         ) : (
           // Normal mode: Render with AppLayout + callouts
           <AppLayout title={title} ContentLayout={ContentLayout} type={navigationMenuTypes.app}>
-            {calloutTopSpacing && hasVisibleCallout ? <div className="pt-14 phone:pt-6 tablet:pt-6" /> : null}
+            {calloutTopSpacing && hasVisibleCallout ? <div className="pt-6 laptop:pt-14" /> : null}
             {isWarmingUp ? <WarmingUpCallout /> : <WakeCallout afterWake={afterWake} onWake={handleWake} />}
             {shouldShowNoPoolsCallout && !isWarmingUp ? (
               <NoPoolsCallout arePoolsConfigured={arePoolsConfigured} />

--- a/client/src/protoOS/components/AppLayout/AppLayout.tsx
+++ b/client/src/protoOS/components/AppLayout/AppLayout.tsx
@@ -70,7 +70,7 @@ const AppLayout = ({
       </div>
       <div className="w-full">
         <PageHeader title={title} openMenu={() => setIsMenuOpen(true)} customButtons={customHeaderButtons} />
-        <div className="relative w-full pt-[60px] pl-60 phone:pt-[100px] phone:pl-0 tablet:pt-[100px] tablet:pl-0">
+        <div className="relative w-full pt-[100px] pl-0 laptop:pt-[60px] laptop:pl-60">
           <ErrorBoundary>
             <ContentLayout>{children}</ContentLayout>
           </ErrorBoundary>

--- a/client/src/protoOS/components/ContentLayout/DefaultContentLayout.tsx
+++ b/client/src/protoOS/components/ContentLayout/DefaultContentLayout.tsx
@@ -2,7 +2,7 @@ import { ContentLayoutProps } from "@/protoOS/components/ContentLayout/types";
 
 const DefaultContentLayout = ({ children }: ContentLayoutProps) => {
   return (
-    <div className="m-14 flex justify-center phone:m-6 tablet:m-6">
+    <div className="m-6 flex justify-center laptop:m-14">
       <div className="w-full max-w-[1280px]">{children}</div>
     </div>
   );

--- a/client/src/protoOS/components/ContentLayout/SettingsContentLayout.tsx
+++ b/client/src/protoOS/components/ContentLayout/SettingsContentLayout.tsx
@@ -2,8 +2,8 @@ import { ContentLayoutProps } from "@/protoOS/components/ContentLayout/types";
 
 const SettingsContentLayout = ({ children }: ContentLayoutProps) => {
   return (
-    <div className="m-14 flex justify-center phone:m-6 tablet:m-6">
-      <div className="container mx-auto h-full max-w-[640px] phone:w-full tablet:w-[584px] laptop:w-[608px]">
+    <div className="m-6 flex justify-center laptop:m-14">
+      <div className="container mx-auto h-full w-full max-w-[640px] tablet:w-[584px] laptop:w-[608px] desktop:w-full">
         {children}
       </div>
     </div>

--- a/client/src/protoOS/components/MiningPools/Pools.tsx
+++ b/client/src/protoOS/components/MiningPools/Pools.tsx
@@ -345,7 +345,7 @@ const Pools = ({ onChangePools, pools }: PoolsProps) => {
   if (configuredPools.length === 0) {
     return (
       <>
-        <div className="flex min-h-[60vh] w-full items-center rounded-xl bg-landing-page p-6 sm:p-20">
+        <div className="flex min-h-[60vh] w-full items-center rounded-xl bg-landing-page p-6 tablet:p-20">
           <div className="flex flex-col gap-6">
             <Header
               title="Pools"

--- a/client/src/protoOS/components/NavigationMenu/Navigation.tsx
+++ b/client/src/protoOS/components/NavigationMenu/Navigation.tsx
@@ -57,9 +57,8 @@ const Navigation = ({ ipAddressInfo, macInfo, minerNameInfo, onItemClick, versio
   return (
     <div
       className={clsx(
-        "flex h-full max-h-screen w-[240px] flex-col border-r border-border-5 bg-surface-base text-text-primary-70",
-        "tablet:absolute tablet:z-30 tablet:max-h-[calc(100vh-16px)] tablet:rounded-lg",
-        "overflow-auto phone:absolute phone:z-30 phone:max-h-[calc(100vh-16px)] phone:rounded-lg",
+        "absolute z-30 flex h-full max-h-[calc(100vh-16px)] w-[240px] flex-col overflow-auto rounded-lg border-r border-border-5 bg-surface-base text-text-primary-70",
+        "laptop:static laptop:z-auto laptop:max-h-screen laptop:rounded-none",
       )}
     >
       <div className="grow">

--- a/client/src/protoOS/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoOS/components/PageHeader/PageHeader.tsx
@@ -85,7 +85,7 @@ const PageHeader = ({ customButtons, openMenu, title }: PageHeaderProps) => {
 
   return (
     <div
-      className="fixed top-0 right-0 left-0 z-20 flex h-[60px] bg-surface-base phone:h-fit tablet:h-fit"
+      className="fixed top-0 right-0 left-0 z-20 flex h-fit bg-surface-base laptop:h-[60px]"
       data-testid="page-header"
     >
       {isPhone || isTablet ? (

--- a/client/src/protoOS/features/diagnostic/components/DiagnosticView/DiagnosticView.tsx
+++ b/client/src/protoOS/features/diagnostic/components/DiagnosticView/DiagnosticView.tsx
@@ -36,7 +36,7 @@ const NoFansEmptyState = () => (
 );
 
 const FansGrid = ({ occupiedSlots }: { occupiedSlots: Set<number> }) => (
-  <div className="grid gap-1 tablet:grid-cols-2 laptop:grid-cols-2 desktop:auto-cols-fr desktop:grid-flow-col desktop:grid-rows-2">
+  <div className="grid gap-1 tablet:grid-cols-2 desktop:auto-cols-fr desktop:grid-flow-col desktop:grid-rows-2">
     {Array.from({ length: TOTAL_FAN_SLOTS }, (_, i) => {
       const slot = i + 1;
       if (occupiedSlots.has(slot)) {
@@ -77,7 +77,7 @@ const HashboardsSection = () => {
 
   return (
     <ComponentSection title="Hashboards">
-      <div className="grid gap-1 tablet:grid-cols-2 laptop:grid-cols-2 desktop:grid-flow-col desktop:grid-cols-3 desktop:grid-rows-3">
+      <div className="grid gap-1 tablet:grid-cols-2 desktop:grid-flow-col desktop:grid-cols-3 desktop:grid-rows-3">
         {bayIndices
           .map((bayIndex) => {
             const serialsInBay = hashboardsByBay[bayIndex] || Array(slotsPerBay).fill(null);
@@ -111,7 +111,7 @@ const PsusSection = () => {
 
   return (
     <ComponentSection title="PSU">
-      <div className="grid gap-1 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid gap-1 tablet:grid-cols-2 desktop:grid-cols-3">
         {Array.from({ length: TOTAL_PSU_SLOTS }, (_, i) => {
           const slot = i + 1;
           if (occupiedSlots.has(slot)) {
@@ -132,7 +132,7 @@ const ControlBoardSection = () => {
 
   return (
     <ComponentSection title="Control Board">
-      <div className="grid gap-1 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid gap-1 tablet:grid-cols-2 desktop:grid-cols-3">
         <ControlBoardStatusCard />
       </div>
     </ComponentSection>
@@ -150,7 +150,7 @@ function DiagnosticView({ className }: DiagnosticViewProps) {
 
   return (
     <div className={`w-full space-y-6 ${className || ""}`}>
-      <div className="flex flex-col items-start gap-3 pb-6 sm:flex-row sm:items-center">
+      <div className="flex flex-col items-start gap-3 pb-6 tablet:flex-row tablet:items-center">
         <div className="grow text-heading-300">Diagnostics</div>
         <ComponentSelector selectedComponent={selectedComponent} onSelect={setSelectedComponent} />
       </div>

--- a/client/src/protoOS/features/diagnostic/components/HashboardTemperature/HashboardTemperature.tsx
+++ b/client/src/protoOS/features/diagnostic/components/HashboardTemperature/HashboardTemperature.tsx
@@ -50,8 +50,8 @@ const getStats = (
   ];
 };
 
-const containerPadX = "px-14 tablet:px-10 phone:px-6";
-const containerMarginX = "mx-14 tablet:mx-10 phone:mx-6";
+const containerPadX = "px-6 tablet:px-10 laptop:px-14";
+const containerMarginX = "mx-6 tablet:mx-10 laptop:mx-14";
 
 type HashboardTemperatureProps = {
   serial: string;

--- a/client/src/protoOS/features/kpis/components/KpiLayout/KpiLayout.tsx
+++ b/client/src/protoOS/features/kpis/components/KpiLayout/KpiLayout.tsx
@@ -54,16 +54,16 @@ const KpiLayout = () => {
 
   return (
     <ErrorBoundary>
-      <div className="p-14 phone:p-6 tablet:p-10">
+      <div className="p-6 tablet:p-10 laptop:p-14">
         {shouldShowNoPoolsCallout ? <NoPoolsCallout arePoolsConfigured={arePoolsConfigured} /> : null}
 
-        <div className="relative flex h-[calc(100vh-theme(spacing.36))] min-h-[800px] flex-col phone:min-h-[1000px]">
+        <div className="relative flex h-[calc(100vh-theme(spacing.36))] min-h-[1000px] flex-col laptop:min-h-[800px]">
           <div className="flex items-center pb-6">
             <div className="grow text-heading-300">Home</div>
             <DurationSelector className="h-fit" duration={duration} onSelect={setDuration} />
           </div>
 
-          <div className="pb-6 phone:pb-6">
+          <div className="pb-6">
             <TabMenu />
           </div>
           <ErrorBoundary>

--- a/client/src/protoOS/features/kpis/components/KpiLayout/KpiLayout.tsx
+++ b/client/src/protoOS/features/kpis/components/KpiLayout/KpiLayout.tsx
@@ -57,7 +57,7 @@ const KpiLayout = () => {
       <div className="p-6 tablet:p-10 laptop:p-14">
         {shouldShowNoPoolsCallout ? <NoPoolsCallout arePoolsConfigured={arePoolsConfigured} /> : null}
 
-        <div className="relative flex h-[calc(100vh-theme(spacing.36))] min-h-[1000px] flex-col laptop:min-h-[800px]">
+        <div className="relative flex h-[calc(100vh-theme(spacing.36))] min-h-[800px] flex-col phone:min-h-[1000px]">
           <div className="flex items-center pb-6">
             <div className="grow text-heading-300">Home</div>
             <DurationSelector className="h-fit" duration={duration} onSelect={setDuration} />

--- a/client/src/protoOS/features/kpis/components/KpiLineChart/KpiLineChart.tsx
+++ b/client/src/protoOS/features/kpis/components/KpiLineChart/KpiLineChart.tsx
@@ -107,13 +107,13 @@ const KpiLineChart = ({
 
   return (
     <>
-      <div className="scrollbar-hide w-[calc(100%+theme(space.28))] -translate-x-14 overflow-x-auto phone:w-[calc(100%+theme(space.12))] phone:-translate-x-6 tablet:w-[calc(100%+theme(space.20))] tablet:-translate-x-10">
+      <div className="scrollbar-hide w-[calc(100%+theme(space.12))] -translate-x-6 overflow-x-auto tablet:w-[calc(100%+theme(space.20))] tablet:-translate-x-10 laptop:w-[calc(100%+theme(space.28))] laptop:-translate-x-14">
         <HashboardSelector
           chartLines={chartLines}
           setActiveChartLines={setActiveChartLines}
           activeChartLines={activeChartLines}
           aggregateKey={aggregateKey}
-          className={"px-14 phone:px-6 tablet:px-10"}
+          className={"px-6 tablet:px-10 laptop:px-14"}
         />
       </div>
       <LineChart

--- a/client/src/protoOS/features/onboarding/components/Verify/Verify.tsx
+++ b/client/src/protoOS/features/onboarding/components/Verify/Verify.tsx
@@ -26,7 +26,7 @@ const Verify = ({ miner, className, handleContinueSetup }: VerifyProps) => {
           />
         </div>
         <div className="rounded-2xl bg-surface-10 px-5 pt-10 pb-7">
-          <div className="mx-auto sm:w-[600px]">
+          <div className="mx-auto tablet:w-[600px]">
             <div className="mx-auto w-fit">
               <Picture className="mb-2 max-w-[228px]" image={MinerImage} />
               <div className="text-center text-heading-100 text-text-primary-50">Proto Rack</div>

--- a/client/src/protoOS/hooks/useWakeMiner/useWakeMiner.ts
+++ b/client/src/protoOS/hooks/useWakeMiner/useWakeMiner.ts
@@ -63,6 +63,18 @@ export const useWakeMiner = ({ afterWake, onSuccess, onError }: UseWakeMinerProp
     intervalIdRef.current = newIntervalId;
   }, [fetchMiningStatus, setMiningStatus]);
 
+  const completeWake = useCallback(() => {
+    if (intervalIdRef.current) {
+      clearInterval(intervalIdRef.current);
+      intervalIdRef.current = undefined;
+    }
+    isWakingRef.current = false;
+    setShouldWake(false);
+    setPending(false);
+    afterWakeRef.current?.();
+    onSuccessRef.current?.();
+  }, []);
+
   // Handle dismissed login modal
   useEffect(() => {
     if (dismissedLoginModal) {
@@ -73,18 +85,10 @@ export const useWakeMiner = ({ afterWake, onSuccess, onError }: UseWakeMinerProp
 
   useEffect(() => {
     if (!isSleeping && isWakingRef.current) {
-      // Miner is awake - stop polling and reset state
-      if (intervalIdRef.current) {
-        clearInterval(intervalIdRef.current);
-        intervalIdRef.current = undefined;
-      }
-      isWakingRef.current = false;
-      setShouldWake(false);
-      setPending(false);
-      afterWakeRef.current?.();
-      onSuccessRef.current?.();
+      const timeoutId = setTimeout(completeWake, 0);
+      return () => clearTimeout(timeoutId);
     }
-  }, [isSleeping]);
+  }, [isSleeping, completeWake]);
 
   const executeWake = useCallback(() => {
     setError(undefined);

--- a/client/src/protoOS/pages/MinerLogs/Logs.tsx
+++ b/client/src/protoOS/pages/MinerLogs/Logs.tsx
@@ -187,7 +187,7 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
       {logs.length ? (
         <>
           <div
-            className="sticky top-[60px] z-10 h-[58px] bg-surface-base phone:top-[100px] tablet:top-[100px]"
+            className="sticky top-[100px] z-10 h-[58px] bg-surface-base laptop:top-[60px]"
             onClick={handleClickSearchBar}
             ref={searchBarRef}
           >

--- a/client/src/shared/components/List/Filters/Filters.tsx
+++ b/client/src/shared/components/List/Filters/Filters.tsx
@@ -183,7 +183,7 @@ const Filters = <ItemType,>({
           return null;
         })}
         {headerControls ? (
-          <div className="ml-auto phone:mr-(--list-padding-phone) tablet:mr-(--list-padding-tablet) laptop:mr-(--list-padding-laptop) desktop:mr-(--list-padding-desktop)">
+          <div className="ml-auto tablet:mr-(--list-padding-tablet) laptop:mr-(--list-padding-laptop) desktop:mr-(--list-padding-desktop) phone:mr-(--list-padding-phone)">
             {headerControls}
           </div>
         ) : null}

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -638,7 +638,7 @@ const rowHoverOverlayClassList =
   "group-hover:bg-[linear-gradient(var(--color-surface-5),var(--color-surface-5))] dark:group-hover:bg-[linear-gradient(var(--color-core-primary-5),var(--color-core-primary-5))]";
 const rowDividerExtensionClassList = `pointer-events-none absolute top-0 left-full h-full w-[100vw] border-b border-border-5 bg-transparent ${rowHoverOverlayClassList}`;
 const thClassList = cellClassList + " py-3 text-emphasis-300 text-text-primary";
-const baseStickyClassList = "tablet:sticky laptop:sticky desktop:sticky z-1";
+const baseStickyClassList = "tablet:sticky z-1";
 const tdClassList = "text-left text-300";
 const tdPaddingClassList = "px-2 py-3";
 const stickyShadowMaskColors: Record<string, string> = {
@@ -1108,12 +1108,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
     tableClassName,
   ]);
 
-  const firstStickyClasses = clsx(
-    baseStickyClassList,
-    "tablet:left-0 laptop:left-0 desktop:left-0",
-    stickyBgColor,
-    paddingClasses,
-  );
+  const firstStickyClasses = clsx(baseStickyClassList, "tablet:left-0", stickyBgColor, paddingClasses);
 
   const secondStickyClasses = clsx(
     baseStickyClassList,

--- a/client/src/shared/components/Search/Search.tsx
+++ b/client/src/shared/components/Search/Search.tsx
@@ -60,7 +60,7 @@ const Search = ({ className, compact, onChange, initValue, shouldFocus }: Search
   }, [shouldFocus]);
 
   return (
-    <div className="w-80 phone:w-24">
+    <div className="w-24 tablet:w-80">
       <Input
         id={id}
         className={className}

--- a/client/src/shared/components/Setup/OnboardingLayout/OnboardingLayout.tsx
+++ b/client/src/shared/components/Setup/OnboardingLayout/OnboardingLayout.tsx
@@ -24,7 +24,7 @@ const OnboardingLayout = ({ children, steps, currentStep }: OnboardingLayoutProp
       <SetupHeader />
       <div className="relative px-6 pt-6 tablet:flex tablet:flex-row">
         {steps && currentStep ? (
-          <div className="absolute w-30 phone:relative phone:mb-4 tablet:relative">
+          <div className="relative mb-4 w-30 laptop:absolute laptop:mb-0">
             <ol className="flex flex-col gap-2 phone:flex-row">
               {Object.entries(steps).map(([key, step]) => (
                 <div key={key} className="flex h-8 items-center gap-2 text-emphasis-300 text-text-primary-50">

--- a/client/src/shared/components/TabMenu/TabMenu.tsx
+++ b/client/src/shared/components/TabMenu/TabMenu.tsx
@@ -45,7 +45,10 @@ const TabMenu = memo(({ items, basePath = "" }: TabMenuProps) => {
 
   return (
     <div
-      className={clsx("relative box-border grid w-full grid-cols-4 gap-1", "phone:grid-cols-2 phone:gap-2 phone:p-2")}
+      className={clsx(
+        "relative box-border grid w-full grid-cols-2 gap-2 p-2",
+        "tablet:grid-cols-4 tablet:gap-1 tablet:p-0",
+      )}
     >
       {tabElements}
     </div>

--- a/client/src/shared/styles/theme.css
+++ b/client/src/shared/styles/theme.css
@@ -43,35 +43,25 @@
 
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
-/* TODO, tw4 implements breakpoints mobile first (no min-widths)
-these custom variants are workaround for supporting our tw3 utility. 
-WOuld be best to switch over to mobile first stying  */
+/* Tablet/laptop/desktop use Tailwind's mobile-first breakpoints from the
+theme below. Phone and tablet-only cover exact-range layouts. */
 @custom-variant phone {
   @media (max-width: 631px) {
     @slot;
   }
 }
 
-@custom-variant tablet {
+@custom-variant tablet-only {
   @media (min-width: 632px) and (max-width: 959px) {
-    @slot;
-  }
-}
-
-@custom-variant laptop {
-  @media (min-width: 960px) and (max-width: 1279px) {
-    @slot;
-  }
-}
-
-@custom-variant desktop {
-  @media (min-width: 1280px) {
     @slot;
   }
 }
 
 @theme {
   --breakpoint-*: initial;
+  --breakpoint-tablet: 39.5rem;
+  --breakpoint-laptop: 60rem;
+  --breakpoint-desktop: 80rem;
 
   /**
    * Colors : light


### PR DESCRIPTION
## Summary
- Switch client breakpoint variants to mobile-first semantics for ProtoFleet, ProtoOS, and shared UI components
- Remove redundant range-based responsive utility pairs and disable unused default Tailwind screen variants
- Keep exact-range variants only where the layout still needs phone/tablet-specific behavior

## Test plan
- [ ] Verify ProtoFleet layouts at phone, tablet, laptop, and desktop widths
- [ ] Verify ProtoOS diagnostics, KPI, setup, and settings layouts across responsive widths
- [ ] Confirm action bars, toasts, filters, and tables do not overlap or regress on narrow screens

Closes #36
