### PR TITLE
Gate curtailment UI by permissions

### DIFF
--- a/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
@@ -4,10 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import PageHeader from "./PageHeader";
 import type { UseSchedulePillDataResult } from "./useSchedulePillData";
 import type { ScheduleListItem } from "@/protoFleet/api/useScheduleApi";
+import { useHasPermission } from "@/protoFleet/store";
 
 const mockUseWindowDimensions = vi.fn();
 const mockUseReactiveLocalStorage = vi.fn();
 const mockCurtailmentPill = vi.fn();
+const mockListSites = vi.fn();
 
 vi.mock("./CurtailmentPill", () => ({
   default: (props: { detailsPath?: string }) => {
@@ -25,12 +27,22 @@ vi.mock("./SchedulePill", () => ({
   default: ({ pillSchedule }: { pillSchedule: { name: string } }) => <div>{pillSchedule.name}</div>,
 }));
 
+vi.mock("@/protoFleet/api/sites", () => ({
+  useSites: () => ({
+    listSites: mockListSites,
+  }),
+}));
+
 vi.mock("@/shared/hooks/useWindowDimensions", () => ({
   useWindowDimensions: () => mockUseWindowDimensions(),
 }));
 
 vi.mock("@/shared/hooks/useReactiveLocalStorage", () => ({
   useReactiveLocalStorage: () => mockUseReactiveLocalStorage(),
+}));
+
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: vi.fn(),
 }));
 
 vi.mock("@/shared/assets/icons", () => ({
@@ -62,11 +74,13 @@ const createSchedulePillData = (overrides: Partial<UseSchedulePillDataResult> = 
 describe("PageHeader", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockListSites.mockReturnValue(undefined);
     mockUseWindowDimensions.mockReturnValue({
       isPhone: true,
       isTablet: false,
     });
     mockUseReactiveLocalStorage.mockReturnValue([false, vi.fn()]);
+    vi.mocked(useHasPermission).mockReturnValue(true);
   });
 
   it("shows the phone widget row when schedules are available even if setup is not dismissed", () => {
@@ -117,5 +131,32 @@ describe("PageHeader", () => {
     );
 
     expect(mockCurtailmentPill).toHaveBeenCalledWith(expect.objectContaining({ detailsPath: "/energy" }));
+  });
+
+  it("hides the curtailment pill without curtailment read permission", () => {
+    vi.mocked(useHasPermission).mockReturnValue(false);
+    mockUseWindowDimensions.mockReturnValue({
+      isPhone: false,
+      isTablet: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <PageHeader
+          schedulePillData={createSchedulePillData()}
+          activeCurtailmentEvent={{
+            reason: "Grid peak call",
+            state: "curtailing",
+            scopeLabel: "Whole fleet",
+            selectedMiners: 48,
+            estimatedReductionKw: 126.4,
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(useHasPermission).toHaveBeenCalledWith("curtailment:read");
+    expect(screen.queryByText("Curtailment pill")).not.toBeInTheDocument();
+    expect(mockCurtailmentPill).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -11,6 +11,7 @@ import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_p
 import { useSites } from "@/protoFleet/api/sites";
 import { MULTI_SITE_ENABLED } from "@/protoFleet/constants/featureFlags";
 import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
+import { useHasPermission } from "@/protoFleet/store";
 import { Pause } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import { useReactiveLocalStorage } from "@/shared/hooks/useReactiveLocalStorage";
@@ -25,6 +26,7 @@ interface PageHeaderProps {
 
 interface HeaderWidgetsProps {
   activeCurtailmentEvent: CurtailmentPillEvent | null;
+  canReadCurtailment: boolean;
   className?: string;
   dismissedSetup: boolean;
   onContinueSetup: () => void;
@@ -35,6 +37,7 @@ const headerWidgetEnabled = true;
 
 function HeaderWidgets({
   activeCurtailmentEvent,
+  canReadCurtailment,
   className,
   dismissedSetup,
   onContinueSetup,
@@ -44,7 +47,9 @@ function HeaderWidgets({
 
   return (
     <div className={clsx("flex space-x-3", className)}>
-      {activeCurtailmentEvent ? <CurtailmentPill event={activeCurtailmentEvent} detailsPath="/energy" /> : null}
+      {activeCurtailmentEvent && canReadCurtailment ? (
+        <CurtailmentPill event={activeCurtailmentEvent} detailsPath="/energy" />
+      ) : null}
       {pillSchedule ? (
         <SchedulePill
           pillSchedule={pillSchedule}
@@ -70,6 +75,7 @@ function PageHeader({
   const { bgClass } = usePageBackground();
   const [dismissedSetup, setDismissedSetup] = useReactiveLocalStorage<boolean>("completeSetupDismissed");
   const hasDismissedSetup = Boolean(dismissedSetup);
+  const canReadCurtailment = useHasPermission("curtailment:read");
 
   // Multi-site: the SitePicker replaces today's LocationSelector when the
   // feature flag is on. Sites are fetched once on mount and held here so the
@@ -108,13 +114,14 @@ function PageHeader({
 
   const headerWidgetsProps = {
     activeCurtailmentEvent,
+    canReadCurtailment,
     dismissedSetup: hasDismissedSetup,
     onContinueSetup: handleCompleteSetup,
     schedulePillData,
   };
-  const hasActiveCurtailmentEvent = activeCurtailmentEvent !== null;
+  const hasVisibleCurtailmentPill = activeCurtailmentEvent !== null && canReadCurtailment;
   const showPhoneWidgets =
-    isPhone && (hasDismissedSetup || schedulePillData.hasVisibleSchedules || hasActiveCurtailmentEvent);
+    isPhone && (hasDismissedSetup || schedulePillData.hasVisibleSchedules || hasVisibleCurtailmentPill);
 
   return (
     <>

--- a/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 
-import { resetActiveCurtailmentData } from "@/protoFleet/api/activeCurtailmentData";
+import { applyActiveCurtailmentEvent, resetActiveCurtailmentData } from "@/protoFleet/api/activeCurtailmentData";
 import { curtailmentClient } from "@/protoFleet/api/clients";
 import { CURTAILMENT_CHANGED_EVENT } from "@/protoFleet/api/curtailmentEvents";
 import {
@@ -12,9 +12,10 @@ import {
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import { useCurtailmentPillData } from "@/protoFleet/components/PageHeader/useCurtailmentPillData";
 
-const { mockGetActiveCurtailment, mockHandleAuthErrors } = vi.hoisted(() => ({
+const { mockGetActiveCurtailment, mockHandleAuthErrors, mockUseHasPermission } = vi.hoisted(() => ({
   mockGetActiveCurtailment: vi.fn(),
   mockHandleAuthErrors: vi.fn(),
+  mockUseHasPermission: vi.fn(),
 }));
 
 vi.mock("@/protoFleet/api/clients", () => ({
@@ -27,6 +28,7 @@ vi.mock("@/protoFleet/store", () => ({
   useAuthErrors: () => ({
     handleAuthErrors: mockHandleAuthErrors,
   }),
+  useHasPermission: mockUseHasPermission,
 }));
 
 function curtailmentEvent(): CurtailmentEvent {
@@ -42,6 +44,7 @@ describe("useCurtailmentPillData", () => {
     vi.useFakeTimers();
     resetActiveCurtailmentData();
     vi.clearAllMocks();
+    mockUseHasPermission.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -77,6 +80,23 @@ describe("useCurtailmentPillData", () => {
       vi.advanceTimersByTime(30_000);
     });
     expect(curtailmentClient.getActiveCurtailment).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not poll or surface cached events without curtailment read permission", async () => {
+    applyActiveCurtailmentEvent(curtailmentEvent());
+    mockUseHasPermission.mockReturnValue(false);
+
+    const { result } = renderHook(() => useCurtailmentPillData());
+
+    expect(result.current.activeEvent).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      window.dispatchEvent(new CustomEvent(CURTAILMENT_CHANGED_EVENT));
+    });
+
+    expect(mockUseHasPermission).toHaveBeenCalledWith("curtailment:read");
+    expect(curtailmentClient.getActiveCurtailment).not.toHaveBeenCalled();
   });
 
   it("polls active curtailments more frequently", async () => {

--- a/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.ts
+++ b/client/src/protoFleet/components/PageHeader/useCurtailmentPillData.ts
@@ -9,7 +9,7 @@ import {
 } from "@/protoFleet/api/activeCurtailmentData";
 import { CURTAILMENT_CHANGED_EVENT } from "@/protoFleet/api/curtailmentEvents";
 import { isAbortError } from "@/protoFleet/api/requestErrors";
-import { useAuthErrors } from "@/protoFleet/store";
+import { useAuthErrors, useHasPermission } from "@/protoFleet/store";
 
 export interface UseCurtailmentPillDataResult {
   activeEvent: CurtailmentPillEvent | null;
@@ -20,10 +20,11 @@ const activeCurtailmentPollIntervalMs = 3_000;
 
 export function useCurtailmentPillData(): UseCurtailmentPillDataResult {
   const { handleAuthErrors } = useAuthErrors();
+  const canReadCurtailment = useHasPermission("curtailment:read");
   const activeCurtailmentEvent = useActiveCurtailmentEvent();
   const activeEvent = useMemo<CurtailmentPillEvent | null>(
-    () => mapCurtailmentPillEvent(activeCurtailmentEvent),
-    [activeCurtailmentEvent],
+    () => (canReadCurtailment ? mapCurtailmentPillEvent(activeCurtailmentEvent) : null),
+    [activeCurtailmentEvent, canReadCurtailment],
   );
   const inFlightRefreshRef = useRef<Promise<void> | null>(null);
   const pendingFreshRefreshRef = useRef(false);
@@ -73,6 +74,10 @@ export function useCurtailmentPillData(): UseCurtailmentPillDataResult {
   );
 
   useEffect(() => {
+    if (!canReadCurtailment) {
+      return undefined;
+    }
+
     const abortController = new AbortController();
 
     const refresh = (): void => {
@@ -90,9 +95,13 @@ export function useCurtailmentPillData(): UseCurtailmentPillDataResult {
       window.removeEventListener(CURTAILMENT_CHANGED_EVENT, refreshAfterCurtailmentChange);
       abortController.abort();
     };
-  }, [refreshActiveCurtailment]);
+  }, [canReadCurtailment, refreshActiveCurtailment]);
 
   useEffect(() => {
+    if (!canReadCurtailment) {
+      return undefined;
+    }
+
     const abortController = new AbortController();
     const intervalId = window.setInterval(() => {
       void refreshActiveCurtailment(abortController.signal);
@@ -102,7 +111,7 @@ export function useCurtailmentPillData(): UseCurtailmentPillDataResult {
       window.clearInterval(intervalId);
       abortController.abort();
     };
-  }, [pollIntervalMs, refreshActiveCurtailment]);
+  }, [canReadCurtailment, pollIntervalMs, refreshActiveCurtailment]);
 
   return { activeEvent };
 }

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -49,12 +49,16 @@ vi.mock("@/protoFleet/features/energy/ActiveCurtailmentStatus", () => ({
           Request edit
         </button>
       ) : null}
-      <button type="button" onClick={onRequestRestore}>
-        Request restore
-      </button>
-      <button type="button" onClick={onRequestStop}>
-        Request stop
-      </button>
+      {onRequestRestore ? (
+        <button type="button" onClick={onRequestRestore}>
+          Request restore
+        </button>
+      ) : null}
+      {onRequestStop ? (
+        <button type="button" onClick={onRequestStop}>
+          Request stop
+        </button>
+      ) : null}
     </div>
   ),
 }));
@@ -94,9 +98,19 @@ vi.mock("@/protoFleet/features/energy/CurtailmentHistory", () => ({
       <button type="button" onClick={() => onStatusFiltersChange?.(["completed", "failed"])}>
         Filter completed and failed
       </button>
-      <button type="button" disabled={events.length === 0} onClick={() => onStopActiveEvent?.(events[0])}>
-        Stop history event
-      </button>
+      {onStopActiveEvent ? (
+        <button
+          type="button"
+          disabled={events.length === 0}
+          onClick={() => {
+            if (events[0]) {
+              onStopActiveEvent(events[0]);
+            }
+          }}
+        >
+          Stop history event
+        </button>
+      ) : null}
     </div>
   ),
 }));
@@ -416,7 +430,7 @@ describe("CurtailmentManagementPanel", () => {
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Manage curtailment" })).not.toBeInTheDocument());
   });
 
-  it("hides active curtailment management for read-only users", () => {
+  it("hides curtailment management actions for users without curtailment manage permission", () => {
     mocks.useCurtailmentApi.mockReturnValue(
       createApiResult({
         activeEvent,
@@ -429,7 +443,10 @@ describe("CurtailmentManagementPanel", () => {
 
     expect(screen.getByTestId("active-curtailment-status")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Request edit" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Plan curtailment" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request restore" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request stop" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Stop history event" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Plan curtailment" })).not.toBeInTheDocument();
   });
 
   it("keeps the edit baseline stable after active event refreshes", async () => {

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -192,13 +192,13 @@ function CurtailmentManagementPanel({
 
   const openStopConfirmation = useCallback(
     (action: CurtailmentStopConfirmationAction, eventId = activeEventId) => {
-      if (!eventId) {
+      if (!canManageCurtailment || !eventId) {
         return;
       }
 
       setPendingStopConfirmation({ action, eventId });
     },
-    [activeEventId],
+    [activeEventId, canManageCurtailment],
   );
 
   const handleStartSubmit = useCallback(
@@ -256,14 +256,14 @@ function CurtailmentManagementPanel({
   );
 
   const handleConfirmStop = useCallback(() => {
-    if (!pendingStopConfirmation) {
+    if (!canManageCurtailment || !pendingStopConfirmation) {
       return;
     }
 
     void stopCurtailment(pendingStopConfirmation.eventId)
       .then(() => setPendingStopConfirmation(null))
       .catch(() => {});
-  }, [pendingStopConfirmation, stopCurtailment]);
+  }, [canManageCurtailment, pendingStopConfirmation, stopCurtailment]);
 
   const handleEditStopCurtailment = useCallback(() => {
     const editEventId = editSession?.eventId ?? activeEventId;
@@ -276,14 +276,16 @@ function CurtailmentManagementPanel({
     <section className={clsx("grid gap-6", className)}>
       <div className="flex items-center justify-between gap-4 phone:flex-col phone:items-stretch">
         <Header title="Curtailment" titleSize="text-heading-300" />
-        <Button
-          variant={variants.primary}
-          size={sizes.base}
-          text="Plan curtailment"
-          onClick={openCreateModal}
-          disabled={isStarting || isUpdating}
-          className="phone:w-full"
-        />
+        {canManageCurtailment ? (
+          <Button
+            variant={variants.primary}
+            size={sizes.base}
+            text="Plan curtailment"
+            onClick={openCreateModal}
+            disabled={isStarting || isUpdating}
+            className="phone:w-full"
+          />
+        ) : null}
       </div>
 
       {errorMessage ? <CurtailmentMessage message={errorMessage} /> : null}
@@ -299,8 +301,8 @@ function CurtailmentManagementPanel({
               event={activeEvent}
               onDismissRestored={dismissTerminalCurtailment}
               onRequestEdit={canManageCurtailment ? openEditModal : undefined}
-              onRequestRestore={() => openStopConfirmation("restore")}
-              onRequestStop={() => openStopConfirmation("stopCurtailment")}
+              onRequestRestore={canManageCurtailment ? () => openStopConfirmation("restore") : undefined}
+              onRequestStop={canManageCurtailment ? () => openStopConfirmation("stopCurtailment") : undefined}
             />
           ) : null}
 
@@ -314,7 +316,7 @@ function CurtailmentManagementPanel({
             selectedStatusFilters={historyStatusFilters}
             onPageChange={handleHistoryPageChange}
             onStatusFiltersChange={handleHistoryStatusFiltersChange}
-            onStopActiveEvent={handleHistoryStop}
+            onStopActiveEvent={canManageCurtailment ? handleHistoryStop : undefined}
           />
         </>
       )}

--- a/client/src/protoFleet/features/energy/pages/EnergyPage.test.tsx
+++ b/client/src/protoFleet/features/energy/pages/EnergyPage.test.tsx
@@ -1,3 +1,4 @@
+import { MemoryRouter } from "react-router-dom";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -20,11 +21,29 @@ describe("EnergyPage", () => {
   });
 
   it("passes curtailment manage permission to the management panel", () => {
-    vi.mocked(useHasPermission).mockReturnValue(false);
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:read");
 
-    render(<EnergyPage />);
+    render(
+      <MemoryRouter>
+        <EnergyPage />
+      </MemoryRouter>,
+    );
 
+    expect(useHasPermission).toHaveBeenCalledWith("curtailment:read");
     expect(useHasPermission).toHaveBeenCalledWith("curtailment:manage");
     expect(screen.getByTestId("curtailment-management-panel")).toHaveTextContent("false");
+  });
+
+  it("redirects without curtailment read permission", () => {
+    vi.mocked(useHasPermission).mockReturnValue(false);
+
+    render(
+      <MemoryRouter>
+        <EnergyPage />
+      </MemoryRouter>,
+    );
+
+    expect(useHasPermission).toHaveBeenCalledWith("curtailment:read");
+    expect(screen.queryByTestId("curtailment-management-panel")).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/energy/pages/EnergyPage.tsx
+++ b/client/src/protoFleet/features/energy/pages/EnergyPage.tsx
@@ -1,8 +1,15 @@
+import { Navigate } from "react-router-dom";
+
 import CurtailmentManagementPanel from "@/protoFleet/features/energy/CurtailmentManagementPanel";
 import { useHasPermission } from "@/protoFleet/store";
 
 const EnergyPage = () => {
+  const canReadCurtailment = useHasPermission("curtailment:read");
   const canManageCurtailment = useHasPermission("curtailment:manage");
+
+  if (!canReadCurtailment) {
+    return <Navigate to="/" replace />;
+  }
 
   return (
     <div className="p-6 laptop:p-10">

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { type BulkAction } from "../BulkActions/types";
 import { ACTION_PERMISSIONS, usePermittedActions } from "./actionPermissions";
-import { deviceActions, settingsActions, type SupportedAction } from "./constants";
+import { deviceActions, performanceActions, settingsActions, type SupportedAction } from "./constants";
 
 vi.mock("@/protoFleet/store", () => ({
   usePermissions: vi.fn(),
@@ -98,6 +98,7 @@ describe("ACTION_PERMISSIONS", () => {
     expect(ACTION_PERMISSIONS[deviceActions.unpair]).toBe("miner:delete");
     expect(ACTION_PERMISSIONS[deviceActions.firmwareUpdate]).toBe("miner:firmware_update");
     expect(ACTION_PERMISSIONS[deviceActions.downloadLogs]).toBe("miner:download_logs");
+    expect(ACTION_PERMISSIONS[performanceActions.curtail]).toBe("curtailment:manage");
     expect(ACTION_PERMISSIONS[settingsActions.miningPool]).toEqual(["miner:update_pools", "pool:read"]);
   });
 });


### PR DESCRIPTION
## Summary
- Gate the Energy route, header curtailment pill, and pill polling on curtailment:read
- Gate curtailment planning, stop, restore, and related miner action affordances on curtailment:manage

## Test plan
- [ ] Confirm users without curtailment:read do not see the Energy nav item/header pill and cannot stay on /energy directly
- [ ] Confirm users with curtailment:read but without curtailment:manage can view curtailment state/history without mutation actions