### PR TITLE
Curtailment: share active event API state

### DIFF
--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -90,10 +90,7 @@ describe("activeCurtailmentData", () => {
     const postMutationRefresh = fetchActiveCurtailmentData();
 
     resolveRefresh({ event: undefined });
-    const [preMutationSnapshot, postMutationSnapshot] = await Promise.all([
-      preMutationRefresh,
-      postMutationRefresh,
-    ]);
+    const [preMutationSnapshot, postMutationSnapshot] = await Promise.all([preMutationRefresh, postMutationRefresh]);
     preMutationSnapshot.commit();
     postMutationSnapshot.commit();
 

--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -21,8 +21,12 @@ const { mockGetActiveCurtailment } = vi.hoisted(() => ({
 }));
 vi.mock("@/protoFleet/api/clients", () => ({ curtailmentClient: { getActiveCurtailment: mockGetActiveCurtailment } }));
 
-function curtailmentEvent(eventUuid: string, state = CurtailmentEventState.ACTIVE): CurtailmentEvent {
-  return create(CurtailmentEventSchema, { eventUuid, state });
+function curtailmentEvent(
+  eventUuid: string,
+  state = CurtailmentEventState.ACTIVE,
+  overrides: { reason?: string } = {},
+): CurtailmentEvent {
+  return create(CurtailmentEventSchema, { eventUuid, state, ...overrides });
 }
 
 describe("activeCurtailmentData", () => {
@@ -95,6 +99,38 @@ describe("activeCurtailmentData", () => {
     postMutationSnapshot.commit();
 
     expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("started-event");
+  });
+
+  it("preserves a mutation-backed event through one stale shared active refresh", async () => {
+    applyActiveCurtailmentEvent(curtailmentEvent("started-event"), { preserveAgainstStaleRefresh: true });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: undefined }).mockResolvedValueOnce({ event: undefined });
+
+    const firstRefresh = fetchActiveCurtailmentData();
+    const secondRefresh = fetchActiveCurtailmentData();
+    const [firstSnapshot, secondSnapshot] = await Promise.all([firstRefresh, secondRefresh]);
+    firstSnapshot.commit();
+    secondSnapshot.commit();
+
+    expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("started-event");
+
+    await refreshActiveCurtailmentData();
+    expect(getActiveCurtailmentSnapshot().event).toBeUndefined();
+  });
+
+  it("preserves mutation-backed fields through one stale same-event active refresh", async () => {
+    applyActiveCurtailmentEvent(
+      curtailmentEvent("updated-event", CurtailmentEventState.ACTIVE, { reason: "Updated" }),
+      {
+        preserveAgainstStaleRefresh: true,
+      },
+    );
+    mockGetActiveCurtailment.mockResolvedValueOnce({
+      event: curtailmentEvent("updated-event", CurtailmentEventState.ACTIVE, { reason: "Previous" }),
+    });
+
+    await refreshActiveCurtailmentData();
+
+    expect(getActiveCurtailmentSnapshot().event?.reason).toBe("Updated");
   });
 
   it("rejects a reset-aborted shared request as an AbortError", async () => {

--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -124,6 +124,30 @@ describe("activeCurtailmentData", () => {
     expect(getActiveCurtailmentSnapshot().event).toBeUndefined();
   });
 
+  it("does not let stale empty refreshes consume the restoring preservation window", async () => {
+    let resolveStaleRefresh: (value: { event?: CurtailmentEvent }) => void = () => undefined;
+    mockGetActiveCurtailment
+      .mockReturnValueOnce(
+        new Promise<{ event?: CurtailmentEvent }>((resolve) => {
+          resolveStaleRefresh = resolve;
+        }),
+      )
+      .mockResolvedValue({ event: undefined });
+
+    const staleRefresh = fetchActiveCurtailmentData();
+    applyActiveCurtailmentEvent(curtailmentEvent("restoring", CurtailmentEventState.RESTORING));
+    resolveStaleRefresh({ event: undefined });
+
+    const staleSnapshot = await staleRefresh;
+    staleSnapshot.commit();
+
+    await refreshActiveCurtailmentData();
+    expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("restoring");
+
+    await refreshActiveCurtailmentData();
+    expect(getActiveCurtailmentSnapshot().event).toBeUndefined();
+  });
+
   it.each([
     ["restored", CurtailmentEventState.COMPLETED],
     ["incomplete restore", CurtailmentEventState.COMPLETED_WITH_FAILURES],

--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -93,18 +93,32 @@ describe("activeCurtailmentData", () => {
     await expect(pendingRefresh).rejects.toBeInstanceOf(DOMException);
   });
 
+  it("preserves a restoring curtailment for one empty active response", async () => {
+    applyActiveCurtailmentEvent(curtailmentEvent("restoring", CurtailmentEventState.RESTORING));
+    mockGetActiveCurtailment.mockResolvedValue({ event: undefined });
+
+    await refreshActiveCurtailmentData();
+    expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("restoring");
+
+    await refreshActiveCurtailmentData();
+    expect(getActiveCurtailmentSnapshot().event).toBeUndefined();
+  });
+
   it.each([
-    ["restoring", CurtailmentEventState.RESTORING],
     ["restored", CurtailmentEventState.COMPLETED],
     ["incomplete restore", CurtailmentEventState.COMPLETED_WITH_FAILURES],
-  ])("preserves a %s curtailment for one empty active response", async (eventUuid, state) => {
+  ])("preserves a %s curtailment through empty active responses until dismissal", async (eventUuid, state) => {
     applyActiveCurtailmentEvent(curtailmentEvent(eventUuid, state));
     mockGetActiveCurtailment.mockResolvedValue({ event: undefined });
 
     await refreshActiveCurtailmentData();
+    await refreshActiveCurtailmentData();
+
     expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe(eventUuid);
 
+    dismissActiveCurtailmentEvent(eventUuid);
     await refreshActiveCurtailmentData();
+
     expect(getActiveCurtailmentSnapshot().event).toBeUndefined();
   });
 });

--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -77,6 +77,29 @@ describe("activeCurtailmentData", () => {
     await expect(abortedRequest).resolves.toBeInstanceOf(DOMException);
   });
 
+  it("keeps a newer applied event when a later subscriber commits a stale shared refresh", async () => {
+    let resolveRefresh: (value: { event?: CurtailmentEvent }) => void = () => undefined;
+    mockGetActiveCurtailment.mockReturnValueOnce(
+      new Promise<{ event?: CurtailmentEvent }>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+
+    const preMutationRefresh = fetchActiveCurtailmentData();
+    applyActiveCurtailmentEvent(curtailmentEvent("started-event"));
+    const postMutationRefresh = fetchActiveCurtailmentData();
+
+    resolveRefresh({ event: undefined });
+    const [preMutationSnapshot, postMutationSnapshot] = await Promise.all([
+      preMutationRefresh,
+      postMutationRefresh,
+    ]);
+    preMutationSnapshot.commit();
+    postMutationSnapshot.commit();
+
+    expect(getActiveCurtailmentSnapshot().event?.eventUuid).toBe("started-event");
+  });
+
   it("rejects a reset-aborted shared request as an AbortError", async () => {
     mockGetActiveCurtailment.mockImplementationOnce(
       (_request: unknown, options?: { signal?: AbortSignal }) =>

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -27,6 +27,12 @@ interface InFlightActiveCurtailmentRequest {
   promise: Promise<ActiveCurtailmentSnapshot>;
   settled: boolean;
   subscribers: number;
+  writeVersion: number;
+}
+
+interface ActiveCurtailmentRequestSnapshot {
+  snapshot: ActiveCurtailmentSnapshot;
+  writeVersion: number;
 }
 
 const initialSnapshot: ActiveCurtailmentSnapshot = { event: undefined };
@@ -149,6 +155,7 @@ function getInFlightActiveCurtailmentRequest(): InFlightActiveCurtailmentRequest
     abortController,
     settled: false,
     subscribers: 0,
+    writeVersion: getNextWriteVersion(),
     promise: curtailmentClient
       .getActiveCurtailment(createMessage(GetActiveCurtailmentRequestSchema, {}), { signal: abortController.signal })
       .then((response) => getActiveCurtailmentSnapshotFromResponse(response.event))
@@ -181,7 +188,7 @@ function releaseActiveCurtailmentRequestSubscriber(request: InFlightActiveCurtai
   }
 }
 
-async function requestActiveCurtailmentSnapshot(signal?: AbortSignal): Promise<ActiveCurtailmentSnapshot> {
+async function requestActiveCurtailmentSnapshot(signal?: AbortSignal): Promise<ActiveCurtailmentRequestSnapshot> {
   assertNotAborted(signal);
 
   const request = getInFlightActiveCurtailmentRequest();
@@ -202,7 +209,7 @@ async function requestActiveCurtailmentSnapshot(signal?: AbortSignal): Promise<A
   try {
     const snapshot = await request.promise;
     assertNotAborted(signal);
-    return snapshot;
+    return { snapshot, writeVersion: request.writeVersion };
   } finally {
     signal?.removeEventListener("abort", handleAbort);
     releaseSubscriber();
@@ -213,8 +220,7 @@ export async function fetchActiveCurtailmentData({
   signal,
 }: RefreshActiveCurtailmentOptions = {}): Promise<PendingActiveCurtailmentRefresh> {
   assertNotAborted(signal);
-  const writeVersion = getNextWriteVersion();
-  const snapshot = await requestActiveCurtailmentSnapshot(signal);
+  const { snapshot, writeVersion } = await requestActiveCurtailmentSnapshot(signal);
   return {
     ...snapshot,
     commit: () => setActiveCurtailmentSnapshot(snapshot, writeVersion),

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -24,7 +24,7 @@ export interface PendingActiveCurtailmentRefresh extends ActiveCurtailmentSnapsh
 
 interface InFlightActiveCurtailmentRequest {
   abortController: AbortController;
-  promise: Promise<ActiveCurtailmentSnapshot>;
+  promise: Promise<ActiveCurtailmentResponseSnapshot>;
   settled: boolean;
   subscribers: number;
   writeVersion: number;
@@ -32,7 +32,17 @@ interface InFlightActiveCurtailmentRequest {
 
 interface ActiveCurtailmentRequestSnapshot {
   snapshot: ActiveCurtailmentSnapshot;
+  preservesRestoringEmptyResponse: boolean;
   writeVersion: number;
+}
+
+interface ActiveCurtailmentResponseSnapshot {
+  snapshot: ActiveCurtailmentSnapshot;
+  preservesRestoringEmptyResponse: boolean;
+}
+
+interface SetActiveCurtailmentSnapshotOptions {
+  preservesRestoringEmptyResponse?: boolean;
 }
 
 const initialSnapshot: ActiveCurtailmentSnapshot = { event: undefined };
@@ -66,6 +76,7 @@ function areActiveCurtailmentSnapshotsEqual(
 function setActiveCurtailmentSnapshot(
   snapshot: ActiveCurtailmentSnapshot,
   writeVersion = getNextWriteVersion(),
+  { preservesRestoringEmptyResponse = false }: SetActiveCurtailmentSnapshotOptions = {},
 ): ActiveCurtailmentSnapshot {
   if (writeVersion < appliedWriteVersion) {
     return getActiveCurtailmentSnapshot();
@@ -77,9 +88,7 @@ function setActiveCurtailmentSnapshot(
     dismissedEventUuid = null;
   }
 
-  if (!snapshot.event) {
-    emptyActiveRefreshCount = 0;
-  }
+  emptyActiveRefreshCount = preservesRestoringEmptyResponse && snapshot.event ? emptyActiveRefreshCount + 1 : 0;
 
   appliedWriteVersion = writeVersion;
   const currentSnapshot = getActiveCurtailmentSnapshot();
@@ -119,16 +128,14 @@ function shouldPreserveRestoringActiveCurtailmentEvent(event: ProtoCurtailmentEv
   return event.state === CurtailmentEventState.RESTORING;
 }
 
-function getActiveCurtailmentSnapshotFromResponse(event?: ProtoCurtailmentEvent): ActiveCurtailmentSnapshot {
+function getActiveCurtailmentSnapshotFromResponse(event?: ProtoCurtailmentEvent): ActiveCurtailmentResponseSnapshot {
   if (event) {
-    emptyActiveRefreshCount = 0;
-    return { event };
+    return { snapshot: { event }, preservesRestoringEmptyResponse: false };
   }
 
   const currentSnapshot = getActiveCurtailmentSnapshot();
   if (currentSnapshot.event && shouldPreserveTerminalActiveCurtailmentEvent(currentSnapshot.event)) {
-    emptyActiveRefreshCount = 0;
-    return currentSnapshot;
+    return { snapshot: currentSnapshot, preservesRestoringEmptyResponse: false };
   }
 
   if (
@@ -136,12 +143,10 @@ function getActiveCurtailmentSnapshotFromResponse(event?: ProtoCurtailmentEvent)
     shouldPreserveRestoringActiveCurtailmentEvent(currentSnapshot.event) &&
     emptyActiveRefreshCount < preservedEmptyActiveRefreshLimit
   ) {
-    emptyActiveRefreshCount += 1;
-    return currentSnapshot;
+    return { snapshot: currentSnapshot, preservesRestoringEmptyResponse: true };
   }
 
-  emptyActiveRefreshCount = 0;
-  return initialSnapshot;
+  return { snapshot: initialSnapshot, preservesRestoringEmptyResponse: false };
 }
 
 function getInFlightActiveCurtailmentRequest(): InFlightActiveCurtailmentRequest {
@@ -206,9 +211,9 @@ async function requestActiveCurtailmentSnapshot(signal?: AbortSignal): Promise<A
   signal?.addEventListener("abort", handleAbort, { once: true });
 
   try {
-    const snapshot = await request.promise;
+    const { snapshot, preservesRestoringEmptyResponse } = await request.promise;
     assertNotAborted(signal);
-    return { snapshot, writeVersion: request.writeVersion };
+    return { snapshot, preservesRestoringEmptyResponse, writeVersion: request.writeVersion };
   } finally {
     signal?.removeEventListener("abort", handleAbort);
     releaseSubscriber();
@@ -219,10 +224,10 @@ export async function fetchActiveCurtailmentData({
   signal,
 }: RefreshActiveCurtailmentOptions = {}): Promise<PendingActiveCurtailmentRefresh> {
   assertNotAborted(signal);
-  const { snapshot, writeVersion } = await requestActiveCurtailmentSnapshot(signal);
+  const { snapshot, preservesRestoringEmptyResponse, writeVersion } = await requestActiveCurtailmentSnapshot(signal);
   return {
     ...snapshot,
-    commit: () => setActiveCurtailmentSnapshot(snapshot, writeVersion),
+    commit: () => setActiveCurtailmentSnapshot(snapshot, writeVersion, { preservesRestoringEmptyResponse }),
   };
 }
 

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -18,6 +18,10 @@ export interface RefreshActiveCurtailmentOptions {
   signal?: AbortSignal;
 }
 
+export interface ApplyActiveCurtailmentEventOptions {
+  preserveAgainstStaleRefresh?: boolean;
+}
+
 export interface PendingActiveCurtailmentRefresh extends ActiveCurtailmentSnapshot {
   commit: () => ActiveCurtailmentSnapshot;
 }
@@ -42,6 +46,8 @@ interface ActiveCurtailmentResponseSnapshot {
 }
 
 interface SetActiveCurtailmentSnapshotOptions {
+  fromActiveRefresh?: boolean;
+  preserveAgainstStaleRefresh?: boolean;
   preservesRestoringEmptyResponse?: boolean;
 }
 
@@ -54,8 +60,11 @@ let appliedWriteVersion = 0;
 let inFlightActiveCurtailmentRequest: InFlightActiveCurtailmentRequest | null = null;
 let dismissedEventUuid: string | null = null;
 let emptyActiveRefreshCount = 0;
+let mutationBackedEventUuid: string | null = null;
+let preservedMutationBackedRefreshWriteVersions = new Set<number>();
 
 const preservedEmptyActiveRefreshLimit = 1;
+const preservedMutationBackedActiveRefreshLimit = 1;
 
 function getNextWriteVersion(): number {
   nextWriteVersion += 1;
@@ -73,10 +82,40 @@ function areActiveCurtailmentSnapshotsEqual(
   return equals(CurtailmentEventSchema, current.event, next.event);
 }
 
+function shouldPreserveMutationBackedSnapshot(
+  current: ActiveCurtailmentSnapshot,
+  next: ActiveCurtailmentSnapshot,
+  writeVersion: number,
+): boolean {
+  if (
+    !mutationBackedEventUuid ||
+    !current.event ||
+    current.event.eventUuid !== mutationBackedEventUuid ||
+    preservedMutationBackedRefreshWriteVersions.size >= preservedMutationBackedActiveRefreshLimit
+  ) {
+    return preservedMutationBackedRefreshWriteVersions.has(writeVersion);
+  }
+
+  if (preservedMutationBackedRefreshWriteVersions.has(writeVersion)) {
+    return true;
+  }
+
+  return !next.event || !equals(CurtailmentEventSchema, current.event, next.event);
+}
+
+function clearMutationBackedPreservation(): void {
+  mutationBackedEventUuid = null;
+  preservedMutationBackedRefreshWriteVersions = new Set<number>();
+}
+
 function setActiveCurtailmentSnapshot(
   snapshot: ActiveCurtailmentSnapshot,
   writeVersion = getNextWriteVersion(),
-  { preservesRestoringEmptyResponse = false }: SetActiveCurtailmentSnapshotOptions = {},
+  {
+    fromActiveRefresh = false,
+    preserveAgainstStaleRefresh = false,
+    preservesRestoringEmptyResponse = false,
+  }: SetActiveCurtailmentSnapshotOptions = {},
 ): ActiveCurtailmentSnapshot {
   if (writeVersion < appliedWriteVersion) {
     return getActiveCurtailmentSnapshot();
@@ -88,10 +127,22 @@ function setActiveCurtailmentSnapshot(
     dismissedEventUuid = null;
   }
 
+  const currentSnapshot = getActiveCurtailmentSnapshot();
+  if (fromActiveRefresh && shouldPreserveMutationBackedSnapshot(currentSnapshot, snapshot, writeVersion)) {
+    preservedMutationBackedRefreshWriteVersions.add(writeVersion);
+    return currentSnapshot;
+  }
+
+  if (preserveAgainstStaleRefresh && snapshot.event) {
+    mutationBackedEventUuid = snapshot.event.eventUuid;
+    preservedMutationBackedRefreshWriteVersions = new Set<number>();
+  } else if (fromActiveRefresh || !snapshot.event || snapshot.event.eventUuid !== mutationBackedEventUuid) {
+    clearMutationBackedPreservation();
+  }
+
   emptyActiveRefreshCount = preservesRestoringEmptyResponse && snapshot.event ? emptyActiveRefreshCount + 1 : 0;
 
   appliedWriteVersion = writeVersion;
-  const currentSnapshot = getActiveCurtailmentSnapshot();
   if (areActiveCurtailmentSnapshotsEqual(currentSnapshot, snapshot)) {
     return currentSnapshot;
   }
@@ -109,8 +160,11 @@ export function useActiveCurtailmentEvent(): ProtoCurtailmentEvent | undefined {
   return useActiveCurtailmentDataStore((state) => state.event);
 }
 
-export function applyActiveCurtailmentEvent(event?: ProtoCurtailmentEvent): ActiveCurtailmentSnapshot {
-  return setActiveCurtailmentSnapshot({ event });
+export function applyActiveCurtailmentEvent(
+  event?: ProtoCurtailmentEvent,
+  options: ApplyActiveCurtailmentEventOptions = {},
+): ActiveCurtailmentSnapshot {
+  return setActiveCurtailmentSnapshot({ event }, undefined, options);
 }
 
 export function dismissActiveCurtailmentEvent(eventUuid?: string | null): ActiveCurtailmentSnapshot {
@@ -227,7 +281,11 @@ export async function fetchActiveCurtailmentData({
   const { snapshot, preservesRestoringEmptyResponse, writeVersion } = await requestActiveCurtailmentSnapshot(signal);
   return {
     ...snapshot,
-    commit: () => setActiveCurtailmentSnapshot(snapshot, writeVersion, { preservesRestoringEmptyResponse }),
+    commit: () =>
+      setActiveCurtailmentSnapshot(snapshot, writeVersion, {
+        fromActiveRefresh: true,
+        preservesRestoringEmptyResponse,
+      }),
   };
 }
 
@@ -243,6 +301,7 @@ export function resetActiveCurtailmentData(): void {
   inFlightActiveCurtailmentRequest = null;
   dismissedEventUuid = null;
   emptyActiveRefreshCount = 0;
+  clearMutationBackedPreservation();
   appliedWriteVersion = getNextWriteVersion();
   useActiveCurtailmentDataStore.setState(initialSnapshot, true);
 }

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -103,12 +103,15 @@ export function dismissActiveCurtailmentEvent(eventUuid?: string | null): Active
   return setActiveCurtailmentSnapshot(initialSnapshot);
 }
 
-function shouldPreserveCurrentActiveCurtailmentEvent(event: ProtoCurtailmentEvent): boolean {
+function shouldPreserveTerminalActiveCurtailmentEvent(event: ProtoCurtailmentEvent): boolean {
   return (
-    event.state === CurtailmentEventState.RESTORING ||
     event.state === CurtailmentEventState.COMPLETED ||
     event.state === CurtailmentEventState.COMPLETED_WITH_FAILURES
   );
+}
+
+function shouldPreserveRestoringActiveCurtailmentEvent(event: ProtoCurtailmentEvent): boolean {
+  return event.state === CurtailmentEventState.RESTORING;
 }
 
 function getActiveCurtailmentSnapshotFromResponse(event?: ProtoCurtailmentEvent): ActiveCurtailmentSnapshot {
@@ -118,9 +121,14 @@ function getActiveCurtailmentSnapshotFromResponse(event?: ProtoCurtailmentEvent)
   }
 
   const currentSnapshot = getActiveCurtailmentSnapshot();
+  if (currentSnapshot.event && shouldPreserveTerminalActiveCurtailmentEvent(currentSnapshot.event)) {
+    emptyActiveRefreshCount = 0;
+    return currentSnapshot;
+  }
+
   if (
     currentSnapshot.event &&
-    shouldPreserveCurrentActiveCurtailmentEvent(currentSnapshot.event) &&
+    shouldPreserveRestoringActiveCurtailmentEvent(currentSnapshot.event) &&
     emptyActiveRefreshCount < preservedEmptyActiveRefreshLimit
   ) {
     emptyActiveRefreshCount += 1;

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -111,8 +111,7 @@ export function dismissActiveCurtailmentEvent(eventUuid?: string | null): Active
 
 function shouldPreserveTerminalActiveCurtailmentEvent(event: ProtoCurtailmentEvent): boolean {
   return (
-    event.state === CurtailmentEventState.COMPLETED ||
-    event.state === CurtailmentEventState.COMPLETED_WITH_FAILURES
+    event.state === CurtailmentEventState.COMPLETED || event.state === CurtailmentEventState.COMPLETED_WITH_FAILURES
   );
 }
 

--- a/client/src/protoFleet/api/curtailmentMappers.ts
+++ b/client/src/protoFleet/api/curtailmentMappers.ts
@@ -148,7 +148,7 @@ export function mapActiveCurtailmentEvent(event: ProtoCurtailmentEvent): ActiveC
     targetKw: getFixedKwTarget(event),
     observedReductionKw: observedPowerSummary.observedReductionKw,
     remainingPowerKw: observedPowerSummary.remainingPowerKw,
-    restoreBatchSize: event.restoreBatchSize || event.effectiveBatchSize,
+    restoreBatchSize: event.effectiveBatchSize || event.restoreBatchSize,
     restoreBatchIntervalSec: event.restoreBatchIntervalSec,
     rollups: getCurtailmentTargetRollups(event),
   };

--- a/client/src/protoFleet/api/curtailmentMappers.ts
+++ b/client/src/protoFleet/api/curtailmentMappers.ts
@@ -6,10 +6,13 @@ import {
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import type { ActiveCurtailmentEvent } from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
 import {
+  getActiveCurtailmentDisplayState,
   getCurtailmentEventEstimatedReductionKw,
+  getCurtailmentEventObservedReductionKw,
   getCurtailmentEventScopeLabel,
   getCurtailmentEventSelectedMinerCount,
   getCurtailmentTargetRollups,
+  isActiveCurtailmentEventState,
   mapCurtailmentEventState,
 } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 import type { CurtailmentHistoryEvent, CurtailmentPriority } from "@/protoFleet/features/energy/CurtailmentHistory";
@@ -116,24 +119,17 @@ function getSourceLabel(event: ProtoCurtailmentEvent): string {
 
 function getObservedPowerSummary(event: ProtoCurtailmentEvent, estimatedReductionKw: number): ObservedPowerSummary {
   let observedPowerTotalW = 0;
-  let observedReductionTotalW = 0;
   let hasObservedPower = false;
-  let hasObservedReduction = false;
 
-  for (const { baselinePowerW, observedPowerW } of event.targets) {
+  for (const { observedPowerW } of event.targets) {
     if (observedPowerW !== undefined) {
       hasObservedPower = true;
       observedPowerTotalW += observedPowerW;
     }
-
-    if (baselinePowerW !== undefined && observedPowerW !== undefined) {
-      hasObservedReduction = true;
-      observedReductionTotalW += Math.max(baselinePowerW - observedPowerW, 0);
-    }
   }
 
   return {
-    observedReductionKw: hasObservedReduction ? observedReductionTotalW / wattsPerKilowatt : estimatedReductionKw,
+    observedReductionKw: getCurtailmentEventObservedReductionKw(event, estimatedReductionKw),
     remainingPowerKw: hasObservedPower ? observedPowerTotalW / wattsPerKilowatt : undefined,
   };
 }
@@ -152,7 +148,7 @@ export function mapActiveCurtailmentEvent(event: ProtoCurtailmentEvent): ActiveC
     targetKw: getFixedKwTarget(event),
     observedReductionKw: observedPowerSummary.observedReductionKw,
     remainingPowerKw: observedPowerSummary.remainingPowerKw,
-    restoreBatchSize: event.effectiveBatchSize || event.restoreBatchSize,
+    restoreBatchSize: event.restoreBatchSize || event.effectiveBatchSize,
     restoreBatchIntervalSec: event.restoreBatchIntervalSec,
     rollups: getCurtailmentTargetRollups(event),
   };
@@ -173,5 +169,20 @@ export function mapCurtailmentHistoryEvent(event: ProtoCurtailmentEvent): Curtai
     endedAt: timestampToIsoString(event.endedAt),
     scheduledAt: timestampToIsoString(event.scheduledStartAt),
     createdAt: timestampToIsoString(event.createdAt),
+  };
+}
+
+export function mapActiveCurtailmentHistoryEvent(event: ProtoCurtailmentEvent): CurtailmentHistoryEvent {
+  const historyEvent = mapCurtailmentHistoryEvent(event);
+
+  if (!isActiveCurtailmentEventState(historyEvent.state)) {
+    return historyEvent;
+  }
+
+  return {
+    ...historyEvent,
+    displayState: getActiveCurtailmentDisplayState(mapActiveCurtailmentEvent(event), {
+      dispatchStartedAsCurtailing: true,
+    }),
   };
 }

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 import { type Timestamp, TimestampSchema } from "@bufbuild/protobuf/wkt";
 
+import { applyActiveCurtailmentEvent, resetActiveCurtailmentData } from "@/protoFleet/api/activeCurtailmentData";
 import { CURTAILMENT_CHANGED_EVENT } from "@/protoFleet/api/curtailmentEvents";
 import {
   type CurtailmentEvent,
@@ -127,6 +128,7 @@ function curtailmentEvent(overrides: Partial<CurtailmentEvent> = {}): Curtailmen
 
 describe("useCurtailmentApi", () => {
   beforeEach(() => {
+    resetActiveCurtailmentData();
     vi.clearAllMocks();
     mockHandleAuthErrors.mockImplementation(({ onError }: { error: unknown; onError?: (error: unknown) => void }) =>
       onError?.(new Error("auth error")),
@@ -184,6 +186,119 @@ describe("useCurtailmentApi", () => {
         priority: "emergency",
         sourceLabel: "Manual",
         startedAt: "2026-05-01T12:00:00.000Z",
+      }),
+    );
+  });
+
+  it("estimates observed reduction from confirmed targets when telemetry is absent", async () => {
+    const activeEvent = curtailmentEvent({
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        dispatched: 1,
+        confirmed: 1,
+        pending: 1,
+        total: 3,
+      }),
+      targets: [
+        create(CurtailmentTargetSchema, {
+          state: CurtailmentTargetState.DISPATCHED,
+          baselinePowerW: 3000,
+        }),
+        create(CurtailmentTargetSchema, {
+          state: CurtailmentTargetState.CONFIRMED,
+          baselinePowerW: 3000,
+        }),
+        create(CurtailmentTargetSchema, {
+          state: CurtailmentTargetState.PENDING,
+          baselinePowerW: 3000,
+        }),
+      ],
+      decisionSnapshot: {
+        estimated_reduction_kw: 6.2,
+        selected_count: 3,
+      },
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [activeEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent?.observedReductionKw).toBeCloseTo(2.07);
+  });
+
+  it("shows the configured restore batch size instead of the effective batch size", async () => {
+    const activeEvent = curtailmentEvent({
+      effectiveBatchSize: 10,
+      restoreBatchSize: 1,
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [activeEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent?.restoreBatchSize).toBe(1);
+    expect(result.current.activeEventFormValues?.restoreBatchSize).toBe("1");
+  });
+
+  it("maps all-pending events without telemetry to zero observed reduction", async () => {
+    const activeEvent = curtailmentEvent({
+      state: CurtailmentEventState.PENDING,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        pending: 2,
+        total: 2,
+      }),
+      targets: [
+        create(CurtailmentTargetSchema, {
+          state: CurtailmentTargetState.PENDING,
+          baselinePowerW: 3000,
+        }),
+        create(CurtailmentTargetSchema, {
+          state: CurtailmentTargetState.PENDING,
+          baselinePowerW: 3000,
+        }),
+      ],
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [activeEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent?.observedReductionKw).toBe(0);
+  });
+
+  it("uses the active display state for the injected active history row", async () => {
+    const activeEvent = curtailmentEvent({
+      state: CurtailmentEventState.PENDING,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        dispatched: 1,
+        pending: 1,
+        total: 2,
+      }),
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [activeEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        state: "pending",
+        displayState: "curtailing",
       }),
     );
   });
@@ -257,7 +372,7 @@ describe("useCurtailmentApi", () => {
     expect(result.current.historyHasNextPage).toBe(false);
   });
 
-  it("sends the server history status filter and resets pagination", async () => {
+  it("sends server history status filters and resets pagination", async () => {
     mockListCurtailmentEvents
       .mockResolvedValueOnce({
         events: [curtailmentEvent({ eventUuid: "curt-page-1" })],
@@ -288,7 +403,7 @@ describe("useCurtailmentApi", () => {
     });
 
     await act(async () => {
-      await result.current.setHistoryStatusFilter("completed");
+      await result.current.setHistoryStatusFilters(["completed", "failed"]);
     });
 
     expect(mockListCurtailmentEvents).toHaveBeenCalledTimes(3);
@@ -296,11 +411,11 @@ describe("useCurtailmentApi", () => {
     expect(mockListCurtailmentEvents.mock.calls[2][0]).toEqual(
       expect.objectContaining({
         pageSize: 50,
-        stateFilter: CurtailmentEventState.COMPLETED,
+        stateFilters: [CurtailmentEventState.COMPLETED, CurtailmentEventState.FAILED],
       }),
     );
     expect(result.current.historyCurrentPage).toBe(0);
-    expect(result.current.historyStatusFilter).toBe("completed");
+    expect(result.current.historyStatusFilters).toEqual(["completed", "failed"]);
     expect(result.current.historyEvents.map((event) => event.id)).toEqual(["curt-completed"]);
   });
 
@@ -316,12 +431,164 @@ describe("useCurtailmentApi", () => {
     const { result } = renderHook(() => useCurtailmentApi());
 
     await act(async () => {
-      await result.current.setHistoryStatusFilter("completed");
+      await result.current.setHistoryStatusFilters(["completed"]);
     });
 
     expect(result.current.activeEventId).toBe("curt-active");
-    expect(result.current.historyStatusFilter).toBe("completed");
+    expect(result.current.historyStatusFilters).toEqual(["completed"]);
     expect(result.current.historyEvents.map((event) => event.id)).toEqual(["curt-completed"]);
+  });
+
+  it("refreshes history without refetching active curtailment when requested", async () => {
+    const activeEvent = curtailmentEvent({ eventUuid: "curt-active" });
+    const completedEvent = curtailmentEvent({
+      eventUuid: "curt-completed",
+      state: CurtailmentEventState.COMPLETED,
+    });
+    applyActiveCurtailmentEvent(activeEvent);
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [completedEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment({ includeActive: false });
+    });
+
+    expect(mockGetActiveCurtailment).not.toHaveBeenCalled();
+    expect(mockListCurtailmentEvents).toHaveBeenCalledTimes(1);
+    expect(result.current.activeEventId).toBe("curt-active");
+    expect(result.current.historyEvents.map((event) => event.id)).toEqual(["curt-active", "curt-completed"]);
+  });
+
+  it("uses the shared active curtailment snapshot for active fields and current history", async () => {
+    const pendingEvent = curtailmentEvent({
+      eventUuid: "curt-shared",
+      reason: "Queued dispatch",
+      state: CurtailmentEventState.PENDING,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        pending: 2,
+        total: 2,
+      }),
+    });
+    const activeEvent = curtailmentEvent({
+      eventUuid: "curt-shared",
+      reason: "Dispatch started",
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 2,
+        total: 2,
+      }),
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: pendingEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [pendingEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent?.reason).toBe("Queued dispatch");
+    expect(result.current.historyEvents[0].reason).toBe("Queued dispatch");
+
+    act(() => {
+      applyActiveCurtailmentEvent(activeEvent);
+    });
+
+    expect(result.current.activeEvent?.reason).toBe("Dispatch started");
+    expect(result.current.historyEvents[0].reason).toBe("Dispatch started");
+  });
+
+  it("keeps a restored curtailment visible until it is dismissed", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-restored",
+      state: CurtailmentEventState.RESTORING,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 1,
+        resolved: 1,
+        total: 2,
+      }),
+    });
+    const restoredEvent = curtailmentEvent({
+      eventUuid: "curt-restored",
+      state: CurtailmentEventState.COMPLETED,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        resolved: 2,
+        total: 2,
+      }),
+    });
+    applyActiveCurtailmentEvent(restoringEvent);
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [restoredEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment({ includeActive: false });
+    });
+
+    expect(result.current.activeEventId).toBe("curt-restored");
+    expect(result.current.activeEvent?.state).toBe("completed");
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-restored",
+        state: "completed",
+      }),
+    );
+    expect(result.current.historyEvents[0]).not.toHaveProperty("displayState");
+
+    act(() => {
+      result.current.dismissTerminalCurtailment();
+    });
+
+    expect(result.current.activeEventId).toBeNull();
+    expect(result.current.activeEvent).toBeNull();
+  });
+
+  it("keeps an incomplete restore visible until it is dismissed", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-restore-incomplete",
+      state: CurtailmentEventState.RESTORING,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 1,
+        resolved: 1,
+        total: 2,
+      }),
+    });
+    const restoreIncompleteEvent = curtailmentEvent({
+      eventUuid: "curt-restore-incomplete",
+      state: CurtailmentEventState.COMPLETED_WITH_FAILURES,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        resolved: 1,
+        restoreFailed: 1,
+        total: 2,
+      }),
+    });
+    applyActiveCurtailmentEvent(restoringEvent);
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [restoreIncompleteEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment({ includeActive: false });
+    });
+
+    expect(result.current.activeEventId).toBe("curt-restore-incomplete");
+    expect(result.current.activeEvent?.state).toBe("completedWithFailures");
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-restore-incomplete",
+        state: "completedWithFailures",
+      }),
+    );
+    expect(result.current.historyEvents[0]).not.toHaveProperty("displayState");
+
+    act(() => {
+      result.current.dismissTerminalCurtailment();
+    });
+
+    expect(result.current.activeEventId).toBeNull();
+    expect(result.current.activeEvent).toBeNull();
   });
 
   it("keeps non-first history pages stable when mutation refresh fails", async () => {
@@ -358,7 +625,7 @@ describe("useCurtailmentApi", () => {
     expect(result.current.loadError).toBe("refresh failed");
   });
 
-  it("passes refresh abort signals to curtailment requests", async () => {
+  it("passes refresh abort signals to history requests and uses a shared active request signal", async () => {
     const abortController = new AbortController();
 
     const { result } = renderHook(() => useCurtailmentApi());
@@ -367,7 +634,7 @@ describe("useCurtailmentApi", () => {
       await result.current.refreshCurtailment({ signal: abortController.signal });
     });
 
-    expect(mockGetActiveCurtailment.mock.calls[0][1]).toEqual({ signal: abortController.signal });
+    expect(mockGetActiveCurtailment.mock.calls[0][1]).toEqual({ signal: expect.any(AbortSignal) });
     expect(mockListCurtailmentEvents.mock.calls[0][1]).toEqual({ signal: abortController.signal });
   });
 

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -498,6 +498,7 @@ describe("useCurtailmentApi", () => {
     expect(result.current.activeEventId).toBe("curt-active");
     expect(result.current.historyStatusFilters).toEqual(["completed"]);
     expect(result.current.historyEvents.map((event) => event.id)).toEqual(["curt-completed"]);
+    expect(mockListCurtailmentEvents).toHaveBeenCalledTimes(1);
   });
 
   it("reconciles terminal active state when current history filters exclude terminal rows", async () => {
@@ -528,13 +529,47 @@ describe("useCurtailmentApi", () => {
     });
 
     expect(mockListCurtailmentEvents.mock.calls[0][0].stateFilters).toEqual([CurtailmentEventState.RESTORING]);
-    expect(mockListCurtailmentEvents.mock.calls[1][0].stateFilters).toEqual([]);
-    expect(mockListCurtailmentEvents.mock.calls[2][0].stateFilters).toEqual([]);
+    const terminalStateFilters = [
+      CurtailmentEventState.COMPLETED,
+      CurtailmentEventState.COMPLETED_WITH_FAILURES,
+      CurtailmentEventState.CANCELLED,
+      CurtailmentEventState.FAILED,
+    ];
+    expect(mockListCurtailmentEvents.mock.calls[1][0].stateFilters).toEqual(terminalStateFilters);
+    expect(mockListCurtailmentEvents.mock.calls[2][0].stateFilters).toEqual(terminalStateFilters);
     expect(mockListCurtailmentEvents.mock.calls.map(([request]) => request.pageToken)).toEqual(["", "", "page-2"]);
     expect(result.current.activeEventId).toBe("curt-filtered-terminal");
     expect(result.current.activeEvent?.state).toBe("completed");
     expect(result.current.historyStatusFilters).toEqual(["restoring"]);
     expect(result.current.historyEvents).toEqual([]);
+  });
+
+  it("caps terminal reconciliation history paging when the active row is not found", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-missing-terminal",
+      state: CurtailmentEventState.RESTORING,
+    });
+    applyActiveCurtailmentEvent(restoringEvent);
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: undefined });
+    mockListCurtailmentEvents
+      .mockResolvedValueOnce({ events: [], nextPageToken: "" })
+      .mockResolvedValueOnce({ events: [curtailmentEvent({ eventUuid: "curt-terminal-1" })], nextPageToken: "page-2" })
+      .mockResolvedValueOnce({ events: [curtailmentEvent({ eventUuid: "curt-terminal-2" })], nextPageToken: "page-3" })
+      .mockResolvedValueOnce({ events: [curtailmentEvent({ eventUuid: "curt-terminal-3" })], nextPageToken: "page-4" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.setHistoryStatusFilters(["restoring"]);
+    });
+
+    expect(mockListCurtailmentEvents.mock.calls.map(([request]) => request.pageToken)).toEqual([
+      "",
+      "",
+      "page-2",
+      "page-3",
+    ]);
+    expect(result.current.activeEvent?.state).toBe("restoring");
   });
 
   it("refreshes history without refetching active curtailment when requested", async () => {

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -303,6 +303,40 @@ describe("useCurtailmentApi", () => {
     );
   });
 
+  it("keeps server-scrubbed history metadata when injecting active display state", async () => {
+    const activeEvent = curtailmentEvent({
+      eventUuid: "curt-scrubbed-source",
+      externalSource: "webhook-secret",
+      state: CurtailmentEventState.PENDING,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        dispatched: 1,
+        pending: 1,
+        total: 2,
+      }),
+    });
+    const historyEvent = curtailmentEvent({
+      eventUuid: "curt-scrubbed-source",
+      externalSource: "",
+      state: CurtailmentEventState.PENDING,
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [historyEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-scrubbed-source",
+        displayState: "curtailing",
+        sourceLabel: "Manual",
+      }),
+    );
+  });
+
   it("loads only the first history page and paginates on demand", async () => {
     mockListCurtailmentEvents
       .mockResolvedValueOnce({
@@ -630,6 +664,44 @@ describe("useCurtailmentApi", () => {
 
     expect(result.current.activeEventId).toBeNull();
     expect(result.current.activeEvent).toBeNull();
+  });
+
+  it("does not preserve stale restoring rollups when terminal history is trimmed", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-trimmed-restore",
+      state: CurtailmentEventState.RESTORING,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 1,
+        resolved: 1,
+        total: 2,
+      }),
+    });
+    const trimmedTerminalEvent = curtailmentEvent({
+      eventUuid: "curt-trimmed-restore",
+      state: CurtailmentEventState.COMPLETED_WITH_FAILURES,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+      targetRollup: undefined,
+      targets: [],
+    });
+    applyActiveCurtailmentEvent(restoringEvent);
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [trimmedTerminalEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment({ includeActive: false });
+    });
+
+    expect(result.current.activeEventId).toBe("curt-trimmed-restore");
+    expect(result.current.activeEvent?.state).toBe("completedWithFailures");
+    expect(result.current.activeEvent?.rollups).toEqual([]);
+    expect(result.current.activeEvent?.remainingPowerKw).toBeUndefined();
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-trimmed-restore",
+        state: "completedWithFailures",
+      }),
+    );
   });
 
   it("clears an active snapshot when history reports a failed terminal event", async () => {

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -686,6 +686,43 @@ describe("useCurtailmentApi", () => {
     expect(result.current.historyEvents[0].reason).toBe("Dispatch started");
   });
 
+  it("replaces cached non-terminal history rows when the shared active event becomes terminal", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-terminal-shared",
+      state: CurtailmentEventState.RESTORING,
+    });
+    const completedEvent = curtailmentEvent({
+      eventUuid: "curt-terminal-shared",
+      state: CurtailmentEventState.COMPLETED,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: restoringEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [restoringEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.historyEvents[0].state).toBe("restoring");
+
+    act(() => {
+      applyActiveCurtailmentEvent(completedEvent);
+    });
+
+    expect(result.current.activeEvent?.state).toBe("completed");
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-terminal-shared",
+        state: "completed",
+        endedAt: "2026-05-01T13:00:00.000Z",
+      }),
+    );
+    expect(result.current.historyEvents[0]).not.toHaveProperty("displayState");
+    expect(result.current.historyEvents[0]).not.toHaveProperty("injectedActive");
+  });
+
   it("drops stale injected active history rows when the shared active event changes", async () => {
     const pendingEvent = curtailmentEvent({
       eventUuid: "curt-shared-a",

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -683,6 +683,44 @@ describe("useCurtailmentApi", () => {
     expect(result.current.historyEvents).toEqual([]);
   });
 
+  it("keeps real history rows when removing stale injected active rows from filtered history", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-injected",
+      state: CurtailmentEventState.RESTORING,
+    });
+    const realHistoryEvent = curtailmentEvent({
+      eventUuid: "curt-real-history",
+      reason: "Real history row",
+      state: CurtailmentEventState.RESTORING,
+    });
+    const filteredActiveEvent = curtailmentEvent({
+      eventUuid: "curt-real-history",
+      state: CurtailmentEventState.PENDING,
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: restoringEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [realHistoryEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.setHistoryStatusFilters(["restoring"]);
+    });
+
+    expect(result.current.historyEvents.map((event) => event.id)).toEqual(["curt-injected", "curt-real-history"]);
+
+    act(() => {
+      applyActiveCurtailmentEvent(filteredActiveEvent);
+    });
+
+    expect(result.current.historyStatusFilters).toEqual(["restoring"]);
+    expect(result.current.historyEvents).toEqual([
+      expect.objectContaining({
+        id: "curt-real-history",
+        reason: "Real history row",
+      }),
+    ]);
+  });
+
   it("keeps a restored curtailment visible until it is dismissed", async () => {
     const restoringEvent = curtailmentEvent({
       eventUuid: "curt-restored",

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -512,10 +512,12 @@ describe("useCurtailmentApi", () => {
       eventUuid: "curt-restored",
       state: CurtailmentEventState.COMPLETED,
       endedAt: timestamp("2026-05-01T13:00:00Z"),
+      decisionSnapshot: undefined,
       targetRollup: create(CurtailmentTargetRollupSchema, {
         resolved: 2,
         total: 2,
       }),
+      targets: [],
     });
     applyActiveCurtailmentEvent(restoringEvent);
     mockListCurtailmentEvents.mockResolvedValueOnce({ events: [restoredEvent], nextPageToken: "" });
@@ -528,6 +530,9 @@ describe("useCurtailmentApi", () => {
 
     expect(result.current.activeEventId).toBe("curt-restored");
     expect(result.current.activeEvent?.state).toBe("completed");
+    expect(result.current.activeEvent?.endedAt).toBe("2026-05-01T13:00:00.000Z");
+    expect(result.current.activeEvent?.remainingPowerKw).toBe(1);
+    expect(result.current.activeEvent?.rollups).toEqual([{ state: "resolved", count: 2 }]);
     expect(result.current.historyEvents[0]).toEqual(
       expect.objectContaining({
         id: "curt-restored",
@@ -558,11 +563,13 @@ describe("useCurtailmentApi", () => {
       eventUuid: "curt-restore-incomplete",
       state: CurtailmentEventState.COMPLETED_WITH_FAILURES,
       endedAt: timestamp("2026-05-01T13:00:00Z"),
+      decisionSnapshot: undefined,
       targetRollup: create(CurtailmentTargetRollupSchema, {
         resolved: 1,
         restoreFailed: 1,
         total: 2,
       }),
+      targets: [],
     });
     applyActiveCurtailmentEvent(restoringEvent);
     mockListCurtailmentEvents.mockResolvedValueOnce({ events: [restoreIncompleteEvent], nextPageToken: "" });
@@ -575,6 +582,11 @@ describe("useCurtailmentApi", () => {
 
     expect(result.current.activeEventId).toBe("curt-restore-incomplete");
     expect(result.current.activeEvent?.state).toBe("completedWithFailures");
+    expect(result.current.activeEvent?.remainingPowerKw).toBe(1);
+    expect(result.current.activeEvent?.rollups).toEqual([
+      { state: "resolved", count: 1 },
+      { state: "restoreFailed", count: 1 },
+    ]);
     expect(result.current.historyEvents[0]).toEqual(
       expect.objectContaining({
         id: "curt-restore-incomplete",
@@ -589,6 +601,37 @@ describe("useCurtailmentApi", () => {
 
     expect(result.current.activeEventId).toBeNull();
     expect(result.current.activeEvent).toBeNull();
+  });
+
+  it("clears an active snapshot when history reports a failed terminal event", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-failed",
+      state: CurtailmentEventState.RESTORING,
+    });
+    const failedEvent = curtailmentEvent({
+      eventUuid: "curt-failed",
+      state: CurtailmentEventState.FAILED,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+      decisionSnapshot: undefined,
+      targets: [],
+    });
+    applyActiveCurtailmentEvent(restoringEvent);
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [failedEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment({ includeActive: false });
+    });
+
+    expect(result.current.activeEventId).toBeNull();
+    expect(result.current.activeEvent).toBeNull();
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-failed",
+        state: "failed",
+      }),
+    );
   });
 
   it("keeps non-first history pages stable when mutation refresh fails", async () => {

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -497,6 +497,36 @@ describe("useCurtailmentApi", () => {
     expect(result.current.historyEvents.map((event) => event.id)).toEqual(["curt-completed"]);
   });
 
+  it("reconciles terminal active state when current history filters exclude terminal rows", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-filtered-terminal",
+      state: CurtailmentEventState.RESTORING,
+    });
+    const completedEvent = curtailmentEvent({
+      eventUuid: "curt-filtered-terminal",
+      state: CurtailmentEventState.COMPLETED,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+    });
+    applyActiveCurtailmentEvent(restoringEvent);
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: undefined });
+    mockListCurtailmentEvents
+      .mockResolvedValueOnce({ events: [], nextPageToken: "" })
+      .mockResolvedValueOnce({ events: [completedEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.setHistoryStatusFilters(["restoring"]);
+    });
+
+    expect(mockListCurtailmentEvents.mock.calls[0][0].stateFilters).toEqual([CurtailmentEventState.RESTORING]);
+    expect(mockListCurtailmentEvents.mock.calls[1][0].stateFilters).toEqual([]);
+    expect(result.current.activeEventId).toBe("curt-filtered-terminal");
+    expect(result.current.activeEvent?.state).toBe("completed");
+    expect(result.current.historyStatusFilters).toEqual(["restoring"]);
+    expect(result.current.historyEvents).toEqual([]);
+  });
+
   it("refreshes history without refetching active curtailment when requested", async () => {
     const activeEvent = curtailmentEvent({ eventUuid: "curt-active" });
     const completedEvent = curtailmentEvent({

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -611,6 +611,49 @@ describe("useCurtailmentApi", () => {
     expect(result.current.historyEvents[0].reason).toBe("Dispatch started");
   });
 
+  it("drops stale injected active history rows when the shared active event changes", async () => {
+    const pendingEvent = curtailmentEvent({
+      eventUuid: "curt-shared-a",
+      reason: "Queued dispatch",
+      state: CurtailmentEventState.PENDING,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        dispatched: 1,
+        pending: 1,
+        total: 2,
+      }),
+    });
+    const activeEvent = curtailmentEvent({
+      eventUuid: "curt-shared-b",
+      reason: "Dispatch started",
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: pendingEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [pendingEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.historyEvents).toEqual([
+      expect.objectContaining({
+        id: "curt-shared-a",
+        displayState: "curtailing",
+      }),
+    ]);
+
+    act(() => {
+      applyActiveCurtailmentEvent(activeEvent);
+    });
+
+    expect(result.current.activeEventId).toBe("curt-shared-b");
+    expect(result.current.historyEvents).toEqual([
+      expect.objectContaining({
+        id: "curt-shared-b",
+      }),
+    ]);
+  });
+
   it("removes injected active history rows when shared active state stops matching filters", async () => {
     const restoringEvent = curtailmentEvent({
       eventUuid: "curt-filtered-active",

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -337,6 +337,30 @@ describe("useCurtailmentApi", () => {
     );
   });
 
+  it("uses a scrubbed source label for injected active history rows without a server history match", async () => {
+    const activeEvent = curtailmentEvent({
+      eventUuid: "curt-unmatched-source",
+      externalSource: "webhook-secret",
+      state: CurtailmentEventState.COMPLETED,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-unmatched-source",
+        sourceLabel: "Manual",
+      }),
+    );
+  });
+
   it("loads only the first history page and paginates on demand", async () => {
     mockListCurtailmentEvents
       .mockResolvedValueOnce({

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -510,10 +510,15 @@ describe("useCurtailmentApi", () => {
       state: CurtailmentEventState.COMPLETED,
       endedAt: timestamp("2026-05-01T13:00:00Z"),
     });
+    const newerHistoryEvent = curtailmentEvent({
+      eventUuid: "curt-newer-history",
+      state: CurtailmentEventState.COMPLETED,
+    });
     applyActiveCurtailmentEvent(restoringEvent);
     mockGetActiveCurtailment.mockResolvedValueOnce({ event: undefined });
     mockListCurtailmentEvents
       .mockResolvedValueOnce({ events: [], nextPageToken: "" })
+      .mockResolvedValueOnce({ events: [newerHistoryEvent], nextPageToken: "page-2" })
       .mockResolvedValueOnce({ events: [completedEvent], nextPageToken: "" });
 
     const { result } = renderHook(() => useCurtailmentApi());
@@ -524,6 +529,8 @@ describe("useCurtailmentApi", () => {
 
     expect(mockListCurtailmentEvents.mock.calls[0][0].stateFilters).toEqual([CurtailmentEventState.RESTORING]);
     expect(mockListCurtailmentEvents.mock.calls[1][0].stateFilters).toEqual([]);
+    expect(mockListCurtailmentEvents.mock.calls[2][0].stateFilters).toEqual([]);
+    expect(mockListCurtailmentEvents.mock.calls.map(([request]) => request.pageToken)).toEqual(["", "", "page-2"]);
     expect(result.current.activeEventId).toBe("curt-filtered-terminal");
     expect(result.current.activeEvent?.state).toBe("completed");
     expect(result.current.historyStatusFilters).toEqual(["restoring"]);

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -277,7 +277,7 @@ describe("useCurtailmentApi", () => {
     expect(result.current.activeEvent?.observedReductionKw).toBe(0);
   });
 
-  it("uses the active display state for the injected active history row", async () => {
+  it("uses the active display state for the active history row", async () => {
     const activeEvent = curtailmentEvent({
       state: CurtailmentEventState.PENDING,
       targetRollup: create(CurtailmentTargetRollupSchema, {
@@ -301,6 +301,7 @@ describe("useCurtailmentApi", () => {
         displayState: "curtailing",
       }),
     );
+    expect(result.current.historyEvents[0]).not.toHaveProperty("injectedActive");
   });
 
   it("keeps server-scrubbed history metadata when injecting active display state", async () => {
@@ -335,12 +336,13 @@ describe("useCurtailmentApi", () => {
         sourceLabel: "Manual",
       }),
     );
+    expect(result.current.historyEvents[0]).not.toHaveProperty("injectedActive");
   });
 
-  it("uses a scrubbed source label for injected active history rows without a server history match", async () => {
+  it("preserves the active source label for injected active history rows without a server history match", async () => {
     const activeEvent = curtailmentEvent({
       eventUuid: "curt-unmatched-source",
-      externalSource: "webhook-secret",
+      externalSource: "Demand response",
       state: CurtailmentEventState.COMPLETED,
       endedAt: timestamp("2026-05-01T13:00:00Z"),
     });
@@ -356,7 +358,8 @@ describe("useCurtailmentApi", () => {
     expect(result.current.historyEvents[0]).toEqual(
       expect.objectContaining({
         id: "curt-unmatched-source",
-        sourceLabel: "Manual",
+        injectedActive: true,
+        sourceLabel: "Demand response",
       }),
     );
   });
@@ -657,7 +660,7 @@ describe("useCurtailmentApi", () => {
       reason: "Dispatch started",
     });
     mockGetActiveCurtailment.mockResolvedValueOnce({ event: pendingEvent });
-    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [pendingEvent], nextPageToken: "" });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [], nextPageToken: "" });
 
     const { result } = renderHook(() => useCurtailmentApi());
 
@@ -747,6 +750,50 @@ describe("useCurtailmentApi", () => {
       expect.objectContaining({
         id: "curt-real-history",
         reason: "Real history row",
+      }),
+    ]);
+  });
+
+  it("keeps server-backed active history rows when shared active state stops matching filters", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-server-backed",
+      state: CurtailmentEventState.RESTORING,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 1,
+        resolved: 1,
+        total: 2,
+      }),
+    });
+    const completedEvent = curtailmentEvent({
+      eventUuid: "curt-server-backed",
+      state: CurtailmentEventState.COMPLETED,
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: restoringEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [restoringEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.setHistoryStatusFilters(["restoring"]);
+    });
+
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-server-backed",
+        displayState: "restoring",
+      }),
+    );
+    expect(result.current.historyEvents[0]).not.toHaveProperty("injectedActive");
+
+    act(() => {
+      applyActiveCurtailmentEvent(completedEvent);
+    });
+
+    expect(result.current.historyStatusFilters).toEqual(["restoring"]);
+    expect(result.current.historyEvents).toEqual([
+      expect.objectContaining({
+        id: "curt-server-backed",
+        state: "restoring",
       }),
     ]);
   });

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -494,6 +494,61 @@ describe("useCurtailmentApi", () => {
     expect(result.current.historyEvents.map((event) => event.id)).toEqual(["curt-active", "curt-completed"]);
   });
 
+  it("does not apply active reconciliation from superseded history refreshes", async () => {
+    const activeEvent = curtailmentEvent({ eventUuid: "curt-superseded" });
+    const completedEvent = curtailmentEvent({
+      eventUuid: "curt-superseded",
+      state: CurtailmentEventState.COMPLETED,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        resolved: 2,
+        total: 2,
+      }),
+      targets: [],
+    });
+    let resolveSupersededHistory: (value: { events: CurtailmentEvent[]; nextPageToken: string }) => void = () =>
+      undefined;
+    mockListCurtailmentEvents
+      .mockReturnValueOnce(
+        new Promise<{ events: CurtailmentEvent[]; nextPageToken: string }>((resolve) => {
+          resolveSupersededHistory = resolve;
+        }),
+      )
+      .mockResolvedValueOnce({ events: [activeEvent], nextPageToken: "" });
+    applyActiveCurtailmentEvent(activeEvent);
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    let supersededRefresh!: Promise<unknown>;
+    act(() => {
+      supersededRefresh = result.current.refreshCurtailment({ includeActive: false });
+    });
+    await act(async () => {
+      await result.current.refreshCurtailment({ includeActive: false });
+    });
+
+    expect(result.current.activeEvent?.state).toBe("active");
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-superseded",
+        state: "active",
+      }),
+    );
+
+    resolveSupersededHistory({ events: [completedEvent], nextPageToken: "" });
+    await act(async () => {
+      await supersededRefresh;
+    });
+
+    expect(result.current.activeEvent?.state).toBe("active");
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-superseded",
+        state: "active",
+      }),
+    );
+  });
+
   it("uses the shared active curtailment snapshot for active fields and current history", async () => {
     const pendingEvent = curtailmentEvent({
       eventUuid: "curt-shared",

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -498,6 +498,35 @@ describe("useCurtailmentApi", () => {
     expect(result.current.historyEvents[0].reason).toBe("Dispatch started");
   });
 
+  it("removes injected active history rows when shared active state stops matching filters", async () => {
+    const restoringEvent = curtailmentEvent({
+      eventUuid: "curt-filtered-active",
+      state: CurtailmentEventState.RESTORING,
+    });
+    const completedEvent = curtailmentEvent({
+      eventUuid: "curt-filtered-active",
+      state: CurtailmentEventState.COMPLETED,
+    });
+    mockGetActiveCurtailment.mockResolvedValueOnce({ event: restoringEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.setHistoryStatusFilters(["restoring"]);
+    });
+
+    expect(result.current.historyEvents.map((event) => event.id)).toEqual(["curt-filtered-active"]);
+
+    act(() => {
+      applyActiveCurtailmentEvent(completedEvent);
+    });
+
+    expect(result.current.activeEvent?.state).toBe("completed");
+    expect(result.current.historyStatusFilters).toEqual(["restoring"]);
+    expect(result.current.historyEvents).toEqual([]);
+  });
+
   it("keeps a restored curtailment visible until it is dismissed", async () => {
     const restoringEvent = curtailmentEvent({
       eventUuid: "curt-restored",

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -229,7 +229,7 @@ describe("useCurtailmentApi", () => {
     expect(result.current.activeEvent?.observedReductionKw).toBeCloseTo(2.07);
   });
 
-  it("shows the configured restore batch size instead of the effective batch size", async () => {
+  it("shows the effective restore batch size while preserving the configured form value", async () => {
     const activeEvent = curtailmentEvent({
       effectiveBatchSize: 10,
       restoreBatchSize: 1,
@@ -243,7 +243,7 @@ describe("useCurtailmentApi", () => {
       await result.current.refreshCurtailment();
     });
 
-    expect(result.current.activeEvent?.restoreBatchSize).toBe(1);
+    expect(result.current.activeEvent?.restoreBatchSize).toBe(10);
     expect(result.current.activeEventFormValues?.restoreBatchSize).toBe("1");
   });
 

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -127,6 +127,13 @@ const historyTerminalCurtailmentEventStates = new Set<CurtailmentEventState>([
   "cancelled",
   "failed",
 ]);
+const activeReconciliationHistoryPageLimit = 3;
+const activeReconciliationHistoryStateFilters: CurtailmentEventState[] = [
+  "completed",
+  "completedWithFailures",
+  "cancelled",
+  "failed",
+];
 
 function mapHistoryStateFilter(stateFilter?: CurtailmentEventState): ProtoCurtailmentEventState {
   switch (stateFilter) {
@@ -435,12 +442,18 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
   );
 
   const findCurtailmentEventInHistory = useCallback(
-    async (eventUuid: string, signal?: AbortSignal): Promise<ProtoCurtailmentEvent | undefined> => {
+    async (
+      eventUuid: string,
+      stateFilters: CurtailmentEventState[],
+      pageLimit: number,
+      signal?: AbortSignal,
+    ): Promise<ProtoCurtailmentEvent | undefined> => {
       let pageToken = "";
       const knownPageTokens: (string | undefined)[] = [undefined];
+      let pageCount = 0;
 
-      while (true) {
-        const page = await listCurtailmentEventsPage(pageToken, knownPageTokens, [], signal);
+      while (pageCount < pageLimit) {
+        const page = await listCurtailmentEventsPage(pageToken, knownPageTokens, stateFilters, signal);
         const matchingEvent = page.events.find((event) => event.eventUuid === eventUuid);
         if (matchingEvent) {
           return matchingEvent;
@@ -452,7 +465,10 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
 
         pageToken = page.nextPageToken;
         knownPageTokens.push(pageToken);
+        pageCount += 1;
       }
+
+      return undefined;
     },
     [listCurtailmentEventsPage],
   );
@@ -466,13 +482,19 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
     ): Promise<ProtoCurtailmentEvent[]> => {
       if (
         !activeEvent ||
+        activeEvent.state !== ProtoCurtailmentEventState.RESTORING ||
         stateFilters.length === 0 ||
         historyEvents.some((historyEvent) => historyEvent.eventUuid === activeEvent.eventUuid)
       ) {
         return historyEvents;
       }
 
-      const matchingEvent = await findCurtailmentEventInHistory(activeEvent.eventUuid, signal);
+      const matchingEvent = await findCurtailmentEventInHistory(
+        activeEvent.eventUuid,
+        activeReconciliationHistoryStateFilters,
+        activeReconciliationHistoryPageLimit,
+        signal,
+      );
       return matchingEvent ? [matchingEvent] : historyEvents;
     },
     [findCurtailmentEventInHistory],

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -244,14 +244,29 @@ function shouldIncludeActiveEventInHistory(
   );
 }
 
+function removeInjectedActiveHistoryEvent(
+  events: CurtailmentHistoryEvent[],
+  activeEvent?: ProtoCurtailmentEvent,
+): CurtailmentHistoryEvent[] {
+  if (!activeEvent) {
+    return events.filter((event) => !event.displayState);
+  }
+
+  return events.filter((event) => event.id !== activeEvent.eventUuid);
+}
+
 function getHistoryEventsWithActiveEvent(
   events: CurtailmentHistoryEvent[],
   activeEvent: ProtoCurtailmentEvent | undefined,
   stateFilters: readonly CurtailmentEventState[],
   currentPage: number,
 ): CurtailmentHistoryEvent[] {
-  if (currentPage !== 0 || !activeEvent || !shouldIncludeActiveEventInHistory(activeEvent, stateFilters)) {
+  if (currentPage !== 0) {
     return events;
+  }
+
+  if (!activeEvent || !shouldIncludeActiveEventInHistory(activeEvent, stateFilters)) {
+    return removeInjectedActiveHistoryEvent(events, activeEvent);
   }
 
   const mappedActiveEvent = mapActiveCurtailmentHistoryEvent(activeEvent);

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -459,10 +459,14 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
           ]);
           assertNotAborted(signal);
           const previewActiveSnapshot = activeRefresh ?? getActiveCurtailmentSnapshot();
-          const previewActiveEvent = reconcileActiveEventWithHistory(
-            previewActiveSnapshot.event,
-            historyPageResponse.events,
-          );
+          const reconciliationEvents =
+            previewActiveSnapshot.event &&
+            stateFilters.length > 0 &&
+            !historyPageResponse.events.some((event) => event.eventUuid === previewActiveSnapshot.event?.eventUuid)
+              ? (await listCurtailmentEventsPage("", [undefined], [], signal)).events
+              : historyPageResponse.events;
+          assertNotAborted(signal);
+          const previewActiveEvent = reconcileActiveEventWithHistory(previewActiveSnapshot.event, reconciliationEvents);
           const previewSnapshot = createSnapshot(
             previewActiveEvent,
             historyPageResponse.events,
@@ -473,7 +477,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
           }
 
           const activeSnapshot = activeRefresh ? activeRefresh.commit() : previewActiveSnapshot;
-          const activeEvent = reconcileActiveEventWithHistory(activeSnapshot.event, historyPageResponse.events);
+          const activeEvent = reconcileActiveEventWithHistory(activeSnapshot.event, reconciliationEvents);
           if (activeEvent !== activeSnapshot.event) {
             applyActiveCurtailmentEvent(activeEvent);
           }

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -187,6 +187,13 @@ function getActiveSnapshotFields(
   };
 }
 
+function markInjectedActiveHistoryEvent(event: CurtailmentHistoryEvent): CurtailmentHistoryEvent {
+  return {
+    ...event,
+    injectedActive: true,
+  };
+}
+
 function getActiveHistoryEvent(
   activeEvent: ProtoCurtailmentEvent,
   historyEvents: CurtailmentHistoryEvent[],
@@ -195,21 +202,21 @@ function getActiveHistoryEvent(
   const matchingHistoryEvent = historyEvents.find((event) => event.id === mappedActiveEvent.id);
 
   if (!matchingHistoryEvent) {
-    return {
+    return markInjectedActiveHistoryEvent({
       ...mappedActiveEvent,
       sourceLabel: defaultHistorySourceLabel,
-    };
+    });
   }
 
   if (!mappedActiveEvent.displayState) {
     return matchingHistoryEvent;
   }
 
-  return {
+  return markInjectedActiveHistoryEvent({
     ...mappedActiveEvent,
     displayState: mappedActiveEvent.displayState,
     sourceLabel: matchingHistoryEvent.sourceLabel,
-  };
+  });
 }
 
 function createSnapshot(
@@ -278,15 +285,8 @@ function shouldIncludeActiveEventInHistory(
   );
 }
 
-function removeInjectedActiveHistoryEvent(
-  events: CurtailmentHistoryEvent[],
-  activeEvent?: ProtoCurtailmentEvent,
-): CurtailmentHistoryEvent[] {
-  if (!activeEvent) {
-    return events.filter((event) => !event.displayState);
-  }
-
-  return events.filter((event) => event.id !== activeEvent.eventUuid);
+function removeInjectedActiveHistoryEvent(events: CurtailmentHistoryEvent[]): CurtailmentHistoryEvent[] {
+  return events.filter((event) => !event.injectedActive);
 }
 
 function getHistoryEventsWithActiveEvent(
@@ -300,11 +300,11 @@ function getHistoryEventsWithActiveEvent(
   }
 
   if (!activeEvent || !shouldIncludeActiveEventInHistory(activeEvent, stateFilters)) {
-    return removeInjectedActiveHistoryEvent(events, activeEvent);
+    return removeInjectedActiveHistoryEvent(events);
   }
 
   const activeHistoryEvent = getActiveHistoryEvent(activeEvent, events);
-  return [activeHistoryEvent, ...events.filter((event) => event.id !== activeHistoryEvent.id && !event.displayState)];
+  return [activeHistoryEvent, ...events.filter((event) => event.id !== activeHistoryEvent.id && !event.injectedActive)];
 }
 
 function upsertHistoryEvent(

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -113,8 +113,6 @@ const initialCurtailmentSnapshot: CurtailmentSnapshot = {
   activeEventFormValues: null,
   historyEvents: [],
 };
-const defaultHistorySourceLabel = "Manual";
-
 const visibleActiveCurtailmentEventStates = new Set<CurtailmentEventState>([
   "pending",
   "active",
@@ -202,21 +200,18 @@ function getActiveHistoryEvent(
   const matchingHistoryEvent = historyEvents.find((event) => event.id === mappedActiveEvent.id);
 
   if (!matchingHistoryEvent) {
-    return markInjectedActiveHistoryEvent({
-      ...mappedActiveEvent,
-      sourceLabel: defaultHistorySourceLabel,
-    });
+    return markInjectedActiveHistoryEvent(mappedActiveEvent);
   }
 
   if (!mappedActiveEvent.displayState) {
     return matchingHistoryEvent;
   }
 
-  return markInjectedActiveHistoryEvent({
+  return {
     ...mappedActiveEvent,
     displayState: mappedActiveEvent.displayState,
     sourceLabel: matchingHistoryEvent.sourceLabel,
-  });
+  };
 }
 
 function createSnapshot(
@@ -391,7 +386,9 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
     (event: ProtoCurtailmentEvent) => {
       const state = mapCurtailmentEventState(event.state);
       const shouldShowActiveEvent = visibleActiveCurtailmentEventStates.has(state);
-      applyActiveCurtailmentEvent(shouldShowActiveEvent ? event : undefined);
+      applyActiveCurtailmentEvent(shouldShowActiveEvent ? event : undefined, {
+        preserveAgainstStaleRefresh: true,
+      });
       const nextActiveEvent = shouldShowActiveEvent ? mapActiveCurtailmentEvent(event) : null;
       const activeStatusFilters = historyStatusFiltersRef.current;
       const shouldUpdateHistoryPage =

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -304,7 +304,7 @@ function getHistoryEventsWithActiveEvent(
   }
 
   const activeHistoryEvent = getActiveHistoryEvent(activeEvent, events);
-  return [activeHistoryEvent, ...events.filter((event) => event.id !== activeHistoryEvent.id)];
+  return [activeHistoryEvent, ...events.filter((event) => event.id !== activeHistoryEvent.id && !event.displayState)];
 }
 
 function upsertHistoryEvent(

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -17,6 +17,7 @@ import {
   mapCurtailmentHistoryEvent,
 } from "@/protoFleet/api/curtailmentMappers";
 import {
+  CurtailmentEventSchema,
   ListCurtailmentEventsRequestSchema,
   type CurtailmentEvent as ProtoCurtailmentEvent,
   CurtailmentEventState as ProtoCurtailmentEventState,
@@ -121,6 +122,13 @@ const visibleActiveCurtailmentEventStates = new Set<CurtailmentEventState>([
   "completedWithFailures",
 ]);
 
+const historyTerminalCurtailmentEventStates = new Set<CurtailmentEventState>([
+  "completed",
+  "completedWithFailures",
+  "cancelled",
+  "failed",
+]);
+
 function mapHistoryStateFilter(stateFilter?: CurtailmentEventState): ProtoCurtailmentEventState {
   switch (stateFilter) {
     case "pending":
@@ -199,7 +207,7 @@ function createSnapshot(
   };
 }
 
-function getActiveEventFromHistory(
+function reconcileActiveEventWithHistory(
   activeEvent: ProtoCurtailmentEvent | undefined,
   historyEvents: ProtoCurtailmentEvent[],
 ): ProtoCurtailmentEvent | undefined {
@@ -208,10 +216,22 @@ function getActiveEventFromHistory(
   }
 
   const matchingHistoryEvent = historyEvents.find((event) => event.eventUuid === activeEvent.eventUuid);
-  return matchingHistoryEvent &&
-    visibleActiveCurtailmentEventStates.has(mapCurtailmentEventState(matchingHistoryEvent.state))
-    ? matchingHistoryEvent
-    : activeEvent;
+  if (!matchingHistoryEvent) {
+    return activeEvent;
+  }
+
+  const historyState = mapCurtailmentEventState(matchingHistoryEvent.state);
+  if (!historyTerminalCurtailmentEventStates.has(historyState)) {
+    return activeEvent;
+  }
+
+  return create(CurtailmentEventSchema, {
+    ...activeEvent,
+    state: matchingHistoryEvent.state,
+    endedAt: matchingHistoryEvent.endedAt ?? activeEvent.endedAt,
+    updatedAt: matchingHistoryEvent.updatedAt ?? activeEvent.updatedAt,
+    targetRollup: matchingHistoryEvent.targetRollup ?? activeEvent.targetRollup,
+  });
 }
 
 function shouldIncludeActiveEventInHistory(
@@ -390,7 +410,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
           ]);
           assertNotAborted(signal);
           const activeSnapshot = activeRefresh ? activeRefresh.commit() : getActiveCurtailmentSnapshot();
-          const activeEvent = getActiveEventFromHistory(activeSnapshot.event, historyPageResponse.events);
+          const activeEvent = reconcileActiveEventWithHistory(activeSnapshot.event, historyPageResponse.events);
           if (activeEvent !== activeSnapshot.event) {
             applyActiveCurtailmentEvent(activeEvent);
           }

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -113,6 +113,7 @@ const initialCurtailmentSnapshot: CurtailmentSnapshot = {
   activeEventFormValues: null,
   historyEvents: [],
 };
+const defaultHistorySourceLabel = "Manual";
 
 const visibleActiveCurtailmentEventStates = new Set<CurtailmentEventState>([
   "pending",
@@ -194,7 +195,10 @@ function getActiveHistoryEvent(
   const matchingHistoryEvent = historyEvents.find((event) => event.id === mappedActiveEvent.id);
 
   if (!matchingHistoryEvent) {
-    return mappedActiveEvent;
+    return {
+      ...mappedActiveEvent,
+      sourceLabel: defaultHistorySourceLabel,
+    };
   }
 
   if (!mappedActiveEvent.displayState) {

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -434,6 +434,50 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
     [],
   );
 
+  const findCurtailmentEventInHistory = useCallback(
+    async (eventUuid: string, signal?: AbortSignal): Promise<ProtoCurtailmentEvent | undefined> => {
+      let pageToken = "";
+      const knownPageTokens: (string | undefined)[] = [undefined];
+
+      while (true) {
+        const page = await listCurtailmentEventsPage(pageToken, knownPageTokens, [], signal);
+        const matchingEvent = page.events.find((event) => event.eventUuid === eventUuid);
+        if (matchingEvent) {
+          return matchingEvent;
+        }
+
+        if (!page.nextPageToken) {
+          return undefined;
+        }
+
+        pageToken = page.nextPageToken;
+        knownPageTokens.push(pageToken);
+      }
+    },
+    [listCurtailmentEventsPage],
+  );
+
+  const getHistoryEventsForActiveReconciliation = useCallback(
+    async (
+      activeEvent: ProtoCurtailmentEvent | undefined,
+      historyEvents: ProtoCurtailmentEvent[],
+      stateFilters: CurtailmentEventState[],
+      signal?: AbortSignal,
+    ): Promise<ProtoCurtailmentEvent[]> => {
+      if (
+        !activeEvent ||
+        stateFilters.length === 0 ||
+        historyEvents.some((historyEvent) => historyEvent.eventUuid === activeEvent.eventUuid)
+      ) {
+        return historyEvents;
+      }
+
+      const matchingEvent = await findCurtailmentEventInHistory(activeEvent.eventUuid, signal);
+      return matchingEvent ? [matchingEvent] : historyEvents;
+    },
+    [findCurtailmentEventInHistory],
+  );
+
   const runRefresh = useCallback(
     (signal?: AbortSignal, requestedHistoryPage = historyPaginationRef.current.currentPage, includeActive = true) => {
       const historyPage = getNormalizedHistoryPage(requestedHistoryPage);
@@ -456,12 +500,12 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
           ]);
           assertNotAborted(signal);
           const previewActiveSnapshot = activeRefresh ?? getActiveCurtailmentSnapshot();
-          const reconciliationEvents =
-            previewActiveSnapshot.event &&
-            stateFilters.length > 0 &&
-            !historyPageResponse.events.some((event) => event.eventUuid === previewActiveSnapshot.event?.eventUuid)
-              ? (await listCurtailmentEventsPage("", [undefined], [], signal)).events
-              : historyPageResponse.events;
+          const reconciliationEvents = await getHistoryEventsForActiveReconciliation(
+            previewActiveSnapshot.event,
+            historyPageResponse.events,
+            stateFilters,
+            signal,
+          );
           assertNotAborted(signal);
           const previewActiveEvent = reconcileActiveEventWithHistory(previewActiveSnapshot.event, reconciliationEvents);
           const previewSnapshot = createSnapshot(
@@ -514,7 +558,13 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
         }
       })();
     },
-    [handleFailure, listCurtailmentEventsPage, updateHistoryPagination, updateSnapshot],
+    [
+      getHistoryEventsForActiveReconciliation,
+      handleFailure,
+      listCurtailmentEventsPage,
+      updateHistoryPagination,
+      updateSnapshot,
+    ],
   );
 
   const refreshCurtailment = useCallback(

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -1,15 +1,22 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { create } from "@bufbuild/protobuf";
 
+import {
+  applyActiveCurtailmentEvent,
+  dismissActiveCurtailmentEvent,
+  fetchActiveCurtailmentData,
+  getActiveCurtailmentSnapshot,
+  useActiveCurtailmentEvent,
+} from "@/protoFleet/api/activeCurtailmentData";
 import { curtailmentClient } from "@/protoFleet/api/clients";
 import { emitCurtailmentChanged } from "@/protoFleet/api/curtailmentEvents";
 import {
   mapActiveCurtailmentEvent,
+  mapActiveCurtailmentHistoryEvent,
   mapCurtailmentEventToFormValues,
   mapCurtailmentHistoryEvent,
 } from "@/protoFleet/api/curtailmentMappers";
 import {
-  GetActiveCurtailmentRequestSchema,
   ListCurtailmentEventsRequestSchema,
   type CurtailmentEvent as ProtoCurtailmentEvent,
   CurtailmentEventState as ProtoCurtailmentEventState,
@@ -19,7 +26,7 @@ import { assertNotAborted, isAbortError, toError } from "@/protoFleet/api/reques
 import type { ActiveCurtailmentEvent } from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
 import {
   type CurtailmentEventState,
-  isActiveCurtailmentEventState,
+  curtailmentEventStates,
   mapCurtailmentEventState,
 } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
 import type { CurtailmentHistoryEvent } from "@/protoFleet/features/energy/CurtailmentHistory";
@@ -33,6 +40,7 @@ import { useAuthErrors } from "@/protoFleet/store";
 export interface RefreshCurtailmentOptions {
   background?: boolean;
   historyPage?: number;
+  includeActive?: boolean;
   signal?: AbortSignal;
 }
 
@@ -68,6 +76,7 @@ export interface UseCurtailmentApiResult extends CurtailmentSnapshot {
   historyHasPreviousPage: boolean;
   historyPageSize: number;
   historyStatusFilter?: CurtailmentEventState;
+  historyStatusFilters: CurtailmentEventState[];
   refreshCurtailment: (options?: RefreshCurtailmentOptions) => Promise<CurtailmentSnapshot>;
   goToHistoryPage: (
     historyPage: number,
@@ -77,7 +86,12 @@ export interface UseCurtailmentApiResult extends CurtailmentSnapshot {
     stateFilter?: CurtailmentEventState,
     options?: Pick<RefreshCurtailmentOptions, "signal">,
   ) => Promise<CurtailmentSnapshot>;
+  setHistoryStatusFilters: (
+    stateFilters?: CurtailmentEventState[],
+    options?: Pick<RefreshCurtailmentOptions, "signal">,
+  ) => Promise<CurtailmentSnapshot>;
   startCurtailment: (values: CurtailmentSubmitValues) => Promise<ProtoCurtailmentEvent>;
+  dismissTerminalCurtailment: () => void;
   updateCurtailment: (
     eventUuid: string,
     values: CurtailmentSubmitValues,
@@ -98,6 +112,14 @@ const initialCurtailmentSnapshot: CurtailmentSnapshot = {
   activeEventFormValues: null,
   historyEvents: [],
 };
+
+const visibleActiveCurtailmentEventStates = new Set<CurtailmentEventState>([
+  "pending",
+  "active",
+  "restoring",
+  "completed",
+  "completedWithFailures",
+]);
 
 function mapHistoryStateFilter(stateFilter?: CurtailmentEventState): ProtoCurtailmentEventState {
   switch (stateFilter) {
@@ -120,17 +142,40 @@ function mapHistoryStateFilter(stateFilter?: CurtailmentEventState): ProtoCurtai
   }
 }
 
+function normalizeHistoryStateFilters(stateFilters: readonly CurtailmentEventState[] = []): CurtailmentEventState[] {
+  const selectedStateFilters = new Set(stateFilters);
+  return curtailmentEventStates.filter((state) => selectedStateFilters.has(state));
+}
+
+function mapHistoryStateFilters(stateFilters: readonly CurtailmentEventState[]): ProtoCurtailmentEventState[] {
+  return normalizeHistoryStateFilters(stateFilters)
+    .map(mapHistoryStateFilter)
+    .filter((state) => state !== ProtoCurtailmentEventState.UNSPECIFIED);
+}
+
 function getActiveSnapshotEvent(activeEvent: ProtoCurtailmentEvent | undefined): ActiveCurtailmentEvent | null {
   if (!activeEvent) {
     return null;
   }
 
   const activeState = mapCurtailmentEventState(activeEvent.state);
-  if (!isActiveCurtailmentEventState(activeState)) {
+  if (!visibleActiveCurtailmentEventStates.has(activeState)) {
     return null;
   }
 
   return mapActiveCurtailmentEvent(activeEvent);
+}
+
+function getActiveSnapshotFields(
+  activeEvent: ProtoCurtailmentEvent | undefined,
+): Omit<CurtailmentSnapshot, "historyEvents"> {
+  const nextActiveEvent = getActiveSnapshotEvent(activeEvent);
+
+  return {
+    activeEvent: nextActiveEvent,
+    activeEventId: activeEvent && nextActiveEvent ? activeEvent.eventUuid : null,
+    activeEventFormValues: activeEvent && nextActiveEvent ? mapCurtailmentEventToFormValues(activeEvent) : null,
+  };
 }
 
 function createSnapshot(
@@ -138,33 +183,69 @@ function createSnapshot(
   historyEvents: ProtoCurtailmentEvent[],
   includeActiveInHistory = true,
 ): CurtailmentSnapshot {
-  const nextActiveEvent = getActiveSnapshotEvent(activeEvent);
   const nextHistoryEvents = historyEvents.map(mapCurtailmentHistoryEvent);
 
-  if (includeActiveInHistory && activeEvent && !nextHistoryEvents.some((event) => event.id === activeEvent.eventUuid)) {
-    nextHistoryEvents.unshift(mapCurtailmentHistoryEvent(activeEvent));
+  if (includeActiveInHistory && activeEvent) {
+    const activeHistoryEvent = mapActiveCurtailmentHistoryEvent(activeEvent);
+    return {
+      ...getActiveSnapshotFields(activeEvent),
+      historyEvents: [activeHistoryEvent, ...nextHistoryEvents.filter((event) => event.id !== activeHistoryEvent.id)],
+    };
   }
 
   return {
-    activeEvent: nextActiveEvent,
-    activeEventId: activeEvent && nextActiveEvent ? activeEvent.eventUuid : null,
-    activeEventFormValues: activeEvent && nextActiveEvent ? mapCurtailmentEventToFormValues(activeEvent) : null,
+    ...getActiveSnapshotFields(activeEvent),
     historyEvents: nextHistoryEvents,
   };
 }
 
+function getActiveEventFromHistory(
+  activeEvent: ProtoCurtailmentEvent | undefined,
+  historyEvents: ProtoCurtailmentEvent[],
+): ProtoCurtailmentEvent | undefined {
+  if (!activeEvent) {
+    return undefined;
+  }
+
+  const matchingHistoryEvent = historyEvents.find((event) => event.eventUuid === activeEvent.eventUuid);
+  return matchingHistoryEvent &&
+    visibleActiveCurtailmentEventStates.has(mapCurtailmentEventState(matchingHistoryEvent.state))
+    ? matchingHistoryEvent
+    : activeEvent;
+}
+
 function shouldIncludeActiveEventInHistory(
   activeEvent: ProtoCurtailmentEvent | undefined,
-  stateFilter: CurtailmentEventState | undefined,
+  stateFilters: readonly CurtailmentEventState[],
 ): boolean {
-  return !stateFilter || Boolean(activeEvent && mapCurtailmentEventState(activeEvent.state) === stateFilter);
+  return (
+    stateFilters.length === 0 ||
+    Boolean(activeEvent && stateFilters.includes(mapCurtailmentEventState(activeEvent.state)))
+  );
+}
+
+function getHistoryEventsWithActiveEvent(
+  events: CurtailmentHistoryEvent[],
+  activeEvent: ProtoCurtailmentEvent | undefined,
+  stateFilters: readonly CurtailmentEventState[],
+  currentPage: number,
+): CurtailmentHistoryEvent[] {
+  if (currentPage !== 0 || !activeEvent || !shouldIncludeActiveEventInHistory(activeEvent, stateFilters)) {
+    return events;
+  }
+
+  const mappedActiveEvent = mapActiveCurtailmentHistoryEvent(activeEvent);
+  return [mappedActiveEvent, ...events.filter((event) => event.id !== mappedActiveEvent.id)];
 }
 
 function upsertHistoryEvent(
   events: CurtailmentHistoryEvent[],
   event: ProtoCurtailmentEvent,
 ): CurtailmentHistoryEvent[] {
-  const mappedEvent = mapCurtailmentHistoryEvent(event);
+  const state = mapCurtailmentEventState(event.state);
+  const mappedEvent = visibleActiveCurtailmentEventStates.has(state)
+    ? mapActiveCurtailmentHistoryEvent(event)
+    : mapCurtailmentHistoryEvent(event);
   return [mappedEvent, ...events.filter((currentEvent) => currentEvent.id !== mappedEvent.id)];
 }
 
@@ -187,6 +268,7 @@ function getSafeNextPageToken(
 
 export function useCurtailmentApi(): UseCurtailmentApiResult {
   const { handleAuthErrors } = useAuthErrors();
+  const activeCurtailmentEvent = useActiveCurtailmentEvent();
   const [snapshot, setSnapshot] = useState<CurtailmentSnapshot>(initialCurtailmentSnapshot);
   const [isLoading, setIsLoading] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
@@ -198,10 +280,10 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
   const [stopError, setStopError] = useState<string | null>(null);
   const [historyPagination, setHistoryPagination] =
     useState<CurtailmentHistoryPaginationState>(initialHistoryPagination);
-  const [historyStatusFilter, setHistoryStatusFilterState] = useState<CurtailmentEventState | undefined>();
+  const [historyStatusFilters, setHistoryStatusFiltersState] = useState<CurtailmentEventState[]>([]);
   const snapshotRef = useRef(snapshot);
   const historyPaginationRef = useRef(historyPagination);
-  const historyStatusFilterRef = useRef(historyStatusFilter);
+  const historyStatusFiltersRef = useRef(historyStatusFilters);
   const latestRefreshRequestIdRef = useRef(0);
   const foregroundRefreshCountRef = useRef(0);
 
@@ -221,9 +303,10 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
     setHistoryPagination(nextPagination);
   }, []);
 
-  const updateHistoryStatusFilter = useCallback((nextStatusFilter: CurtailmentEventState | undefined) => {
-    historyStatusFilterRef.current = nextStatusFilter;
-    setHistoryStatusFilterState(nextStatusFilter);
+  const updateHistoryStatusFilters = useCallback((nextStatusFilters: CurtailmentEventState[] = []) => {
+    const normalizedStatusFilters = normalizeHistoryStateFilters(nextStatusFilters);
+    historyStatusFiltersRef.current = normalizedStatusFilters;
+    setHistoryStatusFiltersState(normalizedStatusFilters);
   }, []);
 
   const handleFailure = useCallback(
@@ -238,10 +321,13 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
   const applyEvent = useCallback(
     (event: ProtoCurtailmentEvent) => {
       const state = mapCurtailmentEventState(event.state);
-      const nextActiveEvent = isActiveCurtailmentEventState(state) ? mapActiveCurtailmentEvent(event) : null;
-      const activeStatusFilter = historyStatusFilterRef.current;
+      const shouldShowActiveEvent = visibleActiveCurtailmentEventStates.has(state);
+      applyActiveCurtailmentEvent(shouldShowActiveEvent ? event : undefined);
+      const nextActiveEvent = shouldShowActiveEvent ? mapActiveCurtailmentEvent(event) : null;
+      const activeStatusFilters = historyStatusFiltersRef.current;
       const shouldUpdateHistoryPage =
-        historyPaginationRef.current.currentPage === 0 && (!activeStatusFilter || activeStatusFilter === state);
+        historyPaginationRef.current.currentPage === 0 &&
+        (activeStatusFilters.length === 0 || activeStatusFilters.includes(state));
 
       updateSnapshot((current) => ({
         activeEvent: nextActiveEvent,
@@ -259,7 +345,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
     async (
       pageToken: string,
       knownPageTokens: (string | undefined)[],
-      stateFilter: CurtailmentEventState | undefined,
+      stateFilters: CurtailmentEventState[],
       signal?: AbortSignal,
     ): Promise<CurtailmentHistoryPage> => {
       assertNotAborted(signal);
@@ -268,7 +354,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
         create(ListCurtailmentEventsRequestSchema, {
           pageSize: curtailmentHistoryPageSize,
           pageToken,
-          stateFilter: mapHistoryStateFilter(stateFilter),
+          stateFilters: mapHistoryStateFilters(stateFilters),
         }),
         signal ? { signal } : undefined,
       );
@@ -283,10 +369,10 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
   );
 
   const runRefresh = useCallback(
-    (signal?: AbortSignal, requestedHistoryPage = historyPaginationRef.current.currentPage) => {
+    (signal?: AbortSignal, requestedHistoryPage = historyPaginationRef.current.currentPage, includeActive = true) => {
       const historyPage = getNormalizedHistoryPage(requestedHistoryPage);
       const currentPagination = historyPaginationRef.current;
-      const stateFilter = historyStatusFilterRef.current;
+      const stateFilters = historyStatusFiltersRef.current;
       const pageToken = historyPage === 0 ? "" : currentPagination.pageTokens[historyPage];
 
       if (historyPage > 0 && pageToken === undefined) {
@@ -298,19 +384,21 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
 
       return (async () => {
         try {
-          const [activeResponse, historyPageResponse] = await Promise.all([
-            curtailmentClient.getActiveCurtailment(
-              create(GetActiveCurtailmentRequestSchema, {}),
-              signal ? { signal } : undefined,
-            ),
-            listCurtailmentEventsPage(pageToken ?? "", knownPageTokens, stateFilter, signal),
+          const [activeRefresh, historyPageResponse] = await Promise.all([
+            includeActive ? fetchActiveCurtailmentData({ signal }) : undefined,
+            listCurtailmentEventsPage(pageToken ?? "", knownPageTokens, stateFilters, signal),
           ]);
           assertNotAborted(signal);
+          const activeSnapshot = activeRefresh ? activeRefresh.commit() : getActiveCurtailmentSnapshot();
+          const activeEvent = getActiveEventFromHistory(activeSnapshot.event, historyPageResponse.events);
+          if (activeEvent !== activeSnapshot.event) {
+            applyActiveCurtailmentEvent(activeEvent);
+          }
 
           const nextSnapshot = createSnapshot(
-            activeResponse.event,
+            activeEvent,
             historyPageResponse.events,
-            historyPage === 0 && shouldIncludeActiveEventInHistory(activeResponse.event, stateFilter),
+            historyPage === 0 && shouldIncludeActiveEventInHistory(activeEvent, stateFilters),
           );
           if (requestId !== latestRefreshRequestIdRef.current) {
             return nextSnapshot;
@@ -347,16 +435,16 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
   );
 
   const refreshCurtailment = useCallback(
-    async ({ background = false, historyPage, signal }: RefreshCurtailmentOptions = {}) => {
+    async ({ background = false, historyPage, includeActive = true, signal }: RefreshCurtailmentOptions = {}) => {
       if (background) {
-        return runRefresh(signal, historyPage);
+        return runRefresh(signal, historyPage, includeActive);
       }
 
       foregroundRefreshCountRef.current += 1;
       setIsLoading(true);
 
       try {
-        return await runRefresh(signal, historyPage);
+        return await runRefresh(signal, historyPage, includeActive);
       } finally {
         foregroundRefreshCountRef.current = Math.max(0, foregroundRefreshCountRef.current - 1);
         if (!signal?.aborted) {
@@ -373,20 +461,26 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
     [refreshCurtailment],
   );
 
-  const setHistoryStatusFilter = useCallback(
-    (stateFilter?: CurtailmentEventState, options: Pick<RefreshCurtailmentOptions, "signal"> = {}) => {
-      updateHistoryStatusFilter(stateFilter);
+  const setHistoryStatusFilters = useCallback(
+    (stateFilters: CurtailmentEventState[] = [], options: Pick<RefreshCurtailmentOptions, "signal"> = {}) => {
+      updateHistoryStatusFilters(stateFilters);
       updateHistoryPagination(initialHistoryPagination);
       return refreshCurtailment({ historyPage: 0, signal: options.signal });
     },
-    [refreshCurtailment, updateHistoryPagination, updateHistoryStatusFilter],
+    [refreshCurtailment, updateHistoryPagination, updateHistoryStatusFilters],
+  );
+
+  const setHistoryStatusFilter = useCallback(
+    (stateFilter?: CurtailmentEventState, options: Pick<RefreshCurtailmentOptions, "signal"> = {}) =>
+      setHistoryStatusFilters(stateFilter ? [stateFilter] : [], options),
+    [setHistoryStatusFilters],
   );
 
   const refreshAfterMutation = useCallback(async () => {
     emitCurtailmentChanged();
 
     try {
-      await refreshCurtailment({ background: true, historyPage: 0 });
+      await refreshCurtailment({ background: true, historyPage: 0, includeActive: false });
     } catch {
       // The mutation succeeded; keep the response-backed optimistic state and
       // leave the load error visible for the next explicit refresh.
@@ -472,9 +566,28 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
     [applyEvent, handleFailure, refreshAfterMutation],
   );
 
+  const dismissTerminalCurtailment = useCallback(() => {
+    dismissActiveCurtailmentEvent(activeCurtailmentEvent?.eventUuid);
+  }, [activeCurtailmentEvent]);
+
+  const activeSnapshotFields = useMemo(() => getActiveSnapshotFields(activeCurtailmentEvent), [activeCurtailmentEvent]);
+  const historyStatusFilter = historyStatusFilters[0];
+  const historyEvents = useMemo(
+    () =>
+      getHistoryEventsWithActiveEvent(
+        snapshot.historyEvents,
+        activeCurtailmentEvent,
+        historyStatusFilters,
+        historyPagination.currentPage,
+      ),
+    [activeCurtailmentEvent, historyPagination.currentPage, historyStatusFilters, snapshot.historyEvents],
+  );
+
   return useMemo(
     () => ({
       ...snapshot,
+      ...activeSnapshotFields,
+      historyEvents,
       isLoading,
       isStarting,
       isUpdating: updatingEventId !== null,
@@ -488,26 +601,34 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       historyHasPreviousPage: historyPagination.currentPage > 0,
       historyPageSize: curtailmentHistoryPageSize,
       historyStatusFilter,
+      historyStatusFilters,
       refreshCurtailment,
       goToHistoryPage,
       setHistoryStatusFilter,
+      setHistoryStatusFilters,
       startCurtailment,
+      dismissTerminalCurtailment,
       updateCurtailment,
       stopCurtailment,
     }),
     [
+      activeSnapshotFields,
       goToHistoryPage,
+      historyEvents,
       historyPagination.currentPage,
       historyPagination.nextPageToken,
       historyStatusFilter,
+      historyStatusFilters,
       isLoading,
       isStarting,
       updatingEventId,
       loadError,
       refreshCurtailment,
       setHistoryStatusFilter,
+      setHistoryStatusFilters,
       snapshot,
       startCurtailment,
+      dismissTerminalCurtailment,
       updateCurtailment,
       stopCurtailment,
       stopError,

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -186,6 +186,28 @@ function getActiveSnapshotFields(
   };
 }
 
+function getActiveHistoryEvent(
+  activeEvent: ProtoCurtailmentEvent,
+  historyEvents: CurtailmentHistoryEvent[],
+): CurtailmentHistoryEvent {
+  const mappedActiveEvent = mapActiveCurtailmentHistoryEvent(activeEvent);
+  const matchingHistoryEvent = historyEvents.find((event) => event.id === mappedActiveEvent.id);
+
+  if (!matchingHistoryEvent) {
+    return mappedActiveEvent;
+  }
+
+  if (!mappedActiveEvent.displayState) {
+    return matchingHistoryEvent;
+  }
+
+  return {
+    ...mappedActiveEvent,
+    displayState: mappedActiveEvent.displayState,
+    sourceLabel: matchingHistoryEvent.sourceLabel,
+  };
+}
+
 function createSnapshot(
   activeEvent: ProtoCurtailmentEvent | undefined,
   historyEvents: ProtoCurtailmentEvent[],
@@ -194,7 +216,7 @@ function createSnapshot(
   const nextHistoryEvents = historyEvents.map(mapCurtailmentHistoryEvent);
 
   if (includeActiveInHistory && activeEvent) {
-    const activeHistoryEvent = mapActiveCurtailmentHistoryEvent(activeEvent);
+    const activeHistoryEvent = getActiveHistoryEvent(activeEvent, nextHistoryEvents);
     return {
       ...getActiveSnapshotFields(activeEvent),
       historyEvents: [activeHistoryEvent, ...nextHistoryEvents.filter((event) => event.id !== activeHistoryEvent.id)],
@@ -225,12 +247,19 @@ function reconcileActiveEventWithHistory(
     return activeEvent;
   }
 
+  const hasHistoryTargetSummary = Boolean(matchingHistoryEvent.targetRollup || matchingHistoryEvent.targets.length > 0);
+  const targets = matchingHistoryEvent.targets.length > 0
+    ? matchingHistoryEvent.targets
+    : hasHistoryTargetSummary
+      ? activeEvent.targets
+      : [];
   return create(CurtailmentEventSchema, {
     ...activeEvent,
     state: matchingHistoryEvent.state,
     endedAt: matchingHistoryEvent.endedAt ?? activeEvent.endedAt,
     updatedAt: matchingHistoryEvent.updatedAt ?? activeEvent.updatedAt,
-    targetRollup: matchingHistoryEvent.targetRollup ?? activeEvent.targetRollup,
+    targetRollup: matchingHistoryEvent.targetRollup,
+    targets,
   });
 }
 
@@ -269,8 +298,8 @@ function getHistoryEventsWithActiveEvent(
     return removeInjectedActiveHistoryEvent(events, activeEvent);
   }
 
-  const mappedActiveEvent = mapActiveCurtailmentHistoryEvent(activeEvent);
-  return [mappedActiveEvent, ...events.filter((event) => event.id !== mappedActiveEvent.id)];
+  const activeHistoryEvent = getActiveHistoryEvent(activeEvent, events);
+  return [activeHistoryEvent, ...events.filter((event) => event.id !== activeHistoryEvent.id)];
 }
 
 function upsertHistoryEvent(

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -248,11 +248,12 @@ function reconcileActiveEventWithHistory(
   }
 
   const hasHistoryTargetSummary = Boolean(matchingHistoryEvent.targetRollup || matchingHistoryEvent.targets.length > 0);
-  const targets = matchingHistoryEvent.targets.length > 0
-    ? matchingHistoryEvent.targets
-    : hasHistoryTargetSummary
-      ? activeEvent.targets
-      : [];
+  const targets =
+    matchingHistoryEvent.targets.length > 0
+      ? matchingHistoryEvent.targets
+      : hasHistoryTargetSummary
+        ? activeEvent.targets
+        : [];
   return create(CurtailmentEventSchema, {
     ...activeEvent,
     state: matchingHistoryEvent.state,
@@ -453,20 +454,33 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
             listCurtailmentEventsPage(pageToken ?? "", knownPageTokens, stateFilters, signal),
           ]);
           assertNotAborted(signal);
-          const activeSnapshot = activeRefresh ? activeRefresh.commit() : getActiveCurtailmentSnapshot();
+          const previewActiveSnapshot = activeRefresh ?? getActiveCurtailmentSnapshot();
+          const previewActiveEvent = reconcileActiveEventWithHistory(
+            previewActiveSnapshot.event,
+            historyPageResponse.events,
+          );
+          const previewSnapshot = createSnapshot(
+            previewActiveEvent,
+            historyPageResponse.events,
+            historyPage === 0 && shouldIncludeActiveEventInHistory(previewActiveEvent, stateFilters),
+          );
+          if (requestId !== latestRefreshRequestIdRef.current) {
+            return previewSnapshot;
+          }
+
+          const activeSnapshot = activeRefresh ? activeRefresh.commit() : previewActiveSnapshot;
           const activeEvent = reconcileActiveEventWithHistory(activeSnapshot.event, historyPageResponse.events);
           if (activeEvent !== activeSnapshot.event) {
             applyActiveCurtailmentEvent(activeEvent);
           }
-
-          const nextSnapshot = createSnapshot(
-            activeEvent,
-            historyPageResponse.events,
-            historyPage === 0 && shouldIncludeActiveEventInHistory(activeEvent, stateFilters),
-          );
-          if (requestId !== latestRefreshRequestIdRef.current) {
-            return nextSnapshot;
-          }
+          const nextSnapshot =
+            activeEvent === previewActiveEvent
+              ? previewSnapshot
+              : createSnapshot(
+                  activeEvent,
+                  historyPageResponse.events,
+                  historyPage === 0 && shouldIncludeActiveEventInHistory(activeEvent, stateFilters),
+                );
 
           const nextPageTokens = currentPagination.pageTokens.slice(0, historyPage + 1);
           nextPageTokens[historyPage] = pageToken || undefined;

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -210,13 +210,12 @@ function getActiveHistoryEvent(
     return markInjectedActiveHistoryEvent(mappedActiveEvent);
   }
 
-  if (!mappedActiveEvent.displayState) {
+  if (!mappedActiveEvent.displayState && mappedActiveEvent.state === matchingHistoryEvent.state) {
     return matchingHistoryEvent;
   }
 
   return {
     ...mappedActiveEvent,
-    displayState: mappedActiveEvent.displayState,
     sourceLabel: matchingHistoryEvent.sourceLabel,
   };
 }

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -297,8 +297,11 @@ describe("ActiveCurtailmentStatus", () => {
     expect(screen.getByText("4 minutes")).toBeVisible();
   });
 
-  it("renders a completed-with-failures event as an incomplete restore", () => {
-    render(<ActiveCurtailmentStatus event={restoreIncompleteCurtailmentEvent} onDismissRestored={vi.fn()} />);
+  it("renders a completed-with-failures event as an incomplete restore", async () => {
+    const user = userEvent.setup();
+    const onDismissRestored = vi.fn();
+
+    render(<ActiveCurtailmentStatus event={restoreIncompleteCurtailmentEvent} onDismissRestored={onDismissRestored} />);
 
     expect(screen.getByText("Power restore")).toBeVisible();
     expect(screen.getByText("56.7 kW of 60.0 kW restored")).toBeVisible();
@@ -308,9 +311,12 @@ describe("ActiveCurtailmentStatus", () => {
     expect(screen.getByText("Not restored")).toBeVisible();
     expect(screen.queryByText("60.0 kW restored")).not.toBeInTheDocument();
     expectProgressValue("94");
-    expectActionButtonHidden("Dismiss");
     expectActionButtonHidden("Stop");
     expectActionButtonHidden("Restore");
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(onDismissRestored).toHaveBeenCalledOnce();
   });
 
   it("renders failed and cancelled events without active controls", () => {

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -495,12 +495,12 @@ function getActiveCurtailmentActionButton({
 }: ActiveCurtailmentActionButtonsProps): ReactElement | null {
   switch (displayState) {
     case "restored":
+    case "restoreIncomplete":
       return onDismissRestored ? (
         <Button variant={variants.secondary} size={sizes.compact} text="Dismiss" onClick={onDismissRestored} />
       ) : null;
     case "cancelled":
     case "failed":
-    case "restoreIncomplete":
       return null;
     case "curtailed":
       return onRequestRestore ? (

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
@@ -99,21 +99,22 @@ describe("CurtailmentHistory", () => {
     expect(getRenderedRows()).toHaveLength(mockCurtailmentHistoryEvents.length);
   });
 
-  it("delegates controlled status filter changes without filtering the current page locally", async () => {
+  it("delegates controlled multi-status filter changes without filtering the current page locally", async () => {
     const user = userEvent.setup();
-    const onStatusFilterChange = vi.fn();
+    const onStatusFiltersChange = vi.fn();
     render(
       <CurtailmentHistory
         events={mockCurtailmentHistoryEvents.slice(0, 2)}
+        selectedStatusFilters={["completed"]}
         onPageChange={vi.fn()}
-        onStatusFilterChange={onStatusFilterChange}
+        onStatusFiltersChange={onStatusFiltersChange}
       />,
     );
 
     await user.click(screen.getByTestId("filter-dropdown-Status"));
-    await user.click(screen.getByTestId("filter-option-completed"));
+    await user.click(screen.getByTestId("filter-option-failed"));
 
-    expect(onStatusFilterChange).toHaveBeenCalledWith("completed");
+    expect(onStatusFiltersChange).toHaveBeenCalledWith(["completed", "failed"]);
     expect(screen.getByText("ERCOT ERS obligation")).toBeInTheDocument();
   });
 

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
@@ -175,6 +175,31 @@ describe("CurtailmentHistory", () => {
     expect(onStopActiveEvent).toHaveBeenCalledTimes(1);
   });
 
+  it("renders injected active rows with their display state", async () => {
+    const user = userEvent.setup();
+    const curtailingPendingEvent = {
+      ...mockCurtailmentHistoryEvents[0],
+      id: "curt-display-state",
+      reason: "Dispatch underway",
+      state: "pending" as const,
+      displayState: "curtailing" as const,
+      startedAt: "",
+    };
+
+    render(<CurtailmentHistory events={[curtailingPendingEvent]} activeEventId={curtailingPendingEvent.id} />);
+
+    const activeRow = screen.getByTestId("curtailment-history-row-curt-display-state");
+    expect(within(activeRow).getByText("Curtailing")).toBeInTheDocument();
+    expect(within(activeRow).queryByText("Pending")).not.toBeInTheDocument();
+    expect(within(activeRow).getByText("Time unavailable")).toBeInTheDocument();
+
+    await user.click(activeRow);
+
+    const modal = screen.getByTestId("modal");
+    expect(within(modal).getByText("Curtailing")).toBeInTheDocument();
+    expect(within(modal).queryByText("Pending")).not.toBeInTheDocument();
+  });
+
   it("opens row details from an empty actions cell", async () => {
     const user = userEvent.setup();
     render(<CurtailmentHistory events={mockCurtailmentHistoryEvents} />);

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -46,10 +46,12 @@ interface CurtailmentHistoryProps {
   hasNextPage?: boolean;
   hasPreviousPage?: boolean;
   selectedStatusFilter?: CurtailmentEventState;
+  selectedStatusFilters?: CurtailmentEventState[];
   className?: string;
   onViewEvent?: (event: CurtailmentHistoryEvent) => void;
   onPageChange?: (page: number) => void;
   onStatusFilterChange?: (filter?: CurtailmentEventState) => void;
+  onStatusFiltersChange?: (filters: CurtailmentEventState[]) => void;
   /**
    * Called from the detail modal for the active non-terminal event. The parent
    * owns opening the edit flow with the selected event's values.
@@ -424,10 +426,12 @@ function CurtailmentHistory({
   hasNextPage: controlledHasNextPage = false,
   hasPreviousPage: controlledHasPreviousPage,
   selectedStatusFilter,
+  selectedStatusFilters: controlledSelectedStatusFilters,
   className,
   onViewEvent,
   onPageChange,
   onStatusFilterChange,
+  onStatusFiltersChange,
   onManageActiveEvent,
   onStopActiveEvent,
 }: CurtailmentHistoryProps): ReactElement {
@@ -457,10 +461,15 @@ function CurtailmentHistory({
   );
   const pendingStoppableEventId = pendingStopEventIsStoppable ? pendingStopEventId : undefined;
   const usesControlledPagination = Boolean(onPageChange);
-  const usesServerStatusFilter = Boolean(onStatusFilterChange);
+  const usesServerStatusFilter = Boolean(onStatusFiltersChange || onStatusFilterChange);
   const selectedStatusFilters = useMemo(
-    () => (usesServerStatusFilter ? (selectedStatusFilter ? [selectedStatusFilter] : []) : localSelectedStatusFilters),
-    [localSelectedStatusFilters, selectedStatusFilter, usesServerStatusFilter],
+    () =>
+      usesServerStatusFilter
+        ? normalizeStatusFilters(
+            controlledSelectedStatusFilters ?? (selectedStatusFilter ? [selectedStatusFilter] : []),
+          )
+        : localSelectedStatusFilters,
+    [controlledSelectedStatusFilters, localSelectedStatusFilters, selectedStatusFilter, usesServerStatusFilter],
   );
   const hasActiveFilters = selectedStatusFilters.length > 0;
 
@@ -497,7 +506,12 @@ function CurtailmentHistory({
 
   const handleStatusFilterChange = (filters: string[]) => {
     const nextFilters = normalizeStatusFilters(filters);
-    if (usesServerStatusFilter) {
+    if (onStatusFiltersChange) {
+      onStatusFiltersChange(nextFilters);
+      return;
+    }
+
+    if (onStatusFilterChange) {
       onStatusFilterChange?.(nextFilters[nextFilters.length - 1]);
       return;
     }

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -26,6 +26,7 @@ export interface CurtailmentHistoryEvent {
   reason: string;
   state: CurtailmentEventState;
   displayState?: ActiveCurtailmentDisplayState;
+  injectedActive?: boolean;
   priority: CurtailmentPriority;
   scopeLabel: string;
   selectedMiners: number;

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
 import {
   type ActiveCurtailmentDisplayState,
+  activeCurtailmentDisplayStateConfigs,
   type CurtailmentEventState,
   curtailmentEventStateConfigs,
   curtailmentEventStates,
@@ -170,6 +171,15 @@ function formatDateTime(value?: string): string | undefined {
   return date ? dateTimeFormatter.format(date) : undefined;
 }
 
+function getHistoryEventStateConfig(event: CurtailmentHistoryEvent): {
+  label: string;
+  dotClassName: string;
+} {
+  return event.displayState
+    ? activeCurtailmentDisplayStateConfigs[event.displayState]
+    : curtailmentEventStateConfigs[event.state];
+}
+
 function getHistoryStatusDetail(event: CurtailmentHistoryEvent): string {
   const endedAt = formatDateTime(event.endedAt);
   if (endedAt) {
@@ -191,7 +201,7 @@ function getHistoryStatusDetail(event: CurtailmentHistoryEvent): string {
     return `Created ${createdAt}`;
   }
 
-  return event.state === "pending" ? "Waiting to start" : "Time unavailable";
+  return (event.displayState ?? event.state) === "pending" ? "Waiting to start" : "Time unavailable";
 }
 
 function getSortTime(event: CurtailmentHistoryEvent): number {
@@ -267,7 +277,7 @@ function CurtailmentSummaryModal({
   const endedAt = formatDateTime(event.endedAt);
   const scheduledAt = formatDateTime(event.scheduledAt);
   const createdAt = formatDateTime(event.createdAt);
-  const eventStateConfig = curtailmentEventStateConfigs[event.state];
+  const eventStateConfig = getHistoryEventStateConfig(event);
   const buttons: CurtailmentSummaryModalButton[] = [];
 
   if (onStop) {
@@ -326,7 +336,7 @@ function CurtailmentHistoryRow({
   stopDisabled,
 }: CurtailmentHistoryRowProps): ReactElement {
   const canStop = Boolean(onRequestStop) && isActiveStoppableEvent(event, activeEventId);
-  const eventStateConfig = curtailmentEventStateConfigs[event.state];
+  const eventStateConfig = getHistoryEventStateConfig(event);
 
   const handleRowClick = (clickEvent: MouseEvent<HTMLTableRowElement>) => {
     if (shouldIgnoreRowActivation(clickEvent.target, clickEvent.currentTarget)) {

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
 import {
+  type ActiveCurtailmentDisplayState,
   type CurtailmentEventState,
   curtailmentEventStateConfigs,
   curtailmentEventStates,
@@ -23,6 +24,7 @@ export interface CurtailmentHistoryEvent {
   id: string;
   reason: string;
   state: CurtailmentEventState;
+  displayState?: ActiveCurtailmentDisplayState;
   priority: CurtailmentPriority;
   scopeLabel: string;
   selectedMiners: number;

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -9,9 +9,11 @@ import CurtailmentManagementPanel from "@/protoFleet/features/energy/Curtailment
 import type { CurtailmentSubmitValues } from "@/protoFleet/features/energy/CurtailmentStartModal";
 
 const mocks = vi.hoisted(() => ({
+  dismissTerminalCurtailment: vi.fn(),
   goToHistoryPage: vi.fn(),
   refreshCurtailment: vi.fn(),
   setHistoryStatusFilter: vi.fn(),
+  setHistoryStatusFilters: vi.fn(),
   startCurtailment: vi.fn(),
   stopCurtailment: vi.fn(),
   submitValues: { reason: "Grid peak" },
@@ -154,10 +156,14 @@ function createApiResult(overrides: Partial<UseCurtailmentApiResult> = {}): UseC
     historyHasNextPage: false,
     historyHasPreviousPage: false,
     historyPageSize: 50,
+    historyStatusFilters: [],
     refreshCurtailment: mocks.refreshCurtailment as UseCurtailmentApiResult["refreshCurtailment"],
     goToHistoryPage: mocks.goToHistoryPage as UseCurtailmentApiResult["goToHistoryPage"],
     setHistoryStatusFilter: mocks.setHistoryStatusFilter as UseCurtailmentApiResult["setHistoryStatusFilter"],
+    setHistoryStatusFilters: mocks.setHistoryStatusFilters as UseCurtailmentApiResult["setHistoryStatusFilters"],
     startCurtailment: mocks.startCurtailment as UseCurtailmentApiResult["startCurtailment"],
+    dismissTerminalCurtailment:
+      mocks.dismissTerminalCurtailment as UseCurtailmentApiResult["dismissTerminalCurtailment"],
     updateCurtailment: mocks.updateCurtailment as UseCurtailmentApiResult["updateCurtailment"],
     stopCurtailment: mocks.stopCurtailment as UseCurtailmentApiResult["stopCurtailment"],
     ...overrides,

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -61,9 +61,9 @@ vi.mock("@/protoFleet/features/energy/CurtailmentHistory", () => ({
     hasNextPage,
     hasPreviousPage,
     pageSize,
-    selectedStatusFilter,
+    selectedStatusFilters,
     onPageChange,
-    onStatusFilterChange,
+    onStatusFiltersChange,
     onStopActiveEvent,
   }: {
     currentPage?: number;
@@ -71,9 +71,9 @@ vi.mock("@/protoFleet/features/energy/CurtailmentHistory", () => ({
     hasNextPage?: boolean;
     hasPreviousPage?: boolean;
     pageSize?: number;
-    selectedStatusFilter?: string;
+    selectedStatusFilters?: string[];
     onPageChange?: (page: number) => void;
-    onStatusFilterChange?: (filter?: string) => void;
+    onStatusFiltersChange?: (filters: string[]) => void;
     onStopActiveEvent?: (event: CurtailmentHistoryEvent) => void | Promise<unknown>;
   }) => (
     <div data-testid="curtailment-history">
@@ -81,13 +81,13 @@ vi.mock("@/protoFleet/features/energy/CurtailmentHistory", () => ({
       <div data-testid="history-page-size">{pageSize}</div>
       <div data-testid="history-has-next">{String(hasNextPage)}</div>
       <div data-testid="history-has-previous">{String(hasPreviousPage)}</div>
-      <div data-testid="history-status-filter">{selectedStatusFilter ?? ""}</div>
+      <div data-testid="history-status-filter">{selectedStatusFilters?.join(",") ?? ""}</div>
       <div data-testid="history-events">{events.map((event) => event.id).join(",")}</div>
       <button type="button" onClick={() => onPageChange?.(2)}>
         Load page 2
       </button>
-      <button type="button" onClick={() => onStatusFilterChange?.("completed")}>
-        Filter completed
+      <button type="button" onClick={() => onStatusFiltersChange?.(["completed", "failed"])}>
+        Filter completed and failed
       </button>
       <button type="button" disabled={events.length === 0} onClick={() => onStopActiveEvent?.(events[0])}>
         Stop history event
@@ -181,6 +181,7 @@ describe("CurtailmentManagementPanel", () => {
     mocks.refreshCurtailment.mockResolvedValue(emptySnapshot);
     mocks.goToHistoryPage.mockResolvedValue(emptySnapshot);
     mocks.setHistoryStatusFilter.mockResolvedValue(emptySnapshot);
+    mocks.setHistoryStatusFilters.mockResolvedValue(emptySnapshot);
     mocks.startCurtailment.mockResolvedValue({});
     mocks.stopCurtailment.mockResolvedValue({});
     mocks.updateCurtailment.mockResolvedValue({});
@@ -387,16 +388,18 @@ describe("CurtailmentManagementPanel", () => {
     mocks.useCurtailmentApi.mockReturnValue(
       createApiResult({
         historyEvents: [historyEvent],
-        historyStatusFilter: "active",
+        historyStatusFilters: ["active", "restoring"],
       }),
     );
 
     render(<CurtailmentManagementPanel />);
 
-    expect(screen.getByTestId("history-status-filter")).toHaveTextContent("active");
+    expect(screen.getByTestId("history-status-filter")).toHaveTextContent("active,restoring");
 
-    await user.click(screen.getByRole("button", { name: "Filter completed" }));
+    await user.click(screen.getByRole("button", { name: "Filter completed and failed" }));
 
-    expect(mocks.setHistoryStatusFilter).toHaveBeenCalledWith("completed", { signal: expect.any(AbortSignal) });
+    expect(mocks.setHistoryStatusFilters).toHaveBeenCalledWith(["completed", "failed"], {
+      signal: expect.any(AbortSignal),
+    });
   });
 });

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -27,15 +27,20 @@ vi.mock("@/protoFleet/api/useCurtailmentApi", () => ({
 
 vi.mock("@/protoFleet/features/energy/ActiveCurtailmentStatus", () => ({
   default: ({
+    onDismissRestored,
     onRequestEdit,
     onRequestRestore,
     onRequestStop,
   }: {
+    onDismissRestored?: () => void;
     onRequestEdit?: () => void;
     onRequestRestore?: () => void;
     onRequestStop?: () => void;
   }) => (
     <div data-testid="active-curtailment-status">
+      <button type="button" onClick={onDismissRestored}>
+        Dismiss restored
+      </button>
       <button type="button" onClick={onRequestEdit}>
         Request edit
       </button>
@@ -242,6 +247,22 @@ describe("CurtailmentManagementPanel", () => {
     await user.click(screen.getByRole("button", { name: "Stop history event" }));
 
     expect(mocks.stopCurtailment).toHaveBeenLastCalledWith("curt-1");
+  });
+
+  it("dismisses terminal active curtailments from the active status card", async () => {
+    const user = userEvent.setup();
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent,
+        activeEventId: "curt-1",
+      }),
+    );
+
+    render(<CurtailmentManagementPanel />);
+
+    await user.click(screen.getByRole("button", { name: "Dismiss restored" }));
+
+    expect(mocks.dismissTerminalCurtailment).toHaveBeenCalledOnce();
   });
 
   it("opens active curtailment management and submits updates", async () => {

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -67,6 +67,7 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
     goToHistoryPage,
     setHistoryStatusFilter,
     startCurtailment,
+    dismissTerminalCurtailment,
     updateCurtailment,
     stopCurtailment,
   } = useCurtailmentApi();
@@ -225,6 +226,7 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
           {activeEvent ? (
             <ActiveCurtailmentStatus
               event={activeEvent}
+              onDismissRestored={dismissTerminalCurtailment}
               onRequestEdit={openEditModal}
               onRequestRestore={() => openStopConfirmation("restore")}
               onRequestStop={() => openStopConfirmation("stopCurtailment")}

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -62,10 +62,10 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
     historyHasNextPage,
     historyHasPreviousPage,
     historyPageSize,
-    historyStatusFilter,
+    historyStatusFilters,
     refreshCurtailment,
     goToHistoryPage,
-    setHistoryStatusFilter,
+    setHistoryStatusFilters,
     startCurtailment,
     dismissTerminalCurtailment,
     updateCurtailment,
@@ -177,11 +177,11 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
     [goToHistoryPage, runAbortableRefresh],
   );
 
-  const handleHistoryStatusFilterChange = useCallback(
-    (stateFilter?: CurtailmentEventState) => {
-      void runAbortableRefresh((signal) => setHistoryStatusFilter(stateFilter, { signal })).catch(() => {});
+  const handleHistoryStatusFiltersChange = useCallback(
+    (stateFilters: CurtailmentEventState[]) => {
+      void runAbortableRefresh((signal) => setHistoryStatusFilters(stateFilters, { signal })).catch(() => {});
     },
-    [runAbortableRefresh, setHistoryStatusFilter],
+    [runAbortableRefresh, setHistoryStatusFilters],
   );
 
   const handleConfirmStop = useCallback(() => {
@@ -240,9 +240,9 @@ function CurtailmentManagementPanel({ className }: CurtailmentManagementPanelPro
             currentPage={historyCurrentPage}
             hasNextPage={historyHasNextPage}
             hasPreviousPage={historyHasPreviousPage}
-            selectedStatusFilter={historyStatusFilter}
+            selectedStatusFilters={historyStatusFilters}
             onPageChange={handleHistoryPageChange}
-            onStatusFilterChange={handleHistoryStatusFilterChange}
+            onStatusFiltersChange={handleHistoryStatusFiltersChange}
             onStopActiveEvent={handleHistoryStop}
           />
         </>


### PR DESCRIPTION
🤖
## Summary
- Share active curtailment API state between the page-header data source and the curtailment management hook
- Add multi-status history filter support in the client hook while preserving the existing single-status hook API for current callers
- Map injected active history rows with their active display state

## Test plan
- [ ] Confirm active curtailment state stays visible in the header and management data after refreshes
- [ ] Confirm history filtering still works for existing single-status callers
- [ ] Confirm multi-status history filters send repeated `state_filters`

Closes #359
