### PR TITLE
[codex] Add ProtoOS authentication settings E2E tests

### DIFF
--- a/client/e2eTests/protoOS/helpers/authenticationHelper.ts
+++ b/client/e2eTests/protoOS/helpers/authenticationHelper.ts
@@ -1,0 +1,40 @@
+import type { APIRequestContext } from "@playwright/test";
+import { testConfig } from "../config/test.config";
+import { expect } from "../fixtures/pageFixtures";
+
+export function generateStrongPassword() {
+  const randomSuffix = Math.random().toString(36).slice(2, 10);
+  return `ProtoOS!${randomSuffix}9A`;
+}
+
+export async function loginViaApi(request: APIRequestContext, password: string) {
+  const response = await request.post("/api/v1/auth/login", {
+    data: { password },
+  });
+
+  expect(response.status()).toBe(200);
+
+  const responseBody = (await response.json()) as { access_token?: string };
+  const accessToken = responseBody.access_token;
+
+  if (!accessToken) {
+    throw new Error("Missing access token in login response");
+  }
+
+  return accessToken;
+}
+
+export async function restoreAdminPassword(request: APIRequestContext, currentPassword: string) {
+  const accessToken = await loginViaApi(request, currentPassword);
+  const response = await request.put("/api/v1/auth/change-password", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    data: {
+      current_password: currentPassword,
+      new_password: testConfig.admin.password,
+    },
+  });
+
+  expect(response.status()).toBe(200);
+}

--- a/client/e2eTests/protoOS/pages/authentication.ts
+++ b/client/e2eTests/protoOS/pages/authentication.ts
@@ -1,3 +1,33 @@
+import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
-export class AuthenticationPage extends BasePage {}
+export class AuthenticationPage extends BasePage {
+  async validateUsernameFieldDisabledWithValue(expectedValue: string) {
+    const usernameField = this.page.locator('input[id="username"]:not([data-testid="username"])');
+    await expect(usernameField).toBeDisabled();
+    await expect(usernameField).toHaveValue(expectedValue);
+  }
+
+  async inputCurrentPassword(password: string) {
+    await this.page.locator('input[id="currentPassword"]').fill(password);
+  }
+
+  async inputNewPassword(password: string) {
+    await this.page.locator('input[id="password"]:not([data-testid="password"])').fill(password);
+  }
+
+  async inputConfirmPassword(password: string) {
+    await this.page.locator('input[id="confirmPassword"]').fill(password);
+  }
+
+  async clickContinue() {
+    await this.page.locator('button:not([data-testid="login-button"])', { hasText: "Continue" }).click();
+  }
+
+  async updateAdminPassword(currentPassword: string, newPassword: string) {
+    await this.inputCurrentPassword(currentPassword);
+    await this.inputNewPassword(newPassword);
+    await this.inputConfirmPassword(newPassword);
+    await this.clickContinue();
+  }
+}

--- a/client/e2eTests/protoOS/pages/authentication.ts
+++ b/client/e2eTests/protoOS/pages/authentication.ts
@@ -2,26 +2,30 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class AuthenticationPage extends BasePage {
+  private settingsForm() {
+    return this.page.getByTestId("authentication-settings-form");
+  }
+
   async validateUsernameFieldDisabledWithValue(expectedValue: string) {
-    const usernameField = this.page.locator('input[id="username"]:not([data-testid="username"])');
+    const usernameField = this.settingsForm().locator('input[id="username"]');
     await expect(usernameField).toBeDisabled();
     await expect(usernameField).toHaveValue(expectedValue);
   }
 
   async inputCurrentPassword(password: string) {
-    await this.page.locator('input[id="currentPassword"]').fill(password);
+    await this.settingsForm().locator('input[id="currentPassword"]').fill(password);
   }
 
   async inputNewPassword(password: string) {
-    await this.page.locator('input[id="password"]:not([data-testid="password"])').fill(password);
+    await this.settingsForm().locator('input[id="password"]').fill(password);
   }
 
   async inputConfirmPassword(password: string) {
-    await this.page.locator('input[id="confirmPassword"]').fill(password);
+    await this.settingsForm().locator('input[id="confirmPassword"]').fill(password);
   }
 
   async clickContinue() {
-    await this.page.locator('button:not([data-testid="login-button"])', { hasText: "Continue" }).click();
+    await this.settingsForm().getByRole("button", { name: "Continue" }).click();
   }
 
   async updateAdminPassword(currentPassword: string, newPassword: string) {

--- a/client/e2eTests/protoOS/spec/authentication.spec.ts
+++ b/client/e2eTests/protoOS/spec/authentication.spec.ts
@@ -46,20 +46,19 @@ test.describe("Authentication settings", () => {
     });
 
     await test.step("Validate the password change request and success state", async () => {
-      const request = await requestPromise;
-      const response = await responsePromise;
+      const changePasswordRequest = await requestPromise;
+      const changePasswordResponse = await responsePromise;
 
-      expect(request.postDataJSON()).toEqual({
+      expect(changePasswordRequest.postDataJSON()).toEqual({
         current_password: testConfig.admin.password,
         new_password: newPassword,
       });
-      expect(response.status()).toBe(200);
+      expect(changePasswordResponse.status()).toBe(200);
+      updatedPassword = newPassword;
 
       await authenticationPage.validateToastMessage("Password updated");
       await authenticationPage.validateLoggedIn();
     });
-
-    updatedPassword = newPassword;
 
     await test.step("Validate the new password can authenticate again", async () => {
       const accessToken = await loginViaApi(request, newPassword);

--- a/client/e2eTests/protoOS/spec/authentication.spec.ts
+++ b/client/e2eTests/protoOS/spec/authentication.spec.ts
@@ -1,0 +1,93 @@
+import { testConfig } from "../config/test.config";
+import { expect, test } from "../fixtures/pageFixtures";
+import { generateStrongPassword, loginViaApi, restoreAdminPassword } from "../helpers/authenticationHelper";
+
+test.describe("Authentication settings", () => {
+  let updatedPassword: string | null;
+
+  test.beforeEach(async ({ page, commonSteps }) => {
+    updatedPassword = null;
+    await page.goto("/");
+    await commonSteps.authenticateAsAdmin();
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    if (!updatedPassword) {
+      return;
+    }
+
+    await restoreAdminPassword(request, updatedPassword);
+    updatedPassword = null;
+    await page.evaluate(() => {
+      window.localStorage.removeItem("proto-os-auth");
+    });
+    await page.goto("/");
+  });
+
+  test("Admin password can be updated from settings and used on the next login", async ({
+    authenticationPage,
+    commonSteps,
+    page,
+    request,
+  }) => {
+    const newPassword = generateStrongPassword();
+    const requestPromise = page.waitForRequest(
+      (request) => request.method() === "PUT" && request.url().includes("/api/v1/auth/change-password"),
+    );
+    const responsePromise = page.waitForResponse(
+      (response) => response.request().method() === "PUT" && response.url().includes("/api/v1/auth/change-password"),
+    );
+
+    await commonSteps.navigateToAuthenticationSettings();
+
+    await test.step("Update the admin password from Authentication settings", async () => {
+      await authenticationPage.validateUsernameFieldDisabledWithValue(testConfig.admin.username);
+      await authenticationPage.updateAdminPassword(testConfig.admin.password, newPassword);
+    });
+
+    await test.step("Validate the password change request and success state", async () => {
+      const request = await requestPromise;
+      const response = await responsePromise;
+
+      expect(request.postDataJSON()).toEqual({
+        current_password: testConfig.admin.password,
+        new_password: newPassword,
+      });
+      expect(response.status()).toBe(200);
+
+      await authenticationPage.validateToastMessage("Password updated");
+      await authenticationPage.validateLoggedIn();
+    });
+
+    updatedPassword = newPassword;
+
+    await test.step("Validate the new password can authenticate again", async () => {
+      const accessToken = await loginViaApi(request, newPassword);
+      expect(accessToken).toBeTruthy();
+    });
+  });
+
+  test("Authentication settings requires the current password before updating", async ({
+    authenticationPage,
+    commonSteps,
+  }) => {
+    const newPassword = generateStrongPassword();
+
+    await commonSteps.navigateToAuthenticationSettings();
+
+    await test.step("Open Authentication settings and review the admin login form", async () => {
+      await authenticationPage.validateTitle("Update your admin login");
+      await authenticationPage.validateUsernameFieldDisabledWithValue(testConfig.admin.username);
+    });
+
+    await test.step("Try to submit a new password without entering the current password", async () => {
+      await authenticationPage.inputNewPassword(newPassword);
+      await authenticationPage.inputConfirmPassword(newPassword);
+      await authenticationPage.clickContinue();
+    });
+
+    await test.step("Validate the current password error is shown", async () => {
+      await authenticationPage.validateTextIsVisible("Current password is required");
+    });
+  });
+});

--- a/client/e2eTests/protoOS/spec/authentication.spec.ts
+++ b/client/e2eTests/protoOS/spec/authentication.spec.ts
@@ -49,12 +49,12 @@ test.describe("Authentication settings", () => {
       const changePasswordRequest = await requestPromise;
       const changePasswordResponse = await responsePromise;
 
+      expect(changePasswordResponse.status()).toBe(200);
+      updatedPassword = newPassword;
       expect(changePasswordRequest.postDataJSON()).toEqual({
         current_password: testConfig.admin.password,
         new_password: newPassword,
       });
-      expect(changePasswordResponse.status()).toBe(200);
-      updatedPassword = newPassword;
 
       await authenticationPage.validateToastMessage("Password updated");
       await authenticationPage.validateLoggedIn();

--- a/client/src/protoOS/features/settings/components/Authentication/Authentication.tsx
+++ b/client/src/protoOS/features/settings/components/Authentication/Authentication.tsx
@@ -75,15 +75,17 @@ const AuthenticationSettings = () => {
   );
 
   return (
-    <Authentication
-      isUpdateMode
-      submit={submit}
-      isSubmitting={isSubmitting}
-      setIsSubmitting={setIsSubmitting}
-      headline="Update your admin login"
-      description="Your admin login is used to modify performance settings or mining pool configurations for this miner."
-      initUsername="admin"
-    />
+    <div data-testid="authentication-settings-form">
+      <Authentication
+        isUpdateMode
+        submit={submit}
+        isSubmitting={isSubmitting}
+        setIsSubmitting={setIsSubmitting}
+        headline="Update your admin login"
+        description="Your admin login is used to modify performance settings or mining pool configurations for this miner."
+        initUsername="admin"
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
🤖 What changed

- added a ProtoOS authentication settings spec
- moved API/password helper logic into a dedicated e2e helper
- expanded the authentication page object with settings-form interactions

Why

- cover the admin password update flow in ProtoOS settings
- verify the change-password request payload and success path
- cover the validation case where current password is required

Validation

- eslint e2eTests/protoOS/helpers/authenticationHelper.ts e2eTests/protoOS/pages/authentication.ts e2eTests/protoOS/spec/authentication.spec.ts
- playwright test e2eTests/protoOS/spec/00-onboarding.spec.ts --project=desktop --config=e2eTests/protoOS/playwright.config.ts
- playwright test e2eTests/protoOS/spec/authentication.spec.ts --project=desktop --config=e2eTests/protoOS/playwright.config.ts