### PR TITLE
fix(server): plumb firmware + zone filters through GetMinerModelGroups (#126)

### DIFF
--- a/server/generated/sqlc/device.sql.go
+++ b/server/generated/sqlc/device.sql.go
@@ -1066,14 +1066,38 @@ WHERE dp.pairing_status = 'PAIRED'
   AND dd.model != ''
   AND ($2::text IS NULL OR dd.model = ANY(string_to_array($2, ',')))
   AND ($3::text IS NULL OR ds.status::text = ANY(string_to_array($3, ',')))
+  -- Firmware version filter (values list passes as a real PG array so values
+  -- can contain commas; the narg sentinel signals "filter applied").
+  AND (
+      $4::text IS NULL
+      OR dd.firmware_version = ANY($5::text[])
+  )
+  -- Zone filter (excludes soft-deleted racks). Uses array values for the same
+  -- comma-safety reason as firmware above.
+  AND (
+      $6::text IS NULL
+      OR EXISTS (
+          SELECT 1 FROM device_set_membership dsm
+          JOIN device_set ds_zone ON ds_zone.id = dsm.device_set_id AND ds_zone.deleted_at IS NULL
+          JOIN device_set_rack dsr ON dsr.device_set_id = dsm.device_set_id
+          WHERE dsm.device_id = d.id
+            AND dsm.org_id = $1
+            AND dsm.device_set_type = 'rack'
+            AND dsr.zone = ANY($7::text[])
+      )
+  )
 GROUP BY dd.model, dd.manufacturer
 ORDER BY dd.manufacturer, dd.model
 `
 
 type GetMinerModelGroupsParams struct {
-	OrgID        int64
-	ModelFilter  sql.NullString
-	StatusFilter sql.NullString
+	OrgID          int64
+	ModelFilter    sql.NullString
+	StatusFilter   sql.NullString
+	FirmwareFilter sql.NullString
+	FirmwareValues []string
+	ZoneFilter     sql.NullString
+	ZoneValues     []string
 }
 
 type GetMinerModelGroupsRow struct {
@@ -1083,7 +1107,15 @@ type GetMinerModelGroupsRow struct {
 }
 
 func (q *Queries) GetMinerModelGroups(ctx context.Context, arg GetMinerModelGroupsParams) ([]GetMinerModelGroupsRow, error) {
-	rows, err := q.query(ctx, q.getMinerModelGroupsStmt, getMinerModelGroups, arg.OrgID, arg.ModelFilter, arg.StatusFilter)
+	rows, err := q.query(ctx, q.getMinerModelGroupsStmt, getMinerModelGroups,
+		arg.OrgID,
+		arg.ModelFilter,
+		arg.StatusFilter,
+		arg.FirmwareFilter,
+		pq.Array(arg.FirmwareValues),
+		arg.ZoneFilter,
+		pq.Array(arg.ZoneValues),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/generated/sqlc/device.sql.go
+++ b/server/generated/sqlc/device.sql.go
@@ -1061,6 +1061,11 @@ JOIN device_pairing dp ON d.id = dp.device_id
 LEFT JOIN device_status ds ON d.id = ds.device_id
 WHERE dp.pairing_status = 'PAIRED'
   AND d.deleted_at IS NULL
+  -- Match the list/count queries so the bulk-password modal invariant holds:
+  -- inactive or soft-deleted discovered_device rows are excluded from both
+  -- the filtered list total and the model-group counts.
+  AND dd.is_active = TRUE
+  AND dd.deleted_at IS NULL
   AND d.org_id = $1
   AND dd.model IS NOT NULL
   AND dd.model != ''

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -312,12 +312,12 @@ func (s *SQLDeviceStore) GetDeviceWithIPAssignment(ctx context.Context, deviceId
 }
 
 func (s *SQLDeviceStore) GetTotalPairedDevices(ctx context.Context, orgID int64, filter *stores.MinerFilter) (int64, error) {
-	statusFilter, modelFilter, _ := buildFilterParams(filter)
+	fp := buildFilterParams(filter)
 
 	return s.GetQueries(ctx).GetTotalPairedDevices(ctx, sqlc.GetTotalPairedDevicesParams{
 		OrgID:        orgID,
-		StatusFilter: statusFilter,
-		ModelFilter:  modelFilter,
+		StatusFilter: fp.statusFilter,
+		ModelFilter:  fp.modelFilter,
 	})
 }
 
@@ -405,12 +405,16 @@ func (s *SQLDeviceStore) GetAvailableFirmwareVersions(ctx context.Context, orgID
 }
 
 func (s *SQLDeviceStore) GetMinerModelGroups(ctx context.Context, orgID int64, filter *stores.MinerFilter) ([]stores.MinerModelGroupResult, error) {
-	statusFilter, modelFilter, _ := buildFilterParams(filter)
+	fp := buildFilterParams(filter)
 
 	rows, err := s.getQueries(ctx).GetMinerModelGroups(ctx, sqlc.GetMinerModelGroupsParams{
-		OrgID:        orgID,
-		ModelFilter:  modelFilter,
-		StatusFilter: statusFilter,
+		OrgID:          orgID,
+		ModelFilter:    fp.modelFilter,
+		StatusFilter:   fp.statusFilter,
+		FirmwareFilter: fp.firmwareFilter,
+		FirmwareValues: fp.firmwareValues,
+		ZoneFilter:     fp.zoneFilter,
+		ZoneValues:     fp.zoneValues,
 	})
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("failed to get miner model groups: %v", err)
@@ -427,24 +431,55 @@ func (s *SQLDeviceStore) GetMinerModelGroups(ctx context.Context, orgID int64, f
 	return results, nil
 }
 
-func buildFilterParams(filter *stores.MinerFilter) (statusFilter, modelFilter, deviceIdentifiersFilter sql.NullString) {
-	if filter != nil && len(filter.DeviceStatusFilter) > 0 {
-		deviceFilter := make([]string, 0, len(filter.DeviceStatusFilter))
+// modelGroupFilterParams carries the parameters consumed by GetTotalPairedDevices
+// and GetMinerModelGroups. Status and model use the legacy CSV+string_to_array
+// pattern (their values are enum/UI-controlled and never contain commas);
+// firmware versions and zones pass as real PG arrays (sentinel + values) so
+// values like "Austin, Building 1" survive intact. The unset sentinel signals
+// "no filter applied".
+type modelGroupFilterParams struct {
+	statusFilter   sql.NullString
+	modelFilter    sql.NullString
+	firmwareFilter sql.NullString
+	firmwareValues []string
+	zoneFilter     sql.NullString
+	zoneValues     []string
+}
+
+// csvNullString joins values with commas. An empty input produces an unset
+// (NULL-valued) NullString so the SQL narg check treats the filter as absent.
+func csvNullString(values []string) sql.NullString {
+	if len(values) == 0 {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: strings.Join(values, ","), Valid: true}
+}
+
+func buildFilterParams(filter *stores.MinerFilter) modelGroupFilterParams {
+	var fp modelGroupFilterParams
+	if filter == nil {
+		return fp
+	}
+
+	if len(filter.DeviceStatusFilter) > 0 {
+		statuses := make([]string, 0, len(filter.DeviceStatusFilter))
 		for _, status := range filter.DeviceStatusFilter {
-			deviceFilter = append(deviceFilter, string(toDeviceStatus(status)))
+			statuses = append(statuses, string(toDeviceStatus(status)))
 		}
-		statusFilter = sql.NullString{String: strings.Join(deviceFilter, ","), Valid: true}
+		fp.statusFilter = csvNullString(statuses)
+	}
+	fp.modelFilter = csvNullString(filter.ModelNames)
+
+	if len(filter.FirmwareVersions) > 0 {
+		fp.firmwareFilter = sql.NullString{Valid: true}
+		fp.firmwareValues = filter.FirmwareVersions
+	}
+	if len(filter.Zones) > 0 {
+		fp.zoneFilter = sql.NullString{Valid: true}
+		fp.zoneValues = filter.Zones
 	}
 
-	if filter != nil && len(filter.ModelNames) > 0 {
-		modelFilter = sql.NullString{String: strings.Join(filter.ModelNames, ","), Valid: true}
-	}
-
-	if filter != nil && len(filter.DeviceIdentifiers) > 0 {
-		deviceIdentifiersFilter = sql.NullString{String: strings.Join(filter.DeviceIdentifiers, ","), Valid: true}
-	}
-
-	return statusFilter, modelFilter, deviceIdentifiersFilter
+	return fp
 }
 
 func (s *SQLDeviceStore) UpsertDeviceStatus(ctx context.Context, deviceIdentifier models.DeviceIdentifier, status minermodels.MinerStatus, details string) error {

--- a/server/internal/domain/stores/sqlstores/device_test.go
+++ b/server/internal/domain/stores/sqlstores/device_test.go
@@ -5,6 +5,9 @@ import (
 
 	fm "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
 	"github.com/block/proto-fleet/server/generated/sqlc"
+	minermodels "github.com/block/proto-fleet/server/internal/domain/miner/models"
+	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,4 +118,86 @@ func TestProtoPairingStatusToSQL(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestBuildFilterParams_NilFilter(t *testing.T) {
+	fp := buildFilterParams(nil)
+
+	assert.False(t, fp.statusFilter.Valid)
+	assert.False(t, fp.modelFilter.Valid)
+	assert.False(t, fp.firmwareFilter.Valid)
+	assert.False(t, fp.zoneFilter.Valid)
+}
+
+func TestBuildFilterParams_FirmwareOnly(t *testing.T) {
+	fp := buildFilterParams(&stores.MinerFilter{
+		FirmwareVersions: []string{"v3.5.1", "v3.5.2"},
+	})
+
+	assert.True(t, fp.firmwareFilter.Valid)
+	assert.Equal(t, []string{"v3.5.1", "v3.5.2"}, fp.firmwareValues)
+	assert.False(t, fp.zoneFilter.Valid)
+	assert.Nil(t, fp.zoneValues)
+}
+
+func TestBuildFilterParams_ZonesOnly(t *testing.T) {
+	fp := buildFilterParams(&stores.MinerFilter{
+		Zones: []string{"building-a", "building-b"},
+	})
+
+	assert.True(t, fp.zoneFilter.Valid)
+	assert.Equal(t, []string{"building-a", "building-b"}, fp.zoneValues)
+	assert.False(t, fp.firmwareFilter.Valid)
+	assert.Nil(t, fp.firmwareValues)
+}
+
+// Zones may contain commas (e.g. "Austin, Building 1"). The values must pass
+// through verbatim — no CSV splitting — so the SQL ANY($N::text[]) match works.
+func TestBuildFilterParams_ZoneWithCommaPassesThrough(t *testing.T) {
+	fp := buildFilterParams(&stores.MinerFilter{
+		Zones: []string{"Austin, Building 1", "Dallas"},
+	})
+
+	assert.True(t, fp.zoneFilter.Valid)
+	assert.Equal(t, []string{"Austin, Building 1", "Dallas"}, fp.zoneValues)
+}
+
+func TestBuildFilterParams_FirmwareAndZones(t *testing.T) {
+	fp := buildFilterParams(&stores.MinerFilter{
+		FirmwareVersions: []string{"v3.5.1"},
+		Zones:            []string{"building-a"},
+	})
+
+	assert.True(t, fp.firmwareFilter.Valid)
+	assert.Equal(t, []string{"v3.5.1"}, fp.firmwareValues)
+	assert.True(t, fp.zoneFilter.Valid)
+	assert.Equal(t, []string{"building-a"}, fp.zoneValues)
+}
+
+// Empty slices must leave the filter unset so the query treats them as
+// "no filter applied" rather than "match nothing".
+func TestBuildFilterParams_EmptySlicesUnset(t *testing.T) {
+	fp := buildFilterParams(&stores.MinerFilter{
+		FirmwareVersions: []string{},
+		Zones:            []string{},
+	})
+
+	assert.False(t, fp.firmwareFilter.Valid)
+	assert.Nil(t, fp.firmwareValues)
+	assert.False(t, fp.zoneFilter.Valid)
+	assert.Nil(t, fp.zoneValues)
+}
+
+func TestBuildFilterParams_AllFilters(t *testing.T) {
+	fp := buildFilterParams(&stores.MinerFilter{
+		DeviceStatusFilter: []minermodels.MinerStatus{minermodels.MinerStatusActive},
+		ModelNames:         []string{"S21 XP"},
+		FirmwareVersions:   []string{"v3.5.1"},
+		Zones:              []string{"zone-a"},
+	})
+
+	assert.True(t, fp.statusFilter.Valid)
+	assert.True(t, fp.modelFilter.Valid)
+	assert.True(t, fp.firmwareFilter.Valid)
+	assert.True(t, fp.zoneFilter.Valid)
 }

--- a/server/internal/domain/stores/sqlstores/get_miner_model_groups_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/get_miner_model_groups_integration_test.go
@@ -1,0 +1,265 @@
+package sqlstores_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	collectionpb "github.com/block/proto-fleet/server/generated/grpc/collection/v1"
+	pb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
+	"github.com/block/proto-fleet/server/generated/sqlc"
+	"github.com/block/proto-fleet/server/internal/domain/miner/models"
+	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	"github.com/block/proto-fleet/server/internal/testutil"
+)
+
+// pairDevice marks a device PAIRED so it shows up in GetMinerModelGroups,
+// which scopes to PAIRED rows only.
+func pairDevice(t *testing.T, ctx context.Context, store *sqlstores.SQLDeviceStore, orgID int64, deviceIdentifier string) {
+	t.Helper()
+	require.NoError(t, store.UpsertDevicePairing(
+		ctx,
+		&pb.Device{DeviceIdentifier: deviceIdentifier},
+		orgID,
+		string(sqlc.PairingStatusEnumPAIRED),
+	))
+}
+
+// setDiscoveredDeviceModel patches discovered_device.model directly because
+// CreateDevice hardcodes model="TestMiner" and exposes no override.
+func setDiscoveredDeviceModel(t *testing.T, db *sql.DB, deviceIdentifier, model string) {
+	t.Helper()
+	res, err := db.Exec(`
+		UPDATE discovered_device
+		SET model = $1
+		WHERE id = (SELECT discovered_device_id FROM device WHERE device_identifier = $2)
+	`, model, deviceIdentifier)
+	require.NoError(t, err)
+	rows, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+}
+
+// TestGetMinerModelGroups_FirmwareFilter proves the firmware filter narrows the
+// model-group counts so the bulk-password modal agrees with the filtered list.
+func TestGetMinerModelGroups_FirmwareFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	tc := testutil.InitializeDBServiceInfrastructure(t)
+	dbSvc := tc.DatabaseService
+	db := tc.ServiceProvider.DB
+	deviceStore := sqlstores.NewSQLDeviceStore(db)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+
+	d1 := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	d2 := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	d3 := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	for _, d := range []string{d1.ID, d2.ID, d3.ID} {
+		pairDevice(t, ctx, deviceStore, user.OrganizationID, d)
+	}
+
+	require.NoError(t, deviceStore.UpdateFirmwareVersion(ctx, models.DeviceIdentifier(d1.ID), "v3.5.1"))
+	require.NoError(t, deviceStore.UpdateFirmwareVersion(ctx, models.DeviceIdentifier(d2.ID), "v3.5.1"))
+	require.NoError(t, deviceStore.UpdateFirmwareVersion(ctx, models.DeviceIdentifier(d3.ID), "v3.5.2"))
+
+	// No filter: all three paired devices roll up into a single TestMiner group.
+	groups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, nil)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, int32(3), groups[0].Count)
+
+	// Firmware filter narrows to the matching subset.
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
+		FirmwareVersions: []string{"v3.5.1"},
+	})
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, int32(2), groups[0].Count, "firmware=v3.5.1 should narrow count to the two matching devices")
+
+	// Multi-value firmware filter unions the matches.
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
+		FirmwareVersions: []string{"v3.5.1", "v3.5.2"},
+	})
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, int32(3), groups[0].Count)
+
+	// No matches: filter returns no groups.
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
+		FirmwareVersions: []string{"v9.9.9"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, groups)
+}
+
+// TestGetMinerModelGroups_ZoneFilter proves the zone filter narrows the
+// model-group counts and excludes miners not in any rack.
+func TestGetMinerModelGroups_ZoneFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	tc := testutil.InitializeDBServiceInfrastructure(t)
+	dbSvc := tc.DatabaseService
+	db := tc.ServiceProvider.DB
+	deviceStore := sqlstores.NewSQLDeviceStore(db)
+	collectionStore := sqlstores.NewSQLCollectionStore(db)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+
+	inZoneA := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	inZoneB := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	noZone := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	for _, d := range []string{inZoneA.ID, inZoneB.ID, noZone.ID} {
+		pairDevice(t, ctx, deviceStore, user.OrganizationID, d)
+	}
+
+	rackA, err := collectionStore.CreateCollection(ctx, user.OrganizationID, collectionpb.CollectionType_COLLECTION_TYPE_RACK, "Rack A", "")
+	require.NoError(t, err)
+	require.NoError(t, collectionStore.CreateRackExtension(ctx, rackA.Id, "zone-a", 4, 8, 0, 0, user.OrganizationID))
+	_, err = collectionStore.AddDevicesToCollection(ctx, user.OrganizationID, rackA.Id, []string{inZoneA.ID})
+	require.NoError(t, err)
+
+	rackB, err := collectionStore.CreateCollection(ctx, user.OrganizationID, collectionpb.CollectionType_COLLECTION_TYPE_RACK, "Rack B", "")
+	require.NoError(t, err)
+	require.NoError(t, collectionStore.CreateRackExtension(ctx, rackB.Id, "zone-b", 4, 8, 0, 0, user.OrganizationID))
+	_, err = collectionStore.AddDevicesToCollection(ctx, user.OrganizationID, rackB.Id, []string{inZoneB.ID})
+	require.NoError(t, err)
+
+	groups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
+		Zones: []string{"zone-a"},
+	})
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, int32(1), groups[0].Count, "zone=zone-a should match only the device in rack A")
+
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
+		Zones: []string{"zone-a", "zone-b"},
+	})
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, int32(2), groups[0].Count, "noZone is unassigned, so zone filter must exclude it")
+
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
+		Zones: []string{"missing-zone"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, groups)
+}
+
+// TestGetMinerModelGroups_ZoneWithComma guards the comma-in-value case. Zones
+// allow free-form names like "Austin, Building 1"; an earlier CSV transport
+// would have split that into two zones and produced zero matches.
+func TestGetMinerModelGroups_ZoneWithComma(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	tc := testutil.InitializeDBServiceInfrastructure(t)
+	dbSvc := tc.DatabaseService
+	db := tc.ServiceProvider.DB
+	deviceStore := sqlstores.NewSQLDeviceStore(db)
+	collectionStore := sqlstores.NewSQLCollectionStore(db)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+	dev := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	pairDevice(t, ctx, deviceStore, user.OrganizationID, dev.ID)
+
+	const zone = "Austin, Building 1"
+	rack, err := collectionStore.CreateCollection(ctx, user.OrganizationID, collectionpb.CollectionType_COLLECTION_TYPE_RACK, "Rack", "")
+	require.NoError(t, err)
+	require.NoError(t, collectionStore.CreateRackExtension(ctx, rack.Id, zone, 4, 8, 0, 0, user.OrganizationID))
+	_, err = collectionStore.AddDevicesToCollection(ctx, user.OrganizationID, rack.Id, []string{dev.ID})
+	require.NoError(t, err)
+
+	groups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
+		Zones: []string{zone},
+	})
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, int32(1), groups[0].Count)
+}
+
+// TestGetMinerModelGroups_FirmwareAndZoneFilters proves both filters compose
+// (AND semantics) and that group counts agree with the filtered list — the
+// invariant the bulk-password modal depends on.
+func TestGetMinerModelGroups_FirmwareAndZoneFilters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	tc := testutil.InitializeDBServiceInfrastructure(t)
+	dbSvc := tc.DatabaseService
+	db := tc.ServiceProvider.DB
+	deviceStore := sqlstores.NewSQLDeviceStore(db)
+	collectionStore := sqlstores.NewSQLCollectionStore(db)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+
+	// Two model groups so we can verify firmware + zone narrow counts WITHIN
+	// each group, not just collapse them into one.
+	s21a := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	s21b := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	m60a := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	m60b := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	for _, d := range []string{s21a.ID, s21b.ID, m60a.ID, m60b.ID} {
+		pairDevice(t, ctx, deviceStore, user.OrganizationID, d)
+	}
+
+	setDiscoveredDeviceModel(t, db, s21a.ID, "S21 XP")
+	setDiscoveredDeviceModel(t, db, s21b.ID, "S21 XP")
+	setDiscoveredDeviceModel(t, db, m60a.ID, "M60")
+	setDiscoveredDeviceModel(t, db, m60b.ID, "M60")
+
+	// Firmware: s21a + m60a on v1, s21b + m60b on v2.
+	require.NoError(t, deviceStore.UpdateFirmwareVersion(ctx, models.DeviceIdentifier(s21a.ID), "v1"))
+	require.NoError(t, deviceStore.UpdateFirmwareVersion(ctx, models.DeviceIdentifier(m60a.ID), "v1"))
+	require.NoError(t, deviceStore.UpdateFirmwareVersion(ctx, models.DeviceIdentifier(s21b.ID), "v2"))
+	require.NoError(t, deviceStore.UpdateFirmwareVersion(ctx, models.DeviceIdentifier(m60b.ID), "v2"))
+
+	// Zones: s21a + s21b in zone-a, m60a + m60b in zone-b.
+	rackA, err := collectionStore.CreateCollection(ctx, user.OrganizationID, collectionpb.CollectionType_COLLECTION_TYPE_RACK, "Rack A", "")
+	require.NoError(t, err)
+	require.NoError(t, collectionStore.CreateRackExtension(ctx, rackA.Id, "zone-a", 4, 8, 0, 0, user.OrganizationID))
+	_, err = collectionStore.AddDevicesToCollection(ctx, user.OrganizationID, rackA.Id, []string{s21a.ID, s21b.ID})
+	require.NoError(t, err)
+
+	rackB, err := collectionStore.CreateCollection(ctx, user.OrganizationID, collectionpb.CollectionType_COLLECTION_TYPE_RACK, "Rack B", "")
+	require.NoError(t, err)
+	require.NoError(t, collectionStore.CreateRackExtension(ctx, rackB.Id, "zone-b", 4, 8, 0, 0, user.OrganizationID))
+	_, err = collectionStore.AddDevicesToCollection(ctx, user.OrganizationID, rackB.Id, []string{m60a.ID, m60b.ID})
+	require.NoError(t, err)
+
+	// Firmware=v1 + Zone=zone-a → only s21a (S21 XP, count=1); M60 drops out.
+	filter := &stores.MinerFilter{
+		FirmwareVersions: []string{"v1"},
+		Zones:            []string{"zone-a"},
+	}
+	groups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, filter)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "S21 XP", groups[0].Model)
+	assert.Equal(t, int32(1), groups[0].Count)
+
+	// The bulk-password modal invariant: sum of model-group counts equals the
+	// total returned by the filtered list view for every filter combination.
+	_, _, listTotal, err := deviceStore.ListMinerStateSnapshots(ctx, user.OrganizationID, "", 100, filter, nil)
+	require.NoError(t, err)
+	var groupTotal int32
+	for _, g := range groups {
+		groupTotal += g.Count
+	}
+	assert.Equal(t, listTotal, int64(groupTotal),
+		"bulk-password modal invariant: model-group counts must match the filtered list total")
+}

--- a/server/internal/domain/stores/sqlstores/get_miner_model_groups_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/get_miner_model_groups_integration_test.go
@@ -62,6 +62,37 @@ func setDiscoveredDeviceModel(t *testing.T, db *sql.DB, deviceIdentifier, model 
 	require.Equal(t, int64(1), rows)
 }
 
+// markDiscoveredDeviceInactive flips dd.is_active = FALSE on the device's
+// discovered_device row. Used to verify that GetMinerModelGroups excludes
+// inactive rows the same way the list/count queries do.
+func markDiscoveredDeviceInactive(t *testing.T, db *sql.DB, deviceIdentifier string) {
+	t.Helper()
+	res, err := db.Exec(`
+		UPDATE discovered_device
+		SET is_active = FALSE
+		WHERE id = (SELECT discovered_device_id FROM device WHERE device_identifier = $1)
+	`, deviceIdentifier)
+	require.NoError(t, err)
+	rows, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+}
+
+// softDeleteDiscoveredDevice sets dd.deleted_at on the device's
+// discovered_device row.
+func softDeleteDiscoveredDevice(t *testing.T, db *sql.DB, deviceIdentifier string) {
+	t.Helper()
+	res, err := db.Exec(`
+		UPDATE discovered_device
+		SET deleted_at = NOW()
+		WHERE id = (SELECT discovered_device_id FROM device WHERE device_identifier = $1)
+	`, deviceIdentifier)
+	require.NoError(t, err)
+	rows, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+}
+
 // TestGetMinerModelGroups_FirmwareFilter proves the firmware filter narrows the
 // model-group counts so the bulk-password modal agrees with the filtered list.
 func TestGetMinerModelGroups_FirmwareFilter(t *testing.T) {
@@ -270,4 +301,48 @@ func TestGetMinerModelGroups_FirmwareAndZoneFilters(t *testing.T) {
 	assert.Equal(t, "S21 XP", groups[0].Model)
 	assert.Equal(t, int32(1), groups[0].Count)
 	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, filter)
+}
+
+// TestGetMinerModelGroups_ExcludesInactiveAndSoftDeletedDiscoveredDevices
+// guards the modal invariant against discovered_device state drift. The
+// list/count queries already exclude rows where dd.is_active = FALSE or
+// dd.deleted_at IS NOT NULL; without matching predicates here, model-group
+// counts would silently include miners the table has hidden.
+func TestGetMinerModelGroups_ExcludesInactiveAndSoftDeletedDiscoveredDevices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	tc := testutil.InitializeDBServiceInfrastructure(t)
+	dbSvc := tc.DatabaseService
+	db := tc.ServiceProvider.DB
+	deviceStore := sqlstores.NewSQLDeviceStore(db)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+
+	healthy := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	inactive := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	deleted := dbSvc.CreateDevice(user.OrganizationID, "proto")
+	for _, d := range []string{healthy.ID, inactive.ID, deleted.ID} {
+		pairDevice(t, ctx, deviceStore, user.OrganizationID, d)
+	}
+
+	// Sanity: all three count before any are removed from scope.
+	groups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, nil)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, int32(3), groups[0].Count)
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, nil)
+
+	markDiscoveredDeviceInactive(t, db, inactive.ID)
+	softDeleteDiscoveredDevice(t, db, deleted.ID)
+
+	// Only the healthy device should count now.
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, nil)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, int32(1), groups[0].Count,
+		"inactive and soft-deleted discovered_device rows must be excluded")
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, nil)
 }

--- a/server/internal/domain/stores/sqlstores/get_miner_model_groups_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/get_miner_model_groups_integration_test.go
@@ -29,6 +29,24 @@ func pairDevice(t *testing.T, ctx context.Context, store *sqlstores.SQLDeviceSto
 	))
 }
 
+// assertModalInvariant fetches model groups and the filtered list total under
+// the same filter, then asserts the bulk-password modal's load-bearing
+// invariant: Σ groups[i].count == ListMinerStateSnapshots(filter).total.
+// The modal cannot show a different fleet-size than the table behind it.
+func assertModalInvariant(t *testing.T, ctx context.Context, store *sqlstores.SQLDeviceStore, orgID int64, filter *stores.MinerFilter) {
+	t.Helper()
+	groups, err := store.GetMinerModelGroups(ctx, orgID, filter)
+	require.NoError(t, err)
+	_, _, listTotal, err := store.ListMinerStateSnapshots(ctx, orgID, "", 100, filter, nil)
+	require.NoError(t, err)
+	var groupTotal int32
+	for _, g := range groups {
+		groupTotal += g.Count
+	}
+	assert.Equal(t, listTotal, int64(groupTotal),
+		"bulk-password modal invariant: model-group counts must match filtered list total")
+}
+
 // setDiscoveredDeviceModel patches discovered_device.model directly because
 // CreateDevice hardcodes model="TestMiner" and exposes no override.
 func setDiscoveredDeviceModel(t *testing.T, db *sql.DB, deviceIdentifier, model string) {
@@ -77,27 +95,27 @@ func TestGetMinerModelGroups_FirmwareFilter(t *testing.T) {
 	assert.Equal(t, int32(3), groups[0].Count)
 
 	// Firmware filter narrows to the matching subset.
-	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
-		FirmwareVersions: []string{"v3.5.1"},
-	})
+	singleFirmware := &stores.MinerFilter{FirmwareVersions: []string{"v3.5.1"}}
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, singleFirmware)
 	require.NoError(t, err)
 	require.Len(t, groups, 1)
 	assert.Equal(t, int32(2), groups[0].Count, "firmware=v3.5.1 should narrow count to the two matching devices")
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, singleFirmware)
 
 	// Multi-value firmware filter unions the matches.
-	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
-		FirmwareVersions: []string{"v3.5.1", "v3.5.2"},
-	})
+	multiFirmware := &stores.MinerFilter{FirmwareVersions: []string{"v3.5.1", "v3.5.2"}}
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, multiFirmware)
 	require.NoError(t, err)
 	require.Len(t, groups, 1)
 	assert.Equal(t, int32(3), groups[0].Count)
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, multiFirmware)
 
 	// No matches: filter returns no groups.
-	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
-		FirmwareVersions: []string{"v9.9.9"},
-	})
+	emptyFirmware := &stores.MinerFilter{FirmwareVersions: []string{"v9.9.9"}}
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, emptyFirmware)
 	require.NoError(t, err)
 	assert.Empty(t, groups)
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, emptyFirmware)
 }
 
 // TestGetMinerModelGroups_ZoneFilter proves the zone filter narrows the
@@ -135,25 +153,25 @@ func TestGetMinerModelGroups_ZoneFilter(t *testing.T) {
 	_, err = collectionStore.AddDevicesToCollection(ctx, user.OrganizationID, rackB.Id, []string{inZoneB.ID})
 	require.NoError(t, err)
 
-	groups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
-		Zones: []string{"zone-a"},
-	})
+	singleZone := &stores.MinerFilter{Zones: []string{"zone-a"}}
+	groups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, singleZone)
 	require.NoError(t, err)
 	require.Len(t, groups, 1)
 	assert.Equal(t, int32(1), groups[0].Count, "zone=zone-a should match only the device in rack A")
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, singleZone)
 
-	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
-		Zones: []string{"zone-a", "zone-b"},
-	})
+	multiZone := &stores.MinerFilter{Zones: []string{"zone-a", "zone-b"}}
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, multiZone)
 	require.NoError(t, err)
 	require.Len(t, groups, 1)
 	assert.Equal(t, int32(2), groups[0].Count, "noZone is unassigned, so zone filter must exclude it")
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, multiZone)
 
-	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
-		Zones: []string{"missing-zone"},
-	})
+	missingZone := &stores.MinerFilter{Zones: []string{"missing-zone"}}
+	groups, err = deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, missingZone)
 	require.NoError(t, err)
 	assert.Empty(t, groups)
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, missingZone)
 }
 
 // TestGetMinerModelGroups_ZoneWithComma guards the comma-in-value case. Zones
@@ -182,12 +200,12 @@ func TestGetMinerModelGroups_ZoneWithComma(t *testing.T) {
 	_, err = collectionStore.AddDevicesToCollection(ctx, user.OrganizationID, rack.Id, []string{dev.ID})
 	require.NoError(t, err)
 
-	groups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
-		Zones: []string{zone},
-	})
+	commaFilter := &stores.MinerFilter{Zones: []string{zone}}
+	groups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, commaFilter)
 	require.NoError(t, err)
 	require.Len(t, groups, 1)
 	assert.Equal(t, int32(1), groups[0].Count)
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, commaFilter)
 }
 
 // TestGetMinerModelGroups_FirmwareAndZoneFilters proves both filters compose
@@ -251,15 +269,5 @@ func TestGetMinerModelGroups_FirmwareAndZoneFilters(t *testing.T) {
 	require.Len(t, groups, 1)
 	assert.Equal(t, "S21 XP", groups[0].Model)
 	assert.Equal(t, int32(1), groups[0].Count)
-
-	// The bulk-password modal invariant: sum of model-group counts equals the
-	// total returned by the filtered list view for every filter combination.
-	_, _, listTotal, err := deviceStore.ListMinerStateSnapshots(ctx, user.OrganizationID, "", 100, filter, nil)
-	require.NoError(t, err)
-	var groupTotal int32
-	for _, g := range groups {
-		groupTotal += g.Count
-	}
-	assert.Equal(t, listTotal, int64(groupTotal),
-		"bulk-password modal invariant: model-group counts must match the filtered list total")
+	assertModalInvariant(t, ctx, deviceStore, user.OrganizationID, filter)
 }

--- a/server/sqlc/queries/device.sql
+++ b/server/sqlc/queries/device.sql
@@ -374,6 +374,26 @@ WHERE dp.pairing_status = 'PAIRED'
   AND dd.model != ''
   AND (sqlc.narg('model_filter')::text IS NULL OR dd.model = ANY(string_to_array(sqlc.narg('model_filter'), ',')))
   AND (sqlc.narg('status_filter')::text IS NULL OR ds.status::text = ANY(string_to_array(sqlc.narg('status_filter'), ',')))
+  -- Firmware version filter (values list passes as a real PG array so values
+  -- can contain commas; the narg sentinel signals "filter applied").
+  AND (
+      sqlc.narg('firmware_filter')::text IS NULL
+      OR dd.firmware_version = ANY(sqlc.arg('firmware_values')::text[])
+  )
+  -- Zone filter (excludes soft-deleted racks). Uses array values for the same
+  -- comma-safety reason as firmware above.
+  AND (
+      sqlc.narg('zone_filter')::text IS NULL
+      OR EXISTS (
+          SELECT 1 FROM device_set_membership dsm
+          JOIN device_set ds_zone ON ds_zone.id = dsm.device_set_id AND ds_zone.deleted_at IS NULL
+          JOIN device_set_rack dsr ON dsr.device_set_id = dsm.device_set_id
+          WHERE dsm.device_id = d.id
+            AND dsm.org_id = @org_id
+            AND dsm.device_set_type = 'rack'
+            AND dsr.zone = ANY(sqlc.arg('zone_values')::text[])
+      )
+  )
 GROUP BY dd.model, dd.manufacturer
 ORDER BY dd.manufacturer, dd.model;
 

--- a/server/sqlc/queries/device.sql
+++ b/server/sqlc/queries/device.sql
@@ -369,6 +369,11 @@ JOIN device_pairing dp ON d.id = dp.device_id
 LEFT JOIN device_status ds ON d.id = ds.device_id
 WHERE dp.pairing_status = 'PAIRED'
   AND d.deleted_at IS NULL
+  -- Match the list/count queries so the bulk-password modal invariant holds:
+  -- inactive or soft-deleted discovered_device rows are excluded from both
+  -- the filtered list total and the model-group counts.
+  AND dd.is_active = TRUE
+  AND dd.deleted_at IS NULL
   AND d.org_id = @org_id
   AND dd.model IS NOT NULL
   AND dd.model != ''


### PR DESCRIPTION
## Summary
- Plumbs `firmware_versions` and `zones` from the shared `MinerListFilter` through `GetMinerModelGroups`, fixing the bulk-password-update modal showing model-group counts across the whole fleet instead of the filtered subset.
- Uses array transport (`pq.Array` + `::text[]`) for the new filters so zone values containing commas (e.g. `"Austin, Building 1"`) survive intact — CSV + `string_to_array` would have split them.
- Adds unit tests for `buildFilterParams` (including comma passthrough) and integration tests asserting the modal invariant `Σ groups[i].count == ListMinerStateSnapshots(filter).total` for firmware-only, zone-only, comma-in-zone, and combined filters.

Closes #126.

## Test plan
- [x] `go test ./internal/domain/stores/sqlstores/...` — unit + integration green
- [x] `golangci-lint run` — clean
- [ ] Spot-check the bulk-password modal in dev with a firmware filter applied and confirm counts match the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)