### PR TITLE
fix(ui): allow selecting unauthenticated miners in bulk actions

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
@@ -27,7 +27,8 @@ const ActionItem = <ActionType,>({ action, onAction }: ActionItemProps<ActionTyp
           className={isDisabled ? "cursor-not-allowed text-emphasis-300 opacity-50" : "text-emphasis-300"}
           prefixIcon={action.icon}
           testId={action.action + "-popover-button"}
-          onClick={isDisabled ? undefined : () => onAction(action)}
+          onClick={() => onAction(action)}
+          disabled={isDisabled}
           compact
           divider={false}
         >

--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
@@ -19,14 +19,15 @@ interface ActionItemProps<ActionType> {
 }
 
 const ActionItem = <ActionType,>({ action, onAction }: ActionItemProps<ActionType>) => {
+  const isDisabled = action.disabled === true;
   return (
     <>
-      <div className="px-4">
+      <div className="px-4" title={isDisabled ? action.disabledReason : undefined}>
         <Row
-          className="text-emphasis-300"
+          className={isDisabled ? "cursor-not-allowed text-emphasis-300 opacity-50" : "text-emphasis-300"}
           prefixIcon={action.icon}
           testId={action.action + "-popover-button"}
-          onClick={() => onAction(action)}
+          onClick={isDisabled ? undefined : () => onAction(action)}
           compact
           divider={false}
         >

--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/types.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/types.ts
@@ -11,6 +11,10 @@ export type BulkAction<ActionType> = {
   confirmation?: ActionWarnDialogOptions;
   /** Shows a thicker divider after this action to separate groups */
   showGroupDivider?: boolean;
+  /** When true the action renders as non-interactive in the popover and quick-action slots. */
+  disabled?: boolean;
+  /** Hover hint shown when `disabled` is true; surfaced via the native title attribute. */
+  disabledReason?: string;
 };
 
 export type ActionWarnDialogOptions = {

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
@@ -50,7 +50,7 @@ vi.mock("@/protoFleet/api/useDeviceSets", () => ({
 }));
 
 vi.mock("@/protoFleet/api/useAuthNeededMiners", () => ({
-  default: vi.fn(() => ({ totalMiners: 0, refetch: vi.fn() })),
+  default: vi.fn(() => ({ totalMiners: 0, refetch: vi.fn(), hasInitialLoadCompleted: true })),
 }));
 
 vi.mock("@/protoFleet/api/useDeviceErrors", () => ({

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
@@ -50,7 +50,7 @@ vi.mock("@/protoFleet/api/useDeviceSets", () => ({
 }));
 
 vi.mock("@/protoFleet/api/useAuthNeededMiners", () => ({
-  default: vi.fn(() => ({ totalMiners: 0 })),
+  default: vi.fn(() => ({ totalMiners: 0, refetch: vi.fn() })),
 }));
 
 vi.mock("@/protoFleet/api/useDeviceErrors", () => ({

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
@@ -50,7 +50,12 @@ vi.mock("@/protoFleet/api/useDeviceSets", () => ({
 }));
 
 vi.mock("@/protoFleet/api/useAuthNeededMiners", () => ({
-  default: vi.fn(() => ({ totalMiners: 0, refetch: vi.fn(), hasInitialLoadCompleted: true })),
+  default: vi.fn(() => ({
+    totalMiners: 0,
+    refetch: vi.fn(),
+    hasInitialLoadCompleted: true,
+    isLoading: false,
+  })),
 }));
 
 vi.mock("@/protoFleet/api/useDeviceErrors", () => ({

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -72,8 +72,14 @@ const Fleet = () => {
     } as const;
   }, [currentSortConfig]);
 
-  // Get count of miners requiring authentication (disabled rows)
-  const { totalMiners: totalAuthNeededMiners } = useAuthNeededMiners({ pageSize: 1, filter: currentFilter });
+  // Count of miners requiring authentication. Refetched in the polling loop
+  // below so the bulk-action gate releases promptly after a fleet-wide auth
+  // resolves (otherwise the count is stale-positive until the next manual
+  // refresh).
+  const { totalMiners: totalAuthNeededMiners, refetch: refetchAuthNeededMiners } = useAuthNeededMiners({
+    pageSize: 1,
+    filter: currentFilter,
+  });
   const { exportCsv, isExportingCsv } = useExportMinerListCsv({
     filter: currentFilter,
   });
@@ -133,9 +139,10 @@ const Fleet = () => {
     const intervalId = setInterval(() => {
       refreshCurrentPage();
       refetchErrors();
+      refetchAuthNeededMiners();
     }, POLL_INTERVAL_MS);
     return () => clearInterval(intervalId);
-  }, [hasInitialLoadCompleted, refreshCurrentPage, refetchErrors]);
+  }, [hasInitialLoadCompleted, refreshCurrentPage, refetchErrors, refetchAuthNeededMiners]);
 
   // Cleanup stale batch operations at the same interval as polling
   useEffect(() => {
@@ -173,7 +180,8 @@ const Fleet = () => {
   const refetchAll = useCallback(() => {
     refetch();
     refreshUnfilteredCount();
-  }, [refetch, refreshUnfilteredCount]);
+    refetchAuthNeededMiners();
+  }, [refetch, refreshUnfilteredCount, refetchAuthNeededMiners]);
 
   const [showAddMinersModal, setShowAddMinersModal] = useState(false);
 

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -76,7 +76,11 @@ const Fleet = () => {
   // below so the bulk-action gate releases promptly after a fleet-wide auth
   // resolves (otherwise the count is stale-positive until the next manual
   // refresh).
-  const { totalMiners: totalAuthNeededMiners, refetch: refetchAuthNeededMiners } = useAuthNeededMiners({
+  const {
+    totalMiners: totalAuthNeededMiners,
+    refetch: refetchAuthNeededMiners,
+    hasInitialLoadCompleted: totalAuthNeededMinersLoaded,
+  } = useAuthNeededMiners({
     pageSize: 1,
     filter: currentFilter,
   });
@@ -229,6 +233,7 @@ const Fleet = () => {
           totalMiners={totalMiners}
           totalUnfilteredMiners={totalUnfilteredMiners}
           totalDisabledMiners={totalAuthNeededMiners}
+          totalDisabledMinersLoaded={totalAuthNeededMinersLoaded}
           paddingLeft={{
             phone: "24px",
             tablet: "24px",

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -75,15 +75,19 @@ const Fleet = () => {
   // Count of miners requiring authentication. Refetched in the polling loop
   // below so the bulk-action gate releases promptly after a fleet-wide auth
   // resolves (otherwise the count is stale-positive until the next manual
-  // refresh).
+  // refresh). `hasInitialLoadCompleted` is sticky across refetches, so it
+  // alone can't tell us the count matches the current filter — combine with
+  // `isLoading` to gate while any refetch is in flight.
   const {
     totalMiners: totalAuthNeededMiners,
     refetch: refetchAuthNeededMiners,
-    hasInitialLoadCompleted: totalAuthNeededMinersLoaded,
+    hasInitialLoadCompleted: totalAuthNeededMinersInitialLoadCompleted,
+    isLoading: totalAuthNeededMinersLoading,
   } = useAuthNeededMiners({
     pageSize: 1,
     filter: currentFilter,
   });
+  const totalAuthNeededMinersFresh = totalAuthNeededMinersInitialLoadCompleted && !totalAuthNeededMinersLoading;
   const { exportCsv, isExportingCsv } = useExportMinerListCsv({
     filter: currentFilter,
   });
@@ -233,7 +237,7 @@ const Fleet = () => {
           totalMiners={totalMiners}
           totalUnfilteredMiners={totalUnfilteredMiners}
           totalDisabledMiners={totalAuthNeededMiners}
-          totalDisabledMinersLoaded={totalAuthNeededMinersLoaded}
+          totalDisabledMinersFresh={totalAuthNeededMinersFresh}
           paddingLeft={{
             phone: "24px",
             tablet: "24px",

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
@@ -1,8 +1,13 @@
 import { Fragment, type ReactNode } from "react";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
 import { deviceActions, groupActions, performanceActions, settingsActions } from "./constants";
 import MinerActionsMenu from "./MinerActionsMenu";
+import {
+  MinerStateSnapshotSchema,
+  PairingStatus,
+} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
 // Use vi.hoisted to properly hoist mock variable declarations
 const {
@@ -663,6 +668,138 @@ describe("MinerActionsMenu", () => {
       expect(latestBulkWorkerNameModalProps?.selectionMode).toBe("subset");
       expect(latestBulkWorkerNameModalProps?.originalSelectionMode).toBe("all");
       expect(latestBulkWorkerNameModalProps?.totalCount).toBe(1);
+    });
+  });
+
+  describe("when the selection includes a miner that needs authentication", () => {
+    const popoverActionsFixture = [
+      {
+        action: deviceActions.reboot,
+        title: "Reboot",
+        icon: null,
+        actionHandler: vi.fn(),
+        requiresConfirmation: true,
+      },
+      {
+        action: deviceActions.unpair,
+        title: "Unpair",
+        icon: null,
+        actionHandler: vi.fn(),
+        requiresConfirmation: true,
+      },
+      {
+        action: settingsActions.miningPool,
+        title: "Edit pool",
+        icon: null,
+        actionHandler: vi.fn(),
+        requiresConfirmation: false,
+      },
+    ];
+
+    const readActions = () => {
+      const widgetCalls = mockBulkActionsWidget.mock.calls as unknown as Array<
+        [{ actions: Array<{ action: string; disabled?: boolean; disabledReason?: string }> }]
+      >;
+      const lastCall = widgetCalls[widgetCalls.length - 1];
+      if (lastCall === undefined) {
+        throw new Error("BulkActionsWidget was not called with props");
+      }
+      return lastCall[0].actions;
+    };
+
+    test("falls back to the miners map and disables every non-unpair action", () => {
+      mockUseMinerActions.mockReturnValueOnce({
+        ...createMockMinerActionsReturn(null),
+        popoverActions: popoverActionsFixture,
+      });
+
+      render(
+        <MinerActionsMenu
+          selectedMiners={["miner-1", "miner-2"]}
+          selectionMode="subset"
+          totalCount={2}
+          miners={{
+            "miner-1": create(MinerStateSnapshotSchema, { pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }),
+            "miner-2": create(MinerStateSnapshotSchema, { pairingStatus: PairingStatus.PAIRED }),
+          }}
+        />,
+      );
+
+      const actions = readActions();
+      const unpair = actions.find((a) => a.action === deviceActions.unpair);
+      const reboot = actions.find((a) => a.action === deviceActions.reboot);
+      const editPool = actions.find((a) => a.action === settingsActions.miningPool);
+
+      expect(unpair?.disabled).not.toBe(true);
+      expect(reboot?.disabled).toBe(true);
+      expect(reboot?.disabledReason).toContain("authentication");
+      expect(editPool?.disabled).toBe(true);
+      expect(editPool?.disabledReason).toContain("authentication");
+    });
+
+    test("uses the parent override even when the miners map is empty (all-mode)", () => {
+      mockUseMinerActions.mockReturnValueOnce({
+        ...createMockMinerActionsReturn(null),
+        popoverActions: popoverActionsFixture,
+      });
+
+      render(
+        <MinerActionsMenu
+          selectedMiners={["miner-1"]}
+          selectionMode="all"
+          totalCount={5}
+          miners={{}}
+          selectionIncludesUnauthenticatedMiner
+        />,
+      );
+
+      const actions = readActions();
+      expect(actions.find((a) => a.action === deviceActions.unpair)?.disabled).not.toBe(true);
+      expect(actions.find((a) => a.action === deviceActions.reboot)?.disabled).toBe(true);
+      expect(actions.find((a) => a.action === settingsActions.miningPool)?.disabled).toBe(true);
+    });
+
+    test("leaves every action enabled when nothing in the selection needs authentication", () => {
+      mockUseMinerActions.mockReturnValueOnce({
+        ...createMockMinerActionsReturn(null),
+        popoverActions: popoverActionsFixture,
+      });
+
+      render(
+        <MinerActionsMenu
+          selectedMiners={["miner-1"]}
+          selectionMode="subset"
+          totalCount={1}
+          miners={{
+            "miner-1": create(MinerStateSnapshotSchema, { pairingStatus: PairingStatus.PAIRED }),
+          }}
+        />,
+      );
+
+      const actions = readActions();
+      expect(actions.every((a) => a.disabled !== true)).toBe(true);
+    });
+
+    test("disables the matching quick-action button on desktop", () => {
+      mockUseWindowDimensions.mockReturnValueOnce({ isPhone: false, isTablet: false });
+      mockUseMinerActions.mockReturnValueOnce({
+        ...createMockMinerActionsReturn(null),
+        popoverActions: popoverActionsFixture,
+      });
+
+      render(
+        <MinerActionsMenu
+          selectedMiners={["miner-1"]}
+          selectionMode="subset"
+          totalCount={1}
+          miners={{
+            "miner-1": create(MinerStateSnapshotSchema, { pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }),
+          }}
+        />,
+      );
+
+      const rebootButton = screen.getByTestId(`actions-menu-quick-action-${deviceActions.reboot}`);
+      expect(rebootButton).toBeDisabled();
     });
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -13,9 +13,10 @@ import ManagePowerModal from "./ManagePowerModal";
 import { ManageSecurityModal, UpdateMinerPasswordModal } from "./ManageSecurity";
 import { useMinerActions } from "./useMinerActions";
 import type { SortConfig } from "@/protoFleet/api/generated/common/v1/sort_pb";
-import type {
-  MinerListFilter,
-  MinerStateSnapshot,
+import {
+  type MinerListFilter,
+  type MinerStateSnapshot,
+  PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import AuthenticateFleetModal from "@/protoFleet/features/auth/components/AuthenticateFleetModal";
 import { useBatchActions } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
@@ -39,6 +40,14 @@ interface MinerActionsMenuProps {
   miners?: Record<string, MinerStateSnapshot>;
   /** Ordered list of miner device identifiers, forwarded to bulk rename modals. */
   minerIds?: string[];
+  /**
+   * Set when the selection includes one or more miners in `AUTHENTICATION_NEEDED`
+   * — including all-mode selections whose individual ids the parent does not pass
+   * down. When true, every action other than Unpair renders disabled with a
+   * tooltip explaining why. Falls back to a subset-only check derived from
+   * `selectedMiners` + `miners` when the parent omits the prop.
+   */
+  selectionIncludesUnauthenticatedMiner?: boolean;
   /** Callback to refetch miners after bulk rename or worker-name update. */
   onRefetchMiners?: () => void;
   onWorkerNameUpdated?: (deviceIdentifier: string, workerName: string) => void;
@@ -61,6 +70,7 @@ const MinerActionsMenu = ({
   currentSort,
   miners = {},
   minerIds = [],
+  selectionIncludesUnauthenticatedMiner: selectionIncludesUnauthenticatedMinerOverride,
   onRefetchMiners,
   onWorkerNameUpdated,
   onActionStart,
@@ -77,6 +87,15 @@ const MinerActionsMenu = ({
     () => selectedMiners.map((id) => ({ deviceIdentifier: id })),
     [selectedMiners],
   );
+  // Fallback when the parent omits the prop. Accurate for subset selections;
+  // for `selectionMode === "all"` the parent is the canonical source because the
+  // miners map only carries the currently-loaded page.
+  const selectedIdsIncludeUnauthenticatedMiner = useMemo(
+    () => selectedMiners.some((id) => miners[id]?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED),
+    [miners, selectedMiners],
+  );
+  const selectionIncludesUnauthenticatedMiner =
+    selectionIncludesUnauthenticatedMinerOverride ?? selectedIdsIncludeUnauthenticatedMiner;
 
   const {
     currentAction,
@@ -200,6 +219,19 @@ const MinerActionsMenu = ({
     return [...actions, renameAction];
   }, [handleBulkWorkerNamesOpen, onActionStart, popoverActions]);
 
+  const visibleActions = useMemo(() => {
+    if (!selectionIncludesUnauthenticatedMiner) return actionsWithBulkRename;
+    return actionsWithBulkRename.map((action) =>
+      action.action === deviceActions.unpair
+        ? action
+        : {
+            ...action,
+            disabled: true,
+            disabledReason: "Selection includes miners that need authentication.",
+          },
+    );
+  }, [actionsWithBulkRename, selectionIncludesUnauthenticatedMiner]);
+
   const poolMiners = useMemo(() => {
     if (poolFilteredDeviceIds) {
       return poolFilteredDeviceIds.map((id) => ({ deviceIdentifier: id }));
@@ -214,13 +246,13 @@ const MinerActionsMenu = ({
       deviceActions.reboot,
       performanceActions.managePower,
     ];
-    const actionMap = new Map(actionsWithBulkRename.map((action) => [action.action, action]));
+    const actionMap = new Map(visibleActions.map((action) => [action.action, action]));
 
     return quickActionOrder.flatMap((actionKey) => {
       const action = actionMap.get(actionKey);
       return action ? [action] : [];
     });
-  }, [actionsWithBulkRename]);
+  }, [visibleActions]);
 
   return (
     <PopoverProvider>
@@ -228,29 +260,38 @@ const MinerActionsMenu = ({
         <BulkActionsWidget<SupportedAction>
           buttonIconSuffix={<ChevronDown width={iconSizes.xSmall} />}
           buttonTitle={showQuickActions ? "More" : "Actions"}
-          actions={actionsWithBulkRename}
+          actions={visibleActions}
           onConfirmation={handleConfirmation}
           onCancel={handleCancel}
           currentAction={currentAction}
           renderQuickActions={(onAction) =>
             showQuickActions
-              ? quickActions.map((action) => (
-                  <Button
-                    key={action.action}
-                    className="bg-grayscale-white-10! text-grayscale-white-90!"
-                    size={sizes.compact}
-                    variant={variants.secondary}
-                    testId={`actions-menu-quick-action-${action.action}`}
-                    onClick={() => onAction(action)}
-                  >
-                    {action.title}
-                  </Button>
-                ))
+              ? quickActions.map((action) => {
+                  const isDisabled = action.disabled === true;
+                  return (
+                    <span
+                      key={action.action}
+                      title={isDisabled ? action.disabledReason : undefined}
+                      className="inline-flex"
+                    >
+                      <Button
+                        className="bg-grayscale-white-10! text-grayscale-white-90!"
+                        size={sizes.compact}
+                        variant={variants.secondary}
+                        testId={`actions-menu-quick-action-${action.action}`}
+                        disabled={isDisabled}
+                        onClick={() => onAction(action)}
+                      >
+                        {action.title}
+                      </Button>
+                    </span>
+                  );
+                })
               : null
           }
           renderPopover={(beforeEach) => (
             <BulkActionsPopover<SupportedAction>
-              actions={actionsWithBulkRename}
+              actions={visibleActions}
               beforeEach={beforeEach}
               testId="actions-menu-popover"
             />

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -41,11 +41,9 @@ interface MinerActionsMenuProps {
   /** Ordered list of miner device identifiers, forwarded to bulk rename modals. */
   minerIds?: string[];
   /**
-   * Set when the selection includes one or more miners in `AUTHENTICATION_NEEDED`
-   * — including all-mode selections whose individual ids the parent does not pass
-   * down. When true, every action other than Unpair renders disabled with a
-   * tooltip explaining why. Falls back to a subset-only check derived from
-   * `selectedMiners` + `miners` when the parent omits the prop.
+   * When true, every action other than Unpair renders disabled. The parent
+   * sets this for all-mode (the local miners map only carries the current page);
+   * falls back to a subset check from `selectedMiners` + `miners`.
    */
   selectionIncludesUnauthenticatedMiner?: boolean;
   /** Callback to refetch miners after bulk rename or worker-name update. */
@@ -87,9 +85,7 @@ const MinerActionsMenu = ({
     () => selectedMiners.map((id) => ({ deviceIdentifier: id })),
     [selectedMiners],
   );
-  // Fallback when the parent omits the prop. Accurate for subset selections;
-  // for `selectionMode === "all"` the parent is the canonical source because the
-  // miners map only carries the currently-loaded page.
+  // Subset-mode fallback when the parent omits the prop.
   const selectedIdsIncludeUnauthenticatedMiner = useMemo(
     () => selectedMiners.some((id) => miners[id]?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED),
     [miners, selectedMiners],

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
@@ -1082,7 +1082,7 @@ describe("MinerList", () => {
       expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("false");
     });
 
-    it("flags all-mode selections as auth-needed while the fleet-wide count is still loading", async () => {
+    it("flags all-mode selections as auth-needed while the fleet-wide count is unsettled (loading or refetching)", async () => {
       const user = userEvent.setup();
 
       renderMinerList({
@@ -1094,7 +1094,7 @@ describe("MinerList", () => {
         },
         totalMiners: 2,
         totalDisabledMiners: 0,
-        totalDisabledMinersLoaded: false,
+        totalDisabledMinersFresh: false,
         currentPage: 0,
         onAddMiners: vi.fn(),
         loading: false,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
@@ -22,12 +22,14 @@ const { mockMinerListActionBar } = vi.hoisted(() => ({
       selectedMiners,
       selectionMode,
       totalCount,
+      selectionIncludesUnauthenticatedMiner,
       onSelectAll,
       onSelectNone,
     }: {
       selectedMiners: string[];
       selectionMode: string;
       totalCount?: number;
+      selectionIncludesUnauthenticatedMiner?: boolean;
       onSelectAll?: () => void;
       onSelectNone?: () => void;
     }) => {
@@ -41,6 +43,9 @@ const { mockMinerListActionBar } = vi.hoisted(() => ({
           <span data-testid="mock-miner-list-selected-miners">{selectedMiners.join(",")}</span>
           <span data-testid="mock-miner-list-selection-count">
             {selectionMode === "all" ? (totalCount ?? selectedMiners.length) : selectedMiners.length}
+          </span>
+          <span data-testid="mock-miner-list-selection-includes-unauth">
+            {String(Boolean(selectionIncludesUnauthenticatedMiner))}
           </span>
           {onSelectAll ? (
             <button type="button" data-testid="mock-action-bar-select-all" onClick={onSelectAll}>
@@ -1024,20 +1029,18 @@ describe("MinerList", () => {
       },
     );
 
-    it("recomputes selectable miners when a row becomes disabled between renders", async () => {
+    it("keeps authentication-needed miners selectable and flags the selection to the action bar", async () => {
       const user = userEvent.setup();
 
-      const initialMiners = {
-        m1: createMinerSnapshot("m1"),
-        m2: createMinerSnapshot("m2"),
-      };
-
-      const { rerender } = renderMinerList({
+      renderMinerList({
         title: "Miners",
         minerIds: ["m1", "m2"],
-        miners: initialMiners,
+        miners: {
+          m1: createMinerSnapshot("m1", PairingStatus.AUTHENTICATION_NEEDED),
+          m2: createMinerSnapshot("m2"),
+        },
         totalMiners: 2,
-        totalDisabledMiners: 0,
+        totalDisabledMiners: 1,
         currentPage: 0,
         onAddMiners: vi.fn(),
         loading: false,
@@ -1046,34 +1049,37 @@ describe("MinerList", () => {
       const rowCheckboxes = screen.getAllByTestId("checkbox");
       await user.click(rowCheckboxes[0].querySelector("input[type='checkbox']") as HTMLInputElement);
 
-      const updatedMiners = {
-        ...initialMiners,
-        m2: createMinerSnapshot("m2", PairingStatus.AUTHENTICATION_NEEDED),
-      };
-
-      await act(async () => {
-        rerender(
-          <BrowserRouter>
-            <MinerList
-              title="Miners"
-              minerIds={["m1", "m2"]}
-              miners={updatedMiners}
-              errorsByDevice={{}}
-              errorsLoaded={true}
-              getActiveBatches={mockGetActiveBatches}
-              totalMiners={2}
-              totalDisabledMiners={0}
-              currentPage={0}
-              onAddMiners={vi.fn()}
-              loading={false}
-            />
-          </BrowserRouter>,
-        );
-      });
+      expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m1");
+      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("true");
 
       await user.click(screen.getByTestId("mock-action-bar-select-all"));
 
+      expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m1,m2");
+      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("true");
+    });
+
+    it("does not flag the selection as auth-needed when no selected miner needs authentication", async () => {
+      const user = userEvent.setup();
+
+      renderMinerList({
+        title: "Miners",
+        minerIds: ["m1", "m2"],
+        miners: {
+          m1: createMinerSnapshot("m1"),
+          m2: createMinerSnapshot("m2", PairingStatus.AUTHENTICATION_NEEDED),
+        },
+        totalMiners: 2,
+        totalDisabledMiners: 1,
+        currentPage: 0,
+        onAddMiners: vi.fn(),
+        loading: false,
+      });
+
+      const rowCheckboxes = screen.getAllByTestId("checkbox");
+      await user.click(rowCheckboxes[0].querySelector("input[type='checkbox']") as HTMLInputElement);
+
       expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m1");
+      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("false");
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
@@ -1081,6 +1081,32 @@ describe("MinerList", () => {
       expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m1");
       expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("false");
     });
+
+    it("flags all-mode selections as auth-needed while the fleet-wide count is still loading", async () => {
+      const user = userEvent.setup();
+
+      renderMinerList({
+        title: "Miners",
+        minerIds: ["m1", "m2"],
+        miners: {
+          m1: createMinerSnapshot("m1"),
+          m2: createMinerSnapshot("m2"),
+        },
+        totalMiners: 2,
+        totalDisabledMiners: 0,
+        totalDisabledMinersLoaded: false,
+        currentPage: 0,
+        onAddMiners: vi.fn(),
+        loading: false,
+      });
+
+      const rowCheckboxes = screen.getAllByTestId("checkbox");
+      await user.click(rowCheckboxes[0].querySelector("input[type='checkbox']") as HTMLInputElement);
+      await user.click(screen.getByTestId("mock-action-bar-select-all"));
+
+      expect(screen.getByTestId("mock-miner-list-selection-mode")).toHaveTextContent("all");
+      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("true");
+    });
   });
 
   describe("row click navigation", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -189,9 +189,7 @@ type MinerListProps = {
   onPairingCompleted?: () => void;
 };
 
-// Stable reference so the `List`'s memoized selectable-items helper doesn't
-// recompute every render. Every visible row participates in selection; visual
-// de-emphasis is governed separately by `isRowDisabled`.
+// Module-level so the `List`'s memoized helpers keep a stable identity.
 const ALL_ROWS_SELECTABLE = () => true;
 
 type ScopedMinerListBodyProps = {
@@ -286,8 +284,6 @@ const ScopedMinerListBody = ({
   }
   const sortableColumnsSet = useMemo(() => new Set(SORTABLE_COLUMNS), []);
 
-  // Every visible row is selectable so unauthenticated miners can be unpaired
-  // in bulk. Visual de-emphasis stays driven by `isRowDisabled` on the List.
   const currentPageSelectableMinerIds = deviceItems.map((item) => item.deviceIdentifier);
 
   const handleSelectAllMiners = useCallback(() => {
@@ -300,11 +296,8 @@ const ScopedMinerListBody = ({
     setSelectionMode("none");
   }, []);
 
-  // For the bulk-action menu's per-action disabled state. In subset mode we
-  // compute from the loaded miners; in all mode the page is incomplete so we
-  // fall back to the fleet-wide auth-needed count. The all-mode signal is
-  // stale-zero until `useAuthNeededMiners` resolves on first mount — see
-  // issue #286 follow-up.
+  // All-mode falls back to `totalDisabledMiners`, which is stale-zero until
+  // `useAuthNeededMiners` resolves on first mount — see #286 follow-up.
   const selectedIncludesUnauthenticatedMiner = useMemo(
     () =>
       selectionMode === "all"

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -189,6 +189,11 @@ type MinerListProps = {
   onPairingCompleted?: () => void;
 };
 
+// Stable reference so the `List`'s memoized selectable-items helper doesn't
+// recompute every render. Every visible row participates in selection; visual
+// de-emphasis is governed separately by `isRowDisabled`.
+const ALL_ROWS_SELECTABLE = () => true;
+
 type ScopedMinerListBodyProps = {
   /**
    * Selection-scope identifier — when this changes, internal selection state resets.
@@ -281,9 +286,9 @@ const ScopedMinerListBody = ({
   }
   const sortableColumnsSet = useMemo(() => new Set(SORTABLE_COLUMNS), []);
 
-  const currentPageSelectableMinerIds = deviceItems
-    .filter((item) => !isRowDisabled(item))
-    .map((item) => item.deviceIdentifier);
+  // Every visible row is selectable so unauthenticated miners can be unpaired
+  // in bulk. Visual de-emphasis stays driven by `isRowDisabled` on the List.
+  const currentPageSelectableMinerIds = deviceItems.map((item) => item.deviceIdentifier);
 
   const handleSelectAllMiners = useCallback(() => {
     setSelectedMinerIds(currentPageSelectableMinerIds);
@@ -294,6 +299,21 @@ const ScopedMinerListBody = ({
     setSelectedMinerIds([]);
     setSelectionMode("none");
   }, []);
+
+  // For the bulk-action menu's per-action disabled state. In subset mode we
+  // compute from the loaded miners; in all mode the page is incomplete so we
+  // fall back to the fleet-wide auth-needed count. The all-mode signal is
+  // stale-zero until `useAuthNeededMiners` resolves on first mount — see
+  // issue #286 follow-up.
+  const selectedIncludesUnauthenticatedMiner = useMemo(
+    () =>
+      selectionMode === "all"
+        ? totalDisabledMiners > 0
+        : selectedMinerIds.some((id) =>
+            deviceItems.some((item) => item.deviceIdentifier === id && isRowDisabled(item)),
+          ),
+    [deviceItems, isRowDisabled, selectedMinerIds, selectionMode, totalDisabledMiners],
+  );
 
   return (
     <>
@@ -346,6 +366,7 @@ const ScopedMinerListBody = ({
               currentSort={currentSortConfig}
               miners={minersProp}
               minerIds={minerIdsProp}
+              selectionIncludesUnauthenticatedMiner={selectedIncludesUnauthenticatedMiner}
               onRefetchMiners={onRefetchMiners}
               onWorkerNameUpdated={onWorkerNameUpdated}
             />
@@ -365,6 +386,7 @@ const ScopedMinerListBody = ({
         initialActiveFilters={initialActiveFilters}
         onSelectionModeChange={setSelectionMode}
         isRowDisabled={isRowDisabled}
+        isRowSelectable={ALL_ROWS_SELECTABLE}
         columnsExemptFromDisabledStyling={new Set([minerCols.name, minerCols.status, minerCols.issues])}
         sortableColumns={sortableColumnsSet}
         currentSort={currentSort}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -296,12 +296,13 @@ const ScopedMinerListBody = ({
     setSelectionMode("none");
   }, []);
 
-  // All-mode falls back to `totalDisabledMiners`, which is stale-zero until
-  // `useAuthNeededMiners` resolves on first mount — see #286 follow-up.
+  // All-mode ORs the fleet-wide auth-needed count with a page-local check so
+  // the gate trips as soon as the user can see an auth-needed row, even when
+  // `useAuthNeededMiners` hasn't yet populated `totalDisabledMiners`.
   const selectedIncludesUnauthenticatedMiner = useMemo(
     () =>
       selectionMode === "all"
-        ? totalDisabledMiners > 0
+        ? totalDisabledMiners > 0 || deviceItems.some(isRowDisabled)
         : selectedMinerIds.some((id) =>
             deviceItems.some((item) => item.deviceIdentifier === id && isRowDisabled(item)),
           ),
@@ -372,7 +373,9 @@ const ScopedMinerListBody = ({
         overflowContainer={false}
         applyColumnWidthsToCells
         total={totalMiners}
-        totalDisabled={totalDisabledMiners}
+        // Every row is selectable; `totalSelectable = totalMiners` so action-bar
+        // copy and confirmation counts cover both paired and auth-needed miners.
+        totalDisabled={0}
         hideTotal
         itemName={{ singular: "miner", plural: "miners" }}
         itemRef={itemRef}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -108,6 +108,14 @@ type MinerListProps = {
    */
   totalDisabledMiners?: number;
   /**
+   * Whether `totalDisabledMiners` reflects a settled response from the
+   * underlying auth-needed query. The all-mode bulk-action gate treats the
+   * count as unreliable until this is true and falls back to blocking the
+   * non-Unpair actions in the meantime (defaults to true so callers that
+   * never load the count keep the historical behavior).
+   */
+  totalDisabledMinersLoaded?: boolean;
+  /**
    * Optional callback to attach refs to list row elements.
    * Used for viewport visibility tracking.
    */
@@ -209,6 +217,7 @@ type ScopedMinerListBodyProps = {
   paddingLeft?: Partial<Record<Breakpoint, string>>;
   totalMiners?: number;
   totalDisabledMiners: number;
+  totalDisabledMinersLoaded: boolean;
   itemRef?: (itemKey: string, element: HTMLTableRowElement | null) => void;
   hasActiveFilters: boolean;
   onAddMiners: () => void;
@@ -247,6 +256,7 @@ const ScopedMinerListBody = ({
   paddingLeft,
   totalMiners,
   totalDisabledMiners,
+  totalDisabledMinersLoaded,
   itemRef,
   hasActiveFilters,
   onAddMiners,
@@ -296,17 +306,19 @@ const ScopedMinerListBody = ({
     setSelectionMode("none");
   }, []);
 
-  // All-mode ORs the fleet-wide auth-needed count with a page-local check so
-  // the gate trips as soon as the user can see an auth-needed row, even when
-  // `useAuthNeededMiners` hasn't yet populated `totalDisabledMiners`.
+  // All-mode fails safe: when the auth-needed count hasn't settled yet, treat
+  // the selection as if it includes one (off-page auth-needed miners are
+  // otherwise invisible to the gate). Once the count is loaded, OR the
+  // fleet-wide count with a page-local check so the gate trips on visible
+  // rows even if the count refresh hasn't caught up.
   const selectedIncludesUnauthenticatedMiner = useMemo(
     () =>
       selectionMode === "all"
-        ? totalDisabledMiners > 0 || deviceItems.some(isRowDisabled)
+        ? !totalDisabledMinersLoaded || totalDisabledMiners > 0 || deviceItems.some(isRowDisabled)
         : selectedMinerIds.some((id) =>
             deviceItems.some((item) => item.deviceIdentifier === id && isRowDisabled(item)),
           ),
-    [deviceItems, isRowDisabled, selectedMinerIds, selectionMode, totalDisabledMiners],
+    [deviceItems, isRowDisabled, selectedMinerIds, selectionMode, totalDisabledMiners, totalDisabledMinersLoaded],
   );
 
   return (
@@ -449,6 +461,7 @@ const MinerList = ({
   totalMiners,
   totalUnfilteredMiners,
   totalDisabledMiners = 0,
+  totalDisabledMinersLoaded = true,
   itemRef,
   loading = false,
   pageSize = MINERS_PAGE_SIZE,
@@ -1033,6 +1046,7 @@ const MinerList = ({
           paddingLeft={paddingLeft}
           totalMiners={totalMiners}
           totalDisabledMiners={totalDisabledMiners}
+          totalDisabledMinersLoaded={totalDisabledMinersLoaded}
           itemRef={itemRef}
           hasActiveFilters={hasActiveFilters}
           onAddMiners={onAddMiners}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -109,12 +109,14 @@ type MinerListProps = {
   totalDisabledMiners?: number;
   /**
    * Whether `totalDisabledMiners` reflects a settled response from the
-   * underlying auth-needed query. The all-mode bulk-action gate treats the
-   * count as unreliable until this is true and falls back to blocking the
-   * non-Unpair actions in the meantime (defaults to true so callers that
-   * never load the count keep the historical behavior).
+   * underlying auth-needed query for the *current* filter and sort — i.e.,
+   * the first request has completed AND there is no refetch in flight. The
+   * all-mode bulk-action gate treats the count as unreliable until this is
+   * true and falls back to blocking non-Unpair actions in the meantime.
+   * Defaults to true so callers that never load the count keep the historical
+   * behavior.
    */
-  totalDisabledMinersLoaded?: boolean;
+  totalDisabledMinersFresh?: boolean;
   /**
    * Optional callback to attach refs to list row elements.
    * Used for viewport visibility tracking.
@@ -217,7 +219,7 @@ type ScopedMinerListBodyProps = {
   paddingLeft?: Partial<Record<Breakpoint, string>>;
   totalMiners?: number;
   totalDisabledMiners: number;
-  totalDisabledMinersLoaded: boolean;
+  totalDisabledMinersFresh: boolean;
   itemRef?: (itemKey: string, element: HTMLTableRowElement | null) => void;
   hasActiveFilters: boolean;
   onAddMiners: () => void;
@@ -256,7 +258,7 @@ const ScopedMinerListBody = ({
   paddingLeft,
   totalMiners,
   totalDisabledMiners,
-  totalDisabledMinersLoaded,
+  totalDisabledMinersFresh,
   itemRef,
   hasActiveFilters,
   onAddMiners,
@@ -314,11 +316,11 @@ const ScopedMinerListBody = ({
   const selectedIncludesUnauthenticatedMiner = useMemo(
     () =>
       selectionMode === "all"
-        ? !totalDisabledMinersLoaded || totalDisabledMiners > 0 || deviceItems.some(isRowDisabled)
+        ? !totalDisabledMinersFresh || totalDisabledMiners > 0 || deviceItems.some(isRowDisabled)
         : selectedMinerIds.some((id) =>
             deviceItems.some((item) => item.deviceIdentifier === id && isRowDisabled(item)),
           ),
-    [deviceItems, isRowDisabled, selectedMinerIds, selectionMode, totalDisabledMiners, totalDisabledMinersLoaded],
+    [deviceItems, isRowDisabled, selectedMinerIds, selectionMode, totalDisabledMiners, totalDisabledMinersFresh],
   );
 
   return (
@@ -461,7 +463,7 @@ const MinerList = ({
   totalMiners,
   totalUnfilteredMiners,
   totalDisabledMiners = 0,
-  totalDisabledMinersLoaded = true,
+  totalDisabledMinersFresh = true,
   itemRef,
   loading = false,
   pageSize = MINERS_PAGE_SIZE,
@@ -1046,7 +1048,7 @@ const MinerList = ({
           paddingLeft={paddingLeft}
           totalMiners={totalMiners}
           totalDisabledMiners={totalDisabledMiners}
-          totalDisabledMinersLoaded={totalDisabledMinersLoaded}
+          totalDisabledMinersFresh={totalDisabledMinersFresh}
           itemRef={itemRef}
           hasActiveFilters={hasActiveFilters}
           onAddMiners={onAddMiners}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
@@ -21,6 +21,7 @@ interface MinerListActionBarProps {
   currentSort?: SortConfig;
   miners?: Record<string, MinerStateSnapshot>;
   minerIds?: string[];
+  selectionIncludesUnauthenticatedMiner?: boolean;
   onRefetchMiners?: () => void;
   onWorkerNameUpdated?: (deviceIdentifier: string, workerName: string) => void;
 }
@@ -36,6 +37,7 @@ const MinerListActionBar = ({
   currentSort,
   miners,
   minerIds,
+  selectionIncludesUnauthenticatedMiner,
   onRefetchMiners,
   onWorkerNameUpdated,
 }: MinerListActionBarProps) => {
@@ -100,6 +102,7 @@ const MinerListActionBar = ({
           currentSort={currentSort}
           miners={miners}
           minerIds={minerIds}
+          selectionIncludesUnauthenticatedMiner={selectionIncludesUnauthenticatedMiner}
           onRefetchMiners={onRefetchMiners}
           onWorkerNameUpdated={onWorkerNameUpdated}
           onActionStart={() => {

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -218,12 +218,22 @@ type ListProps<ListItem, ItemKeyValueType, ColKey extends string = keyof ListIte
    */
   isLoadingMore?: boolean;
   /**
-   * Optional callback to determine if a specific row should be disabled.
-   * Disabled rows are greyed out and cannot be selected.
+   * Optional callback to determine if a specific row should be visually disabled
+   * (greyed out). By default this also blocks selection; pass `isRowSelectable`
+   * to decouple visual de-emphasis from selectability.
    * @param item - The list item
-   * @returns true if the row should be disabled
+   * @returns true if the row should be visually disabled
    */
   isRowDisabled?: (item: ListItem) => boolean;
+  /**
+   * Optional callback to determine if a specific row may be selected.
+   * Defaults to `!isRowDisabled?.(item)` so existing callers keep the historical
+   * behavior. Provide this when a row should be visually disabled but still
+   * selectable (e.g. miners that need authentication but can still be unpaired).
+   * @param item - The list item
+   * @returns true if the row may be selected
+   */
+  isRowSelectable?: (item: ListItem) => boolean;
   /**
    * Optional set of column keys that should NOT be affected by disabled row styling.
    * These columns will maintain full opacity even when the row is disabled.
@@ -313,6 +323,7 @@ type ListRowRenderProps<ListItem, ItemKeyValueType, ColKey extends string = keyo
   activeCols: ColKey[];
   actions: ListAction<ListItem>[];
   rowDisabled: boolean;
+  rowSelectable: boolean;
   columnsExemptFromDisabledStyling?: Set<ColKey>;
   colConfig: ColConfig<ListItem, ItemKeyValueType, ColKey>;
   tdClassList: string;
@@ -356,6 +367,7 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
   activeCols,
   actions,
   rowDisabled,
+  rowSelectable,
   columnsExemptFromDisabledStyling,
   colConfig,
   tdClassList,
@@ -452,17 +464,17 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
                 value={String(rowKey)}
                 selected={currentSelectedItems.includes(rowKey)}
                 onChange={(e) => handleSelectItem(rowKey, e.target.checked, index, e)}
-                disabled={rowDisabled}
+                disabled={!rowSelectable}
               />
             ) : (
               <Checkbox
                 checked={
                   pageScopedSelection && currentSelectionMode === "all"
-                    ? !rowDisabled
+                    ? rowSelectable
                     : currentSelectedItems.includes(rowKey)
                 }
                 onChange={(e) => handleSelectItem(rowKey, e.target.checked, index, e)}
-                disabled={rowDisabled}
+                disabled={!rowSelectable}
               />
             )}
           </div>
@@ -694,6 +706,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   hasMore = false,
   isLoadingMore = false,
   isRowDisabled,
+  isRowSelectable,
   columnsExemptFromDisabledStyling,
   sortableColumns,
   currentSort,
@@ -737,13 +750,16 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
     }),
   );
 
-  // Helper to get selectable items (excludes disabled rows)
+  // Helper to get selectable items. Prefers `isRowSelectable` when provided so
+  // a row can be visually disabled (greyed) but still selectable. Falls back to
+  // `!isRowDisabled(item)` for callers that have not opted into the split.
   const getSelectableItems = useCallback(
     (itemList: ListItem[]) => {
+      if (isRowSelectable) return itemList.filter(isRowSelectable);
       if (!isRowDisabled) return itemList;
       return itemList.filter((item) => !isRowDisabled(item));
     },
-    [isRowDisabled],
+    [isRowDisabled, isRowSelectable],
   );
 
   // Calculate total selectable count (total - disabled)
@@ -1173,6 +1189,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
       activeCols,
       actions,
       rowDisabled: isRowDisabled?.(item) ?? false,
+      rowSelectable: isRowSelectable ? isRowSelectable(item) : !(isRowDisabled?.(item) ?? false),
       columnsExemptFromDisabledStyling,
       colConfig,
       tdClassList,

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -172,8 +172,12 @@ type ListProps<ListItem, ItemKeyValueType, ColKey extends string = keyof ListIte
   stickyBgColor?: string;
   total?: number;
   /**
-   * Total number of disabled items across all pages.
-   * Used with total to calculate selectable count: total - totalDisabled
+   * Total number of *non-selectable* items across all pages (drives
+   * `totalSelectable = total - totalDisabled`, used for action-bar copy and
+   * confirmation counts). When `isRowSelectable` is provided, this must
+   * count rows for which `isRowSelectable` returns false — not rows that
+   * are merely greyed via `isRowDisabled`. Pass 0 when every row is
+   * selectable regardless of disabled styling.
    */
   totalDisabled?: number;
   itemName?: {

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -218,20 +218,13 @@ type ListProps<ListItem, ItemKeyValueType, ColKey extends string = keyof ListIte
    */
   isLoadingMore?: boolean;
   /**
-   * Optional callback to determine if a specific row should be visually disabled
-   * (greyed out). By default this also blocks selection; pass `isRowSelectable`
-   * to decouple visual de-emphasis from selectability.
-   * @param item - The list item
-   * @returns true if the row should be visually disabled
+   * Greys out the row. Also blocks selection unless `isRowSelectable` is
+   * passed to opt into the split.
    */
   isRowDisabled?: (item: ListItem) => boolean;
   /**
-   * Optional callback to determine if a specific row may be selected.
-   * Defaults to `!isRowDisabled?.(item)` so existing callers keep the historical
-   * behavior. Provide this when a row should be visually disabled but still
-   * selectable (e.g. miners that need authentication but can still be unpaired).
-   * @param item - The list item
-   * @returns true if the row may be selected
+   * Whether the row may be selected. Defaults to `!isRowDisabled?.(item)`;
+   * provide explicitly to keep a greyed row checkable.
    */
   isRowSelectable?: (item: ListItem) => boolean;
   /**
@@ -750,9 +743,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
     }),
   );
 
-  // Helper to get selectable items. Prefers `isRowSelectable` when provided so
-  // a row can be visually disabled (greyed) but still selectable. Falls back to
-  // `!isRowDisabled(item)` for callers that have not opted into the split.
+  // Prefers `isRowSelectable`; falls back to `!isRowDisabled(item)` for back-compat.
   const getSelectableItems = useCallback(
     (itemList: ListItem[]) => {
       if (isRowSelectable) return itemList.filter(isRowSelectable);

--- a/client/src/shared/components/Row/Row.tsx
+++ b/client/src/shared/components/Row/Row.tsx
@@ -9,6 +9,13 @@ interface RowProps {
   className?: string;
   divider?: boolean;
   onClick?: () => void;
+  /**
+   * When true, the row's interactive element renders with the native `disabled`
+   * attribute (suppressing `onClick`) and an `aria-disabled` hint for assistive
+   * tech. Implies a `<button>` element so screen readers still announce a
+   * disabled action rather than a generic container.
+   */
+  disabled?: boolean;
   prefixIcon?: ReactNode;
   suffixIcon?: ReactNode;
   testId?: string;
@@ -23,22 +30,29 @@ const Row = ({
   className,
   divider = true,
   onClick,
+  disabled,
   prefixIcon,
   suffixIcon,
   testId,
   attributes,
 }: RowProps) => {
-  const Element = onClick ? "button" : "div";
+  const isInteractive = Boolean(onClick) || disabled === true;
+  const Element = isInteractive ? "button" : "div";
   return (
     <div {...attributes} className={clsx("w-full")}>
       <Element
         className={clsx("peer", {
           "flex items-center gap-4": suffixIcon || prefixIcon,
-          "-ml-3 w-[calc(100%+24px)] rounded-lg px-3 hover:bg-core-primary-5": onClick,
+          "-ml-3 w-[calc(100%+24px)] rounded-lg px-3": isInteractive,
+          "hover:bg-core-primary-5": isInteractive && !disabled,
         })}
-        onClick={onClick}
+        onClick={disabled ? undefined : onClick}
         data-testid={testId}
-        {...(Element === "button" && { type: "button" })}
+        {...(Element === "button" && {
+          type: "button",
+          disabled: disabled === true,
+          "aria-disabled": disabled === true,
+        })}
       >
         {prefixIcon ? <div>{prefixIcon}</div> : null}
         <div


### PR DESCRIPTION
## Summary

Resolves the #286 regression where AUTHENTICATION_NEEDED miners could not be unpaired because the row checkbox was disabled. Supersedes #290 with a redesign that keeps the row selectable, preserves the visual de-emphasis, and uses per-action `disabled` instead of filtering the action list — matching what the issue reporter expected ("nearly all of the control buttons should be disabled").

## What changed

- Shared `List` gains an optional `isRowSelectable` prop. Default falls back to `!isRowDisabled?.(item)` so every other consumer is untouched. The new prop drives the checkbox `disabled` attribute and the selectable-set filter; `isRowDisabled` keeps driving visual `opacity-50` and the row-level context-menu disabled state.
- `BulkAction` gains optional `disabled` and `disabledReason` fields. `BulkActionsPopover` renders disabled rows as non-interactive (`opacity-50`, `cursor-not-allowed`, no `onClick`) and surfaces the reason via the native `title` attribute. Quick-action buttons in `MinerActionsMenu` wrap in `<span title=…>` for the same hover hint.
- `MinerList` keeps `isRowDisabled` as the auth-needed predicate (so visual styling is restored) and additionally passes a stable `ALL_ROWS_SELECTABLE` constant via the new `isRowSelectable` prop. `totalDisabled={totalDisabledMiners}` is restored so confirmation-dialog counts stay accurate.
- `MinerActionsMenu` receives a `selectionIncludesUnauthenticatedMiner` boolean (computed once by `MinerList` and threaded through `MinerListActionBar`). When true, every action other than Unpair is mapped to `disabled: true` with the reason "Selection includes miners that need authentication." Falls back to a subset-mode-only check from `selectedMiners` + `miners` when used without the parent wiring.

## Follow-up

The all-mode gate still uses `totalDisabledMiners > 0`. That count is fed by a separate `useAuthNeededMiners` query that is not refreshed by the 60s fleet poll. If the count is stale-zero (initial mount before the query resolves, or auth-needed miners appear via a later poll), Select-All will not gate non-Unpair actions until the next refresh. A follow-up should either OR with a page-local `deviceItems.some(isRowDisabled)` check or fold the auth-needed query into the polling loop. Flagged inline at MinerList.tsx where `selectedIncludesUnauthenticatedMiner` is computed.

## Test plan

- An AUTHENTICATION_NEEDED row renders greyed out on every column except name/status/issues.
- The row's checkbox is enabled and clickable.
- Selecting an AUTHENTICATION_NEEDED row in subset mode shows the action bar with Unpair enabled and every other action disabled, with the "Selection includes miners that need authentication." tooltip on hover.
- Bulk Unpair on a mixed selection succeeds for both auth-needed and paired miners.
- Confirmation dialog counts ("Reboot N miners?") match the number of selectable miners.
- A selection of only paired miners leaves every action enabled (regression check for the rest of the menu).

Closes #286.