### PR TITLE
fix(ui): ensure unauthenticated miners can be selected and unpaired

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
@@ -3,6 +3,10 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, test, vi } from "vitest";
 import { deviceActions, groupActions, performanceActions, settingsActions } from "./constants";
 import MinerActionsMenu from "./MinerActionsMenu";
+import {
+  type MinerStateSnapshot,
+  PairingStatus,
+} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
 // Use vi.hoisted to properly hoist mock variable declarations
 const {
@@ -483,6 +487,57 @@ describe("MinerActionsMenu", () => {
     expect(actions[2].showGroupDivider).toBe(true);
     expect(actions[3].showGroupDivider).toBeUndefined();
     expect(actions[4].showGroupDivider).toBe(true);
+  });
+
+  test("limits bulk actions to unpair when selection includes an authentication-needed miner", () => {
+    mockUseMinerActions.mockReturnValueOnce({
+      ...createMockMinerActionsReturn(null),
+      popoverActions: [
+        {
+          action: deviceActions.reboot,
+          title: "Reboot",
+          icon: null,
+          actionHandler: vi.fn(),
+          requiresConfirmation: true,
+        },
+        {
+          action: deviceActions.unpair,
+          title: "Unpair",
+          icon: null,
+          actionHandler: vi.fn(),
+          requiresConfirmation: true,
+        },
+        {
+          action: settingsActions.miningPool,
+          title: "Edit pool",
+          icon: null,
+          actionHandler: vi.fn(),
+          requiresConfirmation: false,
+        },
+      ],
+    });
+
+    render(
+      <MinerActionsMenu
+        selectedMiners={["miner-1", "miner-2"]}
+        selectionMode="subset"
+        totalCount={2}
+        miners={{
+          "miner-1": { pairingStatus: PairingStatus.AUTHENTICATION_NEEDED } as MinerStateSnapshot,
+          "miner-2": { pairingStatus: PairingStatus.PAIRED } as MinerStateSnapshot,
+        }}
+      />,
+    );
+
+    const widgetCalls = mockBulkActionsWidget.mock.calls as unknown as Array<[{ actions: Array<{ action: string }> }]>;
+    const widgetCall = widgetCalls[0];
+    expect(widgetCall).toBeDefined();
+
+    if (widgetCall === undefined) {
+      throw new Error("BulkActionsWidget was not called with props");
+    }
+
+    expect(widgetCall[0].actions.map((action) => action.action)).toEqual([deviceActions.unpair]);
   });
 
   test("requests credentials before opening update worker names modal", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -13,9 +13,10 @@ import ManagePowerModal from "./ManagePowerModal";
 import { ManageSecurityModal, UpdateMinerPasswordModal } from "./ManageSecurity";
 import { useMinerActions } from "./useMinerActions";
 import type { SortConfig } from "@/protoFleet/api/generated/common/v1/sort_pb";
-import type {
-  MinerListFilter,
-  MinerStateSnapshot,
+import {
+  type MinerListFilter,
+  type MinerStateSnapshot,
+  PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import AuthenticateFleetModal from "@/protoFleet/features/auth/components/AuthenticateFleetModal";
 import { useBatchActions } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
@@ -39,6 +40,8 @@ interface MinerActionsMenuProps {
   miners?: Record<string, MinerStateSnapshot>;
   /** Ordered list of miner device identifiers, forwarded to bulk rename modals. */
   minerIds?: string[];
+  /** True when the selection includes auth-needed miners not present in selectedMiners, e.g. all-mode selections. */
+  selectionIncludesUnauthenticatedMiner?: boolean;
   /** Callback to refetch miners after bulk rename or worker-name update. */
   onRefetchMiners?: () => void;
   onWorkerNameUpdated?: (deviceIdentifier: string, workerName: string) => void;
@@ -61,6 +64,7 @@ const MinerActionsMenu = ({
   currentSort,
   miners = {},
   minerIds = [],
+  selectionIncludesUnauthenticatedMiner: selectionIncludesUnauthenticatedMinerOverride,
   onRefetchMiners,
   onWorkerNameUpdated,
   onActionStart,
@@ -74,9 +78,19 @@ const MinerActionsMenu = ({
   const workerNameCredentialsRef = useRef<{ username: string; password: string } | undefined>(undefined);
   const { isPhone, isTablet } = useWindowDimensions();
   const selectedMinersWithStatus = useMemo(
-    () => selectedMiners.map((id) => ({ deviceIdentifier: id })),
-    [selectedMiners],
+    () =>
+      selectedMiners.map((id) => ({
+        deviceIdentifier: id,
+        deviceStatus: miners[id]?.deviceStatus,
+      })),
+    [miners, selectedMiners],
   );
+  const selectedIdsIncludeUnauthenticatedMiner = useMemo(
+    () => selectedMiners.some((id) => miners[id]?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED),
+    [miners, selectedMiners],
+  );
+  const selectionIncludesUnauthenticatedMiner =
+    selectionIncludesUnauthenticatedMinerOverride ?? selectedIdsIncludeUnauthenticatedMiner;
 
   const {
     currentAction,
@@ -200,6 +214,14 @@ const MinerActionsMenu = ({
     return [...actions, renameAction];
   }, [handleBulkWorkerNamesOpen, onActionStart, popoverActions]);
 
+  const visibleActions = useMemo(
+    () =>
+      selectionIncludesUnauthenticatedMiner
+        ? actionsWithBulkRename.filter((action) => action.action === deviceActions.unpair)
+        : actionsWithBulkRename,
+    [actionsWithBulkRename, selectionIncludesUnauthenticatedMiner],
+  );
+
   const poolMiners = useMemo(() => {
     if (poolFilteredDeviceIds) {
       return poolFilteredDeviceIds.map((id) => ({ deviceIdentifier: id }));
@@ -214,13 +236,13 @@ const MinerActionsMenu = ({
       deviceActions.reboot,
       performanceActions.managePower,
     ];
-    const actionMap = new Map(actionsWithBulkRename.map((action) => [action.action, action]));
+    const actionMap = new Map(visibleActions.map((action) => [action.action, action]));
 
     return quickActionOrder.flatMap((actionKey) => {
       const action = actionMap.get(actionKey);
       return action ? [action] : [];
     });
-  }, [actionsWithBulkRename]);
+  }, [visibleActions]);
 
   return (
     <PopoverProvider>
@@ -228,7 +250,7 @@ const MinerActionsMenu = ({
         <BulkActionsWidget<SupportedAction>
           buttonIconSuffix={<ChevronDown width={iconSizes.xSmall} />}
           buttonTitle={showQuickActions ? "More" : "Actions"}
-          actions={actionsWithBulkRename}
+          actions={visibleActions}
           onConfirmation={handleConfirmation}
           onCancel={handleCancel}
           currentAction={currentAction}
@@ -250,7 +272,7 @@ const MinerActionsMenu = ({
           }
           renderPopover={(beforeEach) => (
             <BulkActionsPopover<SupportedAction>
-              actions={actionsWithBulkRename}
+              actions={visibleActions}
               beforeEach={beforeEach}
               testId="actions-menu-popover"
             />

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -40,7 +40,7 @@ interface MinerActionsMenuProps {
   miners?: Record<string, MinerStateSnapshot>;
   /** Ordered list of miner device identifiers, forwarded to bulk rename modals. */
   minerIds?: string[];
-  /** True when the selection includes auth-needed miners not present in selectedMiners, e.g. all-mode selections. */
+  /** True when the current selection includes auth-needed miners, including cases not explicitly listed in selectedMiners (for example, all-mode selections). */
   selectionIncludesUnauthenticatedMiner?: boolean;
   /** Callback to refetch miners after bulk rename or worker-name update. */
   onRefetchMiners?: () => void;
@@ -81,9 +81,9 @@ const MinerActionsMenu = ({
     () =>
       selectedMiners.map((id) => ({
         deviceIdentifier: id,
-        deviceStatus: miners[id]?.deviceStatus,
+        deviceStatus: selectionMode === "all" ? undefined : miners[id]?.deviceStatus,
       })),
-    [miners, selectedMiners],
+    [miners, selectedMiners, selectionMode],
   );
   const selectedIdsIncludeUnauthenticatedMiner = useMemo(
     () => selectedMiners.some((id) => miners[id]?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED),

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
@@ -1024,18 +1024,18 @@ describe("MinerList", () => {
       },
     );
 
-    it("recomputes selectable miners when a row becomes disabled between renders", async () => {
+    it("keeps authentication-needed miners selectable for unpair", async () => {
       const user = userEvent.setup();
 
-      const initialMiners = {
-        m1: createMinerSnapshot("m1"),
+      const miners = {
+        m1: createMinerSnapshot("m1", PairingStatus.AUTHENTICATION_NEEDED),
         m2: createMinerSnapshot("m2"),
       };
 
-      const { rerender } = renderMinerList({
+      renderMinerList({
         title: "Miners",
         minerIds: ["m1", "m2"],
-        miners: initialMiners,
+        miners,
         totalMiners: 2,
         totalDisabledMiners: 0,
         currentPage: 0,
@@ -1046,34 +1046,11 @@ describe("MinerList", () => {
       const rowCheckboxes = screen.getAllByTestId("checkbox");
       await user.click(rowCheckboxes[0].querySelector("input[type='checkbox']") as HTMLInputElement);
 
-      const updatedMiners = {
-        ...initialMiners,
-        m2: createMinerSnapshot("m2", PairingStatus.AUTHENTICATION_NEEDED),
-      };
-
-      await act(async () => {
-        rerender(
-          <BrowserRouter>
-            <MinerList
-              title="Miners"
-              minerIds={["m1", "m2"]}
-              miners={updatedMiners}
-              errorsByDevice={{}}
-              errorsLoaded={true}
-              getActiveBatches={mockGetActiveBatches}
-              totalMiners={2}
-              totalDisabledMiners={0}
-              currentPage={0}
-              onAddMiners={vi.fn()}
-              loading={false}
-            />
-          </BrowserRouter>,
-        );
-      });
+      expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m1");
 
       await user.click(screen.getByTestId("mock-action-bar-select-all"));
 
-      expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m1");
+      expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m1,m2");
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -214,6 +214,7 @@ type ScopedMinerListBodyProps = {
   onOpenManageColumns: () => void;
   handleClearFilters: () => void;
   isRowDisabled: (item: DeviceListItem) => boolean;
+  isSelectionLimited: (item: DeviceListItem) => boolean;
   currentFilter?: MinerListFilter;
   currentSortConfig?: SortConfig;
   currentSort?: { field: MinerColumn; direction: SortDirection };
@@ -252,6 +253,7 @@ const ScopedMinerListBody = ({
   onOpenManageColumns,
   handleClearFilters,
   isRowDisabled,
+  isSelectionLimited,
   currentFilter,
   currentSortConfig,
   currentSort,
@@ -281,9 +283,7 @@ const ScopedMinerListBody = ({
   }
   const sortableColumnsSet = useMemo(() => new Set(SORTABLE_COLUMNS), []);
 
-  const currentPageSelectableMinerIds = deviceItems
-    .filter((item) => !isRowDisabled(item))
-    .map((item) => item.deviceIdentifier);
+  const currentPageSelectableMinerIds = deviceItems.map((item) => item.deviceIdentifier);
 
   const handleSelectAllMiners = useCallback(() => {
     setSelectedMinerIds(currentPageSelectableMinerIds);
@@ -294,6 +294,16 @@ const ScopedMinerListBody = ({
     setSelectedMinerIds([]);
     setSelectionMode("none");
   }, []);
+
+  const selectedIncludesUnauthenticatedMiner = useMemo(
+    () =>
+      selectionMode === "all"
+        ? totalDisabledMiners > 0
+        : selectedMinerIds.some((id) =>
+            deviceItems.some((item) => item.deviceIdentifier === id && isSelectionLimited(item)),
+          ),
+    [deviceItems, isSelectionLimited, selectedMinerIds, selectionMode, totalDisabledMiners],
+  );
 
   return (
     <>
@@ -346,6 +356,7 @@ const ScopedMinerListBody = ({
               currentSort={currentSortConfig}
               miners={minersProp}
               minerIds={minerIdsProp}
+              selectionIncludesUnauthenticatedMiner={selectedIncludesUnauthenticatedMiner}
               onRefetchMiners={onRefetchMiners}
               onWorkerNameUpdated={onWorkerNameUpdated}
             />
@@ -358,7 +369,7 @@ const ScopedMinerListBody = ({
         overflowContainer={false}
         applyColumnWidthsToCells
         total={totalMiners}
-        totalDisabled={totalDisabledMiners}
+        totalDisabled={0}
         hideTotal
         itemName={{ singular: "miner", plural: "miners" }}
         itemRef={itemRef}
@@ -495,14 +506,11 @@ const MinerList = ({
     [minerIds, miners, errorsByDevice, batchStateVersion],
   );
 
-  const disabledMinerIdSet = useMemo(
-    () => new Set(minerIds.filter((id) => miners[id]?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED)),
-    [minerIds, miners],
-  );
   const isRowDisabled = useCallback(
-    (item: DeviceListItem) => disabledMinerIdSet.has(item.deviceIdentifier),
-    [disabledMinerIdSet],
+    (item: DeviceListItem) => item.miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED,
+    [],
   );
+  const isRowSelectionDisabled = useCallback((_item: DeviceListItem) => false, []);
 
   const initialActiveFilters = useMemo(() => parseUrlToActiveFilters(searchParams), [searchParams]);
 
@@ -1015,7 +1023,8 @@ const MinerList = ({
           exportCsvLoading={exportCsvLoading}
           onOpenManageColumns={handleOpenManageColumns}
           handleClearFilters={handleClearFilters}
-          isRowDisabled={isRowDisabled}
+          isRowDisabled={isRowSelectionDisabled}
+          isSelectionLimited={isRowDisabled}
           currentFilter={currentFilter}
           currentSortConfig={currentSortConfig}
           currentSort={currentSort}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
@@ -21,6 +21,7 @@ interface MinerListActionBarProps {
   currentSort?: SortConfig;
   miners?: Record<string, MinerStateSnapshot>;
   minerIds?: string[];
+  selectionIncludesUnauthenticatedMiner?: boolean;
   onRefetchMiners?: () => void;
   onWorkerNameUpdated?: (deviceIdentifier: string, workerName: string) => void;
 }
@@ -36,6 +37,7 @@ const MinerListActionBar = ({
   currentSort,
   miners,
   minerIds,
+  selectionIncludesUnauthenticatedMiner,
   onRefetchMiners,
   onWorkerNameUpdated,
 }: MinerListActionBarProps) => {
@@ -100,6 +102,7 @@ const MinerListActionBar = ({
           currentSort={currentSort}
           miners={miners}
           minerIds={minerIds}
+          selectionIncludesUnauthenticatedMiner={selectionIncludesUnauthenticatedMiner}
           onRefetchMiners={onRefetchMiners}
           onWorkerNameUpdated={onWorkerNameUpdated}
           onActionStart={() => {


### PR DESCRIPTION
This is a bit more verbose than I would like, and there may be better ways to do this, but my experience with typescript is pretty limited.  Tested and working, this may affect cases outside the issue specific case, but I think that is generally expected behavior, EG I should always be able to remove a device no matter what state its in, as removing and re-adding may solve some issues.

Fixes: #286