### PR TITLE
fix(fleetmanagement): omit discovery port from unpaired snapshot.Url

### DIFF
--- a/client/src/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb.ts
+++ b/client/src/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb.ts
@@ -131,7 +131,9 @@ export type MinerStateSnapshot = Message<"fleetmanagement.v1.MinerStateSnapshot"
   ipAddress: string;
 
   /**
-   * The full url of the miner including protocol and port (if running on a port other than 80/443)
+   * Web view URL for the miner's UI, in the form "<scheme>://<host>". The port is
+   * intentionally omitted so browsers fall back to the default for the scheme (80
+   * for http, 443 for https). Applies to both paired and unpaired devices.
    *
    * @generated from field: string url = 11;
    */

--- a/proto/fleetmanagement/v1/fleetmanagement.proto
+++ b/proto/fleetmanagement/v1/fleetmanagement.proto
@@ -105,7 +105,9 @@ message MinerStateSnapshot {
 
   string ip_address = 10;
 
-  // The full url of the miner including protocol and port (if running on a port other than 80/443)
+  // Web view URL for the miner's UI, in the form "<scheme>://<host>". The port is
+  // intentionally omitted so browsers fall back to the default for the scheme (80
+  // for http, 443 for https). Applies to both paired and unpaired devices.
   string url = 11;
 
   // Current operational status of the device

--- a/server/generated/grpc/fleetmanagement/v1/fleetmanagement.pb.go
+++ b/server/generated/grpc/fleetmanagement/v1/fleetmanagement.pb.go
@@ -538,7 +538,9 @@ type MinerStateSnapshot struct {
 	// For time series data, this represents when the most recent data was collected
 	Timestamp *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	IpAddress string                 `protobuf:"bytes,10,opt,name=ip_address,json=ipAddress,proto3" json:"ip_address,omitempty"`
-	// The full url of the miner including protocol and port (if running on a port other than 80/443)
+	// Web view URL for the miner's UI, in the form "<scheme>://<host>". The port is
+	// intentionally omitted so browsers fall back to the default for the scheme (80
+	// for http, 443 for https). Applies to both paired and unpaired devices.
 	Url string `protobuf:"bytes,11,opt,name=url,proto3" json:"url,omitempty"`
 	// Current operational status of the device
 	DeviceStatus DeviceStatus `protobuf:"varint,12,opt,name=device_status,json=deviceStatus,proto3,enum=fleetmanagement.v1.DeviceStatus" json:"device_status,omitempty"`

--- a/server/internal/domain/fleetmanagement/service.go
+++ b/server/internal/domain/fleetmanagement/service.go
@@ -45,10 +45,6 @@ const (
 	// maxPageSize is the maximum number of items that can be returned per page
 	maxPageSize = 1000
 
-	// Standard HTTP ports
-	defaultHTTPPort  = "80"
-	defaultHTTPSPort = "443"
-
 	// concurrentClearAuthKeyLimit bounds the number of parallel ClearAuthKey RPCs
 	// fired in the background after a delete operation
 	concurrentClearAuthKeyLimit = 20
@@ -468,25 +464,18 @@ func (s *Service) buildSnapshotsFromUnifiedQuery(
 
 		snapshot.Name = ComposeDeviceName(row.CustomName.String, snapshot.Manufacturer, snapshot.Model)
 
+		snapshot.IpAddress = row.IpAddress
+		snapshot.Url = constructWebViewURL(row.UrlScheme, row.IpAddress)
+
 		if isPaired {
 			snapshot.MacAddress = row.MacAddress
 			if row.SerialNumber.Valid {
 				snapshot.SerialNumber = row.SerialNumber.String
 			}
-			snapshot.IpAddress = row.IpAddress
-			snapshot.Url = constructWebViewURL(row.UrlScheme, row.IpAddress)
-
 			if row.DeviceStatus.Valid {
 				snapshot.DeviceStatus = convertDeviceStatusStringToProto(string(row.DeviceStatus.DeviceStatusEnum))
 			}
 		} else {
-			snapshot.IpAddress = row.IpAddress
-
-			url := row.UrlScheme + "://" + bracketIPv6Host(row.IpAddress)
-			if row.Port != "" && row.Port != defaultHTTPPort && row.Port != defaultHTTPSPort {
-				url += ":" + row.Port
-			}
-			snapshot.Url = url
 			snapshot.DeviceStatus = pb.DeviceStatus_DEVICE_STATUS_INACTIVE
 		}
 

--- a/server/internal/domain/fleetmanagement/service_test.go
+++ b/server/internal/domain/fleetmanagement/service_test.go
@@ -818,6 +818,9 @@ func TestService_ListMinerStateSnapshots_ShouldPopulateCapabilitiesForUnpairedDe
 
 	miner := resp.Miners[0]
 	assert.Equal(t, pb.PairingStatus_PAIRING_STATUS_UNPAIRED, miner.PairingStatus)
+	assert.Equal(t, "192.168.1.100", miner.IpAddress)
+	// Fixture Port="4028" is the discovery API port; snapshot.Url omits it so the link targets the web UI.
+	assert.Equal(t, "http://192.168.1.100", miner.Url)
 	assert.NotNil(t, miner.Capabilities, "Capabilities should be populated for unpaired device")
 
 	// Verify capabilities structure

--- a/server/internal/domain/fleetmanagement/web_view_url_internal_test.go
+++ b/server/internal/domain/fleetmanagement/web_view_url_internal_test.go
@@ -1,0 +1,67 @@
+package fleetmanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestConstructWebViewURL pins the snapshot.Url semantics: scheme preserved,
+// host bracketed for IPv6, and port intentionally omitted so browsers fall back
+// to the default for the scheme. This is the contract for both paired and
+// unpaired device rows in ListMinerStateSnapshots.
+func TestConstructWebViewURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		scheme    string
+		ipAddress string
+		expected  string
+	}{
+		{
+			name:      "HTTP IPv4 address yields scheme and host with no port",
+			scheme:    "http",
+			ipAddress: "192.168.1.100",
+			expected:  "http://192.168.1.100",
+		},
+		{
+			name:      "HTTPS scheme is preserved",
+			scheme:    "https",
+			ipAddress: "192.168.1.100",
+			expected:  "https://192.168.1.100",
+		},
+		{
+			name:      "Bare IPv6 address is bracket-wrapped",
+			scheme:    "http",
+			ipAddress: "fe80::1",
+			expected:  "http://[fe80::1]",
+		},
+		{
+			name:      "Already-bracketed IPv6 address is not double-bracketed",
+			scheme:    "http",
+			ipAddress: "[::1]",
+			expected:  "http://[::1]",
+		},
+		{
+			name:      "Empty ipAddress yields empty URL",
+			scheme:    "http",
+			ipAddress: "",
+			expected:  "",
+		},
+		{
+			name:      "Empty scheme yields empty URL",
+			scheme:    "",
+			ipAddress: "192.168.1.100",
+			expected:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Act
+			actual := constructWebViewURL(tc.scheme, tc.ipAddress)
+
+			// Assert
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Server-side fix for #287: clicking an unpaired/discovered miner's IP in the Miners table opened the device's JSON API port (`:4028` for Whatsminer / CGMiner mAPI) instead of its web UI.
- The unpaired branch in [`buildSnapshotsFromUnifiedQuery`](server/internal/domain/fleetmanagement/service.go) was hand-rolling a URL that re-appended `row.Port` whenever it wasn't 80 or 443. `row.Port` is the discovery / control-plane port stored at pairing time, not the web UI port. Routing through the existing `constructWebViewURL` helper gives unpaired devices the same port-omitted, scheme-preserved URL as paired devices — which is what `snapshot.Url` is documented to mean ([service.go:77-81](server/internal/domain/fleetmanagement/service.go#L77-L81)).
- Hoists the shared `IpAddress` / `Url` assignments above the `isPaired` switch so both branches use the same helper, and drops the two now-unused `defaultHTTPPort` / `defaultHTTPSPort` constants.

## Why this instead of #288

This change fixes `snapshot.Url` at the source so the existing client code (`<a href={miner.url}>`) just works. #288 can be closed.

## Test plan

- [x] New `TestConstructWebViewURL` unit test pins the URL semantics: HTTP IPv4, HTTPS scheme preserved, bare IPv6 bracketed, already-bracketed IPv6 not double-bracketed, empty scheme/host return empty string.
- [x] Existing `TestService_ListMinerStateSnapshots_ShouldPopulateCapabilitiesForUnpairedDevices` now asserts `miner.Url == \"http://192.168.1.100\"` against a fixture with `Port=\"4028\"`, pinning the end-to-end behavior reported in #287.
- [x] `go vet` and `golangci-lint` (changed scope) clean.
- [x] CI runs the full server integration suite against the proto-fleet test DB.
- [x] Manual verification on the Whatsminer M30S+ VH60 device that prompted #287 (clicking the IP cell opens `http://<ip>` on port 80, browser reaches the device web UI).

Fixes #287