### PR TITLE
Add ProtoOS header reboot E2E coverage

### DIFF
--- a/client/e2eTests/protoOS/helpers/apiAuthHelper.ts
+++ b/client/e2eTests/protoOS/helpers/apiAuthHelper.ts
@@ -1,0 +1,60 @@
+import { APIRequestContext, expect, Page } from "@playwright/test";
+
+type WaitForAuthenticatedApiRecoveryParams = {
+  accessToken: string;
+  path: string;
+  request: APIRequestContext;
+  timeoutMs?: number;
+};
+
+export async function getAuthAccessToken(page: Page) {
+  return page.evaluate(() => {
+    const authData = window.localStorage.getItem("proto-os-auth");
+    if (!authData) {
+      throw new Error("Missing proto-os-auth in localStorage");
+    }
+
+    const parsed = JSON.parse(authData) as {
+      state?: {
+        auth?: {
+          authTokens?: {
+            accessToken?: { value?: string };
+          };
+        };
+      };
+    };
+
+    const accessToken = parsed.state?.auth?.authTokens?.accessToken?.value;
+    if (!accessToken) {
+      throw new Error("Missing access token in proto-os-auth");
+    }
+
+    return accessToken;
+  });
+}
+
+export async function waitForAuthenticatedApiRecovery({
+  accessToken,
+  path,
+  request,
+  timeoutMs = 20_000,
+}: WaitForAuthenticatedApiRecoveryParams) {
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await request.get(path, {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          });
+
+          return response.status();
+        } catch {
+          return 0;
+        }
+      },
+      { timeout: timeoutMs },
+    )
+    .toBe(200);
+}

--- a/client/e2eTests/protoOS/helpers/apiAuthHelper.ts
+++ b/client/e2eTests/protoOS/helpers/apiAuthHelper.ts
@@ -4,7 +4,7 @@ type WaitForAuthenticatedApiRecoveryParams = {
   accessToken: string;
   path: string;
   request: APIRequestContext;
-  timeoutMs?: number;
+  timeoutMs: number;
 };
 
 export async function getAuthAccessToken(page: Page) {
@@ -37,7 +37,7 @@ export async function waitForAuthenticatedApiRecovery({
   accessToken,
   path,
   request,
-  timeoutMs = 20_000,
+  timeoutMs,
 }: WaitForAuthenticatedApiRecoveryParams) {
   await expect
     .poll(

--- a/client/e2eTests/protoOS/helpers/apiAuthHelper.ts
+++ b/client/e2eTests/protoOS/helpers/apiAuthHelper.ts
@@ -7,6 +7,24 @@ type WaitForAuthenticatedApiRecoveryParams = {
   timeoutMs: number;
 };
 
+async function getAuthenticatedApiStatus({
+  accessToken,
+  path,
+  request,
+}: Omit<WaitForAuthenticatedApiRecoveryParams, "timeoutMs">) {
+  try {
+    const response = await request.get(path, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    return response.status();
+  } catch {
+    return 0;
+  }
+}
+
 export async function getAuthAccessToken(page: Page) {
   return page.evaluate(() => {
     const authData = window.localStorage.getItem("proto-os-auth");
@@ -39,22 +57,16 @@ export async function waitForAuthenticatedApiRecovery({
   request,
   timeoutMs,
 }: WaitForAuthenticatedApiRecoveryParams) {
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await request.get(path, {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
-          });
+  await expect.poll(() => getAuthenticatedApiStatus({ accessToken, path, request }), { timeout: timeoutMs }).toBe(200);
+}
 
-          return response.status();
-        } catch {
-          return 0;
-        }
-      },
-      { timeout: timeoutMs },
-    )
-    .toBe(200);
+export async function waitForAuthenticatedApiOutage({
+  accessToken,
+  path,
+  request,
+  timeoutMs,
+}: WaitForAuthenticatedApiRecoveryParams) {
+  await expect
+    .poll(() => getAuthenticatedApiStatus({ accessToken, path, request }), { timeout: timeoutMs })
+    .not.toBe(200);
 }

--- a/client/e2eTests/protoOS/helpers/apiAuthHelper.ts
+++ b/client/e2eTests/protoOS/helpers/apiAuthHelper.ts
@@ -1,10 +1,17 @@
 import { APIRequestContext, expect, Page } from "@playwright/test";
 
+const FAKE_PROTO_RIG_SERIAL_PREFIX = "PROTO-SIM-";
+
 type WaitForAuthenticatedApiRecoveryParams = {
   accessToken: string;
   path: string;
   request: APIRequestContext;
   timeoutMs: number;
+};
+
+type SafeSimulatorTargetParams = {
+  actionDescription: string;
+  request: APIRequestContext;
 };
 
 async function getAuthenticatedApiStatus({
@@ -49,6 +56,29 @@ export async function getAuthAccessToken(page: Page) {
 
     return accessToken;
   });
+}
+
+export async function assertSafeSimulatorTarget({ actionDescription, request }: SafeSimulatorTargetParams) {
+  const response = await request.get("/api/v1/system");
+  expect(response.ok()).toBeTruthy();
+
+  const data = (await response.json()) as {
+    "system-info": {
+      cb_sn?: string;
+      product_name?: string;
+      manufacturer?: string;
+      model?: string;
+    };
+  };
+
+  const systemInfo = data["system-info"];
+  const serialNumber = systemInfo.cb_sn ?? "";
+
+  if (!serialNumber.startsWith(FAKE_PROTO_RIG_SERIAL_PREFIX)) {
+    throw new Error(
+      `Refusing to ${actionDescription} non-simulator target "${serialNumber || "unknown"}" (${systemInfo.manufacturer ?? "unknown"} ${systemInfo.product_name ?? systemInfo.model ?? "unknown"}).`,
+    );
+  }
 }
 
 export async function waitForAuthenticatedApiRecovery({

--- a/client/e2eTests/protoOS/pages/components/header.ts
+++ b/client/e2eTests/protoOS/pages/components/header.ts
@@ -22,12 +22,6 @@ export class HeaderComponent extends BasePage {
     await dialog.getByRole("button", { name: "Reboot miner" }).click();
   }
 
-  async validateRebootingDialogVisible() {
-    const dialog = this.page.getByTestId("rebooting-dialog");
-    await expect(dialog).toBeVisible();
-    await expect(dialog).toContainText("Rebooting miner");
-  }
-
   async clickMinerStatusButton(status: string = "Sleeping") {
     const header = this.page.getByTestId("page-header");
     await header.getByRole("button", { name: status }).click();

--- a/client/e2eTests/protoOS/pages/components/header.ts
+++ b/client/e2eTests/protoOS/pages/components/header.ts
@@ -11,6 +11,23 @@ export class HeaderComponent extends BasePage {
     await popover.getByRole("button", { name: buttonText }).click();
   }
 
+  async validateWarnRebootDialog() {
+    const dialog = this.page.getByTestId("warn-reboot-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("Reboot miner?");
+  }
+
+  async clickRebootMinerInDialog() {
+    const dialog = this.page.getByTestId("warn-reboot-dialog");
+    await dialog.getByRole("button", { name: "Reboot miner" }).click();
+  }
+
+  async validateRebootingDialogVisible() {
+    const dialog = this.page.getByTestId("rebooting-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("Rebooting miner");
+  }
+
   async clickMinerStatusButton(status: string = "Sleeping") {
     const header = this.page.getByTestId("page-header");
     await header.getByRole("button", { name: status }).click();

--- a/client/e2eTests/protoOS/spec/power.spec.ts
+++ b/client/e2eTests/protoOS/spec/power.spec.ts
@@ -1,9 +1,48 @@
-import { test } from "../fixtures/pageFixtures";
+import { expect, test } from "../fixtures/pageFixtures";
+import { getAuthAccessToken, waitForAuthenticatedApiRecovery } from "../helpers/apiAuthHelper";
 
 test.describe("Power management", () => {
   test.beforeEach(async ({ page, commonSteps }) => {
     await page.goto("/");
     await commonSteps.authenticateAsAdmin();
+  });
+
+  test("Miner can be rebooted from the header power menu", async ({ headerComponent, page, request }) => {
+    const accessToken = await getAuthAccessToken(page);
+    const rebootRequestPromise = page.waitForRequest(
+      (request) => request.method() === "POST" && request.url().includes("/api/v1/system/reboot"),
+    );
+    const rebootResponsePromise = page.waitForResponse(
+      (response) => response.request().method() === "POST" && response.url().includes("/api/v1/system/reboot"),
+    );
+
+    await test.step("Open the header power menu and choose reboot", async () => {
+      await headerComponent.clickPowerButton();
+      await headerComponent.clickPowerPopoverButton("Reboot");
+      await headerComponent.validateWarnRebootDialog();
+    });
+
+    await test.step("Confirm the reboot request starts", async () => {
+      await headerComponent.clickRebootMinerInDialog();
+
+      const rebootRequest = await rebootRequestPromise;
+      const rebootResponse = await rebootResponsePromise;
+
+      expect(rebootRequest.method()).toBe("POST");
+      expect(rebootResponse.status()).toBe(202);
+      await headerComponent.validateRebootingDialogVisible();
+    });
+
+    await test.step("Wait for the miner to come back and validate the UI recovers", async () => {
+      await waitForAuthenticatedApiRecovery({
+        accessToken,
+        path: "/api/v1/mining",
+        request,
+      });
+
+      await page.goto("/");
+      await headerComponent.validateMinerStatus("Hashing");
+    });
   });
 
   test("Miner sleep status in different pages", async ({

--- a/client/e2eTests/protoOS/spec/power.spec.ts
+++ b/client/e2eTests/protoOS/spec/power.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "../fixtures/pageFixtures";
-import { getAuthAccessToken, waitForAuthenticatedApiRecovery } from "../helpers/apiAuthHelper";
+import {
+  getAuthAccessToken,
+  waitForAuthenticatedApiOutage,
+  waitForAuthenticatedApiRecovery,
+} from "../helpers/apiAuthHelper";
 
+const REBOOT_OUTAGE_TIMEOUT_MS = 15_000;
 const REBOOT_RECOVERY_TIMEOUT_MS = 30_000;
 
 test.describe("Power management", () => {
@@ -25,9 +30,7 @@ test.describe("Power management", () => {
     });
 
     await test.step("Confirm the reboot request starts", async () => {
-      const rebootingDialogPromise = headerComponent.validateRebootingDialogVisible();
       await headerComponent.clickRebootMinerInDialog();
-      await rebootingDialogPromise;
 
       const rebootRequest = await rebootRequestPromise;
       const rebootResponse = await rebootResponsePromise;
@@ -37,6 +40,13 @@ test.describe("Power management", () => {
     });
 
     await test.step("Wait for the miner to come back and validate the UI recovers", async () => {
+      await waitForAuthenticatedApiOutage({
+        accessToken,
+        path: "/api/v1/mining",
+        request,
+        timeoutMs: REBOOT_OUTAGE_TIMEOUT_MS,
+      });
+
       await waitForAuthenticatedApiRecovery({
         accessToken,
         path: "/api/v1/mining",

--- a/client/e2eTests/protoOS/spec/power.spec.ts
+++ b/client/e2eTests/protoOS/spec/power.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "../fixtures/pageFixtures";
 import { getAuthAccessToken, waitForAuthenticatedApiRecovery } from "../helpers/apiAuthHelper";
 
+const REBOOT_RECOVERY_TIMEOUT_MS = 30_000;
+
 test.describe("Power management", () => {
   test.beforeEach(async ({ page, commonSteps }) => {
     await page.goto("/");
@@ -23,14 +25,15 @@ test.describe("Power management", () => {
     });
 
     await test.step("Confirm the reboot request starts", async () => {
+      const rebootingDialogPromise = headerComponent.validateRebootingDialogVisible();
       await headerComponent.clickRebootMinerInDialog();
+      await rebootingDialogPromise;
 
       const rebootRequest = await rebootRequestPromise;
       const rebootResponse = await rebootResponsePromise;
 
       expect(rebootRequest.method()).toBe("POST");
       expect(rebootResponse.status()).toBe(202);
-      await headerComponent.validateRebootingDialogVisible();
     });
 
     await test.step("Wait for the miner to come back and validate the UI recovers", async () => {
@@ -38,6 +41,7 @@ test.describe("Power management", () => {
         accessToken,
         path: "/api/v1/mining",
         request,
+        timeoutMs: REBOOT_RECOVERY_TIMEOUT_MS,
       });
 
       await page.goto("/");

--- a/client/e2eTests/protoOS/spec/power.spec.ts
+++ b/client/e2eTests/protoOS/spec/power.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../fixtures/pageFixtures";
 import {
+  assertSafeSimulatorTarget,
   getAuthAccessToken,
   waitForAuthenticatedApiOutage,
   waitForAuthenticatedApiRecovery,
@@ -15,6 +16,11 @@ test.describe("Power management", () => {
   });
 
   test("Miner can be rebooted from the header power menu", async ({ headerComponent, page, request }) => {
+    await assertSafeSimulatorTarget({
+      actionDescription: "reboot",
+      request,
+    });
+
     const accessToken = await getAuthAccessToken(page);
     const rebootRequestPromise = page.waitForRequest(
       (request) => request.method() === "POST" && request.url().includes("/api/v1/system/reboot"),


### PR DESCRIPTION
## Summary
- add direct ProtoOS E2E coverage for rebooting from the header power menu
- extend the header page object with reboot dialog helpers
- add a small auth API helper to wait for post-reboot recovery

## Testing
- ./node_modules/.bin/eslint e2eTests/protoOS/spec/power.spec.ts e2eTests/protoOS/pages/components/header.ts e2eTests/protoOS/helpers/apiAuthHelper.ts
- ../../node_modules/.bin/playwright test spec/power.spec.ts --grep "Miner can be rebooted from the header power menu"
- ../../node_modules/.bin/playwright test spec/power.spec.ts