### PR TITLE
ci(release): replace softprops/action-gh-release with gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,30 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Synthetic tag for a dry-run release (must contain a hyphen, e.g. v0.0.0-dryrun.1)"
+        required: true
+        type: string
+      dry_run:
+        description: "Skip the final publish step so no public release is created"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
   pull-requests: read
+
+env:
+  TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
 
 jobs:
   validate-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Validate tag format
-        env:
-          TAG_NAME: ${{ github.ref_name }}
         run: |
           if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
             echo "::error::Tag '$TAG_NAME' does not match expected format (e.g., v1.2.3 or v1.2.3-rc.1)"
@@ -23,14 +35,23 @@ jobs:
           fi
           echo "Tag '$TAG_NAME' is valid"
 
+      - name: Reject stable tags from workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [[ "$TAG_NAME" != *-* ]]; then
+            echo "::error::workflow_dispatch only supports prerelease-style tags (must contain a hyphen). Got '$TAG_NAME'."
+            exit 1
+          fi
+          echo "Dispatched tag '$TAG_NAME' is a prerelease — OK"
+
       - name: Require full releases to be on main
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: ${{ !contains(env.TAG_NAME, '-') }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           AHEAD_BY=$(gh api "repos/${{ github.repository }}/compare/main...${{ github.sha }}" --jq '.ahead_by')
           if [[ "$AHEAD_BY" -ne 0 ]]; then
-            echo "::error::Full releases are only allowed from commits on the main branch. Tag '${{ github.ref_name }}' points to a commit not on main."
+            echo "::error::Full releases are only allowed from commits on the main branch. Tag '$TAG_NAME' points to a commit not on main."
             exit 1
           fi
           echo "Full release tag is on main — OK"
@@ -40,10 +61,10 @@ jobs:
     needs: [validate-tag]
     uses: ./.github/workflows/proto-fleet-artifact-build.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ inputs.tag_name || github.ref_name }}
       retention_days: 1
       channel: release
-      is_prerelease: ${{ contains(github.ref_name, '-') }}
+      is_prerelease: ${{ contains(inputs.tag_name || github.ref_name, '-') }}
     secrets: inherit
 
   publish-proto-fleet:
@@ -91,10 +112,10 @@ jobs:
       - name: Create draft release and upload assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           shopt -s failglob
+          trap 'gh release delete "$TAG_NAME" --yes 2>/dev/null || true' ERR
           extra_args=()
           if [[ "$TAG_NAME" == *-* ]]; then
             extra_args+=(--prerelease)
@@ -114,6 +135,7 @@ jobs:
             ./deployment-files/uninstall.sh
 
       - name: Publish release
+        if: github.event_name == 'push' || !inputs.dry_run
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$TAG_NAME" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,13 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s failglob
+          if gh release view "$TAG_NAME" --json id >/dev/null 2>&1; then
+            echo "::error::Release for $TAG_NAME already exists; refusing to overwrite. Delete it manually before re-running (see #254 for the recovery-design discussion)."
+            exit 1
+          fi
+          # Trap is armed only after the existence check so a rerun that hits an
+          # existing release exits before the trap can delete a release we did
+          # not create in this run.
           trap 'gh release delete "$TAG_NAME" --yes 2>/dev/null || true' ERR
           extra_args=()
           if [[ "$TAG_NAME" == *-* ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
+          IS_PRERELEASE: ${{ contains(github.ref_name, '-') }}
         run: |
           set -euo pipefail
           shopt -s failglob
@@ -106,21 +107,32 @@ jobs:
             ./deployment-files/install.sh
             ./deployment-files/uninstall.sh
           )
-          if gh release view "$TAG_NAME" --json id >/dev/null 2>&1; then
-            echo "Release for $TAG_NAME exists; refreshing assets via upload --clobber."
-            gh release upload "$TAG_NAME" --clobber "${files[@]}"
-          else
-            echo "Creating new draft release for $TAG_NAME."
-            extra_args=()
-            if [[ "$TAG_NAME" == *-* ]]; then
-              extra_args+=(--prerelease)
-            fi
-            gh release create "$TAG_NAME" \
-              --draft \
-              --generate-notes \
-              "${extra_args[@]}" \
-              "${files[@]}"
-          fi
+          # Probe for draft state and refuse to clobber a published release so
+          # this workflow never silently mutates assets a human (or a prior
+          # run) already published.
+          existing_draft_state=$(gh release view "$TAG_NAME" --json isDraft --jq .isDraft 2>/dev/null || echo "missing")
+          case "$existing_draft_state" in
+            true)
+              echo "Draft release for $TAG_NAME exists; refreshing assets via upload --clobber."
+              gh release upload "$TAG_NAME" --clobber "${files[@]}"
+              ;;
+            false)
+              echo "::error::Release for $TAG_NAME is already published; refusing to overwrite. Delete it manually before re-running, or bump the tag."
+              exit 1
+              ;;
+            *)
+              echo "Creating new draft release for $TAG_NAME."
+              extra_args=()
+              if [[ "$IS_PRERELEASE" == 'true' ]]; then
+                extra_args+=(--prerelease)
+              fi
+              gh release create "$TAG_NAME" \
+                --draft \
+                --generate-notes \
+                "${extra_args[@]}" \
+                "${files[@]}"
+              ;;
+          esac
 
       - name: Publish release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,30 +4,18 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: "Synthetic tag for a dry-run release (must contain a hyphen, e.g. v0.0.0-dryrun.1)"
-        required: true
-        type: string
-      dry_run:
-        description: "Skip the final publish step so no public release is created"
-        required: false
-        type: boolean
-        default: true
 
 permissions:
   contents: write
   pull-requests: read
-
-env:
-  TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
 
 jobs:
   validate-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Validate tag format
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
             echo "::error::Tag '$TAG_NAME' does not match expected format (e.g., v1.2.3 or v1.2.3-rc.1)"
@@ -35,23 +23,14 @@ jobs:
           fi
           echo "Tag '$TAG_NAME' is valid"
 
-      - name: Reject stable tags from workflow_dispatch
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if [[ "$TAG_NAME" != *-* ]]; then
-            echo "::error::workflow_dispatch only supports prerelease-style tags (must contain a hyphen). Got '$TAG_NAME'."
-            exit 1
-          fi
-          echo "Dispatched tag '$TAG_NAME' is a prerelease — OK"
-
       - name: Require full releases to be on main
-        if: ${{ !contains(env.TAG_NAME, '-') }}
+        if: ${{ !contains(github.ref_name, '-') }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           AHEAD_BY=$(gh api "repos/${{ github.repository }}/compare/main...${{ github.sha }}" --jq '.ahead_by')
           if [[ "$AHEAD_BY" -ne 0 ]]; then
-            echo "::error::Full releases are only allowed from commits on the main branch. Tag '$TAG_NAME' points to a commit not on main."
+            echo "::error::Full releases are only allowed from commits on the main branch. Tag '${{ github.ref_name }}' points to a commit not on main."
             exit 1
           fi
           echo "Full release tag is on main — OK"
@@ -61,10 +40,10 @@ jobs:
     needs: [validate-tag]
     uses: ./.github/workflows/proto-fleet-artifact-build.yml
     with:
-      version: ${{ inputs.tag_name || github.ref_name }}
+      version: ${{ github.ref_name }}
       retention_days: 1
       channel: release
-      is_prerelease: ${{ contains(inputs.tag_name || github.ref_name, '-') }}
+      is_prerelease: ${{ contains(github.ref_name, '-') }}
     secrets: inherit
 
   publish-proto-fleet:
@@ -109,40 +88,42 @@ jobs:
       - name: List all release assets
         run: find /tmp/release-assets -type f | sort
 
-      - name: Create draft release and upload assets
+      - name: Create or refresh draft release and upload assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           shopt -s failglob
-          if gh release view "$TAG_NAME" --json id >/dev/null 2>&1; then
-            echo "::error::Release for $TAG_NAME already exists; refusing to overwrite. Delete it manually before re-running (see #254 for the recovery-design discussion)."
-            exit 1
-          fi
-          # Trap is armed only after the existence check so a rerun that hits an
-          # existing release exits before the trap can delete a release we did
-          # not create in this run.
-          trap 'gh release delete "$TAG_NAME" --yes 2>/dev/null || true' ERR
-          extra_args=()
-          if [[ "$TAG_NAME" == *-* ]]; then
-            extra_args+=(--prerelease)
-          fi
-          gh release create "$TAG_NAME" \
-            --draft \
-            --generate-notes \
-            "${extra_args[@]}" \
-            /tmp/release-assets/bundles/proto-fleet-"$TAG_NAME"-*.tar.gz \
-            /tmp/release-assets/windows/installer.exe \
-            /tmp/release-assets/windows/uninstall.exe \
-            /tmp/release-assets/server/proto-fleet-server-"$TAG_NAME"-*.tar.gz \
-            /tmp/release-assets/client/proto-fleet-client-"$TAG_NAME".tar.gz \
-            /tmp/release-assets/proto-os/proto-os-"$TAG_NAME".tar.gz \
-            /tmp/release-assets/proto-os/proto-os_"$TAG_NAME".ipk \
-            ./deployment-files/install.sh \
+          files=(
+            /tmp/release-assets/bundles/proto-fleet-"$TAG_NAME"-*.tar.gz
+            /tmp/release-assets/windows/installer.exe
+            /tmp/release-assets/windows/uninstall.exe
+            /tmp/release-assets/server/proto-fleet-server-"$TAG_NAME"-*.tar.gz
+            /tmp/release-assets/client/proto-fleet-client-"$TAG_NAME".tar.gz
+            /tmp/release-assets/proto-os/proto-os-"$TAG_NAME".tar.gz
+            /tmp/release-assets/proto-os/proto-os_"$TAG_NAME".ipk
+            ./deployment-files/install.sh
             ./deployment-files/uninstall.sh
+          )
+          if gh release view "$TAG_NAME" --json id >/dev/null 2>&1; then
+            echo "Release for $TAG_NAME exists; refreshing assets via upload --clobber."
+            gh release upload "$TAG_NAME" --clobber "${files[@]}"
+          else
+            echo "Creating new draft release for $TAG_NAME."
+            extra_args=()
+            if [[ "$TAG_NAME" == *-* ]]; then
+              extra_args+=(--prerelease)
+            fi
+            gh release create "$TAG_NAME" \
+              --draft \
+              --generate-notes \
+              "${extra_args[@]}" \
+              "${files[@]}"
+          fi
 
       - name: Publish release
-        if: github.event_name == 'push' || !inputs.dry_run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
         run: gh release edit "$TAG_NAME" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,25 +89,29 @@ jobs:
         run: find /tmp/release-assets -type f | sort
 
       - name: Create draft release and upload assets
-        id: create_release
-        # zizmor: ignore[superfluous-actions] SHA-pinned action handles draft + multi-file uploads cleanly
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          draft: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          generate_release_notes: true
-          files: |
-            /tmp/release-assets/bundles/proto-fleet-${{ github.ref_name }}-*.tar.gz
-            /tmp/release-assets/windows/installer.exe
-            /tmp/release-assets/windows/uninstall.exe
-            /tmp/release-assets/server/proto-fleet-server-${{ github.ref_name }}-*.tar.gz
-            /tmp/release-assets/client/proto-fleet-client-${{ github.ref_name }}.tar.gz
-            /tmp/release-assets/proto-os/proto-os-${{ github.ref_name }}.tar.gz
-            /tmp/release-assets/proto-os/proto-os_${{ github.ref_name }}.ipk
-            ./deployment-files/install.sh
-            ./deployment-files/uninstall.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          shopt -s failglob
+          extra_args=()
+          if [[ "$TAG_NAME" == *-* ]]; then
+            extra_args+=(--prerelease)
+          fi
+          gh release create "$TAG_NAME" \
+            --draft \
+            --generate-notes \
+            "${extra_args[@]}" \
+            /tmp/release-assets/bundles/proto-fleet-"$TAG_NAME"-*.tar.gz \
+            /tmp/release-assets/windows/installer.exe \
+            /tmp/release-assets/windows/uninstall.exe \
+            /tmp/release-assets/server/proto-fleet-server-"$TAG_NAME"-*.tar.gz \
+            /tmp/release-assets/client/proto-fleet-client-"$TAG_NAME".tar.gz \
+            /tmp/release-assets/proto-os/proto-os-"$TAG_NAME".tar.gz \
+            /tmp/release-assets/proto-os/proto-os_"$TAG_NAME".ipk \
+            ./deployment-files/install.sh \
+            ./deployment-files/uninstall.sh
 
       - name: Publish release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,7 @@ jobs:
             ./deployment-files/install.sh
             ./deployment-files/uninstall.sh
           )
-          # Probe for draft state and refuse to clobber a published release so
-          # this workflow never silently mutates assets a human (or a prior
-          # run) already published.
+          # Refuse to clobber a non-draft release — published assets are immutable from this workflow.
           existing_draft_state=$(gh release view "$TAG_NAME" --json isDraft --jq .isDraft 2>/dev/null || echo "missing")
           case "$existing_draft_state" in
             true)


### PR DESCRIPTION
## Summary

Replaces `softprops/action-gh-release@v3.0.0` in `.github/workflows/release.yml` with shell calls to `gh release view` / `gh release create` / `gh release upload --clobber`. The `gh` CLI is pre-installed on GitHub-hosted runners and covers everything the action did here: draft creation, conditional prerelease, auto-generated release notes, and multi-file upload.

Closes the open zizmor `superfluous-actions` code-scanning alert (#11).

## Behavior

Matches the original softprops behavior on the common path, including idempotency on re-runs:

- **First run for a tag** — probes for an existing release with `gh release view --json isDraft`; finding none, calls `gh release create "$TAG_NAME" --draft --generate-notes [--prerelease] <files>` to publish a new draft with all assets.
- **Re-run while the release is still a draft** — refreshes all assets via `gh release upload "$TAG_NAME" --clobber <files>` without re-creating the record. Mirrors how `softprops/action-gh-release` handled re-runs (file overwrite, leaves notes/title/draft state alone).
- **Re-run after the release was published** — fails loudly with `::error::` and requires the operator to delete the existing release (or bump the tag) before re-running. This is a deliberate tightening beyond softprops's default — see "Differences" below.
- **Publish step** — unchanged in intent: `gh release edit "$TAG_NAME" --draft=false` flips the draft to public.

Also renames `GITHUB_TOKEN` → `GH_TOKEN` in both `gh`-invoking steps for env-var consistency (`gh` reads `GH_TOKEN` first and falls back to `GITHUB_TOKEN`; both worked before), and exposes `IS_PRERELEASE: ${{ contains(github.ref_name, '-') }}` in the step env to drop one of the three hyphen-predicate sites from the workflow.

## Differences from the action

- **Stricter glob behavior.** `shopt -s failglob` causes the workflow to fail immediately if any `bundles/proto-fleet-${TAG_NAME}-*.tar.gz` or `server/proto-fleet-server-${TAG_NAME}-*.tar.gz` glob matches zero files. The previous default of `fail_on_unmatched_files: false` could silently produce a partial release.
- **Refuses to overwrite a non-draft release.** Softprops would update an already-published release in place; this workflow now treats published assets as immutable from CI and errors out instead. Trades a re-run convenience for protection against accidental published-release mutation.

## Test plan

CI on the next real release tag is the end-to-end test. Locally validated: `bash -n` parses the new shell blocks clean, the prerelease conditional simulates correctly for both `v1.2.3` (no flag) and `v1.2.3-rc.1` (adds `--prerelease`), and the three `existing_draft_state` branches (`true` → clobber, `false` → error+exit, `missing` → create) each route correctly. After merge, the zizmor scan on `main` closes alert #11.