### PR TITLE
fix(MinerList): center no-results empty state on page, not table (#143)

### DIFF
--- a/client/src/protoFleet/components/NoFilterResultsEmptyState.tsx
+++ b/client/src/protoFleet/components/NoFilterResultsEmptyState.tsx
@@ -1,12 +1,19 @@
+import clsx from "clsx";
+
 import Button, { sizes, variants } from "@/shared/components/Button";
 
 interface NoFilterResultsEmptyStateProps {
   hasActiveFilters?: boolean;
   onClearFilters?: () => void;
+  className?: string;
 }
 
-const NoFilterResultsEmptyState = ({ hasActiveFilters = false, onClearFilters }: NoFilterResultsEmptyStateProps) => (
-  <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
+const NoFilterResultsEmptyState = ({
+  hasActiveFilters = false,
+  onClearFilters,
+  className,
+}: NoFilterResultsEmptyStateProps) => (
+  <div className={clsx("flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center", className)}>
     <div className="text-heading-200 text-text-primary">No results</div>
     {hasActiveFilters ? (
       <>

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -355,7 +355,11 @@ const ScopedMinerListBody = ({
         onRowClick={onRowClick}
         emptyStateRow={
           totalMiners === 0 || deviceItems.length === 0 ? (
-            <NoFilterResultsEmptyState hasActiveFilters={hasActiveFilters} onClearFilters={handleClearFilters} />
+            <NoFilterResultsEmptyState
+              className="sticky left-0 !w-screen laptop:!w-[calc(100vw-theme(spacing.1)*16)] desktop:!w-[calc(100vw-theme(spacing.1)*50)]"
+              hasActiveFilters={hasActiveFilters}
+              onClearFilters={handleClearFilters}
+            />
           ) : undefined
         }
       />


### PR DESCRIPTION
## Summary
- Empty state inside a `<td colSpan>` of a `w-max` table inherited the table's oversized width via `w-full`, so the "No results" message centered on the table instead of the visible page (issue #143).
- Added optional `className` prop to `NoFilterResultsEmptyState`; at the MinerList usage, override with `sticky left-0` plus viewport-minus-sidebar width so the message pins to viewport-left during horizontal scroll and centers on the visible content area.
- Pattern matches existing `sticky left-0` usage in MinerList pagination and AppLayout's `laptop:left-16 desktop:left-50` content offsets.

## Test plan
- [ ] Apply a filter on the Miners page that returns zero results; confirm "No results" centers on the visible page (not the wide table) at desktop, laptop, and phone breakpoints.
- [ ] Horizontally scroll the table; confirm the message stays anchored to the visible area.
- [ ] Confirm other usages of `NoFilterResultsEmptyState` (Racks, Activity, Groups, DeviceSets) render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)