### PR TITLE
Remove single-option curtailment modal dropdowns

### DIFF
--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -120,22 +120,6 @@ function getMaintenanceCheckbox(): HTMLInputElement {
   return checkbox;
 }
 
-function mockVisibleSelectLayout(): () => void {
-  const getBoundingClientRectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
-    x: 16,
-    y: 16,
-    width: 320,
-    height: 56,
-    top: 16,
-    right: 336,
-    bottom: 72,
-    left: 16,
-    toJSON: () => ({}),
-  } as DOMRect);
-
-  return () => getBoundingClientRectSpy.mockRestore();
-}
-
 describe("CurtailmentStartModal", () => {
   beforeEach(() => {
     mockUseCurtailmentPlanPreview.mockReturnValue({
@@ -151,10 +135,12 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByRole("dialog", { name: "Plan a curtailment" })).toBeInTheDocument();
     expect(screen.getAllByText("Configure your curtailment to see a preview.")).toHaveLength(2);
     expect(screen.getByText("Response profile")).toBeInTheDocument();
-    expect(screen.getByText("Custom plan")).toBeInTheDocument();
     expect(screen.getByText("Curtail behavior")).toBeInTheDocument();
-    expect(screen.getByText("Fixed kW reduction")).toBeInTheDocument();
-    expect(screen.getByText("Least efficient first")).toBeInTheDocument();
+    expect(screen.getByText("Fleet will automatically curtail the least efficient miners first.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Fixed target reduction (kW)")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Profile" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Curtailment mode" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Miner selection strategy" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Min duration (sec)")).toBeInTheDocument();
     expect(screen.getByLabelText("Max duration (sec)")).toBeInTheDocument();
     expect(screen.queryByText("Safety")).not.toBeInTheDocument();
@@ -179,7 +165,7 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByRole("dialog", { name: "Manage curtailment" })).toBeInTheDocument();
     expect(screen.queryByRole("dialog", { name: "Plan a curtailment" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Start curtailment" })).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Target reduction")).toHaveValue(40);
+    expect(screen.getByLabelText("Fixed target reduction (kW)")).toHaveValue(40);
     expect(screen.getByLabelText("Reason")).toHaveValue("Grid peak - ERCOT 4CP signal");
 
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -273,7 +259,7 @@ describe("CurtailmentStartModal", () => {
     const { rerender } = renderModal({ initialValues: configuredValues, preview });
 
     expect(screen.getAllByText("Curtail 18 miners across the fleet immediately")).toHaveLength(2);
-    expect(screen.getAllByText("Target reduction")).toHaveLength(3);
+    expect(screen.getAllByText("Target reduction")).toHaveLength(2);
     expect(screen.getAllByText("45.0 kW of 40.0 kW")).toHaveLength(2);
     expect(screen.queryByText("Estimated time to restore ~2 minutes")).not.toBeInTheDocument();
 
@@ -336,7 +322,7 @@ describe("CurtailmentStartModal", () => {
   it("submits the current form values without dismissing the modal", async () => {
     const user = userEvent.setup();
     const { onDismiss, onSubmit } = renderModal();
-    const targetInput = screen.getByLabelText("Target reduction");
+    const targetInput = screen.getByLabelText("Fixed target reduction (kW)");
     const minDurationInput = screen.getByLabelText("Min duration (sec)");
     const maxDurationInput = screen.getByLabelText("Max duration (sec)");
     const restoreBatchSizeInput = screen.getByLabelText("Batch size (miners)");
@@ -373,32 +359,16 @@ describe("CurtailmentStartModal", () => {
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
-  it("only exposes curtailment options supported by the current API", async () => {
+  it("submits default curtailment options without rendering single-option dropdowns", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({ initialValues: { ...configuredValues, includeMaintenance: false } });
     const startButton = screen.getByRole("button", { name: "Start curtailment" });
-    const restoreSelectLayoutMock = mockVisibleSelectLayout();
 
     expect(startButton).toBeEnabled();
-
-    try {
-      await user.click(screen.getByRole("button", { name: "Curtailment mode" }));
-      const fixedReductionOption = await screen.findByRole("option", { name: "Fixed kW reduction" });
-      expect(screen.queryByRole("option", { name: "Percentage reduction" })).not.toBeInTheDocument();
-      await user.click(fixedReductionOption);
-
-      await user.click(screen.getByRole("button", { name: "Miner selection strategy" }));
-      const leastEfficientOption = await screen.findByRole("option", { name: "Least efficient first" });
-      expect(screen.queryByRole("option", { name: "Round robin" })).not.toBeInTheDocument();
-      expect(screen.queryByRole("option", { name: "Oldest miners first" })).not.toBeInTheDocument();
-      expect(screen.queryByRole("option", { name: "Lowest hashrate first" })).not.toBeInTheDocument();
-      await user.click(leastEfficientOption);
-    } finally {
-      restoreSelectLayoutMock();
-    }
-
-    expect(screen.getByText("Fixed kW reduction")).toBeInTheDocument();
-    expect(screen.getByText("Least efficient first")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Profile" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Curtailment mode" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Miner selection strategy" })).not.toBeInTheDocument();
+    expect(screen.getByText("Fleet will automatically curtail the least efficient miners first.")).toBeInTheDocument();
     expect(startButton).toBeEnabled();
 
     await user.click(startButton);
@@ -528,7 +498,7 @@ describe("CurtailmentStartModal", () => {
       />,
     );
 
-    const targetInput = screen.getByLabelText("Target reduction");
+    const targetInput = screen.getByLabelText("Fixed target reduction (kW)");
     await user.clear(targetInput);
     await user.type(targetInput, "99");
     expect(targetInput).toHaveValue(99);
@@ -550,7 +520,7 @@ describe("CurtailmentStartModal", () => {
       />,
     );
 
-    const updatedTargetInput = screen.getByLabelText("Target reduction");
+    const updatedTargetInput = screen.getByLabelText("Fixed target reduction (kW)");
     expect(updatedTargetInput).toHaveValue(25);
     expect(screen.getByLabelText("Reason")).toHaveValue("Updated reason");
   });
@@ -575,7 +545,7 @@ describe("CurtailmentStartModal", () => {
   it("renders required start-field validation errors with accessible error state", () => {
     renderModal();
 
-    const targetInput = screen.getByLabelText("Target reduction");
+    const targetInput = screen.getByLabelText("Fixed target reduction (kW)");
     expect(targetInput).toHaveAttribute("aria-invalid", "true");
     expect(targetInput).toHaveAttribute("aria-describedby", "curtailment-target-kw-error");
     expect(screen.getByText("Enter a target reduction.")).toBeInTheDocument();

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -134,7 +134,8 @@ describe("CurtailmentStartModal", () => {
 
     expect(screen.getByRole("dialog", { name: "Plan a curtailment" })).toBeInTheDocument();
     expect(screen.getAllByText("Configure your curtailment to see a preview.")).toHaveLength(2);
-    expect(screen.getByText("Response profile")).toBeInTheDocument();
+    expect(screen.queryByText("Response profile")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Reason")).toBeInTheDocument();
     expect(screen.getByText("Curtail behavior")).toBeInTheDocument();
     expect(screen.getByText("Fleet will automatically curtail the least efficient miners first.")).toBeInTheDocument();
     expect(screen.getByLabelText("Fixed target reduction (kW)")).toBeInTheDocument();

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -228,7 +228,7 @@ function Field({ id, label, value, units, type = "number", error, onChange }: Fi
 function Section({ title, subtext, children }: SectionProps): ReactElement {
   return (
     <section className="grid gap-3">
-      <div className="grid gap-1">
+      <div className="grid">
         <div className="text-emphasis-300 text-text-primary">{title}</div>
         {subtext ? <div className="text-300 text-text-primary-70">{subtext}</div> : null}
       </div>
@@ -446,18 +446,14 @@ function CurtailmentStartModalContent({
         abovePanes={<div className="px-6 pb-6 laptop:hidden">{previewPane}</div>}
         primaryPane={
           <section className="flex flex-col gap-12 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
-            <Section title="Response profile">
-              <div className="grid gap-3">
-                <Field
-                  id="curtailment-reason"
-                  label="Reason"
-                  value={values.reason}
-                  type="text"
-                  error={effectiveErrors.reason}
-                  onChange={(value) => updateValue("reason", value)}
-                />
-              </div>
-            </Section>
+            <Field
+              id="curtailment-reason"
+              label="Reason"
+              value={values.reason}
+              type="text"
+              error={effectiveErrors.reason}
+              onChange={(value) => updateValue("reason", value)}
+            />
 
             <Section
               title="Curtail behavior"

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -20,7 +20,6 @@ import Checkbox from "@/shared/components/Checkbox";
 import Dialog, { DialogIcon } from "@/shared/components/Dialog";
 import Input from "@/shared/components/Input";
 import ProgressCircular from "@/shared/components/ProgressCircular";
-import Select, { type SelectOption, type SelectProps } from "@/shared/components/Select";
 
 export type CurtailmentPriority = "normal" | "emergency";
 export type CurtailmentScopeType = "wholeOrg" | "deviceSet" | "explicitMiners";
@@ -90,6 +89,7 @@ interface FieldProps {
 
 interface SectionProps {
   title: string;
+  subtext?: string;
   children: ReactNode;
 }
 
@@ -102,19 +102,6 @@ interface PreviewPaneProps {
   preview?: CurtailmentPlanPreview;
   previewError?: string;
   isPreviewLoading?: boolean;
-}
-
-interface TypedSelectOption<Value extends string> extends SelectOption {
-  value: Value;
-}
-
-interface TypedSelectProps<Value extends string> extends Pick<SelectProps, "className" | "disabled" | "testId"> {
-  id: string;
-  label: string;
-  value: Value;
-  options: Array<TypedSelectOption<Value>>;
-  error?: string;
-  onChange: (value: Value) => void;
 }
 
 type ParsedNumberField = { parsed?: number; error?: string };
@@ -137,18 +124,6 @@ const defaultValues: CurtailmentFormValues = {
   reason: "",
   includeMaintenance: true,
 };
-
-const responseProfileOptions: Array<TypedSelectOption<ResponseProfileId>> = [
-  { value: "customPlan", label: "Custom plan" },
-];
-
-const curtailmentModeOptions: Array<TypedSelectOption<CurtailmentMode>> = [
-  { value: "fixedKwReduction", label: "Fixed kW reduction" },
-];
-
-const minerSelectionStrategyOptions: Array<TypedSelectOption<MinerSelectionStrategy>> = [
-  { value: "leastEfficientFirst", label: "Least efficient first" },
-];
 
 function getInitialValues(initialValues?: Partial<CurtailmentFormValues>): CurtailmentFormValues {
   return {
@@ -246,51 +221,17 @@ function validateCurtailmentFormValues(values: CurtailmentFormValues): Curtailme
   return localErrors;
 }
 
-function isSelectOptionValue<Value extends string>(
-  options: Array<TypedSelectOption<Value>>,
-  value: string,
-): value is Value {
-  return options.some((option) => option.value === value);
-}
-
 function Field({ id, label, value, units, type = "number", error, onChange }: FieldProps): ReactElement {
   return <Input id={id} label={label} initValue={value} units={units} type={type} error={error} onChange={onChange} />;
 }
 
-function TypedSelect<Value extends string>({
-  id,
-  label,
-  value,
-  options,
-  error,
-  className,
-  disabled,
-  testId,
-  onChange,
-}: TypedSelectProps<Value>): ReactElement {
-  return (
-    <Select
-      id={id}
-      label={label}
-      value={value}
-      options={options}
-      error={error}
-      className={className}
-      disabled={disabled}
-      testId={testId}
-      onChange={(nextValue) => {
-        if (isSelectOptionValue(options, nextValue)) {
-          onChange(nextValue);
-        }
-      }}
-    />
-  );
-}
-
-function Section({ title, children }: SectionProps): ReactElement {
+function Section({ title, subtext, children }: SectionProps): ReactElement {
   return (
     <section className="grid gap-3">
-      <div className="text-emphasis-300 text-text-primary">{title}</div>
+      <div className="grid gap-1">
+        <div className="text-emphasis-300 text-text-primary">{title}</div>
+        {subtext ? <div className="text-300 text-text-primary-70">{subtext}</div> : null}
+      </div>
       {children}
     </section>
   );
@@ -507,14 +448,6 @@ function CurtailmentStartModalContent({
           <section className="flex flex-col gap-12 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
             <Section title="Response profile">
               <div className="grid gap-3">
-                <TypedSelect
-                  id="curtailment-response-profile"
-                  label="Profile"
-                  value={values.responseProfileId}
-                  options={responseProfileOptions}
-                  error={effectiveErrors.responseProfileId}
-                  onChange={(value) => updateValue("responseProfileId", value)}
-                />
                 <Field
                   id="curtailment-reason"
                   label="Reason"
@@ -526,33 +459,17 @@ function CurtailmentStartModalContent({
               </div>
             </Section>
 
-            <Section title="Curtail behavior">
+            <Section
+              title="Curtail behavior"
+              subtext="Fleet will automatically curtail the least efficient miners first."
+            >
               <div className="grid gap-3">
-                <div className="grid gap-3 tablet:grid-cols-2">
-                  <TypedSelect
-                    id="curtailment-mode"
-                    label="Curtailment mode"
-                    value={values.curtailmentMode}
-                    options={curtailmentModeOptions}
-                    error={effectiveErrors.curtailmentMode}
-                    onChange={(value) => updateValue("curtailmentMode", value)}
-                  />
-                  <Field
-                    id="curtailment-target-kw"
-                    label="Target reduction"
-                    value={values.targetKw}
-                    units="kW"
-                    error={effectiveErrors.targetKw}
-                    onChange={(value) => updateValue("targetKw", value)}
-                  />
-                </div>
-                <TypedSelect
-                  id="curtailment-miner-selection-strategy"
-                  label="Miner selection strategy"
-                  value={values.minerSelectionStrategy}
-                  options={minerSelectionStrategyOptions}
-                  error={effectiveErrors.minerSelectionStrategy}
-                  onChange={(value) => updateValue("minerSelectionStrategy", value)}
+                <Field
+                  id="curtailment-target-kw"
+                  label="Fixed target reduction (kW)"
+                  value={values.targetKw}
+                  error={effectiveErrors.targetKw}
+                  onChange={(value) => updateValue("targetKw", value)}
                 />
                 <div className="grid gap-3 tablet:grid-cols-2">
                   <Field


### PR DESCRIPTION
🤖 Created by Negar's AI agent.

## Summary
- Remove single-option curtailment modal dropdowns while keeping their default submit values.
- Rename the target input to clarify fixed-kW mode and add the least-efficient-miners behavior as helper text.

## Test plan
- [ ] Open the curtailment start modal.
- [ ] Confirm only Reason, Fixed target reduction (kW), duration, restore, and Apply to controls are shown.
- [ ] Confirm starting curtailment still submits with the default fixed-kW and least-efficient-first behavior.

<img width="1245" height="823" alt="image" src="https://github.com/user-attachments/assets/d3a5fb13-6a82-4d3a-8f1e-24464f96c8e1" />


Closes #313
