### PR TITLE
docs(readme): document LAN access for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This starts the Go backend with Docker Compose and the Vite dev server for Proto
 
 #### LAN access
 
-By default, the Go backend is reachable on your LAN at `http://<your-ip>:4000` because the container publishes port `4000:4000` and binds to `0.0.0.0`. The Vite dev server, however, binds to `127.0.0.1` only. To expose it to other devices on your network (e.g. test the UI from a phone), start the client with an explicit host:
+By default, the Go backend is reachable on your LAN at `http://<your-ip>:4000` because the container publishes port `4000:4000` and binds to `0.0.0.0`. The Vite dev server, however, binds to localhost (loopback) by default. To expose it to other devices on your network (e.g. test the UI from a phone), start the client with an explicit host:
 
 ```bash
 cd client && npx vite --mode protoFleet --host 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ cd client && npx vite --mode protoFleet --host 0.0.0.0
 
 Then browse to `http://<your-ip>:5173/` from any device on the same network.
 
-Only do this on networks you trust. The dev server serves unminified source and proxies requests to your backend, so anyone reachable on the network can hit both. macOS will also prompt the firewall the first time Node binds to `0.0.0.0`.
+Only do this on networks you trust. The dev server serves unminified source and proxies requests to your backend, so anyone reachable on the network can hit both. On macOS, you may also see a firewall prompt the first time Node binds to `0.0.0.0`.
 
 ### Protocol Buffer Code Generation
 

--- a/README.md
+++ b/README.md
@@ -150,13 +150,19 @@ This starts the Go backend with Docker Compose and the Vite dev server for Proto
 
 #### LAN access
 
-By default, the Go backend is reachable on your LAN at `http://<your-ip>:4000` because the container publishes port `4000:4000` and binds to `0.0.0.0`. The Vite dev server, however, binds to localhost (loopback) by default. To expose it to other devices on your network (e.g. test the UI from a phone), start the client with an explicit host:
+The Go backend is already reachable on your LAN at `http://<your-ip>:4000` because the container publishes `4000:4000` and binds to `0.0.0.0`. The Vite dev server, however, binds to localhost (loopback) by default.
+
+To expose the client to other devices on your network (e.g. test the UI from a phone), **don't run `just dev`** — it would start the default localhost-bound Vite server. Start the backend and the LAN-bound client separately instead:
 
 ```bash
+# Terminal 1 — backend only
+cd server && just dev
+
+# Terminal 2 — client bound to all interfaces
 cd client && npx vite --mode protoFleet --host 0.0.0.0
 ```
 
-Then browse to `http://<your-ip>:5173/` from any device on the same network.
+Then browse to `http://<your-ip>:5173/` from any device on the same network. If you run the second command alongside `just dev`, Vite will detect that 5173 is busy and fall back to 5174 while the original localhost-only instance keeps holding 5173, so LAN access still fails.
 
 Only do this on networks you trust. The dev server serves unminified source and proxies requests to your backend, so anyone reachable on the network can hit both. On macOS, you may also see a firewall prompt the first time Node binds to `0.0.0.0`.
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ just dev
 
 This starts the Go backend with Docker Compose and the Vite dev server for ProtoFleet at http://localhost:5173.
 
+#### LAN access
+
+By default, the Go backend is reachable on your LAN at `http://<your-ip>:4000` because the container publishes port `4000:4000` and binds to `0.0.0.0`. The Vite dev server, however, binds to `127.0.0.1` only. To expose it to other devices on your network (e.g. test the UI from a phone), start the client with an explicit host:
+
+```bash
+cd client && npx vite --mode protoFleet --host 0.0.0.0
+```
+
+Then browse to `http://<your-ip>:5173/` from any device on the same network.
+
+Only do this on networks you trust. The dev server serves unminified source and proxies requests to your backend, so anyone reachable on the network can hit both. macOS will also prompt the firewall the first time Node binds to `0.0.0.0`.
+
 ### Protocol Buffer Code Generation
 
 After modifying definitions in `proto/`, regenerate generated clients and server code:


### PR DESCRIPTION
## Summary

- Document that the Go backend is already LAN-reachable on `:4000` via the published port mapping in `server/docker-compose.yaml`.
- Show the `npx vite ... --host 0.0.0.0` flag for exposing the Vite dev server, since `client/vite.config.ts` doesn't override Vite's default `127.0.0.1` bind.
- Note the trust trade-off (unminified source, proxied backend) and the macOS firewall prompt.

![WiFi connecting](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjFmNHl3ejI4NHF0aTQxOHN4NWNnNWhqODlneHFwbHEzbWhzdmF0dyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/SA5IWJfBbNCgLpqKjl/giphy.gif)

## Test Plan

- [ ] Render the README diff on the PR and confirm the new `LAN access` subsection sits between `Start Development` and `Protocol Buffer Code Generation`.
- [ ] Run `cd client && npx vite --mode protoFleet --host 0.0.0.0` and load `http://<host-ip>:5173/` from a second device to verify the documented command.
- [ ] No code touched, so no automated tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)