### PR TITLE
feat(authz): hide miner actions the caller can't invoke

### DIFF
--- a/client/src/protoFleet/components/PageHeader/useSchedulePillData.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/useSchedulePillData.test.tsx
@@ -72,10 +72,12 @@ describe("useSchedulePillData", () => {
     expect(refreshSchedules).not.toHaveBeenCalled();
   });
 
-  it("does not poll for sessions without schedule:read", async () => {
-    // ListSchedules is server-side gated on schedule:read; without a
-    // permission-side guard the hook would generate PermissionDenied
-    // every poll interval for sessions whose role lacks the key.
+  it("does not poll for sessions without schedule:manage", async () => {
+    // The hook gates polling on schedule:manage (see useSchedulePillData.ts):
+    // the pill is a "schedules-in-flight" affordance that only acts on
+    // editable schedules, so :read sessions get no header surface and
+    // skipping the 30s poll loop avoids PermissionDenied every tick for
+    // sessions without :manage.
     vi.mocked(useHasPermission).mockReturnValue(false);
 
     renderHook(() => useSchedulePillData());

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -61,8 +61,9 @@ export const primaryNavItems: NavItem[] = [
     path: "/activity",
     label: "Activity",
     icon: Activity,
-    // ActivityService is server-gated on activity:read.
-    requiredPermission: "activity:read",
+    // ActivityService is still pending its activity:read catalog key
+    // (tracked separately). Once the server-side gating lands, gate
+    // this nav entry on activity:read to mirror the RPC gate.
   },
   {
     path: "/settings",

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -34,11 +34,14 @@ export const primaryNavItems: NavItem[] = [
           path: "/sites",
           label: "Sites",
           icon: Site,
-          // SitesPage renders site CRUD with no view-only mode, so gate
-          // the nav on site:manage to match the page's capability
-          // rather than the list RPC's site:read. Same shape as the
-          // Pools and Schedules secondary-nav entries.
-          requiredPermission: "site:manage",
+          // Gate on site:read so any role that can list sites can
+          // navigate to the overview. SitesPage renders the read view
+          // for everyone (ListSites + ListBuildings, both site:read);
+          // the "Add site" CTA and per-card edit/delete affordances
+          // gate on site:manage independently inside the page, so
+          // restricting the nav to site:manage would hide a useful
+          // surface from read-only roles for no security benefit.
+          requiredPermission: "site:read",
         },
       ]
     : []),

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -61,9 +61,8 @@ export const primaryNavItems: NavItem[] = [
     path: "/activity",
     label: "Activity",
     icon: Activity,
-    // ActivityService is still pending its activity:read catalog key
-    // (tracked separately). Once the server-side gating lands, gate
-    // this nav entry on activity:read to mirror the RPC gate.
+    // ActivityService is server-gated on activity:read.
+    requiredPermission: "activity:read",
   },
   {
     path: "/settings",

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -61,9 +61,8 @@ export const primaryNavItems: NavItem[] = [
     path: "/activity",
     label: "Activity",
     icon: Activity,
-    // ActivityService is still pending its activity:read catalog key
-    // (tracked separately). Once the server-side gating lands, gate
-    // this nav entry on activity:read to mirror the RPC gate.
+    // ActivityService is server-gated on activity:read (PR #347).
+    requiredPermission: "activity:read",
   },
   {
     path: "/settings",

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
@@ -192,6 +192,13 @@ vi.mock("./useMinerActions", () => ({
   useMinerActions: mockUseMinerActions,
 }));
 
+// Pass through the permission filter so rendering tests don't need to
+// seed the auth store with every miner permission key. The filter
+// behavior itself is covered by actionPermissions.test.tsx.
+vi.mock("./actionPermissions", () => ({
+  usePermittedActions: <T,>(actions: T[]): T[] => actions,
+}));
+
 vi.mock("@/protoFleet/features/fleetManagement/hooks/useBatchOperations", () => ({
   useBatchActions: mockUseBatchActions,
 }));

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -3,6 +3,7 @@ import PoolSelectionPageWrapper from "../ActionBar/SettingsWidget/PoolSelectionP
 import BulkActionsWidget, { BulkActionsPopover } from "../BulkActions";
 import { type BulkAction } from "../BulkActions/types";
 import { insertActionAfter, insertActionBefore } from "./actionMenuUtils";
+import { usePermittedActions } from "./actionPermissions";
 import AddToGroupModal from "./AddToGroupModal";
 import BulkRenameModal from "./BulkRenameModal";
 import BulkWorkerNameModal from "./BulkWorkerNameModal";
@@ -215,9 +216,14 @@ const MinerActionsMenu = ({
     return [...actions, renameAction];
   }, [handleBulkWorkerNamesOpen, onActionStart, popoverActions]);
 
+  // Hide actions whose backing RPC the caller can't invoke. The server
+  // still enforces every gate; this filter is UX so the menu doesn't
+  // surface options that 403 on click.
+  const permittedActions = usePermittedActions(actionsWithBulkRename);
+
   const visibleActions = useMemo(() => {
-    if (!selectionIncludesUnauthenticatedMiner) return actionsWithBulkRename;
-    return actionsWithBulkRename.map((action) =>
+    if (!selectionIncludesUnauthenticatedMiner) return permittedActions;
+    return permittedActions.map((action) =>
       action.action === deviceActions.unpair
         ? action
         : {
@@ -226,7 +232,7 @@ const MinerActionsMenu = ({
             disabledReason: "Selection includes miners that need authentication.",
           },
     );
-  }, [actionsWithBulkRename, selectionIncludesUnauthenticatedMiner]);
+  }, [permittedActions, selectionIncludesUnauthenticatedMiner]);
 
   const poolMiners = useMemo(() => {
     if (poolFilteredDeviceIds) {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.test.tsx
@@ -98,6 +98,14 @@ vi.mock("./useMinerActions", () => ({
   useMinerActions: mockUseMinerActions,
 }));
 
+// Pass through the permission filter so rendering tests don't need to
+// seed the auth store with every miner permission key. The filter
+// behavior itself is exercised against the real store in component
+// tests that mount through the full path.
+vi.mock("./actionPermissions", () => ({
+  usePermittedActions: <T,>(actions: T[]): T[] => actions,
+}));
+
 vi.mock("@/protoFleet/api/useUpdateWorkerNames", () => ({
   default: mockUseUpdateWorkerNames,
 }));

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.tsx
@@ -4,6 +4,7 @@ import BulkActionConfirmDialog from "../BulkActions/BulkActionConfirmDialog";
 import { BulkAction, UnsupportedMinersInfo } from "../BulkActions/types";
 import UnsupportedMinersModal from "../BulkActions/UnsupportedMinersModal";
 import { insertActionAfter, insertActionBefore } from "./actionMenuUtils";
+import { usePermittedActions } from "./actionPermissions";
 import AddToGroupModal from "./AddToGroupModal";
 import { deviceActions, groupActions, performanceActions, settingsActions, SupportedAction } from "./constants";
 import CoolingModeModal from "./CoolingModeModal";
@@ -353,12 +354,15 @@ const SingleMinerActionsMenu = ({
     return viewMinerAction ? [viewMinerAction, ...actions, renameAction] : [...actions, renameAction];
   }, [handleRenameOpen, handleUpdateWorkerNameAction, handleViewMiner, minerUrl, popoverActions]);
 
+  // Hide actions whose backing RPC the caller can't invoke. viewMiner
+  // has no RPC and stays visible regardless of permissions; the server
+  // still enforces every gate.
+  const permittedActions = usePermittedActions(actionsWithSingleNameFlows);
+
   const visibleActions = useMemo(
     () =>
-      needsAuthentication
-        ? actionsWithSingleNameFlows.filter((a) => unauthenticatedActions.has(a.action))
-        : actionsWithSingleNameFlows,
-    [actionsWithSingleNameFlows, needsAuthentication],
+      needsAuthentication ? permittedActions.filter((a) => unauthenticatedActions.has(a.action)) : permittedActions,
+    [permittedActions, needsAuthentication],
   );
 
   const [isOpen, setIsOpen] = useState(false);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { type BulkAction } from "../BulkActions/types";
+import { ACTION_PERMISSIONS, usePermittedActions } from "./actionPermissions";
+import { deviceActions, type SupportedAction } from "./constants";
+
+vi.mock("@/protoFleet/store", () => ({
+  usePermissions: vi.fn(),
+}));
+
+import { usePermissions } from "@/protoFleet/store";
+
+const action = (a: SupportedAction): BulkAction<SupportedAction> => ({
+  action: a,
+  title: a,
+  icon: null,
+  actionHandler: () => {},
+  requiresConfirmation: false,
+});
+
+describe("usePermittedActions", () => {
+  it("filters out actions whose required catalog key is missing", () => {
+    vi.mocked(usePermissions).mockReturnValue(["miner:reboot"]);
+
+    const { result } = renderHook(() =>
+      usePermittedActions([action(deviceActions.reboot), action(deviceActions.unpair)]),
+    );
+
+    expect(result.current.map((a) => a.action)).toEqual([deviceActions.reboot]);
+  });
+
+  it("keeps actions whose required key is granted", () => {
+    vi.mocked(usePermissions).mockReturnValue(["miner:reboot", "miner:unpair"]);
+
+    const { result } = renderHook(() =>
+      usePermittedActions([action(deviceActions.reboot), action(deviceActions.unpair)]),
+    );
+
+    expect(result.current.map((a) => a.action)).toEqual([deviceActions.reboot, deviceActions.unpair]);
+  });
+
+  it("passes through actions without a mapped permission (e.g. viewMiner)", () => {
+    vi.mocked(usePermissions).mockReturnValue([]);
+
+    const viewMiner: BulkAction<"viewMiner"> = {
+      action: "viewMiner",
+      title: "View miner",
+      icon: null,
+      actionHandler: () => {},
+      requiresConfirmation: false,
+    };
+
+    const { result } = renderHook(() => usePermittedActions([viewMiner]));
+
+    expect(result.current.map((a) => a.action)).toEqual(["viewMiner"]);
+  });
+
+  it("hides every action when permissions are empty", () => {
+    // Pre-U10a sessions and FIELD_TECH-without-miner-permissions both
+    // hit this path; the menu collapses to nothing rather than showing
+    // controls that 403.
+    vi.mocked(usePermissions).mockReturnValue([]);
+
+    const { result } = renderHook(() =>
+      usePermittedActions([action(deviceActions.reboot), action(deviceActions.blinkLEDs)]),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+});
+
+describe("ACTION_PERMISSIONS", () => {
+  it("maps every SupportedAction to its server-side catalog key", () => {
+    // Spot-check the mapping against rpc_permissions.go's
+    // MinerCommandService entries; this test fails loudly if the proto
+    // gains a new action without a matching catalog key here.
+    expect(ACTION_PERMISSIONS[deviceActions.reboot]).toBe("miner:reboot");
+    expect(ACTION_PERMISSIONS[deviceActions.blinkLEDs]).toBe("miner:blink_led");
+    expect(ACTION_PERMISSIONS[deviceActions.unpair]).toBe("miner:unpair");
+    expect(ACTION_PERMISSIONS[deviceActions.firmwareUpdate]).toBe("miner:firmware_update");
+    expect(ACTION_PERMISSIONS[deviceActions.downloadLogs]).toBe("miner:download_logs");
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { type BulkAction } from "../BulkActions/types";
 import { ACTION_PERMISSIONS, usePermittedActions } from "./actionPermissions";
-import { deviceActions, type SupportedAction } from "./constants";
+import { deviceActions, settingsActions, type SupportedAction } from "./constants";
 
 vi.mock("@/protoFleet/store", () => ({
   usePermissions: vi.fn(),
@@ -31,13 +31,26 @@ describe("usePermittedActions", () => {
   });
 
   it("keeps actions whose required key is granted", () => {
-    vi.mocked(usePermissions).mockReturnValue(["miner:reboot", "miner:unpair"]);
+    vi.mocked(usePermissions).mockReturnValue(["miner:reboot", "miner:delete"]);
 
     const { result } = renderHook(() =>
       usePermittedActions([action(deviceActions.reboot), action(deviceActions.unpair)]),
     );
 
     expect(result.current.map((a) => a.action)).toEqual([deviceActions.reboot, deviceActions.unpair]);
+  });
+
+  it("requires every key when the mapping is an AND-list", () => {
+    // miningPool needs both miner:update_pools and pool:read; holding
+    // only one is insufficient because the pool-selection flow calls
+    // ListPools before the miner-side write.
+    vi.mocked(usePermissions).mockReturnValue(["miner:update_pools"]);
+    const onlyMinerKey = renderHook(() => usePermittedActions([action(settingsActions.miningPool)]));
+    expect(onlyMinerKey.result.current).toEqual([]);
+
+    vi.mocked(usePermissions).mockReturnValue(["miner:update_pools", "pool:read"]);
+    const both = renderHook(() => usePermittedActions([action(settingsActions.miningPool)]));
+    expect(both.result.current.map((a) => a.action)).toEqual([settingsActions.miningPool]);
   });
 
   it("passes through actions without a mapped permission (e.g. viewMiner)", () => {
@@ -71,14 +84,20 @@ describe("usePermittedActions", () => {
 });
 
 describe("ACTION_PERMISSIONS", () => {
-  it("maps every SupportedAction to its server-side catalog key", () => {
-    // Spot-check the mapping against rpc_permissions.go's
-    // MinerCommandService entries; this test fails loudly if the proto
-    // gains a new action without a matching catalog key here.
+  it("anchors well-known actions to their server-side catalog keys", () => {
+    // ACTION_PERMISSIONS is typed `Record<SupportedAction, ...>`, so
+    // exhaustiveness is enforced at compile time — adding a new
+    // SupportedAction without an entry fails tsc. This spot-check
+    // anchors a few high-traffic mappings against rpc_permissions.go
+    // so a wire-misalignment lands in code review instead of an
+    // operator's lap.
     expect(ACTION_PERMISSIONS[deviceActions.reboot]).toBe("miner:reboot");
     expect(ACTION_PERMISSIONS[deviceActions.blinkLEDs]).toBe("miner:blink_led");
-    expect(ACTION_PERMISSIONS[deviceActions.unpair]).toBe("miner:unpair");
+    // Unpair routes through FleetManagementService.DeleteMiners
+    // (miner:delete) on the server, not MinerCommandService.Unpair.
+    expect(ACTION_PERMISSIONS[deviceActions.unpair]).toBe("miner:delete");
     expect(ACTION_PERMISSIONS[deviceActions.firmwareUpdate]).toBe("miner:firmware_update");
     expect(ACTION_PERMISSIONS[deviceActions.downloadLogs]).toBe("miner:download_logs");
+    expect(ACTION_PERMISSIONS[settingsActions.miningPool]).toEqual(["miner:update_pools", "pool:read"]);
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.ts
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+
+import { type BulkAction } from "../BulkActions/types";
+import { deviceActions, groupActions, performanceActions, settingsActions, type SupportedAction } from "./constants";
+import { usePermissions } from "@/protoFleet/store";
+
+// ACTION_PERMISSIONS maps each miner action to the catalog key the
+// caller must hold to invoke it. Keys come from the server-side
+// rpc_permissions.go table: the action's RPC is gated on the matching
+// PermMiner* / PermRackManage / PermCurtailmentManage entry, so the UI
+// hides actions a caller cannot exercise. Entries omitted from the map
+// are treated as "no specific key required" and stay visible — used
+// for view-only affordances like "View miner" on SingleMinerActionsMenu.
+//
+// Keep this aligned with rpc_permissions.go's MinerCommandService
+// mapping; the server still enforces every gate regardless of what the
+// UI shows.
+export const ACTION_PERMISSIONS: Partial<Record<SupportedAction, string>> = {
+  [deviceActions.blinkLEDs]: "miner:blink_led",
+  [deviceActions.downloadLogs]: "miner:download_logs",
+  [deviceActions.firmwareUpdate]: "miner:firmware_update",
+  [deviceActions.reboot]: "miner:reboot",
+  [deviceActions.shutdown]: "miner:stop_mining",
+  [deviceActions.wakeUp]: "miner:start_mining",
+  [deviceActions.unpair]: "miner:unpair",
+  // factoryReset is referenced in capability tables but not exposed via
+  // popoverActions today; gate on miner:unpair as the closest semantic
+  // match if/when it surfaces in the UI.
+  [deviceActions.factoryReset]: "miner:unpair",
+
+  [performanceActions.managePower]: "miner:set_power_target",
+  [performanceActions.curtail]: "curtailment:manage",
+
+  [settingsActions.miningPool]: "miner:update_pools",
+  [settingsActions.coolingMode]: "miner:set_cooling_mode",
+  [settingsActions.rename]: "miner:rename",
+  [settingsActions.updateWorkerNames]: "miner:update_worker_names",
+  [settingsActions.security]: "miner:update_password",
+
+  // Adding miners to a collection/group goes through
+  // DeviceCollectionServiceAddDevicesToCollection, server-gated on
+  // rack:manage.
+  [groupActions.addToGroup]: "rack:manage",
+};
+
+/**
+ * Filter a list of {@link BulkAction}s down to the ones whose backing
+ * RPC the caller is allowed to invoke. Action types outside
+ * {@link ACTION_PERMISSIONS} (e.g. SingleMinerActionsMenu's
+ * `viewMiner`) pass through unfiltered — those have no server RPC and
+ * therefore no permission requirement.
+ *
+ * The server enforces every action gate regardless; this hook is purely
+ * for show/hide UX so a caller doesn't click into a 403.
+ */
+export const usePermittedActions = <ActionType extends string>(
+  actions: ReadonlyArray<BulkAction<ActionType>>,
+): BulkAction<ActionType>[] => {
+  const permissions = usePermissions();
+  return useMemo(() => {
+    return actions.filter((action) => {
+      const requiredKey = ACTION_PERMISSIONS[action.action as SupportedAction];
+      return !requiredKey || permissions.includes(requiredKey);
+    });
+  }, [actions, permissions]);
+};

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.ts
@@ -4,51 +4,86 @@ import { type BulkAction } from "../BulkActions/types";
 import { deviceActions, groupActions, performanceActions, settingsActions, type SupportedAction } from "./constants";
 import { usePermissions } from "@/protoFleet/store";
 
-// ACTION_PERMISSIONS maps each miner action to the catalog key the
-// caller must hold to invoke it. Keys come from the server-side
-// rpc_permissions.go table: the action's RPC is gated on the matching
-// PermMiner* / PermRackManage / PermCurtailmentManage entry, so the UI
-// hides actions a caller cannot exercise. Entries omitted from the map
-// are treated as "no specific key required" and stay visible — used
-// for view-only affordances like "View miner" on SingleMinerActionsMenu.
+// ACTION_PERMISSIONS maps every SupportedAction to the catalog key(s)
+// the caller must hold to invoke its backing RPC. A `readonly string[]`
+// value is treated as an AND requirement — used for flows that issue
+// multiple RPCs (e.g. the pool-assignment surface lists pools first,
+// then writes pool config to the miner).
 //
-// Keep this aligned with rpc_permissions.go's MinerCommandService
-// mapping; the server still enforces every gate regardless of what the
-// UI shows.
-export const ACTION_PERMISSIONS: Partial<Record<SupportedAction, string>> = {
+// The map is a full `Record<SupportedAction, ...>` rather than a
+// `Partial<>` so adding a new SupportedAction without a permission
+// entry fails TypeScript compilation, not at runtime. Lookups for
+// action strings outside SupportedAction (e.g. `viewMiner` on
+// SingleMinerActionsMenu) are intentional: those actions have no RPC
+// and no permission requirement, and fall through the string-keyed
+// lookup below as `undefined`.
+//
+// Keep this aligned with rpc_permissions.go's gates; the server still
+// enforces every key regardless of what the UI shows. This filter is a
+// UX improvement, not a security boundary.
+//
+// Scope caveat: the filter uses org-scope semantics via
+// EffectivePermissions.FlatKeys() projected onto UserInfo.permissions,
+// so a *site-scoped* grant for a miner action will still surface the
+// action in the menu even though the click will be denied for miners
+// outside the granted site. Site-aware filtering needs the menu to
+// know the targeted miner's site and is deferred — the server gate
+// catches the 403 regardless.
+export const ACTION_PERMISSIONS: Record<SupportedAction, string | readonly string[]> = {
   [deviceActions.blinkLEDs]: "miner:blink_led",
   [deviceActions.downloadLogs]: "miner:download_logs",
   [deviceActions.firmwareUpdate]: "miner:firmware_update",
   [deviceActions.reboot]: "miner:reboot",
   [deviceActions.shutdown]: "miner:stop_mining",
   [deviceActions.wakeUp]: "miner:start_mining",
-  [deviceActions.unpair]: "miner:unpair",
-  // factoryReset is referenced in capability tables but not exposed via
-  // popoverActions today; gate on miner:unpair as the closest semantic
-  // match if/when it surfaces in the UI.
-  [deviceActions.factoryReset]: "miner:unpair",
+  // Unpair in the UI dispatches to FleetManagementService.DeleteMiners,
+  // which the server gates on miner:delete (not miner:unpair — that
+  // catalog key gates the MinerCommandService.Unpair RPC, which the
+  // menu does not call).
+  [deviceActions.unpair]: "miner:delete",
+  // factoryReset is in the SupportedAction union but not exposed via
+  // popoverActions today; gate on miner:delete as the closest
+  // destructive-action partner if/when it surfaces.
+  [deviceActions.factoryReset]: "miner:delete",
 
   [performanceActions.managePower]: "miner:set_power_target",
   [performanceActions.curtail]: "curtailment:manage",
 
-  [settingsActions.miningPool]: "miner:update_pools",
+  // Pool assignment opens PoolSelectionPage, which calls usePools()
+  // (ListPools / pool:read) before writing the miner-side pool config
+  // (UpdateMiningPools / miner:update_pools). Roles missing pool:read
+  // would otherwise enter a flow that 403s on the very first request;
+  // require both up front.
+  [settingsActions.miningPool]: ["miner:update_pools", "pool:read"],
   [settingsActions.coolingMode]: "miner:set_cooling_mode",
   [settingsActions.rename]: "miner:rename",
   [settingsActions.updateWorkerNames]: "miner:update_worker_names",
   [settingsActions.security]: "miner:update_password",
 
   // Adding miners to a collection/group goes through
-  // DeviceCollectionServiceAddDevicesToCollection, server-gated on
+  // DeviceCollectionService.AddDevicesToCollection, server-gated on
   // rack:manage.
   [groupActions.addToGroup]: "rack:manage",
 };
 
+// hasAllRequired returns true when every required key is present in
+// the caller's effective permission set. A single-string requirement
+// is treated as a one-element AND set.
+const hasAllRequired = (required: string | readonly string[], permissions: readonly string[]): boolean => {
+  if (typeof required === "string") {
+    return permissions.includes(required);
+  }
+  return required.every((key) => permissions.includes(key));
+};
+
 /**
  * Filter a list of {@link BulkAction}s down to the ones whose backing
- * RPC the caller is allowed to invoke. Action types outside
+ * RPC(s) the caller is allowed to invoke. Action types outside
  * {@link ACTION_PERMISSIONS} (e.g. SingleMinerActionsMenu's
  * `viewMiner`) pass through unfiltered — those have no server RPC and
- * therefore no permission requirement.
+ * therefore no permission requirement. The string-keyed lookup is
+ * intentional: it lets unmapped action strings return undefined
+ * without an unsound `as SupportedAction` cast.
  *
  * The server enforces every action gate regardless; this hook is purely
  * for show/hide UX so a caller doesn't click into a 403.
@@ -58,9 +93,10 @@ export const usePermittedActions = <ActionType extends string>(
 ): BulkAction<ActionType>[] => {
   const permissions = usePermissions();
   return useMemo(() => {
+    const lookup: Record<string, string | readonly string[] | undefined> = ACTION_PERMISSIONS;
     return actions.filter((action) => {
-      const requiredKey = ACTION_PERMISSIONS[action.action as SupportedAction];
-      return !requiredKey || permissions.includes(requiredKey);
+      const required = lookup[action.action];
+      return required === undefined || hasAllRequired(required, permissions);
     });
   }, [actions, permissions]);
 };

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.ts
@@ -60,10 +60,12 @@ export const ACTION_PERMISSIONS: Record<SupportedAction, string | readonly strin
   [settingsActions.updateWorkerNames]: "miner:update_worker_names",
   [settingsActions.security]: "miner:update_password",
 
-  // Adding miners to a collection/group goes through
-  // DeviceCollectionService.AddDevicesToCollection, server-gated on
-  // rack:manage.
-  [groupActions.addToGroup]: "rack:manage",
+  // Add-to-group opens AddToGroupModal, which lists existing groups
+  // (DeviceSetService.ListDeviceSets / rack:read) before writing the
+  // membership (DeviceCollectionService.AddDevicesToCollection /
+  // rack:manage). Require both up front so a rack:manage-only role
+  // doesn't enter a flow that 403s on the first list request.
+  [groupActions.addToGroup]: ["rack:manage", "rack:read"],
 };
 
 // hasAllRequired returns true when every required key is present in


### PR DESCRIPTION
## Summary

Subset of U10b: per-button permission gating for the miner actions surface (`MinerActionsMenu` and `SingleMinerActionsMenu`). Now that `useHasPermission` is in the store (U10a) and the server enforces every miner-action RPC via `RequirePermission` (U7), this hides actions the caller can't actually invoke — no more 403s from buttons that a user clicks.

## Changes

### `actionPermissions.ts` (new)

- `ACTION_PERMISSIONS: Partial<Record<SupportedAction, string>>` — maps every `SupportedAction` in `constants.ts` to its catalog key. Mirrors `rpc_permissions.go`:

| Action | Permission key |
|--------|---------------|
| reboot / blinkLEDs / shutdown / wakeUp / unpair / downloadLogs / firmwareUpdate | `miner:reboot` / `miner:blink_led` / `miner:stop_mining` / `miner:start_mining` / `miner:unpair` / `miner:download_logs` / `miner:firmware_update` |
| factoryReset | `miner:unpair` (closest semantic match; not surfaced in popoverActions today) |
| managePower / curtail | `miner:set_power_target` / `curtailment:manage` |
| miningPool / coolingMode / rename / updateWorkerNames / security | `miner:update_pools` / `miner:set_cooling_mode` / `miner:rename` / `miner:update_worker_names` / `miner:update_password` |
| addToGroup | `rack:manage` (routes through `DeviceCollectionService.AddDevicesToCollection`) |

- `usePermittedActions<ActionType>(actions)` — `useMemo`'d filter that drops entries whose mapped key is missing from `usePermissions()`. Actions outside the map (e.g. `SingleMinerActionsMenu`'s `viewMiner`, which just opens the miner web UI in a tab) pass through unfiltered.

### Consumers

- `MinerActionsMenu.tsx` — runs `usePermittedActions(actionsWithBulkRename)` before the `visibleActions` auth-state filter.
- `SingleMinerActionsMenu.tsx` — same, before the `needsAuthentication` filter. `viewMiner` stays visible regardless of permissions (no RPC).
- Both existing component tests mock the filter to identity (they exercise rendering logic on supplied action lists, not perm filtering itself).

### Tests

- `actionPermissions.test.tsx` (new) — pins the filter behavior (granted / denied / empty perms / no mapping) and spot-checks the `ACTION_PERMISSIONS` mapping so a new `SupportedAction` added without a matching catalog key fails loudly.

## Behavior

- **SUPER_ADMIN / ADMIN**: see every action (seed includes all miner keys).
- **FIELD_TECH**: sees `Blink LEDs` and `Download logs` only (the two `miner:*` keys in their seed). Reboot/sleep/wake/etc. are filtered out.
- **Custom role with subset of miner keys**: sees only the actions matching its grants.

The server enforces every gate regardless; this is purely UX so the menu stops surfacing options that fail on click.

## Out of scope (remaining U10b)

- Layout-level route guards (`/`, `/curtailment/*`, `/settings/*`) — conflicts with in-flight Roles WIP that's modifying `router.tsx`. Defer until Roles lands.
- `useDefaultRoute()` selector + `<NoAccess />` terminal page.
- `GetSessionUserInfo` RPC + live-session refresh.

## Test plan
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on touched files.
- [x] `vitest run src/protoFleet` — 1513 passed (+6 from new test file).
- [ ] Manual: log in as FIELD_TECH, confirm `MinerActionsMenu` shows only Blink LEDs + Download logs; SUPER_ADMIN sees the full set.