### PR TITLE
fix(installer): detect prior installs via sudo and on-disk fallback

### DIFF
--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -33,7 +33,15 @@ probe_install_dir_with() {
   #   - No /deployment/<...> segment present  -> mount path unchanged -> miss.
   #   - Mount path is /deployment/<...>       -> install root is "/"; expand
   #                                              empty to "/" before returning.
+  # `${var%/deployment/*}` requires at least one character after /deployment;
+  # a mount source that ends exactly at /deployment (no trailing subpath)
+  # wouldn't match, leaving install_dir == mount_path and tripping the miss
+  # branch below. Try the trailing-segment form first; if the mount source
+  # ends exactly at /deployment, fall back to stripping the bare suffix.
   local install_dir="${mount_path%/${DEPLOYMENT_DIR}/*}"
+  if [ "$install_dir" = "$mount_path" ]; then
+    install_dir="${mount_path%/${DEPLOYMENT_DIR}}"
+  fi
   if [ "$install_dir" = "$mount_path" ]; then
     return 1
   fi
@@ -298,8 +306,12 @@ get_default_install_dir() {
   fi
 
   if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    # `|| true` so a missing `getent` (e.g., on a non-glibc Linux) or a
+    # failing NSS lookup doesn't trip `set -e` before we reach the $HOME
+    # fallback below. `pipefail` would otherwise propagate the inner
+    # failure through `local sudo_home=$(...)` and abort the script.
     local sudo_home
-    sudo_home=$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)
+    sudo_home=$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6 || true)
     if [ -n "$sudo_home" ]; then
       echo "$sudo_home/proto-fleet"
       return

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -255,7 +255,7 @@ check_page_size() {
     echo "4. Reboot: sudo reboot"
     echo "5. Verify with: getconf PAGESIZE (should show 4096)"
     echo "6. Run this installation script again"
-    read -p "Do you want to continue anyway? (y/N): " continue_anyway
+    read -p "Do you want to continue anyway? (y/N): " continue_anyway < /dev/tty
       
     if [[ ! "$continue_anyway" =~ ^[Yy]$ ]]; then
       echo "Installation aborted."
@@ -406,9 +406,13 @@ if [ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" = "1" ]; then
   echo "      curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${QUOTED_VERSION})"
 fi
 
-read -p "   Use this location? (Y/n): " use_suggested
+# Read from /dev/tty so the prompts work under `curl ... | sudo bash -s --`.
+# Without this, stdin is the curl pipe (already consumed) and the reads
+# silently hit EOF, leaving the responses empty — defaulting users into the
+# happy path with no chance to redirect.
+read -p "   Use this location? (Y/n): " use_suggested < /dev/tty
 if [[ "$use_suggested" =~ ^[Nn]$ ]]; then
-  read -p "   Enter installation directory [${DEFAULT_INSTALL_DIR}]: " custom_dir
+  read -p "   Enter installation directory [${DEFAULT_INSTALL_DIR}]: " custom_dir < /dev/tty
   INSTALL_DIR="${custom_dir:-$DEFAULT_INSTALL_DIR}"
 else
   INSTALL_DIR="$SUGGESTED_DIR"

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -3,27 +3,44 @@ set -euo pipefail
 
 DEPLOYMENT_DIR="deployment"
 
-# Function to determine installation directory by detecting previous installations
-find_previous_install_dir() {
-  local container_id=$(docker ps -a --filter "name=${DEPLOYMENT_DIR}-fleet-api" --filter "name=${DEPLOYMENT_DIR}_fleet-api" --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
-  
-  if [ -z "$container_id" ]; then
-    # No container found
-    return 1
-  fi
-  
-  # Get the mount point from the container - suppress failures with || true
-  local mount_path=$(docker inspect --format '{{range .Mounts}}{{if eq .Destination "/var/lib/fleet/start"}}{{.Source}}{{end}}{{end}}' "$container_id" 2>/dev/null || true)
-  
-  if [ -z "$mount_path" ]; then
-    # No mount path found
-    return 1
-  else
-    # Extract install directory from mount path
-    local install_dir=$(echo "$mount_path" | sed "s|/${DEPLOYMENT_DIR}.*$||" || true)
-    echo "$install_dir"
+# Probe a specific docker invocation for an existing fleet-api container and
+# return the install directory inferred from its bind mount. Echoes the path
+# on success; returns 1 on miss.
+probe_install_dir_with() {
+  local docker_cmd="$1"
+  local container_id
+  container_id=$($docker_cmd ps -a --filter "name=${DEPLOYMENT_DIR}-fleet-api" --filter "name=${DEPLOYMENT_DIR}_fleet-api" --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
+  [ -z "$container_id" ] && return 1
+
+  local mount_path
+  mount_path=$($docker_cmd inspect --format '{{range .Mounts}}{{if eq .Destination "/var/lib/fleet/start"}}{{.Source}}{{end}}{{end}}' "$container_id" 2>/dev/null || true)
+  [ -z "$mount_path" ] && return 1
+
+  echo "$mount_path" | sed "s|/${DEPLOYMENT_DIR}.*$||"
+}
+
+# Determines the installation directory by detecting previous installations.
+# Probes the unprivileged docker first; if that misses, falls back to a
+# non-interactive `sudo docker` probe so we can spot installs whose containers
+# live in the root daemon. Writes results to globals (rather than stdout) so
+# the sudo-mismatch signal isn't lost across a subshell:
+#   PREVIOUS_INSTALL_DIR        — install dir, or empty if none detected
+#   PREVIOUS_INSTALL_NEEDS_SUDO — 1 if the install was only visible via sudo
+detect_previous_install() {
+  PREVIOUS_INSTALL_DIR=""
+  PREVIOUS_INSTALL_NEEDS_SUDO=0
+
+  local install_dir
+  if install_dir=$(probe_install_dir_with "docker"); then
+    PREVIOUS_INSTALL_DIR="$install_dir"
     return 0
   fi
+  if install_dir=$(probe_install_dir_with "sudo -n docker"); then
+    PREVIOUS_INSTALL_DIR="$install_dir"
+    PREVIOUS_INSTALL_NEEDS_SUDO=1
+    return 0
+  fi
+  return 1
 }
 
 # Function to extract files to the installation directory and cd to it
@@ -178,6 +195,12 @@ esac
 TAR_NAME="proto-fleet-${VERSION}-${ARCH}.tar.gz"
 URL="${GITHUB_RELEASES_URL}/download/${VERSION}/${TAR_NAME}"
 
+# Clean up the downloaded tarball on any exit path. extract_and_cd also rm's
+# it on the happy path, but early-exit paths (download retry, sudo-mismatch
+# abort, future guards added below) would otherwise leak release-sized files
+# into /tmp on every aborted attempt.
+trap 'rm -f "/tmp/${TAR_NAME}"' EXIT
+
 echo "🛰  Fetching proto-fleet ${VERSION} from ${URL}"
 if ! curl -fsSL "${URL}" -o "/tmp/${TAR_NAME}"; then
   echo "❌ Failed to download ${TAR_NAME} from GitHub Releases — does that release asset exist?"
@@ -196,10 +219,43 @@ get_default_install_dir() {
 }
 
 echo "🔍 Checking for previous ProtoFleet installations via Docker..."
-PREVIOUS_INSTALL_DIR=$(find_previous_install_dir || echo "")
+detect_previous_install || true
 DEFAULT_INSTALL_DIR=$(get_default_install_dir)
 
-if [ -n "$PREVIOUS_INSTALL_DIR" ]; then
+# If the existing containers were only visible via `sudo docker`, this script
+# is running as a user who can't manage them. Bail out loudly rather than
+# silently extracting on top of an install we can't control — continuing
+# would orphan the root-owned containers and likely leave the user with two
+# competing stacks. (Process substitution + sudo is a footgun, so tell them
+# the pipe form that actually works.)
+if [ "${PREVIOUS_INSTALL_NEEDS_SUDO:-0}" = "1" ] && [ "$(id -u)" -ne 0 ]; then
+  echo "❌ Existing fleet containers were detected, but only via sudo."
+  echo "   They are managed by the root Docker daemon, and this script is running as $(id -un)."
+  echo "   Re-run the installer as root so the upgrade targets the same daemon:"
+  echo ""
+  echo "     curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${VERSION}"
+  echo ""
+  echo "   Or, if your user account is already in the 'docker' group but the current"
+  echo "   shell hasn't picked it up yet, log out and back in (or run 'newgrp docker')"
+  echo "   and re-run the original install command without sudo."
+  echo ""
+  echo "   (The 'sudo bash <(curl ...)' form does not work — process substitution"
+  echo "   opens an FD that sudo cannot access.)"
+  exit 1
+fi
+
+# Marker check: docker-compose.yaml ships in every install tarball, so its
+# presence inside a 'deployment/' directory is a strong positive signal that
+# this really is a Proto Fleet install (and not some unrelated 'deployment/'
+# tree the user happened to create).
+if [ -z "${PREVIOUS_INSTALL_DIR:-}" ] \
+  && [ -d "${DEFAULT_INSTALL_DIR}/${DEPLOYMENT_DIR}" ] \
+  && [ -f "${DEFAULT_INSTALL_DIR}/${DEPLOYMENT_DIR}/docker-compose.yaml" ]; then
+  PREVIOUS_INSTALL_DIR="$DEFAULT_INSTALL_DIR"
+  echo "📁 No running fleet containers, but found existing install on disk at: ${PREVIOUS_INSTALL_DIR}"
+fi
+
+if [ -n "${PREVIOUS_INSTALL_DIR:-}" ]; then
   SUGGESTED_DIR="$PREVIOUS_INSTALL_DIR"
   echo "📌 Found previous installation at: ${SUGGESTED_DIR}"
 else

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -134,7 +134,7 @@ detect_previous_install() {
   # Anchor each pattern on `sudo:` so docker stderr that happens to mention
   # "password" / "terminal" / "tty" can't false-positive into SUDO_BLOCKED.
   case "$sudo_probe_err" in
-    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*)
+    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*|*"is not in the sudoers file"*)
       PREVIOUS_INSTALL_SUDO_BLOCKED=1
       return 1
       ;;

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -16,7 +16,15 @@ probe_install_dir_with() {
   mount_path=$($docker_cmd inspect --format '{{range .Mounts}}{{if eq .Destination "/var/lib/fleet/start"}}{{.Source}}{{end}}{{end}}' "$container_id" 2>/dev/null || true)
   [ -z "$mount_path" ] && return 1
 
-  echo "$mount_path" | sed "s|/${DEPLOYMENT_DIR}.*$||"
+  # Strip the trailing /deployment/... segment to recover the install dir.
+  # If the mount source begins with /${DEPLOYMENT_DIR} (install root was /),
+  # the sed yields an empty string — treat that as a miss rather than echoing
+  # an empty dir, so the caller doesn't record a bogus 0-length install path
+  # and skip the sudo / on-disk fallbacks.
+  local install_dir
+  install_dir=$(echo "$mount_path" | sed "s|/${DEPLOYMENT_DIR}.*$||")
+  [ -z "$install_dir" ] && return 1
+  echo "$install_dir"
 }
 
 # Determines the installation directory by detecting previous installations.
@@ -246,7 +254,7 @@ fi
 
 # Marker check: docker-compose.yaml ships in every install tarball, so its
 # presence inside a 'deployment/' directory is a strong positive signal that
-# this really is a Proto Fleet install (and not some unrelated 'deployment/'
+# this really is a ProtoFleet install (and not some unrelated 'deployment/'
 # tree the user happened to create).
 if [ -z "${PREVIOUS_INSTALL_DIR:-}" ] \
   && [ -d "${DEFAULT_INSTALL_DIR}/${DEPLOYMENT_DIR}" ] \

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -56,16 +56,23 @@ probe_install_dir_with() {
   # root-owned install path may be unreadable to the invoking shell, so an
   # unprivileged `[ -f ]` would falsely report missing.
   #
-  # When the elevated marker check itself fails (sudoers may permit `sudo
-  # docker` but not `sudo test`, or the install layout doesn't match), fall
-  # back conservatively: docker already confirmed a name-matching container
-  # at this path, so accept the discovery rather than silently miss the
-  # privilege-mismatch case this whole detection flow exists to handle.
+  # When the elevated check exits non-zero, distinguish two cases via stderr:
+  #   - empty stderr  -> `test -f` ran and the marker is genuinely missing
+  #                       (test is silent on plain misses) -> treat as miss.
+  #   - non-empty     -> sudo refused (sudoers permits docker but not test,
+  #                       missing askpass, etc.) -> accept the discovery
+  #                       conservatively, since docker already confirmed a
+  #                       name-matching container at this path and we'd
+  #                       rather trip the privilege-mismatch guard than
+  #                       silently miss the install.
   local marker="${install_dir%/}/${DEPLOYMENT_DIR}/docker-compose.yaml"
   if [ "${#privilege[@]}" -eq 0 ]; then
     [ -f "$marker" ] || return 1
   else
-    ${privilege[@]+"${privilege[@]}"} test -f "$marker" 2>/dev/null || true
+    local test_err
+    if ! test_err=$(${privilege[@]+"${privilege[@]}"} test -f "$marker" 2>&1); then
+      [ -z "$test_err" ] && return 1
+    fi
   fi
   echo "$install_dir"
 }
@@ -113,8 +120,10 @@ detect_previous_install() {
   # through to the actual probe.
   local sudo_probe_err
   sudo_probe_err=$(sudo -n docker version --format 'x' 2>&1 >/dev/null || true)
+  # Anchor each pattern on `sudo:` so docker stderr that happens to mention
+  # "password" / "terminal" / "tty" can't false-positive into SUDO_BLOCKED.
   case "$sudo_probe_err" in
-    *"password is required"*|*"a terminal is required"*|*"sudo:"*"may not run"*|*"no tty present"*)
+    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*)
       PREVIOUS_INSTALL_SUDO_BLOCKED=1
       return 1
       ;;
@@ -371,15 +380,18 @@ else
   SUGGESTED_DIR="$DEFAULT_INSTALL_DIR"
   echo "📌 No previous installation detected."
   echo "   Suggested installation location: ${SUGGESTED_DIR}"
-  # When sudo would have prompted for a password, we couldn't probe the root
-  # daemon at all — a "not detected" result might just mean we couldn't ask.
-  # Surface that explicitly so the user can re-run as root if appropriate.
-  if [ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" = "1" ]; then
-    echo ""
-    echo "   (Note: sudo required a password, so we couldn't check whether a"
-    echo "    root-managed fleet install exists. If one might, re-run as root:"
-    echo "      curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${QUOTED_VERSION})"
-  fi
+fi
+
+# When sudo would have prompted for a password, we couldn't probe the root
+# daemon at all — a parallel root-managed install would otherwise stay
+# invisible. Print this whenever the sudo probe was blocked, even if the
+# on-disk fallback found an unprivileged install (the two installs could
+# coexist on the same host).
+if [ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" = "1" ]; then
+  echo ""
+  echo "   (Note: sudo required a password, so we couldn't check whether a"
+  echo "    root-managed fleet install also exists. If one might, re-run as root:"
+  echo "      curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${QUOTED_VERSION})"
 fi
 
 read -p "   Use this location? (Y/n): " use_suggested

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -6,24 +6,43 @@ DEPLOYMENT_DIR="deployment"
 # Probe a specific docker invocation for an existing fleet-api container and
 # return the install directory inferred from its bind mount. Echoes the path
 # on success; returns 1 on miss.
+#
+# Accepts the docker command as an argv list so callers can pass
+# `probe_install_dir_with docker` or `probe_install_dir_with sudo -n docker`
+# without relying on unquoted word-splitting (ShellCheck SC2086).
 probe_install_dir_with() {
-  local docker_cmd="$1"
+  local docker_cmd=("$@")
   local container_id
-  container_id=$($docker_cmd ps -a --filter "name=${DEPLOYMENT_DIR}-fleet-api" --filter "name=${DEPLOYMENT_DIR}_fleet-api" --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
+  container_id=$("${docker_cmd[@]}" ps -a --filter "name=${DEPLOYMENT_DIR}-fleet-api" --filter "name=${DEPLOYMENT_DIR}_fleet-api" --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
   [ -z "$container_id" ] && return 1
 
   local mount_path
-  mount_path=$($docker_cmd inspect --format '{{range .Mounts}}{{if eq .Destination "/var/lib/fleet/start"}}{{.Source}}{{end}}{{end}}' "$container_id" 2>/dev/null || true)
+  mount_path=$("${docker_cmd[@]}" inspect --format '{{range .Mounts}}{{if eq .Destination "/var/lib/fleet/start"}}{{.Source}}{{end}}{{end}}' "$container_id" 2>/dev/null || true)
   [ -z "$mount_path" ] && return 1
 
-  # Strip the trailing /deployment/... segment to recover the install dir.
-  # If the mount source begins with /${DEPLOYMENT_DIR} (install root was /),
-  # the sed yields an empty string — treat that as a miss rather than echoing
-  # an empty dir, so the caller doesn't record a bogus 0-length install path
-  # and skip the sudo / on-disk fallbacks.
-  local install_dir
-  install_dir=$(echo "$mount_path" | sed "s|/${DEPLOYMENT_DIR}.*$||")
-  [ -z "$install_dir" ] && return 1
+  # Recover the install dir by stripping the trailing /deployment/<...>
+  # segment with parameter expansion. The previous sed-based approach
+  # `s|/deployment.*$||` was greedy and stripped from the *first* occurrence
+  # of /deployment, so a mount source like /home/alice/deployment/proto-fleet
+  # collapsed to /home/alice. `${var%/deployment/*}` strips only the shortest
+  # trailing match, recovering the correct install root.
+  #
+  # Edge cases:
+  #   - No /deployment/<...> segment present  -> mount path unchanged -> miss.
+  #   - Mount path is /deployment/<...>       -> install root is "/"; expand
+  #                                              empty to "/" before returning.
+  # Then validate the recovered dir actually houses a ProtoFleet install by
+  # checking for the bundled docker-compose.yaml marker. This guards against
+  # an unrelated container that happens to share the name filter and mounts
+  # a path with /deployment/ in it.
+  local install_dir="${mount_path%/${DEPLOYMENT_DIR}/*}"
+  if [ "$install_dir" = "$mount_path" ]; then
+    return 1
+  fi
+  [ -z "$install_dir" ] && install_dir="/"
+  if [ ! -f "${install_dir%/}/${DEPLOYMENT_DIR}/docker-compose.yaml" ]; then
+    return 1
+  fi
   echo "$install_dir"
 }
 
@@ -31,22 +50,38 @@ probe_install_dir_with() {
 # Probes the unprivileged docker first; if that misses, falls back to a
 # non-interactive `sudo docker` probe so we can spot installs whose containers
 # live in the root daemon. Writes results to globals (rather than stdout) so
-# the sudo-mismatch signal isn't lost across a subshell:
-#   PREVIOUS_INSTALL_DIR        — install dir, or empty if none detected
-#   PREVIOUS_INSTALL_NEEDS_SUDO — 1 if the install was only visible via sudo
+# the sudo signal isn't lost across a subshell:
+#   PREVIOUS_INSTALL_DIR          — install dir, or empty if none detected
+#   PREVIOUS_INSTALL_NEEDS_SUDO   — 1 if the install was only visible via sudo
+#   PREVIOUS_INSTALL_SUDO_BLOCKED — 1 if sudo would prompt and we couldn't
+#                                   probe the root daemon at all (so a
+#                                   "not detected" result might just mean
+#                                   "couldn't check"; the caller surfaces
+#                                   this in the suggestion text).
 detect_previous_install() {
   PREVIOUS_INSTALL_DIR=""
   PREVIOUS_INSTALL_NEEDS_SUDO=0
+  PREVIOUS_INSTALL_SUDO_BLOCKED=0
 
   local install_dir
-  if install_dir=$(probe_install_dir_with "docker"); then
+  if install_dir=$(probe_install_dir_with docker); then
     PREVIOUS_INSTALL_DIR="$install_dir"
     return 0
   fi
-  if install_dir=$(probe_install_dir_with "sudo -n docker"); then
-    PREVIOUS_INSTALL_DIR="$install_dir"
-    PREVIOUS_INSTALL_NEEDS_SUDO=1
-    return 0
+
+  # The sudo fallback probe is only meaningful when sudo can actually run
+  # without prompting. `sudo -n docker ps` fails identically when there are
+  # no root-daemon containers AND when sudo just needs a password — so a
+  # bare retry would silently conflate "no install" with "can't ask". Pre-
+  # check sudo non-interactively, then run the probe only if it can succeed.
+  if [ "$(id -u)" -eq 0 ] || sudo -n true 2>/dev/null; then
+    if install_dir=$(probe_install_dir_with sudo -n docker); then
+      PREVIOUS_INSTALL_DIR="$install_dir"
+      PREVIOUS_INSTALL_NEEDS_SUDO=1
+      return 0
+    fi
+  else
+    PREVIOUS_INSTALL_SUDO_BLOCKED=1
   fi
   return 1
 }
@@ -215,15 +250,29 @@ if ! curl -fsSL "${URL}" -o "/tmp/${TAR_NAME}"; then
   usage
 fi
 
-# Function to determine default installation directory based on OS
+# Function to determine default installation directory based on OS.
+# When invoked under sudo on Linux, prefer the invoking user's home over
+# /root — fleet is normally installed under the user account, and falling
+# back to /root/proto-fleet would silently miss the user's on-disk install.
 get_default_install_dir() {
-  local os_type=$(uname -s)
-  
+  local os_type
+  os_type=$(uname -s)
+
   if [ "$os_type" = "Darwin" ]; then
     echo "$HOME/Applications/ProtoFleet"
-  else
-    echo "$HOME/proto-fleet"
+    return
   fi
+
+  if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    local sudo_home
+    sudo_home=$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)
+    if [ -n "$sudo_home" ]; then
+      echo "$sudo_home/proto-fleet"
+      return
+    fi
+  fi
+
+  echo "$HOME/proto-fleet"
 }
 
 echo "🔍 Checking for previous ProtoFleet installations via Docker..."
@@ -236,12 +285,18 @@ DEFAULT_INSTALL_DIR=$(get_default_install_dir)
 # would orphan the root-owned containers and likely leave the user with two
 # competing stacks. (Process substitution + sudo is a footgun, so tell them
 # the pipe form that actually works.)
+# Shell-escape VERSION before embedding it in any copy-pasteable command
+# line we suggest to the user. `printf '%q'` produces a string that is safe
+# to re-paste into bash even if VERSION contains spaces or metachars (which
+# can happen if the user passed garbage as the version argument).
+QUOTED_VERSION=$(printf '%q' "${VERSION}")
+
 if [ "${PREVIOUS_INSTALL_NEEDS_SUDO:-0}" = "1" ] && [ "$(id -u)" -ne 0 ]; then
   echo "❌ Existing fleet containers were detected, but only via sudo."
   echo "   They are managed by the root Docker daemon, and this script is running as $(id -un)."
   echo "   Re-run the installer as root so the upgrade targets the same daemon:"
   echo ""
-  echo "     curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${VERSION}"
+  echo "     curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${QUOTED_VERSION}"
   echo ""
   echo "   Or, if your user account is already in the 'docker' group but the current"
   echo "   shell hasn't picked it up yet, log out and back in (or run 'newgrp docker')"
@@ -270,6 +325,15 @@ else
   SUGGESTED_DIR="$DEFAULT_INSTALL_DIR"
   echo "📌 No previous installation detected."
   echo "   Suggested installation location: ${SUGGESTED_DIR}"
+  # When sudo would have prompted for a password, we couldn't probe the root
+  # daemon at all — a "not detected" result might just mean we couldn't ask.
+  # Surface that explicitly so the user can re-run as root if appropriate.
+  if [ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" = "1" ]; then
+    echo ""
+    echo "   (Note: sudo required a password, so we couldn't check whether a"
+    echo "    root-managed fleet install exists. If one might, re-run as root:"
+    echo "      curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${QUOTED_VERSION})"
+  fi
 fi
 
 read -p "   Use this location? (Y/n): " use_suggested

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -134,7 +134,7 @@ detect_previous_install() {
   # Anchor each pattern on `sudo:` so docker stderr that happens to mention
   # "password" / "terminal" / "tty" can't false-positive into SUDO_BLOCKED.
   case "$sudo_probe_err" in
-    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*|*"is not in the sudoers file"*)
+    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*|*"is not in the sudoers file"*|*"sudo: sorry, you must have a tty to run sudo"*)
       PREVIOUS_INSTALL_SUDO_BLOCKED=1
       return 1
       ;;

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -118,6 +118,8 @@ detect_previous_install() {
   # distinguish "sudo refused (needs password)" from "sudo ran but found
   # no install". Only the refused case sets SUDO_BLOCKED; the rest fall
   # through to the actual probe.
+  # `2>&1 >/dev/null` captures stderr only (redirect order matters: dup
+  # stderr to current stdout first, then point stdout at /dev/null).
   local sudo_probe_err
   sudo_probe_err=$(sudo -n docker version --format 'x' 2>&1 >/dev/null || true)
   # Anchor each pattern on `sudo:` so docker stderr that happens to mention
@@ -315,10 +317,8 @@ get_default_install_dir() {
   fi
 
   if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
-    # `|| true` so a missing `getent` (e.g., on a non-glibc Linux) or a
-    # failing NSS lookup doesn't trip `set -e` before we reach the $HOME
-    # fallback below. `pipefail` would otherwise propagate the inner
-    # failure through `local sudo_home=$(...)` and abort the script.
+    # `|| true` neutralizes set -e / pipefail so a missing getent or failed
+    # NSS lookup falls through to $HOME instead of aborting.
     local sudo_home
     sudo_home=$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6 || true)
     if [ -n "$sudo_home" ]; then
@@ -340,10 +340,8 @@ DEFAULT_INSTALL_DIR=$(get_default_install_dir)
 # would orphan the root-owned containers and likely leave the user with two
 # competing stacks. (Process substitution + sudo is a footgun, so tell them
 # the pipe form that actually works.)
-# Shell-escape VERSION before embedding it in any copy-pasteable command
-# line we suggest to the user. `printf '%q'` produces a string that is safe
-# to re-paste into bash even if VERSION contains spaces or metachars (which
-# can happen if the user passed garbage as the version argument).
+# Shell-escape VERSION so the suggested copy-paste commands below stay safe
+# even when the user-supplied version arg contains spaces or metachars.
 QUOTED_VERSION=$(printf '%q' "${VERSION}")
 
 if [ "${PREVIOUS_INSTALL_NEEDS_SUDO:-0}" = "1" ] && [ "$(id -u)" -ne 0 ]; then

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -45,7 +45,12 @@ probe_install_dir_with() {
   if [ "$install_dir" = "$mount_path" ]; then
     return 1
   fi
-  [ -z "$install_dir" ] && install_dir="/"
+  # Reject install_dir="/" — a mount source like /deployment/<x> would
+  # otherwise propose installing into / itself. No supported layout puts
+  # ProtoFleet directly at the filesystem root.
+  if [ -z "$install_dir" ] || [ "$install_dir" = "/" ]; then
+    return 1
+  fi
 
   # Validate the recovered dir actually houses a ProtoFleet install by
   # checking for the bundled docker-compose.yaml marker. This guards against
@@ -110,6 +115,10 @@ detect_previous_install() {
     fi
     return 1
   fi
+
+  # No sudo binary -> nothing to probe; skip to avoid leaking
+  # "sudo: command not found" to user stderr on minimal hosts.
+  command -v sudo >/dev/null 2>&1 || return 1
 
   # The sudo fallback is only meaningful when sudo can run docker without
   # prompting. An earlier `sudo -n true` gate was too strict — sudoers configs
@@ -325,6 +334,11 @@ get_default_install_dir() {
       echo "$sudo_home/proto-fleet"
       return
     fi
+    # SUDO_USER set but resolution failed — warn so the operator knows the
+    # default below is /root, not their home. Direct >&2 because this
+    # function's stdout is captured by the `$(...)` caller.
+    echo "⚠️  SUDO_USER='$SUDO_USER' set but home lookup returned empty;" >&2
+    echo "    default install dir will fall back to \$HOME ($HOME/proto-fleet)." >&2
   fi
 
   echo "$HOME/proto-fleet"

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -3,45 +3,61 @@ set -euo pipefail
 
 DEPLOYMENT_DIR="deployment"
 
-# Probe a specific docker invocation for an existing fleet-api container and
-# return the install directory inferred from its bind mount. Echoes the path
-# on success; returns 1 on miss.
+# Probe docker for an existing fleet-api container and return the install
+# directory inferred from its bind mount. Echoes the path on success; returns
+# 1 on miss.
 #
-# Accepts the docker command as an argv list so callers can pass
-# `probe_install_dir_with docker` or `probe_install_dir_with sudo -n docker`
-# without relying on unquoted word-splitting (ShellCheck SC2086).
+# Takes a privilege-wrapper argv (empty for unprivileged, or `sudo -n` for
+# elevated). All docker calls AND the marker validation are run through the
+# wrapper at the same privilege level — without that, sudo-detected installs
+# at root-only paths (e.g. /root/proto-fleet) would pass the docker probe
+# but silently fail the unprivileged `test -f` check and look absent.
 probe_install_dir_with() {
-  local docker_cmd=("$@")
+  local privilege=("$@")
+  # Note: `${arr[@]+"${arr[@]}"}` is the set -u-safe expansion idiom for
+  # arrays that may be empty. A bare `"${arr[@]}"` errors out on an empty
+  # array under `set -u` in bash 3.2 and (intermittently) bash 4.x.
   local container_id
-  container_id=$("${docker_cmd[@]}" ps -a --filter "name=${DEPLOYMENT_DIR}-fleet-api" --filter "name=${DEPLOYMENT_DIR}_fleet-api" --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
+  container_id=$(${privilege[@]+"${privilege[@]}"} docker ps -a --filter "name=${DEPLOYMENT_DIR}-fleet-api" --filter "name=${DEPLOYMENT_DIR}_fleet-api" --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
   [ -z "$container_id" ] && return 1
 
   local mount_path
-  mount_path=$("${docker_cmd[@]}" inspect --format '{{range .Mounts}}{{if eq .Destination "/var/lib/fleet/start"}}{{.Source}}{{end}}{{end}}' "$container_id" 2>/dev/null || true)
+  mount_path=$(${privilege[@]+"${privilege[@]}"} docker inspect --format '{{range .Mounts}}{{if eq .Destination "/var/lib/fleet/start"}}{{.Source}}{{end}}{{end}}' "$container_id" 2>/dev/null || true)
   [ -z "$mount_path" ] && return 1
 
   # Recover the install dir by stripping the trailing /deployment/<...>
-  # segment with parameter expansion. The previous sed-based approach
-  # `s|/deployment.*$||` was greedy and stripped from the *first* occurrence
-  # of /deployment, so a mount source like /home/alice/deployment/proto-fleet
-  # collapsed to /home/alice. `${var%/deployment/*}` strips only the shortest
-  # trailing match, recovering the correct install root.
-  #
+  # segment with parameter expansion. `${var%/deployment/*}` strips only the
+  # shortest trailing match, so /home/alice/deployment/proto-fleet/deployment/...
+  # resolves to /home/alice/deployment/proto-fleet (not /home/alice).
   # Edge cases:
   #   - No /deployment/<...> segment present  -> mount path unchanged -> miss.
   #   - Mount path is /deployment/<...>       -> install root is "/"; expand
   #                                              empty to "/" before returning.
-  # Then validate the recovered dir actually houses a ProtoFleet install by
-  # checking for the bundled docker-compose.yaml marker. This guards against
-  # an unrelated container that happens to share the name filter and mounts
-  # a path with /deployment/ in it.
   local install_dir="${mount_path%/${DEPLOYMENT_DIR}/*}"
   if [ "$install_dir" = "$mount_path" ]; then
     return 1
   fi
   [ -z "$install_dir" ] && install_dir="/"
-  if [ ! -f "${install_dir%/}/${DEPLOYMENT_DIR}/docker-compose.yaml" ]; then
-    return 1
+
+  # Validate the recovered dir actually houses a ProtoFleet install by
+  # checking for the bundled docker-compose.yaml marker. This guards against
+  # an unrelated container that happens to share the name filter and mounts
+  # a path with /deployment/ in it.
+  #
+  # Run the marker check at the SAME privilege level used for docker — a
+  # root-owned install path may be unreadable to the invoking shell, so an
+  # unprivileged `[ -f ]` would falsely report missing.
+  #
+  # When the elevated marker check itself fails (sudoers may permit `sudo
+  # docker` but not `sudo test`, or the install layout doesn't match), fall
+  # back conservatively: docker already confirmed a name-matching container
+  # at this path, so accept the discovery rather than silently miss the
+  # privilege-mismatch case this whole detection flow exists to handle.
+  local marker="${install_dir%/}/${DEPLOYMENT_DIR}/docker-compose.yaml"
+  if [ "${#privilege[@]}" -eq 0 ]; then
+    [ -f "$marker" ] || return 1
+  else
+    ${privilege[@]+"${privilege[@]}"} test -f "$marker" 2>/dev/null || true
   fi
   echo "$install_dir"
 }
@@ -64,24 +80,42 @@ detect_previous_install() {
   PREVIOUS_INSTALL_SUDO_BLOCKED=0
 
   local install_dir
-  if install_dir=$(probe_install_dir_with docker); then
+  if install_dir=$(probe_install_dir_with); then
     PREVIOUS_INSTALL_DIR="$install_dir"
     return 0
   fi
 
-  # The sudo fallback probe is only meaningful when sudo can actually run
-  # without prompting. `sudo -n docker ps` fails identically when there are
-  # no root-daemon containers AND when sudo just needs a password — so a
-  # bare retry would silently conflate "no install" with "can't ask". Pre-
-  # check sudo non-interactively, then run the probe only if it can succeed.
-  if [ "$(id -u)" -eq 0 ] || sudo -n true 2>/dev/null; then
-    if install_dir=$(probe_install_dir_with sudo -n docker); then
+  # Already root — no sudo prompt is possible. Probe via sudo for symmetry
+  # (covers rootless-vs-rootful docker daemon splits).
+  if [ "$(id -u)" -eq 0 ]; then
+    if install_dir=$(probe_install_dir_with sudo -n); then
       PREVIOUS_INSTALL_DIR="$install_dir"
       PREVIOUS_INSTALL_NEEDS_SUDO=1
       return 0
     fi
-  else
-    PREVIOUS_INSTALL_SUDO_BLOCKED=1
+    return 1
+  fi
+
+  # The sudo fallback is only meaningful when sudo can run docker without
+  # prompting. An earlier `sudo -n true` gate was too strict — sudoers configs
+  # that NOPASSWD `docker` specifically don't necessarily NOPASSWD arbitrary
+  # commands. Probe sudo's view of docker directly and inspect stderr to
+  # distinguish "sudo refused (needs password)" from "sudo ran but found
+  # no install". Only the refused case sets SUDO_BLOCKED; the rest fall
+  # through to the actual probe.
+  local sudo_probe_err
+  sudo_probe_err=$(sudo -n docker version --format 'x' 2>&1 >/dev/null || true)
+  case "$sudo_probe_err" in
+    *"password is required"*|*"a terminal is required"*|*"sudo:"*"may not run"*|*"no tty present"*)
+      PREVIOUS_INSTALL_SUDO_BLOCKED=1
+      return 1
+      ;;
+  esac
+
+  if install_dir=$(probe_install_dir_with sudo -n); then
+    PREVIOUS_INSTALL_DIR="$install_dir"
+    PREVIOUS_INSTALL_NEEDS_SUDO=1
+    return 0
   fi
   return 1
 }

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -287,8 +287,13 @@ if [ "$(uname)" == "Linux" ]; then
         sudo systemctl enable docker
     fi
 
-    # Check if current user is in the docker group
-    if ! groups $USER | grep -q '\bdocker\b'; then
+    # Check if current user is in the docker group.
+    # Skip when running as root: root accesses /var/run/docker.sock directly
+    # via socket-file permissions and does not need docker-group membership.
+    # Without this skip, `sudo bash install.sh ...` (the recommended remediation
+    # for the sudo-mismatch detection in install.sh) would exit here telling
+    # the user to log out and back in, leaving the upgrade half-applied.
+    if [ "$(id -u)" -ne 0 ] && ! groups $USER | grep -q '\bdocker\b'; then
         echo "Adding current user to the docker group for passwordless Docker usage..."
         sudo usermod -aG docker $USER
         echo "Please log out and log back in to apply group changes, then re-run this script."

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -283,7 +283,7 @@ detect_previous_install() {
   # Anchor each pattern on `sudo:` so docker stderr that happens to mention
   # "password" / "terminal" / "tty" can't false-positive into SUDO_BLOCKED.
   case "$sudo_probe_err" in
-    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*|*"is not in the sudoers file"*)
+    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*|*"is not in the sudoers file"*|*"sudo: sorry, you must have a tty to run sudo"*)
       PREVIOUS_INSTALL_SUDO_BLOCKED=1
       return 1
       ;;

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -329,9 +329,13 @@ resolve_deployment_path() {
       if [[ "${PREVIOUS_INSTALL_NEEDS_SUDO:-0}" == "1" ]] && [[ "$(id -u)" -ne 0 ]]; then
         print_error "Existing fleet containers were detected, but only via sudo."
         print_error "They are managed by the root Docker daemon, and this script is running as $(id -un)."
+        # Use the pipe form rather than `sudo bash $0` — when the user
+        # invoked us via `bash <(curl ...)` (per README.md), $0 is a
+        # transient /dev/fd/* descriptor that sudo cannot reopen, so the
+        # naive suggestion fails immediately.
         print_error "Re-run the uninstaller as root (flags preserved):"
         echo ""
-        echo "    sudo bash $0$(quoted_rerun_argv)"
+        echo "    curl -fsSL https://fleet.proto.xyz/uninstall.sh | sudo bash -s --$(quoted_rerun_argv)"
         echo ""
         exit 1
       fi
@@ -363,7 +367,8 @@ resolve_deployment_path() {
     # root daemon — a root-managed install could exist that we never saw.
     if [[ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" == "1" ]]; then
       print_error "(sudo required a password, so the root Docker daemon was not probed."
-      print_error " If a root-managed install might exist, re-run with: sudo bash $0$(quoted_rerun_argv))"
+      print_error " If a root-managed install might exist, re-run as root:"
+      print_error "   curl -fsSL https://fleet.proto.xyz/uninstall.sh | sudo bash -s --$(quoted_rerun_argv))"
     fi
     exit 1
   fi
@@ -500,7 +505,10 @@ echo "  - Deployment directory: $DEPLOYMENT_PATH"
 echo ""
 
 if ! $DRY_RUN; then
-  read -rp "Proceed with uninstall? (y/N): " confirm
+  # Read from /dev/tty so the prompt works under `curl ... | sudo bash -s --`
+  # (the sudo re-run form suggested above). Without this, stdin is the curl
+  # pipe and the confirm read silently hits EOF.
+  read -rp "Proceed with uninstall? (y/N): " confirm < /dev/tty
   if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     echo "Uninstall canceled."
     exit 0

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -95,9 +95,25 @@ assert_safe_removal_path() {
   fi
   resolved="${resolved%/}"
 
-  local blocked_paths=("/" "/home" "/usr" "/etc" "/var" "/opt" "/root" "/tmp" "/bin" "/sbin" "/lib" "/sys" "/dev" "/proc" "/boot" "/run" "/mnt" "/srv" "/media")
-  for blocked in "${blocked_paths[@]}"; do
+  # Two-tier blocklist:
+  #   - exact_blocked  — paths whose SUBPATHS can legitimately host installs
+  #                       (e.g., /home/<user>/proto-fleet, /opt/proto-fleet).
+  #                       Only the top-level dir itself is refused.
+  #   - subtree_blocked — system paths where no install should ever live;
+  #                        rm -rf anywhere under here is dangerous.
+  # Without the subtree arm, a misrouted PREVIOUS_INSTALL_DIR resolving
+  # to e.g. /etc/foo or /sys/x would slip past and let rm -rf damage
+  # system-owned space.
+  local exact_blocked=("/" "/home" "/Users" "/root" "/opt" "/usr" "/var" "/tmp" "/srv" "/mnt" "/media")
+  local subtree_blocked=("/etc" "/bin" "/sbin" "/lib" "/lib64" "/sys" "/dev" "/proc" "/boot" "/run")
+  for blocked in "${exact_blocked[@]}"; do
     if [[ "$resolved" == "$blocked" ]]; then
+      print_error "Refusing to remove dangerous path: $resolved"
+      exit 1
+    fi
+  done
+  for blocked in "${subtree_blocked[@]}"; do
+    if [[ "$resolved" == "$blocked" || "$resolved" == "$blocked"/* ]]; then
       print_error "Refusing to remove dangerous path: $resolved"
       exit 1
     fi
@@ -140,6 +156,13 @@ get_default_install_dir() {
       echo "$sudo_home/proto-fleet"
       return
     fi
+    # SUDO_USER is set but resolution failed (deleted account, NSS hiccup,
+    # missing getent). Surface this on stderr so the operator knows the
+    # default below is /root, not their home — otherwise the silent
+    # degradation looks like the SUDO_USER branch never ran. Direct >&2
+    # because this function's stdout is captured by the `$(...)` caller.
+    echo "[WARN] SUDO_USER='$SUDO_USER' set but home lookup returned empty;" >&2
+    echo "[WARN]   default install dir will fall back to \$HOME ($HOME/proto-fleet)." >&2
   fi
 
   echo "$HOME/proto-fleet"
@@ -186,7 +209,10 @@ probe_install_dir_with() {
   if [[ "$install_dir" == "$mount_path" ]]; then
     return 1
   fi
-  [[ -z "$install_dir" ]] && install_dir="/"
+  # Reject install_dir="/" — a mount source like /deployment/<x> would
+  # otherwise propose deleting /deployment as the install root. No
+  # supported install layout ever puts ProtoFleet directly at /.
+  [[ -z "$install_dir" || "$install_dir" == "/" ]] && return 1
 
   # Marker check at the same privilege level. Empty stderr on non-zero
   # exit means the marker is genuinely missing; non-empty stderr means
@@ -231,6 +257,10 @@ detect_previous_install() {
     fi
     return 1
   fi
+
+  # No sudo binary -> nothing to probe; skip to avoid leaking
+  # "sudo: command not found" to user stderr on minimal hosts.
+  command -v sudo >/dev/null 2>&1 || return 1
 
   # Probe sudo's view of docker directly and inspect stderr to distinguish
   # "sudo refused (needs password)" from "sudo ran but found no install".

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -49,6 +49,11 @@ EOF
 # Argument Parsing
 # =====================================================================
 
+# Capture the original argv before parsing so the sudo re-run hint below
+# can preserve any flags the user passed (--deployment-path, --dry-run).
+# `set -u` -safe — empty `"$@"` produces an empty array.
+ORIGINAL_ARGV=("$@")
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --deployment-path)
@@ -270,7 +275,7 @@ detect_previous_install() {
   # Anchor each pattern on `sudo:` so docker stderr that happens to mention
   # "password" / "terminal" / "tty" can't false-positive into SUDO_BLOCKED.
   case "$sudo_probe_err" in
-    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*)
+    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*|*"is not in the sudoers file"*)
       PREVIOUS_INSTALL_SUDO_BLOCKED=1
       return 1
       ;;
@@ -316,9 +321,17 @@ resolve_deployment_path() {
       if [[ "${PREVIOUS_INSTALL_NEEDS_SUDO:-0}" == "1" ]] && [[ "$(id -u)" -ne 0 ]]; then
         print_error "Existing fleet containers were detected, but only via sudo."
         print_error "They are managed by the root Docker daemon, and this script is running as $(id -un)."
-        print_error "Re-run the uninstaller as root (preserving any flags you passed):"
+        # Preserve original flags so following the suggestion doesn't drop
+        # --dry-run (real uninstall instead of preview) or --deployment-path
+        # (wrong target). Shell-escape each arg via printf '%q'.
+        local quoted_argv=""
+        local arg
+        for arg in ${ORIGINAL_ARGV[@]+"${ORIGINAL_ARGV[@]}"}; do
+          quoted_argv+=" $(printf '%q' "$arg")"
+        done
+        print_error "Re-run the uninstaller as root:"
         echo ""
-        echo "    sudo bash $0"
+        echo "    sudo bash $0${quoted_argv}"
         echo ""
         exit 1
       fi
@@ -349,8 +362,13 @@ resolve_deployment_path() {
     # When sudo would have prompted for a password, we couldn't probe the
     # root daemon — a root-managed install could exist that we never saw.
     if [[ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" == "1" ]]; then
+      local quoted_argv=""
+      local arg
+      for arg in ${ORIGINAL_ARGV[@]+"${ORIGINAL_ARGV[@]}"}; do
+        quoted_argv+=" $(printf '%q' "$arg")"
+      done
       print_error "(sudo required a password, so the root Docker daemon was not probed."
-      print_error " If a root-managed install might exist, re-run with: sudo bash $0)"
+      print_error " If a root-managed install might exist, re-run with: sudo bash $0${quoted_argv})"
     fi
     exit 1
   fi

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -119,45 +119,139 @@ validate_deployment_path() {
   grep -q "fleet-api" "$path/docker-compose.yaml" 2>/dev/null
 }
 
+# When invoked under sudo on Linux, prefer the invoking user's home over
+# /root — fleet is normally installed under the user account, and falling
+# back to /root/proto-fleet would miss the user's on-disk install.
 get_default_install_dir() {
   local os_type
   os_type=$(uname -s)
 
   if [[ "$os_type" == "Darwin" ]]; then
     echo "$HOME/Applications/ProtoFleet"
-  else
-    echo "$HOME/proto-fleet"
+    return
   fi
+
+  if [[ "$(id -u)" -eq 0 ]] && [[ -n "${SUDO_USER:-}" ]] && [[ "$SUDO_USER" != "root" ]]; then
+    # `|| true` neutralizes set -e / pipefail so a missing getent or failed
+    # NSS lookup falls through to $HOME instead of aborting.
+    local sudo_home
+    sudo_home=$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6 || true)
+    if [[ -n "$sudo_home" ]]; then
+      echo "$sudo_home/proto-fleet"
+      return
+    fi
+  fi
+
+  echo "$HOME/proto-fleet"
 }
 
 # =====================================================================
 # Deployment Path Detection
+#
+# Keep the two helpers below in sync with install.sh — install.sh is a
+# piped bootstrap (`curl | bash`) and can't source a shared lib, so the
+# detection logic intentionally lives in both scripts.
 # =====================================================================
 
-find_previous_install_dir() {
+# Probe docker for an existing fleet-api container and return the install
+# directory inferred from its bind mount. Echoes the path on success;
+# returns 1 on miss.
+#
+# Takes a privilege-wrapper argv (empty for unprivileged, or `sudo -n` for
+# elevated). All docker calls AND the marker validation are run through the
+# wrapper at the same privilege level — without that, sudo-detected installs
+# at root-only paths (e.g. /root/proto-fleet) would pass the docker probe
+# but silently fail the unprivileged `test -f` check and look absent.
+probe_install_dir_with() {
+  local privilege=("$@")
+  # `${arr[@]+"${arr[@]}"}` is the set-u-safe expansion for arrays that
+  # may be empty; bare `"${arr[@]}"` errors on empty arrays in bash 3.2.
   local container_id
-  container_id=$(docker ps -a \
-    --filter "name=${DEPLOYMENT_DIR}-fleet-api" \
-    --filter "name=${DEPLOYMENT_DIR}_fleet-api" \
-    --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
-
-  if [[ -z "$container_id" ]]; then
-    return 1
-  fi
+  container_id=$(${privilege[@]+"${privilege[@]}"} docker ps -a --filter "name=${DEPLOYMENT_DIR}-fleet-api" --filter "name=${DEPLOYMENT_DIR}_fleet-api" --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
+  [[ -z "$container_id" ]] && return 1
 
   local mount_path
-  mount_path=$(docker inspect --format \
-    '{{range .Mounts}}{{if eq .Destination "/var/lib/fleet/start"}}{{.Source}}{{end}}{{end}}' \
-    "$container_id" 2>/dev/null || true)
+  mount_path=$(${privilege[@]+"${privilege[@]}"} docker inspect --format '{{range .Mounts}}{{if eq .Destination "/var/lib/fleet/start"}}{{.Source}}{{end}}{{end}}' "$container_id" 2>/dev/null || true)
+  [[ -z "$mount_path" ]] && return 1
 
-  if [[ -z "$mount_path" ]]; then
+  # Strip the trailing /deployment/<...> segment with parameter expansion.
+  # `${var%/deployment/*}` matches the shortest trailing match, so
+  # /home/alice/deployment/proto-fleet/deployment/... resolves to
+  # /home/alice/deployment/proto-fleet (not /home/alice). Fall back to
+  # the bare /deployment suffix when the mount source ends exactly there.
+  local install_dir="${mount_path%/${DEPLOYMENT_DIR}/*}"
+  if [[ "$install_dir" == "$mount_path" ]]; then
+    install_dir="${mount_path%/${DEPLOYMENT_DIR}}"
+  fi
+  if [[ "$install_dir" == "$mount_path" ]]; then
+    return 1
+  fi
+  [[ -z "$install_dir" ]] && install_dir="/"
+
+  # Marker check at the same privilege level. Empty stderr on non-zero
+  # exit means the marker is genuinely missing; non-empty stderr means
+  # sudo refused (e.g., sudoers permits docker but not test) — in that
+  # case accept conservatively since docker already confirmed the
+  # container.
+  local marker="${install_dir%/}/${DEPLOYMENT_DIR}/docker-compose.yaml"
+  if [[ "${#privilege[@]}" -eq 0 ]]; then
+    [[ -f "$marker" ]] || return 1
+  else
+    local test_err
+    if ! test_err=$(${privilege[@]+"${privilege[@]}"} test -f "$marker" 2>&1); then
+      [[ -z "$test_err" ]] && return 1
+    fi
+  fi
+  echo "$install_dir"
+}
+
+# Determines the installation directory by detecting previous installations.
+# Writes results to globals (rather than stdout) so the sudo signal isn't
+# lost across a subshell:
+#   PREVIOUS_INSTALL_DIR          — install dir, or empty if none detected
+#   PREVIOUS_INSTALL_NEEDS_SUDO   — 1 if the install was only visible via sudo
+#   PREVIOUS_INSTALL_SUDO_BLOCKED — 1 if sudo would prompt and we couldn't
+#                                   probe the root daemon at all
+detect_previous_install() {
+  PREVIOUS_INSTALL_DIR=""
+  PREVIOUS_INSTALL_NEEDS_SUDO=0
+  PREVIOUS_INSTALL_SUDO_BLOCKED=0
+
+  local install_dir
+  if install_dir=$(probe_install_dir_with); then
+    PREVIOUS_INSTALL_DIR="$install_dir"
+    return 0
+  fi
+
+  if [[ "$(id -u)" -eq 0 ]]; then
+    if install_dir=$(probe_install_dir_with sudo -n); then
+      PREVIOUS_INSTALL_DIR="$install_dir"
+      PREVIOUS_INSTALL_NEEDS_SUDO=1
+      return 0
+    fi
     return 1
   fi
 
-  local install_dir
-  install_dir=$(echo "$mount_path" | sed "s|/${DEPLOYMENT_DIR}.*$||" || true)
-  echo "$install_dir"
-  return 0
+  # Probe sudo's view of docker directly and inspect stderr to distinguish
+  # "sudo refused (needs password)" from "sudo ran but found no install".
+  # `2>&1 >/dev/null` captures stderr only (redirect order matters).
+  local sudo_probe_err
+  sudo_probe_err=$(sudo -n docker version --format 'x' 2>&1 >/dev/null || true)
+  # Anchor each pattern on `sudo:` so docker stderr that happens to mention
+  # "password" / "terminal" / "tty" can't false-positive into SUDO_BLOCKED.
+  case "$sudo_probe_err" in
+    *"sudo: a password is required"*|*"sudo: a terminal is required"*|*"sudo:"*"may not run"*|*"sudo: no tty present"*)
+      PREVIOUS_INSTALL_SUDO_BLOCKED=1
+      return 1
+      ;;
+  esac
+
+  if install_dir=$(probe_install_dir_with sudo -n); then
+    PREVIOUS_INSTALL_DIR="$install_dir"
+    PREVIOUS_INSTALL_NEEDS_SUDO=1
+    return 0
+  fi
+  return 1
 }
 
 resolve_deployment_path() {
@@ -183,10 +277,22 @@ resolve_deployment_path() {
 
   # 2) Auto-detect via Docker container mounts
   if [[ -z "$resolved" ]]; then
-    local detected
-    detected=$(find_previous_install_dir || echo "")
-    if [[ -n "$detected" ]]; then
-      local candidate="${detected}/${DEPLOYMENT_DIR}"
+    detect_previous_install || true
+    if [[ -n "${PREVIOUS_INSTALL_DIR:-}" ]]; then
+      # If the install was only visible via sudo and we aren't running as
+      # root, the uninstaller will fail downstream (it needs to bring the
+      # docker-compose stack down and delete root-owned files). Fail loud
+      # now with the same guidance install.sh uses.
+      if [[ "${PREVIOUS_INSTALL_NEEDS_SUDO:-0}" == "1" ]] && [[ "$(id -u)" -ne 0 ]]; then
+        print_error "Existing fleet containers were detected, but only via sudo."
+        print_error "They are managed by the root Docker daemon, and this script is running as $(id -un)."
+        print_error "Re-run the uninstaller as root (preserving any flags you passed):"
+        echo ""
+        echo "    sudo bash $0"
+        echo ""
+        exit 1
+      fi
+      local candidate="${PREVIOUS_INSTALL_DIR}/${DEPLOYMENT_DIR}"
       if validate_deployment_path "$candidate"; then
         resolved="$candidate"
       fi
@@ -210,6 +316,12 @@ resolve_deployment_path() {
   if [[ -z "$resolved" ]]; then
     print_error "Could not locate a valid Proto Fleet deployment."
     print_error "Provide --deployment-path or ensure Proto Fleet is installed."
+    # When sudo would have prompted for a password, we couldn't probe the
+    # root daemon — a root-managed install could exist that we never saw.
+    if [[ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" == "1" ]]; then
+      print_error "(sudo required a password, so the root Docker daemon was not probed."
+      print_error " If a root-managed install might exist, re-run with: sudo bash $0)"
+    fi
     exit 1
   fi
 

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -54,6 +54,14 @@ EOF
 # `set -u` -safe — empty `"$@"` produces an empty array.
 ORIGINAL_ARGV=("$@")
 
+# Shell-escape ORIGINAL_ARGV for embedding in a copy-pasteable sudo command.
+# `printf ' %q'` cycles the format spec over every arg, so a single call
+# shell-escapes the whole array. Emits nothing when the array is empty so
+# the caller can append the result directly to a base command string.
+quoted_rerun_argv() {
+  (( ${#ORIGINAL_ARGV[@]} )) && printf ' %q' "${ORIGINAL_ARGV[@]}"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --deployment-path)
@@ -321,17 +329,9 @@ resolve_deployment_path() {
       if [[ "${PREVIOUS_INSTALL_NEEDS_SUDO:-0}" == "1" ]] && [[ "$(id -u)" -ne 0 ]]; then
         print_error "Existing fleet containers were detected, but only via sudo."
         print_error "They are managed by the root Docker daemon, and this script is running as $(id -un)."
-        # Preserve original flags so following the suggestion doesn't drop
-        # --dry-run (real uninstall instead of preview) or --deployment-path
-        # (wrong target). Shell-escape each arg via printf '%q'.
-        local quoted_argv=""
-        local arg
-        for arg in ${ORIGINAL_ARGV[@]+"${ORIGINAL_ARGV[@]}"}; do
-          quoted_argv+=" $(printf '%q' "$arg")"
-        done
-        print_error "Re-run the uninstaller as root:"
+        print_error "Re-run the uninstaller as root (flags preserved):"
         echo ""
-        echo "    sudo bash $0${quoted_argv}"
+        echo "    sudo bash $0$(quoted_rerun_argv)"
         echo ""
         exit 1
       fi
@@ -362,13 +362,8 @@ resolve_deployment_path() {
     # When sudo would have prompted for a password, we couldn't probe the
     # root daemon — a root-managed install could exist that we never saw.
     if [[ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" == "1" ]]; then
-      local quoted_argv=""
-      local arg
-      for arg in ${ORIGINAL_ARGV[@]+"${ORIGINAL_ARGV[@]}"}; do
-        quoted_argv+=" $(printf '%q' "$arg")"
-      done
       print_error "(sudo required a password, so the root Docker daemon was not probed."
-      print_error " If a root-managed install might exist, re-run with: sudo bash $0${quoted_argv})"
+      print_error " If a root-managed install might exist, re-run with: sudo bash $0$(quoted_rerun_argv))"
     fi
     exit 1
   fi


### PR DESCRIPTION
## Summary

`deployment-files/install.sh` previously detected existing installations only by probing the unprivileged docker daemon for a running `fleet-api` container. That misses two common real-world states:

1. **Containers pruned, install still on disk** — `docker compose down`, `docker system prune`, or a reboot with `--rm` leaves `~/proto-fleet/deployment/` in place but the probe finds nothing.
2. **Containers exist but only visible to root** — `run-fleet.sh` installs docker as root and adds the invoking user to the docker group, but the current shell may not have picked up that membership yet. Unprivileged `docker ps` returns empty even though `sudo docker ps` finds the containers in the root daemon.

In both cases, the installer announced "No previous installation detected" and offered to install into the default path. The first case leads to a redundant prompt; the second is worse — silently extracting on top of an install managed by a daemon the script can't see risks orphaning the existing containers and standing up a second competing stack.

This PR closes both gaps and adds a few hardening fixes along the way.

## What changed

- **Refactor the docker probe** — split into `probe_install_dir_with` (parameterized over the docker command) and `detect_previous_install` (orchestrator that writes globals so the sudo-mismatch signal survives the caller's `|| true`).
- **Sudo fallback probe** — when the unprivileged probe misses, retry with `sudo -n docker` (non-interactive; silently skipped if sudo would prompt). Tracks the result so the caller knows the install was only visible to root.
- **Fail loud on privilege mismatch** — when the install was only seen via sudo and the script isn't running as root, abort with a clear message giving the correct re-run form. The obvious `sudo bash <(curl …)` form does not work because process substitution opens an FD that sudo can't access; the message tells users to use `curl … | sudo bash -s -- <version>` instead, and also offers `newgrp docker` / log-out-and-back-in as an alternative for users whose docker-group membership is just stale.
- **On-disk fallback** — when both probes return nothing but `${DEFAULT_INSTALL_DIR}/deployment/docker-compose.yaml` exists on disk, treat it as the previous install. The `docker-compose.yaml` marker guards against accepting any unrelated `deployment/` directory.
- **Tarball cleanup** — register a `trap 'rm -f /tmp/${TAR_NAME}' EXIT` so the downloaded tarball is removed on every exit path, including the new sudo-mismatch abort. Previously only the happy path cleaned up.
- **Sanitize the suggested re-run command** — print the resolved `${VERSION}` in the error message instead of `${1:-latest}`, so anything the user passed as a version arg doesn't end up in a copy-pasteable `sudo bash` line.

## Test plan

- [x] `bash -n deployment-files/install.sh` passes after changes.
- [x] Reviewed by `compound-engineering:ce-code-review` (6 personas: correctness, maintainability, security, reliability, adversarial, project-standards). All 4 actionable findings introduced by the change have been resolved in this PR. One pre-existing item (substring `--filter name=` plus greedy `sed s|/deployment.*$||` in the docker probe) is documented as out of scope and unchanged.
- [ ] Manual verification on the affected box (`stl-lab-proto-fleet`) where the original bug was reproduced:
  - [ ] Without sudo: `bash <(curl … install.sh) nightly` exits with the fail-loud message naming `sudo bash -s -- nightly` and the `newgrp docker` alternative, rather than offering to install into the default path.
  - [ ] With sudo: `curl … install.sh | sudo bash -s -- nightly` correctly detects the existing install via the root daemon and offers it as the suggested location.
  - [ ] On a machine where containers were pruned: detection falls back to the on-disk path and proposes upgrading in place.
  - [ ] Tarball is removed from `/tmp` after a sudo-mismatch abort.

## Known limitations

- The pre-existing substring container-name filter and greedy mount-path sed are unchanged. They can theoretically misidentify unrelated containers (e.g., a `mydeployment-fleet-api-debug` container) and mount paths that contain `deployment` earlier in the segment. Worth a follow-up if we want the detector to be hardened against collisions and adversarial mount sources.
- The on-disk fallback only checks the default install location. A user who originally installed to a non-default path (e.g., `/opt/proto-fleet`) with no running containers would still get the default suggestion; they can decline and type the real path at the prompt.