### PR TITLE
chore(deps): replace unmaintained serde_yml with serde_yaml_ng in asicrs

### DIFF
--- a/plugin/asicrs/Cargo.lock
+++ b/plugin/asicrs/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
  "prost-types",
  "proto-fleet-plugin",
  "serde",
- "serde_yml",
+ "serde_yaml_ng",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -1216,7 +1216,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1497,16 +1497,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1869,7 +1859,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1907,7 +1897,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2321,18 +2311,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2816,6 +2804,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/plugin/asicrs/Cargo.toml
+++ b/plugin/asicrs/Cargo.toml
@@ -22,7 +22,7 @@ measurements = "0.11"
 
 # config
 serde = { version = "1", features = ["derive"] }
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10"
 
 # logging
 tracing = "0.1"

--- a/plugin/asicrs/src/config.rs
+++ b/plugin/asicrs/src/config.rs
@@ -86,6 +86,6 @@ pub fn load_config() -> Result<PluginConfig> {
     let contents = std::fs::read_to_string(&path)
         .with_context(|| format!("Failed to read {}", path.display()))?;
     let config: PluginConfig =
-        serde_yml::from_str(&contents).with_context(|| "Failed to parse config.yaml")?;
+        serde_yaml_ng::from_str(&contents).with_context(|| "Failed to parse config.yaml")?;
     Ok(config)
 }

--- a/plugin/asicrs/src/driver.rs
+++ b/plugin/asicrs/src/driver.rs
@@ -990,7 +990,7 @@ mod tests {
 
     /// Build a minimal PluginConfig from a YAML snippet for use in tests.
     fn config_from_yaml(yaml: &str) -> PluginConfig {
-        serde_yml::from_str(yaml).expect("invalid test config YAML")
+        serde_yaml_ng::from_str(yaml).expect("invalid test config YAML")
     }
 
     fn make_request(


### PR DESCRIPTION
## Summary

Closes the two unmaintained-crate Dependabot alerts on `plugin/asicrs/Cargo.lock`:

- `serde_yml` 0.0.12 — `GHSA-hhw4-xg65-fp2x` (unmaintained, unsound)
- `libyml` 0.0.5 (transitive) — `GHSA-gfxp-f68g-8x78` (unmaintained, unsound)

`serde_yaml_ng` is the actively maintained community fork of dtolnay's archived `serde_yaml`, API-compatible at the `from_str` surface used in asicrs, and pulls in `unsafe-libyaml` (pure-Rust port) in place of `libyml`. Both replaced crates leave the lockfile entirely.

## Scope of change

- `Cargo.toml`: `serde_yml = "0.0.12"` → `serde_yaml_ng = "0.10"`.
- `src/config.rs`: production `load_config` -- `serde_yml::from_str` → `serde_yaml_ng::from_str`.
- `src/driver.rs`: test helper `config_from_yaml` -- same swap.
- `Cargo.lock`: regenerated. `libyml` and `serde_yml` are gone; `serde_yaml_ng` and `unsafe-libyaml` take their place.

No serialization in this code path; only deserialization. The `PluginConfig` / `MinerFamilyConfig` / `FirmwareConfig` schema is unchanged.

## Test plan

- [ ] `cargo test` for asicrs-plugin — 43 unit tests pass locally on this branch (43/43 verified).
- [ ] asicrs-plugin-checks workflow passes in CI (lint, build, test).
- [ ] After merge, Dependabot alerts for `serde_yml` and `libyml` on `plugin/asicrs/Cargo.lock` auto-close.

## Crate choice rationale

`serde_yaml_ng` is the most direct successor to dtolnay's `serde_yaml` — same API surface, active maintenance, drops `libyml` in favor of `unsafe-libyaml` (a pure-Rust port without the soundness issue). Alternatives considered:

- `serde_norway` — also active, but less widely adopted and slightly different release cadence.
- `serde-saphyr` / `serde_yaml_bw` — emphasize panic-free parsing but diverge from the `serde_yaml` API.
- `noyalib` — pure-Rust zero-unsafe, but still pre-1.0 (0.0.5) and low adoption.