### PR TITLE
Add ProtoOS header actions E2E coverage

### DIFF
--- a/client/e2eTests/protoOS/pages/components/header.ts
+++ b/client/e2eTests/protoOS/pages/components/header.ts
@@ -20,4 +20,42 @@ export class HeaderComponent extends BasePage {
     const header = this.page.getByTestId("page-header");
     await expect(header.getByRole("button", { name: status })).toBeVisible();
   }
+
+  async openGlobalActionsMenu() {
+    await this.page.getByTestId("global-actions-widget").click();
+    await expect(this.page.getByTestId("global-actions-popover")).toBeVisible();
+  }
+
+  async clickBlinkLeds() {
+    await this.page.getByTestId("global-action-blink-leds").click();
+  }
+
+  async clickDownloadLogs() {
+    await this.page.getByTestId("global-action-download-logs").click();
+  }
+
+  async validateGlobalActionsMenuClosed() {
+    await expect(this.page.getByTestId("global-actions-popover")).toHaveCount(0);
+  }
+
+  async openPowerTargetPopover() {
+    await this.page.getByTestId("power-target-widget").click();
+    await expect(this.page.getByTestId("power-target-popover")).toBeVisible();
+  }
+
+  async clickCustomPowerTargetMode() {
+    await this.page.getByTestId("power-target-mode-custom").click();
+  }
+
+  async inputCustomPowerTargetKw(valueKw: number) {
+    await this.page.getByTestId("power-target-input").fill(String(valueKw));
+  }
+
+  async clickApplyPowerTarget() {
+    await this.page.getByTestId("power-target-apply-button").click();
+  }
+
+  async validatePowerTargetWidgetText(expectedText: string) {
+    await expect(this.page.getByTestId("power-target-widget")).toContainText(expectedText);
+  }
 }

--- a/client/e2eTests/protoOS/spec/headerActionsPowerTarget.spec.ts
+++ b/client/e2eTests/protoOS/spec/headerActionsPowerTarget.spec.ts
@@ -1,5 +1,6 @@
 import type { APIRequestContext, Page } from "@playwright/test";
 import { test } from "../fixtures/pageFixtures";
+import type { MiningTarget, MiningTargetResponse } from "@/protoOS/api/generatedApi";
 
 function chooseCustomPowerTargetWatts({
   currentTargetWatts,
@@ -34,6 +35,7 @@ function chooseCustomPowerTargetWatts({
       candidate >= minTargetWatts &&
       candidate <= maxTargetWatts &&
       candidate !== currentTargetWatts &&
+      candidate !== minTargetWatts &&
       candidate !== defaultTargetWatts &&
       candidate !== maxTargetWatts,
   );
@@ -139,19 +141,37 @@ async function getMiningTargetState(request: APIRequestContext, getAccessToken: 
 
   test.expect(response.status()).toBe(200);
 
-  const responseBody = (await response.json()) as {
-    default_power_target_watts?: number;
-    power_target_min_watts?: number;
-    power_target_max_watts?: number;
-    power_target_watts?: number;
-  };
+  const responseBody = (await response.json()) as MiningTargetResponse;
 
   return {
     defaultTargetWatts: responseBody.default_power_target_watts,
     minTargetWatts: responseBody.power_target_min_watts,
     maxTargetWatts: responseBody.power_target_max_watts,
     currentTargetWatts: responseBody.power_target_watts,
+    performanceMode: responseBody.performance_mode,
   };
+}
+
+async function restoreMiningTargetState({
+  request,
+  accessToken,
+  miningTargetState,
+}: {
+  request: APIRequestContext;
+  accessToken: string;
+  miningTargetState: { currentTargetWatts?: number; performanceMode?: MiningTarget["performance_mode"] };
+}) {
+  const response = await request.put("/api/v1/mining/target", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    data: {
+      performance_mode: miningTargetState.performanceMode,
+      power_target_watts: miningTargetState.currentTargetWatts,
+    } satisfies MiningTarget,
+  });
+
+  test.expect(response.status()).toBe(200);
 }
 
 test.describe("ProtoOS header actions and power target", () => {
@@ -201,36 +221,46 @@ test.describe("ProtoOS header actions and power target", () => {
   });
 
   test("Power target custom value applies and persists after reload", async ({ headerComponent, page, request }) => {
-    const miningTargetState = await getMiningTargetState(request, () => getAuthAccessToken(page));
+    const accessToken = await getAuthAccessToken(page);
+    const miningTargetState = await getMiningTargetState(request, () => Promise.resolve(accessToken));
     const customTargetWatts = chooseCustomPowerTargetWatts(miningTargetState);
     const customTargetKw = customTargetWatts / 1000;
-    const requestPromise = page.waitForRequest(
-      (request) => request.method() === "PUT" && request.url().includes("/api/v1/mining/target"),
-    );
-    const responsePromise = page.waitForResponse(
-      (response) => response.request().method() === "PUT" && response.url().includes("/api/v1/mining/target"),
-    );
 
-    await test.step("Apply a custom power target", async () => {
-      await headerComponent.openPowerTargetPopover();
-      await headerComponent.clickCustomPowerTargetMode();
-      await headerComponent.inputCustomPowerTargetKw(customTargetKw);
-      await headerComponent.clickApplyPowerTarget();
-    });
+    try {
+      const requestPromise = page.waitForRequest(
+        (request) => request.method() === "PUT" && request.url().includes("/api/v1/mining/target"),
+      );
+      const responsePromise = page.waitForResponse(
+        (response) => response.request().method() === "PUT" && response.url().includes("/api/v1/mining/target"),
+      );
 
-    await test.step("Validate the update request and widget text", async () => {
-      const request = await requestPromise;
-      const response = await responsePromise;
-      const requestBody = request.postDataJSON();
+      await test.step("Apply a custom power target", async () => {
+        await headerComponent.openPowerTargetPopover();
+        await headerComponent.clickCustomPowerTargetMode();
+        await headerComponent.inputCustomPowerTargetKw(customTargetKw);
+        await headerComponent.clickApplyPowerTarget();
+      });
 
-      test.expect(requestBody.power_target_watts).toBe(customTargetWatts);
-      test.expect(response.status()).toBe(200);
-      await headerComponent.validatePowerTargetWidgetText(formatPowerTargetWidgetText(customTargetWatts));
-    });
+      await test.step("Validate the update request and widget text", async () => {
+        const request = await requestPromise;
+        const response = await responsePromise;
+        const requestBody = request.postDataJSON();
 
-    await test.step("Reload and validate the custom target persists", async () => {
-      await page.reload();
-      await headerComponent.validatePowerTargetWidgetText(formatPowerTargetWidgetText(customTargetWatts));
-    });
+        test.expect(requestBody.power_target_watts).toBe(customTargetWatts);
+        test.expect(response.status()).toBe(200);
+        await headerComponent.validatePowerTargetWidgetText(formatPowerTargetWidgetText(customTargetWatts));
+      });
+
+      await test.step("Reload and validate the custom target persists", async () => {
+        await page.reload();
+        await headerComponent.validatePowerTargetWidgetText(formatPowerTargetWidgetText(customTargetWatts));
+      });
+    } finally {
+      await restoreMiningTargetState({
+        request,
+        accessToken,
+        miningTargetState,
+      });
+    }
   });
 });

--- a/client/e2eTests/protoOS/spec/headerActionsPowerTarget.spec.ts
+++ b/client/e2eTests/protoOS/spec/headerActionsPowerTarget.spec.ts
@@ -1,0 +1,236 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { test } from "../fixtures/pageFixtures";
+
+function chooseCustomPowerTargetWatts({
+  currentTargetWatts,
+  defaultTargetWatts,
+  minTargetWatts,
+  maxTargetWatts,
+}: {
+  currentTargetWatts?: number;
+  defaultTargetWatts?: number;
+  minTargetWatts?: number;
+  maxTargetWatts?: number;
+}) {
+  if (
+    currentTargetWatts === undefined ||
+    defaultTargetWatts === undefined ||
+    minTargetWatts === undefined ||
+    maxTargetWatts === undefined
+  ) {
+    throw new Error("Missing mining target bounds from API.");
+  }
+
+  const candidates = [
+    defaultTargetWatts + 100,
+    defaultTargetWatts - 100,
+    minTargetWatts + 100,
+    maxTargetWatts - 100,
+    Math.round((minTargetWatts + maxTargetWatts) / 200) * 100,
+  ];
+
+  const validCandidate = candidates.find(
+    (candidate) =>
+      candidate >= minTargetWatts &&
+      candidate <= maxTargetWatts &&
+      candidate !== currentTargetWatts &&
+      candidate !== defaultTargetWatts &&
+      candidate !== maxTargetWatts,
+  );
+
+  if (validCandidate === undefined) {
+    throw new Error(
+      `Could not find a distinct custom power target. Current=${currentTargetWatts}, default=${defaultTargetWatts}, min=${minTargetWatts}, max=${maxTargetWatts}`,
+    );
+  }
+
+  return validCandidate;
+}
+
+function formatPowerTargetWidgetText(targetWatts: number) {
+  return `${targetWatts / 1000} kW custom target`;
+}
+
+async function getAuthAccessToken(page: Page) {
+  return page.evaluate(() => {
+    const authData = window.localStorage.getItem("proto-os-auth");
+    if (!authData) {
+      throw new Error("Missing proto-os-auth in localStorage");
+    }
+
+    const parsed = JSON.parse(authData) as {
+      state?: {
+        auth?: {
+          authTokens?: {
+            accessToken?: { value?: string };
+          };
+        };
+      };
+    };
+
+    const accessToken = parsed.state?.auth?.authTokens?.accessToken?.value;
+    if (!accessToken) {
+      throw new Error("Missing access token in proto-os-auth");
+    }
+
+    return accessToken;
+  });
+}
+
+async function waitForAuthenticatedMiningTarget(request: APIRequestContext, page: Page) {
+  await test.expect
+    .poll(
+      async () => {
+        try {
+          const accessToken = await getAuthAccessToken(page);
+          const response = await request.get("/api/v1/mining/target", {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          });
+
+          return response.status();
+        } catch {
+          return 0;
+        }
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(200);
+}
+
+async function authenticateAsAdminAndWaitForAccess({
+  page,
+  commonSteps,
+  request,
+}: {
+  page: Page;
+  commonSteps: { authenticateAsAdmin: () => Promise<void> };
+  request: APIRequestContext;
+}) {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await commonSteps.authenticateAsAdmin();
+      await waitForAuthenticatedMiningTarget(request, page);
+      return;
+    } catch (error) {
+      lastError = error;
+
+      if (attempt === 1) {
+        throw error;
+      }
+
+      await page.goto("/");
+    }
+  }
+
+  throw lastError;
+}
+
+async function getMiningTargetState(request: APIRequestContext, getAccessToken: () => Promise<string>) {
+  const accessToken = await getAccessToken();
+  const response = await request.get("/api/v1/mining/target", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  test.expect(response.status()).toBe(200);
+
+  const responseBody = (await response.json()) as {
+    default_power_target_watts?: number;
+    power_target_min_watts?: number;
+    power_target_max_watts?: number;
+    power_target_watts?: number;
+  };
+
+  return {
+    defaultTargetWatts: responseBody.default_power_target_watts,
+    minTargetWatts: responseBody.power_target_min_watts,
+    maxTargetWatts: responseBody.power_target_max_watts,
+    currentTargetWatts: responseBody.power_target_watts,
+  };
+}
+
+test.describe("ProtoOS header actions and power target", () => {
+  test.beforeEach(async ({ page, commonSteps, request }) => {
+    await page.goto("/");
+    await authenticateAsAdminAndWaitForAccess({ page, commonSteps, request });
+  });
+
+  test("Blink LEDs from header actions sends locate request", async ({ headerComponent, page }) => {
+    const requestPromise = page.waitForRequest(
+      (request) => request.method() === "POST" && request.url().includes("/api/v1/system/locate"),
+    );
+    const responsePromise = page.waitForResponse(
+      (response) => response.request().method() === "POST" && response.url().includes("/api/v1/system/locate"),
+    );
+
+    await test.step("Trigger Blink LEDs from header actions", async () => {
+      await headerComponent.openGlobalActionsMenu();
+      await headerComponent.clickBlinkLeds();
+      await headerComponent.validateGlobalActionsMenuClosed();
+    });
+
+    await test.step("Validate locate request", async () => {
+      const request = await requestPromise;
+      const response = await responsePromise;
+      const requestUrl = new URL(request.url());
+
+      test.expect(requestUrl.searchParams.get("led_on_time")).toBe("30");
+      test.expect(response.status()).toBe(202);
+    });
+  });
+
+  test("Download logs from header actions starts a CSV download", async ({ headerComponent, page }) => {
+    await test.step("Trigger download from header actions", async () => {
+      const downloadPromise = page.waitForEvent("download");
+
+      await headerComponent.openGlobalActionsMenu();
+      await headerComponent.clickDownloadLogs();
+      await headerComponent.validateGlobalActionsMenuClosed();
+
+      const download = await downloadPromise;
+      const fileName = download.suggestedFilename();
+
+      test.expect(fileName.startsWith("miner-logs-")).toBe(true);
+      test.expect(fileName.endsWith(".csv")).toBe(true);
+    });
+  });
+
+  test("Power target custom value applies and persists after reload", async ({ headerComponent, page, request }) => {
+    const miningTargetState = await getMiningTargetState(request, () => getAuthAccessToken(page));
+    const customTargetWatts = chooseCustomPowerTargetWatts(miningTargetState);
+    const customTargetKw = customTargetWatts / 1000;
+    const requestPromise = page.waitForRequest(
+      (request) => request.method() === "PUT" && request.url().includes("/api/v1/mining/target"),
+    );
+    const responsePromise = page.waitForResponse(
+      (response) => response.request().method() === "PUT" && response.url().includes("/api/v1/mining/target"),
+    );
+
+    await test.step("Apply a custom power target", async () => {
+      await headerComponent.openPowerTargetPopover();
+      await headerComponent.clickCustomPowerTargetMode();
+      await headerComponent.inputCustomPowerTargetKw(customTargetKw);
+      await headerComponent.clickApplyPowerTarget();
+    });
+
+    await test.step("Validate the update request and widget text", async () => {
+      const request = await requestPromise;
+      const response = await responsePromise;
+      const requestBody = request.postDataJSON();
+
+      test.expect(requestBody.power_target_watts).toBe(customTargetWatts);
+      test.expect(response.status()).toBe(200);
+      await headerComponent.validatePowerTargetWidgetText(formatPowerTargetWidgetText(customTargetWatts));
+    });
+
+    await test.step("Reload and validate the custom target persists", async () => {
+      await page.reload();
+      await headerComponent.validatePowerTargetWidgetText(formatPowerTargetWidgetText(customTargetWatts));
+    });
+  });
+});

--- a/client/src/protoOS/components/PageHeader/GlobalActions/GlobalActionsPopover.tsx
+++ b/client/src/protoOS/components/PageHeader/GlobalActions/GlobalActionsPopover.tsx
@@ -15,6 +15,7 @@ interface MenuItem {
   icon: ComponentType<IconProps>;
   label: string;
   onClick: () => void;
+  testId: string;
 }
 
 export const GlobalActionsPopover = ({ onBlinkLEDs, onDownloadLogs }: GlobalActionsPopoverProps) => {
@@ -23,11 +24,13 @@ export const GlobalActionsPopover = ({ onBlinkLEDs, onDownloadLogs }: GlobalActi
       icon: LEDIndicator,
       label: "Blink LEDs",
       onClick: onBlinkLEDs,
+      testId: "global-action-blink-leds",
     },
     {
       icon: Terminal,
       label: "Download logs",
       onClick: onDownloadLogs,
+      testId: "global-action-download-logs",
     },
   ];
 
@@ -39,12 +42,13 @@ export const GlobalActionsPopover = ({ onBlinkLEDs, onDownloadLogs }: GlobalActi
       offset={8}
       testId="global-actions-popover"
     >
-      {menuItems.map(({ icon: Icon, label, onClick }) => (
+      {menuItems.map(({ icon: Icon, label, onClick, testId }) => (
         <Row
           key={label}
           className="text-emphasis-300"
           prefixIcon={<Icon width={iconSizes.small} />}
           onClick={onClick}
+          testId={testId}
           compact
           divider
         >

--- a/client/src/protoOS/components/PageHeader/GlobalActions/GlobalActionsWidget.tsx
+++ b/client/src/protoOS/components/PageHeader/GlobalActions/GlobalActionsWidget.tsx
@@ -37,6 +37,7 @@ export const GlobalActionsWidget = ({ onBlinkLEDs, onDownloadLogs }: GlobalActio
         onClick={() => setIsOpen((prev) => !prev)}
         className="w-[28px] p-0 text-text-primary"
         isOpen={isOpen}
+        testId="global-actions-widget"
         ariaLabel="Global actions"
         ariaHasPopup="menu"
         ariaExpanded={isOpen}

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx
@@ -112,6 +112,7 @@ const PowerTarget = () => {
   return (
     <div ref={widgetRef} className="relative">
       <WidgetWrapper
+        testId="power-target-widget"
         onClick={() => {
           setShowPopover(true);
         }}

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
@@ -105,7 +105,11 @@ const PowerTargetPopover = ({ onDismiss, onUpdateStart }: PowerTargetPopoverProp
   }, [pending, selectedPerformanceMode, selectedPowerTargetMode, calculatePowerTargetWattage, onUpdateStart]);
 
   return (
-    <Popover position={positions["bottom left"]} className="flex w-80 flex-col gap-4 !space-y-1 p-6">
+    <Popover
+      position={positions["bottom left"]}
+      className="flex w-80 flex-col gap-4 !space-y-1 p-6"
+      testId="power-target-popover"
+    >
       <div className="flex flex-col gap-1">
         <h2 className="text-heading-100 text-text-primary">Power target</h2>
         <p className="text-300 text-text-primary-70">Set a power target for the miner.</p>
@@ -127,6 +131,7 @@ const PowerTargetPopover = ({ onDismiss, onUpdateStart }: PowerTargetPopoverProp
           },
           {
             id: powerTargetModes.custom,
+            "data-testid": "power-target-mode-custom",
             isSelected: selectedPowerTargetMode === powerTargetModes.custom,
             text: "Custom",
           },
@@ -148,6 +153,7 @@ const PowerTargetPopover = ({ onDismiss, onUpdateStart }: PowerTargetPopoverProp
             onChange={onChange}
             units={"kW"}
             disabled={pending}
+            testId="power-target-input"
           />
           <p className={clsx("text-200", error ? "text-intent-critical-fill" : "text-text-primary-70")}>
             {error ||

--- a/client/src/shared/components/SelectRowList/SelectRow.tsx
+++ b/client/src/shared/components/SelectRowList/SelectRow.tsx
@@ -6,6 +6,7 @@ import { SelectType, selectTypes } from "@/shared/constants";
 
 export interface SelectRowProps {
   className?: string;
+  "data-testid"?: string;
   disabled?: boolean;
   isSelected: boolean;
   onChange: (isSelected: boolean) => void;
@@ -18,6 +19,7 @@ export interface SelectRowProps {
 
 const SelectRow = ({
   className,
+  "data-testid": dataTestId,
   disabled,
   isSelected,
   onChange,
@@ -39,6 +41,7 @@ const SelectRow = ({
 
   return (
     <button
+      data-testid={dataTestId}
       className={clsx(
         "flex w-full items-center justify-between py-3 text-left select-none",
         "transition-[background-color] duration-200 ease-in-out",

--- a/client/src/shared/components/SelectRowList/SelectRowList.tsx
+++ b/client/src/shared/components/SelectRowList/SelectRowList.tsx
@@ -28,6 +28,7 @@ const SelectRowList = ({ className, onChange, selectRows, type }: SelectRowListP
               subtext={selectRow.subtext}
               text={selectRow.text}
               sideText={selectRow.sideText}
+              data-testid={selectRow["data-testid"]}
               disabled={selectRow.disabled}
               isSelected={selectRow.isSelected}
               onChange={handleChange}


### PR DESCRIPTION
## Summary
- add ProtoOS E2E coverage for header Blink LEDs and Download logs actions
- add ProtoOS E2E coverage for custom power target apply + reload persistence
- keep the scope to flows that work cleanly without dev-only auth hooks, and add stable test ids for the new interactions

## Verification
- npx eslint e2eTests/protoOS/helpers/commonSteps.ts e2eTests/protoOS/pages/base.ts e2eTests/protoOS/pages/components/header.ts e2eTests/protoOS/spec/headerActionsPowerTarget.spec.ts src/protoOS/components/PageHeader/GlobalActions/GlobalActionsWidget.tsx src/protoOS/components/PageHeader/GlobalActions/GlobalActionsPopover.tsx src/protoOS/components/PageHeader/PowerTarget/PowerTarget.tsx src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx src/shared/components/SelectRowList/SelectRow.tsx src/shared/components/SelectRowList/SelectRowList.tsx
- npx playwright test -c e2eTests/protoOS/playwright.config.ts e2eTests/protoOS/spec/headerActionsPowerTarget.spec.ts --project=desktop --no-deps
- npx playwright test -c e2eTests/protoOS/playwright.config.ts e2eTests/protoOS/spec/headerActionsPowerTarget.spec.ts --project=mobile --no-deps