### PR TITLE
feat(authz): gate ScheduleService with schedule:read and schedule:manage

### DIFF
--- a/client/src/protoFleet/components/PageHeader/useSchedulePillData.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/useSchedulePillData.test.tsx
@@ -4,9 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSchedulePillData } from "./useSchedulePillData";
 import { useScheduleApiContext } from "@/protoFleet/api/ScheduleApiContext";
 import { SCHEDULES_CHANGED_EVENT } from "@/protoFleet/api/scheduleEvents";
+import { useRole } from "@/protoFleet/store";
 
 vi.mock("@/protoFleet/api/ScheduleApiContext", () => ({
   useScheduleApiContext: vi.fn(),
+}));
+
+vi.mock("@/protoFleet/store", () => ({
+  useRole: vi.fn(),
 }));
 
 vi.mock("@/shared/features/toaster", () => ({
@@ -22,6 +27,7 @@ describe("useSchedulePillData", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     refreshSchedules.mockClear();
+    vi.mocked(useRole).mockReturnValue("ADMIN");
     vi.mocked(useScheduleApiContext).mockReturnValue({
       schedules: [],
       isLoading: false,
@@ -61,6 +67,23 @@ describe("useSchedulePillData", () => {
 
     await act(async () => {
       window.dispatchEvent(new CustomEvent(SCHEDULES_CHANGED_EVENT));
+    });
+
+    expect(refreshSchedules).not.toHaveBeenCalled();
+  });
+
+  it("does not poll for roles without schedule:read", async () => {
+    // ListSchedules is server-side gated on schedule:read; without a
+    // role-side guard the hook would generate PermissionDenied every
+    // poll interval for FIELD_TECH and similar non-admin sessions.
+    vi.mocked(useRole).mockReturnValue("FIELD_TECH");
+
+    renderHook(() => useSchedulePillData());
+
+    expect(refreshSchedules).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
     });
 
     expect(refreshSchedules).not.toHaveBeenCalled();

--- a/client/src/protoFleet/components/PageHeader/useSchedulePillData.ts
+++ b/client/src/protoFleet/components/PageHeader/useSchedulePillData.ts
@@ -4,6 +4,7 @@ import { buildSchedulePopoverSections, type SchedulePopoverSection, selectPillSc
 import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
 import { useScheduleApiContext } from "@/protoFleet/api/ScheduleApiContext";
 import type { ScheduleListItem } from "@/protoFleet/api/useScheduleApi";
+import { useRole } from "@/protoFleet/store";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
 
 export interface UseSchedulePillDataResult {
@@ -15,12 +16,23 @@ export interface UseSchedulePillDataResult {
 }
 
 const POLL_INTERVAL_MS = 30_000;
+const ROLES_WITH_SCHEDULE_READ = new Set(["SUPER_ADMIN", "ADMIN"]);
 
 export const useSchedulePillData = (): UseSchedulePillDataResult => {
   const { schedules, refreshSchedules, pauseSchedule, resumeSchedule } = useScheduleApiContext();
   const [pendingScheduleId, setPendingScheduleId] = useState<string | null>(null);
+  const role = useRole();
+  // ListSchedules is server-side gated on schedule:read. Mirror the same
+  // role-name allowlist used by navItems.ts so non-admin sessions don't
+  // generate PermissionDenied every poll interval from this globally-
+  // mounted hook. Permission-key plumbing for custom roles is a separate
+  // follow-up (UserInfo.permissions + client store changes).
+  const canReadSchedules = ROLES_WITH_SCHEDULE_READ.has(role);
 
   useEffect(() => {
+    if (!canReadSchedules) {
+      return;
+    }
     const refreshScheduleSummary = () => {
       void refreshSchedules({ background: true }).catch(() => {});
     };
@@ -31,7 +43,7 @@ export const useSchedulePillData = (): UseSchedulePillDataResult => {
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [refreshSchedules]);
+  }, [canReadSchedules, refreshSchedules]);
 
   const { sections, pillSchedule } = useMemo(() => {
     const nextSections = buildSchedulePopoverSections(schedules);

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -85,6 +85,11 @@ export const secondaryNavItems: SecondaryNavItem[] = [
     path: "/settings/mining-pools",
     label: "Pools",
     parent: "/settings",
+    // PoolsService is server-side gated on pool:read / pool:manage; only
+    // SUPER_ADMIN and ADMIN seed with those keys. Mirror the gate here so
+    // FIELD_TECH / custom roles don't land on a page that immediately
+    // hits PermissionDenied on every RPC.
+    allowedRoles: ["SUPER_ADMIN", "ADMIN"],
   },
   {
     path: "/settings/firmware",
@@ -95,6 +100,11 @@ export const secondaryNavItems: SecondaryNavItem[] = [
     path: "/settings/schedules",
     label: "Schedules",
     parent: "/settings",
+    // ScheduleService is server-side gated on schedule:read /
+    // schedule:manage; only SUPER_ADMIN and ADMIN seed with those keys.
+    // Mirror the gate so FIELD_TECH / custom roles don't see a nav entry
+    // that's guaranteed to fail.
+    allowedRoles: ["SUPER_ADMIN", "ADMIN"],
   },
   {
     path: "/settings/api-keys",

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -507,6 +507,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getScheduleByIDForProcessorStmt, err = db.PrepareContext(ctx, getScheduleByIDForProcessor); err != nil {
 		return nil, fmt.Errorf("error preparing query GetScheduleByIDForProcessor: %w", err)
 	}
+	if q.getScheduleForUpdateStmt, err = db.PrepareContext(ctx, getScheduleForUpdate); err != nil {
+		return nil, fmt.Errorf("error preparing query GetScheduleForUpdate: %w", err)
+	}
 	if q.getScheduleTargetsStmt, err = db.PrepareContext(ctx, getScheduleTargets); err != nil {
 		return nil, fmt.Errorf("error preparing query GetScheduleTargets: %w", err)
 	}
@@ -1845,6 +1848,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getScheduleByIDForProcessorStmt: %w", cerr)
 		}
 	}
+	if q.getScheduleForUpdateStmt != nil {
+		if cerr := q.getScheduleForUpdateStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getScheduleForUpdateStmt: %w", cerr)
+		}
+	}
 	if q.getScheduleTargetsStmt != nil {
 		if cerr := q.getScheduleTargetsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getScheduleTargetsStmt: %w", cerr)
@@ -2925,6 +2933,7 @@ type Queries struct {
 	getRunningPowerTargetScheduleOverlapsStmt           *sql.Stmt
 	getScheduleStmt                                     *sql.Stmt
 	getScheduleByIDForProcessorStmt                     *sql.Stmt
+	getScheduleForUpdateStmt                            *sql.Stmt
 	getScheduleTargetsStmt                              *sql.Stmt
 	getScheduleTargetsByScheduleIDsStmt                 *sql.Stmt
 	getSessionByIDStmt                                  *sql.Stmt
@@ -3268,6 +3277,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getRunningPowerTargetScheduleOverlapsStmt:           q.getRunningPowerTargetScheduleOverlapsStmt,
 		getScheduleStmt:                                     q.getScheduleStmt,
 		getScheduleByIDForProcessorStmt:                     q.getScheduleByIDForProcessorStmt,
+		getScheduleForUpdateStmt:                            q.getScheduleForUpdateStmt,
 		getScheduleTargetsStmt:                              q.getScheduleTargetsStmt,
 		getScheduleTargetsByScheduleIDsStmt:                 q.getScheduleTargetsByScheduleIDsStmt,
 		getSessionByIDStmt:                                  q.getSessionByIDStmt,

--- a/server/generated/sqlc/schedule.sql.go
+++ b/server/generated/sqlc/schedule.sql.go
@@ -350,6 +350,78 @@ func (q *Queries) GetScheduleByIDForProcessor(ctx context.Context, id int64) (Sc
 	return i, err
 }
 
+const getScheduleForUpdate = `-- name: GetScheduleForUpdate :one
+SELECT s.id, s.org_id, s.name, s.action, s.action_config, s.schedule_type, s.recurrence, s.start_date, s.start_time, s.end_time, s.end_date, s.timezone, s.status, s.priority, s.created_by, s.created_at, s.updated_at, s.deleted_at, s.last_run_at, s.next_run_at, u.username AS created_by_username
+FROM schedule s
+LEFT JOIN "user" u ON u.id = s.created_by
+WHERE s.org_id = $1
+  AND s.id = $2
+  AND s.deleted_at IS NULL
+FOR UPDATE OF s
+`
+
+type GetScheduleForUpdateParams struct {
+	OrgID int64
+	ID    int64
+}
+
+type GetScheduleForUpdateRow struct {
+	ID                int64
+	OrgID             int64
+	Name              string
+	Action            string
+	ActionConfig      json.RawMessage
+	ScheduleType      string
+	Recurrence        pqtype.NullRawMessage
+	StartDate         time.Time
+	StartTime         string
+	EndTime           sql.NullString
+	EndDate           sql.NullTime
+	Timezone          string
+	Status            string
+	Priority          int32
+	CreatedBy         int64
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	DeletedAt         sql.NullTime
+	LastRunAt         sql.NullTime
+	NextRunAt         sql.NullTime
+	CreatedByUsername sql.NullString
+}
+
+// GetScheduleForUpdate is the row-locking variant used by ResumeSchedule
+// so the per-action authorization check inside the transaction is bound
+// to the row state that the resume UPDATE will mutate. A concurrent
+// UpdateSchedule on the same row blocks until this transaction commits.
+func (q *Queries) GetScheduleForUpdate(ctx context.Context, arg GetScheduleForUpdateParams) (GetScheduleForUpdateRow, error) {
+	row := q.queryRow(ctx, q.getScheduleForUpdateStmt, getScheduleForUpdate, arg.OrgID, arg.ID)
+	var i GetScheduleForUpdateRow
+	err := row.Scan(
+		&i.ID,
+		&i.OrgID,
+		&i.Name,
+		&i.Action,
+		&i.ActionConfig,
+		&i.ScheduleType,
+		&i.Recurrence,
+		&i.StartDate,
+		&i.StartTime,
+		&i.EndTime,
+		&i.EndDate,
+		&i.Timezone,
+		&i.Status,
+		&i.Priority,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.LastRunAt,
+		&i.NextRunAt,
+		&i.CreatedByUsername,
+	)
+	return i, err
+}
+
 const getScheduleTargets = `-- name: GetScheduleTargets :many
 SELECT st.id, st.schedule_id, st.target_type, st.target_id
 FROM schedule_target st

--- a/server/internal/domain/authz/catalog.go
+++ b/server/internal/domain/authz/catalog.go
@@ -58,10 +58,11 @@ const (
 	PermPoolManage = "pool:manage"
 
 	// schedule — recurring miner actions (set_power_target, reboot,
-	// sleep). schedule:manage gates the list/CRUD surface; create and
-	// update additionally require the underlying miner action permission
-	// so a manager can't smuggle a privileged action through the
-	// scheduler.
+	// sleep). schedule:read gates the list surface; schedule:manage
+	// gates create/update/delete/pause/resume/reorder. Create, update,
+	// and resume additionally require the underlying miner action
+	// permission so a manager can't smuggle a privileged action through
+	// the scheduler.
 	PermScheduleRead   = "schedule:read"
 	PermScheduleManage = "schedule:manage"
 

--- a/server/internal/domain/authz/catalog.go
+++ b/server/internal/domain/authz/catalog.go
@@ -57,6 +57,14 @@ const (
 	PermPoolRead   = "pool:read"
 	PermPoolManage = "pool:manage"
 
+	// schedule — recurring miner actions (set_power_target, reboot,
+	// sleep). schedule:manage gates the list/CRUD surface; create and
+	// update additionally require the underlying miner action permission
+	// so a manager can't smuggle a privileged action through the
+	// scheduler.
+	PermScheduleRead   = "schedule:read"
+	PermScheduleManage = "schedule:manage"
+
 	// fleetnode — top-nav admin operations.
 	PermFleetnodeRead   = "fleetnode:read"
 	PermFleetnodeManage = "fleetnode:manage"
@@ -85,6 +93,7 @@ const (
 	ResourceServerLog   = "serverlog"
 	ResourceCurtailment = "curtailment"
 	ResourcePool        = "pool"
+	ResourceSchedule    = "schedule"
 	ResourceFleetNode   = "fleetnode"
 	ResourceAPIKey      = "apikey"
 	ResourceUser        = "user"
@@ -139,6 +148,9 @@ var catalog = []CatalogEntry{
 
 	{PermPoolRead, "View saved mining pool configurations.", ResourcePool},
 	{PermPoolManage, "Create, edit, and delete saved mining pool configurations.", ResourcePool},
+
+	{PermScheduleRead, "View scheduled miner actions.", ResourceSchedule},
+	{PermScheduleManage, "Create, edit, pause, resume, and delete scheduled miner actions. Requires the underlying miner action permission to schedule that action.", ResourceSchedule},
 
 	{PermFleetnodeRead, "View fleet-node state.", ResourceFleetNode},
 	{PermFleetnodeManage, "Perform fleet-node admin operations.", ResourceFleetNode},

--- a/server/internal/domain/authz/catalog_test.go
+++ b/server/internal/domain/authz/catalog_test.go
@@ -62,6 +62,8 @@ func TestCatalogCompleteness(t *testing.T) {
 		PermCurtailmentIngest,
 		PermPoolRead,
 		PermPoolManage,
+		PermScheduleRead,
+		PermScheduleManage,
 		PermFleetnodeRead,
 		PermFleetnodeManage,
 		PermAPIKeyManage,
@@ -110,7 +112,7 @@ func TestCatalogByResource_GroupsAndAssociates(t *testing.T) {
 
 	for _, resource := range []string{
 		ResourceFleet, ResourceMiner, ResourceRack, ResourceSite,
-		ResourceServerLog, ResourceCurtailment, ResourcePool, ResourceFleetNode,
+		ResourceServerLog, ResourceCurtailment, ResourcePool, ResourceSchedule, ResourceFleetNode,
 		ResourceAPIKey, ResourceUser, ResourceRole,
 	} {
 		if len(groups[resource]) == 0 {
@@ -140,6 +142,7 @@ func TestResourceOrder_MatchesCatalogDeclarationOrder(t *testing.T) {
 		ResourceServerLog,
 		ResourceCurtailment,
 		ResourcePool,
+		ResourceSchedule,
 		ResourceFleetNode,
 		ResourceAPIKey,
 		ResourceUser,

--- a/server/internal/domain/schedule/service.go
+++ b/server/internal/domain/schedule/service.go
@@ -314,6 +314,19 @@ func (s *Service) ResumeSchedule(ctx context.Context, scheduleID int64, authoriz
 	}
 
 	result, err := s.transactor.RunInTxWithResult(ctx, func(ctx context.Context) (any, error) {
+		// Lock ordering: priority advisory lock before the schedule row
+		// lock. ReorderSchedules and CreateSchedule take the priority
+		// lock first; if Resume took the row lock first it would
+		// deadlock against a concurrent reorder that's already holding
+		// the priority lock and waiting on this row. We acquire the
+		// priority lock unconditionally rather than only on the
+		// completion path because we can't tell which path we're on
+		// until after we've read existing — and switching the order
+		// after the read would reintroduce the deadlock.
+		if err := s.priorityStore.LockSchedulePriority(ctx, info.OrganizationID); err != nil {
+			return nil, fleeterror.NewInternalErrorf("failed to lock priority: %v", err)
+		}
+
 		// FOR UPDATE locks the row so a concurrent UpdateSchedule can't
 		// change the action between authorizeAction and ResumePausedSchedule.
 		existing, err := s.store.GetScheduleForUpdate(ctx, info.OrganizationID, scheduleID)
@@ -337,12 +350,6 @@ func (s *Service) ResumeSchedule(ctx context.Context, scheduleID int64, authoriz
 			nextRunUnix = &u
 		} else {
 			newStatus = statusCompleted
-		}
-
-		if newStatus == statusCompleted {
-			if err := s.priorityStore.LockSchedulePriority(ctx, info.OrganizationID); err != nil {
-				return nil, fleeterror.NewInternalErrorf("failed to lock priority: %v", err)
-			}
 		}
 
 		rows, err := s.store.ResumePausedSchedule(ctx, info.OrganizationID, scheduleID, newStatus, nextRunUnix)

--- a/server/internal/domain/schedule/service.go
+++ b/server/internal/domain/schedule/service.go
@@ -314,7 +314,9 @@ func (s *Service) ResumeSchedule(ctx context.Context, scheduleID int64, authoriz
 	}
 
 	result, err := s.transactor.RunInTxWithResult(ctx, func(ctx context.Context) (any, error) {
-		existing, err := s.store.GetSchedule(ctx, info.OrganizationID, scheduleID)
+		// FOR UPDATE locks the row so a concurrent UpdateSchedule can't
+		// change the action between authorizeAction and ResumePausedSchedule.
+		existing, err := s.store.GetScheduleForUpdate(ctx, info.OrganizationID, scheduleID)
 		if err != nil {
 			return nil, err
 		}

--- a/server/internal/domain/schedule/service.go
+++ b/server/internal/domain/schedule/service.go
@@ -46,6 +46,18 @@ func NewService(store interfaces.ScheduleStore, targetStore interfaces.ScheduleT
 	}
 }
 
+// GetSchedule returns the stored schedule for the caller's organization.
+// Used by the handler to look up a schedule's persisted action before
+// resuming it, so the resumer's underlying-action permission can be
+// re-checked.
+func (s *Service) GetSchedule(ctx context.Context, scheduleID int64) (*pb.Schedule, error) {
+	info, err := session.GetInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.store.GetSchedule(ctx, info.OrganizationID, scheduleID)
+}
+
 func (s *Service) ListSchedules(ctx context.Context, status, action string) ([]*pb.Schedule, error) {
 	info, err := session.GetInfo(ctx)
 	if err != nil {

--- a/server/internal/domain/schedule/service.go
+++ b/server/internal/domain/schedule/service.go
@@ -46,18 +46,6 @@ func NewService(store interfaces.ScheduleStore, targetStore interfaces.ScheduleT
 	}
 }
 
-// GetSchedule returns the stored schedule for the caller's organization.
-// Used by the handler to look up a schedule's persisted action before
-// resuming it, so the resumer's underlying-action permission can be
-// re-checked.
-func (s *Service) GetSchedule(ctx context.Context, scheduleID int64) (*pb.Schedule, error) {
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.store.GetSchedule(ctx, info.OrganizationID, scheduleID)
-}
-
 func (s *Service) ListSchedules(ctx context.Context, status, action string) ([]*pb.Schedule, error) {
 	info, err := session.GetInfo(ctx)
 	if err != nil {
@@ -313,7 +301,13 @@ func (s *Service) PauseSchedule(ctx context.Context, scheduleID int64) (*pb.Sche
 	return paused, nil
 }
 
-func (s *Service) ResumeSchedule(ctx context.Context, scheduleID int64) (*pb.Schedule, error) {
+// ResumeSchedule reactivates a paused schedule. authorizeAction, if
+// non-nil, runs inside the same transaction as the read and update so
+// the caller's authority is checked against the same row state that
+// gets resumed. Used to close a TOCTOU window where a separate
+// pre-flight authz read could authorize a different action than the
+// one finally resumed if an Update raced in between.
+func (s *Service) ResumeSchedule(ctx context.Context, scheduleID int64, authorizeAction func(pb.ScheduleAction) error) (*pb.Schedule, error) {
 	info, err := session.GetInfo(ctx)
 	if err != nil {
 		return nil, err
@@ -323,6 +317,12 @@ func (s *Service) ResumeSchedule(ctx context.Context, scheduleID int64) (*pb.Sch
 		existing, err := s.store.GetSchedule(ctx, info.OrganizationID, scheduleID)
 		if err != nil {
 			return nil, err
+		}
+
+		if authorizeAction != nil {
+			if err := authorizeAction(existing.Action); err != nil {
+				return nil, err
+			}
 		}
 
 		nextRun, err := ComputeNextRun(existing, s.now())

--- a/server/internal/domain/schedule/service.go
+++ b/server/internal/domain/schedule/service.go
@@ -301,12 +301,12 @@ func (s *Service) PauseSchedule(ctx context.Context, scheduleID int64) (*pb.Sche
 	return paused, nil
 }
 
-// ResumeSchedule reactivates a paused schedule. authorizeAction, if
-// non-nil, runs inside the same transaction as the read and update so
-// the caller's authority is checked against the same row state that
-// gets resumed. Used to close a TOCTOU window where a separate
-// pre-flight authz read could authorize a different action than the
-// one finally resumed if an Update raced in between.
+// ResumeSchedule reactivates a paused schedule. authorizeAction runs
+// inside the same transaction as the read and update so the caller's
+// authority is checked against the same row state that gets resumed —
+// without it the per-action gate could authorize one action and then
+// resume a different one if an Update raced in between. Callers must
+// pass a non-nil callback.
 func (s *Service) ResumeSchedule(ctx context.Context, scheduleID int64, authorizeAction func(pb.ScheduleAction) error) (*pb.Schedule, error) {
 	info, err := session.GetInfo(ctx)
 	if err != nil {
@@ -319,10 +319,8 @@ func (s *Service) ResumeSchedule(ctx context.Context, scheduleID int64, authoriz
 			return nil, err
 		}
 
-		if authorizeAction != nil {
-			if err := authorizeAction(existing.Action); err != nil {
-				return nil, err
-			}
+		if err := authorizeAction(existing.Action); err != nil {
+			return nil, err
 		}
 
 		nextRun, err := ComputeNextRun(existing, s.now())

--- a/server/internal/domain/stores/interfaces/mocks/mock_schedule_store.go
+++ b/server/internal/domain/stores/interfaces/mocks/mock_schedule_store.go
@@ -72,6 +72,21 @@ func (mr *MockScheduleStoreMockRecorder) GetSchedule(ctx, orgID, scheduleID any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedule", reflect.TypeOf((*MockScheduleStore)(nil).GetSchedule), ctx, orgID, scheduleID)
 }
 
+// GetScheduleForUpdate mocks base method.
+func (m *MockScheduleStore) GetScheduleForUpdate(ctx context.Context, orgID, scheduleID int64) (*schedulev1.Schedule, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScheduleForUpdate", ctx, orgID, scheduleID)
+	ret0, _ := ret[0].(*schedulev1.Schedule)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScheduleForUpdate indicates an expected call of GetScheduleForUpdate.
+func (mr *MockScheduleStoreMockRecorder) GetScheduleForUpdate(ctx, orgID, scheduleID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScheduleForUpdate", reflect.TypeOf((*MockScheduleStore)(nil).GetScheduleForUpdate), ctx, orgID, scheduleID)
+}
+
 // ListSchedules mocks base method.
 func (m *MockScheduleStore) ListSchedules(ctx context.Context, orgID int64, status, action string) ([]*schedulev1.Schedule, error) {
 	m.ctrl.T.Helper()

--- a/server/internal/domain/stores/interfaces/schedule.go
+++ b/server/internal/domain/stores/interfaces/schedule.go
@@ -28,6 +28,11 @@ type ScheduleWithOrg struct {
 // ScheduleStore handles schedule CRUD and status transitions.
 type ScheduleStore interface {
 	GetSchedule(ctx context.Context, orgID, scheduleID int64) (*pb.Schedule, error)
+	// GetScheduleForUpdate is GetSchedule with FOR UPDATE; callers must
+	// be inside a transaction. Used by ResumeSchedule so the per-action
+	// authorization check is bound to the row state that the resume
+	// update mutates.
+	GetScheduleForUpdate(ctx context.Context, orgID, scheduleID int64) (*pb.Schedule, error)
 	ListSchedules(ctx context.Context, orgID int64, status, action string) ([]*pb.Schedule, error)
 	CreateSchedule(ctx context.Context, orgID int64, schedule *pb.Schedule) (int64, error)
 	UpdateSchedule(ctx context.Context, orgID int64, schedule *pb.Schedule) (int64, error)

--- a/server/internal/domain/stores/sqlstores/schedule.go
+++ b/server/internal/domain/stores/sqlstores/schedule.go
@@ -44,6 +44,17 @@ func (s *SQLScheduleStore) GetSchedule(ctx context.Context, orgID, scheduleID in
 	return convertGetScheduleRowToProtoSchedule(row)
 }
 
+func (s *SQLScheduleStore) GetScheduleForUpdate(ctx context.Context, orgID, scheduleID int64) (*pb.Schedule, error) {
+	row, err := s.GetQueries(ctx).GetScheduleForUpdate(ctx, sqlc.GetScheduleForUpdateParams{OrgID: orgID, ID: scheduleID})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fleeterror.NewNotFoundErrorf("schedule not found: %d", scheduleID)
+		}
+		return nil, fleeterror.NewInternalErrorf("failed to get schedule for update: %v", err)
+	}
+	return convertGetScheduleForUpdateRowToProtoSchedule(row)
+}
+
 func (s *SQLScheduleStore) ListSchedules(ctx context.Context, orgID int64, status, action string) ([]*pb.Schedule, error) {
 	rows, err := s.GetQueries(ctx).ListSchedules(ctx, sqlc.ListSchedulesParams{
 		OrgID:  orgID,
@@ -411,6 +422,36 @@ func convertToProtoSchedule(row sqlc.Schedule) (*pb.Schedule, error) {
 		sched.Recurrence = &rec
 	}
 
+	return sched, nil
+}
+
+func convertGetScheduleForUpdateRowToProtoSchedule(row sqlc.GetScheduleForUpdateRow) (*pb.Schedule, error) {
+	sched, err := convertToProtoSchedule(sqlc.Schedule{
+		ID:           row.ID,
+		OrgID:        row.OrgID,
+		Name:         row.Name,
+		Action:       row.Action,
+		ActionConfig: row.ActionConfig,
+		ScheduleType: row.ScheduleType,
+		Recurrence:   row.Recurrence,
+		StartDate:    row.StartDate,
+		StartTime:    row.StartTime,
+		EndTime:      row.EndTime,
+		EndDate:      row.EndDate,
+		Timezone:     row.Timezone,
+		Status:       row.Status,
+		Priority:     row.Priority,
+		CreatedBy:    row.CreatedBy,
+		CreatedAt:    row.CreatedAt,
+		UpdatedAt:    row.UpdatedAt,
+		DeletedAt:    row.DeletedAt,
+		LastRunAt:    row.LastRunAt,
+		NextRunAt:    row.NextRunAt,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sched.CreatedByUsername = row.CreatedByUsername.String
 	return sched, nil
 }
 

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -200,6 +200,19 @@ var ProcedurePermissions = map[string]string{
 	poolsv1connect.PoolsServiceUpdatePoolProcedure:   authz.PermPoolManage,
 	poolsv1connect.PoolsServiceDeletePoolProcedure:   authz.PermPoolManage,
 
+	// ScheduleService — recurring miner actions. CreateSchedule and
+	// UpdateSchedule additionally re-check the underlying miner action
+	// permission (reboot / stop_mining / set_power_target) inside the
+	// handler so a schedule:manage holder cannot smuggle a privileged
+	// action through the scheduler.
+	schedulev1connect.ScheduleServiceListSchedulesProcedure:    authz.PermScheduleRead,
+	schedulev1connect.ScheduleServiceCreateScheduleProcedure:   authz.PermScheduleManage,
+	schedulev1connect.ScheduleServiceUpdateScheduleProcedure:   authz.PermScheduleManage,
+	schedulev1connect.ScheduleServiceDeleteScheduleProcedure:   authz.PermScheduleManage,
+	schedulev1connect.ScheduleServicePauseScheduleProcedure:    authz.PermScheduleManage,
+	schedulev1connect.ScheduleServiceResumeScheduleProcedure:   authz.PermScheduleManage,
+	schedulev1connect.ScheduleServiceReorderSchedulesProcedure: authz.PermScheduleManage,
+
 	// ServerLogService — gated by PermServerlogRead.
 	serverlogv1connect.ServerLogServiceListServerLogsProcedure: authz.PermServerlogRead,
 
@@ -255,15 +268,4 @@ var ProceduresPendingMigration = map[string]string{
 	// FleetNodeAdminService — DiscoverOnFleetNode remains a stub until
 	// the ControlStream surface lands.
 	fleetnodeadminv1connect.FleetNodeAdminServiceDiscoverOnFleetNodeProcedure: "UNIMPLEMENTED STUB: handler does not override, returns Unimplemented with no gate",
-
-	// ScheduleService — operator-managed schedules. Needs a new
-	// schedule:read / schedule:manage catalog pair + ADMIN backfill
-	// migration; deferred from the new-gate slice.
-	schedulev1connect.ScheduleServiceListSchedulesProcedure:    "ungated; needs new schedule:read catalog key",
-	schedulev1connect.ScheduleServiceCreateScheduleProcedure:   "ungated; needs new schedule:manage catalog key",
-	schedulev1connect.ScheduleServiceUpdateScheduleProcedure:   "ungated; needs new schedule:manage catalog key",
-	schedulev1connect.ScheduleServiceDeleteScheduleProcedure:   "ungated; needs new schedule:manage catalog key",
-	schedulev1connect.ScheduleServicePauseScheduleProcedure:    "ungated; needs new schedule:manage catalog key",
-	schedulev1connect.ScheduleServiceResumeScheduleProcedure:   "ungated; needs new schedule:manage catalog key",
-	schedulev1connect.ScheduleServiceReorderSchedulesProcedure: "ungated; needs new schedule:manage catalog key",
 }

--- a/server/internal/handlers/schedule/handler.go
+++ b/server/internal/handlers/schedule/handler.go
@@ -8,6 +8,7 @@ import (
 	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/schedule/v1/schedulev1connect"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	scheduleDomain "github.com/block/proto-fleet/server/internal/domain/schedule"
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
@@ -123,19 +124,28 @@ func (h *Handler) ReorderSchedules(ctx context.Context, r *connect.Request[pb.Re
 // schedule:manage alone is not enough — a manager without
 // miner:set_power_target should not be able to schedule a
 // SET_POWER_TARGET job that the processor later runs on their behalf.
-// UNSPECIFIED is left to the service-level field validation to reject.
+//
+// UNSPECIFIED falls through to the service's field validation, which
+// rejects it with InvalidArgument. Any other unrecognized enum value
+// fails closed here so a future action added to the proto can't be
+// persisted by a schedule:manage holder before this mapping is updated.
 func requireActionAuthority(ctx context.Context, action pb.ScheduleAction) error {
+	if action == pb.ScheduleAction_SCHEDULE_ACTION_UNSPECIFIED {
+		return nil
+	}
 	key, ok := requiredPermForAction(action)
 	if !ok {
-		return nil
+		return fleeterror.NewInvalidArgumentErrorf("unsupported schedule action %v", action)
 	}
 	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
 	return err
 }
 
 // requiredPermForAction maps a schedule action to the catalog key the
-// caller must hold to schedule it. Returns ok=false for UNSPECIFIED so
-// field validation can produce the canonical "action required" error.
+// caller must hold to schedule it. Returns ok=false for UNSPECIFIED and
+// any unrecognized enum value; the caller (requireActionAuthority)
+// distinguishes the two and rejects unrecognized actions with
+// InvalidArgument so they never reach the service layer.
 func requiredPermForAction(action pb.ScheduleAction) (string, bool) {
 	switch action {
 	case pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET:

--- a/server/internal/handlers/schedule/handler.go
+++ b/server/internal/handlers/schedule/handler.go
@@ -90,6 +90,17 @@ func (h *Handler) ResumeSchedule(ctx context.Context, r *connect.Request[pb.Resu
 	if _, err := middleware.RequirePermission(ctx, authz.PermScheduleManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
+	// Reactivating an existing paused schedule causes the processor to
+	// dispatch its stored action. Re-check the caller's authority for
+	// that action so a schedule:manage holder can't escalate by
+	// resuming a privileged schedule they did not create themselves.
+	existing, err := h.svc.GetSchedule(ctx, r.Msg.ScheduleId)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireActionAuthority(ctx, existing.Action); err != nil {
+		return nil, err
+	}
 	schedule, err := h.svc.ResumeSchedule(ctx, r.Msg.ScheduleId)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/schedule/handler.go
+++ b/server/internal/handlers/schedule/handler.go
@@ -7,7 +7,9 @@ import (
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/schedule/v1/schedulev1connect"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	scheduleDomain "github.com/block/proto-fleet/server/internal/domain/schedule"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 type Handler struct {
@@ -21,6 +23,9 @@ func NewHandler(svc *scheduleDomain.Service) *Handler {
 }
 
 func (h *Handler) ListSchedules(ctx context.Context, r *connect.Request[pb.ListSchedulesRequest]) (*connect.Response[pb.ListSchedulesResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermScheduleRead, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	status := scheduleStatusFilterToString(r.Msg.Status)
 	action := scheduleActionFilterToString(r.Msg.Action)
 
@@ -33,6 +38,12 @@ func (h *Handler) ListSchedules(ctx context.Context, r *connect.Request[pb.ListS
 }
 
 func (h *Handler) CreateSchedule(ctx context.Context, r *connect.Request[pb.CreateScheduleRequest]) (*connect.Response[pb.CreateScheduleResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermScheduleManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
+	if err := requireActionAuthority(ctx, r.Msg.Action); err != nil {
+		return nil, err
+	}
 	schedule, err := h.svc.CreateSchedule(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -41,6 +52,12 @@ func (h *Handler) CreateSchedule(ctx context.Context, r *connect.Request[pb.Crea
 }
 
 func (h *Handler) UpdateSchedule(ctx context.Context, r *connect.Request[pb.UpdateScheduleRequest]) (*connect.Response[pb.UpdateScheduleResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermScheduleManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
+	if err := requireActionAuthority(ctx, r.Msg.Action); err != nil {
+		return nil, err
+	}
 	schedule, err := h.svc.UpdateSchedule(ctx, r.Msg)
 	if err != nil {
 		return nil, err
@@ -49,6 +66,9 @@ func (h *Handler) UpdateSchedule(ctx context.Context, r *connect.Request[pb.Upda
 }
 
 func (h *Handler) DeleteSchedule(ctx context.Context, r *connect.Request[pb.DeleteScheduleRequest]) (*connect.Response[pb.DeleteScheduleResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermScheduleManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	if err := h.svc.DeleteSchedule(ctx, r.Msg.ScheduleId); err != nil {
 		return nil, err
 	}
@@ -56,6 +76,9 @@ func (h *Handler) DeleteSchedule(ctx context.Context, r *connect.Request[pb.Dele
 }
 
 func (h *Handler) PauseSchedule(ctx context.Context, r *connect.Request[pb.PauseScheduleRequest]) (*connect.Response[pb.PauseScheduleResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermScheduleManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	schedule, err := h.svc.PauseSchedule(ctx, r.Msg.ScheduleId)
 	if err != nil {
 		return nil, err
@@ -64,6 +87,9 @@ func (h *Handler) PauseSchedule(ctx context.Context, r *connect.Request[pb.Pause
 }
 
 func (h *Handler) ResumeSchedule(ctx context.Context, r *connect.Request[pb.ResumeScheduleRequest]) (*connect.Response[pb.ResumeScheduleResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermScheduleManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	schedule, err := h.svc.ResumeSchedule(ctx, r.Msg.ScheduleId)
 	if err != nil {
 		return nil, err
@@ -72,10 +98,46 @@ func (h *Handler) ResumeSchedule(ctx context.Context, r *connect.Request[pb.Resu
 }
 
 func (h *Handler) ReorderSchedules(ctx context.Context, r *connect.Request[pb.ReorderSchedulesRequest]) (*connect.Response[pb.ReorderSchedulesResponse], error) {
+	if _, err := middleware.RequirePermission(ctx, authz.PermScheduleManage, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	if err := h.svc.ReorderSchedules(ctx, r.Msg.ScheduleIds); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(&pb.ReorderSchedulesResponse{}), nil
+}
+
+// requireActionAuthority re-checks the caller's permission for the
+// underlying miner action the schedule will eventually dispatch.
+// schedule:manage alone is not enough — a manager without
+// miner:set_power_target should not be able to schedule a
+// SET_POWER_TARGET job that the processor later runs on their behalf.
+// UNSPECIFIED is left to the service-level field validation to reject.
+func requireActionAuthority(ctx context.Context, action pb.ScheduleAction) error {
+	key, ok := requiredPermForAction(action)
+	if !ok {
+		return nil
+	}
+	_, err := middleware.RequirePermission(ctx, key, authz.ResourceContext{})
+	return err
+}
+
+// requiredPermForAction maps a schedule action to the catalog key the
+// caller must hold to schedule it. Returns ok=false for UNSPECIFIED so
+// field validation can produce the canonical "action required" error.
+func requiredPermForAction(action pb.ScheduleAction) (string, bool) {
+	switch action {
+	case pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET:
+		return authz.PermMinerSetPowerTarget, true
+	case pb.ScheduleAction_SCHEDULE_ACTION_REBOOT:
+		return authz.PermMinerReboot, true
+	case pb.ScheduleAction_SCHEDULE_ACTION_SLEEP:
+		return authz.PermMinerStopMining, true
+	case pb.ScheduleAction_SCHEDULE_ACTION_UNSPECIFIED:
+		return "", false
+	default:
+		return "", false
+	}
 }
 
 func scheduleStatusFilterToString(s pb.ScheduleStatus) string {

--- a/server/internal/handlers/schedule/handler.go
+++ b/server/internal/handlers/schedule/handler.go
@@ -91,18 +91,13 @@ func (h *Handler) ResumeSchedule(ctx context.Context, r *connect.Request[pb.Resu
 	if _, err := middleware.RequirePermission(ctx, authz.PermScheduleManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
-	// Reactivating an existing paused schedule causes the processor to
-	// dispatch its stored action. Re-check the caller's authority for
-	// that action so a schedule:manage holder can't escalate by
-	// resuming a privileged schedule they did not create themselves.
-	existing, err := h.svc.GetSchedule(ctx, r.Msg.ScheduleId)
-	if err != nil {
-		return nil, err
-	}
-	if err := requireActionAuthority(ctx, existing.Action); err != nil {
-		return nil, err
-	}
-	schedule, err := h.svc.ResumeSchedule(ctx, r.Msg.ScheduleId)
+	// The action-authority check runs inside the service's transaction
+	// so it sees the same row the resume update operates on; a pre-flight
+	// handler-side read could race with an Update that swapped the
+	// schedule's action between the read and the resume.
+	schedule, err := h.svc.ResumeSchedule(ctx, r.Msg.ScheduleId, func(action pb.ScheduleAction) error {
+		return requireActionAuthority(ctx, action)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/handlers/schedule/handler_test.go
+++ b/server/internal/handlers/schedule/handler_test.go
@@ -42,25 +42,38 @@ func TestRequiredPermForAction_Mapping(t *testing.T) {
 	}
 }
 
-func TestRequireActionAuthority_DeniesWithoutUnderlyingMinerPerm(t *testing.T) {
+// Caller holds schedule:manage but not the underlying miner action key.
+// The scheduler can't be used as an end-run around the action gate, so
+// each action must deny with PermissionDenied. The grant case asserts
+// the per-action key is the only thing missing from the deny case.
+func TestRequireActionAuthority_PerAction(t *testing.T) {
 	t.Parallel()
-	// Caller holds schedule:manage but not miner:reboot. Scheduling a
-	// REBOOT must fail with PermissionDenied so the scheduler can't be
-	// used as an end-run around the action gate.
-	ctx := ctxWithPermissions(t, authz.PermScheduleManage)
+	cases := []struct {
+		action      pb.ScheduleAction
+		requiredKey string
+	}{
+		{pb.ScheduleAction_SCHEDULE_ACTION_REBOOT, authz.PermMinerReboot},
+		{pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET, authz.PermMinerSetPowerTarget},
+		{pb.ScheduleAction_SCHEDULE_ACTION_SLEEP, authz.PermMinerStopMining},
+	}
+	for _, tc := range cases {
+		t.Run(tc.action.String()+"_denies_without_underlying_perm", func(t *testing.T) {
+			t.Parallel()
+			ctx := ctxWithPermissions(t, authz.PermScheduleManage)
 
-	err := requireActionAuthority(ctx, pb.ScheduleAction_SCHEDULE_ACTION_REBOOT)
+			err := requireActionAuthority(ctx, tc.action)
 
-	require.Error(t, err)
-	var fleetErr fleeterror.FleetError
-	require.ErrorAs(t, err, &fleetErr)
-	assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
-}
-
-func TestRequireActionAuthority_AllowsWithUnderlyingMinerPerm(t *testing.T) {
-	t.Parallel()
-	ctx := ctxWithPermissions(t, authz.PermScheduleManage, authz.PermMinerReboot)
-	require.NoError(t, requireActionAuthority(ctx, pb.ScheduleAction_SCHEDULE_ACTION_REBOOT))
+			require.Error(t, err)
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr)
+			assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+		})
+		t.Run(tc.action.String()+"_allows_with_underlying_perm", func(t *testing.T) {
+			t.Parallel()
+			ctx := ctxWithPermissions(t, authz.PermScheduleManage, tc.requiredKey)
+			require.NoError(t, requireActionAuthority(ctx, tc.action))
+		})
+	}
 }
 
 func TestRequireActionAuthority_UnspecifiedIsNoOp(t *testing.T) {
@@ -86,6 +99,82 @@ func TestRequireActionAuthority_UnknownActionFailsClosed(t *testing.T) {
 	var fleetErr fleeterror.FleetError
 	require.ErrorAs(t, err, &fleetErr)
 	assert.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
+}
+
+// Every ScheduleService RPC must reject sessions that hold no schedule
+// permissions before any service work runs. A future refactor that
+// drops a RequirePermission line from a handler stays green only if
+// this list keeps that handler covered.
+func TestScheduleHandler_GatesEveryRPC(t *testing.T) {
+	t.Parallel()
+	h := NewHandler(nil)
+	ctx := ctxWithPermissions(t) // no permissions
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{
+			"ListSchedules",
+			func() error {
+				_, err := h.ListSchedules(ctx, connect.NewRequest(&pb.ListSchedulesRequest{}))
+				return err
+			},
+		},
+		{
+			"CreateSchedule",
+			func() error {
+				_, err := h.CreateSchedule(ctx, connect.NewRequest(&pb.CreateScheduleRequest{}))
+				return err
+			},
+		},
+		{
+			"UpdateSchedule",
+			func() error {
+				_, err := h.UpdateSchedule(ctx, connect.NewRequest(&pb.UpdateScheduleRequest{}))
+				return err
+			},
+		},
+		{
+			"DeleteSchedule",
+			func() error {
+				_, err := h.DeleteSchedule(ctx, connect.NewRequest(&pb.DeleteScheduleRequest{}))
+				return err
+			},
+		},
+		{
+			"PauseSchedule",
+			func() error {
+				_, err := h.PauseSchedule(ctx, connect.NewRequest(&pb.PauseScheduleRequest{}))
+				return err
+			},
+		},
+		{
+			"ResumeSchedule",
+			func() error {
+				_, err := h.ResumeSchedule(ctx, connect.NewRequest(&pb.ResumeScheduleRequest{}))
+				return err
+			},
+		},
+		{
+			"ReorderSchedules",
+			func() error {
+				_, err := h.ReorderSchedules(ctx, connect.NewRequest(&pb.ReorderSchedulesRequest{}))
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.call()
+			require.Error(t, err)
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr, "expected fleeterror.FleetError, got %T", err)
+			assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+		})
+	}
 }
 
 func ctxWithPermissions(t *testing.T, permissions ...string) context.Context {

--- a/server/internal/handlers/schedule/handler_test.go
+++ b/server/internal/handlers/schedule/handler_test.go
@@ -72,6 +72,22 @@ func TestRequireActionAuthority_UnspecifiedIsNoOp(t *testing.T) {
 	require.NoError(t, requireActionAuthority(ctx, pb.ScheduleAction_SCHEDULE_ACTION_UNSPECIFIED))
 }
 
+func TestRequireActionAuthority_UnknownActionFailsClosed(t *testing.T) {
+	t.Parallel()
+	// A future proto value not yet mapped here must be rejected before
+	// it reaches the service. If we no-opped instead, a schedule:manage
+	// holder could persist a schedule the processor doesn't understand.
+	unknown := pb.ScheduleAction(9999)
+	ctx := ctxWithPermissions(t, authz.PermScheduleManage)
+
+	err := requireActionAuthority(ctx, unknown)
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
+}
+
 func ctxWithPermissions(t *testing.T, permissions ...string) context.Context {
 	t.Helper()
 	ctx := authn.SetInfo(t.Context(), &session.Info{OrganizationID: 1})

--- a/server/internal/handlers/schedule/handler_test.go
+++ b/server/internal/handlers/schedule/handler_test.go
@@ -1,0 +1,84 @@
+package schedule
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/authn"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/schedule/v1"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
+)
+
+// Action -> required miner permission is the security contract that
+// keeps a schedule:manage holder from smuggling a privileged action
+// through the scheduler. A drift here (new action, wrong perm) needs
+// to fail loudly.
+func TestRequiredPermForAction_Mapping(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		action  pb.ScheduleAction
+		wantKey string
+		wantOk  bool
+	}{
+		{pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET, authz.PermMinerSetPowerTarget, true},
+		{pb.ScheduleAction_SCHEDULE_ACTION_REBOOT, authz.PermMinerReboot, true},
+		{pb.ScheduleAction_SCHEDULE_ACTION_SLEEP, authz.PermMinerStopMining, true},
+		{pb.ScheduleAction_SCHEDULE_ACTION_UNSPECIFIED, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.action.String(), func(t *testing.T) {
+			t.Parallel()
+			gotKey, gotOk := requiredPermForAction(tc.action)
+			assert.Equal(t, tc.wantKey, gotKey)
+			assert.Equal(t, tc.wantOk, gotOk)
+		})
+	}
+}
+
+func TestRequireActionAuthority_DeniesWithoutUnderlyingMinerPerm(t *testing.T) {
+	t.Parallel()
+	// Caller holds schedule:manage but not miner:reboot. Scheduling a
+	// REBOOT must fail with PermissionDenied so the scheduler can't be
+	// used as an end-run around the action gate.
+	ctx := ctxWithPermissions(t, authz.PermScheduleManage)
+
+	err := requireActionAuthority(ctx, pb.ScheduleAction_SCHEDULE_ACTION_REBOOT)
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+}
+
+func TestRequireActionAuthority_AllowsWithUnderlyingMinerPerm(t *testing.T) {
+	t.Parallel()
+	ctx := ctxWithPermissions(t, authz.PermScheduleManage, authz.PermMinerReboot)
+	require.NoError(t, requireActionAuthority(ctx, pb.ScheduleAction_SCHEDULE_ACTION_REBOOT))
+}
+
+func TestRequireActionAuthority_UnspecifiedIsNoOp(t *testing.T) {
+	t.Parallel()
+	// UNSPECIFIED is the caller leaving the field empty; field
+	// validation in the service layer rejects it with InvalidArgument.
+	// requireActionAuthority must not short-circuit that flow.
+	ctx := ctxWithPermissions(t) // no permissions
+	require.NoError(t, requireActionAuthority(ctx, pb.ScheduleAction_SCHEDULE_ACTION_UNSPECIFIED))
+}
+
+func ctxWithPermissions(t *testing.T, permissions ...string) context.Context {
+	t.Helper()
+	ctx := authn.SetInfo(t.Context(), &session.Info{OrganizationID: 1})
+	eff := authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  permissions,
+	}})
+	return middleware.WithEffectivePermissions(ctx, eff)
+}

--- a/server/migrations/000064_seed_schedule_permissions.down.sql
+++ b/server/migrations/000064_seed_schedule_permissions.down.sql
@@ -1,0 +1,15 @@
+-- Reverses 000064_seed_schedule_permissions.up.sql by removing
+-- schedule:read and schedule:manage from every role that holds them
+-- and then deleting the permission rows themselves. Rolling back the
+-- data migration cleanly is impossible without provenance tracking;
+-- the rollback path is rare/dev-only and assumes no operator has
+-- hand-granted these keys to custom roles. SUPER_ADMIN will re-acquire
+-- them at the next boot via the catalog reconciler unless catalog.go
+-- is also rolled back.
+
+DELETE FROM role_permission
+WHERE permission_id IN (
+    SELECT id FROM permission WHERE key IN ('schedule:read', 'schedule:manage')
+);
+
+DELETE FROM permission WHERE key IN ('schedule:read', 'schedule:manage');

--- a/server/migrations/000064_seed_schedule_permissions.up.sql
+++ b/server/migrations/000064_seed_schedule_permissions.up.sql
@@ -1,0 +1,28 @@
+-- Seed the schedule:read and schedule:manage permission rows and
+-- backfill them onto existing ADMIN roles. The catalog reconciler
+-- upserts new permission rows on startup, but it does NOT re-assert
+-- seed permissions onto already-seeded ADMIN/FIELD_TECH roles
+-- (additive mode, see reconcile.go). Without this migration,
+-- deployments upgraded from any release prior to this one would never
+-- grant ADMIN the new schedule keys, so the newly-gated
+-- ScheduleService endpoints would silently deny.
+--
+-- SUPER_ADMIN is reconciled in full mode at boot and converges on its
+-- own. FIELD_TECH does not receive schedule permissions by design
+-- (operators opt in via the role editor).
+
+INSERT INTO permission (key, description) VALUES
+    ('schedule:read',   'View scheduled miner actions.'),
+    ('schedule:manage', 'Create, edit, pause, resume, and delete scheduled miner actions. Requires the underlying miner action permission to schedule that action.')
+ON CONFLICT (key) DO UPDATE SET description = EXCLUDED.description;
+
+-- Scoped to roles with builtin_key='ADMIN' so operator-created custom
+-- roles aren't touched. ON CONFLICT makes this safe to replay against
+-- orgs that already hold either key.
+INSERT INTO role_permission (role_id, permission_id)
+SELECT r.id, p.id
+FROM role r, permission p
+WHERE r.builtin_key = 'ADMIN'
+  AND r.deleted_at IS NULL
+  AND p.key IN ('schedule:read', 'schedule:manage')
+ON CONFLICT (role_id, permission_id) DO NOTHING;

--- a/server/sqlc/queries/schedule.sql
+++ b/server/sqlc/queries/schedule.sql
@@ -6,6 +6,19 @@ WHERE s.org_id = $1
   AND s.id = $2
   AND s.deleted_at IS NULL;
 
+-- GetScheduleForUpdate is the row-locking variant used by ResumeSchedule
+-- so the per-action authorization check inside the transaction is bound
+-- to the row state that the resume UPDATE will mutate. A concurrent
+-- UpdateSchedule on the same row blocks until this transaction commits.
+-- name: GetScheduleForUpdate :one
+SELECT s.*, u.username AS created_by_username
+FROM schedule s
+LEFT JOIN "user" u ON u.id = s.created_by
+WHERE s.org_id = $1
+  AND s.id = $2
+  AND s.deleted_at IS NULL
+FOR UPDATE OF s;
+
 -- name: ListSchedules :many
 SELECT s.*, u.username AS created_by_username
 FROM schedule s


### PR DESCRIPTION
## Summary

- Adds the `schedule:read` / `schedule:manage` catalog pair and gates the seven `ScheduleService` RPCs.
- `CreateSchedule`, `UpdateSchedule`, and `ResumeSchedule` additionally enforce the underlying miner action permission (REBOOT → `miner:reboot`, SLEEP → `miner:stop_mining`, SET_POWER_TARGET → `miner:set_power_target`), so a `schedule:manage` holder can't smuggle a privileged action through the scheduler.
- `Resume`'s action check runs inside the service's transaction so it sees the same row state the resume operates on — closes a TOCTOU window between a separate authz read and the resume update.
- Migration `000064` seeds the new permission rows and backfills both keys onto every existing `ADMIN` role.
- Client nav: `/settings/schedules` and (parallel gap) `/settings/mining-pools` now carry `allowedRoles: ["SUPER_ADMIN", "ADMIN"]` so non-admin roles don't see a link that immediately 403s.

## Why

Codex security review flagged ungated `ScheduleService` mutations as HIGH on PR #325. The finding had two parts: (1) the procedures were ungated, and (2) scheduled jobs execute miner commands through the scheduler path rather than the gated command handlers — so a manager could store a privileged action that ran later on their behalf. This PR closes both: catalog-level gate, per-action re-check at create/update time, and a transaction-scoped re-check at resume time.

## Behavior

| RPC | Key | Notes |
|-----|-----|-------|
| `ListSchedules` | `schedule:read` | |
| `CreateSchedule` | `schedule:manage` + action perm | Action mapping: REBOOT → `miner:reboot`; SLEEP → `miner:stop_mining`; SET_POWER_TARGET → `miner:set_power_target`. UNSPECIFIED falls through to service-level field validation; any unrecognized enum value is rejected here with `InvalidArgument` so a future proto value can't slip past the per-action gate. |
| `UpdateSchedule` | `schedule:manage` + action perm | Same mapping; covers the case where the action changes on update. |
| `ResumeSchedule` | `schedule:manage` + action perm | Action perm runs **inside** the service's transaction, against the row about to be resumed — an Update racing in between can't authorize one action and resume another. |
| `DeleteSchedule` | `schedule:manage` | |
| `PauseSchedule` | `schedule:manage` | |
| `ReorderSchedules` | `schedule:manage` | |

- **`SUPER_ADMIN`** picks up both schedule keys automatically at startup via the full-mode reconciler.
- **`ADMIN`** receives both keys: new orgs through `adminSeedPermissions()`, existing orgs through migration `000064`.
- **`FIELD_TECH`** does not receive schedule permissions; operators opt in via the role editor.

## Out of scope / follow-ups

- **Execution-time re-check.** The processor runs in the background under the original creator's authority captured at schedule time. If the creator loses the action permission after the schedule lands, the schedule still fires. A proper fix needs creator-identity capture and async perm refresh.
- **Custom-role nav discoverability.** Codex/reviewers flagged that `allowedRoles: ["SUPER_ADMIN", "ADMIN"]` hides Pools/Schedules from custom roles that have been granted the underlying permission keys. Switching the nav from role-name gating to permission-key gating needs the U9/U10 plumbing in `docs/plans/2026-05-19-001-feat-granular-rbac-plan.md` (UserInfo.permissions, client store `permissions` slice + `hasPermission` selector, both `Navigation.tsx`/`SecondaryNavigation.tsx` consumers updated). Out of scope here; today's role-name gate matches every other admin-only nav entry.
- **`ReorderSchedules` per-action precedence check.** Codex suggested re-running the action check on every schedule in the reordered set since a priority change can shift which power-target schedule wins. Reorder doesn't create or enable schedules, so the caller's authority is bounded by what was already approved at create/update/resume. Tracking as a possible behavior expansion rather than a fix.
- Site-scoping for the action perm check — same deferral as the rest of the RBAC migration (`ResourceContext{}` for now; per-target site narrowing lands when selector resolution is available pre-gate).

## Test plan
- [x] `go build ./...` clean.
- [x] Catalog tests pass: `TestCatalogCompleteness`, `TestResourceOrder_*`.
- [x] Contract tests pass: `TestRPCContract_EveryRegisteredProcedureIsClassified`, `TestRPCContract_ProcedurePermissionsKeysAreInCatalog`.
- [x] New handler tests: `TestRequiredPermForAction_Mapping`, `TestRequireActionAuthority_DeniesWithoutUnderlyingMinerPerm`, `TestRequireActionAuthority_AllowsWithUnderlyingMinerPerm`, `TestRequireActionAuthority_UnspecifiedIsNoOp`, `TestRequireActionAuthority_UnknownActionFailsClosed`.
- [x] Client `tsc --noEmit` clean.
- [ ] DB-backed seed/reconcile tests — run in CI; local Postgres not available.
- [ ] E2E smoke: role with `schedule:manage` but not `miner:reboot` rejects `CreateSchedule(action=REBOOT)` and `ResumeSchedule` against a paused REBOOT schedule with `PermissionDenied`.
