### PR TITLE
Fix user-facing copy: "set up" and "log in" phrasal verbs

### DIFF
--- a/client/e2eTests/protoFleet/spec/00-onboarding.spec.ts
+++ b/client/e2eTests/protoFleet/spec/00-onboarding.spec.ts
@@ -24,7 +24,7 @@ test.describe("Proto Fleet - Onboarding", () => {
     await commonSteps.loginAsAdmin();
 
     await test.step("Validate Home screen null state due to no miners added", async () => {
-      await homePage.validateTextIsVisible("Let's setup your fleet.");
+      await homePage.validateTextIsVisible("Let's set up your fleet.");
       await homePage.validateTextIsVisible("Add miners to your fleet to get started.");
       await homePage.validateButtonIsVisible("Get Started");
     });

--- a/client/src/protoFleet/features/onboarding/components/Miners/Miners.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/Miners.tsx
@@ -185,7 +185,7 @@ const Miners = ({
       {mode === "onboarding" ? (
         <NullState
           icon={<LogoAlt width="w-5" />}
-          title="Let's setup your fleet."
+          title="Let's set up your fleet."
           description="Add miners to your fleet to get started."
           action={
             <Button variant="primary" onClick={() => setShowModal(true)}>

--- a/client/src/protoFleet/store/hooks/useAuthentication.ts
+++ b/client/src/protoFleet/store/hooks/useAuthentication.ts
@@ -46,7 +46,7 @@ export const useCheckAuthentication = (shouldCheckAccess = true) => {
 
     if (!isSessionValid) {
       pushToast({
-        message: "Please login to continue.",
+        message: "Please log in to continue.",
         status: TOAST_STATUSES.error,
       });
       timeoutId = setTimeout(() => {


### PR DESCRIPTION
## Summary

Fix three user-facing English errors where noun forms were used as verbs.

- `client/src/protoFleet/features/onboarding/components/Miners/Miners.tsx` — onboarding empty-state heading: "Let's setup your fleet." → "Let's set up your fleet."
- `client/src/protoFleet/store/hooks/useAuthentication.ts` — session-expiry toast: "Please login to continue." → "Please log in to continue." (also brings this string in line with the existing `AuthenticateFleetModal` copy that already uses "Log in to …")
- `client/e2eTests/protoFleet/spec/00-onboarding.spec.ts` — mirror the updated UI string in the onboarding e2e assertion so the test still passes.

Copy-only change, no behavioral impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)