### PR TITLE
Improve schedules mobile table layout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,18 @@
   "editor.formatOnSave": true,
   "files.insertFinalNewline": true,
 
+  // Tailwind CSS
+  "tailwindCSS.classAttributes": [
+    "class",
+    "className",
+    "ngClass",
+    "class:list",
+    "tableClassName"
+  ],
+  "tailwindCSS.experimental.classRegex": [
+    ["ClassName\\s*=\\s*\\[([\\s\\S]*?)\\]\\.join\\(\" \"\\)", "\"([^\"]*)\""]
+  ],
+
   // Hermit
   "terminal.integrated.env.osx": {
     "ACTIVE_HERMIT": null,

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
@@ -141,9 +141,8 @@ describe("SchedulesPage", () => {
     const table = container.querySelector("table");
     expect(table).toHaveClass(
       "phone:table-fixed",
-      "phone:[&_td:last-child]:w-9",
-      "phone:[&_th:last-child]:w-9",
-      "phone:[&_td:last-child>div]:justify-end",
+      "phone:[&_tbody_td[data-testid=action]:last-child]:w-9",
+      "phone:[&_tbody_td[data-testid=action]:last-child>div:first-child]:justify-end",
     );
     for (const columnName of ["Action", "Status", "Created by"]) {
       expect(screen.getByRole("columnheader", { name: columnName })).toHaveClass("phone:hidden");

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
@@ -127,6 +127,30 @@ describe("SchedulesPage", () => {
     expect(screen.getByText("Weekdays · 10:00 PM")).toBeVisible();
   });
 
+  it("keeps only the priority, name, schedule, and row action columns in the phone table layout", async () => {
+    vi.mocked(useScheduleApiContext).mockReturnValue(
+      createScheduleApiContextValue({
+        schedules: [createSchedule()],
+      }),
+    );
+
+    const { container } = render(<SchedulesPage />);
+
+    await waitFor(() => expect(screen.getByRole("columnheader", { name: "Name" })).toBeInTheDocument());
+
+    const table = container.querySelector("table");
+    expect(table).toHaveClass(
+      "phone:table-fixed",
+      "phone:[&_td:last-child]:w-9",
+      "phone:[&_th:last-child]:w-9",
+      "phone:[&_td:last-child>div]:justify-end",
+    );
+    for (const columnName of ["Action", "Status", "Created by"]) {
+      expect(screen.getByRole("columnheader", { name: columnName })).toHaveClass("phone:hidden");
+    }
+    expect(screen.getByTestId("list-actions-trigger")).toBeInTheDocument();
+  });
+
   it("shows an error toast when schedules fail to load", async () => {
     vi.mocked(useScheduleApiContext).mockReturnValue(
       createScheduleApiContextValue({

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
@@ -15,6 +15,7 @@ import {
   scheduleColTitles,
   scheduleColumnAriaLabels,
   scheduleFilters,
+  scheduleTableClassName,
   SORTABLE_COLUMNS,
   sortSchedules,
 } from "@/protoFleet/features/settings/components/Schedules/constants";
@@ -256,7 +257,7 @@ const SchedulesPage = () => {
         getDefaultSortDirection={getDefaultScheduleSortDirection}
         actions={rowActions}
         applyColumnWidthsToCells
-        tableClassName="mb-2 w-full phone:w-max phone:!table-auto"
+        tableClassName={scheduleTableClassName}
       />
       <div className="px-2 pb-2 text-200 text-text-primary-70">{timezoneLabel}</div>
 

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesTable.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesTable.stories.tsx
@@ -13,6 +13,7 @@ import {
   reorderScheduleIdsByDrop,
   scheduleColTitles,
   scheduleFilters,
+  scheduleTableClassName,
   SORTABLE_COLUMNS,
   sortSchedules,
 } from "@/protoFleet/features/settings/components/Schedules/constants";
@@ -230,7 +231,7 @@ const SchedulesTableStory = ({ initialSchedules = demoSchedules }: SchedulesTabl
           getDefaultSortDirection={getDefaultScheduleSortDirection}
           actions={rowActions}
           applyColumnWidthsToCells
-          tableClassName="mb-2 w-full phone:w-max phone:!table-auto"
+          tableClassName={scheduleTableClassName}
         />
         <div className="px-2 pb-2 text-200 text-text-primary-70">{timezoneLabel}</div>
       </div>

--- a/client/src/protoFleet/features/settings/components/Schedules/constants.ts
+++ b/client/src/protoFleet/features/settings/components/Schedules/constants.ts
@@ -44,13 +44,13 @@ export const activeScheduleCols: ScheduleColumn[] = [
 export const scheduleTableClassName = [
   "mb-2 w-full",
   "phone:table-fixed",
-  "phone:[&_td:last-child]:w-9",
-  "phone:[&_th:last-child]:w-9",
-  "phone:[&_td:last-child>div]:box-border",
-  "phone:[&_td:last-child>div]:flex",
-  "phone:[&_td:last-child>div]:justify-end",
-  "phone:[&_td:last-child>div]:w-9",
-  "phone:[&_th:last-child>div]:w-9",
+  "phone:[&_thead_th:last-child]:w-9",
+  "phone:[&_thead_th:last-child>div]:w-9",
+  "phone:[&_tbody_td[data-testid=action]:last-child]:w-9",
+  "phone:[&_tbody_td[data-testid=action]:last-child>div:first-child]:box-border",
+  "phone:[&_tbody_td[data-testid=action]:last-child>div:first-child]:flex",
+  "phone:[&_tbody_td[data-testid=action]:last-child>div:first-child]:justify-end",
+  "phone:[&_tbody_td[data-testid=action]:last-child>div:first-child]:w-9",
 ].join(" ");
 
 export const scheduleStatusLabels: Record<ScheduleStatus, string> = {

--- a/client/src/protoFleet/features/settings/components/Schedules/constants.ts
+++ b/client/src/protoFleet/features/settings/components/Schedules/constants.ts
@@ -41,6 +41,18 @@ export const activeScheduleCols: ScheduleColumn[] = [
   scheduleCols.createdBy,
 ];
 
+export const scheduleTableClassName = [
+  "mb-2 w-full",
+  "phone:table-fixed",
+  "phone:[&_td:last-child]:w-9",
+  "phone:[&_th:last-child]:w-9",
+  "phone:[&_td:last-child>div]:box-border",
+  "phone:[&_td:last-child>div]:flex",
+  "phone:[&_td:last-child>div]:justify-end",
+  "phone:[&_td:last-child>div]:w-9",
+  "phone:[&_th:last-child>div]:w-9",
+].join(" ");
+
 export const scheduleStatusLabels: Record<ScheduleStatus, string> = {
   running: "Running",
   active: "Active",

--- a/client/src/protoFleet/features/settings/components/Schedules/scheduleColConfig.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/scheduleColConfig.tsx
@@ -18,7 +18,7 @@ const createScheduleColConfig = (): ColConfig<ScheduleListItem, string, Schedule
         <Grip width="w-4" className="h-4 shrink-0" />
       </div>
     ),
-    width: "w-[5%] phone:w-auto",
+    width: "w-[5%] phone:w-8",
   },
   [scheduleCols.name]: {
     component: (schedule) => (
@@ -40,7 +40,7 @@ const createScheduleColConfig = (): ColConfig<ScheduleListItem, string, Schedule
   },
   [scheduleCols.action]: {
     component: (schedule) => <span>{scheduleActionLabels[schedule.action]}</span>,
-    width: "w-[14%] phone:w-auto",
+    width: "w-[14%] phone:hidden",
   },
   [scheduleCols.status]: {
     component: (schedule) => (
@@ -49,11 +49,11 @@ const createScheduleColConfig = (): ColConfig<ScheduleListItem, string, Schedule
         <span>{scheduleStatusLabels[schedule.status]}</span>
       </div>
     ),
-    width: "w-[12%] phone:w-auto",
+    width: "w-[12%] phone:hidden",
   },
   [scheduleCols.createdBy]: {
     component: (schedule) => <span>{schedule.createdBy}</span>,
-    width: "w-[14%] phone:w-auto",
+    width: "w-[14%] phone:hidden",
   },
 });
 

--- a/server/sdk/v1/python/proto_fleet_sdk/generated/pb/driver_pb2_grpc.py
+++ b/server/sdk/v1/python/proto_fleet_sdk/generated/pb/driver_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from proto_fleet_sdk.generated.pb import driver_pb2 as pb_dot_driver__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/server/sdk/v1/python/proto_fleet_sdk/generated/pb/driver_pb2_grpc.py
+++ b/server/sdk/v1/python/proto_fleet_sdk/generated/pb/driver_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from proto_fleet_sdk.generated.pb import driver_pb2 as pb_dot_driver__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.76.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 


### PR DESCRIPTION
## Summary
- Keep the schedules row drag handle and action menu visible on phone layouts
- Prioritize the Name and Schedule columns on mobile, truncating their content instead of requiring horizontal scrolling
- Refresh generated Python SDK stubs so generated-code CI matches the repo toolchain

## Test plan
- [ ] Open Settings > Schedules on a phone-width viewport
- [ ] Confirm the drag handle and ellipsis action menu are visible at opposite edges of each row
- [ ] Confirm Name and Schedule remain visible and truncate cleanly without horizontal scrolling
- [ ] Confirm the desktop schedules table still shows the full column set