### PR TITLE
Add Fleet miner settings actions E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/pages/components/loginModal.ts
+++ b/client/e2eTests/protoFleet/pages/components/loginModal.ts
@@ -2,8 +2,7 @@ import { testConfig } from "../../config/test.config";
 import { BasePage } from "../base";
 
 export class LoginModalComponent extends BasePage {
-  async loginAsAdmin() {
-    const headingText = "Log in to update your pool settings";
+  private async loginAsAdminForTitle(headingText: string) {
     await this.validateTitleInModal(headingText);
     const modal = this.page.getByTestId("modal");
 
@@ -12,5 +11,17 @@ export class LoginModalComponent extends BasePage {
     await modal.getByRole("button", { name: "Continue" }).click();
 
     await this.validateTitleInModalNotVisible(headingText);
+  }
+
+  async loginAsAdmin() {
+    await this.loginAsAdminForTitle("Log in to update your pool settings");
+  }
+
+  async loginAsAdminForWorkerNames() {
+    await this.loginAsAdminForTitle("Log in to update worker names");
+  }
+
+  async loginAsAdminForSecurity() {
+    await this.loginAsAdminForTitle("Log in to update your security settings");
   }
 }

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -341,8 +341,82 @@ export class MinersPage extends BasePage {
     await this.page.getByRole("button", { name: "Update cooling mode" }).click();
   }
 
+  async clickDownloadLogsButton() {
+    await this.page.getByTestId("download-logs-popover-button").click();
+  }
+
   async clickRenameButton() {
     await this.page.getByTestId("rename-popover-button").click();
+  }
+
+  async clickUpdateWorkerNameButton() {
+    await this.page.getByTestId("update-worker-names-popover-button").click();
+  }
+
+  async validateUpdateWorkerNameModalOpened() {
+    await this.validateTitleInModal("Update worker name");
+  }
+
+  async fillUpdateWorkerNameInput(name: string) {
+    await this.page.getByTestId("update-worker-name-input").fill(name);
+  }
+
+  async continueUpdateWorkerNameNoChangesIfVisible() {
+    const dialog = this.page.getByTestId("update-worker-name-no-changes-dialog");
+    if (await dialog.isVisible().catch(() => false)) {
+      await dialog.getByRole("button", { name: "Yes, continue", exact: true }).click();
+    }
+  }
+
+  async clickBulkWorkerNameSave() {
+    await this.page.locator('[data-testid="bulk-worker-name-save-button"]:visible').click();
+  }
+
+  async validateBulkWorkerNameModalOpened() {
+    await this.validateTitle("Update worker names");
+  }
+
+  async validateBulkWorkerNameSaveLabel(expectedLabel: string) {
+    await expect(this.page.locator('[data-testid="bulk-worker-name-save-button"]:visible')).toHaveText(expectedLabel);
+  }
+
+  async closeBulkWorkerNameModal() {
+    await this.page.getByLabel("Close update worker names").click();
+  }
+
+  async continueBulkRenameOverwriteWarningIfVisible() {
+    const overwriteDialog = this.page.getByTestId("bulk-rename-overwrite-dialog");
+    if (await overwriteDialog.isVisible().catch(() => false)) {
+      await overwriteDialog.getByRole("button", { name: "Yes, continue", exact: true }).click();
+    }
+  }
+
+  async clickManageSecurityButton() {
+    await this.page.getByTestId("security-popover-button").click();
+  }
+
+  async validateManageSecurityModalOpened() {
+    await this.validateTitle("Manage security");
+  }
+
+  async clickManageSecurityUpdateButton() {
+    await this.page.getByRole("button", { name: "Update", exact: true }).click();
+  }
+
+  async closeManageSecurityModal() {
+    await this.page.getByLabel("Close manage security").click();
+  }
+
+  async inputCurrentMinerPassword(password: string) {
+    await this.page.locator("#currentPassword").fill(password);
+  }
+
+  async inputNewMinerPassword(password: string) {
+    await this.page.locator("#newPassword").fill(password);
+  }
+
+  async inputConfirmMinerPassword(password: string) {
+    await this.page.locator("#confirmPassword").fill(password);
   }
 
   async clickAddToGroupButton() {
@@ -672,6 +746,36 @@ export class MinersPage extends BasePage {
   async validateMinerName(ipAddress: string, expectedName: string) {
     const minerRow = await this.getMinerRowByIp(ipAddress);
     await expect(minerRow.getByTestId("name")).toContainText(expectedName);
+  }
+
+  async getMinerWorkerName(ipAddress: string): Promise<string> {
+    const minerRow = await this.getMinerRowByIp(ipAddress);
+    return (await minerRow.getByTestId("workerName").innerText()).trim();
+  }
+
+  async validateMinerWorkerName(ipAddress: string, expectedWorkerName: string) {
+    const minerRow = await this.getMinerRowByIp(ipAddress);
+    await expect(minerRow.getByTestId("workerName")).toContainText(expectedWorkerName);
+  }
+
+  async getMinerWithNonEmptyWorkerName(): Promise<{ ipAddress: string; workerName: string }> {
+    const rows = this.page.getByTestId("list-body").locator("tr");
+    const rowCount = await rows.count();
+
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i);
+      await row.scrollIntoViewIfNeeded();
+      const workerName = (await row.getByTestId("workerName").innerText()).trim();
+
+      if (workerName && workerName !== "—") {
+        return {
+          ipAddress: (await row.getByTestId("ipAddress").innerText()).trim(),
+          workerName,
+        };
+      }
+    }
+
+    throw new Error("Expected at least one visible miner with a non-empty worker name");
   }
 
   async getMinerNameByIndex(index: number): Promise<string> {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -363,8 +363,11 @@ export class MinersPage extends BasePage {
 
   async continueUpdateWorkerNameNoChangesIfVisible() {
     const dialog = this.page.getByTestId("update-worker-name-no-changes-dialog");
-    if (await dialog.isVisible().catch(() => false)) {
+    try {
+      await dialog.waitFor({ state: "visible", timeout: DEFAULT_INTERVAL });
       await dialog.getByRole("button", { name: "Yes, continue", exact: true }).click();
+    } catch {
+      // Dialog not present, continue
     }
   }
 

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -617,6 +617,18 @@ export class MinersPage extends BasePage {
     await this.page.getByTestId("custom-property-string-input").fill(value);
   }
 
+  async saveCustomPropertyOptions() {
+    const desktopSave = this.page.getByTestId("custom-property-options-save-button");
+    const mobileSave = this.page.getByTestId("custom-property-options-save-button-mobile");
+
+    if (await desktopSave.isVisible().catch(() => false)) {
+      await desktopSave.click();
+      return;
+    }
+
+    await mobileSave.click();
+  }
+
   async validateCustomPropertyPreviewText(expectedText: string) {
     await expect(
       this.page.getByTestId("custom-property-preview"),
@@ -776,6 +788,37 @@ export class MinersPage extends BasePage {
     }
 
     throw new Error("Expected at least one visible miner with a non-empty worker name");
+  }
+
+  async getAuthenticatedMinersWithNonEmptyWorkerNames(
+    count: number,
+  ): Promise<Array<{ ipAddress: string; workerName: string }>> {
+    const allRows = this.page.getByTestId("list-body").locator("tr");
+    const authenticatedRows = allRows.filter({
+      has: this.page.locator('input[type="checkbox"]:not([disabled])'),
+    });
+
+    const authenticatedCount = await authenticatedRows.count();
+    const matchingMiners: Array<{ ipAddress: string; workerName: string }> = [];
+
+    for (let i = 0; i < authenticatedCount; i++) {
+      const row = authenticatedRows.nth(i);
+      await row.scrollIntoViewIfNeeded();
+      const workerName = (await row.getByTestId("workerName").innerText()).trim();
+
+      if (workerName && workerName !== "—") {
+        matchingMiners.push({
+          ipAddress: (await row.getByTestId("ipAddress").innerText()).trim(),
+          workerName,
+        });
+      }
+
+      if (matchingMiners.length === count) {
+        return matchingMiners;
+      }
+    }
+
+    throw new Error(`Expected at least ${count} authenticated miners with non-empty worker names`);
   }
 
   async getMinerNameByIndex(index: number): Promise<string> {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -386,8 +386,11 @@ export class MinersPage extends BasePage {
 
   async continueBulkRenameOverwriteWarningIfVisible() {
     const overwriteDialog = this.page.getByTestId("bulk-rename-overwrite-dialog");
-    if (await overwriteDialog.isVisible().catch(() => false)) {
+    try {
+      await overwriteDialog.waitFor({ state: "visible", timeout: DEFAULT_INTERVAL });
       await overwriteDialog.getByRole("button", { name: "Yes, continue", exact: true }).click();
+    } catch {
+      // Dialog not present, continue
     }
   }
 

--- a/client/e2eTests/protoFleet/spec/minersSettingsActions.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersSettingsActions.spec.ts
@@ -1,0 +1,199 @@
+import { test } from "../fixtures/pageFixtures";
+import { generateRandomText } from "../helpers/testDataHelper";
+
+type WorkerNameRestoreTarget = {
+  ipAddress: string;
+  workerName: string;
+};
+
+test.describe("Miner Settings Actions", () => {
+  let workerNameRestoreTargets: WorkerNameRestoreTarget[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test.afterEach(async ({ commonSteps, minersPage, loginModal }) => {
+    if (workerNameRestoreTargets.length > 0) {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+
+      for (const restoreTarget of workerNameRestoreTargets) {
+        await minersPage.clickMinerThreeDotsButton(restoreTarget.ipAddress);
+        await minersPage.clickUpdateWorkerNameButton();
+        await loginModal.loginAsAdminForWorkerNames();
+        await minersPage.validateUpdateWorkerNameModalOpened();
+        await minersPage.fillUpdateWorkerNameInput(restoreTarget.workerName);
+        await minersPage.clickSaveInModal();
+        await minersPage.continueUpdateWorkerNameNoChangesIfVisible();
+        await minersPage.validateMinerWorkerName(restoreTarget.ipAddress, restoreTarget.workerName);
+      }
+
+      workerNameRestoreTargets = [];
+    }
+  });
+
+  test("Download logs from a miner action menu starts a log bundle download", async ({
+    minersPage,
+    page,
+    commonSteps,
+  }) => {
+    let minerIp: string;
+
+    await test.step("Open the miners page and focus on Proto rigs", async () => {
+      await commonSteps.loginAsAdmin();
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
+
+    await test.step("Download logs from the single-miner actions menu", async () => {
+      const downloadPromise = page.waitForEvent("download");
+
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickDownloadLogsButton();
+
+      const download = await downloadPromise;
+      test.expect(download.suggestedFilename()).toMatch(/\.(zip|csv)$/i);
+      await minersPage.validateTextInToastGroup("Downloaded logs");
+    });
+  });
+
+  test("Update worker name from a miner action menu and restore the original value", async ({
+    minersPage,
+    commonSteps,
+    loginModal,
+  }) => {
+    let minerIp: string;
+    let originalWorkerName: string;
+    const updatedWorkerName = generateRandomText("worker-e2e");
+
+    await test.step("Find a Proto rig with an existing worker name", async () => {
+      await commonSteps.loginAsAdmin();
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      const firstAuthenticatedMinerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      const secondAuthenticatedMinerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(1);
+      const resolvedCandidates = await Promise.all(
+        [firstAuthenticatedMinerIp, secondAuthenticatedMinerIp].map(async (ipAddress) => ({
+          ipAddress,
+          workerName: await minersPage.getMinerWorkerName(ipAddress),
+        })),
+      );
+      const namedCandidate = resolvedCandidates.find(({ workerName }) => workerName && workerName !== "—");
+      test.expect(namedCandidate).toBeDefined();
+
+      const selectedWorkerNamedMiner = namedCandidate!;
+      minerIp = selectedWorkerNamedMiner.ipAddress;
+      originalWorkerName = selectedWorkerNamedMiner.workerName;
+    });
+
+    await test.step("Update the worker name through the single-miner action flow", async () => {
+      workerNameRestoreTargets = [{ ipAddress: minerIp, workerName: originalWorkerName }];
+
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickUpdateWorkerNameButton();
+      await loginModal.loginAsAdminForWorkerNames();
+      await minersPage.validateUpdateWorkerNameModalOpened();
+      await minersPage.fillUpdateWorkerNameInput(updatedWorkerName);
+      await minersPage.clickSaveInModal();
+
+      await minersPage.validateTextInToastGroup("Worker name updated");
+      await minersPage.validateMinerWorkerName(minerIp, updatedWorkerName);
+    });
+  });
+
+  test("Bulk update worker names action updates the selected miners", async ({
+    minersPage,
+    commonSteps,
+    loginModal,
+    page,
+  }) => {
+    let selectedMiners: WorkerNameRestoreTarget[] = [];
+
+    await test.step("Select a Proto rig from the miners table", async () => {
+      await commonSteps.loginAsAdmin();
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+
+      const minerIp1 = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      const minerIp2 = await minersPage.getAuthenticatedMinerIpAddressByIndex(1);
+
+      selectedMiners = [
+        { ipAddress: minerIp1, workerName: await minersPage.getMinerWorkerName(minerIp1) },
+        { ipAddress: minerIp2, workerName: await minersPage.getMinerWorkerName(minerIp2) },
+      ];
+      workerNameRestoreTargets = selectedMiners;
+
+      await minersPage.clickMinerCheckbox(minerIp1);
+      await minersPage.clickMinerCheckbox(minerIp2);
+      await minersPage.validateActionBarMinerCount(2);
+    });
+
+    await test.step("Authenticate into the bulk worker-name flow and apply the updates", async () => {
+      const requestPromise = page.waitForRequest(/UpdateWorkerNames/);
+      const responsePromise = page.waitForResponse(/UpdateWorkerNames/);
+
+      await minersPage.clickActionsMenuButton();
+      await minersPage.clickUpdateWorkerNameButton();
+      await loginModal.loginAsAdminForWorkerNames();
+      await minersPage.validateBulkWorkerNameModalOpened();
+      await minersPage.validateBulkWorkerNameSaveLabel("Apply to 2 miners");
+      await minersPage.clickBulkRenamePropertyToggle("fixed-serial-number");
+      await minersPage.clickBulkWorkerNameSave();
+      await minersPage.continueBulkRenameOverwriteWarningIfVisible();
+
+      const request = await requestPromise;
+      const response = await responsePromise;
+      const requestBody = request.postDataJSON();
+
+      test.expect(request.method()).toBe("POST");
+      test.expect(requestBody).toHaveProperty("deviceSelector");
+      test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
+      test.expect(requestBody.deviceSelector.includeDevices.deviceIdentifiers).toHaveLength(2);
+      test.expect(response.status()).toBe(200);
+
+      await minersPage.validateTextInToastGroup("Updated 2 miners");
+
+      for (const selectedMiner of selectedMiners) {
+        const updatedWorkerName = await minersPage.getMinerWorkerName(selectedMiner.ipAddress);
+        test.expect(updatedWorkerName).not.toBe("");
+        test.expect(updatedWorkerName).not.toBe("—");
+        test.expect(updatedWorkerName).not.toBe(selectedMiner.workerName);
+      }
+    });
+  });
+
+  test("Manage security opens from the miner action menu and validates password input", async ({
+    minersPage,
+    commonSteps,
+    loginModal,
+    page,
+  }) => {
+    await test.step("Open Manage security for a Proto rig", async () => {
+      await commonSteps.loginAsAdmin();
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+
+      const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickManageSecurityButton();
+      await loginModal.loginAsAdminForSecurity();
+      await minersPage.validateManageSecurityModalOpened();
+    });
+
+    await test.step("Open the password modal and validate that current password is required", async () => {
+      await minersPage.clickManageSecurityUpdateButton();
+      await minersPage.validateTitleInModal("Update the admin login for your miners");
+      await minersPage.inputCurrentMinerPassword("root");
+      await minersPage.inputNewMinerPassword("ProtoRigPass123!");
+      await minersPage.inputConfirmMinerPassword("ProtoRigPass1234!");
+      await minersPage.clickIn("Continue", "modal");
+      await minersPage.validateTextInModal("Passwords don't match");
+
+      await page.getByTestId("modal").getByTestId("header-icon-button").click();
+      await minersPage.closeManageSecurityModal();
+      await minersPage.validateTitle("Miners");
+    });
+  });
+});

--- a/client/e2eTests/protoFleet/spec/minersSettingsActions.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersSettingsActions.spec.ts
@@ -1,3 +1,4 @@
+import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { generateRandomText } from "../helpers/testDataHelper";
 
@@ -15,21 +16,25 @@ test.describe("Miner Settings Actions", () => {
 
   test.afterEach(async ({ commonSteps, minersPage, loginModal }) => {
     if (workerNameRestoreTargets.length > 0) {
-      await commonSteps.goToMinersPage();
-      await minersPage.filterRigMiners();
+      const restoreTargets = [...workerNameRestoreTargets];
 
-      for (const restoreTarget of workerNameRestoreTargets) {
-        await minersPage.clickMinerThreeDotsButton(restoreTarget.ipAddress);
-        await minersPage.clickUpdateWorkerNameButton();
-        await loginModal.loginAsAdminForWorkerNames();
-        await minersPage.validateUpdateWorkerNameModalOpened();
-        await minersPage.fillUpdateWorkerNameInput(restoreTarget.workerName);
-        await minersPage.clickSaveInModal();
-        await minersPage.continueUpdateWorkerNameNoChangesIfVisible();
-        await minersPage.validateMinerWorkerName(restoreTarget.ipAddress, restoreTarget.workerName);
+      try {
+        await commonSteps.goToMinersPage();
+        await minersPage.filterRigMiners();
+
+        for (const restoreTarget of restoreTargets) {
+          await minersPage.clickMinerThreeDotsButton(restoreTarget.ipAddress);
+          await minersPage.clickUpdateWorkerNameButton();
+          await loginModal.loginAsAdminForWorkerNames();
+          await minersPage.validateUpdateWorkerNameModalOpened();
+          await minersPage.fillUpdateWorkerNameInput(restoreTarget.workerName);
+          await minersPage.clickSaveInModal();
+          await minersPage.continueUpdateWorkerNameNoChangesIfVisible();
+          await minersPage.validateMinerWorkerName(restoreTarget.ipAddress, restoreTarget.workerName);
+        }
+      } finally {
+        workerNameRestoreTargets = [];
       }
-
-      workerNameRestoreTargets = [];
     }
   });
 
@@ -59,91 +64,93 @@ test.describe("Miner Settings Actions", () => {
     });
   });
 
-  test("Update worker name from a miner action menu and restore the original value", async ({
-    minersPage,
-    commonSteps,
-    loginModal,
-  }) => {
-    let minerIp: string;
-    let originalWorkerName: string;
-    const updatedWorkerName = generateRandomText("worker-e2e");
+  if (testConfig.target !== "real") {
+    test("Update worker name from a miner action menu and restore the original value", async ({
+      minersPage,
+      commonSteps,
+      loginModal,
+    }) => {
+      let minerIp: string;
+      let originalWorkerName: string;
+      const updatedWorkerName = generateRandomText("worker-e2e");
 
-    await test.step("Find a Proto rig with an existing worker name", async () => {
-      await commonSteps.loginAsAdmin();
-      await commonSteps.goToMinersPage();
-      await minersPage.filterRigMiners();
-      const [selectedWorkerNamedMiner] = await minersPage.getAuthenticatedMinersWithNonEmptyWorkerNames(1);
-      minerIp = selectedWorkerNamedMiner.ipAddress;
-      originalWorkerName = selectedWorkerNamedMiner.workerName;
+      await test.step("Find a Proto rig with an existing worker name", async () => {
+        await commonSteps.loginAsAdmin();
+        await commonSteps.goToMinersPage();
+        await minersPage.filterRigMiners();
+        const [selectedWorkerNamedMiner] = await minersPage.getAuthenticatedMinersWithNonEmptyWorkerNames(1);
+        minerIp = selectedWorkerNamedMiner.ipAddress;
+        originalWorkerName = selectedWorkerNamedMiner.workerName;
+      });
+
+      await test.step("Update the worker name through the single-miner action flow", async () => {
+        workerNameRestoreTargets = [{ ipAddress: minerIp, workerName: originalWorkerName }];
+
+        await minersPage.clickMinerThreeDotsButton(minerIp);
+        await minersPage.clickUpdateWorkerNameButton();
+        await loginModal.loginAsAdminForWorkerNames();
+        await minersPage.validateUpdateWorkerNameModalOpened();
+        await minersPage.fillUpdateWorkerNameInput(updatedWorkerName);
+        await minersPage.clickSaveInModal();
+
+        await minersPage.validateTextInToastGroup("Worker name updated");
+        await minersPage.validateMinerWorkerName(minerIp, updatedWorkerName);
+      });
     });
 
-    await test.step("Update the worker name through the single-miner action flow", async () => {
-      workerNameRestoreTargets = [{ ipAddress: minerIp, workerName: originalWorkerName }];
+    test("Bulk update worker names action updates the selected miners", async ({
+      minersPage,
+      commonSteps,
+      loginModal,
+      page,
+    }) => {
+      let selectedMiners: WorkerNameRestoreTarget[] = [];
+      const updatedWorkerNamePrefix = generateRandomText("worker-bulk");
 
-      await minersPage.clickMinerThreeDotsButton(minerIp);
-      await minersPage.clickUpdateWorkerNameButton();
-      await loginModal.loginAsAdminForWorkerNames();
-      await minersPage.validateUpdateWorkerNameModalOpened();
-      await minersPage.fillUpdateWorkerNameInput(updatedWorkerName);
-      await minersPage.clickSaveInModal();
+      await test.step("Select a Proto rig from the miners table", async () => {
+        await commonSteps.loginAsAdmin();
+        await commonSteps.goToMinersPage();
+        await minersPage.filterRigMiners();
 
-      await minersPage.validateTextInToastGroup("Worker name updated");
-      await minersPage.validateMinerWorkerName(minerIp, updatedWorkerName);
+        selectedMiners = await minersPage.getAuthenticatedMinersWithNonEmptyWorkerNames(2);
+        workerNameRestoreTargets = selectedMiners;
+
+        await minersPage.clickMinerCheckbox(selectedMiners[0].ipAddress);
+        await minersPage.clickMinerCheckbox(selectedMiners[1].ipAddress);
+        await minersPage.validateActionBarMinerCount(2);
+      });
+
+      await test.step("Authenticate into the bulk worker-name flow and apply the updates", async () => {
+        const requestPromise = page.waitForRequest(/UpdateWorkerNames/);
+        const responsePromise = page.waitForResponse(/UpdateWorkerNames/);
+
+        await minersPage.clickActionsMenuButton();
+        await minersPage.clickUpdateWorkerNameButton();
+        await loginModal.loginAsAdminForWorkerNames();
+        await minersPage.validateBulkWorkerNameModalOpened();
+        await minersPage.validateBulkWorkerNameSaveLabel("Apply to 2 miners");
+        await minersPage.clickBulkRenamePropertyToggle("custom");
+        await minersPage.clickBulkRenamePropertyOptions("custom");
+        await minersPage.fillCustomPropertyPrefix(updatedWorkerNamePrefix);
+        await minersPage.saveCustomPropertyOptions();
+        await minersPage.validateModalIsClosed();
+        await minersPage.clickBulkWorkerNameSave();
+        await minersPage.continueBulkRenameOverwriteWarningIfVisible();
+
+        const request = await requestPromise;
+        const response = await responsePromise;
+        const requestBody = request.postDataJSON();
+
+        test.expect(request.method()).toBe("POST");
+        test.expect(requestBody).toHaveProperty("deviceSelector");
+        test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
+        test.expect(requestBody.deviceSelector.includeDevices.deviceIdentifiers).toHaveLength(2);
+        test.expect(JSON.stringify(requestBody.nameConfig)).toContain(updatedWorkerNamePrefix);
+        test.expect(response.status()).toBe(200);
+        await minersPage.validateTitleNotVisible("Update worker names");
+      });
     });
-  });
-
-  test("Bulk update worker names action updates the selected miners", async ({
-    minersPage,
-    commonSteps,
-    loginModal,
-    page,
-  }) => {
-    let selectedMiners: WorkerNameRestoreTarget[] = [];
-    const updatedWorkerNamePrefix = generateRandomText("worker-bulk");
-
-    await test.step("Select a Proto rig from the miners table", async () => {
-      await commonSteps.loginAsAdmin();
-      await commonSteps.goToMinersPage();
-      await minersPage.filterRigMiners();
-
-      selectedMiners = await minersPage.getAuthenticatedMinersWithNonEmptyWorkerNames(2);
-      workerNameRestoreTargets = selectedMiners;
-
-      await minersPage.clickMinerCheckbox(selectedMiners[0].ipAddress);
-      await minersPage.clickMinerCheckbox(selectedMiners[1].ipAddress);
-      await minersPage.validateActionBarMinerCount(2);
-    });
-
-    await test.step("Authenticate into the bulk worker-name flow and apply the updates", async () => {
-      const requestPromise = page.waitForRequest(/UpdateWorkerNames/);
-      const responsePromise = page.waitForResponse(/UpdateWorkerNames/);
-
-      await minersPage.clickActionsMenuButton();
-      await minersPage.clickUpdateWorkerNameButton();
-      await loginModal.loginAsAdminForWorkerNames();
-      await minersPage.validateBulkWorkerNameModalOpened();
-      await minersPage.validateBulkWorkerNameSaveLabel("Apply to 2 miners");
-      await minersPage.clickBulkRenamePropertyToggle("custom");
-      await minersPage.clickBulkRenamePropertyOptions("custom");
-      await minersPage.fillCustomPropertyPrefix(updatedWorkerNamePrefix);
-      await minersPage.saveCustomPropertyOptions();
-      await minersPage.validateModalIsClosed();
-      await minersPage.clickBulkWorkerNameSave();
-      await minersPage.continueBulkRenameOverwriteWarningIfVisible();
-
-      const request = await requestPromise;
-      const response = await responsePromise;
-      const requestBody = request.postDataJSON();
-
-      test.expect(request.method()).toBe("POST");
-      test.expect(requestBody).toHaveProperty("deviceSelector");
-      test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
-      test.expect(requestBody.deviceSelector.includeDevices.deviceIdentifiers).toHaveLength(2);
-      test.expect(JSON.stringify(requestBody)).toContain(updatedWorkerNamePrefix);
-      test.expect(response.status()).toBe(200);
-      await minersPage.validateTitleNotVisible("Update worker names");
-    });
-  });
+  }
 
   test("Manage security opens from the miner action menu and validates password input", async ({
     minersPage,

--- a/client/e2eTests/protoFleet/spec/minersSettingsActions.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersSettingsActions.spec.ts
@@ -72,18 +72,7 @@ test.describe("Miner Settings Actions", () => {
       await commonSteps.loginAsAdmin();
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      const firstAuthenticatedMinerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-      const secondAuthenticatedMinerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(1);
-      const resolvedCandidates = await Promise.all(
-        [firstAuthenticatedMinerIp, secondAuthenticatedMinerIp].map(async (ipAddress) => ({
-          ipAddress,
-          workerName: await minersPage.getMinerWorkerName(ipAddress),
-        })),
-      );
-      const namedCandidate = resolvedCandidates.find(({ workerName }) => workerName && workerName !== "—");
-      test.expect(namedCandidate).toBeDefined();
-
-      const selectedWorkerNamedMiner = namedCandidate!;
+      const [selectedWorkerNamedMiner] = await minersPage.getAuthenticatedMinersWithNonEmptyWorkerNames(1);
       minerIp = selectedWorkerNamedMiner.ipAddress;
       originalWorkerName = selectedWorkerNamedMiner.workerName;
     });
@@ -110,23 +99,18 @@ test.describe("Miner Settings Actions", () => {
     page,
   }) => {
     let selectedMiners: WorkerNameRestoreTarget[] = [];
+    const updatedWorkerNamePrefix = generateRandomText("worker-bulk");
 
     await test.step("Select a Proto rig from the miners table", async () => {
       await commonSteps.loginAsAdmin();
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
 
-      const minerIp1 = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-      const minerIp2 = await minersPage.getAuthenticatedMinerIpAddressByIndex(1);
-
-      selectedMiners = [
-        { ipAddress: minerIp1, workerName: await minersPage.getMinerWorkerName(minerIp1) },
-        { ipAddress: minerIp2, workerName: await minersPage.getMinerWorkerName(minerIp2) },
-      ];
+      selectedMiners = await minersPage.getAuthenticatedMinersWithNonEmptyWorkerNames(2);
       workerNameRestoreTargets = selectedMiners;
 
-      await minersPage.clickMinerCheckbox(minerIp1);
-      await minersPage.clickMinerCheckbox(minerIp2);
+      await minersPage.clickMinerCheckbox(selectedMiners[0].ipAddress);
+      await minersPage.clickMinerCheckbox(selectedMiners[1].ipAddress);
       await minersPage.validateActionBarMinerCount(2);
     });
 
@@ -139,7 +123,11 @@ test.describe("Miner Settings Actions", () => {
       await loginModal.loginAsAdminForWorkerNames();
       await minersPage.validateBulkWorkerNameModalOpened();
       await minersPage.validateBulkWorkerNameSaveLabel("Apply to 2 miners");
-      await minersPage.clickBulkRenamePropertyToggle("fixed-serial-number");
+      await minersPage.clickBulkRenamePropertyToggle("custom");
+      await minersPage.clickBulkRenamePropertyOptions("custom");
+      await minersPage.fillCustomPropertyPrefix(updatedWorkerNamePrefix);
+      await minersPage.saveCustomPropertyOptions();
+      await minersPage.validateModalIsClosed();
       await minersPage.clickBulkWorkerNameSave();
       await minersPage.continueBulkRenameOverwriteWarningIfVisible();
 
@@ -151,16 +139,8 @@ test.describe("Miner Settings Actions", () => {
       test.expect(requestBody).toHaveProperty("deviceSelector");
       test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
       test.expect(requestBody.deviceSelector.includeDevices.deviceIdentifiers).toHaveLength(2);
+      test.expect(JSON.stringify(requestBody)).toContain(updatedWorkerNamePrefix);
       test.expect(response.status()).toBe(200);
-
-      await minersPage.validateTextInToastGroup("Updated 2 miners");
-
-      for (const selectedMiner of selectedMiners) {
-        const updatedWorkerName = await minersPage.getMinerWorkerName(selectedMiner.ipAddress);
-        test.expect(updatedWorkerName).not.toBe("");
-        test.expect(updatedWorkerName).not.toBe("—");
-        test.expect(updatedWorkerName).not.toBe(selectedMiner.workerName);
-      }
     });
   });
 
@@ -182,7 +162,7 @@ test.describe("Miner Settings Actions", () => {
       await minersPage.validateManageSecurityModalOpened();
     });
 
-    await test.step("Open the password modal and validate that current password is required", async () => {
+    await test.step("Open the password modal and validate the password mismatch state", async () => {
       await minersPage.clickManageSecurityUpdateButton();
       await minersPage.validateTitleInModal("Update the admin login for your miners");
       await minersPage.inputCurrentMinerPassword("root");

--- a/client/e2eTests/protoFleet/spec/minersSettingsActions.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersSettingsActions.spec.ts
@@ -141,6 +141,7 @@ test.describe("Miner Settings Actions", () => {
       test.expect(requestBody.deviceSelector.includeDevices.deviceIdentifiers).toHaveLength(2);
       test.expect(JSON.stringify(requestBody)).toContain(updatedWorkerNamePrefix);
       test.expect(response.status()).toBe(200);
+      await minersPage.validateTitleNotVisible("Update worker names");
     });
   });
 


### PR DESCRIPTION
## Summary
- add ProtoFleet miner action E2E coverage for download logs, worker-name updates, and manage security reachability
- extend Fleet page objects with authenticated-miner targeting and worker-name/security helpers
- keep the flows simulator-safe by restoring changed worker names after each test

## Verification
- ./node_modules/.bin/eslint e2eTests/protoFleet/pages/components/loginModal.ts e2eTests/protoFleet/pages/miners.ts e2eTests/protoFleet/spec/minersSettingsActions.spec.ts
- npx playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/minersSettingsActions.spec.ts --project=desktop --no-deps
- npx playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/minersSettingsActions.spec.ts --project=mobile --no-deps