### PR TITLE
Add rack overview actions E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -91,6 +91,16 @@ export class RacksPage extends BasePage {
     await this.validateTitleInModal("Select miners");
   }
 
+  async filterModalType(type: string) {
+    await this.page.getByTestId("modal").getByTestId("filter-dropdown-Model").click();
+    const popover = this.page.getByTestId("dropdown-filter-popover");
+    await expect(popover).toBeVisible();
+    await expect(popover).toHaveCSS("opacity", "1");
+    await this.clickDropdownFilterOption(popover, type);
+    await popover.getByRole("button", { name: "Apply" }).click();
+    await expect(popover).toBeHidden();
+  }
+
   async waitForMinerSelectorListToLoad() {
     await this.modalMinerList.waitForListToLoad();
   }
@@ -403,6 +413,16 @@ export class RacksPage extends BasePage {
 
   async clickEditRack() {
     await this.clickButton("Edit rack");
+  }
+
+  async openRackOverviewActionsMenu() {
+    await this.page.getByLabel("Device set actions").click();
+    await expect(this.page.getByTestId("group-actions-popover")).toBeVisible();
+  }
+
+  async clickRackOverviewManagePower() {
+    await this.page.getByTestId("manage-power-popover-button").click();
+    await this.validateTitleInModal("Manage power");
   }
 
   async clickDeleteRack() {

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -6,6 +6,7 @@ import { ModalMinerSelectionList } from "./components/modalMinerSelectionList";
 export interface RackSelectorMiner {
   ipAddress: string;
   sortName: string;
+  model: string;
 }
 
 export class RacksPage extends BasePage {
@@ -95,7 +96,6 @@ export class RacksPage extends BasePage {
     await this.page.getByTestId("modal").getByTestId("filter-dropdown-Model").click();
     const popover = this.page.getByTestId("dropdown-filter-popover");
     await expect(popover).toBeVisible();
-    await expect(popover).toHaveCSS("opacity", "1");
     await this.clickDropdownFilterOption(popover, type);
     await popover.getByRole("button", { name: "Apply" }).click();
     await expect(popover).toBeHidden();
@@ -113,6 +113,7 @@ export class RacksPage extends BasePage {
       miners.push({
         ipAddress: await this.modalMinerList.getCellTextByIndex(i, "ipAddress"),
         sortName: await this.modalMinerList.getCellTextByIndex(i, "name"),
+        model: await this.modalMinerList.getCellTextByIndex(i, "type"),
       });
     }
 
@@ -126,6 +127,7 @@ export class RacksPage extends BasePage {
       miners.push({
         ipAddress: await this.modalMinerList.getCellTextByIndex(index, "ipAddress"),
         sortName: await this.modalMinerList.getCellTextByIndex(index, "name"),
+        model: await this.modalMinerList.getCellTextByIndex(index, "type"),
       });
     }
 

--- a/client/e2eTests/protoFleet/spec/racks.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racks.spec.ts
@@ -1,6 +1,7 @@
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";
+import { PROTO_RIG_MODEL } from "../helpers/minerModels";
 import { AuthPage } from "../pages/auth";
 import { MinersPage } from "../pages/miners";
 import { type RackSelectorMiner, RacksPage } from "../pages/racks";
@@ -91,6 +92,31 @@ test.describe("Racks", () => {
     test.expect(slotNumbers).toHaveLength(minerCount);
 
     await racksPage.clickAddMiners();
+    await racksPage.waitForMinerSelectorListToLoad();
+
+    const selectableMinerIndexes = await racksPage.getSelectableMinerIndexes(minerCount);
+    const selectedMiners = await racksPage.getMinersFromSelector(selectableMinerIndexes);
+    await racksPage.selectMinersInSelectorByIndex(selectableMinerIndexes);
+    await racksPage.clickContinueInMinerSelector();
+
+    for (let i = 0; i < selectedMiners.length; i++) {
+      await racksPage.selectRackMiner(selectedMiners[i].ipAddress);
+      await racksPage.clickRackSlot(slotNumbers[i]);
+    }
+
+    return selectedMiners;
+  }
+
+  async function addSelectableRigMinersToSlots(
+    racksPage: RacksPage,
+    minerCount: number,
+    slotNumbers: readonly number[],
+  ): Promise<RackSelectorMiner[]> {
+    test.expect(slotNumbers).toHaveLength(minerCount);
+
+    await racksPage.clickAddMiners();
+    await racksPage.waitForMinerSelectorListToLoad();
+    await racksPage.filterModalType(PROTO_RIG_MODEL);
     await racksPage.waitForMinerSelectorListToLoad();
 
     const selectableMinerIndexes = await racksPage.getSelectableMinerIndexes(minerCount);
@@ -396,6 +422,66 @@ test.describe("Racks", () => {
       await minersPage.validateActiveFilterNotVisible(rackLabel);
       await minersPage.waitForMinersListToLoad();
       await minersPage.validateMinersAdded(expectedVisibleMinerCount);
+    });
+  });
+
+  test("Rack overview actions menu manages power for assigned rig miners", async ({ racksPage, minersPage, page }) => {
+    let rackLabel = "";
+    let selectedMiners: RackSelectorMiner[] = [];
+
+    await test.step("Create and save a new rack with two rig miners", async () => {
+      await racksPage.clickAddRackButton();
+      await racksPage.inputZone(AUTOMATION_ZONE);
+
+      rackLabel = await racksPage.getGeneratedRackLabel();
+      test.expect(rackLabel).toBeTruthy();
+
+      await racksPage.enableCustomRackLayout();
+      await racksPage.inputColumns(RACK_COLUMNS);
+      await racksPage.inputRows(RACK_ROWS);
+      await racksPage.clickContinueFromRackSettings();
+
+      selectedMiners = await addSelectableRigMinersToSlots(racksPage, 2, [1, 2]);
+      test.expect(selectedMiners).toHaveLength(2);
+
+      await racksPage.clickSaveRack();
+      await racksPage.validateRackToast(rackLabel);
+    });
+
+    await test.step("Open the rack overview and validate assigned slots", async () => {
+      await racksPage.clickViewGrid();
+      await racksPage.openRackCard(rackLabel, AUTOMATION_ZONE);
+      await racksPage.validateRackOverviewAssignedSlots([1, 2]);
+    });
+
+    const requestPromise = page.waitForRequest(/SetPowerTarget/);
+    const responsePromise = page.waitForResponse(/SetPowerTarget/);
+
+    await test.step("Use the overview actions menu to reduce power", async () => {
+      await racksPage.openRackOverviewActionsMenu();
+      await racksPage.clickRackOverviewManagePower();
+      await minersPage.clickReducePowerOption();
+      await minersPage.clickManagePowerConfirm();
+    });
+
+    await test.step("Validate manage power toasts", async () => {
+      await minersPage.validateTextInToastGroup("Updating power settings");
+      await minersPage.validateTextInToastGroup("Updated power settings");
+    });
+
+    await test.step("Validate the SetPowerTarget request targets the rack miners", async () => {
+      const request = await requestPromise;
+      const response = await responsePromise;
+      const requestBody = request.postDataJSON();
+
+      test.expect(request.method()).toBe("POST");
+      test.expect(requestBody).toHaveProperty("performanceMode");
+      test.expect(requestBody.performanceMode).toBe("PERFORMANCE_MODE_EFFICIENCY");
+      test.expect(requestBody).toHaveProperty("deviceSelector");
+      test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
+      test.expect(requestBody.deviceSelector.includeDevices).toHaveProperty("deviceIdentifiers");
+      test.expect(requestBody.deviceSelector.includeDevices.deviceIdentifiers).toHaveLength(2);
+      test.expect(response.status()).toBe(200);
     });
   });
 

--- a/client/e2eTests/protoFleet/spec/racks.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racks.spec.ts
@@ -428,8 +428,11 @@ test.describe("Racks", () => {
   test("Rack overview actions menu manages power for assigned rig miners", async ({ racksPage, minersPage, page }) => {
     let rackLabel = "";
     let selectedMiners: RackSelectorMiner[] = [];
+    let rackDeviceIdentifiers: string[] = [];
 
     await test.step("Create and save a new rack with two rig miners", async () => {
+      const saveRackRequestPromise = page.waitForRequest(/SaveRack/);
+
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
 
@@ -443,9 +446,16 @@ test.describe("Racks", () => {
 
       selectedMiners = await addSelectableRigMinersToSlots(racksPage, 2, [1, 2]);
       test.expect(selectedMiners).toHaveLength(2);
+      test.expect(selectedMiners.every((miner) => miner.model === PROTO_RIG_MODEL)).toBe(true);
 
       await racksPage.clickSaveRack();
+
+      const saveRackRequest = await saveRackRequestPromise;
+      const saveRackRequestBody = saveRackRequest.postDataJSON();
+      rackDeviceIdentifiers = saveRackRequestBody.deviceSelector.deviceList.deviceIdentifiers;
+
       await racksPage.validateRackToast(rackLabel);
+      test.expect(rackDeviceIdentifiers).toHaveLength(2);
     });
 
     await test.step("Open the rack overview and validate assigned slots", async () => {
@@ -473,6 +483,9 @@ test.describe("Racks", () => {
       const request = await requestPromise;
       const response = await responsePromise;
       const requestBody = request.postDataJSON();
+      const targetedDeviceIdentifiers = requestBody.deviceSelector.includeDevices.deviceIdentifiers;
+      const sortedTargetedDeviceIdentifiers = [...targetedDeviceIdentifiers].sort();
+      const sortedRackDeviceIdentifiers = [...rackDeviceIdentifiers].sort();
 
       test.expect(request.method()).toBe("POST");
       test.expect(requestBody).toHaveProperty("performanceMode");
@@ -480,7 +493,7 @@ test.describe("Racks", () => {
       test.expect(requestBody).toHaveProperty("deviceSelector");
       test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
       test.expect(requestBody.deviceSelector.includeDevices).toHaveProperty("deviceIdentifiers");
-      test.expect(requestBody.deviceSelector.includeDevices.deviceIdentifiers).toHaveLength(2);
+      test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedRackDeviceIdentifiers);
       test.expect(response.status()).toBe(200);
     });
   });


### PR DESCRIPTION
## Summary
- add rack overview page-object helpers for the shared device-set actions menu
- add rack overview E2E coverage for manage power via the shared actions menu
- keep setup deterministic by filtering the rack miner selector to Proto rig miners

## Verification
- npx eslint e2eTests/protoFleet/pages/racks.ts e2eTests/protoFleet/spec/racks.spec.ts
- npx playwright test spec/racks.spec.ts --project=desktop --grep "Rack overview actions menu manages power for assigned rig miners" --no-deps
- npx playwright test spec/racks.spec.ts --project=mobile --grep "Rack overview actions menu manages power for assigned rig miners" --no-deps