### PR TITLE
Cargo update for active Rust security advisories

### DIFF
--- a/plugin/asicrs/Cargo.lock
+++ b/plugin/asicrs/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "ipnet",
  "measurements",
  "pyo3-build-config",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rlimit",
  "serde",
  "serde_json",
@@ -1926,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -2163,9 +2163,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/sdk/rust/proto-fleet-plugin/Cargo.lock
+++ b/sdk/rust/proto-fleet-plugin/Cargo.lock
@@ -731,15 +731,14 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -763,9 +762,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -1057,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
Pure lockfile bumps within the existing `Cargo.toml` ranges to clear active Rust security advisories on `openssl`, `rustls-webpki`, and `rand`. No source or manifest changes.

## Changes

### `sdk/rust/proto-fleet-plugin/Cargo.lock`
| Crate | From | To |
|---|---|---|
| `openssl` | 0.10.76 | 0.10.79 |
| `openssl-sys` | 0.9.112 | 0.9.115 |
| `rustls-webpki` | 0.103.10 | 0.103.13 |

`openssl` is transitive via `reqwest` (gated behind the `http-client` feature). Five advisories on `openssl` and three on `rustls-webpki` are resolved by these patches.

### `plugin/asicrs/Cargo.lock`
| Crate | From | To |
|---|---|---|
| `rand` | 0.10.0 | 0.10.1 |
| `rustls-webpki` | 0.103.10 | 0.103.13 |

`cargo update -p 'rand@0.10.0'` was used to target only the vulnerable rand version; the 0.8.5 and 0.9.2 `rand` entries in the asicrs lockfile (transitive via other crates, not flagged by any advisory) are unchanged.

## Verification
- `cargo build` clean in both crates, including `--features http-client` on the SDK.
- `cargo clippy -- -D warnings` clean in both crates.
- `cargo test --no-run` compiles in both crates.
- CI will exercise the Docker-built asicrs plugin and `tests/plugin-contract/` against the patched dependency graph.

## Closes
The two `openssl` (sdk/rust) and `rand` / `rustls-webpki` (both manifests) advisory clusters — 14 of the 16 open Rust Dependabot alerts.

## Follow-up: remaining Rust alerts
Two alerts on `plugin/asicrs/Cargo.lock` cannot be fixed by a `cargo update`:

- `serde_yml` (0.0.12) — unmaintained, no upstream fix available.
- `libyml` (0.0.5) — unmaintained, no upstream fix; transitive through `serde_yml`.

These require an actual crate swap: replace `serde_yml` (currently a direct dep in [plugin/asicrs/Cargo.toml](plugin/asicrs/Cargo.toml#L25)) with a maintained YAML crate (`serde_yaml_ng` is the closest API-compatible successor), update the call sites under `plugin/asicrs/src/`, regenerate the lockfile, and re-run plugin-contract tests. Tracked as a separate change.