### PR TITLE
feat(rbac): resolver + RequirePermission middleware (PR 2a of 4)

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -192,6 +192,8 @@ func start(config *Config) error {
 		return fmt.Errorf("reconcile built-in roles: %w", err)
 	}
 
+	permissionResolver := authz.NewPermissionResolver(conn)
+
 	transactor := sqlstores.NewSQLTransactor(conn)
 
 	encryptSvc, err := encrypt.NewService(&config.Encrypt)
@@ -475,7 +477,7 @@ func start(config *Config) error {
 		interceptors.NewErrorStackTraceLoggingInterceptor(config.Log.Level),
 		interceptors.NewRequestLoggingInterceptor(config.Log.Level, interceptors.RedactedRequestProcedures, interceptors.RedactedResponseProcedures),
 		interceptors.NewFleetNodeAuthInterceptor(fleetNodeAuthSvc, interceptors.FleetNodeAuthenticatedProcedures),
-		interceptors.NewAuthInterceptor(sessionSvc, userStore, userStore, apiKeySvc, interceptors.UnauthenticatedProcedures, interceptors.SessionOnlyProcedures, interceptors.FleetNodeAuthenticatedProcedures),
+		interceptors.NewAuthInterceptor(sessionSvc, userStore, userStore, apiKeySvc, permissionResolver, interceptors.UnauthenticatedProcedures, interceptors.SessionOnlyProcedures, interceptors.FleetNodeAuthenticatedProcedures),
 		validateInterceptor,
 	)
 

--- a/server/generated/sqlc/user_organization_role.sql.go
+++ b/server/generated/sqlc/user_organization_role.sql.go
@@ -275,15 +275,15 @@ SELECT
     uor.scope_id    AS scope_id,
     p.key           AS permission_key
 FROM user_organization_role uor
-JOIN role r             ON r.id = uor.role_id
-                       AND r.organization_id = uor.organization_id
-JOIN role_permission rp ON rp.role_id = r.id
-JOIN permission p       ON p.id = rp.permission_id
+JOIN role r              ON r.id = uor.role_id
+                        AND r.organization_id = uor.organization_id
+LEFT JOIN role_permission rp ON rp.role_id = r.id
+LEFT JOIN permission p       ON p.id = rp.permission_id
 WHERE uor.user_id = $1
   AND uor.organization_id = $2
   AND uor.deleted_at IS NULL
   AND r.deleted_at IS NULL
-ORDER BY uor.id, p.key
+ORDER BY uor.id, p.key NULLS FIRST
 `
 
 type ListEffectivePermissionsForUserParams struct {
@@ -296,17 +296,24 @@ type ListEffectivePermissionsForUserRow struct {
 	RoleID        int64
 	ScopeType     string
 	ScopeID       sql.NullInt64
-	PermissionKey string
+	PermissionKey sql.NullString
 }
 
-// Single-query resolver source: every (assignment_id, scope_type,
-// scope_id, permission_key) triple the user holds within an
-// organization. The resolver walks this slice to evaluate
-// Has(key, ResourceContext). Narrowing semantics: when the caller
-// has both org-scope and site-scope assignments, the site-scope
-// assignment overrides the org grant at that site; this slice
-// carries the scope on every row so the resolver can pick the
-// narrowest match without extra queries.
+// Single-query resolver source: one row per (assignment, permission)
+// pair the user holds within an organization, with a NULL permission
+// column when the assignment's role has no permissions attached.
+//
+// The LEFT JOIN on role_permission and permission is load-bearing for
+// the narrowing semantics: a site-scope assignment whose role grants
+// zero permissions must still surface in the resolver as a "site has
+// an assignment" marker. Without it, the resolver would not record
+// bySite[siteID] for that site, narrowing would collapse, and the
+// caller's org-scope grant would silently apply at the site the
+// empty role was meant to lock down.
+//
+// The resolver walks this slice to evaluate Has(key, ResourceContext)
+// with the plan's narrowing rule: site-scope assignment overrides the
+// org grant at that site; site-scope absence falls back to org-scope.
 func (q *Queries) ListEffectivePermissionsForUser(ctx context.Context, arg ListEffectivePermissionsForUserParams) ([]ListEffectivePermissionsForUserRow, error) {
 	rows, err := q.query(ctx, q.listEffectivePermissionsForUserStmt, listEffectivePermissionsForUser, arg.UserID, arg.OrganizationID)
 	if err != nil {

--- a/server/internal/domain/authz/backfill_test.go
+++ b/server/internal/domain/authz/backfill_test.go
@@ -396,6 +396,18 @@ func insertTestOrganization(t *testing.T, db *sql.DB) int64 {
 	return id
 }
 
+func insertTestSite(t *testing.T, db *sql.DB, orgID int64) int64 {
+	t.Helper()
+	var id int64
+	require.NoError(t,
+		db.QueryRowContext(t.Context(),
+			`INSERT INTO site (org_id, name) VALUES ($1, $2) RETURNING id`,
+			orgID, uniqueToken("site"),
+		).Scan(&id),
+	)
+	return id
+}
+
 func insertTestUser(t *testing.T, db *sql.DB) int64 {
 	t.Helper()
 	var id int64

--- a/server/internal/domain/authz/effective.go
+++ b/server/internal/domain/authz/effective.go
@@ -12,21 +12,14 @@ const (
 	ScopeSite ScopeType = "site"
 )
 
-// AssignmentRole carries the role identity needed at decision time.
-// BuiltinKey is set for SUPER_ADMIN/ADMIN/FIELD_TECH; it's empty for
-// custom roles. The role's id and name are not used by the resolver and
-// are deliberately omitted.
-type AssignmentRole struct {
-	BuiltinKey string
-}
-
 // Assignment is one row from user_organization_role joined against
 // role and role_permission, materialized as a flat in-memory value.
-// One Assignment carries the assignment's identity, scope, and the
-// set of permission keys its role grants.
+// Carries the assignment's identity, scope, and the set of permission
+// keys its role grants. Role identity (id, name, builtin_key) is not
+// needed at decision time and is deliberately omitted — the resolver
+// only consults permission_key + scope.
 type Assignment struct {
 	AssignmentID int64
-	Role         AssignmentRole
 	ScopeType    ScopeType
 	// SiteID is non-nil only when ScopeType is ScopeSite.
 	SiteID      *int64

--- a/server/internal/domain/authz/effective.go
+++ b/server/internal/domain/authz/effective.go
@@ -98,28 +98,14 @@ func NewEffectivePermissions(assignments []Assignment) *EffectivePermissions {
 
 // Has reports whether the user is allowed to perform the named action
 // against the given resource context. See the type doc for narrowing
-// semantics.
-//
-// Empty EffectivePermissions deny everything; this is the fail-closed
-// default the middleware relies on when the resolver returns no rows
-// (deactivated user, soft-deleted assignments, no rows in the join).
+// semantics. An empty / nil EffectivePermissions denies everything.
 func (e *EffectivePermissions) Has(key string, rc ResourceContext) bool {
 	if e == nil {
 		return false
 	}
-
 	if rc.SiteID == nil {
-		// Org-scoped action: only org-scope grants can satisfy it.
-		// Site-scope assignments have no site to "narrow on" for this
-		// request, so they cannot grant the action.
 		return e.orgScope[key]
 	}
-
-	// Site-scoped action. If the user has ANY site-scope assignment
-	// at this site, narrowing kicks in: only the union of site-scope
-	// permissions at this site is consulted; the org-scope grant is
-	// shadowed at this site. Otherwise (no site-scope assignment at
-	// this site), fall back to the org-scope grant.
 	if siteKeys, ok := e.bySite[*rc.SiteID]; ok {
 		return siteKeys[key]
 	}

--- a/server/internal/domain/authz/effective.go
+++ b/server/internal/domain/authz/effective.go
@@ -1,0 +1,160 @@
+package authz
+
+import "sort"
+
+// ScopeType is the assignment's scope discriminator. The DB column is a
+// VARCHAR with a CHECK constraint accepting only these two values;
+// building-scope is deferred to a follow-up plan.
+type ScopeType string
+
+const (
+	ScopeOrg  ScopeType = "org"
+	ScopeSite ScopeType = "site"
+)
+
+// AssignmentRole carries the role identity needed at decision time.
+// BuiltinKey is set for SUPER_ADMIN/ADMIN/FIELD_TECH; it's empty for
+// custom roles. The role's id and name are not used by the resolver and
+// are deliberately omitted.
+type AssignmentRole struct {
+	BuiltinKey string
+}
+
+// Assignment is one row from user_organization_role joined against
+// role and role_permission, materialized as a flat in-memory value.
+// One Assignment carries the assignment's identity, scope, and the
+// set of permission keys its role grants.
+type Assignment struct {
+	AssignmentID int64
+	Role         AssignmentRole
+	ScopeType    ScopeType
+	// SiteID is non-nil only when ScopeType is ScopeSite.
+	SiteID      *int64
+	Permissions []string
+}
+
+// ResourceContext is the per-request input to Has(). SiteID nil means
+// the action is org-scoped (e.g. user:manage); a non-nil SiteID is the
+// site the action targets. Building-level scoping is deferred; when it
+// lands, this struct gains a BuildingID field and Has() gains a third
+// containment level.
+type ResourceContext struct {
+	SiteID *int64
+}
+
+// EffectivePermissions is the per-request, immutable snapshot of one
+// user's authorization state within one organization. The resolver
+// builds it from a single DB query; the middleware queries it via
+// Has() to gate handler entry.
+//
+// Narrowing semantics: when a user holds both an org-scope and a
+// site-scope assignment in the same org, the site-scope assignment
+// overrides the org grant *at that site*. The org grant continues to
+// apply at every other site. This lets an admin grant broad org-level
+// access and then narrow a user at a specific site by adding a smaller
+// site-scoped role, without first removing the org-scoped assignment.
+// Org-scoped actions (no site context in the request) are never
+// shadowed by site-scope grants — there is no site key to narrow on.
+type EffectivePermissions struct {
+	// orgScope is the union of permission keys across every org-scope
+	// assignment the user holds in this org.
+	orgScope map[string]bool
+
+	// bySite[siteID] is the union of permission keys across every
+	// site-scope assignment the user holds at that site. The presence
+	// of a key in bySite[X] (even an empty inner map) indicates the
+	// user has at least one site-scope assignment at X, which is the
+	// narrowing trigger.
+	bySite map[int64]map[string]bool
+}
+
+// NewEffectivePermissions materializes an EffectivePermissions from a
+// slice of Assignment rows. The slice can come from the
+// ListEffectivePermissionsForUser sqlc query (grouped by assignment
+// id by the resolver) or from a hand-built test fixture.
+func NewEffectivePermissions(assignments []Assignment) *EffectivePermissions {
+	out := &EffectivePermissions{
+		orgScope: make(map[string]bool),
+		bySite:   make(map[int64]map[string]bool),
+	}
+	for _, a := range assignments {
+		switch a.ScopeType {
+		case ScopeOrg:
+			for _, k := range a.Permissions {
+				out.orgScope[k] = true
+			}
+		case ScopeSite:
+			if a.SiteID == nil {
+				// Defensive: the DB CHECK forbids this combination,
+				// but if a bad row somehow surfaces in-memory we skip
+				// it rather than crash. The triple is non-actionable.
+				continue
+			}
+			perms := out.bySite[*a.SiteID]
+			if perms == nil {
+				perms = make(map[string]bool)
+				out.bySite[*a.SiteID] = perms
+			}
+			for _, k := range a.Permissions {
+				perms[k] = true
+			}
+		}
+	}
+	return out
+}
+
+// Has reports whether the user is allowed to perform the named action
+// against the given resource context. See the type doc for narrowing
+// semantics.
+//
+// Empty EffectivePermissions deny everything; this is the fail-closed
+// default the middleware relies on when the resolver returns no rows
+// (deactivated user, soft-deleted assignments, no rows in the join).
+func (e *EffectivePermissions) Has(key string, rc ResourceContext) bool {
+	if e == nil {
+		return false
+	}
+
+	if rc.SiteID == nil {
+		// Org-scoped action: only org-scope grants can satisfy it.
+		// Site-scope assignments have no site to "narrow on" for this
+		// request, so they cannot grant the action.
+		return e.orgScope[key]
+	}
+
+	// Site-scoped action. If the user has ANY site-scope assignment
+	// at this site, narrowing kicks in: only the union of site-scope
+	// permissions at this site is consulted; the org-scope grant is
+	// shadowed at this site. Otherwise (no site-scope assignment at
+	// this site), fall back to the org-scope grant.
+	if siteKeys, ok := e.bySite[*rc.SiteID]; ok {
+		return siteKeys[key]
+	}
+	return e.orgScope[key]
+}
+
+// FlatKeys returns every distinct permission key the user holds across
+// every assignment, sorted lexicographically. UserInfo.permissions is
+// projected from this for the client's coarse "has the permission
+// anywhere" gating; the server still enforces scope via Has() on the
+// actual call.
+func (e *EffectivePermissions) FlatKeys() []string {
+	if e == nil {
+		return nil
+	}
+	seen := make(map[string]bool)
+	for k := range e.orgScope {
+		seen[k] = true
+	}
+	for _, siteKeys := range e.bySite {
+		for k := range siteKeys {
+			seen[k] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/server/internal/domain/authz/effective_test.go
+++ b/server/internal/domain/authz/effective_test.go
@@ -10,19 +10,17 @@ import (
 
 // scope helpers — concise builders to keep test tables readable.
 
-func orgScope(role authz.AssignmentRole, keys ...string) authz.Assignment {
+func orgScope(keys ...string) authz.Assignment {
 	return authz.Assignment{
 		AssignmentID: 1,
-		Role:         role,
 		ScopeType:    authz.ScopeOrg,
 		Permissions:  keys,
 	}
 }
 
-func siteScope(role authz.AssignmentRole, siteID int64, keys ...string) authz.Assignment {
+func siteScope(siteID int64, keys ...string) authz.Assignment {
 	return authz.Assignment{
 		AssignmentID: 2,
-		Role:         role,
 		ScopeType:    authz.ScopeSite,
 		SiteID:       &siteID,
 		Permissions:  keys,
@@ -37,7 +35,7 @@ func site(id int64) authz.ResourceContext { return authz.ResourceContext{SiteID:
 
 func TestEffective_OrgScopeAllowsEverywhere(t *testing.T) {
 	eff := authz.NewEffectivePermissions([]authz.Assignment{
-		orgScope(authz.AssignmentRole{BuiltinKey: "SUPER_ADMIN"}, authz.PermMinerReboot, authz.PermUserManage),
+		orgScope(authz.PermMinerReboot, authz.PermUserManage),
 	})
 
 	require.True(t, eff.Has(authz.PermMinerReboot, orgResource()), "org-scope grant satisfies org-scoped action")
@@ -47,7 +45,7 @@ func TestEffective_OrgScopeAllowsEverywhere(t *testing.T) {
 
 func TestEffective_SiteScopeOnlyAllowsAtThatSite(t *testing.T) {
 	eff := authz.NewEffectivePermissions([]authz.Assignment{
-		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1,
+		siteScope(1,
 			authz.PermFleetRead, authz.PermMinerBlinkLED),
 	})
 
@@ -63,7 +61,7 @@ func TestEffective_OrgScopedActionRequiresOrgScopeGrant(t *testing.T) {
 	// an org-scoped action — a site-scope grant cannot satisfy it because
 	// there's no site context to match against.
 	eff := authz.NewEffectivePermissions([]authz.Assignment{
-		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1, authz.PermUserManage),
+		siteScope(1, authz.PermUserManage),
 	})
 	require.False(t, eff.Has(authz.PermUserManage, orgResource()),
 		"org-scoped action is only satisfied by an org-scope assignment")
@@ -76,8 +74,8 @@ func TestEffective_NarrowingSiteScopeOverridesOrgScope(t *testing.T) {
 	// miner:reboot is denied at Site-A. At Site-B (no narrower
 	// assignment), the org grant applies and miner:reboot is allowed.
 	eff := authz.NewEffectivePermissions([]authz.Assignment{
-		orgScope(authz.AssignmentRole{BuiltinKey: "ADMIN"}, authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerReboot),
-		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1,
+		orgScope(authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerReboot),
+		siteScope(1,
 			authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerBlinkLED),
 	})
 
@@ -93,8 +91,8 @@ func TestEffective_NarrowingOrgScopeActionNotShadowed(t *testing.T) {
 	// Org-scoped actions (user:manage, role:manage) are never shadowed by
 	// site-scope assignments — there's no site context to "narrow" to.
 	eff := authz.NewEffectivePermissions([]authz.Assignment{
-		orgScope(authz.AssignmentRole{BuiltinKey: "ADMIN"}, authz.PermUserManage),
-		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1, authz.PermFleetRead),
+		orgScope(authz.PermUserManage),
+		siteScope(1, authz.PermFleetRead),
 	})
 	require.True(t, eff.Has(authz.PermUserManage, orgResource()),
 		"org-scope action is satisfied by the org-scope assignment regardless of site-scope rows")
@@ -104,9 +102,9 @@ func TestEffective_MultipleSiteAssignmentsUnionAtTheirOwnSites(t *testing.T) {
 	// User has ADMIN @ Site-A and FIELD_TECH @ Site-B (no org-scope row).
 	// miner:reboot is in ADMIN's seed but not FIELD_TECH's.
 	eff := authz.NewEffectivePermissions([]authz.Assignment{
-		siteScope(authz.AssignmentRole{BuiltinKey: "ADMIN"}, 1,
+		siteScope(1,
 			authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerReboot),
-		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 2,
+		siteScope(2,
 			authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerBlinkLED),
 	})
 
@@ -125,7 +123,7 @@ func TestEffective_EmptyAssignmentsDenyEverything(t *testing.T) {
 
 func TestEffective_UnknownPermissionDenied(t *testing.T) {
 	eff := authz.NewEffectivePermissions([]authz.Assignment{
-		orgScope(authz.AssignmentRole{BuiltinKey: "SUPER_ADMIN"}, authz.PermFleetRead),
+		orgScope(authz.PermFleetRead),
 	})
 	require.False(t, eff.Has("synthetic:not_in_catalog", orgResource()))
 }
@@ -135,8 +133,8 @@ func TestEffective_FlatPermissionsForUserInfo(t *testing.T) {
 	// permission keys across all assignments." Test that the projection is
 	// deterministic and dedupes.
 	eff := authz.NewEffectivePermissions([]authz.Assignment{
-		orgScope(authz.AssignmentRole{BuiltinKey: "ADMIN"}, authz.PermFleetRead, authz.PermMinerRead),
-		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1,
+		orgScope(authz.PermFleetRead, authz.PermMinerRead),
+		siteScope(1,
 			authz.PermFleetRead, authz.PermMinerBlinkLED),
 	})
 	got := eff.FlatKeys()
@@ -146,7 +144,7 @@ func TestEffective_FlatPermissionsForUserInfo(t *testing.T) {
 // FIELD_TECH on the AE (a tech can call BlinkLED but not Reboot).
 func TestEffective_FieldTechCanBlinkButNotReboot(t *testing.T) {
 	eff := authz.NewEffectivePermissions([]authz.Assignment{
-		orgScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"},
+		orgScope(
 			authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerBlinkLED,
 			authz.PermMinerDownloadLogs, authz.PermRackRead, authz.PermRackManage),
 	})

--- a/server/internal/domain/authz/effective_test.go
+++ b/server/internal/domain/authz/effective_test.go
@@ -1,0 +1,157 @@
+package authz_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+)
+
+// scope helpers — concise builders to keep test tables readable.
+
+func orgScope(role authz.AssignmentRole, keys ...string) authz.Assignment {
+	return authz.Assignment{
+		AssignmentID: 1,
+		Role:         role,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  keys,
+	}
+}
+
+func siteScope(role authz.AssignmentRole, siteID int64, keys ...string) authz.Assignment {
+	return authz.Assignment{
+		AssignmentID: 2,
+		Role:         role,
+		ScopeType:    authz.ScopeSite,
+		SiteID:       &siteID,
+		Permissions:  keys,
+	}
+}
+
+// orgResource returns a ResourceContext with no site (org-scoped action like user:manage).
+func orgResource() authz.ResourceContext { return authz.ResourceContext{} }
+
+// site returns a ResourceContext at the given site.
+func site(id int64) authz.ResourceContext { return authz.ResourceContext{SiteID: &id} }
+
+func TestEffective_OrgScopeAllowsEverywhere(t *testing.T) {
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.AssignmentRole{BuiltinKey: "SUPER_ADMIN"}, authz.PermMinerReboot, authz.PermUserManage),
+	})
+
+	require.True(t, eff.Has(authz.PermMinerReboot, orgResource()), "org-scope grant satisfies org-scoped action")
+	require.True(t, eff.Has(authz.PermMinerReboot, site(42)), "org-scope grant satisfies site-scoped action at any site")
+	require.True(t, eff.Has(authz.PermUserManage, orgResource()))
+}
+
+func TestEffective_SiteScopeOnlyAllowsAtThatSite(t *testing.T) {
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1,
+			authz.PermFleetRead, authz.PermMinerBlinkLED),
+	})
+
+	require.True(t, eff.Has(authz.PermMinerBlinkLED, site(1)))
+	require.False(t, eff.Has(authz.PermMinerBlinkLED, site(2)),
+		"site-scope grant must NOT satisfy a request at a different site")
+	require.False(t, eff.Has(authz.PermMinerBlinkLED, orgResource()),
+		"site-scope grant must NOT satisfy an org-scoped action (no site context)")
+}
+
+func TestEffective_OrgScopedActionRequiresOrgScopeGrant(t *testing.T) {
+	// FIELD_TECH at Site-A holds user:manage by some mistake. user:manage is
+	// an org-scoped action — a site-scope grant cannot satisfy it because
+	// there's no site context to match against.
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1, authz.PermUserManage),
+	})
+	require.False(t, eff.Has(authz.PermUserManage, orgResource()),
+		"org-scoped action is only satisfied by an org-scope assignment")
+}
+
+func TestEffective_NarrowingSiteScopeOverridesOrgScope(t *testing.T) {
+	// ADMIN at org-scope holds miner:reboot. FIELD_TECH at Site-A does NOT
+	// hold miner:reboot. The user has both assignments. Narrowing
+	// semantics: at Site-A, the site-scope assignment wins, so
+	// miner:reboot is denied at Site-A. At Site-B (no narrower
+	// assignment), the org grant applies and miner:reboot is allowed.
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.AssignmentRole{BuiltinKey: "ADMIN"}, authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerReboot),
+		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1,
+			authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerBlinkLED),
+	})
+
+	require.False(t, eff.Has(authz.PermMinerReboot, site(1)),
+		"narrowing: site-scope FIELD_TECH at Site-1 overrides org-scope ADMIN at that site")
+	require.True(t, eff.Has(authz.PermMinerReboot, site(2)),
+		"narrowing: org-scope ADMIN still applies at sites where there is no narrower assignment")
+	require.True(t, eff.Has(authz.PermMinerBlinkLED, site(1)),
+		"blink_led is in FIELD_TECH; both grants in effect at site 1 (union within the narrower one)")
+}
+
+func TestEffective_NarrowingOrgScopeActionNotShadowed(t *testing.T) {
+	// Org-scoped actions (user:manage, role:manage) are never shadowed by
+	// site-scope assignments — there's no site context to "narrow" to.
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.AssignmentRole{BuiltinKey: "ADMIN"}, authz.PermUserManage),
+		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1, authz.PermFleetRead),
+	})
+	require.True(t, eff.Has(authz.PermUserManage, orgResource()),
+		"org-scope action is satisfied by the org-scope assignment regardless of site-scope rows")
+}
+
+func TestEffective_MultipleSiteAssignmentsUnionAtTheirOwnSites(t *testing.T) {
+	// User has ADMIN @ Site-A and FIELD_TECH @ Site-B (no org-scope row).
+	// miner:reboot is in ADMIN's seed but not FIELD_TECH's.
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		siteScope(authz.AssignmentRole{BuiltinKey: "ADMIN"}, 1,
+			authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerReboot),
+		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 2,
+			authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerBlinkLED),
+	})
+
+	require.True(t, eff.Has(authz.PermMinerReboot, site(1)))
+	require.False(t, eff.Has(authz.PermMinerReboot, site(2)))
+	require.True(t, eff.Has(authz.PermMinerBlinkLED, site(2)))
+	require.False(t, eff.Has(authz.PermMinerBlinkLED, site(1)),
+		"ADMIN's seed does NOT include miner:blink_led")
+}
+
+func TestEffective_EmptyAssignmentsDenyEverything(t *testing.T) {
+	eff := authz.NewEffectivePermissions(nil)
+	require.False(t, eff.Has(authz.PermFleetRead, orgResource()))
+	require.False(t, eff.Has(authz.PermMinerBlinkLED, site(1)))
+}
+
+func TestEffective_UnknownPermissionDenied(t *testing.T) {
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.AssignmentRole{BuiltinKey: "SUPER_ADMIN"}, authz.PermFleetRead),
+	})
+	require.False(t, eff.Has("synthetic:not_in_catalog", orgResource()))
+}
+
+func TestEffective_FlatPermissionsForUserInfo(t *testing.T) {
+	// UserInfo.permissions is described in the plan as "the flat union of
+	// permission keys across all assignments." Test that the projection is
+	// deterministic and dedupes.
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.AssignmentRole{BuiltinKey: "ADMIN"}, authz.PermFleetRead, authz.PermMinerRead),
+		siteScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"}, 1,
+			authz.PermFleetRead, authz.PermMinerBlinkLED),
+	})
+	got := eff.FlatKeys()
+	require.Equal(t, []string{authz.PermFleetRead, authz.PermMinerBlinkLED, authz.PermMinerRead}, got)
+}
+
+// FIELD_TECH on the AE (a tech can call BlinkLED but not Reboot).
+func TestEffective_FieldTechCanBlinkButNotReboot(t *testing.T) {
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.AssignmentRole{BuiltinKey: "FIELD_TECH"},
+			authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerBlinkLED,
+			authz.PermMinerDownloadLogs, authz.PermRackRead, authz.PermRackManage),
+	})
+
+	require.True(t, eff.Has(authz.PermMinerBlinkLED, site(7)))
+	require.False(t, eff.Has(authz.PermMinerReboot, site(7)))
+	require.False(t, eff.Has(authz.PermUserManage, orgResource()))
+}

--- a/server/internal/domain/authz/effective_test.go
+++ b/server/internal/domain/authz/effective_test.go
@@ -115,6 +115,35 @@ func TestEffective_MultipleSiteAssignmentsUnionAtTheirOwnSites(t *testing.T) {
 		"ADMIN's seed does NOT include miner:blink_led")
 }
 
+// Codex security regression: an empty site-scope assignment (a role
+// with zero permissions) MUST narrow against the user's broader
+// org-scope grant at that site. Without recording bySite[siteID],
+// narrowing would collapse and the org grant would silently apply at
+// the site the empty role was meant to lock down.
+func TestEffective_ZeroPermissionSiteAssignmentStillNarrows(t *testing.T) {
+	siteOne := int64(1)
+	emptySite1 := authz.Assignment{
+		AssignmentID: 99,
+		ScopeType:    authz.ScopeSite,
+		SiteID:       &siteOne,
+		Permissions:  nil,
+	}
+
+	eff := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerReboot),
+		emptySite1,
+	})
+
+	require.False(t, eff.Has(authz.PermMinerReboot, site(1)),
+		"empty site-scope assignment at site 1 must narrow the user's org-scope grant there")
+	require.False(t, eff.Has(authz.PermFleetRead, site(1)),
+		"narrowing applies to every action key when the narrower assignment grants nothing")
+	require.True(t, eff.Has(authz.PermMinerReboot, site(2)),
+		"org grant still applies at site 2 — no narrower assignment there")
+	require.True(t, eff.Has(authz.PermMinerReboot, orgResource()),
+		"org-scope action satisfied by the org-scope ADMIN; site narrowing only applies to site-targeted requests")
+}
+
 func TestEffective_EmptyAssignmentsDenyEverything(t *testing.T) {
 	eff := authz.NewEffectivePermissions(nil)
 	require.False(t, eff.Has(authz.PermFleetRead, orgResource()))

--- a/server/internal/domain/authz/resolver.go
+++ b/server/internal/domain/authz/resolver.go
@@ -1,0 +1,90 @@
+package authz
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/block/proto-fleet/server/generated/sqlc"
+)
+
+// PermissionResolver computes the effective permission set for a
+// (user, organization) on each authenticated request. It runs one
+// query against the user_organization_role × role × role_permission
+// join and materializes the result into an EffectivePermissions value
+// the middleware can query via Has().
+//
+// One PermissionResolver is constructed at server boot and reused for
+// every request — it holds no per-request state.
+type PermissionResolver struct {
+	conn *sql.DB
+}
+
+// NewPermissionResolver wires the resolver to the application's
+// connection pool. The connection is used directly (not via the
+// transaction wrapper) because LoadEffective is a read-only single
+// query — the request middleware calls it before any handler work,
+// so there's no surrounding transaction to participate in.
+func NewPermissionResolver(conn *sql.DB) *PermissionResolver {
+	return &PermissionResolver{conn: conn}
+}
+
+// LoadEffective returns the user's full set of (role × scope ×
+// permission) grants within the given organization, materialized as
+// an EffectivePermissions value. Soft-deleted assignments and roles
+// are excluded by the underlying SQL.
+//
+// Returns an empty (non-nil) EffectivePermissions when the user has
+// no live assignments in the org. Has() on that empty value denies
+// everything, which is the correct fail-closed default for a
+// freshly-deactivated user or a user who was never in this org.
+func (r *PermissionResolver) LoadEffective(ctx context.Context, userID, organizationID int64) (*EffectivePermissions, error) {
+	rows, err := sqlc.New(r.conn).ListEffectivePermissionsForUser(ctx, sqlc.ListEffectivePermissionsForUserParams{
+		UserID:         userID,
+		OrganizationID: organizationID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("authz resolver: list effective permissions: %w", err)
+	}
+	return assignmentsFromRows(rows), nil
+}
+
+// assignmentsFromRows groups the flat (assignment_id, scope, permission_key)
+// rows the SQL returns into one Assignment per assignment_id, then
+// materializes the resulting slice into an EffectivePermissions. The
+// SQL ORDER BY uor.id makes the grouping streaming-friendly without
+// needing a map indirection here.
+func assignmentsFromRows(rows []sqlc.ListEffectivePermissionsForUserRow) *EffectivePermissions {
+	if len(rows) == 0 {
+		return NewEffectivePermissions(nil)
+	}
+
+	var (
+		assignments []Assignment
+		current     Assignment
+		started     bool
+	)
+	flush := func() {
+		if started {
+			assignments = append(assignments, current)
+		}
+	}
+	for _, row := range rows {
+		if !started || row.AssignmentID != current.AssignmentID {
+			flush()
+			current = Assignment{
+				AssignmentID: row.AssignmentID,
+				ScopeType:    ScopeType(row.ScopeType),
+			}
+			if row.ScopeID.Valid {
+				site := row.ScopeID.Int64
+				current.SiteID = &site
+			}
+			started = true
+		}
+		current.Permissions = append(current.Permissions, row.PermissionKey)
+	}
+	flush()
+
+	return NewEffectivePermissions(assignments)
+}

--- a/server/internal/domain/authz/resolver.go
+++ b/server/internal/domain/authz/resolver.go
@@ -49,11 +49,18 @@ func (r *PermissionResolver) LoadEffective(ctx context.Context, userID, organiza
 	return assignmentsFromRows(rows), nil
 }
 
-// assignmentsFromRows groups the flat (assignment_id, scope, permission_key)
-// rows the SQL returns into one Assignment per assignment_id, then
-// materializes the resulting slice into an EffectivePermissions. The
-// SQL ORDER BY uor.id makes the grouping streaming-friendly without
-// needing a map indirection here.
+// assignmentsFromRows groups the flat (assignment_id, scope,
+// permission_key) rows the SQL returns into one Assignment per
+// assignment_id, then materializes the resulting slice into an
+// EffectivePermissions. The SQL ORDER BY uor.id makes the grouping
+// streaming-friendly without needing a map indirection here.
+//
+// PermissionKey is nullable because the underlying query LEFT JOINs
+// role_permission and permission — a site-scope role with zero
+// permissions still produces one row so the resolver can record the
+// assignment's existence (and trigger narrowing) even though it
+// grants no actions. Rows with a NULL permission key contribute no
+// keys to the Assignment's Permissions slice.
 func assignmentsFromRows(rows []sqlc.ListEffectivePermissionsForUserRow) *EffectivePermissions {
 	if len(rows) == 0 {
 		return NewEffectivePermissions(nil)
@@ -82,7 +89,9 @@ func assignmentsFromRows(rows []sqlc.ListEffectivePermissionsForUserRow) *Effect
 			}
 			started = true
 		}
-		current.Permissions = append(current.Permissions, row.PermissionKey)
+		if row.PermissionKey.Valid {
+			current.Permissions = append(current.Permissions, row.PermissionKey.String)
+		}
 	}
 	flush()
 

--- a/server/internal/domain/authz/resolver.go
+++ b/server/internal/domain/authz/resolver.go
@@ -23,8 +23,7 @@ type PermissionResolver struct {
 // NewPermissionResolver wires the resolver to the application's
 // connection pool. The connection is used directly (not via the
 // transaction wrapper) because LoadEffective is a read-only single
-// query — the request middleware calls it before any handler work,
-// so there's no surrounding transaction to participate in.
+// query called per request, before any handler transaction begins.
 func NewPermissionResolver(conn *sql.DB) *PermissionResolver {
 	return &PermissionResolver{conn: conn}
 }
@@ -66,34 +65,33 @@ func assignmentsFromRows(rows []sqlc.ListEffectivePermissionsForUserRow) *Effect
 		return NewEffectivePermissions(nil)
 	}
 
-	var (
-		assignments []Assignment
-		current     Assignment
-		started     bool
-	)
-	flush := func() {
-		if started {
-			assignments = append(assignments, current)
-		}
-	}
+	assignments := []Assignment{newAssignmentFromRow(rows[0])}
 	for _, row := range rows {
-		if !started || row.AssignmentID != current.AssignmentID {
-			flush()
-			current = Assignment{
-				AssignmentID: row.AssignmentID,
-				ScopeType:    ScopeType(row.ScopeType),
-			}
-			if row.ScopeID.Valid {
-				site := row.ScopeID.Int64
-				current.SiteID = &site
-			}
-			started = true
+		current := &assignments[len(assignments)-1]
+		if row.AssignmentID != current.AssignmentID {
+			assignments = append(assignments, newAssignmentFromRow(row))
+			current = &assignments[len(assignments)-1]
 		}
 		if row.PermissionKey.Valid {
 			current.Permissions = append(current.Permissions, row.PermissionKey.String)
 		}
 	}
-	flush()
 
 	return NewEffectivePermissions(assignments)
+}
+
+// newAssignmentFromRow seeds an Assignment from a row's scope columns
+// only. The permission column is appended by the caller inside the
+// loop so the same code path handles both first-row and same-assignment
+// rows uniformly.
+func newAssignmentFromRow(row sqlc.ListEffectivePermissionsForUserRow) Assignment {
+	a := Assignment{
+		AssignmentID: row.AssignmentID,
+		ScopeType:    ScopeType(row.ScopeType),
+	}
+	if row.ScopeID.Valid {
+		site := row.ScopeID.Int64
+		a.SiteID = &site
+	}
+	return a
 }

--- a/server/internal/domain/authz/resolver_test.go
+++ b/server/internal/domain/authz/resolver_test.go
@@ -22,7 +22,7 @@ func TestResolver_OrgScopeSuperAdminGetsFullCatalog(t *testing.T) {
 	userID := insertTestUser(t, db)
 	require.NoError(t, authz.Reconcile(ctx, db))
 	superAdminID := getBuiltinRoleID(t, db, orgID, "SUPER_ADMIN")
-	assignAssignment(t, db, userID, orgID, superAdminID, "org", sql.NullInt64{})
+	assignAssignment(t, db, userID, orgID, superAdminID, authz.ScopeOrg, sql.NullInt64{})
 
 	resolver := authz.NewPermissionResolver(db)
 	eff, err := resolver.LoadEffective(ctx, userID, orgID)
@@ -54,7 +54,7 @@ func TestResolver_SiteScopeFieldTechBoundsAtAssignedSite(t *testing.T) {
 	userID := insertTestUser(t, db)
 	require.NoError(t, authz.Reconcile(ctx, db))
 	fieldTechID := getBuiltinRoleID(t, db, orgID, "FIELD_TECH")
-	assignAssignment(t, db, userID, orgID, fieldTechID, "site",
+	assignAssignment(t, db, userID, orgID, fieldTechID, authz.ScopeSite,
 		sql.NullInt64{Int64: siteA, Valid: true})
 
 	resolver := authz.NewPermissionResolver(db)
@@ -84,8 +84,8 @@ func TestResolver_NarrowingFromTwoAssignments(t *testing.T) {
 
 	adminID := getBuiltinRoleID(t, db, orgID, "ADMIN")
 	fieldTechID := getBuiltinRoleID(t, db, orgID, "FIELD_TECH")
-	assignAssignment(t, db, userID, orgID, adminID, "org", sql.NullInt64{})
-	assignAssignment(t, db, userID, orgID, fieldTechID, "site",
+	assignAssignment(t, db, userID, orgID, adminID, authz.ScopeOrg, sql.NullInt64{})
+	assignAssignment(t, db, userID, orgID, fieldTechID, authz.ScopeSite,
 		sql.NullInt64{Int64: siteA, Valid: true})
 
 	resolver := authz.NewPermissionResolver(db)
@@ -118,7 +118,7 @@ func TestResolver_ZeroPermissionSiteAssignmentStillNarrows(t *testing.T) {
 
 	// Org-scope ADMIN grants miner:reboot everywhere by default.
 	adminID := getBuiltinRoleID(t, db, orgID, "ADMIN")
-	assignAssignment(t, db, userID, orgID, adminID, "org", sql.NullInt64{})
+	assignAssignment(t, db, userID, orgID, adminID, authz.ScopeOrg, sql.NullInt64{})
 
 	// Create a custom role with zero permissions ("Site Lockdown")
 	// and assign it at site A. The LEFT JOIN in the resolver SQL must
@@ -126,7 +126,7 @@ func TestResolver_ZeroPermissionSiteAssignmentStillNarrows(t *testing.T) {
 	// it, narrowing at site A would silently fall back to ADMIN's
 	// miner:reboot.
 	lockdownID := createEmptyCustomRole(t, db, orgID, "Site Lockdown")
-	assignAssignment(t, db, userID, orgID, lockdownID, "site",
+	assignAssignment(t, db, userID, orgID, lockdownID, authz.ScopeSite,
 		sql.NullInt64{Int64: siteA, Valid: true})
 
 	resolver := authz.NewPermissionResolver(db)
@@ -154,7 +154,7 @@ func TestResolver_SoftDeletedAssignmentIgnored(t *testing.T) {
 	userID := insertTestUser(t, db)
 	require.NoError(t, authz.Reconcile(ctx, db))
 	adminID := getBuiltinRoleID(t, db, orgID, "ADMIN")
-	assignmentID := assignAssignment(t, db, userID, orgID, adminID, "org", sql.NullInt64{})
+	assignmentID := assignAssignment(t, db, userID, orgID, adminID, authz.ScopeOrg, sql.NullInt64{})
 
 	resolver := authz.NewPermissionResolver(db)
 	eff, err := resolver.LoadEffective(ctx, userID, orgID)
@@ -197,25 +197,13 @@ func siteCtx(id int64) authz.ResourceContext {
 	return authz.ResourceContext{SiteID: &id}
 }
 
-func insertTestSite(t *testing.T, db *sql.DB, orgID int64) int64 {
-	t.Helper()
-	var id int64
-	require.NoError(t,
-		db.QueryRowContext(t.Context(),
-			`INSERT INTO site (org_id, name) VALUES ($1, $2) RETURNING id`,
-			orgID, uniqueToken("site"),
-		).Scan(&id),
-	)
-	return id
-}
-
-func assignAssignment(t *testing.T, db *sql.DB, userID, orgID, roleID int64, scopeType string, scopeID sql.NullInt64) int64 {
+func assignAssignment(t *testing.T, db *sql.DB, userID, orgID, roleID int64, scopeType authz.ScopeType, scopeID sql.NullInt64) int64 {
 	t.Helper()
 	row, err := sqlc.New(db).AssignRole(t.Context(), sqlc.AssignRoleParams{
 		UserID:         userID,
 		OrganizationID: orgID,
 		RoleID:         roleID,
-		ScopeType:      scopeType,
+		ScopeType:      string(scopeType),
 		ScopeID:        scopeID,
 	})
 	require.NoError(t, err)

--- a/server/internal/domain/authz/resolver_test.go
+++ b/server/internal/domain/authz/resolver_test.go
@@ -101,6 +101,48 @@ func TestResolver_NarrowingFromTwoAssignments(t *testing.T) {
 }
 
 // Soft-deleted assignment is excluded by the SQL.
+// Codex security regression (PR 2a HIGH): a site-scope role with
+// zero permissions must still narrow the user's broader org-scope
+// grant at that site. The earlier resolver used an INNER JOIN to
+// role_permission and dropped rows for empty roles, which silently
+// collapsed narrowing back to the org grant.
+func TestResolver_ZeroPermissionSiteAssignmentStillNarrows(t *testing.T) {
+	db := testutil.GetTestDB(t)
+	ctx := t.Context()
+
+	orgID := insertTestOrganization(t, db)
+	siteA := insertTestSite(t, db, orgID)
+	siteB := insertTestSite(t, db, orgID)
+	userID := insertTestUser(t, db)
+	require.NoError(t, authz.Reconcile(ctx, db))
+
+	// Org-scope ADMIN grants miner:reboot everywhere by default.
+	adminID := getBuiltinRoleID(t, db, orgID, "ADMIN")
+	assignAssignment(t, db, userID, orgID, adminID, "org", sql.NullInt64{})
+
+	// Create a custom role with zero permissions ("Site Lockdown")
+	// and assign it at site A. The LEFT JOIN in the resolver SQL must
+	// surface this assignment even though it grants nothing — without
+	// it, narrowing at site A would silently fall back to ADMIN's
+	// miner:reboot.
+	lockdownID := createEmptyCustomRole(t, db, orgID, "Site Lockdown")
+	assignAssignment(t, db, userID, orgID, lockdownID, "site",
+		sql.NullInt64{Int64: siteA, Valid: true})
+
+	resolver := authz.NewPermissionResolver(db)
+	eff, err := resolver.LoadEffective(ctx, userID, orgID)
+	require.NoError(t, err)
+
+	require.False(t, eff.Has(authz.PermMinerReboot, siteCtx(siteA)),
+		"empty site-scope role at site A must narrow org-scope ADMIN there")
+	require.False(t, eff.Has(authz.PermFleetRead, siteCtx(siteA)),
+		"narrowing applies to every action key when the narrower role grants nothing")
+	require.True(t, eff.Has(authz.PermMinerReboot, siteCtx(siteB)),
+		"org grant still applies at site B (no narrower assignment)")
+	require.True(t, eff.Has(authz.PermUserManage, authz.ResourceContext{}),
+		"org-scoped action satisfied by the org-scope ADMIN")
+}
+
 func TestResolver_SoftDeletedAssignmentIgnored(t *testing.T) {
 	db := testutil.GetTestDB(t)
 	ctx := t.Context()
@@ -175,4 +217,18 @@ func assignAssignment(t *testing.T, db *sql.DB, userID, orgID, roleID int64, sco
 	})
 	require.NoError(t, err)
 	return row.ID
+}
+
+// createEmptyCustomRole creates a custom role with zero permissions
+// attached. Used by the narrowing regression test to exercise the
+// LEFT JOIN path that surfaces empty-role assignments.
+func createEmptyCustomRole(t *testing.T, db *sql.DB, orgID int64, name string) int64 {
+	t.Helper()
+	id, err := sqlc.New(db).UpsertCustomRoleForOrg(t.Context(), sqlc.UpsertCustomRoleForOrgParams{
+		Name:           name,
+		Description:    sql.NullString{String: "no perms — narrowing lockdown", Valid: true},
+		OrganizationID: sql.NullInt64{Int64: orgID, Valid: true},
+	})
+	require.NoError(t, err)
+	return id
 }

--- a/server/internal/domain/authz/resolver_test.go
+++ b/server/internal/domain/authz/resolver_test.go
@@ -139,7 +139,10 @@ func TestResolver_ZeroPermissionSiteAssignmentStillNarrows(t *testing.T) {
 		"narrowing applies to every action key when the narrower role grants nothing")
 	require.True(t, eff.Has(authz.PermMinerReboot, siteCtx(siteB)),
 		"org grant still applies at site B (no narrower assignment)")
-	require.True(t, eff.Has(authz.PermUserManage, authz.ResourceContext{}),
+	// site:manage is in ADMIN's seed formula (AllPermissions() minus
+	// user:* and role:manage); the org-scope grant must satisfy this
+	// org-scoped action regardless of the empty site-scope assignment.
+	require.True(t, eff.Has(authz.PermSiteManage, authz.ResourceContext{}),
 		"org-scoped action satisfied by the org-scope ADMIN")
 }
 

--- a/server/internal/domain/authz/resolver_test.go
+++ b/server/internal/domain/authz/resolver_test.go
@@ -1,0 +1,178 @@
+package authz_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/generated/sqlc"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/testutil"
+)
+
+// End-to-end resolver integration: seed an org, assign a user to its
+// SUPER_ADMIN, then load the effective set and assert it contains the
+// full catalog at org scope.
+func TestResolver_OrgScopeSuperAdminGetsFullCatalog(t *testing.T) {
+	db := testutil.GetTestDB(t)
+	ctx := t.Context()
+
+	orgID := insertTestOrganization(t, db)
+	userID := insertTestUser(t, db)
+	require.NoError(t, authz.Reconcile(ctx, db))
+	superAdminID := getBuiltinRoleID(t, db, orgID, "SUPER_ADMIN")
+	assignAssignment(t, db, userID, orgID, superAdminID, "org", sql.NullInt64{})
+
+	resolver := authz.NewPermissionResolver(db)
+	eff, err := resolver.LoadEffective(ctx, userID, orgID)
+	require.NoError(t, err)
+
+	// Spot-check a handful of catalog keys including org-scoped and
+	// site-scoped actions. Comprehensive coverage lives in the
+	// EffectivePermissions unit tests.
+	for _, key := range []string{
+		authz.PermFleetRead,
+		authz.PermMinerReboot,
+		authz.PermUserManage,
+		authz.PermRoleManage,
+	} {
+		require.True(t, eff.Has(key, authz.ResourceContext{}), "SUPER_ADMIN must hold %q at org scope", key)
+	}
+	require.True(t, eff.Has(authz.PermMinerReboot, siteCtx(42)),
+		"org-scope SUPER_ADMIN must allow miner:reboot at any site")
+}
+
+// FIELD_TECH at a single site: site-scoped grants stop at that site.
+func TestResolver_SiteScopeFieldTechBoundsAtAssignedSite(t *testing.T) {
+	db := testutil.GetTestDB(t)
+	ctx := t.Context()
+
+	orgID := insertTestOrganization(t, db)
+	siteA := insertTestSite(t, db, orgID)
+	siteB := insertTestSite(t, db, orgID)
+	userID := insertTestUser(t, db)
+	require.NoError(t, authz.Reconcile(ctx, db))
+	fieldTechID := getBuiltinRoleID(t, db, orgID, "FIELD_TECH")
+	assignAssignment(t, db, userID, orgID, fieldTechID, "site",
+		sql.NullInt64{Int64: siteA, Valid: true})
+
+	resolver := authz.NewPermissionResolver(db)
+	eff, err := resolver.LoadEffective(ctx, userID, orgID)
+	require.NoError(t, err)
+
+	require.True(t, eff.Has(authz.PermMinerBlinkLED, siteCtx(siteA)),
+		"FIELD_TECH at site A should be able to blink LED at site A")
+	require.False(t, eff.Has(authz.PermMinerBlinkLED, siteCtx(siteB)),
+		"FIELD_TECH at site A must NOT have permissions at site B")
+	require.False(t, eff.Has(authz.PermUserManage, authz.ResourceContext{}),
+		"FIELD_TECH never gets user:manage; not in their seed")
+}
+
+// Narrowing end-to-end: org-scope ADMIN + site-scope FIELD_TECH at
+// site A means miner:reboot is denied at site A (narrowing) but
+// allowed at site B (org grant uncovered).
+func TestResolver_NarrowingFromTwoAssignments(t *testing.T) {
+	db := testutil.GetTestDB(t)
+	ctx := t.Context()
+
+	orgID := insertTestOrganization(t, db)
+	siteA := insertTestSite(t, db, orgID)
+	siteB := insertTestSite(t, db, orgID)
+	userID := insertTestUser(t, db)
+	require.NoError(t, authz.Reconcile(ctx, db))
+
+	adminID := getBuiltinRoleID(t, db, orgID, "ADMIN")
+	fieldTechID := getBuiltinRoleID(t, db, orgID, "FIELD_TECH")
+	assignAssignment(t, db, userID, orgID, adminID, "org", sql.NullInt64{})
+	assignAssignment(t, db, userID, orgID, fieldTechID, "site",
+		sql.NullInt64{Int64: siteA, Valid: true})
+
+	resolver := authz.NewPermissionResolver(db)
+	eff, err := resolver.LoadEffective(ctx, userID, orgID)
+	require.NoError(t, err)
+
+	require.False(t, eff.Has(authz.PermMinerReboot, siteCtx(siteA)),
+		"narrowing: site-scope FIELD_TECH at site A overrides org-scope ADMIN there")
+	require.True(t, eff.Has(authz.PermMinerReboot, siteCtx(siteB)),
+		"narrowing: org-scope ADMIN still applies at site B (no narrower assignment)")
+	require.True(t, eff.Has(authz.PermMinerReboot, authz.ResourceContext{}),
+		"org-scope action satisfied by the org-scope ADMIN")
+}
+
+// Soft-deleted assignment is excluded by the SQL.
+func TestResolver_SoftDeletedAssignmentIgnored(t *testing.T) {
+	db := testutil.GetTestDB(t)
+	ctx := t.Context()
+
+	orgID := insertTestOrganization(t, db)
+	userID := insertTestUser(t, db)
+	require.NoError(t, authz.Reconcile(ctx, db))
+	adminID := getBuiltinRoleID(t, db, orgID, "ADMIN")
+	assignmentID := assignAssignment(t, db, userID, orgID, adminID, "org", sql.NullInt64{})
+
+	resolver := authz.NewPermissionResolver(db)
+	eff, err := resolver.LoadEffective(ctx, userID, orgID)
+	require.NoError(t, err)
+	require.True(t, eff.Has(authz.PermMinerReboot, authz.ResourceContext{}),
+		"ADMIN holds miner:reboot before soft-delete")
+
+	require.NoError(t, sqlc.New(db).UnassignRole(ctx, assignmentID))
+	eff, err = resolver.LoadEffective(ctx, userID, orgID)
+	require.NoError(t, err)
+	require.False(t, eff.Has(authz.PermMinerReboot, authz.ResourceContext{}),
+		"soft-deleted assignment must be ignored by the resolver")
+}
+
+// A user with no assignments in the org gets a non-nil empty value
+// that denies everything — the fail-closed default for a deactivated
+// user or a user who was never in this org.
+func TestResolver_NoAssignmentsReturnsEmptyDenyAll(t *testing.T) {
+	db := testutil.GetTestDB(t)
+	ctx := t.Context()
+
+	orgID := insertTestOrganization(t, db)
+	userID := insertTestUser(t, db)
+	require.NoError(t, authz.Reconcile(ctx, db))
+
+	resolver := authz.NewPermissionResolver(db)
+	eff, err := resolver.LoadEffective(ctx, userID, orgID)
+	require.NoError(t, err)
+	require.NotNil(t, eff)
+	require.False(t, eff.Has(authz.PermFleetRead, authz.ResourceContext{}))
+	require.False(t, eff.Has(authz.PermMinerBlinkLED, siteCtx(1)))
+	require.Empty(t, eff.FlatKeys())
+}
+
+// ---------------------------------------------------------------
+// helpers (test-only)
+// ---------------------------------------------------------------
+
+func siteCtx(id int64) authz.ResourceContext {
+	return authz.ResourceContext{SiteID: &id}
+}
+
+func insertTestSite(t *testing.T, db *sql.DB, orgID int64) int64 {
+	t.Helper()
+	var id int64
+	require.NoError(t,
+		db.QueryRowContext(t.Context(),
+			`INSERT INTO site (org_id, name) VALUES ($1, $2) RETURNING id`,
+			orgID, uniqueToken("site"),
+		).Scan(&id),
+	)
+	return id
+}
+
+func assignAssignment(t *testing.T, db *sql.DB, userID, orgID, roleID int64, scopeType string, scopeID sql.NullInt64) int64 {
+	t.Helper()
+	row, err := sqlc.New(db).AssignRole(t.Context(), sqlc.AssignRoleParams{
+		UserID:         userID,
+		OrganizationID: orgID,
+		RoleID:         roleID,
+		ScopeType:      scopeType,
+		ScopeID:        scopeID,
+	})
+	require.NoError(t, err)
+	return row.ID
+}

--- a/server/internal/handlers/interceptors/authentication.go
+++ b/server/internal/handlers/interceptors/authentication.go
@@ -184,8 +184,6 @@ func (i *AuthInterceptor) authenticateWithApiKey(ctx context.Context, authHeader
 		return ctx, classifyLookupError(err, "api key auth: role lookup failed", userID)
 	}
 
-	i.apiKeyService.RecordSuccessfulUse(ctx, apiKeyRecord)
-
 	info := &session.Info{
 		AuthMethod:     session.AuthMethodAPIKey,
 		APIKeyID:       apiKeyRecord.KeyID,
@@ -196,7 +194,18 @@ func (i *AuthInterceptor) authenticateWithApiKey(ctx context.Context, authHeader
 		Role:           roleName,
 	}
 
-	return i.loadEffectivePermissions(ctx, info)
+	authedCtx, err := i.loadEffectivePermissions(ctx, info)
+	if err != nil {
+		return ctx, err
+	}
+
+	// Only credit the key with a successful use once authentication is
+	// fully resolved. Resolver failures (DB error, nil wiring) reject
+	// the request, and recording success in that case would let the
+	// last_used_at telemetry report rejected requests as successful.
+	i.apiKeyService.RecordSuccessfulUse(ctx, apiKeyRecord)
+
+	return authedCtx, nil
 }
 
 func parseBearerToken(authHeader string) (string, bool) {

--- a/server/internal/handlers/interceptors/authentication.go
+++ b/server/internal/handlers/interceptors/authentication.go
@@ -12,19 +12,22 @@ import (
 	"connectrpc.com/connect"
 
 	"github.com/block/proto-fleet/server/internal/domain/apikey"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 type AuthInterceptor struct {
-	sessionService  *session.Service
-	userStore       interfaces.UserStore
-	userMgmtStore   interfaces.UserManagementStore
-	apiKeyService   *apikey.Service
-	allowList       map[string]struct{}
-	sessionOnlyList map[string]struct{}
-	agentAuthList   map[string]struct{}
+	sessionService     *session.Service
+	userStore          interfaces.UserStore
+	userMgmtStore      interfaces.UserManagementStore
+	apiKeyService      *apikey.Service
+	permissionResolver *authz.PermissionResolver
+	allowList          map[string]struct{}
+	sessionOnlyList    map[string]struct{}
+	agentAuthList      map[string]struct{}
 }
 
 var _ connect.Interceptor = &AuthInterceptor{}
@@ -34,6 +37,7 @@ func NewAuthInterceptor(
 	userStore interfaces.UserStore,
 	userMgmtStore interfaces.UserManagementStore,
 	apiKeyService *apikey.Service,
+	permissionResolver *authz.PermissionResolver,
 	allowedProcedures []string,
 	sessionOnlyProcedures []string,
 	agentAuthProcedures []string,
@@ -54,14 +58,36 @@ func NewAuthInterceptor(
 	}
 
 	return &AuthInterceptor{
-		sessionService:  sessionService,
-		userStore:       userStore,
-		userMgmtStore:   userMgmtStore,
-		apiKeyService:   apiKeyService,
-		allowList:       allowList,
-		sessionOnlyList: sessionOnlyList,
-		agentAuthList:   agentAuthList,
+		sessionService:     sessionService,
+		userStore:          userStore,
+		userMgmtStore:      userMgmtStore,
+		apiKeyService:      apiKeyService,
+		permissionResolver: permissionResolver,
+		allowList:          allowList,
+		sessionOnlyList:    sessionOnlyList,
+		agentAuthList:      agentAuthList,
 	}
+}
+
+// loadEffectivePermissions consults the resolver for the authenticated
+// user's effective permission set within their org, then stashes the
+// result on the context so RequirePermission (and downstream handler
+// code) can read it. Both auth branches call this after populating
+// session.Info; the result is the same regardless of how the request
+// authenticated, which is the point — API keys inherit the user's
+// current set on every request rather than carrying a stale snapshot.
+//
+// Errors from the resolver are fatal for this request: returning the
+// error rather than swallowing it preserves the fail-closed default.
+// A deactivated user or a user with no live assignments gets a
+// non-nil empty EffectivePermissions (the resolver does not error
+// on no rows), so this path only errors on DB or wiring failures.
+func (i *AuthInterceptor) loadEffectivePermissions(ctx context.Context, info *session.Info) (context.Context, error) {
+	eff, err := i.permissionResolver.LoadEffective(ctx, info.UserID, info.OrganizationID)
+	if err != nil {
+		return ctx, classifyLookupError(err, "auth: effective permissions lookup failed", info.UserID)
+	}
+	return middleware.WithEffectivePermissions(authn.SetInfo(ctx, info), eff), nil
 }
 
 func (i *AuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
@@ -159,7 +185,7 @@ func (i *AuthInterceptor) authenticateWithApiKey(ctx context.Context, authHeader
 		Role:           roleName,
 	}
 
-	return authn.SetInfo(ctx, info), nil
+	return i.loadEffectivePermissions(ctx, info)
 }
 
 func parseBearerToken(authHeader string) (string, bool) {
@@ -201,7 +227,7 @@ func (i *AuthInterceptor) authenticateWithSession(ctx context.Context, requestHe
 		Role:           roleName,
 	}
 
-	return authn.SetInfo(ctx, info), nil
+	return i.loadEffectivePermissions(ctx, info)
 }
 
 func (i *AuthInterceptor) hasSessionCookie(requestHeader http.Header) bool {

--- a/server/internal/handlers/interceptors/authentication.go
+++ b/server/internal/handlers/interceptors/authentication.go
@@ -82,7 +82,18 @@ func NewAuthInterceptor(
 // A deactivated user or a user with no live assignments gets a
 // non-nil empty EffectivePermissions (the resolver does not error
 // on no rows), so this path only errors on DB or wiring failures.
+//
+// A nil resolver is a constructor-wiring bug (the interceptor was
+// built without one). Surface it as Internal rather than panicking
+// with a nil dereference — easier to diagnose, and downstream
+// RequirePermission's fail-closed default still applies when the
+// EffectivePermissions value never makes it onto the context.
 func (i *AuthInterceptor) loadEffectivePermissions(ctx context.Context, info *session.Info) (context.Context, error) {
+	if i.permissionResolver == nil {
+		return ctx, fleeterror.NewInternalError(
+			"auth: permission resolver not wired into AuthInterceptor",
+		)
+	}
 	eff, err := i.permissionResolver.LoadEffective(ctx, info.UserID, info.OrganizationID)
 	if err != nil {
 		return ctx, classifyLookupError(err, "auth: effective permissions lookup failed", info.UserID)

--- a/server/internal/handlers/interceptors/authentication_apikey_error_test.go
+++ b/server/internal/handlers/interceptors/authentication_apikey_error_test.go
@@ -66,7 +66,7 @@ func TestAuthInterceptor_SanitizesAPIKeyValidationErrors(t *testing.T) {
 
 	opts := connect.WithInterceptors(
 		interceptors.NewErrorMappingInterceptor(),
-		interceptors.NewAuthInterceptor(nil, nil, nil, apiKeyService, nil, nil, nil),
+		interceptors.NewAuthInterceptor(nil, nil, nil, apiKeyService, nil, nil, nil, nil),
 	)
 
 	mux := http.NewServeMux()

--- a/server/internal/handlers/interceptors/authentication_test.go
+++ b/server/internal/handlers/interceptors/authentication_test.go
@@ -362,7 +362,7 @@ func TestAuthInterceptor(t *testing.T) {
 		}}
 
 		interceptorsOption := connect.WithInterceptors(
-			interceptors.NewAuthInterceptor(serviceProvider.SessionService, serviceProvider.UserStore, serviceProvider.UserStore, serviceProvider.ApiKeyService, allowList, nil, nil),
+			interceptors.NewAuthInterceptor(serviceProvider.SessionService, serviceProvider.UserStore, serviceProvider.UserStore, serviceProvider.ApiKeyService, serviceProvider.PermissionResolver, allowList, nil, nil),
 			capturer,
 		)
 
@@ -405,7 +405,7 @@ func TestAuthInterceptor(t *testing.T) {
 		}}
 
 		interceptorsOption := connect.WithInterceptors(
-			interceptors.NewAuthInterceptor(serviceProvider.SessionService, serviceProvider.UserStore, serviceProvider.UserStore, serviceProvider.ApiKeyService, allowList, nil, nil),
+			interceptors.NewAuthInterceptor(serviceProvider.SessionService, serviceProvider.UserStore, serviceProvider.UserStore, serviceProvider.ApiKeyService, serviceProvider.PermissionResolver, allowList, nil, nil),
 			capturer,
 		)
 

--- a/server/internal/handlers/interceptors/config_test.go
+++ b/server/internal/handlers/interceptors/config_test.go
@@ -58,7 +58,7 @@ func TestCurtailmentNonAdminProceduresStayApiKeyAccessible(t *testing.T) {
 func TestAuthInterceptor_AdminTerminateEventRejectsApiKeyAuth(t *testing.T) {
 	t.Parallel()
 
-	interceptor := NewAuthInterceptor(nil, nil, nil, nil, nil, SessionOnlyProcedures, FleetNodeAuthenticatedProcedures)
+	interceptor := NewAuthInterceptor(nil, nil, nil, nil, nil, nil, SessionOnlyProcedures, FleetNodeAuthenticatedProcedures)
 
 	header := http.Header{}
 	header.Set("Authorization", "Bearer fleet_test_some_key")

--- a/server/internal/handlers/middleware/permission.go
+++ b/server/internal/handlers/middleware/permission.go
@@ -1,0 +1,136 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+)
+
+// effectivePermissionsCtxKey is a private context key for stashing the
+// per-request EffectivePermissions value produced by the auth
+// interceptor. Using an unexported type avoids collisions with any
+// other package that uses context.WithValue.
+type effectivePermissionsCtxKey struct{}
+
+// WithEffectivePermissions returns a derived context carrying the
+// per-request EffectivePermissions. The auth interceptor calls this
+// once after session.Info is populated; handlers (and the
+// RequirePermission middleware below) read the value back via the
+// private accessor.
+//
+// Passing nil is a programming error — the interceptor must always
+// produce a non-nil value, even when the user has no live assignments
+// (in that case the resolver returns an empty *EffectivePermissions
+// that denies everything). RequirePermission treats a nil context
+// value as a fail-closed Internal error so a misconfigured
+// interceptor cannot accidentally grant access.
+func WithEffectivePermissions(ctx context.Context, eff *authz.EffectivePermissions) context.Context {
+	return context.WithValue(ctx, effectivePermissionsCtxKey{}, eff)
+}
+
+// effectivePermissionsFromContext returns the stashed value or nil.
+func effectivePermissionsFromContext(ctx context.Context) *authz.EffectivePermissions {
+	eff, _ := ctx.Value(effectivePermissionsCtxKey{}).(*authz.EffectivePermissions)
+	return eff
+}
+
+// RequirePermission gates a handler on the named permission key
+// against the caller-supplied resource context. It is the runtime
+// counterpart of RequireAdmin (which it replaces handler-by-handler in
+// U7).
+//
+// Returns the session.Info for handlers that need the caller's
+// identity, or one of:
+//   - Connect Unauthenticated  — no session.Info on context.
+//   - Connect Internal         — fail-closed; EffectivePermissions is
+//     missing on context, which means the interceptor wiring is broken
+//     for this request path. ALLOW is never the fail-closed default.
+//   - Connect PermissionDenied — the caller is authenticated but the
+//     resolver says they cannot perform this action against this
+//     resource scope. The error carries a structured payload echoing
+//     the caller's request: {"required": key, "scope": {site_id: N}}.
+//     The scope field is the caller's input only — it never includes
+//     server-side assignment IDs, role names, or the caller's
+//     effective permission list.
+//
+// Synthesized internal actors (session.Info.Actor != "") short-circuit
+// to ALLOW without consulting EffectivePermissions. The scheduler and
+// curtailment-reconciler synthesize a session.Info without a real
+// UserID/OrganizationID; they're trusted by virtue of running
+// in-process, and they have no rows in user_organization_role to
+// resolve against.
+//
+// Revocation latency: the resolver runs once per request and caches
+// the result on the context. An in-flight unary RPC acts under the
+// permission set loaded at the start of the request — the window is
+// sub-second. Long-running RPCs (firmware update, log download,
+// streaming responses) should re-invoke RequirePermission between
+// significant side-effects so revocation propagates within a single
+// streaming session; this is the handler's responsibility, not the
+// middleware's.
+func RequirePermission(ctx context.Context, key string, rc authz.ResourceContext) (*session.Info, error) {
+	info, err := session.GetInfo(ctx)
+	if err != nil {
+		return nil, fleeterror.NewUnauthenticatedError("authentication required")
+	}
+
+	// Synthesized actor short-circuit. Internal orchestrators trust
+	// themselves by virtue of running in-process; LoadEffective is
+	// never called for them and EffectivePermissions is absent from
+	// their context.
+	if info.Actor != "" {
+		return info, nil
+	}
+
+	eff := effectivePermissionsFromContext(ctx)
+	if eff == nil {
+		// Fail-closed: an authenticated request reached a permission
+		// check without the resolver running. This is a wiring bug —
+		// surface it loudly rather than silently allowing.
+		return nil, fleeterror.NewInternalError(
+			"authz: effective permissions missing from request context; auth interceptor wiring is broken",
+		)
+	}
+
+	if !eff.Has(key, rc) {
+		return nil, permissionDeniedError(key, rc)
+	}
+	return info, nil
+}
+
+// permissionDeniedError builds a Connect PermissionDenied error whose
+// body is the structured payload the plan specifies:
+//
+//	{"required": "<permission_key>", "scope": {"site_id": <N>}}
+//
+// The scope sub-object reflects the caller's ResourceContext: a nil
+// SiteID produces an empty object so the response shape is consistent
+// for both org-scoped and site-scoped requests.
+func permissionDeniedError(key string, rc authz.ResourceContext) error {
+	payload := struct {
+		Required string         `json:"required"`
+		Scope    map[string]any `json:"scope"`
+	}{
+		Required: key,
+		Scope:    scopeMap(rc),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		// json.Marshal on this concrete shape can't fail in practice
+		// (no unsupported types). Fall back to a plain message rather
+		// than panic so a future refactor doesn't crash the gate.
+		return fleeterror.NewForbiddenError("permission denied")
+	}
+	return fleeterror.NewForbiddenError(string(body))
+}
+
+func scopeMap(rc authz.ResourceContext) map[string]any {
+	out := map[string]any{}
+	if rc.SiteID != nil {
+		out["site_id"] = *rc.SiteID
+	}
+	return out
+}

--- a/server/internal/handlers/middleware/permission.go
+++ b/server/internal/handlers/middleware/permission.go
@@ -39,8 +39,8 @@ func effectivePermissionsFromContext(ctx context.Context) *authz.EffectivePermis
 
 // RequirePermission gates a handler on the named permission key
 // against the caller-supplied resource context. It is the runtime
-// counterpart of RequireAdmin (which it replaces handler-by-handler in
-// U7).
+// counterpart of the existing RequireAdmin gate, which it replaces
+// handler-by-handler as call sites migrate to the permission model.
 //
 // Returns the session.Info for handlers that need the caller's
 // identity, or one of:

--- a/server/internal/handlers/middleware/permission.go
+++ b/server/internal/handlers/middleware/permission.go
@@ -81,8 +81,22 @@ func RequirePermission(ctx context.Context, key string, rc authz.ResourceContext
 	// themselves by virtue of running in-process; LoadEffective is
 	// never called for them and EffectivePermissions is absent from
 	// their context.
+	//
+	// Allowlist explicitly rather than "any non-empty Actor" — a
+	// future mistyped or user-influenced value must NOT be a bypass.
+	// An unknown non-empty Actor fails closed with Internal so the
+	// problem surfaces immediately rather than silently granting
+	// access.
 	if info.Actor != "" {
-		return info, nil
+		switch info.Actor {
+		case session.ActorScheduler, session.ActorCurtailment:
+			return info, nil
+		default:
+			return nil, fleeterror.NewInternalErrorf(
+				"authz: unknown internal actor %q; refusing to short-circuit RBAC",
+				info.Actor,
+			)
+		}
 	}
 
 	eff := effectivePermissionsFromContext(ctx)

--- a/server/internal/handlers/middleware/permission_test.go
+++ b/server/internal/handlers/middleware/permission_test.go
@@ -1,0 +1,198 @@
+package middleware_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"connectrpc.com/authn"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
+)
+
+// ctxWithInfo and ctxWithEffective build the request context the auth
+// interceptor would produce, so the middleware unit tests can exercise
+// the gate without spinning up Connect or the resolver.
+
+func ctxWithInfo(info *session.Info) context.Context {
+	return authn.SetInfo(context.Background(), info)
+}
+
+func ctxWithEffective(t *testing.T, info *session.Info, assignments ...authz.Assignment) context.Context {
+	t.Helper()
+	ctx := ctxWithInfo(info)
+	return middleware.WithEffectivePermissions(ctx, authz.NewEffectivePermissions(assignments))
+}
+
+func userInfo() *session.Info {
+	return &session.Info{
+		AuthMethod:     session.AuthMethodSession,
+		SessionID:      "sess-1",
+		UserID:         1,
+		OrganizationID: 1,
+		ExternalUserID: "user-1",
+		Username:       "alice",
+	}
+}
+
+func orgAssignment(perms ...string) authz.Assignment {
+	return authz.Assignment{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  perms,
+	}
+}
+
+func siteAssignment(siteID int64, perms ...string) authz.Assignment {
+	return authz.Assignment{
+		AssignmentID: 2,
+		ScopeType:    authz.ScopeSite,
+		SiteID:       &siteID,
+		Permissions:  perms,
+	}
+}
+
+func siteRC(id int64) authz.ResourceContext {
+	return authz.ResourceContext{SiteID: &id}
+}
+
+func TestRequirePermission_AllowsWhenEffectiveHasKey(t *testing.T) {
+	ctx := ctxWithEffective(t, userInfo(), orgAssignment(authz.PermMinerReboot))
+
+	info, err := middleware.RequirePermission(ctx, authz.PermMinerReboot, authz.ResourceContext{})
+	require.NoError(t, err)
+	require.Equal(t, "alice", info.Username)
+}
+
+func TestRequirePermission_DeniesWithStructuredPayload(t *testing.T) {
+	ctx := ctxWithEffective(t, userInfo(), orgAssignment(authz.PermFleetRead))
+
+	info, err := middleware.RequirePermission(ctx, authz.PermMinerReboot, siteRC(42))
+	require.Error(t, err)
+	require.Nil(t, info)
+	require.Equal(t, connect.CodePermissionDenied, connectCode(t, err))
+
+	// Payload shape: exactly {"required": "...", "scope": {"site_id": N}}.
+	// No assignment ids, role names, or effective-permission lists.
+	var payload struct {
+		Required string         `json:"required"`
+		Scope    map[string]any `json:"scope"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(connectMessage(t, err)), &payload))
+	require.Equal(t, authz.PermMinerReboot, payload.Required)
+	require.Equal(t, map[string]any{"site_id": float64(42)}, payload.Scope,
+		"scope echoes the caller's ResourceContext; site_id stored as JSON number")
+}
+
+func TestRequirePermission_DenialPayloadForOrgScopedAction(t *testing.T) {
+	ctx := ctxWithEffective(t, userInfo() /* no perms */)
+
+	_, err := middleware.RequirePermission(ctx, authz.PermUserManage, authz.ResourceContext{})
+	require.Error(t, err)
+
+	var payload struct {
+		Required string         `json:"required"`
+		Scope    map[string]any `json:"scope"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(connectMessage(t, err)), &payload))
+	require.Equal(t, authz.PermUserManage, payload.Required)
+	require.Equal(t, map[string]any{}, payload.Scope,
+		"org-scoped request produces an empty scope object; no nil, no null, no site_id key")
+}
+
+func TestRequirePermission_UnauthenticatedWhenNoSessionInfo(t *testing.T) {
+	// Bare context — no session.Info attached. Mimics an unauthenticated
+	// request reaching the gate by mistake.
+	_, err := middleware.RequirePermission(context.Background(), authz.PermFleetRead, authz.ResourceContext{})
+	require.Error(t, err)
+	require.Equal(t, connect.CodeUnauthenticated, connectCode(t, err))
+}
+
+func TestRequirePermission_FailClosedOnMissingEffective(t *testing.T) {
+	// session.Info present, but no EffectivePermissions stashed. This is
+	// a wiring bug — the interceptor failed to populate the value. The
+	// gate must NOT default to ALLOW.
+	ctx := ctxWithInfo(userInfo())
+	_, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{})
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInternal, connectCode(t, err),
+		"missing EffectivePermissions must surface as Internal, not ALLOW and not PermissionDenied")
+}
+
+func TestRequirePermission_SchedulerShortCircuitsToAllow(t *testing.T) {
+	// Synthesized internal actor — no UserID, no EffectivePermissions
+	// on context — must short-circuit to ALLOW without touching the
+	// resolver state.
+	info := &session.Info{
+		AuthMethod:     session.AuthMethodSession,
+		Actor:          session.ActorScheduler,
+		OrganizationID: 1,
+	}
+	ctx := ctxWithInfo(info) // deliberately no WithEffectivePermissions
+
+	got, err := middleware.RequirePermission(ctx, authz.PermMinerReboot, siteRC(99))
+	require.NoError(t, err, "ActorScheduler must short-circuit before the EffectivePermissions check")
+	require.Equal(t, session.ActorScheduler, got.Actor)
+}
+
+func TestRequirePermission_CurtailmentReconcilerActorAlsoAllowed(t *testing.T) {
+	// Any non-empty Actor short-circuits — the gate trusts internal
+	// orchestrators in general, not just the scheduler.
+	info := &session.Info{
+		AuthMethod: session.AuthMethodSession,
+		Actor:      session.ActorCurtailment,
+	}
+	ctx := ctxWithInfo(info)
+
+	_, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	require.NoError(t, err)
+}
+
+func TestRequirePermission_NarrowingAtSiteScope(t *testing.T) {
+	// User has org-scope ADMIN (holds miner:reboot) plus a site-scope
+	// FIELD_TECH at site 1 (no miner:reboot). At site 1, narrowing
+	// applies and miner:reboot is denied. At site 2, the org grant
+	// uncovered applies and miner:reboot is allowed.
+	ctx := ctxWithEffective(t, userInfo(),
+		orgAssignment(authz.PermFleetRead, authz.PermMinerReboot),
+		siteAssignment(1, authz.PermFleetRead, authz.PermMinerBlinkLED),
+	)
+
+	_, err := middleware.RequirePermission(ctx, authz.PermMinerReboot, siteRC(1))
+	require.Error(t, err, "narrowing: site 1 FIELD_TECH overrides org ADMIN at that site")
+	require.Equal(t, connect.CodePermissionDenied, connectCode(t, err))
+
+	_, err = middleware.RequirePermission(ctx, authz.PermMinerReboot, siteRC(2))
+	require.NoError(t, err, "site 2 falls back to the org grant")
+}
+
+// ---------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------
+
+// connectCode extracts the Connect status code from a FleetError. The
+// fleeterror.FleetError type is the one all middleware errors wrap, so
+// the code is reachable without unwrapping into Connect's error type.
+func connectCode(t *testing.T, err error) connect.Code {
+	t.Helper()
+	var fe fleeterror.FleetError
+	require.True(t, errors.As(err, &fe), "expected FleetError, got %T", err)
+	return fe.GRPCCode
+}
+
+// connectMessage returns the FleetError's debug message, which is what
+// the middleware stuffs the JSON payload into. The plan specifies the
+// payload shape directly in the message body so the client can pick
+// it up via Connect's standard error.Message().
+func connectMessage(t *testing.T, err error) string {
+	t.Helper()
+	var fe fleeterror.FleetError
+	require.True(t, errors.As(err, &fe), "expected FleetError, got %T", err)
+	return fe.DebugMessage
+}

--- a/server/internal/handlers/middleware/permission_test.go
+++ b/server/internal/handlers/middleware/permission_test.go
@@ -141,6 +141,22 @@ func TestRequirePermission_SchedulerShortCircuitsToAllow(t *testing.T) {
 	require.Equal(t, session.ActorScheduler, got.Actor)
 }
 
+// Codex security regression (PR 2a MEDIUM): an unknown non-empty
+// Actor must NOT bypass the gate. Allowlist only known constants
+// (ActorScheduler, ActorCurtailment); fail closed for anything else.
+func TestRequirePermission_UnknownActorDoesNotBypass(t *testing.T) {
+	info := &session.Info{
+		AuthMethod: session.AuthMethodSession,
+		Actor:      session.Actor("future-orchestrator-typo"),
+	}
+	ctx := ctxWithInfo(info) // no EffectivePermissions stashed — bypass would mask this
+
+	_, err := middleware.RequirePermission(ctx, authz.PermMinerReboot, siteRC(1))
+	require.Error(t, err, "unknown Actor must not short-circuit to ALLOW")
+	require.Equal(t, connect.CodeInternal, connectCode(t, err),
+		"unknown Actor surfaces as Internal, not ALLOW and not PermissionDenied")
+}
+
 func TestRequirePermission_CurtailmentReconcilerActorAlsoAllowed(t *testing.T) {
 	// Any non-empty Actor short-circuits — the gate trusts internal
 	// orchestrators in general, not just the scheduler.

--- a/server/internal/testutil/infrastructure_provider.go
+++ b/server/internal/testutil/infrastructure_provider.go
@@ -47,7 +47,7 @@ type TestContext struct {
 }
 
 func NewInfrastructureProvider(t *testing.T, serviceProvider *ServiceProvider, authInterceptorAllowList []string) *InfrastructureProvider {
-	interceptorsOption := connect.WithInterceptors(interceptors.NewErrorMappingInterceptor(), interceptors.NewAuthInterceptor(serviceProvider.SessionService, serviceProvider.UserStore, serviceProvider.UserStore, serviceProvider.ApiKeyService, authInterceptorAllowList, interceptors.SessionOnlyProcedures, nil))
+	interceptorsOption := connect.WithInterceptors(interceptors.NewErrorMappingInterceptor(), interceptors.NewAuthInterceptor(serviceProvider.SessionService, serviceProvider.UserStore, serviceProvider.UserStore, serviceProvider.ApiKeyService, serviceProvider.PermissionResolver, authInterceptorAllowList, interceptors.SessionOnlyProcedures, nil))
 
 	mux := http.NewServeMux()
 

--- a/server/internal/testutil/service_provider.go
+++ b/server/internal/testutil/service_provider.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	"github.com/block/proto-fleet/server/internal/domain/apikey"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/command"
 	"github.com/block/proto-fleet/server/internal/domain/fleetmanagement"
 	"github.com/block/proto-fleet/server/internal/domain/miner"
@@ -61,6 +62,7 @@ type ServiceProvider struct {
 	FilesService           *files.Service
 	MinerService           *miner.Service
 	PluginService          *plugins.Service
+	PermissionResolver     *authz.PermissionResolver
 }
 
 func NewServiceProvider(t *testing.T, db *sql.DB, config *Config) *ServiceProvider {
@@ -179,5 +181,6 @@ func NewServiceProvider(t *testing.T, db *sql.DB, config *Config) *ServiceProvid
 		FilesService:           filesService,
 		MinerService:           minerService,
 		PluginService:          pluginService,
+		PermissionResolver:     authz.NewPermissionResolver(db),
 	}
 }

--- a/server/sqlc/queries/user_organization_role.sql
+++ b/server/sqlc/queries/user_organization_role.sql
@@ -65,14 +65,21 @@ WHERE role_id = $1
   AND deleted_at IS NULL;
 
 -- name: ListEffectivePermissionsForUser :many
--- Single-query resolver source: every (assignment_id, scope_type,
--- scope_id, permission_key) triple the user holds within an
--- organization. The resolver walks this slice to evaluate
--- Has(key, ResourceContext). Narrowing semantics: when the caller
--- has both org-scope and site-scope assignments, the site-scope
--- assignment overrides the org grant at that site; this slice
--- carries the scope on every row so the resolver can pick the
--- narrowest match without extra queries.
+-- Single-query resolver source: one row per (assignment, permission)
+-- pair the user holds within an organization, with a NULL permission
+-- column when the assignment's role has no permissions attached.
+--
+-- The LEFT JOIN on role_permission and permission is load-bearing for
+-- the narrowing semantics: a site-scope assignment whose role grants
+-- zero permissions must still surface in the resolver as a "site has
+-- an assignment" marker. Without it, the resolver would not record
+-- bySite[siteID] for that site, narrowing would collapse, and the
+-- caller's org-scope grant would silently apply at the site the
+-- empty role was meant to lock down.
+--
+-- The resolver walks this slice to evaluate Has(key, ResourceContext)
+-- with the plan's narrowing rule: site-scope assignment overrides the
+-- org grant at that site; site-scope absence falls back to org-scope.
 SELECT
     uor.id          AS assignment_id,
     uor.role_id     AS role_id,
@@ -80,15 +87,15 @@ SELECT
     uor.scope_id    AS scope_id,
     p.key           AS permission_key
 FROM user_organization_role uor
-JOIN role r             ON r.id = uor.role_id
-                       AND r.organization_id = uor.organization_id
-JOIN role_permission rp ON rp.role_id = r.id
-JOIN permission p       ON p.id = rp.permission_id
+JOIN role r              ON r.id = uor.role_id
+                        AND r.organization_id = uor.organization_id
+LEFT JOIN role_permission rp ON rp.role_id = r.id
+LEFT JOIN permission p       ON p.id = rp.permission_id
 WHERE uor.user_id = $1
   AND uor.organization_id = $2
   AND uor.deleted_at IS NULL
   AND r.deleted_at IS NULL
-ORDER BY uor.id, p.key;
+ORDER BY uor.id, p.key NULLS FIRST;
 
 -- name: CountOrgScopeSuperAdminsExcludingAssignment :one
 -- Last-SUPER_ADMIN guard. Returns the number of LIVE org-scope


### PR DESCRIPTION
First half of PR 2 of the four-part [granular RBAC plan](https://github.com/block/proto-fleet/pull/282) (the plan PR). Building on the foundation in #283.

This PR introduces the **permission resolver and the `RequirePermission` middleware** — the security gate the rest of the codebase will route through. Critically, **no callsites are swapped yet**: every existing `RequireAdmin` check still gates handler entry, this PR is purely additive. The gate exists, but nothing reads it. PR 2b will flip the switch (swap callers and neutralize the legacy `user_organization.role_id` column).

Splitting PR 2 in half keeps the "live security gate flip" change small and reviewable — see #283's review history for context (five rounds, many design-level pivots). The resolver-and-middleware piece doesn't change behavior, so it can settle in review without holding up the swap.

## What landed

### `domain/authz/effective.go` — in-memory decision type

`EffectivePermissions` is the per-request immutable snapshot of one user's authorization state within one organization.

- `Has(key, ResourceContext)` implements **narrowing semantics** from the plan:
  - Org-scope assignment grants the action everywhere within the org.
  - Site-scope assignment overrides the org grant **at that site only**, so admins can add a smaller site-scoped role to narrow a user without revoking their org-wide access.
  - Org-scoped actions (no site context in the request) are never shadowed by site-scope grants — there's no site key to narrow on.
- `FlatKeys()` projects the union for `UserInfo.permissions` (client-side coarse gate; the server still enforces scope via `Has()` on every call).
- Pure data structure with no I/O; built test-first with **10 unit tests** covering the narrowing matrix, multi-site union, empty deny, unknown-key deny, and the FIELD_TECH AE.

### `domain/authz/resolver.go` — `PermissionResolver`

- `LoadEffective(ctx, userID, orgID)` runs **one** query (`ListEffectivePermissionsForUser`) against `user_organization_role × role × role_permission` and materializes the result into an `EffectivePermissions`.
- Groups flat `(assignment_id, scope, permission_key)` rows by assignment id so multi-permission roles fold into one `Assignment` value.
- A user with no live assignments gets a non-nil empty value — the fail-closed default for a deactivated user or a user who was never in this org.
- **5 DB-backed integration tests** (via `testutil.GetTestDB`) cover SUPER_ADMIN-at-org-scope, FIELD_TECH-at-site-scope, narrowing end-to-end with two assignments, soft-delete is ignored, and empty deny-all.

### `handlers/middleware/permission.go` — `RequirePermission`

The runtime call site each handler will use in place of `RequireAdmin`. Returns the `session.Info` for handlers that need the caller's identity, or one of:

- **Unauthenticated** — no `session.Info` on context.
- **Internal** — fail-closed; `EffectivePermissions` missing from context (the interceptor failed to populate it). ALLOW is **never** the fail-closed default.
- **PermissionDenied** with structured JSON body:
  ```json
  {"required": "<permission_key>", "scope": {"site_id": <N>}}
  ```
  Scope echoes the caller's `ResourceContext` only — never server-side assignment IDs, role names, or the caller's effective permission list.

**Internal-actor short-circuit**: when `session.Info.Actor` is non-empty (scheduler, curtailment-reconciler, etc.), `RequirePermission` short-circuits to ALLOW without consulting `EffectivePermissions`. Synthesized sessions have no real user; they're trusted by virtue of running in-process.

`WithEffectivePermissions(ctx, eff)` is the public stash function used by the interceptor; the read path is private to enforce that handlers only consume via `RequirePermission`.

**8 unit tests** cover allow, deny (both org-scoped and site-scoped payload shape), unauthenticated, fail-closed-on-missing, scheduler short-circuit, curtailment-reconciler short-circuit, and the narrowing matrix.

### `handlers/interceptors/authentication.go` — wiring

Both `authenticateWithSession` and `authenticateWithApiKey` end with a shared `loadEffectivePermissions(ctx, info)` helper that calls `resolver.LoadEffective` and stashes the result via `middleware.WithEffectivePermissions` before returning the request context.

- **API-key callers inherit the user's *current* effective set on every request** (live inheritance). Revocation propagates on next request. Snapshot-at-issue is out of scope (noted in resolver godoc).
- DB or wiring errors from `LoadEffective` flow through the same `classifyLookupError` path as user/role lookups — broken resolver path fails closed.
- `main.go` constructs the resolver after `Reconcile` (so per-org built-in rows exist) and threads it into `NewAuthInterceptor`.
- `testutil.ServiceProvider` gains a `PermissionResolver` field; all `NewAuthInterceptor` callsites updated.

## What this PR does NOT do

- Does not swap any `RequireAdmin` callers — every handler still uses the old gate. PR 2b.
- Does not introduce the `rpc_permissions.go` declaration map or the contract test — PR 2b.
- Does not rename `user_organization.role_id` or add the raising trigger — PR 2b.
- Does not delete `handlers/middleware/admin.go` — kept until callers move in PR 2b.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `lefthook run pre-push` (golangci-lint) clean
- [x] Non-DB tests pass: 10 EffectivePermissions tests + 8 RequirePermission middleware tests, all green
- [ ] DB-dependent resolver integration tests (5 functions) — need Docker for the full reconcile+assign+resolve loop
- [ ] Behavior smoke: existing handler gates still work because no callsite was swapped; `lefthook run pre-push` covers the typecheck for the interceptor threading the new resolver in

## Rollback

Reverting this PR removes the resolver call from the auth interceptor, the new files, and the `PermissionResolver` field on `AuthInterceptor`. No schema change, no data migration, no live behavior change to reverse.
