### PR TITLE
feat(multi-site): /sites + /buildings/:id Phase 1b UI (2/2 of #263)

### DIFF
--- a/client/src/protoFleet/api/useBuildingStats.ts
+++ b/client/src/protoFleet/api/useBuildingStats.ts
@@ -1,0 +1,106 @@
+import { useCallback, useRef, useState } from "react";
+
+import { buildingsClient } from "@/protoFleet/api/clients";
+import { type GetBuildingStatsResponse } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { useAuthErrors } from "@/protoFleet/store";
+import { usePoll } from "@/shared/hooks/usePoll";
+
+interface UseBuildingStatsOptions {
+  buildingId: bigint;
+  enabled?: boolean;
+  pollIntervalMs?: number;
+}
+
+interface UseBuildingStatsReturn {
+  stats: GetBuildingStatsResponse | undefined;
+  isLoading: boolean;
+  hasLoaded: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/**
+ * Wraps BuildingService.GetBuildingStats. The response carries both the
+ * building-level rollup and a `rackHealth` list keyed by rack_id +
+ * rack_label so the BuildingCard floor plan can paint per-cell state
+ * without a separate listBuildingRacks fetch.
+ */
+export const useBuildingStats = ({
+  buildingId,
+  enabled = true,
+  pollIntervalMs,
+}: UseBuildingStatsOptions): UseBuildingStatsReturn => {
+  const { handleAuthErrors } = useAuthErrors();
+  const [stats, setStats] = useState<GetBuildingStatsResponse | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestIdRef = useRef(0);
+  const hasLoadedRef = useRef(false);
+
+  const scopeKey = `${buildingId.toString()}|${enabled ? "on" : "off"}`;
+  const prevScopeRef = useRef(scopeKey);
+  if (prevScopeRef.current !== scopeKey) {
+    prevScopeRef.current = scopeKey;
+    ++requestIdRef.current;
+    hasLoadedRef.current = false;
+    setHasLoaded(false);
+    setStats(undefined);
+    // Reset error too — otherwise an error banner from a previous building
+    // stays visible until the new fetch lands.
+    setError(null);
+  }
+
+  const fetchStats = useCallback(async () => {
+    if (!enabled || buildingId === 0n) {
+      ++requestIdRef.current;
+      setIsLoading(false);
+      return;
+    }
+
+    const thisRequestId = ++requestIdRef.current;
+    if (!hasLoadedRef.current) {
+      setIsLoading(true);
+    }
+    setError(null);
+
+    try {
+      const response = await buildingsClient.getBuildingStats({ buildingId });
+      if (thisRequestId !== requestIdRef.current) return;
+      setStats(response);
+      hasLoadedRef.current = true;
+      setHasLoaded(true);
+    } catch (err) {
+      if (thisRequestId !== requestIdRef.current) return;
+      handleAuthErrors({
+        error: err,
+        onError: () => {
+          const message = err instanceof Error ? err.message : String(err);
+          setError(message);
+          console.error("[useBuildingStats] failed to fetch building stats", {
+            buildingId: buildingId.toString(),
+            error: message,
+          });
+        },
+      });
+    } finally {
+      if (thisRequestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [buildingId, enabled, handleAuthErrors]);
+
+  // `usePoll` runs an initial fetch when enabled and schedules follow-ups
+  // when `poll` is true. Keying on scopeKey forces a re-run when the
+  // caller flips the building or toggles polling.
+  usePoll({
+    fetchData: fetchStats,
+    params: scopeKey,
+    poll: pollIntervalMs !== undefined,
+    pollIntervalMs,
+    enabled,
+  });
+
+  return { stats, isLoading, hasLoaded, error, refetch: fetchStats };
+};

--- a/client/src/protoFleet/api/useBuildingStats.ts
+++ b/client/src/protoFleet/api/useBuildingStats.ts
@@ -39,7 +39,11 @@ export const useBuildingStats = ({
   const requestIdRef = useRef(0);
   const hasLoadedRef = useRef(false);
 
-  const scopeKey = `${buildingId.toString()}|${enabled ? "on" : "off"}`;
+  // Scope key only includes buildingId — toggling `enabled` (e.g. by
+  // viewport gating to throttle polling on /sites cards) must not wipe
+  // the last-good stats and force a skeleton on re-reveal. Only a
+  // genuine building change should reset the cached snapshot.
+  const scopeKey = buildingId.toString();
   const prevScopeRef = useRef(scopeKey);
   if (prevScopeRef.current !== scopeKey) {
     prevScopeRef.current = scopeKey;

--- a/client/src/protoFleet/api/useComponentErrors.ts
+++ b/client/src/protoFleet/api/useComponentErrors.ts
@@ -17,7 +17,11 @@ interface ComponentErrorCounts {
   psuErrors: number;
 }
 
-interface UseComponentErrorsReturn extends ComponentErrorCounts {
+interface UseComponentErrorsReturn extends Partial<ComponentErrorCounts> {
+  controlBoardErrors: number | undefined;
+  fanErrors: number | undefined;
+  hashboardErrors: number | undefined;
+  psuErrors: number | undefined;
   isLoading: boolean;
   hasLoaded: boolean;
   error: Error | null;
@@ -29,6 +33,14 @@ interface UseComponentErrorsOptions {
   deviceIdentifiers?: string[];
   /** Optional polling interval in milliseconds */
   pollIntervalMs?: number;
+  /**
+   * Gate the entire hook: skip fetching and return `undefined` for every
+   * count when false. Used by BuildingPage to hold the diagnostics panel
+   * in a loading state until the building's device scope is known —
+   * otherwise an empty-scope fetch races to "No issues" before the real
+   * scope arrives. Default true.
+   */
+  enabled?: boolean;
 }
 
 /**
@@ -38,8 +50,15 @@ interface UseComponentErrorsOptions {
  */
 export const useComponentErrors = (options?: UseComponentErrorsOptions): UseComponentErrorsReturn => {
   const deviceIdentifiers = options?.deviceIdentifiers;
+  const enabled = options?.enabled ?? true;
   const isEmptyScope = deviceIdentifiers !== undefined && deviceIdentifiers.length === 0;
-  const deviceIdentifiersKey = deviceIdentifiers === undefined ? "__undefined__" : deviceIdentifiers.join(",");
+  // Key the scope cache off enabled too so flipping enabled (e.g. scope
+  // becoming known after stats land) re-fetches.
+  const deviceIdentifiersKey = enabled
+    ? deviceIdentifiers === undefined
+      ? "__undefined__"
+      : deviceIdentifiers.join(",")
+    : "__disabled__";
 
   const authLoading = useFleetStore((state) => state.auth.authLoading);
   const { handleAuthErrors } = useAuthErrors();
@@ -76,18 +95,42 @@ export const useComponentErrors = (options?: UseComponentErrorsOptions): UseComp
     hasLoadedRef.current = false;
   }
 
-  const errorCounts: ComponentErrorCounts = {
-    controlBoardErrors: counts[ComponentType.CONTROL_BOARD] || 0,
-    fanErrors: counts[ComponentType.FAN] || 0,
-    hashboardErrors: counts[ComponentType.HASH_BOARD] || 0,
-    psuErrors: counts[ComponentType.PSU] || 0,
-  };
+  // While disabled, every count returns `undefined` so consumers
+  // (ComponentErrors tile) render the skeleton instead of zero. Once
+  // enabled flips true and the fetch lands, hasLoaded gates which mode
+  // we're in.
+  const errorCounts: Pick<
+    UseComponentErrorsReturn,
+    "controlBoardErrors" | "fanErrors" | "hashboardErrors" | "psuErrors"
+  > =
+    enabled && hasLoaded
+      ? {
+          controlBoardErrors: counts[ComponentType.CONTROL_BOARD] || 0,
+          fanErrors: counts[ComponentType.FAN] || 0,
+          hashboardErrors: counts[ComponentType.HASH_BOARD] || 0,
+          psuErrors: counts[ComponentType.PSU] || 0,
+        }
+      : {
+          controlBoardErrors: undefined,
+          fanErrors: undefined,
+          hashboardErrors: undefined,
+          psuErrors: undefined,
+        };
 
   const fetchComponentErrors = useCallback(async () => {
+    if (!enabled) {
+      ++requestIdRef.current;
+      setIsLoading(false);
+      return;
+    }
     if (isEmptyScope) {
       ++requestIdRef.current;
       setCounts({});
       setIsLoading(false);
+      // Empty scope is a real "no devices to query" answer, not loading;
+      // flip hasLoaded so ComponentErrors renders 0 instead of skeleton.
+      hasLoadedRef.current = true;
+      setHasLoaded(true);
       return;
     }
 
@@ -138,7 +181,7 @@ export const useComponentErrors = (options?: UseComponentErrorsOptions): UseComp
         setIsLoading(false);
       }
     }
-  }, [handleAuthErrors, isEmptyScope]);
+  }, [enabled, handleAuthErrors, isEmptyScope]);
 
   // Initial fetch + refetch on scope change
   useEffect(() => {
@@ -150,14 +193,14 @@ export const useComponentErrors = (options?: UseComponentErrorsOptions): UseComp
 
   // Polling
   useEffect(() => {
-    if (!options?.pollIntervalMs || authLoading) return;
+    if (!options?.pollIntervalMs || authLoading || !enabled) return;
 
     const intervalId = setInterval(() => {
       void fetchComponentErrors();
     }, options.pollIntervalMs);
 
     return () => clearInterval(intervalId);
-  }, [options?.pollIntervalMs, authLoading, fetchComponentErrors]);
+  }, [options?.pollIntervalMs, authLoading, enabled, fetchComponentErrors]);
 
   return {
     ...errorCounts,

--- a/client/src/protoFleet/api/useSiteStats.ts
+++ b/client/src/protoFleet/api/useSiteStats.ts
@@ -1,0 +1,106 @@
+import { useCallback, useRef, useState } from "react";
+
+import { sitesClient } from "@/protoFleet/api/clients";
+import { type GetSiteStatsResponse } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { useAuthErrors } from "@/protoFleet/store";
+import { usePoll } from "@/shared/hooks/usePoll";
+
+interface UseSiteStatsOptions {
+  siteId: bigint;
+  // When false the hook skips fetching and stays in the loading state.
+  // Use to defer until the parent has a real site id.
+  enabled?: boolean;
+  pollIntervalMs?: number;
+}
+
+interface UseSiteStatsReturn {
+  stats: GetSiteStatsResponse | undefined;
+  isLoading: boolean;
+  hasLoaded: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/**
+ * Wraps SiteService.GetSiteStats with the standard
+ * loading / hasLoaded / poll-without-spinner pattern. Schedules its
+ * polling via the shared `usePoll` hook so the cadence matches other
+ * polled hooks (useTelemetry, useFleetCounts, etc.).
+ *
+ * Scope is server-side: every device with site_id matching the request
+ * (racked or directly site-attached).
+ */
+export const useSiteStats = ({ siteId, enabled = true, pollIntervalMs }: UseSiteStatsOptions): UseSiteStatsReturn => {
+  const { handleAuthErrors } = useAuthErrors();
+  const [stats, setStats] = useState<GetSiteStatsResponse | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestIdRef = useRef(0);
+  const hasLoadedRef = useRef(false);
+
+  // Reset on scope change so a stale response from a previous site can't
+  // land. Sync-during-render mirrors useTelemetryMetrics.
+  const scopeKey = `${siteId.toString()}|${enabled ? "on" : "off"}`;
+  const prevScopeRef = useRef(scopeKey);
+  if (prevScopeRef.current !== scopeKey) {
+    prevScopeRef.current = scopeKey;
+    ++requestIdRef.current;
+    hasLoadedRef.current = false;
+    setHasLoaded(false);
+    setStats(undefined);
+    // Reset error too — otherwise an error banner from a previous site
+    // stays visible until the new fetch lands, even though it's stale.
+    setError(null);
+  }
+
+  const fetchStats = useCallback(async () => {
+    if (!enabled || siteId === 0n) {
+      ++requestIdRef.current;
+      setIsLoading(false);
+      return;
+    }
+
+    const thisRequestId = ++requestIdRef.current;
+    if (!hasLoadedRef.current) {
+      setIsLoading(true);
+    }
+    setError(null);
+
+    try {
+      const response = await sitesClient.getSiteStats({ siteId });
+      if (thisRequestId !== requestIdRef.current) return;
+      setStats(response);
+      hasLoadedRef.current = true;
+      setHasLoaded(true);
+    } catch (err) {
+      if (thisRequestId !== requestIdRef.current) return;
+      handleAuthErrors({
+        error: err,
+        onError: () => {
+          const message = err instanceof Error ? err.message : String(err);
+          setError(message);
+          console.error("[useSiteStats] failed to fetch site stats", { siteId: siteId.toString(), error: message });
+        },
+      });
+    } finally {
+      if (thisRequestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [siteId, enabled, handleAuthErrors]);
+
+  // `usePoll` runs an initial fetch when enabled and schedules follow-ups
+  // when `poll` is true. Keying on scopeKey + pollIntervalMs forces a
+  // re-run when the caller flips the site or toggles polling.
+  usePoll({
+    fetchData: fetchStats,
+    params: scopeKey,
+    poll: pollIntervalMs !== undefined,
+    pollIntervalMs,
+    enabled,
+  });
+
+  return { stats, isLoading, hasLoaded, error, refetch: fetchStats };
+};

--- a/client/src/protoFleet/components/DeviceSetList/deviceSetColConfig.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/deviceSetColConfig.tsx
@@ -7,7 +7,7 @@ import CompositionBar, { type Segment } from "@/shared/components/CompositionBar
 import { type ColConfig } from "@/shared/components/List/types";
 import type { TemperatureUnit } from "@/shared/features/preferences";
 import { getDisplayValue } from "@/shared/utils/stringUtils";
-import { formatTempRange } from "@/shared/utils/utility";
+import { formatTempRange } from "@/shared/utils/telemetryFormat";
 
 const INACTIVE_PLACEHOLDER = "—";
 

--- a/client/src/protoFleet/features/buildings/components/BuildingCard.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingCard.test.tsx
@@ -1,0 +1,307 @@
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import BuildingCard from "./BuildingCard";
+import { BuildingSchema, BuildingWithCountsSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+
+const statsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/protoFleet/api/useBuildingStats", () => ({
+  useBuildingStats: (...args: unknown[]) => statsMock(...args),
+}));
+
+interface RackHealthInit {
+  rackId: number;
+  rackLabel?: string;
+  aisleIndex?: number;
+  positionInAisle?: number;
+  brokenCount?: number;
+  offlineCount?: number;
+  sleepingCount?: number;
+  hashingCount?: number;
+}
+
+const rackHealth = (init: RackHealthInit) => ({
+  rackId: BigInt(init.rackId),
+  rackLabel: init.rackLabel ?? `R${init.rackId}`,
+  aisleIndex: init.aisleIndex,
+  positionInAisle: init.positionInAisle,
+  hashingCount: init.hashingCount ?? 0,
+  brokenCount: init.brokenCount ?? 0,
+  offlineCount: init.offlineCount ?? 0,
+  sleepingCount: init.sleepingCount ?? 0,
+});
+
+interface StatsOverrides {
+  totalHashrateThs?: number;
+  avgEfficiencyJth?: number;
+  totalPowerKw?: number;
+  reportingCount?: number;
+  hashrateReportingCount?: number;
+  efficiencyReportingCount?: number;
+  powerReportingCount?: number;
+  hashingCount?: number;
+  brokenCount?: number;
+  offlineCount?: number;
+  sleepingCount?: number;
+  rackHealth?: ReturnType<typeof rackHealth>[];
+  rackCount?: number;
+}
+
+// Defaults assume "every reporting device has every field." Tests that
+// exercise per-field missing-data behaviour override the individual
+// counts.
+const buildStats = (overrides: StatsOverrides = {}) => {
+  const reporting = overrides.reportingCount ?? 0;
+  return {
+    buildingId: 7n,
+    rackCount: 0,
+    deviceCount: 0,
+    reportingCount: reporting,
+    hashrateReportingCount: reporting,
+    efficiencyReportingCount: reporting,
+    powerReportingCount: reporting,
+    totalHashrateThs: 0,
+    avgEfficiencyJth: 0,
+    totalPowerKw: 0,
+    hashingCount: 0,
+    brokenCount: 0,
+    offlineCount: 0,
+    sleepingCount: 0,
+    rackHealth: [] as ReturnType<typeof rackHealth>[],
+    ...overrides,
+  };
+};
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="location-probe">{`${location.pathname}${location.search}`}</div>;
+};
+
+interface RenderOptions {
+  rackCount?: bigint;
+  aisles?: number;
+  racksPerAisle?: number;
+}
+
+const renderCard = ({ rackCount = 24n, aisles = 2, racksPerAisle = 12 }: RenderOptions = {}) => {
+  const building = create(BuildingWithCountsSchema, {
+    building: create(BuildingSchema, {
+      id: 7n,
+      name: "Building A",
+      siteId: 1n,
+      aisles,
+      racksPerAisle,
+    }),
+    rackCount,
+  });
+  return render(
+    <MemoryRouter initialEntries={["/sites"]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <BuildingCard building={building} />
+              <LocationProbe />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+};
+
+describe("BuildingCard", () => {
+  it("shows skeletons in the status and footer slots while stats are loading", () => {
+    statsMock.mockReturnValue({ stats: undefined, isLoading: true, hasLoaded: false, error: null, refetch: vi.fn() });
+    renderCard({ rackCount: 3n });
+    expect(screen.getByTestId("building-card-7-name")).toHaveTextContent("Building A");
+    expect(screen.getByTestId("building-card-7-stat-racks")).toHaveTextContent("3 racks");
+    expect(screen.getByTestId("building-card-7-status").querySelector("[data-testid='skeleton-bar']")).not.toBeNull();
+    expect(
+      screen.getByTestId("building-card-7-stat-hashrate").querySelector("[data-testid='skeleton-bar']"),
+    ).not.toBeNull();
+  });
+
+  it("renders one comma-joined clause per non-zero state bucket", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats({
+        brokenCount: 12,
+        offlineCount: 9,
+        sleepingCount: 49,
+        hashingCount: 30,
+        reportingCount: 100,
+        rackHealth: [rackHealth({ rackId: 1, aisleIndex: 0, positionInAisle: 0, brokenCount: 12 })],
+      }),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ rackCount: 20n });
+    expect(screen.getByTestId("building-card-7-status")).toHaveTextContent("12 issues, 9 offline, 49 sleeping");
+  });
+
+  it("omits zero-count buckets from the status line", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats({
+        brokenCount: 0,
+        offlineCount: 3,
+        sleepingCount: 0,
+        hashingCount: 47,
+        reportingCount: 50,
+        rackHealth: [rackHealth({ rackId: 1, aisleIndex: 0, positionInAisle: 0, offlineCount: 3 })],
+      }),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ rackCount: 5n });
+    const status = screen.getByTestId("building-card-7-status");
+    expect(status).toHaveTextContent("3 offline");
+    expect(status.textContent).not.toMatch(/issue|sleeping/);
+  });
+
+  it("shows 'All healthy' only when the building has assigned racks and zero issues", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats({
+        hashingCount: 50,
+        reportingCount: 50,
+        rackHealth: [rackHealth({ rackId: 1, aisleIndex: 0, positionInAisle: 0, hashingCount: 50 })],
+      }),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ rackCount: 5n });
+    expect(screen.getByTestId("building-card-7-status")).toHaveTextContent("All healthy");
+  });
+
+  it("renders an empty status line when no racks are assigned", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats(),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ rackCount: 0n });
+    expect(screen.getByTestId("building-card-7-status")).toHaveTextContent("");
+  });
+
+  it("renders formatted footer stats from the server roll-up", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats({
+        totalHashrateThs: 275_900, // → 275.9 PH/s
+        totalPowerKw: 1_039_100, // → 1,039.1 MW
+        avgEfficiencyJth: 3_766.4,
+        reportingCount: 1000,
+        rackCount: 20,
+      }),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ rackCount: 20n });
+    expect(screen.getByTestId("building-card-7-stat-hashrate")).toHaveTextContent("275.9 PH/s");
+    expect(screen.getByTestId("building-card-7-stat-efficiency")).toHaveTextContent("3,766.4 J/TH");
+    expect(screen.getByTestId("building-card-7-stat-power")).toHaveTextContent("1,039.1 MW");
+    expect(screen.getByTestId("building-card-7-stat-racks")).toHaveTextContent("20 racks");
+  });
+
+  it("renders em dashes in the footer when nothing is reporting", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats({ reportingCount: 0 }),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ rackCount: 0n });
+    expect(screen.getByTestId("building-card-7-stat-hashrate")).toHaveTextContent("—");
+    expect(screen.getByTestId("building-card-7-stat-power")).toHaveTextContent("—");
+    expect(screen.getByTestId("building-card-7-stat-efficiency")).toHaveTextContent("—");
+  });
+
+  it("paints assigned cells with their worst rack state and leaves the rest unassigned", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats({
+        rackHealth: [
+          // R1 (0:0) — broken miner present → needsAttention.
+          rackHealth({ rackId: 1, aisleIndex: 0, positionInAisle: 0, brokenCount: 1, hashingCount: 5 }),
+          // R2 (0:1) — only sleeping → sleeping.
+          rackHealth({ rackId: 2, aisleIndex: 0, positionInAisle: 1, sleepingCount: 3 }),
+          // R3 (1:0) — offline beats sleeping per priority.
+          rackHealth({ rackId: 3, aisleIndex: 1, positionInAisle: 0, offlineCount: 2, sleepingCount: 1 }),
+          // R4 (1:1) — only hashing miners → healthy.
+          rackHealth({ rackId: 4, aisleIndex: 1, positionInAisle: 1, hashingCount: 4 }),
+        ],
+      }),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ aisles: 2, racksPerAisle: 3 });
+    const cells = screen.getByTestId("building-card-7-grid").querySelectorAll("span[aria-hidden='true']");
+    expect(cells.length).toBe(6);
+    expect(cells[0].getAttribute("data-cell-state")).toBe("needsAttention");
+    expect(cells[1].getAttribute("data-cell-state")).toBe("sleeping");
+    expect(cells[2].getAttribute("data-cell-state")).toBe("unassigned");
+    expect(cells[3].getAttribute("data-cell-state")).toBe("offline");
+    expect(cells[4].getAttribute("data-cell-state")).toBe("healthy");
+    expect(cells[5].getAttribute("data-cell-state")).toBe("unassigned");
+  });
+
+  it("navigates to /buildings/:id when the card body is clicked", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats(),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ rackCount: 0n });
+    fireEvent.click(screen.getByTestId("building-card-7"));
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/buildings/7");
+  });
+
+  it("opens an actions menu from the ellipsis trigger and routes to the chosen destination", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats(),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ rackCount: 0n });
+    expect(screen.queryByTestId("building-card-7-menu")).toBeNull();
+    fireEvent.click(screen.getByTestId("building-card-7-menu-trigger"));
+    expect(screen.getByTestId("building-card-7-menu")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("building-card-7-menu-racks"));
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/racks?building=7");
+  });
+
+  it("dismisses the actions menu without navigating when the backdrop is clicked", () => {
+    statsMock.mockReturnValue({
+      stats: buildStats(),
+      isLoading: false,
+      hasLoaded: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderCard({ rackCount: 0n });
+    fireEvent.click(screen.getByTestId("building-card-7-menu-trigger"));
+    const menu = screen.getByTestId("building-card-7-menu");
+    const backdrop = menu.previousElementSibling as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(screen.queryByTestId("building-card-7-menu")).toBeNull();
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/sites");
+  });
+});

--- a/client/src/protoFleet/features/buildings/components/BuildingCard.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingCard.tsx
@@ -1,32 +1,417 @@
-import { Link } from "react-router-dom";
+import { type CSSProperties, type ReactNode, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import clsx from "clsx";
 
-import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
-
-// FPO implementation. Phase 1a ships this card as a grey box with label +
-// rack count so the navigation flow from /sites → /buildings/:id is wired
-// end-to-end. #263 replaces the body with the real BuildingCard (visuals +
-// per-building metrics + health indicators) — the file path stays the same
-// so imports across /sites don't churn during the swap.
+import { type BuildingRackHealth, type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { useBuildingStats } from "@/protoFleet/api/useBuildingStats";
+import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
+import {
+  formatEfficiencyOrDash,
+  formatHashrateOrDash,
+  formatPowerMwOrDash,
+} from "@/protoFleet/features/sites/utils/formatSiteMetrics";
+import { Ellipsis } from "@/shared/assets/icons";
+import { iconSizes } from "@/shared/assets/icons/constants";
+import SkeletonBar from "@/shared/components/SkeletonBar";
+import { useEscapeDismiss } from "@/shared/hooks/useEscapeDismiss";
 
 interface BuildingCardProps {
   building: BuildingWithCounts;
 }
 
-const BuildingCard = ({ building }: BuildingCardProps) => {
-  const id = (building.building?.id ?? 0n).toString();
-  const label = building.building?.name ?? "(unnamed building)";
-  const rackCount = building.rackCount.toString();
+// Rack-cell visual states. Five total: "unassigned" is owned by the renderer
+// (no rack lives at this floor-plan position) and the four others come from
+// the per-rack worst-state aggregation in GetBuildingStats.
+type CellState = "unassigned" | "needsAttention" | "offline" | "sleeping" | "healthy";
+
+// Priority rule for collapsing a rack's count buckets into a single cell
+// state. Lives client-side (per #263 design discussion) so visual iteration
+// doesn't churn the proto.
+const cellStateForRack = (r: BuildingRackHealth): CellState => {
+  if (r.brokenCount > 0) return "needsAttention";
+  if (r.offlineCount > 0) return "offline";
+  if (r.sleepingCount > 0) return "sleeping";
+  return "healthy";
+};
+
+const CELL_CLASS: Record<CellState, string> = {
+  unassigned: "border border-core-primary-10",
+  needsAttention: "border border-core-primary-20 bg-intent-critical-10",
+  offline: "border border-core-primary-20 bg-intent-warning-10",
+  sleeping: "border border-core-primary-10",
+  healthy: "border border-core-primary-20",
+};
+
+const CELL_DOT: Record<CellState, { kind: "none" } | { kind: "dot"; className: string } | { kind: "plus" }> = {
+  unassigned: { kind: "plus" },
+  needsAttention: { kind: "dot", className: "bg-intent-critical-fill" },
+  offline: { kind: "dot", className: "bg-intent-warning-fill" },
+  sleeping: { kind: "dot", className: "bg-core-primary-20" },
+  healthy: { kind: "none" },
+};
+
+interface RackGridProps {
+  aisles: number;
+  racksPerAisle: number;
+  cellStates: Record<string, CellState>;
+  testId: string;
+}
+
+const cellKey = (aisle: number, position: number) => `${aisle}:${position}`;
+
+// Visual constants. Cells normally render at MAX_CELL_PX (16px) with
+// CELL_GAP_PX (4px) between them; once the natural grid width would
+// overflow the container, the cells shrink uniformly via CSS `min()` so
+// the floor plan keeps reading the same shape on narrow cards or wide
+// buildings. MIN_CELL_PX floors the calc so pathological column counts
+// (e.g. 100 cols × 300px card → calc() would resolve negative) still
+// render visible cells; the grid overflows horizontally before going
+// invisible.
+const MAX_CELL_PX = 16;
+const MIN_CELL_PX = 2;
+const CELL_GAP_PX = 4;
+
+const RackGrid = ({ aisles, racksPerAisle, cellStates, testId }: RackGridProps) => {
+  if (aisles <= 0 || racksPerAisle <= 0) {
+    return (
+      <div className="text-200 text-text-primary-50" data-testid={`${testId}-empty`}>
+        Floor plan not configured
+      </div>
+    );
+  }
+
+  const rows: { aisle: number; cells: CellState[] }[] = [];
+  for (let a = 0; a < aisles; a++) {
+    const cells: CellState[] = [];
+    for (let p = 0; p < racksPerAisle; p++) {
+      cells.push(cellStates[cellKey(a, p)] ?? "unassigned");
+    }
+    rows.push({ aisle: a, cells });
+  }
+
+  // Calc against 100% of the row width. `min(16px, ...)` clamps to the
+  // fixed max when there's room; `max(MIN_CELL_PX, ...)` floors it so
+  // pathological column counts (e.g. 100 cols on a 300px-wide card)
+  // can't resolve to a negative width — the grid overflows horizontally
+  // instead, which `justify-center` keeps visually centered. Total gap
+  // is just (N-1) gaps between cells; outer breathing room comes from
+  // the card's px-5 padding.
+  //
+  // Safety: the early return above guarantees racksPerAisle > 0 here, so
+  // the `/ ${racksPerAisle}` divisor in the calc can never be zero. If
+  // future refactors lift that guard, this calc will need a defensive
+  // ceiling restored.
+  const totalGapPx = (racksPerAisle - 1) * CELL_GAP_PX;
+  // Use an intersection type to expose the custom property without a
+  // blanket `as CSSProperties` cast — the css var is typed explicitly,
+  // standard CSSProperties stays type-safe, and unrelated property
+  // names can't be silently smuggled in.
+  const gridStyle: CSSProperties & { "--cell-size": string } = {
+    "--cell-size": `max(${MIN_CELL_PX}px, min(${MAX_CELL_PX}px, calc((100% - ${totalGapPx}px) / ${racksPerAisle})))`,
+  };
 
   return (
-    <Link
-      to={`/buildings/${id}`}
-      className="hover:bg-surface-base-hover block rounded-xl border border-border-5 bg-surface-base p-4"
-      data-testid={`building-card-${id}`}
-    >
-      <div className="text-emphasis-300">{label}</div>
-      <div className="text-300 text-text-primary-70">{rackCount} racks / — miners</div>
-    </Link>
+    <div className="flex w-full max-w-full flex-col gap-1" data-testid={testId} style={gridStyle}>
+      {rows.map((row) => (
+        <div key={row.aisle} className="flex justify-center gap-1">
+          {row.cells.map((state, p) => {
+            const dot = CELL_DOT[state];
+            return (
+              <span
+                key={p}
+                aria-hidden
+                data-cell-state={state}
+                // `aspect-square` keeps the cell a square — `height: var(--cell-size)`
+                // would resolve calc(100% - …) against the row's height (auto → 0)
+                // instead of its width, collapsing the cell. Width drives the size,
+                // aspect-ratio derives the height.
+                className={clsx(
+                  "flex aspect-square shrink-0 items-center justify-center rounded-[3px]",
+                  CELL_CLASS[state],
+                )}
+                style={{ width: "var(--cell-size)" }}
+              >
+                {dot.kind === "dot" ? (
+                  // Inner dot is sized as a percentage of the cell so it
+                  // shrinks with the wrapper when the grid is space-constrained.
+                  <span
+                    className={clsx("block rounded-full", dot.className)}
+                    style={{ width: "37.5%", height: "37.5%" }}
+                  />
+                ) : dot.kind === "plus" ? (
+                  // The + glyph scales off the cell size for the same reason —
+                  // 62.5% of cell = 10px at the 16px max, matching the prior
+                  // text-[10px] design.
+                  <span
+                    className="leading-none text-core-primary-20"
+                    style={{ fontSize: "calc(var(--cell-size) * 0.625)" }}
+                  >
+                    +
+                  </span>
+                ) : null}
+              </span>
+            );
+          })}
+        </div>
+      ))}
+    </div>
   );
 };
+
+interface StatProps {
+  value: ReactNode;
+  testId: string;
+}
+
+const Stat = ({ value, testId }: StatProps) => (
+  <div className="px-3 py-3 text-300 text-text-primary-70 first:pl-5 last:pr-5" data-testid={testId}>
+    {value}
+  </div>
+);
+
+const BuildingCard = ({ building }: BuildingCardProps) => {
+  const id = building.building?.id ?? 0n;
+  const idText = id.toString();
+  const label = building.building?.name ?? "(unnamed building)";
+  const aisles = building.building?.aisles ?? 0;
+  const racksPerAisle = building.building?.racksPerAisle ?? 0;
+
+  // Poll so cards on /sites stay live as miners change state — without
+  // this, the rollup numbers + cell colours drift until the next manual
+  // refresh.
+  const { stats, error: statsError } = useBuildingStats({
+    buildingId: id,
+    enabled: id !== 0n,
+    pollIntervalMs: POLL_INTERVAL_MS,
+  });
+
+  // Derive cell-state map keyed by aisle:position from the server's
+  // rack_health list. Cells with no entry render unassigned.
+  const cellStates = useMemo<Record<string, CellState>>(() => {
+    if (!stats) return {};
+    const acc: Record<string, CellState> = {};
+    for (const r of stats.rackHealth) {
+      if (r.aisleIndex === undefined || r.positionInAisle === undefined) continue;
+      acc[cellKey(r.aisleIndex, r.positionInAisle)] = cellStateForRack(r);
+    }
+    return acc;
+  }, [stats]);
+
+  // Status summary segments. Each non-zero bucket renders as its own
+  // "<N> <label>" clause; the floor plan up top already breaks the states
+  // apart by colour so the summary just needs to surface counts. Order
+  // (issues, offline, sleeping) matches the worst-first priority used by
+  // the cell-state rule.
+  const summarySegments: string[] = [];
+  if (stats) {
+    if (stats.brokenCount > 0) {
+      summarySegments.push(`${stats.brokenCount} ${stats.brokenCount === 1 ? "issue" : "issues"}`);
+    }
+    if (stats.offlineCount > 0) {
+      summarySegments.push(`${stats.offlineCount} offline`);
+    }
+    if (stats.sleepingCount > 0) {
+      summarySegments.push(`${stats.sleepingCount} sleeping`);
+    }
+  }
+  // "All healthy" only when the building actually has a rack assigned —
+  // an empty floor plan shouldn't claim health it doesn't have.
+  const hasAssignedRacks = (stats?.rackHealth.length ?? 0) > 0;
+  const showAllHealthy = stats !== undefined && summarySegments.length === 0 && hasAssignedRacks;
+
+  const navigate = useNavigate();
+  const [menuOpen, setMenuOpen] = useState(false);
+  useEscapeDismiss(menuOpen ? () => setMenuOpen(false) : undefined);
+  const goToDetail = () => navigate(`/buildings/${idText}`);
+
+  return (
+    <div
+      role="link"
+      tabIndex={0}
+      onClick={(e) => {
+        if (menuOpen) return;
+        if ((e.target as HTMLElement).closest("[data-popover='building-card-menu']")) return;
+        goToDetail();
+      }}
+      onKeyDown={(e) => {
+        if (e.key !== "Enter" && e.key !== " ") return;
+        // Don't hijack keyboard activation when the focus is on the
+        // ellipsis menu trigger or a popover menu item — mirror the
+        // onClick guard above so keyboard users can navigate the menu.
+        if ((e.target as HTMLElement).closest("[data-popover='building-card-menu'],[data-testid$='-menu-trigger']"))
+          return;
+        e.preventDefault();
+        goToDetail();
+      }}
+      className="flex h-full cursor-pointer flex-col rounded-2xl bg-surface-5 transition-opacity hover:opacity-80"
+      data-testid={`building-card-${idText}`}
+    >
+      <div className="flex items-center justify-between gap-2 px-5 pt-4">
+        <span className="truncate text-emphasis-300 text-text-primary" data-testid={`building-card-${idText}-name`}>
+          {label}
+        </span>
+        <div className="relative shrink-0">
+          <button
+            type="button"
+            aria-label="Building actions"
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            onClick={(e) => {
+              e.stopPropagation();
+              setMenuOpen((prev) => !prev);
+            }}
+            className="flex size-8 items-center justify-center rounded-full text-text-primary-70 hover:bg-black/[0.06] dark:hover:bg-white/[0.06]"
+            data-testid={`building-card-${idText}-menu-trigger`}
+          >
+            <Ellipsis width={iconSizes.small} />
+          </button>
+          {menuOpen ? (
+            <BuildingCardMenu
+              idText={idText}
+              onDismiss={() => setMenuOpen(false)}
+              onNavigate={(path) => {
+                setMenuOpen(false);
+                navigate(path);
+              }}
+            />
+          ) : null}
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 px-5 py-6">
+        <RackGrid
+          aisles={aisles}
+          racksPerAisle={racksPerAisle}
+          cellStates={cellStates}
+          testId={`building-card-${idText}-grid`}
+        />
+        <div
+          className="flex min-h-5 items-center gap-2 text-200 text-text-primary-70"
+          data-testid={`building-card-${idText}-status`}
+        >
+          {stats === undefined && statsError ? (
+            // Surface stats-fetch failure so the card doesn't sit in a
+            // permanent skeleton state. Card itself remains clickable; the
+            // /buildings/:id page is the recovery path.
+            <span className="text-intent-critical-text" data-testid={`building-card-${idText}-stats-error`}>
+              Couldn&apos;t load stats
+            </span>
+          ) : stats === undefined ? (
+            <SkeletonBar className="w-32" />
+          ) : summarySegments.length > 0 ? (
+            <>
+              <span aria-hidden className="inline-block size-2 rounded-full bg-intent-critical-fill" />
+              <span>{summarySegments.join(", ")}</span>
+            </>
+          ) : showAllHealthy ? (
+            <span>All healthy</span>
+          ) : null}
+        </div>
+      </div>
+      <div className="grid grid-cols-4 divide-x divide-border-5 border-t border-border-5">
+        <Stat
+          testId={`building-card-${idText}-stat-hashrate`}
+          value={
+            stats === undefined ? (
+              <SkeletonBar className="w-14" />
+            ) : (
+              formatHashrateOrDash(stats.hashrateReportingCount > 0 ? stats.totalHashrateThs : null)
+            )
+          }
+        />
+        <Stat
+          testId={`building-card-${idText}-stat-efficiency`}
+          value={
+            stats === undefined ? (
+              <SkeletonBar className="w-14" />
+            ) : (
+              formatEfficiencyOrDash(stats.efficiencyReportingCount > 0 ? stats.avgEfficiencyJth : null)
+            )
+          }
+        />
+        <Stat
+          testId={`building-card-${idText}-stat-power`}
+          value={
+            stats === undefined ? (
+              <SkeletonBar className="w-14" />
+            ) : (
+              formatPowerMwOrDash(stats.powerReportingCount > 0 ? stats.totalPowerKw : null)
+            )
+          }
+        />
+        <Stat
+          testId={`building-card-${idText}-stat-racks`}
+          value={(() => {
+            // Prefer the polled stats.rackCount once available so the
+            // footer stays in sync with rack assignments. Fall back to
+            // the ListBuildings count during the first poll tick.
+            const count = stats?.rackCount ?? Number(building.rackCount);
+            return (
+              <>
+                {count} {count === 1 ? "rack" : "racks"}
+              </>
+            );
+          })()}
+        />
+      </div>
+    </div>
+  );
+};
+
+interface BuildingCardMenuProps {
+  idText: string;
+  onDismiss: () => void;
+  onNavigate: (path: string) => void;
+}
+
+const BuildingCardMenu = ({ idText, onDismiss, onNavigate }: BuildingCardMenuProps) => (
+  <>
+    <div
+      className="fixed inset-0 z-20"
+      role="presentation"
+      onClick={(e) => {
+        e.stopPropagation();
+        onDismiss();
+      }}
+    />
+    <div
+      data-popover="building-card-menu"
+      data-testid={`building-card-${idText}-menu`}
+      role="menu"
+      className="absolute top-full right-0 z-30 mt-1 w-44 rounded-xl border border-border-5 bg-surface-elevated-base py-1 shadow-300"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <BuildingCardMenuItem
+        label="View details"
+        testId={`building-card-${idText}-menu-details`}
+        onClick={() => onNavigate(`/buildings/${idText}`)}
+      />
+      <BuildingCardMenuItem
+        label="View racks"
+        testId={`building-card-${idText}-menu-racks`}
+        onClick={() => onNavigate(`/racks?building=${idText}`)}
+      />
+      <BuildingCardMenuItem
+        label="View miners"
+        testId={`building-card-${idText}-menu-miners`}
+        onClick={() => onNavigate(`/miners?building=${idText}`)}
+      />
+    </div>
+  </>
+);
+
+const BuildingCardMenuItem = ({ label, testId, onClick }: { label: string; testId: string; onClick: () => void }) => (
+  <button
+    type="button"
+    role="menuitem"
+    onClick={(e) => {
+      e.stopPropagation();
+      onClick();
+    }}
+    className="w-full px-4 py-2 text-left text-300 text-text-primary hover:bg-surface-5"
+    data-testid={testId}
+  >
+    {label}
+  </button>
+);
 
 export default BuildingCard;

--- a/client/src/protoFleet/features/buildings/components/BuildingCard.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingCard.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type ReactNode, useMemo, useState } from "react";
+import { type CSSProperties, type ReactNode, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 
@@ -14,6 +14,7 @@ import { Ellipsis } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import SkeletonBar from "@/shared/components/SkeletonBar";
 import { useEscapeDismiss } from "@/shared/hooks/useEscapeDismiss";
+import { useInViewport } from "@/shared/hooks/useInViewport";
 
 interface BuildingCardProps {
   building: BuildingWithCounts;
@@ -176,12 +177,20 @@ const BuildingCard = ({ building }: BuildingCardProps) => {
   const aisles = building.building?.aisles ?? 0;
   const racksPerAisle = building.building?.racksPerAisle ?? 0;
 
+  // Viewport-gate the poll so an "All Sites" page rendering 50+ cards
+  // doesn't fan out 50 GetBuildingStats RPCs every poll tick — only
+  // currently-visible cards refresh. Cards retain their last-good stats
+  // when scrolled offscreen (the hook keeps the snapshot when `enabled`
+  // toggles), so re-revealing doesn't flash a skeleton.
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const isVisible = useInViewport(cardRef);
+
   // Poll so cards on /sites stay live as miners change state — without
   // this, the rollup numbers + cell colours drift until the next manual
   // refresh.
   const { stats, error: statsError } = useBuildingStats({
     buildingId: id,
-    enabled: id !== 0n,
+    enabled: id !== 0n && isVisible,
     pollIntervalMs: POLL_INTERVAL_MS,
   });
 
@@ -226,6 +235,7 @@ const BuildingCard = ({ building }: BuildingCardProps) => {
 
   return (
     <div
+      ref={cardRef}
       role="link"
       tabIndex={0}
       onClick={(e) => {

--- a/client/src/protoFleet/features/buildings/components/BuildingCard.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingCard.tsx
@@ -5,16 +5,12 @@ import clsx from "clsx";
 import { type BuildingRackHealth, type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { useBuildingStats } from "@/protoFleet/api/useBuildingStats";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
-import {
-  formatEfficiencyOrDash,
-  formatHashrateOrDash,
-  formatPowerMwOrDash,
-} from "@/protoFleet/features/sites/utils/formatSiteMetrics";
 import { Ellipsis } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import SkeletonBar from "@/shared/components/SkeletonBar";
 import { useEscapeDismiss } from "@/shared/hooks/useEscapeDismiss";
 import { useInViewport } from "@/shared/hooks/useInViewport";
+import { formatEfficiencyOrDash, formatHashrateOrDash, formatPowerMwOrDash } from "@/shared/utils/telemetryFormat";
 
 interface BuildingCardProps {
   building: BuildingWithCounts;

--- a/client/src/protoFleet/features/buildings/components/BuildingMetricsRow.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingMetricsRow.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import BuildingMetricsRow from "./BuildingMetricsRow";
+
+// Minimal helper — only the fields BuildingMetricsRow reads. Cast to the
+// proto shape via `unknown` so the test stays narrow without depending
+// on every $typeName / $unknown field the generated message carries.
+type MetricsLike = {
+  totalHashrateThs: number;
+  totalPowerKw: number;
+  avgEfficiencyJth: number;
+  reportingCount: number;
+  hashrateReportingCount: number;
+  efficiencyReportingCount: number;
+  powerReportingCount: number;
+  hashingCount: number;
+  deviceCount: number;
+};
+
+const stats = (overrides: Partial<MetricsLike> = {}) =>
+  ({
+    totalHashrateThs: 0,
+    totalPowerKw: 0,
+    avgEfficiencyJth: 0,
+    reportingCount: 0,
+    hashrateReportingCount: 0,
+    efficiencyReportingCount: 0,
+    powerReportingCount: 0,
+    hashingCount: 0,
+    deviceCount: 0,
+    ...overrides,
+  }) as unknown as Parameters<typeof BuildingMetricsRow>[0]["stats"];
+
+describe("BuildingMetricsRow", () => {
+  it("renders skeletons in metric tiles while stats are loading", () => {
+    render(<BuildingMetricsRow powerCapacityKw={20_000} stats={undefined} />);
+    expect(screen.getByTestId("building-metric-hashrate").querySelector("[data-testid='skeleton-bar']")).not.toBeNull();
+    expect(screen.getByTestId("building-metric-online").querySelector("[data-testid='skeleton-bar']")).not.toBeNull();
+  });
+
+  it("renders em dashes when no device is reporting", () => {
+    render(
+      <BuildingMetricsRow
+        powerCapacityKw={20_000}
+        stats={stats({ reportingCount: 0, hashingCount: 0, deviceCount: 0 })}
+      />,
+    );
+    expect(screen.getByTestId("building-metric-hashrate")).toHaveTextContent("—");
+    expect(screen.getByTestId("building-metric-power")).toHaveTextContent("—");
+    expect(screen.getByTestId("building-metric-efficiency")).toHaveTextContent("—");
+    expect(screen.getByTestId("building-metric-online")).toHaveTextContent("0 / 0");
+  });
+
+  it("renders aggregated values once stats resolve", () => {
+    render(
+      <BuildingMetricsRow
+        powerCapacityKw={20_000}
+        stats={stats({
+          totalHashrateThs: 5_500, // 5.50 PH/s
+          totalPowerKw: 12_345, // 12.3 MW
+          avgEfficiencyJth: 28.5,
+          reportingCount: 1_200,
+          hashrateReportingCount: 1_200,
+          efficiencyReportingCount: 1_200,
+          powerReportingCount: 1_200,
+          hashingCount: 1_180,
+          deviceCount: 1_200,
+        })}
+      />,
+    );
+    expect(screen.getByTestId("building-metric-hashrate")).toHaveTextContent("5.50 PH/s");
+    // 20_000 kW = 20 MW capacity; consumed 12_345 kW = 12.3 MW
+    expect(screen.getByTestId("building-metric-power")).toHaveTextContent("12.3 / 20.0 MW");
+    expect(screen.getByTestId("building-metric-efficiency")).toHaveTextContent("28.5 J/TH");
+    expect(screen.getByTestId("building-metric-online")).toHaveTextContent("1,180 / 1,200");
+  });
+
+  it("renders the power tile with an em dash on the capacity side when capacity is unset", () => {
+    render(
+      <BuildingMetricsRow
+        powerCapacityKw={0}
+        stats={stats({
+          totalPowerKw: 5_000,
+          reportingCount: 1,
+          powerReportingCount: 1,
+          hashingCount: 1,
+          deviceCount: 1,
+        })}
+      />,
+    );
+    expect(screen.getByTestId("building-metric-power")).toHaveTextContent("5.0 / — MW");
+  });
+});

--- a/client/src/protoFleet/features/buildings/components/BuildingMetricsRow.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingMetricsRow.tsx
@@ -1,12 +1,7 @@
 import { type GetBuildingStatsResponse } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
-import {
-  formatEfficiency,
-  formatHashrate,
-  formatPowerUsedCapacity,
-  KW_PER_MW,
-} from "@/protoFleet/features/sites/utils/formatSiteMetrics";
 import Metric from "@/shared/components/Metric";
 import { separateByCommas } from "@/shared/utils/stringUtils";
+import { formatEfficiency, formatHashrate, formatPowerUsedCapacity, KW_PER_MW } from "@/shared/utils/telemetryFormat";
 
 interface BuildingMetricsRowProps {
   // Building capacity (power_kw on the Building proto). 0 = unset → renders

--- a/client/src/protoFleet/features/buildings/components/BuildingMetricsRow.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingMetricsRow.tsx
@@ -1,0 +1,54 @@
+import { type GetBuildingStatsResponse } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import {
+  formatEfficiency,
+  formatHashrate,
+  formatPowerUsedCapacity,
+  KW_PER_MW,
+} from "@/protoFleet/features/sites/utils/formatSiteMetrics";
+import Metric from "@/shared/components/Metric";
+import { separateByCommas } from "@/shared/utils/stringUtils";
+
+interface BuildingMetricsRowProps {
+  // Building capacity (power_kw on the Building proto). 0 = unset → renders
+  // as an em dash on the capacity side of the power tile.
+  powerCapacityKw: number;
+  // `undefined` while stats are still loading; the Metric primitive renders
+  // skeletons. `null` on any cell is the no-data em dash.
+  stats: GetBuildingStatsResponse | undefined;
+  testId?: string;
+}
+
+const formatMinersOnline = (hashing: number, total: number): string => {
+  if (total === 0) return "0 / 0";
+  return `${separateByCommas(hashing)} / ${separateByCommas(total)}`;
+};
+
+// Four-metric header for /buildings/:id. Mirrors the rack-overview top
+// strip (hashrate / power / efficiency / online) but power adds a capacity
+// denominator from the building's power_kw config field.
+const BuildingMetricsRow = ({ powerCapacityKw, stats, testId }: BuildingMetricsRowProps) => {
+  // Per-field reporting counts so a device that reported state but not
+  // efficiency doesn't pull the building average toward a misleading
+  // partial number — render the dash instead.
+  const hashrate = stats ? formatHashrate(stats.hashrateReportingCount > 0 ? stats.totalHashrateThs : null) : undefined;
+  // Shared formatter expects capacity in MW; the Building proto stores
+  // power_kw, so convert at the call site.
+  const power = stats
+    ? formatPowerUsedCapacity(stats.powerReportingCount > 0 ? stats.totalPowerKw : null, powerCapacityKw / KW_PER_MW)
+    : undefined;
+  const efficiency = stats
+    ? formatEfficiency(stats.efficiencyReportingCount > 0 ? stats.avgEfficiencyJth : null)
+    : undefined;
+  const onlineDisplay = stats ? formatMinersOnline(stats.hashingCount, stats.deviceCount) : undefined;
+
+  return (
+    <div className="grid grid-cols-2 gap-6 tablet:grid-cols-4" data-testid={testId ?? "building-metrics-row"}>
+      <Metric label="Hashrate" value={hashrate} testId="building-metric-hashrate" />
+      <Metric label="Power" value={power} testId="building-metric-power" />
+      <Metric label="Efficiency" value={efficiency} testId="building-metric-efficiency" />
+      <Metric label="Miners online" value={onlineDisplay} testId="building-metric-online" />
+    </div>
+  );
+};
+
+export default BuildingMetricsRow;

--- a/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
@@ -1,6 +1,8 @@
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
+import { ChevronDown } from "@/shared/assets/icons";
 import Button, { variants } from "@/shared/components/Button";
+import Header from "@/shared/components/Header";
 
 interface BuildingPageHeaderProps {
   label: string;
@@ -11,29 +13,49 @@ interface BuildingPageHeaderProps {
   onEditBuilding?: () => void;
 }
 
-// "View miners" and "View racks" link to their respective lists with the
-// `building` URL filter — the singular key parsed by filterUrlParams.ts
-// (mirroring the existing `group` and `rack` singular keys). RacksPage
-// parses the same param to pre-select its building filter chip.
-const BuildingPageHeader = ({ label, buildingId, onEditBuilding }: BuildingPageHeaderProps) => (
-  <div className="flex items-start justify-between gap-4">
-    <h1 className="text-heading-500 text-text-primary">{label}</h1>
-    <div className="flex items-center gap-2">
-      <Link to={`/racks?building=${buildingId}`} data-testid="building-page-view-racks">
-        <Button variant={variants.secondary} text="View racks" onClick={() => undefined} />
-      </Link>
-      <Link to={`/miners?building=${buildingId}`} data-testid="building-page-view-miners">
-        <Button variant={variants.secondary} text="View miners" onClick={() => undefined} />
-      </Link>
-      <Button
-        variant={variants.primary}
-        text="Edit building"
-        onClick={onEditBuilding ?? (() => undefined)}
-        disabled={!onEditBuilding}
-        testId="building-page-edit"
-      />
-    </div>
-  </div>
-);
+// Mirrors RackOverviewPage's header: chevron-left back button, heading-300
+// title, and a cluster of three secondary buttons. "View miners" and "View
+// racks" link to their respective lists with the `building` URL filter — the
+// singular key parsed by filterUrlParams.ts (mirroring the existing `group`
+// and `rack` singular keys). RacksPage parses the same param to pre-select
+// its building filter chip.
+const BuildingPageHeader = ({ label, buildingId, onEditBuilding }: BuildingPageHeaderProps) => {
+  const navigate = useNavigate();
+  return (
+    <Header
+      title={label}
+      titleSize="text-heading-300"
+      inline
+      icon={<ChevronDown className="rotate-90" />}
+      iconAriaLabel="Back to sites"
+      iconOnClick={() => navigate("/sites")}
+    >
+      <div className="ml-3 flex items-center gap-3">
+        <Button
+          variant={variants.secondary}
+          onClick={() => navigate(`/racks?building=${buildingId}`)}
+          testId="building-page-view-racks"
+        >
+          View racks
+        </Button>
+        <Button
+          variant={variants.secondary}
+          onClick={() => navigate(`/miners?building=${buildingId}`)}
+          testId="building-page-view-miners"
+        >
+          View miners
+        </Button>
+        <Button
+          variant={variants.secondary}
+          onClick={onEditBuilding ?? (() => undefined)}
+          disabled={!onEditBuilding}
+          testId="building-page-edit"
+        >
+          Edit building
+        </Button>
+      </div>
+    </Header>
+  );
+};
 
 export default BuildingPageHeader;

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -2,25 +2,48 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { create } from "@bufbuild/protobuf";
 
+import BuildingMetricsRow from "../components/BuildingMetricsRow";
 import BuildingModals from "../components/BuildingModals";
 import BuildingPageHeader from "../components/BuildingPageHeader";
 import { useBuildingModals } from "../hooks/useBuildingModals";
 import { useBuildings } from "@/protoFleet/api/buildings";
 import { type Building, BuildingWithCountsSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { AggregationType, MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { parseBigIntId } from "@/protoFleet/api/sites";
+import { useBuildingStats } from "@/protoFleet/api/useBuildingStats";
+import { useComponentErrors } from "@/protoFleet/api/useComponentErrors";
+import { useTelemetryMetrics } from "@/protoFleet/api/useTelemetryMetrics";
+import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
+import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
+import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
+import { useDuration, useSetDuration } from "@/protoFleet/store";
 import Button, { sizes, variants } from "@/shared/components/Button";
+import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
 import Header from "@/shared/components/Header";
 import PlaceholderBlock from "@/shared/components/PlaceholderBlock";
+import { useStickyState } from "@/shared/hooks/useStickyState";
 
-// `/buildings/:id` page shell. The header + action buttons are real; the
-// metrics row, diagnostics section, and performance section are placeholders
-// pending #264. Building data comes from the GetBuilding RPC keyed by the
-// URL `:id` segment — no parent site_id required.
+// Same measurement / aggregation slate the rack-overview page uses, so the
+// performance charts render identically across both surfaces.
+const ALL_MEASUREMENT_TYPES: MeasurementType[] = [
+  MeasurementType.HASHRATE,
+  MeasurementType.POWER,
+  MeasurementType.TEMPERATURE,
+  MeasurementType.EFFICIENCY,
+  MeasurementType.UPTIME,
+];
+
+const ALL_AGGREGATION_TYPES: AggregationType[] = [AggregationType.AVERAGE, AggregationType.MIN, AggregationType.MAX];
+
+// `/buildings/:id` page shell. Mirrors RackOverviewPage: header, metric row,
+// diagnostics (rack-health module FPO + component health), and performance
+// charts. The diagnostics rack grid stays FPO pending #264; everything else
+// is wired against GetBuildingStats + the same telemetry hooks the rack
+// page uses.
 //
 // Response state distinguishes three outcomes so the UI can render each
 // honestly: NotFound (server confirmed the id doesn't exist), error (any
-// other failure — permission denied, network, 5xx), and success. Lumping
-// all failures into "not found" would mask real outages.
+// other failure — permission denied, network, 5xx), and success.
 type FetchOutcome =
   | { status: "found"; building: Building }
   | { status: "notFound" }
@@ -38,15 +61,8 @@ const BuildingPage = () => {
   // response against the newer URL while the new request is in flight.
   const [response, setResponse] = useState<{ id: bigint; outcome: FetchOutcome } | undefined>(undefined);
   // Parallel-fetched rack count keyed by buildingId so it can't race a
-  // navigation. Used to populate the cascade-delete dialog's count copy;
-  // falls back to 0n when the count fetch hasn't resolved yet (dialog
-  // then uses the generic "Are you sure?" copy — never undercount).
+  // navigation. Used to populate the cascade-delete dialog's count copy.
   const [rackCountResponse, setRackCountResponse] = useState<{ id: bigint; count: bigint } | undefined>(undefined);
-
-  // Hold the latest in-flight AbortController in a ref so retries (and rapid
-  // re-mounts) abort the previous request before issuing a new one. Without
-  // this, two retry clicks would race and the later result could be
-  // overwritten by the earlier one resolving last.
   const inflightControllerRef = useRef<AbortController | null>(null);
   const racksInflightRef = useRef<AbortController | null>(null);
 
@@ -67,10 +83,6 @@ const BuildingPage = () => {
         onError: (message) => setResponse({ id: targetId, outcome: { status: "error", message } }),
       });
 
-      // Parallel rack-count fetch so the cascade-delete dialog has the
-      // live count without waiting for the user to open the manage
-      // modal. Errors here are silent — the dialog falls back to the
-      // generic copy when the count is unknown, which is acceptable.
       const racksController = new AbortController();
       racksInflightRef.current = racksController;
       void listBuildingRacks({
@@ -78,8 +90,8 @@ const BuildingPage = () => {
         signal: racksController.signal,
         onSuccess: (racks) => setRackCountResponse({ id: targetId, count: BigInt(racks.length) }),
         onError: () => {
-          // Leave rackCountResponse stale on error; cascade dialog
-          // falls back to "Are you sure?" rather than block the page.
+          // Leave rackCountResponse stale on error; cascade dialog falls
+          // back to "Are you sure?" rather than blocking the page.
         },
       });
     },
@@ -91,10 +103,6 @@ const BuildingPage = () => {
     fetchBuilding(buildingId);
   }, [fetchBuilding, buildingId]);
 
-  // Mount BuildingModals at the page level so the manage flow can stack
-  // BuildingSettingsModal on top without re-rendering the page shell. The
-  // delete-from-manage rule (per plan PR 3) redirects to /sites — the
-  // manage modal's anchor is the now-deleted building so we can't stay.
   const buildingModals = useBuildingModals({
     refetchBuildings: () => {
       if (buildingId !== null) fetchBuilding(buildingId);
@@ -102,10 +110,6 @@ const BuildingPage = () => {
     onDeleteFromManage: () => navigate("/sites"),
   });
 
-  // Unmount cleanup aborts whatever's currently in flight — including
-  // retry-spawned controllers that didn't come from the effect above.
-  // Without this, clicking Retry then navigating away leaks a request
-  // whose onSuccess/onError still fires setResponse on the unmounted page.
   useEffect(() => {
     return () => {
       inflightControllerRef.current?.abort();
@@ -114,6 +118,53 @@ const BuildingPage = () => {
       racksInflightRef.current = null;
     };
   }, []);
+
+  // Server-rolled metrics for the header strip. The response now carries
+  // device_identifiers, so telemetry + component-error consumers can scope
+  // themselves directly without a second ListMinerStateSnapshots paginate.
+  const { stats } = useBuildingStats({
+    buildingId: buildingId ?? 0n,
+    enabled: buildingId !== null,
+    pollIntervalMs: POLL_INTERVAL_MS,
+  });
+  // `undefined` while stats are loading (skeletons); `string[]` once the
+  // response lands. Empty array = building genuinely has no members
+  // (telemetry hooks then short-circuit to "no data").
+  const memberDeviceIds: string[] | null = stats ? stats.deviceIdentifiers : null;
+
+  const duration = useDuration();
+  const setDuration = useSetDuration();
+  const { refs } = useStickyState();
+
+  // Component errors scoped to the building's devices. While stats are
+  // loading (memberDeviceIds === null) we pass an explicit empty array so
+  // useComponentErrors short-circuits — passing `undefined` would make
+  // the hook fall back to fleet-wide and momentarily fetch every miner's
+  // error data on every BuildingPage visit until stats land.
+  const componentErrorsOptions = useMemo(
+    () => ({ deviceIdentifiers: memberDeviceIds ?? [], pollIntervalMs: POLL_INTERVAL_MS }),
+    [memberDeviceIds],
+  );
+  const { controlBoardErrors, fanErrors, hashboardErrors, psuErrors } = useComponentErrors(componentErrorsOptions);
+
+  const telemetryEnabled = memberDeviceIds !== null && memberDeviceIds.length > 0;
+  const telemetryOptions = useMemo(
+    () => ({
+      deviceIds: memberDeviceIds ?? [],
+      measurementTypes: ALL_MEASUREMENT_TYPES,
+      aggregations: ALL_AGGREGATION_TYPES,
+      duration,
+      enabled: telemetryEnabled,
+      pollIntervalMs: POLL_INTERVAL_MS,
+    }),
+    [memberDeviceIds, duration, telemetryEnabled],
+  );
+  const { data: telemetryData } = useTelemetryMetrics(telemetryOptions);
+  // For empty buildings, surface a defined-but-empty metrics array so the
+  // performance section renders "No data" instead of an indefinite
+  // skeleton.
+  const isEmptyBuilding = memberDeviceIds !== null && memberDeviceIds.length === 0;
+  const metrics = isEmptyBuilding ? [] : telemetryData?.metrics;
 
   const effectiveOutcome: FetchOutcome | "loading" | "invalid" =
     buildingId === null ? "invalid" : response && response.id === buildingId ? response.outcome : "loading";
@@ -159,32 +210,113 @@ const BuildingPage = () => {
   }
 
   const effectiveBuilding = effectiveOutcome.building;
-
   const label = effectiveBuilding.name || "(unnamed building)";
   const idForHeader = effectiveBuilding.id.toString();
+  const buildingFilterParam = `building=${effectiveBuilding.id.toString()}`;
 
   return (
-    <div className="flex flex-col gap-6 p-10 phone:p-6" data-testid="building-page">
-      <BuildingPageHeader
-        label={label}
-        buildingId={idForHeader}
-        // Synthesize a BuildingWithCounts row for the modal hook,
-        // populating rack_count from the parallel listBuildingRacks
-        // fetch when it's resolved against the same building id. Falls
-        // back to 0n when the count fetch is still in flight or
-        // errored — the cascade dialog then shows the generic
-        // "Are you sure?" copy, never an under-count.
-        onEditBuilding={() => {
-          const liveCount =
-            rackCountResponse && rackCountResponse.id === effectiveBuilding.id ? rackCountResponse.count : 0n;
-          buildingModals.openManage(
-            create(BuildingWithCountsSchema, { building: effectiveBuilding, rackCount: liveCount }),
-          );
-        }}
-      />
-      <PlaceholderBlock label="Metrics row (Hashrate, Power, Efficiency, Miners online) — #264" className="h-20" />
-      <PlaceholderBlock label="Diagnostics (rack grid + health) — #264" className="h-64" />
-      <PlaceholderBlock label="Performance — #264" className="h-64" />
+    <div className="h-full" data-testid="building-page">
+      <div className="flex flex-col">
+        <div className="p-6 pb-0 laptop:p-10 laptop:pb-0">
+          <BuildingPageHeader
+            label={label}
+            buildingId={idForHeader}
+            onEditBuilding={() => {
+              const liveCount =
+                rackCountResponse && rackCountResponse.id === effectiveBuilding.id ? rackCountResponse.count : 0n;
+              buildingModals.openManage(
+                create(BuildingWithCountsSchema, { building: effectiveBuilding, rackCount: liveCount }),
+              );
+            }}
+          />
+        </div>
+
+        {/* Metrics row */}
+        <section className="px-6 pt-6 laptop:px-10 laptop:pt-10">
+          <BuildingMetricsRow powerCapacityKw={effectiveBuilding.powerKw} stats={stats} />
+        </section>
+
+        {/* Diagnostics: rack-health module (FPO) + component health */}
+        <section className="p-6 laptop:p-10">
+          <div className="flex flex-col gap-1">
+            <PlaceholderBlock label="Rack health module — #264" className="h-64" />
+            <FleetErrors
+              controlBoardErrors={controlBoardErrors}
+              fanErrors={fanErrors}
+              hashboardErrors={hashboardErrors}
+              psuErrors={psuErrors}
+              extraFilterParams={buildingFilterParam}
+            />
+          </div>
+        </section>
+
+        {/* Performance section — identical wiring to RackOverviewPage */}
+        <section className="pb-6">
+          <div ref={refs.vertical.start} />
+          <div className="sticky top-0 z-2 bg-surface-5 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10 dark:bg-surface-base">
+            <div className="flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between">
+              <div className="text-heading-200 text-text-primary">Performance</div>
+              <div className="flex items-center gap-6 text-200 text-core-primary-50">
+                <div className="flex items-center gap-2">
+                  <svg width="24" height="4">
+                    <line
+                      x1="0"
+                      y1="2"
+                      x2="24"
+                      y2="2"
+                      stroke="var(--color-core-primary-fill)"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                  <span>Building</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <svg width="24" height="4">
+                    <line
+                      x1="0"
+                      y1="2"
+                      x2="24"
+                      y2="2"
+                      stroke="var(--color-core-primary-50)"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeDasharray="1 6"
+                      strokeOpacity="0.5"
+                    />
+                  </svg>
+                  <span>Max</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <svg width="24" height="4">
+                    <line
+                      x1="0"
+                      y1="2"
+                      x2="24"
+                      y2="2"
+                      stroke="var(--color-intent-critical-fill)"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeDasharray="1 6"
+                      strokeOpacity="0.5"
+                    />
+                  </svg>
+                  <span>Min</span>
+                </div>
+              </div>
+              <div className="flex items-center">
+                <DurationSelector duration={duration} durations={fleetDurations} onSelect={setDuration} />
+              </div>
+            </div>
+          </div>
+
+          <div className="px-6 laptop:px-10">
+            <DeviceSetPerformanceSection duration={duration} metrics={metrics} />
+          </div>
+          {/* eslint-disable-next-line react-hooks/refs -- ref object from useStickyState is passed to <div ref>; React writes .current during commit, not read during render */}
+          <div ref={refs.vertical.end} />
+        </section>
+      </div>
       <BuildingModals modals={buildingModals} />
     </div>
   );

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -225,21 +225,24 @@ const BuildingPage = () => {
   const buildingFilterParam = `building=${effectiveBuilding.id.toString()}`;
 
   // Edit/Delete require the rack count to render an accurate cascade
-  // warning ("deleting this building will unassign N racks"). When
-  // ListBuildingRacks is still inflight (large buildings paginate) or
-  // failed, default to a disabled Edit so the operator can't open the
-  // manage/delete flow with rackCount: 0n and miss the warning.
-  const rackCountReady = rackCountResponse !== undefined && rackCountResponse.id === effectiveBuilding.id;
-  const handleEditBuilding = rackCountReady
-    ? () => {
-        buildingModals.openManage(
-          create(BuildingWithCountsSchema, {
-            building: effectiveBuilding,
-            rackCount: rackCountResponse.count,
-          }),
-        );
-      }
-    : undefined;
+  // warning ("deleting this building will unassign N racks"). Prefer the
+  // precise count from the parallel ListBuildingRacks call when it
+  // landed, but never gate the Edit button on it — a transient
+  // listBuildingRacks failure would otherwise leave Edit permanently
+  // disabled with no recovery path. Falls back to the polled
+  // stats.rackCount (live, refreshes with the page) and finally to 0
+  // (cascade dialog renders a generic warning).
+  const racksFromList =
+    rackCountResponse !== undefined && rackCountResponse.id === effectiveBuilding.id ? rackCountResponse.count : null;
+  const fallbackRackCount = racksFromList ?? (stats ? BigInt(stats.rackCount) : 0n);
+  const handleEditBuilding = () => {
+    buildingModals.openManage(
+      create(BuildingWithCountsSchema, {
+        building: effectiveBuilding,
+        rackCount: fallbackRackCount,
+      }),
+    );
+  };
 
   return (
     <div className="h-full" data-testid="building-page">

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -122,7 +122,12 @@ const BuildingPage = () => {
   // Server-rolled metrics for the header strip. The response now carries
   // device_identifiers, so telemetry + component-error consumers can scope
   // themselves directly without a second ListMinerStateSnapshots paginate.
-  const { stats } = useBuildingStats({
+  const {
+    stats,
+    error: statsError,
+    hasLoaded: statsHasLoaded,
+    refetch: refetchStats,
+  } = useBuildingStats({
     buildingId: buildingId ?? 0n,
     enabled: buildingId !== null,
     pollIntervalMs: POLL_INTERVAL_MS,
@@ -137,12 +142,17 @@ const BuildingPage = () => {
   const { refs } = useStickyState();
 
   // Component errors scoped to the building's devices. While stats are
-  // loading (memberDeviceIds === null) we pass an explicit empty array so
-  // useComponentErrors short-circuits — passing `undefined` would make
-  // the hook fall back to fleet-wide and momentarily fetch every miner's
-  // error data on every BuildingPage visit until stats land.
+  // still loading (memberDeviceIds === null) we pass enabled=false so the
+  // hook holds an undefined-count state — otherwise it would race to an
+  // empty-scope fetch and render "No issues" before the real scope ever
+  // arrives, hiding genuine component failures during the brief
+  // GetBuildingStats outage or initial load.
   const componentErrorsOptions = useMemo(
-    () => ({ deviceIdentifiers: memberDeviceIds ?? [], pollIntervalMs: POLL_INTERVAL_MS }),
+    () => ({
+      deviceIdentifiers: memberDeviceIds ?? [],
+      enabled: memberDeviceIds !== null,
+      pollIntervalMs: POLL_INTERVAL_MS,
+    }),
     [memberDeviceIds],
   );
   const { controlBoardErrors, fanErrors, hashboardErrors, psuErrors } = useComponentErrors(componentErrorsOptions);
@@ -214,22 +224,51 @@ const BuildingPage = () => {
   const idForHeader = effectiveBuilding.id.toString();
   const buildingFilterParam = `building=${effectiveBuilding.id.toString()}`;
 
+  // Edit/Delete require the rack count to render an accurate cascade
+  // warning ("deleting this building will unassign N racks"). When
+  // ListBuildingRacks is still inflight (large buildings paginate) or
+  // failed, default to a disabled Edit so the operator can't open the
+  // manage/delete flow with rackCount: 0n and miss the warning.
+  const rackCountReady = rackCountResponse !== undefined && rackCountResponse.id === effectiveBuilding.id;
+  const handleEditBuilding = rackCountReady
+    ? () => {
+        buildingModals.openManage(
+          create(BuildingWithCountsSchema, {
+            building: effectiveBuilding,
+            rackCount: rackCountResponse.count,
+          }),
+        );
+      }
+    : undefined;
+
   return (
     <div className="h-full" data-testid="building-page">
       <div className="flex flex-col">
         <div className="p-6 pb-0 laptop:p-10 laptop:pb-0">
-          <BuildingPageHeader
-            label={label}
-            buildingId={idForHeader}
-            onEditBuilding={() => {
-              const liveCount =
-                rackCountResponse && rackCountResponse.id === effectiveBuilding.id ? rackCountResponse.count : 0n;
-              buildingModals.openManage(
-                create(BuildingWithCountsSchema, { building: effectiveBuilding, rackCount: liveCount }),
-              );
-            }}
-          />
+          <BuildingPageHeader label={label} buildingId={idForHeader} onEditBuilding={handleEditBuilding} />
         </div>
+
+        {/* Stats fetch failure on initial load — surface it inline so the
+            metrics row, diagnostics, and performance section don't sit
+            indefinitely in skeleton state with no recovery affordance. */}
+        {statsError && !statsHasLoaded ? (
+          <div className="px-6 pt-6 laptop:px-10 laptop:pt-10">
+            <div
+              className="flex items-center justify-between gap-3 rounded-xl border border-intent-critical-20 bg-intent-critical-10 px-4 py-3 text-200 text-intent-critical-text"
+              data-testid="building-page-stats-error"
+            >
+              <span>Couldn&apos;t load building metrics: {statsError}</span>
+              <button
+                type="button"
+                onClick={() => refetchStats()}
+                className="shrink-0 underline hover:opacity-80"
+                data-testid="building-page-stats-retry"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        ) : null}
 
         {/* Metrics row */}
         <section className="px-6 pt-6 laptop:px-10 laptop:pt-10">

--- a/client/src/protoFleet/features/dashboard/components/HashratePanel/utils.ts
+++ b/client/src/protoFleet/features/dashboard/components/HashratePanel/utils.ts
@@ -1,7 +1,7 @@
 import { AggregationType, type Metric } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { normalizeHashrateToTHs } from "@/protoFleet/features/dashboard/utils/metricNormalization";
 import type { ChartData } from "@/shared/components/LineChart/types";
-import { TH_TO_PH_DIVISOR, TH_TO_PH_THRESHOLD } from "@/shared/utils/utility";
+import { TH_TO_PH_DIVISOR, TH_TO_PH_THRESHOLD } from "@/shared/utils/telemetryFormat";
 
 /**
  * Transform hashrate metrics from the API to chart data format

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerTemperature.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerTemperature.tsx
@@ -5,7 +5,7 @@ import { useTemperatureUnit } from "@/protoFleet/store";
 import SkeletonBar from "@/shared/components/SkeletonBar";
 import { getLatestMeasurementWithData } from "@/shared/utils/measurementUtils";
 import { getDisplayValue } from "@/shared/utils/stringUtils";
-import { convertCtoF } from "@/shared/utils/utility";
+import { convertCtoF } from "@/shared/utils/telemetryFormat";
 
 type MinerTemperatureProps = {
   miner: MinerStateSnapshot;

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection.tsx
@@ -14,7 +14,7 @@ import { FleetDuration } from "@/shared/components/DurationSelector";
 import type { ChartData } from "@/shared/components/LineChart/types";
 import SkeletonBar from "@/shared/components/SkeletonBar";
 import { getDisplayValue } from "@/shared/utils/stringUtils";
-import { convertCtoF, TH_TO_PH_DIVISOR, TH_TO_PH_THRESHOLD } from "@/shared/utils/utility";
+import { convertCtoF, TH_TO_PH_DIVISOR, TH_TO_PH_THRESHOLD } from "@/shared/utils/telemetryFormat";
 
 interface DeviceSetPerformanceSectionProps {
   duration: FleetDuration;

--- a/client/src/protoFleet/features/rackManagement/utils/rackCardMapper.ts
+++ b/client/src/protoFleet/features/rackManagement/utils/rackCardMapper.ts
@@ -6,8 +6,7 @@ import {
 } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import type { SlotStatus } from "@/protoFleet/features/rackManagement/components/RackCard/types";
 import type { TemperatureUnit } from "@/shared/features/preferences";
-import { getDisplayValue } from "@/shared/utils/stringUtils";
-import { formatTempRange } from "@/shared/utils/utility";
+import { formatEfficiency, formatHashrate, formatPowerKwOrDash, formatTempRange } from "@/shared/utils/telemetryFormat";
 
 export const SLOT_STATUS_MAP: Record<SlotDeviceStatus, SlotStatus> = {
   [SlotDeviceStatus.UNSPECIFIED]: "empty",
@@ -52,10 +51,16 @@ export function mapSlotStatuses(slotStatuses: RackSlotStatus[], rows: number, co
 }
 
 export function formatRackCardStats(stats: DeviceSetStats, temperatureUnit: TemperatureUnit) {
+  // Hashrate / efficiency / power format through the shared telemetry
+  // helpers so rack cards inherit the same auto-scaling unit ladder
+  // (GH/TH/PH/EH) and decimal precision the /sites + /buildings cards
+  // use. Each metric is gated by its per-field reporting count: 0 ->
+  // `undefined`, which the card renders as a skeleton.
   return {
-    hashrate: stats.hashrateReportingCount > 0 ? `${getDisplayValue(stats.totalHashrateThs)} TH/s` : undefined,
-    efficiency: stats.efficiencyReportingCount > 0 ? `${getDisplayValue(stats.avgEfficiencyJth)} J/TH` : undefined,
-    power: stats.powerReportingCount > 0 ? `${getDisplayValue(stats.totalPowerKw)} kW` : undefined,
+    hashrate: stats.hashrateReportingCount > 0 ? (formatHashrate(stats.totalHashrateThs) ?? undefined) : undefined,
+    efficiency:
+      stats.efficiencyReportingCount > 0 ? (formatEfficiency(stats.avgEfficiencyJth) ?? undefined) : undefined,
+    power: stats.powerReportingCount > 0 ? formatPowerKwOrDash(stats.totalPowerKw) : undefined,
     temperature:
       stats.temperatureReportingCount > 0
         ? formatTempRange(stats.minTemperatureC, stats.maxTemperatureC, temperatureUnit)

--- a/client/src/protoFleet/features/sites/components/SiteMetricsRow.test.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteMetricsRow.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import SiteMetricsRow from "./SiteMetricsRow";
+
+describe("SiteMetricsRow", () => {
+  it("shows location, capacity and buildings count without waiting on metrics", () => {
+    render(
+      <SiteMetricsRow
+        locationCity="Austin"
+        locationState="TX"
+        powerCapacityMw={20}
+        buildingCount={3}
+        metrics={undefined}
+      />,
+    );
+    expect(screen.getByTestId("site-metric-location")).toHaveTextContent("Austin, TX");
+    expect(screen.getByTestId("site-metric-buildings")).toHaveTextContent("3");
+    expect(screen.getByTestId("site-metric-hashrate").querySelector("[data-testid='skeleton-bar']")).not.toBeNull();
+  });
+
+  it("renders aggregated values once stats resolve", () => {
+    render(
+      <SiteMetricsRow
+        locationCity="Austin"
+        locationState="TX"
+        powerCapacityMw={20}
+        buildingCount={2}
+        metrics={{
+          totalHashrateThs: 2_500_000,
+          totalPowerKw: 12_345,
+          avgEfficiencyJth: 28.5,
+          reportingCount: 1200,
+          hashrateReportingCount: 1200,
+          efficiencyReportingCount: 1200,
+          powerReportingCount: 1200,
+        }}
+      />,
+    );
+    expect(screen.getByTestId("site-metric-hashrate")).toHaveTextContent("2.50 EH/s");
+    expect(screen.getByTestId("site-metric-power")).toHaveTextContent("12.3 / 20.0 MW");
+    expect(screen.getByTestId("site-metric-efficiency")).toHaveTextContent("28.5 J/TH");
+  });
+
+  it("renders em dashes when no devices are reporting", () => {
+    render(
+      <SiteMetricsRow
+        locationCity=""
+        locationState=""
+        powerCapacityMw={0}
+        buildingCount={0}
+        metrics={{
+          totalHashrateThs: 0,
+          totalPowerKw: 0,
+          avgEfficiencyJth: 0,
+          reportingCount: 0,
+          hashrateReportingCount: 0,
+          efficiencyReportingCount: 0,
+          powerReportingCount: 0,
+        }}
+      />,
+    );
+    expect(screen.getByTestId("site-metric-location")).toHaveTextContent("—");
+    expect(screen.getByTestId("site-metric-hashrate")).toHaveTextContent("—");
+    expect(screen.getByTestId("site-metric-power")).toHaveTextContent("—");
+    expect(screen.getByTestId("site-metric-efficiency")).toHaveTextContent("—");
+  });
+});

--- a/client/src/protoFleet/features/sites/components/SiteMetricsRow.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteMetricsRow.tsx
@@ -1,10 +1,6 @@
-import {
-  formatEfficiency,
-  formatHashrate,
-  formatLocation,
-  formatPowerUsedCapacity,
-} from "@/protoFleet/features/sites/utils/formatSiteMetrics";
+import { formatLocation } from "@/protoFleet/features/sites/utils/formatSiteMetrics";
 import Metric from "@/shared/components/Metric";
+import { formatEfficiency, formatHashrate, formatPowerUsedCapacity } from "@/shared/utils/telemetryFormat";
 
 // Telemetry roll-up shape accepted by SiteMetricsRow. Mirrors the server's
 // GetSiteStatsResponse, accepts either it or any subset. Numeric fields are

--- a/client/src/protoFleet/features/sites/components/SiteMetricsRow.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteMetricsRow.tsx
@@ -1,0 +1,73 @@
+import {
+  formatEfficiency,
+  formatHashrate,
+  formatLocation,
+  formatPowerUsedCapacity,
+} from "@/protoFleet/features/sites/utils/formatSiteMetrics";
+import Metric from "@/shared/components/Metric";
+
+// Telemetry roll-up shape accepted by SiteMetricsRow. Mirrors the server's
+// GetSiteStatsResponse, accepts either it or any subset. Numeric fields are
+// 0 when the server didn't compute them (no reporting devices); we still
+// surface "—" via formatter helpers. Per-field reporting counts gate the
+// display so a missing field (device reporting but field == nil) renders
+// "—" instead of a misleading zero / partial average.
+interface SiteMetricsRowMetrics {
+  totalHashrateThs: number;
+  totalPowerKw: number;
+  avgEfficiencyJth: number;
+  reportingCount: number;
+  hashrateReportingCount: number;
+  efficiencyReportingCount: number;
+  powerReportingCount: number;
+}
+
+interface SiteMetricsRowProps {
+  locationCity: string;
+  locationState: string;
+  powerCapacityMw: number;
+  buildingCount: number;
+  // `undefined` while metrics are still loading; the children render skeletons.
+  metrics: SiteMetricsRowMetrics | undefined;
+  testId?: string;
+}
+
+// Five metrics in the per-site header: Location, Hashrate, Power (used /
+// capacity MW), Efficiency, Buildings. The shared Metric primitive
+// handles the skeleton vs em-dash vs value rendering so all five tiles
+// stay aligned during loading.
+const SiteMetricsRow = ({
+  locationCity,
+  locationState,
+  powerCapacityMw,
+  buildingCount,
+  metrics,
+  testId,
+}: SiteMetricsRowProps) => {
+  const location = formatLocation(locationCity, locationState);
+  // `null` from the formatters → renders as em-dash via Metric.
+  const hashrate = metrics
+    ? formatHashrate(metrics.hashrateReportingCount > 0 ? metrics.totalHashrateThs : null)
+    : undefined;
+  const power = metrics
+    ? formatPowerUsedCapacity(metrics.powerReportingCount > 0 ? metrics.totalPowerKw : null, powerCapacityMw)
+    : undefined;
+  const efficiency = metrics
+    ? formatEfficiency(metrics.efficiencyReportingCount > 0 ? metrics.avgEfficiencyJth : null)
+    : undefined;
+
+  return (
+    <div
+      className="grid grid-cols-2 gap-6 tablet:grid-cols-3 laptop:grid-cols-5"
+      data-testid={testId ?? "site-metrics-row"}
+    >
+      <Metric label="Location" value={location} testId="site-metric-location" />
+      <Metric label="Hashrate" value={hashrate} testId="site-metric-hashrate" />
+      <Metric label="Power" value={power} testId="site-metric-power" />
+      <Metric label="Efficiency" value={efficiency} testId="site-metric-efficiency" />
+      <Metric label="Buildings" value={String(buildingCount)} testId="site-metric-buildings" />
+    </div>
+  );
+};
+
+export default SiteMetricsRow;

--- a/client/src/protoFleet/features/sites/components/SiteOverviewSection.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteOverviewSection.tsx
@@ -33,8 +33,17 @@ const SiteOverviewSection = ({ site, buildings }: SiteOverviewSectionProps) => {
     refetch: refetchStats,
   } = useSiteStats({ siteId, enabled: hasSiteId, pollIntervalMs: POLL_INTERVAL_MS });
 
+  // Site name renders above the metric row so two sites with blank or
+  // duplicate locations are still distinguishable in the All-Sites view.
+  // Location remains a tile in the metric row for at-a-glance scanning;
+  // the name is the authoritative identifier.
+  const siteName = site.site?.name ?? "(unnamed site)";
+
   return (
     <section className="flex flex-col gap-6" data-testid={`site-overview-section-${siteIdText}`}>
+      <h2 className="text-emphasis-300 text-text-primary" data-testid={`site-overview-section-${siteIdText}-name`}>
+        {siteName}
+      </h2>
       {statsError ? (
         <div
           className="flex items-center justify-between gap-3 rounded-xl border border-intent-critical-20 bg-intent-critical-10 px-4 py-3 text-200 text-intent-critical-text"

--- a/client/src/protoFleet/features/sites/components/SiteOverviewSection.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteOverviewSection.tsx
@@ -1,8 +1,9 @@
+import SiteMetricsRow from "./SiteMetricsRow";
 import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { useSiteStats } from "@/protoFleet/api/useSiteStats";
+import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import BuildingCard from "@/protoFleet/features/buildings/components/BuildingCard";
-import Header from "@/shared/components/Header";
-import PlaceholderBlock from "@/shared/components/PlaceholderBlock";
 
 interface SiteOverviewSectionProps {
   site: SiteWithCounts;
@@ -12,27 +13,63 @@ interface SiteOverviewSectionProps {
   buildings: BuildingWithCounts[] | undefined;
 }
 
+// Per-site overview section — flat metric row at the top, then a responsive
+// grid of BuildingCards. Matches the prototype: no card wrapper around the
+// site itself; the metric row identifies the site via its Location tile.
+//
+// Telemetry roll-up comes from SiteService.GetSiteStats — server-side join
+// covers both racked devices and site-direct (un-racked) devices, so the
+// metric row matches the miner list exactly.
 const SiteOverviewSection = ({ site, buildings }: SiteOverviewSectionProps) => {
   const siteId = site.site?.id ?? 0n;
+  const siteIdText = siteId.toString();
+  const hasSiteId = siteId !== 0n;
+
+  // Poll so the metric row stays live as miners flip state on the
+  // dashboard without forcing the operator to refresh the page.
+  const {
+    stats,
+    error: statsError,
+    refetch: refetchStats,
+  } = useSiteStats({ siteId, enabled: hasSiteId, pollIntervalMs: POLL_INTERVAL_MS });
 
   return (
-    <section
-      className="flex flex-col gap-6 rounded-xl border border-border-5 p-6"
-      data-testid={`site-overview-section-${siteId.toString()}`}
-    >
-      <Header title={site.site?.name ?? "(unnamed)"} titleSize="text-heading-300" />
-      <PlaceholderBlock
-        label="Metrics row (Location, Hashrate, Power, Efficiency, Buildings) — #263"
-        className="h-20"
+    <section className="flex flex-col gap-6" data-testid={`site-overview-section-${siteIdText}`}>
+      {statsError ? (
+        <div
+          className="flex items-center justify-between gap-3 rounded-xl border border-intent-critical-20 bg-intent-critical-10 px-4 py-3 text-200 text-intent-critical-text"
+          data-testid={`site-overview-section-${siteIdText}-error`}
+        >
+          <span>Couldn&apos;t load site metrics: {statsError}</span>
+          <button
+            type="button"
+            onClick={() => refetchStats()}
+            className="shrink-0 underline hover:opacity-80"
+            data-testid={`site-overview-section-${siteIdText}-retry`}
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+      <SiteMetricsRow
+        locationCity={site.site?.locationCity ?? ""}
+        locationState={site.site?.locationState ?? ""}
+        powerCapacityMw={site.site?.powerCapacityMw ?? 0}
+        // Prefer the fresh `buildingCount` from GetSiteStats once it
+        // lands so the tile reflects buildings added/removed while the
+        // page stays open. Fall back to the initial ListSites count
+        // during the first paint.
+        buildingCount={stats?.buildingCount ?? Number(site.buildingCount)}
+        metrics={stats}
       />
       {buildings === undefined ? (
-        <PlaceholderBlock label="Loading buildings…" className="h-32" />
+        <div className="text-200 text-text-primary-50">Loading buildings…</div>
       ) : buildings.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70">
+        <div className="rounded-2xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70">
           No buildings in this site yet.
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-4 laptop:grid-cols-3 phone:grid-cols-2">
+        <div className="grid auto-rows-fr grid-cols-1 gap-4 tablet:grid-cols-2 laptop:grid-cols-3">
           {buildings.map((b) => (
             <BuildingCard key={(b.building?.id ?? 0n).toString()} building={b} />
           ))}

--- a/client/src/protoFleet/features/sites/components/SitesPageHeader.tsx
+++ b/client/src/protoFleet/features/sites/components/SitesPageHeader.tsx
@@ -3,7 +3,10 @@ import Header from "@/shared/components/Header";
 
 interface SitesPageHeaderProps {
   headline: string;
-  subheadline: string;
+  // Optional — /sites suppresses the subheadline so the metric rows below
+  // act as the page's primary information density. /settings/sites still
+  // passes a subheadline since the admin surface benefits from explanatory copy.
+  subheadline?: string;
   // When omitted, the "Add a site" button is hidden entirely. Used by /sites
   // to suppress the CTA outside the All Sites selection per master plan §J8.
   onAddSite?: () => void;

--- a/client/src/protoFleet/features/sites/pages/SitesPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SitesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import SiteModals from "../components/SiteModals";
 import SiteOverviewSection from "../components/SiteOverviewSection";
@@ -10,9 +10,11 @@ import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { buildKnownSiteIds, useSites } from "@/protoFleet/api/sites";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
+import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Header from "@/shared/components/Header";
 import PlaceholderBlock from "@/shared/components/PlaceholderBlock";
+import { usePoll } from "@/shared/hooks/usePoll";
 
 // `/sites` operational overview. Phase 1a renders the scaffolding — header,
 // per-site sections with placeholder metrics + FPO BuildingCards, and the
@@ -30,9 +32,7 @@ const SitesPage = () => {
   // PermissionDenied for non-admins) don't collapse into "no sites yet"
   // and mislead the operator into thinking the org has no sites.
   const fetchSites = useCallback(() => {
-    const controller = new AbortController();
     void listSites({
-      signal: controller.signal,
       onSuccess: (rows) => {
         setSites(rows);
         setSitesError(null);
@@ -42,10 +42,7 @@ const SitesPage = () => {
         setSites([]);
       },
     });
-    return () => controller.abort();
   }, [listSites]);
-
-  useEffect(() => fetchSites(), [fetchSites]);
 
   // One ListBuildings call at the page level, then we bucket the rows by
   // siteId client-side so each SiteOverviewSection can render synchronously
@@ -53,9 +50,7 @@ const SitesPage = () => {
   // the earlier scaffold had. Track buildingsError separately so failures
   // don't collapse every site into "No buildings in this site yet."
   const fetchBuildings = useCallback(() => {
-    const controller = new AbortController();
     void listAllBuildings({
-      signal: controller.signal,
       onSuccess: (rows) => {
         setBuildings(rows);
         setBuildingsError(null);
@@ -65,10 +60,15 @@ const SitesPage = () => {
         setBuildings([]);
       },
     });
-    return () => controller.abort();
   }, [listAllBuildings]);
 
-  useEffect(() => fetchBuildings(), [fetchBuildings]);
+  // Poll both sites + buildings on the same cadence as the per-card stats
+  // (POLL_INTERVAL_MS) so building cards stay in sync when racks are added
+  // or removed without forcing a manual refresh. The shared usePoll
+  // scheduler dedups concurrent fetches and runs an initial fetch on mount,
+  // replacing the earlier one-shot useEffect.
+  usePoll({ fetchData: fetchSites, poll: true, pollIntervalMs: POLL_INTERVAL_MS });
+  usePoll({ fetchData: fetchBuildings, poll: true, pollIntervalMs: POLL_INTERVAL_MS });
 
   const knownSiteIds = useMemo(() => buildKnownSiteIds(sites), [sites]);
 
@@ -104,7 +104,7 @@ const SitesPage = () => {
   if (sites === undefined) {
     return (
       <div className="flex flex-col gap-6 p-10 phone:p-6">
-        <SitesPageHeader headline="Sites" subheadline="Manage your sites, buildings, and rack infrastructure." />
+        <SitesPageHeader headline="Sites" />
         <div className="text-300 text-text-primary-70">Loading…</div>
       </div>
     );
@@ -113,7 +113,7 @@ const SitesPage = () => {
   if (sitesError) {
     return (
       <div className="flex flex-col gap-6 p-10 phone:p-6" data-testid="sites-page-error">
-        <SitesPageHeader headline="Sites" subheadline="Manage your sites, buildings, and rack infrastructure." />
+        <SitesPageHeader headline="Sites" />
         <div
           className="flex flex-col items-start gap-3 rounded-xl border border-border-5 p-6"
           data-testid="sites-page-error-card"
@@ -140,11 +140,7 @@ const SitesPage = () => {
 
   return (
     <div className="flex flex-col gap-6 p-10 phone:p-6" data-testid="sites-page">
-      <SitesPageHeader
-        headline="Sites"
-        subheadline="Manage your sites, buildings, and rack infrastructure."
-        onAddSite={showAddSite ? modals.openCreate : undefined}
-      />
+      <SitesPageHeader headline="Sites" onAddSite={showAddSite ? modals.openCreate : undefined} />
       {sites.length === 0 ? (
         <SitesEmptyState onAddSite={modals.openCreate} />
       ) : activeSite.kind === "unassigned" ? (
@@ -157,7 +153,7 @@ const SitesPage = () => {
           No sites match the current selection.
         </div>
       ) : (
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-12">
           {buildingsError ? (
             <div
               className="flex items-center justify-between rounded-xl border border-border-5 p-4"

--- a/client/src/protoFleet/features/sites/pages/SitesPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SitesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import SiteModals from "../components/SiteModals";
 import SiteOverviewSection from "../components/SiteOverviewSection";
@@ -28,39 +28,66 @@ const SitesPage = () => {
   const [buildings, setBuildings] = useState<BuildingWithCounts[] | undefined>(undefined);
   const [buildingsError, setBuildingsError] = useState<string | null>(null);
 
+  // sitesLoaded / buildingsLoaded distinguish initial-load failures from
+  // poll failures. On init we want the empty-state path (sites=[]) so the
+  // operator sees "no sites yet" / retry CTA. Once we've successfully
+  // loaded at least once, poll-error paths must preserve the last-good
+  // list so a transient hiccup doesn't blank the screen — they show an
+  // inline error toast instead.
+  const sitesLoadedRef = useRef(false);
+  const buildingsLoadedRef = useRef(false);
+
   // Track sites + sitesError separately so transient failures (network,
   // PermissionDenied for non-admins) don't collapse into "no sites yet"
   // and mislead the operator into thinking the org has no sites.
-  const fetchSites = useCallback(() => {
-    void listSites({
-      onSuccess: (rows) => {
-        setSites(rows);
-        setSitesError(null);
-      },
-      onError: (msg) => {
-        setSitesError(msg);
-        setSites([]);
-      },
-    });
-  }, [listSites]);
+  //
+  // Returns the inflight promise so usePoll schedules the next tick from
+  // response completion (not request start) — otherwise slow responses
+  // can overlap and a late older response can clobber newer state.
+  const fetchSites = useCallback(
+    () =>
+      listSites({
+        onSuccess: (rows) => {
+          setSites(rows);
+          setSitesError(null);
+          sitesLoadedRef.current = true;
+        },
+        onError: (msg) => {
+          setSitesError(msg);
+          // Only clear the list on the *initial* failure so the empty-state
+          // / retry surface renders. Once we've shown real data, keep it
+          // visible across transient poll failures.
+          if (!sitesLoadedRef.current) {
+            setSites([]);
+          }
+        },
+      }),
+    [listSites],
+  );
 
   // One ListBuildings call at the page level, then we bucket the rows by
   // siteId client-side so each SiteOverviewSection can render synchronously
   // from props. Avoids the N+1 per-section ListBuildings concurrency that
   // the earlier scaffold had. Track buildingsError separately so failures
   // don't collapse every site into "No buildings in this site yet."
-  const fetchBuildings = useCallback(() => {
-    void listAllBuildings({
-      onSuccess: (rows) => {
-        setBuildings(rows);
-        setBuildingsError(null);
-      },
-      onError: (msg) => {
-        setBuildingsError(msg);
-        setBuildings([]);
-      },
-    });
-  }, [listAllBuildings]);
+  // Promise returned for the same poll-lifecycle reason as fetchSites above.
+  const fetchBuildings = useCallback(
+    () =>
+      listAllBuildings({
+        onSuccess: (rows) => {
+          setBuildings(rows);
+          setBuildingsError(null);
+          buildingsLoadedRef.current = true;
+        },
+        onError: (msg) => {
+          setBuildingsError(msg);
+          if (!buildingsLoadedRef.current) {
+            setBuildings([]);
+          }
+        },
+      }),
+    [listAllBuildings],
+  );
 
   // Poll both sites + buildings on the same cadence as the per-card stats
   // (POLL_INTERVAL_MS) so building cards stay in sync when racks are added
@@ -110,7 +137,11 @@ const SitesPage = () => {
     );
   }
 
-  if (sitesError) {
+  // Full-page error path: only when we have *no* last-good data to show.
+  // Once we've rendered real sites at least once, a transient poll error
+  // surfaces as the inline banner inside the main layout below — blanking
+  // the screen on every hiccup makes the polled view jittery.
+  if (sitesError && !sitesLoadedRef.current) {
     return (
       <div className="flex flex-col gap-6 p-10 phone:p-6" data-testid="sites-page-error">
         <SitesPageHeader headline="Sites" />
@@ -141,6 +172,24 @@ const SitesPage = () => {
   return (
     <div className="flex flex-col gap-6 p-10 phone:p-6" data-testid="sites-page">
       <SitesPageHeader headline="Sites" onAddSite={showAddSite ? modals.openCreate : undefined} />
+      {sitesError ? (
+        // Post-init sites failure: keep the last-good list rendered below
+        // and surface the failure as an inline retry banner so the
+        // operator sees both the data and the issue at once.
+        <div
+          className="flex items-center justify-between rounded-xl border border-border-5 p-4"
+          data-testid="sites-page-sites-error"
+        >
+          <span className="text-300 text-text-primary-70">Couldn&apos;t refresh sites: {sitesError}</span>
+          <Button
+            variant={variants.secondary}
+            size={sizes.compact}
+            text="Retry"
+            onClick={fetchSites}
+            testId="sites-page-sites-retry"
+          />
+        </div>
+      ) : null}
       {sites.length === 0 ? (
         <SitesEmptyState onAddSite={modals.openCreate} />
       ) : activeSite.kind === "unassigned" ? (

--- a/client/src/protoFleet/features/sites/utils/formatSiteMetrics.test.ts
+++ b/client/src/protoFleet/features/sites/utils/formatSiteMetrics.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { formatEfficiency, formatHashrate, formatLocation, formatPowerUsedCapacity } from "./formatSiteMetrics";
+
+describe("formatLocation", () => {
+  it("joins city and state with a comma", () => {
+    expect(formatLocation("Austin", "TX")).toBe("Austin, TX");
+  });
+
+  it("falls back to whichever field is set", () => {
+    expect(formatLocation("Austin", "")).toBe("Austin");
+    expect(formatLocation("", "TX")).toBe("TX");
+  });
+
+  it("returns null when both are empty or whitespace-only", () => {
+    expect(formatLocation("", "")).toBeNull();
+    expect(formatLocation("  ", " ")).toBeNull();
+  });
+});
+
+describe("formatHashrate", () => {
+  it("returns null for missing measurements", () => {
+    expect(formatHashrate(null)).toBeNull();
+  });
+
+  it("renders 0 in TH/s rather than scaling into smaller units", () => {
+    expect(formatHashrate(0)).toBe("0 TH/s");
+  });
+
+  it("scales sub-TH/s values into GH/s", () => {
+    // 0.4 TH/s → 400 GH/s (single test miner case)
+    expect(formatHashrate(0.4)).toBe("400.0 GH/s");
+  });
+
+  it("keeps mid-range values in TH/s", () => {
+    expect(formatHashrate(400)).toBe("400.0 TH/s");
+  });
+
+  it("scales thousands of TH/s into PH/s", () => {
+    // 5500 TH/s → 5.50 PH/s (two decimals below 10)
+    expect(formatHashrate(5_500)).toBe("5.50 PH/s");
+  });
+
+  it("scales millions of TH/s into EH/s with two decimals under 10", () => {
+    expect(formatHashrate(2_500_000)).toBe("2.50 EH/s");
+  });
+
+  it("drops to one decimal above 10 EH/s and separates thousands", () => {
+    expect(formatHashrate(42_000_000)).toBe("42.0 EH/s");
+    expect(formatHashrate(1_234_000_000)).toBe("1,234.0 EH/s");
+  });
+});
+
+describe("formatPowerUsedCapacity", () => {
+  it("formats used MW and capacity MW", () => {
+    // kW → MW: 12_345 kW / 1000 = 12.3 MW
+    expect(formatPowerUsedCapacity(12_345, 20)).toBe("12.3 / 20.0 MW");
+  });
+
+  it("shows an em dash for the missing side when capacity is unset", () => {
+    expect(formatPowerUsedCapacity(5_000, 0)).toBe("5.0 / — MW");
+  });
+
+  it("shows an em dash for the missing side when usage is unknown", () => {
+    expect(formatPowerUsedCapacity(null, 20)).toBe("— / 20.0 MW");
+  });
+
+  it("returns null when both sides are missing", () => {
+    expect(formatPowerUsedCapacity(null, 0)).toBeNull();
+  });
+});
+
+describe("formatEfficiency", () => {
+  it("returns null when efficiency is unknown", () => {
+    expect(formatEfficiency(null)).toBeNull();
+  });
+
+  it("renders J/TH with one decimal", () => {
+    expect(formatEfficiency(28.456)).toBe("28.5 J/TH");
+  });
+});

--- a/client/src/protoFleet/features/sites/utils/formatSiteMetrics.test.ts
+++ b/client/src/protoFleet/features/sites/utils/formatSiteMetrics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatEfficiency, formatHashrate, formatLocation, formatPowerUsedCapacity } from "./formatSiteMetrics";
+import { formatLocation } from "./formatSiteMetrics";
 
 describe("formatLocation", () => {
   it("joins city and state with a comma", () => {
@@ -15,67 +15,5 @@ describe("formatLocation", () => {
   it("returns null when both are empty or whitespace-only", () => {
     expect(formatLocation("", "")).toBeNull();
     expect(formatLocation("  ", " ")).toBeNull();
-  });
-});
-
-describe("formatHashrate", () => {
-  it("returns null for missing measurements", () => {
-    expect(formatHashrate(null)).toBeNull();
-  });
-
-  it("renders 0 in TH/s rather than scaling into smaller units", () => {
-    expect(formatHashrate(0)).toBe("0 TH/s");
-  });
-
-  it("scales sub-TH/s values into GH/s", () => {
-    // 0.4 TH/s → 400 GH/s (single test miner case)
-    expect(formatHashrate(0.4)).toBe("400.0 GH/s");
-  });
-
-  it("keeps mid-range values in TH/s", () => {
-    expect(formatHashrate(400)).toBe("400.0 TH/s");
-  });
-
-  it("scales thousands of TH/s into PH/s", () => {
-    // 5500 TH/s → 5.50 PH/s (two decimals below 10)
-    expect(formatHashrate(5_500)).toBe("5.50 PH/s");
-  });
-
-  it("scales millions of TH/s into EH/s with two decimals under 10", () => {
-    expect(formatHashrate(2_500_000)).toBe("2.50 EH/s");
-  });
-
-  it("drops to one decimal above 10 EH/s and separates thousands", () => {
-    expect(formatHashrate(42_000_000)).toBe("42.0 EH/s");
-    expect(formatHashrate(1_234_000_000)).toBe("1,234.0 EH/s");
-  });
-});
-
-describe("formatPowerUsedCapacity", () => {
-  it("formats used MW and capacity MW", () => {
-    // kW → MW: 12_345 kW / 1000 = 12.3 MW
-    expect(formatPowerUsedCapacity(12_345, 20)).toBe("12.3 / 20.0 MW");
-  });
-
-  it("shows an em dash for the missing side when capacity is unset", () => {
-    expect(formatPowerUsedCapacity(5_000, 0)).toBe("5.0 / — MW");
-  });
-
-  it("shows an em dash for the missing side when usage is unknown", () => {
-    expect(formatPowerUsedCapacity(null, 20)).toBe("— / 20.0 MW");
-  });
-
-  it("returns null when both sides are missing", () => {
-    expect(formatPowerUsedCapacity(null, 0)).toBeNull();
-  });
-});
-
-describe("formatEfficiency", () => {
-  it("returns null when efficiency is unknown", () => {
-    expect(formatEfficiency(null)).toBeNull();
-  });
-
-  it("renders J/TH with one decimal", () => {
-    expect(formatEfficiency(28.456)).toBe("28.5 J/TH");
   });
 });

--- a/client/src/protoFleet/features/sites/utils/formatSiteMetrics.ts
+++ b/client/src/protoFleet/features/sites/utils/formatSiteMetrics.ts
@@ -1,15 +1,8 @@
-// Aggregated site / building metrics ship out of the API in the same units
-// individual miner snapshots use (TH/s, kW, J/TH). These helpers format them
-// for the operational headers on /sites and /buildings/:id.
-//
-// Single source of truth: SiteMetricsRow, BuildingMetricsRow, and
-// BuildingCard's footer all consume the helpers below so the precision +
-// unit ladder stays consistent across surfaces.
-
-import { separateByCommas } from "@/shared/utils/stringUtils";
-import { formatHashrateWithUnit } from "@/shared/utils/utility";
-
-export const KW_PER_MW = 1_000;
+// Site-specific display helpers. The general telemetry formatters
+// (hashrate / efficiency / power) live in `@/shared/utils/telemetryFormat`
+// since they're shared by every rollup surface — sites, buildings,
+// future rack/device-set cards. Only the location string is genuinely
+// site-shaped, so it stays here.
 
 export const formatLocation = (city: string, state: string): string | null => {
   const c = city.trim();
@@ -20,48 +13,16 @@ export const formatLocation = (city: string, state: string): string | null => {
   return null;
 };
 
-// Picks GH/s, TH/s, PH/s, or EH/s based on the input so the displayed value
-// stays in [1, 1000) — small sites (a single test miner at 400 TH/s) don't
-// read as "0.00 EH/s", and EH-scale fleets don't read as "1,250,000 TH/s".
-export const formatHashrate = (hashrateTh: number | null): string | null => {
-  if (hashrateTh === null) return null;
-  if (hashrateTh === 0) return "0 TH/s";
-  const { value, unit } = formatHashrateWithUnit(hashrateTh);
-  // Two decimals when scaled value is < 10 so small magnitudes keep signal
-  // (e.g. 2.50 EH/s); one decimal above that to match the dashboard bar.
-  const decimals = value < 10 ? 2 : 1;
-  // Shared formatter returns uppercase units (PH/S); the metric row uses
-  // lowercase /s throughout.
-  return `${separateByCommas(value.toFixed(decimals))} ${unit.replace("/S", "/s")}`;
-};
-
-export const formatPowerUsedCapacity = (usedKw: number | null, capacityMw: number): string | null => {
-  const hasCapacity = capacityMw > 0;
-  if (usedKw === null && !hasCapacity) return null;
-  const usedMw = usedKw !== null ? usedKw / KW_PER_MW : null;
-  const usedText = usedMw !== null ? usedMw.toFixed(1) : "—";
-  const capacityText = hasCapacity ? capacityMw.toFixed(1) : "—";
-  return `${usedText} / ${capacityText} MW`;
-};
-
-export const formatEfficiency = (efficiencyJTh: number | null): string | null => {
-  if (efficiencyJTh === null) return null;
-  return `${separateByCommas(efficiencyJTh.toFixed(1))} J/TH`;
-};
-
-// Used by BuildingCard's compact footer: same auto-scaled hashrate as
-// `formatHashrate` but always returns a non-null string and falls back to
-// "—" when the input is null. Callers that already disambiguate null vs
-// value can continue using `formatHashrate` directly.
-export const formatHashrateOrDash = (hashrateTh: number | null): string => formatHashrate(hashrateTh) ?? "—";
-
-export const formatEfficiencyOrDash = (efficiencyJTh: number | null): string => formatEfficiency(efficiencyJTh) ?? "—";
-
-// Total power as MW, with em-dash fallback when unset. The
-// site/building rows use `formatPowerUsedCapacity` for "used / capacity"
-// strings; the BuildingCard footer renders only the used value.
-export const formatPowerMwOrDash = (powerKw: number | null): string => {
-  if (powerKw === null) return "—";
-  const mw = powerKw / KW_PER_MW;
-  return `${separateByCommas(mw.toFixed(1))} MW`;
-};
+// Convenience re-exports so existing callsites that pulled both
+// `formatLocation` and the telemetry helpers from this module don't
+// have to change their imports. Prefer importing directly from
+// `@/shared/utils/telemetryFormat` for new code.
+export {
+  formatEfficiency,
+  formatEfficiencyOrDash,
+  formatHashrate,
+  formatHashrateOrDash,
+  formatPowerMwOrDash,
+  formatPowerUsedCapacity,
+  KW_PER_MW,
+} from "@/shared/utils/telemetryFormat";

--- a/client/src/protoFleet/features/sites/utils/formatSiteMetrics.ts
+++ b/client/src/protoFleet/features/sites/utils/formatSiteMetrics.ts
@@ -1,0 +1,67 @@
+// Aggregated site / building metrics ship out of the API in the same units
+// individual miner snapshots use (TH/s, kW, J/TH). These helpers format them
+// for the operational headers on /sites and /buildings/:id.
+//
+// Single source of truth: SiteMetricsRow, BuildingMetricsRow, and
+// BuildingCard's footer all consume the helpers below so the precision +
+// unit ladder stays consistent across surfaces.
+
+import { separateByCommas } from "@/shared/utils/stringUtils";
+import { formatHashrateWithUnit } from "@/shared/utils/utility";
+
+export const KW_PER_MW = 1_000;
+
+export const formatLocation = (city: string, state: string): string | null => {
+  const c = city.trim();
+  const s = state.trim();
+  if (c && s) return `${c}, ${s}`;
+  if (c) return c;
+  if (s) return s;
+  return null;
+};
+
+// Picks GH/s, TH/s, PH/s, or EH/s based on the input so the displayed value
+// stays in [1, 1000) — small sites (a single test miner at 400 TH/s) don't
+// read as "0.00 EH/s", and EH-scale fleets don't read as "1,250,000 TH/s".
+export const formatHashrate = (hashrateTh: number | null): string | null => {
+  if (hashrateTh === null) return null;
+  if (hashrateTh === 0) return "0 TH/s";
+  const { value, unit } = formatHashrateWithUnit(hashrateTh);
+  // Two decimals when scaled value is < 10 so small magnitudes keep signal
+  // (e.g. 2.50 EH/s); one decimal above that to match the dashboard bar.
+  const decimals = value < 10 ? 2 : 1;
+  // Shared formatter returns uppercase units (PH/S); the metric row uses
+  // lowercase /s throughout.
+  return `${separateByCommas(value.toFixed(decimals))} ${unit.replace("/S", "/s")}`;
+};
+
+export const formatPowerUsedCapacity = (usedKw: number | null, capacityMw: number): string | null => {
+  const hasCapacity = capacityMw > 0;
+  if (usedKw === null && !hasCapacity) return null;
+  const usedMw = usedKw !== null ? usedKw / KW_PER_MW : null;
+  const usedText = usedMw !== null ? usedMw.toFixed(1) : "—";
+  const capacityText = hasCapacity ? capacityMw.toFixed(1) : "—";
+  return `${usedText} / ${capacityText} MW`;
+};
+
+export const formatEfficiency = (efficiencyJTh: number | null): string | null => {
+  if (efficiencyJTh === null) return null;
+  return `${separateByCommas(efficiencyJTh.toFixed(1))} J/TH`;
+};
+
+// Used by BuildingCard's compact footer: same auto-scaled hashrate as
+// `formatHashrate` but always returns a non-null string and falls back to
+// "—" when the input is null. Callers that already disambiguate null vs
+// value can continue using `formatHashrate` directly.
+export const formatHashrateOrDash = (hashrateTh: number | null): string => formatHashrate(hashrateTh) ?? "—";
+
+export const formatEfficiencyOrDash = (efficiencyJTh: number | null): string => formatEfficiency(efficiencyJTh) ?? "—";
+
+// Total power as MW, with em-dash fallback when unset. The
+// site/building rows use `formatPowerUsedCapacity` for "used / capacity"
+// strings; the BuildingCard footer renders only the used value.
+export const formatPowerMwOrDash = (powerKw: number | null): string => {
+  if (powerKw === null) return "—";
+  const mw = powerKw / KW_PER_MW;
+  return `${separateByCommas(mw.toFixed(1))} MW`;
+};

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
@@ -9,7 +9,7 @@ import Popover from "@/shared/components/Popover";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import SelectRowList from "@/shared/components/SelectRowList";
 import { positions, selectTypes } from "@/shared/constants";
-import { convertWtoKW } from "@/shared/utils/utility";
+import { convertWtoKW } from "@/shared/utils/telemetryFormat";
 
 export type PowerTargetPopoverProps = {
   onDismiss: () => void;

--- a/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/AsicPopover.tsx
+++ b/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/AsicPopover.tsx
@@ -9,7 +9,7 @@ import { minimalMargin } from "@/shared/components/Popover/constants.ts";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import { positions } from "@/shared/constants";
 import { getDisplayValue } from "@/shared/utils/stringUtils";
-import { formatHashrateWithUnit } from "@/shared/utils/utility";
+import { formatHashrateWithUnit } from "@/shared/utils/telemetryFormat";
 
 // import { dangerTemp } from "../../constants";
 import { getRowLabel } from "@/shared/utils/utility";

--- a/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/utility.ts
+++ b/client/src/protoOS/features/diagnostic/components/HashboardTemperature/Asic/AsicPopover/utility.ts
@@ -6,8 +6,8 @@ import { type MetricTimeSeries } from "@/protoOS/store";
 import { type TemperatureUnit } from "@/protoOS/store";
 import { ChartData } from "@/shared/components/LineChart/types";
 import { getDisplayValue } from "@/shared/utils/stringUtils";
-import { convertMegahashSecToTerahashSec } from "@/shared/utils/utility";
-import { convertCtoF } from "@/shared/utils/utility";
+import { convertMegahashSecToTerahashSec } from "@/shared/utils/telemetryFormat";
+import { convertCtoF } from "@/shared/utils/telemetryFormat";
 
 export const convertTemperatureValues = (data: TemperatureResponseTemperaturedata["data"]) => {
   return data?.map((temperature) => ({

--- a/client/src/protoOS/features/kpis/hooks/utility.ts
+++ b/client/src/protoOS/features/kpis/hooks/utility.ts
@@ -1,7 +1,7 @@
 import { Aggregates, TimeSeriesData } from "@/protoOS/api/generatedApi";
 import { Duration } from "@/shared/components/DurationSelector";
 import { getDateFromEpoch } from "@/shared/utils/datetime";
-import { convertMegahashSecToTerahashSec, convertWtoKW } from "@/shared/utils/utility";
+import { convertMegahashSecToTerahashSec, convertWtoKW } from "@/shared/utils/telemetryFormat";
 
 export const conversionFns = {
   hashrate: convertMegahashSecToTerahashSec,

--- a/client/src/protoOS/store/utils/telemetryUtils.ts
+++ b/client/src/protoOS/store/utils/telemetryUtils.ts
@@ -1,6 +1,11 @@
 import type { Measurement, MetricUnit } from "../types";
 import { getDisplayValue } from "@/shared/utils/stringUtils";
-import { convertCtoF, convertFtoC, convertGigahashSecToTerahashSec, convertWtoKW } from "@/shared/utils/utility";
+import {
+  convertCtoF,
+  convertFtoC,
+  convertGigahashSecToTerahashSec,
+  convertWtoKW,
+} from "@/shared/utils/telemetryFormat";
 
 /**
  * Convert units intelligently based on unit type detection

--- a/client/src/shared/components/HashRateValue/HashRateValue.tsx
+++ b/client/src/shared/components/HashRateValue/HashRateValue.tsx
@@ -1,6 +1,6 @@
 import SkeletonBar from "@/shared/components/SkeletonBar";
 import { separateByCommas } from "@/shared/utils/stringUtils";
-import { formatHashrateWithUnit } from "@/shared/utils/utility";
+import { formatHashrateWithUnit } from "@/shared/utils/telemetryFormat";
 
 interface HashRateValueProps {
   value: number | undefined | null;

--- a/client/src/shared/components/Metric/Metric.tsx
+++ b/client/src/shared/components/Metric/Metric.tsx
@@ -1,0 +1,25 @@
+import { type ReactNode } from "react";
+import clsx from "clsx";
+
+import SkeletonBar from "@/shared/components/SkeletonBar";
+
+interface MetricProps {
+  label: string;
+  // `undefined` shows a skeleton (loading), `null` renders the em dash, a
+  // string renders verbatim. ReactNode is allowed so callers can compose a
+  // value out of small spans for unit styling.
+  value: ReactNode | undefined | null;
+  testId?: string;
+  className?: string;
+}
+
+const Metric = ({ label, value, testId, className }: MetricProps) => (
+  <div className={clsx("flex flex-col gap-1", className)} data-testid={testId}>
+    <div className="text-300 text-text-primary-50">{label}</div>
+    <div className="text-heading-300 text-text-primary">
+      {value === undefined ? <SkeletonBar className="h-7 w-24" /> : value === null ? <span>—</span> : value}
+    </div>
+  </div>
+);
+
+export default Metric;

--- a/client/src/shared/components/Metric/index.ts
+++ b/client/src/shared/components/Metric/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Metric";

--- a/client/src/shared/components/TemperatureValue/TemperatureValue.tsx
+++ b/client/src/shared/components/TemperatureValue/TemperatureValue.tsx
@@ -1,6 +1,6 @@
 import useMinerStore from "@/protoOS/store/useMinerStore";
 import SkeletonBar from "@/shared/components/SkeletonBar";
-import { convertCtoF } from "@/shared/utils/utility";
+import { convertCtoF } from "@/shared/utils/telemetryFormat";
 
 interface TemperatureValueProps {
   value: number | undefined | null;

--- a/client/src/shared/hooks/useInViewport.ts
+++ b/client/src/shared/hooks/useInViewport.ts
@@ -1,0 +1,62 @@
+import { type RefObject, useEffect, useState } from "react";
+
+interface UseInViewportOptions {
+  /**
+   * IntersectionObserver root margin. Pre-load before the element fully
+   * enters the viewport so a fast scroller doesn't see a skeleton.
+   * Defaults to "200px" — about one card-row of pre-roll.
+   */
+  rootMargin?: string;
+  /**
+   * Sticky after first sighting: once the element has been visible once,
+   * stay reported as visible forever. Useful when the cost we're gating
+   * is one-time work (lazy data fetch); for ongoing polling leave this
+   * `false` so we suspend again when scrolled away.
+   */
+  once?: boolean;
+}
+
+/**
+ * Reports whether the supplied element is intersecting the viewport.
+ *
+ * Used to throttle expensive per-card work (polling, heavy renders) so
+ * that an "All Sites" view with hundreds of building cards doesn't
+ * stampede the API every poll tick. Cards below the fold report
+ * `false`; flipping into view resumes their work.
+ */
+// SSR / older browsers without IO default to visible so gated work still
+// runs. Resolved at module load — checking `typeof IntersectionObserver`
+// inside an effect would force a synchronous setState that the React 19
+// lint forbids.
+const HAS_INTERSECTION_OBSERVER = typeof IntersectionObserver !== "undefined";
+
+export const useInViewport = (
+  ref: RefObject<Element | null>,
+  { rootMargin = "200px", once = false }: UseInViewportOptions = {},
+): boolean => {
+  const [isVisible, setIsVisible] = useState(!HAS_INTERSECTION_OBSERVER);
+
+  useEffect(() => {
+    if (!HAS_INTERSECTION_OBSERVER) return undefined;
+    const node = ref.current;
+    if (!node) return undefined;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          if (once) observer.disconnect();
+        } else if (!once) {
+          setIsVisible(false);
+        }
+      },
+      { rootMargin },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [ref, rootMargin, once]);
+
+  return isVisible;
+};

--- a/client/src/shared/hooks/usePoll.ts
+++ b/client/src/shared/hooks/usePoll.ts
@@ -11,8 +11,6 @@ interface UsePollProps {
 }
 
 const usePoll = ({ fetchData, params, poll, pollIntervalMs = 10 * 1000, enabled = true }: UsePollProps) => {
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isMountedRef = useRef(true);
   const fetchDataRef = useRef(fetchData);
 
   // Keep fetchData ref up to date
@@ -23,20 +21,22 @@ const usePoll = ({ fetchData, params, poll, pollIntervalMs = 10 * 1000, enabled 
   }, [fetchData]);
 
   useEffect(() => {
-    isMountedRef.current = true;
+    if (!enabled) return undefined;
 
-    if (!enabled) {
-      return () => {
-        isMountedRef.current = false;
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current);
-          timeoutRef.current = null;
-        }
-      };
-    }
+    // Effect-local cancellation. Each effect run gets its own `alive`
+    // flag and `timeoutId`. Cleanup flips this run's flag and clears
+    // its timeout — so the in-flight fetch's continuation can't
+    // accidentally schedule a follow-up after the user toggles
+    // `enabled` off and back on (e.g. a BuildingCard scrolling out and
+    // back into the viewport before its request resolves). Using a
+    // shared ref here would let the new effect's `alive = true` reset
+    // the flag the old continuation reads, attaching a second
+    // concurrent poll loop to the same card.
+    let alive = true;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const pollWithDelay = async () => {
-      if (!isMountedRef.current) return;
+      if (!alive) return;
 
       try {
         await fetchDataRef.current();
@@ -45,9 +45,10 @@ const usePoll = ({ fetchData, params, poll, pollIntervalMs = 10 * 1000, enabled 
         console.error("Poll request failed:", error);
       }
 
-      // Only schedule next poll if still mounted and polling is enabled
-      if (isMountedRef.current && poll) {
-        timeoutRef.current = setTimeout(pollWithDelay, pollIntervalMs);
+      // Schedule next poll only if this effect run is still alive and
+      // polling is enabled.
+      if (alive && poll) {
+        timeoutId = setTimeout(pollWithDelay, pollIntervalMs);
       }
     };
 
@@ -55,10 +56,10 @@ const usePoll = ({ fetchData, params, poll, pollIntervalMs = 10 * 1000, enabled 
     pollWithDelay();
 
     return () => {
-      isMountedRef.current = false;
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-        timeoutRef.current = null;
+      alive = false;
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
       }
     };
   }, [enabled, params, poll, pollIntervalMs]);

--- a/client/src/shared/utils/telemetryFormat.test.ts
+++ b/client/src/shared/utils/telemetryFormat.test.ts
@@ -5,8 +5,10 @@ import {
   formatEfficiencyOrDash,
   formatHashrate,
   formatHashrateOrDash,
+  formatHashrateWithUnit,
   formatPowerMwOrDash,
   formatPowerUsedCapacity,
+  formatTempRange,
 } from "./telemetryFormat";
 
 describe("formatHashrate", () => {
@@ -82,5 +84,51 @@ describe("OrDash variants", () => {
     expect(formatHashrateOrDash(500)).toBe("500.0 TH/s");
     expect(formatEfficiencyOrDash(28.5)).toBe("28.5 J/TH");
     expect(formatPowerMwOrDash(12_345)).toBe("12.3 MW");
+  });
+});
+
+describe("formatHashrateWithUnit", () => {
+  it("returns TH/S for values <= 1000", () => {
+    expect(formatHashrateWithUnit(0)).toEqual({ value: 0, unit: "TH/S" });
+    expect(formatHashrateWithUnit(500)).toEqual({ value: 500, unit: "TH/S" });
+    expect(formatHashrateWithUnit(1000)).toEqual({ value: 1000, unit: "TH/S" });
+  });
+
+  it("returns PH/S for values > 1000", () => {
+    expect(formatHashrateWithUnit(1001)).toEqual({ value: 1.001, unit: "PH/S" });
+    expect(formatHashrateWithUnit(2000)).toEqual({ value: 2, unit: "PH/S" });
+    expect(formatHashrateWithUnit(5500)).toEqual({ value: 5.5, unit: "PH/S" });
+  });
+
+  it("handles undefined/null values", () => {
+    expect(formatHashrateWithUnit()).toEqual({ value: 0, unit: "TH/S" });
+  });
+
+  it("scales sub-TH/s into GH/S", () => {
+    expect(formatHashrateWithUnit(0.5)).toEqual({ value: 500, unit: "GH/S" });
+    expect(formatHashrateWithUnit(0.001)).toEqual({ value: 1, unit: "GH/S" });
+  });
+
+  it("scales > 1,000,000 TH/s into EH/S", () => {
+    expect(formatHashrateWithUnit(2_500_000)).toEqual({ value: 2.5, unit: "EH/S" });
+    // Strict `>` keeps 1,000,000 TH/s in PH/s rather than tipping into EH/s.
+    expect(formatHashrateWithUnit(1_000_000)).toEqual({ value: 1000, unit: "PH/S" });
+  });
+});
+
+describe("formatTempRange", () => {
+  it("formats Celsius range with one decimal", () => {
+    expect(formatTempRange(20.1, 65.5, "C")).toBe("20.1 °C – 65.5 °C");
+  });
+
+  it("formats Fahrenheit range by converting from Celsius", () => {
+    expect(formatTempRange(0, 100, "F")).toBe("32.0 °F – 212.0 °F");
+  });
+
+  it("uses correct degree sign (U+00B0) and en dash", () => {
+    const result = formatTempRange(30, 40, "C");
+    expect(result).toContain("°"); // U+00B0 degree sign
+    expect(result).toContain("–"); // en dash
+    expect(result).not.toContain("º"); // not U+00BA ordinal indicator
   });
 });

--- a/client/src/shared/utils/telemetryFormat.test.ts
+++ b/client/src/shared/utils/telemetryFormat.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatEfficiency,
+  formatEfficiencyOrDash,
+  formatHashrate,
+  formatHashrateOrDash,
+  formatPowerMwOrDash,
+  formatPowerUsedCapacity,
+} from "./telemetryFormat";
+
+describe("formatHashrate", () => {
+  it("returns null for missing measurements", () => {
+    expect(formatHashrate(null)).toBeNull();
+  });
+
+  it("renders 0 in TH/s rather than scaling into smaller units", () => {
+    expect(formatHashrate(0)).toBe("0 TH/s");
+  });
+
+  it("scales sub-TH/s values into GH/s", () => {
+    // 0.4 TH/s → 400 GH/s (single test miner case)
+    expect(formatHashrate(0.4)).toBe("400.0 GH/s");
+  });
+
+  it("keeps mid-range values in TH/s", () => {
+    expect(formatHashrate(400)).toBe("400.0 TH/s");
+  });
+
+  it("scales thousands of TH/s into PH/s", () => {
+    // 5500 TH/s → 5.50 PH/s (two decimals below 10)
+    expect(formatHashrate(5_500)).toBe("5.50 PH/s");
+  });
+
+  it("scales millions of TH/s into EH/s with two decimals under 10", () => {
+    expect(formatHashrate(2_500_000)).toBe("2.50 EH/s");
+  });
+
+  it("drops to one decimal above 10 EH/s and separates thousands", () => {
+    expect(formatHashrate(42_000_000)).toBe("42.0 EH/s");
+    expect(formatHashrate(1_234_000_000)).toBe("1,234.0 EH/s");
+  });
+});
+
+describe("formatPowerUsedCapacity", () => {
+  it("formats used MW and capacity MW", () => {
+    // kW → MW: 12_345 kW / 1000 = 12.3 MW
+    expect(formatPowerUsedCapacity(12_345, 20)).toBe("12.3 / 20.0 MW");
+  });
+
+  it("shows an em dash for the missing side when capacity is unset", () => {
+    expect(formatPowerUsedCapacity(5_000, 0)).toBe("5.0 / — MW");
+  });
+
+  it("shows an em dash for the missing side when usage is unknown", () => {
+    expect(formatPowerUsedCapacity(null, 20)).toBe("— / 20.0 MW");
+  });
+
+  it("returns null when both sides are missing", () => {
+    expect(formatPowerUsedCapacity(null, 0)).toBeNull();
+  });
+});
+
+describe("formatEfficiency", () => {
+  it("returns null when efficiency is unknown", () => {
+    expect(formatEfficiency(null)).toBeNull();
+  });
+
+  it("renders J/TH with one decimal", () => {
+    expect(formatEfficiency(28.456)).toBe("28.5 J/TH");
+  });
+});
+
+describe("OrDash variants", () => {
+  it("returns em dash on null input", () => {
+    expect(formatHashrateOrDash(null)).toBe("—");
+    expect(formatEfficiencyOrDash(null)).toBe("—");
+    expect(formatPowerMwOrDash(null)).toBe("—");
+  });
+
+  it("delegates formatting to the null-returning helpers when a value is present", () => {
+    expect(formatHashrateOrDash(500)).toBe("500.0 TH/s");
+    expect(formatEfficiencyOrDash(28.5)).toBe("28.5 J/TH");
+    expect(formatPowerMwOrDash(12_345)).toBe("12.3 MW");
+  });
+});

--- a/client/src/shared/utils/telemetryFormat.ts
+++ b/client/src/shared/utils/telemetryFormat.ts
@@ -1,0 +1,63 @@
+// Display formatters for telemetry aggregates (hashrate, efficiency,
+// power). Centralised so every surface — /sites metric row,
+// /buildings/:id metric row, BuildingCard footer, future rack /
+// device-set rollups — renders the same precision + unit ladder.
+//
+// Re-exports the lower-level `formatHashrateWithUnit` / `separateByCommas`
+// already in shared/utils so callers compose these (display strings)
+// rather than re-inventing the parts.
+
+import { separateByCommas } from "@/shared/utils/stringUtils";
+import { formatHashrateWithUnit } from "@/shared/utils/utility";
+
+export const KW_PER_MW = 1_000;
+
+// Picks GH/s, TH/s, PH/s, or EH/s based on the input so the displayed value
+// stays in [1, 1000) — small sites (a single test miner at 400 TH/s) don't
+// read as "0.00 EH/s", and EH-scale fleets don't read as "1,250,000 TH/s".
+export const formatHashrate = (hashrateTh: number | null): string | null => {
+  if (hashrateTh === null) return null;
+  if (hashrateTh === 0) return "0 TH/s";
+  const { value, unit } = formatHashrateWithUnit(hashrateTh);
+  // Two decimals when scaled value is < 10 so small magnitudes keep signal
+  // (e.g. 2.50 EH/s); one decimal above that to match the dashboard bar.
+  const decimals = value < 10 ? 2 : 1;
+  // Shared formatter returns uppercase units (PH/S); the metric row uses
+  // lowercase /s throughout.
+  return `${separateByCommas(value.toFixed(decimals))} ${unit.replace("/S", "/s")}`;
+};
+
+// "12.3 / 20.0 MW" — used/capacity pair with em-dash fallback per side.
+// `usedKw` is in kilowatts; `capacityMw` in megawatts (matches the proto
+// shape on Site / Building).
+export const formatPowerUsedCapacity = (usedKw: number | null, capacityMw: number): string | null => {
+  const hasCapacity = capacityMw > 0;
+  if (usedKw === null && !hasCapacity) return null;
+  const usedMw = usedKw !== null ? usedKw / KW_PER_MW : null;
+  const usedText = usedMw !== null ? usedMw.toFixed(1) : "—";
+  const capacityText = hasCapacity ? capacityMw.toFixed(1) : "—";
+  return `${usedText} / ${capacityText} MW`;
+};
+
+export const formatEfficiency = (efficiencyJTh: number | null): string | null => {
+  if (efficiencyJTh === null) return null;
+  return `${separateByCommas(efficiencyJTh.toFixed(1))} J/TH`;
+};
+
+// "OrDash" variants for compact tiles (BuildingCard footer) that always
+// need a non-null string and use em-dash as their no-data sentinel.
+// Surfaces that disambiguate null vs value (e.g. the shared `Metric`
+// primitive showing a skeleton) should keep using the null-returning
+// versions above.
+export const formatHashrateOrDash = (hashrateTh: number | null): string => formatHashrate(hashrateTh) ?? "—";
+
+export const formatEfficiencyOrDash = (efficiencyJTh: number | null): string => formatEfficiency(efficiencyJTh) ?? "—";
+
+// Total power as MW with em-dash fallback. Site/building rows use
+// `formatPowerUsedCapacity` for used/capacity strings; this single-value
+// variant is for footers that don't carry a capacity.
+export const formatPowerMwOrDash = (powerKw: number | null): string => {
+  if (powerKw === null) return "—";
+  const mw = powerKw / KW_PER_MW;
+  return `${separateByCommas(mw.toFixed(1))} MW`;
+};

--- a/client/src/shared/utils/telemetryFormat.ts
+++ b/client/src/shared/utils/telemetryFormat.ts
@@ -1,20 +1,78 @@
-// Display formatters for telemetry aggregates (hashrate, efficiency,
-// power). Centralised so every surface — /sites metric row,
-// /buildings/:id metric row, BuildingCard footer, future rack /
-// device-set rollups — renders the same precision + unit ladder.
-//
-// Re-exports the lower-level `formatHashrateWithUnit` / `separateByCommas`
-// already in shared/utils so callers compose these (display strings)
-// rather than re-inventing the parts.
+// Telemetry conversions + display formatters. Single home for the unit
+// math (MH→TH, GH→TH, W→kW, °C↔°F) and the display strings built on
+// top of them. Every surface that renders telemetry — /sites,
+// /buildings/:id, BuildingCard footer, HashRateValue, rack cards,
+// the protoOS popovers — should source these from here so the unit
+// ladder, decimal precision, and em-dash fallbacks stay consistent.
 
-import { separateByCommas } from "@/shared/utils/stringUtils";
-import { formatHashrateWithUnit } from "@/shared/utils/utility";
+import { type TemperatureUnit } from "@/shared/features/preferences";
+import { getDisplayValue, separateByCommas } from "@/shared/utils/stringUtils";
 
 export const KW_PER_MW = 1_000;
 
-// Picks GH/s, TH/s, PH/s, or EH/s based on the input so the displayed value
-// stays in [1, 1000) — small sites (a single test miner at 400 TH/s) don't
-// read as "0.00 EH/s", and EH-scale fleets don't read as "1,250,000 TH/s".
+// ---------------------------------------------------------------------------
+// Unit conversions
+// ---------------------------------------------------------------------------
+
+export const convertMegahashSecToTerahashSec = (value?: number | null) => (value ?? 0) / 1_000_000;
+export const convertGigahashSecToTerahashSec = (value?: number | null) => (value ?? 0) / 1_000;
+export const convertWtoKW = (value?: number | null) => (value ?? 0) / 1_000;
+
+export const convertCtoF = (value: number = 0) => (value * 9) / 5 + 32;
+export const convertFtoC = (value: number = 0) => ((value - 32) * 5) / 9;
+
+// ---------------------------------------------------------------------------
+// Hashrate display
+// ---------------------------------------------------------------------------
+
+// Hashrate unit ladder boundary constants. The simpler "if > 1000, scale
+// everything by 1000" pattern in the dashboard chart code uses these so
+// the per-series scaling matches what `formatHashrateWithUnit` would
+// pick for the max. Kept exported for that callsite.
+export const TH_TO_PH_THRESHOLD = 1_000;
+export const TH_TO_PH_DIVISOR = 1_000;
+
+// Internal ladder constants for formatHashrateWithUnit. Identical to the
+// exported pair above for the TH→PH step; named differently here to make
+// the auto-scaling staircase (GH/TH/PH/EH) explicit.
+const TH_PER_PH = 1_000;
+const TH_PER_EH = 1_000_000;
+const GH_PER_TH = 1_000;
+
+// Picks the smallest unit (GH/TH/PH/EH) that keeps the displayed value in
+// [1, 1000) for non-zero inputs. Zero stays in TH/s as the conventional
+// "no signal" default. Used directly by surfaces that need both the value
+// and unit (HashRateValue, AsicPopover); higher-level helpers like
+// `formatHashrate` compose this with separator + decimal rules.
+export const formatHashrateWithUnit = (value: number = 0) => {
+  // NaN/Infinity guard. Bad upstream data (corrupted telemetry, division
+  // by zero in an aggregation) shouldn't propagate `NaN TH/s` to the UI;
+  // fall through to the zero rendering instead.
+  if (!Number.isFinite(value)) {
+    return { value: 0, unit: "TH/S" };
+  }
+  if (value <= 0) {
+    return { value: 0, unit: "TH/S" };
+  }
+  // Strict `>` boundaries keep prior callers (AsicPopover, HashRateValue)
+  // rendering 1000 TH/s as "1000 TH/S" instead of "1 PH/S"; same rule
+  // applies one step up at the EH boundary.
+  if (value > TH_PER_EH) {
+    return { value: value / TH_PER_EH, unit: "EH/S" };
+  }
+  if (value > TH_PER_PH) {
+    return { value: value / TH_PER_PH, unit: "PH/S" };
+  }
+  if (value < 1) {
+    return { value: value * GH_PER_TH, unit: "GH/S" };
+  }
+  return { value, unit: "TH/S" };
+};
+
+// Auto-scaled hashrate string with comma-separated thousands and
+// magnitude-aware decimal precision. Returns `null` for `null` input so
+// callers that render skeletons vs em-dashes can disambiguate; use the
+// `OrDash` variant below for compact tiles that always need a string.
 export const formatHashrate = (hashrateTh: number | null): string | null => {
   if (hashrateTh === null) return null;
   if (hashrateTh === 0) return "0 TH/s";
@@ -22,10 +80,16 @@ export const formatHashrate = (hashrateTh: number | null): string | null => {
   // Two decimals when scaled value is < 10 so small magnitudes keep signal
   // (e.g. 2.50 EH/s); one decimal above that to match the dashboard bar.
   const decimals = value < 10 ? 2 : 1;
-  // Shared formatter returns uppercase units (PH/S); the metric row uses
-  // lowercase /s throughout.
+  // formatHashrateWithUnit returns uppercase units (PH/S); the metric row
+  // uses lowercase /s throughout.
   return `${separateByCommas(value.toFixed(decimals))} ${unit.replace("/S", "/s")}`;
 };
+
+export const formatHashrateOrDash = (hashrateTh: number | null): string => formatHashrate(hashrateTh) ?? "—";
+
+// ---------------------------------------------------------------------------
+// Power display
+// ---------------------------------------------------------------------------
 
 // "12.3 / 20.0 MW" — used/capacity pair with em-dash fallback per side.
 // `usedKw` is in kilowatts; `capacityMw` in megawatts (matches the proto
@@ -39,20 +103,6 @@ export const formatPowerUsedCapacity = (usedKw: number | null, capacityMw: numbe
   return `${usedText} / ${capacityText} MW`;
 };
 
-export const formatEfficiency = (efficiencyJTh: number | null): string | null => {
-  if (efficiencyJTh === null) return null;
-  return `${separateByCommas(efficiencyJTh.toFixed(1))} J/TH`;
-};
-
-// "OrDash" variants for compact tiles (BuildingCard footer) that always
-// need a non-null string and use em-dash as their no-data sentinel.
-// Surfaces that disambiguate null vs value (e.g. the shared `Metric`
-// primitive showing a skeleton) should keep using the null-returning
-// versions above.
-export const formatHashrateOrDash = (hashrateTh: number | null): string => formatHashrate(hashrateTh) ?? "—";
-
-export const formatEfficiencyOrDash = (efficiencyJTh: number | null): string => formatEfficiency(efficiencyJTh) ?? "—";
-
 // Total power as MW with em-dash fallback. Site/building rows use
 // `formatPowerUsedCapacity` for used/capacity strings; this single-value
 // variant is for footers that don't carry a capacity.
@@ -60,4 +110,38 @@ export const formatPowerMwOrDash = (powerKw: number | null): string => {
   if (powerKw === null) return "—";
   const mw = powerKw / KW_PER_MW;
   return `${separateByCommas(mw.toFixed(1))} MW`;
+};
+
+// Total power as kW with em-dash fallback. Used by smaller-scope
+// surfaces (rack cards, single-device popovers) where MW would round to
+// "0.0" for everything under a megawatt.
+export const formatPowerKwOrDash = (powerKw: number | null | undefined): string => {
+  if (powerKw === null || powerKw === undefined) return "—";
+  return `${getDisplayValue(powerKw)} kW`;
+};
+
+// ---------------------------------------------------------------------------
+// Efficiency display
+// ---------------------------------------------------------------------------
+
+export const formatEfficiency = (efficiencyJTh: number | null): string | null => {
+  if (efficiencyJTh === null) return null;
+  return `${separateByCommas(efficiencyJTh.toFixed(1))} J/TH`;
+};
+
+export const formatEfficiencyOrDash = (efficiencyJTh: number | null): string => formatEfficiency(efficiencyJTh) ?? "—";
+
+// ---------------------------------------------------------------------------
+// Temperature display
+// ---------------------------------------------------------------------------
+
+export const formatTempRange = (minC: number, maxC: number, temperatureUnit: TemperatureUnit): string => {
+  const min = temperatureUnit === "F" ? convertCtoF(minC) : minC;
+  const max = temperatureUnit === "F" ? convertCtoF(maxC) : maxC;
+  return `${getDisplayValue(min)} °${temperatureUnit} – ${getDisplayValue(max)} °${temperatureUnit}`;
+};
+
+export const getAsicTempValue = (avgAsicTemp: number | undefined, isFahrenheit: boolean) => {
+  if (!avgAsicTemp) return "N/A"; // TODO: why not return undefined, so we can show skeleton, also 0 cound be falsey
+  return isFahrenheit ? convertCtoF(avgAsicTemp) : avgAsicTemp;
 };

--- a/client/src/shared/utils/utility.test.ts
+++ b/client/src/shared/utils/utility.test.ts
@@ -136,6 +136,17 @@ describe("formatHashrateWithUnit", () => {
   test("should handle undefined/null values", () => {
     expect(formatHashrateWithUnit()).toEqual({ value: 0, unit: "TH/S" });
   });
+
+  test("scales sub-TH/s into GH/S", () => {
+    expect(formatHashrateWithUnit(0.5)).toEqual({ value: 500, unit: "GH/S" });
+    expect(formatHashrateWithUnit(0.001)).toEqual({ value: 1, unit: "GH/S" });
+  });
+
+  test("scales > 1,000,000 TH/s into EH/S", () => {
+    expect(formatHashrateWithUnit(2_500_000)).toEqual({ value: 2.5, unit: "EH/S" });
+    // Strict `>` keeps 1,000,000 TH/s in PH/s rather than tipping into EH/s.
+    expect(formatHashrateWithUnit(1_000_000)).toEqual({ value: 1000, unit: "PH/S" });
+  });
 });
 
 describe("formatTempRange", () => {

--- a/client/src/shared/utils/utility.test.ts
+++ b/client/src/shared/utils/utility.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { copyToClipboard, debounce, deepClone, formatHashrateWithUnit, formatTempRange, getRowLabel } from "./utility";
+import { copyToClipboard, debounce, deepClone, getRowLabel } from "./utility";
 
 describe("deepClone", () => {
   test("should create a deep copy of an object", () => {
@@ -114,55 +114,6 @@ describe("getRowLabel", () => {
     expect(getRowLabel(7)).toBe("H");
     expect(getRowLabel(8)).toBe("I");
     expect(getRowLabel(9)).toBe("J");
-  });
-});
-
-describe("formatHashrateWithUnit", () => {
-  test("should return TH/S for values <= 1000", () => {
-    expect(formatHashrateWithUnit(0)).toEqual({ value: 0, unit: "TH/S" });
-    expect(formatHashrateWithUnit(500)).toEqual({ value: 500, unit: "TH/S" });
-    expect(formatHashrateWithUnit(1000)).toEqual({ value: 1000, unit: "TH/S" });
-  });
-
-  test("should return PH/S for values > 1000", () => {
-    expect(formatHashrateWithUnit(1001)).toEqual({
-      value: 1.001,
-      unit: "PH/S",
-    });
-    expect(formatHashrateWithUnit(2000)).toEqual({ value: 2, unit: "PH/S" });
-    expect(formatHashrateWithUnit(5500)).toEqual({ value: 5.5, unit: "PH/S" });
-  });
-
-  test("should handle undefined/null values", () => {
-    expect(formatHashrateWithUnit()).toEqual({ value: 0, unit: "TH/S" });
-  });
-
-  test("scales sub-TH/s into GH/S", () => {
-    expect(formatHashrateWithUnit(0.5)).toEqual({ value: 500, unit: "GH/S" });
-    expect(formatHashrateWithUnit(0.001)).toEqual({ value: 1, unit: "GH/S" });
-  });
-
-  test("scales > 1,000,000 TH/s into EH/S", () => {
-    expect(formatHashrateWithUnit(2_500_000)).toEqual({ value: 2.5, unit: "EH/S" });
-    // Strict `>` keeps 1,000,000 TH/s in PH/s rather than tipping into EH/s.
-    expect(formatHashrateWithUnit(1_000_000)).toEqual({ value: 1000, unit: "PH/S" });
-  });
-});
-
-describe("formatTempRange", () => {
-  test("formats Celsius range with one decimal", () => {
-    expect(formatTempRange(20.1, 65.5, "C")).toBe("20.1 °C – 65.5 °C");
-  });
-
-  test("formats Fahrenheit range by converting from Celsius", () => {
-    expect(formatTempRange(0, 100, "F")).toBe("32.0 °F – 212.0 °F");
-  });
-
-  test("uses correct degree sign (U+00B0) and en dash", () => {
-    const result = formatTempRange(30, 40, "C");
-    expect(result).toContain("°"); // U+00B0 degree sign
-    expect(result).toContain("–"); // en dash
-    expect(result).not.toContain("º"); // not U+00BA ordinal indicator
   });
 });
 

--- a/client/src/shared/utils/utility.ts
+++ b/client/src/shared/utils/utility.ts
@@ -48,21 +48,43 @@ export const convertMegahashSecToTerahashSec = (value?: number | null) => (value
 export const convertGigahashSecToTerahashSec = (value?: number | null) => (value ?? 0) / 1000;
 export const convertWtoKW = (value?: number | null) => (value ?? 0) / 1000;
 
-// Hashrate unit conversion constants
+// Hashrate unit conversion constants. Retained for backwards compatibility
+// with callers that import these directly; formatHashrateWithUnit no longer
+// uses TH_TO_PH_THRESHOLD/TH_TO_PH_DIVISOR internally.
 export const TH_TO_PH_THRESHOLD = 1000;
 export const TH_TO_PH_DIVISOR = 1000;
 
+// Unit ladder for hashrate display. Value in is always TH/s; the formatter
+// scales it into GH/s, TH/s, PH/s, or EH/s so the displayed number stays in
+// [1, 1000) for non-zero inputs. Zero stays in TH/s as the conventional
+// "no signal" default.
+const TH_PER_PH = 1_000;
+const TH_PER_EH = 1_000_000;
+const GH_PER_TH = 1_000;
+
 export const formatHashrateWithUnit = (value: number = 0) => {
-  if (value > TH_TO_PH_THRESHOLD) {
-    return {
-      value: value / TH_TO_PH_DIVISOR,
-      unit: "PH/S",
-    };
+  // NaN/Infinity guard. Bad upstream data (corrupted telemetry, division
+  // by zero in an aggregation) shouldn't propagate `NaN TH/s` to the UI;
+  // fall through to the zero rendering instead.
+  if (!Number.isFinite(value)) {
+    return { value: 0, unit: "TH/S" };
   }
-  return {
-    value: value,
-    unit: "TH/S",
-  };
+  if (value <= 0) {
+    return { value: 0, unit: "TH/S" };
+  }
+  // Strict `>` boundaries keep prior callers (AsicPopover, HashRateValue)
+  // rendering 1000 TH/s as "1000 TH/S" instead of "1 PH/S"; same rule
+  // applies one step up at the EH boundary.
+  if (value > TH_PER_EH) {
+    return { value: value / TH_PER_EH, unit: "EH/S" };
+  }
+  if (value > TH_PER_PH) {
+    return { value: value / TH_PER_PH, unit: "PH/S" };
+  }
+  if (value < 1) {
+    return { value: value * GH_PER_TH, unit: "GH/S" };
+  }
+  return { value, unit: "TH/S" };
 };
 
 export const convertCtoF = (value: number = 0) => (value * 9) / 5 + 32;

--- a/client/src/shared/utils/utility.ts
+++ b/client/src/shared/utils/utility.ts
@@ -1,5 +1,4 @@
-import type { TemperatureUnit } from "@/shared/features/preferences";
-import { getDisplayValue, padLeft } from "@/shared/utils/stringUtils";
+import { padLeft } from "@/shared/utils/stringUtils";
 
 export const deepClone = (obj: any) => {
   const stringify = JSON.stringify(obj, (_, value) => (typeof value === "bigint" ? Number(value) : value));
@@ -44,62 +43,9 @@ export const getRandomFloat = (min: number, max: number, precision: number = 100
   );
 };
 
-export const convertMegahashSecToTerahashSec = (value?: number | null) => (value ?? 0) / 1000000;
-export const convertGigahashSecToTerahashSec = (value?: number | null) => (value ?? 0) / 1000;
-export const convertWtoKW = (value?: number | null) => (value ?? 0) / 1000;
-
-// Hashrate unit conversion constants. Retained for backwards compatibility
-// with callers that import these directly; formatHashrateWithUnit no longer
-// uses TH_TO_PH_THRESHOLD/TH_TO_PH_DIVISOR internally.
-export const TH_TO_PH_THRESHOLD = 1000;
-export const TH_TO_PH_DIVISOR = 1000;
-
-// Unit ladder for hashrate display. Value in is always TH/s; the formatter
-// scales it into GH/s, TH/s, PH/s, or EH/s so the displayed number stays in
-// [1, 1000) for non-zero inputs. Zero stays in TH/s as the conventional
-// "no signal" default.
-const TH_PER_PH = 1_000;
-const TH_PER_EH = 1_000_000;
-const GH_PER_TH = 1_000;
-
-export const formatHashrateWithUnit = (value: number = 0) => {
-  // NaN/Infinity guard. Bad upstream data (corrupted telemetry, division
-  // by zero in an aggregation) shouldn't propagate `NaN TH/s` to the UI;
-  // fall through to the zero rendering instead.
-  if (!Number.isFinite(value)) {
-    return { value: 0, unit: "TH/S" };
-  }
-  if (value <= 0) {
-    return { value: 0, unit: "TH/S" };
-  }
-  // Strict `>` boundaries keep prior callers (AsicPopover, HashRateValue)
-  // rendering 1000 TH/s as "1000 TH/S" instead of "1 PH/S"; same rule
-  // applies one step up at the EH boundary.
-  if (value > TH_PER_EH) {
-    return { value: value / TH_PER_EH, unit: "EH/S" };
-  }
-  if (value > TH_PER_PH) {
-    return { value: value / TH_PER_PH, unit: "PH/S" };
-  }
-  if (value < 1) {
-    return { value: value * GH_PER_TH, unit: "GH/S" };
-  }
-  return { value, unit: "TH/S" };
-};
-
-export const convertCtoF = (value: number = 0) => (value * 9) / 5 + 32;
-export const convertFtoC = (value: number = 0) => ((value - 32) * 5) / 9;
-
-export const formatTempRange = (minC: number, maxC: number, temperatureUnit: TemperatureUnit): string => {
-  const min = temperatureUnit === "F" ? convertCtoF(minC) : minC;
-  const max = temperatureUnit === "F" ? convertCtoF(maxC) : maxC;
-  return `${getDisplayValue(min)} °${temperatureUnit} – ${getDisplayValue(max)} °${temperatureUnit}`;
-};
-
-export const getAsicTempValue = (avgAsicTemp: number | undefined, isFahrenheit: boolean) => {
-  if (!avgAsicTemp) return "N/A"; // TODO: why not return undefined, so we can show skeleton, also 0 cound be falsey
-  return isFahrenheit ? convertCtoF(avgAsicTemp) : avgAsicTemp;
-};
+// Telemetry conversions + formatters (formatHashrateWithUnit, convertCtoF,
+// formatTempRange, etc.) live in @/shared/utils/telemetryFormat. Import
+// from there for telemetry display; this file keeps non-telemetry helpers.
 
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 


### PR DESCRIPTION
## Summary

Frontend half of the `/sites` + `/buildings/:id` Phase 1b work for #263. Backend RPCs (`GetSiteStats` / `GetBuildingStats`) shipped in #339 (now merged to `main`).

- `/sites` overview: per-site metric row (location / hashrate / power / efficiency / buildings) plus a responsive grid of `BuildingCard`s
- `BuildingCard`: floor-plan rack grid with 5-state cell rendering, polled stats, ellipsis menu, footer metric tiles
- `/buildings/:id`: `BuildingMetricsRow` (hashrate / power / efficiency / miners online) plus diagnostics + performance reusing the rack-overview pattern
- New API hooks `useSiteStats` / `useBuildingStats` that wrap the shared `usePoll` scheduler so both screens stay live without manual refresh
- Shared `Metric` primitive that handles the loading-skeleton vs em-dash vs value rendering so every metric tile lines up during loading
- `SitesPage` polls `ListSites` + `ListBuildings` on the same cadence so building cards stay in sync when racks are added or removed
- Per-field reporting counts (hashrate / efficiency / power) gate display so a missing telemetry field renders the dash instead of a misleading partial average

> **⚠️ Note:** The **building health module** on `/buildings/:id` (rack-health rendering above the FleetErrors component-health row) is still rendering an `FPO` placeholder block — the real visualization is pending design. Tracked in #264 and lands in a follow-up.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run` — sites + buildings + api tests (113 tests, all passing)
- [x] Manual: `/sites` + `/buildings/:id` render against a real fleet-api with sites + buildings