### PR TITLE
Suppress zizmor policy findings with inline rationale

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,6 @@
 name: Pull Request
 
-on: pull_request_target # zizmor: ignore[dangerous-triggers] needed for actions/labeler to write on fork PRs; this workflow does not check out the PR head
+on: pull_request_target # zizmor: ignore[dangerous-triggers] labeler needs fork-PR write access; workflow never checks out PR head
 
 permissions:
   contents: read

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,6 @@
 name: Pull Request
 
-on: pull_request_target
+on: pull_request_target # zizmor: ignore[dangerous-triggers] needed for actions/labeler to write on fork PRs; this workflow does not check out the PR head
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
 
       - name: Create draft release and upload assets
         id: create_release
+        # zizmor: ignore[superfluous-actions] SHA-pinned action handles draft + multi-file uploads cleanly
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           draft: true

--- a/.github/workflows/rust-sdk-checks.yml
+++ b/.github/workflows/rust-sdk-checks.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
+        # zizmor: ignore[superfluous-actions] SHA-pinned action installs explicit rustfmt+clippy components
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
@@ -70,6 +71,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
+        # zizmor: ignore[superfluous-actions] SHA-pinned action provides reproducible rust-toolchain selection
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install protoc


### PR DESCRIPTION
## Summary
Four code-scanning alerts from zizmor are by-design policy violations rather than bugs. Add inline `# zizmor: ignore[rule-name]` directives with a one-line rationale next to each affected directive, so the justification travels with the code.

## Suppressions

### `pull-request.yml` — `dangerous-triggers`
`pull_request_target` is required for `actions/labeler` to apply labels and assignees on PRs opened from forks. The workflow does not check out the PR head, so untrusted code never executes.

### `rust-sdk-checks.yml` (two occurrences) — `superfluous-actions`
`dtolnay/rust-toolchain` is SHA-pinned and installs the explicit `rustfmt` and `clippy` components in a single step. The rustup pre-installed on `ubuntu-latest` does not provide these components out of the box.

### `release.yml` — `superfluous-actions`
`softprops/action-gh-release` is SHA-pinned and cleanly expresses draft creation plus multi-file asset uploads. Re-implementing the same behavior with `gh release create` requires multiple shell steps and bespoke draft handling.

## Closes
Code-scanning alerts #8, #11, #12, #13.