### PR TITLE
Add curtailment sources settings page

### DIFF
--- a/client/src/protoFleet/config/navItems.test.ts
+++ b/client/src/protoFleet/config/navItems.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { primaryNavItems } from "./navItems";
+import { primaryNavItems, secondaryNavItems } from "./navItems";
 import { LightningAlt } from "@/shared/assets/icons";
 
 describe("primaryNavItems", () => {
@@ -14,5 +14,19 @@ describe("primaryNavItems", () => {
       requiredPermission: "curtailment:read",
     });
     expect(labels.indexOf("Energy")).toBe(labels.indexOf("Activity") - 1);
+  });
+});
+
+describe("secondaryNavItems", () => {
+  it("adds Curtailment as a settings management tab after Schedules", () => {
+    const labels = secondaryNavItems.map((item) => item.label);
+    const curtailmentItem = secondaryNavItems.find((item) => item.label === "Curtailment");
+
+    expect(curtailmentItem).toMatchObject({
+      path: "/settings/curtailment",
+      parent: "/settings",
+      requiredPermission: "curtailment:manage",
+    });
+    expect(labels.indexOf("Curtailment")).toBe(labels.indexOf("Schedules") + 1);
   });
 });

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -111,6 +111,12 @@ export const secondaryNavItems: SecondaryNavItem[] = [
     requiredPermission: "schedule:manage",
   },
   {
+    path: "/settings/curtailment",
+    label: "Curtailment",
+    parent: "/settings",
+    requiredPermission: "curtailment:manage",
+  },
+  {
     path: "/settings/api-keys",
     label: "API Keys",
     parent: "/settings",

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.css
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.css
@@ -1,0 +1,37 @@
+.curtailment-settings__section {
+  margin-bottom: 56px;
+}
+
+.curtailment-settings__section--last {
+  margin-bottom: 0;
+}
+
+.curtailment-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.curtailment-section-header__title {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 16px;
+}
+
+.curtailment-section-header__label {
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-size: var(--text-heading-200);
+  font-weight: 500;
+  line-height: var(--text-heading-200--line-height);
+  letter-spacing: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.curtailment-settings__action-button {
+  flex-shrink: 0;
+}

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { CurtailmentSettingsContent } from "./CurtailmentSettingsPage";
+import type { CurtailmentSource } from "./types";
+
+const storySources: CurtailmentSource[] = [
+  {
+    id: "kati-maestro",
+    name: "Kati MaestroOS",
+    triggerType: "MQTT",
+    site: "Kati",
+    brokerHosts: ["10.155.0.3", "10.155.0.4"],
+    port: 1883,
+    topic: "maestro/target",
+    protocol: "MQTT 3.1.1",
+    qos: 1,
+    username: "soluna-kati",
+    scope: "Kati",
+    curtailmentMode: "Curtail entire site",
+    lastTarget: 0,
+    lastSeen: "38 seconds ago",
+    health: "connected",
+    enabled: true,
+  },
+  {
+    id: "dorothy-2-maestro",
+    name: "Dorothy 2 MaestroOS",
+    triggerType: "MQTT",
+    site: "Dorothy 2",
+    brokerHosts: ["10.144.0.3", "10.144.0.4"],
+    port: 1883,
+    topic: "maestro/target",
+    protocol: "MQTT 3.1.1",
+    qos: 1,
+    username: "soluna-dorothy",
+    scope: "Dorothy 2",
+    curtailmentMode: "Curtail entire site",
+    lastTarget: 100,
+    lastSeen: "24 seconds ago",
+    health: "connected",
+    enabled: true,
+  },
+  {
+    id: "helena-maestro",
+    name: "Helena MaestroOS",
+    triggerType: "MQTT",
+    site: "Helena",
+    brokerHosts: ["10.188.0.3", "10.188.0.4"],
+    port: 1883,
+    topic: "maestro/target",
+    protocol: "MQTT 3.1.1",
+    qos: 1,
+    username: "soluna-helena",
+    scope: "Helena",
+    curtailmentMode: "Curtail entire site",
+    lastTarget: 0,
+    lastSeen: "12 minutes ago",
+    health: "stale",
+    enabled: true,
+  },
+];
+
+const meta = {
+  title: "Proto Fleet/Settings/Curtailment",
+  component: CurtailmentSettingsContent,
+  render: (args) => {
+    const sourcesKey = args.initialSources?.map((source) => source.id).join(":") ?? "empty";
+
+    return (
+      <div className="min-h-screen bg-surface-base p-10 phone:p-6">
+        <CurtailmentSettingsContent key={`${sourcesKey}-${String(args.initialSourceModalOpen)}`} {...args} />
+      </div>
+    );
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof CurtailmentSettingsContent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SettingsPage: Story = {
+  args: {
+    initialSources: storySources,
+  },
+};
+
+export const EmptyState: Story = {};
+
+export const AddSourceDialog: Story = {
+  args: {
+    initialSources: storySources,
+    initialSourceModalOpen: true,
+  },
+};

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -1,0 +1,217 @@
+import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import CurtailmentSettingsPage, {
+  CurtailmentSettingsContent,
+} from "@/protoFleet/features/settings/components/Curtailment";
+import type { CurtailmentSource } from "@/protoFleet/features/settings/components/Curtailment/types";
+import { useHasPermission } from "@/protoFleet/store";
+
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: vi.fn(),
+}));
+
+const testSources: CurtailmentSource[] = [
+  {
+    id: "kati-maestro",
+    name: "Kati MaestroOS",
+    triggerType: "MQTT",
+    site: "Kati",
+    brokerHosts: ["10.155.0.3", "10.155.0.4"],
+    port: 1883,
+    topic: "maestro/target",
+    protocol: "MQTT 3.1.1",
+    qos: 1,
+    username: "soluna-kati",
+    scope: "Kati",
+    curtailmentMode: "Curtail entire site",
+    lastTarget: 0,
+    lastSeen: "38 seconds ago",
+    health: "connected",
+    enabled: true,
+  },
+  {
+    id: "dorothy-2-maestro",
+    name: "Dorothy 2 MaestroOS",
+    triggerType: "MQTT",
+    site: "Dorothy 2",
+    brokerHosts: ["10.144.0.3", "10.144.0.4"],
+    port: 1883,
+    topic: "maestro/target",
+    protocol: "MQTT 3.1.1",
+    qos: 1,
+    username: "soluna-dorothy",
+    scope: "Dorothy 2",
+    curtailmentMode: "Curtail entire site",
+    lastTarget: 100,
+    lastSeen: "24 seconds ago",
+    health: "connected",
+    enabled: true,
+  },
+];
+
+describe("CurtailmentSettingsPage", () => {
+  beforeEach(() => {
+    vi.mocked(useHasPermission).mockReset();
+  });
+
+  it("renders the curtailment header and sources table", () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsPage />
+      </MemoryRouter>,
+    );
+
+    expect(useHasPermission).toHaveBeenCalledWith("curtailment:manage");
+    expect(screen.getByTestId("settings-curtailment-page")).toBeVisible();
+    expect(screen.getByText("Curtailment")).toBeVisible();
+    expect(
+      screen.getByText(
+        "Configure response profiles, manage external signal sources, and define automations that trigger curtailment.",
+      ),
+    ).toBeVisible();
+    expect(screen.getByText("Sources")).toBeVisible();
+    expect(screen.getByRole("button", { name: "About sources" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Add source" })).toBeEnabled();
+    expect(document.querySelector(".curtailment-section-header__icon")).not.toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Name" }).closest("table")?.className).toContain(
+      "[&_thead_th]:text-text-primary-50",
+    );
+
+    for (const columnName of ["Name", "Last signal", "Updated", "Connection", "Enabled"]) {
+      expect(screen.getByRole("columnheader", { name: columnName })).toBeInTheDocument();
+    }
+    expect(screen.queryByRole("columnheader", { name: "Last target" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Type" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Broker hosts" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Kati MaestroOS")).not.toBeInTheDocument();
+    expect(screen.queryByText("Dorothy 2 MaestroOS")).not.toBeInTheDocument();
+    expect(screen.getByTestId("list-empty-row")).toBeInTheDocument();
+    expect(screen.getByText("No sources configured")).toBeVisible();
+    expect(screen.getByText("Add a source to receive curtailment signals via MQTT.")).toBeVisible();
+  });
+
+  it("renders provided sources with the current table styling", () => {
+    render(<CurtailmentSettingsContent initialSources={testSources} />);
+
+    expect(screen.getByText("Kati MaestroOS")).toBeVisible();
+    expect(screen.getByText("Dorothy 2 MaestroOS")).toBeVisible();
+    expect(screen.getByText("38 seconds ago")).toBeVisible();
+    expect(screen.getByText("24 seconds ago")).toBeVisible();
+    const connectedLabels = screen.getAllByText("Connected");
+    expect(connectedLabels).toHaveLength(2);
+    for (const connectedLabel of connectedLabels) {
+      expect(connectedLabel.previousElementSibling).toHaveClass("h-2", "w-2", "rounded-full", "bg-intent-success-fill");
+    }
+    expect(document.querySelector(".curtailment-source-health")).not.toBeInTheDocument();
+  });
+
+  it("opens the source dialog and closes it from Save without persisting yet", async () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsContent initialSources={testSources} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add source" }));
+
+    expect(screen.getByTestId("curtailment-source-modal")).toBeInTheDocument();
+    expect(screen.getByText("External systems that send curtailment signals via MQTT.")).toBeInTheDocument();
+    expect(screen.getByText("Configuration name")).toBeInTheDocument();
+    for (const fieldLabel of [
+      "Configuration name",
+      "Broker host 1",
+      "Broker host 2",
+      "Port",
+      "Topic",
+      "Username",
+      "Password",
+    ]) {
+      expect((screen.getByLabelText(fieldLabel) as HTMLInputElement).value).toBe("");
+    }
+    expect(screen.getByLabelText("Source type")).toHaveValue("MQTT");
+    expect(screen.getByLabelText("Source type")).toBeDisabled();
+    const portTooltip = screen.getByText("Default MQTT port is 1883.").parentElement;
+    const topicTooltip = screen.getByText("The MQTT topic to subscribe to for curtailment signals.").parentElement;
+    expect(portTooltip).toHaveClass("z-50", "w-72", "left-[16px]");
+    expect(portTooltip?.parentElement?.parentElement).toHaveClass("z-50");
+    expect(topicTooltip).toHaveClass("w-72");
+    expect(screen.getAllByText("Port")).toHaveLength(1);
+    expect(screen.getAllByText("Topic")).toHaveLength(1);
+    expect(screen.queryByText(/TLS/)).not.toBeInTheDocument();
+
+    const testConnectionButton = screen.getByRole("button", { name: "Test connection" });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(testConnectionButton.compareDocumentPosition(saveButton)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    fireEvent.click(testConnectionButton);
+
+    expect(screen.getByTestId("curtailment-source-modal")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(screen.queryByTestId("curtailment-source-modal")).not.toBeInTheDocument());
+  });
+
+  it("toggles the sources info popover", () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsPage />
+      </MemoryRouter>,
+    );
+
+    const infoButton = screen.getByRole("button", { name: "About sources" });
+
+    expect(infoButton).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByTestId("curtailment-sources-info-popover")).not.toBeInTheDocument();
+
+    fireEvent.click(infoButton);
+
+    expect(infoButton).toHaveAttribute("aria-expanded", "true");
+    const popover = screen.getByTestId("curtailment-sources-info-popover");
+    expect(popover).toHaveTextContent("External systems that send curtailment signals via MQTT.");
+
+    fireEvent.click(infoButton);
+
+    expect(infoButton).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByTestId("curtailment-sources-info-popover")).not.toBeInTheDocument();
+  });
+
+  it("keeps source enablement as local state until the backend exists", () => {
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsContent initialSources={testSources} />
+      </MemoryRouter>,
+    );
+
+    const katiRow = screen.getByText("Kati MaestroOS").closest("tr");
+    expect(katiRow).not.toBeNull();
+
+    const katiSwitch = within(katiRow as HTMLTableRowElement).getByRole("checkbox");
+    expect(katiSwitch).toBeChecked();
+
+    fireEvent.click(katiSwitch);
+
+    expect(katiSwitch).not.toBeChecked();
+  });
+
+  it("redirects callers without curtailment management permission", () => {
+    vi.mocked(useHasPermission).mockReturnValue(false);
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsPage />
+      </MemoryRouter>,
+    );
+
+    expect(useHasPermission).toHaveBeenCalledWith("curtailment:manage");
+    expect(screen.queryByTestId("settings-curtailment-page")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -1,0 +1,317 @@
+import { useCallback, useMemo, useState } from "react";
+import { Navigate } from "react-router-dom";
+import clsx from "clsx";
+
+import type { CurtailmentHealth, CurtailmentSource } from "@/protoFleet/features/settings/components/Curtailment/types";
+import { useHasPermission } from "@/protoFleet/store";
+import { Info } from "@/shared/assets/icons";
+import { iconSizes } from "@/shared/assets/icons/constants";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import Header from "@/shared/components/Header";
+import Input from "@/shared/components/Input";
+import List from "@/shared/components/List";
+import type { ColConfig, ColTitles } from "@/shared/components/List/types";
+import Modal, { sizes as modalSizes } from "@/shared/components/Modal";
+import Popover, { PopoverProvider, popoverSizes, usePopover } from "@/shared/components/Popover";
+import Switch from "@/shared/components/Switch";
+import { positions } from "@/shared/constants";
+import { classNameToSelectors } from "@/shared/utils/cssUtils";
+import "./CurtailmentSettingsPage.css";
+
+const CURTAILMENT_PAGE_DESCRIPTION =
+  "Configure response profiles, manage external signal sources, and define automations that trigger curtailment.";
+const SOURCES_DESCRIPTION = "External systems that send curtailment signals via MQTT.";
+
+const curtailmentSourceCols = {
+  name: "name",
+  lastSignalValue: "lastSignalValue",
+  lastSignalUpdate: "lastSignalUpdate",
+  health: "health",
+  enabled: "enabled",
+} as const;
+
+type CurtailmentSourceColumn = (typeof curtailmentSourceCols)[keyof typeof curtailmentSourceCols];
+
+const activeCurtailmentSourceCols: CurtailmentSourceColumn[] = [
+  curtailmentSourceCols.name,
+  curtailmentSourceCols.lastSignalValue,
+  curtailmentSourceCols.lastSignalUpdate,
+  curtailmentSourceCols.health,
+  curtailmentSourceCols.enabled,
+];
+
+const curtailmentSourceColTitles: ColTitles<CurtailmentSourceColumn> = {
+  name: "Name",
+  lastSignalValue: "Last signal",
+  lastSignalUpdate: "Updated",
+  health: "Connection",
+  enabled: "",
+};
+
+const curtailmentSourceColumnAriaLabels: Partial<Record<CurtailmentSourceColumn, string>> = {
+  enabled: "Enabled",
+};
+
+const curtailmentSourceColumnsExemptFromDisabledStyling = new Set<CurtailmentSourceColumn>([
+  curtailmentSourceCols.enabled,
+]);
+
+const curtailmentSourcesTableClassName = [
+  "mb-2 w-full",
+  "phone:table-fixed",
+  "[&_thead_th]:text-text-primary-50",
+  "phone:[&_thead_th:last-child]:w-9",
+  "phone:[&_thead_th:last-child>div]:w-9",
+].join(" ");
+
+const sourceHealthDotClassName: Record<CurtailmentHealth, string> = {
+  connected: "bg-intent-success-fill",
+  stale: "bg-intent-warning-fill",
+  offline: "bg-intent-critical-fill",
+};
+
+const formatSourceHealth = (health: CurtailmentSource["health"]) =>
+  health
+    .split("-")
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+
+const SOURCES_INFO_TRIGGER_CLASS_NAME = "curtailment-sources-info-trigger";
+
+const SourcesInfoToggleContent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { triggerRef } = usePopover();
+  const closeIgnoreSelectors = classNameToSelectors(SOURCES_INFO_TRIGGER_CLASS_NAME);
+
+  return (
+    <div ref={triggerRef} className={`${SOURCES_INFO_TRIGGER_CLASS_NAME} relative`}>
+      <Button
+        variant={variants.secondary}
+        size={sizes.compact}
+        ariaHasPopup
+        ariaExpanded={isOpen}
+        ariaLabel="About sources"
+        prefixIcon={<Info width={iconSizes.small} className="text-text-primary-70" />}
+        onClick={() => setIsOpen((current) => !current)}
+      />
+      {isOpen ? (
+        <Popover
+          position={positions["bottom left"]}
+          size={popoverSizes.normal}
+          offset={8}
+          className="!space-y-0"
+          closePopover={() => setIsOpen(false)}
+          closeIgnoreSelectors={closeIgnoreSelectors}
+          testId="curtailment-sources-info-popover"
+        >
+          <p className="text-300 text-text-primary-70">{SOURCES_DESCRIPTION}</p>
+        </Popover>
+      ) : null}
+    </div>
+  );
+};
+
+const SourcesInfoToggle = () => (
+  <PopoverProvider>
+    <SourcesInfoToggleContent />
+  </PopoverProvider>
+);
+
+const SourcesEmptyState = () => (
+  <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
+    <div className="text-heading-200 text-text-primary">No sources configured</div>
+    <p className="mt-1 text-400 text-text-primary-70">Add a source to receive curtailment signals via MQTT.</p>
+  </div>
+);
+
+const SourceModal = ({ open, onDismiss }: { open: boolean; onDismiss: () => void }) => (
+  <Modal
+    open={open}
+    title="Add source"
+    description={SOURCES_DESCRIPTION}
+    onDismiss={onDismiss}
+    size={modalSizes.standard}
+    divider={false}
+    testId="curtailment-source-modal"
+    buttons={[
+      {
+        text: "Test connection",
+        variant: variants.secondary,
+        className: "whitespace-nowrap overflow-clip",
+        testId: "curtailment-source-test-connection-button",
+      },
+      {
+        text: "Save",
+        variant: variants.primary,
+      },
+    ]}
+    bodyClassName="text-text-primary"
+  >
+    <div className="grid gap-3 pb-2">
+      <div className="grid gap-4 laptop:grid-cols-2">
+        <Input id="source-name" label="Configuration name" />
+        <Input id="source-type" label="Source type" initValue="MQTT" disabled />
+      </div>
+      <div className="grid gap-4 laptop:grid-cols-2">
+        <Input id="source-host-primary" label="Broker host 1" />
+        <Input id="source-host-backup" label="Broker host 2" />
+      </div>
+      <div className="grid gap-4 laptop:grid-cols-2">
+        <Input
+          id="source-port"
+          label="Port"
+          type="number"
+          tooltip={{
+            body: "Default MQTT port is 1883.",
+            position: positions["top right"],
+            widthClassName: "w-72",
+          }}
+        />
+        <Input
+          id="source-topic"
+          label="Topic"
+          tooltip={{
+            body: "The MQTT topic to subscribe to for curtailment signals.",
+            widthClassName: "w-72",
+          }}
+        />
+      </div>
+      <div className="grid gap-4 laptop:grid-cols-2">
+        <Input id="source-username" label="Username" />
+        <Input id="source-password" label="Password" type="password" />
+      </div>
+    </div>
+  </Modal>
+);
+
+const SectionHeader = ({
+  title,
+  buttonText,
+  onButtonClick,
+}: {
+  title: string;
+  buttonText: string;
+  onButtonClick: () => void;
+}) => (
+  <div className="curtailment-section-header">
+    <div className="curtailment-section-header__title">
+      <h2 className="curtailment-section-header__label">{title}</h2>
+    </div>
+    <div className="flex shrink-0 items-center gap-2">
+      <SourcesInfoToggle />
+      <Button
+        variant={variants.secondary}
+        size={sizes.compact}
+        text={buttonText}
+        onClick={onButtonClick}
+        className="curtailment-settings__action-button"
+      />
+    </div>
+  </div>
+);
+
+const createCurtailmentSourceColConfig = ({
+  onToggle,
+}: {
+  onToggle: (sourceId: string) => void;
+}): ColConfig<CurtailmentSource, string, CurtailmentSourceColumn> => ({
+  [curtailmentSourceCols.name]: {
+    component: (source) => (
+      <span className="block max-w-full truncate text-emphasis-300 text-text-primary">{source.name}</span>
+    ),
+    width: "w-[34%] phone:w-auto",
+  },
+  [curtailmentSourceCols.lastSignalValue]: {
+    component: (source) => <span className="truncate text-text-primary">{source.lastTarget}</span>,
+    width: "w-[20%] phone:w-auto",
+  },
+  [curtailmentSourceCols.lastSignalUpdate]: {
+    component: (source) => <span className="truncate text-text-primary">{source.lastSeen}</span>,
+    width: "w-[20%] phone:w-auto",
+  },
+  [curtailmentSourceCols.health]: {
+    component: (source) => (
+      <div className="inline-flex items-center gap-1.5">
+        <span className={clsx("h-2 w-2 shrink-0 rounded-full", sourceHealthDotClassName[source.health])} />
+        <span className="truncate text-text-primary">{formatSourceHealth(source.health)}</span>
+      </div>
+    ),
+    width: "w-[20%] phone:w-auto",
+  },
+  [curtailmentSourceCols.enabled]: {
+    component: (source) => (
+      <div className="flex justify-end" data-interactive>
+        <Switch checked={source.enabled} setChecked={() => onToggle(source.id)} />
+      </div>
+    ),
+    width: "w-[6%] phone:w-9",
+  },
+});
+
+type CurtailmentSettingsContentProps = {
+  initialSources?: CurtailmentSource[];
+  initialSourceModalOpen?: boolean;
+};
+
+export const CurtailmentSettingsContent = ({
+  initialSources = [],
+  initialSourceModalOpen = false,
+}: CurtailmentSettingsContentProps) => {
+  const [sources, setSources] = useState<CurtailmentSource[]>(() => [...initialSources]);
+  const [isSourceModalOpen, setIsSourceModalOpen] = useState(initialSourceModalOpen);
+
+  const toggleSource = useCallback((sourceId: string) => {
+    setSources((current) =>
+      current.map((source) => (source.id === sourceId ? { ...source, enabled: !source.enabled } : source)),
+    );
+  }, []);
+
+  const colConfig = useMemo(
+    () =>
+      createCurtailmentSourceColConfig({
+        onToggle: toggleSource,
+      }),
+    [toggleSource],
+  );
+
+  return (
+    <div className="flex flex-col gap-14" data-testid="settings-curtailment-page">
+      <Header title="Curtailment" titleSize="text-heading-300" description={CURTAILMENT_PAGE_DESCRIPTION} />
+
+      <section className="curtailment-settings__section curtailment-settings__section--last">
+        <SectionHeader title="Sources" buttonText="Add source" onButtonClick={() => setIsSourceModalOpen(true)} />
+        <List<CurtailmentSource, string, CurtailmentSourceColumn>
+          activeCols={activeCurtailmentSourceCols}
+          colTitles={curtailmentSourceColTitles}
+          columnHeaderAriaLabels={curtailmentSourceColumnAriaLabels}
+          colConfig={colConfig}
+          items={sources}
+          itemKey="id"
+          total={sources.length}
+          hideTotal
+          itemName={{ singular: "source", plural: "sources" }}
+          stickyFirstColumn={false}
+          isRowDisabled={(source) => !source.enabled}
+          columnsExemptFromDisabledStyling={curtailmentSourceColumnsExemptFromDisabledStyling}
+          tableClassName={curtailmentSourcesTableClassName}
+          emptyStateRow={<SourcesEmptyState />}
+          applyColumnWidthsToCells
+        />
+      </section>
+
+      <SourceModal open={isSourceModalOpen} onDismiss={() => setIsSourceModalOpen(false)} />
+    </div>
+  );
+};
+
+const CurtailmentSettingsPage = () => {
+  const canManageCurtailment = useHasPermission("curtailment:manage");
+
+  if (!canManageCurtailment) {
+    return <Navigate to="/settings/general" replace />;
+  }
+
+  return <CurtailmentSettingsContent />;
+};
+
+export default CurtailmentSettingsPage;

--- a/client/src/protoFleet/features/settings/components/Curtailment/index.ts
+++ b/client/src/protoFleet/features/settings/components/Curtailment/index.ts
@@ -1,0 +1,1 @@
+export { CurtailmentSettingsContent, default } from "./CurtailmentSettingsPage";

--- a/client/src/protoFleet/features/settings/components/Curtailment/types.ts
+++ b/client/src/protoFleet/features/settings/components/Curtailment/types.ts
@@ -1,0 +1,44 @@
+export type CurtailmentHealth = "connected" | "stale" | "offline";
+export type AutomationTriggerType = "MQTT";
+
+export type CurtailmentSource = {
+  id: string;
+  name: string;
+  triggerType: AutomationTriggerType;
+  site: string;
+  brokerHosts: string[];
+  port: number;
+  topic: string;
+  protocol: string;
+  qos: number;
+  username: string;
+  scope: string;
+  curtailmentMode: string;
+  lastTarget: 0 | 100;
+  lastSeen: string;
+  health: CurtailmentHealth;
+  enabled: boolean;
+};
+
+export type ResponseProfile = {
+  id: string;
+  name: string;
+  targetSummary: string;
+  scope: string;
+  selectionStrategy: string;
+  restoreBehavior: string;
+  deadlineSummary: string;
+};
+
+export type AutomationConditionType = "mqttTriggerTargetOff" | "marketPriceAbove" | "hashpriceBelow" | "capacityAbove";
+
+export type AutomationRule = {
+  id: string;
+  priority: number;
+  name: string;
+  conditionType: AutomationConditionType;
+  conditionSummary: string;
+  sourceId?: string;
+  responseProfileId: string;
+  enabled: boolean;
+};

--- a/client/src/protoFleet/routePrefetch.test.ts
+++ b/client/src/protoFleet/routePrefetch.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { importSettingsCurtailment, settingsRoutePrefetch } from "@/protoFleet/routePrefetch";
+
+describe("settingsRoutePrefetch", () => {
+  it("warms the curtailment settings tab", () => {
+    expect(settingsRoutePrefetch).toContain(importSettingsCurtailment);
+  });
+});

--- a/client/src/protoFleet/routePrefetch.ts
+++ b/client/src/protoFleet/routePrefetch.ts
@@ -38,6 +38,7 @@ export const importSettingsRoles = () => import("@/protoFleet/features/settings/
 export const importSettingsFirmware = () => import("@/protoFleet/features/settings/components/Firmware");
 export const importSettingsSchedules = () =>
   import("@/protoFleet/features/settings/components/Schedules/SchedulesPage");
+export const importSettingsCurtailment = () => import("@/protoFleet/features/settings/components/Curtailment");
 export const importSettingsApiKeys = () => import("@/protoFleet/features/settings/components/ApiKeys");
 export const importSiteDetailPage = () => import("@/protoFleet/features/sites/pages/SiteDetailPage");
 export const importSitesPage = () => import("@/protoFleet/features/sites/pages/SitesPage");
@@ -73,6 +74,7 @@ export const settingsRoutePrefetch: readonly RouteImporter[] = [
   importSettingsRoles,
   importSettingsFirmware,
   importSettingsSchedules,
+  importSettingsCurtailment,
   importSettingsApiKeys,
   importServerLogsPage,
 ];

--- a/client/src/protoFleet/router.tsx
+++ b/client/src/protoFleet/router.tsx
@@ -26,6 +26,7 @@ import {
   importServerLogsPage,
   importSettingsApiKeys,
   importSettingsAuth,
+  importSettingsCurtailment,
   importSettingsFirmware,
   importSettingsGeneral,
   importSettingsLayout,
@@ -76,6 +77,7 @@ const SettingsTeam = lazy(importSettingsTeam);
 const SettingsRoles = lazy(importSettingsRoles);
 const SettingsFirmware = lazy(importSettingsFirmware);
 const SettingsSchedules = lazy(importSettingsSchedules);
+const SettingsCurtailment = lazy(importSettingsCurtailment);
 const SettingsApiKeys = lazy(importSettingsApiKeys);
 const SiteDetailPage = lazy(importSiteDetailPage);
 const SitesPage = lazy(importSitesPage);
@@ -242,6 +244,12 @@ const router = createBrowserRouter([
     "/settings/schedules",
     <SettingsLayout>
       <SettingsSchedules />
+    </SettingsLayout>,
+  ),
+  createRoute(
+    "/settings/curtailment",
+    <SettingsLayout>
+      <SettingsCurtailment />
     </SettingsLayout>,
   ),
   createRoute(

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -17,7 +17,7 @@ import useValueWidth from "./useValueWidth";
 import { DismissCircle, Eye } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Tooltip from "@/shared/components/Tooltip";
-import { positions } from "@/shared/constants";
+import { type Position, positions } from "@/shared/constants";
 
 interface InputProps {
   autoFocus?: boolean;
@@ -39,7 +39,7 @@ interface InputProps {
   onChangeBlur?: (value: string, id: string) => void;
   onKeyDown?: (key: string) => void;
   testId?: string;
-  tooltip?: { header: string; body: string };
+  tooltip?: { header?: string; body: string; position?: Position; widthClassName?: string };
   type?: string;
   statusIcon?: ReactNode;
   onFocus?: () => void;
@@ -254,8 +254,13 @@ const Input = ({
           {label}
         </label>
         {tooltip ? (
-          <div className="absolute top-7 right-4 -translate-y-1/2 transform">
-            <Tooltip header={tooltip.header} body={tooltip.body} position={positions["top left"]} />
+          <div className="absolute top-7 right-4 z-50 -translate-y-1/2 transform">
+            <Tooltip
+              header={tooltip.header}
+              body={tooltip.body}
+              position={tooltip.position ?? positions["top left"]}
+              widthClassName={tooltip.widthClassName}
+            />
           </div>
         ) : null}
         {dismiss && length(value) && !compact ? (

--- a/client/src/shared/components/Tooltip/Tooltip.tsx
+++ b/client/src/shared/components/Tooltip/Tooltip.tsx
@@ -8,9 +8,10 @@ interface TooltipProps {
   body: string;
   position: Position;
   icon?: "info" | "question";
+  widthClassName?: string;
 }
 
-const Tooltip = ({ header, body, position, icon = "question" }: TooltipProps) => {
+const Tooltip = ({ header, body, position, icon = "question", widthClassName = "w-80" }: TooltipProps) => {
   const isBottom = /^bottom/.test(position);
   const isLeft = /left$/.test(position);
   const yPosition = isBottom ? "top-[16px]" : "bottom-[16px]";
@@ -26,7 +27,8 @@ const Tooltip = ({ header, body, position, icon = "question" }: TooltipProps) =>
         className={clsx(
           "invisible opacity-0 peer-hover:visible peer-hover:opacity-100",
           "peer-hover:transform peer-hover:transition peer-hover:duration-200",
-          "absolute z-10 w-80 rounded-lg bg-surface-base p-4 text-text-primary shadow-200",
+          "absolute z-50 rounded-lg bg-surface-base p-4 text-text-primary shadow-200",
+          widthClassName,
           yPosition,
           xPosition,
           peerHover,


### PR DESCRIPTION
## Summary
- Split out the first curtailment sources settings slice under the 800-added-line review cap
- Add the settings page shell, route/nav wiring, story, and component tests

## Test plan
- [ ] Open Settings > Curtailment Sources and confirm the page renders from the nav
- [ ] Verify empty, loading, and error states display correctly
- [ ] Run the focused Vitest coverage for the page, nav, and route prefetch wiring

Refs #384