### PR TITLE
feat(authz): gate ungated handlers with RequirePermission (PR 2d.1)

### DIFF
--- a/server/internal/handlers/collection/handler.go
+++ b/server/internal/handlers/collection/handler.go
@@ -25,16 +25,9 @@ func NewHandler(svc *collection.Service) *Handler {
 	}
 }
 
-// requirePerm gates a handler at org scope. Per-rack site narrowing
-// is deferred until the request payload surfaces the target site.
-func requirePerm(ctx context.Context, key string) error {
-	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
-	return err
-}
-
 // CreateCollection creates a new collection.
 func (h *Handler) CreateCollection(ctx context.Context, r *connect.Request[pb.CreateCollectionRequest]) (*connect.Response[pb.CreateCollectionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.CreateCollection(ctx, r.Msg)
@@ -46,7 +39,7 @@ func (h *Handler) CreateCollection(ctx context.Context, r *connect.Request[pb.Cr
 
 // GetCollection retrieves a collection by ID.
 func (h *Handler) GetCollection(ctx context.Context, r *connect.Request[pb.GetCollectionRequest]) (*connect.Response[pb.GetCollectionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.GetCollection(ctx, r.Msg)
@@ -58,7 +51,7 @@ func (h *Handler) GetCollection(ctx context.Context, r *connect.Request[pb.GetCo
 
 // UpdateCollection updates a collection's label and/or description.
 func (h *Handler) UpdateCollection(ctx context.Context, r *connect.Request[pb.UpdateCollectionRequest]) (*connect.Response[pb.UpdateCollectionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.UpdateCollection(ctx, r.Msg)
@@ -70,7 +63,7 @@ func (h *Handler) UpdateCollection(ctx context.Context, r *connect.Request[pb.Up
 
 // DeleteCollection soft-deletes a collection.
 func (h *Handler) DeleteCollection(ctx context.Context, r *connect.Request[pb.DeleteCollectionRequest]) (*connect.Response[pb.DeleteCollectionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.DeleteCollection(ctx, r.Msg)
@@ -82,7 +75,7 @@ func (h *Handler) DeleteCollection(ctx context.Context, r *connect.Request[pb.De
 
 // ListCollections returns all collections for the organization.
 func (h *Handler) ListCollections(ctx context.Context, r *connect.Request[pb.ListCollectionsRequest]) (*connect.Response[pb.ListCollectionsResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.ListCollections(ctx, r.Msg)
@@ -94,7 +87,7 @@ func (h *Handler) ListCollections(ctx context.Context, r *connect.Request[pb.Lis
 
 // AddDevicesToCollection adds devices to a collection.
 func (h *Handler) AddDevicesToCollection(ctx context.Context, r *connect.Request[pb.AddDevicesToCollectionRequest]) (*connect.Response[pb.AddDevicesToCollectionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.AddDevicesToCollection(ctx, r.Msg)
@@ -106,7 +99,7 @@ func (h *Handler) AddDevicesToCollection(ctx context.Context, r *connect.Request
 
 // RemoveDevicesFromCollection removes devices from a collection.
 func (h *Handler) RemoveDevicesFromCollection(ctx context.Context, r *connect.Request[pb.RemoveDevicesFromCollectionRequest]) (*connect.Response[pb.RemoveDevicesFromCollectionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.RemoveDevicesFromCollection(ctx, r.Msg)
@@ -118,7 +111,7 @@ func (h *Handler) RemoveDevicesFromCollection(ctx context.Context, r *connect.Re
 
 // ListCollectionMembers returns all members of a collection.
 func (h *Handler) ListCollectionMembers(ctx context.Context, r *connect.Request[pb.ListCollectionMembersRequest]) (*connect.Response[pb.ListCollectionMembersResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.ListCollectionMembers(ctx, r.Msg)
@@ -130,7 +123,7 @@ func (h *Handler) ListCollectionMembers(ctx context.Context, r *connect.Request[
 
 // GetDeviceCollections returns all collections a device belongs to.
 func (h *Handler) GetDeviceCollections(ctx context.Context, r *connect.Request[pb.GetDeviceCollectionsRequest]) (*connect.Response[pb.GetDeviceCollectionsResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.GetDeviceCollections(ctx, r.Msg)
@@ -142,7 +135,7 @@ func (h *Handler) GetDeviceCollections(ctx context.Context, r *connect.Request[p
 
 // SetRackSlotPosition sets a device's slot position within a rack.
 func (h *Handler) SetRackSlotPosition(ctx context.Context, r *connect.Request[pb.SetRackSlotPositionRequest]) (*connect.Response[pb.SetRackSlotPositionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.SetRackSlotPosition(ctx, r.Msg)
@@ -154,7 +147,7 @@ func (h *Handler) SetRackSlotPosition(ctx context.Context, r *connect.Request[pb
 
 // ClearRackSlotPosition clears a device's slot position within a rack.
 func (h *Handler) ClearRackSlotPosition(ctx context.Context, r *connect.Request[pb.ClearRackSlotPositionRequest]) (*connect.Response[pb.ClearRackSlotPositionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.ClearRackSlotPosition(ctx, r.Msg)
@@ -166,7 +159,7 @@ func (h *Handler) ClearRackSlotPosition(ctx context.Context, r *connect.Request[
 
 // GetRackSlots lists all occupied slot positions in a rack.
 func (h *Handler) GetRackSlots(ctx context.Context, r *connect.Request[pb.GetRackSlotsRequest]) (*connect.Response[pb.GetRackSlotsResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.GetRackSlots(ctx, r.Msg)
@@ -178,7 +171,7 @@ func (h *Handler) GetRackSlots(ctx context.Context, r *connect.Request[pb.GetRac
 
 // GetCollectionStats returns aggregated telemetry stats for collections.
 func (h *Handler) GetCollectionStats(ctx context.Context, r *connect.Request[pb.GetCollectionStatsRequest]) (*connect.Response[pb.GetCollectionStatsResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.GetCollectionStats(ctx, r.Msg)
@@ -190,7 +183,7 @@ func (h *Handler) GetCollectionStats(ctx context.Context, r *connect.Request[pb.
 
 // ListRackTypes returns all distinct rack types for the organization.
 func (h *Handler) ListRackTypes(ctx context.Context, r *connect.Request[pb.ListRackTypesRequest]) (*connect.Response[pb.ListRackTypesResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.ListRackTypes(ctx, r.Msg)
@@ -202,7 +195,7 @@ func (h *Handler) ListRackTypes(ctx context.Context, r *connect.Request[pb.ListR
 
 // ListRackZones returns all distinct rack zones for the organization.
 func (h *Handler) ListRackZones(ctx context.Context, r *connect.Request[pb.ListRackZonesRequest]) (*connect.Response[pb.ListRackZonesResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.ListRackZones(ctx, r.Msg)
@@ -214,7 +207,7 @@ func (h *Handler) ListRackZones(ctx context.Context, r *connect.Request[pb.ListR
 
 // SaveRack atomically creates or updates a rack with membership and slot assignments.
 func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[pb.SaveRackRequest]) (*connect.Response[pb.SaveRackResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.collectionSvc.SaveRack(ctx, r.Msg)

--- a/server/internal/handlers/collection/handler.go
+++ b/server/internal/handlers/collection/handler.go
@@ -6,7 +6,9 @@ import (
 	"connectrpc.com/connect"
 	pb "github.com/block/proto-fleet/server/generated/grpc/collection/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/collection/v1/collectionv1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/collection"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // Handler implements the DeviceCollectionService gRPC handler.
@@ -23,8 +25,18 @@ func NewHandler(svc *collection.Service) *Handler {
 	}
 }
 
+// requirePerm gates a handler at org scope. Per-rack site narrowing
+// is deferred until the request payload surfaces the target site.
+func requirePerm(ctx context.Context, key string) error {
+	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
+	return err
+}
+
 // CreateCollection creates a new collection.
 func (h *Handler) CreateCollection(ctx context.Context, r *connect.Request[pb.CreateCollectionRequest]) (*connect.Response[pb.CreateCollectionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.CreateCollection(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -34,6 +46,9 @@ func (h *Handler) CreateCollection(ctx context.Context, r *connect.Request[pb.Cr
 
 // GetCollection retrieves a collection by ID.
 func (h *Handler) GetCollection(ctx context.Context, r *connect.Request[pb.GetCollectionRequest]) (*connect.Response[pb.GetCollectionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.GetCollection(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -43,6 +58,9 @@ func (h *Handler) GetCollection(ctx context.Context, r *connect.Request[pb.GetCo
 
 // UpdateCollection updates a collection's label and/or description.
 func (h *Handler) UpdateCollection(ctx context.Context, r *connect.Request[pb.UpdateCollectionRequest]) (*connect.Response[pb.UpdateCollectionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.UpdateCollection(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -52,6 +70,9 @@ func (h *Handler) UpdateCollection(ctx context.Context, r *connect.Request[pb.Up
 
 // DeleteCollection soft-deletes a collection.
 func (h *Handler) DeleteCollection(ctx context.Context, r *connect.Request[pb.DeleteCollectionRequest]) (*connect.Response[pb.DeleteCollectionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.DeleteCollection(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -61,6 +82,9 @@ func (h *Handler) DeleteCollection(ctx context.Context, r *connect.Request[pb.De
 
 // ListCollections returns all collections for the organization.
 func (h *Handler) ListCollections(ctx context.Context, r *connect.Request[pb.ListCollectionsRequest]) (*connect.Response[pb.ListCollectionsResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.ListCollections(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -70,6 +94,9 @@ func (h *Handler) ListCollections(ctx context.Context, r *connect.Request[pb.Lis
 
 // AddDevicesToCollection adds devices to a collection.
 func (h *Handler) AddDevicesToCollection(ctx context.Context, r *connect.Request[pb.AddDevicesToCollectionRequest]) (*connect.Response[pb.AddDevicesToCollectionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.AddDevicesToCollection(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -79,6 +106,9 @@ func (h *Handler) AddDevicesToCollection(ctx context.Context, r *connect.Request
 
 // RemoveDevicesFromCollection removes devices from a collection.
 func (h *Handler) RemoveDevicesFromCollection(ctx context.Context, r *connect.Request[pb.RemoveDevicesFromCollectionRequest]) (*connect.Response[pb.RemoveDevicesFromCollectionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.RemoveDevicesFromCollection(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -88,6 +118,9 @@ func (h *Handler) RemoveDevicesFromCollection(ctx context.Context, r *connect.Re
 
 // ListCollectionMembers returns all members of a collection.
 func (h *Handler) ListCollectionMembers(ctx context.Context, r *connect.Request[pb.ListCollectionMembersRequest]) (*connect.Response[pb.ListCollectionMembersResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.ListCollectionMembers(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -97,6 +130,9 @@ func (h *Handler) ListCollectionMembers(ctx context.Context, r *connect.Request[
 
 // GetDeviceCollections returns all collections a device belongs to.
 func (h *Handler) GetDeviceCollections(ctx context.Context, r *connect.Request[pb.GetDeviceCollectionsRequest]) (*connect.Response[pb.GetDeviceCollectionsResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.GetDeviceCollections(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -106,6 +142,9 @@ func (h *Handler) GetDeviceCollections(ctx context.Context, r *connect.Request[p
 
 // SetRackSlotPosition sets a device's slot position within a rack.
 func (h *Handler) SetRackSlotPosition(ctx context.Context, r *connect.Request[pb.SetRackSlotPositionRequest]) (*connect.Response[pb.SetRackSlotPositionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.SetRackSlotPosition(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -115,6 +154,9 @@ func (h *Handler) SetRackSlotPosition(ctx context.Context, r *connect.Request[pb
 
 // ClearRackSlotPosition clears a device's slot position within a rack.
 func (h *Handler) ClearRackSlotPosition(ctx context.Context, r *connect.Request[pb.ClearRackSlotPositionRequest]) (*connect.Response[pb.ClearRackSlotPositionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.ClearRackSlotPosition(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -124,6 +166,9 @@ func (h *Handler) ClearRackSlotPosition(ctx context.Context, r *connect.Request[
 
 // GetRackSlots lists all occupied slot positions in a rack.
 func (h *Handler) GetRackSlots(ctx context.Context, r *connect.Request[pb.GetRackSlotsRequest]) (*connect.Response[pb.GetRackSlotsResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.GetRackSlots(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -133,6 +178,9 @@ func (h *Handler) GetRackSlots(ctx context.Context, r *connect.Request[pb.GetRac
 
 // GetCollectionStats returns aggregated telemetry stats for collections.
 func (h *Handler) GetCollectionStats(ctx context.Context, r *connect.Request[pb.GetCollectionStatsRequest]) (*connect.Response[pb.GetCollectionStatsResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.GetCollectionStats(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -142,6 +190,9 @@ func (h *Handler) GetCollectionStats(ctx context.Context, r *connect.Request[pb.
 
 // ListRackTypes returns all distinct rack types for the organization.
 func (h *Handler) ListRackTypes(ctx context.Context, r *connect.Request[pb.ListRackTypesRequest]) (*connect.Response[pb.ListRackTypesResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.ListRackTypes(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -151,6 +202,9 @@ func (h *Handler) ListRackTypes(ctx context.Context, r *connect.Request[pb.ListR
 
 // ListRackZones returns all distinct rack zones for the organization.
 func (h *Handler) ListRackZones(ctx context.Context, r *connect.Request[pb.ListRackZonesRequest]) (*connect.Response[pb.ListRackZonesResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.ListRackZones(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -160,6 +214,9 @@ func (h *Handler) ListRackZones(ctx context.Context, r *connect.Request[pb.ListR
 
 // SaveRack atomically creates or updates a rack with membership and slot assignments.
 func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[pb.SaveRackRequest]) (*connect.Response[pb.SaveRackResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.collectionSvc.SaveRack(ctx, r.Msg)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/command/handler.go
+++ b/server/internal/handlers/command/handler.go
@@ -29,19 +29,11 @@ func NewHandler(commandSvc *command.Service) *Handler {
 	}
 }
 
-// requirePerm gates a handler on the supplied catalog key at org scope.
-// Per-miner site narrowing is deferred until DeviceSelector resolution
-// can surface the target miners' SiteIDs before the gate runs.
-func requirePerm(ctx context.Context, key string) error {
-	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
-	return err
-}
-
 func (h *Handler) Reboot(
 	ctx context.Context,
 	req *connect.Request[pb.RebootRequest],
 ) (*connect.Response[pb.RebootResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerReboot); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerReboot, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.Reboot(ctx, req.Msg.DeviceSelector)
@@ -55,7 +47,7 @@ func (h *Handler) StopMining(
 	ctx context.Context,
 	req *connect.Request[pb.StopMiningRequest],
 ) (*connect.Response[pb.StopMiningResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerStopMining); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerStopMining, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.StopMining(ctx, req.Msg.DeviceSelector)
@@ -69,7 +61,7 @@ func (h *Handler) StartMining(
 	ctx context.Context,
 	req *connect.Request[pb.StartMiningRequest],
 ) (*connect.Response[pb.StartMiningResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerStartMining); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerStartMining, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.StartMining(ctx, req.Msg.DeviceSelector)
@@ -83,7 +75,7 @@ func (h *Handler) SetCoolingMode(
 	ctx context.Context,
 	req *connect.Request[pb.SetCoolingModeRequest],
 ) (*connect.Response[pb.SetCoolingModeResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerSetCoolingMode); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerSetCoolingMode, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.SetCoolingMode(ctx, req.Msg.DeviceSelector, req.Msg.Mode)
@@ -97,7 +89,7 @@ func (h *Handler) SetPowerTarget(
 	ctx context.Context,
 	req *connect.Request[pb.SetPowerTargetRequest],
 ) (*connect.Response[pb.SetPowerTargetResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerSetPowerTarget); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerSetPowerTarget, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.SetPowerTarget(ctx, req.Msg.DeviceSelector, req.Msg.PerformanceMode)
@@ -111,7 +103,7 @@ func (h *Handler) UpdateMiningPools(
 	ctx context.Context,
 	req *connect.Request[pb.UpdateMiningPoolsRequest],
 ) (*connect.Response[pb.UpdateMiningPoolsResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerUpdatePools); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerUpdatePools, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.UpdateMiningPools(
@@ -181,7 +173,7 @@ func (h *Handler) DownloadLogs(
 	ctx context.Context,
 	req *connect.Request[pb.DownloadLogsRequest],
 ) (*connect.Response[pb.DownloadLogsResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerDownloadLogs); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerDownloadLogs, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.DownloadLogs(ctx, req.Msg.DeviceSelector)
@@ -192,7 +184,7 @@ func (h *Handler) DownloadLogs(
 }
 
 func (h *Handler) BlinkLED(ctx context.Context, req *connect.Request[pb.BlinkLEDRequest]) (*connect.Response[pb.BlinkLEDResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerBlinkLED); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerBlinkLED, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.BlinkLED(ctx, req.Msg.DeviceSelector)
@@ -203,7 +195,7 @@ func (h *Handler) BlinkLED(ctx context.Context, req *connect.Request[pb.BlinkLED
 }
 
 func (h *Handler) FirmwareUpdate(ctx context.Context, req *connect.Request[pb.FirmwareUpdateRequest]) (*connect.Response[pb.FirmwareUpdateResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerFirmwareUpdate); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerFirmwareUpdate, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.FirmwareUpdate(ctx, req.Msg.DeviceSelector, req.Msg.GetFirmwareFileId())
@@ -214,7 +206,7 @@ func (h *Handler) FirmwareUpdate(ctx context.Context, req *connect.Request[pb.Fi
 }
 
 func (h *Handler) Unpair(ctx context.Context, req *connect.Request[pb.UnpairRequest]) (*connect.Response[pb.UnpairResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerUnpair); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerUnpair, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.Unpair(ctx, req.Msg.DeviceSelector)
@@ -228,7 +220,7 @@ func (h *Handler) UpdateMinerPassword(
 	ctx context.Context,
 	req *connect.Request[pb.UpdateMinerPasswordRequest],
 ) (*connect.Response[pb.UpdateMinerPasswordResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerUpdatePassword); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerUpdatePassword, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.commandSvc.UpdateMinerPassword(
@@ -246,7 +238,7 @@ func (h *Handler) UpdateMinerPassword(
 }
 
 func (h *Handler) StreamCommandBatchUpdates(ctx context.Context, r *connect.Request[pb.StreamCommandBatchUpdatesRequest], stream *connect.ServerStream[pb.StreamCommandBatchUpdatesResponse]) error {
-	if err := requirePerm(ctx, authz.PermFleetRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{}); err != nil {
 		return err
 	}
 	slog.Debug("handling request to stream command batch updates", "request", r)
@@ -277,7 +269,7 @@ func (h *Handler) GetCommandBatchLogBundle(
 	ctx context.Context,
 	req *connect.Request[pb.GetCommandBatchLogBundleRequest],
 ) (*connect.Response[pb.GetCommandBatchLogBundleResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerDownloadLogs); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerDownloadLogs, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	resp, err := h.commandSvc.GetCommandBatchLogBundle(req.Msg.BatchIdentifier)
@@ -292,7 +284,7 @@ func (h *Handler) CheckCommandCapabilities(
 	ctx context.Context,
 	req *connect.Request[pb.CheckCommandCapabilitiesRequest],
 ) (*connect.Response[pb.CheckCommandCapabilitiesResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	resp, err := h.commandSvc.CheckCommandCapabilities(ctx, req.Msg)
@@ -311,7 +303,7 @@ func (h *Handler) GetCommandBatchDeviceResults(
 	ctx context.Context,
 	req *connect.Request[pb.GetCommandBatchDeviceResultsRequest],
 ) (*connect.Response[pb.GetCommandBatchDeviceResultsResponse], error) {
-	if err := requirePerm(ctx, authz.PermFleetRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	resp, err := h.commandSvc.GetCommandBatchDeviceResults(ctx, req.Msg)

--- a/server/internal/handlers/command/handler.go
+++ b/server/internal/handlers/command/handler.go
@@ -6,7 +6,9 @@ import (
 	"math"
 	"sort"
 
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 
 	"connectrpc.com/connect"
 	pb "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
@@ -27,10 +29,21 @@ func NewHandler(commandSvc *command.Service) *Handler {
 	}
 }
 
+// requirePerm gates a handler on the supplied catalog key at org scope.
+// Per-miner site narrowing is deferred until DeviceSelector resolution
+// can surface the target miners' SiteIDs before the gate runs.
+func requirePerm(ctx context.Context, key string) error {
+	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
+	return err
+}
+
 func (h *Handler) Reboot(
 	ctx context.Context,
 	req *connect.Request[pb.RebootRequest],
 ) (*connect.Response[pb.RebootResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerReboot); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.Reboot(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
@@ -42,6 +55,9 @@ func (h *Handler) StopMining(
 	ctx context.Context,
 	req *connect.Request[pb.StopMiningRequest],
 ) (*connect.Response[pb.StopMiningResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerStopMining); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.StopMining(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
@@ -53,6 +69,9 @@ func (h *Handler) StartMining(
 	ctx context.Context,
 	req *connect.Request[pb.StartMiningRequest],
 ) (*connect.Response[pb.StartMiningResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerStartMining); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.StartMining(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
@@ -64,6 +83,9 @@ func (h *Handler) SetCoolingMode(
 	ctx context.Context,
 	req *connect.Request[pb.SetCoolingModeRequest],
 ) (*connect.Response[pb.SetCoolingModeResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerSetCoolingMode); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.SetCoolingMode(ctx, req.Msg.DeviceSelector, req.Msg.Mode)
 	if err != nil {
 		return nil, err
@@ -75,6 +97,9 @@ func (h *Handler) SetPowerTarget(
 	ctx context.Context,
 	req *connect.Request[pb.SetPowerTargetRequest],
 ) (*connect.Response[pb.SetPowerTargetResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerSetPowerTarget); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.SetPowerTarget(ctx, req.Msg.DeviceSelector, req.Msg.PerformanceMode)
 	if err != nil {
 		return nil, err
@@ -86,6 +111,9 @@ func (h *Handler) UpdateMiningPools(
 	ctx context.Context,
 	req *connect.Request[pb.UpdateMiningPoolsRequest],
 ) (*connect.Response[pb.UpdateMiningPoolsResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerUpdatePools); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.UpdateMiningPools(
 		ctx,
 		req.Msg.DeviceSelector,
@@ -153,6 +181,9 @@ func (h *Handler) DownloadLogs(
 	ctx context.Context,
 	req *connect.Request[pb.DownloadLogsRequest],
 ) (*connect.Response[pb.DownloadLogsResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerDownloadLogs); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.DownloadLogs(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
@@ -161,6 +192,9 @@ func (h *Handler) DownloadLogs(
 }
 
 func (h *Handler) BlinkLED(ctx context.Context, req *connect.Request[pb.BlinkLEDRequest]) (*connect.Response[pb.BlinkLEDResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerBlinkLED); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.BlinkLED(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
@@ -169,6 +203,9 @@ func (h *Handler) BlinkLED(ctx context.Context, req *connect.Request[pb.BlinkLED
 }
 
 func (h *Handler) FirmwareUpdate(ctx context.Context, req *connect.Request[pb.FirmwareUpdateRequest]) (*connect.Response[pb.FirmwareUpdateResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerFirmwareUpdate); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.FirmwareUpdate(ctx, req.Msg.DeviceSelector, req.Msg.GetFirmwareFileId())
 	if err != nil {
 		return nil, err
@@ -177,6 +214,9 @@ func (h *Handler) FirmwareUpdate(ctx context.Context, req *connect.Request[pb.Fi
 }
 
 func (h *Handler) Unpair(ctx context.Context, req *connect.Request[pb.UnpairRequest]) (*connect.Response[pb.UnpairResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerUnpair); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.Unpair(ctx, req.Msg.DeviceSelector)
 	if err != nil {
 		return nil, err
@@ -188,6 +228,9 @@ func (h *Handler) UpdateMinerPassword(
 	ctx context.Context,
 	req *connect.Request[pb.UpdateMinerPasswordRequest],
 ) (*connect.Response[pb.UpdateMinerPasswordResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerUpdatePassword); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.UpdateMinerPassword(
 		ctx,
 		req.Msg.DeviceSelector,
@@ -203,6 +246,9 @@ func (h *Handler) UpdateMinerPassword(
 }
 
 func (h *Handler) StreamCommandBatchUpdates(ctx context.Context, r *connect.Request[pb.StreamCommandBatchUpdatesRequest], stream *connect.ServerStream[pb.StreamCommandBatchUpdatesResponse]) error {
+	if err := requirePerm(ctx, authz.PermFleetRead); err != nil {
+		return err
+	}
 	slog.Debug("handling request to stream command batch updates", "request", r)
 	responseChan, err := h.commandSvc.StreamCommandBatchUpdates(ctx, r.Msg)
 	if err != nil {
@@ -228,9 +274,12 @@ func (h *Handler) StreamCommandBatchUpdates(ctx context.Context, r *connect.Requ
 }
 
 func (h *Handler) GetCommandBatchLogBundle(
-	_ context.Context,
+	ctx context.Context,
 	req *connect.Request[pb.GetCommandBatchLogBundleRequest],
 ) (*connect.Response[pb.GetCommandBatchLogBundleResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerDownloadLogs); err != nil {
+		return nil, err
+	}
 	resp, err := h.commandSvc.GetCommandBatchLogBundle(req.Msg.BatchIdentifier)
 	if err != nil {
 		return nil, err
@@ -243,6 +292,9 @@ func (h *Handler) CheckCommandCapabilities(
 	ctx context.Context,
 	req *connect.Request[pb.CheckCommandCapabilitiesRequest],
 ) (*connect.Response[pb.CheckCommandCapabilitiesResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerRead); err != nil {
+		return nil, err
+	}
 	resp, err := h.commandSvc.CheckCommandCapabilities(ctx, req.Msg)
 	if err != nil {
 		return nil, err
@@ -259,6 +311,9 @@ func (h *Handler) GetCommandBatchDeviceResults(
 	ctx context.Context,
 	req *connect.Request[pb.GetCommandBatchDeviceResultsRequest],
 ) (*connect.Response[pb.GetCommandBatchDeviceResultsResponse], error) {
+	if err := requirePerm(ctx, authz.PermFleetRead); err != nil {
+		return nil, err
+	}
 	resp, err := h.commandSvc.GetCommandBatchDeviceResults(ctx, req.Msg)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -168,9 +168,9 @@ func (h *Handler) GetActiveCurtailment(ctx context.Context, _ *connect.Request[p
 	if h.service == nil {
 		return nil, errCurtailmentNotImplemented("GetActiveCurtailment")
 	}
-	info, err := session.GetInfo(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentRead, authz.ResourceContext{})
 	if err != nil {
-		return nil, fleeterror.NewUnauthenticatedError("authentication required")
+		return nil, err
 	}
 	event, targets, err := h.service.GetActiveWithTargets(ctx, info.OrganizationID)
 	if err != nil {

--- a/server/internal/handlers/curtailment/handler_active_test.go
+++ b/server/internal/handlers/curtailment/handler_active_test.go
@@ -1,6 +1,7 @@
 package curtailment
 
 import (
+	"context"
 	"testing"
 
 	"connectrpc.com/authn"
@@ -9,11 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/curtailment/v1"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	domainCurtailment "github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
+
+// withCurtailmentRead returns ctx wrapped with an org-scope
+// EffectivePermissions carrying PermCurtailmentRead so RequirePermission
+// in the handler clears without further setup.
+func withCurtailmentRead(ctx context.Context) context.Context {
+	eff := authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  []string{authz.PermCurtailmentRead},
+	}})
+	return middleware.WithEffectivePermissions(ctx, eff)
+}
 
 func TestHandler_GetActiveCurtailment_ReturnsActiveEvent(t *testing.T) {
 	t.Parallel()
@@ -27,7 +42,7 @@ func TestHandler_GetActiveCurtailment_ReturnsActiveEvent(t *testing.T) {
 		Role:           "OPERATOR",
 	})
 
-	resp, err := h.GetActiveCurtailment(ctx, connect.NewRequest(&pb.GetActiveCurtailmentRequest{}))
+	resp, err := h.GetActiveCurtailment(withCurtailmentRead(ctx), connect.NewRequest(&pb.GetActiveCurtailmentRequest{}))
 	require.NoError(t, err)
 	require.NotNil(t, resp.Msg.Event)
 	assert.Equal(t, store.event.EventUUID.String(), resp.Msg.Event.EventUuid)
@@ -50,7 +65,7 @@ func TestHandler_GetActiveCurtailment_ReturnsEmptyWhenNoActiveEvent(t *testing.T
 		Role:           "OPERATOR",
 	})
 
-	resp, err := h.GetActiveCurtailment(ctx, connect.NewRequest(&pb.GetActiveCurtailmentRequest{}))
+	resp, err := h.GetActiveCurtailment(withCurtailmentRead(ctx), connect.NewRequest(&pb.GetActiveCurtailmentRequest{}))
 	require.NoError(t, err)
 	assert.Nil(t, resp.Msg.Event)
 }
@@ -79,7 +94,7 @@ func TestHandler_GetActiveCurtailment_PropagatesStoreError(t *testing.T) {
 		Role:           "OPERATOR",
 	})
 
-	_, err := h.GetActiveCurtailment(ctx, connect.NewRequest(&pb.GetActiveCurtailmentRequest{}))
+	_, err := h.GetActiveCurtailment(withCurtailmentRead(ctx), connect.NewRequest(&pb.GetActiveCurtailmentRequest{}))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "db down")
 }
@@ -98,7 +113,7 @@ func TestHandler_GetActiveCurtailment_MapsRestoringEvent(t *testing.T) {
 		Role:           "OPERATOR",
 	})
 
-	resp, err := h.GetActiveCurtailment(ctx, connect.NewRequest(&pb.GetActiveCurtailmentRequest{}))
+	resp, err := h.GetActiveCurtailment(withCurtailmentRead(ctx), connect.NewRequest(&pb.GetActiveCurtailmentRequest{}))
 	require.NoError(t, err)
 	require.NotNil(t, resp.Msg.Event)
 	assert.Equal(t, pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_RESTORING, resp.Msg.Event.State)

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -8,8 +8,17 @@ import (
 	commonpb "github.com/block/proto-fleet/server/generated/grpc/common/v1"
 	dspb "github.com/block/proto-fleet/server/generated/grpc/device_set/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/device_set/v1/device_setv1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/collection"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
+
+// requirePerm gates at org scope. Per-rack site narrowing is deferred
+// until the device-set CRUD payload surfaces the target site.
+func requirePerm(ctx context.Context, key string) error {
+	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
+	return err
+}
 
 // Handler implements the DeviceSetService gRPC handler.
 // It adapts between the new DeviceSet proto types and the existing collection.Service
@@ -26,6 +35,9 @@ func NewHandler(svc *collection.Service) *Handler {
 }
 
 func (h *Handler) CreateDeviceSet(ctx context.Context, r *connect.Request[dspb.CreateDeviceSetRequest]) (*connect.Response[dspb.CreateDeviceSetResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	req := toCollectionCreateReq(r.Msg)
 	result, err := h.svc.CreateCollection(ctx, req)
 	if err != nil {
@@ -38,6 +50,9 @@ func (h *Handler) CreateDeviceSet(ctx context.Context, r *connect.Request[dspb.C
 }
 
 func (h *Handler) GetDeviceSet(ctx context.Context, r *connect.Request[dspb.GetDeviceSetRequest]) (*connect.Response[dspb.GetDeviceSetResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.GetCollection(ctx, &collectionpb.GetCollectionRequest{
 		CollectionId: r.Msg.DeviceSetId,
 	})
@@ -50,6 +65,9 @@ func (h *Handler) GetDeviceSet(ctx context.Context, r *connect.Request[dspb.GetD
 }
 
 func (h *Handler) UpdateDeviceSet(ctx context.Context, r *connect.Request[dspb.UpdateDeviceSetRequest]) (*connect.Response[dspb.UpdateDeviceSetResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	req := toCollectionUpdateReq(r.Msg)
 	result, err := h.svc.UpdateCollection(ctx, req)
 	if err != nil {
@@ -61,6 +79,9 @@ func (h *Handler) UpdateDeviceSet(ctx context.Context, r *connect.Request[dspb.U
 }
 
 func (h *Handler) DeleteDeviceSet(ctx context.Context, r *connect.Request[dspb.DeleteDeviceSetRequest]) (*connect.Response[dspb.DeleteDeviceSetResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	_, err := h.svc.DeleteCollection(ctx, &collectionpb.DeleteCollectionRequest{
 		CollectionId: r.Msg.DeviceSetId,
 	})
@@ -71,6 +92,9 @@ func (h *Handler) DeleteDeviceSet(ctx context.Context, r *connect.Request[dspb.D
 }
 
 func (h *Handler) ListDeviceSets(ctx context.Context, r *connect.Request[dspb.ListDeviceSetsRequest]) (*connect.Response[dspb.ListDeviceSetsResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	params, err := toListCollectionsParams(r.Msg)
 	if err != nil {
 		return nil, err
@@ -91,6 +115,9 @@ func (h *Handler) ListDeviceSets(ctx context.Context, r *connect.Request[dspb.Li
 }
 
 func (h *Handler) AddDevicesToDeviceSet(ctx context.Context, r *connect.Request[dspb.AddDevicesToDeviceSetRequest]) (*connect.Response[dspb.AddDevicesToDeviceSetResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.AddDevicesToCollection(ctx, &collectionpb.AddDevicesToCollectionRequest{
 		CollectionId:   r.Msg.DeviceSetId,
 		DeviceSelector: r.Msg.DeviceSelector,
@@ -106,6 +133,9 @@ func (h *Handler) AddDevicesToDeviceSet(ctx context.Context, r *connect.Request[
 }
 
 func (h *Handler) RemoveDevicesFromDeviceSet(ctx context.Context, r *connect.Request[dspb.RemoveDevicesFromDeviceSetRequest]) (*connect.Response[dspb.RemoveDevicesFromDeviceSetResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.RemoveDevicesFromCollection(ctx, &collectionpb.RemoveDevicesFromCollectionRequest{
 		CollectionId:   r.Msg.DeviceSetId,
 		DeviceSelector: r.Msg.DeviceSelector,
@@ -119,6 +149,9 @@ func (h *Handler) RemoveDevicesFromDeviceSet(ctx context.Context, r *connect.Req
 }
 
 func (h *Handler) ListDeviceSetMembers(ctx context.Context, r *connect.Request[dspb.ListDeviceSetMembersRequest]) (*connect.Response[dspb.ListDeviceSetMembersResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.ListCollectionMembers(ctx, &collectionpb.ListCollectionMembersRequest{
 		CollectionId: r.Msg.DeviceSetId,
 		PageSize:     r.Msg.PageSize,
@@ -138,6 +171,9 @@ func (h *Handler) ListDeviceSetMembers(ctx context.Context, r *connect.Request[d
 }
 
 func (h *Handler) GetDeviceDeviceSets(ctx context.Context, r *connect.Request[dspb.GetDeviceDeviceSetsRequest]) (*connect.Response[dspb.GetDeviceDeviceSetsResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.GetDeviceCollections(ctx, &collectionpb.GetDeviceCollectionsRequest{
 		DeviceIdentifier: r.Msg.DeviceIdentifier,
 		Type:             toCollectionType(r.Msg.Type),
@@ -155,6 +191,9 @@ func (h *Handler) GetDeviceDeviceSets(ctx context.Context, r *connect.Request[ds
 }
 
 func (h *Handler) SetRackSlotPosition(ctx context.Context, r *connect.Request[dspb.SetRackSlotPositionRequest]) (*connect.Response[dspb.SetRackSlotPositionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.SetRackSlotPosition(ctx, &collectionpb.SetRackSlotPositionRequest{
 		CollectionId:     r.Msg.DeviceSetId,
 		DeviceIdentifier: r.Msg.DeviceIdentifier,
@@ -170,6 +209,9 @@ func (h *Handler) SetRackSlotPosition(ctx context.Context, r *connect.Request[ds
 }
 
 func (h *Handler) ClearRackSlotPosition(ctx context.Context, r *connect.Request[dspb.ClearRackSlotPositionRequest]) (*connect.Response[dspb.ClearRackSlotPositionResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	_, err := h.svc.ClearRackSlotPosition(ctx, &collectionpb.ClearRackSlotPositionRequest{
 		CollectionId:     r.Msg.DeviceSetId,
 		DeviceIdentifier: r.Msg.DeviceIdentifier,
@@ -181,6 +223,9 @@ func (h *Handler) ClearRackSlotPosition(ctx context.Context, r *connect.Request[
 }
 
 func (h *Handler) GetRackSlots(ctx context.Context, r *connect.Request[dspb.GetRackSlotsRequest]) (*connect.Response[dspb.GetRackSlotsResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.GetRackSlots(ctx, &collectionpb.GetRackSlotsRequest{
 		CollectionId: r.Msg.DeviceSetId,
 	})
@@ -197,6 +242,9 @@ func (h *Handler) GetRackSlots(ctx context.Context, r *connect.Request[dspb.GetR
 }
 
 func (h *Handler) GetDeviceSetStats(ctx context.Context, r *connect.Request[dspb.GetDeviceSetStatsRequest]) (*connect.Response[dspb.GetDeviceSetStatsResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.GetCollectionStats(ctx, &collectionpb.GetCollectionStatsRequest{
 		CollectionIds: r.Msg.DeviceSetIds,
 	})
@@ -213,6 +261,9 @@ func (h *Handler) GetDeviceSetStats(ctx context.Context, r *connect.Request[dspb
 }
 
 func (h *Handler) ListRackZones(ctx context.Context, r *connect.Request[dspb.ListRackZonesRequest]) (*connect.Response[dspb.ListRackZonesResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.ListRackZones(ctx, &collectionpb.ListRackZonesRequest{})
 	if err != nil {
 		return nil, err
@@ -223,6 +274,9 @@ func (h *Handler) ListRackZones(ctx context.Context, r *connect.Request[dspb.Lis
 }
 
 func (h *Handler) ListRackZoneRefs(ctx context.Context, r *connect.Request[dspb.ListRackZoneRefsRequest]) (*connect.Response[dspb.ListRackZoneRefsResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	refs, err := h.svc.ListRackZoneRefs(ctx)
 	if err != nil {
 		return nil, err
@@ -243,6 +297,9 @@ func (h *Handler) ListRackZoneRefs(ctx context.Context, r *connect.Request[dspb.
 }
 
 func (h *Handler) ListRackTypes(ctx context.Context, r *connect.Request[dspb.ListRackTypesRequest]) (*connect.Response[dspb.ListRackTypesResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+		return nil, err
+	}
 	result, err := h.svc.ListRackTypes(ctx, &collectionpb.ListRackTypesRequest{})
 	if err != nil {
 		return nil, err
@@ -261,6 +318,9 @@ func (h *Handler) ListRackTypes(ctx context.Context, r *connect.Request[dspb.Lis
 }
 
 func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[dspb.SaveRackRequest]) (*connect.Response[dspb.SaveRackResponse], error) {
+	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+		return nil, err
+	}
 	req := toCollectionSaveRackReq(r.Msg)
 	result, err := h.svc.SaveRack(ctx, req)
 	if err != nil {

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -13,13 +13,6 @@ import (
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
-// requirePerm gates at org scope. Per-rack site narrowing is deferred
-// until the device-set CRUD payload surfaces the target site.
-func requirePerm(ctx context.Context, key string) error {
-	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
-	return err
-}
-
 // Handler implements the DeviceSetService gRPC handler.
 // It adapts between the new DeviceSet proto types and the existing collection.Service
 // which still uses the old Collection proto types internally.
@@ -35,7 +28,7 @@ func NewHandler(svc *collection.Service) *Handler {
 }
 
 func (h *Handler) CreateDeviceSet(ctx context.Context, r *connect.Request[dspb.CreateDeviceSetRequest]) (*connect.Response[dspb.CreateDeviceSetResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	req := toCollectionCreateReq(r.Msg)
@@ -50,7 +43,7 @@ func (h *Handler) CreateDeviceSet(ctx context.Context, r *connect.Request[dspb.C
 }
 
 func (h *Handler) GetDeviceSet(ctx context.Context, r *connect.Request[dspb.GetDeviceSetRequest]) (*connect.Response[dspb.GetDeviceSetResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.GetCollection(ctx, &collectionpb.GetCollectionRequest{
@@ -65,7 +58,7 @@ func (h *Handler) GetDeviceSet(ctx context.Context, r *connect.Request[dspb.GetD
 }
 
 func (h *Handler) UpdateDeviceSet(ctx context.Context, r *connect.Request[dspb.UpdateDeviceSetRequest]) (*connect.Response[dspb.UpdateDeviceSetResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	req := toCollectionUpdateReq(r.Msg)
@@ -79,7 +72,7 @@ func (h *Handler) UpdateDeviceSet(ctx context.Context, r *connect.Request[dspb.U
 }
 
 func (h *Handler) DeleteDeviceSet(ctx context.Context, r *connect.Request[dspb.DeleteDeviceSetRequest]) (*connect.Response[dspb.DeleteDeviceSetResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	_, err := h.svc.DeleteCollection(ctx, &collectionpb.DeleteCollectionRequest{
@@ -92,7 +85,7 @@ func (h *Handler) DeleteDeviceSet(ctx context.Context, r *connect.Request[dspb.D
 }
 
 func (h *Handler) ListDeviceSets(ctx context.Context, r *connect.Request[dspb.ListDeviceSetsRequest]) (*connect.Response[dspb.ListDeviceSetsResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	params, err := toListCollectionsParams(r.Msg)
@@ -115,7 +108,7 @@ func (h *Handler) ListDeviceSets(ctx context.Context, r *connect.Request[dspb.Li
 }
 
 func (h *Handler) AddDevicesToDeviceSet(ctx context.Context, r *connect.Request[dspb.AddDevicesToDeviceSetRequest]) (*connect.Response[dspb.AddDevicesToDeviceSetResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.AddDevicesToCollection(ctx, &collectionpb.AddDevicesToCollectionRequest{
@@ -133,7 +126,7 @@ func (h *Handler) AddDevicesToDeviceSet(ctx context.Context, r *connect.Request[
 }
 
 func (h *Handler) RemoveDevicesFromDeviceSet(ctx context.Context, r *connect.Request[dspb.RemoveDevicesFromDeviceSetRequest]) (*connect.Response[dspb.RemoveDevicesFromDeviceSetResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.RemoveDevicesFromCollection(ctx, &collectionpb.RemoveDevicesFromCollectionRequest{
@@ -149,7 +142,7 @@ func (h *Handler) RemoveDevicesFromDeviceSet(ctx context.Context, r *connect.Req
 }
 
 func (h *Handler) ListDeviceSetMembers(ctx context.Context, r *connect.Request[dspb.ListDeviceSetMembersRequest]) (*connect.Response[dspb.ListDeviceSetMembersResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.ListCollectionMembers(ctx, &collectionpb.ListCollectionMembersRequest{
@@ -171,7 +164,7 @@ func (h *Handler) ListDeviceSetMembers(ctx context.Context, r *connect.Request[d
 }
 
 func (h *Handler) GetDeviceDeviceSets(ctx context.Context, r *connect.Request[dspb.GetDeviceDeviceSetsRequest]) (*connect.Response[dspb.GetDeviceDeviceSetsResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.GetDeviceCollections(ctx, &collectionpb.GetDeviceCollectionsRequest{
@@ -191,7 +184,7 @@ func (h *Handler) GetDeviceDeviceSets(ctx context.Context, r *connect.Request[ds
 }
 
 func (h *Handler) SetRackSlotPosition(ctx context.Context, r *connect.Request[dspb.SetRackSlotPositionRequest]) (*connect.Response[dspb.SetRackSlotPositionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.SetRackSlotPosition(ctx, &collectionpb.SetRackSlotPositionRequest{
@@ -209,7 +202,7 @@ func (h *Handler) SetRackSlotPosition(ctx context.Context, r *connect.Request[ds
 }
 
 func (h *Handler) ClearRackSlotPosition(ctx context.Context, r *connect.Request[dspb.ClearRackSlotPositionRequest]) (*connect.Response[dspb.ClearRackSlotPositionResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	_, err := h.svc.ClearRackSlotPosition(ctx, &collectionpb.ClearRackSlotPositionRequest{
@@ -223,7 +216,7 @@ func (h *Handler) ClearRackSlotPosition(ctx context.Context, r *connect.Request[
 }
 
 func (h *Handler) GetRackSlots(ctx context.Context, r *connect.Request[dspb.GetRackSlotsRequest]) (*connect.Response[dspb.GetRackSlotsResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.GetRackSlots(ctx, &collectionpb.GetRackSlotsRequest{
@@ -242,7 +235,7 @@ func (h *Handler) GetRackSlots(ctx context.Context, r *connect.Request[dspb.GetR
 }
 
 func (h *Handler) GetDeviceSetStats(ctx context.Context, r *connect.Request[dspb.GetDeviceSetStatsRequest]) (*connect.Response[dspb.GetDeviceSetStatsResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.GetCollectionStats(ctx, &collectionpb.GetCollectionStatsRequest{
@@ -261,7 +254,7 @@ func (h *Handler) GetDeviceSetStats(ctx context.Context, r *connect.Request[dspb
 }
 
 func (h *Handler) ListRackZones(ctx context.Context, r *connect.Request[dspb.ListRackZonesRequest]) (*connect.Response[dspb.ListRackZonesResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.ListRackZones(ctx, &collectionpb.ListRackZonesRequest{})
@@ -274,7 +267,7 @@ func (h *Handler) ListRackZones(ctx context.Context, r *connect.Request[dspb.Lis
 }
 
 func (h *Handler) ListRackZoneRefs(ctx context.Context, r *connect.Request[dspb.ListRackZoneRefsRequest]) (*connect.Response[dspb.ListRackZoneRefsResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	refs, err := h.svc.ListRackZoneRefs(ctx)
@@ -297,7 +290,7 @@ func (h *Handler) ListRackZoneRefs(ctx context.Context, r *connect.Request[dspb.
 }
 
 func (h *Handler) ListRackTypes(ctx context.Context, r *connect.Request[dspb.ListRackTypesRequest]) (*connect.Response[dspb.ListRackTypesResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.svc.ListRackTypes(ctx, &collectionpb.ListRackTypesRequest{})
@@ -318,7 +311,7 @@ func (h *Handler) ListRackTypes(ctx context.Context, r *connect.Request[dspb.Lis
 }
 
 func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[dspb.SaveRackRequest]) (*connect.Response[dspb.SaveRackResponse], error) {
-	if err := requirePerm(ctx, authz.PermRackManage); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	req := toCollectionSaveRackReq(r.Msg)

--- a/server/internal/handlers/errorquery/handler.go
+++ b/server/internal/handlers/errorquery/handler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/diagnostics"
 	"github.com/block/proto-fleet/server/internal/domain/diagnostics/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
-	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
@@ -33,20 +32,12 @@ func NewHandler(diagnosticsService *diagnostics.Service) *Handler {
 	}
 }
 
-// requireFleetRead is the read gate for every ErrorQueryService method.
-// Diagnostics are scoped to the caller's organization; the gate runs
-// before any service call to fail closed on missing session / missing
-// effective permissions.
-func requireFleetRead(ctx context.Context) (*session.Info, error) {
-	return middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{})
-}
-
 // Query handles the Query RPC call.
 func (h *Handler) Query(
 	ctx context.Context,
 	req *connect.Request[errorsv1.QueryRequest],
 ) (*connect.Response[errorsv1.QueryResponse], error) {
-	info, err := requireFleetRead(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +64,7 @@ func (h *Handler) GetError(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("error_id is required"))
 	}
 
-	info, err := requireFleetRead(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +89,7 @@ func (h *Handler) ListMinerErrors(
 	ctx context.Context,
 	_ *connect.Request[errorsv1.ListMinerErrorsRequest],
 ) (*connect.Response[errorsv1.ListMinerErrorsResponse], error) {
-	if _, err := requireFleetRead(ctx); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	metadata := h.diagnosticsService.ListMinerErrors(ctx)
@@ -131,7 +122,7 @@ func (h *Handler) Watch(
 	req *connect.Request[errorsv1.WatchRequest],
 	stream *connect.ServerStream[errorsv1.WatchResponse],
 ) error {
-	info, err := requireFleetRead(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{})
 	if err != nil {
 		return err
 	}

--- a/server/internal/handlers/errorquery/handler.go
+++ b/server/internal/handlers/errorquery/handler.go
@@ -10,10 +10,12 @@ import (
 
 	errorsv1 "github.com/block/proto-fleet/server/generated/grpc/errors/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/errors/v1/errorsv1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/diagnostics"
 	"github.com/block/proto-fleet/server/internal/domain/diagnostics/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // Ensure Handler implements the service interface.
@@ -31,13 +33,12 @@ func NewHandler(diagnosticsService *diagnostics.Service) *Handler {
 	}
 }
 
-// getSessionInfo retrieves session information from the context and returns an authentication error if not present.
-func getSessionInfo(ctx context.Context) (*session.Info, error) {
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeUnauthenticated, err)
-	}
-	return info, nil
+// requireFleetRead is the read gate for every ErrorQueryService method.
+// Diagnostics are scoped to the caller's organization; the gate runs
+// before any service call to fail closed on missing session / missing
+// effective permissions.
+func requireFleetRead(ctx context.Context) (*session.Info, error) {
+	return middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{})
 }
 
 // Query handles the Query RPC call.
@@ -45,7 +46,7 @@ func (h *Handler) Query(
 	ctx context.Context,
 	req *connect.Request[errorsv1.QueryRequest],
 ) (*connect.Response[errorsv1.QueryResponse], error) {
-	info, err := getSessionInfo(ctx)
+	info, err := requireFleetRead(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +73,7 @@ func (h *Handler) GetError(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("error_id is required"))
 	}
 
-	info, err := getSessionInfo(ctx)
+	info, err := requireFleetRead(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -97,6 +98,9 @@ func (h *Handler) ListMinerErrors(
 	ctx context.Context,
 	_ *connect.Request[errorsv1.ListMinerErrorsRequest],
 ) (*connect.Response[errorsv1.ListMinerErrorsResponse], error) {
+	if _, err := requireFleetRead(ctx); err != nil {
+		return nil, err
+	}
 	metadata := h.diagnosticsService.ListMinerErrors(ctx)
 
 	var items []*errorsv1.MinerErrorInfo
@@ -127,7 +131,7 @@ func (h *Handler) Watch(
 	req *connect.Request[errorsv1.WatchRequest],
 	stream *connect.ServerStream[errorsv1.WatchResponse],
 ) error {
-	info, err := getSessionInfo(ctx)
+	info, err := requireFleetRead(ctx)
 	if err != nil {
 		return err
 	}

--- a/server/internal/handlers/errorquery/handler_test.go
+++ b/server/internal/handlers/errorquery/handler_test.go
@@ -2,10 +2,10 @@ package errorquery
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
-	"connectrpc.com/authn"
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -14,8 +14,8 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/diagnostics"
 	"github.com/block/proto-fleet/server/internal/domain/diagnostics/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
-	"github.com/block/proto-fleet/server/internal/domain/session"
 	storesMocks "github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
+	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
 const (
@@ -29,13 +29,7 @@ const (
 var testTime = time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 
 func setupTestContext() context.Context {
-	ctx := context.Background()
-	info := &session.Info{
-		SessionID:      testSessionID,
-		UserID:         testUserID,
-		OrganizationID: testOrgID,
-	}
-	return authn.SetInfo(ctx, info)
+	return testutil.MockAuthContextForTesting(context.Background(), testUserID, testOrgID)
 }
 
 func createTestErrorMessage() *models.ErrorMessage {
@@ -121,7 +115,7 @@ func TestHandler_GetError(t *testing.T) {
 			setupContext:  context.Background, // No session info
 			expectedError: true,
 			expectedCode:  connect.CodeUnauthenticated,
-			errorContains: "Context does not have session info",
+			errorContains: "authentication required",
 		},
 		{
 			name: "error not found",
@@ -218,11 +212,18 @@ func TestHandler_GetError(t *testing.T) {
 				require.Error(t, err)
 				require.Nil(t, resp)
 
-				var connectErr *connect.Error
-				require.ErrorAs(t, err, &connectErr)
-				require.Equal(t, tt.expectedCode, connectErr.Code())
-				if tt.errorContains != "" {
-					require.Contains(t, connectErr.Message(), tt.errorContains)
+				var fleetErr fleeterror.FleetError
+				if connectErr := new(connect.Error); errors.As(err, &connectErr) {
+					require.Equal(t, tt.expectedCode, connectErr.Code())
+					if tt.errorContains != "" {
+						require.Contains(t, connectErr.Message(), tt.errorContains)
+					}
+				} else {
+					require.ErrorAs(t, err, &fleetErr)
+					require.Equal(t, tt.expectedCode, fleetErr.GRPCCode)
+					if tt.errorContains != "" {
+						require.Contains(t, err.Error(), tt.errorContains)
+					}
 				}
 			} else {
 				require.NoError(t, err)

--- a/server/internal/handlers/fleetmanagement/handler.go
+++ b/server/internal/handlers/fleetmanagement/handler.go
@@ -6,7 +6,9 @@ import (
 	"connectrpc.com/connect"
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1/fleetmanagementv1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleetmanagement"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // Handler handles the Connect-RPC endpoints
@@ -22,7 +24,19 @@ func NewHandler(fleetMgmtSvc *fleetmanagement.Service) *Handler {
 	}
 }
 
+// requirePerm is a local thin wrapper so each handler reads as
+// "gate then service call" without three lines of boilerplate.
+// ResourceContext is always empty here: per-miner site narrowing is
+// deferred until DeviceSelector resolution lands.
+func requirePerm(ctx context.Context, key string) error {
+	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
+	return err
+}
+
 func (h *Handler) ListMinerStateSnapshots(ctx context.Context, r *connect.Request[pb.ListMinerStateSnapshotsRequest]) (*connect.Response[pb.ListMinerStateSnapshotsResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerRead); err != nil {
+		return nil, err
+	}
 	result, err := h.fleetMgmtSvc.ListMinerStateSnapshots(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -32,12 +46,18 @@ func (h *Handler) ListMinerStateSnapshots(ctx context.Context, r *connect.Reques
 }
 
 func (h *Handler) ExportMinerListCsv(ctx context.Context, r *connect.Request[pb.ExportMinerListCsvRequest], stream *connect.ServerStream[pb.ExportMinerListCsvResponse]) error {
+	if err := requirePerm(ctx, authz.PermMinerExportCSV); err != nil {
+		return err
+	}
 	return h.fleetMgmtSvc.ExportMinerListCsv(ctx, r.Msg, func(chunk *pb.ExportMinerListCsvResponse) error {
 		return stream.Send(chunk)
 	})
 }
 
 func (h *Handler) GetMinerStateCounts(ctx context.Context, r *connect.Request[pb.GetMinerStateCountsRequest]) (*connect.Response[pb.GetMinerStateCountsResponse], error) {
+	if err := requirePerm(ctx, authz.PermFleetRead); err != nil {
+		return nil, err
+	}
 	result, err := h.fleetMgmtSvc.GetMinerStateCounts(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -47,6 +67,9 @@ func (h *Handler) GetMinerStateCounts(ctx context.Context, r *connect.Request[pb
 }
 
 func (h *Handler) GetMinerPoolAssignments(ctx context.Context, r *connect.Request[pb.GetMinerPoolAssignmentsRequest]) (*connect.Response[pb.GetMinerPoolAssignmentsResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerRead); err != nil {
+		return nil, err
+	}
 	result, err := h.fleetMgmtSvc.GetMinerPoolAssignments(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -56,6 +79,9 @@ func (h *Handler) GetMinerPoolAssignments(ctx context.Context, r *connect.Reques
 }
 
 func (h *Handler) GetMinerCoolingMode(ctx context.Context, r *connect.Request[pb.GetMinerCoolingModeRequest]) (*connect.Response[pb.GetMinerCoolingModeResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerRead); err != nil {
+		return nil, err
+	}
 	result, err := h.fleetMgmtSvc.GetMinerCoolingMode(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -65,6 +91,9 @@ func (h *Handler) GetMinerCoolingMode(ctx context.Context, r *connect.Request[pb
 }
 
 func (h *Handler) DeleteMiners(ctx context.Context, r *connect.Request[pb.DeleteMinersRequest]) (*connect.Response[pb.DeleteMinersResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerDelete); err != nil {
+		return nil, err
+	}
 	result, err := h.fleetMgmtSvc.DeleteMiners(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -74,6 +103,9 @@ func (h *Handler) DeleteMiners(ctx context.Context, r *connect.Request[pb.Delete
 }
 
 func (h *Handler) GetMinerModelGroups(ctx context.Context, r *connect.Request[pb.GetMinerModelGroupsRequest]) (*connect.Response[pb.GetMinerModelGroupsResponse], error) {
+	if err := requirePerm(ctx, authz.PermFleetRead); err != nil {
+		return nil, err
+	}
 	result, err := h.fleetMgmtSvc.GetMinerModelGroups(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -83,6 +115,9 @@ func (h *Handler) GetMinerModelGroups(ctx context.Context, r *connect.Request[pb
 }
 
 func (h *Handler) RenameMiners(ctx context.Context, r *connect.Request[pb.RenameMinersRequest]) (*connect.Response[pb.RenameMinersResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerRename); err != nil {
+		return nil, err
+	}
 	result, err := h.fleetMgmtSvc.RenameMiners(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -92,6 +127,9 @@ func (h *Handler) RenameMiners(ctx context.Context, r *connect.Request[pb.Rename
 }
 
 func (h *Handler) UpdateWorkerNames(ctx context.Context, r *connect.Request[pb.UpdateWorkerNamesRequest]) (*connect.Response[pb.UpdateWorkerNamesResponse], error) {
+	if err := requirePerm(ctx, authz.PermMinerUpdateWorkerName); err != nil {
+		return nil, err
+	}
 	result, err := h.fleetMgmtSvc.UpdateWorkerNames(ctx, r.Msg)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/fleetmanagement/handler.go
+++ b/server/internal/handlers/fleetmanagement/handler.go
@@ -24,17 +24,8 @@ func NewHandler(fleetMgmtSvc *fleetmanagement.Service) *Handler {
 	}
 }
 
-// requirePerm is a local thin wrapper so each handler reads as
-// "gate then service call" without three lines of boilerplate.
-// ResourceContext is always empty here: per-miner site narrowing is
-// deferred until DeviceSelector resolution lands.
-func requirePerm(ctx context.Context, key string) error {
-	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
-	return err
-}
-
 func (h *Handler) ListMinerStateSnapshots(ctx context.Context, r *connect.Request[pb.ListMinerStateSnapshotsRequest]) (*connect.Response[pb.ListMinerStateSnapshotsResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.fleetMgmtSvc.ListMinerStateSnapshots(ctx, r.Msg)
@@ -46,7 +37,7 @@ func (h *Handler) ListMinerStateSnapshots(ctx context.Context, r *connect.Reques
 }
 
 func (h *Handler) ExportMinerListCsv(ctx context.Context, r *connect.Request[pb.ExportMinerListCsvRequest], stream *connect.ServerStream[pb.ExportMinerListCsvResponse]) error {
-	if err := requirePerm(ctx, authz.PermMinerExportCSV); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerExportCSV, authz.ResourceContext{}); err != nil {
 		return err
 	}
 	return h.fleetMgmtSvc.ExportMinerListCsv(ctx, r.Msg, func(chunk *pb.ExportMinerListCsvResponse) error {
@@ -55,7 +46,7 @@ func (h *Handler) ExportMinerListCsv(ctx context.Context, r *connect.Request[pb.
 }
 
 func (h *Handler) GetMinerStateCounts(ctx context.Context, r *connect.Request[pb.GetMinerStateCountsRequest]) (*connect.Response[pb.GetMinerStateCountsResponse], error) {
-	if err := requirePerm(ctx, authz.PermFleetRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.fleetMgmtSvc.GetMinerStateCounts(ctx, r.Msg)
@@ -67,7 +58,7 @@ func (h *Handler) GetMinerStateCounts(ctx context.Context, r *connect.Request[pb
 }
 
 func (h *Handler) GetMinerPoolAssignments(ctx context.Context, r *connect.Request[pb.GetMinerPoolAssignmentsRequest]) (*connect.Response[pb.GetMinerPoolAssignmentsResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.fleetMgmtSvc.GetMinerPoolAssignments(ctx, r.Msg)
@@ -79,7 +70,7 @@ func (h *Handler) GetMinerPoolAssignments(ctx context.Context, r *connect.Reques
 }
 
 func (h *Handler) GetMinerCoolingMode(ctx context.Context, r *connect.Request[pb.GetMinerCoolingModeRequest]) (*connect.Response[pb.GetMinerCoolingModeResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.fleetMgmtSvc.GetMinerCoolingMode(ctx, r.Msg)
@@ -91,7 +82,7 @@ func (h *Handler) GetMinerCoolingMode(ctx context.Context, r *connect.Request[pb
 }
 
 func (h *Handler) DeleteMiners(ctx context.Context, r *connect.Request[pb.DeleteMinersRequest]) (*connect.Response[pb.DeleteMinersResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerDelete); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerDelete, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.fleetMgmtSvc.DeleteMiners(ctx, r.Msg)
@@ -103,7 +94,7 @@ func (h *Handler) DeleteMiners(ctx context.Context, r *connect.Request[pb.Delete
 }
 
 func (h *Handler) GetMinerModelGroups(ctx context.Context, r *connect.Request[pb.GetMinerModelGroupsRequest]) (*connect.Response[pb.GetMinerModelGroupsResponse], error) {
-	if err := requirePerm(ctx, authz.PermFleetRead); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.fleetMgmtSvc.GetMinerModelGroups(ctx, r.Msg)
@@ -115,7 +106,7 @@ func (h *Handler) GetMinerModelGroups(ctx context.Context, r *connect.Request[pb
 }
 
 func (h *Handler) RenameMiners(ctx context.Context, r *connect.Request[pb.RenameMinersRequest]) (*connect.Response[pb.RenameMinersResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerRename); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerRename, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.fleetMgmtSvc.RenameMiners(ctx, r.Msg)
@@ -127,7 +118,7 @@ func (h *Handler) RenameMiners(ctx context.Context, r *connect.Request[pb.Rename
 }
 
 func (h *Handler) UpdateWorkerNames(ctx context.Context, r *connect.Request[pb.UpdateWorkerNamesRequest]) (*connect.Response[pb.UpdateWorkerNamesResponse], error) {
-	if err := requirePerm(ctx, authz.PermMinerUpdateWorkerName); err != nil {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerUpdateWorkerName, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
 	result, err := h.fleetMgmtSvc.UpdateWorkerNames(ctx, r.Msg)

--- a/server/internal/handlers/foremanimport/handler.go
+++ b/server/internal/handlers/foremanimport/handler.go
@@ -49,6 +49,13 @@ func (h *Handler) CompleteImport(ctx context.Context, r *connect.Request[pb.Comp
 	if _, err := middleware.RequirePermission(ctx, authz.PermMinerPair, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
+	// ImportGroups/ImportRacks branches create rack/group collections, so
+	// they need the same authority as direct rack mutations.
+	if r.Msg.GetImportGroups() || r.Msg.GetImportRacks() {
+		if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
+			return nil, err
+		}
+	}
 	if err := validateCredentials(r.Msg.Credentials); err != nil {
 		return nil, err
 	}

--- a/server/internal/handlers/foremanimport/handler.go
+++ b/server/internal/handlers/foremanimport/handler.go
@@ -6,8 +6,10 @@ import (
 	"connectrpc.com/connect"
 	pb "github.com/block/proto-fleet/server/generated/grpc/foremanimport/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/foremanimport/v1/foremanimportv1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	domain "github.com/block/proto-fleet/server/internal/domain/foremanimport"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 type Handler struct {
@@ -28,6 +30,9 @@ func validateCredentials(creds *pb.ForemanCredentials) error {
 }
 
 func (h *Handler) ImportFromForeman(ctx context.Context, r *connect.Request[pb.ImportFromForemanRequest]) (*connect.Response[pb.ImportFromForemanResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerPair, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	if err := validateCredentials(r.Msg.Credentials); err != nil {
 		return nil, err
 	}
@@ -41,6 +46,9 @@ func (h *Handler) ImportFromForeman(ctx context.Context, r *connect.Request[pb.I
 }
 
 func (h *Handler) CompleteImport(ctx context.Context, r *connect.Request[pb.CompleteImportRequest]) (*connect.Response[pb.CompleteImportResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerPair, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	if err := validateCredentials(r.Msg.Credentials); err != nil {
 		return nil, err
 	}

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -45,11 +45,6 @@ import (
 // glance: shrinking ProceduresPendingMigration to zero is the exit
 // criterion for retiring the legacy RequireAdmin middleware.
 var ProcedurePermissions = map[string]string{
-	// Populated as handler callsites swap from legacy gates to
-	// RequirePermission. Empty entries are expected while the
-	// migration is in flight; the contract test catches missing
-	// classifications either way.
-
 	// API key management — gated by RequirePermission(PermAPIKeyManage).
 	apikeyv1connect.ApiKeyServiceCreateApiKeyProcedure: authz.PermAPIKeyManage,
 	apikeyv1connect.ApiKeyServiceListApiKeysProcedure:  authz.PermAPIKeyManage,
@@ -73,10 +68,72 @@ var ProcedurePermissions = map[string]string{
 	buildingsv1connect.BuildingServiceUpdateBuildingProcedure: authz.PermSiteManage,
 	buildingsv1connect.BuildingServiceDeleteBuildingProcedure: authz.PermSiteManage,
 
-	// CurtailmentService — only AdminTerminateEvent moves in this swap.
-	// Start/Stop/Preview retain their conditional inline gates pending
-	// the broader curtailment authz redesign.
-	curtailmentv1connect.CurtailmentServiceAdminTerminateEventProcedure: authz.PermCurtailmentManage,
+	// CurtailmentService — reads + AdminTerminateEvent + UpdateCurtailmentEvent.
+	// Start/Stop/Preview retain conditional inline gates pending a redesign.
+	curtailmentv1connect.CurtailmentServiceListCurtailmentEventsProcedure:  authz.PermCurtailmentRead,
+	curtailmentv1connect.CurtailmentServiceGetActiveCurtailmentProcedure:   authz.PermCurtailmentRead,
+	curtailmentv1connect.CurtailmentServiceUpdateCurtailmentEventProcedure: authz.PermCurtailmentManage,
+	curtailmentv1connect.CurtailmentServiceAdminTerminateEventProcedure:    authz.PermCurtailmentManage,
+
+	// DeviceCollectionService — rack:read for reads, rack:manage for writes.
+	// Collections are the legacy name for racks; the wire surface still
+	// carries Collection-prefixed names while the domain has been
+	// renamed.
+	collectionv1connect.DeviceCollectionServiceGetCollectionProcedure:               authz.PermRackRead,
+	collectionv1connect.DeviceCollectionServiceGetCollectionStatsProcedure:          authz.PermRackRead,
+	collectionv1connect.DeviceCollectionServiceListCollectionsProcedure:             authz.PermRackRead,
+	collectionv1connect.DeviceCollectionServiceListCollectionMembersProcedure:       authz.PermRackRead,
+	collectionv1connect.DeviceCollectionServiceGetDeviceCollectionsProcedure:        authz.PermRackRead,
+	collectionv1connect.DeviceCollectionServiceListRackTypesProcedure:               authz.PermRackRead,
+	collectionv1connect.DeviceCollectionServiceListRackZonesProcedure:               authz.PermRackRead,
+	collectionv1connect.DeviceCollectionServiceGetRackSlotsProcedure:                authz.PermRackRead,
+	collectionv1connect.DeviceCollectionServiceCreateCollectionProcedure:            authz.PermRackManage,
+	collectionv1connect.DeviceCollectionServiceUpdateCollectionProcedure:            authz.PermRackManage,
+	collectionv1connect.DeviceCollectionServiceDeleteCollectionProcedure:            authz.PermRackManage,
+	collectionv1connect.DeviceCollectionServiceAddDevicesToCollectionProcedure:      authz.PermRackManage,
+	collectionv1connect.DeviceCollectionServiceRemoveDevicesFromCollectionProcedure: authz.PermRackManage,
+	collectionv1connect.DeviceCollectionServiceSaveRackProcedure:                    authz.PermRackManage,
+	collectionv1connect.DeviceCollectionServiceSetRackSlotPositionProcedure:         authz.PermRackManage,
+	collectionv1connect.DeviceCollectionServiceClearRackSlotPositionProcedure:       authz.PermRackManage,
+
+	// DeviceSetService (racks via the new wire surface) — same mapping
+	// as DeviceCollectionService; the handler is a proto-adapter shim.
+	device_setv1connect.DeviceSetServiceGetDeviceSetProcedure:               authz.PermRackRead,
+	device_setv1connect.DeviceSetServiceGetDeviceSetStatsProcedure:          authz.PermRackRead,
+	device_setv1connect.DeviceSetServiceListDeviceSetsProcedure:             authz.PermRackRead,
+	device_setv1connect.DeviceSetServiceListDeviceSetMembersProcedure:       authz.PermRackRead,
+	device_setv1connect.DeviceSetServiceGetDeviceDeviceSetsProcedure:        authz.PermRackRead,
+	device_setv1connect.DeviceSetServiceListRackTypesProcedure:              authz.PermRackRead,
+	device_setv1connect.DeviceSetServiceListRackZonesProcedure:              authz.PermRackRead,
+	device_setv1connect.DeviceSetServiceListRackZoneRefsProcedure:           authz.PermRackRead,
+	device_setv1connect.DeviceSetServiceGetRackSlotsProcedure:               authz.PermRackRead,
+	device_setv1connect.DeviceSetServiceCreateDeviceSetProcedure:            authz.PermRackManage,
+	device_setv1connect.DeviceSetServiceUpdateDeviceSetProcedure:            authz.PermRackManage,
+	device_setv1connect.DeviceSetServiceDeleteDeviceSetProcedure:            authz.PermRackManage,
+	device_setv1connect.DeviceSetServiceAddDevicesToDeviceSetProcedure:      authz.PermRackManage,
+	device_setv1connect.DeviceSetServiceRemoveDevicesFromDeviceSetProcedure: authz.PermRackManage,
+	device_setv1connect.DeviceSetServiceSaveRackProcedure:                   authz.PermRackManage,
+	device_setv1connect.DeviceSetServiceSetRackSlotPositionProcedure:        authz.PermRackManage,
+	device_setv1connect.DeviceSetServiceClearRackSlotPositionProcedure:      authz.PermRackManage,
+
+	// ErrorQueryService — fleet:read; diagnostics are scoped to the org
+	// and live alongside the fleet dashboard.
+	errorsv1connect.ErrorQueryServiceGetErrorProcedure:        authz.PermFleetRead,
+	errorsv1connect.ErrorQueryServiceQueryProcedure:           authz.PermFleetRead,
+	errorsv1connect.ErrorQueryServiceListMinerErrorsProcedure: authz.PermFleetRead,
+	errorsv1connect.ErrorQueryServiceWatchProcedure:           authz.PermFleetRead,
+
+	// FleetManagementService — list/read against fleet/miner reads,
+	// mutations against matching miner action keys.
+	fleetmanagementv1connect.FleetManagementServiceListMinerStateSnapshotsProcedure: authz.PermMinerRead,
+	fleetmanagementv1connect.FleetManagementServiceGetMinerPoolAssignmentsProcedure: authz.PermMinerRead,
+	fleetmanagementv1connect.FleetManagementServiceGetMinerCoolingModeProcedure:     authz.PermMinerRead,
+	fleetmanagementv1connect.FleetManagementServiceGetMinerStateCountsProcedure:     authz.PermFleetRead,
+	fleetmanagementv1connect.FleetManagementServiceGetMinerModelGroupsProcedure:     authz.PermFleetRead,
+	fleetmanagementv1connect.FleetManagementServiceUpdateWorkerNamesProcedure:       authz.PermMinerUpdateWorkerName,
+	fleetmanagementv1connect.FleetManagementServiceRenameMinersProcedure:            authz.PermMinerRename,
+	fleetmanagementv1connect.FleetManagementServiceDeleteMinersProcedure:            authz.PermMinerDelete,
+	fleetmanagementv1connect.FleetManagementServiceExportMinerListCsvProcedure:      authz.PermMinerExportCSV,
 
 	// FleetNodeAdminService — read for List, manage for the rest.
 	// Pair/Unpair/ListFleetNodeDevices/DiscoverOnFleetNode remain
@@ -85,6 +142,43 @@ var ProcedurePermissions = map[string]string{
 	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodesProcedure:       authz.PermFleetnodeRead,
 	fleetnodeadminv1connect.FleetNodeAdminServiceConfirmFleetNodeProcedure:     authz.PermFleetnodeManage,
 	fleetnodeadminv1connect.FleetNodeAdminServiceRevokeFleetNodeProcedure:      authz.PermFleetnodeManage,
+
+	// ForemanImportService — bulk miner import flow. Gated on
+	// miner:pair, the same key as the per-miner pairing endpoints —
+	// Foreman import is "pair N miners we found out-of-band."
+	foremanimportv1connect.ForemanImportServiceImportFromForemanProcedure: authz.PermMinerPair,
+	foremanimportv1connect.ForemanImportServiceCompleteImportProcedure:    authz.PermMinerPair,
+
+	// MinerCommandService — each action gates on its matching catalog
+	// key. Stream/batch endpoints gate on fleet:read since they're
+	// status surfaces.
+	minercommandv1connect.MinerCommandServiceBlinkLEDProcedure:                     authz.PermMinerBlinkLED,
+	minercommandv1connect.MinerCommandServiceRebootProcedure:                       authz.PermMinerReboot,
+	minercommandv1connect.MinerCommandServiceStartMiningProcedure:                  authz.PermMinerStartMining,
+	minercommandv1connect.MinerCommandServiceStopMiningProcedure:                   authz.PermMinerStopMining,
+	minercommandv1connect.MinerCommandServiceUpdateMiningPoolsProcedure:            authz.PermMinerUpdatePools,
+	minercommandv1connect.MinerCommandServiceSetCoolingModeProcedure:               authz.PermMinerSetCoolingMode,
+	minercommandv1connect.MinerCommandServiceSetPowerTargetProcedure:               authz.PermMinerSetPowerTarget,
+	minercommandv1connect.MinerCommandServiceFirmwareUpdateProcedure:               authz.PermMinerFirmwareUpdate,
+	minercommandv1connect.MinerCommandServiceDownloadLogsProcedure:                 authz.PermMinerDownloadLogs,
+	minercommandv1connect.MinerCommandServiceUpdateMinerPasswordProcedure:          authz.PermMinerUpdatePassword,
+	minercommandv1connect.MinerCommandServiceUnpairProcedure:                       authz.PermMinerUnpair,
+	minercommandv1connect.MinerCommandServiceCheckCommandCapabilitiesProcedure:     authz.PermMinerRead,
+	minercommandv1connect.MinerCommandServiceGetCommandBatchDeviceResultsProcedure: authz.PermFleetRead,
+	minercommandv1connect.MinerCommandServiceGetCommandBatchLogBundleProcedure:     authz.PermMinerDownloadLogs,
+	minercommandv1connect.MinerCommandServiceStreamCommandBatchUpdatesProcedure:    authz.PermFleetRead,
+
+	// NetworkInfoService — site network discovery + nickname.
+	networkinfov1connect.NetworkInfoServiceGetNetworkInfoProcedure:        authz.PermSiteRead,
+	networkinfov1connect.NetworkInfoServiceUpdateNetworkNicknameProcedure: authz.PermSiteManage,
+
+	// OnboardingService — fleet-init status. Other onboarding procedures
+	// are unauthenticated (covered by UnauthenticatedProcedures).
+	onboardingv1connect.OnboardingServiceGetFleetOnboardingStatusProcedure: authz.PermFleetRead,
+
+	// PairingService — discovery + pair.
+	pairingv1connect.PairingServiceDiscoverProcedure: authz.PermMinerPair,
+	pairingv1connect.PairingServicePairProcedure:     authz.PermMinerPair,
 
 	// ServerLogService — gated by PermServerlogRead.
 	serverlogv1connect.ServerLogServiceListServerLogsProcedure: authz.PermServerlogRead,
@@ -96,13 +190,17 @@ var ProcedurePermissions = map[string]string{
 	sitesv1connect.SiteServiceDeleteSiteProcedure:            authz.PermSiteManage,
 	sitesv1connect.SiteServiceReassignDevicesToSiteProcedure: authz.PermSiteManage,
 	sitesv1connect.SiteServiceAssignBuildingToSiteProcedure:  authz.PermSiteManage,
+
+	// TelemetryService — fleet:read for combined-metrics surfaces.
+	telemetryv1connect.TelemetryServiceGetCombinedMetricsProcedure:          authz.PermFleetRead,
+	telemetryv1connect.TelemetryServiceStreamCombinedMetricUpdatesProcedure: authz.PermFleetRead,
 }
 
 // ProceduresPendingMigration lists authenticated Connect procedures that
 // have not yet migrated to RequirePermission. The map value is a
 // brief note about the procedure's current gate — the legacy
-// RequireAdmin middleware, an inline role-string check, or (for
-// command, fleetmanagement, deviceset) no gate at all.
+// RequireAdmin middleware, an inline role-string check, or no gate
+// at all.
 //
 // Adding entries to this map is a regression: every new RPC SHOULD
 // declare its catalog key in ProcedurePermissions from the moment it
@@ -111,7 +209,9 @@ var ProcedurePermissions = map[string]string{
 // "intentional pending entry" and "shipped without thinking about
 // authz." Reviewers should treat any growth here as a red flag.
 var ProceduresPendingMigration = map[string]string{
-	// Activity log reads — currently authenticated but ungated.
+	// Activity log reads — currently authenticated but ungated. Needs a
+	// new activity:read catalog key + ADMIN backfill migration; deferred
+	// from the new-gate slice.
 	activityv1connect.ActivityServiceListActivitiesProcedure:            "ungated; read-only activity log",
 	activityv1connect.ActivityServiceExportActivitiesProcedure:          "ungated; activity log CSV export",
 	activityv1connect.ActivityServiceListActivityFilterOptionsProcedure: "ungated; filter option lookup",
@@ -124,125 +224,37 @@ var ProceduresPendingMigration = map[string]string{
 	authv1connect.AuthServiceVerifyCredentialsProcedure: "authenticated self-read, no role check",
 	authv1connect.AuthServiceLogoutProcedure:            "session-only; FailedPrecondition guard in handler",
 
-	// DeviceCollectionService — ungated reads + writes on shared collections.
-	collectionv1connect.DeviceCollectionServiceCreateCollectionProcedure:            "ungated",
-	collectionv1connect.DeviceCollectionServiceGetCollectionProcedure:               "ungated",
-	collectionv1connect.DeviceCollectionServiceGetCollectionStatsProcedure:          "ungated",
-	collectionv1connect.DeviceCollectionServiceListCollectionsProcedure:             "ungated",
-	collectionv1connect.DeviceCollectionServiceListCollectionMembersProcedure:       "ungated",
-	collectionv1connect.DeviceCollectionServiceUpdateCollectionProcedure:            "ungated",
-	collectionv1connect.DeviceCollectionServiceDeleteCollectionProcedure:            "ungated",
-	collectionv1connect.DeviceCollectionServiceAddDevicesToCollectionProcedure:      "ungated",
-	collectionv1connect.DeviceCollectionServiceRemoveDevicesFromCollectionProcedure: "ungated",
-	collectionv1connect.DeviceCollectionServiceGetDeviceCollectionsProcedure:        "ungated",
-	collectionv1connect.DeviceCollectionServiceListRackTypesProcedure:               "ungated",
-	collectionv1connect.DeviceCollectionServiceListRackZonesProcedure:               "ungated",
-	collectionv1connect.DeviceCollectionServiceSaveRackProcedure:                    "ungated",
-	collectionv1connect.DeviceCollectionServiceGetRackSlotsProcedure:                "ungated",
-	collectionv1connect.DeviceCollectionServiceSetRackSlotPositionProcedure:         "ungated",
-	collectionv1connect.DeviceCollectionServiceClearRackSlotPositionProcedure:       "ungated",
-
-	// CurtailmentService — gates are conditional or absent; migration must close the gaps.
-	// AdminTerminateEvent already swapped to RequirePermission(PermCurtailmentManage).
+	// CurtailmentService — Start/Stop/Preview gate conditionally on
+	// override fields / force; the unconditional codepath remains
+	// ungated. Pending the curtailment authz redesign that swaps these
+	// to RequirePermission with the right resource context.
 	curtailmentv1connect.CurtailmentServiceStartCurtailmentProcedure:       "CONDITIONAL: requireAdminFromContext only when CandidateMinPowerWOverride set or AllowUnbounded; otherwise any authenticated user can start",
 	curtailmentv1connect.CurtailmentServiceStopCurtailmentProcedure:        "CONDITIONAL: requireAdminFromContext only when force=true; non-force stop is ungated",
-	curtailmentv1connect.CurtailmentServiceUpdateCurtailmentEventProcedure: "UNIMPLEMENTED STUB: returns Unimplemented with no gate; needs a real gate when implemented",
-	curtailmentv1connect.CurtailmentServiceListCurtailmentEventsProcedure:  "ungated read",
-	curtailmentv1connect.CurtailmentServiceGetActiveCurtailmentProcedure:   "ungated read",
 	curtailmentv1connect.CurtailmentServicePreviewCurtailmentPlanProcedure: "CONDITIONAL: requireAdminFromContext only when CandidateMinPowerWOverride set; otherwise ungated",
 
-	// DeviceSetService (racks) — ungated.
-	device_setv1connect.DeviceSetServiceCreateDeviceSetProcedure:            "ungated",
-	device_setv1connect.DeviceSetServiceGetDeviceSetProcedure:               "ungated",
-	device_setv1connect.DeviceSetServiceGetDeviceSetStatsProcedure:          "ungated",
-	device_setv1connect.DeviceSetServiceListDeviceSetsProcedure:             "ungated",
-	device_setv1connect.DeviceSetServiceListDeviceSetMembersProcedure:       "ungated",
-	device_setv1connect.DeviceSetServiceUpdateDeviceSetProcedure:            "ungated",
-	device_setv1connect.DeviceSetServiceDeleteDeviceSetProcedure:            "ungated",
-	device_setv1connect.DeviceSetServiceAddDevicesToDeviceSetProcedure:      "ungated",
-	device_setv1connect.DeviceSetServiceRemoveDevicesFromDeviceSetProcedure: "ungated",
-	device_setv1connect.DeviceSetServiceGetDeviceDeviceSetsProcedure:        "ungated",
-	device_setv1connect.DeviceSetServiceListRackTypesProcedure:              "ungated",
-	device_setv1connect.DeviceSetServiceListRackZonesProcedure:              "ungated",
-	device_setv1connect.DeviceSetServiceListRackZoneRefsProcedure:           "ungated",
-	device_setv1connect.DeviceSetServiceSaveRackProcedure:                   "ungated",
-	device_setv1connect.DeviceSetServiceGetRackSlotsProcedure:               "ungated",
-	device_setv1connect.DeviceSetServiceSetRackSlotPositionProcedure:        "ungated",
-	device_setv1connect.DeviceSetServiceClearRackSlotPositionProcedure:      "ungated",
-
-	// ErrorQueryService — ungated diagnostics reads.
-	errorsv1connect.ErrorQueryServiceGetErrorProcedure:        "ungated diagnostics read",
-	errorsv1connect.ErrorQueryServiceQueryProcedure:           "ungated diagnostics read",
-	errorsv1connect.ErrorQueryServiceListMinerErrorsProcedure: "ungated diagnostics read",
-	errorsv1connect.ErrorQueryServiceWatchProcedure:           "ungated diagnostics stream",
-
-	// FleetManagementService — ungated. This is the first service that gets a NEW gate.
-	fleetmanagementv1connect.FleetManagementServiceListMinerStateSnapshotsProcedure: "ungated",
-	fleetmanagementv1connect.FleetManagementServiceGetMinerPoolAssignmentsProcedure: "ungated",
-	fleetmanagementv1connect.FleetManagementServiceGetMinerCoolingModeProcedure:     "ungated",
-	fleetmanagementv1connect.FleetManagementServiceGetMinerStateCountsProcedure:     "ungated",
-	fleetmanagementv1connect.FleetManagementServiceGetMinerModelGroupsProcedure:     "ungated",
-	fleetmanagementv1connect.FleetManagementServiceUpdateWorkerNamesProcedure:       "ungated",
-	fleetmanagementv1connect.FleetManagementServiceRenameMinersProcedure:            "ungated",
-	fleetmanagementv1connect.FleetManagementServiceDeleteMinersProcedure:            "ungated",
-	fleetmanagementv1connect.FleetManagementServiceExportMinerListCsvProcedure:      "ungated",
-
-	// FleetNodeAdminService — only the unimplemented stubs remain;
-	// CreateEnrollmentCode/List/Confirm/Revoke moved to ProcedurePermissions.
+	// FleetNodeAdminService — Unimplemented stubs; gate when implemented.
 	fleetnodeadminv1connect.FleetNodeAdminServicePairDeviceToFleetNodeProcedure: "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
 	fleetnodeadminv1connect.FleetNodeAdminServiceUnpairDeviceProcedure:          "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
 	fleetnodeadminv1connect.FleetNodeAdminServiceListFleetNodeDevicesProcedure:  "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
 	fleetnodeadminv1connect.FleetNodeAdminServiceDiscoverOnFleetNodeProcedure:   "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
 
-	// ForemanImportService — ungated.
-	foremanimportv1connect.ForemanImportServiceImportFromForemanProcedure: "ungated",
-	foremanimportv1connect.ForemanImportServiceCompleteImportProcedure:    "ungated",
+	// PoolsService — operator-managed pool definitions. Needs a new
+	// pool:read / pool:manage catalog pair + ADMIN backfill migration;
+	// deferred from the new-gate slice.
+	poolsv1connect.PoolsServiceCreatePoolProcedure:   "ungated; needs new pool:manage catalog key",
+	poolsv1connect.PoolsServiceListPoolsProcedure:    "ungated; needs new pool:read catalog key",
+	poolsv1connect.PoolsServiceUpdatePoolProcedure:   "ungated; needs new pool:manage catalog key",
+	poolsv1connect.PoolsServiceDeletePoolProcedure:   "ungated; needs new pool:manage catalog key",
+	poolsv1connect.PoolsServiceValidatePoolProcedure: "ungated; needs new pool:read catalog key",
 
-	// MinerCommandService — ungated. The largest single block of new gates.
-	minercommandv1connect.MinerCommandServiceBlinkLEDProcedure:                     "ungated",
-	minercommandv1connect.MinerCommandServiceRebootProcedure:                       "ungated",
-	minercommandv1connect.MinerCommandServiceStartMiningProcedure:                  "ungated",
-	minercommandv1connect.MinerCommandServiceStopMiningProcedure:                   "ungated",
-	minercommandv1connect.MinerCommandServiceUpdateMiningPoolsProcedure:            "ungated",
-	minercommandv1connect.MinerCommandServiceSetCoolingModeProcedure:               "ungated",
-	minercommandv1connect.MinerCommandServiceSetPowerTargetProcedure:               "ungated",
-	minercommandv1connect.MinerCommandServiceFirmwareUpdateProcedure:               "ungated",
-	minercommandv1connect.MinerCommandServiceDownloadLogsProcedure:                 "ungated",
-	minercommandv1connect.MinerCommandServiceUpdateMinerPasswordProcedure:          "ungated",
-	minercommandv1connect.MinerCommandServiceUnpairProcedure:                       "ungated",
-	minercommandv1connect.MinerCommandServiceCheckCommandCapabilitiesProcedure:     "ungated",
-	minercommandv1connect.MinerCommandServiceGetCommandBatchDeviceResultsProcedure: "ungated",
-	minercommandv1connect.MinerCommandServiceGetCommandBatchLogBundleProcedure:     "ungated",
-	minercommandv1connect.MinerCommandServiceStreamCommandBatchUpdatesProcedure:    "ungated",
-
-	// NetworkInfoService — ungated.
-	networkinfov1connect.NetworkInfoServiceGetNetworkInfoProcedure:        "ungated",
-	networkinfov1connect.NetworkInfoServiceUpdateNetworkNicknameProcedure: "ungated",
-
-	// OnboardingService — fleet-init status. Other onboarding procedures are unauthenticated.
-	onboardingv1connect.OnboardingServiceGetFleetOnboardingStatusProcedure: "ungated authenticated read",
-
-	// PairingService — ungated.
-	pairingv1connect.PairingServiceDiscoverProcedure: "ungated",
-	pairingv1connect.PairingServicePairProcedure:     "ungated",
-
-	// PoolsService — ungated.
-	poolsv1connect.PoolsServiceCreatePoolProcedure:   "ungated",
-	poolsv1connect.PoolsServiceListPoolsProcedure:    "ungated",
-	poolsv1connect.PoolsServiceUpdatePoolProcedure:   "ungated",
-	poolsv1connect.PoolsServiceDeletePoolProcedure:   "ungated",
-	poolsv1connect.PoolsServiceValidatePoolProcedure: "ungated",
-
-	// ScheduleService — ungated.
-	schedulev1connect.ScheduleServiceListSchedulesProcedure:    "ungated",
-	schedulev1connect.ScheduleServiceCreateScheduleProcedure:   "ungated",
-	schedulev1connect.ScheduleServiceUpdateScheduleProcedure:   "ungated",
-	schedulev1connect.ScheduleServiceDeleteScheduleProcedure:   "ungated",
-	schedulev1connect.ScheduleServicePauseScheduleProcedure:    "ungated",
-	schedulev1connect.ScheduleServiceResumeScheduleProcedure:   "ungated",
-	schedulev1connect.ScheduleServiceReorderSchedulesProcedure: "ungated",
-
-	// TelemetryService — ungated.
-	telemetryv1connect.TelemetryServiceGetCombinedMetricsProcedure:          "ungated",
-	telemetryv1connect.TelemetryServiceStreamCombinedMetricUpdatesProcedure: "ungated",
+	// ScheduleService — operator-managed schedules. Needs a new
+	// schedule:read / schedule:manage catalog pair + ADMIN backfill
+	// migration; deferred from the new-gate slice.
+	schedulev1connect.ScheduleServiceListSchedulesProcedure:    "ungated; needs new schedule:read catalog key",
+	schedulev1connect.ScheduleServiceCreateScheduleProcedure:   "ungated; needs new schedule:manage catalog key",
+	schedulev1connect.ScheduleServiceUpdateScheduleProcedure:   "ungated; needs new schedule:manage catalog key",
+	schedulev1connect.ScheduleServiceDeleteScheduleProcedure:   "ungated; needs new schedule:manage catalog key",
+	schedulev1connect.ScheduleServicePauseScheduleProcedure:    "ungated; needs new schedule:manage catalog key",
+	schedulev1connect.ScheduleServiceResumeScheduleProcedure:   "ungated; needs new schedule:manage catalog key",
+	schedulev1connect.ScheduleServiceReorderSchedulesProcedure: "ungated; needs new schedule:manage catalog key",
 }

--- a/server/internal/handlers/networkinfo/handler.go
+++ b/server/internal/handlers/networkinfo/handler.go
@@ -7,6 +7,7 @@ import (
 	pb "github.com/block/proto-fleet/server/generated/grpc/networkinfo/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/networkinfo/v1/networkinfov1connect"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/pairing"
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
@@ -46,6 +47,5 @@ func (h Handler) UpdateNetworkNickname(ctx context.Context, _ *connect.Request[p
 	if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
-	// TODO implement me
-	panic("unimplemented")
+	return nil, fleeterror.NewUnimplementedError("UpdateNetworkNickname is not implemented")
 }

--- a/server/internal/handlers/networkinfo/handler.go
+++ b/server/internal/handlers/networkinfo/handler.go
@@ -6,7 +6,9 @@ import (
 	"connectrpc.com/connect"
 	pb "github.com/block/proto-fleet/server/generated/grpc/networkinfo/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/networkinfo/v1/networkinfov1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/pairing"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // Handler handles the Connect-RPC endpoints
@@ -21,6 +23,9 @@ func NewHandler(pairingSvc *pairing.Service) *Handler {
 }
 
 func (h Handler) GetNetworkInfo(ctx context.Context, _ *connect.Request[pb.GetNetworkInfoRequest]) (*connect.Response[pb.GetNetworkInfoResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermSiteRead, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	info, err := h.pairingSvc.GetLocalNetworkInfo(ctx)
 	if err != nil {
 		return nil, err
@@ -37,7 +42,10 @@ func (h Handler) GetNetworkInfo(ctx context.Context, _ *connect.Request[pb.GetNe
 	}), nil
 }
 
-func (h Handler) UpdateNetworkNickname(context.Context, *connect.Request[pb.UpdateNetworkNicknameRequest]) (*connect.Response[pb.UpdateNetworkNicknameResponse], error) {
+func (h Handler) UpdateNetworkNickname(ctx context.Context, _ *connect.Request[pb.UpdateNetworkNicknameRequest]) (*connect.Response[pb.UpdateNetworkNicknameResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	// TODO implement me
 	panic("unimplemented")
 }

--- a/server/internal/handlers/onboarding/handler.go
+++ b/server/internal/handlers/onboarding/handler.go
@@ -6,7 +6,9 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/onboarding/v1/onboardingv1connect"
 
 	"github.com/block/proto-fleet/server/internal/domain/auth"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/onboarding"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 
 	"connectrpc.com/connect"
 	pb "github.com/block/proto-fleet/server/generated/grpc/onboarding/v1"
@@ -47,6 +49,9 @@ func (s *Handler) GetFleetInitStatus(ctx context.Context, _ *connect.Request[pb.
 }
 
 func (s *Handler) GetFleetOnboardingStatus(ctx context.Context, _ *connect.Request[pb.GetFleetOnboardingStatusRequest]) (*connect.Response[pb.GetFleetOnboardingStatusResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	status, err := s.onboardingSvc.GetFleetOnboardingStatus(ctx)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/pairing/handler.go
+++ b/server/internal/handlers/pairing/handler.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 
 	"connectrpc.com/connect"
 	pb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
@@ -28,6 +30,9 @@ func NewHandler(pairingSvc *pairing.Service) *Handler {
 
 // Discover implements pairingv1connect.DeviceDiscoveryServiceHandler.
 func (h *Handler) Discover(ctx context.Context, r *connect.Request[pb.DiscoverRequest], s *connect.ServerStream[pb.DiscoverResponse]) error {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerPair, authz.ResourceContext{}); err != nil {
+		return err
+	}
 	slog.Debug("Discover: handling discover request", "payload", r.Msg)
 	var resultChan <-chan *pb.DiscoverResponse
 	var err error
@@ -69,6 +74,9 @@ func (h *Handler) Discover(ctx context.Context, r *connect.Request[pb.DiscoverRe
 
 // Pair implements pairingv1connect.PairingServiceHandler.
 func (h *Handler) Pair(ctx context.Context, r *connect.Request[pb.PairRequest]) (*connect.Response[pb.PairResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerPair, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	resp, err := h.pairingSvc.PairDevices(ctx, r.Msg)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/telemetry/handler.go
+++ b/server/internal/handlers/telemetry/handler.go
@@ -9,10 +9,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	telemetryv1 "github.com/block/proto-fleet/server/generated/grpc/telemetry/v1"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/telemetry"
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 type Handler struct {
@@ -29,6 +31,9 @@ func (h *Handler) GetCombinedMetrics(
 	ctx context.Context,
 	req *connect.Request[telemetryv1.GetCombinedMetricsRequest],
 ) (*connect.Response[telemetryv1.GetCombinedMetricsResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	query, err := toCombinedMetricsQuery(req.Msg)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
@@ -57,9 +62,9 @@ func (h *Handler) StreamCombinedMetricUpdates(
 	req *connect.Request[telemetryv1.StreamCombinedMetricUpdatesRequest],
 	stream *connect.ServerStream[telemetryv1.StreamCombinedMetricUpdatesResponse],
 ) error {
-	info, err := session.GetInfo(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{})
 	if err != nil {
-		return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to get session info: %w", err))
+		return err
 	}
 
 	query, err := toStreamCombinedMetricsQuery(req.Msg)

--- a/server/internal/handlers/telemetry/handler.go
+++ b/server/internal/handlers/telemetry/handler.go
@@ -11,7 +11,6 @@ import (
 	telemetryv1 "github.com/block/proto-fleet/server/generated/grpc/telemetry/v1"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
-	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/telemetry"
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
@@ -31,18 +30,15 @@ func (h *Handler) GetCombinedMetrics(
 	ctx context.Context,
 	req *connect.Request[telemetryv1.GetCombinedMetricsRequest],
 ) (*connect.Response[telemetryv1.GetCombinedMetricsResponse], error) {
-	if _, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{}); err != nil {
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetRead, authz.ResourceContext{})
+	if err != nil {
 		return nil, err
 	}
 	query, err := toCombinedMetricsQuery(req.Msg)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
-
-	// Scope to caller's org; store returns nil counts when OrgID is unset.
-	if info, err := session.GetInfo(ctx); err == nil {
-		query.OrganizationID = info.OrganizationID
-	}
+	query.OrganizationID = info.OrganizationID
 
 	combinedMetrics, err := h.telemetryService.GetCombinedMetrics(ctx, query)
 	if err != nil {

--- a/server/internal/handlers/telemetry/handler_test.go
+++ b/server/internal/handlers/telemetry/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/telemetry"
 	mock "github.com/block/proto-fleet/server/internal/domain/telemetry/mocks"
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
+	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
 var mockTime = time.Now()
@@ -227,12 +228,18 @@ func TestHandler_GetCombinedMetrics(t *testing.T) {
 			mockMinerGetter := mock.NewMockCachedMinerGetter(ctrl)
 			mockScheduler := mock.NewMockUpdateScheduler(ctrl)
 			mockDeviceStore := storesMocks.NewMockDeviceStore(ctrl)
+			// The live-uptime-bar pass calls GetMinerStateCounts whenever
+			// orgID != 0. These tests now run with a real orgID (gated
+			// handlers require session+permissions), so allow the call
+			// to fall through without asserting on its arguments.
+			mockDeviceStore.EXPECT().GetMinerStateCounts(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&telemetryv1.MinerStateCounts{}, nil).AnyTimes()
 			mockErrorPoller := mock.NewMockErrorPoller(ctrl)
 
 			service := telemetry.NewTelemetryService(config, mockStore, mockMinerGetter, mockScheduler, mockDeviceStore, mockErrorPoller)
 			handler := NewHandler(service)
 
-			resp, err := handler.GetCombinedMetrics(t.Context(), connect.NewRequest(tt.request))
+			resp, err := handler.GetCombinedMetrics(testutil.MockAuthContextForTesting(t.Context(), 1, 1), connect.NewRequest(tt.request))
 
 			if tt.expectedError {
 				require.Error(t, err, "Expected error but got none - this indicates a bug!")

--- a/server/internal/handlers/telemetry/handler_units_test.go
+++ b/server/internal/handlers/telemetry/handler_units_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/telemetry"
 	mock "github.com/block/proto-fleet/server/internal/domain/telemetry/mocks"
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
+	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
 // Unit conversion test constants - raw storage values
@@ -108,7 +109,7 @@ func TestHandler_GetCombinedMetrics_UnitsConversion(t *testing.T) {
 				Aggregations:     []telemetryv1.AggregationType{telemetryv1.AggregationType_AGGREGATION_TYPE_SUM},
 			}
 
-			resp, err := handler.GetCombinedMetrics(t.Context(), connect.NewRequest(req))
+			resp, err := handler.GetCombinedMetrics(testutil.MockAuthContextForTesting(t.Context(), 1, 1), connect.NewRequest(req))
 
 			require.NoError(t, err)
 			require.NotNil(t, resp)
@@ -217,6 +218,12 @@ func createTestHandler(ctrl *gomock.Controller, mockStore *mock.MockTelemetryDat
 	mockMinerGetter := mock.NewMockCachedMinerGetter(ctrl)
 	mockScheduler := mock.NewMockUpdateScheduler(ctrl)
 	mockDeviceStore := storesMocks.NewMockDeviceStore(ctrl)
+	// The live-uptime-bar pass calls GetMinerStateCounts whenever
+	// orgID != 0. These tests now run with a real orgID (gated
+	// handlers require session+permissions), so allow the call
+	// to fall through without asserting on its arguments.
+	mockDeviceStore.EXPECT().GetMinerStateCounts(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&telemetryv1.MinerStateCounts{}, nil).AnyTimes()
 	mockErrorPoller := mock.NewMockErrorPoller(ctrl)
 
 	service := telemetry.NewTelemetryService(config, mockStore, mockMinerGetter, mockScheduler, mockDeviceStore, mockErrorPoller)

--- a/server/internal/testutil/test_auth_context.go
+++ b/server/internal/testutil/test_auth_context.go
@@ -4,18 +4,23 @@ import (
 	"context"
 
 	"connectrpc.com/authn"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // MockAuthContextForTesting creates a context with session info for testing.
 // This sets up the session-based authentication context expected by domain services.
+// EffectivePermissions is populated with the full catalog at org scope so unit
+// tests that exercise handler logic clear every RequirePermission gate without
+// each test having to opt in.
 func MockAuthContextForTesting(ctx context.Context, userID, orgID int64) context.Context {
 	info := &session.Info{
 		SessionID:      "test-session-id",
 		UserID:         userID,
 		OrganizationID: orgID,
 	}
-	return authn.SetInfo(ctx, info)
+	return middleware.WithEffectivePermissions(authn.SetInfo(ctx, info), allCatalogEffective())
 }
 
 // MockAuthContextWithSessionID creates a context with a custom session ID for testing.
@@ -26,5 +31,16 @@ func MockAuthContextWithSessionID(ctx context.Context, sessionID string, userID,
 		UserID:         userID,
 		OrganizationID: orgID,
 	}
-	return authn.SetInfo(ctx, info)
+	return middleware.WithEffectivePermissions(authn.SetInfo(ctx, info), allCatalogEffective())
+}
+
+// allCatalogEffective returns an org-scope EffectivePermissions that
+// grants every catalog key — the SUPER_ADMIN equivalent for unit
+// tests that don't want to declare a permission set per call site.
+func allCatalogEffective() *authz.EffectivePermissions {
+	return authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  authz.AllPermissions(),
+	}})
 }


### PR DESCRIPTION
First slice of PR 2d. New-gate work for every currently-ungated authenticated procedure whose target catalog key already exists. Per-miner site-scope narrowing is deferred until DeviceSelector resolution lands.

## What landed

71 procedures move from `ProceduresPendingMigration` → `ProcedurePermissions`:

| Package | # | Mapping |
|---|---|---|
| `fleetmanagement` | 9 | `fleet:read` for aggregates, `miner:read` for per-row reads, matching `miner:*` for mutations (rename, delete, update_worker_names, export_csv) |
| `minercommand` | 15 | one-to-one with catalog `miner:*` keys; stream/batch endpoints on `fleet:read` |
| `deviceset` | 17 | `rack:read` / `rack:manage` |
| `collection` (DeviceCollectionService) | 16 | `rack:read` / `rack:manage` — same mapping as deviceset; the two are the legacy + new wire surfaces for the same domain |
| `errorquery` | 4 | `fleet:read` (org-scoped diagnostics) |
| `telemetry` | 2 | `fleet:read` |
| `networkinfo` | 2 | `site:read` (Get), `site:manage` (Update) |
| `pairing` | 2 | `miner:pair` |
| `foremanimport` | 2 | `miner:pair` (bulk pair flow) |
| `onboarding` | 1 | `fleet:read` |
| `curtailment` reads | 1 | `curtailment:read` (`GetActiveCurtailment`; `ListCurtailmentEvents` was already gated) |

## What this PR does NOT do

- **No per-miner site narrowing.** Every gate runs at org scope (`ResourceContext{}`). Threading `SiteID` per miner requires resolving `DeviceSelector` payloads first — its own slice.
- **Activity (3), Pools (5), Schedule (7) — deferred.** They need new catalog keys (`activity:read`, `pool:read`/`manage`, `schedule:read`/`manage`) plus an ADMIN backfill migration; staying in `ProceduresPendingMigration` with explicit notes.
- **Curtailment Start/Stop/Preview — deferred.** Conditional inline gates that need a redesign (PR 2d.2 scope).
- **fleetnodeadmin Pair/Unpair/ListFleetNodeDevices/DiscoverOnFleetNode — deferred.** Unimplemented stubs.
- **No schema migration in this PR.** The legacy `user_organization.role_id` rename + raising trigger + `middleware/admin.go` deletion are PR 2d.3.

## Test infrastructure

- `testutil.MockAuthContextForTesting` now wires an org-scope `EffectivePermissions` carrying every catalog key. Unit tests that exercise gated handler logic clear the gate without each call site opting in; tests that need to assert `PermissionDenied` build their own `EffectivePermissions` explicitly.
- `errorquery` handler test: swapped direct `authn.SetInfo` for the shared testutil helper. Expected-code assertion now handles both `FleetError` (from `RequirePermission`) and `connect.Error` wrappers.
- `telemetry` tests: added a permissive `GetMinerStateCounts` mock since the live-uptime-bar pass now fires when `orgID != 0` (skipped on the prior no-session test paths).
- `curtailment GetActiveCurtailment` tests use a local `withCurtailmentRead` wrapper to add `PermCurtailmentRead` to the context.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/handlers/middleware/...` green — contract test confirms every registered procedure is classified into one of the four buckets after the swap.
- [x] All non-DB handler unit tests green: activity, buildings, command, curtailment, deviceset, errorquery, firmware, fleetnodegateway, middleware, pairing, sites, telemetry.
- [ ] CI confirms no regression on Postgres-backed integration tests (apikey, auth, interceptors, fleetmanagement ListMinerStateSnapshots, onboarding CreateAdminLogin / GetFleetInitStatus — all pre-existing DB dependencies).

## Rollback

Revert is mechanical: each handler removes its `RequirePermission` call and the procedure moves back to `ProceduresPendingMigration`. The `testutil` helper change is additive (test-only); no production behavior depends on the new permission set in the test context.