### PR TITLE
Add Fleet saved view lifecycle E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -1204,12 +1204,15 @@ export class MinersPage extends BasePage {
     await expect(this.page.getByTestId("view-modal")).toBeHidden();
   }
 
-  private getViewTab(viewName: string) {
+  private getViewTabs(viewName: string) {
     return this.page
       .getByTestId("views-bar")
       .locator('[data-testid^="views-bar-tab-"]')
-      .filter({ has: this.page.getByRole("button", { name: viewName, exact: true }) })
-      .first();
+      .filter({ has: this.page.getByRole("button", { name: viewName, exact: true }) });
+  }
+
+  private getViewTab(viewName: string) {
+    return this.getViewTabs(viewName).first();
   }
 
   async validateViewTabVisible(viewName: string) {
@@ -1236,6 +1239,32 @@ export class MinersPage extends BasePage {
   async clickUpdateViewAction(viewName: string) {
     await this.openViewTabKebab(viewName);
     await this.page.getByText("Update view", { exact: true }).click();
+  }
+
+  async clickRenameViewAction(viewName: string) {
+    await this.openViewTabKebab(viewName);
+    await this.page.getByText("Rename", { exact: true }).click();
+  }
+
+  async clickDeleteViewAction(viewName: string) {
+    await this.openViewTabKebab(viewName);
+    await this.page.getByText("Delete", { exact: true }).click();
+  }
+
+  async validateViewTabNotVisible(viewName: string) {
+    await expect(this.getViewTabs(viewName)).toHaveCount(0);
+  }
+
+  async validateDeleteViewDialogOpened(viewName: string) {
+    const dialog = this.page.getByTestId("views-bar-delete-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(`Delete the view "${viewName}"? This can't be undone.`);
+  }
+
+  async confirmDeleteView() {
+    const dialog = this.page.getByTestId("views-bar-delete-dialog");
+    await dialog.getByRole("button", { name: "Delete", exact: true }).click();
+    await expect(dialog).toBeHidden();
   }
 
   async clickMinerElementByTestId(ipAddress: string, testId: string) {

--- a/client/e2eTests/protoFleet/spec/minersFiltersViews.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersFiltersViews.spec.ts
@@ -254,11 +254,12 @@ test.describe("Proto Fleet - Miners filters and saved views", () => {
     });
   });
 
-  test("Saved view can be renamed and persists after reload", async ({ minersPage, commonSteps }) => {
+  test("Saved view can be renamed and persists after reload", async ({ minersPage, commonSteps, page }) => {
     const originalViewName = generateRandomText("miners_view");
     const renamedViewName = generateRandomText("renamed_view");
     let firstMinerIp = "";
     let firstMinerSubnet = "";
+    let activeViewId = "";
 
     await commonSteps.loginAsAdmin();
     await commonSteps.goToMinersPage();
@@ -289,6 +290,11 @@ test.describe("Proto Fleet - Miners filters and saved views", () => {
       await minersPage.validateViewTabNotVisible(originalViewName);
       await minersPage.validateActiveFilterSummary("subnet", firstMinerSubnet);
       await minersPage.validateMinerInList(firstMinerIp);
+
+      const searchParams = new URL(page.url()).searchParams;
+      activeViewId = searchParams.get("view") ?? "";
+      test.expect(activeViewId).not.toBe("");
+      test.expect(searchParams.getAll("subnet")).toEqual([firstMinerSubnet]);
     });
 
     await test.step("Reload and validate the renamed view persists", async () => {
@@ -301,6 +307,10 @@ test.describe("Proto Fleet - Miners filters and saved views", () => {
       await minersPage.validateViewTabNotVisible(originalViewName);
       await minersPage.validateActiveFilterSummary("subnet", firstMinerSubnet);
       await minersPage.validateMinerInList(firstMinerIp);
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.get("view")).toBe(activeViewId);
+      test.expect(searchParams.getAll("subnet")).toEqual([firstMinerSubnet]);
     });
   });
 
@@ -351,6 +361,53 @@ test.describe("Proto Fleet - Miners filters and saved views", () => {
       await minersPage.validateViewTabNotVisible(viewName);
       await minersPage.validateViewTabActive("All miners");
       await minersPage.validateActiveFilterNotVisible("Subnet");
+    });
+  });
+
+  test("Active saved view can be deleted and clears the URL state", async ({ minersPage, commonSteps, page }) => {
+    const viewName = generateRandomText("miners_view");
+    let firstMinerSubnet = "";
+
+    await commonSteps.loginAsAdmin();
+    await commonSteps.goToMinersPage();
+
+    await test.step("Create a saved view from the first miner subnet", async () => {
+      const firstMinerIp = await getFirstVisibleIpv4MinerIp(minersPage);
+      firstMinerSubnet = toSubnet24(firstMinerIp);
+
+      await minersPage.applySubnetFilter([firstMinerSubnet]);
+      await minersPage.waitForMinersListToLoad();
+      await minersPage.clickNewSavedViewButton();
+      await minersPage.validateViewModalOpened("New view");
+      await minersPage.inputViewName(viewName);
+      await minersPage.saveNewView();
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.get("view")).not.toBeNull();
+      test.expect(searchParams.getAll("subnet")).toEqual([firstMinerSubnet]);
+    });
+
+    await test.step("Delete the active saved view", async () => {
+      await minersPage.clickDeleteViewAction(viewName);
+      await minersPage.validateDeleteViewDialogOpened(viewName);
+      await minersPage.confirmDeleteView();
+    });
+
+    await test.step("Validate the deleted active view clears only the view param and keeps the live filters", async () => {
+      await minersPage.validateViewTabNotVisible(viewName);
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.get("view")).toBeNull();
+      test.expect(searchParams.getAll("subnet")).toEqual([firstMinerSubnet]);
+    });
+
+    await test.step("Reload and validate the deleted active view stays gone", async () => {
+      await minersPage.reloadPage();
+      await minersPage.waitForMinersTitle();
+      await minersPage.waitForMinersListToLoad();
+
+      await minersPage.validateViewTabNotVisible(viewName);
+      await minersPage.validateActiveFilterSummary("subnet", firstMinerSubnet);
     });
   });
 });

--- a/client/e2eTests/protoFleet/spec/minersFiltersViews.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersFiltersViews.spec.ts
@@ -253,4 +253,104 @@ test.describe("Proto Fleet - Miners filters and saved views", () => {
       test.expect(new URL(page.url()).searchParams.get("power_max")).toBeNull();
     });
   });
+
+  test("Saved view can be renamed and persists after reload", async ({ minersPage, commonSteps }) => {
+    const originalViewName = generateRandomText("miners_view");
+    const renamedViewName = generateRandomText("renamed_view");
+    let firstMinerIp = "";
+    let firstMinerSubnet = "";
+
+    await commonSteps.loginAsAdmin();
+    await commonSteps.goToMinersPage();
+
+    await test.step("Create a saved view from the first miner subnet", async () => {
+      firstMinerIp = await getFirstVisibleIpv4MinerIp(minersPage);
+      firstMinerSubnet = toSubnet24(firstMinerIp);
+
+      await minersPage.applySubnetFilter([firstMinerSubnet]);
+      await minersPage.waitForMinersListToLoad();
+      firstMinerIp = await minersPage.getMinerIpAddressByIndex(0);
+      await minersPage.clickNewSavedViewButton();
+      await minersPage.validateViewModalOpened("New view");
+      await minersPage.inputViewName(originalViewName);
+      await minersPage.saveNewView();
+    });
+
+    await test.step("Rename the saved view", async () => {
+      await minersPage.clickRenameViewAction(originalViewName);
+      await minersPage.validateViewModalOpened("Update view");
+      await minersPage.inputViewName(renamedViewName);
+      await minersPage.updateSavedView();
+    });
+
+    await test.step("Validate the renamed view is active and the old name is gone", async () => {
+      await minersPage.validateViewTabVisible(renamedViewName);
+      await minersPage.validateViewTabActive(renamedViewName);
+      await minersPage.validateViewTabNotVisible(originalViewName);
+      await minersPage.validateActiveFilterSummary("subnet", firstMinerSubnet);
+      await minersPage.validateMinerInList(firstMinerIp);
+    });
+
+    await test.step("Reload and validate the renamed view persists", async () => {
+      await minersPage.reloadPage();
+      await minersPage.waitForMinersTitle();
+      await minersPage.waitForMinersListToLoad();
+
+      await minersPage.validateViewTabVisible(renamedViewName);
+      await minersPage.validateViewTabActive(renamedViewName);
+      await minersPage.validateViewTabNotVisible(originalViewName);
+      await minersPage.validateActiveFilterSummary("subnet", firstMinerSubnet);
+      await minersPage.validateMinerInList(firstMinerIp);
+    });
+  });
+
+  test("Saved view can be deleted from the views bar", async ({ minersPage, commonSteps, page }) => {
+    const viewName = generateRandomText("miners_view");
+
+    await commonSteps.loginAsAdmin();
+    await commonSteps.goToMinersPage();
+
+    await test.step("Create a saved view from the first miner subnet", async () => {
+      const firstMinerIp = await getFirstVisibleIpv4MinerIp(minersPage);
+      const firstMinerSubnet = toSubnet24(firstMinerIp);
+
+      await minersPage.applySubnetFilter([firstMinerSubnet]);
+      await minersPage.waitForMinersListToLoad();
+      await minersPage.clickNewSavedViewButton();
+      await minersPage.validateViewModalOpened("New view");
+      await minersPage.inputViewName(viewName);
+      await minersPage.saveNewView();
+    });
+
+    await test.step("Return to All miners so the saved view becomes inactive", async () => {
+      await minersPage.clickViewTab("All miners");
+      await minersPage.waitForMinersListToLoad();
+      await minersPage.validateViewTabActive("All miners");
+    });
+
+    await test.step("Delete the saved view", async () => {
+      await minersPage.clickDeleteViewAction(viewName);
+      await minersPage.validateDeleteViewDialogOpened(viewName);
+      await minersPage.confirmDeleteView();
+    });
+
+    await test.step("Validate the deleted view is gone and the URL stayed clean", async () => {
+      await minersPage.validateViewTabNotVisible(viewName);
+      await minersPage.validateViewTabActive("All miners");
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.get("view")).toBeNull();
+      test.expect(searchParams.getAll("subnet")).toEqual([]);
+    });
+
+    await test.step("Reload and validate the deleted view stays gone", async () => {
+      await minersPage.reloadPage();
+      await minersPage.waitForMinersTitle();
+      await minersPage.waitForMinersListToLoad();
+
+      await minersPage.validateViewTabNotVisible(viewName);
+      await minersPage.validateViewTabActive("All miners");
+      await minersPage.validateActiveFilterNotVisible("Subnet");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add Fleet miners saved view rename coverage
- add Fleet miners saved view delete coverage
- extend the miners page object with rename/delete view helpers

## Test plan
- ./node_modules/.bin/eslint e2eTests/protoFleet/pages/miners.ts e2eTests/protoFleet/spec/minersFiltersViews.spec.ts
- ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/minersFiltersViews.spec.ts --project=desktop --no-deps
- ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/minersFiltersViews.spec.ts --project=mobile --no-deps