### PR TITLE
Improve curtailment workflow UX

### DIFF
--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -359,8 +359,10 @@ describe("CurtailmentManagementPanel", () => {
     await user.click(screen.getByRole("button", { name: "Run curtailment" }));
 
     expect(screen.getByTestId("modal-response-profiles")).toHaveTextContent("Standard shed");
-    expect(screen.getByTestId("modal-response-profile-values")).not.toHaveTextContent('"scopeType"');
-    expect(screen.getByTestId("modal-response-profile-values")).not.toHaveTextContent('"deviceIdentifiers"');
+    expect(screen.getByTestId("modal-response-profile-values")).toHaveTextContent('"scopeType":"site"');
+    expect(screen.getByTestId("modal-response-profile-values")).toHaveTextContent('"scopeId":"Austin, TX"');
+    expect(screen.getByTestId("modal-response-profile-values")).toHaveTextContent('"siteId":"101"');
+    expect(screen.getByTestId("modal-response-profile-values")).toHaveTextContent('"deviceIdentifiers":[]');
     expect(screen.getByTestId("modal-response-profile-values")).toHaveTextContent('"targetKw":"50"');
   });
 

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -484,6 +484,34 @@ describe("CurtailmentManagementPanel", () => {
     }
   });
 
+  it("keeps polling while visible history has a non-terminal event after active clears", async () => {
+    vi.useFakeTimers();
+    const restoringHistoryEvent = {
+      ...historyEvent,
+      state: "restoring",
+    } as CurtailmentHistoryEvent;
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent: null,
+        activeEventId: null,
+        historyEvents: [restoringHistoryEvent],
+      }),
+    );
+
+    try {
+      render(<CurtailmentManagementPanel />);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      expect(mocks.refreshCurtailment).toHaveBeenCalledWith({
+        background: true,
+        signal: expect.any(AbortSignal),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("lets user-driven history navigation supersede active polling", async () => {
     vi.useFakeTimers();
     const pollingSignals: AbortSignal[] = [];

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -67,11 +67,13 @@ function minutesToSeconds(value: string): string {
 
 function createResponseProfileFormValuesFromProfile(profile: ResponseProfile): ResponseProfileFormValues {
   if (profile.formValues) {
+    const siteId = profile.formValues.siteId.trim();
+
     return {
       ...profile.formValues,
       deviceIdentifiers: [],
-      siteId: "",
-      siteName: "",
+      siteId,
+      siteName: siteId ? profile.formValues.siteName.trim() : "",
     };
   }
 
@@ -106,11 +108,18 @@ function createCurtailmentResponseProfileOption(profile: ResponseProfile): Curta
   const restoreBatchSize =
     values.restoreBatchSize ||
     (values.restoreBehavior === "automaticImmediateRestore" ? immediateRestoreBatchSize : "");
+  const siteId = values.siteId.trim();
+  const siteName = siteId ? values.siteName || `Site ${siteId}` : "";
 
   return {
     id: profile.id,
     label: profile.name,
     values: {
+      scopeType: siteId ? "site" : "wholeOrg",
+      scopeId: siteId ? siteName : "whole-org",
+      siteId,
+      deviceSetIds: [],
+      deviceIdentifiers: [],
       curtailmentMode: values.actionType,
       minerSelectionStrategy: values.selectionStrategy,
       targetKw: values.targetKw,

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -194,6 +194,8 @@ function CurtailmentManagementPanel({
   const isModalSubmitting = isEditingCurtailment ? isUpdating : isStarting;
   const activeEventState = activeEvent?.state;
   const hasOngoingCurtailment = activeEventState ? nonTerminalActiveEventStates.has(activeEventState) : false;
+  const hasOngoingHistoryEvent = historyEvents.some((event) => nonTerminalActiveEventStates.has(event.state));
+  const shouldPollCurtailment = hasOngoingCurtailment || hasOngoingHistoryEvent;
 
   const runAbortableRefresh = useCallback(<T,>(operation: (signal: AbortSignal) => Promise<T>) => {
     activeRefreshAbortControllerRef.current?.abort();
@@ -218,7 +220,7 @@ function CurtailmentManagementPanel({
   }, [refreshCurtailment, runAbortableRefresh]);
 
   useEffect(() => {
-    if (!hasOngoingCurtailment) {
+    if (!shouldPollCurtailment) {
       return undefined;
     }
 
@@ -252,7 +254,7 @@ function CurtailmentManagementPanel({
       activeRefreshAbortControllerRef.current?.abort();
       activeRefreshAbortControllerRef.current = null;
     };
-  }, [hasOngoingCurtailment, refreshCurtailment]);
+  }, [refreshCurtailment, shouldPollCurtailment]);
 
   const closeModal = useCallback(() => {
     setModalMode(null);

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -364,6 +364,10 @@ describe("CurtailmentStartModal", () => {
       responseProfiles: siteResponseProfiles,
     });
 
+    await user.click(screen.getByRole("button", { name: /Miners\s+Select/ }));
+    await user.click(screen.getByRole("button", { name: "Save miners" }));
+    expect(screen.getByRole("button", { name: /Miners\s+3 miners/ })).toBeInTheDocument();
+
     await user.click(screen.getByRole("button", { name: "Profile" }));
     await user.click(screen.getByText("Austin site shed"));
 

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -156,6 +156,16 @@ const wholeFleetResponseProfiles: CurtailmentResponseProfileOption[] = [
   },
 ];
 
+const scopeLessResponseProfiles: CurtailmentResponseProfileOption[] = [
+  {
+    ...responseProfiles[1],
+    values: {
+      ...responseProfiles[1].values,
+      includeMaintenance: false,
+    },
+  },
+];
+
 const preview: CurtailmentPlanPreview = {
   selectedMinerCount: 18,
   targetKw: 40,
@@ -327,6 +337,41 @@ describe("CurtailmentStartModal", () => {
         siteId: "",
         deviceSetIds: [],
         deviceIdentifiers: [],
+      }),
+    );
+  });
+
+  it("preserves the selected target when a response profile option has no scope values", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      initialValues: { ...configuredValues, includeMaintenance: false },
+      responseProfiles: scopeLessResponseProfiles,
+    });
+
+    await user.click(screen.getByRole("button", { name: /Miners\s+Select/ }));
+    await user.click(screen.getByRole("button", { name: "Save miners" }));
+    expect(screen.getByRole("button", { name: /Miners\s+3 miners/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Profile" }));
+    await user.click(screen.getByText("Emergency shed"));
+
+    expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Emergency shed");
+    expect(screen.getByRole("button", { name: /Miners\s+3 miners/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Run curtailment" }));
+    expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
+    expect(
+      screen.getByText("This will curtail 3 miners immediately. Schedules stay suppressed until miners are restored."),
+    ).toBeInTheDocument();
+    await confirmCurtailment(user);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseProfileId: "emergency-shed",
+        scopeType: "explicitMiners",
+        scopeId: undefined,
+        deviceSetIds: [],
+        deviceIdentifiers: ["miner-1", "miner-2", "miner-3"],
       }),
     );
   });

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -140,6 +140,22 @@ const responseProfiles: CurtailmentResponseProfileOption[] = [
   },
 ];
 
+const wholeFleetResponseProfiles: CurtailmentResponseProfileOption[] = [
+  {
+    id: "standard-shed",
+    label: "Standard shed",
+    values: {
+      ...responseProfiles[0].values,
+      scopeType: "wholeOrg",
+      scopeId: "whole-org",
+      siteId: "",
+      deviceSetIds: [],
+      deviceIdentifiers: [],
+      includeMaintenance: false,
+    },
+  },
+];
+
 const preview: CurtailmentPlanPreview = {
   selectedMinerCount: 18,
   targetKw: 40,
@@ -257,7 +273,7 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Standard shed");
     expect(screen.getByLabelText("Reason")).toHaveValue("Operator-requested event");
     expect(screen.getByLabelText("Fixed target reduction (kW)")).toHaveValue("50");
-    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Miners\s+3 miners/ })).toBeInTheDocument();
     expect(screen.queryByLabelText("Min duration (sec)")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Max duration (sec)")).not.toBeInTheDocument();
     expect(screen.queryByTestId("curtailment-curtail-batch-size")).not.toBeInTheDocument();
@@ -275,6 +291,44 @@ describe("CurtailmentStartModal", () => {
     await user.type(screen.getByLabelText("Fixed target reduction (kW)"), "75");
 
     expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Custom plan");
+  });
+
+  it("restores the selected response profile scope after a target selection", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      initialValues: { ...configuredValues, includeMaintenance: false },
+      responseProfiles: wholeFleetResponseProfiles,
+    });
+
+    await user.click(screen.getByRole("button", { name: /Miners\s+Select/ }));
+    await user.click(screen.getByRole("button", { name: "Save miners" }));
+    expect(screen.getByRole("button", { name: /Miners\s+3 miners/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Profile" }));
+    await user.click(screen.getByText("Standard shed"));
+
+    expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Standard shed");
+    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Run curtailment" }));
+    expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This will curtail miners across the fleet immediately. Schedules stay suppressed until miners are restored.",
+      ),
+    ).toBeInTheDocument();
+    await confirmCurtailment(user);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseProfileId: "standard-shed",
+        scopeType: "wholeOrg",
+        scopeId: "whole-org",
+        siteId: "",
+        deviceSetIds: [],
+        deviceIdentifiers: [],
+      }),
+    );
   });
 
   it("renders the response profile create variant", async () => {
@@ -617,7 +671,7 @@ describe("CurtailmentStartModal", () => {
     await user.clear(screen.getByLabelText("Batch interval (sec)"));
 
     expect(screen.getByText("Restore interval cannot be cleared.")).toBeInTheDocument();
-    expect(saveButton).toBeDisabled();
+    expect(saveButton).toBeEnabled();
 
     await user.click(saveButton);
     expect(onSubmit).not.toHaveBeenCalled();
@@ -639,7 +693,7 @@ describe("CurtailmentStartModal", () => {
     await user.type(screen.getByLabelText("Batch interval (sec)"), "0");
 
     expect(screen.getByText("Enter batch interval greater than 0.")).toBeInTheDocument();
-    expect(saveButton).toBeDisabled();
+    expect(saveButton).toBeEnabled();
 
     await user.click(saveButton);
     expect(onSubmit).not.toHaveBeenCalled();
@@ -867,7 +921,7 @@ describe("CurtailmentStartModal", () => {
     });
     const startButton = screen.getByRole("button", { name: "Run curtailment" });
 
-    expect(startButton).toBeDisabled();
+    expect(startButton).toBeEnabled();
 
     await user.click(screen.getByRole("button", { name: "Curtailment mode" }));
     const fullShutdownOption = await screen.findByText("Full shutdown");
@@ -1030,7 +1084,7 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByText("Enter batch interval as a whole number.")).toBeInTheDocument();
     expect(batchSizeInput).toHaveAttribute("aria-invalid", "true");
     expect(batchIntervalInput).toHaveAttribute("aria-invalid", "true");
-    expect(saveButton).toBeDisabled();
+    expect(saveButton).toBeEnabled();
 
     await user.click(saveButton);
     expect(onSubmit).not.toHaveBeenCalled();
@@ -1093,15 +1147,25 @@ describe("CurtailmentStartModal", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("keeps required start-field validation hidden until fields are edited", async () => {
+  it("shows required start-field validation when the CTA is clicked or fields are edited", async () => {
     const user = userEvent.setup();
-    renderModal();
+    const { onSubmit } = renderModal();
 
+    const startButton = screen.getByRole("button", { name: "Run curtailment" });
     const targetInput = screen.getByLabelText("Fixed target reduction (kW)");
     const reasonInput = screen.getByLabelText("Reason");
 
     expect(screen.queryByText("Enter a target reduction.")).not.toBeInTheDocument();
     expect(screen.queryByText("Enter a reason.")).not.toBeInTheDocument();
+    expect(startButton).toBeEnabled();
+
+    await user.click(startButton);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(reasonInput).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Enter a reason.")).toBeInTheDocument();
+    expect(targetInput).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Enter a target reduction.")).toBeInTheDocument();
 
     await user.type(reasonInput, " ");
     await user.type(targetInput, "5");

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -334,7 +334,7 @@ describe("CurtailmentStartModal", () => {
     await user.click(screen.getByText("Standard shed"));
 
     expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Standard shed");
-    expect(screen.getByRole("button", { name: /Miners\s+Whole fleet/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Run curtailment" }));
     expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
@@ -357,7 +357,7 @@ describe("CurtailmentStartModal", () => {
     );
   });
 
-  it("shows the selected response profile site scope in create mode", async () => {
+  it("ignores unsupported site scope from response profiles in create mode", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
       initialValues: { ...configuredValues, includeMaintenance: false },
@@ -368,23 +368,29 @@ describe("CurtailmentStartModal", () => {
     await user.click(screen.getByText("Austin site shed"));
 
     expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Austin site shed");
-    expect(screen.getByRole("button", { name: /Site\s+Austin, TX/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText("Fixed target reduction (kW)"));
+    await user.type(screen.getByLabelText("Fixed target reduction (kW)"), "75");
+
+    expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Custom plan");
+    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Run curtailment" }));
     expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This will curtail miners in Austin, TX immediately. Schedules stay suppressed until miners are restored.",
+        "This will curtail miners across the fleet immediately. Schedules stay suppressed until miners are restored.",
       ),
     ).toBeInTheDocument();
     await confirmCurtailment(user);
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
-        responseProfileId: "austin-shed",
-        scopeType: "site",
-        scopeId: "Austin, TX",
-        siteId: "austin-tx",
+        responseProfileId: "customPlan",
+        scopeType: "wholeOrg",
+        scopeId: "whole-org",
+        siteId: "",
         deviceSetIds: [],
         deviceIdentifiers: [],
       }),
@@ -698,7 +704,7 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByRole("dialog", { name: "Manage curtailment" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Curtailment mode" })).toBeDisabled();
     expect(screen.getByLabelText("Fixed target reduction (kW)")).toBeDisabled();
-    expect(screen.getByRole("button", { name: /Miners\s+Whole fleet/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeDisabled();
     expect(screen.getByText("Include miners in maintenance").closest("label")).toHaveClass("cursor-not-allowed");
 
     const saveButton = screen.getByRole("button", { name: "Save" });

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -156,6 +156,22 @@ const wholeFleetResponseProfiles: CurtailmentResponseProfileOption[] = [
   },
 ];
 
+const siteResponseProfiles: CurtailmentResponseProfileOption[] = [
+  {
+    id: "austin-shed",
+    label: "Austin site shed",
+    values: {
+      ...responseProfiles[0].values,
+      scopeType: "site",
+      scopeId: "Austin, TX",
+      siteId: "austin-tx",
+      deviceSetIds: [],
+      deviceIdentifiers: [],
+      includeMaintenance: false,
+    },
+  },
+];
+
 const scopeLessResponseProfiles: CurtailmentResponseProfileOption[] = [
   {
     ...responseProfiles[1],
@@ -318,7 +334,7 @@ describe("CurtailmentStartModal", () => {
     await user.click(screen.getByText("Standard shed"));
 
     expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Standard shed");
-    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Miners\s+Whole fleet/ })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Run curtailment" }));
     expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
@@ -335,6 +351,40 @@ describe("CurtailmentStartModal", () => {
         scopeType: "wholeOrg",
         scopeId: "whole-org",
         siteId: "",
+        deviceSetIds: [],
+        deviceIdentifiers: [],
+      }),
+    );
+  });
+
+  it("shows the selected response profile site scope in create mode", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      initialValues: { ...configuredValues, includeMaintenance: false },
+      responseProfiles: siteResponseProfiles,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Profile" }));
+    await user.click(screen.getByText("Austin site shed"));
+
+    expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Austin site shed");
+    expect(screen.getByRole("button", { name: /Site\s+Austin, TX/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Run curtailment" }));
+    expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This will curtail miners in Austin, TX immediately. Schedules stay suppressed until miners are restored.",
+      ),
+    ).toBeInTheDocument();
+    await confirmCurtailment(user);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseProfileId: "austin-shed",
+        scopeType: "site",
+        scopeId: "Austin, TX",
+        siteId: "austin-tx",
         deviceSetIds: [],
         deviceIdentifiers: [],
       }),

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -212,14 +212,31 @@ function hasResponseProfileScopeValues(responseProfileValues: CurtailmentRespons
   );
 }
 
+function removeResponseProfileScopeValues(
+  values: CurtailmentResponseProfileOption["values"],
+): CurtailmentResponseProfileOption["values"] {
+  const behaviorValues = { ...values };
+
+  delete behaviorValues.scopeType;
+  delete behaviorValues.scopeId;
+  delete behaviorValues.siteId;
+  delete behaviorValues.deviceSetIds;
+  delete behaviorValues.deviceIdentifiers;
+
+  return behaviorValues;
+}
+
 function withSelectedResponseProfileValues(
   values: CurtailmentFormValues,
   responseProfileValues: CurtailmentResponseProfileOption["values"],
 ): CurtailmentFormValues {
   const hasScopeValues = hasResponseProfileScopeValues(responseProfileValues);
+  const behaviorValues = hasScopeValues
+    ? removeResponseProfileScopeValues(responseProfileValues)
+    : responseProfileValues;
   const nextValues = {
     ...values,
-    ...responseProfileValues,
+    ...behaviorValues,
   };
 
   if (!hasScopeValues) {
@@ -236,33 +253,14 @@ function withSelectedResponseProfileValues(
           ? "explicitMiners"
           : "wholeOrg");
 
-  nextValues.scopeType = scopeType;
-
-  if (nextValues.scopeType === "site") {
-    const siteId = responseProfileValues.siteId ?? "";
-
-    return {
-      ...nextValues,
-      siteId,
-      scopeId: responseProfileValues.scopeId ?? (siteId ? `Site ${siteId}` : undefined),
-      deviceSetIds: [],
-      deviceIdentifiers: [],
-    };
+  if (scopeType === "site" || scopeType === "deviceSet") {
+    return nextValues;
   }
 
-  if (nextValues.scopeType === "deviceSet") {
+  if (scopeType === "explicitMiners") {
     return {
       ...nextValues,
-      scopeId: undefined,
-      siteId: "",
-      deviceSetIds: responseProfileValues.deviceSetIds ?? [],
-      deviceIdentifiers: [],
-    };
-  }
-
-  if (nextValues.scopeType === "explicitMiners") {
-    return {
-      ...nextValues,
+      scopeType,
       scopeId: undefined,
       siteId: "",
       deviceSetIds: [],
@@ -644,7 +642,7 @@ function getApplyToTarget(values: CurtailmentFormValues, shouldUseFormScope: boo
   if (values.scopeType === "wholeOrg") {
     return {
       label: "Miners",
-      value: "Whole fleet",
+      value: getTargetButtonLabel(0, "miner"),
     };
   }
 
@@ -781,16 +779,7 @@ function CurtailmentStartModalContent({
   const hasEditableChanges = !isLiveCurtailmentEditMode || hasEditableCurtailmentChanges(values, initialFormValues);
   const isSubmitDisabled = isBusy || hasBlockingPreviewState || hasExternalFormError || !hasEditableChanges;
   const selectedMinerIds = getSelectedMinerIds(values);
-  const selectedResponseProfile =
-    values.responseProfileId === customResponseProfileId
-      ? undefined
-      : responseProfiles.find((profile) => profile.id === values.responseProfileId);
-  const shouldShowSelectedResponseProfileScope =
-    !isResponseProfileVariant &&
-    !isLiveCurtailmentEditMode &&
-    selectedResponseProfile !== undefined &&
-    hasResponseProfileScopeValues(selectedResponseProfile.values);
-  const applyToTarget = getApplyToTarget(values, isLiveCurtailmentEditMode || shouldShowSelectedResponseProfileScope);
+  const applyToTarget = getApplyToTarget(values, isLiveCurtailmentEditMode);
   const isFullFleetMode = values.curtailmentMode === "fullFleet";
   const curtailmentBehaviorSubtext = isLiveCurtailmentEditMode
     ? undefined

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -206,11 +206,32 @@ function withSelectedResponseProfileValues(
   values: CurtailmentFormValues,
   responseProfileValues: CurtailmentResponseProfileOption["values"],
 ): CurtailmentFormValues {
+  const hasScopeValues =
+    "scopeType" in responseProfileValues ||
+    "scopeId" in responseProfileValues ||
+    "siteId" in responseProfileValues ||
+    "deviceSetIds" in responseProfileValues ||
+    "deviceIdentifiers" in responseProfileValues;
   const nextValues = {
     ...values,
     ...responseProfileValues,
-    scopeType: responseProfileValues.scopeType ?? "wholeOrg",
   };
+
+  if (!hasScopeValues) {
+    return nextValues;
+  }
+
+  const scopeType =
+    responseProfileValues.scopeType ??
+    (responseProfileValues.siteId
+      ? "site"
+      : responseProfileValues.deviceSetIds?.length
+        ? "deviceSet"
+        : responseProfileValues.deviceIdentifiers?.length
+          ? "explicitMiners"
+          : "wholeOrg");
+
+  nextValues.scopeType = scopeType;
 
   if (nextValues.scopeType === "site") {
     const siteId = responseProfileValues.siteId ?? "";

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -202,16 +202,21 @@ function withResponseProfileScope(
   return withWholeFleetScope(values);
 }
 
-function withSelectedResponseProfileValues(
-  values: CurtailmentFormValues,
-  responseProfileValues: CurtailmentResponseProfileOption["values"],
-): CurtailmentFormValues {
-  const hasScopeValues =
+function hasResponseProfileScopeValues(responseProfileValues: CurtailmentResponseProfileOption["values"]): boolean {
+  return (
     "scopeType" in responseProfileValues ||
     "scopeId" in responseProfileValues ||
     "siteId" in responseProfileValues ||
     "deviceSetIds" in responseProfileValues ||
-    "deviceIdentifiers" in responseProfileValues;
+    "deviceIdentifiers" in responseProfileValues
+  );
+}
+
+function withSelectedResponseProfileValues(
+  values: CurtailmentFormValues,
+  responseProfileValues: CurtailmentResponseProfileOption["values"],
+): CurtailmentFormValues {
+  const hasScopeValues = hasResponseProfileScopeValues(responseProfileValues);
   const nextValues = {
     ...values,
     ...responseProfileValues,
@@ -616,10 +621,9 @@ function getCurtailmentConfirmationCopy(
 
 function getApplyToTarget(
   values: CurtailmentFormValues,
-  isEditMode: boolean,
-  selectedMinerCount?: number,
+  shouldUseFormScope: boolean,
 ): ApplyToTarget {
-  if (!isEditMode) {
+  if (!shouldUseFormScope) {
     return {
       label: "Miners",
       value: getTargetButtonLabel(getSelectedMinerIds(values).length, "miner"),
@@ -629,14 +633,7 @@ function getApplyToTarget(
   if (values.scopeType === "site") {
     return {
       label: "Site",
-      value: values.siteId ? `Site ${values.siteId}` : "Site",
-    };
-  }
-
-  if (selectedMinerCount !== undefined) {
-    return {
-      label: "Miners",
-      value: formatCountLabel(selectedMinerCount, "miner"),
+      value: values.scopeId ?? (values.siteId ? `Site ${values.siteId}` : "Site"),
     };
   }
 
@@ -787,7 +784,19 @@ function CurtailmentStartModalContent({
   const hasEditableChanges = !isLiveCurtailmentEditMode || hasEditableCurtailmentChanges(values, initialFormValues);
   const isSubmitDisabled = isBusy || hasBlockingPreviewState || hasExternalFormError || !hasEditableChanges;
   const selectedMinerIds = getSelectedMinerIds(values);
-  const applyToTarget = getApplyToTarget(values, isLiveCurtailmentEditMode, previewState.preview?.selectedMinerCount);
+  const selectedResponseProfile =
+    values.responseProfileId === customResponseProfileId
+      ? undefined
+      : responseProfiles.find((profile) => profile.id === values.responseProfileId);
+  const shouldShowSelectedResponseProfileScope =
+    !isResponseProfileVariant &&
+    !isLiveCurtailmentEditMode &&
+    selectedResponseProfile !== undefined &&
+    hasResponseProfileScopeValues(selectedResponseProfile.values);
+  const applyToTarget = getApplyToTarget(
+    values,
+    isLiveCurtailmentEditMode || shouldShowSelectedResponseProfileScope,
+  );
   const isFullFleetMode = values.curtailmentMode === "fullFleet";
   const curtailmentBehaviorSubtext = isLiveCurtailmentEditMode
     ? undefined

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -254,7 +254,7 @@ function withSelectedResponseProfileValues(
           : "wholeOrg");
 
   if (scopeType === "site" || scopeType === "deviceSet") {
-    return nextValues;
+    return withWholeFleetScope(nextValues);
   }
 
   if (scopeType === "explicitMiners") {

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -202,18 +202,49 @@ function withResponseProfileScope(
   return withWholeFleetScope(values);
 }
 
-function removeScopeValues(
-  values: CurtailmentResponseProfileOption["values"],
-): CurtailmentResponseProfileOption["values"] {
-  const behaviorValues = { ...values };
+function withSelectedResponseProfileValues(
+  values: CurtailmentFormValues,
+  responseProfileValues: CurtailmentResponseProfileOption["values"],
+): CurtailmentFormValues {
+  const nextValues = {
+    ...values,
+    ...responseProfileValues,
+    scopeType: responseProfileValues.scopeType ?? "wholeOrg",
+  };
 
-  delete behaviorValues.scopeType;
-  delete behaviorValues.scopeId;
-  delete behaviorValues.siteId;
-  delete behaviorValues.deviceSetIds;
-  delete behaviorValues.deviceIdentifiers;
+  if (nextValues.scopeType === "site") {
+    const siteId = responseProfileValues.siteId ?? "";
 
-  return behaviorValues;
+    return {
+      ...nextValues,
+      siteId,
+      scopeId: responseProfileValues.scopeId ?? (siteId ? `Site ${siteId}` : undefined),
+      deviceSetIds: [],
+      deviceIdentifiers: [],
+    };
+  }
+
+  if (nextValues.scopeType === "deviceSet") {
+    return {
+      ...nextValues,
+      scopeId: undefined,
+      siteId: "",
+      deviceSetIds: responseProfileValues.deviceSetIds ?? [],
+      deviceIdentifiers: [],
+    };
+  }
+
+  if (nextValues.scopeType === "explicitMiners") {
+    return {
+      ...nextValues,
+      scopeId: undefined,
+      siteId: "",
+      deviceSetIds: [],
+      deviceIdentifiers: responseProfileValues.deviceIdentifiers ?? [],
+    };
+  }
+
+  return withWholeFleetScope(nextValues);
 }
 
 function isCurtailmentMode(value: string): value is CurtailmentMode {
@@ -728,12 +759,12 @@ function CurtailmentStartModalContent({
     unsupportedDeviceSetPreviewError,
   });
 
-  const hasBlockingFormError = Object.keys(localErrors).length > 0 || Object.keys(errors ?? {}).length > 0;
+  const hasLocalFormError = Object.keys(localErrors).length > 0;
+  const hasExternalFormError = Object.keys(errors ?? {}).length > 0;
   const hasBlockingPreviewState =
     previewState.previewError !== undefined || (!isResponseProfileVariant && previewState.isPreviewLoading);
-  const hasBlockingValidationError = hasBlockingPreviewState || hasBlockingFormError;
   const hasEditableChanges = !isLiveCurtailmentEditMode || hasEditableCurtailmentChanges(values, initialFormValues);
-  const isSubmitDisabled = isBusy || hasBlockingValidationError || !hasEditableChanges;
+  const isSubmitDisabled = isBusy || hasBlockingPreviewState || hasExternalFormError || !hasEditableChanges;
   const selectedMinerIds = getSelectedMinerIds(values);
   const applyToTarget = getApplyToTarget(values, isLiveCurtailmentEditMode, previewState.preview?.selectedMinerCount);
   const isFullFleetMode = values.curtailmentMode === "fullFleet";
@@ -808,8 +839,7 @@ function CurtailmentStartModalContent({
     setEditedFields(new Set());
     setMaintenanceInclusionConfirmed(false);
     setValues((current) => ({
-      ...current,
-      ...removeScopeValues(responseProfile.values),
+      ...withSelectedResponseProfileValues(current, responseProfile.values),
       responseProfileId: responseProfile.id,
     }));
   };
@@ -845,6 +875,12 @@ function CurtailmentStartModalContent({
     setPendingCurtailmentConfirmation({ action, values: confirmationValues });
   };
 
+  const showLocalFormErrors = () => {
+    setEditedFields(
+      (current) => new Set([...current, ...(Object.keys(localErrors) as (keyof CurtailmentFormValues)[])]),
+    );
+  };
+
   const confirmCurtailmentAction = () => {
     if (!pendingCurtailmentConfirmation) {
       return;
@@ -862,6 +898,15 @@ function CurtailmentStartModalContent({
   };
 
   const handleSubmit = () => {
+    if (isBusy) {
+      return;
+    }
+
+    if (hasLocalFormError) {
+      showLocalFormErrors();
+      return;
+    }
+
     if (isSubmitDisabled) {
       return;
     }
@@ -881,6 +926,19 @@ function CurtailmentStartModalContent({
   };
 
   const requestResponseProfileCurtailment = () => {
+    if (isBusy) {
+      return;
+    }
+
+    if (hasLocalFormError) {
+      showLocalFormErrors();
+      return;
+    }
+
+    if (hasBlockingPreviewState || hasExternalFormError) {
+      return;
+    }
+
     if (values.includeMaintenance && !maintenanceInclusionConfirmed) {
       setSubmitAfterMaintenanceConfirmation("test");
       setShowMaintenanceConfirmation(true);
@@ -916,7 +974,7 @@ function CurtailmentStartModalContent({
       text: "Run curtailment",
       variant: variants.secondary,
       onClick: requestResponseProfileCurtailment,
-      disabled: isBusy || hasBlockingValidationError,
+      disabled: isBusy || hasBlockingPreviewState || hasExternalFormError,
       loading: isTestingCurtailment,
     });
   }

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -619,10 +619,7 @@ function getCurtailmentConfirmationCopy(
   };
 }
 
-function getApplyToTarget(
-  values: CurtailmentFormValues,
-  shouldUseFormScope: boolean,
-): ApplyToTarget {
+function getApplyToTarget(values: CurtailmentFormValues, shouldUseFormScope: boolean): ApplyToTarget {
   if (!shouldUseFormScope) {
     return {
       label: "Miners",
@@ -793,10 +790,7 @@ function CurtailmentStartModalContent({
     !isLiveCurtailmentEditMode &&
     selectedResponseProfile !== undefined &&
     hasResponseProfileScopeValues(selectedResponseProfile.values);
-  const applyToTarget = getApplyToTarget(
-    values,
-    isLiveCurtailmentEditMode || shouldShowSelectedResponseProfileScope,
-  );
+  const applyToTarget = getApplyToTarget(values, isLiveCurtailmentEditMode || shouldShowSelectedResponseProfileScope);
   const isFullFleetMode = values.curtailmentMode === "fullFleet";
   const curtailmentBehaviorSubtext = isLiveCurtailmentEditMode
     ? undefined

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
@@ -129,10 +129,16 @@ describe("CurtailmentAutomationsContent", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByTestId("automation-response-profile-select")).toHaveTextContent("Standard shed");
-    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeEnabled();
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(screen.getByText("Enter a rule name.")).toBeVisible());
+    expect(screen.queryByText("High LMP spike")).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Rule name"), { target: { value: "High LMP spike" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.keyDown(screen.getByLabelText("Rule name"), { key: "Enter", code: "Enter" });
 
     await waitFor(() => expect(screen.queryByTestId("curtailment-automation-modal")).not.toBeInTheDocument());
 

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
@@ -1,6 +1,7 @@
-import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
+import { type KeyboardEvent, type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 
+import { isInputEnterSaveEvent } from "@/protoFleet/features/settings/components/Curtailment/keyboard";
 import type {
   AutomationRule,
   AutomationRuleFormValues,
@@ -88,6 +89,8 @@ type AutomationModalProps = {
   onDelete?: () => Promise<void>;
 };
 
+type AutomationFormErrors = Partial<Record<keyof AutomationRuleFormValues, string>>;
+
 type InfoToggleContentProps = {
   ariaLabel: string;
   description: string;
@@ -174,8 +177,20 @@ function createOption(entry: CurtailmentSource | ResponseProfile): SelectOption 
   };
 }
 
-function isAutomationFormValid(values: AutomationRuleFormValues): boolean {
-  return values.name.trim() !== "" && values.sourceId !== "" && values.responseProfileId !== "";
+function validateAutomationFormValues(values: AutomationRuleFormValues): AutomationFormErrors {
+  const errors: AutomationFormErrors = {};
+
+  if (values.name.trim() === "") {
+    errors.name = "Enter a rule name.";
+  }
+  if (values.sourceId === "") {
+    errors.sourceId = "Select a trigger.";
+  }
+  if (values.responseProfileId === "") {
+    errors.responseProfileId = "Select a response profile.";
+  }
+
+  return errors;
 }
 
 function InfoToggleContent({ ariaLabel, description, testId, triggerClassName }: InfoToggleContentProps): ReactElement {
@@ -291,10 +306,14 @@ function AutomationModal({
 }: AutomationModalProps): ReactElement {
   const [values, setValues] = useState<AutomationRuleFormValues>(() => initialValues);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [showValidationErrors, setShowValidationErrors] = useState(false);
   const sourceOptions = useMemo(() => sources.map(createOption), [sources]);
   const responseProfileOptions = useMemo(() => responseProfiles.map(createOption), [responseProfiles]);
   const isBusy = saving || deleting;
-  const canSave = isAutomationFormValid(values) && !isLoadingSources && !isLoadingResponseProfiles && !isBusy;
+  const validationErrors = useMemo(() => validateAutomationFormValues(values), [values]);
+  const visibleValidationErrors = showValidationErrors ? validationErrors : {};
+  const hasValidationErrors = Object.keys(validationErrors).length > 0;
+  const isSaveUnavailable = isLoadingSources || isLoadingResponseProfiles || isBusy;
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- dependency options can load after the modal opens
@@ -310,7 +329,12 @@ function AutomationModal({
   }, []);
 
   const handleSave = useCallback(async () => {
-    if (!canSave) {
+    if (isSaveUnavailable) {
+      return;
+    }
+
+    if (hasValidationErrors) {
+      setShowValidationErrors(true);
       return;
     }
 
@@ -321,7 +345,19 @@ function AutomationModal({
     } catch (error) {
       setSaveError(error instanceof Error && error.message ? error.message : "Failed to save automation.");
     }
-  }, [canSave, onDismiss, onSave, values]);
+  }, [hasValidationErrors, isSaveUnavailable, onDismiss, onSave, values]);
+
+  const handleFormKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!isInputEnterSaveEvent(event)) {
+        return;
+      }
+
+      event.preventDefault();
+      void handleSave();
+    },
+    [handleSave],
+  );
 
   const handleDelete = useCallback(async () => {
     if (!onDelete || isBusy) {
@@ -353,7 +389,7 @@ function AutomationModal({
     {
       text: "Save",
       variant: variants.primary,
-      disabled: !canSave,
+      disabled: isSaveUnavailable,
       loading: saving,
       dismissModalOnClick: false,
       onClick: () => void handleSave(),
@@ -372,11 +408,17 @@ function AutomationModal({
       buttons={modalButtons}
       bodyClassName="text-text-primary"
     >
-      <div className="grid gap-6 pb-2">
+      <div className="grid gap-6 pb-2" onKeyDown={handleFormKeyDown}>
         {saveError ? (
           <div className="rounded-lg bg-intent-critical-10 px-4 py-3 text-300 text-text-critical">{saveError}</div>
         ) : null}
-        <Input id="automation-rule-name" label="Rule name" initValue={values.name} onChange={handleNameChange} />
+        <Input
+          id="automation-rule-name"
+          label="Rule name"
+          initValue={values.name}
+          error={visibleValidationErrors.name}
+          onChange={handleNameChange}
+        />
 
         <div className="grid gap-3">
           <div className="text-200 font-semibold tracking-[0.08em] text-text-primary-50 uppercase">When</div>
@@ -388,6 +430,7 @@ function AutomationModal({
               value={values.sourceId}
               onChange={(sourceId) => setValues((currentValues) => ({ ...currentValues, sourceId }))}
               disabled={isLoadingSources || sourceOptions.length === 0}
+              error={visibleValidationErrors.sourceId}
               testId="automation-trigger-source-select"
               forceBelow
             />
@@ -425,6 +468,7 @@ function AutomationModal({
               value={values.responseProfileId}
               onChange={(responseProfileId) => setValues((currentValues) => ({ ...currentValues, responseProfileId }))}
               disabled={isLoadingResponseProfiles || responseProfileOptions.length === 0}
+              error={visibleValidationErrors.responseProfileId}
               testId="automation-response-profile-select"
               forceBelow
             />

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -1232,6 +1232,29 @@ describe("CurtailmentSettingsPage", () => {
     expect(testConnectionMock).not.toHaveBeenCalled();
   });
 
+  it("clears the saved-password placeholder when saving an edited source requires a password", async () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
+    mockSourcesApi({ sources: apiSources });
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(getSourceRow("Site Alpha MQTT"));
+
+    const passwordInput = screen.getByLabelText("Password");
+    expect(passwordInput).toHaveValue("......");
+
+    fireEvent.change(screen.getByLabelText("Username"), { target: { value: "updated-alpha" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(screen.getByText("Enter a password.")).toBeVisible());
+    expect(passwordInput).toHaveValue("");
+    expect(updateSourceMock).not.toHaveBeenCalled();
+  });
+
   it("updates a source through the API hook from the routed page", async () => {
     vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
     updateSourceMock.mockResolvedValue({ ...apiSources[0], name: "Site Alpha MQTT updated" });

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -1210,6 +1210,28 @@ describe("CurtailmentSettingsPage", () => {
     );
   });
 
+  it("clears the saved-password placeholder when testing an edited source requires a password", async () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
+    mockSourcesApi({ sources: apiSources });
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(getSourceRow("Site Alpha MQTT"));
+
+    const passwordInput = screen.getByLabelText("Password");
+    expect(passwordInput).toHaveValue("......");
+
+    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+
+    await waitFor(() => expect(screen.getByText("Enter a password.")).toBeVisible());
+    expect(passwordInput).toHaveValue("");
+    expect(testConnectionMock).not.toHaveBeenCalled();
+  });
+
   it("updates a source through the API hook from the routed page", async () => {
     vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
     updateSourceMock.mockResolvedValue({ ...apiSources[0], name: "Site Alpha MQTT updated" });

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -962,7 +962,10 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByTestId("response-profile-restore-batch-interval")).toHaveValue("");
 
     const saveButtons = screen.getAllByRole("button", { name: "Save profile" });
-    expect(saveButtons.every((button) => button instanceof HTMLButtonElement && button.disabled)).toBe(true);
+    expect(saveButtons.every((button) => button instanceof HTMLButtonElement && !button.disabled)).toBe(true);
+
+    fireEvent.click(getEnabledButton("Save profile"));
+    await waitFor(() => expect(screen.getByText("Enter a profile name.")).toBeVisible());
 
     fireEvent.change(screen.getByLabelText("Profile name"), { target: { value: "Emergency full shed" } });
     fireEvent.change(screen.getByTestId("response-profile-curtail-batch-size"), { target: { value: "25" } });
@@ -1056,12 +1059,19 @@ describe("CurtailmentSettingsPage", () => {
     const testConnectionButton = screen.getByRole("button", { name: "Test connection" });
     const saveButton = screen.getByRole("button", { name: "Save" });
     expect(testConnectionButton).toBeDisabled();
-    expect(saveButton).toBeDisabled();
+    expect(saveButton).toBeEnabled();
     expect(testConnectionButton.compareDocumentPosition(saveButton)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
 
-    fireEvent.click(testConnectionButton);
+    fireEvent.click(saveButton);
 
     expect(screen.getByTestId("curtailment-source-modal")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Enter a configuration name.")).toBeVisible());
+    expect(screen.getByText("Enter broker host 1.")).toBeVisible();
+    expect(screen.getByText("Enter broker host 2.")).toBeVisible();
+    expect(screen.getByText("Enter a port.")).toBeVisible();
+    expect(screen.getByText("Enter a topic.")).toBeVisible();
+    expect(screen.getByText("Enter a username.")).toBeVisible();
+    expect(screen.getByText("Enter a password.")).toBeVisible();
 
     fillSourceForm();
 
@@ -1085,7 +1095,7 @@ describe("CurtailmentSettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add source" }));
     fillSourceForm();
 
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.keyDown(screen.getByLabelText("Password"), { key: "Enter", code: "Enter" });
 
     await waitFor(() => expect(createSourceMock).toHaveBeenCalledWith(testSourceFormValues));
     await waitFor(() => expect(screen.queryByTestId("curtailment-source-modal")).not.toBeInTheDocument());

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -810,6 +810,9 @@ function SourceModal({
     }
 
     if (!canTestConnection) {
+      if (showSavedPasswordPlaceholder && testConnectionValidationErrors.password) {
+        setPasswordPlaceholderActive(false);
+      }
       setValidationIntent("testConnection");
       return;
     }
@@ -824,7 +827,14 @@ function SourceModal({
     } finally {
       setShowConnectionCallout(true);
     }
-  }, [canTestConnection, isBusy, onTestConnection, values]);
+  }, [
+    canTestConnection,
+    isBusy,
+    onTestConnection,
+    showSavedPasswordPlaceholder,
+    testConnectionValidationErrors,
+    values,
+  ]);
 
   const handleDelete = useCallback(async () => {
     if (!onDelete || isBusy) {

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
+import { type KeyboardEvent, type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import { Navigate, useNavigate } from "react-router-dom";
 import clsx from "clsx";
 
@@ -14,6 +14,7 @@ import CurtailmentStartModal, {
   type ResponseProfileModalMode,
 } from "@/protoFleet/features/energy/CurtailmentStartModal";
 import CurtailmentAutomationsContent from "@/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations";
+import { isInputEnterSaveEvent } from "@/protoFleet/features/settings/components/Curtailment/keyboard";
 import type {
   AutomationRule,
   AutomationRuleFormValues,
@@ -447,21 +448,36 @@ function sourceCredentialFieldsChanged(
   );
 }
 
-function isSourceFormValid(values: CurtailmentSourceFormValues, passwordRequired: boolean): boolean {
-  const requiredTrimmedValues = [
-    values.name,
-    values.brokerPrimaryHost,
-    values.brokerSecondaryHost,
-    values.topic,
-    values.username,
-  ];
+function validateSourceFormValues(values: CurtailmentSourceFormValues, passwordRequired: boolean): SourceFormErrors {
+  const errors: SourceFormErrors = {};
 
-  return (
-    requiredTrimmedValues.every((value) => value.trim() !== "") &&
-    (!passwordRequired || values.password !== "") &&
-    isPositiveInteger(values.brokerPort) &&
-    Number(values.brokerPort) <= MAX_BROKER_PORT
-  );
+  if (values.name.trim() === "") {
+    errors.name = "Enter a configuration name.";
+  }
+  if (values.brokerPrimaryHost.trim() === "") {
+    errors.brokerPrimaryHost = "Enter broker host 1.";
+  }
+  if (values.brokerSecondaryHost.trim() === "") {
+    errors.brokerSecondaryHost = "Enter broker host 2.";
+  }
+  if (values.topic.trim() === "") {
+    errors.topic = "Enter a topic.";
+  }
+  if (values.username.trim() === "") {
+    errors.username = "Enter a username.";
+  }
+  if (passwordRequired && values.password === "") {
+    errors.password = "Enter a password.";
+  }
+  if (values.brokerPort.trim() === "") {
+    errors.brokerPort = "Enter a port.";
+  } else if (!isPositiveInteger(values.brokerPort)) {
+    errors.brokerPort = "Enter port as a whole number greater than 0.";
+  } else if (Number(values.brokerPort) > MAX_BROKER_PORT) {
+    errors.brokerPort = `Enter port of ${MAX_BROKER_PORT.toLocaleString()} or less.`;
+  }
+
+  return errors;
 }
 
 function getErrorMessage(error: unknown, fallbackMessage: string): string {
@@ -689,6 +705,9 @@ type SourceModalProps = {
   deleting?: boolean;
 };
 
+type SourceFormErrors = Partial<Record<keyof CurtailmentSourceFormValues, string>>;
+type SourceValidationIntent = "save" | "testConnection";
+
 function SourceModal({
   open,
   mode = "create",
@@ -705,13 +724,25 @@ function SourceModal({
   const [values, setValues] = useState<CurtailmentSourceFormValues>(() => initialValues);
   const [passwordPlaceholderActive, setPasswordPlaceholderActive] = useState(() => mode === "edit" && hasSavedPassword);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [validationIntent, setValidationIntent] = useState<SourceValidationIntent | null>(null);
   const [showConnectionCallout, setShowConnectionCallout] = useState(false);
   const [connectionError, setConnectionError] = useState(false);
   const isEditMode = mode === "edit";
   const isBusy = saving || deleting || testingConnection;
   const passwordRequired = !isEditMode || sourceCredentialFieldsChanged(values, initialValues);
-  const canSave = isSourceFormValid(values, passwordRequired);
-  const canTestConnection = isSourceFormValid(values, true);
+  const saveValidationErrors = useMemo(
+    () => validateSourceFormValues(values, passwordRequired),
+    [passwordRequired, values],
+  );
+  const testConnectionValidationErrors = useMemo(() => validateSourceFormValues(values, true), [values]);
+  const visibleValidationErrors =
+    validationIntent === "testConnection"
+      ? testConnectionValidationErrors
+      : validationIntent === "save"
+        ? saveValidationErrors
+        : {};
+  const canSave = Object.keys(saveValidationErrors).length === 0;
+  const canTestConnection = Object.keys(testConnectionValidationErrors).length === 0;
   const showSavedPasswordPlaceholder = isEditMode && hasSavedPassword && passwordPlaceholderActive;
   const passwordInputValue = showSavedPasswordPlaceholder ? savedPasswordPlaceholder : values.password;
   const showConnectionSuccessCallout = showConnectionCallout && !testingConnection && !connectionError;
@@ -743,7 +774,12 @@ function SourceModal({
   }, [showSavedPasswordPlaceholder]);
 
   const handleSave = useCallback(async () => {
-    if (!canSave || isBusy) {
+    if (isBusy) {
+      return;
+    }
+
+    if (!canSave) {
+      setValidationIntent("save");
       return;
     }
 
@@ -756,8 +792,25 @@ function SourceModal({
     }
   }, [canSave, isBusy, onDismiss, onSave, values]);
 
+  const handleFormKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!isInputEnterSaveEvent(event)) {
+        return;
+      }
+
+      event.preventDefault();
+      void handleSave();
+    },
+    [handleSave],
+  );
+
   const handleTestConnection = useCallback(async () => {
-    if (!canTestConnection || isBusy || !onTestConnection) {
+    if (isBusy || !onTestConnection) {
+      return;
+    }
+
+    if (!canTestConnection) {
+      setValidationIntent("testConnection");
       return;
     }
 
@@ -814,7 +867,7 @@ function SourceModal({
           variant: variants.secondary,
           className: "whitespace-nowrap overflow-clip",
           testId: "curtailment-source-test-connection-button",
-          disabled: !canTestConnection || isBusy || !onTestConnection,
+          disabled: isBusy || !onTestConnection,
           loading: testingConnection,
           dismissModalOnClick: false,
           onClick: () => void handleTestConnection(),
@@ -822,7 +875,7 @@ function SourceModal({
         {
           text: "Save",
           variant: variants.primary,
-          disabled: !canSave || isBusy,
+          disabled: isBusy,
           loading: saving,
           dismissModalOnClick: false,
           onClick: () => void handleSave(),
@@ -830,7 +883,7 @@ function SourceModal({
       ]}
       bodyClassName="text-text-primary"
     >
-      <div className="grid gap-3 pb-2">
+      <div className="grid gap-3 pb-2" onKeyDown={handleFormKeyDown}>
         <DismissibleCalloutWrapper
           icon={<Success />}
           intent={intents.success}
@@ -855,6 +908,7 @@ function SourceModal({
             id={sourceInputIds.name}
             label="Configuration name"
             initValue={values.name}
+            error={visibleValidationErrors.name}
             onChange={updateSourceValue}
           />
           <Input id="source-type" label="Source type" initValue="MaestroOS" disabled />
@@ -864,12 +918,14 @@ function SourceModal({
             id={sourceInputIds.brokerPrimaryHost}
             label="Broker host 1"
             initValue={values.brokerPrimaryHost}
+            error={visibleValidationErrors.brokerPrimaryHost}
             onChange={updateSourceValue}
           />
           <Input
             id={sourceInputIds.brokerSecondaryHost}
             label="Broker host 2"
             initValue={values.brokerSecondaryHost}
+            error={visibleValidationErrors.brokerSecondaryHost}
             onChange={updateSourceValue}
           />
         </div>
@@ -880,6 +936,7 @@ function SourceModal({
             type="number"
             inputMode="numeric"
             initValue={values.brokerPort}
+            error={visibleValidationErrors.brokerPort}
             onChange={updateSourceValue}
             tooltip={{
               body: "Default MaestroOS port is 1883.",
@@ -891,6 +948,7 @@ function SourceModal({
             id={sourceInputIds.topic}
             label="Topic"
             initValue={values.topic}
+            error={visibleValidationErrors.topic}
             onChange={updateSourceValue}
             tooltip={{
               body: "The MaestroOS topic to subscribe to for curtailment signals.",
@@ -903,6 +961,7 @@ function SourceModal({
             id={sourceInputIds.username}
             label="Username"
             initValue={values.username}
+            error={visibleValidationErrors.username}
             onChange={updateSourceValue}
           />
           <Input
@@ -910,6 +969,7 @@ function SourceModal({
             label="Password"
             type="password"
             initValue={passwordInputValue}
+            error={visibleValidationErrors.password}
             onChange={updateSourceValue}
             onFocus={handlePasswordFocus}
             hidePasswordToggle={showSavedPasswordPlaceholder}

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -779,6 +779,9 @@ function SourceModal({
     }
 
     if (!canSave) {
+      if (showSavedPasswordPlaceholder && saveValidationErrors.password) {
+        setPasswordPlaceholderActive(false);
+      }
       setValidationIntent("save");
       return;
     }
@@ -790,7 +793,7 @@ function SourceModal({
     } catch (error) {
       setSaveError(getErrorMessage(error, "Failed to save source."));
     }
-  }, [canSave, isBusy, onDismiss, onSave, values]);
+  }, [canSave, isBusy, onDismiss, onSave, saveValidationErrors, showSavedPasswordPlaceholder, values]);
 
   const handleFormKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {

--- a/client/src/protoFleet/features/settings/components/Curtailment/keyboard.ts
+++ b/client/src/protoFleet/features/settings/components/Curtailment/keyboard.ts
@@ -1,0 +1,14 @@
+import type { KeyboardEvent } from "react";
+
+export function isInputEnterSaveEvent(event: KeyboardEvent<HTMLElement>): boolean {
+  return (
+    event.key === "Enter" &&
+    !event.defaultPrevented &&
+    !event.nativeEvent.isComposing &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey &&
+    event.target instanceof HTMLInputElement
+  );
+}

--- a/client/src/shared/components/Input/Input.test.tsx
+++ b/client/src/shared/components/Input/Input.test.tsx
@@ -97,6 +97,18 @@ describe("Input", () => {
     expect(inputElement).not.toHaveClass("pr-20");
     expect(suffixActionWrapper).toHaveClass("right-20");
   });
+
+  test("does not apply focus highlight classes to readonly inputs", () => {
+    render(<Input id="readonly-field" label="Readonly field" initValue="0" readOnly />);
+
+    const inputElement = screen.getByLabelText("Readonly field");
+
+    expect(inputElement).toHaveAttribute("readonly");
+    expect(inputElement).toHaveClass("cursor-default");
+    expect(inputElement).not.toHaveClass("focus:border-border-20");
+    expect(inputElement).not.toHaveClass("focus:ring-4");
+    expect(inputElement).not.toHaveClass("focus:ring-core-primary-5");
+  });
 });
 
 describe("Input ARIA attributes", () => {

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -126,6 +126,7 @@ const Input = ({
   const showPasswordToggle = type === "password" && !hidePasswordToggle;
   const showTrailingIcon = showPasswordToggle || statusIcon !== undefined;
   const trailingAdornmentCount = [tooltip, showTrailingIcon, suffixAction].filter(Boolean).length;
+  const canShowFocusState = !disabled && !readOnly;
 
   useEffect(() => {
     if (error) return;
@@ -190,10 +191,13 @@ const Input = ({
               "border border-border-5": !error && !compact,
             },
             {
-              "focus:border-border-20 focus:ring-4 focus:ring-core-primary-5": !error && !compact && !disabled,
+              "focus:border-border-20 focus:ring-4 focus:ring-core-primary-5": !error && !compact && canShowFocusState,
             },
             {
-              "border border-intent-critical-50 focus:ring-4 focus:ring-intent-critical-20": error,
+              "border border-intent-critical-50": error,
+            },
+            {
+              "focus:ring-4 focus:ring-intent-critical-20": error && canShowFocusState,
             },
             { "pt-[18px]": !hideLabelOnFocus },
             { "h-14 pl-4": !compact },
@@ -204,6 +208,7 @@ const Input = ({
             { "h-6": compact },
             { "no-spinner": type === "number" },
             { uppercase: type === "date" },
+            { "cursor-default": readOnly },
             className,
           )}
           onChange={handleChange}
@@ -253,7 +258,7 @@ const Input = ({
           htmlFor={id}
           className={clsx(
             "absolute text-text-primary-50",
-            { "cursor-text": !disabled },
+            { "cursor-text": canShowFocusState },
             { "text-300": !hasFloatingLabel },
             { "left-0": compact },
             { "left-[17px]": !compact },
@@ -263,9 +268,10 @@ const Input = ({
             { "top-0": !hasFloatingLabel && compact },
             { "top-[7px] text-200": hasFloatingLabel },
             {
-              "duration-150ms transition-[top] ease-in-out peer-focus:top-[7px] peer-focus:text-200": !hideLabelOnFocus,
+              "duration-150ms transition-[top] ease-in-out peer-focus:top-[7px] peer-focus:text-200":
+                !hideLabelOnFocus && canShowFocusState,
             },
-            { "peer-focus:invisible": hideLabelOnFocus },
+            { "peer-focus:invisible": hideLabelOnFocus && canShowFocusState },
             { invisible: hideLabelOnFocus && hasFloatingLabel },
           )}
         >

--- a/server/internal/domain/curtailment/automation.go
+++ b/server/internal/domain/curtailment/automation.go
@@ -343,7 +343,7 @@ func (s *AutomationService) validateAndNormalize(
 		rule.TriggerType = models.AutomationTriggerTypeMQTT
 	}
 	if rule.TriggerType != models.AutomationTriggerTypeMQTT {
-		return models.AutomationRule{}, fleeterror.NewInvalidArgumentErrorf("trigger_type %q is not supported; only MQTT", rule.TriggerType)
+		return models.AutomationRule{}, fleeterror.NewInvalidArgumentErrorf("trigger_type %q is not supported; only MaestroOS sources are supported", rule.TriggerType)
 	}
 	if rule.MQTTSourceID <= 0 {
 		return models.AutomationRule{}, fleeterror.NewInvalidArgumentError("mqtt_source_id must be set")
@@ -409,7 +409,7 @@ func validateAutomationRuleName(name string) error {
 
 func mqttSourceLookupError(err error) error {
 	if errors.Is(err, mqttingest.ErrSourceConfigNotFound) {
-		return fleeterror.NewNotFoundError("mqtt source not found")
+		return fleeterror.NewNotFoundError("MaestroOS source not found")
 	}
 	return err
 }
@@ -417,13 +417,13 @@ func mqttSourceLookupError(err error) error {
 func automationSignalFromMQTTTarget(target mqttingest.Target) (models.AutomationSignal, error) {
 	switch target {
 	case mqttingest.TargetUnknown:
-		return "", fleeterror.NewInvalidArgumentError("unsupported MQTT target \"unknown\"")
+		return "", fleeterror.NewInvalidArgumentError("unsupported MaestroOS target \"unknown\"")
 	case mqttingest.TargetOff:
 		return models.AutomationSignalOff, nil
 	case mqttingest.TargetOn:
 		return models.AutomationSignalOn, nil
 	default:
-		return "", fleeterror.NewInvalidArgumentErrorf("unsupported MQTT target %q", target.String())
+		return "", fleeterror.NewInvalidArgumentErrorf("unsupported MaestroOS target %q", target.String())
 	}
 }
 
@@ -436,7 +436,7 @@ func startRequestFromAutomationProfile(rule *models.AutomationRule, profile *mod
 	toleranceKW := float64Value(profile.ToleranceKW)
 	externalReference, idempotencyKey := automationRuleEventReference(rule.ID)
 	sourceActorID := externalReference
-	reason := fmt.Sprintf("Automation %q from MQTT source %q", rule.RuleName, signal.Source.SourceName)
+	reason := fmt.Sprintf("Automation %q from MaestroOS source %q", rule.RuleName, signal.Source.SourceName)
 	return StartRequest{
 		PreviewRequest: PreviewRequest{
 			OrgID:                   rule.OrgID,

--- a/server/internal/domain/curtailment/automation.go
+++ b/server/internal/domain/curtailment/automation.go
@@ -343,7 +343,7 @@ func (s *AutomationService) validateAndNormalize(
 		rule.TriggerType = models.AutomationTriggerTypeMQTT
 	}
 	if rule.TriggerType != models.AutomationTriggerTypeMQTT {
-		return models.AutomationRule{}, fleeterror.NewInvalidArgumentErrorf("trigger_type %q is not supported; only MaestroOS sources are supported", rule.TriggerType)
+		return models.AutomationRule{}, fleeterror.NewInvalidArgumentErrorf("trigger_type %q is not supported; only MQTT (MaestroOS source) is supported", rule.TriggerType)
 	}
 	if rule.MQTTSourceID <= 0 {
 		return models.AutomationRule{}, fleeterror.NewInvalidArgumentError("mqtt_source_id must be set")

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -64,6 +64,7 @@ func TestAutomationService_CreateRejectsCrossOrgSource(t *testing.T) {
 
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsNotFoundError(err))
+	assert.Contains(t, err.Error(), "MaestroOS source not found")
 	assert.Equal(t, 0, h.rules.createCalls)
 }
 
@@ -264,6 +265,11 @@ func TestAutomationService_HandleMQTTSignal_OffStartsCurtailmentFromResponseProf
 	assert.Equal(t, int32(15), h.curtailments.lastInsertEvent.CurtailBatchIntervalSec)
 	assert.Equal(t, int32(50), h.curtailments.lastInsertEvent.RestoreBatchSize)
 	assert.Equal(t, int32(5), h.curtailments.lastInsertEvent.RestoreBatchIntervalSec)
+	assert.Equal(
+		t,
+		`Automation "MaestroOS curtailment" from MaestroOS source "Dorothy 2 MaestroOS"`,
+		h.curtailments.lastInsertEvent.Reason,
+	)
 	assert.Equal(t, models.SourceActorAutomation, h.curtailments.lastInsertEvent.SourceActorType)
 	assert.Equal(t, h.source.ServiceUserID, h.curtailments.lastInsertEvent.CreatedByUserID)
 	assert.Equal(t, automationExternalSource, *h.curtailments.lastInsertEvent.ExternalSource)

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -68,6 +68,30 @@ func TestAutomationService_CreateRejectsCrossOrgSource(t *testing.T) {
 	assert.Equal(t, 0, h.rules.createCalls)
 }
 
+func TestAutomationService_CreateRejectsUnsupportedTriggerType(t *testing.T) {
+	t.Parallel()
+
+	h := newAutomationHarness(t)
+	h.sources.configs[h.source.ID] = h.source
+	h.profiles.profiles = []*models.ResponseProfile{h.profile}
+
+	_, err := h.automation.Create(t.Context(), SaveAutomationRuleRequest{
+		Rule: models.AutomationRule{
+			OrgID:             h.orgID,
+			RuleName:          "MaestroOS curtailment",
+			TriggerType:       models.AutomationTriggerType("marketPriceAbove"),
+			MQTTSourceID:      h.source.ID,
+			ResponseProfileID: h.profile.ID,
+		},
+	})
+
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsInvalidArgumentError(err))
+	assert.Contains(t, err.Error(), `trigger_type "marketPriceAbove" is not supported`)
+	assert.Contains(t, err.Error(), "only MQTT (MaestroOS source) is supported")
+	assert.Equal(t, 0, h.rules.createCalls)
+}
+
 func TestAutomationService_CreateRejectsAdminOnlyProfileWithoutAdminControls(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -289,9 +289,10 @@ func TestAutomationService_HandleMQTTSignal_OffStartsCurtailmentFromResponseProf
 	assert.Equal(t, int32(15), h.curtailments.lastInsertEvent.CurtailBatchIntervalSec)
 	assert.Equal(t, int32(50), h.curtailments.lastInsertEvent.RestoreBatchSize)
 	assert.Equal(t, int32(5), h.curtailments.lastInsertEvent.RestoreBatchIntervalSec)
+	expectedReason := `Automation "MaestroOS curtailment" from MaestroOS source "` + h.source.SourceName + `"`
 	assert.Equal(
 		t,
-		`Automation "MaestroOS curtailment" from MaestroOS source "Dorothy 2 MaestroOS"`,
+		expectedReason,
 		h.curtailments.lastInsertEvent.Reason,
 	)
 	assert.Equal(t, models.SourceActorAutomation, h.curtailments.lastInsertEvent.SourceActorType)

--- a/server/internal/domain/curtailment/mqttingest/settings_service.go
+++ b/server/internal/domain/curtailment/mqttingest/settings_service.go
@@ -298,7 +298,7 @@ func (s *SettingsService) Delete(ctx context.Context, orgID, sourceID int64) err
 
 func (s *SettingsService) TestConnection(ctx context.Context, req TestSourceConnectionRequest) (TestSourceConnectionResult, error) {
 	if s.connectionTester == nil {
-		return TestSourceConnectionResult{}, fleeterror.NewUnimplementedError("mqtt source connection testing is not configured")
+		return TestSourceConnectionResult{}, fleeterror.NewUnimplementedError("MaestroOS source connection testing is not configured")
 	}
 	source := normalizeSourceConfig(req.Source)
 	if source.SourceName == "" {
@@ -468,7 +468,7 @@ func (s *SettingsService) reconcile(ctx context.Context) error {
 	reconcileCtx, cancel := context.WithTimeout(detachedContext(ctx), s.reconcileTimeout)
 	defer cancel()
 	if err := s.runtime.Reconcile(reconcileCtx); err != nil {
-		return fleeterror.NewUnavailableErrorf("mqtt source saved but runtime reload failed: %v", err)
+		return fleeterror.NewUnavailableErrorf("MaestroOS source saved but runtime reload failed: %v", err)
 	}
 	return nil
 }
@@ -480,7 +480,7 @@ func (s *SettingsService) quiesceSource(ctx context.Context, sourceID int64) err
 	reconcileCtx, cancel := context.WithTimeout(detachedContext(ctx), s.reconcileTimeout)
 	defer cancel()
 	if err := s.runtime.QuiesceSource(reconcileCtx, sourceID); err != nil {
-		return fleeterror.NewUnavailableErrorf("mqtt source saved but runtime reload failed: %v", err)
+		return fleeterror.NewUnavailableErrorf("MaestroOS source saved but runtime reload failed: %v", err)
 	}
 	return nil
 }
@@ -544,13 +544,13 @@ func mqttCredentialBindingChanged(current, next SourceConfig) bool {
 func sourceStoreError(prefix string, err error) error {
 	switch {
 	case errors.Is(err, ErrSourceConfigNotFound):
-		return fleeterror.NewNotFoundError("mqtt source not found")
+		return fleeterror.NewNotFoundError("MaestroOS source not found")
 	case errors.Is(err, ErrSourceConfigNameExists):
-		return fleeterror.NewAlreadyExistsError("an MQTT curtailment source with this name already exists")
+		return fleeterror.NewAlreadyExistsError("a MaestroOS curtailment source with this name already exists")
 	case errors.Is(err, ErrSourceConfigDeleteBlocked):
-		return fleeterror.NewFailedPreconditionError("disable the MQTT source before deleting it")
+		return fleeterror.NewFailedPreconditionError("disable the MaestroOS source before deleting it")
 	case errors.Is(err, ErrSourceConfigReferenced):
-		return fleeterror.NewFailedPreconditionError("MQTT source is referenced by a curtailment automation rule")
+		return fleeterror.NewFailedPreconditionError("MaestroOS source is referenced by a curtailment automation rule")
 	default:
 		return fmt.Errorf("%s: %w", prefix, err)
 	}

--- a/server/internal/domain/curtailment/mqttingest/settings_service.go
+++ b/server/internal/domain/curtailment/mqttingest/settings_service.go
@@ -480,7 +480,7 @@ func (s *SettingsService) quiesceSource(ctx context.Context, sourceID int64) err
 	reconcileCtx, cancel := context.WithTimeout(detachedContext(ctx), s.reconcileTimeout)
 	defer cancel()
 	if err := s.runtime.QuiesceSource(reconcileCtx, sourceID); err != nil {
-		return fleeterror.NewUnavailableErrorf("MaestroOS source saved but runtime reload failed: %v", err)
+		return fleeterror.NewUnavailableErrorf("MaestroOS source disable failed while quiescing runtime: %v", err)
 	}
 	return nil
 }

--- a/server/internal/domain/curtailment/mqttingest/settings_service_test.go
+++ b/server/internal/domain/curtailment/mqttingest/settings_service_test.go
@@ -2,6 +2,7 @@ package mqttingest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -164,6 +165,7 @@ type fakeRuntimeController struct {
 	reconcileCalls     int
 	quiesceCalls       int
 	reconcileErr       error
+	quiesceErr         error
 	sawCanceledContext bool
 	contextValue       any
 	status             RuntimeStatus
@@ -186,7 +188,7 @@ func (f *fakeRuntimeController) SourceRuntimeStatus(int64) RuntimeStatus {
 
 func (f *fakeRuntimeController) QuiesceSource(context.Context, int64) error {
 	f.quiesceCalls++
-	return nil
+	return f.quiesceErr
 }
 
 type fakeSourceConnectionTester struct {
@@ -510,6 +512,29 @@ func TestSettingsService_DisableQuiescesRuntimeAndKeepsSourceState(t *testing.T)
 	assert.False(t, view.Config.Enabled)
 	assert.Equal(t, 1, runtime.quiesceCalls)
 	assert.Equal(t, 1, runtime.reconcileCalls)
+}
+
+func TestSettingsService_DisableReportsQuiesceFailureBeforeStoreUpdate(t *testing.T) {
+	t.Parallel()
+
+	source := validSettingsSource()
+	source.ID = 7
+	source.Enabled = true
+	source.MQTTPasswordEncrypted = "enc:secret"
+	store := newFakeSettingsStore(source)
+	runtime := &fakeRuntimeController{quiesceErr: errors.New("broker still connected")}
+	svc, err := NewSettingsService(SettingsServiceConfig{Store: store, Cipher: &fakeSettingsCipher{}, Runtime: runtime})
+	require.NoError(t, err)
+
+	_, err = svc.SetEnabled(t.Context(), 42, 7, false)
+
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsUnavailableError(err))
+	assert.Contains(t, err.Error(), "MaestroOS source disable failed while quiescing runtime")
+	assert.NotContains(t, err.Error(), "saved")
+	assert.Equal(t, 1, runtime.quiesceCalls)
+	assert.Equal(t, 0, runtime.reconcileCalls)
+	assert.True(t, store.configs[source.ID].Enabled)
 }
 
 func TestSettingsService_DeleteRejectsEnabledSource(t *testing.T) {

--- a/server/internal/domain/curtailment/mqttingest/settings_service_test.go
+++ b/server/internal/domain/curtailment/mqttingest/settings_service_test.go
@@ -301,6 +301,32 @@ func TestSettingsService_TestConnectionRejectsMissingPasswordBeforeBrokerCall(t 
 	assert.Zero(t, tester.calls)
 }
 
+func TestSettingsService_TestConnectionUsesMaestroOSCopyForNonLocalTCPBroker(t *testing.T) {
+	t.Parallel()
+
+	tester := &fakeSourceConnectionTester{}
+	svc, err := NewSettingsService(SettingsServiceConfig{
+		Store:            newFakeSettingsStore(),
+		Cipher:           &fakeSettingsCipher{},
+		ConnectionTester: tester,
+	})
+	require.NoError(t, err)
+
+	source := validSettingsSource()
+	source.SourceName = ""
+	source.BrokerPrimaryHost = "1"
+	_, err = svc.TestConnection(t.Context(), TestSourceConnectionRequest{
+		Source:            source,
+		PlaintextPassword: "secret",
+	})
+
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsInvalidArgumentError(err))
+	assert.Contains(t, err.Error(), `MaestroOS source "connection-test" uses TCP transport with non-local broker host "1"`)
+	assert.NotContains(t, err.Error(), "mqttingest")
+	assert.Zero(t, tester.calls)
+}
+
 func TestSettingsService_CreateDuplicateNameReturnsAlreadyExists(t *testing.T) {
 	t.Parallel()
 
@@ -318,6 +344,7 @@ func TestSettingsService_CreateDuplicateNameReturnsAlreadyExists(t *testing.T) {
 
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsAlreadyExistsError(err))
+	assert.Contains(t, err.Error(), "a MaestroOS curtailment source with this name already exists")
 	assert.Zero(t, runtime.reconcileCalls, "duplicate-name writes must not trigger runtime reload")
 }
 
@@ -498,7 +525,7 @@ func TestSettingsService_DeleteRejectsEnabledSource(t *testing.T) {
 
 	err = svc.Delete(t.Context(), 42, 7)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "disable the MQTT source")
+	assert.Contains(t, err.Error(), "disable the MaestroOS source")
 }
 
 func TestSettingsService_DeleteRejectsReferencedSource(t *testing.T) {

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -658,14 +658,14 @@ func validateBrokerTransport(src SourceConfig, hosts ...string) error {
 		for _, host := range hosts {
 			addr, err := netip.ParseAddr(host)
 			if err != nil || !(addr.IsPrivate() || addr.IsLoopback() || addr.IsLinkLocalUnicast()) {
-				return fmt.Errorf("mqttingest: source %s uses tcp transport with non-local broker host %q", src.SourceName, host)
+				return fmt.Errorf("MaestroOS source %q uses TCP transport with non-local broker host %q", src.SourceName, host)
 			}
 		}
 		return nil
 	case brokerTransportTLS:
 		return nil
 	default:
-		return fmt.Errorf("mqttingest: source %s has unsupported broker_transport %q", src.SourceName, src.BrokerTransport)
+		return fmt.Errorf("MaestroOS source %q has unsupported broker_transport %q", src.SourceName, src.BrokerTransport)
 	}
 }
 

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -23,7 +23,7 @@ import (
 // Action verb for requireAdminFromContext error messages on the legacy
 // admin-only override checks that run after the curtailment:manage gate.
 const actionSupplyOverrideFields = "supply curtailment override fields"
-const actionManageMqttSources = "manage MQTT curtailment sources"
+const actionManageMqttSources = "manage MaestroOS curtailment sources"
 
 // Handler implements the curtailment RPC surface; service=nil keeps
 // RPC bodies at Unimplemented after any entry auth gates run.


### PR DESCRIPTION
## Summary
- Allow curtailment CTAs to surface required-field validation instead of staying disabled for missing local inputs

https://github.com/user-attachments/assets/a08dcb2a-a885-465f-bf9f-c75fd82ec99a

- Restore saved response profile scope when switching profiles, including clearing stale miner selections for whole-fleet profiles


https://github.com/user-attachments/assets/edeea1aa-dd33-4eca-9418-e87655ae9ec0


- Keep readonly inputs from showing focus highlights and update leftover MQTT wording to MaestroOS


https://github.com/user-attachments/assets/8a8b3de3-a7d3-4039-b2c1-020c076fa6bf

- Update curtailment polling so that when restoring has completed, the curtailment history status changes to "completed" instead of remaining at "restoring" until manually refreshing the page

https://github.com/user-attachments/assets/a82e3321-ad9a-43db-91c3-44b28ff1fed6




## Test plan
- [ ] In New curtailment, click Run with required fields empty and confirm field errors appear on the form
- [ ] Select miners, switch to a whole-fleet response profile, and confirm the Apply to selection resets before running
- [ ] Verify MaestroOS source and automation modals surface required-field errors from their Save/Test actions
