### PR TITLE
Label curtailment sources as MaestroOS

### DIFF
--- a/client/src/protoFleet/api/useMqttCurtailmentSources.test.tsx
+++ b/client/src/protoFleet/api/useMqttCurtailmentSources.test.tsx
@@ -207,7 +207,7 @@ describe("useMqttCurtailmentSources", () => {
     const { result } = renderHook(() => useMqttCurtailmentSources(false));
 
     await expect(result.current.testConnection(testSourceFormValues)).rejects.toThrow(
-      "Failed to connect to the MQTT source.",
+      "Failed to connect to the Maestro source.",
     );
     expect(mockHandleAuthErrors).toHaveBeenCalled();
     expect(result.current.isTestingConnection).toBe(false);

--- a/client/src/protoFleet/api/useMqttCurtailmentSources.test.tsx
+++ b/client/src/protoFleet/api/useMqttCurtailmentSources.test.tsx
@@ -207,7 +207,7 @@ describe("useMqttCurtailmentSources", () => {
     const { result } = renderHook(() => useMqttCurtailmentSources(false));
 
     await expect(result.current.testConnection(testSourceFormValues)).rejects.toThrow(
-      "Failed to connect to the Maestro source.",
+      "Failed to connect to the MaestroOS source.",
     );
     expect(mockHandleAuthErrors).toHaveBeenCalled();
     expect(result.current.isTestingConnection).toBe(false);

--- a/client/src/protoFleet/api/useMqttCurtailmentSources.ts
+++ b/client/src/protoFleet/api/useMqttCurtailmentSources.ts
@@ -302,10 +302,10 @@ export default function useMqttCurtailmentSources(enabled = true): UseMqttCurtai
           buildTestConnectionRequest(values),
         );
         if (!response.ok) {
-          throw new Error("Failed to connect to the Maestro source.");
+          throw new Error("Failed to connect to the MaestroOS source.");
         }
       } catch (error) {
-        throw handleFailure(error, "Failed to connect to the Maestro source.");
+        throw handleFailure(error, "Failed to connect to the MaestroOS source.");
       } finally {
         setIsTestingConnection(false);
       }

--- a/client/src/protoFleet/api/useMqttCurtailmentSources.ts
+++ b/client/src/protoFleet/api/useMqttCurtailmentSources.ts
@@ -302,10 +302,10 @@ export default function useMqttCurtailmentSources(enabled = true): UseMqttCurtai
           buildTestConnectionRequest(values),
         );
         if (!response.ok) {
-          throw new Error("Failed to connect to the MQTT source.");
+          throw new Error("Failed to connect to the Maestro source.");
         }
       } catch (error) {
-        throw handleFailure(error, "Failed to connect to the MQTT source.");
+        throw handleFailure(error, "Failed to connect to the Maestro source.");
       } finally {
         setIsTestingConnection(false);
       }

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -371,7 +371,7 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByText("No response profiles configured")).toBeVisible();
     expect(screen.getByText("Add a profile to reuse curtailment actions across automation rules.")).toBeVisible();
     expect(screen.getByText("No sources configured")).toBeVisible();
-    expect(screen.getByText("Add a source to receive curtailment signals via Maestro.")).toBeVisible();
+    expect(screen.getByText("Add a source to receive curtailment signals via MaestroOS.")).toBeVisible();
   });
 
   it("renders sources returned by the API hook", () => {
@@ -807,7 +807,7 @@ describe("CurtailmentSettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add source" }));
 
     expect(screen.getByTestId("curtailment-source-modal")).toBeInTheDocument();
-    expect(screen.getByText("External systems that send curtailment signals via Maestro.")).toBeInTheDocument();
+    expect(screen.getByText("External systems that send curtailment signals via MaestroOS.")).toBeInTheDocument();
     expect(screen.getByText("Configuration name")).toBeInTheDocument();
     for (const fieldLabel of [
       "Configuration name",
@@ -820,10 +820,10 @@ describe("CurtailmentSettingsPage", () => {
     ]) {
       expect((screen.getByLabelText(fieldLabel) as HTMLInputElement).value).toBe("");
     }
-    expect(screen.getByLabelText("Source type")).toHaveValue("Maestro");
+    expect(screen.getByLabelText("Source type")).toHaveValue("MaestroOS");
     expect(screen.getByLabelText("Source type")).toBeDisabled();
-    const portTooltip = screen.getByText("Default Maestro port is 1883.").parentElement;
-    const topicTooltip = screen.getByText("The Maestro topic to subscribe to for curtailment signals.").parentElement;
+    const portTooltip = screen.getByText("Default MaestroOS port is 1883.").parentElement;
+    const topicTooltip = screen.getByText("The MaestroOS topic to subscribe to for curtailment signals.").parentElement;
     expect(portTooltip).toHaveClass("z-50", "w-72", "left-[16px]");
     expect(portTooltip?.parentElement?.parentElement).toHaveClass("z-50");
     expect(topicTooltip).toHaveClass("w-72");
@@ -1052,7 +1052,7 @@ describe("CurtailmentSettingsPage", () => {
 
     expect(infoButton).toHaveAttribute("aria-expanded", "true");
     const popover = screen.getByTestId("curtailment-sources-info-popover");
-    expect(popover).toHaveTextContent("External systems that send curtailment signals via Maestro.");
+    expect(popover).toHaveTextContent("External systems that send curtailment signals via MaestroOS.");
 
     fireEvent.click(infoButton);
 

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -371,7 +371,7 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByText("No response profiles configured")).toBeVisible();
     expect(screen.getByText("Add a profile to reuse curtailment actions across automation rules.")).toBeVisible();
     expect(screen.getByText("No sources configured")).toBeVisible();
-    expect(screen.getByText("Add a source to receive curtailment signals via MQTT.")).toBeVisible();
+    expect(screen.getByText("Add a source to receive curtailment signals via Maestro.")).toBeVisible();
   });
 
   it("renders sources returned by the API hook", () => {
@@ -807,7 +807,7 @@ describe("CurtailmentSettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add source" }));
 
     expect(screen.getByTestId("curtailment-source-modal")).toBeInTheDocument();
-    expect(screen.getByText("External systems that send curtailment signals via MQTT.")).toBeInTheDocument();
+    expect(screen.getByText("External systems that send curtailment signals via Maestro.")).toBeInTheDocument();
     expect(screen.getByText("Configuration name")).toBeInTheDocument();
     for (const fieldLabel of [
       "Configuration name",
@@ -820,10 +820,10 @@ describe("CurtailmentSettingsPage", () => {
     ]) {
       expect((screen.getByLabelText(fieldLabel) as HTMLInputElement).value).toBe("");
     }
-    expect(screen.getByLabelText("Source type")).toHaveValue("MQTT");
+    expect(screen.getByLabelText("Source type")).toHaveValue("Maestro");
     expect(screen.getByLabelText("Source type")).toBeDisabled();
-    const portTooltip = screen.getByText("Default MQTT port is 1883.").parentElement;
-    const topicTooltip = screen.getByText("The MQTT topic to subscribe to for curtailment signals.").parentElement;
+    const portTooltip = screen.getByText("Default Maestro port is 1883.").parentElement;
+    const topicTooltip = screen.getByText("The Maestro topic to subscribe to for curtailment signals.").parentElement;
     expect(portTooltip).toHaveClass("z-50", "w-72", "left-[16px]");
     expect(portTooltip?.parentElement?.parentElement).toHaveClass("z-50");
     expect(topicTooltip).toHaveClass("w-72");
@@ -1052,7 +1052,7 @@ describe("CurtailmentSettingsPage", () => {
 
     expect(infoButton).toHaveAttribute("aria-expanded", "true");
     const popover = screen.getByTestId("curtailment-sources-info-popover");
-    expect(popover).toHaveTextContent("External systems that send curtailment signals via MQTT.");
+    expect(popover).toHaveTextContent("External systems that send curtailment signals via Maestro.");
 
     fireEvent.click(infoButton);
 

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -40,7 +40,7 @@ import "./CurtailmentSettingsPage.css";
 const CURTAILMENT_PAGE_DESCRIPTION =
   "Configure response profiles, manage external signal sources, and define automations that trigger curtailment.";
 const RESPONSE_PROFILES_DESCRIPTION = "Saved configurations that define how much power to shed and how to restore it.";
-const SOURCES_DESCRIPTION = "External systems that send curtailment signals via MQTT.";
+const SOURCES_DESCRIPTION = "External systems that send curtailment signals via Maestro.";
 const SOURCE_CONNECTION_FAILURE_MESSAGE =
   "We couldn't connect with your source. Review your source details and try again.";
 const MAX_BROKER_PORT = 65_535;
@@ -527,7 +527,7 @@ function SourcesEmptyState(): ReactElement {
   return (
     <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
       <div className="text-heading-200 text-text-primary">No sources configured</div>
-      <p className="mt-1 text-400 text-text-primary-70">Add a source to receive curtailment signals via MQTT.</p>
+      <p className="mt-1 text-400 text-text-primary-70">Add a source to receive curtailment signals via Maestro.</p>
     </div>
   );
 }
@@ -835,7 +835,7 @@ function SourceModal({
             initValue={values.name}
             onChange={updateSourceValue}
           />
-          <Input id="source-type" label="Source type" initValue="MQTT" disabled />
+          <Input id="source-type" label="Source type" initValue="Maestro" disabled />
         </div>
         <div className="grid gap-4 laptop:grid-cols-2">
           <Input
@@ -860,7 +860,7 @@ function SourceModal({
             initValue={values.brokerPort}
             onChange={updateSourceValue}
             tooltip={{
-              body: "Default MQTT port is 1883.",
+              body: "Default Maestro port is 1883.",
               position: positions["top right"],
               widthClassName: "w-72",
             }}
@@ -871,7 +871,7 @@ function SourceModal({
             initValue={values.topic}
             onChange={updateSourceValue}
             tooltip={{
-              body: "The MQTT topic to subscribe to for curtailment signals.",
+              body: "The Maestro topic to subscribe to for curtailment signals.",
               widthClassName: "w-72",
             }}
           />

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -40,7 +40,7 @@ import "./CurtailmentSettingsPage.css";
 const CURTAILMENT_PAGE_DESCRIPTION =
   "Configure response profiles, manage external signal sources, and define automations that trigger curtailment.";
 const RESPONSE_PROFILES_DESCRIPTION = "Saved configurations that define how much power to shed and how to restore it.";
-const SOURCES_DESCRIPTION = "External systems that send curtailment signals via Maestro.";
+const SOURCES_DESCRIPTION = "External systems that send curtailment signals via MaestroOS.";
 const SOURCE_CONNECTION_FAILURE_MESSAGE =
   "We couldn't connect with your source. Review your source details and try again.";
 const MAX_BROKER_PORT = 65_535;
@@ -527,7 +527,7 @@ function SourcesEmptyState(): ReactElement {
   return (
     <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
       <div className="text-heading-200 text-text-primary">No sources configured</div>
-      <p className="mt-1 text-400 text-text-primary-70">Add a source to receive curtailment signals via Maestro.</p>
+      <p className="mt-1 text-400 text-text-primary-70">Add a source to receive curtailment signals via MaestroOS.</p>
     </div>
   );
 }
@@ -835,7 +835,7 @@ function SourceModal({
             initValue={values.name}
             onChange={updateSourceValue}
           />
-          <Input id="source-type" label="Source type" initValue="Maestro" disabled />
+          <Input id="source-type" label="Source type" initValue="MaestroOS" disabled />
         </div>
         <div className="grid gap-4 laptop:grid-cols-2">
           <Input
@@ -860,7 +860,7 @@ function SourceModal({
             initValue={values.brokerPort}
             onChange={updateSourceValue}
             tooltip={{
-              body: "Default Maestro port is 1883.",
+              body: "Default MaestroOS port is 1883.",
               position: positions["top right"],
               widthClassName: "w-72",
             }}
@@ -871,7 +871,7 @@ function SourceModal({
             initValue={values.topic}
             onChange={updateSourceValue}
             tooltip={{
-              body: "The Maestro topic to subscribe to for curtailment signals.",
+              body: "The MaestroOS topic to subscribe to for curtailment signals.",
               widthClassName: "w-72",
             }}
           />


### PR DESCRIPTION
## Summary
- Rename user-facing curtailment source copy from MQTT to MaestroOS
- Update the source connection fallback message and UI assertions

## Test plan
- [ ] Open Settings > Curtailment and confirm source descriptions, source type, and tooltips say MaestroOS
- [ ] Verify a source connection failure references MaestroOS in the fallback message
