### PR TITLE
Add ProtoOS general settings E2E coverage

### DIFF
--- a/client/e2eTests/protoOS/pages/base.ts
+++ b/client/e2eTests/protoOS/pages/base.ts
@@ -14,19 +14,24 @@ export class BasePage {
     await expect(this.page.getByTestId("power-button")).toBeVisible();
   }
 
+  private getPageTitleLocator(expectedTitle: string) {
+    return this.page.locator('[class*="text-heading"]').getByText(expectedTitle, { exact: true });
+  }
+
+  private getModalTitleLocator(expectedTitle: string) {
+    return this.page.getByTestId("modal").locator('[class*="text-heading"]').getByText(expectedTitle, { exact: true });
+  }
+
   async validateTitle(expectedTitle: string) {
-    const titleLocator = this.page.getByText(expectedTitle, { exact: true });
-    await expect(titleLocator).toBeVisible();
+    await expect(this.getPageTitleLocator(expectedTitle)).toBeVisible();
   }
 
   async validateTitleInModal(expectedTitle: string) {
-    const titleLocator = this.page.getByTestId("modal").getByText(expectedTitle, { exact: true });
-    await expect(titleLocator).toBeVisible();
+    await expect(this.getModalTitleLocator(expectedTitle)).toBeVisible();
   }
 
   async validateTitleNotVisible(expectedTitle: string) {
-    const titleLocator = this.page.getByText(expectedTitle, { exact: true });
-    await expect(titleLocator).toBeHidden();
+    await expect(this.getPageTitleLocator(expectedTitle)).toBeHidden();
   }
 
   async validateTextIsVisible(text: string) {

--- a/client/e2eTests/protoOS/pages/base.ts
+++ b/client/e2eTests/protoOS/pages/base.ts
@@ -15,19 +15,17 @@ export class BasePage {
   }
 
   async validateTitle(expectedTitle: string) {
-    const titleLocator = this.page.locator(`//*[contains(@class,'heading')][text()="${expectedTitle}"]`);
+    const titleLocator = this.page.getByText(expectedTitle, { exact: true });
     await expect(titleLocator).toBeVisible();
   }
 
   async validateTitleInModal(expectedTitle: string) {
-    const titleLocator = this.page.locator(
-      `//*[@data-testid='modal']//*[contains(@class,'heading')][text()="${expectedTitle}"]`,
-    );
+    const titleLocator = this.page.getByTestId("modal").getByText(expectedTitle, { exact: true });
     await expect(titleLocator).toBeVisible();
   }
 
   async validateTitleNotVisible(expectedTitle: string) {
-    const titleLocator = this.page.locator(`//*[contains(@class,'heading')][text()="${expectedTitle}"]`);
+    const titleLocator = this.page.getByText(expectedTitle, { exact: true });
     await expect(titleLocator).toBeHidden();
   }
 

--- a/client/e2eTests/protoOS/pages/general.ts
+++ b/client/e2eTests/protoOS/pages/general.ts
@@ -3,19 +3,46 @@ import { BasePage } from "./base";
 
 type ThemeLabel = "System" | "Light" | "Dark";
 type ThemeColor = "light" | "dark";
-type MinerIdState = "missing" | "existing";
+
+type ProtoOsApi = {
+  getSystemTag: () => Promise<{ data: unknown }>;
+  deleteSystemTag: () => Promise<void>;
+};
 
 export class GeneralPage extends BasePage {
-  private async getMinerIdState(): Promise<MinerIdState> {
-    const editButton = this.page.getByTestId("edit-details-button");
+  private async getSystemTagFromApi(): Promise<string | null> {
+    return this.page.evaluate(async () => {
+      const protoOsWindow = window as Window & { api?: ProtoOsApi };
+      if (!protoOsWindow.api) {
+        throw new Error("ProtoOS API is not available on window");
+      }
 
-    try {
-      await editButton.waitFor({ state: "visible", timeout: 3000 });
-      return "existing";
-    } catch {
-      await this.page.getByTestId("add-miner-id").waitFor({ state: "visible" });
-      return "missing";
-    }
+      try {
+        const response = await protoOsWindow.api.getSystemTag();
+        if (typeof response.data === "string") {
+          return response.data.trim() || null;
+        }
+
+        return JSON.stringify(response.data);
+      } catch (error: unknown) {
+        if ((error as { status?: number })?.status === 404) {
+          return null;
+        }
+
+        throw error;
+      }
+    });
+  }
+
+  private async deleteSystemTagViaApi() {
+    await this.page.evaluate(async () => {
+      const protoOsWindow = window as Window & { api?: ProtoOsApi };
+      if (!protoOsWindow.api) {
+        throw new Error("ProtoOS API is not available on window");
+      }
+
+      await protoOsWindow.api.deleteSystemTag();
+    });
   }
 
   async clickThemeButton() {
@@ -43,7 +70,7 @@ export class GeneralPage extends BasePage {
   }
 
   async getSelectedTheme(): Promise<ThemeLabel> {
-    const theme = await this.page.getByTestId("theme-button").innerText();
+    const theme = (await this.page.getByTestId("theme-button").innerText()).trim();
 
     if (theme === "System" || theme === "Light" || theme === "Dark") {
       return theme;
@@ -73,19 +100,17 @@ export class GeneralPage extends BasePage {
   }
 
   async getMinerId(): Promise<string | null> {
-    if ((await this.getMinerIdState()) === "missing") {
-      return null;
-    }
-
-    return (await this.page.getByTestId("miner-id-value").innerText()).trim();
+    return this.getSystemTagFromApi();
   }
 
   async openMinerIdEditor() {
-    if ((await this.getMinerIdState()) === "existing") {
+    if (await this.getSystemTagFromApi()) {
+      await this.page.getByTestId("edit-details-button").waitFor({ state: "visible" });
       await this.page.getByTestId("edit-details-button").click();
       return;
     }
 
+    await this.page.getByTestId("add-miner-id").waitFor({ state: "visible" });
     await this.page.getByTestId("add-miner-id").click();
   }
 
@@ -111,15 +136,18 @@ export class GeneralPage extends BasePage {
   }
 
   async restoreMinerIdIfNeeded(originalMinerId: string | null) {
-    if (!originalMinerId) {
+    if (originalMinerId) {
+      await this.openMinerIdEditor();
+      await this.validateMinerIdModalOpened();
+      await this.inputMinerId(originalMinerId);
+      await this.saveMinerId();
+      await this.validateMinerIdSavedToast();
+      await this.validateMinerId(originalMinerId);
       return;
     }
 
-    await this.openMinerIdEditor();
-    await this.validateMinerIdModalOpened();
-    await this.inputMinerId(originalMinerId);
-    await this.saveMinerId();
-    await this.validateMinerIdSavedToast();
-    await this.validateMinerId(originalMinerId);
+    await this.deleteSystemTagViaApi();
+    await this.reloadPage();
+    await this.page.getByTestId("add-miner-id").waitFor({ state: "visible" });
   }
 }

--- a/client/e2eTests/protoOS/pages/general.ts
+++ b/client/e2eTests/protoOS/pages/general.ts
@@ -3,8 +3,21 @@ import { BasePage } from "./base";
 
 type ThemeLabel = "System" | "Light" | "Dark";
 type ThemeColor = "light" | "dark";
+type MinerIdState = "missing" | "existing";
 
 export class GeneralPage extends BasePage {
+  private async getMinerIdState(): Promise<MinerIdState> {
+    const editButton = this.page.getByTestId("edit-details-button");
+
+    try {
+      await editButton.waitFor({ state: "visible", timeout: 3000 });
+      return "existing";
+    } catch {
+      await this.page.getByTestId("add-miner-id").waitFor({ state: "visible" });
+      return "missing";
+    }
+  }
+
   async clickThemeButton() {
     await this.page.getByTestId("theme-button").click();
   }
@@ -60,8 +73,7 @@ export class GeneralPage extends BasePage {
   }
 
   async getMinerId(): Promise<string | null> {
-    const addButton = this.page.getByTestId("add-miner-id");
-    if (await addButton.isVisible()) {
+    if ((await this.getMinerIdState()) === "missing") {
       return null;
     }
 
@@ -69,12 +81,12 @@ export class GeneralPage extends BasePage {
   }
 
   async openMinerIdEditor() {
-    const addButton = this.page.getByTestId("add-miner-id");
-    if (await addButton.isVisible()) {
-      await addButton.click();
-    } else {
+    if ((await this.getMinerIdState()) === "existing") {
       await this.page.getByTestId("edit-details-button").click();
+      return;
     }
+
+    await this.page.getByTestId("add-miner-id").click();
   }
 
   async validateMinerIdModalOpened() {

--- a/client/e2eTests/protoOS/pages/general.ts
+++ b/client/e2eTests/protoOS/pages/general.ts
@@ -1,9 +1,20 @@
 import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
+type ThemeLabel = "System" | "Light" | "Dark";
+type ThemeColor = "light" | "dark";
+
 export class GeneralPage extends BasePage {
+  async clickThemeButton() {
+    await this.page.getByTestId("theme-button").click();
+  }
+
   async clickTemperatureButton() {
     await this.page.locator('[data-testid="temperature-button"]').click();
+  }
+
+  async selectTheme(theme: ThemeLabel) {
+    await this.page.getByTestId(`theme-${theme.toLowerCase()}-option`).click();
   }
 
   async selectFahrenheit() {
@@ -18,6 +29,24 @@ export class GeneralPage extends BasePage {
     await this.clickButton("Done");
   }
 
+  async getSelectedTheme(): Promise<ThemeLabel> {
+    const theme = await this.page.getByTestId("theme-button").innerText();
+
+    if (theme === "System" || theme === "Light" || theme === "Dark") {
+      return theme;
+    }
+
+    throw new Error(`Unexpected theme value: ${theme}`);
+  }
+
+  async validateSelectedTheme(theme: ThemeLabel) {
+    await expect(this.page.getByTestId("theme-button")).toHaveText(theme);
+  }
+
+  async validateBodyTheme(theme: ThemeColor) {
+    await expect(this.page.locator("body")).toHaveAttribute("data-theme", theme);
+  }
+
   private async validateTemperatureFormat(format: string) {
     await expect(this.page.locator('[data-testid="temperature-button"]')).toHaveText(format);
   }
@@ -28,5 +57,57 @@ export class GeneralPage extends BasePage {
 
   async validateTemperatureFormatCelsius() {
     await this.validateTemperatureFormat("Celsius");
+  }
+
+  async getMinerId(): Promise<string | null> {
+    const addButton = this.page.getByTestId("add-miner-id");
+    if (await addButton.isVisible()) {
+      return null;
+    }
+
+    return (await this.page.getByTestId("miner-id-value").innerText()).trim();
+  }
+
+  async openMinerIdEditor() {
+    const addButton = this.page.getByTestId("add-miner-id");
+    if (await addButton.isVisible()) {
+      await addButton.click();
+    } else {
+      await this.page.getByTestId("edit-details-button").click();
+    }
+  }
+
+  async validateMinerIdModalOpened() {
+    await this.validateModalIsOpen();
+    await this.validateTitleInModal("Proto Rig identification");
+  }
+
+  async inputMinerId(value: string) {
+    await this.page.getByTestId("miner-id-input").fill(value);
+  }
+
+  async saveMinerId() {
+    await this.page.getByTestId("modal").getByRole("button", { name: "Save" }).click();
+  }
+
+  async validateMinerIdSavedToast() {
+    await expect(this.page.getByTestId("toast").getByText("Miner ID saved").last()).toBeVisible();
+  }
+
+  async validateMinerId(value: string) {
+    await expect(this.page.getByTestId("miner-id-value")).toHaveText(value);
+  }
+
+  async restoreMinerIdIfNeeded(originalMinerId: string | null) {
+    if (!originalMinerId) {
+      return;
+    }
+
+    await this.openMinerIdEditor();
+    await this.validateMinerIdModalOpened();
+    await this.inputMinerId(originalMinerId);
+    await this.saveMinerId();
+    await this.validateMinerIdSavedToast();
+    await this.validateMinerId(originalMinerId);
   }
 }

--- a/client/e2eTests/protoOS/spec/general.spec.ts
+++ b/client/e2eTests/protoOS/spec/general.spec.ts
@@ -10,9 +10,20 @@ function getThemeColor(theme: "Light" | "Dark") {
 }
 
 test.describe("General settings", () => {
+  let originalMinerId: string | null | undefined;
+
   test.beforeEach(async ({ page, commonSteps }) => {
+    originalMinerId = undefined;
     await page.goto("/");
     await commonSteps.authenticateAsAdmin();
+  });
+
+  test.afterEach(async ({ generalPage }) => {
+    if (originalMinerId === undefined) {
+      return;
+    }
+
+    await generalPage.restoreMinerIdIfNeeded(originalMinerId);
   });
 
   test("Theme preference persists after reload", async ({ generalPage, commonSteps }) => {
@@ -47,7 +58,7 @@ test.describe("General settings", () => {
     const nextMinerId = generateRandomText("miner-id");
     await commonSteps.navigateToGeneralSettings();
 
-    const originalMinerId = await generalPage.getMinerId();
+    originalMinerId = await generalPage.getMinerId();
 
     await test.step("Save a new Miner ID", async () => {
       await generalPage.openMinerIdEditor();
@@ -56,10 +67,6 @@ test.describe("General settings", () => {
       await generalPage.saveMinerId();
       await generalPage.validateMinerIdSavedToast();
       await generalPage.validateMinerId(nextMinerId);
-    });
-
-    await test.step("Restore the original Miner ID when one already existed", async () => {
-      await generalPage.restoreMinerIdIfNeeded(originalMinerId);
     });
   });
 });

--- a/client/e2eTests/protoOS/spec/general.spec.ts
+++ b/client/e2eTests/protoOS/spec/general.spec.ts
@@ -1,0 +1,65 @@
+import { test } from "../fixtures/pageFixtures";
+import { generateRandomText } from "../helpers/testDataHelper";
+
+function getThemeSwitchTarget(currentTheme: "System" | "Light" | "Dark") {
+  return currentTheme === "Dark" ? "Light" : "Dark";
+}
+
+function getThemeColor(theme: "Light" | "Dark") {
+  return theme === "Dark" ? "dark" : "light";
+}
+
+test.describe("General settings", () => {
+  test.beforeEach(async ({ page, commonSteps }) => {
+    await page.goto("/");
+    await commonSteps.authenticateAsAdmin();
+  });
+
+  test("Theme preference persists after reload", async ({ generalPage, commonSteps }) => {
+    await commonSteps.navigateToGeneralSettings();
+
+    const originalTheme = await generalPage.getSelectedTheme();
+    const nextTheme = getThemeSwitchTarget(originalTheme);
+
+    await test.step("Switch to a different explicit theme", async () => {
+      await generalPage.clickThemeButton();
+      await generalPage.selectTheme(nextTheme);
+      await generalPage.clickDoneButton();
+      await generalPage.validateSelectedTheme(nextTheme);
+      await generalPage.validateBodyTheme(getThemeColor(nextTheme));
+    });
+
+    await test.step("Reload and validate the theme persists", async () => {
+      await generalPage.reloadPage();
+      await generalPage.validateSelectedTheme(nextTheme);
+      await generalPage.validateBodyTheme(getThemeColor(nextTheme));
+    });
+
+    await test.step("Restore the original theme preference", async () => {
+      await generalPage.clickThemeButton();
+      await generalPage.selectTheme(originalTheme);
+      await generalPage.clickDoneButton();
+      await generalPage.validateSelectedTheme(originalTheme);
+    });
+  });
+
+  test("Miner ID can be added or edited", async ({ generalPage, commonSteps }) => {
+    const nextMinerId = generateRandomText("miner-id");
+    await commonSteps.navigateToGeneralSettings();
+
+    const originalMinerId = await generalPage.getMinerId();
+
+    await test.step("Save a new Miner ID", async () => {
+      await generalPage.openMinerIdEditor();
+      await generalPage.validateMinerIdModalOpened();
+      await generalPage.inputMinerId(nextMinerId);
+      await generalPage.saveMinerId();
+      await generalPage.validateMinerIdSavedToast();
+      await generalPage.validateMinerId(nextMinerId);
+    });
+
+    await test.step("Restore the original Miner ID when one already existed", async () => {
+      await generalPage.restoreMinerIdIfNeeded(originalMinerId);
+    });
+  });
+});

--- a/client/src/protoOS/features/settings/components/General/General.tsx
+++ b/client/src/protoOS/features/settings/components/General/General.tsx
@@ -113,7 +113,9 @@ const General = () => {
         <Row className="flex justify-between">
           <h4 className="text-emphasis-300">Miner ID</h4>
           {hasTag ? (
-            <div className="text-300">{minerTag}</div>
+            <div className="text-300" data-testid="miner-id-value">
+              {minerTag}
+            </div>
           ) : (
             <Button
               text="Add"
@@ -145,6 +147,7 @@ const General = () => {
             onClick={() => setShowThemeSwitcher(true)}
             textColor="text-intent-warning-fill"
             text={convertToSentenceCase(theme)}
+            testId="theme-button"
           />
           {showThemeSwitcher ? (
             <ThemeSwitcher onClickDone={() => setShowThemeSwitcher(false)} theme={theme} setTheme={setTheme} />

--- a/client/src/shared/features/preferences/ThemeSwitcher.tsx
+++ b/client/src/shared/features/preferences/ThemeSwitcher.tsx
@@ -55,6 +55,7 @@ const ThemeSwitcher = ({ onClickDone, theme, setTheme }: ThemeSwitcherProps) => 
             </div>
           }
           type={selectTypes.radio}
+          data-testid="theme-system-option"
         />
         <SelectRow
           id={"light"}
@@ -71,6 +72,7 @@ const ThemeSwitcher = ({ onClickDone, theme, setTheme }: ThemeSwitcherProps) => 
             </div>
           }
           type={selectTypes.radio}
+          data-testid="theme-light-option"
         />
         <SelectRow
           id={"dark"}
@@ -87,6 +89,7 @@ const ThemeSwitcher = ({ onClickDone, theme, setTheme }: ThemeSwitcherProps) => 
             </div>
           }
           type={selectTypes.radio}
+          data-testid="theme-dark-option"
         />
       </div>
     </Modal>


### PR DESCRIPTION
## Summary
- add ProtoOS General Settings E2E coverage for theme persistence after reload
- add ProtoOS General Settings E2E coverage for Miner ID add/edit flow
- add stable test hooks for the ProtoOS General page and shared theme switcher

## Verification
- npx eslint e2eTests/protoOS/pages/general.ts e2eTests/protoOS/spec/general.spec.ts src/protoOS/features/settings/components/General/General.tsx src/shared/features/preferences/ThemeSwitcher.tsx
- npx playwright test spec/general.spec.ts --project=desktop --no-deps
- npx playwright test spec/general.spec.ts --project=mobile --no-deps