### PR TITLE
Add groups view action E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/pages/groups.ts
+++ b/client/e2eTests/protoFleet/pages/groups.ts
@@ -83,6 +83,22 @@ export class GroupsPage extends BasePage {
     await this.validateTitle(groupName);
   }
 
+  async openSavedGroupOverviewFromActionsMenu(groupName: string) {
+    const groupRow = this.getGroupRow(groupName);
+    const expectedPath = `/groups/${encodeURIComponent(groupName)}`;
+
+    await expect(groupRow).toBeVisible();
+    await groupRow.getByLabel("Device set actions").click();
+    await this.page.getByTestId("view-group-popover-button").click();
+    await expect(this.page).toHaveURL((url) => url.pathname === expectedPath);
+    await this.validateTitle(groupName);
+  }
+
+  async returnToGroupsListFromOverview() {
+    await this.page.getByLabel("Back to groups").click();
+    await this.waitForSavedGroupsListToLoad();
+  }
+
   async inputGroupName(groupName: string) {
     await this.page.locator(`//input[@id='group-name']`).fill(groupName);
   }

--- a/client/e2eTests/protoFleet/spec/groups.spec.ts
+++ b/client/e2eTests/protoFleet/spec/groups.spec.ts
@@ -342,6 +342,32 @@ test.describe("Groups", () => {
     });
   });
 
+  test("View group from the groups list actions menu", async ({ groupsPage }) => {
+    const groupName = generateRandomText("automation");
+    const minerCount = 2;
+
+    await test.step("Create a group with two miners", async () => {
+      await groupsPage.clickAddGroupButton();
+      await groupsPage.inputGroupName(groupName);
+      await groupsPage.waitForModalListToLoad();
+      await groupsPage.selectMinersByIndex([0, 1]);
+      await groupsPage.clickSaveInModal();
+
+      await groupsPage.validateTextInToast(`Group "${groupName}" created`);
+      await groupsPage.validateSavedGroupVisible(groupName);
+      await groupsPage.validateSavedGroupMinerCount(groupName, minerCount);
+    });
+
+    await test.step("Open the group overview from the row actions menu", async () => {
+      await groupsPage.openSavedGroupOverviewFromActionsMenu(groupName);
+    });
+
+    await test.step("Return to the groups list", async () => {
+      await groupsPage.returnToGroupsListFromOverview();
+      await groupsPage.validateSavedGroupVisible(groupName);
+    });
+  });
+
   test("Group overview actions menu manages power for selected rig miners", async ({
     groupsPage,
     minersPage,


### PR DESCRIPTION
## Summary
- add Groups page-object helpers for opening a saved group overview from the row actions menu
- add coverage for the shared `View group` action from the groups list
- verify the flow can return to the groups list and the created group remains visible

## Testing
- npx eslint e2eTests/protoFleet/pages/groups.ts e2eTests/protoFleet/spec/groups.spec.ts
- npx playwright test spec/groups.spec.ts --project=desktop --grep "View group from the groups list actions menu" --no-deps
- npx playwright test spec/groups.spec.ts --project=mobile --grep "View group from the groups list actions menu" --no-deps