### PR TITLE
Update workflow dependencies

### DIFF
--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET SDK from global.json
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           global-json-file: deployment-files/windows/global.json
 
@@ -184,7 +184,7 @@ jobs:
           chmod +x server/proto-plugin-* server/antminer-plugin-*
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build asicrs plugin binary
         run: |
@@ -345,7 +345,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build TimescaleDB image
         run: |

--- a/.github/workflows/protofleet-contract-checks.yml
+++ b/.github/workflows/protofleet-contract-checks.yml
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/go-cache-setup
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       # buildx's type=gha cache backend reads ACTIONS_RUNTIME_TOKEN and
       # ACTIONS_CACHE_URL (aka ACTIONS_RESULTS_URL) from the environment. These

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -79,7 +79,7 @@ jobs:
           npm run build:protoFleet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       # Docker cache is computed before the plugin build so the gitignored
       # `server/plugins/*` binaries (not a Docker build input) don't enter

--- a/.github/workflows/windows-csharp-checks.yml
+++ b/.github/workflows/windows-csharp-checks.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET SDK from global.json
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           global-json-file: deployment-files/windows/global.json
 


### PR DESCRIPTION
Bumps the two GitHub Actions that were behind their latest release to the
commit SHA of the new tag, keeping the SHA pin with the version in a trailing
comment per repo convention.

- `actions/setup-dotnet` v5.2.0 → v5.3.0
- `docker/setup-buildx-action` v4.0.0 → v4.1.0

All other actions in `.github/` were already pinned to their latest release.