### PR TITLE
Harden Dependabot config: cooldown + Go/Rust ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       default-days: 7
 
   - package-ecosystem: npm
-    directory: client
+    directory: /client
     schedule:
       interval: monthly
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,21 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
 
   - package-ecosystem: npm
     directory: client
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
     groups:
       node-dependencies:
         applies-to: version-updates
@@ -24,3 +34,53 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
+
+  - package-ecosystem: gomod
+    directories:
+      - /server
+      - /server/fake-antminer
+      - /server/fake-proto-rig
+      - /plugin/proto
+      - /plugin/antminer
+      - /plugin/virtual
+      - /tests/plugin-contract
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
+    groups:
+      go-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: cargo
+    directories:
+      - /sdk/rust/proto-fleet-plugin
+      - /plugin/asicrs
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
+    groups:
+      rust-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,17 +8,16 @@ updates:
     # github-actions and docker ecosystems do not track semver, so only
     # default-days is supported on their cooldown blocks.
     cooldown:
-      default-days: 3
+      default-days: 7
 
   - package-ecosystem: npm
     directory: client
     schedule:
       interval: monthly
     cooldown:
-      default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
+      default-days: 7
+      semver-major-days: 14
+      semver-patch-days: 3
     groups:
       node-dependencies:
         applies-to: version-updates
@@ -34,7 +33,7 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 3
+      default-days: 7
 
   - package-ecosystem: gomod
     directories:
@@ -48,10 +47,9 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
+      default-days: 7
+      semver-major-days: 14
+      semver-patch-days: 3
     groups:
       go-dependencies:
         applies-to: version-updates
@@ -68,10 +66,9 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
+      default-days: 7
+      semver-major-days: 14
+      semver-patch-days: 3
     groups:
       rust-dependencies:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # github-actions and docker ecosystems do not track semver, so only
+    # default-days is supported on their cooldown blocks.
     cooldown:
       default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
 
   - package-ecosystem: npm
     directory: client
@@ -36,9 +35,6 @@ updates:
       interval: monthly
     cooldown:
       default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
 
   - package-ecosystem: gomod
     directories:


### PR DESCRIPTION
## Summary
- Adds a cooldown buffer to every Dependabot ecosystem block.
- Adds `gomod` and `cargo` ecosystem coverage so existing Rust/Go advisories begin auto-filing.
- Normalizes the npm block's `directory` to the same root-relative form (`/client`) as the rest of the file.
- Resolves the open `zizmor/dependabot-cooldown` code-scanning alerts on `.github/dependabot.yml`.

## Cooldown values

For ecosystems that track semver (`npm`, `gomod`, `cargo`):

```yaml
cooldown:
  default-days: 7
  semver-major-days: 14
  semver-patch-days: 3
```

For ecosystems that do not track semver (`github-actions` is pinned by ref/SHA, `docker` base-image tags don't follow strict semver):

```yaml
cooldown:
  default-days: 7
```

Notes on each value:

- `default-days: 7` — Matches zizmor's documented `dependabot-cooldown` threshold and the broadly-cited "1 week" convention for letting a new release settle before auto-PR. Most documented supply-chain compromises in these ecosystems (xz-utils, ua-parser-js, eslint-scope, node-ipc) were detected and yanked within roughly 24–72 hours of the malicious release; 7 days is a comfortable margin over that observed window. `semver-minor-days` falls back to this value.
- `semver-patch-days: 3` — Patch releases are predominantly bug or security fixes with small diffs and review surface, so the buffer is shortened to keep patch uptake fast.
- `semver-major-days: 14` — Not for security but for non-security regression signal (API breakage, behavior drift) to surface in upstream issue trackers and downstream consumers before a major bump is auto-PR'd.

Cooldown applies only to **version-update** PRs. **Security-update** PRs driven by GHSA advisories bypass cooldown and file immediately, so this configuration does not lengthen exposure to known CVEs.

## New ecosystems

`gomod` and `cargo` blocks use the `directories:` plural form to cover all module/crate roots in one entry each:

- `gomod` — `server`, `server/fake-antminer`, `server/fake-proto-rig`, `plugin/proto`, `plugin/antminer`, `plugin/virtual`, `tests/plugin-contract`
- `cargo` — `sdk/rust/proto-fleet-plugin`, `plugin/asicrs`

Both ecosystems group version updates into a single PR per ecosystem and ignore `semver-major` version-update PRs, mirroring the existing npm pattern. Security advisories ignore this filter and continue to file individually.

Until this change, neither ecosystem was being watched by Dependabot, which is why the 16 open Rust and 2 open transitive Go advisories had never produced auto-PRs.

## What this closes

- The open `zizmor/dependabot-cooldown` code-scanning alerts on `.github/dependabot.yml`.
- Unblocks future auto-filing of Rust and Go advisories.