### PR TITLE
feat(fleet): cut miner data staleness from ~2.5min to ~40s

### DIFF
--- a/client/src/protoFleet/constants/polling.ts
+++ b/client/src/protoFleet/constants/polling.ts
@@ -1,6 +1,8 @@
 /**
  * Shared polling interval for refreshing data across all ProtoFleet pages.
  * Can be overridden via VITE_POLL_INTERVAL_MS environment variable.
- * Default: 60 seconds
+ * Default: 15 seconds, chosen to roughly match the server's per-device
+ * telemetry collection cadence (STALENESS_THRESHOLD) so the UI picks up
+ * fresh rows shortly after they land.
  */
-export const POLL_INTERVAL_MS = Number(import.meta.env.VITE_POLL_INTERVAL_MS) || 60000;
+export const POLL_INTERVAL_MS = Number(import.meta.env.VITE_POLL_INTERVAL_MS) || 15000;

--- a/plugin/proto/internal/device/device.go
+++ b/plugin/proto/internal/device/device.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -33,7 +34,7 @@ import (
 var _ sdk.Device = (*Device)(nil)
 
 const (
-	defaultStatusTTL          = 30 * time.Second
+	defaultStatusTTL          = 5 * time.Second
 	maxLogLines               = 10000
 	deviceVerificationTimeout = 10 * time.Second
 	firmwareRefreshInterval   = 5 * time.Minute
@@ -41,6 +42,17 @@ const (
 	teraHashToHashConversion                   = 1e12
 	joulesPerTeraHashToJoulesPerHashConversion = 1e-12
 )
+
+// statusCacheTTL returns the status cache TTL, reading from PROTO_STATUS_CACHE_TTL
+// env var (Go duration string) with a default of 5s.
+func statusCacheTTL() time.Duration {
+	if v := os.Getenv("PROTO_STATUS_CACHE_TTL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return defaultStatusTTL
+}
 
 // Device implements the SDK Device interface for a single Proto miner.
 //
@@ -131,7 +143,7 @@ func New(deviceID string, deviceInfo sdk.DeviceInfo, bearerToken sdk.BearerToken
 		id:         deviceID,
 		deviceInfo: deviceInfo,
 		client:     client,
-		statusTTL:  defaultStatusTTL,
+		statusTTL:  statusCacheTTL(),
 		mutex:      sync.Mutex{},
 	}
 

--- a/server/internal/domain/telemetry/config.go
+++ b/server/internal/domain/telemetry/config.go
@@ -5,8 +5,8 @@ import (
 )
 
 type Config struct {
-	StalenessThreshold       time.Duration `help:"Staleness threshold for telemetry data. If a device's last update is older than this duration, it will be considered stale." default:"1m" env:"STALENESS_THRESHOLD"`
-	FetchInterval            time.Duration `help:"Interval at which to fetch telemetry data from devices." default:"10s" env:"FETCH_INTERVAL"`
+	StalenessThreshold       time.Duration `help:"Staleness threshold for telemetry data. If a device's last update is older than this duration, it will be considered stale. Must be greater than FETCH_INTERVAL: the scheduler re-polls a device once its last update is older than STALENESS_THRESHOLD - FETCH_INTERVAL, so values <= FETCH_INTERVAL make every device stale on every tick (over-polling)." default:"20s" env:"STALENESS_THRESHOLD"`
+	FetchInterval            time.Duration `help:"Interval at which to fetch telemetry data from devices. Must be less than STALENESS_THRESHOLD (see its help for the re-poll cadence math)." default:"5s" env:"FETCH_INTERVAL"`
 	ConcurrencyLimit         int           `help:"Maximum number of concurrent telemetry fetch operations." default:"500" env:"CONCURRENCY_LIMIT"`
 	MetricTimeout            time.Duration `help:"Timeout for telemetry measurements from miners." default:"5s" env:"METRIC_TIMEOUT"`
 	DevicePollInterval       time.Duration `help:"Interval at which to poll for new paired devices." default:"10m" env:"DEVICE_POLL_INTERVAL"`

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -91,7 +91,7 @@ import (
 const (
 	// Default intervals
 	defaultStatusUpdateInterval    = 1 * time.Second
-	defaultFetchInterval           = 10 * time.Second
+	defaultFetchInterval           = 5 * time.Second
 	defaultDevicePollInterval      = 10 * time.Minute
 	defaultHeartbeatInterval       = 30 * time.Second
 	defaultBroadcasterPollInterval = 5 * time.Second


### PR DESCRIPTION
## Summary

Latest miner data was slow to surface in ProtoFleet because three independent polling layers compound, none of which push:

```
miner -> [plugin status cache: 30s Proto / 5s Antminer] -> plugin
      -> [server re-poll cadence: 50-60s effective]      -> fleetd
      -> [client list poll: 60s]                          -> UI
```

Worst-case staleness was ~151s for Proto miners / ~126s for Antminers. This PR tightens each layer via config defaults only, bringing worst case to **~41s for both miner types** (average ~20s).

![Lightning McQueen speeding](https://media.giphy.com/media/Dz1Dfah20TAha/giphy.gif)

## What changed

- Server: `STALENESS_THRESHOLD` 1m -> 20s, `FETCH_INTERVAL` 10s -> 5s. The scheduler only re-polls a device once its last update is older than `STALENESS_THRESHOLD - FETCH_INTERVAL`, so the effective per-device cadence drops from 50-60s to 15-20s. Help text now documents that invariant.
- Proto plugin: status cache TTL 30s -> 5s (matches the Antminer default), now overridable via `PROTO_STATUS_CACHE_TTL` (mirrors `ANTMINER_STATUS_CACHE_TTL`).
- Client: `POLL_INTERVAL_MS` default 60s -> 15s (`VITE_POLL_INTERVAL_MS` still overrides).

## Reviewer notes

- **Relationship to #431 (RefreshMiners RPC TDD):** complementary — no scheduler changes, no on-demand refresh path here.
- **Load tradeoffs:** ~3x `device_metrics` row rate (1440 -> 4320 rows/device/day) and ~3x plugin polls; 4x client RPC volume per open page, including hidden tabs. Plugin cache TTLs stay below the server cadence, so each server poll gets fresh data without hammering miner management APIs.
- All values remain env-tunable if a large fleet needs to back off.

## Test plan

- Server telemetry domain + scheduler tests pass (tests construct their own configs; defaults are not asserted anywhere).
- `plugin/proto` builds and device tests pass (tests inject their own TTL).
- Client suite passes; `Fleet.test.tsx` consumes `POLL_INTERVAL_MS` symbolically.
- Live end-to-end timestamp measurement not run (steps: compare `device_metrics.time` in psql vs `ListMinerStateSnapshots` response timestamp vs UI update with `just dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)