### PR TITLE
Curtailment: distinguish empty scope from all-skipped full fleet

### DIFF
--- a/server/generated/sqlc/curtailment_mqtt.sql.go
+++ b/server/generated/sqlc/curtailment_mqtt.sql.go
@@ -14,7 +14,7 @@ import (
 )
 
 const getMQTTSourceStateByID = `-- name: GetMQTTSourceStateByID :one
-SELECT source_config_id, last_target, last_target_at, last_processed_target, last_processed_targets, last_received_at, last_received_broker, last_edge_at, last_edge_event_uuid, pending_direction, pending_target, pending_target_at, pending_received_at, pending_received_broker, pending_prior_edge_at, last_empty_full_fleet_watchdog_ref, updated_at
+SELECT source_config_id, last_target, last_target_at, last_processed_target, last_processed_targets, last_received_at, last_received_broker, last_edge_at, last_edge_event_uuid, pending_direction, pending_target, pending_target_at, pending_received_at, pending_received_broker, pending_prior_edge_at, last_empty_full_fleet_watchdog_ref, updated_at, pending_retry_at
 FROM curtailment_mqtt_source_state
 WHERE source_config_id = $1
 `
@@ -40,6 +40,7 @@ func (q *Queries) GetMQTTSourceStateByID(ctx context.Context, sourceConfigID int
 		&i.PendingPriorEdgeAt,
 		&i.LastEmptyFullFleetWatchdogRef,
 		&i.UpdatedAt,
+		&i.PendingRetryAt,
 	)
 	return i, err
 }
@@ -235,6 +236,7 @@ INSERT INTO curtailment_mqtt_source_state (
     pending_received_at,
     pending_received_broker,
     pending_prior_edge_at,
+    pending_retry_at,
     last_empty_full_fleet_watchdog_ref
 ) VALUES (
     $1,
@@ -252,7 +254,8 @@ INSERT INTO curtailment_mqtt_source_state (
     $13,
     $14,
     $15,
-    $16
+    $16,
+    $17
 )
 ON CONFLICT (source_config_id) DO UPDATE
 SET
@@ -270,6 +273,7 @@ SET
     pending_received_at    = EXCLUDED.pending_received_at,
     pending_received_broker = EXCLUDED.pending_received_broker,
     pending_prior_edge_at  = EXCLUDED.pending_prior_edge_at,
+    pending_retry_at       = EXCLUDED.pending_retry_at,
     last_empty_full_fleet_watchdog_ref = EXCLUDED.last_empty_full_fleet_watchdog_ref
 `
 
@@ -289,6 +293,7 @@ type UpsertMQTTSourceStateParams struct {
 	PendingReceivedAt             sql.NullTime
 	PendingReceivedBroker         sql.NullString
 	PendingPriorEdgeAt            sql.NullTime
+	PendingRetryAt                sql.NullTime
 	LastEmptyFullFleetWatchdogRef sql.NullString
 }
 
@@ -311,6 +316,7 @@ func (q *Queries) UpsertMQTTSourceState(ctx context.Context, arg UpsertMQTTSourc
 		arg.PendingReceivedAt,
 		arg.PendingReceivedBroker,
 		arg.PendingPriorEdgeAt,
+		arg.PendingRetryAt,
 		arg.LastEmptyFullFleetWatchdogRef,
 	)
 	return err

--- a/server/generated/sqlc/models.go
+++ b/server/generated/sqlc/models.go
@@ -487,6 +487,8 @@ type CurtailmentMqttSourceState struct {
 	PendingPriorEdgeAt            sql.NullTime
 	LastEmptyFullFleetWatchdogRef sql.NullString
 	UpdatedAt                     time.Time
+	// Earliest retry time for durable pending MQTT edge dispatches that intentionally throttle retryable outcomes.
+	PendingRetryAt sql.NullTime
 }
 
 type CurtailmentOrgConfig struct {

--- a/server/internal/domain/curtailment/mqttingest/driver.go
+++ b/server/internal/domain/curtailment/mqttingest/driver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/modes"
 )
 
 // curtailmentService is the subset of curtailment.Service the driver needs.
@@ -149,7 +150,7 @@ func (d *Driver) dispatchStart(ctx context.Context, src SourceConfig, direction 
 		return plan.ReplayEvent.EventUUID, false, nil
 	}
 	if plan.InsufficientLoadDetail != nil {
-		return uuid.Nil, false, fmt.Errorf("mqttingest: curtailment service rejected Start (insufficient load): %+v", plan.InsufficientLoadDetail)
+		return uuid.Nil, false, &StartInsufficientLoadError{Detail: plan.InsufficientLoadDetail}
 	}
 	if plan.EventUUID == nil {
 		return uuid.Nil, false, errors.New("mqttingest: curtailment service returned plan with no event UUID")
@@ -227,6 +228,17 @@ func eventIsRestoring(event *models.Event) bool {
 // non-terminal event exists. Caller treats this as a benign no-op
 // (the subscriber's edge bookkeeping still moves to ON).
 var ErrNoActiveEvent = errors.New("mqttingest: no active event to stop")
+
+// StartInsufficientLoadError means Start evaluated successfully but selected no
+// dispatchable load. MQTT ingest keeps the pending OFF retryable, but callers
+// can throttle this stable outcome separately from transient service failures.
+type StartInsufficientLoadError struct {
+	Detail *modes.InsufficientLoadDetail
+}
+
+func (e *StartInsufficientLoadError) Error() string {
+	return fmt.Sprintf("mqttingest: curtailment service rejected Start (insufficient load): %+v", e.Detail)
+}
 
 // clampToInt32Seconds converts a duration to int32 seconds, saturating
 // rather than wrapping on an outsized (operator-typo) value.

--- a/server/internal/domain/curtailment/mqttingest/driver_test.go
+++ b/server/internal/domain/curtailment/mqttingest/driver_test.go
@@ -432,7 +432,12 @@ func TestDriver_Dispatch_InsufficientLoadIsError(t *testing.T) {
 	_, err := d.Dispatch(context.Background(), sampleSource(), EdgeOnToOff, time.Now())
 
 	require.Error(t, err)
+	var insufficient *StartInsufficientLoadError
+	require.ErrorAs(t, err, &insufficient)
 	assert.Contains(t, err.Error(), "insufficient load")
+	require.NotNil(t, insufficient.Detail)
+	assert.Equal(t, 1000.0, insufficient.Detail.AvailableKW)
+	assert.Equal(t, 12500.0, insufficient.Detail.RequestedKW)
 }
 
 func TestDriver_Dispatch_OffToOn(t *testing.T) {

--- a/server/internal/domain/curtailment/mqttingest/store.go
+++ b/server/internal/domain/curtailment/mqttingest/store.go
@@ -67,6 +67,7 @@ type PendingEdge struct {
 	ReceivedAt     time.Time
 	ReceivedBroker string
 	PriorEdgeAt    time.Time
+	RetryAt        time.Time
 }
 
 // StateUpdate replaces a source state row. Zero values map to SQL NULL, which
@@ -149,6 +150,7 @@ func (s *sqlcStore) UpsertSourceState(ctx context.Context, update StateUpdate) e
 		params.PendingReceivedAt = nullTimeFrom(update.PendingEdge.ReceivedAt)
 		params.PendingReceivedBroker = nullStringFrom(update.PendingEdge.ReceivedBroker)
 		params.PendingPriorEdgeAt = nullTimeFrom(update.PendingEdge.PriorEdgeAt)
+		params.PendingRetryAt = nullTimeFrom(update.PendingEdge.RetryAt)
 	}
 	if err := s.queries.UpsertMQTTSourceState(ctx, params); err != nil {
 		return fmt.Errorf("upsert mqtt source state: %w", err)
@@ -213,6 +215,7 @@ func sourceStateFromRow(r sqlc.CurtailmentMqttSourceState) SourceState {
 			r.PendingReceivedAt,
 			r.PendingReceivedBroker,
 			r.PendingPriorEdgeAt,
+			r.PendingRetryAt,
 		),
 		LastEmptyFullFleetWatchdogRef: stringFromNullString(r.LastEmptyFullFleetWatchdogRef),
 	}

--- a/server/internal/domain/curtailment/mqttingest/store_marshal.go
+++ b/server/internal/domain/curtailment/mqttingest/store_marshal.go
@@ -128,6 +128,7 @@ func pendingEdgeFromRow(
 	receivedAt sql.NullTime,
 	receivedBroker sql.NullString,
 	priorEdgeAt sql.NullTime,
+	retryAt sql.NullTime,
 ) *PendingEdge {
 	d := edgeDirectionFromNullString(direction)
 	t := targetFromNullString(target)
@@ -141,6 +142,7 @@ func pendingEdgeFromRow(
 		ReceivedAt:     timeFromNullTime(receivedAt),
 		ReceivedBroker: stringFromNullString(receivedBroker),
 		PriorEdgeAt:    timeFromNullTime(priorEdgeAt),
+		RetryAt:        timeFromNullTime(retryAt),
 	}
 }
 

--- a/server/internal/domain/curtailment/mqttingest/worker.go
+++ b/server/internal/domain/curtailment/mqttingest/worker.go
@@ -36,6 +36,7 @@ type observation struct {
 // broker callback backpressures instead of accepting and losing a state signal.
 const observationChannelBuffer = 256
 const initialBrokerRetryMax = 30 * time.Second
+const pendingInsufficientLoadRetryEvery = 30 * time.Second
 
 func (w *sourceWorker) run(ctx context.Context) {
 	w.lastObs = make(map[BrokerRole]*Observation)
@@ -222,6 +223,13 @@ func (w *sourceWorker) startupRetryEvery() time.Duration {
 	return time.Second
 }
 
+func (w *sourceWorker) pendingInsufficientLoadRetryEvery() time.Duration {
+	if w.source.StalenessThreshold > 0 && w.source.StalenessThreshold < pendingInsufficientLoadRetryEvery {
+		return w.source.StalenessThreshold
+	}
+	return pendingInsufficientLoadRetryEvery
+}
+
 func mqttClientIdentity(src SourceConfig, host string) string {
 	return fmt.Sprintf("%d|%s|%s|%d|%s", src.ID, src.SourceName, host, src.BrokerPort, src.Topic)
 }
@@ -355,6 +363,12 @@ func (w *sourceWorker) handleMessage(ctx context.Context, prior SourceState, obs
 		pendingSuperseded = true
 	}
 
+	if prior.PendingEdge != nil && !w.pendingEdgeRetryReady(prior.PendingEdge) {
+		state := w.advanceLiveness(prior, canonical, liveness)
+		w.persistState(ctx, state)
+		return state
+	}
+
 	priorTarget := prior.LastTarget
 	priorEdgeAt := prior.LastEdgeAt
 	direction := Decide(PriorState{LastTarget: priorTarget, LastEdgeAt: priorEdgeAt}, canonical)
@@ -470,6 +484,9 @@ func (w *sourceWorker) handleWatchdog(ctx context.Context, prior SourceState) So
 	canonical := CanonicalState{Target: TargetOff, ReceivedAt: now}
 	state, dispatched := w.applyEdge(ctx, prior, canonical, EdgeWatchdogOff)
 	if !dispatched {
+		if state.PendingEdge != nil && !state.PendingEdge.RetryAt.IsZero() {
+			return state
+		}
 		return prior
 	}
 	w.persistState(ctx, state)
@@ -501,8 +518,14 @@ func (w *sourceWorker) applyEdge(ctx context.Context, prior SourceState, canonic
 }
 
 func (w *sourceWorker) retryPendingEdge(ctx context.Context, prior SourceState) (SourceState, bool) {
+	if !w.pendingEdgeRetryReady(prior.PendingEdge) {
+		return prior, false
+	}
 	state, dispatched := w.dispatchPendingEdge(ctx, prior)
 	if !dispatched {
+		if pendingRetryUpdated(prior.PendingEdge, state.PendingEdge) {
+			return state, true
+		}
 		return prior, false
 	}
 	if !w.persistState(ctx, state) {
@@ -515,6 +538,9 @@ func (w *sourceWorker) dispatchPendingEdge(ctx context.Context, prior SourceStat
 	pending := prior.PendingEdge
 	if pending == nil {
 		return prior, true
+	}
+	if !w.pendingEdgeRetryReady(pending) {
+		return prior, false
 	}
 	if !w.ensureCanDispatch(ctx) {
 		return prior, false
@@ -547,6 +573,10 @@ func (w *sourceWorker) dispatchPendingEdge(ctx context.Context, prior SourceStat
 		if errors.Is(err, ErrNoActiveEvent) {
 			return w.settlePendingEdge(prior, pending, pending.Target, uuid.Nil, false, dispatchAt), true
 		}
+		var insufficientLoad *StartInsufficientLoadError
+		if errors.As(err, &insufficientLoad) {
+			return w.deferPendingRetry(ctx, prior, pending, err), false
+		}
 		w.cfg.Logger.Error("mqttingest: edge dispatch failed",
 			slog.String("source", w.source.SourceName),
 			slog.String("direction", pending.Direction.String()),
@@ -560,6 +590,35 @@ func (w *sourceWorker) dispatchPendingEdge(ctx context.Context, prior SourceStat
 		slog.String("direction", pending.Direction.String()),
 		slog.String("event_uuid", state.LastEdgeEventUUID))
 	return state, true
+}
+
+func (w *sourceWorker) pendingEdgeRetryReady(pending *PendingEdge) bool {
+	return pending == nil || pending.RetryAt.IsZero() || !w.cfg.Clock().Before(pending.RetryAt)
+}
+
+func pendingRetryUpdated(before, after *PendingEdge) bool {
+	if before == nil || after == nil {
+		return false
+	}
+	return !after.RetryAt.IsZero() && !after.RetryAt.Equal(before.RetryAt)
+}
+
+func (w *sourceWorker) deferPendingRetry(ctx context.Context, prior SourceState, pending *PendingEdge, err error) SourceState {
+	state := prior
+	next := *pending
+	retryAfter := w.pendingInsufficientLoadRetryEvery()
+	next.RetryAt = w.cfg.Clock().Add(retryAfter).UTC()
+	state.PendingEdge = &next
+	if !w.persistState(ctx, state) {
+		return prior
+	}
+	w.cfg.Logger.Warn("mqttingest: edge dispatch deferred",
+		slog.String("source", w.source.SourceName),
+		slog.String("direction", pending.Direction.String()),
+		slog.Duration("retry_after", retryAfter),
+		slog.Time("retry_at", next.RetryAt),
+		slog.Any("error", err))
+	return state
 }
 
 func (w *sourceWorker) settlePendingEdge(

--- a/server/internal/domain/curtailment/mqttingest/worker_test.go
+++ b/server/internal/domain/curtailment/mqttingest/worker_test.go
@@ -166,8 +166,10 @@ func TestWorker_HandleWatchdog_AllSkippedFullFleetKeepsOffPending(t *testing.T) 
 		},
 	}
 	w := newTestWorker(t, store, svc, workerSource())
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	w.cfg.Clock = func() time.Time { return now }
 
-	stale := time.Now().Add(-5 * time.Minute)
+	stale := now.Add(-5 * time.Minute)
 	prior := SourceState{
 		SourceConfigID: w.source.ID,
 		LastTarget:     TargetOn,
@@ -182,8 +184,63 @@ func TestWorker_HandleWatchdog_AllSkippedFullFleetKeepsOffPending(t *testing.T) 
 	require.NoError(t, err)
 	require.NotNil(t, persisted.PendingEdge, "all-skipped full_fleet must remain retryable")
 	assert.Equal(t, EdgeWatchdogOff, persisted.PendingEdge.Direction)
+	assert.Equal(t, now.Add(pendingInsufficientLoadRetryEvery), persisted.PendingEdge.RetryAt,
+		"stable all-skipped outcomes should be retried on a coarser durable cadence")
 	assert.Empty(t, persisted.LastEmptyFullFleetWatchdogRef,
 		"all-skipped is not a genuinely empty full_fleet no-op window")
+}
+
+func TestWorker_HandleWatchdog_AllSkippedFullFleetThrottlesPendingRetry(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	svc := &fakeService{
+		startResult: &curtailment.Plan{
+			InsufficientLoadDetail: &modes.InsufficientLoadDetail{
+				ExcludedMaintenance: 10,
+			},
+		},
+	}
+	w := newTestWorker(t, store, svc, workerSource())
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	w.cfg.Clock = func() time.Time { return now }
+
+	prior := SourceState{
+		SourceConfigID: w.source.ID,
+		LastTarget:     TargetOn,
+		LastReceivedAt: now.Add(-5 * time.Minute),
+	}
+
+	first := w.handleWatchdog(context.Background(), prior)
+
+	require.Equal(t, 1, svc.startCallsLen(), "first stale watchdog tick must attempt Start")
+	require.NotNil(t, first.PendingEdge)
+	firstRetryAt := first.PendingEdge.RetryAt
+	require.Equal(t, now.Add(pendingInsufficientLoadRetryEvery), firstRetryAt)
+
+	second := w.handleWatchdog(context.Background(), first)
+
+	assert.Equal(t, 1, svc.startCallsLen(), "pending retry must not dispatch before retry_at")
+	require.NotNil(t, second.PendingEdge)
+	assert.Equal(t, firstRetryAt, second.PendingEdge.RetryAt)
+
+	duplicateAt := now.Add(time.Second)
+	offBody, err := json.Marshal(map[string]any{"target": 0, "timestamp": duplicateAt.Unix()})
+	require.NoError(t, err)
+	afterDuplicate := w.handleMessage(context.Background(), second,
+		observation{broker: w.primaryHost, payload: offBody, receivedAt: duplicateAt})
+
+	assert.Equal(t, 1, svc.startCallsLen(), "duplicate OFF payload must also wait for retry_at")
+	require.NotNil(t, afterDuplicate.PendingEdge)
+	assert.Equal(t, firstRetryAt, afterDuplicate.PendingEdge.RetryAt)
+	assert.Equal(t, duplicateAt, afterDuplicate.LastReceivedAt)
+
+	now = firstRetryAt.Add(time.Nanosecond)
+	third := w.handleWatchdog(context.Background(), afterDuplicate)
+
+	assert.Equal(t, 2, svc.startCallsLen(), "pending retry should dispatch once retry_at has passed")
+	require.NotNil(t, third.PendingEdge)
+	assert.True(t, third.PendingEdge.RetryAt.After(firstRetryAt))
 }
 
 // Failed Start must not settle LastTarget.

--- a/server/internal/domain/curtailment/mqttingest/worker_test.go
+++ b/server/internal/domain/curtailment/mqttingest/worker_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/modes"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 )
 
@@ -151,6 +152,38 @@ func TestWorker_HandleWatchdog_DispatchFailure_DoesNotAdvance(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, persisted.PendingEdge, "failed dispatch must persist pending retry state")
 	assert.Equal(t, EdgeWatchdogOff, persisted.PendingEdge.Direction)
+}
+
+func TestWorker_HandleWatchdog_AllSkippedFullFleetKeepsOffPending(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	svc := &fakeService{
+		startResult: &curtailment.Plan{
+			InsufficientLoadDetail: &modes.InsufficientLoadDetail{
+				ExcludedStale: 1,
+			},
+		},
+	}
+	w := newTestWorker(t, store, svc, workerSource())
+
+	stale := time.Now().Add(-5 * time.Minute)
+	prior := SourceState{
+		SourceConfigID: w.source.ID,
+		LastTarget:     TargetOn,
+		LastReceivedAt: stale,
+	}
+
+	next := w.handleWatchdog(context.Background(), prior)
+
+	require.Equal(t, 1, svc.startCallsLen(), "watchdog must attempt full_fleet Start")
+	assert.Equal(t, TargetOn, next.LastTarget, "all-skipped full_fleet must not settle OFF")
+	persisted, err := store.GetSourceState(context.Background(), w.source.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted.PendingEdge, "all-skipped full_fleet must remain retryable")
+	assert.Equal(t, EdgeWatchdogOff, persisted.PendingEdge.Direction)
+	assert.Empty(t, persisted.LastEmptyFullFleetWatchdogRef,
+		"all-skipped is not a genuinely empty full_fleet no-op window")
 }
 
 // Failed Start must not settle LastTarget.

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -175,8 +175,11 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 		// Defense-in-depth; FIXED_KW's validator + selector prevent this.
 		return nil, fleeterror.NewInvalidArgumentError("no targets selected")
 	}
-	// FULL_FLEET with an empty eligible set is valid (nothing curtailable ==
+	// FULL_FLEET with a genuinely empty scope is valid (nothing curtailable ==
 	// vacuously off); it persists directly COMPLETED with no targets below.
+	// runSelector rejects the unsafe non-empty/all-skipped case before this
+	// point so automation cannot interpret "nothing actionable curtailed" as
+	// satisfied.
 
 	// max_duration_seconds=nil + !AllowUnbounded means "use org default".
 	// Bounds-check the normalized value so a misconfigured default surfaces
@@ -878,7 +881,47 @@ func (s *Service) runSelector(ctx context.Context, req PreviewRequest) (*Plan, i
 	}
 
 	plan := BuildPlan(eligible, preFiltered, minPowerW, mode)
+	if req.Mode == models.ModeFullFleet && len(plan.Selected) == 0 && len(plan.Skipped) > 0 {
+		detail := fullFleetAllSkippedDetail(plan.Skipped, minPowerW)
+		plan.Outcome = modes.OutcomeInsufficientLoad
+		plan.InsufficientLoadDetail = &detail
+	}
 	return &plan, minPowerW, orgConfig, nil
+}
+
+func fullFleetAllSkippedDetail(skipped []SkippedDevice, minPowerW int32) modes.InsufficientLoadDetail {
+	detail := modes.InsufficientLoadDetail{CandidateMinPowerW: minPowerW}
+	for _, skip := range skipped {
+		switch skip.Reason {
+		case SkipBelowThreshold:
+			detail.ExcludedBelowThreshold++
+		case SkipPhantomLoadNoHash:
+			detail.ExcludedPhantomLoad++
+		case SkipPowerTelemetryUnreliable:
+			detail.ExcludedDeadMonitor++
+		case SkipUnreachableResidualLoad:
+			detail.ExcludedOffline++
+		case SkipMaintenance:
+			detail.ExcludedMaintenance++
+		case SkipUpdating:
+			detail.ExcludedUpdating++
+		case SkipRebootRequired:
+			detail.ExcludedRebootRequired++
+		case SkipStaleTelemetry:
+			detail.ExcludedStale++
+		case SkipNonActionableStatus:
+			detail.ExcludedNonActionable++
+		case SkipPairing:
+			detail.ExcludedPairing++
+		case SkipCooldown:
+			detail.ExcludedCooldown++
+		case SkipActiveEvent:
+			detail.ExcludedActiveEvent++
+		case SkipCurtailFullUnsupported:
+			detail.ExcludedCapabilityMiss++
+		}
+	}
+	return detail
 }
 
 // buildMode constructs the selection mode from the request. FULL_FLEET takes

--- a/server/internal/domain/curtailment/service_start_fullfleet_test.go
+++ b/server/internal/domain/curtailment/service_start_fullfleet_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/modes"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 )
 
@@ -57,6 +58,86 @@ func TestService_Start_FullFleet_NoEligibleMinersPersistsCompleted(t *testing.T)
 		"nothing eligible == vacuously complete on arrival")
 	assert.NotNil(t, store.lastInsertEvent.EndedAt, "a completed-empty event records its completion time")
 	assert.Empty(t, store.lastInsertTargets, "a completed-empty event has no targets")
+}
+
+func TestService_Preview_FullFleet_AllSkippedReturnsInsufficientDetail(t *testing.T) {
+	t.Parallel()
+	const orgID = int64(1)
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.candidatesByOrg[orgID] = []*models.Candidate{
+		miner("offline", "OFFLINE", "PAIRED", 0, 0),
+		miner("updating", "UPDATING", "PAIRED", 0, 0),
+		staleMiner("stale"),
+		miner("below-floor", "ACTIVE", "PAIRED", 100, 0),
+	}
+	svc := NewService(store)
+	req := validRequest(orgID)
+	req.Scope = Scope{Type: models.ScopeTypeWholeOrg}
+	req.Mode = models.ModeFullFleet
+	req.TargetKW = 0
+
+	plan, err := svc.Preview(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, plan.InsufficientLoadDetail)
+	assert.Equal(t, modes.OutcomeInsufficientLoad, plan.Outcome)
+	assert.Empty(t, plan.Selected)
+	assert.Len(t, plan.Skipped, 4)
+	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedOffline)
+	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedUpdating)
+	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedStale)
+	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedBelowThreshold)
+	assert.Equal(t, int32(1500), plan.InsufficientLoadDetail.CandidateMinPowerW)
+	assert.Zero(t, store.insertEventCalls, "Preview must not persist")
+}
+
+func TestService_Start_FullFleet_AllSkippedDoesNotPersist(t *testing.T) {
+	t.Parallel()
+	const orgID = int64(1)
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.candidatesByOrg[orgID] = []*models.Candidate{
+		miner("offline", "OFFLINE", "PAIRED", 0, 0),
+		staleMiner("stale"),
+	}
+	svc := NewService(store)
+	req := validStartRequest(orgID)
+	req.Scope = Scope{Type: models.ScopeTypeWholeOrg}
+	req.Mode = models.ModeFullFleet
+	req.TargetKW = 0
+
+	plan, err := svc.Start(t.Context(), req)
+	require.NoError(t, err, "all-skipped full_fleet surfaces via Plan, not as a service error")
+	require.NotNil(t, plan.InsufficientLoadDetail)
+	assert.Equal(t, modes.OutcomeInsufficientLoad, plan.Outcome)
+	assert.Nil(t, plan.EventUUID, "no event must be persisted when no miner was actionable")
+	assert.Zero(t, store.insertEventCalls, "all-skipped full_fleet must not persist a completed event")
+}
+
+func TestService_Start_FullFleet_MixedSelectedAndSkippedPersists(t *testing.T) {
+	t.Parallel()
+	const orgID = int64(1)
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.candidatesByOrg[orgID] = []*models.Candidate{
+		minerWithEff("eligible", 6000, 100, 40),
+		miner("offline", "OFFLINE", "PAIRED", 0, 0),
+	}
+	svc := NewService(store)
+	req := validStartRequest(orgID)
+	req.Scope = Scope{Type: models.ScopeTypeWholeOrg}
+	req.Mode = models.ModeFullFleet
+	req.TargetKW = 0
+
+	plan, err := svc.Start(t.Context(), req)
+	require.NoError(t, err)
+	assert.Nil(t, plan.InsufficientLoadDetail)
+	require.Len(t, plan.Selected, 1)
+	assert.Equal(t, "eligible", plan.Selected[0].DeviceIdentifier)
+	assert.Len(t, plan.Skipped, 1)
+	assert.Equal(t, 1, store.insertEventCalls)
+	assert.Equal(t, models.EventStatePending, store.lastInsertEvent.State)
+	assert.Len(t, store.lastInsertTargets, 1)
 }
 
 // FIXED_KW still requires a positive target_kw; FULL_FLEET does not.

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -371,6 +371,38 @@ func TestHandler_StartCurtailment_InsufficientLoadSurfacesAsInvalidArgument(t *t
 	assert.Empty(t, store.lastTargets)
 }
 
+func TestHandler_StartCurtailment_FullFleetAllSkippedSurfacesSkippedReasons(t *testing.T) {
+	t.Parallel()
+
+	store := newStartStubStore()
+	store.candidates = []*models.Candidate{
+		miner("offline", "OFFLINE", "PAIRED", 0, 0, 40),
+		miner("updating", "UPDATING", "PAIRED", 0, 0, 40),
+	}
+	h := NewHandler(curtailment.NewService(store))
+
+	ctx := authn.SetInfo(t.Context(), &session.Info{
+		AuthMethod:     session.AuthMethodSession,
+		OrganizationID: 1,
+		UserID:         9,
+		Role:           "OPERATOR",
+	})
+
+	req := validStartRequestBuilder()
+	req.Mode = pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET
+	req.ModeParams = nil
+
+	_, err := h.StartCurtailment(ctx, connect.NewRequest(req))
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
+	assert.Contains(t, err.Error(), "insufficient curtailable load")
+	assert.Contains(t, err.Error(), "unreachable_residual_load=1")
+	assert.Contains(t, err.Error(), "updating=1")
+	assert.Empty(t, store.lastTargets, "all-skipped full_fleet must not persist a completed event")
+}
+
 // TestHandler_StartCurtailment_RejectsMissingSession pins the auth gate:
 // without session.Info in context, Start must fail with Unauthenticated
 // (not crash on a nil-dereference of OrganizationID).

--- a/server/migrations/000077_add_mqtt_pending_retry_at.down.sql
+++ b/server/migrations/000077_add_mqtt_pending_retry_at.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE curtailment_mqtt_source_state
+    DROP COLUMN IF EXISTS pending_retry_at;

--- a/server/migrations/000077_add_mqtt_pending_retry_at.up.sql
+++ b/server/migrations/000077_add_mqtt_pending_retry_at.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE curtailment_mqtt_source_state
+    ADD COLUMN pending_retry_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN curtailment_mqtt_source_state.pending_retry_at IS
+    'Earliest retry time for durable pending MQTT edge dispatches that intentionally throttle retryable outcomes.';

--- a/server/sqlc/queries/curtailment_mqtt.sql
+++ b/server/sqlc/queries/curtailment_mqtt.sql
@@ -30,6 +30,7 @@ INSERT INTO curtailment_mqtt_source_state (
     pending_received_at,
     pending_received_broker,
     pending_prior_edge_at,
+    pending_retry_at,
     last_empty_full_fleet_watchdog_ref
 ) VALUES (
     sqlc.arg('source_config_id'),
@@ -47,6 +48,7 @@ INSERT INTO curtailment_mqtt_source_state (
     sqlc.narg('pending_received_at'),
     sqlc.narg('pending_received_broker'),
     sqlc.narg('pending_prior_edge_at'),
+    sqlc.narg('pending_retry_at'),
     sqlc.narg('last_empty_full_fleet_watchdog_ref')
 )
 ON CONFLICT (source_config_id) DO UPDATE
@@ -65,6 +67,7 @@ SET
     pending_received_at    = EXCLUDED.pending_received_at,
     pending_received_broker = EXCLUDED.pending_received_broker,
     pending_prior_edge_at  = EXCLUDED.pending_prior_edge_at,
+    pending_retry_at       = EXCLUDED.pending_retry_at,
     last_empty_full_fleet_watchdog_ref = EXCLUDED.last_empty_full_fleet_watchdog_ref;
 
 -- name: InsertMQTTSourceConfig :one


### PR DESCRIPTION
## Summary

- Treat `FULL_FLEET` plans with zero selected miners and one or more skipped miners as an explicit insufficient-load result instead of a successful empty event.
- Preserve valid zero-target completion for genuinely empty scopes.
- Keep the all-skipped outcome from being treated as satisfied automation behavior.
- Add durable retry throttling for the legacy MQTT direct-dispatch path that existed when this PR landed.

## Merged State

- Merged into `main` as `0d64a7d`.
- Closed #394.
- Introduced migration `000077_add_mqtt_pending_retry_at`.

## Current Product Context

PR #409 later removed the legacy MQTT direct-dispatch model. MQTT sources now record source/runtime state only and no longer call curtailment start/stop directly.

The core safety behavior from this PR still matters for the future automation executor: when an MQTT source trigger starts a response profile and the selected scope is non-empty but every miner is skipped, the executor must treat that as not satisfied rather than as a successful OFF response.

## Validation

- `go test -count=1 ./server/internal/domain/curtailment ./server/internal/domain/curtailment/mqttingest`
- `go test -count=1 ./server/internal/handlers/curtailment`
- `git diff --check`
- pre-push `server-lint`
- Attempted `go test -count=1 ./server/internal/domain/stores/sqlstores`; local Postgres rejected the `fleet` password before test logic ran.

Closes #394.

