### PR TITLE
Fix Proto firmware uploads and progress reporting

### DIFF
--- a/client/src/protoFleet/api/useFileUpload.test.ts
+++ b/client/src/protoFleet/api/useFileUpload.test.ts
@@ -147,6 +147,34 @@ describe("useFileUpload", () => {
   });
 
   describe("chunked upload (fetch)", () => {
+    let xhrInstances: ChunkXHR[];
+
+    class ChunkXHR {
+      open = vi.fn();
+      send = vi.fn();
+      abort = vi.fn();
+      setRequestHeader = vi.fn();
+      withCredentials = false;
+      status = 0;
+      statusText = "";
+      responseText = "";
+      upload = { addEventListener: vi.fn() };
+      private listeners: Record<string, (() => void)[]> = {};
+
+      constructor() {
+        xhrInstances.push(this);
+      }
+
+      addEventListener(event: string, handler: () => void) {
+        if (!this.listeners[event]) this.listeners[event] = [];
+        this.listeners[event].push(handler);
+      }
+
+      trigger(event: string) {
+        this.listeners[event]?.forEach((h) => h());
+      }
+    }
+
     function mockFetchSequence(...responses: Array<{ status: number; body?: object }>) {
       const mocked = vi.fn();
       for (const { status, body } of responses) {
@@ -161,6 +189,19 @@ describe("useFileUpload", () => {
       return mocked;
     }
 
+    async function completeChunk(index: number, status = 200) {
+      await vi.waitFor(() => expect(xhrInstances.length).toBeGreaterThan(index));
+      const xhr = xhrInstances[index];
+      xhr.status = status;
+      xhr.trigger("load");
+    }
+
+    function triggerChunkProgress(xhr: ChunkXHR, loaded: number, total: number) {
+      const handler = xhr.upload.addEventListener.mock.calls[0]?.[1];
+      expect(handler).toBeTypeOf("function");
+      handler({ lengthComputable: true, loaded, total });
+    }
+
     const chunkedConfig = {
       enabled: true,
       chunkSize: 5,
@@ -169,25 +210,32 @@ describe("useFileUpload", () => {
       completeUrl: (id: string) => `/upload/chunked/${id}/complete`,
     };
 
+    beforeEach(() => {
+      xhrInstances = [];
+      vi.stubGlobal("XMLHttpRequest", ChunkXHR);
+    });
+
     it("uploads via initiate → PUT chunks → complete", async () => {
       const mockFetch = mockFetchSequence(
         { status: 200, body: { upload_id: "u1" } },
-        { status: 200 },
-        { status: 200 },
         { status: 200, body: { firmware_file_id: "fw-1" } },
       );
 
       const file = new File(["a".repeat(10)], "file.swu");
       const { result } = renderHook(() => useFileUpload());
-      const data = await result.current.upload("/ignored", file, { chunked: chunkedConfig });
+      const promise = result.current.upload("/ignored", file, { chunked: chunkedConfig });
+
+      await completeChunk(0);
+      await completeChunk(1);
+      const data = await promise;
 
       expect(data).toEqual({ firmware_file_id: "fw-1" });
-      expect(mockFetch).toHaveBeenCalledTimes(4);
-
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(mockFetch.mock.calls[0][0]).toBe("/upload/chunked");
-      expect(mockFetch.mock.calls[1][0]).toBe("/upload/chunked/u1");
-      expect(mockFetch.mock.calls[2][0]).toBe("/upload/chunked/u1");
-      expect(mockFetch.mock.calls[3][0]).toBe("/upload/chunked/u1/complete");
+      expect(mockFetch.mock.calls[1][0]).toBe("/upload/chunked/u1/complete");
+      expect(xhrInstances[0].open).toHaveBeenCalledWith("PUT", "/upload/chunked/u1");
+      expect(xhrInstances[0].setRequestHeader).toHaveBeenCalledWith("Content-Range", "bytes 0-4/10");
+      expect(xhrInstances[1].setRequestHeader).toHaveBeenCalledWith("Content-Range", "bytes 5-9/10");
     });
 
     it("calls logout on 401 during initiate", async () => {
@@ -200,32 +248,37 @@ describe("useFileUpload", () => {
     });
 
     it("calls logout on 401 during chunk upload", async () => {
-      mockFetchSequence({ status: 200, body: { upload_id: "u1" } }, { status: 401 });
+      mockFetchSequence({ status: 200, body: { upload_id: "u1" } });
       const file = new File(["a".repeat(10)], "file.swu");
       const { result } = renderHook(() => useFileUpload());
+      const promise = result.current.upload("/x", file, { chunked: chunkedConfig });
 
-      await expect(result.current.upload("/x", file, { chunked: chunkedConfig })).rejects.toThrow("Session expired");
+      await completeChunk(0, 401);
+
+      await expect(promise).rejects.toThrow("Session expired");
       expect(mockLogout).toHaveBeenCalledOnce();
     });
 
     it("reports progress after each chunk", async () => {
-      mockFetchSequence(
-        { status: 200, body: { upload_id: "u1" } },
-        { status: 200 },
-        { status: 200 },
-        { status: 200 },
-        { status: 200, body: { result: "ok" } },
-      );
+      mockFetchSequence({ status: 200, body: { upload_id: "u1" } }, { status: 200, body: { result: "ok" } });
 
       const file = new File(["a".repeat(15)], "file.swu");
       const onProgress = vi.fn();
       const { result } = renderHook(() => useFileUpload());
-      await result.current.upload("/x", file, { chunked: chunkedConfig, onProgress });
+      const promise = result.current.upload("/x", file, { chunked: chunkedConfig, onProgress });
 
-      expect(onProgress).toHaveBeenCalledTimes(3);
-      expect(onProgress).toHaveBeenNthCalledWith(1, 33);
-      expect(onProgress).toHaveBeenNthCalledWith(2, 67);
-      expect(onProgress).toHaveBeenNthCalledWith(3, 100);
+      await vi.waitFor(() => expect(xhrInstances).toHaveLength(1));
+      triggerChunkProgress(xhrInstances[0], 2, 5);
+      await completeChunk(0);
+      await vi.waitFor(() => expect(xhrInstances).toHaveLength(2));
+      triggerChunkProgress(xhrInstances[1], 2, 5);
+      await completeChunk(1);
+      await vi.waitFor(() => expect(xhrInstances).toHaveLength(3));
+      triggerChunkProgress(xhrInstances[2], 2, 5);
+      await completeChunk(2);
+      await promise;
+
+      expect(onProgress.mock.calls.map(([percent]) => percent)).toEqual([13, 33, 47, 67, 80, 100]);
     });
 
     it("respects abort signal between chunks", async () => {

--- a/client/src/protoFleet/api/useFileUpload.ts
+++ b/client/src/protoFleet/api/useFileUpload.ts
@@ -47,6 +47,76 @@ function handleAuth401(status: number, logout: () => void): void {
   }
 }
 
+function uploadChunk(
+  url: string,
+  chunk: Blob,
+  range: { start: number; end: number; total: number },
+  options: Pick<FileUploadOptions, "signal"> & { onUploadedBytes?: (uploadedBytes: number) => void },
+  logout: () => void,
+): Promise<void> {
+  if (options.signal?.aborted) {
+    return Promise.reject(new Error("Upload was cancelled."));
+  }
+
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    let settled = false;
+
+    const abortHandler = () => xhr.abort();
+    const cleanup = () => {
+      options.signal?.removeEventListener("abort", abortHandler);
+    };
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+
+    xhr.open("PUT", url);
+    xhr.withCredentials = true;
+    xhr.setRequestHeader("Content-Type", "application/octet-stream");
+    xhr.setRequestHeader("Content-Range", `bytes ${range.start}-${range.end - 1}/${range.total}`);
+
+    if (options.onUploadedBytes) {
+      xhr.upload.addEventListener("progress", (event) => {
+        if (event.lengthComputable) {
+          options.onUploadedBytes?.(range.start + event.loaded);
+        }
+      });
+    }
+
+    options.signal?.addEventListener("abort", abortHandler, { once: true });
+
+    xhr.addEventListener("load", () => {
+      if (xhr.status === 401) {
+        logout();
+        settle(() => reject(new Error("Session expired. Please log in again.")));
+        return;
+      }
+
+      if (xhr.status >= 200 && xhr.status < 300) {
+        options.onUploadedBytes?.(range.end);
+        settle(resolve);
+        return;
+      }
+
+      const message = extractXhrError(xhr.responseText, `Chunk upload failed: ${xhr.status} ${xhr.statusText}`);
+      settle(() => reject(new Error(message)));
+    });
+
+    xhr.addEventListener("error", () => {
+      settle(() => reject(new Error("Network error during upload.")));
+    });
+
+    xhr.addEventListener("abort", () => {
+      settle(() => reject(new Error("Upload was cancelled.")));
+    });
+
+    xhr.send(chunk);
+  });
+}
+
 async function uploadChunked(
   file: File,
   options: FileUploadOptions & { chunked: ChunkedUploadConfig },
@@ -54,6 +124,15 @@ async function uploadChunked(
 ): Promise<unknown> {
   const { chunked, onProgress, signal } = options;
   const totalChunks = Math.ceil(file.size / chunked.chunkSize);
+  let lastProgress = -1;
+  const reportProgress = (uploadedBytes: number) => {
+    if (!onProgress) return;
+    const percent = Math.min(100, Math.round((uploadedBytes / file.size) * 100));
+    if (percent !== lastProgress) {
+      lastProgress = percent;
+      onProgress(percent);
+    }
+  };
 
   const initResponse = await fetch(chunked.initiateUrl, {
     method: "POST",
@@ -87,28 +166,14 @@ async function uploadChunked(
     const start = i * chunked.chunkSize;
     const end = Math.min(start + chunked.chunkSize, file.size);
 
-    const chunkResponse = await fetch(chunked.chunkUrl(uploadId), {
-      method: "PUT",
-      credentials: "include",
-      headers: {
-        "Content-Type": "application/octet-stream",
-        "Content-Range": `bytes ${start}-${end - 1}/${file.size}`,
-      },
-      body: file.slice(start, end),
-      signal,
-    });
-
-    handleAuth401(chunkResponse.status, logout);
-    if (!chunkResponse.ok) {
-      throw new Error(
-        await extractFetchError(
-          chunkResponse,
-          `Chunk upload failed: ${chunkResponse.status} ${chunkResponse.statusText}`,
-        ),
-      );
-    }
-
-    onProgress?.(Math.round(((i + 1) / totalChunks) * 100));
+    await uploadChunk(
+      chunked.chunkUrl(uploadId),
+      file.slice(start, end),
+      { start, end, total: file.size },
+      { signal, onUploadedBytes: reportProgress },
+      logout,
+    );
+    reportProgress(end);
   }
 
   const completeResponse = await fetch(chunked.completeUrl(uploadId), {

--- a/plugin/proto/pkg/proto/client.go
+++ b/plugin/proto/pkg/proto/client.go
@@ -1141,51 +1141,26 @@ func (c *Client) UploadFirmware(ctx context.Context, firmware sdk.FirmwareFile) 
 	if firmware.Reader == nil {
 		return fmt.Errorf("firmware reader is required")
 	}
+	if firmware.Size < 0 {
+		return fmt.Errorf("firmware size must be non-negative")
+	}
 
 	uploadURL := fmt.Sprintf("%s/api/v1/system/update", c.baseURL)
 
 	ctx, cancel := context.WithTimeout(ctx, firmwareUploadTimeout)
 	defer cancel()
 
-	pr, pw := io.Pipe()
-	defer pr.Close()
+	body, contentType, contentLength, err := multipartFirmwareBody(firmware)
+	if err != nil {
+		return err
+	}
 
-	mw := multipart.NewWriter(pw)
-
-	// Channel captures the goroutine's outcome so we can confirm the entire
-	// multipart body was written before reporting success.
-	writerDone := make(chan error, 1)
-
-	go func() {
-		defer pw.Close()
-
-		part, err := mw.CreateFormFile("file", firmware.Filename)
-		if err != nil {
-			pw.CloseWithError(fmt.Errorf("failed to create multipart form file: %w", err))
-			writerDone <- err
-			return
-		}
-
-		if _, err := io.Copy(part, firmware.Reader); err != nil {
-			pw.CloseWithError(fmt.Errorf("failed to write firmware data: %w", err))
-			writerDone <- err
-			return
-		}
-
-		if err := mw.Close(); err != nil {
-			pw.CloseWithError(fmt.Errorf("failed to close multipart writer: %w", err))
-			writerDone <- err
-			return
-		}
-
-		writerDone <- nil
-	}()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, pr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, body)
 	if err != nil {
 		return fmt.Errorf("failed to create firmware upload request: %w", err)
 	}
-	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Content-Type", contentType)
+	req.ContentLength = contentLength
 	if c.bearerToken.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.bearerToken.Token)
 	}
@@ -1209,9 +1184,6 @@ func (c *Client) UploadFirmware(ctx context.Context, firmware sdk.FirmwareFile) 
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		if err := <-writerDone; err != nil {
-			return fmt.Errorf("firmware upload: multipart writer failed: %w", err)
-		}
 		return nil
 	case http.StatusUnauthorized:
 		return fmt.Errorf("firmware upload unauthorized: %s", withDetail("check bearer token", detail))
@@ -1226,6 +1198,20 @@ func (c *Client) UploadFirmware(ctx context.Context, firmware sdk.FirmwareFile) 
 	default:
 		return fmt.Errorf("firmware upload failed with status %d: %s", resp.StatusCode, withDetail("unknown error", detail))
 	}
+}
+
+func multipartFirmwareBody(firmware sdk.FirmwareFile) (io.Reader, string, int64, error) {
+	var header bytes.Buffer
+	writer := multipart.NewWriter(&header)
+	if _, err := writer.CreateFormFile("file", firmware.Filename); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to create multipart form file: %w", err)
+	}
+
+	footer := "\r\n--" + writer.Boundary() + "--\r\n"
+	contentLength := int64(header.Len()) + firmware.Size + int64(len(footer))
+	body := io.MultiReader(bytes.NewReader(header.Bytes()), firmware.Reader, strings.NewReader(footer))
+
+	return body, writer.FormDataContentType(), contentLength, nil
 }
 
 // withDetail returns detail if non-empty, otherwise falls back to fallback.

--- a/plugin/proto/pkg/proto/client.go
+++ b/plugin/proto/pkg/proto/client.go
@@ -1150,17 +1150,30 @@ func (c *Client) UploadFirmware(ctx context.Context, firmware sdk.FirmwareFile) 
 	ctx, cancel := context.WithTimeout(ctx, firmwareUploadTimeout)
 	defer cancel()
 
-	body, contentType, contentLength, err := multipartFirmwareBody(firmware)
+	parts, err := multipartFirmwareParts(firmware)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, body)
+	pr, pw := io.Pipe()
+	defer pr.Close()
+
+	writerDone := make(chan error, 1)
+	go func() {
+		if err := writeMultipartFirmwareBody(pw, firmware, parts); err != nil {
+			_ = pw.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		writerDone <- pw.Close()
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, pr)
 	if err != nil {
 		return fmt.Errorf("failed to create firmware upload request: %w", err)
 	}
-	req.Header.Set("Content-Type", contentType)
-	req.ContentLength = contentLength
+	req.Header.Set("Content-Type", parts.contentType)
+	req.ContentLength = parts.contentLength
 	if c.bearerToken.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.bearerToken.Token)
 	}
@@ -1184,6 +1197,9 @@ func (c *Client) UploadFirmware(ctx context.Context, firmware sdk.FirmwareFile) 
 
 	switch resp.StatusCode {
 	case http.StatusOK:
+		if err := <-writerDone; err != nil {
+			return fmt.Errorf("firmware upload: multipart writer failed: %w", err)
+		}
 		return nil
 	case http.StatusUnauthorized:
 		return fmt.Errorf("firmware upload unauthorized: %s", withDetail("check bearer token", detail))
@@ -1200,18 +1216,51 @@ func (c *Client) UploadFirmware(ctx context.Context, firmware sdk.FirmwareFile) 
 	}
 }
 
-func multipartFirmwareBody(firmware sdk.FirmwareFile) (io.Reader, string, int64, error) {
+type multipartFirmwareUpload struct {
+	header        []byte
+	footer        []byte
+	contentType   string
+	contentLength int64
+}
+
+func multipartFirmwareParts(firmware sdk.FirmwareFile) (multipartFirmwareUpload, error) {
 	var header bytes.Buffer
 	writer := multipart.NewWriter(&header)
 	if _, err := writer.CreateFormFile("file", firmware.Filename); err != nil {
-		return nil, "", 0, fmt.Errorf("failed to create multipart form file: %w", err)
+		return multipartFirmwareUpload{}, fmt.Errorf("failed to create multipart form file: %w", err)
 	}
 
-	footer := "\r\n--" + writer.Boundary() + "--\r\n"
-	contentLength := int64(header.Len()) + firmware.Size + int64(len(footer))
-	body := io.MultiReader(bytes.NewReader(header.Bytes()), firmware.Reader, strings.NewReader(footer))
+	var footer bytes.Buffer
+	footerWriter := multipart.NewWriter(&footer)
+	if err := footerWriter.SetBoundary(writer.Boundary()); err != nil {
+		return multipartFirmwareUpload{}, fmt.Errorf("failed to set multipart boundary: %w", err)
+	}
+	if err := footerWriter.Close(); err != nil {
+		return multipartFirmwareUpload{}, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
 
-	return body, writer.FormDataContentType(), contentLength, nil
+	return multipartFirmwareUpload{
+		header:        header.Bytes(),
+		footer:        footer.Bytes(),
+		contentType:   writer.FormDataContentType(),
+		contentLength: int64(header.Len()) + firmware.Size + int64(footer.Len()),
+	}, nil
+}
+
+func writeMultipartFirmwareBody(w io.Writer, firmware sdk.FirmwareFile, parts multipartFirmwareUpload) error {
+	if _, err := w.Write(parts.header); err != nil {
+		return fmt.Errorf("failed to write multipart header: %w", err)
+	}
+	if _, err := io.CopyN(w, firmware.Reader, firmware.Size); err != nil {
+		if errors.Is(err, io.EOF) {
+			return fmt.Errorf("firmware reader ended before declared size %d: %w", firmware.Size, io.ErrUnexpectedEOF)
+		}
+		return fmt.Errorf("failed to write firmware data: %w", err)
+	}
+	if _, err := w.Write(parts.footer); err != nil {
+		return fmt.Errorf("failed to write multipart footer: %w", err)
+	}
+	return nil
 }
 
 // withDetail returns detail if non-empty, otherwise falls back to fallback.

--- a/plugin/proto/pkg/proto/client_test.go
+++ b/plugin/proto/pkg/proto/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,6 +33,23 @@ type zeroReader struct{}
 
 func (zeroReader) Read(p []byte) (int, error) {
 	clear(p)
+	return len(p), nil
+}
+
+type errorAfterReader struct {
+	remaining int
+	err       error
+}
+
+func (r *errorAfterReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, r.err
+	}
+	if len(p) > r.remaining {
+		p = p[:r.remaining]
+	}
+	clear(p)
+	r.remaining -= len(p)
 	return len(p), nil
 }
 
@@ -1070,6 +1088,42 @@ func TestUploadFirmware(t *testing.T) {
 	}
 }
 
+func TestMultipartFirmwareBody_ContentLengthMatchesWrittenBytes(t *testing.T) {
+	firmwareContent := []byte("firmware-data")
+	firmware := sdk.FirmwareFile{
+		Reader:   bytes.NewReader(firmwareContent),
+		Filename: "firmware.swu",
+		Size:     int64(len(firmwareContent)),
+	}
+
+	parts, err := multipartFirmwareParts(firmware)
+	require.NoError(t, err)
+
+	var body bytes.Buffer
+	err = writeMultipartFirmwareBody(&body, firmware, parts)
+
+	require.NoError(t, err)
+	assert.Equal(t, parts.contentLength, int64(body.Len()))
+	assert.Contains(t, body.String(), `name="file"; filename="firmware.swu"`)
+}
+
+func TestMultipartFirmwareBody_ShortReaderReturnsError(t *testing.T) {
+	firmware := sdk.FirmwareFile{
+		Reader:   strings.NewReader("short"),
+		Filename: "firmware.swu",
+		Size:     100,
+	}
+
+	parts, err := multipartFirmwareParts(firmware)
+	require.NoError(t, err)
+
+	var body bytes.Buffer
+	err = writeMultipartFirmwareBody(&body, firmware, parts)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "firmware reader ended before declared size")
+}
+
 // TestUploadFirmware_413_ReturnsFailedPrecondition verifies that an HTTP 413 from the rig
 // produces a gRPC FailedPrecondition status error (which the server classifies as permanent).
 func TestUploadFirmware_413_ReturnsFailedPrecondition(t *testing.T) {
@@ -1101,6 +1155,31 @@ func TestUploadFirmware_413_ReturnsFailedPrecondition(t *testing.T) {
 	assert.Contains(t, st.Message(), "payload too large")
 	assert.Contains(t, st.Message(), "97000000")
 	assert.Contains(t, st.Message(), "413 Request Entity Too Large")
+}
+
+func TestUploadFirmware_EarlyOKWaitsForWriterError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	defer func() { _ = client.Close() }()
+
+	firmwareErr := errors.New("firmware stream failed")
+	firmware := sdk.FirmwareFile{
+		Reader:   &errorAfterReader{remaining: 1024, err: firmwareErr},
+		Filename: "firmware.swu",
+		Size:     97_000_000,
+	}
+
+	err := client.UploadFirmware(context.Background(), firmware)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "firmware stream failed")
 }
 
 // TestUploadFirmware_ContextCancellation tests that firmware upload respects context cancellation.

--- a/plugin/proto/pkg/proto/client_test.go
+++ b/plugin/proto/pkg/proto/client_test.go
@@ -28,6 +28,13 @@ const (
 	int32Bits   = 32
 )
 
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
+}
+
 // TestClientCreation tests the NewClient function with different configurations
 func TestClientCreation(t *testing.T) {
 	tests := []struct {
@@ -941,6 +948,8 @@ func TestUploadFirmware(t *testing.T) {
 					assert.Equal(t, "/api/v1/system/update", r.URL.Path)
 					assert.Equal(t, "Bearer "+testToken, r.Header.Get("Authorization"))
 					assert.True(t, strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data"))
+					assert.Empty(t, r.TransferEncoding, "firmware upload must not use chunked transfer encoding")
+					assert.Greater(t, r.ContentLength, int64(len(firmwareContent)), "multipart content length should include file plus form boundaries")
 
 					file, header, err := r.FormFile("file")
 					require.NoError(t, err, "should be able to read 'file' field")
@@ -1076,10 +1085,11 @@ func TestUploadFirmware_413_ReturnsFailedPrecondition(t *testing.T) {
 	err := client.SetCredentials(sdk.BearerToken{Token: "test-token"})
 	require.NoError(t, err)
 
+	const firmwareSize = 97_000_000
 	firmware := sdk.FirmwareFile{
-		Reader:   bytes.NewReader([]byte("firmware-data")),
+		Reader:   io.LimitReader(zeroReader{}, firmwareSize),
 		Filename: "firmware.swu",
-		Size:     97_000_000,
+		Size:     firmwareSize,
 	}
 
 	err = client.UploadFirmware(context.Background(), firmware)
@@ -1138,6 +1148,26 @@ func TestUploadFirmware_NilReader(t *testing.T) {
 	err := client.UploadFirmware(context.Background(), firmware)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "firmware reader is required")
+}
+
+func TestUploadFirmware_NegativeSize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("server should not be called when firmware size is invalid")
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	defer func() { _ = client.Close() }()
+
+	firmware := sdk.FirmwareFile{
+		Reader:   bytes.NewReader([]byte("firmware-data")),
+		Filename: "firmware.swu",
+		Size:     -1,
+	}
+
+	err := client.UploadFirmware(context.Background(), firmware)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "firmware size must be non-negative")
 }
 
 func TestErrorsResponse_UnmarshalJSON(t *testing.T) {

--- a/plugin/proto/pkg/proto/client_test.go
+++ b/plugin/proto/pkg/proto/client_test.go
@@ -1179,7 +1179,10 @@ func TestUploadFirmware_EarlyOKWaitsForWriterError(t *testing.T) {
 	err := client.UploadFirmware(context.Background(), firmware)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "firmware stream failed")
+	assert.True(t,
+		strings.Contains(err.Error(), "firmware stream failed") ||
+			strings.Contains(err.Error(), "multipart writer failed"),
+		"expected upload to surface the body writer failure, got: %v", err)
 }
 
 // TestUploadFirmware_ContextCancellation tests that firmware upload respects context cancellation.


### PR DESCRIPTION
## Summary
- Fix Proto firmware uploads by sending multipart/form-data with a fixed `Content-Length` instead of `Transfer-Encoding: chunked`.
- Preserve streaming behavior and wait for the multipart writer to finish before treating HTTP `200` as upload success.
- Make large firmware upload progress more responsive by reporting per-chunk XHR upload progress instead of only updating after each 32MB chunk completes.
- Add regression coverage for request framing, multipart body length, writer/reader failure handling, invalid size metadata, and byte-based chunk progress.

## Test plan
- `env -u GOROOT go test ./plugin/proto/pkg/proto -run 'TestUploadFirmware|TestMultipartFirmwareBody'`
- `env -u GOROOT go test ./plugin/proto/pkg/proto`
- `cd client && npm test -- --run src/protoFleet/api/useFileUpload.test.ts`
- `cd client && npx eslint src/protoFleet/api/useFileUpload.ts src/protoFleet/api/useFileUpload.test.ts`
- PR Gate is green, including Proto Plugin Checks, Client Checks, Plugin Contract Checks, and ProtoFleet E2E firmware specs.

## Investigation notes
Production Proto firmware uploads failed through Fleet because the Go client streamed multipart bodies without `Content-Length`, causing the miner/nginx path to reject large uploads before `miner-api-server` recorded `PUT /api/v1/system/update`. A direct fixed-length `curl -F` upload to the same miner succeeded and reached `sw_update_status: installed`, confirming the request framing difference.

The frontend upload-progress issue was separate: large firmware files use 32MB chunked uploads, and the UI only advanced after each chunk finished. This PR keeps the same backend chunk size and request count, but uses XHR progress events for each chunk PUT to compute global upload progress from uploaded bytes.
