### PR TITLE
Auto-reboot firmware updates

### DIFF
--- a/client/e2eTests/protoFleet/spec/firmware.spec.ts
+++ b/client/e2eTests/protoFleet/spec/firmware.spec.ts
@@ -8,8 +8,13 @@ import { SettingsFirmwarePage } from "../pages/settingsFirmware";
 async function cleanupUpdatedRigMiner(minersPage: MinersPage, rigMinerIp: string) {
   const currentStatus = (await minersPage.getMinerStatus(rigMinerIp)).trim();
 
-  if (currentStatus === "Updating firmware") {
-    await minersPage.validateMinerStatusSettled(rigMinerIp, "Reboot required", testConfig.testTimeout);
+  if (currentStatus === "Updating firmware" || currentStatus === "Rebooting") {
+    try {
+      await minersPage.validateMinerStatusSettled(rigMinerIp, "Hashing", testConfig.testTimeout);
+    } catch (error) {
+      const fallbackStatus = (await minersPage.getMinerStatus(rigMinerIp)).trim();
+      if (fallbackStatus !== "Reboot required") throw error;
+    }
   }
 
   const rebootRequiredStatus = (await minersPage.getMinerStatus(rigMinerIp)).trim();
@@ -115,14 +120,8 @@ test.describe("Firmware", () => {
 
     await test.step("Validate the miner transitions through firmware update states", async () => {
       await minersPage.validateMinerStatusSettled(rigMinerIp, "Updating firmware", firmwareStatusTimeout);
-      await minersPage.validateMinerStatusSettled(rigMinerIp, "Reboot required", firmwareStatusTimeout);
-    });
-
-    await test.step("Reboot the miner and validate it returns to hashing", async () => {
-      await minersPage.clickMinerThreeDotsButton(rigMinerIp);
-      await minersPage.clickRebootButton();
-      await minersPage.clickRebootConfirm();
-      await minersPage.validateMinerStatusSettled(rigMinerIp, "Hashing");
+      await minersPage.validateMinerStatus(rigMinerIp, "Rebooting");
+      await minersPage.validateMinerStatusSettled(rigMinerIp, "Hashing", firmwareStatusTimeout);
     });
   });
 });

--- a/client/e2eTests/protoFleet/spec/firmware.spec.ts
+++ b/client/e2eTests/protoFleet/spec/firmware.spec.ts
@@ -26,6 +26,21 @@ async function cleanupUpdatedRigMiner(minersPage: MinersPage, rigMinerIp: string
   }
 }
 
+async function waitForFirmwareActivation(minersPage: MinersPage, rigMinerIp: string, timeoutMs: number) {
+  await test.expect
+    .poll(
+      async () => {
+        try {
+          return (await minersPage.getMinerStatus(rigMinerIp)).trim();
+        } catch {
+          return "";
+        }
+      },
+      { timeout: timeoutMs },
+    )
+    .toMatch(/^(Rebooting|Hashing)$/);
+}
+
 test.describe("Firmware", () => {
   let updatedRigMinerIp = "";
 
@@ -120,7 +135,7 @@ test.describe("Firmware", () => {
 
     await test.step("Validate the miner transitions through firmware update states", async () => {
       await minersPage.validateMinerStatusSettled(rigMinerIp, "Updating firmware", firmwareStatusTimeout);
-      await minersPage.validateMinerStatus(rigMinerIp, "Rebooting");
+      await waitForFirmwareActivation(minersPage, rigMinerIp, firmwareStatusTimeout);
       await minersPage.validateMinerStatusSettled(rigMinerIp, "Hashing", firmwareStatusTimeout);
     });
   });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
@@ -88,4 +88,12 @@ describe("FirmwareUpdateModal", () => {
     expect(await screen.findByText("Select an existing firmware file")).toBeInTheDocument();
     expect(screen.getByText("alpha.swu")).toBeInTheDocument();
   });
+
+  it("explains that miners reboot automatically after firmware installation", () => {
+    mockListFirmwareFiles.mockResolvedValue([]);
+
+    render(<FirmwareUpdateModal open onConfirm={vi.fn()} onDismiss={vi.fn()} />);
+
+    expect(screen.getByText(/reboot automatically after installation completes/i)).toBeInTheDocument();
+  });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -109,7 +109,9 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
 
   return (
     <Modal open={open} title="Add firmware payload" onDismiss={handleDismiss} buttons={buttons} divider={false}>
-      <div className="text-text-secondary mt-2 text-300">Upload the firmware payload file to update your miners.</div>
+      <div className="text-text-secondary mt-2 text-300">
+        Select a firmware payload to update your miners. They will reboot automatically after installation completes.
+      </div>
       <div className="mt-6 flex flex-col gap-4">
         {showLoadingSpinner ? (
           <div className="flex items-center justify-center p-8">

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.test.tsx
@@ -51,6 +51,16 @@ describe("usePermittedActions", () => {
     vi.mocked(usePermissions).mockReturnValue(["miner:update_pools", "pool:read"]);
     const both = renderHook(() => usePermittedActions([action(settingsActions.miningPool)]));
     expect(both.result.current.map((a) => a.action)).toEqual([settingsActions.miningPool]);
+
+    // Firmware update needs miner:reboot too because successful installs
+    // automatically reboot the miner after activation.
+    vi.mocked(usePermissions).mockReturnValue(["miner:firmware_update"]);
+    const firmwareWithoutReboot = renderHook(() => usePermittedActions([action(deviceActions.firmwareUpdate)]));
+    expect(firmwareWithoutReboot.result.current).toEqual([]);
+
+    vi.mocked(usePermissions).mockReturnValue(["miner:firmware_update", "miner:reboot"]);
+    const firmwareWithReboot = renderHook(() => usePermittedActions([action(deviceActions.firmwareUpdate)]));
+    expect(firmwareWithReboot.result.current.map((a) => a.action)).toEqual([deviceActions.firmwareUpdate]);
   });
 
   it("passes through actions without a mapped permission (e.g. viewMiner)", () => {
@@ -96,7 +106,7 @@ describe("ACTION_PERMISSIONS", () => {
     // Unpair routes through FleetManagementService.DeleteMiners
     // (miner:delete) on the server, not MinerCommandService.Unpair.
     expect(ACTION_PERMISSIONS[deviceActions.unpair]).toBe("miner:delete");
-    expect(ACTION_PERMISSIONS[deviceActions.firmwareUpdate]).toBe("miner:firmware_update");
+    expect(ACTION_PERMISSIONS[deviceActions.firmwareUpdate]).toEqual(["miner:firmware_update", "miner:reboot"]);
     expect(ACTION_PERMISSIONS[deviceActions.downloadLogs]).toBe("miner:download_logs");
     expect(ACTION_PERMISSIONS[performanceActions.curtail]).toBe("curtailment:manage");
     expect(ACTION_PERMISSIONS[settingsActions.miningPool]).toEqual(["miner:update_pools", "pool:read"]);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions.ts
@@ -32,7 +32,7 @@ import { usePermissions } from "@/protoFleet/store";
 export const ACTION_PERMISSIONS: Record<SupportedAction, string | readonly string[]> = {
   [deviceActions.blinkLEDs]: "miner:blink_led",
   [deviceActions.downloadLogs]: "miner:download_logs",
-  [deviceActions.firmwareUpdate]: "miner:firmware_update",
+  [deviceActions.firmwareUpdate]: ["miner:firmware_update", "miner:reboot"],
   [deviceActions.reboot]: "miner:reboot",
   [deviceActions.shutdown]: "miner:stop_mining",
   [deviceActions.wakeUp]: "miner:start_mining",

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -3682,6 +3682,57 @@ describe("useMinerActions", () => {
       ).toBe(false);
     });
 
+    it("does not infer rebooting devices when successful identifiers are omitted", async () => {
+      mockFirmwareUpdate.mockImplementation(({ onSuccess }: any) => {
+        onSuccess({ batchIdentifier: "batch-firmware" });
+      });
+      mockStreamCommandBatchUpdates.mockImplementation(({ onStreamData }: any) => {
+        onStreamData({
+          status: {
+            commandBatchDeviceCount: {
+              total: BigInt(2),
+              success: BigInt(1),
+              failure: BigInt(0),
+              successDeviceIdentifiers: [],
+              failureDeviceIdentifiers: [],
+            },
+          },
+        });
+        return Promise.resolve();
+      });
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [
+            { deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE },
+            { deviceIdentifier: "device-2", deviceStatus: DeviceStatus.ONLINE },
+          ],
+          selectionMode: "subset",
+        }),
+      );
+
+      await act(async () => {
+        result.current.handleFirmwareUpdateConfirm("firmware-file-1");
+        await Promise.resolve();
+      });
+
+      expect(mockStartBatchOperation).toHaveBeenCalledTimes(1);
+      expect(mockStartBatchOperation).toHaveBeenCalledWith({
+        batchIdentifier: "batch-firmware",
+        action: deviceActions.firmwareUpdate,
+        deviceIdentifiers: ["device-1", "device-2"],
+      });
+      expect(mockCompleteBatchOperation).toHaveBeenCalledWith("batch-firmware");
+      expect(toaster.updateToast).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({
+          message: expect.not.stringContaining("rebooting"),
+          status: toaster.STATUSES.success,
+        }),
+      );
+    });
+
     it("does not open the firmware modal when capability verification fails", async () => {
       mockCheckCommandCapabilities.mockImplementationOnce(({ onError }: any) => {
         onError(new Error("Network error"));

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -30,6 +30,7 @@ const mockSetCoolingMode = vi.fn();
 const mockUpdateMinerPassword = vi.fn();
 const mockGetMinerModelGroups = vi.fn();
 const mockDownloadLogs = vi.fn();
+const mockFirmwareUpdate = vi.fn();
 const mockGetCommandBatchLogBundle = vi.fn();
 const mockRenameSingleMiner = vi.fn();
 const mockCheckCommandCapabilities = vi.fn(({ onSuccess }) => {
@@ -59,7 +60,7 @@ vi.mock("@/protoFleet/api/useMinerCommand", () => ({
     checkCommandCapabilities: mockCheckCommandCapabilities,
     updateMinerPassword: mockUpdateMinerPassword,
     downloadLogs: mockDownloadLogs,
-    firmwareUpdate: vi.fn(),
+    firmwareUpdate: mockFirmwareUpdate,
     getCommandBatchLogBundle: mockGetCommandBatchLogBundle,
   }),
 }));
@@ -3619,6 +3620,101 @@ describe("useMinerActions", () => {
       const fwAction = result.current.popoverActions.find((a) => a.action === deviceActions.firmwareUpdate);
 
       expect(fwAction).toEqual(expect.objectContaining({ icon: expect.objectContaining({ type: Settings }) }));
+    });
+
+    it("tracks successful firmware installs as rebooting after command completion", async () => {
+      mockFirmwareUpdate.mockImplementation(({ onSuccess }: any) => {
+        onSuccess({ batchIdentifier: "batch-firmware" });
+      });
+      mockStreamCommandBatchUpdates.mockImplementation(({ onStreamData }: any) => {
+        onStreamData({
+          status: {
+            commandBatchDeviceCount: {
+              total: BigInt(2),
+              success: BigInt(1),
+              failure: BigInt(1),
+              successDeviceIdentifiers: ["device-1"],
+              failureDeviceIdentifiers: ["device-2"],
+            },
+          },
+        });
+        return Promise.resolve();
+      });
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [
+            { deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE },
+            { deviceIdentifier: "device-2", deviceStatus: DeviceStatus.ONLINE },
+          ],
+          selectionMode: "subset",
+        }),
+      );
+
+      await act(async () => {
+        result.current.handleFirmwareUpdateConfirm("firmware-file-1");
+        await Promise.resolve();
+      });
+
+      expect(mockStartBatchOperation).toHaveBeenNthCalledWith(1, {
+        batchIdentifier: "batch-firmware",
+        action: deviceActions.firmwareUpdate,
+        deviceIdentifiers: ["device-1", "device-2"],
+      });
+      expect(mockStartBatchOperation).toHaveBeenNthCalledWith(2, {
+        batchIdentifier: "batch-firmware",
+        action: deviceActions.reboot,
+        deviceIdentifiers: ["device-1"],
+      });
+      expect(mockRemoveDevicesFromBatch).toHaveBeenCalledWith("batch-firmware", ["device-2"]);
+      expect(toaster.updateToast).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({
+          message: expect.stringContaining("rebooting"),
+          status: toaster.STATUSES.success,
+        }),
+      );
+      expect(
+        (toaster.updateToast as ReturnType<typeof vi.fn>).mock.calls.some(([, toast]) =>
+          String(toast?.message ?? "").includes("reboot required"),
+        ),
+      ).toBe(false);
+    });
+
+    it("does not open the firmware modal when capability verification fails", async () => {
+      mockCheckCommandCapabilities.mockImplementationOnce(({ onError }: any) => {
+        onError(new Error("Network error"));
+      });
+      const onActionComplete = vi.fn();
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [
+            { deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE },
+            { deviceIdentifier: "device-2", deviceStatus: DeviceStatus.ONLINE },
+          ],
+          selectionMode: "subset",
+          onActionComplete,
+        }),
+      );
+
+      const fwAction = result.current.popoverActions.find((a) => a.action === deviceActions.firmwareUpdate);
+
+      await act(async () => {
+        await fwAction!.actionHandler();
+      });
+
+      expect(result.current.showFirmwareUpdateModal).toBe(false);
+      expect(mockFirmwareUpdate).not.toHaveBeenCalled();
+      expect(onActionComplete).toHaveBeenCalled();
+      expect(toaster.pushToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("Unable to verify firmware update support"),
+          status: "error",
+        }),
+      );
     });
 
     it("should show error toast and not open modal when selected miners have mixed models", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -381,6 +381,8 @@ export const useMinerActions = ({
                 status: TOAST_STATUSES.error,
               });
               onActionComplete?.();
+              // Returning true means "handled": keep firmware updates
+              // fail-closed without showing the unsupported-miners modal.
               resolve(true);
               return;
             }
@@ -740,23 +742,27 @@ export const useMinerActions = ({
             completionHandled = true;
 
             if (successCount > 0) {
-              const rebootDeviceIds =
-                successIds.length > 0 ? successIds : deviceIdsToUse.filter((id) => !failureIds.includes(id));
+              const rebootDeviceIds = successIds;
+              const hasRebootDeviceIds = rebootDeviceIds.length > 0;
 
               updateToast(toastId, {
-                message: `${successMessages[deviceActions.firmwareUpdate]} ${successCount} out of ${totalCount} ${minersMessage}; rebooting`,
+                message: `${successMessages[deviceActions.firmwareUpdate]} ${successCount} out of ${totalCount} ${minersMessage}${
+                  hasRebootDeviceIds ? "; rebooting" : ""
+                }`,
                 status: TOAST_STATUSES.success,
                 progress: undefined,
                 longRunning: true,
                 ttl: false,
               });
 
-              if (rebootDeviceIds.length > 0) {
+              if (hasRebootDeviceIds) {
                 startBatchOperation({
                   batchIdentifier: value.batchIdentifier,
                   action: deviceActions.reboot,
                   deviceIdentifiers: rebootDeviceIds,
                 });
+              } else {
+                completeBatchOperation(value.batchIdentifier);
               }
             } else {
               removeToast(toastId);
@@ -835,6 +841,7 @@ export const useMinerActions = ({
       deviceSelector,
       firmwareUpdate,
       startBatchOperation,
+      completeBatchOperation,
       removeDevicesFromBatch,
       streamCommandBatchUpdates,
       deviceIdentifiers,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -375,13 +375,23 @@ export const useMinerActions = ({
             resolve(true);
           },
           onError: () => {
+            if (action === deviceActions.firmwareUpdate) {
+              pushToast({
+                message: "Unable to verify firmware update support for the selected miners. Please try again.",
+                status: TOAST_STATUSES.error,
+              });
+              onActionComplete?.();
+              resolve(true);
+              return;
+            }
+
             // On error, proceed without showing modal (fail-open for capability check)
             resolve(false);
           },
         });
       });
     },
-    [deviceSelector, checkCommandCapabilities],
+    [deviceSelector, checkCommandCapabilities, onActionComplete],
   );
 
   // Wraps checkAndShowUnsupportedMinersModal with the common proceed pattern:
@@ -721,6 +731,7 @@ export const useMinerActions = ({
           let errorToastId: number | null = null;
           let successCount = 0;
           let totalCount = 0;
+          let successIds: string[] = [];
           let failureIds: string[] = [];
           let completionHandled = false;
 
@@ -729,13 +740,24 @@ export const useMinerActions = ({
             completionHandled = true;
 
             if (successCount > 0) {
+              const rebootDeviceIds =
+                successIds.length > 0 ? successIds : deviceIdsToUse.filter((id) => !failureIds.includes(id));
+
               updateToast(toastId, {
-                message: `${successMessages[deviceActions.firmwareUpdate]} ${successCount} out of ${totalCount} ${minersMessage} — reboot required`,
+                message: `${successMessages[deviceActions.firmwareUpdate]} ${successCount} out of ${totalCount} ${minersMessage}; rebooting`,
                 status: TOAST_STATUSES.success,
                 progress: undefined,
                 longRunning: true,
                 ttl: false,
               });
+
+              if (rebootDeviceIds.length > 0) {
+                startBatchOperation({
+                  batchIdentifier: value.batchIdentifier,
+                  action: deviceActions.reboot,
+                  deviceIdentifiers: rebootDeviceIds,
+                });
+              }
             } else {
               removeToast(toastId);
             }
@@ -744,9 +766,9 @@ export const useMinerActions = ({
               removeDevicesFromBatch(value.batchIdentifier, failureIds);
             }
 
-            // Don't complete batch — let hasReachedExpectedStatus clear the
-            // in-progress state once the device reports REBOOT_REQUIRED.
-            // Stale cleanup handles eventual state cleanup.
+            // Re-track successful firmware installs as a reboot batch. The
+            // firmware REBOOT_REQUIRED status remains a fallback for failed
+            // auto-reboots and legacy in-flight updates.
             onRefetchMiners?.();
             onActionComplete?.();
           };
@@ -760,8 +782,8 @@ export const useMinerActions = ({
               totalCount = Number(response.status?.commandBatchDeviceCount?.total || 0);
               successCount = Number(response.status?.commandBatchDeviceCount?.success || 0);
               const failureCount = Number(response.status?.commandBatchDeviceCount?.failure || 0);
+              successIds = response.status?.commandBatchDeviceCount?.successDeviceIdentifiers || [];
               failureIds = response.status?.commandBatchDeviceCount?.failureDeviceIdentifiers || [];
-              // successDeviceIdentifiers no longer needed — optimistic mutation removed
               const completed = successCount + failureCount;
               const progress = totalCount > 0 ? Math.round((completed / totalCount) * 100) : 0;
 

--- a/client/src/protoFleet/features/fleetManagement/utils/batchStatusCheck.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/batchStatusCheck.ts
@@ -39,6 +39,7 @@ export function hasReachedExpectedStatus(
     // After 15s, complete when device is no longer OFFLINE
     return deviceStatus !== DeviceStatus.OFFLINE;
   } else if (action === deviceActions.firmwareUpdate) {
+    // Fallback for failed automatic reboots and legacy in-flight firmware updates.
     return deviceStatus === DeviceStatus.REBOOT_REQUIRED;
   }
 

--- a/server/internal/domain/authz/builtin_test.go
+++ b/server/internal/domain/authz/builtin_test.go
@@ -1,0 +1,44 @@
+package authz
+
+import "testing"
+
+func TestBuiltinRoles_AdminSeedsFirmwareUpdateAndReboot(t *testing.T) {
+	admin := builtinRoleByKey(t, BuiltinKeyAdmin)
+	perms := permissionSet(admin.SeedPermissions)
+
+	for _, key := range []string{PermMinerFirmwareUpdate, PermMinerReboot} {
+		if !perms[key] {
+			t.Fatalf("ADMIN seed permissions missing %q", key)
+		}
+	}
+}
+
+func TestBuiltinRoles_FieldTechDoesNotSeedFirmwareUpdateOrReboot(t *testing.T) {
+	fieldTech := builtinRoleByKey(t, BuiltinKeyFieldTech)
+	perms := permissionSet(fieldTech.SeedPermissions)
+
+	for _, key := range []string{PermMinerFirmwareUpdate, PermMinerReboot} {
+		if perms[key] {
+			t.Fatalf("FIELD_TECH seed permissions unexpectedly include %q", key)
+		}
+	}
+}
+
+func builtinRoleByKey(t *testing.T, key BuiltinKey) BuiltinRoleSpec {
+	t.Helper()
+	for _, role := range BuiltinRoles() {
+		if role.Key == key {
+			return role
+		}
+	}
+	t.Fatalf("builtin role %q not found", key)
+	return BuiltinRoleSpec{}
+}
+
+func permissionSet(keys []string) map[string]bool {
+	out := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		out[key] = true
+	}
+	return out
+}

--- a/server/internal/domain/authz/catalog.go
+++ b/server/internal/domain/authz/catalog.go
@@ -133,7 +133,7 @@ var catalog = []CatalogEntry{
 	{PermMinerDelete, "Delete a miner.", ResourceMiner},
 	{PermMinerSetCoolingMode, "Change a miner's cooling mode.", ResourceMiner},
 	{PermMinerSetPowerTarget, "Change a miner's power target.", ResourceMiner},
-	{PermMinerFirmwareUpdate, "Push and activate a firmware update on a miner, including an automatic reboot when required.", ResourceMiner},
+	{PermMinerFirmwareUpdate, "Push a firmware update to a miner. Firmware dispatch also requires miner:reboot because successful installs may reboot automatically.", ResourceMiner},
 	{PermMinerDownloadLogs, "Download diagnostic logs from a miner.", ResourceMiner},
 	{PermMinerUpdatePassword, "Change the miner's device-local web UI password.", ResourceMiner},
 	{PermMinerUnpair, "Unpair a miner from the fleet.", ResourceMiner},

--- a/server/internal/domain/authz/catalog.go
+++ b/server/internal/domain/authz/catalog.go
@@ -133,7 +133,7 @@ var catalog = []CatalogEntry{
 	{PermMinerDelete, "Delete a miner.", ResourceMiner},
 	{PermMinerSetCoolingMode, "Change a miner's cooling mode.", ResourceMiner},
 	{PermMinerSetPowerTarget, "Change a miner's power target.", ResourceMiner},
-	{PermMinerFirmwareUpdate, "Push a firmware update to a miner.", ResourceMiner},
+	{PermMinerFirmwareUpdate, "Push and activate a firmware update on a miner, including an automatic reboot when required.", ResourceMiner},
 	{PermMinerDownloadLogs, "Download diagnostic logs from a miner.", ResourceMiner},
 	{PermMinerUpdatePassword, "Change the miner's device-local web UI password.", ResourceMiner},
 	{PermMinerUnpair, "Unpair a miner from the fleet.", ResourceMiner},

--- a/server/internal/domain/authz/reconcile_test.go
+++ b/server/internal/domain/authz/reconcile_test.go
@@ -59,6 +59,7 @@ func TestReconcile_FreshInstall_AdminExcludesRoleManagement(t *testing.T) {
 	require.Contains(t, got, authz.PermUserRead, "ADMIN holds user:read so org admins can view the team roster")
 	require.Contains(t, got, authz.PermUserManage, "ADMIN holds user:manage; hierarchy check blocks elevated targets at the domain layer")
 	require.Contains(t, got, authz.PermMinerReboot, "ADMIN should still hold miner action permissions")
+	require.Contains(t, got, authz.PermMinerFirmwareUpdate, "ADMIN should seed with firmware update permissions")
 }
 
 func TestReconcile_FreshInstall_FieldTechHasExactSeedSet(t *testing.T) {

--- a/server/internal/domain/command/capability_checker.go
+++ b/server/internal/domain/command/capability_checker.go
@@ -193,7 +193,6 @@ func (c *CapabilityChecker) checkDeviceCapabilities(
 }
 
 // deviceSupportsCommand checks if a device supports the command.
-// Returns true if ANY of the required capabilities is supported.
 func (c *CapabilityChecker) deviceSupportsCommand(
 	ctx context.Context,
 	device deviceInfo,
@@ -209,72 +208,79 @@ func (c *CapabilityChecker) deviceSupportsCommand(
 		return false
 	}
 
+	if requiresAllCapabilities(requiredCaps) {
+		return hasAllCapabilities(capabilities.Commands, capabilities.Firmware, requiredCaps)
+	}
+
 	return hasAnyCapability(capabilities.Commands, capabilities.Firmware, requiredCaps)
+}
+
+func requiresAllCapabilities(requiredCaps []string) bool {
+	hasManualUpload := false
+	hasReboot := false
+	for _, cap := range requiredCaps {
+		switch cap {
+		case sdk.CapabilityManualUpload:
+			hasManualUpload = true
+		case sdk.CapabilityReboot:
+			hasReboot = true
+		}
+	}
+	return hasManualUpload && hasReboot
+}
+
+func hasAllCapabilities(commands *capabilitiespb.CommandCapabilities, firmware *capabilitiespb.FirmwareCapabilities, requiredCaps []string) bool {
+	for _, cap := range requiredCaps {
+		if !hasCapability(commands, firmware, cap) {
+			return false
+		}
+	}
+	return true
 }
 
 // hasAnyCapability checks if the device capabilities include any of the required capabilities.
 func hasAnyCapability(commands *capabilitiespb.CommandCapabilities, firmware *capabilitiespb.FirmwareCapabilities, requiredCaps []string) bool {
 	for _, cap := range requiredCaps {
-		switch cap {
-		case sdk.CapabilityReboot:
-			if commands.RebootSupported {
-				return true
-			}
-		case sdk.CapabilityMiningStart:
-			if commands.MiningStartSupported {
-				return true
-			}
-		case sdk.CapabilityMiningStop:
-			if commands.MiningStopSupported {
-				return true
-			}
-		case sdk.CapabilityLEDBlink:
-			if commands.LedBlinkSupported {
-				return true
-			}
-		case sdk.CapabilityCoolingModeAir:
-			if commands.AirCoolingSupported {
-				return true
-			}
-		case sdk.CapabilityCoolingModeImmerse:
-			if commands.ImmersionCoolingSupported {
-				return true
-			}
-		case sdk.CapabilityPoolConfig:
-			if commands.PoolSwitchingSupported {
-				return true
-			}
-		case sdk.CapabilityLogsDownload:
-			if commands.LogsDownloadSupported {
-				return true
-			}
-		case sdk.CapabilityManualUpload:
-			if firmware != nil && firmware.ManualUploadSupported {
-				return true
-			}
-		case sdk.CapabilityFactoryReset:
-			if commands.FactoryResetSupported {
-				return true
-			}
-		case sdk.CapabilityPowerModeEfficiency:
-			if commands.PowerModeEfficiencySupported {
-				return true
-			}
-		case sdk.CapabilityUpdateMinerPassword:
-			if commands.UpdateMinerPasswordSupported {
-				return true
-			}
-		case sdk.CapabilityCurtailFull:
-			if commands.CurtailFullSupported {
-				return true
-			}
-		case sdk.CapabilityCurtailEfficiency:
-			if commands.CurtailEfficiencySupported {
-				return true
-			}
+		if hasCapability(commands, firmware, cap) {
+			return true
 		}
 	}
 	return false
+}
+
+func hasCapability(commands *capabilitiespb.CommandCapabilities, firmware *capabilitiespb.FirmwareCapabilities, capability string) bool {
+	switch capability {
+	case sdk.CapabilityReboot:
+		return commands.RebootSupported
+	case sdk.CapabilityMiningStart:
+		return commands.MiningStartSupported
+	case sdk.CapabilityMiningStop:
+		return commands.MiningStopSupported
+	case sdk.CapabilityLEDBlink:
+		return commands.LedBlinkSupported
+	case sdk.CapabilityCoolingModeAir:
+		return commands.AirCoolingSupported
+	case sdk.CapabilityCoolingModeImmerse:
+		return commands.ImmersionCoolingSupported
+	case sdk.CapabilityPoolConfig:
+		return commands.PoolSwitchingSupported
+	case sdk.CapabilityLogsDownload:
+		return commands.LogsDownloadSupported
+	case sdk.CapabilityManualUpload:
+		return firmware != nil && firmware.ManualUploadSupported
+	case sdk.CapabilityFactoryReset:
+		return commands.FactoryResetSupported
+	case sdk.CapabilityPowerModeEfficiency:
+		return commands.PowerModeEfficiencySupported
+	case sdk.CapabilityUpdateMinerPassword:
+		return commands.UpdateMinerPasswordSupported
+	case sdk.CapabilityCurtailFull:
+		return commands.CurtailFullSupported
+	case sdk.CapabilityCurtailEfficiency:
+		return commands.CurtailEfficiencySupported
+	default:
+		return false
+	}
 }
 
 // stringOrEmpty returns the string value or empty string if the sql.NullString is not valid.

--- a/server/internal/domain/command/capability_checker_test.go
+++ b/server/internal/domain/command/capability_checker_test.go
@@ -445,6 +445,41 @@ func TestCheckDeviceCapabilities(t *testing.T) {
 		assert.True(t, result.NoneSupported)
 	})
 
+	t.Run("requires manual upload and reboot for firmware update", func(t *testing.T) {
+		provider := &mockCapabilitiesProvider{
+			capabilities: map[string]*capabilitiespb.MinerCapabilities{
+				"proto|Proto|Rig1": {
+					Commands: &capabilitiespb.CommandCapabilities{RebootSupported: true},
+					Firmware: &capabilitiespb.FirmwareCapabilities{ManualUploadSupported: true},
+				},
+				"proto|Proto|UploadOnly": {
+					Commands: &capabilitiespb.CommandCapabilities{RebootSupported: false},
+					Firmware: &capabilitiespb.FirmwareCapabilities{ManualUploadSupported: true},
+				},
+				"proto|Proto|RebootOnly": {
+					Commands: &capabilitiespb.CommandCapabilities{RebootSupported: true},
+					Firmware: &capabilitiespb.FirmwareCapabilities{ManualUploadSupported: false},
+				},
+			},
+		}
+		checker := NewCapabilityChecker(nil, provider)
+
+		devices := []deviceInfo{
+			{DeviceIdentifier: "device-1", DriverName: "proto", Manufacturer: "Proto", Model: "Rig1", FirmwareVersion: "2.0.0"},
+			{DeviceIdentifier: "device-2", DriverName: "proto", Manufacturer: "Proto", Model: "UploadOnly", FirmwareVersion: "2.0.0"},
+			{DeviceIdentifier: "device-3", DriverName: "proto", Manufacturer: "Proto", Model: "RebootOnly", FirmwareVersion: "2.0.0"},
+		}
+
+		result := checker.checkDeviceCapabilities(ctx, devices, []string{sdk.CapabilityManualUpload, sdk.CapabilityReboot})
+
+		assert.Equal(t, int32(1), result.SupportedCount)
+		assert.Equal(t, int32(2), result.UnsupportedCount)
+		assert.Equal(t, int32(3), result.TotalCount)
+		assert.False(t, result.AllSupported)
+		assert.False(t, result.NoneSupported)
+		assert.Equal(t, []string{"device-1"}, result.SupportedDeviceIdentifiers)
+	})
+
 	t.Run("returns unsupported when commands is nil", func(t *testing.T) {
 		provider := &mockCapabilitiesProvider{
 			capabilities: map[string]*capabilitiespb.MinerCapabilities{
@@ -511,7 +546,7 @@ func TestGetRequiredCapabilities(t *testing.T) {
 	t.Run("returns correct capabilities for firmware update command", func(t *testing.T) {
 		caps := GetRequiredCapabilities(pb.CommandType_COMMAND_TYPE_FIRMWARE_UPDATE)
 
-		assert.Equal(t, []string{sdk.CapabilityManualUpload}, caps)
+		assert.Equal(t, []string{sdk.CapabilityManualUpload, sdk.CapabilityReboot}, caps)
 	})
 
 	t.Run("returns nil for unknown command type", func(t *testing.T) {

--- a/server/internal/domain/command/capability_mapping.go
+++ b/server/internal/domain/command/capability_mapping.go
@@ -16,7 +16,7 @@ var commandTypeCapabilityMap = map[pb.CommandType][]string{
 	pb.CommandType_COMMAND_TYPE_SET_COOLING_MODE:      {sdk.CapabilityCoolingModeAir, sdk.CapabilityCoolingModeImmerse},
 	pb.CommandType_COMMAND_TYPE_UPDATE_MINING_POOLS:   {sdk.CapabilityPoolConfig},
 	pb.CommandType_COMMAND_TYPE_DOWNLOAD_LOGS:         {sdk.CapabilityLogsDownload},
-	pb.CommandType_COMMAND_TYPE_FIRMWARE_UPDATE:       {sdk.CapabilityManualUpload},
+	pb.CommandType_COMMAND_TYPE_FIRMWARE_UPDATE:       {sdk.CapabilityManualUpload, sdk.CapabilityReboot},
 	pb.CommandType_COMMAND_TYPE_SET_POWER_TARGET:      {sdk.CapabilityPowerModeEfficiency},
 	pb.CommandType_COMMAND_TYPE_UPDATE_MINER_PASSWORD: {sdk.CapabilityUpdateMinerPassword},
 	// CURTAIL: dispatch sends FULL level only, so Efficiency-only devices

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -535,7 +535,14 @@ func (es *ExecutionService) executeCommandOnDevice(ctx context.Context, commandT
 		if err != nil {
 			break
 		}
-		err = es.pollFirmwareInstallStatus(ctx, minerInfo, message.DeviceID)
+		installVerified, pollErr := es.pollFirmwareInstallStatus(ctx, minerInfo, message.DeviceID)
+		if pollErr != nil {
+			err = pollErr
+			break
+		}
+		if installVerified {
+			err = es.rebootAfterFirmwareInstall(ctx, minerInfo, message.DeviceID)
+		}
 	case commandtype.Unpair:
 		err = minerInfo.Unpair(ctx)
 		if err == nil {
@@ -942,8 +949,6 @@ const (
 	firmwareInstallGraceWindow  = 60 * time.Second
 )
 
-var errPollComplete = errors.New("polling complete")
-
 // clearFirmwareUpdateStatus resets the device status from REBOOT_REQUIRED back to ACTIVE
 // after a successful reboot command, allowing telemetry to take over status management.
 func (es *ExecutionService) clearFirmwareUpdateStatus(ctx context.Context, deviceID int64) {
@@ -962,7 +967,11 @@ func (es *ExecutionService) clearFirmwareUpdateStatus(ctx context.Context, devic
 	}
 	devID := tmodels.DeviceIdentifier(deviceIdentifier)
 
-	currentStatuses, err := es.deviceStore.GetDeviceStatusForDeviceIdentifiers(cleanupCtx, []tmodels.DeviceIdentifier{devID})
+	es.clearFirmwareUpdateStatusForDevice(cleanupCtx, deviceID, devID)
+}
+
+func (es *ExecutionService) clearFirmwareUpdateStatusForDevice(ctx context.Context, deviceID int64, devID tmodels.DeviceIdentifier) {
+	currentStatuses, err := es.deviceStore.GetDeviceStatusForDeviceIdentifiers(ctx, []tmodels.DeviceIdentifier{devID})
 	if err != nil {
 		slog.Warn("failed to read current device status for firmware status cleanup", "device_id", deviceID, "error", err)
 		return
@@ -974,7 +983,7 @@ func (es *ExecutionService) clearFirmwareUpdateStatus(ctx context.Context, devic
 
 	var upsertErr error
 	for attempt := range 3 {
-		upsertErr = es.deviceStore.UpsertDeviceStatus(cleanupCtx, devID, models.MinerStatusActive, "")
+		upsertErr = es.deviceStore.UpsertDeviceStatus(ctx, devID, models.MinerStatusActive, "")
 		if upsertErr == nil {
 			slog.Info("cleared firmware update status after reboot", "device_id", deviceID, "previous_status", currentStatus)
 			return
@@ -982,7 +991,7 @@ func (es *ExecutionService) clearFirmwareUpdateStatus(ctx context.Context, devic
 		slog.Warn("failed to clear firmware update status after reboot, retrying",
 			"device_id", deviceID, "attempt", attempt+1, "error", upsertErr)
 		select {
-		case <-cleanupCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-time.After(1 * time.Second):
 		}
@@ -994,31 +1003,31 @@ func (es *ExecutionService) clearFirmwareUpdateStatus(ctx context.Context, devic
 // pollFirmwareInstallStatus polls the rig's install status after a successful firmware
 // upload until installation completes or fails. The device status is set to UPDATING
 // only after the probe confirms the device supports install status reporting, then
-// transitions to REBOOT_REQUIRED on success.
-// Returns nil on successful install, or an error if installation fails or times out.
-// For miners that don't support install status polling, returns nil immediately.
-func (es *ExecutionService) pollFirmwareInstallStatus(ctx context.Context, minerInfo interfaces.Miner, deviceID int64) error {
+// transitions to REBOOT_REQUIRED on success. Returns true only when install
+// completion was verified and the device is ready for an activation reboot.
+// For miners that don't support install status polling, returns false, nil.
+func (es *ExecutionService) pollFirmwareInstallStatus(ctx context.Context, minerInfo interfaces.Miner, deviceID int64) (bool, error) {
 	provider, canPoll := minerInfo.(interfaces.FirmwareUpdateStatusProvider)
 	if !canPoll {
-		return nil
+		return false, nil
 	}
 
 	probeStatus, probeErr := provider.GetFirmwareUpdateStatus(ctx)
 	if probeErr == nil && probeStatus == nil {
 		slog.Info("firmware update status provider does not report install status, skipping polling", "device_id", deviceID)
-		return nil
+		return false, nil
 	}
 
 	deviceIdentifier, err := db.WithTransaction(ctx, es.conn, func(q *sqlc.Queries) (string, error) {
 		return q.GetDeviceIdentifierByID(ctx, deviceID)
 	})
 	if err != nil {
-		return fleeterror.NewInternalErrorf("failed to resolve device identifier for firmware status polling: %v", err)
+		return false, fleeterror.NewInternalErrorf("failed to resolve device identifier for firmware status polling: %v", err)
 	}
 
 	devID := tmodels.DeviceIdentifier(deviceIdentifier)
 
-	pollResult := es.doPollFirmwareInstall(ctx, provider, devID, deviceID, probeStatus, probeErr)
+	installVerified, pollResult := es.doPollFirmwareInstall(ctx, provider, devID, deviceID, probeStatus, probeErr)
 
 	if pollResult != nil {
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
@@ -1027,10 +1036,10 @@ func (es *ExecutionService) pollFirmwareInstallStatus(ctx context.Context, miner
 			slog.Warn("failed to clear firmware update status after polling failure", "device_id", deviceID, "error", upsertErr)
 		}
 	}
-	return pollResult
+	return installVerified, pollResult
 }
 
-func (es *ExecutionService) doPollFirmwareInstall(ctx context.Context, provider interfaces.FirmwareUpdateStatusProvider, devID tmodels.DeviceIdentifier, deviceID int64, probeStatus *sdk.FirmwareUpdateStatus, probeErr error) error {
+func (es *ExecutionService) doPollFirmwareInstall(ctx context.Context, provider interfaces.FirmwareUpdateStatusProvider, devID tmodels.DeviceIdentifier, deviceID int64, probeStatus *sdk.FirmwareUpdateStatus, probeErr error) (bool, error) {
 	if upsertErr := es.deviceStore.UpsertDeviceStatus(ctx, devID, models.MinerStatusUpdating, ""); upsertErr != nil {
 		slog.Warn("failed to set device status to UPDATING", "device_id", deviceID, "error", upsertErr)
 	}
@@ -1039,13 +1048,13 @@ func (es *ExecutionService) doPollFirmwareInstall(ctx context.Context, provider 
 	defer ticker.Stop()
 	uploadCompletedAt := time.Now()
 
-	handleStatus := func(status *sdk.FirmwareUpdateStatus, pollErr error) error {
+	handleStatus := func(status *sdk.FirmwareUpdateStatus, pollErr error) (bool, error) {
 		if pollErr != nil {
 			slog.Warn("firmware install status poll failed", "device_id", deviceID, "error", pollErr)
-			return nil
+			return false, nil
 		}
 		if status == nil {
-			return nil
+			return false, nil
 		}
 
 		switch status.State {
@@ -1055,18 +1064,18 @@ func (es *ExecutionService) doPollFirmwareInstall(ctx context.Context, provider 
 			if upsertErr := es.deviceStore.UpsertDeviceStatus(cleanupCtx, devID, models.MinerStatusRebootRequired, ""); upsertErr != nil {
 				slog.Error("firmware install completed but failed to persist REBOOT_REQUIRED, treating as success to avoid re-upload", "device_id", deviceID, "error", upsertErr)
 			}
-			slog.Info("firmware install completed, reboot required", "device_id", deviceID)
-			return errPollComplete
+			slog.Info("firmware install completed, rebooting device", "device_id", deviceID)
+			return true, nil
 
 		case "installing", "downloaded":
 			slog.Debug("firmware install in progress", "device_id", deviceID, "state", status.State, "progress", status.Progress)
 
 		case "current":
 			if status.Error != nil && *status.Error != "" {
-				return fleeterror.NewInternalErrorf("firmware install failed on device %d: %s", deviceID, *status.Error)
+				return false, fleeterror.NewInternalErrorf("firmware install failed on device %d: %s", deviceID, *status.Error)
 			}
 			if time.Since(uploadCompletedAt) > firmwareInstallGraceWindow {
-				return fleeterror.NewInternalErrorf("firmware install reverted to 'current' on device %d (install may have failed silently)", deviceID)
+				return false, fleeterror.NewInternalErrorf("firmware install reverted to 'current' on device %d (install may have failed silently)", deviceID)
 			}
 			slog.Debug("firmware install not started yet (grace window)", "device_id", deviceID)
 
@@ -1075,35 +1084,43 @@ func (es *ExecutionService) doPollFirmwareInstall(ctx context.Context, provider 
 			if status.Error != nil && *status.Error != "" {
 				errMsg = *status.Error
 			}
-			return fleeterror.NewInternalErrorf("firmware install failed on device %d: %s", deviceID, errMsg)
+			return false, fleeterror.NewInternalErrorf("firmware install failed on device %d: %s", deviceID, errMsg)
 
 		default:
 			slog.Debug("unexpected firmware install state", "device_id", deviceID, "state", status.State)
 		}
-		return nil
+		return false, nil
 	}
 
-	if result := handleStatus(probeStatus, probeErr); result != nil {
-		if errors.Is(result, errPollComplete) {
-			return nil
-		}
-		return result
+	if installVerified, result := handleStatus(probeStatus, probeErr); installVerified || result != nil {
+		return installVerified, result
 	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			return fleeterror.NewInternalErrorf("firmware install polling timed out for device %d", deviceID)
+			return false, fleeterror.NewInternalErrorf("firmware install polling timed out for device %d", deviceID)
 		case <-ticker.C:
 			status, pollErr := provider.GetFirmwareUpdateStatus(ctx)
-			if result := handleStatus(status, pollErr); result != nil {
-				if errors.Is(result, errPollComplete) {
-					return nil
-				}
-				return result
+			if installVerified, result := handleStatus(status, pollErr); installVerified || result != nil {
+				return installVerified, result
 			}
 		}
 	}
+}
+
+func (es *ExecutionService) rebootAfterFirmwareInstall(ctx context.Context, minerInfo interfaces.Miner, deviceID int64) error {
+	if err := minerInfo.Reboot(ctx); err != nil {
+		slog.Error("firmware install completed but automatic reboot failed",
+			"device_id", deviceID, "error", err)
+		return fleeterror.NewFailedPreconditionErrorf(
+			"firmware installed on device %d but automatic reboot failed: %v",
+			deviceID, err)
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	es.clearFirmwareUpdateStatusForDevice(cleanupCtx, deviceID, minerInfo.GetID())
+	return nil
 }
 
 // updateMinerPasswordInDB encrypts and stores the miner password in the database

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -535,12 +535,12 @@ func (es *ExecutionService) executeCommandOnDevice(ctx context.Context, commandT
 		if err != nil {
 			break
 		}
-		installVerified, pollErr := es.pollFirmwareInstallStatus(ctx, minerInfo, message.DeviceID)
+		shouldReboot, pollErr := es.pollFirmwareInstallStatus(ctx, minerInfo, message.DeviceID)
 		if pollErr != nil {
 			err = pollErr
 			break
 		}
-		if installVerified {
+		if shouldReboot {
 			err = es.rebootAfterFirmwareInstall(ctx, minerInfo, message.DeviceID)
 		}
 	case commandtype.Unpair:
@@ -949,8 +949,9 @@ const (
 	firmwareInstallGraceWindow  = 60 * time.Second
 )
 
-// clearFirmwareUpdateStatus resets the device status from REBOOT_REQUIRED back to ACTIVE
-// after a successful reboot command, allowing telemetry to take over status management.
+// clearFirmwareUpdateStatus resets stale firmware statuses back to ACTIVE after
+// a reboot command or firmware cleanup path, allowing telemetry to take over
+// status management.
 func (es *ExecutionService) clearFirmwareUpdateStatus(ctx context.Context, deviceID int64) {
 	if es.conn == nil {
 		return
@@ -1001,21 +1002,24 @@ func (es *ExecutionService) clearFirmwareUpdateStatusForDevice(ctx context.Conte
 }
 
 // pollFirmwareInstallStatus polls the rig's install status after a successful firmware
-// upload until installation completes or fails. The device status is set to UPDATING
-// only after the probe confirms the device supports install status reporting, then
-// transitions to REBOOT_REQUIRED on success. Returns true only when install
-// completion was verified and the device is ready for an activation reboot.
-// For miners that don't support install status polling, returns false, nil.
+// upload until installation completes or fails. Devices without install-status
+// reporting are still reboot-ready after upload success; capability dispatch has
+// already verified reboot support for firmware updates. For polling-capable
+// devices, status transitions to UPDATING while installation runs, then
+// REBOOT_REQUIRED on success.
 func (es *ExecutionService) pollFirmwareInstallStatus(ctx context.Context, minerInfo interfaces.Miner, deviceID int64) (bool, error) {
 	provider, canPoll := minerInfo.(interfaces.FirmwareUpdateStatusProvider)
 	if !canPoll {
-		return false, nil
+		slog.Info("firmware update status provider unavailable, rebooting after upload", "device_id", deviceID)
+		es.markFirmwareRebootRequired(ctx, deviceID)
+		return true, nil
 	}
 
 	probeStatus, probeErr := provider.GetFirmwareUpdateStatus(ctx)
 	if probeErr == nil && probeStatus == nil {
-		slog.Info("firmware update status provider does not report install status, skipping polling", "device_id", deviceID)
-		return false, nil
+		slog.Info("firmware update status provider does not report install status, rebooting after upload", "device_id", deviceID)
+		es.markFirmwareRebootRequired(ctx, deviceID)
+		return true, nil
 	}
 
 	deviceIdentifier, err := db.WithTransaction(ctx, es.conn, func(q *sqlc.Queries) (string, error) {
@@ -1037,6 +1041,24 @@ func (es *ExecutionService) pollFirmwareInstallStatus(ctx context.Context, miner
 		}
 	}
 	return installVerified, pollResult
+}
+
+func (es *ExecutionService) markFirmwareRebootRequired(ctx context.Context, deviceID int64) {
+	if es.conn == nil || es.deviceStore == nil {
+		return
+	}
+	deviceIdentifier, err := db.WithTransaction(ctx, es.conn, func(q *sqlc.Queries) (string, error) {
+		return q.GetDeviceIdentifierByID(ctx, deviceID)
+	})
+	if err != nil {
+		slog.Warn("failed to resolve device identifier for firmware reboot status", "device_id", deviceID, "error", err)
+		return
+	}
+
+	devID := tmodels.DeviceIdentifier(deviceIdentifier)
+	if upsertErr := es.deviceStore.UpsertDeviceStatus(ctx, devID, models.MinerStatusRebootRequired, ""); upsertErr != nil {
+		slog.Warn("failed to set firmware status to REBOOT_REQUIRED before automatic reboot", "device_id", deviceID, "error", upsertErr)
+	}
 }
 
 func (es *ExecutionService) doPollFirmwareInstall(ctx context.Context, provider interfaces.FirmwareUpdateStatusProvider, devID tmodels.DeviceIdentifier, deviceID int64, probeStatus *sdk.FirmwareUpdateStatus, probeErr error) (bool, error) {

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -596,7 +596,7 @@ func TestFirmwareUpdateAutoReboot(t *testing.T) {
 		assert.Contains(t, err.Error(), "automatic reboot failed")
 	})
 
-	t.Run("miner without firmware status provider does not auto reboot", func(t *testing.T) {
+	t.Run("miner without firmware status provider is reboot ready after upload", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -606,10 +606,10 @@ func TestFirmwareUpdateAutoReboot(t *testing.T) {
 		installVerified, err := svc.pollFirmwareInstallStatus(t.Context(), mockMiner, 42)
 
 		require.NoError(t, err)
-		assert.False(t, installVerified)
+		assert.True(t, installVerified)
 	})
 
-	t.Run("status provider with nil status does not auto reboot", func(t *testing.T) {
+	t.Run("status provider with nil status is reboot ready after upload", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -623,7 +623,7 @@ func TestFirmwareUpdateAutoReboot(t *testing.T) {
 		installVerified, err := svc.pollFirmwareInstallStatus(t.Context(), miner, 42)
 
 		require.NoError(t, err)
-		assert.False(t, installVerified)
+		assert.True(t, installVerified)
 	})
 }
 

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/miner/models"
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	storeMocks "github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
+	tmodels "github.com/block/proto-fleet/server/internal/domain/telemetry/models"
 	"github.com/block/proto-fleet/server/internal/infrastructure/queue"
 	"github.com/block/proto-fleet/server/internal/infrastructure/queue/mocks"
 	sdk "github.com/block/proto-fleet/server/sdk/v1"
@@ -24,6 +25,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+type firmwareStatusMiner struct {
+	minerInterfaces.Miner
+	minerInterfaces.FirmwareUpdateStatusProvider
+}
 
 func TestExecutionService_Start(t *testing.T) {
 	t.Run("starts when not running and returns true", func(t *testing.T) {
@@ -510,6 +516,114 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 
 		_, err := svc.executeCommandOnDevice(t.Context(), commandtype.Uncurtail, message)
 		require.NoError(t, err)
+	})
+}
+
+func TestFirmwareUpdateAutoReboot(t *testing.T) {
+	t.Run("verified install status is reboot ready", func(t *testing.T) {
+		for _, state := range []string{"installed", "success", "confirming"} {
+			t.Run(state, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+
+				mockDeviceStore := storeMocks.NewMockDeviceStore(ctrl)
+				mockProvider := minerIfaceMocks.NewMockFirmwareUpdateStatusProvider(ctrl)
+				devID := tmodels.DeviceIdentifier("device-123")
+
+				mockDeviceStore.EXPECT().
+					UpsertDeviceStatus(gomock.Any(), devID, models.MinerStatusUpdating, "").
+					Return(nil)
+				mockDeviceStore.EXPECT().
+					UpsertDeviceStatus(gomock.Any(), devID, models.MinerStatusRebootRequired, "").
+					Return(nil)
+
+				svc := &ExecutionService{deviceStore: mockDeviceStore}
+
+				installVerified, err := svc.doPollFirmwareInstall(
+					t.Context(),
+					mockProvider,
+					devID,
+					42,
+					&sdk.FirmwareUpdateStatus{State: state},
+					nil,
+				)
+
+				require.NoError(t, err)
+				assert.True(t, installVerified)
+			})
+		}
+	})
+
+	t.Run("successful automatic reboot clears firmware status", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockDeviceStore := storeMocks.NewMockDeviceStore(ctrl)
+		mockMiner := minerIfaceMocks.NewMockMiner(ctrl)
+		devID := tmodels.DeviceIdentifier("device-123")
+
+		mockMiner.EXPECT().Reboot(gomock.Any()).Return(nil)
+		mockMiner.EXPECT().GetID().Return(models.DeviceIdentifier("device-123"))
+		mockDeviceStore.EXPECT().
+			GetDeviceStatusForDeviceIdentifiers(gomock.Any(), []tmodels.DeviceIdentifier{devID}).
+			Return(map[tmodels.DeviceIdentifier]models.MinerStatus{devID: models.MinerStatusRebootRequired}, nil)
+		mockDeviceStore.EXPECT().
+			UpsertDeviceStatus(gomock.Any(), devID, models.MinerStatusActive, "").
+			Return(nil)
+
+		svc := &ExecutionService{deviceStore: mockDeviceStore}
+
+		err := svc.rebootAfterFirmwareInstall(t.Context(), mockMiner, 42)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("automatic reboot failure is permanent and leaves reboot required", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockDeviceStore := storeMocks.NewMockDeviceStore(ctrl)
+		mockMiner := minerIfaceMocks.NewMockMiner(ctrl)
+
+		mockMiner.EXPECT().Reboot(gomock.Any()).Return(errors.New("connection refused"))
+
+		svc := &ExecutionService{deviceStore: mockDeviceStore}
+
+		err := svc.rebootAfterFirmwareInstall(t.Context(), mockMiner, 42)
+
+		require.Error(t, err)
+		assert.True(t, fleeterror.IsFailedPreconditionError(err), "expected FailedPrecondition, got %v", err)
+		assert.Contains(t, err.Error(), "automatic reboot failed")
+	})
+
+	t.Run("miner without firmware status provider does not auto reboot", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockMiner := minerIfaceMocks.NewMockMiner(ctrl)
+		svc := &ExecutionService{}
+
+		installVerified, err := svc.pollFirmwareInstallStatus(t.Context(), mockMiner, 42)
+
+		require.NoError(t, err)
+		assert.False(t, installVerified)
+	})
+
+	t.Run("status provider with nil status does not auto reboot", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockMiner := minerIfaceMocks.NewMockMiner(ctrl)
+		mockProvider := minerIfaceMocks.NewMockFirmwareUpdateStatusProvider(ctrl)
+		mockProvider.EXPECT().GetFirmwareUpdateStatus(gomock.Any()).Return(nil, nil)
+
+		svc := &ExecutionService{}
+		miner := firmwareStatusMiner{Miner: mockMiner, FirmwareUpdateStatusProvider: mockProvider}
+
+		installVerified, err := svc.pollFirmwareInstallStatus(t.Context(), miner, 42)
+
+		require.NoError(t, err)
+		assert.False(t, installVerified)
 	})
 }
 

--- a/server/internal/handlers/command/handler.go
+++ b/server/internal/handlers/command/handler.go
@@ -198,6 +198,9 @@ func (h *Handler) FirmwareUpdate(ctx context.Context, req *connect.Request[pb.Fi
 	if _, err := middleware.RequirePermission(ctx, authz.PermMinerFirmwareUpdate, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerReboot, authz.ResourceContext{}); err != nil {
+		return nil, err
+	}
 	result, err := h.commandSvc.FirmwareUpdate(ctx, req.Msg.DeviceSelector, req.Msg.GetFirmwareFileId())
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/command/handler_test.go
+++ b/server/internal/handlers/command/handler_test.go
@@ -14,9 +14,11 @@ import (
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
 	"github.com/block/proto-fleet/server/generated/sqlc"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/command"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	handler "github.com/block/proto-fleet/server/internal/handlers/command"
+	"github.com/block/proto-fleet/server/internal/handlers/handlerstest"
 	db2 "github.com/block/proto-fleet/server/internal/infrastructure/db"
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
@@ -26,6 +28,43 @@ import (
 // and don't need plugin support.
 func TestCommandHandler(t *testing.T) {
 	t.Skip("Disabled pending plugin-based test infrastructure")
+}
+
+func TestHandler_FirmwareUpdateRequiresFirmwareUpdateAndRebootPermissions(t *testing.T) {
+	t.Parallel()
+	h := handler.NewHandler(nil)
+
+	cases := []struct {
+		name         string
+		permissions  []string
+		wantRequired string
+	}{
+		{
+			name:         "denies without firmware update permission",
+			permissions:  []string{authz.PermMinerReboot},
+			wantRequired: authz.PermMinerFirmwareUpdate,
+		},
+		{
+			name:         "denies without reboot permission",
+			permissions:  []string{authz.PermMinerFirmwareUpdate},
+			wantRequired: authz.PermMinerReboot,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := handlerstest.CtxWithPermissions(t, 1, tc.permissions...)
+
+			_, err := h.FirmwareUpdate(ctx, connect.NewRequest(&pb.FirmwareUpdateRequest{}))
+
+			require.Error(t, err)
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr)
+			assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+			assert.JSONEq(t, `{"required":"`+tc.wantRequired+`","scope":{}}`, fleetErr.DebugMessage)
+		})
+	}
 }
 
 // TestHandler_GetCommandBatchDeviceResults_PassesThroughHappyPath builds the

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -211,13 +211,15 @@ var ProcedurePermissions = map[string]string{
 	// MinerCommandService — each action gates on its matching catalog
 	// key. Stream/batch endpoints gate on fleet:read since they're
 	// status surfaces.
-	minercommandv1connect.MinerCommandServiceBlinkLEDProcedure:                     authz.PermMinerBlinkLED,
-	minercommandv1connect.MinerCommandServiceRebootProcedure:                       authz.PermMinerReboot,
-	minercommandv1connect.MinerCommandServiceStartMiningProcedure:                  authz.PermMinerStartMining,
-	minercommandv1connect.MinerCommandServiceStopMiningProcedure:                   authz.PermMinerStopMining,
-	minercommandv1connect.MinerCommandServiceUpdateMiningPoolsProcedure:            authz.PermMinerUpdatePools,
-	minercommandv1connect.MinerCommandServiceSetCoolingModeProcedure:               authz.PermMinerSetCoolingMode,
-	minercommandv1connect.MinerCommandServiceSetPowerTargetProcedure:               authz.PermMinerSetPowerTarget,
+	minercommandv1connect.MinerCommandServiceBlinkLEDProcedure:          authz.PermMinerBlinkLED,
+	minercommandv1connect.MinerCommandServiceRebootProcedure:            authz.PermMinerReboot,
+	minercommandv1connect.MinerCommandServiceStartMiningProcedure:       authz.PermMinerStartMining,
+	minercommandv1connect.MinerCommandServiceStopMiningProcedure:        authz.PermMinerStopMining,
+	minercommandv1connect.MinerCommandServiceUpdateMiningPoolsProcedure: authz.PermMinerUpdatePools,
+	minercommandv1connect.MinerCommandServiceSetCoolingModeProcedure:    authz.PermMinerSetCoolingMode,
+	minercommandv1connect.MinerCommandServiceSetPowerTargetProcedure:    authz.PermMinerSetPowerTarget,
+	// Primary procedure gate remains miner:firmware_update; the handler
+	// also requires miner:reboot because successful installs now reboot.
 	minercommandv1connect.MinerCommandServiceFirmwareUpdateProcedure:               authz.PermMinerFirmwareUpdate,
 	minercommandv1connect.MinerCommandServiceDownloadLogsProcedure:                 authz.PermMinerDownloadLogs,
 	minercommandv1connect.MinerCommandServiceUpdateMinerPasswordProcedure:          authz.PermMinerUpdatePassword,

--- a/server/internal/handlers/middleware/rpc_permissions_test.go
+++ b/server/internal/handlers/middleware/rpc_permissions_test.go
@@ -168,6 +168,13 @@ func TestRPCContract_ProcedurePermissionsKeysAreInCatalog(t *testing.T) {
 	}
 }
 
+func TestRPCContract_FirmwareUpdateUsesFirmwareUpdatePermission(t *testing.T) {
+	require.Equal(t,
+		authz.PermMinerFirmwareUpdate,
+		middleware.ProcedurePermissions[minercommandv1connect.MinerCommandServiceFirmwareUpdateProcedure],
+	)
+}
+
 // mainConnectMountRe captures both the connect-package shortname and
 // the service-handler short name (e.g. "authv1connect" + "Auth") from
 // every Connect handler mount in main.go like


### PR DESCRIPTION
## Summary
- Auto-reboot miners after verified firmware install states (`installed`, `success`, or `confirming`).
- Keep `miner:firmware_update` as the single RBAC gate while requiring firmware update capability checks to include both manual upload and reboot support.
- Update firmware update UI copy and active-batch handling so successful devices show `Rebooting` instead of `Reboot required`.

## Validation
- `go test ./server/internal/domain/command -run 'Test(FirmwareUpdateAutoReboot|CheckDeviceCapabilities|GetRequiredCapabilities|HasAnyCapability)'`
- `go test ./server/internal/handlers/middleware -run 'TestRPCContract_FirmwareUpdateUsesFirmwareUpdatePermission|TestRPCContract_ProcedurePermissionsKeysAreInCatalog'`
- `go test ./server/internal/domain/authz -run 'TestCatalog|TestLookup_UnknownKeyReturnsFalse|TestResourceOrder'`
- `npm test -- --run src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx src/protoFleet/features/fleetManagement/utils/batchStatusCheck.test.ts`
- `npx eslint --max-warnings 0 e2eTests/protoFleet/spec/firmware.spec.ts src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx src/protoFleet/features/fleetManagement/utils/batchStatusCheck.ts`
- pre-push hooks: `server-lint`, `client-typecheck`

Not run: Playwright E2E firmware spec.