### PR TITLE
fix(server): dedupe per-device samples in temperature & uptime counts (#87)

### DIFF
--- a/server/internal/infrastructure/timescaledb/aggregation_test.go
+++ b/server/internal/infrastructure/timescaledb/aggregation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
 	modelsV2 "github.com/block/proto-fleet/server/internal/domain/telemetry/models/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsCumulativeMetric(t *testing.T) {
@@ -592,7 +593,7 @@ func TestCalculateTemperatureStatusCount_DedupesPerDevice(t *testing.T) {
 
 	// Two miners, each reporting many samples in the same bucket.
 	// Miner A: stable at 50°C (Ok). Miner B: stable at 85°C (Hot).
-	// Without dedup the per-sample counter returns 6 Ok + 6 Hot = 12 entries.
+	// Without dedup the per-sample counter returns 3 Ok + 3 Hot = 6 entries.
 	data := []modelsV2.DeviceMetrics{
 		{DeviceIdentifier: "miner-a", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 50}},
 		{DeviceIdentifier: "miner-a", Timestamp: now.Add(10 * time.Second), TempC: &modelsV2.MetricValue{Value: 50}},
@@ -692,4 +693,54 @@ func TestCalculateUptimeStatusCount_LatestHealthWins(t *testing.T) {
 func TestLatestSamplePerDevice_Empty(t *testing.T) {
 	assert.Nil(t, latestSamplePerDevice(nil))
 	assert.Nil(t, latestSamplePerDevice([]modelsV2.DeviceMetrics{}))
+}
+
+// TestCalculateTemperatureStatusCount_FallsBackToEarlierTempSample verifies
+// that a device whose latest sample is missing TempC is still counted using
+// its most recent sample that has TempC populated. Without this fallback the
+// chart would underreport device counts whenever telemetry temporarily drops
+// the temperature field.
+func TestCalculateTemperatureStatusCount_FallsBackToEarlierTempSample(t *testing.T) {
+	now := time.Now()
+
+	// miner-a: earlier sample has TempC=85 (Hot), latest sample has nil TempC.
+	// miner-b: only one sample, with TempC=50 (Ok).
+	data := []modelsV2.DeviceMetrics{
+		{DeviceIdentifier: "miner-a", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 85}},
+		{DeviceIdentifier: "miner-a", Timestamp: now.Add(30 * time.Second)}, // TempC nil
+		{DeviceIdentifier: "miner-b", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 50}},
+	}
+
+	result := calculateTemperatureStatusCount(data, now)
+
+	assert.Equal(t, int32(1), result.OkCount, "miner-b counted from its only sample")
+	assert.Equal(t, int32(1), result.HotCount, "miner-a counted from its earlier TempC sample")
+}
+
+func TestLatestSamplesForStatusCounts_Empty(t *testing.T) {
+	uptime, temp := latestSamplesForStatusCounts(nil)
+	assert.Nil(t, uptime)
+	assert.Nil(t, temp)
+}
+
+// TestLatestSamplesForStatusCounts_DivergentLatest covers the case where
+// uptime and temperature views diverge: a device's latest sample drops TempC
+// but still carries Health, so it appears in the uptime view but is
+// represented by an earlier sample in the temperature view.
+func TestLatestSamplesForStatusCounts_DivergentLatest(t *testing.T) {
+	now := time.Now()
+	data := []modelsV2.DeviceMetrics{
+		{DeviceIdentifier: "miner-a", Timestamp: now, Health: modelsV2.HealthHealthyActive, TempC: &modelsV2.MetricValue{Value: 70}},
+		{DeviceIdentifier: "miner-a", Timestamp: now.Add(30 * time.Second), Health: modelsV2.HealthHealthyActive},
+	}
+
+	uptime, temp := latestSamplesForStatusCounts(data)
+
+	require.Len(t, uptime, 1)
+	assert.Equal(t, now.Add(30*time.Second), uptime[0].Timestamp, "uptime view uses absolute latest")
+
+	require.Len(t, temp, 1)
+	require.NotNil(t, temp[0].TempC)
+	assert.Equal(t, 70.0, temp[0].TempC.Value, "temp view uses latest sample with TempC")
+	assert.Equal(t, now, temp[0].Timestamp)
 }

--- a/server/internal/infrastructure/timescaledb/aggregation_test.go
+++ b/server/internal/infrastructure/timescaledb/aggregation_test.go
@@ -582,3 +582,114 @@ func TestEstimateEnergyKWh(t *testing.T) {
 		})
 	}
 }
+
+// TestCalculateTemperatureStatusCount_DedupesPerDevice verifies that buckets
+// containing many samples per device (raw ~10s polling) count each device
+// once, not once per sample. Regression for issue #87.
+func TestCalculateTemperatureStatusCount_DedupesPerDevice(t *testing.T) {
+	now := time.Now()
+	bucket := now.Truncate(time.Minute)
+
+	// Two miners, each reporting many samples in the same bucket.
+	// Miner A: stable at 50°C (Ok). Miner B: stable at 85°C (Hot).
+	// Without dedup the per-sample counter returns 6 Ok + 6 Hot = 12 entries.
+	data := []modelsV2.DeviceMetrics{
+		{DeviceIdentifier: "miner-a", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 50}},
+		{DeviceIdentifier: "miner-a", Timestamp: now.Add(10 * time.Second), TempC: &modelsV2.MetricValue{Value: 50}},
+		{DeviceIdentifier: "miner-a", Timestamp: now.Add(20 * time.Second), TempC: &modelsV2.MetricValue{Value: 50}},
+		{DeviceIdentifier: "miner-b", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 85}},
+		{DeviceIdentifier: "miner-b", Timestamp: now.Add(10 * time.Second), TempC: &modelsV2.MetricValue{Value: 85}},
+		{DeviceIdentifier: "miner-b", Timestamp: now.Add(20 * time.Second), TempC: &modelsV2.MetricValue{Value: 85}},
+	}
+
+	result := calculateTemperatureStatusCount(data, bucket)
+
+	assert.Equal(t, int32(0), result.ColdCount)
+	assert.Equal(t, int32(1), result.OkCount, "miner-a should count once")
+	assert.Equal(t, int32(1), result.HotCount, "miner-b should count once")
+	assert.Equal(t, int32(0), result.CriticalCount)
+	assert.Equal(t, bucket, result.Timestamp)
+}
+
+// TestCalculateTemperatureStatusCount_UsesLatestSamplePerDevice verifies that
+// when a device crosses a threshold within a bucket, the latest sample wins
+// (represents the device's state at end of bucket).
+func TestCalculateTemperatureStatusCount_UsesLatestSamplePerDevice(t *testing.T) {
+	now := time.Now()
+	bucket := now.Truncate(time.Minute)
+
+	// miner-a starts Ok (50°C), warms into Critical (95°C) by end.
+	data := []modelsV2.DeviceMetrics{
+		{DeviceIdentifier: "miner-a", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 50}},
+		{DeviceIdentifier: "miner-a", Timestamp: now.Add(30 * time.Second), TempC: &modelsV2.MetricValue{Value: 75}},
+		{DeviceIdentifier: "miner-a", Timestamp: now.Add(50 * time.Second), TempC: &modelsV2.MetricValue{Value: 95}},
+	}
+
+	result := calculateTemperatureStatusCount(data, bucket)
+
+	assert.Equal(t, int32(0), result.OkCount)
+	assert.Equal(t, int32(0), result.HotCount)
+	assert.Equal(t, int32(1), result.CriticalCount, "latest sample (95°C) wins")
+}
+
+// TestCalculateTemperatureStatusCount_AllThresholds covers the 4 buckets.
+func TestCalculateTemperatureStatusCount_AllThresholds(t *testing.T) {
+	now := time.Now()
+	data := []modelsV2.DeviceMetrics{
+		{DeviceIdentifier: "cold-1", Timestamp: now, TempC: &modelsV2.MetricValue{Value: -5}},
+		{DeviceIdentifier: "ok-1", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 25}},
+		{DeviceIdentifier: "ok-2", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 69.9}},
+		{DeviceIdentifier: "hot-1", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 70}},
+		{DeviceIdentifier: "hot-2", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 89.9}},
+		{DeviceIdentifier: "crit-1", Timestamp: now, TempC: &modelsV2.MetricValue{Value: 90}},
+		{DeviceIdentifier: "no-temp", Timestamp: now}, // missing TempC: ignored
+	}
+
+	result := calculateTemperatureStatusCount(data, now)
+
+	assert.Equal(t, int32(1), result.ColdCount)
+	assert.Equal(t, int32(2), result.OkCount)
+	assert.Equal(t, int32(2), result.HotCount)
+	assert.Equal(t, int32(1), result.CriticalCount)
+}
+
+// TestCalculateUptimeStatusCount_DedupesPerDevice mirrors the temperature
+// regression — uptime status was overcounted the same way. Regression for
+// issue #87.
+func TestCalculateUptimeStatusCount_DedupesPerDevice(t *testing.T) {
+	now := time.Now()
+	bucket := now.Truncate(time.Minute)
+
+	data := []modelsV2.DeviceMetrics{
+		{DeviceIdentifier: "hashing-1", Timestamp: now, Health: modelsV2.HealthHealthyActive},
+		{DeviceIdentifier: "hashing-1", Timestamp: now.Add(10 * time.Second), Health: modelsV2.HealthHealthyActive},
+		{DeviceIdentifier: "hashing-1", Timestamp: now.Add(20 * time.Second), Health: modelsV2.HealthHealthyActive},
+		{DeviceIdentifier: "down-1", Timestamp: now, Health: modelsV2.HealthWarning},
+		{DeviceIdentifier: "down-1", Timestamp: now.Add(10 * time.Second), Health: modelsV2.HealthWarning},
+	}
+
+	result := calculateUptimeStatusCount(data, bucket)
+
+	assert.Equal(t, int32(1), result.HashingCount)
+	assert.Equal(t, int32(1), result.NotHashingCount)
+}
+
+// TestCalculateUptimeStatusCount_LatestHealthWins confirms a device that
+// recovers within the bucket is counted as hashing (latest sample wins).
+func TestCalculateUptimeStatusCount_LatestHealthWins(t *testing.T) {
+	now := time.Now()
+	data := []modelsV2.DeviceMetrics{
+		{DeviceIdentifier: "miner-a", Timestamp: now, Health: modelsV2.HealthWarning},
+		{DeviceIdentifier: "miner-a", Timestamp: now.Add(30 * time.Second), Health: modelsV2.HealthHealthyActive},
+	}
+
+	result := calculateUptimeStatusCount(data, now)
+
+	assert.Equal(t, int32(1), result.HashingCount)
+	assert.Equal(t, int32(0), result.NotHashingCount)
+}
+
+func TestLatestSamplePerDevice_Empty(t *testing.T) {
+	assert.Nil(t, latestSamplePerDevice(nil))
+	assert.Nil(t, latestSamplePerDevice([]modelsV2.DeviceMetrics{}))
+}

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -1157,10 +1157,14 @@ func (s *TimescaleTelemetryStore) aggregateMetrics(
 	for _, bucketTime := range bucketTimes {
 		bucketData := buckets[bucketTime]
 
-		tempCount := calculateTemperatureStatusCount(bucketData, bucketTime)
+		// Dedupe once per bucket — both status-count functions need the
+		// per-device latest sample, and raw buckets can be large.
+		latestPerDevice := latestSamplePerDevice(bucketData)
+
+		tempCount := temperatureStatusCountFromLatest(latestPerDevice, bucketTime)
 		tempCounts = append(tempCounts, tempCount)
 
-		uptimeCount := calculateUptimeStatusCount(bucketData, bucketTime)
+		uptimeCount := uptimeStatusCountFromLatest(latestPerDevice, bucketTime)
 		uptimeCounts = append(uptimeCounts, uptimeCount)
 
 		for _, measurementType := range measurementTypes {
@@ -1365,10 +1369,19 @@ func latestSamplePerDevice(data []modelsV2.DeviceMetrics) []modelsV2.DeviceMetri
 	return out
 }
 
+// calculateTemperatureStatusCount dedupes the bucket and counts each device
+// once. Prefer temperatureStatusCountFromLatest in hot loops where the caller
+// has already deduped.
 func calculateTemperatureStatusCount(data []modelsV2.DeviceMetrics, timestamp time.Time) models.TemperatureStatusCount {
+	return temperatureStatusCountFromLatest(latestSamplePerDevice(data), timestamp)
+}
+
+// temperatureStatusCountFromLatest classifies an already-deduped slice (one
+// DeviceMetrics per device, latest sample in the bucket).
+func temperatureStatusCountFromLatest(latestPerDevice []modelsV2.DeviceMetrics, timestamp time.Time) models.TemperatureStatusCount {
 	var cold, ok, hot, critical int32
 
-	for _, m := range latestSamplePerDevice(data) {
+	for _, m := range latestPerDevice {
 		if m.TempC == nil {
 			continue
 		}
@@ -1394,10 +1407,19 @@ func calculateTemperatureStatusCount(data []modelsV2.DeviceMetrics, timestamp ti
 	}
 }
 
+// calculateUptimeStatusCount dedupes the bucket and counts each device once.
+// Prefer uptimeStatusCountFromLatest in hot loops where the caller has
+// already deduped.
 func calculateUptimeStatusCount(data []modelsV2.DeviceMetrics, timestamp time.Time) models.UptimeStatusCount {
+	return uptimeStatusCountFromLatest(latestSamplePerDevice(data), timestamp)
+}
+
+// uptimeStatusCountFromLatest classifies an already-deduped slice (one
+// DeviceMetrics per device, latest sample in the bucket).
+func uptimeStatusCountFromLatest(latestPerDevice []modelsV2.DeviceMetrics, timestamp time.Time) models.UptimeStatusCount {
 	var hashing, notHashing int32
 
-	for _, m := range latestSamplePerDevice(data) {
+	for _, m := range latestPerDevice {
 		if m.Health == modelsV2.HealthHealthyActive {
 			hashing++
 		} else {

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -1343,10 +1343,32 @@ func parseMetricKindOrDefault(s string) modelsV2.MetricKind {
 	return kind
 }
 
+// latestSamplePerDevice returns one DeviceMetrics per device — the sample with
+// the latest Timestamp. Raw buckets contain many samples per device (~10s
+// polling cadence), so callers that classify devices into status categories
+// must dedupe first to avoid counting one device multiple times.
+func latestSamplePerDevice(data []modelsV2.DeviceMetrics) []modelsV2.DeviceMetrics {
+	if len(data) == 0 {
+		return nil
+	}
+	latest := make(map[string]modelsV2.DeviceMetrics, len(data))
+	for _, m := range data {
+		existing, ok := latest[m.DeviceIdentifier]
+		if !ok || m.Timestamp.After(existing.Timestamp) {
+			latest[m.DeviceIdentifier] = m
+		}
+	}
+	out := make([]modelsV2.DeviceMetrics, 0, len(latest))
+	for _, m := range latest {
+		out = append(out, m)
+	}
+	return out
+}
+
 func calculateTemperatureStatusCount(data []modelsV2.DeviceMetrics, timestamp time.Time) models.TemperatureStatusCount {
 	var cold, ok, hot, critical int32
 
-	for _, m := range data {
+	for _, m := range latestSamplePerDevice(data) {
 		if m.TempC == nil {
 			continue
 		}
@@ -1375,7 +1397,7 @@ func calculateTemperatureStatusCount(data []modelsV2.DeviceMetrics, timestamp ti
 func calculateUptimeStatusCount(data []modelsV2.DeviceMetrics, timestamp time.Time) models.UptimeStatusCount {
 	var hashing, notHashing int32
 
-	for _, m := range data {
+	for _, m := range latestSamplePerDevice(data) {
 		if m.Health == modelsV2.HealthHealthyActive {
 			hashing++
 		} else {

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -1157,14 +1157,15 @@ func (s *TimescaleTelemetryStore) aggregateMetrics(
 	for _, bucketTime := range bucketTimes {
 		bucketData := buckets[bucketTime]
 
-		// Dedupe once per bucket — both status-count functions need the
-		// per-device latest sample, and raw buckets can be large.
-		latestPerDevice := latestSamplePerDevice(bucketData)
+		// Dedupe once per bucket — both status-count functions need a
+		// per-device latest sample, with temperature using the latest
+		// sample that actually has TempC populated.
+		uptimeLatest, tempLatest := latestSamplesForStatusCounts(bucketData)
 
-		tempCount := temperatureStatusCountFromLatest(latestPerDevice, bucketTime)
+		tempCount := temperatureStatusCountFromLatest(tempLatest, bucketTime)
 		tempCounts = append(tempCounts, tempCount)
 
-		uptimeCount := uptimeStatusCountFromLatest(latestPerDevice, bucketTime)
+		uptimeCount := uptimeStatusCountFromLatest(uptimeLatest, bucketTime)
 		uptimeCounts = append(uptimeCounts, uptimeCount)
 
 		for _, measurementType := range measurementTypes {
@@ -1369,15 +1370,51 @@ func latestSamplePerDevice(data []modelsV2.DeviceMetrics) []modelsV2.DeviceMetri
 	return out
 }
 
+// latestSamplesForStatusCounts walks the bucket once and returns two deduped
+// views: the latest sample per device (for uptime), and the latest sample per
+// device that has a TempC reading (for temperature). The TempC-aware view
+// avoids dropping a device just because its very latest sample happens to be
+// missing a temperature — TempC reporting can be intermittent, while Health
+// is set on every sample.
+func latestSamplesForStatusCounts(data []modelsV2.DeviceMetrics) (uptime, temperature []modelsV2.DeviceMetrics) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	allLatest := make(map[string]modelsV2.DeviceMetrics, len(data))
+	tempLatest := make(map[string]modelsV2.DeviceMetrics, len(data))
+	for _, m := range data {
+		if existing, ok := allLatest[m.DeviceIdentifier]; !ok || m.Timestamp.After(existing.Timestamp) {
+			allLatest[m.DeviceIdentifier] = m
+		}
+		if m.TempC == nil {
+			continue
+		}
+		if existing, ok := tempLatest[m.DeviceIdentifier]; !ok || m.Timestamp.After(existing.Timestamp) {
+			tempLatest[m.DeviceIdentifier] = m
+		}
+	}
+	uptime = make([]modelsV2.DeviceMetrics, 0, len(allLatest))
+	for _, m := range allLatest {
+		uptime = append(uptime, m)
+	}
+	temperature = make([]modelsV2.DeviceMetrics, 0, len(tempLatest))
+	for _, m := range tempLatest {
+		temperature = append(temperature, m)
+	}
+	return uptime, temperature
+}
+
 // calculateTemperatureStatusCount dedupes the bucket and counts each device
-// once. Prefer temperatureStatusCountFromLatest in hot loops where the caller
-// has already deduped.
+// once, using its latest sample that has a TempC reading. Prefer
+// temperatureStatusCountFromLatest in hot loops where the caller has already
+// deduped.
 func calculateTemperatureStatusCount(data []modelsV2.DeviceMetrics, timestamp time.Time) models.TemperatureStatusCount {
-	return temperatureStatusCountFromLatest(latestSamplePerDevice(data), timestamp)
+	_, temp := latestSamplesForStatusCounts(data)
+	return temperatureStatusCountFromLatest(temp, timestamp)
 }
 
 // temperatureStatusCountFromLatest classifies an already-deduped slice (one
-// DeviceMetrics per device, latest sample in the bucket).
+// DeviceMetrics per device, latest sample with TempC populated).
 func temperatureStatusCountFromLatest(latestPerDevice []modelsV2.DeviceMetrics, timestamp time.Time) models.TemperatureStatusCount {
 	var cold, ok, hot, critical int32
 


### PR DESCRIPTION
## Summary

Fixes #87 — temperature bar chart sometimes showed more devices than configured (e.g., 5+ entries with 2 miners).

`calculateTemperatureStatusCount` and `calculateUptimeStatusCount` in `telemetry_store.go` iterated raw `DeviceMetrics` and incremented a category per sample. The raw-data path (≤24h queries) holds many samples per device per bucket from ~10s polling, so each miner was classified N times instead of once. Hourly/daily aggregate paths were already correct.

Fix: a small `latestSamplePerDevice` helper dedupes a bucket by `DeviceIdentifier`, keeping the most recent sample (which represents device state at end of bucket). Both status-count functions now consume the deduped slice.

## Test plan

- [x] `go test -short ./internal/infrastructure/timescaledb/...` passes (added 6 unit tests covering dedup, latest-wins, threshold boundaries, and missing TempC)
- [x] `golangci-lint` clean
- [ ] Manually verify temperature chart shows ≤ configured device count across the duration selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)