### PR TITLE
feat(authz): swap existing-gate handlers to RequirePermission (PR 2c)

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -228,7 +228,7 @@ func start(config *Config) error {
 	sessionSvc := sessionDomain.NewService(config.Session, sessionStore)
 
 	// userStore implements both UserStore and UserManagementStore interfaces
-	authSvc := authDomain.NewService(userStore, userStore, transactor, tokenSvc, sessionSvc, encryptSvc, activitySvc)
+	authSvc := authDomain.NewService(userStore, userStore, transactor, tokenSvc, sessionSvc, encryptSvc, activitySvc, permissionResolver)
 
 	// Start session cleanup goroutine
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -614,21 +614,19 @@ func (s *Service) authorizeCallerForNewUserWithRole(ctx context.Context, callerU
 	return role, nil
 }
 
-// requireCallerCanManageTarget denies the mutation unless the caller's
-// effective permissions strictly exceed the target's at matching scope,
-// or the caller holds org-scope role:manage (the peer-management
-// bypass that lets SUPER_ADMIN — or any role granted role:manage —
-// manage equals). Equality without the bypass would turn CreateUser
-// into a way for ADMIN to mint new ADMINs and walk off with the temp
-// password.
+// requireCallerCanManageTarget enforces the user-management hierarchy:
+// callers with org-scope role:manage need only subsume the target;
+// everyone else must strictly dominate it. Without the strict-dominate
+// requirement, ADMIN (equal perms to a fresh ADMIN account) could mint
+// new ADMINs via CreateUser and walk off with the temp password.
 func requireCallerCanManageTarget(callerEff, targetEff *authz.EffectivePermissions) error {
-	if !targetEff.IsSubsumedBy(callerEff) {
-		return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
-	}
 	if callerEff.Has(authz.PermRoleManage, authz.ResourceContext{}) {
+		if !targetEff.IsSubsumedBy(callerEff) {
+			return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
+		}
 		return nil
 	}
-	if callerEff.IsSubsumedBy(targetEff) {
+	if !callerEff.StrictlyDominates(targetEff) {
 		return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
 	}
 	return nil

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -544,6 +544,31 @@ func generateDefaultOrgName(orgID string) string {
 	return fmt.Sprintf("Organization %s", orgID[:8])
 }
 
+// isElevatedRole reports whether a role name is in the elevated tier
+// (ADMIN or SUPER_ADMIN). The handler's PermUserManage gate authorizes
+// the action; this hierarchy check restricts which targets a non-
+// SUPER_ADMIN caller may act on. Operator-created custom roles are
+// non-elevated regardless of their permission set — granting
+// user:manage to a custom role would let its members manage other
+// non-elevated users, which is the intent.
+func isElevatedRole(roleName string) bool {
+	return roleName == SuperAdminRoleName || roleName == AdminRoleName
+}
+
+// requireCanManageTargetRole enforces the role hierarchy for user
+// mutations: a non-SUPER_ADMIN caller may not act on an elevated
+// target. Returns PermissionDenied when the gate blocks the action,
+// nil when the caller may proceed.
+func requireCanManageTargetRole(callerRoleName, targetRoleName string) error {
+	if callerRoleName == SuperAdminRoleName {
+		return nil
+	}
+	if isElevatedRole(targetRoleName) {
+		return fleeterror.NewForbiddenError("insufficient role to manage this user")
+	}
+	return nil
+}
+
 // CreateUser creates a new user with a temporary password. Authorization is
 // enforced by the Connect handler via RequirePermission(PermUserManage);
 // callers outside the handler layer must add their own permission gate.
@@ -570,6 +595,18 @@ func (s *Service) CreateUser(ctx context.Context, req *authv1.CreateUserRequest)
 	}
 
 	orgID := orgs[0].ID
+
+	// CreateUser always assigns the ADMIN role today (the proto has no
+	// role field). That makes ADMIN itself the effective target role,
+	// so a non-SUPER_ADMIN caller cannot create users until the proto
+	// grows a role parameter that lets them pick a non-elevated tier.
+	callerRoleName, err := s.userManagementStore.GetUserRoleName(ctx, info.UserID, orgID)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("error getting caller role: %v", err)
+	}
+	if err := requireCanManageTargetRole(callerRoleName, AdminRoleName); err != nil {
+		return nil, err
+	}
 
 	// Generate temporary password
 	tempPassword, err := generateTemporaryPassword()
@@ -716,8 +753,18 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 	// target to be a member of the caller's org so a SUPER_ADMIN cannot
 	// reset a password for a user in a different tenant. NotFound (mapped
 	// from invalid user_id) avoids leaking whether the user exists elsewhere.
-	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
+	// The returned role doubles as the input to the hierarchy check below.
+	targetRoleName, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID)
+	if err != nil {
 		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
+	}
+
+	callerRoleName, err := s.userManagementStore.GetUserRoleName(ctx, info.UserID, orgID)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("error getting caller role: %v", err)
+	}
+	if err := requireCanManageTargetRole(callerRoleName, targetRoleName); err != nil {
+		return nil, err
 	}
 
 	// Generate new temporary password
@@ -807,9 +854,19 @@ func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUser
 
 	// Cross-org guard: GetUserByExternalID is a global lookup. Require the
 	// target to belong to the caller's org so a SUPER_ADMIN cannot
-	// deactivate a user in a different tenant.
-	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
+	// deactivate a user in a different tenant. The returned role doubles
+	// as the input to the hierarchy check below.
+	targetRoleName, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID)
+	if err != nil {
 		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
+	}
+
+	callerRoleName, err := s.userManagementStore.GetUserRoleName(ctx, info.UserID, orgID)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("error getting caller role: %v", err)
+	}
+	if err := requireCanManageTargetRole(callerRoleName, targetRoleName); err != nil {
+		return nil, err
 	}
 
 	// Soft delete user

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -548,6 +548,72 @@ func generateDefaultOrgName(orgID string) string {
 	return fmt.Sprintf("Organization %s", orgID[:8])
 }
 
+// authorizeCallerForUser is the shared lookup + parity check for
+// ResetUserPassword and DeactivateUser. It resolves the target by
+// external ID, masks cross-tenant lookups as InvalidArgument so
+// existence does not leak across orgs, and runs the privilege-parity
+// gate. Returns the resolved target so callers can use its IDs / name
+// downstream.
+func (s *Service) authorizeCallerForUser(ctx context.Context, callerUserID, orgID int64, targetExternalID string) (stores.User, error) {
+	target, err := s.userStore.GetUserByExternalID(ctx, targetExternalID)
+	if err != nil {
+		return stores.User{}, fleeterror.NewInvalidArgumentError("invalid user_id")
+	}
+
+	// Cross-org guard: GetUserByExternalID is a global lookup. ErrNoRows
+	// here means the target isn't in the caller's org; mask as
+	// InvalidArgument to avoid leaking existence across tenants. Other
+	// errors are transient and must propagate as Internal.
+	if _, err := s.userManagementStore.GetUserRoleName(ctx, target.ID, orgID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return stores.User{}, fleeterror.NewInvalidArgumentError("invalid user_id")
+		}
+		return stores.User{}, fleeterror.NewInternalErrorf("error getting target user role: %v", err)
+	}
+
+	targetEff, err := s.permResolver.LoadEffective(ctx, target.ID, orgID)
+	if err != nil {
+		return stores.User{}, fleeterror.NewInternalErrorf("error loading target permissions: %v", err)
+	}
+	callerEff, err := s.permResolver.LoadEffective(ctx, callerUserID, orgID)
+	if err != nil {
+		return stores.User{}, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
+	}
+	if err := requireCallerCanManageTarget(callerEff, targetEff); err != nil {
+		return stores.User{}, err
+	}
+	return target, nil
+}
+
+// authorizeCallerForNewUserWithRole is the CreateUser counterpart of
+// authorizeCallerForUser: the target does not yet exist, so the parity
+// check uses a synthetic effective-permissions snapshot built from the
+// role being assigned. Returns the resolved role so the caller can
+// bind the new user to it.
+func (s *Service) authorizeCallerForNewUserWithRole(ctx context.Context, callerUserID, orgID int64, roleName string) (stores.Role, error) {
+	role, err := s.userManagementStore.GetBuiltinRoleForOrg(ctx, orgID, roleName)
+	if err != nil {
+		return stores.Role{}, fleeterror.NewInternalErrorf("error getting %s role for org: %v", roleName, err)
+	}
+
+	targetKeys, err := s.userManagementStore.ListPermissionKeysByRoleID(ctx, role.ID)
+	if err != nil {
+		return stores.Role{}, fleeterror.NewInternalErrorf("error listing target role permissions: %v", err)
+	}
+	targetEff := authz.NewEffectivePermissions([]authz.Assignment{{
+		ScopeType:   authz.ScopeOrg,
+		Permissions: targetKeys,
+	}})
+	callerEff, err := s.permResolver.LoadEffective(ctx, callerUserID, orgID)
+	if err != nil {
+		return stores.Role{}, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
+	}
+	if err := requireCallerCanManageTarget(callerEff, targetEff); err != nil {
+		return stores.Role{}, err
+	}
+	return role, nil
+}
+
 // requireCallerCanManageTarget denies the mutation unless the caller's
 // effective permissions strictly exceed the target's at matching scope,
 // or the caller holds org-scope role:manage (the peer-management
@@ -595,33 +661,11 @@ func (s *Service) CreateUser(ctx context.Context, req *authv1.CreateUserRequest)
 
 	orgID := orgs[0].ID
 
-	// Look up the ADMIN role belonging to this user's organization. Each
-	// org owns its own ADMIN row, so a name-only lookup would return an
-	// arbitrary org's row (or the soft-deleted legacy global one) and
-	// could bind the new user to a role record from a different tenant.
-	// The role's actual permission set (which may include operator-added
-	// keys beyond the seed) is the input to the privilege-parity check
-	// below.
-	role, err := s.userManagementStore.GetBuiltinRoleForOrg(ctx, orgID, AdminRoleName)
+	// Look up the ADMIN role for this org and gate the caller against
+	// the permission set the new user will inherit. Org-scoped row
+	// lookup avoids binding to a different tenant's ADMIN.
+	role, err := s.authorizeCallerForNewUserWithRole(ctx, info.UserID, orgID, AdminRoleName)
 	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error getting admin role for org: %v", err)
-	}
-
-	// The new user inherits the ADMIN role's full permission set at
-	// org scope; the parity check below gates against the caller.
-	targetKeys, err := s.userManagementStore.ListPermissionKeysByRoleID(ctx, role.ID)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error listing target role permissions: %v", err)
-	}
-	targetEff := authz.NewEffectivePermissions([]authz.Assignment{{
-		ScopeType:   authz.ScopeOrg,
-		Permissions: targetKeys,
-	}})
-	callerEff, err := s.permResolver.LoadEffective(ctx, info.UserID, orgID)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
-	}
-	if err := requireCallerCanManageTarget(callerEff, targetEff); err != nil {
 		return nil, err
 	}
 
@@ -751,32 +795,8 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 
 	orgID := orgs[0].ID
 
-	// Get target user
-	user, err := s.userStore.GetUserByExternalID(ctx, req.UserId)
+	user, err := s.authorizeCallerForUser(ctx, info.UserID, orgID, req.UserId)
 	if err != nil {
-		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
-	}
-
-	// Cross-org guard: GetUserByExternalID is a global lookup. ErrNoRows
-	// here means the target isn't in the caller's org; mask as
-	// InvalidArgument to avoid leaking existence across tenants. Other
-	// errors are transient and must propagate as Internal.
-	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
-		}
-		return nil, fleeterror.NewInternalErrorf("error getting target user role: %v", err)
-	}
-
-	targetEff, err := s.permResolver.LoadEffective(ctx, user.ID, orgID)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error loading target permissions: %v", err)
-	}
-	callerEff, err := s.permResolver.LoadEffective(ctx, info.UserID, orgID)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
-	}
-	if err := requireCallerCanManageTarget(callerEff, targetEff); err != nil {
 		return nil, err
 	}
 
@@ -859,32 +879,8 @@ func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUser
 		)
 	}
 
-	// Get target user
-	user, err := s.userStore.GetUserByExternalID(ctx, req.UserId)
+	user, err := s.authorizeCallerForUser(ctx, info.UserID, orgID, req.UserId)
 	if err != nil {
-		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
-	}
-
-	// Cross-org guard: GetUserByExternalID is a global lookup. ErrNoRows
-	// here means the target isn't in the caller's org; mask as
-	// InvalidArgument to avoid leaking existence across tenants. Other
-	// errors are transient and must propagate as Internal.
-	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
-		}
-		return nil, fleeterror.NewInternalErrorf("error getting target user role: %v", err)
-	}
-
-	targetEff, err := s.permResolver.LoadEffective(ctx, user.ID, orgID)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error loading target permissions: %v", err)
-	}
-	callerEff, err := s.permResolver.LoadEffective(ctx, info.UserID, orgID)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
-	}
-	if err := requireCallerCanManageTarget(callerEff, targetEff); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -19,6 +19,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	id "github.com/block/proto-fleet/server/internal/infrastructure/id"
@@ -51,6 +52,7 @@ type Service struct {
 	sessionSvc          *session.Service
 	encryptSvc          *encrypt.Service
 	activitySvc         *activity.Service
+	permResolver        *authz.PermissionResolver
 }
 
 func NewService(
@@ -61,6 +63,7 @@ func NewService(
 	sessionSvc *session.Service,
 	encryptSvc *encrypt.Service,
 	activitySvc *activity.Service,
+	permResolver *authz.PermissionResolver,
 ) *Service {
 	return &Service{
 		userStore:           userStore,
@@ -70,6 +73,7 @@ func NewService(
 		sessionSvc:          sessionSvc,
 		encryptSvc:          encryptSvc,
 		activitySvc:         activitySvc,
+		permResolver:        permResolver,
 	}
 }
 
@@ -544,27 +548,38 @@ func generateDefaultOrgName(orgID string) string {
 	return fmt.Sprintf("Organization %s", orgID[:8])
 }
 
-// isElevatedRole reports whether a role name is in the elevated tier
-// (ADMIN or SUPER_ADMIN). The handler's PermUserManage gate authorizes
-// the action; this hierarchy check restricts which targets a non-
-// SUPER_ADMIN caller may act on. Operator-created custom roles are
-// non-elevated regardless of their permission set — granting
-// user:manage to a custom role would let its members manage other
-// non-elevated users, which is the intent.
-func isElevatedRole(roleName string) bool {
-	return roleName == SuperAdminRoleName || roleName == AdminRoleName
+// callerPermissionKeys resolves the caller's full set of permission
+// keys across every scope they hold in the org. The privilege-parity
+// check in CreateUser / ResetUserPassword / DeactivateUser uses this
+// against the target's keys. The resolver is consulted directly so the
+// service doesn't depend on the middleware's request-context plumbing.
+func (s *Service) callerPermissionKeys(ctx context.Context, userID, orgID int64) ([]string, error) {
+	eff, err := s.permResolver.LoadEffective(ctx, userID, orgID)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
+	}
+	return eff.FlatKeys(), nil
 }
 
-// requireCanManageTargetRole enforces the role hierarchy for user
-// mutations: a non-SUPER_ADMIN caller may not act on an elevated
-// target. Returns PermissionDenied when the gate blocks the action,
-// nil when the caller may proceed.
-func requireCanManageTargetRole(callerRoleName, targetRoleName string) error {
-	if callerRoleName == SuperAdminRoleName {
-		return nil
+// requireCallerCanManageTarget enforces the rule that a caller may
+// only mutate a target user whose effective permissions are a subset
+// of the caller's. This prevents privilege escalation via password
+// reset / deactivation against an account that holds permissions the
+// caller does not (e.g., a custom role with role:manage).
+//
+// Role names are not consulted — the check operates on the underlying
+// permission keys, so operator-created custom roles get the right
+// treatment automatically. SUPER_ADMIN holds every permission in the
+// catalog and therefore always passes the subset check.
+func requireCallerCanManageTarget(callerKeys, targetKeys []string) error {
+	caller := make(map[string]struct{}, len(callerKeys))
+	for _, k := range callerKeys {
+		caller[k] = struct{}{}
 	}
-	if isElevatedRole(targetRoleName) {
-		return fleeterror.NewForbiddenError("insufficient role to manage this user")
+	for _, k := range targetKeys {
+		if _, ok := caller[k]; !ok {
+			return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
+		}
 	}
 	return nil
 }
@@ -596,15 +611,31 @@ func (s *Service) CreateUser(ctx context.Context, req *authv1.CreateUserRequest)
 
 	orgID := orgs[0].ID
 
-	// CreateUser always assigns the ADMIN role today (the proto has no
-	// role field). That makes ADMIN itself the effective target role,
-	// so a non-SUPER_ADMIN caller cannot create users until the proto
-	// grows a role parameter that lets them pick a non-elevated tier.
-	callerRoleName, err := s.userManagementStore.GetUserRoleName(ctx, info.UserID, orgID)
+	// Look up the ADMIN role belonging to this user's organization. Each
+	// org owns its own ADMIN row, so a name-only lookup would return an
+	// arbitrary org's row (or the soft-deleted legacy global one) and
+	// could bind the new user to a role record from a different tenant.
+	// The role's actual permission set (which may include operator-added
+	// keys beyond the seed) is the input to the privilege-parity check
+	// below.
+	role, err := s.userManagementStore.GetBuiltinRoleForOrg(ctx, orgID, AdminRoleName)
 	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error getting caller role: %v", err)
+		return nil, fleeterror.NewInternalErrorf("error getting admin role for org: %v", err)
 	}
-	if err := requireCanManageTargetRole(callerRoleName, AdminRoleName); err != nil {
+
+	// Privilege parity: the new user will hold every permission of the
+	// ADMIN role they're being assigned. The caller must already hold
+	// each of those permissions, otherwise CreateUser becomes an
+	// escalation primitive.
+	targetKeys, err := s.userManagementStore.ListPermissionKeysByRoleID(ctx, role.ID)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("error listing target role permissions: %v", err)
+	}
+	callerKeys, err := s.callerPermissionKeys(ctx, info.UserID, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireCallerCanManageTarget(callerKeys, targetKeys); err != nil {
 		return nil, err
 	}
 
@@ -618,15 +649,6 @@ func (s *Service) CreateUser(ctx context.Context, req *authv1.CreateUserRequest)
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(tempPassword), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error generating password hash: %v", err)
-	}
-
-	// Look up the ADMIN role belonging to this user's organization. Each
-	// org owns its own ADMIN row, so a name-only lookup would return an
-	// arbitrary org's row (or the soft-deleted legacy global one) and
-	// could bind the new user to a role record from a different tenant.
-	role, err := s.userManagementStore.GetBuiltinRoleForOrg(ctx, orgID, AdminRoleName)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error getting admin role for org: %v", err)
 	}
 
 	var createdUserID string
@@ -754,21 +776,27 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 	// reset a password for a user in a different tenant. Only ErrNoRows
 	// means "not in caller's org" — other errors are transient store
 	// failures and must surface as Internal so callers retry instead of
-	// treating a backend hiccup as bad input. The returned role doubles
-	// as the input to the hierarchy check below.
-	targetRoleName, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID)
-	if err != nil {
+	// treating a backend hiccup as bad input.
+	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
 		}
 		return nil, fleeterror.NewInternalErrorf("error getting target user role: %v", err)
 	}
 
-	callerRoleName, err := s.userManagementStore.GetUserRoleName(ctx, info.UserID, orgID)
+	// Privilege parity: the caller must hold every permission the
+	// target holds. Otherwise password reset becomes an escalation
+	// primitive — the caller could log in as a target whose role grants
+	// permissions the caller doesn't have.
+	targetEff, err := s.permResolver.LoadEffective(ctx, user.ID, orgID)
 	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error getting caller role: %v", err)
+		return nil, fleeterror.NewInternalErrorf("error loading target permissions: %v", err)
 	}
-	if err := requireCanManageTargetRole(callerRoleName, targetRoleName); err != nil {
+	callerKeys, err := s.callerPermissionKeys(ctx, info.UserID, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireCallerCanManageTarget(callerKeys, targetEff.FlatKeys()); err != nil {
 		return nil, err
 	}
 
@@ -862,21 +890,28 @@ func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUser
 	// deactivate a user in a different tenant. Only ErrNoRows means
 	// "not in caller's org" — other errors are transient store failures
 	// and must surface as Internal so callers retry instead of treating
-	// a backend hiccup as bad input. The returned role doubles as the
-	// input to the hierarchy check below.
-	targetRoleName, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID)
-	if err != nil {
+	// a backend hiccup as bad input.
+	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
 		}
 		return nil, fleeterror.NewInternalErrorf("error getting target user role: %v", err)
 	}
 
-	callerRoleName, err := s.userManagementStore.GetUserRoleName(ctx, info.UserID, orgID)
+	// Privilege parity: the caller must hold every permission the
+	// target holds. Otherwise deactivation becomes a denial-of-service
+	// primitive against accounts that hold permissions the caller can't
+	// reproduce (and a step toward escalation if the deactivation is
+	// followed by a fresh account claim).
+	targetEff, err := s.permResolver.LoadEffective(ctx, user.ID, orgID)
 	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error getting caller role: %v", err)
+		return nil, fleeterror.NewInternalErrorf("error loading target permissions: %v", err)
 	}
-	if err := requireCanManageTargetRole(callerRoleName, targetRoleName); err != nil {
+	callerKeys, err := s.callerPermissionKeys(ctx, info.UserID, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireCallerCanManageTarget(callerKeys, targetEff.FlatKeys()); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -544,7 +544,9 @@ func generateDefaultOrgName(orgID string) string {
 	return fmt.Sprintf("Organization %s", orgID[:8])
 }
 
-// CreateUser creates a new user with a temporary password (Super Admin only)
+// CreateUser creates a new user with a temporary password. Authorization is
+// enforced by the Connect handler via RequirePermission(PermUserManage);
+// callers outside the handler layer must add their own permission gate.
 func (s *Service) CreateUser(ctx context.Context, req *authv1.CreateUserRequest) (*authv1.CreateUserResponse, error) {
 	// Validate username
 	trimmedUsername := strings.TrimSpace(req.Username)
@@ -678,7 +680,10 @@ func (s *Service) ListUsers(ctx context.Context) (*authv1.ListUsersResponse, err
 	}, nil
 }
 
-// ResetUserPassword generates a new temporary password for a user (Super Admin only)
+// ResetUserPassword generates a new temporary password for a user.
+// Authorization is enforced by the Connect handler via RequirePermission
+// (PermUserManage); callers outside the handler layer must add their own
+// permission gate.
 func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPasswordRequest) (*authv1.ResetUserPasswordResponse, error) {
 	if req.UserId == "" {
 		return nil, fleeterror.NewInvalidArgumentError("user_id is required")
@@ -704,6 +709,14 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 	// Get target user
 	user, err := s.userStore.GetUserByExternalID(ctx, req.UserId)
 	if err != nil {
+		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
+	}
+
+	// Cross-org guard: GetUserByExternalID is a global lookup. Require the
+	// target to be a member of the caller's org so a SUPER_ADMIN cannot
+	// reset a password for a user in a different tenant. NotFound (mapped
+	// from invalid user_id) avoids leaking whether the user exists elsewhere.
+	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
 		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
 	}
 
@@ -747,7 +760,9 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 	}, nil
 }
 
-// DeactivateUser soft-deletes a user (Super Admin only)
+// DeactivateUser soft-deletes a user. Authorization is enforced by the
+// Connect handler via RequirePermission(PermUserManage); callers outside
+// the handler layer must add their own permission gate.
 func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUserRequest) (*authv1.DeactivateUserResponse, error) {
 	if req.UserId == "" {
 		return nil, fleeterror.NewInvalidArgumentError("user_id is required")
@@ -787,6 +802,13 @@ func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUser
 	// Get target user
 	user, err := s.userStore.GetUserByExternalID(ctx, req.UserId)
 	if err != nil {
+		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
+	}
+
+	// Cross-org guard: GetUserByExternalID is a global lookup. Require the
+	// target to belong to the caller's org so a SUPER_ADMIN cannot
+	// deactivate a user in a different tenant.
+	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
 		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
 	}
 

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -544,31 +544,6 @@ func generateDefaultOrgName(orgID string) string {
 	return fmt.Sprintf("Organization %s", orgID[:8])
 }
 
-// checkCanManageUser checks if the current user can manage (deactivate/reset password) other users
-// Only SUPER_ADMIN users can manage other users
-func (s *Service) checkCanManageUser(ctx context.Context, organizationID int64) error {
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return err
-	}
-
-	currentUserRoleName, err := s.userManagementStore.GetUserRoleName(ctx, info.UserID, organizationID)
-	if err != nil {
-		return fleeterror.NewInternalErrorf("error getting current user role: %v", err)
-	}
-
-	// Only SUPER_ADMIN users can manage other users
-	if currentUserRoleName != SuperAdminRoleName {
-		return fleeterror.NewErrorWithEndpointCode(
-			"only super admin users can manage other user accounts",
-			connect.CodePermissionDenied,
-			int32(authv1.UserManagementErrorCode_USER_MANAGEMENT_ERROR_CODE_UNAUTHORIZED),
-		)
-	}
-
-	return nil
-}
-
 // CreateUser creates a new user with a temporary password (Super Admin only)
 func (s *Service) CreateUser(ctx context.Context, req *authv1.CreateUserRequest) (*authv1.CreateUserResponse, error) {
 	// Validate username
@@ -593,18 +568,6 @@ func (s *Service) CreateUser(ctx context.Context, req *authv1.CreateUserRequest)
 	}
 
 	orgID := orgs[0].ID
-
-	// Authorization gate: only a SUPER_ADMIN in this org can create new
-	// users. Without this, any authenticated session can mint a fresh
-	// ADMIN account, receive the returned temporary password, and log
-	// in as it — a direct privilege escalation. Companion methods
-	// (ResetUserPassword, DeactivateUser) already enforce this via
-	// checkCanManageUser; CreateUser must too. Runs before the
-	// temp-password generation and role lookup so an unauthorized
-	// caller does not even consume entropy or touch the role table.
-	if err := s.checkCanManageUser(ctx, orgID); err != nil {
-		return nil, err
-	}
 
 	// Generate temporary password
 	tempPassword, err := generateTemporaryPassword()
@@ -738,11 +701,6 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 
 	orgID := orgs[0].ID
 
-	// Check if current user can manage other users (only SUPER_ADMIN can)
-	if err := s.checkCanManageUser(ctx, orgID); err != nil {
-		return nil, err
-	}
-
 	// Get target user
 	user, err := s.userStore.GetUserByExternalID(ctx, req.UserId)
 	if err != nil {
@@ -815,11 +773,6 @@ func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUser
 	currentUser, err := s.userStore.GetUserByID(ctx, info.UserID)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error getting current user: %v", err)
-	}
-
-	// Check if current user can manage other users (only SUPER_ADMIN can)
-	if err := s.checkCanManageUser(ctx, orgID); err != nil {
-		return nil, err
 	}
 
 	// Prevent self-deactivation

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -548,21 +548,38 @@ func generateDefaultOrgName(orgID string) string {
 	return fmt.Sprintf("Organization %s", orgID[:8])
 }
 
-// requireCallerCanManageTarget enforces the rule that a caller may
-// only mutate a target user whose effective permissions are a subset
-// of the caller's *at matching scope*. This prevents privilege
-// escalation via password reset / deactivation against an account that
-// holds permissions the caller does not (e.g., a custom role with
-// role:manage), and prevents a site-scoped grant from being laundered
-// into org-scoped authority by flattening keys across scopes.
+// requireCallerCanManageTarget enforces two conditions for the caller
+// to mutate the target:
+//
+//  1. Subset: every (key, scope) pair the target holds is also held by
+//     the caller. Reuses the narrowing-aware Has() inside
+//     IsSubsumedBy, so a site-scoped grant cannot be laundered into
+//     apparent org-scope authority.
+//
+//  2. Strict authority: the caller's permission set must be strictly
+//     larger than the target's, OR the caller must hold role:manage at
+//     org scope. Without this, peer-admin management is allowed by
+//     equality (ADMIN has exactly the ADMIN seed, so target.perms ==
+//     caller.perms for an ADMIN creating/resetting another ADMIN —
+//     ADMIN would be a CreateUser primitive that hands back a new
+//     account's temp password). org-scope role:manage is the explicit
+//     "I can manage equal peers" capability; SUPER_ADMIN holds it by
+//     default and operators can grant it to a custom role.
 //
 // Role names are not consulted — the check operates on the underlying
 // (key, scope) pairs, so operator-created custom roles and any future
-// builtin keys get the right treatment automatically. SUPER_ADMIN
-// holds every org-scope permission in the catalog and therefore
-// always passes the subset check.
+// builtin keys get the right treatment automatically.
 func requireCallerCanManageTarget(callerEff, targetEff *authz.EffectivePermissions) error {
 	if !targetEff.IsSubsumedBy(callerEff) {
+		return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
+	}
+	if callerEff.Has(authz.PermRoleManage, authz.ResourceContext{}) {
+		return nil
+	}
+	// Subset is mutual ⇒ permission sets are equal ⇒ peer-tier
+	// management, which requires the org-scope role:manage bypass
+	// above.
+	if callerEff.IsSubsumedBy(targetEff) {
 		return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
 	}
 	return nil

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -548,27 +548,13 @@ func generateDefaultOrgName(orgID string) string {
 	return fmt.Sprintf("Organization %s", orgID[:8])
 }
 
-// requireCallerCanManageTarget enforces two conditions for the caller
-// to mutate the target:
-//
-//  1. Subset: every (key, scope) pair the target holds is also held by
-//     the caller. Reuses the narrowing-aware Has() inside
-//     IsSubsumedBy, so a site-scoped grant cannot be laundered into
-//     apparent org-scope authority.
-//
-//  2. Strict authority: the caller's permission set must be strictly
-//     larger than the target's, OR the caller must hold role:manage at
-//     org scope. Without this, peer-admin management is allowed by
-//     equality (ADMIN has exactly the ADMIN seed, so target.perms ==
-//     caller.perms for an ADMIN creating/resetting another ADMIN —
-//     ADMIN would be a CreateUser primitive that hands back a new
-//     account's temp password). org-scope role:manage is the explicit
-//     "I can manage equal peers" capability; SUPER_ADMIN holds it by
-//     default and operators can grant it to a custom role.
-//
-// Role names are not consulted — the check operates on the underlying
-// (key, scope) pairs, so operator-created custom roles and any future
-// builtin keys get the right treatment automatically.
+// requireCallerCanManageTarget denies the mutation unless the caller's
+// effective permissions strictly exceed the target's at matching scope,
+// or the caller holds org-scope role:manage (the peer-management
+// bypass that lets SUPER_ADMIN — or any role granted role:manage —
+// manage equals). Equality without the bypass would turn CreateUser
+// into a way for ADMIN to mint new ADMINs and walk off with the temp
+// password.
 func requireCallerCanManageTarget(callerEff, targetEff *authz.EffectivePermissions) error {
 	if !targetEff.IsSubsumedBy(callerEff) {
 		return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
@@ -576,9 +562,6 @@ func requireCallerCanManageTarget(callerEff, targetEff *authz.EffectivePermissio
 	if callerEff.Has(authz.PermRoleManage, authz.ResourceContext{}) {
 		return nil
 	}
-	// Subset is mutual ⇒ permission sets are equal ⇒ peer-tier
-	// management, which requires the org-scope role:manage bypass
-	// above.
 	if callerEff.IsSubsumedBy(targetEff) {
 		return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
 	}
@@ -624,10 +607,8 @@ func (s *Service) CreateUser(ctx context.Context, req *authv1.CreateUserRequest)
 		return nil, fleeterror.NewInternalErrorf("error getting admin role for org: %v", err)
 	}
 
-	// Privilege parity: the new user will hold every permission of the
-	// ADMIN role they're being assigned, at org scope. The caller must
-	// already hold each of those permissions at org scope as well —
-	// otherwise CreateUser becomes an escalation primitive.
+	// The new user inherits the ADMIN role's full permission set at
+	// org scope; the parity check below gates against the caller.
 	targetKeys, err := s.userManagementStore.ListPermissionKeysByRoleID(ctx, role.ID)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error listing target role permissions: %v", err)
@@ -776,12 +757,10 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
 	}
 
-	// Cross-org guard: GetUserByExternalID is a global lookup. Require the
-	// target to be a member of the caller's org so a SUPER_ADMIN cannot
-	// reset a password for a user in a different tenant. Only ErrNoRows
-	// means "not in caller's org" — other errors are transient store
-	// failures and must surface as Internal so callers retry instead of
-	// treating a backend hiccup as bad input.
+	// Cross-org guard: GetUserByExternalID is a global lookup. ErrNoRows
+	// here means the target isn't in the caller's org; mask as
+	// InvalidArgument to avoid leaking existence across tenants. Other
+	// errors are transient and must propagate as Internal.
 	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
@@ -789,11 +768,6 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 		return nil, fleeterror.NewInternalErrorf("error getting target user role: %v", err)
 	}
 
-	// Privilege parity: the caller must hold every permission the
-	// target holds at matching scope. Otherwise password reset becomes
-	// an escalation primitive — the caller could log in as a target
-	// whose role grants permissions the caller doesn't have at the
-	// scope where they'd matter.
 	targetEff, err := s.permResolver.LoadEffective(ctx, user.ID, orgID)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error loading target permissions: %v", err)
@@ -891,12 +865,10 @@ func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUser
 		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
 	}
 
-	// Cross-org guard: GetUserByExternalID is a global lookup. Require the
-	// target to belong to the caller's org so a SUPER_ADMIN cannot
-	// deactivate a user in a different tenant. Only ErrNoRows means
-	// "not in caller's org" — other errors are transient store failures
-	// and must surface as Internal so callers retry instead of treating
-	// a backend hiccup as bad input.
+	// Cross-org guard: GetUserByExternalID is a global lookup. ErrNoRows
+	// here means the target isn't in the caller's org; mask as
+	// InvalidArgument to avoid leaking existence across tenants. Other
+	// errors are transient and must propagate as Internal.
 	if _, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
@@ -904,12 +876,6 @@ func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUser
 		return nil, fleeterror.NewInternalErrorf("error getting target user role: %v", err)
 	}
 
-	// Privilege parity: the caller must hold every permission the
-	// target holds at matching scope. Otherwise deactivation becomes a
-	// denial-of-service primitive against accounts that hold
-	// permissions the caller can't reproduce (and a step toward
-	// escalation if the deactivation is followed by a fresh account
-	// claim).
 	targetEff, err := s.permResolver.LoadEffective(ctx, user.ID, orgID)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error loading target permissions: %v", err)

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -751,12 +751,17 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 
 	// Cross-org guard: GetUserByExternalID is a global lookup. Require the
 	// target to be a member of the caller's org so a SUPER_ADMIN cannot
-	// reset a password for a user in a different tenant. NotFound (mapped
-	// from invalid user_id) avoids leaking whether the user exists elsewhere.
-	// The returned role doubles as the input to the hierarchy check below.
+	// reset a password for a user in a different tenant. Only ErrNoRows
+	// means "not in caller's org" — other errors are transient store
+	// failures and must surface as Internal so callers retry instead of
+	// treating a backend hiccup as bad input. The returned role doubles
+	// as the input to the hierarchy check below.
 	targetRoleName, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID)
 	if err != nil {
-		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
+		}
+		return nil, fleeterror.NewInternalErrorf("error getting target user role: %v", err)
 	}
 
 	callerRoleName, err := s.userManagementStore.GetUserRoleName(ctx, info.UserID, orgID)
@@ -854,11 +859,17 @@ func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUser
 
 	// Cross-org guard: GetUserByExternalID is a global lookup. Require the
 	// target to belong to the caller's org so a SUPER_ADMIN cannot
-	// deactivate a user in a different tenant. The returned role doubles
-	// as the input to the hierarchy check below.
+	// deactivate a user in a different tenant. Only ErrNoRows means
+	// "not in caller's org" — other errors are transient store failures
+	// and must surface as Internal so callers retry instead of treating
+	// a backend hiccup as bad input. The returned role doubles as the
+	// input to the hierarchy check below.
 	targetRoleName, err := s.userManagementStore.GetUserRoleName(ctx, user.ID, orgID)
 	if err != nil {
-		return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fleeterror.NewInvalidArgumentError("invalid user_id")
+		}
+		return nil, fleeterror.NewInternalErrorf("error getting target user role: %v", err)
 	}
 
 	callerRoleName, err := s.userManagementStore.GetUserRoleName(ctx, info.UserID, orgID)

--- a/server/internal/domain/auth/service.go
+++ b/server/internal/domain/auth/service.go
@@ -548,38 +548,22 @@ func generateDefaultOrgName(orgID string) string {
 	return fmt.Sprintf("Organization %s", orgID[:8])
 }
 
-// callerPermissionKeys resolves the caller's full set of permission
-// keys across every scope they hold in the org. The privilege-parity
-// check in CreateUser / ResetUserPassword / DeactivateUser uses this
-// against the target's keys. The resolver is consulted directly so the
-// service doesn't depend on the middleware's request-context plumbing.
-func (s *Service) callerPermissionKeys(ctx context.Context, userID, orgID int64) ([]string, error) {
-	eff, err := s.permResolver.LoadEffective(ctx, userID, orgID)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
-	}
-	return eff.FlatKeys(), nil
-}
-
 // requireCallerCanManageTarget enforces the rule that a caller may
 // only mutate a target user whose effective permissions are a subset
-// of the caller's. This prevents privilege escalation via password
-// reset / deactivation against an account that holds permissions the
-// caller does not (e.g., a custom role with role:manage).
+// of the caller's *at matching scope*. This prevents privilege
+// escalation via password reset / deactivation against an account that
+// holds permissions the caller does not (e.g., a custom role with
+// role:manage), and prevents a site-scoped grant from being laundered
+// into org-scoped authority by flattening keys across scopes.
 //
 // Role names are not consulted — the check operates on the underlying
-// permission keys, so operator-created custom roles get the right
-// treatment automatically. SUPER_ADMIN holds every permission in the
-// catalog and therefore always passes the subset check.
-func requireCallerCanManageTarget(callerKeys, targetKeys []string) error {
-	caller := make(map[string]struct{}, len(callerKeys))
-	for _, k := range callerKeys {
-		caller[k] = struct{}{}
-	}
-	for _, k := range targetKeys {
-		if _, ok := caller[k]; !ok {
-			return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
-		}
+// (key, scope) pairs, so operator-created custom roles and any future
+// builtin keys get the right treatment automatically. SUPER_ADMIN
+// holds every org-scope permission in the catalog and therefore
+// always passes the subset check.
+func requireCallerCanManageTarget(callerEff, targetEff *authz.EffectivePermissions) error {
+	if !targetEff.IsSubsumedBy(callerEff) {
+		return fleeterror.NewForbiddenError("insufficient permissions to manage this user")
 	}
 	return nil
 }
@@ -624,18 +608,22 @@ func (s *Service) CreateUser(ctx context.Context, req *authv1.CreateUserRequest)
 	}
 
 	// Privilege parity: the new user will hold every permission of the
-	// ADMIN role they're being assigned. The caller must already hold
-	// each of those permissions, otherwise CreateUser becomes an
-	// escalation primitive.
+	// ADMIN role they're being assigned, at org scope. The caller must
+	// already hold each of those permissions at org scope as well —
+	// otherwise CreateUser becomes an escalation primitive.
 	targetKeys, err := s.userManagementStore.ListPermissionKeysByRoleID(ctx, role.ID)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error listing target role permissions: %v", err)
 	}
-	callerKeys, err := s.callerPermissionKeys(ctx, info.UserID, orgID)
+	targetEff := authz.NewEffectivePermissions([]authz.Assignment{{
+		ScopeType:   authz.ScopeOrg,
+		Permissions: targetKeys,
+	}})
+	callerEff, err := s.permResolver.LoadEffective(ctx, info.UserID, orgID)
 	if err != nil {
-		return nil, err
+		return nil, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
 	}
-	if err := requireCallerCanManageTarget(callerKeys, targetKeys); err != nil {
+	if err := requireCallerCanManageTarget(callerEff, targetEff); err != nil {
 		return nil, err
 	}
 
@@ -785,18 +773,19 @@ func (s *Service) ResetUserPassword(ctx context.Context, req *authv1.ResetUserPa
 	}
 
 	// Privilege parity: the caller must hold every permission the
-	// target holds. Otherwise password reset becomes an escalation
-	// primitive — the caller could log in as a target whose role grants
-	// permissions the caller doesn't have.
+	// target holds at matching scope. Otherwise password reset becomes
+	// an escalation primitive — the caller could log in as a target
+	// whose role grants permissions the caller doesn't have at the
+	// scope where they'd matter.
 	targetEff, err := s.permResolver.LoadEffective(ctx, user.ID, orgID)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error loading target permissions: %v", err)
 	}
-	callerKeys, err := s.callerPermissionKeys(ctx, info.UserID, orgID)
+	callerEff, err := s.permResolver.LoadEffective(ctx, info.UserID, orgID)
 	if err != nil {
-		return nil, err
+		return nil, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
 	}
-	if err := requireCallerCanManageTarget(callerKeys, targetEff.FlatKeys()); err != nil {
+	if err := requireCallerCanManageTarget(callerEff, targetEff); err != nil {
 		return nil, err
 	}
 
@@ -899,19 +888,20 @@ func (s *Service) DeactivateUser(ctx context.Context, req *authv1.DeactivateUser
 	}
 
 	// Privilege parity: the caller must hold every permission the
-	// target holds. Otherwise deactivation becomes a denial-of-service
-	// primitive against accounts that hold permissions the caller can't
-	// reproduce (and a step toward escalation if the deactivation is
-	// followed by a fresh account claim).
+	// target holds at matching scope. Otherwise deactivation becomes a
+	// denial-of-service primitive against accounts that hold
+	// permissions the caller can't reproduce (and a step toward
+	// escalation if the deactivation is followed by a fresh account
+	// claim).
 	targetEff, err := s.permResolver.LoadEffective(ctx, user.ID, orgID)
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error loading target permissions: %v", err)
 	}
-	callerKeys, err := s.callerPermissionKeys(ctx, info.UserID, orgID)
+	callerEff, err := s.permResolver.LoadEffective(ctx, info.UserID, orgID)
 	if err != nil {
-		return nil, err
+		return nil, fleeterror.NewInternalErrorf("error loading caller permissions: %v", err)
 	}
-	if err := requireCallerCanManageTarget(callerKeys, targetEff.FlatKeys()); err != nil {
+	if err := requireCallerCanManageTarget(callerEff, targetEff); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/domain/auth/service_test.go
+++ b/server/internal/domain/auth/service_test.go
@@ -866,38 +866,45 @@ func TestActivityLogging_UpdateUsernameLogsOldAndNew(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRequireCanManageTargetRole(t *testing.T) {
+func TestRequireCallerCanManageTarget(t *testing.T) {
 	t.Parallel()
+
+	superAdmin := []string{"user:read", "user:manage", "role:manage", "miner:reboot", "site:manage", "miner:read", "miner:blink_led"}
+	admin := []string{"user:read", "user:manage", "miner:reboot", "site:manage", "miner:read", "miner:blink_led"}
+	customWithRoleManage := []string{"user:read", "role:manage"} // dangerous escalation primitive
+	fieldTech := []string{"miner:read", "miner:blink_led"}
 
 	cases := []struct {
 		name       string
-		caller     string
-		target     string
+		caller     []string
+		target     []string
 		wantDenied bool
 	}{
-		{"super admin manages super admin", SuperAdminRoleName, SuperAdminRoleName, false},
-		{"super admin manages admin", SuperAdminRoleName, AdminRoleName, false},
-		{"super admin manages field tech", SuperAdminRoleName, "FIELD_TECH", false},
-		{"admin manages field tech", AdminRoleName, "FIELD_TECH", false},
-		{"admin manages custom role", AdminRoleName, "TECH_LEAD", false},
-		{"admin cannot manage admin", AdminRoleName, AdminRoleName, true},
-		{"admin cannot manage super admin", AdminRoleName, SuperAdminRoleName, true},
-		{"custom role cannot manage admin", "TECH_LEAD", AdminRoleName, true},
-		{"custom role cannot manage super admin", "TECH_LEAD", SuperAdminRoleName, true},
-		{"custom role manages custom role", "TECH_LEAD", "FIELD_TECH", false},
+		{"super admin manages super admin", superAdmin, superAdmin, false},
+		{"super admin manages admin", superAdmin, admin, false},
+		{"super admin manages field tech", superAdmin, fieldTech, false},
+		{"super admin manages custom-with-role-manage", superAdmin, customWithRoleManage, false},
+		{"admin manages field tech", admin, fieldTech, false},
+		{"admin manages peer admin (subset by equality)", admin, admin, false},
+		{"admin BLOCKED from custom-with-role-manage (escalation)", admin, customWithRoleManage, true},
+		{"admin cannot manage super admin", admin, superAdmin, true},
+		{"field tech cannot manage admin", fieldTech, admin, true},
+		{"field tech manages peer field tech", fieldTech, fieldTech, false},
+		{"empty caller cannot manage anyone with perms", nil, fieldTech, true},
+		{"anyone manages empty target", admin, nil, false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := requireCanManageTargetRole(tc.caller, tc.target)
+			err := requireCallerCanManageTarget(tc.caller, tc.target)
 			if tc.wantDenied {
 				require.Error(t, err)
 				var fleetErr fleeterror.FleetError
 				require.ErrorAs(t, err, &fleetErr)
 				assert.Equal(t, fleeterror.NewForbiddenError("").GRPCCode, fleetErr.GRPCCode,
-					"hierarchy denial should return PermissionDenied")
+					"privilege-parity denial should return PermissionDenied")
 			} else {
 				require.NoError(t, err)
 			}

--- a/server/internal/domain/auth/service_test.go
+++ b/server/internal/domain/auth/service_test.go
@@ -865,3 +865,42 @@ func TestActivityLogging_UpdateUsernameLogsOldAndNew(t *testing.T) {
 	err := service.UpdateUsername(ctx, "newname")
 	require.NoError(t, err)
 }
+
+func TestRequireCanManageTargetRole(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		caller     string
+		target     string
+		wantDenied bool
+	}{
+		{"super admin manages super admin", SuperAdminRoleName, SuperAdminRoleName, false},
+		{"super admin manages admin", SuperAdminRoleName, AdminRoleName, false},
+		{"super admin manages field tech", SuperAdminRoleName, "FIELD_TECH", false},
+		{"admin manages field tech", AdminRoleName, "FIELD_TECH", false},
+		{"admin manages custom role", AdminRoleName, "TECH_LEAD", false},
+		{"admin cannot manage admin", AdminRoleName, AdminRoleName, true},
+		{"admin cannot manage super admin", AdminRoleName, SuperAdminRoleName, true},
+		{"custom role cannot manage admin", "TECH_LEAD", AdminRoleName, true},
+		{"custom role cannot manage super admin", "TECH_LEAD", SuperAdminRoleName, true},
+		{"custom role manages custom role", "TECH_LEAD", "FIELD_TECH", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := requireCanManageTargetRole(tc.caller, tc.target)
+			if tc.wantDenied {
+				require.Error(t, err)
+				var fleetErr fleeterror.FleetError
+				require.ErrorAs(t, err, &fleetErr)
+				assert.Equal(t, fleeterror.NewForbiddenError("").GRPCCode, fleetErr.GRPCCode,
+					"hierarchy denial should return PermissionDenied")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/server/internal/domain/auth/service_test.go
+++ b/server/internal/domain/auth/service_test.go
@@ -903,16 +903,16 @@ func TestRequireCallerCanManageTarget(t *testing.T) {
 		target     []authz.Assignment
 		wantDenied bool
 	}{
-		{"super admin manages super admin", superAdminOrg, superAdminOrg, false},
+		{"super admin manages super admin (peer via role:manage bypass)", superAdminOrg, superAdminOrg, false},
 		{"super admin manages admin", superAdminOrg, adminOrg, false},
 		{"super admin manages field tech", superAdminOrg, fieldTechOrg, false},
 		{"super admin manages custom-with-role-manage", superAdminOrg, customOrgWithRoleManage, false},
 		{"admin manages field tech", adminOrg, fieldTechOrg, false},
-		{"admin manages peer admin", adminOrg, adminOrg, false},
+		{"admin BLOCKED from peer admin (equality without role:manage)", adminOrg, adminOrg, true},
 		{"admin BLOCKED from custom-with-org-role-manage (escalation)", adminOrg, customOrgWithRoleManage, true},
 		{"admin cannot manage super admin", adminOrg, superAdminOrg, true},
 		{"field tech cannot manage admin", fieldTechOrg, adminOrg, true},
-		{"field tech manages peer field tech", fieldTechOrg, fieldTechOrg, false},
+		{"field tech BLOCKED from peer field tech (equality without role:manage)", fieldTechOrg, fieldTechOrg, true},
 		{"empty caller cannot manage anyone with perms", nil, fieldTechOrg, true},
 		{"anyone manages empty target", adminOrg, nil, false},
 		{
@@ -924,6 +924,18 @@ func TestRequireCallerCanManageTarget(t *testing.T) {
 			[]authz.Assignment{orgScope("user:manage")},
 			[]authz.Assignment{siteScope(7, "miner:reboot")},
 			true,
+		},
+		{
+			"custom role with org-scope role:manage manages peer with same set",
+			[]authz.Assignment{orgScope("user:read", "user:manage", "role:manage")},
+			[]authz.Assignment{orgScope("user:read", "user:manage", "role:manage")},
+			false,
+		},
+		{
+			"admin with operator-added extra perm manages vanilla admin (strict superset)",
+			[]authz.Assignment{orgScope("user:read", "user:manage", "miner:reboot", "miner:read", "miner:blink_led", "site:manage", "synthetic:extra")},
+			adminOrg,
+			false,
 		},
 	}
 

--- a/server/internal/domain/auth/service_test.go
+++ b/server/internal/domain/auth/service_test.go
@@ -920,6 +920,22 @@ func TestRequireCallerCanManageTarget(t *testing.T) {
 			adminOrgPlusSiteRoleManage, superAdminOrg, true,
 		},
 		{
+			// Caller has org-scope SUPER_ADMIN but narrows to FIELD_TECH at site 7.
+			// Target is org-scope ADMIN with no narrowing. Even though the caller's
+			// flat org-scope set covers ADMIN's keys, the caller cannot perform
+			// ADMIN actions at site 7 (the narrowed FIELD_TECH set excludes them),
+			// while the ADMIN target still can. Resetting target's password would
+			// hand the caller an account with broader site-7 authority than they
+			// themselves possess.
+			"caller-side narrowing must block subsumption of an unnarrowed target",
+			[]authz.Assignment{
+				orgScope("user:read", "user:manage", "role:manage", "miner:reboot", "miner:read", "site:manage"),
+				siteScope(7, "miner:read"),
+			},
+			adminOrg,
+			true,
+		},
+		{
 			"site-scoped target requires site-scoped caller authority",
 			[]authz.Assignment{orgScope("user:manage")},
 			[]authz.Assignment{siteScope(7, "miner:reboot")},

--- a/server/internal/domain/auth/service_test.go
+++ b/server/internal/domain/auth/service_test.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/authn"
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -869,36 +870,71 @@ func TestActivityLogging_UpdateUsernameLogsOldAndNew(t *testing.T) {
 func TestRequireCallerCanManageTarget(t *testing.T) {
 	t.Parallel()
 
-	superAdmin := []string{"user:read", "user:manage", "role:manage", "miner:reboot", "site:manage", "miner:read", "miner:blink_led"}
-	admin := []string{"user:read", "user:manage", "miner:reboot", "site:manage", "miner:read", "miner:blink_led"}
-	customWithRoleManage := []string{"user:read", "role:manage"} // dangerous escalation primitive
-	fieldTech := []string{"miner:read", "miner:blink_led"}
+	orgScope := func(perms ...string) authz.Assignment {
+		return authz.Assignment{ScopeType: authz.ScopeOrg, Permissions: perms}
+	}
+	siteScope := func(siteID int64, perms ...string) authz.Assignment {
+		sid := siteID
+		return authz.Assignment{ScopeType: authz.ScopeSite, SiteID: &sid, Permissions: perms}
+	}
+
+	superAdminOrg := []authz.Assignment{
+		orgScope("user:read", "user:manage", "role:manage", "miner:reboot", "site:manage", "miner:read", "miner:blink_led"),
+	}
+	adminOrg := []authz.Assignment{
+		orgScope("user:read", "user:manage", "miner:reboot", "site:manage", "miner:read", "miner:blink_led"),
+	}
+	customOrgWithRoleManage := []authz.Assignment{orgScope("user:read", "role:manage")}
+	fieldTechOrg := []authz.Assignment{orgScope("miner:read", "miner:blink_led")}
+
+	// Reviewer-flagged case: ADMIN at org-scope plus a site-scoped
+	// custom role granting role:manage *at one site*. The flattened-key
+	// approach would let this caller subsume a SUPER_ADMIN target whose
+	// role:manage is org-scoped, even though the caller cannot wield
+	// role:manage org-wide. Scope-aware comparison must reject.
+	adminOrgPlusSiteRoleManage := []authz.Assignment{
+		orgScope("user:read", "user:manage", "miner:reboot", "site:manage", "miner:read", "miner:blink_led"),
+		siteScope(7, "role:manage"),
+	}
 
 	cases := []struct {
 		name       string
-		caller     []string
-		target     []string
+		caller     []authz.Assignment
+		target     []authz.Assignment
 		wantDenied bool
 	}{
-		{"super admin manages super admin", superAdmin, superAdmin, false},
-		{"super admin manages admin", superAdmin, admin, false},
-		{"super admin manages field tech", superAdmin, fieldTech, false},
-		{"super admin manages custom-with-role-manage", superAdmin, customWithRoleManage, false},
-		{"admin manages field tech", admin, fieldTech, false},
-		{"admin manages peer admin (subset by equality)", admin, admin, false},
-		{"admin BLOCKED from custom-with-role-manage (escalation)", admin, customWithRoleManage, true},
-		{"admin cannot manage super admin", admin, superAdmin, true},
-		{"field tech cannot manage admin", fieldTech, admin, true},
-		{"field tech manages peer field tech", fieldTech, fieldTech, false},
-		{"empty caller cannot manage anyone with perms", nil, fieldTech, true},
-		{"anyone manages empty target", admin, nil, false},
+		{"super admin manages super admin", superAdminOrg, superAdminOrg, false},
+		{"super admin manages admin", superAdminOrg, adminOrg, false},
+		{"super admin manages field tech", superAdminOrg, fieldTechOrg, false},
+		{"super admin manages custom-with-role-manage", superAdminOrg, customOrgWithRoleManage, false},
+		{"admin manages field tech", adminOrg, fieldTechOrg, false},
+		{"admin manages peer admin", adminOrg, adminOrg, false},
+		{"admin BLOCKED from custom-with-org-role-manage (escalation)", adminOrg, customOrgWithRoleManage, true},
+		{"admin cannot manage super admin", adminOrg, superAdminOrg, true},
+		{"field tech cannot manage admin", fieldTechOrg, adminOrg, true},
+		{"field tech manages peer field tech", fieldTechOrg, fieldTechOrg, false},
+		{"empty caller cannot manage anyone with perms", nil, fieldTechOrg, true},
+		{"anyone manages empty target", adminOrg, nil, false},
+		{
+			"admin-with-site-scoped-role-manage cannot launder it into org authority over SUPER_ADMIN",
+			adminOrgPlusSiteRoleManage, superAdminOrg, true,
+		},
+		{
+			"site-scoped target requires site-scoped caller authority",
+			[]authz.Assignment{orgScope("user:manage")},
+			[]authz.Assignment{siteScope(7, "miner:reboot")},
+			true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := requireCallerCanManageTarget(tc.caller, tc.target)
+			caller := authz.NewEffectivePermissions(tc.caller)
+			target := authz.NewEffectivePermissions(tc.target)
+
+			err := requireCallerCanManageTarget(caller, target)
 			if tc.wantDenied {
 				require.Error(t, err)
 				var fleetErr fleeterror.FleetError

--- a/server/internal/domain/authz/builtin.go
+++ b/server/internal/domain/authz/builtin.go
@@ -75,13 +75,14 @@ func BuiltinRoles() []BuiltinRoleSpec {
 	}
 }
 
-// adminSeedPermissions is the formula AllPermissions() − {user:*,
-// role:manage}. Computed from the catalog so adding a new permission
-// in catalog.go automatically grows ADMIN (subject to the
-// additive-only contract — existing operator edits are preserved).
+// adminSeedPermissions is the formula AllPermissions() − {user:manage,
+// role:manage}. ADMIN holds user:read so an org admin can view the team
+// roster, but cannot create/reset/deactivate users — those gates require
+// SUPER_ADMIN. Computed from the catalog so adding a new permission in
+// catalog.go automatically grows ADMIN (subject to the additive-only
+// contract — existing operator edits are preserved).
 func adminSeedPermissions() []string {
 	excluded := map[string]bool{
-		PermUserRead:   true,
 		PermUserManage: true,
 		PermRoleManage: true,
 	}

--- a/server/internal/domain/authz/builtin.go
+++ b/server/internal/domain/authz/builtin.go
@@ -75,15 +75,17 @@ func BuiltinRoles() []BuiltinRoleSpec {
 	}
 }
 
-// adminSeedPermissions is the formula AllPermissions() − {user:manage,
-// role:manage}. ADMIN holds user:read so an org admin can view the team
-// roster, but cannot create/reset/deactivate users — those gates require
-// SUPER_ADMIN. Computed from the catalog so adding a new permission in
-// catalog.go automatically grows ADMIN (subject to the additive-only
-// contract — existing operator edits are preserved).
+// adminSeedPermissions is the formula AllPermissions() − {role:manage}.
+// ADMIN holds user:read for the team roster and user:manage to mutate
+// non-elevated users; the role-hierarchy check in the auth domain layer
+// blocks an ADMIN from creating, resetting, or deactivating an ADMIN or
+// SUPER_ADMIN target. role:manage stays SUPER_ADMIN-only because role
+// edits can grant arbitrary permissions and have no comparable
+// per-target hierarchy gate. Computed from the catalog so adding a new
+// permission in catalog.go automatically grows ADMIN (subject to the
+// additive-only contract — existing operator edits are preserved).
 func adminSeedPermissions() []string {
 	excluded := map[string]bool{
-		PermUserManage: true,
 		PermRoleManage: true,
 	}
 	all := AllPermissions()

--- a/server/internal/domain/authz/builtin.go
+++ b/server/internal/domain/authz/builtin.go
@@ -77,13 +77,16 @@ func BuiltinRoles() []BuiltinRoleSpec {
 
 // adminSeedPermissions is the formula AllPermissions() − {role:manage}.
 // ADMIN holds user:read for the team roster and user:manage to mutate
-// non-elevated users; the role-hierarchy check in the auth domain layer
-// blocks an ADMIN from creating, resetting, or deactivating an ADMIN or
-// SUPER_ADMIN target. role:manage stays SUPER_ADMIN-only because role
-// edits can grant arbitrary permissions and have no comparable
-// per-target hierarchy gate. Computed from the catalog so adding a new
-// permission in catalog.go automatically grows ADMIN (subject to the
-// additive-only contract — existing operator edits are preserved).
+// non-elevated users; the privilege-parity check in the auth domain
+// layer (see requireCallerCanManageTarget) blocks an ADMIN from
+// mutating a target whose effective permissions are not a subset of
+// the caller's. role:manage stays SUPER_ADMIN-only because role edits
+// can grant arbitrary permissions and have no comparable per-target
+// gate. Computed from the catalog so adding a new permission in
+// catalog.go automatically grows the seed for *new* orgs; seed-formula
+// changes that need to reach existing orgs ship as explicit one-off
+// migrations (see migrations/000060_backfill_admin_user_manage.up.sql
+// for the user:read/user:manage backfill).
 func adminSeedPermissions() []string {
 	excluded := map[string]bool{
 		PermRoleManage: true,

--- a/server/internal/domain/authz/builtin.go
+++ b/server/internal/domain/authz/builtin.go
@@ -77,16 +77,21 @@ func BuiltinRoles() []BuiltinRoleSpec {
 
 // adminSeedPermissions is the formula AllPermissions() − {role:manage}.
 // ADMIN holds user:read for the team roster and user:manage to mutate
-// non-elevated users; the privilege-parity check in the auth domain
-// layer (see requireCallerCanManageTarget) blocks an ADMIN from
-// mutating a target whose effective permissions are not a subset of
-// the caller's. role:manage stays SUPER_ADMIN-only because role edits
-// can grant arbitrary permissions and have no comparable per-target
-// gate. Computed from the catalog so adding a new permission in
-// catalog.go automatically grows the seed for *new* orgs; seed-formula
-// changes that need to reach existing orgs ship as explicit one-off
-// migrations (see migrations/000060_backfill_admin_user_manage.up.sql
-// for the user:read/user:manage backfill).
+// non-elevated users. role:manage is excluded for two compounding
+// reasons: it can grant arbitrary permissions (so it's the catalog's
+// ultimate authority key), and the privilege-parity check in the auth
+// domain layer (see requireCallerCanManageTarget) uses *org-scope
+// role:manage* as the bypass for peer-tier management — only callers
+// who hold it can mutate a target whose permissions equal their own.
+// Without that gate, ADMIN could create new ADMINs (the target's seed
+// equals the caller's) and walk away with the new account's temp
+// password.
+//
+// Computed from the catalog so adding a new permission in catalog.go
+// automatically grows the seed for *new* orgs; seed-formula changes
+// that need to reach existing orgs ship as explicit one-off migrations
+// (see migrations/000060_backfill_admin_user_manage.up.sql for the
+// user:read/user:manage backfill).
 func adminSeedPermissions() []string {
 	excluded := map[string]bool{
 		PermRoleManage: true,

--- a/server/internal/domain/authz/effective.go
+++ b/server/internal/domain/authz/effective.go
@@ -112,6 +112,15 @@ func (e *EffectivePermissions) Has(key string, rc ResourceContext) bool {
 	return e.orgScope[key]
 }
 
+// StrictlyDominates reports whether this EffectivePermissions
+// subsumes other AND holds at least one (key, scope) pair other does
+// not — i.e., a proper superset. Used as the no-role:manage branch of
+// the user-management parity check, where equal permission sets must
+// be rejected so peer-tier accounts can't manage each other.
+func (e *EffectivePermissions) StrictlyDominates(other *EffectivePermissions) bool {
+	return other.IsSubsumedBy(e) && !e.IsSubsumedBy(other)
+}
+
 // IsSubsumedBy reports whether every (permission key, scope) pair this
 // EffectivePermissions holds is also held by other. Scope is part of
 // the comparison: a permission held only at site 7 is *not* subsumed by

--- a/server/internal/domain/authz/effective.go
+++ b/server/internal/domain/authz/effective.go
@@ -112,6 +112,36 @@ func (e *EffectivePermissions) Has(key string, rc ResourceContext) bool {
 	return e.orgScope[key]
 }
 
+// IsSubsumedBy reports whether every (permission key, scope) pair this
+// EffectivePermissions holds is also held by other. Scope is part of
+// the comparison: a permission held only at site 7 is *not* subsumed by
+// the same key held only at org scope (and vice versa), because
+// narrowing semantics make them functionally different grants. This is
+// the predicate the auth domain layer uses to gate user-management
+// mutations — a caller can mutate a target only when the caller's
+// effective permissions subsume the target's at the same scope, so the
+// caller could not gain capabilities by hijacking the target's session.
+func (e *EffectivePermissions) IsSubsumedBy(other *EffectivePermissions) bool {
+	if e == nil {
+		return true
+	}
+	for key := range e.orgScope {
+		if !other.Has(key, ResourceContext{}) {
+			return false
+		}
+	}
+	for siteID, perms := range e.bySite {
+		sid := siteID
+		rc := ResourceContext{SiteID: &sid}
+		for key := range perms {
+			if !other.Has(key, rc) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // FlatKeys returns every distinct permission key the user holds across
 // every assignment, sorted lexicographically. UserInfo.permissions is
 // projected from this for the client's coarse "has the permission

--- a/server/internal/domain/authz/effective.go
+++ b/server/internal/domain/authz/effective.go
@@ -121,15 +121,29 @@ func (e *EffectivePermissions) StrictlyDominates(other *EffectivePermissions) bo
 	return other.IsSubsumedBy(e) && !e.IsSubsumedBy(other)
 }
 
-// IsSubsumedBy reports whether every (permission key, scope) pair this
-// EffectivePermissions holds is also held by other. Scope is part of
-// the comparison: a permission held only at site 7 is *not* subsumed by
-// the same key held only at org scope (and vice versa), because
-// narrowing semantics make them functionally different grants. This is
-// the predicate the auth domain layer uses to gate user-management
-// mutations — a caller can mutate a target only when the caller's
-// effective permissions subsume the target's at the same scope, so the
-// caller could not gain capabilities by hijacking the target's session.
+// IsSubsumedBy reports whether every (permission key, resource scope)
+// the receiver can act under is also actionable by other. Scope-aware:
+// a permission held only at site 7 is *not* subsumed by the same key
+// held only at org scope (and vice versa), and — crucially —
+// other-side narrowing is treated as reducing coverage for the
+// receiver's org-scope keys at every site where other narrows. Without
+// that, a caller with org-scope SUPER_ADMIN plus a restrictive
+// FIELD_TECH assignment at site 7 would falsely subsume an org ADMIN
+// target whose ADMIN authority still applies at site 7 (the target
+// has no narrowing there, so its org-scope grants are live).
+//
+// The check covers two domains:
+//
+//  1. The org-scope action space. Every org-scope key the receiver
+//     holds must be held by other at org scope.
+//
+//  2. The site-scope action space at every site where either party
+//     narrows. For each such site s, the receiver's effective key set
+//     at s is its site-scope set if it has one (narrowing applies),
+//     otherwise its org-scope set; every such key must be actionable
+//     by other at s via the same narrowing-aware Has().
+//
+// Sites where neither party narrows are covered by the org-scope pass.
 func (e *EffectivePermissions) IsSubsumedBy(other *EffectivePermissions) bool {
 	if e == nil {
 		return true
@@ -139,10 +153,25 @@ func (e *EffectivePermissions) IsSubsumedBy(other *EffectivePermissions) bool {
 			return false
 		}
 	}
-	for siteID, perms := range e.bySite {
-		sid := siteID
+
+	relevantSites := make(map[int64]struct{}, len(e.bySite)+len(other.bySite))
+	for s := range e.bySite {
+		relevantSites[s] = struct{}{}
+	}
+	for s := range other.bySite {
+		relevantSites[s] = struct{}{}
+	}
+	for s := range relevantSites {
+		sid := s
 		rc := ResourceContext{SiteID: &sid}
-		for key := range perms {
+		keys := e.bySite[s]
+		if keys == nil {
+			// e has no narrowing at this site, so its org-scope grants
+			// apply here and become the action set that other must
+			// cover at this site.
+			keys = e.orgScope
+		}
+		for key := range keys {
 			if !other.Has(key, rc) {
 				return false
 			}

--- a/server/internal/domain/authz/effective_test.go
+++ b/server/internal/domain/authz/effective_test.go
@@ -183,6 +183,27 @@ func TestEffective_FieldTechCanBlinkButNotReboot(t *testing.T) {
 	require.False(t, eff.Has(authz.PermUserManage, orgResource()))
 }
 
+func TestEffective_StrictlyDominates(t *testing.T) {
+	t.Parallel()
+
+	larger := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.PermUserRead, authz.PermUserManage, authz.PermRoleManage),
+	})
+	smaller := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.PermUserRead, authz.PermUserManage),
+	})
+	equalToSmaller := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.PermUserRead, authz.PermUserManage),
+	})
+
+	require.True(t, larger.StrictlyDominates(smaller),
+		"a proper superset strictly dominates")
+	require.False(t, smaller.StrictlyDominates(larger),
+		"a proper subset does not dominate its superset")
+	require.False(t, smaller.StrictlyDominates(equalToSmaller),
+		"equality is not strict domination (this is what blocks peer-tier user management)")
+}
+
 func TestEffective_IsSubsumedBy(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/domain/authz/effective_test.go
+++ b/server/internal/domain/authz/effective_test.go
@@ -235,4 +235,16 @@ func TestEffective_IsSubsumedBy(t *testing.T) {
 		"a site-scope assignment that narrows away the target's key must NOT subsume the target")
 	require.True(t, authz.NewEffectivePermissions(nil).IsSubsumedBy(adminOrg),
 		"empty target is trivially subsumed by any caller")
+
+	// Caller-side narrowing must reduce coverage of the caller's
+	// org-scope grants at the narrowed site. Otherwise a caller with
+	// broad org-scope authority + a restrictive site assignment would
+	// falsely subsume a target whose org-scope authority is still live
+	// at that site.
+	callerOrgFullPlusNarrowSite7 := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.PermUserRead, authz.PermUserManage, authz.PermRoleManage, authz.PermMinerReboot),
+		siteScope(7, authz.PermUserRead), // narrows site 7 to read-only
+	})
+	require.False(t, adminOrg.IsSubsumedBy(callerOrgFullPlusNarrowSite7),
+		"caller's site-7 narrowing strips miner:reboot, but the org-scope ADMIN target's miner:reboot authority remains live at site 7 — caller must not subsume target")
 }

--- a/server/internal/domain/authz/effective_test.go
+++ b/server/internal/domain/authz/effective_test.go
@@ -182,3 +182,36 @@ func TestEffective_FieldTechCanBlinkButNotReboot(t *testing.T) {
 	require.False(t, eff.Has(authz.PermMinerReboot, site(7)))
 	require.False(t, eff.Has(authz.PermUserManage, orgResource()))
 }
+
+func TestEffective_IsSubsumedBy(t *testing.T) {
+	t.Parallel()
+
+	superAdminOrg := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.PermUserRead, authz.PermUserManage, authz.PermRoleManage, authz.PermMinerReboot),
+	})
+	adminOrg := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.PermUserRead, authz.PermUserManage, authz.PermMinerReboot),
+	})
+	adminOrgPlusSiteRoleManage := authz.NewEffectivePermissions([]authz.Assignment{
+		orgScope(authz.PermUserRead, authz.PermUserManage, authz.PermMinerReboot),
+		siteScope(7, authz.PermRoleManage),
+	})
+	siteOnlyMinerReboot := authz.NewEffectivePermissions([]authz.Assignment{
+		siteScope(7, authz.PermMinerReboot),
+	})
+
+	require.True(t, adminOrg.IsSubsumedBy(superAdminOrg),
+		"super_admin's catalog covers admin's org-scope keys")
+	require.False(t, superAdminOrg.IsSubsumedBy(adminOrg),
+		"admin lacks role:manage that super_admin holds at org scope")
+	require.False(t, superAdminOrg.IsSubsumedBy(adminOrgPlusSiteRoleManage),
+		"a caller's site-scoped role:manage must NOT subsume a target's org-scoped role:manage")
+	require.True(t, siteOnlyMinerReboot.IsSubsumedBy(superAdminOrg),
+		"org-scope grants narrow into the site scope when no site-scope assignment exists, so the org-only super_admin covers site-only miner:reboot")
+	require.False(t, siteOnlyMinerReboot.IsSubsumedBy(authz.NewEffectivePermissions([]authz.Assignment{
+		siteScope(7, authz.PermMinerRead), // narrowing at site 7 excludes miner:reboot
+	})),
+		"a site-scope assignment that narrows away the target's key must NOT subsume the target")
+	require.True(t, authz.NewEffectivePermissions(nil).IsSubsumedBy(adminOrg),
+		"empty target is trivially subsumed by any caller")
+}

--- a/server/internal/domain/authz/reconcile.go
+++ b/server/internal/domain/authz/reconcile.go
@@ -125,7 +125,9 @@ func seedOrgBuiltins(ctx context.Context, q *sqlc.Queries, orgID int64) (map[Bui
 			// Additive-only built-ins: leave role_permission untouched.
 			// The operator owns this role once it exists; re-asserting
 			// seed permissions would silently restore anything they
-			// deliberately revoked.
+			// deliberately revoked. Seed-formula changes that need to
+			// reach existing rows ship as explicit one-off migrations
+			// (see migrations/000055_backfill_admin_user_manage.up.sql).
 
 		case errors.Is(err, sql.ErrNoRows):
 			role, err := q.UpsertBuiltinRoleForOrg(ctx, sqlc.UpsertBuiltinRoleForOrgParams{

--- a/server/internal/domain/authz/reconcile_test.go
+++ b/server/internal/domain/authz/reconcile_test.go
@@ -48,16 +48,17 @@ func TestReconcile_FreshInstall_SuperAdminHasEveryCatalogPermission(t *testing.T
 	require.Equal(t, want, got)
 }
 
-func TestReconcile_FreshInstall_AdminExcludesUserAndRoleManagement(t *testing.T) {
+func TestReconcile_FreshInstall_AdminExcludesUserManageAndRoleManagement(t *testing.T) {
 	db := testutil.GetTestDB(t)
 	ctx := t.Context()
 	orgID := insertTestOrganization(t, db)
 	require.NoError(t, authz.Reconcile(ctx, db))
 
 	got := orgRolePermissionKeys(t, db, orgID, "ADMIN")
-	for _, forbidden := range []string{authz.PermUserRead, authz.PermUserManage, authz.PermRoleManage} {
+	for _, forbidden := range []string{authz.PermUserManage, authz.PermRoleManage} {
 		require.NotContains(t, got, forbidden, "ADMIN must not seed with %q", forbidden)
 	}
+	require.Contains(t, got, authz.PermUserRead, "ADMIN holds user:read so org admins can view the team roster")
 	require.Contains(t, got, authz.PermMinerReboot, "ADMIN should still hold miner action permissions")
 }
 

--- a/server/internal/domain/authz/reconcile_test.go
+++ b/server/internal/domain/authz/reconcile_test.go
@@ -48,17 +48,16 @@ func TestReconcile_FreshInstall_SuperAdminHasEveryCatalogPermission(t *testing.T
 	require.Equal(t, want, got)
 }
 
-func TestReconcile_FreshInstall_AdminExcludesUserManageAndRoleManagement(t *testing.T) {
+func TestReconcile_FreshInstall_AdminExcludesRoleManagement(t *testing.T) {
 	db := testutil.GetTestDB(t)
 	ctx := t.Context()
 	orgID := insertTestOrganization(t, db)
 	require.NoError(t, authz.Reconcile(ctx, db))
 
 	got := orgRolePermissionKeys(t, db, orgID, "ADMIN")
-	for _, forbidden := range []string{authz.PermUserManage, authz.PermRoleManage} {
-		require.NotContains(t, got, forbidden, "ADMIN must not seed with %q", forbidden)
-	}
+	require.NotContains(t, got, authz.PermRoleManage, "ADMIN must not seed with role:manage")
 	require.Contains(t, got, authz.PermUserRead, "ADMIN holds user:read so org admins can view the team roster")
+	require.Contains(t, got, authz.PermUserManage, "ADMIN holds user:manage; hierarchy check blocks elevated targets at the domain layer")
 	require.Contains(t, got, authz.PermMinerReboot, "ADMIN should still hold miner action permissions")
 }
 

--- a/server/internal/domain/authz/reconcile_test.go
+++ b/server/internal/domain/authz/reconcile_test.go
@@ -176,7 +176,7 @@ func TestReconcile_NewCatalogPermissionDoesNotPropagateToExistingBuiltins(t *tes
 	require.NoError(t, authz.Reconcile(ctx, db))
 
 	require.Equal(t, beforeAdmin, orgRolePermissionKeys(t, db, orgID, "ADMIN"),
-		"new catalog permissions must not auto-add to an existing org's ADMIN")
+		"new catalog permissions must not auto-add to an existing org's ADMIN; seed-formula changes that need to reach existing rows ship as explicit one-off migrations")
 	require.Equal(t, beforeFieldTech, orgRolePermissionKeys(t, db, orgID, "FIELD_TECH"),
 		"new catalog permissions must not auto-add to an existing org's FIELD_TECH")
 }

--- a/server/internal/domain/stores/interfaces/mocks/mock_user_store.go
+++ b/server/internal/domain/stores/interfaces/mocks/mock_user_store.go
@@ -301,6 +301,21 @@ func (mr *MockUserManagementStoreMockRecorder) GetUserRoleName(ctx, userID, orga
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserRoleName", reflect.TypeOf((*MockUserManagementStore)(nil).GetUserRoleName), ctx, userID, organizationID)
 }
 
+// ListPermissionKeysByRoleID mocks base method.
+func (m *MockUserManagementStore) ListPermissionKeysByRoleID(ctx context.Context, roleID int64) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPermissionKeysByRoleID", ctx, roleID)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPermissionKeysByRoleID indicates an expected call of ListPermissionKeysByRoleID.
+func (mr *MockUserManagementStoreMockRecorder) ListPermissionKeysByRoleID(ctx, roleID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPermissionKeysByRoleID", reflect.TypeOf((*MockUserManagementStore)(nil).ListPermissionKeysByRoleID), ctx, roleID)
+}
+
 // ListUsersForOrganization mocks base method.
 func (m *MockUserManagementStore) ListUsersForOrganization(ctx context.Context, organizationID int64) ([]interfaces.User, error) {
 	m.ctrl.T.Helper()

--- a/server/internal/domain/stores/interfaces/user.go
+++ b/server/internal/domain/stores/interfaces/user.go
@@ -33,6 +33,7 @@ type UserManagementStore interface { //nolint:interfacebloat // user mgmt store 
 	UpdateLastLogin(ctx context.Context, userID int64) error
 	ListUsersForOrganization(ctx context.Context, organizationID int64) ([]User, error)
 	GetUserRoleName(ctx context.Context, userID int64, organizationID int64) (string, error)
+	ListPermissionKeysByRoleID(ctx context.Context, roleID int64) ([]string, error)
 }
 
 type User struct {

--- a/server/internal/domain/stores/sqlstores/user.go
+++ b/server/internal/domain/stores/sqlstores/user.go
@@ -297,3 +297,7 @@ func (s *SQLUserStore) GetUserRoleName(ctx context.Context, userID int64, organi
 		OrganizationID: organizationID,
 	})
 }
+
+func (s *SQLUserStore) ListPermissionKeysByRoleID(ctx context.Context, roleID int64) ([]string, error) {
+	return s.getQueries(ctx).ListRolePermissionKeys(ctx, roleID)
+}

--- a/server/internal/handlers/apikey/handler.go
+++ b/server/internal/handlers/apikey/handler.go
@@ -11,10 +11,9 @@ import (
 	pb "github.com/block/proto-fleet/server/generated/grpc/apikey/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/apikey/v1/apikeyv1connect"
 	domainApiKey "github.com/block/proto-fleet/server/internal/domain/apikey"
-	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
-	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
-	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // Handler handles API key management requests.
@@ -30,12 +29,8 @@ func NewHandler(apiKeySvc *domainApiKey.Service) *Handler {
 }
 
 func (h *Handler) CreateApiKey(ctx context.Context, req *connect.Request[pb.CreateApiKeyRequest]) (*connect.Response[pb.CreateApiKeyResponse], error) {
-	info, err := session.GetInfo(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermAPIKeyManage, authz.ResourceContext{})
 	if err != nil {
-		return nil, err
-	}
-
-	if err := requireAdmin(info); err != nil {
 		return nil, err
 	}
 
@@ -57,12 +52,8 @@ func (h *Handler) CreateApiKey(ctx context.Context, req *connect.Request[pb.Crea
 }
 
 func (h *Handler) ListApiKeys(ctx context.Context, _ *connect.Request[pb.ListApiKeysRequest]) (*connect.Response[pb.ListApiKeysResponse], error) {
-	info, err := session.GetInfo(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermAPIKeyManage, authz.ResourceContext{})
 	if err != nil {
-		return nil, err
-	}
-
-	if err := requireAdmin(info); err != nil {
 		return nil, err
 	}
 
@@ -82,12 +73,8 @@ func (h *Handler) ListApiKeys(ctx context.Context, _ *connect.Request[pb.ListApi
 }
 
 func (h *Handler) RevokeApiKey(ctx context.Context, req *connect.Request[pb.RevokeApiKeyRequest]) (*connect.Response[pb.RevokeApiKeyResponse], error) {
-	info, err := session.GetInfo(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermAPIKeyManage, authz.ResourceContext{})
 	if err != nil {
-		return nil, err
-	}
-
-	if err := requireAdmin(info); err != nil {
 		return nil, err
 	}
 
@@ -96,13 +83,6 @@ func (h *Handler) RevokeApiKey(ctx context.Context, req *connect.Request[pb.Revo
 	}
 
 	return connect.NewResponse(&pb.RevokeApiKeyResponse{}), nil
-}
-
-func requireAdmin(info *session.Info) error {
-	if info.Role != domainAuth.SuperAdminRoleName && info.Role != domainAuth.AdminRoleName {
-		return fleeterror.NewForbiddenError("only admins can manage API keys")
-	}
-	return nil
 }
 
 func apiKeyToProto(key *interfaces.ApiKey) *pb.ApiKeyInfo {

--- a/server/internal/handlers/apikey/handler_error_sanitization_test.go
+++ b/server/internal/handlers/apikey/handler_error_sanitization_test.go
@@ -16,7 +16,6 @@ import (
 	apikeyv1 "github.com/block/proto-fleet/server/generated/grpc/apikey/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/apikey/v1/apikeyv1connect"
 	domainApiKey "github.com/block/proto-fleet/server/internal/domain/apikey"
-	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -90,7 +89,6 @@ func (adminAuthInjector) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			OrganizationID: 1,
 			ExternalUserID: "user-1",
 			Username:       "admin",
-			Role:           domainAuth.AdminRoleName,
 		}
 		eff := authz.NewEffectivePermissions([]authz.Assignment{{
 			AssignmentID: 1,

--- a/server/internal/handlers/apikey/handler_error_sanitization_test.go
+++ b/server/internal/handlers/apikey/handler_error_sanitization_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/apikey/v1/apikeyv1connect"
 	domainApiKey "github.com/block/proto-fleet/server/internal/domain/apikey"
 	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	apikeyHandler "github.com/block/proto-fleet/server/internal/handlers/apikey"
 	"github.com/block/proto-fleet/server/internal/handlers/interceptors"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 type apiKeyStoreStub struct {
@@ -90,7 +92,13 @@ func (adminAuthInjector) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			Username:       "admin",
 			Role:           domainAuth.AdminRoleName,
 		}
-		return next(authn.SetInfo(ctx, info), req)
+		eff := authz.NewEffectivePermissions([]authz.Assignment{{
+			AssignmentID: 1,
+			ScopeType:    authz.ScopeOrg,
+			Permissions:  []string{authz.PermAPIKeyManage},
+		}})
+		ctx = middleware.WithEffectivePermissions(authn.SetInfo(ctx, info), eff)
+		return next(ctx, req)
 	}
 }
 

--- a/server/internal/handlers/auth/handler.go
+++ b/server/internal/handlers/auth/handler.go
@@ -9,6 +9,8 @@ import (
 	pb "github.com/block/proto-fleet/server/generated/grpc/auth/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/auth/v1/authv1connect"
 	"github.com/block/proto-fleet/server/internal/domain/auth"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // Handler handles authentication requests
@@ -107,8 +109,11 @@ func (s *Handler) GetUserAuditInfo(ctx context.Context, _ *connect.Request[pb.Ge
 	return connect.NewResponse(resp), nil
 }
 
-// CreateUser creates a new user with a temporary password (Super Admin only)
+// CreateUser creates a new user with a temporary password.
 func (s *Handler) CreateUser(ctx context.Context, req *connect.Request[pb.CreateUserRequest]) (*connect.Response[pb.CreateUserResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermUserManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	resp, err := s.authSvc.CreateUser(ctx, req.Msg)
 	if err != nil {
 		return nil, err
@@ -117,8 +122,11 @@ func (s *Handler) CreateUser(ctx context.Context, req *connect.Request[pb.Create
 	return connect.NewResponse(resp), nil
 }
 
-// ListUsers returns all users in the organization (Super Admin only)
+// ListUsers returns all users in the organization.
 func (s *Handler) ListUsers(ctx context.Context, _ *connect.Request[pb.ListUsersRequest]) (*connect.Response[pb.ListUsersResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermUserRead, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	resp, err := s.authSvc.ListUsers(ctx)
 	if err != nil {
 		return nil, err
@@ -127,8 +135,11 @@ func (s *Handler) ListUsers(ctx context.Context, _ *connect.Request[pb.ListUsers
 	return connect.NewResponse(resp), nil
 }
 
-// ResetUserPassword generates a new temporary password for a user (Super Admin only)
+// ResetUserPassword generates a new temporary password for a user.
 func (s *Handler) ResetUserPassword(ctx context.Context, req *connect.Request[pb.ResetUserPasswordRequest]) (*connect.Response[pb.ResetUserPasswordResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermUserManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	resp, err := s.authSvc.ResetUserPassword(ctx, req.Msg)
 	if err != nil {
 		return nil, err
@@ -137,8 +148,11 @@ func (s *Handler) ResetUserPassword(ctx context.Context, req *connect.Request[pb
 	return connect.NewResponse(resp), nil
 }
 
-// DeactivateUser soft-deletes a user (Super Admin only)
+// DeactivateUser soft-deletes a user.
 func (s *Handler) DeactivateUser(ctx context.Context, req *connect.Request[pb.DeactivateUserRequest]) (*connect.Response[pb.DeactivateUserResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermUserManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	resp, err := s.authSvc.DeactivateUser(ctx, req.Msg)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/auth/handler_gate_test.go
+++ b/server/internal/handlers/auth/handler_gate_test.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/auth/v1"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/handlers/handlerstest"
+)
+
+// Fast-path gate tests for the four user-management handlers. These
+// run without a database — the authSvc is nil and the gate fails
+// before any service call. The PermissionDenied path is the only thing
+// under test; positive (gate-clears, body runs) coverage lives in the
+// DB-backed handler_test.go integration tests.
+
+func TestAuthHandler_userManagementGates_denyWithoutPermission(t *testing.T) {
+	t.Parallel()
+
+	h := NewHandler(nil)
+
+	cases := []struct {
+		name        string
+		permissions []string
+		call        func(*Handler, context.Context) error
+	}{
+		{
+			name:        "ListUsers without user:read",
+			permissions: []string{authz.PermFleetRead},
+			call: func(h *Handler, ctx context.Context) error {
+				_, err := h.ListUsers(ctx, connect.NewRequest(&pb.ListUsersRequest{}))
+				return err
+			},
+		},
+		{
+			name:        "CreateUser without user:manage",
+			permissions: []string{authz.PermUserRead},
+			call: func(h *Handler, ctx context.Context) error {
+				_, err := h.CreateUser(ctx, connect.NewRequest(&pb.CreateUserRequest{Username: "x"}))
+				return err
+			},
+		},
+		{
+			name:        "DeactivateUser without user:manage",
+			permissions: []string{authz.PermUserRead},
+			call: func(h *Handler, ctx context.Context) error {
+				_, err := h.DeactivateUser(ctx, connect.NewRequest(&pb.DeactivateUserRequest{UserId: "u"}))
+				return err
+			},
+		},
+		{
+			name:        "ResetUserPassword without user:manage",
+			permissions: []string{authz.PermUserRead},
+			call: func(h *Handler, ctx context.Context) error {
+				_, err := h.ResetUserPassword(ctx, connect.NewRequest(&pb.ResetUserPasswordRequest{UserId: "u"}))
+				return err
+			},
+		},
+		{
+			name:        "ListUsers with empty permission set",
+			permissions: nil,
+			call: func(h *Handler, ctx context.Context) error {
+				_, err := h.ListUsers(ctx, connect.NewRequest(&pb.ListUsersRequest{}))
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := handlerstest.CtxWithPermissions(t, 1, tc.permissions...)
+			err := tc.call(h, ctx)
+
+			require.Error(t, err)
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr, "expected fleeterror.FleetError, got %T", err)
+			assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+		})
+	}
+}

--- a/server/internal/handlers/buildings/handler.go
+++ b/server/internal/handlers/buildings/handler.go
@@ -8,6 +8,7 @@ import (
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/buildings/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/buildings/v1/buildingsv1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/buildings"
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
@@ -26,7 +27,7 @@ func NewHandler(service *buildings.Service) *Handler {
 }
 
 func (h *Handler) ListBuildings(ctx context.Context, req *connect.Request[pb.ListBuildingsRequest]) (*connect.Response[pb.ListBuildingsResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "list buildings")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteRead, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +39,7 @@ func (h *Handler) ListBuildings(ctx context.Context, req *connect.Request[pb.Lis
 }
 
 func (h *Handler) GetBuilding(ctx context.Context, req *connect.Request[pb.GetBuildingRequest]) (*connect.Response[pb.GetBuildingResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "get building")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteRead, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +53,7 @@ func (h *Handler) GetBuilding(ctx context.Context, req *connect.Request[pb.GetBu
 }
 
 func (h *Handler) CreateBuilding(ctx context.Context, req *connect.Request[pb.CreateBuildingRequest]) (*connect.Response[pb.CreateBuildingResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "create buildings")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +67,7 @@ func (h *Handler) CreateBuilding(ctx context.Context, req *connect.Request[pb.Cr
 }
 
 func (h *Handler) UpdateBuilding(ctx context.Context, req *connect.Request[pb.UpdateBuildingRequest]) (*connect.Response[pb.UpdateBuildingResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "update buildings")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +81,7 @@ func (h *Handler) UpdateBuilding(ctx context.Context, req *connect.Request[pb.Up
 }
 
 func (h *Handler) DeleteBuilding(ctx context.Context, req *connect.Request[pb.DeleteBuildingRequest]) (*connect.Response[pb.DeleteBuildingResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "delete buildings")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/handlers/buildings/handler_test.go
+++ b/server/internal/handlers/buildings/handler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/authn"
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,9 +14,8 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/buildings"
 	"github.com/block/proto-fleet/server/internal/domain/buildings/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
-	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
-	"github.com/block/proto-fleet/server/internal/handlers/middleware"
+	"github.com/block/proto-fleet/server/internal/handlers/handlerstest"
 )
 
 // testHarness wires a real *buildings.Service against mock stores.
@@ -51,22 +49,9 @@ func newTestHandler(t *testing.T) *testHarness {
 	}
 }
 
-// ctxWithPermissions builds a context wired with session.Info and an
-// org-scope EffectivePermissions assignment carrying the supplied keys.
-func ctxWithPermissions(t *testing.T, orgID int64, permissions ...string) context.Context {
+func sitePermsCtx(t *testing.T, orgID int64) context.Context {
 	t.Helper()
-	ctx := authn.SetInfo(t.Context(), &session.Info{OrganizationID: orgID})
-	eff := authz.NewEffectivePermissions([]authz.Assignment{{
-		AssignmentID: 1,
-		ScopeType:    authz.ScopeOrg,
-		Permissions:  permissions,
-	}})
-	return middleware.WithEffectivePermissions(ctx, eff)
-}
-
-func adminCtx(t *testing.T, orgID int64) context.Context {
-	t.Helper()
-	return ctxWithPermissions(t, orgID, authz.PermSiteRead, authz.PermSiteManage)
+	return handlerstest.CtxWithPermissions(t, orgID, authz.PermSiteRead, authz.PermSiteManage)
 }
 
 func TestHandler_authGate(t *testing.T) {
@@ -87,7 +72,7 @@ func TestHandler_authGate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := ctxWithPermissions(t, 1, tc.permissions...)
+			ctx := handlerstest.CtxWithPermissions(t, 1, tc.permissions...)
 
 			_, err := h.ListBuildings(ctx, connect.NewRequest(&pb.ListBuildingsRequest{}))
 			require.Error(t, err)
@@ -132,7 +117,7 @@ func TestHandler_sitePermissionsPassGate(t *testing.T) {
 			t.Parallel()
 			h := newTestHandler(t)
 			h.buildingStore.EXPECT().ListBuildings(gomock.Any(), gomock.AssignableToTypeOf(models.ListFilter{})).Return(nil, nil)
-			ctx := ctxWithPermissions(t, 1, tc.perm, authz.PermSiteRead)
+			ctx := handlerstest.CtxWithPermissions(t, 1, tc.perm, authz.PermSiteRead)
 			_, err := h.handler.ListBuildings(ctx, connect.NewRequest(&pb.ListBuildingsRequest{}))
 			assert.NoError(t, err)
 		})
@@ -150,7 +135,7 @@ func TestHandler_ListBuildings_unfiltered(t *testing.T) {
 			return nil, nil
 		})
 
-	_, err := h.handler.ListBuildings(adminCtx(t, 7), connect.NewRequest(&pb.ListBuildingsRequest{}))
+	_, err := h.handler.ListBuildings(sitePermsCtx(t, 7), connect.NewRequest(&pb.ListBuildingsRequest{}))
 	require.NoError(t, err)
 }
 
@@ -166,7 +151,7 @@ func TestHandler_ListBuildings_filterBySiteID(t *testing.T) {
 			return nil, nil
 		})
 
-	_, err := h.handler.ListBuildings(adminCtx(t, 7), connect.NewRequest(&pb.ListBuildingsRequest{
+	_, err := h.handler.ListBuildings(sitePermsCtx(t, 7), connect.NewRequest(&pb.ListBuildingsRequest{
 		SiteFilter: &pb.ListBuildingsRequest_SiteId{SiteId: 42},
 	}))
 	require.NoError(t, err)
@@ -183,7 +168,7 @@ func TestHandler_ListBuildings_filterByUnassignedOnly(t *testing.T) {
 			return nil, nil
 		})
 
-	_, err := h.handler.ListBuildings(adminCtx(t, 7), connect.NewRequest(&pb.ListBuildingsRequest{
+	_, err := h.handler.ListBuildings(sitePermsCtx(t, 7), connect.NewRequest(&pb.ListBuildingsRequest{
 		SiteFilter: &pb.ListBuildingsRequest_UnassignedOnly{UnassignedOnly: true},
 	}))
 	require.NoError(t, err)
@@ -196,7 +181,7 @@ func TestHandler_CreateBuilding_happy(t *testing.T) {
 	h.buildingStore.EXPECT().CreateBuilding(gomock.Any(), gomock.AssignableToTypeOf(models.CreateParams{})).
 		Return(&models.Building{ID: 1, Name: "Aisle-1"}, nil)
 
-	resp, err := h.handler.CreateBuilding(adminCtx(t, 7), connect.NewRequest(&pb.CreateBuildingRequest{
+	resp, err := h.handler.CreateBuilding(sitePermsCtx(t, 7), connect.NewRequest(&pb.CreateBuildingRequest{
 		Name:                  "Aisle-1",
 		DefaultRackOrderIndex: pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
 	}))
@@ -216,7 +201,7 @@ func TestHandler_CreateBuilding_rejectsUnknownSite(t *testing.T) {
 		Return(fleeterror.NewNotFoundErrorf("site %d not found", 123))
 
 	siteID := int64(123)
-	_, err := h.handler.CreateBuilding(adminCtx(t, 7), connect.NewRequest(&pb.CreateBuildingRequest{
+	_, err := h.handler.CreateBuilding(sitePermsCtx(t, 7), connect.NewRequest(&pb.CreateBuildingRequest{
 		SiteId:                &siteID,
 		Name:                  "Aisle-1",
 		DefaultRackOrderIndex: pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
@@ -234,7 +219,7 @@ func TestHandler_GetBuilding_happy(t *testing.T) {
 	h.buildingStore.EXPECT().GetBuilding(gomock.Any(), int64(7), int64(42)).
 		Return(&models.Building{ID: 42, Name: "Hangar"}, nil)
 
-	resp, err := h.handler.GetBuilding(adminCtx(t, 7), connect.NewRequest(&pb.GetBuildingRequest{Id: 42}))
+	resp, err := h.handler.GetBuilding(sitePermsCtx(t, 7), connect.NewRequest(&pb.GetBuildingRequest{Id: 42}))
 	require.NoError(t, err)
 	assert.Equal(t, int64(42), resp.Msg.GetBuilding().GetId())
 	assert.Equal(t, "Hangar", resp.Msg.GetBuilding().GetName())
@@ -247,7 +232,7 @@ func TestHandler_GetBuilding_notFound(t *testing.T) {
 	h.buildingStore.EXPECT().GetBuilding(gomock.Any(), int64(7), int64(999)).
 		Return(nil, fleeterror.NewNotFoundErrorf("building %d not found", 999))
 
-	_, err := h.handler.GetBuilding(adminCtx(t, 7), connect.NewRequest(&pb.GetBuildingRequest{Id: 999}))
+	_, err := h.handler.GetBuilding(sitePermsCtx(t, 7), connect.NewRequest(&pb.GetBuildingRequest{Id: 999}))
 	require.Error(t, err)
 	var fleetErr fleeterror.FleetError
 	require.ErrorAs(t, err, &fleetErr)
@@ -267,7 +252,7 @@ func TestHandler_GetBuilding_crossOrgIsNotFound(t *testing.T) {
 	h.buildingStore.EXPECT().GetBuilding(gomock.Any(), int64(7), int64(42)).
 		Return(nil, fleeterror.NewNotFoundErrorf("building %d not found", 42))
 
-	_, err := h.handler.GetBuilding(adminCtx(t, 7), connect.NewRequest(&pb.GetBuildingRequest{Id: 42}))
+	_, err := h.handler.GetBuilding(sitePermsCtx(t, 7), connect.NewRequest(&pb.GetBuildingRequest{Id: 42}))
 	require.Error(t, err)
 	var fleetErr fleeterror.FleetError
 	require.ErrorAs(t, err, &fleetErr)
@@ -281,7 +266,7 @@ func TestHandler_UpdateBuilding_happy(t *testing.T) {
 	h.buildingStore.EXPECT().UpdateBuilding(gomock.Any(), gomock.AssignableToTypeOf(models.UpdateParams{})).
 		Return(&models.Building{ID: 1, Name: "renamed"}, nil)
 
-	resp, err := h.handler.UpdateBuilding(adminCtx(t, 7), connect.NewRequest(&pb.UpdateBuildingRequest{
+	resp, err := h.handler.UpdateBuilding(sitePermsCtx(t, 7), connect.NewRequest(&pb.UpdateBuildingRequest{
 		Id:                    1,
 		Name:                  "renamed",
 		DefaultRackOrderIndex: pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
@@ -297,7 +282,7 @@ func TestHandler_DeleteBuilding_surfacesRackCount(t *testing.T) {
 	h.buildingStore.EXPECT().SoftDeleteBuilding(gomock.Any(), int64(7), int64(33)).Return(int64(1), nil)
 	h.buildingStore.EXPECT().UnassignRacksFromBuilding(gomock.Any(), int64(7), int64(33)).Return(int64(5), nil)
 
-	resp, err := h.handler.DeleteBuilding(adminCtx(t, 7), connect.NewRequest(&pb.DeleteBuildingRequest{Id: 33}))
+	resp, err := h.handler.DeleteBuilding(sitePermsCtx(t, 7), connect.NewRequest(&pb.DeleteBuildingRequest{Id: 33}))
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), resp.Msg.GetUnassignedRackCount())
 }

--- a/server/internal/handlers/buildings/handler_test.go
+++ b/server/internal/handlers/buildings/handler_test.go
@@ -11,12 +11,13 @@ import (
 	"go.uber.org/mock/gomock"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/buildings/v1"
-	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/buildings"
 	"github.com/block/proto-fleet/server/internal/domain/buildings/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // testHarness wires a real *buildings.Service against mock stores.
@@ -50,12 +51,22 @@ func newTestHandler(t *testing.T) *testHarness {
 	}
 }
 
+// ctxWithPermissions builds a context wired with session.Info and an
+// org-scope EffectivePermissions assignment carrying the supplied keys.
+func ctxWithPermissions(t *testing.T, orgID int64, permissions ...string) context.Context {
+	t.Helper()
+	ctx := authn.SetInfo(t.Context(), &session.Info{OrganizationID: orgID})
+	eff := authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  permissions,
+	}})
+	return middleware.WithEffectivePermissions(ctx, eff)
+}
+
 func adminCtx(t *testing.T, orgID int64) context.Context {
 	t.Helper()
-	return authn.SetInfo(t.Context(), &session.Info{
-		Role:           domainAuth.AdminRoleName,
-		OrganizationID: orgID,
-	})
+	return ctxWithPermissions(t, orgID, authz.PermSiteRead, authz.PermSiteManage)
 }
 
 func TestHandler_authGate(t *testing.T) {
@@ -64,19 +75,19 @@ func TestHandler_authGate(t *testing.T) {
 	h := NewHandler(nil)
 
 	cases := []struct {
-		name     string
-		role     string
-		wantCode connect.Code
+		name        string
+		permissions []string
+		wantCode    connect.Code
 	}{
-		{"viewer role is rejected", "VIEWER", connect.CodePermissionDenied},
-		{"empty role is rejected", "", connect.CodePermissionDenied},
+		{"caller without site permissions is rejected", []string{authz.PermFleetRead}, connect.CodePermissionDenied},
+		{"caller with no permissions is rejected", nil, connect.CodePermissionDenied},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := authn.SetInfo(t.Context(), &session.Info{Role: tc.role})
+			ctx := ctxWithPermissions(t, 1, tc.permissions...)
 
 			_, err := h.ListBuildings(ctx, connect.NewRequest(&pb.ListBuildingsRequest{}))
 			require.Error(t, err)
@@ -103,16 +114,25 @@ func TestHandler_unauthenticatedWithoutSession(t *testing.T) {
 	assert.Equal(t, connect.CodeUnauthenticated, fleetErr.GRPCCode)
 }
 
-func TestHandler_adminRolesPassGate(t *testing.T) {
+// TestHandler_sitePermissionsPassGate confirms that callers holding
+// the right site permission clear the gate and the body runs cleanly
+// against a real service + mock stores.
+func TestHandler_sitePermissionsPassGate(t *testing.T) {
 	t.Parallel()
 
-	for _, role := range []string{domainAuth.AdminRoleName, domainAuth.SuperAdminRoleName} {
-		t.Run(role, func(t *testing.T) {
+	cases := []struct {
+		name string
+		perm string
+	}{
+		{"PermSiteRead clears ListBuildings", authz.PermSiteRead},
+		{"PermSiteManage clears ListBuildings (caller also holds read for the call site)", authz.PermSiteManage},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			h := newTestHandler(t)
-			// Unfiltered ListBuildings: SiteID nil, UnassignedOnly false.
 			h.buildingStore.EXPECT().ListBuildings(gomock.Any(), gomock.AssignableToTypeOf(models.ListFilter{})).Return(nil, nil)
-			ctx := authn.SetInfo(t.Context(), &session.Info{Role: role, OrganizationID: 1})
+			ctx := ctxWithPermissions(t, 1, tc.perm, authz.PermSiteRead)
 			_, err := h.handler.ListBuildings(ctx, connect.NewRequest(&pb.ListBuildingsRequest{}))
 			assert.NoError(t, err)
 		})

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -16,11 +16,10 @@ import (
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
-// Action verbs for requireAdminFromContext error messages.
-const (
-	actionSupplyOverrideFields = "supply curtailment override fields"
-	actionTerminateEvents      = "terminate curtailment events"
-)
+// Action verb for requireAdminFromContext error messages on the conditional
+// override gates in Start/Stop/Preview. AdminTerminateEvent uses
+// RequirePermission instead.
+const actionSupplyOverrideFields = "supply curtailment override fields"
 
 // Handler implements the curtailment RPC surface; service=nil keeps
 // every RPC at Unimplemented (test stubs).
@@ -204,14 +203,9 @@ func (h *Handler) ListCurtailmentEvents(ctx context.Context, req *connect.Reques
 }
 
 // AdminTerminateEvent forces a non-terminal event to terminal. Paired
-// with SessionOnlyProcedures (see interceptors/config.go). Defense in
-// depth: the session-only admin-role gate fires first for legacy
-// configurations; the curtailment:manage permission gate is the
-// authoritative RBAC check.
+// with SessionOnlyProcedures (see interceptors/config.go); the
+// curtailment:manage permission gate is the authoritative RBAC check.
 func (h *Handler) AdminTerminateEvent(ctx context.Context, req *connect.Request[pb.AdminTerminateEventRequest]) (*connect.Response[pb.AdminTerminateEventResponse], error) {
-	if err := requireAdminFromContext(ctx, actionTerminateEvents); err != nil {
-		return nil, err
-	}
 	if h.service == nil {
 		return nil, errCurtailmentNotImplemented("AdminTerminateEvent")
 	}

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -206,12 +206,12 @@ func (h *Handler) ListCurtailmentEvents(ctx context.Context, req *connect.Reques
 // with SessionOnlyProcedures (see interceptors/config.go); the
 // curtailment:manage permission gate is the authoritative RBAC check.
 func (h *Handler) AdminTerminateEvent(ctx context.Context, req *connect.Request[pb.AdminTerminateEventRequest]) (*connect.Response[pb.AdminTerminateEventResponse], error) {
-	if h.service == nil {
-		return nil, errCurtailmentNotImplemented("AdminTerminateEvent")
-	}
 	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
+	}
+	if h.service == nil {
+		return nil, errCurtailmentNotImplemented("AdminTerminateEvent")
 	}
 	terminateReq, err := toAdminTerminateRequest(req.Msg, info)
 	if err != nil {

--- a/server/internal/handlers/curtailment/handler_admin_terminate_test.go
+++ b/server/internal/handlers/curtailment/handler_admin_terminate_test.go
@@ -170,36 +170,11 @@ func TestHandler_AdminTerminateEvent_HappyPath(t *testing.T) {
 	assert.Equal(t, "operator escalation", store.lastReason)
 }
 
-// TestHandler_AdminTerminateEvent_RejectsNonAdmin: OPERATOR is rejected
-// at the role gate before any service call. Mirrors the StopCurtailment
-// admin-force gate.
-func TestHandler_AdminTerminateEvent_RejectsNonAdmin(t *testing.T) {
-	t.Parallel()
-	store := &adminTerminateStubStore{}
-	h := NewHandler(domainCurtailment.NewService(store))
-
-	_, err := h.AdminTerminateEvent(
-		adminTerminateSessionCtx(42, "OPERATOR"),
-		connect.NewRequest(&pb.AdminTerminateEventRequest{
-			EventUuid:   uuid.New().String(),
-			TargetState: pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_CANCELLED,
-			Reason:      "test",
-		}),
-	)
-	require.Error(t, err)
-	var fleetErr fleeterror.FleetError
-	require.ErrorAs(t, err, &fleetErr)
-	assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
-	assert.Equal(t, 0, store.calls, "role gate must fail before reaching the service")
-}
-
-// TestHandler_AdminTerminateEvent_RejectsAdminWithoutCurtailmentManage:
-// even with the admin role, the caller is denied when curtailment:manage
-// is absent from their effective permissions. This proves the new RBAC
-// gate is the authoritative check; the legacy admin-role gate is only
-// defense-in-depth for sessions that have not yet had their permission
-// set audited.
-func TestHandler_AdminTerminateEvent_RejectsAdminWithoutCurtailmentManage(t *testing.T) {
+// TestHandler_AdminTerminateEvent_RejectsCallerWithoutCurtailmentManage:
+// the caller is denied when curtailment:manage is absent from their
+// effective permissions, regardless of role. RBAC is the authoritative
+// gate on this handler.
+func TestHandler_AdminTerminateEvent_RejectsCallerWithoutCurtailmentManage(t *testing.T) {
 	t.Parallel()
 	store := &adminTerminateStubStore{}
 	h := NewHandler(domainCurtailment.NewService(store))

--- a/server/internal/handlers/curtailment/handler_test.go
+++ b/server/internal/handlers/curtailment/handler_test.go
@@ -292,8 +292,8 @@ func TestHandler_AdminTerminateEventPermissionGate(t *testing.T) {
 // buf.validate constraints on AdminTerminateEventRequest: event_uuid
 // min_len, target_state restricted to CANCELLED/FAILED, reason min_len.
 // Validator-passed requests reach the handler and surface CodeUnauthenticated
-// from requireAdminFromContext (no session in context); we accept that as
-// "validator passed". Role-gate behavior is covered by
+// from middleware.RequirePermission (no session in context); we accept that
+// as "validator passed". Permission-gate behavior is covered by
 // TestHandler_AdminTerminateEventPermissionGate.
 func TestHandler_AdminTerminateEventValidation(t *testing.T) {
 	t.Parallel()

--- a/server/internal/handlers/curtailment/handler_test.go
+++ b/server/internal/handlers/curtailment/handler_test.go
@@ -15,14 +15,16 @@ import (
 	pb "github.com/block/proto-fleet/server/generated/grpc/curtailment/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/curtailment/v1/curtailmentv1connect"
 	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/handlers/interceptors"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // Non-admin-gated routes are wired and return CodeUnimplemented when
 // called without override fields. AdminTerminateEvent's Unimplemented body
-// is covered by TestHandler_AdminTerminateEventRoleGate (admin/super-admin
+// is covered by TestHandler_AdminTerminateEventPermissionGate (admin/super-admin
 // subcases), since its admin-role gate fires before the body.
 func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 	t.Parallel()
@@ -242,36 +244,40 @@ func TestHandler_RequestValidation(t *testing.T) {
 	})
 }
 
-// AdminTerminateEvent rejects non-Admin roles before the Unimplemented body.
-// Direct handler call so session.Info can be injected via authn.SetInfo.
-func TestHandler_AdminTerminateEventRoleGate(t *testing.T) {
+// AdminTerminateEvent gates on PermCurtailmentManage; callers without
+// the permission see PermissionDenied; callers with it fall through to
+// the Unimplemented stub body.
+func TestHandler_AdminTerminateEventPermissionGate(t *testing.T) {
 	t.Parallel()
 
 	h := NewHandler(nil)
 	req := connect.NewRequest(&pb.AdminTerminateEventRequest{
 		EventUuid:   "event-uuid",
 		TargetState: pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_CANCELLED,
-		Reason:      "operator role-gate test",
+		Reason:      "operator permission-gate test",
 	})
 
 	cases := []struct {
-		name     string
-		role     string
-		wantCode connect.Code
+		name        string
+		permissions []string
+		wantCode    connect.Code
 	}{
-		{"viewer role is rejected", "VIEWER", connect.CodePermissionDenied},
-		{"empty role is rejected", "", connect.CodePermissionDenied},
-		{"admin role reaches Unimplemented body", domainAuth.AdminRoleName, connect.CodeUnimplemented},
-		{"super admin role reaches Unimplemented body", domainAuth.SuperAdminRoleName, connect.CodeUnimplemented},
+		{"caller without curtailment:manage is rejected", []string{authz.PermFleetRead}, connect.CodePermissionDenied},
+		{"empty permissions set is rejected", nil, connect.CodePermissionDenied},
+		{"caller with curtailment:manage reaches Unimplemented body", []string{authz.PermCurtailmentManage}, connect.CodeUnimplemented},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := authn.SetInfo(t.Context(), &session.Info{
-				Role: tc.role,
-			})
+			eff := authz.NewEffectivePermissions([]authz.Assignment{{
+				AssignmentID: 1,
+				ScopeType:    authz.ScopeOrg,
+				Permissions:  tc.permissions,
+			}})
+			ctx := authn.SetInfo(t.Context(), &session.Info{})
+			ctx = middleware.WithEffectivePermissions(ctx, eff)
 
 			_, err := h.AdminTerminateEvent(ctx, req)
 
@@ -288,7 +294,7 @@ func TestHandler_AdminTerminateEventRoleGate(t *testing.T) {
 // Validator-passed requests reach the handler and surface CodeUnauthenticated
 // from requireAdminFromContext (no session in context); we accept that as
 // "validator passed". Role-gate behavior is covered by
-// TestHandler_AdminTerminateEventRoleGate.
+// TestHandler_AdminTerminateEventPermissionGate.
 func TestHandler_AdminTerminateEventValidation(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/handlers/fleetnodeadmin/handler.go
+++ b/server/internal/handlers/fleetnodeadmin/handler.go
@@ -8,10 +8,9 @@ import (
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1/fleetnodeadminv1connect"
-	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
-	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleetnodeenrollment"
-	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 type Handler struct {
@@ -27,7 +26,7 @@ func NewHandler(enrollment *fleetnodeenrollment.Service) *Handler {
 }
 
 func (h *Handler) CreateEnrollmentCode(ctx context.Context, _ *connect.Request[pb.CreateEnrollmentCodeRequest]) (*connect.Response[pb.CreateEnrollmentCodeResponse], error) {
-	info, err := h.requireAdminSession(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetnodeManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +41,7 @@ func (h *Handler) CreateEnrollmentCode(ctx context.Context, _ *connect.Request[p
 }
 
 func (h *Handler) ListFleetNodes(ctx context.Context, _ *connect.Request[pb.ListFleetNodesRequest]) (*connect.Response[pb.ListFleetNodesResponse], error) {
-	info, err := h.requireAdminSession(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetnodeRead, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +67,7 @@ func (h *Handler) ListFleetNodes(ctx context.Context, _ *connect.Request[pb.List
 }
 
 func (h *Handler) ConfirmFleetNode(ctx context.Context, req *connect.Request[pb.ConfirmFleetNodeRequest]) (*connect.Response[pb.ConfirmFleetNodeResponse], error) {
-	info, err := h.requireAdminSession(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetnodeManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +83,7 @@ func (h *Handler) ConfirmFleetNode(ctx context.Context, req *connect.Request[pb.
 }
 
 func (h *Handler) RevokeFleetNode(ctx context.Context, req *connect.Request[pb.RevokeFleetNodeRequest]) (*connect.Response[pb.RevokeFleetNodeResponse], error) {
-	info, err := h.requireAdminSession(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetnodeManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -92,17 +91,6 @@ func (h *Handler) RevokeFleetNode(ctx context.Context, req *connect.Request[pb.R
 		return nil, err
 	}
 	return connect.NewResponse(&pb.RevokeFleetNodeResponse{}), nil
-}
-
-func (h *Handler) requireAdminSession(ctx context.Context) (*session.Info, error) {
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if info.Role != domainAuth.SuperAdminRoleName && info.Role != domainAuth.AdminRoleName {
-		return nil, fleeterror.NewForbiddenError("only admins can manage fleet nodes")
-	}
-	return info, nil
 }
 
 // AWAITING_CONFIRMATION lives only on pending_enrollment, so a PENDING fleet

--- a/server/internal/handlers/handlerstest/permissions.go
+++ b/server/internal/handlers/handlerstest/permissions.go
@@ -1,0 +1,35 @@
+// Package handlerstest provides shared helpers for handler-layer
+// unit tests across Connect-RPC packages. Helpers here build the
+// minimum context any RequirePermission gate needs to evaluate
+// without standing up the full auth interceptor pipeline.
+package handlerstest
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/authn"
+
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
+)
+
+// CtxWithPermissions returns a context carrying session.Info for the
+// supplied organization plus an org-scope EffectivePermissions
+// assignment with the given permission keys. Use it from handler unit
+// tests to satisfy middleware.RequirePermission without wiring the
+// resolver against a real database.
+//
+// Caller identity fields (UserID, Username, ExternalUserID) are left
+// zero — tests that need them should layer additional wiring on top.
+func CtxWithPermissions(t *testing.T, orgID int64, permissions ...string) context.Context {
+	t.Helper()
+	ctx := authn.SetInfo(t.Context(), &session.Info{OrganizationID: orgID})
+	eff := authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  permissions,
+	}})
+	return middleware.WithEffectivePermissions(ctx, eff)
+}

--- a/server/internal/handlers/middleware/permission.go
+++ b/server/internal/handlers/middleware/permission.go
@@ -71,6 +71,13 @@ func effectivePermissionsFromContext(ctx context.Context) *authz.EffectivePermis
 // significant side-effects so revocation propagates within a single
 // streaming session; this is the handler's responsibility, not the
 // middleware's.
+//
+// TODO: every current caller passes authz.ResourceContext{} because
+// the migrated handlers are all org-scoped. The first site-scoped
+// migration (miner actions, rack ops, log download) should add a
+// shared helper — e.g. siteResourceForMiner(ctx, minerID) — rather
+// than inlining the miner_id → site_id lookup at each callsite. Drop
+// this TODO once the helper exists.
 func RequirePermission(ctx context.Context, key string, rc authz.ResourceContext) (*session.Info, error) {
 	info, err := session.GetInfo(ctx)
 	if err != nil {

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -58,7 +58,9 @@ var ProcedurePermissions = map[string]string{
 	// Auth user management — gated at the handler layer via
 	// RequirePermission. ListUsers previously had no role check at all;
 	// it is now gated by PermUserRead (ADMIN + SUPER_ADMIN). Mutations
-	// require PermUserManage (SUPER_ADMIN only).
+	// require PermUserManage; the auth domain layer additionally enforces
+	// a role-hierarchy check so an ADMIN cannot create, reset, or
+	// deactivate an elevated (ADMIN/SUPER_ADMIN) target.
 	authv1connect.AuthServiceCreateUserProcedure:        authz.PermUserManage,
 	authv1connect.AuthServiceDeactivateUserProcedure:    authz.PermUserManage,
 	authv1connect.AuthServiceResetUserPasswordProcedure: authz.PermUserManage,

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -21,6 +21,7 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/serverlog/v1/serverlogv1connect"
 	"github.com/block/proto-fleet/server/generated/grpc/sites/v1/sitesv1connect"
 	"github.com/block/proto-fleet/server/generated/grpc/telemetry/v1/telemetryv1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 )
 
 // ProcedurePermissions maps gated Connect procedures to the catalog
@@ -48,6 +49,50 @@ var ProcedurePermissions = map[string]string{
 	// RequirePermission. Empty entries are expected while the
 	// migration is in flight; the contract test catches missing
 	// classifications either way.
+
+	// API key management — gated by RequirePermission(PermAPIKeyManage).
+	apikeyv1connect.ApiKeyServiceCreateApiKeyProcedure: authz.PermAPIKeyManage,
+	apikeyv1connect.ApiKeyServiceListApiKeysProcedure:  authz.PermAPIKeyManage,
+	apikeyv1connect.ApiKeyServiceRevokeApiKeyProcedure: authz.PermAPIKeyManage,
+
+	// Auth user management — gated at the handler layer via
+	// RequirePermission. ListUsers previously had no role check at all;
+	// it is now gated by PermUserRead (held only by SUPER_ADMIN).
+	authv1connect.AuthServiceCreateUserProcedure:        authz.PermUserManage,
+	authv1connect.AuthServiceDeactivateUserProcedure:    authz.PermUserManage,
+	authv1connect.AuthServiceResetUserPasswordProcedure: authz.PermUserManage,
+	authv1connect.AuthServiceListUsersProcedure:         authz.PermUserRead,
+
+	// Buildings CRUD — site:read for reads, site:manage for writes.
+	buildingsv1connect.BuildingServiceListBuildingsProcedure:  authz.PermSiteRead,
+	buildingsv1connect.BuildingServiceGetBuildingProcedure:    authz.PermSiteRead,
+	buildingsv1connect.BuildingServiceCreateBuildingProcedure: authz.PermSiteManage,
+	buildingsv1connect.BuildingServiceUpdateBuildingProcedure: authz.PermSiteManage,
+	buildingsv1connect.BuildingServiceDeleteBuildingProcedure: authz.PermSiteManage,
+
+	// CurtailmentService — only AdminTerminateEvent moves in this swap.
+	// Start/Stop/Preview retain their conditional inline gates pending
+	// the broader curtailment authz redesign.
+	curtailmentv1connect.CurtailmentServiceAdminTerminateEventProcedure: authz.PermCurtailmentManage,
+
+	// FleetNodeAdminService — read for List, manage for the rest.
+	// Pair/Unpair/ListFleetNodeDevices/DiscoverOnFleetNode remain
+	// Unimplemented stubs and stay in ProceduresPendingMigration.
+	fleetnodeadminv1connect.FleetNodeAdminServiceCreateEnrollmentCodeProcedure: authz.PermFleetnodeManage,
+	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodesProcedure:       authz.PermFleetnodeRead,
+	fleetnodeadminv1connect.FleetNodeAdminServiceConfirmFleetNodeProcedure:     authz.PermFleetnodeManage,
+	fleetnodeadminv1connect.FleetNodeAdminServiceRevokeFleetNodeProcedure:      authz.PermFleetnodeManage,
+
+	// ServerLogService — gated by PermServerlogRead.
+	serverlogv1connect.ServerLogServiceListServerLogsProcedure: authz.PermServerlogRead,
+
+	// Sites CRUD — site:read for List, site:manage for everything else.
+	sitesv1connect.SiteServiceListSitesProcedure:             authz.PermSiteRead,
+	sitesv1connect.SiteServiceCreateSiteProcedure:            authz.PermSiteManage,
+	sitesv1connect.SiteServiceUpdateSiteProcedure:            authz.PermSiteManage,
+	sitesv1connect.SiteServiceDeleteSiteProcedure:            authz.PermSiteManage,
+	sitesv1connect.SiteServiceReassignDevicesToSiteProcedure: authz.PermSiteManage,
+	sitesv1connect.SiteServiceAssignBuildingToSiteProcedure:  authz.PermSiteManage,
 }
 
 // ProceduresPendingMigration lists authenticated Connect procedures that
@@ -68,28 +113,13 @@ var ProceduresPendingMigration = map[string]string{
 	activityv1connect.ActivityServiceExportActivitiesProcedure:          "ungated; activity log CSV export",
 	activityv1connect.ActivityServiceListActivityFilterOptionsProcedure: "ungated; filter option lookup",
 
-	// API key management — local requireAdmin helper in apikey/handler.go.
-	apikeyv1connect.ApiKeyServiceCreateApiKeyProcedure: "inline requireAdmin in apikey/handler.go",
-	apikeyv1connect.ApiKeyServiceListApiKeysProcedure:  "inline requireAdmin in apikey/handler.go",
-	apikeyv1connect.ApiKeyServiceRevokeApiKeyProcedure: "inline requireAdmin in apikey/handler.go",
-
-	// Auth user management — checkCanManageUser in auth/service.go.
-	authv1connect.AuthServiceCreateUserProcedure:        "domain-layer checkCanManageUser",
-	authv1connect.AuthServiceDeactivateUserProcedure:    "domain-layer checkCanManageUser",
-	authv1connect.AuthServiceResetUserPasswordProcedure: "domain-layer checkCanManageUser",
-	authv1connect.AuthServiceListUsersProcedure:         "UNGATED: auth/service.go ListUsers has no role check; any authenticated org member can enumerate users — migration must add a real gate",
+	// Auth self-service and session procedures — caller acts on own
+	// session/identity, no separate role check needed.
 	authv1connect.AuthServiceGetUserAuditInfoProcedure:  "authenticated self-read, no role check",
 	authv1connect.AuthServiceUpdatePasswordProcedure:    "authenticated self-write, no role check",
 	authv1connect.AuthServiceUpdateUsernameProcedure:    "authenticated self-write, no role check",
 	authv1connect.AuthServiceVerifyCredentialsProcedure: "authenticated self-read, no role check",
 	authv1connect.AuthServiceLogoutProcedure:            "session-only; FailedPrecondition guard in handler",
-
-	// Buildings — middleware.RequireAdmin in buildings/handler.go.
-	buildingsv1connect.BuildingServiceListBuildingsProcedure:  "middleware.RequireAdmin",
-	buildingsv1connect.BuildingServiceGetBuildingProcedure:    "middleware.RequireAdmin",
-	buildingsv1connect.BuildingServiceCreateBuildingProcedure: "middleware.RequireAdmin",
-	buildingsv1connect.BuildingServiceUpdateBuildingProcedure: "middleware.RequireAdmin",
-	buildingsv1connect.BuildingServiceDeleteBuildingProcedure: "middleware.RequireAdmin",
 
 	// DeviceCollectionService — ungated reads + writes on shared collections.
 	collectionv1connect.DeviceCollectionServiceCreateCollectionProcedure:            "ungated",
@@ -110,10 +140,10 @@ var ProceduresPendingMigration = map[string]string{
 	collectionv1connect.DeviceCollectionServiceClearRackSlotPositionProcedure:       "ungated",
 
 	// CurtailmentService — gates are conditional or absent; migration must close the gaps.
+	// AdminTerminateEvent already swapped to RequirePermission(PermCurtailmentManage).
 	curtailmentv1connect.CurtailmentServiceStartCurtailmentProcedure:       "CONDITIONAL: requireAdminFromContext only when CandidateMinPowerWOverride set or AllowUnbounded; otherwise any authenticated user can start",
 	curtailmentv1connect.CurtailmentServiceStopCurtailmentProcedure:        "CONDITIONAL: requireAdminFromContext only when force=true; non-force stop is ungated",
 	curtailmentv1connect.CurtailmentServiceUpdateCurtailmentEventProcedure: "UNIMPLEMENTED STUB: returns Unimplemented with no gate; needs a real gate when implemented",
-	curtailmentv1connect.CurtailmentServiceAdminTerminateEventProcedure:    "session-only + inline requireAdminFromContext",
 	curtailmentv1connect.CurtailmentServiceListCurtailmentEventsProcedure:  "ungated read",
 	curtailmentv1connect.CurtailmentServiceGetActiveCurtailmentProcedure:   "ungated read",
 	curtailmentv1connect.CurtailmentServicePreviewCurtailmentPlanProcedure: "CONDITIONAL: requireAdminFromContext only when CandidateMinPowerWOverride set; otherwise ungated",
@@ -154,12 +184,8 @@ var ProceduresPendingMigration = map[string]string{
 	fleetmanagementv1connect.FleetManagementServiceDeleteMinersProcedure:            "ungated",
 	fleetmanagementv1connect.FleetManagementServiceExportMinerListCsvProcedure:      "ungated",
 
-	// FleetNodeAdminService — only the first four overrides exist; the rest fall through
-	// the embedded UnimplementedFleetNodeAdminServiceHandler and never reach a role check.
-	fleetnodeadminv1connect.FleetNodeAdminServiceCreateEnrollmentCodeProcedure:  "inline requireAdminSession (info.Role check)",
-	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodesProcedure:        "inline requireAdminSession (info.Role check)",
-	fleetnodeadminv1connect.FleetNodeAdminServiceConfirmFleetNodeProcedure:      "inline requireAdminSession (info.Role check)",
-	fleetnodeadminv1connect.FleetNodeAdminServiceRevokeFleetNodeProcedure:       "inline requireAdminSession (info.Role check)",
+	// FleetNodeAdminService — only the unimplemented stubs remain;
+	// CreateEnrollmentCode/List/Confirm/Revoke moved to ProcedurePermissions.
 	fleetnodeadminv1connect.FleetNodeAdminServicePairDeviceToFleetNodeProcedure: "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
 	fleetnodeadminv1connect.FleetNodeAdminServiceUnpairDeviceProcedure:          "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
 	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodeDevicesProcedure:  "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
@@ -212,17 +238,6 @@ var ProceduresPendingMigration = map[string]string{
 	schedulev1connect.ScheduleServicePauseScheduleProcedure:    "ungated",
 	schedulev1connect.ScheduleServiceResumeScheduleProcedure:   "ungated",
 	schedulev1connect.ScheduleServiceReorderSchedulesProcedure: "ungated",
-
-	// ServerLogService — inline role check.
-	serverlogv1connect.ServerLogServiceListServerLogsProcedure: "inline info.Role check",
-
-	// SiteService — middleware.RequireAdmin.
-	sitesv1connect.SiteServiceListSitesProcedure:             "middleware.RequireAdmin",
-	sitesv1connect.SiteServiceCreateSiteProcedure:            "middleware.RequireAdmin",
-	sitesv1connect.SiteServiceUpdateSiteProcedure:            "middleware.RequireAdmin",
-	sitesv1connect.SiteServiceDeleteSiteProcedure:            "middleware.RequireAdmin",
-	sitesv1connect.SiteServiceReassignDevicesToSiteProcedure: "middleware.RequireAdmin",
-	sitesv1connect.SiteServiceAssignBuildingToSiteProcedure:  "middleware.RequireAdmin",
 
 	// TelemetryService — ungated.
 	telemetryv1connect.TelemetryServiceGetCombinedMetricsProcedure:          "ungated",

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -57,7 +57,8 @@ var ProcedurePermissions = map[string]string{
 
 	// Auth user management — gated at the handler layer via
 	// RequirePermission. ListUsers previously had no role check at all;
-	// it is now gated by PermUserRead (held only by SUPER_ADMIN).
+	// it is now gated by PermUserRead (ADMIN + SUPER_ADMIN). Mutations
+	// require PermUserManage (SUPER_ADMIN only).
 	authv1connect.AuthServiceCreateUserProcedure:        authz.PermUserManage,
 	authv1connect.AuthServiceDeactivateUserProcedure:    authz.PermUserManage,
 	authv1connect.AuthServiceResetUserPasswordProcedure: authz.PermUserManage,

--- a/server/internal/handlers/serverlog/handler.go
+++ b/server/internal/handlers/serverlog/handler.go
@@ -9,9 +9,9 @@ import (
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/serverlog/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/serverlog/v1/serverlogv1connect"
-	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
-	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 	"github.com/block/proto-fleet/server/internal/infrastructure/logging"
 )
 
@@ -31,12 +31,7 @@ func (h *Handler) ListServerLogs(
 	ctx context.Context,
 	req *connect.Request[pb.ListServerLogsRequest],
 ) (*connect.Response[pb.ListServerLogsResponse], error) {
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := requireAdmin(info); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermServerlogRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 
@@ -68,13 +63,6 @@ func (h *Handler) ListServerLogs(
 		BufferSize: int32(snap.Size),
 		Truncated:  snap.Truncated,
 	}), nil
-}
-
-func requireAdmin(info *session.Info) error {
-	if info.Role != domainAuth.AdminRoleName && info.Role != domainAuth.SuperAdminRoleName {
-		return fleeterror.NewForbiddenError("only super admins can view server logs")
-	}
-	return nil
 }
 
 func recordToProto(r logging.BufferedRecord) *pb.LogEntry {

--- a/server/internal/handlers/sites/handler.go
+++ b/server/internal/handlers/sites/handler.go
@@ -10,6 +10,7 @@ import (
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/sites/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/sites/v1/sitesv1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/sites"
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
@@ -28,7 +29,7 @@ func NewHandler(service *sites.Service) *Handler {
 }
 
 func (h *Handler) ListSites(ctx context.Context, _ *connect.Request[pb.ListSitesRequest]) (*connect.Response[pb.ListSitesResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "list sites")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteRead, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +41,7 @@ func (h *Handler) ListSites(ctx context.Context, _ *connect.Request[pb.ListSites
 }
 
 func (h *Handler) CreateSite(ctx context.Context, req *connect.Request[pb.CreateSiteRequest]) (*connect.Response[pb.CreateSiteResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "create sites")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +56,7 @@ func (h *Handler) CreateSite(ctx context.Context, req *connect.Request[pb.Create
 }
 
 func (h *Handler) UpdateSite(ctx context.Context, req *connect.Request[pb.UpdateSiteRequest]) (*connect.Response[pb.UpdateSiteResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "update sites")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +71,7 @@ func (h *Handler) UpdateSite(ctx context.Context, req *connect.Request[pb.Update
 }
 
 func (h *Handler) DeleteSite(ctx context.Context, req *connect.Request[pb.DeleteSiteRequest]) (*connect.Response[pb.DeleteSiteResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "delete sites")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +87,7 @@ func (h *Handler) DeleteSite(ctx context.Context, req *connect.Request[pb.Delete
 }
 
 func (h *Handler) ReassignDevicesToSite(ctx context.Context, req *connect.Request[pb.ReassignDevicesToSiteRequest]) (*connect.Response[pb.ReassignDevicesToSiteResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "reassign devices")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +102,7 @@ func (h *Handler) ReassignDevicesToSite(ctx context.Context, req *connect.Reques
 }
 
 func (h *Handler) AssignBuildingToSite(ctx context.Context, req *connect.Request[pb.AssignBuildingToSiteRequest]) (*connect.Response[pb.AssignBuildingToSiteResponse], error) {
-	info, err := middleware.RequireAdmin(ctx, "assign buildings to sites")
+	info, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/handlers/sites/handler_test.go
+++ b/server/internal/handlers/sites/handler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"connectrpc.com/authn"
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,11 +12,10 @@ import (
 	pb "github.com/block/proto-fleet/server/generated/grpc/sites/v1"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
-	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/sites"
 	"github.com/block/proto-fleet/server/internal/domain/sites/models"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
-	"github.com/block/proto-fleet/server/internal/handlers/middleware"
+	"github.com/block/proto-fleet/server/internal/handlers/handlerstest"
 )
 
 // testHarness wires a real *sites.Service against mock stores so handler
@@ -52,26 +50,12 @@ func newTestHandler(t *testing.T) *testHarness {
 	}
 }
 
-// ctxWithPermissions builds a context wired with session.Info and the
-// supplied permission set so RequirePermission resolves against an
-// org-scope assignment.
-func ctxWithPermissions(t *testing.T, orgID int64, permissions ...string) context.Context {
-	t.Helper()
-	ctx := authn.SetInfo(t.Context(), &session.Info{OrganizationID: orgID})
-	eff := authz.NewEffectivePermissions([]authz.Assignment{{
-		AssignmentID: 1,
-		ScopeType:    authz.ScopeOrg,
-		Permissions:  permissions,
-	}})
-	return middleware.WithEffectivePermissions(ctx, eff)
-}
-
-// adminCtx is the workhorse for body-level tests: a caller with both
-// site:read and site:manage at org scope clears every gate this
+// sitePermsCtx is the workhorse for body-level tests: a caller with
+// both site:read and site:manage at org scope clears every gate this
 // package defines.
-func adminCtx(t *testing.T, orgID int64) context.Context {
+func sitePermsCtx(t *testing.T, orgID int64) context.Context {
 	t.Helper()
-	return ctxWithPermissions(t, orgID, authz.PermSiteRead, authz.PermSiteManage)
+	return handlerstest.CtxWithPermissions(t, orgID, authz.PermSiteRead, authz.PermSiteManage)
 }
 
 func ptrInt64(v int64) *int64 { return &v }
@@ -97,7 +81,7 @@ func TestHandler_authGate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := ctxWithPermissions(t, 1, tc.permissions...)
+			ctx := handlerstest.CtxWithPermissions(t, 1, tc.permissions...)
 
 			_, err := h.ListSites(ctx, connect.NewRequest(&pb.ListSitesRequest{}))
 			require.Error(t, err)
@@ -147,7 +131,7 @@ func TestHandler_sitePermissionsPassGate(t *testing.T) {
 			t.Parallel()
 			h := newTestHandler(t)
 			h.siteStore.EXPECT().ListSites(gomock.Any(), int64(1)).Return(nil, nil)
-			ctx := ctxWithPermissions(t, 1, tc.perm, authz.PermSiteRead)
+			ctx := handlerstest.CtxWithPermissions(t, 1, tc.perm, authz.PermSiteRead)
 			_, err := h.handler.ListSites(ctx, connect.NewRequest(&pb.ListSitesRequest{}))
 			assert.NoError(t, err)
 		})
@@ -166,7 +150,7 @@ func TestHandler_ListSites_returnsRowsWithAllCounts(t *testing.T) {
 		},
 	}, nil)
 
-	resp, err := h.handler.ListSites(adminCtx(t, 7), connect.NewRequest(&pb.ListSitesRequest{}))
+	resp, err := h.handler.ListSites(sitePermsCtx(t, 7), connect.NewRequest(&pb.ListSitesRequest{}))
 	require.NoError(t, err)
 	require.Len(t, resp.Msg.GetSites(), 1)
 	row := resp.Msg.GetSites()[0]
@@ -188,7 +172,7 @@ func TestHandler_CreateSite_canonicalizesNetworkConfig(t *testing.T) {
 			return &models.Site{ID: 1, Name: p.Name, NetworkConfig: p.NetworkConfig}, nil
 		})
 
-	resp, err := h.handler.CreateSite(adminCtx(t, 7), connect.NewRequest(&pb.CreateSiteRequest{
+	resp, err := h.handler.CreateSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.CreateSiteRequest{
 		Name:          "alpha",
 		NetworkConfig: "  10.0.0.0/24  ",
 	}))
@@ -205,7 +189,7 @@ func TestHandler_UpdateSite_happy(t *testing.T) {
 	h.siteStore.EXPECT().UpdateSite(gomock.Any(), gomock.AssignableToTypeOf(models.UpdateSiteParams{})).
 		Return(&models.Site{ID: 42, Name: "renamed"}, nil)
 
-	resp, err := h.handler.UpdateSite(adminCtx(t, 7), connect.NewRequest(&pb.UpdateSiteRequest{
+	resp, err := h.handler.UpdateSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.UpdateSiteRequest{
 		Id:   42,
 		Name: "renamed",
 	}))
@@ -229,7 +213,7 @@ func TestHandler_DeleteSite_surfacesCascadeCounts(t *testing.T) {
 	h.siteStore.EXPECT().UnassignDevicesFromSite(gomock.Any(), int64(7), int64(11)).Return(int64(9), nil)
 	h.siteStore.EXPECT().SoftDeleteSite(gomock.Any(), int64(7), int64(11)).Return(int64(1), nil)
 
-	resp, err := h.handler.DeleteSite(adminCtx(t, 7), connect.NewRequest(&pb.DeleteSiteRequest{Id: 11}))
+	resp, err := h.handler.DeleteSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.DeleteSiteRequest{Id: 11}))
 	require.NoError(t, err)
 	assert.Equal(t, int64(9), resp.Msg.GetUnassignedDeviceCount())
 	assert.Equal(t, int64(2), resp.Msg.GetDeletedBuildingCount())
@@ -249,7 +233,7 @@ func TestHandler_ReassignDevicesToSite_success(t *testing.T) {
 	h.siteStore.EXPECT().FindDeviceSiteConflicts(gomock.Any(), int64(7), idents).Return(map[string]int64{}, nil)
 	h.siteStore.EXPECT().ReassignDevicesToSite(gomock.Any(), int64(7), gomock.AssignableToTypeOf(ptrInt64(0)), idents).Return(int64(2), nil)
 
-	resp, err := h.handler.ReassignDevicesToSite(adminCtx(t, 7), connect.NewRequest(&pb.ReassignDevicesToSiteRequest{
+	resp, err := h.handler.ReassignDevicesToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.ReassignDevicesToSiteRequest{
 		TargetSiteId:      &target,
 		DeviceIdentifiers: idents,
 	}))
@@ -274,7 +258,7 @@ func TestHandler_ReassignDevicesToSite_conflictsReturnTypedReason(t *testing.T) 
 	}, nil)
 	// No ReassignDevicesToSite store call — conflict path rejects entire batch.
 
-	resp, err := h.handler.ReassignDevicesToSite(adminCtx(t, 7), connect.NewRequest(&pb.ReassignDevicesToSiteRequest{
+	resp, err := h.handler.ReassignDevicesToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.ReassignDevicesToSiteRequest{
 		TargetSiteId:      &target,
 		DeviceIdentifiers: idents,
 	}))
@@ -299,7 +283,7 @@ func TestHandler_AssignBuildingToSite_surfacesCascadeCounts(t *testing.T) {
 	h.siteStore.EXPECT().ReassignRacksUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(3), nil)
 	h.siteStore.EXPECT().ReassignDevicesUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(15), nil)
 
-	resp, err := h.handler.AssignBuildingToSite(adminCtx(t, 7), connect.NewRequest(&pb.AssignBuildingToSiteRequest{
+	resp, err := h.handler.AssignBuildingToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.AssignBuildingToSiteRequest{
 		BuildingId:   50,
 		TargetSiteId: &target,
 	}))
@@ -320,7 +304,7 @@ func TestHandler_AssignBuildingToSite_targetUnsetCascadesToUnassigned(t *testing
 	h.siteStore.EXPECT().ReassignRacksUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.Nil()).Return(int64(0), nil)
 	h.siteStore.EXPECT().ReassignDevicesUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.Nil()).Return(int64(0), nil)
 
-	resp, err := h.handler.AssignBuildingToSite(adminCtx(t, 7), connect.NewRequest(&pb.AssignBuildingToSiteRequest{
+	resp, err := h.handler.AssignBuildingToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.AssignBuildingToSiteRequest{
 		BuildingId: 50,
 	}))
 	require.NoError(t, err)

--- a/server/internal/handlers/sites/handler_test.go
+++ b/server/internal/handlers/sites/handler_test.go
@@ -11,12 +11,13 @@ import (
 	"go.uber.org/mock/gomock"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/sites/v1"
-	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/sites"
 	"github.com/block/proto-fleet/server/internal/domain/sites/models"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // testHarness wires a real *sites.Service against mock stores so handler
@@ -51,37 +52,52 @@ func newTestHandler(t *testing.T) *testHarness {
 	}
 }
 
+// ctxWithPermissions builds a context wired with session.Info and the
+// supplied permission set so RequirePermission resolves against an
+// org-scope assignment.
+func ctxWithPermissions(t *testing.T, orgID int64, permissions ...string) context.Context {
+	t.Helper()
+	ctx := authn.SetInfo(t.Context(), &session.Info{OrganizationID: orgID})
+	eff := authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  permissions,
+	}})
+	return middleware.WithEffectivePermissions(ctx, eff)
+}
+
+// adminCtx is the workhorse for body-level tests: a caller with both
+// site:read and site:manage at org scope clears every gate this
+// package defines.
 func adminCtx(t *testing.T, orgID int64) context.Context {
 	t.Helper()
-	return authn.SetInfo(t.Context(), &session.Info{
-		Role:           domainAuth.AdminRoleName,
-		OrganizationID: orgID,
-	})
+	return ctxWithPermissions(t, orgID, authz.PermSiteRead, authz.PermSiteManage)
 }
 
 func ptrInt64(v int64) *int64 { return &v }
 
-// TestHandler_authGate covers the requireAdmin gate at the handler
-// boundary. We use a non-admin role to assert PermissionDenied.
+// TestHandler_authGate exercises the permission gate at the handler
+// boundary. Callers without the required key get PermissionDenied
+// before the body runs.
 func TestHandler_authGate(t *testing.T) {
 	t.Parallel()
 
 	h := NewHandler(nil)
 
 	cases := []struct {
-		name     string
-		role     string
-		wantCode connect.Code
+		name        string
+		permissions []string
+		wantCode    connect.Code
 	}{
-		{"viewer role is rejected", "VIEWER", connect.CodePermissionDenied},
-		{"empty role is rejected", "", connect.CodePermissionDenied},
+		{"caller without site permissions is rejected", []string{authz.PermFleetRead}, connect.CodePermissionDenied},
+		{"caller with no permissions is rejected", nil, connect.CodePermissionDenied},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := authn.SetInfo(t.Context(), &session.Info{Role: tc.role})
+			ctx := ctxWithPermissions(t, 1, tc.permissions...)
 
 			_, err := h.ListSites(ctx, connect.NewRequest(&pb.ListSitesRequest{}))
 			require.Error(t, err)
@@ -113,17 +129,25 @@ func TestHandler_unauthenticatedWithoutSession(t *testing.T) {
 	assert.Equal(t, connect.CodeUnauthenticated, fleetErr.GRPCCode)
 }
 
-// TestHandler_adminRolesPassGate confirms ADMIN/SUPER_ADMIN clear the
-// gate and the body runs cleanly against a real service + mock stores.
-func TestHandler_adminRolesPassGate(t *testing.T) {
+// TestHandler_sitePermissionsPassGate confirms callers holding the
+// appropriate site permission clear the gate and the body runs
+// cleanly against a real service + mock stores.
+func TestHandler_sitePermissionsPassGate(t *testing.T) {
 	t.Parallel()
 
-	for _, role := range []string{domainAuth.AdminRoleName, domainAuth.SuperAdminRoleName} {
-		t.Run(role, func(t *testing.T) {
+	cases := []struct {
+		name string
+		perm string
+	}{
+		{"PermSiteRead clears ListSites", authz.PermSiteRead},
+		{"PermSiteManage clears ListSites (read is implied by holding manage at the catalog level — test wires both)", authz.PermSiteManage},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			h := newTestHandler(t)
 			h.siteStore.EXPECT().ListSites(gomock.Any(), int64(1)).Return(nil, nil)
-			ctx := authn.SetInfo(t.Context(), &session.Info{Role: role, OrganizationID: 1})
+			ctx := ctxWithPermissions(t, 1, tc.perm, authz.PermSiteRead)
 			_, err := h.handler.ListSites(ctx, connect.NewRequest(&pb.ListSitesRequest{}))
 			assert.NoError(t, err)
 		})

--- a/server/internal/testutil/service_provider.go
+++ b/server/internal/testutil/service_provider.go
@@ -103,7 +103,8 @@ func NewServiceProvider(t *testing.T, db *sql.DB, config *Config) *ServiceProvid
 	apiKeyStore := sqlstores.NewSQLApiKeyStore(db)
 	apiKeySvc := apikey.NewService(apiKeyStore, activitySvc)
 
-	authService := auth.NewService(userStore, userStore, transactor, tokenService, sessionService, encryptService, activitySvc)
+	permissionResolver := authz.NewPermissionResolver(db)
+	authService := auth.NewService(userStore, userStore, transactor, tokenService, sessionService, encryptService, activitySvc, permissionResolver)
 
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
@@ -181,6 +182,6 @@ func NewServiceProvider(t *testing.T, db *sql.DB, config *Config) *ServiceProvid
 		FilesService:           filesService,
 		MinerService:           minerService,
 		PluginService:          pluginService,
-		PermissionResolver:     authz.NewPermissionResolver(db),
+		PermissionResolver:     permissionResolver,
 	}
 }

--- a/server/migrations/000060_backfill_admin_user_manage.down.sql
+++ b/server/migrations/000060_backfill_admin_user_manage.down.sql
@@ -1,0 +1,12 @@
+-- Reverses 000060_backfill_admin_user_manage.up.sql by removing the
+-- two specific keys from ADMIN roles. This will also remove the keys
+-- from orgs where they were already present pre-backfill; rolling back
+-- the data migration cleanly is impossible without provenance
+-- tracking, and the rollback path is rare/dev-only.
+DELETE FROM role_permission
+WHERE permission_id IN (
+  SELECT id FROM permission WHERE key IN ('user:read', 'user:manage')
+)
+AND role_id IN (
+  SELECT id FROM role WHERE builtin_key = 'ADMIN' AND deleted_at IS NULL
+);

--- a/server/migrations/000060_backfill_admin_user_manage.up.sql
+++ b/server/migrations/000060_backfill_admin_user_manage.up.sql
@@ -1,0 +1,18 @@
+-- Backfill missing user:read and user:manage on existing ADMIN roles.
+-- The ADMIN seed formula now includes both keys (only role:manage is
+-- excluded). Without this backfill, deployments seeded by migration
+-- 000053 (which excluded user:read and user:manage from ADMIN) would
+-- keep those exclusions forever — the additive reconciler does not
+-- re-assert seed permissions onto existing role rows, so newly-gated
+-- user-management endpoints would silently deny ADMIN on upgraded orgs.
+--
+-- Scoped to roles with builtin_key='ADMIN' so operator-created custom
+-- roles aren't touched. The ON CONFLICT clause makes this safe to
+-- replay against orgs that already hold either key.
+INSERT INTO role_permission (role_id, permission_id)
+SELECT r.id, p.id
+FROM role r, permission p
+WHERE r.builtin_key = 'ADMIN'
+  AND r.deleted_at IS NULL
+  AND p.key IN ('user:read', 'user:manage')
+ON CONFLICT (role_id, permission_id) DO NOTHING;


### PR DESCRIPTION
Third slice of PR 2 from the [granular RBAC plan](https://github.com/block/proto-fleet/pull/282). Mechanical handler swap plus the privilege-parity check and migration that fell out of code review.

PR 2b (rpc_permissions infra, #303) is merged on main; this PR now targets `main` directly.

## What landed

### Handler swaps (RequireAdmin → RequirePermission)
- `buildings/handler.go` (5 procedures): `site:read` for reads, `site:manage` for writes.
- `sites/handler.go` (6 procedures): `site:read` for ListSites, `site:manage` for the rest.

### Inline-check swaps (drop local helpers)
- `apikey/handler.go` (3): drop `requireAdmin`; gate every endpoint on `apikey:manage`.
- `fleetnodeadmin/handler.go` (4 working procedures): drop `requireAdminSession`; gate by `fleetnode:read` (List) or `fleetnode:manage` (Create/Confirm/Revoke). The four Unimplemented stubs stay in `ProceduresPendingMigration` — they don't reach a gate today and won't until the methods are actually implemented.
- `serverlog/handler.go`: drop `requireAdmin`; gate by `serverlog:read`.
- `curtailment/handler.go` `AdminTerminateEvent`: drop the legacy `requireAdminFromContext` defense-in-depth gate and rely on `RequirePermission(PermCurtailmentManage)` as the authoritative check. Start/Stop/Preview keep their conditional inline gates pending the broader curtailment authz redesign (PR 2d).

### Auth domain layer
- Delete `auth/service.go::checkCanManageUser` (sole callers were the Connect handlers; no domain-internal callers).
- Handler-layer gates added in `handlers/auth/handler.go`:
  - `CreateUser`, `DeactivateUser`, `ResetUserPassword` → `RequirePermission(PermUserManage)`
  - `ListUsers` → `RequirePermission(PermUserRead)`. **This closes the P0 surfaced in PR 2b's review** — `ListUsers` previously had **no role check at all**, so any authenticated org member could enumerate users.
- Classify `GetUserRoleName` errors: `sql.ErrNoRows` (target not in caller's org) → `InvalidArgument`; any other error (transient store failure) → `Internal`. Avoids treating a backend hiccup as bad input.

### ADMIN seed + privilege-parity check
- ADMIN now seeds with `user:read` + `user:manage`; only `role:manage` is excluded from the formula. `role:manage` stays SUPER_ADMIN-only because it can grant arbitrary permissions and is the catalog's ultimate authority key.
- `requireCallerCanManageTarget` (in `auth/service.go`) gates every user mutation (`CreateUser` / `ResetUserPassword` / `DeactivateUser`) on two conditions:
  1. **Scope-aware subset**: every `(permission key, scope)` the target holds must also be held by the caller. New `EffectivePermissions.IsSubsumedBy` reuses the narrowing-aware `Has()`, so a site-scoped grant cannot launder into apparent org-scope authority.
  2. **Strict authority**: caller's perms must be *strictly* larger than target's, OR caller must hold org-scope `role:manage`. Without this, equality (ADMIN target equals ADMIN caller) would make CreateUser a primitive for ADMIN to mint new ADMINs and walk off with the temp password.
- Resulting semantics:
  - SUPER_ADMIN manages anyone (org-scope `role:manage` bypass).
  - ADMIN manages strictly-fewer-perms targets (FIELD_TECH, custom non-elevated roles).
  - ADMIN **denied** on peer ADMIN, on SUPER_ADMIN, on any target whose role holds a permission ADMIN doesn't, and on CreateUser (which assigns ADMIN to the new account — same perm set as the caller).
- The check is permission-based, not role-name-based: an operator can authorize a custom role for peer management by explicitly granting it `role:manage`.

### Migration: backfill user:read + user:manage to existing ADMIN rows
- `migrations/000060_backfill_admin_user_manage.up.sql`. Migration 000053 seeded ADMIN explicitly excluding both keys; the additive-only reconciler does not re-assert seed permissions onto existing role rows, so upgraded orgs would silently deny ADMIN on every newly-gated user-management endpoint without an explicit backfill.
- `INSERT ... ON CONFLICT DO NOTHING`, scoped to `WHERE builtin_key = 'ADMIN'`. Idempotent; operator-created custom roles untouched. Down migration removes both keys from ADMIN.
- `builtin.go` docstring updated to point at this migration as the pattern for future seed-formula changes.

### rpc_permissions.go bookkeeping
- 23 procedures move from `ProceduresPendingMigration` → `ProcedurePermissions`.
- The PR 2b contract test catches any drift between the map and the actual handler call.

## What this PR does NOT do

- **Site-scoped narrowing on site/building handlers.** All `RequirePermission` callers in this PR pass `authz.ResourceContext{}`, which makes the check org-scoped. `EffectivePermissions.Has()` does implement narrowing (a site-scope assignment shadows org-scope at that site), so the migrated handlers preserve the pre-existing `RequireAdmin` (org-wide) semantics rather than introducing narrowing. Site-scope wiring lands in PR 2d, tracked by a TODO at `middleware/permission.go` calling out the shared `siteResourceForMiner` / `siteResourceForBuilding` helper that should accompany the first site-scoped handler migration so `building_id → site_id` lookups don't get inlined across handlers.
- **New gates on currently-ungated handlers** (fleetmanagement, command, deviceset, collection, pools, schedule, errors, telemetry, activity, networkinfo, pairing, foremanimport, curtailment reads). PR 2d.
- **Conditional curtailment gates** (Start/Stop/Preview, UpdateCurtailmentEvent stub). PR 2d.
- **Rename `user_organization.role_id`** or add the raising trigger. PR 2d.
- **Delete `middleware/admin.go`.** PR 2d once `ProceduresPendingMigration` empties.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/handlers/middleware/...` green (contract test still passes; the map matches every swapped handler).
- [x] `go test ./internal/handlers/buildings/... ./internal/handlers/sites/... ./internal/handlers/curtailment/...` green after switching handler-level gate tests from role-based to permission-based assertions.
- [x] `go test ./internal/handlers/apikey/... -run TestAPIKeyHandler_SanitizesInternalErrors` green after wiring `EffectivePermissions` through the test's `adminAuthInjector`.
- [x] `go test ./internal/domain/auth/...` green. Privilege-parity helper covered by `TestRequireCallerCanManageTarget` (super_admin/admin/field_tech/custom-role combos, including the equality block, the site-scope laundering case, and the operator-granted-`role:manage`-custom-role bypass).
- [x] `go test ./internal/domain/authz/...` green. `TestEffective_IsSubsumedBy` covers scope-aware subset semantics directly. `TestReconcile_NewCatalogPermissionDoesNotPropagateToExistingBuiltins` confirms operator-revoked permissions still survive restart (additive contract intact); the migration is what propagates seed-formula changes to upgraded orgs.
- [x] Full `go test ./...` green.

## Rollback

Reverting this PR reinstates `RequireAdmin`, `checkCanManageUser`, and the local helper functions. Migration `000060_backfill_admin_user_manage` has a `.down.sql` that removes `user:read` and `user:manage` from every ADMIN row; note this also removes the keys from orgs that already held them pre-backfill (provenance isn't tracked, so the down migration over-corrects on first-install orgs — acceptable in dev rollback scenarios but not for prod recovery).