### PR TITLE
Add group overview actions E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/pages/groups.ts
+++ b/client/e2eTests/protoFleet/pages/groups.ts
@@ -74,6 +74,14 @@ export class GroupsPage extends BasePage {
     await this.validateModalIsOpen();
   }
 
+  async openSavedGroupOverview(groupName: string) {
+    const groupRow = this.getGroupRow(groupName);
+    await expect(groupRow).toBeVisible();
+    await groupRow.getByTestId("name").getByRole("link", { name: groupName, exact: true }).click();
+    await expect(this.page).toHaveURL(new RegExp(`/groups/${groupName}$`));
+    await this.validateTitle(groupName);
+  }
+
   async inputGroupName(groupName: string) {
     await this.page.locator(`//input[@id='group-name']`).fill(groupName);
   }
@@ -237,6 +245,16 @@ export class GroupsPage extends BasePage {
     const groupRow = this.getGroupRow(groupName);
     await expect(groupRow).toBeVisible();
     await groupRow.getByLabel("Device set actions").click();
+  }
+
+  async openGroupOverviewActionsMenu() {
+    await this.page.getByLabel("Device set actions").click();
+    await expect(this.page.getByTestId("group-actions-popover")).toBeVisible();
+  }
+
+  async clickGroupOverviewManagePower() {
+    await this.page.getByTestId("manage-power-popover-button").click();
+    await this.validateTitleInModal("Manage power");
   }
 
   async clickRebootGroupButton() {

--- a/client/e2eTests/protoFleet/pages/groups.ts
+++ b/client/e2eTests/protoFleet/pages/groups.ts
@@ -78,7 +78,8 @@ export class GroupsPage extends BasePage {
     const groupRow = this.getGroupRow(groupName);
     await expect(groupRow).toBeVisible();
     await groupRow.getByTestId("name").getByRole("link", { name: groupName, exact: true }).click();
-    await expect(this.page).toHaveURL(new RegExp(`/groups/${groupName}$`));
+    const expectedPath = `/groups/${encodeURIComponent(groupName)}`;
+    await expect(this.page).toHaveURL((url) => url.pathname === expectedPath);
     await this.validateTitle(groupName);
   }
 

--- a/client/e2eTests/protoFleet/spec/groups.spec.ts
+++ b/client/e2eTests/protoFleet/spec/groups.spec.ts
@@ -349,8 +349,11 @@ test.describe("Groups", () => {
   }) => {
     const groupName = generateRandomText("automation");
     let minerCount = 0;
+    let selectedDeviceIdentifiers: string[] = [];
 
     await test.step("Create a rig-only group with two miners", async () => {
+      const createGroupRequestPromise = page.waitForRequest(/CreateDeviceSet/);
+
       await groupsPage.clickAddGroupButton();
       await groupsPage.inputGroupName(groupName);
       await groupsPage.waitForModalListToLoad();
@@ -361,9 +364,14 @@ test.describe("Groups", () => {
       await groupsPage.selectMinersByIndex([0, 1]);
       await groupsPage.clickSaveInModal();
 
+      const createGroupRequest = await createGroupRequestPromise;
+      const createGroupRequestBody = createGroupRequest.postDataJSON();
+      selectedDeviceIdentifiers = createGroupRequestBody.deviceSelector.deviceList.deviceIdentifiers;
+
       await groupsPage.validateTextInToast(`Group "${groupName}" created`);
       await groupsPage.validateSavedGroupVisible(groupName);
       await groupsPage.validateSavedGroupMinerCount(groupName, minerCount);
+      test.expect(selectedDeviceIdentifiers).toHaveLength(minerCount);
     });
 
     await test.step("Open the group overview", async () => {
@@ -389,6 +397,9 @@ test.describe("Groups", () => {
       const request = await requestPromise;
       const response = await responsePromise;
       const requestBody = request.postDataJSON();
+      const targetedDeviceIdentifiers = requestBody.deviceSelector.includeDevices.deviceIdentifiers;
+      const sortedTargetedDeviceIdentifiers = [...targetedDeviceIdentifiers].sort();
+      const sortedSelectedDeviceIdentifiers = [...selectedDeviceIdentifiers].sort();
 
       test.expect(request.method()).toBe("POST");
       test.expect(requestBody).toHaveProperty("performanceMode");
@@ -396,7 +407,7 @@ test.describe("Groups", () => {
       test.expect(requestBody).toHaveProperty("deviceSelector");
       test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
       test.expect(requestBody.deviceSelector.includeDevices).toHaveProperty("deviceIdentifiers");
-      test.expect(requestBody.deviceSelector.includeDevices.deviceIdentifiers).toHaveLength(minerCount);
+      test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedSelectedDeviceIdentifiers);
       test.expect(response.status()).toBe(200);
     });
   });

--- a/client/e2eTests/protoFleet/spec/groups.spec.ts
+++ b/client/e2eTests/protoFleet/spec/groups.spec.ts
@@ -341,4 +341,63 @@ test.describe("Groups", () => {
       await minersPage.validateNoMinerWithStatus("Rebooting");
     });
   });
+
+  test("Group overview actions menu manages power for selected rig miners", async ({
+    groupsPage,
+    minersPage,
+    page,
+  }) => {
+    const groupName = generateRandomText("automation");
+    let minerCount = 0;
+
+    await test.step("Create a rig-only group with two miners", async () => {
+      await groupsPage.clickAddGroupButton();
+      await groupsPage.inputGroupName(groupName);
+      await groupsPage.waitForModalListToLoad();
+      await groupsPage.filterModalType(PROTO_RIG_MODEL);
+      await groupsPage.waitForModalListToLoad();
+
+      minerCount = 2;
+      await groupsPage.selectMinersByIndex([0, 1]);
+      await groupsPage.clickSaveInModal();
+
+      await groupsPage.validateTextInToast(`Group "${groupName}" created`);
+      await groupsPage.validateSavedGroupVisible(groupName);
+      await groupsPage.validateSavedGroupMinerCount(groupName, minerCount);
+    });
+
+    await test.step("Open the group overview", async () => {
+      await groupsPage.openSavedGroupOverview(groupName);
+    });
+
+    const requestPromise = page.waitForRequest(/SetPowerTarget/);
+    const responsePromise = page.waitForResponse(/SetPowerTarget/);
+
+    await test.step("Use the overview actions menu to reduce power", async () => {
+      await groupsPage.openGroupOverviewActionsMenu();
+      await groupsPage.clickGroupOverviewManagePower();
+      await minersPage.clickReducePowerOption();
+      await minersPage.clickManagePowerConfirm();
+    });
+
+    await test.step("Validate manage power toasts", async () => {
+      await groupsPage.validateTextInToastGroup("Updating power settings");
+      await groupsPage.validateTextInToastGroup("Updated power settings");
+    });
+
+    await test.step("Validate the SetPowerTarget request targets the grouped miners", async () => {
+      const request = await requestPromise;
+      const response = await responsePromise;
+      const requestBody = request.postDataJSON();
+
+      test.expect(request.method()).toBe("POST");
+      test.expect(requestBody).toHaveProperty("performanceMode");
+      test.expect(requestBody.performanceMode).toBe("PERFORMANCE_MODE_EFFICIENCY");
+      test.expect(requestBody).toHaveProperty("deviceSelector");
+      test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
+      test.expect(requestBody.deviceSelector.includeDevices).toHaveProperty("deviceIdentifiers");
+      test.expect(requestBody.deviceSelector.includeDevices.deviceIdentifiers).toHaveLength(minerCount);
+      test.expect(response.status()).toBe(200);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add group overview page-object helpers for the shared actions menu
- cover group overview manage power for rig-only groups
- validate the SetPowerTarget request targets the grouped miners

## Testing
- npx eslint e2eTests/protoFleet/pages/groups.ts e2eTests/protoFleet/spec/groups.spec.ts
- npx playwright test spec/groups.spec.ts --project=desktop --grep "Group overview actions menu manages power for selected rig miners" --no-deps
- npx playwright test spec/groups.spec.ts --project=mobile --grep "Group overview actions menu manages power for selected rig miners" --no-deps