### PR TITLE
chore(deps): bump rand to 0.8.6 / 0.9.3 in asicrs lockfile

### DIFF
--- a/plugin/asicrs/Cargo.lock
+++ b/plugin/asicrs/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
  "digest",
  "hex",
  "md-5",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2",
 ]
 
@@ -1886,7 +1886,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1935,9 +1935,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",


### PR DESCRIPTION
## Summary

Patches GHSA-cq8v-f236-94qc — `rand` was unsound when a custom logger called `rand::rng()`. The lockfile carried both `rand 0.8.5` (used transitively by `bcrypt-pbkdf` and friends) and `rand 0.9.2` (used by `quinn-proto`); both lines are advisory-affected and both have a fixed release on the same minor series.

This is a lockfile-only update via `cargo update -p rand@0.8.5 --precise 0.8.6` and `cargo update -p rand@0.9.2 --precise 0.9.3`. No source code, no `Cargo.toml`, no other deps moved. The third entry in the lockfile (`rand 0.10.1`) is already outside the vulnerable range and is untouched.

## Test plan

- [ ] asicrs-plugin-checks workflow passes (Rust lint, build & test).
- [ ] After merge, the two Dependabot alerts on `plugin/asicrs/Cargo.lock` for `GHSA-cq8v-f236-94qc` auto-close.