### PR TITLE
feat(fleet): saved views for the miner list (#138)

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
@@ -1089,6 +1089,7 @@ describe("MinerList", () => {
         title: "Miners",
         minerIds: [],
         totalMiners: 0,
+        totalUnfilteredMiners: 0,
         onAddMiners,
       });
 
@@ -1108,12 +1109,26 @@ describe("MinerList", () => {
         title: "Miners",
         minerIds: [],
         totalMiners: 0,
+        totalUnfilteredMiners: 0,
         onAddMiners,
       });
 
       await user.click(screen.getByRole("button", { name: "Get started" }));
 
       expect(onAddMiners).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to totalMiners=0 when totalUnfilteredMiners is omitted", () => {
+      // Callers that don't plumb totalUnfilteredMiners still get the null state
+      // when totalMiners is 0 — preserves the prior contract on a shared component.
+      renderMinerList({
+        title: "Miners",
+        minerIds: [],
+        totalMiners: 0,
+        onAddMiners: vi.fn(),
+      });
+
+      expect(screen.getByText("You haven't paired any miners")).toBeInTheDocument();
     });
 
     it("should not show null state when loading", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import clsx from "clsx";
@@ -34,6 +34,8 @@ import AuthenticateFleetModal from "@/protoFleet/features/auth/components/Authen
 import { AuthenticateMiners } from "@/protoFleet/features/auth/components/AuthenticateMiners";
 import PoolSelectionPageWrapper from "@/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage";
 import MinerListActionBar from "@/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar";
+import ViewsBar from "@/protoFleet/features/fleetManagement/components/ViewsBar";
+import ViewActions from "@/protoFleet/features/fleetManagement/components/ViewsBar/ViewActions";
 import type { BatchOperation } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 
 import {
@@ -41,6 +43,8 @@ import {
   parseUrlToActiveFilters,
 } from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
 import { encodeSortToURL, parseSortFromURL } from "@/protoFleet/features/fleetManagement/utils/sortUrlParams";
+import { VIEW_URL_PARAM } from "@/protoFleet/features/fleetManagement/views/savedViews";
+import useMinerViews from "@/protoFleet/features/fleetManagement/views/useMinerViews";
 import { useUsername } from "@/protoFleet/store";
 
 import { ChevronDown, LogoAlt, Plus, Slider } from "@/shared/assets/icons";
@@ -212,6 +216,7 @@ type ScopedMinerListBodyProps = {
   minerIds?: string[];
   onRefetchMiners?: () => void;
   onWorkerNameUpdated?: (deviceIdentifier: string, workerName: string) => void;
+  chipsRowTrailing?: ReactNode;
 };
 
 const ScopedMinerListBody = ({
@@ -250,6 +255,7 @@ const ScopedMinerListBody = ({
   minerIds: minerIdsProp,
   onRefetchMiners,
   onWorkerNameUpdated,
+  chipsRowTrailing,
 }: ScopedMinerListBodyProps) => {
   const [selectedMinerIds, setSelectedMinerIds] = useState<string[]>([]);
   const [selectionMode, setSelectionMode] = useState<SelectionMode>("none");
@@ -293,6 +299,7 @@ const ScopedMinerListBody = ({
         itemSelectable
         pageScopedSelection
         hasActiveFilters={hasActiveFilters}
+        chipsRowTrailing={chipsRowTrailing}
         headerControls={
           <div className="flex items-center gap-2">
             <Button
@@ -440,6 +447,7 @@ const MinerList = ({
   const username = useUsername();
   const { preferences: columnPreferences, setPreferences: setColumnPreferences } =
     useMinerTableColumnPreferences(username);
+  const viewsState = useMinerViews(username);
 
   const [modalFlow, setModalFlow] = useState<MinerModalFlow>({ kind: "closed" });
   const [showManageColumnsModal, setShowManageColumnsModal] = useState(false);
@@ -624,6 +632,7 @@ const MinerList = ({
     nextSearchParams.delete("rack");
     nextSearchParams.delete("firmware");
     nextSearchParams.delete("zone");
+    nextSearchParams.delete(VIEW_URL_PARAM);
 
     const nextSearch = nextSearchParams.toString();
     navigate({ search: nextSearch ? `?${nextSearch}` : "" }, { replace: true });
@@ -827,13 +836,16 @@ const MinerList = ({
         minerFilter.zones.push(...zoneFilters);
       }
 
-      // Navigate with URL params instead of calling parent callback
-      // Start fresh with filter params, then preserve existing sort params
+      // Navigate with URL params instead of calling parent callback.
+      // Start fresh with filter params, then preserve existing sort + active
+      // view so dirtying a view doesn't lose its identity.
       const params = encodeFilterToURL(minerFilter);
       const sortParam = searchParams.get("sort");
       const dirParam = searchParams.get("dir");
+      const viewParam = searchParams.get(VIEW_URL_PARAM);
       if (sortParam) params.set("sort", sortParam);
       if (dirParam) params.set("dir", dirParam);
+      if (viewParam) params.set(VIEW_URL_PARAM, viewParam);
       navigate(`?${params.toString()}`, { replace: true });
     },
     [navigate, searchParams],
@@ -862,8 +874,12 @@ const MinerList = ({
     [activeSortColumn, navigate, searchParams, setColumnPreferences],
   );
 
-  // Show null state when no miners are paired and not loading
-  const showNullState = !loading && totalMiners === 0 && !hasActiveFilters;
+  // Show null state when no miners are paired and not loading. Prefer the
+  // unfiltered count (stable across filter switches; avoids flashing during
+  // refetch); fall back to totalMiners so callers that don't pass the
+  // unfiltered count still get the null state.
+  const referenceMinerCount = totalUnfilteredMiners ?? totalMiners;
+  const showNullState = !loading && referenceMinerCount === 0 && !hasActiveFilters;
 
   if (showNullState) {
     return (
@@ -908,6 +924,8 @@ const MinerList = ({
           : `${totalMiners ?? 0} miners`}
       </div>
 
+      <ViewsBar viewsState={viewsState} availableGroups={availableGroups} availableRacks={availableRacks} />
+
       {loading ? (
         <div className="flex justify-center py-20">
           <ProgressCircular indeterminate />
@@ -949,6 +967,9 @@ const MinerList = ({
           minerIds={minerIds}
           onRefetchMiners={onRefetchMiners}
           onWorkerNameUpdated={onWorkerNameUpdated}
+          chipsRowTrailing={
+            <ViewActions viewsState={viewsState} availableGroups={availableGroups} availableRacks={availableRacks} />
+          }
         />
       )}
 

--- a/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewActions.test.tsx
@@ -1,0 +1,172 @@
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import ViewActions from "./ViewActions";
+import { getSavedViewsStorageKey, VIEW_URL_PARAM } from "@/protoFleet/features/fleetManagement/views/savedViews";
+import useMinerViews from "@/protoFleet/features/fleetManagement/views/useMinerViews";
+
+const STORAGE_KEY = getSavedViewsStorageKey("alice");
+
+const LocationProbe = ({ onLocation }: { onLocation: (search: string) => void }) => {
+  const location = useLocation();
+  onLocation(location.search);
+  return null;
+};
+
+const ViewActionsHarness = ({ onLocation }: { onLocation: (search: string) => void }) => {
+  const viewsState = useMinerViews("alice");
+  return (
+    <>
+      <ViewActions viewsState={viewsState} availableGroups={[]} availableRacks={[]} />
+      <LocationProbe onLocation={onLocation} />
+    </>
+  );
+};
+
+const renderViewActions = (initialEntries: string[] = ["/"]) => {
+  const locations: string[] = [];
+  const captureLocation = (search: string) => {
+    locations.push(search);
+  };
+
+  const utils = render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/" element={<ViewActionsHarness onLocation={captureLocation} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  return {
+    ...utils,
+    currentSearch: () => locations[locations.length - 1] ?? "",
+  };
+};
+
+const readPersistedRecord = () => {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
+};
+
+const seedRecord = (record: object) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+};
+
+describe("ViewActions", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders nothing when no view is active", () => {
+    renderViewActions();
+    expect(screen.queryByTestId("view-actions-reset-button")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the active view is unmodified", () => {
+    renderViewActions(["/?view=needs-attention&status=needs-attention"]);
+    expect(screen.queryByTestId("view-actions-reset-button")).not.toBeInTheDocument();
+  });
+
+  it("renders only Reset when a built-in view is dirty", () => {
+    renderViewActions(["/?view=needs-attention&status=needs-attention&model=S21"]);
+    expect(screen.getByTestId("view-actions-reset-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("view-actions-update-button")).not.toBeInTheDocument();
+  });
+
+  it("renders Reset and Update view when a user view is dirty", () => {
+    seedRecord({
+      version: 1,
+      views: [{ id: "u1", name: "Mine", searchParams: "status=offline", createdAt: "2026-04-30T00:00:00.000Z" }],
+      deletedBuiltInIds: [],
+    });
+    renderViewActions(["/?view=u1&status=offline&model=S21"]);
+    expect(screen.getByTestId("view-actions-reset-button")).toBeInTheDocument();
+    expect(screen.getByTestId("view-actions-update-button")).toBeInTheDocument();
+  });
+
+  it("Reset restores the saved view's params", async () => {
+    const user = userEvent.setup();
+    const { currentSearch } = renderViewActions(["/?view=needs-attention&status=needs-attention&model=S21"]);
+
+    await user.click(screen.getByTestId("view-actions-reset-button"));
+
+    await waitFor(() => {
+      const params = new URLSearchParams(currentSearch());
+      expect(params.get("model")).toBeNull();
+      expect(params.get("status")).toBe("needs-attention");
+      expect(params.get(VIEW_URL_PARAM)).toBe("needs-attention");
+    });
+  });
+
+  it("Update view writes current params back to the saved view", async () => {
+    const user = userEvent.setup();
+
+    seedRecord({
+      version: 1,
+      views: [{ id: "u1", name: "Mine", searchParams: "status=offline", createdAt: "2026-04-30T00:00:00.000Z" }],
+      deletedBuiltInIds: [],
+    });
+
+    renderViewActions(["/?view=u1&status=offline&model=S21"]);
+
+    await user.click(screen.getByTestId("view-actions-update-button"));
+    await user.click(screen.getByText("Update"));
+
+    await waitFor(() => {
+      const stored = readPersistedRecord();
+      expect(stored.views[0].searchParams).toBe("model=S21&status=offline");
+    });
+  });
+
+  it("syncs URL to saved params after updating with Include sort order off (view becomes clean)", async () => {
+    const user = userEvent.setup();
+
+    // Saved view has sort baked in; current URL adds an extra filter so the
+    // view is dirty and the Update button is visible.
+    seedRecord({
+      version: 1,
+      views: [
+        {
+          id: "u1",
+          name: "Mine",
+          searchParams: "dir=desc&sort=hashrate&status=offline",
+          createdAt: "2026-04-30T00:00:00.000Z",
+        },
+      ],
+      deletedBuiltInIds: [],
+    });
+
+    const { currentSearch } = renderViewActions(["/?view=u1&status=offline&sort=hashrate&dir=desc&model=S21"]);
+
+    await user.click(screen.getByTestId("view-actions-update-button"));
+    // Toggle "Include sort order" off — the only checkbox in the modal.
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByText("Update"));
+
+    // Saved view should drop sort/dir but keep the new model filter.
+    await waitFor(() => {
+      const stored = readPersistedRecord();
+      expect(stored.views[0].searchParams).toBe("model=S21&status=offline");
+    });
+
+    // URL should match the saved view (no sort/dir, model still there).
+    await waitFor(() => {
+      const params = new URLSearchParams(currentSearch());
+      expect(params.get("sort")).toBeNull();
+      expect(params.get("dir")).toBeNull();
+      expect(params.get("status")).toBe("offline");
+      expect(params.get("model")).toBe("S21");
+      expect(params.get(VIEW_URL_PARAM)).toBe("u1");
+    });
+
+    // Reset/Update view actions disappear because state is clean again.
+    await waitFor(() => {
+      expect(screen.queryByTestId("view-actions-reset-button")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewActions.tsx
@@ -106,9 +106,14 @@ const ViewActions = ({ viewsState, availableGroups, availableRacks }: ViewAction
     [activeView, currentCanonical, updateUserViewParams, renameUserView, navigate],
   );
 
+  // Reserve built-in names too — otherwise an Update view rename could land
+  // on "All miners" / "Offline" / "Needs attention" and produce duplicate tabs.
   const existingNames = useMemo(
-    () => record.views.filter((view) => view.id !== activeView?.id).map((view) => view.name),
-    [record.views, activeView],
+    () => [
+      ...visibleBuiltInViews(record).map((view) => view.name),
+      ...record.views.filter((view) => view.id !== activeView?.id).map((view) => view.name),
+    ],
+    [record, activeView],
   );
 
   if (!isModified || !activeView) return null;

--- a/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewActions.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import ViewModal, { type ViewModalState } from "./ViewModal";
+import type { DeviceSet } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import {
+  ALL_MINERS_VIEW_ID,
+  buildUrlForView,
+  canonicalizeSearchParams,
+  findView,
+  VIEW_URL_PARAM,
+  visibleBuiltInViews,
+} from "@/protoFleet/features/fleetManagement/views/savedViews";
+import type { UseMinerViewsResult } from "@/protoFleet/features/fleetManagement/views/useMinerViews";
+import {
+  stripSortFromSearchParams,
+  summarizeFilters,
+  summarizeSort,
+} from "@/protoFleet/features/fleetManagement/views/viewSummary";
+import { Checkmark, Reboot } from "@/shared/assets/icons";
+import { iconSizes } from "@/shared/assets/icons/constants";
+import Button, { sizes, variants } from "@/shared/components/Button";
+
+type ViewActionsProps = {
+  viewsState: UseMinerViewsResult;
+  availableGroups: DeviceSet[];
+  availableRacks: DeviceSet[];
+};
+
+/**
+ * Reset / Update view actions for a dirtied view. Mounts in the filter row's
+ * right-aligned chip-row slot so it stays in view even when the tab strip
+ * overflows or the page narrows.
+ */
+const ViewActions = ({ viewsState, availableGroups, availableRacks }: ViewActionsProps) => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { record, updateUserViewParams, renameUserView } = viewsState;
+
+  const builtIns = useMemo(() => visibleBuiltInViews(record), [record]);
+  const currentCanonical = useMemo(() => canonicalizeSearchParams(searchParams), [searchParams]);
+
+  const activeViewId = searchParams.get(VIEW_URL_PARAM) ?? (currentCanonical === "" ? ALL_MINERS_VIEW_ID : undefined);
+  const activeView = activeViewId ? findView(activeViewId, record) : undefined;
+  const isModified = activeView !== undefined && activeView.searchParams !== currentCanonical;
+  const activeIsBuiltIn = activeView !== undefined && builtIns.some((view) => view.id === activeView.id);
+
+  const currentFilters = useMemo(
+    () => summarizeFilters(searchParams, { availableGroups, availableRacks }),
+    [searchParams, availableGroups, availableRacks],
+  );
+  const currentSort = useMemo(() => summarizeSort(searchParams), [searchParams]);
+
+  const savedFilters = useMemo(() => {
+    if (!activeView) return [];
+    return summarizeFilters(new URLSearchParams(activeView.searchParams), { availableGroups, availableRacks });
+  }, [activeView, availableGroups, availableRacks]);
+  const savedSort = useMemo(() => {
+    if (!activeView) return undefined;
+    return summarizeSort(new URLSearchParams(activeView.searchParams));
+  }, [activeView]);
+
+  const [modal, setModal] = useState<ViewModalState>({ open: false });
+
+  const handleReset = useCallback(() => {
+    if (!activeView) return;
+    if (activeView.id === ALL_MINERS_VIEW_ID) {
+      navigate({ search: "" }, { replace: true });
+      return;
+    }
+    navigate(`?${buildUrlForView(activeView, searchParams)}`, { replace: true });
+  }, [activeView, navigate, searchParams]);
+
+  const handleOpenUpdate = useCallback(() => {
+    if (!activeView || activeIsBuiltIn) return;
+    setModal({
+      open: true,
+      mode: {
+        kind: "update",
+        viewId: activeView.id,
+        currentName: activeView.name,
+        savedFilters,
+        savedSort,
+      },
+      defaultName: activeView.name,
+      currentFilters,
+      currentSort,
+    });
+  }, [activeView, activeIsBuiltIn, savedFilters, savedSort, currentFilters, currentSort]);
+
+  const handleSubmit = useCallback(
+    ({ name, includeSort }: { name: string; includeSort: boolean }) => {
+      if (!activeView) return;
+      const paramsForView = includeSort ? currentCanonical : stripSortFromSearchParams(currentCanonical);
+      updateUserViewParams(activeView.id, paramsForView);
+      if (name !== activeView.name) {
+        renameUserView(activeView.id, name);
+      }
+      // Sync URL to the saved params so the view is immediately clean —
+      // otherwise toggling off Include sort order leaves sort/dir in the URL
+      // and the view stays "dirty" right after the user saved.
+      const next = new URLSearchParams(paramsForView);
+      next.set(VIEW_URL_PARAM, activeView.id);
+      navigate(`?${next.toString()}`, { replace: true });
+      setModal({ open: false });
+    },
+    [activeView, currentCanonical, updateUserViewParams, renameUserView, navigate],
+  );
+
+  const existingNames = useMemo(
+    () => record.views.filter((view) => view.id !== activeView?.id).map((view) => view.name),
+    [record.views, activeView],
+  );
+
+  if (!isModified || !activeView) return null;
+
+  return (
+    <>
+      <Button
+        text="Reset view"
+        size={sizes.compact}
+        variant={variants.secondary}
+        prefixIcon={<Reboot width={iconSizes.small} />}
+        onClick={handleReset}
+        testId="view-actions-reset-button"
+      />
+      {activeIsBuiltIn ? null : (
+        <Button
+          text="Update view"
+          size={sizes.compact}
+          variant={variants.secondary}
+          prefixIcon={<Checkmark width={iconSizes.small} />}
+          onClick={handleOpenUpdate}
+          testId="view-actions-update-button"
+        />
+      )}
+
+      <ViewModal
+        state={modal}
+        existingNames={existingNames}
+        onDismiss={() => setModal({ open: false })}
+        onSubmit={handleSubmit}
+      />
+    </>
+  );
+};
+
+export default ViewActions;

--- a/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewModal.tsx
@@ -1,0 +1,260 @@
+import { type ReactNode, useCallback, useMemo, useState } from "react";
+import clsx from "clsx";
+import {
+  diffFilterSummaries,
+  diffSortSummaries,
+  type FilterDiff,
+  type FilterDiffEntry,
+  type FilterSummaryEntry,
+  type SortDiff,
+  type SortSummary,
+} from "@/protoFleet/features/fleetManagement/views/viewSummary";
+import { variants } from "@/shared/components/Button";
+import Input from "@/shared/components/Input";
+import Modal from "@/shared/components/Modal";
+import Switch from "@/shared/components/Switch";
+
+export type ViewModalMode =
+  | { kind: "create" }
+  | {
+      kind: "update";
+      viewId: string;
+      currentName: string;
+      savedFilters: FilterSummaryEntry[];
+      savedSort: SortSummary | undefined;
+    };
+
+export type ViewModalState =
+  | { open: false }
+  | {
+      open: true;
+      mode: ViewModalMode;
+      defaultName: string;
+      currentFilters: FilterSummaryEntry[];
+      currentSort: SortSummary | undefined;
+    };
+
+type ViewModalProps = {
+  state: ViewModalState;
+  existingNames: string[];
+  onDismiss: () => void;
+  onSubmit: (input: { name: string; includeSort: boolean }) => void;
+};
+
+const CHANGE_LABELS: Record<FilterDiffEntry["change"], string | undefined> = {
+  unchanged: undefined,
+  added: "Added",
+  changed: "Changed",
+};
+
+const CHANGE_BADGE_CLASS: Record<FilterDiffEntry["change"], string> = {
+  unchanged: "",
+  added: "bg-intent-success-10 text-intent-success-fill",
+  changed: "bg-intent-warning-10 text-intent-warning-fill",
+};
+
+const ChangeBadge = ({ change }: { change: FilterDiffEntry["change"] }) => {
+  const text = CHANGE_LABELS[change];
+  if (!text) return null;
+  return (
+    <span
+      className={clsx("rounded-md px-1.5 py-0.5 text-200", CHANGE_BADGE_CLASS[change])}
+      data-testid={`view-summary-change-${change}`}
+    >
+      {text}
+    </span>
+  );
+};
+
+const FilterSummaryRows = ({ entries, diff }: { entries: FilterSummaryEntry[]; diff: FilterDiff | undefined }) => {
+  if (!diff) {
+    if (entries.length === 0) return <EmptyState />;
+    return (
+      <ul className="flex flex-col" data-testid="view-summary-list">
+        {entries.map((entry) => (
+          <li key={entry.key} className="flex items-baseline gap-2 text-300" data-testid={`view-summary-${entry.key}`}>
+            <span className="text-text-primary-70">{entry.label}:</span>
+            <span className="text-text-primary">{entry.values.join(", ")}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (diff.current.length === 0 && diff.removed.length === 0) return <EmptyState />;
+
+  return (
+    <ul className="flex flex-col" data-testid="view-summary-list">
+      {diff.current.map((entry) => (
+        <li key={entry.key} className="flex items-baseline gap-2 text-300" data-testid={`view-summary-${entry.key}`}>
+          <span className="text-text-primary-70">{entry.label}:</span>
+          <span className="text-text-primary">{entry.values.join(", ")}</span>
+          <ChangeBadge change={entry.change} />
+        </li>
+      ))}
+      {diff.removed.map((entry) => (
+        <li
+          key={`removed-${entry.key}`}
+          className="flex items-baseline gap-2 text-300"
+          data-testid={`view-summary-removed-${entry.key}`}
+        >
+          <span className="text-text-primary-70">{entry.label}:</span>
+          <span className="text-text-primary">{entry.values.join(", ")}</span>
+          <span
+            className="rounded-md bg-intent-critical-10 px-1.5 py-0.5 text-200 text-intent-critical-fill"
+            data-testid="view-summary-change-removed"
+          >
+            Removed
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const EmptyState = () => (
+  <div className="rounded-lg bg-surface-5 px-4 py-3 text-300 text-text-primary-70" data-testid="view-summary-empty">
+    No filters applied. Saving will create an unfiltered view.
+  </div>
+);
+
+const sortDescription = (sort: SortSummary | undefined) =>
+  sort ? `${sort.fieldLabel} (${sort.direction === "asc" ? "ascending" : "descending"})` : "No sort applied";
+
+const SortSection = ({
+  current,
+  diff,
+  includeSort,
+  setIncludeSort,
+}: {
+  current: SortSummary | undefined;
+  diff: SortDiff | undefined;
+  includeSort: boolean;
+  setIncludeSort: (checked: boolean | ((prev: boolean) => boolean)) => void;
+}) => {
+  const renderBadge = (): ReactNode => {
+    switch (diff?.change) {
+      case "added":
+      case "changed":
+        return <ChangeBadge change={diff.change} />;
+      case "removed":
+        return (
+          <span
+            className="rounded-md bg-intent-critical-10 px-1.5 py-0.5 text-200 text-intent-critical-fill"
+            data-testid="view-summary-sort-change-removed"
+          >
+            Removed
+          </span>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4" data-testid="view-summary-include-sort">
+      <div className="flex flex-col">
+        <span className="text-emphasis-300 text-text-primary">Include sort order</span>
+        <span className="inline-flex items-center gap-2 text-300 text-text-primary-70">
+          <span>{sortDescription(current)}</span>
+          {renderBadge()}
+        </span>
+      </div>
+      <Switch checked={includeSort} setChecked={setIncludeSort} disabled={!current} />
+    </div>
+  );
+};
+
+const ViewModal = ({ state, existingNames, onDismiss, onSubmit }: ViewModalProps) => {
+  const open = state.open;
+  const defaultName = state.open ? state.defaultName : "";
+  const mode: ViewModalMode = state.open ? state.mode : { kind: "create" };
+
+  const [name, setName] = useState(defaultName);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [includeSort, setIncludeSort] = useState(true);
+
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    setName(defaultName);
+    setError(undefined);
+    setIncludeSort(true);
+  }
+
+  const filterDiff = useMemo<FilterDiff | undefined>(() => {
+    if (!state.open || state.mode.kind !== "update") return undefined;
+    return diffFilterSummaries(state.currentFilters, state.mode.savedFilters);
+  }, [state]);
+
+  const sortDiff = useMemo<SortDiff | undefined>(() => {
+    if (!state.open || state.mode.kind !== "update") return undefined;
+    return diffSortSummaries(state.currentSort, state.mode.savedSort);
+  }, [state]);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Name is required");
+      return;
+    }
+    const conflict = existingNames.some((existing) => existing.toLowerCase() === trimmed.toLowerCase());
+    if (conflict) {
+      setError("A view with this name already exists");
+      return;
+    }
+    onSubmit({ name: trimmed, includeSort });
+  }, [name, existingNames, onSubmit, includeSort]);
+
+  const isUpdate = mode.kind === "update";
+  const title = isUpdate ? "Update view" : "New view";
+  const description = isUpdate
+    ? "Replace the saved filters and sort with the current set."
+    : "Save the current filters and sort as a view.";
+  const submitText = isUpdate ? "Update" : "Save";
+
+  return (
+    <Modal
+      open={open}
+      title={title}
+      description={description}
+      onDismiss={onDismiss}
+      testId="view-modal"
+      buttons={[
+        { text: "Cancel", onClick: onDismiss, variant: variants.secondary },
+        { text: submitText, onClick: handleSubmit, variant: variants.primary, dismissModalOnClick: false },
+      ]}
+    >
+      <div className="flex flex-col gap-6">
+        <Input
+          id="view-name"
+          label="Name"
+          initValue={defaultName}
+          autoFocus
+          error={error ?? false}
+          onChange={(value) => {
+            setName(value);
+            setError(undefined);
+          }}
+          onKeyDown={(key) => {
+            if (key === "Enter") handleSubmit();
+          }}
+        />
+
+        <div className="flex flex-col">
+          <span className="text-emphasis-300 text-text-primary">Filters</span>
+          <FilterSummaryRows entries={state.open ? state.currentFilters : []} diff={filterDiff} />
+        </div>
+
+        <SortSection
+          current={state.open ? state.currentSort : undefined}
+          diff={sortDiff}
+          includeSort={includeSort}
+          setIncludeSort={setIncludeSort}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default ViewModal;

--- a/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewsBar.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewsBar.test.tsx
@@ -1,0 +1,185 @@
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import ViewsBar from "./ViewsBar";
+import { getSavedViewsStorageKey, VIEW_URL_PARAM } from "@/protoFleet/features/fleetManagement/views/savedViews";
+import useMinerViews from "@/protoFleet/features/fleetManagement/views/useMinerViews";
+
+const STORAGE_KEY = getSavedViewsStorageKey("alice");
+
+const LocationProbe = ({ onLocation }: { onLocation: (search: string) => void }) => {
+  const location = useLocation();
+  onLocation(location.search);
+  return null;
+};
+
+const ViewsBarHarness = ({ onLocation }: { onLocation: (search: string) => void }) => {
+  const viewsState = useMinerViews("alice");
+  return (
+    <>
+      <ViewsBar viewsState={viewsState} availableGroups={[]} availableRacks={[]} />
+      <LocationProbe onLocation={onLocation} />
+    </>
+  );
+};
+
+const renderViewsBar = (initialEntries: string[] = ["/"]) => {
+  const locations: string[] = [];
+  const captureLocation = (search: string) => {
+    locations.push(search);
+  };
+
+  const utils = render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/" element={<ViewsBarHarness onLocation={captureLocation} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  return {
+    ...utils,
+    /** The most recent location.search value the router has emitted. */
+    currentSearch: () => locations[locations.length - 1] ?? "",
+  };
+};
+
+const readPersistedRecord = () => {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
+};
+
+describe("ViewsBar", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders all built-in views as tabs by default", () => {
+    renderViewsBar();
+    expect(screen.getByTestId("views-bar-tab-all-miners")).toBeInTheDocument();
+    expect(screen.getByTestId("views-bar-tab-needs-attention")).toBeInTheDocument();
+    expect(screen.getByTestId("views-bar-tab-offline")).toBeInTheDocument();
+  });
+
+  it("activates a built-in view, writing the view id and its filters into the URL", async () => {
+    const user = userEvent.setup();
+    const { currentSearch } = renderViewsBar();
+
+    await user.click(screen.getByTestId("views-bar-tab-needs-attention-activate"));
+
+    await waitFor(() => {
+      const params = new URLSearchParams(currentSearch());
+      expect(params.get(VIEW_URL_PARAM)).toBe("needs-attention");
+      expect(params.get("status")).toBe("needs-attention");
+    });
+  });
+
+  it("flags the active tab as warning-toned when current URL drifts from active view", () => {
+    renderViewsBar(["/?view=needs-attention&status=needs-attention&model=S21"]);
+    const activeTab = screen.getByTestId("views-bar-tab-needs-attention");
+    expect(activeTab).toHaveAttribute("data-active", "true");
+    expect(activeTab.className).toContain("text-intent-warning-50");
+  });
+
+  it("persists a new user view via the modal and activates it", async () => {
+    const user = userEvent.setup();
+    const { currentSearch } = renderViewsBar(["/?status=offline&model=S21"]);
+
+    await user.click(screen.getByTestId("views-bar-new-view-button"));
+
+    const nameInput = screen.getByLabelText("Name");
+    await user.type(nameInput, "S21 offline");
+    await user.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      const stored = readPersistedRecord();
+      expect(stored.views).toHaveLength(1);
+      expect(stored.views[0].name).toBe("S21 offline");
+      expect(stored.views[0].searchParams).toBe("model=S21&status=offline");
+    });
+
+    await waitFor(() => {
+      const params = new URLSearchParams(currentSearch());
+      expect(params.get(VIEW_URL_PARAM)).toBeTruthy();
+    });
+  });
+
+  it("lists current filters and humanizes status values inside the modal", async () => {
+    const user = userEvent.setup();
+    renderViewsBar(["/?status=offline&model=S21"]);
+
+    await user.click(screen.getByTestId("views-bar-new-view-button"));
+
+    const statusRow = screen.getByTestId("view-summary-status");
+    expect(statusRow).toHaveTextContent("Status:");
+    expect(statusRow).toHaveTextContent("Offline");
+
+    const modelRow = screen.getByTestId("view-summary-model");
+    expect(modelRow).toHaveTextContent("S21");
+  });
+
+  it("shows the empty-state copy when no filters or sort are applied", async () => {
+    const user = userEvent.setup();
+    renderViewsBar();
+
+    await user.click(screen.getByTestId("views-bar-new-view-button"));
+
+    expect(screen.getByTestId("view-summary-empty")).toBeInTheDocument();
+  });
+
+  it("strips sort+dir from the saved view AND from the URL when the include-sort toggle is off", async () => {
+    const user = userEvent.setup();
+    const { currentSearch } = renderViewsBar(["/?status=offline&sort=hashrate&dir=desc"]);
+
+    await user.click(screen.getByTestId("views-bar-new-view-button"));
+
+    // Include-sort toggle row reflects the active sort.
+    const includeSortRow = screen.getByTestId("view-summary-include-sort");
+    expect(includeSortRow).toHaveTextContent("Hashrate (descending)");
+
+    // Flip the include-sort switch (the only checkbox in the modal).
+    await user.click(screen.getByRole("checkbox"));
+
+    const nameInput = screen.getByLabelText("Name");
+    await user.type(nameInput, "Sortless");
+    await user.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      const stored = readPersistedRecord();
+      expect(stored.views[0].searchParams).toBe("status=offline");
+    });
+
+    // URL should match the saved view (no sort/dir) so the new view is clean
+    // immediately — otherwise the user sees Reset/Update view right after save.
+    await waitFor(() => {
+      const params = new URLSearchParams(currentSearch());
+      expect(params.get("sort")).toBeNull();
+      expect(params.get("dir")).toBeNull();
+      expect(params.get("status")).toBe("offline");
+      expect(params.get(VIEW_URL_PARAM)).toBeTruthy();
+    });
+  });
+
+  it("rejects an empty name and surfaces an error in the modal", async () => {
+    const user = userEvent.setup();
+    renderViewsBar();
+
+    await user.click(screen.getByTestId("views-bar-new-view-button"));
+    await user.click(screen.getByText("Save"));
+
+    expect(screen.getByText("Name is required")).toBeInTheDocument();
+    expect(readPersistedRecord()).toBeNull();
+  });
+
+  it("does not render dirty-state actions in the strip — those live in <ViewActions>", () => {
+    renderViewsBar(["/?view=needs-attention&status=needs-attention&model=S21"]);
+    expect(screen.queryByTestId("views-bar-modified-actions")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("views-bar-reset-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("views-bar-update-button")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewsBar.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewsBar.test.tsx
@@ -176,6 +176,20 @@ describe("ViewsBar", () => {
     expect(readPersistedRecord()).toBeNull();
   });
 
+  it("rejects a name that matches a built-in view (case-insensitive)", async () => {
+    const user = userEvent.setup();
+    renderViewsBar();
+
+    await user.click(screen.getByTestId("views-bar-new-view-button"));
+
+    const nameInput = screen.getByLabelText("Name");
+    await user.type(nameInput, "all miners");
+    await user.click(screen.getByText("Save"));
+
+    expect(screen.getByText("A view with this name already exists")).toBeInTheDocument();
+    expect(readPersistedRecord()).toBeNull();
+  });
+
   it("does not render dirty-state actions in the strip — those live in <ViewActions>", () => {
     renderViewsBar(["/?view=needs-attention&status=needs-attention&model=S21"]);
     expect(screen.queryByTestId("views-bar-modified-actions")).not.toBeInTheDocument();

--- a/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewsBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewsBar.tsx
@@ -1,0 +1,473 @@
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import clsx from "clsx";
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  type Modifier,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  horizontalListSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import ViewModal, { type ViewModalState } from "./ViewModal";
+import type { DeviceSet } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import {
+  ALL_MINERS_VIEW_ID,
+  buildUrlForView,
+  canonicalizeSearchParams,
+  findView,
+  type SavedView,
+  VIEW_URL_PARAM,
+  visibleBuiltInViews,
+} from "@/protoFleet/features/fleetManagement/views/savedViews";
+import type { UseMinerViewsResult } from "@/protoFleet/features/fleetManagement/views/useMinerViews";
+import {
+  stripSortFromSearchParams,
+  summarizeFilters,
+  summarizeSort,
+} from "@/protoFleet/features/fleetManagement/views/viewSummary";
+import { Edit, Ellipsis, Plus, Trash } from "@/shared/assets/icons";
+import { iconSizes } from "@/shared/assets/icons/constants";
+import { variants } from "@/shared/components/Button";
+import Dialog from "@/shared/components/Dialog";
+import Popover, { PopoverProvider, popoverSizes, usePopover } from "@/shared/components/Popover";
+import Row from "@/shared/components/Row";
+import { TabStrip, TabStripItem } from "@/shared/components/Tab";
+import { positions } from "@/shared/constants";
+import { useClickOutside } from "@/shared/hooks/useClickOutside";
+
+type ViewsBarProps = {
+  viewsState: UseMinerViewsResult;
+  availableGroups: DeviceSet[];
+  availableRacks: DeviceSet[];
+  className?: string;
+};
+
+/**
+ * Pin the drag transform to the X axis. Without this dnd-kit lets the dragged
+ * tab move vertically too, which causes the tablist to scroll/flicker when the
+ * pointer wanders below the row.
+ */
+const restrictToHorizontalAxis: Modifier = ({ transform }) => ({ ...transform, y: 0 });
+
+type BuiltInTabProps = {
+  view: SavedView;
+  isActive: boolean;
+  isDirty: boolean;
+};
+
+const BuiltInTab = ({ view, isActive, isDirty }: BuiltInTabProps) => (
+  <TabStripItem
+    id={view.id}
+    testId={`views-bar-tab-${view.id}`}
+    label={view.name}
+    tone={isActive && isDirty ? "warning" : "default"}
+  />
+);
+
+type ViewKebabProps = {
+  view: SavedView;
+  isOpen: boolean;
+  setIsOpen: (next: boolean | ((prev: boolean) => boolean)) => void;
+  onRename: (view: SavedView) => void;
+  onDelete: (view: SavedView) => void;
+};
+
+const ViewKebab = ({ view, isOpen, setIsOpen, onRename, onDelete }: ViewKebabProps) => (
+  <>
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        setIsOpen((prev) => !prev);
+      }}
+      className="flex items-center justify-center px-1 pb-2 text-text-primary-70 outline-none hover:text-text-primary focus-visible:underline"
+      aria-label={`Actions for ${view.name}`}
+      aria-haspopup="menu"
+      data-testid={`views-bar-tab-${view.id}-kebab`}
+    >
+      <Ellipsis width={iconSizes.xSmall} />
+    </button>
+    {isOpen ? (
+      <Popover
+        className="!space-y-0 px-4 pt-2 pb-1"
+        position={positions["bottom right"]}
+        size={popoverSizes.small}
+        offset={8}
+        testId={`views-bar-tab-${view.id}-kebab-popover`}
+      >
+        <Row
+          className="text-emphasis-300"
+          testId={`views-bar-tab-${view.id}-rename-action`}
+          onClick={() => {
+            setIsOpen(false);
+            onRename(view);
+          }}
+          compact
+          divider
+          prefixIcon={<Edit width={iconSizes.small} className="text-text-primary-70" />}
+        >
+          Rename
+        </Row>
+        <Row
+          className="text-emphasis-300"
+          testId={`views-bar-tab-${view.id}-delete-action`}
+          onClick={() => {
+            setIsOpen(false);
+            onDelete(view);
+          }}
+          compact
+          divider={false}
+          prefixIcon={<Trash width={iconSizes.small} className="text-text-primary-70" />}
+        >
+          Delete
+        </Row>
+      </Popover>
+    ) : null}
+  </>
+);
+
+type UserTabProps = {
+  view: SavedView;
+  isActive: boolean;
+  isDirty: boolean;
+  onRename: (view: SavedView) => void;
+  onDelete: (view: SavedView) => void;
+};
+
+const UserTabInner = ({ view, isActive, isDirty, onRename, onDelete }: UserTabProps) => {
+  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({ id: view.id });
+  const { triggerRef, setPopoverRenderMode } = usePopover();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  // Tabs render inside an `overflow-x-auto` container, which clips an inline
+  // popover. Portal it out so the menu can extend past the strip.
+  useEffect(() => {
+    setPopoverRenderMode("portal-scrolling");
+  }, [setPopoverRenderMode]);
+
+  useClickOutside({
+    ref: triggerRef,
+    onClickOutside: () => setIsMenuOpen(false),
+    ignoreSelectors: [".popover-content"],
+  });
+
+  // Anchor the popover to the TabStripItem cell, not the kebab button — gives
+  // the menu a wider, more predictable position relative to the visible tab.
+  const wrapperRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setNodeRef(node);
+      triggerRef.current = node;
+    },
+    [setNodeRef, triggerRef],
+  );
+
+  // Use Translate (not Transform) so dnd-kit doesn't apply scaleX/scaleY when
+  // sibling tabs have different widths — that's what causes the dragged tab to
+  // look stretched or squished. While dragging we also paint an opaque surface
+  // background so the floating chip cleanly covers the tabs it passes over.
+  return (
+    <TabStripItem
+      id={view.id}
+      testId={`views-bar-tab-${view.id}`}
+      label={view.name}
+      tone={isActive && isDirty ? "warning" : "default"}
+      trailing={
+        <ViewKebab view={view} isOpen={isMenuOpen} setIsOpen={setIsMenuOpen} onRename={onRename} onDelete={onDelete} />
+      }
+      wrapperRef={wrapperRef}
+      wrapperStyle={{
+        transform: CSS.Translate.toString(transform),
+        transition,
+        cursor: isDragging ? "grabbing" : "grab",
+      }}
+      wrapperProps={{
+        ...attributes,
+        ...listeners,
+        className: clsx("touch-none", isDragging && "z-10 bg-surface-base shadow-100"),
+      }}
+    />
+  );
+};
+
+const UserTab = (props: UserTabProps) => (
+  <PopoverProvider>
+    <UserTabInner {...props} />
+  </PopoverProvider>
+);
+
+type TabActionProps = {
+  text: string;
+  onClick: () => void;
+  testId: string;
+  prefixIcon?: ReactNode;
+};
+
+/**
+ * Tab-styled action: same typography and underline alignment as TabStripItem,
+ * but click triggers an action rather than activating a tab.
+ */
+const TabAction = ({ text, onClick, testId, prefixIcon }: TabActionProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="relative inline-flex items-center gap-1 px-2 pb-2 text-300 text-text-primary-70 outline-none hover:text-text-primary focus-visible:underline"
+    data-testid={testId}
+  >
+    {prefixIcon}
+    <span>{text}</span>
+  </button>
+);
+
+const ViewsBar = ({ viewsState, availableGroups, availableRacks, className }: ViewsBarProps) => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { record, addUserView, reorderUserViews, updateUserViewParams, renameUserView, deleteUserView } = viewsState;
+
+  const [modal, setModal] = useState<ViewModalState>({ open: false });
+  const [deleteConfirm, setDeleteConfirm] = useState<
+    { open: false } | { open: true; viewId: string; viewName: string }
+  >({ open: false });
+
+  const builtIns = useMemo(() => visibleBuiltInViews(record), [record]);
+  const userViews = record.views;
+
+  const currentCanonical = useMemo(() => canonicalizeSearchParams(searchParams), [searchParams]);
+  // No `view=` param + no filters/sort → implicitly the All miners view, so
+  // a fresh URL like "/" still highlights All miners and clicking it is a no-op.
+  const activeViewId = searchParams.get(VIEW_URL_PARAM) ?? (currentCanonical === "" ? ALL_MINERS_VIEW_ID : undefined);
+  const activeView = activeViewId ? findView(activeViewId, record) : undefined;
+  const isDirty = activeView !== undefined && activeView.searchParams !== currentCanonical;
+
+  const filterSummary = useMemo(
+    () => summarizeFilters(searchParams, { availableGroups, availableRacks }),
+    [searchParams, availableGroups, availableRacks],
+  );
+  const sortSummary = useMemo(() => summarizeSort(searchParams), [searchParams]);
+
+  const navigateToView = useCallback(
+    (view: SavedView) => {
+      // All miners is the implicit default state — keep URLs clean.
+      if (view.id === ALL_MINERS_VIEW_ID) {
+        navigate({ search: "" }, { replace: true });
+        return;
+      }
+      navigate(`?${buildUrlForView(view, searchParams)}`, { replace: true });
+    },
+    [navigate, searchParams],
+  );
+
+  /**
+   * After a save/update, sync the URL to the params we just stored so the
+   * view is immediately "clean" — otherwise toggling off Include sort order
+   * leaves sort/dir in the URL and the view shows as dirty post-save.
+   */
+  const navigateToSavedView = useCallback(
+    (viewId: string, savedParams: string) => {
+      const next = new URLSearchParams(savedParams);
+      next.set(VIEW_URL_PARAM, viewId);
+      navigate(`?${next.toString()}`, { replace: true });
+    },
+    [navigate],
+  );
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      const view = findView(id, record);
+      if (!view) return;
+      if (id === activeViewId && !isDirty) return;
+      navigateToView(view);
+    },
+    [record, activeViewId, isDirty, navigateToView],
+  );
+
+  const handleOpenNew = useCallback(() => {
+    setModal({
+      open: true,
+      mode: { kind: "create" },
+      defaultName: "",
+      currentFilters: filterSummary,
+      currentSort: sortSummary,
+    });
+  }, [filterSummary, sortSummary]);
+
+  const handleOpenRename = useCallback(
+    (view: SavedView) => {
+      const viewFilters = summarizeFilters(new URLSearchParams(view.searchParams), { availableGroups, availableRacks });
+      const viewSort = summarizeSort(new URLSearchParams(view.searchParams));
+      // Rename launches the same modal; current = saved → no diff badges,
+      // user is just editing the name.
+      setModal({
+        open: true,
+        mode: {
+          kind: "update",
+          viewId: view.id,
+          currentName: view.name,
+          savedFilters: viewFilters,
+          savedSort: viewSort,
+        },
+        defaultName: view.name,
+        currentFilters: viewFilters,
+        currentSort: viewSort,
+      });
+    },
+    [availableGroups, availableRacks],
+  );
+
+  const handleOpenDelete = useCallback((view: SavedView) => {
+    setDeleteConfirm({ open: true, viewId: view.id, viewName: view.name });
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!deleteConfirm.open) return;
+    const idToDelete = deleteConfirm.viewId;
+    deleteUserView(idToDelete);
+    setDeleteConfirm({ open: false });
+    if (activeViewId === idToDelete) {
+      // Active view just deleted — drop the view param from URL.
+      const next = new URLSearchParams(searchParams);
+      next.delete(VIEW_URL_PARAM);
+      const nextSearch = next.toString();
+      navigate({ search: nextSearch ? `?${nextSearch}` : "" }, { replace: true });
+    }
+  }, [deleteConfirm, deleteUserView, activeViewId, navigate, searchParams]);
+
+  const handleSubmit = useCallback(
+    ({ name, includeSort }: { name: string; includeSort: boolean }) => {
+      if (modal.open && modal.mode.kind === "update") {
+        const targetId = modal.mode.viewId;
+        const target = record.views.find((view) => view.id === targetId);
+        if (!target) {
+          setModal({ open: false });
+          return;
+        }
+        const baseCanonical = targetId === activeViewId ? currentCanonical : target.searchParams;
+        const paramsForView = includeSort ? baseCanonical : stripSortFromSearchParams(baseCanonical);
+        updateUserViewParams(targetId, paramsForView);
+        if (name !== target.name) {
+          renameUserView(targetId, name);
+        }
+        // Only realign the URL when we just edited the *active* view —
+        // renames on a non-active view shouldn't navigate.
+        if (targetId === activeViewId) {
+          navigateToSavedView(targetId, paramsForView);
+        }
+      } else {
+        const paramsForView = includeSort ? currentCanonical : stripSortFromSearchParams(currentCanonical);
+        const newView = addUserView({ name, searchParams: paramsForView });
+        navigateToSavedView(newView.id, paramsForView);
+      }
+      setModal({ open: false });
+    },
+    [
+      modal,
+      record.views,
+      activeViewId,
+      addUserView,
+      currentCanonical,
+      navigateToSavedView,
+      renameUserView,
+      updateUserViewParams,
+    ],
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const activeIndex = userViews.findIndex((view) => view.id === active.id);
+      const overIndex = userViews.findIndex((view) => view.id === over.id);
+      if (activeIndex === -1 || overIndex === -1) return;
+      const next = [...userViews];
+      const [moved] = next.splice(activeIndex, 1);
+      next.splice(overIndex, 0, moved);
+      reorderUserViews(next.map((view) => view.id));
+    },
+    [userViews, reorderUserViews],
+  );
+
+  const existingNames = useMemo(() => {
+    if (modal.open && modal.mode.kind === "update") {
+      const editingId = modal.mode.viewId;
+      return userViews.filter((view) => view.id !== editingId).map((view) => view.name);
+    }
+    return userViews.map((view) => view.name);
+  }, [userViews, modal]);
+
+  return (
+    <>
+      <div className={clsx("sticky left-0 z-2 w-full", className)} data-testid="views-bar">
+        <div className="overflow-x-auto px-6 pt-4 laptop:px-10">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+            modifiers={[restrictToHorizontalAxis]}
+          >
+            <SortableContext items={userViews.map((view) => view.id)} strategy={horizontalListSortingStrategy}>
+              <TabStrip activeId={activeViewId} onSelect={handleSelect} ariaLabel="Saved views">
+                {builtIns.map((view) => (
+                  <BuiltInTab key={view.id} view={view} isActive={view.id === activeViewId} isDirty={isDirty} />
+                ))}
+                {userViews.map((view) => (
+                  <UserTab
+                    key={view.id}
+                    view={view}
+                    isActive={view.id === activeViewId}
+                    isDirty={isDirty}
+                    onRename={handleOpenRename}
+                    onDelete={handleOpenDelete}
+                  />
+                ))}
+                <TabAction
+                  text="New view"
+                  onClick={handleOpenNew}
+                  testId="views-bar-new-view-button"
+                  prefixIcon={<Plus width={iconSizes.xSmall} />}
+                />
+              </TabStrip>
+            </SortableContext>
+          </DndContext>
+        </div>
+      </div>
+
+      <ViewModal
+        state={modal}
+        existingNames={existingNames}
+        onDismiss={() => setModal({ open: false })}
+        onSubmit={handleSubmit}
+      />
+
+      <Dialog
+        open={deleteConfirm.open}
+        title="Delete view"
+        onDismiss={() => setDeleteConfirm({ open: false })}
+        testId="views-bar-delete-dialog"
+        buttons={[
+          { text: "Cancel", onClick: () => setDeleteConfirm({ open: false }), variant: variants.secondary },
+          { text: "Delete", onClick: handleConfirmDelete, variant: variants.danger },
+        ]}
+      >
+        <div className="text-300 text-text-primary-70">
+          {deleteConfirm.open ? `Delete the view "${deleteConfirm.viewName}"? This can't be undone.` : null}
+        </div>
+      </Dialog>
+    </>
+  );
+};
+
+export default ViewsBar;

--- a/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewsBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ViewsBar/ViewsBar.tsx
@@ -400,13 +400,17 @@ const ViewsBar = ({ viewsState, availableGroups, availableRacks, className }: Vi
     [userViews, reorderUserViews],
   );
 
+  // Reserve built-in names too — otherwise a user view named "All miners"
+  // would collide with the built-in tab and produce duplicate labels.
   const existingNames = useMemo(() => {
+    const builtInNames = builtIns.map((view) => view.name);
     if (modal.open && modal.mode.kind === "update") {
       const editingId = modal.mode.viewId;
-      return userViews.filter((view) => view.id !== editingId).map((view) => view.name);
+      const otherUserNames = userViews.filter((view) => view.id !== editingId).map((view) => view.name);
+      return [...builtInNames, ...otherUserNames];
     }
-    return userViews.map((view) => view.name);
-  }, [userViews, modal]);
+    return [...builtInNames, ...userViews.map((view) => view.name)];
+  }, [builtIns, userViews, modal]);
 
   return (
     <>

--- a/client/src/protoFleet/features/fleetManagement/components/ViewsBar/index.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/ViewsBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ViewsBar";

--- a/client/src/protoFleet/features/fleetManagement/views/savedViews.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/savedViews.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILT_IN_VIEWS,
+  canonicalizeSearchParams,
+  createDefaultSavedViewsRecord,
+  createUserView,
+  findView,
+  getSavedViewsStorageKey,
+  isBuiltInViewId,
+  isSavedViewsRecordDefault,
+  normalizeSavedViewsRecord,
+  type SavedViewsRecord,
+  VIEW_URL_PARAM,
+  VIEWS_SCHEMA_VERSION,
+  visibleBuiltInViews,
+} from "./savedViews";
+
+describe("savedViews helpers", () => {
+  describe("canonicalizeSearchParams", () => {
+    it("sorts keys and values, dropping the view key", () => {
+      expect(canonicalizeSearchParams("status=offline&model=S21&view=foo&status=hashing")).toBe(
+        "model=S21&status=hashing&status=offline",
+      );
+    });
+
+    it("is idempotent", () => {
+      const once = canonicalizeSearchParams("model=S21&status=offline");
+      const twice = canonicalizeSearchParams(once);
+      expect(twice).toBe(once);
+    });
+
+    it("treats URLSearchParams and string equivalently", () => {
+      const params = new URLSearchParams("status=hashing&status=offline&model=S21");
+      expect(canonicalizeSearchParams(params)).toBe(
+        canonicalizeSearchParams("status=hashing&status=offline&model=S21"),
+      );
+    });
+  });
+
+  describe("normalizeSavedViewsRecord", () => {
+    it("returns default record for non-object input", () => {
+      expect(normalizeSavedViewsRecord(null)).toEqual(createDefaultSavedViewsRecord());
+      expect(normalizeSavedViewsRecord("oops")).toEqual(createDefaultSavedViewsRecord());
+      expect(normalizeSavedViewsRecord(42)).toEqual(createDefaultSavedViewsRecord());
+    });
+
+    it("drops malformed view entries and de-dupes by id", () => {
+      const result = normalizeSavedViewsRecord({
+        version: VIEWS_SCHEMA_VERSION,
+        views: [
+          { id: "a", name: "First", searchParams: "status=offline", createdAt: "2026-04-30T00:00:00.000Z" },
+          { id: "a", name: "Duplicate", searchParams: "status=hashing", createdAt: "2026-04-30T00:00:00.000Z" },
+          { id: "", name: "Empty id", searchParams: "" },
+          null,
+          { id: "b", name: "Second" },
+          { id: "c", searchParams: "model=S21" },
+        ],
+        deletedBuiltInIds: ["needs-attention", "needs-attention", "offline"],
+      });
+
+      expect(result.views.map((view) => view.id)).toEqual(["a"]);
+      expect(result.deletedBuiltInIds).toEqual(["needs-attention", "offline"]);
+    });
+
+    it("rejects entries that collide with built-in ids", () => {
+      const result = normalizeSavedViewsRecord({
+        version: VIEWS_SCHEMA_VERSION,
+        views: [{ id: "all-miners", name: "Sneaky", searchParams: "" }],
+        deletedBuiltInIds: [],
+      });
+      expect(result.views).toEqual([]);
+    });
+
+    it("canonicalizes searchParams on read", () => {
+      const result = normalizeSavedViewsRecord({
+        version: VIEWS_SCHEMA_VERSION,
+        views: [
+          {
+            id: "a",
+            name: "Mixed",
+            searchParams: "status=offline&model=S21&view=ignored",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+        ],
+        deletedBuiltInIds: [],
+      });
+      expect(result.views[0].searchParams).toBe("model=S21&status=offline");
+    });
+  });
+
+  describe("findView", () => {
+    const record: SavedViewsRecord = {
+      version: VIEWS_SCHEMA_VERSION,
+      views: [{ id: "u1", name: "User one", searchParams: "model=S21", createdAt: "2026-04-30T00:00:00.000Z" }],
+      deletedBuiltInIds: ["offline"],
+    };
+
+    it("finds user views", () => {
+      expect(findView("u1", record)?.name).toBe("User one");
+    });
+
+    it("finds visible built-ins", () => {
+      expect(findView("all-miners", record)?.name).toBe("All miners");
+    });
+
+    it("returns undefined for dismissed built-ins", () => {
+      expect(findView("offline", record)).toBeUndefined();
+    });
+
+    it("returns undefined for unknown ids", () => {
+      expect(findView("nope", record)).toBeUndefined();
+    });
+  });
+
+  describe("visibleBuiltInViews", () => {
+    it("filters dismissed built-ins, preserving order", () => {
+      const record: SavedViewsRecord = {
+        version: VIEWS_SCHEMA_VERSION,
+        views: [],
+        deletedBuiltInIds: ["needs-attention"],
+      };
+      expect(visibleBuiltInViews(record).map((view) => view.id)).toEqual(["all-miners", "offline"]);
+    });
+  });
+
+  describe("createUserView", () => {
+    it("canonicalizes searchParams and yields unique ids", () => {
+      const a = createUserView({ name: "A", searchParams: "status=offline&view=ignore" });
+      const b = createUserView({ name: "B", searchParams: "status=offline" });
+      expect(a.searchParams).toBe("status=offline");
+      expect(b.searchParams).toBe("status=offline");
+      expect(a.id).not.toBe(b.id);
+    });
+  });
+
+  describe("misc", () => {
+    it("isBuiltInViewId reflects BUILT_IN_VIEWS", () => {
+      for (const view of BUILT_IN_VIEWS) {
+        expect(isBuiltInViewId(view.id)).toBe(true);
+      }
+      expect(isBuiltInViewId("not-a-builtin")).toBe(false);
+    });
+
+    it("isSavedViewsRecordDefault detects empty record", () => {
+      expect(isSavedViewsRecordDefault(createDefaultSavedViewsRecord())).toBe(true);
+      expect(
+        isSavedViewsRecordDefault({
+          version: VIEWS_SCHEMA_VERSION,
+          views: [],
+          deletedBuiltInIds: ["offline"],
+        }),
+      ).toBe(false);
+    });
+
+    it("getSavedViewsStorageKey scopes by username", () => {
+      expect(getSavedViewsStorageKey("alice")).toBe("proto-fleet-miner-views:alice");
+      expect(getSavedViewsStorageKey("")).toBe("proto-fleet-miner-views:anonymous");
+    });
+
+    it("VIEW_URL_PARAM matches the URL key used for active view", () => {
+      expect(VIEW_URL_PARAM).toBe("view");
+    });
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/views/savedViews.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/savedViews.test.ts
@@ -35,6 +35,10 @@ describe("savedViews helpers", () => {
         canonicalizeSearchParams("status=hashing&status=offline&model=S21"),
       );
     });
+
+    it("drops keys outside the filter+sort+view set so unrelated URL state never enters a saved view", () => {
+      expect(canonicalizeSearchParams("status=offline&page=3&debug=1&utm_source=test")).toBe("status=offline");
+    });
   });
 
   describe("normalizeSavedViewsRecord", () => {

--- a/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
@@ -96,16 +96,19 @@ export const createDefaultSavedViewsRecord = (): SavedViewsRecord => ({
 export const getSavedViewsStorageKey = (username: string): string => `${STORAGE_KEY_PREFIX}:${username || "anonymous"}`;
 
 /**
- * Sort URLSearchParams entries deterministically and drop the `view` key
- * so two states can be compared by string equality.
+ * Sort the filter+sort URL entries deterministically so two states can be
+ * compared by string equality. Keys outside the filter+sort set (including
+ * the `view` key and any unrelated URL state) are dropped, so a saved view
+ * never accidentally captures transient query params.
  */
 export const canonicalizeSearchParams = (params: URLSearchParams | string): string => {
   const source = typeof params === "string" ? new URLSearchParams(params) : new URLSearchParams(params);
-  source.delete(VIEW_URL_PARAM);
 
   const entries: [string, string][] = [];
   source.forEach((value, key) => {
-    entries.push([key, value]);
+    if (FILTER_AND_SORT_KEYS.has(key)) {
+      entries.push([key, value]);
+    }
   });
   entries.sort(([aKey, aValue], [bKey, bValue]) => {
     if (aKey !== bKey) return aKey < bKey ? -1 : 1;

--- a/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
@@ -1,0 +1,205 @@
+/**
+ * Saved miner-list views: filters + sort bundled into named, persistable
+ * presets. See docs/plans/2026-04-30-custom-views.md.
+ */
+
+const STORAGE_KEY_PREFIX = "proto-fleet-miner-views";
+
+export const VIEWS_SCHEMA_VERSION = 1;
+
+/** URL search-param key that records the active view id. */
+export const VIEW_URL_PARAM = "view";
+
+/** Built-in view id for the unfiltered default — kept as a clean URL. */
+export const ALL_MINERS_VIEW_ID = "all-miners";
+
+/** URL keys owned by filter + sort + view machinery. */
+const FILTER_AND_SORT_KEYS: ReadonlySet<string> = new Set([
+  "status",
+  "issues",
+  "model",
+  "group",
+  "rack",
+  "firmware",
+  "zone",
+  "sort",
+  "dir",
+]);
+
+/**
+ * Build the URL params for activating a view. Layers the view's own
+ * (canonical) params on top of any current params that are unrelated to
+ * filter/sort/view, so unrelated URL keys aren't dropped on activation.
+ */
+export const buildUrlForView = (view: SavedView, currentParams: URLSearchParams): string => {
+  const next = new URLSearchParams(view.searchParams);
+  next.set(VIEW_URL_PARAM, view.id);
+  currentParams.forEach((value, key) => {
+    if (key === VIEW_URL_PARAM) return;
+    if (next.has(key)) return;
+    if (FILTER_AND_SORT_KEYS.has(key)) return;
+    next.append(key, value);
+  });
+  return next.toString();
+};
+
+export type SavedView = {
+  id: string;
+  name: string;
+  /** Canonical URLSearchParams string, sans the `view` key. */
+  searchParams: string;
+  createdAt: string;
+};
+
+export type SavedViewsRecord = {
+  version: typeof VIEWS_SCHEMA_VERSION;
+  views: SavedView[];
+  deletedBuiltInIds: string[];
+};
+
+export type BuiltInView = SavedView & { builtIn: true };
+
+export const BUILT_IN_VIEWS: readonly BuiltInView[] = [
+  {
+    id: ALL_MINERS_VIEW_ID,
+    name: "All miners",
+    searchParams: "",
+    createdAt: "1970-01-01T00:00:00.000Z",
+    builtIn: true,
+  },
+  {
+    id: "needs-attention",
+    name: "Needs attention",
+    searchParams: "status=needs-attention",
+    createdAt: "1970-01-01T00:00:00.000Z",
+    builtIn: true,
+  },
+  {
+    id: "offline",
+    name: "Offline",
+    searchParams: "status=offline",
+    createdAt: "1970-01-01T00:00:00.000Z",
+    builtIn: true,
+  },
+];
+
+const BUILT_IN_IDS: ReadonlySet<string> = new Set(BUILT_IN_VIEWS.map((view) => view.id));
+
+export const isBuiltInViewId = (id: string): boolean => BUILT_IN_IDS.has(id);
+
+export const createDefaultSavedViewsRecord = (): SavedViewsRecord => ({
+  version: VIEWS_SCHEMA_VERSION,
+  views: [],
+  deletedBuiltInIds: [],
+});
+
+export const getSavedViewsStorageKey = (username: string): string => `${STORAGE_KEY_PREFIX}:${username || "anonymous"}`;
+
+/**
+ * Sort URLSearchParams entries deterministically and drop the `view` key
+ * so two states can be compared by string equality.
+ */
+export const canonicalizeSearchParams = (params: URLSearchParams | string): string => {
+  const source = typeof params === "string" ? new URLSearchParams(params) : new URLSearchParams(params);
+  source.delete(VIEW_URL_PARAM);
+
+  const entries: [string, string][] = [];
+  source.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  entries.sort(([aKey, aValue], [bKey, bValue]) => {
+    if (aKey !== bKey) return aKey < bKey ? -1 : 1;
+    if (aValue !== bValue) return aValue < bValue ? -1 : 1;
+    return 0;
+  });
+
+  const out = new URLSearchParams();
+  entries.forEach(([key, value]) => {
+    out.append(key, value);
+  });
+  return out.toString();
+};
+
+const isNonEmptyString = (value: unknown): value is string => typeof value === "string" && value.length > 0;
+
+const normalizeSavedView = (raw: unknown): SavedView | null => {
+  if (typeof raw !== "object" || raw === null) return null;
+  const candidate = raw as Partial<SavedView>;
+
+  if (!isNonEmptyString(candidate.id)) return null;
+  if (isBuiltInViewId(candidate.id)) return null;
+  if (!isNonEmptyString(candidate.name)) return null;
+  if (typeof candidate.searchParams !== "string") return null;
+
+  const createdAt = isNonEmptyString(candidate.createdAt) ? candidate.createdAt : new Date().toISOString();
+
+  return {
+    id: candidate.id,
+    name: candidate.name,
+    searchParams: canonicalizeSearchParams(candidate.searchParams),
+    createdAt,
+  };
+};
+
+export const normalizeSavedViewsRecord = (raw: unknown): SavedViewsRecord => {
+  if (typeof raw !== "object" || raw === null) {
+    return createDefaultSavedViewsRecord();
+  }
+  const candidate = raw as Partial<SavedViewsRecord>;
+
+  const views: SavedView[] = [];
+  const seenIds = new Set<string>();
+  for (const entry of Array.isArray(candidate.views) ? candidate.views : []) {
+    const normalized = normalizeSavedView(entry);
+    if (!normalized || seenIds.has(normalized.id)) continue;
+    seenIds.add(normalized.id);
+    views.push(normalized);
+  }
+
+  const deletedBuiltInIds: string[] = [];
+  const seenDeleted = new Set<string>();
+  for (const id of Array.isArray(candidate.deletedBuiltInIds) ? candidate.deletedBuiltInIds : []) {
+    if (typeof id !== "string" || seenDeleted.has(id)) continue;
+    seenDeleted.add(id);
+    deletedBuiltInIds.push(id);
+  }
+
+  return {
+    version: VIEWS_SCHEMA_VERSION,
+    views,
+    deletedBuiltInIds,
+  };
+};
+
+export const isSavedViewsRecordDefault = (record: SavedViewsRecord): boolean =>
+  record.views.length === 0 && record.deletedBuiltInIds.length === 0;
+
+/**
+ * Built-in views the user hasn't dismissed, in declaration order.
+ */
+export const visibleBuiltInViews = (record: SavedViewsRecord): BuiltInView[] => {
+  const dismissed = new Set(record.deletedBuiltInIds);
+  return BUILT_IN_VIEWS.filter((view) => !dismissed.has(view.id));
+};
+
+export const findView = (id: string, record: SavedViewsRecord): SavedView | undefined => {
+  if (isBuiltInViewId(id)) {
+    if (record.deletedBuiltInIds.includes(id)) return undefined;
+    return BUILT_IN_VIEWS.find((view) => view.id === id);
+  }
+  return record.views.find((view) => view.id === id);
+};
+
+const generateUserViewId = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `view-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+};
+
+export const createUserView = (input: { name: string; searchParams: string }): SavedView => ({
+  id: generateUserViewId(),
+  name: input.name,
+  searchParams: canonicalizeSearchParams(input.searchParams),
+  createdAt: new Date().toISOString(),
+});

--- a/client/src/protoFleet/features/fleetManagement/views/useMinerViews.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/views/useMinerViews.test.tsx
@@ -1,0 +1,186 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getSavedViewsStorageKey } from "./savedViews";
+import useMinerViews from "./useMinerViews";
+
+const KEY_ALICE = getSavedViewsStorageKey("alice");
+const KEY_BOB = getSavedViewsStorageKey("bob");
+
+describe("useMinerViews", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts with default record when storage is empty", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+    expect(result.current.record.views).toEqual([]);
+    expect(result.current.record.deletedBuiltInIds).toEqual([]);
+  });
+
+  it("hydrates from existing localStorage payload", () => {
+    localStorage.setItem(
+      KEY_ALICE,
+      JSON.stringify({
+        version: 1,
+        views: [{ id: "u1", name: "User one", searchParams: "model=S21", createdAt: "2026-04-30T00:00:00.000Z" }],
+        deletedBuiltInIds: ["offline"],
+      }),
+    );
+
+    const { result } = renderHook(() => useMinerViews("alice"));
+    expect(result.current.record.views).toHaveLength(1);
+    expect(result.current.record.views[0].name).toBe("User one");
+    expect(result.current.record.deletedBuiltInIds).toEqual(["offline"]);
+  });
+
+  it("falls back to default record on corrupt JSON", () => {
+    localStorage.setItem(KEY_ALICE, "{not json");
+    const { result } = renderHook(() => useMinerViews("alice"));
+    expect(result.current.record.views).toEqual([]);
+    expect(result.current.record.deletedBuiltInIds).toEqual([]);
+  });
+
+  it("addUserView roundtrips through localStorage", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+
+    act(() => {
+      result.current.addUserView({ name: "S21", searchParams: "status=hashing&model=S21" });
+    });
+
+    expect(result.current.record.views).toHaveLength(1);
+    expect(result.current.record.views[0].name).toBe("S21");
+    expect(result.current.record.views[0].searchParams).toBe("model=S21&status=hashing");
+
+    const stored = JSON.parse(localStorage.getItem(KEY_ALICE) ?? "{}");
+    expect(stored.views[0].name).toBe("S21");
+  });
+
+  it("renameUserView updates the stored name", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      result.current.addUserView({ name: "First", searchParams: "" });
+    });
+    const id = result.current.record.views[0].id;
+    act(() => {
+      result.current.renameUserView(id, "Renamed");
+    });
+    expect(result.current.record.views[0].name).toBe("Renamed");
+  });
+
+  it("renameUserView ignores empty/whitespace names", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      result.current.addUserView({ name: "Keep", searchParams: "" });
+    });
+    const id = result.current.record.views[0].id;
+    act(() => {
+      result.current.renameUserView(id, "   ");
+    });
+    expect(result.current.record.views[0].name).toBe("Keep");
+  });
+
+  it("updateUserViewParams canonicalizes new params", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      result.current.addUserView({ name: "Mixed", searchParams: "status=offline" });
+    });
+    const id = result.current.record.views[0].id;
+    act(() => {
+      result.current.updateUserViewParams(id, "view=ignored&status=hashing&model=S21");
+    });
+    expect(result.current.record.views[0].searchParams).toBe("model=S21&status=hashing");
+  });
+
+  it("deleteUserView removes the entry", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      result.current.addUserView({ name: "A", searchParams: "" });
+      result.current.addUserView({ name: "B", searchParams: "model=S21" });
+    });
+    const idA = result.current.record.views[0].id;
+    act(() => {
+      result.current.deleteUserView(idA);
+    });
+    expect(result.current.record.views.map((view) => view.name)).toEqual(["B"]);
+  });
+
+  it("reorderUserViews respects the supplied id order", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      result.current.addUserView({ name: "A", searchParams: "" });
+      result.current.addUserView({ name: "B", searchParams: "model=S21" });
+      result.current.addUserView({ name: "C", searchParams: "status=offline" });
+    });
+    const ids = result.current.record.views.map((view) => view.id);
+    act(() => {
+      result.current.reorderUserViews([ids[2], ids[0], ids[1]]);
+    });
+    expect(result.current.record.views.map((view) => view.name)).toEqual(["C", "A", "B"]);
+  });
+
+  it("dismissBuiltInView and restoreBuiltInView toggle the dismissal", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      result.current.dismissBuiltInView("offline");
+    });
+    expect(result.current.record.deletedBuiltInIds).toEqual(["offline"]);
+    act(() => {
+      result.current.dismissBuiltInView("offline");
+    });
+    expect(result.current.record.deletedBuiltInIds).toEqual(["offline"]);
+    act(() => {
+      result.current.restoreBuiltInView("offline");
+    });
+    expect(result.current.record.deletedBuiltInIds).toEqual([]);
+  });
+
+  it("dismissBuiltInView ignores unknown ids", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      result.current.dismissBuiltInView("not-a-builtin");
+    });
+    expect(result.current.record.deletedBuiltInIds).toEqual([]);
+  });
+
+  it("scopes records by username", () => {
+    const alice = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      alice.result.current.addUserView({ name: "Alice view", searchParams: "model=S21" });
+    });
+    expect(localStorage.getItem(KEY_ALICE)).toBeTruthy();
+    expect(localStorage.getItem(KEY_BOB)).toBeNull();
+
+    const bob = renderHook(() => useMinerViews("bob"));
+    expect(bob.result.current.record.views).toEqual([]);
+  });
+
+  it("clearing storage restores built-ins (no dismissals on next read)", () => {
+    const first = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      first.result.current.dismissBuiltInView("offline");
+    });
+    expect(first.result.current.record.deletedBuiltInIds).toEqual(["offline"]);
+
+    localStorage.clear();
+
+    const second = renderHook(() => useMinerViews("alice"));
+    expect(second.result.current.record.deletedBuiltInIds).toEqual([]);
+  });
+
+  it("removes the storage entry when reverting to default state", () => {
+    const { result } = renderHook(() => useMinerViews("alice"));
+    act(() => {
+      result.current.addUserView({ name: "Temp", searchParams: "" });
+    });
+    expect(localStorage.getItem(KEY_ALICE)).not.toBeNull();
+    const id = result.current.record.views[0].id;
+    act(() => {
+      result.current.deleteUserView(id);
+    });
+    expect(localStorage.getItem(KEY_ALICE)).toBeNull();
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/views/useMinerViews.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/useMinerViews.ts
@@ -1,0 +1,190 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  canonicalizeSearchParams,
+  createDefaultSavedViewsRecord,
+  createUserView,
+  getSavedViewsStorageKey,
+  isBuiltInViewId,
+  isSavedViewsRecordDefault,
+  normalizeSavedViewsRecord,
+  type SavedView,
+  type SavedViewsRecord,
+} from "./savedViews";
+
+const readSavedViewsRecord = (storageKey: string): SavedViewsRecord => {
+  try {
+    const rawValue = localStorage.getItem(storageKey);
+    if (!rawValue) {
+      return createDefaultSavedViewsRecord();
+    }
+    return normalizeSavedViewsRecord(JSON.parse(rawValue));
+  } catch {
+    return createDefaultSavedViewsRecord();
+  }
+};
+
+const persistSavedViewsRecord = (storageKey: string, record: SavedViewsRecord): void => {
+  try {
+    if (isSavedViewsRecordDefault(record)) {
+      localStorage.removeItem(storageKey);
+      return;
+    }
+    localStorage.setItem(storageKey, JSON.stringify(record));
+  } catch {
+    // Ignore persistence failures and continue using in-memory state.
+  }
+};
+
+type RecordState = {
+  storageKey: string;
+  record: SavedViewsRecord;
+};
+
+export type UseMinerViewsResult = {
+  record: SavedViewsRecord;
+  addUserView: (input: { name: string; searchParams: string }) => SavedView;
+  renameUserView: (id: string, name: string) => void;
+  updateUserViewParams: (id: string, searchParams: string) => void;
+  deleteUserView: (id: string) => void;
+  reorderUserViews: (orderedIds: string[]) => void;
+  dismissBuiltInView: (id: string) => void;
+  restoreBuiltInView: (id: string) => void;
+};
+
+const useMinerViews = (username: string): UseMinerViewsResult => {
+  const storageKey = useMemo(() => getSavedViewsStorageKey(username), [username]);
+  const [recordState, setRecordState] = useState<RecordState>(() => ({
+    storageKey,
+    record: readSavedViewsRecord(storageKey),
+  }));
+
+  // Re-key when the username changes (e.g. after sign-out/sign-in).
+  const record = useMemo(
+    () => (recordState.storageKey === storageKey ? recordState.record : readSavedViewsRecord(storageKey)),
+    [recordState.record, recordState.storageKey, storageKey],
+  );
+
+  // Functional updater so consecutive mutations within a single React batch
+  // each read the latest state. Persistence happens inside the updater so it
+  // can never lag the in-memory state. Callers that detect a no-op can return
+  // the same reference to short-circuit the localStorage write + re-render.
+  const commit = useCallback(
+    (updater: (prev: SavedViewsRecord) => SavedViewsRecord) => {
+      setRecordState((prev) => {
+        const base = prev.storageKey === storageKey ? prev.record : readSavedViewsRecord(storageKey);
+        const draft = updater(base);
+        if (draft === base) return prev;
+        const next = normalizeSavedViewsRecord(draft);
+        persistSavedViewsRecord(storageKey, next);
+        return { storageKey, record: next };
+      });
+    },
+    [storageKey],
+  );
+
+  const addUserView = useCallback<UseMinerViewsResult["addUserView"]>(
+    ({ name, searchParams }) => {
+      const view = createUserView({ name, searchParams });
+      commit((current) => ({
+        ...current,
+        views: [...current.views, view],
+      }));
+      return view;
+    },
+    [commit],
+  );
+
+  const renameUserView = useCallback<UseMinerViewsResult["renameUserView"]>(
+    (id, name) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      commit((current) => {
+        const target = current.views.find((view) => view.id === id);
+        if (!target || target.name === trimmed) return current;
+        return {
+          ...current,
+          views: current.views.map((view) => (view.id === id ? { ...view, name: trimmed } : view)),
+        };
+      });
+    },
+    [commit],
+  );
+
+  const updateUserViewParams = useCallback<UseMinerViewsResult["updateUserViewParams"]>(
+    (id, searchParams) => {
+      const canonical = canonicalizeSearchParams(searchParams);
+      commit((current) => {
+        const target = current.views.find((view) => view.id === id);
+        if (!target || target.searchParams === canonical) return current;
+        return {
+          ...current,
+          views: current.views.map((view) => (view.id === id ? { ...view, searchParams: canonical } : view)),
+        };
+      });
+    },
+    [commit],
+  );
+
+  const deleteUserView = useCallback<UseMinerViewsResult["deleteUserView"]>(
+    (id) => {
+      commit((current) => {
+        if (!current.views.some((view) => view.id === id)) return current;
+        return { ...current, views: current.views.filter((view) => view.id !== id) };
+      });
+    },
+    [commit],
+  );
+
+  const reorderUserViews = useCallback<UseMinerViewsResult["reorderUserViews"]>(
+    (orderedIds) => {
+      const indexById = new Map(orderedIds.map((id, index) => [id, index]));
+      commit((current) => {
+        const next = [...current.views].sort((a, b) => {
+          const aIndex = indexById.has(a.id) ? indexById.get(a.id)! : Number.MAX_SAFE_INTEGER;
+          const bIndex = indexById.has(b.id) ? indexById.get(b.id)! : Number.MAX_SAFE_INTEGER;
+          return aIndex - bIndex;
+        });
+        const sameOrder = next.every((view, i) => view.id === current.views[i]?.id);
+        if (sameOrder) return current;
+        return { ...current, views: next };
+      });
+    },
+    [commit],
+  );
+
+  const dismissBuiltInView = useCallback<UseMinerViewsResult["dismissBuiltInView"]>(
+    (id) => {
+      if (!isBuiltInViewId(id)) return;
+      commit((current) =>
+        current.deletedBuiltInIds.includes(id)
+          ? current
+          : { ...current, deletedBuiltInIds: [...current.deletedBuiltInIds, id] },
+      );
+    },
+    [commit],
+  );
+
+  const restoreBuiltInView = useCallback<UseMinerViewsResult["restoreBuiltInView"]>(
+    (id) => {
+      commit((current) =>
+        current.deletedBuiltInIds.includes(id)
+          ? { ...current, deletedBuiltInIds: current.deletedBuiltInIds.filter((entry) => entry !== id) }
+          : current,
+      );
+    },
+    [commit],
+  );
+
+  return {
+    record,
+    addUserView,
+    renameUserView,
+    updateUserViewParams,
+    deleteUserView,
+    reorderUserViews,
+    dismissBuiltInView,
+    restoreBuiltInView,
+  };
+};
+
+export default useMinerViews;

--- a/client/src/protoFleet/features/fleetManagement/views/viewSummary.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/viewSummary.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { stripSortFromSearchParams, summarizeFilters, summarizeSort } from "./viewSummary";
+import { type DeviceSet, DeviceSetSchema } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+
+const makeDeviceSet = (id: bigint, label: string): DeviceSet => create(DeviceSetSchema, { id, label });
+
+describe("summarizeFilters", () => {
+  const ctx = {
+    availableGroups: [makeDeviceSet(1n, "Site A"), makeDeviceSet(2n, "Site B")],
+    availableRacks: [makeDeviceSet(10n, "R1"), makeDeviceSet(11n, "R2")],
+  };
+
+  it("returns empty list when no filters are present", () => {
+    expect(summarizeFilters(new URLSearchParams(""), ctx)).toEqual([]);
+  });
+
+  it("humanizes statuses", () => {
+    const result = summarizeFilters(new URLSearchParams("status=offline&status=hashing"), ctx);
+    expect(result).toEqual([{ key: "status", label: "Status", values: ["Hashing", "Offline"] }]);
+  });
+
+  it("humanizes issues", () => {
+    const result = summarizeFilters(new URLSearchParams("issues=fans&issues=psu"), ctx);
+    expect(result).toEqual([{ key: "issues", label: "Issues", values: ["Fans", "PSU"] }]);
+  });
+
+  it("preserves model and firmware values verbatim", () => {
+    const result = summarizeFilters(new URLSearchParams("model=S21&model=S19&firmware=1.0.5"), ctx);
+    expect(result).toContainEqual({ key: "model", label: "Model", values: ["S19", "S21"] });
+    expect(result).toContainEqual({ key: "firmware", label: "Firmware", values: ["1.0.5"] });
+  });
+
+  it("looks up group and rack ids against available device sets", () => {
+    const result = summarizeFilters(new URLSearchParams("group=1&group=2&rack=10"), ctx);
+    expect(result).toContainEqual({ key: "group", label: "Groups", values: ["Site A", "Site B"] });
+    expect(result).toContainEqual({ key: "rack", label: "Racks", values: ["R1"] });
+  });
+
+  it("falls back to an id placeholder when a group/rack is not in context", () => {
+    const result = summarizeFilters(new URLSearchParams("group=999"), ctx);
+    expect(result).toEqual([{ key: "group", label: "Groups", values: ["#999"] }]);
+  });
+});
+
+describe("summarizeSort", () => {
+  it("returns undefined when no sort param is set", () => {
+    expect(summarizeSort(new URLSearchParams(""))).toBeUndefined();
+  });
+
+  it("humanizes the field name and defaults direction to desc when missing", () => {
+    expect(summarizeSort(new URLSearchParams("sort=hashrate"))).toEqual({ fieldLabel: "Hashrate", direction: "desc" });
+  });
+
+  it("respects asc direction when present", () => {
+    expect(summarizeSort(new URLSearchParams("sort=name&dir=asc"))).toEqual({ fieldLabel: "Name", direction: "asc" });
+  });
+});
+
+describe("stripSortFromSearchParams", () => {
+  it("removes sort and dir keys, leaving the rest intact", () => {
+    expect(stripSortFromSearchParams("model=S21&sort=hashrate&dir=desc&status=offline")).toBe(
+      "model=S21&status=offline",
+    );
+  });
+
+  it("is a no-op when sort params are absent", () => {
+    expect(stripSortFromSearchParams("model=S21")).toBe("model=S21");
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/views/viewSummary.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/viewSummary.ts
@@ -1,0 +1,180 @@
+import type { DeviceSet } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+
+const STATUS_LABELS: Record<string, string> = {
+  hashing: "Hashing",
+  "needs-attention": "Needs attention",
+  offline: "Offline",
+  sleeping: "Sleeping",
+};
+
+const ISSUE_LABELS: Record<string, string> = {
+  "control-board": "Control board",
+  fans: "Fans",
+  "hash-boards": "Hash boards",
+  psu: "PSU",
+};
+
+const SORT_FIELD_LABELS: Record<string, string> = {
+  name: "Name",
+  "worker-name": "Worker name",
+  ip: "IP address",
+  mac: "MAC address",
+  model: "Model",
+  hashrate: "Hashrate",
+  temp: "Temperature",
+  power: "Power",
+  efficiency: "Efficiency",
+  firmware: "Firmware",
+};
+
+export type FilterSummaryEntry = {
+  /** Stable category key, e.g. "status", for keys + tests. */
+  key: string;
+  /** Human-readable category label, e.g. "Status". */
+  label: string;
+  /** Display values, already humanized. */
+  values: string[];
+};
+
+export type SortSummary = {
+  fieldLabel: string;
+  direction: "asc" | "desc";
+};
+
+const lookupDeviceSetLabels = (ids: string[], deviceSets: DeviceSet[]): string[] => {
+  const labelById = new Map<string, string>();
+  deviceSets.forEach((set) => {
+    labelById.set(String(set.id), set.label);
+  });
+  return ids.map((id) => labelById.get(id) ?? `#${id}`);
+};
+
+const dedupedSorted = (params: URLSearchParams, key: string): string[] =>
+  Array.from(new Set(params.getAll(key)))
+    .filter((value) => value !== "")
+    .sort();
+
+export const summarizeFilters = (
+  params: URLSearchParams,
+  context: { availableGroups: DeviceSet[]; availableRacks: DeviceSet[] },
+): FilterSummaryEntry[] => {
+  const entries: FilterSummaryEntry[] = [];
+
+  const statusValues = dedupedSorted(params, "status").map((value) => STATUS_LABELS[value] ?? value);
+  if (statusValues.length) entries.push({ key: "status", label: "Status", values: statusValues });
+
+  const issueValues = dedupedSorted(params, "issues").map((value) => ISSUE_LABELS[value] ?? value);
+  if (issueValues.length) entries.push({ key: "issues", label: "Issues", values: issueValues });
+
+  const modelValues = dedupedSorted(params, "model");
+  if (modelValues.length) entries.push({ key: "model", label: "Model", values: modelValues });
+
+  const groupValues = dedupedSorted(params, "group");
+  if (groupValues.length) {
+    entries.push({
+      key: "group",
+      label: "Groups",
+      values: lookupDeviceSetLabels(groupValues, context.availableGroups),
+    });
+  }
+
+  const rackValues = dedupedSorted(params, "rack");
+  if (rackValues.length) {
+    entries.push({
+      key: "rack",
+      label: "Racks",
+      values: lookupDeviceSetLabels(rackValues, context.availableRacks),
+    });
+  }
+
+  const firmwareValues = dedupedSorted(params, "firmware");
+  if (firmwareValues.length) entries.push({ key: "firmware", label: "Firmware", values: firmwareValues });
+
+  const zoneValues = dedupedSorted(params, "zone");
+  if (zoneValues.length) entries.push({ key: "zone", label: "Zone", values: zoneValues });
+
+  return entries;
+};
+
+export const summarizeSort = (params: URLSearchParams): SortSummary | undefined => {
+  const sortField = params.get("sort");
+  if (!sortField) return undefined;
+
+  const fieldLabel = SORT_FIELD_LABELS[sortField.toLowerCase()] ?? sortField;
+  const direction = params.get("dir") === "asc" ? "asc" : "desc";
+  return { fieldLabel, direction };
+};
+
+/**
+ * Strips sort/dir keys from a canonical search-params string. Used when the
+ * "Include sort order" toggle is off.
+ */
+export const stripSortFromSearchParams = (searchParams: string): string => {
+  const params = new URLSearchParams(searchParams);
+  params.delete("sort");
+  params.delete("dir");
+  return params.toString();
+};
+
+export type FilterChange = "unchanged" | "added" | "changed";
+
+export type FilterDiffEntry = FilterSummaryEntry & {
+  change: FilterChange;
+  /** Previous values, only set when change === "changed". */
+  previousValues?: string[];
+};
+
+export type FilterDiff = {
+  /** Entries present in the current set, marked with their change status. */
+  current: FilterDiffEntry[];
+  /** Entries that were in the saved view but are absent from current. */
+  removed: FilterSummaryEntry[];
+};
+
+/**
+ * Compares two filter summaries (saved view vs current URL) and classifies
+ * each entry as added/changed/unchanged, plus collects entries that were in
+ * the saved view but no longer exist.
+ */
+export const diffFilterSummaries = (current: FilterSummaryEntry[], saved: FilterSummaryEntry[]): FilterDiff => {
+  const savedByKey = new Map(saved.map((entry) => [entry.key, entry]));
+  const seen = new Set<string>();
+
+  const currentDiff: FilterDiffEntry[] = current.map((entry) => {
+    seen.add(entry.key);
+    const previous = savedByKey.get(entry.key);
+    if (!previous) {
+      return { ...entry, change: "added" };
+    }
+    if (
+      previous.values.length === entry.values.length &&
+      previous.values.every((value, i) => value === entry.values[i])
+    ) {
+      return { ...entry, change: "unchanged" };
+    }
+    return { ...entry, change: "changed", previousValues: previous.values };
+  });
+
+  const removed = saved.filter((entry) => !seen.has(entry.key));
+
+  return { current: currentDiff, removed };
+};
+
+export type SortChange = "unchanged" | "added" | "changed" | "removed";
+
+export type SortDiff = {
+  current: SortSummary | undefined;
+  saved: SortSummary | undefined;
+  change: SortChange;
+};
+
+const sortEqual = (a: SortSummary, b: SortSummary): boolean =>
+  a.fieldLabel === b.fieldLabel && a.direction === b.direction;
+
+export const diffSortSummaries = (current: SortSummary | undefined, saved: SortSummary | undefined): SortDiff => {
+  if (!current && !saved) return { current, saved, change: "unchanged" };
+  if (current && !saved) return { current, saved, change: "added" };
+  if (!current && saved) return { current, saved, change: "removed" };
+  if (current && saved && sortEqual(current, saved)) return { current, saved, change: "unchanged" };
+  return { current, saved, change: "changed" };
+};

--- a/client/src/shared/components/List/Filters/Filters.tsx
+++ b/client/src/shared/components/List/Filters/Filters.tsx
@@ -17,6 +17,12 @@ type FilterProps<ItemType> = {
   onFilter: (activeFilters: ActiveFilters) => void | Promise<void>;
   isServerSide?: boolean;
   headerControls?: ReactNode;
+  /**
+   * Right-aligned content rendered alongside the active filter chips. Appears
+   * inline after the chips so callers can attach actions that visually belong
+   * with them (e.g. "Reset view" / "Update view" for saved views).
+   */
+  chipsRowTrailing?: ReactNode;
   initialActiveFilters?: ActiveFilters;
 };
 
@@ -36,6 +42,7 @@ const Filters = <ItemType,>({
   onFilter,
   isServerSide = false,
   headerControls,
+  chipsRowTrailing,
   initialActiveFilters,
 }: FilterProps<ItemType>) => {
   const defaultActiveFilters = useMemo<ActiveFilters>(
@@ -243,6 +250,8 @@ const Filters = <ItemType,>({
           }
         />
       ))}
+
+      {chipsRowTrailing}
 
       {nestedFilters.map((filter) => {
         const categories: FilterCategory[] = filter.children.map((child) => ({

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -145,6 +145,8 @@ type ListProps<ListItem, ItemKeyValueType, ColKey extends string = keyof ListIte
   onServerFilter?: (filters: ActiveFilters) => Promise<void>;
   filterSize?: keyof typeof sizes;
   headerControls?: ReactNode;
+  /** Right-aligned trailing slot in the active-filter-chips row (renders the row even with no chips). */
+  chipsRowTrailing?: ReactNode;
   items: ListItem[];
   itemKey: keyof ListItem;
   itemSelectable?: boolean;
@@ -662,6 +664,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   onServerFilter,
   filterSize = sizes.compact,
   headerControls,
+  chipsRowTrailing,
   initialSelectedItems = [],
   customSetSelectedItems,
   customSelectedItems,
@@ -912,7 +915,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   );
 
   // Determine if Filters component will render (and handle filtering)
-  const shouldRenderFilters = !!(filters?.length || headerControls);
+  const shouldRenderFilters = !!(filters?.length || headerControls || chipsRowTrailing);
 
   // Update filteredItems when items change
   useEffect(() => {
@@ -1119,7 +1122,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   );
 
   const filtersElement =
-    filters?.length || headerControls ? (
+    filters?.length || headerControls || chipsRowTrailing ? (
       <Filters<ListItem>
         className={clsx("gap-4 py-6", paddingClasses)}
         filterItems={filters ?? []}
@@ -1128,6 +1131,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
         onFilter={isServerSideFiltering ? handleServerFiltering : handleClientFiltering}
         isServerSide={isServerSideFiltering}
         headerControls={headerControls}
+        chipsRowTrailing={chipsRowTrailing}
         initialActiveFilters={initialActiveFilters}
       />
     ) : null;

--- a/client/src/shared/components/Tab/TabStrip.test.tsx
+++ b/client/src/shared/components/Tab/TabStrip.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import TabStrip, { TabStripItem } from "./TabStrip";
+
+describe("TabStrip", () => {
+  it("renders items as tabs and marks the active one with aria-selected", () => {
+    render(
+      <TabStrip activeId="b" onSelect={() => {}} ariaLabel="Demo">
+        <TabStripItem id="a" label="A" testId="tab-a" />
+        <TabStripItem id="b" label="B" testId="tab-b" />
+      </TabStrip>,
+    );
+
+    const tabA = screen.getByTestId("tab-a-activate");
+    const tabB = screen.getByTestId("tab-b-activate");
+
+    expect(tabA).toHaveAttribute("aria-selected", "false");
+    expect(tabB).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("invokes onSelect with the item id when clicked", async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TabStrip activeId="a" onSelect={onSelect}>
+        <TabStripItem id="a" label="A" testId="tab-a" />
+        <TabStripItem id="b" label="B" testId="tab-b" />
+      </TabStrip>,
+    );
+
+    await user.click(screen.getByTestId("tab-b-activate"));
+    expect(onSelect).toHaveBeenCalledWith("b");
+  });
+
+  it("does not call onSelect when the tab is disabled", async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TabStrip activeId="a" onSelect={onSelect}>
+        <TabStripItem id="a" label="A" testId="tab-a" />
+        <TabStripItem id="b" label="B" disabled testId="tab-b" />
+      </TabStrip>,
+    );
+
+    await user.click(screen.getByTestId("tab-b-activate"));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("renders leading and trailing adornments around the activate button", () => {
+    render(
+      <TabStrip activeId="a" onSelect={() => {}}>
+        <TabStripItem
+          id="a"
+          label="A"
+          testId="tab-a"
+          leading={<span data-testid="lead">L</span>}
+          trailing={<span data-testid="trail">T</span>}
+        />
+      </TabStrip>,
+    );
+
+    expect(screen.getByTestId("lead")).toBeInTheDocument();
+    expect(screen.getByTestId("trail")).toBeInTheDocument();
+  });
+
+  it("throws if TabStripItem is rendered outside TabStrip", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<TabStripItem id="a" label="A" />)).toThrow(/inside <TabStrip>/);
+    consoleError.mockRestore();
+  });
+});

--- a/client/src/shared/components/Tab/TabStrip.test.tsx
+++ b/client/src/shared/components/Tab/TabStrip.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import TabStrip, { TabStripItem } from "./TabStrip";
 
 describe("TabStrip", () => {
-  it("renders items as tabs and marks the active one with aria-selected", () => {
+  it("marks the active item with aria-current=page", () => {
     render(
       <TabStrip activeId="b" onSelect={() => {}} ariaLabel="Demo">
         <TabStripItem id="a" label="A" testId="tab-a" />
@@ -15,8 +15,8 @@ describe("TabStrip", () => {
     const tabA = screen.getByTestId("tab-a-activate");
     const tabB = screen.getByTestId("tab-b-activate");
 
-    expect(tabA).toHaveAttribute("aria-selected", "false");
-    expect(tabB).toHaveAttribute("aria-selected", "true");
+    expect(tabA).not.toHaveAttribute("aria-current");
+    expect(tabB).toHaveAttribute("aria-current", "page");
   });
 
   it("invokes onSelect with the item id when clicked", async () => {

--- a/client/src/shared/components/Tab/TabStrip.tsx
+++ b/client/src/shared/components/Tab/TabStrip.tsx
@@ -41,19 +41,25 @@ type TabStripProps = {
 /**
  * Controlled, content-less tab bar. Use `<TabStripItem>` as children.
  * For tabs that own panel content too, use `Tabs` from this same module.
+ *
+ * Note on ARIA: this is a navigation-style tab strip, not an ARIA tabs widget.
+ * Children may include non-tab controls (e.g. "+ New view"), so we don't put
+ * `role="tablist"` on the container, and items use plain buttons rather than
+ * `role="tab"` (we don't implement the ARIA tabs keyboard model — roving
+ * tabindex, arrow keys, Home/End). The active item is announced via
+ * `aria-current="page"` instead.
  */
 const TabStrip = ({ children, activeId, onSelect, className, ariaLabel, trailing }: TabStripProps) => {
   const value = useMemo<TabStripContextValue>(() => ({ activeId, onSelect }), [activeId, onSelect]);
   return (
     <TabStripContext.Provider value={value}>
-      <div
-        role="tablist"
+      <nav
         aria-label={ariaLabel}
         className={clsx("flex w-full items-end space-x-2 border-b-2 border-border-5 whitespace-nowrap", className)}
       >
         {children}
         {trailing ? <div className="ml-auto flex items-end gap-4">{trailing}</div> : null}
-      </div>
+      </nav>
     </TabStripContext.Provider>
   );
 };
@@ -127,8 +133,7 @@ export const TabStripItem = ({
       {leading}
       <button
         type="button"
-        role="tab"
-        aria-selected={isActive}
+        aria-current={isActive ? "page" : undefined}
         disabled={disabled}
         onClick={() => {
           if (!disabled) onSelect(id);

--- a/client/src/shared/components/Tab/TabStrip.tsx
+++ b/client/src/shared/components/Tab/TabStrip.tsx
@@ -1,0 +1,153 @@
+import {
+  createContext,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+  type Ref,
+  useContext,
+  useMemo,
+} from "react";
+import clsx from "clsx";
+
+type TabStripContextValue = {
+  activeId?: string;
+  onSelect: (id: string) => void;
+};
+
+const TabStripContext = createContext<TabStripContextValue | null>(null);
+
+const useTabStripContext = () => {
+  const ctx = useContext(TabStripContext);
+  if (!ctx) {
+    throw new Error("TabStripItem must be rendered inside <TabStrip>");
+  }
+  return ctx;
+};
+
+type TabStripProps = {
+  children: ReactNode;
+  activeId?: string;
+  onSelect: (id: string) => void;
+  className?: string;
+  ariaLabel?: string;
+  /**
+   * Rendered inside the tablist container after the tab items, sharing the
+   * underline. Use for trailing actions that visually belong on the tab row
+   * but aren't selectable tabs (e.g. "Save view").
+   */
+  trailing?: ReactNode;
+};
+
+/**
+ * Controlled, content-less tab bar. Use `<TabStripItem>` as children.
+ * For tabs that own panel content too, use `Tabs` from this same module.
+ */
+const TabStrip = ({ children, activeId, onSelect, className, ariaLabel, trailing }: TabStripProps) => {
+  const value = useMemo<TabStripContextValue>(() => ({ activeId, onSelect }), [activeId, onSelect]);
+  return (
+    <TabStripContext.Provider value={value}>
+      <div
+        role="tablist"
+        aria-label={ariaLabel}
+        className={clsx("flex w-full items-end space-x-2 border-b-2 border-border-5 whitespace-nowrap", className)}
+      >
+        {children}
+        {trailing ? <div className="ml-auto flex items-end gap-4">{trailing}</div> : null}
+      </div>
+    </TabStripContext.Provider>
+  );
+};
+
+export type TabStripItemTone = "default" | "warning";
+
+const TONE_ACTIVE_TEXT: Record<TabStripItemTone, string> = {
+  default: "text-text-emphasis",
+  warning: "text-intent-warning-50",
+};
+
+const TONE_UNDERLINE: Record<TabStripItemTone, string> = {
+  default: "bg-text-emphasis",
+  warning: "bg-intent-warning-50",
+};
+
+export type TabStripItemProps = {
+  id: string;
+  label: ReactNode;
+  /** Rendered before the label inside the tab cell, outside the activate button. */
+  leading?: ReactNode;
+  /** Rendered after the label inside the tab cell, outside the activate button. */
+  trailing?: ReactNode;
+  /** When true, the tab is rendered but cannot be activated. */
+  disabled?: boolean;
+  testId?: string;
+  /**
+   * Color treatment for the tab. "warning" swaps the active text/underline
+   * colors to intent-warning — used to signal a dirty/modified state.
+   * Only applies when the tab is the active one.
+   */
+  tone?: TabStripItemTone;
+  /** Forwarded to the tab cell wrapper — e.g. dnd-kit's `setNodeRef`. */
+  wrapperRef?: Ref<HTMLDivElement>;
+  /** Spread onto the tab cell wrapper — e.g. dnd-kit's `attributes`. */
+  wrapperProps?: HTMLAttributes<HTMLDivElement>;
+  /** Style on the tab cell wrapper — kept separate so consumers can pass dnd transforms. */
+  wrapperStyle?: CSSProperties;
+};
+
+export const TabStripItem = ({
+  id,
+  label,
+  leading,
+  trailing,
+  disabled,
+  testId,
+  tone = "default",
+  wrapperRef,
+  wrapperProps,
+  wrapperStyle,
+}: TabStripItemProps) => {
+  const { activeId, onSelect } = useTabStripContext();
+  const isActive = id === activeId;
+  const activeTextClass = TONE_ACTIVE_TEXT[tone];
+  const underlineClass = TONE_UNDERLINE[tone];
+
+  return (
+    <div
+      ref={wrapperRef}
+      style={wrapperStyle}
+      {...wrapperProps}
+      className={clsx(
+        "relative flex items-center gap-1 px-2 first:pl-0",
+        isActive ? activeTextClass : "text-text-primary-70",
+        wrapperProps?.className,
+      )}
+      data-testid={testId}
+      data-active={isActive ? "true" : undefined}
+    >
+      {leading}
+      <button
+        type="button"
+        role="tab"
+        aria-selected={isActive}
+        disabled={disabled}
+        onClick={() => {
+          if (!disabled) onSelect(id);
+        }}
+        className={clsx(
+          "relative pb-2 text-300 outline-none focus-visible:underline",
+          isActive ? activeTextClass : "hover:text-text-primary",
+          disabled && "cursor-not-allowed opacity-50",
+        )}
+        data-testid={testId ? `${testId}-activate` : undefined}
+      >
+        {isActive ? (
+          <span aria-hidden className={clsx("absolute right-0 bottom-[-0.1rem] left-0 h-0.5", underlineClass)} />
+        ) : null}
+        <span className="relative">{label}</span>
+      </button>
+      {trailing}
+    </div>
+  );
+};
+
+export default TabStrip;

--- a/client/src/shared/components/Tab/index.ts
+++ b/client/src/shared/components/Tab/index.ts
@@ -1,3 +1,6 @@
 import Tabs from "./Tabs";
+import TabStrip, { TabStripItem, type TabStripItemProps } from "./TabStrip";
 
+export { TabStrip, TabStripItem };
+export type { TabStripItemProps };
 export default Tabs;


### PR DESCRIPTION
## Summary

<img width="1103" height="346" alt="image" src="https://github.com/user-attachments/assets/d265245b-7d32-4927-9759-0d23d659e673" />


Adds named view presets that bundle filters + sort and persist per-user to localStorage. Active view is reflected in the URL via `?view=<id>` so views are shareable; built-in defaults (All miners / Needs attention / Offline) ship out of the box. The Miners tab strip supports drag-to-reorder, kebab rename/delete on user views, a New view modal that summarizes filters + lets you opt out of saving sort, and Reset / Update view actions in the filter chip row when an active view is dirty (with a diff-highlighting modal).

This also adds a new shared `<TabStrip>` primitive (controlled, no panels, with leading/trailing slots) and a \`chipsRowTrailing\` slot on the shared `<List>` / `<Filters>` so feature code can mount actions alongside the active filter chips.

Closes #138.

## Test plan

- [ ] Activate each built-in view and verify URL + filter state
- [ ] Save a new view; confirm it persists across reload
- [ ] Toggle "Include sort order" off — verify saved view + URL both drop sort/dir
- [ ] Modify an active user view; use Reset and Update view in the chip row
- [ ] Rename + delete a user view via the kebab; confirm storage updates
- [ ] Drag-reorder user views; verify order persists
- [ ] Narrow the window with many views — Reset/Update buttons stay visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)