### PR TITLE
Pass matrix and step inputs via env in protofleet-e2e-tests workflow

### DIFF
--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -185,10 +185,12 @@ jobs:
 
       - name: Set artifact name
         id: artifact
+        env:
+          MATRIX_SPEC: ${{ matrix.spec }}
         run: |
           # Sanitize spec name for use in artifact names
-          SPEC_NAME=$(echo "${{ matrix.spec }}" | sed 's/\.spec\.ts$//' | sed 's/[^a-zA-Z0-9]/-/g')
-          echo "spec_name=${SPEC_NAME}" >> $GITHUB_OUTPUT
+          SPEC_NAME=$(echo "$MATRIX_SPEC" | sed 's/\.spec\.ts$//' | sed 's/[^a-zA-Z0-9]/-/g')
+          echo "spec_name=${SPEC_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -265,16 +267,19 @@ jobs:
         working-directory: client/e2eTests/protoFleet
         env:
           CI: true
+          MATRIX_PROJECT: ${{ matrix.project }}
+          MATRIX_SPEC: ${{ matrix.spec }}
+          SPEC_NAME: ${{ steps.artifact.outputs.spec_name }}
         run: |
           rm -rf blob-report playwright-report test-results
           mkdir -p blob-report
 
-          # The viewport-matched setup project (setup-${{ matrix.project }}:
-          # onboarding + pools + auth storageState) runs automatically before
+          # The viewport-matched setup project (setup-$MATRIX_PROJECT):
+          # onboarding + pools + auth storageState runs automatically before
           # the target via project `dependencies`.
-          PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${{ matrix.project }}-${{ steps.artifact.outputs.spec_name }}.zip" \
+          PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${MATRIX_PROJECT}-${SPEC_NAME}.zip" \
           PWTEST_BLOB_DO_NOT_REMOVE=1 \
-          npx playwright test --project=${{ matrix.project }} --reporter=blob "spec/${{ matrix.spec }}"
+          npx playwright test --project="$MATRIX_PROJECT" --reporter=blob "spec/$MATRIX_SPEC"
 
           echo "Blob reports created:"
           find blob-report -maxdepth 2 -type f -print | sort || true

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -189,7 +189,7 @@ jobs:
           MATRIX_SPEC: ${{ matrix.spec }}
         run: |
           # Sanitize spec name for use in artifact names
-          SPEC_NAME=$(echo "$MATRIX_SPEC" | sed 's/\.spec\.ts$//' | sed 's/[^a-zA-Z0-9]/-/g')
+          SPEC_NAME=$(printf '%s' "$MATRIX_SPEC" | sed 's/\.spec\.ts$//' | sed 's/[^a-zA-Z0-9]/-/g')
           echo "spec_name=${SPEC_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Hermit


### PR DESCRIPTION
## Summary
Move `${{ matrix.spec }}`, `${{ matrix.project }}`, and `${{ steps.artifact.outputs.spec_name }}` out of inline `${{ … }}` expansions inside `run:` blocks and into `env:` blocks, referencing them as `"$VAR"` in the shell. The two step `name:` fields keep their `${{ matrix.* }}` references — those render as GitHub UI labels, not shell.

## Why
`matrix.spec` is sourced from spec filenames discovered via `find` under `client/e2eTests/protoFleet/spec`. A future spec filename containing shell metacharacters would execute on push — the same class of issue semgrep's `run-shell-injection` rule flags.

## Closes
Code-scanning alert #16 (`Intersect.semgrep.custom_ruleset.rules.run-shell-injection`).

## Risk
Low — pure refactor of how inputs reach the shell. Same commands run against the same values; the E2E matrix exercises this on every PR/scheduled run.