### PR TITLE
server: add notifications sidecars

### DIFF
--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -441,6 +441,8 @@ jobs:
           cp deployment-files/client/nginx.https.conf deployment/client/
           cp deployment-files/server/Dockerfile deployment/server/
           cp deployment-files/docker-compose.yaml deployment/
+          cp deployment-files/docker-compose.notifications.yaml deployment/
+          cp -a deployment-files/server/monitoring deployment/server/
           cp server/docker-compose.base.yaml deployment/server/
           cp deployment-files/run-fleet.sh deployment/
           cp deployment-files/uninstall.sh deployment/

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -90,3 +90,45 @@ The script will auto-detect existing certificates and use HTTPS mode automatical
 - Certificate file: `ssl/cert.pem` (PEM format)
 - Private key file: `ssl/key.pem` (PEM format, unencrypted)
 - For LAN access, ensure the certificate includes the server's IP address(es) in the Subject Alternative Names (SANs)
+
+## Notifications
+
+The deployment runs four additional containers that together form the alerting pipeline:
+
+| Service             | Image (pinned)                                       | Purpose                                                                        |
+| ------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `otel-collector`    | `otel/opentelemetry-collector-contrib:0.150.1`       | Receives OTLP from `fleet-api` and forwards metrics to VictoriaMetrics.        |
+| `victoria-metrics`  | `victoriametrics/victoria-metrics:v1.107.0`          | Stores metrics. 30-day retention by default. Persistent volume.                |
+| `vmalert`           | `victoriametrics/vmalert:v1.107.0`                   | Evaluates alert rules against VictoriaMetrics, fires to Alertmanager.          |
+| `alertmanager`      | `prom/alertmanager:v0.27.0`                          | Routes firing alerts to channels (email/webhook). Persistent volume.           |
+
+### Network topology
+
+All four sidecars run on a private docker bridge network called `monitoring`.
+Operators running tools on the box can hit `127.0.0.1:8880` (vmalert),
+`127.0.0.1:9093` (Alertmanager), and `127.0.0.1:4317`/`4318` (OTLP collector) —
+these endpoints are not exposed beyond loopback.
+VictoriaMetrics itself is reachable only from inside the `monitoring` network.
+
+### Enabling the notifications stack
+
+The notifications sidecars are a beta feature and are **off by default**. The
+four sidecars live in a separate compose file,
+`docker-compose.notifications.yaml`, that `run-fleet.sh` layers in via a
+second `-f` flag when the `--enable-beta-notifications` flag is passed. To
+run a fleet with the beta notifications stack:
+
+```bash
+./run-fleet.sh --enable-beta-notifications
+```
+
+### Configuration files
+
+The configs live under `deployment-files/server/monitoring/`:
+
+- `otel-collector.yaml` — read-only OTLP receiver + VictoriaMetrics exporter.
+- `vmalert/rules.yml` — user-rendered rule file (rewritten by ProtoFleet).
+- `vmalert/rules.d/*.yml` — built-in rule groups (e.g. `protofleet-self.yml`)
+  that ship with the deployment and are not mutated by the reload pipeline.
+- `alertmanager/alertmanager.yml` — receivers and routes (rewritten by
+  ProtoFleet).

--- a/deployment-files/docker-compose.notifications.yaml
+++ b/deployment-files/docker-compose.notifications.yaml
@@ -1,0 +1,97 @@
+services:
+  fleet-api:
+    environment:
+      FLEET_NOTIFICATIONS_ENABLED: "${FLEET_NOTIFICATIONS_ENABLED:-true}"
+    depends_on:
+      otel-collector:
+        # service_started, not service_healthy: the contrib image is
+        # distroless and cannot run an in-container HTTP probe.
+        condition: service_started
+      victoria-metrics:
+        condition: service_healthy
+      vmalert:
+        condition: service_healthy
+      alertmanager:
+        condition: service_healthy
+    extra_hosts:
+      - "otel-collector:127.0.0.1"
+      - "victoria-metrics:127.0.0.1"
+      - "vmalert:127.0.0.1"
+      - "alertmanager:127.0.0.1"
+    volumes:
+      - ./server/monitoring/vmalert:/etc/protofleet/monitoring/vmalert:rw
+      - ./server/monitoring/alertmanager:/etc/protofleet/monitoring/alertmanager:rw
+
+  otel-collector:
+    extends:
+      file: ./server/docker-compose.base.yaml
+      service: otel-collector
+    volumes:
+      - ./server/monitoring/otel-collector.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
+        compress: "true"
+
+  victoria-metrics:
+    extends:
+      file: ./server/docker-compose.base.yaml
+      service: victoria-metrics
+    # No host port binding: vmalert and otel-collector both reach VM by
+    # service name on the `monitoring` bridge network. fleet-api never
+    # queries VM directly — it goes through vmalert (Issue 22).
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
+        compress: "true"
+
+  vmalert:
+    extends:
+      file: ./server/docker-compose.base.yaml
+      service: vmalert
+    volumes:
+      - ./server/monitoring/vmalert/rules.yml:/etc/vmalert/rules.yml:rw
+      - ./server/monitoring/vmalert/rules.d:/etc/vmalert/rules.d:ro
+    ports:
+      - "127.0.0.1:8880:8880"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
+        compress: "true"
+
+  alertmanager:
+    extends:
+      file: ./server/docker-compose.base.yaml
+      service: alertmanager
+    volumes:
+      - ./server/monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:rw
+    ports:
+      - "127.0.0.1:9093:9093"
+    # alertmanager's `__protofleet_internal` receiver POSTs to
+    # http://fleet-api:4000/internal/alertmanager-webhook. fleet-api uses
+    # host networking, so we route via the docker host gateway.
+    extra_hosts:
+      - "fleet-api:host-gateway"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
+        compress: "true"
+
+volumes:
+  victoria-metrics-data:
+  alertmanager-data:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/deployment-files/docker-compose.notifications.yaml
+++ b/deployment-files/docker-compose.notifications.yaml
@@ -1,6 +1,7 @@
 services:
   fleet-api:
     environment:
+      FLEET_TELEMETRY_ENABLED: "${FLEET_TELEMETRY_ENABLED:-true}"
       FLEET_NOTIFICATIONS_ENABLED: "${FLEET_NOTIFICATIONS_ENABLED:-true}"
     depends_on:
       otel-collector:

--- a/deployment-files/docker-compose.yaml
+++ b/deployment-files/docker-compose.yaml
@@ -59,11 +59,7 @@ services:
       POSTGRES_PASSWORD: "${DB_PASSWORD}"
     restart: always
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "psql -U ${DB_USERNAME:-fleet} -d ${DB_NAME:-fleet} -c 'SELECT 1' > /dev/null 2>&1",
-        ]
+      test: [ "CMD-SHELL", "psql -U ${DB_USERNAME:-fleet} -d ${DB_NAME:-fleet} -c 'SELECT 1' > /dev/null 2>&1" ]
       interval: 10s
       timeout: 10s
       retries: 18

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -6,7 +6,52 @@
 
 PROJECT_ROOT="$(pwd)"
 COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yaml"
+COMPOSE_NOTIFICATIONS_FILE="$PROJECT_ROOT/docker-compose.notifications.yaml"
 ENV_FILE="$PROJECT_ROOT/.env"
+
+ENABLE_BETA_NOTIFICATIONS=false
+
+usage() {
+    cat <<'EOF'
+Usage: run-fleet.sh [options]
+
+Options:
+  --enable-beta-notifications   Layer in the beta notifications sidecar stack
+                                (otel-collector, victoria-metrics, vmalert,
+                                alertmanager). Off by default.
+  -h, --help                    Show this help and exit.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --enable-beta-notifications)
+            ENABLE_BETA_NOTIFICATIONS=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Error: unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+refresh_compose_files() {
+    COMPOSE_FILES=(-f "$COMPOSE_FILE")
+    if [ "$ENABLE_BETA_NOTIFICATIONS" = "true" ] && [ -f "$COMPOSE_NOTIFICATIONS_FILE" ]; then
+        COMPOSE_FILES+=(-f "$COMPOSE_NOTIFICATIONS_FILE")
+    fi
+}
+refresh_compose_files
 SSL_DIR="$PROJECT_ROOT/ssl"
 SSL_CERT="$SSL_DIR/cert.pem"
 SSL_KEY="$SSL_DIR/key.pem"
@@ -352,7 +397,7 @@ prompt_store_reinit() {
     read -p "   Remove & reinitialize this volume now? ALL DATA WILL BE LOST (y/N): " answer
     if [[ $answer =~ ^[Yy]$ ]]; then
       echo "   Shutting down containers…"
-      docker compose -f "$COMPOSE_FILE" down
+      docker compose "${COMPOSE_FILES[@]}" down --remove-orphans
       echo "   Removing volume $vol…"
       docker volume rm "$vol"
       echo "   Volume removed; new credentials will apply next startup."
@@ -487,6 +532,21 @@ if [ ! -f "$COMPOSE_FILE" ]; then
     exit 1
 fi
 
+# Refresh COMPOSE_FILES and announce the choice to the operator. The
+# --enable-beta-notifications CLI flag (off by default) controls whether the
+# notifications overlay is layered on. When the flag is set the overlay must
+# exist; otherwise we proceed without it.
+refresh_compose_files
+if [ "$ENABLE_BETA_NOTIFICATIONS" = "true" ]; then
+    if [ ! -f "$COMPOSE_NOTIFICATIONS_FILE" ]; then
+        echo "Error: --enable-beta-notifications was passed but $COMPOSE_NOTIFICATIONS_FILE is missing."
+        exit 1
+    fi
+    echo "Notifications stack: enabled (otel-collector, victoria-metrics, vmalert, alertmanager)"
+else
+    echo "Notifications stack: disabled (pass --enable-beta-notifications to turn on the beta notifications sidecars)"
+fi
+
 # ----------------------------------------------------------------------------
 # SSL/TLS Configuration
 # ----------------------------------------------------------------------------
@@ -574,7 +634,7 @@ fi
 # ----------------------------------------------------------------------------
 
 echo "Pulling latest Docker images..."
-docker compose -f "$COMPOSE_FILE" pull
+docker compose "${COMPOSE_FILES[@]}" pull
 
 # Load pre-built TimescaleDB image if available (built in CI for the target architecture)
 TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
@@ -592,22 +652,22 @@ else
 fi
 
 # Build Docker images (fleet-api and fleet-client only; TimescaleDB uses pre-built image)
-docker compose -f "$COMPOSE_FILE" build --no-cache || { echo "Error: Build failed. Exiting."; exit 1; }
+docker compose "${COMPOSE_FILES[@]}" build --no-cache || { echo "Error: Build failed. Exiting."; exit 1; }
 
 # ----------------------------------------------------------------------------
 # Service Management
 # ----------------------------------------------------------------------------
 
 echo "Stopping any running services..."
-docker compose -f "$COMPOSE_FILE" down
+docker compose "${COMPOSE_FILES[@]}" down --remove-orphans
 
 echo "Starting services..."
 # --wait blocks until every service is running (or healthy, when a healthcheck is defined).
 # Without it, `up -d` can exit 0 while containers stay in Created (e.g. port conflicts under
 # host networking), producing a false "Proto Fleet is now running!" banner.
-if ! docker compose -f "$COMPOSE_FILE" up -d --wait --wait-timeout 300; then
+if ! docker compose "${COMPOSE_FILES[@]}" up --remove-orphans -d --wait --wait-timeout 300; then
     echo "Error: services failed to reach running state."
-    echo "Check logs with: docker compose -f \"$COMPOSE_FILE\" logs"
+    echo "Check logs with: docker compose ${COMPOSE_FILES[*]} logs"
     exit 1
 fi
 

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -532,11 +532,6 @@ if [ ! -f "$COMPOSE_FILE" ]; then
     exit 1
 fi
 
-# Refresh COMPOSE_FILES and announce the choice to the operator. The
-# --enable-beta-notifications CLI flag (off by default) controls whether the
-# notifications overlay is layered on. When the flag is set the overlay must
-# exist; otherwise we proceed without it.
-refresh_compose_files
 if [ "$ENABLE_BETA_NOTIFICATIONS" = "true" ]; then
     if [ ! -f "$COMPOSE_NOTIFICATIONS_FILE" ]; then
         echo "Error: --enable-beta-notifications was passed but $COMPOSE_NOTIFICATIONS_FILE is missing."

--- a/deployment-files/server/monitoring/alertmanager/alertmanager.yml
+++ b/deployment-files/server/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,29 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ["alertname", "organization_id", "device_id"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+  receiver: "null"
+  routes:
+    - matchers:
+        - rule_group="protofleet-self"
+      receiver: __protofleet_internal
+      continue: true
+
+receivers:
+  # Placeholder until overwritten
+  - name: "null"
+
+  # Internal receiver: fleet-api receives alerts here and projects them into the activity log.
+  # NOTE: fleet route not yet implemented
+  - name: __protofleet_internal
+    webhook_configs:
+      - url: http://fleet-api:4000/internal/alertmanager-webhook
+        send_resolved: true
+
+inhibit_rules: []
+
+templates: []

--- a/deployment-files/server/monitoring/otel-collector.yaml
+++ b/deployment-files/server/monitoring/otel-collector.yaml
@@ -1,0 +1,48 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+  # Drop noisy resource attributes that would balloon victoria-metrics
+  # cardinality without adding signal value.
+  resource:
+    attributes:
+      - key: process.command_args
+        action: delete
+      - key: process.executable.path
+        action: delete
+      - key: process.runtime.description
+        action: delete
+
+exporters:
+  otlphttp/vm:
+    endpoint: http://victoria-metrics:8428/opentelemetry
+    tls:
+      insecure: true
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 5m
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [resource, batch]
+      exporters: [otlphttp/vm]
+  telemetry:
+    logs:
+      level: info

--- a/deployment-files/server/monitoring/vmalert/rules.d/protofleet-self.yml
+++ b/deployment-files/server/monitoring/vmalert/rules.d/protofleet-self.yml
@@ -1,0 +1,74 @@
+groups:
+  - name: protofleet-self
+    interval: 30s
+    rules:
+      - alert: OTelCollectorDown
+        # vmalert evaluates this against victoria-metrics. The vm_app_uptime
+        # series is emitted by victoria-metrics itself for every OTLP source
+        # it has seen recently; absent_over_time fires when the collector
+        # has stopped writing for 5 minutes.
+        expr: absent_over_time(vm_app_uptime_seconds{job="protofleet-fleet-api"}[5m]) == 1
+        for: 5m
+        labels:
+          severity: critical
+          rule_group: protofleet-self
+          component: otel-collector
+        annotations:
+          summary: "OpenTelemetry Collector has stopped ingesting from fleet-api"
+          description: |
+            No metric samples have arrived from the fleet-api OTLP source for
+            5 minutes. Either the collector is down or the connection from
+            fleet-api to the collector is broken. The fleet may still be
+            healthy, but ProtoFleet cannot tell — alerts will not fire.
+
+      - alert: VMAlertEvaluationStalled
+        # vmalert reports its own last-evaluation timestamp. If it stops
+        # evaluating, no user alerts can fire.
+        expr: time() - max(vmalert_alerting_rules_last_evaluation_timestamp_seconds) > 120
+        for: 5m
+        labels:
+          severity: critical
+          rule_group: protofleet-self
+          component: vmalert
+        annotations:
+          summary: "vmalert rule evaluation has stalled"
+          description: |
+            vmalert has not evaluated any rule group in over 2 minutes. New
+            alert conditions cannot be detected until evaluation resumes.
+
+      - alert: AlertmanagerUnreachable
+        # vmalert exposes notification failure counters. A sustained increase
+        # means alerts are being generated but not delivered.
+        expr: increase(vmalert_alerts_send_errors_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+          rule_group: protofleet-self
+          component: alertmanager
+        annotations:
+          summary: "vmalert cannot deliver alerts to Alertmanager"
+          description: |
+            vmalert recorded delivery errors against Alertmanager in the last
+            5 minutes. Alerts may be evaluated but are not reaching channels.
+
+      - alert: MonitoringStackDegraded
+        # OR over the previous three with a 5-minute `for:` window. Designed
+        # so an operator can wire a single high-priority channel (PagerDuty
+        # etc.) just to this alert and catch any monitoring outage.
+        expr: |
+          (absent_over_time(vm_app_uptime_seconds{job="protofleet-fleet-api"}[5m]) == 1)
+          or
+          ((time() - max(vmalert_alerting_rules_last_evaluation_timestamp_seconds)) > 120)
+          or
+          (increase(vmalert_alerts_send_errors_total[5m]) > 0)
+        for: 5m
+        labels:
+          severity: critical
+          rule_group: protofleet-self
+          component: monitoring-stack
+        annotations:
+          summary: "ProtoFleet monitoring stack is degraded"
+          description: |
+            One or more components of the monitoring pipeline (otel-collector,
+            vmalert, alertmanager) are unhealthy. The fleet may appear quiet
+            because alerts cannot fire, NOT because everything is fine.

--- a/deployment-files/server/monitoring/vmalert/rules.yml
+++ b/deployment-files/server/monitoring/vmalert/rules.yml
@@ -1,0 +1,7 @@
+# vmalert user-rules file.
+# rewritten by proto-fleet
+
+groups:
+  - name: protofleet
+    interval: 30s
+    rules: []

--- a/server/docker-compose.base.yaml
+++ b/server/docker-compose.base.yaml
@@ -107,7 +107,7 @@ services:
       - "4318" # OTLP HTTP ingest
     restart: unless-stopped
     networks:
-      - fleet-network
+      - monitoring
 
   victoria-metrics:
     image: victoriametrics/victoria-metrics:v1.107.0

--- a/server/docker-compose.base.yaml
+++ b/server/docker-compose.base.yaml
@@ -16,9 +16,13 @@ services:
       FLEET_COMMAND_BATCH_STATUS_UPDATE_POLLING_INTERVAL: "1s"
       FLEET_QUEUE_DEQUE_LIMIT: "500"
       FLEET_QUEUE_MAX_FAILURE_RETRIES: "5"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      FLEET_VMALERT_URL: "http://vmalert:8880"
+      FLEET_ALERTMANAGER_URL: "http://alertmanager:9093"
+      FLEET_TELEMETRY_ENDPOINT: "http://otel-collector:4318"
       # HTTP_PPROF_ADDR: "0.0.0.0:6060"  # Uncomment to enable pprof debug server; port mapping below restricts access to host loopback only
-    # ports:
-    #   - "127.0.0.1:6060:6060"  # pprof debug server (requires HTTP_PPROF_ADDR=0.0.0.0:6060)
+      # ports:
+      #   - "127.0.0.1:6060:6060"  # pprof debug server (requires HTTP_PPROF_ADDR=0.0.0.0:6060)
     cap_add:
       - NET_ADMIN
       - NET_RAW
@@ -73,8 +77,7 @@ services:
     volumes:
       - timescaledb-data:/home/postgres/pgdata/data
     healthcheck:
-      test:
-        ["CMD-SHELL", "psql -U fleet -d fleet -c 'SELECT 1' > /dev/null 2>&1"]
+      test: [ "CMD-SHELL", "psql -U fleet -d fleet -c 'SELECT 1' > /dev/null 2>&1" ]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -82,9 +85,105 @@ services:
     networks:
       - fleet-network
 
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.150.1
+    command: [ "--config", "/etc/otelcol-contrib/config.yaml" ]
+    expose:
+      - "4317" # OTLP gRPC ingest
+      - "4318" # OTLP HTTP ingest
+      - "13133" # health_check extension (probed externally — see below)
+    healthcheck:
+      disable: true
+    restart: unless-stopped
+    networks:
+      - monitoring
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.76.0
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    expose:
+      - "4317" # OTLP gRPC ingest
+      - "4318" # OTLP HTTP ingest
+    restart: unless-stopped
+    networks:
+      - fleet-network
+
+  victoria-metrics:
+    image: victoriametrics/victoria-metrics:v1.107.0
+    command:
+      - "-storageDataPath=/storage"
+      - "-retentionPeriod=30d"
+      - "-httpListenAddr=:8428"
+      - "-promscrape.config="
+    expose:
+      - "8428" # write + query API (also the OTLP/HTTP ingest endpoint)
+    volumes:
+      - victoria-metrics-data:/storage
+    healthcheck:
+      test: [ "CMD", "wget", "--spider", "-q", "http://127.0.0.1:8428/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - monitoring
+
+  vmalert:
+    image: victoriametrics/vmalert:v1.107.0
+    depends_on:
+      victoria-metrics:
+        condition: service_healthy
+      alertmanager:
+        condition: service_healthy
+    command:
+      - "-rule=/etc/vmalert/rules.yml"
+      - "-rule=/etc/vmalert/rules.d/*.yml"
+      - "-notifier.url=http://alertmanager:9093"
+      - "-datasource.url=http://victoria-metrics:8428"
+      - "-remoteWrite.url=http://victoria-metrics:8428"
+      - "-httpListenAddr=:8880"
+    expose:
+      - "8880" # API + reload endpoint
+    healthcheck:
+      test: [ "CMD", "wget", "--spider", "-q", "http://127.0.0.1:8880/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - monitoring
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+      - "--web.listen-address=:9093"
+    expose:
+      - "9093"
+    volumes:
+      - alertmanager-data:/alertmanager
+    healthcheck:
+      test: [ "CMD", "wget", "--spider", "-q", "http://127.0.0.1:9093/-/ready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - monitoring
+
 volumes:
   timescaledb-data:
+  victoria-metrics-data:
+  alertmanager-data:
 
 networks:
   fleet-network:
     driver: bridge
+  monitoring:
+    driver: bridge
+    internal: false

--- a/server/docker-compose.notifications.yaml
+++ b/server/docker-compose.notifications.yaml
@@ -1,0 +1,76 @@
+services:
+  fleet-api:
+    environment:
+      FLEET_TELEMETRY_ENABLED: "${FLEET_TELEMETRY_ENABLED:-true}"
+      FLEET_NOTIFICATIONS_ENABLED: "${FLEET_NOTIFICATIONS_ENABLED:-true}"
+    depends_on:
+      otel-collector:
+        condition: service_started
+      victoria-metrics:
+        condition: service_healthy
+      vmalert:
+        condition: service_healthy
+      alertmanager:
+        condition: service_healthy
+    volumes:
+      - ../deployment-files/server/monitoring/vmalert:/etc/protofleet/monitoring/vmalert:rw
+      - ../deployment-files/server/monitoring/alertmanager:/etc/protofleet/monitoring/alertmanager:rw
+    networks:
+      - monitoring
+
+  otel-collector:
+    extends:
+      file: ./docker-compose.base.yaml
+      service: otel-collector
+    depends_on:
+      - jaeger
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+    networks:
+      - monitoring
+
+  jaeger:
+    extends:
+      file: ./docker-compose.base.yaml
+      service: jaeger
+    ports:
+      - "127.0.0.1:16686:16686" # UI
+
+  victoria-metrics:
+    extends:
+      file: ./docker-compose.base.yaml
+      service: victoria-metrics
+    networks:
+      - monitoring
+    ports:
+      - "127.0.0.1:8428:8428"
+
+  vmalert:
+    extends:
+      file: ./docker-compose.base.yaml
+      service: vmalert
+    volumes:
+      - ../deployment-files/server/monitoring/vmalert/rules.yml:/etc/vmalert/rules.yml:rw
+      - ../deployment-files/server/monitoring/vmalert/rules.d:/etc/vmalert/rules.d:ro
+    networks:
+      - monitoring
+    ports:
+      - "127.0.0.1:8880:8880"
+
+  alertmanager:
+    extends:
+      file: ./docker-compose.base.yaml
+      service: alertmanager
+    volumes:
+      - ../deployment-files/server/monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:rw
+    networks:
+      - monitoring
+    ports:
+      - "127.0.0.1:9093:9093"
+
+volumes:
+  victoria-metrics-data:
+  alertmanager-data:

--- a/server/docker-compose.notifications.yaml
+++ b/server/docker-compose.notifications.yaml
@@ -15,8 +15,6 @@ services:
     volumes:
       - ../deployment-files/server/monitoring/vmalert:/etc/protofleet/monitoring/vmalert:rw
       - ../deployment-files/server/monitoring/alertmanager:/etc/protofleet/monitoring/alertmanager:rw
-    networks:
-      - monitoring
 
   otel-collector:
     extends:
@@ -29,8 +27,6 @@ services:
     ports:
       - "127.0.0.1:4317:4317"
       - "127.0.0.1:4318:4318"
-    networks:
-      - monitoring
 
   jaeger:
     extends:
@@ -43,8 +39,6 @@ services:
     extends:
       file: ./docker-compose.base.yaml
       service: victoria-metrics
-    networks:
-      - monitoring
     ports:
       - "127.0.0.1:8428:8428"
 
@@ -55,8 +49,6 @@ services:
     volumes:
       - ../deployment-files/server/monitoring/vmalert/rules.yml:/etc/vmalert/rules.yml:rw
       - ../deployment-files/server/monitoring/vmalert/rules.d:/etc/vmalert/rules.d:ro
-    networks:
-      - monitoring
     ports:
       - "127.0.0.1:8880:8880"
 
@@ -66,11 +58,13 @@ services:
       service: alertmanager
     volumes:
       - ../deployment-files/server/monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:rw
-    networks:
-      - monitoring
     ports:
       - "127.0.0.1:9093:9093"
 
 volumes:
   victoria-metrics-data:
   alertmanager-data:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -43,13 +43,9 @@ services:
       PLUGINS_DIR: "/app/plugins"
       PLUGINS_ENABLED: "true"
       PROTO_MINER_PORT: "8080"
-      FLEET_TELEMETRY_ENABLED: "true"
-      FLEET_TELEMETRY_ENDPOINT: "http://otel-collector:4318"
     depends_on:
       timescaledb:
         condition: service_healthy
-      otel-collector:
-        condition: service_started
     volumes:
       - ./plugins:/app/plugins:ro
     restart: unless-stopped
@@ -101,33 +97,6 @@ services:
       timeout: 3s
       retries: 5
       start_period: 5s
-
-  otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.150.1
-    command: [ "--config", "/etc/otelcol-contrib/config.yaml" ]
-    ports:
-      - "127.0.0.1:4317:4317" # OTLP gRPC
-      - "127.0.0.1:4318:4318" # OTLP HTTP
-    depends_on:
-      - jaeger
-    volumes:
-      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
-    restart: unless-stopped
-    networks:
-      - fleet-network
-
-  jaeger:
-    image: jaegertracing/all-in-one:1.76.0
-    ports:
-      - "127.0.0.1:16686:16686" # UI
-    environment:
-      COLLECTOR_OTLP_ENABLED: "true"
-    expose:
-      - "4317"
-      - "4318"
-    restart: unless-stopped
-    networks:
-      - fleet-network
 
   # Development-specific services
   fake-proto-rig:
@@ -357,10 +326,11 @@ services:
 volumes:
   timescaledb-data:
 
-
 networks:
   fleet-network:
     ipam:
       config:
         - subnet: "192.168.2.0/24"
           gateway: "192.168.2.1"
+  monitoring:
+    driver: bridge

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -332,5 +332,3 @@ networks:
       config:
         - subnet: "192.168.2.0/24"
           gateway: "192.168.2.1"
-  monitoring:
-    driver: bridge

--- a/server/justfile
+++ b/server/justfile
@@ -21,6 +21,10 @@ install:
 dev: _build-plugins-docker start
   docker compose up --watch fleet-api --remove-orphans --no-deps
 
+# run fleet with notifications stack turned on
+dev-notifs: _build-plugins-docker start
+  docker compose -f docker-compose.yaml -f docker-compose.notifications.yaml up --watch fleet-api --remove-orphans --no-deps
+
 # start services in docker compose
 start:
   docker compose up --wait

--- a/server/justfile
+++ b/server/justfile
@@ -22,7 +22,8 @@ dev: _build-plugins-docker start
   docker compose up --watch fleet-api --remove-orphans --no-deps
 
 # run fleet with notifications stack turned on
-dev-notifs: _build-plugins-docker start
+dev-notifs: _build-plugins-docker
+  docker compose -f docker-compose.yaml -f docker-compose.notifications.yaml up --wait
   docker compose -f docker-compose.yaml -f docker-compose.notifications.yaml up --watch fleet-api --remove-orphans --no-deps
 
 # start services in docker compose

--- a/server/otel-collector-config.yaml
+++ b/server/otel-collector-config.yaml
@@ -6,12 +6,30 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 
+processors:
+  batch:
+    timeout: 5s
+
 exporters:
-  otlphttp:
+  # Traces -> jaeger (dev only).
+  otlphttp/jaeger:
     endpoint: http://jaeger:4318
+  # Metrics -> victoria-metrics (OTLP/HTTP write endpoint).
+  otlphttp/vm:
+    endpoint: http://victoria-metrics:8428/opentelemetry
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
 
 service:
+  extensions: [health_check]
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp]
+      processors: [batch]
+      exporters: [otlphttp/jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/vm]


### PR DESCRIPTION
PR for #174:

 - [x] Add `otel-collector`, `victoria-metrics` (with vmalert), and `alertmanager` services to `deployment-files/docker-compose.yaml` and `server/docker-compose.base.yaml`.
 - [x] `FLEET_NOTIFICATIONS_ENABLED` env (default `true`) gates sidecar startup and the notifications surface in the API.
 - [x] Provision starter configs at `deployment-files/server/monitoring/{otel-collector.yaml,vmalert/rules.yml,alertmanager/alertmanager.yml}`.
 - [x] Wire vmalert to alertmanager and victoria-metrics.
 - [x] Built-in `protofleet-self` rule group (always loaded, undeletable from the API): `OTelCollectorDown`, `VMAlertEvaluationStalled`, `AlertmanagerUnreachable`, `MonitoringStackDegraded` with a 5-minute `for:`. Self alerts route to a built-in `__protofleet_internal` receiver that always logs.
 - [x] Update `deployment-files/README.md`

Notes:
 - **This feature is in beta** while it is being developed and is marked as such in the documentation.
 - Users can opt-in to the notifications stack by passing `--enable-beta-notifications` to `fleet-run.sh`
 - There are no metrics being collected atm, will be added in a forthcoming PR.