### PR TITLE
fix(protoOS): render ASIC table when telemetry beats hashboard status (#207)

### DIFF
--- a/client/src/protoOS/api/hooks/useHashboardStatus.test.ts
+++ b/client/src/protoOS/api/hooks/useHashboardStatus.test.ts
@@ -6,6 +6,13 @@ import { usePoll } from "@/shared/hooks/usePoll";
 
 const mockGetHashboardStatus = vi.fn();
 
+const mockGetHashboard = vi.fn();
+const mockAddHashboard = vi.fn();
+const mockGetAsic = vi.fn();
+const mockLinkAsicToHashboard = vi.fn();
+const mockBatchAddAsics = vi.fn();
+const mockSetState = vi.fn();
+
 vi.mock("@/protoOS/contexts/MinerHostingContext", () => ({
   useMinerHosting: vi.fn(),
 }));
@@ -18,17 +25,17 @@ vi.mock("@/protoOS/store", () => ({
   useMinerStore: {
     getState: () => ({
       hardware: {
-        getHashboard: vi.fn(),
-        addHashboard: vi.fn(),
-        getAsic: vi.fn(),
-        linkAsicToHashboard: vi.fn(),
-        batchAddAsics: vi.fn(),
+        getHashboard: mockGetHashboard,
+        addHashboard: mockAddHashboard,
+        getAsic: mockGetAsic,
+        linkAsicToHashboard: mockLinkAsicToHashboard,
+        batchAddAsics: mockBatchAddAsics,
       },
       telemetry: {
         asics: new Map(),
       },
     }),
-    setState: vi.fn(),
+    setState: mockSetState,
   },
   getAsicId: (serial: string, index: number) => `${serial}-${index}`,
 }));
@@ -70,5 +77,53 @@ describe("useHashboardStatus", () => {
     });
 
     expect(mockGetHashboardStatus).toHaveBeenCalledWith({ hbSn: "HB-1" }, expect.any(Object));
+  });
+
+  // Regression for #207: when useTelemetry has already created an ASIC entry
+  // (with index but no row/column), useHashboardStatus must still patch row
+  // and column. Skipping that update left the ASIC grid unable to render rows
+  // because `getAsicsRows` filters out ASICs missing position data.
+  test("merges row/column onto ASICs that already exist in the hardware store", async () => {
+    mockGetHashboard.mockReturnValue(undefined);
+    mockGetAsic.mockReturnValue({
+      id: "HB-1-0",
+      hashboardSerial: "HB-1",
+      index: 0,
+      hashboardIndex: 1,
+    });
+    mockGetHashboardStatus.mockResolvedValue({
+      data: {
+        "hashboard-stats": {
+          asics: [{ index: 0, row: 2, column: 3 }],
+        },
+      },
+    });
+
+    renderHook(() =>
+      useHashboardStatus({
+        hashboardSerialNumbers: ["HB-1"],
+        poll: false,
+      }),
+    );
+
+    const pollArgs = (usePoll as Mock).mock.calls[0][0];
+
+    await act(async () => {
+      await pollArgs.fetchData();
+    });
+
+    expect(mockBatchAddAsics).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: "HB-1-0",
+        hashboardSerial: "HB-1",
+        index: 0,
+        hashboardIndex: 1,
+        row: 2,
+        column: 3,
+      }),
+    ]);
+    // linkAsicToHashboard is a no-op when the entry pre-existed (the hashboard
+    // is updated separately with the full asicIds list).
+    expect(mockLinkAsicToHashboard).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoOS/api/hooks/useHashboardStatus.test.ts
+++ b/client/src/protoOS/api/hooks/useHashboardStatus.test.ts
@@ -6,12 +6,21 @@ import { usePoll } from "@/shared/hooks/usePoll";
 
 const mockGetHashboardStatus = vi.fn();
 
-const mockGetHashboard = vi.fn();
-const mockAddHashboard = vi.fn();
-const mockGetAsic = vi.fn();
-const mockLinkAsicToHashboard = vi.fn();
-const mockBatchAddAsics = vi.fn();
-const mockSetState = vi.fn();
+const {
+  mockGetHashboard,
+  mockAddHashboard,
+  mockGetAsic,
+  mockLinkAsicToHashboard,
+  mockBatchAddAsics,
+  mockSetState,
+} = vi.hoisted(() => ({
+  mockGetHashboard: vi.fn(),
+  mockAddHashboard: vi.fn(),
+  mockGetAsic: vi.fn(),
+  mockLinkAsicToHashboard: vi.fn(),
+  mockBatchAddAsics: vi.fn(),
+  mockSetState: vi.fn(),
+}));
 
 vi.mock("@/protoOS/contexts/MinerHostingContext", () => ({
   useMinerHosting: vi.fn(),

--- a/client/src/protoOS/api/hooks/useHashboardStatus.test.ts
+++ b/client/src/protoOS/api/hooks/useHashboardStatus.test.ts
@@ -79,10 +79,10 @@ describe("useHashboardStatus", () => {
     expect(mockGetHashboardStatus).toHaveBeenCalledWith({ hbSn: "HB-1" }, expect.any(Object));
   });
 
-  // Regression for #207: when useTelemetry has already created an ASIC entry
-  // (with index but no row/column), useHashboardStatus must still patch row
-  // and column. Skipping that update left the ASIC grid unable to render rows
-  // because `getAsicsRows` filters out ASICs missing position data.
+  // When useTelemetry has already created an ASIC entry (with index but no
+  // row/column), useHashboardStatus must still patch row and column.
+  // Skipping that update left the ASIC grid unable to render rows because
+  // `getAsicsRows` filters out ASICs missing position data.
   test("merges row/column onto ASICs that already exist in the hardware store", async () => {
     mockGetHashboard.mockReturnValue(undefined);
     mockGetAsic.mockReturnValue({

--- a/client/src/protoOS/api/hooks/useHashboardStatus.test.ts
+++ b/client/src/protoOS/api/hooks/useHashboardStatus.test.ts
@@ -6,21 +6,15 @@ import { usePoll } from "@/shared/hooks/usePoll";
 
 const mockGetHashboardStatus = vi.fn();
 
-const {
-  mockGetHashboard,
-  mockAddHashboard,
-  mockGetAsic,
-  mockLinkAsicToHashboard,
-  mockBatchAddAsics,
-  mockSetState,
-} = vi.hoisted(() => ({
-  mockGetHashboard: vi.fn(),
-  mockAddHashboard: vi.fn(),
-  mockGetAsic: vi.fn(),
-  mockLinkAsicToHashboard: vi.fn(),
-  mockBatchAddAsics: vi.fn(),
-  mockSetState: vi.fn(),
-}));
+const { mockGetHashboard, mockAddHashboard, mockGetAsic, mockLinkAsicToHashboard, mockBatchAddAsics, mockSetState } =
+  vi.hoisted(() => ({
+    mockGetHashboard: vi.fn(),
+    mockAddHashboard: vi.fn(),
+    mockGetAsic: vi.fn(),
+    mockLinkAsicToHashboard: vi.fn(),
+    mockBatchAddAsics: vi.fn(),
+    mockSetState: vi.fn(),
+  }));
 
 vi.mock("@/protoOS/contexts/MinerHostingContext", () => ({
   useMinerHosting: vi.fn(),

--- a/client/src/protoOS/api/hooks/useHashboardStatus.ts
+++ b/client/src/protoOS/api/hooks/useHashboardStatus.ts
@@ -97,7 +97,7 @@ const useHashboardStatus = ({ hashboardSerialNumbers, poll }: UseHashboardStatus
 
           // Always merge row/column onto the entry: useTelemetry may have created an
           // entry without positional data, and skipping the update here leaves the
-          // ASIC table unable to render rows (issue #207).
+          // ASIC table unable to render rows.
           asicsToAdd.push({
             ...existingAsic,
             id: asicId,

--- a/client/src/protoOS/api/hooks/useHashboardStatus.ts
+++ b/client/src/protoOS/api/hooks/useHashboardStatus.ts
@@ -95,15 +95,18 @@ const useHashboardStatus = ({ hashboardSerialNumbers, poll }: UseHashboardStatus
           const asicId = getAsicId(hashboardSerialNumber, asic.index);
           const existingAsic = useMinerStore.getState().hardware.getAsic(asicId);
 
-          if (!existingAsic) {
-            const asicInfo = {
-              id: asicId,
-              hashboardSerial: hashboardSerialNumber,
-              row: asic.row,
-              column: asic.column,
-            };
+          // Always merge row/column onto the entry: useTelemetry may have created an
+          // entry without positional data, and skipping the update here leaves the
+          // ASIC table unable to render rows (issue #207).
+          asicsToAdd.push({
+            ...existingAsic,
+            id: asicId,
+            hashboardSerial: hashboardSerialNumber,
+            row: asic.row,
+            column: asic.column,
+          });
 
-            asicsToAdd.push(asicInfo);
+          if (!existingAsic) {
             useMinerStore.getState().hardware.linkAsicToHashboard(asicId, hashboardSerialNumber);
           }
 


### PR DESCRIPTION
## Summary

Fixes #207: ASIC table intermittently blank (no spinner) after refresh of `/diagnostics/:serial`.

Race: when `useTelemetry` resolves before `useHashboardStatus`, telemetry creates ASIC hardware entries with only `index`/`hashboardIndex`; `useHashboardStatus`'s `if (!existingAsic)` guard then skips writing `row`/`column`. `hashboard.asicIds` is populated, so `asics.length > 0` (no spinner), but every ASIC lacks position → `getAsicsRows` filters all of them out → empty grid.

Fix: always merge `row`/`column` onto the entry in `useHashboardStatus`, preserving any fields the telemetry path already set. Mirrors the inverse merge already in `useTelemetry`. Added a regression test that pre-seeds an existing ASIC and asserts `batchAddAsics` receives the positional patch.

## Test plan
- [ ] `cd client && npm test -- useHashboardStatus`
- [ ] Manual: hard-refresh `/diagnostics/:serial` repeatedly; ASIC grid renders every time
- [ ] Manual: navigate diagnostics → View → still renders (non-refresh path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)