### PR TITLE
Add ProtoFleet activity E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/README.md
+++ b/client/e2eTests/protoFleet/README.md
@@ -66,6 +66,7 @@ npx playwright test --headed             # See browser
 npx playwright test --debug              # Debug mode
 npx playwright test --ui                 # Interactive UI
 npx playwright test spec/auth.spec.ts    # Run specific file
+PW_UI_NO_DEPS=1 npx playwright test --ui --project=desktop  # Skip setup project deps for targeted reruns
 ```
 
 ### Viewing Test Reports

--- a/client/e2eTests/protoFleet/pages/activity.ts
+++ b/client/e2eTests/protoFleet/pages/activity.ts
@@ -37,8 +37,25 @@ export class ActivityPage extends BasePage {
     await this.selectDropdownFilter("Type", optionLabel);
   }
 
+  async selectScopeFilter(optionLabel: string) {
+    await this.selectDropdownFilter("Scope", optionLabel);
+  }
+
   async selectUserFilter(optionLabel: string) {
     await this.selectDropdownFilter("Users", optionLabel);
+  }
+
+  async validateFilterPillVisible(label: string) {
+    await expect(this.filterPillsContainer().getByRole("button", { name: label, exact: true })).toBeVisible();
+  }
+
+  async validateFilterPillNotVisible(label: string) {
+    await expect(this.filterPillsContainer().getByRole("button", { name: label, exact: true })).toHaveCount(0);
+  }
+
+  async removeFilterPill(label: string) {
+    await this.filterPillsContainer().getByRole("button", { name: label, exact: true }).click();
+    await this.waitForActivityListToLoad();
   }
 
   async validateNoResultsVisible() {
@@ -79,6 +96,34 @@ export class ActivityPage extends BasePage {
     await expect(this.activityRowByDescription(description)).toBeVisible();
   }
 
+  async openLatestActivityDetails() {
+    await this.latestActivityRow().click();
+  }
+
+  async validateActivityDetailModalOpened() {
+    await expect(this.activityDetailModal()).toBeVisible();
+    await expect(this.activityDetailModal()).toContainText("Actions");
+  }
+
+  async validateActivityDetailContainsText(text: string) {
+    await expect(this.activityDetailModal()).toContainText(text);
+  }
+
+  async validateActivityDetailDeviceResultsRowCount(expectedCount: number) {
+    await expect(this.activityDetailModal().locator("tbody tr")).toHaveCount(expectedCount);
+  }
+
+  async dismissActivityDetailModal() {
+    await this.activityDetailModal().getByTestId("header-icon-button").click();
+    await expect(this.activityDetailModal()).toBeHidden();
+  }
+
+  async exportCsv() {
+    const downloadPromise = this.page.waitForEvent("download");
+    await this.page.getByRole("button", { name: "Export CSV", exact: true }).click();
+    return await downloadPromise;
+  }
+
   private latestActivityRow(): Locator {
     return this.page.getByTestId("list-row").first();
   }
@@ -97,6 +142,14 @@ export class ActivityPage extends BasePage {
     await popover.getByRole("button", { name: "Apply", exact: true }).click();
     await expect(popover).toBeHidden();
     await this.waitForActivityListToLoad();
+  }
+
+  private filterPillsContainer(): Locator {
+    return this.page.getByTestId("activity-filter-pills");
+  }
+
+  private activityDetailModal(): Locator {
+    return this.page.getByTestId("modal");
   }
 
   private async getVisibleActivityListState(): Promise<string> {

--- a/client/e2eTests/protoFleet/pages/activity.ts
+++ b/client/e2eTests/protoFleet/pages/activity.ts
@@ -96,6 +96,10 @@ export class ActivityPage extends BasePage {
     await expect(this.activityRowByDescription(description)).toBeVisible();
   }
 
+  async validateActivityDescriptionMarkedFailed(description: string) {
+    await expect(this.activityRowByDescription(description).getByText("Failed", { exact: true })).toBeVisible();
+  }
+
   async openLatestActivityDetails() {
     await this.latestActivityRow().click();
   }

--- a/client/e2eTests/protoFleet/pages/auth.ts
+++ b/client/e2eTests/protoFleet/pages/auth.ts
@@ -2,6 +2,10 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class AuthPage extends BasePage {
+  private invalidCredentialsContainer() {
+    return this.page.getByTestId("error");
+  }
+
   async isAlreadyLoggedIn(timeoutMs = 5000): Promise<boolean> {
     const loggedInMarker = this.isMobile
       ? this.page.getByTestId("navigation-menu-button")
@@ -27,7 +31,9 @@ export class AuthPage extends BasePage {
   }
 
   async inputPassword(password: string) {
-    await this.page.locator(`//input[@id='password']`).fill(password);
+    const passwordInput = this.page.locator(`//input[@id='password']`);
+    await passwordInput.clear();
+    await passwordInput.fill(password);
   }
 
   async clickLogin() {
@@ -59,7 +65,14 @@ export class AuthPage extends BasePage {
   }
 
   async validateInvalidCredentials() {
-    await expect(this.page.getByText("Invalid credentials entered.")).toBeVisible();
+    await expect(this.invalidCredentialsContainer()).not.toHaveClass(/hidden/);
+    await expect(
+      this.invalidCredentialsContainer().getByText("Invalid credentials entered.", { exact: true }),
+    ).toBeVisible();
+  }
+
+  async validateInvalidCredentialsNotVisible() {
+    await expect(this.invalidCredentialsContainer()).toHaveClass(/hidden/);
   }
 
   async validateUpdatePasswordTitle() {

--- a/client/e2eTests/protoFleet/playwright.config.ts
+++ b/client/e2eTests/protoFleet/playwright.config.ts
@@ -6,6 +6,7 @@ import { testConfig } from "./config/test.config";
 const configDir = path.dirname(fileURLToPath(import.meta.url));
 const adminStorageState = path.join(configDir, "playwright", ".auth", "admin.json");
 const SETUP_FILE_GLOB = "**/[0-9][0-9]-*.spec.ts";
+const skipProjectDeps = process.env.PW_UI_NO_DEPS === "1";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -77,7 +78,7 @@ export default defineConfig({
       name: "desktop",
       testMatch: /.*\.spec\.ts$/,
       testIgnore: SETUP_FILE_GLOB,
-      dependencies: ["setup-desktop"],
+      dependencies: skipProjectDeps ? [] : ["setup-desktop"],
       use: {
         viewport: { width: 1600, height: 900 },
         isMobile: false,
@@ -89,7 +90,7 @@ export default defineConfig({
       name: "mobile",
       testMatch: /.*\.spec\.ts$/,
       testIgnore: SETUP_FILE_GLOB,
-      dependencies: ["setup-mobile"],
+      dependencies: skipProjectDeps ? [] : ["setup-mobile"],
       use: {
         viewport: { width: 393, height: 852 },
         isMobile: true,

--- a/client/e2eTests/protoFleet/spec/activity.spec.ts
+++ b/client/e2eTests/protoFleet/spec/activity.spec.ts
@@ -298,4 +298,58 @@ test.describe("Proto Fleet - Activity Login", () => {
       await activityPage.validateLatestActivityNotMarkedFailed();
     });
   });
+
+  test("Failed login activity is visible after correcting invalid credentials and signing in", async ({
+    authPage,
+    activityPage,
+  }) => {
+    await test.step("Log in as admin", async () => {
+      await authPage.inputUsername(testConfig.users.admin.username);
+      await authPage.inputPassword(testConfig.users.admin.password);
+      await authPage.clickLogin();
+      await authPage.validateLoggedIn();
+    });
+
+    await test.step("Open Activity and validate the latest login row", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.selectTypeFilter("Login");
+      await activityPage.selectUserFilter(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityDescription("Login");
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityNotMarkedFailed();
+    });
+
+    await test.step("Log out", async () => {
+      await authPage.logout();
+      await authPage.validateRedirectedToAuth();
+    });
+
+    await test.step("Attempt login with an invalid password and validate the error", async () => {
+      await authPage.inputUsername(testConfig.users.admin.username);
+      await authPage.inputPassword(`${testConfig.users.admin.password}-invalid`);
+      await authPage.clickLogin();
+      await authPage.validateInvalidCredentials();
+    });
+
+    await test.step("Rewrite the correct password and validate the error clears", async () => {
+      await authPage.inputPassword(testConfig.users.admin.password);
+      await authPage.validateInvalidCredentialsNotVisible();
+    });
+
+    await test.step("Log in successfully with corrected credentials", async () => {
+      await authPage.clickLogin();
+      await authPage.validateLoggedIn();
+    });
+
+    await test.step("Validate the failed login attempt appears in Activity", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.searchActivity("Login failed");
+      await activityPage.selectUserFilter(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityDescription("Login failed");
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityMarkedFailed();
+    });
+  });
 });

--- a/client/e2eTests/protoFleet/spec/activity.spec.ts
+++ b/client/e2eTests/protoFleet/spec/activity.spec.ts
@@ -3,10 +3,43 @@ import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";
 import { generateRandomText } from "../helpers/testDataHelper";
 import { AuthPage } from "../pages/auth";
+import { GroupsPage } from "../pages/groups";
 import { MinersPage } from "../pages/miners";
 import { SettingsSchedulesPage } from "../pages/settingsSchedules";
 
 const SCHEDULE_PREFIX = "activity_schedule_e2e";
+
+async function triggerBlinkLedsActivity(commonSteps: CommonSteps, minersPage: MinersPage) {
+  await commonSteps.loginAsAdmin();
+  await commonSteps.goToMinersPage();
+  await minersPage.filterRigMiners();
+  await minersPage.waitForMinersListToLoad();
+
+  const selectedMinerIps: string[] = [];
+
+  for (let index = 0; index < 3; index++) {
+    selectedMinerIps.push(await minersPage.getMinerIpAddressByIndex(index));
+    await minersPage.clickMinerCheckboxByIndex(index);
+    await minersPage.validateActionBarMinerCount(index + 1);
+  }
+
+  await minersPage.clickBlinkLEDsButton();
+  await minersPage.validateTextInToastGroup("Blinking LEDs");
+  await minersPage.validateTextInToastGroup("Blinked LEDs");
+
+  return selectedMinerIps;
+}
+
+async function createGroupActivity(commonSteps: CommonSteps, groupsPage: GroupsPage, groupName: string) {
+  await commonSteps.loginAsAdmin();
+  await groupsPage.navigateToGroupsPage();
+  await groupsPage.clickAddGroupButton();
+  await groupsPage.inputGroupName(groupName);
+  await groupsPage.waitForModalListToLoad();
+  await groupsPage.selectMinersByIndex([0]);
+  await groupsPage.clickSaveInModal();
+  await groupsPage.validateTextInToast(`Group "${groupName}" created`);
+}
 
 test.describe("Proto Fleet - Activity", () => {
   test.beforeEach(async ({ page }) => {
@@ -75,6 +108,108 @@ test.describe("Proto Fleet - Activity", () => {
       await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
       await activityPage.validateLatestActivityNotMarkedFailed();
     });
+  });
+
+  test("Blink LEDs activity detail modal shows batch summary and per-miner results", async ({
+    activityPage,
+    commonSteps,
+    minersPage,
+  }) => {
+    const selectedMinerIps = await triggerBlinkLedsActivity(commonSteps, minersPage);
+
+    await test.step("Open Activity and narrow to the Blink LEDs batch", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.searchActivity("Blink LEDs");
+      await activityPage.selectUserFilter(testConfig.users.admin.username);
+    });
+
+    await test.step("Validate the Blink LEDs activity row", async () => {
+      await activityPage.validateLatestActivityDescription("Blink LEDs");
+      await activityPage.validateLatestActivityScope("3 miners");
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityNotMarkedFailed();
+    });
+
+    await test.step("Open the detail modal and validate the batch results", async () => {
+      await activityPage.openLatestActivityDetails();
+      await activityPage.validateActivityDetailModalOpened();
+      await activityPage.validateActivityDetailContainsText("Blink led");
+      await activityPage.validateActivityDetailContainsText(testConfig.users.admin.username);
+      await activityPage.validateActivityDetailContainsText("Success");
+      await activityPage.validateActivityDetailContainsText("Succeeded");
+      await activityPage.validateActivityDetailContainsText("Failed");
+      await activityPage.validateActivityDetailContainsText("3 miners");
+      await activityPage.validateActivityDetailContainsText("0 miners");
+      await activityPage.validateActivityDetailDeviceResultsRowCount(3);
+
+      for (const minerIp of selectedMinerIps) {
+        await activityPage.validateActivityDetailContainsText(minerIp);
+      }
+
+      await activityPage.dismissActivityDetailModal();
+    });
+  });
+
+  test("Type and user filter pills can be removed and Activity export starts a CSV download", async ({
+    page,
+    activityPage,
+    commonSteps,
+  }) => {
+    await commonSteps.loginAsAdmin();
+
+    await test.step("Open Activity and apply type and user filters", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.selectTypeFilter("Login");
+      await activityPage.selectUserFilter(testConfig.users.admin.username);
+    });
+
+    await test.step("Validate and remove the type filter pill", async () => {
+      await activityPage.validateFilterPillVisible("Login");
+      await activityPage.validateFilterPillVisible(testConfig.users.admin.username);
+      await activityPage.removeFilterPill("Login");
+      await activityPage.validateFilterPillNotVisible("Login");
+      await activityPage.validateFilterPillVisible(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+    });
+
+    await test.step("Export the filtered activity list", async () => {
+      const download = await activityPage.exportCsv();
+      test.expect(download.suggestedFilename()).toMatch(/activity-export.*\.csv$/i);
+    });
+
+    await test.step("Keep the list stable after export", async () => {
+      await page.bringToFront();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+    });
+  });
+
+  test("Scope filter pills can be removed for group activity", async ({ activityPage, commonSteps, groupsPage }) => {
+    const groupName = generateRandomText("activity_group");
+
+    try {
+      await createGroupActivity(commonSteps, groupsPage, groupName);
+
+      await test.step("Open Activity and apply the group scope filter", async () => {
+        await activityPage.navigateToActivityPage();
+        await activityPage.waitForActivityListToLoad();
+        await activityPage.selectScopeFilter("Group");
+        await activityPage.searchActivity(groupName);
+      });
+
+      await test.step("Validate and remove the scope filter pill", async () => {
+        await activityPage.validateFilterPillVisible("Group");
+        await activityPage.validateActivityDescriptionVisible(`Create group: ${groupName}`);
+        await activityPage.removeFilterPill("Group");
+        await activityPage.validateFilterPillNotVisible("Group");
+        await activityPage.validateActivityDescriptionVisible(`Create group: ${groupName}`);
+      });
+    } finally {
+      await groupsPage.navigateToGroupsPage();
+      await groupsPage.deleteSavedGroupIfVisible(groupName);
+    }
   });
 
   test("Search, no-results, and clear-filters work for schedule activity", async ({

--- a/client/src/protoFleet/features/activity/pages/ActivityPage.tsx
+++ b/client/src/protoFleet/features/activity/pages/ActivityPage.tsx
@@ -147,7 +147,7 @@ const ActivityPage = () => {
             onUsersChange={setSelectedUsers}
           />
           {activeFilterPills.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-2" data-testid="activity-filter-pills">
               {activeFilterPills.map((pill) => (
                 <Button
                   key={pill.key}
@@ -155,6 +155,7 @@ const ActivityPage = () => {
                   variant={variants.accent}
                   prefixIcon={<DismissTiny />}
                   onClick={pill.onRemove}
+                  testId={`activity-filter-pill-${pill.key}`}
                 >
                   {pill.label}
                 </Button>


### PR DESCRIPTION
## Summary
- add Activity detail modal coverage for a real Blink LEDs batch action
- add Activity filter-pill and CSV export coverage
- add Scope filter coverage using group activity and stable test hooks for Activity pills

## Verification
- ./node_modules/.bin/eslint e2eTests/protoFleet/pages/activity.ts e2eTests/protoFleet/spec/activity.spec.ts src/protoFleet/features/activity/pages/ActivityPage.tsx
- npx playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/activity.spec.ts --project=desktop --no-deps
- npx playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/activity.spec.ts --project=mobile --no-deps