### PR TITLE
Extract active curtailment status component

### DIFF
--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures.ts
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures.ts
@@ -1,0 +1,47 @@
+import type { ActiveCurtailmentEvent } from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
+
+export const curtailingCurtailmentEvent: ActiveCurtailmentEvent = {
+  reason: "ERCOT ERS obligation",
+  state: "active",
+  scopeLabel: "Rockdale, TX",
+  selectedMiners: 18,
+  estimatedReductionKw: 60.2,
+  targetKw: 60,
+  observedReductionKw: 59.4,
+  remainingPowerKw: 132.5,
+  restoreBatchSize: 10,
+  restoreBatchIntervalSec: 120,
+  rollups: [
+    { state: "confirmed", count: 16 },
+    { state: "dispatched", count: 1 },
+    { state: "drifted", count: 1 },
+    { state: "resolved", count: 0 },
+    { state: "restoreFailed", count: 0 },
+  ],
+};
+
+export const curtailedCurtailmentEvent: ActiveCurtailmentEvent = {
+  ...curtailingCurtailmentEvent,
+  observedReductionKw: curtailingCurtailmentEvent.targetKw ?? curtailingCurtailmentEvent.estimatedReductionKw,
+  remainingPowerKw: 131.9,
+  rollups: [{ state: "confirmed", count: curtailingCurtailmentEvent.selectedMiners }],
+};
+
+export const restoringCurtailmentEvent: ActiveCurtailmentEvent = {
+  ...curtailingCurtailmentEvent,
+  state: "restoring",
+  rollups: [
+    { state: "resolved", count: 8 },
+    { state: "confirmed", count: 9 },
+    { state: "restoreFailed", count: 1 },
+  ],
+};
+
+export const restoredCurtailmentEvent: ActiveCurtailmentEvent = {
+  ...curtailingCurtailmentEvent,
+  state: "completed",
+  observedReductionKw: 0,
+  remainingPowerKw: 191.9,
+  endedAt: "2026-04-30T14:08:00-04:00",
+  rollups: [{ state: "resolved", count: curtailingCurtailmentEvent.selectedMiners }],
+};

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures.ts
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures.ts
@@ -45,3 +45,12 @@ export const restoredCurtailmentEvent: ActiveCurtailmentEvent = {
   endedAt: "2026-04-30T14:08:00-04:00",
   rollups: [{ state: "resolved", count: curtailingCurtailmentEvent.selectedMiners }],
 };
+
+export const restoreIncompleteCurtailmentEvent: ActiveCurtailmentEvent = {
+  ...restoredCurtailmentEvent,
+  state: "completedWithFailures",
+  rollups: [
+    { state: "resolved", count: 17 },
+    { state: "restoreFailed", count: 1 },
+  ],
+};

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.stories.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.stories.tsx
@@ -1,0 +1,217 @@
+import { type ReactElement, useEffect, useMemo, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ActiveCurtailmentStatus, {
+  type ActiveCurtailmentEvent,
+} from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
+import {
+  curtailedCurtailmentEvent,
+  curtailingCurtailmentEvent,
+  restoredCurtailmentEvent,
+  restoringCurtailmentEvent,
+} from "@/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures";
+
+const meta = {
+  title: "Proto Fleet/Energy/Active Curtailment Status",
+  component: ActiveCurtailmentStatus,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-surface-base p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ActiveCurtailmentStatus>;
+
+export default meta;
+
+type Story = StoryObj<typeof ActiveCurtailmentStatus>;
+type AnimationPhase = "shed" | "curtailed" | "restore" | "restored";
+type AnimatedEventPhase = Exclude<AnimationPhase, "curtailed">;
+
+interface BuildAnimatedEventArgs {
+  phase: AnimatedEventPhase;
+  progressPercent: number;
+}
+
+interface GetAnimatedEventArgs {
+  phase: AnimationPhase;
+  restoreProgressPercent: number;
+  shedProgressPercent: number;
+}
+
+interface StartProgressIntervalArgs {
+  onComplete: () => void;
+  setProgressPercent: (updater: (currentPercent: number) => number) => void;
+}
+
+const animationStepPercent = 10;
+const animationStepMs = 450;
+const restoreStartDelayMs = 900;
+
+function startProgressInterval({ onComplete, setProgressPercent }: StartProgressIntervalArgs): number {
+  const intervalId = window.setInterval(() => {
+    setProgressPercent((currentPercent) => {
+      const nextPercent = Math.min(currentPercent + animationStepPercent, 100);
+
+      if (nextPercent === 100) {
+        window.clearInterval(intervalId);
+        onComplete();
+      }
+
+      return nextPercent;
+    });
+  }, animationStepMs);
+
+  return intervalId;
+}
+
+function buildAnimatedEvent({ phase, progressPercent }: BuildAnimatedEventArgs): ActiveCurtailmentEvent {
+  const targetKw = curtailingCurtailmentEvent.targetKw ?? curtailingCurtailmentEvent.estimatedReductionKw;
+  const selectedMiners = curtailingCurtailmentEvent.selectedMiners;
+  const completedMiners = Math.round((selectedMiners * progressPercent) / 100);
+  const pendingMiners = Math.max(selectedMiners - completedMiners, 0);
+
+  switch (phase) {
+    case "restored":
+      return restoredCurtailmentEvent;
+    case "restore":
+      return {
+        ...curtailingCurtailmentEvent,
+        state: "restoring",
+        observedReductionKw: targetKw,
+        rollups: [
+          { state: "resolved", count: completedMiners },
+          { state: "confirmed", count: pendingMiners },
+        ],
+      };
+    case "shed":
+      return {
+        ...curtailingCurtailmentEvent,
+        state: "active",
+        observedReductionKw: (targetKw * progressPercent) / 100,
+        rollups: [
+          { state: "confirmed", count: completedMiners },
+          { state: "pending", count: pendingMiners },
+        ],
+      };
+  }
+}
+
+function getAnimatedEvent({
+  phase,
+  restoreProgressPercent,
+  shedProgressPercent,
+}: GetAnimatedEventArgs): ActiveCurtailmentEvent {
+  switch (phase) {
+    case "restore":
+      return buildAnimatedEvent({ phase: "restore", progressPercent: restoreProgressPercent });
+    case "restored":
+      return buildAnimatedEvent({ phase: "restored", progressPercent: 100 });
+    case "curtailed":
+    case "shed":
+      return buildAnimatedEvent({ phase: "shed", progressPercent: shedProgressPercent });
+  }
+}
+
+function AnimatedCurtailmentLifecycleStory(): ReactElement {
+  const [phase, setPhase] = useState<AnimationPhase>("shed");
+  const [shedProgressPercent, setShedProgressPercent] = useState(0);
+  const [restoreProgressPercent, setRestoreProgressPercent] = useState(0);
+
+  useEffect(() => {
+    if (phase !== "shed") {
+      return;
+    }
+
+    const intervalId = startProgressInterval({
+      onComplete: () => setPhase("curtailed"),
+      setProgressPercent: setShedProgressPercent,
+    });
+
+    return () => window.clearInterval(intervalId);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== "curtailed") {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setRestoreProgressPercent(0);
+      setPhase("restore");
+    }, restoreStartDelayMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== "restore") {
+      return;
+    }
+
+    const intervalId = startProgressInterval({
+      onComplete: () => setPhase("restored"),
+      setProgressPercent: setRestoreProgressPercent,
+    });
+
+    return () => window.clearInterval(intervalId);
+  }, [phase]);
+
+  const activeEvent = useMemo<ActiveCurtailmentEvent>(
+    () => getAnimatedEvent({ phase, restoreProgressPercent, shedProgressPercent }),
+    [phase, restoreProgressPercent, shedProgressPercent],
+  );
+
+  function resetAnimation(): void {
+    setShedProgressPercent(0);
+    setRestoreProgressPercent(0);
+    setPhase("shed");
+  }
+
+  return (
+    <ActiveCurtailmentStatus
+      event={activeEvent}
+      onDismissRestored={resetAnimation}
+      onRequestRestore={() => setPhase("restore")}
+      onRequestStop={() => setPhase("restore")}
+    />
+  );
+}
+
+export const Curtailing: Story = {
+  args: {
+    event: curtailingCurtailmentEvent,
+    onRequestStop: () => undefined,
+  },
+};
+
+export const Curtailed: Story = {
+  args: {
+    event: curtailedCurtailmentEvent,
+    onRequestRestore: () => undefined,
+  },
+};
+
+export const Restoring: Story = {
+  args: {
+    event: restoringCurtailmentEvent,
+  },
+};
+
+export const Restored: Story = {
+  args: {
+    event: restoredCurtailmentEvent,
+    onDismissRestored: () => undefined,
+  },
+};
+
+export const AnimatedCurtailmentLifecycle: Story = {
+  name: "Animated curtailment lifecycle",
+  render: function renderAnimatedCurtailmentLifecycle(): ReactElement {
+    return <AnimatedCurtailmentLifecycleStory />;
+  },
+};

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.stories.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.stories.tsx
@@ -8,6 +8,7 @@ import {
   curtailedCurtailmentEvent,
   curtailingCurtailmentEvent,
   restoredCurtailmentEvent,
+  restoreIncompleteCurtailmentEvent,
   restoringCurtailmentEvent,
 } from "@/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures";
 
@@ -206,6 +207,12 @@ export const Restored: Story = {
   args: {
     event: restoredCurtailmentEvent,
     onDismissRestored: () => undefined,
+  },
+};
+
+export const RestoreIncomplete: Story = {
+  args: {
+    event: restoreIncompleteCurtailmentEvent,
   },
 };
 

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -176,6 +176,34 @@ describe("ActiveCurtailmentStatus", () => {
     }
   });
 
+  it("excludes failed targets from the restoring completion estimate", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T10:00:00-04:00"));
+
+    try {
+      render(
+        <ActiveCurtailmentStatus
+          event={{
+            ...restoringCurtailmentEvent,
+            restoreBatchSize: 5,
+            rollups: [
+              { state: "resolved", count: 10 },
+              { state: "restoreFailed", count: 8 },
+            ],
+            selectedMiners: 18,
+          }}
+        />,
+      );
+
+      expect(screen.getByText("Estimated time to restore")).toBeVisible();
+      expect(screen.getByText("Immediate")).toBeVisible();
+      expect(screen.getByText(formatExpectedDateTime("2026-05-01T10:00:00-04:00"))).toBeVisible();
+      expect(screen.queryByText(formatExpectedDateTime("2026-05-01T10:02:00-04:00"))).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("renders an unavailable restore completion when the estimate is out of range", () => {
     render(
       <ActiveCurtailmentStatus

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -189,6 +189,13 @@ describe("ActiveCurtailmentStatus", () => {
     expect(onDismissRestored).toHaveBeenCalledOnce();
   });
 
+  it("shows an unavailable completed time when a restored event has no end time", () => {
+    render(<ActiveCurtailmentStatus event={{ ...restoredCurtailmentEvent, endedAt: undefined }} />);
+
+    expect(screen.getByText("Completed")).toBeVisible();
+    expect(screen.getByText("Time unavailable")).toBeVisible();
+  });
+
   it("uses rollup totals for terminal restore duration when selected miner count is stale", () => {
     render(
       <ActiveCurtailmentStatus

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ActiveCurtailmentStatus from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
+import {
+  curtailedCurtailmentEvent,
+  curtailingCurtailmentEvent,
+  restoredCurtailmentEvent,
+  restoringCurtailmentEvent,
+} from "@/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures";
+
+function expectActionButtonHidden(name: string): void {
+  expect(screen.queryByRole("button", { name })).not.toBeInTheDocument();
+}
+
+function expectProgressValue(value: string): void {
+  expect(screen.getByTestId("active-curtailment-progress")).toHaveAttribute("aria-valuenow", value);
+}
+
+function formatExpectedDateTime(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+describe("ActiveCurtailmentStatus", () => {
+  it("renders a curtailing event with stop available and no manage action", () => {
+    const onRequestStop = vi.fn();
+
+    render(<ActiveCurtailmentStatus event={curtailingCurtailmentEvent} onRequestStop={onRequestStop} />);
+
+    expect(screen.getByText("Active curtailment")).toBeInTheDocument();
+    expect(screen.getByText("ERCOT ERS obligation (Applies to Rockdale, TX)")).toBeVisible();
+    expect(screen.getByText("Power shed")).toBeVisible();
+    expect(screen.getByText("59.4 kW of 60.0 kW")).toBeVisible();
+    expect(screen.getAllByText("Curtailing")[0]).toBeVisible();
+    expect(screen.getByText("89% curtailed")).toBeVisible();
+    expectProgressValue("89");
+    expectActionButtonHidden("Manage");
+    expectActionButtonHidden("Restore");
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(onRequestStop).toHaveBeenCalledOnce();
+  });
+
+  it("renders a curtailed event with restore available", () => {
+    const onRequestRestore = vi.fn();
+
+    render(<ActiveCurtailmentStatus event={curtailedCurtailmentEvent} onRequestRestore={onRequestRestore} />);
+
+    expect(screen.getByText("60.0 kW of 60.0 kW")).toBeVisible();
+    expect(screen.getAllByText("Curtailed")[0]).toBeVisible();
+    expectProgressValue("100");
+    expectActionButtonHidden("Manage");
+    expectActionButtonHidden("Stop");
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+
+    expect(onRequestRestore).toHaveBeenCalledOnce();
+  });
+
+  it("renders a restoring event without stop, restore, or manage actions", () => {
+    render(<ActiveCurtailmentStatus event={restoringCurtailmentEvent} />);
+
+    expect(screen.getByText("Power restore")).toBeVisible();
+    expect(screen.getByText("26.7 kW of 60.0 kW restored")).toBeVisible();
+    expect(screen.getByText("Restoring")).toBeVisible();
+    expect(screen.getByText("10 miners every 120s")).toBeVisible();
+    expect(screen.getByText("Estimated time to restore")).toBeVisible();
+    expect(screen.getByText("Immediate")).toBeVisible();
+    expectProgressValue("44");
+    expectActionButtonHidden("Manage");
+    expectActionButtonHidden("Stop");
+    expectActionButtonHidden("Restore");
+  });
+
+  it("counts released targets as restored during restoration", () => {
+    render(
+      <ActiveCurtailmentStatus
+        event={{
+          ...restoringCurtailmentEvent,
+          rollups: [
+            { state: "resolved", count: 8 },
+            { state: "released", count: 2 },
+            { state: "confirmed", count: 8 },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("33.3 kW of 60.0 kW restored")).toBeVisible();
+    expectProgressValue("56");
+  });
+
+  it("estimates restoring completion from the current time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T10:00:00-04:00"));
+
+    try {
+      render(
+        <ActiveCurtailmentStatus
+          event={{
+            ...restoringCurtailmentEvent,
+            selectedMiners: 25,
+            rollups: [
+              { state: "resolved", count: 10 },
+              { state: "confirmed", count: 15 },
+            ],
+          }}
+        />,
+      );
+
+      expect(screen.getByText(formatExpectedDateTime("2026-05-01T10:02:00-04:00"))).toBeVisible();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("estimates restoring completion from rollup totals when selected miner count is stale", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T10:00:00-04:00"));
+
+    try {
+      render(
+        <ActiveCurtailmentStatus
+          event={{
+            ...restoringCurtailmentEvent,
+            selectedMiners: 0,
+            rollups: [
+              { state: "resolved", count: 10 },
+              { state: "confirmed", count: 15 },
+            ],
+          }}
+        />,
+      );
+
+      expect(screen.getByText(formatExpectedDateTime("2026-05-01T10:02:00-04:00"))).toBeVisible();
+      expectProgressValue("40");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("renders a restored event with dismiss available", () => {
+    const onDismissRestored = vi.fn();
+
+    render(<ActiveCurtailmentStatus event={restoredCurtailmentEvent} onDismissRestored={onDismissRestored} />);
+
+    expect(screen.getByText("Power restore")).toBeVisible();
+    expect(screen.getByText("60.0 kW restored")).toBeVisible();
+    expect(screen.getAllByText("Restored")[0]).toBeVisible();
+    expect(screen.getByText("Time to restore")).toBeVisible();
+    expect(screen.getByText("2 minutes")).toBeVisible();
+    expectProgressValue("100");
+    expectActionButtonHidden("Manage");
+    expectActionButtonHidden("Stop");
+    expectActionButtonHidden("Restore");
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(onDismissRestored).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -50,6 +50,33 @@ describe("ActiveCurtailmentStatus", () => {
     expect(onRequestStop).toHaveBeenCalledOnce();
   });
 
+  it("renders a pending event with stop available", async () => {
+    const user = userEvent.setup();
+    const onRequestStop = vi.fn();
+
+    render(
+      <ActiveCurtailmentStatus
+        event={{
+          ...curtailingCurtailmentEvent,
+          observedReductionKw: 0,
+          rollups: [{ state: "pending", count: curtailingCurtailmentEvent.selectedMiners }],
+          state: "pending",
+        }}
+        onRequestStop={onRequestStop}
+      />,
+    );
+
+    expect(screen.getByText("0.0 kW of 60.0 kW")).toBeVisible();
+    expect(screen.getAllByText("Pending")[0]).toBeVisible();
+    expect(screen.queryByText("Curtailing")).not.toBeInTheDocument();
+    expectProgressValue("0");
+    expectActionButtonHidden("Restore");
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(onRequestStop).toHaveBeenCalledOnce();
+  });
+
   it("renders a curtailed event with restore available", async () => {
     const user = userEvent.setup();
     const onRequestRestore = vi.fn();

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -6,6 +6,7 @@ import {
   curtailedCurtailmentEvent,
   curtailingCurtailmentEvent,
   restoredCurtailmentEvent,
+  restoreIncompleteCurtailmentEvent,
   restoringCurtailmentEvent,
 } from "@/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures";
 
@@ -163,5 +164,21 @@ describe("ActiveCurtailmentStatus", () => {
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
 
     expect(onDismissRestored).toHaveBeenCalledOnce();
+  });
+
+  it("renders a completed-with-failures event as an incomplete restore", () => {
+    render(<ActiveCurtailmentStatus event={restoreIncompleteCurtailmentEvent} onDismissRestored={vi.fn()} />);
+
+    expect(screen.getByText("Power restore")).toBeVisible();
+    expect(screen.getByText("56.7 kW of 60.0 kW restored")).toBeVisible();
+    expect(screen.getByText("Restore incomplete")).toBeVisible();
+    expect(screen.getByText("Failed to restore")).toBeVisible();
+    expect(screen.getByText("1 miner")).toBeVisible();
+    expect(screen.getByText("Not restored")).toBeVisible();
+    expect(screen.queryByText("60.0 kW restored")).not.toBeInTheDocument();
+    expectProgressValue("94");
+    expectActionButtonHidden("Dismiss");
+    expectActionButtonHidden("Stop");
+    expectActionButtonHidden("Restore");
   });
 });

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
 
 import ActiveCurtailmentStatus from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
 import {
@@ -28,7 +29,8 @@ function formatExpectedDateTime(value: string): string {
 }
 
 describe("ActiveCurtailmentStatus", () => {
-  it("renders a curtailing event with stop available and no manage action", () => {
+  it("renders a curtailing event with stop available and no manage action", async () => {
+    const user = userEvent.setup();
     const onRequestStop = vi.fn();
 
     render(<ActiveCurtailmentStatus event={curtailingCurtailmentEvent} onRequestStop={onRequestStop} />);
@@ -43,12 +45,13 @@ describe("ActiveCurtailmentStatus", () => {
     expectActionButtonHidden("Manage");
     expectActionButtonHidden("Restore");
 
-    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+    await user.click(screen.getByRole("button", { name: "Stop" }));
 
     expect(onRequestStop).toHaveBeenCalledOnce();
   });
 
-  it("renders a curtailed event with restore available", () => {
+  it("renders a curtailed event with restore available", async () => {
+    const user = userEvent.setup();
     const onRequestRestore = vi.fn();
 
     render(<ActiveCurtailmentStatus event={curtailedCurtailmentEvent} onRequestRestore={onRequestRestore} />);
@@ -59,7 +62,7 @@ describe("ActiveCurtailmentStatus", () => {
     expectActionButtonHidden("Manage");
     expectActionButtonHidden("Stop");
 
-    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    await user.click(screen.getByRole("button", { name: "Restore" }));
 
     expect(onRequestRestore).toHaveBeenCalledOnce();
   });
@@ -146,7 +149,27 @@ describe("ActiveCurtailmentStatus", () => {
     }
   });
 
-  it("renders a restored event with dismiss available", () => {
+  it("renders an unavailable restore completion when the estimate is out of range", () => {
+    render(
+      <ActiveCurtailmentStatus
+        event={{
+          ...restoringCurtailmentEvent,
+          restoreBatchIntervalSec: Number.MAX_SAFE_INTEGER,
+          restoreBatchSize: 1,
+          rollups: [
+            { state: "resolved", count: 0 },
+            { state: "confirmed", count: 2 },
+          ],
+          selectedMiners: 2,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Time unavailable")).toBeVisible();
+  });
+
+  it("renders a restored event with dismiss available", async () => {
+    const user = userEvent.setup();
     const onDismissRestored = vi.fn();
 
     render(<ActiveCurtailmentStatus event={restoredCurtailmentEvent} onDismissRestored={onDismissRestored} />);
@@ -161,9 +184,24 @@ describe("ActiveCurtailmentStatus", () => {
     expectActionButtonHidden("Stop");
     expectActionButtonHidden("Restore");
 
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
 
     expect(onDismissRestored).toHaveBeenCalledOnce();
+  });
+
+  it("uses rollup totals for terminal restore duration when selected miner count is stale", () => {
+    render(
+      <ActiveCurtailmentStatus
+        event={{
+          ...restoredCurtailmentEvent,
+          rollups: [{ state: "resolved", count: 25 }],
+          selectedMiners: 0,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Time to restore")).toBeVisible();
+    expect(screen.getByText("4 minutes")).toBeVisible();
   });
 
   it("renders a completed-with-failures event as an incomplete restore", () => {
@@ -177,6 +215,40 @@ describe("ActiveCurtailmentStatus", () => {
     expect(screen.getByText("Not restored")).toBeVisible();
     expect(screen.queryByText("60.0 kW restored")).not.toBeInTheDocument();
     expectProgressValue("94");
+    expectActionButtonHidden("Dismiss");
+    expectActionButtonHidden("Stop");
+    expectActionButtonHidden("Restore");
+  });
+
+  it("renders failed and cancelled events without active controls", () => {
+    const onDismissRestored = vi.fn();
+    const onRequestRestore = vi.fn();
+    const onRequestStop = vi.fn();
+
+    const { rerender } = render(
+      <ActiveCurtailmentStatus
+        event={{ ...curtailingCurtailmentEvent, state: "failed" }}
+        onDismissRestored={onDismissRestored}
+        onRequestRestore={onRequestRestore}
+        onRequestStop={onRequestStop}
+      />,
+    );
+
+    expect(screen.getByText("Failed")).toBeVisible();
+    expectActionButtonHidden("Dismiss");
+    expectActionButtonHidden("Stop");
+    expectActionButtonHidden("Restore");
+
+    rerender(
+      <ActiveCurtailmentStatus
+        event={{ ...curtailedCurtailmentEvent, state: "cancelled" }}
+        onDismissRestored={onDismissRestored}
+        onRequestRestore={onRequestRestore}
+        onRequestStop={onRequestStop}
+      />,
+    );
+
+    expect(screen.getByText("Cancelled")).toBeVisible();
     expectActionButtonHidden("Dismiss");
     expectActionButtonHidden("Stop");
     expectActionButtonHidden("Restore");

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -96,6 +96,7 @@ type ActiveCurtailmentDisplayState =
   | "curtailing"
   | "curtailed"
   | "failed"
+  | "pending"
   | "restoring"
   | "restored"
   | "restoreIncomplete";
@@ -129,6 +130,7 @@ interface StatusIconArgs {
 
 interface ActiveCurtailmentDisplayFlags {
   isCurtailmentComplete: boolean;
+  isPending: boolean;
   isRestored: boolean;
   isRestoreIncomplete: boolean;
   isRestoring: boolean;
@@ -170,6 +172,7 @@ const displayStateLabels: Record<ActiveCurtailmentDisplayState, string> = {
   curtailed: "Curtailed",
   curtailing: "Curtailing",
   failed: "Failed",
+  pending: "Pending",
   restoreIncomplete: "Restore incomplete",
   restored: "Restored",
   restoring: "Restoring",
@@ -309,6 +312,10 @@ function getActiveCurtailmentDisplayState(
     return "restoring";
   }
 
+  if (event.state === "pending") {
+    return "pending";
+  }
+
   if (isRestoreIncompleteEventState(event.state)) {
     return "restoreIncomplete";
   }
@@ -418,6 +425,7 @@ function formatRestoreTimeValue({
 }
 
 function getDisplayFlags(displayState: ActiveCurtailmentDisplayState): ActiveCurtailmentDisplayFlags {
+  const isPending = displayState === "pending";
   const isRestored = displayState === "restored";
   const isRestoreIncomplete = displayState === "restoreIncomplete";
   const isRestoring = displayState === "restoring";
@@ -425,6 +433,7 @@ function getDisplayFlags(displayState: ActiveCurtailmentDisplayState): ActiveCur
 
   return {
     isCurtailmentComplete: displayState === "curtailed",
+    isPending,
     isRestored,
     isRestoreIncomplete,
     isRestoring,
@@ -447,7 +456,7 @@ function getProgressLegend(displayFlags: ActiveCurtailmentDisplayFlags): ActiveC
     primaryDotClassName: "bg-core-primary-fill",
     primaryLabel: "Curtailed",
     secondaryDotClassName: "bg-core-accent-fill",
-    secondaryLabel: "Curtailing",
+    secondaryLabel: displayFlags.isPending ? "Pending" : "Curtailing",
   };
 }
 
@@ -500,6 +509,7 @@ function getActiveCurtailmentActionButton({
       return onRequestRestore ? (
         <Button variant={variants.primary} size={sizes.compact} text="Restore" onClick={onRequestRestore} />
       ) : null;
+    case "pending":
     case "curtailing":
       return onRequestStop ? (
         <Button variant={variants.danger} size={sizes.compact} text="Stop" onClick={onRequestStop} />
@@ -629,11 +639,8 @@ export default function ActiveCurtailmentStatus({
     totalRestoreSeconds,
   });
   const restoreCompletionLabel = displayFlags.isRestored ? "Completed" : "Estimated completion";
-  const restoreCompletionValue = displayFlags.isRestored
-    ? formatDateTime(event.endedAt)
-    : event.endedAt
-      ? formatDateTime(event.endedAt)
-      : estimatedCompletion;
+  const restoreCompletionValue =
+    displayFlags.isRestored || event.endedAt ? formatDateTime(event.endedAt) : estimatedCompletion;
   const restoreFailureValue = formatMinerCount(compliance.restoreFailedCount);
   const restoreProgressPercent = displayFlags.isRestored ? 100 : restoredPercent;
   const curtailProgressPercent = displayFlags.isCurtailmentComplete ? 100 : curtailedPercent;

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -2,7 +2,7 @@ import { type ReactElement, type ReactNode } from "react";
 import clsx from "clsx";
 
 import type { CurtailmentEventState } from "@/protoFleet/features/energy/CurtailmentHistory";
-import { Success } from "@/shared/assets/icons";
+import { Alert, Success } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Header from "@/shared/components/Header";
 import ProgressCircular from "@/shared/components/ProgressCircular";
@@ -86,15 +86,16 @@ interface StatBlockProps {
 
 interface MinerCompliance {
   curtailedCount: number;
+  restoreFailedCount: number;
   restoredCount: number;
   totalCount: number;
 }
 
-type ActiveCurtailmentDisplayState = "curtailing" | "curtailed" | "restoring" | "restored";
+type ActiveCurtailmentDisplayState = "curtailing" | "curtailed" | "restoring" | "restored" | "restoreIncomplete";
 
 interface FormatActivePowerValueArgs {
   isRestored: boolean;
-  isRestoring: boolean;
+  isRestoreFlow: boolean;
   observedReductionKw: number;
   restoredKw: number;
   targetKw: number;
@@ -115,11 +116,13 @@ interface RestoreTimeValueArgs {
 interface StatusIconArgs {
   isCurtailmentComplete: boolean;
   isRestored: boolean;
+  isRestoreIncomplete: boolean;
 }
 
 interface ActiveCurtailmentDisplayFlags {
   isCurtailmentComplete: boolean;
   isRestored: boolean;
+  isRestoreIncomplete: boolean;
   isRestoring: boolean;
   isRestoreFlow: boolean;
 }
@@ -150,11 +153,13 @@ const countedTargetStates: CurtailmentTargetState[] = [
   "restoreFailed",
 ];
 const curtailedTargetStates: CurtailmentTargetState[] = ["confirmed", "resolved"];
+const restoreFailedTargetStates: CurtailmentTargetState[] = ["restoreFailed"];
 const restoredTargetStates: CurtailmentTargetState[] = ["resolved", "released"];
 
 const displayStateLabels: Record<ActiveCurtailmentDisplayState, string> = {
   curtailed: "Curtailed",
   curtailing: "Curtailing",
+  restoreIncomplete: "Restore incomplete",
   restored: "Restored",
   restoring: "Restoring",
 };
@@ -254,21 +259,25 @@ function getRollupCount(event: ActiveCurtailmentEvent, states: CurtailmentTarget
 
 function getMinerCompliance(event: ActiveCurtailmentEvent): MinerCompliance {
   const curtailedCount = getRollupCount(event, curtailedTargetStates);
+  const restoreFailedCount = getRollupCount(event, restoreFailedTargetStates);
   const restoredCount = getRollupCount(event, restoredTargetStates);
   const countedTargetCount = getRollupCount(event, countedTargetStates);
   const totalCount = Math.max(event.selectedMiners, countedTargetCount);
 
   return {
     curtailedCount,
+    restoreFailedCount,
     restoredCount,
     totalCount,
   };
 }
 
 function isRestoredEventState(state: CurtailmentEventState): boolean {
-  const isCompleted = state === "completed";
-  const isCompletedWithFailures = state === "completedWithFailures";
-  return isCompleted || isCompletedWithFailures;
+  return state === "completed";
+}
+
+function isRestoreIncompleteEventState(state: CurtailmentEventState): boolean {
+  return state === "completedWithFailures";
 }
 
 function getActiveCurtailmentDisplayState(
@@ -278,6 +287,10 @@ function getActiveCurtailmentDisplayState(
 ): ActiveCurtailmentDisplayState {
   if (event.state === "restoring") {
     return "restoring";
+  }
+
+  if (isRestoreIncompleteEventState(event.state)) {
+    return "restoreIncomplete";
   }
 
   if (isRestoredEventState(event.state)) {
@@ -297,7 +310,7 @@ function getRestoredPercent(event: ActiveCurtailmentEvent, restoredCount: number
 
 function formatActivePowerValue({
   isRestored,
-  isRestoring,
+  isRestoreFlow,
   observedReductionKw,
   restoredKw,
   targetKw,
@@ -306,7 +319,7 @@ function formatActivePowerValue({
     return `${formatKw(targetKw)} restored`;
   }
 
-  if (isRestoring) {
+  if (isRestoreFlow) {
     return `${formatKw(restoredKw)} of ${formatKw(targetKw)} restored`;
   }
 
@@ -378,13 +391,15 @@ function formatRestoreTimeValue({
 
 function getDisplayFlags(displayState: ActiveCurtailmentDisplayState): ActiveCurtailmentDisplayFlags {
   const isRestored = displayState === "restored";
+  const isRestoreIncomplete = displayState === "restoreIncomplete";
   const isRestoring = displayState === "restoring";
 
   return {
     isCurtailmentComplete: displayState === "curtailed",
     isRestored,
+    isRestoreIncomplete,
     isRestoring,
-    isRestoreFlow: isRestoring || isRestored,
+    isRestoreFlow: isRestoring || isRestored || isRestoreIncomplete,
   };
 }
 
@@ -393,8 +408,8 @@ function getProgressLegend(displayFlags: ActiveCurtailmentDisplayFlags): ActiveC
     return {
       primaryDotClassName: "bg-intent-success-fill",
       primaryLabel: "Restored",
-      secondaryDotClassName: "bg-core-primary-fill",
-      secondaryLabel: "Curtailed",
+      secondaryDotClassName: displayFlags.isRestoreIncomplete ? "bg-intent-critical-fill" : "bg-core-primary-fill",
+      secondaryLabel: displayFlags.isRestoreIncomplete ? "Not restored" : "Curtailed",
     };
   }
 
@@ -443,6 +458,8 @@ function getActiveCurtailmentActionButton({
       return onDismissRestored ? (
         <Button variant={variants.secondary} size={sizes.compact} text="Dismiss" onClick={onDismissRestored} />
       ) : null;
+    case "restoreIncomplete":
+      return null;
     case "curtailed":
       return onRequestRestore ? (
         <Button variant={variants.primary} size={sizes.compact} text="Restore" onClick={onRequestRestore} />
@@ -469,7 +486,15 @@ function ActiveCurtailmentActionButtons(props: ActiveCurtailmentActionButtonsPro
   );
 }
 
-function getActiveCurtailmentStatusIcon({ isRestored, isCurtailmentComplete }: StatusIconArgs): ReactNode {
+function getActiveCurtailmentStatusIcon({
+  isRestored,
+  isRestoreIncomplete,
+  isCurtailmentComplete,
+}: StatusIconArgs): ReactNode {
+  if (isRestoreIncomplete) {
+    return <Alert className="text-intent-critical-fill" />;
+  }
+
   if (isRestored) {
     return <Success className="text-intent-success-fill" />;
   }
@@ -551,7 +576,7 @@ export default function ActiveCurtailmentStatus({
   const powerLabel = displayFlags.isRestoreFlow ? "Power restore" : "Power shed";
   const powerValue = formatActivePowerValue({
     isRestored: displayFlags.isRestored,
-    isRestoring: displayFlags.isRestoring,
+    isRestoreFlow: displayFlags.isRestoreFlow,
     observedReductionKw,
     restoredKw,
     targetKw,
@@ -559,14 +584,16 @@ export default function ActiveCurtailmentStatus({
   const dispatchStatus = displayStateLabels[displayState];
   const minerStatus =
     compliance.totalCount > 0 ? `${Math.round(curtailedPercent).toLocaleString()}% curtailed` : "No miners selected";
-  const restoreTimeLabel = displayFlags.isRestored ? "Time to restore" : "Estimated time to restore";
+  const isTerminalRestoreFlow = displayFlags.isRestored || displayFlags.isRestoreIncomplete;
+  const restoreTimeLabel = isTerminalRestoreFlow ? "Time to restore" : "Estimated time to restore";
   const restoreTimeValue = formatRestoreTimeValue({
-    isRestored: displayFlags.isRestored,
+    isRestored: isTerminalRestoreFlow,
     remainingRestoreSeconds,
     totalRestoreSeconds,
   });
   const restoreCompletionLabel = displayFlags.isRestored ? "Completed" : "Estimated completion";
   const restoreCompletionValue = event.endedAt ? formatDateTime(event.endedAt) : estimatedCompletion;
+  const restoreFailureValue = formatMinerCount(compliance.restoreFailedCount);
   const restoreProgressPercent = displayFlags.isRestored ? 100 : restoredPercent;
   const curtailProgressPercent = displayFlags.isCurtailmentComplete ? 100 : curtailedPercent;
   const primaryProgressPercent = displayFlags.isRestoreFlow ? restoreProgressPercent : curtailProgressPercent;
@@ -575,6 +602,7 @@ export default function ActiveCurtailmentStatus({
   const showSecondaryProgress = shouldShowSecondaryProgress(displayFlags);
   const statusIcon = getActiveCurtailmentStatusIcon({
     isRestored: displayFlags.isRestored,
+    isRestoreIncomplete: displayFlags.isRestoreIncomplete,
     isCurtailmentComplete: displayFlags.isCurtailmentComplete,
   });
 
@@ -608,7 +636,11 @@ export default function ActiveCurtailmentStatus({
             <>
               <StatBlock label="Restore" value={formatRestoreProfile(event)} />
               <StatBlock label={restoreTimeLabel} value={restoreTimeValue} />
-              <StatBlock label={restoreCompletionLabel} value={restoreCompletionValue} />
+              {displayFlags.isRestoreIncomplete ? (
+                <StatBlock label="Failed to restore" value={restoreFailureValue} />
+              ) : (
+                <StatBlock label={restoreCompletionLabel} value={restoreCompletionValue} />
+              )}
             </>
           ) : (
             <>

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -629,7 +629,11 @@ export default function ActiveCurtailmentStatus({
     totalRestoreSeconds,
   });
   const restoreCompletionLabel = displayFlags.isRestored ? "Completed" : "Estimated completion";
-  const restoreCompletionValue = event.endedAt ? formatDateTime(event.endedAt) : estimatedCompletion;
+  const restoreCompletionValue = displayFlags.isRestored
+    ? formatDateTime(event.endedAt)
+    : event.endedAt
+      ? formatDateTime(event.endedAt)
+      : estimatedCompletion;
   const restoreFailureValue = formatMinerCount(compliance.restoreFailedCount);
   const restoreProgressPercent = displayFlags.isRestored ? 100 : restoredPercent;
   const curtailProgressPercent = displayFlags.isCurtailmentComplete ? 100 : curtailedPercent;

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -91,7 +91,14 @@ interface MinerCompliance {
   totalCount: number;
 }
 
-type ActiveCurtailmentDisplayState = "curtailing" | "curtailed" | "restoring" | "restored" | "restoreIncomplete";
+type ActiveCurtailmentDisplayState =
+  | "cancelled"
+  | "curtailing"
+  | "curtailed"
+  | "failed"
+  | "restoring"
+  | "restored"
+  | "restoreIncomplete";
 
 interface FormatActivePowerValueArgs {
   isRestored: boolean;
@@ -115,6 +122,7 @@ interface RestoreTimeValueArgs {
 
 interface StatusIconArgs {
   isCurtailmentComplete: boolean;
+  isTerminalFailure: boolean;
   isRestored: boolean;
   isRestoreIncomplete: boolean;
 }
@@ -125,6 +133,7 @@ interface ActiveCurtailmentDisplayFlags {
   isRestoreIncomplete: boolean;
   isRestoring: boolean;
   isRestoreFlow: boolean;
+  isTerminalFailure: boolean;
 }
 
 interface ActiveCurtailmentLegend {
@@ -157,8 +166,10 @@ const restoreFailedTargetStates: CurtailmentTargetState[] = ["restoreFailed"];
 const restoredTargetStates: CurtailmentTargetState[] = ["resolved", "released"];
 
 const displayStateLabels: Record<ActiveCurtailmentDisplayState, string> = {
+  cancelled: "Cancelled",
   curtailed: "Curtailed",
   curtailing: "Curtailing",
+  failed: "Failed",
   restoreIncomplete: "Restore incomplete",
   restored: "Restored",
   restoring: "Restoring",
@@ -235,8 +246,17 @@ function formatEstimatedCompletion(remainingSeconds: number, currentTime = new D
     return unavailableTimeLabel;
   }
 
-  const estimatedCompletionMs = currentTime.getTime() + Math.max(remainingSeconds, 0) * millisecondsPerSecond;
-  return formatDateTimeValue(new Date(estimatedCompletionMs));
+  const currentTimeMs = currentTime.getTime();
+  const estimatedCompletionMs = currentTimeMs + Math.max(remainingSeconds, 0) * millisecondsPerSecond;
+
+  if (!Number.isFinite(currentTimeMs) || !Number.isFinite(estimatedCompletionMs)) {
+    return unavailableTimeLabel;
+  }
+
+  const estimatedCompletionDate = new Date(estimatedCompletionMs);
+  return Number.isNaN(estimatedCompletionDate.getTime())
+    ? unavailableTimeLabel
+    : formatDateTimeValue(estimatedCompletionDate);
 }
 
 function getProgressPercent(value: number, total: number): number {
@@ -295,6 +315,14 @@ function getActiveCurtailmentDisplayState(
 
   if (isRestoredEventState(event.state)) {
     return "restored";
+  }
+
+  if (event.state === "cancelled") {
+    return "cancelled";
+  }
+
+  if (event.state === "failed") {
+    return "failed";
   }
 
   return powerShedPercent >= 100 || curtailedPercent >= 100 ? "curtailed" : "curtailing";
@@ -393,6 +421,7 @@ function getDisplayFlags(displayState: ActiveCurtailmentDisplayState): ActiveCur
   const isRestored = displayState === "restored";
   const isRestoreIncomplete = displayState === "restoreIncomplete";
   const isRestoring = displayState === "restoring";
+  const isTerminalFailure = displayState === "cancelled" || displayState === "failed";
 
   return {
     isCurtailmentComplete: displayState === "curtailed",
@@ -400,6 +429,7 @@ function getDisplayFlags(displayState: ActiveCurtailmentDisplayState): ActiveCur
     isRestoreIncomplete,
     isRestoring,
     isRestoreFlow: isRestoring || isRestored || isRestoreIncomplete,
+    isTerminalFailure,
   };
 }
 
@@ -422,6 +452,10 @@ function getProgressLegend(displayFlags: ActiveCurtailmentDisplayFlags): ActiveC
 }
 
 function shouldShowSecondaryProgress(displayFlags: ActiveCurtailmentDisplayFlags): boolean {
+  if (displayFlags.isTerminalFailure) {
+    return false;
+  }
+
   if (displayFlags.isRestoreFlow) {
     return !displayFlags.isRestored;
   }
@@ -458,6 +492,8 @@ function getActiveCurtailmentActionButton({
       return onDismissRestored ? (
         <Button variant={variants.secondary} size={sizes.compact} text="Dismiss" onClick={onDismissRestored} />
       ) : null;
+    case "cancelled":
+    case "failed":
     case "restoreIncomplete":
       return null;
     case "curtailed":
@@ -487,11 +523,12 @@ function ActiveCurtailmentActionButtons(props: ActiveCurtailmentActionButtonsPro
 }
 
 function getActiveCurtailmentStatusIcon({
+  isTerminalFailure,
   isRestored,
   isRestoreIncomplete,
   isCurtailmentComplete,
 }: StatusIconArgs): ReactNode {
-  if (isRestoreIncomplete) {
+  if (isRestoreIncomplete || isTerminalFailure) {
     return <Alert className="text-intent-critical-fill" />;
   }
 
@@ -569,7 +606,7 @@ export default function ActiveCurtailmentStatus({
   const remainingRestoreSeconds = getRestoreRemainingSeconds(event, compliance.restoredCount, compliance.totalCount);
   const estimatedCompletion = formatEstimatedCompletion(remainingRestoreSeconds);
   const totalRestoreSeconds = getRestoreEstimateSeconds({
-    selectedMinerCount: event.selectedMiners,
+    selectedMinerCount: compliance.totalCount,
     restoreBatchSize: event.restoreBatchSize,
     restoreBatchIntervalSec: event.restoreBatchIntervalSec,
   });
@@ -601,6 +638,7 @@ export default function ActiveCurtailmentStatus({
   const secondaryProgressPercent = Math.max(100 - activePhaseProgressPercent, 0);
   const showSecondaryProgress = shouldShowSecondaryProgress(displayFlags);
   const statusIcon = getActiveCurtailmentStatusIcon({
+    isTerminalFailure: displayFlags.isTerminalFailure,
     isRestored: displayFlags.isRestored,
     isRestoreIncomplete: displayFlags.isRestoreIncomplete,
     isCurtailmentComplete: displayFlags.isCurtailmentComplete,

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -1,0 +1,640 @@
+import { type ReactElement, type ReactNode } from "react";
+import clsx from "clsx";
+
+import type { CurtailmentEventState } from "@/protoFleet/features/energy/CurtailmentHistory";
+import { Success } from "@/shared/assets/icons";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import Header from "@/shared/components/Header";
+import ProgressCircular from "@/shared/components/ProgressCircular";
+
+export type CurtailmentTargetState =
+  | "pending"
+  | "dispatched"
+  | "confirmed"
+  | "drifted"
+  | "resolved"
+  | "released"
+  | "restoreFailed";
+
+export interface CurtailmentTargetRollup {
+  state: CurtailmentTargetState;
+  count: number;
+}
+
+export interface ActiveCurtailmentEvent {
+  reason: string;
+  state: CurtailmentEventState;
+  scopeLabel: string;
+  endedAt?: string;
+  selectedMiners: number;
+  estimatedReductionKw: number;
+  targetKw?: number;
+  observedReductionKw: number;
+  remainingPowerKw?: number;
+  restoreBatchSize: number;
+  restoreBatchIntervalSec: number;
+  rollups: CurtailmentTargetRollup[];
+}
+
+interface ActiveCurtailmentStatusProps {
+  event: ActiveCurtailmentEvent;
+  className?: string;
+  onDismissRestored?: () => void;
+  onRequestRestore?: () => void;
+  onRequestStop?: () => void;
+}
+
+interface ActiveCurtailmentActionButtonsProps {
+  displayState: ActiveCurtailmentDisplayState;
+  onDismissRestored?: () => void;
+  onRequestRestore?: () => void;
+  onRequestStop?: () => void;
+}
+
+interface ActiveCurtailmentProgressBarProps {
+  primaryClassName: string;
+  primaryProgressPercent: number;
+  secondaryClassName: string;
+  secondaryProgressPercent: number;
+  showSecondaryProgress: boolean;
+}
+
+interface DotProps {
+  className: string;
+}
+
+interface ProgressLegendItemProps {
+  dotClassName: string;
+  label: string;
+}
+
+interface ProgressSegmentProps {
+  className: string;
+  percent: number;
+}
+
+interface SectionHeaderProps {
+  title: string;
+  children?: ReactNode;
+}
+
+interface StatBlockProps {
+  label: string;
+  value: string;
+  detail?: string;
+}
+
+interface MinerCompliance {
+  curtailedCount: number;
+  restoredCount: number;
+  totalCount: number;
+}
+
+type ActiveCurtailmentDisplayState = "curtailing" | "curtailed" | "restoring" | "restored";
+
+interface FormatActivePowerValueArgs {
+  isRestored: boolean;
+  isRestoring: boolean;
+  observedReductionKw: number;
+  restoredKw: number;
+  targetKw: number;
+}
+
+interface RestoreEstimateArgs {
+  selectedMinerCount: number;
+  restoreBatchSize: number;
+  restoreBatchIntervalSec: number;
+}
+
+interface RestoreTimeValueArgs {
+  isRestored: boolean;
+  remainingRestoreSeconds: number;
+  totalRestoreSeconds: number;
+}
+
+interface StatusIconArgs {
+  isCurtailmentComplete: boolean;
+  isRestored: boolean;
+}
+
+interface ActiveCurtailmentDisplayFlags {
+  isCurtailmentComplete: boolean;
+  isRestored: boolean;
+  isRestoring: boolean;
+  isRestoreFlow: boolean;
+}
+
+interface ActiveCurtailmentLegend {
+  primaryDotClassName: string;
+  primaryLabel: string;
+  secondaryDotClassName: string;
+  secondaryLabel: string;
+}
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+const millisecondsPerSecond = 1000;
+const unavailableTimeLabel = "Time unavailable";
+
+const countedTargetStates: CurtailmentTargetState[] = [
+  "pending",
+  "dispatched",
+  "confirmed",
+  "drifted",
+  "resolved",
+  "released",
+  "restoreFailed",
+];
+const curtailedTargetStates: CurtailmentTargetState[] = ["confirmed", "resolved"];
+const restoredTargetStates: CurtailmentTargetState[] = ["resolved", "released"];
+
+const displayStateLabels: Record<ActiveCurtailmentDisplayState, string> = {
+  curtailed: "Curtailed",
+  curtailing: "Curtailing",
+  restored: "Restored",
+  restoring: "Restoring",
+};
+
+function Dot({ className }: DotProps): ReactElement {
+  return <span className={clsx("inline-block h-2 w-2 shrink-0 rounded-full", className)} />;
+}
+
+function SectionHeader({ title, children }: SectionHeaderProps): ReactElement {
+  return (
+    <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
+      <div className="min-w-0">
+        <Header title={title} titleSize="text-heading-200" />
+        {children ? <div className="mt-1 text-300 text-text-primary">{children}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+function StatBlock({ label, value, detail }: StatBlockProps): ReactElement {
+  return (
+    <div className="min-w-0">
+      <div className="text-200 text-text-primary-50">{label}</div>
+      <div className="mt-1 truncate text-emphasis-300 text-text-primary" title={value}>
+        {value}
+      </div>
+      {detail ? (
+        <div className="mt-1 truncate text-200 text-text-primary-70" title={detail}>
+          {detail}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function getTargetKw(event: Pick<ActiveCurtailmentEvent, "targetKw" | "estimatedReductionKw">): number {
+  return event.targetKw ?? event.estimatedReductionKw;
+}
+
+function formatKw(value: number, fractionDigits = 1): string {
+  const finiteValue = Number.isFinite(value) ? value : 0;
+
+  return `${finiteValue.toLocaleString(undefined, {
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits,
+  })} kW`;
+}
+
+function formatMinerCount(minerCount: number): string {
+  return `${minerCount.toLocaleString()} ${minerCount === 1 ? "miner" : "miners"}`;
+}
+
+function getDateTime(value?: string): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function formatDateTimeValue(date: Date): string {
+  return dateTimeFormatter.format(date);
+}
+
+function formatDateTime(value?: string): string {
+  const date = getDateTime(value);
+  return date ? formatDateTimeValue(date) : unavailableTimeLabel;
+}
+
+function formatEstimatedCompletion(remainingSeconds: number, currentTime = new Date()): string {
+  if (!Number.isFinite(remainingSeconds)) {
+    return unavailableTimeLabel;
+  }
+
+  const estimatedCompletionMs = currentTime.getTime() + Math.max(remainingSeconds, 0) * millisecondsPerSecond;
+  return formatDateTimeValue(new Date(estimatedCompletionMs));
+}
+
+function getProgressPercent(value: number, total: number): number {
+  if (!Number.isFinite(value) || !Number.isFinite(total) || total <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max((value / total) * 100, 0), 100);
+}
+
+function getRollupCount(event: ActiveCurtailmentEvent, states: CurtailmentTargetState[]): number {
+  return event.rollups.reduce((total, rollup) => {
+    if (!states.includes(rollup.state)) {
+      return total;
+    }
+
+    return total + rollup.count;
+  }, 0);
+}
+
+function getMinerCompliance(event: ActiveCurtailmentEvent): MinerCompliance {
+  const curtailedCount = getRollupCount(event, curtailedTargetStates);
+  const restoredCount = getRollupCount(event, restoredTargetStates);
+  const countedTargetCount = getRollupCount(event, countedTargetStates);
+  const totalCount = Math.max(event.selectedMiners, countedTargetCount);
+
+  return {
+    curtailedCount,
+    restoredCount,
+    totalCount,
+  };
+}
+
+function isRestoredEventState(state: CurtailmentEventState): boolean {
+  const isCompleted = state === "completed";
+  const isCompletedWithFailures = state === "completedWithFailures";
+  return isCompleted || isCompletedWithFailures;
+}
+
+function getActiveCurtailmentDisplayState(
+  event: ActiveCurtailmentEvent,
+  powerShedPercent: number,
+  curtailedPercent: number,
+): ActiveCurtailmentDisplayState {
+  if (event.state === "restoring") {
+    return "restoring";
+  }
+
+  if (isRestoredEventState(event.state)) {
+    return "restored";
+  }
+
+  return powerShedPercent >= 100 || curtailedPercent >= 100 ? "curtailed" : "curtailing";
+}
+
+function getRestoredPercent(event: ActiveCurtailmentEvent, restoredCount: number, totalCount: number): number {
+  if (isRestoredEventState(event.state)) {
+    return 100;
+  }
+
+  return getProgressPercent(restoredCount, totalCount);
+}
+
+function formatActivePowerValue({
+  isRestored,
+  isRestoring,
+  observedReductionKw,
+  restoredKw,
+  targetKw,
+}: FormatActivePowerValueArgs): string {
+  if (isRestored) {
+    return `${formatKw(targetKw)} restored`;
+  }
+
+  if (isRestoring) {
+    return `${formatKw(restoredKw)} of ${formatKw(targetKw)} restored`;
+  }
+
+  const cappedObservedReductionKw = Math.min(Math.max(observedReductionKw, 0), targetKw);
+  return `${formatKw(cappedObservedReductionKw)} of ${formatKw(targetKw)}`;
+}
+
+function formatDurationLong(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) {
+    return "Immediate";
+  }
+
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const parts: string[] = [];
+
+  if (minutes > 0) {
+    parts.push(`${minutes.toLocaleString()} ${minutes === 1 ? "minute" : "minutes"}`);
+  }
+
+  if (seconds > 0) {
+    parts.push(`${seconds.toLocaleString()} ${seconds === 1 ? "second" : "seconds"}`);
+  }
+
+  return parts.join(", ");
+}
+
+function getRestoreEstimateSeconds({
+  selectedMinerCount,
+  restoreBatchSize,
+  restoreBatchIntervalSec,
+}: RestoreEstimateArgs): number {
+  if (
+    !Number.isFinite(selectedMinerCount) ||
+    !Number.isFinite(restoreBatchSize) ||
+    !Number.isFinite(restoreBatchIntervalSec) ||
+    selectedMinerCount <= 0 ||
+    restoreBatchSize <= 0 ||
+    restoreBatchIntervalSec <= 0
+  ) {
+    return 0;
+  }
+
+  const batchCount = Math.ceil(selectedMinerCount / restoreBatchSize);
+  return Math.max(batchCount - 1, 0) * restoreBatchIntervalSec;
+}
+
+function getRestoreRemainingSeconds(event: ActiveCurtailmentEvent, restoredCount: number, totalCount: number): number {
+  const remainingMiners = Math.max(totalCount - restoredCount, 0);
+
+  return getRestoreEstimateSeconds({
+    selectedMinerCount: remainingMiners,
+    restoreBatchSize: event.restoreBatchSize,
+    restoreBatchIntervalSec: event.restoreBatchIntervalSec,
+  });
+}
+
+function formatRestoreTimeValue({
+  isRestored,
+  remainingRestoreSeconds,
+  totalRestoreSeconds,
+}: RestoreTimeValueArgs): string {
+  if (isRestored) {
+    return formatDurationLong(totalRestoreSeconds);
+  }
+
+  return formatDurationLong(remainingRestoreSeconds);
+}
+
+function getDisplayFlags(displayState: ActiveCurtailmentDisplayState): ActiveCurtailmentDisplayFlags {
+  const isRestored = displayState === "restored";
+  const isRestoring = displayState === "restoring";
+
+  return {
+    isCurtailmentComplete: displayState === "curtailed",
+    isRestored,
+    isRestoring,
+    isRestoreFlow: isRestoring || isRestored,
+  };
+}
+
+function getProgressLegend(displayFlags: ActiveCurtailmentDisplayFlags): ActiveCurtailmentLegend {
+  if (displayFlags.isRestoreFlow) {
+    return {
+      primaryDotClassName: "bg-intent-success-fill",
+      primaryLabel: "Restored",
+      secondaryDotClassName: "bg-core-primary-fill",
+      secondaryLabel: "Curtailed",
+    };
+  }
+
+  return {
+    primaryDotClassName: "bg-core-primary-fill",
+    primaryLabel: "Curtailed",
+    secondaryDotClassName: "bg-core-accent-fill",
+    secondaryLabel: "Curtailing",
+  };
+}
+
+function shouldShowSecondaryProgress(displayFlags: ActiveCurtailmentDisplayFlags): boolean {
+  if (displayFlags.isRestoreFlow) {
+    return !displayFlags.isRestored;
+  }
+
+  return !displayFlags.isCurtailmentComplete;
+}
+
+function formatRestoreProfile(
+  event: Pick<ActiveCurtailmentEvent, "restoreBatchSize" | "restoreBatchIntervalSec">,
+): string {
+  return `${formatMinerCount(event.restoreBatchSize)} every ${event.restoreBatchIntervalSec.toLocaleString()}s`;
+}
+
+function formatRemainingPower(remainingPowerKw?: number): string {
+  if (remainingPowerKw === undefined) {
+    return "Unavailable";
+  }
+
+  return `${formatKw(remainingPowerKw)} remaining`;
+}
+
+function formatActiveCurtailmentHeaderDetail(event: ActiveCurtailmentEvent): string {
+  return `${event.reason} (Applies to ${event.scopeLabel})`;
+}
+
+function getActiveCurtailmentActionButton({
+  displayState,
+  onDismissRestored,
+  onRequestRestore,
+  onRequestStop,
+}: ActiveCurtailmentActionButtonsProps): ReactElement | null {
+  switch (displayState) {
+    case "restored":
+      return onDismissRestored ? (
+        <Button variant={variants.secondary} size={sizes.compact} text="Dismiss" onClick={onDismissRestored} />
+      ) : null;
+    case "curtailed":
+      return onRequestRestore ? (
+        <Button variant={variants.primary} size={sizes.compact} text="Restore" onClick={onRequestRestore} />
+      ) : null;
+    case "curtailing":
+      return onRequestStop ? (
+        <Button variant={variants.danger} size={sizes.compact} text="Stop" onClick={onRequestStop} />
+      ) : null;
+    case "restoring":
+      return null;
+  }
+}
+
+function ActiveCurtailmentActionButtons(props: ActiveCurtailmentActionButtonsProps): ReactElement | null {
+  const actionButton = getActiveCurtailmentActionButton(props);
+  if (!actionButton) {
+    return null;
+  }
+
+  return (
+    <div className="mb-8 flex shrink-0 justify-end gap-3 tablet:absolute tablet:top-10 tablet:right-10 tablet:mb-0">
+      {actionButton}
+    </div>
+  );
+}
+
+function getActiveCurtailmentStatusIcon({ isRestored, isCurtailmentComplete }: StatusIconArgs): ReactNode {
+  if (isRestored) {
+    return <Success className="text-intent-success-fill" />;
+  }
+
+  if (isCurtailmentComplete) {
+    return <Success className="text-core-primary-fill" />;
+  }
+
+  return <ProgressCircular indeterminate className="text-core-primary-fill" />;
+}
+
+function ProgressSegment({ className, percent }: ProgressSegmentProps): ReactElement {
+  return (
+    <div
+      className={clsx("rounded-full transition-[flex-basis,width] duration-700 ease-out", className)}
+      style={{ flexBasis: `${percent}%` }}
+    />
+  );
+}
+
+function ActiveCurtailmentProgressBar({
+  primaryClassName,
+  primaryProgressPercent,
+  secondaryClassName,
+  secondaryProgressPercent,
+  showSecondaryProgress,
+}: ActiveCurtailmentProgressBarProps): ReactElement {
+  return (
+    <div
+      aria-label="Active curtailment progress"
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={Math.round(primaryProgressPercent)}
+      className="flex h-3 w-full gap-1 overflow-hidden rounded-full"
+      data-testid="active-curtailment-progress"
+      role="progressbar"
+    >
+      <ProgressSegment className={primaryClassName} percent={primaryProgressPercent} />
+      {showSecondaryProgress ? (
+        <ProgressSegment className={secondaryClassName} percent={secondaryProgressPercent} />
+      ) : null}
+    </div>
+  );
+}
+
+function ProgressLegendItem({ dotClassName, label }: ProgressLegendItemProps): ReactElement {
+  return (
+    <span className="flex items-center gap-2">
+      <Dot className={clsx("h-3 w-3", dotClassName)} />
+      {label}
+    </span>
+  );
+}
+
+export default function ActiveCurtailmentStatus({
+  event,
+  className,
+  onDismissRestored,
+  onRequestRestore,
+  onRequestStop,
+}: ActiveCurtailmentStatusProps): ReactElement {
+  const observedReductionKw = event.state === "pending" ? 0 : event.observedReductionKw;
+  const targetKw = getTargetKw(event);
+  const powerShedPercent = getProgressPercent(observedReductionKw, targetKw);
+  const compliance = getMinerCompliance(event);
+  const curtailedPercent = getProgressPercent(compliance.curtailedCount, compliance.totalCount);
+  const restoredPercent = getRestoredPercent(event, compliance.restoredCount, compliance.totalCount);
+  const displayState = getActiveCurtailmentDisplayState(event, powerShedPercent, curtailedPercent);
+  const displayFlags = getDisplayFlags(displayState);
+  const legend = getProgressLegend(displayFlags);
+  const restoredKw = displayFlags.isRestored ? targetKw : (targetKw * restoredPercent) / 100;
+  const remainingRestoreSeconds = getRestoreRemainingSeconds(event, compliance.restoredCount, compliance.totalCount);
+  const estimatedCompletion = formatEstimatedCompletion(remainingRestoreSeconds);
+  const totalRestoreSeconds = getRestoreEstimateSeconds({
+    selectedMinerCount: event.selectedMiners,
+    restoreBatchSize: event.restoreBatchSize,
+    restoreBatchIntervalSec: event.restoreBatchIntervalSec,
+  });
+  const powerLabel = displayFlags.isRestoreFlow ? "Power restore" : "Power shed";
+  const powerValue = formatActivePowerValue({
+    isRestored: displayFlags.isRestored,
+    isRestoring: displayFlags.isRestoring,
+    observedReductionKw,
+    restoredKw,
+    targetKw,
+  });
+  const dispatchStatus = displayStateLabels[displayState];
+  const minerStatus =
+    compliance.totalCount > 0 ? `${Math.round(curtailedPercent).toLocaleString()}% curtailed` : "No miners selected";
+  const restoreTimeLabel = displayFlags.isRestored ? "Time to restore" : "Estimated time to restore";
+  const restoreTimeValue = formatRestoreTimeValue({
+    isRestored: displayFlags.isRestored,
+    remainingRestoreSeconds,
+    totalRestoreSeconds,
+  });
+  const restoreCompletionLabel = displayFlags.isRestored ? "Completed" : "Estimated completion";
+  const restoreCompletionValue = event.endedAt ? formatDateTime(event.endedAt) : estimatedCompletion;
+  const restoreProgressPercent = displayFlags.isRestored ? 100 : restoredPercent;
+  const curtailProgressPercent = displayFlags.isCurtailmentComplete ? 100 : curtailedPercent;
+  const primaryProgressPercent = displayFlags.isRestoreFlow ? restoreProgressPercent : curtailProgressPercent;
+  const activePhaseProgressPercent = displayFlags.isRestoreFlow ? restoredPercent : curtailedPercent;
+  const secondaryProgressPercent = Math.max(100 - activePhaseProgressPercent, 0);
+  const showSecondaryProgress = shouldShowSecondaryProgress(displayFlags);
+  const statusIcon = getActiveCurtailmentStatusIcon({
+    isRestored: displayFlags.isRestored,
+    isCurtailmentComplete: displayFlags.isCurtailmentComplete,
+  });
+
+  return (
+    <section className={clsx("grid gap-3", className)}>
+      <SectionHeader title="Active curtailment">
+        <div className="max-w-xl">
+          <div className="text-emphasis-300">{formatActiveCurtailmentHeaderDetail(event)}</div>
+        </div>
+      </SectionHeader>
+
+      <div className="relative rounded-xl bg-surface-elevated-base p-6 shadow-100 tablet:p-10">
+        <ActiveCurtailmentActionButtons
+          displayState={displayState}
+          onDismissRestored={onDismissRestored}
+          onRequestRestore={onRequestRestore}
+          onRequestStop={onRequestStop}
+        />
+
+        <div className="grid gap-3 tablet:pr-32">
+          <div className="flex size-10 items-center justify-center rounded-lg bg-core-primary-5">{statusIcon}</div>
+          <div>
+            <div className="text-heading-50 text-text-primary-70">{powerLabel}</div>
+            <div className="text-heading-300 text-text-primary">{powerValue}</div>
+          </div>
+        </div>
+
+        <div className="mt-12 grid gap-x-12 gap-y-5 text-text-primary tablet:grid-cols-4">
+          <StatBlock label="Dispatch status" value={dispatchStatus} />
+          {displayFlags.isRestoreFlow ? (
+            <>
+              <StatBlock label="Restore" value={formatRestoreProfile(event)} />
+              <StatBlock label={restoreTimeLabel} value={restoreTimeValue} />
+              <StatBlock label={restoreCompletionLabel} value={restoreCompletionValue} />
+            </>
+          ) : (
+            <>
+              <StatBlock label="Applies to" value={formatMinerCount(event.selectedMiners)} />
+              <StatBlock label="Miner status" value={minerStatus} />
+              <StatBlock label="Current load" value={formatRemainingPower(event.remainingPowerKw)} />
+            </>
+          )}
+        </div>
+
+        <div className="mt-8 grid gap-3">
+          <ActiveCurtailmentProgressBar
+            primaryClassName={legend.primaryDotClassName}
+            primaryProgressPercent={primaryProgressPercent}
+            secondaryClassName={legend.secondaryDotClassName}
+            secondaryProgressPercent={secondaryProgressPercent}
+            showSecondaryProgress={showSecondaryProgress}
+          />
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-200 text-text-primary-70">
+            <ProgressLegendItem dotClassName={legend.primaryDotClassName} label={legend.primaryLabel} />
+            {showSecondaryProgress ? (
+              <ProgressLegendItem dotClassName={legend.secondaryDotClassName} label={legend.secondaryLabel} />
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -402,8 +402,13 @@ function getRestoreEstimateSeconds({
   return Math.max(batchCount - 1, 0) * restoreBatchIntervalSec;
 }
 
-function getRestoreRemainingSeconds(event: ActiveCurtailmentEvent, restoredCount: number, totalCount: number): number {
-  const remainingMiners = Math.max(totalCount - restoredCount, 0);
+function getRestoreRemainingSeconds(
+  event: ActiveCurtailmentEvent,
+  restoredCount: number,
+  restoreFailedCount: number,
+  totalCount: number,
+): number {
+  const remainingMiners = Math.max(totalCount - restoredCount - restoreFailedCount, 0);
 
   return getRestoreEstimateSeconds({
     selectedMinerCount: remainingMiners,
@@ -613,7 +618,12 @@ export default function ActiveCurtailmentStatus({
   const displayFlags = getDisplayFlags(displayState);
   const legend = getProgressLegend(displayFlags);
   const restoredKw = displayFlags.isRestored ? targetKw : (targetKw * restoredPercent) / 100;
-  const remainingRestoreSeconds = getRestoreRemainingSeconds(event, compliance.restoredCount, compliance.totalCount);
+  const remainingRestoreSeconds = getRestoreRemainingSeconds(
+    event,
+    compliance.restoredCount,
+    compliance.restoreFailedCount,
+    compliance.totalCount,
+  );
   const estimatedCompletion = formatEstimatedCompletion(remainingRestoreSeconds);
   const totalRestoreSeconds = getRestoreEstimateSeconds({
     selectedMinerCount: compliance.totalCount,


### PR DESCRIPTION
## Summary
- Add a reusable ActiveCurtailmentStatus component for active, curtailed, restoring, and restored energy curtailment states
- Add fixtures, Storybook stories, and focused tests for the curtailment lifecycle

## Test plan
- [ ] Open the Active Curtailment Status Storybook stories and verify each lifecycle state renders correctly
- [ ] Confirm the component actions fire for Stop, Restore, and Dismiss where available
- [ ] Run the focused ActiveCurtailmentStatus Vitest test


https://github.com/user-attachments/assets/743ba610-b38a-476f-bcfe-aa269bcabf0e



Closes #281