### PR TITLE
feat(fleetnode): discovery scan + ReportDiscoveredDevices agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ lefthook-local.yml
 # Binary files
 server/cmd/fleetd/fleetd
 server/fleetnode
-server/nmap
+server/.fleetnode/
 server/fake-antminer/fake-antminer
 server/fake-proto-rig/fake-proto-rig
 server/miner-debug-cli

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lefthook-local.yml
 # Binary files
 server/cmd/fleetd/fleetd
 server/fleetnode
+server/nmap
 server/fake-antminer/fake-antminer
 server/fake-proto-rig/fake-proto-rig
 server/miner-debug-cli

--- a/justfile
+++ b/justfile
@@ -172,10 +172,25 @@ update-go-deps:
 
 # --- Packaging ---
 
-# build the fleetnode operator CLI (writes to server/fleetnode)
+# Build the fleetnode operator CLI and stage plugins/nmap next to it so the
+# binary-adjacent defaults in `fleetnode run` resolve without extra flags.
+# server/plugins/ is already adjacent (populated by `just build-plugins`); this
+# recipe additionally symlinks ./nmap from PATH for the agent's NmapMode path.
 [working-directory: 'server']
 build-fleetnode:
+  #!/usr/bin/env bash
+  set -euo pipefail
   go build -o ./fleetnode ./cmd/fleetnode
+  if [ ! -d ./plugins ] || [ -z "$(ls -A ./plugins 2>/dev/null)" ]; then
+    echo "note: server/plugins/ is empty; run 'just build-plugins' so the agent's control loop has probes to run"
+  fi
+  if NMAP=$(command -v nmap 2>/dev/null); then
+    ln -sfn "$NMAP" ./nmap
+    echo "linked ./nmap -> $NMAP"
+  else
+    rm -f ./nmap
+    echo "note: nmap not on PATH; install it (brew install nmap / apt-get install nmap) or pass --nmap-path at runtime"
+  fi
 
 # build Windows installer
 [working-directory: 'deployment-files/windows']

--- a/justfile
+++ b/justfile
@@ -172,25 +172,25 @@ update-go-deps:
 
 # --- Packaging ---
 
-# Build the fleetnode operator CLI and stage plugins/nmap next to it so the
-# binary-adjacent defaults in `fleetnode run` resolve without extra flags.
-# server/plugins/ is already adjacent (populated by `just build-plugins`); this
-# recipe additionally symlinks ./nmap from PATH for the agent's NmapMode path.
-[working-directory: 'server']
-build-fleetnode:
+# Build the fleetnode operator CLI into server/.fleetnode/ along with native
+# plugins and an nmap symlink so the binary-adjacent defaults in
+# `fleetnode run` resolve without flags. Kept separate from server/plugins/
+# because `just dev` puts cross-compiled Linux/arm64 plugins there for the
+# Docker server, and the native agent can't exec ELF binaries.
+build-fleetnode: (_build-go-plugins-native "server/.fleetnode/plugins")
   #!/usr/bin/env bash
   set -euo pipefail
-  go build -o ./fleetnode ./cmd/fleetnode
-  if [ ! -d ./plugins ] || [ -z "$(ls -A ./plugins 2>/dev/null)" ]; then
-    echo "note: server/plugins/ is empty; run 'just build-plugins' so the agent's control loop has probes to run"
-  fi
+  cd server
+  mkdir -p ./.fleetnode
+  go build -o ./.fleetnode/fleetnode ./cmd/fleetnode
   if NMAP=$(command -v nmap 2>/dev/null); then
-    ln -sfn "$NMAP" ./nmap
-    echo "linked ./nmap -> $NMAP"
+    ln -sfn "$NMAP" ./.fleetnode/nmap
+    echo "linked server/.fleetnode/nmap -> $NMAP"
   else
-    rm -f ./nmap
+    rm -f ./.fleetnode/nmap
     echo "note: nmap not on PATH; install it (brew install nmap / apt-get install nmap) or pass --nmap-path at runtime"
   fi
+  echo "agent staged at server/.fleetnode/fleetnode"
 
 # build Windows installer
 [working-directory: 'deployment-files/windows']

--- a/justfile
+++ b/justfile
@@ -177,7 +177,7 @@ update-go-deps:
 # `fleetnode run` resolve without flags. Kept separate from server/plugins/
 # because `just dev` puts cross-compiled Linux/arm64 plugins there for the
 # Docker server, and the native agent can't exec ELF binaries.
-build-fleetnode: (_build-go-plugins-native "server/.fleetnode/plugins")
+build-fleetnode: (_build-go-plugins-native "server/.fleetnode/plugins") (_asicrs-build "server/.fleetnode/plugins")
   #!/usr/bin/env bash
   set -euo pipefail
   cd server
@@ -340,30 +340,47 @@ _build-go-plugins-multi-arch: _go-work-sync
   (cd plugin/antminer && GOOS=linux GOARCH=arm64 go build -o ../../deployment-files/server/antminer-plugin-arm64 .)
   chmod +x deployment-files/server/*-plugin-*
 
-_asicrs-build:
+_asicrs-build outdir="server/plugins":
   #!/usr/bin/env bash
   set -euo pipefail
-  BIN=server/plugins/asicrs-plugin
-  PLATFORM_MARKER=server/plugins/.asicrs-platform
-  WANT_PLATFORM="native"
+  BIN={{outdir}}/asicrs-plugin
+  PLATFORM_MARKER={{outdir}}/.asicrs-platform
+  HOST_OS="$(uname -s)"
+  # Docker on macOS produces a Linux ELF that the host can't exec. Use local
+  # cargo there; Linux hosts stay on the docker path so CI doesn't need Rust.
+  if [ "$HOST_OS" = "Darwin" ]; then
+    WANT_PLATFORM="darwin-native"
+  else
+    WANT_PLATFORM="native"
+  fi
   if [ -f "$BIN" ] \
      && [ -f "$PLATFORM_MARKER" ] && [ "$(cat "$PLATFORM_MARKER")" = "$WANT_PLATFORM" ] \
      && [ -z "$(find plugin/asicrs sdk/rust server/sdk/v1/pb -newer "$BIN" -type f 2>/dev/null | head -1)" ]; then
     echo "asicrs plugin up to date, skipping build."
     exit 0
   fi
-  echo "Building asicrs plugin..."
-  mkdir -p server/plugins
-  CACHE_ARGS=()
-  if [ -n "${GITHUB_ACTIONS:-}" ]; then
-    CACHE_ARGS+=(--cache-from 'type=gha,scope=asicrs-native')
-    CACHE_ARGS+=(--cache-to 'type=gha,mode=max,scope=asicrs-native')
+  echo "Building asicrs plugin ($WANT_PLATFORM)..."
+  mkdir -p {{outdir}}
+  if [ "$HOST_OS" = "Darwin" ]; then
+    if ! command -v cargo >/dev/null 2>&1; then
+      echo "cargo not on PATH; install Rust (https://rustup.rs/) to build asicrs natively on macOS" >&2
+      exit 1
+    fi
+    (cd plugin/asicrs && cargo build --release)
+    cp plugin/asicrs/target/release/asicrs-plugin "$BIN"
+    cp plugin/asicrs/config.yaml {{outdir}}/asicrs-config.yaml
+  else
+    CACHE_ARGS=()
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+      CACHE_ARGS+=(--cache-from 'type=gha,scope=asicrs-native')
+      CACHE_ARGS+=(--cache-to 'type=gha,mode=max,scope=asicrs-native')
+    fi
+    docker buildx build \
+      ${CACHE_ARGS[@]+"${CACHE_ARGS[@]}"} \
+      --file plugin/asicrs/Dockerfile.build \
+      --output type=local,dest={{outdir}} \
+      .
   fi
-  docker buildx build \
-    ${CACHE_ARGS[@]+"${CACHE_ARGS[@]}"} \
-    --file plugin/asicrs/Dockerfile.build \
-    --output type=local,dest=server/plugins \
-    .
   chmod +x "$BIN"
   # buildx --output type=local preserves the in-image mtime; touch so freshness checks see "now".
   touch "$BIN"

--- a/justfile
+++ b/justfile
@@ -188,7 +188,7 @@ build-fleetnode: (_build-go-plugins-native "server/.fleetnode/plugins") (_asicrs
     echo "linked server/.fleetnode/nmap -> $NMAP"
   else
     rm -f ./.fleetnode/nmap
-    echo "note: nmap not on PATH; install it (brew install nmap / apt-get install nmap) or pass --nmap-path at runtime"
+    echo "note: nmap not on PATH; install it (brew install nmap / apt-get install nmap) so the agent finds it at scan time"
   fi
   echo "agent staged at server/.fleetnode/fleetnode"
 

--- a/server/cmd/fleetnode/README.md
+++ b/server/cmd/fleetnode/README.md
@@ -1,0 +1,116 @@
+# fleetnode
+
+`fleetnode` is the on-prem agent that enrolls with a fleet server, holds a session, opens a `ControlStream`, executes server-issued discovery commands against the operator's local network, and reports discovered devices back. It is the on-prem counterpart to combined-mode `pairing.PairingService.Discover` — the same `DiscoverRequest` payload, executed by the agent on the operator's behalf.
+
+## Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| `fleetnode enroll`  | Register with a fleet server using a one-time enrollment code. Persists keys and `api_key`. See [enroll.go](enroll.go). |
+| `fleetnode status`  | Print local state (server URL, fleet_node_id, fingerprint, session expiry). See [status.go](status.go). |
+| `fleetnode refresh` | Renew the session token using the stored `api_key`. See [refresh.go](refresh.go). |
+| `fleetnode run`     | Long-running daemon: heartbeat + control stream. See [run.go](run.go). |
+
+## State directory and lock
+
+State lives in `state.yaml` under one of, in order:
+
+1. `--state-dir <path>` (override; primarily for tests)
+2. `$XDG_STATE_HOME/fleetnode`
+3. `~/.local/state/fleetnode`
+
+The file holds `server_url`, `fleet_node_id`, `identity_fingerprint`, both keypairs, the `api_key`, and the current `session_token`. It is created `0600` under a `0700` directory. See [state.go](../../internal/fleetnodebootstrap/state.go).
+
+A `state.lock` file in the same directory serializes commands. Only one process may hold it at a time (`LOCK_EX | LOCK_NB`). The PID of the holder is written under the lock; if another invocation hits contention, the error includes that PID. To clear a stale lock, identify the owner with `ps -p <pid>`; remove the lock file only if the process is gone.
+
+## Plugins
+
+Discovery is plugin-driven. The agent loads every executable in `<exe-dir>/plugins` at startup (subprocess plugins over gRPC via `hashicorp/go-plugin`). If that directory is missing the agent runs in heartbeat-only mode and refuses control commands; if it is present but loosens beyond owner-only write, the agent refuses to start (`plugins dir ... must not be group- or world-writable`).
+
+There is no `--plugins-dir` flag: the path is fixed relative to the binary so an installer always owns it. See [plugins_dir.go](plugins_dir.go) and [plugins_dir_unix.go](plugins_dir_unix.go).
+
+The repository's `just build-fleetnode` target stages a working layout at `server/.fleetnode/`:
+
+```
+server/.fleetnode/
+├── fleetnode
+├── nmap         (symlink to system nmap, if present)
+└── plugins/
+    ├── proto-plugin
+    ├── antminer-plugin
+    ├── virtual-plugin
+    └── asicrs-plugin
+```
+
+## Nmap
+
+When a server-issued `DiscoverRequest` arrives in `NmapModeRequest` form, the agent shells out to `<exe-dir>/nmap` if that file exists and is executable, otherwise to `nmap` on `PATH`. Install via `brew install nmap` (macOS) or your distro package manager.
+
+The target is validated against a strict grammar before invocation: bare IPv4/IPv6, CIDR, `A.B.C.D-N` range, or hostname. Leading dashes, whitespace, and shell metacharacters are rejected — this defends against a compromised server crafting a target like `-iL/etc/passwd` that nmap would otherwise interpret as a flag. See `validateNmapTarget` in [nmap.go](nmap.go).
+
+## Control stream
+
+`run` opens a bidirectional `ControlStream` over the gateway:
+
+1. Agent dials gateway, sends `ControlHello`.
+2. Server replies `ControlAccepted`; stream stays open.
+3. Server pushes `ControlCommand{command_id, payload}`. Payload is a serialized `pairing.v1.DiscoverRequest`.
+4. Agent runs the scan locally (plugin probes for `IPList`/`Mdns`, nmap for `Nmap`), batches results, and sends each batch via `ReportDiscoveredDevices` with `command_id` set.
+5. Agent sends `ControlAck{command_id, succeeded}` on completion.
+
+If the server side is older than RFC-0001 phase 2, the stream returns `Unimplemented`. The agent reconnects with exponential backoff (1s → 30s), so older servers degrade quietly. See [control.go](control.go).
+
+Reconnect is newest-wins on the server: a freshly opened stream evicts any prior registration for the same `fleet_node_id`.
+
+## Build
+
+```bash
+just build-fleetnode               # produces server/.fleetnode/{fleetnode, nmap, plugins/}
+go build -o fleetnode ./server/cmd/fleetnode   # fast iteration
+```
+
+## Run
+
+```bash
+fleetnode enroll --server-url=https://fleet.example.com
+fleetnode run     # long-running daemon; logs to stdout
+```
+
+Stop with `SIGINT`, `SIGTERM`, or `SIGHUP` (terminal close). On shutdown the agent closes the control stream, drains in-flight probes, and reaps plugin subprocesses. At startup it also reaps any orphan plugin processes left under `<exe-dir>/plugins/` by a previous crash — see [orphan_reaper.go](orphan_reaper.go).
+
+## Enrollment flow
+
+1. Operator mints an enrollment code in the UI and shares it.
+2. `fleetnode enroll --server-url=...` prompts for the code, registers, prints a fingerprint.
+3. Operator verifies the fingerprint in the UI and clicks confirm; the UI displays the `api_key`.
+4. Agent prompts for the `api_key`, completes the handshake, persists session.
+5. `fleetnode run` keeps the session refreshed and the control stream open.
+
+If anything is interrupted between Register and Complete, `fleetnode refresh` resumes from the persisted state.
+
+## Security model
+
+- **Transport.** `ValidateServerURL` requires `https://` for non-loopback servers; `--allow-insecure-transport` permits `http://` for testing only. The HTTP/2 transport is scheme-aware: `https://` goes through a TLS-validating `http2.Transport`, `http://` goes through h2c. See [client.go](../../internal/fleetnodebootstrap/client.go).
+- **State file.** `state.yaml` is `0600` under a `0700` directory; the writer fsyncs the temp file, renames, then fsyncs the directory. Symlinks at the state dir leaf are refused.
+- **Lock contention.** PID is written under the lock so contention reports are actionable.
+- **Plugins.** The directory must be owned by root or the running uid and must not be group- or world-writable; the agent refuses to load otherwise. The Windows build performs an existence-only check — production Windows installs must place the binary under an Administrator-only directory (e.g., `%ProgramFiles%\fleetnode\`) so the `plugins\` subdirectory inherits a safe ACL.
+- **Nmap targets.** Server-supplied targets are restricted by `validateNmapTarget` (no leading dashes, no whitespace, no shell metacharacters).
+- **Server compatibility.** The control stream depends on RFC-0001 phase 2 server handlers; older servers return `Unimplemented` and the agent reconnects with backoff without crashing.
+
+## Development
+
+```bash
+go test ./server/cmd/fleetnode -race -count=1
+```
+
+[fake_gateway_test.go](fake_gateway_test.go) provides an in-process h2c gateway for handler tests. Pair the agent with a local server via `just dev` (see [server/README.md](../../README.md)).
+
+## Troubleshooting
+
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| `exec format error` from plugin | Plugins were built for a different OS/arch (often Linux ELF on macOS). | Re-run `just build-fleetnode` on the host that will execute the agent. |
+| `state lock held by PID N` | Another `fleetnode` process is holding the lock; or a stale lock file with a dead PID. | `ps -p N`. If dead, remove the lock file. |
+| `control stream returned Unimplemented` | Server is older than RFC-0001 phase 2. | Upgrade fleetd to a build that implements `ControlStream` and `ReportDiscoveredDevices`. Until then the agent stays in heartbeat-only mode. |
+| `fleet node already has an active control stream` | A prior stream is still being reaped on the server. | Self-resolves: the server now applies newest-wins, evicting the prior stream on the next connect. |
+| `BeginAuth rejected` | Revoked `api_key`, identity_pubkey mismatch, expired challenge, or server clock drift. | Verify the `api_key` in the operator UI; re-enroll if revoked. Check clock skew. |

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -29,7 +29,10 @@ const (
 	perProbeTimeout        = 3 * time.Second
 	probeConcurrency       = 32
 	discoveryReportTimeout = 30 * time.Second
-	maxDevicesPerReport    = 1024 // server enforces max_items=1024
+	maxDevicesPerReport    = 1024             // server enforces max_items=1024
+	maxIPsPerCommand       = 1024             // mirrors pairing-service safety bar
+	maxPortsPerIP          = 10               // mirrors pairing.MaxPortsPerIP
+	commandTimeout         = 10 * time.Minute // mirrors pairing default discovery timeout
 )
 
 type discoverer interface {
@@ -128,12 +131,15 @@ func (r *RunCmd) handleCommand(ctx context.Context, client gatewayClient, stream
 		return
 	}
 
-	reports, err := r.discoverForCommand(ctx, &req, logger)
+	cmdCtx, cancel := context.WithTimeout(ctx, commandTimeout)
+	defer cancel()
+
+	reports, err := r.discoverForCommand(cmdCtx, &req, logger)
 	if err != nil {
 		r.sendAck(stream, commandID, false, err.Error(), logger)
 		return
 	}
-	if err := r.streamReports(ctx, client, commandID, reports, logger); err != nil {
+	if err := r.streamReports(cmdCtx, client, commandID, reports, logger); err != nil {
 		r.sendAck(stream, commandID, false, err.Error(), logger)
 		return
 	}
@@ -151,6 +157,12 @@ func (r *RunCmd) discoverForCommand(ctx context.Context, req *pairingpb.Discover
 		if len(ips) == 0 || len(ports) == 0 {
 			return nil, fmt.Errorf("ip_addresses and ports must both be non-empty")
 		}
+		if len(ips) > maxIPsPerCommand {
+			return nil, fmt.Errorf("too many ip_addresses: %d exceeds the limit of %d", len(ips), maxIPsPerCommand)
+		}
+		if len(ports) > maxPortsPerIP {
+			return nil, fmt.Errorf("too many ports: %d exceeds the limit of %d", len(ports), maxPortsPerIP)
+		}
 		endpoints := make([]endpoint, 0, len(ips)*len(ports))
 		for _, ip := range ips {
 			for _, port := range ports {
@@ -159,6 +171,9 @@ func (r *RunCmd) discoverForCommand(ctx context.Context, req *pairingpb.Discover
 		}
 		return fanOutProbes(ctx, endpoints, probeConcurrency, r.discoverer.Probe, logger), nil
 	case *pairingpb.DiscoverRequest_Nmap:
+		if ports := m.Nmap.GetPorts(); len(ports) > maxPortsPerIP {
+			return nil, fmt.Errorf("too many ports: %d exceeds the limit of %d", len(ports), maxPortsPerIP)
+		}
 		return r.runNmapDiscovery(ctx, m.Nmap, logger)
 	case *pairingpb.DiscoverRequest_Mdns:
 		return nil, fmt.Errorf("mdns mode is not supported on the fleet node agent")

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -24,9 +24,13 @@ import (
 const (
 	controlReconnectInitial = 1 * time.Second
 	controlReconnectMax     = 30 * time.Second
-	perProbeTimeout         = 3 * time.Second
-	probeConcurrency        = 32
-	discoveryReportTimeout  = 30 * time.Second
+	// stableSessionThreshold marks how long a control session must live before
+	// the next disconnect resets the reconnect backoff. Anything shorter is
+	// treated as a continued failure and keeps backoff growing.
+	stableSessionThreshold = 30 * time.Second
+	perProbeTimeout        = 3 * time.Second
+	probeConcurrency       = 32
+	discoveryReportTimeout = 30 * time.Second
 	// Server enforces max_items = 1024 on the report batch.
 	maxDevicesPerReport = 1024
 )
@@ -36,12 +40,10 @@ type discoverer interface {
 	DefaultDiscoveryPorts(ctx context.Context) []string
 }
 
-// runControlLoop opens a ControlStream and consumes server-issued
-// DiscoverRequests for the lifetime of ctx. On stream error it
-// reconnects with exponential backoff up to controlReconnectMax.
-// Permanent server-side rejections (NotFound, ErrBeginAuthRejected)
-// exit the loop so the daemon shuts down rather than spinning.
+type endpoint struct{ ip, port string }
+
 func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, logger *slog.Logger) error {
+	loopLogger := logger.With("fleet_node_id", st.FleetNodeID)
 	backoff := controlReconnectInitial
 	for {
 		select {
@@ -49,14 +51,20 @@ func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *f
 			return nil
 		default:
 		}
-		err := r.runControlSession(ctx, client, st, logger)
+		started := time.Now()
+		err := r.runControlSession(ctx, client, st, loopLogger)
 		if err == nil {
 			return nil
 		}
 		if errors.Is(err, fleetnodebootstrap.ErrBeginAuthRejected) || connect.CodeOf(err) == connect.CodeNotFound {
 			return err
 		}
-		logger.Warn("control stream disconnected; will reconnect", "fleet_node_id", st.FleetNodeID, "backoff", backoff.String(), "err", err)
+		// A session that stayed up past stableSessionThreshold reset to a
+		// healthy state; the next failure starts the backoff window over.
+		if time.Since(started) > stableSessionThreshold {
+			backoff = controlReconnectInitial
+		}
+		loopLogger.Warn("control stream disconnected; will reconnect", "backoff", backoff.String(), "err", err)
 		select {
 		case <-ctx.Done():
 			return nil
@@ -83,7 +91,7 @@ func (r *RunCmd) runControlSession(ctx context.Context, client gatewayClient, st
 	if first.GetAccepted() == nil {
 		return fmt.Errorf("first server message was not Accepted")
 	}
-	logger.Info("control stream opened", "fleet_node_id", st.FleetNodeID)
+	logger.Info("control stream opened")
 
 	for {
 		msg, err := stream.Receive()
@@ -97,11 +105,11 @@ func (r *RunCmd) runControlSession(ctx context.Context, client gatewayClient, st
 		if cmd == nil {
 			continue
 		}
-		r.handleCommand(ctx, client, stream, cmd, logger, st.FleetNodeID)
+		r.handleCommand(ctx, client, stream, cmd, logger)
 	}
 }
 
-func (r *RunCmd) handleCommand(ctx context.Context, client gatewayClient, stream *connect.BidiStreamForClient[pb.ControlStreamRequest, pb.ControlStreamResponse], cmd *pb.ControlCommand, logger *slog.Logger, fleetNodeID int64) {
+func (r *RunCmd) handleCommand(ctx context.Context, client gatewayClient, stream *connect.BidiStreamForClient[pb.ControlStreamRequest, pb.ControlStreamResponse], cmd *pb.ControlCommand, logger *slog.Logger) {
 	commandID := cmd.GetCommandId()
 	logger.Info("control command received", "command_id", commandID, "payload_bytes", len(cmd.GetPayload()))
 
@@ -116,7 +124,7 @@ func (r *RunCmd) handleCommand(ctx context.Context, client gatewayClient, stream
 		r.sendAck(stream, commandID, false, err.Error(), logger)
 		return
 	}
-	if err := r.streamReports(ctx, client, commandID, reports, logger, fleetNodeID); err != nil {
+	if err := r.streamReports(ctx, client, commandID, reports, logger); err != nil {
 		r.sendAck(stream, commandID, false, err.Error(), logger)
 		return
 	}
@@ -134,7 +142,13 @@ func (r *RunCmd) discoverForCommand(ctx context.Context, req *pairingpb.Discover
 		if len(ips) == 0 || len(ports) == 0 {
 			return nil, fmt.Errorf("ip_addresses and ports must both be non-empty")
 		}
-		return r.runProbes(ctx, ips, ports, logger), nil
+		endpoints := make([]endpoint, 0, len(ips)*len(ports))
+		for _, ip := range ips {
+			for _, port := range ports {
+				endpoints = append(endpoints, endpoint{ip: ip, port: port})
+			}
+		}
+		return fanOutProbes(ctx, endpoints, probeConcurrency, r.discoverer.Probe, logger), nil
 	case *pairingpb.DiscoverRequest_Nmap:
 		return r.runNmapDiscovery(ctx, m.Nmap, logger)
 	case *pairingpb.DiscoverRequest_Mdns:
@@ -144,49 +158,44 @@ func (r *RunCmd) discoverForCommand(ctx context.Context, req *pairingpb.Discover
 	}
 }
 
-func (r *RunCmd) runProbes(ctx context.Context, ips, ports []string, logger *slog.Logger) []*pb.DiscoveredDeviceReport {
+func fanOutProbes(ctx context.Context, endpoints []endpoint, concurrency int, probe func(context.Context, string, string) (*pb.DiscoveredDeviceReport, error), logger *slog.Logger) []*pb.DiscoveredDeviceReport {
 	var (
 		mu    sync.Mutex
 		batch []*pb.DiscoveredDeviceReport
 		wg    sync.WaitGroup
 	)
-	sem := make(chan struct{}, probeConcurrency)
-	for _, ip := range ips {
-		for _, port := range ports {
-			select {
-			case sem <- struct{}{}:
-			case <-ctx.Done():
-				wg.Wait()
-				return batch
-			}
-			wg.Add(1)
-			go func(ip, port string) {
-				defer wg.Done()
-				defer func() { <-sem }()
-				probeCtx, cancel := context.WithTimeout(ctx, perProbeTimeout)
-				defer cancel()
-				report, err := r.discoverer.Probe(probeCtx, ip, port)
-				if err != nil {
-					logger.Debug("probe failed", "ip", ip, "port", port, "err", err)
-					return
-				}
-				if report == nil {
-					return
-				}
-				if report.GetDeviceIdentifier() == "" {
-					return
-				}
-				mu.Lock()
-				batch = append(batch, report)
-				mu.Unlock()
-			}(ip, port)
+	sem := make(chan struct{}, concurrency)
+	for _, e := range endpoints {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return batch
 		}
+		wg.Add(1)
+		go func(ip, port string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			probeCtx, cancel := context.WithTimeout(ctx, perProbeTimeout)
+			defer cancel()
+			report, err := probe(probeCtx, ip, port)
+			if err != nil {
+				logger.Debug("probe failed", "ip", ip, "port", port, "err", err)
+				return
+			}
+			if report == nil || report.GetDeviceIdentifier() == "" {
+				return
+			}
+			mu.Lock()
+			batch = append(batch, report)
+			mu.Unlock()
+		}(e.ip, e.port)
 	}
 	wg.Wait()
 	return batch
 }
 
-func (r *RunCmd) streamReports(ctx context.Context, client gatewayClient, commandID string, reports []*pb.DiscoveredDeviceReport, logger *slog.Logger, fleetNodeID int64) error {
+func (r *RunCmd) streamReports(ctx context.Context, client gatewayClient, commandID string, reports []*pb.DiscoveredDeviceReport, logger *slog.Logger) error {
 	if len(reports) == 0 {
 		return nil
 	}
@@ -203,10 +212,10 @@ func (r *RunCmd) streamReports(ctx context.Context, client gatewayClient, comman
 		}))
 		cancel()
 		if err != nil {
-			logger.Error("report failed", "command_id", commandID, "fleet_node_id", fleetNodeID, "err", err)
+			logger.Error("report failed", "command_id", commandID, "err", err)
 			return fmt.Errorf("report devices: %w", err)
 		}
-		logger.Info("report accepted", "command_id", commandID, "fleet_node_id", fleetNodeID, "batch_size", len(chunk))
+		logger.Info("report accepted", "command_id", commandID, "batch_size", len(chunk))
 	}
 	return nil
 }
@@ -226,10 +235,9 @@ type pluginDiscoverer struct {
 	svc   *plugins.Service
 }
 
-// pluginsDir must be an absolute path: the manager exec's every executable in
-// that directory, so a relative path would resolve against the daemon's CWD
-// and let anyone with write access there plant code that runs with the
-// agent's privileges.
+// pluginsDir must be an absolute path: the manager execs every file in this
+// directory, so a relative path would resolve against the daemon's CWD and
+// let a writable launch directory plant code that runs with agent privileges.
 func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
 	if !filepath.IsAbs(pluginsDir) {
 		return nil, func() {}, fmt.Errorf("--plugins-dir must be an absolute path, got %q", pluginsDir)
@@ -269,8 +277,8 @@ func (p *pluginDiscoverer) DefaultDiscoveryPorts(ctx context.Context) []string {
 	return p.svc.GetDefaultDiscoveryPorts(ctx)
 }
 
-// Production SDK drivers leave DeviceIdentifier empty; the agent has no DB to
-// reconcile against, so it synthesizes auto:* identifiers and the server
+// Production SDK drivers leave DeviceIdentifier empty; the agent has no DB
+// to reconcile against, so it synthesizes auto:* identifiers and the server
 // reconciles by (fleet_node, ip, port).
 func reportFromDiscovered(dev *discoverymodels.DiscoveredDevice) *pb.DiscoveredDeviceReport {
 	deviceID := dev.GetDeviceIdentifier()

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -79,6 +79,21 @@ func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *f
 
 func (r *RunCmd) runControlSession(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, logger *slog.Logger) error {
 	stream := client.ControlStream(ctx)
+	// The bidi response body is read via http2.pipe whose Read is parked in
+	// sync.Cond.Wait, which is not ctx-aware. Without this watcher, a
+	// stream.Receive() in the loop below will block past parent ctx
+	// cancellation (Ctrl+C never returns the daemon). Force-closing the
+	// stream broadcasts the cond and unblocks Receive with an error.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = stream.CloseRequest()
+			_ = stream.CloseResponse()
+		case <-done:
+		}
+	}()
 	defer func() { _ = stream.CloseRequest(); _ = stream.CloseResponse() }()
 
 	if err := stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}}); err != nil {
@@ -242,12 +257,16 @@ func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
 	if !filepath.IsAbs(pluginsDir) {
 		return nil, func() {}, fmt.Errorf("--plugins-dir must be an absolute path, got %q", pluginsDir)
 	}
+	// The plugin manager's Shutdown waits the full grace period regardless
+	// of whether the plugin already exited, so we keep it tight for
+	// interactive dev. A real stuck plugin still gets killed; we just don't
+	// wait around for clean ones.
 	manager := plugins.NewManager(&plugins.Config{
 		Enabled:                    true,
 		PluginsDir:                 pluginsDir,
 		MaxStartupTimeSeconds:      30,
 		ShutdownTimeoutSeconds:     10,
-		ShutdownGracePeriodSeconds: 5,
+		ShutdownGracePeriodSeconds: 2,
 		LogLevel:                   "info",
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -245,13 +244,7 @@ type pluginDiscoverer struct {
 	svc   *plugins.Service
 }
 
-// Requires an absolute path because plugins.Manager execs every file in the
-// dir; a relative path would resolve against the daemon's CWD and let a
-// writable launch directory plant code that runs with agent privileges.
 func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
-	if !filepath.IsAbs(pluginsDir) {
-		return nil, func() {}, fmt.Errorf("--plugins-dir must be an absolute path, got %q", pluginsDir)
-	}
 	// Manager.Shutdown waits the full grace period even when a plugin already
 	// exited, so keep it tight; a stuck plugin still gets killed.
 	manager := plugins.NewManager(&plugins.Config{

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
+	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
+	"github.com/block/proto-fleet/server/internal/domain/plugins"
+	"github.com/block/proto-fleet/server/internal/fleetnodebootstrap"
+	"github.com/block/proto-fleet/server/internal/infrastructure/id"
+)
+
+const (
+	controlReconnectInitial = 1 * time.Second
+	controlReconnectMax     = 30 * time.Second
+	perProbeTimeout         = 3 * time.Second
+	probeConcurrency        = 32
+	discoveryReportTimeout  = 30 * time.Second
+	// Server enforces max_items = 1024 on the report batch.
+	maxDevicesPerReport = 1024
+)
+
+type discoverer interface {
+	Probe(ctx context.Context, ipAddress, port string) (*pb.DiscoveredDeviceReport, error)
+	DefaultDiscoveryPorts(ctx context.Context) []string
+}
+
+// runControlLoop opens a ControlStream and consumes server-issued
+// DiscoverRequests for the lifetime of ctx. On stream error it
+// reconnects with exponential backoff up to controlReconnectMax.
+// Permanent server-side rejections (NotFound, ErrBeginAuthRejected)
+// exit the loop so the daemon shuts down rather than spinning.
+func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, logger *slog.Logger) error {
+	backoff := controlReconnectInitial
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+		err := r.runControlSession(ctx, client, st, logger)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, fleetnodebootstrap.ErrBeginAuthRejected) || connect.CodeOf(err) == connect.CodeNotFound {
+			return err
+		}
+		logger.Warn("control stream disconnected; will reconnect", "fleet_node_id", st.FleetNodeID, "backoff", backoff.String(), "err", err)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > controlReconnectMax {
+			backoff = controlReconnectMax
+		}
+	}
+}
+
+func (r *RunCmd) runControlSession(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, logger *slog.Logger) error {
+	stream := client.ControlStream(ctx)
+	defer func() { _ = stream.CloseRequest(); _ = stream.CloseResponse() }()
+
+	if err := stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}}); err != nil {
+		return fmt.Errorf("send hello: %w", err)
+	}
+	first, err := stream.Receive()
+	if err != nil {
+		return fmt.Errorf("await accepted: %w", err)
+	}
+	if first.GetAccepted() == nil {
+		return fmt.Errorf("first server message was not Accepted")
+	}
+	logger.Info("control stream opened", "fleet_node_id", st.FleetNodeID)
+
+	for {
+		msg, err := stream.Receive()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return fmt.Errorf("control stream closed by server: %w", err)
+			}
+			return fmt.Errorf("recv: %w", err)
+		}
+		cmd := msg.GetCommand()
+		if cmd == nil {
+			continue
+		}
+		r.handleCommand(ctx, client, stream, cmd, logger, st.FleetNodeID)
+	}
+}
+
+func (r *RunCmd) handleCommand(ctx context.Context, client gatewayClient, stream *connect.BidiStreamForClient[pb.ControlStreamRequest, pb.ControlStreamResponse], cmd *pb.ControlCommand, logger *slog.Logger, fleetNodeID int64) {
+	commandID := cmd.GetCommandId()
+	logger.Info("control command received", "command_id", commandID, "payload_bytes", len(cmd.GetPayload()))
+
+	var req pairingpb.DiscoverRequest
+	if err := proto.Unmarshal(cmd.GetPayload(), &req); err != nil {
+		r.sendAck(stream, commandID, false, fmt.Sprintf("decode payload: %v", err), logger)
+		return
+	}
+	list := req.GetIpList()
+	if list == nil {
+		r.sendAck(stream, commandID, false, "only IPList mode is supported on the fleet node agent", logger)
+		return
+	}
+
+	ips := list.GetIpAddresses()
+	ports := list.GetPorts()
+	if len(ports) == 0 {
+		ports = r.discoverer.DefaultDiscoveryPorts(ctx)
+	}
+	if len(ips) == 0 || len(ports) == 0 {
+		r.sendAck(stream, commandID, false, "ip_addresses and ports must both be non-empty", logger)
+		return
+	}
+
+	reports := r.runProbes(ctx, ips, ports, logger)
+	if err := r.streamReports(ctx, client, commandID, reports, logger, fleetNodeID); err != nil {
+		r.sendAck(stream, commandID, false, err.Error(), logger)
+		return
+	}
+	r.sendAck(stream, commandID, true, "", logger)
+}
+
+func (r *RunCmd) runProbes(ctx context.Context, ips, ports []string, logger *slog.Logger) []*pb.DiscoveredDeviceReport {
+	var (
+		mu    sync.Mutex
+		batch []*pb.DiscoveredDeviceReport
+		wg    sync.WaitGroup
+	)
+	sem := make(chan struct{}, probeConcurrency)
+	for _, ip := range ips {
+		for _, port := range ports {
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				wg.Wait()
+				return batch
+			}
+			wg.Add(1)
+			go func(ip, port string) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				probeCtx, cancel := context.WithTimeout(ctx, perProbeTimeout)
+				defer cancel()
+				report, err := r.discoverer.Probe(probeCtx, ip, port)
+				if err != nil {
+					logger.Debug("probe failed", "ip", ip, "port", port, "err", err)
+					return
+				}
+				if report == nil {
+					return
+				}
+				if report.GetDeviceIdentifier() == "" {
+					return
+				}
+				mu.Lock()
+				batch = append(batch, report)
+				mu.Unlock()
+			}(ip, port)
+		}
+	}
+	wg.Wait()
+	return batch
+}
+
+func (r *RunCmd) streamReports(ctx context.Context, client gatewayClient, commandID string, reports []*pb.DiscoveredDeviceReport, logger *slog.Logger, fleetNodeID int64) error {
+	if len(reports) == 0 {
+		return nil
+	}
+	for start := 0; start < len(reports); start += maxDevicesPerReport {
+		end := start + maxDevicesPerReport
+		if end > len(reports) {
+			end = len(reports)
+		}
+		chunk := reports[start:end]
+		callCtx, cancel := context.WithTimeout(ctx, discoveryReportTimeout)
+		_, err := client.ReportDiscoveredDevices(callCtx, connect.NewRequest(&pb.ReportDiscoveredDevicesRequest{
+			CommandId: commandID,
+			Devices:   chunk,
+		}))
+		cancel()
+		if err != nil {
+			logger.Error("report failed", "command_id", commandID, "fleet_node_id", fleetNodeID, "err", err)
+			return fmt.Errorf("report devices: %w", err)
+		}
+		logger.Info("report accepted", "command_id", commandID, "fleet_node_id", fleetNodeID, "batch_size", len(chunk))
+	}
+	return nil
+}
+
+func (r *RunCmd) sendAck(stream *connect.BidiStreamForClient[pb.ControlStreamRequest, pb.ControlStreamResponse], commandID string, succeeded bool, errMsg string, logger *slog.Logger) {
+	if err := stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Ack{Ack: &pb.ControlAck{
+		CommandId:    commandID,
+		Succeeded:    succeeded,
+		ErrorMessage: errMsg,
+	}}}); err != nil {
+		logger.Warn("send ack failed", "command_id", commandID, "err", err)
+	}
+}
+
+type pluginDiscoverer struct {
+	multi *plugins.MultiTypeDiscoverer
+	svc   *plugins.Service
+}
+
+// pluginsDir must be an absolute path: the manager exec's every executable in
+// that directory, so a relative path would resolve against the daemon's CWD
+// and let anyone with write access there plant code that runs with the
+// agent's privileges.
+func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
+	if !filepath.IsAbs(pluginsDir) {
+		return nil, func() {}, fmt.Errorf("--plugins-dir must be an absolute path, got %q", pluginsDir)
+	}
+	manager := plugins.NewManager(&plugins.Config{
+		Enabled:                    true,
+		PluginsDir:                 pluginsDir,
+		MaxStartupTimeSeconds:      30,
+		ShutdownTimeoutSeconds:     10,
+		ShutdownGracePeriodSeconds: 5,
+		LogLevel:                   "info",
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := manager.LoadPlugins(ctx); err != nil {
+		return nil, func() {}, fmt.Errorf("load plugins: %w", err)
+	}
+	cleanup := func() { _ = manager.Shutdown(context.Background()) }
+	return &pluginDiscoverer{
+		multi: plugins.NewMultiTypeDiscoverer(manager),
+		svc:   plugins.NewService(manager),
+	}, cleanup, nil
+}
+
+func (p *pluginDiscoverer) Probe(ctx context.Context, ipAddress, port string) (*pb.DiscoveredDeviceReport, error) {
+	dev, err := p.multi.Discover(ctx, ipAddress, port)
+	if err != nil {
+		return nil, err
+	}
+	if dev == nil {
+		return nil, nil
+	}
+	return reportFromDiscovered(dev), nil
+}
+
+func (p *pluginDiscoverer) DefaultDiscoveryPorts(ctx context.Context) []string {
+	return p.svc.GetDefaultDiscoveryPorts(ctx)
+}
+
+// Production SDK drivers leave DeviceIdentifier empty; the agent has no DB to
+// reconcile against, so it synthesizes auto:* identifiers and the server
+// reconciles by (fleet_node, ip, port).
+func reportFromDiscovered(dev *discoverymodels.DiscoveredDevice) *pb.DiscoveredDeviceReport {
+	deviceID := dev.GetDeviceIdentifier()
+	if deviceID == "" {
+		deviceID = synthesizeIdentifier(dev.GetMacAddress(), dev.GetSerialNumber())
+	}
+	return &pb.DiscoveredDeviceReport{
+		DeviceIdentifier: deviceID,
+		IpAddress:        dev.GetIpAddress(),
+		Port:             dev.GetPort(),
+		UrlScheme:        dev.GetUrlScheme(),
+		DriverName:       dev.GetDriverName(),
+		Model:            dev.GetModel(),
+		Manufacturer:     dev.GetManufacturer(),
+		FirmwareVersion:  dev.GetFirmwareVersion(),
+	}
+}
+
+func synthesizeIdentifier(mac, serial string) string {
+	if mac != "" {
+		return "mac:" + mac
+	}
+	if serial != "" {
+		return "serial:" + serial
+	}
+	return "auto:" + id.GenerateID()
+}

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -24,15 +24,13 @@ import (
 const (
 	controlReconnectInitial = 1 * time.Second
 	controlReconnectMax     = 30 * time.Second
-	// stableSessionThreshold marks how long a control session must live before
-	// the next disconnect resets the reconnect backoff. Anything shorter is
-	// treated as a continued failure and keeps backoff growing.
+	// A session that survives this long resets the reconnect backoff; flapping
+	// connections keep backoff growing.
 	stableSessionThreshold = 30 * time.Second
 	perProbeTimeout        = 3 * time.Second
 	probeConcurrency       = 32
 	discoveryReportTimeout = 30 * time.Second
-	// Server enforces max_items = 1024 on the report batch.
-	maxDevicesPerReport = 1024
+	maxDevicesPerReport    = 1024 // server enforces max_items=1024
 )
 
 type discoverer interface {
@@ -59,8 +57,6 @@ func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *f
 		if errors.Is(err, fleetnodebootstrap.ErrBeginAuthRejected) || connect.CodeOf(err) == connect.CodeNotFound {
 			return err
 		}
-		// A session that stayed up past stableSessionThreshold reset to a
-		// healthy state; the next failure starts the backoff window over.
 		if time.Since(started) > stableSessionThreshold {
 			backoff = controlReconnectInitial
 		}
@@ -79,15 +75,10 @@ func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *f
 
 func (r *RunCmd) runControlSession(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, logger *slog.Logger) error {
 	stream := client.ControlStream(ctx)
-	// http2.pipe.Read parks in sync.Cond.Wait, which isn't ctx-aware -- a
-	// stream.Receive() in the loop below blocks past parent ctx cancellation
-	// (Ctrl+C never returns the daemon). The watcher goroutine closes the
-	// stream when ctx fires, which broadcasts the cond and unblocks Receive.
-	//
-	// Defer order matters here: defers run LIFO, so the stream-close defer
-	// (registered first) runs last. That gives close(done) (registered
-	// second, runs first) a chance to retire the watcher on the quiet path
-	// before the close defer fires, avoiding a redundant close race.
+	// stream.Receive blocks in http2.pipe.Read on a sync.Cond that ctx can't
+	// unblock; without this watcher Ctrl+C never returns the daemon. Defers
+	// run LIFO so close(done) fires before the stream-close defer, letting
+	// the watcher exit via its quiet path on normal return.
 	defer func() { _ = stream.CloseRequest(); _ = stream.CloseResponse() }()
 	done := make(chan struct{})
 	defer close(done)
@@ -254,17 +245,15 @@ type pluginDiscoverer struct {
 	svc   *plugins.Service
 }
 
-// pluginsDir must be an absolute path: the manager execs every file in this
-// directory, so a relative path would resolve against the daemon's CWD and
-// let a writable launch directory plant code that runs with agent privileges.
+// Requires an absolute path because plugins.Manager execs every file in the
+// dir; a relative path would resolve against the daemon's CWD and let a
+// writable launch directory plant code that runs with agent privileges.
 func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
 	if !filepath.IsAbs(pluginsDir) {
 		return nil, func() {}, fmt.Errorf("--plugins-dir must be an absolute path, got %q", pluginsDir)
 	}
-	// The plugin manager's Shutdown waits the full grace period regardless
-	// of whether the plugin already exited, so we keep it tight for
-	// interactive dev. A real stuck plugin still gets killed; we just don't
-	// wait around for clean ones.
+	// Manager.Shutdown waits the full grace period even when a plugin already
+	// exited, so keep it tight; a stuck plugin still gets killed.
 	manager := plugins.NewManager(&plugins.Config{
 		Enabled:                    true,
 		PluginsDir:                 pluginsDir,
@@ -300,9 +289,8 @@ func (p *pluginDiscoverer) DefaultDiscoveryPorts(ctx context.Context) []string {
 	return p.svc.GetDefaultDiscoveryPorts(ctx)
 }
 
-// Production SDK drivers leave DeviceIdentifier empty; the agent has no DB
-// to reconcile against, so it synthesizes auto:* identifiers and the server
-// reconciles by (fleet_node, ip, port).
+// SDK drivers often leave DeviceIdentifier empty; the agent has no DB so it
+// synthesizes auto:* and lets the server reconcile by (fleet_node, ip, port).
 func reportFromDiscovered(dev *discoverymodels.DiscoveredDevice) *pb.DiscoveredDeviceReport {
 	deviceID := dev.GetDeviceIdentifier()
 	if deviceID == "" {

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -79,11 +79,16 @@ func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *f
 
 func (r *RunCmd) runControlSession(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, logger *slog.Logger) error {
 	stream := client.ControlStream(ctx)
-	// The bidi response body is read via http2.pipe whose Read is parked in
-	// sync.Cond.Wait, which is not ctx-aware. Without this watcher, a
-	// stream.Receive() in the loop below will block past parent ctx
-	// cancellation (Ctrl+C never returns the daemon). Force-closing the
-	// stream broadcasts the cond and unblocks Receive with an error.
+	// http2.pipe.Read parks in sync.Cond.Wait, which isn't ctx-aware -- a
+	// stream.Receive() in the loop below blocks past parent ctx cancellation
+	// (Ctrl+C never returns the daemon). The watcher goroutine closes the
+	// stream when ctx fires, which broadcasts the cond and unblocks Receive.
+	//
+	// Defer order matters here: defers run LIFO, so the stream-close defer
+	// (registered first) runs last. That gives close(done) (registered
+	// second, runs first) a chance to retire the watcher on the quiet path
+	// before the close defer fires, avoiding a redundant close race.
+	defer func() { _ = stream.CloseRequest(); _ = stream.CloseResponse() }()
 	done := make(chan struct{})
 	defer close(done)
 	go func() {
@@ -94,7 +99,6 @@ func (r *RunCmd) runControlSession(ctx context.Context, client gatewayClient, st
 		case <-done:
 		}
 	}()
-	defer func() { _ = stream.CloseRequest(); _ = stream.CloseResponse() }()
 
 	if err := stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}}); err != nil {
 		return fmt.Errorf("send hello: %w", err)

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -152,18 +153,15 @@ func (r *RunCmd) discoverForCommand(ctx context.Context, req *pairingpb.Discover
 	switch m := req.GetMode().(type) {
 	case *pairingpb.DiscoverRequest_IpList:
 		ips := m.IpList.GetIpAddresses()
-		ports := m.IpList.GetPorts()
-		if len(ports) == 0 {
-			ports = r.discoverer.DefaultDiscoveryPorts(ctx)
-		}
-		if len(ips) == 0 || len(ports) == 0 {
-			return nil, fmt.Errorf("ip_addresses and ports must both be non-empty")
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("ip_addresses must be non-empty")
 		}
 		if len(ips) > maxIPsPerCommand {
 			return nil, fmt.Errorf("too many ip_addresses: %d exceeds the limit of %d", len(ips), maxIPsPerCommand)
 		}
-		if len(ports) > maxPortsPerIP {
-			return nil, fmt.Errorf("too many ports: %d exceeds the limit of %d", len(ports), maxPortsPerIP)
+		ports, err := r.resolveAndValidatePorts(ctx, m.IpList.GetPorts())
+		if err != nil {
+			return nil, err
 		}
 		normalized := make([]string, 0, len(ips))
 		for _, raw := range ips {
@@ -185,15 +183,48 @@ func (r *RunCmd) discoverForCommand(ctx context.Context, req *pairingpb.Discover
 		}
 		return fanOutProbes(ctx, endpoints, probeConcurrency, r.discoverer.Probe, logger), nil
 	case *pairingpb.DiscoverRequest_Nmap:
-		if ports := m.Nmap.GetPorts(); len(ports) > maxPortsPerIP {
-			return nil, fmt.Errorf("too many ports: %d exceeds the limit of %d", len(ports), maxPortsPerIP)
+		ports, err := r.resolveAndValidatePorts(ctx, m.Nmap.GetPorts())
+		if err != nil {
+			return nil, err
 		}
-		return r.runNmapDiscovery(ctx, m.Nmap, logger)
+		return r.runNmapDiscovery(ctx, m.Nmap, ports, logger)
 	case *pairingpb.DiscoverRequest_Mdns:
 		return nil, fmt.Errorf("mdns mode is not supported on the fleet node agent")
 	default:
 		return nil, fmt.Errorf("discover request mode is required")
 	}
+}
+
+// resolveAndValidatePorts falls back to plugin defaults when empty, then
+// requires each entry to be a single decimal TCP port in 1..65535. Range
+// syntax ("1-65535") and comma syntax ("80,443") would otherwise let a
+// single list entry bypass maxPortsPerIP. Default ports are validated too:
+// a buggy or hostile plugin should not be able to slip in odd specs.
+func (r *RunCmd) resolveAndValidatePorts(ctx context.Context, supplied []string) ([]string, error) {
+	ports := supplied
+	if len(ports) == 0 {
+		ports = r.discoverer.DefaultDiscoveryPorts(ctx)
+	}
+	if len(ports) == 0 {
+		return nil, fmt.Errorf("ports must be non-empty (no defaults available)")
+	}
+	if len(ports) > maxPortsPerIP {
+		return nil, fmt.Errorf("too many ports: %d exceeds the limit of %d", len(ports), maxPortsPerIP)
+	}
+	seen := make(map[string]struct{}, len(ports))
+	out := make([]string, 0, len(ports))
+	for _, p := range ports {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 1 || n > 65535 {
+			return nil, fmt.Errorf("invalid port %q: must be decimal 1-65535 (ranges, commas, and protocol prefixes are not allowed)", p)
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out, nil
 }
 
 func fanOutProbes(ctx context.Context, endpoints []endpoint, concurrency int, probe func(context.Context, string, string) (*pb.DiscoveredDeviceReport, error), logger *slog.Logger) []*pb.DiscoveredDeviceReport {

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -110,28 +110,38 @@ func (r *RunCmd) handleCommand(ctx context.Context, client gatewayClient, stream
 		r.sendAck(stream, commandID, false, fmt.Sprintf("decode payload: %v", err), logger)
 		return
 	}
-	list := req.GetIpList()
-	if list == nil {
-		r.sendAck(stream, commandID, false, "only IPList mode is supported on the fleet node agent", logger)
+
+	reports, err := r.discoverForCommand(ctx, &req, logger)
+	if err != nil {
+		r.sendAck(stream, commandID, false, err.Error(), logger)
 		return
 	}
-
-	ips := list.GetIpAddresses()
-	ports := list.GetPorts()
-	if len(ports) == 0 {
-		ports = r.discoverer.DefaultDiscoveryPorts(ctx)
-	}
-	if len(ips) == 0 || len(ports) == 0 {
-		r.sendAck(stream, commandID, false, "ip_addresses and ports must both be non-empty", logger)
-		return
-	}
-
-	reports := r.runProbes(ctx, ips, ports, logger)
 	if err := r.streamReports(ctx, client, commandID, reports, logger, fleetNodeID); err != nil {
 		r.sendAck(stream, commandID, false, err.Error(), logger)
 		return
 	}
 	r.sendAck(stream, commandID, true, "", logger)
+}
+
+func (r *RunCmd) discoverForCommand(ctx context.Context, req *pairingpb.DiscoverRequest, logger *slog.Logger) ([]*pb.DiscoveredDeviceReport, error) {
+	switch m := req.GetMode().(type) {
+	case *pairingpb.DiscoverRequest_IpList:
+		ips := m.IpList.GetIpAddresses()
+		ports := m.IpList.GetPorts()
+		if len(ports) == 0 {
+			ports = r.discoverer.DefaultDiscoveryPorts(ctx)
+		}
+		if len(ips) == 0 || len(ports) == 0 {
+			return nil, fmt.Errorf("ip_addresses and ports must both be non-empty")
+		}
+		return r.runProbes(ctx, ips, ports, logger), nil
+	case *pairingpb.DiscoverRequest_Nmap:
+		return r.runNmapDiscovery(ctx, m.Nmap, logger)
+	case *pairingpb.DiscoverRequest_Mdns:
+		return nil, fmt.Errorf("mdns mode is not supported on the fleet node agent")
+	default:
+		return nil, fmt.Errorf("discover request mode is required")
+	}
 }
 
 func (r *RunCmd) runProbes(ctx context.Context, ips, ports []string, logger *slog.Logger) []*pb.DiscoveredDeviceReport {

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
+	"github.com/block/proto-fleet/server/internal/domain/netutil"
 	"github.com/block/proto-fleet/server/internal/domain/plugins"
 	"github.com/block/proto-fleet/server/internal/fleetnodebootstrap"
 	"github.com/block/proto-fleet/server/internal/infrastructure/id"
@@ -163,8 +165,20 @@ func (r *RunCmd) discoverForCommand(ctx context.Context, req *pairingpb.Discover
 		if len(ports) > maxPortsPerIP {
 			return nil, fmt.Errorf("too many ports: %d exceeds the limit of %d", len(ports), maxPortsPerIP)
 		}
-		endpoints := make([]endpoint, 0, len(ips)*len(ports))
-		for _, ip := range ips {
+		normalized := make([]string, 0, len(ips))
+		for _, raw := range ips {
+			n, err := netutil.NormalizeIPListEntry(ctx, raw, net.DefaultResolver)
+			if err != nil {
+				logger.Debug("skipping ipList entry", "input", raw, "err", err)
+				continue
+			}
+			normalized = append(normalized, n)
+		}
+		if len(normalized) == 0 {
+			return nil, fmt.Errorf("no usable ip_addresses after normalization (scoped/link-local IPv6 and unresolvable hostnames are skipped)")
+		}
+		endpoints := make([]endpoint, 0, len(normalized)*len(ports))
+		for _, ip := range normalized {
 			for _, port := range ports {
 				endpoints = append(endpoints, endpoint{ip: ip, port: port})
 			}

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -146,7 +146,7 @@ func TestResolveAndValidatePorts(t *testing.T) {
 }
 
 func TestControlLoop_RejectsNmapPortRangeBypass(t *testing.T) {
-	// Arrange: one entry, but it expands to 65k ports inside nmap.
+	// Arrange
 	cmd := &RunCmd{discoverer: &stubDiscoverer{}}
 	state := &fleetnodebootstrap.State{FleetNodeID: 7}
 
@@ -176,8 +176,7 @@ func TestControlLoop_RejectsNmapPortRangeBypass(t *testing.T) {
 }
 
 func TestControlLoop_NormalizesIPListEntries(t *testing.T) {
-	// Arrange: scoped IPv6 + link-local IPv6 should be skipped; canonical
-	// IPv6 spelling should be preserved and probed.
+	// Arrange
 	disc := &stubDiscoverer{
 		probes: map[string]*pb.DiscoveredDeviceReport{
 			"2001:db8::1|4028": {DeviceIdentifier: "auto:v6", IpAddress: "2001:db8::1", Port: "4028", UrlScheme: "http"},
@@ -218,8 +217,7 @@ func TestControlLoop_NormalizesIPListEntries(t *testing.T) {
 }
 
 func TestControlLoop_RejectsAllUnusableIPs(t *testing.T) {
-	// Arrange: every entry is unusable; agent must ack failure rather than
-	// silently returning zero reports.
+	// Arrange
 	cmd := &RunCmd{discoverer: &stubDiscoverer{}}
 	state := &fleetnodebootstrap.State{FleetNodeID: 7}
 

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
+	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
+	"github.com/block/proto-fleet/server/internal/fleetnodebootstrap"
+)
+
+func TestControlLoop_RunsProbesAndReports(t *testing.T) {
+	// Arrange
+	disc := &stubDiscoverer{
+		probes: map[string]*pb.DiscoveredDeviceReport{
+			"10.0.0.5|4028": {DeviceIdentifier: "auto:1", IpAddress: "10.0.0.5", Port: "4028", UrlScheme: "http"},
+		},
+	}
+	cmd := &RunCmd{discoverer: disc}
+	state := &fleetnodebootstrap.State{FleetNodeID: 7}
+
+	fake := &controlFakeGateway{}
+	fake.queue(mustMarshal(t, &pairingpb.DiscoverRequest{
+		Mode: &pairingpb.DiscoverRequest_IpList{
+			IpList: &pairingpb.IPListModeRequest{IpAddresses: []string{"10.0.0.5"}, Ports: []string{"4028"}},
+		},
+	}))
+	client := newControlClient(t, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Act
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.runControlLoop(ctx, client, state, discardLogger(t))
+	}()
+
+	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 3*time.Second, 20*time.Millisecond)
+	cancel()
+	<-done
+
+	// Assert
+	acks := fake.acksCopy()
+	require.Len(t, acks, 1)
+	assert.True(t, acks[0].GetSucceeded())
+	require.Len(t, fake.reportsCopy(), 1)
+	assert.Equal(t, "auto:1", fake.reportsCopy()[0].GetDevices()[0].GetDeviceIdentifier())
+	commandID := acks[0].GetCommandId()
+	assert.Equal(t, commandID, fake.reportsCopy()[0].GetCommandId())
+}
+
+func TestControlLoop_RejectsNonIPListMode(t *testing.T) {
+	// Arrange
+	cmd := &RunCmd{discoverer: &stubDiscoverer{}}
+	state := &fleetnodebootstrap.State{FleetNodeID: 7}
+
+	fake := &controlFakeGateway{}
+	fake.queue(mustMarshal(t, &pairingpb.DiscoverRequest{
+		Mode: &pairingpb.DiscoverRequest_Mdns{Mdns: &pairingpb.MDNSModeRequest{}},
+	}))
+	client := newControlClient(t, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Act
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.runControlLoop(ctx, client, state, discardLogger(t))
+	}()
+	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 3*time.Second, 20*time.Millisecond)
+	cancel()
+	<-done
+
+	// Assert
+	acks := fake.acksCopy()
+	require.Len(t, acks, 1)
+	assert.False(t, acks[0].GetSucceeded())
+	assert.Contains(t, acks[0].GetErrorMessage(), "IPList")
+	assert.Empty(t, fake.reportsCopy())
+}
+
+func TestControlLoop_ReconnectsAfterStreamEOF(t *testing.T) {
+	// Arrange
+	cmd := &RunCmd{discoverer: &stubDiscoverer{}}
+	state := &fleetnodebootstrap.State{FleetNodeID: 9}
+
+	fake := &controlFakeGateway{}
+	fake.setBehavior(controlFakeBehavior{closeAfterAccepted: true})
+	client := newControlClient(t, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	// Act
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.runControlLoop(ctx, client, state, discardLogger(t))
+	}()
+
+	require.Eventually(t, func() bool { return fake.helloCount() >= 2 }, 3*time.Second, 50*time.Millisecond)
+	cancel()
+	<-done
+
+	// Assert: the loop reconnected at least once.
+	assert.GreaterOrEqual(t, fake.helloCount(), 2)
+}
+
+type stubDiscoverer struct {
+	probes map[string]*pb.DiscoveredDeviceReport
+}
+
+func (s *stubDiscoverer) Probe(_ context.Context, ip, port string) (*pb.DiscoveredDeviceReport, error) {
+	if r, ok := s.probes[ip+"|"+port]; ok {
+		return r, nil
+	}
+	return nil, nil
+}
+
+func (s *stubDiscoverer) DefaultDiscoveryPorts(_ context.Context) []string {
+	return []string{"4028"}
+}
+
+type controlFakeBehavior struct {
+	closeAfterAccepted bool
+}
+
+type controlFakeGateway struct {
+	fleetnodegatewayv1connect.UnimplementedFleetNodeGatewayServiceHandler
+
+	mu       sync.Mutex
+	pending  [][]byte
+	hellos   int32
+	acks     []*pb.ControlAck
+	reports  []*pb.ReportDiscoveredDevicesRequest
+	behavior controlFakeBehavior
+}
+
+func (f *controlFakeGateway) queue(payload []byte) {
+	f.mu.Lock()
+	f.pending = append(f.pending, payload)
+	f.mu.Unlock()
+}
+
+func (f *controlFakeGateway) setBehavior(b controlFakeBehavior) {
+	f.mu.Lock()
+	f.behavior = b
+	f.mu.Unlock()
+}
+
+func (f *controlFakeGateway) ackCount() int { f.mu.Lock(); defer f.mu.Unlock(); return len(f.acks) }
+func (f *controlFakeGateway) acksCopy() []*pb.ControlAck {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*pb.ControlAck, len(f.acks))
+	copy(out, f.acks)
+	return out
+}
+func (f *controlFakeGateway) reportsCopy() []*pb.ReportDiscoveredDevicesRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*pb.ReportDiscoveredDevicesRequest, len(f.reports))
+	copy(out, f.reports)
+	return out
+}
+func (f *controlFakeGateway) helloCount() int { return int(atomic.LoadInt32(&f.hellos)) }
+
+func (f *controlFakeGateway) ReportDiscoveredDevices(_ context.Context, req *connect.Request[pb.ReportDiscoveredDevicesRequest]) (*connect.Response[pb.ReportDiscoveredDevicesResponse], error) {
+	f.mu.Lock()
+	f.reports = append(f.reports, req.Msg)
+	f.mu.Unlock()
+	return connect.NewResponse(&pb.ReportDiscoveredDevicesResponse{AcceptedCount: int64(len(req.Msg.GetDevices()))}), nil
+}
+
+func (f *controlFakeGateway) UploadHeartbeat(_ context.Context, _ *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error) {
+	return connect.NewResponse(&pb.UploadHeartbeatResponse{ReceivedAt: timestamppb.Now()}), nil
+}
+
+func (f *controlFakeGateway) ControlStream(ctx context.Context, stream *connect.BidiStream[pb.ControlStreamRequest, pb.ControlStreamResponse]) error {
+	first, err := stream.Receive()
+	if err != nil {
+		return fmt.Errorf("recv hello: %w", err)
+	}
+	if first.GetHello() == nil {
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("expected hello"))
+	}
+	atomic.AddInt32(&f.hellos, 1)
+
+	if err := stream.Send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Accepted{Accepted: &pb.ControlAccepted{ServerTime: timestamppb.Now()}}}); err != nil {
+		return fmt.Errorf("send accepted: %w", err)
+	}
+
+	f.mu.Lock()
+	closeNow := f.behavior.closeAfterAccepted
+	pending := f.pending
+	f.pending = nil
+	f.mu.Unlock()
+	if closeNow {
+		return nil
+	}
+
+	for _, payload := range pending {
+		if err := stream.Send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Command{Command: &pb.ControlCommand{
+			CommandId: "test-cmd",
+			Payload:   payload,
+		}}}); err != nil {
+			return fmt.Errorf("send command: %w", err)
+		}
+	}
+
+	type recvResult struct {
+		msg *pb.ControlStreamRequest
+		err error
+	}
+	incoming := make(chan recvResult, 1)
+	go func() {
+		for {
+			msg, err := stream.Receive()
+			incoming <- recvResult{msg: msg, err: err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case r := <-incoming:
+			if r.err != nil {
+				if errors.Is(r.err, io.EOF) {
+					return nil
+				}
+				return r.err
+			}
+			if ack := r.msg.GetAck(); ack != nil {
+				f.mu.Lock()
+				f.acks = append(f.acks, ack)
+				f.mu.Unlock()
+			}
+		}
+	}
+}
+
+func newControlClient(t *testing.T, fake *controlFakeGateway) gatewayClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
+	mux.Handle(path, h)
+	srv := httptest.NewUnstartedServer(h2c.NewHandler(mux, &http2.Server{}))
+	srv.Start()
+	t.Cleanup(srv.Close)
+	httpClient := &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
+			},
+		},
+	}
+	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(httpClient, srv.URL, connect.WithGRPC())
+}
+
+func discardLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.DiscardHandler)
+}
+
+func mustMarshal(t *testing.T, m proto.Message) []byte {
+	t.Helper()
+	b, err := proto.Marshal(m)
+	require.NoError(t, err)
+	return b
+}

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -70,7 +70,7 @@ func TestControlLoop_RunsProbesAndReports(t *testing.T) {
 	assert.Equal(t, commandID, fake.reportsCopy()[0].GetCommandId())
 }
 
-func TestControlLoop_RejectsNonIPListMode(t *testing.T) {
+func TestControlLoop_RejectsMDNSMode(t *testing.T) {
 	// Arrange
 	cmd := &RunCmd{discoverer: &stubDiscoverer{}}
 	state := &fleetnodebootstrap.State{FleetNodeID: 7}
@@ -97,7 +97,7 @@ func TestControlLoop_RejectsNonIPListMode(t *testing.T) {
 	acks := fake.acksCopy()
 	require.Len(t, acks, 1)
 	assert.False(t, acks[0].GetSucceeded())
-	assert.Contains(t, acks[0].GetErrorMessage(), "IPList")
+	assert.Contains(t, acks[0].GetErrorMessage(), "mdns")
 	assert.Empty(t, fake.reportsCopy())
 }
 

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -97,6 +97,75 @@ func TestControlLoop_RejectsMDNSMode(t *testing.T) {
 	assert.Empty(t, fake.reportsCopy())
 }
 
+func TestControlLoop_RejectsTooManyIPs(t *testing.T) {
+	// Arrange
+	cmd := &RunCmd{discoverer: &stubDiscoverer{}}
+	state := &fleetnodebootstrap.State{FleetNodeID: 7}
+
+	tooMany := make([]string, maxIPsPerCommand+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("10.0.%d.%d", i/256, i%256)
+	}
+	fake := &controlFakeGateway{}
+	fake.queue(mustMarshal(t, &pairingpb.DiscoverRequest{
+		Mode: &pairingpb.DiscoverRequest_IpList{
+			IpList: &pairingpb.IPListModeRequest{IpAddresses: tooMany, Ports: []string{"4028"}},
+		},
+	}))
+	client := newControlClient(t, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Act
+	done := make(chan error, 1)
+	go func() { done <- cmd.runControlLoop(ctx, client, state, discardLogger(t)) }()
+	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 3*time.Second, 20*time.Millisecond)
+	cancel()
+	<-done
+
+	// Assert
+	acks := fake.acksCopy()
+	require.Len(t, acks, 1)
+	assert.False(t, acks[0].GetSucceeded())
+	assert.Contains(t, acks[0].GetErrorMessage(), "too many ip_addresses")
+	assert.Empty(t, fake.reportsCopy())
+}
+
+func TestControlLoop_RejectsTooManyPorts(t *testing.T) {
+	// Arrange
+	cmd := &RunCmd{discoverer: &stubDiscoverer{}}
+	state := &fleetnodebootstrap.State{FleetNodeID: 7}
+
+	ports := make([]string, maxPortsPerIP+1)
+	for i := range ports {
+		ports[i] = fmt.Sprintf("%d", 4000+i)
+	}
+	fake := &controlFakeGateway{}
+	fake.queue(mustMarshal(t, &pairingpb.DiscoverRequest{
+		Mode: &pairingpb.DiscoverRequest_IpList{
+			IpList: &pairingpb.IPListModeRequest{IpAddresses: []string{"10.0.0.1"}, Ports: ports},
+		},
+	}))
+	client := newControlClient(t, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Act
+	done := make(chan error, 1)
+	go func() { done <- cmd.runControlLoop(ctx, client, state, discardLogger(t)) }()
+	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 3*time.Second, 20*time.Millisecond)
+	cancel()
+	<-done
+
+	// Assert
+	acks := fake.acksCopy()
+	require.Len(t, acks, 1)
+	assert.False(t, acks[0].GetSucceeded())
+	assert.Contains(t, acks[0].GetErrorMessage(), "too many ports")
+}
+
 func TestControlLoop_ReconnectsAfterStreamEOF(t *testing.T) {
 	// Arrange
 	cmd := &RunCmd{discoverer: &stubDiscoverer{}}

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -97,6 +97,83 @@ func TestControlLoop_RejectsMDNSMode(t *testing.T) {
 	assert.Empty(t, fake.reportsCopy())
 }
 
+func TestControlLoop_NormalizesIPListEntries(t *testing.T) {
+	// Arrange: scoped IPv6 + link-local IPv6 should be skipped; canonical
+	// IPv6 spelling should be preserved and probed.
+	disc := &stubDiscoverer{
+		probes: map[string]*pb.DiscoveredDeviceReport{
+			"2001:db8::1|4028": {DeviceIdentifier: "auto:v6", IpAddress: "2001:db8::1", Port: "4028", UrlScheme: "http"},
+		},
+	}
+	cmd := &RunCmd{discoverer: disc}
+	state := &fleetnodebootstrap.State{FleetNodeID: 7}
+
+	fake := &controlFakeGateway{}
+	fake.queue(mustMarshal(t, &pairingpb.DiscoverRequest{
+		Mode: &pairingpb.DiscoverRequest_IpList{
+			IpList: &pairingpb.IPListModeRequest{
+				IpAddresses: []string{"fe80::1%eth0", "fe80::1", "2001:0DB8::1"},
+				Ports:       []string{"4028"},
+			},
+		},
+	}))
+	client := newControlClient(t, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Act
+	done := make(chan error, 1)
+	go func() { done <- cmd.runControlLoop(ctx, client, state, discardLogger(t)) }()
+	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 3*time.Second, 20*time.Millisecond)
+	cancel()
+	<-done
+
+	// Assert
+	acks := fake.acksCopy()
+	require.Len(t, acks, 1)
+	assert.True(t, acks[0].GetSucceeded(), "ack=%+v", acks[0])
+	reports := fake.reportsCopy()
+	require.Len(t, reports, 1)
+	require.Len(t, reports[0].GetDevices(), 1)
+	assert.Equal(t, "2001:db8::1", reports[0].GetDevices()[0].GetIpAddress())
+}
+
+func TestControlLoop_RejectsAllUnusableIPs(t *testing.T) {
+	// Arrange: every entry is unusable; agent must ack failure rather than
+	// silently returning zero reports.
+	cmd := &RunCmd{discoverer: &stubDiscoverer{}}
+	state := &fleetnodebootstrap.State{FleetNodeID: 7}
+
+	fake := &controlFakeGateway{}
+	fake.queue(mustMarshal(t, &pairingpb.DiscoverRequest{
+		Mode: &pairingpb.DiscoverRequest_IpList{
+			IpList: &pairingpb.IPListModeRequest{
+				IpAddresses: []string{"fe80::1%eth0", "fe80::1"},
+				Ports:       []string{"4028"},
+			},
+		},
+	}))
+	client := newControlClient(t, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Act
+	done := make(chan error, 1)
+	go func() { done <- cmd.runControlLoop(ctx, client, state, discardLogger(t)) }()
+	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 3*time.Second, 20*time.Millisecond)
+	cancel()
+	<-done
+
+	// Assert
+	acks := fake.acksCopy()
+	require.Len(t, acks, 1)
+	assert.False(t, acks[0].GetSucceeded())
+	assert.Contains(t, acks[0].GetErrorMessage(), "no usable ip_addresses")
+	assert.Empty(t, fake.reportsCopy())
+}
+
 func TestControlLoop_RejectsTooManyIPs(t *testing.T) {
 	// Arrange
 	cmd := &RunCmd{discoverer: &stubDiscoverer{}}

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -2,14 +2,11 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -18,8 +15,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -27,6 +22,7 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	"github.com/block/proto-fleet/server/internal/fleetnodebootstrap"
+	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
 func TestControlLoop_RunsProbesAndReports(t *testing.T) {
@@ -269,19 +265,8 @@ func newControlClient(t *testing.T, fake *controlFakeGateway) gatewayClient {
 	mux := http.NewServeMux()
 	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
 	mux.Handle(path, h)
-	srv := httptest.NewUnstartedServer(h2c.NewHandler(mux, &http2.Server{}))
-	srv.Start()
-	t.Cleanup(srv.Close)
-	httpClient := &http.Client{
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-				var d net.Dialer
-				return d.DialContext(ctx, network, addr)
-			},
-		},
-	}
-	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(httpClient, srv.URL, connect.WithGRPC())
+	srv := testutil.NewH2CServer(t, mux)
+	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(testutil.NewH2CClient(), srv.URL, connect.WithGRPC())
 }
 
 func discardLogger(t *testing.T) *slog.Logger {

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -97,6 +97,84 @@ func TestControlLoop_RejectsMDNSMode(t *testing.T) {
 	assert.Empty(t, fake.reportsCopy())
 }
 
+func TestResolveAndValidatePorts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		supplied  []string
+		defaults  []string
+		want      []string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "valid single port", supplied: []string{"4028"}, want: []string{"4028"}},
+		{name: "uses defaults when empty", supplied: nil, defaults: []string{"80", "4028"}, want: []string{"80", "4028"}},
+		{name: "rejects range bypass", supplied: []string{"1-65535"}, wantErr: true, errSubstr: "invalid port"},
+		{name: "rejects comma bypass", supplied: []string{"80,443,8080"}, wantErr: true, errSubstr: "invalid port"},
+		{name: "rejects protocol prefix", supplied: []string{"T:80"}, wantErr: true, errSubstr: "invalid port"},
+		{name: "rejects whitespace", supplied: []string{" 4028 "}, wantErr: true, errSubstr: "invalid port"},
+		{name: "rejects service name", supplied: []string{"http"}, wantErr: true, errSubstr: "invalid port"},
+		{name: "rejects zero", supplied: []string{"0"}, wantErr: true, errSubstr: "invalid port"},
+		{name: "rejects 65536", supplied: []string{"65536"}, wantErr: true, errSubstr: "invalid port"},
+		{name: "rejects negative", supplied: []string{"-1"}, wantErr: true, errSubstr: "invalid port"},
+		{name: "rejects over-cap count", supplied: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"}, wantErr: true, errSubstr: "too many ports"},
+		{name: "dedupes", supplied: []string{"80", "80", "4028"}, want: []string{"80", "4028"}},
+		{name: "rejects all-empty when no defaults", supplied: nil, defaults: []string{}, wantErr: true, errSubstr: "non-empty"},
+		{name: "validates plugin defaults", supplied: nil, defaults: []string{"1-65535"}, wantErr: true, errSubstr: "invalid port"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			r := &RunCmd{discoverer: &stubDiscoverer{ports: tc.defaults}}
+
+			// Act
+			got, err := r.resolveAndValidatePorts(context.Background(), tc.supplied)
+
+			// Assert
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestControlLoop_RejectsNmapPortRangeBypass(t *testing.T) {
+	// Arrange: one entry, but it expands to 65k ports inside nmap.
+	cmd := &RunCmd{discoverer: &stubDiscoverer{}}
+	state := &fleetnodebootstrap.State{FleetNodeID: 7}
+
+	fake := &controlFakeGateway{}
+	fake.queue(mustMarshal(t, &pairingpb.DiscoverRequest{
+		Mode: &pairingpb.DiscoverRequest_Nmap{
+			Nmap: &pairingpb.NmapModeRequest{Target: "10.0.0.1", Ports: []string{"1-65535"}},
+		},
+	}))
+	client := newControlClient(t, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Act
+	done := make(chan error, 1)
+	go func() { done <- cmd.runControlLoop(ctx, client, state, discardLogger(t)) }()
+	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 3*time.Second, 20*time.Millisecond)
+	cancel()
+	<-done
+
+	// Assert
+	acks := fake.acksCopy()
+	require.Len(t, acks, 1)
+	assert.False(t, acks[0].GetSucceeded())
+	assert.Contains(t, acks[0].GetErrorMessage(), "invalid port")
+}
+
 func TestControlLoop_NormalizesIPListEntries(t *testing.T) {
 	// Arrange: scoped IPv6 + link-local IPv6 should be skipped; canonical
 	// IPv6 spelling should be preserved and probed.
@@ -271,6 +349,7 @@ func TestControlLoop_ReconnectsAfterStreamEOF(t *testing.T) {
 
 type stubDiscoverer struct {
 	probes map[string]*pb.DiscoveredDeviceReport
+	ports  []string
 }
 
 func (s *stubDiscoverer) Probe(_ context.Context, ip, port string) (*pb.DiscoveredDeviceReport, error) {
@@ -281,6 +360,9 @@ func (s *stubDiscoverer) Probe(_ context.Context, ip, port string) (*pb.Discover
 }
 
 func (s *stubDiscoverer) DefaultDiscoveryPorts(_ context.Context) []string {
+	if s.ports != nil {
+		return s.ports
+	}
 	return []string{"4028"}
 }
 

--- a/server/cmd/fleetnode/fake_gateway_test.go
+++ b/server/cmd/fleetnode/fake_gateway_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
@@ -125,7 +127,8 @@ func newFakeServer(t *testing.T, fake *fakeFleetNodeGateway) *httptest.Server {
 	mux := http.NewServeMux()
 	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
 	mux.Handle(path, h)
-	srv := httptest.NewServer(mux)
+	srv := httptest.NewUnstartedServer(h2c.NewHandler(mux, &http2.Server{}))
+	srv.Start()
 	t.Cleanup(srv.Close)
 	return srv
 }

--- a/server/cmd/fleetnode/fake_gateway_test.go
+++ b/server/cmd/fleetnode/fake_gateway_test.go
@@ -12,14 +12,12 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
-
 	"github.com/block/proto-fleet/server/internal/fleetnodebootstrap"
+	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
 type fakeFleetNodeGateway struct {
@@ -127,8 +125,5 @@ func newFakeServer(t *testing.T, fake *fakeFleetNodeGateway) *httptest.Server {
 	mux := http.NewServeMux()
 	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
 	mux.Handle(path, h)
-	srv := httptest.NewUnstartedServer(h2c.NewHandler(mux, &http2.Server{}))
-	srv.Start()
-	t.Cleanup(srv.Close)
-	return srv
+	return testutil.NewH2CServer(t, mux)
 }

--- a/server/cmd/fleetnode/nmap.go
+++ b/server/cmd/fleetnode/nmap.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,7 +17,46 @@ import (
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
+	"github.com/block/proto-fleet/server/internal/domain/netutil"
 )
+
+// Targets reach nmap as argv (no shell), so the risk is nmap interpreting a
+// leading dash as a flag (-iL, -oN -> arbitrary file read/write on the agent
+// host). The range regex discriminates "A.B.C.D-N" from hostnames-with-dashes
+// like "miner-01.lan" which the hostname grammar must still accept.
+var (
+	nmapHostnameRE  = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*$`)
+	nmapIPv4RangeRE = regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}-\d{1,3}$`)
+	nmapAllowedRE   = regexp.MustCompile(`^[A-Za-z0-9.:/-]+$`)
+)
+
+func validateNmapTarget(s string) error {
+	if s == "" {
+		return errors.New("nmap target is required")
+	}
+	if strings.HasPrefix(s, "-") {
+		return fmt.Errorf("nmap target %q must not start with '-'", s)
+	}
+	if !nmapAllowedRE.MatchString(s) {
+		return fmt.Errorf("nmap target %q contains disallowed characters", s)
+	}
+	if _, err := netutil.ParseCIDROrIP(s); err == nil {
+		return nil
+	}
+	if nmapIPv4RangeRE.MatchString(s) {
+		head, tail, _ := strings.Cut(s, "-")
+		ip := net.ParseIP(head)
+		n, perr := strconv.Atoi(tail)
+		if ip != nil && ip.To4() != nil && perr == nil && n >= 0 && n <= 255 {
+			return nil
+		}
+		return fmt.Errorf("nmap target %q has invalid IPv4 range", s)
+	}
+	if nmapHostnameRE.MatchString(s) {
+		return nil
+	}
+	return fmt.Errorf("nmap target %q is not a valid IP, CIDR, range, or hostname", s)
+}
 
 const (
 	nmapScanTimeout       = 600 * time.Second
@@ -24,25 +66,16 @@ const (
 	nmapDefaultBinaryName = "nmap"
 )
 
-// Returns an absolute path when found; otherwise "nmap" -- the Ullaakut
-// scanner's exec.LookPath resolves a bare name from PATH at scan time.
-func resolveNmapPath(flag, exeDir string) (string, error) {
-	if flag != "" {
-		if !filepath.IsAbs(flag) {
-			return "", fmt.Errorf("--nmap-path must be an absolute path, got %q", flag)
-		}
-		if err := checkExecutableFile(flag); err != nil {
-			return "", fmt.Errorf("--nmap-path %s: %w", flag, err)
-		}
-		return flag, nil
-	}
+// PATH fallback keeps dev machines (brew install nmap) working without the
+// installer-staged layout.
+func resolveNmapPath(exeDir string) string {
 	if exeDir != "" {
 		candidate := filepath.Join(exeDir, nmapDefaultBinaryName)
 		if err := checkExecutableFile(candidate); err == nil {
-			return candidate, nil
+			return candidate
 		}
 	}
-	return nmapDefaultBinaryName, nil
+	return nmapDefaultBinaryName
 }
 
 func checkExecutableFile(path string) error {
@@ -61,8 +94,8 @@ func checkExecutableFile(path string) error {
 
 func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRequest, logger *slog.Logger) ([]*pb.DiscoveredDeviceReport, error) {
 	target := strings.TrimSpace(req.GetTarget())
-	if target == "" {
-		return nil, errors.New("nmap target is required")
+	if err := validateNmapTarget(target); err != nil {
+		return nil, err
 	}
 	ports := req.GetPorts()
 	if len(ports) == 0 {

--- a/server/cmd/fleetnode/nmap.go
+++ b/server/cmd/fleetnode/nmap.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Ullaakut/nmap/v3"
@@ -25,15 +24,10 @@ const (
 	nmapDefaultBinaryName = "nmap"
 )
 
-// resolveNmapPath picks the nmap binary path.
-//
-// Explicit flag: must be an absolute path that points at an executable file.
-// No flag:       prefer <exeDir>/nmap (bundled-with-installer layout) when
-//
-//	it exists and is executable; otherwise return "nmap" so the
-//	Ullaakut library + exec.LookPath resolve it from PATH at
-//	scan time. Returning a name (not a path) here is the same
-//	contract the underlying library uses internally.
+// resolveNmapPath returns either an absolute path (explicit flag or
+// binary-adjacent default) or the bare name "nmap" so Ullaakut's exec.LookPath
+// resolves from PATH at scan time. Bare name is a deliberate contract with the
+// library, not an oversight.
 func resolveNmapPath(flag, exeDir string) (string, error) {
 	if flag != "" {
 		if !filepath.IsAbs(flag) {
@@ -67,9 +61,6 @@ func checkExecutableFile(path string) error {
 	return nil
 }
 
-// runNmapDiscovery executes an nmap scan against the request's target and
-// ports, then runs the plugin Probe on every open host:port the scan
-// reports. Returns reports the caller streams via ReportDiscoveredDevices.
 func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRequest, logger *slog.Logger) ([]*pb.DiscoveredDeviceReport, error) {
 	target := strings.TrimSpace(req.GetTarget())
 	if target == "" {
@@ -109,8 +100,7 @@ func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRe
 		return nil, nil
 	}
 
-	type hostPort struct{ ip, port string }
-	var open []hostPort
+	var open []endpoint
 	for _, host := range result.Hosts {
 		var ip string
 		for _, a := range host.Addresses {
@@ -123,48 +113,12 @@ func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRe
 			continue
 		}
 		for _, p := range host.Ports {
-			if p.Status() == "open" {
-				open = append(open, hostPort{ip: ip, port: fmt.Sprintf("%d", p.ID)})
+			if p.Status() == nmap.Open {
+				open = append(open, endpoint{ip: ip, port: fmt.Sprintf("%d", p.ID)})
 			}
 		}
 	}
 	logger.Info("nmap scan complete", "open_endpoints", len(open))
 
-	// Probe each open endpoint via the plugin manager. Mirror runProbes'
-	// concurrency model so a flood of open hosts can't fork the plugin
-	// manager into the ground.
-	var (
-		mu  sync.Mutex
-		out []*pb.DiscoveredDeviceReport
-		wg  sync.WaitGroup
-	)
-	sem := make(chan struct{}, nmapProbeConcurrency)
-	for _, hp := range open {
-		select {
-		case sem <- struct{}{}:
-		case <-ctx.Done():
-			wg.Wait()
-			return out, nil
-		}
-		wg.Add(1)
-		go func(ip, port string) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			probeCtx, cancel := context.WithTimeout(ctx, perProbeTimeout)
-			defer cancel()
-			report, err := r.discoverer.Probe(probeCtx, ip, port)
-			if err != nil {
-				logger.Debug("nmap follow-up probe failed", "ip", ip, "port", port, "err", err)
-				return
-			}
-			if report == nil || report.GetDeviceIdentifier() == "" {
-				return
-			}
-			mu.Lock()
-			out = append(out, report)
-			mu.Unlock()
-		}(hp.ip, hp.port)
-	}
-	wg.Wait()
-	return out, nil
+	return fanOutProbes(ctx, open, nmapProbeConcurrency, r.discoverer.Probe, logger), nil
 }

--- a/server/cmd/fleetnode/nmap.go
+++ b/server/cmd/fleetnode/nmap.go
@@ -24,10 +24,8 @@ const (
 	nmapDefaultBinaryName = "nmap"
 )
 
-// resolveNmapPath returns either an absolute path (explicit flag or
-// binary-adjacent default) or the bare name "nmap" so Ullaakut's exec.LookPath
-// resolves from PATH at scan time. Bare name is a deliberate contract with the
-// library, not an oversight.
+// Returns an absolute path when found; otherwise "nmap" -- the Ullaakut
+// scanner's exec.LookPath resolves a bare name from PATH at scan time.
 func resolveNmapPath(flag, exeDir string) (string, error) {
 	if flag != "" {
 		if !filepath.IsAbs(flag) {

--- a/server/cmd/fleetnode/nmap.go
+++ b/server/cmd/fleetnode/nmap.go
@@ -118,7 +118,7 @@ func detectIPv6Target(ctx context.Context, target string) (useIPv6 bool, err err
 	return true, nil
 }
 
-func (r *RunCmd) buildNmapOptions(ctx context.Context, req *pairingpb.NmapModeRequest) ([]nmap.Option, error) {
+func (r *RunCmd) buildNmapOptions(ctx context.Context, req *pairingpb.NmapModeRequest, ports []string) ([]nmap.Option, error) {
 	target := strings.TrimSpace(req.GetTarget())
 	if err := validateNmapTarget(target); err != nil {
 		return nil, err
@@ -126,10 +126,6 @@ func (r *RunCmd) buildNmapOptions(ctx context.Context, req *pairingpb.NmapModeRe
 	useIPv6, err := detectIPv6Target(ctx, target)
 	if err != nil {
 		return nil, err
-	}
-	ports := req.GetPorts()
-	if len(ports) == 0 {
-		ports = r.discoverer.DefaultDiscoveryPorts(ctx)
 	}
 	if len(ports) == 0 {
 		return nil, errors.New("no ports to scan; pass ports or load discovery plugins")
@@ -151,8 +147,8 @@ func (r *RunCmd) buildNmapOptions(ctx context.Context, req *pairingpb.NmapModeRe
 	return opts, nil
 }
 
-func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRequest, logger *slog.Logger) ([]*pb.DiscoveredDeviceReport, error) {
-	opts, err := r.buildNmapOptions(ctx, req)
+func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRequest, ports []string, logger *slog.Logger) ([]*pb.DiscoveredDeviceReport, error) {
+	opts, err := r.buildNmapOptions(ctx, req, ports)
 	if err != nil {
 		return nil, err
 	}

--- a/server/cmd/fleetnode/nmap.go
+++ b/server/cmd/fleetnode/nmap.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -92,18 +93,17 @@ func checkExecutableFile(path string) error {
 	return nil
 }
 
-// detectIPv6Target mirrors pairing.validateNmapTargets: literal IPv6
-// addresses and IPv6-only hostname resolutions need -6; IPv6 CIDR is
-// rejected because nmap subnet scans don't make sense for 2^64 hosts.
+// IPv6 CIDR is rejected because nmap subnet scans don't make sense for
+// 2^64 hosts. Literal IPv6 and IPv6-only hostname resolutions need -6.
 func detectIPv6Target(ctx context.Context, target string) (useIPv6 bool, err error) {
-	if _, ipNet, cerr := net.ParseCIDR(target); cerr == nil {
-		if _, bits := ipNet.Mask.Size(); bits == 128 {
+	if prefix, perr := netip.ParsePrefix(target); perr == nil {
+		if prefix.Addr().Is6() {
 			return false, errors.New("IPv6 CIDR is not supported; use IpList for IPv6 devices")
 		}
 		return false, nil
 	}
-	if ip := net.ParseIP(target); ip != nil {
-		return ip.To4() == nil, nil
+	if addr, perr := netip.ParseAddr(target); perr == nil {
+		return addr.Is6(), nil
 	}
 	addrs, lookupErr := net.DefaultResolver.LookupIPAddr(ctx, target)
 	if lookupErr != nil || len(addrs) == 0 {
@@ -126,9 +126,6 @@ func (r *RunCmd) buildNmapOptions(ctx context.Context, req *pairingpb.NmapModeRe
 	useIPv6, err := detectIPv6Target(ctx, target)
 	if err != nil {
 		return nil, err
-	}
-	if len(ports) == 0 {
-		return nil, errors.New("no ports to scan; pass ports or load discovery plugins")
 	}
 	opts := []nmap.Option{
 		nmap.WithBinaryPath(r.nmapPath),

--- a/server/cmd/fleetnode/nmap.go
+++ b/server/cmd/fleetnode/nmap.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Ullaakut/nmap/v3"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
+)
+
+const (
+	nmapScanTimeout       = 600 * time.Second
+	nmapHostTimeoutMs     = 10000
+	nmapMinRTTMs          = 100
+	nmapProbeConcurrency  = 16
+	nmapDefaultBinaryName = "nmap"
+)
+
+// resolveNmapPath picks the nmap binary path.
+//
+// Explicit flag: must be an absolute path that points at an executable file.
+// No flag:       prefer <exeDir>/nmap (bundled-with-installer layout) when
+//
+//	it exists and is executable; otherwise return "nmap" so the
+//	Ullaakut library + exec.LookPath resolve it from PATH at
+//	scan time. Returning a name (not a path) here is the same
+//	contract the underlying library uses internally.
+func resolveNmapPath(flag, exeDir string) (string, error) {
+	if flag != "" {
+		if !filepath.IsAbs(flag) {
+			return "", fmt.Errorf("--nmap-path must be an absolute path, got %q", flag)
+		}
+		if err := checkExecutableFile(flag); err != nil {
+			return "", fmt.Errorf("--nmap-path %s: %w", flag, err)
+		}
+		return flag, nil
+	}
+	if exeDir != "" {
+		candidate := filepath.Join(exeDir, nmapDefaultBinaryName)
+		if err := checkExecutableFile(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return nmapDefaultBinaryName, nil
+}
+
+func checkExecutableFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat: %w", err)
+	}
+	if info.IsDir() {
+		return errors.New("is a directory, not a file")
+	}
+	if info.Mode()&0o111 == 0 {
+		return errors.New("not executable")
+	}
+	return nil
+}
+
+// runNmapDiscovery executes an nmap scan against the request's target and
+// ports, then runs the plugin Probe on every open host:port the scan
+// reports. Returns reports the caller streams via ReportDiscoveredDevices.
+func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRequest, logger *slog.Logger) ([]*pb.DiscoveredDeviceReport, error) {
+	target := strings.TrimSpace(req.GetTarget())
+	if target == "" {
+		return nil, errors.New("nmap target is required")
+	}
+	ports := req.GetPorts()
+	if len(ports) == 0 {
+		ports = r.discoverer.DefaultDiscoveryPorts(ctx)
+	}
+	if len(ports) == 0 {
+		return nil, errors.New("no ports to scan; pass ports or load discovery plugins")
+	}
+
+	scanCtx, cancel := context.WithTimeout(ctx, nmapScanTimeout)
+	defer cancel()
+
+	opts := []nmap.Option{
+		nmap.WithBinaryPath(r.nmapPath),
+		nmap.WithTargets(target),
+		nmap.WithPorts(strings.Join(ports, ",")),
+		nmap.WithUnique(),
+		nmap.WithDisabledDNSResolution(),
+		nmap.WithTimingTemplate(nmap.TimingAggressive),
+		nmap.WithMaxRetries(1),
+		nmap.WithHostTimeout(time.Duration(nmapHostTimeoutMs) * time.Millisecond),
+		nmap.WithMinRTTTimeout(time.Duration(nmapMinRTTMs) * time.Millisecond),
+	}
+	scanner, err := nmap.NewScanner(scanCtx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create nmap scanner: %w", err)
+	}
+	result, _, err := scanner.Run()
+	if err != nil {
+		return nil, fmt.Errorf("nmap scan failed: %w", err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+
+	type hostPort struct{ ip, port string }
+	var open []hostPort
+	for _, host := range result.Hosts {
+		var ip string
+		for _, a := range host.Addresses {
+			if a.AddrType == "ipv4" || a.AddrType == "ipv6" {
+				ip = a.Addr
+				break
+			}
+		}
+		if ip == "" {
+			continue
+		}
+		for _, p := range host.Ports {
+			if p.Status() == "open" {
+				open = append(open, hostPort{ip: ip, port: fmt.Sprintf("%d", p.ID)})
+			}
+		}
+	}
+	logger.Info("nmap scan complete", "open_endpoints", len(open))
+
+	// Probe each open endpoint via the plugin manager. Mirror runProbes'
+	// concurrency model so a flood of open hosts can't fork the plugin
+	// manager into the ground.
+	var (
+		mu  sync.Mutex
+		out []*pb.DiscoveredDeviceReport
+		wg  sync.WaitGroup
+	)
+	sem := make(chan struct{}, nmapProbeConcurrency)
+	for _, hp := range open {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return out, nil
+		}
+		wg.Add(1)
+		go func(ip, port string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			probeCtx, cancel := context.WithTimeout(ctx, perProbeTimeout)
+			defer cancel()
+			report, err := r.discoverer.Probe(probeCtx, ip, port)
+			if err != nil {
+				logger.Debug("nmap follow-up probe failed", "ip", ip, "port", port, "err", err)
+				return
+			}
+			if report == nil || report.GetDeviceIdentifier() == "" {
+				return
+			}
+			mu.Lock()
+			out = append(out, report)
+			mu.Unlock()
+		}(hp.ip, hp.port)
+	}
+	wg.Wait()
+	return out, nil
+}

--- a/server/cmd/fleetnode/nmap.go
+++ b/server/cmd/fleetnode/nmap.go
@@ -92,9 +92,39 @@ func checkExecutableFile(path string) error {
 	return nil
 }
 
-func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRequest, logger *slog.Logger) ([]*pb.DiscoveredDeviceReport, error) {
+// detectIPv6Target mirrors pairing.validateNmapTargets: literal IPv6
+// addresses and IPv6-only hostname resolutions need -6; IPv6 CIDR is
+// rejected because nmap subnet scans don't make sense for 2^64 hosts.
+func detectIPv6Target(ctx context.Context, target string) (useIPv6 bool, err error) {
+	if _, ipNet, cerr := net.ParseCIDR(target); cerr == nil {
+		if _, bits := ipNet.Mask.Size(); bits == 128 {
+			return false, errors.New("IPv6 CIDR is not supported; use IpList for IPv6 devices")
+		}
+		return false, nil
+	}
+	if ip := net.ParseIP(target); ip != nil {
+		return ip.To4() == nil, nil
+	}
+	addrs, lookupErr := net.DefaultResolver.LookupIPAddr(ctx, target)
+	if lookupErr != nil || len(addrs) == 0 {
+		// Fall through so nmap can try to resolve; matches pairing-service behavior.
+		return false, nil //nolint:nilerr
+	}
+	for _, a := range addrs {
+		if a.IP.To4() != nil {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (r *RunCmd) buildNmapOptions(ctx context.Context, req *pairingpb.NmapModeRequest) ([]nmap.Option, error) {
 	target := strings.TrimSpace(req.GetTarget())
 	if err := validateNmapTarget(target); err != nil {
+		return nil, err
+	}
+	useIPv6, err := detectIPv6Target(ctx, target)
+	if err != nil {
 		return nil, err
 	}
 	ports := req.GetPorts()
@@ -104,10 +134,6 @@ func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRe
 	if len(ports) == 0 {
 		return nil, errors.New("no ports to scan; pass ports or load discovery plugins")
 	}
-
-	scanCtx, cancel := context.WithTimeout(ctx, nmapScanTimeout)
-	defer cancel()
-
 	opts := []nmap.Option{
 		nmap.WithBinaryPath(r.nmapPath),
 		nmap.WithTargets(target),
@@ -119,6 +145,21 @@ func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRe
 		nmap.WithHostTimeout(time.Duration(nmapHostTimeoutMs) * time.Millisecond),
 		nmap.WithMinRTTTimeout(time.Duration(nmapMinRTTMs) * time.Millisecond),
 	}
+	if useIPv6 {
+		opts = append(opts, nmap.WithIPv6Scanning())
+	}
+	return opts, nil
+}
+
+func (r *RunCmd) runNmapDiscovery(ctx context.Context, req *pairingpb.NmapModeRequest, logger *slog.Logger) ([]*pb.DiscoveredDeviceReport, error) {
+	opts, err := r.buildNmapOptions(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	scanCtx, cancel := context.WithTimeout(ctx, nmapScanTimeout)
+	defer cancel()
+
 	scanner, err := nmap.NewScanner(scanCtx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create nmap scanner: %w", err)

--- a/server/cmd/fleetnode/nmap_test.go
+++ b/server/cmd/fleetnode/nmap_test.go
@@ -3,12 +3,15 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 )
 
 func TestResolveNmapPath_Default_BinaryAdjacent(t *testing.T) {
@@ -101,4 +104,66 @@ func TestValidateNmapTarget(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDetectIPv6Target(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		wantIPv6 bool
+		wantErr  bool
+	}{
+		{name: "ipv4 literal", input: "10.0.0.1", wantIPv6: false},
+		{name: "ipv6 literal", input: "2001:db8::1", wantIPv6: true},
+		{name: "ipv4 cidr", input: "10.0.0.0/24", wantIPv6: false},
+		{name: "ipv6 cidr rejected", input: "2001:db8::/32", wantErr: true},
+		{name: "unresolvable hostname falls through to v4", input: "no-such-host.invalid", wantIPv6: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got, err := detectIPv6Target(context.Background(), tc.input)
+
+			// Assert
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantIPv6, got)
+		})
+	}
+}
+
+func TestBuildNmapOptions_AddsIPv6Scanning(t *testing.T) {
+	// Arrange
+	r := &RunCmd{nmapPath: "/usr/bin/nmap", discoverer: &stubDiscoverer{}}
+	v4 := &pairingpb.NmapModeRequest{Target: "10.0.0.1", Ports: []string{"4028"}}
+	v6 := &pairingpb.NmapModeRequest{Target: "2001:db8::1", Ports: []string{"4028"}}
+
+	// Act
+	v4Opts, err := r.buildNmapOptions(context.Background(), v4)
+	require.NoError(t, err)
+	v6Opts, err := r.buildNmapOptions(context.Background(), v6)
+	require.NoError(t, err)
+
+	// Assert
+	assert.Equal(t, len(v4Opts)+1, len(v6Opts), "IPv6 target should add exactly one option (WithIPv6Scanning)")
+}
+
+func TestBuildNmapOptions_RejectsIPv6CIDR(t *testing.T) {
+	// Arrange
+	r := &RunCmd{nmapPath: "/usr/bin/nmap", discoverer: &stubDiscoverer{}}
+	req := &pairingpb.NmapModeRequest{Target: "2001:db8::/32", Ports: []string{"4028"}}
+
+	// Act
+	_, err := r.buildNmapOptions(context.Background(), req)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IPv6 CIDR")
 }

--- a/server/cmd/fleetnode/nmap_test.go
+++ b/server/cmd/fleetnode/nmap_test.go
@@ -1,0 +1,101 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveNmapPath_ExplicitFlag_RelativeRejected(t *testing.T) {
+	// Act
+	_, err := resolveNmapPath("nmap", "/anything")
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
+}
+
+func TestResolveNmapPath_ExplicitFlag_NonExecutableRejected(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nmap")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o644))
+
+	// Act
+	_, err := resolveNmapPath(path, "")
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not executable")
+}
+
+func TestResolveNmapPath_ExplicitFlag_DirectoryRejected(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+
+	// Act
+	_, err := resolveNmapPath(dir, "")
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "directory")
+}
+
+func TestResolveNmapPath_ExplicitFlag_ExecutableReturned(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nmap")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755))
+
+	// Act
+	got, err := resolveNmapPath(path, "")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, path, got)
+}
+
+func TestResolveNmapPath_Default_BinaryAdjacent(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+	candidate := filepath.Join(exeDir, "nmap")
+	require.NoError(t, os.WriteFile(candidate, []byte("#!/bin/sh\n"), 0o755))
+
+	// Act
+	got, err := resolveNmapPath("", exeDir)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, candidate, got)
+}
+
+func TestResolveNmapPath_Default_FallsBackToPATH(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir() // empty
+
+	// Act
+	got, err := resolveNmapPath("", exeDir)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, "nmap", got)
+}
+
+func TestResolveNmapPath_Default_AdjacentNotExecutableFallsBack(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+	candidate := filepath.Join(exeDir, "nmap")
+	require.NoError(t, os.WriteFile(candidate, []byte("nope"), 0o644))
+
+	// Act
+	got, err := resolveNmapPath("", exeDir)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, "nmap", got)
+}

--- a/server/cmd/fleetnode/nmap_test.go
+++ b/server/cmd/fleetnode/nmap_test.go
@@ -11,55 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolveNmapPath_ExplicitFlag_RelativeRejected(t *testing.T) {
-	// Act
-	_, err := resolveNmapPath("nmap", "/anything")
-
-	// Assert
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "absolute")
-}
-
-func TestResolveNmapPath_ExplicitFlag_NonExecutableRejected(t *testing.T) {
-	// Arrange
-	dir := t.TempDir()
-	path := filepath.Join(dir, "nmap")
-	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o644))
-
-	// Act
-	_, err := resolveNmapPath(path, "")
-
-	// Assert
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not executable")
-}
-
-func TestResolveNmapPath_ExplicitFlag_DirectoryRejected(t *testing.T) {
-	// Arrange
-	dir := t.TempDir()
-
-	// Act
-	_, err := resolveNmapPath(dir, "")
-
-	// Assert
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "directory")
-}
-
-func TestResolveNmapPath_ExplicitFlag_ExecutableReturned(t *testing.T) {
-	// Arrange
-	dir := t.TempDir()
-	path := filepath.Join(dir, "nmap")
-	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755))
-
-	// Act
-	got, err := resolveNmapPath(path, "")
-
-	// Assert
-	require.NoError(t, err)
-	assert.Equal(t, path, got)
-}
-
 func TestResolveNmapPath_Default_BinaryAdjacent(t *testing.T) {
 	// Arrange
 	exeDir := t.TempDir()
@@ -67,10 +18,9 @@ func TestResolveNmapPath_Default_BinaryAdjacent(t *testing.T) {
 	require.NoError(t, os.WriteFile(candidate, []byte("#!/bin/sh\n"), 0o755))
 
 	// Act
-	got, err := resolveNmapPath("", exeDir)
+	got := resolveNmapPath(exeDir)
 
 	// Assert
-	require.NoError(t, err)
 	assert.Equal(t, candidate, got)
 }
 
@@ -79,10 +29,9 @@ func TestResolveNmapPath_Default_FallsBackToPATH(t *testing.T) {
 	exeDir := t.TempDir() // empty
 
 	// Act
-	got, err := resolveNmapPath("", exeDir)
+	got := resolveNmapPath(exeDir)
 
 	// Assert
-	require.NoError(t, err)
 	assert.Equal(t, "nmap", got)
 }
 
@@ -93,9 +42,63 @@ func TestResolveNmapPath_Default_AdjacentNotExecutableFallsBack(t *testing.T) {
 	require.NoError(t, os.WriteFile(candidate, []byte("nope"), 0o644))
 
 	// Act
-	got, err := resolveNmapPath("", exeDir)
+	got := resolveNmapPath(exeDir)
 
 	// Assert
-	require.NoError(t, err)
 	assert.Equal(t, "nmap", got)
+}
+
+func TestResolveNmapPath_EmptyExeDir(t *testing.T) {
+	// Act
+	got := resolveNmapPath("")
+
+	// Assert
+	assert.Equal(t, "nmap", got)
+}
+
+func TestValidateNmapTarget(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty", input: "", wantErr: true},
+		{name: "ipv4", input: "10.0.0.1", wantErr: false},
+		{name: "ipv6", input: "2001:db8::1", wantErr: false},
+		{name: "ipv4 cidr", input: "10.0.0.0/24", wantErr: false},
+		{name: "ipv6 cidr", input: "2001:db8::/32", wantErr: false},
+		{name: "ipv4 range", input: "10.0.0.1-50", wantErr: false},
+		{name: "hostname", input: "miner-01.lan", wantErr: false},
+		{name: "hostname single label", input: "miner", wantErr: false},
+		{name: "leading dash flag", input: "-iL/etc/passwd", wantErr: true},
+		{name: "nmap output flag", input: "-oN/tmp/loot", wantErr: true},
+		{name: "embedded space", input: "10.0.0.1 -oN/tmp/x", wantErr: true},
+		{name: "embedded null", input: "10.0.0.1\x00", wantErr: true},
+		{name: "ipv6 with brackets", input: "[2001:db8::1]", wantErr: true},
+		{name: "ipv4 range upper bound too high", input: "10.0.0.1-300", wantErr: true},
+		{name: "ipv4 range bad head", input: "10.0.0.999-50", wantErr: true},
+		{name: "shell metacharacter semicolon", input: "10.0.0.1;rm", wantErr: true},
+		{name: "shell metacharacter ampersand", input: "10.0.0.1&touch", wantErr: true},
+		{name: "leading whitespace", input: " 10.0.0.1", wantErr: true},
+		{name: "trailing newline", input: "10.0.0.1\n", wantErr: true},
+		{name: "hostname starts with dash", input: "-bad.lan", wantErr: true},
+		{name: "hostname with underscore", input: "bad_name", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			err := validateNmapTarget(tc.input)
+
+			// Assert
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/server/cmd/fleetnode/nmap_test.go
+++ b/server/cmd/fleetnode/nmap_test.go
@@ -146,9 +146,9 @@ func TestBuildNmapOptions_AddsIPv6Scanning(t *testing.T) {
 	v6 := &pairingpb.NmapModeRequest{Target: "2001:db8::1", Ports: []string{"4028"}}
 
 	// Act
-	v4Opts, err := r.buildNmapOptions(context.Background(), v4)
+	v4Opts, err := r.buildNmapOptions(context.Background(), v4, v4.Ports)
 	require.NoError(t, err)
-	v6Opts, err := r.buildNmapOptions(context.Background(), v6)
+	v6Opts, err := r.buildNmapOptions(context.Background(), v6, v6.Ports)
 	require.NoError(t, err)
 
 	// Assert
@@ -161,7 +161,7 @@ func TestBuildNmapOptions_RejectsIPv6CIDR(t *testing.T) {
 	req := &pairingpb.NmapModeRequest{Target: "2001:db8::/32", Ports: []string{"4028"}}
 
 	// Act
-	_, err := r.buildNmapOptions(context.Background(), req)
+	_, err := r.buildNmapOptions(context.Background(), req, req.Ports)
 
 	// Assert
 	require.Error(t, err)

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -11,11 +12,16 @@ import (
 	"syscall"
 )
 
-// reapOrphanedPlugins kills plugin-binary processes whose original parent
-// died and were re-parented to init (ppid == 1). Without this, a SIGKILL
-// on the agent (or any other defer-skipping exit) leaves go-plugin
-// children running, occupying their sockets and eventually blocking the
-// next agent's plugin handshake.
+// reapOrphanedPlugins kills any plugin-binary process whose executable lives
+// in pluginsDir. The reaper runs before newPluginDiscoverer, so at this
+// point the current agent has not yet spawned anything; every match is
+// leftover from a prior run that didn't shut down cleanly (SIGKILL, panic,
+// OOM, or the brief window between parent-death and kernel reparenting).
+//
+// An earlier version restricted reaping to processes whose ppid was 1, but
+// that missed real strays whose parent zombie had not yet been collected,
+// and contributed nothing because two concurrent agents on the same
+// pluginsDir is already impossible (state.lock contention).
 //
 // Best-effort: silently skips on any error so a missing `ps` binary or
 // permission failure never blocks normal startup.
@@ -29,14 +35,11 @@ func reapOrphanedPlugins(pluginsDir string, logger *slog.Logger) {
 		logger.Debug("orphan reaper: ps failed; skipping", "err", err)
 		return
 	}
+	selfPID := os.Getpid()
 	prefix := abs + string(filepath.Separator)
 	for _, line := range strings.Split(string(out), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 3 {
-			continue
-		}
-		ppid, err := strconv.Atoi(fields[1])
-		if err != nil || ppid != 1 {
 			continue
 		}
 		command := strings.Join(fields[2:], " ")
@@ -44,13 +47,13 @@ func reapOrphanedPlugins(pluginsDir string, logger *slog.Logger) {
 			continue
 		}
 		pid, err := strconv.Atoi(fields[0])
-		if err != nil {
+		if err != nil || pid == selfPID {
 			continue
 		}
 		if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
 			logger.Warn("orphan reaper: kill failed", "pid", pid, "command", command, "err", err)
 			continue
 		}
-		logger.Info("reaped orphaned plugin process", "pid", pid, "command", command)
+		logger.Info("reaped stray plugin process", "pid", pid, "command", command)
 	}
 }

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -12,19 +12,11 @@ import (
 	"syscall"
 )
 
-// reapOrphanedPlugins kills any plugin-binary process whose executable lives
-// in pluginsDir. The reaper runs before newPluginDiscoverer, so at this
-// point the current agent has not yet spawned anything; every match is
-// leftover from a prior run that didn't shut down cleanly (SIGKILL, panic,
-// OOM, or the brief window between parent-death and kernel reparenting).
-//
-// An earlier version restricted reaping to processes whose ppid was 1, but
-// that missed real strays whose parent zombie had not yet been collected,
-// and contributed nothing because two concurrent agents on the same
-// pluginsDir is already impossible (state.lock contention).
-//
-// Best-effort: silently skips on any error so a missing `ps` binary or
-// permission failure never blocks normal startup.
+// reapOrphanedPlugins kills any plugin-binary process under pluginsDir.
+// Runs before newPluginDiscoverer and under the state lock, so any match is
+// leftover from a prior crash; concurrent agents are already excluded by
+// state.lock contention. Best-effort: a missing/broken ps never blocks
+// startup.
 func reapOrphanedPlugins(pluginsDir string, logger *slog.Logger) {
 	abs, err := filepath.EvalSymlinks(pluginsDir)
 	if err != nil {

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -1,0 +1,56 @@
+//go:build !windows
+
+package main
+
+import (
+	"log/slog"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// reapOrphanedPlugins kills plugin-binary processes whose original parent
+// died and were re-parented to init (ppid == 1). Without this, a SIGKILL
+// on the agent (or any other defer-skipping exit) leaves go-plugin
+// children running, occupying their sockets and eventually blocking the
+// next agent's plugin handshake.
+//
+// Best-effort: silently skips on any error so a missing `ps` binary or
+// permission failure never blocks normal startup.
+func reapOrphanedPlugins(pluginsDir string, logger *slog.Logger) {
+	abs, err := filepath.EvalSymlinks(pluginsDir)
+	if err != nil {
+		return
+	}
+	out, err := exec.Command("ps", "-eo", "pid=,ppid=,command=").Output()
+	if err != nil {
+		logger.Debug("orphan reaper: ps failed; skipping", "err", err)
+		return
+	}
+	prefix := abs + string(filepath.Separator)
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		ppid, err := strconv.Atoi(fields[1])
+		if err != nil || ppid != 1 {
+			continue
+		}
+		command := strings.Join(fields[2:], " ")
+		if !strings.HasPrefix(command, prefix) {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+			logger.Warn("orphan reaper: kill failed", "pid", pid, "command", command, "err", err)
+			continue
+		}
+		logger.Info("reaped orphaned plugin process", "pid", pid, "command", command)
+	}
+}

--- a/server/cmd/fleetnode/orphan_reaper_windows.go
+++ b/server/cmd/fleetnode/orphan_reaper_windows.go
@@ -4,7 +4,6 @@ package main
 
 import "log/slog"
 
-// On Windows, go-plugin children inherit a job object that terminates them
-// when the parent exits, so we don't need a manual reaper. A proper ACL-
-// aware enumeration is out of scope here; this is a documented no-op.
+// No-op: Windows go-plugin children share a job object that auto-terminates
+// when the parent exits.
 func reapOrphanedPlugins(_ string, _ *slog.Logger) {}

--- a/server/cmd/fleetnode/orphan_reaper_windows.go
+++ b/server/cmd/fleetnode/orphan_reaper_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package main
+
+import "log/slog"
+
+// On Windows, go-plugin children inherit a job object that terminates them
+// when the parent exits, so we don't need a manual reaper. A proper ACL-
+// aware enumeration is out of scope here; this is a documented no-op.
+func reapOrphanedPlugins(_ string, _ *slog.Logger) {}

--- a/server/cmd/fleetnode/plugins_dir.go
+++ b/server/cmd/fleetnode/plugins_dir.go
@@ -6,12 +6,11 @@ import (
 	"path/filepath"
 )
 
-// resolvePluginsDir returns the plugins directory or "" when no usable
-// directory exists. A missing binary-adjacent default is silent (heartbeat
-// only); a present but unsafe default is a hard error so the operator who
-// shipped plugins learns about it. Any returned non-empty path has passed
-// checkPluginsDirPerms — the plugin manager execs everything in this
-// directory, so non-owner write capability there is RCE-equivalent.
+// resolvePluginsDir returns "" when the binary-adjacent default is missing
+// (silent heartbeat-only mode); a present-but-unsafe default is a hard
+// error so a shipped plugins dir doesn't get silently downgraded. The
+// plugin manager execs everything in the returned path, so non-owner write
+// capability there is RCE-equivalent (checkPluginsDirPerms enforces).
 func resolvePluginsDir(flag, exeDir string) (string, error) {
 	if flag != "" {
 		if !filepath.IsAbs(flag) {

--- a/server/cmd/fleetnode/plugins_dir.go
+++ b/server/cmd/fleetnode/plugins_dir.go
@@ -26,6 +26,9 @@ func resolvePluginsDir(exeDir string) (string, error) {
 	if err := checkPluginsDirPerms(candidate); err != nil {
 		return "", err
 	}
+	if err := validatePluginFiles(candidate); err != nil {
+		return "", err
+	}
 	return candidate, nil
 }
 

--- a/server/cmd/fleetnode/plugins_dir.go
+++ b/server/cmd/fleetnode/plugins_dir.go
@@ -6,20 +6,12 @@ import (
 	"path/filepath"
 )
 
-// resolvePluginsDir picks the plugins directory the control loop should use.
-//
-// Explicit flag: must be an absolute path; perms are enforced.
-// No flag:       look for <exeDir>/plugins. Missing dir means "no control
-//
-//	loop, heartbeat only" so operators get a heartbeat-only
-//	daemon out of the box. A present but unsafe dir is a hard
-//	error — silently downgrading would hide misconfiguration
-//	that an operator who shipped plugins probably wants to know
-//	about.
-//
-// Any returned non-empty path has passed checkPluginsDirPerms: the plugin
-// manager execs everything in this directory as the agent's user, so any
-// non-owner write capability is RCE-equivalent.
+// resolvePluginsDir returns the plugins directory or "" when no usable
+// directory exists. A missing binary-adjacent default is silent (heartbeat
+// only); a present but unsafe default is a hard error so the operator who
+// shipped plugins learns about it. Any returned non-empty path has passed
+// checkPluginsDirPerms — the plugin manager execs everything in this
+// directory, so non-owner write capability there is RCE-equivalent.
 func resolvePluginsDir(flag, exeDir string) (string, error) {
 	if flag != "" {
 		if !filepath.IsAbs(flag) {
@@ -50,8 +42,6 @@ func resolvePluginsDir(flag, exeDir string) (string, error) {
 	return candidate, nil
 }
 
-// executableDir returns the directory containing the running binary, or ""
-// if os.Executable fails (e.g. on platforms where it isn't supported).
 func executableDir() string {
 	exe, err := os.Executable()
 	if err != nil {

--- a/server/cmd/fleetnode/plugins_dir.go
+++ b/server/cmd/fleetnode/plugins_dir.go
@@ -6,21 +6,9 @@ import (
 	"path/filepath"
 )
 
-// resolvePluginsDir returns "" when the binary-adjacent default is missing
-// (silent heartbeat-only mode); a present-but-unsafe default is a hard
-// error so a shipped plugins dir doesn't get silently downgraded. The
-// plugin manager execs everything in the returned path, so non-owner write
-// capability there is RCE-equivalent (checkPluginsDirPerms enforces).
-func resolvePluginsDir(flag, exeDir string) (string, error) {
-	if flag != "" {
-		if !filepath.IsAbs(flag) {
-			return "", fmt.Errorf("--plugins-dir must be an absolute path, got %q", flag)
-		}
-		if err := checkPluginsDirPerms(flag); err != nil {
-			return "", err
-		}
-		return flag, nil
-	}
+// The plugin manager execs every file in the returned path, so non-owner
+// write capability there is RCE-equivalent (checkPluginsDirPerms enforces).
+func resolvePluginsDir(exeDir string) (string, error) {
 	if exeDir == "" {
 		return "", nil
 	}

--- a/server/cmd/fleetnode/plugins_dir.go
+++ b/server/cmd/fleetnode/plugins_dir.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// resolvePluginsDir picks the plugins directory the control loop should use.
+//
+// Explicit flag: must be an absolute path; perms are enforced.
+// No flag:       look for <exeDir>/plugins. Missing dir means "no control
+//
+//	loop, heartbeat only" so operators get a heartbeat-only
+//	daemon out of the box. A present but unsafe dir is a hard
+//	error — silently downgrading would hide misconfiguration
+//	that an operator who shipped plugins probably wants to know
+//	about.
+//
+// Any returned non-empty path has passed checkPluginsDirPerms: the plugin
+// manager execs everything in this directory as the agent's user, so any
+// non-owner write capability is RCE-equivalent.
+func resolvePluginsDir(flag, exeDir string) (string, error) {
+	if flag != "" {
+		if !filepath.IsAbs(flag) {
+			return "", fmt.Errorf("--plugins-dir must be an absolute path, got %q", flag)
+		}
+		if err := checkPluginsDirPerms(flag); err != nil {
+			return "", err
+		}
+		return flag, nil
+	}
+	if exeDir == "" {
+		return "", nil
+	}
+	candidate := filepath.Join(exeDir, "plugins")
+	info, err := os.Stat(candidate)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("stat plugins dir %s: %w", candidate, err)
+	}
+	if !info.IsDir() {
+		return "", nil
+	}
+	if err := checkPluginsDirPerms(candidate); err != nil {
+		return "", err
+	}
+	return candidate, nil
+}
+
+// executableDir returns the directory containing the running binary, or ""
+// if os.Executable fails (e.g. on platforms where it isn't supported).
+func executableDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		resolved = exe
+	}
+	return filepath.Dir(resolved)
+}

--- a/server/cmd/fleetnode/plugins_dir_test.go
+++ b/server/cmd/fleetnode/plugins_dir_test.go
@@ -1,0 +1,121 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePluginsDir_ExplicitFlag_RelativeRejected(t *testing.T) {
+	// Act
+	_, err := resolvePluginsDir("plugins", "/anything")
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
+}
+
+func TestResolvePluginsDir_ExplicitFlag_MissingPathRejected(t *testing.T) {
+	// Act
+	_, err := resolvePluginsDir(filepath.Join(t.TempDir(), "nonexistent"), "")
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such file or directory")
+}
+
+func TestResolvePluginsDir_ExplicitFlag_WorldWritableRejected(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o777)) //nolint:gosec // test exercises the reject path
+
+	// Act
+	_, err := resolvePluginsDir(dir, "")
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "writable")
+}
+
+func TestResolvePluginsDir_ExplicitFlag_OwnedAndTight_Returned(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o755)) //nolint:gosec // test fixture
+
+	// Act
+	got, err := resolvePluginsDir(dir, "")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, dir, got)
+}
+
+func TestResolvePluginsDir_Default_BinaryAdjacent(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+	candidate := filepath.Join(exeDir, "plugins")
+	require.NoError(t, os.Mkdir(candidate, 0o755)) //nolint:gosec // test fixture
+
+	// Act
+	got, err := resolvePluginsDir("", exeDir)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, candidate, got)
+}
+
+func TestResolvePluginsDir_Default_MissingReturnsEmpty(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+
+	// Act
+	got, err := resolvePluginsDir("", exeDir)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestResolvePluginsDir_Default_PresentButUnsafeIsHardError(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+	candidate := filepath.Join(exeDir, "plugins")
+	require.NoError(t, os.Mkdir(candidate, 0o755)) //nolint:gosec // test fixture
+	// chmod after Mkdir because umask masks the requested mode.
+	require.NoError(t, os.Chmod(candidate, 0o777)) //nolint:gosec // test exercises the reject path
+
+	// Act
+	_, err := resolvePluginsDir("", exeDir)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "writable")
+}
+
+func TestResolvePluginsDir_NoFlagAndNoExeDir(t *testing.T) {
+	// Act
+	got, err := resolvePluginsDir("", "")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestResolvePluginsDir_Default_FileAtCandidateIgnored(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(exeDir, "plugins"), []byte("not a dir"), 0o644))
+
+	// Act
+	got, err := resolvePluginsDir("", exeDir)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/server/cmd/fleetnode/plugins_dir_test.go
+++ b/server/cmd/fleetnode/plugins_dir_test.go
@@ -12,50 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolvePluginsDir_ExplicitFlag_RelativeRejected(t *testing.T) {
-	// Act
-	_, err := resolvePluginsDir("plugins", "/anything")
-
-	// Assert
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "absolute")
-}
-
-func TestResolvePluginsDir_ExplicitFlag_MissingPathRejected(t *testing.T) {
-	// Act
-	_, err := resolvePluginsDir(filepath.Join(t.TempDir(), "nonexistent"), "")
-
-	// Assert
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no such file or directory")
-}
-
-func TestResolvePluginsDir_ExplicitFlag_WorldWritableRejected(t *testing.T) {
-	// Arrange
-	dir := t.TempDir()
-	require.NoError(t, os.Chmod(dir, 0o777)) //nolint:gosec // test exercises the reject path
-
-	// Act
-	_, err := resolvePluginsDir(dir, "")
-
-	// Assert
-	require.Error(t, err)
-	assert.Contains(t, strings.ToLower(err.Error()), "writable")
-}
-
-func TestResolvePluginsDir_ExplicitFlag_OwnedAndTight_Returned(t *testing.T) {
-	// Arrange
-	dir := t.TempDir()
-	require.NoError(t, os.Chmod(dir, 0o755)) //nolint:gosec // test fixture
-
-	// Act
-	got, err := resolvePluginsDir(dir, "")
-
-	// Assert
-	require.NoError(t, err)
-	assert.Equal(t, dir, got)
-}
-
 func TestResolvePluginsDir_Default_BinaryAdjacent(t *testing.T) {
 	// Arrange
 	exeDir := t.TempDir()
@@ -63,7 +19,7 @@ func TestResolvePluginsDir_Default_BinaryAdjacent(t *testing.T) {
 	require.NoError(t, os.Mkdir(candidate, 0o755)) //nolint:gosec // test fixture
 
 	// Act
-	got, err := resolvePluginsDir("", exeDir)
+	got, err := resolvePluginsDir(exeDir)
 
 	// Assert
 	require.NoError(t, err)
@@ -75,7 +31,7 @@ func TestResolvePluginsDir_Default_MissingReturnsEmpty(t *testing.T) {
 	exeDir := t.TempDir()
 
 	// Act
-	got, err := resolvePluginsDir("", exeDir)
+	got, err := resolvePluginsDir(exeDir)
 
 	// Assert
 	require.NoError(t, err)
@@ -87,20 +43,19 @@ func TestResolvePluginsDir_Default_PresentButUnsafeIsHardError(t *testing.T) {
 	exeDir := t.TempDir()
 	candidate := filepath.Join(exeDir, "plugins")
 	require.NoError(t, os.Mkdir(candidate, 0o755)) //nolint:gosec // test fixture
-	// chmod after Mkdir because umask masks the requested mode.
 	require.NoError(t, os.Chmod(candidate, 0o777)) //nolint:gosec // test exercises the reject path
 
 	// Act
-	_, err := resolvePluginsDir("", exeDir)
+	_, err := resolvePluginsDir(exeDir)
 
 	// Assert
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "writable")
 }
 
-func TestResolvePluginsDir_NoFlagAndNoExeDir(t *testing.T) {
+func TestResolvePluginsDir_NoExeDir(t *testing.T) {
 	// Act
-	got, err := resolvePluginsDir("", "")
+	got, err := resolvePluginsDir("")
 
 	// Assert
 	require.NoError(t, err)
@@ -113,7 +68,7 @@ func TestResolvePluginsDir_Default_FileAtCandidateIgnored(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(exeDir, "plugins"), []byte("not a dir"), 0o644))
 
 	// Act
-	got, err := resolvePluginsDir("", exeDir)
+	got, err := resolvePluginsDir(exeDir)
 
 	// Assert
 	require.NoError(t, err)

--- a/server/cmd/fleetnode/plugins_dir_test.go
+++ b/server/cmd/fleetnode/plugins_dir_test.go
@@ -74,3 +74,94 @@ func TestResolvePluginsDir_Default_FileAtCandidateIgnored(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
+
+func newPluginsDir(t *testing.T) (exeDir, plugins string) {
+	t.Helper()
+	exeDir = t.TempDir()
+	plugins = filepath.Join(exeDir, "plugins")
+	require.NoError(t, os.Mkdir(plugins, 0o755)) //nolint:gosec // test fixture
+	return exeDir, plugins
+}
+
+func TestValidatePluginFiles_AcceptsOwnedAndTightExecutable(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	require.NoError(t, os.WriteFile(filepath.Join(plugins, "x"), []byte("#!/bin/sh\n"), 0o755))
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.NoError(t, err)
+}
+
+func TestValidatePluginFiles_RejectsSymlink(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	target := filepath.Join(t.TempDir(), "elsewhere")
+	require.NoError(t, os.WriteFile(target, []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.Symlink(target, filepath.Join(plugins, "x")))
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "symlink")
+}
+
+func TestValidatePluginFiles_RejectsWorldWritableExecutable(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	path := filepath.Join(plugins, "x")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.Chmod(path, 0o777)) //nolint:gosec // test exercises the reject path
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "writable")
+}
+
+func TestValidatePluginFiles_IgnoresNonExecutableFiles(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	require.NoError(t, os.WriteFile(filepath.Join(plugins, "README.md"), []byte("docs"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(plugins, "x"), []byte("#!/bin/sh\n"), 0o755))
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.NoError(t, err)
+}
+
+func TestValidatePluginFiles_IgnoresSubdirectories(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	require.NoError(t, os.Mkdir(filepath.Join(plugins, "data"), 0o755)) //nolint:gosec // test fixture
+	require.NoError(t, os.WriteFile(filepath.Join(plugins, "x"), []byte("#!/bin/sh\n"), 0o755))
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.NoError(t, err)
+}
+
+func TestResolvePluginsDir_Default_BadFileBlocksResolution(t *testing.T) {
+	// Arrange
+	exeDir, plugins := newPluginsDir(t)
+	bad := filepath.Join(plugins, "evil")
+	require.NoError(t, os.WriteFile(bad, []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.Chmod(bad, 0o777)) //nolint:gosec // test exercises the reject path
+
+	// Act
+	_, err := resolvePluginsDir(exeDir)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "evil")
+}

--- a/server/cmd/fleetnode/plugins_dir_unix.go
+++ b/server/cmd/fleetnode/plugins_dir_unix.go
@@ -8,9 +8,8 @@ import (
 	"syscall"
 )
 
-// checkPluginsDirPerms refuses any directory where someone other than the
-// owner can write. The owner must be root or the running process; otherwise
-// a different user could swap files in the dir between checks and exec.
+// checkPluginsDirPerms rejects dirs where someone other than root or the
+// running uid could plant an executable between our check and exec.
 func checkPluginsDirPerms(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/server/cmd/fleetnode/plugins_dir_unix.go
+++ b/server/cmd/fleetnode/plugins_dir_unix.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
 )
 
@@ -28,6 +29,48 @@ func checkPluginsDirPerms(path string) error {
 	}
 	if mode := info.Mode().Perm(); mode&0o022 != 0 {
 		return fmt.Errorf("plugins dir %s: mode %#o must not be group- or world-writable", path, mode)
+	}
+	return nil
+}
+
+// validatePluginFiles enforces the per-file safety bar that the container
+// check can't see: a writable plugin binary or a symlink to one elsewhere
+// would still be RCE-equivalent under the agent uid.
+func validatePluginFiles(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read plugins dir %s: %w", dir, err)
+	}
+	uid := uint32(os.Getuid()) //nolint:gosec // os.Getuid() is non-negative on Unix
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+		info, err := os.Lstat(path)
+		if err != nil {
+			return fmt.Errorf("lstat %s: %w", path, err)
+		}
+		mode := info.Mode()
+		if mode&os.ModeSymlink != 0 {
+			return fmt.Errorf("plugin %s is a symlink; refuse to follow", path)
+		}
+		if mode.IsDir() {
+			continue
+		}
+		if !mode.IsRegular() {
+			return fmt.Errorf("plugin %s is not a regular file (mode %s)", path, mode)
+		}
+		if mode.Perm()&0o111 == 0 {
+			continue
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("plugin %s: unsupported stat type %T", path, info.Sys())
+		}
+		if stat.Uid != 0 && stat.Uid != uid {
+			return fmt.Errorf("plugin %s: owner uid %d must be 0 (root) or %d (this process)", path, stat.Uid, uid)
+		}
+		if mode.Perm()&0o022 != 0 {
+			return fmt.Errorf("plugin %s: mode %#o must not be group- or world-writable", path, mode.Perm())
+		}
 	}
 	return nil
 }

--- a/server/cmd/fleetnode/plugins_dir_unix.go
+++ b/server/cmd/fleetnode/plugins_dir_unix.go
@@ -44,20 +44,21 @@ func validatePluginFiles(dir string) error {
 	uid := uint32(os.Getuid()) //nolint:gosec // os.Getuid() is non-negative on Unix
 	for _, entry := range entries {
 		path := filepath.Join(dir, entry.Name())
-		info, err := os.Lstat(path)
-		if err != nil {
-			return fmt.Errorf("lstat %s: %w", path, err)
-		}
-		mode := info.Mode()
-		if mode&os.ModeSymlink != 0 {
+		t := entry.Type()
+		if t&os.ModeSymlink != 0 {
 			return fmt.Errorf("plugin %s is a symlink; refuse to follow", path)
 		}
-		if mode.IsDir() {
+		if t.IsDir() {
 			continue
 		}
-		if !mode.IsRegular() {
-			return fmt.Errorf("plugin %s is not a regular file (mode %s)", path, mode)
+		if !t.IsRegular() {
+			return fmt.Errorf("plugin %s is not a regular file (mode %s)", path, t)
 		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		mode := info.Mode()
 		if mode.Perm()&0o111 == 0 {
 			continue
 		}

--- a/server/cmd/fleetnode/plugins_dir_unix.go
+++ b/server/cmd/fleetnode/plugins_dir_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// checkPluginsDirPerms refuses any directory where someone other than the
+// owner can write. The owner must be root or the running process; otherwise
+// a different user could swap files in the dir between checks and exec.
+func checkPluginsDirPerms(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat plugins dir %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("plugins dir %s is not a directory", path)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("plugins dir %s: unsupported stat type %T", path, info.Sys())
+	}
+	uid := uint32(os.Getuid()) //nolint:gosec // os.Getuid() is non-negative on Unix
+	if stat.Uid != 0 && stat.Uid != uid {
+		return fmt.Errorf("plugins dir %s: owner uid %d must be 0 (root) or %d (this process)", path, stat.Uid, uid)
+	}
+	if mode := info.Mode().Perm(); mode&0o022 != 0 {
+		return fmt.Errorf("plugins dir %s: mode %#o must not be group- or world-writable", path, mode)
+	}
+	return nil
+}

--- a/server/cmd/fleetnode/plugins_dir_windows.go
+++ b/server/cmd/fleetnode/plugins_dir_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// On Windows the MSI installer places the plugins directory under a path
+// that requires Administrator rights to modify. A proper ACL inspection is
+// out of scope here; this check only verifies the path exists and is a
+// directory. Operators on Windows should rely on the installer-controlled
+// default rather than passing --plugins-dir from a user shell.
+func checkPluginsDirPerms(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat plugins dir %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("plugins dir %s is not a directory", path)
+	}
+	return nil
+}

--- a/server/cmd/fleetnode/plugins_dir_windows.go
+++ b/server/cmd/fleetnode/plugins_dir_windows.go
@@ -7,11 +7,8 @@ import (
 	"os"
 )
 
-// On Windows the MSI installer places the plugins directory under a path
-// that requires Administrator rights to modify. A proper ACL inspection is
-// out of scope here; this check only verifies the path exists and is a
-// directory. Operators on Windows should rely on the installer-controlled
-// default rather than passing --plugins-dir from a user shell.
+// Windows relies on the MSI installer placing plugins under an
+// Administrator-only path; an ACL check is out of scope here.
 func checkPluginsDirPerms(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/server/cmd/fleetnode/plugins_dir_windows.go
+++ b/server/cmd/fleetnode/plugins_dir_windows.go
@@ -19,3 +19,7 @@ func checkPluginsDirPerms(path string) error {
 	}
 	return nil
 }
+
+// validatePluginFiles is a no-op on Windows; per-file ACL inspection needs
+// golang.org/x/sys/windows SID/ACE work that is tracked separately.
+func validatePluginFiles(_ string) error { return nil }

--- a/server/cmd/fleetnode/plugins_dir_windows.go
+++ b/server/cmd/fleetnode/plugins_dir_windows.go
@@ -20,6 +20,7 @@ func checkPluginsDirPerms(path string) error {
 	return nil
 }
 
-// validatePluginFiles is a no-op on Windows; per-file ACL inspection needs
-// golang.org/x/sys/windows SID/ACE work that is tracked separately.
+// Windows ACL inspection needs golang.org/x/sys/windows SID/ACE work.
+// Production deployments must place plugins under an Administrator-only
+// directory; runtime cannot verify that on Windows.
 func validatePluginFiles(_ string) error { return nil }

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -48,10 +48,6 @@ type gatewayClient interface {
 }
 
 func (r *RunCmd) Run(c *Context) error {
-	// Stdout (not stderr) so logs are visible in IDE terminal panels and
-	// shells that filter or buffer FD 2. CLI daemons (caddy, prometheus,
-	// vault) follow the same convention; redirect with `2>&1` and standard
-	// shell tools still work.
 	return r.run(c, os.Stdout)
 }
 

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -48,7 +48,11 @@ type gatewayClient interface {
 }
 
 func (r *RunCmd) Run(c *Context) error {
-	return r.run(c, os.Stderr)
+	// Stdout (not stderr) so logs are visible in IDE terminal panels and
+	// shells that filter or buffer FD 2. CLI daemons (caddy, prometheus,
+	// vault) follow the same convention; redirect with `2>&1` and standard
+	// shell tools still work.
+	return r.run(c, os.Stdout)
 }
 
 func (r *RunCmd) run(c *Context, stderr io.Writer) error {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -27,15 +27,13 @@ const (
 
 type RunCmd struct {
 	HeartbeatInterval time.Duration `name:"heartbeat-interval" default:"30s" help:"interval between UploadHeartbeat calls"`
-	PluginsDir        string        `name:"plugins-dir" help:"absolute path to the discovery plugins directory; defaults to <dir-of-binary>/plugins. If the resolved directory is missing the control loop stays off (heartbeat only)."`
-	NmapPath          string        `name:"nmap-path" help:"absolute path to the nmap binary; defaults to <dir-of-binary>/nmap when present, otherwise to 'nmap' on PATH at scan time"`
 
-	now           func() time.Time                                                `kong:"-"`
-	clientFactory func(serverURL string, tokenSource func() string) gatewayClient `kong:"-"`
-	signals       []os.Signal                                                     `kong:"-"`
-	parentCtx     context.Context                                                 `kong:"-"` //nolint:containedctx // test seam for daemon shutdown without OS signals
-	discoverer    discoverer                                                      `kong:"-"`
-	nmapPath      string                                                          `kong:"-"`
+	now           func() time.Time                                                         `kong:"-"`
+	clientFactory func(serverURL string, tokenSource func() string) (gatewayClient, error) `kong:"-"`
+	signals       []os.Signal                                                              `kong:"-"`
+	parentCtx     context.Context                                                          `kong:"-"` //nolint:containedctx // test seam for daemon shutdown without OS signals
+	discoverer    discoverer                                                               `kong:"-"`
+	nmapPath      string                                                                   `kong:"-"`
 
 	stateMu sync.Mutex `kong:"-"` // guards st.SessionToken across refreshAndSave + tokenSource.
 }
@@ -58,7 +56,7 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		r.now = func() time.Time { return time.Now().UTC() }
 	}
 	if r.clientFactory == nil {
-		r.clientFactory = func(url string, src func() string) gatewayClient {
+		r.clientFactory = func(url string, src func() string) (gatewayClient, error) {
 			return fleetnodebootstrap.NewAuthenticatedGatewayClient(url, src)
 		}
 	}
@@ -71,22 +69,18 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		r.parentCtx = context.Background()
 	}
 
-	// Resolve --plugins-dir / --nmap-path before touching disk state so
+	// Resolve binary-adjacent plugins/nmap before touching disk state so
 	// misconfiguration fails fast.
 	exeDir := executableDir()
 	var resolvedPluginsDir string
 	if r.discoverer == nil {
-		resolved, resolveErr := resolvePluginsDir(r.PluginsDir, exeDir)
+		resolved, resolveErr := resolvePluginsDir(exeDir)
 		if resolveErr != nil {
 			return resolveErr
 		}
 		resolvedPluginsDir = resolved
 	}
-	resolvedNmapPath, err := resolveNmapPath(r.NmapPath, exeDir)
-	if err != nil {
-		return err
-	}
-	r.nmapPath = resolvedNmapPath
+	r.nmapPath = resolveNmapPath(exeDir)
 
 	path := fleetnodebootstrap.StatePath(c.StateDir)
 	st, exists, err := fleetnodebootstrap.LoadState(path)
@@ -102,12 +96,8 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 
 	logger := slog.New(slog.NewTextHandler(stderr, nil))
 	if resolvedPluginsDir != "" {
-		source := "binary-adjacent"
-		if r.PluginsDir != "" {
-			source = "flag"
-		}
-		logger.Info("plugins dir resolved", "plugins_dir", resolvedPluginsDir, "source", source)
-	} else if r.PluginsDir == "" {
+		logger.Info("plugins dir resolved", "plugins_dir", resolvedPluginsDir)
+	} else {
 		logger.Info("no plugins dir found adjacent to binary; control loop disabled (heartbeat only)")
 	}
 
@@ -161,7 +151,10 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 		defer r.stateMu.Unlock()
 		return st.SessionToken
 	}
-	client := r.clientFactory(st.ServerURL, tokenSource)
+	client, err := r.clientFactory(st.ServerURL, tokenSource)
+	if err != nil {
+		return err
+	}
 
 	controlEnabled := r.discoverer != nil
 

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -106,15 +106,6 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 
 	logger := slog.New(slog.NewTextHandler(stderr, nil))
 	if resolvedPluginsDir != "" {
-		reapOrphanedPlugins(resolvedPluginsDir, logger)
-		disc, cleanup, bootstrapErr := newPluginDiscoverer(resolvedPluginsDir)
-		if bootstrapErr != nil {
-			return fmt.Errorf("bootstrap discovery plugins: %w", bootstrapErr)
-		}
-		defer cleanup()
-		r.discoverer = disc
-	}
-	if resolvedPluginsDir != "" {
 		source := "binary-adjacent"
 		if r.PluginsDir != "" {
 			source = "flag"
@@ -124,7 +115,20 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		logger.Info("no plugins dir found adjacent to binary; control loop disabled (heartbeat only)")
 	}
 
+	// Plugin reap + spawn happens INSIDE the state lock so a second
+	// concurrent agent (errored out on lock contention) can't kill our
+	// plugin children before we finish startup.
+	logger.Info("acquiring state lock", "state_dir", c.StateDir)
 	return fleetnodebootstrap.WithStateLock(c.StateDir, func() error {
+		if resolvedPluginsDir != "" {
+			reapOrphanedPlugins(resolvedPluginsDir, logger)
+			disc, cleanup, bootstrapErr := newPluginDiscoverer(resolvedPluginsDir)
+			if bootstrapErr != nil {
+				return fmt.Errorf("bootstrap discovery plugins: %w", bootstrapErr)
+			}
+			defer cleanup()
+			r.discoverer = disc
+		}
 		return r.runLocked(c, logger)
 	})
 }

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -305,8 +305,12 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *fleetnodebo
 	return nil
 }
 
+const heartbeatTimeout = 30 * time.Second
+
 func (r *RunCmd) sendHeartbeat(ctx context.Context, client gatewayClient) error {
-	_, err := client.UploadHeartbeat(ctx, connect.NewRequest(&pb.UploadHeartbeatRequest{
+	callCtx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
+	defer cancel()
+	_, err := client.UploadHeartbeat(callCtx, connect.NewRequest(&pb.UploadHeartbeatRequest{
 		SentAt: timestamppb.New(r.now()),
 	}))
 	return err

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -26,15 +28,22 @@ const (
 
 type RunCmd struct {
 	HeartbeatInterval time.Duration `name:"heartbeat-interval" default:"30s" help:"interval between UploadHeartbeat calls"`
+	PluginsDir        string        `name:"plugins-dir" help:"absolute path to the discovery plugins directory; required when the agent should execute server-issued discovery commands"`
 
 	now           func() time.Time                                                `kong:"-"`
 	clientFactory func(serverURL string, tokenSource func() string) gatewayClient `kong:"-"`
 	signals       []os.Signal                                                     `kong:"-"`
 	parentCtx     context.Context                                                 `kong:"-"` //nolint:containedctx // test seam for daemon shutdown without OS signals
+	discoverer    discoverer                                                      `kong:"-"`
+
+	// Guards st.SessionToken: refreshAndSave writes; tokenSource reads.
+	stateMu sync.Mutex `kong:"-"`
 }
 
 type gatewayClient interface {
 	UploadHeartbeat(ctx context.Context, req *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error)
+	ReportDiscoveredDevices(ctx context.Context, req *connect.Request[pb.ReportDiscoveredDevicesRequest]) (*connect.Response[pb.ReportDiscoveredDevicesResponse], error)
+	ControlStream(ctx context.Context) *connect.BidiStreamForClient[pb.ControlStreamRequest, pb.ControlStreamResponse]
 }
 
 func (r *RunCmd) Run(c *Context) error {
@@ -60,6 +69,15 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		r.parentCtx = context.Background()
 	}
 
+	// CLI-flag validation runs before any disk/state work so misconfiguration
+	// fails fast. The plugin manager execs anything in PluginsDir, so a
+	// relative path would resolve against the daemon's CWD and let a writable
+	// launch directory host arbitrary code as the agent user.
+	controlWanted := r.discoverer == nil && r.PluginsDir != ""
+	if controlWanted && !filepath.IsAbs(r.PluginsDir) {
+		return fmt.Errorf("--plugins-dir must be an absolute path, got %q", r.PluginsDir)
+	}
+
 	path := fleetnodebootstrap.StatePath(c.StateDir)
 	st, exists, err := fleetnodebootstrap.LoadState(path)
 	if err != nil {
@@ -70,6 +88,15 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 	}
 	if st.APIKey == "" {
 		return fmt.Errorf("state at %s has no api_key; complete enrollment via `fleetnode refresh` before running the daemon", path)
+	}
+
+	if controlWanted {
+		disc, cleanup, bootstrapErr := newPluginDiscoverer(r.PluginsDir)
+		if bootstrapErr != nil {
+			return fmt.Errorf("bootstrap discovery plugins: %w", bootstrapErr)
+		}
+		defer cleanup()
+		r.discoverer = disc
 	}
 
 	logger := slog.New(slog.NewTextHandler(stderr, nil))
@@ -107,25 +134,70 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 		}
 	}
 
-	client := r.clientFactory(st.ServerURL, func() string { return st.SessionToken })
+	tokenSource := func() string {
+		r.stateMu.Lock()
+		defer r.stateMu.Unlock()
+		return st.SessionToken
+	}
+	client := r.clientFactory(st.ServerURL, tokenSource)
+
+	controlEnabled := r.discoverer != nil
 
 	logger.Info("daemon started",
 		"fleet_node_id", st.FleetNodeID,
 		"server_url", st.ServerURL,
 		"heartbeat_interval", r.HeartbeatInterval.String(),
+		"control_loop_enabled", controlEnabled,
 		"session_expires_at", st.SessionExpiresAt.Format(time.RFC3339),
 	)
-
-	ticker := time.NewTicker(r.HeartbeatInterval)
-	defer ticker.Stop()
 
 	if err := r.tick(ctx, client, st, path, logger); err != nil {
 		return err
 	}
+
+	loopCtx, cancelLoops := context.WithCancel(ctx)
+	defer cancelLoops()
+
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := r.runHeartbeatLoop(loopCtx, client, st, path, logger); err != nil {
+			errCh <- err
+			cancelLoops()
+		}
+	}()
+
+	if controlEnabled {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := r.runControlLoop(loopCtx, client, st, logger); err != nil {
+				errCh <- err
+				cancelLoops()
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+	logger.Info("daemon shutting down", "fleet_node_id", st.FleetNodeID)
+	return nil
+}
+
+func (r *RunCmd) runHeartbeatLoop(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, path string, logger *slog.Logger) error {
+	ticker := time.NewTicker(r.HeartbeatInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Info("daemon shutting down", "fleet_node_id", st.FleetNodeID)
 			return nil
 		case <-ticker.C:
 			if err := r.tick(ctx, client, st, path, logger); err != nil {
@@ -147,9 +219,16 @@ func (r *RunCmd) sessionNeedsRefresh(st *fleetnodebootstrap.State) bool {
 
 func (r *RunCmd) refreshAndSave(ctx context.Context, st *fleetnodebootstrap.State, path string, logger *slog.Logger) error {
 	logger.Info("refreshing session", "fleet_node_id", st.FleetNodeID, "session_expires_at", st.SessionExpiresAt.Format(time.RFC3339))
-	if err := fleetnodebootstrap.Refresh(ctx, st); err != nil {
+	// Handshake against a shallow copy so the 2-RPC network call doesn't hold
+	// stateMu and stall the control loop's token reads.
+	next := *st
+	if err := fleetnodebootstrap.Refresh(ctx, &next); err != nil {
 		return err
 	}
+	r.stateMu.Lock()
+	st.SessionToken = next.SessionToken
+	st.SessionExpiresAt = next.SessionExpiresAt
+	r.stateMu.Unlock()
 	if err := fleetnodebootstrap.SaveState(path, st); err != nil {
 		return fmt.Errorf("save state after refresh: %w", err)
 	}

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -37,8 +37,7 @@ type RunCmd struct {
 	discoverer    discoverer                                                      `kong:"-"`
 	nmapPath      string                                                          `kong:"-"`
 
-	// Guards st.SessionToken: refreshAndSave writes; tokenSource reads.
-	stateMu sync.Mutex `kong:"-"`
+	stateMu sync.Mutex `kong:"-"` // guards st.SessionToken across refreshAndSave + tokenSource.
 }
 
 type gatewayClient interface {
@@ -64,19 +63,16 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		}
 	}
 	if len(r.signals) == 0 {
-		// SIGHUP catches the terminal-close case so plugin children get the
-		// same orderly shutdown as Ctrl+C; without it the parent dies
-		// uncaught and leaves orphaned plugin processes behind.
+		// SIGHUP catches terminal-close so plugin children get the same
+		// orderly shutdown as Ctrl+C instead of being orphaned.
 		r.signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP}
 	}
 	if r.parentCtx == nil {
 		r.parentCtx = context.Background()
 	}
 
-	// Resolve --plugins-dir and --nmap-path before touching disk state so
-	// misconfiguration fails fast. The plugin manager execs anything in the
-	// resolved plugins dir, so any non-owner write capability there is
-	// RCE-equivalent.
+	// Resolve --plugins-dir / --nmap-path before touching disk state so
+	// misconfiguration fails fast.
 	exeDir := executableDir()
 	var resolvedPluginsDir string
 	if r.discoverer == nil {
@@ -115,9 +111,8 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		logger.Info("no plugins dir found adjacent to binary; control loop disabled (heartbeat only)")
 	}
 
-	// Plugin reap + spawn happens INSIDE the state lock so a second
-	// concurrent agent (errored out on lock contention) can't kill our
-	// plugin children before we finish startup.
+	// Reap + spawn plugins inside the lock so a contending agent's reaper
+	// can't kill our children before we finish startup.
 	logger.Info("acquiring state lock", "state_dir", c.StateDir)
 	return fleetnodebootstrap.WithStateLock(c.StateDir, func() error {
 		if resolvedPluginsDir != "" {
@@ -142,9 +137,9 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 	if !exists || st.FleetNodeID == 0 || st.APIKey == "" {
 		return fmt.Errorf("state at %s became invalid between checks; re-run after `fleetnode enroll`", path)
 	}
-	// Validate on every entry, not just on the refresh path, so a tampered
-	// state cannot redirect bearer heartbeats to a plaintext non-loopback
-	// URL when the existing session_token is still fresh.
+	// Re-validate on every entry so a tampered state.yaml can't redirect
+	// bearer heartbeats to a plaintext non-loopback URL while the cached
+	// session_token is still fresh.
 	if err := fleetnodebootstrap.ValidateServerURL(st.ServerURL, st.AllowInsecureTransport); err != nil {
 		return err
 	}
@@ -246,8 +241,8 @@ func (r *RunCmd) sessionNeedsRefresh(st *fleetnodebootstrap.State) bool {
 
 func (r *RunCmd) refreshAndSave(ctx context.Context, st *fleetnodebootstrap.State, path string, logger *slog.Logger) error {
 	logger.Info("refreshing session", "fleet_node_id", st.FleetNodeID, "session_expires_at", st.SessionExpiresAt.Format(time.RFC3339))
-	// Handshake against a shallow copy so the 2-RPC network call doesn't hold
-	// stateMu and stall the control loop's token reads.
+	// Handshake on a shallow copy so the 2-RPC call doesn't hold stateMu and
+	// stall the control loop's token reads.
 	next := *st
 	if err := fleetnodebootstrap.Refresh(ctx, &next); err != nil {
 		return err
@@ -263,11 +258,9 @@ func (r *RunCmd) refreshAndSave(ctx context.Context, st *fleetnodebootstrap.Stat
 	return nil
 }
 
-// tick runs one heartbeat cycle. A non-nil return signals a permanent
-// condition (server-side credential revoked or fleet_node deleted) that
-// the operator must resolve by re-enrolling; the daemon exits instead of
-// looping forever. Transient errors are logged and tick returns nil so
-// the next tick can retry.
+// tick runs one heartbeat cycle. A non-nil return is a permanent condition
+// (revoked credential / deleted fleet_node) that requires re-enrollment;
+// transient errors return nil so the next tick retries.
 func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, path string, logger *slog.Logger) error {
 	if r.sessionNeedsRefresh(st) {
 		if err := r.refreshAndSave(ctx, st, path, logger); err != nil {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -70,19 +70,20 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		r.parentCtx = context.Background()
 	}
 
-	// Resolve --plugins-dir (or the binary-adjacent default) before touching
-	// disk state so misconfiguration fails fast. The plugin manager execs
-	// anything in the resolved directory, so any non-owner write capability
-	// at that path is RCE-equivalent.
+	// Resolve --plugins-dir and --nmap-path before touching disk state so
+	// misconfiguration fails fast. The plugin manager execs anything in the
+	// resolved plugins dir, so any non-owner write capability there is
+	// RCE-equivalent.
+	exeDir := executableDir()
 	var resolvedPluginsDir string
 	if r.discoverer == nil {
-		resolved, resolveErr := resolvePluginsDir(r.PluginsDir, executableDir())
+		resolved, resolveErr := resolvePluginsDir(r.PluginsDir, exeDir)
 		if resolveErr != nil {
 			return resolveErr
 		}
 		resolvedPluginsDir = resolved
 	}
-	resolvedNmapPath, err := resolveNmapPath(r.NmapPath, executableDir())
+	resolvedNmapPath, err := resolveNmapPath(r.NmapPath, exeDir)
 	if err != nil {
 		return err
 	}

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -64,7 +64,10 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		}
 	}
 	if len(r.signals) == 0 {
-		r.signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+		// SIGHUP catches the terminal-close case so plugin children get the
+		// same orderly shutdown as Ctrl+C; without it the parent dies
+		// uncaught and leaves orphaned plugin processes behind.
+		r.signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP}
 	}
 	if r.parentCtx == nil {
 		r.parentCtx = context.Background()
@@ -101,7 +104,9 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		return fmt.Errorf("state at %s has no api_key; complete enrollment via `fleetnode refresh` before running the daemon", path)
 	}
 
+	logger := slog.New(slog.NewTextHandler(stderr, nil))
 	if resolvedPluginsDir != "" {
+		reapOrphanedPlugins(resolvedPluginsDir, logger)
 		disc, cleanup, bootstrapErr := newPluginDiscoverer(resolvedPluginsDir)
 		if bootstrapErr != nil {
 			return fmt.Errorf("bootstrap discovery plugins: %w", bootstrapErr)
@@ -109,8 +114,6 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		defer cleanup()
 		r.discoverer = disc
 	}
-
-	logger := slog.New(slog.NewTextHandler(stderr, nil))
 	if resolvedPluginsDir != "" {
 		source := "binary-adjacent"
 		if r.PluginsDir != "" {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
@@ -28,13 +27,15 @@ const (
 
 type RunCmd struct {
 	HeartbeatInterval time.Duration `name:"heartbeat-interval" default:"30s" help:"interval between UploadHeartbeat calls"`
-	PluginsDir        string        `name:"plugins-dir" help:"absolute path to the discovery plugins directory; required when the agent should execute server-issued discovery commands"`
+	PluginsDir        string        `name:"plugins-dir" help:"absolute path to the discovery plugins directory; defaults to <dir-of-binary>/plugins. If the resolved directory is missing the control loop stays off (heartbeat only)."`
+	NmapPath          string        `name:"nmap-path" help:"absolute path to the nmap binary; defaults to <dir-of-binary>/nmap when present, otherwise to 'nmap' on PATH at scan time"`
 
 	now           func() time.Time                                                `kong:"-"`
 	clientFactory func(serverURL string, tokenSource func() string) gatewayClient `kong:"-"`
 	signals       []os.Signal                                                     `kong:"-"`
 	parentCtx     context.Context                                                 `kong:"-"` //nolint:containedctx // test seam for daemon shutdown without OS signals
 	discoverer    discoverer                                                      `kong:"-"`
+	nmapPath      string                                                          `kong:"-"`
 
 	// Guards st.SessionToken: refreshAndSave writes; tokenSource reads.
 	stateMu sync.Mutex `kong:"-"`
@@ -69,14 +70,23 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		r.parentCtx = context.Background()
 	}
 
-	// CLI-flag validation runs before any disk/state work so misconfiguration
-	// fails fast. The plugin manager execs anything in PluginsDir, so a
-	// relative path would resolve against the daemon's CWD and let a writable
-	// launch directory host arbitrary code as the agent user.
-	controlWanted := r.discoverer == nil && r.PluginsDir != ""
-	if controlWanted && !filepath.IsAbs(r.PluginsDir) {
-		return fmt.Errorf("--plugins-dir must be an absolute path, got %q", r.PluginsDir)
+	// Resolve --plugins-dir (or the binary-adjacent default) before touching
+	// disk state so misconfiguration fails fast. The plugin manager execs
+	// anything in the resolved directory, so any non-owner write capability
+	// at that path is RCE-equivalent.
+	var resolvedPluginsDir string
+	if r.discoverer == nil {
+		resolved, resolveErr := resolvePluginsDir(r.PluginsDir, executableDir())
+		if resolveErr != nil {
+			return resolveErr
+		}
+		resolvedPluginsDir = resolved
 	}
+	resolvedNmapPath, err := resolveNmapPath(r.NmapPath, executableDir())
+	if err != nil {
+		return err
+	}
+	r.nmapPath = resolvedNmapPath
 
 	path := fleetnodebootstrap.StatePath(c.StateDir)
 	st, exists, err := fleetnodebootstrap.LoadState(path)
@@ -90,8 +100,8 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		return fmt.Errorf("state at %s has no api_key; complete enrollment via `fleetnode refresh` before running the daemon", path)
 	}
 
-	if controlWanted {
-		disc, cleanup, bootstrapErr := newPluginDiscoverer(r.PluginsDir)
+	if resolvedPluginsDir != "" {
+		disc, cleanup, bootstrapErr := newPluginDiscoverer(resolvedPluginsDir)
 		if bootstrapErr != nil {
 			return fmt.Errorf("bootstrap discovery plugins: %w", bootstrapErr)
 		}
@@ -100,6 +110,15 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 	}
 
 	logger := slog.New(slog.NewTextHandler(stderr, nil))
+	if resolvedPluginsDir != "" {
+		source := "binary-adjacent"
+		if r.PluginsDir != "" {
+			source = "flag"
+		}
+		logger.Info("plugins dir resolved", "plugins_dir", resolvedPluginsDir, "source", source)
+	} else if r.PluginsDir == "" {
+		logger.Info("no plugins dir found adjacent to binary; control loop disabled (heartbeat only)")
+	}
 
 	return fleetnodebootstrap.WithStateLock(c.StateDir, func() error {
 		return r.runLocked(c, logger)

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -55,6 +55,14 @@ func (s *stubGatewayClient) UploadHeartbeat(_ context.Context, req *connect.Requ
 	return connect.NewResponse(&pb.UploadHeartbeatResponse{}), nil
 }
 
+func (s *stubGatewayClient) ReportDiscoveredDevices(_ context.Context, _ *connect.Request[pb.ReportDiscoveredDevicesRequest]) (*connect.Response[pb.ReportDiscoveredDevicesResponse], error) {
+	return connect.NewResponse(&pb.ReportDiscoveredDevicesResponse{}), nil
+}
+
+func (s *stubGatewayClient) ControlStream(_ context.Context) *connect.BidiStreamForClient[pb.ControlStreamRequest, pb.ControlStreamResponse] {
+	return nil
+}
+
 func (s *stubGatewayClient) snapshot() (int, []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -104,7 +104,7 @@ func TestRunCmd_HappyPathThreeTicks(t *testing.T) {
 	cmd := &RunCmd{
 		HeartbeatInterval: 5 * time.Millisecond,
 		parentCtx:         parent,
-		clientFactory:     func(_ string, _ func() string) gatewayClient { return stub },
+		clientFactory:     func(_ string, _ func() string) (gatewayClient, error) { return stub, nil },
 	}
 
 	done := make(chan error, 1)
@@ -335,7 +335,7 @@ func TestRunCmd_ValidatesServerURLBeforeBuildingClient(t *testing.T) {
 	stub := &stubGatewayClient{}
 	cmd := &RunCmd{
 		HeartbeatInterval: time.Second,
-		clientFactory:     func(_ string, _ func() string) gatewayClient { return stub },
+		clientFactory:     func(_ string, _ func() string) (gatewayClient, error) { return stub, nil },
 	}
 
 	// Act
@@ -361,7 +361,7 @@ func TestRunCmd_ExitsOnCodeNotFoundHeartbeat(t *testing.T) {
 	}
 	cmd := &RunCmd{
 		HeartbeatInterval: 5 * time.Millisecond,
-		clientFactory:     func(_ string, _ func() string) gatewayClient { return stub },
+		clientFactory:     func(_ string, _ func() string) (gatewayClient, error) { return stub, nil },
 	}
 
 	// Act

--- a/server/internal/domain/netutil/iplist.go
+++ b/server/internal/domain/netutil/iplist.go
@@ -1,0 +1,69 @@
+package netutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// IPListResolver narrows net.Resolver to the one method NormalizeIPListEntry
+// needs, so callers can stub DNS in tests without spinning up a real
+// resolver. *net.Resolver satisfies the interface as-is.
+type IPListResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+// Sentinel errors so callers can branch on cause and emit useful logs.
+var (
+	ErrEmptyTarget        = errors.New("empty IP/hostname")
+	ErrScopedIPv6         = errors.New("scoped IPv6 (%zone) is not supported")
+	ErrLinkLocalIPv6      = errors.New("link-local IPv6 requires interface scope")
+	ErrHostnameUnresolved = errors.New("hostname did not resolve to a usable address")
+)
+
+// NormalizeIPListEntry returns the canonical IP literal for an entry in
+// pairing.v1.IPListModeRequest.ip_addresses. Hostnames are resolved via the
+// supplied resolver, preferring IPv4 and falling back to non-link-local
+// IPv6. Scoped IPv6 ("%zone") and link-local IPv6 ("fe80::/10") are
+// rejected: the TCP stack can't dial them without interface scope, and
+// net.IP.String() does not round-trip scope through DNS resolution.
+//
+// Callers should skip-and-log on error rather than fail the whole command;
+// partial scan beats no scan when one entry in a long list is bad.
+func NormalizeIPListEntry(ctx context.Context, raw string, resolver IPListResolver) (string, error) {
+	if raw == "" {
+		return "", ErrEmptyTarget
+	}
+	if strings.Contains(raw, "%") {
+		return "", fmt.Errorf("%w: %s", ErrScopedIPv6, raw)
+	}
+	if ip := net.ParseIP(raw); ip != nil {
+		if ip.To4() == nil && ip.IsLinkLocalUnicast() {
+			return "", fmt.Errorf("%w: %s", ErrLinkLocalIPv6, raw)
+		}
+		return ip.String(), nil
+	}
+	addrs, err := resolver.LookupIPAddr(ctx, raw)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", raw, err)
+	}
+	var ipv4, ipv6 string
+	for _, a := range addrs {
+		if a.IP.To4() != nil {
+			ipv4 = a.IP.String()
+			break
+		}
+		if ipv6 == "" && !a.IP.IsLinkLocalUnicast() {
+			ipv6 = a.IP.String()
+		}
+	}
+	if ipv4 != "" {
+		return ipv4, nil
+	}
+	if ipv6 != "" {
+		return ipv6, nil
+	}
+	return "", fmt.Errorf("%w: %s", ErrHostnameUnresolved, raw)
+}

--- a/server/internal/domain/netutil/iplist.go
+++ b/server/internal/domain/netutil/iplist.go
@@ -15,12 +15,13 @@ type IPListResolver interface {
 	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
 }
 
-// Sentinel errors so callers can branch on cause and emit useful logs.
+// Unexported because no caller branches on cause -- both pairing and the
+// agent just skip-and-log. The tests use these for clearer assertions.
 var (
-	ErrEmptyTarget        = errors.New("empty IP/hostname")
-	ErrScopedIPv6         = errors.New("scoped IPv6 (%zone) is not supported")
-	ErrLinkLocalIPv6      = errors.New("link-local IPv6 requires interface scope")
-	ErrHostnameUnresolved = errors.New("hostname did not resolve to a usable address")
+	errEmptyTarget        = errors.New("empty IP/hostname")
+	errScopedIPv6         = errors.New("scoped IPv6 (%zone) is not supported")
+	errLinkLocalIPv6      = errors.New("link-local IPv6 requires interface scope")
+	errHostnameUnresolved = errors.New("hostname did not resolve to a usable address")
 )
 
 // NormalizeIPListEntry returns the canonical IP literal for an entry in
@@ -34,14 +35,14 @@ var (
 // partial scan beats no scan when one entry in a long list is bad.
 func NormalizeIPListEntry(ctx context.Context, raw string, resolver IPListResolver) (string, error) {
 	if raw == "" {
-		return "", ErrEmptyTarget
+		return "", errEmptyTarget
 	}
 	if strings.Contains(raw, "%") {
-		return "", fmt.Errorf("%w: %s", ErrScopedIPv6, raw)
+		return "", fmt.Errorf("%w: %s", errScopedIPv6, raw)
 	}
 	if ip := net.ParseIP(raw); ip != nil {
 		if ip.To4() == nil && ip.IsLinkLocalUnicast() {
-			return "", fmt.Errorf("%w: %s", ErrLinkLocalIPv6, raw)
+			return "", fmt.Errorf("%w: %s", errLinkLocalIPv6, raw)
 		}
 		return ip.String(), nil
 	}
@@ -65,5 +66,5 @@ func NormalizeIPListEntry(ctx context.Context, raw string, resolver IPListResolv
 	if ipv6 != "" {
 		return ipv6, nil
 	}
-	return "", fmt.Errorf("%w: %s", ErrHostnameUnresolved, raw)
+	return "", fmt.Errorf("%w: %s", errHostnameUnresolved, raw)
 }

--- a/server/internal/domain/netutil/iplist_test.go
+++ b/server/internal/domain/netutil/iplist_test.go
@@ -1,0 +1,89 @@
+package netutil
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubResolver struct {
+	addrs map[string][]net.IPAddr
+	err   error
+}
+
+func (s stubResolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAddr, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if a, ok := s.addrs[host]; ok {
+		return a, nil
+	}
+	return nil, &net.DNSError{Err: "not found", Name: host, IsNotFound: true}
+}
+
+func TestNormalizeIPListEntry(t *testing.T) {
+	t.Parallel()
+
+	resolver := stubResolver{
+		addrs: map[string][]net.IPAddr{
+			"dual.example": {{IP: net.ParseIP("2001:db8::5")}, {IP: net.ParseIP("10.0.0.5")}},
+			"v6only.example": {
+				{IP: net.ParseIP("fe80::1")}, // link-local skipped
+				{IP: net.ParseIP("2001:db8::1")},
+			},
+			"linklocalonly.example": {{IP: net.ParseIP("fe80::1")}},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		input     string
+		want      string
+		wantErr   error
+		errSubstr string
+	}{
+		{name: "empty rejected", input: "", wantErr: ErrEmptyTarget},
+		{name: "scoped ipv6 rejected", input: "fe80::1%eth0", wantErr: ErrScopedIPv6},
+		{name: "link-local ipv6 rejected", input: "fe80::1", wantErr: ErrLinkLocalIPv6},
+		{name: "ipv4 passes through", input: "10.0.0.1", want: "10.0.0.1"},
+		{name: "ipv6 canonicalized", input: "2001:0DB8::1", want: "2001:db8::1"},
+		{name: "loopback ipv4", input: "127.0.0.1", want: "127.0.0.1"},
+		{name: "hostname prefers ipv4", input: "dual.example", want: "10.0.0.5"},
+		{name: "hostname falls back to non-link-local v6", input: "v6only.example", want: "2001:db8::1"},
+		{name: "hostname with only link-local v6 unresolved", input: "linklocalonly.example", wantErr: ErrHostnameUnresolved},
+		{name: "unknown hostname surfaces resolver error", input: "missing.example", errSubstr: "resolve missing.example"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got, err := NormalizeIPListEntry(context.Background(), tc.input, resolver)
+
+			// Assert
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr), "want %v, got %v", tc.wantErr, err)
+				return
+			}
+			if tc.errSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNormalizeIPListEntry_DefaultResolverSatisfiesInterface(t *testing.T) {
+	// Compile-time check that *net.Resolver satisfies IPListResolver. If a
+	// future Go release narrows or widens the method set, this test fails
+	// at build time and signals callers to update.
+	var _ IPListResolver = net.DefaultResolver
+}

--- a/server/internal/domain/netutil/iplist_test.go
+++ b/server/internal/domain/netutil/iplist_test.go
@@ -46,15 +46,15 @@ func TestNormalizeIPListEntry(t *testing.T) {
 		wantErr   error
 		errSubstr string
 	}{
-		{name: "empty rejected", input: "", wantErr: ErrEmptyTarget},
-		{name: "scoped ipv6 rejected", input: "fe80::1%eth0", wantErr: ErrScopedIPv6},
-		{name: "link-local ipv6 rejected", input: "fe80::1", wantErr: ErrLinkLocalIPv6},
+		{name: "empty rejected", input: "", wantErr: errEmptyTarget},
+		{name: "scoped ipv6 rejected", input: "fe80::1%eth0", wantErr: errScopedIPv6},
+		{name: "link-local ipv6 rejected", input: "fe80::1", wantErr: errLinkLocalIPv6},
 		{name: "ipv4 passes through", input: "10.0.0.1", want: "10.0.0.1"},
 		{name: "ipv6 canonicalized", input: "2001:0DB8::1", want: "2001:db8::1"},
 		{name: "loopback ipv4", input: "127.0.0.1", want: "127.0.0.1"},
 		{name: "hostname prefers ipv4", input: "dual.example", want: "10.0.0.5"},
 		{name: "hostname falls back to non-link-local v6", input: "v6only.example", want: "2001:db8::1"},
-		{name: "hostname with only link-local v6 unresolved", input: "linklocalonly.example", wantErr: ErrHostnameUnresolved},
+		{name: "hostname with only link-local v6 unresolved", input: "linklocalonly.example", wantErr: errHostnameUnresolved},
 		{name: "unknown hostname surfaces resolver error", input: "missing.example", errSubstr: "resolve missing.example"},
 	}
 	for _, tc := range cases {

--- a/server/internal/domain/pairing/service.go
+++ b/server/internal/domain/pairing/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/miner/models"
 	"github.com/block/proto-fleet/server/internal/domain/minerdiscovery"
 	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
+	"github.com/block/proto-fleet/server/internal/domain/netutil"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	tmodels "github.com/block/proto-fleet/server/internal/domain/telemetry/models"
@@ -801,54 +802,12 @@ func (s *Service) DiscoverWithIPList(ctx context.Context, r *pb.IPListModeReques
 					defer wg.Done()
 					defer func() { <-semaphore }()
 
-					// Reject scoped IPv6 literals (%zone) — the connection
-					// stack does not propagate interface scope.
-					if strings.Contains(ipAddr, "%") {
-						slog.Debug("rejecting scoped IPv6 address", "input", ipAddr)
+					normalized, err := netutil.NormalizeIPListEntry(timeoutCtx, ipAddr, net.DefaultResolver)
+					if err != nil {
+						slog.Debug("skipping ipList entry", "input", ipAddr, "err", err)
 						return
 					}
-					if parsedIP := net.ParseIP(ipAddr); parsedIP != nil {
-						// Reject link-local IPv6 — requires interface scope for
-						// TCP connections, consistent with mDNS and hostname paths.
-						if parsedIP.To4() == nil && parsedIP.IsLinkLocalUnicast() {
-							slog.Debug("rejecting link-local IPv6 address", "input", ipAddr)
-							return
-						}
-						// Normalize to canonical form so dedupe and storage
-						// treat equivalent spellings (e.g. 2001:0DB8::1 vs
-						// 2001:db8::1) as the same address.
-						ipAddr = parsedIP.String()
-					} else {
-						var resolver net.Resolver
-						addrs, err := resolver.LookupIPAddr(timeoutCtx, ipAddr)
-						if err != nil {
-							slog.Debug("hostname resolution failed, skipping entry", "input", ipAddr, "error", err)
-							return
-						}
-						var resolvedIPv4, resolvedIPv6 string
-						for _, addr := range addrs {
-							if addr.IP.To4() != nil {
-								resolvedIPv4 = addr.IP.String()
-								break // IPv4 is preferred; no need to look further
-							} else if resolvedIPv6 == "" && !addr.IP.IsLinkLocalUnicast() {
-								// Skip link-local IPv6 (fe80::) because net.IP.String()
-								// does not preserve the interface scope (%eth0) required
-								// for TCP connections.
-								resolvedIPv6 = addr.IP.String()
-							}
-						}
-						resolved := resolvedIPv4
-						if resolved == "" {
-							resolved = resolvedIPv6
-						}
-						if resolved == "" {
-							slog.Debug("hostname resolved but no address found, skipping entry", "input", ipAddr)
-							return
-						}
-						ipAddr = resolved
-					}
-
-					s.discoverAllPortsForIP(timeoutCtx, ipAddr, ports, rawResultChan)
+					s.discoverAllPortsForIP(timeoutCtx, normalized, ports, rawResultChan)
 				}(ip)
 			}
 		}

--- a/server/internal/fleetnodebootstrap/authclient.go
+++ b/server/internal/fleetnodebootstrap/authclient.go
@@ -13,12 +13,16 @@ import (
 // tokenSource is invoked per-call so a daemon that mutates its own
 // state.SessionToken via Refresh picks up the new value on the next
 // request without rebuilding the client.
-func NewAuthenticatedGatewayClient(serverURL string, tokenSource func() string) fleetnodegatewayv1connect.FleetNodeGatewayServiceClient {
+func NewAuthenticatedGatewayClient(serverURL string, tokenSource func() string) (fleetnodegatewayv1connect.FleetNodeGatewayServiceClient, error) {
+	httpClient, err := newGatewayHTTPClient(serverURL)
+	if err != nil {
+		return nil, err
+	}
 	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(
-		newGatewayHTTPClient(),
+		httpClient,
 		serverURL,
 		connect.WithInterceptors(bearerInterceptor(tokenSource)),
-	)
+	), nil
 }
 
 func bearerInterceptor(tokenSource func() string) connect.Interceptor {

--- a/server/internal/fleetnodebootstrap/authclient_test.go
+++ b/server/internal/fleetnodebootstrap/authclient_test.go
@@ -11,6 +11,8 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
@@ -47,7 +49,8 @@ func TestAuthenticatedClient_AttachesBearerHeaderPerCall(t *testing.T) {
 	mux := http.NewServeMux()
 	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
 	mux.Handle(path, h)
-	srv := httptest.NewServer(mux)
+	srv := httptest.NewUnstartedServer(h2c.NewHandler(mux, &http2.Server{}))
+	srv.Start()
 	t.Cleanup(srv.Close)
 
 	var token string
@@ -72,7 +75,8 @@ func TestAuthenticatedClient_RejectsEmptyToken(t *testing.T) {
 	t.Parallel()
 
 	// Arrange
-	srv := httptest.NewServer(http.NewServeMux())
+	srv := httptest.NewUnstartedServer(h2c.NewHandler(http.NewServeMux(), &http2.Server{}))
+	srv.Start()
 	t.Cleanup(srv.Close)
 	client := NewAuthenticatedGatewayClient(srv.URL, func() string { return "" })
 

--- a/server/internal/fleetnodebootstrap/authclient_test.go
+++ b/server/internal/fleetnodebootstrap/authclient_test.go
@@ -3,7 +3,6 @@ package fleetnodebootstrap
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -11,12 +10,11 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
+	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
 type captureGateway struct {
@@ -49,9 +47,7 @@ func TestAuthenticatedClient_AttachesBearerHeaderPerCall(t *testing.T) {
 	mux := http.NewServeMux()
 	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
 	mux.Handle(path, h)
-	srv := httptest.NewUnstartedServer(h2c.NewHandler(mux, &http2.Server{}))
-	srv.Start()
-	t.Cleanup(srv.Close)
+	srv := testutil.NewH2CServer(t, mux)
 
 	var token string
 	client := NewAuthenticatedGatewayClient(srv.URL, func() string { return token })
@@ -75,9 +71,7 @@ func TestAuthenticatedClient_RejectsEmptyToken(t *testing.T) {
 	t.Parallel()
 
 	// Arrange
-	srv := httptest.NewUnstartedServer(h2c.NewHandler(http.NewServeMux(), &http2.Server{}))
-	srv.Start()
-	t.Cleanup(srv.Close)
+	srv := testutil.NewH2CServer(t, http.NewServeMux())
 	client := NewAuthenticatedGatewayClient(srv.URL, func() string { return "" })
 
 	// Act

--- a/server/internal/fleetnodebootstrap/authclient_test.go
+++ b/server/internal/fleetnodebootstrap/authclient_test.go
@@ -50,11 +50,12 @@ func TestAuthenticatedClient_AttachesBearerHeaderPerCall(t *testing.T) {
 	srv := testutil.NewH2CServer(t, mux)
 
 	var token string
-	client := NewAuthenticatedGatewayClient(srv.URL, func() string { return token })
+	client, err := NewAuthenticatedGatewayClient(srv.URL, func() string { return token })
+	require.NoError(t, err)
 
 	// Act
 	token = "t1"
-	_, err := client.UploadHeartbeat(context.Background(), connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()}))
+	_, err = client.UploadHeartbeat(context.Background(), connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()}))
 	require.NoError(t, err)
 	token = "t2"
 	_, err = client.UploadHeartbeat(context.Background(), connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()}))
@@ -72,12 +73,13 @@ func TestAuthenticatedClient_RejectsEmptyToken(t *testing.T) {
 
 	// Arrange
 	srv := testutil.NewH2CServer(t, http.NewServeMux())
-	client := NewAuthenticatedGatewayClient(srv.URL, func() string { return "" })
+	client, err := NewAuthenticatedGatewayClient(srv.URL, func() string { return "" })
+	require.NoError(t, err)
 
 	// Act
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_, err := client.UploadHeartbeat(ctx, connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()}))
+	_, err = client.UploadHeartbeat(ctx, connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()}))
 
 	// Assert
 	require.Error(t, err)

--- a/server/internal/fleetnodebootstrap/client.go
+++ b/server/internal/fleetnodebootstrap/client.go
@@ -1,25 +1,39 @@
 package fleetnodebootstrap
 
 import (
+	"context"
+	"crypto/tls"
 	"errors"
+	"net"
 	"net/http"
-	"time"
+
+	"golang.org/x/net/http2"
 
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 )
-
-const httpClientTimeout = 30 * time.Second
 
 // Refusing every 30x stops a downgrade redirect from replaying the POST body
 // (enrollment token, api_key, signature) to a plaintext target; Connect-RPC
 // itself never expects redirects.
 var errRedirectNotAllowed = errors.New("redirects are not allowed for connect-rpc calls")
 
+// newGatewayHTTPClient returns a client speaking HTTP/2. The gateway's
+// ControlStream is a bidi RPC, which the standard HTTP/1.1 transport can't
+// carry. The h2c (plaintext HTTP/2) pattern below mirrors what the server's
+// h2c.NewHandler accepts; production HTTPS support is a follow-up. Timeout
+// is omitted on purpose -- it would cap long-lived streams; callers wrap
+// individual RPCs in per-call context deadlines.
 func newGatewayHTTPClient() *http.Client {
 	return &http.Client{
-		Timeout: httpClientTimeout,
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return errRedirectNotAllowed
+		},
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
+			},
 		},
 	}
 }

--- a/server/internal/fleetnodebootstrap/client.go
+++ b/server/internal/fleetnodebootstrap/client.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 
 	"golang.org/x/net/http2"
 
@@ -16,23 +18,40 @@ import (
 // body (enrollment token, api_key, signature) to an attacker-chosen target.
 var errRedirectNotAllowed = errors.New("redirects are not allowed for connect-rpc calls")
 
-// Timeout is intentionally unset -- it would cap long-lived bidi streams.
-// Callers wrap individual RPCs in per-call context deadlines instead.
-func newGatewayHTTPClient() *http.Client {
-	return &http.Client{
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return errRedirectNotAllowed
-		},
-		Transport: &http2.Transport{
+// A shared AllowHTTP+DialTLSContext shim would silently downgrade https to
+// plaintext, defeating ValidateServerURL's https-required policy.
+func newGatewayHTTPClient(serverURL string) (*http.Client, error) {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse server-url: %w", err)
+	}
+	var tr http.RoundTripper
+	switch u.Scheme {
+	case "http":
+		tr = &http2.Transport{
 			AllowHTTP: true,
 			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
 				var d net.Dialer
 				return d.DialContext(ctx, network, addr)
 			},
-		},
+		}
+	case "https":
+		tr = &http2.Transport{}
+	default:
+		return nil, fmt.Errorf("server-url scheme must be http or https; got %q", u.Scheme)
 	}
+	return &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errRedirectNotAllowed
+		},
+		Transport: tr,
+	}, nil
 }
 
-func NewGatewayClient(serverURL string) fleetnodegatewayv1connect.FleetNodeGatewayServiceClient {
-	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(newGatewayHTTPClient(), serverURL)
+func NewGatewayClient(serverURL string) (fleetnodegatewayv1connect.FleetNodeGatewayServiceClient, error) {
+	httpClient, err := newGatewayHTTPClient(serverURL)
+	if err != nil {
+		return nil, err
+	}
+	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(httpClient, serverURL), nil
 }

--- a/server/internal/fleetnodebootstrap/client.go
+++ b/server/internal/fleetnodebootstrap/client.go
@@ -17,12 +17,8 @@ import (
 // itself never expects redirects.
 var errRedirectNotAllowed = errors.New("redirects are not allowed for connect-rpc calls")
 
-// newGatewayHTTPClient returns a client speaking HTTP/2. The gateway's
-// ControlStream is a bidi RPC, which the standard HTTP/1.1 transport can't
-// carry. The h2c (plaintext HTTP/2) pattern below mirrors what the server's
-// h2c.NewHandler accepts; production HTTPS support is a follow-up. Timeout
-// is omitted on purpose -- it would cap long-lived streams; callers wrap
-// individual RPCs in per-call context deadlines.
+// http.Client.Timeout is omitted on purpose -- it would cap long-lived
+// streams. Callers wrap individual RPCs in per-call context deadlines.
 func newGatewayHTTPClient() *http.Client {
 	return &http.Client{
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {

--- a/server/internal/fleetnodebootstrap/client.go
+++ b/server/internal/fleetnodebootstrap/client.go
@@ -12,13 +12,12 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 )
 
-// Refusing every 30x stops a downgrade redirect from replaying the POST body
-// (enrollment token, api_key, signature) to a plaintext target; Connect-RPC
-// itself never expects redirects.
+// Refusing 3xx stops a downgrade redirect from replaying the signed POST
+// body (enrollment token, api_key, signature) to an attacker-chosen target.
 var errRedirectNotAllowed = errors.New("redirects are not allowed for connect-rpc calls")
 
-// http.Client.Timeout is omitted on purpose -- it would cap long-lived
-// streams. Callers wrap individual RPCs in per-call context deadlines.
+// Timeout is intentionally unset -- it would cap long-lived bidi streams.
+// Callers wrap individual RPCs in per-call context deadlines instead.
 func newGatewayHTTPClient() *http.Client {
 	return &http.Client{
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {

--- a/server/internal/fleetnodebootstrap/client_test.go
+++ b/server/internal/fleetnodebootstrap/client_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 func TestGatewayHTTPClient_RejectsRedirect(t *testing.T) {
@@ -25,10 +27,12 @@ func TestGatewayHTTPClient_RejectsRedirect(t *testing.T) {
 			t.Parallel()
 
 			// Arrange
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Location", "http://attacker.example.com/")
 				w.WriteHeader(code)
-			}))
+			})
+			srv := httptest.NewUnstartedServer(h2c.NewHandler(handler, &http2.Server{}))
+			srv.Start()
 			t.Cleanup(srv.Close)
 			client := newGatewayHTTPClient()
 
@@ -43,14 +47,4 @@ func TestGatewayHTTPClient_RejectsRedirect(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGatewayHTTPClient_HasTimeout(t *testing.T) {
-	t.Parallel()
-
-	// Act
-	client := newGatewayHTTPClient()
-
-	// Assert
-	assert.Equal(t, httpClientTimeout, client.Timeout)
 }

--- a/server/internal/fleetnodebootstrap/client_test.go
+++ b/server/internal/fleetnodebootstrap/client_test.go
@@ -2,14 +2,13 @@ package fleetnodebootstrap
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
+
+	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
 func TestGatewayHTTPClient_RejectsRedirect(t *testing.T) {
@@ -27,13 +26,10 @@ func TestGatewayHTTPClient_RejectsRedirect(t *testing.T) {
 			t.Parallel()
 
 			// Arrange
-			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			srv := testutil.NewH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Location", "http://attacker.example.com/")
 				w.WriteHeader(code)
-			})
-			srv := httptest.NewUnstartedServer(h2c.NewHandler(handler, &http2.Server{}))
-			srv.Start()
-			t.Cleanup(srv.Close)
+			}))
 			client := newGatewayHTTPClient()
 
 			// Act

--- a/server/internal/fleetnodebootstrap/client_test.go
+++ b/server/internal/fleetnodebootstrap/client_test.go
@@ -1,15 +1,89 @@
 package fleetnodebootstrap
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
 
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
+
+func newHTTP2TestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Regression coverage for the prior DialTLSContext shim that quietly
+// bypassed TLS for https:// URLs.
+func TestGatewayHTTPClient_HTTPS_ValidatesCertificate(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	srv := newHTTP2TestServer(t)
+	trusted, err := newGatewayHTTPClient(srv.URL)
+	require.NoError(t, err)
+	tlsTransport, ok := trusted.Transport.(*http2.Transport)
+	require.True(t, ok, "https client must use http2.Transport")
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	tlsTransport.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+
+	// Act
+	resp, err := trusted.Get(srv.URL)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestGatewayHTTPClient_HTTPS_RejectsUntrustedCertificate(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	srv := newHTTP2TestServer(t)
+	client, err := newGatewayHTTPClient(srv.URL)
+	require.NoError(t, err)
+
+	// Act
+	resp, err := client.Get(srv.URL) //nolint:bodyclose // request fails; resp is nil
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "x509", "expected x509 cert validation error, got %v", err)
+}
+
+func TestNewGatewayClient_RejectsNonHTTPScheme(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"ftp://example.com", "://no-scheme", "ws://example.com"}
+	for _, target := range cases {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			_, err := NewGatewayClient(target)
+
+			// Assert
+			require.Error(t, err)
+		})
+	}
+}
 
 func TestGatewayHTTPClient_RejectsRedirect(t *testing.T) {
 	t.Parallel()
@@ -30,7 +104,8 @@ func TestGatewayHTTPClient_RejectsRedirect(t *testing.T) {
 				w.Header().Set("Location", "http://attacker.example.com/")
 				w.WriteHeader(code)
 			}))
-			client := newGatewayHTTPClient()
+			client, err := newGatewayHTTPClient(srv.URL)
+			require.NoError(t, err)
 
 			// Act
 			resp, err := client.Post(srv.URL, "application/proto", strings.NewReader(""))

--- a/server/internal/fleetnodebootstrap/enrollment.go
+++ b/server/internal/fleetnodebootstrap/enrollment.go
@@ -59,12 +59,14 @@ func Register(ctx context.Context, p RegisterParams) (*RegisterResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Register(ctx, connect.NewRequest(&pb.RegisterRequest{
+	callCtx, cancel := withHandshakeTimeout(ctx)
+	resp, err := client.Register(callCtx, connect.NewRequest(&pb.RegisterRequest{
 		EnrollmentToken:    p.Code,
 		Name:               p.Name,
 		IdentityPubkey:     idPub,
 		MinerSigningPubkey: mPub,
 	}))
+	cancel()
 	if err != nil {
 		code := connect.CodeOf(err)
 		if code == connect.CodeAlreadyExists || code == connect.CodeFailedPrecondition || code == connect.CodeUnauthenticated {

--- a/server/internal/fleetnodebootstrap/enrollment.go
+++ b/server/internal/fleetnodebootstrap/enrollment.go
@@ -55,7 +55,10 @@ func Register(ctx context.Context, p RegisterParams) (*RegisterResult, error) {
 		return nil, err
 	}
 
-	client := NewGatewayClient(p.ServerURL)
+	client, err := NewGatewayClient(p.ServerURL)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := client.Register(ctx, connect.NewRequest(&pb.RegisterRequest{
 		EnrollmentToken:    p.Code,
 		Name:               p.Name,
@@ -107,7 +110,11 @@ func CompleteEnrollment(ctx context.Context, state *State, apiKey string) error 
 
 	attempt := *state
 	attempt.APIKey = apiKey
-	if err := RunHandshake(ctx, NewGatewayClient(state.ServerURL), &attempt); err != nil {
+	client, err := NewGatewayClient(state.ServerURL)
+	if err != nil {
+		return err
+	}
+	if err := RunHandshake(ctx, client, &attempt); err != nil {
 		return err
 	}
 	state.APIKey = attempt.APIKey

--- a/server/internal/fleetnodebootstrap/enrollment_test.go
+++ b/server/internal/fleetnodebootstrap/enrollment_test.go
@@ -246,9 +246,7 @@ func TestCompleteEnrollment_RejectsEmptyInputs(t *testing.T) {
 }
 
 func TestRegister_TimesOutAgainstBlackholeServer(t *testing.T) {
-	// Arrange: a TCP listener that accepts but never speaks. Register must
-	// bail within the handshake timeout instead of hanging while it holds
-	// the state lock at the call site.
+	// Arrange
 	prev := handshakeStepTimeout
 	handshakeStepTimeout = 250 * time.Millisecond
 	t.Cleanup(func() { handshakeStepTimeout = prev })

--- a/server/internal/fleetnodebootstrap/enrollment_test.go
+++ b/server/internal/fleetnodebootstrap/enrollment_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
+	"net"
 	"testing"
 	"time"
 
@@ -242,6 +243,42 @@ func TestCompleteEnrollment_RejectsEmptyInputs(t *testing.T) {
 	require.Error(t, errEmptyKey)
 	assert.Contains(t, errNilState.Error(), "state")
 	assert.Contains(t, errEmptyKey.Error(), "apiKey")
+}
+
+func TestRegister_TimesOutAgainstBlackholeServer(t *testing.T) {
+	// Arrange: a TCP listener that accepts but never speaks. Register must
+	// bail within the handshake timeout instead of hanging while it holds
+	// the state lock at the call site.
+	prev := handshakeStepTimeout
+	handshakeStepTimeout = 250 * time.Millisecond
+	t.Cleanup(func() { handshakeStepTimeout = prev })
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	// Act
+	start := time.Now()
+	_, err = Register(t.Context(), RegisterParams{
+		ServerURL:              "http://" + ln.Addr().String(),
+		Name:                   "stuck",
+		Code:                   "anything",
+		AllowInsecureTransport: true,
+	})
+	elapsed := time.Since(start)
+
+	// Assert
+	require.Error(t, err)
+	assert.Less(t, elapsed, 5*time.Second, "Register should not block past the per-call timeout")
 }
 
 func TestValidateServerURL(t *testing.T) {

--- a/server/internal/fleetnodebootstrap/handshake.go
+++ b/server/internal/fleetnodebootstrap/handshake.go
@@ -14,7 +14,6 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 )
 
-// var (not const) so tests can shorten the timeout without 30s waits.
 var handshakeStepTimeout = 30 * time.Second
 
 // ErrBeginAuthRejected wraps Unauthenticated from BeginAuthHandshake, which

--- a/server/internal/fleetnodebootstrap/handshake.go
+++ b/server/internal/fleetnodebootstrap/handshake.go
@@ -45,12 +45,12 @@ func RunHandshake(ctx context.Context, c fleetnodegatewayv1connect.FleetNodeGate
 		return errors.New("client is required")
 	}
 
-	beginCtx, cancelBegin := context.WithTimeout(ctx, handshakeStepTimeout)
+	beginCtx, cancel := withHandshakeTimeout(ctx)
 	begin, err := c.BeginAuthHandshake(beginCtx, connect.NewRequest(&pb.BeginAuthHandshakeRequest{
 		ApiKey:         s.APIKey,
 		IdentityPubkey: pub,
 	}))
-	cancelBegin()
+	cancel()
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeUnauthenticated {
 			return fmt.Errorf("%w: %w", ErrBeginAuthRejected, err)
@@ -60,12 +60,12 @@ func RunHandshake(ctx context.Context, c fleetnodegatewayv1connect.FleetNodeGate
 	challenge := begin.Msg.GetChallenge()
 	signature := ed25519.Sign(ed25519.PrivateKey(priv), challenge)
 
-	completeCtx, cancelComplete := context.WithTimeout(ctx, handshakeStepTimeout)
+	completeCtx, cancel := withHandshakeTimeout(ctx)
 	complete, err := c.CompleteAuthHandshake(completeCtx, connect.NewRequest(&pb.CompleteAuthHandshakeRequest{
 		Challenge: challenge,
 		Signature: signature,
 	}))
-	cancelComplete()
+	cancel()
 	if err != nil {
 		return fmt.Errorf("complete handshake: %w", err)
 	}
@@ -75,4 +75,8 @@ func RunHandshake(ctx context.Context, c fleetnodegatewayv1connect.FleetNodeGate
 		s.SessionExpiresAt = exp.AsTime()
 	}
 	return nil
+}
+
+func withHandshakeTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, handshakeStepTimeout)
 }

--- a/server/internal/fleetnodebootstrap/handshake.go
+++ b/server/internal/fleetnodebootstrap/handshake.go
@@ -6,12 +6,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
 
 	"connectrpc.com/connect"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 )
+
+const handshakeStepTimeout = 30 * time.Second
 
 // Wraps Unauthenticated from BeginAuthHandshake. The server returns it for
 // api_key revocation, identity_pubkey mismatch, or any other auth failure
@@ -42,10 +45,12 @@ func RunHandshake(ctx context.Context, c fleetnodegatewayv1connect.FleetNodeGate
 		return errors.New("client is required")
 	}
 
-	begin, err := c.BeginAuthHandshake(ctx, connect.NewRequest(&pb.BeginAuthHandshakeRequest{
+	beginCtx, cancelBegin := context.WithTimeout(ctx, handshakeStepTimeout)
+	begin, err := c.BeginAuthHandshake(beginCtx, connect.NewRequest(&pb.BeginAuthHandshakeRequest{
 		ApiKey:         s.APIKey,
 		IdentityPubkey: pub,
 	}))
+	cancelBegin()
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeUnauthenticated {
 			return fmt.Errorf("%w: %w", ErrBeginAuthRejected, err)
@@ -55,10 +60,12 @@ func RunHandshake(ctx context.Context, c fleetnodegatewayv1connect.FleetNodeGate
 	challenge := begin.Msg.GetChallenge()
 	signature := ed25519.Sign(ed25519.PrivateKey(priv), challenge)
 
-	complete, err := c.CompleteAuthHandshake(ctx, connect.NewRequest(&pb.CompleteAuthHandshakeRequest{
+	completeCtx, cancelComplete := context.WithTimeout(ctx, handshakeStepTimeout)
+	complete, err := c.CompleteAuthHandshake(completeCtx, connect.NewRequest(&pb.CompleteAuthHandshakeRequest{
 		Challenge: challenge,
 		Signature: signature,
 	}))
+	cancelComplete()
 	if err != nil {
 		return fmt.Errorf("complete handshake: %w", err)
 	}

--- a/server/internal/fleetnodebootstrap/handshake.go
+++ b/server/internal/fleetnodebootstrap/handshake.go
@@ -14,7 +14,8 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 )
 
-const handshakeStepTimeout = 30 * time.Second
+// var (not const) so tests can shorten the timeout without 30s waits.
+var handshakeStepTimeout = 30 * time.Second
 
 // ErrBeginAuthRejected wraps Unauthenticated from BeginAuthHandshake, which
 // the server returns for revoked api_key, identity_pubkey mismatch, or any

--- a/server/internal/fleetnodebootstrap/handshake.go
+++ b/server/internal/fleetnodebootstrap/handshake.go
@@ -16,13 +16,13 @@ import (
 
 const handshakeStepTimeout = 30 * time.Second
 
-// Wraps Unauthenticated from BeginAuthHandshake. The server returns it for
-// api_key revocation, identity_pubkey mismatch, or any other auth failure
-// on that call; the library cannot distinguish the cause. Distinct from
-// CompleteAuthHandshake failures (expired challenge, bad signature).
+// ErrBeginAuthRejected wraps Unauthenticated from BeginAuthHandshake, which
+// the server returns for revoked api_key, identity_pubkey mismatch, or any
+// auth failure on that call. Kept distinct from CompleteAuthHandshake errors
+// (expired challenge, bad signature) so callers can branch on root cause.
 var ErrBeginAuthRejected = errors.New("BeginAuthHandshake rejected")
 
-// Mutates s.SessionToken and s.SessionExpiresAt only on success.
+// RunHandshake mutates s.SessionToken / s.SessionExpiresAt only on success.
 func RunHandshake(ctx context.Context, c fleetnodegatewayv1connect.FleetNodeGatewayServiceClient, s *State) error {
 	if s == nil {
 		return errors.New("state is required")

--- a/server/internal/fleetnodebootstrap/handshake_test.go
+++ b/server/internal/fleetnodebootstrap/handshake_test.go
@@ -14,12 +14,11 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
+	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
 type fakeAgentGateway struct {
@@ -83,10 +82,7 @@ func newFakeServer(t *testing.T, fake *fakeAgentGateway) *httptest.Server {
 	mux := http.NewServeMux()
 	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
 	mux.Handle(path, h)
-	srv := httptest.NewUnstartedServer(h2c.NewHandler(mux, &http2.Server{}))
-	srv.Start()
-	t.Cleanup(srv.Close)
-	return srv
+	return testutil.NewH2CServer(t, mux)
 }
 
 func TestRunHandshake_RejectsNilState(t *testing.T) {

--- a/server/internal/fleetnodebootstrap/handshake_test.go
+++ b/server/internal/fleetnodebootstrap/handshake_test.go
@@ -14,6 +14,8 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
@@ -81,7 +83,8 @@ func newFakeServer(t *testing.T, fake *fakeAgentGateway) *httptest.Server {
 	mux := http.NewServeMux()
 	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
 	mux.Handle(path, h)
-	srv := httptest.NewServer(mux)
+	srv := httptest.NewUnstartedServer(h2c.NewHandler(mux, &http2.Server{}))
+	srv.Start()
 	t.Cleanup(srv.Close)
 	return srv
 }

--- a/server/internal/fleetnodebootstrap/handshake_test.go
+++ b/server/internal/fleetnodebootstrap/handshake_test.go
@@ -136,7 +136,8 @@ func TestRunHandshake_HappyPath(t *testing.T) {
 		IdentityPrivateKeyHex: hex.EncodeToString(priv),
 		IdentityPublicKeyHex:  hex.EncodeToString(pub),
 	}
-	client := NewGatewayClient(srv.URL)
+	client, err := NewGatewayClient(srv.URL)
+	require.NoError(t, err)
 
 	// Act
 	err = RunHandshake(t.Context(), client, state)
@@ -165,7 +166,8 @@ func TestRunHandshake_WrongAPIKey(t *testing.T) {
 		IdentityPrivateKeyHex: hex.EncodeToString(priv),
 		IdentityPublicKeyHex:  hex.EncodeToString(pub),
 	}
-	client := NewGatewayClient(srv.URL)
+	client, err := NewGatewayClient(srv.URL)
+	require.NoError(t, err)
 
 	// Act
 	err = RunHandshake(t.Context(), client, state)
@@ -249,7 +251,8 @@ func TestRunHandshake_BadSignature(t *testing.T) {
 		IdentityPrivateKeyHex: hex.EncodeToString(otherPriv),
 		IdentityPublicKeyHex:  hex.EncodeToString(pub),
 	}
-	client := NewGatewayClient(srv.URL)
+	client, err := NewGatewayClient(srv.URL)
+	require.NoError(t, err)
 
 	// Act
 	err = RunHandshake(t.Context(), client, state)

--- a/server/internal/fleetnodebootstrap/locking_unix.go
+++ b/server/internal/fleetnodebootstrap/locking_unix.go
@@ -46,11 +46,9 @@ func WithStateLock(dir string, fn func() error) error {
 		}
 		return fmt.Errorf("acquire state lock: %w", err)
 	}
-	if err := writeLockOwnerPID(f); err != nil {
-		// Non-fatal: future contention diagnostics will be less specific,
-		// but the lock itself is held and fn can proceed.
-		_ = err
-	}
+	// Best-effort: a failed write leaves the lockfile empty, which only
+	// degrades the next contention error to the "unknown holder" form.
+	_ = writeLockOwnerPID(f)
 	return fn()
 }
 

--- a/server/internal/fleetnodebootstrap/locking_unix.go
+++ b/server/internal/fleetnodebootstrap/locking_unix.go
@@ -13,15 +13,11 @@ import (
 	"syscall"
 )
 
-// Serializes concurrent refreshes via flock on <dir>/state.lock so a slower
-// writer can't clobber a newer state.yaml. Refuses to follow a symlink at
-// the dir leaf so the lock can't land in an attacker-chosen location and
-// silently break serialization for the SaveState that follows.
-//
-// Acquires with LOCK_NB so a held lock fails fast with a useful error
-// instead of blocking the caller forever. On contention, reads the current
-// holder's PID (recorded inside the lock) and tells the operator who to
-// stop, distinguishing a live process from a stale lockfile.
+// WithStateLock serializes refreshes via flock on <dir>/state.lock. Lstat
+// rejects symlink leaves so an attacker can't redirect the lock to a path
+// they control and break serialization of the following SaveState. LOCK_NB
+// fails fast with a useful error (naming the recorded holder pid) instead
+// of blocking forever.
 func WithStateLock(dir string, fn func() error) error {
 	if info, err := os.Lstat(dir); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("state dir %s is a symlink; refusing to take a lock through it", dir)
@@ -37,8 +33,7 @@ func WithStateLock(dir string, fn func() error) error {
 	if err != nil {
 		return fmt.Errorf("open state lock: %w", err)
 	}
-	// Kernel releases flock on close; explicit LOCK_UN would race with the
-	// deferred Close.
+	// Closing f releases the flock; explicit LOCK_UN would race the defer.
 	defer func() { _ = f.Close() }()
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		if errors.Is(err, syscall.EWOULDBLOCK) {
@@ -46,9 +41,7 @@ func WithStateLock(dir string, fn func() error) error {
 		}
 		return fmt.Errorf("acquire state lock: %w", err)
 	}
-	// Best-effort: a failed write leaves the lockfile empty, which only
-	// degrades the next contention error to the "unknown holder" form.
-	_ = writeLockOwnerPID(f)
+	_ = writeLockOwnerPID(f) // best-effort; failure only degrades the next contention error.
 	return fn()
 }
 
@@ -70,9 +63,7 @@ func contendedLockError(lockPath string, f *os.File) error {
 		if processAlive(pid) {
 			return fmt.Errorf("state lock %s held by fleetnode pid=%d; stop it (kill %d) or use a different --state-dir", lockPath, pid, pid)
 		}
-		// Owner is dead but the kernel hasn't released the flock yet,
-		// usually because a subprocess inherited the FD. Operator
-		// intervention is still required.
+		// Dead owner + held lock means a subprocess inherited the FD.
 		return fmt.Errorf("state lock %s contended; recorded owner pid=%d is not running but the lock is still held (likely a subprocess inherited the FD); kill any lingering fleetnode children or use a different --state-dir", lockPath, pid)
 	}
 	return fmt.Errorf("state lock %s held by an unknown process; check `pgrep -lf fleetnode` and stop it, or use a different --state-dir", lockPath)
@@ -95,17 +86,12 @@ func readLockOwnerPID(f *os.File) (int, bool) {
 
 func processAlive(pid int) bool {
 	err := syscall.Kill(pid, 0)
-	if err == nil {
-		return true
-	}
-	// EPERM means the process exists but we don't have permission to
-	// signal it (different uid); still "alive" for our purposes.
-	return errors.Is(err, syscall.EPERM)
+	// EPERM means alive but different uid -- still "alive" for our purposes.
+	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
-// fsyncs a directory so a preceding os.Rename is durable across a power
-// loss. POSIX only: Windows directory handles do not support
-// FlushFileBuffers.
+// syncDir fsyncs a directory so a preceding os.Rename survives a power loss.
+// POSIX only; Windows directory handles don't support FlushFileBuffers.
 func syncDir(path string) error {
 	f, err := os.Open(path)
 	if err != nil {

--- a/server/internal/fleetnodebootstrap/locking_unix.go
+++ b/server/internal/fleetnodebootstrap/locking_unix.go
@@ -3,9 +3,13 @@
 package fleetnodebootstrap
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -13,6 +17,11 @@ import (
 // writer can't clobber a newer state.yaml. Refuses to follow a symlink at
 // the dir leaf so the lock can't land in an attacker-chosen location and
 // silently break serialization for the SaveState that follows.
+//
+// Acquires with LOCK_NB so a held lock fails fast with a useful error
+// instead of blocking the caller forever. On contention, reads the current
+// holder's PID (recorded inside the lock) and tells the operator who to
+// stop, distinguishing a live process from a stale lockfile.
 func WithStateLock(dir string, fn func() error) error {
 	if info, err := os.Lstat(dir); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("state dir %s is a symlink; refusing to take a lock through it", dir)
@@ -23,17 +32,77 @@ func WithStateLock(dir string, fn func() error) error {
 	if err := tightenStateDirPerms(dir); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(filepath.Join(dir, "state.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	lockPath := filepath.Join(dir, "state.lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return fmt.Errorf("open state lock: %w", err)
 	}
 	// Kernel releases flock on close; explicit LOCK_UN would race with the
 	// deferred Close.
 	defer func() { _ = f.Close() }()
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return contendedLockError(lockPath, f)
+		}
 		return fmt.Errorf("acquire state lock: %w", err)
 	}
+	if err := writeLockOwnerPID(f); err != nil {
+		// Non-fatal: future contention diagnostics will be less specific,
+		// but the lock itself is held and fn can proceed.
+		_ = err
+	}
 	return fn()
+}
+
+func writeLockOwnerPID(f *os.File) error {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek lock file: %w", err)
+	}
+	if err := f.Truncate(0); err != nil {
+		return fmt.Errorf("truncate lock file: %w", err)
+	}
+	if _, err := fmt.Fprintf(f, "%d\n", os.Getpid()); err != nil {
+		return fmt.Errorf("write lock owner pid: %w", err)
+	}
+	return nil
+}
+
+func contendedLockError(lockPath string, f *os.File) error {
+	if pid, ok := readLockOwnerPID(f); ok {
+		if processAlive(pid) {
+			return fmt.Errorf("state lock %s held by fleetnode pid=%d; stop it (kill %d) or use a different --state-dir", lockPath, pid, pid)
+		}
+		// Owner is dead but the kernel hasn't released the flock yet,
+		// usually because a subprocess inherited the FD. Operator
+		// intervention is still required.
+		return fmt.Errorf("state lock %s contended; recorded owner pid=%d is not running but the lock is still held (likely a subprocess inherited the FD); kill any lingering fleetnode children or use a different --state-dir", lockPath, pid)
+	}
+	return fmt.Errorf("state lock %s held by an unknown process; check `pgrep -lf fleetnode` and stop it, or use a different --state-dir", lockPath)
+}
+
+func readLockOwnerPID(f *os.File) (int, bool) {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return 0, false
+	}
+	data, err := io.ReadAll(io.LimitReader(f, 32))
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	// EPERM means the process exists but we don't have permission to
+	// signal it (different uid); still "alive" for our purposes.
+	return errors.Is(err, syscall.EPERM)
 }
 
 // fsyncs a directory so a preceding os.Rename is durable across a power

--- a/server/internal/fleetnodebootstrap/refresh.go
+++ b/server/internal/fleetnodebootstrap/refresh.go
@@ -21,5 +21,9 @@ func Refresh(ctx context.Context, state *State) error {
 	if err := ValidateServerURL(state.ServerURL, state.AllowInsecureTransport); err != nil {
 		return err
 	}
-	return RunHandshake(ctx, NewGatewayClient(state.ServerURL), state)
+	client, err := NewGatewayClient(state.ServerURL)
+	if err != nil {
+		return err
+	}
+	return RunHandshake(ctx, client, state)
 }

--- a/server/internal/testutil/h2c.go
+++ b/server/internal/testutil/h2c.go
@@ -12,8 +12,8 @@ import (
 	"golang.org/x/net/http2/h2c"
 )
 
-// NewH2CServer wraps h in an h2c handler and starts an httptest server.
-// Required for Connect-RPC bidi streams, which can't run over HTTP/1.1.
+// NewH2CServer is HTTP/2-over-cleartext; required for Connect-RPC bidi
+// streams, which can't run over HTTP/1.1.
 func NewH2CServer(t *testing.T, h http.Handler) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewUnstartedServer(h2c.NewHandler(h, &http2.Server{}))
@@ -22,8 +22,6 @@ func NewH2CServer(t *testing.T, h http.Handler) *httptest.Server {
 	return srv
 }
 
-// NewH2CClient returns an http.Client speaking plaintext HTTP/2 (h2c). Used
-// to talk to servers from NewH2CServer.
 func NewH2CClient() *http.Client {
 	return &http.Client{
 		Transport: &http2.Transport{

--- a/server/internal/testutil/h2c.go
+++ b/server/internal/testutil/h2c.go
@@ -1,0 +1,37 @@
+package testutil
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+// NewH2CServer wraps h in an h2c handler and starts an httptest server.
+// Required for Connect-RPC bidi streams, which can't run over HTTP/1.1.
+func NewH2CServer(t *testing.T, h http.Handler) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(h2c.NewHandler(h, &http2.Server{}))
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// NewH2CClient returns an http.Client speaking plaintext HTTP/2 (h2c). Used
+// to talk to servers from NewH2CServer.
+func NewH2CClient() *http.Client {
+	return &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Adds the on-prem fleet-node agent's control-stream consumer (RFC 0001 phase 2). After enrollment is `CONFIRMED`, the agent opens `ControlStream`, executes the `pairing.v1.DiscoverRequest` the server dispatches, streams results via `ReportDiscoveredDevices` correlated by `command_id`, and acks.

**Pairs with #235** (server-side `ControlStream` handler, `DiscoverOnFleetNode` admin RPC, in-memory registry). Wire contracts merged in #257. Until #235 lands, the agent's control loop receives `Unimplemented` and reconnects with backoff — degrades quietly. PR order between #235 and this one doesn't matter.

![mission control](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZXdzN2U1cTBxNXY5MDEzYnUxbWM3ZGs0a2h3a2doNnhkbjJ6OGhhcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5qFNtulYh74lDEUsKl/giphy.gif)

## Agent invocation

`fleetnode run` — no scan flags needed. Plugins resolved from `<exe-dir>/plugins`; nmap from `<exe-dir>/nmap` or `PATH` at scan time. State, enrollment, and heartbeat configuration via existing flags.

## Control loop (`control.go`)

- `runControlLoop` opens the stream and reconnects with exponential backoff (1s → 30s cap). Permanent errors (`CodeNotFound`, `ErrBeginAuthRejected`) propagate so the daemon exits rather than spinning.
- `runControlSession` performs `Hello` → `Accepted` handshake, then receives `ControlCommand`s. A watcher goroutine closes the stream on `ctx.Done` because `http2.pipe.Read` blocks on a `sync.Cond` that ctx alone cannot unblock.
- `handleCommand` decodes the payload as `pairing.v1.DiscoverRequest` and dispatches:
  - `IPListModeRequest` → bounded-concurrency probes via the plugin manager (32 in-flight, 3s per probe).
  - `NmapModeRequest` → `runNmapDiscovery` shells out via `Ullaakut/nmap/v3`, then runs plugin probes against every open host:port (16 in-flight). 10-minute overall scan budget.
  - `MDNSModeRequest` → rejected via ack `error_message`.
- `streamReports` chunks at the server's `max_items = 1024` limit and sets `command_id` so the operator stream wakes up.
- Runs alongside the heartbeat loop. `sync.Mutex` guards `SessionToken`; `refreshAndSave` handshakes against a shallow `State` copy so the 2-RPC refresh does not stall token reads.

## Plugins

Loaded from `<exe-dir>/plugins` (fixed; no CLI flag). Missing dir → heartbeat-only mode. Present-but-unsafe → hard error: the plugin manager execs every file there as the agent uid, so non-owner write capability is RCE-equivalent. Unix `checkPluginsDirPerms` refuses non-root/non-self owners or any group/world write bits. Windows production deployments must install the binary under an Administrator-only directory (e.g., `%ProgramFiles%\fleetnode\`) so `plugins\` inherits a safe ACL.

## Nmap

`<exe-dir>/nmap` if present, otherwise `nmap` from PATH at scan time. Server-supplied targets pass through `validateNmapTarget`, which accepts only IP / CIDR / `A.B.C.D-N` range / hostname. Leading dashes, whitespace, and shell metacharacters are rejected — a compromised server cannot pivot via flags like `-iL/etc/passwd` or `-oN /tmp/loot`.

## Transport security

`newGatewayHTTPClient` is scheme-aware: `http://` uses h2c (loopback streaming), `https://` uses a TLS-validating `http2.Transport`. A shared `AllowHTTP + DialTLSContext` shim would silently downgrade `https://` to plaintext, defeating `ValidateServerURL`'s non-loopback HTTPS requirement.

## Identifier synthesis

Production SDK drivers leave `DeviceIdentifier` empty. The agent synthesizes:
- `mac:<addr>` when MAC is exposed
- `serial:<sn>` when only serial is exposed
- `auto:<uuid>` otherwise (server reconciles by `(fleet_node, ip, port)`)

## Docs

[server/cmd/fleetnode/README.md](server/cmd/fleetnode/README.md) covers overview, subcommands, state/lock semantics, plugins, nmap, control-stream flow, build, run, enrollment, security model, development, troubleshooting.

## Tests

- `control_test.go`: happy path (probe → report → ack with correlated `command_id`), MDNS rejection ack, reconnect after stream EOF.
- `nmap_test.go`: `TestValidateNmapTarget` (21 cases covering IP/CIDR/range/hostname acceptance and `-iL`, whitespace, null-byte, shell-metachar, leading-dash rejection); resolver tests.
- `plugins_dir_test.go`: binary-adjacent default discovery, missing-default-returns-empty, present-but-unsafe hard error.
- `client_test.go`: TLS round-trip with pinned cert succeeds; untrusted cert fails with `x509`; non-http(s) scheme rejected; redirects refused.
- `run_test.go`: `stubGatewayClient` satisfies the extended `gatewayClient` interface (`ReportDiscoveredDevices`, `ControlStream`).

## Test plan
- [x] `go build ./server/...`
- [x] `go vet ./server/...`
- [x] `golangci-lint run -c .golangci.yaml ./cmd/fleetnode/... ./internal/fleetnodebootstrap/...`
- [x] `go test ./server/cmd/fleetnode/... ./server/internal/fleetnodebootstrap/... -race -count=1`
- [x] E2E (post-#235): `fleetnode enroll`, confirm, then `fleetnode run`. Verify `control stream opened` log. With the fake antminer on `:4028`, hit `DiscoverOnFleetNode` from the operator side with an `ipList` request and confirm streaming `DiscoverResponse` containing the device + a `discovered_device` row with `discovered_by_fleet_node_id` set. Re-run with an `nmap` request and confirm the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)