### PR TITLE
feat(rbac): RPC permission declaration map + contract test (PR 2b of 4)

### DIFF
--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -32,24 +32,25 @@ import (
 //
 //   - interceptors.UnauthenticatedProcedures
 //   - interceptors.FleetNodeAuthenticatedProcedures
-//   - ProcedurePermissions               (gated by catalog key)
-//   - ProceduresPendingGate              (allowlisted, not yet gated)
+//   - ProcedurePermissions          (gated by catalog key)
+//   - ProceduresPendingMigration    (declared but not yet enforced via RequirePermission)
 //
 // Adding a new RPC without registering it fails the contract test
-// loudly. Handlers move from ProceduresPendingGate to
+// loudly. Handlers move from ProceduresPendingMigration to
 // ProcedurePermissions as they swap from RequireAdmin to
 // RequirePermission.
 //
 // The two maps are split so the migration's progress is visible at a
-// glance: shrinking ProceduresPendingGate to zero is the exit
+// glance: shrinking ProceduresPendingMigration to zero is the exit
 // criterion for retiring the legacy RequireAdmin middleware.
 var ProcedurePermissions = map[string]string{
-	// Empty in this PR (infrastructure-only). Handlers populate this
-	// map in follow-up PRs as their callsites migrate to
-	// RequirePermission.
+	// Populated as handler callsites swap from legacy gates to
+	// RequirePermission. Empty entries are expected while the
+	// migration is in flight; the contract test catches missing
+	// classifications either way.
 }
 
-// ProceduresPendingGate lists authenticated Connect procedures that
+// ProceduresPendingMigration lists authenticated Connect procedures that
 // have not yet migrated to RequirePermission. The map value is a
 // brief note about the procedure's current gate — the legacy
 // RequireAdmin middleware, an inline role-string check, or (for
@@ -61,7 +62,7 @@ var ProcedurePermissions = map[string]string{
 // without classification, but it cannot tell the difference between
 // "intentional pending entry" and "shipped without thinking about
 // authz." Reviewers should treat any growth here as a red flag.
-var ProceduresPendingGate = map[string]string{
+var ProceduresPendingMigration = map[string]string{
 	// Activity log reads — currently authenticated but ungated.
 	activityv1connect.ActivityServiceListActivitiesProcedure:            "ungated; read-only activity log",
 	activityv1connect.ActivityServiceExportActivitiesProcedure:          "ungated; activity log CSV export",
@@ -76,7 +77,7 @@ var ProceduresPendingGate = map[string]string{
 	authv1connect.AuthServiceCreateUserProcedure:        "domain-layer checkCanManageUser",
 	authv1connect.AuthServiceDeactivateUserProcedure:    "domain-layer checkCanManageUser",
 	authv1connect.AuthServiceResetUserPasswordProcedure: "domain-layer checkCanManageUser",
-	authv1connect.AuthServiceListUsersProcedure:         "SUPER_ADMIN role check in auth/service.go",
+	authv1connect.AuthServiceListUsersProcedure:         "UNGATED: auth/service.go ListUsers has no role check; any authenticated org member can enumerate users — migration must add a real gate",
 	authv1connect.AuthServiceGetUserAuditInfoProcedure:  "authenticated self-read, no role check",
 	authv1connect.AuthServiceUpdatePasswordProcedure:    "authenticated self-write, no role check",
 	authv1connect.AuthServiceUpdateUsernameProcedure:    "authenticated self-write, no role check",
@@ -108,14 +109,14 @@ var ProceduresPendingGate = map[string]string{
 	collectionv1connect.DeviceCollectionServiceSetRackSlotPositionProcedure:         "ungated",
 	collectionv1connect.DeviceCollectionServiceClearRackSlotPositionProcedure:       "ungated",
 
-	// CurtailmentService — local requireAdminFromContext for writes; reads ungated.
-	curtailmentv1connect.CurtailmentServiceStartCurtailmentProcedure:       "inline requireAdminFromContext",
-	curtailmentv1connect.CurtailmentServiceStopCurtailmentProcedure:        "inline requireAdminFromContext",
-	curtailmentv1connect.CurtailmentServiceUpdateCurtailmentEventProcedure: "inline requireAdminFromContext",
+	// CurtailmentService — gates are conditional or absent; migration must close the gaps.
+	curtailmentv1connect.CurtailmentServiceStartCurtailmentProcedure:       "CONDITIONAL: requireAdminFromContext only when CandidateMinPowerWOverride set or AllowUnbounded; otherwise any authenticated user can start",
+	curtailmentv1connect.CurtailmentServiceStopCurtailmentProcedure:        "CONDITIONAL: requireAdminFromContext only when force=true; non-force stop is ungated",
+	curtailmentv1connect.CurtailmentServiceUpdateCurtailmentEventProcedure: "UNIMPLEMENTED STUB: returns Unimplemented with no gate; needs a real gate when implemented",
 	curtailmentv1connect.CurtailmentServiceAdminTerminateEventProcedure:    "session-only + inline requireAdminFromContext",
 	curtailmentv1connect.CurtailmentServiceListCurtailmentEventsProcedure:  "ungated read",
 	curtailmentv1connect.CurtailmentServiceGetActiveCurtailmentProcedure:   "ungated read",
-	curtailmentv1connect.CurtailmentServicePreviewCurtailmentPlanProcedure: "ungated preview",
+	curtailmentv1connect.CurtailmentServicePreviewCurtailmentPlanProcedure: "CONDITIONAL: requireAdminFromContext only when CandidateMinPowerWOverride set; otherwise ungated",
 
 	// DeviceSetService (racks) — ungated.
 	device_setv1connect.DeviceSetServiceCreateDeviceSetProcedure:            "ungated",
@@ -153,15 +154,16 @@ var ProceduresPendingGate = map[string]string{
 	fleetmanagementv1connect.FleetManagementServiceDeleteMinersProcedure:            "ungated",
 	fleetmanagementv1connect.FleetManagementServiceExportMinerListCsvProcedure:      "ungated",
 
-	// FleetNodeAdminService — inline info.Role check.
-	fleetnodeadminv1connect.FleetNodeAdminServiceCreateEnrollmentCodeProcedure:  "inline info.Role check",
-	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodesProcedure:        "inline info.Role check",
-	fleetnodeadminv1connect.FleetNodeAdminServiceConfirmFleetNodeProcedure:      "inline info.Role check",
-	fleetnodeadminv1connect.FleetNodeAdminServiceRevokeFleetNodeProcedure:       "inline info.Role check",
-	fleetnodeadminv1connect.FleetNodeAdminServicePairDeviceToFleetNodeProcedure: "inline info.Role check",
-	fleetnodeadminv1connect.FleetNodeAdminServiceUnpairDeviceProcedure:          "inline info.Role check",
-	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodeDevicesProcedure:  "inline info.Role check",
-	fleetnodeadminv1connect.FleetNodeAdminServiceDiscoverOnFleetNodeProcedure:   "inline info.Role check",
+	// FleetNodeAdminService — only the first four overrides exist; the rest fall through
+	// the embedded UnimplementedFleetNodeAdminServiceHandler and never reach a role check.
+	fleetnodeadminv1connect.FleetNodeAdminServiceCreateEnrollmentCodeProcedure:  "inline requireAdminSession (info.Role check)",
+	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodesProcedure:        "inline requireAdminSession (info.Role check)",
+	fleetnodeadminv1connect.FleetNodeAdminServiceConfirmFleetNodeProcedure:      "inline requireAdminSession (info.Role check)",
+	fleetnodeadminv1connect.FleetNodeAdminServiceRevokeFleetNodeProcedure:       "inline requireAdminSession (info.Role check)",
+	fleetnodeadminv1connect.FleetNodeAdminServicePairDeviceToFleetNodeProcedure: "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
+	fleetnodeadminv1connect.FleetNodeAdminServiceUnpairDeviceProcedure:          "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
+	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodeDevicesProcedure:  "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
+	fleetnodeadminv1connect.FleetNodeAdminServiceDiscoverOnFleetNodeProcedure:   "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
 
 	// ForemanImportService — ungated.
 	foremanimportv1connect.ForemanImportServiceImportFromForemanProcedure: "ungated",

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -1,0 +1,228 @@
+package middleware
+
+import (
+	"github.com/block/proto-fleet/server/generated/grpc/activity/v1/activityv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/apikey/v1/apikeyv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/auth/v1/authv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/buildings/v1/buildingsv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/collection/v1/collectionv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/curtailment/v1/curtailmentv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/device_set/v1/device_setv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/errors/v1/errorsv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1/fleetmanagementv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1/fleetnodeadminv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/foremanimport/v1/foremanimportv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/minercommand/v1/minercommandv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/networkinfo/v1/networkinfov1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/onboarding/v1/onboardingv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/pairing/v1/pairingv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/pools/v1/poolsv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/schedule/v1/schedulev1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/serverlog/v1/serverlogv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/sites/v1/sitesv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/telemetry/v1/telemetryv1connect"
+)
+
+// ProcedurePermissions maps gated Connect procedures to the catalog
+// permission key their handler enforces via RequirePermission. The
+// contract test in rpc_permissions_test.go enumerates every procedure
+// registered on the production Connect server via reflection on the
+// generated *ServiceHandler interfaces, and asserts each appears in
+// exactly one of:
+//
+//   - interceptors.UnauthenticatedProcedures
+//   - interceptors.FleetNodeAuthenticatedProcedures
+//   - ProcedurePermissions               (gated by catalog key)
+//   - ProceduresPendingGate              (allowlisted, not yet gated)
+//
+// Adding a new RPC without registering it fails the contract test
+// loudly. Handlers move from ProceduresPendingGate to
+// ProcedurePermissions as they swap from RequireAdmin to
+// RequirePermission.
+//
+// The two maps are split so the migration's progress is visible at a
+// glance: shrinking ProceduresPendingGate to zero is the exit
+// criterion for retiring the legacy RequireAdmin middleware.
+var ProcedurePermissions = map[string]string{
+	// Empty in this PR (infrastructure-only). Handlers populate this
+	// map in follow-up PRs as their callsites migrate to
+	// RequirePermission.
+}
+
+// ProceduresPendingGate lists authenticated Connect procedures that
+// have not yet migrated to RequirePermission. The map value is a
+// brief note about the procedure's current gate — the legacy
+// RequireAdmin middleware, an inline role-string check, or (for
+// command, fleetmanagement, deviceset) no gate at all.
+//
+// Adding entries to this map is a regression: every new RPC SHOULD
+// declare its catalog key in ProcedurePermissions from the moment it
+// ships. The contract test prevents new procedures from being added
+// without classification, but it cannot tell the difference between
+// "intentional pending entry" and "shipped without thinking about
+// authz." Reviewers should treat any growth here as a red flag.
+var ProceduresPendingGate = map[string]string{
+	// Activity log reads — currently authenticated but ungated.
+	activityv1connect.ActivityServiceListActivitiesProcedure:            "ungated; read-only activity log",
+	activityv1connect.ActivityServiceExportActivitiesProcedure:          "ungated; activity log CSV export",
+	activityv1connect.ActivityServiceListActivityFilterOptionsProcedure: "ungated; filter option lookup",
+
+	// API key management — local requireAdmin helper in apikey/handler.go.
+	apikeyv1connect.ApiKeyServiceCreateApiKeyProcedure: "inline requireAdmin in apikey/handler.go",
+	apikeyv1connect.ApiKeyServiceListApiKeysProcedure:  "inline requireAdmin in apikey/handler.go",
+	apikeyv1connect.ApiKeyServiceRevokeApiKeyProcedure: "inline requireAdmin in apikey/handler.go",
+
+	// Auth user management — checkCanManageUser in auth/service.go.
+	authv1connect.AuthServiceCreateUserProcedure:        "domain-layer checkCanManageUser",
+	authv1connect.AuthServiceDeactivateUserProcedure:    "domain-layer checkCanManageUser",
+	authv1connect.AuthServiceResetUserPasswordProcedure: "domain-layer checkCanManageUser",
+	authv1connect.AuthServiceListUsersProcedure:         "SUPER_ADMIN role check in auth/service.go",
+	authv1connect.AuthServiceGetUserAuditInfoProcedure:  "authenticated self-read, no role check",
+	authv1connect.AuthServiceUpdatePasswordProcedure:    "authenticated self-write, no role check",
+	authv1connect.AuthServiceUpdateUsernameProcedure:    "authenticated self-write, no role check",
+	authv1connect.AuthServiceVerifyCredentialsProcedure: "authenticated self-read, no role check",
+	authv1connect.AuthServiceLogoutProcedure:            "session-only; FailedPrecondition guard in handler",
+
+	// Buildings — middleware.RequireAdmin in buildings/handler.go.
+	buildingsv1connect.BuildingServiceListBuildingsProcedure:  "middleware.RequireAdmin",
+	buildingsv1connect.BuildingServiceGetBuildingProcedure:    "middleware.RequireAdmin",
+	buildingsv1connect.BuildingServiceCreateBuildingProcedure: "middleware.RequireAdmin",
+	buildingsv1connect.BuildingServiceUpdateBuildingProcedure: "middleware.RequireAdmin",
+	buildingsv1connect.BuildingServiceDeleteBuildingProcedure: "middleware.RequireAdmin",
+
+	// DeviceCollectionService — ungated reads + writes on shared collections.
+	collectionv1connect.DeviceCollectionServiceCreateCollectionProcedure:            "ungated",
+	collectionv1connect.DeviceCollectionServiceGetCollectionProcedure:               "ungated",
+	collectionv1connect.DeviceCollectionServiceGetCollectionStatsProcedure:          "ungated",
+	collectionv1connect.DeviceCollectionServiceListCollectionsProcedure:             "ungated",
+	collectionv1connect.DeviceCollectionServiceListCollectionMembersProcedure:       "ungated",
+	collectionv1connect.DeviceCollectionServiceUpdateCollectionProcedure:            "ungated",
+	collectionv1connect.DeviceCollectionServiceDeleteCollectionProcedure:            "ungated",
+	collectionv1connect.DeviceCollectionServiceAddDevicesToCollectionProcedure:      "ungated",
+	collectionv1connect.DeviceCollectionServiceRemoveDevicesFromCollectionProcedure: "ungated",
+	collectionv1connect.DeviceCollectionServiceGetDeviceCollectionsProcedure:        "ungated",
+	collectionv1connect.DeviceCollectionServiceListRackTypesProcedure:               "ungated",
+	collectionv1connect.DeviceCollectionServiceListRackZonesProcedure:               "ungated",
+	collectionv1connect.DeviceCollectionServiceSaveRackProcedure:                    "ungated",
+	collectionv1connect.DeviceCollectionServiceGetRackSlotsProcedure:                "ungated",
+	collectionv1connect.DeviceCollectionServiceSetRackSlotPositionProcedure:         "ungated",
+	collectionv1connect.DeviceCollectionServiceClearRackSlotPositionProcedure:       "ungated",
+
+	// CurtailmentService — local requireAdminFromContext for writes; reads ungated.
+	curtailmentv1connect.CurtailmentServiceStartCurtailmentProcedure:       "inline requireAdminFromContext",
+	curtailmentv1connect.CurtailmentServiceStopCurtailmentProcedure:        "inline requireAdminFromContext",
+	curtailmentv1connect.CurtailmentServiceUpdateCurtailmentEventProcedure: "inline requireAdminFromContext",
+	curtailmentv1connect.CurtailmentServiceAdminTerminateEventProcedure:    "session-only + inline requireAdminFromContext",
+	curtailmentv1connect.CurtailmentServiceListCurtailmentEventsProcedure:  "ungated read",
+	curtailmentv1connect.CurtailmentServiceGetActiveCurtailmentProcedure:   "ungated read",
+	curtailmentv1connect.CurtailmentServicePreviewCurtailmentPlanProcedure: "ungated preview",
+
+	// DeviceSetService (racks) — ungated.
+	device_setv1connect.DeviceSetServiceCreateDeviceSetProcedure:            "ungated",
+	device_setv1connect.DeviceSetServiceGetDeviceSetProcedure:               "ungated",
+	device_setv1connect.DeviceSetServiceGetDeviceSetStatsProcedure:          "ungated",
+	device_setv1connect.DeviceSetServiceListDeviceSetsProcedure:             "ungated",
+	device_setv1connect.DeviceSetServiceListDeviceSetMembersProcedure:       "ungated",
+	device_setv1connect.DeviceSetServiceUpdateDeviceSetProcedure:            "ungated",
+	device_setv1connect.DeviceSetServiceDeleteDeviceSetProcedure:            "ungated",
+	device_setv1connect.DeviceSetServiceAddDevicesToDeviceSetProcedure:      "ungated",
+	device_setv1connect.DeviceSetServiceRemoveDevicesFromDeviceSetProcedure: "ungated",
+	device_setv1connect.DeviceSetServiceGetDeviceDeviceSetsProcedure:        "ungated",
+	device_setv1connect.DeviceSetServiceListRackTypesProcedure:              "ungated",
+	device_setv1connect.DeviceSetServiceListRackZonesProcedure:              "ungated",
+	device_setv1connect.DeviceSetServiceListRackZoneRefsProcedure:           "ungated",
+	device_setv1connect.DeviceSetServiceSaveRackProcedure:                   "ungated",
+	device_setv1connect.DeviceSetServiceGetRackSlotsProcedure:               "ungated",
+	device_setv1connect.DeviceSetServiceSetRackSlotPositionProcedure:        "ungated",
+	device_setv1connect.DeviceSetServiceClearRackSlotPositionProcedure:      "ungated",
+
+	// ErrorQueryService — ungated diagnostics reads.
+	errorsv1connect.ErrorQueryServiceGetErrorProcedure:        "ungated diagnostics read",
+	errorsv1connect.ErrorQueryServiceQueryProcedure:           "ungated diagnostics read",
+	errorsv1connect.ErrorQueryServiceListMinerErrorsProcedure: "ungated diagnostics read",
+	errorsv1connect.ErrorQueryServiceWatchProcedure:           "ungated diagnostics stream",
+
+	// FleetManagementService — ungated. This is the first service that gets a NEW gate.
+	fleetmanagementv1connect.FleetManagementServiceListMinerStateSnapshotsProcedure: "ungated",
+	fleetmanagementv1connect.FleetManagementServiceGetMinerPoolAssignmentsProcedure: "ungated",
+	fleetmanagementv1connect.FleetManagementServiceGetMinerCoolingModeProcedure:     "ungated",
+	fleetmanagementv1connect.FleetManagementServiceGetMinerStateCountsProcedure:     "ungated",
+	fleetmanagementv1connect.FleetManagementServiceGetMinerModelGroupsProcedure:     "ungated",
+	fleetmanagementv1connect.FleetManagementServiceUpdateWorkerNamesProcedure:       "ungated",
+	fleetmanagementv1connect.FleetManagementServiceRenameMinersProcedure:            "ungated",
+	fleetmanagementv1connect.FleetManagementServiceDeleteMinersProcedure:            "ungated",
+	fleetmanagementv1connect.FleetManagementServiceExportMinerListCsvProcedure:      "ungated",
+
+	// FleetNodeAdminService — inline info.Role check.
+	fleetnodeadminv1connect.FleetNodeAdminServiceCreateEnrollmentCodeProcedure:  "inline info.Role check",
+	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodesProcedure:        "inline info.Role check",
+	fleetnodeadminv1connect.FleetNodeAdminServiceConfirmFleetNodeProcedure:      "inline info.Role check",
+	fleetnodeadminv1connect.FleetNodeAdminServiceRevokeFleetNodeProcedure:       "inline info.Role check",
+	fleetnodeadminv1connect.FleetNodeAdminServicePairDeviceToFleetNodeProcedure: "inline info.Role check",
+	fleetnodeadminv1connect.FleetNodeAdminServiceUnpairDeviceProcedure:          "inline info.Role check",
+	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodeDevicesProcedure:  "inline info.Role check",
+	fleetnodeadminv1connect.FleetNodeAdminServiceDiscoverOnFleetNodeProcedure:   "inline info.Role check",
+
+	// ForemanImportService — ungated.
+	foremanimportv1connect.ForemanImportServiceImportFromForemanProcedure: "ungated",
+	foremanimportv1connect.ForemanImportServiceCompleteImportProcedure:    "ungated",
+
+	// MinerCommandService — ungated. The largest single block of new gates.
+	minercommandv1connect.MinerCommandServiceBlinkLEDProcedure:                     "ungated",
+	minercommandv1connect.MinerCommandServiceRebootProcedure:                       "ungated",
+	minercommandv1connect.MinerCommandServiceStartMiningProcedure:                  "ungated",
+	minercommandv1connect.MinerCommandServiceStopMiningProcedure:                   "ungated",
+	minercommandv1connect.MinerCommandServiceUpdateMiningPoolsProcedure:            "ungated",
+	minercommandv1connect.MinerCommandServiceSetCoolingModeProcedure:               "ungated",
+	minercommandv1connect.MinerCommandServiceSetPowerTargetProcedure:               "ungated",
+	minercommandv1connect.MinerCommandServiceFirmwareUpdateProcedure:               "ungated",
+	minercommandv1connect.MinerCommandServiceDownloadLogsProcedure:                 "ungated",
+	minercommandv1connect.MinerCommandServiceUpdateMinerPasswordProcedure:          "ungated",
+	minercommandv1connect.MinerCommandServiceUnpairProcedure:                       "ungated",
+	minercommandv1connect.MinerCommandServiceCheckCommandCapabilitiesProcedure:     "ungated",
+	minercommandv1connect.MinerCommandServiceGetCommandBatchDeviceResultsProcedure: "ungated",
+	minercommandv1connect.MinerCommandServiceGetCommandBatchLogBundleProcedure:     "ungated",
+	minercommandv1connect.MinerCommandServiceStreamCommandBatchUpdatesProcedure:    "ungated",
+
+	// NetworkInfoService — ungated.
+	networkinfov1connect.NetworkInfoServiceGetNetworkInfoProcedure:        "ungated",
+	networkinfov1connect.NetworkInfoServiceUpdateNetworkNicknameProcedure: "ungated",
+
+	// OnboardingService — fleet-init status. Other onboarding procedures are unauthenticated.
+	onboardingv1connect.OnboardingServiceGetFleetOnboardingStatusProcedure: "ungated authenticated read",
+
+	// PairingService — ungated.
+	pairingv1connect.PairingServiceDiscoverProcedure: "ungated",
+	pairingv1connect.PairingServicePairProcedure:     "ungated",
+
+	// PoolsService — ungated.
+	poolsv1connect.PoolsServiceCreatePoolProcedure:   "ungated",
+	poolsv1connect.PoolsServiceListPoolsProcedure:    "ungated",
+	poolsv1connect.PoolsServiceUpdatePoolProcedure:   "ungated",
+	poolsv1connect.PoolsServiceDeletePoolProcedure:   "ungated",
+	poolsv1connect.PoolsServiceValidatePoolProcedure: "ungated",
+
+	// ScheduleService — ungated.
+	schedulev1connect.ScheduleServiceListSchedulesProcedure:    "ungated",
+	schedulev1connect.ScheduleServiceCreateScheduleProcedure:   "ungated",
+	schedulev1connect.ScheduleServiceUpdateScheduleProcedure:   "ungated",
+	schedulev1connect.ScheduleServiceDeleteScheduleProcedure:   "ungated",
+	schedulev1connect.ScheduleServicePauseScheduleProcedure:    "ungated",
+	schedulev1connect.ScheduleServiceResumeScheduleProcedure:   "ungated",
+	schedulev1connect.ScheduleServiceReorderSchedulesProcedure: "ungated",
+
+	// ServerLogService — inline role check.
+	serverlogv1connect.ServerLogServiceListServerLogsProcedure: "inline info.Role check",
+
+	// SiteService — middleware.RequireAdmin.
+	sitesv1connect.SiteServiceListSitesProcedure:             "middleware.RequireAdmin",
+	sitesv1connect.SiteServiceCreateSiteProcedure:            "middleware.RequireAdmin",
+	sitesv1connect.SiteServiceUpdateSiteProcedure:            "middleware.RequireAdmin",
+	sitesv1connect.SiteServiceDeleteSiteProcedure:            "middleware.RequireAdmin",
+	sitesv1connect.SiteServiceReassignDevicesToSiteProcedure: "middleware.RequireAdmin",
+	sitesv1connect.SiteServiceAssignBuildingToSiteProcedure:  "middleware.RequireAdmin",
+
+	// TelemetryService — ungated.
+	telemetryv1connect.TelemetryServiceGetCombinedMetricsProcedure:          "ungated",
+	telemetryv1connect.TelemetryServiceStreamCombinedMetricUpdatesProcedure: "ungated",
+}

--- a/server/internal/handlers/middleware/rpc_permissions_test.go
+++ b/server/internal/handlers/middleware/rpc_permissions_test.go
@@ -166,49 +166,61 @@ func TestRPCContract_ProcedurePermissionsKeysAreInCatalog(t *testing.T) {
 	}
 }
 
-// mainConnectMountRe captures the connect-package shortname (e.g.
-// "authv1connect", "fooserverv2connect") from every Connect handler
-// mount in main.go like `mux.Handle(authv1connect.NewAuthServiceHandler(...)`.
-// The capture is the package selector, which uniquely identifies the
-// service. Matching any `\w+v\d+connect` keeps the guard honest as
-// future services land on v2+.
-var mainConnectMountRe = regexp.MustCompile(`\b(\w+v\d+connect)\.New\w+ServiceHandler\(`)
+// mainConnectMountRe captures both the connect-package shortname and
+// the service-handler short name (e.g. "authv1connect" + "Auth") from
+// every Connect handler mount in main.go like
+// `mux.Handle(authv1connect.NewAuthServiceHandler(...)`. Capturing both
+// keeps the guard honest at constructor granularity: a second service
+// added to an already-mounted v1connect package will not pass the check
+// just because its package is present.
+var mainConnectMountRe = regexp.MustCompile(`\b(\w+v\d+connect)\.New(\w+)ServiceHandler\(`)
+
+// mountIdentifier formats a (pkg, ServiceShortName) tuple into the
+// canonical "<pkg>.<ServiceShortName>" used to compare main.go mounts
+// against registeredServices.
+func mountIdentifier(pkg, serviceShortName string) string {
+	return pkg + "." + serviceShortName
+}
 
 // TestRPCContract_RegisteredServicesMatchMainMux asserts that every
 // connect handler mounted in cmd/fleetd/main.go is enumerated in
-// registeredServices, and vice versa. Without this, adding a new
-// service to main.go but forgetting to list it here is a silent
-// false-negative: the contract test still passes because reflection
-// never sees the new service's procedures.
+// registeredServices, and vice versa. The comparison runs at
+// constructor granularity (`<pkg>.<ServiceShortName>`), so adding a
+// second service to an existing v1connect package without listing it
+// here fails the test — package-level granularity would silently miss
+// that case.
 func TestRPCContract_RegisteredServicesMatchMainMux(t *testing.T) {
 	mainPath := locateMainGo(t)
 	src, err := os.ReadFile(mainPath)
 	require.NoError(t, err, "reading %s", mainPath)
 
-	mountedPkgs := make(map[string]struct{})
+	mounted := make(map[string]struct{})
 	for _, m := range mainConnectMountRe.FindAllSubmatch(src, -1) {
-		mountedPkgs[string(m[1])] = struct{}{}
+		mounted[mountIdentifier(string(m[1]), string(m[2]))] = struct{}{}
 	}
-	require.NotEmpty(t, mountedPkgs,
+	require.NotEmpty(t, mounted,
 		"regex found no connect handler mounts in %s — pattern may have drifted", mainPath)
 
-	registeredPkgs := make(map[string]struct{}, len(registeredServices))
+	registered := make(map[string]struct{}, len(registeredServices))
 	for _, svc := range registeredServices {
 		// reflect.Type.PkgPath returns the import path; the last segment
-		// is the connect-package shortname that appears in main.go.
+		// is the v1connect package shortname that appears in main.go.
+		// reflect.Type.Name returns "<ServiceShortName>ServiceHandler".
 		pkg := svc.ifaceType.PkgPath()
-		registeredPkgs[pkg[strings.LastIndex(pkg, "/")+1:]] = struct{}{}
+		pkg = pkg[strings.LastIndex(pkg, "/")+1:]
+		shortName := strings.TrimSuffix(svc.ifaceType.Name(), "ServiceHandler")
+		registered[mountIdentifier(pkg, shortName)] = struct{}{}
 	}
 
 	var missingFromTest, missingFromMux []string
-	for pkg := range mountedPkgs {
-		if _, ok := registeredPkgs[pkg]; !ok {
-			missingFromTest = append(missingFromTest, pkg)
+	for id := range mounted {
+		if _, ok := registered[id]; !ok {
+			missingFromTest = append(missingFromTest, id)
 		}
 	}
-	for pkg := range registeredPkgs {
-		if _, ok := mountedPkgs[pkg]; !ok {
-			missingFromMux = append(missingFromMux, pkg)
+	for id := range registered {
+		if _, ok := mounted[id]; !ok {
+			missingFromMux = append(missingFromMux, id)
 		}
 	}
 	sort.Strings(missingFromTest)

--- a/server/internal/handlers/middleware/rpc_permissions_test.go
+++ b/server/internal/handlers/middleware/rpc_permissions_test.go
@@ -1,0 +1,157 @@
+package middleware_test
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/generated/grpc/activity/v1/activityv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/apikey/v1/apikeyv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/auth/v1/authv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/buildings/v1/buildingsv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/collection/v1/collectionv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/curtailment/v1/curtailmentv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/device_set/v1/device_setv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/errors/v1/errorsv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1/fleetmanagementv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1/fleetnodeadminv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/foremanimport/v1/foremanimportv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/minercommand/v1/minercommandv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/networkinfo/v1/networkinfov1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/onboarding/v1/onboardingv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/pairing/v1/pairingv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/pools/v1/poolsv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/schedule/v1/schedulev1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/serverlog/v1/serverlogv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/sites/v1/sitesv1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/telemetry/v1/telemetryv1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/handlers/interceptors"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
+)
+
+// permissionKeyExists returns true when the supplied permission key
+// is registered in the authz catalog. Wraps authz.Lookup to keep the
+// test code readable.
+func permissionKeyExists(key string) bool {
+	_, ok := authz.Lookup(key)
+	return ok
+}
+
+// registeredServices mirrors the Connect handler registrations in
+// cmd/fleetd/main.go. Each entry pairs a service's fully-qualified
+// name with the type of its generated handler interface so the
+// contract test can enumerate methods via reflection without needing
+// to construct real handler implementations.
+//
+// Adding a new service to the production mux requires adding it here
+// too; otherwise the contract test cannot reach its procedures and
+// the auto-discovery property collapses. The reverse direction is
+// caught by the build — removing a service makes the import unused.
+var registeredServices = []struct {
+	name      string
+	ifaceType reflect.Type
+}{
+	{activityv1connect.ActivityServiceName, reflect.TypeOf((*activityv1connect.ActivityServiceHandler)(nil)).Elem()},
+	{apikeyv1connect.ApiKeyServiceName, reflect.TypeOf((*apikeyv1connect.ApiKeyServiceHandler)(nil)).Elem()},
+	{authv1connect.AuthServiceName, reflect.TypeOf((*authv1connect.AuthServiceHandler)(nil)).Elem()},
+	{buildingsv1connect.BuildingServiceName, reflect.TypeOf((*buildingsv1connect.BuildingServiceHandler)(nil)).Elem()},
+	{collectionv1connect.DeviceCollectionServiceName, reflect.TypeOf((*collectionv1connect.DeviceCollectionServiceHandler)(nil)).Elem()},
+	{curtailmentv1connect.CurtailmentServiceName, reflect.TypeOf((*curtailmentv1connect.CurtailmentServiceHandler)(nil)).Elem()},
+	{device_setv1connect.DeviceSetServiceName, reflect.TypeOf((*device_setv1connect.DeviceSetServiceHandler)(nil)).Elem()},
+	{errorsv1connect.ErrorQueryServiceName, reflect.TypeOf((*errorsv1connect.ErrorQueryServiceHandler)(nil)).Elem()},
+	{fleetmanagementv1connect.FleetManagementServiceName, reflect.TypeOf((*fleetmanagementv1connect.FleetManagementServiceHandler)(nil)).Elem()},
+	{fleetnodeadminv1connect.FleetNodeAdminServiceName, reflect.TypeOf((*fleetnodeadminv1connect.FleetNodeAdminServiceHandler)(nil)).Elem()},
+	{fleetnodegatewayv1connect.FleetNodeGatewayServiceName, reflect.TypeOf((*fleetnodegatewayv1connect.FleetNodeGatewayServiceHandler)(nil)).Elem()},
+	{foremanimportv1connect.ForemanImportServiceName, reflect.TypeOf((*foremanimportv1connect.ForemanImportServiceHandler)(nil)).Elem()},
+	{minercommandv1connect.MinerCommandServiceName, reflect.TypeOf((*minercommandv1connect.MinerCommandServiceHandler)(nil)).Elem()},
+	{networkinfov1connect.NetworkInfoServiceName, reflect.TypeOf((*networkinfov1connect.NetworkInfoServiceHandler)(nil)).Elem()},
+	{onboardingv1connect.OnboardingServiceName, reflect.TypeOf((*onboardingv1connect.OnboardingServiceHandler)(nil)).Elem()},
+	{pairingv1connect.PairingServiceName, reflect.TypeOf((*pairingv1connect.PairingServiceHandler)(nil)).Elem()},
+	{poolsv1connect.PoolsServiceName, reflect.TypeOf((*poolsv1connect.PoolsServiceHandler)(nil)).Elem()},
+	{schedulev1connect.ScheduleServiceName, reflect.TypeOf((*schedulev1connect.ScheduleServiceHandler)(nil)).Elem()},
+	{serverlogv1connect.ServerLogServiceName, reflect.TypeOf((*serverlogv1connect.ServerLogServiceHandler)(nil)).Elem()},
+	{sitesv1connect.SiteServiceName, reflect.TypeOf((*sitesv1connect.SiteServiceHandler)(nil)).Elem()},
+	{telemetryv1connect.TelemetryServiceName, reflect.TypeOf((*telemetryv1connect.TelemetryServiceHandler)(nil)).Elem()},
+}
+
+func allRegisteredProcedures() []string {
+	var out []string
+	for _, svc := range registeredServices {
+		for i := range svc.ifaceType.NumMethod() {
+			method := svc.ifaceType.Method(i)
+			out = append(out, fmt.Sprintf("/%s/%s", svc.name, method.Name))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestRPCContract_EveryRegisteredProcedureIsClassified asserts every
+// Connect procedure registered on the production mux appears in
+// exactly one of: UnauthenticatedProcedures, FleetNodeAuthenticatedProcedures,
+// ProcedurePermissions, or ProceduresPendingGate. Adding a new RPC
+// without classifying it fails this test loudly; a procedure that
+// shows up in two lists is also flagged.
+func TestRPCContract_EveryRegisteredProcedureIsClassified(t *testing.T) {
+	type bucket struct{ name string }
+	classified := make(map[string]bucket)
+
+	add := func(name string, items []string) {
+		for _, p := range items {
+			if existing, ok := classified[p]; ok {
+				t.Errorf("procedure %q listed in both %s and %s", p, existing.name, name)
+				continue
+			}
+			classified[p] = bucket{name: name}
+		}
+	}
+	addMap := func(name string, m map[string]string) {
+		for p := range m {
+			if existing, ok := classified[p]; ok {
+				t.Errorf("procedure %q listed in both %s and %s", p, existing.name, name)
+				continue
+			}
+			classified[p] = bucket{name: name}
+		}
+	}
+
+	add("UnauthenticatedProcedures", interceptors.UnauthenticatedProcedures)
+	add("FleetNodeAuthenticatedProcedures", interceptors.FleetNodeAuthenticatedProcedures)
+	addMap("ProcedurePermissions", middleware.ProcedurePermissions)
+	addMap("ProceduresPendingGate", middleware.ProceduresPendingGate)
+
+	var missing []string
+	for _, p := range allRegisteredProcedures() {
+		if _, ok := classified[p]; !ok {
+			missing = append(missing, p)
+		}
+	}
+	require.Empty(t, missing,
+		"every procedure registered on the production Connect mux must be classified by RBAC; "+
+			"add each of the procedures below to UnauthenticatedProcedures, FleetNodeAuthenticatedProcedures, "+
+			"ProcedurePermissions, or ProceduresPendingGate:\n  %s",
+		fmt.Sprintf("%q", missing))
+}
+
+// TestRPCContract_ProcedurePermissionsKeysAreInCatalog asserts every
+// permission key referenced by ProcedurePermissions exists in the
+// catalog. Stale keys (typos, removed permissions) get caught at test
+// time rather than slipping into production and quietly failing
+// every gate.
+//
+// In PR 2b (infrastructure-only) ProcedurePermissions is empty so
+// this test is a no-op; it becomes load-bearing in PR 2c onwards.
+func TestRPCContract_ProcedurePermissionsKeysAreInCatalog(t *testing.T) {
+	// Imported via the test so the package compiles when
+	// ProcedurePermissions is empty.
+	for procedure, key := range middleware.ProcedurePermissions {
+		if !permissionKeyExists(key) {
+			t.Errorf("procedure %q gated by %q, which is not in the permission catalog", procedure, key)
+		}
+	}
+}

--- a/server/internal/handlers/middleware/rpc_permissions_test.go
+++ b/server/internal/handlers/middleware/rpc_permissions_test.go
@@ -166,14 +166,16 @@ func TestRPCContract_ProcedurePermissionsKeysAreInCatalog(t *testing.T) {
 	}
 }
 
-// mainConnectMountRe captures the v1connect package shortname (e.g.
-// "authv1connect") from every Connect handler mount in main.go like
-// `mux.Handle(authv1connect.NewAuthServiceHandler(...)`. The capture
-// is the package selector, which uniquely identifies the service.
-var mainConnectMountRe = regexp.MustCompile(`\b(\w+v1connect)\.New\w+ServiceHandler\(`)
+// mainConnectMountRe captures the connect-package shortname (e.g.
+// "authv1connect", "fooserverv2connect") from every Connect handler
+// mount in main.go like `mux.Handle(authv1connect.NewAuthServiceHandler(...)`.
+// The capture is the package selector, which uniquely identifies the
+// service. Matching any `\w+v\d+connect` keeps the guard honest as
+// future services land on v2+.
+var mainConnectMountRe = regexp.MustCompile(`\b(\w+v\d+connect)\.New\w+ServiceHandler\(`)
 
 // TestRPCContract_RegisteredServicesMatchMainMux asserts that every
-// v1connect handler mounted in cmd/fleetd/main.go is enumerated in
+// connect handler mounted in cmd/fleetd/main.go is enumerated in
 // registeredServices, and vice versa. Without this, adding a new
 // service to main.go but forgetting to list it here is a silent
 // false-negative: the contract test still passes because reflection
@@ -188,12 +190,12 @@ func TestRPCContract_RegisteredServicesMatchMainMux(t *testing.T) {
 		mountedPkgs[string(m[1])] = struct{}{}
 	}
 	require.NotEmpty(t, mountedPkgs,
-		"regex found no v1connect handler mounts in %s — pattern may have drifted", mainPath)
+		"regex found no connect handler mounts in %s — pattern may have drifted", mainPath)
 
 	registeredPkgs := make(map[string]struct{}, len(registeredServices))
 	for _, svc := range registeredServices {
 		// reflect.Type.PkgPath returns the import path; the last segment
-		// is the v1connect package shortname that appears in main.go.
+		// is the connect-package shortname that appears in main.go.
 		pkg := svc.ifaceType.PkgPath()
 		registeredPkgs[pkg[strings.LastIndex(pkg, "/")+1:]] = struct{}{}
 	}

--- a/server/internal/handlers/middleware/rpc_permissions_test.go
+++ b/server/internal/handlers/middleware/rpc_permissions_test.go
@@ -2,8 +2,13 @@ package middleware_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
+	"regexp"
+	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -94,7 +99,7 @@ func allRegisteredProcedures() []string {
 // TestRPCContract_EveryRegisteredProcedureIsClassified asserts every
 // Connect procedure registered on the production mux appears in
 // exactly one of: UnauthenticatedProcedures, FleetNodeAuthenticatedProcedures,
-// ProcedurePermissions, or ProceduresPendingGate. Adding a new RPC
+// ProcedurePermissions, or ProceduresPendingMigration. Adding a new RPC
 // without classifying it fails this test loudly; a procedure that
 // shows up in two lists is also flagged.
 func TestRPCContract_EveryRegisteredProcedureIsClassified(t *testing.T) {
@@ -123,10 +128,18 @@ func TestRPCContract_EveryRegisteredProcedureIsClassified(t *testing.T) {
 	add("UnauthenticatedProcedures", interceptors.UnauthenticatedProcedures)
 	add("FleetNodeAuthenticatedProcedures", interceptors.FleetNodeAuthenticatedProcedures)
 	addMap("ProcedurePermissions", middleware.ProcedurePermissions)
-	addMap("ProceduresPendingGate", middleware.ProceduresPendingGate)
+	addMap("ProceduresPendingMigration", middleware.ProceduresPendingMigration)
+
+	procedures := allRegisteredProcedures()
+	// Guard against silent pass when reflection finds nothing — e.g.
+	// connect-go renames the *Handler interfaces or every service is
+	// accidentally dropped from registeredServices.
+	require.NotEmpty(t, procedures,
+		"reflection discovered zero procedures across registeredServices; "+
+			"the contract test would pass vacuously")
 
 	var missing []string
-	for _, p := range allRegisteredProcedures() {
+	for _, p := range procedures {
 		if _, ok := classified[p]; !ok {
 			missing = append(missing, p)
 		}
@@ -134,7 +147,7 @@ func TestRPCContract_EveryRegisteredProcedureIsClassified(t *testing.T) {
 	require.Empty(t, missing,
 		"every procedure registered on the production Connect mux must be classified by RBAC; "+
 			"add each of the procedures below to UnauthenticatedProcedures, FleetNodeAuthenticatedProcedures, "+
-			"ProcedurePermissions, or ProceduresPendingGate:\n  %s",
+			"ProcedurePermissions, or ProceduresPendingMigration:\n  %s",
 		fmt.Sprintf("%q", missing))
 }
 
@@ -143,9 +156,6 @@ func TestRPCContract_EveryRegisteredProcedureIsClassified(t *testing.T) {
 // catalog. Stale keys (typos, removed permissions) get caught at test
 // time rather than slipping into production and quietly failing
 // every gate.
-//
-// In PR 2b (infrastructure-only) ProcedurePermissions is empty so
-// this test is a no-op; it becomes load-bearing in PR 2c onwards.
 func TestRPCContract_ProcedurePermissionsKeysAreInCatalog(t *testing.T) {
 	// Imported via the test so the package compiles when
 	// ProcedurePermissions is empty.
@@ -154,4 +164,74 @@ func TestRPCContract_ProcedurePermissionsKeysAreInCatalog(t *testing.T) {
 			t.Errorf("procedure %q gated by %q, which is not in the permission catalog", procedure, key)
 		}
 	}
+}
+
+// mainConnectMountRe captures the v1connect package shortname (e.g.
+// "authv1connect") from every Connect handler mount in main.go like
+// `mux.Handle(authv1connect.NewAuthServiceHandler(...)`. The capture
+// is the package selector, which uniquely identifies the service.
+var mainConnectMountRe = regexp.MustCompile(`\b(\w+v1connect)\.New\w+ServiceHandler\(`)
+
+// TestRPCContract_RegisteredServicesMatchMainMux asserts that every
+// v1connect handler mounted in cmd/fleetd/main.go is enumerated in
+// registeredServices, and vice versa. Without this, adding a new
+// service to main.go but forgetting to list it here is a silent
+// false-negative: the contract test still passes because reflection
+// never sees the new service's procedures.
+func TestRPCContract_RegisteredServicesMatchMainMux(t *testing.T) {
+	mainPath := locateMainGo(t)
+	src, err := os.ReadFile(mainPath)
+	require.NoError(t, err, "reading %s", mainPath)
+
+	mountedPkgs := make(map[string]struct{})
+	for _, m := range mainConnectMountRe.FindAllSubmatch(src, -1) {
+		mountedPkgs[string(m[1])] = struct{}{}
+	}
+	require.NotEmpty(t, mountedPkgs,
+		"regex found no v1connect handler mounts in %s — pattern may have drifted", mainPath)
+
+	registeredPkgs := make(map[string]struct{}, len(registeredServices))
+	for _, svc := range registeredServices {
+		// reflect.Type.PkgPath returns the import path; the last segment
+		// is the v1connect package shortname that appears in main.go.
+		pkg := svc.ifaceType.PkgPath()
+		registeredPkgs[pkg[strings.LastIndex(pkg, "/")+1:]] = struct{}{}
+	}
+
+	var missingFromTest, missingFromMux []string
+	for pkg := range mountedPkgs {
+		if _, ok := registeredPkgs[pkg]; !ok {
+			missingFromTest = append(missingFromTest, pkg)
+		}
+	}
+	for pkg := range registeredPkgs {
+		if _, ok := mountedPkgs[pkg]; !ok {
+			missingFromMux = append(missingFromMux, pkg)
+		}
+	}
+	sort.Strings(missingFromTest)
+	sort.Strings(missingFromMux)
+
+	require.Empty(t, missingFromTest,
+		"services mounted in main.go but missing from registeredServices "+
+			"(their procedures escape the classification check): %v", missingFromTest)
+	require.Empty(t, missingFromMux,
+		"services in registeredServices but not mounted in main.go "+
+			"(stale entries — drop them): %v", missingFromMux)
+}
+
+// locateMainGo resolves cmd/fleetd/main.go relative to this test
+// file's location via runtime.Caller, which is stable regardless of
+// the test runner's working directory.
+func locateMainGo(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	// thisFile = .../server/internal/handlers/middleware/rpc_permissions_test.go
+	// main.go  = .../server/cmd/fleetd/main.go
+	serverRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", ".."))
+	mainPath := filepath.Join(serverRoot, "cmd", "fleetd", "main.go")
+	_, err := os.Stat(mainPath)
+	require.NoError(t, err, "expected main.go at %s", mainPath)
+	return mainPath
 }


### PR DESCRIPTION
**Stacked on #301** (PR 2a — resolver + middleware). Targets `feat/rbac-pr2a-resolver` as base; will retarget to `main` once 2a merges.

Second slice of PR 2 from the [granular RBAC plan](https://github.com/block/proto-fleet/pull/282). Pure infrastructure — no behavior change. The maps exist, the contract test classifies every registered procedure, but no handler reads `ProcedurePermissions` yet.

## What landed

### `server/internal/handlers/middleware/rpc_permissions.go`

Two exported maps:

- **`ProcedurePermissions{procedure → catalog key}`** — gated procedures. Empty in this PR. Populated as handlers swap from `RequireAdmin` to `RequirePermission` in subsequent PRs.
- **`ProceduresPendingMigration{procedure → note}`** — every authenticated procedure on the production Connect mux that has not yet migrated. Each entry carries a brief note about the current gate:
  - `middleware.RequireAdmin` — buildings (5), sites (6) — **11 procedures**
  - Inline `info.Role` check — fleetnodeadmin (8), serverlog (1), apikey (3, via local helper) — **12 procedures**
  - Inline `requireAdminFromContext` — curtailment writes (4) — **4 procedures**
  - Domain-layer `checkCanManageUser` — auth user-management (3) — **3 procedures**
  - `SUPER_ADMIN` role string check — auth ListUsers (1) — **1 procedure**
  - Authenticated self-read/write — auth UpdatePassword / UpdateUsername / VerifyCredentials / GetUserAuditInfo / Logout (5) — **5 procedures**
  - **Ungated** — fleetmanagement (9), command/minercommand (15), deviceset (17), collection (16), pools (5), schedule (7), errors (4), telemetry (2), activity (3), networkinfo (2), pairing (2), foremanimport (2), onboarding GetFleetOnboardingStatus (1), curtailment reads (3) — **88 procedures**

**Total: 110 entries**. Shrinking this map to zero is the exit criterion for removing `middleware/admin.go`.

### `server/internal/handlers/middleware/rpc_permissions_test.go`

Contract test that uses **reflection on the generated `*ServiceHandler` interfaces** to enumerate every procedure registered on the production mux, then asserts each appears in exactly one of:

- `interceptors.UnauthenticatedProcedures`
- `interceptors.FleetNodeAuthenticatedProcedures`
- `ProcedurePermissions`
- `ProceduresPendingMigration`

Adding a new RPC without classifying it fails the test loudly. Double-classification is also flagged.

A companion test (`TestRPCContract_ProcedurePermissionsKeysAreInCatalog`) ensures every gate key references a real catalog permission — a no-op today because `ProcedurePermissions` is empty; becomes load-bearing as PR 2c lands gates.

## What this PR does NOT do

- Does not swap any handler from `RequireAdmin` to `RequirePermission` — that's PR 2c (existing gates) and PR 2d (new gates).
- Does not change runtime authz behavior. The auth interceptor doesn't consult these maps yet; the middleware doesn't enforce them at request time.
- Does not delete `middleware/admin.go` — that lands once `ProceduresPendingMigration` is empty.
- Does not rename `user_organization.role_id` or add the raising trigger — PR 2d.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/handlers/middleware/...` clean
- [x] `go test ./internal/handlers/middleware/...` green (contract test + the existing `RequirePermission` unit tests from 2a)
- [x] Reflection-based discovery enumerates 110 authenticated procedures; the maps cover them with no gaps and no overlap
- [ ] CI run on the stack confirms no regression

## Rollback

Reverting this PR removes two files. No schema change, no data migration, no runtime behavior change to reverse.

