### PR TITLE
Curtailment: gate public preview, start, and stop operations

### DIFF
--- a/server/internal/domain/authz/catalog.go
+++ b/server/internal/domain/authz/catalog.go
@@ -150,8 +150,8 @@ var catalog = []CatalogEntry{
 
 	{PermServerlogRead, "View server-side logs.", ResourceServerLog},
 
-	{PermCurtailmentRead, "View curtailment policies and preview impact.", ResourceCurtailment},
-	{PermCurtailmentManage, "Create, edit, and delete curtailment policies.", ResourceCurtailment},
+	{PermCurtailmentRead, "View curtailment status, events, and policies.", ResourceCurtailment},
+	{PermCurtailmentManage, "Preview, start, stop, and manage curtailment policies.", ResourceCurtailment},
 	{PermCurtailmentIngest, "Accept curtailment dispatch signals from external providers (QSE bridge, aggregator, OpenADR VTN).", ResourceCurtailment},
 
 	{PermPoolRead, "View saved mining pool configurations.", ResourcePool},

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -16,13 +16,12 @@ import (
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
-// Action verb for requireAdminFromContext error messages on the conditional
-// override gates in Start/Stop/Preview. AdminTerminateEvent uses
-// RequirePermission instead.
+// Action verb for requireAdminFromContext error messages on the legacy
+// admin-only override checks that run after the curtailment:manage gate.
 const actionSupplyOverrideFields = "supply curtailment override fields"
 
 // Handler implements the curtailment RPC surface; service=nil keeps
-// every RPC at Unimplemented (test stubs).
+// RPC bodies at Unimplemented after any entry auth gates run.
 type Handler struct {
 	service *curtailment.Service
 }
@@ -34,6 +33,10 @@ func NewHandler(service *curtailment.Service) *Handler {
 }
 
 func (h *Handler) PreviewCurtailmentPlan(ctx context.Context, req *connect.Request[pb.PreviewCurtailmentPlanRequest]) (*connect.Response[pb.PreviewCurtailmentPlanResponse], error) {
+	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	if err != nil {
+		return nil, err
+	}
 	if req.Msg.CandidateMinPowerWOverride != nil {
 		if err := requireAdminFromContext(ctx, actionSupplyOverrideFields); err != nil {
 			return nil, err
@@ -41,11 +44,6 @@ func (h *Handler) PreviewCurtailmentPlan(ctx context.Context, req *connect.Reque
 	}
 	if h.service == nil {
 		return nil, errCurtailmentNotImplemented("PreviewCurtailmentPlan")
-	}
-
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return nil, fleeterror.NewUnauthenticatedError("authentication required")
 	}
 
 	previewReq, err := toPreviewRequest(req.Msg, info.OrganizationID)
@@ -66,6 +64,10 @@ func (h *Handler) PreviewCurtailmentPlan(ctx context.Context, req *connect.Reque
 }
 
 func (h *Handler) StartCurtailment(ctx context.Context, req *connect.Request[pb.StartCurtailmentRequest]) (*connect.Response[pb.StartCurtailmentResponse], error) {
+	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	if err != nil {
+		return nil, err
+	}
 	if req.Msg.CandidateMinPowerWOverride != nil || req.Msg.AllowUnbounded || req.Msg.ForceIncludeMaintenance {
 		// force_include_maintenance is safety-critical (curtails miners
 		// under physical maintenance), so the same admin gate applies.
@@ -73,18 +75,8 @@ func (h *Handler) StartCurtailment(ctx context.Context, req *connect.Request[pb.
 			return nil, err
 		}
 	}
-	if requiresHighBlastCurtailmentManage(req.Msg) {
-		if _, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{}); err != nil {
-			return nil, err
-		}
-	}
 	if h.service == nil {
 		return nil, errCurtailmentNotImplemented("StartCurtailment")
-	}
-
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return nil, fleeterror.NewUnauthenticatedError("authentication required")
 	}
 
 	startReq, err := toStartRequest(req.Msg, info)
@@ -107,14 +99,6 @@ func (h *Handler) StartCurtailment(ctx context.Context, req *connect.Request[pb.
 	}
 
 	return connect.NewResponse(toStartResponse(plan, req.Msg)), nil
-}
-
-func requiresHighBlastCurtailmentManage(msg *pb.StartCurtailmentRequest) bool {
-	if msg.GetMode() != pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET {
-		return false
-	}
-	_, wholeOrg := msg.GetScope().(*pb.StartCurtailmentRequest_WholeOrg)
-	return wholeOrg
 }
 
 func (h *Handler) UpdateCurtailmentEvent(ctx context.Context, req *connect.Request[pb.UpdateCurtailmentEventRequest]) (*connect.Response[pb.UpdateCurtailmentEventResponse], error) {
@@ -144,6 +128,10 @@ func (h *Handler) UpdateCurtailmentEvent(ctx context.Context, req *connect.Reque
 }
 
 func (h *Handler) StopCurtailment(ctx context.Context, req *connect.Request[pb.StopCurtailmentRequest]) (*connect.Response[pb.StopCurtailmentResponse], error) {
+	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	if err != nil {
+		return nil, err
+	}
 	if req.Msg.GetForce() {
 		if err := requireAdminFromContext(ctx, actionSupplyOverrideFields); err != nil {
 			return nil, err
@@ -151,11 +139,6 @@ func (h *Handler) StopCurtailment(ctx context.Context, req *connect.Request[pb.S
 	}
 	if h.service == nil {
 		return nil, errCurtailmentNotImplemented("StopCurtailment")
-	}
-
-	info, err := session.GetInfo(ctx)
-	if err != nil {
-		return nil, fleeterror.NewUnauthenticatedError("authentication required")
 	}
 
 	stopReq, err := toStopRequest(req.Msg, info.OrganizationID)

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -73,6 +73,11 @@ func (h *Handler) StartCurtailment(ctx context.Context, req *connect.Request[pb.
 			return nil, err
 		}
 	}
+	if requiresHighBlastCurtailmentManage(req.Msg) {
+		if _, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{}); err != nil {
+			return nil, err
+		}
+	}
 	if h.service == nil {
 		return nil, errCurtailmentNotImplemented("StartCurtailment")
 	}
@@ -102,6 +107,14 @@ func (h *Handler) StartCurtailment(ctx context.Context, req *connect.Request[pb.
 	}
 
 	return connect.NewResponse(toStartResponse(plan, req.Msg)), nil
+}
+
+func requiresHighBlastCurtailmentManage(msg *pb.StartCurtailmentRequest) bool {
+	if msg.GetMode() != pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET {
+		return false
+	}
+	_, wholeOrg := msg.GetScope().(*pb.StartCurtailmentRequest_WholeOrg)
+	return wholeOrg
 }
 
 func (h *Handler) UpdateCurtailmentEvent(ctx context.Context, req *connect.Request[pb.UpdateCurtailmentEventRequest]) (*connect.Response[pb.UpdateCurtailmentEventResponse], error) {

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -195,13 +195,18 @@ func validStartRequestBuilder() *pb.StartCurtailmentRequest {
 
 func startSessionCtxWithPerms(t *testing.T, orgID int64, role string, perms ...string) context.Context {
 	t.Helper()
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	return startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
 		OrganizationID: orgID,
 		UserID:         9,
 		Role:           role,
 		SessionID:      "sess-start-perms",
-	})
+	}, perms...)
+}
+
+func startSessionInfoCtxWithPerms(t *testing.T, info *session.Info, perms ...string) context.Context {
+	t.Helper()
+	ctx := authn.SetInfo(t.Context(), info)
 	return middleware.WithEffectivePermissions(ctx, authz.NewEffectivePermissions([]authz.Assignment{{
 		AssignmentID: 1,
 		ScopeType:    authz.ScopeOrg,
@@ -222,13 +227,13 @@ func TestHandler_StartCurtailment_HappyPath(t *testing.T) {
 	}
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
 		OrganizationID: 42,
 		UserID:         9,
 		Role:           "OPERATOR",
 		SessionID:      "sess-abc",
-	})
+	}, authz.PermCurtailmentManage)
 
 	resp, err := h.StartCurtailment(ctx, connect.NewRequest(validStartRequestBuilder()))
 	require.NoError(t, err)
@@ -265,82 +270,41 @@ func TestHandler_StartCurtailment_HappyPath(t *testing.T) {
 	assert.Equal(t, uint32(10), ev.EffectiveBatchSize)
 }
 
-func TestHandler_StartCurtailment_FullFleetWholeOrgRequiresCurtailmentManage(t *testing.T) {
+func TestHandler_StartCurtailment_RequiresCurtailmentManage(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name        string
+		mutateReq   func(*pb.StartCurtailmentRequest)
 		permissions []string
+		wantMode    models.Mode
 		wantCode    connect.Code
 		wantPersist bool
 	}{
 		{
-			name:        "caller without curtailment manage is rejected",
+			name:        "fixed kw whole org without manage is rejected",
 			permissions: []string{authz.PermCurtailmentRead},
+			wantMode:    models.ModeFixedKw,
 			wantCode:    connect.CodePermissionDenied,
 		},
 		{
 			name:        "empty permissions set is rejected",
 			permissions: nil,
+			wantMode:    models.ModeFixedKw,
 			wantCode:    connect.CodePermissionDenied,
 		},
 		{
-			name:        "caller with curtailment manage can start whole org full fleet",
-			permissions: []string{authz.PermCurtailmentManage},
-			wantPersist: true,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			store := newStartStubStore()
-			store.candidates = []*models.Candidate{
-				miner("eligible", "ACTIVE", "PAIRED", 6000, 100, 40),
-			}
-			h := NewHandler(curtailment.NewService(store))
-
-			req := validStartRequestBuilder()
-			req.Mode = pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET
-			req.ModeParams = nil
-
-			_, err := h.StartCurtailment(
-				startSessionCtxWithPerms(t, 1, "OPERATOR", tc.permissions...),
-				connect.NewRequest(req),
-			)
-
-			if tc.wantPersist {
-				require.NoError(t, err)
-				assert.Equal(t, models.ModeFullFleet, store.lastEvent.Mode)
-				assert.Len(t, store.lastTargets, 1)
-				return
-			}
-
-			require.Error(t, err)
-			var fleetErr fleeterror.FleetError
-			require.ErrorAs(t, err, &fleetErr)
-			assert.Equal(t, tc.wantCode, fleetErr.GRPCCode)
-			assert.Zero(t, store.lastEvent.OrgID, "permission gate must fail before persistence")
-			assert.Empty(t, store.lastTargets, "permission gate must fail before target selection persists")
-		})
-	}
-}
-
-func TestHandler_StartCurtailment_LowerBlastStartsDoNotRequireCurtailmentManage(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name      string
-		mutateReq func(*pb.StartCurtailmentRequest)
-		wantMode  models.Mode
-	}{
-		{
-			name:     "fixed kw whole org",
-			wantMode: models.ModeFixedKw,
+			name: "full fleet whole org without manage is rejected",
+			mutateReq: func(req *pb.StartCurtailmentRequest) {
+				req.Mode = pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET
+				req.ModeParams = nil
+			},
+			permissions: []string{authz.PermCurtailmentRead},
+			wantMode:    models.ModeFullFleet,
+			wantCode:    connect.CodePermissionDenied,
 		},
 		{
-			name: "full fleet explicit device list",
+			name: "full fleet explicit device list without manage is rejected",
 			mutateReq: func(req *pb.StartCurtailmentRequest) {
 				req.Scope = &pb.StartCurtailmentRequest_DeviceIdentifiers{
 					DeviceIdentifiers: &pb.ScopeDeviceList{DeviceIdentifiers: []string{"eligible"}},
@@ -348,7 +312,25 @@ func TestHandler_StartCurtailment_LowerBlastStartsDoNotRequireCurtailmentManage(
 				req.Mode = pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET
 				req.ModeParams = nil
 			},
-			wantMode: models.ModeFullFleet,
+			permissions: []string{authz.PermCurtailmentRead},
+			wantMode:    models.ModeFullFleet,
+			wantCode:    connect.CodePermissionDenied,
+		},
+		{
+			name:        "fixed kw whole org with manage can start",
+			permissions: []string{authz.PermCurtailmentManage},
+			wantMode:    models.ModeFixedKw,
+			wantPersist: true,
+		},
+		{
+			name: "full fleet whole org with manage can start",
+			mutateReq: func(req *pb.StartCurtailmentRequest) {
+				req.Mode = pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET
+				req.ModeParams = nil
+			},
+			permissions: []string{authz.PermCurtailmentManage},
+			wantMode:    models.ModeFullFleet,
+			wantPersist: true,
 		},
 	}
 
@@ -368,12 +350,23 @@ func TestHandler_StartCurtailment_LowerBlastStartsDoNotRequireCurtailmentManage(
 			}
 
 			_, err := h.StartCurtailment(
-				startSessionCtxWithPerms(t, 1, "OPERATOR", authz.PermCurtailmentRead),
+				startSessionCtxWithPerms(t, 1, "OPERATOR", tc.permissions...),
 				connect.NewRequest(req),
 			)
-			require.NoError(t, err)
-			assert.Equal(t, tc.wantMode, store.lastEvent.Mode)
-			assert.Len(t, store.lastTargets, 1)
+
+			if tc.wantPersist {
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantMode, store.lastEvent.Mode)
+				assert.Len(t, store.lastTargets, 1)
+				return
+			}
+
+			require.Error(t, err)
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr)
+			assert.Equal(t, tc.wantCode, fleetErr.GRPCCode)
+			assert.Zero(t, store.lastEvent.OrgID, "permission gate must fail before persistence")
+			assert.Empty(t, store.lastTargets, "permission gate must fail before target selection persists")
 		})
 	}
 }
@@ -413,13 +406,13 @@ func TestHandler_StartCurtailment_IdempotentReplayRendersPersistedEvent(t *testi
 	}
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
 		OrganizationID: 42,
 		UserID:         9,
 		Role:           "OPERATOR",
 		SessionID:      "sess-abc",
-	})
+	}, authz.PermCurtailmentManage)
 	req := validStartRequestBuilder()
 	req.Reason = "changed retry reason"
 	req.IdempotencyKey = "retry-key"
@@ -450,13 +443,13 @@ func TestHandler_StartCurtailment_APIKeyDerivesAPIKeyActor(t *testing.T) {
 	}
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodAPIKey,
 		OrganizationID: 1,
 		UserID:         9,
 		Role:           "OPERATOR",
 		APIKeyID:       "key-77",
-	})
+	}, authz.PermCurtailmentManage)
 
 	_, err := h.StartCurtailment(ctx, connect.NewRequest(validStartRequestBuilder()))
 	require.NoError(t, err)
@@ -480,12 +473,12 @@ func TestHandler_StartCurtailment_InsufficientLoadSurfacesAsInvalidArgument(t *t
 	}
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
 		OrganizationID: 1,
 		UserID:         9,
 		Role:           "OPERATOR",
-	})
+	}, authz.PermCurtailmentManage)
 
 	req := validStartRequestBuilder()
 	req.ModeParams = &pb.StartCurtailmentRequest_FixedKw{
@@ -531,12 +524,12 @@ func TestHandler_StartCurtailment_OverrideRoleGateBlocksNonAdmin(t *testing.T) {
 	}
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
 		OrganizationID: 1,
 		UserID:         9,
 		Role:           "VIEWER",
-	})
+	}, authz.PermCurtailmentManage)
 
 	req := validStartRequestBuilder()
 	req.CandidateMinPowerWOverride = ptr(uint32(800))
@@ -563,13 +556,13 @@ func TestHandler_StartCurtailment_ZeroMaxDurationUsesOrgDefault(t *testing.T) {
 	}
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
 		OrganizationID: 1,
 		UserID:         9,
 		Role:           "OPERATOR",
 		SessionID:      "sess-zero-dur",
-	})
+	}, authz.PermCurtailmentManage)
 
 	req := validStartRequestBuilder()
 	req.MaxDurationSeconds = 0 // sentinel: use org default.
@@ -592,12 +585,12 @@ func TestHandler_StartCurtailment_AllowUnboundedAdminPersistsNullDuration(t *tes
 	}
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
 		OrganizationID: 1,
 		UserID:         9,
 		Role:           "ADMIN",
-	})
+	}, authz.PermCurtailmentManage)
 
 	req := validStartRequestBuilder()
 	req.MaxDurationSeconds = 0
@@ -622,12 +615,12 @@ func TestHandler_StartCurtailment_RejectsAllowUnboundedWithMaxDuration(t *testin
 	}
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
 		OrganizationID: 1,
 		UserID:         9,
 		Role:           "ADMIN",
-	})
+	}, authz.PermCurtailmentManage)
 
 	req := validStartRequestBuilder()
 	req.AllowUnbounded = true
@@ -665,13 +658,13 @@ func TestHandler_StartCurtailment_RejectsUint32Overflow(t *testing.T) {
 			t.Parallel()
 			store := newStartStubStore()
 			h := NewHandler(curtailment.NewService(store))
-			ctx := authn.SetInfo(t.Context(), &session.Info{
+			ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 				AuthMethod:     session.AuthMethodSession,
 				OrganizationID: 1,
 				UserID:         9,
 				Role:           "OPERATOR",
 				SessionID:      "sess",
-			})
+			}, authz.PermCurtailmentManage)
 
 			req := validStartRequestBuilder()
 			tc.mut(req)
@@ -695,12 +688,12 @@ func TestHandler_StartCurtailment_OutcomeMirrorsInsufficientLoadShapeOnZeroPool(
 	store.candidates = nil
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
+	ctx := startSessionInfoCtxWithPerms(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
 		OrganizationID: 1,
 		UserID:         9,
 		Role:           "OPERATOR",
-	})
+	}, authz.PermCurtailmentManage)
 
 	_, err := h.StartCurtailment(ctx, connect.NewRequest(validStartRequestBuilder()))
 	require.Error(t, err)

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -13,12 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/curtailment/v1"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/modes"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // startStubStore implements interfaces.CurtailmentStore for handler-level
@@ -191,6 +193,22 @@ func validStartRequestBuilder() *pb.StartCurtailmentRequest {
 	}
 }
 
+func startSessionCtxWithPerms(t *testing.T, orgID int64, role string, perms ...string) context.Context {
+	t.Helper()
+	ctx := authn.SetInfo(t.Context(), &session.Info{
+		AuthMethod:     session.AuthMethodSession,
+		OrganizationID: orgID,
+		UserID:         9,
+		Role:           role,
+		SessionID:      "sess-start-perms",
+	})
+	return middleware.WithEffectivePermissions(ctx, authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  perms,
+	}}))
+}
+
 // TestHandler_StartCurtailment_HappyPath: with a stubbed service, a valid
 // session, and ample candidates, Start returns the populated event with
 // EventUuid set and pending targets echoed back.
@@ -245,6 +263,119 @@ func TestHandler_StartCurtailment_HappyPath(t *testing.T) {
 	// echoed in the Start response. Two selected candidates with no caller
 	// preference clamps to the minimum floor (10).
 	assert.Equal(t, uint32(10), ev.EffectiveBatchSize)
+}
+
+func TestHandler_StartCurtailment_FullFleetWholeOrgRequiresCurtailmentManage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		permissions []string
+		wantCode    connect.Code
+		wantPersist bool
+	}{
+		{
+			name:        "caller without curtailment manage is rejected",
+			permissions: []string{authz.PermCurtailmentRead},
+			wantCode:    connect.CodePermissionDenied,
+		},
+		{
+			name:        "empty permissions set is rejected",
+			permissions: nil,
+			wantCode:    connect.CodePermissionDenied,
+		},
+		{
+			name:        "caller with curtailment manage can start whole org full fleet",
+			permissions: []string{authz.PermCurtailmentManage},
+			wantPersist: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newStartStubStore()
+			store.candidates = []*models.Candidate{
+				miner("eligible", "ACTIVE", "PAIRED", 6000, 100, 40),
+			}
+			h := NewHandler(curtailment.NewService(store))
+
+			req := validStartRequestBuilder()
+			req.Mode = pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET
+			req.ModeParams = nil
+
+			_, err := h.StartCurtailment(
+				startSessionCtxWithPerms(t, 1, "OPERATOR", tc.permissions...),
+				connect.NewRequest(req),
+			)
+
+			if tc.wantPersist {
+				require.NoError(t, err)
+				assert.Equal(t, models.ModeFullFleet, store.lastEvent.Mode)
+				assert.Len(t, store.lastTargets, 1)
+				return
+			}
+
+			require.Error(t, err)
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr)
+			assert.Equal(t, tc.wantCode, fleetErr.GRPCCode)
+			assert.Zero(t, store.lastEvent.OrgID, "permission gate must fail before persistence")
+			assert.Empty(t, store.lastTargets, "permission gate must fail before target selection persists")
+		})
+	}
+}
+
+func TestHandler_StartCurtailment_LowerBlastStartsDoNotRequireCurtailmentManage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		mutateReq func(*pb.StartCurtailmentRequest)
+		wantMode  models.Mode
+	}{
+		{
+			name:     "fixed kw whole org",
+			wantMode: models.ModeFixedKw,
+		},
+		{
+			name: "full fleet explicit device list",
+			mutateReq: func(req *pb.StartCurtailmentRequest) {
+				req.Scope = &pb.StartCurtailmentRequest_DeviceIdentifiers{
+					DeviceIdentifiers: &pb.ScopeDeviceList{DeviceIdentifiers: []string{"eligible"}},
+				}
+				req.Mode = pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET
+				req.ModeParams = nil
+			},
+			wantMode: models.ModeFullFleet,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newStartStubStore()
+			store.candidates = []*models.Candidate{
+				miner("eligible", "ACTIVE", "PAIRED", 6000, 100, 40),
+			}
+			h := NewHandler(curtailment.NewService(store))
+
+			req := validStartRequestBuilder()
+			if tc.mutateReq != nil {
+				tc.mutateReq(req)
+			}
+
+			_, err := h.StartCurtailment(
+				startSessionCtxWithPerms(t, 1, "OPERATOR", authz.PermCurtailmentRead),
+				connect.NewRequest(req),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMode, store.lastEvent.Mode)
+			assert.Len(t, store.lastTargets, 1)
+		})
+	}
 }
 
 func TestHandler_StartCurtailment_IdempotentReplayRendersPersistedEvent(t *testing.T) {

--- a/server/internal/handlers/curtailment/handler_stop_test.go
+++ b/server/internal/handlers/curtailment/handler_stop_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/curtailment/v1"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
 // stopStubStore is a focused fake for Stop handler tests. Only the methods
@@ -147,18 +149,28 @@ func newStopStubStore() *stopStubStore {
 	}
 }
 
+func stopSessionCtxWithPerms(t *testing.T, orgID int64, role string, perms ...string) context.Context {
+	t.Helper()
+	ctx := authn.SetInfo(t.Context(), &session.Info{
+		AuthMethod:     session.AuthMethodSession,
+		OrganizationID: orgID,
+		UserID:         9,
+		Role:           role,
+	})
+	return middleware.WithEffectivePermissions(ctx, authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  perms,
+	}}))
+}
+
 func TestHandler_StopCurtailment_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	store := newStopStubStore()
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
-		AuthMethod:     session.AuthMethodSession,
-		OrganizationID: 42,
-		UserID:         9,
-		Role:           "OPERATOR",
-	})
+	ctx := stopSessionCtxWithPerms(t, 42, "OPERATOR", authz.PermCurtailmentManage)
 
 	resp, err := h.StopCurtailment(ctx, connect.NewRequest(&pb.StopCurtailmentRequest{
 		EventUuid: store.event.EventUUID.String(),
@@ -173,6 +185,35 @@ func TestHandler_StopCurtailment_HappyPath(t *testing.T) {
 	assert.Equal(t, int32(2), resp.Msg.Event.TargetRollup.Pending)
 	assert.Equal(t, int32(2), resp.Msg.Event.TargetRollup.Total)
 	assert.Equal(t, 1, store.beginRestoreCalls)
+}
+
+func TestHandler_StopCurtailment_RequiresCurtailmentManage(t *testing.T) {
+	t.Parallel()
+	store := newStopStubStore()
+	h := NewHandler(curtailment.NewService(store))
+
+	for _, tc := range []struct {
+		name        string
+		permissions []string
+	}{
+		{"caller without curtailment:manage is rejected", []string{authz.PermCurtailmentRead}},
+		{"empty permissions set is rejected", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := h.StopCurtailment(
+				stopSessionCtxWithPerms(t, 42, "OPERATOR", tc.permissions...),
+				connect.NewRequest(&pb.StopCurtailmentRequest{EventUuid: store.event.EventUUID.String()}),
+			)
+
+			require.Error(t, err)
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr)
+			assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+			assert.Equal(t, 0, store.beginRestoreCalls)
+		})
+	}
 }
 
 func TestHandler_StopCurtailment_RejectsMissingSession(t *testing.T) {
@@ -195,12 +236,7 @@ func TestHandler_StopCurtailment_RejectsMalformedUUID(t *testing.T) {
 	store := newStopStubStore()
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
-		AuthMethod:     session.AuthMethodSession,
-		OrganizationID: 42,
-		UserID:         9,
-		Role:           "OPERATOR",
-	})
+	ctx := stopSessionCtxWithPerms(t, 42, "OPERATOR", authz.PermCurtailmentManage)
 
 	_, err := h.StopCurtailment(ctx, connect.NewRequest(&pb.StopCurtailmentRequest{
 		EventUuid: "not-a-uuid",
@@ -216,12 +252,7 @@ func TestHandler_StopCurtailment_ForceRequiresAdmin(t *testing.T) {
 	store := newStopStubStore()
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
-		AuthMethod:     session.AuthMethodSession,
-		OrganizationID: 42,
-		UserID:         9,
-		Role:           "OPERATOR", // non-Admin
-	})
+	ctx := stopSessionCtxWithPerms(t, 42, "OPERATOR" /* non-Admin */, authz.PermCurtailmentManage)
 
 	_, err := h.StopCurtailment(ctx, connect.NewRequest(&pb.StopCurtailmentRequest{
 		EventUuid: store.event.EventUUID.String(),
@@ -243,12 +274,7 @@ func TestHandler_StopCurtailment_AdminForcePassesThrough(t *testing.T) {
 	store.event.StartedAt = &startedAt
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
-		AuthMethod:     session.AuthMethodSession,
-		OrganizationID: 42,
-		UserID:         9,
-		Role:           "ADMIN",
-	})
+	ctx := stopSessionCtxWithPerms(t, 42, "ADMIN", authz.PermCurtailmentManage)
 
 	_, err := h.StopCurtailment(ctx, connect.NewRequest(&pb.StopCurtailmentRequest{
 		EventUuid: store.event.EventUUID.String(),
@@ -269,12 +295,7 @@ func TestHandler_StopCurtailment_ListTargetsErrorPropagates(t *testing.T) {
 	store.listTargetsErr = errors.New("simulated targets read failure")
 	h := NewHandler(curtailment.NewService(store))
 
-	ctx := authn.SetInfo(t.Context(), &session.Info{
-		AuthMethod:     session.AuthMethodSession,
-		OrganizationID: 42,
-		UserID:         9,
-		Role:           "OPERATOR",
-	})
+	ctx := stopSessionCtxWithPerms(t, 42, "OPERATOR", authz.PermCurtailmentManage)
 
 	resp, err := h.StopCurtailment(ctx, connect.NewRequest(&pb.StopCurtailmentRequest{
 		EventUuid: store.event.EventUUID.String(),

--- a/server/internal/handlers/curtailment/handler_test.go
+++ b/server/internal/handlers/curtailment/handler_test.go
@@ -22,11 +22,10 @@ import (
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
 
-// Non-admin-gated routes are wired and return CodeUnimplemented when
-// called without override fields. AdminTerminateEvent's Unimplemented body
-// is covered by TestHandler_AdminTerminateEventPermissionGate (admin/super-admin
-// subcases), since its admin-role gate fires before the body.
-func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
+// Stubbed routes are wired. Ungated/read routes reach CodeUnimplemented
+// when service=nil; permission-gated routes can fail earlier when the
+// request lacks authentication.
+func TestHandler_StubbedRPCsReturnExpectedAuthOrUnimplemented(t *testing.T) {
 	t.Parallel()
 
 	mux := http.NewServeMux()
@@ -40,8 +39,9 @@ func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 	client := curtailmentv1connect.NewCurtailmentServiceClient(http.DefaultClient, server.URL)
 
 	cases := []struct {
-		name string
-		call func() error
+		name     string
+		call     func() error
+		wantCode connect.Code
 	}{
 		{
 			"PreviewCurtailmentPlan",
@@ -49,6 +49,7 @@ func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 				_, err := client.PreviewCurtailmentPlan(t.Context(), connect.NewRequest(&pb.PreviewCurtailmentPlanRequest{}))
 				return err
 			},
+			connect.CodeUnauthenticated,
 		},
 		{
 			"StartCurtailment",
@@ -56,6 +57,7 @@ func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 				_, err := client.StartCurtailment(t.Context(), connect.NewRequest(&pb.StartCurtailmentRequest{}))
 				return err
 			},
+			connect.CodeUnauthenticated,
 		},
 		{
 			"UpdateCurtailmentEvent",
@@ -63,6 +65,7 @@ func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 				_, err := client.UpdateCurtailmentEvent(t.Context(), connect.NewRequest(&pb.UpdateCurtailmentEventRequest{}))
 				return err
 			},
+			connect.CodeUnimplemented,
 		},
 		{
 			"StopCurtailment",
@@ -70,6 +73,7 @@ func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 				_, err := client.StopCurtailment(t.Context(), connect.NewRequest(&pb.StopCurtailmentRequest{}))
 				return err
 			},
+			connect.CodeUnauthenticated,
 		},
 		{
 			"GetActiveCurtailment",
@@ -77,6 +81,7 @@ func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 				_, err := client.GetActiveCurtailment(t.Context(), connect.NewRequest(&pb.GetActiveCurtailmentRequest{}))
 				return err
 			},
+			connect.CodeUnimplemented,
 		},
 		{
 			"ListCurtailmentEvents",
@@ -84,6 +89,7 @@ func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 				_, err := client.ListCurtailmentEvents(t.Context(), connect.NewRequest(&pb.ListCurtailmentEventsRequest{}))
 				return err
 			},
+			connect.CodeUnimplemented,
 		},
 		{
 			"ListActiveCurtailments",
@@ -91,6 +97,7 @@ func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 				_, err := client.ListActiveCurtailments(t.Context(), connect.NewRequest(&pb.ListActiveCurtailmentsRequest{}))
 				return err
 			},
+			connect.CodeUnimplemented,
 		},
 	}
 
@@ -101,7 +108,7 @@ func TestHandler_NonAdminRPCsReturnUnimplemented(t *testing.T) {
 			require.Error(t, err)
 			var connectErr *connect.Error
 			require.ErrorAs(t, err, &connectErr, "expected connect.Error, got %T", err)
-			assert.Equal(t, connect.CodeUnimplemented, connectErr.Code())
+			assert.Equal(t, tc.wantCode, connectErr.Code())
 		})
 	}
 }
@@ -122,7 +129,7 @@ func TestHandler_RequestValidation(t *testing.T) {
 		require.Error(t, err)
 		var connectErr *connect.Error
 		require.ErrorAs(t, err, &connectErr)
-		assert.Equal(t, connect.CodeUnimplemented, connectErr.Code())
+		assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
 	})
 
 	t.Run("Preview rejects HIGH", func(t *testing.T) {
@@ -181,7 +188,7 @@ func TestHandler_RequestValidation(t *testing.T) {
 		require.Error(t, err)
 		var connectErr *connect.Error
 		require.ErrorAs(t, err, &connectErr)
-		assert.Equal(t, connect.CodeUnimplemented, connectErr.Code())
+		assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
 	})
 
 	t.Run("Start rejects HIGH", func(t *testing.T) {
@@ -513,6 +520,11 @@ func TestHandler_OverrideFieldsRoleGate(t *testing.T) {
 				Role:       tc.role,
 				AuthMethod: tc.authMethod,
 			})
+			ctx = middleware.WithEffectivePermissions(ctx, authz.NewEffectivePermissions([]authz.Assignment{{
+				AssignmentID: 1,
+				ScopeType:    authz.ScopeOrg,
+				Permissions:  []string{authz.PermCurtailmentManage},
+			}}))
 
 			err := tc.invoke(ctx)
 
@@ -524,37 +536,75 @@ func TestHandler_OverrideFieldsRoleGate(t *testing.T) {
 	}
 }
 
-// Without an override field, Preview/Start/Stop skip the role gate and
-// reach Unimplemented — preserves API-key-accessible reads.
-func TestHandler_NoOverrideSkipsRoleGate(t *testing.T) {
+// Preview/Start/Stop require curtailment:manage even when no legacy
+// admin-only override field is set.
+func TestHandler_PublicPlanStartStopRequireCurtailmentManage(t *testing.T) {
 	t.Parallel()
 
 	h := NewHandler(nil)
 
-	previewNoOverride := connect.NewRequest(&pb.PreviewCurtailmentPlanRequest{
-		Scope: &pb.PreviewCurtailmentPlanRequest_WholeOrg{WholeOrg: &pb.ScopeWholeOrg{}},
-		Mode:  pb.CurtailmentMode_CURTAILMENT_MODE_FIXED_KW,
-		ModeParams: &pb.PreviewCurtailmentPlanRequest_FixedKw{
-			FixedKw: &pb.FixedKwParams{TargetKw: 50},
+	cases := []struct {
+		name   string
+		invoke func(context.Context) error
+	}{
+		{
+			name: "PreviewCurtailmentPlan",
+			invoke: func(ctx context.Context) error {
+				_, err := h.PreviewCurtailmentPlan(ctx, connect.NewRequest(&pb.PreviewCurtailmentPlanRequest{
+					Scope: &pb.PreviewCurtailmentPlanRequest_WholeOrg{WholeOrg: &pb.ScopeWholeOrg{}},
+					Mode:  pb.CurtailmentMode_CURTAILMENT_MODE_FIXED_KW,
+					ModeParams: &pb.PreviewCurtailmentPlanRequest_FixedKw{
+						FixedKw: &pb.FixedKwParams{TargetKw: 50},
+					},
+				}))
+				return err
+			},
 		},
-	})
-	stopNoOverride := connect.NewRequest(&pb.StopCurtailmentRequest{
-		EventUuid: "00000000-0000-0000-0000-000000000001",
-	})
+		{
+			name: "StartCurtailment",
+			invoke: func(ctx context.Context) error {
+				_, err := h.StartCurtailment(ctx, connect.NewRequest(validStartCurtailmentRequest(pb.CurtailmentPriority_CURTAILMENT_PRIORITY_NORMAL)))
+				return err
+			},
+		},
+		{
+			name: "StopCurtailment",
+			invoke: func(ctx context.Context) error {
+				_, err := h.StopCurtailment(ctx, connect.NewRequest(&pb.StopCurtailmentRequest{
+					EventUuid: "00000000-0000-0000-0000-000000000001",
+				}))
+				return err
+			},
+		},
+	}
 
-	// No session info in context — would fail role gate if invoked. The fact
-	// that these reach Unimplemented proves the gate is skipped when no
-	// override field is set.
-	_, err := h.PreviewCurtailmentPlan(t.Context(), previewNoOverride)
-	require.Error(t, err)
-	var fleetErr fleeterror.FleetError
-	require.ErrorAs(t, err, &fleetErr)
-	assert.Equal(t, connect.CodeUnimplemented, fleetErr.GRPCCode, "Preview without override must skip role gate")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err = h.StopCurtailment(t.Context(), stopNoOverride)
-	require.Error(t, err)
-	require.ErrorAs(t, err, &fleetErr)
-	assert.Equal(t, connect.CodeUnimplemented, fleetErr.GRPCCode, "Stop without override must skip role gate")
+			base := authn.SetInfo(t.Context(), &session.Info{})
+			withoutManage := middleware.WithEffectivePermissions(base, authz.NewEffectivePermissions([]authz.Assignment{{
+				AssignmentID: 1,
+				ScopeType:    authz.ScopeOrg,
+				Permissions:  []string{authz.PermCurtailmentRead},
+			}}))
+			err := tc.invoke(withoutManage)
+			require.Error(t, err)
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr)
+			assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+
+			withManage := middleware.WithEffectivePermissions(base, authz.NewEffectivePermissions([]authz.Assignment{{
+				AssignmentID: 1,
+				ScopeType:    authz.ScopeOrg,
+				Permissions:  []string{authz.PermCurtailmentManage},
+			}}))
+			err = tc.invoke(withManage)
+			require.Error(t, err)
+			require.ErrorAs(t, err, &fleetErr)
+			assert.Equal(t, connect.CodeUnimplemented, fleetErr.GRPCCode)
+		})
+	}
 }
 
 // AdminTerminateEvent rejects a request with no session info in context.

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -104,12 +104,15 @@ var ProcedurePermissions = map[string]string{
 	// entry is the primary gate (site:read = "can see this building").
 	buildingsv1connect.BuildingServiceGetBuildingStatsProcedure: authz.PermSiteRead,
 
-	// CurtailmentService — reads + AdminTerminateEvent + UpdateCurtailmentEvent
-	// + IngestCurtailmentSignal. Start/Stop/Preview retain conditional inline
-	// gates pending the broader curtailment authz redesign.
+	// CurtailmentService — reads use curtailment:read; user-facing preview
+	// and mutation flows use curtailment:manage; external signal ingest uses
+	// curtailment:ingest.
 	curtailmentv1connect.CurtailmentServiceListCurtailmentEventsProcedure:   authz.PermCurtailmentRead,
 	curtailmentv1connect.CurtailmentServiceGetActiveCurtailmentProcedure:    authz.PermCurtailmentRead,
 	curtailmentv1connect.CurtailmentServiceListActiveCurtailmentsProcedure:  authz.PermCurtailmentRead,
+	curtailmentv1connect.CurtailmentServicePreviewCurtailmentPlanProcedure:  authz.PermCurtailmentManage,
+	curtailmentv1connect.CurtailmentServiceStartCurtailmentProcedure:        authz.PermCurtailmentManage,
+	curtailmentv1connect.CurtailmentServiceStopCurtailmentProcedure:         authz.PermCurtailmentManage,
 	curtailmentv1connect.CurtailmentServiceUpdateCurtailmentEventProcedure:  authz.PermCurtailmentManage,
 	curtailmentv1connect.CurtailmentServiceAdminTerminateEventProcedure:     authz.PermCurtailmentManage,
 	curtailmentv1connect.CurtailmentServiceIngestCurtailmentSignalProcedure: authz.PermCurtailmentIngest,
@@ -293,16 +296,6 @@ var ProceduresPendingMigration = map[string]string{
 	authv1connect.AuthServiceUpdateUsernameProcedure:    "authenticated self-write, no role check",
 	authv1connect.AuthServiceVerifyCredentialsProcedure: "authenticated self-read, no role check",
 	authv1connect.AuthServiceLogoutProcedure:            "session-only; FailedPrecondition guard in handler",
-
-	// CurtailmentService — Start gates conditionally on high-blast
-	// FULL_FLEET whole-org starts and override fields; Stop/Preview
-	// gate conditionally on force/override fields. Lower-blast start
-	// paths remain authenticated-only pending the curtailment authz
-	// redesign that swaps these to RequirePermission with the right
-	// resource context.
-	curtailmentv1connect.CurtailmentServiceStartCurtailmentProcedure:       "CONDITIONAL: curtailment:manage for FULL_FLEET whole_org; requireAdminFromContext when CandidateMinPowerWOverride set, AllowUnbounded, or ForceIncludeMaintenance; otherwise any authenticated user can start",
-	curtailmentv1connect.CurtailmentServiceStopCurtailmentProcedure:        "CONDITIONAL: requireAdminFromContext only when force=true; non-force stop is ungated",
-	curtailmentv1connect.CurtailmentServicePreviewCurtailmentPlanProcedure: "CONDITIONAL: requireAdminFromContext only when CandidateMinPowerWOverride set; otherwise ungated",
 
 	// AuthzService — assignment trio is not implemented yet. The Roles
 	// management surface (Settings → Roles) does not need these; they

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -294,11 +294,13 @@ var ProceduresPendingMigration = map[string]string{
 	authv1connect.AuthServiceVerifyCredentialsProcedure: "authenticated self-read, no role check",
 	authv1connect.AuthServiceLogoutProcedure:            "session-only; FailedPrecondition guard in handler",
 
-	// CurtailmentService — Start/Stop/Preview gate conditionally on
-	// override fields / force; the unconditional codepath remains
-	// ungated. Pending the curtailment authz redesign that swaps these
-	// to RequirePermission with the right resource context.
-	curtailmentv1connect.CurtailmentServiceStartCurtailmentProcedure:       "CONDITIONAL: requireAdminFromContext only when CandidateMinPowerWOverride set or AllowUnbounded; otherwise any authenticated user can start",
+	// CurtailmentService — Start gates conditionally on high-blast
+	// FULL_FLEET whole-org starts and override fields; Stop/Preview
+	// gate conditionally on force/override fields. Lower-blast start
+	// paths remain authenticated-only pending the curtailment authz
+	// redesign that swaps these to RequirePermission with the right
+	// resource context.
+	curtailmentv1connect.CurtailmentServiceStartCurtailmentProcedure:       "CONDITIONAL: curtailment:manage for FULL_FLEET whole_org; requireAdminFromContext when CandidateMinPowerWOverride set, AllowUnbounded, or ForceIncludeMaintenance; otherwise any authenticated user can start",
 	curtailmentv1connect.CurtailmentServiceStopCurtailmentProcedure:        "CONDITIONAL: requireAdminFromContext only when force=true; non-force stop is ungated",
 	curtailmentv1connect.CurtailmentServicePreviewCurtailmentPlanProcedure: "CONDITIONAL: requireAdminFromContext only when CandidateMinPowerWOverride set; otherwise ungated",
 


### PR DESCRIPTION
## Summary

- Require org-scoped `curtailment:manage` for public `PreviewCurtailmentPlan`, `StartCurtailment`, and `StopCurtailment` calls.
- Remove the high-blast-only exception: fixed-kW whole-org starts and full-fleet explicit device-list starts now require `curtailment:manage` too.
- Move Preview/Start/Stop from `ProceduresPendingMigration` into the RPC permission inventory and update handler coverage for denied/allowed paths.
- Preserve the existing Admin/SuperAdmin-only override checks for safety-critical controls such as candidate-min-power overrides, unbounded starts, maintenance inclusion, and forced stop.

## Why

Preview, start, and stop are user-facing operational curtailment controls. Gating all three with `curtailment:manage` gives the frontend a simple and conservative authorization boundary before exposing manual full-fleet controls, while leaving trusted MQTT and in-process service dispatch unaffected because those paths do not go through these public Connect handler gates.

## PR Coordination

- This PR has no schema migration and can merge independently of #406, #407, and #409.
- #409 adds MQTT source settings RPCs and gates those settings RPCs with the same org-scoped `curtailment:manage` rule. If this PR lands first, #409 should only need a small permission-map rebase.
- #407 and #409 MQTT dispatch behavior is unchanged by this PR because MQTT ingest uses the in-process driver/service path, not public Preview/Start/Stop handlers.
- #380 manual FULL_FLEET UI should wait for this PR and #407 so the UI has both the authorization boundary and all-skipped FULL_FLEET safety behavior.

## Validation

- `go test -count=1 ./server/internal/handlers/curtailment ./server/internal/handlers/middleware`
- `go test -count=1 ./server/internal/domain/curtailment ./server/internal/domain/curtailment/mqttingest ./server/internal/handlers/curtailment ./server/internal/handlers/middleware`
- `git diff --check`
- Pre-push `server-lint`

Closes #392
