### PR TITLE
Update GitHub workflows dependencies

### DIFF
--- a/.github/workflows/asicrs-plugin-checks.yml
+++ b/.github/workflows/asicrs-plugin-checks.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
+        uses: dtolnay/rust-toolchain@nightly # nightly
         with:
           toolchain: nightly
           components: rustfmt, clippy
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
+        uses: dtolnay/rust-toolchain@nightly # nightly
         with:
           toolchain: nightly
 

--- a/.github/workflows/asicrs-plugin-checks.yml
+++ b/.github/workflows/asicrs-plugin-checks.yml
@@ -30,10 +30,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly # nightly
-        with:
-          toolchain: nightly
-          components: rustfmt, clippy
+        run: |
+          rustup toolchain install nightly --profile minimal --component rustfmt --component clippy --allow-downgrade
+          rustup override set nightly
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -69,9 +68,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly # nightly
-        with:
-          toolchain: nightly
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup override set nightly
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0

--- a/.github/workflows/asicrs-plugin-checks.yml
+++ b/.github/workflows/asicrs-plugin-checks.yml
@@ -30,8 +30,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
+          toolchain: nightly
           components: rustfmt, clippy
 
       - name: Install protoc
@@ -68,7 +69,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
+        with:
+          toolchain: nightly
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0

--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run Codex Security Review
         id: run_codex
         if: ${{ env.OPENAI_API_KEY != '' }}
-        uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1.6
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1.8
         with:
           openai-api-key: ${{ env.OPENAI_API_KEY }}
           model: ${{ env.CODEX_MODEL }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Dependency Review
         if: ${{ !github.event.repository.private }}
-        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-scopes: runtime,unknown
           fail-on-severity: moderate


### PR DESCRIPTION
## Summary
- Bumps the pinned GitHub Actions dependencies used by dependency review and Codex security review workflows.
- Replaces the unpinned `dtolnay/rust-toolchain@nightly` usage in the AsicRS plugin checks with runner-provided `rustup` commands.

## What Changed
- `.github/workflows/dependency-review.yml`: bumps `actions/dependency-review-action` from v4.8.2 to v4.9.0 by pinned commit SHA.
- `.github/workflows/codex-security-review.yml`: bumps `openai/codex-action` from v1.6 to v1.8 by pinned commit SHA.
- `.github/workflows/asicrs-plugin-checks.yml`: removes the `dtolnay/rust-toolchain` action from both Rust jobs.
- `.github/workflows/asicrs-plugin-checks.yml`: the lint/format job now runs `rustup toolchain install nightly --profile minimal --component rustfmt --component clippy --allow-downgrade` and sets a `nightly` rustup override.
- `.github/workflows/asicrs-plugin-checks.yml`: the build/test job now runs `rustup toolchain install nightly --profile minimal` and sets a `nightly` rustup override.

## Reviewer Notes
- Workflow-only change; no product code, proto files, generated code, or migrations are touched.
- The AsicRS workflow still uses the floating `nightly` Rust toolchain; this branch changes the installation mechanism and removes the third-party Rust toolchain action.
- The `rustup override set nightly` commands run under the jobs' `plugin/asicrs` working directory, so the override applies to the subsequent AsicRS cargo commands.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/asicrs-plugin-checks.yml")'`
- GitHub Actions should validate the workflow behavior on the PR.
