### PR TITLE
chore(timescaledb): remove unused timescaledb_toolkit extension

### DIFF
--- a/server/docker-compose.base.yaml
+++ b/server/docker-compose.base.yaml
@@ -24,8 +24,8 @@ services:
       - NET_RAW
 
   # TimescaleDB (PostgreSQL with time-series extension)
-  # Custom lightweight image (~123 MB) replacing timescale/timescaledb-ha (~1.67 GB)
-  # Includes PostgreSQL 18, TimescaleDB, and timescaledb_toolkit — without HA bloat
+  # Custom lightweight image replacing timescale/timescaledb-ha (~1.67 GB)
+  # Includes PostgreSQL 18, TimescaleDB, and pgvector — without HA bloat
   timescaledb:
     restart: always
     environment:

--- a/server/migrations/000048_drop_timescaledb_toolkit.down.sql
+++ b/server/migrations/000048_drop_timescaledb_toolkit.down.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS timescaledb_toolkit;

--- a/server/migrations/000048_drop_timescaledb_toolkit.up.sql
+++ b/server/migrations/000048_drop_timescaledb_toolkit.up.sql
@@ -1,0 +1,7 @@
+-- Drop the timescaledb_toolkit extension.
+--
+-- It was enabled in 000006_create_continuous_aggregates.up.sql for
+-- time-weighted aggregates that were never wired up. The continuous aggregates
+-- on main only use base TimescaleDB (time_bucket, add_continuous_aggregate_policy)
+-- and standard SQL aggregates, so no objects depend on the extension.
+DROP EXTENSION IF EXISTS timescaledb_toolkit;

--- a/server/timescaledb/Dockerfile
+++ b/server/timescaledb/Dockerfile
@@ -1,7 +1,7 @@
 # Proto Fleet Custom TimescaleDB Image
 #
 # A lightweight alternative to timescale/timescaledb-ha (~1.6 GB) that includes
-# PostgreSQL 18, TimescaleDB, timescaledb_toolkit, pgvector, and timescaledb-tune.
+# PostgreSQL 18, TimescaleDB, pgvector, and timescaledb-tune.
 #
 # What's excluded (and why this image is ~75% smaller):
 #   - Patroni + Python 3 (~120 MB) — HA cluster manager, not needed for single-node
@@ -15,7 +15,6 @@
 #
 # Base image choice: Ubuntu 24.04 (Noble)
 #   - Matches the HA image's base (glibc compatibility, same collation behavior)
-#   - Pre-compiled toolkit .deb packages available on packagecloud (Rust-compiled, no build step)
 #   - Multi-arch support: amd64 + arm64 packages available
 #
 # PGDATA path: /home/postgres/pgdata/data
@@ -74,13 +73,12 @@ RUN set -eux; \
         https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -cs) main" \
         > /etc/apt/sources.list.d/timescaledb.list; \
     \
-    # --- Install PostgreSQL + TimescaleDB + Toolkit + pgvector ---
+    # --- Install PostgreSQL + TimescaleDB + pgvector ---
     apt-get update; \
     apt-get install -y --no-install-recommends \
         postgresql-${PG_MAJOR} \
         postgresql-client-${PG_MAJOR} \
         timescaledb-2-postgresql-${PG_MAJOR} \
-        timescaledb-toolkit-postgresql-${PG_MAJOR} \
         postgresql-${PG_MAJOR}-pgvector; \
     \
     # --- Cleanup to minimize image size ---

--- a/server/timescaledb/README.md
+++ b/server/timescaledb/README.md
@@ -1,54 +1,29 @@
 # Custom TimescaleDB Docker Image
 
-A lightweight alternative to `timescale/timescaledb-ha` that includes only what Proto Fleet needs:
-PostgreSQL 18, TimescaleDB, timescaledb_toolkit, pgvector, and timescaledb-tune.
+A lightweight alternative to `timescale/timescaledb-ha` that includes only what
+Proto Fleet needs: PostgreSQL 18, TimescaleDB, pgvector, and timescaledb-tune.
 
 ## Size Comparison
 
-| Image | Content Size | Toolkit? | pgvector? | timescaledb-tune? |
-|---|---|---|---|---|
-| `timescale/timescaledb-ha:pg17-ts2.25` | **1.67 GB** | ✅ | ✅ | ✅ |
-| `timescale/timescaledb:2.25.1-pg18` (Alpine) | **169 MB** | ❌ | ✅ | ✅ |
-| `proto-fleet/timescaledb` (this image) | **~120 MB** | ✅ | ✅ | ✅ |
+| Image | Content Size | pgvector? | timescaledb-tune? |
+|---|---|---|---|
+| `timescale/timescaledb-ha:pg17-ts2.25` | **1.67 GB** | ✅ | ✅ |
+| `timescale/timescaledb:2.25.1-pg18` (Alpine) | **169 MB** | ✅ | ✅ |
+| `proto-fleet/timescaledb` (this image) | **~95 MB** | ✅ | ✅ |
 
-**93% smaller** than the HA image, and **29% smaller** than the standard Alpine
-image — while including the toolkit that Alpine can't support.
-
-## Comparison with the Standard Alpine Image
-
-The standard `timescale/timescaledb:2.25.1-pg18` is Alpine-based and includes
-timescaledb-tune, pgvector, and PL/Python3 (for PG < 18), but **cannot** include
-the timescaledb_toolkit extension (requires glibc; Alpine uses musl libc).
-
-| Feature | Alpine (`timescale/timescaledb`) | This Image |
-|---|---|---|
-| Base OS | Alpine (musl libc) | Ubuntu 24.04 (glibc) |
-| PostgreSQL | 18 | 18 |
-| TimescaleDB | ✅ | ✅ |
-| timescaledb_toolkit | ❌ (requires glibc) | ✅ |
-| pgvector | ✅ (built from source) | ✅ (pre-built PGDG package) |
-| timescaledb-tune | ✅ (built from source) | ✅ (built from source) |
-| PL/Python3 | ❌ (not available for PG18) | ❌ (not installed) |
-| timescaledb-parallel-copy | ✅ | ❌ (not needed) |
-| Auto-tune on first start | ✅ | ✅ |
-| Image size | ~169 MB | ~120 MB |
-
-The Alpine image builds both pgvector and TimescaleDB from source during the
-Docker build, resulting in a larger image. This image uses pre-compiled `.deb`
-packages from PGDG and Timescale's packagecloud repositories.
+Substantially smaller than the HA image, and smaller than the standard Alpine
+image because we install pre-compiled `.deb` packages rather than rebuilding
+pgvector and TimescaleDB from source.
 
 ## Why This Image Exists
 
-The only reason Proto Fleet used the `timescaledb-ha` image was to get the
-`timescaledb_toolkit` extension (required by migration 000006). The HA image
-bundles a large number of components for Kubernetes-based high availability that
-Proto Fleet does not use:
+The HA image bundles a large number of components for Kubernetes-based high
+availability that Proto Fleet does not use:
 
 | Component | ~Size | Purpose | Used by Proto Fleet? |
 |---|---|---|---|
 | PostgreSQL 17 + contrib | ~90 MB | Database server | ✅ Yes |
 | TimescaleDB | ~20 MB | Time-series extension | ✅ Yes |
-| timescaledb_toolkit | ~24 MB | Analytical hyperfunctions | ✅ Yes |
 | Patroni + Python 3 | ~120 MB | HA cluster manager + runtime | ❌ No |
 | PostGIS + GDAL/GEOS/PROJ | ~130 MB | Geospatial extensions | ❌ No |
 | LLVM/Clang JIT | ~80 MB | Query JIT compilation | ❌ No |
@@ -61,13 +36,10 @@ Proto Fleet does not use:
 ## What's Included
 
 - **Ubuntu 24.04** (Noble) base — matches the HA image's glibc for collation
-  compatibility. The toolkit extension is a Rust-compiled binary distributed as
-  a pre-compiled `.deb` package, and Ubuntu Noble is one of the supported targets.
+  compatibility with existing data.
 - **PostgreSQL 18** from the official PGDG apt repository — async I/O (up to 3×
   read perf), `uuidv7()`, virtual generated columns, faster `pg_upgrade`
 - **TimescaleDB 2.x** from Timescale's packagecloud apt repository
-- **timescaledb_toolkit** from the same repository — provides `time_weight()`,
-  `stats_agg()`, and other analytical hyperfunctions
 - **pgvector** from the PGDG apt repository — vector similarity search for
   embeddings and nearest-neighbor queries
 - **timescaledb-tune** — auto-tunes PostgreSQL configuration based on container
@@ -81,7 +53,6 @@ Proto Fleet does not use:
 |---|---|
 | PostgreSQL | 18.2 |
 | TimescaleDB | 2.25.1 |
-| timescaledb_toolkit | 1.22.0 |
 | pgvector | 0.8.1 |
 | timescaledb-tune | 0.18.1 |
 
@@ -145,10 +116,10 @@ without data migration.
 
 ## Architecture Support
 
-Pre-compiled packages for TimescaleDB, the toolkit, and pgvector are available
-for both `amd64` and `arm64` on Ubuntu Noble via the PGDG and Timescale
-packagecloud repositories. The timescaledb-tune binary is compiled from Go
-source during the Docker build, supporting any architecture Go targets.
+Pre-compiled packages for TimescaleDB and pgvector are available for both
+`amd64` and `arm64` on Ubuntu Noble via the PGDG and Timescale packagecloud
+repositories. The timescaledb-tune binary is compiled from Go source during
+the Docker build, supporting any architecture Go targets.
 
 ## Initialization Scripts
 
@@ -159,24 +130,10 @@ first start (before the main postgres process starts).
 
 ### Why Ubuntu instead of Alpine?
 
-The standard `timescale/timescaledb` image is Alpine-based (~168 MB) but the
-toolkit extension cannot be installed on Alpine — it requires glibc (Alpine uses
-musl libc) and pre-compiled packages are only published for Debian and Ubuntu.
-Building the toolkit from Rust source on Alpine is possible but adds significant
-build complexity and time.
+The standard `timescale/timescaledb` image is Alpine-based (~169 MB) but
+rebuilds pgvector and TimescaleDB from source during the Docker build. Using
+Ubuntu lets us install pre-compiled `.deb` packages from PGDG and Timescale's
+packagecloud repositories, resulting in a smaller image with faster builds.
 
-### Why not `postgres:17-bookworm` as the base?
-
-Toolkit packages are available for Debian Bookworm, so this would also work.
-Ubuntu was chosen because:
-1. The HA image is already Ubuntu-based, so this is a known-good environment
-2. Collation behavior matches what the existing data was created with
-3. Both options produce similar image sizes
-
-### Toolkit usage note
-
-As of this writing, the `timescaledb_toolkit` extension is created in migration
-000006 but no toolkit-specific functions (`time_weight`, `stats_agg`,
-`counter_agg`, etc.) are currently called in any SQL queries. The continuous
-aggregates only use standard TimescaleDB functions (`time_bucket`,
-`add_continuous_aggregate_policy`). The extension is included for future use.
+Ubuntu Noble also matches the glibc/collation environment of the previous HA
+image, so existing data volumes work without a collation rebuild.


### PR DESCRIPTION
## Summary

- The `timescaledb_toolkit` extension was enabled in [migration 000006](server/migrations/000006_create_continuous_aggregates.up.sql#L7) for time-weighted energy aggregates that never got wired up.
- A repo-wide search found **zero** call sites for any toolkit function (`time_weight`, `stats_agg`, `counter_agg`, `percentile_agg`, `lttb`, `hyperloglog`, etc.). The continuous aggregates use only base TimescaleDB (`time_bucket`, `add_continuous_aggregate_policy`) and standard SQL aggregates.
- Energy is computed in Go in [telemetry_store.go](server/internal/infrastructure/timescaledb/telemetry_store.go) via `avgPowerW * activeHours / 1000`, not via `time_weight`.
- The repo's own [README note](server/timescaledb/README.md#L176-L183) already acknowledged the extension was unused and "included for future use." This PR removes it instead.

## Changes

- `server/migrations/000048_drop_timescaledb_toolkit.{up,down}.sql` — drop the extension going forward; `down` recreates it for rollback symmetry.
- `server/timescaledb/Dockerfile` — drop the `timescaledb-toolkit-postgresql-${PG_MAJOR}` apt package and its header/comment references.
- `server/timescaledb/README.md` — restructured around the new value prop (smaller than HA, faster build than Alpine because of pre-built `.deb` packages). Removed the toolkit-only justification sections.
- `server/docker-compose.base.yaml` — update the service comment to drop the toolkit mention.

Migration 000006 itself is left untouched (it's already deployed and immutable per the `migration-immutability` skill); the new 000048 supersedes it.

## Test plan

- [ ] `cd server && just db-migrate` applies 000048 cleanly against a freshly-rebuilt DB
- [ ] `cd server && just db-migrate-down` (or equivalent) followed by re-up to verify the down migration recreates the extension without error
- [ ] `docker build -t proto-fleet/timescaledb:latest server/timescaledb/` succeeds without the toolkit package
- [ ] Inspect resulting image size (`docker image ls`) — expect ~25 MB drop
- [ ] `just dev` brings up the stack and `psql` confirms `\dx` lists `timescaledb` + `vector` but no `timescaledb_toolkit`
- [ ] `cd server && just test` still passes
- [ ] Continuous aggregates (`device_metrics_hourly`, `device_metrics_daily`) still populate correctly after a `just seed-telemetry --days 1 --devices 1`

## Rollback

`migrate down 1` against 000048 recreates the extension. The Dockerfile/README changes are reversible via `git revert`. No data loss is possible since no objects depend on the toolkit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)