### PR TITLE
Curtailment: refine page header status pill

### DIFF
--- a/client/src/protoFleet/api/curtailmentMappers.ts
+++ b/client/src/protoFleet/api/curtailmentMappers.ts
@@ -3,16 +3,13 @@ import type { Timestamp } from "@bufbuild/protobuf/wkt";
 import {
   type CurtailmentEvent as ProtoCurtailmentEvent,
   CurtailmentPriority as ProtoCurtailmentPriority,
-  CurtailmentTargetState as ProtoCurtailmentTargetState,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
-import type {
-  ActiveCurtailmentEvent,
-  CurtailmentTargetRollup,
-} from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
+import type { ActiveCurtailmentEvent } from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
 import {
   getCurtailmentEventEstimatedReductionKw,
   getCurtailmentEventScopeLabel,
   getCurtailmentEventSelectedMinerCount,
+  getCurtailmentTargetRollups,
   mapCurtailmentEventState,
 } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 import type { CurtailmentHistoryEvent, CurtailmentPriority } from "@/protoFleet/features/energy/CurtailmentHistory";
@@ -113,60 +110,8 @@ export function mapCurtailmentPriority(priority: ProtoCurtailmentPriority): Curt
   }
 }
 
-function mapCurtailmentTargetState(state: ProtoCurtailmentTargetState): CurtailmentTargetRollup["state"] {
-  switch (state) {
-    case ProtoCurtailmentTargetState.DISPATCHING:
-    case ProtoCurtailmentTargetState.DISPATCHED:
-      return "dispatched";
-    case ProtoCurtailmentTargetState.CONFIRMED:
-      return "confirmed";
-    case ProtoCurtailmentTargetState.DRIFTED:
-      return "drifted";
-    case ProtoCurtailmentTargetState.RESOLVED:
-      return "resolved";
-    case ProtoCurtailmentTargetState.RELEASED:
-      return "released";
-    case ProtoCurtailmentTargetState.RESTORE_FAILED:
-      return "restoreFailed";
-    case ProtoCurtailmentTargetState.PENDING:
-    case ProtoCurtailmentTargetState.UNSPECIFIED:
-    default:
-      return "pending";
-  }
-}
-
 function getSourceLabel(event: ProtoCurtailmentEvent): string {
   return event.externalSource.trim() || "Manual";
-}
-
-function getRollupsFromTargets(event: ProtoCurtailmentEvent): CurtailmentTargetRollup[] {
-  const counts = new Map<CurtailmentTargetRollup["state"], number>();
-
-  for (const target of event.targets) {
-    const state = mapCurtailmentTargetState(target.state);
-    counts.set(state, (counts.get(state) ?? 0) + 1);
-  }
-
-  return Array.from(counts, ([state, count]) => ({ state, count }));
-}
-
-function getRollups(event: ProtoCurtailmentEvent): CurtailmentTargetRollup[] {
-  const rollup = event.targetRollup;
-  if (!rollup) {
-    return getRollupsFromTargets(event);
-  }
-
-  const rollups: CurtailmentTargetRollup[] = [
-    { state: "pending", count: rollup.pending },
-    { state: "dispatched", count: rollup.dispatched },
-    { state: "confirmed", count: rollup.confirmed },
-    { state: "drifted", count: rollup.drifted },
-    { state: "resolved", count: rollup.resolved },
-    { state: "released", count: rollup.released },
-    { state: "restoreFailed", count: rollup.restoreFailed },
-  ];
-
-  return rollups.filter((targetRollup) => targetRollup.count > 0);
 }
 
 function getObservedPowerSummary(event: ProtoCurtailmentEvent, estimatedReductionKw: number): ObservedPowerSummary {
@@ -209,7 +154,7 @@ export function mapActiveCurtailmentEvent(event: ProtoCurtailmentEvent): ActiveC
     remainingPowerKw: observedPowerSummary.remainingPowerKw,
     restoreBatchSize: event.effectiveBatchSize || event.restoreBatchSize,
     restoreBatchIntervalSec: event.restoreBatchIntervalSec,
-    rollups: getRollups(event),
+    rollups: getCurtailmentTargetRollups(event),
   };
 }
 

--- a/client/src/protoFleet/components/AppLayout/AppLayout.test.tsx
+++ b/client/src/protoFleet/components/AppLayout/AppLayout.test.tsx
@@ -53,7 +53,7 @@ const createSchedulePillData = (overrides: Partial<UseSchedulePillDataResult> = 
 
 const activeCurtailmentEvent: CurtailmentPillEvent = {
   reason: "Grid peak call",
-  state: "active",
+  state: "curtailing",
   scopeLabel: "Whole fleet",
   selectedMiners: 48,
   estimatedReductionKw: 126.4,

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
@@ -8,7 +8,7 @@ const triggerName = "View curtailment details for Grid peak call";
 
 const activeCurtailmentEvent: CurtailmentPillEvent = {
   reason: "Grid peak call",
-  state: "active",
+  state: "curtailing",
   scopeLabel: "Whole org",
   selectedMiners: 48,
   estimatedReductionKw: 126.4,
@@ -44,16 +44,18 @@ function getPlannedReductionText(selectedMiners: number, estimatedReductionKw: n
 }
 
 describe("CurtailmentPill", () => {
-  it("renders the current curtailment state in the trigger", () => {
-    renderCurtailmentPill({
-      event: {
-        ...activeCurtailmentEvent,
-        state: "restoring",
-      },
-    });
+  it.each([
+    ["pending", "Curtailment pending", "bg-core-accent-fill"],
+    ["curtailing", "Curtailment active", "bg-intent-warning-fill"],
+    ["curtailed", "Curtailment active", "bg-intent-warning-fill"],
+    ["restoring", "Curtailment restoring", "bg-core-accent-fill"],
+  ] as const)("renders the legacy %s curtailment state in the trigger", (state, label, dotClassName) => {
+    renderCurtailmentPill({ event: { ...activeCurtailmentEvent, state } });
 
-    expect(screen.getByRole("button", { name: triggerName })).toHaveAttribute("aria-expanded", "false");
-    expect(screen.getByText("Curtailment restoring")).toBeVisible();
+    const trigger = screen.getByRole("button", { name: triggerName });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger.querySelector(`.${dotClassName}`)).not.toBeNull();
+    expect(screen.getByText(label)).toBeVisible();
   });
 
   it("shows curtailment details in the popover", () => {
@@ -62,7 +64,7 @@ describe("CurtailmentPill", () => {
     openCurtailmentPopover();
 
     expect(screen.getByText("Grid peak call")).toBeInTheDocument();
-    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Curtailing")).toBeInTheDocument();
     expect(screen.getByText("Whole org")).toBeInTheDocument();
     expect(screen.getByText(getPlannedReductionText(48, 126.4))).toBeInTheDocument();
   });

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
@@ -1,8 +1,11 @@
+import type { ReactElement } from "react";
 import { Link } from "react-router-dom";
 
-import type { CurtailmentPillProps } from "./curtailmentPillTypes";
+import type { CurtailmentPillProps, CurtailmentPillState } from "./curtailmentPillTypes";
 import PageHeaderPopoverPill from "./PageHeaderPopoverPill";
 import {
+  activeCurtailmentDisplayStateConfigs,
+  type CurtailmentEventState,
   curtailmentEventStateConfigs,
   formatCurtailmentKw,
   formatCurtailmentSelectedMinerCount,
@@ -10,8 +13,20 @@ import {
 
 export type { CurtailmentPillEvent, CurtailmentPillProps, CurtailmentPillState } from "./curtailmentPillTypes";
 
-function CurtailmentPill({ event, detailsPath }: CurtailmentPillProps) {
-  const stateConfig = curtailmentEventStateConfigs[event.state];
+function getLegacyCurtailmentPillHeaderState(state: CurtailmentPillState): CurtailmentEventState {
+  switch (state) {
+    case "curtailing":
+    case "curtailed":
+      return "active";
+    case "pending":
+    case "restoring":
+      return state;
+  }
+}
+
+function CurtailmentPill({ event, detailsPath }: CurtailmentPillProps): ReactElement {
+  const stateConfig = activeCurtailmentDisplayStateConfigs[event.state];
+  const headerStateConfig = curtailmentEventStateConfigs[getLegacyCurtailmentPillHeaderState(event.state)];
   const plannedReductionDetail = `${formatCurtailmentSelectedMinerCount(event.selectedMiners)} - ${formatCurtailmentKw(
     event.estimatedReductionKw,
   )} planned`;
@@ -24,9 +39,9 @@ function CurtailmentPill({ event, detailsPath }: CurtailmentPillProps) {
   return (
     <PageHeaderPopoverPill
       ariaLabel={`View curtailment details for ${event.reason}`}
-      dotClassName={stateConfig.dotClassName}
+      dotClassName={headerStateConfig.dotClassName}
       triggerClassName="curtailment-pill-trigger"
-      triggerLabel={`Curtailment ${stateConfig.label.toLowerCase()}`}
+      triggerLabel={`Curtailment ${headerStateConfig.label.toLowerCase()}`}
     >
       {({ closePopover }) => (
         <div className="flex flex-col gap-3">

--- a/client/src/protoFleet/components/PageHeader/PageHeader.stories.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.stories.tsx
@@ -189,7 +189,7 @@ const InteractiveSchedulePillStory = () => {
 
 const storyCurtailmentEvent: CurtailmentPillEvent = {
   reason: "ERCOT demand response",
-  state: "active",
+  state: "curtailing",
   scopeLabel: "Racks A1-A4",
   selectedMiners: 48,
   estimatedReductionKw: 126.4,
@@ -219,7 +219,7 @@ export const SchedulePill = () => {
   );
 };
 
-export const CurtailmentPill = ({ state = "active" }: { state?: CurtailmentPillState }) => {
+export const CurtailmentPill = ({ state = "curtailing" }: { state?: CurtailmentPillState }) => {
   return (
     <StoryFrame>
       <CurtailmentPillComponent event={{ ...storyCurtailmentEvent, state }} />
@@ -228,7 +228,7 @@ export const CurtailmentPill = ({ state = "active" }: { state?: CurtailmentPillS
 };
 
 CurtailmentPill.args = {
-  state: "active",
+  state: "curtailing",
 };
 
 CurtailmentPill.argTypes = {

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import { mapCurtailmentPillEvent } from "./curtailmentPillMapper";
+import {
+  type CurtailmentEvent,
+  CurtailmentEventSchema,
+  CurtailmentEventState,
+  CurtailmentMode,
+  CurtailmentPriority,
+  CurtailmentTargetRollupSchema,
+  FixedKwParamsSchema,
+  ScopeWholeOrgSchema,
+} from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
+
+function curtailmentEvent(overrides: Partial<CurtailmentEvent> = {}): CurtailmentEvent {
+  const event = create(CurtailmentEventSchema, {
+    eventUuid: "curt-1",
+    reason: "Grid peak",
+    state: CurtailmentEventState.PENDING,
+    mode: CurtailmentMode.FIXED_KW,
+    priority: CurtailmentPriority.NORMAL,
+    scope: {
+      case: "wholeOrg",
+      value: create(ScopeWholeOrgSchema, {}),
+    },
+    modeParams: {
+      case: "fixedKw",
+      value: create(FixedKwParamsSchema, { targetKw: 20 }),
+    },
+    targetRollup: create(CurtailmentTargetRollupSchema, {
+      pending: 2,
+      total: 2,
+    }),
+    decisionSnapshot: {
+      estimated_reduction_kw: 23.4,
+      selected_count: 2,
+    },
+  });
+
+  return Object.assign(event, overrides);
+}
+
+describe("mapCurtailmentPillEvent", () => {
+  it("keeps a fully pending active event pending", () => {
+    expect(mapCurtailmentPillEvent(curtailmentEvent())).toEqual(
+      expect.objectContaining({
+        state: "pending",
+      }),
+    );
+  });
+
+  it("shows a pending event with started targets as curtailing", () => {
+    const event = curtailmentEvent({
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 1,
+        pending: 1,
+        total: 2,
+      }),
+    });
+
+    expect(mapCurtailmentPillEvent(event)).toEqual(
+      expect.objectContaining({
+        state: "curtailing",
+      }),
+    );
+  });
+
+  it("keeps a pending event with all targets confirmed as curtailing", () => {
+    const event = curtailmentEvent({
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 2,
+        total: 2,
+      }),
+    });
+
+    expect(mapCurtailmentPillEvent(event)).toEqual(
+      expect.objectContaining({
+        state: "curtailing",
+      }),
+    );
+  });
+
+  it("shows an active event with remaining targets as curtailing", () => {
+    const event = curtailmentEvent({
+      state: CurtailmentEventState.ACTIVE,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 1,
+        pending: 1,
+        total: 2,
+      }),
+    });
+
+    expect(mapCurtailmentPillEvent(event)).toEqual(
+      expect.objectContaining({
+        state: "curtailing",
+      }),
+    );
+  });
+
+  it("shows an active event with all targets confirmed as curtailed", () => {
+    const event = curtailmentEvent({
+      state: CurtailmentEventState.ACTIVE,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 2,
+        total: 2,
+      }),
+    });
+
+    expect(mapCurtailmentPillEvent(event)).toEqual(
+      expect.objectContaining({
+        state: "curtailed",
+      }),
+    );
+  });
+
+  it("passes through restoring events as restoring", () => {
+    expect(mapCurtailmentPillEvent(curtailmentEvent({ state: CurtailmentEventState.RESTORING }))).toEqual(
+      expect.objectContaining({
+        state: "restoring",
+      }),
+    );
+  });
+
+  it("hides inactive terminal events", () => {
+    expect(mapCurtailmentPillEvent(curtailmentEvent({ state: CurtailmentEventState.COMPLETED }))).toBeNull();
+  });
+});

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
@@ -5,8 +5,6 @@ import { mapCurtailmentPillEvent } from "./curtailmentPillMapper";
 import {
   CurtailmentEventSchema,
   CurtailmentEventState,
-  CurtailmentMode,
-  CurtailmentPriority,
   CurtailmentTargetRollupSchema,
   FixedKwParamsSchema,
   ScopeWholeOrgSchema,
@@ -19,11 +17,8 @@ function targetRollup(values: { pending?: number; confirmed?: number; total?: nu
 
 function curtailmentEvent(overrides: Partial<CurtailmentEvent> = {}): CurtailmentEvent {
   const event = create(CurtailmentEventSchema, {
-    eventUuid: "curt-1",
     reason: "Grid peak",
     state: CurtailmentEventState.PENDING,
-    mode: CurtailmentMode.FIXED_KW,
-    priority: CurtailmentPriority.NORMAL,
     scope: {
       case: "wholeOrg",
       value: create(ScopeWholeOrgSchema, {}),
@@ -56,15 +51,13 @@ describe("mapCurtailmentPillEvent", () => {
     );
   });
 
-  it("falls back when the event reason is blank", () => {
+  it("falls back for blank reasons and hides inactive terminal events", () => {
     expect(mapCurtailmentPillEvent(curtailmentEvent({ reason: "" }))).toEqual(
       expect.objectContaining({
         reason: "Curtailment",
       }),
     );
-  });
 
-  it("hides inactive terminal events", () => {
     expect(mapCurtailmentPillEvent(curtailmentEvent({ state: CurtailmentEventState.COMPLETED }))).toBeNull();
   });
 });

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
@@ -3,7 +3,6 @@ import { create } from "@bufbuild/protobuf";
 
 import { mapCurtailmentPillEvent } from "./curtailmentPillMapper";
 import {
-  type CurtailmentEvent,
   CurtailmentEventSchema,
   CurtailmentEventState,
   CurtailmentMode,
@@ -12,6 +11,11 @@ import {
   FixedKwParamsSchema,
   ScopeWholeOrgSchema,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
+import type { CurtailmentEvent } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
+
+function targetRollup(values: { pending?: number; confirmed?: number; total?: number }) {
+  return create(CurtailmentTargetRollupSchema, values);
+}
 
 function curtailmentEvent(overrides: Partial<CurtailmentEvent> = {}): CurtailmentEvent {
   const event = create(CurtailmentEventSchema, {
@@ -28,10 +32,7 @@ function curtailmentEvent(overrides: Partial<CurtailmentEvent> = {}): Curtailmen
       case: "fixedKw",
       value: create(FixedKwParamsSchema, { targetKw: 20 }),
     },
-    targetRollup: create(CurtailmentTargetRollupSchema, {
-      pending: 2,
-      total: 2,
-    }),
+    targetRollup: targetRollup({ pending: 2, total: 2 }),
     decisionSnapshot: {
       estimated_reduction_kw: 23.4,
       selected_count: 2,
@@ -42,82 +43,23 @@ function curtailmentEvent(overrides: Partial<CurtailmentEvent> = {}): Curtailmen
 }
 
 describe("mapCurtailmentPillEvent", () => {
-  it("keeps a fully pending active event pending", () => {
-    expect(mapCurtailmentPillEvent(curtailmentEvent())).toEqual(
+  it.each([
+    [{}, "pending"],
+    [{ targetRollup: targetRollup({ confirmed: 1, pending: 1, total: 2 }) }, "curtailing"],
+    [{ state: CurtailmentEventState.ACTIVE, targetRollup: targetRollup({ confirmed: 2, total: 2 }) }, "curtailed"],
+    [{ state: CurtailmentEventState.RESTORING }, "restoring"],
+  ] satisfies readonly [Partial<CurtailmentEvent>, string][])("maps display state", (overrides, state) => {
+    expect(mapCurtailmentPillEvent(curtailmentEvent(overrides))).toEqual(
       expect.objectContaining({
-        state: "pending",
+        state,
       }),
     );
   });
 
-  it("shows a pending event with started targets as curtailing", () => {
-    const event = curtailmentEvent({
-      targetRollup: create(CurtailmentTargetRollupSchema, {
-        confirmed: 1,
-        pending: 1,
-        total: 2,
-      }),
-    });
-
-    expect(mapCurtailmentPillEvent(event)).toEqual(
+  it("falls back when the event reason is blank", () => {
+    expect(mapCurtailmentPillEvent(curtailmentEvent({ reason: "" }))).toEqual(
       expect.objectContaining({
-        state: "curtailing",
-      }),
-    );
-  });
-
-  it("keeps a pending event with all targets confirmed as curtailing", () => {
-    const event = curtailmentEvent({
-      targetRollup: create(CurtailmentTargetRollupSchema, {
-        confirmed: 2,
-        total: 2,
-      }),
-    });
-
-    expect(mapCurtailmentPillEvent(event)).toEqual(
-      expect.objectContaining({
-        state: "curtailing",
-      }),
-    );
-  });
-
-  it("shows an active event with remaining targets as curtailing", () => {
-    const event = curtailmentEvent({
-      state: CurtailmentEventState.ACTIVE,
-      targetRollup: create(CurtailmentTargetRollupSchema, {
-        confirmed: 1,
-        pending: 1,
-        total: 2,
-      }),
-    });
-
-    expect(mapCurtailmentPillEvent(event)).toEqual(
-      expect.objectContaining({
-        state: "curtailing",
-      }),
-    );
-  });
-
-  it("shows an active event with all targets confirmed as curtailed", () => {
-    const event = curtailmentEvent({
-      state: CurtailmentEventState.ACTIVE,
-      targetRollup: create(CurtailmentTargetRollupSchema, {
-        confirmed: 2,
-        total: 2,
-      }),
-    });
-
-    expect(mapCurtailmentPillEvent(event)).toEqual(
-      expect.objectContaining({
-        state: "curtailed",
-      }),
-    );
-  });
-
-  it("passes through restoring events as restoring", () => {
-    expect(mapCurtailmentPillEvent(curtailmentEvent({ state: CurtailmentEventState.RESTORING }))).toEqual(
-      expect.objectContaining({
-        state: "restoring",
+        reason: "Curtailment",
       }),
     );
   });

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.ts
@@ -24,14 +24,17 @@ export function mapCurtailmentPillEvent(event?: ProtoCurtailmentEvent): Curtailm
 
   const selectedMiners = getCurtailmentEventSelectedMinerCount(event);
   const estimatedReductionKw = getCurtailmentEventEstimatedReductionKw(event);
-  const displayState = getActiveCurtailmentDisplayState({
-    state,
-    selectedMiners,
-    estimatedReductionKw,
-    targetKw: getFixedKwTarget(event),
-    observedReductionKw: getCurtailmentEventObservedReductionKw(event, estimatedReductionKw),
-    rollups: getCurtailmentTargetRollups(event),
-  });
+  const displayState = getActiveCurtailmentDisplayState(
+    {
+      state,
+      selectedMiners,
+      estimatedReductionKw,
+      targetKw: getFixedKwTarget(event),
+      observedReductionKw: getCurtailmentEventObservedReductionKw(event, estimatedReductionKw),
+      rollups: getCurtailmentTargetRollups(event),
+    },
+    { dispatchStartedAsCurtailing: true },
+  );
 
   if (!isCurtailmentPillState(displayState)) {
     return null;

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.ts
@@ -1,9 +1,13 @@
-import type { CurtailmentPillEvent } from "./curtailmentPillTypes";
+import { type CurtailmentPillEvent, isCurtailmentPillState } from "./curtailmentPillTypes";
+import { getFixedKwTarget } from "@/protoFleet/api/curtailmentMappers";
 import type { CurtailmentEvent as ProtoCurtailmentEvent } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import {
+  getActiveCurtailmentDisplayState,
   getCurtailmentEventEstimatedReductionKw,
+  getCurtailmentEventObservedReductionKw,
   getCurtailmentEventScopeLabel,
   getCurtailmentEventSelectedMinerCount,
+  getCurtailmentTargetRollups,
   isActiveCurtailmentEventState,
   mapCurtailmentEventState,
 } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
@@ -18,11 +22,26 @@ export function mapCurtailmentPillEvent(event?: ProtoCurtailmentEvent): Curtailm
     return null;
   }
 
+  const selectedMiners = getCurtailmentEventSelectedMinerCount(event);
+  const estimatedReductionKw = getCurtailmentEventEstimatedReductionKw(event);
+  const displayState = getActiveCurtailmentDisplayState({
+    state,
+    selectedMiners,
+    estimatedReductionKw,
+    targetKw: getFixedKwTarget(event),
+    observedReductionKw: getCurtailmentEventObservedReductionKw(event, estimatedReductionKw),
+    rollups: getCurtailmentTargetRollups(event),
+  });
+
+  if (!isCurtailmentPillState(displayState)) {
+    return null;
+  }
+
   return {
     reason: event.reason,
-    state,
+    state: displayState,
     scopeLabel: getCurtailmentEventScopeLabel(event),
-    selectedMiners: getCurtailmentEventSelectedMinerCount(event),
-    estimatedReductionKw: getCurtailmentEventEstimatedReductionKw(event),
+    selectedMiners,
+    estimatedReductionKw,
   };
 }

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.ts
@@ -38,7 +38,7 @@ export function mapCurtailmentPillEvent(event?: ProtoCurtailmentEvent): Curtailm
   }
 
   return {
-    reason: event.reason,
+    reason: event.reason || "Curtailment",
     state: displayState,
     scopeLabel: getCurtailmentEventScopeLabel(event),
     selectedMiners,

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillTypes.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillTypes.ts
@@ -1,11 +1,19 @@
-import {
-  type ActiveCurtailmentEventState,
-  activeCurtailmentEventStates,
-} from "@/protoFleet/features/energy/curtailmentDisplayUtils";
+import type { ActiveCurtailmentDisplayState } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 
-export const curtailmentPillStates = activeCurtailmentEventStates;
+export const curtailmentPillStates = [
+  "pending",
+  "curtailing",
+  "curtailed",
+  "restoring",
+] as const satisfies readonly ActiveCurtailmentDisplayState[];
 
-export type CurtailmentPillState = ActiveCurtailmentEventState;
+export type CurtailmentPillState = (typeof curtailmentPillStates)[number];
+
+const curtailmentPillStateSet = new Set<ActiveCurtailmentDisplayState>(curtailmentPillStates);
+
+export function isCurtailmentPillState(state: ActiveCurtailmentDisplayState): state is CurtailmentPillState {
+  return curtailmentPillStateSet.has(state);
+}
 
 export interface CurtailmentPillEvent {
   reason: string;

--- a/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
+++ b/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
@@ -112,6 +112,10 @@ interface ActiveCurtailmentDisplayEvent {
   rollups: CurtailmentTargetRollup[];
 }
 
+interface ActiveCurtailmentDisplayOptions {
+  dispatchStartedAsCurtailing?: boolean;
+}
+
 export interface ActiveCurtailmentMinerCompliance {
   curtailedCount: number;
   restoreFailedCount: number;
@@ -358,13 +362,16 @@ function isRestoreIncompleteEventState(state: CurtailmentEventState): boolean {
   return state === "completedWithFailures";
 }
 
-export function getActiveCurtailmentDisplayState(event: ActiveCurtailmentDisplayEvent): ActiveCurtailmentDisplayState {
+export function getActiveCurtailmentDisplayState(
+  event: ActiveCurtailmentDisplayEvent,
+  options: ActiveCurtailmentDisplayOptions = {},
+): ActiveCurtailmentDisplayState {
   if (event.state === "restoring") {
     return "restoring";
   }
 
   if (event.state === "pending") {
-    return hasActiveCurtailmentDispatchStarted(event) ? "curtailing" : "pending";
+    return options.dispatchStartedAsCurtailing && hasActiveCurtailmentDispatchStarted(event) ? "curtailing" : "pending";
   }
 
   if (isRestoreIncompleteEventState(event.state)) {

--- a/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
+++ b/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
@@ -1,6 +1,7 @@
 import {
   type CurtailmentEvent as ProtoCurtailmentEvent,
   CurtailmentEventState as ProtoCurtailmentEventState,
+  CurtailmentTargetState as ProtoCurtailmentTargetState,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 
 export const curtailmentEventStateConfigs = {
@@ -51,8 +52,92 @@ export const activeCurtailmentEventStates = [
 ] as const satisfies readonly CurtailmentEventState[];
 
 export type ActiveCurtailmentEventState = (typeof activeCurtailmentEventStates)[number];
+export type CurtailmentTargetState =
+  | "pending"
+  | "dispatched"
+  | "confirmed"
+  | "drifted"
+  | "resolved"
+  | "released"
+  | "restoreFailed";
+
+export interface CurtailmentTargetRollup {
+  state: CurtailmentTargetState;
+  count: number;
+}
+
+export const activeCurtailmentDisplayStateConfigs = {
+  cancelled: {
+    label: "Cancelled",
+    dotClassName: "bg-intent-critical-fill",
+  },
+  curtailed: {
+    label: "Curtailed",
+    dotClassName: "bg-text-primary",
+  },
+  curtailing: {
+    label: "Curtailing",
+    dotClassName: "bg-core-accent-fill",
+  },
+  failed: {
+    label: "Failed",
+    dotClassName: "bg-intent-critical-fill",
+  },
+  pending: {
+    label: "Pending",
+    dotClassName: "bg-core-accent-fill",
+  },
+  restoreIncomplete: {
+    label: "Restore incomplete",
+    dotClassName: "bg-text-primary-30",
+  },
+  restored: {
+    label: "Restored",
+    dotClassName: "bg-text-primary-30",
+  },
+  restoring: {
+    label: "Restoring",
+    dotClassName: "bg-core-accent-fill",
+  },
+} as const;
+
+export type ActiveCurtailmentDisplayState = keyof typeof activeCurtailmentDisplayStateConfigs;
+
+interface ActiveCurtailmentDisplayEvent {
+  state: CurtailmentEventState;
+  selectedMiners: number;
+  estimatedReductionKw: number;
+  targetKw?: number;
+  observedReductionKw: number;
+  rollups: CurtailmentTargetRollup[];
+}
+
+export interface ActiveCurtailmentMinerCompliance {
+  curtailedCount: number;
+  restoreFailedCount: number;
+  restoredCount: number;
+  totalCount: number;
+}
 
 const activeCurtailmentEventStateSet = new Set<CurtailmentEventState>(activeCurtailmentEventStates);
+const countedTargetStates: CurtailmentTargetState[] = [
+  "pending",
+  "dispatched",
+  "confirmed",
+  "drifted",
+  "resolved",
+  "released",
+  "restoreFailed",
+];
+const startedCurtailmentDispatchTargetStates: CurtailmentTargetState[] = [
+  "dispatched",
+  "confirmed",
+  "drifted",
+  "restoreFailed",
+];
+const curtailedTargetStates: CurtailmentTargetState[] = ["confirmed", "resolved"];
+const restoreFailedTargetStates: CurtailmentTargetState[] = ["restoreFailed"];
+const restoredTargetStates: CurtailmentTargetState[] = ["resolved", "released"];
 const estimatedReductionKwSnapshotKeys = ["estimated_reduction_kw", "estimatedReductionKw"] as const;
 const selectedCountSnapshotKeys = ["selected_count", "selectedCount"] as const;
 const wattsPerKilowatt = 1000;
@@ -101,6 +186,58 @@ export function mapCurtailmentEventState(state: ProtoCurtailmentEventState): Cur
   }
 }
 
+export function mapCurtailmentTargetState(state: ProtoCurtailmentTargetState): CurtailmentTargetState {
+  switch (state) {
+    case ProtoCurtailmentTargetState.DISPATCHING:
+    case ProtoCurtailmentTargetState.DISPATCHED:
+      return "dispatched";
+    case ProtoCurtailmentTargetState.CONFIRMED:
+      return "confirmed";
+    case ProtoCurtailmentTargetState.DRIFTED:
+      return "drifted";
+    case ProtoCurtailmentTargetState.RESOLVED:
+      return "resolved";
+    case ProtoCurtailmentTargetState.RELEASED:
+      return "released";
+    case ProtoCurtailmentTargetState.RESTORE_FAILED:
+      return "restoreFailed";
+    case ProtoCurtailmentTargetState.PENDING:
+    case ProtoCurtailmentTargetState.UNSPECIFIED:
+    default:
+      return "pending";
+  }
+}
+
+function getRollupsFromTargets(event: ProtoCurtailmentEvent): CurtailmentTargetRollup[] {
+  const counts = new Map<CurtailmentTargetState, number>();
+
+  for (const target of event.targets) {
+    const state = mapCurtailmentTargetState(target.state);
+    counts.set(state, (counts.get(state) ?? 0) + 1);
+  }
+
+  return Array.from(counts, ([state, count]) => ({ state, count }));
+}
+
+export function getCurtailmentTargetRollups(event: ProtoCurtailmentEvent): CurtailmentTargetRollup[] {
+  const rollup = event.targetRollup;
+  if (!rollup) {
+    return getRollupsFromTargets(event);
+  }
+
+  const rollups: CurtailmentTargetRollup[] = [
+    { state: "pending", count: rollup.pending },
+    { state: "dispatched", count: rollup.dispatched },
+    { state: "confirmed", count: rollup.confirmed },
+    { state: "drifted", count: rollup.drifted },
+    { state: "resolved", count: rollup.resolved },
+    { state: "released", count: rollup.released },
+    { state: "restoreFailed", count: rollup.restoreFailed },
+  ];
+
+  return rollups.filter((targetRollup) => targetRollup.count > 0);
+}
+
 export function getCurtailmentEventSelectedMinerCount(event: ProtoCurtailmentEvent): number {
   const snapshotSelectedCount = getSnapshotNumber(event, selectedCountSnapshotKeys);
   return snapshotSelectedCount ?? event.targetRollup?.total ?? event.targets.length;
@@ -114,6 +251,42 @@ export function getCurtailmentEventEstimatedReductionKw(event: ProtoCurtailmentE
 
   const baselinePowerW = event.targets.reduce((total, target) => total + (target.baselinePowerW ?? 0), 0);
   return baselinePowerW / wattsPerKilowatt;
+}
+
+function getConfirmedTargetCount(event: ProtoCurtailmentEvent): number {
+  if (event.targetRollup) {
+    return event.targetRollup.confirmed;
+  }
+
+  return event.targets.filter((target) => target.state === ProtoCurtailmentTargetState.CONFIRMED).length;
+}
+
+function getEstimatedObservedReductionKw(event: ProtoCurtailmentEvent, estimatedReductionKw: number): number {
+  const selectedCount = getCurtailmentEventSelectedMinerCount(event);
+  if (selectedCount <= 0) {
+    return 0;
+  }
+
+  return estimatedReductionKw * (getConfirmedTargetCount(event) / selectedCount);
+}
+
+export function getCurtailmentEventObservedReductionKw(
+  event: ProtoCurtailmentEvent,
+  estimatedReductionKw = getCurtailmentEventEstimatedReductionKw(event),
+): number {
+  let observedReductionTotalW = 0;
+  let hasObservedReduction = false;
+
+  for (const { baselinePowerW, observedPowerW } of event.targets) {
+    if (baselinePowerW !== undefined && observedPowerW !== undefined) {
+      hasObservedReduction = true;
+      observedReductionTotalW += Math.max(baselinePowerW - observedPowerW, 0);
+    }
+  }
+
+  return hasObservedReduction
+    ? observedReductionTotalW / wattsPerKilowatt
+    : getEstimatedObservedReductionKw(event, estimatedReductionKw);
 }
 
 export function getCurtailmentEventScopeLabel(event: ProtoCurtailmentEvent): string {
@@ -133,6 +306,89 @@ export function getCurtailmentEventScopeLabel(event: ProtoCurtailmentEvent): str
 
 export function getCurtailmentTargetKw(event: CurtailmentTargetKwEvent): number {
   return event.targetKw ?? event.estimatedReductionKw;
+}
+
+export function getCurtailmentProgressPercent(value: number, total: number): number {
+  if (!Number.isFinite(value) || !Number.isFinite(total) || total <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max((value / total) * 100, 0), 100);
+}
+
+export function getActiveCurtailmentRollupCount(
+  event: ActiveCurtailmentDisplayEvent,
+  states: CurtailmentTargetState[],
+): number {
+  return event.rollups.reduce((total, rollup) => {
+    if (!states.includes(rollup.state)) {
+      return total;
+    }
+
+    return total + rollup.count;
+  }, 0);
+}
+
+export function getActiveCurtailmentMinerCompliance(
+  event: ActiveCurtailmentDisplayEvent,
+): ActiveCurtailmentMinerCompliance {
+  const curtailedCount = getActiveCurtailmentRollupCount(event, curtailedTargetStates);
+  const restoreFailedCount = getActiveCurtailmentRollupCount(event, restoreFailedTargetStates);
+  const restoredCount = getActiveCurtailmentRollupCount(event, restoredTargetStates);
+  const countedTargetCount = getActiveCurtailmentRollupCount(event, countedTargetStates);
+  const totalCount = Math.max(event.selectedMiners, countedTargetCount);
+
+  return {
+    curtailedCount,
+    restoreFailedCount,
+    restoredCount,
+    totalCount,
+  };
+}
+
+export function hasActiveCurtailmentDispatchStarted(event: ActiveCurtailmentDisplayEvent): boolean {
+  return getActiveCurtailmentRollupCount(event, startedCurtailmentDispatchTargetStates) > 0;
+}
+
+function isRestoredEventState(state: CurtailmentEventState): boolean {
+  return state === "completed";
+}
+
+function isRestoreIncompleteEventState(state: CurtailmentEventState): boolean {
+  return state === "completedWithFailures";
+}
+
+export function getActiveCurtailmentDisplayState(event: ActiveCurtailmentDisplayEvent): ActiveCurtailmentDisplayState {
+  if (event.state === "restoring") {
+    return "restoring";
+  }
+
+  if (event.state === "pending") {
+    return hasActiveCurtailmentDispatchStarted(event) ? "curtailing" : "pending";
+  }
+
+  if (isRestoreIncompleteEventState(event.state)) {
+    return "restoreIncomplete";
+  }
+
+  if (isRestoredEventState(event.state)) {
+    return "restored";
+  }
+
+  if (event.state === "cancelled") {
+    return "cancelled";
+  }
+
+  if (event.state === "failed") {
+    return "failed";
+  }
+
+  const targetKw = getCurtailmentTargetKw(event);
+  const compliance = getActiveCurtailmentMinerCompliance(event);
+  const powerShedPercent = getCurtailmentProgressPercent(event.observedReductionKw, targetKw);
+  const curtailedPercent = getCurtailmentProgressPercent(compliance.curtailedCount, compliance.totalCount);
+
+  return powerShedPercent >= 100 || curtailedPercent >= 100 ? "curtailed" : "curtailing";
 }
 
 export function formatCurtailmentKw(value: number, fractionDigits = 1): string {


### PR DESCRIPTION
## Summary
- Add shared curtailment display-state helpers for target rollups and observed reduction
- Map the page-header curtailment pill to pending, curtailing, curtailed, and restoring states without exposing the Energy route

## Test plan
- [ ] Confirm the page-header curtailment pill shows the expected active state label and details
- [ ] Confirm there are no route, nav, or Energy page entry-point changes in this split

Closes #349