### PR TITLE
Update GitHub Action Dependencies

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Dependency Review
         if: ${{ !github.event.repository.private }}
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-scopes: runtime,unknown
           fail-on-severity: moderate

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Apply labels
-        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true


### PR DESCRIPTION
## Summary
- Bumps the pinned GitHub Actions used by the dependency review and pull-request labeler workflows.

## What Changed
- `.github/workflows/dependency-review.yml`: bumps `actions/dependency-review-action` from v4.9.0 to v5.0.0 by pinned commit SHA.
- `.github/workflows/pull-request.yml`: bumps `actions/labeler` from v6.0.1 to v6.1.0 by pinned commit SHA.