### PR TITLE
Curtailment: share active event polling data

### DIFF
--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  applyActiveCurtailmentEvent,
+  fetchActiveCurtailmentData,
+  getActiveCurtailmentSnapshot,
+  refreshActiveCurtailmentData,
+  resetActiveCurtailmentData,
+} from "@/protoFleet/api/activeCurtailmentData";
+import {
+  type CurtailmentEvent,
+  CurtailmentEventSchema,
+  CurtailmentEventState,
+} from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
+
+const { mockGetActiveCurtailment } = vi.hoisted(() => ({
+  mockGetActiveCurtailment: vi.fn(),
+}));
+
+vi.mock("@/protoFleet/api/clients", () => ({
+  curtailmentClient: {
+    getActiveCurtailment: mockGetActiveCurtailment,
+  },
+}));
+
+function curtailmentEvent(eventUuid: string, state = CurtailmentEventState.ACTIVE): CurtailmentEvent {
+  return create(CurtailmentEventSchema, {
+    eventUuid,
+    state,
+  });
+}
+
+describe("activeCurtailmentData", () => {
+  beforeEach(() => {
+    resetActiveCurtailmentData();
+    vi.clearAllMocks();
+  });
+
+  it("keeps newer active curtailment data when an older refresh returns later", async () => {
+    let resolveRefresh: (value: { event: CurtailmentEvent }) => void = () => {};
+    mockGetActiveCurtailment.mockReturnValue(
+      new Promise<{ event: CurtailmentEvent }>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+
+    const refreshPromise = refreshActiveCurtailmentData();
+    applyActiveCurtailmentEvent(curtailmentEvent("newer-event"));
+    resolveRefresh({ event: curtailmentEvent("older-event") });
+
+    await refreshPromise;
+
+    expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("newer-event");
+  });
+
+  it("shares one active curtailment request across concurrent refresh callers", async () => {
+    let resolveRefresh: (value: { event: CurtailmentEvent }) => void = () => {};
+    mockGetActiveCurtailment.mockReturnValue(
+      new Promise<{ event: CurtailmentEvent }>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+
+    const refreshPromise = refreshActiveCurtailmentData();
+    const pendingRefreshPromise = fetchActiveCurtailmentData();
+
+    expect(mockGetActiveCurtailment).toHaveBeenCalledTimes(1);
+
+    resolveRefresh({ event: curtailmentEvent("shared-event") });
+    const [snapshot, pendingRefresh] = await Promise.all([refreshPromise, pendingRefreshPromise]);
+
+    expect(snapshot.event?.eventUuid).toBe("shared-event");
+    expect(pendingRefresh.event?.eventUuid).toBe("shared-event");
+
+    pendingRefresh.commit();
+
+    expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("shared-event");
+    expect(mockGetActiveCurtailment).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["restoring", CurtailmentEventState.RESTORING],
+    ["restored", CurtailmentEventState.COMPLETED],
+    ["incomplete restore", CurtailmentEventState.COMPLETED_WITH_FAILURES],
+  ])("preserves a %s curtailment when active polling briefly returns empty", async (eventUuid, state) => {
+    applyActiveCurtailmentEvent(curtailmentEvent(eventUuid, state));
+    mockGetActiveCurtailment.mockResolvedValue({ event: undefined });
+
+    await refreshActiveCurtailmentData();
+
+    expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe(eventUuid);
+  });
+});

--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
 
 import {
   applyActiveCurtailmentEvent,
@@ -18,18 +19,10 @@ import {
 const { mockGetActiveCurtailment } = vi.hoisted(() => ({
   mockGetActiveCurtailment: vi.fn(),
 }));
-
-vi.mock("@/protoFleet/api/clients", () => ({
-  curtailmentClient: {
-    getActiveCurtailment: mockGetActiveCurtailment,
-  },
-}));
+vi.mock("@/protoFleet/api/clients", () => ({ curtailmentClient: { getActiveCurtailment: mockGetActiveCurtailment } }));
 
 function curtailmentEvent(eventUuid: string, state = CurtailmentEventState.ACTIVE): CurtailmentEvent {
-  return create(CurtailmentEventSchema, {
-    eventUuid,
-    state,
-  });
+  return create(CurtailmentEventSchema, { eventUuid, state });
 }
 
 describe("activeCurtailmentData", () => {
@@ -82,6 +75,22 @@ describe("activeCurtailmentData", () => {
     expect(freshRefresh.event?.eventUuid).toBe("fresh-event");
     expect(mockGetActiveCurtailment).toHaveBeenCalledTimes(2);
     await expect(abortedRequest).resolves.toBeInstanceOf(DOMException);
+  });
+
+  it("rejects a reset-aborted shared request as an AbortError", async () => {
+    mockGetActiveCurtailment.mockImplementationOnce(
+      (_request: unknown, options?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => reject(new ConnectError("canceled", Code.Canceled)), {
+            once: true,
+          });
+        }),
+    );
+
+    const pendingRefresh = refreshActiveCurtailmentData();
+    resetActiveCurtailmentData();
+
+    await expect(pendingRefresh).rejects.toBeInstanceOf(DOMException);
   });
 
   it.each([

--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -3,6 +3,7 @@ import { create } from "@bufbuild/protobuf";
 
 import {
   applyActiveCurtailmentEvent,
+  dismissActiveCurtailmentEvent,
   fetchActiveCurtailmentData,
   getActiveCurtailmentSnapshot,
   refreshActiveCurtailmentData,
@@ -37,21 +38,24 @@ describe("activeCurtailmentData", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps newer active curtailment data when an older refresh returns later", async () => {
+  it("keeps dismissed events suppressed when an older refresh is discarded", async () => {
     let resolveRefresh: (value: { event: CurtailmentEvent }) => void = () => {};
-    mockGetActiveCurtailment.mockReturnValue(
-      new Promise<{ event: CurtailmentEvent }>((resolve) => {
-        resolveRefresh = resolve;
-      }),
-    );
+    mockGetActiveCurtailment
+      .mockReturnValueOnce(
+        new Promise<{ event: CurtailmentEvent }>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      )
+      .mockResolvedValueOnce({ event: curtailmentEvent("dismissed-event") });
 
-    const refreshPromise = refreshActiveCurtailmentData();
-    applyActiveCurtailmentEvent(curtailmentEvent("newer-event"));
-    resolveRefresh({ event: curtailmentEvent("older-event") });
+    const staleRefreshPromise = refreshActiveCurtailmentData();
+    dismissActiveCurtailmentEvent("dismissed-event");
+    resolveRefresh({ event: curtailmentEvent("different-event") });
 
-    await refreshPromise;
+    await staleRefreshPromise;
+    await refreshActiveCurtailmentData();
 
-    expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("newer-event");
+    expect(getActiveCurtailmentSnapshot().event).toBeUndefined();
   });
 
   it("shares one active curtailment request across concurrent refresh callers", async () => {
@@ -77,6 +81,32 @@ describe("activeCurtailmentData", () => {
 
     expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("shared-event");
     expect(mockGetActiveCurtailment).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a fresh request after all shared request subscribers abort", async () => {
+    mockGetActiveCurtailment
+      .mockImplementationOnce(
+        (_request: unknown, options?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("The operation was aborted.", "AbortError")),
+              { once: true },
+            );
+          }),
+      )
+      .mockResolvedValueOnce({ event: curtailmentEvent("fresh-event") });
+
+    const abortController = new AbortController();
+    const abortedRequest = fetchActiveCurtailmentData({ signal: abortController.signal }).catch((error) => error);
+
+    abortController.abort();
+
+    const freshRefresh = await fetchActiveCurtailmentData();
+
+    expect(freshRefresh.event?.eventUuid).toBe("fresh-event");
+    expect(mockGetActiveCurtailment).toHaveBeenCalledTimes(2);
+    await expect(abortedRequest).resolves.toBeInstanceOf(DOMException);
   });
 
   it.each([

--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -58,31 +58,6 @@ describe("activeCurtailmentData", () => {
     expect(getActiveCurtailmentSnapshot().event).toBeUndefined();
   });
 
-  it("shares one active curtailment request across concurrent refresh callers", async () => {
-    let resolveRefresh: (value: { event: CurtailmentEvent }) => void = () => {};
-    mockGetActiveCurtailment.mockReturnValue(
-      new Promise<{ event: CurtailmentEvent }>((resolve) => {
-        resolveRefresh = resolve;
-      }),
-    );
-
-    const refreshPromise = refreshActiveCurtailmentData();
-    const pendingRefreshPromise = fetchActiveCurtailmentData();
-
-    expect(mockGetActiveCurtailment).toHaveBeenCalledTimes(1);
-
-    resolveRefresh({ event: curtailmentEvent("shared-event") });
-    const [snapshot, pendingRefresh] = await Promise.all([refreshPromise, pendingRefreshPromise]);
-
-    expect(snapshot.event?.eventUuid).toBe("shared-event");
-    expect(pendingRefresh.event?.eventUuid).toBe("shared-event");
-
-    pendingRefresh.commit();
-
-    expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("shared-event");
-    expect(mockGetActiveCurtailment).toHaveBeenCalledTimes(1);
-  });
-
   it("starts a fresh request after all shared request subscribers abort", async () => {
     mockGetActiveCurtailment
       .mockImplementationOnce(
@@ -113,12 +88,14 @@ describe("activeCurtailmentData", () => {
     ["restoring", CurtailmentEventState.RESTORING],
     ["restored", CurtailmentEventState.COMPLETED],
     ["incomplete restore", CurtailmentEventState.COMPLETED_WITH_FAILURES],
-  ])("preserves a %s curtailment when active polling briefly returns empty", async (eventUuid, state) => {
+  ])("preserves a %s curtailment for one empty active response", async (eventUuid, state) => {
     applyActiveCurtailmentEvent(curtailmentEvent(eventUuid, state));
     mockGetActiveCurtailment.mockResolvedValue({ event: undefined });
 
     await refreshActiveCurtailmentData();
-
     expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe(eventUuid);
+
+    await refreshActiveCurtailmentData();
+    expect(getActiveCurtailmentSnapshot().event).toBeUndefined();
   });
 });

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -205,7 +205,6 @@ export function resetActiveCurtailmentData(): void {
   inFlightActiveCurtailmentRequest = null;
   dismissedEventUuid = null;
   emptyActiveRefreshCount = 0;
-  nextWriteVersion = 0;
-  appliedWriteVersion = 0;
-  useActiveCurtailmentDataStore.setState(initialStoreState, true);
+  appliedWriteVersion = getNextWriteVersion();
+  useActiveCurtailmentDataStore.setState({ ...initialSnapshot, version: appliedWriteVersion }, true);
 }

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -1,13 +1,14 @@
-import { create as createMessage } from "@bufbuild/protobuf";
+import { create as createMessage, equals } from "@bufbuild/protobuf";
 import { create as createStore } from "zustand";
 
 import { curtailmentClient } from "@/protoFleet/api/clients";
 import {
+  CurtailmentEventSchema,
   CurtailmentEventState,
   GetActiveCurtailmentRequestSchema,
   type CurtailmentEvent as ProtoCurtailmentEvent,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
-import { assertNotAborted } from "@/protoFleet/api/requestErrors";
+import { assertNotAborted, isAbortError } from "@/protoFleet/api/requestErrors";
 
 export interface ActiveCurtailmentSnapshot {
   event: ProtoCurtailmentEvent | undefined;
@@ -21,10 +22,6 @@ export interface PendingActiveCurtailmentRefresh extends ActiveCurtailmentSnapsh
   commit: () => ActiveCurtailmentSnapshot;
 }
 
-interface ActiveCurtailmentDataStore extends ActiveCurtailmentSnapshot {
-  version: number;
-}
-
 interface InFlightActiveCurtailmentRequest {
   abortController: AbortController;
   promise: Promise<ActiveCurtailmentSnapshot>;
@@ -33,12 +30,8 @@ interface InFlightActiveCurtailmentRequest {
 }
 
 const initialSnapshot: ActiveCurtailmentSnapshot = { event: undefined };
-const initialStoreState: ActiveCurtailmentDataStore = {
-  ...initialSnapshot,
-  version: 0,
-};
 
-const useActiveCurtailmentDataStore = createStore<ActiveCurtailmentDataStore>(() => initialStoreState);
+const useActiveCurtailmentDataStore = createStore<ActiveCurtailmentSnapshot>(() => initialSnapshot);
 
 let nextWriteVersion = 0;
 let appliedWriteVersion = 0;
@@ -51,6 +44,17 @@ const preservedEmptyActiveRefreshLimit = 1;
 function getNextWriteVersion(): number {
   nextWriteVersion += 1;
   return nextWriteVersion;
+}
+
+function areActiveCurtailmentSnapshotsEqual(
+  current: ActiveCurtailmentSnapshot,
+  next: ActiveCurtailmentSnapshot,
+): boolean {
+  if (!current.event || !next.event) {
+    return current.event === next.event;
+  }
+
+  return equals(CurtailmentEventSchema, current.event, next.event);
 }
 
 function setActiveCurtailmentSnapshot(
@@ -67,8 +71,17 @@ function setActiveCurtailmentSnapshot(
     dismissedEventUuid = null;
   }
 
+  if (!snapshot.event) {
+    emptyActiveRefreshCount = 0;
+  }
+
   appliedWriteVersion = writeVersion;
-  useActiveCurtailmentDataStore.setState({ event: snapshot.event, version: writeVersion });
+  const currentSnapshot = getActiveCurtailmentSnapshot();
+  if (areActiveCurtailmentSnapshotsEqual(currentSnapshot, snapshot)) {
+    return currentSnapshot;
+  }
+
+  useActiveCurtailmentDataStore.setState(snapshot);
   return snapshot;
 }
 
@@ -131,6 +144,13 @@ function getInFlightActiveCurtailmentRequest(): InFlightActiveCurtailmentRequest
     promise: curtailmentClient
       .getActiveCurtailment(createMessage(GetActiveCurtailmentRequestSchema, {}), { signal: abortController.signal })
       .then((response) => getActiveCurtailmentSnapshotFromResponse(response.event))
+      .catch((error) => {
+        if (isAbortError(error, abortController.signal)) {
+          throw new DOMException("The operation was aborted.", "AbortError");
+        }
+
+        throw error;
+      })
       .finally(() => {
         request.settled = true;
         if (inFlightActiveCurtailmentRequest === request) {
@@ -206,5 +226,5 @@ export function resetActiveCurtailmentData(): void {
   dismissedEventUuid = null;
   emptyActiveRefreshCount = 0;
   appliedWriteVersion = getNextWriteVersion();
-  useActiveCurtailmentDataStore.setState({ ...initialSnapshot, version: appliedWriteVersion }, true);
+  useActiveCurtailmentDataStore.setState(initialSnapshot, true);
 }

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -54,14 +54,14 @@ function setActiveCurtailmentSnapshot(
   snapshot: ActiveCurtailmentSnapshot,
   writeVersion = getNextWriteVersion(),
 ): ActiveCurtailmentSnapshot {
+  if (writeVersion < appliedWriteVersion) {
+    return getActiveCurtailmentSnapshot();
+  }
+
   if (snapshot.event?.eventUuid && snapshot.event.eventUuid === dismissedEventUuid) {
     snapshot = initialSnapshot;
   } else if (snapshot.event?.eventUuid) {
     dismissedEventUuid = null;
-  }
-
-  if (writeVersion < appliedWriteVersion) {
-    return getActiveCurtailmentSnapshot();
   }
 
   appliedWriteVersion = writeVersion;
@@ -134,6 +134,9 @@ function getInFlightActiveCurtailmentRequest(): InFlightActiveCurtailmentRequest
 function releaseActiveCurtailmentRequestSubscriber(request: InFlightActiveCurtailmentRequest): void {
   request.subscribers = Math.max(0, request.subscribers - 1);
   if (request.subscribers === 0 && !request.settled) {
+    if (inFlightActiveCurtailmentRequest === request) {
+      inFlightActiveCurtailmentRequest = null;
+    }
     request.abortController.abort();
   }
 }

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -1,0 +1,195 @@
+import { create as createMessage } from "@bufbuild/protobuf";
+import { create as createStore } from "zustand";
+
+import { curtailmentClient } from "@/protoFleet/api/clients";
+import {
+  CurtailmentEventState,
+  GetActiveCurtailmentRequestSchema,
+  type CurtailmentEvent as ProtoCurtailmentEvent,
+} from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
+import { assertNotAborted } from "@/protoFleet/api/requestErrors";
+
+export interface ActiveCurtailmentSnapshot {
+  event: ProtoCurtailmentEvent | undefined;
+}
+
+export interface RefreshActiveCurtailmentOptions {
+  signal?: AbortSignal;
+}
+
+export interface PendingActiveCurtailmentRefresh extends ActiveCurtailmentSnapshot {
+  commit: () => ActiveCurtailmentSnapshot;
+}
+
+interface ActiveCurtailmentDataStore extends ActiveCurtailmentSnapshot {
+  version: number;
+}
+
+interface InFlightActiveCurtailmentRequest {
+  abortController: AbortController;
+  promise: Promise<ActiveCurtailmentSnapshot>;
+  settled: boolean;
+  subscribers: number;
+}
+
+const initialSnapshot: ActiveCurtailmentSnapshot = { event: undefined };
+const initialStoreState: ActiveCurtailmentDataStore = {
+  ...initialSnapshot,
+  version: 0,
+};
+
+const useActiveCurtailmentDataStore = createStore<ActiveCurtailmentDataStore>(() => initialStoreState);
+
+let nextWriteVersion = 0;
+let appliedWriteVersion = 0;
+let inFlightActiveCurtailmentRequest: InFlightActiveCurtailmentRequest | null = null;
+let dismissedEventUuid: string | null = null;
+
+function getNextWriteVersion(): number {
+  nextWriteVersion += 1;
+  return nextWriteVersion;
+}
+
+function setActiveCurtailmentSnapshot(
+  snapshot: ActiveCurtailmentSnapshot,
+  writeVersion = getNextWriteVersion(),
+): ActiveCurtailmentSnapshot {
+  if (snapshot.event?.eventUuid && snapshot.event.eventUuid === dismissedEventUuid) {
+    snapshot = initialSnapshot;
+  } else if (snapshot.event?.eventUuid) {
+    dismissedEventUuid = null;
+  }
+
+  if (writeVersion < appliedWriteVersion) {
+    return getActiveCurtailmentSnapshot();
+  }
+
+  appliedWriteVersion = writeVersion;
+  useActiveCurtailmentDataStore.setState({ event: snapshot.event, version: writeVersion });
+  return snapshot;
+}
+
+export function getActiveCurtailmentSnapshot(): ActiveCurtailmentSnapshot {
+  const { event } = useActiveCurtailmentDataStore.getState();
+  return { event };
+}
+
+export function useActiveCurtailmentEvent(): ProtoCurtailmentEvent | undefined {
+  return useActiveCurtailmentDataStore((state) => state.event);
+}
+
+export function applyActiveCurtailmentEvent(event?: ProtoCurtailmentEvent): ActiveCurtailmentSnapshot {
+  return setActiveCurtailmentSnapshot({ event });
+}
+
+export function dismissActiveCurtailmentEvent(eventUuid?: string | null): ActiveCurtailmentSnapshot {
+  dismissedEventUuid = eventUuid ?? getActiveCurtailmentSnapshot().event?.eventUuid ?? null;
+  return setActiveCurtailmentSnapshot(initialSnapshot);
+}
+
+function shouldPreserveCurrentActiveCurtailmentEvent(event: ProtoCurtailmentEvent): boolean {
+  return (
+    event.state === CurtailmentEventState.RESTORING ||
+    event.state === CurtailmentEventState.COMPLETED ||
+    event.state === CurtailmentEventState.COMPLETED_WITH_FAILURES
+  );
+}
+
+function getActiveCurtailmentSnapshotFromResponse(event?: ProtoCurtailmentEvent): ActiveCurtailmentSnapshot {
+  if (event) {
+    return { event };
+  }
+
+  const currentSnapshot = getActiveCurtailmentSnapshot();
+  return currentSnapshot.event && shouldPreserveCurrentActiveCurtailmentEvent(currentSnapshot.event)
+    ? currentSnapshot
+    : initialSnapshot;
+}
+
+function getInFlightActiveCurtailmentRequest(): InFlightActiveCurtailmentRequest {
+  if (inFlightActiveCurtailmentRequest) {
+    return inFlightActiveCurtailmentRequest;
+  }
+
+  const abortController = new AbortController();
+  const request: InFlightActiveCurtailmentRequest = {
+    abortController,
+    settled: false,
+    subscribers: 0,
+    promise: curtailmentClient
+      .getActiveCurtailment(createMessage(GetActiveCurtailmentRequestSchema, {}), { signal: abortController.signal })
+      .then((response) => getActiveCurtailmentSnapshotFromResponse(response.event))
+      .finally(() => {
+        request.settled = true;
+        if (inFlightActiveCurtailmentRequest === request) {
+          inFlightActiveCurtailmentRequest = null;
+        }
+      }),
+  };
+
+  inFlightActiveCurtailmentRequest = request;
+  return request;
+}
+
+function releaseActiveCurtailmentRequestSubscriber(request: InFlightActiveCurtailmentRequest): void {
+  request.subscribers = Math.max(0, request.subscribers - 1);
+  if (request.subscribers === 0 && !request.settled) {
+    request.abortController.abort();
+  }
+}
+
+async function requestActiveCurtailmentSnapshot(signal?: AbortSignal): Promise<ActiveCurtailmentSnapshot> {
+  assertNotAborted(signal);
+
+  const request = getInFlightActiveCurtailmentRequest();
+  request.subscribers += 1;
+  let released = false;
+
+  const releaseSubscriber = (): void => {
+    if (released) {
+      return;
+    }
+
+    released = true;
+    releaseActiveCurtailmentRequestSubscriber(request);
+  };
+  const handleAbort = (): void => releaseSubscriber();
+  signal?.addEventListener("abort", handleAbort, { once: true });
+
+  try {
+    const snapshot = await request.promise;
+    assertNotAborted(signal);
+    return snapshot;
+  } finally {
+    signal?.removeEventListener("abort", handleAbort);
+    releaseSubscriber();
+  }
+}
+
+export async function fetchActiveCurtailmentData({
+  signal,
+}: RefreshActiveCurtailmentOptions = {}): Promise<PendingActiveCurtailmentRefresh> {
+  assertNotAborted(signal);
+  const writeVersion = getNextWriteVersion();
+  const snapshot = await requestActiveCurtailmentSnapshot(signal);
+  return {
+    ...snapshot,
+    commit: () => setActiveCurtailmentSnapshot(snapshot, writeVersion),
+  };
+}
+
+export async function refreshActiveCurtailmentData(
+  options: RefreshActiveCurtailmentOptions = {},
+): Promise<ActiveCurtailmentSnapshot> {
+  const refresh = await fetchActiveCurtailmentData(options);
+  return refresh.commit();
+}
+
+export function resetActiveCurtailmentData(): void {
+  inFlightActiveCurtailmentRequest?.abortController.abort();
+  inFlightActiveCurtailmentRequest = null;
+  dismissedEventUuid = null;
+  nextWriteVersion = 0;
+  appliedWriteVersion = 0;
+  useActiveCurtailmentDataStore.setState(initialStoreState, true);
+}

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -44,6 +44,9 @@ let nextWriteVersion = 0;
 let appliedWriteVersion = 0;
 let inFlightActiveCurtailmentRequest: InFlightActiveCurtailmentRequest | null = null;
 let dismissedEventUuid: string | null = null;
+let emptyActiveRefreshCount = 0;
+
+const preservedEmptyActiveRefreshLimit = 1;
 
 function getNextWriteVersion(): number {
   nextWriteVersion += 1;
@@ -97,13 +100,22 @@ function shouldPreserveCurrentActiveCurtailmentEvent(event: ProtoCurtailmentEven
 
 function getActiveCurtailmentSnapshotFromResponse(event?: ProtoCurtailmentEvent): ActiveCurtailmentSnapshot {
   if (event) {
+    emptyActiveRefreshCount = 0;
     return { event };
   }
 
   const currentSnapshot = getActiveCurtailmentSnapshot();
-  return currentSnapshot.event && shouldPreserveCurrentActiveCurtailmentEvent(currentSnapshot.event)
-    ? currentSnapshot
-    : initialSnapshot;
+  if (
+    currentSnapshot.event &&
+    shouldPreserveCurrentActiveCurtailmentEvent(currentSnapshot.event) &&
+    emptyActiveRefreshCount < preservedEmptyActiveRefreshLimit
+  ) {
+    emptyActiveRefreshCount += 1;
+    return currentSnapshot;
+  }
+
+  emptyActiveRefreshCount = 0;
+  return initialSnapshot;
 }
 
 function getInFlightActiveCurtailmentRequest(): InFlightActiveCurtailmentRequest {
@@ -192,6 +204,7 @@ export function resetActiveCurtailmentData(): void {
   inFlightActiveCurtailmentRequest?.abortController.abort();
   inFlightActiveCurtailmentRequest = null;
   dismissedEventUuid = null;
+  emptyActiveRefreshCount = 0;
   nextWriteVersion = 0;
   appliedWriteVersion = 0;
   useActiveCurtailmentDataStore.setState(initialStoreState, true);

--- a/client/src/protoFleet/api/useLogin.ts
+++ b/client/src/protoFleet/api/useLogin.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 
+import { resetActiveCurtailmentData } from "@/protoFleet/api/activeCurtailmentData";
 import { authClient } from "@/protoFleet/api/clients";
 import type { AuthenticateRequest } from "@/protoFleet/api/generated/auth/v1/auth_pb";
 import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
@@ -47,6 +48,7 @@ const useLogin = () => {
 
           // Session cookie is automatically stored by browser
           // We just track the expiry and user info in state
+          resetActiveCurtailmentData();
           setSessionExpiry(new Date(Number(sessionExpiry) * 1000));
           setIsAuthenticated(true);
           setUsername(userInfo.username);

--- a/client/src/protoFleet/api/useLogin.ts
+++ b/client/src/protoFleet/api/useLogin.ts
@@ -48,7 +48,9 @@ const useLogin = () => {
 
           // Session cookie is automatically stored by browser
           // We just track the expiry and user info in state
-          resetActiveCurtailmentData();
+          if (!skipLogoutOnError) {
+            resetActiveCurtailmentData();
+          }
           setSessionExpiry(new Date(Number(sessionExpiry) * 1000));
           setIsAuthenticated(true);
           setUsername(userInfo.username);

--- a/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.test.tsx
@@ -9,12 +9,6 @@ import {
   type CurtailmentEvent,
   CurtailmentEventSchema,
   CurtailmentEventState,
-  CurtailmentMode,
-  CurtailmentTargetRollupSchema,
-  CurtailmentTargetSchema,
-  CurtailmentTargetState,
-  FixedKwParamsSchema,
-  ScopeWholeOrgSchema,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import { useCurtailmentPillData } from "@/protoFleet/components/PageHeader/useCurtailmentPillData";
 
@@ -35,33 +29,12 @@ vi.mock("@/protoFleet/store", () => ({
   }),
 }));
 
-function curtailmentEvent(overrides: Partial<CurtailmentEvent> = {}): CurtailmentEvent {
-  const event = create(CurtailmentEventSchema, {
+function curtailmentEvent(): CurtailmentEvent {
+  return create(CurtailmentEventSchema, {
     eventUuid: "curt-1",
     reason: "Grid peak call",
     state: CurtailmentEventState.ACTIVE,
-    mode: CurtailmentMode.FIXED_KW,
-    scope: {
-      case: "wholeOrg",
-      value: create(ScopeWholeOrgSchema, {}),
-    },
-    modeParams: {
-      case: "fixedKw",
-      value: create(FixedKwParamsSchema, { targetKw: 126.4 }),
-    },
-    targetRollup: create(CurtailmentTargetRollupSchema, {
-      dispatched: 48,
-      total: 48,
-    }),
-    targets: [
-      create(CurtailmentTargetSchema, {
-        state: CurtailmentTargetState.DISPATCHED,
-        baselinePowerW: 126_400,
-      }),
-    ],
   });
-
-  return Object.assign(event, overrides);
 }
 
 describe("useCurtailmentPillData", () => {

--- a/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.test.tsx
@@ -167,6 +167,32 @@ describe("useCurtailmentPillData", () => {
     expect(curtailmentClient.getActiveCurtailment).toHaveBeenCalledTimes(2);
   });
 
+  it("clears the cached active event when a refresh fails", async () => {
+    mockHandleAuthErrors.mockImplementation(({ onError }: { onError?: (error: unknown) => void }) => {
+      onError?.(new Error("load failed"));
+    });
+    mockGetActiveCurtailment
+      .mockResolvedValueOnce({ event: curtailmentEvent() })
+      .mockRejectedValueOnce(new Error("load failed"));
+
+    const { result } = renderHook(() => useCurtailmentPillData());
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    await act(async () => {});
+
+    expect(result.current.activeEvent?.reason).toBe("Grid peak call");
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent(CURTAILMENT_CHANGED_EVENT));
+      await Promise.resolve();
+    });
+
+    expect(result.current.activeEvent).toBeNull();
+    expect(mockHandleAuthErrors).toHaveBeenCalledOnce();
+  });
+
   it("queues a fresh refresh when curtailment changes during an in-flight poll", async () => {
     let resolveFirstRequest: (value: { event: CurtailmentEvent }) => void = () => {};
     let resolveSecondRequest: (value: { event: CurtailmentEvent }) => void = () => {};

--- a/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.test.tsx
@@ -1,15 +1,26 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
 
-import type { CurtailmentPillEvent } from "./curtailmentPillTypes";
+import { resetActiveCurtailmentData } from "@/protoFleet/api/activeCurtailmentData";
 import { curtailmentClient } from "@/protoFleet/api/clients";
 import { CURTAILMENT_CHANGED_EVENT } from "@/protoFleet/api/curtailmentEvents";
+import {
+  type CurtailmentEvent,
+  CurtailmentEventSchema,
+  CurtailmentEventState,
+  CurtailmentMode,
+  CurtailmentTargetRollupSchema,
+  CurtailmentTargetSchema,
+  CurtailmentTargetState,
+  FixedKwParamsSchema,
+  ScopeWholeOrgSchema,
+} from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import { useCurtailmentPillData } from "@/protoFleet/components/PageHeader/useCurtailmentPillData";
 
-const { mockGetActiveCurtailment, mockHandleAuthErrors, mockMapCurtailmentPillEvent } = vi.hoisted(() => ({
+const { mockGetActiveCurtailment, mockHandleAuthErrors } = vi.hoisted(() => ({
   mockGetActiveCurtailment: vi.fn(),
   mockHandleAuthErrors: vi.fn(),
-  mockMapCurtailmentPillEvent: vi.fn(),
 }));
 
 vi.mock("@/protoFleet/api/clients", () => ({
@@ -24,23 +35,40 @@ vi.mock("@/protoFleet/store", () => ({
   }),
 }));
 
-vi.mock("./curtailmentPillMapper", () => ({
-  mapCurtailmentPillEvent: mockMapCurtailmentPillEvent,
-}));
+function curtailmentEvent(overrides: Partial<CurtailmentEvent> = {}): CurtailmentEvent {
+  const event = create(CurtailmentEventSchema, {
+    eventUuid: "curt-1",
+    reason: "Grid peak call",
+    state: CurtailmentEventState.ACTIVE,
+    mode: CurtailmentMode.FIXED_KW,
+    scope: {
+      case: "wholeOrg",
+      value: create(ScopeWholeOrgSchema, {}),
+    },
+    modeParams: {
+      case: "fixedKw",
+      value: create(FixedKwParamsSchema, { targetKw: 126.4 }),
+    },
+    targetRollup: create(CurtailmentTargetRollupSchema, {
+      dispatched: 48,
+      total: 48,
+    }),
+    targets: [
+      create(CurtailmentTargetSchema, {
+        state: CurtailmentTargetState.DISPATCHED,
+        baselinePowerW: 126_400,
+      }),
+    ],
+  });
 
-const activeCurtailmentEvent: CurtailmentPillEvent = {
-  reason: "Grid peak call",
-  state: "active",
-  scopeLabel: "Whole fleet",
-  selectedMiners: 48,
-  estimatedReductionKw: 126.4,
-};
+  return Object.assign(event, overrides);
+}
 
 describe("useCurtailmentPillData", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    resetActiveCurtailmentData();
     vi.clearAllMocks();
-    mockMapCurtailmentPillEvent.mockReturnValue(activeCurtailmentEvent);
   });
 
   afterEach(() => {
@@ -48,10 +76,10 @@ describe("useCurtailmentPillData", () => {
   });
 
   it("does not start overlapping polling requests", async () => {
-    let resolveRequest: (value: { event: unknown }) => void = () => {};
+    let resolveRequest: (value: { event?: CurtailmentEvent }) => void = () => {};
     mockGetActiveCurtailment.mockImplementation(
       () =>
-        new Promise((resolve) => {
+        new Promise<{ event?: CurtailmentEvent }>((resolve) => {
           resolveRequest = resolve;
         }),
     );
@@ -69,12 +97,36 @@ describe("useCurtailmentPillData", () => {
     expect(curtailmentClient.getActiveCurtailment).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      resolveRequest({ event: {} });
+      resolveRequest({ event: undefined });
     });
 
     act(() => {
       vi.advanceTimersByTime(30_000);
     });
+    expect(curtailmentClient.getActiveCurtailment).toHaveBeenCalledTimes(2);
+  });
+
+  it("polls active curtailments more frequently", async () => {
+    mockGetActiveCurtailment.mockResolvedValue({ event: curtailmentEvent() });
+
+    renderHook(() => useCurtailmentPillData());
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    await act(async () => {});
+
+    expect(curtailmentClient.getActiveCurtailment).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2_999);
+    });
+    expect(curtailmentClient.getActiveCurtailment).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
     expect(curtailmentClient.getActiveCurtailment).toHaveBeenCalledTimes(2);
   });
 
@@ -96,7 +148,7 @@ describe("useCurtailmentPillData", () => {
   });
 
   it("refreshes immediately when curtailment changes", async () => {
-    mockGetActiveCurtailment.mockResolvedValue({ event: {} });
+    mockGetActiveCurtailment.mockResolvedValue({ event: curtailmentEvent() });
 
     renderHook(() => useCurtailmentPillData());
 
@@ -116,18 +168,18 @@ describe("useCurtailmentPillData", () => {
   });
 
   it("queues a fresh refresh when curtailment changes during an in-flight poll", async () => {
-    let resolveFirstRequest: (value: { event: unknown }) => void = () => {};
-    let resolveSecondRequest: (value: { event: unknown }) => void = () => {};
+    let resolveFirstRequest: (value: { event: CurtailmentEvent }) => void = () => {};
+    let resolveSecondRequest: (value: { event: CurtailmentEvent }) => void = () => {};
     mockGetActiveCurtailment
       .mockImplementationOnce(
         () =>
-          new Promise((resolve) => {
+          new Promise<{ event: CurtailmentEvent }>((resolve) => {
             resolveFirstRequest = resolve;
           }),
       )
       .mockImplementationOnce(
         () =>
-          new Promise((resolve) => {
+          new Promise<{ event: CurtailmentEvent }>((resolve) => {
             resolveSecondRequest = resolve;
           }),
       );
@@ -146,13 +198,13 @@ describe("useCurtailmentPillData", () => {
     expect(curtailmentClient.getActiveCurtailment).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      resolveFirstRequest({ event: {} });
+      resolveFirstRequest({ event: curtailmentEvent() });
       await Promise.resolve();
     });
     expect(curtailmentClient.getActiveCurtailment).toHaveBeenCalledTimes(2);
 
     await act(async () => {
-      resolveSecondRequest({ event: {} });
+      resolveSecondRequest({ event: curtailmentEvent() });
     });
   });
 });

--- a/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.ts
+++ b/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.ts
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { mapCurtailmentPillEvent } from "./curtailmentPillMapper";
 import type { CurtailmentPillEvent } from "./curtailmentPillTypes";
-import { refreshActiveCurtailmentData, useActiveCurtailmentEvent } from "@/protoFleet/api/activeCurtailmentData";
+import {
+  applyActiveCurtailmentEvent,
+  refreshActiveCurtailmentData,
+  useActiveCurtailmentEvent,
+} from "@/protoFleet/api/activeCurtailmentData";
 import { CURTAILMENT_CHANGED_EVENT } from "@/protoFleet/api/curtailmentEvents";
 import { isAbortError } from "@/protoFleet/api/requestErrors";
 import { useAuthErrors } from "@/protoFleet/store";
@@ -56,7 +60,7 @@ export function useCurtailmentPillData(): UseCurtailmentPillDataResult {
             return;
           }
 
-          handleAuthErrors({ error });
+          handleAuthErrors({ error, onError: () => applyActiveCurtailmentEvent(undefined) });
         } finally {
           inFlightRefreshRef.current = null;
         }

--- a/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.ts
+++ b/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.ts
@@ -1,11 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { create } from "@bufbuild/protobuf";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { mapCurtailmentPillEvent } from "./curtailmentPillMapper";
 import type { CurtailmentPillEvent } from "./curtailmentPillTypes";
-import { curtailmentClient } from "@/protoFleet/api/clients";
+import { refreshActiveCurtailmentData, useActiveCurtailmentEvent } from "@/protoFleet/api/activeCurtailmentData";
 import { CURTAILMENT_CHANGED_EVENT } from "@/protoFleet/api/curtailmentEvents";
-import { GetActiveCurtailmentRequestSchema } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import { isAbortError } from "@/protoFleet/api/requestErrors";
 import { useAuthErrors } from "@/protoFleet/store";
 
@@ -13,13 +11,19 @@ export interface UseCurtailmentPillDataResult {
   activeEvent: CurtailmentPillEvent | null;
 }
 
-const POLL_INTERVAL_MS = 30_000;
+const idlePollIntervalMs = 30_000;
+const activeCurtailmentPollIntervalMs = 3_000;
 
 export function useCurtailmentPillData(): UseCurtailmentPillDataResult {
   const { handleAuthErrors } = useAuthErrors();
-  const [activeEvent, setActiveEvent] = useState<CurtailmentPillEvent | null>(null);
+  const activeCurtailmentEvent = useActiveCurtailmentEvent();
+  const activeEvent = useMemo<CurtailmentPillEvent | null>(
+    () => mapCurtailmentPillEvent(activeCurtailmentEvent),
+    [activeCurtailmentEvent],
+  );
   const inFlightRefreshRef = useRef<Promise<void> | null>(null);
   const pendingFreshRefreshRef = useRef(false);
+  const pollIntervalMs = activeEvent === null ? idlePollIntervalMs : activeCurtailmentPollIntervalMs;
 
   const refreshActiveCurtailment = useCallback(
     (signal: AbortSignal, forceFresh = false): Promise<void> => {
@@ -46,23 +50,13 @@ export function useCurtailmentPillData(): UseCurtailmentPillDataResult {
       pendingFreshRefreshRef.current = false;
       const refreshPromise = (async (): Promise<void> => {
         try {
-          const response = await curtailmentClient.getActiveCurtailment(create(GetActiveCurtailmentRequestSchema, {}), {
-            signal,
-          });
-          if (signal.aborted) {
-            return;
-          }
-
-          setActiveEvent(mapCurtailmentPillEvent(response.event));
+          await refreshActiveCurtailmentData({ signal });
         } catch (error) {
           if (isAbortError(error, signal)) {
             return;
           }
 
-          handleAuthErrors({
-            error,
-            onError: () => setActiveEvent(null),
-          });
+          handleAuthErrors({ error });
         } finally {
           inFlightRefreshRef.current = null;
         }
@@ -85,16 +79,26 @@ export function useCurtailmentPillData(): UseCurtailmentPillDataResult {
     };
 
     const initialRefreshId = window.setTimeout(refresh, 0);
-    const intervalId = window.setInterval(refresh, POLL_INTERVAL_MS);
     window.addEventListener(CURTAILMENT_CHANGED_EVENT, refreshAfterCurtailmentChange);
 
     return () => {
       window.clearTimeout(initialRefreshId);
-      window.clearInterval(intervalId);
       window.removeEventListener(CURTAILMENT_CHANGED_EVENT, refreshAfterCurtailmentChange);
       abortController.abort();
     };
   }, [refreshActiveCurtailment]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    const intervalId = window.setInterval(() => {
+      void refreshActiveCurtailment(abortController.signal);
+    }, pollIntervalMs);
+
+    return () => {
+      window.clearInterval(intervalId);
+      abortController.abort();
+    };
+  }, [pollIntervalMs, refreshActiveCurtailment]);
 
   return { activeEvent };
 }

--- a/client/src/protoFleet/store/slices/authSlice.ts
+++ b/client/src/protoFleet/store/slices/authSlice.ts
@@ -69,9 +69,9 @@ export const createAuthSlice: StateCreator<FleetStore, [["zustand/immer", never]
       state.auth.temporaryPassword = password;
     }),
 
-  logout: () =>
+  logout: () => {
+    resetActiveCurtailmentData();
     set((state) => {
-      resetActiveCurtailmentData();
       state.auth.sessionExpiry = null;
       state.auth.isAuthenticated = false;
       state.auth.username = "";
@@ -83,5 +83,6 @@ export const createAuthSlice: StateCreator<FleetStore, [["zustand/immer", never]
       // scoping already prevents data exposure; this is a UX-level
       // hygiene reset.
       state.ui.activeSite = DEFAULT_ACTIVE_SITE;
-    }),
+    });
+  },
 });

--- a/client/src/protoFleet/store/slices/authSlice.ts
+++ b/client/src/protoFleet/store/slices/authSlice.ts
@@ -1,6 +1,7 @@
 import type { StateCreator } from "zustand";
 import { DEFAULT_ACTIVE_SITE } from "../types/activeSite";
 import type { FleetStore } from "../useFleetStore";
+import { resetActiveCurtailmentData } from "@/protoFleet/api/activeCurtailmentData";
 
 // =============================================================================
 // Auth Slice Interface
@@ -70,6 +71,7 @@ export const createAuthSlice: StateCreator<FleetStore, [["zustand/immer", never]
 
   logout: () =>
     set((state) => {
+      resetActiveCurtailmentData();
       state.auth.sessionExpiry = null;
       state.auth.isAuthenticated = false;
       state.auth.username = "";


### PR DESCRIPTION
🤖

## Summary
- Add a shared active curtailment data cache that coalesces active-event refreshes
- Move page-header curtailment polling onto the shared cache, including faster polling while an active event is present

## Test plan
- [ ] Run the active curtailment data and page-header polling unit tests
- [ ] Confirm this split does not include /energy route or nav menu wiring

Refs #172
Closes #337