### PR TITLE
Curtailment: add start modal control support

### DIFF
--- a/client/src/protoFleet/components/TargetSelectButton/TargetSelectButton.tsx
+++ b/client/src/protoFleet/components/TargetSelectButton/TargetSelectButton.tsx
@@ -4,14 +4,21 @@ import Row from "@/shared/components/Row";
 interface TargetSelectButtonProps {
   label: string;
   value: string;
+  disabled?: boolean;
   onClick: () => void;
 }
 
-function TargetSelectButton({ label, value, onClick }: TargetSelectButtonProps) {
+function TargetSelectButton({ label, value, disabled = false, onClick }: TargetSelectButtonProps) {
   return (
     <Row compact className="flex items-center justify-between gap-4">
       <span className="min-w-0 truncate text-emphasis-300 text-text-primary">{label}</span>
-      <Button ariaLabel={`${label} ${value}`} text={value} variant={variants.secondary} onClick={onClick} />
+      <Button
+        ariaLabel={`${label} ${value}`}
+        text={value}
+        variant={variants.secondary}
+        disabled={disabled}
+        onClick={onClick}
+      />
     </Row>
   );
 }

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -25,6 +25,17 @@ const { mockUseCurtailmentPlanPreview } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/protoFleet/features/energy/useCurtailmentPlanPreview", () => ({
+  createCurtailmentPlanPreview: (
+    values: CurtailmentFormValues,
+    source: { selectedMinerCount: number; targetKw?: number; estimatedReductionKw: number },
+  ): CurtailmentPlanPreview => ({
+    selectedMinerCount: source.selectedMinerCount,
+    targetKw: source.targetKw ?? Number(values.targetKw),
+    estimatedReductionKw: source.estimatedReductionKw,
+    curtailEstimate: "5 minutes - 30 minutes",
+    restoreEstimate: "~2 minutes",
+    scopeLabel: "across the fleet",
+  }),
   getUnsupportedDeviceSetPreviewError: (values: CurtailmentFormValues) =>
     values.scopeType === "deviceSet" && values.deviceSetIds.length > 0
       ? "Rack and group curtailment previews are not supported yet. Select specific miners or the whole fleet to preview and start this curtailment."
@@ -87,6 +98,7 @@ vi.mock("@/protoFleet/features/settings/components/Schedules/MinerSelectionModal
 
 const configuredValues: Partial<CurtailmentFormValues> = {
   targetKw: "40",
+  minDurationSec: "300",
   maxDurationSec: "1800",
   restoreBatchSize: "10",
   restoreIntervalSec: "120",
@@ -153,7 +165,7 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeEnabled();
   });
 
-  it("renders edit mode with only updateable fields prefilled", async () => {
+  it("renders edit mode with the full plan visible and locked where fields are not updateable", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
       mode: "edit",
@@ -168,14 +180,23 @@ describe("CurtailmentStartModal", () => {
     expect(screen.queryByRole("dialog", { name: "Plan a curtailment" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Start curtailment" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Reason")).toHaveValue("Grid peak - ERCOT 4CP signal");
-    expect(screen.getByLabelText("Max duration (sec)")).toHaveValue(1800);
-    expect(screen.getByLabelText("Batch interval (sec)")).toHaveValue(120);
-    expect(screen.queryByLabelText("Fixed target reduction (kW)")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Min duration (sec)")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Batch size (miners)")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Miners\s+Select/ })).not.toBeInTheDocument();
-    expect(screen.queryByText("Include miners in maintenance")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Fixed target reduction (kW)")).toHaveValue("40");
+    expect(screen.getByLabelText("Fixed target reduction (kW)")).toBeDisabled();
+    expect(screen.getByLabelText("Min duration (sec)")).toHaveValue("300");
+    expect(screen.getByLabelText("Min duration (sec)")).toBeDisabled();
+    expect(screen.getByLabelText("Max duration (sec)")).toHaveValue("1800");
+    expect(screen.getByLabelText("Max duration (sec)")).toBeEnabled();
+    expect(screen.getByLabelText("Batch size (miners)")).toHaveValue("10");
+    expect(screen.getByLabelText("Batch size (miners)")).toBeDisabled();
+    expect(screen.getByLabelText("Batch interval (sec)")).toHaveValue("120");
+    expect(screen.getByLabelText("Batch interval (sec)")).toBeEnabled();
+    expect(screen.getByRole("button", { name: /Miners\s+18 miners/ })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /Miners\s+Whole fleet/ })).not.toBeInTheDocument();
+    expect(screen.getByText("Include miners in maintenance")).toBeInTheDocument();
+    expect(getMaintenanceCheckbox()).toBeDisabled();
     expect(screen.queryByText("Configure your curtailment to see a preview.")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Curtail 18 miners across the fleet immediately")).toHaveLength(2);
+    expect(screen.getAllByText("45.0 kW of 40.0 kW")).toHaveLength(2);
     expect(mockUseCurtailmentPlanPreview).toHaveBeenCalledWith(
       expect.objectContaining({
         disabled: true,
@@ -230,7 +251,7 @@ describe("CurtailmentStartModal", () => {
     );
 
     expect(screen.getByLabelText("Reason")).toHaveValue("Operator draft");
-    expect(screen.getByLabelText("Batch interval (sec)")).toHaveValue(120);
+    expect(screen.getByLabelText("Batch interval (sec)")).toHaveValue("120");
   });
 
   it("blocks max duration clears in edit mode", async () => {
@@ -606,19 +627,26 @@ describe("CurtailmentStartModal", () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
       initialValues: {
+        ...configuredValues,
         includeMaintenance: false,
         minDurationSec: "3600",
-        maxDurationSec: "300",
+        maxDurationSec: "7200",
       },
       errors: {
         maxDurationSec: "Server-side max duration error",
       },
     });
     const startButton = screen.getByRole("button", { name: "Start curtailment" });
+    const maxDurationInput = screen.getByLabelText("Max duration (sec)");
+
+    expect(screen.getByText("Server-side max duration error")).toBeInTheDocument();
+
+    await user.clear(maxDurationInput);
+    await user.type(maxDurationInput, "300");
 
     expect(screen.getByText("Max duration must be greater than or equal to min duration.")).toBeInTheDocument();
     expect(screen.queryByText("Server-side max duration error")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Max duration (sec)")).toHaveAttribute("aria-invalid", "true");
+    expect(maxDurationInput).toHaveAttribute("aria-invalid", "true");
     expect(startButton).toBeDisabled();
 
     await user.click(startButton);
@@ -631,19 +659,26 @@ describe("CurtailmentStartModal", () => {
       initialValues: {
         ...configuredValues,
         includeMaintenance: false,
-        maxDurationSec: "604801",
-        restoreBatchSize: "-1",
-        restoreIntervalSec: "1.5",
       },
     });
     const startButton = screen.getByRole("button", { name: "Start curtailment" });
+    const maxDurationInput = screen.getByLabelText("Max duration (sec)");
+    const batchSizeInput = screen.getByLabelText("Batch size (miners)");
+    const batchIntervalInput = screen.getByLabelText("Batch interval (sec)");
+
+    await user.clear(maxDurationInput);
+    await user.type(maxDurationInput, "604801");
+    await user.clear(batchSizeInput);
+    await user.type(batchSizeInput, "10001");
+    await user.clear(batchIntervalInput);
+    await user.type(batchIntervalInput, "1.5");
 
     expect(screen.getByText("Enter max duration of 604,800 or less.")).toBeInTheDocument();
-    expect(screen.getByText("Enter batch size of 0 or more.")).toBeInTheDocument();
+    expect(screen.getByText("Enter batch size of 10,000 or less.")).toBeInTheDocument();
     expect(screen.getByText("Enter batch interval as a whole number.")).toBeInTheDocument();
-    expect(screen.getByLabelText("Max duration (sec)")).toHaveAttribute("aria-invalid", "true");
-    expect(screen.getByLabelText("Batch size (miners)")).toHaveAttribute("aria-invalid", "true");
-    expect(screen.getByLabelText("Batch interval (sec)")).toHaveAttribute("aria-invalid", "true");
+    expect(maxDurationInput).toHaveAttribute("aria-invalid", "true");
+    expect(batchSizeInput).toHaveAttribute("aria-invalid", "true");
+    expect(batchIntervalInput).toHaveAttribute("aria-invalid", "true");
     expect(startButton).toBeDisabled();
 
     await user.click(startButton);
@@ -666,7 +701,7 @@ describe("CurtailmentStartModal", () => {
     const targetInput = screen.getByLabelText("Fixed target reduction (kW)");
     await user.clear(targetInput);
     await user.type(targetInput, "99");
-    expect(targetInput).toHaveValue(99);
+    expect(targetInput).toHaveValue("99");
 
     rerender(
       <CurtailmentStartModal
@@ -686,7 +721,7 @@ describe("CurtailmentStartModal", () => {
     );
 
     const updatedTargetInput = screen.getByLabelText("Fixed target reduction (kW)");
-    expect(updatedTargetInput).toHaveValue(25);
+    expect(updatedTargetInput).toHaveValue("25");
     expect(screen.getByLabelText("Reason")).toHaveValue("Updated reason");
   });
 
@@ -707,14 +742,28 @@ describe("CurtailmentStartModal", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("renders required start-field validation errors with accessible error state", () => {
+  it("keeps required start-field validation hidden until fields are edited", async () => {
+    const user = userEvent.setup();
     renderModal();
 
     const targetInput = screen.getByLabelText("Fixed target reduction (kW)");
+    const reasonInput = screen.getByLabelText("Reason");
+    const startButton = screen.getByRole("button", { name: "Start curtailment" });
+
+    expect(startButton).toBeDisabled();
+    expect(targetInput).not.toHaveAttribute("aria-invalid");
+    expect(reasonInput).not.toHaveAttribute("aria-invalid");
+    expect(screen.queryByText("Enter a target reduction.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Enter a reason.")).not.toBeInTheDocument();
+
+    await user.type(reasonInput, " ");
+    await user.type(targetInput, "5");
+    await user.clear(targetInput);
+
+    expect(reasonInput).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Enter a reason.")).toBeInTheDocument();
     expect(targetInput).toHaveAttribute("aria-invalid", "true");
     expect(targetInput).toHaveAttribute("aria-describedby", "curtailment-target-kw-error");
     expect(screen.getByText("Enter a target reduction.")).toBeInTheDocument();
-    expect(screen.getByLabelText("Reason")).toHaveAttribute("aria-invalid", "true");
-    expect(screen.getByText("Enter a reason.")).toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -173,35 +173,12 @@ describe("CurtailmentStartModal", () => {
         ...configuredValues,
         includeMaintenance: false,
       },
-      preview,
     });
 
     expect(screen.getByRole("dialog", { name: "Manage curtailment" })).toBeInTheDocument();
-    expect(screen.queryByRole("dialog", { name: "Plan a curtailment" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Start curtailment" })).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Reason")).toHaveValue("Grid peak - ERCOT 4CP signal");
-    expect(screen.getByLabelText("Fixed target reduction (kW)")).toHaveValue("40");
     expect(screen.getByLabelText("Fixed target reduction (kW)")).toBeDisabled();
-    expect(screen.getByLabelText("Min duration (sec)")).toHaveValue("300");
-    expect(screen.getByLabelText("Min duration (sec)")).toBeDisabled();
-    expect(screen.getByLabelText("Max duration (sec)")).toHaveValue("1800");
-    expect(screen.getByLabelText("Max duration (sec)")).toBeEnabled();
-    expect(screen.getByLabelText("Batch size (miners)")).toHaveValue("10");
-    expect(screen.getByLabelText("Batch size (miners)")).toBeDisabled();
-    expect(screen.getByLabelText("Batch interval (sec)")).toHaveValue("120");
-    expect(screen.getByLabelText("Batch interval (sec)")).toBeEnabled();
-    expect(screen.getByRole("button", { name: /Miners\s+18 miners/ })).toBeDisabled();
-    expect(screen.queryByRole("button", { name: /Miners\s+Whole fleet/ })).not.toBeInTheDocument();
-    expect(screen.getByText("Include miners in maintenance")).toBeInTheDocument();
-    expect(getMaintenanceCheckbox()).toBeDisabled();
-    expect(screen.queryByText("Configure your curtailment to see a preview.")).not.toBeInTheDocument();
-    expect(screen.getAllByText("Curtail 18 miners across the fleet immediately")).toHaveLength(2);
-    expect(screen.getAllByText("45.0 kW of 40.0 kW")).toHaveLength(2);
-    expect(mockUseCurtailmentPlanPreview).toHaveBeenCalledWith(
-      expect.objectContaining({
-        disabled: true,
-      }),
-    );
+    expect(screen.getByRole("button", { name: /Miners\s+Whole fleet/ })).toBeDisabled();
+    expect(screen.getByText("Include miners in maintenance").closest("label")).toHaveClass("cursor-not-allowed");
 
     const saveButton = screen.getByRole("button", { name: "Save" });
     expect(saveButton).toBeDisabled();
@@ -748,11 +725,7 @@ describe("CurtailmentStartModal", () => {
 
     const targetInput = screen.getByLabelText("Fixed target reduction (kW)");
     const reasonInput = screen.getByLabelText("Reason");
-    const startButton = screen.getByRole("button", { name: "Start curtailment" });
 
-    expect(startButton).toBeDisabled();
-    expect(targetInput).not.toHaveAttribute("aria-invalid");
-    expect(reasonInput).not.toHaveAttribute("aria-invalid");
     expect(screen.queryByText("Enter a target reduction.")).not.toBeInTheDocument();
     expect(screen.queryByText("Enter a reason.")).not.toBeInTheDocument();
 

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -10,6 +10,7 @@ import {
   parseOptionalUint32Field,
 } from "@/protoFleet/features/energy/curtailmentNumericFields";
 import {
+  createCurtailmentPlanPreview,
   getUnsupportedDeviceSetPreviewError,
   useCurtailmentPlanPreview,
 } from "@/protoFleet/features/energy/useCurtailmentPlanPreview";
@@ -81,7 +82,9 @@ interface FieldProps {
   id: string;
   label: string;
   value: string;
+  disabled?: boolean;
   units?: string;
+  inputMode?: "decimal" | "numeric";
   type?: "number" | "text";
   error?: string;
   onChange: (value: string) => void;
@@ -109,6 +112,11 @@ interface PreviewStateOptions {
   controlledPreview?: PreviewPaneProps;
   isEditMode: boolean;
   unsupportedDeviceSetPreviewError?: string;
+}
+
+interface ApplyToTarget {
+  label: string;
+  value: string;
 }
 
 type ParsedNumberField = { parsed?: number; error?: string };
@@ -282,8 +290,30 @@ function validateCurtailmentFormValues(
   return localErrors;
 }
 
-function Field({ id, label, value, units, type = "number", error, onChange }: FieldProps): ReactElement {
-  return <Input id={id} label={label} initValue={value} units={units} type={type} error={error} onChange={onChange} />;
+function Field({
+  id,
+  label,
+  value,
+  disabled = false,
+  units,
+  inputMode,
+  type = "text",
+  error,
+  onChange,
+}: FieldProps): ReactElement {
+  return (
+    <Input
+      id={id}
+      label={label}
+      initValue={value}
+      disabled={disabled}
+      units={units}
+      inputMode={inputMode}
+      type={type}
+      error={error}
+      onChange={onChange}
+    />
+  );
 }
 
 function Section({ title, subtext, children }: SectionProps): ReactElement {
@@ -385,6 +415,42 @@ function getSelectedMinerIds(values: CurtailmentFormValues): string[] {
   return values.deviceIdentifiers;
 }
 
+function formatCountLabel(count: number, singular: string): string {
+  return getTargetButtonLabel(count, singular);
+}
+
+function getApplyToTarget(
+  values: CurtailmentFormValues,
+  isEditMode: boolean,
+  selectedMinerCount?: number,
+): ApplyToTarget {
+  if (!isEditMode) {
+    return {
+      label: "Miners",
+      value: getTargetButtonLabel(getSelectedMinerIds(values).length, "miner"),
+    };
+  }
+
+  if (selectedMinerCount !== undefined) {
+    return {
+      label: "Miners",
+      value: formatCountLabel(selectedMinerCount, "miner"),
+    };
+  }
+
+  if (values.scopeType === "deviceSet") {
+    return {
+      label: "Device sets",
+      value: formatCountLabel(values.deviceSetIds.length, "device set"),
+    };
+  }
+
+  return {
+    label: "Miners",
+    value: formatCountLabel(values.deviceIdentifiers.length, "miner"),
+  };
+}
+
 function getPreviewState({
   apiPreview,
   controlledPreview,
@@ -392,7 +458,7 @@ function getPreviewState({
   unsupportedDeviceSetPreviewError,
 }: PreviewStateOptions): PreviewPaneProps {
   if (isEditMode) {
-    return { preview: undefined, previewError: undefined, isPreviewLoading: false };
+    return controlledPreview ?? { preview: undefined, previewError: undefined, isPreviewLoading: false };
   }
 
   if (unsupportedDeviceSetPreviewError) {
@@ -420,19 +486,40 @@ function CurtailmentStartModalContent({
   const [maintenanceInclusionConfirmed, setMaintenanceInclusionConfirmed] = useState(false);
   const [submitAfterMaintenanceConfirmation, setSubmitAfterMaintenanceConfirmation] = useState(false);
   const [showMinerSelectionModal, setShowMinerSelectionModal] = useState(false);
-  const updateValue = <Key extends keyof CurtailmentFormValues>(key: Key, value: CurtailmentFormValues[Key]) =>
+  const [editedFields, setEditedFields] = useState<ReadonlySet<keyof CurtailmentFormValues>>(() => new Set());
+  const updateValue = <Key extends keyof CurtailmentFormValues>(key: Key, value: CurtailmentFormValues[Key]) => {
+    setEditedFields((current) => (current.has(key) ? current : new Set(current).add(key)));
     setValues((current) => ({ ...current, [key]: value }));
+  };
   const updateValues = (updater: (current: CurtailmentFormValues) => CurtailmentFormValues) => setValues(updater);
   const isEditMode = mode === "edit";
   const localErrors = useMemo(
     () => validateCurtailmentFormValues(values, mode, initialFormValues),
     [initialFormValues, mode, values],
   );
-  const effectiveErrors = { ...errors, ...localErrors };
+  const visibleLocalErrors = useMemo(() => {
+    const visibleErrors: CurtailmentFormErrors = {};
+
+    editedFields.forEach((field) => {
+      if (localErrors[field] !== undefined) {
+        visibleErrors[field] = localErrors[field];
+      }
+    });
+
+    return visibleErrors;
+  }, [editedFields, localErrors]);
+  const effectiveErrors = { ...errors, ...visibleLocalErrors };
   const unsupportedDeviceSetPreviewError = getUnsupportedDeviceSetPreviewError(values);
+  const controlledPreviewValue = preview
+    ? createCurtailmentPlanPreview(values, {
+        selectedMinerCount: preview.selectedMinerCount,
+        targetKw: preview.targetKw,
+        estimatedReductionKw: preview.estimatedReductionKw,
+      })
+    : undefined;
   const controlledPreview =
     preview !== undefined || previewError !== undefined
-      ? { preview, previewError, isPreviewLoading: false }
+      ? { preview: controlledPreviewValue, previewError, isPreviewLoading: false }
       : undefined;
   const apiPreview = useCurtailmentPlanPreview({
     open,
@@ -453,12 +540,16 @@ function CurtailmentStartModalContent({
   const hasEditableChanges = !isEditMode || hasEditableCurtailmentChanges(values, initialFormValues);
   const isSubmitDisabled = hasBlockingValidationError || !hasEditableChanges;
   const selectedMinerIds = getSelectedMinerIds(values);
-  const previewPane = isEditMode ? null : <PreviewPane {...previewState} />;
-  const paneContainerClassName = isEditMode
+  const applyToTarget = getApplyToTarget(values, isEditMode, previewState.preview?.selectedMinerCount);
+  const shouldShowPreviewPane =
+    !isEditMode || previewState.preview !== undefined || previewState.previewError !== undefined;
+  const previewPane = shouldShowPreviewPane ? <PreviewPane {...previewState} /> : null;
+  const useSinglePaneLayout = isEditMode && previewPane === null;
+  const paneContainerClassName = useSinglePaneLayout
     ? "flex min-h-[calc(100dvh-200px)] w-full flex-1 flex-col laptop:px-10"
     : undefined;
-  const primaryPaneClassName = isEditMode ? "mx-auto w-full max-w-[720px] laptop:pl-0" : undefined;
-  const secondaryPaneClassName = isEditMode
+  const primaryPaneClassName = useSinglePaneLayout ? "mx-auto w-full max-w-[720px] laptop:pl-0" : undefined;
+  const secondaryPaneClassName = useSinglePaneLayout
     ? "!hidden"
     : "!hidden !bg-transparent laptop:!flex laptop:!pl-0 laptop:!rounded-[24px]";
 
@@ -546,110 +637,94 @@ function CurtailmentStartModalContent({
               onChange={(value) => updateValue("reason", value)}
             />
 
-            {isEditMode ? (
-              <Section title="Curtail behavior">
+            <Section
+              title="Curtail behavior"
+              subtext={isEditMode ? undefined : "Fleet will automatically curtail the least efficient miners first."}
+            >
+              <div className="grid gap-3">
                 <Field
-                  id="curtailment-max-duration"
-                  label="Max duration (sec)"
-                  value={values.maxDurationSec}
-                  error={effectiveErrors.maxDurationSec}
-                  onChange={(value) => updateValue("maxDurationSec", value)}
+                  id="curtailment-target-kw"
+                  label="Fixed target reduction (kW)"
+                  value={values.targetKw}
+                  disabled={isEditMode}
+                  inputMode="decimal"
+                  error={effectiveErrors.targetKw}
+                  onChange={(value) => updateValue("targetKw", value)}
                 />
-              </Section>
-            ) : (
-              <Section
-                title="Curtail behavior"
-                subtext="Fleet will automatically curtail the least efficient miners first."
-              >
-                <div className="grid gap-3">
+                <div className="grid gap-3 tablet:grid-cols-2">
                   <Field
-                    id="curtailment-target-kw"
-                    label="Fixed target reduction (kW)"
-                    value={values.targetKw}
-                    error={effectiveErrors.targetKw}
-                    onChange={(value) => updateValue("targetKw", value)}
+                    id="curtailment-min-duration"
+                    label="Min duration (sec)"
+                    value={values.minDurationSec}
+                    disabled={isEditMode}
+                    inputMode="numeric"
+                    error={effectiveErrors.minDurationSec}
+                    onChange={(value) => updateValue("minDurationSec", value)}
                   />
-                  <div className="grid gap-3 tablet:grid-cols-2">
-                    <Field
-                      id="curtailment-min-duration"
-                      label="Min duration (sec)"
-                      value={values.minDurationSec}
-                      error={effectiveErrors.minDurationSec}
-                      onChange={(value) => updateValue("minDurationSec", value)}
-                    />
-                    <Field
-                      id="curtailment-max-duration"
-                      label="Max duration (sec)"
-                      value={values.maxDurationSec}
-                      error={effectiveErrors.maxDurationSec}
-                      onChange={(value) => updateValue("maxDurationSec", value)}
-                    />
-                  </div>
+                  <Field
+                    id="curtailment-max-duration"
+                    label="Max duration (sec)"
+                    value={values.maxDurationSec}
+                    inputMode="numeric"
+                    error={effectiveErrors.maxDurationSec}
+                    onChange={(value) => updateValue("maxDurationSec", value)}
+                  />
                 </div>
-              </Section>
-            )}
+              </div>
+            </Section>
 
             <Section title="Restore behavior">
-              {isEditMode ? (
+              <div className="grid gap-3 tablet:grid-cols-2">
+                <Field
+                  id="curtailment-restore-batch-size"
+                  label="Batch size (miners)"
+                  value={values.restoreBatchSize}
+                  disabled={isEditMode}
+                  inputMode="numeric"
+                  error={effectiveErrors.restoreBatchSize}
+                  onChange={(value) => updateValue("restoreBatchSize", value)}
+                />
                 <Field
                   id="curtailment-restore-batch-interval"
                   label="Batch interval (sec)"
                   value={values.restoreIntervalSec}
+                  inputMode="numeric"
                   error={effectiveErrors.restoreIntervalSec}
                   onChange={(value) => updateValue("restoreIntervalSec", value)}
                 />
-              ) : (
-                <div className="grid gap-3 tablet:grid-cols-2">
-                  <Field
-                    id="curtailment-restore-batch-size"
-                    label="Batch size (miners)"
-                    value={values.restoreBatchSize}
-                    error={effectiveErrors.restoreBatchSize}
-                    onChange={(value) => updateValue("restoreBatchSize", value)}
-                  />
-                  <Field
-                    id="curtailment-restore-batch-interval"
-                    label="Batch interval (sec)"
-                    value={values.restoreIntervalSec}
-                    error={effectiveErrors.restoreIntervalSec}
-                    onChange={(value) => updateValue("restoreIntervalSec", value)}
-                  />
-                </div>
-              )}
+              </div>
             </Section>
 
-            {isEditMode ? null : (
-              <>
-                <Section title="Apply to">
-                  <div className="grid">
-                    <TargetSelectButton
-                      label="Miners"
-                      value={getTargetButtonLabel(selectedMinerIds.length, "miner")}
-                      onClick={() => setShowMinerSelectionModal(true)}
-                    />
-                  </div>
-                </Section>
+            <Section title="Apply to">
+              <div className="grid">
+                <TargetSelectButton
+                  label={applyToTarget.label}
+                  value={applyToTarget.value}
+                  disabled={isEditMode}
+                  onClick={() => setShowMinerSelectionModal(true)}
+                />
+              </div>
+            </Section>
 
-                <label className="flex cursor-pointer items-start gap-3 text-left">
-                  <Checkbox
-                    checked={values.includeMaintenance}
-                    onChange={(event) => {
-                      if (event.currentTarget.checked) {
-                        setSubmitAfterMaintenanceConfirmation(false);
-                        setShowMaintenanceConfirmation(true);
-                        return;
-                      }
+            <label className="flex cursor-pointer items-start gap-3 text-left">
+              <Checkbox
+                checked={values.includeMaintenance}
+                disabled={isEditMode}
+                onChange={(event) => {
+                  if (event.currentTarget.checked) {
+                    setSubmitAfterMaintenanceConfirmation(false);
+                    setShowMaintenanceConfirmation(true);
+                    return;
+                  }
 
-                      setMaintenanceInclusionConfirmed(false);
-                      updateValue("includeMaintenance", false);
-                    }}
-                  />
-                  <span>
-                    <span className="block text-300 text-text-primary">Include miners in maintenance</span>
-                  </span>
-                </label>
-              </>
-            )}
+                  setMaintenanceInclusionConfirmed(false);
+                  updateValue("includeMaintenance", false);
+                }}
+              />
+              <span>
+                <span className="block text-300 text-text-primary">Include miners in maintenance</span>
+              </span>
+            </label>
           </section>
         }
         secondaryPane={previewPane}

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -78,18 +78,6 @@ interface CurtailmentStartModalProps {
   isSubmitting?: boolean;
 }
 
-interface FieldProps {
-  id: string;
-  label: string;
-  value: string;
-  disabled?: boolean;
-  units?: string;
-  inputMode?: "decimal" | "numeric";
-  type?: "number" | "text";
-  error?: string;
-  onChange: (value: string) => void;
-}
-
 interface SectionProps {
   title: string;
   subtext?: string;
@@ -288,32 +276,6 @@ function validateCurtailmentFormValues(
   }
 
   return localErrors;
-}
-
-function Field({
-  id,
-  label,
-  value,
-  disabled = false,
-  units,
-  inputMode,
-  type = "text",
-  error,
-  onChange,
-}: FieldProps): ReactElement {
-  return (
-    <Input
-      id={id}
-      label={label}
-      initValue={value}
-      disabled={disabled}
-      units={units}
-      inputMode={inputMode}
-      type={type}
-      error={error}
-      onChange={onChange}
-    />
-  );
 }
 
 function Section({ title, subtext, children }: SectionProps): ReactElement {
@@ -635,10 +597,10 @@ function CurtailmentStartModalContent({
         abovePanes={previewPane ? <div className="px-6 pb-6 laptop:hidden">{previewPane}</div> : null}
         primaryPane={
           <section className="flex flex-col gap-12 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
-            <Field
+            <Input
               id="curtailment-reason"
               label="Reason"
-              value={values.reason}
+              initValue={values.reason}
               type="text"
               error={effectiveErrors.reason}
               onChange={(value) => updateValue("reason", value)}
@@ -649,29 +611,29 @@ function CurtailmentStartModalContent({
               subtext={isEditMode ? undefined : "Fleet will automatically curtail the least efficient miners first."}
             >
               <div className="grid gap-3">
-                <Field
+                <Input
                   id="curtailment-target-kw"
                   label="Fixed target reduction (kW)"
-                  value={values.targetKw}
+                  initValue={values.targetKw}
                   disabled={isEditMode}
                   inputMode="decimal"
                   error={effectiveErrors.targetKw}
                   onChange={(value) => updateValue("targetKw", value)}
                 />
                 <div className="grid gap-3 tablet:grid-cols-2">
-                  <Field
+                  <Input
                     id="curtailment-min-duration"
                     label="Min duration (sec)"
-                    value={values.minDurationSec}
+                    initValue={values.minDurationSec}
                     disabled={isEditMode}
                     inputMode="numeric"
                     error={effectiveErrors.minDurationSec}
                     onChange={(value) => updateValue("minDurationSec", value)}
                   />
-                  <Field
+                  <Input
                     id="curtailment-max-duration"
                     label="Max duration (sec)"
-                    value={values.maxDurationSec}
+                    initValue={values.maxDurationSec}
                     inputMode="numeric"
                     error={effectiveErrors.maxDurationSec}
                     onChange={(value) => updateValue("maxDurationSec", value)}
@@ -682,19 +644,19 @@ function CurtailmentStartModalContent({
 
             <Section title="Restore behavior">
               <div className="grid gap-3 tablet:grid-cols-2">
-                <Field
+                <Input
                   id="curtailment-restore-batch-size"
                   label="Batch size (miners)"
-                  value={values.restoreBatchSize}
+                  initValue={values.restoreBatchSize}
                   disabled={isEditMode}
                   inputMode="numeric"
                   error={effectiveErrors.restoreBatchSize}
                   onChange={(value) => updateValue("restoreBatchSize", value)}
                 />
-                <Field
+                <Input
                   id="curtailment-restore-batch-interval"
                   label="Batch interval (sec)"
-                  value={values.restoreIntervalSec}
+                  initValue={values.restoreIntervalSec}
                   inputMode="numeric"
                   error={effectiveErrors.restoreIntervalSec}
                   onChange={(value) => updateValue("restoreIntervalSec", value)}

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -445,6 +445,13 @@ function getApplyToTarget(
     };
   }
 
+  if (values.scopeType === "wholeOrg") {
+    return {
+      label: "Miners",
+      value: "Whole fleet",
+    };
+  }
+
   return {
     label: "Miners",
     value: formatCountLabel(values.deviceIdentifiers.length, "miner"),
@@ -706,7 +713,9 @@ function CurtailmentStartModalContent({
               </div>
             </Section>
 
-            <label className="flex cursor-pointer items-start gap-3 text-left">
+            <label
+              className={`flex items-start gap-3 text-left ${isEditMode ? "cursor-not-allowed" : "cursor-pointer"}`}
+            >
               <Checkbox
                 checked={values.includeMaintenance}
                 disabled={isEditMode}

--- a/client/src/protoFleet/features/energy/useCurtailmentPlanPreview.ts
+++ b/client/src/protoFleet/features/energy/useCurtailmentPlanPreview.ts
@@ -65,10 +65,16 @@ const emptyPreviewState: CurtailmentPlanPreviewState = {
   requestKey: undefined,
 };
 
+interface CurtailmentPlanPreviewSource {
+  selectedMinerCount: number;
+  targetKw?: number;
+  estimatedReductionKw: number;
+}
+
 const emptyCandidatesPreviewError = "No miners match this curtailment.";
 
-function parseNumber(value: string, isValid: (value: number) => boolean): number | undefined {
-  const trimmed = value.trim();
+function parseNumber(value: string | undefined, isValid: (value: number) => boolean): number | undefined {
+  const trimmed = value?.trim() ?? "";
   if (trimmed === "") {
     return undefined;
   }
@@ -174,17 +180,18 @@ function formatScopeLabel(values: CurtailmentFormValues): string {
   switch (values.scopeType) {
     case "deviceSet":
       if (values.scopeId === "racks") {
-        return formatSelectedScopeLabel(values.deviceSetIds.length, "rack");
+        return formatSelectedScopeLabel(values.deviceSetIds?.length ?? 0, "rack");
       }
 
       if (values.scopeId === "groups") {
-        return formatSelectedScopeLabel(values.deviceSetIds.length, "group");
+        return formatSelectedScopeLabel(values.deviceSetIds?.length ?? 0, "group");
       }
 
-      return formatSelectedScopeLabel(values.deviceSetIds.length, "set");
+      return formatSelectedScopeLabel(values.deviceSetIds?.length ?? 0, "set");
     case "explicitMiners":
-      return formatSelectedScopeLabel(values.deviceIdentifiers.length, "miner");
+      return formatSelectedScopeLabel(values.deviceIdentifiers?.length ?? 0, "miner");
     case "wholeOrg":
+    default:
       return "across the fleet";
   }
 }
@@ -250,20 +257,38 @@ function estimateRestoreDuration(values: CurtailmentFormValues, selectedMinerCou
   return formatDurationEstimate(Math.max(restoreBatchCount - 1, 0) * restoreIntervalSec);
 }
 
+export function createCurtailmentPlanPreview(
+  values: CurtailmentFormValues,
+  source: CurtailmentPlanPreviewSource,
+): CurtailmentPlanPreview {
+  const selectedMinerCount = Number.isFinite(source.selectedMinerCount) ? source.selectedMinerCount : 0;
+  const targetKw =
+    source.targetKw !== undefined && Number.isFinite(source.targetKw)
+      ? source.targetKw
+      : (parsePositiveNumber(values.targetKw) ?? 0);
+  const estimatedReductionKw = Number.isFinite(source.estimatedReductionKw) ? source.estimatedReductionKw : targetKw;
+
+  return {
+    selectedMinerCount,
+    targetKw,
+    estimatedReductionKw,
+    curtailEstimate: estimateCurtailDuration(values),
+    restoreEstimate: estimateRestoreDuration(values, selectedMinerCount),
+    scopeLabel: formatScopeLabel(values),
+  };
+}
+
 function toCurtailmentPlanPreview(
   response: PreviewCurtailmentPlanResponse,
   values: CurtailmentFormValues,
 ): CurtailmentPlanPreview {
   const fixedKw = response.modeParams.case === "fixedKw" ? response.modeParams.value : undefined;
 
-  return {
+  return createCurtailmentPlanPreview(values, {
     selectedMinerCount: response.candidates.length,
-    targetKw: fixedKw?.targetKw ?? parsePositiveNumber(values.targetKw) ?? 0,
+    targetKw: fixedKw?.targetKw,
     estimatedReductionKw: response.estimatedReductionKw,
-    curtailEstimate: estimateCurtailDuration(values),
-    restoreEstimate: estimateRestoreDuration(values, response.candidates.length),
-    scopeLabel: formatScopeLabel(values),
-  };
+  });
 }
 
 export function useCurtailmentPlanPreview({

--- a/client/src/shared/components/Checkbox/Checkbox.test.tsx
+++ b/client/src/shared/components/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Checkbox from "@/shared/components/Checkbox";
+
+describe("Checkbox", () => {
+  it("shows the checked indicator when checked and disabled", () => {
+    render(<Checkbox checked disabled />);
+
+    const checkbox = screen.getByRole("checkbox");
+
+    expect(checkbox).toBeDisabled();
+    expect(checkbox.className).toContain("checked:bg-border-20");
+    expect(checkbox.className).not.toContain("checked:bg-core-accent-fill");
+    expect(screen.getByTestId("checkmark-icon")).toBeInTheDocument();
+  });
+});

--- a/client/src/shared/components/Checkbox/Checkbox.tsx
+++ b/client/src/shared/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from "react";
+import { type ChangeEvent, type ReactElement } from "react";
 import clsx from "clsx";
 import { Checkmark, PartialCheckmark } from "@/shared/assets/icons";
 
@@ -10,7 +10,13 @@ type CheckboxProps = {
   disabled?: boolean;
 };
 
-const Checkbox = ({ onChange, checked, partiallyChecked = false, className = "", disabled = false }: CheckboxProps) => {
+function Checkbox({
+  onChange,
+  checked,
+  partiallyChecked = false,
+  className = "",
+  disabled = false,
+}: CheckboxProps): ReactElement {
   return (
     <div className={clsx(className, "relative h-[20px] w-[20px]")}>
       <input
@@ -18,29 +24,28 @@ const Checkbox = ({ onChange, checked, partiallyChecked = false, className = "",
         checked={checked}
         onChange={onChange}
         disabled={disabled}
-        className={clsx(
-          "peer h-full w-full appearance-none rounded-sm border checked:border-transparent checked:bg-core-accent-fill",
-          {
-            "cursor-pointer border-border-20": !disabled,
-            "cursor-not-allowed border-transparent bg-border-20": disabled,
-          },
-        )}
+        className={clsx("peer h-full w-full appearance-none rounded-sm border", {
+          "cursor-pointer border-border-20 checked:border-transparent checked:bg-core-accent-fill": !disabled,
+          "cursor-not-allowed border-transparent bg-border-20 checked:bg-border-20": disabled,
+        })}
       />
-      {!disabled ? (
-        <>
-          {partiallyChecked ? (
-            <PartialCheckmark
-              className={clsx(
-                "pointer-events-none absolute top-0 block cursor-pointer rounded-sm bg-core-primary-fill/40 text-surface-base",
-              )}
-            />
-          ) : (
-            <Checkmark className="pointer-events-none absolute top-0 hidden h-full w-full text-text-contrast peer-checked:block" />
-          )}
-        </>
-      ) : null}
+      {partiallyChecked ? (
+        <PartialCheckmark
+          className={clsx("pointer-events-none absolute top-0 block rounded-sm", {
+            "cursor-pointer bg-core-primary-fill/40 text-surface-base": !disabled,
+            "cursor-not-allowed bg-border-20 text-text-primary-50": disabled,
+          })}
+        />
+      ) : (
+        <Checkmark
+          className={clsx("pointer-events-none absolute top-0 hidden h-full w-full peer-checked:block", {
+            "text-text-contrast": !disabled,
+            "text-text-primary-50": disabled,
+          })}
+        />
+      )}
     </div>
   );
-};
+}
 
 export default Checkbox;

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -1,6 +1,7 @@
 import {
   ChangeEvent,
   Fragment,
+  InputHTMLAttributes,
   KeyboardEvent,
   ReactNode,
   RefObject,
@@ -30,6 +31,7 @@ interface InputProps {
   id: string;
   initValue?: string | number;
   inputRef?: RefObject<HTMLInputElement>;
+  inputMode?: InputHTMLAttributes<HTMLInputElement>["inputMode"];
   keyboardShortcuts?: string[];
   label: string;
   maxLength?: number;
@@ -65,6 +67,7 @@ const Input = ({
   id,
   initValue = "",
   inputRef,
+  inputMode,
   keyboardShortcuts,
   label,
   maxLength,
@@ -189,6 +192,7 @@ const Input = ({
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           maxLength={maxLength}
+          inputMode={inputMode}
           // Use "new-password" to prevent browser autofill on all fields.
           // Chrome ignores autocomplete="off" for password fields as a "security feature".
           // MDN recommends "new-password" which tells browsers this is NOT a login form.


### PR DESCRIPTION
🤖

## Summary
- Add shared control support needed by the curtailment modal
- Show the full curtailment plan in edit mode while locking non-editable fields
- Keep /energy route, prefetch, and navigation exposure out of this split

## Test plan
- [ ] Review the modal in start and edit mode
- [ ] Run `cd client && /Users/negar/Development/proto-fleet/bin/npm exec -- vitest run src/shared/components/Checkbox/Checkbox.test.tsx src/protoFleet/features/energy/CurtailmentStartModal.test.tsx src/protoFleet/features/energy/useCurtailmentPlanPreview.test.ts`
- [ ] Run `cd client && /Users/negar/Development/proto-fleet/bin/npx tsc --noEmit`
- [ ] Run `cd client && /Users/negar/Development/proto-fleet/bin/npm run lint`

Closes #343