### PR TITLE
fix(fleetnode): drop http.Client.Timeout on authenticated gateway client

### DIFF
--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -22,6 +22,7 @@ import (
 const (
 	defaultHeartbeatInterval = 30 * time.Second
 	sessionRefreshLeeway     = 1 * time.Hour
+	heartbeatRequestTimeout  = 30 * time.Second
 )
 
 type RunCmd struct {
@@ -206,7 +207,13 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *fleetnodebo
 	return nil
 }
 
+// Per-call deadline so a single hung heartbeat doesn't pin the daemon
+// loop until shutdown. The authenticated gateway client has no
+// http.Client.Timeout (that would forcibly tear down future streaming
+// RPCs); unary callers attach their own deadlines via context.
 func (r *RunCmd) sendHeartbeat(ctx context.Context, client gatewayClient) error {
+	ctx, cancel := context.WithTimeout(ctx, heartbeatRequestTimeout)
+	defer cancel()
 	_, err := client.UploadHeartbeat(ctx, connect.NewRequest(&pb.UploadHeartbeatRequest{
 		SentAt: timestamppb.New(r.now()),
 	}))

--- a/server/internal/fleetnodebootstrap/authclient.go
+++ b/server/internal/fleetnodebootstrap/authclient.go
@@ -15,10 +15,23 @@ import (
 // request without rebuilding the client.
 func NewAuthenticatedGatewayClient(serverURL string, tokenSource func() string) fleetnodegatewayv1connect.FleetNodeGatewayServiceClient {
 	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(
-		newGatewayHTTPClient(),
+		newStreamingGatewayHTTPClient(),
 		serverURL,
 		connect.WithInterceptors(bearerInterceptor(tokenSource)),
 	)
+}
+
+// http.Client.Timeout covers the entire request lifecycle including the
+// response body, so a non-zero value would forcibly tear down long-lived
+// streaming RPCs (ControlStream, UploadTelemetry, UploadEvents). Callers
+// apply per-call deadlines via context.WithTimeout for unary calls and
+// rely on context cancellation + connection health for streaming.
+func newStreamingGatewayHTTPClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errRedirectNotAllowed
+		},
+	}
 }
 
 func bearerInterceptor(tokenSource func() string) connect.Interceptor {

--- a/server/internal/fleetnodebootstrap/authclient_test.go
+++ b/server/internal/fleetnodebootstrap/authclient_test.go
@@ -85,3 +85,17 @@ func TestAuthenticatedClient_RejectsEmptyToken(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 }
+
+func TestStreamingGatewayHTTPClient_HasNoTopLevelTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Act
+	c := newStreamingGatewayHTTPClient()
+
+	// Assert: a non-zero http.Client.Timeout would forcibly tear down
+	// long-lived streaming RPCs (ControlStream, UploadTelemetry,
+	// UploadEvents). Per-call deadlines are applied via context instead.
+	assert.Equal(t, time.Duration(0), c.Timeout, "authenticated client must not set http.Client.Timeout; streaming RPCs would be cut off")
+	require.NotNil(t, c.CheckRedirect, "redirect rejection must remain")
+	assert.Error(t, c.CheckRedirect(nil, nil), "CheckRedirect must refuse all redirects")
+}


### PR DESCRIPTION
## Summary

The authenticated gateway client introduced in #227 reuses \`newGatewayHTTPClient()\` whose \`http.Client.Timeout: 30s\` covers the *entire* request lifecycle (including reading the response body). For long-lived streaming RPCs that's the streamed message channel itself — so any \`ControlStream\` / \`UploadTelemetry\` / \`UploadEvents\` open via this client would be forcibly torn down at the 30-second mark.

Latent today (\`fleetnode run\` only does the unary \`UploadHeartbeat\`, which finishes well under 30s), but the next PR that wires up any streaming RPC would have discovered it immediately. Fixing the foundation here keeps that PR focused on its actual feature.


## Changes

- **New \`newStreamingGatewayHTTPClient()\`** in \`authclient.go\`: no top-level \`Timeout\`; keeps the no-redirect \`CheckRedirect\`. Used by \`NewAuthenticatedGatewayClient\`.
- **Unchanged**: \`newGatewayHTTPClient()\` (used by bootstrap's unary \`Register\` / \`BeginAuthHandshake\` / \`CompleteAuthHandshake\`). Those calls are bounded and the 30s circuit-breaker is correct for the interactive enroll/refresh flows.
- **Daemon**: \`sendHeartbeat\` now wraps each call in \`context.WithTimeout(heartbeatRequestTimeout)\`. Preserves the \"single hung heartbeat doesn't pin the daemon\" guarantee that the client-level \`Timeout\` used to provide, but applies it only to unary calls; future streaming methods will pass the loop ctx without an artificial deadline.
- **Regression test** pins that \`newStreamingGatewayHTTPClient().Timeout == 0\` and that \`CheckRedirect\` still refuses redirects.

## Test plan

- [x] \`PATH=./bin:\$PATH go build ./server/...\`
- [x] \`PATH=./bin:\$PATH go vet ./server/...\`
- [x] \`cd server && PATH=../bin:\$PATH golangci-lint run -c .golangci.yaml ./...\` — 0 issues
- [x] \`DB_PASSWORD=fleet PATH=./bin:\$PATH go test ./server/... -count=1\` — 68 packages OK
- [ ] CI runs the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)