### PR TITLE
fleetnode: run with heartbeat + plugin scaffolding (stack 2/3)

### DIFF
--- a/server/cmd/fleetnode/README.md
+++ b/server/cmd/fleetnode/README.md
@@ -9,7 +9,7 @@
 | `fleetnode enroll`  | Register with a fleet server using a one-time enrollment code. Persists keys and `api_key`. See [enroll.go](enroll.go). |
 | `fleetnode status`  | Print local state (server URL, fleet_node_id, fingerprint, session expiry). See [status.go](status.go). |
 | `fleetnode refresh` | Renew the session token using the stored `api_key`. See [refresh.go](refresh.go). |
-| `fleetnode run`     | Long-running daemon: maintain session, post heartbeats, and (in the discovery PR) consume the control stream. See [run.go](run.go). |
+| `fleetnode run`     | Long-running daemon: heartbeat. See [run.go](run.go). |
 
 ## State directory and lock
 
@@ -23,6 +23,25 @@ The file holds `server_url`, `fleet_node_id`, `identity_fingerprint`, both keypa
 
 A `state.lock` file in the same directory serializes commands. Only one process may hold it at a time (`LOCK_EX | LOCK_NB`). The PID of the holder is written under the lock; if another invocation hits contention, the error includes that PID. To clear a stale lock, identify the owner with `ps -p <pid>`; remove the lock file only if the process is gone.
 
+## Plugins
+
+Discovery (added in the next stack PR) is plugin-driven. The agent loads every executable in `<exe-dir>/plugins` at startup (subprocess plugins over gRPC via `hashicorp/go-plugin`). If that directory is missing the agent runs in heartbeat-only mode; if it is present but loosens beyond owner-only write, the agent refuses to start (`plugins dir ... must not be group- or world-writable`).
+
+There is no `--plugins-dir` flag: the path is fixed relative to the binary so an installer always owns it. See [plugins_dir.go](plugins_dir.go) and [plugins_dir_unix.go](plugins_dir_unix.go).
+
+The repository's `just build-fleetnode` target stages a working layout at `server/.fleetnode/`:
+
+```
+server/.fleetnode/
+├── fleetnode
+├── nmap         (symlink to system nmap, if present)
+└── plugins/
+    ├── proto-plugin
+    ├── antminer-plugin
+    ├── virtual-plugin
+    └── asicrs-plugin
+```
+
 ## Build
 
 ```bash
@@ -30,7 +49,14 @@ just build-fleetnode               # produces server/.fleetnode/{fleetnode, nmap
 go build -o fleetnode ./server/cmd/fleetnode   # fast iteration
 ```
 
-The staged layout reserves a `plugins/` subdirectory and a `nmap` symlink for the discovery PR. The agent does not yet exec anything from those locations.
+## Run
+
+```bash
+fleetnode enroll --server-url=https://fleet.example.com
+fleetnode run     # long-running daemon; logs to stdout
+```
+
+Stop with `SIGINT`, `SIGTERM`, or `SIGHUP` (terminal close). On shutdown the agent closes any open streams and reaps plugin subprocesses. At startup it also reaps any orphan plugin processes left under `<exe-dir>/plugins/` by a previous crash — see [orphan_reaper.go](orphan_reaper.go).
 
 ## Enrollment flow
 
@@ -46,9 +72,19 @@ If anything is interrupted between Register and Complete, `fleetnode refresh` re
 - **Transport.** `ValidateServerURL` requires `https://` for non-loopback servers; `--allow-insecure-transport` permits `http://` for testing only. The HTTP/2 transport is scheme-aware: `https://` goes through a TLS-validating `http2.Transport`, `http://` goes through h2c. See [client.go](../../internal/fleetnodebootstrap/client.go).
 - **State file.** `state.yaml` is `0600` under a `0700` directory; the writer fsyncs the temp file, renames, then fsyncs the directory. Symlinks at the state dir leaf are refused.
 - **Lock contention.** PID is written under the lock so contention reports are actionable.
+- **Plugins.** The directory must be owned by root or the agent uid and not group- or world-writable; the agent refuses to load otherwise. Individual plugin files must be regular executables (no symlinks) with the same ownership + write-bit rules. The Windows build performs an existence-only check — production Windows installs must place the binary under an Administrator-only directory (e.g., `%ProgramFiles%\fleetnode\`).
 
 ## Development
 
 ```bash
+go test ./server/cmd/fleetnode -race -count=1
 go test ./server/internal/fleetnodebootstrap/... -race -count=1
 ```
+
+## Troubleshooting
+
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| `exec format error` from plugin | Plugins were built for a different OS/arch (often Linux ELF on macOS). | Re-run `just build-fleetnode` on the host that will execute the agent. |
+| `state lock held by PID N` | Another `fleetnode` process is holding the lock; or a stale lock file with a dead PID. | `ps -p N`. If dead, remove the lock file. |
+| `BeginAuth rejected` | Revoked `api_key`, identity_pubkey mismatch, expired challenge, or server clock drift. | Verify the `api_key` in the operator UI; re-enroll if revoked. Check clock skew. |

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
+	"github.com/block/proto-fleet/server/internal/domain/plugins"
+	"github.com/block/proto-fleet/server/internal/infrastructure/id"
+)
+
+type discoverer interface {
+	Probe(ctx context.Context, ipAddress, port string) (*pb.DiscoveredDeviceReport, error)
+	DefaultDiscoveryPorts(ctx context.Context) []string
+}
+
+type pluginDiscoverer struct {
+	multi *plugins.MultiTypeDiscoverer
+	svc   *plugins.Service
+}
+
+func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
+	// Manager.Shutdown waits the full grace period even when a plugin already
+	// exited, so keep it tight; a stuck plugin still gets killed.
+	manager := plugins.NewManager(&plugins.Config{
+		Enabled:                    true,
+		PluginsDir:                 pluginsDir,
+		MaxStartupTimeSeconds:      30,
+		ShutdownTimeoutSeconds:     10,
+		ShutdownGracePeriodSeconds: 2,
+		LogLevel:                   "info",
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := manager.LoadPlugins(ctx); err != nil {
+		return nil, func() {}, fmt.Errorf("load plugins: %w", err)
+	}
+	cleanup := func() { _ = manager.Shutdown(context.Background()) }
+	return &pluginDiscoverer{
+		multi: plugins.NewMultiTypeDiscoverer(manager),
+		svc:   plugins.NewService(manager),
+	}, cleanup, nil
+}
+
+func (p *pluginDiscoverer) Probe(ctx context.Context, ipAddress, port string) (*pb.DiscoveredDeviceReport, error) {
+	dev, err := p.multi.Discover(ctx, ipAddress, port)
+	if err != nil {
+		return nil, err
+	}
+	if dev == nil {
+		return nil, nil
+	}
+	return reportFromDiscovered(dev), nil
+}
+
+func (p *pluginDiscoverer) DefaultDiscoveryPorts(ctx context.Context) []string {
+	return p.svc.GetDefaultDiscoveryPorts(ctx)
+}
+
+// SDK drivers often leave DeviceIdentifier empty; the agent has no DB so it
+// synthesizes auto:* and lets the server reconcile by (fleet_node, ip, port).
+func reportFromDiscovered(dev *discoverymodels.DiscoveredDevice) *pb.DiscoveredDeviceReport {
+	deviceID := dev.GetDeviceIdentifier()
+	if deviceID == "" {
+		deviceID = synthesizeIdentifier(dev.GetMacAddress(), dev.GetSerialNumber())
+	}
+	return &pb.DiscoveredDeviceReport{
+		DeviceIdentifier: deviceID,
+		IpAddress:        dev.GetIpAddress(),
+		Port:             dev.GetPort(),
+		UrlScheme:        dev.GetUrlScheme(),
+		DriverName:       dev.GetDriverName(),
+		Model:            dev.GetModel(),
+		Manufacturer:     dev.GetManufacturer(),
+		FirmwareVersion:  dev.GetFirmwareVersion(),
+	}
+}
+
+func synthesizeIdentifier(mac, serial string) string {
+	if mac != "" {
+		return "mac:" + mac
+	}
+	if serial != "" {
+		return "serial:" + serial
+	}
+	return "auto:" + id.GenerateID()
+}

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -21,7 +21,7 @@ type pluginDiscoverer struct {
 	svc   *plugins.Service
 }
 
-func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
+func newPluginDiscoverer(parent context.Context, pluginsDir string) (*pluginDiscoverer, func(), error) {
 	// Manager.Shutdown waits the full grace period even when a plugin already
 	// exited, so keep it tight; a stuck plugin still gets killed.
 	manager := plugins.NewManager(&plugins.Config{
@@ -32,7 +32,7 @@ func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
 		ShutdownGracePeriodSeconds: 2,
 		LogLevel:                   "info",
 	})
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 60*time.Second)
 	defer cancel()
 	if err := manager.LoadPlugins(ctx); err != nil {
 		// Partial loads can leave plugin subprocesses running even when an
@@ -43,7 +43,13 @@ func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
 		shutdownCancel()
 		return nil, func() {}, fmt.Errorf("load plugins: %w", err)
 	}
-	cleanup := func() { _ = manager.Shutdown(context.Background()) }
+	// Shutdown runs after the parent ctx has typically been cancelled by a
+	// signal, so use a fresh background ctx bounded by the same 10s budget.
+	cleanup := func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		_ = manager.Shutdown(shutdownCtx)
+	}
 	return &pluginDiscoverer{
 		multi: plugins.NewMultiTypeDiscoverer(manager),
 		svc:   plugins.NewService(manager),

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -35,16 +35,15 @@ func newPluginDiscoverer(parent context.Context, pluginsDir string) (*pluginDisc
 	ctx, cancel := context.WithTimeout(parent, 60*time.Second)
 	defer cancel()
 	if err := manager.LoadPlugins(ctx); err != nil {
-		// Partial loads can leave plugin subprocesses running even when an
-		// aggregate error is returned; reap them before returning so the
-		// agent doesn't exit with orphans behind it.
+		// LoadPlugins can leave partial subprocesses on error; reap them so
+		// the agent doesn't exit with orphans behind it.
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		_ = manager.Shutdown(shutdownCtx)
 		shutdownCancel()
 		return nil, func() {}, fmt.Errorf("load plugins: %w", err)
 	}
-	// Shutdown runs after the parent ctx has typically been cancelled by a
-	// signal, so use a fresh background ctx bounded by the same 10s budget.
+	// Parent ctx is typically already cancelled by a signal when cleanup
+	// runs; use a fresh background ctx bounded by the same 10s budget.
 	cleanup := func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer shutdownCancel()

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -35,6 +35,12 @@ func newPluginDiscoverer(pluginsDir string) (*pluginDiscoverer, func(), error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	if err := manager.LoadPlugins(ctx); err != nil {
+		// Partial loads can leave plugin subprocesses running even when an
+		// aggregate error is returned; reap them before returning so the
+		// agent doesn't exit with orphans behind it.
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_ = manager.Shutdown(shutdownCtx)
+		shutdownCancel()
 		return nil, func() {}, fmt.Errorf("load plugins: %w", err)
 	}
 	cleanup := func() { _ = manager.Shutdown(context.Background()) }

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
+)
+
+type stubDiscoverer struct {
+	probes map[string]*pb.DiscoveredDeviceReport
+	ports  []string
+}
+
+func (s *stubDiscoverer) Probe(_ context.Context, ip, port string) (*pb.DiscoveredDeviceReport, error) {
+	if r, ok := s.probes[ip+"|"+port]; ok {
+		return r, nil
+	}
+	return nil, nil
+}
+
+func (s *stubDiscoverer) DefaultDiscoveryPorts(_ context.Context) []string {
+	if s.ports != nil {
+		return s.ports
+	}
+	return []string{"4028"}
+}
+
+func discardLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.DiscardHandler)
+}
+
+func mustMarshal(t *testing.T, m proto.Message) []byte {
+	t.Helper()
+	b, err := proto.Marshal(m)
+	require.NoError(t, err)
+	return b
+}
+
+func TestSynthesizeIdentifier(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		mac    string
+		serial string
+		prefix string
+	}{
+		{name: "mac wins", mac: "aa:bb:cc:dd:ee:ff", serial: "SN1", prefix: "mac:aa:bb:cc:dd:ee:ff"},
+		{name: "serial when no mac", serial: "SN1", prefix: "serial:SN1"},
+		{name: "auto when neither", prefix: "auto:"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			got := synthesizeIdentifier(tc.mac, tc.serial)
+
+			// Assert
+			if tc.name == "auto when neither" {
+				assert.True(t, len(got) > len(tc.prefix), "auto:* must include a non-empty id, got %q", got)
+				assert.Equal(t, tc.prefix, got[:len(tc.prefix)])
+				return
+			}
+			assert.Equal(t, tc.prefix, got)
+		})
+	}
+}
+
+func TestReportFromDiscovered_CopiesFieldsAndSynthesizesIdentifier(t *testing.T) {
+	// Arrange
+	dev := &discoverymodels.DiscoveredDevice{}
+	dev.MacAddress = "aa:bb:cc:dd:ee:ff"
+	dev.IpAddress = "10.0.0.5"
+	dev.Port = "4028"
+	dev.UrlScheme = "http"
+	dev.DriverName = "antminer"
+	dev.Model = "S19"
+	dev.Manufacturer = "Bitmain"
+	dev.FirmwareVersion = "v1"
+
+	// Act
+	got := reportFromDiscovered(dev)
+
+	// Assert
+	assert.Equal(t, "mac:aa:bb:cc:dd:ee:ff", got.GetDeviceIdentifier())
+	assert.Equal(t, "10.0.0.5", got.GetIpAddress())
+	assert.Equal(t, "4028", got.GetPort())
+	assert.Equal(t, "http", got.GetUrlScheme())
+	assert.Equal(t, "antminer", got.GetDriverName())
+	assert.Equal(t, "S19", got.GetModel())
+	assert.Equal(t, "Bitmain", got.GetManufacturer())
+	assert.Equal(t, "v1", got.GetFirmwareVersion())
+}

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -48,14 +48,15 @@ func TestSynthesizeIdentifier(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name   string
-		mac    string
-		serial string
-		prefix string
+		name       string
+		mac        string
+		serial     string
+		prefix     string
+		prefixOnly bool
 	}{
 		{name: "mac wins", mac: "aa:bb:cc:dd:ee:ff", serial: "SN1", prefix: "mac:aa:bb:cc:dd:ee:ff"},
 		{name: "serial when no mac", serial: "SN1", prefix: "serial:SN1"},
-		{name: "auto when neither", prefix: "auto:"},
+		{name: "auto when neither", prefix: "auto:", prefixOnly: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -65,7 +66,7 @@ func TestSynthesizeIdentifier(t *testing.T) {
 			got := synthesizeIdentifier(tc.mac, tc.serial)
 
 			// Assert
-			if tc.name == "auto when neither" {
+			if tc.prefixOnly {
 				assert.True(t, len(got) > len(tc.prefix), "auto:* must include a non-empty id, got %q", got)
 				assert.Equal(t, tc.prefix, got[:len(tc.prefix)])
 				return
@@ -73,6 +74,21 @@ func TestSynthesizeIdentifier(t *testing.T) {
 			assert.Equal(t, tc.prefix, got)
 		})
 	}
+}
+
+func TestReportFromDiscovered_PreservesExplicitDeviceIdentifier(t *testing.T) {
+	// Arrange
+	dev := &discoverymodels.DiscoveredDevice{}
+	dev.DeviceIdentifier = "drv-explicit-123"
+	dev.MacAddress = "aa:bb:cc:dd:ee:ff"
+	dev.IpAddress = "10.0.0.5"
+	dev.Port = "4028"
+
+	// Act
+	got := reportFromDiscovered(dev)
+
+	// Assert
+	assert.Equal(t, "drv-explicit-123", got.GetDeviceIdentifier(), "explicit DeviceIdentifier must pass through unchanged when set by the SDK driver")
 }
 
 func TestReportFromDiscovered_CopiesFieldsAndSynthesizesIdentifier(t *testing.T) {

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -14,22 +14,40 @@ import (
 	"time"
 )
 
-// reapOrphanedPlugins kills plugin-binary processes under pluginsDir whose
-// parent is no longer alive (true orphans). Runs before newPluginDiscoverer
-// and under the state lock, so any match left after the ppid filter is
-// leftover from a prior crash. Best-effort: a missing/broken ps never blocks
-// startup.
+// reapOrphanedPlugins kills plugin-binary processes whose argv0 matches an
+// installed plugin under pluginsDir and whose parent is no longer alive
+// (true orphans). Runs before newPluginDiscoverer and under the state lock,
+// so any match left after the ppid filter is leftover from a prior crash.
+// Best-effort: a missing/broken ps never blocks startup.
 //
 // pluginsDir must be the same string the loader passes to exec.Command so
-// argv0 in ps matches the prefix used here. resolvePluginsDir rejects a
-// symlinked dir at the leaf, but path components above can still be symlinks
-// -- using the unresolved path keeps loader and reaper aligned in either
-// case.
+// argv0 in ps matches the paths enumerated here. resolvePluginsDir rejects
+// a symlinked leaf, but path components above can still be symlinks --
+// using the unresolved path keeps loader and reaper aligned in either case.
+//
+// We match against os.ReadDir entries (the actual plugin filenames) rather
+// than splitting ps's space-joined argv on spaces; that way install paths
+// containing spaces ("/opt/Proto Fleet/plugins/...") match correctly.
 //
 // The ppid check matters when two agents share a binary/plugins layout but
 // hold different state locks (e.g. --state-dir variants). Without it, agent
 // B's startup would kill agent A's live plugin children.
 func reapOrphanedPlugins(ctx context.Context, pluginsDir string, logger *slog.Logger) {
+	entries, err := os.ReadDir(pluginsDir)
+	if err != nil {
+		logger.Debug("orphan reaper: read plugins dir failed; skipping", "plugins_dir", pluginsDir, "err", err)
+		return
+	}
+	allowed := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		allowed = append(allowed, filepath.Join(pluginsDir, e.Name()))
+	}
+	if len(allowed) == 0 {
+		return
+	}
 	psCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(psCtx, "ps", "-eo", "pid=,ppid=,command=").Output()
@@ -37,7 +55,7 @@ func reapOrphanedPlugins(ctx context.Context, pluginsDir string, logger *slog.Lo
 		logger.Debug("orphan reaper: ps failed; skipping", "err", err)
 		return
 	}
-	reapOrphans(string(out), pluginsDir, os.Getpid(), logger, syscall.Kill)
+	reapOrphans(string(out), allowed, os.Getpid(), logger, syscall.Kill)
 }
 
 type psEntry struct {
@@ -47,9 +65,11 @@ type psEntry struct {
 }
 
 // reapOrphans is split out for testability: callers inject the ps output,
-// the running self pid, and the kill function.
-func reapOrphans(psOutput, pluginsAbs string, selfPID int, logger *slog.Logger, killFn func(pid int, sig syscall.Signal) error) {
-	prefix := pluginsAbs + string(filepath.Separator)
+// the set of allowed plugin paths, the running self pid, and the kill
+// function. Matching against allowed paths sidesteps ps's space-joined argv
+// representation -- an entry matches when e.command is exactly an allowed
+// path, or an allowed path followed by a space (its first argument).
+func reapOrphans(psOutput string, allowed []string, selfPID int, logger *slog.Logger, killFn func(pid int, sig syscall.Signal) error) {
 	var entries []psEntry
 	alive := make(map[int]bool)
 	for _, line := range strings.Split(psOutput, "\n") {
@@ -72,22 +92,14 @@ func reapOrphans(psOutput, pluginsAbs string, selfPID int, logger *slog.Logger, 
 		if e.pid == selfPID {
 			continue
 		}
-		if !strings.HasPrefix(e.command, prefix) {
-			continue
+		matchedPath := ""
+		for _, path := range allowed {
+			if e.command == path || strings.HasPrefix(e.command, path+" ") {
+				matchedPath = path
+				break
+			}
 		}
-		// Only kill direct children of pluginsAbs so an operator process
-		// invoked from a subdirectory under the prefix isn't reaped. The
-		// argv0 re-check after space-truncation guards plugin paths that
-		// themselves contain spaces (e.g. "/opt/Proto Fleet/plugins/x"),
-		// where truncating at the first space slices into the prefix.
-		argv0 := e.command
-		if i := strings.IndexByte(argv0, ' '); i >= 0 {
-			argv0 = argv0[:i]
-		}
-		if !strings.HasPrefix(argv0, prefix) {
-			continue
-		}
-		if strings.ContainsRune(argv0[len(prefix):], filepath.Separator) {
+		if matchedPath == "" {
 			continue
 		}
 		// Skip if the parent is still alive and not init/launchd. A live
@@ -101,6 +113,6 @@ func reapOrphans(psOutput, pluginsAbs string, selfPID int, logger *slog.Logger, 
 			logger.Warn("orphan reaper: kill failed", "pid", e.pid, "command", e.command, "err", err)
 			continue
 		}
-		logger.Info("reaped stray plugin process", "pid", e.pid, "command", e.command)
+		logger.Info("reaped stray plugin process", "pid", e.pid, "plugin", matchedPath)
 	}
 }

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // reapOrphanedPlugins kills plugin-binary processes under pluginsDir whose
@@ -21,12 +23,15 @@ import (
 // The ppid check matters when two agents share a binary/plugins layout but
 // hold different state locks (e.g. --state-dir variants). Without it, agent
 // B's startup would kill agent A's live plugin children.
-func reapOrphanedPlugins(pluginsDir string, logger *slog.Logger) {
+func reapOrphanedPlugins(ctx context.Context, pluginsDir string, logger *slog.Logger) {
 	abs, err := filepath.EvalSymlinks(pluginsDir)
 	if err != nil {
+		logger.Debug("orphan reaper: resolve symlinks failed; skipping", "plugins_dir", pluginsDir, "err", err)
 		return
 	}
-	out, err := exec.Command("ps", "-eo", "pid=,ppid=,command=").Output()
+	psCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(psCtx, "ps", "-eo", "pid=,ppid=,command=").Output()
 	if err != nil {
 		logger.Debug("orphan reaper: ps failed; skipping", "err", err)
 		return
@@ -67,6 +72,15 @@ func reapOrphans(psOutput, pluginsAbs string, selfPID int, logger *slog.Logger, 
 			continue
 		}
 		if !strings.HasPrefix(e.command, prefix) {
+			continue
+		}
+		// Only kill direct children of pluginsAbs so an operator process
+		// invoked from a subdirectory under the prefix isn't reaped.
+		argv0 := e.command
+		if i := strings.IndexByte(argv0, ' '); i >= 0 {
+			argv0 = argv0[:i]
+		}
+		if strings.ContainsRune(argv0[len(prefix):], filepath.Separator) {
 			continue
 		}
 		// Skip if the parent is still alive and not init/launchd. A live

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -20,15 +20,16 @@ import (
 // leftover from a prior crash. Best-effort: a missing/broken ps never blocks
 // startup.
 //
+// pluginsDir must be the same string the loader passes to exec.Command so
+// argv0 in ps matches the prefix used here. resolvePluginsDir rejects a
+// symlinked dir at the leaf, but path components above can still be symlinks
+// -- using the unresolved path keeps loader and reaper aligned in either
+// case.
+//
 // The ppid check matters when two agents share a binary/plugins layout but
 // hold different state locks (e.g. --state-dir variants). Without it, agent
 // B's startup would kill agent A's live plugin children.
 func reapOrphanedPlugins(ctx context.Context, pluginsDir string, logger *slog.Logger) {
-	abs, err := filepath.EvalSymlinks(pluginsDir)
-	if err != nil {
-		logger.Debug("orphan reaper: resolve symlinks failed; skipping", "plugins_dir", pluginsDir, "err", err)
-		return
-	}
 	psCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(psCtx, "ps", "-eo", "pid=,ppid=,command=").Output()
@@ -36,7 +37,7 @@ func reapOrphanedPlugins(ctx context.Context, pluginsDir string, logger *slog.Lo
 		logger.Debug("orphan reaper: ps failed; skipping", "err", err)
 		return
 	}
-	reapOrphans(string(out), abs, os.Getpid(), logger, syscall.Kill)
+	reapOrphans(string(out), pluginsDir, os.Getpid(), logger, syscall.Kill)
 }
 
 type psEntry struct {
@@ -75,10 +76,16 @@ func reapOrphans(psOutput, pluginsAbs string, selfPID int, logger *slog.Logger, 
 			continue
 		}
 		// Only kill direct children of pluginsAbs so an operator process
-		// invoked from a subdirectory under the prefix isn't reaped.
+		// invoked from a subdirectory under the prefix isn't reaped. The
+		// argv0 re-check after space-truncation guards plugin paths that
+		// themselves contain spaces (e.g. "/opt/Proto Fleet/plugins/x"),
+		// where truncating at the first space slices into the prefix.
 		argv0 := e.command
 		if i := strings.IndexByte(argv0, ' '); i >= 0 {
 			argv0 = argv0[:i]
+		}
+		if !strings.HasPrefix(argv0, prefix) {
+			continue
 		}
 		if strings.ContainsRune(argv0[len(prefix):], filepath.Separator) {
 			continue

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package main
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// reapOrphanedPlugins kills any plugin-binary process under pluginsDir.
+// Runs before newPluginDiscoverer and under the state lock, so any match is
+// leftover from a prior crash; concurrent agents are already excluded by
+// state.lock contention. Best-effort: a missing/broken ps never blocks
+// startup.
+func reapOrphanedPlugins(pluginsDir string, logger *slog.Logger) {
+	abs, err := filepath.EvalSymlinks(pluginsDir)
+	if err != nil {
+		return
+	}
+	out, err := exec.Command("ps", "-eo", "pid=,ppid=,command=").Output()
+	if err != nil {
+		logger.Debug("orphan reaper: ps failed; skipping", "err", err)
+		return
+	}
+	selfPID := os.Getpid()
+	prefix := abs + string(filepath.Separator)
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		command := strings.Join(fields[2:], " ")
+		if !strings.HasPrefix(command, prefix) {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || pid == selfPID {
+			continue
+		}
+		if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+			logger.Warn("orphan reaper: kill failed", "pid", pid, "command", command, "err", err)
+			continue
+		}
+		logger.Info("reaped stray plugin process", "pid", pid, "command", command)
+	}
+}

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -14,24 +14,10 @@ import (
 	"time"
 )
 
-// reapOrphanedPlugins kills plugin-binary processes whose argv0 matches an
-// installed plugin under pluginsDir and whose parent is no longer alive
-// (true orphans). Runs before newPluginDiscoverer and under the state lock,
-// so any match left after the ppid filter is leftover from a prior crash.
-// Best-effort: a missing/broken ps never blocks startup.
-//
-// pluginsDir must be the same string the loader passes to exec.Command so
-// argv0 in ps matches the paths enumerated here. resolvePluginsDir rejects
-// a symlinked leaf, but path components above can still be symlinks --
-// using the unresolved path keeps loader and reaper aligned in either case.
-//
-// We match against os.ReadDir entries (the actual plugin filenames) rather
-// than splitting ps's space-joined argv on spaces; that way install paths
-// containing spaces ("/opt/Proto Fleet/plugins/...") match correctly.
-//
-// The ppid check matters when two agents share a binary/plugins layout but
-// hold different state locks (e.g. --state-dir variants). Without it, agent
-// B's startup would kill agent A's live plugin children.
+// Matching against os.ReadDir entries (rather than parsing ps argv) lets
+// plugin paths containing spaces resolve correctly. The ppid filter avoids
+// killing live plugins owned by another agent sharing the same pluginsDir
+// under a different --state-dir.
 func reapOrphanedPlugins(ctx context.Context, pluginsDir string, logger *slog.Logger) {
 	entries, err := os.ReadDir(pluginsDir)
 	if err != nil {
@@ -50,10 +36,7 @@ func reapOrphanedPlugins(ctx context.Context, pluginsDir string, logger *slog.Lo
 	}
 	psCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	// Hard-coded absolute path: /bin/ps is the canonical location on Linux
-	// (real binary or merge-usr symlink) and macOS, and dropping PATH
-	// resolution prevents a hostile $PATH from injecting a shim that runs
-	// as the daemon during startup.
+	// /bin/ps explicit so a hostile $PATH can't inject a shim during startup.
 	out, err := exec.CommandContext(psCtx, "/bin/ps", "-eo", "pid=,ppid=,command=").Output()
 	if err != nil {
 		logger.Debug("orphan reaper: ps failed; skipping", "err", err)
@@ -68,11 +51,8 @@ type psEntry struct {
 	command string
 }
 
-// reapOrphans is split out for testability: callers inject the ps output,
-// the set of allowed plugin paths, the running self pid, and the kill
-// function. Matching against allowed paths sidesteps ps's space-joined argv
-// representation -- an entry matches when e.command is exactly an allowed
-// path, or an allowed path followed by a space (its first argument).
+// Split from reapOrphanedPlugins so tests inject ps output and the kill
+// function directly instead of forking.
 func reapOrphans(psOutput string, allowed []string, selfPID int, logger *slog.Logger, killFn func(pid int, sig syscall.Signal) error) {
 	var entries []psEntry
 	alive := make(map[int]bool)
@@ -106,9 +86,7 @@ func reapOrphans(psOutput string, allowed []string, selfPID int, logger *slog.Lo
 		if matchedPath == "" {
 			continue
 		}
-		// Skip if the parent is still alive and not init/launchd. A live
-		// non-init parent means another agent (or a debugger) still owns
-		// this child.
+		// Live non-init parent = another agent (or debugger) still owns this child.
 		if e.ppid > 1 && alive[e.ppid] {
 			logger.Debug("orphan reaper: parent still alive; skipping", "pid", e.pid, "ppid", e.ppid)
 			continue

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -12,11 +12,15 @@ import (
 	"syscall"
 )
 
-// reapOrphanedPlugins kills any plugin-binary process under pluginsDir.
-// Runs before newPluginDiscoverer and under the state lock, so any match is
-// leftover from a prior crash; concurrent agents are already excluded by
-// state.lock contention. Best-effort: a missing/broken ps never blocks
+// reapOrphanedPlugins kills plugin-binary processes under pluginsDir whose
+// parent is no longer alive (true orphans). Runs before newPluginDiscoverer
+// and under the state lock, so any match left after the ppid filter is
+// leftover from a prior crash. Best-effort: a missing/broken ps never blocks
 // startup.
+//
+// The ppid check matters when two agents share a binary/plugins layout but
+// hold different state locks (e.g. --state-dir variants). Without it, agent
+// B's startup would kill agent A's live plugin children.
 func reapOrphanedPlugins(pluginsDir string, logger *slog.Logger) {
 	abs, err := filepath.EvalSymlinks(pluginsDir)
 	if err != nil {
@@ -27,25 +31,55 @@ func reapOrphanedPlugins(pluginsDir string, logger *slog.Logger) {
 		logger.Debug("orphan reaper: ps failed; skipping", "err", err)
 		return
 	}
-	selfPID := os.Getpid()
-	prefix := abs + string(filepath.Separator)
-	for _, line := range strings.Split(string(out), "\n") {
+	reapOrphans(string(out), abs, os.Getpid(), logger, syscall.Kill)
+}
+
+type psEntry struct {
+	pid     int
+	ppid    int
+	command string
+}
+
+// reapOrphans is split out for testability: callers inject the ps output,
+// the running self pid, and the kill function.
+func reapOrphans(psOutput, pluginsAbs string, selfPID int, logger *slog.Logger, killFn func(pid int, sig syscall.Signal) error) {
+	prefix := pluginsAbs + string(filepath.Separator)
+	var entries []psEntry
+	alive := make(map[int]bool)
+	for _, line := range strings.Split(psOutput, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 3 {
 			continue
 		}
-		command := strings.Join(fields[2:], " ")
-		if !strings.HasPrefix(command, prefix) {
-			continue
-		}
 		pid, err := strconv.Atoi(fields[0])
-		if err != nil || pid == selfPID {
+		if err != nil {
 			continue
 		}
-		if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
-			logger.Warn("orphan reaper: kill failed", "pid", pid, "command", command, "err", err)
+		ppid, err := strconv.Atoi(fields[1])
+		if err != nil {
 			continue
 		}
-		logger.Info("reaped stray plugin process", "pid", pid, "command", command)
+		alive[pid] = true
+		entries = append(entries, psEntry{pid: pid, ppid: ppid, command: strings.Join(fields[2:], " ")})
+	}
+	for _, e := range entries {
+		if e.pid == selfPID {
+			continue
+		}
+		if !strings.HasPrefix(e.command, prefix) {
+			continue
+		}
+		// Skip if the parent is still alive and not init/launchd. A live
+		// non-init parent means another agent (or a debugger) still owns
+		// this child.
+		if e.ppid > 1 && alive[e.ppid] {
+			logger.Debug("orphan reaper: parent still alive; skipping", "pid", e.pid, "ppid", e.ppid)
+			continue
+		}
+		if err := killFn(e.pid, syscall.SIGKILL); err != nil {
+			logger.Warn("orphan reaper: kill failed", "pid", e.pid, "command", e.command, "err", err)
+			continue
+		}
+		logger.Info("reaped stray plugin process", "pid", e.pid, "command", e.command)
 	}
 }

--- a/server/cmd/fleetnode/orphan_reaper.go
+++ b/server/cmd/fleetnode/orphan_reaper.go
@@ -50,7 +50,11 @@ func reapOrphanedPlugins(ctx context.Context, pluginsDir string, logger *slog.Lo
 	}
 	psCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(psCtx, "ps", "-eo", "pid=,ppid=,command=").Output()
+	// Hard-coded absolute path: /bin/ps is the canonical location on Linux
+	// (real binary or merge-usr symlink) and macOS, and dropping PATH
+	// resolution prevents a hostile $PATH from injecting a shim that runs
+	// as the daemon during startup.
+	out, err := exec.CommandContext(psCtx, "/bin/ps", "-eo", "pid=,ppid=,command=").Output()
 	if err != nil {
 		logger.Debug("orphan reaper: ps failed; skipping", "err", err)
 		return

--- a/server/cmd/fleetnode/orphan_reaper_test.go
+++ b/server/cmd/fleetnode/orphan_reaper_test.go
@@ -27,6 +27,11 @@ func TestReapOrphans_SkipsLivePluginsOfOtherAgents(t *testing.T) {
 		"999 1 /plugins/leftover-plugin",
 		"",
 	}, "\n")
+	allowed := []string{
+		"/plugins/proto-plugin",
+		"/plugins/antminer-plugin",
+		"/plugins/leftover-plugin",
+	}
 
 	var (
 		mu     sync.Mutex
@@ -40,7 +45,7 @@ func TestReapOrphans_SkipsLivePluginsOfOtherAgents(t *testing.T) {
 	}
 
 	// Act
-	reapOrphans(psOutput, "/plugins", 100, slog.New(slog.DiscardHandler), killFn)
+	reapOrphans(psOutput, allowed, 100, slog.New(slog.DiscardHandler), killFn)
 
 	// Assert
 	require.Len(t, killed, 1, "should reap only the ppid==1 orphan")
@@ -52,13 +57,14 @@ func TestReapOrphans_SkipsSelfPID(t *testing.T) {
 
 	// Arrange
 	psOutput := "100 1 /plugins/foo\n"
+	allowed := []string{"/plugins/foo"}
 	killFn := func(pid int, _ syscall.Signal) error {
 		t.Fatalf("kill called for self pid %d", pid)
 		return nil
 	}
 
 	// Act
-	reapOrphans(psOutput, "/plugins", 100, slog.New(slog.DiscardHandler), killFn)
+	reapOrphans(psOutput, allowed, 100, slog.New(slog.DiscardHandler), killFn)
 }
 
 func TestReapOrphans_KillsWhenParentExited(t *testing.T) {
@@ -67,6 +73,7 @@ func TestReapOrphans_KillsWhenParentExited(t *testing.T) {
 	// Arrange — child's ppid 777 is NOT in the alive set; kernel hasn't
 	// reparented yet, so reap it anyway.
 	psOutput := "500 777 /plugins/foo\n"
+	allowed := []string{"/plugins/foo"}
 	var killed []int
 	killFn := func(pid int, _ syscall.Signal) error {
 		killed = append(killed, pid)
@@ -74,7 +81,7 @@ func TestReapOrphans_KillsWhenParentExited(t *testing.T) {
 	}
 
 	// Act
-	reapOrphans(psOutput, "/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+	reapOrphans(psOutput, allowed, 1, slog.New(slog.DiscardHandler), killFn)
 
 	// Assert
 	require.Equal(t, []int{500}, killed)
@@ -95,13 +102,14 @@ func TestReapOrphans_EmptyPsOutput(t *testing.T) {
 			t.Parallel()
 
 			// Arrange
+			allowed := []string{"/plugins/foo"}
 			killFn := func(pid int, _ syscall.Signal) error {
 				t.Fatalf("kill must not be called for empty ps output (pid=%d)", pid)
 				return nil
 			}
 
 			// Act
-			reapOrphans(tc.out, "/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+			reapOrphans(tc.out, allowed, 1, slog.New(slog.DiscardHandler), killFn)
 		})
 	}
 }
@@ -117,6 +125,7 @@ func TestReapOrphans_ContinuesAfterKillFailure(t *testing.T) {
 		"501 1 /plugins/second",
 		"",
 	}, "\n")
+	allowed := []string{"/plugins/first", "/plugins/second"}
 	var killed []int
 	killFn := func(pid int, _ syscall.Signal) error {
 		killed = append(killed, pid)
@@ -127,22 +136,26 @@ func TestReapOrphans_ContinuesAfterKillFailure(t *testing.T) {
 	}
 
 	// Act
-	reapOrphans(psOutput, "/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+	reapOrphans(psOutput, allowed, 1, slog.New(slog.DiscardHandler), killFn)
 
 	// Assert
 	require.Equal(t, []int{500, 501}, killed, "reaper must attempt to kill every matching entry even when one fails")
 }
 
-func TestReapOrphans_SkipsSubdirectoryProcesses(t *testing.T) {
+func TestReapOrphans_SkipsUnknownProcessesUnderPluginsDir(t *testing.T) {
 	t.Parallel()
 
-	// Arrange — a process invoked from a subdirectory of the plugins dir
-	// must not be killed; only direct children of pluginsAbs are plugins.
+	// Arrange — a process whose command is under the plugins dir but does
+	// NOT match any allowed entry (e.g. a subdirectory invocation, or a
+	// plugin file that has since been removed) must not be killed. Only
+	// processes whose argv0 matches an installed plugin file are reaped.
 	psOutput := strings.Join([]string{
 		"500 1 /plugins/sub/foo",
-		"501 1 /plugins/direct-plugin",
+		"501 1 /plugins/removed-plugin",
+		"502 1 /plugins/direct-plugin",
 		"",
 	}, "\n")
+	allowed := []string{"/plugins/direct-plugin"}
 	var killed []int
 	killFn := func(pid int, _ syscall.Signal) error {
 		killed = append(killed, pid)
@@ -150,26 +163,30 @@ func TestReapOrphans_SkipsSubdirectoryProcesses(t *testing.T) {
 	}
 
 	// Act
-	reapOrphans(psOutput, "/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+	reapOrphans(psOutput, allowed, 1, slog.New(slog.DiscardHandler), killFn)
 
 	// Assert
-	require.Equal(t, []int{501}, killed)
+	require.Equal(t, []int{502}, killed)
 }
 
 func TestReapOrphans_PluginsPathWithSpaces(t *testing.T) {
 	t.Parallel()
 
-	// Arrange — plugin install path contains spaces. ps prints argv
-	// space-separated, so the earlier HasPrefix(e.command, prefix) passes
-	// while truncating argv0 at the first space slices into the prefix.
-	// The re-check after truncation must skip such entries instead of
-	// panicking. A genuine orphan whose argv0 has no embedded space (e.g.
-	// the plugin binary name has none after the dir) is still reaped.
+	// Arrange — plugin install path contains spaces. ps space-joins argv
+	// without quoting, so naive argv0 extraction by splitting on the first
+	// space would slice into the prefix. Matching against the exact
+	// installed-plugin paths sidesteps the parsing problem entirely:
+	// e.command must equal an allowed path, or start with an allowed path
+	// followed by a space (its first argument).
 	psOutput := strings.Join([]string{
-		"500 1 /opt/Proto Fleet/plugins/proto-plugin arg1",
+		"500 1 /opt/Proto Fleet/plugins/proto-plugin arg1 arg2",
 		"600 1 /opt/Proto Fleet/plugins/legit-plugin",
 		"",
 	}, "\n")
+	allowed := []string{
+		"/opt/Proto Fleet/plugins/proto-plugin",
+		"/opt/Proto Fleet/plugins/legit-plugin",
+	}
 	var killed []int
 	killFn := func(pid int, _ syscall.Signal) error {
 		killed = append(killed, pid)
@@ -177,11 +194,9 @@ func TestReapOrphans_PluginsPathWithSpaces(t *testing.T) {
 	}
 
 	// Act
-	reapOrphans(psOutput, "/opt/Proto Fleet/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+	reapOrphans(psOutput, allowed, 1, slog.New(slog.DiscardHandler), killFn)
 
-	// Assert — neither entry can be reaped because ps splits the path
-	// at the first space; the guard is correctness-of-no-panic, not a
-	// promise that space-containing install paths reap correctly. The
-	// recommended deployment is a no-space path.
-	require.Empty(t, killed, "reaper must not panic or kill on space-containing install paths")
+	// Assert — both genuine orphans are reaped even though their install
+	// path contains whitespace.
+	require.Equal(t, []int{500, 600}, killed, "space-containing install paths must still reap orphans by allowed-path matching")
 }

--- a/server/cmd/fleetnode/orphan_reaper_test.go
+++ b/server/cmd/fleetnode/orphan_reaper_test.go
@@ -155,3 +155,33 @@ func TestReapOrphans_SkipsSubdirectoryProcesses(t *testing.T) {
 	// Assert
 	require.Equal(t, []int{501}, killed)
 }
+
+func TestReapOrphans_PluginsPathWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — plugin install path contains spaces. ps prints argv
+	// space-separated, so the earlier HasPrefix(e.command, prefix) passes
+	// while truncating argv0 at the first space slices into the prefix.
+	// The re-check after truncation must skip such entries instead of
+	// panicking. A genuine orphan whose argv0 has no embedded space (e.g.
+	// the plugin binary name has none after the dir) is still reaped.
+	psOutput := strings.Join([]string{
+		"500 1 /opt/Proto Fleet/plugins/proto-plugin arg1",
+		"600 1 /opt/Proto Fleet/plugins/legit-plugin",
+		"",
+	}, "\n")
+	var killed []int
+	killFn := func(pid int, _ syscall.Signal) error {
+		killed = append(killed, pid)
+		return nil
+	}
+
+	// Act
+	reapOrphans(psOutput, "/opt/Proto Fleet/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+
+	// Assert — neither entry can be reaped because ps splits the path
+	// at the first space; the guard is correctness-of-no-panic, not a
+	// promise that space-containing install paths reap correctly. The
+	// recommended deployment is a no-space path.
+	require.Empty(t, killed, "reaper must not panic or kill on space-containing install paths")
+}

--- a/server/cmd/fleetnode/orphan_reaper_test.go
+++ b/server/cmd/fleetnode/orphan_reaper_test.go
@@ -1,0 +1,81 @@
+//go:build !windows
+
+package main
+
+import (
+	"log/slog"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReapOrphans_SkipsLivePluginsOfOtherAgents(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — two parent agents (pids 100 and 200), each owns a plugin
+	// under the same plugins dir. Pid 999 is a true orphan reparented to
+	// init.
+	psOutput := strings.Join([]string{
+		"100 1 fleetnode run",
+		"200 1 fleetnode run --state-dir /alt",
+		"500 100 /plugins/proto-plugin",
+		"600 200 /plugins/antminer-plugin",
+		"999 1 /plugins/leftover-plugin",
+		"",
+	}, "\n")
+
+	var (
+		mu     sync.Mutex
+		killed []int
+	)
+	killFn := func(pid int, _ syscall.Signal) error {
+		mu.Lock()
+		defer mu.Unlock()
+		killed = append(killed, pid)
+		return nil
+	}
+
+	// Act
+	reapOrphans(psOutput, "/plugins", 100, slog.New(slog.DiscardHandler), killFn)
+
+	// Assert
+	require.Len(t, killed, 1, "should reap only the ppid==1 orphan")
+	assert.Equal(t, 999, killed[0])
+}
+
+func TestReapOrphans_SkipsSelfPID(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	psOutput := "100 1 /plugins/foo\n"
+	killFn := func(pid int, _ syscall.Signal) error {
+		t.Fatalf("kill called for self pid %d", pid)
+		return nil
+	}
+
+	// Act
+	reapOrphans(psOutput, "/plugins", 100, slog.New(slog.DiscardHandler), killFn)
+}
+
+func TestReapOrphans_KillsWhenParentExited(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — child's ppid 777 is NOT in the alive set; kernel hasn't
+	// reparented yet, so reap it anyway.
+	psOutput := "500 777 /plugins/foo\n"
+	var killed []int
+	killFn := func(pid int, _ syscall.Signal) error {
+		killed = append(killed, pid)
+		return nil
+	}
+
+	// Act
+	reapOrphans(psOutput, "/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+
+	// Assert
+	require.Equal(t, []int{500}, killed)
+}

--- a/server/cmd/fleetnode/orphan_reaper_test.go
+++ b/server/cmd/fleetnode/orphan_reaper_test.go
@@ -79,3 +79,79 @@ func TestReapOrphans_KillsWhenParentExited(t *testing.T) {
 	// Assert
 	require.Equal(t, []int{500}, killed)
 }
+
+func TestReapOrphans_EmptyPsOutput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		out  string
+	}{
+		{name: "empty", out: ""},
+		{name: "blank lines", out: "\n\n\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			killFn := func(pid int, _ syscall.Signal) error {
+				t.Fatalf("kill must not be called for empty ps output (pid=%d)", pid)
+				return nil
+			}
+
+			// Act
+			reapOrphans(tc.out, "/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+		})
+	}
+}
+
+func TestReapOrphans_ContinuesAfterKillFailure(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — two orphans; the first kill returns an error. The second
+	// orphan still has to be reaped so a stuck kill on pid A doesn't block
+	// cleanup of pid B.
+	psOutput := strings.Join([]string{
+		"500 1 /plugins/first",
+		"501 1 /plugins/second",
+		"",
+	}, "\n")
+	var killed []int
+	killFn := func(pid int, _ syscall.Signal) error {
+		killed = append(killed, pid)
+		if pid == 500 {
+			return syscall.EPERM
+		}
+		return nil
+	}
+
+	// Act
+	reapOrphans(psOutput, "/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+
+	// Assert
+	require.Equal(t, []int{500, 501}, killed, "reaper must attempt to kill every matching entry even when one fails")
+}
+
+func TestReapOrphans_SkipsSubdirectoryProcesses(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — a process invoked from a subdirectory of the plugins dir
+	// must not be killed; only direct children of pluginsAbs are plugins.
+	psOutput := strings.Join([]string{
+		"500 1 /plugins/sub/foo",
+		"501 1 /plugins/direct-plugin",
+		"",
+	}, "\n")
+	var killed []int
+	killFn := func(pid int, _ syscall.Signal) error {
+		killed = append(killed, pid)
+		return nil
+	}
+
+	// Act
+	reapOrphans(psOutput, "/plugins", 1, slog.New(slog.DiscardHandler), killFn)
+
+	// Assert
+	require.Equal(t, []int{501}, killed)
+}

--- a/server/cmd/fleetnode/orphan_reaper_windows.go
+++ b/server/cmd/fleetnode/orphan_reaper_windows.go
@@ -2,8 +2,12 @@
 
 package main
 
-import "log/slog"
+import (
+	"context"
+	"log/slog"
+)
 
 // No-op: Windows go-plugin children share a job object that auto-terminates
-// when the parent exits.
-func reapOrphanedPlugins(_ string, _ *slog.Logger) {}
+// when the parent exits. The signature matches the Unix variant so the
+// shared run.go caller compiles on both platforms.
+func reapOrphanedPlugins(_ context.Context, _ string, _ *slog.Logger) {}

--- a/server/cmd/fleetnode/orphan_reaper_windows.go
+++ b/server/cmd/fleetnode/orphan_reaper_windows.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 )
 
-// No-op: Windows go-plugin children share a job object that auto-terminates
-// when the parent exits. The signature matches the Unix variant so the
-// shared run.go caller compiles on both platforms.
+// Windows go-plugin children share a job object that auto-terminates with
+// the parent, so no manual reaping is needed.
 func reapOrphanedPlugins(_ context.Context, _ string, _ *slog.Logger) {}

--- a/server/cmd/fleetnode/orphan_reaper_windows.go
+++ b/server/cmd/fleetnode/orphan_reaper_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "log/slog"
+
+// No-op: Windows go-plugin children share a job object that auto-terminates
+// when the parent exits.
+func reapOrphanedPlugins(_ string, _ *slog.Logger) {}

--- a/server/cmd/fleetnode/plugins_dir.go
+++ b/server/cmd/fleetnode/plugins_dir.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// The plugin manager execs every file in the returned path, so non-owner
+// write capability there is RCE-equivalent (checkPluginsDirPerms enforces).
+func resolvePluginsDir(exeDir string) (string, error) {
+	if exeDir == "" {
+		return "", nil
+	}
+	candidate := filepath.Join(exeDir, "plugins")
+	info, err := os.Stat(candidate)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("stat plugins dir %s: %w", candidate, err)
+	}
+	if !info.IsDir() {
+		return "", nil
+	}
+	if err := checkPluginsDirPerms(candidate); err != nil {
+		return "", err
+	}
+	if err := validatePluginFiles(candidate); err != nil {
+		return "", err
+	}
+	return candidate, nil
+}
+
+func executableDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		resolved = exe
+	}
+	return filepath.Dir(resolved)
+}

--- a/server/cmd/fleetnode/plugins_dir.go
+++ b/server/cmd/fleetnode/plugins_dir.go
@@ -20,9 +20,8 @@ func resolvePluginsDir(exeDir string) (string, error) {
 		}
 		return "", fmt.Errorf("lstat plugins dir %s: %w", candidate, err)
 	}
-	// A symlink as the dir entry defeats checkPluginsDirPerms (which Stats
-	// the target) and creates a path-mismatch with the orphan reaper, which
-	// resolves symlinks. Refuse early.
+	// Symlink leaves add a mutable layer between validation and exec; refuse
+	// so the reaper, validator, and loader all see the same path.
 	if info.Mode()&os.ModeSymlink != 0 {
 		return "", fmt.Errorf("plugins dir %s is a symlink; refuse to follow", candidate)
 	}

--- a/server/cmd/fleetnode/plugins_dir.go
+++ b/server/cmd/fleetnode/plugins_dir.go
@@ -13,12 +13,18 @@ func resolvePluginsDir(exeDir string) (string, error) {
 		return "", nil
 	}
 	candidate := filepath.Join(exeDir, "plugins")
-	info, err := os.Stat(candidate)
+	info, err := os.Lstat(candidate)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil
 		}
-		return "", fmt.Errorf("stat plugins dir %s: %w", candidate, err)
+		return "", fmt.Errorf("lstat plugins dir %s: %w", candidate, err)
+	}
+	// A symlink as the dir entry defeats checkPluginsDirPerms (which Stats
+	// the target) and creates a path-mismatch with the orphan reaper, which
+	// resolves symlinks. Refuse early.
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("plugins dir %s is a symlink; refuse to follow", candidate)
 	}
 	if !info.IsDir() {
 		return "", nil

--- a/server/cmd/fleetnode/plugins_dir.go
+++ b/server/cmd/fleetnode/plugins_dir.go
@@ -35,6 +35,9 @@ func resolvePluginsDir(exeDir string) (string, error) {
 	if err := validatePluginFiles(candidate); err != nil {
 		return "", err
 	}
+	if err := validatePathChain(candidate); err != nil {
+		return "", err
+	}
 	return candidate, nil
 }
 

--- a/server/cmd/fleetnode/plugins_dir_test.go
+++ b/server/cmd/fleetnode/plugins_dir_test.go
@@ -125,8 +125,10 @@ func TestValidatePluginFiles_RejectsWorldWritableExecutable(t *testing.T) {
 	assert.Contains(t, strings.ToLower(err.Error()), "writable")
 }
 
-func TestValidatePluginFiles_IgnoresNonExecutableFiles(t *testing.T) {
-	// Arrange
+func TestValidatePluginFiles_AcceptsOwnedNonExecutableFiles(t *testing.T) {
+	// Arrange — a non-executable file owned by the running uid and not
+	// group/world-writable is fine. The check now runs for every regular
+	// file (not just executables) but a benign README still passes.
 	_, plugins := newPluginsDir(t)
 	require.NoError(t, os.WriteFile(filepath.Join(plugins, "README.md"), []byte("docs"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(plugins, "x"), []byte("#!/bin/sh\n"), 0o755))
@@ -136,6 +138,23 @@ func TestValidatePluginFiles_IgnoresNonExecutableFiles(t *testing.T) {
 
 	// Assert
 	require.NoError(t, err)
+}
+
+func TestValidatePluginFiles_RejectsWritableNonExecutableFile(t *testing.T) {
+	// Arrange — a non-executable file that is group/world-writable can be
+	// chmod +x'd by another local user between validation and plugin load,
+	// becoming a stealth RCE vector. Reject before reaching that window.
+	_, plugins := newPluginsDir(t)
+	path := filepath.Join(plugins, "config.txt")
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+	require.NoError(t, os.Chmod(path, 0o646)) //nolint:gosec // test exercises the reject path
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "writable")
 }
 
 func TestValidatePluginFiles_IgnoresSubdirectories(t *testing.T) {
@@ -212,4 +231,69 @@ func TestCheckPluginsDirPerms_RejectsEachWritableBitIndependently(t *testing.T) 
 			assert.Contains(t, strings.ToLower(err.Error()), "writable")
 		})
 	}
+}
+
+func TestValidatePathChain_RejectsWritableAncestor(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "group writable parent", mode: 0o775},
+		{name: "world writable parent", mode: 0o757},
+		{name: "fully writable parent", mode: 0o777},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange — an attacker-writable ancestor lets another user
+			// swap our validated plugins dir between the check and the
+			// loader's exec. validatePathChain must reject the ancestor
+			// regardless of whether the leaf itself is fine.
+			base := t.TempDir()
+			parent := filepath.Join(base, "writable")
+			require.NoError(t, os.Mkdir(parent, 0o755)) //nolint:gosec // test fixture
+			candidate := filepath.Join(parent, "plugins")
+			require.NoError(t, os.Mkdir(candidate, 0o755)) //nolint:gosec // test fixture
+			require.NoError(t, os.Chmod(parent, tc.mode))
+
+			// Act
+			err := validatePathChain(candidate)
+
+			// Assert
+			require.Error(t, err)
+			assert.Contains(t, strings.ToLower(err.Error()), "writable")
+		})
+	}
+}
+
+func TestValidatePathChain_AllowsStickyWritableAncestor(t *testing.T) {
+	t.Parallel()
+
+	// Arrange — /tmp-style sticky+writable ancestors (mode 0o1777) are
+	// acceptable because the sticky bit prevents other users from
+	// deleting or renaming our dir even though they can create siblings.
+	base := t.TempDir()
+	sticky := filepath.Join(base, "sticky")
+	require.NoError(t, os.Mkdir(sticky, 0o755)) //nolint:gosec // test fixture
+	candidate := filepath.Join(sticky, "plugins")
+	require.NoError(t, os.Mkdir(candidate, 0o755))             //nolint:gosec // test fixture
+	require.NoError(t, os.Chmod(sticky, 0o1777|os.ModeSticky)) //nolint:gosec // test fixture
+
+	// Act
+	err := validatePathChain(candidate)
+
+	// Assert
+	require.NoError(t, err)
+}
+
+func TestValidatePathChain_RequiresAbsolutePath(t *testing.T) {
+	// Act
+	err := validatePathChain("relative/path")
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
 }

--- a/server/cmd/fleetnode/plugins_dir_test.go
+++ b/server/cmd/fleetnode/plugins_dir_test.go
@@ -165,3 +165,51 @@ func TestResolvePluginsDir_Default_BadFileBlocksResolution(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "evil")
 }
+
+func TestResolvePluginsDir_RejectsSymlinkedDir(t *testing.T) {
+	// Arrange — <exe-dir>/plugins is a symlink to a real directory. The
+	// orphan reaper resolves symlinks via EvalSymlinks; the plugin loader
+	// would exec the unresolved path. Refuse to follow at resolve time so
+	// the two stay aligned.
+	exeDir := t.TempDir()
+	target := t.TempDir()
+	require.NoError(t, os.Symlink(target, filepath.Join(exeDir, "plugins")))
+
+	// Act
+	_, err := resolvePluginsDir(exeDir)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "symlink")
+}
+
+func TestCheckPluginsDirPerms_RejectsEachWritableBitIndependently(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "group writable only", mode: 0o775},
+		{name: "world writable only", mode: 0o757},
+		{name: "both group and world", mode: 0o777},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			exeDir := t.TempDir()
+			candidate := filepath.Join(exeDir, "plugins")
+			require.NoError(t, os.Mkdir(candidate, 0o755)) //nolint:gosec // test fixture
+			require.NoError(t, os.Chmod(candidate, tc.mode))
+
+			// Act
+			_, err := resolvePluginsDir(exeDir)
+
+			// Assert
+			require.Error(t, err)
+			assert.Contains(t, strings.ToLower(err.Error()), "writable")
+		})
+	}
+}

--- a/server/cmd/fleetnode/plugins_dir_test.go
+++ b/server/cmd/fleetnode/plugins_dir_test.go
@@ -1,0 +1,167 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePluginsDir_Default_BinaryAdjacent(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+	candidate := filepath.Join(exeDir, "plugins")
+	require.NoError(t, os.Mkdir(candidate, 0o755)) //nolint:gosec // test fixture
+
+	// Act
+	got, err := resolvePluginsDir(exeDir)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, candidate, got)
+}
+
+func TestResolvePluginsDir_Default_MissingReturnsEmpty(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+
+	// Act
+	got, err := resolvePluginsDir(exeDir)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestResolvePluginsDir_Default_PresentButUnsafeIsHardError(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+	candidate := filepath.Join(exeDir, "plugins")
+	require.NoError(t, os.Mkdir(candidate, 0o755)) //nolint:gosec // test fixture
+	require.NoError(t, os.Chmod(candidate, 0o777)) //nolint:gosec // test exercises the reject path
+
+	// Act
+	_, err := resolvePluginsDir(exeDir)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "writable")
+}
+
+func TestResolvePluginsDir_NoExeDir(t *testing.T) {
+	// Act
+	got, err := resolvePluginsDir("")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestResolvePluginsDir_Default_FileAtCandidateIgnored(t *testing.T) {
+	// Arrange
+	exeDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(exeDir, "plugins"), []byte("not a dir"), 0o644))
+
+	// Act
+	got, err := resolvePluginsDir(exeDir)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func newPluginsDir(t *testing.T) (exeDir, plugins string) {
+	t.Helper()
+	exeDir = t.TempDir()
+	plugins = filepath.Join(exeDir, "plugins")
+	require.NoError(t, os.Mkdir(plugins, 0o755)) //nolint:gosec // test fixture
+	return exeDir, plugins
+}
+
+func TestValidatePluginFiles_AcceptsOwnedAndTightExecutable(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	require.NoError(t, os.WriteFile(filepath.Join(plugins, "x"), []byte("#!/bin/sh\n"), 0o755))
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.NoError(t, err)
+}
+
+func TestValidatePluginFiles_RejectsSymlink(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	target := filepath.Join(t.TempDir(), "elsewhere")
+	require.NoError(t, os.WriteFile(target, []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.Symlink(target, filepath.Join(plugins, "x")))
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "symlink")
+}
+
+func TestValidatePluginFiles_RejectsWorldWritableExecutable(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	path := filepath.Join(plugins, "x")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.Chmod(path, 0o777)) //nolint:gosec // test exercises the reject path
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "writable")
+}
+
+func TestValidatePluginFiles_IgnoresNonExecutableFiles(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	require.NoError(t, os.WriteFile(filepath.Join(plugins, "README.md"), []byte("docs"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(plugins, "x"), []byte("#!/bin/sh\n"), 0o755))
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.NoError(t, err)
+}
+
+func TestValidatePluginFiles_IgnoresSubdirectories(t *testing.T) {
+	// Arrange
+	_, plugins := newPluginsDir(t)
+	require.NoError(t, os.Mkdir(filepath.Join(plugins, "data"), 0o755)) //nolint:gosec // test fixture
+	require.NoError(t, os.WriteFile(filepath.Join(plugins, "x"), []byte("#!/bin/sh\n"), 0o755))
+
+	// Act
+	err := validatePluginFiles(plugins)
+
+	// Assert
+	require.NoError(t, err)
+}
+
+func TestResolvePluginsDir_Default_BadFileBlocksResolution(t *testing.T) {
+	// Arrange
+	exeDir, plugins := newPluginsDir(t)
+	bad := filepath.Join(plugins, "evil")
+	require.NoError(t, os.WriteFile(bad, []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.Chmod(bad, 0o777)) //nolint:gosec // test exercises the reject path
+
+	// Act
+	_, err := resolvePluginsDir(exeDir)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "evil")
+}

--- a/server/cmd/fleetnode/plugins_dir_unix.go
+++ b/server/cmd/fleetnode/plugins_dir_unix.go
@@ -33,11 +33,9 @@ func checkPluginsDirPerms(path string) error {
 	return nil
 }
 
-// validatePluginFiles enforces the per-file safety bar that the container
-// check can't see. Ownership and writability checks apply to every regular
-// file, not just executable ones: a non-executable file owned by another
-// user can be chmod +x'd by that user between validation and plugin load,
-// turning it into an RCE vector under the agent uid.
+// Every regular file is checked, not just executables: a non-exec file
+// owned by another user can be chmod +x'd between validation and load,
+// becoming RCE under the agent uid.
 func validatePluginFiles(dir string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -75,16 +73,11 @@ func validatePluginFiles(dir string) error {
 	return nil
 }
 
-// validatePathChain verifies that every directory above path is owned by
-// root or the running uid and not group/world-writable. Without this, a
-// writable ancestor lets another user swap the validated plugins dir
-// between resolvePluginsDir and the loader's exec call.
-//
-// Both the original path and (when it differs) its symlink-resolved form
-// are walked: walking the original chain catches a swappable symlink
-// component (its containing dir's perms protect it from replacement);
-// walking the resolved chain catches the case where a trusted symlink
-// points into an attacker-writable target tree.
+// Without ancestor validation a writable parent lets another user swap the
+// validated plugins dir between resolvePluginsDir and the loader's exec.
+// Both the original and resolved chains are walked: the original catches
+// swappable symlinks (via their containing dir's perms), the resolved
+// catches a trusted symlink pointing into an attacker-writable target.
 func validatePathChain(path string) error {
 	if !filepath.IsAbs(path) {
 		return fmt.Errorf("validatePathChain requires absolute path, got %q", path)
@@ -113,10 +106,9 @@ func walkAncestors(path string) error {
 			return fmt.Errorf("lstat path component %s: %w", current, err)
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			// Symlink components reduce to two checks already in scope:
-			// the symlink's containing dir (next iteration) protects it
-			// from replacement, and EvalSymlinks-resolved target chain
-			// validates the underlying directory.
+			// Symlink components are guarded transitively: containing dir
+			// (next iteration) blocks replacement; resolved-chain walk
+			// covers the target.
 			parent := filepath.Dir(current)
 			if parent == current {
 				break
@@ -134,10 +126,8 @@ func walkAncestors(path string) error {
 		if stat.Uid != 0 && stat.Uid != uid {
 			return fmt.Errorf("path component %s: owner uid %d must be 0 (root) or %d (this process)", current, stat.Uid, uid)
 		}
-		// Sticky-bit exception: dirs like /tmp are mode 0o1777 (world-
-		// writable + sticky) so other users can create their own entries
-		// but cannot delete or rename ours. That protects the descendants
-		// we actually care about, so accept sticky+writable ancestors.
+		// /tmp-style 0o1777: sticky bit blocks non-owner delete/rename, so
+		// our descendants are protected even though the dir is world-writable.
 		if mode := info.Mode().Perm(); mode&0o022 != 0 && info.Mode()&os.ModeSticky == 0 {
 			return fmt.Errorf("path component %s: mode %#o must not be group- or world-writable", current, mode)
 		}

--- a/server/cmd/fleetnode/plugins_dir_unix.go
+++ b/server/cmd/fleetnode/plugins_dir_unix.go
@@ -1,0 +1,77 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// checkPluginsDirPerms rejects dirs where someone other than root or the
+// running uid could plant an executable between our check and exec.
+func checkPluginsDirPerms(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat plugins dir %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("plugins dir %s is not a directory", path)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("plugins dir %s: unsupported stat type %T", path, info.Sys())
+	}
+	uid := uint32(os.Getuid()) //nolint:gosec // os.Getuid() is non-negative on Unix
+	if stat.Uid != 0 && stat.Uid != uid {
+		return fmt.Errorf("plugins dir %s: owner uid %d must be 0 (root) or %d (this process)", path, stat.Uid, uid)
+	}
+	if mode := info.Mode().Perm(); mode&0o022 != 0 {
+		return fmt.Errorf("plugins dir %s: mode %#o must not be group- or world-writable", path, mode)
+	}
+	return nil
+}
+
+// validatePluginFiles enforces the per-file safety bar that the container
+// check can't see: a writable plugin binary or a symlink to one elsewhere
+// would still be RCE-equivalent under the agent uid.
+func validatePluginFiles(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read plugins dir %s: %w", dir, err)
+	}
+	uid := uint32(os.Getuid()) //nolint:gosec // os.Getuid() is non-negative on Unix
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+		t := entry.Type()
+		if t&os.ModeSymlink != 0 {
+			return fmt.Errorf("plugin %s is a symlink; refuse to follow", path)
+		}
+		if t.IsDir() {
+			continue
+		}
+		if !t.IsRegular() {
+			return fmt.Errorf("plugin %s is not a regular file (mode %s)", path, t)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		mode := info.Mode()
+		if mode.Perm()&0o111 == 0 {
+			continue
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("plugin %s: unsupported stat type %T", path, info.Sys())
+		}
+		if stat.Uid != 0 && stat.Uid != uid {
+			return fmt.Errorf("plugin %s: owner uid %d must be 0 (root) or %d (this process)", path, stat.Uid, uid)
+		}
+		if mode.Perm()&0o022 != 0 {
+			return fmt.Errorf("plugin %s: mode %#o must not be group- or world-writable", path, mode.Perm())
+		}
+	}
+	return nil
+}

--- a/server/cmd/fleetnode/plugins_dir_unix.go
+++ b/server/cmd/fleetnode/plugins_dir_unix.go
@@ -34,8 +34,10 @@ func checkPluginsDirPerms(path string) error {
 }
 
 // validatePluginFiles enforces the per-file safety bar that the container
-// check can't see: a writable plugin binary or a symlink to one elsewhere
-// would still be RCE-equivalent under the agent uid.
+// check can't see. Ownership and writability checks apply to every regular
+// file, not just executable ones: a non-executable file owned by another
+// user can be chmod +x'd by that user between validation and plugin load,
+// turning it into an RCE vector under the agent uid.
 func validatePluginFiles(dir string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -59,9 +61,6 @@ func validatePluginFiles(dir string) error {
 			return fmt.Errorf("stat %s: %w", path, err)
 		}
 		mode := info.Mode()
-		if mode.Perm()&0o111 == 0 {
-			continue
-		}
 		stat, ok := info.Sys().(*syscall.Stat_t)
 		if !ok {
 			return fmt.Errorf("plugin %s: unsupported stat type %T", path, info.Sys())
@@ -72,6 +71,81 @@ func validatePluginFiles(dir string) error {
 		if mode.Perm()&0o022 != 0 {
 			return fmt.Errorf("plugin %s: mode %#o must not be group- or world-writable", path, mode.Perm())
 		}
+	}
+	return nil
+}
+
+// validatePathChain verifies that every directory above path is owned by
+// root or the running uid and not group/world-writable. Without this, a
+// writable ancestor lets another user swap the validated plugins dir
+// between resolvePluginsDir and the loader's exec call.
+//
+// Both the original path and (when it differs) its symlink-resolved form
+// are walked: walking the original chain catches a swappable symlink
+// component (its containing dir's perms protect it from replacement);
+// walking the resolved chain catches the case where a trusted symlink
+// points into an attacker-writable target tree.
+func validatePathChain(path string) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("validatePathChain requires absolute path, got %q", path)
+	}
+	if err := walkAncestors(path); err != nil {
+		return err
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return fmt.Errorf("resolve %s: %w", path, err)
+	}
+	if resolved != path {
+		if err := walkAncestors(resolved); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func walkAncestors(path string) error {
+	uid := uint32(os.Getuid()) //nolint:gosec // os.Getuid() is non-negative on Unix
+	current := filepath.Dir(path)
+	for {
+		info, err := os.Lstat(current)
+		if err != nil {
+			return fmt.Errorf("lstat path component %s: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			// Symlink components reduce to two checks already in scope:
+			// the symlink's containing dir (next iteration) protects it
+			// from replacement, and EvalSymlinks-resolved target chain
+			// validates the underlying directory.
+			parent := filepath.Dir(current)
+			if parent == current {
+				break
+			}
+			current = parent
+			continue
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("path component %s is not a directory", current)
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("path component %s: unsupported stat type %T", current, info.Sys())
+		}
+		if stat.Uid != 0 && stat.Uid != uid {
+			return fmt.Errorf("path component %s: owner uid %d must be 0 (root) or %d (this process)", current, stat.Uid, uid)
+		}
+		// Sticky-bit exception: dirs like /tmp are mode 0o1777 (world-
+		// writable + sticky) so other users can create their own entries
+		// but cannot delete or rename ours. That protects the descendants
+		// we actually care about, so accept sticky+writable ancestors.
+		if mode := info.Mode().Perm(); mode&0o022 != 0 && info.Mode()&os.ModeSticky == 0 {
+			return fmt.Errorf("path component %s: mode %#o must not be group- or world-writable", current, mode)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
 	}
 	return nil
 }

--- a/server/cmd/fleetnode/plugins_dir_windows.go
+++ b/server/cmd/fleetnode/plugins_dir_windows.go
@@ -4,24 +4,14 @@ package main
 
 import "fmt"
 
-// Windows plugin loading is disabled. The Unix path uses uid + permission-
-// mask checks (plus symlink rejection) to refuse RCE-equivalent
-// configurations before exec'ing adjacent plugin binaries. Equivalent
-// Windows ACL / SID / reparse-point validation needs golang.org/x/sys/windows
-// work that hasn't landed yet; refusing a present plugins dir is safer than
-// running with no validation. When the dir does not exist, resolvePluginsDir
-// returns ("", nil) without reaching here, so Windows fleetnode runs in
-// heartbeat-only mode by default.
+// Windows plugin loading is disabled until ACL/SID validation lands.
+// Refusing a present plugins dir is safer than running with no checks; an
+// absent dir returns ("", nil) from resolvePluginsDir before reaching here,
+// so heartbeat-only mode remains the Windows default.
 func checkPluginsDirPerms(path string) error {
 	return fmt.Errorf("plugin loading is not yet supported on Windows; remove %s or run fleetnode on a Unix host until Windows ACL validation is implemented", path)
 }
 
-// validatePluginFiles is unreachable while checkPluginsDirPerms refuses, but
-// kept as a no-op so the shared resolvePluginsDir call sequence type-checks
-// on both platforms.
+// Unreachable while checkPluginsDirPerms refuses; no-op for cross-platform compile.
 func validatePluginFiles(_ string) error { return nil }
-
-// validatePathChain is unreachable on Windows for the same reason as
-// validatePluginFiles. ACL-based ancestor validation would be the right
-// shape here when Windows plugin loading is wired up.
-func validatePathChain(_ string) error { return nil }
+func validatePathChain(_ string) error   { return nil }

--- a/server/cmd/fleetnode/plugins_dir_windows.go
+++ b/server/cmd/fleetnode/plugins_dir_windows.go
@@ -20,3 +20,8 @@ func checkPluginsDirPerms(path string) error {
 // kept as a no-op so the shared resolvePluginsDir call sequence type-checks
 // on both platforms.
 func validatePluginFiles(_ string) error { return nil }
+
+// validatePathChain is unreachable on Windows for the same reason as
+// validatePluginFiles. ACL-based ancestor validation would be the right
+// shape here when Windows plugin loading is wired up.
+func validatePathChain(_ string) error { return nil }

--- a/server/cmd/fleetnode/plugins_dir_windows.go
+++ b/server/cmd/fleetnode/plugins_dir_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// Windows relies on the MSI installer placing plugins under an
+// Administrator-only path; an ACL check is out of scope here.
+func checkPluginsDirPerms(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat plugins dir %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("plugins dir %s is not a directory", path)
+	}
+	return nil
+}
+
+// Windows ACL inspection needs golang.org/x/sys/windows SID/ACE work.
+// Production deployments must place plugins under an Administrator-only
+// directory; runtime cannot verify that on Windows.
+func validatePluginFiles(_ string) error { return nil }

--- a/server/cmd/fleetnode/plugins_dir_windows.go
+++ b/server/cmd/fleetnode/plugins_dir_windows.go
@@ -2,25 +2,21 @@
 
 package main
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
-// Windows relies on the MSI installer placing plugins under an
-// Administrator-only path; an ACL check is out of scope here.
+// Windows plugin loading is disabled. The Unix path uses uid + permission-
+// mask checks (plus symlink rejection) to refuse RCE-equivalent
+// configurations before exec'ing adjacent plugin binaries. Equivalent
+// Windows ACL / SID / reparse-point validation needs golang.org/x/sys/windows
+// work that hasn't landed yet; refusing a present plugins dir is safer than
+// running with no validation. When the dir does not exist, resolvePluginsDir
+// returns ("", nil) without reaching here, so Windows fleetnode runs in
+// heartbeat-only mode by default.
 func checkPluginsDirPerms(path string) error {
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("stat plugins dir %s: %w", path, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("plugins dir %s is not a directory", path)
-	}
-	return nil
+	return fmt.Errorf("plugin loading is not yet supported on Windows; remove %s or run fleetnode on a Unix host until Windows ACL validation is implemented", path)
 }
 
-// Windows ACL inspection needs golang.org/x/sys/windows SID/ACE work.
-// Production deployments must place plugins under an Administrator-only
-// directory; runtime cannot verify that on Windows.
+// validatePluginFiles is unreachable while checkPluginsDirPerms refuses, but
+// kept as a no-op so the shared resolvePluginsDir call sequence type-checks
+// on both platforms.
 func validatePluginFiles(_ string) error { return nil }

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"connectrpc.com/connect"
@@ -60,9 +59,7 @@ func (r *RunCmd) run(c *Context, logOutput io.Writer) error {
 		}
 	}
 	if len(r.signals) == 0 {
-		// SIGHUP catches terminal-close so plugin children get the same
-		// orderly shutdown as Ctrl+C instead of being orphaned.
-		r.signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP}
+		r.signals = defaultSignals()
 	}
 	if r.parentCtx == nil {
 		r.parentCtx = context.Background()
@@ -98,9 +95,12 @@ func (r *RunCmd) run(c *Context, logOutput io.Writer) error {
 	}
 
 	logger := slog.New(slog.NewTextHandler(logOutput, nil))
-	if resolvedPluginsDir != "" {
+	switch {
+	case resolvedPluginsDir != "":
 		logger.Info("plugins dir resolved", "plugins_dir", resolvedPluginsDir)
-	} else {
+	case r.discoverer != nil:
+		logger.Info("using injected discoverer; plugins dir resolution skipped")
+	default:
 		logger.Info("no plugins dir found adjacent to binary; control loop disabled (heartbeat only)")
 	}
 

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -47,7 +47,7 @@ func (r *RunCmd) Run(c *Context) error {
 	return r.run(c, os.Stdout)
 }
 
-func (r *RunCmd) run(c *Context, stderr io.Writer) error {
+func (r *RunCmd) run(c *Context, logOutput io.Writer) error {
 	if r.HeartbeatInterval <= 0 {
 		r.HeartbeatInterval = defaultHeartbeatInterval
 	}
@@ -67,6 +67,11 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 	if r.parentCtx == nil {
 		r.parentCtx = context.Background()
 	}
+
+	// Wire signals before plugin work so a SIGTERM during the up-to-60s
+	// plugin load aborts cleanly instead of orphaning subprocesses.
+	ctx, stop := signal.NotifyContext(r.parentCtx, r.signals...)
+	defer stop()
 
 	// Resolve binary-adjacent plugins before touching disk state so
 	// misconfiguration fails fast.
@@ -92,7 +97,7 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		return fmt.Errorf("state at %s has no api_key; complete enrollment via `fleetnode refresh` before running the daemon", path)
 	}
 
-	logger := slog.New(slog.NewTextHandler(stderr, nil))
+	logger := slog.New(slog.NewTextHandler(logOutput, nil))
 	if resolvedPluginsDir != "" {
 		logger.Info("plugins dir resolved", "plugins_dir", resolvedPluginsDir)
 	} else {
@@ -104,19 +109,19 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 	logger.Info("acquiring state lock", "state_dir", c.StateDir)
 	return fleetnodebootstrap.WithStateLock(c.StateDir, func() error {
 		if resolvedPluginsDir != "" {
-			reapOrphanedPlugins(resolvedPluginsDir, logger)
-			disc, cleanup, bootstrapErr := newPluginDiscoverer(resolvedPluginsDir)
+			reapOrphanedPlugins(ctx, resolvedPluginsDir, logger)
+			disc, cleanup, bootstrapErr := newPluginDiscoverer(ctx, resolvedPluginsDir)
 			if bootstrapErr != nil {
 				return fmt.Errorf("bootstrap discovery plugins: %w", bootstrapErr)
 			}
 			defer cleanup()
 			r.discoverer = disc
 		}
-		return r.runLocked(c, logger)
+		return r.runLocked(ctx, c, logger)
 	})
 }
 
-func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
+func (r *RunCmd) runLocked(ctx context.Context, c *Context, logger *slog.Logger) error {
 	path := fleetnodebootstrap.StatePath(c.StateDir)
 	st, exists, err := fleetnodebootstrap.LoadState(path)
 	if err != nil {
@@ -131,9 +136,6 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 	if err := fleetnodebootstrap.ValidateServerURL(st.ServerURL, st.AllowInsecureTransport); err != nil {
 		return err
 	}
-
-	ctx, stop := signal.NotifyContext(r.parentCtx, r.signals...)
-	defer stop()
 
 	if r.sessionNeedsRefresh(st) {
 		if err := r.refreshAndSave(ctx, st, path, logger); err != nil {
@@ -208,8 +210,11 @@ func (r *RunCmd) refreshAndSave(ctx context.Context, st *fleetnodebootstrap.Stat
 	r.stateMu.Lock()
 	st.SessionToken = next.SessionToken
 	st.SessionExpiresAt = next.SessionExpiresAt
+	// Snapshot under the lock so SaveState's yaml.Marshal doesn't race the
+	// tokenSource goroutine that the control loop will add later.
+	snapshot := *st
 	r.stateMu.Unlock()
-	if err := fleetnodebootstrap.SaveState(path, st); err != nil {
+	if err := fleetnodebootstrap.SaveState(path, &snapshot); err != nil {
 		return fmt.Errorf("save state after refresh: %w", err)
 	}
 	logger.Info("session refreshed", "fleet_node_id", st.FleetNodeID, "session_expires_at", st.SessionExpiresAt.Format(time.RFC3339))

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -31,14 +32,19 @@ type RunCmd struct {
 	clientFactory func(serverURL string, tokenSource func() string) (gatewayClient, error) `kong:"-"`
 	signals       []os.Signal                                                              `kong:"-"`
 	parentCtx     context.Context                                                          `kong:"-"` //nolint:containedctx // test seam for daemon shutdown without OS signals
+	discoverer    discoverer                                                               `kong:"-"`
+
+	stateMu sync.Mutex `kong:"-"` // guards st.SessionToken across refreshAndSave + tokenSource.
 }
 
 type gatewayClient interface {
 	UploadHeartbeat(ctx context.Context, req *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error)
+	ReportDiscoveredDevices(ctx context.Context, req *connect.Request[pb.ReportDiscoveredDevicesRequest]) (*connect.Response[pb.ReportDiscoveredDevicesResponse], error)
+	ControlStream(ctx context.Context) *connect.BidiStreamForClient[pb.ControlStreamRequest, pb.ControlStreamResponse]
 }
 
 func (r *RunCmd) Run(c *Context) error {
-	return r.run(c, os.Stderr)
+	return r.run(c, os.Stdout)
 }
 
 func (r *RunCmd) run(c *Context, stderr io.Writer) error {
@@ -54,10 +60,24 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 		}
 	}
 	if len(r.signals) == 0 {
-		r.signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+		// SIGHUP catches terminal-close so plugin children get the same
+		// orderly shutdown as Ctrl+C instead of being orphaned.
+		r.signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP}
 	}
 	if r.parentCtx == nil {
 		r.parentCtx = context.Background()
+	}
+
+	// Resolve binary-adjacent plugins before touching disk state so
+	// misconfiguration fails fast.
+	exeDir := executableDir()
+	var resolvedPluginsDir string
+	if r.discoverer == nil {
+		resolved, resolveErr := resolvePluginsDir(exeDir)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		resolvedPluginsDir = resolved
 	}
 
 	path := fleetnodebootstrap.StatePath(c.StateDir)
@@ -73,8 +93,25 @@ func (r *RunCmd) run(c *Context, stderr io.Writer) error {
 	}
 
 	logger := slog.New(slog.NewTextHandler(stderr, nil))
+	if resolvedPluginsDir != "" {
+		logger.Info("plugins dir resolved", "plugins_dir", resolvedPluginsDir)
+	} else {
+		logger.Info("no plugins dir found adjacent to binary; control loop disabled (heartbeat only)")
+	}
 
+	// Reap + spawn plugins inside the lock so a contending agent's reaper
+	// can't kill our children before we finish startup.
+	logger.Info("acquiring state lock", "state_dir", c.StateDir)
 	return fleetnodebootstrap.WithStateLock(c.StateDir, func() error {
+		if resolvedPluginsDir != "" {
+			reapOrphanedPlugins(resolvedPluginsDir, logger)
+			disc, cleanup, bootstrapErr := newPluginDiscoverer(resolvedPluginsDir)
+			if bootstrapErr != nil {
+				return fmt.Errorf("bootstrap discovery plugins: %w", bootstrapErr)
+			}
+			defer cleanup()
+			r.discoverer = disc
+		}
 		return r.runLocked(c, logger)
 	})
 }
@@ -88,9 +125,9 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 	if !exists || st.FleetNodeID == 0 || st.APIKey == "" {
 		return fmt.Errorf("state at %s became invalid between checks; re-run after `fleetnode enroll`", path)
 	}
-	// Validate on every entry, not just on the refresh path, so a tampered
-	// state cannot redirect bearer heartbeats to a plaintext non-loopback
-	// URL when the existing session_token is still fresh.
+	// Re-validate on every entry so a tampered state.yaml can't redirect
+	// bearer heartbeats to a plaintext non-loopback URL while the cached
+	// session_token is still fresh.
 	if err := fleetnodebootstrap.ValidateServerURL(st.ServerURL, st.AllowInsecureTransport); err != nil {
 		return err
 	}
@@ -107,7 +144,12 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 		}
 	}
 
-	client, err := r.clientFactory(st.ServerURL, func() string { return st.SessionToken })
+	tokenSource := func() string {
+		r.stateMu.Lock()
+		defer r.stateMu.Unlock()
+		return st.SessionToken
+	}
+	client, err := r.clientFactory(st.ServerURL, tokenSource)
 	if err != nil {
 		return err
 	}
@@ -119,16 +161,23 @@ func (r *RunCmd) runLocked(c *Context, logger *slog.Logger) error {
 		"session_expires_at", st.SessionExpiresAt.Format(time.RFC3339),
 	)
 
-	ticker := time.NewTicker(r.HeartbeatInterval)
-	defer ticker.Stop()
-
 	if err := r.tick(ctx, client, st, path, logger); err != nil {
 		return err
 	}
+
+	if err := r.runHeartbeatLoop(ctx, client, st, path, logger); err != nil {
+		return err
+	}
+	logger.Info("daemon shutting down", "fleet_node_id", st.FleetNodeID)
+	return nil
+}
+
+func (r *RunCmd) runHeartbeatLoop(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, path string, logger *slog.Logger) error {
+	ticker := time.NewTicker(r.HeartbeatInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Info("daemon shutting down", "fleet_node_id", st.FleetNodeID)
 			return nil
 		case <-ticker.C:
 			if err := r.tick(ctx, client, st, path, logger); err != nil {
@@ -150,9 +199,16 @@ func (r *RunCmd) sessionNeedsRefresh(st *fleetnodebootstrap.State) bool {
 
 func (r *RunCmd) refreshAndSave(ctx context.Context, st *fleetnodebootstrap.State, path string, logger *slog.Logger) error {
 	logger.Info("refreshing session", "fleet_node_id", st.FleetNodeID, "session_expires_at", st.SessionExpiresAt.Format(time.RFC3339))
-	if err := fleetnodebootstrap.Refresh(ctx, st); err != nil {
+	// Handshake on a shallow copy so the 2-RPC call doesn't hold stateMu and
+	// stall the control loop's token reads.
+	next := *st
+	if err := fleetnodebootstrap.Refresh(ctx, &next); err != nil {
 		return err
 	}
+	r.stateMu.Lock()
+	st.SessionToken = next.SessionToken
+	st.SessionExpiresAt = next.SessionExpiresAt
+	r.stateMu.Unlock()
 	if err := fleetnodebootstrap.SaveState(path, st); err != nil {
 		return fmt.Errorf("save state after refresh: %w", err)
 	}
@@ -160,11 +216,9 @@ func (r *RunCmd) refreshAndSave(ctx context.Context, st *fleetnodebootstrap.Stat
 	return nil
 }
 
-// tick runs one heartbeat cycle. A non-nil return signals a permanent
-// condition (server-side credential revoked or fleet_node deleted) that
-// the operator must resolve by re-enrolling; the daemon exits instead of
-// looping forever. Transient errors are logged and tick returns nil so
-// the next tick can retry.
+// tick runs one heartbeat cycle. A non-nil return is a permanent condition
+// (revoked credential / deleted fleet_node) that requires re-enrollment;
+// transient errors return nil so the next tick retries.
 func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *fleetnodebootstrap.State, path string, logger *slog.Logger) error {
 	if r.sessionNeedsRefresh(st) {
 		if err := r.refreshAndSave(ctx, st, path, logger); err != nil {
@@ -209,8 +263,12 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *fleetnodebo
 	return nil
 }
 
+const heartbeatTimeout = 30 * time.Second
+
 func (r *RunCmd) sendHeartbeat(ctx context.Context, client gatewayClient) error {
-	_, err := client.UploadHeartbeat(ctx, connect.NewRequest(&pb.UploadHeartbeatRequest{
+	callCtx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
+	defer cancel()
+	_, err := client.UploadHeartbeat(callCtx, connect.NewRequest(&pb.UploadHeartbeatRequest{
 		SentAt: timestamppb.New(r.now()),
 	}))
 	return err

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -55,6 +55,14 @@ func (s *stubGatewayClient) UploadHeartbeat(_ context.Context, req *connect.Requ
 	return connect.NewResponse(&pb.UploadHeartbeatResponse{}), nil
 }
 
+func (s *stubGatewayClient) ReportDiscoveredDevices(_ context.Context, _ *connect.Request[pb.ReportDiscoveredDevicesRequest]) (*connect.Response[pb.ReportDiscoveredDevicesResponse], error) {
+	return connect.NewResponse(&pb.ReportDiscoveredDevicesResponse{}), nil
+}
+
+func (s *stubGatewayClient) ControlStream(_ context.Context) *connect.BidiStreamForClient[pb.ControlStreamRequest, pb.ControlStreamResponse] {
+	return nil
+}
+
 func (s *stubGatewayClient) snapshot() (int, []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/server/cmd/fleetnode/signals_unix.go
+++ b/server/cmd/fleetnode/signals_unix.go
@@ -7,9 +7,8 @@ import (
 	"syscall"
 )
 
-// defaultSignals returns the OS signals that should drive an orderly daemon
-// shutdown on Unix. SIGHUP catches terminal-close so plugin children get the
-// same orderly shutdown as Ctrl+C instead of being orphaned.
+// SIGHUP catches terminal-close so plugin children shut down orderly
+// instead of being orphaned on TTY close.
 func defaultSignals() []os.Signal {
 	return []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP}
 }

--- a/server/cmd/fleetnode/signals_unix.go
+++ b/server/cmd/fleetnode/signals_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// defaultSignals returns the OS signals that should drive an orderly daemon
+// shutdown on Unix. SIGHUP catches terminal-close so plugin children get the
+// same orderly shutdown as Ctrl+C instead of being orphaned.
+func defaultSignals() []os.Signal {
+	return []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP}
+}

--- a/server/cmd/fleetnode/signals_windows.go
+++ b/server/cmd/fleetnode/signals_windows.go
@@ -6,9 +6,8 @@ import (
 	"os"
 )
 
-// defaultSignals returns the OS signals that should drive an orderly daemon
-// shutdown on Windows. SIGHUP doesn't exist there; os.Interrupt is what
-// signal.NotifyContext delivers for Ctrl+C and service-stop events.
+// os.Interrupt is what signal.NotifyContext delivers for Ctrl+C and
+// service-stop on Windows; SIGHUP doesn't exist there.
 func defaultSignals() []os.Signal {
 	return []os.Signal{os.Interrupt}
 }

--- a/server/cmd/fleetnode/signals_windows.go
+++ b/server/cmd/fleetnode/signals_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+)
+
+// defaultSignals returns the OS signals that should drive an orderly daemon
+// shutdown on Windows. SIGHUP doesn't exist there; os.Interrupt is what
+// signal.NotifyContext delivers for Ctrl+C and service-stop events.
+func defaultSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}


### PR DESCRIPTION
## Summary

PR 2 of 3. Stacked on [#322](https://github.com/block/proto-fleet/pull/322). Lights up \`fleetnode run\` as a heartbeat-only daemon and carries the agent's runtime scaffolding (plugin-dir validator, orphan reaper, plugin manager wrapper) that PR 3's control loop consumes.

- **\`fleetnode run\`.** State-lock acquisition (\`WithStateLock\`), session-refresh-on-tick (1h leeway), 30s heartbeat loop. SIGINT/SIGTERM/SIGHUP shutdown. Logs to stdout so IDE-attached terminals see them.
- **Plugin-dir validator.** \`resolvePluginsDir\` checks \`<exe-dir>/plugins\` ownership + permissions; \`validatePluginFiles\` walks each entry, rejects symlinks and group/world-writable files, requires regular files owned by root or the agent uid.
- **Orphan reaper** sweeps stray plugin children from prior crashes before the new agent spawns its own.
- **Plugin manager wrapper.** \`pluginDiscoverer\` + \`newPluginDiscoverer\` load subprocess plugins via \`hashicorp/go-plugin\`. Heartbeat-only mode loads them but never dispatches — the control loop lands in PR 3. \`reportFromDiscovered\` + \`synthesizeIdentifier\` ride along for the next layer.
- **\`stubGatewayClient\`** in \`run_test.go\` already satisfies the full gateway interface (UploadHeartbeat / ReportDiscoveredDevices / ControlStream) so PR 3 doesn't have to retouch the fixture.
- **README** grows Plugins, Run, Security-plugins, Troubleshooting sections.

## Stack

1. PR 1: install + enrollment hardening → \`main\`
2. **PR 2 (this one):** \`fleetnode run\` heartbeat + plugin scaffolding → PR 1
3. PR 3: discovery (\`ControlStream\` + nmap + IPList normalizer) → PR 2

## Test plan
- [x] \`go build ./server/...\`
- [x] \`go vet ./server/...\`
- [x] \`golangci-lint run\` → 0 issues
- [x] \`go test -race ./server/cmd/fleetnode/... ./server/internal/fleetnodebootstrap/...\`
- [ ] \`just build-fleetnode\` then \`./server/.fleetnode/fleetnode run --server-url=http://localhost:4000\` after enrolling; verify heartbeat logs every 30s and \`acquiring state lock\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)