### PR TITLE
notifications (2/5): notification_history keyset listing

### DIFF
--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -753,6 +753,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listNonTerminalCurtailmentEventsStmt, err = db.PrepareContext(ctx, listNonTerminalCurtailmentEvents); err != nil {
 		return nil, fmt.Errorf("error preparing query ListNonTerminalCurtailmentEvents: %w", err)
 	}
+	if q.listNotificationHistoryStmt, err = db.PrepareContext(ctx, listNotificationHistory); err != nil {
+		return nil, fmt.Errorf("error preparing query ListNotificationHistory: %w", err)
+	}
 	if q.listOrganizationsStmt, err = db.PrepareContext(ctx, listOrganizations); err != nil {
 		return nil, fmt.Errorf("error preparing query ListOrganizations: %w", err)
 	}
@@ -2411,6 +2414,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listNonTerminalCurtailmentEventsStmt: %w", cerr)
 		}
 	}
+	if q.listNotificationHistoryStmt != nil {
+		if cerr := q.listNotificationHistoryStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listNotificationHistoryStmt: %w", cerr)
+		}
+	}
 	if q.listOrganizationsStmt != nil {
 		if cerr := q.listOrganizationsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listOrganizationsStmt: %w", cerr)
@@ -3423,6 +3431,7 @@ type Queries struct {
 	listMQTTSourceStatesByOrgStmt                         *sql.Stmt
 	listMinerStateSnapshotsStmt                           *sql.Stmt
 	listNonTerminalCurtailmentEventsStmt                  *sql.Stmt
+	listNotificationHistoryStmt                           *sql.Stmt
 	listOrganizationsStmt                                 *sql.Stmt
 	listPermissionsStmt                                   *sql.Stmt
 	listPoolsStmt                                         *sql.Stmt
@@ -3818,6 +3827,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listMQTTSourceStatesByOrgStmt:                         q.listMQTTSourceStatesByOrgStmt,
 		listMinerStateSnapshotsStmt:                           q.listMinerStateSnapshotsStmt,
 		listNonTerminalCurtailmentEventsStmt:                  q.listNonTerminalCurtailmentEventsStmt,
+		listNotificationHistoryStmt:                           q.listNotificationHistoryStmt,
 		listOrganizationsStmt:                                 q.listOrganizationsStmt,
 		listPermissionsStmt:                                   q.listPermissionsStmt,
 		listPoolsStmt:                                         q.listPoolsStmt,

--- a/server/generated/sqlc/notification_history.sql.go
+++ b/server/generated/sqlc/notification_history.sql.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"time"
 )
 
 const insertNotificationHistory = `-- name: InsertNotificationHistory :exec
@@ -59,7 +60,6 @@ type InsertNotificationHistoryParams struct {
 	Annotations    json.RawMessage
 }
 
-// Persist one notification delivered by the Grafana alertmanager webhook receiver.
 func (q *Queries) InsertNotificationHistory(ctx context.Context, arg InsertNotificationHistoryParams) error {
 	_, err := q.exec(ctx, q.insertNotificationHistoryStmt, insertNotificationHistory,
 		arg.AlertName,
@@ -77,4 +77,102 @@ func (q *Queries) InsertNotificationHistory(ctx context.Context, arg InsertNotif
 		arg.Annotations,
 	)
 	return err
+}
+
+const listNotificationHistory = `-- name: ListNotificationHistory :many
+SELECT
+    nh.id,
+    nh.received_at,
+    nh.alert_name,
+    nh.status,
+    nh.severity,
+    nh.rule_group,
+    nh.fingerprint,
+    nh.organization_id,
+    nh.device_id,
+    COALESCE(
+        TRIM(COALESCE(
+            NULLIF(d.custom_name, ''),
+            COALESCE(dd.manufacturer, '') || ' ' || COALESCE(dd.model, '')
+        )),
+        ''
+    )::text AS device_name,
+    COALESCE(d.mac_address, '') AS device_mac,
+    nh.template,
+    nh.summary,
+    nh.starts_at,
+    nh.ends_at
+FROM notification_history nh
+LEFT JOIN device d
+    ON d.device_identifier = nh.device_id
+    AND d.org_id = nh.organization_id
+    AND d.deleted_at IS NULL
+LEFT JOIN discovered_device dd ON dd.id = d.discovered_device_id
+WHERE nh.organization_id = $1
+  AND ($2::bigint IS NULL OR nh.id < $2)
+ORDER BY nh.id DESC
+LIMIT $3
+`
+
+type ListNotificationHistoryParams struct {
+	OrganizationID sql.NullInt64
+	BeforeID       sql.NullInt64
+	PageLimit      int32
+}
+
+type ListNotificationHistoryRow struct {
+	ID             int64
+	ReceivedAt     time.Time
+	AlertName      string
+	Status         string
+	Severity       string
+	RuleGroup      string
+	Fingerprint    string
+	OrganizationID sql.NullInt64
+	DeviceID       string
+	DeviceName     string
+	DeviceMac      string
+	Template       string
+	Summary        string
+	StartsAt       sql.NullTime
+	EndsAt         sql.NullTime
+}
+
+func (q *Queries) ListNotificationHistory(ctx context.Context, arg ListNotificationHistoryParams) ([]ListNotificationHistoryRow, error) {
+	rows, err := q.query(ctx, q.listNotificationHistoryStmt, listNotificationHistory, arg.OrganizationID, arg.BeforeID, arg.PageLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListNotificationHistoryRow
+	for rows.Next() {
+		var i ListNotificationHistoryRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ReceivedAt,
+			&i.AlertName,
+			&i.Status,
+			&i.Severity,
+			&i.RuleGroup,
+			&i.Fingerprint,
+			&i.OrganizationID,
+			&i.DeviceID,
+			&i.DeviceName,
+			&i.DeviceMac,
+			&i.Template,
+			&i.Summary,
+			&i.StartsAt,
+			&i.EndsAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/server/internal/domain/notificationhistory/notificationhistory.go
+++ b/server/internal/domain/notificationhistory/notificationhistory.go
@@ -1,5 +1,3 @@
-// Package notificationhistory models notifications received from Grafana's
-// alertmanager webhook and persisted to the notification_history table.
 package notificationhistory
 
 import (
@@ -7,7 +5,6 @@ import (
 	"time"
 )
 
-// Notification is one row destined for notification_history.
 type Notification struct {
 	AlertName      string
 	Status         string
@@ -24,7 +21,19 @@ type Notification struct {
 	Annotations    map[string]string
 }
 
-// Store persists Notification rows.
 type Store interface {
 	Insert(ctx context.Context, n *Notification) error
+}
+
+type StoredNotification struct {
+	ID         int64
+	ReceivedAt time.Time
+	DeviceName string
+	DeviceMAC  string
+	Notification
+}
+
+// beforeID is the keyset cursor, nil for the first page.
+type Lister interface {
+	List(ctx context.Context, organizationID int64, beforeID *int64, limit int32) ([]StoredNotification, error)
 }

--- a/server/internal/domain/stores/sqlstores/notification_history.go
+++ b/server/internal/domain/stores/sqlstores/notification_history.go
@@ -21,6 +21,7 @@ func NewSQLNotificationHistoryStore(conn *sql.DB) *SQLNotificationHistoryStore {
 }
 
 var _ notificationhistory.Store = (*SQLNotificationHistoryStore)(nil)
+var _ notificationhistory.Lister = (*SQLNotificationHistoryStore)(nil)
 
 func (s *SQLNotificationHistoryStore) Insert(ctx context.Context, n *notificationhistory.Notification) error {
 	marshalJSONMap := func(m map[string]string) (json.RawMessage, error) {
@@ -54,4 +55,38 @@ func (s *SQLNotificationHistoryStore) Insert(ctx context.Context, n *notificatio
 		Labels:         labels,
 		Annotations:    annotations,
 	})
+}
+
+func (s *SQLNotificationHistoryStore) List(ctx context.Context, organizationID int64, beforeID *int64, limit int32) ([]notificationhistory.StoredNotification, error) {
+	rows, err := s.GetQueries(ctx).ListNotificationHistory(ctx, sqlc.ListNotificationHistoryParams{
+		OrganizationID: sql.NullInt64{Int64: organizationID, Valid: true},
+		BeforeID:       ptrToNullInt64(beforeID),
+		PageLimit:      limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list notification history: %w", err)
+	}
+	out := make([]notificationhistory.StoredNotification, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, notificationhistory.StoredNotification{
+			ID:         row.ID,
+			ReceivedAt: row.ReceivedAt,
+			DeviceName: row.DeviceName,
+			DeviceMAC:  row.DeviceMac,
+			Notification: notificationhistory.Notification{
+				AlertName:      row.AlertName,
+				Status:         row.Status,
+				Severity:       row.Severity,
+				RuleGroup:      row.RuleGroup,
+				Fingerprint:    row.Fingerprint,
+				OrganizationID: nullInt64ToPtr(row.OrganizationID),
+				DeviceID:       row.DeviceID,
+				Template:       row.Template,
+				Summary:        row.Summary,
+				StartsAt:       nullTimeToPtr(row.StartsAt),
+				EndsAt:         nullTimeToPtr(row.EndsAt),
+			},
+		})
+	}
+	return out, nil
 }

--- a/server/migrations/000087_notification_history_keyset_index.down.sql
+++ b/server/migrations/000087_notification_history_keyset_index.down.sql
@@ -1,0 +1,2 @@
+-- CONCURRENTLY must be the sole statement and cannot run in a transaction (golang-migrate runs it directly).
+DROP INDEX CONCURRENTLY IF EXISTS idx_notification_history_org_id;

--- a/server/migrations/000087_notification_history_keyset_index.up.sql
+++ b/server/migrations/000087_notification_history_keyset_index.up.sql
@@ -1,0 +1,3 @@
+-- CONCURRENTLY must be the sole statement and cannot run in a transaction (golang-migrate runs it directly).
+CREATE INDEX CONCURRENTLY idx_notification_history_org_id
+    ON notification_history (organization_id, id DESC);

--- a/server/sqlc/queries/notification_history.sql
+++ b/server/sqlc/queries/notification_history.sql
@@ -1,5 +1,4 @@
 -- name: InsertNotificationHistory :exec
--- Persist one notification delivered by the Grafana alertmanager webhook receiver.
 INSERT INTO notification_history (
     alert_name,
     status,
@@ -29,3 +28,37 @@ INSERT INTO notification_history (
     sqlc.arg('labels'),
     sqlc.arg('annotations')
 );
+
+-- name: ListNotificationHistory :many
+SELECT
+    nh.id,
+    nh.received_at,
+    nh.alert_name,
+    nh.status,
+    nh.severity,
+    nh.rule_group,
+    nh.fingerprint,
+    nh.organization_id,
+    nh.device_id,
+    COALESCE(
+        TRIM(COALESCE(
+            NULLIF(d.custom_name, ''),
+            COALESCE(dd.manufacturer, '') || ' ' || COALESCE(dd.model, '')
+        )),
+        ''
+    )::text AS device_name,
+    COALESCE(d.mac_address, '') AS device_mac,
+    nh.template,
+    nh.summary,
+    nh.starts_at,
+    nh.ends_at
+FROM notification_history nh
+LEFT JOIN device d
+    ON d.device_identifier = nh.device_id
+    AND d.org_id = nh.organization_id
+    AND d.deleted_at IS NULL
+LEFT JOIN discovered_device dd ON dd.id = d.discovered_device_id
+WHERE nh.organization_id = sqlc.arg('organization_id')
+  AND (sqlc.narg('before_id')::bigint IS NULL OR nh.id < sqlc.narg('before_id'))
+ORDER BY nh.id DESC
+LIMIT sqlc.arg('page_limit');


### PR DESCRIPTION
**Stack 2/5** — base: `eden/notifications-1-proto` (#452)

## 1. Summary

Adds the **read/list path for notification history**. Background already on `main`: an Alertmanager webhook receiver persists each fired-alert notification into the `notification_history` table. This PR adds the ability to **page through that history newest-first**, so an operator can review what alerts fired for their organization. It delivers the DB/query/store layer only — a `ListNotificationHistory` SQL query, a supporting index, and a `List` store method using keyset pagination. The gRPC handler that calls this arrives in #455.

## 2. How it works

The flow is a single-page read keyed off the caller's organization and an optional cursor:

1. A caller (the `HistoryService` handler landing in #455) invokes `store.List(ctx, organizationID, beforeID, limit)`. `beforeID` is `nil` for the first page; for subsequent pages the caller passes the `id` of the last row it already received.
2. `List` maps the Go arguments into sqlc query params (`organizationID` → `NullInt64`, `beforeID` → nullable cursor, `limit` → page size) and calls the generated `ListNotificationHistory`.
3. The SQL selects from `notification_history` filtered to the organization, with `id < before_id` applied only when a cursor is present, ordered `id DESC`, capped by `LIMIT`. It `LEFT JOIN`s the `device` and `discovered_device` tables to resolve `device_id` into a human-readable device name and MAC at read time (falling back to `''` when the device is unknown or soft-deleted).
4. Postgres serves the ordering and seek from the new `(organization_id, id DESC)` index rather than scanning.
5. `List` converts each generated row into a `StoredNotification` (the persisted `Notification` plus row identity `ID`, `ReceivedAt`, and the read-time `DeviceName`/`DeviceMAC`) and returns the slice.

**Keyset (cursor) pagination:** instead of `OFFSET`, each next page seeks past the last seen `id` (`id < before_id`) and reads the next `LIMIT` rows in `id DESC` order. Because `notification_history` is insert-only, ids are monotonic and stable, so pages never shift or duplicate as new rows arrive. The handler in #455 owns page-size policy (default 50, max 200); this layer just honors the `limit` it is given.

## 3. Diagrams

Component / data flow (boundaries this PR touches are bold in prose; the handler is in #455):

```mermaid
flowchart LR
    H["HistoryService handler (#455)"] -->|"List(orgID, beforeID, limit)"| S["SQLNotificationHistoryStore.List"]
    S -->|"ListNotificationHistoryParams"| Q["sqlc: ListNotificationHistory (generated)"]
    Q -->|"SELECT ... WHERE org_id=? AND id&lt;? ORDER BY id DESC LIMIT ?"| PG[("Postgres: notification_history")]
    PG -. "index scan" .-> IDX["idx_notification_history_org_id (organization_id, id DESC)"]
    Q -.->|"LEFT JOIN"| DEV[("device / discovered_device")]
    PG -->|"rows"| S
    S -->|"[]StoredNotification"| H
```

Keyset pagination over an insert-only table (ordering by `id DESC`, seeking past the cursor):

```mermaid
sequenceDiagram
    participant C as Caller (#455)
    participant L as Store.List
    participant DB as Postgres
    C->>L: List(org, beforeID=nil, limit=50)
    L->>DB: WHERE org_id=org ORDER BY id DESC LIMIT 50
    DB-->>L: rows [id=900 .. 851]
    L-->>C: page 1 (last id = 851)
    C->>L: List(org, beforeID=851, limit=50)
    L->>DB: WHERE org_id=org AND id < 851 ORDER BY id DESC LIMIT 50
    DB-->>L: rows [id=850 .. 801]
    L-->>C: page 2 (last id = 801)
    Note over C,DB: New inserts get higher ids, already-paged rows never shift.
```

## 4. Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/sqlc/queries/notification_history.sql` | **New query** `ListNotificationHistory`: org filter, optional `before_id` cursor, `id DESC`, `LIMIT`, device-enrichment joins | Source of truth for the read path — review the SQL, cursor predicate, join correctness, and `''` fallbacks here |
| `server/internal/domain/notificationhistory/notificationhistory.go` | **New** `StoredNotification` read-back type and `Lister` interface (`List` with `beforeID *int64` cursor) | Defines the domain contract the handler (#455) codes against |
| `server/internal/domain/stores/sqlstores/notification_history.go` | **New** `List` method on the SQL store; asserts `Lister` is implemented; maps params and rows | Mapping layer between domain and sqlc; check cursor passthrough and row→`StoredNotification` conversion (helpers `ptrToNullInt64`/`nullInt64ToPtr`/`nullTimeToPtr` are pre-existing) |
| `server/migrations/000087_notification_history_keyset_index.up.sql` | **New** migration: `CREATE INDEX CONCURRENTLY (organization_id, id DESC)` | Backs the access pattern; review the CONCURRENTLY rationale and recovery note |
| `server/migrations/000087_notification_history_keyset_index.down.sql` | **New** `DROP INDEX CONCURRENTLY IF EXISTS` | Matching online rollback |
| `server/generated/sqlc/notification_history.sql.go` | Generated `ListNotificationHistory` query, params, row, scanner | **Generated — skip** |
| `server/generated/sqlc/db.go` | Generated prepared-statement registration/teardown for the new query | **Generated — skip** |

## 5. Key technical decisions & trade-offs

- **Keyset pagination (`id < before_id`, `id DESC`) over `OFFSET`/`LIMIT`** — stable on an insert-only table (no page drift/skew as rows arrive) and index-friendly; cost is the caller must thread the last id as a cursor rather than a page number.
- **`CREATE INDEX CONCURRENTLY` over a plain `CREATE INDEX`** — a plain build takes `ACCESS EXCLUSIVE` on the live table and blocks webhook inserts for the build duration; CONCURRENTLY builds online (matches the convention in migration 000074). Trade-off: must be the sole statement and cannot run in a transaction, and a failed build can leave a dirty migration + an `INVALID` index (recovery noted inline in the migration).
- **Migration numbered 000087** so it merges before the 000088 permission seed in #454 — guarantees `schema_migrations` advances in numeric = merge order, avoiding golang-migrate skipping a lower-numbered migration on already-upgraded DBs.
- **Device name/MAC resolved at read time via `LEFT JOIN`** rather than denormalized onto `notification_history` at insert — names stay current and deleted/unknown devices degrade to `''`; cost is a join per page (served by existing device keys).
- **`Lister` as a separate interface from the existing `Store` (insert) interface** — read and write capabilities are segregated so the #455 handler can depend only on the read surface.

## 6. Testing & validation

- `just gen` re-run so `server/generated/sqlc` matches the committed query (the generated-code CI check enforces a clean tree).
- The SQL compiles under sqlc; the store satisfies both `notificationhistory.Store` and `notificationhistory.Lister` via compile-time `var _ = (*...)` assertions.
- **Not covered in this PR:** no unit/integration test exercises `List` against a live DB, and there is no handler/end-to-end coverage — the gRPC `HistoryService` that calls `List` (and enforces the page-size clamp of default 50 / max 200) lands in #455, where request-level validation and tests belong. The `CONCURRENTLY` migration's online behavior is asserted by convention (matching 000074), not by an automated deploy test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

