### PR TITLE
Add ProtoOS cooling settings E2E coverage

### DIFF
--- a/client/e2eTests/protoOS/pages/components/sleepWakeDialog.ts
+++ b/client/e2eTests/protoOS/pages/components/sleepWakeDialog.ts
@@ -2,6 +2,12 @@ import { expect } from "@playwright/test";
 import { BasePage } from "../base";
 
 export class SleepWakeDialogsComponent extends BasePage {
+  async validateEnteringSleepDialogVisible() {
+    const dialog = this.page.getByTestId("entering-sleep-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("Entering sleep mode");
+  }
+
   async clickEnterSleepMode() {
     const dialog = this.page.getByTestId("warn-sleep-dialog");
     await dialog.getByRole("button", { name: "Enter sleep mode" }).click();
@@ -9,8 +15,7 @@ export class SleepWakeDialogsComponent extends BasePage {
 
   async validateEnteringSleepDialog() {
     const dialog = this.page.getByTestId("entering-sleep-dialog");
-    await expect(dialog).toBeVisible();
-    await expect(dialog).toContainText("Entering sleep mode");
+    await this.validateEnteringSleepDialogVisible();
     await expect(dialog).toBeHidden();
   }
 

--- a/client/e2eTests/protoOS/pages/cooling.ts
+++ b/client/e2eTests/protoOS/pages/cooling.ts
@@ -2,52 +2,63 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class CoolingPage extends BasePage {
-  private airCoolingHeading() {
-    return this.page.getByRole("heading", { name: "Air cooled", exact: true });
+  private airCoolingOption() {
+    return this.page.getByTestId("cooling-option-air");
   }
 
-  private immersionCoolingHeading() {
-    return this.page.getByRole("heading", { name: "Immersion cooled", exact: true });
+  private immersionCoolingOption() {
+    return this.page.getByTestId("cooling-option-immersion");
   }
 
   private airCoolingRadio() {
-    return this.page.getByRole("radio").first();
+    return this.airCoolingOption().locator('input[type="radio"]');
   }
 
   private immersionCoolingRadio() {
-    return this.page.getByRole("radio").nth(1);
+    return this.immersionCoolingOption().locator('input[type="radio"]');
   }
 
   private coolingInfoModal() {
     return this.page.getByTestId("modal");
   }
 
+  async waitForCoolingOptions() {
+    await expect(this.airCoolingOption()).toBeVisible();
+    await expect(this.immersionCoolingOption()).toBeVisible();
+  }
+
   async validateAirCooledSelected() {
+    await this.waitForCoolingOptions();
     await expect(this.airCoolingRadio()).toBeChecked();
   }
 
   async validateImmersionCooledSelected() {
+    await this.waitForCoolingOptions();
     await expect(this.immersionCoolingRadio()).toBeChecked();
   }
 
   async isAirCooledSelected() {
+    await this.waitForCoolingOptions();
     return this.airCoolingRadio().isChecked();
   }
 
   async isImmersionCooledSelected() {
+    await this.waitForCoolingOptions();
     return this.immersionCoolingRadio().isChecked();
   }
 
   async clickAirCooledOption() {
-    await this.airCoolingHeading().click();
+    await this.waitForCoolingOptions();
+    await this.airCoolingOption().click();
   }
 
   async clickImmersionCooledOption() {
-    await this.immersionCoolingHeading().click();
+    await this.waitForCoolingOptions();
+    await this.immersionCoolingOption().click();
   }
 
   async clickLearnMoreButton() {
-    await this.page.getByRole("button", { name: "Learn more" }).click();
+    await this.page.getByTestId("cooling-learn-more-button").click();
   }
 
   async validateImmersionCoolingModalOpen() {

--- a/client/e2eTests/protoOS/pages/cooling.ts
+++ b/client/e2eTests/protoOS/pages/cooling.ts
@@ -1,3 +1,86 @@
+import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
-export class CoolingPage extends BasePage {}
+export class CoolingPage extends BasePage {
+  private airCoolingHeading() {
+    return this.page.getByRole("heading", { name: "Air cooled", exact: true });
+  }
+
+  private immersionCoolingHeading() {
+    return this.page.getByRole("heading", { name: "Immersion cooled", exact: true });
+  }
+
+  private airCoolingRadio() {
+    return this.page.getByRole("radio").first();
+  }
+
+  private immersionCoolingRadio() {
+    return this.page.getByRole("radio").nth(1);
+  }
+
+  private coolingInfoModal() {
+    return this.page.getByTestId("modal");
+  }
+
+  async validateAirCooledSelected() {
+    await expect(this.airCoolingRadio()).toBeChecked();
+  }
+
+  async validateImmersionCooledSelected() {
+    await expect(this.immersionCoolingRadio()).toBeChecked();
+  }
+
+  async isAirCooledSelected() {
+    return this.airCoolingRadio().isChecked();
+  }
+
+  async isImmersionCooledSelected() {
+    return this.immersionCoolingRadio().isChecked();
+  }
+
+  async clickAirCooledOption() {
+    await this.airCoolingHeading().click();
+  }
+
+  async clickImmersionCooledOption() {
+    await this.immersionCoolingHeading().click();
+  }
+
+  async clickLearnMoreButton() {
+    await this.page.getByRole("button", { name: "Learn more" }).click();
+  }
+
+  async validateImmersionCoolingModalOpen() {
+    await this.validateModalIsOpen();
+    await this.validateTitleInModal("Immersion cooling");
+    await expect(this.coolingInfoModal().getByRole("button", { name: "Enter sleep mode" })).toBeVisible();
+  }
+
+  async validateLearnMoreModalOpen() {
+    await this.validateModalIsOpen();
+    await this.validateTitleInModal("Immersion cooling");
+    await expect(this.coolingInfoModal().getByRole("button", { name: "Enter sleep mode" })).toHaveCount(0);
+    await this.validateTextInModal("Prepare your miner for immersion");
+  }
+
+  async clickEnterSleepModeInModal() {
+    await this.coolingInfoModal().getByRole("button", { name: "Enter sleep mode" }).click();
+  }
+
+  async dismissInfoModal() {
+    await this.page.keyboard.press("Escape");
+    await this.validateModalIsClosed();
+  }
+
+  async validateCoolingModeUpdatedTo(mode: "air cooled" | "immersion cooled") {
+    await this.validateToastMessage(`Cooling mode updated to ${mode}`);
+  }
+
+  async isCoolingInfoModalVisible() {
+    return this.coolingInfoModal().isVisible();
+  }
+
+  async isWakeCalloutVisible() {
+    return this.page.getByTestId("callout").getByRole("button", { name: "Wake up miner" }).isVisible();
+  }
+}

--- a/client/e2eTests/protoOS/spec/cooling.spec.ts
+++ b/client/e2eTests/protoOS/spec/cooling.spec.ts
@@ -1,0 +1,124 @@
+import { Page } from "@playwright/test";
+import { test } from "../fixtures/pageFixtures";
+
+type CoolingCleanupFixtures = {
+  page: Page;
+  coolingPage: InstanceType<typeof import("../pages/cooling").CoolingPage>;
+  wakeCalloutComponent: InstanceType<typeof import("../pages/components/wakeCallout").WakeCalloutComponent>;
+  sleepWakeDialogsComponent: InstanceType<
+    typeof import("../pages/components/sleepWakeDialog").SleepWakeDialogsComponent
+  >;
+  headerComponent: InstanceType<typeof import("../pages/components/header").HeaderComponent>;
+};
+
+async function restoreDefaultCoolingState({
+  page,
+  coolingPage,
+  wakeCalloutComponent,
+  sleepWakeDialogsComponent,
+  headerComponent,
+}: CoolingCleanupFixtures) {
+  if (await coolingPage.isCoolingInfoModalVisible()) {
+    await coolingPage.dismissInfoModal();
+  }
+
+  await page.goto("/settings/cooling");
+  await coolingPage.validateTitle("Cooling");
+
+  if (await coolingPage.isImmersionCooledSelected()) {
+    await coolingPage.clickAirCooledOption();
+    await coolingPage.validateCoolingModeUpdatedTo("air cooled");
+    await coolingPage.validateAirCooledSelected();
+  }
+
+  if (await coolingPage.isWakeCalloutVisible()) {
+    await wakeCalloutComponent.clickWakeMinerInCallout();
+    await sleepWakeDialogsComponent.clickWakeMinerInDialog();
+    await sleepWakeDialogsComponent.validateWakingDialog();
+    await headerComponent.validateMinerStatus("Hashing");
+    await wakeCalloutComponent.validateWakeCalloutNotVisible();
+  }
+}
+
+test.describe("Cooling settings", () => {
+  test.beforeEach(
+    async ({ page, commonSteps, coolingPage, wakeCalloutComponent, sleepWakeDialogsComponent, headerComponent }) => {
+      await page.goto("/");
+      await commonSteps.authenticateAsAdmin();
+      await page.goto("/settings/cooling");
+      await coolingPage.validateTitle("Cooling");
+      await restoreDefaultCoolingState({
+        page,
+        coolingPage,
+        wakeCalloutComponent,
+        sleepWakeDialogsComponent,
+        headerComponent,
+      });
+    },
+  );
+
+  test.afterEach(async ({ page, coolingPage, wakeCalloutComponent, sleepWakeDialogsComponent, headerComponent }) => {
+    await restoreDefaultCoolingState({
+      page,
+      coolingPage,
+      wakeCalloutComponent,
+      sleepWakeDialogsComponent,
+      headerComponent,
+    });
+  });
+
+  test("Switching to immersion requires confirmation and enters sleep flow", async ({
+    coolingPage,
+    sleepWakeDialogsComponent,
+  }) => {
+    await test.step("Select immersion cooling", async () => {
+      await coolingPage.validateAirCooledSelected();
+      await coolingPage.clickImmersionCooledOption();
+    });
+
+    await test.step("Confirm immersion cooling", async () => {
+      await coolingPage.validateImmersionCoolingModalOpen();
+      await coolingPage.clickEnterSleepModeInModal();
+      await coolingPage.validateCoolingModeUpdatedTo("immersion cooled");
+      await sleepWakeDialogsComponent.validateEnteringSleepDialogVisible();
+    });
+
+    await test.step("Validate immersion transition feedback", async () => {
+      await sleepWakeDialogsComponent.validateEnteringSleepDialogVisible();
+    });
+  });
+
+  test("Switching back to air cooled succeeds after immersion mode", async ({
+    page,
+    coolingPage,
+    sleepWakeDialogsComponent,
+  }) => {
+    await test.step("Enter immersion mode and sleep", async () => {
+      await coolingPage.clickImmersionCooledOption();
+      await coolingPage.validateImmersionCoolingModalOpen();
+      await coolingPage.clickEnterSleepModeInModal();
+      await coolingPage.validateCoolingModeUpdatedTo("immersion cooled");
+      await sleepWakeDialogsComponent.validateEnteringSleepDialogVisible();
+    });
+
+    await test.step("Switch back to air cooling", async () => {
+      await page.goto("/settings/cooling");
+      await coolingPage.validateTitle("Cooling");
+      await coolingPage.validateImmersionCooledSelected();
+      await coolingPage.clickAirCooledOption();
+      await coolingPage.validateCoolingModeUpdatedTo("air cooled");
+      await coolingPage.validateAirCooledSelected();
+    });
+  });
+
+  test("Learn more modal opens and closes", async ({ coolingPage }) => {
+    await test.step("Open learn more modal", async () => {
+      await coolingPage.clickLearnMoreButton();
+      await coolingPage.validateLearnMoreModalOpen();
+    });
+
+    await test.step("Close learn more modal", async () => {
+      await coolingPage.dismissInfoModal();
+    });
+  });
+});

--- a/client/e2eTests/protoOS/spec/cooling.spec.ts
+++ b/client/e2eTests/protoOS/spec/cooling.spec.ts
@@ -67,7 +67,8 @@ test.describe("Cooling settings", () => {
     });
   });
 
-  test("Switching to immersion requires confirmation and enters sleep flow", async ({
+  test("Switching between immersion and air cooling works as a single round-trip flow", async ({
+    page,
     coolingPage,
     sleepWakeDialogsComponent,
   }) => {
@@ -84,20 +85,6 @@ test.describe("Cooling settings", () => {
     });
 
     await test.step("Validate immersion transition feedback", async () => {
-      await sleepWakeDialogsComponent.validateEnteringSleepDialogVisible();
-    });
-  });
-
-  test("Switching back to air cooled succeeds after immersion mode", async ({
-    page,
-    coolingPage,
-    sleepWakeDialogsComponent,
-  }) => {
-    await test.step("Enter immersion mode and sleep", async () => {
-      await coolingPage.clickImmersionCooledOption();
-      await coolingPage.validateImmersionCoolingModalOpen();
-      await coolingPage.clickEnterSleepModeInModal();
-      await coolingPage.validateCoolingModeUpdatedTo("immersion cooled");
       await sleepWakeDialogsComponent.validateEnteringSleepDialogVisible();
     });
 

--- a/client/src/protoOS/features/settings/components/Cooling/Cooling.tsx
+++ b/client/src/protoOS/features/settings/components/Cooling/Cooling.tsx
@@ -188,6 +188,7 @@ const Cooling = () => {
       <div className="mb-10 flex flex-col gap-4">
         <SelectRow
           id={COOLING_MODES.air}
+          data-testid="cooling-option-air"
           isSelected={isSelected(coolingMode, userSelectedCoolingMode, pending, COOLING_MODES.air)}
           onChange={(id) => handleChange(id)}
           divider={false}
@@ -208,6 +209,7 @@ const Cooling = () => {
         <div className="flex flex-col gap-3">
           <SelectRow
             id={COOLING_MODES.immersion}
+            data-testid="cooling-option-immersion"
             isSelected={isSelected(coolingMode, userSelectedCoolingMode, pending, COOLING_MODES.immersion)}
             onChange={(id) => handleChange(id)}
             divider={false}
@@ -227,6 +229,7 @@ const Cooling = () => {
           />
           <div className="text-200 text-text-primary-70">
             <Button
+              testId="cooling-learn-more-button"
               className="inline"
               textColor="text-text-emphasis"
               variant="textOnly"


### PR DESCRIPTION
## Summary
- add ProtoOS cooling settings E2E coverage for immersion confirmation, switching back to air cooling, and the learn more modal
- add focused cooling page-object helpers and a dialog helper for validating the entering-sleep transition
- add stable cooling test hooks in the ProtoOS Cooling settings UI

## Verification
- npx eslint e2eTests/protoOS/pages/cooling.ts e2eTests/protoOS/pages/components/sleepWakeDialog.ts e2eTests/protoOS/spec/cooling.spec.ts src/protoOS/features/settings/components/Cooling/Cooling.tsx
- npx playwright test -c e2eTests/protoOS/playwright.config.ts e2eTests/protoOS/spec/cooling.spec.ts --project=desktop --no-deps
- npx playwright test -c e2eTests/protoOS/playwright.config.ts e2eTests/protoOS/spec/cooling.spec.ts --project=mobile --no-deps