### PR TITLE
feat(fleetnode): long-running daemon (heartbeat-first)

### DIFF
--- a/server/cmd/fleetnode/fake_gateway_test.go
+++ b/server/cmd/fleetnode/fake_gateway_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -34,6 +35,16 @@ type fakeFleetNodeGateway struct {
 
 	registered        bool
 	signatureVerified bool
+
+	heartbeatMu          sync.Mutex
+	heartbeatsReceived   []heartbeatRecord
+	expectedSessionToken string
+	onHeartbeat          func(count int)
+}
+
+type heartbeatRecord struct {
+	authHeader string
+	sentAt     time.Time
 }
 
 func (f *fakeFleetNodeGateway) Register(_ context.Context, req *connect.Request[pb.RegisterRequest]) (*connect.Response[pb.RegisterResponse], error) {
@@ -77,6 +88,36 @@ func (f *fakeFleetNodeGateway) CompleteAuthHandshake(_ context.Context, req *con
 		SessionToken: f.sessionToken,
 		ExpiresAt:    timestamppb.New(f.sessionExpiresAt),
 	}), nil
+}
+
+func (f *fakeFleetNodeGateway) UploadHeartbeat(_ context.Context, req *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error) {
+	auth := req.Header().Get("Authorization")
+	if f.expectedSessionToken != "" && auth != "Bearer "+f.expectedSessionToken {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("invalid session token"))
+	}
+	f.heartbeatMu.Lock()
+	f.heartbeatsReceived = append(f.heartbeatsReceived, heartbeatRecord{authHeader: auth, sentAt: req.Msg.GetSentAt().AsTime()})
+	count := len(f.heartbeatsReceived)
+	cb := f.onHeartbeat
+	f.heartbeatMu.Unlock()
+	if cb != nil {
+		cb(count)
+	}
+	return connect.NewResponse(&pb.UploadHeartbeatResponse{ReceivedAt: timestamppb.Now()}), nil
+}
+
+func (f *fakeFleetNodeGateway) heartbeatCount() int {
+	f.heartbeatMu.Lock()
+	defer f.heartbeatMu.Unlock()
+	return len(f.heartbeatsReceived)
+}
+
+func (f *fakeFleetNodeGateway) heartbeats() []heartbeatRecord {
+	f.heartbeatMu.Lock()
+	defer f.heartbeatMu.Unlock()
+	out := make([]heartbeatRecord, len(f.heartbeatsReceived))
+	copy(out, f.heartbeatsReceived)
+	return out
 }
 
 func newFakeServer(t *testing.T, fake *fakeFleetNodeGateway) *httptest.Server {

--- a/server/cmd/fleetnode/main.go
+++ b/server/cmd/fleetnode/main.go
@@ -17,6 +17,7 @@ type CLI struct {
 	Enroll  EnrollCmd  `cmd:"" help:"register this fleet node with a fleet server"`
 	Status  StatusCmd  `cmd:"" help:"print local fleet node state"`
 	Refresh RefreshCmd `cmd:"" help:"renew the session token using the stored api_key"`
+	Run     RunCmd     `cmd:"" help:"run as a long-running daemon; maintain session and post heartbeats"`
 }
 
 func main() {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -88,9 +88,18 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 	if !exists || st.FleetNodeID == 0 || st.APIKey == "" {
 		return fmt.Errorf("state at %s became invalid between checks; re-run after `fleetnode enroll`", path)
 	}
+	// Validate on every entry, not just on the refresh path, so a tampered
+	// state cannot redirect bearer heartbeats to a plaintext non-loopback
+	// URL when the existing session_token is still fresh.
+	if err := fleetnodebootstrap.ValidateServerURL(st.ServerURL, st.AllowInsecureTransport); err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(r.parentCtx, r.signals...)
+	defer stop()
 
 	if r.sessionNeedsRefresh(st) {
-		if err := r.refreshAndSave(context.Background(), st, path, logger); err != nil {
+		if err := r.refreshAndSave(ctx, st, path, logger); err != nil {
 			if errors.Is(err, fleetnodebootstrap.ErrBeginAuthRejected) {
 				return fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Verify the api_key matches the one minted in the UI and retry; local credentials are preserved", fleetnodebootstrap.ErrBeginAuthRejected)
 			}
@@ -99,9 +108,6 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 	}
 
 	client := r.clientFactory(st.ServerURL, func() string { return st.SessionToken })
-
-	ctx, stop := signal.NotifyContext(r.parentCtx, r.signals...)
-	defer stop()
 
 	logger.Info("daemon started",
 		"fleet_node_id", st.FleetNodeID,
@@ -172,7 +178,7 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *fleetnodebo
 		logger.Error("heartbeat failed", "fleet_node_id", st.FleetNodeID, "err", err)
 		return
 	}
-	logger.Debug("heartbeat sent", "fleet_node_id", st.FleetNodeID)
+	logger.Info("heartbeat sent", "fleet_node_id", st.FleetNodeID)
 }
 
 func (r *RunCmd) sendHeartbeat(ctx context.Context, client gatewayClient) error {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -119,14 +119,18 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 	ticker := time.NewTicker(r.HeartbeatInterval)
 	defer ticker.Stop()
 
-	r.tick(ctx, client, st, path, logger)
+	if err := r.tick(ctx, client, st, path, logger); err != nil {
+		return err
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			logger.Info("daemon shutting down", "fleet_node_id", st.FleetNodeID)
 			return nil
 		case <-ticker.C:
-			r.tick(ctx, client, st, path, logger)
+			if err := r.tick(ctx, client, st, path, logger); err != nil {
+				return err
+			}
 		}
 	}
 }
@@ -153,32 +157,53 @@ func (r *RunCmd) refreshAndSave(ctx context.Context, st *fleetnodebootstrap.Stat
 	return nil
 }
 
-func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, path string, logger *slog.Logger) {
+// tick runs one heartbeat cycle. A non-nil return signals a permanent
+// condition (server-side credential revoked or fleet_node deleted) that
+// the operator must resolve by re-enrolling; the daemon exits instead of
+// looping forever. Transient errors are logged and tick returns nil so
+// the next tick can retry.
+func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, path string, logger *slog.Logger) error {
 	if r.sessionNeedsRefresh(st) {
 		if err := r.refreshAndSave(ctx, st, path, logger); err != nil {
+			if errors.Is(err, fleetnodebootstrap.ErrBeginAuthRejected) {
+				return fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Exiting; re-enroll once the operator-side cause is resolved", fleetnodebootstrap.ErrBeginAuthRejected)
+			}
 			logger.Error("session refresh failed; will retry on next tick", "fleet_node_id", st.FleetNodeID, "err", err)
-			return
+			return nil
 		}
 	}
 
-	if err := r.sendHeartbeat(ctx, client); err != nil {
-		if connect.CodeOf(err) == connect.CodeUnauthenticated {
-			logger.Warn("heartbeat rejected as Unauthenticated; refreshing session and retrying", "fleet_node_id", st.FleetNodeID, "err", err)
-			if refreshErr := r.refreshAndSave(ctx, st, path, logger); refreshErr != nil {
-				logger.Error("post-Unauthenticated refresh failed; will retry on next tick", "fleet_node_id", st.FleetNodeID, "err", refreshErr)
-				return
-			}
-			if retryErr := r.sendHeartbeat(ctx, client); retryErr != nil {
-				logger.Error("heartbeat retry after refresh failed", "fleet_node_id", st.FleetNodeID, "err", retryErr)
-				return
-			}
-			logger.Info("heartbeat sent after refresh", "fleet_node_id", st.FleetNodeID)
-			return
-		}
-		logger.Error("heartbeat failed", "fleet_node_id", st.FleetNodeID, "err", err)
-		return
+	err := r.sendHeartbeat(ctx, client)
+	if err == nil {
+		logger.Info("heartbeat sent", "fleet_node_id", st.FleetNodeID)
+		return nil
 	}
-	logger.Info("heartbeat sent", "fleet_node_id", st.FleetNodeID)
+	if code := connect.CodeOf(err); code == connect.CodeNotFound {
+		return fmt.Errorf("fleet_node not found server-side (revoked or deleted); exiting, re-enroll on this host: %w", err)
+	}
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		logger.Error("heartbeat failed", "fleet_node_id", st.FleetNodeID, "err", err)
+		return nil
+	}
+
+	logger.Warn("heartbeat rejected as Unauthenticated; refreshing session and retrying", "fleet_node_id", st.FleetNodeID, "err", err)
+	if refreshErr := r.refreshAndSave(ctx, st, path, logger); refreshErr != nil {
+		if errors.Is(refreshErr, fleetnodebootstrap.ErrBeginAuthRejected) {
+			return fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Exiting; re-enroll once the operator-side cause is resolved", fleetnodebootstrap.ErrBeginAuthRejected)
+		}
+		logger.Error("post-Unauthenticated refresh failed; will retry on next tick", "fleet_node_id", st.FleetNodeID, "err", refreshErr)
+		return nil
+	}
+	retryErr := r.sendHeartbeat(ctx, client)
+	if retryErr == nil {
+		logger.Info("heartbeat sent after refresh", "fleet_node_id", st.FleetNodeID)
+		return nil
+	}
+	if code := connect.CodeOf(retryErr); code == connect.CodeNotFound {
+		return fmt.Errorf("fleet_node not found server-side (revoked or deleted); exiting, re-enroll on this host: %w", retryErr)
+	}
+	logger.Error("heartbeat retry after refresh failed", "fleet_node_id", st.FleetNodeID, "err", retryErr)
+	return nil
 }
 
 func (r *RunCmd) sendHeartbeat(ctx context.Context, client gatewayClient) error {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
+	"github.com/block/proto-fleet/server/internal/fleetnodebootstrap"
+)
+
+const (
+	defaultHeartbeatInterval = 30 * time.Second
+	sessionRefreshLeeway     = 1 * time.Hour
+)
+
+type RunCmd struct {
+	HeartbeatInterval time.Duration `name:"heartbeat-interval" default:"30s" help:"interval between UploadHeartbeat calls"`
+
+	now           func() time.Time                                                `kong:"-"`
+	clientFactory func(serverURL string, tokenSource func() string) gatewayClient `kong:"-"`
+	signals       []os.Signal                                                     `kong:"-"`
+	parentCtx     context.Context                                                 `kong:"-"` //nolint:containedctx // test seam for daemon shutdown without OS signals
+}
+
+type gatewayClient interface {
+	UploadHeartbeat(ctx context.Context, req *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error)
+}
+
+func (r *RunCmd) Run(c *Context) error {
+	return r.run(c, os.Stderr)
+}
+
+func (r *RunCmd) run(c *Context, stderr io.Writer) error {
+	if r.HeartbeatInterval <= 0 {
+		r.HeartbeatInterval = defaultHeartbeatInterval
+	}
+	if r.now == nil {
+		r.now = func() time.Time { return time.Now().UTC() }
+	}
+	if r.clientFactory == nil {
+		r.clientFactory = func(url string, src func() string) gatewayClient {
+			return fleetnodebootstrap.NewAuthenticatedGatewayClient(url, src)
+		}
+	}
+	if len(r.signals) == 0 {
+		r.signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+	}
+	if r.parentCtx == nil {
+		r.parentCtx = context.Background()
+	}
+
+	path := fleetnodebootstrap.StatePath(c.StateDir)
+	st, exists, err := fleetnodebootstrap.LoadState(path)
+	if err != nil {
+		return err
+	}
+	if !exists || st.FleetNodeID == 0 {
+		return fmt.Errorf("no state at %s; run `fleetnode enroll` first", path)
+	}
+	if st.APIKey == "" {
+		return fmt.Errorf("state at %s has no api_key; complete enrollment via `fleetnode refresh` before running the daemon", path)
+	}
+
+	logger := slog.New(slog.NewTextHandler(stderr, nil))
+
+	return fleetnodebootstrap.WithStateLock(c.StateDir, func() error {
+		return r.runLocked(c, logger)
+	})
+}
+
+func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
+	path := fleetnodebootstrap.StatePath(c.StateDir)
+	st, exists, err := fleetnodebootstrap.LoadState(path)
+	if err != nil {
+		return err
+	}
+	if !exists || st.FleetNodeID == 0 || st.APIKey == "" {
+		return fmt.Errorf("state at %s became invalid between checks; re-run after `fleetnode enroll`", path)
+	}
+
+	if r.sessionNeedsRefresh(st) {
+		if err := r.refreshAndSave(context.Background(), st, path, logger); err != nil {
+			if errors.Is(err, fleetnodebootstrap.ErrBeginAuthRejected) {
+				return fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Verify the api_key matches the one minted in the UI and retry; local credentials are preserved", fleetnodebootstrap.ErrBeginAuthRejected)
+			}
+			return fmt.Errorf("initial session refresh: %w", err)
+		}
+	}
+
+	client := r.clientFactory(st.ServerURL, func() string { return st.SessionToken })
+
+	ctx, stop := signal.NotifyContext(r.parentCtx, r.signals...)
+	defer stop()
+
+	logger.Info("daemon started",
+		"fleet_node_id", st.FleetNodeID,
+		"server_url", st.ServerURL,
+		"heartbeat_interval", r.HeartbeatInterval.String(),
+		"session_expires_at", st.SessionExpiresAt.Format(time.RFC3339),
+	)
+
+	ticker := time.NewTicker(r.HeartbeatInterval)
+	defer ticker.Stop()
+
+	r.tick(ctx, client, st, path, logger)
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("daemon shutting down", "fleet_node_id", st.FleetNodeID)
+			return nil
+		case <-ticker.C:
+			r.tick(ctx, client, st, path, logger)
+		}
+	}
+}
+
+func (r *RunCmd) sessionNeedsRefresh(st *fleetnodebootstrap.State) bool {
+	if st.SessionToken == "" {
+		return true
+	}
+	if st.SessionExpiresAt.IsZero() {
+		return true
+	}
+	return st.SessionExpiresAt.Sub(r.now()) < sessionRefreshLeeway
+}
+
+func (r *RunCmd) refreshAndSave(ctx context.Context, st *fleetnodebootstrap.State, path string, logger *slog.Logger) error {
+	logger.Info("refreshing session", "fleet_node_id", st.FleetNodeID, "session_expires_at", st.SessionExpiresAt.Format(time.RFC3339))
+	if err := fleetnodebootstrap.Refresh(ctx, st); err != nil {
+		return err
+	}
+	if err := fleetnodebootstrap.SaveState(path, st); err != nil {
+		return fmt.Errorf("save state after refresh: %w", err)
+	}
+	logger.Info("session refreshed", "fleet_node_id", st.FleetNodeID, "session_expires_at", st.SessionExpiresAt.Format(time.RFC3339))
+	return nil
+}
+
+func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, path string, logger *slog.Logger) {
+	if r.sessionNeedsRefresh(st) {
+		if err := r.refreshAndSave(ctx, st, path, logger); err != nil {
+			logger.Error("session refresh failed; will retry on next tick", "fleet_node_id", st.FleetNodeID, "err", err)
+			return
+		}
+	}
+
+	if err := r.sendHeartbeat(ctx, client); err != nil {
+		if connect.CodeOf(err) == connect.CodeUnauthenticated {
+			logger.Warn("heartbeat rejected as Unauthenticated; refreshing session and retrying", "fleet_node_id", st.FleetNodeID, "err", err)
+			if refreshErr := r.refreshAndSave(ctx, st, path, logger); refreshErr != nil {
+				logger.Error("post-Unauthenticated refresh failed; will retry on next tick", "fleet_node_id", st.FleetNodeID, "err", refreshErr)
+				return
+			}
+			if retryErr := r.sendHeartbeat(ctx, client); retryErr != nil {
+				logger.Error("heartbeat retry after refresh failed", "fleet_node_id", st.FleetNodeID, "err", retryErr)
+				return
+			}
+			logger.Info("heartbeat sent after refresh", "fleet_node_id", st.FleetNodeID)
+			return
+		}
+		logger.Error("heartbeat failed", "fleet_node_id", st.FleetNodeID, "err", err)
+		return
+	}
+	logger.Debug("heartbeat sent", "fleet_node_id", st.FleetNodeID)
+}
+
+func (r *RunCmd) sendHeartbeat(ctx context.Context, client gatewayClient) error {
+	_, err := client.UploadHeartbeat(ctx, connect.NewRequest(&pb.UploadHeartbeatRequest{
+		SentAt: timestamppb.New(r.now()),
+	}))
+	return err
+}
+
+var _ gatewayClient = fleetnodegatewayv1connect.FleetNodeGatewayServiceClient(nil)

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -1,0 +1,303 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+
+	"github.com/block/proto-fleet/server/internal/fleetnodebootstrap"
+)
+
+type stubGatewayClient struct {
+	mu               sync.Mutex
+	calls            int
+	authHeaders      []string
+	responder        func(call int) error
+	cancelAfterCalls int
+	cancel           context.CancelFunc
+}
+
+func (s *stubGatewayClient) UploadHeartbeat(_ context.Context, req *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error) {
+	s.mu.Lock()
+	s.calls++
+	s.authHeaders = append(s.authHeaders, req.Header().Get("Authorization"))
+	call := s.calls
+	cancelAt := s.cancelAfterCalls
+	cancel := s.cancel
+	resp := s.responder
+	s.mu.Unlock()
+
+	var err error
+	if resp != nil {
+		err = resp(call)
+	}
+	if cancelAt > 0 && call >= cancelAt && cancel != nil {
+		cancel()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&pb.UploadHeartbeatResponse{}), nil
+}
+
+func (s *stubGatewayClient) snapshot() (int, []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.authHeaders))
+	copy(out, s.authHeaders)
+	return s.calls, out
+}
+
+func freshState(t *testing.T, dir string, sessionExpiresAt time.Time) *fleetnodebootstrap.State {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	st := &fleetnodebootstrap.State{
+		ServerURL:              "http://127.0.0.1:0",
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityFingerprint:    "0011223344556677",
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pub),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "session-1",
+		SessionExpiresAt:       sessionExpiresAt,
+	}
+	require.NoError(t, fleetnodebootstrap.SaveState(fleetnodebootstrap.StatePath(dir), st))
+	return st
+}
+
+func TestRunCmd_HappyPathThreeTicks(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	freshState(t, dir, time.Now().Add(24*time.Hour))
+
+	parent, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stub := &stubGatewayClient{cancelAfterCalls: 3, cancel: cancel}
+
+	cmd := &RunCmd{
+		HeartbeatInterval: 5 * time.Millisecond,
+		parentCtx:         parent,
+		clientFactory:     func(_ string, _ func() string) gatewayClient { return stub },
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.run(&Context{StateDir: dir}, &bytes.Buffer{}) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon did not shut down within 2s after the stub cancelled parent ctx")
+	}
+
+	// Assert
+	calls, _ := stub.snapshot()
+	assert.GreaterOrEqual(t, calls, 3, "daemon must send at least 3 heartbeats before shutdown")
+}
+
+func TestRunCmd_RefreshesNearExpirySession(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	pub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	fake := &fakeFleetNodeGateway{
+		expectedAPIKey:   "fleet_known_key",
+		identityPub:      pub,
+		challenge:        bytes.Repeat([]byte{0x33}, 32),
+		sessionToken:     "session-rotated",
+		sessionExpiresAt: time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second),
+	}
+	srv := newFakeServer(t, fake)
+
+	pubKey, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	fake.identityPub = pubKey
+	st := &fleetnodebootstrap.State{
+		ServerURL:              srv.URL,
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityFingerprint:    "0011223344556677",
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "session-stale",
+		SessionExpiresAt:       time.Now().Add(30 * time.Minute),
+	}
+	require.NoError(t, fleetnodebootstrap.SaveState(fleetnodebootstrap.StatePath(dir), st))
+
+	parent, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fake.onHeartbeat = func(int) { cancel() }
+
+	cmd := &RunCmd{HeartbeatInterval: 5 * time.Millisecond, parentCtx: parent}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.run(&Context{StateDir: dir}, &bytes.Buffer{}) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon did not shut down within 3s of the first heartbeat")
+	}
+
+	// Assert
+	loaded, _, err := fleetnodebootstrap.LoadState(fleetnodebootstrap.StatePath(dir))
+	require.NoError(t, err)
+	assert.Equal(t, "session-rotated", loaded.SessionToken, "near-expiry session must be refreshed before first heartbeat")
+	assert.Equal(t, 1, fake.heartbeatCount(), "exactly one heartbeat before shutdown")
+}
+
+func TestRunCmd_RefreshesOnUnauthenticatedResponse(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	pubKey, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	fake := &fakeFleetNodeGateway{
+		expectedAPIKey:       "fleet_known_key",
+		identityPub:          pubKey,
+		challenge:            bytes.Repeat([]byte{0x44}, 32),
+		sessionToken:         "session-2",
+		sessionExpiresAt:     time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second),
+		expectedSessionToken: "session-2",
+	}
+	srv := newFakeServer(t, fake)
+	require.NoError(t, fleetnodebootstrap.SaveState(fleetnodebootstrap.StatePath(dir), &fleetnodebootstrap.State{
+		ServerURL:              srv.URL,
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityFingerprint:    "0011223344556677",
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "session-1",
+		SessionExpiresAt:       time.Now().Add(24 * time.Hour),
+	}))
+
+	parent, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	successfulHeartbeats := atomic.Int64{}
+	fake.onHeartbeat = func(count int) {
+		successfulHeartbeats.Store(int64(count))
+		if count >= 3 {
+			cancel()
+		}
+	}
+
+	cmd := &RunCmd{HeartbeatInterval: 5 * time.Millisecond, parentCtx: parent}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.run(&Context{StateDir: dir}, &bytes.Buffer{}) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatalf("daemon did not recover and reach 3 successful heartbeats; got %d", successfulHeartbeats.Load())
+	}
+
+	// Assert
+	loaded, _, _ := fleetnodebootstrap.LoadState(fleetnodebootstrap.StatePath(dir))
+	assert.Equal(t, "session-2", loaded.SessionToken, "Unauthenticated rejection must trigger a refresh that persists the new token")
+}
+
+func TestRunCmd_FailsWhenStateIsMissing(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	parent := t.TempDir()
+	stateDir := filepath.Join(parent, "never-existed")
+	cmd := &RunCmd{HeartbeatInterval: time.Second}
+	var stderr bytes.Buffer
+
+	// Act
+	err := cmd.run(&Context{StateDir: stateDir}, &stderr)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fleetnode enroll")
+	_, statErr := os.Stat(stateDir)
+	assert.True(t, os.IsNotExist(statErr), "state dir must not be created when run bails out on missing state")
+}
+
+func TestRunCmd_FailsWhenApiKeyIsMissing(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	pubKey, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	require.NoError(t, fleetnodebootstrap.SaveState(fleetnodebootstrap.StatePath(dir), &fleetnodebootstrap.State{
+		ServerURL:              "http://127.0.0.1:1",
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityFingerprint:    "0011223344556677",
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+	}))
+	cmd := &RunCmd{HeartbeatInterval: time.Second}
+
+	// Act
+	err = cmd.run(&Context{StateDir: dir}, &bytes.Buffer{})
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fleetnode refresh")
+}
+
+func TestRunCmd_BailsOutWhenInitialRefreshHitsBeginAuthRejected(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	pubKey, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	fake := &fakeFleetNodeGateway{
+		expectedAPIKey:   "the-real-key",
+		identityPub:      pubKey,
+		challenge:        bytes.Repeat([]byte{0x55}, 32),
+		sessionToken:     "irrelevant",
+		sessionExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	srv := newFakeServer(t, fake)
+	require.NoError(t, fleetnodebootstrap.SaveState(fleetnodebootstrap.StatePath(dir), &fleetnodebootstrap.State{
+		ServerURL:              srv.URL,
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityFingerprint:    "0011223344556677",
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "wrong-key",
+		SessionToken:           "",
+	}))
+	cmd := &RunCmd{HeartbeatInterval: time.Second}
+
+	// Act
+	err = cmd.run(&Context{StateDir: dir}, &bytes.Buffer{})
+
+	// Assert
+	require.Error(t, err)
+	assert.ErrorIs(t, err, fleetnodebootstrap.ErrBeginAuthRejected)
+	assert.Contains(t, err.Error(), "local credentials are preserved")
+}

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -337,4 +338,82 @@ func TestRunCmd_ValidatesServerURLBeforeBuildingClient(t *testing.T) {
 	assert.Contains(t, err.Error(), "https")
 	calls, _ := stub.snapshot()
 	assert.Equal(t, 0, calls, "no heartbeat must be sent when server URL fails validation")
+}
+
+func TestRunCmd_ExitsOnCodeNotFoundHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	dir := t.TempDir()
+	freshState(t, dir, time.Now().Add(24*time.Hour))
+	stub := &stubGatewayClient{
+		responder: func(int) error {
+			return connect.NewError(connect.CodeNotFound, errors.New("fleet node not found"))
+		},
+	}
+	cmd := &RunCmd{
+		HeartbeatInterval: 5 * time.Millisecond,
+		clientFactory:     func(_ string, _ func() string) gatewayClient { return stub },
+	}
+
+	// Act
+	done := make(chan error, 1)
+	go func() { done <- cmd.run(&Context{StateDir: dir}, &bytes.Buffer{}) }()
+
+	// Assert
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+		assert.Contains(t, err.Error(), "re-enroll")
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon did not exit within 2s after server returned CodeNotFound")
+	}
+}
+
+func TestRunCmd_ExitsWhenTickRefreshHitsBeginAuthRejected(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: heartbeat returns Unauthenticated which forces a tick
+	// refresh; the fake's expectedAPIKey is wrong, so the refresh
+	// BeginAuthHandshake also returns Unauthenticated -> ErrBeginAuthRejected.
+	// The daemon must exit instead of looping forever.
+	dir := t.TempDir()
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	fake := &fakeFleetNodeGateway{
+		expectedAPIKey:       "the-key-that-was-revoked",
+		identityPub:          pubKey,
+		challenge:            bytes.Repeat([]byte{0x99}, 32),
+		sessionToken:         "never-issued",
+		sessionExpiresAt:     time.Now().Add(24 * time.Hour),
+		expectedSessionToken: "different-from-state",
+	}
+	srv := newFakeServer(t, fake)
+	require.NoError(t, fleetnodebootstrap.SaveState(fleetnodebootstrap.StatePath(dir), &fleetnodebootstrap.State{
+		ServerURL:              srv.URL,
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityFingerprint:    "0011223344556677",
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "stale-session",
+		SessionExpiresAt:       time.Now().Add(24 * time.Hour),
+	}))
+	cmd := &RunCmd{HeartbeatInterval: 5 * time.Millisecond}
+
+	// Act
+	done := make(chan error, 1)
+	go func() { done <- cmd.run(&Context{StateDir: dir}, &bytes.Buffer{}) }()
+
+	// Assert
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, fleetnodebootstrap.ErrBeginAuthRejected)
+		assert.Contains(t, err.Error(), "Exiting")
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon did not exit within 3s after tick refresh hit ErrBeginAuthRejected")
+	}
 }

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/hex"
 	"os"
 	"path/filepath"
@@ -63,7 +64,7 @@ func (s *stubGatewayClient) snapshot() (int, []string) {
 
 func freshState(t *testing.T, dir string, sessionExpiresAt time.Time) *fleetnodebootstrap.State {
 	t.Helper()
-	pub, priv, err := ed25519.GenerateKey(nil)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 	st := &fleetnodebootstrap.State{
 		ServerURL:              "http://127.0.0.1:0",
@@ -117,7 +118,7 @@ func TestRunCmd_RefreshesNearExpirySession(t *testing.T) {
 
 	// Arrange
 	dir := t.TempDir()
-	pub, _, err := ed25519.GenerateKey(nil)
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 	fake := &fakeFleetNodeGateway{
 		expectedAPIKey:   "fleet_known_key",
@@ -128,7 +129,7 @@ func TestRunCmd_RefreshesNearExpirySession(t *testing.T) {
 	}
 	srv := newFakeServer(t, fake)
 
-	pubKey, priv, err := ed25519.GenerateKey(nil)
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 	fake.identityPub = pubKey
 	st := &fleetnodebootstrap.State{
@@ -172,7 +173,7 @@ func TestRunCmd_RefreshesOnUnauthenticatedResponse(t *testing.T) {
 
 	// Arrange
 	dir := t.TempDir()
-	pubKey, priv, err := ed25519.GenerateKey(nil)
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 	fake := &fakeFleetNodeGateway{
 		expectedAPIKey:       "fleet_known_key",
@@ -246,7 +247,7 @@ func TestRunCmd_FailsWhenApiKeyIsMissing(t *testing.T) {
 
 	// Arrange
 	dir := t.TempDir()
-	pubKey, priv, err := ed25519.GenerateKey(nil)
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 	require.NoError(t, fleetnodebootstrap.SaveState(fleetnodebootstrap.StatePath(dir), &fleetnodebootstrap.State{
 		ServerURL:              "http://127.0.0.1:1",
@@ -271,7 +272,7 @@ func TestRunCmd_BailsOutWhenInitialRefreshHitsBeginAuthRejected(t *testing.T) {
 
 	// Arrange
 	dir := t.TempDir()
-	pubKey, priv, err := ed25519.GenerateKey(nil)
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 	fake := &fakeFleetNodeGateway{
 		expectedAPIKey:   "the-real-key",
@@ -300,4 +301,40 @@ func TestRunCmd_BailsOutWhenInitialRefreshHitsBeginAuthRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, fleetnodebootstrap.ErrBeginAuthRejected)
 	assert.Contains(t, err.Error(), "local credentials are preserved")
+}
+
+func TestRunCmd_ValidatesServerURLBeforeBuildingClient(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: state has a fresh session_token but an http:// non-loopback
+	// server_url and AllowInsecureTransport=false. The daemon must refuse
+	// to start before any heartbeat would leak the bearer to plaintext.
+	dir := t.TempDir()
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	require.NoError(t, fleetnodebootstrap.SaveState(fleetnodebootstrap.StatePath(dir), &fleetnodebootstrap.State{
+		ServerURL:              "http://fleet.example.com",
+		AllowInsecureTransport: false,
+		FleetNodeID:            42,
+		IdentityFingerprint:    "0011223344556677",
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "session-still-fresh",
+		SessionExpiresAt:       time.Now().Add(24 * time.Hour),
+	}))
+	stub := &stubGatewayClient{}
+	cmd := &RunCmd{
+		HeartbeatInterval: time.Second,
+		clientFactory:     func(_ string, _ func() string) gatewayClient { return stub },
+	}
+
+	// Act
+	err = cmd.run(&Context{StateDir: dir}, &bytes.Buffer{})
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+	calls, _ := stub.snapshot()
+	assert.Equal(t, 0, calls, "no heartbeat must be sent when server URL fails validation")
 }

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -774,6 +774,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.updateDiscoveredDeviceFirmwareVersionStmt, err = db.PrepareContext(ctx, updateDiscoveredDeviceFirmwareVersion); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateDiscoveredDeviceFirmwareVersion: %w", err)
 	}
+	if q.updateFleetNodeLastSeenAtStmt, err = db.PrepareContext(ctx, updateFleetNodeLastSeenAt); err != nil {
+		return nil, fmt.Errorf("error preparing query UpdateFleetNodeLastSeenAt: %w", err)
+	}
 	if q.updateLastLoginStmt, err = db.PrepareContext(ctx, updateLastLogin); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateLastLogin: %w", err)
 	}
@@ -2107,6 +2110,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing updateDiscoveredDeviceFirmwareVersionStmt: %w", cerr)
 		}
 	}
+	if q.updateFleetNodeLastSeenAtStmt != nil {
+		if cerr := q.updateFleetNodeLastSeenAtStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing updateFleetNodeLastSeenAtStmt: %w", cerr)
+		}
+	}
 	if q.updateLastLoginStmt != nil {
 		if cerr := q.updateLastLoginStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateLastLoginStmt: %w", cerr)
@@ -2526,6 +2534,7 @@ type Queries struct {
 	updateDeviceWorkerNameStmt                          *sql.Stmt
 	updateDeviceWorkerNamePoolSyncStatusByIDStmt        *sql.Stmt
 	updateDiscoveredDeviceFirmwareVersionStmt           *sql.Stmt
+	updateFleetNodeLastSeenAtStmt                       *sql.Stmt
 	updateLastLoginStmt                                 *sql.Stmt
 	updateMessageAfterFailureStmt                       *sql.Stmt
 	updateMessagePermanentlyFailedStmt                  *sql.Stmt
@@ -2808,6 +2817,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		updateDeviceWorkerNameStmt:                          q.updateDeviceWorkerNameStmt,
 		updateDeviceWorkerNamePoolSyncStatusByIDStmt:        q.updateDeviceWorkerNamePoolSyncStatusByIDStmt,
 		updateDiscoveredDeviceFirmwareVersionStmt:           q.updateDiscoveredDeviceFirmwareVersionStmt,
+		updateFleetNodeLastSeenAtStmt:                       q.updateFleetNodeLastSeenAtStmt,
 		updateLastLoginStmt:                                 q.updateLastLoginStmt,
 		updateMessageAfterFailureStmt:                       q.updateMessageAfterFailureStmt,
 		updateMessagePermanentlyFailedStmt:                  q.updateMessagePermanentlyFailedStmt,

--- a/server/generated/sqlc/fleetnode_enrollment.sql.go
+++ b/server/generated/sqlc/fleetnode_enrollment.sql.go
@@ -482,3 +482,23 @@ func (q *Queries) SweepExpiredEnrollments(ctx context.Context, expiresAt time.Ti
 	}
 	return result.RowsAffected()
 }
+
+const updateFleetNodeLastSeenAt = `-- name: UpdateFleetNodeLastSeenAt :execrows
+UPDATE fleet_node
+SET last_seen_at = $1
+WHERE id = $2 AND org_id = $3 AND deleted_at IS NULL
+`
+
+type UpdateFleetNodeLastSeenAtParams struct {
+	LastSeenAt sql.NullTime
+	ID         int64
+	OrgID      int64
+}
+
+func (q *Queries) UpdateFleetNodeLastSeenAt(ctx context.Context, arg UpdateFleetNodeLastSeenAtParams) (int64, error) {
+	result, err := q.exec(ctx, q.updateFleetNodeLastSeenAtStmt, updateFleetNodeLastSeenAt, arg.LastSeenAt, arg.ID, arg.OrgID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/server/internal/domain/fleetnodeenrollment/integration_test.go
+++ b/server/internal/domain/fleetnodeenrollment/integration_test.go
@@ -433,3 +433,39 @@ func TestListAgentsSurfacesAwaitingConfirmation(t *testing.T) {
 	require.Equal(t, fleetnodeenrollment.FleetNodeStatusPending, found.EnrollmentStatus)
 	require.Equal(t, fleetnodeenrollment.StatusAwaitingConfirmation, found.PendingEnrollmentStatus)
 }
+
+func TestUpdateLastSeenAdvancesTimestamp(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	db, userID, orgID, enrollment, _ := setupEnrollmentTest(t)
+	pubKey, _, _ := ed25519.GenerateKey(rand.Reader)
+	signing, _, _ := ed25519.GenerateKey(rand.Reader)
+	code, _, err := enrollment.CreateCode(ctx, userID, orgID, time.Hour)
+	require.NoError(t, err)
+	agent, _, err := enrollment.RegisterFleetNode(ctx, code, "agent-heartbeat", pubKey, signing)
+	require.NoError(t, err)
+	heartbeat := time.Now().UTC().Truncate(time.Second)
+
+	// Act
+	err = enrollment.UpdateLastSeen(ctx, agent.ID, orgID, heartbeat)
+
+	// Assert
+	require.NoError(t, err)
+	var lastSeen sql.NullTime
+	require.NoError(t, db.QueryRow(`SELECT last_seen_at FROM fleet_node WHERE id = $1`, agent.ID).Scan(&lastSeen))
+	require.True(t, lastSeen.Valid, "last_seen_at must be set after heartbeat")
+	require.WithinDuration(t, heartbeat, lastSeen.Time, time.Second)
+}
+
+func TestUpdateLastSeenReturnsNotFoundForDeletedFleetNode(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	_, _, orgID, enrollment, _ := setupEnrollmentTest(t)
+
+	// Act
+	err := enrollment.UpdateLastSeen(ctx, 99999, orgID, time.Now().UTC())
+
+	// Assert
+	require.Error(t, err)
+	require.True(t, fleeterror.IsNotFoundError(err))
+}

--- a/server/internal/domain/fleetnodeenrollment/service.go
+++ b/server/internal/domain/fleetnodeenrollment/service.go
@@ -31,6 +31,7 @@ const (
 	clientErrCancel            = "enrollment cancellation failed"
 	clientErrListFleetNodes    = "failed to list fleet nodes"
 	clientErrRevokeFleetNode   = "fleet node revocation failed"
+	clientErrUpdateLastSeen    = "heartbeat update failed"
 
 	component = "fleet node enrollment"
 )
@@ -60,6 +61,7 @@ type AgentStore interface {
 	SetFleetNodeEnrollmentStatus(ctx context.Context, status FleetNodeStatus, agentID, orgID int64) (int64, error)
 	SoftDeleteFleetNode(ctx context.Context, agentID, orgID int64, deletedAt time.Time) (int64, error)
 	SoftDeleteFleetNodesForExpiredEnrollments(ctx context.Context, now time.Time) (int64, error)
+	UpdateLastSeen(ctx context.Context, fleetNodeID, orgID int64, now time.Time) (int64, error)
 }
 
 type Store interface {
@@ -261,6 +263,21 @@ func (s *Service) RevokeFleetNode(ctx context.Context, agentID, orgID int64) err
 		return err
 	}
 	s.logActivity(ctx, "revoke_fleet_node", fmt.Sprintf("Revoked fleet node '%s' (id=%d)", agentName, agentID))
+	return nil
+}
+
+// UpdateLastSeen advances last_seen_at on the fleet_node row. 0 rows
+// affected means the fleet_node was soft-deleted (or scoped to a different
+// org) between the auth interceptor's session lookup and now; surface
+// NotFound so the daemon's session resolver fails on its next refresh.
+func (s *Service) UpdateLastSeen(ctx context.Context, fleetNodeID, orgID int64, now time.Time) error {
+	rows, err := s.store.UpdateLastSeen(ctx, fleetNodeID, orgID, now)
+	if err != nil {
+		return logInternal("update last_seen_at", clientErrUpdateLastSeen, err)
+	}
+	if rows == 0 {
+		return fleeterror.NewNotFoundError("fleet node not found")
+	}
 	return nil
 }
 

--- a/server/internal/domain/stores/sqlstores/fleetnodeenrollment.go
+++ b/server/internal/domain/stores/sqlstores/fleetnodeenrollment.go
@@ -178,6 +178,14 @@ func (s *SQLFleetNodeEnrollmentStore) SoftDeleteFleetNodesForExpiredEnrollments(
 	return s.q(ctx).SoftDeleteFleetNodesForExpiredEnrollments(ctx, sql.NullTime{Time: now, Valid: true})
 }
 
+func (s *SQLFleetNodeEnrollmentStore) UpdateLastSeen(ctx context.Context, fleetNodeID, orgID int64, now time.Time) (int64, error) {
+	return s.q(ctx).UpdateFleetNodeLastSeenAt(ctx, sqlc.UpdateFleetNodeLastSeenAtParams{
+		LastSeenAt: sql.NullTime{Time: now, Valid: true},
+		ID:         fleetNodeID,
+		OrgID:      orgID,
+	})
+}
+
 func rowToPending(row sqlc.PendingEnrollment) *fleetnodeenrollment.PendingEnrollment {
 	return &fleetnodeenrollment.PendingEnrollment{
 		ID:          row.ID,

--- a/server/internal/fleetnodebootstrap/authclient.go
+++ b/server/internal/fleetnodebootstrap/authclient.go
@@ -42,12 +42,29 @@ func (b *bearerAuth) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 func (b *bearerAuth) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
 	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
 		conn := next(ctx, spec)
-		if token := b.tokenSource(); token != "" {
-			conn.RequestHeader().Set("Authorization", "Bearer "+token)
+		token := b.tokenSource()
+		if token == "" {
+			return &failingStreamingClientConn{
+				StreamingClientConn: conn,
+				err:                 connect.NewError(connect.CodeUnauthenticated, errors.New("no session token available")),
+			}
 		}
+		conn.RequestHeader().Set("Authorization", "Bearer "+token)
 		return conn
 	}
 }
+
+// failingStreamingClientConn wraps a real conn but forces Send/Receive to
+// surface a fixed error. Used by WrapStreamingClient when the token source
+// returns empty so streaming callers fail fast like the unary path,
+// instead of opening an unauthenticated stream that errors later.
+type failingStreamingClientConn struct {
+	connect.StreamingClientConn
+	err error
+}
+
+func (c *failingStreamingClientConn) Send(any) error    { return c.err }
+func (c *failingStreamingClientConn) Receive(any) error { return c.err }
 
 func (b *bearerAuth) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return next

--- a/server/internal/fleetnodebootstrap/authclient.go
+++ b/server/internal/fleetnodebootstrap/authclient.go
@@ -3,6 +3,7 @@ package fleetnodebootstrap
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"connectrpc.com/connect"
 
@@ -41,30 +42,37 @@ func (b *bearerAuth) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 
 func (b *bearerAuth) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
 	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
-		conn := next(ctx, spec)
 		token := b.tokenSource()
 		if token == "" {
 			return &failingStreamingClientConn{
-				StreamingClientConn: conn,
-				err:                 connect.NewError(connect.CodeUnauthenticated, errors.New("no session token available")),
+				spec: spec,
+				err:  connect.NewError(connect.CodeUnauthenticated, errors.New("no session token available")),
 			}
 		}
+		conn := next(ctx, spec)
 		conn.RequestHeader().Set("Authorization", "Bearer "+token)
 		return conn
 	}
 }
 
-// failingStreamingClientConn wraps a real conn but forces Send/Receive to
-// surface a fixed error. Used by WrapStreamingClient when the token source
-// returns empty so streaming callers fail fast like the unary path,
-// instead of opening an unauthenticated stream that errors later.
+// failingStreamingClientConn is a stub StreamingClientConn that surfaces
+// the configured error from every operation that could open or progress
+// the underlying HTTP request. The real conn is never constructed, so a
+// stream open with no session token does not hit the network at all.
 type failingStreamingClientConn struct {
-	connect.StreamingClientConn
-	err error
+	spec connect.Spec
+	err  error
 }
 
-func (c *failingStreamingClientConn) Send(any) error    { return c.err }
-func (c *failingStreamingClientConn) Receive(any) error { return c.err }
+func (c *failingStreamingClientConn) Spec() connect.Spec           { return c.spec }
+func (c *failingStreamingClientConn) Peer() connect.Peer           { return connect.Peer{} }
+func (c *failingStreamingClientConn) Send(any) error               { return c.err }
+func (c *failingStreamingClientConn) RequestHeader() http.Header   { return http.Header{} }
+func (c *failingStreamingClientConn) CloseRequest() error          { return c.err }
+func (c *failingStreamingClientConn) Receive(any) error            { return c.err }
+func (c *failingStreamingClientConn) ResponseHeader() http.Header  { return http.Header{} }
+func (c *failingStreamingClientConn) ResponseTrailer() http.Header { return http.Header{} }
+func (c *failingStreamingClientConn) CloseResponse() error         { return c.err }
 
 func (b *bearerAuth) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return next

--- a/server/internal/fleetnodebootstrap/authclient.go
+++ b/server/internal/fleetnodebootstrap/authclient.go
@@ -1,0 +1,54 @@
+package fleetnodebootstrap
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+
+	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
+)
+
+// tokenSource is invoked per-call so a daemon that mutates its own
+// state.SessionToken via Refresh picks up the new value on the next
+// request without rebuilding the client.
+func NewAuthenticatedGatewayClient(serverURL string, tokenSource func() string) fleetnodegatewayv1connect.FleetNodeGatewayServiceClient {
+	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(
+		newGatewayHTTPClient(),
+		serverURL,
+		connect.WithInterceptors(bearerInterceptor(tokenSource)),
+	)
+}
+
+func bearerInterceptor(tokenSource func() string) connect.Interceptor {
+	return &bearerAuth{tokenSource: tokenSource}
+}
+
+type bearerAuth struct {
+	tokenSource func() string
+}
+
+func (b *bearerAuth) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		token := b.tokenSource()
+		if token == "" {
+			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("no session token available"))
+		}
+		req.Header().Set("Authorization", "Bearer "+token)
+		return next(ctx, req)
+	}
+}
+
+func (b *bearerAuth) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		conn := next(ctx, spec)
+		if token := b.tokenSource(); token != "" {
+			conn.RequestHeader().Set("Authorization", "Bearer "+token)
+		}
+		return conn
+	}
+}
+
+func (b *bearerAuth) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}

--- a/server/internal/fleetnodebootstrap/authclient_test.go
+++ b/server/internal/fleetnodebootstrap/authclient_test.go
@@ -1,0 +1,87 @@
+package fleetnodebootstrap
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
+)
+
+type captureGateway struct {
+	fleetnodegatewayv1connect.UnimplementedFleetNodeGatewayServiceHandler
+
+	mu              sync.Mutex
+	authHeadersSeen []string
+}
+
+func (c *captureGateway) UploadHeartbeat(_ context.Context, req *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error) {
+	c.mu.Lock()
+	c.authHeadersSeen = append(c.authHeadersSeen, req.Header().Get("Authorization"))
+	c.mu.Unlock()
+	return connect.NewResponse(&pb.UploadHeartbeatResponse{ReceivedAt: timestamppb.Now()}), nil
+}
+
+func (c *captureGateway) headers() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.authHeadersSeen))
+	copy(out, c.authHeadersSeen)
+	return out
+}
+
+func TestAuthenticatedClient_AttachesBearerHeaderPerCall(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fake := &captureGateway{}
+	mux := http.NewServeMux()
+	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
+	mux.Handle(path, h)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	var token string
+	client := NewAuthenticatedGatewayClient(srv.URL, func() string { return token })
+
+	// Act
+	token = "t1"
+	_, err := client.UploadHeartbeat(context.Background(), connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()}))
+	require.NoError(t, err)
+	token = "t2"
+	_, err = client.UploadHeartbeat(context.Background(), connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()}))
+	require.NoError(t, err)
+
+	// Assert
+	got := fake.headers()
+	require.Len(t, got, 2)
+	assert.Equal(t, "Bearer t1", got[0])
+	assert.Equal(t, "Bearer t2", got[1])
+}
+
+func TestAuthenticatedClient_RejectsEmptyToken(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	srv := httptest.NewServer(http.NewServeMux())
+	t.Cleanup(srv.Close)
+	client := NewAuthenticatedGatewayClient(srv.URL, func() string { return "" })
+
+	// Act
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := client.UploadHeartbeat(ctx, connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()}))
+
+	// Assert
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}

--- a/server/internal/handlers/fleetnodegateway/handler.go
+++ b/server/internal/handlers/fleetnodegateway/handler.go
@@ -2,6 +2,7 @@ package fleetnodegateway
 
 import (
 	"context"
+	"time"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -56,5 +57,19 @@ func (h *Handler) CompleteAuthHandshake(ctx context.Context, req *connect.Reques
 	return connect.NewResponse(&pb.CompleteAuthHandshakeResponse{
 		SessionToken: token,
 		ExpiresAt:    timestamppb.New(expiresAt),
+	}), nil
+}
+
+func (h *Handler) UploadHeartbeat(ctx context.Context, _ *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error) {
+	subject, err := fleetnodeauth.GetSubject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	if err := h.enrollment.UpdateLastSeen(ctx, subject.FleetNodeID, subject.OrgID, now); err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&pb.UploadHeartbeatResponse{
+		ReceivedAt: timestamppb.New(now),
 	}), nil
 }

--- a/server/internal/handlers/fleetnodegateway/handler_heartbeat_test.go
+++ b/server/internal/handlers/fleetnodegateway/handler_heartbeat_test.go
@@ -1,0 +1,108 @@
+package fleetnodegateway_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"database/sql"
+	"testing"
+	"time"
+
+	"connectrpc.com/authn"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	"github.com/block/proto-fleet/server/internal/domain/apikey"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/fleetnodeauth"
+	"github.com/block/proto-fleet/server/internal/domain/fleetnodeenrollment"
+	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	"github.com/block/proto-fleet/server/internal/handlers/fleetnodegateway"
+	"github.com/block/proto-fleet/server/internal/testutil"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func newHeartbeatHandler(t *testing.T) (*fleetnodegateway.Handler, *sql.DB, int64) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := testutil.GetTestDB(t)
+	_, err := db.Exec(`INSERT INTO organization (id, org_id, name, miner_auth_private_key) VALUES (1, 'test-org', 'Test Org', 'dummy-key') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO "user" (id, user_id, username, password_hash) VALUES (1, 'test-user', 'op', 'dummy') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err)
+
+	apiKeyStore := sqlstores.NewSQLApiKeyStore(db)
+	apiKeySvc := apikey.NewService(apiKeyStore, nil)
+	transactor := sqlstores.NewSQLTransactor(db)
+	enrollmentStore := sqlstores.NewSQLFleetNodeEnrollmentStore(db)
+	enrollmentSvc := fleetnodeenrollment.NewService(enrollmentStore, apiKeySvc, transactor, nil)
+	authStore := sqlstores.NewSQLFleetNodeAuthStore(db)
+	authSvc := fleetnodeauth.NewService(authStore, enrollmentStore, apiKeySvc)
+
+	pubKey, _, _ := ed25519.GenerateKey(rand.Reader)
+	signing, _, _ := ed25519.GenerateKey(rand.Reader)
+	code, _, err := enrollmentSvc.CreateCode(t.Context(), 1, 1, time.Hour)
+	require.NoError(t, err)
+	agent, _, err := enrollmentSvc.RegisterFleetNode(t.Context(), code, "agent-heartbeat", pubKey, signing)
+	require.NoError(t, err)
+
+	return fleetnodegateway.NewHandler(enrollmentSvc, authSvc), db, agent.ID
+}
+
+func TestUploadHeartbeat_AdvancesLastSeen(t *testing.T) {
+	// Arrange
+	handler, db, fleetNodeID := newHeartbeatHandler(t)
+	ctx := authn.SetInfo(t.Context(), &fleetnodeauth.Subject{
+		FleetNodeID: fleetNodeID,
+		OrgID:       1,
+		Name:        "agent-heartbeat",
+	})
+	req := connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()})
+
+	// Act
+	resp, err := handler.UploadHeartbeat(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.GetReceivedAt())
+	assert.WithinDuration(t, time.Now(), resp.Msg.GetReceivedAt().AsTime(), 2*time.Second)
+	var lastSeen sql.NullTime
+	require.NoError(t, db.QueryRow(`SELECT last_seen_at FROM fleet_node WHERE id = $1`, fleetNodeID).Scan(&lastSeen))
+	require.True(t, lastSeen.Valid)
+	assert.WithinDuration(t, time.Now(), lastSeen.Time, 2*time.Second)
+}
+
+func TestUploadHeartbeat_RejectsMissingSubject(t *testing.T) {
+	// Arrange
+	handler, _, _ := newHeartbeatHandler(t)
+	req := connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()})
+
+	// Act
+	_, err := handler.UploadHeartbeat(t.Context(), req)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fleet node subject")
+}
+
+func TestUploadHeartbeat_NotFoundForUnknownFleetNode(t *testing.T) {
+	// Arrange
+	handler, _, _ := newHeartbeatHandler(t)
+	ctx := authn.SetInfo(t.Context(), &fleetnodeauth.Subject{
+		FleetNodeID: 99999,
+		OrgID:       1,
+		Name:        "ghost",
+	})
+	req := connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()})
+
+	// Act
+	_, err := handler.UploadHeartbeat(ctx, req)
+
+	// Assert
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsNotFoundError(err))
+}

--- a/server/sqlc/queries/fleetnode_enrollment.sql
+++ b/server/sqlc/queries/fleetnode_enrollment.sql
@@ -102,3 +102,8 @@ WHERE a.id = pe.fleet_node_id
   AND a.deleted_at IS NULL
   AND pe.status IN ('PENDING', 'AWAITING_CONFIRMATION')
   AND pe.expires_at < $1;
+
+-- name: UpdateFleetNodeLastSeenAt :execrows
+UPDATE fleet_node
+SET last_seen_at = $1
+WHERE id = $2 AND org_id = $3 AND deleted_at IS NULL;


### PR DESCRIPTION
## Summary

Adds the \`fleetnode run\` subcommand: a long-running daemon that holds an authenticated session and posts \`UploadHeartbeat\` on a ticker. This is the smallest viable slice of the "agent runtime" described in RFC 0001 Phase 2, and lays the scaffolding that \`UploadTelemetry\` / \`UploadEvents\` / \`ControlStream\` will reuse without further plumbing.

![heart beating](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExYXNqMGpmOTR6MGF3NnU4YmR4d2J0ZDBmY2N2N2ttNGd1djI3ZGZtZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/wzclsv1x3zhVS/giphy.gif)

## What's in this PR

**Server side**
- New \`UpdateFleetNodeLastSeenAt\` sqlc query + Store wrapper.
- \`fleetnodeenrollment.Service.UpdateLastSeen\` (0 rows → NotFound).
- \`Handler.UploadHeartbeat\` resolves the Subject from \`FleetNodeAuthInterceptor\` and stamps \`last_seen_at\`.

**Client library (\`fleetnodebootstrap\`)**
- New \`NewAuthenticatedGatewayClient(serverURL, tokenSource)\` — a connect-rpc client that attaches \`Authorization: Bearer <token>\` on every call, re-reading the token from \`tokenSource\` so a daemon that rotates its own \`state.SessionToken\` via \`Refresh\` picks up the new value without rebuilding the client. Streaming variants wired so future \`ControlStream\` work needs no client-side surgery.

**CLI**
\\\text
fleetnode run [--heartbeat-interval=30s]
              [--state-dir=<path>]
\\\

- Refuses to start when state is missing or \`api_key\` is empty (no state-lock side effect on never-enrolled hosts).
- Refreshes the session on entry if it's within 1h of expiry, surfacing \`ErrBeginAuthRejected\` with the standard "could be revoked / mismatched / drifted" guidance.
- Tick loop: refresh-on-near-expiry, send heartbeat, retry once after refresh on \`Unauthenticated\`; transient errors are logged and the daemon keeps running.
- \`signal.NotifyContext(SIGINT, SIGTERM)\` for clean shutdown; tests inject a cancellable parent ctx for deterministic shutdown.

## Test coverage

- \`TestUpdateLastSeen*\` (integration) — service + SQL.
- \`TestUploadHeartbeat_*\` (handler integration) — happy path advances \`last_seen_at\`, missing Subject is rejected, unknown fleet_node returns NotFound.
- \`TestAuthenticatedClient_*\` — bearer header is attached per-call and re-read after rotation; empty token returns Unauthenticated.
- \`TestRunCmd_*\` — happy path 3 ticks, near-expiry refresh, Unauthenticated triggers refresh-and-retry, missing-state and missing-api_key bailouts (no state-lock side effect), initial-refresh \`ErrBeginAuthRejected\` propagation.

## Out of scope (explicitly)

- \`UploadTelemetry\` / \`UploadEvents\` / \`ControlStream\` (next PRs; same daemon scaffolding).
- Plugin orchestration.
- \`fleetd --mode=server\` wiring.
- Per-org credential encryption, per-agent JWT signing, device-scoped authz.

## Test plan

- [x] \`PATH=./bin:\$PATH go build ./server/...\`
- [x] \`PATH=./bin:\$PATH go vet ./server/...\`
- [x] \`cd server && PATH=../bin:\$PATH golangci-lint run -c .golangci.yaml ./...\` — 0 issues
- [x] \`DB_PASSWORD=fleet PATH=./bin:\$PATH go test ./server/... -count=1\` — 64 packages OK
- [x] CI runs the full suite
- [ ] Manual smoke (below)

### Smoke

1. \`just dev\` brings up the gateway on \`:4000\`.
2. Mint an enrollment code (admin cookie + curl, as in PR #221 smoke).
3. \`just build-fleetnode && ./server/fleetnode enroll --server-url=http://localhost:4000 --allow-insecure-transport\`.
4. \`./server/fleetnode run --heartbeat-interval=2s\` in one terminal; watch heartbeat lines.
5. In another terminal, hit \`ListFleetNodes\` admin RPC and observe \`last_seen_at\` advancing.
6. SIGINT (Ctrl-C) the daemon; assert it exits cleanly within a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)