### PR TITLE
Curtailment: Add MQTT curtailment simulator devtool

### DIFF
--- a/justfile
+++ b/justfile
@@ -147,6 +147,26 @@ test-e2e-protoos-headed: (_e2e "protoOS" "--headed" "--project=desktop")
 # run ProtoOS WIP E2E tests
 test-e2e-protoos-wip: (_e2e "protoOS" "--headed" "--grep" "@wip" "--project=desktop")
 
+# start MQTT simulator brokers and browser control UI
+[working-directory: 'server']
+mqtt-sim-up:
+  just mqtt-sim-up
+
+# rebuild and restart MQTT simulator services
+[working-directory: 'server']
+mqtt-sim-rebuild:
+  just mqtt-sim-rebuild
+
+# stop MQTT simulator services
+[working-directory: 'server']
+mqtt-sim-down:
+  just mqtt-sim-down
+
+# follow MQTT simulator logs
+[working-directory: 'server']
+mqtt-sim-logs:
+  just mqtt-sim-logs
+
 # --- Dependency management ---
 
 # update all Go dependencies across workspace

--- a/server/devtools/mqttsim/Dockerfile
+++ b/server/devtools/mqttsim/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.25-alpine AS build
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY devtools/mqttsim ./devtools/mqttsim
+RUN go build -o /out/mqttsim ./devtools/mqttsim
+
+FROM alpine:3.22
+
+COPY --from=build /out/mqttsim /usr/local/bin/mqttsim
+
+EXPOSE 4183
+ENTRYPOINT ["mqttsim"]

--- a/server/devtools/mqttsim/README.md
+++ b/server/devtools/mqttsim/README.md
@@ -3,6 +3,11 @@
 This devtool runs two local Mosquitto brokers and a small browser UI for
 publishing MaestroOS-style curtailment targets.
 
+The Docker Compose ports are bound to host loopback only. The brokers are still
+reachable from other Docker Compose services on `fleet-network` through their
+static container IPs, but they are not exposed to other machines on the LAN by
+default.
+
 From the repository root:
 
 ```sh

--- a/server/devtools/mqttsim/README.md
+++ b/server/devtools/mqttsim/README.md
@@ -1,0 +1,58 @@
+# MQTT Curtailment Simulator
+
+This devtool runs two local Mosquitto brokers and a small browser UI for
+publishing MaestroOS-style curtailment targets.
+
+From the repository root:
+
+```sh
+just mqtt-sim-up
+```
+
+Then open:
+
+```text
+http://localhost:4183
+```
+
+Use this source configuration when `fleet-api` is running in Docker Compose:
+
+| Field | Value |
+| --- | --- |
+| Primary broker host | `192.168.2.240` |
+| Secondary broker host | `192.168.2.241` |
+| Broker port | `1883` |
+| Broker transport | `tcp` |
+| Topic | `maestro/target` |
+| Payload format | `target_timestamp` |
+| MQTT username | `proto-fleet` |
+| MQTT password | `proto-fleet` |
+
+The local Mosquitto brokers allow anonymous connections. Proto Fleet source
+settings still require non-empty credentials, so the simulator UI and this table
+use stable development-only placeholder values.
+
+The simulator header links to the Proto Fleet curtailment settings page. Override
+the destination without editing code when your frontend runs somewhere else:
+
+```sh
+PROTO_FLEET_BASE_URL=http://localhost:5174 just mqtt-sim-up
+```
+
+The simulator publishes this payload shape:
+
+```json
+{"target":100,"timestamp":1778538975}
+```
+
+`target: 100` means ON/full power. `target: 0` means OFF/curtail. The loop mode
+publishes the selected target every 30 seconds by default to match the MaestroOS
+API notes.
+
+Useful commands:
+
+```sh
+just mqtt-sim-up
+just mqtt-sim-logs
+just mqtt-sim-down
+```

--- a/server/devtools/mqttsim/main.go
+++ b/server/devtools/mqttsim/main.go
@@ -329,6 +329,7 @@ func (a *app) handleLoopStart(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("select at least one broker"))
 		return
 	}
+	a.stopLoopIfRunning("stopped previous loop")
 	if err := a.publishOnce(r.Context(), opts); err != nil {
 		writeError(w, http.StatusBadGateway, err)
 		return
@@ -336,9 +337,6 @@ func (a *app) handleLoopStart(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	a.mu.Lock()
-	if a.cancel != nil {
-		a.cancel()
-	}
 	a.cancel = cancel
 	a.state.Running = true
 	a.state.Target = target
@@ -403,12 +401,27 @@ func (a *app) runLoop(ctx context.Context, interval time.Duration, opts publishO
 func (a *app) stopLoop(message string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.cancel != nil {
-		a.cancel()
-		a.cancel = nil
+	if a.stopLoopLocked() {
+		a.addLogLocked("info", message)
 	}
+}
+
+func (a *app) stopLoopIfRunning(message string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.stopLoopLocked() {
+		a.addLogLocked("info", message)
+	}
+}
+
+func (a *app) stopLoopLocked() bool {
+	if a.cancel == nil {
+		return false
+	}
+	a.cancel()
+	a.cancel = nil
 	a.state.Running = false
-	a.addLogLocked("info", message)
+	return true
 }
 
 type publishOptions struct {

--- a/server/devtools/mqttsim/main.go
+++ b/server/devtools/mqttsim/main.go
@@ -1,0 +1,617 @@
+// mqttsim provides a small web UI for driving MaestroOS-style MQTT
+// curtailment signals during local development.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+)
+
+const (
+	defaultHTTPAddr     = ":4183"
+	defaultTopic        = "maestro/target"
+	defaultInterval     = 30 * time.Second
+	defaultSettingsPath = "/settings/curtailment"
+	qosAtLeastOnce      = 1
+	wireTargetOff       = 0
+	wireTargetOn        = 100
+	maxLogEntries       = 100
+	maxPayloadBytes     = 1024
+)
+
+type broker struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type config struct {
+	httpAddr        string
+	defaultTopic    string
+	defaultInterval time.Duration
+	brokers         []broker
+	links           simulatorLinks
+}
+
+type simulatorLinks struct {
+	CurtailmentSettingsURL string `json:"curtailment_settings_url,omitempty"`
+}
+
+type app struct {
+	mu     sync.Mutex
+	cfg    config
+	state  simulatorState
+	logs   []logEntry
+	cancel context.CancelFunc
+}
+
+type simulatorState struct {
+	Running           bool      `json:"running"`
+	Target            string    `json:"target"`
+	Topic             string    `json:"topic"`
+	IntervalSeconds   int       `json:"interval_seconds"`
+	Retain            bool      `json:"retain"`
+	PrimaryEnabled    bool      `json:"primary_enabled"`
+	SecondaryEnabled  bool      `json:"secondary_enabled"`
+	TimestampOffset   int       `json:"timestamp_offset_seconds"`
+	LastPublishedAt   time.Time `json:"last_published_at,omitempty"`
+	LastPayload       string    `json:"last_payload,omitempty"`
+	LastError         string    `json:"last_error,omitempty"`
+	PublishedMessages int64     `json:"published_messages"`
+}
+
+type logEntry struct {
+	Time    time.Time `json:"time"`
+	Level   string    `json:"level"`
+	Message string    `json:"message"`
+}
+
+type statusResponse struct {
+	Brokers []broker       `json:"brokers"`
+	Links   simulatorLinks `json:"links,omitempty"`
+	State   simulatorState `json:"state"`
+	Logs    []logEntry     `json:"logs"`
+}
+
+type publishRequest struct {
+	Target                 string `json:"target"`
+	Topic                  string `json:"topic"`
+	Retain                 bool   `json:"retain"`
+	PrimaryEnabled         bool   `json:"primary_enabled"`
+	SecondaryEnabled       bool   `json:"secondary_enabled"`
+	TimestampOffsetSeconds int    `json:"timestamp_offset_seconds"`
+	CustomPayload          string `json:"custom_payload"`
+}
+
+type loopRequest struct {
+	Target                 string `json:"target"`
+	Topic                  string `json:"topic"`
+	IntervalSeconds        int    `json:"interval_seconds"`
+	Retain                 bool   `json:"retain"`
+	PrimaryEnabled         bool   `json:"primary_enabled"`
+	SecondaryEnabled       bool   `json:"secondary_enabled"`
+	TimestampOffsetSeconds int    `json:"timestamp_offset_seconds"`
+}
+
+type clearRequest struct {
+	Topic            string `json:"topic"`
+	PrimaryEnabled   bool   `json:"primary_enabled"`
+	SecondaryEnabled bool   `json:"secondary_enabled"`
+}
+
+func main() {
+	cfg, err := loadConfig()
+	if err != nil {
+		slog.Error("invalid mqtt simulator config", slog.Any("error", err))
+		os.Exit(1)
+	}
+	a := newApp(cfg)
+	mux := http.NewServeMux()
+	a.register(mux)
+
+	slog.Info("mqtt simulator starting",
+		slog.String("addr", cfg.httpAddr),
+		slog.String("topic", cfg.defaultTopic),
+		slog.Any("brokers", cfg.brokers))
+	server := &http.Server{
+		Addr:              cfg.httpAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil {
+		slog.Error("mqtt simulator stopped", slog.Any("error", err))
+		os.Exit(1)
+	}
+}
+
+func loadConfig() (config, error) {
+	cfg := config{
+		httpAddr:        envOrDefault("HTTP_ADDR", defaultHTTPAddr),
+		defaultTopic:    envOrDefault("MQTT_DEFAULT_TOPIC", defaultTopic),
+		defaultInterval: defaultInterval,
+		brokers: []broker{
+			{Name: "primary", URL: "tcp://127.0.0.1:1883"},
+			{Name: "secondary", URL: "tcp://127.0.0.1:1884"},
+		},
+	}
+	if raw := strings.TrimSpace(os.Getenv("MQTT_DEFAULT_INTERVAL")); raw != "" {
+		interval, err := time.ParseDuration(raw)
+		if err != nil {
+			return config{}, fmt.Errorf("parse MQTT_DEFAULT_INTERVAL: %w", err)
+		}
+		cfg.defaultInterval = interval
+	}
+	if raw := strings.TrimSpace(os.Getenv("MQTT_BROKERS")); raw != "" {
+		brokers, err := parseBrokers(raw)
+		if err != nil {
+			return config{}, err
+		}
+		cfg.brokers = brokers
+	}
+	settingsURL, err := buildCurtailmentSettingsURL(
+		strings.TrimSpace(os.Getenv("PROTO_FLEET_BASE_URL")),
+		envOrDefault("PROTO_FLEET_CURTAILMENT_SETTINGS_PATH", defaultSettingsPath),
+	)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.links.CurtailmentSettingsURL = settingsURL
+	if strings.TrimSpace(cfg.defaultTopic) == "" {
+		return config{}, errors.New("MQTT_DEFAULT_TOPIC is required")
+	}
+	if cfg.defaultInterval <= 0 {
+		return config{}, errors.New("MQTT_DEFAULT_INTERVAL must be positive")
+	}
+	if len(cfg.brokers) == 0 {
+		return config{}, errors.New("at least one MQTT broker is required")
+	}
+	return cfg, nil
+}
+
+func buildCurtailmentSettingsURL(baseURL, settingsPath string) (string, error) {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return "", nil
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse PROTO_FLEET_BASE_URL: %w", err)
+	}
+	if base.Scheme == "" || base.Host == "" {
+		return "", errors.New("PROTO_FLEET_BASE_URL must be an absolute URL")
+	}
+	settingsPath = strings.TrimSpace(settingsPath)
+	if settingsPath == "" {
+		settingsPath = defaultSettingsPath
+	}
+	if !strings.HasPrefix(settingsPath, "/") {
+		settingsPath = "/" + settingsPath
+	}
+	relative := &url.URL{Path: settingsPath}
+	return base.ResolveReference(relative).String(), nil
+}
+
+func parseBrokers(raw string) ([]broker, error) {
+	parts := strings.Split(raw, ",")
+	out := make([]broker, 0, len(parts))
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		name := fmt.Sprintf("broker-%d", i+1)
+		url := part
+		if before, after, ok := strings.Cut(part, "="); ok {
+			name = strings.TrimSpace(before)
+			url = strings.TrimSpace(after)
+		}
+		if name == "" || url == "" {
+			return nil, fmt.Errorf("invalid MQTT_BROKERS entry %q", part)
+		}
+		if !strings.HasPrefix(url, "tcp://") && !strings.HasPrefix(url, "ssl://") {
+			return nil, fmt.Errorf("broker %q URL must start with tcp:// or ssl://", name)
+		}
+		out = append(out, broker{Name: name, URL: url})
+	}
+	if len(out) == 0 {
+		return nil, errors.New("MQTT_BROKERS did not contain any brokers")
+	}
+	return out, nil
+}
+
+func envOrDefault(key, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func newApp(cfg config) *app {
+	return &app{
+		cfg: cfg,
+		state: simulatorState{
+			Target:           "ON",
+			Topic:            cfg.defaultTopic,
+			IntervalSeconds:  int(cfg.defaultInterval / time.Second),
+			Retain:           true,
+			PrimaryEnabled:   true,
+			SecondaryEnabled: true,
+		},
+	}
+}
+
+func (a *app) register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /", a.handleIndex)
+	mux.HandleFunc("GET /api/status", a.handleStatus)
+	mux.HandleFunc("POST /api/publish", a.handlePublish)
+	mux.HandleFunc("POST /api/loop/start", a.handleLoopStart)
+	mux.HandleFunc("POST /api/loop/stop", a.handleLoopStop)
+	mux.HandleFunc("POST /api/clear", a.handleClear)
+}
+
+func (a *app) handleIndex(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(indexHTML))
+}
+
+func (a *app) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	a.writeStatus(w)
+}
+
+func (a *app) handlePublish(w http.ResponseWriter, r *http.Request) {
+	var req publishRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	target, err := normalizeTarget(req.Target)
+	if err != nil && strings.TrimSpace(req.CustomPayload) == "" {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := a.publishOnce(r.Context(), publishOptions{
+		Target:                 target,
+		Topic:                  topicOrDefault(req.Topic, a.cfg.defaultTopic),
+		Retain:                 req.Retain,
+		PrimaryEnabled:         req.PrimaryEnabled,
+		SecondaryEnabled:       req.SecondaryEnabled,
+		TimestampOffsetSeconds: req.TimestampOffsetSeconds,
+		CustomPayload:          req.CustomPayload,
+	}); err != nil {
+		writeError(w, http.StatusBadGateway, err)
+		return
+	}
+	a.writeStatus(w)
+}
+
+func (a *app) handleLoopStart(w http.ResponseWriter, r *http.Request) {
+	var req loopRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	target, err := normalizeTarget(req.Target)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	interval := time.Duration(req.IntervalSeconds) * time.Second
+	if interval <= 0 {
+		writeError(w, http.StatusBadRequest, errors.New("interval_seconds must be positive"))
+		return
+	}
+	opts := publishOptions{
+		Target:                 target,
+		Topic:                  topicOrDefault(req.Topic, a.cfg.defaultTopic),
+		Retain:                 req.Retain,
+		PrimaryEnabled:         req.PrimaryEnabled,
+		SecondaryEnabled:       req.SecondaryEnabled,
+		TimestampOffsetSeconds: req.TimestampOffsetSeconds,
+	}
+	if len(a.selectedBrokers(opts.PrimaryEnabled, opts.SecondaryEnabled)) == 0 {
+		writeError(w, http.StatusBadRequest, errors.New("select at least one broker"))
+		return
+	}
+	if err := a.publishOnce(r.Context(), opts); err != nil {
+		writeError(w, http.StatusBadGateway, err)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a.mu.Lock()
+	if a.cancel != nil {
+		a.cancel()
+	}
+	a.cancel = cancel
+	a.state.Running = true
+	a.state.Target = target
+	a.state.Topic = opts.Topic
+	a.state.IntervalSeconds = req.IntervalSeconds
+	a.state.Retain = opts.Retain
+	a.state.PrimaryEnabled = opts.PrimaryEnabled
+	a.state.SecondaryEnabled = opts.SecondaryEnabled
+	a.state.TimestampOffset = opts.TimestampOffsetSeconds
+	a.state.LastError = ""
+	a.addLogLocked("info", fmt.Sprintf("started %s loop every %s", target, interval))
+	a.mu.Unlock()
+
+	go a.runLoop(ctx, interval, opts)
+	a.writeStatus(w)
+}
+
+func (a *app) handleLoopStop(w http.ResponseWriter, _ *http.Request) {
+	a.stopLoop("stopped loop")
+	a.writeStatus(w)
+}
+
+func (a *app) handleClear(w http.ResponseWriter, r *http.Request) {
+	var req clearRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	opts := publishOptions{
+		Topic:            topicOrDefault(req.Topic, a.cfg.defaultTopic),
+		Retain:           true,
+		PrimaryEnabled:   req.PrimaryEnabled,
+		SecondaryEnabled: req.SecondaryEnabled,
+		CustomPayload:    "",
+		ClearRetained:    true,
+	}
+	if err := a.publishOnce(r.Context(), opts); err != nil {
+		writeError(w, http.StatusBadGateway, err)
+		return
+	}
+	a.writeStatus(w)
+}
+
+func (a *app) runLoop(ctx context.Context, interval time.Duration, opts publishOptions) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := a.publishOnce(ctx, opts); err != nil {
+				a.mu.Lock()
+				a.state.LastError = err.Error()
+				a.addLogLocked("error", err.Error())
+				a.mu.Unlock()
+			}
+		}
+	}
+}
+
+func (a *app) stopLoop(message string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cancel != nil {
+		a.cancel()
+		a.cancel = nil
+	}
+	a.state.Running = false
+	a.addLogLocked("info", message)
+}
+
+type publishOptions struct {
+	Target                 string
+	Topic                  string
+	Retain                 bool
+	PrimaryEnabled         bool
+	SecondaryEnabled       bool
+	TimestampOffsetSeconds int
+	CustomPayload          string
+	ClearRetained          bool
+}
+
+func (a *app) publishOnce(ctx context.Context, opts publishOptions) error {
+	topic := topicOrDefault(opts.Topic, a.cfg.defaultTopic)
+	brokers := a.selectedBrokers(opts.PrimaryEnabled, opts.SecondaryEnabled)
+	if len(brokers) == 0 {
+		return errors.New("select at least one broker")
+	}
+	payload, err := buildPayload(opts)
+	if err != nil {
+		return err
+	}
+	for _, broker := range brokers {
+		if err := publishToBroker(ctx, broker, topic, opts.Retain || opts.ClearRetained, payload); err != nil {
+			return err
+		}
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.state.Target = opts.Target
+	a.state.Topic = topic
+	a.state.Retain = opts.Retain
+	a.state.PrimaryEnabled = opts.PrimaryEnabled
+	a.state.SecondaryEnabled = opts.SecondaryEnabled
+	a.state.TimestampOffset = opts.TimestampOffsetSeconds
+	a.state.LastError = ""
+	a.state.LastPayload = string(payload)
+	a.state.LastPublishedAt = time.Now().UTC()
+	a.state.PublishedMessages += int64(len(brokers))
+	action := "published"
+	if opts.ClearRetained {
+		action = "cleared retained"
+	}
+	a.addLogLocked("info", fmt.Sprintf("%s topic=%q brokers=%d payload=%s", action, topic, len(brokers), payload))
+	return nil
+}
+
+func buildPayload(opts publishOptions) ([]byte, error) {
+	if opts.ClearRetained {
+		return []byte{}, nil
+	}
+	if custom := strings.TrimSpace(opts.CustomPayload); custom != "" {
+		if len(custom) > maxPayloadBytes {
+			return nil, fmt.Errorf("custom payload exceeds %d bytes", maxPayloadBytes)
+		}
+		return []byte(custom), nil
+	}
+	target, err := normalizeTarget(opts.Target)
+	if err != nil {
+		return nil, err
+	}
+	wireTarget := wireTargetOn
+	if target == "OFF" {
+		wireTarget = wireTargetOff
+	}
+	body := struct {
+		Target    int   `json:"target"`
+		Timestamp int64 `json:"timestamp"`
+	}{
+		Target:    wireTarget,
+		Timestamp: time.Now().UTC().Add(time.Duration(opts.TimestampOffsetSeconds) * time.Second).Unix(),
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal target payload: %w", err)
+	}
+	return payload, nil
+}
+
+func publishToBroker(ctx context.Context, broker broker, topic string, retain bool, payload []byte) error {
+	clientID := "proto-fleet-mqttsim-" + randomHex(6)
+	opts := paho.NewClientOptions().
+		AddBroker(broker.URL).
+		SetClientID(clientID).
+		SetConnectTimeout(5 * time.Second).
+		SetWriteTimeout(5 * time.Second)
+	client := paho.NewClient(opts)
+	if err := waitToken(ctx, client.Connect(), 6*time.Second); err != nil {
+		return fmt.Errorf("connect broker %s (%s): %w", broker.Name, broker.URL, err)
+	}
+	defer client.Disconnect(250)
+	if err := waitToken(ctx, client.Publish(topic, qosAtLeastOnce, retain, payload), 6*time.Second); err != nil {
+		return fmt.Errorf("publish broker %s topic %q: %w", broker.Name, topic, err)
+	}
+	return nil
+}
+
+func waitToken(ctx context.Context, token paho.Token, timeout time.Duration) error {
+	done := make(chan struct{})
+	go func() {
+		token.Wait()
+		close(done)
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("context canceled while waiting for MQTT token: %w", ctx.Err())
+	case <-timer.C:
+		return fmt.Errorf("timed out after %s", timeout)
+	case <-done:
+		if err := token.Error(); err != nil {
+			return fmt.Errorf("MQTT token failed: %w", err)
+		}
+		return nil
+	}
+}
+
+func (a *app) selectedBrokers(primary, secondary bool) []broker {
+	out := make([]broker, 0, len(a.cfg.brokers))
+	for i, broker := range a.cfg.brokers {
+		switch {
+		case i == 0 && primary:
+			out = append(out, broker)
+		case i == 1 && secondary:
+			out = append(out, broker)
+		case i > 1:
+			out = append(out, broker)
+		}
+	}
+	return out
+}
+
+func decodeJSON(r *http.Request, target any) error {
+	defer r.Body.Close()
+	decoder := json.NewDecoder(http.MaxBytesReader(nil, r.Body, 16*1024))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("decode request: %w", err)
+	}
+	return nil
+}
+
+func (a *app) writeStatus(w http.ResponseWriter) {
+	a.mu.Lock()
+	resp := statusResponse{
+		Brokers: append([]broker(nil), a.cfg.brokers...),
+		Links:   a.cfg.links,
+		State:   a.state,
+		Logs:    append([]logEntry(nil), a.logs...),
+	}
+	a.mu.Unlock()
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func writeError(w http.ResponseWriter, status int, err error) {
+	writeJSON(w, status, map[string]string{"error": err.Error()})
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Warn("write json response", slog.Any("error", err))
+	}
+}
+
+func (a *app) addLogLocked(level, message string) {
+	a.logs = append([]logEntry{{
+		Time:    time.Now().UTC(),
+		Level:   level,
+		Message: message,
+	}}, a.logs...)
+	if len(a.logs) > maxLogEntries {
+		a.logs = a.logs[:maxLogEntries]
+	}
+}
+
+func normalizeTarget(target string) (string, error) {
+	switch strings.ToUpper(strings.TrimSpace(target)) {
+	case "OFF":
+		return "OFF", nil
+	case "ON":
+		return "ON", nil
+	default:
+		return "", fmt.Errorf("unsupported target %q; use ON or OFF", target)
+	}
+}
+
+func topicOrDefault(topic, fallback string) string {
+	topic = strings.TrimSpace(topic)
+	if topic == "" {
+		return fallback
+	}
+	return topic
+}
+
+func randomHex(n int) string {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 16)
+	}
+	return hex.EncodeToString(buf)
+}

--- a/server/devtools/mqttsim/main.go
+++ b/server/devtools/mqttsim/main.go
@@ -134,7 +134,7 @@ func main() {
 		WriteTimeout:      10 * time.Second,
 		IdleTimeout:       60 * time.Second,
 	}
-	if err := server.ListenAndServe(); err != nil {
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.Error("mqtt simulator stopped", slog.Any("error", err))
 		os.Exit(1)
 	}
@@ -509,19 +509,22 @@ func publishToBroker(ctx context.Context, broker broker, topic string, retain bo
 }
 
 func waitToken(ctx context.Context, token paho.Token, timeout time.Duration) error {
-	done := make(chan struct{})
-	go func() {
-		token.Wait()
-		close(done)
-	}()
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("context canceled while waiting for MQTT token: %w", ctx.Err())
-	case <-timer.C:
-		return fmt.Errorf("timed out after %s", timeout)
-	case <-done:
+	if timeout <= 0 {
+		return errors.New("MQTT token timeout must be positive")
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("context canceled while waiting for MQTT token: %w", err)
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf("timed out after %s", timeout)
+		}
+		wait := min(100*time.Millisecond, remaining)
+		if !token.WaitTimeout(wait) {
+			continue
+		}
 		if err := token.Error(); err != nil {
 			return fmt.Errorf("MQTT token failed: %w", err)
 		}
@@ -531,13 +534,17 @@ func waitToken(ctx context.Context, token paho.Token, timeout time.Duration) err
 
 func (a *app) selectedBrokers(primary, secondary bool) []broker {
 	out := make([]broker, 0, len(a.cfg.brokers))
-	for i, broker := range a.cfg.brokers {
-		switch {
-		case i == 0 && primary:
-			out = append(out, broker)
-		case i == 1 && secondary:
-			out = append(out, broker)
-		case i > 1:
+	for _, broker := range a.cfg.brokers {
+		switch strings.ToLower(broker.Name) {
+		case "primary", "broker-1":
+			if primary {
+				out = append(out, broker)
+			}
+		case "secondary", "broker-2":
+			if secondary {
+				out = append(out, broker)
+			}
+		default:
 			out = append(out, broker)
 		}
 	}

--- a/server/devtools/mqttsim/main_test.go
+++ b/server/devtools/mqttsim/main_test.go
@@ -55,6 +55,44 @@ func TestParseBrokers(t *testing.T) {
 	}
 }
 
+func TestSelectedBrokersUsesBrokerNames(t *testing.T) {
+	a := newApp(config{
+		defaultTopic:    defaultTopic,
+		defaultInterval: defaultInterval,
+		brokers: []broker{
+			{Name: "secondary", URL: "tcp://mqtt-secondary:1883"},
+			{Name: "primary", URL: "tcp://mqtt-primary:1883"},
+		},
+	})
+
+	got := a.selectedBrokers(true, false)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Name != "primary" {
+		t.Fatalf("selected broker = %q, want primary", got[0].Name)
+	}
+}
+
+func TestSelectedBrokersSupportsUnnamedBrokerFallback(t *testing.T) {
+	a := newApp(config{
+		defaultTopic:    defaultTopic,
+		defaultInterval: defaultInterval,
+		brokers: []broker{
+			{Name: "broker-1", URL: "tcp://mqtt-a:1883"},
+			{Name: "broker-2", URL: "tcp://mqtt-b:1883"},
+		},
+	})
+
+	got := a.selectedBrokers(false, true)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Name != "broker-2" {
+		t.Fatalf("selected broker = %q, want broker-2", got[0].Name)
+	}
+}
+
 func TestBuildCurtailmentSettingsURL(t *testing.T) {
 	got, err := buildCurtailmentSettingsURL("http://localhost:5173", "/settings/curtailment")
 	if err != nil {

--- a/server/devtools/mqttsim/main_test.go
+++ b/server/devtools/mqttsim/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBuildPayload(t *testing.T) {
+	body, err := buildPayload(publishOptions{Target: "OFF"})
+	if err != nil {
+		t.Fatalf("build payload: %v", err)
+	}
+	var got struct {
+		Target    int   `json:"target"`
+		Timestamp int64 `json:"timestamp"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if got.Target != wireTargetOff {
+		t.Fatalf("target = %d, want %d", got.Target, wireTargetOff)
+	}
+	if got.Timestamp <= 0 {
+		t.Fatalf("timestamp = %d, want positive", got.Timestamp)
+	}
+}
+
+func TestBuildPayloadRejectsInvalidTarget(t *testing.T) {
+	_, err := buildPayload(publishOptions{Target: "SLEEP"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestBuildPayloadAllowsCustomPayload(t *testing.T) {
+	got, err := buildPayload(publishOptions{CustomPayload: `{"target":50}`})
+	if err != nil {
+		t.Fatalf("build custom payload: %v", err)
+	}
+	if string(got) != `{"target":50}` {
+		t.Fatalf("payload = %s", got)
+	}
+}
+
+func TestParseBrokers(t *testing.T) {
+	got, err := parseBrokers("primary=tcp://mqtt-a:1883,secondary=tcp://mqtt-b:1883")
+	if err != nil {
+		t.Fatalf("parse brokers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Name != "primary" || got[0].URL != "tcp://mqtt-a:1883" {
+		t.Fatalf("first broker = %+v", got[0])
+	}
+}
+
+func TestBuildCurtailmentSettingsURL(t *testing.T) {
+	got, err := buildCurtailmentSettingsURL("http://localhost:5173", "/settings/curtailment")
+	if err != nil {
+		t.Fatalf("build URL: %v", err)
+	}
+	if got != "http://localhost:5173/settings/curtailment" {
+		t.Fatalf("URL = %q", got)
+	}
+}
+
+func TestBuildCurtailmentSettingsURLAllowsEmptyBase(t *testing.T) {
+	got, err := buildCurtailmentSettingsURL("", "/settings/curtailment")
+	if err != nil {
+		t.Fatalf("build URL: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("URL = %q, want empty", got)
+	}
+}
+
+func TestBuildCurtailmentSettingsURLRejectsRelativeBase(t *testing.T) {
+	_, err := buildCurtailmentSettingsURL("localhost:5173", "/settings/curtailment")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/server/devtools/mqttsim/mosquitto.conf
+++ b/server/devtools/mqttsim/mosquitto.conf
@@ -1,0 +1,6 @@
+listener 1883 0.0.0.0
+allow_anonymous true
+persistence true
+persistence_location /mosquitto/data/
+log_dest stdout
+connection_messages true

--- a/server/devtools/mqttsim/ui.go
+++ b/server/devtools/mqttsim/ui.go
@@ -1,0 +1,772 @@
+package main
+
+const indexHTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MQTT Curtailment Simulator</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --base-black: 0 0 0;
+      --base-white: 255 255 255;
+      --base-gray-2: 250 250 250;
+      --base-gray-5: 242 242 242;
+      --base-gray-10: 224 224 224;
+      --base-orange: 254 124 0;
+      --base-red: 250 43 55;
+      --base-green: 56 166 0;
+      --base-yellow: 253 138 0;
+      --base-text-critical: 116 20 13;
+      --base-text-success: 6 63 37;
+      --base-text-warning: 135 73 0;
+
+      --surface-base: rgb(var(--base-white));
+      --surface-2: rgb(var(--base-gray-2));
+      --surface-5: rgb(var(--base-gray-5));
+      --text-primary: rgb(var(--base-black) / 90%);
+      --text-primary-70: rgb(var(--base-black) / 70%);
+      --text-primary-50: rgb(var(--base-black) / 50%);
+      --text-contrast: rgb(var(--base-white));
+      --border-5: rgb(var(--base-black) / 5%);
+      --border-10: rgb(var(--base-black) / 10%);
+      --border-20: rgb(var(--base-black) / 20%);
+      --core-primary: rgb(var(--base-black) / 90%);
+      --core-primary-5: rgb(var(--base-black) / 5%);
+      --core-primary-10: rgb(var(--base-black) / 10%);
+      --core-accent: rgb(var(--base-orange));
+      --core-accent-10: rgb(var(--base-orange) / 10%);
+      --intent-critical: rgb(var(--base-red));
+      --intent-critical-10: rgb(var(--base-red) / 10%);
+      --intent-critical-20: rgb(var(--base-red) / 20%);
+      --intent-critical-text: rgb(var(--base-text-critical));
+      --intent-success-10: rgb(var(--base-green) / 10%);
+      --intent-success-text: rgb(var(--base-text-success));
+      --intent-warning-10: rgb(var(--base-yellow) / 10%);
+      --intent-warning-text: rgb(var(--base-text-warning));
+      --shadow-50: 0 0 1px 0 rgb(var(--base-black) / 37%);
+
+      --radius-xl: 12px;
+      --radius-lg: 8px;
+      --font-body: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-mono: JetBrainsMono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: var(--font-body);
+      background: var(--surface-base);
+      color: var(--text-primary);
+    }
+    main {
+      width: min(1160px, calc(100vw - 48px));
+      margin: 40px auto;
+      display: grid;
+      gap: 24px;
+    }
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 16px;
+      padding-bottom: 8px;
+    }
+    .header-actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 10px;
+    }
+    h1 {
+      margin: 0;
+      font-size: 28px;
+      font-weight: 500;
+      line-height: 40px;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin: 0 0 16px;
+      color: var(--text-primary);
+      font-size: 20px;
+      font-weight: 500;
+      line-height: 28px;
+      letter-spacing: 0;
+    }
+    p {
+      margin: 6px 0 0;
+      color: var(--text-primary-70);
+      font-size: 16px;
+      line-height: 24px;
+      letter-spacing: 0;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(360px, 420px);
+      gap: 16px;
+      align-items: start;
+    }
+    .main-stack,
+    .side {
+      display: grid;
+      gap: 16px;
+      align-content: start;
+    }
+    .panel {
+      background: var(--surface-base);
+      border: 1px solid var(--border-5);
+      border-radius: var(--radius-xl);
+      padding: 24px;
+    }
+    .panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .panel-header h2 {
+      margin: 0;
+    }
+    .fields {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+    label {
+      display: grid;
+      gap: 6px;
+      color: var(--text-primary-70);
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 20px;
+      letter-spacing: 0;
+    }
+    input, textarea {
+      width: 100%;
+      border: 1px solid var(--border-5);
+      border-radius: var(--radius-lg);
+      padding: 12px 16px;
+      font: inherit;
+      font-size: 14px;
+      line-height: 24px;
+      background: var(--surface-base);
+      color: var(--text-primary);
+      outline: none;
+      transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+    }
+    input {
+      min-height: 56px;
+    }
+    input:focus, textarea:focus {
+      border-color: var(--border-20);
+      box-shadow: 0 0 0 4px var(--core-primary-5);
+    }
+    textarea {
+      min-height: 104px;
+      resize: vertical;
+      font-family: var(--font-mono);
+      font-size: 13px;
+    }
+    .checks {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 16px;
+    }
+    .check {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--text-primary);
+      font-size: 14px;
+      font-weight: 400;
+      line-height: 24px;
+    }
+    .check input {
+      min-height: 0;
+      width: 16px;
+      height: 16px;
+      accent-color: var(--core-accent);
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 20px;
+    }
+    button, .button-link {
+      border: 0;
+      background: var(--core-primary-5);
+      color: var(--text-primary);
+      border-radius: 999px;
+      padding: 8px 12px;
+      font: inherit;
+      font-size: 14px;
+      font-weight: 500;
+      line-height: 24px;
+      letter-spacing: 0;
+      cursor: pointer;
+      transition: opacity 160ms ease, background-color 160ms ease, color 160ms ease;
+      text-decoration: none;
+    }
+    button:hover, .button-link:hover {
+      opacity: 0.8;
+    }
+    button:focus-visible, .button-link:focus-visible {
+      outline: 2px solid var(--core-primary);
+      outline-offset: 2px;
+    }
+    button.primary {
+      background: var(--core-primary);
+      color: var(--text-contrast);
+    }
+    button.danger {
+      background: var(--intent-critical);
+      color: var(--text-contrast);
+    }
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.4;
+    }
+    .status {
+      display: grid;
+      gap: 0;
+      font-size: 14px;
+    }
+    .row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 12px 0;
+      border-bottom: 1px solid var(--border-5);
+    }
+    .row:first-child {
+      padding-top: 0;
+    }
+    .row:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+    .copy-row {
+      display: grid;
+      grid-template-columns: minmax(92px, 0.55fr) minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border-5);
+    }
+    .copy-row:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+    .key {
+      color: var(--text-primary-50);
+      font-size: 12px;
+      line-height: 20px;
+    }
+    .value {
+      text-align: right;
+      color: var(--text-primary);
+      font-weight: 500;
+      overflow-wrap: anywhere;
+    }
+    .copy-value {
+      min-width: 0;
+      color: var(--text-primary);
+      font-family: var(--font-mono);
+      font-size: 12px;
+      line-height: 20px;
+      overflow-wrap: anywhere;
+    }
+    .copy-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      padding: 0;
+      flex: 0 0 auto;
+    }
+    .copy-button svg {
+      width: 16px;
+      height: 16px;
+      stroke: currentColor;
+      stroke-width: 2;
+      fill: none;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    .copy-all {
+      flex-shrink: 0;
+    }
+    .panel-footer {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      border-top: 1px solid var(--border-5);
+      margin-top: 16px;
+      padding-top: 16px;
+    }
+    .button-link[hidden] {
+      display: none;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 24px;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: var(--intent-success-10);
+      color: var(--intent-success-text);
+      font-size: 12px;
+      font-weight: 500;
+    }
+    .pill.off {
+      background: var(--intent-critical-10);
+      color: var(--intent-critical-text);
+    }
+    .hint {
+      border-top: 1px solid var(--border-5);
+      margin-top: 16px;
+      padding-top: 14px;
+      color: var(--text-primary-70);
+      font-size: 12px;
+      line-height: 20px;
+      letter-spacing: 0;
+    }
+    code {
+      font-family: var(--font-mono);
+      color: var(--text-primary);
+      background: var(--core-primary-5);
+      border-radius: 6px;
+      padding: 1px 5px;
+    }
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+    .log {
+      display: grid;
+      max-height: 360px;
+      overflow: auto;
+      border-top: 1px solid var(--border-5);
+    }
+    .log-entry {
+      border-bottom: 1px solid var(--border-5);
+      padding: 12px 0;
+      background: var(--surface-base);
+    }
+    .log-entry:last-child {
+      border-bottom: 0;
+    }
+    .log-entry.error {
+      color: var(--intent-critical-text);
+    }
+    .log-time {
+      display: block;
+      color: var(--text-primary-50);
+      font-size: 12px;
+      line-height: 20px;
+      margin-bottom: 4px;
+    }
+    @media (max-width: 860px) {
+      main {
+        width: min(100vw - 32px, 1160px);
+        margin: 24px auto;
+      }
+      .grid, .fields {
+        grid-template-columns: 1fr;
+      }
+      .copy-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+      }
+      .copy-row .key {
+        grid-column: 1 / -1;
+      }
+      header {
+        display: grid;
+      }
+      .header-actions {
+        justify-content: flex-start;
+      }
+      .value {
+        text-align: left;
+      }
+      .row {
+        display: grid;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>MQTT Curtailment Simulator</h1>
+        <p>Publish MaestroOS-style ON and OFF targets to local brokers for Proto Fleet testing.</p>
+      </div>
+      <div class="header-actions">
+        <button id="refresh" type="button">Refresh</button>
+      </div>
+    </header>
+
+    <div class="grid">
+      <div class="main-stack">
+        <section class="panel">
+          <h2>Signal Controls</h2>
+          <div class="fields">
+            <label>Topic
+              <input id="topic" value="maestro/target">
+            </label>
+            <label>Loop interval seconds
+              <input id="interval" type="number" min="1" value="30">
+            </label>
+            <label>Timestamp offset seconds
+              <input id="offset" type="number" value="0">
+            </label>
+            <label>Custom payload
+              <textarea id="custom"></textarea>
+            </label>
+          </div>
+
+          <div class="checks">
+            <label class="check"><input id="retain" type="checkbox" checked>Retain payload</label>
+            <label class="check"><input id="primary" type="checkbox" checked>Primary broker</label>
+            <label class="check"><input id="secondary" type="checkbox" checked>Secondary broker</label>
+          </div>
+
+          <div class="actions">
+            <button class="primary" type="button" data-action="publish" data-target="ON">Send ON Once</button>
+            <button class="danger" type="button" data-action="publish" data-target="OFF">Send OFF Once</button>
+            <button class="primary" type="button" data-action="loop" data-target="ON">Start ON Loop</button>
+            <button class="danger" type="button" data-action="loop" data-target="OFF">Start OFF Loop</button>
+            <button type="button" data-action="custom">Send Custom Once</button>
+            <button type="button" data-action="clear">Clear Retained</button>
+            <button type="button" data-action="stop">Stop Loop</button>
+          </div>
+
+          <div class="hint">
+            Standard ON sends <code>{"target":100,"timestamp":now}</code>. Standard OFF sends
+            <code>{"target":0,"timestamp":now}</code>. Loop mode publishes every 30 seconds by default.
+          </div>
+        </section>
+
+        <section class="panel">
+          <h2>Activity</h2>
+          <div id="logs" class="log"></div>
+        </section>
+      </div>
+
+      <div class="side">
+        <section class="panel">
+          <div class="panel-header">
+            <h2>Connection Details</h2>
+            <button class="copy-all" id="copy-all" type="button">Copy All</button>
+          </div>
+          <div id="connection-details"></div>
+          <div class="panel-footer" id="settings-footer" hidden>
+            <a class="button-link" id="settings-link" target="_blank" rel="noopener noreferrer" hidden>
+              Open Curtailment Settings
+            </a>
+          </div>
+        </section>
+
+        <section class="panel">
+          <h2>Status</h2>
+          <div id="status" class="status"></div>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const state = {
+      busy: false
+    };
+
+    const fields = {
+      topic: document.getElementById("topic"),
+      interval: document.getElementById("interval"),
+      offset: document.getElementById("offset"),
+      custom: document.getElementById("custom"),
+      retain: document.getElementById("retain"),
+      primary: document.getElementById("primary"),
+      secondary: document.getElementById("secondary"),
+      connectionDetails: document.getElementById("connection-details"),
+      settingsFooter: document.getElementById("settings-footer"),
+      settingsLink: document.getElementById("settings-link"),
+      status: document.getElementById("status"),
+      logs: document.getElementById("logs")
+    };
+
+    const connectionDefaults = [
+      ["Broker host 1", "192.168.2.240"],
+      ["Broker host 2", "192.168.2.241"],
+      ["Port", "1883"],
+      ["Transport", "tcp"],
+      ["Topic", "maestro/target"],
+      ["Username", "proto-fleet"],
+      ["Password", "proto-fleet"]
+    ];
+
+    fields.custom.placeholder = JSON.stringify({
+      target: 0,
+      timestamp: Math.floor(Date.now() / 1000)
+    });
+
+    renderConnectionDetails(connectionDefaults);
+
+    document.querySelectorAll("[data-action]").forEach((button) => {
+      button.addEventListener("click", async () => {
+        const action = button.dataset.action;
+        const target = button.dataset.target;
+        if (action === "publish") await publish(target);
+        if (action === "loop") await startLoop(target);
+        if (action === "custom") await publishCustom();
+        if (action === "clear") await clearRetained();
+        if (action === "stop") await stopLoop();
+      });
+    });
+    document.getElementById("refresh").addEventListener("click", refresh);
+    fields.topic.addEventListener("input", () => updateConnectionTopic(fields.topic.value.trim()));
+    document.getElementById("copy-all").addEventListener("click", async (event) => {
+      await copyText(connectionDefaults.map(([key, value]) => key + ": " + value).join("\n"), event.currentTarget);
+    });
+    fields.connectionDetails.addEventListener("click", async (event) => {
+      const button = event.target.closest("[data-copy]");
+      if (!button) return;
+      await copyText(button.dataset.copy, button);
+    });
+
+    function basePayload() {
+      return {
+        topic: fields.topic.value.trim(),
+        retain: fields.retain.checked,
+        primary_enabled: fields.primary.checked,
+        secondary_enabled: fields.secondary.checked,
+        timestamp_offset_seconds: Number(fields.offset.value || 0)
+      };
+    }
+
+    async function publish(target) {
+      await post("/api/publish", { ...basePayload(), target });
+    }
+
+    async function publishCustom() {
+      await post("/api/publish", {
+        ...basePayload(),
+        target: "ON",
+        custom_payload: fields.custom.value
+      });
+    }
+
+    async function startLoop(target) {
+      await post("/api/loop/start", {
+        ...basePayload(),
+        target,
+        interval_seconds: Number(fields.interval.value || 30)
+      });
+    }
+
+    async function stopLoop() {
+      await post("/api/loop/stop", {});
+    }
+
+    async function clearRetained() {
+      await post("/api/clear", {
+        topic: fields.topic.value.trim(),
+        primary_enabled: fields.primary.checked,
+        secondary_enabled: fields.secondary.checked
+      });
+    }
+
+    async function post(path, body) {
+      setBusy(true);
+      try {
+        const response = await fetch(path, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body)
+        });
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.error || "request failed");
+        render(payload);
+      } catch (error) {
+        renderError(error);
+      } finally {
+        setBusy(false);
+      }
+    }
+
+    async function refresh() {
+      try {
+        const response = await fetch("/api/status");
+        render(await response.json());
+      } catch (error) {
+        renderError(error);
+      }
+    }
+
+    function render(payload) {
+      updateSettingsLink(payload.links && payload.links.curtailment_settings_url);
+      const s = payload.state || {};
+      syncInput(fields.topic, s.topic || fields.topic.value.trim());
+      updateConnectionTopic(fields.topic.value.trim() || s.topic);
+      syncInput(fields.interval, s.interval_seconds || fields.interval.value);
+      fields.retain.checked = Boolean(s.retain);
+      fields.primary.checked = Boolean(s.primary_enabled);
+      fields.secondary.checked = Boolean(s.secondary_enabled);
+      syncInput(fields.offset, s.timestamp_offset_seconds || 0);
+      fields.status.innerHTML = [
+        row("Loop", s.running ? "Running" : "Stopped"),
+        row("Target", pill(s.target || "UNKNOWN")),
+        row("Topic", escapeHTML(s.topic || "")),
+        row("Interval", String(s.interval_seconds || 0) + "s"),
+        row("Last publish", formatDate(s.last_published_at)),
+        row("Messages", String(s.published_messages || 0)),
+        row("Last error", escapeHTML(s.last_error || "-")),
+        row("Last payload", "<pre>" + escapeHTML(s.last_payload || "-") + "</pre>")
+      ].join("");
+      fields.logs.innerHTML = (payload.logs || []).map((entry) =>
+        "<div class=\"log-entry " + (entry.level === "error" ? "error" : "") + "\">" +
+          "<span class=\"log-time\">" + new Date(entry.time).toLocaleString() + " - " + escapeHTML(entry.level) + "</span>" +
+          "<pre>" + escapeHTML(entry.message) + "</pre>" +
+        "</div>"
+      ).join("") || "<p>No activity yet.</p>";
+    }
+
+    function syncInput(input, value) {
+      if (document.activeElement === input) return;
+      input.value = value;
+    }
+
+    function updateSettingsLink(url) {
+      if (!url) {
+        fields.settingsFooter.hidden = true;
+        fields.settingsLink.hidden = true;
+        fields.settingsLink.removeAttribute("href");
+        return;
+      }
+      fields.settingsLink.href = url;
+      fields.settingsFooter.hidden = false;
+      fields.settingsLink.hidden = false;
+    }
+
+    function row(key, value) {
+      return "<div class=\"row\"><span class=\"key\">" + escapeHTML(key) + "</span><span class=\"value\">" + value + "</span></div>";
+    }
+
+    function renderConnectionDetails(details) {
+      fields.connectionDetails.innerHTML = details.map(([key, value]) =>
+        "<div class=\"copy-row\" data-key=\"" + escapeHTML(key) + "\">" +
+          "<span class=\"key\">" + escapeHTML(key) + "</span>" +
+          "<span class=\"copy-value\">" + escapeHTML(value) + "</span>" +
+          "<button class=\"copy-button\" type=\"button\" aria-label=\"Copy " + escapeHTML(key) + "\" data-copy=\"" + escapeHTML(value) + "\">" +
+            copyIcon() +
+          "</button>" +
+        "</div>"
+      ).join("");
+    }
+
+    function updateConnectionTopic(topic) {
+      const normalized = topic || "maestro/target";
+      connectionDefaults[4][1] = normalized;
+      renderConnectionDetails(connectionDefaults);
+    }
+
+    async function copyText(value, button) {
+      try {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(value);
+        } else {
+          fallbackCopy(value);
+        }
+        flashCopied(button);
+      } catch (error) {
+        renderError(error);
+      }
+    }
+
+    function fallbackCopy(value) {
+      const textarea = document.createElement("textarea");
+      textarea.value = value;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      textarea.remove();
+    }
+
+    function flashCopied(button) {
+      const previous = button.innerHTML;
+      const previousLabel = button.getAttribute("aria-label");
+      if (button.classList.contains("copy-button")) {
+        button.innerHTML = checkIcon();
+      } else {
+        button.textContent = "Copied";
+      }
+      button.setAttribute("aria-label", "Copied");
+      window.setTimeout(() => {
+        button.innerHTML = previous;
+        if (previousLabel) button.setAttribute("aria-label", previousLabel);
+      }, 1200);
+    }
+
+    function copyIcon() {
+      return "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><rect x=\"9\" y=\"9\" width=\"13\" height=\"13\" rx=\"2\"></rect><path d=\"M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1\"></path></svg>";
+    }
+
+    function checkIcon() {
+      return "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M20 6 9 17l-5-5\"></path></svg>";
+    }
+
+    function pill(target) {
+      const cls = target === "OFF" ? "pill off" : "pill";
+      return "<span class=\"" + cls + "\">" + escapeHTML(target) + "</span>";
+    }
+
+    function formatDate(value) {
+      if (!value || String(value).startsWith("0001-01-01T")) return "-";
+      return new Date(value).toLocaleString();
+    }
+
+    function renderError(error) {
+      fields.logs.insertAdjacentHTML("afterbegin",
+        "<div class=\"log-entry error\">" +
+          "<span class=\"log-time\">" + new Date().toLocaleString() + " - error</span>" +
+          "<pre>" + escapeHTML(error.message) + "</pre>" +
+        "</div>"
+      );
+    }
+
+    function setBusy(busy) {
+      state.busy = busy;
+      document.querySelectorAll("button").forEach((button) => {
+        if (button.id !== "refresh") button.disabled = busy;
+      });
+    }
+
+    function escapeHTML(value) {
+      return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+    }
+
+    refresh();
+    setInterval(refresh, 2000);
+  </script>
+</body>
+</html>`

--- a/server/devtools/mqttsim/ui.go
+++ b/server/devtools/mqttsim/ui.go
@@ -489,7 +489,9 @@ const indexHTML = `<!doctype html>
 
   <script>
     const state = {
-      busy: false
+      busy: false,
+      formDirty: false,
+      formHydrated: false
     };
 
     const fields = {
@@ -523,6 +525,7 @@ const indexHTML = `<!doctype html>
     });
 
     renderConnectionDetails(connectionDefaults);
+    watchFormEdits();
 
     document.querySelectorAll("[data-action]").forEach((button) => {
       button.addEventListener("click", async () => {
@@ -536,7 +539,6 @@ const indexHTML = `<!doctype html>
       });
     });
     document.getElementById("refresh").addEventListener("click", refresh);
-    fields.topic.addEventListener("input", () => updateConnectionTopic(fields.topic.value.trim()));
     document.getElementById("copy-all").addEventListener("click", async (event) => {
       await copyText(connectionDefaults.map(([key, value]) => key + ": " + value).join("\n"), event.currentTarget);
     });
@@ -598,7 +600,8 @@ const indexHTML = `<!doctype html>
         });
         const payload = await response.json();
         if (!response.ok) throw new Error(payload.error || "request failed");
-        render(payload);
+        state.formDirty = false;
+        render(payload, { syncForm: true });
       } catch (error) {
         renderError(error);
       } finally {
@@ -609,22 +612,18 @@ const indexHTML = `<!doctype html>
     async function refresh() {
       try {
         const response = await fetch("/api/status");
-        render(await response.json());
+        render(await response.json(), { syncForm: !state.formHydrated });
       } catch (error) {
         renderError(error);
       }
     }
 
-    function render(payload) {
+    function render(payload, options = {}) {
       updateSettingsLink(payload.links && payload.links.curtailment_settings_url);
       const s = payload.state || {};
-      syncInput(fields.topic, s.topic || fields.topic.value.trim());
-      updateConnectionTopic(fields.topic.value.trim() || s.topic);
-      syncInput(fields.interval, s.interval_seconds || fields.interval.value);
-      fields.retain.checked = Boolean(s.retain);
-      fields.primary.checked = Boolean(s.primary_enabled);
-      fields.secondary.checked = Boolean(s.secondary_enabled);
-      syncInput(fields.offset, s.timestamp_offset_seconds || 0);
+      if (options.syncForm && !state.formDirty) {
+        hydrateForm(s);
+      }
       fields.status.innerHTML = [
         row("Loop", s.running ? "Running" : "Stopped"),
         row("Target", pill(s.target || "UNKNOWN")),
@@ -643,8 +642,32 @@ const indexHTML = `<!doctype html>
       ).join("") || "<p>No activity yet.</p>";
     }
 
+    function watchFormEdits() {
+      [fields.topic, fields.interval, fields.offset, fields.custom].forEach((input) => {
+        input.addEventListener("input", markFormDirty);
+      });
+      [fields.retain, fields.primary, fields.secondary].forEach((input) => {
+        input.addEventListener("change", markFormDirty);
+      });
+    }
+
+    function markFormDirty() {
+      state.formDirty = true;
+      updateConnectionTopic(fields.topic.value.trim());
+    }
+
+    function hydrateForm(status) {
+      syncInput(fields.topic, status.topic || fields.topic.value.trim());
+      updateConnectionTopic(fields.topic.value.trim() || status.topic);
+      syncInput(fields.interval, status.interval_seconds || fields.interval.value);
+      fields.retain.checked = Boolean(status.retain);
+      fields.primary.checked = Boolean(status.primary_enabled);
+      fields.secondary.checked = Boolean(status.secondary_enabled);
+      syncInput(fields.offset, status.timestamp_offset_seconds || 0);
+      state.formHydrated = true;
+    }
+
     function syncInput(input, value) {
-      if (document.activeElement === input) return;
       input.value = value;
     }
 

--- a/server/docker-compose.mqtt-sim.yaml
+++ b/server/docker-compose.mqtt-sim.yaml
@@ -1,0 +1,48 @@
+services:
+  mqtt-sim-primary:
+    image: eclipse-mosquitto:2
+    restart: unless-stopped
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./devtools/mqttsim/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - mqtt-sim-primary-data:/mosquitto/data
+    networks:
+      fleet-network:
+        ipv4_address: 192.168.2.240
+
+  mqtt-sim-secondary:
+    image: eclipse-mosquitto:2
+    restart: unless-stopped
+    ports:
+      - "1884:1883"
+    volumes:
+      - ./devtools/mqttsim/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - mqtt-sim-secondary-data:/mosquitto/data
+    networks:
+      fleet-network:
+        ipv4_address: 192.168.2.241
+
+  mqtt-sim-ui:
+    build:
+      context: .
+      dockerfile: devtools/mqttsim/Dockerfile
+    restart: unless-stopped
+    environment:
+      HTTP_ADDR: ":4183"
+      MQTT_BROKERS: "primary=tcp://mqtt-sim-primary:1883,secondary=tcp://mqtt-sim-secondary:1883"
+      MQTT_DEFAULT_TOPIC: "maestro/target"
+      MQTT_DEFAULT_INTERVAL: "30s"
+      PROTO_FLEET_BASE_URL: "${PROTO_FLEET_BASE_URL:-http://localhost:5173}"
+      PROTO_FLEET_CURTAILMENT_SETTINGS_PATH: "${PROTO_FLEET_CURTAILMENT_SETTINGS_PATH:-/settings/curtailment}"
+    depends_on:
+      - mqtt-sim-primary
+      - mqtt-sim-secondary
+    ports:
+      - "4183:4183"
+    networks:
+      - fleet-network
+
+volumes:
+  mqtt-sim-primary-data:
+  mqtt-sim-secondary-data:

--- a/server/docker-compose.mqtt-sim.yaml
+++ b/server/docker-compose.mqtt-sim.yaml
@@ -3,7 +3,7 @@ services:
     image: eclipse-mosquitto:2
     restart: unless-stopped
     ports:
-      - "1883:1883"
+      - "127.0.0.1:1883:1883"
     volumes:
       - ./devtools/mqttsim/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
       - mqtt-sim-primary-data:/mosquitto/data
@@ -15,7 +15,7 @@ services:
     image: eclipse-mosquitto:2
     restart: unless-stopped
     ports:
-      - "1884:1883"
+      - "127.0.0.1:1884:1883"
     volumes:
       - ./devtools/mqttsim/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
       - mqtt-sim-secondary-data:/mosquitto/data
@@ -39,7 +39,7 @@ services:
       - mqtt-sim-primary
       - mqtt-sim-secondary
     ports:
-      - "4183:4183"
+      - "127.0.0.1:4183:4183"
     networks:
       - fleet-network
 

--- a/server/justfile
+++ b/server/justfile
@@ -102,6 +102,42 @@ _run: db-up install
 seed-telemetry *args:
     go run ./devtools/seedtelemetry {{args}}
 
+# start MQTT simulator brokers and browser control UI
+mqtt-sim-up:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  docker compose -f docker-compose.yaml -f docker-compose.mqtt-sim.yaml up -d --build mqtt-sim-primary mqtt-sim-secondary mqtt-sim-ui
+  for port in 1883 1884 4183; do
+    ready=false
+    for _ in $(seq 1 60); do
+      if (echo >"/dev/tcp/127.0.0.1/${port}") >/dev/null 2>&1; then
+        ready=true
+        break
+      fi
+      sleep 0.25
+    done
+    if [ "${ready}" != true ]; then
+      echo "MQTT simulator did not become ready on 127.0.0.1:${port}" >&2
+      docker compose -f docker-compose.yaml -f docker-compose.mqtt-sim.yaml logs --tail=120 mqtt-sim-primary mqtt-sim-secondary mqtt-sim-ui >&2 || true
+      exit 1
+    fi
+  done
+  echo "MQTT simulator UI: http://localhost:4183"
+  echo "Proto Fleet Docker source config: primary=192.168.2.240 secondary=192.168.2.241 port=1883 topic=maestro/target"
+
+# rebuild and restart MQTT simulator services
+mqtt-sim-rebuild:
+  docker compose -f docker-compose.yaml -f docker-compose.mqtt-sim.yaml up -d --build --force-recreate mqtt-sim-primary mqtt-sim-secondary mqtt-sim-ui
+
+# stop MQTT simulator services
+mqtt-sim-down:
+  docker compose -f docker-compose.yaml -f docker-compose.mqtt-sim.yaml stop mqtt-sim-primary mqtt-sim-secondary mqtt-sim-ui
+  docker compose -f docker-compose.yaml -f docker-compose.mqtt-sim.yaml rm -f mqtt-sim-primary mqtt-sim-secondary mqtt-sim-ui
+
+# follow MQTT simulator logs
+mqtt-sim-logs:
+  docker compose -f docker-compose.yaml -f docker-compose.mqtt-sim.yaml logs -f mqtt-sim-primary mqtt-sim-secondary mqtt-sim-ui
+
 # wipe and rebuild all docker compose services from scratch (includes plugin rebuild)
 rebuild-all: _build-plugins-docker rebuild-services
 


### PR DESCRIPTION
## Summary
- Add a Docker Compose-backed MQTT curtailment simulator with two local Mosquitto brokers and a small browser UI.
- Add root/server `just` recipes for starting, rebuilding, stopping, and tailing simulator logs.
- Provide a Proto Fleet-style simulator UI for sending ON/OFF MaestroOS-style target payloads, looping signals, clearing retained messages, copying source connection details, and opening the curtailment settings page via configurable URL.
- Document local source settings and frontend URL override knobs in the simulator README.

<img width="1822" height="1129" alt="Screenshot 2026-06-09 at 18 23 22" src="https://github.com/user-attachments/assets/052778c3-cf25-4c5c-927c-875f33c5d2b7" />

## Validation
- `go test ./devtools/mqttsim`
- `docker compose -f docker-compose.yaml -f docker-compose.mqtt-sim.yaml config --quiet`
- `git diff --check`
- Pre-push `server-lint` hook: `0 issues`