### PR TITLE
Cover curtailment with Playwright E2E

### DIFF
--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -7,6 +7,7 @@ import { AddMinersPage } from "../pages/addMiners";
 import { AuthPage } from "../pages/auth";
 import { LoginModalComponent } from "../pages/components/loginModal";
 import { EditPoolPage } from "../pages/editPool";
+import { EnergyPage } from "../pages/energy";
 import { GroupsPage } from "../pages/groups";
 import { HomePage } from "../pages/home";
 import { MinersPage } from "../pages/miners";
@@ -38,6 +39,7 @@ type PageFixtures = {
   settingsTeamPage: SettingsTeamPage;
   settingsPoolsPage: SettingsPoolsPage;
   editPoolPage: EditPoolPage;
+  energyPage: EnergyPage;
   newPoolModal: NewPoolModalPage;
   loginModal: LoginModalComponent;
   commonSteps: CommonSteps;
@@ -91,6 +93,9 @@ export const test = base.extend<PageFixtures>({
   },
   editPoolPage: async ({ page, isMobile }, use) => {
     await use(new EditPoolPage(page, isMobile));
+  },
+  energyPage: async ({ page, isMobile }, use) => {
+    await use(new EnergyPage(page, isMobile));
   },
   newPoolModal: async ({ page, isMobile }, use) => {
     await use(new NewPoolModalPage(page, isMobile));

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -107,10 +107,7 @@ export class EnergyPage extends BasePage {
       return;
     }
 
-    const historyStopButton = this.curtailmentHistoryStopButton(target);
-    if (await historyStopButton.isVisible().catch(() => false)) {
-      await this.confirmStopAction(historyStopButton, "Confirm stop");
-    }
+    await this.stopHistoryCurtailmentIfPresent(target);
   }
 
   async waitForCurtailmentToRestore(target: CurtailmentCleanupTarget) {
@@ -153,9 +150,7 @@ export class EnergyPage extends BasePage {
       return;
     }
 
-    const historyStopButton = this.curtailmentHistoryStopButton(target);
-    if (await historyStopButton.isVisible().catch(() => false)) {
-      await this.confirmStopAction(historyStopButton, "Confirm stop");
+    if (await this.stopHistoryCurtailmentIfPresent(target)) {
       await this.waitForCurtailmentToRestore(target);
       return;
     }
@@ -196,6 +191,17 @@ export class EnergyPage extends BasePage {
 
   private curtailmentHistoryStopButton(target: CurtailmentCleanupTarget): Locator {
     return this.curtailmentHistoryRow(target).getByRole("button", { name: `Stop ${target.reason}` });
+  }
+
+  private async stopHistoryCurtailmentIfPresent(target: CurtailmentCleanupTarget): Promise<boolean> {
+    const historyStopButton = this.curtailmentHistoryStopButton(target);
+    if ((await historyStopButton.count()) === 0) {
+      return false;
+    }
+
+    await historyStopButton.first().scrollIntoViewIfNeeded();
+    await this.confirmStopAction(historyStopButton.first(), "Confirm stop");
+    return true;
   }
 
   private async hasMatchingStoppableCurtailment(target: CurtailmentCleanupTarget): Promise<boolean> {

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -1,0 +1,214 @@
+import { expect, type Locator, type Request, type Response } from "@playwright/test";
+import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
+import { BasePage } from "./base";
+
+const stopRequestPattern = /StopCurtailment/;
+
+export interface CurtailmentCleanupTarget {
+  reason: string;
+  eventUuid?: string;
+}
+
+export class EnergyPage extends BasePage {
+  async navigateToEnergyPage() {
+    await this.clickNavigationMenuIfMobile();
+    await this.page.getByTestId("navigation-menu").locator('a[href="/energy"]').click();
+    await expect(this.page).toHaveURL(/.*\/energy/);
+  }
+
+  async validateEnergyPageOpened() {
+    await this.validateTitle("Curtailment");
+    await this.validateTitle("Curtailment history");
+  }
+
+  async openCurtailmentPlanner() {
+    await this.clickButton("Plan curtailment");
+    await expect(this.page.getByTestId("full-screen-two-pane-modal").getByText("Plan a curtailment")).toBeVisible();
+  }
+
+  async fillCurtailmentPlan({
+    reason,
+    targetKw,
+    restoreBatchIntervalSec,
+  }: {
+    reason: string;
+    targetKw: string;
+    restoreBatchIntervalSec: string;
+  }) {
+    const modal = this.page.getByTestId("full-screen-two-pane-modal");
+
+    await modal.locator("#curtailment-reason").fill(reason);
+    await modal.locator("#curtailment-target-kw").fill(targetKw);
+    await modal.locator("#curtailment-restore-batch-interval").fill(restoreBatchIntervalSec);
+  }
+
+  async waitForPreview() {
+    const modal = this.page.getByTestId("full-screen-two-pane-modal");
+
+    await expect(modal.getByText("Curtailment target reduction").first()).toBeVisible();
+    await expect(modal.getByText(/Curtail \d+ miners .* immediately/).first()).toBeVisible();
+  }
+
+  async startCurtailment() {
+    await this.page
+      .getByTestId("full-screen-two-pane-modal")
+      .getByRole("button", { name: "Start curtailment" })
+      .click();
+    const maintenanceConfirmation = this.page.getByTestId("curtailment-maintenance-confirmation");
+    if (await maintenanceConfirmation.isVisible().catch(() => false)) {
+      await maintenanceConfirmation.getByRole("button", { name: "Force include" }).click();
+    }
+    await expect(this.page.getByTestId("full-screen-two-pane-modal")).toBeHidden();
+  }
+
+  async validateActiveCurtailment(reason: string) {
+    await this.validateTitle("Active curtailment");
+    const activeCurtailmentSection = this.activeCurtailmentSection(reason);
+
+    await expect(activeCurtailmentSection).toBeVisible();
+    await expect(activeCurtailmentSection.getByTestId("active-curtailment-primary-lockup")).toContainText(
+      /Pending|Curtailing|Curtailed/,
+    );
+  }
+
+  async validateCurtailmentHistoryRow(reason: string) {
+    await expect(this.curtailmentHistoryRowByReason(reason)).toBeVisible();
+  }
+
+  async stopMatchingActiveCurtailmentIfPresent(reason: string): Promise<boolean> {
+    const stopButton = this.activeCurtailmentStopButton(reason);
+    if (await stopButton.isVisible().catch(() => false)) {
+      await this.confirmStopAction(stopButton, "Confirm stop");
+      return true;
+    }
+
+    const restoreButton = this.activeCurtailmentRestoreButton(reason);
+    if (await restoreButton.isVisible().catch(() => false)) {
+      await this.confirmStopAction(restoreButton, "Restore power");
+      return true;
+    }
+
+    return false;
+  }
+
+  async stopCurtailment(target: CurtailmentCleanupTarget) {
+    await expect
+      .poll(
+        async () => {
+          if (
+            await this.activeCurtailmentStopButton(target.reason)
+              .isVisible()
+              .catch(() => false)
+          ) {
+            return true;
+          }
+
+          if (
+            await this.activeCurtailmentRestoreButton(target.reason)
+              .isVisible()
+              .catch(() => false)
+          ) {
+            return true;
+          }
+
+          return (await this.curtailmentHistoryStopButton(target).count()) > 0;
+        },
+        { timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] },
+      )
+      .toBe(true);
+
+    if (await this.stopMatchingActiveCurtailmentIfPresent(target.reason)) {
+      return;
+    }
+
+    const historyStopButton = this.curtailmentHistoryStopButton(target);
+    if (await historyStopButton.isVisible().catch(() => false)) {
+      await this.confirmStopAction(historyStopButton, "Confirm stop");
+    }
+  }
+
+  async cleanupStartedCurtailment(target: CurtailmentCleanupTarget) {
+    await this.page.goto("/energy");
+    await expect(this.page).toHaveURL(/.*\/energy/);
+
+    if (await this.stopMatchingActiveCurtailmentIfPresent(target.reason)) {
+      return;
+    }
+
+    const historyStopButton = this.curtailmentHistoryStopButton(target);
+    if (await historyStopButton.isVisible().catch(() => false)) {
+      await this.confirmStopAction(historyStopButton, "Confirm stop");
+    }
+  }
+
+  private activeCurtailmentSection(reason: string): Locator {
+    return this.page
+      .getByRole("heading", { name: "Active curtailment" })
+      .locator("xpath=ancestor::section[1]")
+      .filter({ hasText: reason });
+  }
+
+  private activeCurtailmentStopButton(reason: string): Locator {
+    return this.activeCurtailmentSection(reason).getByRole("button", { name: "Stop", exact: true });
+  }
+
+  private activeCurtailmentRestoreButton(reason: string): Locator {
+    return this.activeCurtailmentSection(reason).getByRole("button", { name: "Restore", exact: true });
+  }
+
+  private curtailmentHistoryRowByReason(reason: string): Locator {
+    return this.page
+      .locator('[data-testid^="curtailment-history-row-"]')
+      .filter({ has: this.page.getByText(reason, { exact: true }) });
+  }
+
+  private curtailmentHistoryRow({ reason, eventUuid }: CurtailmentCleanupTarget): Locator {
+    if (eventUuid) {
+      return this.page.getByTestId(`curtailment-history-row-${eventUuid}`);
+    }
+
+    return this.curtailmentHistoryRowByReason(reason);
+  }
+
+  private curtailmentHistoryStopButton(target: CurtailmentCleanupTarget): Locator {
+    return this.curtailmentHistoryRow(target).getByRole("button", { name: `Stop ${target.reason}` });
+  }
+
+  private async confirmStopAction(button: Locator, confirmationButtonName: "Confirm stop" | "Restore power") {
+    const stopRequest = this.page.waitForRequest(stopRequestPattern);
+    const stopResponse = this.page.waitForResponse(stopRequestPattern);
+    const confirmationButton = this.page.getByRole("button", { name: confirmationButtonName });
+
+    await button.click();
+    await confirmationButton.click();
+    await stopRequest;
+    await stopResponse;
+    await expect(confirmationButton).toBeHidden();
+  }
+}
+
+export function getStartCurtailmentRequestBody(request: Request) {
+  return request.postDataJSON() as {
+    forceIncludeMaintenance?: boolean;
+    includeMaintenance?: boolean;
+    mode?: string;
+    modeParams?: { fixedKw?: { targetKw?: number; toleranceKw?: number } };
+    reason?: string;
+    restoreBatchIntervalSec?: number;
+    scope?: { wholeOrg?: Record<string, never> };
+  };
+}
+
+export async function getStartCurtailmentResponseBody(response: Response): Promise<{
+  event?: {
+    eventUuid?: string;
+    reason?: string;
+  };
+}> {
+  return (await response.json()) as {
+    event?: {
+      eventUuid?: string;
+      reason?: string;
+    };
+  };
+}

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -161,10 +161,7 @@ export class EnergyPage extends BasePage {
   }
 
   private activeCurtailmentSection(reason: string): Locator {
-    return this.page
-      .getByRole("heading", { name: "Active curtailment" })
-      .locator("xpath=ancestor::section[1]")
-      .filter({ hasText: reason });
+    return this.page.locator("section").filter({ hasText: "Active curtailment" }).filter({ hasText: reason });
   }
 
   private activeCurtailmentStopButton(reason: string): Locator {

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -181,8 +181,8 @@ export class EnergyPage extends BasePage {
 
   private activeCurtailmentSection(reason: string): Locator {
     return this.page
-      .locator("section")
-      .filter({ has: this.page.getByTestId("active-curtailment-primary-lockup") })
+      .getByTestId("active-curtailment-primary-lockup")
+      .locator("xpath=ancestor::section[1]")
       .filter({ hasText: reason });
   }
 

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -46,11 +46,30 @@ export class EnergyPage extends BasePage {
     await modal.locator("#curtailment-restore-batch-interval").fill(restoreBatchIntervalSec);
   }
 
-  async waitForPreview() {
+  async waitForPreview(targetKw: string) {
     const modal = this.page.getByTestId("full-screen-two-pane-modal");
+    const targetInput = modal.locator("#curtailment-target-kw");
+    const previewTarget = modal.getByText("Curtailment target reduction").first();
+    const previewSummary = modal.getByText(/Curtail \d+ miners .* immediately/).first();
+    const deadline = Date.now() + DEFAULT_TIMEOUT * 2;
 
-    await expect(modal.getByText("Curtailment target reduction").first()).toBeVisible();
-    await expect(modal.getByText(/Curtail \d+ miners .* immediately/).first()).toBeVisible();
+    do {
+      if (await previewTarget.isVisible().catch(() => false)) {
+        await expect(previewSummary).toBeVisible();
+        return;
+      }
+
+      const previewResponse = this.page
+        .waitForResponse(/PreviewCurtailmentPlan/, { timeout: DEFAULT_INTERVAL * 4 })
+        .catch(() => undefined);
+      await targetInput.fill("");
+      await targetInput.fill(targetKw);
+      await previewResponse;
+      await delay(DEFAULT_INTERVAL);
+    } while (Date.now() < deadline);
+
+    await expect(previewTarget).toBeVisible();
+    await expect(previewSummary).toBeVisible();
   }
 
   async startCurtailment() {
@@ -161,7 +180,10 @@ export class EnergyPage extends BasePage {
   }
 
   private activeCurtailmentSection(reason: string): Locator {
-    return this.page.locator("section").filter({ hasText: "Active curtailment" }).filter({ hasText: reason });
+    return this.page
+      .locator("section")
+      .filter({ has: this.page.getByTestId("active-curtailment-primary-lockup") })
+      .filter({ hasText: reason });
   }
 
   private activeCurtailmentStopButton(reason: string): Locator {

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -3,6 +3,7 @@ import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
 import { BasePage } from "./base";
 
 const stopRequestPattern = /StopCurtailment/;
+const restoreReconciliationTimeout = DEFAULT_TIMEOUT * 2;
 
 export interface CurtailmentCleanupTarget {
   reason: string;
@@ -145,7 +146,7 @@ export class EnergyPage extends BasePage {
             (await activeCurtailmentSection.getByTestId("active-curtailment-primary-lockup").textContent()) ?? "";
           return /Restored|Restore incomplete/.test(primaryLockupText) ? terminalRestoreState : primaryLockupText;
         },
-        { timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] },
+        { timeout: restoreReconciliationTimeout, intervals: [DEFAULT_INTERVAL] },
       )
       .toMatch(new RegExp(`${terminalRestoreState}|${inactiveState}`));
 

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -113,21 +113,55 @@ export class EnergyPage extends BasePage {
     }
   }
 
+  async waitForCurtailmentToRestore(target: CurtailmentCleanupTarget) {
+    const activeCurtailmentSection = this.activeCurtailmentSection(target.reason);
+    const terminalRestoreState = "terminal";
+    const inactiveState = "inactive";
+
+    await expect
+      .poll(
+        async () => {
+          if (!(await activeCurtailmentSection.isVisible().catch(() => false))) {
+            return inactiveState;
+          }
+
+          const primaryLockupText =
+            (await activeCurtailmentSection.getByTestId("active-curtailment-primary-lockup").textContent()) ?? "";
+          return /Restored|Restore incomplete/.test(primaryLockupText) ? terminalRestoreState : primaryLockupText;
+        },
+        { timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] },
+      )
+      .toMatch(new RegExp(`${terminalRestoreState}|${inactiveState}`));
+
+    const dismissButton = activeCurtailmentSection.getByRole("button", { name: "Dismiss", exact: true });
+    if (await dismissButton.isVisible().catch(() => false)) {
+      await dismissButton.click();
+      await activeCurtailmentSection.waitFor({ state: "hidden", timeout: DEFAULT_TIMEOUT }).catch(() => undefined);
+    }
+  }
+
   async cleanupStartedCurtailment(target: CurtailmentCleanupTarget) {
     await this.page.goto("/energy");
     await expect(this.page).toHaveURL(/.*\/energy/);
 
-    if (!(await this.waitForMatchingStoppableCurtailment(target))) {
+    if (!(await this.waitForMatchingCleanupCurtailment(target))) {
       return;
     }
 
     if (await this.stopMatchingActiveCurtailmentIfPresent(target.reason)) {
+      await this.waitForCurtailmentToRestore(target);
       return;
     }
 
     const historyStopButton = this.curtailmentHistoryStopButton(target);
     if (await historyStopButton.isVisible().catch(() => false)) {
       await this.confirmStopAction(historyStopButton, "Confirm stop");
+      await this.waitForCurtailmentToRestore(target);
+      return;
+    }
+
+    if (await this.hasMatchingActiveCurtailment(target.reason)) {
+      await this.waitForCurtailmentToRestore(target);
     }
   }
 
@@ -184,18 +218,31 @@ export class EnergyPage extends BasePage {
     return (await this.curtailmentHistoryStopButton(target).count()) > 0;
   }
 
-  private async waitForMatchingStoppableCurtailment(target: CurtailmentCleanupTarget): Promise<boolean> {
+  private async hasMatchingActiveCurtailment(reason: string): Promise<boolean> {
+    return this.activeCurtailmentSection(reason)
+      .isVisible()
+      .catch(() => false);
+  }
+
+  private async hasMatchingCleanupCurtailment(target: CurtailmentCleanupTarget): Promise<boolean> {
+    return (
+      (await this.hasMatchingActiveCurtailment(target.reason)) ||
+      (await this.curtailmentHistoryStopButton(target).count()) > 0
+    );
+  }
+
+  private async waitForMatchingCleanupCurtailment(target: CurtailmentCleanupTarget): Promise<boolean> {
     const deadline = Date.now() + DEFAULT_TIMEOUT;
 
     do {
-      if (await this.hasMatchingStoppableCurtailment(target)) {
+      if (await this.hasMatchingCleanupCurtailment(target)) {
         return true;
       }
 
       await delay(DEFAULT_INTERVAL);
     } while (Date.now() < deadline);
 
-    return this.hasMatchingStoppableCurtailment(target);
+    return this.hasMatchingCleanupCurtailment(target);
   }
 
   private async confirmStopAction(button: Locator, confirmationButtonName: "Confirm stop" | "Restore power") {

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -9,6 +9,10 @@ export interface CurtailmentCleanupTarget {
   eventUuid?: string;
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export class EnergyPage extends BasePage {
   async navigateToEnergyPage() {
     await this.clickNavigationMenuIfMobile();
@@ -93,28 +97,10 @@ export class EnergyPage extends BasePage {
 
   async stopCurtailment(target: CurtailmentCleanupTarget) {
     await expect
-      .poll(
-        async () => {
-          if (
-            await this.activeCurtailmentStopButton(target.reason)
-              .isVisible()
-              .catch(() => false)
-          ) {
-            return true;
-          }
-
-          if (
-            await this.activeCurtailmentRestoreButton(target.reason)
-              .isVisible()
-              .catch(() => false)
-          ) {
-            return true;
-          }
-
-          return (await this.curtailmentHistoryStopButton(target).count()) > 0;
-        },
-        { timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] },
-      )
+      .poll(async () => this.hasMatchingStoppableCurtailment(target), {
+        timeout: DEFAULT_TIMEOUT,
+        intervals: [DEFAULT_INTERVAL],
+      })
       .toBe(true);
 
     if (await this.stopMatchingActiveCurtailmentIfPresent(target.reason)) {
@@ -130,6 +116,10 @@ export class EnergyPage extends BasePage {
   async cleanupStartedCurtailment(target: CurtailmentCleanupTarget) {
     await this.page.goto("/energy");
     await expect(this.page).toHaveURL(/.*\/energy/);
+
+    if (!(await this.waitForMatchingStoppableCurtailment(target))) {
+      return;
+    }
 
     if (await this.stopMatchingActiveCurtailmentIfPresent(target.reason)) {
       return;
@@ -172,6 +162,40 @@ export class EnergyPage extends BasePage {
 
   private curtailmentHistoryStopButton(target: CurtailmentCleanupTarget): Locator {
     return this.curtailmentHistoryRow(target).getByRole("button", { name: `Stop ${target.reason}` });
+  }
+
+  private async hasMatchingStoppableCurtailment(target: CurtailmentCleanupTarget): Promise<boolean> {
+    if (
+      await this.activeCurtailmentStopButton(target.reason)
+        .isVisible()
+        .catch(() => false)
+    ) {
+      return true;
+    }
+
+    if (
+      await this.activeCurtailmentRestoreButton(target.reason)
+        .isVisible()
+        .catch(() => false)
+    ) {
+      return true;
+    }
+
+    return (await this.curtailmentHistoryStopButton(target).count()) > 0;
+  }
+
+  private async waitForMatchingStoppableCurtailment(target: CurtailmentCleanupTarget): Promise<boolean> {
+    const deadline = Date.now() + DEFAULT_TIMEOUT;
+
+    do {
+      if (await this.hasMatchingStoppableCurtailment(target)) {
+        return true;
+      }
+
+      await delay(DEFAULT_INTERVAL);
+    } while (Date.now() < deadline);
+
+    return this.hasMatchingStoppableCurtailment(target);
   }
 
   private async confirmStopAction(button: Locator, confirmationButtonName: "Confirm stop" | "Restore power") {

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -213,12 +213,14 @@ export class EnergyPage extends BasePage {
 
 export function getStartCurtailmentRequestBody(request: Request) {
   return request.postDataJSON() as {
+    fixedKw?: { targetKw?: number; toleranceKw?: number };
     forceIncludeMaintenance?: boolean;
     includeMaintenance?: boolean;
     mode?: string;
     modeParams?: { fixedKw?: { targetKw?: number; toleranceKw?: number } };
     reason?: string;
     restoreBatchIntervalSec?: number;
+    wholeOrg?: Record<string, never>;
     scope?: { wholeOrg?: Record<string, never> };
   };
 }

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -49,27 +49,27 @@ export class EnergyPage extends BasePage {
   async waitForPreview(targetKw: string) {
     const modal = this.page.getByTestId("full-screen-two-pane-modal");
     const targetInput = modal.locator("#curtailment-target-kw");
-    const previewTarget = modal.getByText("Curtailment target reduction").first();
-    const previewSummary = modal.getByText(/Curtail \d+ miners .* immediately/).first();
+    const startButton = modal.getByRole("button", { name: "Start curtailment" });
     const deadline = Date.now() + DEFAULT_TIMEOUT * 2;
 
     do {
-      if (await previewTarget.isVisible().catch(() => false)) {
-        await expect(previewSummary).toBeVisible();
-        return;
-      }
-
       const previewResponse = this.page
         .waitForResponse(/PreviewCurtailmentPlan/, { timeout: DEFAULT_INTERVAL * 4 })
         .catch(() => undefined);
       await targetInput.fill("");
       await targetInput.fill(targetKw);
-      await previewResponse;
+      const response = await previewResponse;
+      if (response?.status() === 200) {
+        await delay(DEFAULT_INTERVAL);
+        if (await startButton.isEnabled().catch(() => false)) {
+          return;
+        }
+      }
+
       await delay(DEFAULT_INTERVAL);
     } while (Date.now() < deadline);
 
-    await expect(previewTarget).toBeVisible();
-    await expect(previewSummary).toBeVisible();
+    expect(false, "Curtailment preview did not become ready").toBe(true);
   }
 
   async startCurtailment() {

--- a/client/e2eTests/protoFleet/spec/curtailment.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailment.spec.ts
@@ -64,8 +64,8 @@ test.describe("Proto Fleet - Curtailment", () => {
         expect(request.method()).toBe("POST");
         expect(requestBody.reason).toBe(curtailmentReason);
         expect(requestBody.mode).toBe("CURTAILMENT_MODE_FIXED_KW");
-        expect(requestBody.modeParams?.fixedKw?.targetKw).toBe(Number(targetKw));
-        expect(requestBody.scope?.wholeOrg).toEqual({});
+        expect(requestBody.fixedKw?.targetKw).toBe(Number(targetKw));
+        expect(requestBody.wholeOrg).toEqual({});
         expect(requestBody.includeMaintenance).toBe(true);
         expect(requestBody.forceIncludeMaintenance).toBe(true);
         expect(requestBody.restoreBatchIntervalSec).toBe(Number(restoreBatchIntervalSec));

--- a/client/e2eTests/protoFleet/spec/curtailment.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailment.spec.ts
@@ -98,7 +98,7 @@ test.describe("Proto Fleet - Curtailment", () => {
 
         expect(stopRequest.method()).toBe("POST");
         expect(stopBody.eventUuid).toBe(expectedEventUuid);
-        expect(stopBody.force).toBe(false);
+        expect(stopBody.force ?? false).toBe(false);
         expect(stopResponse.status()).toBe(200);
 
         startedCurtailment = undefined;

--- a/client/e2eTests/protoFleet/spec/curtailment.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailment.spec.ts
@@ -101,6 +101,7 @@ test.describe("Proto Fleet - Curtailment", () => {
         expect(stopBody.force ?? false).toBe(false);
         expect(stopResponse.status()).toBe(200);
 
+        await energyPage.waitForCurtailmentToRestore(curtailmentToStop);
         startedCurtailment = undefined;
       });
     });

--- a/client/e2eTests/protoFleet/spec/curtailment.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailment.spec.ts
@@ -1,0 +1,108 @@
+import { testConfig } from "../config/test.config";
+import { expect, test } from "../fixtures/pageFixtures";
+import { generateRandomText } from "../helpers/testDataHelper";
+import {
+  type CurtailmentCleanupTarget,
+  getStartCurtailmentRequestBody,
+  getStartCurtailmentResponseBody,
+} from "../pages/energy";
+
+const CURTAILMENT_PREFIX = "curtailment_e2e";
+
+test.describe("Proto Fleet - Curtailment", () => {
+  let startedCurtailment: CurtailmentCleanupTarget | undefined;
+
+  test.beforeEach(async ({ page }) => {
+    startedCurtailment = undefined;
+    await page.goto("/");
+  });
+
+  test.afterEach("CLEANUP: Stop curtailments created during tests", async ({ energyPage }) => {
+    if (!startedCurtailment) {
+      return;
+    }
+
+    await energyPage.cleanupStartedCurtailment(startedCurtailment);
+  });
+
+  if (testConfig.target !== "real") {
+    test("Start and stop a whole-fleet curtailment", async ({ commonSteps, energyPage, page }) => {
+      const curtailmentReason = generateRandomText(CURTAILMENT_PREFIX);
+      const targetKw = "1";
+      const restoreBatchIntervalSec = "1";
+
+      await test.step("Log in as an admin with curtailment permissions", async () => {
+        await commonSteps.loginAsAdmin();
+      });
+
+      await test.step("Navigate to Energy", async () => {
+        await energyPage.navigateToEnergyPage();
+        await energyPage.validateEnergyPageOpened();
+      });
+
+      const startRequestPromise = page.waitForRequest(/StartCurtailment/);
+      const startResponsePromise = page.waitForResponse(/StartCurtailment/);
+
+      await test.step("Start a whole-fleet curtailment", async () => {
+        await energyPage.openCurtailmentPlanner();
+        await energyPage.fillCurtailmentPlan({
+          reason: curtailmentReason,
+          targetKw,
+          restoreBatchIntervalSec,
+        });
+        await energyPage.waitForPreview();
+        startedCurtailment = { reason: curtailmentReason };
+        await energyPage.startCurtailment();
+      });
+
+      await test.step("Validate the StartCurtailment request", async () => {
+        const request = await startRequestPromise;
+        const response = await startResponsePromise;
+        const requestBody = getStartCurtailmentRequestBody(request);
+        const responseBody = await getStartCurtailmentResponseBody(response);
+
+        expect(request.method()).toBe("POST");
+        expect(requestBody.reason).toBe(curtailmentReason);
+        expect(requestBody.mode).toBe("CURTAILMENT_MODE_FIXED_KW");
+        expect(requestBody.modeParams?.fixedKw?.targetKw).toBe(Number(targetKw));
+        expect(requestBody.scope?.wholeOrg).toEqual({});
+        expect(requestBody.includeMaintenance).toBe(true);
+        expect(requestBody.forceIncludeMaintenance).toBe(true);
+        expect(requestBody.restoreBatchIntervalSec).toBe(Number(restoreBatchIntervalSec));
+        expect(response.status()).toBe(200);
+        expect(responseBody.event?.eventUuid).toEqual(expect.any(String));
+        expect(responseBody.event?.reason).toBe(curtailmentReason);
+        startedCurtailment = {
+          reason: curtailmentReason,
+          eventUuid: responseBody.event?.eventUuid as string,
+        };
+      });
+
+      await test.step("Validate active curtailment UI and history", async () => {
+        await energyPage.validateActiveCurtailment(curtailmentReason);
+        await energyPage.validateCurtailmentHistoryRow(curtailmentReason);
+      });
+
+      await test.step("Stop the curtailment", async () => {
+        expect(startedCurtailment?.eventUuid).toEqual(expect.any(String));
+        const curtailmentToStop = startedCurtailment as CurtailmentCleanupTarget;
+        const expectedEventUuid = curtailmentToStop.eventUuid;
+        const stopRequestPromise = page.waitForRequest(/StopCurtailment/);
+        const stopResponsePromise = page.waitForResponse(/StopCurtailment/);
+
+        await energyPage.stopCurtailment(curtailmentToStop);
+
+        const stopRequest = await stopRequestPromise;
+        const stopResponse = await stopResponsePromise;
+        const stopBody = stopRequest.postDataJSON() as { eventUuid?: string; force?: boolean };
+
+        expect(stopRequest.method()).toBe("POST");
+        expect(stopBody.eventUuid).toBe(expectedEventUuid);
+        expect(stopBody.force).toBe(false);
+        expect(stopResponse.status()).toBe(200);
+
+        startedCurtailment = undefined;
+      });
+    });
+  }
+});

--- a/client/e2eTests/protoFleet/spec/curtailment.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailment.spec.ts
@@ -40,8 +40,8 @@ test.describe("Proto Fleet - Curtailment", () => {
         await energyPage.validateEnergyPageOpened();
       });
 
-      const startRequestPromise = page.waitForRequest(/StartCurtailment/);
-      const startResponsePromise = page.waitForResponse(/StartCurtailment/);
+      let startRequestPromise!: ReturnType<typeof page.waitForRequest>;
+      let startResponsePromise!: ReturnType<typeof page.waitForResponse>;
 
       await test.step("Start a whole-fleet curtailment", async () => {
         await energyPage.openCurtailmentPlanner();
@@ -50,8 +50,10 @@ test.describe("Proto Fleet - Curtailment", () => {
           targetKw,
           restoreBatchIntervalSec,
         });
-        await energyPage.waitForPreview();
+        await energyPage.waitForPreview(targetKw);
         startedCurtailment = { reason: curtailmentReason };
+        startRequestPromise = page.waitForRequest(/StartCurtailment/);
+        startResponsePromise = page.waitForResponse(/StartCurtailment/);
         await energyPage.startCurtailment();
       });
 


### PR DESCRIPTION
🤖
## Summary
- Add a ProtoFleet Energy page object for curtailment planner, active status, history, and cleanup flows
- Cover the fake-simulator whole-fleet curtailment path from Energy: start, assert StartCurtailment payload, verify active/history UI, then stop and assert StopCurtailment payload
- Keep the flow on the admin session so the pending permission-gating fix in #366 still leaves the route and actions accessible

## Test plan
- [x] Run touched-file ESLint for the new E2E files
- [x] Run touched-file Prettier check for the new E2E files
- [x] Run client TypeScript check with e2eTests included
- [x] Confirm Playwright lists the new desktop curtailment scenario
- [ ] Run the targeted Playwright scenario against a running fake ProtoFleet dev environment; local run was blocked because localhost:5173 was not serving
