### PR TITLE
Update Proto Rig API

### DIFF
--- a/client/src/protoOS/api/generatedApi.ts
+++ b/client/src/protoOS/api/generatedApi.ts
@@ -630,7 +630,7 @@ export interface HashboardInfo {
   /** @example "1.0" */
   api_version?: string;
   /** @example "B3a" */
-  board?: "CpuSimulated" | "B2" | "B3a" | "B3b" | "B3bSim" | "B4" | "B4Sim";
+  board?: "CpuSimulated" | "B2" | "B3a" | "B3b" | "B3bSim" | "B4_128" | "B4_192" | "B4Sim";
   /** Firmware version and build information */
   bootloader?: FWInfo;
   /** @example "ABC123" */
@@ -1636,7 +1636,7 @@ export interface SystemInfoSysteminfo {
 /** System status information including onboarding and password setup */
 export interface SystemStatuses {
   /**
-   * True when the miner is in secure mode and the factory default password is still active. Clients should prompt for a password change, and most authenticated endpoints are 403-gated until changed.
+   * True when the system is secure and the default password has not been changed. Clients should prompt the user to change their password when this is true.
    * @example false
    */
   default_password_active?: boolean;
@@ -1646,10 +1646,10 @@ export interface SystemStatuses {
   password_set?: boolean;
 }
 
-/** Configuration for telemetry data collection */
+/** Desired telemetry-service state */
 export interface TelemetryConfig {
   /**
-   * Enable or disable telemetry
+   * Whether telemetry-service should be running
    * @example true
    */
   enabled: boolean;
@@ -1677,10 +1677,10 @@ export interface TelemetryData {
   timestamp: string;
 }
 
-/** Response containing telemetry status information */
+/** Response containing telemetry-service status information */
 export interface TelemetryResponse {
   /**
-   * Whether telemetry is currently enabled
+   * Whether telemetry-service is currently running
    * @example true
    */
   enabled: boolean;
@@ -2237,7 +2237,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
 /**
  * @title Mining Development Kit API
- * @version 1.8.0
+ * @version 1.8.1
  * @license MIT (https://opensource.org/license/mit)
  * @baseUrl http://127.0.0.1:8080
  * @contact <mining.support@block.xyz>
@@ -2606,7 +2606,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/api/v1/system/locate
      * @secure
      */
-    locateSystem: (query: LocateSystemParams, params: RequestParams = {}) =>
+    locateSystem: (query: LocateSystemParams = {}, params: RequestParams = {}) =>
       this.request<MessageResponse, MessageResponse>({
         path: `/api/v1/system/locate`,
         method: "POST",
@@ -2624,7 +2624,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/api/v1/system/logs
      * @secure
      */
-    getSystemLogs: (query: GetSystemLogsParams, params: RequestParams = {}) =>
+    getSystemLogs: (query: GetSystemLogsParams = {}, params: RequestParams = {}) =>
       this.request<LogsResponse, MessageResponse>({
         path: `/api/v1/system/logs`,
         method: "GET",
@@ -2836,7 +2836,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/api/v1/hashrate
      * @secure
      */
-    getMinerHashrate: (query: GetMinerHashrateParams, params: RequestParams = {}) =>
+    getMinerHashrate: (query: GetMinerHashrateParams = {}, params: RequestParams = {}) =>
       this.request<HashrateResponse, MessageResponse>({
         path: `/api/v1/hashrate`,
         method: "GET",
@@ -2890,7 +2890,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/api/v1/temperature
      * @secure
      */
-    getMinerTemperature: (query: GetMinerTemperatureParams, params: RequestParams = {}) =>
+    getMinerTemperature: (query: GetMinerTemperatureParams = {}, params: RequestParams = {}) =>
       this.request<TemperatureResponse, MessageResponse>({
         path: `/api/v1/temperature`,
         method: "GET",
@@ -2944,7 +2944,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/api/v1/power
      * @secure
      */
-    getMinerPower: (query: GetMinerPowerParams, params: RequestParams = {}) =>
+    getMinerPower: (query: GetMinerPowerParams = {}, params: RequestParams = {}) =>
       this.request<PowerResponse, MessageResponse>({
         path: `/api/v1/power`,
         method: "GET",
@@ -3006,19 +3006,31 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Triggers a PSU firmware update. Publishes a firmware update command to each connected PSU via NATS. Use the `force` parameter to allow re-flashing the same firmware version.
+     * @description Triggers a PSU firmware update. Publishes a firmware update command to each connected PSU via NATS. Use the `force` query parameter to allow re-flashing the same firmware version. Use `psu_types` in the request body to override auto-detected PSU types per slot.
      *
      * @tags PSUs
      * @name PostUpdatePsu
      * @request POST:/api/v1/power-supplies/update
      * @secure
      */
-    postUpdatePsu: (query: PostUpdatePsuParams, params: RequestParams = {}) =>
+    postUpdatePsu: (
+      query: PostUpdatePsuParams = {},
+      data?: {
+        /**
+         * Per-PSU type overrides. Keys are PSU slot IDs (1-3). Omitted slots use auto-detection.
+         * @example {"1":"boco_bs502a17","2":"boco_bs402a17"}
+         */
+        psu_types?: Record<string, "chicony_s24" | "boco_bs402a17" | "boco_bs502a17">;
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<MessageResponse, MessageResponse>({
         path: `/api/v1/power-supplies/update`,
         method: "POST",
         query: query,
+        body: data,
         secure: true,
+        type: ContentType.Json,
         format: "json",
         ...params,
       }),
@@ -3049,7 +3061,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/api/v1/efficiency
      * @secure
      */
-    getMinerEfficiency: (query: GetMinerEfficiencyParams, params: RequestParams = {}) =>
+    getMinerEfficiency: (query: GetMinerEfficiencyParams = {}, params: RequestParams = {}) =>
       this.request<EfficiencyResponse, MessageResponse>({
         path: `/api/v1/efficiency`,
         method: "GET",
@@ -3215,7 +3227,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Get the current system telemetry enabled status.
+     * @description Get whether telemetry-service is currently running.
      *
      * @tags System
      * @name GetSystemTelemetryEnabled
@@ -3230,7 +3242,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Configure system telemetry enabled settings.
+     * @description Start or stop telemetry-service.
      *
      * @tags System
      * @name SetSystemTelemetryEnabled
@@ -3276,7 +3288,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/api/v1/telemetry
      * @secure
      */
-    getCurrentTelemetry: (query: GetCurrentTelemetryParams, params: RequestParams = {}) =>
+    getCurrentTelemetry: (query: GetCurrentTelemetryParams = {}, params: RequestParams = {}) =>
       this.request<TelemetryData, MessageResponse>({
         path: `/api/v1/telemetry`,
         method: "GET",

--- a/proto-rig-api/README.md
+++ b/proto-rig-api/README.md
@@ -6,11 +6,16 @@ This directory contains vendored API specifications for the Proto miner devices.
 
 ```
 proto-rig-api/
+├── grpc/           # Vendored gRPC + hashboard .proto files (reference only)
 ├── openapi/        # OpenAPI specification for REST API
 │   └── MDK-API.json
 ├── VERSION.md      # Version tracking (single source of truth)
 └── README.md       # This file
 ```
+
+The `grpc/` proto files are vendored as reference documentation of the on-rig
+gRPC surface; they are not inputs to Proto Fleet code generation. The OpenAPI
+spec is the source that drives generated code and the simulator (see below).
 
 ## Usage
 
@@ -41,11 +46,12 @@ The `VERSION.md` file in this directory contains:
 
 When the miner API changes:
 
-1. Update the OpenAPI specification file
-2. Update the VERSION.md with new commit information
+1. Re-vendor the gRPC/hashboard proto files and the OpenAPI specification from
+   miner-firmware (see `VERSION.md` for the exact source paths and steps)
+2. Update `VERSION.md` with the new commit SHA(s) and dates
 3. Regenerate dependent code:
-   - `cd client && npm run generate-api-types` (TypeScript types)
-4. Update the simulator REST API if OpenAPI spec changed:
+   - `cd client && npm run generate-api-types` (TypeScript types from the OpenAPI spec)
+4. Update the simulator REST API if the OpenAPI spec changed:
    - See `server/fake-proto-rig/README.md` for maintenance checklist
 5. Run tests to verify compatibility
 6. Commit all changes together

--- a/proto-rig-api/VERSION.md
+++ b/proto-rig-api/VERSION.md
@@ -2,9 +2,14 @@
 
 ## Source
 - Repository: miner-firmware (private)
-- Commit SHA: b9372f6a80379c857051758145c6a1748896f98a
-- Commit Date: 2026-05-04
-- Extraction Date: 2026-05-04
+- Commit SHA: c97ac9ed3402dca829c30be4bd38b4accc9cd3e2
+- Commit Date: 2026-06-01
+- Extraction Date: 2026-06-01
+
+The hashboard proto files live in the `external/hashboard` submodule, pinned by
+the superproject commit above to:
+- Submodule: external/hashboard (github.com/btc-mining/hashboard)
+- Commit SHA: 54d78b5f7791ad8e235b82d49bcb17b4dee0c141
 
 ## Files Extracted
 
@@ -21,13 +26,15 @@
 - miner_psu_api.proto
 - miner_psu_test_api.proto
 - miner_system_api.proto
+- miner_telemetry_api.proto
 - miner_ui_api.proto
 
-### Hashboard Proto Files (from `crates/mcdd/hashboard/lib/protobuf/protos/`)
+### Hashboard Proto Files (from `external/hashboard/lib/protobuf/protos/`)
 - hashboard.proto
 - hashboard_async.proto
 - hashboard_cmd.proto
 - hashboard_cmd_debug.proto
+- hashboard_cmd_evb.proto
 - hashboard_cmd_mfgtest.proto
 - hashboard_log.proto
 
@@ -39,14 +46,23 @@
 To update these API specifications:
 
 1. Clone or access the miner-firmware repository
-2. Checkout the desired commit/tag
-3. Copy proto files from `crates/rpc/protos/` to `grpc/`
-4. Copy MDK-API.json from `crates/miner-api-server/docs/` to `openapi/`
-5. Update this VERSION.md with the new commit SHA and date
-6. Regenerate code:
-   - Server: `cd server && just gen`
-   - Client: `cd client && npm run generate-api-types`
-7. Run tests to verify compatibility
-8. Commit all changes together
+2. Checkout the desired commit/tag and sync submodules:
+   `git submodule update --init external/hashboard`
+3. Copy gRPC proto files from `crates/rpc/protos/` to `grpc/`
+4. Copy hashboard proto files from `external/hashboard/lib/protobuf/protos/` to `grpc/`
+5. Copy MDK-API.json from `crates/miner-api-server/docs/` to `openapi/`
+6. Update this VERSION.md with the new commit SHA(s) and dates
+7. Regenerate the dependent generated code:
+   - Client: `cd client && npm run generate-api-types` (TypeScript types from the OpenAPI spec)
+8. Update the simulator REST API if the OpenAPI spec changed
+   (see `server/fake-proto-rig/README.md`)
+9. Run tests to verify compatibility
+10. Commit all changes together
 
-**Important**: Always update both gRPC and OpenAPI specs together to maintain version consistency.
+**Note**: The gRPC proto files are vendored as reference only — they document
+the on-rig gRPC surface and are not inputs to Proto Fleet code generation. The
+OpenAPI spec (`MDK-API.json`) is the source that drives generated code (the
+ProtoOS TypeScript client) and the hand-maintained fake-proto-rig simulator.
+
+**Important**: Always update the gRPC and OpenAPI specs together to maintain
+version consistency.

--- a/proto-rig-api/grpc/hashboard.proto
+++ b/proto-rig-api/grpc/hashboard.proto
@@ -33,3 +33,35 @@ enum mining_performance_mode {
     // Dynamically adjust the PLL frequency to minimize J/THs, with an upper bound of power consumption.
     PERFORMANCE_EFFICIENCY = 3;
 }
+
+enum mining_performance_pll_algorithm {
+    // Disable PLL tuning, also the default for backwards compatibility.
+    PLL_ALGORITHM_NONE = 0;
+    // Voltage imbalance compensation. The FW will only enable this on B2/3 boards.
+    PLL_ALGORITHM_VOLTAGE_IMBALANCE = 1;
+
+    // Debug/Testing algorithms
+
+    // "Fuzzing", sweeps ASIC frequencies one at a time to build behavior models.
+    PLL_ALGORITHM_DEBUG_FUZZING = 100;
+}
+
+enum mcu_reset_reason {
+  MCU_RESET_UNKNOWN = 0;
+  MCU_RESET_INVALID_SIGNATURE = 1;
+  MCU_RESET_FATAL = 2;
+  MCU_RESET_INVALID_PROPERTIES = 3;
+  MCU_RESET_APP_FAILED_TO_UPDATE_VERSION = 4;
+  MCU_RESET_BAD_BOOT_ADDR = 5;
+  MCU_RESET_FROM_PROTO = 6;
+  MCU_RESET_FAULT = 7;
+  MCU_RESET_FWUP = 8;
+  MCU_RESET_STACK_CANARY_NOT_SET = 9;
+  MCU_RESET_STACK_SMASHING_DETECTED = 10;
+  MCU_RESET_WATCHDOG_TIMEOUT = 11;
+  MCU_RESET_TAMPER = 12;
+  MCU_RESET_ECC_ERROR = 13;
+  MCU_RESET_FLASH_BANK_SWAP = 14;
+  MCU_RESET_ASSERT = 15;
+  MCU_RESET_LAST_ENTRY = 16;
+}

--- a/proto-rig-api/grpc/hashboard_async.proto
+++ b/proto-rig-api/grpc/hashboard_async.proto
@@ -34,6 +34,21 @@ enum error_cause {
     UNKNOWN_ERROR = 99;
 }
 
+enum voltage_domain {
+    // Default, voltage domain VDD
+    VDD = 0;
+
+    // MC3 voltage domains, difference between the voltage sensors
+    VDD_VDDI3 = 1;
+    VDDI3_VDDI2 = 2;
+    VDDI2_VDDI1 = 3;
+    VDDI1 = 4;
+
+    // MC3 Cross domain voltage limits
+    VDD_VDDI1 = 5;
+    VDDI3_VSS = 6;
+}
+
 message asic_error_state {
     // The ID of the ASIC
     uint32 id = 1;
@@ -43,6 +58,10 @@ message asic_error_state {
 
     // At the time of the error, the temperature of the ASIC
     float temperature = 3;
+
+    // The voltage domain for the limit violation at time of error.
+    // Only valid for under/over voltage limit errors
+    voltage_domain voltage_domain = 4;
 }
 
 message hashboard_error {
@@ -93,8 +112,23 @@ message async_system_health {
     // The speed of fans in RPM
     uint32 fan = 11;
 
+    // The fan current in amps
+    float fan_current = 13;
+
+    // The fan current in watts, voltage is system voltage
+    float fan_power = 14;
+
+    // New diagnostic info available for fetching
+    bool coredump_available = 15;
+
+    // True if the disciplined clock is synchronised to server time.
+    bool time_synced = 16;
+
     // Optional: The cause of the error if the mining state is MINING_STATE_ERROR
     repeated hashboard_error errors = 99;
+
+    // Transient warnings (auto-clearing, sent once per occurrence)
+    repeated hashboard_error warnings = 100;
 }
 
 message async_mining_nonce {
@@ -127,8 +161,19 @@ message asic_status {
     // Pass rate of the ASIC in percent
     float pass_rate = 4;
 
-    // Hashrate of the ASIC in GH/s
+    // Hashrate of the ASIC in H/s
     float hash_rate = 5;
+}
+
+message asic_debug_status {
+    // Ulink ECC (MC3 only)
+    uint32 uecc0 = 1;
+    uint32 uecc1 = 2;
+    uint32 uecc2 = 3;
+
+    float vddi1 = 4;
+    float vddi2 = 5;
+    float vddi3 = 6;
 }
 
 message async_asic_health {
@@ -137,6 +182,22 @@ message async_asic_health {
 
     // Array of ASIC statuses
     repeated asic_status asics = 2;
+}
+
+message async_asic_debug_health {
+    // Monotonic counter of the number slots processed by the scheduler
+    uint32 slot_counter = 1;
+
+    // Array of ASIC statuses
+    repeated asic_debug_status asics = 2;
+}
+
+enum hashboard_async_message_type {
+    ASYNC_NONE = 0;
+    ASYNC_HEARTBEAT = 1;
+    ASYNC_SYSTEM_HEALTH = 2;
+    ASYNC_ASIC_HEALTH = 100;
+    ASYNC_MINING_NONCE = 101;
 }
 
 message hashboard_async {
@@ -150,6 +211,7 @@ message hashboard_async {
         // Mining
         async_asic_health async_asic_health = 100;
         async_mining_nonce async_mining_nonce = 101;
+        async_asic_debug_health async_asic_debug_health = 102;
     }
 
     // The timestamp of the message in milliseconds

--- a/proto-rig-api/grpc/hashboard_cmd.proto
+++ b/proto-rig-api/grpc/hashboard_cmd.proto
@@ -7,6 +7,7 @@ option go_package = "pkg/proto;hashboard";
 import "hashboard.proto";
 import "hashboard_cmd_debug.proto";
 import "hashboard_cmd_mfgtest.proto";
+import "hashboard_cmd_evb.proto";
 
 message reset_cmd {}
 
@@ -54,8 +55,11 @@ enum hardware_revision {
     HARDWARE_REV_B3B_MP = 34;
 
     // B4
+    HARDWARE_REV_B4_192_PROTO_0 = 40;
     HARDWARE_REV_B4_192_PROTO_1 = 41;
     HARDWARE_REV_B4_128_PROTO_1 = 42;
+    HARDWARE_REV_B4_192_PROTO_2 = 43;
+    HARDWARE_REV_B4_128_PROTO_2 = 44;
 }
 
 // A command used by the mobile client to ask the hw device for its metadata.
@@ -76,7 +80,8 @@ message asic_metadata {
     uint32 die_y = 4;
     uint32 binning_version = 5;
     uint32 binning = 6;
-    bool valid = 7;  // True if there was an error trying to decode this metadata
+    bool valid = 7;     // True if there was an error trying to decode this metadata
+    uint64 grwvpl = 8;  // Manufacturer Part Number
 }
 
 message mining_asic_metadata_get_cmd {}
@@ -136,12 +141,13 @@ message diagnostics_capabilities {
 
 // Operational limits - defines safe operating thresholds.
 message operational_limits {
-    float voltage_min = 1;     // Minimum input voltage (V).
-    float voltage_max = 2;     // Maximum input voltage (V).
-    float current_max = 3;     // Maximum input current (A).
-    float board_temp_max = 4;  // Maximum board temperature (C).
-    float asic_temp_max = 5;   // Maximum ASIC temperature (C).
-    float asic_temp_min = 6;   // Minimum ASIC temperature (C).
+    float voltage_min = 1;      // Minimum input voltage (V).
+    float voltage_max = 2;      // Maximum input voltage (V).
+    float current_max = 3;      // Maximum input current (A).
+    float board_temp_max = 4;   // Maximum board temperature (C).
+    float asic_temp_max = 5;    // Maximum ASIC temperature (C).
+    float asic_temp_min = 6;    // Minimum ASIC temperature (C).
+    float voltage_initial = 7;  // Initial/starting input voltage (V).
 }
 
 // Capabilities API - response containing all hashboard capabilities.
@@ -208,6 +214,7 @@ message mining_difficulty_set_rsp {}
 message mining_performance_mode_set_cmd {
     mining_performance_mode mode = 1;
     float power_target_watts = 2;
+    mining_performance_pll_algorithm pll_algorithm = 3;
 }
 
 message mining_performance_mode_set_rsp {}
@@ -258,6 +265,31 @@ message dfu_unlock_cmd {
 }
 
 message dfu_unlock_rsp {}
+
+enum diagnostic_data_status {
+    DIAGNOSTIC_DATA_STATUS_UNSPECIFIED = 0;
+    DIAGNOSTIC_DATA_STATUS_DATA = 1;
+    DIAGNOSTIC_DATA_STATUS_NO_DATA = 2;
+}
+
+message diagnostic_data_status_cmd {}
+
+message diagnostic_data_status_rsp {
+    bool data_available = 1;
+    uint32 unexpected_reboot_count = 2;
+    mcu_reset_reason last_reboot_reason = 3;
+}
+
+message diagnostic_data_read_cmd {}
+
+message diagnostic_data_read_rsp {
+    diagnostic_data_status data_status = 1;
+    bytes data = 2;
+}
+
+message diagnostic_data_abort_cmd {}
+
+message diagnostic_data_abort_rsp {}
 
 // ASIC type enumeration.
 enum asic_type {
@@ -326,6 +358,9 @@ message hashboard_cmd {
         reset_cmd reset_cmd = 4;
         fan_speed_set_cmd fan_speed_set_cmd = 5;
         capabilities_cmd capabilities_cmd = 6;
+        diagnostic_data_status_cmd diagnostic_data_status_cmd = 7;
+        diagnostic_data_read_cmd diagnostic_data_read_cmd = 8;
+        diagnostic_data_abort_cmd diagnostic_data_abort_cmd = 9;
 
         // Mining
         mining_asic_metadata_get_cmd mining_asic_metadata_get_cmd = 10;
@@ -335,6 +370,7 @@ message hashboard_cmd {
         mining_performance_mode_set_cmd mining_performance_mode_set_cmd = 14;
 
         // Mfgtest
+        mfgtest_read_bist_cmd mfgtest_read_bist_cmd = 29;
         mfgtest_serial_write_cmd mfgtest_serial_write_cmd = 30;
         mfgtest_serial_read_cmd mfgtest_serial_read_cmd = 31;
         mfgtest_store_binning_cmd mfgtest_store_binning_cmd = 32;
@@ -346,6 +382,9 @@ message hashboard_cmd {
         mfgtest_stack_status_cmd mfgtest_stack_status_cmd = 38;
         dfu_write_secure_id_cmd dfu_write_secure_id_cmd = 39;
         mfgtest_asic_debug_cmd mfgtest_asic_debug_cmd = 40;
+        // TODO: Temporary hack for MTE
+        mfgtest_mc3_quick_test_cmd mfgtest_mc3_quick_test_cmd = 27;
+        mfgtest_mc3_get_asic_data_cmd mfgtest_mc3_get_asic_data_cmd = 28;
 
         // Debug
         echo_cmd echo_cmd = 41;
@@ -358,6 +397,10 @@ message hashboard_cmd {
         asic_freq_set_cmd asic_freq_set_cmd = 48;
         async_message_interval_cmd async_message_interval_cmd = 49;
         asic_freq_gain_set_cmd asic_freq_gain_set_cmd = 50;
+
+        // EVB
+        evb_power_on_cmd evb_power_on_cmd = 60;
+        evb_packet_send_cmd evb_packet_send_cmd = 61;
 
         // DFU
         dfu_status_cmd dfu_status_cmd = 100;
@@ -388,6 +431,9 @@ message hashboard_rsp {
         reset_rsp reset_rsp = 4;  // This is only sent if the reset fails
         fan_speed_set_rsp fan_speed_set_rsp = 5;
         capabilities_rsp capabilities_rsp = 6;
+        diagnostic_data_status_rsp diagnostic_data_status_rsp = 7;
+        diagnostic_data_read_rsp diagnostic_data_read_rsp = 8;
+        diagnostic_data_abort_rsp diagnostic_data_abort_rsp = 9;
 
         // Mining
         mining_asic_metadata_get_rsp mining_asic_metadata_get_rsp = 10;
@@ -397,6 +443,7 @@ message hashboard_rsp {
         mining_performance_mode_set_rsp mining_performance_mode_set_rsp = 14;
 
         // Mfgtest
+        mfgtest_read_bist_rsp mfgtest_read_bist_rsp = 29;
         mfgtest_serial_write_rsp mfgtest_serial_write_rsp = 30;
         mfgtest_serial_read_rsp mfgtest_serial_read_rsp = 31;
         mfgtest_store_binning_rsp mfgtest_store_binning_rsp = 32;
@@ -408,6 +455,9 @@ message hashboard_rsp {
         mfgtest_stack_status_rsp mfgtest_stack_status_rsp = 38;
         dfu_write_secure_id_rsp dfu_write_secure_id_rsp = 39;
         mfgtest_asic_debug_rsp mfgtest_asic_debug_rsp = 40;
+        // TODO: Temporary hack for MTE
+        mfgtest_mc3_quick_test_rsp mfgtest_mc3_quick_test_rsp = 27;
+        mfgtest_mc3_get_asic_data_rsp mfgtest_mc3_get_asic_data_rsp = 28;
 
         // Debug
         echo_rsp echo_rsp = 41;
@@ -420,6 +470,10 @@ message hashboard_rsp {
         asic_freq_set_rsp asic_freq_set_rsp = 48;
         async_message_interval_rsp async_message_interval_rsp = 49;
         asic_freq_gain_set_rsp asic_freq_gain_set_rsp = 50;
+
+        // EVB
+        evb_power_on_rsp evb_power_on_rsp = 60;
+        evb_packet_send_rsp evb_packet_send_rsp = 61;
 
         // DFU
         dfu_status_rsp dfu_status_rsp = 100;

--- a/proto-rig-api/grpc/hashboard_cmd_debug.proto
+++ b/proto-rig-api/grpc/hashboard_cmd_debug.proto
@@ -107,7 +107,7 @@ message async_message_interval_cmd {
     uint32 interval = 1;
 
     // The message to change the interval on
-    hashboard_async message = 2;
+    hashboard_async_message_type message_type = 2;
 }
 
 message async_message_interval_rsp {}

--- a/proto-rig-api/grpc/hashboard_cmd_evb.proto
+++ b/proto-rig-api/grpc/hashboard_cmd_evb.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package fwpb;
+
+option go_package = "pkg/proto;hashboard";
+
+message evb_power_on_cmd {
+    bool power_on = 1;
+}
+
+message evb_power_on_rsp {}
+
+message evb_packet_send_cmd {
+    bytes data = 1;
+    uint32 rx_len = 2;
+}
+
+message evb_packet_send_rsp {
+    bytes data = 1;
+}

--- a/proto-rig-api/grpc/hashboard_cmd_mfgtest.proto
+++ b/proto-rig-api/grpc/hashboard_cmd_mfgtest.proto
@@ -4,10 +4,24 @@ package fwpb;
 
 option go_package = "pkg/proto;hashboard";
 
+import "hashboard_async.proto";
+
 enum serial_type {
     SERIAL_UNSPECIFIED = 0;
     SERIAL_PCBA = 1;  // PCB Assembly Serial Number (After SMT)
     DEPRECATED = 2;   // Previously SERIAL_ASSEMBLY
+}
+
+message bist_reading {
+    uint32 domain = 1;
+    float asic_vdd = 2;
+    float vddio = 3;
+    float vddh = 4;
+}
+
+message mfgtest_read_bist_cmd {}
+message mfgtest_read_bist_rsp {
+    repeated bist_reading bist = 1;
 }
 
 message mfgtest_serial_write_cmd {
@@ -78,3 +92,15 @@ message dfu_write_secure_id_cmd {
 }
 
 message dfu_write_secure_id_rsp {}
+
+// TODO: Temporary hack for MTE
+message mfgtest_mc3_quick_test_cmd {}
+message mfgtest_mc3_quick_test_rsp {
+    bool success = 1;
+}
+
+message mfgtest_mc3_get_asic_data_cmd {}
+message mfgtest_mc3_get_asic_data_rsp {
+    repeated asic_status asics = 1;
+    repeated asic_debug_status asics_debug = 2;
+}

--- a/proto-rig-api/grpc/mfgtool_test_commands.proto
+++ b/proto-rig-api/grpc/mfgtool_test_commands.proto
@@ -25,7 +25,7 @@ enum ButtonState {
 
 // Service definition for communication between mfgtoolctl and mfgtoold.
 service MfgToolTestCommandsApi {
-    rpc FanSet(FanSetRequest) returns (miner_common_api.ApiResultResponse);
+    rpc FanSet(FanSetRequest) returns (miner_debug_api.SetFanSpeedResponse);
     rpc FanGet(FanGetRequest) returns (FanGetResponse);
     rpc LedSet(LedSetRequest) returns (miner_common_api.ApiResultResponse);
     rpc LedsSet(LedsSetRequest) returns (miner_common_api.ApiResultResponse);

--- a/proto-rig-api/grpc/miner_data_api.proto
+++ b/proto-rig-api/grpc/miner_data_api.proto
@@ -27,6 +27,7 @@ import "miner_error_code.proto";
 import "miner_psu_api.proto";
 import "miner_fan_api.proto";
 import "hashboard_cmd.proto";
+import "miner_hb_api.proto";
 
 // ---------------------------------
 // Miner Data API service definition
@@ -95,19 +96,6 @@ enum CoolingMode {
     COOLING_MODE_OFF = 1;
     COOLING_MODE_AUTO = 2;
     COOLING_MODE_MANUAL = 3;
-}
-
-enum HashboardState {
-    HASHBOARD_STATE_UNKNOWN = 0;
-    HASHBOARD_STATE_OFF = 1;
-    HASHBOARD_STATE_READY_FOR_POWER_ON = 2;
-    HASHBOARD_STATE_POWERING_ON = 3;
-    HASHBOARD_STATE_ON = 4;
-    HASHBOARD_STATE_CALIBRATING = 5;
-    HASHBOARD_STATE_MINING = 6;
-    HASHBOARD_STATE_POWERING_OFF = 7;
-    HASHBOARD_STATE_ERROR = 8;
-    HASHBOARD_STATE_ERROR_WITH_CONNECTED = 9;
 }
 
 enum UnifiedMinerFieldType {
@@ -485,13 +473,12 @@ message HashboardStatusResponse {
 
     uint32 hashboard_id = 2;
     string serial_number = 3;
-    HashboardState state = 4;
+    miner_hb_api.HashboardServiceState state = 4;
     uint32 uptime_s = 5;
-    uint32 power_on_count = 6;
-    uint32 hardware_errors = 7;
+    uint32 hardware_errors = 6;
 
-    MiningStatistics mining_statistics = 10;
-    repeated AsicStatusResponse asics = 11;
+    MiningStatistics mining_statistics = 7;
+    repeated AsicStatusResponse asics = 8;
 
 }
 
@@ -502,6 +489,9 @@ message AsicMiningStatistics {
     double temperature_c = 4;
     double voltage_mv = 5;
     double frequency_mhz = 6;
+    double vddi3_mv = 21;
+    double vddi2_mv = 22;
+    double vddi1_mv = 23;
 }
 
 message AsicStatusRequest {

--- a/proto-rig-api/grpc/miner_debug_api.proto
+++ b/proto-rig-api/grpc/miner_debug_api.proto
@@ -54,7 +54,7 @@ service MinerDebugApi {
     rpc SetRecoveryLimits(SetRecoveryLimitsMessage) returns (miner_common_api.ApiResultResponse);
 
     // Fan control
-    rpc SetFanSpeed(SetFanSpeedRequest) returns (miner_common_api.ApiResultResponse);
+    rpc SetFanSpeed(SetFanSpeedRequest) returns (SetFanSpeedResponse);
     rpc GetFanSpeed(miner_common_api.EmptyRequest) returns (GetFanSpeedResponse);
 
     // Temperature control
@@ -65,7 +65,6 @@ service MinerDebugApi {
     rpc GetMinerErrorStats(miner_common_api.EmptyRequest) returns (MinerErrorStats);
     rpc ResetMinerErrorStats(miner_common_api.EmptyRequest) returns (miner_common_api.ApiResultResponse);
     rpc GetHashboardErrorStats(miner_common_api.EmptyRequest) returns (HashboardErrorStatsList);
-    rpc ResetHashboardErrorStats(miner_common_api.EmptyRequest) returns (miner_common_api.ApiResultResponse);
     rpc GetPsuErrorStats(miner_common_api.EmptyRequest) returns (PsuErrorStatsList);
     rpc ResetPsuErrorStats(miner_common_api.EmptyRequest) returns (miner_common_api.ApiResultResponse);
 
@@ -121,7 +120,6 @@ message HashboardErrorStats {
     uint32 hb_max_temp_count = 6;              // [HB] Count of hashboard exceeding max temp.
     uint32 hb_over_current_count = 7;          // [HB] Count of hashboard over current errors.
     uint32 hb_over_voltage_count = 8;          // [HB] Count of hashboard over voltage errors.
-    uint32 hb_power_lost_count = 9;            // [HB] Count of hashboard power lost errors.
     uint32 hb_under_voltage_count = 10;        // [HB] Count of hashboard under voltage errors.
     uint32 hb_usb_connection_lost_count = 11;  // [HB] Count of hashboard USB connection lost errors.
     bool is_connected = 12;                    // [HB] Has the hashboard reconnected since the last disconnect.
@@ -133,6 +131,13 @@ message PsuErrorStatsList {
 }
 
 message PsuErrorStats {
+    reserved 8, 9, 10, 13, 19;
+    reserved "fans_fault_count",
+             "input_fault_count",
+             "output_fault_count",
+             "no_input_voltage_fault_count",
+             "power_no_good_count";
+
     uint32 index = 1;
     uint32 bay_index = 2;
     uint32 over_temp_count = 3;
@@ -140,18 +145,13 @@ message PsuErrorStats {
     uint32 over_voltage_count = 5;
     uint32 under_voltage_count = 6;
     uint32 communication_error_count = 7;
-    uint32 fans_fault_count = 8;
-    uint32 input_fault_count = 9;
-    uint32 output_fault_count = 10;
     uint32 llc_fault_count = 11;
     uint32 pfc_fault_count = 12;
-    uint32 no_input_voltage_fault_count = 13;
     bool enabled = 14;
     uint32 input_over_voltage_count = 15;
     uint32 input_under_voltage_count = 16;
     uint32 input_over_current_count = 17;
     uint32 over_power_count = 18;
-    uint32 power_no_good_count = 19;
 }
 
 // --------------------
@@ -176,6 +176,11 @@ message MiningInitStats {
 // --------------------
 // Fan control messages
 // --------------------
+message SetFanSpeedResponse {
+    miner_common_api.ApiResult result = 1;
+    repeated uint32 updated_fan_ids = 2; // Fan IDs whose speed was set successfully
+    repeated uint32 failed_fan_ids = 3;  // Fan IDs that failed to update
+}
 
 message GetFanSpeedResponse {
     miner_common_api.ApiResult result = 1;
@@ -288,6 +293,9 @@ message RecoveryLimitSetting {
 // This config structure is used in mcdd mining_control task to store/track the
 // recovery limits
 message RecoveryLimits {
+    reserved 13, 15, 18;
+    reserved "psu_fans_fault", "psu_output_fault", "psu_other";
+
     RecoveryLimitSetting asic_temp_and_voltage = 1;
     RecoveryLimitSetting hashboard_over_temp = 2;
     RecoveryLimitSetting hashboard_over_current = 3;
@@ -300,12 +308,9 @@ message RecoveryLimits {
     RecoveryLimitSetting psu_over_voltage = 10;
     RecoveryLimitSetting psu_under_voltage = 11;
     RecoveryLimitSetting psu_communication_error = 12;
-    RecoveryLimitSetting psu_fans_fault = 13;
     RecoveryLimitSetting psu_input_fault = 14;
-    RecoveryLimitSetting psu_output_fault = 15;
     RecoveryLimitSetting asic_communication_error = 16;
     RecoveryLimitSetting asic_over_temp = 17;
-    RecoveryLimitSetting psu_other = 18;  // Bucket for other PSU errors (e.g., transient MFR register issues)
     RecoveryLimitSetting psu_hardware_failure = 19;  // Hardware failures requiring shutdown (e.g., PFC/LLC circuit failures)
 }
 

--- a/proto-rig-api/grpc/miner_hb_api.proto
+++ b/proto-rig-api/grpc/miner_hb_api.proto
@@ -2,51 +2,30 @@ syntax = "proto3";
 
 package miner_hb_api;
 
-import "hashboard.proto";
 import "hashboard_async.proto";
 import "hashboard_cmd.proto";
 
 option go_package = "pkg/proto;miner_rpc";
 
-// HB Error code offset start at  0x40000;
 enum HbErrorCode {
     HB_ERROR_CODE_COMMUNICATION = 0;
-    HB_ERROR_CODE_INVALID_PARAM = 1;
-    HB_ERROR_CODE_MINING = 2;
-    HB_ERROR_CODE_NOT_READY = 3;
-    HB_ERROR_CODE_HASHBOARD_IN_ERROR_STATE = 4;
-    HB_ERROR_CODE_PARAM_NOT_IMPLEMENTED = 5;
-    HB_ERROR_CODE_SEND_STATS = 6;
-    HB_ERROR_CODE_SEND_WORK = 7;
-    HB_ERROR_CODE_SET_PARAM_FAILURE = 8;
-    HB_ERROR_CODE_STATE_TIMEOUT = 9;
-    HB_ERROR_CODE_INVALID_HASHBOARD_TYPE = 10;
-    HB_ERROR_CODE_COMMS_ALIVE = 11;
-    HB_ERROR_CODE_HARDWARE_LIMIT_TRIP = 12;
-    HB_ERROR_CODE_OVER_HEAT = 13;
-    HB_ERROR_CODE_TASK_COMMUNICATION_ERROR = 14;
-    HB_ERROR_CODE_UNKNOWN = 15;
-    HB_ERROR_CODE_COMMAND_TIMEOUT = 16;
-    HB_ERROR_CODE_USB_DEVICE_CREATION_ERROR = 17;
-    HB_ERROR_CODE_MISSING_COMM_CHANNEL = 18;
-    HB_ERROR_CODE_INVALID_METADATA_RESPONSE = 19;
-    HB_ERROR_CODE_INVALID_ADD_WORK_RESPONSE = 20;
-    HB_ERROR_CODE_COMM_TASKS_NOT_INITIALIZED = 21;
-    HB_ERROR_CODE_POWER_ON_TIMEOUT = 22;
-    HB_ERROR_CODE_OVER_CURRENT = 23;
-    HB_ERROR_CODE_POWER_LOST = 24;
-    HB_ERROR_CODE_USB_CONNECTION_LOST = 25;
-    HB_ERROR_CODE_ASIC_OVER_HEAT = 26;
-    HB_ERROR_CODE_ASIC_UNDER_VOLTAGE = 27;
-    HB_ERROR_CODE_ASIC_OVER_VOLTAGE = 28;
-    HB_ERROR_CODE_ASIC_ECC = 29;
-    HB_ERROR_CODE_ASIC_ENUMERATION = 30;
-    HB_ERROR_CODE_ASIC_NOT_HASHING = 31;
-    HB_ERROR_CODE_ASIC_UNDER_HEAT = 32;
-    HB_ERROR_CODE_OVER_VOLTAGE = 33;
-    HB_ERROR_CODE_UNDER_VOLTAGE = 34;
-    HB_ERROR_CODE_RECOVERY_IN_PROGRESS = 35;
-    HB_ERROR_CODE_CONNECT_FAILED = 36;
+    HB_ERROR_CODE_HASHBOARD_IN_ERROR_STATE = 1;
+    HB_ERROR_CODE_INVALID_HASHBOARD_TYPE = 2;
+    HB_ERROR_CODE_OVER_HEAT = 3;
+    HB_ERROR_CODE_UNKNOWN = 4;
+    HB_ERROR_CODE_POWER_ON_TIMEOUT = 5;
+    HB_ERROR_CODE_OVER_CURRENT = 6;
+    HB_ERROR_CODE_USB_CONNECTION_LOST = 7;
+    HB_ERROR_CODE_ASIC_OVER_HEAT = 8;
+    HB_ERROR_CODE_ASIC_UNDER_VOLTAGE = 9;
+    HB_ERROR_CODE_ASIC_OVER_VOLTAGE = 10;
+    HB_ERROR_CODE_ASIC_ECC = 11;
+    HB_ERROR_CODE_ASIC_ENUMERATION = 12;
+    HB_ERROR_CODE_ASIC_NOT_HASHING = 13;
+    HB_ERROR_CODE_ASIC_UNDER_HEAT = 14;
+    HB_ERROR_CODE_OVER_VOLTAGE = 15;
+    HB_ERROR_CODE_UNDER_VOLTAGE = 16;
+    HB_ERROR_CODE_USB_CONNECTION_ERROR = 17;
 }
 
 message HbError {
@@ -100,6 +79,12 @@ message PowerRange {
     uint32 max_watts = 2;
 }
 
+message MaxAvgMinTemps {
+    float max_c = 1;
+    float avg_c = 2;
+    float min_c = 3;
+}
+
 // hashboard.<slot>.status — published every 1s
 message HashboardPerformanceState {
     uint32 power_target_watts = 1;
@@ -110,29 +95,15 @@ message HashboardPerformanceState {
     bool sent = 5;
 }
 
-// Recovery counter snapshot for a single error code.
-message RecoveryState {
-    HbErrorCode error_code = 1;
-    uint32 current_try_count = 2; // attempts so far in the current window
-    uint32 max_try_count     = 3; // limit before the board is disabled
-}
-
 message HashboardStatus {
     HashboardServiceState state = 1;
-    uint32 up_time_ms = 2;
-    // Snapshot of all active recovery counters (non-zero within the rolling window).
-    repeated RecoveryState recovery_states = 3;
-    uint32 work_id = 4;
-    uint64 difficulty = 5;
-    HashboardPerformanceState performance_state = 6;
-    // Firmware mining FSM state; updated from AsyncSystemHealth.
-    fwpb.mining_state board_mining_state = 7;
-    // Last error code recorded before the most recent Init transition; absent if no error has occurred.
-    optional int32 last_error_code = 8;
+    uint32 work_id = 2;
+    uint64 difficulty = 3;
+    HashboardPerformanceState performance_state = 4;
     // Accumulated seconds spent in the Mining state; pauses when not mining.
-    uint32 mining_uptime_s = 9;
-    // Number of times this hashboard has transitioned into the Mining state.
-    uint32 power_on_count = 10;
+    uint32 mining_uptime_s = 5;
+    // Latched mining intent from the most recent StartMining/StopMining control command.
+    bool mining_enabled = 6;
 }
 
 // hashboard.<slot>.share — published on nonce received
@@ -170,6 +141,10 @@ message HashboardOperatingStats {
 // hashboard.<slot>.data.asic — published on ASIC stats update
 message AsicOperatingStats {
     repeated fwpb.asic_status asic_stats = 1;
+}
+
+message AsicDebugStats {
+  repeated fwpb.asic_debug_status asic_debug_stats = 1;
 }
 
 // fan.<fan_id>.data — published periodically with current fan state
@@ -245,12 +220,19 @@ message FanControl {
 // =============================================================================
 
 message InjectHashboardError {
-    repeated uint32 error_codes = 1;
+    // Firmware error causes to inject into simulated AsyncSystemHealth messages.
+    repeated fwpb.error_cause error_codes = 1;
+    // If false, errors are one-shot and consumed by the next health message.
+    // If true, errors persist until cleared with clear_injections.
+    bool persistent = 2;
 }
+
+message ClearHashboardInjections {}
 
 message HashboardSimControl {
     oneof cmd {
         InjectHashboardError inject_error = 1;
+        ClearHashboardInjections clear_injections = 2;
     }
 }
 

--- a/proto-rig-api/grpc/miner_psu_api.proto
+++ b/proto-rig-api/grpc/miner_psu_api.proto
@@ -16,24 +16,26 @@ enum SubPsuId {
 }
 
 enum PsuErrorCode {
+    reserved 5, 6, 7, 8, 9, 11, 12, 14, 16, 17, 19, 21;
+    reserved "PSU_ERROR_CODE_FANS",
+             "PSU_ERROR_CODE_INPUT",
+             "PSU_ERROR_CODE_OUTPUT_FAILURE",
+             "PSU_ERROR_CODE_POWER_NO_GOOD",
+             "PSU_ERROR_CODE_NO_INPUT_VOLTAGE",
+             "PSU_ERROR_CODE_SW_SET_OUTPUT_VOLTAGE_FAIL";
+
     PSU_ERROR_CODE_UNSPECIFIED = 0;
     PSU_ERROR_CODE_OUTPUT_OVER_VOLTAGE = 1;     // [PMBUS] (PMBUS_STATUS_VOUT)           Output voltage exceeds safe threshold
     PSU_ERROR_CODE_OUTPUT_OVER_CURRENT = 2;     // [PMBUS] (PMBUS_STATUS_IOUT)           Output current exceeds safe threshold
     PSU_ERROR_CODE_OVER_TEMPERATURE = 3;        // [PMBUS] (PMBUS_STATUS_TEMPERATURE)    PSU temperature exceeds safe threshold
     PSU_ERROR_CODE_OUTPUT_UNDER_VOLTAGE = 4;    // [PMBUS] (PMBUS_STATUS_VOUT)           Output voltage below minimum threshold
-    PSU_ERROR_CODE_FANS = 5;                    // [PMBUS] (PMBUS_STATUS_FANS_1_2)       PSU fan fault detected
-    PSU_ERROR_CODE_INPUT = 6;                   // [PMBUS] (PMBUS_STATUS_INPUT)          Input-side fault (generic)
     PSU_ERROR_CODE_OUTPUT_OVER_POWER = 10;      // [PMBUS] (PMBUS_STATUS_IOUT:POUT)     Output power exceeds rated capacity
-    PSU_ERROR_CODE_OUTPUT_FAILURE = 11;         // [PMBUS] (PMBUS_STATUS_VOUT)           Output stage failure
     PSU_ERROR_CODE_COMM_LOST = 13;              // [PMBUS] (PMBUS_STATUS_CML)            Communication with PSU lost (I2C/PMBus)
     PSU_ERROR_CODE_UNDER_TEMPERATURE = 15;      // [PMBUS] (PMBUS_STATUS_TEMPERATURE)    PSU temperature below minimum threshold
-    PSU_ERROR_CODE_POWER_NO_GOOD = 17;          // [PMBUS] (PMBUS_STATUS_MFR_SPECIFIC)  One of two internal PSU modules is not functioning properly (Chicony-specific)
     PSU_ERROR_CODE_PFC_FAILURE = 18;            // [PMBUS] (PMBUS_STATUS_MFR_SPECIFIC)  PFC circuit failure (Chicony-specific)
-    PSU_ERROR_CODE_NO_INPUT_VOLTAGE = 19;       // [PMBUS] (PMBUS_STATUS_INPUT)          No input AC/DC voltage detected
 
     // Software detected errors
     PSU_ERROR_CODE_SW_ENABLE_FAIL = 20;              // Failed to enable PSU output (includes voltage settle timeout)
-    PSU_ERROR_CODE_SW_SET_OUTPUT_VOLTAGE_FAIL = 21;  // Failed to set output voltage
     PSU_ERROR_CODE_FIRMWARE_MISMATCH = 22;           // PSU firmware version mismatch detected
 
     // Input-side faults
@@ -268,6 +270,7 @@ message PsuControl {
   // Firmware update command - triggers update from /etc/psu-firmware
   message FwUpdate {
     bool force = 1;
+    string psu_type = 2;  // Optional PSU type override (e.g. "boco_bs502a17"). Empty = auto-detect.
   }
 
   oneof cmd {

--- a/proto-rig-api/grpc/miner_system_api.proto
+++ b/proto-rig-api/grpc/miner_system_api.proto
@@ -129,6 +129,7 @@ message UploadResponse {
 
 message SchedulePsuFirmwareUpdateRequest {
     bool force = 1;
+    map<uint32, string> psu_types = 2;  // Per-PSU type overrides: psu_id → type string. Absent = auto-detect.
 }
 
 message SchedulePsuFirmwareUpdateResponse {

--- a/proto-rig-api/grpc/miner_telemetry_api.proto
+++ b/proto-rig-api/grpc/miner_telemetry_api.proto
@@ -1,0 +1,67 @@
+// Copyright 2024 Block, Inc. <btcm-sw-team@squareup.com>.
+//
+// File: miner_telemetry_api.proto
+// Description: gRPC server-streaming API exposed by the on-rig
+//              telemetry-service. Streams OTLP metrics and OTLP logs
+//              aggregated from all services on the rig to an off-rig client
+//              (otlp-bridge). Each batch carries a prost-encoded OTLP request
+//              as opaque bytes so the bridge can pass it through to a
+//              Prometheus / OTel collector without transcoding.
+
+syntax = "proto3";
+
+package miner_telemetry_api;
+
+option go_package = "pkg/proto;miner_rpc";
+
+import "google/protobuf/timestamp.proto";
+
+// ---------------------------------------------------------------------------
+// MinerTelemetryApi service
+// ---------------------------------------------------------------------------
+
+service MinerTelemetryApi {
+  // Server-streaming. The server emits an immediate snapshot, then a fresh
+  // MetricsBatch on every NATS ingestion update for any matching service.
+  // service_names may filter the stream (empty = all services).
+  rpc StreamMetrics(StreamMetricsRequest) returns (stream MetricsBatch);
+
+  // Server-streaming. The server follows live log entries as they arrive on
+  // NATS. Logs emitted while no client is connected are not replayed.
+  rpc StreamLogs(StreamLogsRequest) returns (stream LogsBatch);
+}
+
+// ---------------------------------------------------------------------------
+// Metrics stream
+// ---------------------------------------------------------------------------
+
+message StreamMetricsRequest {
+  // Optional service-name filter. Empty list streams every service.
+  repeated string service_names = 1;
+}
+
+message MetricsBatch {
+  // Prost-encoded
+  // opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest.
+  // Treated as opaque bytes on the wire so the rpc crate does not need the
+  // OTLP message types compiled in.
+  bytes otlp_payload = 1;
+
+  // Server wall-clock time at which this batch was emitted.
+  google.protobuf.Timestamp emitted_at = 2;
+}
+
+// ---------------------------------------------------------------------------
+// Logs stream
+// ---------------------------------------------------------------------------
+
+message StreamLogsRequest {
+  // Optional service-name filter. Empty list streams every service.
+  repeated string service_names = 1;
+}
+
+message LogsBatch {
+  // Prost-encoded
+  // opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest.
+  bytes otlp_payload = 1;
+}

--- a/proto-rig-api/openapi/MDK-API.json
+++ b/proto-rig-api/openapi/MDK-API.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "url": "https://opensource.org/license/mit"
     },
-    "version": "1.8.0"
+    "version": "1.8.1"
   },
   "servers": [
     {
@@ -1988,7 +1988,7 @@
         "tags": [
           "PSUs"
         ],
-        "description": "Triggers a PSU firmware update. Publishes a firmware update command to each connected PSU via NATS. Use the `force` parameter to allow re-flashing the same firmware version.",
+        "description": "Triggers a PSU firmware update. Publishes a firmware update command to each connected PSU via NATS. Use the `force` query parameter to allow re-flashing the same firmware version. Use `psu_types` in the request body to override auto-detected PSU types per slot.",
         "operationId": "PostUpdatePsu",
         "parameters": [
           {
@@ -2002,6 +2002,34 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "psu_types": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string",
+                      "enum": [
+                        "chicony_s24",
+                        "boco_bs402a17",
+                        "boco_bs502a17"
+                      ]
+                    },
+                    "description": "Per-PSU type overrides. Keys are PSU slot IDs (1-3). Omitted slots use auto-detection.",
+                    "example": {
+                      "1": "boco_bs502a17",
+                      "2": "boco_bs402a17"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "202": {
             "description": "The PSU firmware update has been requested.",
@@ -2639,7 +2667,7 @@
         "tags": [
           "System"
         ],
-        "description": "Get the current system telemetry enabled status.",
+        "description": "Get whether telemetry-service is currently running.",
         "operationId": "GetSystemTelemetryEnabled",
         "responses": {
           "200": {
@@ -2667,7 +2695,7 @@
             }
           },
           "500": {
-            "description": "Internal server error while reading telemetry configuration.",
+            "description": "Internal server error while reading telemetry-service state.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2682,10 +2710,10 @@
         "tags": [
           "System"
         ],
-        "description": "Configure system telemetry enabled settings.",
+        "description": "Start or stop telemetry-service.",
         "operationId": "SetSystemTelemetryEnabled",
         "requestBody": {
-          "description": "Telemetry configuration settings for data collection",
+          "description": "Desired telemetry-service state",
           "content": {
             "application/json": {
               "schema": {
@@ -2700,7 +2728,7 @@
         },
         "responses": {
           "200": {
-            "description": "The telemetry configuration has been successfully updated.",
+            "description": "The telemetry-service state has been successfully updated.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2708,7 +2736,7 @@
                 },
                 "example": {
                   "enabled": true,
-                  "message": "Enabling telemetry"
+                  "message": "Telemetry is enabled"
                 }
               }
             }
@@ -2717,7 +2745,7 @@
             "$ref": "#/components/responses/BadRequest"
           },
           "500": {
-            "description": "Internal server error while setting telemetry configuration.",
+            "description": "Internal server error while setting telemetry-service state.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4389,7 +4417,8 @@
               "B3a",
               "B3b",
               "B3bSim",
-              "B4",
+              "B4_128",
+              "B4_192",
               "B4Sim"
             ]
           },
@@ -5004,18 +5033,18 @@
           },
           "default_password_active": {
             "type": "boolean",
-            "description": "True when the miner is in secure mode and the factory default password is still active. Clients should prompt for a password change, and most authenticated endpoints are 403-gated until changed.",
+            "description": "True when the system is secure and the default password has not been changed. Clients should prompt the user to change their password when this is true.",
             "example": false
           }
         }
       },
       "TelemetryConfig": {
         "type": "object",
-        "description": "Configuration for telemetry data collection",
+        "description": "Desired telemetry-service state",
         "properties": {
           "enabled": {
             "type": "boolean",
-            "description": "Enable or disable telemetry",
+            "description": "Whether telemetry-service should be running",
             "example": true
           }
         },
@@ -5025,11 +5054,11 @@
       },
       "TelemetryResponse": {
         "type": "object",
-        "description": "Response containing telemetry status information",
+        "description": "Response containing telemetry-service status information",
         "properties": {
           "enabled": {
             "type": "boolean",
-            "description": "Whether telemetry is currently enabled",
+            "description": "Whether telemetry-service is currently running",
             "example": true
           },
           "message": {

--- a/server/fake-proto-rig/README.md
+++ b/server/fake-proto-rig/README.md
@@ -202,6 +202,9 @@ When implementing or updating endpoints, verify these common patterns from the O
 | **Hashboard status enum** | `"Running"`, `"Stopped"`, `"Error"`, `"Overheated"`, `"Unknown"` | `"Mining"`, `"Off"` |
 | **Mining status enum** | `"PoweringOn"`, `"Uninitialized"` | `"Starting"`, `"Unknown"` |
 | **PerformanceMode enum** | `"MaximumHashrate"`, `"Efficiency"` | `"MaximumEfficiency"` |
+| **Board enum** | `"B4_128"`, `"B4_192"` | `"B4"` (split in MDK-API 1.8.1) |
+| **Telemetry-service status** | GET/PUT `/system/telemetry` return `{"enabled", "message"}` (TelemetryResponse) | bare `{"enabled"}` or a message-only body |
+| **PSU update body** | optional `psu_types` map (slot ID → PSU type enum), validated (422 on bad value/slot) | ignore body or accept unknown PSU types |
 | **Port field** | `json:"port"` (0 is valid) | `json:"port,omitempty"` (omits 0) |
 | **TimeSeriesRequest** | Validate `start_time` and `levels` are required (return 422) | Accept missing required fields |
 

--- a/server/fake-proto-rig/models.go
+++ b/server/fake-proto-rig/models.go
@@ -177,6 +177,9 @@ type MinerState struct {
 	// Locate sequence active
 	LocateActive bool
 
+	// Telemetry-service running state (toggled via PUT /api/v1/system/telemetry)
+	TelemetryEnabled bool
+
 	// Firmware update simulation
 	FWUpdateStatus    string // "current", "downloading", "downloaded", "installing", "installed"
 	FWCurrentVersion  string // running firmware version; initialized to defaultFirmwareVersion
@@ -220,6 +223,7 @@ func NewMinerState(serialNumber, macAddress string) *MinerState {
 		TargetTempC:        defaultTargetTempC,
 		PowerTargetW:       defaultPowerTargetW,
 		PerformanceModeVal: PerformanceModeMaxHashrate,
+		TelemetryEnabled:   true,
 		DHCP:               true,
 		NetMask:            "255.255.255.0",
 		Gateway:            "192.168.2.1",
@@ -566,6 +570,20 @@ func (s *MinerState) SetLocateActive(active bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.LocateActive = active
+}
+
+// IsTelemetryEnabled reports whether the telemetry-service is running.
+func (s *MinerState) IsTelemetryEnabled() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.TelemetryEnabled
+}
+
+// SetTelemetryEnabled starts or stops the telemetry-service.
+func (s *MinerState) SetTelemetryEnabled(enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.TelemetryEnabled = enabled
 }
 
 // applyVariation adds random variation to a base value.

--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -456,8 +456,10 @@ type TelemetryResponse struct {
 
 // TelemetryConfig is the desired telemetry-service state for
 // PUT /api/v1/system/telemetry (matches OpenAPI TelemetryConfig).
+// Enabled is a pointer so an absent or null field (which the schema marks
+// required) is rejected rather than silently read as false.
 type TelemetryConfig struct {
-	Enabled bool `json:"enabled"`
+	Enabled *bool `json:"enabled"`
 }
 
 // TelemetryServiceStatus reports whether the telemetry-service is running
@@ -1786,8 +1788,14 @@ func (h *RESTApiHandler) handleTelemetryConfig(w http.ResponseWriter, r *http.Re
 			h.writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
-		h.state.SetTelemetryEnabled(cfg.Enabled)
-		h.writeJSON(w, http.StatusOK, telemetryServiceStatus(cfg.Enabled))
+		// enabled is required by the schema; reject {} or {"enabled": null}
+		// rather than letting a missing field silently stop the telemetry-service.
+		if cfg.Enabled == nil {
+			h.writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "enabled is required")
+			return
+		}
+		h.state.SetTelemetryEnabled(*cfg.Enabled)
+		h.writeJSON(w, http.StatusOK, telemetryServiceStatus(*cfg.Enabled))
 	default:
 		h.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Method not allowed")
 	}

--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -451,6 +452,19 @@ type TelemetryResponse struct {
 	Miner      *MinerTelemetry      `json:"miner,omitempty"`
 	Hashboards []HashboardTelemetry `json:"hashboards,omitempty"`
 	PSUs       []PSUTelemetry       `json:"psus,omitempty"`
+}
+
+// TelemetryConfig is the desired telemetry-service state for
+// PUT /api/v1/system/telemetry (matches OpenAPI TelemetryConfig).
+type TelemetryConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
+// TelemetryServiceStatus reports whether the telemetry-service is running
+// (matches OpenAPI TelemetryResponse, returned by GET/PUT system/telemetry).
+type TelemetryServiceStatus struct {
+	Enabled bool   `json:"enabled"`
+	Message string `json:"message"`
 }
 
 // MetricValue represents a metric with value and unit
@@ -1765,12 +1779,27 @@ func (h *RESTApiHandler) handleTag(w http.ResponseWriter, r *http.Request) {
 func (h *RESTApiHandler) handleTelemetryConfig(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		h.writeJSON(w, http.StatusOK, map[string]bool{"enabled": true})
+		h.writeJSON(w, http.StatusOK, telemetryServiceStatus(h.state.IsTelemetryEnabled()))
 	case http.MethodPut:
-		h.writeJSON(w, http.StatusOK, MessageResponse{Message: "Telemetry configuration updated"})
+		var cfg TelemetryConfig
+		if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+			h.writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+			return
+		}
+		h.state.SetTelemetryEnabled(cfg.Enabled)
+		h.writeJSON(w, http.StatusOK, telemetryServiceStatus(cfg.Enabled))
 	default:
 		h.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Method not allowed")
 	}
+}
+
+// telemetryServiceStatus builds the OpenAPI TelemetryResponse for a given state.
+func telemetryServiceStatus(enabled bool) TelemetryServiceStatus {
+	msg := "Telemetry is disabled"
+	if enabled {
+		msg = "Telemetry is enabled"
+	}
+	return TelemetryServiceStatus{Enabled: enabled, Message: msg}
 }
 
 // Mining handlers
@@ -1995,7 +2024,7 @@ func (h *RESTApiHandler) handleHardware(w http.ResponseWriter, r *http.Request) 
 			ChipID:       "BM1370",
 			ASICCount:    defaultASICCount,
 			MiningASIC:   "BZM",
-			Board:        "B4",
+			Board:        "B4_128",
 		})
 	}
 
@@ -2093,7 +2122,7 @@ func (h *RESTApiHandler) handleHashboards(w http.ResponseWriter, r *http.Request
 			ChipID:       "BM1370",
 			ASICCount:    defaultASICCount,
 			MiningASIC:   "BZM",
-			Board:        "B4",
+			Board:        "B4_128",
 		})
 	}
 
@@ -2321,12 +2350,51 @@ func (h *RESTApiHandler) handlePowerSupplies(w http.ResponseWriter, r *http.Requ
 	h.writeJSON(w, http.StatusOK, PowerSuppliesResponse{PSUs: psus})
 }
 
+// PowerSuppliesUpdateRequest is the optional body for the PSU firmware update.
+// psu_types overrides auto-detected PSU types per slot (matches OpenAPI psu_types).
+type PowerSuppliesUpdateRequest struct {
+	PSUTypes map[string]string `json:"psu_types,omitempty"`
+}
+
+// validPSUTypes are the PSU type identifiers accepted by psu_types overrides.
+var validPSUTypes = map[string]bool{
+	"chicony_s24":   true,
+	"boco_bs402a17": true,
+	"boco_bs502a17": true,
+}
+
 func (h *RESTApiHandler) handlePowerSuppliesUpdate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		h.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Method not allowed")
 		return
 	}
-	h.writeJSON(w, http.StatusAccepted, MessageResponse{Message: "PSU firmware update started"})
+
+	// The request body is optional; an empty body means auto-detect every PSU.
+	var req PowerSuppliesUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		h.writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	// Validate per-slot overrides: keys are PSU slot IDs (1-3), values are known PSU types.
+	for slot, psuType := range req.PSUTypes {
+		if id, err := strconv.Atoi(slot); err != nil || id < 1 || id > 3 {
+			h.writeError(w, http.StatusUnprocessableEntity, "INVALID_PSU_SLOT",
+				fmt.Sprintf("psu_types key %q must be a slot ID between 1 and 3", slot))
+			return
+		}
+		if !validPSUTypes[psuType] {
+			h.writeError(w, http.StatusUnprocessableEntity, "INVALID_PSU_TYPE",
+				fmt.Sprintf("unknown PSU type %q for slot %s", psuType, slot))
+			return
+		}
+	}
+
+	msg := "PSU firmware update started"
+	if n := len(req.PSUTypes); n > 0 {
+		msg = fmt.Sprintf("PSU firmware update started with %d PSU type override(s)", n)
+	}
+	h.writeJSON(w, http.StatusAccepted, MessageResponse{Message: msg})
 }
 
 // Cooling handlers

--- a/server/fake-proto-rig/rest_api_handler_test.go
+++ b/server/fake-proto-rig/rest_api_handler_test.go
@@ -2042,3 +2042,178 @@ func TestHandleUpdate_PutWhileDownloading_Rejects(t *testing.T) {
 		t.Fatalf("expected %d, got %d; body=%s", http.StatusConflict, rr.Code, rr.Body.String())
 	}
 }
+
+func TestTelemetryService_GET_ReturnsRunningStatus(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/telemetry", nil)
+	h.handleTelemetryConfig(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	var status TelemetryServiceStatus
+	if err := json.Unmarshal(rr.Body.Bytes(), &status); err != nil {
+		t.Fatalf("failed to unmarshal status: %v; body=%s", err, rr.Body.String())
+	}
+	if !status.Enabled {
+		t.Errorf("expected telemetry enabled by default, got %v", status.Enabled)
+	}
+	if status.Message != "Telemetry is enabled" {
+		t.Errorf("expected message %q, got %q", "Telemetry is enabled", status.Message)
+	}
+}
+
+func TestTelemetryService_PUT_StopsServiceAndPersists(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/telemetry", strings.NewReader(`{"enabled":false}`))
+	h.handleTelemetryConfig(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	var status TelemetryServiceStatus
+	if err := json.Unmarshal(rr.Body.Bytes(), &status); err != nil {
+		t.Fatalf("failed to unmarshal status: %v; body=%s", err, rr.Body.String())
+	}
+	if status.Enabled || status.Message != "Telemetry is disabled" {
+		t.Errorf("expected disabled status, got %+v", status)
+	}
+	if state.IsTelemetryEnabled() {
+		t.Error("expected telemetry state to be disabled after PUT")
+	}
+
+	// A subsequent GET reflects the persisted state.
+	getRR := httptest.NewRecorder()
+	h.handleTelemetryConfig(getRR, httptest.NewRequest(http.MethodGet, "/api/v1/system/telemetry", nil))
+	var getStatus TelemetryServiceStatus
+	if err := json.Unmarshal(getRR.Body.Bytes(), &getStatus); err != nil {
+		t.Fatalf("failed to unmarshal status: %v; body=%s", err, getRR.Body.String())
+	}
+	if getStatus.Enabled {
+		t.Error("expected GET after PUT to report telemetry disabled")
+	}
+}
+
+func TestTelemetryService_PUT_InvalidBody_Returns400(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/telemetry", strings.NewReader(`{not json`))
+	h.handleTelemetryConfig(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+}
+
+func TestPowerSuppliesUpdate_EmptyBody_Returns202(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/power-supplies/update", nil)
+	h.handlePowerSuppliesUpdate(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusAccepted, rr.Code, rr.Body.String())
+	}
+}
+
+func TestPowerSuppliesUpdate_ValidPSUTypes_Returns202(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+
+	rr := httptest.NewRecorder()
+	body := `{"psu_types":{"1":"boco_bs502a17","2":"boco_bs402a17"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/power-supplies/update", strings.NewReader(body))
+	h.handlePowerSuppliesUpdate(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusAccepted, rr.Code, rr.Body.String())
+	}
+}
+
+func TestPowerSuppliesUpdate_UnknownPSUType_Returns422(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+
+	rr := httptest.NewRecorder()
+	body := `{"psu_types":{"1":"acme_9000"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/power-supplies/update", strings.NewReader(body))
+	h.handlePowerSuppliesUpdate(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusUnprocessableEntity, rr.Code, rr.Body.String())
+	}
+}
+
+func TestPowerSuppliesUpdate_InvalidSlot_Returns422(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+
+	rr := httptest.NewRecorder()
+	body := `{"psu_types":{"9":"chicony_s24"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/power-supplies/update", strings.NewReader(body))
+	h.handlePowerSuppliesUpdate(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusUnprocessableEntity, rr.Code, rr.Body.String())
+	}
+}
+
+func TestPowerSuppliesUpdate_MalformedJSON_Returns400(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/power-supplies/update", strings.NewReader(`{"psu_types":`))
+	h.handlePowerSuppliesUpdate(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+}
+
+func TestHashboardEndpoints_ReportValidBoardEnum(t *testing.T) {
+	// MDK-API 1.8.1 split the "B4" board enum into "B4_128"/"B4_192"; both the
+	// /hardware and /hashboards handlers must report a value still in the enum.
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+
+	hwRR := httptest.NewRecorder()
+	h.handleHardware(hwRR, httptest.NewRequest(http.MethodGet, "/api/v1/hardware", nil))
+	var hw HardwareInfo
+	if err := json.Unmarshal(hwRR.Body.Bytes(), &hw); err != nil {
+		t.Fatalf("failed to unmarshal hardware info: %v; body=%s", err, hwRR.Body.String())
+	}
+	if len(hw.HardwareInfo.Hashboards) == 0 {
+		t.Fatal("expected at least one hashboard from /hardware")
+	}
+	for _, hb := range hw.HardwareInfo.Hashboards {
+		if hb.Board != "B4_128" {
+			t.Errorf("/hardware: expected board %q, got %q", "B4_128", hb.Board)
+		}
+	}
+
+	hbRR := httptest.NewRecorder()
+	h.handleHashboards(hbRR, httptest.NewRequest(http.MethodGet, "/api/v1/hashboards", nil))
+	var hbs HashboardsResponse
+	if err := json.Unmarshal(hbRR.Body.Bytes(), &hbs); err != nil {
+		t.Fatalf("failed to unmarshal hashboards: %v; body=%s", err, hbRR.Body.String())
+	}
+	if len(hbs.Hashboards) == 0 {
+		t.Fatal("expected at least one hashboard from /hashboards")
+	}
+	for _, hb := range hbs.Hashboards {
+		if hb.Board != "B4_128" {
+			t.Errorf("/hashboards: expected board %q, got %q", "B4_128", hb.Board)
+		}
+	}
+}

--- a/server/fake-proto-rig/rest_api_handler_test.go
+++ b/server/fake-proto-rig/rest_api_handler_test.go
@@ -2101,15 +2101,31 @@ func TestTelemetryService_PUT_StopsServiceAndPersists(t *testing.T) {
 }
 
 func TestTelemetryService_PUT_InvalidBody_Returns400(t *testing.T) {
-	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
-	h := NewRESTApiHandler(state)
+	// enabled is required by the schema, so a malformed body, an empty object,
+	// or an explicit null must be rejected without mutating telemetry state.
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"malformed JSON", `{not json`},
+		{"missing enabled", `{}`},
+		{"null enabled", `{"enabled": null}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+			h := NewRESTApiHandler(state)
 
-	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/telemetry", strings.NewReader(`{not json`))
-	h.handleTelemetryConfig(rr, req)
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/system/telemetry", strings.NewReader(tc.body))
+			h.handleTelemetryConfig(rr, req)
 
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("expected %d, got %d; body=%s", http.StatusBadRequest, rr.Code, rr.Body.String())
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("expected %d, got %d; body=%s", http.StatusBadRequest, rr.Code, rr.Body.String())
+			}
+			if !state.IsTelemetryEnabled() {
+				t.Error("telemetry must stay enabled (default) when the request is rejected")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Re-vendors the Proto Rig API specifications from the private `miner-firmware` repository and brings the in-repo consumers — the ProtoOS TypeScript client and the fake-proto-rig simulator — in line with MDK-API **1.8.1**. The previous vendored snapshot was from 2026-05-04.

## What changed in the API

- **Board enum split.** The hashboard `board` value `"B4"` is replaced by two variants, `"B4_128"` and `"B4_192"`.
- **PSU firmware update gains an optional `psu_types` body.** Callers may override the auto-detected PSU type per slot (slot IDs `1`–`3`, values from the `chicony_s24` / `boco_bs402a17` / `boco_bs502a17` enum).
- **Telemetry reframed as a "telemetry-service".** `GET`/`PUT /api/v1/system/telemetry` now describe starting/stopping the on-rig telemetry-service and return `{ enabled, message }`. A new `miner_telemetry_api.proto` defines its OTLP metrics/logs streaming gRPC API.
- New `hashboard_cmd_evb.proto`, plus assorted reference-only proto updates (error-code enums, a new `HashboardState`, RPC signature changes).

## Vendoring notes

- Hashboard protos now come from the `external/hashboard` submodule, not the old `crates/mcdd/hashboard` path. `VERSION.md` records the exact source revisions and the corrected source paths.
- The `grpc/*.proto` files are vendored as reference only — they document the on-rig gRPC surface and are not inputs to code generation. `MDK-API.json` is the spec that drives the generated ProtoOS client and the simulator; this is now stated in `VERSION.md`/`README.md`.

## Simulator (fake-proto-rig)

- Reports `board: "B4_128"` (the removed `"B4"` value).
- `/system/telemetry` returns the `TelemetryResponse` shape and persists the telemetry-service on/off state across requests. The `PUT` honors the schema's required `enabled` field, rejecting a missing or null value with `400` rather than silently disabling the service.
- The PSU firmware update accepts and validates the optional `psu_types` body (`422` on an unknown PSU type or out-of-range slot, `400` on malformed JSON).
- New table-driven tests cover each of the above.

## Generated client

`generatedApi.ts` is regenerated from the new spec. Besides the spec-driven changes, the diff also reflects `swagger-typescript-api` **13.12.0** output — the version pinned in `package.json`/lockfile. The committed file had been generated with a stale `13.9.1`, so a handful of all-optional query params pick up `= {}` defaults. Running `npm ci` first reproduces this exactly.

## Verification

- All 21 vendored protos and the OpenAPI spec match the firmware source byte for byte.
- `fake-proto-rig`: `go build`, `go vet`, `gofmt`/`goimports`, and the full test suite pass (including the new cases).
- Pre-push hooks pass: `golangci-lint` reports 0 issues and `tsc --noEmit` type-checks the client against the regenerated types.
