### PR TITLE
Fix activity failed label

### DIFF
--- a/client/src/protoFleet/features/activity/components/ActivityTable.tsx
+++ b/client/src/protoFleet/features/activity/components/ActivityTable.tsx
@@ -75,7 +75,7 @@ const ActivityTable = ({ activities, noDataElement }: ActivityTableProps) => {
                     ? entry.description.replace(/\s*completed\s*/i, " ").trim()
                     : entry.description}
                 </span>
-                {isFailed ? <span className="text-intent-critical shrink-0 text-200">Failed</span> : null}
+                {isFailed ? <span className="sr-only">Failed</span> : null}
               </div>
               <div data-testid="scope" className="text-text-primary">
                 {formatScope(entry.scopeType, entry.scopeLabel, entry.scopeCount || undefined)}

--- a/client/src/protoFleet/features/activity/components/ActivityTable.tsx
+++ b/client/src/protoFleet/features/activity/components/ActivityTable.tsx
@@ -69,13 +69,13 @@ const ActivityTable = ({ activities, noDataElement }: ActivityTableProps) => {
               <div data-testid="type" className="flex items-start gap-2">
                 <div className={clsx("shrink-0", isFailed ? "text-intent-critical" : "text-text-primary")}>
                   <Icon width="w-4" />
+                  {isFailed ? <span className="sr-only">Failed</span> : null}
                 </div>
                 <span className="min-w-0 break-words">
                   {isCompletedEvent(entry.eventType)
                     ? entry.description.replace(/\s*completed\s*/i, " ").trim()
                     : entry.description}
                 </span>
-                {isFailed ? <span className="sr-only">Failed</span> : null}
               </div>
               <div data-testid="scope" className="text-text-primary">
                 {formatScope(entry.scopeType, entry.scopeLabel, entry.scopeCount || undefined)}


### PR DESCRIPTION
## Summary
- Remove the redundant inline `Failed` label from failed activity rows.
- Keep the failed-row alert icon/color and the detail modal's structured result/error display.

## Verification
- `npm exec -- eslint src/protoFleet/features/activity/components/ActivityTable.tsx --max-warnings 0`
- `npm exec -- tsc --noEmit --pretty false`
