### PR TITLE
notifications (3/5): notification:read and notification:manage permissions

### DIFF
--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -753,6 +753,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listNonTerminalCurtailmentEventsStmt, err = db.PrepareContext(ctx, listNonTerminalCurtailmentEvents); err != nil {
 		return nil, fmt.Errorf("error preparing query ListNonTerminalCurtailmentEvents: %w", err)
 	}
+	if q.listNotificationHistoryStmt, err = db.PrepareContext(ctx, listNotificationHistory); err != nil {
+		return nil, fmt.Errorf("error preparing query ListNotificationHistory: %w", err)
+	}
 	if q.listOrganizationsStmt, err = db.PrepareContext(ctx, listOrganizations); err != nil {
 		return nil, fmt.Errorf("error preparing query ListOrganizations: %w", err)
 	}
@@ -2411,6 +2414,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listNonTerminalCurtailmentEventsStmt: %w", cerr)
 		}
 	}
+	if q.listNotificationHistoryStmt != nil {
+		if cerr := q.listNotificationHistoryStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listNotificationHistoryStmt: %w", cerr)
+		}
+	}
 	if q.listOrganizationsStmt != nil {
 		if cerr := q.listOrganizationsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listOrganizationsStmt: %w", cerr)
@@ -3423,6 +3431,7 @@ type Queries struct {
 	listMQTTSourceStatesByOrgStmt                         *sql.Stmt
 	listMinerStateSnapshotsStmt                           *sql.Stmt
 	listNonTerminalCurtailmentEventsStmt                  *sql.Stmt
+	listNotificationHistoryStmt                           *sql.Stmt
 	listOrganizationsStmt                                 *sql.Stmt
 	listPermissionsStmt                                   *sql.Stmt
 	listPoolsStmt                                         *sql.Stmt
@@ -3818,6 +3827,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listMQTTSourceStatesByOrgStmt:                         q.listMQTTSourceStatesByOrgStmt,
 		listMinerStateSnapshotsStmt:                           q.listMinerStateSnapshotsStmt,
 		listNonTerminalCurtailmentEventsStmt:                  q.listNonTerminalCurtailmentEventsStmt,
+		listNotificationHistoryStmt:                           q.listNotificationHistoryStmt,
 		listOrganizationsStmt:                                 q.listOrganizationsStmt,
 		listPermissionsStmt:                                   q.listPermissionsStmt,
 		listPoolsStmt:                                         q.listPoolsStmt,

--- a/server/generated/sqlc/notification_history.sql.go
+++ b/server/generated/sqlc/notification_history.sql.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"time"
 )
 
 const insertNotificationHistory = `-- name: InsertNotificationHistory :exec
@@ -59,7 +60,6 @@ type InsertNotificationHistoryParams struct {
 	Annotations    json.RawMessage
 }
 
-// Persist one notification delivered by the Grafana alertmanager webhook receiver.
 func (q *Queries) InsertNotificationHistory(ctx context.Context, arg InsertNotificationHistoryParams) error {
 	_, err := q.exec(ctx, q.insertNotificationHistoryStmt, insertNotificationHistory,
 		arg.AlertName,
@@ -77,4 +77,102 @@ func (q *Queries) InsertNotificationHistory(ctx context.Context, arg InsertNotif
 		arg.Annotations,
 	)
 	return err
+}
+
+const listNotificationHistory = `-- name: ListNotificationHistory :many
+SELECT
+    nh.id,
+    nh.received_at,
+    nh.alert_name,
+    nh.status,
+    nh.severity,
+    nh.rule_group,
+    nh.fingerprint,
+    nh.organization_id,
+    nh.device_id,
+    COALESCE(
+        TRIM(COALESCE(
+            NULLIF(d.custom_name, ''),
+            COALESCE(dd.manufacturer, '') || ' ' || COALESCE(dd.model, '')
+        )),
+        ''
+    )::text AS device_name,
+    COALESCE(d.mac_address, '') AS device_mac,
+    nh.template,
+    nh.summary,
+    nh.starts_at,
+    nh.ends_at
+FROM notification_history nh
+LEFT JOIN device d
+    ON d.device_identifier = nh.device_id
+    AND d.org_id = nh.organization_id
+    AND d.deleted_at IS NULL
+LEFT JOIN discovered_device dd ON dd.id = d.discovered_device_id
+WHERE nh.organization_id = $1
+  AND ($2::bigint IS NULL OR nh.id < $2)
+ORDER BY nh.id DESC
+LIMIT $3
+`
+
+type ListNotificationHistoryParams struct {
+	OrganizationID sql.NullInt64
+	BeforeID       sql.NullInt64
+	PageLimit      int32
+}
+
+type ListNotificationHistoryRow struct {
+	ID             int64
+	ReceivedAt     time.Time
+	AlertName      string
+	Status         string
+	Severity       string
+	RuleGroup      string
+	Fingerprint    string
+	OrganizationID sql.NullInt64
+	DeviceID       string
+	DeviceName     string
+	DeviceMac      string
+	Template       string
+	Summary        string
+	StartsAt       sql.NullTime
+	EndsAt         sql.NullTime
+}
+
+func (q *Queries) ListNotificationHistory(ctx context.Context, arg ListNotificationHistoryParams) ([]ListNotificationHistoryRow, error) {
+	rows, err := q.query(ctx, q.listNotificationHistoryStmt, listNotificationHistory, arg.OrganizationID, arg.BeforeID, arg.PageLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListNotificationHistoryRow
+	for rows.Next() {
+		var i ListNotificationHistoryRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ReceivedAt,
+			&i.AlertName,
+			&i.Status,
+			&i.Severity,
+			&i.RuleGroup,
+			&i.Fingerprint,
+			&i.OrganizationID,
+			&i.DeviceID,
+			&i.DeviceName,
+			&i.DeviceMac,
+			&i.Template,
+			&i.Summary,
+			&i.StartsAt,
+			&i.EndsAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/server/internal/domain/authz/catalog.go
+++ b/server/internal/domain/authz/catalog.go
@@ -74,6 +74,9 @@ const (
 	PermFleetnodeRead   = "fleetnode:read"
 	PermFleetnodeManage = "fleetnode:manage"
 
+	PermNotificationRead   = "notification:read"
+	PermNotificationManage = "notification:manage"
+
 	// apikey — org-admin API key management. No separate :read; the surface
 	// lives under route-guarded Settings, so a viewer-only role has no
 	// reachable UI.
@@ -91,19 +94,20 @@ const (
 // and as the lookup key for the read-pairing rule (every action
 // permission requires its same-resource read partner).
 const (
-	ResourceFleet       = "fleet"
-	ResourceMiner       = "miner"
-	ResourceRack        = "rack"
-	ResourceSite        = "site"
-	ResourceActivity    = "activity"
-	ResourceServerLog   = "serverlog"
-	ResourceCurtailment = "curtailment"
-	ResourcePool        = "pool"
-	ResourceSchedule    = "schedule"
-	ResourceFleetNode   = "fleetnode"
-	ResourceAPIKey      = "apikey"
-	ResourceUser        = "user"
-	ResourceRole        = "role"
+	ResourceFleet        = "fleet"
+	ResourceMiner        = "miner"
+	ResourceRack         = "rack"
+	ResourceSite         = "site"
+	ResourceActivity     = "activity"
+	ResourceServerLog    = "serverlog"
+	ResourceCurtailment  = "curtailment"
+	ResourcePool         = "pool"
+	ResourceSchedule     = "schedule"
+	ResourceFleetNode    = "fleetnode"
+	ResourceNotification = "notification"
+	ResourceAPIKey       = "apikey"
+	ResourceUser         = "user"
+	ResourceRole         = "role"
 )
 
 // CatalogEntry is the in-code shape of a single permission. The wire-level
@@ -162,6 +166,9 @@ var catalog = []CatalogEntry{
 
 	{PermFleetnodeRead, "View fleet-node state.", ResourceFleetNode},
 	{PermFleetnodeManage, "Perform fleet-node admin operations.", ResourceFleetNode},
+
+	{PermNotificationRead, "View notification channels, alert rules, silences, and delivery history.", ResourceNotification},
+	{PermNotificationManage, "Create, edit, test, and delete notification channels; pause and resume alert rules; create and lift silences.", ResourceNotification},
 
 	{PermAPIKeyManage, "List, create, and revoke API keys for the organization.", ResourceAPIKey},
 

--- a/server/internal/domain/authz/catalog_test.go
+++ b/server/internal/domain/authz/catalog_test.go
@@ -67,6 +67,8 @@ func TestCatalogCompleteness(t *testing.T) {
 		PermScheduleManage,
 		PermFleetnodeRead,
 		PermFleetnodeManage,
+		PermNotificationRead,
+		PermNotificationManage,
 		PermAPIKeyManage,
 		PermUserRead,
 		PermUserManage,
@@ -114,7 +116,7 @@ func TestCatalogByResource_GroupsAndAssociates(t *testing.T) {
 	for _, resource := range []string{
 		ResourceFleet, ResourceMiner, ResourceRack, ResourceSite, ResourceActivity,
 		ResourceServerLog, ResourceCurtailment, ResourcePool, ResourceSchedule, ResourceFleetNode,
-		ResourceAPIKey, ResourceUser, ResourceRole,
+		ResourceNotification, ResourceAPIKey, ResourceUser, ResourceRole,
 	} {
 		if len(groups[resource]) == 0 {
 			t.Errorf("resource %q has no permissions in catalog", resource)
@@ -146,6 +148,7 @@ func TestResourceOrder_MatchesCatalogDeclarationOrder(t *testing.T) {
 		ResourcePool,
 		ResourceSchedule,
 		ResourceFleetNode,
+		ResourceNotification,
 		ResourceAPIKey,
 		ResourceUser,
 		ResourceRole,

--- a/server/internal/domain/notificationhistory/notificationhistory.go
+++ b/server/internal/domain/notificationhistory/notificationhistory.go
@@ -1,5 +1,3 @@
-// Package notificationhistory models notifications received from Grafana's
-// alertmanager webhook and persisted to the notification_history table.
 package notificationhistory
 
 import (
@@ -7,7 +5,6 @@ import (
 	"time"
 )
 
-// Notification is one row destined for notification_history.
 type Notification struct {
 	AlertName      string
 	Status         string
@@ -24,7 +21,19 @@ type Notification struct {
 	Annotations    map[string]string
 }
 
-// Store persists Notification rows.
 type Store interface {
 	Insert(ctx context.Context, n *Notification) error
+}
+
+type StoredNotification struct {
+	ID         int64
+	ReceivedAt time.Time
+	DeviceName string
+	DeviceMAC  string
+	Notification
+}
+
+// beforeID is the keyset cursor, nil for the first page.
+type Lister interface {
+	List(ctx context.Context, organizationID int64, beforeID *int64, limit int32) ([]StoredNotification, error)
 }

--- a/server/internal/domain/stores/sqlstores/notification_history.go
+++ b/server/internal/domain/stores/sqlstores/notification_history.go
@@ -21,6 +21,7 @@ func NewSQLNotificationHistoryStore(conn *sql.DB) *SQLNotificationHistoryStore {
 }
 
 var _ notificationhistory.Store = (*SQLNotificationHistoryStore)(nil)
+var _ notificationhistory.Lister = (*SQLNotificationHistoryStore)(nil)
 
 func (s *SQLNotificationHistoryStore) Insert(ctx context.Context, n *notificationhistory.Notification) error {
 	marshalJSONMap := func(m map[string]string) (json.RawMessage, error) {
@@ -54,4 +55,38 @@ func (s *SQLNotificationHistoryStore) Insert(ctx context.Context, n *notificatio
 		Labels:         labels,
 		Annotations:    annotations,
 	})
+}
+
+func (s *SQLNotificationHistoryStore) List(ctx context.Context, organizationID int64, beforeID *int64, limit int32) ([]notificationhistory.StoredNotification, error) {
+	rows, err := s.GetQueries(ctx).ListNotificationHistory(ctx, sqlc.ListNotificationHistoryParams{
+		OrganizationID: sql.NullInt64{Int64: organizationID, Valid: true},
+		BeforeID:       ptrToNullInt64(beforeID),
+		PageLimit:      limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list notification history: %w", err)
+	}
+	out := make([]notificationhistory.StoredNotification, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, notificationhistory.StoredNotification{
+			ID:         row.ID,
+			ReceivedAt: row.ReceivedAt,
+			DeviceName: row.DeviceName,
+			DeviceMAC:  row.DeviceMac,
+			Notification: notificationhistory.Notification{
+				AlertName:      row.AlertName,
+				Status:         row.Status,
+				Severity:       row.Severity,
+				RuleGroup:      row.RuleGroup,
+				Fingerprint:    row.Fingerprint,
+				OrganizationID: nullInt64ToPtr(row.OrganizationID),
+				DeviceID:       row.DeviceID,
+				Template:       row.Template,
+				Summary:        row.Summary,
+				StartsAt:       nullTimeToPtr(row.StartsAt),
+				EndsAt:         nullTimeToPtr(row.EndsAt),
+			},
+		})
+	}
+	return out, nil
 }

--- a/server/internal/handlers/middleware/rpc_permissions.go
+++ b/server/internal/handlers/middleware/rpc_permissions.go
@@ -15,6 +15,7 @@ import (
 	"github.com/block/proto-fleet/server/generated/grpc/foremanimport/v1/foremanimportv1connect"
 	"github.com/block/proto-fleet/server/generated/grpc/minercommand/v1/minercommandv1connect"
 	"github.com/block/proto-fleet/server/generated/grpc/networkinfo/v1/networkinfov1connect"
+	"github.com/block/proto-fleet/server/generated/grpc/notifications/v1/notificationsv1connect"
 	"github.com/block/proto-fleet/server/generated/grpc/onboarding/v1/onboardingv1connect"
 	"github.com/block/proto-fleet/server/generated/grpc/pairing/v1/pairingv1connect"
 	"github.com/block/proto-fleet/server/generated/grpc/pools/v1/poolsv1connect"
@@ -248,6 +249,20 @@ var ProcedurePermissions = map[string]string{
 	// site's network identity and stays on site:manage.
 	networkinfov1connect.NetworkInfoServiceGetNetworkInfoProcedure:        authz.PermFleetRead,
 	networkinfov1connect.NetworkInfoServiceUpdateNetworkNicknameProcedure: authz.PermSiteManage,
+
+	notificationsv1connect.ChannelServiceListChannelsProcedure:                      authz.PermNotificationRead,
+	notificationsv1connect.ChannelServiceCreateChannelProcedure:                     authz.PermNotificationManage,
+	notificationsv1connect.ChannelServiceUpdateChannelProcedure:                     authz.PermNotificationManage,
+	notificationsv1connect.ChannelServiceDeleteChannelProcedure:                     authz.PermNotificationManage,
+	notificationsv1connect.ChannelServiceTestChannelProcedure:                       authz.PermNotificationManage,
+	notificationsv1connect.RuleServiceListRulesProcedure:                            authz.PermNotificationRead,
+	notificationsv1connect.RuleServicePauseRuleProcedure:                            authz.PermNotificationManage,
+	notificationsv1connect.RuleServiceResumeRuleProcedure:                           authz.PermNotificationManage,
+	notificationsv1connect.MaintenanceWindowServiceListMaintenanceWindowsProcedure:  authz.PermNotificationRead,
+	notificationsv1connect.MaintenanceWindowServiceCreateMaintenanceWindowProcedure: authz.PermNotificationManage,
+	notificationsv1connect.MaintenanceWindowServiceUpdateMaintenanceWindowProcedure: authz.PermNotificationManage,
+	notificationsv1connect.MaintenanceWindowServiceDeleteMaintenanceWindowProcedure: authz.PermNotificationManage,
+	notificationsv1connect.HistoryServiceListNotificationsProcedure:                 authz.PermNotificationRead,
 
 	// OnboardingService — fleet-init status. Other onboarding procedures
 	// are unauthenticated (covered by UnauthenticatedProcedures).

--- a/server/migrations/000087_notification_history_keyset_index.down.sql
+++ b/server/migrations/000087_notification_history_keyset_index.down.sql
@@ -1,0 +1,2 @@
+-- CONCURRENTLY must be the sole statement and cannot run in a transaction (golang-migrate runs it directly).
+DROP INDEX CONCURRENTLY IF EXISTS idx_notification_history_org_id;

--- a/server/migrations/000087_notification_history_keyset_index.up.sql
+++ b/server/migrations/000087_notification_history_keyset_index.up.sql
@@ -1,0 +1,3 @@
+-- CONCURRENTLY must be the sole statement and cannot run in a transaction (golang-migrate runs it directly).
+CREATE INDEX CONCURRENTLY idx_notification_history_org_id
+    ON notification_history (organization_id, id DESC);

--- a/server/migrations/000088_seed_notification_permissions.down.sql
+++ b/server/migrations/000088_seed_notification_permissions.down.sql
@@ -1,0 +1,6 @@
+DELETE FROM role_permission
+WHERE permission_id IN (
+    SELECT id FROM permission WHERE key IN ('notification:read', 'notification:manage')
+);
+
+DELETE FROM permission WHERE key IN ('notification:read', 'notification:manage');

--- a/server/migrations/000088_seed_notification_permissions.up.sql
+++ b/server/migrations/000088_seed_notification_permissions.up.sql
@@ -1,0 +1,12 @@
+INSERT INTO permission (key, description) VALUES
+    ('notification:read', 'View notification channels, alert rules, silences, and delivery history.'),
+    ('notification:manage', 'Create, edit, test, and delete notification channels; pause and resume alert rules; create and lift silences.')
+ON CONFLICT (key) DO UPDATE SET description = EXCLUDED.description;
+
+INSERT INTO role_permission (role_id, permission_id)
+SELECT r.id, p.id
+FROM role r, permission p
+WHERE r.builtin_key = 'ADMIN'
+  AND r.deleted_at IS NULL
+  AND p.key IN ('notification:read', 'notification:manage')
+ON CONFLICT (role_id, permission_id) DO NOTHING;

--- a/server/sqlc/queries/notification_history.sql
+++ b/server/sqlc/queries/notification_history.sql
@@ -1,5 +1,4 @@
 -- name: InsertNotificationHistory :exec
--- Persist one notification delivered by the Grafana alertmanager webhook receiver.
 INSERT INTO notification_history (
     alert_name,
     status,
@@ -29,3 +28,37 @@ INSERT INTO notification_history (
     sqlc.arg('labels'),
     sqlc.arg('annotations')
 );
+
+-- name: ListNotificationHistory :many
+SELECT
+    nh.id,
+    nh.received_at,
+    nh.alert_name,
+    nh.status,
+    nh.severity,
+    nh.rule_group,
+    nh.fingerprint,
+    nh.organization_id,
+    nh.device_id,
+    COALESCE(
+        TRIM(COALESCE(
+            NULLIF(d.custom_name, ''),
+            COALESCE(dd.manufacturer, '') || ' ' || COALESCE(dd.model, '')
+        )),
+        ''
+    )::text AS device_name,
+    COALESCE(d.mac_address, '') AS device_mac,
+    nh.template,
+    nh.summary,
+    nh.starts_at,
+    nh.ends_at
+FROM notification_history nh
+LEFT JOIN device d
+    ON d.device_identifier = nh.device_id
+    AND d.org_id = nh.organization_id
+    AND d.deleted_at IS NULL
+LEFT JOIN discovered_device dd ON dd.id = d.discovered_device_id
+WHERE nh.organization_id = sqlc.arg('organization_id')
+  AND (sqlc.narg('before_id')::bigint IS NULL OR nh.id < sqlc.narg('before_id'))
+ORDER BY nh.id DESC
+LIMIT sqlc.arg('page_limit');


### PR DESCRIPTION
## Summary

This PR makes the Notifications surface (channels, alert rules, maintenance windows, delivery history) permission-gated. It introduces a new `notification` authorization resource with two permissions — `notification:read` (view) and `notification:manage` (mutate) — wires every Notifications RPC to the permission it requires, and seeds the permission rows while granting them to existing ADMIN roles. No Notifications handlers are mounted yet (that lands in the next stack PR); this PR establishes the authorization *policy* those handlers will enforce.

It is PR 3 of a 5-PR stack: #452 (proto + generated) → #453 (history-listing DB) → **#454 (this PR, authz)** → #455 (service + handler mounts + wiring) → #456 (client UI).

## How it works

There are two independent paths: the **request-time enforcement policy** (in code) and the **permission data in the database** (rows + role grants).

**Request-time enforcement.** Every authenticated request flows through an auth interceptor that resolves the caller's `EffectivePermissions` (the union of permissions granted by the caller's roles) and stashes it on the request context. A handler gates itself by calling `RequirePermission(key, scope)`, which fails closed: missing context value → `Internal`; no session → `Unauthenticated`; caller lacks the key → `PermissionDenied`. The `ProcedurePermissions` map is the central policy table that says which catalog key each gated procedure needs. This PR adds the Notifications entries to that map: all list/read procedures → `notification:read`; every mutation → `notification:manage`. `TestChannel` is classified as a mutation (`:manage`) because it triggers a real outbound delivery, not just a read.

**Permission data reaching the database.** Two mechanisms populate the `permission` and `role_permission` tables:
1. **Boot reconciler** (`authz.Reconcile`, runs once per server start after migrations): upserts every catalog permission row (refreshing description text), and seeds built-in roles. Crucially, the reconciler seeds ADMIN/FIELD_TECH role grants **only when the role row is first created** — it never re-asserts the seed set onto an already-existing role, so operators' revocations are preserved. That means new catalog keys do NOT auto-propagate onto already-seeded ADMIN roles.
2. **Seed migration** (`000088_seed_notification_permissions`): does the one-time job the reconciler deliberately won't do — backfill the two new permissions onto **existing** ADMIN roles. It also inserts the permission rows itself (`ON CONFLICT` makes this redundant-but-safe alongside the reconciler), scopes the role grant to `builtin_key = 'ADMIN'` so custom roles are untouched, and uses `ON CONFLICT DO NOTHING` so it is replay-safe.

The migration is numbered `000088` so it sorts above the keyset-index migration `000087` from #453 (which merges first), keeping golang-migrate's numeric order aligned with merge order.

## Diagrams

Request authorization flow:

```mermaid
flowchart TD
    client["Client RPC call"] --> interceptor["Auth interceptor"]
    interceptor -->|"resolves caller roles -> EffectivePermissions"| ctx["Request context (stashed permissions)"]
    ctx --> handler["Notifications handler"]
    handler -->|"RequirePermission(key, scope)"| gate{"Caller has key?"}
    policy["ProcedurePermissions map (read -> notification:read, mutations -> notification:manage)"] -.->|"supplies required key"| gate
    gate -->|"yes"| allow["Handler executes (proxies to Grafana)"]
    gate -->|"no"| deny["PermissionDenied"]
    gate -->|"no session"| unauth["Unauthenticated"]
    gate -->|"missing ctx value"| internal["Internal (fail-closed)"]
```

Two ways the permissions reach the database:

```mermaid
flowchart LR
    catalog["catalog.go (in-code permission definitions)"]
    subgraph boot["Every server boot"]
        reconcile["authz.Reconcile"]
    end
    subgraph migrate["One-time migration 000088"]
        seed["seed_notification_permissions.up.sql"]
    end
    permTable[("permission rows")]
    rpTable[("role_permission grants")]

    catalog --> reconcile
    reconcile -->|"upsert all catalog rows"| permTable
    reconcile -->|"seed grants ONLY on first role creation"| rpTable
    seed -->|"insert permission rows (ON CONFLICT safe)"| permTable
    seed -->|"backfill grants onto EXISTING ADMIN roles"| rpTable
```

Lifecycle of a `notification:*` permission on an existing-DB upgrade:

```mermaid
stateDiagram-v2
    [*] --> CatalogDefined: "added to catalog.go"
    CatalogDefined --> RowUpserted: "reconciler upserts permission row on boot"
    RowUpserted --> GrantedToAdmin: "migration 000088 backfills existing ADMIN roles"
    CatalogDefined --> GrantedToAdmin: "migration also inserts rows if reconciler has not run"
    GrantedToAdmin --> [*]: "ADMIN callers now pass RequirePermission"
    note right of RowUpserted
      Reconciler will NOT grant new keys
      onto already-existing roles, hence
      the migration does the backfill.
    end note
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/authz/catalog.go` | New `notification` resource constant; `notification:read` / `notification:manage` permission constants; two `CatalogEntry` rows. | Source of truth for the permission catalog. Confirm the resource is placed in declaration order (the order is contract-tested) and the descriptions match the migration text. |
| `server/internal/handlers/middleware/rpc_permissions.go` | Imports `notificationsv1connect`; adds 13 `ProcedurePermissions` entries (Channel/Rule/MaintenanceWindow/History services) mapping reads → `:read`, mutations → `:manage`. | The actual enforcement policy. Verify each mutation is `:manage`, each read is `:read`, and that `TestChannel` is `:manage` (outbound delivery). |
| `server/migrations/000088_seed_notification_permissions.up.sql` | **New.** Inserts the two permission rows (`ON CONFLICT` upsert) and backfills them onto existing `ADMIN` roles (`ON CONFLICT DO NOTHING`). | The one-time grant onto existing ADMIN roles. Verify scoping to `builtin_key = 'ADMIN'`, `deleted_at IS NULL`, and replay-safety. |
| `server/migrations/000088_seed_notification_permissions.down.sql` | **New.** Deletes the role grants then the permission rows. | Dev-only rollback. Confirm ordering (grants before rows, FK safety). |
| `server/internal/domain/authz/catalog_test.go` | Adds the two new permissions and the `notification` resource to the completeness / grouping / ordering contract fixtures. | Generated/derived expectations — quick check that fixtures match catalog.go, not deep review. |

No DB table for permissions-on-channels exists or is added: channels, rules, and maintenance windows live in Grafana, not in this database.

## Key technical decisions & trade-offs

- **`TestChannel` gated on `:manage`, not `:read`** — chosen because it triggers an outbound delivery (a side-effecting action), over treating "test" as a read-only diagnostic.
- **Migration backfills existing ADMIN roles, even though the reconciler upserts rows** — chosen because the reconciler is intentionally additive only on first role creation and won't grant new keys to already-seeded roles; without the migration, existing orgs' admins would silently lack the new permissions.
- **Permission rows inserted in BOTH the reconciler and the migration** — chosen (with `ON CONFLICT`) over relying solely on the reconciler, so the migration is self-contained and the grant step has its FK target present regardless of boot ordering.
- **Numbered `000088` (above #453's `000087`)** — chosen to keep golang-migrate numeric order aligned with stack merge order, over a lower number that an already-upgraded DB would skip.
- **Grant scoped to `builtin_key = 'ADMIN'` with `DO NOTHING`** — chosen over a broad grant so custom/operator-tuned roles are untouched and re-runs are idempotent.
- **Notifications services intentionally absent from the `registeredServices` RPC-contract fixture** — those entries land in #455 alongside the real `main.go` handler mounts, because the contract test compares `registeredServices` against the live mux; the procedure→permission *policy* stays here.

## Testing & validation

- **Catalog contract tests** (`catalog_test.go`): assert the new permissions and resource appear in the completeness set, are grouped under `notification`, and respect declaration order.
- **RPC contract tests** (`rpc_permissions_test.go`): every key referenced by `ProcedurePermissions` must exist in the catalog, and every registered procedure must be classified in exactly one bucket.
- **Reconciler backfill tests** (`backfill_test.go`) exercise the additive-on-first-creation policy that motivates the migration.

Explicitly NOT covered here:
- **End-to-end handler enforcement** — no Notifications handlers are mounted in `main.go` yet (that is #455), so there is no integration test exercising a real gated Notifications request in this PR.
- **Migration apply/rollback against a live DB** — relies on the standard migration harness; the `down` migration is dev-only and assumes no custom-role hand-grants.
- **Per-scope authorization** — these permissions are org-level; no site/resource-scoped checks are introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
