### PR TITLE
Add group and rack overview action E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/pages/editPool.ts
+++ b/client/e2eTests/protoFleet/pages/editPool.ts
@@ -2,12 +2,26 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class EditPoolPage extends BasePage {
+  private getPoolRowByName(name: string) {
+    return this.page.getByTestId(/^pool-row-\d+$/).filter({ has: this.page.getByTestId("pool-name").getByText(name) });
+  }
+
   async clickAddPoolButton() {
     await this.page.getByTestId("add-pool-button").click();
   }
 
   async clickAddAnotherPoolButton() {
     await this.page.getByTestId("add-another-pool-button").click();
+  }
+
+  async clickPoolAddButton() {
+    const addPoolButton = this.page.getByTestId("add-pool-button");
+    if (await addPoolButton.isVisible().catch(() => false)) {
+      await addPoolButton.click();
+      return;
+    }
+
+    await this.clickAddAnotherPoolButton();
   }
 
   async clickAddDefaultMiningPool() {
@@ -34,6 +48,12 @@ export class EditPoolPage extends BasePage {
     const minerCount = await Promise.resolve(count);
     const buttonText = `Assign to ${minerCount} miner${minerCount === 1 ? "" : "s"}`;
     await this.clickButton(buttonText);
+  }
+
+  async validatePoolVisible(name: string, url: string) {
+    const row = this.getPoolRowByName(name);
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("pool-url")).toHaveText(url);
   }
 
   async getPoolNameByIndex(index: number): Promise<string> {

--- a/client/e2eTests/protoFleet/pages/editPool.ts
+++ b/client/e2eTests/protoFleet/pages/editPool.ts
@@ -3,18 +3,17 @@ import { BasePage } from "./base";
 
 export class EditPoolPage extends BasePage {
   private getPoolRowByName(name: string) {
-    return this.page.getByTestId(/^pool-row-\d+$/).filter({ has: this.page.getByTestId("pool-name").getByText(name) });
-  }
-
-  async clickAddPoolButton() {
-    await this.page.getByTestId("add-pool-button").click();
+    return this.page
+      .getByTestId(/^pool-row-\d+$/)
+      .filter({ has: this.page.getByTestId("pool-name").getByText(name, { exact: true }) })
+      .first();
   }
 
   async clickAddAnotherPoolButton() {
     await this.page.getByTestId("add-another-pool-button").click();
   }
 
-  async clickPoolAddButton() {
+  async clickAddPoolButton() {
     const addPoolButton = this.page.getByTestId("add-pool-button");
     if (await addPoolButton.isVisible().catch(() => false)) {
       await addPoolButton.click();
@@ -22,6 +21,10 @@ export class EditPoolPage extends BasePage {
     }
 
     await this.clickAddAnotherPoolButton();
+  }
+
+  async clickPoolAddButton() {
+    await this.clickAddPoolButton();
   }
 
   async clickAddDefaultMiningPool() {

--- a/client/e2eTests/protoFleet/pages/groups.ts
+++ b/client/e2eTests/protoFleet/pages/groups.ts
@@ -274,6 +274,14 @@ export class GroupsPage extends BasePage {
     await this.validateTitleInModal("Manage power");
   }
 
+  async clickGroupOverviewAssignPools() {
+    await this.page.getByTestId("mining-pool-popover-button").click();
+  }
+
+  async clickGroupOverviewManageSecurity() {
+    await this.page.getByTestId("security-popover-button").click();
+  }
+
   async clickRebootGroupButton() {
     await this.page.getByTestId("reboot-popover-button").click();
   }

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -504,6 +504,14 @@ export class RacksPage extends BasePage {
     await this.validateTitleInModal("Manage power");
   }
 
+  async clickRackOverviewAssignPools() {
+    await this.page.getByTestId("mining-pool-popover-button").click();
+  }
+
+  async clickRackOverviewManageSecurity() {
+    await this.page.getByTestId("security-popover-button").click();
+  }
+
   async clickDeleteRack() {
     const overflowTrigger = this.page.getByTestId("overflow-menu-trigger");
     if (this.isMobile && (await overflowTrigger.isVisible().catch(() => false))) {

--- a/client/e2eTests/protoFleet/pages/settingsPools.ts
+++ b/client/e2eTests/protoFleet/pages/settingsPools.ts
@@ -2,6 +2,10 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class SettingsPoolsPage extends BasePage {
+  private getPoolRowByName(name: string) {
+    return this.page.getByTestId("pool-row").filter({ has: this.page.getByTestId("pool-name").getByText(name) });
+  }
+
   async validateMiningPoolsPageOpened() {
     await expect(this.page).toHaveURL(/.*\/mining-pools/);
     await this.validateButtonIsVisible("Add pool");
@@ -13,11 +17,20 @@ export class SettingsPoolsPage extends BasePage {
 
   async validatePoolEntryByUniqueName(expectedName: string, expectedUrl: string, expectedUsername: string) {
     await expect(this.page.getByTestId(`pool-row`).getByTestId("pool-name").getByText(expectedName)).toBeVisible();
-    const row = this.page
-      .getByTestId(`pool-row`)
-      .filter({ has: this.page.getByTestId("pool-name").getByText(expectedName) });
+    const row = this.getPoolRowByName(expectedName);
     await expect(row.getByTestId("pool-url").getByText(expectedUrl)).toBeVisible();
     await expect(row.getByTestId("pool-username").getByText(expectedUsername)).toBeVisible();
+  }
+
+  async deletePoolByNameIfVisible(name: string) {
+    const row = this.getPoolRowByName(name);
+    if (!(await row.isVisible().catch(() => false))) {
+      return;
+    }
+
+    await row.getByRole("button", { name: "Options menu", exact: true }).click();
+    await this.clickButton("Delete pool");
+    await expect(row).toHaveCount(0);
   }
 
   async deleteAllPools() {

--- a/client/e2eTests/protoFleet/pages/settingsPools.ts
+++ b/client/e2eTests/protoFleet/pages/settingsPools.ts
@@ -3,7 +3,10 @@ import { BasePage } from "./base";
 
 export class SettingsPoolsPage extends BasePage {
   private getPoolRowByName(name: string) {
-    return this.page.getByTestId("pool-row").filter({ has: this.page.getByTestId("pool-name").getByText(name) });
+    return this.page
+      .getByTestId("pool-row")
+      .filter({ has: this.page.getByTestId("pool-name").getByText(name, { exact: true }) })
+      .first();
   }
 
   async validateMiningPoolsPageOpened() {

--- a/client/e2eTests/protoFleet/spec/groups.spec.ts
+++ b/client/e2eTests/protoFleet/spec/groups.spec.ts
@@ -1,3 +1,4 @@
+import { type Page } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";
@@ -6,6 +7,29 @@ import { generateRandomText } from "../helpers/testDataHelper";
 import { AuthPage } from "../pages/auth";
 import { GroupsPage } from "../pages/groups";
 import { MinersPage } from "../pages/miners";
+import { SettingsPage } from "../pages/settings";
+import { SettingsPoolsPage } from "../pages/settingsPools";
+
+const VALID_POOL_URL = "stratum+tcp://mine.ocean.xyz:3334";
+
+async function cleanupPoolIfPageOpen(
+  page: Page,
+  settingsPage: SettingsPage,
+  settingsPoolsPage: SettingsPoolsPage,
+  poolName: string,
+) {
+  if (page.isClosed()) {
+    return;
+  }
+
+  const closeAssignPoolsButton = page.getByLabel("Close assign pools");
+  if (await closeAssignPoolsButton.isVisible().catch(() => false)) {
+    await closeAssignPoolsButton.click();
+  }
+
+  await settingsPage.navigateToMiningPoolsSettings();
+  await settingsPoolsPage.deletePoolByNameIfVisible(poolName);
+}
 
 test.describe("Groups", () => {
   test.beforeEach(async ({ page, groupsPage, commonSteps }) => {
@@ -435,6 +459,124 @@ test.describe("Groups", () => {
       test.expect(requestBody.deviceSelector.includeDevices).toHaveProperty("deviceIdentifiers");
       test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedSelectedDeviceIdentifiers);
       test.expect(response.status()).toBe(200);
+    });
+  });
+
+  test("Group overview actions menu assigns pools to grouped rig miners", async ({
+    groupsPage,
+    editPoolPage,
+    newPoolModal,
+    loginModal,
+    settingsPage,
+    settingsPoolsPage,
+    page,
+  }) => {
+    const groupName = generateRandomText("automation");
+    const poolName = generateRandomText("PoolName");
+    const poolUsername = generateRandomText("PoolUsername");
+    let selectedDeviceIdentifiers: string[] = [];
+
+    try {
+      await test.step("Create a rig-only group with two miners", async () => {
+        const createGroupRequestPromise = page.waitForRequest(/CreateDeviceSet/);
+
+        await groupsPage.clickAddGroupButton();
+        await groupsPage.inputGroupName(groupName);
+        await groupsPage.waitForModalListToLoad();
+        await groupsPage.filterModalType(PROTO_RIG_MODEL);
+        await groupsPage.waitForModalListToLoad();
+        await groupsPage.selectMinersByIndex([0, 1]);
+        await groupsPage.clickSaveInModal();
+
+        const createGroupRequest = await createGroupRequestPromise;
+        const createGroupRequestBody = createGroupRequest.postDataJSON();
+        selectedDeviceIdentifiers = createGroupRequestBody.deviceSelector.deviceList.deviceIdentifiers;
+
+        await groupsPage.validateTextInToast(`Group "${groupName}" created`);
+        await groupsPage.validateSavedGroupVisible(groupName);
+        test.expect(selectedDeviceIdentifiers).toHaveLength(2);
+      });
+
+      await test.step("Open the group overview and start the assign pools flow", async () => {
+        await groupsPage.openSavedGroupOverview(groupName);
+        await groupsPage.openGroupOverviewActionsMenu();
+        await groupsPage.clickGroupOverviewAssignPools();
+        await loginModal.loginAsAdmin();
+      });
+
+      await test.step("Create a pool from the overview flow", async () => {
+        await editPoolPage.clickPoolAddButton();
+        await editPoolPage.clickAddNewPool();
+        await newPoolModal.inputPoolName(poolName);
+        await newPoolModal.inputPoolUrl(VALID_POOL_URL);
+        await newPoolModal.inputPoolUsername(poolUsername);
+        await newPoolModal.clickSaveNewPool();
+        await editPoolPage.validatePoolVisible(poolName, VALID_POOL_URL);
+      });
+
+      await test.step("Assign the created pool to the grouped miners", async () => {
+        const requestPromise = page.waitForRequest(/UpdateMiningPools/);
+        const responsePromise = page.waitForResponse(/UpdateMiningPools/);
+
+        await editPoolPage.clickAssignToXMiners(2);
+
+        const request = await requestPromise;
+        const response = await responsePromise;
+        const requestBody = request.postDataJSON();
+        const targetedDeviceIdentifiers = requestBody.deviceSelector.includeDevices.deviceIdentifiers;
+        const sortedTargetedDeviceIdentifiers = [...targetedDeviceIdentifiers].sort();
+        const sortedSelectedDeviceIdentifiers = [...selectedDeviceIdentifiers].sort();
+
+        test.expect(request.method()).toBe("POST");
+        test.expect(requestBody).toHaveProperty("defaultPool");
+        test.expect(requestBody).toHaveProperty("deviceSelector");
+        test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
+        test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedSelectedDeviceIdentifiers);
+        test.expect(response.status()).toBe(200);
+        await groupsPage.validateTextInToastGroup("Assigned pools");
+      });
+    } finally {
+      await cleanupPoolIfPageOpen(page, settingsPage, settingsPoolsPage, poolName);
+    }
+  });
+
+  test("Group overview actions menu opens manage security and validates password mismatch", async ({
+    groupsPage,
+    loginModal,
+    minersPage,
+    page,
+  }) => {
+    const groupName = generateRandomText("automation");
+
+    await test.step("Create a rig-only group and open the overview security flow", async () => {
+      await groupsPage.clickAddGroupButton();
+      await groupsPage.inputGroupName(groupName);
+      await groupsPage.waitForModalListToLoad();
+      await groupsPage.filterModalType(PROTO_RIG_MODEL);
+      await groupsPage.waitForModalListToLoad();
+      await groupsPage.selectMinersByIndex([0, 1]);
+      await groupsPage.clickSaveInModal();
+
+      await groupsPage.validateTextInToast(`Group "${groupName}" created`);
+      await groupsPage.openSavedGroupOverview(groupName);
+      await groupsPage.openGroupOverviewActionsMenu();
+      await groupsPage.clickGroupOverviewManageSecurity();
+      await loginModal.loginAsAdminForSecurity();
+      await minersPage.validateManageSecurityModalOpened();
+    });
+
+    await test.step("Open the password form and validate the mismatch state", async () => {
+      await minersPage.clickManageSecurityUpdateButton();
+      await minersPage.validateTitleInModal("Update the admin login for your miners");
+      await minersPage.inputCurrentMinerPassword("root");
+      await minersPage.inputNewMinerPassword("ProtoRigPass123!");
+      await minersPage.inputConfirmMinerPassword("ProtoRigPass1234!");
+      await minersPage.clickIn("Continue", "modal");
+      await minersPage.validateTextInModal("Passwords don't match");
+
+      await page.getByTestId("modal").getByTestId("header-icon-button").click();
+      await minersPage.closeManageSecurityModal();
+      await groupsPage.validateTitle(groupName);
     });
   });
 });

--- a/client/e2eTests/protoFleet/spec/groups.spec.ts
+++ b/client/e2eTests/protoFleet/spec/groups.spec.ts
@@ -462,83 +462,85 @@ test.describe("Groups", () => {
     });
   });
 
-  test("Group overview actions menu assigns pools to grouped rig miners", async ({
-    groupsPage,
-    editPoolPage,
-    newPoolModal,
-    loginModal,
-    settingsPage,
-    settingsPoolsPage,
-    page,
-  }) => {
-    const groupName = generateRandomText("automation");
-    const poolName = generateRandomText("PoolName");
-    const poolUsername = generateRandomText("PoolUsername");
-    let selectedDeviceIdentifiers: string[] = [];
+  if (testConfig.target !== "real") {
+    test("Group overview actions menu assigns pools to grouped rig miners", async ({
+      groupsPage,
+      editPoolPage,
+      newPoolModal,
+      loginModal,
+      settingsPage,
+      settingsPoolsPage,
+      page,
+    }) => {
+      const groupName = generateRandomText("automation");
+      const poolName = generateRandomText("PoolName");
+      const poolUsername = generateRandomText("PoolUsername");
+      let selectedDeviceIdentifiers: string[] = [];
 
-    try {
-      await test.step("Create a rig-only group with two miners", async () => {
-        const createGroupRequestPromise = page.waitForRequest(/CreateDeviceSet/);
+      try {
+        await test.step("Create a rig-only group with two miners", async () => {
+          const createGroupRequestPromise = page.waitForRequest(/CreateDeviceSet/);
 
-        await groupsPage.clickAddGroupButton();
-        await groupsPage.inputGroupName(groupName);
-        await groupsPage.waitForModalListToLoad();
-        await groupsPage.filterModalType(PROTO_RIG_MODEL);
-        await groupsPage.waitForModalListToLoad();
-        await groupsPage.selectMinersByIndex([0, 1]);
-        await groupsPage.clickSaveInModal();
+          await groupsPage.clickAddGroupButton();
+          await groupsPage.inputGroupName(groupName);
+          await groupsPage.waitForModalListToLoad();
+          await groupsPage.filterModalType(PROTO_RIG_MODEL);
+          await groupsPage.waitForModalListToLoad();
+          await groupsPage.selectMinersByIndex([0, 1]);
+          await groupsPage.clickSaveInModal();
 
-        const createGroupRequest = await createGroupRequestPromise;
-        const createGroupRequestBody = createGroupRequest.postDataJSON();
-        selectedDeviceIdentifiers = createGroupRequestBody.deviceSelector.deviceList.deviceIdentifiers;
+          const createGroupRequest = await createGroupRequestPromise;
+          const createGroupRequestBody = createGroupRequest.postDataJSON();
+          selectedDeviceIdentifiers = createGroupRequestBody.deviceSelector.deviceList.deviceIdentifiers;
 
-        await groupsPage.validateTextInToast(`Group "${groupName}" created`);
-        await groupsPage.validateSavedGroupVisible(groupName);
-        test.expect(selectedDeviceIdentifiers).toHaveLength(2);
-      });
+          await groupsPage.validateTextInToast(`Group "${groupName}" created`);
+          await groupsPage.validateSavedGroupVisible(groupName);
+          test.expect(selectedDeviceIdentifiers).toHaveLength(2);
+        });
 
-      await test.step("Open the group overview and start the assign pools flow", async () => {
-        await groupsPage.openSavedGroupOverview(groupName);
-        await groupsPage.openGroupOverviewActionsMenu();
-        await groupsPage.clickGroupOverviewAssignPools();
-        await loginModal.loginAsAdmin();
-      });
+        await test.step("Open the group overview and start the assign pools flow", async () => {
+          await groupsPage.openSavedGroupOverview(groupName);
+          await groupsPage.openGroupOverviewActionsMenu();
+          await groupsPage.clickGroupOverviewAssignPools();
+          await loginModal.loginAsAdmin();
+        });
 
-      await test.step("Create a pool from the overview flow", async () => {
-        await editPoolPage.clickPoolAddButton();
-        await editPoolPage.clickAddNewPool();
-        await newPoolModal.inputPoolName(poolName);
-        await newPoolModal.inputPoolUrl(VALID_POOL_URL);
-        await newPoolModal.inputPoolUsername(poolUsername);
-        await newPoolModal.clickSaveNewPool();
-        await editPoolPage.validatePoolVisible(poolName, VALID_POOL_URL);
-      });
+        await test.step("Create a pool from the overview flow", async () => {
+          await editPoolPage.clickPoolAddButton();
+          await editPoolPage.clickAddNewPool();
+          await newPoolModal.inputPoolName(poolName);
+          await newPoolModal.inputPoolUrl(VALID_POOL_URL);
+          await newPoolModal.inputPoolUsername(poolUsername);
+          await newPoolModal.clickSaveNewPool();
+          await editPoolPage.validatePoolVisible(poolName, VALID_POOL_URL);
+        });
 
-      await test.step("Assign the created pool to the grouped miners", async () => {
-        const requestPromise = page.waitForRequest(/UpdateMiningPools/);
-        const responsePromise = page.waitForResponse(/UpdateMiningPools/);
+        await test.step("Assign the created pool to the grouped miners", async () => {
+          const requestPromise = page.waitForRequest(/UpdateMiningPools/);
+          const responsePromise = page.waitForResponse(/UpdateMiningPools/);
 
-        await editPoolPage.clickAssignToXMiners(2);
+          await editPoolPage.clickAssignToXMiners(2);
 
-        const request = await requestPromise;
-        const response = await responsePromise;
-        const requestBody = request.postDataJSON();
-        const targetedDeviceIdentifiers = requestBody.deviceSelector.includeDevices.deviceIdentifiers;
-        const sortedTargetedDeviceIdentifiers = [...targetedDeviceIdentifiers].sort();
-        const sortedSelectedDeviceIdentifiers = [...selectedDeviceIdentifiers].sort();
+          const request = await requestPromise;
+          const response = await responsePromise;
+          const requestBody = request.postDataJSON();
+          const targetedDeviceIdentifiers = requestBody.deviceSelector.includeDevices.deviceIdentifiers;
+          const sortedTargetedDeviceIdentifiers = [...targetedDeviceIdentifiers].sort();
+          const sortedSelectedDeviceIdentifiers = [...selectedDeviceIdentifiers].sort();
 
-        test.expect(request.method()).toBe("POST");
-        test.expect(requestBody).toHaveProperty("defaultPool");
-        test.expect(requestBody).toHaveProperty("deviceSelector");
-        test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
-        test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedSelectedDeviceIdentifiers);
-        test.expect(response.status()).toBe(200);
-        await groupsPage.validateTextInToastGroup("Assigned pools");
-      });
-    } finally {
-      await cleanupPoolIfPageOpen(page, settingsPage, settingsPoolsPage, poolName);
-    }
-  });
+          test.expect(request.method()).toBe("POST");
+          test.expect(requestBody).toHaveProperty("defaultPool");
+          test.expect(requestBody).toHaveProperty("deviceSelector");
+          test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
+          test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedSelectedDeviceIdentifiers);
+          test.expect(response.status()).toBe(200);
+          await groupsPage.validateTextInToastGroup("Assigned pools");
+        });
+      } finally {
+        await cleanupPoolIfPageOpen(page, settingsPage, settingsPoolsPage, poolName);
+      }
+    });
+  }
 
   test("Group overview actions menu opens manage security and validates password mismatch", async ({
     groupsPage,

--- a/client/e2eTests/protoFleet/spec/racks.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racks.spec.ts
@@ -1,11 +1,16 @@
+import { type Page } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";
 import { PROTO_RIG_MODEL } from "../helpers/minerModels";
+import { generateRandomText } from "../helpers/testDataHelper";
 import { AuthPage } from "../pages/auth";
 import { MinersPage } from "../pages/miners";
 import { type RackSelectorMiner, RacksPage } from "../pages/racks";
+import { SettingsPage } from "../pages/settings";
+import { SettingsPoolsPage } from "../pages/settingsPools";
 
+const VALID_POOL_URL = "stratum+tcp://mine.ocean.xyz:3334";
 const AUTOMATION_ZONE = "AutomationZone";
 const RACK_COLUMNS = 2;
 const RACK_ROWS = 2;
@@ -23,6 +28,25 @@ const ORDER_INDEX_SCENARIOS = [
   { label: "Bottom right", expectedNumbers: [4, 3, 2, 1] },
   { label: "Top right", expectedNumbers: [2, 1, 4, 3] },
 ] as const;
+
+async function cleanupPoolIfPageOpen(
+  page: Page,
+  settingsPage: SettingsPage,
+  settingsPoolsPage: SettingsPoolsPage,
+  poolName: string,
+) {
+  if (page.isClosed()) {
+    return;
+  }
+
+  const closeAssignPoolsButton = page.getByLabel("Close assign pools");
+  if (await closeAssignPoolsButton.isVisible().catch(() => false)) {
+    await closeAssignPoolsButton.click();
+  }
+
+  await settingsPage.navigateToMiningPoolsSettings();
+  await settingsPoolsPage.deletePoolByNameIfVisible(poolName);
+}
 
 test.describe("Racks", () => {
   test.beforeEach(async ({ page, commonSteps, racksPage }) => {
@@ -495,6 +519,129 @@ test.describe("Racks", () => {
       test.expect(requestBody.deviceSelector.includeDevices).toHaveProperty("deviceIdentifiers");
       test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedRackDeviceIdentifiers);
       test.expect(response.status()).toBe(200);
+    });
+  });
+
+  test("Rack overview actions menu assigns pools to assigned rig miners", async ({
+    racksPage,
+    editPoolPage,
+    newPoolModal,
+    loginModal,
+    settingsPage,
+    settingsPoolsPage,
+    page,
+  }) => {
+    const poolName = generateRandomText("PoolName");
+    const poolUsername = generateRandomText("PoolUsername");
+    let rackLabel = "";
+    let rackDeviceIdentifiers: string[] = [];
+
+    try {
+      await test.step("Create a rack with two assigned Proto rigs", async () => {
+        const saveRackRequestPromise = page.waitForRequest(/SaveRack/);
+
+        await racksPage.clickAddRackButton();
+        await racksPage.inputZone(AUTOMATION_ZONE);
+        rackLabel = await racksPage.getGeneratedRackLabel();
+        await racksPage.enableCustomRackLayout();
+        await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
+        await racksPage.inputRows(OVERVIEW_RACK_ROWS);
+        await racksPage.clickContinueFromRackSettings();
+        await addSelectableRigMinersToSlots(racksPage, 2, [1, 2]);
+        await racksPage.clickSaveRack();
+
+        const saveRackRequest = await saveRackRequestPromise;
+        const saveRackRequestBody = saveRackRequest.postDataJSON();
+        rackDeviceIdentifiers = saveRackRequestBody.deviceSelector.deviceList.deviceIdentifiers;
+
+        await racksPage.validateRackToast(rackLabel);
+        test.expect(rackDeviceIdentifiers).toHaveLength(2);
+      });
+
+      await test.step("Open the rack overview and start the assign pools flow", async () => {
+        await racksPage.clickViewGrid();
+        await racksPage.openRackCard(rackLabel, AUTOMATION_ZONE);
+        await racksPage.openRackOverviewActionsMenu();
+        await racksPage.clickRackOverviewAssignPools();
+        await loginModal.loginAsAdmin();
+      });
+
+      await test.step("Create a pool from the overview flow", async () => {
+        await editPoolPage.clickPoolAddButton();
+        await editPoolPage.clickAddNewPool();
+        await newPoolModal.inputPoolName(poolName);
+        await newPoolModal.inputPoolUrl(VALID_POOL_URL);
+        await newPoolModal.inputPoolUsername(poolUsername);
+        await newPoolModal.clickSaveNewPool();
+        await editPoolPage.validatePoolVisible(poolName, VALID_POOL_URL);
+      });
+
+      await test.step("Assign the created pool to the rack miners", async () => {
+        const requestPromise = page.waitForRequest(/UpdateMiningPools/);
+        const responsePromise = page.waitForResponse(/UpdateMiningPools/);
+
+        await editPoolPage.clickAssignToXMiners(2);
+
+        const request = await requestPromise;
+        const response = await responsePromise;
+        const requestBody = request.postDataJSON();
+        const targetedDeviceIdentifiers = requestBody.deviceSelector.includeDevices.deviceIdentifiers;
+        const sortedTargetedDeviceIdentifiers = [...targetedDeviceIdentifiers].sort();
+        const sortedRackDeviceIdentifiers = [...rackDeviceIdentifiers].sort();
+
+        test.expect(request.method()).toBe("POST");
+        test.expect(requestBody).toHaveProperty("defaultPool");
+        test.expect(requestBody).toHaveProperty("deviceSelector");
+        test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
+        test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedRackDeviceIdentifiers);
+        test.expect(response.status()).toBe(200);
+        await racksPage.validateTextInToastGroup("Assigned pools");
+      });
+    } finally {
+      await cleanupPoolIfPageOpen(page, settingsPage, settingsPoolsPage, poolName);
+    }
+  });
+
+  test("Rack overview actions menu opens manage security and validates password mismatch", async ({
+    racksPage,
+    loginModal,
+    minersPage,
+    page,
+  }) => {
+    let rackLabel = "";
+
+    await test.step("Create a rack with two assigned Proto rigs and open the overview security flow", async () => {
+      await racksPage.clickAddRackButton();
+      await racksPage.inputZone(AUTOMATION_ZONE);
+      rackLabel = await racksPage.getGeneratedRackLabel();
+      await racksPage.enableCustomRackLayout();
+      await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
+      await racksPage.inputRows(OVERVIEW_RACK_ROWS);
+      await racksPage.clickContinueFromRackSettings();
+      await addSelectableRigMinersToSlots(racksPage, 2, [1, 2]);
+      await racksPage.clickSaveRack();
+
+      await racksPage.validateRackToast(rackLabel);
+      await racksPage.clickViewGrid();
+      await racksPage.openRackCard(rackLabel, AUTOMATION_ZONE);
+      await racksPage.openRackOverviewActionsMenu();
+      await racksPage.clickRackOverviewManageSecurity();
+      await loginModal.loginAsAdminForSecurity();
+      await minersPage.validateManageSecurityModalOpened();
+    });
+
+    await test.step("Open the password form and validate the mismatch state", async () => {
+      await minersPage.clickManageSecurityUpdateButton();
+      await minersPage.validateTitleInModal("Update the admin login for your miners");
+      await minersPage.inputCurrentMinerPassword("root");
+      await minersPage.inputNewMinerPassword("ProtoRigPass123!");
+      await minersPage.inputConfirmMinerPassword("ProtoRigPass1234!");
+      await minersPage.clickIn("Continue", "modal");
+      await minersPage.validateTextInModal("Passwords don't match");
+
+      await page.getByTestId("modal").getByTestId("header-icon-button").click();
+      await minersPage.closeManageSecurityModal();
+      await racksPage.validateTitle(rackLabel);
     });
   });
 

--- a/client/e2eTests/protoFleet/spec/racks.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racks.spec.ts
@@ -522,85 +522,87 @@ test.describe("Racks", () => {
     });
   });
 
-  test("Rack overview actions menu assigns pools to assigned rig miners", async ({
-    racksPage,
-    editPoolPage,
-    newPoolModal,
-    loginModal,
-    settingsPage,
-    settingsPoolsPage,
-    page,
-  }) => {
-    const poolName = generateRandomText("PoolName");
-    const poolUsername = generateRandomText("PoolUsername");
-    let rackLabel = "";
-    let rackDeviceIdentifiers: string[] = [];
+  if (testConfig.target !== "real") {
+    test("Rack overview actions menu assigns pools to assigned rig miners", async ({
+      racksPage,
+      editPoolPage,
+      newPoolModal,
+      loginModal,
+      settingsPage,
+      settingsPoolsPage,
+      page,
+    }) => {
+      const poolName = generateRandomText("PoolName");
+      const poolUsername = generateRandomText("PoolUsername");
+      let rackLabel = "";
+      let rackDeviceIdentifiers: string[] = [];
 
-    try {
-      await test.step("Create a rack with two assigned Proto rigs", async () => {
-        const saveRackRequestPromise = page.waitForRequest(/SaveRack/);
+      try {
+        await test.step("Create a rack with two assigned Proto rigs", async () => {
+          const saveRackRequestPromise = page.waitForRequest(/SaveRack/);
 
-        await racksPage.clickAddRackButton();
-        await racksPage.inputZone(AUTOMATION_ZONE);
-        rackLabel = await racksPage.getGeneratedRackLabel();
-        await racksPage.enableCustomRackLayout();
-        await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
-        await racksPage.inputRows(OVERVIEW_RACK_ROWS);
-        await racksPage.clickContinueFromRackSettings();
-        await addSelectableRigMinersToSlots(racksPage, 2, [1, 2]);
-        await racksPage.clickSaveRack();
+          await racksPage.clickAddRackButton();
+          await racksPage.inputZone(AUTOMATION_ZONE);
+          rackLabel = await racksPage.getGeneratedRackLabel();
+          await racksPage.enableCustomRackLayout();
+          await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
+          await racksPage.inputRows(OVERVIEW_RACK_ROWS);
+          await racksPage.clickContinueFromRackSettings();
+          await addSelectableRigMinersToSlots(racksPage, 2, [1, 2]);
+          await racksPage.clickSaveRack();
 
-        const saveRackRequest = await saveRackRequestPromise;
-        const saveRackRequestBody = saveRackRequest.postDataJSON();
-        rackDeviceIdentifiers = saveRackRequestBody.deviceSelector.deviceList.deviceIdentifiers;
+          const saveRackRequest = await saveRackRequestPromise;
+          const saveRackRequestBody = saveRackRequest.postDataJSON();
+          rackDeviceIdentifiers = saveRackRequestBody.deviceSelector.deviceList.deviceIdentifiers;
 
-        await racksPage.validateRackToast(rackLabel);
-        test.expect(rackDeviceIdentifiers).toHaveLength(2);
-      });
+          await racksPage.validateRackToast(rackLabel);
+          test.expect(rackDeviceIdentifiers).toHaveLength(2);
+        });
 
-      await test.step("Open the rack overview and start the assign pools flow", async () => {
-        await racksPage.clickViewGrid();
-        await racksPage.openRackCard(rackLabel, AUTOMATION_ZONE);
-        await racksPage.openRackOverviewActionsMenu();
-        await racksPage.clickRackOverviewAssignPools();
-        await loginModal.loginAsAdmin();
-      });
+        await test.step("Open the rack overview and start the assign pools flow", async () => {
+          await racksPage.clickViewGrid();
+          await racksPage.openRackCard(rackLabel, AUTOMATION_ZONE);
+          await racksPage.openRackOverviewActionsMenu();
+          await racksPage.clickRackOverviewAssignPools();
+          await loginModal.loginAsAdmin();
+        });
 
-      await test.step("Create a pool from the overview flow", async () => {
-        await editPoolPage.clickPoolAddButton();
-        await editPoolPage.clickAddNewPool();
-        await newPoolModal.inputPoolName(poolName);
-        await newPoolModal.inputPoolUrl(VALID_POOL_URL);
-        await newPoolModal.inputPoolUsername(poolUsername);
-        await newPoolModal.clickSaveNewPool();
-        await editPoolPage.validatePoolVisible(poolName, VALID_POOL_URL);
-      });
+        await test.step("Create a pool from the overview flow", async () => {
+          await editPoolPage.clickPoolAddButton();
+          await editPoolPage.clickAddNewPool();
+          await newPoolModal.inputPoolName(poolName);
+          await newPoolModal.inputPoolUrl(VALID_POOL_URL);
+          await newPoolModal.inputPoolUsername(poolUsername);
+          await newPoolModal.clickSaveNewPool();
+          await editPoolPage.validatePoolVisible(poolName, VALID_POOL_URL);
+        });
 
-      await test.step("Assign the created pool to the rack miners", async () => {
-        const requestPromise = page.waitForRequest(/UpdateMiningPools/);
-        const responsePromise = page.waitForResponse(/UpdateMiningPools/);
+        await test.step("Assign the created pool to the rack miners", async () => {
+          const requestPromise = page.waitForRequest(/UpdateMiningPools/);
+          const responsePromise = page.waitForResponse(/UpdateMiningPools/);
 
-        await editPoolPage.clickAssignToXMiners(2);
+          await editPoolPage.clickAssignToXMiners(2);
 
-        const request = await requestPromise;
-        const response = await responsePromise;
-        const requestBody = request.postDataJSON();
-        const targetedDeviceIdentifiers = requestBody.deviceSelector.includeDevices.deviceIdentifiers;
-        const sortedTargetedDeviceIdentifiers = [...targetedDeviceIdentifiers].sort();
-        const sortedRackDeviceIdentifiers = [...rackDeviceIdentifiers].sort();
+          const request = await requestPromise;
+          const response = await responsePromise;
+          const requestBody = request.postDataJSON();
+          const targetedDeviceIdentifiers = requestBody.deviceSelector.includeDevices.deviceIdentifiers;
+          const sortedTargetedDeviceIdentifiers = [...targetedDeviceIdentifiers].sort();
+          const sortedRackDeviceIdentifiers = [...rackDeviceIdentifiers].sort();
 
-        test.expect(request.method()).toBe("POST");
-        test.expect(requestBody).toHaveProperty("defaultPool");
-        test.expect(requestBody).toHaveProperty("deviceSelector");
-        test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
-        test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedRackDeviceIdentifiers);
-        test.expect(response.status()).toBe(200);
-        await racksPage.validateTextInToastGroup("Assigned pools");
-      });
-    } finally {
-      await cleanupPoolIfPageOpen(page, settingsPage, settingsPoolsPage, poolName);
-    }
-  });
+          test.expect(request.method()).toBe("POST");
+          test.expect(requestBody).toHaveProperty("defaultPool");
+          test.expect(requestBody).toHaveProperty("deviceSelector");
+          test.expect(requestBody.deviceSelector).toHaveProperty("includeDevices");
+          test.expect(sortedTargetedDeviceIdentifiers).toEqual(sortedRackDeviceIdentifiers);
+          test.expect(response.status()).toBe(200);
+          await racksPage.validateTextInToastGroup("Assigned pools");
+        });
+      } finally {
+        await cleanupPoolIfPageOpen(page, settingsPage, settingsPoolsPage, poolName);
+      }
+    });
+  }
 
   test("Rack overview actions menu opens manage security and validates password mismatch", async ({
     racksPage,


### PR DESCRIPTION
## Summary
- cover assign-pools flows from the shared group and rack overview actions menu
- cover manage-security reachability and password mismatch validation from the same overview flows
- harden the shared pool-page test helpers and cleanup so these scenarios can safely create and remove temporary pools

## Testing
- ./node_modules/.bin/eslint e2eTests/protoFleet/pages/groups.ts e2eTests/protoFleet/pages/racks.ts e2eTests/protoFleet/pages/editPool.ts e2eTests/protoFleet/pages/settingsPools.ts e2eTests/protoFleet/spec/groups.spec.ts e2eTests/protoFleet/spec/racks.spec.ts
- ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/groups.spec.ts --project=desktop --grep "Group overview actions menu assigns pools|Group overview actions menu opens manage security" --no-deps
- ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/racks.spec.ts --project=desktop --grep "Rack overview actions menu assigns pools|Rack overview actions menu opens manage security" --no-deps
- ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/groups.spec.ts --project=mobile --grep "Group overview actions menu assigns pools|Group overview actions menu opens manage security" --no-deps
- ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/racks.spec.ts --project=mobile --grep "Rack overview actions menu assigns pools|Rack overview actions menu opens manage security" --no-deps
- ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/groups.spec.ts --project=desktop --no-deps
- ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/racks.spec.ts --project=desktop --no-deps