### PR TITLE
[codex] Add ProtoOS hardware settings E2E tests

### DIFF
--- a/client/e2eTests/protoOS/pages/hardware.ts
+++ b/client/e2eTests/protoOS/pages/hardware.ts
@@ -1,3 +1,53 @@
+import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
-export class HardwarePage extends BasePage {}
+export class HardwarePage extends BasePage {
+  private controlBoardSection() {
+    return this.page.getByTestId("hardware-control-board-section");
+  }
+
+  private hashboardsSection() {
+    return this.page.getByTestId("hardware-hashboards-section");
+  }
+
+  private fansSection() {
+    return this.page.getByTestId("hardware-fans-section");
+  }
+
+  private psusSection() {
+    return this.page.getByTestId("hardware-psus-section");
+  }
+
+  async validateSectionHeadings() {
+    await expect(this.controlBoardSection().getByRole("heading", { name: "Control Board" })).toBeVisible();
+    await expect(this.hashboardsSection().getByRole("heading", { name: "Hashboards" })).toBeVisible();
+    await expect(this.fansSection().getByRole("heading", { name: "Fans" })).toBeVisible();
+    await expect(this.psusSection().getByRole("heading", { name: "Power supply" })).toBeVisible();
+  }
+
+  async validateControlBoardSerialLooksLikeSimulatorData() {
+    await expect(this.controlBoardSection().getByText(/PROTO-SIM-/)).toBeVisible();
+  }
+
+  async validateHashboardInventory() {
+    await expect(this.hashboardsSection().getByText("Model B4_128")).toHaveCount(4);
+    await expect(this.hashboardsSection().getByText(/HB-PROTO-SIM-/)).toHaveCount(4);
+  }
+
+  async validateFanInventory() {
+    await expect(this.fansSection().getByText("Fan 1")).toBeVisible();
+    await expect(this.fansSection().getByText("Fan 2")).toBeVisible();
+    await expect(this.fansSection().getByText("Fan 3")).toBeVisible();
+    await expect(this.fansSection().getByText("Fan 4")).toBeVisible();
+  }
+
+  async validatePsuInventory() {
+    await expect(this.psusSection().getByText("Model PSU-3600W")).toHaveCount(2);
+    await expect(this.psusSection().getByText(/PSU-PROTO-SIM-/)).toHaveCount(2);
+  }
+
+  async validateNoFansConnectedCalloutHidden() {
+    await expect(this.fansSection().getByText("No fans connected")).toHaveCount(0);
+    await expect(this.fansSection().getByText("This miner is set to immersion cooling")).toHaveCount(0);
+  }
+}

--- a/client/e2eTests/protoOS/spec/hardware.spec.ts
+++ b/client/e2eTests/protoOS/spec/hardware.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "../fixtures/pageFixtures";
+
+test.describe("Hardware settings", () => {
+  test.beforeEach(async ({ page, commonSteps }) => {
+    await page.goto("/");
+    await commonSteps.authenticateAsAdmin();
+  });
+
+  test("Hardware settings show the current control board, hashboards, fans, and PSUs", async ({
+    commonSteps,
+    hardwarePage,
+  }) => {
+    await commonSteps.navigateToHardwareSettings();
+
+    await test.step("Validate the main hardware sections are visible", async () => {
+      await hardwarePage.validateSectionHeadings();
+      await hardwarePage.validateControlBoardSerialLooksLikeSimulatorData();
+    });
+
+    await test.step("Validate the default fake rig inventory is shown", async () => {
+      await hardwarePage.validateHashboardInventory();
+      await hardwarePage.validateFanInventory();
+      await hardwarePage.validatePsuInventory();
+    });
+  });
+
+  test("Hardware settings keep the fan table visible in the default cooling mode", async ({
+    commonSteps,
+    hardwarePage,
+    page,
+  }) => {
+    await commonSteps.navigateToHardwareSettings();
+
+    await test.step("Validate the default Hardware page shows the fan table instead of the immersion callout", async () => {
+      await expect(page.getByTestId("hardware-fans-section").getByText("No fans connected")).toHaveCount(0);
+      await expect(
+        page.getByTestId("hardware-fans-section").getByText("This miner is set to immersion cooling"),
+      ).toHaveCount(0);
+      await hardwarePage.validateFanInventory();
+    });
+  });
+});

--- a/client/e2eTests/protoOS/spec/hardware.spec.ts
+++ b/client/e2eTests/protoOS/spec/hardware.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "../fixtures/pageFixtures";
+import { test } from "../fixtures/pageFixtures";
 
 test.describe("Hardware settings", () => {
   test.beforeEach(async ({ page, commonSteps }) => {
@@ -27,15 +27,11 @@ test.describe("Hardware settings", () => {
   test("Hardware settings keep the fan table visible in the default cooling mode", async ({
     commonSteps,
     hardwarePage,
-    page,
   }) => {
     await commonSteps.navigateToHardwareSettings();
 
     await test.step("Validate the default Hardware page shows the fan table instead of the immersion callout", async () => {
-      await expect(page.getByTestId("hardware-fans-section").getByText("No fans connected")).toHaveCount(0);
-      await expect(
-        page.getByTestId("hardware-fans-section").getByText("This miner is set to immersion cooling"),
-      ).toHaveCount(0);
+      await hardwarePage.validateNoFansConnectedCalloutHidden();
       await hardwarePage.validateFanInventory();
     });
   });

--- a/client/src/protoOS/features/settings/components/Hardware/Hardware.tsx
+++ b/client/src/protoOS/features/settings/components/Hardware/Hardware.tsx
@@ -49,7 +49,7 @@ const Hardware = () => {
   return (
     <>
       <h2 className="mb-10 text-heading-300">Hardware</h2>
-      <div className="mb-10">
+      <div className="mb-10" data-testid="hardware-control-board-section">
         <h3 className="mb-2 text-heading-100">Control Board</h3>
         <Row className="flex" attributes={{ role: "row" }}>
           <h4 className="w-92 text-emphasis-300">Type</h4>
@@ -64,7 +64,7 @@ const Hardware = () => {
           <div className="w-46 text-300">{controlBoardInfo?.serial_number ?? skeletonBar}</div>
         </Row>
       </div>
-      <div className="mb-10" role="table">
+      <div className="mb-10" role="table" data-testid="hardware-hashboards-section">
         <h3 className="mb-2 text-heading-100">Hashboards</h3>
         <Row className="flex" attributes={{ role: "row" }}>
           <h4 className="w-46 text-emphasis-300">Position</h4>
@@ -94,7 +94,7 @@ const Hardware = () => {
           );
         })}
       </div>
-      <div className="mb-10">
+      <div className="mb-10" data-testid="hardware-fans-section">
         <h3 className="mb-2 text-heading-100">Fans</h3>
         {showNoFansCallout ? (
           <Callout
@@ -128,7 +128,7 @@ const Hardware = () => {
           </>
         )}
       </div>
-      <div className="mb-10">
+      <div className="mb-10" data-testid="hardware-psus-section">
         <h3 className="mb-2 text-heading-100">Power supply</h3>
         <Row className="flex" attributes={{ role: "row" }}>
           <h4 className="w-46 text-emphasis-300">Position</h4>


### PR DESCRIPTION
🤖 What changed

- added a ProtoOS hardware settings spec
- expanded the hardware page object with direct UI assertions for the Hardware screen
- added section-level test ids to the Hardware page to scope those assertions cleanly

Why

- cover the Hardware settings screen with e2e checks
- keep the scenarios aligned with human verification instead of mirroring product internals
- verify the default fake-rig inventory and fan-table behavior in the current local environment

Validation

- eslint src/protoOS/features/settings/components/Hardware/Hardware.tsx e2eTests/protoOS/pages/hardware.ts e2eTests/protoOS/spec/hardware.spec.ts
- playwright test e2eTests/protoOS/spec/hardware.spec.ts --project=desktop --config=e2eTests/protoOS/playwright.config.ts