### PR TITLE
refactor(server): lift command preflight filtering into commandSvc

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -345,7 +345,7 @@ func start(config *Config) error {
 	// sees the same priority/manual-fallback semantics. Pre-pre-work this
 	// only ran inline inside the schedule processor, leaving manual
 	// SetPowerTarget calls free to race a running power-target schedule.
-	commandSvc.RegisterFilter(commandDomain.NewScheduleConflictFilter(scheduleStore, scheduleStore, collectionStore))
+	commandSvc.RegisterFilter(commandDomain.NewScheduleConflictFilter(scheduleStore))
 
 	scheduleProcessor := scheduleDomain.NewProcessor(scheduleStore, scheduleStore, collectionStore, commandSvc, activitySvc)
 	if err := scheduleProcessor.Start(context.Background()); err != nil {

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -340,6 +340,13 @@ func start(config *Config) error {
 	scheduleStore := sqlstores.NewSQLScheduleStore(conn)
 	scheduleSvc := scheduleDomain.NewService(scheduleStore, scheduleStore, scheduleStore, transactor, activitySvc)
 
+	// Register the schedule-conflict preflight filter on commandSvc so every
+	// caller (manual API, schedule processor, future curtailment reconciler)
+	// sees the same priority/manual-fallback semantics. Pre-pre-work this
+	// only ran inline inside the schedule processor, leaving manual
+	// SetPowerTarget calls free to race a running power-target schedule.
+	commandSvc.RegisterFilter(commandDomain.NewScheduleConflictFilter(scheduleStore, scheduleStore, collectionStore))
+
 	scheduleProcessor := scheduleDomain.NewProcessor(scheduleStore, scheduleStore, collectionStore, commandSvc, activitySvc)
 	if err := scheduleProcessor.Start(context.Background()); err != nil {
 		return fmt.Errorf("failed to start schedule processor: %w", err)

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -345,8 +345,8 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getRoleByNameStmt, err = db.PrepareContext(ctx, getRoleByName); err != nil {
 		return nil, fmt.Errorf("error preparing query GetRoleByName: %w", err)
 	}
-	if q.getRunningPowerTargetSchedulesStmt, err = db.PrepareContext(ctx, getRunningPowerTargetSchedules); err != nil {
-		return nil, fmt.Errorf("error preparing query GetRunningPowerTargetSchedules: %w", err)
+	if q.getRunningPowerTargetScheduleOverlapsStmt, err = db.PrepareContext(ctx, getRunningPowerTargetScheduleOverlaps); err != nil {
+		return nil, fmt.Errorf("error preparing query GetRunningPowerTargetScheduleOverlaps: %w", err)
 	}
 	if q.getScheduleStmt, err = db.PrepareContext(ctx, getSchedule); err != nil {
 		return nil, fmt.Errorf("error preparing query GetSchedule: %w", err)
@@ -1203,9 +1203,9 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getRoleByNameStmt: %w", cerr)
 		}
 	}
-	if q.getRunningPowerTargetSchedulesStmt != nil {
-		if cerr := q.getRunningPowerTargetSchedulesStmt.Close(); cerr != nil {
-			err = fmt.Errorf("error closing getRunningPowerTargetSchedulesStmt: %w", cerr)
+	if q.getRunningPowerTargetScheduleOverlapsStmt != nil {
+		if cerr := q.getRunningPowerTargetScheduleOverlapsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getRunningPowerTargetScheduleOverlapsStmt: %w", cerr)
 		}
 	}
 	if q.getScheduleStmt != nil {
@@ -1879,7 +1879,7 @@ type Queries struct {
 	getRackSlotsStmt                                    *sql.Stmt
 	getRoleByIDStmt                                     *sql.Stmt
 	getRoleByNameStmt                                   *sql.Stmt
-	getRunningPowerTargetSchedulesStmt                  *sql.Stmt
+	getRunningPowerTargetScheduleOverlapsStmt           *sql.Stmt
 	getScheduleStmt                                     *sql.Stmt
 	getScheduleByIDForProcessorStmt                     *sql.Stmt
 	getScheduleTargetsStmt                              *sql.Stmt
@@ -2098,7 +2098,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getRackSlotsStmt:                                    q.getRackSlotsStmt,
 		getRoleByIDStmt:                                     q.getRoleByIDStmt,
 		getRoleByNameStmt:                                   q.getRoleByNameStmt,
-		getRunningPowerTargetSchedulesStmt:                  q.getRunningPowerTargetSchedulesStmt,
+		getRunningPowerTargetScheduleOverlapsStmt:           q.getRunningPowerTargetScheduleOverlapsStmt,
 		getScheduleStmt:                                     q.getScheduleStmt,
 		getScheduleByIDForProcessorStmt:                     q.getScheduleByIDForProcessorStmt,
 		getScheduleTargetsStmt:                              q.getScheduleTargetsStmt,

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -258,6 +258,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getErrorByIDStmt, err = db.PrepareContext(ctx, getErrorByID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetErrorByID: %w", err)
 	}
+	if q.getFilteredDeviceIdentifiersStmt, err = db.PrepareContext(ctx, getFilteredDeviceIdentifiers); err != nil {
+		return nil, fmt.Errorf("error preparing query GetFilteredDeviceIdentifiers: %w", err)
+	}
 	if q.getFilteredDeviceIdsStmt, err = db.PrepareContext(ctx, getFilteredDeviceIds); err != nil {
 		return nil, fmt.Errorf("error preparing query GetFilteredDeviceIds: %w", err)
 	}
@@ -1055,6 +1058,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getErrorByIDStmt: %w", cerr)
 		}
 	}
+	if q.getFilteredDeviceIdentifiersStmt != nil {
+		if cerr := q.getFilteredDeviceIdentifiersStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getFilteredDeviceIdentifiersStmt: %w", cerr)
+		}
+	}
 	if q.getFilteredDeviceIdsStmt != nil {
 		if cerr := q.getFilteredDeviceIdsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getFilteredDeviceIdsStmt: %w", cerr)
@@ -1842,6 +1850,7 @@ type Queries struct {
 	getDistinctScopeTypesStmt                           *sql.Stmt
 	getErrorByErrorIDStmt                               *sql.Stmt
 	getErrorByIDStmt                                    *sql.Stmt
+	getFilteredDeviceIdentifiersStmt                    *sql.Stmt
 	getFilteredDeviceIdsStmt                            *sql.Stmt
 	getGroupLabelsForDevicesStmt                        *sql.Stmt
 	getKnownSubnetsStmt                                 *sql.Stmt
@@ -2060,6 +2069,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getDistinctScopeTypesStmt:                           q.getDistinctScopeTypesStmt,
 		getErrorByErrorIDStmt:                               q.getErrorByErrorIDStmt,
 		getErrorByIDStmt:                                    q.getErrorByIDStmt,
+		getFilteredDeviceIdentifiersStmt:                    q.getFilteredDeviceIdentifiersStmt,
 		getFilteredDeviceIdsStmt:                            q.getFilteredDeviceIdsStmt,
 		getGroupLabelsForDevicesStmt:                        q.getGroupLabelsForDevicesStmt,
 		getKnownSubnetsStmt:                                 q.getKnownSubnetsStmt,

--- a/server/generated/sqlc/device.sql.go
+++ b/server/generated/sqlc/device.sql.go
@@ -830,6 +830,62 @@ func (q *Queries) GetDeviceStatusForDeviceIdentifiers(ctx context.Context, devic
 	return items, nil
 }
 
+const getFilteredDeviceIdentifiers = `-- name: GetFilteredDeviceIdentifiers :many
+SELECT
+    d.device_identifier
+FROM device d
+JOIN device_pairing dp ON d.id = dp.device_id
+JOIN discovered_device dd ON d.discovered_device_id = dd.id
+LEFT JOIN device_status ds ON d.id = ds.device_id
+WHERE d.org_id = $1
+    AND dp.pairing_status::text = COALESCE($2::text, 'PAIRED')
+    AND d.deleted_at IS NULL
+    AND ($3::text IS NULL OR ds.status::text = $3::text)
+    AND ($4::text IS NULL OR dd.model = ANY(string_to_array($4, ',')))
+    AND ($5::text IS NULL OR dd.manufacturer = ANY(string_to_array($5, ',')))
+ORDER BY d.device_identifier
+`
+
+type GetFilteredDeviceIdentifiersParams struct {
+	OrgID              int64
+	PairingStatus      sql.NullString
+	DeviceStatus       sql.NullString
+	ModelFilter        sql.NullString
+	ManufacturerFilter sql.NullString
+}
+
+// Mirrors GetFilteredDeviceIds but returns device_identifier strings instead of
+// internal IDs. Used by command preflight filtering, which operates on
+// identifiers (the same primitive used by selectors and schedules).
+func (q *Queries) GetFilteredDeviceIdentifiers(ctx context.Context, arg GetFilteredDeviceIdentifiersParams) ([]string, error) {
+	rows, err := q.query(ctx, q.getFilteredDeviceIdentifiersStmt, getFilteredDeviceIdentifiers,
+		arg.OrgID,
+		arg.PairingStatus,
+		arg.DeviceStatus,
+		arg.ModelFilter,
+		arg.ManufacturerFilter,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var device_identifier string
+		if err := rows.Scan(&device_identifier); err != nil {
+			return nil, err
+		}
+		items = append(items, device_identifier)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getFilteredDeviceIds = `-- name: GetFilteredDeviceIds :many
 SELECT
     d.id as device_id

--- a/server/generated/sqlc/schedule.sql.go
+++ b/server/generated/sqlc/schedule.sql.go
@@ -204,8 +204,7 @@ JOIN requested r ON (
             WHERE dsm.org_id = s.org_id
               AND ds.org_id = s.org_id
               AND ds.deleted_at IS NULL
-              -- Match schedule target expansion semantics: rack/group targets
-              -- resolve by device_set ID, not by the stored target_type label.
+              -- Match expansion: rack/group targets resolve by device_set ID.
               AND dsm.device_set_id = CASE WHEN st.target_id ~ '^[0-9]+$' THEN st.target_id::bigint ELSE NULL END
               AND dsm.device_identifier = r.device_identifier
         )

--- a/server/generated/sqlc/schedule.sql.go
+++ b/server/generated/sqlc/schedule.sql.go
@@ -204,8 +204,9 @@ JOIN requested r ON (
             WHERE dsm.org_id = s.org_id
               AND ds.org_id = s.org_id
               AND ds.deleted_at IS NULL
+              -- Match schedule target expansion semantics: rack/group targets
+              -- resolve by device_set ID, not by the stored target_type label.
               AND dsm.device_set_id = CASE WHEN st.target_id ~ '^[0-9]+$' THEN st.target_id::bigint ELSE NULL END
-              AND dsm.device_set_type::text = st.target_type
               AND dsm.device_identifier = r.device_identifier
         )
     )

--- a/server/generated/sqlc/schedule.sql.go
+++ b/server/generated/sqlc/schedule.sql.go
@@ -183,47 +183,61 @@ func (q *Queries) GetMaxPriority(ctx context.Context, orgID int64) (int32, error
 	return max_priority, err
 }
 
-const getRunningPowerTargetSchedules = `-- name: GetRunningPowerTargetSchedules :many
-SELECT id, org_id, name, action, action_config, schedule_type, recurrence, start_date, start_time, end_time, end_date, timezone, status, priority, created_by, created_at, updated_at, deleted_at, last_run_at, next_run_at
-FROM schedule
-WHERE org_id = $1
-  AND status = 'running'
-  AND action = 'set_power_target'
-  AND deleted_at IS NULL
-ORDER BY priority, id
+const getRunningPowerTargetScheduleOverlaps = `-- name: GetRunningPowerTargetScheduleOverlaps :many
+WITH requested AS (
+    SELECT UNNEST($2::text[]) AS device_identifier
+)
+SELECT DISTINCT
+    s.id AS schedule_id,
+    s.priority AS schedule_priority,
+    r.device_identifier::text AS device_identifier
+FROM schedule s
+JOIN schedule_target st ON st.schedule_id = s.id
+JOIN requested r ON (
+    (st.target_type = 'miner' AND st.target_id = r.device_identifier)
+    OR (
+        st.target_type IN ('rack', 'group')
+        AND EXISTS (
+            SELECT 1
+            FROM device_set_membership dsm
+            JOIN device_set ds ON ds.id = dsm.device_set_id
+            WHERE dsm.org_id = s.org_id
+              AND ds.org_id = s.org_id
+              AND ds.deleted_at IS NULL
+              AND dsm.device_set_id = CASE WHEN st.target_id ~ '^[0-9]+$' THEN st.target_id::bigint ELSE NULL END
+              AND dsm.device_set_type::text = st.target_type
+              AND dsm.device_identifier = r.device_identifier
+        )
+    )
+)
+WHERE s.org_id = $1
+  AND s.status = 'running'
+  AND s.action = 'set_power_target'
+  AND s.deleted_at IS NULL
+ORDER BY s.priority, s.id, r.device_identifier
 `
 
-func (q *Queries) GetRunningPowerTargetSchedules(ctx context.Context, orgID int64) ([]Schedule, error) {
-	rows, err := q.query(ctx, q.getRunningPowerTargetSchedulesStmt, getRunningPowerTargetSchedules, orgID)
+type GetRunningPowerTargetScheduleOverlapsParams struct {
+	OrgID             int64
+	DeviceIdentifiers []string
+}
+
+type GetRunningPowerTargetScheduleOverlapsRow struct {
+	ScheduleID       int64
+	SchedulePriority int32
+	DeviceIdentifier string
+}
+
+func (q *Queries) GetRunningPowerTargetScheduleOverlaps(ctx context.Context, arg GetRunningPowerTargetScheduleOverlapsParams) ([]GetRunningPowerTargetScheduleOverlapsRow, error) {
+	rows, err := q.query(ctx, q.getRunningPowerTargetScheduleOverlapsStmt, getRunningPowerTargetScheduleOverlaps, arg.OrgID, pq.Array(arg.DeviceIdentifiers))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Schedule
+	var items []GetRunningPowerTargetScheduleOverlapsRow
 	for rows.Next() {
-		var i Schedule
-		if err := rows.Scan(
-			&i.ID,
-			&i.OrgID,
-			&i.Name,
-			&i.Action,
-			&i.ActionConfig,
-			&i.ScheduleType,
-			&i.Recurrence,
-			&i.StartDate,
-			&i.StartTime,
-			&i.EndTime,
-			&i.EndDate,
-			&i.Timezone,
-			&i.Status,
-			&i.Priority,
-			&i.CreatedBy,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.DeletedAt,
-			&i.LastRunAt,
-			&i.NextRunAt,
-		); err != nil {
+		var i GetRunningPowerTargetScheduleOverlapsRow
+		if err := rows.Scan(&i.ScheduleID, &i.SchedulePriority, &i.DeviceIdentifier); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/server/internal/domain/command/filter.go
+++ b/server/internal/domain/command/filter.go
@@ -7,21 +7,15 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/session"
 )
 
-// SkippedDevice describes a single device that a CommandFilter excluded from
-// the dispatch list. Callers that need to log "we skipped N devices because
-// X" use the Reason and FilterName fields. Reason is human-readable; for
-// machine-grouping use FilterName.
+// SkippedDevice describes one identifier excluded by a CommandFilter.
 type SkippedDevice struct {
 	DeviceIdentifier string
 	FilterName       string
 	Reason           string
 }
 
-// CommandResult is what processCommand returns to every public wrapper on
-// Service. BatchIdentifier is empty when nothing was dispatched (either the
-// caller's selector was empty or every selected device was filtered out) — in
-// that case no command_batch_log row is created and no queue messages are
-// enqueued, but Skipped may still be populated so callers can audit the skip.
+// CommandResult is the command-domain result before handlers project it back
+// to the existing response protos.
 type CommandResult struct {
 	BatchIdentifier string
 	DispatchedCount int
@@ -29,7 +23,7 @@ type CommandResult struct {
 }
 
 // CommandFilterInput is what processCommand passes to each registered filter.
-// Filters MUST NOT mutate DeviceIdentifiers; copy if you need to.
+// Filters must not mutate DeviceIdentifiers.
 type CommandFilterInput struct {
 	CommandType       commandtype.Type
 	OrganizationID    int64
@@ -38,20 +32,14 @@ type CommandFilterInput struct {
 	DeviceIdentifiers []string
 }
 
-// CommandFilterOutput partitions the input identifiers into kept (will be
-// dispatched if no later filter excludes them) and skipped. Filters that
-// don't apply to a given input should return Kept=in.DeviceIdentifiers with
-// Skipped=nil — the framework treats that as a pass-through.
+// CommandFilterOutput partitions identifiers into kept and skipped.
 type CommandFilterOutput struct {
 	Kept    []string
 	Skipped []SkippedDevice
 }
 
-// CommandFilter is a preflight gate consulted by processCommand before a
-// command is enqueued. Filters are idempotent: re-running a filter on its
-// own output must produce no further skips. Filter ordering is deterministic
-// (registration order); each filter sees only the survivors of earlier
-// filters.
+// CommandFilter is a preflight gate consulted before enqueue. Filters run in
+// registration order, each seeing only survivors from earlier filters.
 //
 // Apply returns an error only for I/O / data-fetch failures, never for the
 // policy decision itself — a "no devices pass this filter" outcome is
@@ -61,9 +49,7 @@ type CommandFilter interface {
 	Apply(ctx context.Context, in CommandFilterInput) (CommandFilterOutput, error)
 }
 
-// applyFilters runs every registered filter in order. Each filter sees only
-// the kept slice from the previous filter. Skipped devices accumulate across
-// filters and preserve which filter rejected them.
+// applyFilters accumulates skips while passing survivors through the chain.
 func applyFilters(ctx context.Context, filters []CommandFilter, in CommandFilterInput) (kept []string, skipped []SkippedDevice, err error) {
 	kept = in.DeviceIdentifiers
 	for _, f := range filters {

--- a/server/internal/domain/command/filter.go
+++ b/server/internal/domain/command/filter.go
@@ -38,12 +38,10 @@ type CommandFilterOutput struct {
 	Skipped []SkippedDevice
 }
 
-// CommandFilter is a preflight gate consulted before enqueue. Filters run in
-// registration order, each seeing only survivors from earlier filters.
+// CommandFilter gates identifiers before enqueue. Filters run in registration
+// order, each seeing only survivors from earlier filters.
 //
-// Apply returns an error only for I/O / data-fetch failures, never for the
-// policy decision itself — a "no devices pass this filter" outcome is
-// expressed by an empty Kept slice with the rejected devices in Skipped.
+// Policy exclusions are returned as Skipped, not errors.
 type CommandFilter interface {
 	Name() string
 	Apply(ctx context.Context, in CommandFilterInput) (CommandFilterOutput, error)

--- a/server/internal/domain/command/filter.go
+++ b/server/internal/domain/command/filter.go
@@ -1,0 +1,83 @@
+package command
+
+import (
+	"context"
+
+	"github.com/block/proto-fleet/server/internal/domain/commandtype"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+)
+
+// SkippedDevice describes a single device that a CommandFilter excluded from
+// the dispatch list. Callers that need to log "we skipped N devices because
+// X" use the Reason and FilterName fields. Reason is human-readable; for
+// machine-grouping use FilterName.
+type SkippedDevice struct {
+	DeviceIdentifier string
+	FilterName       string
+	Reason           string
+}
+
+// CommandResult is what processCommand returns to every public wrapper on
+// Service. BatchIdentifier is empty when nothing was dispatched (either the
+// caller's selector was empty or every selected device was filtered out) — in
+// that case no command_batch_log row is created and no queue messages are
+// enqueued, but Skipped may still be populated so callers can audit the skip.
+type CommandResult struct {
+	BatchIdentifier string
+	DispatchedCount int
+	Skipped         []SkippedDevice
+}
+
+// CommandFilterInput is what processCommand passes to each registered filter.
+// Filters MUST NOT mutate DeviceIdentifiers; copy if you need to.
+type CommandFilterInput struct {
+	CommandType       commandtype.Type
+	OrganizationID    int64
+	Actor             session.Actor
+	Source            session.Source
+	DeviceIdentifiers []string
+}
+
+// CommandFilterOutput partitions the input identifiers into kept (will be
+// dispatched if no later filter excludes them) and skipped. Filters that
+// don't apply to a given input should return Kept=in.DeviceIdentifiers with
+// Skipped=nil — the framework treats that as a pass-through.
+type CommandFilterOutput struct {
+	Kept    []string
+	Skipped []SkippedDevice
+}
+
+// CommandFilter is a preflight gate consulted by processCommand before a
+// command is enqueued. Filters are idempotent: re-running a filter on its
+// own output must produce no further skips. Filter ordering is deterministic
+// (registration order); each filter sees only the survivors of earlier
+// filters.
+//
+// Apply returns an error only for I/O / data-fetch failures, never for the
+// policy decision itself — a "no devices pass this filter" outcome is
+// expressed by an empty Kept slice with the rejected devices in Skipped.
+type CommandFilter interface {
+	Name() string
+	Apply(ctx context.Context, in CommandFilterInput) (CommandFilterOutput, error)
+}
+
+// applyFilters runs every registered filter in order. Each filter sees only
+// the kept slice from the previous filter. Skipped devices accumulate across
+// filters and preserve which filter rejected them.
+func applyFilters(ctx context.Context, filters []CommandFilter, in CommandFilterInput) (kept []string, skipped []SkippedDevice, err error) {
+	kept = in.DeviceIdentifiers
+	for _, f := range filters {
+		if len(kept) == 0 {
+			break
+		}
+		stepIn := in
+		stepIn.DeviceIdentifiers = kept
+		out, err := f.Apply(ctx, stepIn)
+		if err != nil {
+			return nil, nil, err
+		}
+		kept = out.Kept
+		skipped = append(skipped, out.Skipped...)
+	}
+	return kept, skipped, nil
+}

--- a/server/internal/domain/command/filter_test.go
+++ b/server/internal/domain/command/filter_test.go
@@ -1,0 +1,146 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/proto-fleet/server/internal/domain/commandtype"
+)
+
+// fakeFilter is a minimal CommandFilter for exercising applyFilters in
+// isolation from the full Service. Each instance excludes a fixed set of
+// device identifiers and records its invocations so tests can assert
+// chaining/ordering behaviour.
+type fakeFilter struct {
+	name      string
+	exclude   map[string]struct{}
+	calls     int
+	lastInput CommandFilterInput
+	err       error
+}
+
+func newFakeFilter(name string, exclude ...string) *fakeFilter {
+	set := make(map[string]struct{}, len(exclude))
+	for _, e := range exclude {
+		set[e] = struct{}{}
+	}
+	return &fakeFilter{name: name, exclude: set}
+}
+
+func (f *fakeFilter) Name() string { return f.name }
+
+func (f *fakeFilter) Apply(_ context.Context, in CommandFilterInput) (CommandFilterOutput, error) {
+	f.calls++
+	f.lastInput = in
+	if f.err != nil {
+		return CommandFilterOutput{}, f.err
+	}
+	var kept []string
+	var skipped []SkippedDevice
+	for _, id := range in.DeviceIdentifiers {
+		if _, drop := f.exclude[id]; drop {
+			skipped = append(skipped, SkippedDevice{
+				DeviceIdentifier: id,
+				FilterName:       f.name,
+				Reason:           "excluded by " + f.name,
+			})
+			continue
+		}
+		kept = append(kept, id)
+	}
+	return CommandFilterOutput{Kept: kept, Skipped: skipped}, nil
+}
+
+func TestApplyFilters_NoFiltersIsPassThrough(t *testing.T) {
+	in := CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		DeviceIdentifiers: []string{"a", "b", "c"},
+	}
+	kept, skipped, err := applyFilters(context.Background(), nil, in)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, kept)
+	assert.Equal(t, 0, len(skipped))
+}
+
+func TestApplyFilters_SingleFilterPartitions(t *testing.T) {
+	f := newFakeFilter("f1", "b")
+	in := CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		DeviceIdentifiers: []string{"a", "b", "c"},
+	}
+	kept, skipped, err := applyFilters(context.Background(), []CommandFilter{f}, in)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a", "c"}, kept)
+	assert.Equal(t, 1, len(skipped))
+	assert.Equal(t, "b", skipped[0].DeviceIdentifier)
+	assert.Equal(t, "f1", skipped[0].FilterName)
+}
+
+func TestApplyFilters_OrderedChainAccumulatesSkips(t *testing.T) {
+	// f1 excludes "b"; f2 excludes "c". Expect f2 to see ["a", "c"] (post-f1)
+	// and the final skipped slice to record both rejections with their
+	// respective filter names.
+	f1 := newFakeFilter("f1", "b")
+	f2 := newFakeFilter("f2", "c")
+	in := CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		DeviceIdentifiers: []string{"a", "b", "c"},
+	}
+	kept, skipped, err := applyFilters(context.Background(), []CommandFilter{f1, f2}, in)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a"}, kept)
+	assert.Equal(t, []string{"a", "c"}, f2.lastInput.DeviceIdentifiers)
+	assert.Equal(t, 2, len(skipped))
+	assert.Equal(t, "b", skipped[0].DeviceIdentifier)
+	assert.Equal(t, "f1", skipped[0].FilterName)
+	assert.Equal(t, "c", skipped[1].DeviceIdentifier)
+	assert.Equal(t, "f2", skipped[1].FilterName)
+}
+
+func TestApplyFilters_ShortCircuitsWhenKeptEmpty(t *testing.T) {
+	// If filter 1 leaves nothing, filter 2 is never asked.
+	f1 := newFakeFilter("f1", "a", "b", "c")
+	f2 := newFakeFilter("f2")
+	in := CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		DeviceIdentifiers: []string{"a", "b", "c"},
+	}
+	kept, skipped, err := applyFilters(context.Background(), []CommandFilter{f1, f2}, in)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(kept))
+	assert.Equal(t, 3, len(skipped))
+	assert.Equal(t, 1, f1.calls)
+	assert.Equal(t, 0, f2.calls, "filter 2 must not be invoked once kept goes empty")
+}
+
+func TestApplyFilters_ErrorBubblesUpAndStopsChain(t *testing.T) {
+	f1 := &fakeFilter{name: "f1", err: errors.New("boom")}
+	f2 := newFakeFilter("f2")
+	in := CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		DeviceIdentifiers: []string{"a"},
+	}
+	_, _, err := applyFilters(context.Background(), []CommandFilter{f1, f2}, in)
+	assert.Error(t, err)
+	assert.Equal(t, 0, f2.calls)
+}
+
+func TestApplyFilters_Idempotent(t *testing.T) {
+	// Re-running a filter on its own output is a no-op: nothing further
+	// gets skipped, kept slice is stable.
+	f := newFakeFilter("f1", "b")
+	in := CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		DeviceIdentifiers: []string{"a", "b", "c"},
+	}
+	kept1, _, _ := applyFilters(context.Background(), []CommandFilter{f}, in)
+	in2 := in
+	in2.DeviceIdentifiers = kept1
+	kept2, skipped2, err := applyFilters(context.Background(), []CommandFilter{f}, in2)
+	assert.NoError(t, err)
+	assert.Equal(t, kept1, kept2)
+	assert.Equal(t, 0, len(skipped2))
+}

--- a/server/internal/domain/command/preflight_block_test.go
+++ b/server/internal/domain/command/preflight_block_test.go
@@ -19,9 +19,8 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/session"
 )
 
-// recordingActivityStore implements just enough of the ActivityStore interface
-// to record inserts. The other methods panic — every test in this file must
-// take a path that only calls Insert.
+// recordingActivityStore records inserts; other ActivityStore methods are not
+// used by these tests.
 type recordingActivityStore struct {
 	inserts []*activitymodels.Event
 	failErr error
@@ -52,39 +51,8 @@ func (s *recordingActivityStore) GetDistinctScopeTypes(context.Context, int64) (
 	panic("not used in preflight_block_test")
 }
 
-// blockingFilter excludes a fixed set of device identifiers. Drives the
-// preflight chain into "skipped" states without needing the real
-// ScheduleConflictFilter and its store dependencies.
-type blockingFilter struct {
-	exclude map[string]struct{}
-}
-
-func newBlockingFilter(exclude ...string) *blockingFilter {
-	set := make(map[string]struct{}, len(exclude))
-	for _, e := range exclude {
-		set[e] = struct{}{}
-	}
-	return &blockingFilter{exclude: set}
-}
-
-func (f *blockingFilter) Name() string { return "test_block" }
-
-func (f *blockingFilter) Apply(_ context.Context, in CommandFilterInput) (CommandFilterOutput, error) {
-	var kept []string
-	var skipped []SkippedDevice
-	for _, id := range in.DeviceIdentifiers {
-		if _, drop := f.exclude[id]; drop {
-			skipped = append(skipped, SkippedDevice{DeviceIdentifier: id, FilterName: f.Name(), Reason: "test"})
-			continue
-		}
-		kept = append(kept, id)
-	}
-	return CommandFilterOutput{Kept: kept, Skipped: skipped}, nil
-}
-
-// newPreflightTestService wires the minimum surface processCommand needs to
-// reach (or NOT reach) the manual-block path. messageQueue/conn are
-// intentionally nil — every test must short-circuit before they're touched.
+// newPreflightTestService leaves queue/DB nil so tests prove blocked paths
+// short-circuit before enqueue.
 func newPreflightTestService(t *testing.T, filter CommandFilter) (*Service, *recordingActivityStore) {
 	t.Helper()
 	store := &recordingActivityStore{}
@@ -128,7 +96,6 @@ func includeSelector(ids ...string) *pb.DeviceSelector {
 	}
 }
 
-// findActivity returns the single event with the given type, or fails.
 func findActivity(t *testing.T, store *recordingActivityStore, eventType string) *activitymodels.Event {
 	t.Helper()
 	var found *activitymodels.Event
@@ -145,7 +112,7 @@ func findActivity(t *testing.T, store *recordingActivityStore, eventType string)
 // --- Manual-origin block path: HIGH finding ---
 
 func TestProcessCommand_ManualPartialSkip_Blocks(t *testing.T) {
-	svc, store := newPreflightTestService(t, newBlockingFilter("miner-1"))
+	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "miner-1"))
 
 	_, err := svc.processCommand(manualSessionCtx(1), &Command{
 		commandType:    commandtype.SetPowerTarget,
@@ -168,7 +135,7 @@ func TestProcessCommand_ManualPartialSkip_Blocks(t *testing.T) {
 }
 
 func TestProcessCommand_ManualFullSkip_Blocks(t *testing.T) {
-	svc, store := newPreflightTestService(t, newBlockingFilter("miner-1", "miner-2"))
+	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "miner-1", "miner-2"))
 
 	_, err := svc.processCommand(manualSessionCtx(1), &Command{
 		commandType:    commandtype.SetPowerTarget,
@@ -189,7 +156,7 @@ func TestProcessCommand_ManualFullSkip_Blocks(t *testing.T) {
 // --- Scheduler-origin: block path must NOT fire ---
 
 func TestProcessCommand_SchedulerFullSkip_NoBlockActivity(t *testing.T) {
-	svc, store := newPreflightTestService(t, newBlockingFilter("miner-1", "miner-2"))
+	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "miner-1", "miner-2"))
 
 	result, err := svc.processCommand(schedulerSessionCtx(1), &Command{
 		commandType:    commandtype.SetPowerTarget,
@@ -209,7 +176,7 @@ func TestProcessCommand_SchedulerFullSkip_NoBlockActivity(t *testing.T) {
 // --- Audit-failure path: must NOT degrade into a normal FailedPrecondition ---
 
 func TestProcessCommand_ManualBlock_AuditFailure_ReturnsInternal(t *testing.T) {
-	svc, store := newPreflightTestService(t, newBlockingFilter("miner-1"))
+	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "miner-1"))
 	store.failErr = errors.New("activity_log: connection refused")
 
 	_, err := svc.processCommand(manualSessionCtx(1), &Command{
@@ -224,16 +191,11 @@ func TestProcessCommand_ManualBlock_AuditFailure_ReturnsInternal(t *testing.T) {
 	assert.Contains(t, err.Error(), "logging preflight block")
 }
 
-// --- Wrapper-level boundary check ---
-//
-// The Connect handler is a 3-line passthrough that returns the wrapper's
-// error verbatim; ErrorMappingInterceptor.mapError translates FleetError →
-// connect.Error using the FleetError.GRPCCode. Verifying the wrapper
-// returns a FleetError with CodeFailedPrecondition is the meaningful
-// boundary check at the unit test layer.
+// The handler passes wrapper errors through; ErrorMappingInterceptor maps this
+// FleetError.GRPCCode to the wire-level connect.Code.
 
 func TestSetPowerTarget_ManualBlock_PropagatesFailedPrecondition(t *testing.T) {
-	svc, _ := newPreflightTestService(t, newBlockingFilter("miner-1"))
+	svc, _ := newPreflightTestService(t, newFakeFilter("test_block", "miner-1"))
 
 	resp, err := svc.SetPowerTarget(
 		manualSessionCtx(1),

--- a/server/internal/domain/command/preflight_block_test.go
+++ b/server/internal/domain/command/preflight_block_test.go
@@ -167,9 +167,34 @@ func TestProcessCommand_SchedulerFullSkip_NoBlockActivity(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, "", result.BatchIdentifier)
 	assert.Equal(t, 0, result.DispatchedCount)
-	assert.Equal(t, 2, len(result.Skipped))
+	require.Equal(t, 2, len(result.Skipped))
+	assert.Equal(t, "miner-1", result.Skipped[0].DeviceIdentifier)
+	assert.Equal(t, "test_block", result.Skipped[0].FilterName)
+	assert.Equal(t, "excluded by test_block", result.Skipped[0].Reason)
+	assert.Equal(t, "miner-2", result.Skipped[1].DeviceIdentifier)
+	assert.Equal(t, "test_block", result.Skipped[1].FilterName)
+	assert.Equal(t, "excluded by test_block", result.Skipped[1].Reason)
 	for _, ev := range store.inserts {
 		assert.NotEqual(t, "command_preflight_blocked", ev.Type, "scheduler must not trigger the block path")
+	}
+}
+
+func TestProcessCommand_ExternalEmptySelector_ReturnsInvalidArgument(t *testing.T) {
+	svc, store := newPreflightTestService(t, newFakeFilter("test_block"))
+
+	result, err := svc.processCommand(manualSessionCtx(1), &Command{
+		commandType:    commandtype.SetPowerTarget,
+		deviceSelector: includeSelector(),
+	})
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.True(t, errors.As(err, &fleetErr), "expected FleetError, got %T", err)
+	require.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
+	assert.Contains(t, err.Error(), "no devices matched selector")
+	for _, ev := range store.inserts {
+		assert.NotEqual(t, "command_preflight_blocked", ev.Type, "zero-target selector is not a preflight block")
 	}
 }
 

--- a/server/internal/domain/command/preflight_block_test.go
+++ b/server/internal/domain/command/preflight_block_test.go
@@ -1,0 +1,268 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/authn"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/block/proto-fleet/server/generated/grpc/common/v1"
+	pb "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
+	"github.com/block/proto-fleet/server/internal/domain/activity"
+	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/domain/commandtype"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+)
+
+// recordingActivityStore implements just enough of the ActivityStore interface
+// to record inserts. The other methods panic — every test in this file must
+// take a path that only calls Insert.
+type recordingActivityStore struct {
+	inserts []*activitymodels.Event
+	failErr error
+}
+
+func (s *recordingActivityStore) Insert(_ context.Context, event *activitymodels.Event) error {
+	if s.failErr != nil {
+		return s.failErr
+	}
+	clone := *event
+	s.inserts = append(s.inserts, &clone)
+	return nil
+}
+
+func (s *recordingActivityStore) List(context.Context, activitymodels.Filter) ([]activitymodels.Entry, error) {
+	panic("not used in preflight_block_test")
+}
+func (s *recordingActivityStore) Count(context.Context, activitymodels.Filter) (int64, error) {
+	panic("not used in preflight_block_test")
+}
+func (s *recordingActivityStore) GetDistinctUsers(context.Context, int64) ([]activitymodels.UserInfo, error) {
+	panic("not used in preflight_block_test")
+}
+func (s *recordingActivityStore) GetDistinctEventTypes(context.Context, int64) ([]activitymodels.EventTypeInfo, error) {
+	panic("not used in preflight_block_test")
+}
+func (s *recordingActivityStore) GetDistinctScopeTypes(context.Context, int64) ([]string, error) {
+	panic("not used in preflight_block_test")
+}
+
+// blockingFilter excludes a fixed set of device identifiers. Drives the
+// preflight chain into "skipped" states without needing the real
+// ScheduleConflictFilter and its store dependencies.
+type blockingFilter struct {
+	exclude map[string]struct{}
+}
+
+func newBlockingFilter(exclude ...string) *blockingFilter {
+	set := make(map[string]struct{}, len(exclude))
+	for _, e := range exclude {
+		set[e] = struct{}{}
+	}
+	return &blockingFilter{exclude: set}
+}
+
+func (f *blockingFilter) Name() string { return "test_block" }
+
+func (f *blockingFilter) Apply(_ context.Context, in CommandFilterInput) (CommandFilterOutput, error) {
+	var kept []string
+	var skipped []SkippedDevice
+	for _, id := range in.DeviceIdentifiers {
+		if _, drop := f.exclude[id]; drop {
+			skipped = append(skipped, SkippedDevice{DeviceIdentifier: id, FilterName: f.Name(), Reason: "test"})
+			continue
+		}
+		kept = append(kept, id)
+	}
+	return CommandFilterOutput{Kept: kept, Skipped: skipped}, nil
+}
+
+// newPreflightTestService wires the minimum surface processCommand needs to
+// reach (or NOT reach) the manual-block path. messageQueue/conn are
+// intentionally nil — every test must short-circuit before they're touched.
+func newPreflightTestService(t *testing.T, filter CommandFilter) (*Service, *recordingActivityStore) {
+	t.Helper()
+	store := &recordingActivityStore{}
+	svc := &Service{
+		config:           &Config{},
+		executionService: &ExecutionService{queueProcessorRunning: true},
+		activitySvc:      activity.NewService(store),
+		filters:          []CommandFilter{filter},
+	}
+	return svc, store
+}
+
+func manualSessionCtx(orgID int64) context.Context {
+	return authn.SetInfo(context.Background(), &session.Info{
+		SessionID:      "manual-test",
+		UserID:         42,
+		OrganizationID: orgID,
+		ExternalUserID: "user-1",
+		Username:       "test-user",
+		// Actor empty, Source zero → external manual caller.
+	})
+}
+
+func schedulerSessionCtx(orgID int64) context.Context {
+	return authn.SetInfo(context.Background(), &session.Info{
+		SessionID:      "scheduler",
+		UserID:         42,
+		OrganizationID: orgID,
+		ExternalUserID: "scheduler",
+		Username:       "scheduler",
+		Actor:          session.ActorScheduler,
+		Source:         session.Source{ScheduleID: 99, SchedulePriority: 5},
+	})
+}
+
+func includeSelector(ids ...string) *pb.DeviceSelector {
+	return &pb.DeviceSelector{
+		SelectionType: &pb.DeviceSelector_IncludeDevices{
+			IncludeDevices: &commonpb.DeviceIdentifierList{DeviceIdentifiers: ids},
+		},
+	}
+}
+
+// findActivity returns the single event with the given type, or fails.
+func findActivity(t *testing.T, store *recordingActivityStore, eventType string) *activitymodels.Event {
+	t.Helper()
+	var found *activitymodels.Event
+	for _, ev := range store.inserts {
+		if ev.Type == eventType {
+			require.Nil(t, found, "expected exactly one %q activity, found another", eventType)
+			found = ev
+		}
+	}
+	require.NotNil(t, found, "expected one %q activity, got %d events of other types", eventType, len(store.inserts))
+	return found
+}
+
+// --- Manual-origin block path: HIGH finding ---
+
+func TestProcessCommand_ManualPartialSkip_Blocks(t *testing.T) {
+	svc, store := newPreflightTestService(t, newBlockingFilter("miner-1"))
+
+	_, err := svc.processCommand(manualSessionCtx(1), &Command{
+		commandType:    commandtype.SetPowerTarget,
+		deviceSelector: includeSelector("miner-1", "miner-2", "miner-3"),
+	})
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.True(t, errors.As(err, &fleetErr), "expected FleetError, got %T", err)
+	require.Equal(t, connect.CodeFailedPrecondition, fleetErr.GRPCCode)
+
+	ev := findActivity(t, store, "command_preflight_blocked")
+	assert.Equal(t, activitymodels.CategoryDeviceCommand, ev.Category)
+	assert.Equal(t, activitymodels.ResultFailure, ev.Result)
+	assert.Equal(t, "set_power_target", ev.Metadata["command_type"])
+	assert.Equal(t, 3, ev.Metadata["requested_count"])
+	assert.Equal(t, 1, ev.Metadata["skipped_count"])
+	assert.Equal(t, []string{"miner-1"}, ev.Metadata["skipped_identifiers"])
+	assert.Equal(t, []string{"test_block"}, ev.Metadata["filters"])
+}
+
+func TestProcessCommand_ManualFullSkip_Blocks(t *testing.T) {
+	svc, store := newPreflightTestService(t, newBlockingFilter("miner-1", "miner-2"))
+
+	_, err := svc.processCommand(manualSessionCtx(1), &Command{
+		commandType:    commandtype.SetPowerTarget,
+		deviceSelector: includeSelector("miner-1", "miner-2"),
+	})
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.True(t, errors.As(err, &fleetErr))
+	require.Equal(t, connect.CodeFailedPrecondition, fleetErr.GRPCCode)
+
+	ev := findActivity(t, store, "command_preflight_blocked")
+	assert.Equal(t, 2, ev.Metadata["requested_count"])
+	assert.Equal(t, 2, ev.Metadata["skipped_count"])
+	assert.Equal(t, []string{"miner-1", "miner-2"}, ev.Metadata["skipped_identifiers"])
+}
+
+// --- Scheduler-origin: block path must NOT fire ---
+
+func TestProcessCommand_SchedulerFullSkip_NoBlockActivity(t *testing.T) {
+	svc, store := newPreflightTestService(t, newBlockingFilter("miner-1", "miner-2"))
+
+	result, err := svc.processCommand(schedulerSessionCtx(1), &Command{
+		commandType:    commandtype.SetPowerTarget,
+		deviceSelector: includeSelector("miner-1", "miner-2"),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "", result.BatchIdentifier)
+	assert.Equal(t, 0, result.DispatchedCount)
+	assert.Equal(t, 2, len(result.Skipped))
+	for _, ev := range store.inserts {
+		assert.NotEqual(t, "command_preflight_blocked", ev.Type, "scheduler must not trigger the block path")
+	}
+}
+
+// --- Audit-failure path: must NOT degrade into a normal FailedPrecondition ---
+
+func TestProcessCommand_ManualBlock_AuditFailure_ReturnsInternal(t *testing.T) {
+	svc, store := newPreflightTestService(t, newBlockingFilter("miner-1"))
+	store.failErr = errors.New("activity_log: connection refused")
+
+	_, err := svc.processCommand(manualSessionCtx(1), &Command{
+		commandType:    commandtype.SetPowerTarget,
+		deviceSelector: includeSelector("miner-1", "miner-2"),
+	})
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.True(t, errors.As(err, &fleetErr))
+	require.Equal(t, connect.CodeInternal, fleetErr.GRPCCode)
+	assert.Contains(t, err.Error(), "logging preflight block")
+}
+
+// --- Wrapper-level boundary check ---
+//
+// The Connect handler is a 3-line passthrough that returns the wrapper's
+// error verbatim; ErrorMappingInterceptor.mapError translates FleetError →
+// connect.Error using the FleetError.GRPCCode. Verifying the wrapper
+// returns a FleetError with CodeFailedPrecondition is the meaningful
+// boundary check at the unit test layer.
+
+func TestSetPowerTarget_ManualBlock_PropagatesFailedPrecondition(t *testing.T) {
+	svc, _ := newPreflightTestService(t, newBlockingFilter("miner-1"))
+
+	resp, err := svc.SetPowerTarget(
+		manualSessionCtx(1),
+		includeSelector("miner-1", "miner-2"),
+		pb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY,
+	)
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.True(t, errors.As(err, &fleetErr), "expected FleetError, got %T", err)
+	require.Equal(t, connect.CodeFailedPrecondition, fleetErr.GRPCCode,
+		"FleetError.GRPCCode is what ErrorMappingInterceptor uses to set the wire-level connect.Code")
+}
+
+// --- Skip metadata helper unit tests ---
+
+func TestSkipMetadata_DeduplicatesFilterNames(t *testing.T) {
+	skipped := []SkippedDevice{
+		{DeviceIdentifier: "a", FilterName: "f1"},
+		{DeviceIdentifier: "b", FilterName: "f2"},
+		{DeviceIdentifier: "c", FilterName: "f1"}, // duplicate filter name
+	}
+	md := skipMetadata("set_power_target", 5, skipped)
+
+	assert.Equal(t, "set_power_target", md["command_type"])
+	assert.Equal(t, 5, md["requested_count"])
+	assert.Equal(t, 3, md["skipped_count"])
+	assert.Equal(t, []string{"a", "b", "c"}, md["skipped_identifiers"])
+	// filters deduplicated and sorted
+	assert.Equal(t, []string{"f1", "f2"}, md["filters"])
+}

--- a/server/internal/domain/command/preflight_block_test.go
+++ b/server/internal/domain/command/preflight_block_test.go
@@ -136,6 +136,10 @@ func TestProcessCommand_ManualPartialSkip_Blocks(t *testing.T) {
 
 func TestProcessCommand_ManualFullSkip_Blocks(t *testing.T) {
 	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "miner-1", "miner-2"))
+	svc.resolveDeviceIDsOverride = func(_ context.Context, identifiers []string) ([]int64, error) {
+		assert.Equal(t, []string{"miner-1", "miner-2"}, identifiers)
+		return []int64{101, 102}, nil
+	}
 
 	_, err := svc.processCommand(manualSessionCtx(1), &Command{
 		commandType:    commandtype.SetPowerTarget,
@@ -151,6 +155,29 @@ func TestProcessCommand_ManualFullSkip_Blocks(t *testing.T) {
 	assert.Equal(t, 2, ev.Metadata["requested_count"])
 	assert.Equal(t, 2, ev.Metadata["skipped_count"])
 	assert.Equal(t, []string{"miner-1", "miner-2"}, ev.Metadata["skipped_identifiers"])
+}
+
+func TestProcessCommand_ManualFullSkipWithNoLiveDevices_ReturnsInvalidArgument(t *testing.T) {
+	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "stale-miner"))
+	svc.resolveDeviceIDsOverride = func(_ context.Context, identifiers []string) ([]int64, error) {
+		assert.Equal(t, []string{"stale-miner"}, identifiers)
+		return nil, nil
+	}
+
+	result, err := svc.processCommand(manualSessionCtx(1), &Command{
+		commandType:    commandtype.SetPowerTarget,
+		deviceSelector: includeSelector("stale-miner"),
+	})
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.True(t, errors.As(err, &fleetErr), "expected FleetError, got %T", err)
+	require.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
+	assert.Contains(t, err.Error(), "no devices matched selector")
+	for _, ev := range store.inserts {
+		assert.NotEqual(t, "command_preflight_blocked", ev.Type, "zero-live-device selector is not a preflight block")
+	}
 }
 
 // --- Scheduler-origin: block path must NOT fire ---

--- a/server/internal/domain/command/preflight_block_test.go
+++ b/server/internal/domain/command/preflight_block_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"connectrpc.com/authn"
@@ -34,7 +35,7 @@ func (s *recordingActivityStore) Insert(ctx context.Context, event *activitymode
 		return s.failErr
 	}
 	if err := ctx.Err(); err != nil {
-		return err
+		return fmt.Errorf("recording activity store insert: %w", err)
 	}
 	s.insertCtxErrs = append(s.insertCtxErrs, ctx.Err())
 	clone := *event

--- a/server/internal/domain/command/preflight_block_test.go
+++ b/server/internal/domain/command/preflight_block_test.go
@@ -20,16 +20,23 @@ import (
 )
 
 // recordingActivityStore records inserts; other ActivityStore methods are not
-// used by these tests.
+// used by these tests. Insert honours ctx cancellation and snapshots ctx.Err()
+// at insert time (callers typically defer-cancel the audit ctx right after the
+// write returns).
 type recordingActivityStore struct {
-	inserts []*activitymodels.Event
-	failErr error
+	inserts       []*activitymodels.Event
+	failErr       error
+	insertCtxErrs []error
 }
 
-func (s *recordingActivityStore) Insert(_ context.Context, event *activitymodels.Event) error {
+func (s *recordingActivityStore) Insert(ctx context.Context, event *activitymodels.Event) error {
 	if s.failErr != nil {
 		return s.failErr
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.insertCtxErrs = append(s.insertCtxErrs, ctx.Err())
 	clone := *event
 	s.inserts = append(s.inserts, &clone)
 	return nil
@@ -113,6 +120,10 @@ func findActivity(t *testing.T, store *recordingActivityStore, eventType string)
 
 func TestProcessCommand_ManualPartialSkip_Blocks(t *testing.T) {
 	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "miner-1"))
+	svc.resolveDeviceIDsOverride = func(_ context.Context, identifiers []string) ([]int64, error) {
+		assert.Equal(t, []string{"miner-1", "miner-2", "miner-3"}, identifiers)
+		return []int64{101, 102, 103}, nil
+	}
 
 	_, err := svc.processCommand(manualSessionCtx(1), &Command{
 		commandType:    commandtype.SetPowerTarget,
@@ -132,6 +143,31 @@ func TestProcessCommand_ManualPartialSkip_Blocks(t *testing.T) {
 	assert.Equal(t, 1, ev.Metadata["skipped_count"])
 	assert.Equal(t, []string{"miner-1"}, ev.Metadata["skipped_identifiers"])
 	assert.Equal(t, []string{"test_block"}, ev.Metadata["filters"])
+}
+
+// Mixed-stale selector: filter skips one stale ID, the other stays in kept,
+// but neither resolves to a live device. Should be InvalidArgument, not a
+// misleading FailedPrecondition.
+func TestProcessCommand_ManualPartialSkipWithNoLiveDevices_ReturnsInvalidArgument(t *testing.T) {
+	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "stale-A"))
+	svc.resolveDeviceIDsOverride = func(_ context.Context, identifiers []string) ([]int64, error) {
+		assert.Equal(t, []string{"stale-A", "stale-B"}, identifiers)
+		return nil, nil
+	}
+
+	_, err := svc.processCommand(manualSessionCtx(1), &Command{
+		commandType:    commandtype.SetPowerTarget,
+		deviceSelector: includeSelector("stale-A", "stale-B"),
+	})
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.True(t, errors.As(err, &fleetErr), "expected FleetError, got %T", err)
+	require.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
+	assert.Contains(t, err.Error(), "no devices matched selector")
+	for _, ev := range store.inserts {
+		assert.NotEqual(t, "command_preflight_blocked", ev.Type, "stale-mixed selector is not a preflight block")
+	}
 }
 
 func TestProcessCommand_ManualFullSkip_Blocks(t *testing.T) {
@@ -229,6 +265,9 @@ func TestProcessCommand_ExternalEmptySelector_ReturnsInvalidArgument(t *testing.
 
 func TestProcessCommand_ManualBlock_AuditFailure_ReturnsInternal(t *testing.T) {
 	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "miner-1"))
+	svc.resolveDeviceIDsOverride = func(_ context.Context, _ []string) ([]int64, error) {
+		return []int64{101, 102}, nil
+	}
 	store.failErr = errors.New("activity_log: connection refused")
 
 	_, err := svc.processCommand(manualSessionCtx(1), &Command{
@@ -243,11 +282,43 @@ func TestProcessCommand_ManualBlock_AuditFailure_ReturnsInternal(t *testing.T) {
 	assert.Contains(t, err.Error(), "logging preflight block")
 }
 
+// A request-ctx cancel at the deny-point must not suppress the audit row or
+// degrade FailedPrecondition into Internal.
+func TestProcessCommand_ManualBlock_AuditWritesOnCanceledRequestCtx(t *testing.T) {
+	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "miner-1"))
+	svc.resolveDeviceIDsOverride = func(_ context.Context, _ []string) ([]int64, error) {
+		return []int64{101, 102}, nil
+	}
+
+	reqCtx, cancel := context.WithCancel(manualSessionCtx(1))
+	cancel()
+
+	_, err := svc.processCommand(reqCtx, &Command{
+		commandType:    commandtype.SetPowerTarget,
+		deviceSelector: includeSelector("miner-1", "miner-2"),
+	})
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.True(t, errors.As(err, &fleetErr))
+	require.Equal(t, connect.CodeFailedPrecondition, fleetErr.GRPCCode,
+		"audit write on a bounded background ctx should not turn the deny into Internal")
+
+	findActivity(t, store, "command_preflight_blocked")
+
+	require.NotEmpty(t, store.insertCtxErrs)
+	insertErr := store.insertCtxErrs[len(store.insertCtxErrs)-1]
+	require.NoError(t, insertErr, "Insert must receive a live context, not the cancelled request ctx")
+}
+
 // The handler passes wrapper errors through; ErrorMappingInterceptor maps this
 // FleetError.GRPCCode to the wire-level connect.Code.
 
 func TestSetPowerTarget_ManualBlock_PropagatesFailedPrecondition(t *testing.T) {
 	svc, _ := newPreflightTestService(t, newFakeFilter("test_block", "miner-1"))
+	svc.resolveDeviceIDsOverride = func(_ context.Context, _ []string) ([]int64, error) {
+		return []int64{101, 102}, nil
+	}
 
 	resp, err := svc.SetPowerTarget(
 		manualSessionCtx(1),

--- a/server/internal/domain/command/schedule_conflict_filter.go
+++ b/server/internal/domain/command/schedule_conflict_filter.go
@@ -1,0 +1,175 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
+	"github.com/block/proto-fleet/server/internal/domain/commandtype"
+	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+)
+
+// ScheduleConflictFilter prevents a SetPowerTarget command from racing a
+// running power-target schedule.
+//
+// Two priority semantics, distinguished by session.Source:
+//
+//   - Scheduler-origin (Source.ScheduleID != 0): only schedules with strictly
+//     higher priority (numerically lower Priority field) than the caller block
+//     overlapping devices. This preserves today's behaviour for the schedule
+//     processor's normal dispatch and end-of-window revert paths.
+//
+//   - Manual-origin (Source.ScheduleID == 0, e.g. MinerCommandService over
+//     ConnectRPC, future curtailment-or-other paths that don't claim to be
+//     scheduler-origin): every running power-target schedule blocks
+//     overlapping devices. Manual callers have no priority to compare
+//     against; "skip the device, log it, dispatch the rest" is the same
+//     outcome the schedule processor would produce against itself.
+//
+// The filter only applies to SetPowerTarget commands — Reboot, StopMining,
+// etc. pass through unchanged, matching the existing scope of the inlined
+// filterConflictedMiners that this lift-and-shift replaces.
+type ScheduleConflictFilter struct {
+	procStore       stores.ScheduleProcessorStore
+	targetStore     stores.ScheduleTargetStore
+	collectionStore stores.CollectionStore
+}
+
+// NewScheduleConflictFilter wires the stores the filter needs to enumerate
+// running power-target schedules and expand their target sets to identifiers.
+// The collection store is needed for rack/group expansion, mirroring the
+// schedule processor's resolveTargets path.
+func NewScheduleConflictFilter(
+	procStore stores.ScheduleProcessorStore,
+	targetStore stores.ScheduleTargetStore,
+	collectionStore stores.CollectionStore,
+) *ScheduleConflictFilter {
+	return &ScheduleConflictFilter{
+		procStore:       procStore,
+		targetStore:     targetStore,
+		collectionStore: collectionStore,
+	}
+}
+
+func (f *ScheduleConflictFilter) Name() string {
+	return "schedule_conflict"
+}
+
+func (f *ScheduleConflictFilter) Apply(ctx context.Context, in CommandFilterInput) (CommandFilterOutput, error) {
+	if in.CommandType != commandtype.SetPowerTarget {
+		return CommandFilterOutput{Kept: in.DeviceIdentifiers}, nil
+	}
+	if len(in.DeviceIdentifiers) == 0 {
+		return CommandFilterOutput{Kept: in.DeviceIdentifiers}, nil
+	}
+
+	running, err := f.procStore.GetRunningPowerTargetSchedules(ctx, in.OrganizationID)
+	if err != nil {
+		return CommandFilterOutput{}, fmt.Errorf("failed to get running power target schedules: %w", err)
+	}
+
+	// device_identifier -> blocking schedule id (first one wins for diagnostic Reason)
+	conflicted := make(map[string]int64)
+	for _, r := range running {
+		// Don't conflict with self (scheduler-origin re-entering its own dispatch).
+		if r.Id == in.Source.ScheduleID {
+			continue
+		}
+		// Scheduler-origin priority semantics: only blocks if running has
+		// strictly higher priority (lower numeric value). Manual-origin
+		// (Source.ScheduleID == 0): every running schedule is a blocker.
+		if in.Source.ScheduleID != 0 && r.Priority >= in.Source.SchedulePriority {
+			continue
+		}
+		rTargets, err := f.targetStore.GetScheduleTargets(ctx, in.OrganizationID, r.Id)
+		if err != nil {
+			return CommandFilterOutput{}, fmt.Errorf("failed to load targets for conflicting schedule %d: %w", r.Id, err)
+		}
+		rDevices, err := f.expandTargets(ctx, rTargets, in.OrganizationID)
+		if err != nil {
+			return CommandFilterOutput{}, fmt.Errorf("failed to expand targets for conflicting schedule %d: %w", r.Id, err)
+		}
+		for _, d := range rDevices {
+			if _, exists := conflicted[d]; !exists {
+				conflicted[d] = r.Id
+			}
+		}
+	}
+
+	if len(conflicted) == 0 {
+		return CommandFilterOutput{Kept: in.DeviceIdentifiers}, nil
+	}
+
+	var kept []string
+	var skipped []SkippedDevice
+	for _, id := range in.DeviceIdentifiers {
+		if blockingID, blocked := conflicted[id]; blocked {
+			skipped = append(skipped, SkippedDevice{
+				DeviceIdentifier: id,
+				FilterName:       f.Name(),
+				Reason:           fmt.Sprintf("schedule %d holds higher priority for set_power_target", blockingID),
+			})
+			continue
+		}
+		kept = append(kept, id)
+	}
+	return CommandFilterOutput{Kept: kept, Skipped: skipped}, nil
+}
+
+// expandTargets converts a slice of ScheduleTarget into deduplicated device
+// identifiers. Mirrors schedule.Processor.expandTargets — the duplication is
+// intentional: we don't want a schedule package import from command, and the
+// target-resolution shape may diverge once curtailment introduces its own
+// scope vocabulary.
+func (f *ScheduleConflictFilter) expandTargets(ctx context.Context, targets []*pb.ScheduleTarget, orgID int64) ([]string, error) {
+	seen := make(map[string]struct{})
+	var identifiers []string
+
+	for _, t := range targets {
+		switch t.TargetType {
+		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER:
+			if _, dup := seen[t.TargetId]; !dup {
+				seen[t.TargetId] = struct{}{}
+				identifiers = append(identifiers, t.TargetId)
+			}
+
+		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_RACK:
+			rackID, err := strconv.ParseInt(t.TargetId, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid rack target_id %q: %w", t.TargetId, err)
+			}
+			rackDevices, err := f.collectionStore.GetDeviceIdentifiersByDeviceSetID(ctx, rackID, orgID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve rack %d devices: %w", rackID, err)
+			}
+			for _, d := range rackDevices {
+				if _, dup := seen[d]; !dup {
+					seen[d] = struct{}{}
+					identifiers = append(identifiers, d)
+				}
+			}
+
+		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_GROUP:
+			groupID, err := strconv.ParseInt(t.TargetId, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid group target_id %q: %w", t.TargetId, err)
+			}
+			groupDevices, err := f.collectionStore.GetDeviceIdentifiersByDeviceSetID(ctx, groupID, orgID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve group %d devices: %w", groupID, err)
+			}
+			for _, d := range groupDevices {
+				if _, dup := seen[d]; !dup {
+					seen[d] = struct{}{}
+					identifiers = append(identifiers, d)
+				}
+			}
+
+		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_UNSPECIFIED:
+			// Unknown target type — skip silently, matches schedule.Processor.expandTargets.
+		}
+	}
+
+	return identifiers, nil
+}

--- a/server/internal/domain/command/schedule_conflict_filter.go
+++ b/server/internal/domain/command/schedule_conflict_filter.go
@@ -3,10 +3,9 @@ package command
 import (
 	"context"
 	"fmt"
-	"strconv"
 
-	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
 	"github.com/block/proto-fleet/server/internal/domain/commandtype"
+	scheduletargets "github.com/block/proto-fleet/server/internal/domain/schedule/targets"
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
 
@@ -86,7 +85,7 @@ func (f *ScheduleConflictFilter) Apply(ctx context.Context, in CommandFilterInpu
 		if err != nil {
 			return CommandFilterOutput{}, fmt.Errorf("failed to load targets for conflicting schedule %d: %w", r.Id, err)
 		}
-		rDevices, err := f.expandTargets(ctx, rTargets, in.OrganizationID)
+		rDevices, err := scheduletargets.Expand(ctx, f.collectionStore, rTargets, in.OrganizationID, nil)
 		if err != nil {
 			return CommandFilterOutput{}, fmt.Errorf("failed to expand targets for conflicting schedule %d: %w", r.Id, err)
 		}
@@ -115,61 +114,4 @@ func (f *ScheduleConflictFilter) Apply(ctx context.Context, in CommandFilterInpu
 		kept = append(kept, id)
 	}
 	return CommandFilterOutput{Kept: kept, Skipped: skipped}, nil
-}
-
-// expandTargets converts a slice of ScheduleTarget into deduplicated device
-// identifiers. Mirrors schedule.Processor.expandTargets — the duplication is
-// intentional: we don't want a schedule package import from command, and the
-// target-resolution shape may diverge once curtailment introduces its own
-// scope vocabulary.
-func (f *ScheduleConflictFilter) expandTargets(ctx context.Context, targets []*pb.ScheduleTarget, orgID int64) ([]string, error) {
-	seen := make(map[string]struct{})
-	var identifiers []string
-
-	for _, t := range targets {
-		switch t.TargetType {
-		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER:
-			if _, dup := seen[t.TargetId]; !dup {
-				seen[t.TargetId] = struct{}{}
-				identifiers = append(identifiers, t.TargetId)
-			}
-
-		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_RACK:
-			rackID, err := strconv.ParseInt(t.TargetId, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid rack target_id %q: %w", t.TargetId, err)
-			}
-			rackDevices, err := f.collectionStore.GetDeviceIdentifiersByDeviceSetID(ctx, rackID, orgID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve rack %d devices: %w", rackID, err)
-			}
-			for _, d := range rackDevices {
-				if _, dup := seen[d]; !dup {
-					seen[d] = struct{}{}
-					identifiers = append(identifiers, d)
-				}
-			}
-
-		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_GROUP:
-			groupID, err := strconv.ParseInt(t.TargetId, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid group target_id %q: %w", t.TargetId, err)
-			}
-			groupDevices, err := f.collectionStore.GetDeviceIdentifiersByDeviceSetID(ctx, groupID, orgID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve group %d devices: %w", groupID, err)
-			}
-			for _, d := range groupDevices {
-				if _, dup := seen[d]; !dup {
-					seen[d] = struct{}{}
-					identifiers = append(identifiers, d)
-				}
-			}
-
-		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_UNSPECIFIED:
-			// Unknown target type — skip silently, matches schedule.Processor.expandTargets.
-		}
-	}
-
-	return identifiers, nil
 }

--- a/server/internal/domain/command/schedule_conflict_filter.go
+++ b/server/internal/domain/command/schedule_conflict_filter.go
@@ -9,26 +9,17 @@ import (
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
 
+const ScheduleConflictFilterName = "schedule_conflict"
+
 // ScheduleConflictFilter prevents a SetPowerTarget command from racing a
 // running power-target schedule.
 //
-// Two priority semantics, distinguished by session.Source:
+// Scheduler-origin calls use schedule priority: only strictly higher-priority
+// running schedules block. Manual-origin calls have no priority context, so any
+// running power-target schedule blocks overlapping devices; processCommand then
+// rejects the whole external command.
 //
-//   - Scheduler-origin (Source.ScheduleID != 0): only schedules with strictly
-//     higher priority (numerically lower Priority field) than the caller block
-//     overlapping devices. This preserves today's behaviour for the schedule
-//     processor's normal dispatch and end-of-window revert paths.
-//
-//   - Manual-origin (Source.ScheduleID == 0, e.g. MinerCommandService over
-//     ConnectRPC, future curtailment-or-other paths that don't claim to be
-//     scheduler-origin): every running power-target schedule blocks
-//     overlapping devices. Manual callers have no priority to compare
-//     against; "skip the device, log it, dispatch the rest" is the same
-//     outcome the schedule processor would produce against itself.
-//
-// The filter only applies to SetPowerTarget commands — Reboot, StopMining,
-// etc. pass through unchanged, matching the existing scope of the inlined
-// filterConflictedMiners that this lift-and-shift replaces.
+// Only SetPowerTarget is gated; other command types pass through unchanged.
 type ScheduleConflictFilter struct {
 	procStore       stores.ScheduleProcessorStore
 	targetStore     stores.ScheduleTargetStore
@@ -52,7 +43,7 @@ func NewScheduleConflictFilter(
 }
 
 func (f *ScheduleConflictFilter) Name() string {
-	return "schedule_conflict"
+	return ScheduleConflictFilterName
 }
 
 func (f *ScheduleConflictFilter) Apply(ctx context.Context, in CommandFilterInput) (CommandFilterOutput, error) {
@@ -75,9 +66,6 @@ func (f *ScheduleConflictFilter) Apply(ctx context.Context, in CommandFilterInpu
 		if r.Id == in.Source.ScheduleID {
 			continue
 		}
-		// Scheduler-origin priority semantics: only blocks if running has
-		// strictly higher priority (lower numeric value). Manual-origin
-		// (Source.ScheduleID == 0): every running schedule is a blocker.
 		if in.Source.ScheduleID != 0 && r.Priority >= in.Source.SchedulePriority {
 			continue
 		}
@@ -104,10 +92,14 @@ func (f *ScheduleConflictFilter) Apply(ctx context.Context, in CommandFilterInpu
 	var skipped []SkippedDevice
 	for _, id := range in.DeviceIdentifiers {
 		if blockingID, blocked := conflicted[id]; blocked {
+			reason := fmt.Sprintf("schedule %d blocks set_power_target", blockingID)
+			if in.Source.ScheduleID != 0 {
+				reason = fmt.Sprintf("schedule %d holds higher priority for set_power_target", blockingID)
+			}
 			skipped = append(skipped, SkippedDevice{
 				DeviceIdentifier: id,
 				FilterName:       f.Name(),
-				Reason:           fmt.Sprintf("schedule %d holds higher priority for set_power_target", blockingID),
+				Reason:           reason,
 			})
 			continue
 		}

--- a/server/internal/domain/command/schedule_conflict_filter.go
+++ b/server/internal/domain/command/schedule_conflict_filter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/block/proto-fleet/server/internal/domain/commandtype"
-	scheduletargets "github.com/block/proto-fleet/server/internal/domain/schedule/targets"
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
 
@@ -21,24 +20,12 @@ const ScheduleConflictFilterName = "schedule_conflict"
 //
 // Only SetPowerTarget is gated; other command types pass through unchanged.
 type ScheduleConflictFilter struct {
-	procStore       stores.ScheduleProcessorStore
-	targetStore     stores.ScheduleTargetStore
-	collectionStore stores.CollectionStore
+	procStore stores.ScheduleProcessorStore
 }
 
-// NewScheduleConflictFilter wires the stores the filter needs to enumerate
-// running power-target schedules and expand their target sets to identifiers.
-// The collection store is needed for rack/group expansion, mirroring the
-// schedule processor's resolveTargets path.
-func NewScheduleConflictFilter(
-	procStore stores.ScheduleProcessorStore,
-	targetStore stores.ScheduleTargetStore,
-	collectionStore stores.CollectionStore,
-) *ScheduleConflictFilter {
+func NewScheduleConflictFilter(procStore stores.ScheduleProcessorStore) *ScheduleConflictFilter {
 	return &ScheduleConflictFilter{
-		procStore:       procStore,
-		targetStore:     targetStore,
-		collectionStore: collectionStore,
+		procStore: procStore,
 	}
 }
 
@@ -54,33 +41,23 @@ func (f *ScheduleConflictFilter) Apply(ctx context.Context, in CommandFilterInpu
 		return CommandFilterOutput{Kept: in.DeviceIdentifiers}, nil
 	}
 
-	running, err := f.procStore.GetRunningPowerTargetSchedules(ctx, in.OrganizationID)
+	overlaps, err := f.procStore.GetRunningPowerTargetScheduleOverlaps(ctx, in.OrganizationID, in.DeviceIdentifiers)
 	if err != nil {
-		return CommandFilterOutput{}, fmt.Errorf("failed to get running power target schedules: %w", err)
+		return CommandFilterOutput{}, fmt.Errorf("failed to get running power target schedule overlaps: %w", err)
 	}
 
 	// device_identifier -> blocking schedule id (first one wins for diagnostic Reason)
 	conflicted := make(map[string]int64)
-	for _, r := range running {
+	for _, r := range overlaps {
 		// Don't conflict with self (scheduler-origin re-entering its own dispatch).
-		if r.Id == in.Source.ScheduleID {
+		if r.ScheduleID == in.Source.ScheduleID {
 			continue
 		}
-		if in.Source.ScheduleID != 0 && r.Priority >= in.Source.SchedulePriority {
+		if in.Source.ScheduleID != 0 && r.SchedulePriority >= in.Source.SchedulePriority {
 			continue
 		}
-		rTargets, err := f.targetStore.GetScheduleTargets(ctx, in.OrganizationID, r.Id)
-		if err != nil {
-			return CommandFilterOutput{}, fmt.Errorf("failed to load targets for conflicting schedule %d: %w", r.Id, err)
-		}
-		rDevices, err := scheduletargets.Expand(ctx, f.collectionStore, rTargets, in.OrganizationID, nil)
-		if err != nil {
-			return CommandFilterOutput{}, fmt.Errorf("failed to expand targets for conflicting schedule %d: %w", r.Id, err)
-		}
-		for _, d := range rDevices {
-			if _, exists := conflicted[d]; !exists {
-				conflicted[d] = r.Id
-			}
+		if _, exists := conflicted[r.DeviceIdentifier]; !exists {
+			conflicted[r.DeviceIdentifier] = r.ScheduleID
 		}
 	}
 

--- a/server/internal/domain/command/schedule_conflict_filter.go
+++ b/server/internal/domain/command/schedule_conflict_filter.go
@@ -10,15 +10,9 @@ import (
 
 const ScheduleConflictFilterName = "schedule_conflict"
 
-// ScheduleConflictFilter prevents a SetPowerTarget command from racing a
-// running power-target schedule.
-//
-// Scheduler-origin calls use schedule priority: only strictly higher-priority
-// running schedules block. Manual-origin calls have no priority context, so any
-// running power-target schedule blocks overlapping devices; processCommand then
-// rejects the whole external command.
-//
-// Only SetPowerTarget is gated; other command types pass through unchanged.
+// ScheduleConflictFilter gates SetPowerTarget against running power-target
+// schedules. Scheduler-origin calls use schedule priority; manual calls treat
+// any overlapping running schedule as a blocker.
 type ScheduleConflictFilter struct {
 	procStore stores.ScheduleProcessorStore
 }
@@ -49,7 +43,7 @@ func (f *ScheduleConflictFilter) Apply(ctx context.Context, in CommandFilterInpu
 	// device_identifier -> blocking schedule id (first one wins for diagnostic Reason)
 	conflicted := make(map[string]int64)
 	for _, r := range overlaps {
-		// Don't conflict with self (scheduler-origin re-entering its own dispatch).
+		// Scheduler-origin dispatch should not conflict with itself.
 		if r.ScheduleID == in.Source.ScheduleID {
 			continue
 		}

--- a/server/internal/domain/command/schedule_conflict_filter_test.go
+++ b/server/internal/domain/command/schedule_conflict_filter_test.go
@@ -80,7 +80,8 @@ func TestScheduleConflictFilter_SchedulerOriginHigherPriorityBlocks(t *testing.T
 	assert.Equal(t, []string{"miner-2", "miner-3"}, out.Kept)
 	assert.Equal(t, 1, len(out.Skipped))
 	assert.Equal(t, "miner-1", out.Skipped[0].DeviceIdentifier)
-	assert.Equal(t, "schedule_conflict", out.Skipped[0].FilterName)
+	assert.Equal(t, ScheduleConflictFilterName, out.Skipped[0].FilterName)
+	assert.Equal(t, "schedule 20 holds higher priority for set_power_target", out.Skipped[0].Reason)
 }
 
 func TestScheduleConflictFilter_SchedulerOriginLowerPriorityIgnored(t *testing.T) {
@@ -149,6 +150,7 @@ func TestScheduleConflictFilter_ManualBlockedByAnyRunningSchedule(t *testing.T) 
 	assert.Equal(t, []string{"miner-2"}, out.Kept)
 	assert.Equal(t, 1, len(out.Skipped))
 	assert.Equal(t, "miner-1", out.Skipped[0].DeviceIdentifier)
+	assert.Equal(t, "schedule 20 blocks set_power_target", out.Skipped[0].Reason)
 }
 
 func TestScheduleConflictFilter_ManualUnaffectedWhenNoRunningSchedules(t *testing.T) {

--- a/server/internal/domain/command/schedule_conflict_filter_test.go
+++ b/server/internal/domain/command/schedule_conflict_filter_test.go
@@ -1,0 +1,194 @@
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"go.uber.org/mock/gomock"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
+	"github.com/block/proto-fleet/server/internal/domain/commandtype"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
+)
+
+// newScheduleConflictFilter wires the filter against fresh gomock-backed
+// stores. The collection store is included because expandTargets needs it
+// for rack/group target types — leaving it nil would panic on the first
+// non-miner target.
+func newScheduleConflictFilter(t *testing.T) (*ScheduleConflictFilter, *mocks.MockScheduleProcessorStore, *mocks.MockScheduleTargetStore, *mocks.MockCollectionStore) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	procStore := mocks.NewMockScheduleProcessorStore(ctrl)
+	targetStore := mocks.NewMockScheduleTargetStore(ctrl)
+	collectionStore := mocks.NewMockCollectionStore(ctrl)
+	f := NewScheduleConflictFilter(procStore, targetStore, collectionStore)
+	return f, procStore, targetStore, collectionStore
+}
+
+// --- Command-type gating ---
+
+func TestScheduleConflictFilter_NonPowerTargetCommandPassesThrough(t *testing.T) {
+	// Reboot/StopMining/etc. shouldn't even consult the schedule store —
+	// the existing inline filter only ran for SetPowerTarget and we're
+	// preserving that scope.
+	f, _, _, _ := newScheduleConflictFilter(t)
+
+	out, err := f.Apply(context.Background(), CommandFilterInput{
+		CommandType:       commandtype.Reboot,
+		OrganizationID:    1,
+		DeviceIdentifiers: []string{"miner-1"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"miner-1"}, out.Kept)
+	assert.Equal(t, 0, len(out.Skipped))
+}
+
+func TestScheduleConflictFilter_EmptyInputPassesThrough(t *testing.T) {
+	f, _, _, _ := newScheduleConflictFilter(t)
+	out, err := f.Apply(context.Background(), CommandFilterInput{
+		CommandType:    commandtype.SetPowerTarget,
+		OrganizationID: 1,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(out.Kept))
+	assert.Equal(t, 0, len(out.Skipped))
+}
+
+// --- Scheduler-origin priority semantics ---
+
+func TestScheduleConflictFilter_SchedulerOriginHigherPriorityBlocks(t *testing.T) {
+	// Caller is schedule 10 priority 5; running schedule 20 has priority 2
+	// (numerically lower → higher priority). Devices held by 20 must drop.
+	f, procStore, targetStore, _ := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
+		{Id: 20, Priority: 2, Action: pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET},
+	}, nil)
+	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(20)).Return([]*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
+	}, nil)
+
+	out, err := f.Apply(context.Background(), CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		OrganizationID:    1,
+		Actor:             session.ActorScheduler,
+		Source:            session.Source{ScheduleID: 10, SchedulePriority: 5},
+		DeviceIdentifiers: []string{"miner-1", "miner-2", "miner-3"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"miner-2", "miner-3"}, out.Kept)
+	assert.Equal(t, 1, len(out.Skipped))
+	assert.Equal(t, "miner-1", out.Skipped[0].DeviceIdentifier)
+	assert.Equal(t, "schedule_conflict", out.Skipped[0].FilterName)
+}
+
+func TestScheduleConflictFilter_SchedulerOriginLowerPriorityIgnored(t *testing.T) {
+	// Caller is schedule 10 priority 2; running schedule 20 has priority 5
+	// (numerically higher → lower priority). Devices held by 20 do NOT
+	// block — the caller wins, so nothing is filtered, and we don't even
+	// need to inspect that running schedule's targets.
+	f, procStore, _, _ := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
+		{Id: 20, Priority: 5},
+	}, nil)
+
+	out, err := f.Apply(context.Background(), CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		OrganizationID:    1,
+		Actor:             session.ActorScheduler,
+		Source:            session.Source{ScheduleID: 10, SchedulePriority: 2},
+		DeviceIdentifiers: []string{"miner-1"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"miner-1"}, out.Kept)
+	assert.Equal(t, 0, len(out.Skipped))
+}
+
+func TestScheduleConflictFilter_SchedulerOriginIgnoresSelf(t *testing.T) {
+	// A schedule must not conflict with itself even when its targets and
+	// the caller's selector overlap (which they always do by definition).
+	f, procStore, _, _ := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
+		{Id: 10, Priority: 5},
+	}, nil)
+
+	out, err := f.Apply(context.Background(), CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		OrganizationID:    1,
+		Actor:             session.ActorScheduler,
+		Source:            session.Source{ScheduleID: 10, SchedulePriority: 5},
+		DeviceIdentifiers: []string{"miner-1"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"miner-1"}, out.Kept)
+	assert.Equal(t, 0, len(out.Skipped))
+}
+
+// --- Manual-origin (Source.ScheduleID == 0) semantics ---
+
+func TestScheduleConflictFilter_ManualBlockedByAnyRunningSchedule(t *testing.T) {
+	// This is the headline pre-work behaviour change. With Source unset
+	// (manual API call, no priority), every running power-target schedule
+	// is a blocker for overlapping devices.
+	f, procStore, targetStore, _ := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
+		{Id: 20, Priority: 100, Action: pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET},
+	}, nil)
+	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(20)).Return([]*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
+	}, nil)
+
+	out, err := f.Apply(context.Background(), CommandFilterInput{
+		CommandType:    commandtype.SetPowerTarget,
+		OrganizationID: 1,
+		// Actor empty; Source zero — both indicate user/API origin.
+		DeviceIdentifiers: []string{"miner-1", "miner-2"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"miner-2"}, out.Kept)
+	assert.Equal(t, 1, len(out.Skipped))
+	assert.Equal(t, "miner-1", out.Skipped[0].DeviceIdentifier)
+}
+
+func TestScheduleConflictFilter_ManualUnaffectedWhenNoRunningSchedules(t *testing.T) {
+	f, procStore, _, _ := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return(nil, nil)
+
+	out, err := f.Apply(context.Background(), CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		OrganizationID:    1,
+		DeviceIdentifiers: []string{"miner-1", "miner-2"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"miner-1", "miner-2"}, out.Kept)
+	assert.Equal(t, 0, len(out.Skipped))
+}
+
+// --- Rack/group expansion ---
+
+func TestScheduleConflictFilter_ExpandsRackTargetsBeforeMatching(t *testing.T) {
+	// The running schedule targets a rack rather than individual miners;
+	// the filter must expand it via the collection store before deciding
+	// which of the caller's identifiers to skip.
+	f, procStore, targetStore, collectionStore := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
+		{Id: 20, Priority: 2, Action: pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET},
+	}, nil)
+	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(20)).Return([]*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_RACK, TargetId: "100"},
+	}, nil)
+	collectionStore.EXPECT().GetDeviceIdentifiersByDeviceSetID(gomock.Any(), int64(100), int64(1)).
+		Return([]string{"miner-1", "miner-3"}, nil)
+
+	out, err := f.Apply(context.Background(), CommandFilterInput{
+		CommandType:       commandtype.SetPowerTarget,
+		OrganizationID:    1,
+		Actor:             session.ActorScheduler,
+		Source:            session.Source{ScheduleID: 10, SchedulePriority: 5},
+		DeviceIdentifiers: []string{"miner-1", "miner-2", "miner-3"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"miner-2"}, out.Kept)
+	assert.Equal(t, 2, len(out.Skipped))
+}

--- a/server/internal/domain/command/schedule_conflict_filter_test.go
+++ b/server/internal/domain/command/schedule_conflict_filter_test.go
@@ -7,24 +7,18 @@ import (
 	"github.com/alecthomas/assert/v2"
 	"go.uber.org/mock/gomock"
 
-	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
 	"github.com/block/proto-fleet/server/internal/domain/commandtype"
 	"github.com/block/proto-fleet/server/internal/domain/session"
+	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
 )
 
-// newScheduleConflictFilter wires the filter against fresh gomock-backed
-// stores. The collection store is included because expandTargets needs it
-// for rack/group target types — leaving it nil would panic on the first
-// non-miner target.
-func newScheduleConflictFilter(t *testing.T) (*ScheduleConflictFilter, *mocks.MockScheduleProcessorStore, *mocks.MockScheduleTargetStore, *mocks.MockCollectionStore) {
+func newScheduleConflictFilter(t *testing.T) (*ScheduleConflictFilter, *mocks.MockScheduleProcessorStore) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	procStore := mocks.NewMockScheduleProcessorStore(ctrl)
-	targetStore := mocks.NewMockScheduleTargetStore(ctrl)
-	collectionStore := mocks.NewMockCollectionStore(ctrl)
-	f := NewScheduleConflictFilter(procStore, targetStore, collectionStore)
-	return f, procStore, targetStore, collectionStore
+	f := NewScheduleConflictFilter(procStore)
+	return f, procStore
 }
 
 // --- Command-type gating ---
@@ -33,7 +27,7 @@ func TestScheduleConflictFilter_NonPowerTargetCommandPassesThrough(t *testing.T)
 	// Reboot/StopMining/etc. shouldn't even consult the schedule store —
 	// the existing inline filter only ran for SetPowerTarget and we're
 	// preserving that scope.
-	f, _, _, _ := newScheduleConflictFilter(t)
+	f, _ := newScheduleConflictFilter(t)
 
 	out, err := f.Apply(context.Background(), CommandFilterInput{
 		CommandType:       commandtype.Reboot,
@@ -46,7 +40,7 @@ func TestScheduleConflictFilter_NonPowerTargetCommandPassesThrough(t *testing.T)
 }
 
 func TestScheduleConflictFilter_EmptyInputPassesThrough(t *testing.T) {
-	f, _, _, _ := newScheduleConflictFilter(t)
+	f, _ := newScheduleConflictFilter(t)
 	out, err := f.Apply(context.Background(), CommandFilterInput{
 		CommandType:    commandtype.SetPowerTarget,
 		OrganizationID: 1,
@@ -61,12 +55,9 @@ func TestScheduleConflictFilter_EmptyInputPassesThrough(t *testing.T) {
 func TestScheduleConflictFilter_SchedulerOriginHigherPriorityBlocks(t *testing.T) {
 	// Caller is schedule 10 priority 5; running schedule 20 has priority 2
 	// (numerically lower → higher priority). Devices held by 20 must drop.
-	f, procStore, targetStore, _ := newScheduleConflictFilter(t)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
-		{Id: 20, Priority: 2, Action: pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET},
-	}, nil)
-	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(20)).Return([]*pb.ScheduleTarget{
-		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
+	f, procStore := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetScheduleOverlaps(gomock.Any(), int64(1), []string{"miner-1", "miner-2", "miner-3"}).Return([]stores.ScheduleTargetOverlap{
+		{ScheduleID: 20, SchedulePriority: 2, DeviceIdentifier: "miner-1"},
 	}, nil)
 
 	out, err := f.Apply(context.Background(), CommandFilterInput{
@@ -89,9 +80,9 @@ func TestScheduleConflictFilter_SchedulerOriginLowerPriorityIgnored(t *testing.T
 	// (numerically higher → lower priority). Devices held by 20 do NOT
 	// block — the caller wins, so nothing is filtered, and we don't even
 	// need to inspect that running schedule's targets.
-	f, procStore, _, _ := newScheduleConflictFilter(t)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
-		{Id: 20, Priority: 5},
+	f, procStore := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetScheduleOverlaps(gomock.Any(), int64(1), []string{"miner-1"}).Return([]stores.ScheduleTargetOverlap{
+		{ScheduleID: 20, SchedulePriority: 5, DeviceIdentifier: "miner-1"},
 	}, nil)
 
 	out, err := f.Apply(context.Background(), CommandFilterInput{
@@ -109,9 +100,9 @@ func TestScheduleConflictFilter_SchedulerOriginLowerPriorityIgnored(t *testing.T
 func TestScheduleConflictFilter_SchedulerOriginIgnoresSelf(t *testing.T) {
 	// A schedule must not conflict with itself even when its targets and
 	// the caller's selector overlap (which they always do by definition).
-	f, procStore, _, _ := newScheduleConflictFilter(t)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
-		{Id: 10, Priority: 5},
+	f, procStore := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetScheduleOverlaps(gomock.Any(), int64(1), []string{"miner-1"}).Return([]stores.ScheduleTargetOverlap{
+		{ScheduleID: 10, SchedulePriority: 5, DeviceIdentifier: "miner-1"},
 	}, nil)
 
 	out, err := f.Apply(context.Background(), CommandFilterInput{
@@ -132,12 +123,9 @@ func TestScheduleConflictFilter_ManualBlockedByAnyRunningSchedule(t *testing.T) 
 	// This is the headline pre-work behaviour change. With Source unset
 	// (manual API call, no priority), every running power-target schedule
 	// is a blocker for overlapping devices.
-	f, procStore, targetStore, _ := newScheduleConflictFilter(t)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
-		{Id: 20, Priority: 100, Action: pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET},
-	}, nil)
-	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(20)).Return([]*pb.ScheduleTarget{
-		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
+	f, procStore := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetScheduleOverlaps(gomock.Any(), int64(1), []string{"miner-1", "miner-2"}).Return([]stores.ScheduleTargetOverlap{
+		{ScheduleID: 20, SchedulePriority: 100, DeviceIdentifier: "miner-1"},
 	}, nil)
 
 	out, err := f.Apply(context.Background(), CommandFilterInput{
@@ -154,8 +142,8 @@ func TestScheduleConflictFilter_ManualBlockedByAnyRunningSchedule(t *testing.T) 
 }
 
 func TestScheduleConflictFilter_ManualUnaffectedWhenNoRunningSchedules(t *testing.T) {
-	f, procStore, _, _ := newScheduleConflictFilter(t)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return(nil, nil)
+	f, procStore := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetScheduleOverlaps(gomock.Any(), int64(1), []string{"miner-1", "miner-2"}).Return(nil, nil)
 
 	out, err := f.Apply(context.Background(), CommandFilterInput{
 		CommandType:       commandtype.SetPowerTarget,
@@ -167,21 +155,14 @@ func TestScheduleConflictFilter_ManualUnaffectedWhenNoRunningSchedules(t *testin
 	assert.Equal(t, 0, len(out.Skipped))
 }
 
-// --- Rack/group expansion ---
+// --- Rack/group overlaps from store ---
 
-func TestScheduleConflictFilter_ExpandsRackTargetsBeforeMatching(t *testing.T) {
-	// The running schedule targets a rack rather than individual miners;
-	// the filter must expand it via the collection store before deciding
-	// which of the caller's identifiers to skip.
-	f, procStore, targetStore, collectionStore := newScheduleConflictFilter(t)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return([]*pb.Schedule{
-		{Id: 20, Priority: 2, Action: pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET},
+func TestScheduleConflictFilter_RackOverlapFromStoreBlocks(t *testing.T) {
+	f, procStore := newScheduleConflictFilter(t)
+	procStore.EXPECT().GetRunningPowerTargetScheduleOverlaps(gomock.Any(), int64(1), []string{"miner-1", "miner-2", "miner-3"}).Return([]stores.ScheduleTargetOverlap{
+		{ScheduleID: 20, SchedulePriority: 2, DeviceIdentifier: "miner-1"},
+		{ScheduleID: 20, SchedulePriority: 2, DeviceIdentifier: "miner-3"},
 	}, nil)
-	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(20)).Return([]*pb.ScheduleTarget{
-		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_RACK, TargetId: "100"},
-	}, nil)
-	collectionStore.EXPECT().GetDeviceIdentifiersByDeviceSetID(gomock.Any(), int64(100), int64(1)).
-		Return([]string{"miner-1", "miner-3"}, nil)
 
 	out, err := f.Apply(context.Background(), CommandFilterInput{
 		CommandType:       commandtype.SetPowerTarget,

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -606,7 +606,8 @@ func (s *Service) resolveIdentifiersToDeviceIDs(ctx context.Context, identifiers
 // processCommand resolves selectors, runs preflight filters, writes the batch
 // row for surviving devices, and enqueues work. External callers fail fast on
 // any skip; internal callers may inspect CommandResult.Skipped and dispatch the
-// survivors. An empty BatchIdentifier means nothing was enqueued.
+// survivors. An empty BatchIdentifier is only valid for internal fully-filtered
+// no-ops.
 func (s *Service) processCommand(ctx context.Context, command *Command) (*CommandResult, error) {
 	if !s.executionService.IsRunning() {
 		slog.Error("command execution service is not running, attempting to start it")
@@ -655,8 +656,11 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 			len(skipped), len(identifiers))
 	}
 
-	if len(kept) == 0 {
+	if len(kept) == 0 && len(skipped) > 0 {
 		return &CommandResult{Skipped: skipped}, nil
+	}
+	if len(kept) == 0 {
+		return nil, fleeterror.NewInvalidArgumentError("no devices matched selector")
 	}
 
 	payloadBytes, err := json.Marshal(command.payload)
@@ -667,6 +671,12 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 	deviceIDs, err := s.resolveIdentifiersToDeviceIDs(ctx, kept)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error resolving identifiers to device IDs: %v", err)
+	}
+	if len(deviceIDs) == 0 {
+		if !isExternalCommand(info) {
+			return &CommandResult{Skipped: skipped}, nil
+		}
+		return nil, fleeterror.NewInvalidArgumentError("no devices matched selector")
 	}
 
 	batchLogIdentifier, err := s.saveCommandBatchLogToDB(ctx, info.UserID, info.OrganizationID, command, payloadBytes, len(deviceIDs))

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -63,11 +63,8 @@ type Service struct {
 	capabilityChecker   *CapabilityChecker
 	activitySvc         *activity.Service
 
-	// filters are consulted by processCommand before each dispatch. Order of
-	// registration is preserved at runtime; each filter sees only the survivors
-	// of earlier filters. Filters are registered at startup via RegisterFilter
-	// and the slice is not protected by a mutex — registration after the
-	// service starts handling traffic is not supported.
+	// filters run in registration order before commands are enqueued. Registered
+	// at startup only; the slice is not mutex-protected.
 	filters []CommandFilter
 }
 
@@ -139,22 +136,14 @@ func actorTypeFromSession(info *session.Info) activitymodels.ActorType {
 	return ""
 }
 
-// isExternalCommand reports whether the command is being issued by an
-// end-user / API-key caller (as opposed to an internal orchestrator like
-// the schedule processor or, later, the curtailment reconciler). External
-// callers are blocked outright on any preflight skip; internal callers
-// MUST set a non-empty session.Actor (or session.Source.ScheduleID for
-// the scheduler) so they aren't accidentally treated as external. This
-// fail-safe default protects against silent override attempts.
+// isExternalCommand is true for user/API-key traffic. Internal orchestrators
+// must set Actor or Source so preflight skips can use their domain semantics.
 func isExternalCommand(info *session.Info) bool {
 	return info.Actor == "" && info.Source.ScheduleID == 0
 }
 
-// activityEventType maps a commandtype.Type to its snake_case activity
-// event_type string, matching the literals each wrapper passes to
-// finalizeDispatch (e.g. commandtype.SetPowerTarget → "set_power_target").
-// Centralised here so processCommand's manual-block path uses the same
-// string the wrapper would have used on the success path.
+// activityEventType mirrors the event_type literals used by successful command
+// activity rows, so blocked-command audit uses the same names.
 func activityEventType(t commandtype.Type) string {
 	switch t {
 	case commandtype.StartMining:
@@ -184,11 +173,9 @@ func activityEventType(t commandtype.Type) string {
 	}
 }
 
-// logPreflightBlockedStrict writes the audit row recording that an external
-// command was rejected because preflight filters skipped one or more devices.
-// Returns the persistence error so callers can fail the request — the
-// security finding is about *invisible* override attempts, so a lost audit
-// row must not degrade into a normal FailedPrecondition.
+// logPreflightBlockedStrict records an external command rejected by preflight.
+// If this audit write fails, the caller must fail closed instead of returning
+// a normal FailedPrecondition with no durable trace.
 func (s *Service) logPreflightBlockedStrict(
 	ctx context.Context,
 	commandType commandtype.Type,
@@ -216,14 +203,8 @@ func (s *Service) logPreflightBlockedStrict(
 	})
 }
 
-// logFilterSkips writes the audit row recording that a dispatched command
-// had some devices excluded by preflight filters. Best-effort: a missing
-// audit row here is annoying but not security-critical (the dispatched
-// portion succeeded), and the schedule processor's own schedule_conflict_skip
-// activity provides a backup record.
-//
-// eventType is the snake_case activity event_type (matching the wrapper's
-// activity log row, e.g. "set_power_target"), not commandtype.Type.String().
+// logFilterSkips best-effort records a dispatched command whose preflight
+// filters excluded some devices. eventType is the snake_case activity name.
 func (s *Service) logFilterSkips(
 	ctx context.Context,
 	eventType string,
@@ -252,9 +233,7 @@ func (s *Service) logFilterSkips(
 	})
 }
 
-// skipMetadata is the shared metadata schema used by both
-// command_preflight_blocked and command_filter_skip activity rows so a
-// downstream consumer can parse either with a single struct.
+// skipMetadata is shared by command_preflight_blocked and command_filter_skip.
 func skipMetadata(eventType string, requestedCount int, skipped []SkippedDevice) map[string]any {
 	skippedIDs := make([]string, 0, len(skipped))
 	filterSet := make(map[string]struct{}, len(skipped))
@@ -539,18 +518,13 @@ func (s *Service) initializeStatusUpdateRoutine(commandBatchLogUUID string, onFi
 	}()
 }
 
-// RegisterFilter appends a CommandFilter to the preflight chain. Filters run
-// in registration order on every command flowing through processCommand —
-// schedule processor, manual API handler, curtailment reconciler, and any
-// future caller. Call this only at startup, before the service begins
-// handling traffic; the filter slice is not mutex-protected.
+// RegisterFilter appends to the startup-only preflight chain.
 func (s *Service) RegisterFilter(f CommandFilter) {
 	s.filters = append(s.filters, f)
 }
 
-// resolveSelectorIdentifiers expands a DeviceSelector to a list of
-// device_identifier strings within the caller's org. Used by processCommand
-// to feed preflight filters before resolving to internal IDs for enqueue.
+// resolveSelectorIdentifiers expands selectors to device_identifier strings for
+// preflight filtering.
 func (s *Service) resolveSelectorIdentifiers(ctx context.Context, selector *pb.DeviceSelector) ([]string, error) {
 	info, err := session.GetInfo(ctx)
 	if err != nil {
@@ -610,9 +584,7 @@ func (s *Service) resolveSelectorIdentifiers(ctx context.Context, selector *pb.D
 		if x.IncludeDevices == nil {
 			return []string{}, nil
 		}
-		// Defensive copy: filters MUST NOT mutate input slices, but a hostile
-		// or buggy filter shouldn't be able to corrupt the caller's request
-		// proto either.
+		// Isolate caller-owned proto slices from filter implementations.
 		out := make([]string, len(x.IncludeDevices.DeviceIdentifiers))
 		copy(out, x.IncludeDevices.DeviceIdentifiers)
 		return out, nil
@@ -621,8 +593,7 @@ func (s *Service) resolveSelectorIdentifiers(ctx context.Context, selector *pb.D
 	}
 }
 
-// resolveIdentifiersToDeviceIDs converts identifiers (post-filter) into the
-// internal int64 IDs the message queue uses.
+// resolveIdentifiersToDeviceIDs converts post-filter identifiers for the queue.
 func (s *Service) resolveIdentifiersToDeviceIDs(ctx context.Context, identifiers []string) ([]int64, error) {
 	if len(identifiers) == 0 {
 		return []int64{}, nil
@@ -632,27 +603,10 @@ func (s *Service) resolveIdentifiersToDeviceIDs(ctx context.Context, identifiers
 	})
 }
 
-// processCommand is the single internal entry point used by every public
-// dispatch wrapper (Reboot, StopMining, SetPowerTarget, …).
-//
-// Order of operations:
-//  1. Ensure the execution service is running.
-//  2. Resolve the selector to device_identifier strings.
-//  3. Run registered preflight filters; partition into kept + skipped.
-//  4. If kept is empty: return a CommandResult with empty BatchIdentifier
-//     and the skipped slice. NO command_batch_log row is created and NO
-//     queue messages are enqueued — callers MUST treat empty
-//     BatchIdentifier as "nothing was dispatched, do not start a status
-//     watcher or write a 'started' activity row".
-//  5. Save the batch log row, resolve kept identifiers to internal IDs,
-//     and enqueue.
-//
-// Empty-after-filter semantics: returning an empty BatchIdentifier is the
-// success-with-no-op outcome. Manual handlers translate this into an empty
-// BatchIdentifier on the wire response (existing wrappers' clients already
-// tolerate empty UUIDs since they previously appeared on no-error
-// no-dispatch paths). Schedule-origin and curtailment-origin callers
-// inspect Skipped to decide what to log.
+// processCommand resolves selectors, runs preflight filters, writes the batch
+// row for surviving devices, and enqueues work. External callers fail fast on
+// any skip; internal callers may inspect CommandResult.Skipped and dispatch the
+// survivors. An empty BatchIdentifier means nothing was enqueued.
 func (s *Service) processCommand(ctx context.Context, command *Command) (*CommandResult, error) {
 	if !s.executionService.IsRunning() {
 		slog.Error("command execution service is not running, attempting to start it")
@@ -690,12 +644,8 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 		return nil, fleeterror.NewInternalErrorf("preflight filter failed: %v", err)
 	}
 
-	// External callers (manual API, API key) are blocked outright on any
-	// preflight skip — silent subset dispatch lets operators believe a
-	// command applied to all selected devices when it only applied to a
-	// subset (Codex security review HIGH on PR #110). Internal orchestrators
-	// like the schedule processor handle skips themselves and keep the
-	// dispatch-survivors path below.
+	// External callers should not see a successful subset dispatch without an
+	// explicit best-effort API contract.
 	if isExternalCommand(info) && len(skipped) > 0 {
 		if err := s.logPreflightBlockedStrict(ctx, command.commandType, identifiers, skipped); err != nil {
 			return nil, fleeterror.NewInternalErrorf("logging preflight block: %v", err)
@@ -736,14 +686,9 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 	}, nil
 }
 
-// finalizeDispatch wires up the activity-started log row and the post-batch
-// status routine for any wrapper that successfully enqueued a batch. When
-// result.BatchIdentifier is empty (the all-skipped or empty-selector case
-// from processCommand) the dispatch path is skipped entirely — there is no
-// batch to track. The skip-audit path runs whenever any device was excluded
-// by preflight filters AND a real dispatch happened (BatchIdentifier != "");
-// the manual-blocked path emits its own command_preflight_blocked entry
-// inside processCommand and never reaches finalizeDispatch.
+// finalizeDispatch starts batch tracking for real dispatches and records any
+// best-effort filter skips. Blocked external commands are audited in
+// processCommand before this helper is reached.
 func (s *Service) finalizeDispatch(ctx context.Context, result *CommandResult, eventType, description string) {
 	if result.BatchIdentifier == "" {
 		return

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -144,8 +144,7 @@ func isExternalCommand(info *session.Info) bool {
 	return info.Actor == "" && info.Source.ScheduleID == 0
 }
 
-// activityEventType mirrors the event_type literals used by successful command
-// activity rows, so blocked-command audit uses the same names.
+// activityEventType mirrors successful command activity event names.
 func activityEventType(t commandtype.Type) string {
 	switch t {
 	case commandtype.StartMining:
@@ -175,9 +174,8 @@ func activityEventType(t commandtype.Type) string {
 	}
 }
 
-// logPreflightBlockedStrict records an external command rejected by preflight.
-// If this audit write fails, the caller must fail closed instead of returning
-// a normal FailedPrecondition with no durable trace.
+// logPreflightBlockedStrict records an external preflight rejection. Audit
+// failures are fatal so blocked commands always leave a durable trace.
 func (s *Service) logPreflightBlockedStrict(
 	ctx context.Context,
 	commandType commandtype.Type,
@@ -608,11 +606,9 @@ func (s *Service) resolveIdentifiersToDeviceIDs(ctx context.Context, identifiers
 	})
 }
 
-// processCommand resolves selectors, runs preflight filters, writes the batch
-// row for surviving devices, and enqueues work. External callers fail fast on
-// any skip; internal callers may inspect CommandResult.Skipped and dispatch the
-// survivors. An empty BatchIdentifier is only valid for internal fully-filtered
-// no-ops.
+// processCommand resolves selectors, filters, writes the batch row, and
+// enqueues work. External callers fail on skips; internal callers may inspect
+// CommandResult.Skipped.
 func (s *Service) processCommand(ctx context.Context, command *Command) (*CommandResult, error) {
 	if !s.executionService.IsRunning() {
 		slog.Error("command execution service is not running, attempting to start it")
@@ -627,9 +623,7 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 		return nil, fleeterror.NewInternalErrorf("error getting session info from ctx: %v", err)
 	}
 
-	// Org-id check moved up from saveCommandBatchLogToDB. With the preflight
-	// reorder, the selector resolver now runs first; we still want the same
-	// fast-path validation error to surface before any DB or filter call.
+	// Selector resolution now runs before batch creation, so validate org first.
 	if info.OrganizationID <= 0 {
 		return nil, fleeterror.NewInternalErrorf("cannot create command batch: session missing organization_id")
 	}

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -62,6 +62,13 @@ type Service struct {
 	telemetryListener   TelemetryListener
 	capabilityChecker   *CapabilityChecker
 	activitySvc         *activity.Service
+
+	// filters are consulted by processCommand before each dispatch. Order of
+	// registration is preserved at runtime; each filter sees only the survivors
+	// of earlier filters. Filters are registered at startup via RegisterFilter
+	// and the slice is not protected by a mutex — registration after the
+	// service starts handling traffic is not supported.
+	filters []CommandFilter
 }
 
 const defaultPoolPriority uint32 = 0
@@ -256,41 +263,9 @@ func (s *Service) buildActivityCompletedCallback(ctx context.Context, batchID, e
 	}
 }
 
-func (s *Service) getDevicesCount(ctx context.Context, selector *pb.DeviceSelector) (int32, error) {
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return 0, fleeterror.NewInternalErrorf("error getting session info from ctx: %v", err)
-	}
-
-	switch x := selector.SelectionType.(type) {
-	case *pb.DeviceSelector_AllDevices:
-		return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (int32, error) {
-			count, err := q.GetTotalPairedDevices(ctx, sqlc.GetTotalPairedDevicesParams{OrgID: info.OrganizationID})
-			if err != nil {
-				return 0, err
-			}
-			// #nosec G115 - We know device identifiers len won't exceed int32 max value
-			return int32(count), nil
-		})
-	case *pb.DeviceSelector_IncludeDevices:
-		// #nosec G115 - We know device identifiers len won't exceed int32 max value
-		return int32(len(x.IncludeDevices.DeviceIdentifiers)), nil
-	default:
-		return 0, fleeterror.NewInternalErrorf("getDevicesCount called with unknown type: %v", x)
-	}
-}
-
-func (s *Service) saveCommandBatchLogToDB(ctx context.Context, userID, organizationID int64, command *Command, payloadBytes []byte) (string, error) {
-	// Guard ordering matters: this check must fire before getDevicesCount so
-	// unit tests without a wired deviceStore still hit the org-id check
-	// cleanly, and invalid inputs do not waste a store round-trip.
+func (s *Service) saveCommandBatchLogToDB(ctx context.Context, userID, organizationID int64, command *Command, payloadBytes []byte, devicesCount int) (string, error) {
 	if organizationID <= 0 {
 		return "", fleeterror.NewInternalErrorf("cannot create command batch: session missing organization_id")
-	}
-
-	devicesCount, err := s.getDevicesCount(ctx, command.deviceSelector)
-	if err != nil {
-		return "", err
 	}
 
 	return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (string, error) {
@@ -303,7 +278,7 @@ func (s *Service) saveCommandBatchLogToDB(ctx context.Context, userID, organizat
 			CreatedBy:      userID,
 			CreatedAt:      timeNow,
 			Status:         sqlc.BatchStatusEnumPENDING,
-			DevicesCount:   devicesCount,
+			DevicesCount:   int32(devicesCount), //nolint:gosec // bounded by fleet size
 			Payload:        pqtype.NullRawMessage{RawMessage: payloadBytes, Valid: len(payloadBytes) > 0},
 			OrganizationID: sql.NullInt64{Int64: organizationID, Valid: true},
 		})
@@ -425,7 +400,19 @@ func (s *Service) initializeStatusUpdateRoutine(commandBatchLogUUID string, onFi
 	}()
 }
 
-func (s *Service) getDeviceIDs(ctx context.Context, selector *pb.DeviceSelector) ([]int64, error) {
+// RegisterFilter appends a CommandFilter to the preflight chain. Filters run
+// in registration order on every command flowing through processCommand —
+// schedule processor, manual API handler, curtailment reconciler, and any
+// future caller. Call this only at startup, before the service begins
+// handling traffic; the filter slice is not mutex-protected.
+func (s *Service) RegisterFilter(f CommandFilter) {
+	s.filters = append(s.filters, f)
+}
+
+// resolveSelectorIdentifiers expands a DeviceSelector to a list of
+// device_identifier strings within the caller's org. Used by processCommand
+// to feed preflight filters before resolving to internal IDs for enqueue.
+func (s *Service) resolveSelectorIdentifiers(ctx context.Context, selector *pb.DeviceSelector) ([]string, error) {
 	info, err := session.GetInfo(ctx)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error getting session info from context: %v", err)
@@ -438,7 +425,7 @@ func (s *Service) getDeviceIDs(ctx context.Context, selector *pb.DeviceSelector)
 			filter = &pb.DeviceFilter{}
 		}
 
-		return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]int64, error) {
+		return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]string, error) {
 			var deviceStatus sql.NullString
 			var pairingStatus sql.NullString
 			var modelFilter sql.NullString
@@ -472,7 +459,7 @@ func (s *Service) getDeviceIDs(ctx context.Context, selector *pb.DeviceSelector)
 				}
 			}
 
-			return q.GetFilteredDeviceIds(ctx, sqlc.GetFilteredDeviceIdsParams{
+			return q.GetFilteredDeviceIdentifiers(ctx, sqlc.GetFilteredDeviceIdentifiersParams{
 				OrgID:              info.OrganizationID,
 				DeviceStatus:       deviceStatus,
 				PairingStatus:      pairingStatus,
@@ -481,146 +468,194 @@ func (s *Service) getDeviceIDs(ctx context.Context, selector *pb.DeviceSelector)
 			})
 		})
 	case *pb.DeviceSelector_IncludeDevices:
-		if len(x.IncludeDevices.DeviceIdentifiers) == 0 {
-			return []int64{}, nil
+		if x.IncludeDevices == nil {
+			return []string{}, nil
 		}
-
-		return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]int64, error) {
-			return q.GetDeviceIDsByDeviceIdentifiers(ctx, x.IncludeDevices.DeviceIdentifiers)
-		})
+		// Defensive copy: filters MUST NOT mutate input slices, but a hostile
+		// or buggy filter shouldn't be able to corrupt the caller's request
+		// proto either.
+		out := make([]string, len(x.IncludeDevices.DeviceIdentifiers))
+		copy(out, x.IncludeDevices.DeviceIdentifiers)
+		return out, nil
 	default:
-		return nil, fleeterror.NewInternalErrorf("getDeviceIDs called with unknown type: %v", x)
+		return nil, fleeterror.NewInternalErrorf("resolveSelectorIdentifiers called with unknown selector type: %v", x)
 	}
 }
 
-func (s *Service) processCommand(ctx context.Context, command *Command) (string, int, error) {
+// resolveIdentifiersToDeviceIDs converts identifiers (post-filter) into the
+// internal int64 IDs the message queue uses.
+func (s *Service) resolveIdentifiersToDeviceIDs(ctx context.Context, identifiers []string) ([]int64, error) {
+	if len(identifiers) == 0 {
+		return []int64{}, nil
+	}
+	return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]int64, error) {
+		return q.GetDeviceIDsByDeviceIdentifiers(ctx, identifiers)
+	})
+}
+
+// processCommand is the single internal entry point used by every public
+// dispatch wrapper (Reboot, StopMining, SetPowerTarget, …).
+//
+// Order of operations:
+//  1. Ensure the execution service is running.
+//  2. Resolve the selector to device_identifier strings.
+//  3. Run registered preflight filters; partition into kept + skipped.
+//  4. If kept is empty: return a CommandResult with empty BatchIdentifier
+//     and the skipped slice. NO command_batch_log row is created and NO
+//     queue messages are enqueued — callers MUST treat empty
+//     BatchIdentifier as "nothing was dispatched, do not start a status
+//     watcher or write a 'started' activity row".
+//  5. Save the batch log row, resolve kept identifiers to internal IDs,
+//     and enqueue.
+//
+// Empty-after-filter semantics: returning an empty BatchIdentifier is the
+// success-with-no-op outcome. Manual handlers translate this into an empty
+// BatchIdentifier on the wire response (existing wrappers' clients already
+// tolerate empty UUIDs since they previously appeared on no-error
+// no-dispatch paths). Schedule-origin and curtailment-origin callers
+// inspect Skipped to decide what to log.
+func (s *Service) processCommand(ctx context.Context, command *Command) (*CommandResult, error) {
 	if !s.executionService.IsRunning() {
 		slog.Error("command execution service is not running, attempting to start it")
 		err := s.executionService.Start(ctx)
 		if err != nil {
-			return "", 0, fleeterror.NewInternalErrorf("failed to start command execution service: %v", err)
+			return nil, fleeterror.NewInternalErrorf("failed to start command execution service: %v", err)
 		}
 	}
 
 	info, err := session.GetInfo(ctx)
 	if err != nil {
-		return "", 0, fleeterror.NewInternalErrorf("error getting session info from ctx: %v", err)
+		return nil, fleeterror.NewInternalErrorf("error getting session info from ctx: %v", err)
+	}
+
+	// Org-id check moved up from saveCommandBatchLogToDB. With the preflight
+	// reorder, the selector resolver now runs first; we still want the same
+	// fast-path validation error to surface before any DB or filter call.
+	if info.OrganizationID <= 0 {
+		return nil, fleeterror.NewInternalErrorf("cannot create command batch: session missing organization_id")
+	}
+
+	identifiers, err := s.resolveSelectorIdentifiers(ctx, command.deviceSelector)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("error resolving device identifiers: %v", err)
+	}
+
+	kept, skipped, err := applyFilters(ctx, s.filters, CommandFilterInput{
+		CommandType:       command.commandType,
+		OrganizationID:    info.OrganizationID,
+		Actor:             info.Actor,
+		Source:            info.Source,
+		DeviceIdentifiers: identifiers,
+	})
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("preflight filter failed: %v", err)
+	}
+
+	if len(kept) == 0 {
+		return &CommandResult{Skipped: skipped}, nil
 	}
 
 	payloadBytes, err := json.Marshal(command.payload)
 	if err != nil {
-		return "", 0, fleeterror.NewInternalErrorf("error marshalling payload: %v", err)
+		return nil, fleeterror.NewInternalErrorf("error marshalling payload: %v", err)
 	}
 
-	batchLogIdentifier, err := s.saveCommandBatchLogToDB(ctx, info.UserID, info.OrganizationID, command, payloadBytes)
+	deviceIDs, err := s.resolveIdentifiersToDeviceIDs(ctx, kept)
 	if err != nil {
-		return "", 0, fleeterror.NewInternalErrorf("error saving command batch log to db: %v", err)
+		return nil, fleeterror.NewInternalErrorf("error resolving identifiers to device IDs: %v", err)
 	}
-	deviceIDs, err := s.getDeviceIDs(ctx, command.deviceSelector)
+
+	batchLogIdentifier, err := s.saveCommandBatchLogToDB(ctx, info.UserID, info.OrganizationID, command, payloadBytes, len(deviceIDs))
 	if err != nil {
-		return "", 0, fleeterror.NewInternalErrorf("error getting device IDs from device selector: %v", err)
+		return nil, fleeterror.NewInternalErrorf("error saving command batch log to db: %v", err)
 	}
 
 	err = s.messageQueue.Enqueue(ctx, batchLogIdentifier, command.commandType, deviceIDs, command.payload)
 	if err != nil {
-		return "", 0, fleeterror.NewInternalErrorf("error enqueuing a batch of commands: %v", err)
+		return nil, fleeterror.NewInternalErrorf("error enqueuing a batch of commands: %v", err)
 	}
 
-	return batchLogIdentifier, len(deviceIDs), nil
-}
-
-func (s *Service) Reboot(ctx context.Context, deviceSelector *pb.DeviceSelector) (*pb.RebootResponse, error) {
-	commandBatchLogUUID, deviceCount, err := s.processCommand(ctx, &Command{commandType: commandtype.Reboot, deviceSelector: deviceSelector, payload: nil})
-	if err != nil {
-		return nil, err
-	}
-
-	s.logCommandActivity(ctx, "reboot", "Reboot", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "reboot", "Reboot"))
-
-	return &pb.RebootResponse{
-		BatchIdentifier: commandBatchLogUUID,
+	return &CommandResult{
+		BatchIdentifier: batchLogIdentifier,
+		DispatchedCount: len(deviceIDs),
+		Skipped:         skipped,
 	}, nil
 }
 
+// finalizeDispatch wires up the activity-started log row and the post-batch
+// status routine for any wrapper that successfully enqueued a batch. It is a
+// no-op when result.BatchIdentifier is empty (the all-skipped or empty-selector
+// case from processCommand) — there is no batch to track.
+func (s *Service) finalizeDispatch(ctx context.Context, result *CommandResult, eventType, description string) {
+	if result.BatchIdentifier == "" {
+		return
+	}
+	s.logCommandActivity(ctx, eventType, description, result.DispatchedCount, result.BatchIdentifier)
+	s.initializeStatusUpdateRoutine(result.BatchIdentifier,
+		s.buildActivityCompletedCallback(ctx, result.BatchIdentifier, eventType, description))
+}
+
+func (s *Service) Reboot(ctx context.Context, deviceSelector *pb.DeviceSelector) (*CommandResult, error) {
+	result, err := s.processCommand(ctx, &Command{commandType: commandtype.Reboot, deviceSelector: deviceSelector, payload: nil})
+	if err != nil {
+		return nil, err
+	}
+	s.finalizeDispatch(ctx, result, "reboot", "Reboot")
+	return result, nil
+}
+
 // StopMining stops mining on the specified miners
-func (s *Service) StopMining(ctx context.Context, deviceSelector *pb.DeviceSelector) (*pb.StopMiningResponse, error) {
-	commandBatchLogUUID, deviceCount, err := s.processCommand(
+func (s *Service) StopMining(ctx context.Context, deviceSelector *pb.DeviceSelector) (*CommandResult, error) {
+	result, err := s.processCommand(
 		ctx,
 		&Command{commandType: commandtype.StopMining, deviceSelector: deviceSelector, payload: nil},
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	s.logCommandActivity(ctx, "stop_mining", "Sleep", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "stop_mining", "Sleep"))
-
-	return &pb.StopMiningResponse{
-		BatchIdentifier: commandBatchLogUUID,
-	}, nil
+	s.finalizeDispatch(ctx, result, "stop_mining", "Sleep")
+	return result, nil
 }
 
 // StartMining starts mining on the specified miners
-func (s *Service) StartMining(ctx context.Context, deviceSelector *pb.DeviceSelector) (*pb.StartMiningResponse, error) {
-	commandBatchLogUUID, deviceCount, err := s.processCommand(
+func (s *Service) StartMining(ctx context.Context, deviceSelector *pb.DeviceSelector) (*CommandResult, error) {
+	result, err := s.processCommand(
 		ctx,
 		&Command{commandType: commandtype.StartMining, deviceSelector: deviceSelector, payload: nil},
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	s.logCommandActivity(ctx, "start_mining", "Wake up", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "start_mining", "Wake up"))
-
-	return &pb.StartMiningResponse{
-		BatchIdentifier: commandBatchLogUUID,
-	}, nil
+	s.finalizeDispatch(ctx, result, "start_mining", "Wake up")
+	return result, nil
 }
 
-func (s *Service) SetCoolingMode(ctx context.Context, deviceSelector *pb.DeviceSelector, modeType commonpb.CoolingMode) (*pb.SetCoolingModeResponse, error) {
+func (s *Service) SetCoolingMode(ctx context.Context, deviceSelector *pb.DeviceSelector, modeType commonpb.CoolingMode) (*CommandResult, error) {
 	cm := dto.CoolingModePayload{Mode: modeType}
-	commandBatchLogUUID, deviceCount, err := s.processCommand(
+	result, err := s.processCommand(
 		ctx,
 		&Command{commandType: commandtype.SetCoolingMode, deviceSelector: deviceSelector, payload: cm},
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	s.logCommandActivity(ctx, "set_cooling_mode", "Cooling mode changed", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "set_cooling_mode", "Cooling mode changed"))
-
-	return &pb.SetCoolingModeResponse{
-		BatchIdentifier: commandBatchLogUUID,
-	}, nil
+	s.finalizeDispatch(ctx, result, "set_cooling_mode", "Cooling mode changed")
+	return result, nil
 }
 
-func (s *Service) SetPowerTarget(ctx context.Context, deviceSelector *pb.DeviceSelector, performanceMode pb.PerformanceMode) (*pb.SetPowerTargetResponse, error) {
+func (s *Service) SetPowerTarget(ctx context.Context, deviceSelector *pb.DeviceSelector, performanceMode pb.PerformanceMode) (*CommandResult, error) {
 	pt := dto.PowerTargetPayload{
 		PerformanceMode: performanceMode,
 	}
-	commandBatchLogUUID, deviceCount, err := s.processCommand(
+	result, err := s.processCommand(
 		ctx,
 		&Command{commandType: commandtype.SetPowerTarget, deviceSelector: deviceSelector, payload: pt},
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	description := fmt.Sprintf("Power target changed to %s", performanceMode.String())
-	s.logCommandActivity(ctx, "set_power_target", description, deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "set_power_target", description))
-
-	return &pb.SetPowerTargetResponse{
-		BatchIdentifier: commandBatchLogUUID,
-	}, nil
+	s.finalizeDispatch(ctx, result, "set_power_target", fmt.Sprintf("Power target changed to %s", performanceMode.String()))
+	return result, nil
 }
 
 func (s *Service) createMiningPoolDTO(ctx context.Context, poolID int64, priorityIncrement uint32) (*dto.MiningPool, error) {
@@ -726,7 +761,7 @@ func (s *Service) UpdateMiningPools(
 	defaultPool, backup1Pool, backup2Pool *pb.PoolSlotConfig,
 	userUsername string,
 	userPassword string,
-) (*pb.UpdateMiningPoolsResponse, error) {
+) (*CommandResult, error) {
 	if err := s.verifyUserCredentials(ctx, userUsername, userPassword); err != nil {
 		return nil, err
 	}
@@ -736,19 +771,15 @@ func (s *Service) UpdateMiningPools(
 		return nil, err
 	}
 
-	commandBatchLogUUID, deviceCount, err := s.processCommand(
+	result, err := s.processCommand(
 		ctx,
 		&Command{commandType: commandtype.UpdateMiningPools, deviceSelector: deviceSelector, payload: pld},
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	s.logCommandActivity(ctx, "update_mining_pools", "Edit pool", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "update_mining_pools", "Edit pool"))
-
-	return &pb.UpdateMiningPoolsResponse{BatchIdentifier: commandBatchLogUUID}, nil
+	s.finalizeDispatch(ctx, result, "update_mining_pools", "Edit pool")
+	return result, nil
 }
 
 func (s *Service) VerifyCredentials(ctx context.Context, username string, password string) error {
@@ -801,7 +832,7 @@ func (s *Service) ReapplyCurrentPoolsWithWorkerNames(
 		return "", fleeterror.NewInternalErrorf("error marshalling payload: %v", err)
 	}
 
-	commandBatchLogUUID, err := s.saveCommandBatchLogToDB(ctx, info.UserID, info.OrganizationID, command, payloadBytes)
+	commandBatchLogUUID, err := s.saveCommandBatchLogToDB(ctx, info.UserID, info.OrganizationID, command, payloadBytes, len(deviceIdentifiers))
 	if err != nil {
 		return "", fleeterror.NewInternalErrorf("error saving command batch log to db: %v", err)
 	}
@@ -870,8 +901,8 @@ func (s *Service) enqueueWorkerNameReapplyMessages(
 	})
 }
 
-func (s *Service) DownloadLogs(ctx context.Context, deviceSelector *pb.DeviceSelector) (*pb.DownloadLogsResponse, error) {
-	commandBatchLogUUID, deviceCount, err := s.processCommand(
+func (s *Service) DownloadLogs(ctx context.Context, deviceSelector *pb.DeviceSelector) (*CommandResult, error) {
+	result, err := s.processCommand(
 		ctx,
 		&Command{commandType: commandtype.DownloadLogs, deviceSelector: deviceSelector, payload: nil},
 	)
@@ -879,37 +910,35 @@ func (s *Service) DownloadLogs(ctx context.Context, deviceSelector *pb.DeviceSel
 		return nil, err
 	}
 
-	// Bundle callback runs first so the ZIP is on disk before the activity log
-	// marks the batch as completed; the activity finalizer then writes the
-	// completion row. Both are chained through composeFinalizers.
-	bundleCb := s.filesService.DownloadLogsOnFinishedCallback(commandBatchLogUUID)
-	activityCb := s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "download_logs", "Download logs")
-	s.logCommandActivity(ctx, "download_logs", "Download logs", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID, composeFinalizers(bundleCb, activityCb))
+	if result.BatchIdentifier != "" {
+		// Bundle callback runs first so the ZIP is on disk before the activity
+		// log marks the batch as completed; the activity finalizer then writes
+		// the completion row. Both are chained through composeFinalizers.
+		bundleCb := s.filesService.DownloadLogsOnFinishedCallback(result.BatchIdentifier)
+		activityCb := s.buildActivityCompletedCallback(ctx, result.BatchIdentifier, "download_logs", "Download logs")
+		s.logCommandActivity(ctx, "download_logs", "Download logs", result.DispatchedCount, result.BatchIdentifier)
+		s.initializeStatusUpdateRoutine(result.BatchIdentifier, composeFinalizers(bundleCb, activityCb))
+	}
 
-	return &pb.DownloadLogsResponse{BatchIdentifier: commandBatchLogUUID}, nil
+	return result, nil
 }
 
-func (s *Service) BlinkLED(ctx context.Context, deviceSelector *pb.DeviceSelector) (*pb.BlinkLEDResponse, error) {
-	commandBatchLogUUID, deviceCount, err := s.processCommand(ctx, &Command{commandType: commandtype.BlinkLED, deviceSelector: deviceSelector, payload: nil})
+func (s *Service) BlinkLED(ctx context.Context, deviceSelector *pb.DeviceSelector) (*CommandResult, error) {
+	result, err := s.processCommand(ctx, &Command{commandType: commandtype.BlinkLED, deviceSelector: deviceSelector, payload: nil})
 	if err != nil {
 		return nil, err
 	}
-
-	s.logCommandActivity(ctx, "blink_led", "Blink LEDs", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "blink_led", "Blink LEDs"))
-
-	return &pb.BlinkLEDResponse{BatchIdentifier: commandBatchLogUUID}, nil
+	s.finalizeDispatch(ctx, result, "blink_led", "Blink LEDs")
+	return result, nil
 }
 
-func (s *Service) FirmwareUpdate(ctx context.Context, deviceSelector *pb.DeviceSelector, firmwareFileID string) (*pb.FirmwareUpdateResponse, error) {
+func (s *Service) FirmwareUpdate(ctx context.Context, deviceSelector *pb.DeviceSelector, firmwareFileID string) (*CommandResult, error) {
 	if _, err := s.filesService.GetFirmwareFilePath(firmwareFileID); err != nil {
 		return nil, fleeterror.NewInvalidArgumentError(fmt.Sprintf("invalid firmware_file_id: %v", err))
 	}
 
 	payload := dto.FirmwareUpdatePayload{FirmwareFileID: firmwareFileID}
-	commandBatchLogUUID, deviceCount, err := s.processCommand(ctx, &Command{
+	result, err := s.processCommand(ctx, &Command{
 		commandType:    commandtype.FirmwareUpdate,
 		deviceSelector: deviceSelector,
 		payload:        payload,
@@ -917,25 +946,17 @@ func (s *Service) FirmwareUpdate(ctx context.Context, deviceSelector *pb.DeviceS
 	if err != nil {
 		return nil, err
 	}
-
-	s.logCommandActivity(ctx, "firmware_update", "Update firmware", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "firmware_update", "Update firmware"))
-
-	return &pb.FirmwareUpdateResponse{BatchIdentifier: commandBatchLogUUID}, nil
+	s.finalizeDispatch(ctx, result, "firmware_update", "Update firmware")
+	return result, nil
 }
 
-func (s *Service) Unpair(ctx context.Context, deviceSelector *pb.DeviceSelector) (*pb.UnpairResponse, error) {
-	commandBatchLogUUID, deviceCount, err := s.processCommand(ctx, &Command{commandType: commandtype.Unpair, deviceSelector: deviceSelector, payload: nil})
+func (s *Service) Unpair(ctx context.Context, deviceSelector *pb.DeviceSelector) (*CommandResult, error) {
+	result, err := s.processCommand(ctx, &Command{commandType: commandtype.Unpair, deviceSelector: deviceSelector, payload: nil})
 	if err != nil {
 		return nil, err
 	}
-
-	s.logCommandActivity(ctx, "unpair", "Unpair", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "unpair", "Unpair"))
-
-	return &pb.UnpairResponse{BatchIdentifier: commandBatchLogUUID}, nil
+	s.finalizeDispatch(ctx, result, "unpair", "Unpair")
+	return result, nil
 }
 
 // verifyUserCredentials verifies the provided username and password match the current authenticated user
@@ -980,7 +1001,7 @@ func (s *Service) UpdateMinerPassword(
 	currentPassword string,
 	userUsername string,
 	userPassword string,
-) (*pb.UpdateMinerPasswordResponse, error) {
+) (*CommandResult, error) {
 	// Validate required fields
 	if newPassword == "" {
 		return nil, fleeterror.NewInvalidArgumentError("new_password is required")
@@ -999,7 +1020,7 @@ func (s *Service) UpdateMinerPassword(
 		CurrentPassword: currentPassword,
 	}
 
-	commandBatchLogUUID, deviceCount, err := s.processCommand(
+	result, err := s.processCommand(
 		ctx,
 		&Command{
 			commandType:    commandtype.UpdateMinerPassword,
@@ -1010,14 +1031,8 @@ func (s *Service) UpdateMinerPassword(
 	if err != nil {
 		return nil, err
 	}
-
-	s.logCommandActivity(ctx, "update_miner_password", "Manage security", deviceCount, commandBatchLogUUID)
-	s.initializeStatusUpdateRoutine(commandBatchLogUUID,
-		s.buildActivityCompletedCallback(ctx, commandBatchLogUUID, "update_miner_password", "Manage security"))
-
-	return &pb.UpdateMinerPasswordResponse{
-		BatchIdentifier: commandBatchLogUUID,
-	}, nil
+	s.finalizeDispatch(ctx, result, "update_miner_password", "Manage security")
+	return result, nil
 }
 
 func (s *Service) StreamCommandBatchUpdates(ctx context.Context, msg *pb.StreamCommandBatchUpdatesRequest) (<-chan *pb.StreamCommandBatchUpdatesResponse, error) {

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -139,6 +139,145 @@ func actorTypeFromSession(info *session.Info) activitymodels.ActorType {
 	return ""
 }
 
+// isExternalCommand reports whether the command is being issued by an
+// end-user / API-key caller (as opposed to an internal orchestrator like
+// the schedule processor or, later, the curtailment reconciler). External
+// callers are blocked outright on any preflight skip; internal callers
+// MUST set a non-empty session.Actor (or session.Source.ScheduleID for
+// the scheduler) so they aren't accidentally treated as external. This
+// fail-safe default protects against silent override attempts.
+func isExternalCommand(info *session.Info) bool {
+	return info.Actor == "" && info.Source.ScheduleID == 0
+}
+
+// activityEventType maps a commandtype.Type to its snake_case activity
+// event_type string, matching the literals each wrapper passes to
+// finalizeDispatch (e.g. commandtype.SetPowerTarget → "set_power_target").
+// Centralised here so processCommand's manual-block path uses the same
+// string the wrapper would have used on the success path.
+func activityEventType(t commandtype.Type) string {
+	switch t {
+	case commandtype.StartMining:
+		return "start_mining"
+	case commandtype.StopMining:
+		return "stop_mining"
+	case commandtype.SetCoolingMode:
+		return "set_cooling_mode"
+	case commandtype.SetPowerTarget:
+		return "set_power_target"
+	case commandtype.UpdateMiningPools:
+		return "update_mining_pools"
+	case commandtype.DownloadLogs:
+		return "download_logs"
+	case commandtype.Reboot:
+		return "reboot"
+	case commandtype.BlinkLED:
+		return "blink_led"
+	case commandtype.FirmwareUpdate:
+		return "firmware_update"
+	case commandtype.Unpair:
+		return "unpair"
+	case commandtype.UpdateMinerPassword:
+		return "update_miner_password"
+	default:
+		return t.String()
+	}
+}
+
+// logPreflightBlockedStrict writes the audit row recording that an external
+// command was rejected because preflight filters skipped one or more devices.
+// Returns the persistence error so callers can fail the request — the
+// security finding is about *invisible* override attempts, so a lost audit
+// row must not degrade into a normal FailedPrecondition.
+func (s *Service) logPreflightBlockedStrict(
+	ctx context.Context,
+	commandType commandtype.Type,
+	requestedIdentifiers []string,
+	skipped []SkippedDevice,
+) error {
+	if s.activitySvc == nil {
+		return nil
+	}
+	info, err := session.GetInfo(ctx)
+	if err != nil {
+		return fleeterror.NewInternalErrorf("error getting session info from ctx: %v", err)
+	}
+	eventType := activityEventType(commandType)
+	return s.activitySvc.LogStrict(ctx, activitymodels.Event{
+		Category:       activitymodels.CategoryDeviceCommand,
+		Type:           "command_preflight_blocked",
+		Description:    fmt.Sprintf("Command %q blocked: %d of %d device(s) excluded by preflight filters", eventType, len(skipped), len(requestedIdentifiers)),
+		Result:         activitymodels.ResultFailure,
+		ActorType:      actorTypeFromSession(info),
+		UserID:         &info.ExternalUserID,
+		Username:       &info.Username,
+		OrganizationID: &info.OrganizationID,
+		Metadata:       skipMetadata(eventType, len(requestedIdentifiers), skipped),
+	})
+}
+
+// logFilterSkips writes the audit row recording that a dispatched command
+// had some devices excluded by preflight filters. Best-effort: a missing
+// audit row here is annoying but not security-critical (the dispatched
+// portion succeeded), and the schedule processor's own schedule_conflict_skip
+// activity provides a backup record.
+//
+// eventType is the snake_case activity event_type (matching the wrapper's
+// activity log row, e.g. "set_power_target"), not commandtype.Type.String().
+func (s *Service) logFilterSkips(
+	ctx context.Context,
+	eventType string,
+	dispatchedCount int,
+	skipped []SkippedDevice,
+) {
+	if s.activitySvc == nil {
+		return
+	}
+	info, err := session.GetInfo(ctx)
+	if err != nil {
+		slog.Warn("failed to log filter skips: session info unavailable", "error", err)
+		return
+	}
+	requestedCount := dispatchedCount + len(skipped)
+	s.activitySvc.Log(ctx, activitymodels.Event{
+		Category:       activitymodels.CategoryDeviceCommand,
+		Type:           "command_filter_skip",
+		Description:    fmt.Sprintf("Command %q dispatched with %d device(s) excluded by preflight filters", eventType, len(skipped)),
+		Result:         activitymodels.ResultSuccess,
+		ActorType:      actorTypeFromSession(info),
+		UserID:         &info.ExternalUserID,
+		Username:       &info.Username,
+		OrganizationID: &info.OrganizationID,
+		Metadata:       skipMetadata(eventType, requestedCount, skipped),
+	})
+}
+
+// skipMetadata is the shared metadata schema used by both
+// command_preflight_blocked and command_filter_skip activity rows so a
+// downstream consumer can parse either with a single struct.
+func skipMetadata(eventType string, requestedCount int, skipped []SkippedDevice) map[string]any {
+	skippedIDs := make([]string, 0, len(skipped))
+	filterSet := make(map[string]struct{}, len(skipped))
+	for _, sk := range skipped {
+		skippedIDs = append(skippedIDs, sk.DeviceIdentifier)
+		if sk.FilterName != "" {
+			filterSet[sk.FilterName] = struct{}{}
+		}
+	}
+	filters := make([]string, 0, len(filterSet))
+	for name := range filterSet {
+		filters = append(filters, name)
+	}
+	sort.Strings(filters)
+	return map[string]any{
+		"command_type":        eventType,
+		"requested_count":     requestedCount,
+		"skipped_count":       len(skipped),
+		"skipped_identifiers": skippedIDs,
+		"filters":             filters,
+	}
+}
+
 // composeFinalizers chains onFinished callbacks so commands like DownloadLogs
 // can layer a bundle builder alongside the activity finalizer. Nil callbacks
 // are skipped; empty input returns nil. Best-effort: every callback runs even
@@ -551,6 +690,21 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 		return nil, fleeterror.NewInternalErrorf("preflight filter failed: %v", err)
 	}
 
+	// External callers (manual API, API key) are blocked outright on any
+	// preflight skip — silent subset dispatch lets operators believe a
+	// command applied to all selected devices when it only applied to a
+	// subset (Codex security review HIGH on PR #110). Internal orchestrators
+	// like the schedule processor handle skips themselves and keep the
+	// dispatch-survivors path below.
+	if isExternalCommand(info) && len(skipped) > 0 {
+		if err := s.logPreflightBlockedStrict(ctx, command.commandType, identifiers, skipped); err != nil {
+			return nil, fleeterror.NewInternalErrorf("logging preflight block: %v", err)
+		}
+		return nil, fleeterror.NewFailedPreconditionErrorf(
+			"command blocked: %d of %d device(s) excluded by preflight filters",
+			len(skipped), len(identifiers))
+	}
+
 	if len(kept) == 0 {
 		return &CommandResult{Skipped: skipped}, nil
 	}
@@ -583,9 +737,13 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 }
 
 // finalizeDispatch wires up the activity-started log row and the post-batch
-// status routine for any wrapper that successfully enqueued a batch. It is a
-// no-op when result.BatchIdentifier is empty (the all-skipped or empty-selector
-// case from processCommand) — there is no batch to track.
+// status routine for any wrapper that successfully enqueued a batch. When
+// result.BatchIdentifier is empty (the all-skipped or empty-selector case
+// from processCommand) the dispatch path is skipped entirely — there is no
+// batch to track. The skip-audit path runs whenever any device was excluded
+// by preflight filters AND a real dispatch happened (BatchIdentifier != "");
+// the manual-blocked path emits its own command_preflight_blocked entry
+// inside processCommand and never reaches finalizeDispatch.
 func (s *Service) finalizeDispatch(ctx context.Context, result *CommandResult, eventType, description string) {
 	if result.BatchIdentifier == "" {
 		return
@@ -593,6 +751,9 @@ func (s *Service) finalizeDispatch(ctx context.Context, result *CommandResult, e
 	s.logCommandActivity(ctx, eventType, description, result.DispatchedCount, result.BatchIdentifier)
 	s.initializeStatusUpdateRoutine(result.BatchIdentifier,
 		s.buildActivityCompletedCallback(ctx, result.BatchIdentifier, eventType, description))
+	if len(result.Skipped) > 0 {
+		s.logFilterSkips(ctx, eventType, result.DispatchedCount, result.Skipped)
+	}
 }
 
 func (s *Service) Reboot(ctx context.Context, deviceSelector *pb.DeviceSelector) (*CommandResult, error) {

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -175,7 +175,10 @@ func activityEventType(t commandtype.Type) string {
 }
 
 // logPreflightBlockedStrict records an external preflight rejection. Audit
-// failures are fatal so blocked commands always leave a durable trace.
+// failures are fatal so blocked commands always leave a durable trace. The
+// store write uses a bounded background ctx so a client disconnect at the
+// deny-point cannot suppress the row or degrade FailedPrecondition into
+// Internal.
 func (s *Service) logPreflightBlockedStrict(
 	ctx context.Context,
 	commandType commandtype.Type,
@@ -190,7 +193,9 @@ func (s *Service) logPreflightBlockedStrict(
 		return fleeterror.NewInternalErrorf("error getting session info from ctx: %v", err)
 	}
 	eventType := activityEventType(commandType)
-	return s.activitySvc.LogStrict(ctx, activitymodels.Event{
+	auditCtx, cancel := context.WithTimeout(context.Background(), finalizerDBTimeout)
+	defer cancel()
+	return s.activitySvc.LogStrict(auditCtx, activitymodels.Event{
 		Category:       activitymodels.CategoryDeviceCommand,
 		Type:           "command_preflight_blocked",
 		Description:    fmt.Sprintf("Command %q blocked: %d of %d device(s) excluded by preflight filters", eventType, len(skipped), len(requestedIdentifiers)),
@@ -644,17 +649,16 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 		return nil, fleeterror.NewInternalErrorf("preflight filter failed: %v", err)
 	}
 
-	// External callers should not see a successful subset dispatch without an
-	// explicit best-effort API contract.
+	// External callers fail-closed on any skip. Resolve original identifiers
+	// first so a stale selector with zero live devices returns InvalidArgument
+	// regardless of how the kept/skipped partition fell.
 	if isExternalCommand(info) && len(skipped) > 0 {
-		if len(kept) == 0 {
-			deviceIDs, err := s.resolveIdentifiersToDeviceIDs(ctx, identifiers)
-			if err != nil {
-				return nil, fleeterror.NewInternalErrorf("error resolving identifiers to device IDs: %v", err)
-			}
-			if len(deviceIDs) == 0 {
-				return nil, fleeterror.NewInvalidArgumentError("no devices matched selector")
-			}
+		deviceIDs, err := s.resolveIdentifiersToDeviceIDs(ctx, identifiers)
+		if err != nil {
+			return nil, fleeterror.NewInternalErrorf("error resolving identifiers to device IDs: %v", err)
+		}
+		if len(deviceIDs) == 0 {
+			return nil, fleeterror.NewInvalidArgumentError("no devices matched selector")
 		}
 		if err := s.logPreflightBlockedStrict(ctx, command.commandType, identifiers, skipped); err != nil {
 			return nil, fleeterror.NewInternalErrorf("logging preflight block: %v", err)

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -63,6 +63,8 @@ type Service struct {
 	capabilityChecker   *CapabilityChecker
 	activitySvc         *activity.Service
 
+	resolveDeviceIDsOverride func(context.Context, []string) ([]int64, error)
+
 	// filters run in registration order before commands are enqueued. Registered
 	// at startup only; the slice is not mutex-protected.
 	filters []CommandFilter
@@ -598,6 +600,9 @@ func (s *Service) resolveIdentifiersToDeviceIDs(ctx context.Context, identifiers
 	if len(identifiers) == 0 {
 		return []int64{}, nil
 	}
+	if s.resolveDeviceIDsOverride != nil {
+		return s.resolveDeviceIDsOverride(ctx, identifiers)
+	}
 	return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]int64, error) {
 		return q.GetDeviceIDsByDeviceIdentifiers(ctx, identifiers)
 	})
@@ -648,6 +653,15 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 	// External callers should not see a successful subset dispatch without an
 	// explicit best-effort API contract.
 	if isExternalCommand(info) && len(skipped) > 0 {
+		if len(kept) == 0 {
+			deviceIDs, err := s.resolveIdentifiersToDeviceIDs(ctx, identifiers)
+			if err != nil {
+				return nil, fleeterror.NewInternalErrorf("error resolving identifiers to device IDs: %v", err)
+			}
+			if len(deviceIDs) == 0 {
+				return nil, fleeterror.NewInvalidArgumentError("no devices matched selector")
+			}
+		}
 		if err := s.logPreflightBlockedStrict(ctx, command.commandType, identifiers, skipped); err != nil {
 			return nil, fleeterror.NewInternalErrorf("logging preflight block: %v", err)
 		}

--- a/server/internal/domain/command/session_org_validation_test.go
+++ b/server/internal/domain/command/session_org_validation_test.go
@@ -50,7 +50,7 @@ func TestProcessCommand_RejectsMissingOrgID(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := sessionCtxWithOrg(tc.orgID)
-			_, _, err := svc.processCommand(ctx, &Command{
+			_, err := svc.processCommand(ctx, &Command{
 				commandType:    commandtype.Reboot,
 				deviceSelector: &pb.DeviceSelector{},
 			})

--- a/server/internal/domain/command/zero_target_integration_test.go
+++ b/server/internal/domain/command/zero_target_integration_test.go
@@ -1,0 +1,162 @@
+package command_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"connectrpc.com/authn"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/block/proto-fleet/server/generated/grpc/common/v1"
+	pb "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
+	"github.com/block/proto-fleet/server/internal/domain/command"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/infrastructure/queue"
+	"github.com/block/proto-fleet/server/internal/testutil"
+)
+
+func newZeroTargetDispatchTestService(t *testing.T, conn *sql.DB) *command.Service {
+	t.Helper()
+
+	commandConfig := &command.Config{
+		MaxWorkers:                       1,
+		MasterPollingInterval:            10 * time.Millisecond,
+		WorkerExecutionTimeout:           time.Second,
+		BatchStatusUpdatePollingInterval: 10 * time.Millisecond,
+		DequeueRetries:                   0,
+		StuckMessageTimeout:              time.Hour,
+		ReaperInterval:                   time.Hour,
+	}
+	queueConfig := &queue.Config{
+		DequeLimit:        10,
+		MaxFailureRetries: 1,
+	}
+	messageQueue := queue.NewDatabaseMessageQueue(queueConfig, conn)
+	executionCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	executionService := command.NewExecutionService(
+		executionCtx,
+		commandConfig,
+		conn,
+		messageQueue,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, executionService.Start(executionCtx))
+
+	return command.NewService(
+		commandConfig,
+		conn,
+		executionService,
+		messageQueue,
+		command.NewStatusService(conn, messageQueue),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func countCommandBatches(t *testing.T, conn *sql.DB, orgID int64) int {
+	t.Helper()
+	var count int
+	err := conn.QueryRowContext(
+		context.Background(),
+		`SELECT COUNT(*) FROM command_batch_log WHERE organization_id = $1`,
+		orgID,
+	).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+func TestSetPowerTarget_UnresolvedIncludeSelector_ReturnsInvalidArgumentBeforeBatchCreation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	conn, dbService, user := setupRetentionTest(t)
+	svc := newZeroTargetDispatchTestService(t, conn)
+
+	deletedDevice := dbService.CreateDevice(user.OrganizationID, "proto")
+	_, err := conn.ExecContext(
+		context.Background(),
+		`UPDATE device SET deleted_at = NOW() WHERE id = $1`,
+		deletedDevice.DatabaseID,
+	)
+	require.NoError(t, err)
+
+	before := countCommandBatches(t, conn, user.OrganizationID)
+	authCtx := testutil.MockAuthContextForTesting(context.Background(), user.DatabaseID, user.OrganizationID)
+	resp, err := svc.SetPowerTarget(
+		authCtx,
+		&pb.DeviceSelector{
+			SelectionType: &pb.DeviceSelector_IncludeDevices{
+				IncludeDevices: &commonpb.DeviceIdentifierList{
+					DeviceIdentifiers: []string{"missing-device", deletedDevice.ID},
+				},
+			},
+		},
+		pb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY,
+	)
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.True(t, errors.As(err, &fleetErr), "expected FleetError, got %T", err)
+	assert.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
+	assert.Contains(t, err.Error(), "no devices matched selector")
+	assert.Equal(t, before, countCommandBatches(t, conn, user.OrganizationID))
+}
+
+func TestSetPowerTarget_SchedulerStaleTargets_ReturnsNoOpBeforeBatchCreation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	conn, _, user := setupRetentionTest(t)
+	svc := newZeroTargetDispatchTestService(t, conn)
+
+	before := countCommandBatches(t, conn, user.OrganizationID)
+	schedulerCtx := authn.SetInfo(context.Background(), &session.Info{
+		SessionID:      "scheduler",
+		UserID:         user.DatabaseID,
+		OrganizationID: user.OrganizationID,
+		ExternalUserID: "scheduler",
+		Username:       "scheduler",
+		Actor:          session.ActorScheduler,
+		Source:         session.Source{ScheduleID: 99, SchedulePriority: 5},
+	})
+	resp, err := svc.SetPowerTarget(
+		schedulerCtx,
+		&pb.DeviceSelector{
+			SelectionType: &pb.DeviceSelector_IncludeDevices{
+				IncludeDevices: &commonpb.DeviceIdentifierList{
+					DeviceIdentifiers: []string{"missing-device"},
+				},
+			},
+		},
+		pb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.BatchIdentifier)
+	assert.Zero(t, resp.DispatchedCount)
+	assert.Empty(t, resp.Skipped)
+	assert.Equal(t, before, countCommandBatches(t, conn, user.OrganizationID))
+}

--- a/server/internal/domain/schedule/mock_command_dispatcher_test.go
+++ b/server/internal/domain/schedule/mock_command_dispatcher_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	minercommandv1 "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
+	command "github.com/block/proto-fleet/server/internal/domain/command"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -42,10 +43,10 @@ func (m *MockCommandDispatcher) EXPECT() *MockCommandDispatcherMockRecorder {
 }
 
 // Reboot mocks base method.
-func (m *MockCommandDispatcher) Reboot(ctx context.Context, selector *minercommandv1.DeviceSelector) (*minercommandv1.RebootResponse, error) {
+func (m *MockCommandDispatcher) Reboot(ctx context.Context, selector *minercommandv1.DeviceSelector) (*command.CommandResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reboot", ctx, selector)
-	ret0, _ := ret[0].(*minercommandv1.RebootResponse)
+	ret0, _ := ret[0].(*command.CommandResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -57,10 +58,10 @@ func (mr *MockCommandDispatcherMockRecorder) Reboot(ctx, selector any) *gomock.C
 }
 
 // SetPowerTarget mocks base method.
-func (m *MockCommandDispatcher) SetPowerTarget(ctx context.Context, selector *minercommandv1.DeviceSelector, mode minercommandv1.PerformanceMode) (*minercommandv1.SetPowerTargetResponse, error) {
+func (m *MockCommandDispatcher) SetPowerTarget(ctx context.Context, selector *minercommandv1.DeviceSelector, mode minercommandv1.PerformanceMode) (*command.CommandResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPowerTarget", ctx, selector, mode)
-	ret0, _ := ret[0].(*minercommandv1.SetPowerTargetResponse)
+	ret0, _ := ret[0].(*command.CommandResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -72,10 +73,10 @@ func (mr *MockCommandDispatcherMockRecorder) SetPowerTarget(ctx, selector, mode 
 }
 
 // StopMining mocks base method.
-func (m *MockCommandDispatcher) StopMining(ctx context.Context, selector *minercommandv1.DeviceSelector) (*minercommandv1.StopMiningResponse, error) {
+func (m *MockCommandDispatcher) StopMining(ctx context.Context, selector *minercommandv1.DeviceSelector) (*command.CommandResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopMining", ctx, selector)
-	ret0, _ := ret[0].(*minercommandv1.StopMiningResponse)
+	ret0, _ := ret[0].(*command.CommandResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -49,6 +49,7 @@ type jobEntry struct {
 	timer       *time.Timer
 	isOneTime   bool
 	fingerprint string
+	generation  uint64
 }
 
 type Processor struct {
@@ -60,10 +61,13 @@ type Processor struct {
 	activitySvc     *activity.Service
 	now             func() time.Time
 
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
-	mu     sync.Mutex
-	jobs   map[int64]jobEntry
+	stopCancel context.CancelFunc
+	workCancel context.CancelFunc
+	wg         sync.WaitGroup
+	timerWG    sync.WaitGroup
+	mu         sync.Mutex
+	jobs       map[int64]jobEntry
+	nextGen    uint64
 }
 
 func NewProcessor(
@@ -106,76 +110,90 @@ func scheduleFingerprint(sched *pb.Schedule) string {
 }
 
 func (p *Processor) Start(_ context.Context) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	p.cancel = cancel
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	workCtx, workCancel := context.WithCancel(context.Background())
+	p.stopCancel = stopCancel
+	p.workCancel = workCancel
 
 	p.cron = cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)))
 
-	if err := p.recoverStaleRunning(ctx); err != nil {
-		cancel()
+	if err := p.recoverStaleRunning(workCtx); err != nil {
+		stopCancel()
+		workCancel()
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
-	if err := p.syncSchedules(ctx); err != nil {
-		cancel()
+	if err := p.syncSchedules(workCtx); err != nil {
+		stopCancel()
+		workCancel()
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
 
 	p.cron.Start()
 
 	p.wg.Add(2)
-	go p.reconcileLoop(ctx)
-	go p.endOfWindowLoop(ctx)
+	go p.reconcileLoop(stopCtx, workCtx)
+	go p.endOfWindowLoop(stopCtx, workCtx)
 
 	slog.Info("schedule processor started")
 	return nil
 }
 
 func (p *Processor) Stop() error {
-	if p.cancel != nil {
-		p.cancel()
+	if p.stopCancel != nil {
+		p.stopCancel()
 	}
+	p.wg.Wait()
+
 	if p.cron != nil {
 		cronCtx := p.cron.Stop()
 		<-cronCtx.Done()
 	}
-	p.wg.Wait()
+
 	p.mu.Lock()
 	for _, entry := range p.jobs {
 		if entry.isOneTime && entry.timer != nil {
-			entry.timer.Stop()
+			if entry.timer.Stop() {
+				p.timerWG.Done()
+			}
 		}
 	}
 	p.mu.Unlock()
+
+	p.timerWG.Wait()
+
+	if p.workCancel != nil {
+		p.workCancel()
+	}
 	slog.Info("schedule processor stopped")
 	return nil
 }
 
-func (p *Processor) reconcileLoop(ctx context.Context) {
+func (p *Processor) reconcileLoop(stopCtx, workCtx context.Context) {
 	defer p.wg.Done()
 	ticker := time.NewTicker(reconcileInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-ctx.Done():
+		case <-stopCtx.Done():
 			return
 		case <-ticker.C:
-			if err := p.syncSchedules(ctx); err != nil {
+			if err := p.syncSchedules(workCtx); err != nil {
 				slog.Error("reconciliation failed, will retry next cycle", "error", err)
 			}
 		}
 	}
 }
 
-func (p *Processor) endOfWindowLoop(ctx context.Context) {
+func (p *Processor) endOfWindowLoop(stopCtx, workCtx context.Context) {
 	defer p.wg.Done()
 	ticker := time.NewTicker(endOfWindowInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-ctx.Done():
+		case <-stopCtx.Done():
 			return
 		case <-ticker.C:
-			p.checkEndOfWindow(ctx)
+			p.checkEndOfWindow(workCtx)
 		}
 	}
 }
@@ -243,6 +261,7 @@ func (p *Processor) syncSchedules(ctx context.Context) error {
 
 func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 	scheduleID := sched.Id
+	generation := p.nextJobGenerationLocked()
 
 	if sched.ScheduleType == pb.ScheduleType_SCHEDULE_TYPE_ONE_TIME {
 		t, err := ParseScheduleTime(sched.StartDate, sched.StartTime, sched.Timezone)
@@ -253,8 +272,12 @@ func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 		if delay < oneTimeRetryDelay {
 			delay = oneTimeRetryDelay
 		}
-		timer := time.AfterFunc(delay, func() { p.executeSchedule(ctx, scheduleID) })
-		p.jobs[scheduleID] = jobEntry{timer: timer, isOneTime: true, fingerprint: scheduleFingerprint(sched)}
+		p.timerWG.Add(1)
+		timer := time.AfterFunc(delay, func() {
+			defer p.timerWG.Done()
+			p.executeSchedule(ctx, scheduleID)
+		})
+		p.jobs[scheduleID] = jobEntry{timer: timer, isOneTime: true, fingerprint: scheduleFingerprint(sched), generation: generation}
 		return nil
 	}
 
@@ -272,12 +295,18 @@ func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 		return fmt.Errorf("failed to register cron job: %w", err)
 	}
 
-	p.jobs[scheduleID] = jobEntry{entryID: entryID, fingerprint: scheduleFingerprint(sched)}
+	p.jobs[scheduleID] = jobEntry{entryID: entryID, fingerprint: scheduleFingerprint(sched), generation: generation}
 	return nil
+}
+
+func (p *Processor) nextJobGenerationLocked() uint64 {
+	p.nextGen++
+	return p.nextGen
 }
 
 // executeSchedule is called when a job fires.
 func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
+	gen, hasGen := p.currentJobGeneration(scheduleID)
 	slog.Info("executing schedule", "schedule_id", scheduleID)
 
 	rows, err := p.procStore.SetScheduleRunning(ctx, scheduleID)
@@ -297,7 +326,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 			slog.Error("failed to revert schedule after read failure", "schedule_id", scheduleID, "error", rerr)
 			return
 		}
-		p.removeJob(scheduleID)
+		p.removeJobForRetry(scheduleID, gen, hasGen)
 		return
 	}
 
@@ -320,7 +349,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 	if sched.EndDate != "" {
 		deadline, err := parseDateInLocation(sched.EndDate, sched.Timezone)
 		if err == nil && now.After(endOfDay(deadline)) {
-			p.transitionToCompleted(ctx, sched, orgID, now)
+			p.transitionToCompletedWithGeneration(ctx, sched, orgID, now, gen, hasGen)
 			return
 		}
 	}
@@ -332,13 +361,13 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 			slog.Error("failed to revert schedule after target resolution failure", "schedule_id", scheduleID, "error", rerr)
 			return
 		}
-		p.removeJob(scheduleID)
+		p.removeJobForRetry(scheduleID, gen, hasGen)
 		return
 	}
 
 	if len(deviceIdentifiers) == 0 {
 		slog.Info("no target devices resolved, skipping dispatch", "schedule_id", scheduleID)
-		p.updateAfterRun(ctx, sched, orgID, now)
+		p.updateAfterRunWithGeneration(ctx, sched, orgID, now, gen, hasGen)
 		return
 	}
 
@@ -362,7 +391,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 		}
 		// Remove the job so syncSchedules re-registers it. This is necessary
 		// for one-time schedules whose timer has already fired and won't retrigger.
-		p.removeJob(scheduleID)
+		p.removeJobForRetry(scheduleID, gen, hasGen)
 		return
 	}
 
@@ -379,7 +408,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 		}
 	}
 
-	p.updateAfterRun(ctx, sched, orgID, now)
+	p.updateAfterRunWithGeneration(ctx, sched, orgID, now, gen, hasGen)
 	// Fully filtered dispatches are already captured by schedule_conflict_skip.
 	if dispatched > 0 || conflictSkips == 0 {
 		p.logExecution(ctx, sched, orgID, dispatched)
@@ -399,6 +428,31 @@ func countConflictSkips(result *command.CommandResult) int {
 		}
 	}
 	return n
+}
+
+func (p *Processor) currentJobGeneration(scheduleID int64) (uint64, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	entry, ok := p.jobs[scheduleID]
+	if !ok {
+		return 0, false
+	}
+	return entry.generation, true
+}
+
+func (p *Processor) removeJobIfCurrent(scheduleID int64, gen uint64, ok bool) {
+	if !ok {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if entry, exists := p.jobs[scheduleID]; exists && entry.generation == gen {
+		p.removeJobLocked(scheduleID)
+	}
+}
+
+func (p *Processor) removeJobForRetry(scheduleID int64, gen uint64, hasGen bool) {
+	p.removeJobIfCurrent(scheduleID, gen, hasGen)
 }
 
 func (p *Processor) dispatch(ctx context.Context, sched *pb.Schedule, selector *commandpb.DeviceSelector) (*command.CommandResult, error) {
@@ -447,6 +501,11 @@ func (p *Processor) resolveTargets(ctx context.Context, sched *pb.Schedule, orgI
 }
 
 func (p *Processor) updateAfterRun(ctx context.Context, sched *pb.Schedule, orgID int64, now time.Time) {
+	gen, hasGen := p.currentJobGeneration(sched.Id)
+	p.updateAfterRunWithGeneration(ctx, sched, orgID, now, gen, hasGen)
+}
+
+func (p *Processor) updateAfterRunWithGeneration(ctx context.Context, sched *pb.Schedule, orgID int64, now time.Time, gen uint64, hasGen bool) {
 	lastRun := now.Unix()
 	nextRun, err := ComputeNextRun(sched, now)
 	if err != nil {
@@ -482,7 +541,7 @@ func (p *Processor) updateAfterRun(ctx context.Context, sched *pb.Schedule, orgI
 			slog.Error("failed to revert schedule after update failure", "schedule_id", sched.Id, "error", rerr)
 			return
 		}
-		p.removeJob(sched.Id)
+		p.removeJobForRetry(sched.Id, gen, hasGen)
 		return
 	}
 
@@ -493,6 +552,11 @@ func (p *Processor) updateAfterRun(ctx context.Context, sched *pb.Schedule, orgI
 }
 
 func (p *Processor) transitionToCompleted(ctx context.Context, sched *pb.Schedule, orgID int64, now time.Time) {
+	gen, hasGen := p.currentJobGeneration(sched.Id)
+	p.transitionToCompletedWithGeneration(ctx, sched, orgID, now, gen, hasGen)
+}
+
+func (p *Processor) transitionToCompletedWithGeneration(ctx context.Context, sched *pb.Schedule, orgID int64, now time.Time, gen uint64, hasGen bool) {
 	lastRun := now.Unix()
 	if err := p.procStore.UpdateScheduleAfterRun(ctx, sched.Id, &lastRun, nil, statusCompleted); err != nil {
 		slog.Error("failed to transition schedule to completed, reverting to active", "schedule_id", sched.Id, "error", err)
@@ -500,7 +564,7 @@ func (p *Processor) transitionToCompleted(ctx context.Context, sched *pb.Schedul
 			slog.Error("failed to revert schedule after completion failure", "schedule_id", sched.Id, "error", rerr)
 			return
 		}
-		p.removeJob(sched.Id)
+		p.removeJobForRetry(sched.Id, gen, hasGen)
 		return
 	}
 	p.removeJob(sched.Id)
@@ -646,8 +710,8 @@ func (p *Processor) removeJob(scheduleID int64) {
 func (p *Processor) removeJobLocked(scheduleID int64) {
 	if entry, ok := p.jobs[scheduleID]; ok {
 		if entry.isOneTime {
-			if entry.timer != nil {
-				entry.timer.Stop()
+			if entry.timer != nil && entry.timer.Stop() {
+				p.timerWG.Done()
 			}
 		} else {
 			p.cron.Remove(entry.entryID)

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -386,7 +386,13 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 	}
 
 	p.updateAfterRun(ctx, sched, orgID, now)
-	p.logExecution(ctx, sched, orgID, dispatched)
+	// Skip the schedule_executed activity row when the entire dispatch was
+	// filtered out — the schedule_conflict_skip row already records the
+	// outcome, and a schedule_executed with device_count=0 misleads readers
+	// who scan the activity log for actual mining-state changes.
+	if dispatched > 0 {
+		p.logExecution(ctx, sched, orgID, dispatched)
+	}
 }
 
 // countConflictSkips returns how many devices the schedule-conflict filter

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -152,12 +152,18 @@ func (p *Processor) Stop() error {
 	if p.stopCancel != nil {
 		p.stopCancel()
 	}
-	p.wg.Wait()
 
+	// Stop cron before waiting on the loops so no new cron callbacks fire
+	// during shutdown. In-flight callbacks complete with workCtx still live;
+	// cron.Stop() returns a context that's done once they finish. AddFunc on
+	// a stopped cron appends to entries without firing, so a late
+	// registration from the reconcile loop's last iteration is harmless.
 	if p.cron != nil {
 		cronCtx := p.cron.Stop()
 		<-cronCtx.Done()
 	}
+
+	p.wg.Wait()
 
 	p.mu.Lock()
 	for _, entry := range p.jobs {

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -17,6 +17,7 @@ import (
 	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/domain/command"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
@@ -30,10 +31,18 @@ const (
 )
 
 // CommandDispatcher is the subset of command.Service the processor needs.
+//
+// Each method returns a *command.CommandResult so the processor can read the
+// per-call list of devices the registered command preflight filters chose
+// to skip — primarily the schedule-conflict filter, which today only the
+// schedule processor cared about but now lives at the command-service layer
+// and runs for every caller (manual API, future curtailment, …). The
+// processor uses the skipped slice to emit `schedule_conflict_skip` activity
+// for both the normal dispatch and the end-of-window revert paths.
 type CommandDispatcher interface {
-	SetPowerTarget(ctx context.Context, selector *commandpb.DeviceSelector, mode commandpb.PerformanceMode) (*commandpb.SetPowerTargetResponse, error)
-	Reboot(ctx context.Context, selector *commandpb.DeviceSelector) (*commandpb.RebootResponse, error)
-	StopMining(ctx context.Context, selector *commandpb.DeviceSelector) (*commandpb.StopMiningResponse, error)
+	SetPowerTarget(ctx context.Context, selector *commandpb.DeviceSelector, mode commandpb.PerformanceMode) (*command.CommandResult, error)
+	Reboot(ctx context.Context, selector *commandpb.DeviceSelector) (*command.CommandResult, error)
+	StopMining(ctx context.Context, selector *commandpb.DeviceSelector) (*command.CommandResult, error)
 }
 
 // jobEntry tracks a registered job and a fingerprint of the schedule's timing
@@ -338,28 +347,6 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 		return
 	}
 
-	if sched.Action == pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET {
-		beforeCount := len(deviceIdentifiers)
-		deviceIdentifiers, err = p.filterConflictedMiners(ctx, sched, orgID, deviceIdentifiers)
-		if err != nil {
-			slog.Error("failed to check conflicts", "schedule_id", scheduleID, "error", err)
-			if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
-				slog.Error("failed to revert schedule after conflict check failure", "schedule_id", scheduleID, "error", rerr)
-				return
-			}
-			p.removeJob(scheduleID)
-			return
-		}
-		if skipped := beforeCount - len(deviceIdentifiers); skipped > 0 {
-			p.logConflictSkip(ctx, sched, orgID, skipped)
-		}
-		if len(deviceIdentifiers) == 0 {
-			slog.Info("all miners overridden by higher-priority schedule", "schedule_id", scheduleID)
-			p.updateAfterRun(ctx, sched, orgID, now)
-			return
-		}
-	}
-
 	cmdCtx := schedulerContext(ctx, sched, orgID)
 	selector := &commandpb.DeviceSelector{
 		SelectionType: &commandpb.DeviceSelector_IncludeDevices{
@@ -369,7 +356,12 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 		},
 	}
 
-	if err := p.dispatch(cmdCtx, sched, selector); err != nil {
+	// Dispatch through commandSvc — schedule-conflict filtering runs at the
+	// command-service layer for every caller now (see ScheduleConflictFilter).
+	// We read the skipped slice back to preserve the schedule_conflict_skip
+	// activity row.
+	result, err := p.dispatch(cmdCtx, sched, selector)
+	if err != nil {
 		slog.Error("failed to dispatch command", "schedule_id", scheduleID, "action", sched.Action, "error", err)
 		if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
 			slog.Error("failed to revert schedule after dispatch failure", "schedule_id", scheduleID, "error", rerr)
@@ -381,11 +373,40 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 		return
 	}
 
+	if skipped := countConflictSkips(result); skipped > 0 {
+		p.logConflictSkip(ctx, sched, orgID, skipped)
+	}
+
+	dispatched := 0
+	if result != nil {
+		dispatched = result.DispatchedCount
+		if dispatched == 0 && len(result.Skipped) > 0 {
+			slog.Info("all miners overridden by preflight filters", "schedule_id", scheduleID)
+		}
+	}
+
 	p.updateAfterRun(ctx, sched, orgID, now)
-	p.logExecution(ctx, sched, orgID, len(deviceIdentifiers))
+	p.logExecution(ctx, sched, orgID, dispatched)
 }
 
-func (p *Processor) dispatch(ctx context.Context, sched *pb.Schedule, selector *commandpb.DeviceSelector) error {
+// countConflictSkips returns how many devices the schedule-conflict filter
+// excluded from this dispatch. result may be nil for actions that don't fan
+// out to commandSvc (none today, but defensive); other filters' skips do not
+// count.
+func countConflictSkips(result *command.CommandResult) int {
+	if result == nil {
+		return 0
+	}
+	n := 0
+	for _, s := range result.Skipped {
+		if s.FilterName == "schedule_conflict" {
+			n++
+		}
+	}
+	return n
+}
+
+func (p *Processor) dispatch(ctx context.Context, sched *pb.Schedule, selector *commandpb.DeviceSelector) (*command.CommandResult, error) {
 	switch sched.Action {
 	case pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET:
 		mode := commandpb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY
@@ -399,22 +420,19 @@ func (p *Processor) dispatch(ctx context.Context, sched *pb.Schedule, selector *
 				mode = commandpb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY
 			}
 		}
-		_, err := p.commandSvc.SetPowerTarget(ctx, selector, mode)
-		return err
+		return p.commandSvc.SetPowerTarget(ctx, selector, mode)
 
 	case pb.ScheduleAction_SCHEDULE_ACTION_REBOOT:
-		_, err := p.commandSvc.Reboot(ctx, selector)
-		return err
+		return p.commandSvc.Reboot(ctx, selector)
 
 	case pb.ScheduleAction_SCHEDULE_ACTION_SLEEP:
-		_, err := p.commandSvc.StopMining(ctx, selector)
-		return err
+		return p.commandSvc.StopMining(ctx, selector)
 
 	case pb.ScheduleAction_SCHEDULE_ACTION_UNSPECIFIED:
-		return fmt.Errorf("unspecified schedule action for schedule %d", sched.Id)
+		return nil, fmt.Errorf("unspecified schedule action for schedule %d", sched.Id)
 
 	default:
-		return fmt.Errorf("unsupported schedule action %v for schedule %d", sched.Action, sched.Id)
+		return nil, fmt.Errorf("unsupported schedule action %v for schedule %d", sched.Action, sched.Id)
 	}
 }
 
@@ -477,46 +495,6 @@ func (p *Processor) resolveTargets(ctx context.Context, sched *pb.Schedule, orgI
 		return nil, fmt.Errorf("failed to load schedule targets: %w", err)
 	}
 	return p.expandTargets(ctx, targets, orgID)
-}
-
-// filterConflictedMiners removes miners already covered by a higher-priority
-// running power-target schedule within the same org.
-func (p *Processor) filterConflictedMiners(ctx context.Context, sched *pb.Schedule, orgID int64, deviceIdentifiers []string) ([]string, error) {
-	running, err := p.procStore.GetRunningPowerTargetSchedules(ctx, orgID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get running power target schedules: %w", err)
-	}
-
-	conflicted := make(map[string]struct{})
-	for _, r := range running {
-		if r.Id == sched.Id || r.Priority >= sched.Priority {
-			continue
-		}
-		rTargets, err := p.targetStore.GetScheduleTargets(ctx, orgID, r.Id)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load targets for conflicting schedule %d: %w", r.Id, err)
-		}
-		rDevices, err := p.expandTargets(ctx, rTargets, orgID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to expand targets for conflicting schedule %d: %w", r.Id, err)
-		}
-		for _, d := range rDevices {
-			conflicted[d] = struct{}{}
-		}
-	}
-
-	if len(conflicted) == 0 {
-		return deviceIdentifiers, nil
-	}
-
-	var filtered []string
-	for _, id := range deviceIdentifiers {
-		if _, blocked := conflicted[id]; !blocked {
-			filtered = append(filtered, id)
-		}
-	}
-
-	return filtered, nil
 }
 
 func (p *Processor) updateAfterRun(ctx context.Context, sched *pb.Schedule, orgID int64, now time.Time) {
@@ -679,13 +657,10 @@ func (p *Processor) checkEndOfWindow(ctx context.Context) {
 			continue
 		}
 
-		// Exclude miners still covered by a higher-priority running schedule.
-		deviceIdentifiers, err = p.filterConflictedMiners(ctx, sched, sw.OrgID, deviceIdentifiers)
-		if err != nil {
-			slog.Error("failed to filter conflicts for revert", "schedule_id", sched.Id, "error", err)
-			continue
-		}
-
+		// commandSvc applies the schedule-conflict filter for us; we consume
+		// the skipped slice and log it the same way the normal dispatch path
+		// does. This makes audit symmetric — pre-pre-work, the revert path
+		// silently dropped overlapping miners.
 		if len(deviceIdentifiers) > 0 {
 			cmdCtx := schedulerContext(ctx, sched, sw.OrgID)
 			selector := &commandpb.DeviceSelector{
@@ -695,9 +670,13 @@ func (p *Processor) checkEndOfWindow(ctx context.Context) {
 					},
 				},
 			}
-			if _, err := p.commandSvc.SetPowerTarget(cmdCtx, selector, revertPerformanceMode); err != nil {
+			result, err := p.commandSvc.SetPowerTarget(cmdCtx, selector, revertPerformanceMode)
+			if err != nil {
 				slog.Error("failed to dispatch revert command, will retry next cycle", "schedule_id", sched.Id, "error", err)
 				continue
+			}
+			if skipped := countConflictSkips(result); skipped > 0 {
+				p.logConflictSkip(ctx, sched, sw.OrgID, skipped)
 			}
 		}
 
@@ -730,6 +709,13 @@ func (p *Processor) removeJobLocked(scheduleID int64) {
 
 // schedulerContext creates a context with synthetic session info so the command
 // service can create batch logs and resolve devices using the schedule's org.
+//
+// Source carries this schedule's id and priority so the command-service-level
+// schedule-conflict filter can apply scheduler-priority semantics (only
+// strictly higher-priority running schedules block) instead of the manual
+// fallback (every running schedule blocks). Without Source the filter would
+// treat every scheduler-origin call as if it were a manual call and block
+// against itself.
 func schedulerContext(parent context.Context, sched *pb.Schedule, orgID int64) context.Context {
 	return authn.SetInfo(parent, &session.Info{
 		SessionID:      schedulerActorName,
@@ -740,6 +726,10 @@ func schedulerContext(parent context.Context, sched *pb.Schedule, orgID int64) c
 		// Mark the session as scheduler-driven so downstream activity logging
 		// tags both the initiated and completed rows with ActorScheduler.
 		Actor: session.ActorScheduler,
+		Source: session.Source{
+			ScheduleID:       sched.Id,
+			SchedulePriority: sched.Priority,
+		},
 	})
 }
 

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -31,19 +31,14 @@ const (
 )
 
 // CommandDispatcher is the subset of command.Service the processor needs.
-//
-// CommandResult carries preflight skips so the processor can emit
-// schedule_conflict_skip activity while command.Service owns the filtering.
+// CommandResult carries preflight skips for schedule-level audit.
 type CommandDispatcher interface {
 	SetPowerTarget(ctx context.Context, selector *commandpb.DeviceSelector, mode commandpb.PerformanceMode) (*command.CommandResult, error)
 	Reboot(ctx context.Context, selector *commandpb.DeviceSelector) (*command.CommandResult, error)
 	StopMining(ctx context.Context, selector *commandpb.DeviceSelector) (*command.CommandResult, error)
 }
 
-// jobEntry tracks a registered job and a fingerprint of the schedule's timing
-// fields so that edits can be detected during reconciliation. For recurring
-// schedules entryID holds the cron.EntryID; for one-time schedules timer holds
-// a *time.Timer that fires the callback.
+// jobEntry tracks a registered cron/timer job and its timing fingerprint.
 type jobEntry struct {
 	entryID     cron.EntryID
 	timer       *time.Timer
@@ -670,10 +665,7 @@ func (p *Processor) checkEndOfWindow(ctx context.Context) {
 			continue
 		}
 
-		// commandSvc applies the schedule-conflict filter for us; we consume
-		// the skipped slice and log it the same way the normal dispatch path
-		// does. This makes audit symmetric — pre-pre-work, the revert path
-		// silently dropped overlapping miners.
+		// commandSvc applies conflict filtering; mirror normal dispatch audit.
 		if len(deviceIdentifiers) > 0 {
 			cmdCtx := schedulerContext(ctx, sched, sw.OrgID)
 			selector := &commandpb.DeviceSelector{
@@ -720,10 +712,8 @@ func (p *Processor) removeJobLocked(scheduleID int64) {
 	}
 }
 
-// schedulerContext creates a context with synthetic session info so the command
-// service can create batch logs and resolve devices using the schedule's org.
-//
-// Source lets ScheduleConflictFilter apply scheduler priority semantics.
+// schedulerContext adds synthetic scheduler session info for command dispatch.
+// Source lets ScheduleConflictFilter apply priority semantics.
 func schedulerContext(parent context.Context, sched *pb.Schedule, orgID int64) context.Context {
 	return authn.SetInfo(parent, &session.Info{
 		SessionID:      schedulerActorName,
@@ -731,9 +721,7 @@ func schedulerContext(parent context.Context, sched *pb.Schedule, orgID int64) c
 		OrganizationID: orgID,
 		ExternalUserID: schedulerActorName,
 		Username:       schedulerActorName,
-		// Mark the session as scheduler-driven so downstream activity logging
-		// tags both the initiated and completed rows with ActorScheduler.
-		Actor: session.ActorScheduler,
+		Actor:          session.ActorScheduler,
 		Source: session.Source{
 			ScheduleID:       sched.Id,
 			SchedulePriority: sched.Priority,

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
 	"github.com/block/proto-fleet/server/internal/domain/command"
+	scheduletargets "github.com/block/proto-fleet/server/internal/domain/schedule/targets"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
@@ -438,55 +438,9 @@ func (p *Processor) dispatch(ctx context.Context, sched *pb.Schedule, selector *
 
 // expandTargets converts a slice of ScheduleTarget into deduplicated device identifiers.
 func (p *Processor) expandTargets(ctx context.Context, targets []*pb.ScheduleTarget, orgID int64) ([]string, error) {
-	seen := make(map[string]struct{})
-	var identifiers []string
-
-	for _, t := range targets {
-		switch t.TargetType {
-		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER:
-			if _, dup := seen[t.TargetId]; !dup {
-				seen[t.TargetId] = struct{}{}
-				identifiers = append(identifiers, t.TargetId)
-			}
-
-		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_RACK:
-			rackID, err := strconv.ParseInt(t.TargetId, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid rack target_id %q: %w", t.TargetId, err)
-			}
-			rackDevices, err := p.collectionStore.GetDeviceIdentifiersByDeviceSetID(ctx, rackID, orgID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve rack %d devices: %w", rackID, err)
-			}
-			for _, d := range rackDevices {
-				if _, dup := seen[d]; !dup {
-					seen[d] = struct{}{}
-					identifiers = append(identifiers, d)
-				}
-			}
-
-		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_GROUP:
-			groupID, err := strconv.ParseInt(t.TargetId, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid group target_id %q: %w", t.TargetId, err)
-			}
-			groupDevices, err := p.collectionStore.GetDeviceIdentifiersByDeviceSetID(ctx, groupID, orgID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve group %d devices: %w", groupID, err)
-			}
-			for _, d := range groupDevices {
-				if _, dup := seen[d]; !dup {
-					seen[d] = struct{}{}
-					identifiers = append(identifiers, d)
-				}
-			}
-
-		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_UNSPECIFIED:
-			slog.Warn("unspecified target type", "target_id", t.TargetId)
-		}
-	}
-
-	return identifiers, nil
+	return scheduletargets.Expand(ctx, p.collectionStore, targets, orgID, func(targetID string) {
+		slog.Warn("unspecified target type", "target_id", targetID)
+	})
 }
 
 func (p *Processor) resolveTargets(ctx context.Context, sched *pb.Schedule, orgID int64) ([]string, error) {

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -28,7 +28,14 @@ const (
 	revertPerformanceMode = commandpb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY
 	schedulerActorName    = "scheduler"
 	oneTimeRetryDelay     = time.Second
+	// shutdownDeadline bounds Stop(): drain-before-cancel is the graceful
+	// path, the watchdog cancels workCtx if a DB/dispatch call wedges.
+	// Sized within the fleetd-wide shutdownTimeout (10s).
+	shutdownDeadline = 10 * time.Second
 )
+
+// shutdownDeadlineFn lets tests shrink the watchdog without affecting prod.
+var shutdownDeadlineFn = func() time.Duration { return shutdownDeadline }
 
 // CommandDispatcher is the subset of command.Service the processor needs.
 // CommandResult carries preflight skips for schedule-level audit.
@@ -134,6 +141,14 @@ func (p *Processor) Start(_ context.Context) error {
 }
 
 func (p *Processor) Stop() error {
+	// Watchdog bounds total shutdown: workCancel is idempotent, so an early
+	// fire just unblocks wedged in-flight calls; the drain sequence below
+	// still runs to completion.
+	if p.workCancel != nil {
+		watchdog := time.AfterFunc(shutdownDeadlineFn(), p.workCancel)
+		defer watchdog.Stop()
+	}
+
 	if p.stopCancel != nil {
 		p.stopCancel()
 	}

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -366,8 +366,9 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 		return
 	}
 
-	if skipped := countConflictSkips(result); skipped > 0 {
-		p.logConflictSkip(ctx, sched, orgID, skipped)
+	conflictSkips := countConflictSkips(result)
+	if conflictSkips > 0 {
+		p.logConflictSkip(ctx, sched, orgID, conflictSkips)
 	}
 
 	dispatched := 0
@@ -380,7 +381,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 
 	p.updateAfterRun(ctx, sched, orgID, now)
 	// Fully filtered dispatches are already captured by schedule_conflict_skip.
-	if dispatched > 0 {
+	if dispatched > 0 || conflictSkips == 0 {
 		p.logExecution(ctx, sched, orgID, dispatched)
 	}
 }

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -32,13 +32,8 @@ const (
 
 // CommandDispatcher is the subset of command.Service the processor needs.
 //
-// Each method returns a *command.CommandResult so the processor can read the
-// per-call list of devices the registered command preflight filters chose
-// to skip — primarily the schedule-conflict filter, which today only the
-// schedule processor cared about but now lives at the command-service layer
-// and runs for every caller (manual API, future curtailment, …). The
-// processor uses the skipped slice to emit `schedule_conflict_skip` activity
-// for both the normal dispatch and the end-of-window revert paths.
+// CommandResult carries preflight skips so the processor can emit
+// schedule_conflict_skip activity while command.Service owns the filtering.
 type CommandDispatcher interface {
 	SetPowerTarget(ctx context.Context, selector *commandpb.DeviceSelector, mode commandpb.PerformanceMode) (*command.CommandResult, error)
 	Reboot(ctx context.Context, selector *commandpb.DeviceSelector) (*command.CommandResult, error)
@@ -356,10 +351,8 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 		},
 	}
 
-	// Dispatch through commandSvc — schedule-conflict filtering runs at the
-	// command-service layer for every caller now (see ScheduleConflictFilter).
-	// We read the skipped slice back to preserve the schedule_conflict_skip
-	// activity row.
+	// commandSvc owns preflight filtering; the processor only records
+	// schedule-level skip activity from the returned metadata.
 	result, err := p.dispatch(cmdCtx, sched, selector)
 	if err != nil {
 		slog.Error("failed to dispatch command", "schedule_id", scheduleID, "action", sched.Action, "error", err)
@@ -386,26 +379,21 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 	}
 
 	p.updateAfterRun(ctx, sched, orgID, now)
-	// Skip the schedule_executed activity row when the entire dispatch was
-	// filtered out — the schedule_conflict_skip row already records the
-	// outcome, and a schedule_executed with device_count=0 misleads readers
-	// who scan the activity log for actual mining-state changes.
+	// Fully filtered dispatches are already captured by schedule_conflict_skip.
 	if dispatched > 0 {
 		p.logExecution(ctx, sched, orgID, dispatched)
 	}
 }
 
-// countConflictSkips returns how many devices the schedule-conflict filter
-// excluded from this dispatch. result may be nil for actions that don't fan
-// out to commandSvc (none today, but defensive); other filters' skips do not
-// count.
+// countConflictSkips ignores other command preflight filters; schedule activity
+// should only summarize schedule-priority conflicts.
 func countConflictSkips(result *command.CommandResult) int {
 	if result == nil {
 		return 0
 	}
 	n := 0
 	for _, s := range result.Skipped {
-		if s.FilterName == "schedule_conflict" {
+		if s.FilterName == command.ScheduleConflictFilterName {
 			n++
 		}
 	}
@@ -670,12 +658,7 @@ func (p *Processor) removeJobLocked(scheduleID int64) {
 // schedulerContext creates a context with synthetic session info so the command
 // service can create batch logs and resolve devices using the schedule's org.
 //
-// Source carries this schedule's id and priority so the command-service-level
-// schedule-conflict filter can apply scheduler-priority semantics (only
-// strictly higher-priority running schedules block) instead of the manual
-// fallback (every running schedule blocks). Without Source the filter would
-// treat every scheduler-origin call as if it were a manual call and block
-// against itself.
+// Source lets ScheduleConflictFilter apply scheduler priority semantics.
 func schedulerContext(parent context.Context, sched *pb.Schedule, orgID int64) context.Context {
 	return authn.SetInfo(parent, &session.Info{
 		SessionID:      schedulerActorName,

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -13,6 +13,9 @@ import (
 
 	commandpb "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
 	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
+	"github.com/block/proto-fleet/server/internal/domain/activity"
+	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	commanddomain "github.com/block/proto-fleet/server/internal/domain/command"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
 )
@@ -29,6 +32,48 @@ func newTestProcessor(t *testing.T, now time.Time) (*Processor, *mocks.MockSched
 	p := NewProcessor(procStore, targetStore, collectionStore, cmdSvc, nil)
 	p.now = func() time.Time { return now }
 	return p, procStore, targetStore, collectionStore, cmdSvc
+}
+
+type recordingActivityStore struct {
+	inserts []*activitymodels.Event
+}
+
+func (s *recordingActivityStore) Insert(_ context.Context, event *activitymodels.Event) error {
+	clone := *event
+	s.inserts = append(s.inserts, &clone)
+	return nil
+}
+
+func (s *recordingActivityStore) List(context.Context, activitymodels.Filter) ([]activitymodels.Entry, error) {
+	panic("not used in processor_test")
+}
+func (s *recordingActivityStore) Count(context.Context, activitymodels.Filter) (int64, error) {
+	panic("not used in processor_test")
+}
+func (s *recordingActivityStore) GetDistinctUsers(context.Context, int64) ([]activitymodels.UserInfo, error) {
+	panic("not used in processor_test")
+}
+func (s *recordingActivityStore) GetDistinctEventTypes(context.Context, int64) ([]activitymodels.EventTypeInfo, error) {
+	panic("not used in processor_test")
+}
+func (s *recordingActivityStore) GetDistinctScopeTypes(context.Context, int64) ([]string, error) {
+	panic("not used in processor_test")
+}
+
+func withRecordingActivity(p *Processor) *recordingActivityStore {
+	store := &recordingActivityStore{}
+	p.activitySvc = activity.NewService(store)
+	return store
+}
+
+func countActivityType(store *recordingActivityStore, eventType string) int {
+	n := 0
+	for _, event := range store.inserts {
+		if event.Type == eventType {
+			n++
+		}
+	}
+	return n
 }
 
 // --- recoverStaleRunning ---
@@ -474,6 +519,68 @@ func TestExecuteSchedule_DispatchFailureRevertFails_KeepsJob(t *testing.T) {
 	defer p.mu.Unlock()
 	_, exists := p.jobs[1]
 	assert.True(t, exists, "job should still exist when revert fails")
+}
+
+func TestExecuteSchedule_FullyConflictFilteredSkipsExecutionActivity(t *testing.T) {
+	now := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	p, procStore, targetStore, _, cmdSvc := newTestProcessor(t, now)
+	activityStore := withRecordingActivity(p)
+
+	sched := &pb.Schedule{
+		Id:           1,
+		Name:         "power",
+		Action:       pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET,
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_ONE_TIME,
+		StartDate:    "2026-04-01",
+		StartTime:    "10:00",
+		Timezone:     "UTC",
+		CreatedBy:    42,
+	}
+
+	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).Return(int64(1), nil)
+	procStore.EXPECT().GetScheduleByID(gomock.Any(), int64(1)).Return(&interfaces.ScheduleWithOrg{Schedule: sched, OrgID: 1}, nil)
+	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
+	}, nil)
+	cmdSvc.EXPECT().SetPowerTarget(gomock.Any(), gomock.Any(), revertPerformanceMode).Return(&commanddomain.CommandResult{
+		Skipped: []commanddomain.SkippedDevice{{DeviceIdentifier: "miner-1", FilterName: commanddomain.ScheduleConflictFilterName}},
+	}, nil)
+	procStore.EXPECT().UpdateScheduleAfterRun(gomock.Any(), int64(1), gomock.Any(), gomock.Nil(), statusCompleted).Return(nil)
+
+	p.executeSchedule(context.Background(), 1)
+
+	assert.Equal(t, 1, countActivityType(activityStore, "schedule_conflict_skip"))
+	assert.Equal(t, 0, countActivityType(activityStore, "schedule_executed"))
+}
+
+func TestExecuteSchedule_NonConflictZeroDispatchLogsExecution(t *testing.T) {
+	now := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	p, procStore, targetStore, _, cmdSvc := newTestProcessor(t, now)
+	activityStore := withRecordingActivity(p)
+
+	sched := &pb.Schedule{
+		Id:           1,
+		Name:         "power",
+		Action:       pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET,
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_ONE_TIME,
+		StartDate:    "2026-04-01",
+		StartTime:    "10:00",
+		Timezone:     "UTC",
+		CreatedBy:    42,
+	}
+
+	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).Return(int64(1), nil)
+	procStore.EXPECT().GetScheduleByID(gomock.Any(), int64(1)).Return(&interfaces.ScheduleWithOrg{Schedule: sched, OrgID: 1}, nil)
+	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "stale-miner"},
+	}, nil)
+	cmdSvc.EXPECT().SetPowerTarget(gomock.Any(), gomock.Any(), revertPerformanceMode).Return(&commanddomain.CommandResult{}, nil)
+	procStore.EXPECT().UpdateScheduleAfterRun(gomock.Any(), int64(1), gomock.Any(), gomock.Nil(), statusCompleted).Return(nil)
+
+	p.executeSchedule(context.Background(), 1)
+
+	assert.Equal(t, 0, countActivityType(activityStore, "schedule_conflict_skip"))
+	assert.Equal(t, 1, countActivityType(activityStore, "schedule_executed"))
 }
 
 // --- updateAfterRun ---

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -273,7 +273,7 @@ func TestDispatch(t *testing.T) {
 			tt.setup(cmdSvc)
 
 			sched := &pb.Schedule{Id: 1, Action: tt.action, ActionConfig: tt.config}
-			err := p.dispatch(context.Background(), sched, &commandpb.DeviceSelector{})
+			_, err := p.dispatch(context.Background(), sched, &commandpb.DeviceSelector{})
 			assert.NoError(t, err)
 		})
 	}
@@ -282,7 +282,7 @@ func TestDispatch(t *testing.T) {
 func TestDispatchUnspecifiedAction(t *testing.T) {
 	p, _, _, _, _ := newTestProcessor(t, time.Now())
 	sched := &pb.Schedule{Id: 1, Action: pb.ScheduleAction_SCHEDULE_ACTION_UNSPECIFIED}
-	err := p.dispatch(context.Background(), sched, &commandpb.DeviceSelector{})
+	_, err := p.dispatch(context.Background(), sched, &commandpb.DeviceSelector{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unspecified")
 }
@@ -368,43 +368,9 @@ func TestResolveTargets_Empty(t *testing.T) {
 	assert.Equal(t, 0, len(ids))
 }
 
-// --- filterConflictedMiners ---
-
-func TestFilterConflictedMiners(t *testing.T) {
-	p, procStore, targetStore, _, _ := newTestProcessor(t, time.Now())
-
-	sched := &pb.Schedule{Id: 10, Priority: 5, Action: pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET}
-	orgID := int64(1)
-
-	// A higher-priority (lower number) running schedule targets miner-1.
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), orgID).Return([]*pb.Schedule{
-		{Id: 20, Priority: 2, Action: pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET},
-	}, nil)
-
-	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), orgID, int64(20)).Return([]*pb.ScheduleTarget{
-		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
-	}, nil)
-
-	filtered, err := p.filterConflictedMiners(context.Background(), sched, orgID, []string{"miner-1", "miner-2", "miner-3"})
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"miner-2", "miner-3"}, filtered)
-}
-
-func TestFilterConflictedMiners_LowerPriorityIgnored(t *testing.T) {
-	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-
-	sched := &pb.Schedule{Id: 10, Priority: 2}
-	orgID := int64(1)
-
-	// A lower-priority (higher number) running schedule — should not conflict.
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), orgID).Return([]*pb.Schedule{
-		{Id: 20, Priority: 5},
-	}, nil)
-
-	filtered, err := p.filterConflictedMiners(context.Background(), sched, orgID, []string{"miner-1"})
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"miner-1"}, filtered)
-}
+// Schedule-conflict filtering moved to command.ScheduleConflictFilter; the
+// equivalent priority-semantics tests live in
+// server/internal/domain/command/schedule_conflict_filter_test.go.
 
 // --- executeSchedule ---
 
@@ -675,7 +641,8 @@ func TestCheckEndOfWindow_RevertsExpiredWindow(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return([]interfaces.ScheduleWithOrg{
 		{Schedule: sched, OrgID: 1},
 	}, nil)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return(nil, nil)
+	// GetRunningPowerTargetSchedules now lives behind commandSvc's filter,
+	// which is mocked at the dispatcher boundary — so no expectation here.
 	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
 		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
 	}, nil)
@@ -737,7 +704,8 @@ func TestCheckEndOfWindow_OvernightWindowExpired(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return([]interfaces.ScheduleWithOrg{
 		{Schedule: sched, OrgID: 1},
 	}, nil)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return(nil, nil)
+	// GetRunningPowerTargetSchedules now lives behind commandSvc's filter,
+	// which is mocked at the dispatcher boundary — so no expectation here.
 	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
 		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
 	}, nil)
@@ -771,7 +739,8 @@ func TestCheckEndOfWindow_FailedRevertRetries(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return([]interfaces.ScheduleWithOrg{
 		{Schedule: sched, OrgID: 1},
 	}, nil)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return(nil, nil)
+	// GetRunningPowerTargetSchedules now lives behind commandSvc's filter,
+	// which is mocked at the dispatcher boundary — so no expectation here.
 	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
 		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
 	}, nil)
@@ -804,7 +773,8 @@ func TestCheckEndOfWindow_RevertStateFailSkipsLog(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return([]interfaces.ScheduleWithOrg{
 		{Schedule: sched, OrgID: 1},
 	}, nil)
-	procStore.EXPECT().GetRunningPowerTargetSchedules(gomock.Any(), int64(1)).Return(nil, nil)
+	// GetRunningPowerTargetSchedules now lives behind commandSvc's filter,
+	// which is mocked at the dispatcher boundary — so no expectation here.
 	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
 		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
 	}, nil)

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -641,8 +641,6 @@ func TestCheckEndOfWindow_RevertsExpiredWindow(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return([]interfaces.ScheduleWithOrg{
 		{Schedule: sched, OrgID: 1},
 	}, nil)
-	// GetRunningPowerTargetSchedules now lives behind commandSvc's filter,
-	// which is mocked at the dispatcher boundary — so no expectation here.
 	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
 		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
 	}, nil)
@@ -704,8 +702,6 @@ func TestCheckEndOfWindow_OvernightWindowExpired(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return([]interfaces.ScheduleWithOrg{
 		{Schedule: sched, OrgID: 1},
 	}, nil)
-	// GetRunningPowerTargetSchedules now lives behind commandSvc's filter,
-	// which is mocked at the dispatcher boundary — so no expectation here.
 	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
 		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
 	}, nil)
@@ -739,8 +735,6 @@ func TestCheckEndOfWindow_FailedRevertRetries(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return([]interfaces.ScheduleWithOrg{
 		{Schedule: sched, OrgID: 1},
 	}, nil)
-	// GetRunningPowerTargetSchedules now lives behind commandSvc's filter,
-	// which is mocked at the dispatcher boundary — so no expectation here.
 	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
 		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
 	}, nil)
@@ -773,8 +767,6 @@ func TestCheckEndOfWindow_RevertStateFailSkipsLog(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return([]interfaces.ScheduleWithOrg{
 		{Schedule: sched, OrgID: 1},
 	}, nil)
-	// GetRunningPowerTargetSchedules now lives behind commandSvc's filter,
-	// which is mocked at the dispatcher boundary — so no expectation here.
 	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
 		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
 	}, nil)

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -76,6 +76,155 @@ func countActivityType(store *recordingActivityStore, eventType string) int {
 	return n
 }
 
+func waitForSignal(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal(msg)
+	}
+}
+
+func assertNoSignal(t *testing.T, ch <-chan struct{}, d time.Duration, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal(msg)
+	case <-time.After(d):
+	}
+}
+
+// --- lifecycle shutdown ---
+
+func TestStop_WaitsForInFlightTimerCallback(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	workCtx, workCancel := context.WithCancel(context.Background())
+	p.workCancel = workCancel
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	stopped := make(chan struct{})
+
+	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
+		func(ctx context.Context, scheduleID int64) (int64, error) {
+			close(started)
+			<-release
+			assert.NoError(t, ctx.Err())
+			return int64(0), nil
+		},
+	)
+
+	p.timerWG.Add(1)
+	timer := time.AfterFunc(time.Hour, func() {
+		defer p.timerWG.Done()
+		p.executeSchedule(workCtx, 1)
+	})
+	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
+	timer.Reset(0)
+
+	waitForSignal(t, started, "timer callback did not start")
+
+	go func() {
+		assert.NoError(t, p.Stop())
+		close(stopped)
+	}()
+
+	assertNoSignal(t, stopped, 50*time.Millisecond, "Stop returned before timer callback finished")
+	close(release)
+	waitForSignal(t, stopped, "Stop did not return after timer callback finished")
+}
+
+func TestStop_DoesNotWaitForFutureStoppedTimer(t *testing.T) {
+	p, _, _, _, _ := newTestProcessor(t, time.Now())
+	_, workCancel := context.WithCancel(context.Background())
+	p.workCancel = workCancel
+
+	fired := make(chan struct{})
+	stopped := make(chan struct{})
+
+	p.timerWG.Add(1)
+	timer := time.AfterFunc(time.Hour, func() {
+		defer p.timerWG.Done()
+		close(fired)
+	})
+	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
+
+	go func() {
+		assert.NoError(t, p.Stop())
+		close(stopped)
+	}()
+
+	waitForSignal(t, stopped, "Stop waited for a future timer instead of stopping it")
+	assertNoSignal(t, fired, 10*time.Millisecond, "stopped timer fired")
+}
+
+func TestStop_DrainsTimersRegisteredByStoppingLoop(t *testing.T) {
+	p, _, _, _, _ := newTestProcessor(t, time.Now())
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	_, workCancel := context.WithCancel(context.Background())
+	p.stopCancel = stopCancel
+	p.workCancel = workCancel
+
+	registered := make(chan struct{})
+	fired := make(chan struct{})
+	stopped := make(chan struct{})
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		<-stopCtx.Done()
+
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.timerWG.Add(1)
+		timer := time.AfterFunc(time.Hour, func() {
+			defer p.timerWG.Done()
+			close(fired)
+		})
+		p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
+		close(registered)
+	}()
+
+	go func() {
+		assert.NoError(t, p.Stop())
+		close(stopped)
+	}()
+
+	waitForSignal(t, stopped, "Stop did not drain timer registered while stopping loops")
+	waitForSignal(t, registered, "stopping loop did not register timer before drain")
+	assertNoSignal(t, fired, 10*time.Millisecond, "timer registered during shutdown fired")
+}
+
+func TestStop_CronJobsFinishWithLiveContext(t *testing.T) {
+	p, _, _, _, _ := newTestProcessor(t, time.Now())
+	workCtx, workCancel := context.WithCancel(context.Background())
+	p.workCancel = workCancel
+	p.cron = cron.New(cron.WithSeconds())
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	stopped := make(chan struct{})
+
+	_, err := p.cron.AddFunc("@every 1s", func() {
+		close(started)
+		<-release
+		assert.NoError(t, workCtx.Err())
+	})
+	assert.NoError(t, err)
+	p.cron.Start()
+
+	waitForSignal(t, started, "cron callback did not start")
+
+	go func() {
+		assert.NoError(t, p.Stop())
+		close(stopped)
+	}()
+
+	assertNoSignal(t, stopped, 50*time.Millisecond, "Stop returned before cron callback finished")
+	close(release)
+	waitForSignal(t, stopped, "Stop did not return after cron callback finished")
+}
+
 // --- recoverStaleRunning ---
 
 func TestRecoverStaleRunning_ResetsNonWindowSchedules(t *testing.T) {
@@ -211,6 +360,26 @@ func TestSyncSchedules_ReRegistersOnFingerprintChange(t *testing.T) {
 	assert.Equal(t, scheduleFingerprint(sched), entry.fingerprint)
 	// Should have a new entryID (old one removed, new one registered).
 	assert.NotEqual(t, entryID, entry.entryID)
+}
+
+func TestRemoveJobIfCurrent_SkipsReregistered(t *testing.T) {
+	p, _, _, _, _ := newTestProcessor(t, time.Now())
+	p.jobs[1] = jobEntry{isOneTime: true, generation: 2}
+
+	p.removeJobIfCurrent(1, 1, true)
+
+	p.mu.Lock()
+	entry, exists := p.jobs[1]
+	p.mu.Unlock()
+	assert.True(t, exists)
+	assert.Equal(t, uint64(2), entry.generation)
+
+	p.removeJobIfCurrent(1, 2, true)
+
+	p.mu.Lock()
+	_, exists = p.jobs[1]
+	p.mu.Unlock()
+	assert.False(t, exists)
 }
 
 // --- scheduleFingerprint ---
@@ -685,6 +854,36 @@ func TestUpdateAfterRun_UpdateFailsRevertFails_KeepsJob(t *testing.T) {
 	assert.True(t, exists, "job should still exist when revert fails")
 }
 
+func TestUpdateAfterRun_UpdateFails_DoesNotRemoveReregisteredJob(t *testing.T) {
+	now := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	p, procStore, _, _, _ := newTestProcessor(t, now)
+	p.jobs[1] = jobEntry{isOneTime: true, generation: 2}
+
+	sched := &pb.Schedule{
+		Id:           1,
+		Action:       pb.ScheduleAction_SCHEDULE_ACTION_REBOOT,
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_RECURRING,
+		StartDate:    "2026-04-01",
+		StartTime:    "10:00",
+		Timezone:     "UTC",
+		Recurrence: &pb.ScheduleRecurrence{
+			Frequency: pb.RecurrenceFrequency_RECURRENCE_FREQUENCY_DAILY,
+			Interval:  1,
+		},
+	}
+
+	procStore.EXPECT().UpdateScheduleAfterRun(gomock.Any(), int64(1), gomock.Any(), gomock.Any(), statusActive).Return(errors.New("db down"))
+	procStore.EXPECT().RevertScheduleToActive(gomock.Any(), int64(1)).Return(nil)
+
+	p.updateAfterRunWithGeneration(context.Background(), sched, int64(1), now, 1, true)
+
+	p.mu.Lock()
+	entry, exists := p.jobs[1]
+	p.mu.Unlock()
+	assert.True(t, exists, "newer job should not be removed by stale retry cleanup")
+	assert.Equal(t, uint64(2), entry.generation)
+}
+
 // --- transitionToCompleted ---
 
 func TestTransitionToCompleted_UpdateFailsRevertFails_KeepsJob(t *testing.T) {
@@ -720,6 +919,37 @@ func TestTransitionToCompleted_UpdateFailsRevertFails_KeepsJob(t *testing.T) {
 	defer p.mu.Unlock()
 	_, exists := p.jobs[1]
 	assert.True(t, exists, "job should still exist when revert fails")
+}
+
+func TestTransitionToCompleted_UpdateFails_DoesNotRemoveReregisteredJob(t *testing.T) {
+	now := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	p, procStore, _, _, _ := newTestProcessor(t, now)
+	p.jobs[1] = jobEntry{isOneTime: true, generation: 2}
+
+	sched := &pb.Schedule{
+		Id:           1,
+		Action:       pb.ScheduleAction_SCHEDULE_ACTION_REBOOT,
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_RECURRING,
+		StartDate:    "2026-03-01",
+		StartTime:    "10:00",
+		EndDate:      "2026-03-31",
+		Timezone:     "UTC",
+		Recurrence: &pb.ScheduleRecurrence{
+			Frequency: pb.RecurrenceFrequency_RECURRENCE_FREQUENCY_DAILY,
+			Interval:  1,
+		},
+	}
+
+	procStore.EXPECT().UpdateScheduleAfterRun(gomock.Any(), int64(1), gomock.Any(), gomock.Nil(), statusCompleted).Return(errors.New("db down"))
+	procStore.EXPECT().RevertScheduleToActive(gomock.Any(), int64(1)).Return(nil)
+
+	p.transitionToCompletedWithGeneration(context.Background(), sched, int64(1), now, 1, true)
+
+	p.mu.Lock()
+	entry, exists := p.jobs[1]
+	p.mu.Unlock()
+	assert.True(t, exists, "newer job should not be removed by stale retry cleanup")
+	assert.Equal(t, uint64(2), entry.generation)
 }
 
 // --- checkEndOfWindow ---

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -225,6 +225,54 @@ func TestStop_CronJobsFinishWithLiveContext(t *testing.T) {
 	waitForSignal(t, stopped, "Stop did not return after cron callback finished")
 }
 
+// Drain must still be bounded: if work wedges, the watchdog cancels workCtx
+// so the in-flight call returns and the wg waits release.
+func TestStop_WatchdogCancelsHungWork(t *testing.T) {
+	prev := shutdownDeadlineFn
+	shutdownDeadlineFn = func() time.Duration { return 50 * time.Millisecond }
+	t.Cleanup(func() { shutdownDeadlineFn = prev })
+
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	workCtx, workCancel := context.WithCancel(context.Background())
+	p.workCancel = workCancel
+
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	stopped := make(chan struct{})
+
+	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
+		func(ctx context.Context, _ int64) (int64, error) {
+			close(started)
+			<-ctx.Done()
+			close(cancelled)
+			return int64(0), ctx.Err()
+		},
+	)
+
+	p.timerWG.Add(1)
+	timer := time.AfterFunc(time.Hour, func() {
+		defer p.timerWG.Done()
+		p.executeSchedule(workCtx, 1)
+	})
+	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
+	timer.Reset(0)
+
+	waitForSignal(t, started, "hung callback did not start")
+
+	begin := time.Now()
+	go func() {
+		assert.NoError(t, p.Stop())
+		close(stopped)
+	}()
+
+	waitForSignal(t, cancelled, "watchdog did not cancel hung work via workCancel")
+	waitForSignal(t, stopped, "Stop did not return after watchdog fired")
+
+	if elapsed := time.Since(begin); elapsed > time.Second {
+		t.Fatalf("Stop took %v; watchdog should have bounded shutdown well below this", elapsed)
+	}
+}
+
 // --- recoverStaleRunning ---
 
 func TestRecoverStaleRunning_ResetsNonWindowSchedules(t *testing.T) {

--- a/server/internal/domain/schedule/targets/expand.go
+++ b/server/internal/domain/schedule/targets/expand.go
@@ -1,0 +1,78 @@
+package targets
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
+	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+)
+
+// UnspecifiedTargetHandler lets callers preserve their local behavior for
+// SCHEDULE_TARGET_TYPE_UNSPECIFIED without duplicating the target expansion
+// logic. Pass nil to ignore unspecified targets silently.
+type UnspecifiedTargetHandler func(targetID string)
+
+// Expand converts schedule targets into deduplicated device identifiers. Rack
+// and group targets are expanded through the collection store. Output order
+// follows target order, with duplicate identifiers omitted.
+func Expand(
+	ctx context.Context,
+	collectionStore stores.CollectionStore,
+	scheduleTargets []*pb.ScheduleTarget,
+	orgID int64,
+	onUnspecified UnspecifiedTargetHandler,
+) ([]string, error) {
+	seen := make(map[string]struct{})
+	var identifiers []string
+
+	for _, target := range scheduleTargets {
+		switch target.TargetType {
+		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER:
+			if _, dup := seen[target.TargetId]; !dup {
+				seen[target.TargetId] = struct{}{}
+				identifiers = append(identifiers, target.TargetId)
+			}
+
+		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_RACK:
+			rackID, err := strconv.ParseInt(target.TargetId, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid rack target_id %q: %w", target.TargetId, err)
+			}
+			rackDevices, err := collectionStore.GetDeviceIdentifiersByDeviceSetID(ctx, rackID, orgID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve rack %d devices: %w", rackID, err)
+			}
+			for _, device := range rackDevices {
+				if _, dup := seen[device]; !dup {
+					seen[device] = struct{}{}
+					identifiers = append(identifiers, device)
+				}
+			}
+
+		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_GROUP:
+			groupID, err := strconv.ParseInt(target.TargetId, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid group target_id %q: %w", target.TargetId, err)
+			}
+			groupDevices, err := collectionStore.GetDeviceIdentifiersByDeviceSetID(ctx, groupID, orgID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve group %d devices: %w", groupID, err)
+			}
+			for _, device := range groupDevices {
+				if _, dup := seen[device]; !dup {
+					seen[device] = struct{}{}
+					identifiers = append(identifiers, device)
+				}
+			}
+
+		case pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_UNSPECIFIED:
+			if onUnspecified != nil {
+				onUnspecified(target.TargetId)
+			}
+		}
+	}
+
+	return identifiers, nil
+}

--- a/server/internal/domain/schedule/targets/expand_test.go
+++ b/server/internal/domain/schedule/targets/expand_test.go
@@ -1,0 +1,73 @@
+package targets
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
+)
+
+func TestExpandDeduplicatesMinerRackAndGroupTargets(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	collectionStore := mocks.NewMockCollectionStore(ctrl)
+	collectionStore.EXPECT().
+		GetDeviceIdentifiersByDeviceSetID(gomock.Any(), int64(10), int64(1)).
+		Return([]string{"rack-1", "shared"}, nil)
+	collectionStore.EXPECT().
+		GetDeviceIdentifiersByDeviceSetID(gomock.Any(), int64(20), int64(1)).
+		Return([]string{"group-1", "shared"}, nil)
+
+	got, err := Expand(context.Background(), collectionStore, []*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_RACK, TargetId: "10"},
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_GROUP, TargetId: "20"},
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
+	}, 1, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"miner-1", "rack-1", "shared", "group-1"}, got)
+}
+
+func TestExpandCallsUnspecifiedHandler(t *testing.T) {
+	var warned []string
+
+	got, err := Expand(context.Background(), nil, []*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_UNSPECIFIED, TargetId: "bad-target"},
+	}, 1, func(targetID string) {
+		warned = append(warned, targetID)
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.Equal(t, []string{"bad-target"}, warned)
+}
+
+func TestExpandReturnsInvalidRackIDError(t *testing.T) {
+	_, err := Expand(context.Background(), nil, []*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_RACK, TargetId: "not-an-id"},
+	}, 1, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid rack target_id "not-an-id"`)
+}
+
+func TestExpandWrapsCollectionStoreErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	collectionStore := mocks.NewMockCollectionStore(ctrl)
+	collectionStore.EXPECT().
+		GetDeviceIdentifiersByDeviceSetID(gomock.Any(), int64(10), int64(1)).
+		Return(nil, errors.New("db down"))
+
+	_, err := Expand(context.Background(), collectionStore, []*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_RACK, TargetId: "10"},
+	}, 1, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve rack 10")
+}

--- a/server/internal/domain/session/models.go
+++ b/server/internal/domain/session/models.go
@@ -36,16 +36,10 @@ const (
 	ActorScheduler Actor = "scheduler"
 )
 
-// Source carries optional caller policy context used by command preflight
-// filters to make priority/conflict decisions. All fields are zero by default.
-// Filters that don't require a particular field should ignore it.
+// Source carries optional policy context for command preflight filters.
 type Source struct {
-	// ScheduleID + SchedulePriority are populated by the schedule processor
-	// for scheduler-origin commands. Manual callers (and any caller without
-	// schedule context) leave them zero. ScheduleID == 0 is the convention
-	// for "no source schedule" — the schedule_conflict filter uses it to
-	// decide whether to apply scheduler priority semantics or treat every
-	// running power-target schedule as a blocker.
+	// ScheduleID == 0 means there is no source schedule, so schedule-conflict
+	// filtering cannot apply priority semantics.
 	ScheduleID       int64
 	SchedulePriority int32
 }

--- a/server/internal/domain/session/models.go
+++ b/server/internal/domain/session/models.go
@@ -36,6 +36,20 @@ const (
 	ActorScheduler Actor = "scheduler"
 )
 
+// Source carries optional caller policy context used by command preflight
+// filters to make priority/conflict decisions. All fields are zero by default.
+// Filters that don't require a particular field should ignore it.
+type Source struct {
+	// ScheduleID + SchedulePriority are populated by the schedule processor
+	// for scheduler-origin commands. Manual callers (and any caller without
+	// schedule context) leave them zero. ScheduleID == 0 is the convention
+	// for "no source schedule" — the schedule_conflict filter uses it to
+	// decide whether to apply scheduler priority semantics or treat every
+	// running power-target schedule as a blocker.
+	ScheduleID       int64
+	SchedulePriority int32
+}
+
 // Info contains authenticated request context passed to handlers.
 // Populated by the auth interceptor for both session and API key authentication.
 type Info struct {
@@ -58,6 +72,11 @@ type Info struct {
 	// Actor is set by internal orchestrators that synthesize a session.Info
 	// (e.g. scheduler). Empty for user/API-key traffic.
 	Actor Actor
+
+	// Source is populated by orchestrators that have policy context filters
+	// can act on (priority, schedule ID, etc.). Zero-valued for user/API-key
+	// traffic.
+	Source Source
 }
 
 // CredentialID returns a stable identifier for the authenticated credential.

--- a/server/internal/domain/stores/interfaces/mocks/mock_schedule_store.go
+++ b/server/internal/domain/stores/interfaces/mocks/mock_schedule_store.go
@@ -350,19 +350,19 @@ func (mr *MockScheduleProcessorStoreMockRecorder) GetActiveSchedules(ctx any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveSchedules", reflect.TypeOf((*MockScheduleProcessorStore)(nil).GetActiveSchedules), ctx)
 }
 
-// GetRunningPowerTargetSchedules mocks base method.
-func (m *MockScheduleProcessorStore) GetRunningPowerTargetSchedules(ctx context.Context, orgID int64) ([]*schedulev1.Schedule, error) {
+// GetRunningPowerTargetScheduleOverlaps mocks base method.
+func (m *MockScheduleProcessorStore) GetRunningPowerTargetScheduleOverlaps(ctx context.Context, orgID int64, deviceIdentifiers []string) ([]interfaces.ScheduleTargetOverlap, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRunningPowerTargetSchedules", ctx, orgID)
-	ret0, _ := ret[0].([]*schedulev1.Schedule)
+	ret := m.ctrl.Call(m, "GetRunningPowerTargetScheduleOverlaps", ctx, orgID, deviceIdentifiers)
+	ret0, _ := ret[0].([]interfaces.ScheduleTargetOverlap)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetRunningPowerTargetSchedules indicates an expected call of GetRunningPowerTargetSchedules.
-func (mr *MockScheduleProcessorStoreMockRecorder) GetRunningPowerTargetSchedules(ctx, orgID any) *gomock.Call {
+// GetRunningPowerTargetScheduleOverlaps indicates an expected call of GetRunningPowerTargetScheduleOverlaps.
+func (mr *MockScheduleProcessorStoreMockRecorder) GetRunningPowerTargetScheduleOverlaps(ctx, orgID, deviceIdentifiers any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunningPowerTargetSchedules", reflect.TypeOf((*MockScheduleProcessorStore)(nil).GetRunningPowerTargetSchedules), ctx, orgID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunningPowerTargetScheduleOverlaps", reflect.TypeOf((*MockScheduleProcessorStore)(nil).GetRunningPowerTargetScheduleOverlaps), ctx, orgID, deviceIdentifiers)
 }
 
 // GetScheduleByID mocks base method.

--- a/server/internal/domain/stores/interfaces/schedule.go
+++ b/server/internal/domain/stores/interfaces/schedule.go
@@ -11,6 +11,12 @@ type ScheduleIDStatus struct {
 	Status string
 }
 
+type ScheduleTargetOverlap struct {
+	ScheduleID       int64
+	SchedulePriority int32
+	DeviceIdentifier string
+}
+
 // ScheduleWithOrg pairs a proto Schedule with its org_id for cross-org processor queries.
 // The proto Schedule message is org-agnostic (all CRUD is org-scoped via session),
 // but the processor operates across orgs and needs the org_id for command dispatch.
@@ -54,7 +60,7 @@ type SchedulePriorityStore interface {
 // Schedule message omits. Org-scoped queries return plain *pb.Schedule.
 type ScheduleProcessorStore interface {
 	GetActiveSchedules(ctx context.Context) ([]ScheduleWithOrg, error)
-	GetRunningPowerTargetSchedules(ctx context.Context, orgID int64) ([]*pb.Schedule, error)
+	GetRunningPowerTargetScheduleOverlaps(ctx context.Context, orgID int64, deviceIdentifiers []string) ([]ScheduleTargetOverlap, error)
 	UpdateScheduleAfterRun(ctx context.Context, scheduleID int64, lastRunAt, nextRunAt *int64, status string) error
 	SetScheduleRunning(ctx context.Context, scheduleID int64) (int64, error)
 	GetScheduleByID(ctx context.Context, scheduleID int64) (*ScheduleWithOrg, error)

--- a/server/internal/domain/stores/sqlstores/schedule.go
+++ b/server/internal/domain/stores/sqlstores/schedule.go
@@ -299,18 +299,24 @@ func (s *SQLScheduleStore) GetActiveSchedules(ctx context.Context) ([]interfaces
 	return result, nil
 }
 
-func (s *SQLScheduleStore) GetRunningPowerTargetSchedules(ctx context.Context, orgID int64) ([]*pb.Schedule, error) {
-	rows, err := s.GetQueries(ctx).GetRunningPowerTargetSchedules(ctx, orgID)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("failed to get running power target schedules: %v", err)
+func (s *SQLScheduleStore) GetRunningPowerTargetScheduleOverlaps(ctx context.Context, orgID int64, deviceIdentifiers []string) ([]interfaces.ScheduleTargetOverlap, error) {
+	if len(deviceIdentifiers) == 0 {
+		return nil, nil
 	}
-	result := make([]*pb.Schedule, 0, len(rows))
-	for _, row := range rows {
-		sched, err := convertToProtoSchedule(row)
-		if err != nil {
-			return nil, err
+	rows, err := s.GetQueries(ctx).GetRunningPowerTargetScheduleOverlaps(ctx, sqlc.GetRunningPowerTargetScheduleOverlapsParams{
+		OrgID:             orgID,
+		DeviceIdentifiers: deviceIdentifiers,
+	})
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("failed to get running power target schedule overlaps: %v", err)
+	}
+	result := make([]interfaces.ScheduleTargetOverlap, len(rows))
+	for i, row := range rows {
+		result[i] = interfaces.ScheduleTargetOverlap{
+			ScheduleID:       row.ScheduleID,
+			SchedulePriority: row.SchedulePriority,
+			DeviceIdentifier: row.DeviceIdentifier,
 		}
-		result = append(result, sched)
 	}
 	return result, nil
 }

--- a/server/internal/handlers/command/handler.go
+++ b/server/internal/handlers/command/handler.go
@@ -29,67 +29,62 @@ func (h *Handler) Reboot(
 	ctx context.Context,
 	req *connect.Request[pb.RebootRequest],
 ) (*connect.Response[pb.RebootResponse], error) {
-	resp, err := h.commandSvc.Reboot(ctx, req.Msg.DeviceSelector)
+	result, err := h.commandSvc.Reboot(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.RebootResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) StopMining(
 	ctx context.Context,
 	req *connect.Request[pb.StopMiningRequest],
 ) (*connect.Response[pb.StopMiningResponse], error) {
-	resp, err := h.commandSvc.StopMining(ctx, req.Msg.DeviceSelector)
+	result, err := h.commandSvc.StopMining(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.StopMiningResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) StartMining(
 	ctx context.Context,
 	req *connect.Request[pb.StartMiningRequest],
 ) (*connect.Response[pb.StartMiningResponse], error) {
-	resp, err := h.commandSvc.StartMining(ctx, req.Msg.DeviceSelector)
+	result, err := h.commandSvc.StartMining(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.StartMiningResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) SetCoolingMode(
 	ctx context.Context,
 	req *connect.Request[pb.SetCoolingModeRequest],
 ) (*connect.Response[pb.SetCoolingModeResponse], error) {
-	resp, err := h.commandSvc.SetCoolingMode(ctx, req.Msg.DeviceSelector, req.Msg.Mode)
+	result, err := h.commandSvc.SetCoolingMode(ctx, req.Msg.DeviceSelector, req.Msg.Mode)
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.SetCoolingModeResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) SetPowerTarget(
 	ctx context.Context,
 	req *connect.Request[pb.SetPowerTargetRequest],
 ) (*connect.Response[pb.SetPowerTargetResponse], error) {
-	resp, err := h.commandSvc.SetPowerTarget(ctx, req.Msg.DeviceSelector, req.Msg.PerformanceMode)
+	result, err := h.commandSvc.SetPowerTarget(ctx, req.Msg.DeviceSelector, req.Msg.PerformanceMode)
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.SetPowerTargetResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) UpdateMiningPools(
 	ctx context.Context,
 	req *connect.Request[pb.UpdateMiningPoolsRequest],
 ) (*connect.Response[pb.UpdateMiningPoolsResponse], error) {
-	resp, err := h.commandSvc.UpdateMiningPools(
+	result, err := h.commandSvc.UpdateMiningPools(
 		ctx,
 		req.Msg.DeviceSelector,
 		req.Msg.DefaultPool,
@@ -101,54 +96,49 @@ func (h *Handler) UpdateMiningPools(
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.UpdateMiningPoolsResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) DownloadLogs(
 	ctx context.Context,
 	req *connect.Request[pb.DownloadLogsRequest],
 ) (*connect.Response[pb.DownloadLogsResponse], error) {
-	resp, err := h.commandSvc.DownloadLogs(ctx, req.Msg.DeviceSelector)
+	result, err := h.commandSvc.DownloadLogs(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.DownloadLogsResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) BlinkLED(ctx context.Context, req *connect.Request[pb.BlinkLEDRequest]) (*connect.Response[pb.BlinkLEDResponse], error) {
-	resp, err := h.commandSvc.BlinkLED(ctx, req.Msg.DeviceSelector)
+	result, err := h.commandSvc.BlinkLED(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.BlinkLEDResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) FirmwareUpdate(ctx context.Context, req *connect.Request[pb.FirmwareUpdateRequest]) (*connect.Response[pb.FirmwareUpdateResponse], error) {
-	resp, err := h.commandSvc.FirmwareUpdate(ctx, req.Msg.DeviceSelector, req.Msg.GetFirmwareFileId())
+	result, err := h.commandSvc.FirmwareUpdate(ctx, req.Msg.DeviceSelector, req.Msg.GetFirmwareFileId())
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.FirmwareUpdateResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) Unpair(ctx context.Context, req *connect.Request[pb.UnpairRequest]) (*connect.Response[pb.UnpairResponse], error) {
-	resp, err := h.commandSvc.Unpair(ctx, req.Msg.DeviceSelector)
+	result, err := h.commandSvc.Unpair(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.UnpairResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) UpdateMinerPassword(
 	ctx context.Context,
 	req *connect.Request[pb.UpdateMinerPasswordRequest],
 ) (*connect.Response[pb.UpdateMinerPasswordResponse], error) {
-	resp, err := h.commandSvc.UpdateMinerPassword(
+	result, err := h.commandSvc.UpdateMinerPassword(
 		ctx,
 		req.Msg.DeviceSelector,
 		req.Msg.NewPassword,
@@ -159,8 +149,7 @@ func (h *Handler) UpdateMinerPassword(
 	if err != nil {
 		return nil, err
 	}
-
-	return connect.NewResponse(resp), nil
+	return connect.NewResponse(&pb.UpdateMinerPasswordResponse{BatchIdentifier: result.BatchIdentifier}), nil
 }
 
 func (h *Handler) StreamCommandBatchUpdates(ctx context.Context, r *connect.Request[pb.StreamCommandBatchUpdatesRequest], stream *connect.ServerStream[pb.StreamCommandBatchUpdatesResponse]) error {

--- a/server/sqlc/queries/device.sql
+++ b/server/sqlc/queries/device.sql
@@ -611,6 +611,24 @@ WHERE d.org_id = sqlc.arg('org_id')
     AND (sqlc.narg('manufacturer_filter')::text IS NULL OR dd.manufacturer = ANY(string_to_array(sqlc.narg('manufacturer_filter'), ',')))
 ORDER BY d.id;
 
+-- name: GetFilteredDeviceIdentifiers :many
+-- Mirrors GetFilteredDeviceIds but returns device_identifier strings instead of
+-- internal IDs. Used by command preflight filtering, which operates on
+-- identifiers (the same primitive used by selectors and schedules).
+SELECT
+    d.device_identifier
+FROM device d
+JOIN device_pairing dp ON d.id = dp.device_id
+JOIN discovered_device dd ON d.discovered_device_id = dd.id
+LEFT JOIN device_status ds ON d.id = ds.device_id
+WHERE d.org_id = sqlc.arg('org_id')
+    AND dp.pairing_status::text = COALESCE(sqlc.narg('pairing_status')::text, 'PAIRED')
+    AND d.deleted_at IS NULL
+    AND (sqlc.narg('device_status')::text IS NULL OR ds.status::text = sqlc.narg('device_status')::text)
+    AND (sqlc.narg('model_filter')::text IS NULL OR dd.model = ANY(string_to_array(sqlc.narg('model_filter'), ',')))
+    AND (sqlc.narg('manufacturer_filter')::text IS NULL OR dd.manufacturer = ANY(string_to_array(sqlc.narg('manufacturer_filter'), ',')))
+ORDER BY d.device_identifier;
+
 -- name: GetDeviceInfoForCapabilityCheck :many
 -- Returns device information needed for capability checking.
 -- Used when checking if specific devices support a command.

--- a/server/sqlc/queries/schedule.sql
+++ b/server/sqlc/queries/schedule.sql
@@ -115,8 +115,7 @@ JOIN requested r ON (
             WHERE dsm.org_id = s.org_id
               AND ds.org_id = s.org_id
               AND ds.deleted_at IS NULL
-              -- Match schedule target expansion semantics: rack/group targets
-              -- resolve by device_set ID, not by the stored target_type label.
+              -- Match expansion: rack/group targets resolve by device_set ID.
               AND dsm.device_set_id = CASE WHEN st.target_id ~ '^[0-9]+$' THEN st.target_id::bigint ELSE NULL END
               AND dsm.device_identifier = r.device_identifier
         )

--- a/server/sqlc/queries/schedule.sql
+++ b/server/sqlc/queries/schedule.sql
@@ -115,8 +115,9 @@ JOIN requested r ON (
             WHERE dsm.org_id = s.org_id
               AND ds.org_id = s.org_id
               AND ds.deleted_at IS NULL
+              -- Match schedule target expansion semantics: rack/group targets
+              -- resolve by device_set ID, not by the stored target_type label.
               AND dsm.device_set_id = CASE WHEN st.target_id ~ '^[0-9]+$' THEN st.target_id::bigint ELSE NULL END
-              AND dsm.device_set_type::text = st.target_type
               AND dsm.device_identifier = r.device_identifier
         )
     )

--- a/server/sqlc/queries/schedule.sql
+++ b/server/sqlc/queries/schedule.sql
@@ -94,14 +94,38 @@ FROM schedule
 WHERE org_id = $1
   AND deleted_at IS NULL;
 
--- name: GetRunningPowerTargetSchedules :many
-SELECT *
-FROM schedule
-WHERE org_id = $1
-  AND status = 'running'
-  AND action = 'set_power_target'
-  AND deleted_at IS NULL
-ORDER BY priority, id;
+-- name: GetRunningPowerTargetScheduleOverlaps :many
+WITH requested AS (
+    SELECT UNNEST(sqlc.arg('device_identifiers')::text[]) AS device_identifier
+)
+SELECT DISTINCT
+    s.id AS schedule_id,
+    s.priority AS schedule_priority,
+    r.device_identifier::text AS device_identifier
+FROM schedule s
+JOIN schedule_target st ON st.schedule_id = s.id
+JOIN requested r ON (
+    (st.target_type = 'miner' AND st.target_id = r.device_identifier)
+    OR (
+        st.target_type IN ('rack', 'group')
+        AND EXISTS (
+            SELECT 1
+            FROM device_set_membership dsm
+            JOIN device_set ds ON ds.id = dsm.device_set_id
+            WHERE dsm.org_id = s.org_id
+              AND ds.org_id = s.org_id
+              AND ds.deleted_at IS NULL
+              AND dsm.device_set_id = CASE WHEN st.target_id ~ '^[0-9]+$' THEN st.target_id::bigint ELSE NULL END
+              AND dsm.device_set_type::text = st.target_type
+              AND dsm.device_identifier = r.device_identifier
+        )
+    )
+)
+WHERE s.org_id = $1
+  AND s.status = 'running'
+  AND s.action = 'set_power_target'
+  AND s.deleted_at IS NULL
+ORDER BY s.priority, s.id, r.device_identifier;
 
 -- name: CreateScheduleTarget :exec
 INSERT INTO schedule_target (schedule_id, target_type, target_id)


### PR DESCRIPTION
## Summary

This PR moves command preflight filtering into `commandSvc` so command suppression rules run consistently for manual API calls, schedules, and future orchestrators. This is also useful prework for future curtailment support, where command-layer filters can block schedule/manual commands without adding new hooks to `schedule.Processor`.

It introduces three main areas of change:

1. **Command preflight framework**
   - Adds `CommandFilter`, `CommandResult`, and skip metadata in `server/internal/domain/command/filter.go`.
   - Reorders `processCommand` in `server/internal/domain/command/service.go` so selectors resolve before batch creation, filters run before enqueue, and command batches reflect the final dispatched device set.
   - External/manual commands resolve original identifiers up front: stale selectors with no live devices return `InvalidArgument` regardless of how the kept/skipped partition fell; otherwise the request is rejected with `FailedPrecondition` and a `command_preflight_blocked` audit row written on a bounded background context (request-ctx cancellation cannot suppress the row or degrade the deny into `Internal`).
   - Scheduler/internal calls can remain best-effort and inspect skipped devices.

2. **Schedule conflict filtering at the command layer**
   - Extracts schedule conflict behavior into `command.ScheduleConflictFilter` in `server/internal/domain/command/schedule_conflict_filter.go`.
   - Registers the filter in `server/cmd/fleetd/main.go` so manual `SetPowerTarget` calls can no longer bypass running power-target schedules.
   - Uses a SQL overlap query that mirrors schedule target expansion semantics for miner, rack, and group targets.
   - Updates `schedule.Processor` to consume `CommandResult` skip metadata instead of owning inline conflict hooks.

3. **Schedule processor cleanup and hardening**
   - Extracts shared schedule target expansion into `server/internal/domain/schedule/targets/expand.go`.
   - Makes schedule audit more accurate for fully filtered dispatches and end-of-window reverts.
   - Hardens processor shutdown in `server/internal/domain/schedule/processor.go` by draining cron/timer work before cancelling execution contexts, bounding total shutdown duration with a 10s watchdog (so a wedged DB/dispatch call cannot hang shutdown), and using job generations to avoid stale retry cleanup removing newer registrations.

## Behavior Changes

- Manual/API `SetPowerTarget` requests that overlap active power-target schedules now fail with `FailedPrecondition` instead of overriding schedules or partially dispatching.
- External selectors that match no live devices now fail with `InvalidArgument` before creating a zero-device command batch — including mixed selectors where a stale identifier overlaps a running schedule but no kept identifier maps to a live device.
- `command_preflight_blocked` audit rows are written on a bounded background context, so a client disconnect at the deny-point cannot suppress the row or convert `FailedPrecondition` into `Internal`.
- Scheduler-origin commands remain best-effort: partial skips dispatch surviving devices, all-skipped outcomes are successful no-ops, and skipped devices are audited.
- Schedule processor `Stop()` is bounded by a 10s watchdog: drain-before-cancel remains the happy path, but a wedged DB or dispatch call no longer hangs shutdown indefinitely.

## Reviewer Guide

Start with these files:

- `server/internal/domain/command/filter.go`
- `server/internal/domain/command/service.go`
- `server/internal/domain/command/schedule_conflict_filter.go`
- `server/sqlc/queries/schedule.sql`
- `server/internal/domain/schedule/processor.go`
- `server/internal/domain/schedule/targets/expand.go`
- `server/cmd/fleetd/main.go`

The generated SQL/mock files support the new overlap query and updated interfaces. The focused tests are in the matching `*_test.go` files under `command`, `schedule`, and `schedule/targets`.

## Deferred Follow-Up

Explicit `include_devices` ID-to-DB-ID resolution is still not org-scoped. That issue predates this refactor and should be handled separately as command/device authorization hardening across shared selector resolution paths.

## Test Plan

- [x] Command filter unit tests for chaining, short-circuiting, errors, and idempotency.
- [x] Schedule conflict filter tests for scheduler priority behavior, manual blocking, self-schedule behavior, and rack/group overlap behavior.
- [x] Preflight block and zero-target tests for external failure behavior, scheduler no-op behavior, stale all-skipped and mixed-stale partial-skip behavior, audit metadata, and audit-survives-cancelled-request-ctx.
- [x] Schedule processor tests for conflict skip audit, zero-dispatch behavior, end-of-window revert behavior, shutdown/TOCTOU hardening, and shutdown watchdog cancelling wedged work.
- [x] `schedule/targets.Expand` tests for dedupe, expansion, unspecified targets, and error wrapping.
- [x] `env -u GOROOT /usr/local/go/bin/go test ./server/internal/domain/command -run 'TestProcessCommand_ManualFullSkip|TestProcessCommand_ManualPartialSkip|TestProcessCommand_SchedulerFullSkip|TestSetPowerTarget_ManualBlock|TestProcessCommand_ManualBlock_AuditWritesOnCanceledRequestCtx'`
- [x] `env -u GOROOT /usr/local/go/bin/go test ./server/internal/domain/schedule`