### PR TITLE
Clean up ProtoFleet E2E spec structure

### DIFF
--- a/client/e2eTests/protoFleet/helpers/minersFiltersViews.ts
+++ b/client/e2eTests/protoFleet/helpers/minersFiltersViews.ts
@@ -1,0 +1,61 @@
+function parseIpv4(ip: string) {
+  const normalizedIp = ip.trim();
+  const octets = normalizedIp.split(".");
+
+  if (octets.length !== 4) {
+    return null;
+  }
+
+  const numericOctets = octets.map((octet) => Number(octet));
+  const isValidIpv4 = numericOctets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255);
+
+  if (!isValidIpv4) {
+    return null;
+  }
+
+  return normalizedIp;
+}
+
+export async function getFirstVisibleIpv4MinerIp(minersPage: {
+  getMinersCount(): Promise<number>;
+  getMinerIpAddressByIndex(index: number): Promise<string>;
+}) {
+  const minerCount = await minersPage.getMinersCount();
+
+  for (let index = 0; index < minerCount; index++) {
+    const ipAddress = await minersPage.getMinerIpAddressByIndex(index);
+    const parsedIp = parseIpv4(ipAddress);
+
+    if (parsedIp !== null) {
+      return parsedIp;
+    }
+  }
+
+  throw new Error("Subnet filter coverage requires at least one visible IPv4 miner.");
+}
+
+export function toSubnet24(ip: string) {
+  const parsedIp = parseIpv4(ip);
+  if (parsedIp === null) {
+    throw new Error(`Expected a valid IPv4 address, got "${ip}".`);
+  }
+
+  const [first, second, third] = parsedIp.split(".");
+  return `${first}.${second}.${third}.0/24`;
+}
+
+export function formatPowerFilterSummary(min: number | undefined, max: number | undefined) {
+  if (min !== undefined && max !== undefined) {
+    return `${min} kW - ${max} kW`;
+  }
+
+  if (min !== undefined) {
+    return `≥ ${min} kW`;
+  }
+
+  if (max !== undefined) {
+    return `≤ ${max} kW`;
+  }
+
+  return "";
+}

--- a/client/e2eTests/protoFleet/helpers/racksHelpers.ts
+++ b/client/e2eTests/protoFleet/helpers/racksHelpers.ts
@@ -1,0 +1,67 @@
+import { expect } from "@playwright/test";
+import { type RackSelectorMiner, type RacksPage } from "../pages/racks";
+import { PROTO_RIG_MODEL } from "./minerModels";
+
+export function createZoneName(prefix: "A" | "B") {
+  const suffix = Math.random()
+    .toString(36)
+    .replace(/[^a-z]+/g, "")
+    .slice(0, 6);
+  return `${prefix}-${suffix || "zone"}`;
+}
+
+export async function addSelectableMinersToSlots(
+  racksPage: RacksPage,
+  minerCount: number,
+  slotNumbers: readonly number[],
+): Promise<RackSelectorMiner[]> {
+  expect(slotNumbers).toHaveLength(minerCount);
+
+  await racksPage.clickAddMiners();
+  await racksPage.waitForMinerSelectorListToLoad();
+
+  const selectableMinerIndexes = await racksPage.getSelectableMinerIndexes(minerCount);
+  const selectedMiners = await racksPage.getMinersFromSelector(selectableMinerIndexes);
+  await racksPage.selectMinersInSelectorByIndex(selectableMinerIndexes);
+  await racksPage.clickContinueInMinerSelector();
+
+  for (let i = 0; i < selectedMiners.length; i++) {
+    await racksPage.selectRackMiner(selectedMiners[i].ipAddress);
+    await racksPage.clickRackSlot(slotNumbers[i]);
+  }
+
+  return selectedMiners;
+}
+
+export async function addSelectableRigMinersToSlots(
+  racksPage: RacksPage,
+  minerCount: number,
+  slotNumbers: readonly number[],
+): Promise<RackSelectorMiner[]> {
+  expect(slotNumbers).toHaveLength(minerCount);
+
+  await racksPage.clickAddMiners();
+  await racksPage.waitForMinerSelectorListToLoad();
+  await racksPage.filterModalType(PROTO_RIG_MODEL);
+  await racksPage.waitForMinerSelectorListToLoad();
+
+  const selectableMinerIndexes = await racksPage.getSelectableMinerIndexes(minerCount);
+  const selectedMiners = await racksPage.getMinersFromSelector(selectableMinerIndexes);
+  await racksPage.selectMinersInSelectorByIndex(selectableMinerIndexes);
+  await racksPage.clickContinueInMinerSelector();
+
+  for (let i = 0; i < selectedMiners.length; i++) {
+    await racksPage.selectRackMiner(selectedMiners[i].ipAddress);
+    await racksPage.clickRackSlot(slotNumbers[i]);
+  }
+
+  return selectedMiners;
+}
+
+export async function expectGridRackLabels(racksPage: RacksPage, expectedLabels: string[]) {
+  await expect.poll(async () => await racksPage.getGridRackLabels()).toEqual(expectedLabels);
+}
+
+export async function expectListRackLabels(racksPage: RacksPage, expectedLabels: string[]) {
+  await expect.poll(async () => await racksPage.listRackNames()).toEqual(expectedLabels);
+}

--- a/client/e2eTests/protoFleet/helpers/serverLogsMocks.ts
+++ b/client/e2eTests/protoFleet/helpers/serverLogsMocks.ts
@@ -1,0 +1,59 @@
+import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
+import { type Route } from "@playwright/test";
+import {
+  ListServerLogsRequestSchema,
+  ListServerLogsResponseSchema,
+  LogEntrySchema,
+  type LogLevel,
+} from "@/protoFleet/api/generated/serverlog/v1/serverlog_pb";
+
+export function createServerLogEntry({
+  id,
+  level,
+  message,
+  source,
+  time,
+  attrs = [],
+}: {
+  id: bigint;
+  level: LogLevel;
+  message: string;
+  source: string;
+  time: Date;
+  attrs?: Array<{ key: string; value: string }>;
+}) {
+  return create(LogEntrySchema, {
+    id,
+    level,
+    message,
+    source,
+    attrs,
+    time: create(TimestampSchema, {
+      seconds: BigInt(Math.floor(time.getTime() / 1000)),
+      nanos: 0,
+    }),
+  });
+}
+
+export type ServerLogEntry = ReturnType<typeof createServerLogEntry>;
+
+export function parseServerLogsRequest(route: Route) {
+  return fromJsonString(ListServerLogsRequestSchema, route.request().postData() ?? "{}");
+}
+
+export function fulfillServerLogs(route: Route, entries: ServerLogEntry[], latestId: bigint) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: toJsonString(
+      ListServerLogsResponseSchema,
+      create(ListServerLogsResponseSchema, {
+        entries,
+        latestId,
+        bufferSize: entries.length,
+        truncated: false,
+      }),
+    ),
+  });
+}

--- a/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
+++ b/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
@@ -26,65 +26,68 @@ test.describe("Mining Pools", () => {
     await page.goto("/");
   });
 
-  test.afterAll("CLEANUP: Add default pool to miners", async ({ browser }, testInfo) => {
-    const isMobile = testInfo.project.use?.isMobile ?? false;
-    const context = await browser.newContext({ baseURL: testConfig.baseUrl });
-    try {
-      const page = await context.newPage();
-      await page.goto("/");
+  test.afterAll(
+    "CLEANUP: Restore the default pool assignment and remove temporary pools",
+    async ({ browser }, testInfo) => {
+      const isMobile = testInfo.project.use?.isMobile ?? false;
+      const context = await browser.newContext({ baseURL: testConfig.baseUrl });
+      try {
+        const page = await context.newPage();
+        await page.goto("/");
 
-      const authPage = new AuthPage(page, isMobile);
-      const minersPage = new MinersPage(page, isMobile);
-      const editPoolPage = new EditPoolPage(page, isMobile);
-      const newPoolModal = new NewPoolModalPage(page, isMobile);
-      const loginModal = new LoginModalComponent(page, isMobile);
-      const settingsPage = new SettingsPage(page, isMobile);
-      const settingsPoolsPage = new SettingsPoolsPage(page, isMobile);
-      const commonSteps = new CommonSteps(authPage, minersPage);
+        const authPage = new AuthPage(page, isMobile);
+        const minersPage = new MinersPage(page, isMobile);
+        const editPoolPage = new EditPoolPage(page, isMobile);
+        const newPoolModal = new NewPoolModalPage(page, isMobile);
+        const loginModal = new LoginModalComponent(page, isMobile);
+        const settingsPage = new SettingsPage(page, isMobile);
+        const settingsPoolsPage = new SettingsPoolsPage(page, isMobile);
+        const commonSteps = new CommonSteps(authPage, minersPage);
 
-      await commonSteps.loginAsAdmin();
+        await commonSteps.loginAsAdmin();
 
-      await commonSteps.goToMinersPage();
+        await commonSteps.goToMinersPage();
 
-      const amountOfMiners = await minersPage.getMinersCount();
-      if (amountOfMiners > 0) {
-        await minersPage.clickSelectAllCheckbox();
-        await minersPage.clickActionsMenuButton();
-        await minersPage.clickEditMiningPoolButton();
-        await loginModal.loginAsAdmin();
+        const amountOfMiners = await minersPage.getMinersCount();
+        if (amountOfMiners > 0) {
+          await minersPage.clickSelectAllCheckbox();
+          await minersPage.clickActionsMenuButton();
+          await minersPage.clickEditMiningPoolButton();
+          await loginModal.loginAsAdmin();
 
-        await editPoolPage.clickAddPoolButton();
-        await editPoolPage.clickAddNewPool();
-        await newPoolModal.inputPoolName("PoolNameDefault");
-        await newPoolModal.inputPoolUrl(validPoolUrl);
+          await editPoolPage.clickAddPoolButton();
+          await editPoolPage.clickAddNewPool();
+          await newPoolModal.inputPoolName("PoolNameDefault");
+          await newPoolModal.inputPoolUrl(validPoolUrl);
 
-        await newPoolModal.inputPoolUsername(generateRandomText("Afterhook"));
-        // await newPoolModal.inputPoolUsername(validUsername); // use when DASH-1407 is fixed
-        await newPoolModal.clickSaveNewPool();
-        await editPoolPage.clickAssignToXMiners(amountOfMiners);
-        await editPoolPage.validateTextInToastGroup("Assigned pools");
-      }
-
-      await settingsPage.navigateToMiningPoolsSettings();
-      await settingsPoolsPage.validateMiningPoolsPageOpened();
-
-      const poolRows = page.getByTestId("pool-row");
-      const poolCount = await poolRows.count();
-
-      for (let i = poolCount - 1; i >= 0; i--) {
-        const row = poolRows.nth(i);
-        const poolNameElement = row.getByTestId("pool-name");
-        const poolName = await poolNameElement.textContent();
-
-        if (poolName && poolName.startsWith("PoolName")) {
-          await row.getByRole("button", { name: "Options menu", exact: true }).click();
-          await settingsPoolsPage.clickButton("Delete pool");
+          await newPoolModal.inputPoolUsername(generateRandomText("Afterhook"));
+          // await newPoolModal.inputPoolUsername(validUsername); // use when DASH-1407 is fixed
+          await newPoolModal.clickSaveNewPool();
+          await editPoolPage.clickAssignToXMiners(amountOfMiners);
+          await editPoolPage.validateTextInToastGroup("Assigned pools");
         }
+
+        await settingsPage.navigateToMiningPoolsSettings();
+        await settingsPoolsPage.validateMiningPoolsPageOpened();
+
+        const poolRows = page.getByTestId("pool-row");
+        const poolCount = await poolRows.count();
+
+        for (let i = poolCount - 1; i >= 0; i--) {
+          const row = poolRows.nth(i);
+          const poolNameElement = row.getByTestId("pool-name");
+          const poolName = await poolNameElement.textContent();
+
+          if (poolName && poolName.startsWith("PoolName")) {
+            await row.getByRole("button", { name: "Options menu", exact: true }).click();
+            await settingsPoolsPage.clickButton("Delete pool");
+          }
+        }
+      } finally {
+        await context.close();
       }
-    } finally {
-      await context.close();
-    }
-  });
+    },
+  );
 
   const validPoolUrl = "stratum+tcp://mine.ocean.xyz:3334";
   // When DASH-1407 is fixed, use a real wallet, so that real miners always have it configured

--- a/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
+++ b/client/e2eTests/protoFleet/spec/02-saveAuthState.spec.ts
@@ -7,15 +7,17 @@ import { test } from "../fixtures/pageFixtures";
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 const adminStorageStatePath = path.join(specDir, "..", "playwright", ".auth", "admin.json");
 
-test("save admin auth storage state @setup", async ({ page, authPage }) => {
-  await page.goto("/");
+test.describe("Proto Fleet - Save Auth State", () => {
+  test("save admin auth storage state @setup", async ({ page, authPage }) => {
+    await page.goto("/");
 
-  await authPage.inputUsername(testConfig.users.admin.username);
-  await authPage.inputPassword(testConfig.users.admin.password);
-  await authPage.clickLogin();
-  await authPage.validateLoggedIn();
+    await authPage.inputUsername(testConfig.users.admin.username);
+    await authPage.inputPassword(testConfig.users.admin.password);
+    await authPage.clickLogin();
+    await authPage.validateLoggedIn();
 
-  // playwright/.auth/ is gitignored and absent on fresh checkouts.
-  await fs.mkdir(path.dirname(adminStorageStatePath), { recursive: true });
-  await page.context().storageState({ path: adminStorageStatePath });
+    // playwright/.auth/ is gitignored and absent on fresh checkouts.
+    await fs.mkdir(path.dirname(adminStorageStatePath), { recursive: true });
+    await page.context().storageState({ path: adminStorageStatePath });
+  });
 });

--- a/client/e2eTests/protoFleet/spec/activity.spec.ts
+++ b/client/e2eTests/protoFleet/spec/activity.spec.ts
@@ -3,43 +3,10 @@ import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";
 import { generateRandomText } from "../helpers/testDataHelper";
 import { AuthPage } from "../pages/auth";
-import { GroupsPage } from "../pages/groups";
 import { MinersPage } from "../pages/miners";
 import { SettingsSchedulesPage } from "../pages/settingsSchedules";
 
 const SCHEDULE_PREFIX = "activity_schedule_e2e";
-
-async function triggerBlinkLedsActivity(commonSteps: CommonSteps, minersPage: MinersPage) {
-  await commonSteps.loginAsAdmin();
-  await commonSteps.goToMinersPage();
-  await minersPage.filterRigMiners();
-  await minersPage.waitForMinersListToLoad();
-
-  const selectedMinerIps: string[] = [];
-
-  for (let index = 0; index < 3; index++) {
-    selectedMinerIps.push(await minersPage.getMinerIpAddressByIndex(index));
-    await minersPage.clickMinerCheckboxByIndex(index);
-    await minersPage.validateActionBarMinerCount(index + 1);
-  }
-
-  await minersPage.clickBlinkLEDsButton();
-  await minersPage.validateTextInToastGroup("Blinking LEDs");
-  await minersPage.validateTextInToastGroup("Blinked LEDs");
-
-  return selectedMinerIps;
-}
-
-async function createGroupActivity(commonSteps: CommonSteps, groupsPage: GroupsPage, groupName: string) {
-  await commonSteps.loginAsAdmin();
-  await groupsPage.navigateToGroupsPage();
-  await groupsPage.clickAddGroupButton();
-  await groupsPage.inputGroupName(groupName);
-  await groupsPage.waitForModalListToLoad();
-  await groupsPage.selectMinersByIndex([0]);
-  await groupsPage.clickSaveInModal();
-  await groupsPage.validateTextInToast(`Group "${groupName}" created`);
-}
 
 test.describe("Proto Fleet - Activity", () => {
   test.beforeEach(async ({ page }) => {
@@ -76,7 +43,7 @@ test.describe("Proto Fleet - Activity", () => {
     await commonSteps.loginAsAdmin();
     await commonSteps.goToMinersPage();
 
-    await test.step("Filter Proto miners as a workaround", async () => {
+    await test.step("Filter to Proto rig miners", async () => {
       await minersPage.filterRigMiners();
     });
 
@@ -115,7 +82,24 @@ test.describe("Proto Fleet - Activity", () => {
     commonSteps,
     minersPage,
   }) => {
-    const selectedMinerIps = await triggerBlinkLedsActivity(commonSteps, minersPage);
+    let selectedMinerIps: string[] = [];
+
+    await test.step("Trigger Blink LEDs for three Proto rig miners", async () => {
+      await commonSteps.loginAsAdmin();
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      await minersPage.waitForMinersListToLoad();
+
+      for (let index = 0; index < 3; index++) {
+        selectedMinerIps.push(await minersPage.getMinerIpAddressByIndex(index));
+        await minersPage.clickMinerCheckboxByIndex(index);
+        await minersPage.validateActionBarMinerCount(index + 1);
+      }
+
+      await minersPage.clickBlinkLEDsButton();
+      await minersPage.validateTextInToastGroup("Blinking LEDs");
+      await minersPage.validateTextInToastGroup("Blinked LEDs");
+    });
 
     await test.step("Open Activity and narrow to the Blink LEDs batch", async () => {
       await activityPage.navigateToActivityPage();
@@ -190,7 +174,16 @@ test.describe("Proto Fleet - Activity", () => {
     const groupName = generateRandomText("activity_group");
 
     try {
-      await createGroupActivity(commonSteps, groupsPage, groupName);
+      await test.step("Create a group that will appear in Activity", async () => {
+        await commonSteps.loginAsAdmin();
+        await groupsPage.navigateToGroupsPage();
+        await groupsPage.clickAddGroupButton();
+        await groupsPage.inputGroupName(groupName);
+        await groupsPage.waitForModalListToLoad();
+        await groupsPage.selectMinersByIndex([0]);
+        await groupsPage.clickSaveInModal();
+        await groupsPage.validateTextInToast(`Group "${groupName}" created`);
+      });
 
       await test.step("Open Activity and apply the group scope filter", async () => {
         await activityPage.navigateToActivityPage();
@@ -266,90 +259,6 @@ test.describe("Proto Fleet - Activity", () => {
       await activityPage.waitForActivityListToLoad();
       await activityPage.validateSearchInputValue("");
       await activityPage.validateActivityDescriptionVisible(`Created schedule: ${scheduleName}`);
-    });
-  });
-});
-
-test.describe("Proto Fleet - Activity Login", () => {
-  test.use({ storageState: { cookies: [], origins: [] } });
-
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Login activity is visible for the signed-in admin", async ({ authPage, activityPage }) => {
-    await test.step("Log in as admin", async () => {
-      await authPage.inputUsername(testConfig.users.admin.username);
-      await authPage.inputPassword(testConfig.users.admin.password);
-      await authPage.clickLogin();
-      await authPage.validateLoggedIn();
-    });
-
-    await test.step("Open Activity and filter to login events", async () => {
-      await activityPage.navigateToActivityPage();
-      await activityPage.waitForActivityListToLoad();
-      await activityPage.selectTypeFilter("Login");
-      await activityPage.selectUserFilter(testConfig.users.admin.username);
-    });
-
-    await test.step("Validate the latest login row", async () => {
-      await activityPage.validateLatestActivityDescription("Login");
-      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
-      await activityPage.validateLatestActivityNotMarkedFailed();
-    });
-  });
-
-  test("Failed login activity is visible after correcting invalid credentials and signing in", async ({
-    authPage,
-    activityPage,
-  }) => {
-    await test.step("Log in as admin", async () => {
-      await authPage.inputUsername(testConfig.users.admin.username);
-      await authPage.inputPassword(testConfig.users.admin.password);
-      await authPage.clickLogin();
-      await authPage.validateLoggedIn();
-    });
-
-    await test.step("Open Activity and validate the latest login row", async () => {
-      await activityPage.navigateToActivityPage();
-      await activityPage.waitForActivityListToLoad();
-      await activityPage.selectTypeFilter("Login");
-      await activityPage.selectUserFilter(testConfig.users.admin.username);
-      await activityPage.validateLatestActivityDescription("Login");
-      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
-      await activityPage.validateLatestActivityNotMarkedFailed();
-    });
-
-    await test.step("Log out", async () => {
-      await authPage.logout();
-      await authPage.validateRedirectedToAuth();
-    });
-
-    await test.step("Attempt login with an invalid password and validate the error", async () => {
-      await authPage.inputUsername(testConfig.users.admin.username);
-      await authPage.inputPassword(`${testConfig.users.admin.password}-invalid`);
-      await authPage.clickLogin();
-      await authPage.validateInvalidCredentials();
-    });
-
-    await test.step("Rewrite the correct password and validate the error clears", async () => {
-      await authPage.inputPassword(testConfig.users.admin.password);
-      await authPage.validateInvalidCredentialsNotVisible();
-    });
-
-    await test.step("Log in successfully with corrected credentials", async () => {
-      await authPage.clickLogin();
-      await authPage.validateLoggedIn();
-    });
-
-    await test.step("Validate the failed login attempt appears in Activity", async () => {
-      await activityPage.navigateToActivityPage();
-      await activityPage.waitForActivityListToLoad();
-      await activityPage.searchActivity("Login failed");
-      await activityPage.selectUserFilter(testConfig.users.admin.username);
-      await activityPage.validateLatestActivityDescription("Login failed");
-      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
-      await activityPage.validateLatestActivityMarkedFailed();
     });
   });
 });

--- a/client/e2eTests/protoFleet/spec/activityLogin.spec.ts
+++ b/client/e2eTests/protoFleet/spec/activityLogin.spec.ts
@@ -1,0 +1,86 @@
+import { testConfig } from "../config/test.config";
+import { test } from "../fixtures/pageFixtures";
+
+test.describe("Proto Fleet - Activity Login", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("Login activity is visible for the signed-in admin", async ({ authPage, activityPage }) => {
+    await test.step("Log in as admin", async () => {
+      await authPage.inputUsername(testConfig.users.admin.username);
+      await authPage.inputPassword(testConfig.users.admin.password);
+      await authPage.clickLogin();
+      await authPage.validateLoggedIn();
+    });
+
+    await test.step("Open Activity and filter to login events", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.selectTypeFilter("Login");
+      await activityPage.selectUserFilter(testConfig.users.admin.username);
+    });
+
+    await test.step("Validate the latest login row", async () => {
+      await activityPage.validateLatestActivityDescription("Login");
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityNotMarkedFailed();
+    });
+  });
+
+  test("Failed login activity is visible after correcting invalid credentials and signing in", async ({
+    authPage,
+    activityPage,
+  }) => {
+    await test.step("Log in as admin", async () => {
+      await authPage.inputUsername(testConfig.users.admin.username);
+      await authPage.inputPassword(testConfig.users.admin.password);
+      await authPage.clickLogin();
+      await authPage.validateLoggedIn();
+    });
+
+    await test.step("Confirm the successful login activity is present before testing a failed login", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.selectTypeFilter("Login");
+      await activityPage.selectUserFilter(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityDescription("Login");
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityNotMarkedFailed();
+    });
+
+    await test.step("Log out", async () => {
+      await authPage.logout();
+      await authPage.validateRedirectedToAuth();
+    });
+
+    await test.step("Attempt login with an invalid password and validate the error", async () => {
+      await authPage.inputUsername(testConfig.users.admin.username);
+      await authPage.inputPassword(`${testConfig.users.admin.password}-invalid`);
+      await authPage.clickLogin();
+      await authPage.validateInvalidCredentials();
+    });
+
+    await test.step("Rewrite the correct password and validate the error clears", async () => {
+      await authPage.inputPassword(testConfig.users.admin.password);
+      await authPage.validateInvalidCredentialsNotVisible();
+    });
+
+    await test.step("Log in successfully with corrected credentials", async () => {
+      await authPage.clickLogin();
+      await authPage.validateLoggedIn();
+    });
+
+    await test.step("Validate the failed login attempt appears in Activity", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+      await activityPage.searchActivity("Login failed");
+      await activityPage.selectUserFilter(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityDescription("Login failed");
+      await activityPage.validateLatestActivityUser(testConfig.users.admin.username);
+      await activityPage.validateLatestActivityMarkedFailed();
+    });
+  });
+});

--- a/client/e2eTests/protoFleet/spec/curtailment.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailment.spec.ts
@@ -40,8 +40,8 @@ test.describe("Proto Fleet - Curtailment", () => {
         await energyPage.validateEnergyPageOpened();
       });
 
-      let startRequestPromise!: ReturnType<typeof page.waitForRequest>;
-      let startResponsePromise!: ReturnType<typeof page.waitForResponse>;
+      let startRequest!: Awaited<ReturnType<typeof page.waitForRequest>>;
+      let startResponse!: Awaited<ReturnType<typeof page.waitForResponse>>;
 
       await test.step("Start a whole-fleet curtailment", async () => {
         await energyPage.openCurtailmentPlanner();
@@ -52,18 +52,18 @@ test.describe("Proto Fleet - Curtailment", () => {
         });
         await energyPage.waitForPreview(targetKw);
         startedCurtailment = { reason: curtailmentReason };
-        startRequestPromise = page.waitForRequest(/StartCurtailment/);
-        startResponsePromise = page.waitForResponse(/StartCurtailment/);
-        await energyPage.startCurtailment();
+        [startRequest, startResponse] = await Promise.all([
+          page.waitForRequest(/StartCurtailment/),
+          page.waitForResponse(/StartCurtailment/),
+          energyPage.startCurtailment(),
+        ]);
       });
 
       await test.step("Validate the StartCurtailment request", async () => {
-        const request = await startRequestPromise;
-        const response = await startResponsePromise;
-        const requestBody = getStartCurtailmentRequestBody(request);
-        const responseBody = await getStartCurtailmentResponseBody(response);
+        const requestBody = getStartCurtailmentRequestBody(startRequest);
+        const responseBody = await getStartCurtailmentResponseBody(startResponse);
 
-        expect(request.method()).toBe("POST");
+        expect(startRequest.method()).toBe("POST");
         expect(requestBody.reason).toBe(curtailmentReason);
         expect(requestBody.mode).toBe("CURTAILMENT_MODE_FIXED_KW");
         expect(requestBody.fixedKw?.targetKw).toBe(Number(targetKw));
@@ -71,7 +71,7 @@ test.describe("Proto Fleet - Curtailment", () => {
         expect(requestBody.includeMaintenance).toBe(true);
         expect(requestBody.forceIncludeMaintenance).toBe(true);
         expect(requestBody.restoreBatchIntervalSec).toBe(Number(restoreBatchIntervalSec));
-        expect(response.status()).toBe(200);
+        expect(startResponse.status()).toBe(200);
         expect(responseBody.event?.eventUuid).toEqual(expect.any(String));
         expect(responseBody.event?.reason).toBe(curtailmentReason);
         startedCurtailment = {

--- a/client/e2eTests/protoFleet/spec/minersFiltersViews.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersFiltersViews.spec.ts
@@ -1,67 +1,6 @@
 import { test } from "../fixtures/pageFixtures";
+import { formatPowerFilterSummary, getFirstVisibleIpv4MinerIp, toSubnet24 } from "../helpers/minersFiltersViews";
 import { generateRandomText } from "../helpers/testDataHelper";
-
-function parseIpv4(ip: string) {
-  const normalizedIp = ip.trim();
-  const octets = normalizedIp.split(".");
-
-  if (octets.length !== 4) {
-    return null;
-  }
-
-  const numericOctets = octets.map((octet) => Number(octet));
-  const isValidIpv4 = numericOctets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255);
-
-  if (!isValidIpv4) {
-    return null;
-  }
-
-  return normalizedIp;
-}
-
-async function getFirstVisibleIpv4MinerIp(minersPage: {
-  getMinersCount(): Promise<number>;
-  getMinerIpAddressByIndex(index: number): Promise<string>;
-}) {
-  const minerCount = await minersPage.getMinersCount();
-
-  for (let index = 0; index < minerCount; index++) {
-    const ipAddress = await minersPage.getMinerIpAddressByIndex(index);
-    const parsedIp = parseIpv4(ipAddress);
-
-    if (parsedIp !== null) {
-      return parsedIp;
-    }
-  }
-
-  throw new Error("Subnet filter coverage requires at least one visible IPv4 miner.");
-}
-
-function toSubnet24(ip: string) {
-  const parsedIp = parseIpv4(ip);
-  if (parsedIp === null) {
-    throw new Error(`Expected a valid IPv4 address, got "${ip}".`);
-  }
-
-  const [first, second, third] = parsedIp.split(".");
-  return `${first}.${second}.${third}.0/24`;
-}
-
-function formatPowerFilterSummary(min: number | undefined, max: number | undefined) {
-  if (min !== undefined && max !== undefined) {
-    return `${min} kW - ${max} kW`;
-  }
-
-  if (min !== undefined) {
-    return `≥ ${min} kW`;
-  }
-
-  if (max !== undefined) {
-    return `≤ ${max} kW`;
-  }
-
-  return "";
-}
 
 test.describe("Proto Fleet - Miners filters and saved views", () => {
   test.beforeEach(async ({ page }) => {
@@ -124,9 +63,12 @@ test.describe("Proto Fleet - Miners filters and saved views", () => {
       test.expect(await minersPage.getMinersCount()).toBeGreaterThan(0);
     });
 
-    await test.step("Drive the filtered empty state and clear filters", async () => {
+    await test.step("Apply a strict power filter and validate the empty state", async () => {
       await minersPage.applyPowerFilter(50, 50);
       await minersPage.validateNoResultsEmptyState();
+    });
+
+    await test.step("Clear the filters and validate the full list returns", async () => {
       await minersPage.clickClearAllFilters();
       await minersPage.waitForMinersListToLoad();
 
@@ -226,19 +168,24 @@ test.describe("Proto Fleet - Miners filters and saved views", () => {
       await minersPage.validateMinerInList(updatedMinerIp);
     });
 
-    await test.step("Update the saved view to the new subnet", async () => {
+    await test.step("Update the saved view to include the power filter", async () => {
       await minersPage.clickUpdateViewAction(viewName);
       await minersPage.validateViewModalOpened("Update view");
       await minersPage.updateSavedView();
     });
 
-    await test.step("Reload, leave the view, and reopen it", async () => {
+    await test.step("Reload the page and wait for the miners view to stabilize", async () => {
       await minersPage.reloadPage();
       await minersPage.waitForMinersTitle();
       await minersPage.waitForMinersListToLoad();
+    });
 
+    await test.step("Switch back to All miners before reopening the saved view", async () => {
       await minersPage.clickViewTab("All miners");
       await minersPage.waitForMinersListToLoad();
+    });
+
+    await test.step("Reopen the updated saved view", async () => {
       await minersPage.clickViewTab(viewName);
       await minersPage.waitForMinersListToLoad();
     });

--- a/client/e2eTests/protoFleet/spec/racks.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racks.spec.ts
@@ -3,6 +3,13 @@ import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";
 import { PROTO_RIG_MODEL } from "../helpers/minerModels";
+import {
+  addSelectableMinersToSlots,
+  addSelectableRigMinersToSlots,
+  createZoneName,
+  expectGridRackLabels,
+  expectListRackLabels,
+} from "../helpers/racksHelpers";
 import { generateRandomText } from "../helpers/testDataHelper";
 import { AuthPage } from "../pages/auth";
 import { MinersPage } from "../pages/miners";
@@ -98,70 +105,6 @@ test.describe("Racks", () => {
       await racksPage.waitForRackListToLoad();
       rackNames = await racksPage.listRackNames();
     }
-  }
-
-  function createZoneName(prefix: "A" | "B") {
-    const suffix = Math.random()
-      .toString(36)
-      .replace(/[^a-z]+/g, "")
-      .slice(0, 6);
-    return `${prefix}-${suffix || "zone"}`;
-  }
-
-  async function addSelectableMinersToSlots(
-    racksPage: RacksPage,
-    minerCount: number,
-    slotNumbers: readonly number[],
-  ): Promise<RackSelectorMiner[]> {
-    test.expect(slotNumbers).toHaveLength(minerCount);
-
-    await racksPage.clickAddMiners();
-    await racksPage.waitForMinerSelectorListToLoad();
-
-    const selectableMinerIndexes = await racksPage.getSelectableMinerIndexes(minerCount);
-    const selectedMiners = await racksPage.getMinersFromSelector(selectableMinerIndexes);
-    await racksPage.selectMinersInSelectorByIndex(selectableMinerIndexes);
-    await racksPage.clickContinueInMinerSelector();
-
-    for (let i = 0; i < selectedMiners.length; i++) {
-      await racksPage.selectRackMiner(selectedMiners[i].ipAddress);
-      await racksPage.clickRackSlot(slotNumbers[i]);
-    }
-
-    return selectedMiners;
-  }
-
-  async function addSelectableRigMinersToSlots(
-    racksPage: RacksPage,
-    minerCount: number,
-    slotNumbers: readonly number[],
-  ): Promise<RackSelectorMiner[]> {
-    test.expect(slotNumbers).toHaveLength(minerCount);
-
-    await racksPage.clickAddMiners();
-    await racksPage.waitForMinerSelectorListToLoad();
-    await racksPage.filterModalType(PROTO_RIG_MODEL);
-    await racksPage.waitForMinerSelectorListToLoad();
-
-    const selectableMinerIndexes = await racksPage.getSelectableMinerIndexes(minerCount);
-    const selectedMiners = await racksPage.getMinersFromSelector(selectableMinerIndexes);
-    await racksPage.selectMinersInSelectorByIndex(selectableMinerIndexes);
-    await racksPage.clickContinueInMinerSelector();
-
-    for (let i = 0; i < selectedMiners.length; i++) {
-      await racksPage.selectRackMiner(selectedMiners[i].ipAddress);
-      await racksPage.clickRackSlot(slotNumbers[i]);
-    }
-
-    return selectedMiners;
-  }
-
-  async function expectGridRackLabels(racksPage: RacksPage, expectedLabels: string[]) {
-    await test.expect.poll(async () => await racksPage.getGridRackLabels()).toEqual(expectedLabels);
-  }
-
-  async function expectListRackLabels(racksPage: RacksPage, expectedLabels: string[]) {
-    await test.expect.poll(async () => await racksPage.listRackNames()).toEqual(expectedLabels);
   }
 
   test("Create rack with miners assigned by name", async ({ racksPage }) => {

--- a/client/e2eTests/protoFleet/spec/serverLogs.spec.ts
+++ b/client/e2eTests/protoFleet/spec/serverLogs.spec.ts
@@ -1,13 +1,7 @@
-import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
-import { TimestampSchema } from "@bufbuild/protobuf/wkt";
-import { type Route } from "@playwright/test";
+import { fromJsonString } from "@bufbuild/protobuf";
 import { expect, test } from "../fixtures/pageFixtures";
-import {
-  ListServerLogsRequestSchema,
-  ListServerLogsResponseSchema,
-  LogEntrySchema,
-  LogLevel,
-} from "@/protoFleet/api/generated/serverlog/v1/serverlog_pb";
+import { createServerLogEntry, fulfillServerLogs, parseServerLogsRequest } from "../helpers/serverLogsMocks";
+import { ListServerLogsRequestSchema, LogLevel } from "@/protoFleet/api/generated/serverlog/v1/serverlog_pb";
 
 const serverLogsRpcPattern = /ServerLogService\/ListServerLogs/;
 const loadErrorMessage = "Polling failed for test";
@@ -149,51 +143,3 @@ test.describe("Proto Fleet - Server Logs", () => {
     await serverLogsPage.validateExportErrorCallout(exportErrorMessage);
   });
 });
-
-function createServerLogEntry({
-  id,
-  level,
-  message,
-  source,
-  time,
-  attrs = [],
-}: {
-  id: bigint;
-  level: LogLevel;
-  message: string;
-  source: string;
-  time: Date;
-  attrs?: Array<{ key: string; value: string }>;
-}) {
-  return create(LogEntrySchema, {
-    id,
-    level,
-    message,
-    source,
-    attrs,
-    time: create(TimestampSchema, {
-      seconds: BigInt(Math.floor(time.getTime() / 1000)),
-      nanos: 0,
-    }),
-  });
-}
-
-function parseServerLogsRequest(route: Route) {
-  return fromJsonString(ListServerLogsRequestSchema, route.request().postData() ?? "{}");
-}
-
-function fulfillServerLogs(route: Route, entries: typeof initialEntries, latestId: bigint) {
-  return route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    body: toJsonString(
-      ListServerLogsResponseSchema,
-      create(ListServerLogsResponseSchema, {
-        entries,
-        latestId,
-        bufferSize: entries.length,
-        truncated: false,
-      }),
-    ),
-  });
-}


### PR DESCRIPTION
## Summary
- fix the curtailment spec request/response wait pattern so it satisfies the Playwright lint rule
- split login activity coverage into its own spec, keep `activity.spec.ts` to a single describe block, and wrap the auth-state setup in `test.describe`
- extract support-only helper logic from the miners filters, racks, and server logs specs while tightening a few step and cleanup labels

## Verification
- `./node_modules/.bin/eslint e2eTests --max-warnings 0`

## Commits
- `test(e2e): fix curtailment request waits`
- `test(e2e): split activity login coverage`
- `test(e2e): extract protofleet spec helpers`