### PR TITLE
Add ProtoOS logs E2E coverage

### DIFF
--- a/client/e2eTests/protoOS/pages/logs.ts
+++ b/client/e2eTests/protoOS/pages/logs.ts
@@ -1,3 +1,75 @@
+import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
-export class LogsPage extends BasePage {}
+export class LogsPage extends BasePage {
+  async validateLogsPageOpened() {
+    await expect(this.page).toHaveURL(/.*\/logs/);
+    await expect(this.page.getByLabel("Search")).toBeVisible();
+    await expect(this.page.getByRole("button", { name: "Export" })).toBeVisible();
+  }
+
+  async validateLogRowsVisible() {
+    await expect(this.page.getByTestId("log-row").first()).toBeVisible();
+  }
+
+  async getLogRowCount() {
+    return await this.page.getByTestId("log-row").count();
+  }
+
+  async getLogRowCountByType(logType: "error" | "warn") {
+    return await this.page.locator(`[data-testid="log-row"][data-log-type="${logType}"]`).count();
+  }
+
+  async searchLogs(query: string) {
+    const searchInput = this.page.getByLabel("Search");
+    await searchInput.fill(query);
+  }
+
+  async clearSearch() {
+    const searchInput = this.page.getByLabel("Search");
+    await searchInput.focus();
+    await searchInput.press("Escape");
+    await expect(searchInput).toHaveValue("");
+  }
+
+  async clickErrorFilter() {
+    await this.page.getByTestId("logs-error-filter").click();
+  }
+
+  async clickWarningFilter() {
+    await this.page.getByTestId("logs-warning-filter").click();
+  }
+
+  async validateOnlyLogTypeVisible(logType: "error" | "warn") {
+    const rows = this.page.getByTestId("log-row");
+    const count = await rows.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      await expect(rows.nth(i)).toHaveAttribute("data-log-type", logType);
+    }
+  }
+
+  async validateNoResultsState(message: string) {
+    await expect(this.page.getByTestId("logs-empty-state")).toBeVisible();
+    await expect(this.page.getByTestId("logs-empty-state")).toHaveText(message);
+  }
+
+  async getSearchableSubstringFromFirstRow() {
+    const firstRowText = (await this.page.getByTestId("log-row").first().textContent()) ?? "";
+    const normalizedText = firstRowText
+      .replace(/^\s*\d+\s*/, "")
+      .replace(/^\[\d{2}:\d{2}:\d{2}\]\s*/, "")
+      .trim();
+
+    const match = normalizedText.match(/[A-Za-z0-9][A-Za-z0-9 .:_/-]{4,}/);
+    const query = match?.[0]?.trim().slice(0, 12) ?? normalizedText.slice(0, 12).trim();
+
+    expect(query, "Expected a searchable log substring from the first row").not.toBe("");
+    return query;
+  }
+
+  async waitForLogsListToBeReady() {
+    await expect(this.page.getByTestId("log-row").first()).toBeVisible();
+  }
+}

--- a/client/e2eTests/protoOS/pages/logs.ts
+++ b/client/e2eTests/protoOS/pages/logs.ts
@@ -33,11 +33,11 @@ export class LogsPage extends BasePage {
   }
 
   async clickErrorFilter() {
-    await this.page.getByTestId("logs-error-filter").click();
+    await this.page.getByTestId("logs-error-badge").click();
   }
 
   async clickWarningFilter() {
-    await this.page.getByTestId("logs-warning-filter").click();
+    await this.page.getByTestId("logs-warning-badge").click();
   }
 
   async validateOnlyLogTypeVisible(logType: "error" | "warn") {

--- a/client/e2eTests/protoOS/spec/logs.spec.ts
+++ b/client/e2eTests/protoOS/spec/logs.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "../fixtures/pageFixtures";
+
+test.describe("Logs", () => {
+  test.beforeEach(async ({ page, commonSteps }) => {
+    await page.goto("/");
+    await commonSteps.authenticateAsAdmin();
+  });
+
+  test("Search and log-type filters work", async ({ commonSteps, logsPage }) => {
+    let initialRowCount = 0;
+    let initialErrorCount = 0;
+    let initialWarningCount = 0;
+    let searchableQuery = "";
+    const noMatchQuery = `no-match-${Date.now()}`;
+
+    await test.step("Open Logs and validate the page shell", async () => {
+      await commonSteps.navigateToLogs();
+      await logsPage.validateLogsPageOpened();
+      await logsPage.waitForLogsListToBeReady();
+      await logsPage.validateLogRowsVisible();
+      initialRowCount = await logsPage.getLogRowCount();
+      initialErrorCount = await logsPage.getLogRowCountByType("error");
+      initialWarningCount = await logsPage.getLogRowCountByType("warn");
+      searchableQuery = await logsPage.getSearchableSubstringFromFirstRow();
+
+      expect(initialRowCount).toBeGreaterThan(0);
+    });
+
+    await test.step("Filter by errors", async () => {
+      await logsPage.clickErrorFilter();
+
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      if (initialErrorCount > 0) {
+        await logsPage.validateOnlyLogTypeVisible("error");
+      } else {
+        await logsPage.validateNoResultsState("No errors found");
+      }
+
+      await logsPage.clickErrorFilter();
+      await logsPage.validateLogRowsVisible();
+    });
+
+    await test.step("Filter by warnings", async () => {
+      await logsPage.clickWarningFilter();
+
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      if (initialWarningCount > 0) {
+        await logsPage.validateOnlyLogTypeVisible("warn");
+      } else {
+        await logsPage.validateNoResultsState("No warnings found");
+      }
+
+      await logsPage.clickWarningFilter();
+      await logsPage.validateLogRowsVisible();
+    });
+
+    await test.step("Search matching logs", async () => {
+      await logsPage.searchLogs(searchableQuery);
+      await logsPage.validateLogRowsVisible();
+      expect(await logsPage.getLogRowCount()).toBeGreaterThan(0);
+    });
+
+    await test.step("Search with no matches and validate filtered empty state", async () => {
+      await logsPage.searchLogs(noMatchQuery);
+      await logsPage.validateNoResultsState(`No results match “${noMatchQuery}”`);
+    });
+
+    await test.step("Combine search and error filter empty state", async () => {
+      await logsPage.clickErrorFilter();
+      await logsPage.validateNoResultsState(`No errors match “${noMatchQuery}”`);
+      await logsPage.clickErrorFilter();
+    });
+
+    await test.step("Clear search and restore logs", async () => {
+      await logsPage.clearSearch();
+      await logsPage.validateLogRowsVisible();
+      expect(await logsPage.getLogRowCount()).toBeGreaterThanOrEqual(initialRowCount);
+    });
+  });
+
+  test("Export logs starts a download", async ({ commonSteps, logsPage, page }) => {
+    await commonSteps.navigateToLogs();
+    await logsPage.validateLogsPageOpened();
+    await logsPage.waitForLogsListToBeReady();
+
+    const downloadPromise = page.waitForEvent("download");
+
+    await test.step("Start a logs export", async () => {
+      await page.getByRole("button", { name: "Export" }).click();
+    });
+
+    await test.step("Validate the download starts", async () => {
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toMatch(/miner-logs.*\.csv$/i);
+    });
+  });
+});

--- a/client/src/protoOS/pages/MinerLogs/LogBadges.tsx
+++ b/client/src/protoOS/pages/MinerLogs/LogBadges.tsx
@@ -9,13 +9,15 @@ interface LogBadgesProps {
   label: string;
   onClick: (e: MouseEvent<HTMLDivElement>) => void;
   selected: boolean;
+  testId?: string;
 }
 
-const LogBadges = ({ className, count, label, onClick, selected }: LogBadgesProps) => {
+const LogBadges = ({ className, count, label, onClick, selected, testId }: LogBadgesProps) => {
   return (
     <div
       className={clsx("cursor-pointer rounded-lg border text-emphasis-300 whitespace-nowrap", className)}
       onClick={onClick}
+      data-testid={testId}
     >
       <div className="flex items-center px-2 py-[1px]">
         {count} {label}

--- a/client/src/protoOS/pages/MinerLogs/Logs.tsx
+++ b/client/src/protoOS/pages/MinerLogs/Logs.tsx
@@ -207,36 +207,40 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
                 />
               </div>
               <div className="flex items-center space-x-4">
-                <LogBadges
-                  label={errorCount === 1 ? "error" : "errors"}
-                  count={errorCount}
-                  className={clsx(
-                    "text-text-critical",
-                    {
-                      "border-transparent bg-intent-critical-10": filterByLogType?.includes(logTypes.error),
-                    },
-                    {
-                      "border-intent-critical-10": !filterByLogType?.includes(logTypes.error),
-                    },
-                  )}
-                  selected={filterByLogType?.includes(logTypes.error) || false}
-                  onClick={createToggleFilter(logTypes.error)}
-                />
-                <LogBadges
-                  label={warningCount === 1 ? "warning" : "warnings"}
-                  count={warningCount}
-                  className={clsx(
-                    "text-text-warning",
-                    {
-                      "border-transparent bg-intent-warning-10": filterByLogType?.includes(logTypes.warn),
-                    },
-                    {
-                      "border-intent-warning-10": !filterByLogType?.includes(logTypes.warn),
-                    },
-                  )}
-                  selected={filterByLogType?.includes(logTypes.warn) || false}
-                  onClick={createToggleFilter(logTypes.warn)}
-                />
+                <div data-testid="logs-error-filter">
+                  <LogBadges
+                    label={errorCount === 1 ? "error" : "errors"}
+                    count={errorCount}
+                    className={clsx(
+                      "text-text-critical",
+                      {
+                        "border-transparent bg-intent-critical-10": filterByLogType?.includes(logTypes.error),
+                      },
+                      {
+                        "border-intent-critical-10": !filterByLogType?.includes(logTypes.error),
+                      },
+                    )}
+                    selected={filterByLogType?.includes(logTypes.error) || false}
+                    onClick={createToggleFilter(logTypes.error)}
+                  />
+                </div>
+                <div data-testid="logs-warning-filter">
+                  <LogBadges
+                    label={warningCount === 1 ? "warning" : "warnings"}
+                    count={warningCount}
+                    className={clsx(
+                      "text-text-warning",
+                      {
+                        "border-transparent bg-intent-warning-10": filterByLogType?.includes(logTypes.warn),
+                      },
+                      {
+                        "border-intent-warning-10": !filterByLogType?.includes(logTypes.warn),
+                      },
+                    )}
+                    selected={filterByLogType?.includes(logTypes.warn) || false}
+                    onClick={createToggleFilter(logTypes.warn)}
+                  />
+                </div>
                 <Button
                   size={sizes.compact}
                   variant={variants.secondary}
@@ -268,6 +272,8 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
                   return (
                     <div
                       key={line}
+                      data-testid="log-row"
+                      data-log-type={log.logType}
                       className={clsx("mb-1 flex leading-6", {
                         "ml-[2px] text-text-primary-70": !isError && !isWarning && !isDebug,
                         "-ml-[16px] border-l-[2px] pl-4": isError || isWarning || isDebug,
@@ -285,7 +291,10 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
                   );
                 })
               ) : (
-                <div className="flex h-[189px] w-full items-center justify-center rounded-2xl bg-core-primary-5">
+                <div
+                  data-testid="logs-empty-state"
+                  className="flex h-[189px] w-full items-center justify-center rounded-2xl bg-core-primary-5"
+                >
                   <div className="font-body text-heading-100 text-text-primary-50">{noResultsMessage}</div>
                 </div>
               )}

--- a/client/src/protoOS/pages/MinerLogs/Logs.tsx
+++ b/client/src/protoOS/pages/MinerLogs/Logs.tsx
@@ -267,11 +267,12 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
                   const isDebug = log.logType === logTypes.debug;
                   const isError = log.logType === logTypes.error;
                   const isWarning = log.logType === logTypes.warn;
+                  const normalizedLogType = isError ? "error" : isWarning ? "warn" : isDebug ? "debug" : "info";
                   return (
                     <div
                       key={line}
                       data-testid="log-row"
-                      data-log-type={log.logType}
+                      data-log-type={normalizedLogType}
                       className={clsx("mb-1 flex leading-6", {
                         "ml-[2px] text-text-primary-70": !isError && !isWarning && !isDebug,
                         "-ml-[16px] border-l-[2px] pl-4": isError || isWarning || isDebug,

--- a/client/src/protoOS/pages/MinerLogs/Logs.tsx
+++ b/client/src/protoOS/pages/MinerLogs/Logs.tsx
@@ -207,40 +207,38 @@ const Logs = ({ logsData, fetchMaxLogs }: LogsProps) => {
                 />
               </div>
               <div className="flex items-center space-x-4">
-                <div data-testid="logs-error-filter">
-                  <LogBadges
-                    label={errorCount === 1 ? "error" : "errors"}
-                    count={errorCount}
-                    className={clsx(
-                      "text-text-critical",
-                      {
-                        "border-transparent bg-intent-critical-10": filterByLogType?.includes(logTypes.error),
-                      },
-                      {
-                        "border-intent-critical-10": !filterByLogType?.includes(logTypes.error),
-                      },
-                    )}
-                    selected={filterByLogType?.includes(logTypes.error) || false}
-                    onClick={createToggleFilter(logTypes.error)}
-                  />
-                </div>
-                <div data-testid="logs-warning-filter">
-                  <LogBadges
-                    label={warningCount === 1 ? "warning" : "warnings"}
-                    count={warningCount}
-                    className={clsx(
-                      "text-text-warning",
-                      {
-                        "border-transparent bg-intent-warning-10": filterByLogType?.includes(logTypes.warn),
-                      },
-                      {
-                        "border-intent-warning-10": !filterByLogType?.includes(logTypes.warn),
-                      },
-                    )}
-                    selected={filterByLogType?.includes(logTypes.warn) || false}
-                    onClick={createToggleFilter(logTypes.warn)}
-                  />
-                </div>
+                <LogBadges
+                  label={errorCount === 1 ? "error" : "errors"}
+                  count={errorCount}
+                  testId="logs-error-badge"
+                  className={clsx(
+                    "text-text-critical",
+                    {
+                      "border-transparent bg-intent-critical-10": filterByLogType?.includes(logTypes.error),
+                    },
+                    {
+                      "border-intent-critical-10": !filterByLogType?.includes(logTypes.error),
+                    },
+                  )}
+                  selected={filterByLogType?.includes(logTypes.error) || false}
+                  onClick={createToggleFilter(logTypes.error)}
+                />
+                <LogBadges
+                  label={warningCount === 1 ? "warning" : "warnings"}
+                  count={warningCount}
+                  testId="logs-warning-badge"
+                  className={clsx(
+                    "text-text-warning",
+                    {
+                      "border-transparent bg-intent-warning-10": filterByLogType?.includes(logTypes.warn),
+                    },
+                    {
+                      "border-intent-warning-10": !filterByLogType?.includes(logTypes.warn),
+                    },
+                  )}
+                  selected={filterByLogType?.includes(logTypes.warn) || false}
+                  onClick={createToggleFilter(logTypes.warn)}
+                />
                 <Button
                   size={sizes.compact}
                   variant={variants.secondary}


### PR DESCRIPTION
## What changed
- add ProtoOS Logs E2E coverage for search, error/warning filters, no-results handling, and export downloads
- add a small ProtoOS Logs page object to keep the spec declarative
- add stable Logs test hooks for rows, empty state, and filter controls

## Why
- ProtoOS Logs previously had no page-specific E2E coverage beyond being a navigation waypoint in sleep/wake tests
- these scenarios are deterministic and simulator-friendly, which makes them a good first CI slice for ProtoOS Logs

## Validation
- npx eslint e2eTests/protoOS/pages/logs.ts e2eTests/protoOS/spec/logs.spec.ts src/protoOS/pages/MinerLogs/Logs.tsx
- npx playwright test spec/00-onboarding.spec.ts --project=desktop --grep "Complete onboarding flow" --no-deps
- npx playwright test spec/logs.spec.ts --project=desktop --no-deps
- npx playwright test spec/logs.spec.ts --project=mobile --no-deps