### PR TITLE
Curtailment: page header pill component

### DIFF
--- a/.github/workflows/protoos-e2e-tests.yml
+++ b/.github/workflows/protoos-e2e-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   e2e-tests:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
@@ -1,0 +1,92 @@
+import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import CurtailmentPill, { type CurtailmentPillEvent } from "./CurtailmentPill";
+
+const triggerName = "View curtailment details for Grid peak call";
+
+const activeCurtailmentEvent: CurtailmentPillEvent = {
+  id: "curt-1",
+  reason: "Grid peak call",
+  state: "active",
+  scopeLabel: "Whole org",
+  selectedMiners: 48,
+  estimatedReductionKw: 126.4,
+};
+
+function renderCurtailmentPill({
+  event = activeCurtailmentEvent,
+  detailsPath,
+}: {
+  event?: CurtailmentPillEvent;
+  detailsPath?: string;
+} = {}) {
+  return render(
+    <MemoryRouter>
+      <CurtailmentPill event={event} detailsPath={detailsPath} />
+    </MemoryRouter>,
+  );
+}
+
+function openCurtailmentPopover() {
+  fireEvent.click(screen.getByRole("button", { name: triggerName }));
+}
+
+describe("CurtailmentPill", () => {
+  it("renders the current curtailment state in the trigger", () => {
+    renderCurtailmentPill({
+      event: {
+        ...activeCurtailmentEvent,
+        state: "restoring",
+      },
+    });
+
+    expect(screen.getByRole("button", { name: triggerName })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByText("Curtailment restoring")).toBeVisible();
+  });
+
+  it("shows curtailment details in the popover", () => {
+    renderCurtailmentPill();
+
+    openCurtailmentPopover();
+
+    expect(screen.getByText("Grid peak call")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Whole org")).toBeInTheDocument();
+    expect(screen.getByText("48 selected miners - 126.4 kW planned")).toBeInTheDocument();
+  });
+
+  it("formats singular miner counts", () => {
+    renderCurtailmentPill({
+      event: {
+        ...activeCurtailmentEvent,
+        selectedMiners: 1,
+        estimatedReductionKw: 4,
+      },
+    });
+
+    openCurtailmentPopover();
+
+    expect(screen.getByText("1 selected miner - 4.0 kW planned")).toBeInTheDocument();
+  });
+
+  it("renders the details link only when a details path is provided", () => {
+    const { unmount } = renderCurtailmentPill();
+
+    openCurtailmentPopover();
+
+    expect(screen.queryByText("View curtailment")).not.toBeInTheDocument();
+
+    unmount();
+    render(
+      <MemoryRouter>
+        <CurtailmentPill event={activeCurtailmentEvent} detailsPath="/energy" />
+      </MemoryRouter>,
+    );
+
+    openCurtailmentPopover();
+
+    expect(screen.getByText("View curtailment").closest("a")).toHaveAttribute("href", "/energy");
+  });
+});

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
@@ -32,6 +32,17 @@ function openCurtailmentPopover(): void {
   fireEvent.click(screen.getByRole("button", { name: triggerName }));
 }
 
+function getPlannedReductionText(selectedMiners: number, estimatedReductionKw: number): string {
+  const minerLabel = selectedMiners === 1 ? "miner" : "miners";
+  const selectedMinersText = `${selectedMiners.toLocaleString()} selected ${minerLabel}`;
+  const estimatedReductionText = `${estimatedReductionKw.toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 1,
+  })} kW`;
+
+  return `${selectedMinersText} - ${estimatedReductionText} planned`;
+}
+
 describe("CurtailmentPill", () => {
   it("renders the current curtailment state in the trigger", () => {
     renderCurtailmentPill({
@@ -53,7 +64,7 @@ describe("CurtailmentPill", () => {
     expect(screen.getByText("Grid peak call")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.getByText("Whole org")).toBeInTheDocument();
-    expect(screen.getByText("48 selected miners - 126.4 kW planned")).toBeInTheDocument();
+    expect(screen.getByText(getPlannedReductionText(48, 126.4))).toBeInTheDocument();
   });
 
   it("formats singular miner counts", () => {
@@ -67,7 +78,7 @@ describe("CurtailmentPill", () => {
 
     openCurtailmentPopover();
 
-    expect(screen.getByText("1 selected miner - 4.0 kW planned")).toBeInTheDocument();
+    expect(screen.getByText(getPlannedReductionText(1, 4))).toBeInTheDocument();
   });
 
   it("does not render the details link without a details path", () => {

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
@@ -7,7 +7,6 @@ import CurtailmentPill, { type CurtailmentPillEvent } from "./CurtailmentPill";
 const triggerName = "View curtailment details for Grid peak call";
 
 const activeCurtailmentEvent: CurtailmentPillEvent = {
-  id: "curt-1",
   reason: "Grid peak call",
   state: "active",
   scopeLabel: "Whole org",
@@ -29,7 +28,7 @@ function renderCurtailmentPill({
   );
 }
 
-function openCurtailmentPopover() {
+function openCurtailmentPopover(): void {
   fireEvent.click(screen.getByRole("button", { name: triggerName }));
 }
 
@@ -71,22 +70,19 @@ describe("CurtailmentPill", () => {
     expect(screen.getByText("1 selected miner - 4.0 kW planned")).toBeInTheDocument();
   });
 
-  it("renders the details link only when a details path is provided", () => {
-    const { unmount } = renderCurtailmentPill();
+  it("does not render the details link without a details path", () => {
+    renderCurtailmentPill();
 
     openCurtailmentPopover();
 
     expect(screen.queryByText("View curtailment")).not.toBeInTheDocument();
+  });
 
-    unmount();
-    render(
-      <MemoryRouter>
-        <CurtailmentPill event={activeCurtailmentEvent} detailsPath="/energy" />
-      </MemoryRouter>,
-    );
+  it("links to the provided details path", () => {
+    renderCurtailmentPill({ detailsPath: "/energy" });
 
     openCurtailmentPopover();
 
-    expect(screen.getByText("View curtailment").closest("a")).toHaveAttribute("href", "/energy");
+    expect(screen.getByText("View curtailment")).toHaveAttribute("href", "/energy");
   });
 });

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
@@ -1,11 +1,9 @@
 import { Link } from "react-router-dom";
-import clsx from "clsx";
 
 import type { CurtailmentPillProps } from "./curtailmentPillTypes";
 import PageHeaderPopoverPill from "./PageHeaderPopoverPill";
 import {
-  curtailmentEventStateDotClassNames,
-  curtailmentEventStateLabels,
+  curtailmentEventStateConfigs,
   formatCurtailmentKw,
   formatCurtailmentSelectedMinerCount,
 } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
@@ -13,27 +11,32 @@ import {
 export type { CurtailmentPillEvent, CurtailmentPillProps, CurtailmentPillState } from "./curtailmentPillTypes";
 
 function CurtailmentPill({ event, detailsPath }: CurtailmentPillProps) {
-  const stateLabel = curtailmentEventStateLabels[event.state];
+  const stateConfig = curtailmentEventStateConfigs[event.state];
+  const plannedReductionDetail = `${formatCurtailmentSelectedMinerCount(event.selectedMiners)} - ${formatCurtailmentKw(
+    event.estimatedReductionKw,
+  )} planned`;
+  const detailRows = [
+    { id: "state", value: stateConfig.label },
+    { id: "scope", value: event.scopeLabel },
+    { id: "planned-reduction", value: plannedReductionDetail },
+  ];
 
   return (
     <PageHeaderPopoverPill
       ariaLabel={`View curtailment details for ${event.reason}`}
-      prefixIcon={
-        <span className={clsx("h-2.5 w-2.5 rounded-full", curtailmentEventStateDotClassNames[event.state])} />
-      }
+      dotClassName={stateConfig.dotClassName}
       triggerClassName="curtailment-pill-trigger"
-      triggerContent={<span className="block max-w-56 truncate">Curtailment {stateLabel.toLowerCase()}</span>}
+      triggerLabel={`Curtailment ${stateConfig.label.toLowerCase()}`}
     >
       {({ closePopover }) => (
         <div className="flex flex-col gap-3">
           <div className="min-w-0 space-y-1">
             <div className="truncate text-heading-100 text-text-primary">{event.reason}</div>
-            <div className="text-200 leading-snug text-text-primary-70">{stateLabel}</div>
-            <div className="text-200 leading-snug text-text-primary-70">{event.scopeLabel}</div>
-            <div className="text-200 leading-snug text-text-primary-70">
-              {formatCurtailmentSelectedMinerCount(event.selectedMiners)} -{" "}
-              {formatCurtailmentKw(event.estimatedReductionKw)} planned
-            </div>
+            {detailRows.map(({ id, value }) => (
+              <div key={id} className="text-200 leading-snug text-text-primary-70">
+                {value}
+              </div>
+            ))}
           </div>
 
           {detailsPath ? (

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
@@ -1,39 +1,32 @@
-import { useState } from "react";
+import { type MouseEvent, useState } from "react";
 import { Link } from "react-router-dom";
 import clsx from "clsx";
 
+import { type CurtailmentPillProps, type CurtailmentPillState } from "./curtailmentPillTypes";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Popover, { PopoverProvider, popoverSizes, useResponsivePopover } from "@/shared/components/Popover";
 import { positions } from "@/shared/constants";
 
-export const curtailmentPillStates = ["pending", "active", "restoring"] as const;
+export type { CurtailmentPillEvent, CurtailmentPillProps, CurtailmentPillState } from "./curtailmentPillTypes";
 
-export type CurtailmentPillState = (typeof curtailmentPillStates)[number];
-
-export interface CurtailmentPillEvent {
-  id: string;
-  reason: string;
-  state: CurtailmentPillState;
-  scopeLabel: string;
-  selectedMiners: number;
-  estimatedReductionKw: number;
-}
-
-export interface CurtailmentPillProps {
-  event: CurtailmentPillEvent;
-  detailsPath?: string;
-}
-
-const eventStateLabels: Record<CurtailmentPillState, string> = {
-  pending: "Pending",
-  active: "Active",
-  restoring: "Restoring",
+type CurtailmentStateViewConfig = {
+  label: string;
+  dotClassName: string;
 };
 
-const eventStateDotClassNames: Record<CurtailmentPillState, string> = {
-  pending: "bg-core-accent-fill",
-  active: "bg-intent-warning-fill",
-  restoring: "bg-core-accent-fill",
+const curtailmentStateViewConfig: Record<CurtailmentPillState, CurtailmentStateViewConfig> = {
+  pending: {
+    label: "Pending",
+    dotClassName: "bg-core-accent-fill",
+  },
+  active: {
+    label: "Active",
+    dotClassName: "bg-intent-warning-fill",
+  },
+  restoring: {
+    label: "Restoring",
+    dotClassName: "bg-core-accent-fill",
+  },
 };
 
 function formatKw(value: number): string {
@@ -50,7 +43,19 @@ function formatMinerCount(minerCount: number): string {
 function CurtailmentPillContent({ event, detailsPath }: CurtailmentPillProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { triggerRef } = useResponsivePopover();
-  const stateLabel = eventStateLabels[event.state];
+  const stateConfig = curtailmentStateViewConfig[event.state];
+
+  function closePopover(): void {
+    setIsPopoverOpen(false);
+  }
+
+  function handleTriggerClick(clickEvent: MouseEvent<HTMLButtonElement>): void {
+    setIsPopoverOpen((current) => !current);
+
+    if (clickEvent.detail > 0) {
+      clickEvent.currentTarget.blur();
+    }
+  }
 
   return (
     <div className="curtailment-pill-trigger relative" ref={triggerRef}>
@@ -60,16 +65,10 @@ function CurtailmentPillContent({ event, detailsPath }: CurtailmentPillProps) {
         ariaHasPopup={true}
         ariaExpanded={isPopoverOpen}
         ariaLabel={`View curtailment details for ${event.reason}`}
-        onClick={(clickEvent) => {
-          setIsPopoverOpen((current) => !current);
-
-          if (clickEvent.detail > 0) {
-            clickEvent.currentTarget.blur();
-          }
-        }}
-        prefixIcon={<span className={clsx("h-2.5 w-2.5 rounded-full", eventStateDotClassNames[event.state])} />}
+        onClick={handleTriggerClick}
+        prefixIcon={<span className={clsx("h-2.5 w-2.5 rounded-full", stateConfig.dotClassName)} />}
       >
-        <span className="block max-w-56 truncate">Curtailment {stateLabel.toLowerCase()}</span>
+        <span className="block max-w-56 truncate">Curtailment {stateConfig.label.toLowerCase()}</span>
       </Button>
 
       {isPopoverOpen ? (
@@ -77,13 +76,13 @@ function CurtailmentPillContent({ event, detailsPath }: CurtailmentPillProps) {
           position={positions["bottom left"]}
           size={popoverSizes.small}
           className="!space-y-0 px-4 pt-4 pb-3"
-          closePopover={() => setIsPopoverOpen(false)}
+          closePopover={closePopover}
           closeIgnoreSelectors={[".curtailment-pill-trigger"]}
         >
           <div className="flex flex-col gap-3">
             <div className="min-w-0 space-y-1">
               <div className="truncate text-heading-100 text-text-primary">{event.reason}</div>
-              <div className="text-200 leading-snug text-text-primary-70">{stateLabel}</div>
+              <div className="text-200 leading-snug text-text-primary-70">{stateConfig.label}</div>
               <div className="text-200 leading-snug text-text-primary-70">{event.scopeLabel}</div>
               <div className="text-200 leading-snug text-text-primary-70">
                 {formatMinerCount(event.selectedMiners)} - {formatKw(event.estimatedReductionKw)} planned
@@ -94,7 +93,7 @@ function CurtailmentPillContent({ event, detailsPath }: CurtailmentPillProps) {
               <div className="border-t border-border-5 pt-3">
                 <Link
                   to={detailsPath}
-                  onClick={() => setIsPopoverOpen(false)}
+                  onClick={closePopover}
                   className="block rounded-xl px-3 py-2.5 text-emphasis-300 text-text-primary transition-[background-color] duration-200 ease-in-out hover:bg-core-primary-5"
                 >
                   View curtailment

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
@@ -1,117 +1,55 @@
-import { type MouseEvent, useState } from "react";
 import { Link } from "react-router-dom";
 import clsx from "clsx";
 
-import { type CurtailmentPillProps, type CurtailmentPillState } from "./curtailmentPillTypes";
-import Button, { sizes, variants } from "@/shared/components/Button";
-import Popover, { PopoverProvider, popoverSizes, useResponsivePopover } from "@/shared/components/Popover";
-import { positions } from "@/shared/constants";
+import type { CurtailmentPillProps } from "./curtailmentPillTypes";
+import PageHeaderPopoverPill from "./PageHeaderPopoverPill";
+import {
+  curtailmentEventStateDotClassNames,
+  curtailmentEventStateLabels,
+  formatCurtailmentKw,
+  formatCurtailmentSelectedMinerCount,
+} from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 
 export type { CurtailmentPillEvent, CurtailmentPillProps, CurtailmentPillState } from "./curtailmentPillTypes";
 
-type CurtailmentStateViewConfig = {
-  label: string;
-  dotClassName: string;
-};
-
-const curtailmentStateViewConfig: Record<CurtailmentPillState, CurtailmentStateViewConfig> = {
-  pending: {
-    label: "Pending",
-    dotClassName: "bg-core-accent-fill",
-  },
-  active: {
-    label: "Active",
-    dotClassName: "bg-intent-warning-fill",
-  },
-  restoring: {
-    label: "Restoring",
-    dotClassName: "bg-core-accent-fill",
-  },
-};
-
-function formatKw(value: number): string {
-  return `${value.toLocaleString(undefined, {
-    maximumFractionDigits: 1,
-    minimumFractionDigits: 1,
-  })} kW`;
-}
-
-function formatMinerCount(minerCount: number): string {
-  return `${minerCount.toLocaleString()} selected ${minerCount === 1 ? "miner" : "miners"}`;
-}
-
-function CurtailmentPillContent({ event, detailsPath }: CurtailmentPillProps) {
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const { triggerRef } = useResponsivePopover();
-  const stateConfig = curtailmentStateViewConfig[event.state];
-
-  function closePopover(): void {
-    setIsPopoverOpen(false);
-  }
-
-  function handleTriggerClick(clickEvent: MouseEvent<HTMLButtonElement>): void {
-    setIsPopoverOpen((current) => !current);
-
-    if (clickEvent.detail > 0) {
-      clickEvent.currentTarget.blur();
-    }
-  }
+function CurtailmentPill({ event, detailsPath }: CurtailmentPillProps) {
+  const stateLabel = curtailmentEventStateLabels[event.state];
 
   return (
-    <div className="curtailment-pill-trigger relative" ref={triggerRef}>
-      <Button
-        variant={variants.secondary}
-        size={sizes.compact}
-        ariaHasPopup={true}
-        ariaExpanded={isPopoverOpen}
-        ariaLabel={`View curtailment details for ${event.reason}`}
-        onClick={handleTriggerClick}
-        prefixIcon={<span className={clsx("h-2.5 w-2.5 rounded-full", stateConfig.dotClassName)} />}
-      >
-        <span className="block max-w-56 truncate">Curtailment {stateConfig.label.toLowerCase()}</span>
-      </Button>
-
-      {isPopoverOpen ? (
-        <Popover
-          position={positions["bottom left"]}
-          size={popoverSizes.small}
-          className="!space-y-0 px-4 pt-4 pb-3"
-          closePopover={closePopover}
-          closeIgnoreSelectors={[".curtailment-pill-trigger"]}
-        >
-          <div className="flex flex-col gap-3">
-            <div className="min-w-0 space-y-1">
-              <div className="truncate text-heading-100 text-text-primary">{event.reason}</div>
-              <div className="text-200 leading-snug text-text-primary-70">{stateConfig.label}</div>
-              <div className="text-200 leading-snug text-text-primary-70">{event.scopeLabel}</div>
-              <div className="text-200 leading-snug text-text-primary-70">
-                {formatMinerCount(event.selectedMiners)} - {formatKw(event.estimatedReductionKw)} planned
-              </div>
+    <PageHeaderPopoverPill
+      ariaLabel={`View curtailment details for ${event.reason}`}
+      prefixIcon={
+        <span className={clsx("h-2.5 w-2.5 rounded-full", curtailmentEventStateDotClassNames[event.state])} />
+      }
+      triggerClassName="curtailment-pill-trigger"
+      triggerContent={<span className="block max-w-56 truncate">Curtailment {stateLabel.toLowerCase()}</span>}
+    >
+      {({ closePopover }) => (
+        <div className="flex flex-col gap-3">
+          <div className="min-w-0 space-y-1">
+            <div className="truncate text-heading-100 text-text-primary">{event.reason}</div>
+            <div className="text-200 leading-snug text-text-primary-70">{stateLabel}</div>
+            <div className="text-200 leading-snug text-text-primary-70">{event.scopeLabel}</div>
+            <div className="text-200 leading-snug text-text-primary-70">
+              {formatCurtailmentSelectedMinerCount(event.selectedMiners)} -{" "}
+              {formatCurtailmentKw(event.estimatedReductionKw)} planned
             </div>
-
-            {detailsPath ? (
-              <div className="border-t border-border-5 pt-3">
-                <Link
-                  to={detailsPath}
-                  onClick={closePopover}
-                  className="block rounded-xl px-3 py-2.5 text-emphasis-300 text-text-primary transition-[background-color] duration-200 ease-in-out hover:bg-core-primary-5"
-                >
-                  View curtailment
-                </Link>
-              </div>
-            ) : null}
           </div>
-        </Popover>
-      ) : null}
-    </div>
-  );
-}
 
-function CurtailmentPill(props: CurtailmentPillProps) {
-  return (
-    <PopoverProvider>
-      <CurtailmentPillContent {...props} />
-    </PopoverProvider>
+          {detailsPath ? (
+            <div className="border-t border-border-5 pt-3">
+              <Link
+                to={detailsPath}
+                onClick={closePopover}
+                className="block rounded-xl px-3 py-2.5 text-emphasis-300 text-text-primary transition-[background-color] duration-200 ease-in-out hover:bg-core-primary-5"
+              >
+                View curtailment
+              </Link>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </PageHeaderPopoverPill>
   );
 }
 

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import clsx from "clsx";
+
+import Button, { sizes, variants } from "@/shared/components/Button";
+import Popover, { PopoverProvider, popoverSizes, useResponsivePopover } from "@/shared/components/Popover";
+import { positions } from "@/shared/constants";
+
+export const curtailmentPillStates = ["pending", "active", "restoring"] as const;
+
+export type CurtailmentPillState = (typeof curtailmentPillStates)[number];
+
+export interface CurtailmentPillEvent {
+  id: string;
+  reason: string;
+  state: CurtailmentPillState;
+  scopeLabel: string;
+  selectedMiners: number;
+  estimatedReductionKw: number;
+}
+
+export interface CurtailmentPillProps {
+  event: CurtailmentPillEvent;
+  detailsPath?: string;
+}
+
+const eventStateLabels: Record<CurtailmentPillState, string> = {
+  pending: "Pending",
+  active: "Active",
+  restoring: "Restoring",
+};
+
+const eventStateDotClassNames: Record<CurtailmentPillState, string> = {
+  pending: "bg-core-accent-fill",
+  active: "bg-intent-warning-fill",
+  restoring: "bg-core-accent-fill",
+};
+
+function formatKw(value: number): string {
+  return `${value.toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 1,
+  })} kW`;
+}
+
+function formatMinerCount(minerCount: number): string {
+  return `${minerCount.toLocaleString()} selected ${minerCount === 1 ? "miner" : "miners"}`;
+}
+
+function CurtailmentPillContent({ event, detailsPath }: CurtailmentPillProps) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const { triggerRef } = useResponsivePopover();
+  const stateLabel = eventStateLabels[event.state];
+
+  return (
+    <div className="curtailment-pill-trigger relative" ref={triggerRef}>
+      <Button
+        variant={variants.secondary}
+        size={sizes.compact}
+        ariaHasPopup={true}
+        ariaExpanded={isPopoverOpen}
+        ariaLabel={`View curtailment details for ${event.reason}`}
+        onClick={(clickEvent) => {
+          setIsPopoverOpen((current) => !current);
+
+          if (clickEvent.detail > 0) {
+            clickEvent.currentTarget.blur();
+          }
+        }}
+        prefixIcon={<span className={clsx("h-2.5 w-2.5 rounded-full", eventStateDotClassNames[event.state])} />}
+      >
+        <span className="block max-w-56 truncate">Curtailment {stateLabel.toLowerCase()}</span>
+      </Button>
+
+      {isPopoverOpen ? (
+        <Popover
+          position={positions["bottom left"]}
+          size={popoverSizes.small}
+          className="!space-y-0 px-4 pt-4 pb-3"
+          closePopover={() => setIsPopoverOpen(false)}
+          closeIgnoreSelectors={[".curtailment-pill-trigger"]}
+        >
+          <div className="flex flex-col gap-3">
+            <div className="min-w-0 space-y-1">
+              <div className="truncate text-heading-100 text-text-primary">{event.reason}</div>
+              <div className="text-200 leading-snug text-text-primary-70">{stateLabel}</div>
+              <div className="text-200 leading-snug text-text-primary-70">{event.scopeLabel}</div>
+              <div className="text-200 leading-snug text-text-primary-70">
+                {formatMinerCount(event.selectedMiners)} - {formatKw(event.estimatedReductionKw)} planned
+              </div>
+            </div>
+
+            {detailsPath ? (
+              <div className="border-t border-border-5 pt-3">
+                <Link
+                  to={detailsPath}
+                  onClick={() => setIsPopoverOpen(false)}
+                  className="block rounded-xl px-3 py-2.5 text-emphasis-300 text-text-primary transition-[background-color] duration-200 ease-in-out hover:bg-core-primary-5"
+                >
+                  View curtailment
+                </Link>
+              </div>
+            ) : null}
+          </div>
+        </Popover>
+      ) : null}
+    </div>
+  );
+}
+
+function CurtailmentPill(props: CurtailmentPillProps) {
+  return (
+    <PopoverProvider>
+      <CurtailmentPillContent {...props} />
+    </PopoverProvider>
+  );
+}
+
+export default CurtailmentPill;

--- a/client/src/protoFleet/components/PageHeader/PageHeader.stories.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.stories.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useState } from "react";
 import { create } from "@bufbuild/protobuf";
 import { action } from "storybook/actions";
 
+import CurtailmentPillComponent, { curtailmentPillStates, type CurtailmentPillEvent } from "./CurtailmentPill";
 import SchedulePillComponent from "./SchedulePill";
 import { buildSchedulePopoverSections, selectPillSchedule } from "./schedulePillUtils";
 import type { UseSchedulePillDataResult } from "./useSchedulePillData";
@@ -185,6 +186,19 @@ const InteractiveSchedulePillStory = () => {
   );
 };
 
+const storyCurtailmentEvent: CurtailmentPillEvent = {
+  id: "curtailment-1",
+  reason: "ERCOT demand response",
+  state: "active",
+  scopeLabel: "Racks A1-A4",
+  selectedMiners: 48,
+  estimatedReductionKw: 126.4,
+};
+
+const CurtailmentPillStory = ({ state = "active" }: { state?: CurtailmentPillEvent["state"] }) => (
+  <CurtailmentPillComponent event={{ ...storyCurtailmentEvent, state }} />
+);
+
 const StoryFrame = ({ children }: { children: ReactNode }) => (
   <div className="flex min-h-[32rem] items-start justify-end bg-surface-base px-16 py-10">{children}</div>
 );
@@ -207,6 +221,29 @@ export const SchedulePill = () => {
       <InteractiveSchedulePillStory />
     </StoryFrame>
   );
+};
+
+export const CurtailmentPill = ({ state }: { state?: CurtailmentPillEvent["state"] }) => {
+  return (
+    <StoryFrame>
+      <CurtailmentPillStory state={state} />
+    </StoryFrame>
+  );
+};
+
+CurtailmentPill.args = {
+  state: "active",
+};
+
+CurtailmentPill.argTypes = {
+  state: {
+    control: "select",
+    options: curtailmentPillStates,
+  },
+};
+
+CurtailmentPill.parameters = {
+  withRouter: false,
 };
 
 export default {

--- a/client/src/protoFleet/components/PageHeader/PageHeader.stories.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.stories.tsx
@@ -2,7 +2,8 @@ import { type ReactNode, useState } from "react";
 import { create } from "@bufbuild/protobuf";
 import { action } from "storybook/actions";
 
-import CurtailmentPillComponent, { curtailmentPillStates, type CurtailmentPillEvent } from "./CurtailmentPill";
+import CurtailmentPillComponent from "./CurtailmentPill";
+import { type CurtailmentPillEvent, type CurtailmentPillState, curtailmentPillStates } from "./curtailmentPillTypes";
 import SchedulePillComponent from "./SchedulePill";
 import { buildSchedulePopoverSections, selectPillSchedule } from "./schedulePillUtils";
 import type { UseSchedulePillDataResult } from "./useSchedulePillData";
@@ -187,17 +188,12 @@ const InteractiveSchedulePillStory = () => {
 };
 
 const storyCurtailmentEvent: CurtailmentPillEvent = {
-  id: "curtailment-1",
   reason: "ERCOT demand response",
   state: "active",
   scopeLabel: "Racks A1-A4",
   selectedMiners: 48,
   estimatedReductionKw: 126.4,
 };
-
-const CurtailmentPillStory = ({ state = "active" }: { state?: CurtailmentPillEvent["state"] }) => (
-  <CurtailmentPillComponent event={{ ...storyCurtailmentEvent, state }} />
-);
 
 const StoryFrame = ({ children }: { children: ReactNode }) => (
   <div className="flex min-h-[32rem] items-start justify-end bg-surface-base px-16 py-10">{children}</div>
@@ -223,10 +219,10 @@ export const SchedulePill = () => {
   );
 };
 
-export const CurtailmentPill = ({ state }: { state?: CurtailmentPillEvent["state"] }) => {
+export const CurtailmentPill = ({ state = "active" }: { state?: CurtailmentPillState }) => {
   return (
     <StoryFrame>
-      <CurtailmentPillStory state={state} />
+      <CurtailmentPillComponent event={{ ...storyCurtailmentEvent, state }} />
     </StoryFrame>
   );
 };

--- a/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import PageHeaderPopoverPill from "./PageHeaderPopoverPill";
+
+function renderPageHeaderPopoverPill() {
+  return render(
+    <PageHeaderPopoverPill
+      ariaLabel="Toggle details"
+      dotClassName="bg-core-accent-fill"
+      triggerClassName="first-trigger second-trigger"
+      triggerLabel="Details"
+    >
+      {() => <div>Popover content</div>}
+    </PageHeaderPopoverPill>,
+  );
+}
+
+describe("PageHeaderPopoverPill", () => {
+  it("keeps trigger clicks ignored when the trigger has multiple classes", () => {
+    renderPageHeaderPopoverPill();
+
+    const trigger = screen.getByRole("button", { name: "Toggle details" });
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("Popover content")).toBeInTheDocument();
+
+    fireEvent.mouseDown(trigger);
+    fireEvent.click(trigger);
+
+    expect(screen.queryByText("Popover content")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Popover, { PopoverProvider, popoverSizes, useResponsivePopover } from "@/shared/components/Popover";
 import { positions } from "@/shared/constants";
+import { classNameToSelectors } from "@/shared/utils/cssUtils";
 
 interface PageHeaderPopoverPillProps {
   ariaLabel: string;
@@ -11,14 +12,6 @@ interface PageHeaderPopoverPillProps {
   dotClassName: string;
   triggerClassName: string;
   triggerLabel: ReactNode;
-}
-
-function getClassNameSelectors(className: string): string[] {
-  return className
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((classNameToken) => `.${classNameToken}`);
 }
 
 function PageHeaderPopoverPillContent({
@@ -30,7 +23,7 @@ function PageHeaderPopoverPillContent({
 }: PageHeaderPopoverPillProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { triggerRef } = useResponsivePopover();
-  const closeIgnoreSelectors = getClassNameSelectors(triggerClassName);
+  const closeIgnoreSelectors = classNameToSelectors(triggerClassName);
 
   function closePopover(): void {
     setIsPopoverOpen(false);

--- a/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
@@ -1,0 +1,74 @@
+import { type MouseEvent, type ReactNode, useState } from "react";
+
+import Button, { sizes, variants } from "@/shared/components/Button";
+import Popover, { PopoverProvider, popoverSizes, useResponsivePopover } from "@/shared/components/Popover";
+import { positions } from "@/shared/constants";
+
+interface PageHeaderPopoverPillProps {
+  ariaLabel: string;
+  children: (props: { closePopover: () => void }) => ReactNode;
+  prefixIcon: ReactNode;
+  triggerClassName: string;
+  triggerContent: ReactNode;
+}
+
+function PageHeaderPopoverPillContent({
+  ariaLabel,
+  children,
+  prefixIcon,
+  triggerClassName,
+  triggerContent,
+}: PageHeaderPopoverPillProps) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const { triggerRef } = useResponsivePopover();
+
+  function closePopover(): void {
+    setIsPopoverOpen(false);
+  }
+
+  function handleTriggerClick(clickEvent: MouseEvent<HTMLButtonElement>): void {
+    setIsPopoverOpen((current) => !current);
+
+    if (clickEvent.detail > 0) {
+      clickEvent.currentTarget.blur();
+    }
+  }
+
+  return (
+    <div className={`${triggerClassName} relative`} ref={triggerRef}>
+      <Button
+        variant={variants.secondary}
+        size={sizes.compact}
+        ariaHasPopup={true}
+        ariaExpanded={isPopoverOpen}
+        ariaLabel={ariaLabel}
+        onClick={handleTriggerClick}
+        prefixIcon={prefixIcon}
+      >
+        {triggerContent}
+      </Button>
+
+      {isPopoverOpen ? (
+        <Popover
+          position={positions["bottom left"]}
+          size={popoverSizes.small}
+          className="!space-y-0 px-4 pt-4 pb-3"
+          closePopover={closePopover}
+          closeIgnoreSelectors={[`.${triggerClassName}`]}
+        >
+          {children({ closePopover })}
+        </Popover>
+      ) : null}
+    </div>
+  );
+}
+
+function PageHeaderPopoverPill(props: PageHeaderPopoverPillProps) {
+  return (
+    <PopoverProvider>
+      <PageHeaderPopoverPillContent {...props} />
+    </PopoverProvider>
+  );
+}
+
+export default PageHeaderPopoverPill;

--- a/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
@@ -1,4 +1,5 @@
 import { type MouseEvent, type ReactNode, useState } from "react";
+import clsx from "clsx";
 
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Popover, { PopoverProvider, popoverSizes, useResponsivePopover } from "@/shared/components/Popover";
@@ -7,17 +8,17 @@ import { positions } from "@/shared/constants";
 interface PageHeaderPopoverPillProps {
   ariaLabel: string;
   children: (props: { closePopover: () => void }) => ReactNode;
-  prefixIcon: ReactNode;
+  dotClassName: string;
   triggerClassName: string;
-  triggerContent: ReactNode;
+  triggerLabel: ReactNode;
 }
 
 function PageHeaderPopoverPillContent({
   ariaLabel,
   children,
-  prefixIcon,
+  dotClassName,
   triggerClassName,
-  triggerContent,
+  triggerLabel,
 }: PageHeaderPopoverPillProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { triggerRef } = useResponsivePopover();
@@ -43,9 +44,9 @@ function PageHeaderPopoverPillContent({
         ariaExpanded={isPopoverOpen}
         ariaLabel={ariaLabel}
         onClick={handleTriggerClick}
-        prefixIcon={prefixIcon}
+        prefixIcon={<span className={clsx("h-2.5 w-2.5 rounded-full", dotClassName)} />}
       >
-        {triggerContent}
+        <span className="block max-w-56 truncate">{triggerLabel}</span>
       </Button>
 
       {isPopoverOpen ? (

--- a/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
@@ -13,6 +13,14 @@ interface PageHeaderPopoverPillProps {
   triggerLabel: ReactNode;
 }
 
+function getClassNameSelectors(className: string): string[] {
+  return className
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((classNameToken) => `.${classNameToken}`);
+}
+
 function PageHeaderPopoverPillContent({
   ariaLabel,
   children,
@@ -22,6 +30,7 @@ function PageHeaderPopoverPillContent({
 }: PageHeaderPopoverPillProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { triggerRef } = useResponsivePopover();
+  const closeIgnoreSelectors = getClassNameSelectors(triggerClassName);
 
   function closePopover(): void {
     setIsPopoverOpen(false);
@@ -55,7 +64,7 @@ function PageHeaderPopoverPillContent({
           size={popoverSizes.small}
           className="!space-y-0 px-4 pt-4 pb-3"
           closePopover={closePopover}
-          closeIgnoreSelectors={[`.${triggerClassName}`]}
+          closeIgnoreSelectors={closeIgnoreSelectors}
         >
           {children({ closePopover })}
         </Popover>

--- a/client/src/protoFleet/components/PageHeader/SchedulePill.tsx
+++ b/client/src/protoFleet/components/PageHeader/SchedulePill.tsx
@@ -1,5 +1,3 @@
-import clsx from "clsx";
-
 import PageHeaderPopoverPill from "./PageHeaderPopoverPill";
 import type { ScheduleListItem } from "@/protoFleet/api/useScheduleApi";
 import type { SchedulePopoverSection } from "@/protoFleet/components/PageHeader/schedulePillUtils";
@@ -17,11 +15,9 @@ const SchedulePill = ({ pillSchedule, sections, pendingScheduleId, onToggleSched
   return (
     <PageHeaderPopoverPill
       ariaLabel={`View schedule details for ${pillSchedule.name}`}
-      prefixIcon={
-        <span className={clsx("h-2.5 w-2.5 rounded-full", scheduleStatusDotClassName[pillSchedule.status])} />
-      }
+      dotClassName={scheduleStatusDotClassName[pillSchedule.status]}
       triggerClassName="schedule-pill-trigger"
-      triggerContent={<span className="block max-w-56 truncate">{pillSchedule.name}</span>}
+      triggerLabel={pillSchedule.name}
     >
       {({ closePopover }) => (
         <SchedulePopover

--- a/client/src/protoFleet/components/PageHeader/SchedulePill.tsx
+++ b/client/src/protoFleet/components/PageHeader/SchedulePill.tsx
@@ -1,13 +1,10 @@
-import { useState } from "react";
 import clsx from "clsx";
 
+import PageHeaderPopoverPill from "./PageHeaderPopoverPill";
 import type { ScheduleListItem } from "@/protoFleet/api/useScheduleApi";
 import type { SchedulePopoverSection } from "@/protoFleet/components/PageHeader/schedulePillUtils";
 import SchedulePopover from "@/protoFleet/components/PageHeader/SchedulePopover";
 import { scheduleStatusDotClassName } from "@/protoFleet/features/settings/components/Schedules/constants";
-import Button, { sizes, variants } from "@/shared/components/Button";
-import Popover, { PopoverProvider, popoverSizes, useResponsivePopover } from "@/shared/components/Popover";
-import { positions } from "@/shared/constants";
 
 interface SchedulePillProps {
   pillSchedule: ScheduleListItem;
@@ -16,61 +13,26 @@ interface SchedulePillProps {
   onToggleScheduleStatus: (schedule: ScheduleListItem) => Promise<void>;
 }
 
-const SchedulePillContent = ({
-  pillSchedule,
-  sections,
-  pendingScheduleId,
-  onToggleScheduleStatus,
-}: SchedulePillProps) => {
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const { triggerRef } = useResponsivePopover();
-
+const SchedulePill = ({ pillSchedule, sections, pendingScheduleId, onToggleScheduleStatus }: SchedulePillProps) => {
   return (
-    <div className="schedule-pill-trigger relative" ref={triggerRef}>
-      <Button
-        variant={variants.secondary}
-        size={sizes.compact}
-        ariaHasPopup={true}
-        ariaExpanded={isPopoverOpen}
-        ariaLabel={`View schedule details for ${pillSchedule.name}`}
-        onClick={(event) => {
-          setIsPopoverOpen((current) => !current);
-
-          if (event.detail > 0) {
-            event.currentTarget.blur();
-          }
-        }}
-        prefixIcon={
-          <span className={clsx("h-2.5 w-2.5 rounded-full", scheduleStatusDotClassName[pillSchedule.status])} />
-        }
-      >
-        <span className="block max-w-56 truncate">{pillSchedule.name}</span>
-      </Button>
-
-      {isPopoverOpen ? (
-        <Popover
-          position={positions["bottom left"]}
-          size={popoverSizes.small}
-          className="!space-y-0 px-4 pt-4 pb-3"
-          closePopover={() => setIsPopoverOpen(false)}
-          closeIgnoreSelectors={[".schedule-pill-trigger"]}
-        >
-          <SchedulePopover
-            sections={sections}
-            pendingScheduleId={pendingScheduleId}
-            onToggleScheduleStatus={onToggleScheduleStatus}
-            onNavigateToSchedules={() => setIsPopoverOpen(false)}
-          />
-        </Popover>
-      ) : null}
-    </div>
+    <PageHeaderPopoverPill
+      ariaLabel={`View schedule details for ${pillSchedule.name}`}
+      prefixIcon={
+        <span className={clsx("h-2.5 w-2.5 rounded-full", scheduleStatusDotClassName[pillSchedule.status])} />
+      }
+      triggerClassName="schedule-pill-trigger"
+      triggerContent={<span className="block max-w-56 truncate">{pillSchedule.name}</span>}
+    >
+      {({ closePopover }) => (
+        <SchedulePopover
+          sections={sections}
+          pendingScheduleId={pendingScheduleId}
+          onToggleScheduleStatus={onToggleScheduleStatus}
+          onNavigateToSchedules={closePopover}
+        />
+      )}
+    </PageHeaderPopoverPill>
   );
 };
-
-const SchedulePill = (props: SchedulePillProps) => (
-  <PopoverProvider>
-    <SchedulePillContent {...props} />
-  </PopoverProvider>
-);
 
 export default SchedulePill;

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillTypes.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillTypes.ts
@@ -1,4 +1,10 @@
-export const curtailmentPillStates = ["pending", "active", "restoring"] as const;
+import type { CurtailmentEventState } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
+
+export const curtailmentPillStates = [
+  "pending",
+  "active",
+  "restoring",
+] as const satisfies readonly CurtailmentEventState[];
 
 export type CurtailmentPillState = (typeof curtailmentPillStates)[number];
 

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillTypes.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillTypes.ts
@@ -1,0 +1,16 @@
+export const curtailmentPillStates = ["pending", "active", "restoring"] as const;
+
+export type CurtailmentPillState = (typeof curtailmentPillStates)[number];
+
+export interface CurtailmentPillEvent {
+  reason: string;
+  state: CurtailmentPillState;
+  scopeLabel: string;
+  selectedMiners: number;
+  estimatedReductionKw: number;
+}
+
+export interface CurtailmentPillProps {
+  event: CurtailmentPillEvent;
+  detailsPath?: string;
+}

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -1,7 +1,12 @@
 import { type ReactElement, type ReactNode } from "react";
 import clsx from "clsx";
 
-import type { CurtailmentEventState } from "@/protoFleet/features/energy/CurtailmentHistory";
+import {
+  type CurtailmentEventState,
+  formatCurtailmentKw as formatKw,
+  formatCurtailmentMinerCount as formatMinerCount,
+  getCurtailmentTargetKw as getTargetKw,
+} from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 import { Alert, Success } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Header from "@/shared/components/Header";
@@ -216,23 +221,6 @@ function StatBlock({ label, value, detail }: StatBlockProps): ReactElement {
       ) : null}
     </div>
   );
-}
-
-function getTargetKw(event: Pick<ActiveCurtailmentEvent, "targetKw" | "estimatedReductionKw">): number {
-  return event.targetKw ?? event.estimatedReductionKw;
-}
-
-function formatKw(value: number, fractionDigits = 1): string {
-  const finiteValue = Number.isFinite(value) ? value : 0;
-
-  return `${finiteValue.toLocaleString(undefined, {
-    maximumFractionDigits: fractionDigits,
-    minimumFractionDigits: fractionDigits,
-  })} kW`;
-}
-
-function formatMinerCount(minerCount: number): string {
-  return `${minerCount.toLocaleString()} ${minerCount === 1 ? "miner" : "miners"}`;
 }
 
 function getDateTime(value?: string): Date | undefined {

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -4,10 +4,8 @@ import clsx from "clsx";
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
 import {
   type CurtailmentEventState,
+  curtailmentEventStateConfigs,
   curtailmentEventStates,
-  curtailmentEventStateDotClassNames as eventStateDotClassNames,
-  curtailmentEventStateLabels as eventStateLabels,
-  curtailmentEventStateOrder as eventStateOrder,
   formatCurtailmentMinerCount as formatMinerCount,
   formatCurtailmentTargetVsActual as formatTargetVsActual,
   getCurtailmentTargetKw as getTargetKw,
@@ -105,7 +103,10 @@ const priorityLabels: Record<CurtailmentPriority, string> = {
   emergency: "Emergency",
 };
 
-const statusFilterOptions = curtailmentEventStates.map((state) => ({ id: state, label: eventStateLabels[state] }));
+const statusFilterOptions = curtailmentEventStates.map((state) => ({
+  id: state,
+  label: curtailmentEventStateConfigs[state].label,
+}));
 const statusFilterOptionIds = new Set<string>(curtailmentEventStates);
 
 const historyColumns = ["event", "scope", "target", "state"] as const;
@@ -198,7 +199,7 @@ function getHistoryColumnSortValue(event: CurtailmentHistoryEvent, field: Histor
     case "target":
       return getTargetKw(event);
     case "state":
-      return eventStateOrder[event.state];
+      return curtailmentEventStateConfigs[event.state].order;
   }
 }
 
@@ -299,6 +300,7 @@ function CurtailmentSummaryModal({
   const endedAt = formatDateTime(event.endedAt);
   const scheduledAt = formatDateTime(event.scheduledAt);
   const createdAt = formatDateTime(event.createdAt);
+  const eventStateConfig = curtailmentEventStateConfigs[event.state];
   const buttons: CurtailmentSummaryModalButton[] = [];
 
   if (onStop) {
@@ -336,7 +338,7 @@ function CurtailmentSummaryModal({
           <DetailRow label="ID" value={event.id} />
           <DetailRow label="Applies to" value={event.scopeLabel} secondary={formatMinerCount(event.selectedMiners)} />
           <DetailRow label="Power target vs actual" value={formatTargetVsActual(event)} />
-          <DetailRow label="Status" value={eventStateLabels[event.state]} secondary={getHistoryStatusDetail(event)} />
+          <DetailRow label="Status" value={eventStateConfig.label} secondary={getHistoryStatusDetail(event)} />
           <DetailRow label="Started" value={startedAt ?? "Not started yet"} />
           {scheduledAt ? <DetailRow label="Scheduled" value={scheduledAt} /> : null}
           {createdAt ? <DetailRow label="Created" value={createdAt} /> : null}
@@ -357,6 +359,7 @@ function CurtailmentHistoryRow({
   stopDisabled,
 }: CurtailmentHistoryRowProps): ReactElement {
   const canStop = Boolean(onRequestStop) && isActiveStoppableEvent(event, activeEventId);
+  const eventStateConfig = curtailmentEventStateConfigs[event.state];
 
   const handleRowClick = (clickEvent: MouseEvent<HTMLTableRowElement>) => {
     if (shouldIgnoreRowActivation(clickEvent.target, clickEvent.currentTarget)) {
@@ -413,8 +416,8 @@ function CurtailmentHistoryRow({
       <td className="py-4 pr-6 align-top text-text-primary">{formatTargetVsActual(event)}</td>
       <td className="py-4 pr-6 align-top">
         <div className="flex items-center gap-2 text-emphasis-300 text-text-primary">
-          <Dot className={eventStateDotClassNames[event.state]} />
-          {eventStateLabels[event.state]}
+          <Dot className={eventStateConfig.dotClassName} />
+          {eventStateConfig.label}
         </div>
         <div className="text-200 text-text-primary-50">{getHistoryStatusDetail(event)}</div>
       </td>

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -2,6 +2,16 @@ import { type KeyboardEvent, type MouseEvent, type ReactElement, useMemo, useSta
 import clsx from "clsx";
 
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
+import {
+  type CurtailmentEventState,
+  curtailmentEventStates,
+  curtailmentEventStateDotClassNames as eventStateDotClassNames,
+  curtailmentEventStateLabels as eventStateLabels,
+  curtailmentEventStateOrder as eventStateOrder,
+  formatCurtailmentMinerCount as formatMinerCount,
+  formatCurtailmentTargetVsActual as formatTargetVsActual,
+  getCurtailmentTargetKw as getTargetKw,
+} from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 import CurtailmentStopConfirmationDialog from "@/protoFleet/features/energy/CurtailmentStopConfirmationDialog";
 import { ChevronDown } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
@@ -12,18 +22,6 @@ import FilterChip from "@/shared/components/List/Filters/FilterChip";
 import Modal, { sizes as modalSizes } from "@/shared/components/Modal";
 
 export type CurtailmentPriority = "normal" | "high" | "emergency";
-
-const curtailmentEventStates = [
-  "pending",
-  "active",
-  "restoring",
-  "completed",
-  "completedWithFailures",
-  "cancelled",
-  "failed",
-] as const;
-
-export type CurtailmentEventState = (typeof curtailmentEventStates)[number];
 
 export interface CurtailmentHistoryEvent {
   id: string;
@@ -101,30 +99,10 @@ const manageableEventStates = new Set<CurtailmentEventState>(["pending", "active
 const rowInteractiveElementSelector =
   'button, a, input, select, textarea, [role="button"], [role="link"], [data-interactive]';
 
-const eventStateLabels: Record<CurtailmentEventState, string> = {
-  pending: "Pending",
-  active: "Active",
-  restoring: "Restoring",
-  completed: "Completed",
-  completedWithFailures: "Completed with failures",
-  cancelled: "Cancelled",
-  failed: "Failed",
-};
-
 const priorityLabels: Record<CurtailmentPriority, string> = {
   normal: "Normal",
   high: "High",
   emergency: "Emergency",
-};
-
-const eventStateDotClassNames: Record<CurtailmentEventState, string> = {
-  pending: "bg-core-accent-fill",
-  active: "bg-intent-warning-fill",
-  restoring: "bg-core-accent-fill",
-  completed: "bg-text-primary-30",
-  completedWithFailures: "bg-text-primary-30",
-  cancelled: "bg-intent-critical-fill",
-  failed: "bg-intent-critical-fill",
 };
 
 const statusFilterOptions = curtailmentEventStates.map((state) => ({ id: state, label: eventStateLabels[state] }));
@@ -141,16 +119,6 @@ const historyColumnLabels: Record<HistoryColumn, string> = {
   scope: "Applies to",
   target: "Target vs actual",
   state: "Status",
-};
-
-const eventStateOrder: Record<CurtailmentEventState, number> = {
-  pending: 0,
-  active: 1,
-  restoring: 2,
-  completed: 3,
-  completedWithFailures: 4,
-  cancelled: 5,
-  failed: 6,
 };
 
 const collator = new Intl.Collator(undefined, { sensitivity: "base", numeric: true });
@@ -183,17 +151,6 @@ function DetailRow({ label, value, secondary }: DetailRowProps): ReactElement {
   );
 }
 
-function getTargetKw(event: Pick<CurtailmentHistoryEvent, "targetKw" | "estimatedReductionKw">): number {
-  return event.targetKw ?? event.estimatedReductionKw;
-}
-
-function formatKw(value: number, fractionDigits = 1): string {
-  return `${value.toLocaleString(undefined, {
-    maximumFractionDigits: fractionDigits,
-    minimumFractionDigits: fractionDigits,
-  })} kW`;
-}
-
 function getDateTime(value?: string): Date | undefined {
   if (!value) {
     return undefined;
@@ -206,14 +163,6 @@ function getDateTime(value?: string): Date | undefined {
 function formatDateTime(value?: string): string | undefined {
   const date = getDateTime(value);
   return date ? dateTimeFormatter.format(date) : undefined;
-}
-
-function formatTargetVsActual(event: Pick<CurtailmentHistoryEvent, "targetKw" | "estimatedReductionKw">): string {
-  return `${formatKw(getTargetKw(event))} / ${formatKw(event.estimatedReductionKw)}`;
-}
-
-function formatMinerCount(minerCount: number): string {
-  return `${minerCount.toLocaleString()} ${minerCount === 1 ? "miner" : "miners"}`;
 }
 
 function getHistoryStatusDetail(event: CurtailmentHistoryEvent): string {

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -4,6 +4,7 @@ import FullScreenTwoPaneModal, {
   type FullScreenTwoPaneModalProps,
 } from "@/protoFleet/components/FullScreenTwoPaneModal";
 import TargetSelectButton, { getTargetButtonLabel } from "@/protoFleet/components/TargetSelectButton";
+import { formatCurtailmentKw as formatKw } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 import {
   getUnsupportedDeviceSetPreviewError,
   useCurtailmentPlanPreview,
@@ -256,13 +257,6 @@ function Section({ title, children }: SectionProps): ReactElement {
       {children}
     </section>
   );
-}
-
-function formatKw(value: number): string {
-  return `${value.toLocaleString(undefined, {
-    maximumFractionDigits: 1,
-    minimumFractionDigits: 1,
-  })} kW`;
 }
 
 function clampPercentage(value: number): number {

--- a/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
+++ b/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
@@ -1,0 +1,75 @@
+export const curtailmentEventStates = [
+  "pending",
+  "active",
+  "restoring",
+  "completed",
+  "completedWithFailures",
+  "cancelled",
+  "failed",
+] as const;
+
+export type CurtailmentEventState = (typeof curtailmentEventStates)[number];
+
+export const curtailmentEventStateLabels: Record<CurtailmentEventState, string> = {
+  pending: "Pending",
+  active: "Active",
+  restoring: "Restoring",
+  completed: "Completed",
+  completedWithFailures: "Completed with failures",
+  cancelled: "Cancelled",
+  failed: "Failed",
+};
+
+export const curtailmentEventStateDotClassNames: Record<CurtailmentEventState, string> = {
+  pending: "bg-core-accent-fill",
+  active: "bg-intent-warning-fill",
+  restoring: "bg-core-accent-fill",
+  completed: "bg-text-primary-30",
+  completedWithFailures: "bg-text-primary-30",
+  cancelled: "bg-intent-critical-fill",
+  failed: "bg-intent-critical-fill",
+};
+
+export const curtailmentEventStateOrder: Record<CurtailmentEventState, number> = {
+  pending: 0,
+  active: 1,
+  restoring: 2,
+  completed: 3,
+  completedWithFailures: 4,
+  cancelled: 5,
+  failed: 6,
+};
+
+interface CurtailmentTargetKwEvent {
+  estimatedReductionKw: number;
+  targetKw?: number;
+}
+
+function getMinerCountLabel(minerCount: number): string {
+  return minerCount === 1 ? "miner" : "miners";
+}
+
+export function getCurtailmentTargetKw(event: CurtailmentTargetKwEvent): number {
+  return event.targetKw ?? event.estimatedReductionKw;
+}
+
+export function formatCurtailmentKw(value: number, fractionDigits = 1): string {
+  const finiteValue = Number.isFinite(value) ? value : 0;
+
+  return `${finiteValue.toLocaleString(undefined, {
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits,
+  })} kW`;
+}
+
+export function formatCurtailmentMinerCount(minerCount: number): string {
+  return `${minerCount.toLocaleString()} ${getMinerCountLabel(minerCount)}`;
+}
+
+export function formatCurtailmentSelectedMinerCount(minerCount: number): string {
+  return `${minerCount.toLocaleString()} selected ${getMinerCountLabel(minerCount)}`;
+}
+
+export function formatCurtailmentTargetVsActual(event: CurtailmentTargetKwEvent): string {
+  return `${formatCurtailmentKw(getCurtailmentTargetKw(event))} / ${formatCurtailmentKw(event.estimatedReductionKw)}`;
+}

--- a/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
+++ b/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
@@ -1,44 +1,44 @@
-export const curtailmentEventStates = [
-  "pending",
-  "active",
-  "restoring",
-  "completed",
-  "completedWithFailures",
-  "cancelled",
-  "failed",
-] as const;
+export const curtailmentEventStateConfigs = {
+  pending: {
+    label: "Pending",
+    dotClassName: "bg-core-accent-fill",
+    order: 0,
+  },
+  active: {
+    label: "Active",
+    dotClassName: "bg-intent-warning-fill",
+    order: 1,
+  },
+  restoring: {
+    label: "Restoring",
+    dotClassName: "bg-core-accent-fill",
+    order: 2,
+  },
+  completed: {
+    label: "Completed",
+    dotClassName: "bg-text-primary-30",
+    order: 3,
+  },
+  completedWithFailures: {
+    label: "Completed with failures",
+    dotClassName: "bg-text-primary-30",
+    order: 4,
+  },
+  cancelled: {
+    label: "Cancelled",
+    dotClassName: "bg-intent-critical-fill",
+    order: 5,
+  },
+  failed: {
+    label: "Failed",
+    dotClassName: "bg-intent-critical-fill",
+    order: 6,
+  },
+} as const;
 
-export type CurtailmentEventState = (typeof curtailmentEventStates)[number];
+export type CurtailmentEventState = keyof typeof curtailmentEventStateConfigs;
 
-export const curtailmentEventStateLabels: Record<CurtailmentEventState, string> = {
-  pending: "Pending",
-  active: "Active",
-  restoring: "Restoring",
-  completed: "Completed",
-  completedWithFailures: "Completed with failures",
-  cancelled: "Cancelled",
-  failed: "Failed",
-};
-
-export const curtailmentEventStateDotClassNames: Record<CurtailmentEventState, string> = {
-  pending: "bg-core-accent-fill",
-  active: "bg-intent-warning-fill",
-  restoring: "bg-core-accent-fill",
-  completed: "bg-text-primary-30",
-  completedWithFailures: "bg-text-primary-30",
-  cancelled: "bg-intent-critical-fill",
-  failed: "bg-intent-critical-fill",
-};
-
-export const curtailmentEventStateOrder: Record<CurtailmentEventState, number> = {
-  pending: 0,
-  active: 1,
-  restoring: 2,
-  completed: 3,
-  completedWithFailures: 4,
-  cancelled: 5,
-  failed: 6,
-};
+export const curtailmentEventStates = Object.keys(curtailmentEventStateConfigs) as CurtailmentEventState[];
 
 interface CurtailmentTargetKwEvent {
   estimatedReductionKw: number;

--- a/client/src/shared/utils/cssUtils.test.ts
+++ b/client/src/shared/utils/cssUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { cubicBezierValues } from "./cssUtils";
+import { classNameToSelectors, cubicBezierValues } from "./cssUtils";
 
 describe("cubicBezierValues", () => {
   test("should extract cubic bezier values from a css string", () => {
@@ -28,5 +28,28 @@ describe("cubicBezierValues", () => {
     const string2 = "cubic-bezier(0.47, 0, 0.23, 1.38, 0.5)";
     const result2 = cubicBezierValues(string2);
     expect(result2).toEqual(undefined);
+  });
+});
+
+describe("classNameToSelectors", () => {
+  test("should return a selector for each class token", () => {
+    expect(classNameToSelectors("schedule-pill-trigger relative")).toEqual([
+      '[class~="schedule-pill-trigger"]',
+      '[class~="relative"]',
+    ]);
+  });
+
+  test("should ignore extra whitespace between class tokens", () => {
+    expect(classNameToSelectors("  schedule-pill-trigger   relative  ")).toEqual([
+      '[class~="schedule-pill-trigger"]',
+      '[class~="relative"]',
+    ]);
+  });
+
+  test("should escape class tokens for css attribute selectors", () => {
+    expect(classNameToSelectors('before:content-["open"] path\\to\\trigger')).toEqual([
+      '[class~="before:content-[\\"open\\"]"]',
+      '[class~="path\\\\to\\\\trigger"]',
+    ]);
   });
 });

--- a/client/src/shared/utils/cssUtils.test.ts
+++ b/client/src/shared/utils/cssUtils.test.ts
@@ -32,24 +32,21 @@ describe("cubicBezierValues", () => {
 });
 
 describe("classNameToSelectors", () => {
-  test("should return a selector for each class token", () => {
+  test("should return a compound selector for all class tokens", () => {
     expect(classNameToSelectors("schedule-pill-trigger relative")).toEqual([
-      '[class~="schedule-pill-trigger"]',
-      '[class~="relative"]',
+      '[class~="schedule-pill-trigger"][class~="relative"]',
     ]);
   });
 
   test("should ignore extra whitespace between class tokens", () => {
     expect(classNameToSelectors("  schedule-pill-trigger   relative  ")).toEqual([
-      '[class~="schedule-pill-trigger"]',
-      '[class~="relative"]',
+      '[class~="schedule-pill-trigger"][class~="relative"]',
     ]);
   });
 
   test("should escape class tokens for css attribute selectors", () => {
     expect(classNameToSelectors('before:content-["open"] path\\to\\trigger')).toEqual([
-      '[class~="before:content-[\\"open\\"]"]',
-      '[class~="path\\\\to\\\\trigger"]',
+      '[class~="before:content-[\\"open\\"]"][class~="path\\\\to\\\\trigger"]',
     ]);
   });
 });

--- a/client/src/shared/utils/cssUtils.ts
+++ b/client/src/shared/utils/cssUtils.ts
@@ -16,9 +16,12 @@ export const cubicBezierValues = (string: string) => {
 const escapeCssAttributeValue = (value: string): string => value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 
 export const classNameToSelectors = (className: string): string[] => {
-  return className
+  const selector = className
     .trim()
     .split(/\s+/)
     .filter(Boolean)
-    .map((classNameToken) => `[class~="${escapeCssAttributeValue(classNameToken)}"]`);
+    .map((classNameToken) => `[class~="${escapeCssAttributeValue(classNameToken)}"]`)
+    .join("");
+
+  return selector ? [selector] : [];
 };

--- a/client/src/shared/utils/cssUtils.ts
+++ b/client/src/shared/utils/cssUtils.ts
@@ -12,3 +12,13 @@ export const cubicBezierValues = (string: string) => {
 
   return values.length == 4 ? values : undefined;
 };
+
+const escapeCssAttributeValue = (value: string): string => value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+export const classNameToSelectors = (className: string): string[] => {
+  return className
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((classNameToken) => `[class~="${escapeCssAttributeValue(classNameToken)}"]`);
+};


### PR DESCRIPTION
🤖

## Summary
- Add a curtailment status pill for the PageHeader
- Split shared curtailment pill event/type definitions for component and Storybook reuse

## Test plan
- [ ] Open the Page Header Storybook curtailment pill story
- [ ] Confirm pending, active, and restoring states render correctly
- [ ] Confirm the details link appears only when a details path is provided

https://github.com/user-attachments/assets/d8fbb8c9-7510-4aae-854e-b17a34de8109



Closes #302