### PR TITLE
Multi-site: rack list building filter + re-enable /buildings/:id View racks (#274)

### DIFF
--- a/client/src/protoFleet/api/useDeviceSets.ts
+++ b/client/src/protoFleet/api/useDeviceSets.ts
@@ -56,6 +56,7 @@ interface ListDeviceSetsProps {
   sort?: SortConfig;
   errorComponentTypes?: number[];
   zones?: string[];
+  buildingIds?: bigint[];
   onSuccess?: (deviceSets: DeviceSet[], nextPageToken: string, totalCount: number) => void;
   onError?: (message: string) => void;
   onFinally?: () => void;
@@ -348,6 +349,7 @@ const useDeviceSets = () => {
       sort,
       errorComponentTypes,
       zones,
+      buildingIds,
       onSuccess,
       onError,
       onFinally,
@@ -361,6 +363,7 @@ const useDeviceSets = () => {
             sort,
             errorComponentTypes: errorComponentTypes ?? [],
             zones: zones ?? [],
+            buildingIds: buildingIds ?? [],
           });
           onSuccess?.(response.deviceSets, response.nextPageToken, response.totalCount);
         } else {
@@ -375,6 +378,7 @@ const useDeviceSets = () => {
               pageToken: nextToken,
               sort,
               zones: zones ?? [],
+              buildingIds: buildingIds ?? [],
             });
             all.push(...response.deviceSets);
             nextToken = response.nextPageToken;

--- a/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
@@ -7,24 +7,17 @@ interface BuildingPageHeaderProps {
   buildingId: string;
 }
 
-// "View miners" links to /miners with the building URL filter — matches the
-// URL key parsed by filterUrlParams.ts (mirroring the existing `group` and
-// `rack` singular keys). "View racks" is disabled because the racks page
-// filter ships in #274; until then we render the affordance with an
-// explanatory title so reviewers see the planned destination.
+// "View miners" and "View racks" link to their respective lists with the
+// `building` URL filter — the singular key parsed by filterUrlParams.ts
+// (mirroring the existing `group` and `rack` singular keys). RacksPage
+// parses the same param to pre-select its building filter chip.
 const BuildingPageHeader = ({ label, buildingId }: BuildingPageHeaderProps) => (
   <div className="flex items-start justify-between gap-4">
     <h1 className="text-heading-500 text-text-primary">{label}</h1>
     <div className="flex items-center gap-2">
-      <span title="Rack list building filter is in development — see #274">
-        <Button
-          variant={variants.secondary}
-          text="View racks"
-          onClick={() => undefined}
-          disabled
-          testId="building-page-view-racks"
-        />
-      </span>
+      <Link to={`/racks?building=${buildingId}`} data-testid="building-page-view-racks">
+        <Button variant={variants.secondary} text="View racks" onClick={() => undefined} />
+      </Link>
       <Link to={`/miners?building=${buildingId}`} data-testid="building-page-view-miners">
         <Button variant={variants.secondary} text="View miners" onClick={() => undefined} />
       </Link>

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -870,6 +870,13 @@ const MinerList = ({
         });
       }
 
+      const buildingFilters = filters.dropdownFilters.building;
+      if (buildingFilters && buildingFilters.length > 0) {
+        buildingFilters.forEach((id) => {
+          minerFilter.buildingIds.push(BigInt(id));
+        });
+      }
+
       const firmwareFilters = filters.dropdownFilters.firmware;
       if (firmwareFilters && firmwareFilters.length > 0) {
         minerFilter.firmwareVersions.push(...firmwareFilters);

--- a/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
@@ -27,6 +27,7 @@ const FILTER_AND_SORT_KEYS: ReadonlySet<string> = new Set([
   "model",
   "group",
   "rack",
+  "building",
   "firmware",
   "zone",
   "subnet",

--- a/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
@@ -17,6 +17,10 @@ import {
 } from "@/protoFleet/features/rackManagement/components/AssignMinersModal";
 import { RackCard } from "@/protoFleet/features/rackManagement/components/RackCard";
 import RackSettingsModal from "@/protoFleet/features/rackManagement/components/RackSettingsModal";
+import {
+  BUILDING_URL_PARAM,
+  parseBuildingIdsFromParams,
+} from "@/protoFleet/features/rackManagement/utils/buildingFilterUrl";
 import { mapRackToCardProps } from "@/protoFleet/features/rackManagement/utils/rackCardMapper";
 import { useDeviceSetListState } from "@/protoFleet/hooks/useDeviceSetListState";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -43,29 +47,6 @@ const RACK_COLUMNS: DeviceSetColumn[] = [
   "temperature",
   "health",
 ];
-
-const BUILDING_URL_PARAM = "building";
-
-// Reads the `building=…` URL params and returns only the valid bigint
-// values. Deep-linking from `/buildings/:id` seeds initial state and stays
-// the source of truth for the building filter so back/forward navigation
-// keeps the chip and list in sync. Accepts both repeated-key
-// (`?building=1&building=2`) and legacy comma-joined (`?building=1,2`)
-// forms to mirror filterUrlParams.ts on the miner list.
-function parseBuildingIdsFromParams(params: URLSearchParams): bigint[] {
-  return params
-    .getAll(BUILDING_URL_PARAM)
-    .flatMap((raw) => raw.split(","))
-    .flatMap((raw) => {
-      const trimmed = raw.trim();
-      if (!trimmed || !/^\d+$/.test(trimmed)) return [];
-      try {
-        return [BigInt(trimmed)];
-      } catch {
-        return [];
-      }
-    });
-}
 
 const RacksPage = () => {
   const navigate = useNavigate();
@@ -233,13 +214,22 @@ const RacksPage = () => {
     selectedBuildingIdStrings.length > 0 || selectedZones.length > 0 || selectedIssues.length > 0;
 
   const handleClearFilters = useCallback(() => {
+    // Snapshot before any state changes — drives whether the URL-change
+    // effect will refetch for us.
+    const hadBuildingFilter = selectedBuildingIdStrings.length > 0;
     setSelectedZones([]);
     selectedZonesRef.current = [];
     setSelectedIssues([]);
     selectedIssuesRef.current = [];
     setBuildingFilter([]);
-    resetAndFetch();
-  }, [resetAndFetch, selectedIssuesRef, selectedZonesRef, setBuildingFilter]);
+    // When the building filter was active, clearing the URL fires the
+    // `prevBuildingKey` effect which calls resetAndFetch with the cleared
+    // ref. Calling it here too would double-fetch (the first call would
+    // read stale building ids from the ref before the URL change settles).
+    if (!hadBuildingFilter) {
+      resetAndFetch();
+    }
+  }, [resetAndFetch, selectedBuildingIdStrings, selectedIssuesRef, selectedZonesRef, setBuildingFilter]);
 
   const emptyStateRow: ReactNode = useMemo(() => {
     if (isLoading || totalCount > 0) return undefined;
@@ -345,7 +335,12 @@ const RacksPage = () => {
     );
   }
 
-  const hasRacks = hasEverLoaded || totalCount > 0 || racks.length > 0;
+  // `hasActiveFilters` short-circuits the null state when the user is
+  // filtering. `hasEverLoaded` only flips when an unfiltered fetch returns
+  // a non-empty page (useDeviceSetListState), so deep-linking to a building
+  // that has no racks would otherwise render "You haven't set up any racks"
+  // instead of the filtered-empty state with the chip showing.
+  const hasRacks = hasEverLoaded || totalCount > 0 || racks.length > 0 || hasActiveFilters;
 
   if (!hasRacks) {
     return (

--- a/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/rackManagement/pages/RacksPage.tsx
@@ -1,5 +1,8 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
+import { useBuildings } from "@/protoFleet/api/buildings";
+import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import type { DeviceSetListItem } from "@/protoFleet/components/DeviceSetList";
 import type { DeviceSetColumn } from "@/protoFleet/components/DeviceSetList";
@@ -41,13 +44,47 @@ const RACK_COLUMNS: DeviceSetColumn[] = [
   "health",
 ];
 
+const BUILDING_URL_PARAM = "building";
+
+// Reads the `building=…` URL params and returns only the valid bigint
+// values. Deep-linking from `/buildings/:id` seeds initial state and stays
+// the source of truth for the building filter so back/forward navigation
+// keeps the chip and list in sync. Accepts both repeated-key
+// (`?building=1&building=2`) and legacy comma-joined (`?building=1,2`)
+// forms to mirror filterUrlParams.ts on the miner list.
+function parseBuildingIdsFromParams(params: URLSearchParams): bigint[] {
+  return params
+    .getAll(BUILDING_URL_PARAM)
+    .flatMap((raw) => raw.split(","))
+    .flatMap((raw) => {
+      const trimmed = raw.trim();
+      if (!trimmed || !/^\d+$/.test(trimmed)) return [];
+      try {
+        return [BigInt(trimmed)];
+      } catch {
+        return [];
+      }
+    });
+}
+
 const RacksPage = () => {
   const navigate = useNavigate();
   const { listRacks, listRackZones, deleteGroup } = useDeviceSets();
+  const { listAllBuildings } = useBuildings();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [showRackSettingsModal, setShowRackSettingsModal] = useState(false);
   const [selectedZones, setSelectedZones] = useState<string[]>([]);
   const [selectedIssues, setSelectedIssues] = useState<string[]>([]);
   const [allZones, setAllZones] = useState<{ id: string; label: string }[]>([]);
+  const [allBuildings, setAllBuildings] = useState<{ id: string; label: string }[]>([]);
+
+  const selectedBuildingIds = useMemo(() => parseBuildingIdsFromParams(searchParams), [searchParams]);
+  const selectedBuildingIdStrings = useMemo(() => selectedBuildingIds.map(String), [selectedBuildingIds]);
+  const selectedBuildingIdsRef = useRef<bigint[]>(selectedBuildingIds);
+  useEffect(() => {
+    selectedBuildingIdsRef.current = selectedBuildingIds;
+  }, [selectedBuildingIds]);
+  const getBuildingIds = useCallback(() => selectedBuildingIdsRef.current, []);
 
   // AssignMinersModal state
   const [assignMinersFormData, setAssignMinersFormData] = useState<RackFormData | null>(null);
@@ -74,7 +111,7 @@ const RacksPage = () => {
     handlePrevPage,
     resetAndFetch,
     refreshCurrentPage,
-  } = useDeviceSetListState(listRacks, DEFAULT_PAGE_SIZE, getErrorComponentTypes, getZones);
+  } = useDeviceSetListState(listRacks, DEFAULT_PAGE_SIZE, getErrorComponentTypes, getZones, getBuildingIds);
 
   const racksViewMode = useFleetStore((s) => s.ui.racksViewMode);
   const setRacksViewMode = useFleetStore((s) => s.ui.setRacksViewMode);
@@ -96,6 +133,54 @@ const RacksPage = () => {
     fetchZones();
   }, [fetchZones]);
 
+  // Fetch all buildings once for the building filter dropdown. The list
+  // is small (org-scoped) and stable enough that a single load on mount
+  // is fine; the rack list re-renders independently when filters change.
+  useEffect(() => {
+    const controller = new AbortController();
+    void listAllBuildings({
+      signal: controller.signal,
+      onSuccess: (buildings: BuildingWithCounts[]) => {
+        setAllBuildings(
+          buildings
+            .filter((b) => b.building !== undefined)
+            .map((b) => ({ id: b.building!.id.toString(), label: b.building!.name })),
+        );
+      },
+    });
+    return () => controller.abort();
+  }, [listAllBuildings]);
+
+  const setBuildingFilter = useCallback(
+    (ids: string[]) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete(BUILDING_URL_PARAM);
+          ids.forEach((id) => {
+            const trimmed = id.trim();
+            if (trimmed && /^\d+$/.test(trimmed)) next.append(BUILDING_URL_PARAM, trimmed);
+          });
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  // Refetch when the URL-driven building filter changes. The ref is read
+  // by useDeviceSetListState's fetchPage so this effect just kicks the
+  // pagination reset; the filter value itself flows through the ref.
+  const prevBuildingKey = useRef<string | null>(null);
+  useEffect(() => {
+    const key = selectedBuildingIdStrings.join(",");
+    if (prevBuildingKey.current !== null && prevBuildingKey.current !== key) {
+      resetAndFetch();
+    }
+    prevBuildingKey.current = key;
+  }, [selectedBuildingIdStrings, resetAndFetch]);
+
   const handleFilterChange = useCallback(
     (key: string, values: string[]) => {
       if (key === "zone") {
@@ -108,13 +193,24 @@ const RacksPage = () => {
         setSelectedIssues(values);
         selectedIssuesRef.current = values;
         resetAndFetch();
+        return;
+      }
+      if (key === "building") {
+        setBuildingFilter(values);
       }
     },
-    [resetAndFetch, selectedIssuesRef, selectedZonesRef],
+    [resetAndFetch, selectedIssuesRef, selectedZonesRef, setBuildingFilter],
   );
 
   const filterChipsBarFilters = useMemo(
     () => [
+      {
+        key: "building",
+        title: "Building",
+        pluralTitle: "buildings",
+        options: allBuildings,
+        selectedValues: selectedBuildingIdStrings,
+      },
       {
         key: "zone",
         title: "Zone",
@@ -130,18 +226,20 @@ const RacksPage = () => {
         selectedValues: selectedIssues,
       },
     ],
-    [allZones, selectedZones, selectedIssues],
+    [allBuildings, selectedBuildingIdStrings, allZones, selectedZones, selectedIssues],
   );
 
-  const hasActiveFilters = selectedZones.length > 0 || selectedIssues.length > 0;
+  const hasActiveFilters =
+    selectedBuildingIdStrings.length > 0 || selectedZones.length > 0 || selectedIssues.length > 0;
 
   const handleClearFilters = useCallback(() => {
     setSelectedZones([]);
     selectedZonesRef.current = [];
     setSelectedIssues([]);
     selectedIssuesRef.current = [];
+    setBuildingFilter([]);
     resetAndFetch();
-  }, [resetAndFetch, selectedIssuesRef, selectedZonesRef]);
+  }, [resetAndFetch, selectedIssuesRef, selectedZonesRef, setBuildingFilter]);
 
   const emptyStateRow: ReactNode = useMemo(() => {
     if (isLoading || totalCount > 0) return undefined;

--- a/client/src/protoFleet/features/rackManagement/utils/buildingFilterUrl.test.ts
+++ b/client/src/protoFleet/features/rackManagement/utils/buildingFilterUrl.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { BUILDING_URL_PARAM, parseBuildingIdsFromParams } from "./buildingFilterUrl";
+
+describe("parseBuildingIdsFromParams", () => {
+  it("returns empty array when no building param present", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams(""))).toEqual([]);
+    expect(parseBuildingIdsFromParams(new URLSearchParams("zone=Room+2"))).toEqual([]);
+  });
+
+  it("parses a single numeric id", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=10"))).toEqual([10n]);
+  });
+
+  it("parses repeated keys (`?building=1&building=2`)", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=1&building=2"))).toEqual([1n, 2n]);
+  });
+
+  it("parses legacy comma-joined values (`?building=1,2`)", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=1,2"))).toEqual([1n, 2n]);
+  });
+
+  it("mixes repeated keys and comma-joined values", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=1,2&building=3"))).toEqual([1n, 2n, 3n]);
+  });
+
+  it("trims whitespace within comma-joined values", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=1%2C+2"))).toEqual([1n, 2n]);
+  });
+
+  it("skips empty entries", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=&building=5"))).toEqual([5n]);
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=,,7"))).toEqual([7n]);
+  });
+
+  it("rejects non-numeric values", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=foo"))).toEqual([]);
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=10abc"))).toEqual([]);
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=-3"))).toEqual([]);
+  });
+
+  it("rejects floating-point and signed values", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=1.5"))).toEqual([]);
+    // URLSearchParams decodes `+` as space, so `?building=+4` parses to "4".
+    // Test the literal sign case using percent-encoding (`%2B4` → `+4`).
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=%2B4"))).toEqual([]);
+  });
+
+  it("keeps valid entries when other entries are invalid", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=foo,42,bar"))).toEqual([42n]);
+  });
+
+  it("preserves order across repeated entries", () => {
+    expect(parseBuildingIdsFromParams(new URLSearchParams("building=3&building=1&building=2"))).toEqual([3n, 1n, 2n]);
+  });
+
+  it("handles very large ids (beyond Number.MAX_SAFE_INTEGER)", () => {
+    const big = "9007199254740993"; // 2^53 + 1
+    expect(parseBuildingIdsFromParams(new URLSearchParams(`building=${big}`))).toEqual([BigInt(big)]);
+  });
+
+  it("exports the URL param name so callers stay in sync", () => {
+    expect(BUILDING_URL_PARAM).toBe("building");
+  });
+});

--- a/client/src/protoFleet/features/rackManagement/utils/buildingFilterUrl.ts
+++ b/client/src/protoFleet/features/rackManagement/utils/buildingFilterUrl.ts
@@ -1,0 +1,31 @@
+/**
+ * URL contract for the rack-list building filter.
+ *
+ * Mirrors the singular `building` key shipped by the miner-list
+ * filterUrlParams.ts (and the link emitted by BuildingPageHeader). Kept
+ * here so RacksPage state and any future deep-link callers reuse one
+ * parser and one URL key.
+ */
+export const BUILDING_URL_PARAM = "building";
+
+/**
+ * Read `building=<id>` (or `building=<id1>,<id2>`) from URLSearchParams and
+ * return only the well-formed bigint values. Accepts both repeated-key
+ * (`?building=1&building=2`) and legacy comma-joined (`?building=1,2`)
+ * forms to mirror the `getMultiLegacy` parsing used by the miner-list
+ * filterUrlParams.ts; old bookmarks keep working.
+ */
+export function parseBuildingIdsFromParams(params: URLSearchParams): bigint[] {
+  return params
+    .getAll(BUILDING_URL_PARAM)
+    .flatMap((raw) => raw.split(","))
+    .flatMap((raw) => {
+      const trimmed = raw.trim();
+      if (!trimmed || !/^\d+$/.test(trimmed)) return [];
+      try {
+        return [BigInt(trimmed)];
+      } catch {
+        return [];
+      }
+    });
+}

--- a/client/src/protoFleet/hooks/useDeviceSetListState.ts
+++ b/client/src/protoFleet/hooks/useDeviceSetListState.ts
@@ -43,6 +43,7 @@ export function useDeviceSetListState(
   pageSize: number,
   getErrorComponentTypes?: () => number[],
   getZones?: () => string[],
+  getBuildingIds?: () => bigint[],
 ) {
   const { getDeviceSetStats } = useDeviceSets();
   const [deviceSets, setDeviceSets] = useState<DeviceSet[]>([]);
@@ -99,6 +100,7 @@ export function useDeviceSetListState(
         sort: sortRef.current,
         errorComponentTypes: getErrorComponentTypes?.() ?? [],
         zones: getZones?.() ?? [],
+        buildingIds: getBuildingIds?.() ?? [],
         onSuccess: (items, nextPageToken, total) => {
           if (requestId !== listRequestId.current) return;
           if (total > 0) setHasEverLoaded(true);
@@ -126,7 +128,7 @@ export function useDeviceSetListState(
         },
       });
     },
-    [listFn, pageSize, fetchStats, getErrorComponentTypes, getZones],
+    [listFn, pageSize, fetchStats, getErrorComponentTypes, getZones, getBuildingIds],
   );
 
   const resetAndFetch = useCallback(() => {

--- a/server/go.mod
+++ b/server/go.mod
@@ -31,8 +31,12 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.54.0
@@ -56,7 +60,7 @@ require (
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
 	github.com/docker/docker v28.5.2+incompatible // indirect
-	github.com/docker/go-connections v0.6.0 // indirect
+	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -79,12 +83,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
 	golang.org/x/mod v0.36.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -62,8 +62,7 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
-github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
+github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary

Wires the `?building=<id>` URL contract through the rack list and re-enables the **View racks** affordance on `/buildings/:id` (was disabled in #269 pending this work). Backend `building_ids` / `include_no_building` filter on `ListDeviceSetsRequest` already shipped in #229 / #198; this PR is the FE side.

Closes #274.

## Changes

- **`RacksPage.tsx`** — parses `?building=<id>` from URL (accepts repeated-key + legacy comma-joined forms, matches `filterUrlParams.ts`), loads all buildings via `listAllBuildings`, registers a **Building** filter in `FilterChipsBar` with the building name. URL is the source of truth — back/forward navigation and chip removal stay in sync.
- **`useDeviceSets.ts` / `useDeviceSetListState.ts`** — thread `buildingIds` through `listRacks` → `ListDeviceSets`.
- **`BuildingPageHeader.tsx`** — replaces the disabled `View racks` button + tooltip with `<Link to="/racks?building=…">`. Mirrors the existing `View miners` URL contract.
- **`MinerList.handleServerFilter`** (drive-by, fixes regression surfaced by this PR's deep-link) — also translates `dropdownFilters.building` → `MinerListFilter.buildingIds`. Without this, the building filter was silently dropped on mount and the URL was rewritten without `?building=`. `savedViews.FILTER_AND_SORT_KEYS` now includes `"building"` so building-scoped URLs canonicalize as filtered state (instead of "All miners").

## Deferred

- **Miner list building chip — name resolution.** The miner list now honors `?building=<id>` end-to-end, but the FilterChipsBar dropdown sources don't include a `Building` entry, so the chip renders the raw id (`10`) rather than the building name (`Bldg-A-23924`) and there's no UI affordance to clear it. Punted to #202 (Phase 1b miner/rack list active-site consumption) since the fix needs `listAllBuildings` plumbed into `Fleet.tsx` + a new `DropdownFilterItem` in `MinerList.tsx` — naturally overlaps with the site-picker consumption work tracked there. Tracking comment: https://github.com/block/proto-fleet/issues/202#issuecomment-4510173529

## Test plan

- [ ] On `/buildings/:id`, click **View racks** — lands on `/racks?building=<id>`.
- [ ] Building chip on `/racks` renders the building name, removable like other filters; clearing the chip strips `?building=` from the URL.
- [ ] Back/forward navigation keeps the chip and list in sync with the URL.
- [ ] On `/buildings/:id`, click **View miners** — lands on `/miners?building=<id>` and the URL stays intact (no on-mount strip).
- [ ] `just lint`, `tsc --noEmit`, `vitest run` (full client suite), Go tests for `internal/handlers/deviceset` + `internal/domain/collection` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)