### PR TITLE
ci(rust-sdk-checks): replace dtolnay/rust-toolchain with rustup shell

### DIFF
--- a/.github/workflows/rust-sdk-checks.yml
+++ b/.github/workflows/rust-sdk-checks.yml
@@ -29,10 +29,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        # zizmor: ignore[superfluous-actions] SHA-pinned action installs explicit rustfmt+clippy components
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: rustfmt, clippy
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+          rustup override set stable
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -71,8 +70,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        # zizmor: ignore[superfluous-actions] SHA-pinned action provides reproducible rust-toolchain selection
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup override set stable
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0


### PR DESCRIPTION
## Summary

- Both `Install Rust toolchain` steps in `.github/workflows/rust-sdk-checks.yml` now call `rustup` directly instead of going through `dtolnay/rust-toolchain`, matching the pattern already used in `asicrs-plugin-checks.yml`.
- `rust-lint` still pulls in `rustfmt` and `clippy` via `--component`; `rust-build-test` uses `--profile minimal`. Behavior unchanged for both jobs.
- Closes the two open zizmor `superfluous-actions` code-scanning alerts on this workflow (alerts #12 and #13). The inline `# zizmor: ignore[...]` rationale added previously was not being honored on the dashboard; replacing the action removes the finding at the source, as it did for the matching asicrs alerts.

The remaining open alert (`release.yml:94`, `softprops/action-gh-release`) is intentionally left for a separate PR — the action does real work (draft + multi-file upload + auto-generated notes) and the trade-off is worth evaluating on its own.

## Test plan

- [ ] `rust-lint` job passes (fmt + clippy default + clippy http-client).
- [ ] `rust-build-test` job passes (build/test for default + http-client).
- [ ] After merge, zizmor scan on `main` clears alerts #12 and #13.