### PR TITLE
docs(agents): add rule for the client route-prefetch protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ These are the rules that recur in code review and that contributors most often m
 7. **Server: prepared statements only.** All DB access goes through sqlc.
 8. **Go workspace.** Run `go work sync` after touching dependencies in any
    module under `server/` or `plugin/`.
+9. **Client routes use idle-time prefetch.** Adding a route requires
+   coordinated edits across `routePrefetch.ts` (factory plus tier) and
+   `router.tsx` (`lazy()` wrapper). See the top-of-file runbook in either
+   app's `routePrefetch.ts`.
 
 ## Git workflow
 


### PR DESCRIPTION
## Summary

Adds a single rule to `AGENTS.md` pointing readers at the canonical route-prefetch runbook before they touch `router.tsx`. The runbook already lives in the top-of-file comment of each app's `routePrefetch.ts` (where someone adding a new factory will see it). The new rule is the entry-point breadcrumb so an AI agent or human contributor reading `AGENTS.md` first knows the protocol exists and doesn't fall back to the inline `lazy(() => import(...))` pattern that bypasses the prefetch tier.

Closes #223.
Ref #53.

## Test plan

- [ ] `AGENTS.md` renders the new rule as item 9 in "Rules that matter".
- [ ] The reference text "either app's `routePrefetch.ts`" resolves to `client/src/protoFleet/routePrefetch.ts` and `client/src/protoOS/routePrefetch.ts`, both of which carry the canonical add-a-route runbook at the top of the file.
