### PR TITLE
Curtailment: wire update event API

### DIFF
--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -468,4 +468,23 @@ describe("useCurtailmentApi", () => {
 
     window.removeEventListener(CURTAILMENT_CHANGED_EVENT, changedListener);
   });
+
+  it("surfaces update failures without refreshing listeners", async () => {
+    const changedListener = vi.fn();
+    window.addEventListener(CURTAILMENT_CHANGED_EVENT, changedListener);
+    mockUpdateCurtailment.mockRejectedValueOnce(new Error("rpc failed"));
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await expect(result.current.updateCurtailment("curt-1", baseSubmitValues, baseSubmitValues)).rejects.toThrow(
+        "rpc failed",
+      );
+    });
+
+    expect(result.current.updateError).toBe("rpc failed");
+    expect(changedListener).not.toHaveBeenCalled();
+
+    window.removeEventListener(CURTAILMENT_CHANGED_EVENT, changedListener);
+  });
 });

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -25,12 +25,14 @@ const {
   mockListCurtailmentEvents,
   mockStartCurtailment,
   mockStopCurtailment,
+  mockUpdateCurtailment,
 } = vi.hoisted(() => ({
   mockGetActiveCurtailment: vi.fn(),
   mockHandleAuthErrors: vi.fn(),
   mockListCurtailmentEvents: vi.fn(),
   mockStartCurtailment: vi.fn(),
   mockStopCurtailment: vi.fn(),
+  mockUpdateCurtailment: vi.fn(),
 }));
 
 vi.mock("@/protoFleet/api/clients", () => ({
@@ -39,6 +41,7 @@ vi.mock("@/protoFleet/api/clients", () => ({
     listCurtailmentEvents: mockListCurtailmentEvents,
     startCurtailment: mockStartCurtailment,
     stopCurtailment: mockStopCurtailment,
+    updateCurtailmentEvent: mockUpdateCurtailment,
   },
 }));
 
@@ -159,6 +162,16 @@ describe("useCurtailmentApi", () => {
         targetKw: 5,
         observedReductionKw: 5,
         remainingPowerKw: 1,
+      }),
+    );
+    expect(result.current.activeEventFormValues).toEqual(
+      expect.objectContaining({
+        reason: "Grid peak",
+        scopeType: "wholeOrg",
+        targetKw: "5",
+        priority: "emergency",
+        restoreBatchSize: "10",
+        restoreIntervalSec: "60",
       }),
     );
     expect(result.current.activeEvent?.rollups).toEqual([
@@ -405,6 +418,43 @@ describe("useCurtailmentApi", () => {
     );
     expect(changedListener).toHaveBeenCalledTimes(2);
     expect(result.current.activeEvent?.state).toBe("restoring");
+
+    window.removeEventListener(CURTAILMENT_CHANGED_EVENT, changedListener);
+  });
+
+  it("updates active curtailment fields and refreshes listeners", async () => {
+    const changedListener = vi.fn();
+    window.addEventListener(CURTAILMENT_CHANGED_EVENT, changedListener);
+    const updatedEvent = curtailmentEvent({ reason: "Updated grid peak", restoreBatchIntervalSec: 120 });
+    mockUpdateCurtailment.mockResolvedValueOnce({ event: updatedEvent });
+    mockGetActiveCurtailment.mockResolvedValue({ event: updatedEvent });
+    mockListCurtailmentEvents.mockResolvedValue({ events: [updatedEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.updateCurtailment("curt-1", {
+        ...baseSubmitValues,
+        reason: " Updated grid peak ",
+        maxDurationSec: "1800",
+        restoreBatchSize: "",
+        restoreIntervalSec: "120",
+      });
+    });
+
+    const updateRequest = mockUpdateCurtailment.mock.calls[0][0];
+    expect(mockUpdateCurtailment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventUuid: "curt-1",
+        reason: "Updated grid peak",
+        maxDurationSeconds: 1800,
+        restoreBatchIntervalSec: 120,
+      }),
+    );
+    expect(updateRequest.restoreBatchSize).toBeUndefined();
+    expect(changedListener).toHaveBeenCalledTimes(1);
+    expect(result.current.activeEvent?.reason).toBe("Updated grid peak");
+    expect(result.current.activeEventFormValues?.restoreIntervalSec).toBe("120");
 
     window.removeEventListener(CURTAILMENT_CHANGED_EVENT, changedListener);
   });

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -170,7 +170,7 @@ describe("useCurtailmentApi", () => {
         scopeType: "wholeOrg",
         targetKw: "5",
         priority: "emergency",
-        restoreBatchSize: "10",
+        restoreBatchSize: "",
         restoreIntervalSec: "60",
       }),
     );
@@ -433,13 +433,23 @@ describe("useCurtailmentApi", () => {
     const { result } = renderHook(() => useCurtailmentApi());
 
     await act(async () => {
-      await result.current.updateCurtailment("curt-1", {
-        ...baseSubmitValues,
-        reason: " Updated grid peak ",
-        maxDurationSec: "1800",
-        restoreBatchSize: "",
-        restoreIntervalSec: "120",
-      });
+      await result.current.updateCurtailment(
+        "curt-1",
+        {
+          ...baseSubmitValues,
+          reason: " Updated grid peak ",
+          maxDurationSec: "1800",
+          restoreBatchSize: "",
+          restoreIntervalSec: "120",
+        },
+        {
+          ...baseSubmitValues,
+          reason: "Grid peak",
+          maxDurationSec: "",
+          restoreBatchSize: "",
+          restoreIntervalSec: "60",
+        },
+      );
     });
 
     const updateRequest = mockUpdateCurtailment.mock.calls[0][0];

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -102,6 +102,12 @@ const initialHistoryPagination: CurtailmentHistoryPaginationState = {
   nextPageToken: "",
   pageTokens: [undefined],
 };
+const initialCurtailmentSnapshot: CurtailmentSnapshot = {
+  activeEvent: null,
+  activeEventId: null,
+  activeEventFormValues: null,
+  historyEvents: [],
+};
 
 function timestampToIsoString(timestamp?: Timestamp): string | undefined {
   if (!timestamp) {
@@ -120,8 +126,12 @@ function getFixedKwTolerance(event: ProtoCurtailmentEvent): number | undefined {
   return event.modeParams.case === "fixedKw" ? event.modeParams.value.toleranceKw : undefined;
 }
 
-function formatNumberField(value: number | undefined): string {
-  return value && value > 0 ? String(value) : "";
+function formatPositiveNumberField(value: number | undefined): string {
+  if (value === undefined || value <= 0) {
+    return "";
+  }
+
+  return String(value);
 }
 
 function mapCurtailmentEventScopeToFormValues(
@@ -165,10 +175,10 @@ function mapCurtailmentEventToFormValues(event: ProtoCurtailmentEvent): Curtailm
     targetKw: fixedKwTarget !== undefined ? String(fixedKwTarget) : "",
     toleranceKw: fixedKwTolerance !== undefined ? String(fixedKwTolerance) : "",
     priority: event.priority === ProtoCurtailmentPriority.EMERGENCY ? "emergency" : "normal",
-    minDurationSec: formatNumberField(event.minCurtailedDurationSec),
-    maxDurationSec: formatNumberField(event.maxDurationSeconds),
-    restoreBatchSize: formatNumberField(event.restoreBatchSize),
-    restoreIntervalSec: formatNumberField(event.restoreBatchIntervalSec),
+    minDurationSec: formatPositiveNumberField(event.minCurtailedDurationSec),
+    maxDurationSec: formatPositiveNumberField(event.maxDurationSeconds),
+    restoreBatchSize: formatPositiveNumberField(event.restoreBatchSize),
+    restoreIntervalSec: formatPositiveNumberField(event.restoreBatchIntervalSec),
     reason: event.reason || "Curtailment",
     includeMaintenance: event.includeMaintenance,
   };
@@ -393,12 +403,7 @@ function getSafeNextPageToken(
 
 export function useCurtailmentApi(): UseCurtailmentApiResult {
   const { handleAuthErrors } = useAuthErrors();
-  const [snapshot, setSnapshot] = useState<CurtailmentSnapshot>({
-    activeEvent: null,
-    activeEventId: null,
-    activeEventFormValues: null,
-    historyEvents: [],
-  });
+  const [snapshot, setSnapshot] = useState<CurtailmentSnapshot>(initialCurtailmentSnapshot);
   const [isLoading, setIsLoading] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
   const [updatingEventId, setUpdatingEventId] = useState<string | null>(null);

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -87,7 +87,11 @@ export interface UseCurtailmentApiResult extends CurtailmentSnapshot {
     options?: Pick<RefreshCurtailmentOptions, "signal">,
   ) => Promise<CurtailmentSnapshot>;
   startCurtailment: (values: CurtailmentSubmitValues) => Promise<ProtoCurtailmentEvent>;
-  updateCurtailment: (eventUuid: string, values: CurtailmentSubmitValues) => Promise<ProtoCurtailmentEvent>;
+  updateCurtailment: (
+    eventUuid: string,
+    values: CurtailmentSubmitValues,
+    initialValues?: Partial<CurtailmentSubmitValues>,
+  ) => Promise<ProtoCurtailmentEvent>;
   stopCurtailment: (eventUuid: string) => Promise<ProtoCurtailmentEvent>;
 }
 
@@ -163,7 +167,7 @@ function mapCurtailmentEventToFormValues(event: ProtoCurtailmentEvent): Curtailm
     priority: event.priority === ProtoCurtailmentPriority.EMERGENCY ? "emergency" : "normal",
     minDurationSec: formatNumberField(event.minCurtailedDurationSec),
     maxDurationSec: formatNumberField(event.maxDurationSeconds),
-    restoreBatchSize: formatNumberField(event.restoreBatchSize || event.effectiveBatchSize),
+    restoreBatchSize: formatNumberField(event.restoreBatchSize),
     restoreIntervalSec: formatNumberField(event.restoreBatchIntervalSec),
     reason: event.reason || "Curtailment",
     includeMaintenance: event.includeMaintenance,
@@ -626,13 +630,13 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
   );
 
   const updateCurtailment = useCallback(
-    async (eventUuid: string, values: CurtailmentSubmitValues) => {
+    async (eventUuid: string, values: CurtailmentSubmitValues, initialValues?: Partial<CurtailmentSubmitValues>) => {
       setUpdatingEventId(eventUuid);
       setUpdateError(null);
 
       try {
         const response = await curtailmentClient.updateCurtailmentEvent(
-          buildUpdateCurtailmentEventRequest(eventUuid, values),
+          buildUpdateCurtailmentEventRequest(eventUuid, values, initialValues),
         );
         if (!response.event) {
           throw new Error("Updated curtailment response was missing an event.");

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -27,7 +27,10 @@ import {
   mapCurtailmentEventState,
 } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 import type { CurtailmentHistoryEvent, CurtailmentPriority } from "@/protoFleet/features/energy/CurtailmentHistory";
-import { buildStartCurtailmentRequest } from "@/protoFleet/features/energy/curtailmentRequestBuilders";
+import {
+  buildStartCurtailmentRequest,
+  buildUpdateCurtailmentEventRequest,
+} from "@/protoFleet/features/energy/curtailmentRequestBuilders";
 import type { CurtailmentSubmitValues } from "@/protoFleet/features/energy/CurtailmentStartModal";
 import { useAuthErrors } from "@/protoFleet/store";
 
@@ -40,6 +43,7 @@ export interface RefreshCurtailmentOptions {
 interface CurtailmentSnapshot {
   activeEvent: ActiveCurtailmentEvent | null;
   activeEventId: string | null;
+  activeEventFormValues: CurtailmentSubmitValues | null;
   historyEvents: CurtailmentHistoryEvent[];
 }
 
@@ -62,9 +66,11 @@ interface CurtailmentHistoryPaginationState {
 export interface UseCurtailmentApiResult extends CurtailmentSnapshot {
   isLoading: boolean;
   isStarting: boolean;
+  isUpdating: boolean;
   stoppingEventId: string | null;
   loadError: string | null;
   startError: string | null;
+  updateError: string | null;
   stopError: string | null;
   historyCurrentPage: number;
   historyHasNextPage: boolean;
@@ -81,6 +87,7 @@ export interface UseCurtailmentApiResult extends CurtailmentSnapshot {
     options?: Pick<RefreshCurtailmentOptions, "signal">,
   ) => Promise<CurtailmentSnapshot>;
   startCurtailment: (values: CurtailmentSubmitValues) => Promise<ProtoCurtailmentEvent>;
+  updateCurtailment: (eventUuid: string, values: CurtailmentSubmitValues) => Promise<ProtoCurtailmentEvent>;
   stopCurtailment: (eventUuid: string) => Promise<ProtoCurtailmentEvent>;
 }
 
@@ -103,6 +110,64 @@ function timestampToIsoString(timestamp?: Timestamp): string | undefined {
 
 function getFixedKwTarget(event: ProtoCurtailmentEvent): number | undefined {
   return event.modeParams.case === "fixedKw" ? event.modeParams.value.targetKw : undefined;
+}
+
+function getFixedKwTolerance(event: ProtoCurtailmentEvent): number | undefined {
+  return event.modeParams.case === "fixedKw" ? event.modeParams.value.toleranceKw : undefined;
+}
+
+function formatNumberField(value: number | undefined): string {
+  return value && value > 0 ? String(value) : "";
+}
+
+function mapCurtailmentEventScopeToFormValues(
+  event: ProtoCurtailmentEvent,
+): Pick<CurtailmentSubmitValues, "scopeType" | "scopeId" | "deviceSetIds" | "deviceIdentifiers"> {
+  switch (event.scope.case) {
+    case "deviceIdentifiers":
+      return {
+        scopeType: "explicitMiners",
+        scopeId: "explicit-miners",
+        deviceSetIds: [],
+        deviceIdentifiers: [...event.scope.value.deviceIdentifiers],
+      };
+    case "deviceSetIds":
+      return {
+        scopeType: "deviceSet",
+        scopeId: "device-sets",
+        deviceSetIds: [...event.scope.value.deviceSetIds],
+        deviceIdentifiers: [],
+      };
+    case "wholeOrg":
+    default:
+      return {
+        scopeType: "wholeOrg",
+        scopeId: "whole-org",
+        deviceSetIds: [],
+        deviceIdentifiers: [],
+      };
+  }
+}
+
+function mapCurtailmentEventToFormValues(event: ProtoCurtailmentEvent): CurtailmentSubmitValues {
+  const fixedKwTarget = getFixedKwTarget(event);
+  const fixedKwTolerance = getFixedKwTolerance(event);
+
+  return {
+    ...mapCurtailmentEventScopeToFormValues(event),
+    responseProfileId: "customPlan",
+    curtailmentMode: "fixedKwReduction",
+    minerSelectionStrategy: "leastEfficientFirst",
+    targetKw: fixedKwTarget !== undefined ? String(fixedKwTarget) : "",
+    toleranceKw: fixedKwTolerance !== undefined ? String(fixedKwTolerance) : "",
+    priority: event.priority === ProtoCurtailmentPriority.EMERGENCY ? "emergency" : "normal",
+    minDurationSec: formatNumberField(event.minCurtailedDurationSec),
+    maxDurationSec: formatNumberField(event.maxDurationSeconds),
+    restoreBatchSize: formatNumberField(event.restoreBatchSize || event.effectiveBatchSize),
+    restoreIntervalSec: formatNumberField(event.restoreBatchIntervalSec),
+    reason: event.reason || "Curtailment",
+    includeMaintenance: event.includeMaintenance,
+  };
 }
 
 function mapCurtailmentPriority(priority: ProtoCurtailmentPriority): CurtailmentPriority {
@@ -285,6 +350,7 @@ function createSnapshot(
   return {
     activeEvent: nextActiveEvent,
     activeEventId: activeEvent && nextActiveEvent ? activeEvent.eventUuid : null,
+    activeEventFormValues: activeEvent && nextActiveEvent ? mapCurtailmentEventToFormValues(activeEvent) : null,
     historyEvents: nextHistoryEvents,
   };
 }
@@ -326,13 +392,16 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
   const [snapshot, setSnapshot] = useState<CurtailmentSnapshot>({
     activeEvent: null,
     activeEventId: null,
+    activeEventFormValues: null,
     historyEvents: [],
   });
   const [isLoading, setIsLoading] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
+  const [updatingEventId, setUpdatingEventId] = useState<string | null>(null);
   const [stoppingEventId, setStoppingEventId] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [startError, setStartError] = useState<string | null>(null);
+  const [updateError, setUpdateError] = useState<string | null>(null);
   const [stopError, setStopError] = useState<string | null>(null);
   const [historyPagination, setHistoryPagination] =
     useState<CurtailmentHistoryPaginationState>(initialHistoryPagination);
@@ -384,6 +453,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       updateSnapshot((current) => ({
         activeEvent: nextActiveEvent,
         activeEventId: nextActiveEvent ? event.eventUuid : null,
+        activeEventFormValues: nextActiveEvent ? mapCurtailmentEventToFormValues(event) : null,
         historyEvents: shouldUpdateHistoryPage
           ? upsertHistoryEvent(current.historyEvents, event)
           : current.historyEvents,
@@ -555,6 +625,33 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
     [applyEvent, handleFailure, refreshAfterMutation],
   );
 
+  const updateCurtailment = useCallback(
+    async (eventUuid: string, values: CurtailmentSubmitValues) => {
+      setUpdatingEventId(eventUuid);
+      setUpdateError(null);
+
+      try {
+        const response = await curtailmentClient.updateCurtailmentEvent(
+          buildUpdateCurtailmentEventRequest(eventUuid, values),
+        );
+        if (!response.event) {
+          throw new Error("Updated curtailment response was missing an event.");
+        }
+
+        applyEvent(response.event);
+        await refreshAfterMutation();
+        return response.event;
+      } catch (error) {
+        const resolvedError = handleFailure(error, "Failed to update curtailment.");
+        setUpdateError(resolvedError.message);
+        throw resolvedError;
+      } finally {
+        setUpdatingEventId((currentEventId) => (currentEventId === eventUuid ? null : currentEventId));
+      }
+    },
+    [applyEvent, handleFailure, refreshAfterMutation],
+  );
+
   const stopCurtailment = useCallback(
     async (eventUuid: string) => {
       setStoppingEventId(eventUuid);
@@ -587,9 +684,11 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       ...snapshot,
       isLoading,
       isStarting,
+      isUpdating: updatingEventId !== null,
       stoppingEventId,
       loadError,
       startError,
+      updateError,
       stopError,
       historyCurrentPage: historyPagination.currentPage,
       historyHasNextPage: historyPagination.nextPageToken !== "",
@@ -600,6 +699,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       goToHistoryPage,
       setHistoryStatusFilter,
       startCurtailment,
+      updateCurtailment,
       stopCurtailment,
     }),
     [
@@ -609,15 +709,18 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       historyStatusFilter,
       isLoading,
       isStarting,
+      updatingEventId,
       loadError,
       refreshCurtailment,
       setHistoryStatusFilter,
       snapshot,
       startCurtailment,
+      updateCurtailment,
       stopCurtailment,
       stopError,
       stoppingEventId,
       startError,
+      updateError,
     ],
   );
 }

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -97,17 +97,15 @@ describe("ActiveCurtailmentStatus", () => {
     expect(screen.getByRole("button", { name: "Stop" })).toBeVisible();
   });
 
-  it("shows manage without stop or restore while restoring", async () => {
-    const user = userEvent.setup();
+  it("does not show manage while restoring", () => {
     const onRequestEdit = vi.fn();
 
     render(<ActiveCurtailmentStatus event={restoringCurtailmentEvent} onRequestEdit={onRequestEdit} />);
 
-    await user.click(screen.getByRole("button", { name: "Manage" }));
-
-    expect(onRequestEdit).toHaveBeenCalledOnce();
+    expectActionButtonHidden("Manage");
     expectActionButtonHidden("Stop");
     expectActionButtonHidden("Restore");
+    expect(onRequestEdit).not.toHaveBeenCalled();
   });
 
   it("renders a curtailed event with restore available", async () => {

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -185,12 +185,7 @@ const displayStateLabels: Record<ActiveCurtailmentDisplayState, string> = {
   restoring: "Restoring",
 };
 
-const manageableDisplayStates = new Set<ActiveCurtailmentDisplayState>([
-  "curtailed",
-  "curtailing",
-  "pending",
-  "restoring",
-]);
+const manageableDisplayStates = new Set<ActiveCurtailmentDisplayState>(["curtailed", "curtailing", "pending"]);
 
 function Dot({ className }: DotProps): ReactElement {
   return <span className={clsx("inline-block h-2 w-2 shrink-0 rounded-full", className)} />;

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   startCurtailment: vi.fn(),
   stopCurtailment: vi.fn(),
   submitValues: { reason: "Grid peak" },
+  updateCurtailment: vi.fn(),
   useCurtailmentApi: vi.fn(),
 }));
 
@@ -23,8 +24,19 @@ vi.mock("@/protoFleet/api/useCurtailmentApi", () => ({
 }));
 
 vi.mock("@/protoFleet/features/energy/ActiveCurtailmentStatus", () => ({
-  default: ({ onRequestRestore, onRequestStop }: { onRequestRestore?: () => void; onRequestStop?: () => void }) => (
+  default: ({
+    onRequestEdit,
+    onRequestRestore,
+    onRequestStop,
+  }: {
+    onRequestEdit?: () => void;
+    onRequestRestore?: () => void;
+    onRequestStop?: () => void;
+  }) => (
     <div data-testid="active-curtailment-status">
+      <button type="button" onClick={onRequestEdit}>
+        Request edit
+      </button>
       <button type="button" onClick={onRequestRestore}>
         Request restore
       </button>
@@ -78,11 +90,27 @@ vi.mock("@/protoFleet/features/energy/CurtailmentHistory", () => ({
 }));
 
 vi.mock("@/protoFleet/features/energy/CurtailmentStartModal", () => ({
-  default: ({ onSubmit }: { onSubmit: (values: CurtailmentSubmitValues) => void }) => (
-    <div role="dialog" aria-label="Plan curtailment">
+  default: ({
+    initialValues,
+    mode,
+    onStopCurtailment,
+    onSubmit,
+  }: {
+    initialValues?: Partial<CurtailmentSubmitValues>;
+    mode?: string;
+    onStopCurtailment?: () => void;
+    onSubmit: (values: CurtailmentSubmitValues) => void;
+  }) => (
+    <div role="dialog" aria-label={mode === "edit" ? "Manage curtailment" : "Plan curtailment"}>
+      <div data-testid="modal-initial-reason">{initialValues?.reason ?? ""}</div>
       <button type="button" onClick={() => onSubmit(mocks.submitValues as CurtailmentSubmitValues)}>
-        Submit plan
+        Submit {mode === "edit" ? "edit" : "plan"}
       </button>
+      {mode === "edit" ? (
+        <button type="button" onClick={onStopCurtailment}>
+          Stop from editor
+        </button>
+      ) : null}
     </div>
   ),
 }));
@@ -98,24 +126,29 @@ vi.mock("@/protoFleet/features/energy/CurtailmentStopConfirmationDialog", () => 
 }));
 
 const activeEvent = { reason: "Grid peak" } as ActiveCurtailmentEvent;
+const activeEventFormValues = { reason: "Grid peak", targetKw: "5" } as CurtailmentSubmitValues;
 const historyEvent = { id: "curt-1" } as CurtailmentHistoryEvent;
 
 const emptySnapshot = {
   activeEvent: null,
   activeEventId: null,
+  activeEventFormValues: null,
   historyEvents: [],
 };
 
 function createApiResult(overrides: Partial<UseCurtailmentApiResult> = {}): UseCurtailmentApiResult {
-  return {
+  const apiResult: UseCurtailmentApiResult = {
     activeEvent: null,
     activeEventId: null,
     historyEvents: [],
+    activeEventFormValues: null,
     isLoading: false,
     isStarting: false,
+    isUpdating: false,
     stoppingEventId: null,
     loadError: null,
     startError: null,
+    updateError: null,
     stopError: null,
     historyCurrentPage: 0,
     historyHasNextPage: false,
@@ -125,9 +158,11 @@ function createApiResult(overrides: Partial<UseCurtailmentApiResult> = {}): UseC
     goToHistoryPage: mocks.goToHistoryPage as UseCurtailmentApiResult["goToHistoryPage"],
     setHistoryStatusFilter: mocks.setHistoryStatusFilter as UseCurtailmentApiResult["setHistoryStatusFilter"],
     startCurtailment: mocks.startCurtailment as UseCurtailmentApiResult["startCurtailment"],
+    updateCurtailment: mocks.updateCurtailment as UseCurtailmentApiResult["updateCurtailment"],
     stopCurtailment: mocks.stopCurtailment as UseCurtailmentApiResult["stopCurtailment"],
-    ...overrides,
   };
+
+  return Object.assign(apiResult, overrides);
 }
 
 describe("CurtailmentManagementPanel", () => {
@@ -138,6 +173,7 @@ describe("CurtailmentManagementPanel", () => {
     mocks.setHistoryStatusFilter.mockResolvedValue(emptySnapshot);
     mocks.startCurtailment.mockResolvedValue({});
     mocks.stopCurtailment.mockResolvedValue({});
+    mocks.updateCurtailment.mockResolvedValue({});
     mocks.useCurtailmentApi.mockReturnValue(createApiResult());
   });
 
@@ -201,6 +237,48 @@ describe("CurtailmentManagementPanel", () => {
     await user.click(screen.getByRole("button", { name: "Stop history event" }));
 
     expect(mocks.stopCurtailment).toHaveBeenLastCalledWith("curt-1");
+  });
+
+  it("opens active curtailment management and submits updates", async () => {
+    const user = userEvent.setup();
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent,
+        activeEventId: "curt-1",
+        activeEventFormValues,
+      }),
+    );
+
+    render(<CurtailmentManagementPanel />);
+
+    await user.click(screen.getByRole("button", { name: "Request edit" }));
+
+    expect(screen.getByRole("dialog", { name: "Manage curtailment" })).toBeInTheDocument();
+    expect(screen.getByTestId("modal-initial-reason")).toHaveTextContent("Grid peak");
+
+    await user.click(screen.getByRole("button", { name: "Submit edit" }));
+
+    await waitFor(() => expect(mocks.updateCurtailment).toHaveBeenCalledWith("curt-1", mocks.submitValues));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Manage curtailment" })).not.toBeInTheDocument());
+  });
+
+  it("opens stop confirmation from the management modal", async () => {
+    const user = userEvent.setup();
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent,
+        activeEventId: "curt-1",
+        activeEventFormValues,
+      }),
+    );
+
+    render(<CurtailmentManagementPanel />);
+
+    await user.click(screen.getByRole("button", { name: "Request edit" }));
+    await user.click(screen.getByRole("button", { name: "Stop from editor" }));
+
+    expect(screen.queryByRole("dialog", { name: "Manage curtailment" })).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "stopCurtailment confirmation" })).toBeInTheDocument();
   });
 
   it("loads controlled history pages and surfaces focused errors", async () => {

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -137,7 +137,7 @@ const emptySnapshot = {
 };
 
 function createApiResult(overrides: Partial<UseCurtailmentApiResult> = {}): UseCurtailmentApiResult {
-  const apiResult: UseCurtailmentApiResult = {
+  return {
     activeEvent: null,
     activeEventId: null,
     historyEvents: [],
@@ -160,9 +160,8 @@ function createApiResult(overrides: Partial<UseCurtailmentApiResult> = {}): UseC
     startCurtailment: mocks.startCurtailment as UseCurtailmentApiResult["startCurtailment"],
     updateCurtailment: mocks.updateCurtailment as UseCurtailmentApiResult["updateCurtailment"],
     stopCurtailment: mocks.stopCurtailment as UseCurtailmentApiResult["stopCurtailment"],
+    ...overrides,
   };
-
-  return Object.assign(apiResult, overrides);
 }
 
 describe("CurtailmentManagementPanel", () => {

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -258,7 +258,9 @@ describe("CurtailmentManagementPanel", () => {
 
     await user.click(screen.getByRole("button", { name: "Submit edit" }));
 
-    await waitFor(() => expect(mocks.updateCurtailment).toHaveBeenCalledWith("curt-1", mocks.submitValues));
+    await waitFor(() =>
+      expect(mocks.updateCurtailment).toHaveBeenCalledWith("curt-1", mocks.submitValues, activeEventFormValues),
+    );
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Manage curtailment" })).not.toBeInTheDocument());
   });
 

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -307,6 +307,18 @@ describe("CurtailmentManagementPanel", () => {
     expect(mocks.goToHistoryPage).toHaveBeenCalledWith(2, { signal: expect.any(AbortSignal) });
   });
 
+  it("surfaces update errors", () => {
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        updateError: "Failed to update curtailment.",
+      }),
+    );
+
+    render(<CurtailmentManagementPanel />);
+
+    expect(screen.getByText("Failed to update curtailment.")).toBeInTheDocument();
+  });
+
   it("passes status filters through to the curtailment API hook", async () => {
     const user = userEvent.setup();
     mocks.useCurtailmentApi.mockReturnValue(

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -263,6 +263,42 @@ describe("CurtailmentManagementPanel", () => {
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Manage curtailment" })).not.toBeInTheDocument());
   });
 
+  it("keeps the edit baseline stable after active event refreshes", async () => {
+    const user = userEvent.setup();
+    const refreshedFormValues = {
+      ...activeEventFormValues,
+      reason: "Operator draft",
+    } as CurtailmentSubmitValues;
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent,
+        activeEventId: "curt-1",
+        activeEventFormValues,
+      }),
+    );
+
+    const { rerender } = render(<CurtailmentManagementPanel />);
+
+    await user.click(screen.getByRole("button", { name: "Request edit" }));
+
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent,
+        activeEventId: "curt-1",
+        activeEventFormValues: refreshedFormValues,
+      }),
+    );
+    rerender(<CurtailmentManagementPanel />);
+
+    expect(screen.getByTestId("modal-initial-reason")).toHaveTextContent("Grid peak");
+
+    await user.click(screen.getByRole("button", { name: "Submit edit" }));
+
+    await waitFor(() =>
+      expect(mocks.updateCurtailment).toHaveBeenCalledWith("curt-1", mocks.submitValues, activeEventFormValues),
+    );
+  });
+
   it("opens stop confirmation from the management modal", async () => {
     const user = userEvent.setup();
     mocks.useCurtailmentApi.mockReturnValue(

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -6,6 +6,7 @@ import ActiveCurtailmentStatus from "@/protoFleet/features/energy/ActiveCurtailm
 import type { CurtailmentEventState } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 import CurtailmentHistory, { type CurtailmentHistoryEvent } from "@/protoFleet/features/energy/CurtailmentHistory";
 import CurtailmentStartModal, {
+  type CurtailmentStartModalMode,
   type CurtailmentSubmitValues,
 } from "@/protoFleet/features/energy/CurtailmentStartModal";
 import CurtailmentStopConfirmationDialog, {
@@ -42,12 +43,15 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
   const {
     activeEvent,
     activeEventId,
+    activeEventFormValues,
     historyEvents,
     isLoading,
     isStarting,
+    isUpdating,
     stoppingEventId,
     loadError,
     startError,
+    updateError,
     stopError,
     historyCurrentPage,
     historyHasNextPage,
@@ -58,15 +62,17 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
     goToHistoryPage,
     setHistoryStatusFilter,
     startCurtailment,
+    updateCurtailment,
     stopCurtailment,
   } = useCurtailmentApi();
-  const [showStartModal, setShowStartModal] = useState(false);
+  const [modalMode, setModalMode] = useState<CurtailmentStartModalMode | null>(null);
   const [pendingStopConfirmation, setPendingStopConfirmation] = useState<PendingStopConfirmation | null>(null);
   const refreshAbortControllerRef = useRef<AbortController | null>(null);
-  const errorMessage = startError ?? stopError ?? loadError;
+  const errorMessage = startError ?? updateError ?? stopError ?? loadError;
   const isInitialLoading = isLoading && !activeEvent && historyEvents.length === 0;
   const isStopConfirmationSubmitting =
     pendingStopConfirmation !== null && stoppingEventId === pendingStopConfirmation.eventId;
+  const isModalSubmitting = modalMode === "edit" ? isUpdating : isStarting;
 
   const runAbortableRefresh = useCallback(<T,>(operation: (signal: AbortSignal) => Promise<T>) => {
     refreshAbortControllerRef.current?.abort();
@@ -100,10 +106,35 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
   const handleStartSubmit = useCallback(
     (values: CurtailmentSubmitValues) => {
       void startCurtailment(values)
-        .then(() => setShowStartModal(false))
+        .then(() => setModalMode(null))
         .catch(() => {});
     },
     [startCurtailment],
+  );
+
+  const handleUpdateSubmit = useCallback(
+    (values: CurtailmentSubmitValues) => {
+      if (!activeEventId) {
+        return;
+      }
+
+      void updateCurtailment(activeEventId, values)
+        .then(() => setModalMode(null))
+        .catch(() => {});
+    },
+    [activeEventId, updateCurtailment],
+  );
+
+  const handleModalSubmit = useCallback(
+    (values: CurtailmentSubmitValues) => {
+      if (modalMode === "edit") {
+        handleUpdateSubmit(values);
+        return;
+      }
+
+      handleStartSubmit(values);
+    },
+    [handleStartSubmit, handleUpdateSubmit, modalMode],
   );
 
   const handleHistoryStop = useCallback(
@@ -135,6 +166,11 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
       .catch(() => {});
   }, [pendingStopConfirmation, stopCurtailment]);
 
+  const handleEditStopCurtailment = useCallback(() => {
+    setModalMode(null);
+    openStopConfirmation("stopCurtailment");
+  }, [openStopConfirmation]);
+
   return (
     <section className={clsx("grid gap-6", className)}>
       <div className="flex items-center justify-between gap-4 phone:flex-col phone:items-stretch">
@@ -143,8 +179,8 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
           variant={variants.primary}
           size={sizes.base}
           text="Plan curtailment"
-          onClick={() => setShowStartModal(true)}
-          disabled={isStarting}
+          onClick={() => setModalMode("create")}
+          disabled={isStarting || isUpdating}
           className="phone:w-full"
         />
       </div>
@@ -160,6 +196,7 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
           {activeEvent ? (
             <ActiveCurtailmentStatus
               event={activeEvent}
+              onRequestEdit={() => setModalMode("edit")}
               onRequestRestore={() => openStopConfirmation("restore")}
               onRequestStop={() => openStopConfirmation("stopCurtailment")}
             />
@@ -180,12 +217,15 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
         </>
       )}
 
-      {showStartModal ? (
+      {modalMode ? (
         <CurtailmentStartModal
           open
-          onDismiss={() => setShowStartModal(false)}
-          onSubmit={handleStartSubmit}
-          isSubmitting={isStarting}
+          mode={modalMode}
+          initialValues={modalMode === "edit" ? (activeEventFormValues ?? undefined) : undefined}
+          onDismiss={() => setModalMode(null)}
+          onSubmit={handleModalSubmit}
+          onStopCurtailment={modalMode === "edit" ? handleEditStopCurtailment : undefined}
+          isSubmitting={isModalSubmitting}
         />
       ) : null}
 

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -118,11 +118,11 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
         return;
       }
 
-      void updateCurtailment(activeEventId, values)
+      void updateCurtailment(activeEventId, values, activeEventFormValues ?? undefined)
         .then(() => setModalMode(null))
         .catch(() => {});
     },
-    [activeEventId, updateCurtailment],
+    [activeEventFormValues, activeEventId, updateCurtailment],
   );
 
   const handleModalSubmit = useCallback(

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -72,7 +72,8 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
   const isInitialLoading = isLoading && !activeEvent && historyEvents.length === 0;
   const isStopConfirmationSubmitting =
     pendingStopConfirmation !== null && stoppingEventId === pendingStopConfirmation.eventId;
-  const isModalSubmitting = modalMode === "edit" ? isUpdating : isStarting;
+  const isEditingCurtailment = modalMode === "edit";
+  const isModalSubmitting = isEditingCurtailment ? isUpdating : isStarting;
 
   const runAbortableRefresh = useCallback(<T,>(operation: (signal: AbortSignal) => Promise<T>) => {
     refreshAbortControllerRef.current?.abort();
@@ -127,14 +128,14 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
 
   const handleModalSubmit = useCallback(
     (values: CurtailmentSubmitValues) => {
-      if (modalMode === "edit") {
+      if (isEditingCurtailment) {
         handleUpdateSubmit(values);
         return;
       }
 
       handleStartSubmit(values);
     },
-    [handleStartSubmit, handleUpdateSubmit, modalMode],
+    [handleStartSubmit, handleUpdateSubmit, isEditingCurtailment],
   );
 
   const handleHistoryStop = useCallback(
@@ -221,10 +222,10 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
         <CurtailmentStartModal
           open
           mode={modalMode}
-          initialValues={modalMode === "edit" ? (activeEventFormValues ?? undefined) : undefined}
+          initialValues={isEditingCurtailment ? (activeEventFormValues ?? undefined) : undefined}
           onDismiss={() => setModalMode(null)}
           onSubmit={handleModalSubmit}
-          onStopCurtailment={modalMode === "edit" ? handleEditStopCurtailment : undefined}
+          onStopCurtailment={isEditingCurtailment ? handleEditStopCurtailment : undefined}
           isSubmitting={isModalSubmitting}
         />
       ) : null}

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -26,6 +26,11 @@ interface PendingStopConfirmation {
   eventId: string;
 }
 
+interface EditCurtailmentSession {
+  eventId: string;
+  initialValues: CurtailmentSubmitValues;
+}
+
 interface CurtailmentMessageProps {
   message: string;
 }
@@ -66,6 +71,7 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
     stopCurtailment,
   } = useCurtailmentApi();
   const [modalMode, setModalMode] = useState<CurtailmentStartModalMode | null>(null);
+  const [editSession, setEditSession] = useState<EditCurtailmentSession | null>(null);
   const [pendingStopConfirmation, setPendingStopConfirmation] = useState<PendingStopConfirmation | null>(null);
   const refreshAbortControllerRef = useRef<AbortController | null>(null);
   const errorMessage = startError ?? updateError ?? stopError ?? loadError;
@@ -93,13 +99,32 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
     return () => refreshAbortControllerRef.current?.abort();
   }, [refreshCurtailment, runAbortableRefresh]);
 
+  const closeModal = useCallback(() => {
+    setModalMode(null);
+    setEditSession(null);
+  }, []);
+
+  const openCreateModal = useCallback(() => {
+    setEditSession(null);
+    setModalMode("create");
+  }, []);
+
+  const openEditModal = useCallback(() => {
+    if (!activeEventId || !activeEventFormValues) {
+      return;
+    }
+
+    setEditSession({ eventId: activeEventId, initialValues: activeEventFormValues });
+    setModalMode("edit");
+  }, [activeEventFormValues, activeEventId]);
+
   const openStopConfirmation = useCallback(
-    (action: CurtailmentStopConfirmationAction) => {
-      if (!activeEventId) {
+    (action: CurtailmentStopConfirmationAction, eventId = activeEventId) => {
+      if (!eventId) {
         return;
       }
 
-      setPendingStopConfirmation({ action, eventId: activeEventId });
+      setPendingStopConfirmation({ action, eventId });
     },
     [activeEventId],
   );
@@ -107,23 +132,24 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
   const handleStartSubmit = useCallback(
     (values: CurtailmentSubmitValues) => {
       void startCurtailment(values)
-        .then(() => setModalMode(null))
+        .then(closeModal)
         .catch(() => {});
     },
-    [startCurtailment],
+    [closeModal, startCurtailment],
   );
 
   const handleUpdateSubmit = useCallback(
     (values: CurtailmentSubmitValues) => {
-      if (!activeEventId) {
+      const editEventId = editSession?.eventId ?? activeEventId;
+      if (!editEventId) {
         return;
       }
 
-      void updateCurtailment(activeEventId, values, activeEventFormValues ?? undefined)
-        .then(() => setModalMode(null))
+      void updateCurtailment(editEventId, values, editSession?.initialValues ?? activeEventFormValues ?? undefined)
+        .then(closeModal)
         .catch(() => {});
     },
-    [activeEventFormValues, activeEventId, updateCurtailment],
+    [activeEventFormValues, activeEventId, closeModal, editSession, updateCurtailment],
   );
 
   const handleModalSubmit = useCallback(
@@ -168,9 +194,11 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
   }, [pendingStopConfirmation, stopCurtailment]);
 
   const handleEditStopCurtailment = useCallback(() => {
-    setModalMode(null);
-    openStopConfirmation("stopCurtailment");
-  }, [openStopConfirmation]);
+    const editEventId = editSession?.eventId ?? activeEventId;
+
+    closeModal();
+    openStopConfirmation("stopCurtailment", editEventId);
+  }, [activeEventId, closeModal, editSession, openStopConfirmation]);
 
   return (
     <section className={clsx("grid gap-6", className)}>
@@ -180,7 +208,7 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
           variant={variants.primary}
           size={sizes.base}
           text="Plan curtailment"
-          onClick={() => setModalMode("create")}
+          onClick={openCreateModal}
           disabled={isStarting || isUpdating}
           className="phone:w-full"
         />
@@ -197,7 +225,7 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
           {activeEvent ? (
             <ActiveCurtailmentStatus
               event={activeEvent}
-              onRequestEdit={() => setModalMode("edit")}
+              onRequestEdit={openEditModal}
               onRequestRestore={() => openStopConfirmation("restore")}
               onRequestStop={() => openStopConfirmation("stopCurtailment")}
             />
@@ -222,8 +250,8 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
         <CurtailmentStartModal
           open
           mode={modalMode}
-          initialValues={isEditingCurtailment ? (activeEventFormValues ?? undefined) : undefined}
-          onDismiss={() => setModalMode(null)}
+          initialValues={isEditingCurtailment ? (editSession?.initialValues ?? undefined) : undefined}
+          onDismiss={closeModal}
           onSubmit={handleModalSubmit}
           onStopCurtailment={isEditingCurtailment ? handleEditStopCurtailment : undefined}
           isSubmitting={isModalSubmitting}

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -169,10 +169,10 @@ describe("CurtailmentStartModal", () => {
     expect(screen.queryByRole("button", { name: "Start curtailment" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Reason")).toHaveValue("Grid peak - ERCOT 4CP signal");
     expect(screen.getByLabelText("Max duration (sec)")).toHaveValue(1800);
-    expect(screen.getByLabelText("Batch size (miners)")).toHaveValue(10);
     expect(screen.getByLabelText("Batch interval (sec)")).toHaveValue(120);
     expect(screen.queryByLabelText("Fixed target reduction (kW)")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Min duration (sec)")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Batch size (miners)")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Miners\s+Select/ })).not.toBeInTheDocument();
     expect(screen.queryByText("Include miners in maintenance")).not.toBeInTheDocument();
     expect(screen.queryByText("Configure your curtailment to see a preview.")).not.toBeInTheDocument();
@@ -193,7 +193,6 @@ describe("CurtailmentStartModal", () => {
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         maxDurationSec: "1800",
-        restoreBatchSize: "10",
         restoreIntervalSec: "180",
         reason: "Grid peak - ERCOT 4CP signal",
       }),

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -220,6 +220,29 @@ describe("CurtailmentStartModal", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("keeps max duration above the existing min duration in edit mode", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      mode: "edit",
+      initialValues: {
+        ...configuredValues,
+        minDurationSec: "600",
+        includeMaintenance: false,
+      },
+      preview,
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+
+    await user.clear(screen.getByLabelText("Max duration (sec)"));
+    await user.type(screen.getByLabelText("Max duration (sec)"), "300");
+
+    expect(screen.getByText("Max duration must be greater than or equal to min duration.")).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+
+    await user.click(saveButton);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("submits edit mode without maintenance confirmation", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -275,6 +275,28 @@ describe("CurtailmentStartModal", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("blocks zero restore interval in edit mode", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      mode: "edit",
+      initialValues: {
+        ...configuredValues,
+        includeMaintenance: false,
+      },
+      preview,
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+
+    await user.clear(screen.getByLabelText("Batch interval (sec)"));
+    await user.type(screen.getByLabelText("Batch interval (sec)"), "0");
+
+    expect(screen.getByText("Enter batch interval greater than 0.")).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+
+    await user.click(saveButton);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("keeps max duration above the existing min duration in edit mode", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -87,6 +87,7 @@ vi.mock("@/protoFleet/features/settings/components/Schedules/MinerSelectionModal
 
 const configuredValues: Partial<CurtailmentFormValues> = {
   targetKw: "40",
+  maxDurationSec: "1800",
   restoreBatchSize: "10",
   restoreIntervalSec: "120",
   reason: "Grid peak - ERCOT 4CP signal",
@@ -152,7 +153,7 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeEnabled();
   });
 
-  it("renders edit mode with prefilled values and save copy", async () => {
+  it("renders edit mode with only updateable fields prefilled", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
       mode: "edit",
@@ -166,14 +167,26 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByRole("dialog", { name: "Manage curtailment" })).toBeInTheDocument();
     expect(screen.queryByRole("dialog", { name: "Plan a curtailment" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Start curtailment" })).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Fixed target reduction (kW)")).toHaveValue(40);
     expect(screen.getByLabelText("Reason")).toHaveValue("Grid peak - ERCOT 4CP signal");
+    expect(screen.getByLabelText("Max duration (sec)")).toHaveValue(1800);
+    expect(screen.getByLabelText("Batch size (miners)")).toHaveValue(10);
+    expect(screen.getByLabelText("Batch interval (sec)")).toHaveValue(120);
+    expect(screen.queryByLabelText("Fixed target reduction (kW)")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Min duration (sec)")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Miners\s+Select/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("Include miners in maintenance")).not.toBeInTheDocument();
+    expect(screen.queryByText("Configure your curtailment to see a preview.")).not.toBeInTheDocument();
+    expect(mockUseCurtailmentPlanPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disabled: true,
+      }),
+    );
 
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
-        targetKw: "40",
+        maxDurationSec: "1800",
         restoreBatchSize: "10",
         restoreIntervalSec: "120",
         reason: "Grid peak - ERCOT 4CP signal",

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -182,16 +182,43 @@ describe("CurtailmentStartModal", () => {
       }),
     );
 
-    await user.click(screen.getByRole("button", { name: "Save" }));
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+
+    await user.clear(screen.getByLabelText("Batch interval (sec)"));
+    await user.type(screen.getByLabelText("Batch interval (sec)"), "180");
+    expect(saveButton).toBeEnabled();
+    await user.click(saveButton);
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         maxDurationSec: "1800",
         restoreBatchSize: "10",
-        restoreIntervalSec: "120",
+        restoreIntervalSec: "180",
         reason: "Grid peak - ERCOT 4CP signal",
       }),
     );
+  });
+
+  it("blocks max duration clears in edit mode", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      mode: "edit",
+      initialValues: {
+        ...configuredValues,
+        includeMaintenance: false,
+      },
+      preview,
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+
+    await user.clear(screen.getByLabelText("Max duration (sec)"));
+
+    expect(screen.getByText("Max duration cannot be cleared.")).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+
+    await user.click(saveButton);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("renders a stop curtailment action in edit mode", async () => {

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -199,6 +199,40 @@ describe("CurtailmentStartModal", () => {
     );
   });
 
+  it("keeps in-progress edit values when initial values refresh", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderModal({
+      mode: "edit",
+      initialValues: {
+        ...configuredValues,
+        includeMaintenance: false,
+      },
+      preview,
+    });
+
+    await user.clear(screen.getByLabelText("Reason"));
+    await user.type(screen.getByLabelText("Reason"), "Operator draft");
+
+    rerender(
+      <CurtailmentStartModal
+        open
+        mode="edit"
+        initialValues={{
+          ...configuredValues,
+          reason: "Server refresh",
+          restoreIntervalSec: "240",
+          includeMaintenance: false,
+        }}
+        onDismiss={vi.fn()}
+        onSubmit={vi.fn()}
+        preview={preview}
+      />,
+    );
+
+    expect(screen.getByLabelText("Reason")).toHaveValue("Operator draft");
+    expect(screen.getByLabelText("Batch interval (sec)")).toHaveValue(120);
+  });
+
   it("blocks max duration clears in edit mode", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
@@ -214,6 +248,27 @@ describe("CurtailmentStartModal", () => {
     await user.clear(screen.getByLabelText("Max duration (sec)"));
 
     expect(screen.getByText("Max duration cannot be cleared.")).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+
+    await user.click(saveButton);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("blocks restore interval clears in edit mode", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      mode: "edit",
+      initialValues: {
+        ...configuredValues,
+        includeMaintenance: false,
+      },
+      preview,
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+
+    await user.clear(screen.getByLabelText("Batch interval (sec)"));
+
+    expect(screen.getByText("Restore interval cannot be cleared.")).toBeInTheDocument();
     expect(saveButton).toBeDisabled();
 
     await user.click(saveButton);

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -220,6 +220,31 @@ describe("CurtailmentStartModal", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("submits edit mode without maintenance confirmation", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      mode: "edit",
+      initialValues: {
+        ...configuredValues,
+        includeMaintenance: true,
+      },
+      preview,
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+
+    await user.clear(screen.getByLabelText("Batch interval (sec)"));
+    await user.type(screen.getByLabelText("Batch interval (sec)"), "180");
+    await user.click(saveButton);
+
+    expect(screen.queryByText("Force include maintenance miners?")).not.toBeInTheDocument();
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeMaintenance: true,
+        restoreIntervalSec: "180",
+      }),
+    );
+  });
+
   it("renders a stop curtailment action in edit mode", async () => {
     const user = userEvent.setup();
     const onStopCurtailment = vi.fn();

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -141,12 +141,6 @@ function getInitialValues(initialValues?: Partial<CurtailmentFormValues>): Curta
   };
 }
 
-function getInitialValuesKey(initialValues?: Partial<CurtailmentFormValues>): string {
-  return Object.entries(getInitialValues(initialValues))
-    .map(([key, value]) => `${key}:${String(value)}`)
-    .join("|");
-}
-
 function parseRequiredPositiveNumberField(value: string, fieldLabel: string): ParsedNumberField {
   const trimmed = value.trim();
   if (trimmed === "") {
@@ -239,6 +233,14 @@ function validateCurtailmentFormValues(
   }
   if (restoreInterval.error) {
     localErrors.restoreIntervalSec = restoreInterval.error;
+  }
+  if (
+    isEditMode &&
+    restoreInterval.error === undefined &&
+    values.restoreIntervalSec.trim() === "" &&
+    initialValues.restoreIntervalSec.trim() !== ""
+  ) {
+    localErrors.restoreIntervalSec = "Restore interval cannot be cleared.";
   }
   if (
     minDuration.error === undefined &&
@@ -409,7 +411,7 @@ function CurtailmentStartModalContent({
   previewError,
   isSubmitting = false,
 }: CurtailmentStartModalProps): ReactElement {
-  const initialFormValues = useMemo(() => getInitialValues(initialValues), [initialValues]);
+  const [initialFormValues] = useState<CurtailmentFormValues>(() => getInitialValues(initialValues));
   const [values, setValues] = useState<CurtailmentFormValues>(() => initialFormValues);
   const [showMaintenanceConfirmation, setShowMaintenanceConfirmation] = useState(false);
   const [maintenanceInclusionConfirmed, setMaintenanceInclusionConfirmed] = useState(false);
@@ -700,7 +702,7 @@ function CurtailmentStartModal(props: CurtailmentStartModalProps): ReactElement 
     return null;
   }
 
-  return <CurtailmentStartModalContent key={getInitialValuesKey(props.initialValues)} {...props} />;
+  return <CurtailmentStartModalContent {...props} />;
 }
 
 export default CurtailmentStartModal;

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -211,6 +211,10 @@ function validateCurtailmentFormValues(
     label: "max duration",
     max: curtailmentNumericFieldLimits.maxDurationSec,
   });
+  const minDuration = parseOptionalUint32Field(isEditMode ? initialValues.minDurationSec : values.minDurationSec, {
+    label: "min duration",
+    max: curtailmentNumericFieldLimits.minDurationSec,
+  });
   const restoreInterval = parseOptionalUint32Field(values.restoreIntervalSec, {
     label: "batch interval",
     max: curtailmentNumericFieldLimits.restoreIntervalSec,
@@ -236,6 +240,15 @@ function validateCurtailmentFormValues(
   if (restoreInterval.error) {
     localErrors.restoreIntervalSec = restoreInterval.error;
   }
+  if (
+    minDuration.error === undefined &&
+    maxDuration.error === undefined &&
+    minDuration.parsed !== undefined &&
+    maxDuration.parsed !== undefined &&
+    minDuration.parsed > maxDuration.parsed
+  ) {
+    localErrors.maxDurationSec = "Max duration must be greater than or equal to min duration.";
+  }
 
   if (isEditMode) {
     return localErrors;
@@ -246,10 +259,6 @@ function validateCurtailmentFormValues(
   const restoreBatchSize = parseOptionalUint32Field(values.restoreBatchSize, {
     label: "batch size",
     max: curtailmentNumericFieldLimits.restoreBatchSize,
-  });
-  const minDuration = parseOptionalUint32Field(values.minDurationSec, {
-    label: "min duration",
-    max: curtailmentNumericFieldLimits.minDurationSec,
   });
 
   if (targetKw.error) {
@@ -263,15 +272,6 @@ function validateCurtailmentFormValues(
   }
   if (minDuration.error) {
     localErrors.minDurationSec = minDuration.error;
-  }
-  if (
-    minDuration.error === undefined &&
-    maxDuration.error === undefined &&
-    minDuration.parsed !== undefined &&
-    maxDuration.parsed !== undefined &&
-    minDuration.parsed > maxDuration.parsed
-  ) {
-    localErrors.maxDurationSec = "Max duration must be greater than or equal to min duration.";
   }
 
   return localErrors;

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -104,6 +104,13 @@ interface PreviewPaneProps {
   isPreviewLoading?: boolean;
 }
 
+interface PreviewStateOptions {
+  apiPreview: PreviewPaneProps;
+  controlledPreview?: PreviewPaneProps;
+  isEditMode: boolean;
+  unsupportedDeviceSetPreviewError?: string;
+}
+
 type ParsedNumberField = { parsed?: number; error?: string };
 
 const defaultValues: CurtailmentFormValues = {
@@ -334,6 +341,23 @@ function getSelectedMinerIds(values: CurtailmentFormValues): string[] {
   return values.deviceIdentifiers;
 }
 
+function getPreviewState({
+  apiPreview,
+  controlledPreview,
+  isEditMode,
+  unsupportedDeviceSetPreviewError,
+}: PreviewStateOptions): PreviewPaneProps {
+  if (isEditMode) {
+    return { preview: undefined, previewError: undefined, isPreviewLoading: false };
+  }
+
+  if (unsupportedDeviceSetPreviewError) {
+    return { preview: undefined, previewError: unsupportedDeviceSetPreviewError, isPreviewLoading: false };
+  }
+
+  return controlledPreview ?? apiPreview;
+}
+
 function CurtailmentStartModalContent({
   open,
   onDismiss,
@@ -358,31 +382,35 @@ function CurtailmentStartModalContent({
   const localErrors = useMemo(() => validateCurtailmentFormValues(values, mode), [mode, values]);
   const effectiveErrors = { ...errors, ...localErrors };
   const unsupportedDeviceSetPreviewError = getUnsupportedDeviceSetPreviewError(values);
-  const hasControlledPreview = isEditMode || preview !== undefined || previewError !== undefined;
+  const controlledPreview =
+    preview !== undefined || previewError !== undefined
+      ? { preview, previewError, isPreviewLoading: false }
+      : undefined;
   const apiPreview = useCurtailmentPlanPreview({
     open,
     values,
-    disabled: hasControlledPreview,
+    disabled: isEditMode || controlledPreview !== undefined,
   });
-  let previewState: PreviewPaneProps = hasControlledPreview
-    ? { preview, previewError, isPreviewLoading: false }
-    : apiPreview;
-
-  if (unsupportedDeviceSetPreviewError) {
-    previewState = { preview: undefined, previewError: unsupportedDeviceSetPreviewError, isPreviewLoading: false };
-  }
-  if (isEditMode) {
-    previewState = { preview: undefined, previewError: undefined, isPreviewLoading: false };
-  }
+  const previewState = getPreviewState({
+    apiPreview,
+    controlledPreview,
+    isEditMode,
+    unsupportedDeviceSetPreviewError,
+  });
 
   const hasBlockingValidationError =
     previewState.previewError !== undefined ||
     Object.keys(localErrors).length > 0 ||
     Object.keys(errors ?? {}).length > 0;
-  const selectedTargets = {
-    miners: getSelectedMinerIds(values),
-  };
+  const selectedMinerIds = getSelectedMinerIds(values);
   const previewPane = isEditMode ? null : <PreviewPane {...previewState} />;
+  const paneContainerClassName = isEditMode
+    ? "flex min-h-[calc(100dvh-200px)] w-full flex-1 flex-col laptop:px-10"
+    : undefined;
+  const primaryPaneClassName = isEditMode ? "mx-auto w-full max-w-[720px] laptop:pl-0" : undefined;
+  const secondaryPaneClassName = isEditMode
+    ? "!hidden"
+    : "!hidden !bg-transparent laptop:!flex laptop:!pl-0 laptop:!rounded-[24px]";
 
   const handleMinerSelection = (deviceIdentifiers: string[]) => {
     const hasSelectedMiners = deviceIdentifiers.length > 0;
@@ -536,7 +564,7 @@ function CurtailmentStartModalContent({
                   <div className="grid">
                     <TargetSelectButton
                       label="Miners"
-                      value={getTargetButtonLabel(selectedTargets.miners.length, "miner")}
+                      value={getTargetButtonLabel(selectedMinerIds.length, "miner")}
                       onClick={() => setShowMinerSelectionModal(true)}
                     />
                   </div>
@@ -565,13 +593,9 @@ function CurtailmentStartModalContent({
           </section>
         }
         secondaryPane={previewPane}
-        paneContainerClassName={
-          isEditMode ? "flex min-h-[calc(100dvh-200px)] w-full flex-1 flex-col laptop:px-10" : undefined
-        }
-        primaryPaneClassName={isEditMode ? "mx-auto w-full max-w-[720px] laptop:pl-0" : undefined}
-        secondaryPaneClassName={
-          isEditMode ? "!hidden" : "!hidden !bg-transparent laptop:!flex laptop:!pl-0 laptop:!rounded-[24px]"
-        }
+        paneContainerClassName={paneContainerClassName}
+        primaryPaneClassName={primaryPaneClassName}
+        secondaryPaneClassName={secondaryPaneClassName}
       />
       <Dialog
         open={showMaintenanceConfirmation}
@@ -604,7 +628,7 @@ function CurtailmentStartModalContent({
       {showMinerSelectionModal ? (
         <MinerSelectionModal
           open={showMinerSelectionModal}
-          selectedMinerIds={selectedTargets.miners}
+          selectedMinerIds={selectedMinerIds}
           onDismiss={() => setShowMinerSelectionModal(false)}
           onSave={(minerIds) => {
             handleMinerSelection(minerIds);

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -234,6 +234,9 @@ function validateCurtailmentFormValues(
   if (restoreInterval.error) {
     localErrors.restoreIntervalSec = restoreInterval.error;
   }
+  if (isEditMode && restoreInterval.error === undefined && restoreInterval.parsed === 0) {
+    localErrors.restoreIntervalSec = "Enter batch interval greater than 0.";
+  }
   if (
     isEditMode &&
     restoreInterval.error === undefined &&

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -479,7 +479,7 @@ function CurtailmentStartModalContent({
       return;
     }
 
-    if (values.includeMaintenance && !maintenanceInclusionConfirmed) {
+    if (!isEditMode && values.includeMaintenance && !maintenanceInclusionConfirmed) {
       setSubmitAfterMaintenanceConfirmation(true);
       setShowMaintenanceConfirmation(true);
       return;

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -166,14 +166,12 @@ function parseOptionalNonNegativeNumberField(value: string, fieldLabel: string):
   return { parsed };
 }
 
-function validateCurtailmentFormValues(values: CurtailmentFormValues): CurtailmentFormErrors {
+function validateCurtailmentFormValues(
+  values: CurtailmentFormValues,
+  mode: CurtailmentStartModalMode = "create",
+): CurtailmentFormErrors {
   const localErrors: CurtailmentFormErrors = {};
-  const targetKw = parseRequiredPositiveNumberField(values.targetKw, "a target reduction");
-  const toleranceKw = parseOptionalNonNegativeNumberField(values.toleranceKw, "a tolerance");
-  const minDuration = parseOptionalUint32Field(values.minDurationSec, {
-    label: "min duration",
-    max: curtailmentNumericFieldLimits.minDurationSec,
-  });
+  const isEditMode = mode === "edit";
   const maxDuration = parseOptionalUint32Field(values.maxDurationSec, {
     label: "max duration",
     max: curtailmentNumericFieldLimits.maxDurationSec,
@@ -187,17 +185,8 @@ function validateCurtailmentFormValues(values: CurtailmentFormValues): Curtailme
     max: curtailmentNumericFieldLimits.restoreIntervalSec,
   });
 
-  if (targetKw.error) {
-    localErrors.targetKw = targetKw.error;
-  }
-  if (toleranceKw.error) {
-    localErrors.toleranceKw = toleranceKw.error;
-  }
   if (values.reason.trim() === "") {
     localErrors.reason = "Enter a reason.";
-  }
-  if (minDuration.error) {
-    localErrors.minDurationSec = minDuration.error;
   }
   if (maxDuration.error) {
     localErrors.maxDurationSec = maxDuration.error;
@@ -207,6 +196,27 @@ function validateCurtailmentFormValues(values: CurtailmentFormValues): Curtailme
   }
   if (restoreInterval.error) {
     localErrors.restoreIntervalSec = restoreInterval.error;
+  }
+
+  if (isEditMode) {
+    return localErrors;
+  }
+
+  const targetKw = parseRequiredPositiveNumberField(values.targetKw, "a target reduction");
+  const toleranceKw = parseOptionalNonNegativeNumberField(values.toleranceKw, "a tolerance");
+  const minDuration = parseOptionalUint32Field(values.minDurationSec, {
+    label: "min duration",
+    max: curtailmentNumericFieldLimits.minDurationSec,
+  });
+
+  if (targetKw.error) {
+    localErrors.targetKw = targetKw.error;
+  }
+  if (toleranceKw.error) {
+    localErrors.toleranceKw = toleranceKw.error;
+  }
+  if (minDuration.error) {
+    localErrors.minDurationSec = minDuration.error;
   }
   if (
     minDuration.error === undefined &&
@@ -344,11 +354,11 @@ function CurtailmentStartModalContent({
   const updateValue = <Key extends keyof CurtailmentFormValues>(key: Key, value: CurtailmentFormValues[Key]) =>
     setValues((current) => ({ ...current, [key]: value }));
   const updateValues = (updater: (current: CurtailmentFormValues) => CurtailmentFormValues) => setValues(updater);
-  const localErrors = useMemo(() => validateCurtailmentFormValues(values), [values]);
-  const effectiveErrors = { ...errors, ...localErrors };
   const isEditMode = mode === "edit";
+  const localErrors = useMemo(() => validateCurtailmentFormValues(values, mode), [mode, values]);
+  const effectiveErrors = { ...errors, ...localErrors };
   const unsupportedDeviceSetPreviewError = getUnsupportedDeviceSetPreviewError(values);
-  const hasControlledPreview = preview !== undefined || previewError !== undefined;
+  const hasControlledPreview = isEditMode || preview !== undefined || previewError !== undefined;
   const apiPreview = useCurtailmentPlanPreview({
     open,
     values,
@@ -361,6 +371,9 @@ function CurtailmentStartModalContent({
   if (unsupportedDeviceSetPreviewError) {
     previewState = { preview: undefined, previewError: unsupportedDeviceSetPreviewError, isPreviewLoading: false };
   }
+  if (isEditMode) {
+    previewState = { preview: undefined, previewError: undefined, isPreviewLoading: false };
+  }
 
   const hasBlockingValidationError =
     previewState.previewError !== undefined ||
@@ -369,7 +382,7 @@ function CurtailmentStartModalContent({
   const selectedTargets = {
     miners: getSelectedMinerIds(values),
   };
-  const previewPane = <PreviewPane {...previewState} />;
+  const previewPane = isEditMode ? null : <PreviewPane {...previewState} />;
 
   const handleMinerSelection = (deviceIdentifiers: string[]) => {
     const hasSelectedMiners = deviceIdentifiers.length > 0;
@@ -443,7 +456,7 @@ function CurtailmentStartModalContent({
         onDismiss={onDismiss}
         isBusy={isSubmitting}
         buttons={buttons}
-        abovePanes={<div className="px-6 pb-6 laptop:hidden">{previewPane}</div>}
+        abovePanes={previewPane ? <div className="px-6 pb-6 laptop:hidden">{previewPane}</div> : null}
         primaryPane={
           <section className="flex flex-col gap-12 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
             <Field
@@ -455,36 +468,48 @@ function CurtailmentStartModalContent({
               onChange={(value) => updateValue("reason", value)}
             />
 
-            <Section
-              title="Curtail behavior"
-              subtext="Fleet will automatically curtail the least efficient miners first."
-            >
-              <div className="grid gap-3">
+            {isEditMode ? (
+              <Section title="Curtail behavior">
                 <Field
-                  id="curtailment-target-kw"
-                  label="Fixed target reduction (kW)"
-                  value={values.targetKw}
-                  error={effectiveErrors.targetKw}
-                  onChange={(value) => updateValue("targetKw", value)}
+                  id="curtailment-max-duration"
+                  label="Max duration (sec)"
+                  value={values.maxDurationSec}
+                  error={effectiveErrors.maxDurationSec}
+                  onChange={(value) => updateValue("maxDurationSec", value)}
                 />
-                <div className="grid gap-3 tablet:grid-cols-2">
+              </Section>
+            ) : (
+              <Section
+                title="Curtail behavior"
+                subtext="Fleet will automatically curtail the least efficient miners first."
+              >
+                <div className="grid gap-3">
                   <Field
-                    id="curtailment-min-duration"
-                    label="Min duration (sec)"
-                    value={values.minDurationSec}
-                    error={effectiveErrors.minDurationSec}
-                    onChange={(value) => updateValue("minDurationSec", value)}
+                    id="curtailment-target-kw"
+                    label="Fixed target reduction (kW)"
+                    value={values.targetKw}
+                    error={effectiveErrors.targetKw}
+                    onChange={(value) => updateValue("targetKw", value)}
                   />
-                  <Field
-                    id="curtailment-max-duration"
-                    label="Max duration (sec)"
-                    value={values.maxDurationSec}
-                    error={effectiveErrors.maxDurationSec}
-                    onChange={(value) => updateValue("maxDurationSec", value)}
-                  />
+                  <div className="grid gap-3 tablet:grid-cols-2">
+                    <Field
+                      id="curtailment-min-duration"
+                      label="Min duration (sec)"
+                      value={values.minDurationSec}
+                      error={effectiveErrors.minDurationSec}
+                      onChange={(value) => updateValue("minDurationSec", value)}
+                    />
+                    <Field
+                      id="curtailment-max-duration"
+                      label="Max duration (sec)"
+                      value={values.maxDurationSec}
+                      error={effectiveErrors.maxDurationSec}
+                      onChange={(value) => updateValue("maxDurationSec", value)}
+                    />
+                  </div>
                 </div>
-              </div>
-            </Section>
+              </Section>
+            )}
 
             <Section title="Restore behavior">
               <div className="grid gap-3 tablet:grid-cols-2">
@@ -505,38 +530,48 @@ function CurtailmentStartModalContent({
               </div>
             </Section>
 
-            <Section title="Apply to">
-              <div className="grid">
-                <TargetSelectButton
-                  label="Miners"
-                  value={getTargetButtonLabel(selectedTargets.miners.length, "miner")}
-                  onClick={() => setShowMinerSelectionModal(true)}
-                />
-              </div>
-            </Section>
+            {isEditMode ? null : (
+              <>
+                <Section title="Apply to">
+                  <div className="grid">
+                    <TargetSelectButton
+                      label="Miners"
+                      value={getTargetButtonLabel(selectedTargets.miners.length, "miner")}
+                      onClick={() => setShowMinerSelectionModal(true)}
+                    />
+                  </div>
+                </Section>
 
-            <label className="flex cursor-pointer items-start gap-3 text-left">
-              <Checkbox
-                checked={values.includeMaintenance}
-                onChange={(event) => {
-                  if (event.currentTarget.checked) {
-                    setSubmitAfterMaintenanceConfirmation(false);
-                    setShowMaintenanceConfirmation(true);
-                    return;
-                  }
+                <label className="flex cursor-pointer items-start gap-3 text-left">
+                  <Checkbox
+                    checked={values.includeMaintenance}
+                    onChange={(event) => {
+                      if (event.currentTarget.checked) {
+                        setSubmitAfterMaintenanceConfirmation(false);
+                        setShowMaintenanceConfirmation(true);
+                        return;
+                      }
 
-                  setMaintenanceInclusionConfirmed(false);
-                  updateValue("includeMaintenance", false);
-                }}
-              />
-              <span>
-                <span className="block text-300 text-text-primary">Include miners in maintenance</span>
-              </span>
-            </label>
+                      setMaintenanceInclusionConfirmed(false);
+                      updateValue("includeMaintenance", false);
+                    }}
+                  />
+                  <span>
+                    <span className="block text-300 text-text-primary">Include miners in maintenance</span>
+                  </span>
+                </label>
+              </>
+            )}
           </section>
         }
         secondaryPane={previewPane}
-        secondaryPaneClassName="!hidden !bg-transparent laptop:!flex laptop:!pl-0 laptop:!rounded-[24px]"
+        paneContainerClassName={
+          isEditMode ? "flex min-h-[calc(100dvh-200px)] w-full flex-1 flex-col laptop:px-10" : undefined
+        }
+        primaryPaneClassName={isEditMode ? "mx-auto w-full max-w-[720px] laptop:pl-0" : undefined}
+        secondaryPaneClassName={
+          isEditMode ? "!hidden" : "!hidden !bg-transparent laptop:!flex laptop:!pl-0 laptop:!rounded-[24px]"
+        }
       />
       <Dialog
         open={showMaintenanceConfirmation}

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -112,7 +112,7 @@ interface PreviewStateOptions {
 }
 
 type ParsedNumberField = { parsed?: number; error?: string };
-type EditableCurtailmentField = "reason" | "maxDurationSec" | "restoreBatchSize" | "restoreIntervalSec";
+type EditableCurtailmentField = "reason" | "maxDurationSec" | "restoreIntervalSec";
 
 const defaultValues: CurtailmentFormValues = {
   scopeType: "wholeOrg",
@@ -132,12 +132,7 @@ const defaultValues: CurtailmentFormValues = {
   reason: "",
   includeMaintenance: true,
 };
-const editableCurtailmentFields: EditableCurtailmentField[] = [
-  "reason",
-  "maxDurationSec",
-  "restoreBatchSize",
-  "restoreIntervalSec",
-];
+const editableCurtailmentFields: EditableCurtailmentField[] = ["reason", "maxDurationSec", "restoreIntervalSec"];
 
 function getInitialValues(initialValues?: Partial<CurtailmentFormValues>): CurtailmentFormValues {
   return {
@@ -198,13 +193,6 @@ function hasEditableCurtailmentChanges(values: CurtailmentFormValues, initialVal
       );
     }
 
-    if (field === "restoreBatchSize") {
-      return (
-        parseComparableUint32Field(values.restoreBatchSize, curtailmentNumericFieldLimits.restoreBatchSize) !==
-        parseComparableUint32Field(initialValues.restoreBatchSize, curtailmentNumericFieldLimits.restoreBatchSize)
-      );
-    }
-
     return (
       parseComparableUint32Field(values.restoreIntervalSec, curtailmentNumericFieldLimits.restoreIntervalSec) !==
       parseComparableUint32Field(initialValues.restoreIntervalSec, curtailmentNumericFieldLimits.restoreIntervalSec)
@@ -222,10 +210,6 @@ function validateCurtailmentFormValues(
   const maxDuration = parseOptionalUint32Field(values.maxDurationSec, {
     label: "max duration",
     max: curtailmentNumericFieldLimits.maxDurationSec,
-  });
-  const restoreBatchSize = parseOptionalUint32Field(values.restoreBatchSize, {
-    label: "batch size",
-    max: curtailmentNumericFieldLimits.restoreBatchSize,
   });
   const restoreInterval = parseOptionalUint32Field(values.restoreIntervalSec, {
     label: "batch interval",
@@ -249,9 +233,6 @@ function validateCurtailmentFormValues(
   ) {
     localErrors.maxDurationSec = "Max duration cannot be cleared.";
   }
-  if (restoreBatchSize.error) {
-    localErrors.restoreBatchSize = restoreBatchSize.error;
-  }
   if (restoreInterval.error) {
     localErrors.restoreIntervalSec = restoreInterval.error;
   }
@@ -262,6 +243,10 @@ function validateCurtailmentFormValues(
 
   const targetKw = parseRequiredPositiveNumberField(values.targetKw, "a target reduction");
   const toleranceKw = parseOptionalNonNegativeNumberField(values.toleranceKw, "a tolerance");
+  const restoreBatchSize = parseOptionalUint32Field(values.restoreBatchSize, {
+    label: "batch size",
+    max: curtailmentNumericFieldLimits.restoreBatchSize,
+  });
   const minDuration = parseOptionalUint32Field(values.minDurationSec, {
     label: "min duration",
     max: curtailmentNumericFieldLimits.minDurationSec,
@@ -272,6 +257,9 @@ function validateCurtailmentFormValues(
   }
   if (toleranceKw.error) {
     localErrors.toleranceKw = toleranceKw.error;
+  }
+  if (restoreBatchSize.error) {
+    localErrors.restoreBatchSize = restoreBatchSize.error;
   }
   if (minDuration.error) {
     localErrors.minDurationSec = minDuration.error;
@@ -597,14 +585,7 @@ function CurtailmentStartModalContent({
             )}
 
             <Section title="Restore behavior">
-              <div className="grid gap-3 tablet:grid-cols-2">
-                <Field
-                  id="curtailment-restore-batch-size"
-                  label="Batch size (miners)"
-                  value={values.restoreBatchSize}
-                  error={effectiveErrors.restoreBatchSize}
-                  onChange={(value) => updateValue("restoreBatchSize", value)}
-                />
+              {isEditMode ? (
                 <Field
                   id="curtailment-restore-batch-interval"
                   label="Batch interval (sec)"
@@ -612,7 +593,24 @@ function CurtailmentStartModalContent({
                   error={effectiveErrors.restoreIntervalSec}
                   onChange={(value) => updateValue("restoreIntervalSec", value)}
                 />
-              </div>
+              ) : (
+                <div className="grid gap-3 tablet:grid-cols-2">
+                  <Field
+                    id="curtailment-restore-batch-size"
+                    label="Batch size (miners)"
+                    value={values.restoreBatchSize}
+                    error={effectiveErrors.restoreBatchSize}
+                    onChange={(value) => updateValue("restoreBatchSize", value)}
+                  />
+                  <Field
+                    id="curtailment-restore-batch-interval"
+                    label="Batch interval (sec)"
+                    value={values.restoreIntervalSec}
+                    error={effectiveErrors.restoreIntervalSec}
+                    onChange={(value) => updateValue("restoreIntervalSec", value)}
+                  />
+                </div>
+              )}
             </Section>
 
             {isEditMode ? null : (

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -112,6 +112,7 @@ interface PreviewStateOptions {
 }
 
 type ParsedNumberField = { parsed?: number; error?: string };
+type EditableCurtailmentField = "reason" | "maxDurationSec" | "restoreBatchSize" | "restoreIntervalSec";
 
 const defaultValues: CurtailmentFormValues = {
   scopeType: "wholeOrg",
@@ -131,6 +132,12 @@ const defaultValues: CurtailmentFormValues = {
   reason: "",
   includeMaintenance: true,
 };
+const editableCurtailmentFields: EditableCurtailmentField[] = [
+  "reason",
+  "maxDurationSec",
+  "restoreBatchSize",
+  "restoreIntervalSec",
+];
 
 function getInitialValues(initialValues?: Partial<CurtailmentFormValues>): CurtailmentFormValues {
   return {
@@ -173,9 +180,42 @@ function parseOptionalNonNegativeNumberField(value: string, fieldLabel: string):
   return { parsed };
 }
 
+function parseComparableUint32Field(value: string, max: number): number {
+  const parsedField = parseOptionalUint32Field(value, { label: "value", max });
+  return parsedField.parsed ?? 0;
+}
+
+function hasEditableCurtailmentChanges(values: CurtailmentFormValues, initialValues: CurtailmentFormValues): boolean {
+  return editableCurtailmentFields.some((field) => {
+    if (field === "reason") {
+      return values.reason.trim() !== initialValues.reason.trim();
+    }
+
+    if (field === "maxDurationSec") {
+      return (
+        parseComparableUint32Field(values.maxDurationSec, curtailmentNumericFieldLimits.maxDurationSec) !==
+        parseComparableUint32Field(initialValues.maxDurationSec, curtailmentNumericFieldLimits.maxDurationSec)
+      );
+    }
+
+    if (field === "restoreBatchSize") {
+      return (
+        parseComparableUint32Field(values.restoreBatchSize, curtailmentNumericFieldLimits.restoreBatchSize) !==
+        parseComparableUint32Field(initialValues.restoreBatchSize, curtailmentNumericFieldLimits.restoreBatchSize)
+      );
+    }
+
+    return (
+      parseComparableUint32Field(values.restoreIntervalSec, curtailmentNumericFieldLimits.restoreIntervalSec) !==
+      parseComparableUint32Field(initialValues.restoreIntervalSec, curtailmentNumericFieldLimits.restoreIntervalSec)
+    );
+  });
+}
+
 function validateCurtailmentFormValues(
   values: CurtailmentFormValues,
   mode: CurtailmentStartModalMode = "create",
+  initialValues: CurtailmentFormValues = defaultValues,
 ): CurtailmentFormErrors {
   const localErrors: CurtailmentFormErrors = {};
   const isEditMode = mode === "edit";
@@ -197,6 +237,17 @@ function validateCurtailmentFormValues(
   }
   if (maxDuration.error) {
     localErrors.maxDurationSec = maxDuration.error;
+  }
+  if (isEditMode && maxDuration.error === undefined && maxDuration.parsed === 0) {
+    localErrors.maxDurationSec = "Enter max duration greater than 0.";
+  }
+  if (
+    isEditMode &&
+    maxDuration.error === undefined &&
+    values.maxDurationSec.trim() === "" &&
+    initialValues.maxDurationSec.trim() !== ""
+  ) {
+    localErrors.maxDurationSec = "Max duration cannot be cleared.";
   }
   if (restoreBatchSize.error) {
     localErrors.restoreBatchSize = restoreBatchSize.error;
@@ -370,7 +421,8 @@ function CurtailmentStartModalContent({
   previewError,
   isSubmitting = false,
 }: CurtailmentStartModalProps): ReactElement {
-  const [values, setValues] = useState<CurtailmentFormValues>(() => getInitialValues(initialValues));
+  const initialFormValues = useMemo(() => getInitialValues(initialValues), [initialValues]);
+  const [values, setValues] = useState<CurtailmentFormValues>(() => initialFormValues);
   const [showMaintenanceConfirmation, setShowMaintenanceConfirmation] = useState(false);
   const [maintenanceInclusionConfirmed, setMaintenanceInclusionConfirmed] = useState(false);
   const [submitAfterMaintenanceConfirmation, setSubmitAfterMaintenanceConfirmation] = useState(false);
@@ -379,7 +431,10 @@ function CurtailmentStartModalContent({
     setValues((current) => ({ ...current, [key]: value }));
   const updateValues = (updater: (current: CurtailmentFormValues) => CurtailmentFormValues) => setValues(updater);
   const isEditMode = mode === "edit";
-  const localErrors = useMemo(() => validateCurtailmentFormValues(values, mode), [mode, values]);
+  const localErrors = useMemo(
+    () => validateCurtailmentFormValues(values, mode, initialFormValues),
+    [initialFormValues, mode, values],
+  );
   const effectiveErrors = { ...errors, ...localErrors };
   const unsupportedDeviceSetPreviewError = getUnsupportedDeviceSetPreviewError(values);
   const controlledPreview =
@@ -402,6 +457,8 @@ function CurtailmentStartModalContent({
     previewState.previewError !== undefined ||
     Object.keys(localErrors).length > 0 ||
     Object.keys(errors ?? {}).length > 0;
+  const hasEditableChanges = !isEditMode || hasEditableCurtailmentChanges(values, initialFormValues);
+  const isSubmitDisabled = hasBlockingValidationError || !hasEditableChanges;
   const selectedMinerIds = getSelectedMinerIds(values);
   const previewPane = isEditMode ? null : <PreviewPane {...previewState} />;
   const paneContainerClassName = isEditMode
@@ -430,7 +487,7 @@ function CurtailmentStartModalContent({
   };
 
   const handleSubmit = () => {
-    if (hasBlockingValidationError) {
+    if (isSubmitDisabled) {
       return;
     }
 
@@ -458,7 +515,7 @@ function CurtailmentStartModalContent({
     text: isEditMode ? "Save" : "Start curtailment",
     variant: variants.primary,
     onClick: handleSubmit,
-    disabled: hasBlockingValidationError,
+    disabled: isSubmitDisabled,
     loading: isSubmitting,
   });
 

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
@@ -186,4 +186,20 @@ describe("curtailmentRequestBuilders", () => {
       ),
     ).toThrow("Enter max duration greater than 0.");
   });
+
+  it("rejects zero restore interval updates", () => {
+    expect(() =>
+      buildUpdateCurtailmentEventRequest(
+        "curt-1",
+        {
+          ...baseValues,
+          restoreIntervalSec: "0",
+        },
+        {
+          ...baseValues,
+          restoreIntervalSec: "60",
+        },
+      ),
+    ).toThrow("Enter restore batch interval greater than 0.");
+  });
 });

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
@@ -152,6 +152,25 @@ describe("curtailmentRequestBuilders", () => {
     expect(request.maxDurationSeconds).toBeUndefined();
   });
 
+  it("does not send zero when an update clears restore interval", () => {
+    const request = buildUpdateCurtailmentEventRequest(
+      "curt-1",
+      {
+        ...baseValues,
+        reason: "Updated grid peak",
+        restoreIntervalSec: "",
+      },
+      {
+        ...baseValues,
+        reason: "Grid peak",
+        restoreIntervalSec: "60",
+      },
+    );
+
+    expect(request.reason).toBe("Updated grid peak");
+    expect(request.restoreBatchIntervalSec).toBeUndefined();
+  });
+
   it("rejects zero max duration updates", () => {
     expect(() =>
       buildUpdateCurtailmentEventRequest(

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
@@ -114,20 +114,23 @@ describe("curtailmentRequestBuilders", () => {
     expect(request.restoreBatchSize).toBeUndefined();
   });
 
-  it("sends zero when an update clears a numeric setting", () => {
+  it("does not include restore batch size in update requests", () => {
     const request = buildUpdateCurtailmentEventRequest(
       "curt-1",
       {
         ...baseValues,
-        restoreBatchSize: "",
+        reason: "Updated grid peak",
+        restoreBatchSize: "20",
       },
       {
         ...baseValues,
+        reason: "Grid peak",
         restoreBatchSize: "10",
       },
     );
 
-    expect(request.restoreBatchSize).toBe(0);
+    expect(request.reason).toBe("Updated grid peak");
+    expect(request.restoreBatchSize).toBeUndefined();
   });
 
   it("does not send zero when an update clears max duration", () => {

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildStartCurtailmentRequest } from "@/protoFleet/features/energy/curtailmentRequestBuilders";
+import {
+  buildStartCurtailmentRequest,
+  buildUpdateCurtailmentEventRequest,
+} from "@/protoFleet/features/energy/curtailmentRequestBuilders";
 import type { CurtailmentSubmitValues } from "@/protoFleet/features/energy/CurtailmentStartModal";
 
 const baseValues: CurtailmentSubmitValues = {
@@ -79,5 +82,25 @@ describe("curtailmentRequestBuilders", () => {
         maxDurationSec: "604801",
       }),
     ).toThrow("Enter max duration of 604,800 or less.");
+  });
+
+  it("builds update requests with optional operator-safe fields only when provided", () => {
+    const request = buildUpdateCurtailmentEventRequest("curt-1", {
+      ...baseValues,
+      reason: "  Updated grid peak  ",
+      maxDurationSec: "1800",
+      restoreBatchSize: "",
+      restoreIntervalSec: "0",
+    });
+
+    expect(request).toEqual(
+      expect.objectContaining({
+        eventUuid: "curt-1",
+        reason: "Updated grid peak",
+        maxDurationSeconds: 1800,
+        restoreBatchIntervalSec: 0,
+      }),
+    );
+    expect(request.restoreBatchSize).toBeUndefined();
   });
 });

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
@@ -129,4 +129,39 @@ describe("curtailmentRequestBuilders", () => {
 
     expect(request.restoreBatchSize).toBe(0);
   });
+
+  it("does not send zero when an update clears max duration", () => {
+    const request = buildUpdateCurtailmentEventRequest(
+      "curt-1",
+      {
+        ...baseValues,
+        reason: "Updated grid peak",
+        maxDurationSec: "",
+      },
+      {
+        ...baseValues,
+        reason: "Grid peak",
+        maxDurationSec: "1800",
+      },
+    );
+
+    expect(request.reason).toBe("Updated grid peak");
+    expect(request.maxDurationSeconds).toBeUndefined();
+  });
+
+  it("rejects zero max duration updates", () => {
+    expect(() =>
+      buildUpdateCurtailmentEventRequest(
+        "curt-1",
+        {
+          ...baseValues,
+          maxDurationSec: "0",
+        },
+        {
+          ...baseValues,
+          maxDurationSec: "1800",
+        },
+      ),
+    ).toThrow("Enter max duration greater than 0.");
+  });
 });

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts
@@ -84,23 +84,49 @@ describe("curtailmentRequestBuilders", () => {
     ).toThrow("Enter max duration of 604,800 or less.");
   });
 
-  it("builds update requests with optional operator-safe fields only when provided", () => {
-    const request = buildUpdateCurtailmentEventRequest("curt-1", {
-      ...baseValues,
-      reason: "  Updated grid peak  ",
-      maxDurationSec: "1800",
-      restoreBatchSize: "",
-      restoreIntervalSec: "0",
-    });
+  it("builds update requests with changed operator-safe fields only", () => {
+    const request = buildUpdateCurtailmentEventRequest(
+      "curt-1",
+      {
+        ...baseValues,
+        reason: "  Updated grid peak  ",
+        maxDurationSec: "1800",
+        restoreBatchSize: "",
+        restoreIntervalSec: "120",
+      },
+      {
+        ...baseValues,
+        reason: "Grid peak",
+        maxDurationSec: "1800",
+        restoreBatchSize: "",
+        restoreIntervalSec: "60",
+      },
+    );
 
     expect(request).toEqual(
       expect.objectContaining({
         eventUuid: "curt-1",
         reason: "Updated grid peak",
-        maxDurationSeconds: 1800,
-        restoreBatchIntervalSec: 0,
+        restoreBatchIntervalSec: 120,
       }),
     );
+    expect(request.maxDurationSeconds).toBeUndefined();
     expect(request.restoreBatchSize).toBeUndefined();
+  });
+
+  it("sends zero when an update clears a numeric setting", () => {
+    const request = buildUpdateCurtailmentEventRequest(
+      "curt-1",
+      {
+        ...baseValues,
+        restoreBatchSize: "",
+      },
+      {
+        ...baseValues,
+        restoreBatchSize: "10",
+      },
+    );
+
+    expect(request.restoreBatchSize).toBe(0);
   });
 });

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
@@ -181,11 +181,6 @@ export function buildUpdateCurtailmentEventRequest(
       initialValues?.maxDurationSec,
       maxDurationOptions,
     ),
-    restoreBatchSize: getChangedUpdateUint32Setting(
-      values.restoreBatchSize,
-      initialValues?.restoreBatchSize,
-      restoreBatchSizeOptions,
-    ),
     restoreBatchIntervalSec: getChangedUpdateUint32Setting(
       values.restoreIntervalSec,
       initialValues?.restoreIntervalSec,

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
@@ -88,6 +88,28 @@ function getChangedUpdateUint32Setting(
   return nextValue === previousValue ? undefined : nextValue;
 }
 
+function getChangedUpdatePositiveUint32Setting(
+  value: string,
+  initialValue: string | undefined,
+  options: OptionalUint32FieldOptions,
+): number | undefined {
+  const nextValue = getOptionalUpdateUint32Setting(value, options);
+  if (nextValue === 0) {
+    throw new Error(`Enter ${options.label} greater than 0.`);
+  }
+
+  if (initialValue === undefined || initialValue.trim() === "") {
+    return nextValue;
+  }
+
+  const previousValue = getOptionalUpdateUint32Setting(initialValue, options);
+  if (nextValue === undefined || nextValue === previousValue) {
+    return undefined;
+  }
+
+  return nextValue;
+}
+
 function getPriority(priority: CurtailmentSubmitValues["priority"]): ProtoCurtailmentPriority {
   return priority === "emergency" ? ProtoCurtailmentPriority.EMERGENCY : ProtoCurtailmentPriority.NORMAL;
 }
@@ -154,7 +176,7 @@ export function buildUpdateCurtailmentEventRequest(
   return create(UpdateCurtailmentEventRequestSchema, {
     eventUuid,
     reason: getChangedUpdateStringSetting(values.reason, initialValues?.reason),
-    maxDurationSeconds: getChangedUpdateUint32Setting(
+    maxDurationSeconds: getChangedUpdatePositiveUint32Setting(
       values.maxDurationSec,
       initialValues?.maxDurationSec,
       maxDurationOptions,

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
@@ -73,20 +73,6 @@ function getChangedUpdateStringSetting(value: string, initialValue?: string): st
   return trimmedValue === initialValue.trim() ? undefined : trimmedValue;
 }
 
-function getChangedUpdateUint32Setting(
-  value: string,
-  initialValue: string | undefined,
-  options: OptionalUint32FieldOptions,
-): number | undefined {
-  const nextValue = getOptionalUpdateUint32Setting(value, options);
-  if (nextValue === undefined) {
-    return undefined;
-  }
-
-  const previousValue = initialValue === undefined ? undefined : getOptionalUpdateUint32Setting(initialValue, options);
-  return nextValue === previousValue ? undefined : nextValue;
-}
-
 function getChangedUpdatePositiveUint32Setting(
   value: string,
   initialValue: string | undefined,
@@ -180,7 +166,7 @@ export function buildUpdateCurtailmentEventRequest(
       initialValues?.maxDurationSec,
       maxDurationOptions,
     ),
-    restoreBatchIntervalSec: getChangedUpdateUint32Setting(
+    restoreBatchIntervalSec: getChangedUpdatePositiveUint32Setting(
       values.restoreIntervalSec,
       initialValues?.restoreIntervalSec,
       restoreBatchIntervalOptions,

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
@@ -21,10 +21,29 @@ import {
 } from "@/protoFleet/features/energy/curtailmentNumericFields";
 import type { CurtailmentSubmitValues } from "@/protoFleet/features/energy/CurtailmentStartModal";
 
+type OptionalUint32FieldOptions = Parameters<typeof parseOptionalUint32Field>[1];
+
 type CurtailmentRequestFields = Pick<
   StartCurtailmentRequest,
   "scope" | "mode" | "strategy" | "level" | "priority" | "modeParams" | "includeMaintenance" | "forceIncludeMaintenance"
 >;
+
+const maxDurationOptions: OptionalUint32FieldOptions = {
+  label: "max duration",
+  max: curtailmentNumericFieldLimits.maxDurationSec,
+};
+const minCurtailedDurationOptions: OptionalUint32FieldOptions = {
+  label: "min curtailed duration",
+  max: curtailmentNumericFieldLimits.minDurationSec,
+};
+const restoreBatchSizeOptions: OptionalUint32FieldOptions = {
+  label: "restore batch size",
+  max: curtailmentNumericFieldLimits.restoreBatchSize,
+};
+const restoreBatchIntervalOptions: OptionalUint32FieldOptions = {
+  label: "restore batch interval",
+  max: curtailmentNumericFieldLimits.restoreIntervalSec,
+};
 
 function parseOptionalNumber(value: string): number | undefined {
   const trimmed = value.trim();
@@ -36,10 +55,7 @@ function parseOptionalNumber(value: string): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
-function getOptionalUpdateUint32Setting(
-  value: string,
-  options: Parameters<typeof parseOptionalUint32Field>[1],
-): number | undefined {
+function getOptionalUpdateUint32Setting(value: string, options: OptionalUint32FieldOptions): number | undefined {
   const parsedField = parseOptionalUint32Field(value, options);
   if (parsedField.error) {
     throw new Error(parsedField.error);
@@ -60,7 +76,7 @@ function getChangedUpdateStringSetting(value: string, initialValue?: string): st
 function getChangedUpdateUint32Setting(
   value: string,
   initialValue: string | undefined,
-  options: Parameters<typeof parseOptionalUint32Field>[1],
+  options: OptionalUint32FieldOptions,
 ): number | undefined {
   if (initialValue === undefined) {
     return getOptionalUpdateUint32Setting(value, options);
@@ -122,22 +138,10 @@ function buildCurtailmentRequestFields(values: CurtailmentSubmitValues): Curtail
 export function buildStartCurtailmentRequest(values: CurtailmentSubmitValues): StartCurtailmentRequest {
   return create(StartCurtailmentRequestSchema, {
     ...buildCurtailmentRequestFields(values),
-    maxDurationSeconds: getOptionalUint32Setting(values.maxDurationSec, {
-      label: "max duration",
-      max: curtailmentNumericFieldLimits.maxDurationSec,
-    }),
-    restoreBatchSize: getOptionalUint32Setting(values.restoreBatchSize, {
-      label: "restore batch size",
-      max: curtailmentNumericFieldLimits.restoreBatchSize,
-    }),
-    restoreBatchIntervalSec: getOptionalUint32Setting(values.restoreIntervalSec, {
-      label: "restore batch interval",
-      max: curtailmentNumericFieldLimits.restoreIntervalSec,
-    }),
-    minCurtailedDurationSec: getOptionalUint32Setting(values.minDurationSec, {
-      label: "min curtailed duration",
-      max: curtailmentNumericFieldLimits.minDurationSec,
-    }),
+    maxDurationSeconds: getOptionalUint32Setting(values.maxDurationSec, maxDurationOptions),
+    restoreBatchSize: getOptionalUint32Setting(values.restoreBatchSize, restoreBatchSizeOptions),
+    restoreBatchIntervalSec: getOptionalUint32Setting(values.restoreIntervalSec, restoreBatchIntervalOptions),
+    minCurtailedDurationSec: getOptionalUint32Setting(values.minDurationSec, minCurtailedDurationOptions),
     reason: values.reason.trim(),
   });
 }
@@ -150,21 +154,20 @@ export function buildUpdateCurtailmentEventRequest(
   return create(UpdateCurtailmentEventRequestSchema, {
     eventUuid,
     reason: getChangedUpdateStringSetting(values.reason, initialValues?.reason),
-    maxDurationSeconds: getChangedUpdateUint32Setting(values.maxDurationSec, initialValues?.maxDurationSec, {
-      label: "max duration",
-      max: curtailmentNumericFieldLimits.maxDurationSec,
-    }),
-    restoreBatchSize: getChangedUpdateUint32Setting(values.restoreBatchSize, initialValues?.restoreBatchSize, {
-      label: "restore batch size",
-      max: curtailmentNumericFieldLimits.restoreBatchSize,
-    }),
+    maxDurationSeconds: getChangedUpdateUint32Setting(
+      values.maxDurationSec,
+      initialValues?.maxDurationSec,
+      maxDurationOptions,
+    ),
+    restoreBatchSize: getChangedUpdateUint32Setting(
+      values.restoreBatchSize,
+      initialValues?.restoreBatchSize,
+      restoreBatchSizeOptions,
+    ),
     restoreBatchIntervalSec: getChangedUpdateUint32Setting(
       values.restoreIntervalSec,
       initialValues?.restoreIntervalSec,
-      {
-        label: "restore batch interval",
-        max: curtailmentNumericFieldLimits.restoreIntervalSec,
-      },
+      restoreBatchIntervalOptions,
     ),
   });
 }

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
@@ -78,13 +78,12 @@ function getChangedUpdateUint32Setting(
   initialValue: string | undefined,
   options: OptionalUint32FieldOptions,
 ): number | undefined {
-  if (initialValue === undefined) {
-    return getOptionalUpdateUint32Setting(value, options);
+  const nextValue = getOptionalUpdateUint32Setting(value, options);
+  if (nextValue === undefined) {
+    return undefined;
   }
 
-  const nextValue = getOptionalUpdateUint32Setting(value, options) ?? 0;
-  const previousValue = getOptionalUpdateUint32Setting(initialValue, options) ?? 0;
-
+  const previousValue = initialValue === undefined ? undefined : getOptionalUpdateUint32Setting(initialValue, options);
   return nextValue === previousValue ? undefined : nextValue;
 }
 

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
@@ -48,6 +48,30 @@ function getOptionalUpdateUint32Setting(
   return parsedField.parsed;
 }
 
+function getChangedUpdateStringSetting(value: string, initialValue?: string): string | undefined {
+  const trimmedValue = value.trim();
+  if (initialValue === undefined) {
+    return trimmedValue;
+  }
+
+  return trimmedValue === initialValue.trim() ? undefined : trimmedValue;
+}
+
+function getChangedUpdateUint32Setting(
+  value: string,
+  initialValue: string | undefined,
+  options: Parameters<typeof parseOptionalUint32Field>[1],
+): number | undefined {
+  if (initialValue === undefined) {
+    return getOptionalUpdateUint32Setting(value, options);
+  }
+
+  const nextValue = getOptionalUpdateUint32Setting(value, options) ?? 0;
+  const previousValue = getOptionalUpdateUint32Setting(initialValue, options) ?? 0;
+
+  return nextValue === previousValue ? undefined : nextValue;
+}
+
 function getPriority(priority: CurtailmentSubmitValues["priority"]): ProtoCurtailmentPriority {
   return priority === "emergency" ? ProtoCurtailmentPriority.EMERGENCY : ProtoCurtailmentPriority.NORMAL;
 }
@@ -121,21 +145,26 @@ export function buildStartCurtailmentRequest(values: CurtailmentSubmitValues): S
 export function buildUpdateCurtailmentEventRequest(
   eventUuid: string,
   values: CurtailmentSubmitValues,
+  initialValues?: Partial<CurtailmentSubmitValues>,
 ): UpdateCurtailmentEventRequest {
   return create(UpdateCurtailmentEventRequestSchema, {
     eventUuid,
-    reason: values.reason.trim(),
-    maxDurationSeconds: getOptionalUpdateUint32Setting(values.maxDurationSec, {
+    reason: getChangedUpdateStringSetting(values.reason, initialValues?.reason),
+    maxDurationSeconds: getChangedUpdateUint32Setting(values.maxDurationSec, initialValues?.maxDurationSec, {
       label: "max duration",
       max: curtailmentNumericFieldLimits.maxDurationSec,
     }),
-    restoreBatchSize: getOptionalUpdateUint32Setting(values.restoreBatchSize, {
+    restoreBatchSize: getChangedUpdateUint32Setting(values.restoreBatchSize, initialValues?.restoreBatchSize, {
       label: "restore batch size",
       max: curtailmentNumericFieldLimits.restoreBatchSize,
     }),
-    restoreBatchIntervalSec: getOptionalUpdateUint32Setting(values.restoreIntervalSec, {
-      label: "restore batch interval",
-      max: curtailmentNumericFieldLimits.restoreIntervalSec,
-    }),
+    restoreBatchIntervalSec: getChangedUpdateUint32Setting(
+      values.restoreIntervalSec,
+      initialValues?.restoreIntervalSec,
+      {
+        label: "restore batch interval",
+        max: curtailmentNumericFieldLimits.restoreIntervalSec,
+      },
+    ),
   });
 }

--- a/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
+++ b/client/src/protoFleet/features/energy/curtailmentRequestBuilders.ts
@@ -11,10 +11,13 @@ import {
   ScopeWholeOrgSchema,
   type StartCurtailmentRequest,
   StartCurtailmentRequestSchema,
+  type UpdateCurtailmentEventRequest,
+  UpdateCurtailmentEventRequestSchema,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import {
   curtailmentNumericFieldLimits,
   getOptionalUint32Setting,
+  parseOptionalUint32Field,
 } from "@/protoFleet/features/energy/curtailmentNumericFields";
 import type { CurtailmentSubmitValues } from "@/protoFleet/features/energy/CurtailmentStartModal";
 
@@ -31,6 +34,18 @@ function parseOptionalNumber(value: string): number | undefined {
 
   const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function getOptionalUpdateUint32Setting(
+  value: string,
+  options: Parameters<typeof parseOptionalUint32Field>[1],
+): number | undefined {
+  const parsedField = parseOptionalUint32Field(value, options);
+  if (parsedField.error) {
+    throw new Error(parsedField.error);
+  }
+
+  return parsedField.parsed;
 }
 
 function getPriority(priority: CurtailmentSubmitValues["priority"]): ProtoCurtailmentPriority {
@@ -100,5 +115,27 @@ export function buildStartCurtailmentRequest(values: CurtailmentSubmitValues): S
       max: curtailmentNumericFieldLimits.minDurationSec,
     }),
     reason: values.reason.trim(),
+  });
+}
+
+export function buildUpdateCurtailmentEventRequest(
+  eventUuid: string,
+  values: CurtailmentSubmitValues,
+): UpdateCurtailmentEventRequest {
+  return create(UpdateCurtailmentEventRequestSchema, {
+    eventUuid,
+    reason: values.reason.trim(),
+    maxDurationSeconds: getOptionalUpdateUint32Setting(values.maxDurationSec, {
+      label: "max duration",
+      max: curtailmentNumericFieldLimits.maxDurationSec,
+    }),
+    restoreBatchSize: getOptionalUpdateUint32Setting(values.restoreBatchSize, {
+      label: "restore batch size",
+      max: curtailmentNumericFieldLimits.restoreBatchSize,
+    }),
+    restoreBatchIntervalSec: getOptionalUpdateUint32Setting(values.restoreIntervalSec, {
+      label: "restore batch interval",
+      max: curtailmentNumericFieldLimits.restoreIntervalSec,
+    }),
   });
 }


### PR DESCRIPTION
🤖 Created by AI agent for Negar.

## Summary
- Wire the active curtailment Manage flow to UpdateCurtailmentEvent
- Map live active-event data into the edit modal and refresh curtailment surfaces after update
- Add focused hook, panel, and request-builder coverage for the update path

## Test plan
- [ ] Open the active curtailment Manage modal and confirm fields are prefilled from the active event
- [ ] Save operator-safe changes and confirm active status/history/header data refresh
- [ ] Confirm start and stop/restore flows still work from the curtailment panel

Closes #328