### PR TITLE
Update plan curtailment modal form layout

### DIFF
--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
@@ -46,6 +46,11 @@ const preview: CurtailmentPlanPreview = {
   scopeLabel: "across the fleet",
 };
 
+const percentageReductionPreview: CurtailmentPlanPreview = {
+  ...preview,
+  targetKw: 30,
+};
+
 function ModalStory(props: ModalStoryProps): ReactElement {
   const [open, setOpen] = useState(true);
 
@@ -67,5 +72,5 @@ export const WithPreview: Story = {
 
 export const PercentageReductionPreview: Story = {
   name: "Percentage reduction preview",
-  render: () => <ModalStory initialValues={percentageReductionValues} preview={preview} />,
+  render: () => <ModalStory initialValues={percentageReductionValues} preview={percentageReductionPreview} />,
 };

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
@@ -66,7 +66,7 @@ export const Empty: Story = {
 };
 
 export const WithPreview: Story = {
-  name: "With preview",
+  name: "Fixed kW target preview",
   render: () => <ModalStory initialValues={configuredValues} preview={preview} />,
 };
 

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
@@ -23,18 +23,25 @@ type ModalStoryProps = {
 };
 
 const configuredValues: Partial<CurtailmentFormValues> = {
-  targetKw: "60",
-  minDurationSec: "300",
-  maxDurationSec: "3600",
+  targetKw: "45",
+  curtailBatchSize: "8",
+  curtailIntervalSec: "60",
   restoreBatchSize: "10",
   restoreIntervalSec: "120",
   reason: "Grid peak - ERCOT 4CP signal",
 };
 
+const percentageReductionValues: Partial<CurtailmentFormValues> = {
+  ...configuredValues,
+  curtailmentMode: "percentageReduction",
+  targetKw: "50",
+};
+
 const preview: CurtailmentPlanPreview = {
   selectedMinerCount: 18,
-  targetKw: 60,
-  estimatedReductionKw: 60.2,
+  targetKw: 45,
+  currentUsageKw: 60,
+  curtailEstimate: "~2 minutes",
   restoreEstimate: "~2 minutes",
   scopeLabel: "across the fleet",
 };
@@ -56,4 +63,9 @@ export const Empty: Story = {
 export const WithPreview: Story = {
   name: "With preview",
   render: () => <ModalStory initialValues={configuredValues} preview={preview} />,
+};
+
+export const PercentageReductionPreview: Story = {
+  name: "Percentage reduction preview",
+  render: () => <ModalStory initialValues={percentageReductionValues} preview={preview} />,
 };

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
@@ -33,7 +33,6 @@ const preview: CurtailmentPlanPreview = {
   selectedMinerCount: 18,
   targetKw: 40,
   estimatedReductionKw: 45,
-  curtailEstimate: "~2 minutes",
   restoreEstimate: "~2 minutes",
   scopeLabel: "across the fleet",
 };

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
@@ -23,32 +23,19 @@ type ModalStoryProps = {
 };
 
 const configuredValues: Partial<CurtailmentFormValues> = {
-  targetKw: "45",
-  curtailBatchSize: "8",
-  curtailIntervalSec: "60",
+  targetKw: "40",
   restoreBatchSize: "10",
   restoreIntervalSec: "120",
   reason: "Grid peak - ERCOT 4CP signal",
 };
 
-const percentageReductionValues: Partial<CurtailmentFormValues> = {
-  ...configuredValues,
-  curtailmentMode: "percentageReduction",
-  targetKw: "50",
-};
-
 const preview: CurtailmentPlanPreview = {
   selectedMinerCount: 18,
-  targetKw: 45,
-  currentUsageKw: 60,
+  targetKw: 40,
+  estimatedReductionKw: 45,
   curtailEstimate: "~2 minutes",
   restoreEstimate: "~2 minutes",
   scopeLabel: "across the fleet",
-};
-
-const percentageReductionPreview: CurtailmentPlanPreview = {
-  ...preview,
-  targetKw: 30,
 };
 
 function ModalStory(props: ModalStoryProps): ReactElement {
@@ -66,11 +53,6 @@ export const Empty: Story = {
 };
 
 export const WithPreview: Story = {
-  name: "Fixed kW target preview",
+  name: "Fixed kW reduction preview",
   render: () => <ModalStory initialValues={configuredValues} preview={preview} />,
-};
-
-export const PercentageReductionPreview: Story = {
-  name: "Percentage reduction preview",
-  render: () => <ModalStory initialValues={percentageReductionValues} preview={percentageReductionPreview} />,
 };

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -17,7 +17,11 @@ type MockFullScreenTwoPaneModalProps = Pick<
 vi.mock("@/protoFleet/components/FullScreenTwoPaneModal", () => ({
   default: ({ title, isBusy, buttons, abovePanes, primaryPane, secondaryPane }: MockFullScreenTwoPaneModalProps) => (
     <div role="dialog" aria-label={title} data-busy={isBusy ? "true" : "false"}>
-      <button type="button" disabled={Boolean(buttons?.[0]?.loading)} onClick={buttons?.[0]?.onClick}>
+      <button
+        type="button"
+        disabled={Boolean(buttons?.[0]?.loading || buttons?.[0]?.disabled)}
+        onClick={buttons?.[0]?.onClick}
+      >
         {buttons?.[0]?.text}
       </button>
       <div data-testid="above-panes">{abovePanes}</div>
@@ -124,6 +128,8 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByText("Curtail behavior")).toBeInTheDocument();
     expect(screen.getByText("Fixed kW target")).toBeInTheDocument();
     expect(screen.getByText("Worst miners first")).toBeInTheDocument();
+    expect(screen.getByText("Safety")).toBeInTheDocument();
+    expect(screen.getByText("Normal")).toBeInTheDocument();
     expect(screen.getByText("Restore behavior")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Racks\s+Select/ })).toBeEnabled();
     expect(screen.getByRole("button", { name: /Groups\s+Select/ })).toBeEnabled();
@@ -155,7 +161,7 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getAllByText("Preview is unavailable until a valid target reduction is entered.")).toHaveLength(2);
   });
 
-  it("renders percentage reduction previews as remaining target energy", () => {
+  it("renders preview values from the preview snapshot", () => {
     renderModal({
       initialValues: {
         ...configuredValues,
@@ -165,7 +171,7 @@ describe("CurtailmentStartModal", () => {
       preview,
     });
 
-    expect(screen.getAllByText("30.0 kW of 60.0 kW")).toHaveLength(2);
+    expect(screen.getAllByText("45.0 kW of 60.0 kW")).toHaveLength(2);
   });
 
   it("submits the current form values without dismissing the modal", async () => {
@@ -174,43 +180,50 @@ describe("CurtailmentStartModal", () => {
     const targetInput = screen.getByLabelText("Target value");
 
     await user.type(targetInput, "75");
+    await user.type(screen.getByLabelText("Tolerance"), "5");
+    await user.type(screen.getByLabelText("Min duration"), "300");
+    await user.type(screen.getByLabelText("Max duration"), "3600");
     await user.type(screen.getByLabelText("Reason"), "Grid response");
     await user.click(screen.getByRole("button", { name: "Start curtailment" }));
 
-    expect(onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        targetKw: "75",
-        reason: "Grid response",
-        responseProfileId: "customPlan",
-        curtailmentMode: "fixedKwTarget",
-        minerSelectionStrategy: "worstMinersFirst",
-        priority: "normal",
-      }),
-    );
+    const submittedValues = onSubmit.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(submittedValues).toMatchObject({
+      targetKw: "75",
+      toleranceKw: "5",
+      minDurationSec: "300",
+      maxDurationSec: "3600",
+      reason: "Grid response",
+      priority: "normal",
+    });
+    expect(submittedValues).not.toHaveProperty("responseProfileId");
+    expect(submittedValues).not.toHaveProperty("curtailmentMode");
+    expect(submittedValues).not.toHaveProperty("minerSelectionStrategy");
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
-  it("updates the curtailment dropdown values", async () => {
+  it("updates design-only dropdown values without submitting unsupported mappings", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal();
+    const startButton = screen.getByRole("button", { name: "Start curtailment" });
     const restoreSelectLayoutMock = mockVisibleSelectLayout();
+
+    expect(startButton).toBeEnabled();
 
     try {
       await user.click(screen.getByRole("button", { name: "Curtailment mode" }));
       await user.click(await screen.findByRole("option", { name: "Percentage reduction" }));
       await user.click(screen.getByRole("button", { name: "Miner selection strategy" }));
       await user.click(await screen.findByRole("option", { name: "Round robin" }));
-      await user.click(screen.getByRole("button", { name: "Start curtailment" }));
     } finally {
       restoreSelectLayoutMock();
     }
 
-    expect(onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        curtailmentMode: "percentageReduction",
-        minerSelectionStrategy: "roundRobin",
-      }),
-    );
+    expect(screen.getByText("Percentage reduction")).toBeInTheDocument();
+    expect(screen.getByText("Round robin")).toBeInTheDocument();
+    expect(startButton).toBeDisabled();
+
+    await user.click(startButton);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("requires confirmation before including maintenance miners", async () => {
@@ -330,6 +343,7 @@ describe("CurtailmentStartModal", () => {
     renderModal({
       errors: {
         targetKw: "Required",
+        minDurationSec: "Minimum duration is required",
         reason: "Reason is required",
       },
     });
@@ -338,6 +352,8 @@ describe("CurtailmentStartModal", () => {
     expect(targetInput).toHaveAttribute("aria-invalid", "true");
     expect(targetInput).toHaveAttribute("aria-describedby", "curtailment-target-kw-error");
     expect(screen.getByText("Required")).toBeInTheDocument();
+    expect(screen.getByLabelText("Min duration")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Minimum duration is required")).toBeInTheDocument();
     expect(screen.getByLabelText("Reason")).toHaveAttribute("aria-invalid", "true");
     expect(screen.getByText("Reason is required")).toBeInTheDocument();
   });

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -177,12 +177,18 @@ describe("CurtailmentStartModal", () => {
   it("submits the current form values without dismissing the modal", async () => {
     const user = userEvent.setup();
     const { onDismiss, onSubmit } = renderModal();
-    const targetInput = screen.getByLabelText("Target value");
+    const targetInput = screen.getByLabelText("Target reduction");
+    const [curtailBatchSizeInput, restoreBatchSizeInput] = screen.getAllByLabelText("Batch size (miners)");
+    const [curtailIntervalInput, restoreIntervalInput] = screen.getAllByLabelText("Batch interval (sec)");
 
     await user.type(targetInput, "75");
+    await user.type(curtailBatchSizeInput, "8");
+    await user.type(curtailIntervalInput, "60");
     await user.type(screen.getByLabelText("Tolerance"), "5");
     await user.type(screen.getByLabelText("Min duration"), "300");
     await user.type(screen.getByLabelText("Max duration"), "3600");
+    await user.type(restoreBatchSizeInput, "10");
+    await user.type(restoreIntervalInput, "120");
     await user.type(screen.getByLabelText("Reason"), "Grid response");
     await user.click(screen.getByRole("button", { name: "Start curtailment" }));
 
@@ -194,14 +200,18 @@ describe("CurtailmentStartModal", () => {
       maxDurationSec: "3600",
       reason: "Grid response",
       priority: "normal",
+      responseProfileId: "customPlan",
+      curtailmentMode: "fixedKwTarget",
+      minerSelectionStrategy: "worstMinersFirst",
+      curtailBatchSize: "8",
+      curtailIntervalSec: "60",
+      restoreBatchSize: "10",
+      restoreIntervalSec: "120",
     });
-    expect(submittedValues).not.toHaveProperty("responseProfileId");
-    expect(submittedValues).not.toHaveProperty("curtailmentMode");
-    expect(submittedValues).not.toHaveProperty("minerSelectionStrategy");
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
-  it("updates design-only dropdown values without submitting unsupported mappings", async () => {
+  it("submits selected curtailment mode and miner strategy values", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal();
     const startButton = screen.getByRole("button", { name: "Start curtailment" });
@@ -220,10 +230,15 @@ describe("CurtailmentStartModal", () => {
 
     expect(screen.getByText("Percentage reduction")).toBeInTheDocument();
     expect(screen.getByText("Round robin")).toBeInTheDocument();
-    expect(startButton).toBeDisabled();
+    expect(startButton).toBeEnabled();
 
     await user.click(startButton);
-    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        curtailmentMode: "percentageReduction",
+        minerSelectionStrategy: "roundRobin",
+      }),
+    );
   });
 
   it("requires confirmation before including maintenance miners", async () => {
@@ -312,7 +327,7 @@ describe("CurtailmentStartModal", () => {
       />,
     );
 
-    const targetInput = screen.getByLabelText("Target value");
+    const targetInput = screen.getByLabelText("Target reduction");
     await user.clear(targetInput);
     await user.type(targetInput, "99");
     expect(targetInput).toHaveValue(99);
@@ -334,7 +349,7 @@ describe("CurtailmentStartModal", () => {
       />,
     );
 
-    const updatedTargetInput = screen.getByLabelText("Target value");
+    const updatedTargetInput = screen.getByLabelText("Target reduction");
     expect(updatedTargetInput).toHaveValue(25);
     expect(screen.getByLabelText("Reason")).toHaveValue("Updated reason");
   });
@@ -348,7 +363,7 @@ describe("CurtailmentStartModal", () => {
       },
     });
 
-    const targetInput = screen.getByLabelText("Target value");
+    const targetInput = screen.getByLabelText("Target reduction");
     expect(targetInput).toHaveAttribute("aria-invalid", "true");
     expect(targetInput).toHaveAttribute("aria-describedby", "curtailment-target-kw-error");
     expect(screen.getByText("Required")).toBeInTheDocument();

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -75,7 +75,6 @@ const preview: CurtailmentPlanPreview = {
   selectedMinerCount: 18,
   targetKw: 40,
   estimatedReductionKw: 45,
-  curtailEstimate: "~2 minutes",
   restoreEstimate: "~2 minutes",
   scopeLabel: "across the fleet",
 };
@@ -143,9 +142,9 @@ describe("CurtailmentStartModal", () => {
     expect(screen.queryByText("Estimated time to restore ~2 minutes")).not.toBeInTheDocument();
 
     const secondaryPane = within(screen.getByTestId("secondary-pane"));
-    expect(secondaryPane.getByText("Time to curtail")).toBeInTheDocument();
+    expect(secondaryPane.queryByText("Time to curtail")).not.toBeInTheDocument();
     expect(secondaryPane.getByText("Time to restore")).toBeInTheDocument();
-    expect(secondaryPane.getAllByText("~2 minutes")).toHaveLength(2);
+    expect(secondaryPane.getAllByText("~2 minutes")).toHaveLength(1);
 
     rerender(
       <CurtailmentStartModal

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -189,6 +189,11 @@ describe("CurtailmentStartModal", () => {
     await user.type(screen.getByLabelText("Reason"), "Grid response");
     await user.click(screen.getByRole("button", { name: "Start curtailment" }));
 
+    expect(screen.getByText("Force include maintenance miners?")).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Force include" }));
+
     const submittedValues = onSubmit.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(submittedValues).toMatchObject({
       targetKw: "75",
@@ -209,7 +214,7 @@ describe("CurtailmentStartModal", () => {
 
   it("only exposes curtailment options supported by the current API", async () => {
     const user = userEvent.setup();
-    const { onSubmit } = renderModal();
+    const { onSubmit } = renderModal({ initialValues: { includeMaintenance: false } });
     const startButton = screen.getByRole("button", { name: "Start curtailment" });
     const restoreSelectLayoutMock = mockVisibleSelectLayout();
 
@@ -279,7 +284,7 @@ describe("CurtailmentStartModal", () => {
 
   it("opens target selectors and submits the selected target scope", async () => {
     const user = userEvent.setup();
-    const { onSubmit } = renderModal();
+    const { onSubmit } = renderModal({ initialValues: { includeMaintenance: false } });
 
     await user.click(screen.getByRole("button", { name: /Racks\s+Select/ }));
     expect(screen.getByRole("dialog", { name: "Rack selection" })).toBeInTheDocument();

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 
@@ -61,9 +61,9 @@ vi.mock("@/protoFleet/features/settings/components/Schedules/MinerSelectionModal
 }));
 
 const configuredValues: Partial<CurtailmentFormValues> = {
-  targetKw: "60",
-  minDurationSec: "300",
-  maxDurationSec: "3600",
+  targetKw: "45",
+  curtailBatchSize: "8",
+  curtailIntervalSec: "60",
   restoreBatchSize: "10",
   restoreIntervalSec: "120",
   reason: "Grid peak - ERCOT 4CP signal",
@@ -71,8 +71,9 @@ const configuredValues: Partial<CurtailmentFormValues> = {
 
 const preview: CurtailmentPlanPreview = {
   selectedMinerCount: 18,
-  targetKw: 60,
-  estimatedReductionKw: 60.2,
+  targetKw: 45,
+  currentUsageKw: 60,
+  curtailEstimate: "~2 minutes",
   restoreEstimate: "~2 minutes",
   scopeLabel: "across the fleet",
 };
@@ -96,12 +97,34 @@ const getMaintenanceCheckbox = (): HTMLInputElement => {
   return checkbox;
 };
 
+function mockVisibleSelectLayout(): () => void {
+  const getBoundingClientRectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+    x: 16,
+    y: 16,
+    width: 320,
+    height: 56,
+    top: 16,
+    right: 336,
+    bottom: 72,
+    left: 16,
+    toJSON: () => ({}),
+  } as DOMRect);
+
+  return () => getBoundingClientRectSpy.mockRestore();
+}
+
 describe("CurtailmentStartModal", () => {
   it("renders the empty state and target selectors", () => {
     renderModal();
 
     expect(screen.getByRole("dialog", { name: "Plan a curtailment" })).toBeInTheDocument();
     expect(screen.getAllByText("Configure your curtailment to see a preview.")).toHaveLength(2);
+    expect(screen.getByText("Response profile")).toBeInTheDocument();
+    expect(screen.getByText("Custom plan")).toBeInTheDocument();
+    expect(screen.getByText("Curtail behavior")).toBeInTheDocument();
+    expect(screen.getByText("Fixed kW target")).toBeInTheDocument();
+    expect(screen.getByText("Worst miners first")).toBeInTheDocument();
+    expect(screen.getByText("Restore behavior")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Racks\s+Select/ })).toBeEnabled();
     expect(screen.getByRole("button", { name: /Groups\s+Select/ })).toBeEnabled();
     expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeEnabled();
@@ -111,9 +134,13 @@ describe("CurtailmentStartModal", () => {
     const { rerender } = renderModal({ initialValues: configuredValues, preview });
 
     expect(screen.getAllByText("Curtail 18 miners across the fleet immediately")).toHaveLength(2);
-    expect(screen.getAllByText("60.2 kW of 60.0 kW")).toHaveLength(2);
-    expect(screen.getAllByText("~2 minutes")).toHaveLength(2);
-    expect(screen.getByText("Estimated time to restore ~2 minutes")).toBeInTheDocument();
+    expect(screen.getAllByText("45.0 kW of 60.0 kW")).toHaveLength(2);
+    expect(screen.queryByText("Estimated time to restore ~2 minutes")).not.toBeInTheDocument();
+
+    const secondaryPane = within(screen.getByTestId("secondary-pane"));
+    expect(secondaryPane.getByText("Time to curtail")).toBeInTheDocument();
+    expect(secondaryPane.getByText("Time to restore")).toBeInTheDocument();
+    expect(secondaryPane.getAllByText("~2 minutes")).toHaveLength(2);
 
     rerender(
       <CurtailmentStartModal
@@ -128,11 +155,25 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getAllByText("Preview is unavailable until a valid target reduction is entered.")).toHaveLength(2);
   });
 
+  it("renders percentage reduction previews as remaining target energy", () => {
+    renderModal({
+      initialValues: {
+        ...configuredValues,
+        curtailmentMode: "percentageReduction",
+        targetKw: "50",
+      },
+      preview,
+    });
+
+    expect(screen.getAllByText("30.0 kW of 60.0 kW")).toHaveLength(2);
+  });
+
   it("submits the current form values without dismissing the modal", async () => {
     const user = userEvent.setup();
     const { onDismiss, onSubmit } = renderModal();
+    const targetInput = screen.getByLabelText("Target value");
 
-    await user.type(screen.getByLabelText("Target reduction"), "75");
+    await user.type(targetInput, "75");
     await user.type(screen.getByLabelText("Reason"), "Grid response");
     await user.click(screen.getByRole("button", { name: "Start curtailment" }));
 
@@ -140,10 +181,36 @@ describe("CurtailmentStartModal", () => {
       expect.objectContaining({
         targetKw: "75",
         reason: "Grid response",
+        responseProfileId: "customPlan",
+        curtailmentMode: "fixedKwTarget",
+        minerSelectionStrategy: "worstMinersFirst",
         priority: "normal",
       }),
     );
     expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("updates the curtailment dropdown values", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal();
+    const restoreSelectLayoutMock = mockVisibleSelectLayout();
+
+    try {
+      await user.click(screen.getByRole("button", { name: "Curtailment mode" }));
+      await user.click(await screen.findByRole("option", { name: "Percentage reduction" }));
+      await user.click(screen.getByRole("button", { name: "Miner selection strategy" }));
+      await user.click(await screen.findByRole("option", { name: "Round robin" }));
+      await user.click(screen.getByRole("button", { name: "Start curtailment" }));
+    } finally {
+      restoreSelectLayoutMock();
+    }
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        curtailmentMode: "percentageReduction",
+        minerSelectionStrategy: "roundRobin",
+      }),
+    );
   });
 
   it("requires confirmation before including maintenance miners", async () => {
@@ -232,9 +299,10 @@ describe("CurtailmentStartModal", () => {
       />,
     );
 
-    await user.clear(screen.getByLabelText("Target reduction"));
-    await user.type(screen.getByLabelText("Target reduction"), "99");
-    expect(screen.getByLabelText("Target reduction")).toHaveValue(99);
+    const targetInput = screen.getByLabelText("Target value");
+    await user.clear(targetInput);
+    await user.type(targetInput, "99");
+    expect(targetInput).toHaveValue(99);
 
     rerender(
       <CurtailmentStartModal
@@ -253,7 +321,8 @@ describe("CurtailmentStartModal", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Target reduction")).toHaveValue(25);
+    const updatedTargetInput = screen.getByLabelText("Target value");
+    expect(updatedTargetInput).toHaveValue(25);
     expect(screen.getByLabelText("Reason")).toHaveValue("Updated reason");
   });
 
@@ -265,11 +334,9 @@ describe("CurtailmentStartModal", () => {
       },
     });
 
-    expect(screen.getByLabelText("Target reduction")).toHaveAttribute("aria-invalid", "true");
-    expect(screen.getByLabelText("Target reduction")).toHaveAttribute(
-      "aria-describedby",
-      "curtailment-target-kw-error",
-    );
+    const targetInput = screen.getByLabelText("Target value");
+    expect(targetInput).toHaveAttribute("aria-invalid", "true");
+    expect(targetInput).toHaveAttribute("aria-describedby", "curtailment-target-kw-error");
     expect(screen.getByText("Required")).toBeInTheDocument();
     expect(screen.getByLabelText("Reason")).toHaveAttribute("aria-invalid", "true");
     expect(screen.getByText("Reason is required")).toBeInTheDocument();

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -202,6 +202,7 @@ describe("CurtailmentStartModal", () => {
       minerSelectionStrategy: "leastEfficientFirst",
       restoreBatchSize: "10",
       restoreIntervalSec: "120",
+      includeMaintenance: true,
     });
     expect(onDismiss).not.toHaveBeenCalled();
   });
@@ -243,9 +244,17 @@ describe("CurtailmentStartModal", () => {
     );
   });
 
-  it("requires confirmation before including maintenance miners", async () => {
+  it("includes maintenance miners by default and confirms re-inclusion", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal();
+
+    expect(getMaintenanceCheckbox()).toBeChecked();
+    expect(screen.queryByText("Requires explicit force acknowledgement")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Include miners in maintenance"));
+
+    expect(getMaintenanceCheckbox()).not.toBeChecked();
+    expect(screen.queryByText("Force include maintenance miners?")).not.toBeInTheDocument();
 
     await user.click(screen.getByText("Include miners in maintenance"));
 

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -65,9 +65,7 @@ vi.mock("@/protoFleet/features/settings/components/Schedules/MinerSelectionModal
 }));
 
 const configuredValues: Partial<CurtailmentFormValues> = {
-  targetKw: "45",
-  curtailBatchSize: "8",
-  curtailIntervalSec: "60",
+  targetKw: "40",
   restoreBatchSize: "10",
   restoreIntervalSec: "120",
   reason: "Grid peak - ERCOT 4CP signal",
@@ -75,8 +73,8 @@ const configuredValues: Partial<CurtailmentFormValues> = {
 
 const preview: CurtailmentPlanPreview = {
   selectedMinerCount: 18,
-  targetKw: 45,
-  currentUsageKw: 60,
+  targetKw: 40,
+  estimatedReductionKw: 45,
   curtailEstimate: "~2 minutes",
   restoreEstimate: "~2 minutes",
   scopeLabel: "across the fleet",
@@ -126,10 +124,10 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByText("Response profile")).toBeInTheDocument();
     expect(screen.getByText("Custom plan")).toBeInTheDocument();
     expect(screen.getByText("Curtail behavior")).toBeInTheDocument();
-    expect(screen.getByText("Fixed kW target")).toBeInTheDocument();
-    expect(screen.getByText("Worst miners first")).toBeInTheDocument();
-    expect(screen.getByText("Safety")).toBeInTheDocument();
-    expect(screen.getByText("Normal")).toBeInTheDocument();
+    expect(screen.getByText("Fixed kW reduction")).toBeInTheDocument();
+    expect(screen.getByText("Least efficient first")).toBeInTheDocument();
+    expect(screen.queryByText("Safety")).not.toBeInTheDocument();
+    expect(screen.queryByText("Normal")).not.toBeInTheDocument();
     expect(screen.getByText("Restore behavior")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Racks\s+Select/ })).toBeEnabled();
     expect(screen.getByRole("button", { name: /Groups\s+Select/ })).toBeEnabled();
@@ -140,7 +138,8 @@ describe("CurtailmentStartModal", () => {
     const { rerender } = renderModal({ initialValues: configuredValues, preview });
 
     expect(screen.getAllByText("Curtail 18 miners across the fleet immediately")).toHaveLength(2);
-    expect(screen.getAllByText("45.0 kW of 60.0 kW")).toHaveLength(2);
+    expect(screen.getAllByText("Target reduction")).toHaveLength(3);
+    expect(screen.getAllByText("45.0 kW of 40.0 kW")).toHaveLength(2);
     expect(screen.queryByText("Estimated time to restore ~2 minutes")).not.toBeInTheDocument();
 
     const secondaryPane = within(screen.getByTestId("secondary-pane"));
@@ -161,32 +160,30 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getAllByText("Preview is unavailable until a valid target reduction is entered.")).toHaveLength(2);
   });
 
-  it("renders preview values from the preview snapshot", () => {
+  it("renders estimated reduction against the requested reduction", () => {
     renderModal({
       initialValues: {
         ...configuredValues,
-        curtailmentMode: "percentageReduction",
-        targetKw: "50",
+        targetKw: "40",
       },
-      preview,
+      preview: {
+        ...preview,
+        targetKw: 40,
+        estimatedReductionKw: 48,
+      },
     });
 
-    expect(screen.getAllByText("45.0 kW of 60.0 kW")).toHaveLength(2);
+    expect(screen.getAllByText("48.0 kW of 40.0 kW")).toHaveLength(2);
   });
 
   it("submits the current form values without dismissing the modal", async () => {
     const user = userEvent.setup();
     const { onDismiss, onSubmit } = renderModal();
     const targetInput = screen.getByLabelText("Target reduction");
-    const [curtailBatchSizeInput, restoreBatchSizeInput] = screen.getAllByLabelText("Batch size (miners)");
-    const [curtailIntervalInput, restoreIntervalInput] = screen.getAllByLabelText("Batch interval (sec)");
+    const restoreBatchSizeInput = screen.getByLabelText("Batch size (miners)");
+    const restoreIntervalInput = screen.getByLabelText("Batch interval (sec)");
 
     await user.type(targetInput, "75");
-    await user.type(curtailBatchSizeInput, "8");
-    await user.type(curtailIntervalInput, "60");
-    await user.type(screen.getByLabelText("Tolerance"), "5");
-    await user.type(screen.getByLabelText("Min duration"), "300");
-    await user.type(screen.getByLabelText("Max duration"), "3600");
     await user.type(restoreBatchSizeInput, "10");
     await user.type(restoreIntervalInput, "120");
     await user.type(screen.getByLabelText("Reason"), "Grid response");
@@ -195,23 +192,21 @@ describe("CurtailmentStartModal", () => {
     const submittedValues = onSubmit.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(submittedValues).toMatchObject({
       targetKw: "75",
-      toleranceKw: "5",
-      minDurationSec: "300",
-      maxDurationSec: "3600",
+      toleranceKw: "",
+      minDurationSec: "",
+      maxDurationSec: "",
       reason: "Grid response",
       priority: "normal",
       responseProfileId: "customPlan",
-      curtailmentMode: "fixedKwTarget",
-      minerSelectionStrategy: "worstMinersFirst",
-      curtailBatchSize: "8",
-      curtailIntervalSec: "60",
+      curtailmentMode: "fixedKwReduction",
+      minerSelectionStrategy: "leastEfficientFirst",
       restoreBatchSize: "10",
       restoreIntervalSec: "120",
     });
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
-  it("submits selected curtailment mode and miner strategy values", async () => {
+  it("only exposes curtailment options supported by the current API", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal();
     const startButton = screen.getByRole("button", { name: "Start curtailment" });
@@ -221,22 +216,29 @@ describe("CurtailmentStartModal", () => {
 
     try {
       await user.click(screen.getByRole("button", { name: "Curtailment mode" }));
-      await user.click(await screen.findByRole("option", { name: "Percentage reduction" }));
+      const fixedReductionOption = await screen.findByRole("option", { name: "Fixed kW reduction" });
+      expect(screen.queryByRole("option", { name: "Percentage reduction" })).not.toBeInTheDocument();
+      await user.click(fixedReductionOption);
+
       await user.click(screen.getByRole("button", { name: "Miner selection strategy" }));
-      await user.click(await screen.findByRole("option", { name: "Round robin" }));
+      const leastEfficientOption = await screen.findByRole("option", { name: "Least efficient first" });
+      expect(screen.queryByRole("option", { name: "Round robin" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "Oldest miners first" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "Lowest hashrate first" })).not.toBeInTheDocument();
+      await user.click(leastEfficientOption);
     } finally {
       restoreSelectLayoutMock();
     }
 
-    expect(screen.getByText("Percentage reduction")).toBeInTheDocument();
-    expect(screen.getByText("Round robin")).toBeInTheDocument();
+    expect(screen.getByText("Fixed kW reduction")).toBeInTheDocument();
+    expect(screen.getByText("Least efficient first")).toBeInTheDocument();
     expect(startButton).toBeEnabled();
 
     await user.click(startButton);
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
-        curtailmentMode: "percentageReduction",
-        minerSelectionStrategy: "roundRobin",
+        curtailmentMode: "fixedKwReduction",
+        minerSelectionStrategy: "leastEfficientFirst",
       }),
     );
   });
@@ -358,7 +360,6 @@ describe("CurtailmentStartModal", () => {
     renderModal({
       errors: {
         targetKw: "Required",
-        minDurationSec: "Minimum duration is required",
         reason: "Reason is required",
       },
     });
@@ -367,8 +368,6 @@ describe("CurtailmentStartModal", () => {
     expect(targetInput).toHaveAttribute("aria-invalid", "true");
     expect(targetInput).toHaveAttribute("aria-describedby", "curtailment-target-kw-error");
     expect(screen.getByText("Required")).toBeInTheDocument();
-    expect(screen.getByLabelText("Min duration")).toHaveAttribute("aria-invalid", "true");
-    expect(screen.getByText("Minimum duration is required")).toBeInTheDocument();
     expect(screen.getByLabelText("Reason")).toHaveAttribute("aria-invalid", "true");
     expect(screen.getByText("Reason is required")).toBeInTheDocument();
   });

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -39,6 +39,23 @@ export interface CurtailmentFormValues {
   includeMaintenance: boolean;
 }
 
+export type CurtailmentSubmitValues = Pick<
+  CurtailmentFormValues,
+  | "scopeType"
+  | "scopeId"
+  | "deviceSetIds"
+  | "deviceIdentifiers"
+  | "targetKw"
+  | "toleranceKw"
+  | "priority"
+  | "minDurationSec"
+  | "maxDurationSec"
+  | "restoreBatchSize"
+  | "restoreIntervalSec"
+  | "reason"
+  | "includeMaintenance"
+>;
+
 export interface CurtailmentPlanPreview {
   selectedMinerCount: number;
   targetKw: number;
@@ -53,7 +70,7 @@ export type CurtailmentFormErrors = Partial<Record<keyof CurtailmentFormValues, 
 interface CurtailmentStartModalProps {
   open: boolean;
   onDismiss: () => void;
-  onSubmit: (values: CurtailmentFormValues) => void;
+  onSubmit: (values: CurtailmentSubmitValues) => void;
   initialValues?: Partial<CurtailmentFormValues>;
   errors?: CurtailmentFormErrors;
   preview?: CurtailmentPlanPreview;
@@ -84,7 +101,6 @@ interface ReductionProgressBarProps {
 interface PreviewPaneProps {
   preview?: CurtailmentPlanPreview;
   previewError?: string;
-  values: CurtailmentFormValues;
 }
 
 interface TypedSelectOption<Value extends string> extends SelectOption {
@@ -137,6 +153,11 @@ const minerSelectionStrategyOptions: Array<TypedSelectOption<MinerSelectionStrat
   { value: "oldestMinersFirst", label: "Oldest miners first" },
   { value: "lowestHashrateFirst", label: "Lowest hashrate first" },
   { value: "roundRobin", label: "Round robin" },
+];
+
+const priorityOptions: Array<TypedSelectOption<CurtailmentPriority>> = [
+  { value: "normal", label: "Normal" },
+  { value: "emergency", label: "Emergency" },
 ];
 
 function getInitialValues(initialValues?: Partial<CurtailmentFormValues>): CurtailmentFormValues {
@@ -203,30 +224,8 @@ function formatKw(value: number): string {
   })} kW`;
 }
 
-function parseTargetValue(value: string): number | undefined {
-  const numericValue = Number(value);
-
-  return Number.isFinite(numericValue) ? numericValue : undefined;
-}
-
 function clampPercentage(value: number): number {
   return Math.min(Math.max(value, 0), 100);
-}
-
-function getTargetUsageKw(preview: CurtailmentPlanPreview, values: CurtailmentFormValues): number {
-  const targetValue = parseTargetValue(values.targetKw);
-
-  if (targetValue === undefined) {
-    return preview.targetKw;
-  }
-
-  if (values.curtailmentMode === "percentageReduction") {
-    const remainingPercentage = 100 - clampPercentage(targetValue);
-
-    return preview.currentUsageKw * (remainingPercentage / 100);
-  }
-
-  return targetValue;
 }
 
 function ReductionProgressBar({ value, max }: ReductionProgressBarProps): ReactElement {
@@ -240,7 +239,7 @@ function ReductionProgressBar({ value, max }: ReductionProgressBarProps): ReactE
   );
 }
 
-function PreviewPane({ preview, previewError, values }: PreviewPaneProps): ReactElement {
+function PreviewPane({ preview, previewError }: PreviewPaneProps): ReactElement {
   if (previewError) {
     return (
       <div className="flex min-h-40 flex-1 items-center justify-center rounded-[24px] bg-surface-overlay px-6 py-10 text-300 text-text-primary-70 laptop:px-16">
@@ -260,8 +259,6 @@ function PreviewPane({ preview, previewError, values }: PreviewPaneProps): React
     );
   }
 
-  const targetUsageKw = getTargetUsageKw(preview, values);
-
   return (
     <div className="flex min-h-[360px] flex-1 items-center justify-center rounded-[24px] bg-surface-overlay px-8 py-12 laptop:min-h-0 laptop:px-16 laptop:py-6">
       <div className="flex w-full max-w-[520px] flex-col gap-10">
@@ -273,10 +270,10 @@ function PreviewPane({ preview, previewError, values }: PreviewPaneProps): React
           <div>
             <div className="text-emphasis-200 text-text-primary-70">Target value</div>
             <div className="text-heading-300 text-text-primary">
-              {formatKw(targetUsageKw)} of {formatKw(preview.currentUsageKw)}
+              {formatKw(preview.targetKw)} of {formatKw(preview.currentUsageKw)}
             </div>
           </div>
-          <ReductionProgressBar value={targetUsageKw} max={preview.currentUsageKw} />
+          <ReductionProgressBar value={preview.targetKw} max={preview.currentUsageKw} />
         </div>
 
         <div className="grid gap-6">
@@ -311,6 +308,28 @@ function getSelectedMinerIds(values: CurtailmentFormValues): string[] {
   return values.deviceIdentifiers;
 }
 
+function canSubmitWithCurrentMapping(values: CurtailmentFormValues): boolean {
+  return values.curtailmentMode === "fixedKwTarget" && values.minerSelectionStrategy === "worstMinersFirst";
+}
+
+function getSubmitValues(values: CurtailmentFormValues): CurtailmentSubmitValues {
+  return {
+    scopeType: values.scopeType,
+    scopeId: values.scopeId,
+    deviceSetIds: values.deviceSetIds,
+    deviceIdentifiers: values.deviceIdentifiers,
+    targetKw: values.targetKw,
+    toleranceKw: values.toleranceKw,
+    priority: values.priority,
+    minDurationSec: values.minDurationSec,
+    maxDurationSec: values.maxDurationSec,
+    restoreBatchSize: values.restoreBatchSize,
+    restoreIntervalSec: values.restoreIntervalSec,
+    reason: values.reason,
+    includeMaintenance: values.includeMaintenance,
+  };
+}
+
 function CurtailmentStartModalContent({
   onDismiss,
   onSubmit,
@@ -333,7 +352,8 @@ function CurtailmentStartModalContent({
     groups: getSelectedDeviceSetIds(values, "groups"),
     miners: getSelectedMinerIds(values),
   };
-  const previewPane = <PreviewPane preview={preview} previewError={previewError} values={values} />;
+  const previewPane = <PreviewPane preview={preview} previewError={previewError} />;
+  const supportsCurrentSubmitMapping = canSubmitWithCurrentMapping(values);
 
   const handleDeviceSetSelection = (deviceSetIds: string[], scopeId: DeviceSetScopeId) => {
     const hasSelectedDeviceSets = deviceSetIds.length > 0;
@@ -371,7 +391,8 @@ function CurtailmentStartModalContent({
           {
             text: "Start curtailment",
             variant: variants.primary,
-            onClick: () => onSubmit(values),
+            onClick: () => onSubmit(getSubmitValues(values)),
+            disabled: !supportsCurrentSubmitMapping,
             loading: isSubmitting,
           },
         ]}
@@ -440,6 +461,47 @@ function CurtailmentStartModalContent({
                     value={values.curtailIntervalSec}
                     error={errors?.curtailIntervalSec}
                     onChange={(value) => updateValue("curtailIntervalSec", value)}
+                  />
+                </div>
+              </div>
+            </Section>
+
+            <Section title="Safety">
+              <div className="grid gap-3">
+                <div className="grid gap-3 tablet:grid-cols-2">
+                  <TypedSelect
+                    id="curtailment-priority"
+                    label="Priority"
+                    value={values.priority}
+                    options={priorityOptions}
+                    error={errors?.priority}
+                    onChange={(value) => updateValue("priority", value)}
+                  />
+                  <Field
+                    id="curtailment-tolerance-kw"
+                    label="Tolerance"
+                    value={values.toleranceKw}
+                    units="kW"
+                    error={errors?.toleranceKw}
+                    onChange={(value) => updateValue("toleranceKw", value)}
+                  />
+                </div>
+                <div className="grid gap-3 tablet:grid-cols-2">
+                  <Field
+                    id="curtailment-min-duration"
+                    label="Min duration"
+                    value={values.minDurationSec}
+                    units="sec"
+                    error={errors?.minDurationSec}
+                    onChange={(value) => updateValue("minDurationSec", value)}
+                  />
+                  <Field
+                    id="curtailment-max-duration"
+                    label="Max duration"
+                    value={values.maxDurationSec}
+                    units="sec"
+                    error={errors?.maxDurationSec}
+                    onChange={(value) => updateValue("maxDurationSec", value)}
                   />
                 </div>
               </div>

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -117,7 +117,7 @@ const defaultValues: CurtailmentFormValues = {
   restoreBatchSize: "",
   restoreIntervalSec: "",
   reason: "",
-  includeMaintenance: false,
+  includeMaintenance: true,
 };
 
 const responseProfileOptions: Array<TypedSelectOption<ResponseProfileId>> = [
@@ -458,7 +458,6 @@ function CurtailmentStartModalContent({
               />
               <span>
                 <span className="block text-300 text-text-primary">Include miners in maintenance</span>
-                <span className="block text-200 text-text-primary-70">Requires explicit force acknowledgement</span>
               </span>
             </label>
           </section>

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -43,7 +43,6 @@ export interface CurtailmentPlanPreview {
   selectedMinerCount: number;
   targetKw: number;
   estimatedReductionKw: number;
-  curtailEstimate: string;
   restoreEstimate: string;
   scopeLabel: string;
 }
@@ -255,11 +254,6 @@ function PreviewPane({ preview, previewError }: PreviewPaneProps): ReactElement 
         </div>
 
         <div className="grid gap-6">
-          <div>
-            <div className="text-emphasis-200 text-text-primary-70">Time to curtail</div>
-            <div className="text-heading-300 text-text-primary">{preview.curtailEstimate}</div>
-          </div>
-
           <div>
             <div className="text-emphasis-200 text-text-primary-70">Time to restore</div>
             <div className="text-heading-300 text-text-primary">{preview.restoreEstimate}</div>

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -297,6 +297,8 @@ function CurtailmentStartModalContent({
 }: CurtailmentStartModalProps): ReactElement {
   const [values, setValues] = useState<CurtailmentFormValues>(() => getInitialValues(initialValues));
   const [showMaintenanceConfirmation, setShowMaintenanceConfirmation] = useState(false);
+  const [maintenanceInclusionConfirmed, setMaintenanceInclusionConfirmed] = useState(false);
+  const [submitAfterMaintenanceConfirmation, setSubmitAfterMaintenanceConfirmation] = useState(false);
   const [showRackSelectionModal, setShowRackSelectionModal] = useState(false);
   const [showGroupSelectionModal, setShowGroupSelectionModal] = useState(false);
   const [showMinerSelectionModal, setShowMinerSelectionModal] = useState(false);
@@ -334,6 +336,34 @@ function CurtailmentStartModalContent({
     }));
   };
 
+  const closeMaintenanceConfirmation = () => {
+    setSubmitAfterMaintenanceConfirmation(false);
+    setShowMaintenanceConfirmation(false);
+  };
+
+  const handleSubmit = () => {
+    if (values.includeMaintenance && !maintenanceInclusionConfirmed) {
+      setSubmitAfterMaintenanceConfirmation(true);
+      setShowMaintenanceConfirmation(true);
+      return;
+    }
+
+    onSubmit(values);
+  };
+
+  const confirmMaintenanceInclusion = () => {
+    const nextValues = { ...values, includeMaintenance: true };
+
+    setMaintenanceInclusionConfirmed(true);
+    setValues(nextValues);
+    setShowMaintenanceConfirmation(false);
+
+    if (submitAfterMaintenanceConfirmation) {
+      setSubmitAfterMaintenanceConfirmation(false);
+      onSubmit(nextValues);
+    }
+  };
+
   return (
     <>
       <FullScreenTwoPaneModal
@@ -346,7 +376,7 @@ function CurtailmentStartModalContent({
           {
             text: "Start curtailment",
             variant: variants.primary,
-            onClick: () => onSubmit(values),
+            onClick: handleSubmit,
             loading: isSubmitting,
           },
         ]}
@@ -449,10 +479,12 @@ function CurtailmentStartModalContent({
                 checked={values.includeMaintenance}
                 onChange={(event) => {
                   if (event.currentTarget.checked) {
+                    setSubmitAfterMaintenanceConfirmation(false);
                     setShowMaintenanceConfirmation(true);
                     return;
                   }
 
+                  setMaintenanceInclusionConfirmed(false);
                   updateValue("includeMaintenance", false);
                 }}
               />
@@ -469,7 +501,7 @@ function CurtailmentStartModalContent({
         open={showMaintenanceConfirmation}
         title="Force include maintenance miners?"
         testId="curtailment-maintenance-confirmation"
-        onDismiss={() => setShowMaintenanceConfirmation(false)}
+        onDismiss={closeMaintenanceConfirmation}
         icon={
           <DialogIcon intent="warning">
             <Alert />
@@ -478,15 +510,12 @@ function CurtailmentStartModalContent({
         buttons={[
           {
             text: "Cancel",
-            onClick: () => setShowMaintenanceConfirmation(false),
+            onClick: closeMaintenanceConfirmation,
             variant: variants.secondary,
           },
           {
             text: "Force include",
-            onClick: () => {
-              updateValue("includeMaintenance", true);
-              setShowMaintenanceConfirmation(false);
-            },
+            onClick: confirmMaintenanceInclusion,
             variant: variants.danger,
           },
         ]}

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -10,19 +10,27 @@ import { variants } from "@/shared/components/Button";
 import Checkbox from "@/shared/components/Checkbox";
 import Dialog, { DialogIcon } from "@/shared/components/Dialog";
 import Input from "@/shared/components/Input";
-import Select from "@/shared/components/Select";
+import Select, { type SelectOption } from "@/shared/components/Select";
 
 export type CurtailmentPriority = "normal" | "emergency";
 export type CurtailmentScopeType = "wholeOrg" | "deviceSet" | "explicitMiners";
+export type ResponseProfileId = "customPlan";
+export type CurtailmentMode = "percentageReduction" | "fixedKwTarget";
+export type MinerSelectionStrategy = "worstMinersFirst" | "oldestMinersFirst" | "lowestHashrateFirst" | "roundRobin";
 
 export interface CurtailmentFormValues {
   scopeType: CurtailmentScopeType;
   scopeId?: string;
   deviceSetIds: string[];
   deviceIdentifiers: string[];
+  responseProfileId: ResponseProfileId;
+  curtailmentMode: CurtailmentMode;
+  minerSelectionStrategy: MinerSelectionStrategy;
   targetKw: string;
   toleranceKw: string;
   priority: CurtailmentPriority;
+  curtailBatchSize: string;
+  curtailIntervalSec: string;
   minDurationSec: string;
   maxDurationSec: string;
   restoreBatchSize: string;
@@ -34,7 +42,8 @@ export interface CurtailmentFormValues {
 export interface CurtailmentPlanPreview {
   selectedMinerCount: number;
   targetKw: number;
-  estimatedReductionKw: number;
+  currentUsageKw: number;
+  curtailEstimate: string;
   restoreEstimate: string;
   scopeLabel: string;
 }
@@ -67,6 +76,30 @@ interface SectionProps {
   children: ReactNode;
 }
 
+interface ReductionProgressBarProps {
+  value: number;
+  max: number;
+}
+
+interface PreviewPaneProps {
+  preview?: CurtailmentPlanPreview;
+  previewError?: string;
+  values: CurtailmentFormValues;
+}
+
+interface TypedSelectOption<Value extends string> extends SelectOption {
+  value: Value;
+}
+
+interface TypedSelectProps<Value extends string> {
+  id: string;
+  label: string;
+  value: Value;
+  options: Array<TypedSelectOption<Value>>;
+  error?: string;
+  onChange: (value: Value) => void;
+}
+
 type DeviceSetScopeId = "racks" | "groups";
 
 const defaultValues: CurtailmentFormValues = {
@@ -74,9 +107,14 @@ const defaultValues: CurtailmentFormValues = {
   scopeId: "whole-org",
   deviceSetIds: [],
   deviceIdentifiers: [],
+  responseProfileId: "customPlan",
+  curtailmentMode: "fixedKwTarget",
+  minerSelectionStrategy: "worstMinersFirst",
   targetKw: "",
   toleranceKw: "",
   priority: "normal",
+  curtailBatchSize: "",
+  curtailIntervalSec: "",
   minDurationSec: "",
   maxDurationSec: "",
   restoreBatchSize: "",
@@ -85,42 +123,74 @@ const defaultValues: CurtailmentFormValues = {
   includeMaintenance: false,
 };
 
-const priorityOptions: Array<{ value: CurtailmentPriority; label: string }> = [
-  { value: "normal", label: "Normal" },
-  { value: "emergency", label: "Emergency" },
+const responseProfileOptions: Array<TypedSelectOption<ResponseProfileId>> = [
+  { value: "customPlan", label: "Custom plan" },
 ];
 
-const isCurtailmentPriority = (value: string): value is CurtailmentPriority =>
-  priorityOptions.some((option) => option.value === value);
+const curtailmentModeOptions: Array<TypedSelectOption<CurtailmentMode>> = [
+  { value: "percentageReduction", label: "Percentage reduction" },
+  { value: "fixedKwTarget", label: "Fixed kW target" },
+];
 
-const getInitialValues = (initialValues?: Partial<CurtailmentFormValues>): CurtailmentFormValues => ({
-  ...defaultValues,
-  ...initialValues,
-});
+const minerSelectionStrategyOptions: Array<TypedSelectOption<MinerSelectionStrategy>> = [
+  { value: "worstMinersFirst", label: "Worst miners first" },
+  { value: "oldestMinersFirst", label: "Oldest miners first" },
+  { value: "lowestHashrateFirst", label: "Lowest hashrate first" },
+  { value: "roundRobin", label: "Round robin" },
+];
 
-const getInitialValuesKey = (initialValues?: Partial<CurtailmentFormValues>): string =>
-  Object.entries(getInitialValues(initialValues))
+function getInitialValues(initialValues?: Partial<CurtailmentFormValues>): CurtailmentFormValues {
+  return {
+    ...defaultValues,
+    ...initialValues,
+  };
+}
+
+function getInitialValuesKey(initialValues?: Partial<CurtailmentFormValues>): string {
+  return Object.entries(getInitialValues(initialValues))
     .map(([key, value]) => `${key}:${String(value)}`)
     .join("|");
+}
+
+function isSelectOptionValue<Value extends string>(
+  options: Array<TypedSelectOption<Value>>,
+  value: string,
+): value is Value {
+  return options.some((option) => option.value === value);
+}
 
 function Field({ id, label, value, units, type = "number", error, onChange }: FieldProps): ReactElement {
+  return <Input id={id} label={label} initValue={value} units={units} type={type} error={error} onChange={onChange} />;
+}
+
+function TypedSelect<Value extends string>({
+  id,
+  label,
+  value,
+  options,
+  error,
+  onChange,
+}: TypedSelectProps<Value>): ReactElement {
   return (
-    <Input
+    <Select
       id={id}
       label={label}
-      initValue={value}
-      units={units}
-      type={type}
+      value={value}
+      options={options}
       error={error}
-      onChange={(nextValue) => onChange(nextValue)}
+      onChange={(nextValue) => {
+        if (isSelectOptionValue(options, nextValue)) {
+          onChange(nextValue);
+        }
+      }}
     />
   );
 }
 
 function Section({ title, children }: SectionProps): ReactElement {
   return (
-    <section className="grid gap-3">
-      <div className="text-emphasis-300 text-text-primary">{title}</div>
+    <section className="grid gap-6">
+      <h2 className="text-heading-200 text-text-primary">{title}</h2>
       {children}
     </section>
   );
@@ -133,8 +203,34 @@ function formatKw(value: number): string {
   })} kW`;
 }
 
-function ReductionProgressBar({ value, max }: { value: number; max: number }): ReactElement {
-  const reductionPercentage = max > 0 ? Math.min(Math.max((value / max) * 100, 0), 100) : 0;
+function parseTargetValue(value: string): number | undefined {
+  const numericValue = Number(value);
+
+  return Number.isFinite(numericValue) ? numericValue : undefined;
+}
+
+function clampPercentage(value: number): number {
+  return Math.min(Math.max(value, 0), 100);
+}
+
+function getTargetUsageKw(preview: CurtailmentPlanPreview, values: CurtailmentFormValues): number {
+  const targetValue = parseTargetValue(values.targetKw);
+
+  if (targetValue === undefined) {
+    return preview.targetKw;
+  }
+
+  if (values.curtailmentMode === "percentageReduction") {
+    const remainingPercentage = 100 - clampPercentage(targetValue);
+
+    return preview.currentUsageKw * (remainingPercentage / 100);
+  }
+
+  return targetValue;
+}
+
+function ReductionProgressBar({ value, max }: ReductionProgressBarProps): ReactElement {
+  const reductionPercentage = max > 0 ? clampPercentage((value / max) * 100) : 0;
 
   return (
     <div className="flex h-3 w-full gap-1 overflow-hidden">
@@ -144,13 +240,7 @@ function ReductionProgressBar({ value, max }: { value: number; max: number }): R
   );
 }
 
-function PreviewPane({
-  preview,
-  previewError,
-}: {
-  preview?: CurtailmentPlanPreview;
-  previewError?: string;
-}): ReactElement {
+function PreviewPane({ preview, previewError, values }: PreviewPaneProps): ReactElement {
   if (previewError) {
     return (
       <div className="flex min-h-40 flex-1 items-center justify-center rounded-[24px] bg-surface-overlay px-6 py-10 text-300 text-text-primary-70 laptop:px-16">
@@ -170,6 +260,8 @@ function PreviewPane({
     );
   }
 
+  const targetUsageKw = getTargetUsageKw(preview, values);
+
   return (
     <div className="flex min-h-[360px] flex-1 items-center justify-center rounded-[24px] bg-surface-overlay px-8 py-12 laptop:min-h-0 laptop:px-16 laptop:py-6">
       <div className="flex w-full max-w-[520px] flex-col gap-10">
@@ -179,17 +271,24 @@ function PreviewPane({
 
         <div className="grid gap-3">
           <div>
-            <div className="text-emphasis-200 text-text-primary-70">Target reduction</div>
+            <div className="text-emphasis-200 text-text-primary-70">Target value</div>
             <div className="text-heading-300 text-text-primary">
-              {formatKw(preview.estimatedReductionKw)} of {formatKw(preview.targetKw)}
+              {formatKw(targetUsageKw)} of {formatKw(preview.currentUsageKw)}
             </div>
           </div>
-          <ReductionProgressBar value={preview.estimatedReductionKw} max={preview.targetKw} />
+          <ReductionProgressBar value={targetUsageKw} max={preview.currentUsageKw} />
         </div>
 
-        <div>
-          <div className="text-emphasis-200 text-text-primary-70">Time to restore</div>
-          <div className="text-heading-300 text-text-primary">{preview.restoreEstimate}</div>
+        <div className="grid gap-6">
+          <div>
+            <div className="text-emphasis-200 text-text-primary-70">Time to curtail</div>
+            <div className="text-heading-300 text-text-primary">{preview.curtailEstimate}</div>
+          </div>
+
+          <div>
+            <div className="text-emphasis-200 text-text-primary-70">Time to restore</div>
+            <div className="text-heading-300 text-text-primary">{preview.restoreEstimate}</div>
+          </div>
         </div>
       </div>
     </div>
@@ -234,7 +333,7 @@ function CurtailmentStartModalContent({
     groups: getSelectedDeviceSetIds(values, "groups"),
     miners: getSelectedMinerIds(values),
   };
-  const previewPane = <PreviewPane preview={preview} previewError={previewError} />;
+  const previewPane = <PreviewPane preview={preview} previewError={previewError} values={values} />;
 
   const handleDeviceSetSelection = (deviceSetIds: string[], scopeId: DeviceSetScopeId) => {
     const hasSelectedDeviceSets = deviceSetIds.length > 0;
@@ -278,87 +377,17 @@ function CurtailmentStartModalContent({
         ]}
         abovePanes={<div className="px-6 pb-6 laptop:hidden">{previewPane}</div>}
         primaryPane={
-          <section className="flex flex-col gap-10 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
-            <Section title="Details">
+          <section className="flex flex-col gap-12 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
+            <Section title="Response profile">
               <div className="grid gap-3">
-                <div className="grid gap-3 tablet:grid-cols-2">
-                  <Field
-                    id="curtailment-target-kw"
-                    label="Target reduction"
-                    value={values.targetKw}
-                    units="kW"
-                    error={errors?.targetKw}
-                    onChange={(value) => updateValue("targetKw", value)}
-                  />
-                  <Field
-                    id="curtailment-tolerance-kw"
-                    label="Tolerance"
-                    value={values.toleranceKw}
-                    units="kW"
-                    error={errors?.toleranceKw}
-                    onChange={(value) => updateValue("toleranceKw", value)}
-                  />
-                </div>
-
-                <Select
-                  id="curtailment-priority"
-                  label="Priority"
-                  value={values.priority}
-                  className="max-w-[274px]"
-                  options={priorityOptions}
-                  error={errors?.priority}
-                  onChange={(value) => {
-                    if (isCurtailmentPriority(value)) {
-                      updateValue("priority", value);
-                    }
-                  }}
+                <TypedSelect
+                  id="curtailment-response-profile"
+                  label="Profile"
+                  value={values.responseProfileId}
+                  options={responseProfileOptions}
+                  error={errors?.responseProfileId}
+                  onChange={(value) => updateValue("responseProfileId", value)}
                 />
-              </div>
-            </Section>
-
-            <Section title="Safety and restore">
-              <div className="grid gap-3">
-                <div className="grid gap-3 tablet:grid-cols-2">
-                  <Field
-                    id="curtailment-min-duration"
-                    label="Min duration"
-                    value={values.minDurationSec}
-                    units="sec"
-                    error={errors?.minDurationSec}
-                    onChange={(value) => updateValue("minDurationSec", value)}
-                  />
-                  <Field
-                    id="curtailment-max-duration"
-                    label="Max duration"
-                    value={values.maxDurationSec}
-                    units="sec"
-                    error={errors?.maxDurationSec}
-                    onChange={(value) => updateValue("maxDurationSec", value)}
-                  />
-                  <Field
-                    id="curtailment-batch-size"
-                    label="Restore batch size"
-                    value={values.restoreBatchSize}
-                    units="miners"
-                    error={errors?.restoreBatchSize}
-                    onChange={(value) => updateValue("restoreBatchSize", value)}
-                  />
-                  <Field
-                    id="curtailment-batch-interval"
-                    label="Restore interval"
-                    value={values.restoreIntervalSec}
-                    units="sec"
-                    error={errors?.restoreIntervalSec}
-                    onChange={(value) => updateValue("restoreIntervalSec", value)}
-                  />
-                </div>
-
-                {preview ? (
-                  <div className="text-200 text-text-primary-50">
-                    Estimated time to restore {preview.restoreEstimate}
-                  </div>
-                ) : null}
-
                 <Field
                   id="curtailment-reason"
                   label="Reason"
@@ -366,6 +395,71 @@ function CurtailmentStartModalContent({
                   type="text"
                   error={errors?.reason}
                   onChange={(value) => updateValue("reason", value)}
+                />
+              </div>
+            </Section>
+
+            <Section title="Curtail behavior">
+              <div className="grid gap-3">
+                <div className="grid gap-3 tablet:grid-cols-2">
+                  <TypedSelect
+                    id="curtailment-mode"
+                    label="Curtailment mode"
+                    value={values.curtailmentMode}
+                    options={curtailmentModeOptions}
+                    error={errors?.curtailmentMode}
+                    onChange={(value) => updateValue("curtailmentMode", value)}
+                  />
+                  <Field
+                    id="curtailment-target-kw"
+                    label="Target value"
+                    value={values.targetKw}
+                    error={errors?.targetKw}
+                    onChange={(value) => updateValue("targetKw", value)}
+                  />
+                </div>
+                <TypedSelect
+                  id="curtailment-miner-selection-strategy"
+                  label="Miner selection strategy"
+                  value={values.minerSelectionStrategy}
+                  options={minerSelectionStrategyOptions}
+                  error={errors?.minerSelectionStrategy}
+                  onChange={(value) => updateValue("minerSelectionStrategy", value)}
+                />
+                <div className="grid gap-3 tablet:grid-cols-2">
+                  <Field
+                    id="curtailment-batch-size"
+                    label="Batch size (miners)"
+                    value={values.curtailBatchSize}
+                    error={errors?.curtailBatchSize}
+                    onChange={(value) => updateValue("curtailBatchSize", value)}
+                  />
+                  <Field
+                    id="curtailment-batch-interval"
+                    label="Batch interval (sec)"
+                    value={values.curtailIntervalSec}
+                    error={errors?.curtailIntervalSec}
+                    onChange={(value) => updateValue("curtailIntervalSec", value)}
+                  />
+                </div>
+              </div>
+            </Section>
+
+            <Section title="Restore behavior">
+              <div className="grid gap-3 tablet:grid-cols-2">
+                <Field
+                  id="curtailment-restore-batch-size"
+                  label="Batch size (miners)"
+                  value={values.restoreBatchSize}
+                  error={errors?.restoreBatchSize}
+                  onChange={(value) => updateValue("restoreBatchSize", value)}
+                />
+                <Field
+                  id="curtailment-restore-batch-interval"
+                  label="Batch interval (sec)"
+                  value={values.restoreIntervalSec}
+                  error={errors?.restoreIntervalSec}
+                  onChange={(value) => updateValue("restoreIntervalSec", value)}
                 />
               </div>
             </Section>

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -39,22 +39,7 @@ export interface CurtailmentFormValues {
   includeMaintenance: boolean;
 }
 
-export type CurtailmentSubmitValues = Pick<
-  CurtailmentFormValues,
-  | "scopeType"
-  | "scopeId"
-  | "deviceSetIds"
-  | "deviceIdentifiers"
-  | "targetKw"
-  | "toleranceKw"
-  | "priority"
-  | "minDurationSec"
-  | "maxDurationSec"
-  | "restoreBatchSize"
-  | "restoreIntervalSec"
-  | "reason"
-  | "includeMaintenance"
->;
+export type CurtailmentSubmitValues = CurtailmentFormValues;
 
 export interface CurtailmentPlanPreview {
   selectedMinerCount: number;
@@ -210,8 +195,8 @@ function TypedSelect<Value extends string>({
 
 function Section({ title, children }: SectionProps): ReactElement {
   return (
-    <section className="grid gap-6">
-      <h2 className="text-heading-200 text-text-primary">{title}</h2>
+    <section className="grid gap-3">
+      <div className="text-emphasis-300 text-text-primary">{title}</div>
       {children}
     </section>
   );
@@ -268,7 +253,7 @@ function PreviewPane({ preview, previewError }: PreviewPaneProps): ReactElement 
 
         <div className="grid gap-3">
           <div>
-            <div className="text-emphasis-200 text-text-primary-70">Target value</div>
+            <div className="text-emphasis-200 text-text-primary-70">Target reduction</div>
             <div className="text-heading-300 text-text-primary">
               {formatKw(preview.targetKw)} of {formatKw(preview.currentUsageKw)}
             </div>
@@ -308,28 +293,6 @@ function getSelectedMinerIds(values: CurtailmentFormValues): string[] {
   return values.deviceIdentifiers;
 }
 
-function canSubmitWithCurrentMapping(values: CurtailmentFormValues): boolean {
-  return values.curtailmentMode === "fixedKwTarget" && values.minerSelectionStrategy === "worstMinersFirst";
-}
-
-function getSubmitValues(values: CurtailmentFormValues): CurtailmentSubmitValues {
-  return {
-    scopeType: values.scopeType,
-    scopeId: values.scopeId,
-    deviceSetIds: values.deviceSetIds,
-    deviceIdentifiers: values.deviceIdentifiers,
-    targetKw: values.targetKw,
-    toleranceKw: values.toleranceKw,
-    priority: values.priority,
-    minDurationSec: values.minDurationSec,
-    maxDurationSec: values.maxDurationSec,
-    restoreBatchSize: values.restoreBatchSize,
-    restoreIntervalSec: values.restoreIntervalSec,
-    reason: values.reason,
-    includeMaintenance: values.includeMaintenance,
-  };
-}
-
 function CurtailmentStartModalContent({
   onDismiss,
   onSubmit,
@@ -353,7 +316,6 @@ function CurtailmentStartModalContent({
     miners: getSelectedMinerIds(values),
   };
   const previewPane = <PreviewPane preview={preview} previewError={previewError} />;
-  const supportsCurrentSubmitMapping = canSubmitWithCurrentMapping(values);
 
   const handleDeviceSetSelection = (deviceSetIds: string[], scopeId: DeviceSetScopeId) => {
     const hasSelectedDeviceSets = deviceSetIds.length > 0;
@@ -391,8 +353,7 @@ function CurtailmentStartModalContent({
           {
             text: "Start curtailment",
             variant: variants.primary,
-            onClick: () => onSubmit(getSubmitValues(values)),
-            disabled: !supportsCurrentSubmitMapping,
+            onClick: () => onSubmit(values),
             loading: isSubmitting,
           },
         ]}
@@ -433,7 +394,7 @@ function CurtailmentStartModalContent({
                   />
                   <Field
                     id="curtailment-target-kw"
-                    label="Target value"
+                    label="Target reduction"
                     value={values.targetKw}
                     error={errors?.targetKw}
                     onChange={(value) => updateValue("targetKw", value)}

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -10,13 +10,13 @@ import { variants } from "@/shared/components/Button";
 import Checkbox from "@/shared/components/Checkbox";
 import Dialog, { DialogIcon } from "@/shared/components/Dialog";
 import Input from "@/shared/components/Input";
-import Select, { type SelectOption } from "@/shared/components/Select";
+import Select, { type SelectOption, type SelectProps } from "@/shared/components/Select";
 
 export type CurtailmentPriority = "normal" | "emergency";
 export type CurtailmentScopeType = "wholeOrg" | "deviceSet" | "explicitMiners";
 export type ResponseProfileId = "customPlan";
-export type CurtailmentMode = "percentageReduction" | "fixedKwTarget";
-export type MinerSelectionStrategy = "worstMinersFirst" | "oldestMinersFirst" | "lowestHashrateFirst" | "roundRobin";
+export type CurtailmentMode = "fixedKwReduction";
+export type MinerSelectionStrategy = "leastEfficientFirst";
 
 export interface CurtailmentFormValues {
   scopeType: CurtailmentScopeType;
@@ -29,8 +29,6 @@ export interface CurtailmentFormValues {
   targetKw: string;
   toleranceKw: string;
   priority: CurtailmentPriority;
-  curtailBatchSize: string;
-  curtailIntervalSec: string;
   minDurationSec: string;
   maxDurationSec: string;
   restoreBatchSize: string;
@@ -44,7 +42,7 @@ export type CurtailmentSubmitValues = CurtailmentFormValues;
 export interface CurtailmentPlanPreview {
   selectedMinerCount: number;
   targetKw: number;
-  currentUsageKw: number;
+  estimatedReductionKw: number;
   curtailEstimate: string;
   restoreEstimate: string;
   scopeLabel: string;
@@ -92,7 +90,7 @@ interface TypedSelectOption<Value extends string> extends SelectOption {
   value: Value;
 }
 
-interface TypedSelectProps<Value extends string> {
+interface TypedSelectProps<Value extends string> extends Pick<SelectProps, "className" | "disabled" | "testId"> {
   id: string;
   label: string;
   value: Value;
@@ -109,13 +107,11 @@ const defaultValues: CurtailmentFormValues = {
   deviceSetIds: [],
   deviceIdentifiers: [],
   responseProfileId: "customPlan",
-  curtailmentMode: "fixedKwTarget",
-  minerSelectionStrategy: "worstMinersFirst",
+  curtailmentMode: "fixedKwReduction",
+  minerSelectionStrategy: "leastEfficientFirst",
   targetKw: "",
   toleranceKw: "",
   priority: "normal",
-  curtailBatchSize: "",
-  curtailIntervalSec: "",
   minDurationSec: "",
   maxDurationSec: "",
   restoreBatchSize: "",
@@ -129,20 +125,11 @@ const responseProfileOptions: Array<TypedSelectOption<ResponseProfileId>> = [
 ];
 
 const curtailmentModeOptions: Array<TypedSelectOption<CurtailmentMode>> = [
-  { value: "percentageReduction", label: "Percentage reduction" },
-  { value: "fixedKwTarget", label: "Fixed kW target" },
+  { value: "fixedKwReduction", label: "Fixed kW reduction" },
 ];
 
 const minerSelectionStrategyOptions: Array<TypedSelectOption<MinerSelectionStrategy>> = [
-  { value: "worstMinersFirst", label: "Worst miners first" },
-  { value: "oldestMinersFirst", label: "Oldest miners first" },
-  { value: "lowestHashrateFirst", label: "Lowest hashrate first" },
-  { value: "roundRobin", label: "Round robin" },
-];
-
-const priorityOptions: Array<TypedSelectOption<CurtailmentPriority>> = [
-  { value: "normal", label: "Normal" },
-  { value: "emergency", label: "Emergency" },
+  { value: "leastEfficientFirst", label: "Least efficient first" },
 ];
 
 function getInitialValues(initialValues?: Partial<CurtailmentFormValues>): CurtailmentFormValues {
@@ -175,6 +162,9 @@ function TypedSelect<Value extends string>({
   value,
   options,
   error,
+  className,
+  disabled,
+  testId,
   onChange,
 }: TypedSelectProps<Value>): ReactElement {
   return (
@@ -184,6 +174,9 @@ function TypedSelect<Value extends string>({
       value={value}
       options={options}
       error={error}
+      className={className}
+      disabled={disabled}
+      testId={testId}
       onChange={(nextValue) => {
         if (isSelectOptionValue(options, nextValue)) {
           onChange(nextValue);
@@ -255,10 +248,10 @@ function PreviewPane({ preview, previewError }: PreviewPaneProps): ReactElement 
           <div>
             <div className="text-emphasis-200 text-text-primary-70">Target reduction</div>
             <div className="text-heading-300 text-text-primary">
-              {formatKw(preview.targetKw)} of {formatKw(preview.currentUsageKw)}
+              {formatKw(preview.estimatedReductionKw)} of {formatKw(preview.targetKw)}
             </div>
           </div>
-          <ReductionProgressBar value={preview.targetKw} max={preview.currentUsageKw} />
+          <ReductionProgressBar value={preview.estimatedReductionKw} max={preview.targetKw} />
         </div>
 
         <div className="grid gap-6">
@@ -396,6 +389,7 @@ function CurtailmentStartModalContent({
                     id="curtailment-target-kw"
                     label="Target reduction"
                     value={values.targetKw}
+                    units="kW"
                     error={errors?.targetKw}
                     onChange={(value) => updateValue("targetKw", value)}
                   />
@@ -408,63 +402,6 @@ function CurtailmentStartModalContent({
                   error={errors?.minerSelectionStrategy}
                   onChange={(value) => updateValue("minerSelectionStrategy", value)}
                 />
-                <div className="grid gap-3 tablet:grid-cols-2">
-                  <Field
-                    id="curtailment-batch-size"
-                    label="Batch size (miners)"
-                    value={values.curtailBatchSize}
-                    error={errors?.curtailBatchSize}
-                    onChange={(value) => updateValue("curtailBatchSize", value)}
-                  />
-                  <Field
-                    id="curtailment-batch-interval"
-                    label="Batch interval (sec)"
-                    value={values.curtailIntervalSec}
-                    error={errors?.curtailIntervalSec}
-                    onChange={(value) => updateValue("curtailIntervalSec", value)}
-                  />
-                </div>
-              </div>
-            </Section>
-
-            <Section title="Safety">
-              <div className="grid gap-3">
-                <div className="grid gap-3 tablet:grid-cols-2">
-                  <TypedSelect
-                    id="curtailment-priority"
-                    label="Priority"
-                    value={values.priority}
-                    options={priorityOptions}
-                    error={errors?.priority}
-                    onChange={(value) => updateValue("priority", value)}
-                  />
-                  <Field
-                    id="curtailment-tolerance-kw"
-                    label="Tolerance"
-                    value={values.toleranceKw}
-                    units="kW"
-                    error={errors?.toleranceKw}
-                    onChange={(value) => updateValue("toleranceKw", value)}
-                  />
-                </div>
-                <div className="grid gap-3 tablet:grid-cols-2">
-                  <Field
-                    id="curtailment-min-duration"
-                    label="Min duration"
-                    value={values.minDurationSec}
-                    units="sec"
-                    error={errors?.minDurationSec}
-                    onChange={(value) => updateValue("minDurationSec", value)}
-                  />
-                  <Field
-                    id="curtailment-max-duration"
-                    label="Max duration"
-                    value={values.maxDurationSec}
-                    units="sec"
-                    error={errors?.maxDurationSec}
-                    onChange={(value) => updateValue("maxDurationSec", value)}
-                  />
-                </div>
               </div>
             </Section>
 


### PR DESCRIPTION
🤖

## Summary
- Rework the plan curtailment modal into response profile, reason, curtail behavior, restore behavior, and target sections while preserving the existing input/control sizing.
- Constrain curtailment behavior to the API-supported values: fixed kW reduction and least efficient first.
- Remove unsupported percentage reduction, alternate miner selection strategies, curtail batch controls, and the Safety section from the form.
- Keep the preview copy aligned with the existing estimated reduction vs requested reduction behavior.
- Default maintenance-mode miner inclusion to checked, remove its helper line, and require confirmation before submitting with maintenance miners included.
- Update modal tests and stories for the supported layout and payload behavior.

## Test plan
- [x] `git diff --check`
- [x] `bin/npx prettier --check src/protoFleet/features/energy/CurtailmentStartModal.tsx src/protoFleet/features/energy/CurtailmentStartModal.test.tsx src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx`
- [x] `bin/npx vitest run src/protoFleet/features/energy/CurtailmentStartModal.test.tsx`
- [x] `bin/npx eslint src/protoFleet/features/energy/CurtailmentStartModal.tsx src/protoFleet/features/energy/CurtailmentStartModal.test.tsx src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx --max-warnings 0`
- [x] `bin/npx tsc --noEmit`
- [x] `bin/npm run build:protoFleet`
- [x] PR CI passed after rerunning the transient generated-code check


https://github.com/user-attachments/assets/b17329fb-cca9-4c28-ae99-a2567b8529d2



Closes #242