### PR TITLE
chore(deps): bump Go and Rust deps (#244, #245)

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -523,6 +523,7 @@ golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/plugin/asicrs/Cargo.lock
+++ b/plugin/asicrs/Cargo.lock
@@ -45,8 +45,8 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "asic-rs"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -59,6 +59,7 @@ dependencies = [
  "asic-rs-firmwares-luxminer",
  "asic-rs-firmwares-marathon",
  "asic-rs-firmwares-nerdaxe",
+ "asic-rs-firmwares-sealminer",
  "asic-rs-firmwares-vnish",
  "asic-rs-firmwares-whatsminer",
  "asic-rs-makes-antminer",
@@ -69,6 +70,7 @@ dependencies = [
  "asic-rs-makes-epic",
  "asic-rs-makes-marathon",
  "asic-rs-makes-nerdaxe",
+ "asic-rs-makes-sealminer",
  "asic-rs-makes-whatsminer",
  "async-stream",
  "futures",
@@ -86,8 +88,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-core"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -107,8 +109,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-antminer"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -128,8 +130,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-auradine"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -145,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-avalonminer"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -162,8 +164,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-bitaxe"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -180,8 +182,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-braiins"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -200,8 +202,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-epic"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -222,8 +224,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-luxminer"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -238,8 +240,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-marathon"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -257,8 +259,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-nerdaxe"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -274,9 +276,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "asic-rs-firmwares-sealminer"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-sealminer",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "asic-rs-firmwares-vnish"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -293,8 +312,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-whatsminer"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "aes",
  "anyhow",
@@ -318,8 +337,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-antminer"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -329,8 +348,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-auradine"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -340,8 +359,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-avalon"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -351,8 +370,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-bitaxe"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -362,8 +381,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-braiins"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -373,8 +392,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-epic"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -384,8 +403,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-marathon"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -394,8 +413,19 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-nerdaxe"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-sealminer"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -405,8 +435,8 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-whatsminer"
-version = "0.5.0"
-source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+version = "0.5.1"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.1#3cea82fa9c93cd522f44698ee3f254b29abc12fe"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -2019,9 +2049,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2538,9 +2568,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/plugin/asicrs/Cargo.toml
+++ b/plugin/asicrs/Cargo.toml
@@ -16,8 +16,8 @@ tokio-stream = "0.1"
 prost-types = "0.13"
 
 # asic-rs miner library
-asic-rs = { git = "https://github.com/256foundation/asic-rs.git", tag = "v0.5.0" }
-asic-rs-core = { git = "https://github.com/256foundation/asic-rs.git", tag = "v0.5.0" }
+asic-rs = { git = "https://github.com/256foundation/asic-rs.git", tag = "v0.5.1" }
+asic-rs-core = { git = "https://github.com/256foundation/asic-rs.git", tag = "v0.5.1" }
 measurements = "0.11"
 
 # config

--- a/plugin/proto/go.mod
+++ b/plugin/proto/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/block/proto-fleet/server v0.0.0-20260514185933-a67a9e3bd8ce
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hashicorp/go-plugin v1.8.0
-	github.com/moby/moby/api v1.54.1
-	github.com/moby/moby/client v0.4.0
+	github.com/moby/moby/api v1.54.2
+	github.com/moby/moby/client v0.4.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	google.golang.org/grpc v1.81.1
@@ -28,7 +28,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/go-connections v0.6.0 // indirect
+	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/fatih/color v1.19.0 // indirect

--- a/plugin/proto/go.sum
+++ b/plugin/proto/go.sum
@@ -30,8 +30,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
-github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
+github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
+github.com/docker/go-connections v0.7.0/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
@@ -87,10 +87,10 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=
 github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
-github.com/moby/moby/api v1.54.1 h1:TqVzuJkOLsgLDDwNLmYqACUuTehOHRGKiPhvH8V3Nn4=
-github.com/moby/moby/api v1.54.1/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
-github.com/moby/moby/client v0.4.0 h1:S+2XegzHQrrvTCvF6s5HFzcrywWQmuVnhOXe2kiWjIw=
-github.com/moby/moby/client v0.4.0/go.mod h1:QWPbvWchQbxBNdaLSpoKpCdf5E+WxFAgNHogCWDoa7g=
+github.com/moby/moby/api v1.54.2 h1:wiat9QAhnDQjA7wk1kh/TqHz2I1uUA7M7t9SAl/JNXg=
+github.com/moby/moby/api v1.54.2/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
+github.com/moby/moby/client v0.4.1 h1:DMQgisVoMkmMs7fp3ROSdiBnoAu8+vo3GggFl06M/wY=
+github.com/moby/moby/client v0.4.1/go.mod h1:z52C9O2POPOsnxZAy//WtKcQ32P+jT/NGeXu/7nfjGQ=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=

--- a/sdk/rust/proto-fleet-plugin/Cargo.lock
+++ b/sdk/rust/proto-fleet-plugin/Cargo.lock
@@ -691,9 +691,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1317,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1332,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sdk/rust/proto-fleet-plugin/src/http_client.rs
+++ b/sdk/rust/proto-fleet-plugin/src/http_client.rs
@@ -148,13 +148,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect_error_maps_to_device_unavailable() {
-        // Arrange — bind a port then drop the listener so nothing is listening
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        drop(listener);
+        // Arrange — the `.invalid` TLD is reserved by RFC 6761 and never resolves.
+        // `no_proxy()` bypasses any ambient HTTP(S)_PROXY env that might
+        // otherwise route the request to a proxy and return a real response.
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let url = "http://does-not-exist.invalid/";
 
         // Act
-        let err = reqwest::get(format!("http://{addr}")).await.unwrap_err();
+        let err = client.get(url).send().await.unwrap_err();
         let plugin_err = map_reqwest_error(err, DEVICE_ID);
 
         // Assert


### PR DESCRIPTION
## Summary

Combines and supersedes #244 and #245, applying CI-clean equivalents of the dependabot bumps plus a small test fix that the tokio bump made unavoidable.

- **Go (supersedes #244):** bumps `github.com/moby/moby/api` 1.54.1 -> 1.54.2 and `github.com/moby/moby/client` 0.4.0 -> 0.4.1 in `plugin/proto`, plus the transitive `github.com/docker/go-connections` 0.6.0 -> 0.7.0. Adds the missing `go.work.sum` entry so the workspace lock matches.
- **Rust (supersedes #245):** bumps `tokio` 1.51.1 -> 1.52.3 in `plugin/asicrs` and `sdk/rust/proto-fleet-plugin`, and `asic-rs` 0.5.0 -> 0.5.1 in `plugin/asicrs`. Also bumps the directly-pinned `asic-rs-core` tag to v0.5.1 so the `Cargo.lock` no longer carries two `asic_rs_core` versions from different commits.
- **Test fix in `sdk/rust/proto-fleet-plugin/src/http_client.rs`:** point `test_connect_error_maps_to_device_unavailable` at `http://does-not-exist.invalid/` instead of binding-then-dropping an ephemeral port.

## Why the bots couldn't ship these on their own

- #244 failed `generated-code-check` because the dependabot run only updates the bumped module's `go.mod`/`go.sum`; the workspace `go.work.sum` needs a follow-up sync that dependabot doesn't perform.
- #245 failed clippy with `mismatched types ... expected asic_rs_core::traits::miner::Miner, found asic_rs::asic_rs_core::traits::miner::Miner`. dependabot only bumped `asic-rs` to v0.5.1 but left `asic-rs-core` pinned to v0.5.0, leaving the lockfile with two `asic_rs_core` commits in the graph and the plugin source using both types.

## Why the test fix is in scope

The tokio 1.51 -> 1.52 bump in `sdk/rust/proto-fleet-plugin` shifted parallel test scheduling enough to surface a latent race between two http_client tests on the Linux CI runner. The connect-refused test was binding `127.0.0.1:0`, dropping the listener, then connecting to the freed ephemeral port; concurrently, `status_server`-based tests (e.g. `test_error_messages_do_not_leak_urls`) could rebind that same freed port before the connect attempt. The first failing CI run showed both tests crashing on the same port (`127.0.0.1:45593`): the connect test got the other test's HTTP 500 instead of a connect error, and the status-500 test got an RST when its own listener was dropped after serving the wrong client.

The `.invalid` TLD is reserved by [RFC 6761 §6.4](https://datatracker.ietf.org/doc/html/rfc6761#section-6.4) as a name that "must not be... looked up in the public DNS" and is guaranteed not to resolve. `reqwest` classifies the DNS lookup failure as a connect-time error (`is_connect()` is `true`), which is the exact code path `map_reqwest_error` maps to `DeviceUnavailable`. No port allocation, no environment-dependent port assumptions — diff is 3 lines added, 5 removed.

## Test plan

- [x] `cargo check` + `cargo clippy -- -D warnings` + `cargo fmt -- --check` pass under `plugin/asicrs`
- [x] `cargo test --features http-client` passes in `sdk/rust/proto-fleet-plugin` (all 8 http_client tests green locally)
- [x] `go build ./...` clean under `plugin/proto` and `tests/plugin-contract`
- [x] `git diff --quiet` after `cd plugin/proto && go mod download` (the `go.work.sum` line is committed)
- [ ] CI: PR Gate green (Generated Code Check, asicrs Plugin Checks, Plugin Contract Checks, Rust SDK Checks)