### PR TITLE
Curtailment: edit modal component

### DIFF
--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.stories.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.stories.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useMemo, useState } from "react";
+import { type ComponentProps, type ReactElement, useEffect, useMemo, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import ActiveCurtailmentStatus, {
@@ -11,6 +11,9 @@ import {
   restoreIncompleteCurtailmentEvent,
   restoringCurtailmentEvent,
 } from "@/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures";
+import CurtailmentStopConfirmationDialog, {
+  type CurtailmentStopConfirmationAction,
+} from "@/protoFleet/features/energy/CurtailmentStopConfirmationDialog";
 
 const meta = {
   title: "Proto Fleet/Energy/Active Curtailment Status",
@@ -52,6 +55,32 @@ interface StartProgressIntervalArgs {
 const animationStepPercent = 10;
 const animationStepMs = 450;
 const restoreStartDelayMs = 900;
+
+function ActiveCurtailmentStatusStory(props: ComponentProps<typeof ActiveCurtailmentStatus>): ReactElement {
+  const [dialogAction, setDialogAction] = useState<CurtailmentStopConfirmationAction>();
+
+  function closeDialog(): void {
+    setDialogAction(undefined);
+  }
+
+  return (
+    <>
+      <ActiveCurtailmentStatus
+        {...props}
+        onDismissRestored={() => undefined}
+        onRequestEdit={() => undefined}
+        onRequestRestore={() => setDialogAction("restore")}
+        onRequestStop={() => setDialogAction("stopCurtailment")}
+      />
+      <CurtailmentStopConfirmationDialog
+        open={dialogAction !== undefined}
+        action={dialogAction ?? "stopCurtailment"}
+        onCancel={closeDialog}
+        onConfirm={closeDialog}
+      />
+    </>
+  );
+}
 
 function startProgressInterval({ onComplete, setProgressPercent }: StartProgressIntervalArgs): number {
   const intervalId = window.setInterval(() => {
@@ -122,6 +151,7 @@ function AnimatedCurtailmentLifecycleStory(): ReactElement {
   const [phase, setPhase] = useState<AnimationPhase>("shed");
   const [shedProgressPercent, setShedProgressPercent] = useState(0);
   const [restoreProgressPercent, setRestoreProgressPercent] = useState(0);
+  const [dialogAction, setDialogAction] = useState<CurtailmentStopConfirmationAction>();
 
   useEffect(() => {
     if (phase !== "shed") {
@@ -173,47 +203,68 @@ function AnimatedCurtailmentLifecycleStory(): ReactElement {
     setPhase("shed");
   }
 
+  function closeDialog(): void {
+    setDialogAction(undefined);
+  }
+
+  function confirmRestore(): void {
+    closeDialog();
+    setRestoreProgressPercent(0);
+    setPhase("restore");
+  }
+
   return (
-    <ActiveCurtailmentStatus
-      event={activeEvent}
-      onDismissRestored={resetAnimation}
-      onRequestRestore={() => setPhase("restore")}
-      onRequestStop={() => setPhase("restore")}
-    />
+    <>
+      <ActiveCurtailmentStatus
+        event={activeEvent}
+        onDismissRestored={resetAnimation}
+        onRequestEdit={() => undefined}
+        onRequestRestore={() => setDialogAction("restore")}
+        onRequestStop={() => setDialogAction("stopCurtailment")}
+      />
+      <CurtailmentStopConfirmationDialog
+        open={dialogAction !== undefined}
+        action={dialogAction ?? "stopCurtailment"}
+        onCancel={closeDialog}
+        onConfirm={confirmRestore}
+      />
+    </>
   );
 }
 
 export const Curtailing: Story = {
   args: {
     event: curtailingCurtailmentEvent,
-    onRequestStop: () => undefined,
   },
+  render: (args) => <ActiveCurtailmentStatusStory {...args} />,
 };
 
 export const Curtailed: Story = {
   args: {
     event: curtailedCurtailmentEvent,
-    onRequestRestore: () => undefined,
   },
+  render: (args) => <ActiveCurtailmentStatusStory {...args} />,
 };
 
 export const Restoring: Story = {
   args: {
     event: restoringCurtailmentEvent,
   },
+  render: (args) => <ActiveCurtailmentStatusStory {...args} />,
 };
 
 export const Restored: Story = {
   args: {
     event: restoredCurtailmentEvent,
-    onDismissRestored: () => undefined,
   },
+  render: (args) => <ActiveCurtailmentStatusStory {...args} />,
 };
 
 export const RestoreIncomplete: Story = {
   args: {
     event: restoreIncompleteCurtailmentEvent,
   },
+  render: (args) => <ActiveCurtailmentStatusStory {...args} />,
 };
 
 export const AnimatedCurtailmentLifecycle: Story = {

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -77,6 +77,39 @@ describe("ActiveCurtailmentStatus", () => {
     expect(onRequestStop).toHaveBeenCalledOnce();
   });
 
+  it("calls the manage handler when edit is available", async () => {
+    const user = userEvent.setup();
+    const onRequestEdit = vi.fn();
+    const onRequestStop = vi.fn();
+
+    render(
+      <ActiveCurtailmentStatus
+        event={curtailingCurtailmentEvent}
+        onRequestEdit={onRequestEdit}
+        onRequestStop={onRequestStop}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Manage" }));
+
+    expect(onRequestEdit).toHaveBeenCalledOnce();
+    expect(onRequestStop).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Stop" })).toBeVisible();
+  });
+
+  it("shows manage without stop or restore while restoring", async () => {
+    const user = userEvent.setup();
+    const onRequestEdit = vi.fn();
+
+    render(<ActiveCurtailmentStatus event={restoringCurtailmentEvent} onRequestEdit={onRequestEdit} />);
+
+    await user.click(screen.getByRole("button", { name: "Manage" }));
+
+    expect(onRequestEdit).toHaveBeenCalledOnce();
+    expectActionButtonHidden("Stop");
+    expectActionButtonHidden("Restore");
+  });
+
   it("renders a curtailed event with restore available", async () => {
     const user = userEvent.setup();
     const onRequestRestore = vi.fn();

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -40,6 +40,7 @@ interface ActiveCurtailmentStatusProps {
   event: ActiveCurtailmentEvent;
   className?: string;
   onDismissRestored?: () => void;
+  onRequestEdit?: () => void;
   onRequestRestore?: () => void;
   onRequestStop?: () => void;
 }
@@ -47,6 +48,7 @@ interface ActiveCurtailmentStatusProps {
 interface ActiveCurtailmentActionButtonsProps {
   displayState: ActiveCurtailmentDisplayState;
   onDismissRestored?: () => void;
+  onRequestEdit?: () => void;
   onRequestRestore?: () => void;
   onRequestStop?: () => void;
 }
@@ -177,6 +179,13 @@ const displayStateLabels: Record<ActiveCurtailmentDisplayState, string> = {
   restored: "Restored",
   restoring: "Restoring",
 };
+
+const manageableDisplayStates = new Set<ActiveCurtailmentDisplayState>([
+  "curtailed",
+  "curtailing",
+  "pending",
+  "restoring",
+]);
 
 function Dot({ className }: DotProps): ReactElement {
   return <span className={clsx("inline-block h-2 w-2 shrink-0 rounded-full", className)} />;
@@ -524,14 +533,30 @@ function getActiveCurtailmentActionButton({
   }
 }
 
-function ActiveCurtailmentActionButtons(props: ActiveCurtailmentActionButtonsProps): ReactElement | null {
-  const actionButton = getActiveCurtailmentActionButton(props);
-  if (!actionButton) {
+function ActiveCurtailmentActionButtons({
+  displayState,
+  onDismissRestored,
+  onRequestEdit,
+  onRequestRestore,
+  onRequestStop,
+}: ActiveCurtailmentActionButtonsProps): ReactElement | null {
+  const actionButton = getActiveCurtailmentActionButton({
+    displayState,
+    onDismissRestored,
+    onRequestRestore,
+    onRequestStop,
+  });
+  const showManageButton = Boolean(onRequestEdit && manageableDisplayStates.has(displayState));
+
+  if (!actionButton && !showManageButton) {
     return null;
   }
 
   return (
     <div className="mb-8 flex shrink-0 justify-end gap-3 tablet:absolute tablet:top-10 tablet:right-10 tablet:mb-0">
+      {showManageButton ? (
+        <Button variant={variants.secondary} size={sizes.compact} text="Manage" onClick={onRequestEdit} />
+      ) : null}
       {actionButton}
     </div>
   );
@@ -605,6 +630,7 @@ export default function ActiveCurtailmentStatus({
   event,
   className,
   onDismissRestored,
+  onRequestEdit,
   onRequestRestore,
   onRequestStop,
 }: ActiveCurtailmentStatusProps): ReactElement {
@@ -677,6 +703,7 @@ export default function ActiveCurtailmentStatus({
         <ActiveCurtailmentActionButtons
           displayState={displayState}
           onDismissRestored={onDismissRestored}
+          onRequestEdit={onRequestEdit}
           onRequestRestore={onRequestRestore}
           onRequestStop={onRequestStop}
         />

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.stories.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.stories.tsx
@@ -1,9 +1,8 @@
-import { type ReactElement, useState } from "react";
+import type { ReactElement } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import CurtailmentHistory from "@/protoFleet/features/energy/CurtailmentHistory";
 import { mockCurtailmentHistoryEvents } from "@/protoFleet/features/energy/CurtailmentHistory.fixtures";
-import CurtailmentStopConfirmationDialog from "@/protoFleet/features/energy/CurtailmentStopConfirmationDialog";
 
 const meta = {
   title: "Proto Fleet/Energy/Curtailment History",
@@ -25,32 +24,14 @@ export default meta;
 type Story = StoryObj<typeof CurtailmentHistory>;
 
 function CurtailmentHistoryStory(): ReactElement {
-  const [showStopDialog, setShowStopDialog] = useState(false);
-
-  function closeStopDialog(): void {
-    setShowStopDialog(false);
-  }
-
-  function openStopDialog(): void {
-    setShowStopDialog(true);
-  }
-
   return (
-    <>
-      <CurtailmentHistory
-        events={mockCurtailmentHistoryEvents}
-        activeEventId="curt-1042"
-        pageSize={2}
-        onManageActiveEvent={() => undefined}
-        onStopActiveEvent={openStopDialog}
-      />
-      <CurtailmentStopConfirmationDialog
-        open={showStopDialog}
-        action="stopCurtailment"
-        onCancel={closeStopDialog}
-        onConfirm={closeStopDialog}
-      />
-    </>
+    <CurtailmentHistory
+      events={mockCurtailmentHistoryEvents}
+      activeEventId="curt-1042"
+      pageSize={2}
+      onManageActiveEvent={() => undefined}
+      onStopActiveEvent={() => undefined}
+    />
   );
 }
 

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.stories.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.stories.tsx
@@ -1,7 +1,9 @@
+import { type ReactElement, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import CurtailmentHistory from "@/protoFleet/features/energy/CurtailmentHistory";
 import { mockCurtailmentHistoryEvents } from "@/protoFleet/features/energy/CurtailmentHistory.fixtures";
+import CurtailmentStopConfirmationDialog from "@/protoFleet/features/energy/CurtailmentStopConfirmationDialog";
 
 const meta = {
   title: "Proto Fleet/Energy/Curtailment History",
@@ -22,13 +24,38 @@ export default meta;
 
 type Story = StoryObj<typeof CurtailmentHistory>;
 
+function CurtailmentHistoryStory(): ReactElement {
+  const [showStopDialog, setShowStopDialog] = useState(false);
+
+  function closeStopDialog(): void {
+    setShowStopDialog(false);
+  }
+
+  function openStopDialog(): void {
+    setShowStopDialog(true);
+  }
+
+  return (
+    <>
+      <CurtailmentHistory
+        events={mockCurtailmentHistoryEvents}
+        activeEventId="curt-1042"
+        pageSize={2}
+        onManageActiveEvent={() => undefined}
+        onStopActiveEvent={openStopDialog}
+      />
+      <CurtailmentStopConfirmationDialog
+        open={showStopDialog}
+        action="stopCurtailment"
+        onCancel={closeStopDialog}
+        onConfirm={closeStopDialog}
+      />
+    </>
+  );
+}
+
 export const Default: Story = {
-  args: {
-    events: mockCurtailmentHistoryEvents,
-    activeEventId: "curt-1042",
-    pageSize: 2,
-    onStopActiveEvent: () => undefined,
-  },
+  render: () => <CurtailmentHistoryStory />,
 };
 
 export const Empty: Story = {

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
@@ -121,8 +121,13 @@ describe("CurtailmentHistory", () => {
     const pendingRow = screen.getByTestId("curtailment-history-row-curt-pending");
     await user.click(within(pendingRow).getByRole("button", { name: "Stop Queued curtailment" }));
 
-    expect(onStopActiveEvent).toHaveBeenCalledWith(pendingEvent);
+    expect(onStopActiveEvent).not.toHaveBeenCalled();
+    expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Start restore" }));
+
+    expect(onStopActiveEvent).toHaveBeenCalledWith(pendingEvent);
 
     await user.click(pendingRow);
 
@@ -132,7 +137,12 @@ describe("CurtailmentHistory", () => {
 
     await user.click(within(modal).getByRole("button", { name: "Stop curtailment" }));
 
-    expect(onStopActiveEvent).toHaveBeenCalledWith(pendingEvent);
+    expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
+    expect(onStopActiveEvent).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Start restore" }));
+
+    expect(onStopActiveEvent).toHaveBeenCalledTimes(2);
   });
 
   it("opens row details from an empty actions cell", async () => {
@@ -175,6 +185,11 @@ describe("CurtailmentHistory", () => {
 
     await user.click(stopButton);
 
+    expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
+    expect(onStopActiveEvent).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Start restore" }));
+
     expect(onStopActiveEvent).toHaveBeenCalledWith(activeEvent);
     expect(stopButton).toBeDisabled();
 
@@ -191,7 +206,7 @@ describe("CurtailmentHistory", () => {
     expect(screen.queryByRole("button", { name: "Stop curtailment" })).not.toBeInTheDocument();
   });
 
-  it("routes row stop actions directly to the stop callback", async () => {
+  it("opens row stop actions in the stop confirmation dialog", async () => {
     const user = userEvent.setup();
     const stopRequest = createPendingStopRequest();
     const onStopActiveEvent = vi.fn(() => stopRequest);
@@ -213,12 +228,18 @@ describe("CurtailmentHistory", () => {
 
     await user.click(stopButton);
 
-    expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
+    expect(onStopActiveEvent).not.toHaveBeenCalled();
+    expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+    expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).not.toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Start restore" }));
+
+    expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
     expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).toBeDisabled();
   });
 
-  it("keeps stop actions enabled when the stop callback opens confirmation only", async () => {
+  it("keeps stop actions enabled while confirmation is awaiting a decision", async () => {
     const user = userEvent.setup();
     const onStopActiveEvent = vi.fn();
 
@@ -233,8 +254,14 @@ describe("CurtailmentHistory", () => {
     const activeRow = screen.getByTestId("curtailment-history-row-curt-1042");
     await user.click(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" }));
 
-    expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
+    expect(onStopActiveEvent).not.toHaveBeenCalled();
+    expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+    expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).not.toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Stop curtailment?")).not.toBeInTheDocument();
     expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).not.toBeDisabled();
   });
 
@@ -304,6 +331,11 @@ describe("CurtailmentHistory", () => {
 
     await user.click(modalStopButton);
 
+    expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
+    expect(onStopActiveEvent).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Start restore" }));
+
     expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
     expect(modalStopButton).toBeDisabled();
     expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).toBeDisabled();
@@ -314,6 +346,10 @@ describe("CurtailmentHistory", () => {
     expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).not.toBeDisabled();
 
     await user.click(modalStopButton);
+
+    expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Start restore" }));
 
     expect(onStopActiveEvent).toHaveBeenCalledTimes(2);
   });
@@ -338,9 +374,14 @@ describe("CurtailmentHistory", () => {
     stopButton.focus();
     await user.keyboard("{Enter}");
 
-    expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
+    expect(onStopActiveEvent).not.toHaveBeenCalled();
     expect(onViewEvent).not.toHaveBeenCalled();
+    expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Start restore" }));
+
+    expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
   });
 
   it("renders an empty state when there are no events", () => {

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
@@ -9,6 +9,22 @@ function getRenderedRows(): HTMLElement[] {
   return screen.queryAllByTestId(/^curtailment-history-row-/);
 }
 
+function createPendingStopRequest(): Promise<void> {
+  return new Promise(() => undefined);
+}
+
+function createRejectableStopRequest(): {
+  stopRequest: Promise<void>;
+  rejectStopRequest: (error: Error) => void;
+} {
+  let rejectStopRequest: (error: Error) => void = () => undefined;
+  const stopRequest = new Promise<void>((_, reject) => {
+    rejectStopRequest = reject;
+  });
+
+  return { stopRequest, rejectStopRequest };
+}
+
 describe("CurtailmentHistory", () => {
   it("renders history rows with pagination", async () => {
     const user = userEvent.setup();
@@ -105,7 +121,11 @@ describe("CurtailmentHistory", () => {
     const pendingRow = screen.getByTestId("curtailment-history-row-curt-pending");
     await user.click(within(pendingRow).getByRole("button", { name: "Stop Queued curtailment" }));
 
-    expect(onStopActiveEvent).not.toHaveBeenCalled();
+    expect(onStopActiveEvent).toHaveBeenCalledWith(pendingEvent);
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+
+    await user.click(pendingRow);
+
     const modal = screen.getByTestId("modal");
     expect(within(modal).getByText("Queued curtailment")).toBeInTheDocument();
     expect(within(modal).getByText("Not started yet")).toBeInTheDocument();
@@ -132,7 +152,8 @@ describe("CurtailmentHistory", () => {
 
   it("keeps an open detail modal synced to event updates", async () => {
     const user = userEvent.setup();
-    const onStopActiveEvent = vi.fn();
+    const stopRequest = createPendingStopRequest();
+    const onStopActiveEvent = vi.fn(() => stopRequest);
     const activeEvent = mockCurtailmentHistoryEvents[0];
     const completedEvent = {
       ...activeEvent,
@@ -170,9 +191,10 @@ describe("CurtailmentHistory", () => {
     expect(screen.queryByRole("button", { name: "Stop curtailment" })).not.toBeInTheDocument();
   });
 
-  it("routes row stop actions through the summary modal", async () => {
+  it("routes row stop actions directly to the stop callback", async () => {
     const user = userEvent.setup();
-    const onStopActiveEvent = vi.fn();
+    const stopRequest = createPendingStopRequest();
+    const onStopActiveEvent = vi.fn(() => stopRequest);
 
     render(
       <CurtailmentHistory
@@ -191,26 +213,14 @@ describe("CurtailmentHistory", () => {
 
     await user.click(stopButton);
 
-    expect(onStopActiveEvent).not.toHaveBeenCalled();
-    const modal = screen.getByTestId("modal");
-    expect(within(modal).getByText("Curtailment detail")).toBeInTheDocument();
-    expect(within(modal).getByText("ERCOT ERS obligation")).toBeInTheDocument();
-    expect(within(modal).getByText("Power target vs actual")).toBeInTheDocument();
-
-    await user.click(within(modal).getByRole("button", { name: "Stop curtailment" }));
-
     expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
-    expect(within(modal).getByRole("button", { name: "Stop curtailment" })).toBeDisabled();
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
     expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).toBeDisabled();
   });
 
-  it("re-enables stop actions when the stop request fails", async () => {
+  it("keeps stop actions enabled when the stop callback opens confirmation only", async () => {
     const user = userEvent.setup();
-    let rejectStopRequest: (error: Error) => void = () => undefined;
-    const stopRequest = new Promise<void>((_, reject) => {
-      rejectStopRequest = reject;
-    });
-    const onStopActiveEvent = vi.fn(() => stopRequest);
+    const onStopActiveEvent = vi.fn();
 
     render(
       <CurtailmentHistory
@@ -222,6 +232,72 @@ describe("CurtailmentHistory", () => {
 
     const activeRow = screen.getByTestId("curtailment-history-row-curt-1042");
     await user.click(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" }));
+
+    expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+    expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).not.toBeDisabled();
+  });
+
+  it("routes active row manage actions through the summary modal", async () => {
+    const user = userEvent.setup();
+    const onManageActiveEvent = vi.fn();
+    const onStopActiveEvent = vi.fn();
+
+    render(
+      <CurtailmentHistory
+        events={mockCurtailmentHistoryEvents}
+        activeEventId="curt-1042"
+        onManageActiveEvent={onManageActiveEvent}
+        onStopActiveEvent={onStopActiveEvent}
+      />,
+    );
+
+    await user.click(screen.getByTestId("curtailment-history-row-curt-1042"));
+
+    const modal = screen.getByTestId("modal");
+    expect(within(modal).getByText("ERCOT ERS obligation")).toBeInTheDocument();
+    expect(within(modal).getByRole("button", { name: "Stop curtailment" })).toBeInTheDocument();
+
+    await user.click(within(modal).getByRole("button", { name: "Manage" }));
+
+    expect(onManageActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
+    expect(onStopActiveEvent).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+  });
+
+  it("does not show manage actions for inactive row summaries", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CurtailmentHistory
+        events={mockCurtailmentHistoryEvents}
+        activeEventId="curt-1042"
+        onManageActiveEvent={() => undefined}
+      />,
+    );
+
+    await user.click(screen.getByTestId("curtailment-history-row-curt-1039"));
+
+    const modal = screen.getByTestId("modal");
+    expect(within(modal).getByText("Grid peak call")).toBeInTheDocument();
+    expect(within(modal).queryByRole("button", { name: "Manage" })).not.toBeInTheDocument();
+  });
+
+  it("re-enables stop actions when the stop request fails", async () => {
+    const user = userEvent.setup();
+    const { stopRequest, rejectStopRequest } = createRejectableStopRequest();
+    const onStopActiveEvent = vi.fn(() => stopRequest);
+
+    render(
+      <CurtailmentHistory
+        events={mockCurtailmentHistoryEvents}
+        activeEventId="curt-1042"
+        onStopActiveEvent={onStopActiveEvent}
+      />,
+    );
+
+    const activeRow = screen.getByTestId("curtailment-history-row-curt-1042");
+    await user.click(activeRow);
 
     const modal = screen.getByTestId("modal");
     const modalStopButton = within(modal).getByRole("button", { name: "Stop curtailment" });
@@ -262,13 +338,9 @@ describe("CurtailmentHistory", () => {
     stopButton.focus();
     await user.keyboard("{Enter}");
 
-    expect(onStopActiveEvent).not.toHaveBeenCalled();
-    expect(onViewEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
-    expect(screen.getByTestId("modal")).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Stop curtailment" }));
-
     expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
+    expect(onViewEvent).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
   });
 
   it("renders an empty state when there are no events", () => {

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
@@ -334,6 +334,35 @@ describe("CurtailmentHistory", () => {
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
   });
 
+  it("hides manage actions while a stop request is pending", async () => {
+    const user = userEvent.setup();
+    const stopRequest = createPendingStopRequest();
+    const onManageActiveEvent = vi.fn();
+    const onStopActiveEvent = vi.fn(() => stopRequest);
+
+    render(
+      <CurtailmentHistory
+        events={mockCurtailmentHistoryEvents}
+        activeEventId="curt-1042"
+        onManageActiveEvent={onManageActiveEvent}
+        onStopActiveEvent={onStopActiveEvent}
+      />,
+    );
+
+    const activeRow = screen.getByTestId("curtailment-history-row-curt-1042");
+    await user.click(activeRow);
+
+    const modal = screen.getByTestId("modal");
+    expect(within(modal).getByRole("button", { name: "Manage" })).toBeInTheDocument();
+
+    await user.click(within(modal).getByRole("button", { name: "Stop curtailment" }));
+    await user.click(screen.getByRole("button", { name: "Confirm stop" }));
+
+    expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
+    expect(within(modal).queryByRole("button", { name: "Manage" })).not.toBeInTheDocument();
+    expect(onManageActiveEvent).not.toHaveBeenCalled();
+  });
+
   it("does not show manage actions for inactive row summaries", async () => {
     const user = userEvent.setup();
 

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
@@ -125,7 +125,7 @@ describe("CurtailmentHistory", () => {
     expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Start restore" }));
+    await user.click(screen.getByRole("button", { name: "Confirm stop" }));
 
     expect(onStopActiveEvent).toHaveBeenCalledWith(pendingEvent);
 
@@ -135,14 +135,8 @@ describe("CurtailmentHistory", () => {
     expect(within(modal).getByText("Queued curtailment")).toBeInTheDocument();
     expect(within(modal).getByText("Not started yet")).toBeInTheDocument();
 
-    await user.click(within(modal).getByRole("button", { name: "Stop curtailment" }));
-
-    expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
+    expect(within(modal).getByRole("button", { name: "Stop curtailment" })).toBeDisabled();
     expect(onStopActiveEvent).toHaveBeenCalledTimes(1);
-
-    await user.click(screen.getByRole("button", { name: "Start restore" }));
-
-    expect(onStopActiveEvent).toHaveBeenCalledTimes(2);
   });
 
   it("opens row details from an empty actions cell", async () => {
@@ -188,7 +182,7 @@ describe("CurtailmentHistory", () => {
     expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
     expect(onStopActiveEvent).not.toHaveBeenCalled();
 
-    await user.click(screen.getByRole("button", { name: "Start restore" }));
+    await user.click(screen.getByRole("button", { name: "Confirm stop" }));
 
     expect(onStopActiveEvent).toHaveBeenCalledWith(activeEvent);
     expect(stopButton).toBeDisabled();
@@ -233,10 +227,58 @@ describe("CurtailmentHistory", () => {
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
     expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).not.toBeDisabled();
 
-    await user.click(screen.getByRole("button", { name: "Start restore" }));
+    await user.click(screen.getByRole("button", { name: "Confirm stop" }));
 
     expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
     expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).toBeDisabled();
+  });
+
+  it("keeps stop actions disabled when a confirmed stop handler returns synchronously", async () => {
+    const user = userEvent.setup();
+    const onStopActiveEvent = vi.fn();
+
+    render(
+      <CurtailmentHistory
+        events={mockCurtailmentHistoryEvents}
+        activeEventId="curt-1042"
+        onStopActiveEvent={onStopActiveEvent}
+      />,
+    );
+
+    const activeRow = screen.getByTestId("curtailment-history-row-curt-1042");
+    await user.click(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" }));
+    await user.click(screen.getByRole("button", { name: "Confirm stop" }));
+
+    expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
+    expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).toBeDisabled();
+
+    await user.click(activeRow);
+
+    const modal = screen.getByTestId("modal");
+    expect(within(modal).getByRole("button", { name: "Stop curtailment" })).toBeDisabled();
+  });
+
+  it("re-enables stop actions when a confirmed stop handler throws synchronously", async () => {
+    const user = userEvent.setup();
+    const onStopActiveEvent = vi.fn(() => {
+      throw new Error("Stop request failed");
+    });
+
+    render(
+      <CurtailmentHistory
+        events={mockCurtailmentHistoryEvents}
+        activeEventId="curt-1042"
+        onStopActiveEvent={onStopActiveEvent}
+      />,
+    );
+
+    const activeRow = screen.getByTestId("curtailment-history-row-curt-1042");
+    await user.click(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" }));
+    await user.click(screen.getByRole("button", { name: "Confirm stop" }));
+
+    expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
+    expect(screen.queryByText("Stop curtailment?")).not.toBeInTheDocument();
+    expect(within(activeRow).getByRole("button", { name: "Stop ERCOT ERS obligation" })).not.toBeDisabled();
   });
 
   it("keeps stop actions enabled while confirmation is awaiting a decision", async () => {
@@ -334,7 +376,7 @@ describe("CurtailmentHistory", () => {
     expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
     expect(onStopActiveEvent).not.toHaveBeenCalled();
 
-    await user.click(screen.getByRole("button", { name: "Start restore" }));
+    await user.click(screen.getByRole("button", { name: "Confirm stop" }));
 
     expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
     expect(modalStopButton).toBeDisabled();
@@ -349,7 +391,7 @@ describe("CurtailmentHistory", () => {
 
     expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Start restore" }));
+    await user.click(screen.getByRole("button", { name: "Confirm stop" }));
 
     expect(onStopActiveEvent).toHaveBeenCalledTimes(2);
   });
@@ -379,7 +421,7 @@ describe("CurtailmentHistory", () => {
     expect(screen.getByText("Stop curtailment?")).toBeInTheDocument();
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Start restore" }));
+    await user.click(screen.getByRole("button", { name: "Confirm stop" }));
 
     expect(onStopActiveEvent).toHaveBeenCalledWith(mockCurtailmentHistoryEvents[0]);
   });

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -607,7 +607,10 @@ function CurtailmentHistory({
   };
 
   const handleManageSelectedDetailEvent =
-    selectedDetailEvent && onManageActiveEvent && isActiveManageableEvent(selectedDetailEvent, activeEventId)
+    selectedDetailEvent &&
+    onManageActiveEvent &&
+    isActiveManageableEvent(selectedDetailEvent, activeEventId) &&
+    selectedDetailEvent.id !== pendingStoppableEventId
       ? () => {
           setSelectedDetailEventId(undefined);
           onManageActiveEvent(selectedDetailEvent);

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -587,14 +587,20 @@ function CurtailmentHistory({
 
     const event = selectedStopEvent;
     setSelectedStopEventId(undefined);
+    setPendingStopEventId(event.id);
 
-    const stopRequest = onStopActiveEvent(event);
+    let stopRequest: void | PromiseLike<unknown>;
+    try {
+      stopRequest = onStopActiveEvent(event);
+    } catch {
+      setPendingStopEventId((currentEventId) => (currentEventId === event.id ? undefined : currentEventId));
+      return;
+    }
 
     if (!isPromiseLike(stopRequest)) {
       return;
     }
 
-    setPendingStopEventId(event.id);
     void Promise.resolve(stopRequest).catch(() => {
       setPendingStopEventId((currentEventId) => (currentEventId === event.id ? undefined : currentEventId));
     });

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -2,6 +2,7 @@ import { type KeyboardEvent, type MouseEvent, type ReactElement, useMemo, useSta
 import clsx from "clsx";
 
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
+import CurtailmentStopConfirmationDialog from "@/protoFleet/features/energy/CurtailmentStopConfirmationDialog";
 import { ChevronDown } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { type ButtonVariant, sizes, variants } from "@/shared/components/Button";
@@ -52,10 +53,9 @@ interface CurtailmentHistoryProps {
    */
   onManageActiveEvent?: (event: CurtailmentHistoryEvent) => void;
   /**
-   * Called when the operator requests a stop for the active event. The parent
-   * owns persistence and any additional confirmation. Return a promise only
-   * after an actual stop request starts; a rejected promise re-enables retry
-   * controls.
+   * Called after the operator confirms stopping the active event. The parent
+   * owns persistence. Return a promise only after an actual stop request
+   * starts; a rejected promise re-enables retry controls.
    */
   onStopActiveEvent?: (event: CurtailmentHistoryEvent) => void | Promise<unknown>;
 }
@@ -500,12 +500,20 @@ function CurtailmentHistory({
   const [currentSort, setCurrentSort] = useState<HistorySort | undefined>();
   const [currentPage, setCurrentPage] = useState(0);
   const [selectedDetailEventId, setSelectedDetailEventId] = useState<string>();
+  const [selectedStopEventId, setSelectedStopEventId] = useState<string>();
   const [pendingStopEventId, setPendingStopEventId] = useState<string>();
   const normalizedPageSize = getNormalizedPageSize(pageSize);
   const hasActiveFilters = selectedStatusFilters.length > 0;
   const selectedDetailEvent = useMemo(
     () => events.find((event) => event.id === selectedDetailEventId),
     [events, selectedDetailEventId],
+  );
+  const selectedStopEvent = useMemo(
+    () => events.find((event) => event.id === selectedStopEventId),
+    [events, selectedStopEventId],
+  );
+  const selectedStopEventIsStoppable = Boolean(
+    selectedStopEvent && isActiveStoppableEvent(selectedStopEvent, activeEventId),
   );
   const pendingStopEvent = useMemo(
     () => events.find((event) => event.id === pendingStopEventId),
@@ -562,10 +570,23 @@ function CurtailmentHistory({
 
   const handleDismissSummary = () => setSelectedDetailEventId(undefined);
 
-  const handleRequestStop = (event: CurtailmentHistoryEvent) => {
+  const handleOpenStopConfirmation = (event: CurtailmentHistoryEvent) => {
     if (!onStopActiveEvent || !isActiveStoppableEvent(event, activeEventId) || pendingStoppableEventId === event.id) {
       return;
     }
+
+    setSelectedStopEventId(event.id);
+  };
+
+  const handleDismissStopConfirmation = () => setSelectedStopEventId(undefined);
+
+  const handleConfirmStop = () => {
+    if (!selectedStopEvent || !onStopActiveEvent || !isActiveStoppableEvent(selectedStopEvent, activeEventId)) {
+      return;
+    }
+
+    const event = selectedStopEvent;
+    setSelectedStopEventId(undefined);
 
     const stopRequest = onStopActiveEvent(event);
 
@@ -589,7 +610,7 @@ function CurtailmentHistory({
 
   const handleStopSelectedDetailEvent =
     selectedDetailEvent && onStopActiveEvent && isActiveStoppableEvent(selectedDetailEvent, activeEventId)
-      ? () => handleRequestStop(selectedDetailEvent)
+      ? () => handleOpenStopConfirmation(selectedDetailEvent)
       : undefined;
 
   return (
@@ -652,7 +673,7 @@ function CurtailmentHistory({
                 event={event}
                 activeEventId={activeEventId}
                 onOpenSummary={handleOpenSummary}
-                onRequestStop={onStopActiveEvent ? handleRequestStop : undefined}
+                onRequestStop={onStopActiveEvent ? handleOpenStopConfirmation : undefined}
                 stopDisabled={event.id === pendingStoppableEventId}
               />
             ))}
@@ -705,6 +726,15 @@ function CurtailmentHistory({
           onManage={handleManageSelectedDetailEvent}
           onStop={handleStopSelectedDetailEvent}
           stopDisabled={selectedDetailEvent.id === pendingStoppableEventId}
+        />
+      ) : null}
+
+      {selectedStopEvent && selectedStopEventIsStoppable ? (
+        <CurtailmentStopConfirmationDialog
+          open
+          action="stopCurtailment"
+          onCancel={handleDismissStopConfirmation}
+          onConfirm={handleConfirmStop}
         />
       ) : null}
     </section>

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -47,9 +47,15 @@ interface CurtailmentHistoryProps {
   className?: string;
   onViewEvent?: (event: CurtailmentHistoryEvent) => void;
   /**
-   * Called from the detail modal after the operator reviews the active event.
-   * The parent owns persistence and any additional confirmation. Return a
-   * rejected promise to let this component re-enable retry controls.
+   * Called from the detail modal for the active non-terminal event. The parent
+   * owns opening the edit flow with the selected event's values.
+   */
+  onManageActiveEvent?: (event: CurtailmentHistoryEvent) => void;
+  /**
+   * Called when the operator requests a stop for the active event. The parent
+   * owns persistence and any additional confirmation. Return a promise only
+   * after an actual stop request starts; a rejected promise re-enables retry
+   * controls.
    */
   onStopActiveEvent?: (event: CurtailmentHistoryEvent) => void | Promise<unknown>;
 }
@@ -68,6 +74,7 @@ interface CurtailmentSummaryModalProps {
   event: CurtailmentHistoryEvent;
   open: boolean;
   onDismiss: () => void;
+  onManage?: () => void;
   onStop?: () => void;
   stopDisabled?: boolean;
 }
@@ -90,6 +97,7 @@ interface CurtailmentSummaryModalButton {
 
 const defaultPageSize = 50;
 const stoppableEventStates = new Set<CurtailmentEventState>(["pending", "active"]);
+const manageableEventStates = new Set<CurtailmentEventState>(["pending", "active", "restoring"]);
 const rowInteractiveElementSelector =
   'button, a, input, select, textarea, [role="button"], [role="link"], [data-interactive]';
 
@@ -287,6 +295,18 @@ function isActiveStoppableEvent(event: CurtailmentHistoryEvent, activeEventId?: 
   return event.id === activeEventId && stoppableEventStates.has(event.state);
 }
 
+function isActiveManageableEvent(event: CurtailmentHistoryEvent, activeEventId?: string): boolean {
+  return event.id === activeEventId && manageableEventStates.has(event.state);
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  if (value === null || (typeof value !== "object" && typeof value !== "function")) {
+    return false;
+  }
+
+  return typeof (value as { then?: unknown }).then === "function";
+}
+
 function getNormalizedPageSize(pageSize: number): number {
   return Number.isFinite(pageSize) && pageSize >= 1 ? Math.floor(pageSize) : defaultPageSize;
 }
@@ -322,6 +342,7 @@ function CurtailmentSummaryModal({
   event,
   open,
   onDismiss,
+  onManage,
   onStop,
   stopDisabled,
 }: CurtailmentSummaryModalProps): ReactElement {
@@ -329,17 +350,26 @@ function CurtailmentSummaryModal({
   const endedAt = formatDateTime(event.endedAt);
   const scheduledAt = formatDateTime(event.scheduledAt);
   const createdAt = formatDateTime(event.createdAt);
-  const buttons: CurtailmentSummaryModalButton[] = onStop
-    ? [
-        {
-          text: "Stop curtailment",
-          variant: variants.secondaryDanger,
-          onClick: onStop,
-          dismissModalOnClick: false,
-          disabled: stopDisabled,
-        },
-      ]
-    : [];
+  const buttons: CurtailmentSummaryModalButton[] = [];
+
+  if (onStop) {
+    buttons.push({
+      text: "Stop curtailment",
+      variant: variants.secondaryDanger,
+      onClick: onStop,
+      dismissModalOnClick: false,
+      disabled: stopDisabled,
+    });
+  }
+
+  if (onManage) {
+    buttons.push({
+      text: "Manage",
+      variant: variants.primary,
+      onClick: onManage,
+      dismissModalOnClick: false,
+    });
+  }
 
   return (
     <Modal
@@ -463,6 +493,7 @@ function CurtailmentHistory({
   pageSize = defaultPageSize,
   className,
   onViewEvent,
+  onManageActiveEvent,
   onStopActiveEvent,
 }: CurtailmentHistoryProps): ReactElement {
   const [selectedStatusFilters, setSelectedStatusFilters] = useState<CurtailmentEventState[]>([]);
@@ -529,30 +560,36 @@ function CurtailmentHistory({
     onViewEvent?.(event);
   };
 
-  const handleRequestStop = (event: CurtailmentHistoryEvent) => handleOpenSummary(event);
-
   const handleDismissSummary = () => setSelectedDetailEventId(undefined);
+
+  const handleRequestStop = (event: CurtailmentHistoryEvent) => {
+    if (!onStopActiveEvent || !isActiveStoppableEvent(event, activeEventId) || pendingStoppableEventId === event.id) {
+      return;
+    }
+
+    const stopRequest = onStopActiveEvent(event);
+
+    if (!isPromiseLike(stopRequest)) {
+      return;
+    }
+
+    setPendingStopEventId(event.id);
+    void Promise.resolve(stopRequest).catch(() => {
+      setPendingStopEventId((currentEventId) => (currentEventId === event.id ? undefined : currentEventId));
+    });
+  };
+
+  const handleManageSelectedDetailEvent =
+    selectedDetailEvent && onManageActiveEvent && isActiveManageableEvent(selectedDetailEvent, activeEventId)
+      ? () => {
+          setSelectedDetailEventId(undefined);
+          onManageActiveEvent(selectedDetailEvent);
+        }
+      : undefined;
+
   const handleStopSelectedDetailEvent =
     selectedDetailEvent && onStopActiveEvent && isActiveStoppableEvent(selectedDetailEvent, activeEventId)
-      ? () => {
-          if (pendingStoppableEventId === selectedDetailEvent.id) {
-            return;
-          }
-
-          setPendingStopEventId(selectedDetailEvent.id);
-          try {
-            void Promise.resolve(onStopActiveEvent(selectedDetailEvent)).catch(() => {
-              setPendingStopEventId((currentEventId) =>
-                currentEventId === selectedDetailEvent.id ? undefined : currentEventId,
-              );
-            });
-          } catch (error) {
-            setPendingStopEventId((currentEventId) =>
-              currentEventId === selectedDetailEvent.id ? undefined : currentEventId,
-            );
-            throw error;
-          }
-        }
+      ? () => handleRequestStop(selectedDetailEvent)
       : undefined;
 
   return (
@@ -665,6 +702,7 @@ function CurtailmentHistory({
           event={selectedDetailEvent}
           open
           onDismiss={handleDismissSummary}
+          onManage={handleManageSelectedDetailEvent}
           onStop={handleStopSelectedDetailEvent}
           stopDisabled={selectedDetailEvent.id === pendingStoppableEventId}
         />

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.stories.tsx
@@ -4,7 +4,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import CurtailmentStartModal, {
   type CurtailmentFormValues,
   type CurtailmentPlanPreview,
+  type CurtailmentStartModalMode,
 } from "@/protoFleet/features/energy/CurtailmentStartModal";
+import CurtailmentStopConfirmationDialog from "@/protoFleet/features/energy/CurtailmentStopConfirmationDialog";
 
 const meta = {
   title: "Proto Fleet/Energy/Plan Curtailment Modal",
@@ -17,10 +19,12 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof CurtailmentStartModal>;
-type ModalStoryProps = {
+
+interface ModalStoryProps {
   initialValues?: Partial<CurtailmentFormValues>;
+  mode?: CurtailmentStartModalMode;
   preview?: CurtailmentPlanPreview;
-};
+}
 
 const configuredValues: Partial<CurtailmentFormValues> = {
   targetKw: "40",
@@ -42,10 +46,32 @@ const preview: CurtailmentPlanPreview = {
 
 function ModalStory(props: ModalStoryProps): ReactElement {
   const [open, setOpen] = useState(true);
+  const [showStopDialog, setShowStopDialog] = useState(false);
+
+  function closeStopDialog(): void {
+    setShowStopDialog(false);
+  }
+
+  function handleConfirmStop(): void {
+    closeStopDialog();
+    setOpen(false);
+  }
 
   return (
     <div className="min-h-screen bg-surface-base">
-      <CurtailmentStartModal open={open} onDismiss={() => setOpen(false)} onSubmit={() => setOpen(false)} {...props} />
+      <CurtailmentStartModal
+        open={open}
+        onDismiss={() => setOpen(false)}
+        onSubmit={() => setOpen(false)}
+        {...props}
+        onStopCurtailment={props.mode === "edit" ? () => setShowStopDialog(true) : undefined}
+      />
+      <CurtailmentStopConfirmationDialog
+        open={showStopDialog}
+        action="stopCurtailment"
+        onCancel={closeStopDialog}
+        onConfirm={handleConfirmStop}
+      />
     </div>
   );
 }
@@ -57,4 +83,9 @@ export const Empty: Story = {
 export const WithPreview: Story = {
   name: "Fixed kW reduction preview",
   render: () => <ModalStory initialValues={configuredValues} preview={preview} />,
+};
+
+export const EditMode: Story = {
+  name: "Edit mode",
+  render: () => <ModalStory initialValues={configuredValues} preview={preview} mode="edit" />,
 };

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -35,13 +35,16 @@ vi.mock("@/protoFleet/features/energy/useCurtailmentPlanPreview", () => ({
 vi.mock("@/protoFleet/components/FullScreenTwoPaneModal", () => ({
   default: ({ title, isBusy, buttons, abovePanes, primaryPane, secondaryPane }: MockFullScreenTwoPaneModalProps) => (
     <div role="dialog" aria-label={title} data-busy={isBusy ? "true" : "false"}>
-      <button
-        type="button"
-        disabled={Boolean(buttons?.[0]?.loading || buttons?.[0]?.disabled)}
-        onClick={buttons?.[0]?.onClick}
-      >
-        {buttons?.[0]?.text}
-      </button>
+      {buttons?.map((button) => (
+        <button
+          key={button.text}
+          type="button"
+          disabled={Boolean(button.loading || button.disabled)}
+          onClick={button.onClick}
+        >
+          {button.text}
+        </button>
+      ))}
       <div data-testid="above-panes">{abovePanes}</div>
       <div data-testid="primary-pane">{primaryPane}</div>
       <div data-testid="secondary-pane">{secondaryPane}</div>
@@ -160,6 +163,65 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByRole("button", { name: /Racks\s+Select/ })).toBeEnabled();
     expect(screen.getByRole("button", { name: /Groups\s+Select/ })).toBeEnabled();
     expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeEnabled();
+  });
+
+  it("renders edit mode with prefilled values and save copy", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      mode: "edit",
+      initialValues: {
+        ...configuredValues,
+        includeMaintenance: false,
+      },
+      preview,
+    });
+
+    expect(screen.getByRole("dialog", { name: "Manage curtailment" })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Plan a curtailment" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Start curtailment" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Target reduction")).toHaveValue(40);
+    expect(screen.getByLabelText("Reason")).toHaveValue("Grid peak - ERCOT 4CP signal");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetKw: "40",
+        restoreBatchSize: "10",
+        restoreIntervalSec: "120",
+        reason: "Grid peak - ERCOT 4CP signal",
+      }),
+    );
+  });
+
+  it("renders a stop curtailment action in edit mode", async () => {
+    const user = userEvent.setup();
+    const onStopCurtailment = vi.fn();
+    const { onSubmit } = renderModal({
+      mode: "edit",
+      initialValues: {
+        ...configuredValues,
+        includeMaintenance: false,
+      },
+      onStopCurtailment,
+      preview,
+    });
+
+    expect(screen.getByRole("dialog", { name: "Manage curtailment" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Stop curtailment" }));
+
+    expect(onStopCurtailment).toHaveBeenCalledOnce();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not render the stop curtailment action while planning", () => {
+    renderModal({
+      onStopCurtailment: vi.fn(),
+    });
+
+    expect(screen.getByRole("dialog", { name: "Plan a curtailment" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Stop curtailment" })).not.toBeInTheDocument();
   });
 
   it("renders the API preview when preview props are not controlled", () => {

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -1,6 +1,8 @@
 import { type ReactElement, type ReactNode, useMemo, useState } from "react";
 
-import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
+import FullScreenTwoPaneModal, {
+  type FullScreenTwoPaneModalProps,
+} from "@/protoFleet/components/FullScreenTwoPaneModal";
 import TargetSelectButton, { getTargetButtonLabel } from "@/protoFleet/components/TargetSelectButton";
 import {
   getUnsupportedDeviceSetPreviewError,
@@ -22,6 +24,7 @@ export type CurtailmentScopeType = "wholeOrg" | "deviceSet" | "explicitMiners";
 export type ResponseProfileId = "customPlan";
 export type CurtailmentMode = "fixedKwReduction";
 export type MinerSelectionStrategy = "leastEfficientFirst";
+export type CurtailmentStartModalMode = "create" | "edit";
 
 export interface CurtailmentFormValues {
   scopeType: CurtailmentScopeType;
@@ -59,6 +62,12 @@ interface CurtailmentStartModalProps {
   open: boolean;
   onDismiss: () => void;
   onSubmit: (values: CurtailmentSubmitValues) => void;
+  /**
+   * Called from edit mode when the operator requests a curtailment stop. The
+   * parent owns confirmation and the stop-curtailment RPC.
+   */
+  onStopCurtailment?: () => void;
+  mode?: CurtailmentStartModalMode;
   initialValues?: Partial<CurtailmentFormValues>;
   errors?: CurtailmentFormErrors;
   preview?: CurtailmentPlanPreview;
@@ -355,6 +364,8 @@ function CurtailmentStartModalContent({
   open,
   onDismiss,
   onSubmit,
+  onStopCurtailment,
+  mode = "create",
   initialValues,
   errors,
   preview,
@@ -380,15 +391,21 @@ function CurtailmentStartModalContent({
     values,
     disabled: hasControlledPreview,
   });
-  const previewState: PreviewPaneProps = unsupportedDeviceSetPreviewError
-    ? { preview: undefined, previewError: unsupportedDeviceSetPreviewError, isPreviewLoading: false }
-    : hasControlledPreview
-      ? { preview, previewError, isPreviewLoading: false }
-      : apiPreview;
+  let previewState: PreviewPaneProps = apiPreview;
+
+  if (hasControlledPreview) {
+    previewState = { preview, previewError, isPreviewLoading: false };
+  }
+
+  if (unsupportedDeviceSetPreviewError) {
+    previewState = { preview: undefined, previewError: unsupportedDeviceSetPreviewError, isPreviewLoading: false };
+  }
+
   const hasBlockingValidationError =
     previewState.previewError !== undefined ||
     Object.keys(localErrors).length > 0 ||
     Object.keys(errors ?? {}).length > 0;
+  const isEditMode = mode === "edit";
   const selectedTargets = {
     racks: getSelectedDeviceSetIds(values, "racks"),
     groups: getSelectedDeviceSetIds(values, "groups"),
@@ -439,6 +456,25 @@ function CurtailmentStartModalContent({
     onSubmit(values);
   };
 
+  const buttons: NonNullable<FullScreenTwoPaneModalProps["buttons"]> = [];
+
+  if (isEditMode && onStopCurtailment) {
+    buttons.push({
+      text: "Stop curtailment",
+      variant: variants.secondaryDanger,
+      onClick: onStopCurtailment,
+      disabled: isSubmitting,
+    });
+  }
+
+  buttons.push({
+    text: isEditMode ? "Save" : "Start curtailment",
+    variant: variants.primary,
+    onClick: handleSubmit,
+    disabled: hasBlockingValidationError,
+    loading: isSubmitting,
+  });
+
   const confirmMaintenanceInclusion = () => {
     const nextValues = { ...values, includeMaintenance: true };
 
@@ -456,19 +492,11 @@ function CurtailmentStartModalContent({
     <>
       <FullScreenTwoPaneModal
         open={open}
-        title="Plan a curtailment"
-        closeAriaLabel="Close curtailment planner"
+        title={isEditMode ? "Manage curtailment" : "Plan a curtailment"}
+        closeAriaLabel={isEditMode ? "Close curtailment editor" : "Close curtailment planner"}
         onDismiss={onDismiss}
         isBusy={isSubmitting}
-        buttons={[
-          {
-            text: "Start curtailment",
-            variant: variants.primary,
-            onClick: handleSubmit,
-            disabled: hasBlockingValidationError,
-            loading: isSubmitting,
-          },
-        ]}
+        buttons={buttons}
         abovePanes={<div className="px-6 pb-6 laptop:hidden">{previewPane}</div>}
         primaryPane={
           <section className="flex flex-col gap-12 pr-6 pb-6 laptop:pr-10 laptop:pb-10">

--- a/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 
-import { Stop } from "@/shared/assets/icons";
+import { Power, Stop } from "@/shared/assets/icons";
 import { type ButtonVariant, variants } from "@/shared/components/Button";
 import Dialog, { DialogIcon } from "@/shared/components/Dialog";
 
@@ -18,23 +18,29 @@ interface StopDialogCopy {
   body: string;
   confirmText: string;
   confirmVariant: ButtonVariant;
+  icon: ReactElement;
+  iconIntent: "critical" | "success";
 }
 
 function getStopDialogCopy(action: CurtailmentStopConfirmationAction): StopDialogCopy {
   if (action === "restore") {
     return {
       title: "Restore power?",
-      body: "Restore will run in configured batches and keep schedules suppressed until every miner is restored.",
-      confirmText: "Restore",
+      body: "Restore miners in configured batches. Schedules stay suppressed until every miner is restored.",
+      confirmText: "Restore power",
       confirmVariant: variants.primary,
+      icon: <Power />,
+      iconIntent: "success",
     };
   }
 
   return {
     title: "Stop curtailment?",
-    body: "Restore will run in configured batches and keep schedules suppressed until the event leaves restoring.",
-    confirmText: "Start restore",
+    body: "Stop this curtailment and start restoring miners in configured batches. Schedules stay suppressed until the event leaves restoring.",
+    confirmText: "Confirm stop",
     confirmVariant: variants.danger,
+    icon: <Stop />,
+    iconIntent: "critical",
   };
 }
 
@@ -51,11 +57,7 @@ function CurtailmentStopConfirmationDialog({
       open={open}
       title={copy.title}
       onDismiss={onCancel}
-      icon={
-        <DialogIcon intent="critical">
-          <Stop />
-        </DialogIcon>
-      }
+      icon={<DialogIcon intent={copy.iconIntent}>{copy.icon}</DialogIcon>}
       buttons={[
         {
           text: "Cancel",

--- a/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.tsx
@@ -1,0 +1,77 @@
+import type { ReactElement } from "react";
+
+import { Stop } from "@/shared/assets/icons";
+import { type ButtonVariant, variants } from "@/shared/components/Button";
+import Dialog, { DialogIcon } from "@/shared/components/Dialog";
+
+export type CurtailmentStopConfirmationAction = "restore" | "stopCurtailment";
+
+interface CurtailmentStopConfirmationDialogProps {
+  open: boolean;
+  action: CurtailmentStopConfirmationAction;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+interface StopDialogCopy {
+  title: string;
+  body: string;
+  confirmText: string;
+  confirmVariant: ButtonVariant;
+}
+
+function getStopDialogCopy(action: CurtailmentStopConfirmationAction): StopDialogCopy {
+  if (action === "restore") {
+    return {
+      title: "Restore power?",
+      body: "Restore will run in configured batches and keep schedules suppressed until every miner is restored.",
+      confirmText: "Restore",
+      confirmVariant: variants.primary,
+    };
+  }
+
+  return {
+    title: "Stop curtailment?",
+    body: "Restore will run in configured batches and keep schedules suppressed until the event leaves restoring.",
+    confirmText: "Start restore",
+    confirmVariant: variants.danger,
+  };
+}
+
+function CurtailmentStopConfirmationDialog({
+  open,
+  action,
+  onCancel,
+  onConfirm,
+}: CurtailmentStopConfirmationDialogProps): ReactElement {
+  const copy = getStopDialogCopy(action);
+
+  return (
+    <Dialog
+      open={open}
+      title={copy.title}
+      onDismiss={onCancel}
+      icon={
+        <DialogIcon intent="critical">
+          <Stop />
+        </DialogIcon>
+      }
+      buttons={[
+        {
+          text: "Cancel",
+          variant: variants.secondary,
+          onClick: onCancel,
+        },
+        {
+          text: copy.confirmText,
+          variant: copy.confirmVariant,
+          onClick: onConfirm,
+        },
+      ]}
+    >
+      <div className="text-300 text-text-primary-70">{copy.body}</div>
+    </Dialog>
+  );
+}
+
+export default CurtailmentStopConfirmationDialog;


### PR DESCRIPTION
🤖 Created by my AI agent.

## Summary
- Add manage/edit actions for active curtailments from the status banner and history detail modal
- Update the curtailment modal for edit mode, including a stop-curtailment action and confirmation dialog
- Expand stories and tests around active curtailment manage and stop flows

## Test plan
- [ ] Open an active curtailment from the energy status banner and confirm Manage opens the edit modal
- [ ] Open active curtailment history details and confirm Manage and Stop curtailment behave correctly
- [ ] Confirm the updated curtailment stories render the create, edit, and stop-confirmation states

https://github.com/user-attachments/assets/921b3658-491d-40ff-aa66-7c10b66c9df2


Closes #293