### PR TITLE
feat(authz): gate ActivityService with activity:read

### DIFF
--- a/server/internal/domain/authz/catalog.go
+++ b/server/internal/domain/authz/catalog.go
@@ -43,6 +43,10 @@ const (
 	PermSiteRead   = "site:read"
 	PermSiteManage = "site:manage"
 
+	// activity — org audit/event log. Read-only catalog; writes happen
+	// implicitly as a side effect of every gated mutation.
+	PermActivityRead = "activity:read"
+
 	// serverlog — admin server-side log viewer.
 	PermServerlogRead = "serverlog:read"
 
@@ -91,6 +95,7 @@ const (
 	ResourceMiner       = "miner"
 	ResourceRack        = "rack"
 	ResourceSite        = "site"
+	ResourceActivity    = "activity"
 	ResourceServerLog   = "serverlog"
 	ResourceCurtailment = "curtailment"
 	ResourcePool        = "pool"
@@ -140,6 +145,8 @@ var catalog = []CatalogEntry{
 
 	{PermSiteRead, "View sites and buildings.", ResourceSite},
 	{PermSiteManage, "Create, edit, and delete sites and buildings.", ResourceSite},
+
+	{PermActivityRead, "View the organization-wide activity log and export it as CSV.", ResourceActivity},
 
 	{PermServerlogRead, "View server-side logs.", ResourceServerLog},
 

--- a/server/internal/domain/authz/catalog_test.go
+++ b/server/internal/domain/authz/catalog_test.go
@@ -56,6 +56,7 @@ func TestCatalogCompleteness(t *testing.T) {
 		PermRackManage,
 		PermSiteRead,
 		PermSiteManage,
+		PermActivityRead,
 		PermServerlogRead,
 		PermCurtailmentRead,
 		PermCurtailmentManage,
@@ -111,7 +112,7 @@ func TestCatalogByResource_GroupsAndAssociates(t *testing.T) {
 	groups := CatalogByResource()
 
 	for _, resource := range []string{
-		ResourceFleet, ResourceMiner, ResourceRack, ResourceSite,
+		ResourceFleet, ResourceMiner, ResourceRack, ResourceSite, ResourceActivity,
 		ResourceServerLog, ResourceCurtailment, ResourcePool, ResourceSchedule, ResourceFleetNode,
 		ResourceAPIKey, ResourceUser, ResourceRole,
 	} {
@@ -139,6 +140,7 @@ func TestResourceOrder_MatchesCatalogDeclarationOrder(t *testing.T) {
 		ResourceMiner,
 		ResourceRack,
 		ResourceSite,
+		ResourceActivity,
 		ResourceServerLog,
 		ResourceCurtailment,
 		ResourcePool,

--- a/server/internal/handlers/activity/handler.go
+++ b/server/internal/handlers/activity/handler.go
@@ -18,8 +18,9 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/activity/v1/activityv1connect"
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	"github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
-	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 var _ activityv1connect.ActivityServiceHandler = &Handler{}
@@ -36,7 +37,7 @@ func (h *Handler) ListActivities(
 	ctx context.Context,
 	req *connect.Request[pb.ListActivitiesRequest],
 ) (*connect.Response[pb.ListActivitiesResponse], error) {
-	info, err := getSessionInfo(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermActivityRead, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +87,7 @@ func (h *Handler) ExportActivities(
 	req *connect.Request[pb.ExportActivitiesRequest],
 	stream *connect.ServerStream[pb.ExportActivitiesResponse],
 ) error {
-	info, err := getSessionInfo(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermActivityRead, authz.ResourceContext{})
 	if err != nil {
 		return err
 	}
@@ -143,7 +144,7 @@ func (h *Handler) ListActivityFilterOptions(
 	ctx context.Context,
 	_ *connect.Request[pb.ListActivityFilterOptionsRequest],
 ) (*connect.Response[pb.ListActivityFilterOptionsResponse], error) {
-	info, err := getSessionInfo(ctx)
+	info, err := middleware.RequirePermission(ctx, authz.PermActivityRead, authz.ResourceContext{})
 	if err != nil {
 		return nil, err
 	}
@@ -190,16 +191,6 @@ func contextError(ctx context.Context) fleeterror.FleetError {
 		return fleeterror.NewPlainError("deadline exceeded", connect.CodeDeadlineExceeded)
 	}
 	return fleeterror.NewCanceledError()
-}
-
-// --- session helper ---
-
-func getSessionInfo(ctx context.Context) (*session.Info, error) {
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return nil, fleeterror.NewUnauthenticatedError("authentication required")
-	}
-	return info, nil
 }
 
 // --- filter mapping ---

--- a/server/internal/handlers/activity/handler_test.go
+++ b/server/internal/handlers/activity/handler_test.go
@@ -21,10 +21,12 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/activity/v1/activityv1connect"
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	"github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
 	"github.com/block/proto-fleet/server/internal/handlers/interceptors"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 const testOrgID = int64(42)
@@ -32,13 +34,18 @@ const testOrgID = int64(42)
 var testTime = time.Date(2026, 3, 23, 21, 30, 0, 0, time.UTC)
 
 func authedCtx() context.Context {
-	return authn.SetInfo(context.Background(), &session.Info{
+	ctx := authn.SetInfo(context.Background(), &session.Info{
 		SessionID:      "sess-1",
 		UserID:         1,
 		OrganizationID: testOrgID,
 		ExternalUserID: "usr_abc",
 		Username:       "admin",
 	})
+	return middleware.WithEffectivePermissions(ctx, authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  []string{authz.PermActivityRead},
+	}}))
 }
 
 func newTestHandler(t *testing.T) (*Handler, *mocks.MockActivityStore) {

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -45,6 +45,13 @@ import (
 // glance: shrinking ProceduresPendingMigration to zero is the exit
 // criterion for retiring the legacy RequireAdmin middleware.
 var ProcedurePermissions = map[string]string{
+	// Activity log — read-only audit trail. Export is the CSV variant of
+	// the same query; filter options is the lookup endpoint that drives
+	// the UI's filter panel. All three sit on activity:read.
+	activityv1connect.ActivityServiceListActivitiesProcedure:            authz.PermActivityRead,
+	activityv1connect.ActivityServiceExportActivitiesProcedure:          authz.PermActivityRead,
+	activityv1connect.ActivityServiceListActivityFilterOptionsProcedure: authz.PermActivityRead,
+
 	// API key management — gated by RequirePermission(PermAPIKeyManage).
 	apikeyv1connect.ApiKeyServiceCreateApiKeyProcedure: authz.PermAPIKeyManage,
 	apikeyv1connect.ApiKeyServiceListApiKeysProcedure:  authz.PermAPIKeyManage,
@@ -242,13 +249,6 @@ var ProcedurePermissions = map[string]string{
 // "intentional pending entry" and "shipped without thinking about
 // authz." Reviewers should treat any growth here as a red flag.
 var ProceduresPendingMigration = map[string]string{
-	// Activity log reads — currently authenticated but ungated. Needs a
-	// new activity:read catalog key + ADMIN backfill migration; deferred
-	// from the new-gate slice.
-	activityv1connect.ActivityServiceListActivitiesProcedure:            "ungated; read-only activity log",
-	activityv1connect.ActivityServiceExportActivitiesProcedure:          "ungated; activity log CSV export",
-	activityv1connect.ActivityServiceListActivityFilterOptionsProcedure: "ungated; filter option lookup",
-
 	// Auth self-service and session procedures — caller acts on own
 	// session/identity, no separate role check needed.
 	authv1connect.AuthServiceGetUserAuditInfoProcedure:  "authenticated self-read, no role check",

--- a/server/migrations/000065_seed_activity_read_permission.down.sql
+++ b/server/migrations/000065_seed_activity_read_permission.down.sql
@@ -1,0 +1,14 @@
+-- Reverses 000065_seed_activity_read_permission.up.sql by removing
+-- activity:read from every role that holds it and then deleting the
+-- permission row itself. Rolling back the data migration cleanly is
+-- impossible without provenance tracking; the rollback path is rare/
+-- dev-only and assumes no operator has hand-granted this key to custom
+-- roles. SUPER_ADMIN will re-acquire it at the next boot via the
+-- catalog reconciler unless catalog.go is also rolled back.
+
+DELETE FROM role_permission
+WHERE permission_id IN (
+    SELECT id FROM permission WHERE key = 'activity:read'
+);
+
+DELETE FROM permission WHERE key = 'activity:read';

--- a/server/migrations/000065_seed_activity_read_permission.up.sql
+++ b/server/migrations/000065_seed_activity_read_permission.up.sql
@@ -1,0 +1,26 @@
+-- Seed the activity:read permission row and backfill it onto every
+-- existing ADMIN role. The catalog reconciler upserts new permission
+-- rows on startup but does NOT re-assert seed permissions onto
+-- already-seeded ADMIN/FIELD_TECH roles (additive mode, see
+-- reconcile.go). Without this migration, deployments upgraded from any
+-- release prior to this one would never grant ADMIN activity:read, so
+-- the newly-gated ActivityService endpoints would silently deny.
+--
+-- SUPER_ADMIN is reconciled in full mode at boot and converges on its
+-- own. FIELD_TECH does not receive activity:read by design — operators
+-- opt in via the role editor.
+
+INSERT INTO permission (key, description) VALUES
+    ('activity:read', 'View the organization-wide activity log and export it as CSV.')
+ON CONFLICT (key) DO UPDATE SET description = EXCLUDED.description;
+
+-- Scoped to roles with builtin_key='ADMIN' so operator-created custom
+-- roles aren't touched. ON CONFLICT makes this safe to replay against
+-- orgs that already hold the key.
+INSERT INTO role_permission (role_id, permission_id)
+SELECT r.id, p.id
+FROM role r, permission p
+WHERE r.builtin_key = 'ADMIN'
+  AND r.deleted_at IS NULL
+  AND p.key = 'activity:read'
+ON CONFLICT (role_id, permission_id) DO NOTHING;


### PR DESCRIPTION
## Summary

- Adds the `activity:read` catalog key and gates all three `ActivityService` RPCs (`ListActivities`, `ExportActivities`, `ListActivityFilterOptions`) with `middleware.RequirePermission`.
- Migration `000065` seeds the permission row and backfills it onto every existing `ADMIN` role.
- Drops the local `getSessionInfo` helper — `RequirePermission` now covers both the authentication check and the catalog-key check.

## Why

These three procedures were the last "ungated, authenticated read" entry in `ProceduresPendingMigration`. The activity log is the org-wide audit trail; gating it cleans up an ungated read surface in the same shape as the pools/schedules slices.

## Behavior

| RPC | Key |
|-----|-----|
| `ListActivities` | `activity:read` |
| `ExportActivities` | `activity:read` |
| `ListActivityFilterOptions` | `activity:read` |

- **`SUPER_ADMIN`** picks up the key automatically at startup via the full-mode reconciler.
- **`ADMIN`** receives the key: new orgs through `adminSeedPermissions()`, existing orgs through migration `000065`.
- **`FIELD_TECH`** does not receive `activity:read` by design; operators opt in via the role editor.

## Out of scope / follow-ups

- Activity nav guard on the client. The `/activity` route is mounted unconditionally in `navItems.ts:primaryNavItems` — FIELD_TECH and similar sessions will now hit `PermissionDenied` on the initial `ListActivities` call. Same situation as the Schedules/Pools nav gap; the proper fix needs the U9/U10 permission-key plumbing called out in the RBAC plan. Worth a follow-up.

## Test plan
- [x] `go build ./...` clean.
- [x] Catalog tests pass: `TestCatalogCompleteness`, `TestResourceOrder_*`.
- [x] Contract tests pass: `TestRPCContract_EveryRegisteredProcedureIsClassified`, `TestRPCContract_ProcedurePermissionsKeysAreInCatalog`.
- [x] Activity handler tests pass (28 cases; existing `authedCtx` now seeds `activity:read`).
- [ ] DB-backed seed/reconcile tests — run in CI.
- [ ] E2E smoke: role without `activity:read` rejects all three activity RPCs with `PermissionDenied`.