### PR TITLE
notifications (5/5): notifications UI

### DIFF
--- a/client/src/protoFleet/api/clients.ts
+++ b/client/src/protoFleet/api/clients.ts
@@ -12,6 +12,12 @@ import { FleetManagementService } from "@/protoFleet/api/generated/fleetmanageme
 import { ForemanImportService } from "@/protoFleet/api/generated/foremanimport/v1/foremanimport_pb";
 import { MinerCommandService } from "@/protoFleet/api/generated/minercommand/v1/command_pb";
 import { NetworkInfoService } from "@/protoFleet/api/generated/networkinfo/v1/networkinfo_pb";
+import {
+  ChannelService as NotificationChannelService,
+  HistoryService as NotificationHistoryService,
+  MaintenanceWindowService as NotificationMaintenanceWindowService,
+  RuleService as NotificationRuleService,
+} from "@/protoFleet/api/generated/notifications/v1/notifications_pb";
 import { OnboardingService } from "@/protoFleet/api/generated/onboarding/v1/onboarding_pb";
 import { PairingService } from "@/protoFleet/api/generated/pairing/v1/pairing_pb";
 import { PoolsService } from "@/protoFleet/api/generated/pools/v1/pools_pb";
@@ -39,8 +45,16 @@ const telemetryClient = createClient(TelemetryService, transport);
 const foremanImportClient = createClient(ForemanImportService, transport);
 const sitesClient = createClient(SiteService, transport);
 const buildingsClient = createClient(BuildingService, transport);
+const notificationChannelClient = createClient(NotificationChannelService, transport);
+const notificationRuleClient = createClient(NotificationRuleService, transport);
+const notificationMaintenanceWindowClient = createClient(NotificationMaintenanceWindowService, transport);
+const notificationHistoryClient = createClient(NotificationHistoryService, transport);
 
 export {
+  notificationChannelClient,
+  notificationRuleClient,
+  notificationMaintenanceWindowClient,
+  notificationHistoryClient,
   activityClient,
   apiKeyClient,
   authClient,

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -123,6 +123,12 @@ export const secondaryNavItems: SecondaryNavItem[] = [
     requiredPermission: "apikey:manage",
   },
   {
+    path: "/settings/notifications",
+    label: "Notifications",
+    parent: "/settings",
+    requiredPermission: "notification:read",
+  },
+  {
     path: "/settings/server-logs",
     label: "Server Logs",
     parent: "/settings",

--- a/client/src/protoFleet/features/dashboard/pages/Dashboard.tsx
+++ b/client/src/protoFleet/features/dashboard/pages/Dashboard.tsx
@@ -13,9 +13,10 @@ import SectionHeading from "@/protoFleet/features/dashboard/components/SectionHe
 import { TemperaturePanel } from "@/protoFleet/features/dashboard/components/TemperaturePanel";
 import { UptimePanel } from "@/protoFleet/features/dashboard/components/UptimePanel";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
+import ActiveNotificationsCard from "@/protoFleet/features/notifications/components/ActiveNotificationsCard";
 import { MinersPage } from "@/protoFleet/features/onboarding";
 import { CompleteSetup } from "@/protoFleet/features/onboarding/components/CompleteSetup";
-import { useDuration, useSetDuration } from "@/protoFleet/store";
+import { useDuration, useHasPermission, useSetDuration } from "@/protoFleet/store";
 import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import { useStickyState } from "@/shared/hooks/useStickyState";
@@ -35,6 +36,7 @@ const Dashboard = () => {
   const { devicePaired, statusLoaded } = useOnboardedStatus();
   const duration = useDuration();
   const setDuration = useSetDuration();
+  const canViewNotifications = useHasPermission("notification:read");
   const currentYear = new Date().getFullYear();
   const { refs } = useStickyState();
 
@@ -108,6 +110,7 @@ const Dashboard = () => {
                 hashboardErrors={hashboardErrors}
                 psuErrors={psuErrors}
               />
+              {canViewNotifications ? <ActiveNotificationsCard /> : null}
             </div>
           </section>
 

--- a/client/src/protoFleet/features/notifications/api/notificationsApi.ts
+++ b/client/src/protoFleet/features/notifications/api/notificationsApi.ts
@@ -1,0 +1,329 @@
+import { type Timestamp, timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import {
+  notificationChannelClient,
+  notificationHistoryClient,
+  notificationMaintenanceWindowClient,
+  notificationRuleClient,
+} from "@/protoFleet/api/clients";
+import {
+  type Channel as ProtoChannel,
+  ChannelKind as ProtoChannelKind,
+  type NotificationHistoryEntry as ProtoHistoryEntry,
+  type MaintenanceWindow as ProtoMaintenanceWindow,
+  MaintenanceWindowScopeKind as ProtoMaintenanceWindowScopeKind,
+  type Rule as ProtoRule,
+  RuleTemplate as ProtoRuleTemplate,
+  ValidationState as ProtoValidationState,
+} from "@/protoFleet/api/generated/notifications/v1/notifications_pb";
+import type {
+  Channel,
+  ChannelKind,
+  MaintenanceWindow,
+  MaintenanceWindowScope,
+  MaintenanceWindowScopeKind,
+  NotificationHistoryEntry,
+  NotificationHistoryStatus,
+  Rule,
+  RuleTemplate,
+  SlackConfig,
+  SmtpConfig,
+  ValidationState,
+  WebhookConfig,
+} from "@/protoFleet/features/notifications/types";
+
+const isoFromTs = (ts?: Timestamp): string => (ts ? timestampDate(ts).toISOString() : "");
+const isoOrNull = (ts?: Timestamp): string | null => (ts ? timestampDate(ts).toISOString() : null);
+const tsFromIso = (iso: string): Timestamp => timestampFromDate(new Date(iso));
+
+function required<T>(value: T | undefined, name: string): T {
+  if (value == null) {
+    throw new Error(`notifications: response missing ${name}`);
+  }
+  return value;
+}
+
+const channelKindToProto = (k: ChannelKind): ProtoChannelKind => {
+  switch (k) {
+    case "webhook":
+      return ProtoChannelKind.WEBHOOK;
+    case "smtp":
+      return ProtoChannelKind.SMTP;
+    case "slack":
+      return ProtoChannelKind.SLACK;
+  }
+};
+
+const channelKindFromProto = (k: ProtoChannelKind): ChannelKind => {
+  switch (k) {
+    case ProtoChannelKind.SMTP:
+      return "smtp";
+    case ProtoChannelKind.SLACK:
+      return "slack";
+    default:
+      return "webhook";
+  }
+};
+
+const validationStateFromProto = (s: ProtoValidationState): ValidationState => {
+  switch (s) {
+    case ProtoValidationState.OK:
+      return "ok";
+    case ProtoValidationState.FAILED:
+      return "failed";
+    default:
+      return "pending";
+  }
+};
+
+const ruleTemplateFromProto = (t: ProtoRuleTemplate): RuleTemplate => {
+  switch (t) {
+    case ProtoRuleTemplate.OFFLINE:
+      return "offline";
+    case ProtoRuleTemplate.HASHRATE:
+      return "hashrate";
+    case ProtoRuleTemplate.TEMPERATURE:
+      return "temperature";
+    case ProtoRuleTemplate.POOL:
+      return "pool";
+    case ProtoRuleTemplate.COMMAND_FAILURE:
+      return "command_failure";
+    case ProtoRuleTemplate.TELEMETRY_POLL:
+      return "telemetry-poll";
+    default:
+      return "";
+  }
+};
+
+const scopeKindToProto = (k: MaintenanceWindowScopeKind): ProtoMaintenanceWindowScopeKind => {
+  switch (k) {
+    case "rule":
+      return ProtoMaintenanceWindowScopeKind.RULE;
+    case "group":
+      return ProtoMaintenanceWindowScopeKind.GROUP;
+    case "site":
+      return ProtoMaintenanceWindowScopeKind.SITE;
+    case "device":
+      return ProtoMaintenanceWindowScopeKind.DEVICE;
+  }
+};
+
+const scopeKindFromProto = (k: ProtoMaintenanceWindowScopeKind): MaintenanceWindowScopeKind => {
+  switch (k) {
+    case ProtoMaintenanceWindowScopeKind.GROUP:
+      return "group";
+    case ProtoMaintenanceWindowScopeKind.SITE:
+      return "site";
+    case ProtoMaintenanceWindowScopeKind.DEVICE:
+      return "device";
+    default:
+      return "rule";
+  }
+};
+
+const channelFromProto = (c: ProtoChannel): Channel => ({
+  id: c.id,
+  organization_id: String(c.organizationId),
+  name: c.name,
+  kind: channelKindFromProto(c.kind),
+  webhook: c.webhook ? { url: c.webhook.url, bearer_header: null } : null,
+  smtp: c.smtp
+    ? { host: c.smtp.host, port: c.smtp.port, username: c.smtp.username, from: c.smtp.from, to: c.smtp.to }
+    : null,
+  slack: c.slack ? {} : null,
+  created_at: isoFromTs(c.createdAt),
+  updated_at: isoFromTs(c.updatedAt),
+  validated_at: isoOrNull(c.validatedAt),
+  validation_state: validationStateFromProto(c.validationState),
+  validation_error: c.validationError,
+  has_secret: c.hasSecret,
+});
+
+const ruleFromProto = (r: ProtoRule): Rule => ({
+  id: r.id,
+  organization_id: String(r.organizationId),
+  name: r.name,
+  template: ruleTemplateFromProto(r.template),
+  group: r.group,
+  severity: r.severity,
+  summary: r.summary,
+  description: r.description,
+  duration_seconds: r.durationSeconds,
+  enabled: r.enabled,
+});
+
+const maintenanceWindowFromProto = (s: ProtoMaintenanceWindow): MaintenanceWindow => ({
+  id: s.id,
+  organization_id: String(s.organizationId),
+  scope: {
+    kind: s.scope ? scopeKindFromProto(s.scope.kind) : "rule",
+    rule_id: s.scope?.ruleId || null,
+    group_id: s.scope?.groupId || null,
+    site_id: s.scope?.siteId || null,
+    device_ids: s.scope?.deviceIds ?? [],
+  },
+  starts_at: isoFromTs(s.startsAt),
+  ends_at: isoOrNull(s.endsAt),
+  comment: s.comment,
+  created_by: s.createdBy,
+  created_at: isoFromTs(s.createdAt),
+});
+
+const historyFromProto = (n: ProtoHistoryEntry): NotificationHistoryEntry => ({
+  id: n.id,
+  received_at: isoFromTs(n.receivedAt),
+  alert_name: n.alertName,
+  status: n.status as NotificationHistoryStatus,
+  severity: n.severity,
+  rule_group: n.ruleGroup,
+  fingerprint: n.fingerprint,
+  device_id: n.deviceId,
+  device_name: n.deviceName,
+  device_mac: n.deviceMac,
+  template: n.template,
+  summary: n.summary,
+  starts_at: isoOrNull(n.startsAt),
+  ends_at: isoOrNull(n.endsAt),
+});
+
+const webhookToProto = (w?: WebhookConfig | null) =>
+  w ? { url: w.url, bearerHeader: w.bearer_header ?? "" } : undefined;
+
+const smtpToProto = (s?: SmtpConfig | null) =>
+  s
+    ? { host: s.host, port: s.port, username: s.username, from: s.from, to: s.to, password: s.password ?? "" }
+    : undefined;
+
+const slackToProto = (s?: SlackConfig | null) => (s ? { webhookUrl: s.webhook_url ?? "" } : undefined);
+
+const scopeToProto = (s: MaintenanceWindowScope) => ({
+  kind: scopeKindToProto(s.kind),
+  ruleId: s.rule_id ?? "",
+  groupId: s.group_id ?? "",
+  siteId: s.site_id ?? "",
+  deviceIds: s.device_ids,
+});
+
+const channelDestinationFields = (input: ChannelMutationInput) => ({
+  kind: channelKindToProto(input.kind),
+  webhook: webhookToProto(input.webhook),
+  smtp: smtpToProto(input.smtp),
+  slack: slackToProto(input.slack),
+});
+
+export async function listChannels(): Promise<Channel[]> {
+  const res = await notificationChannelClient.listChannels({});
+  return res.channels.map(channelFromProto);
+}
+
+export interface ChannelMutationInput {
+  id?: string;
+  name: string;
+  kind: ChannelKind;
+  webhook?: WebhookConfig | null;
+  smtp?: SmtpConfig | null;
+  slack?: SlackConfig | null;
+}
+
+export async function createChannel(input: ChannelMutationInput): Promise<Channel> {
+  const res = await notificationChannelClient.createChannel({
+    name: input.name,
+    ...channelDestinationFields(input),
+  });
+  return channelFromProto(required(res.channel, "channel"));
+}
+
+export async function updateChannel(input: ChannelMutationInput & { id: string }): Promise<Channel> {
+  const res = await notificationChannelClient.updateChannel({
+    id: input.id,
+    name: input.name,
+    ...channelDestinationFields(input),
+  });
+  return channelFromProto(required(res.channel, "channel"));
+}
+
+export async function deleteChannel(id: string): Promise<void> {
+  await notificationChannelClient.deleteChannel({ id });
+}
+
+export interface TestChannelResult {
+  ok: boolean;
+  error: string;
+  response_code: number;
+}
+
+export async function testChannel(input: ChannelMutationInput): Promise<TestChannelResult> {
+  const res = await notificationChannelClient.testChannel({
+    id: input.id ?? "",
+    ...channelDestinationFields(input),
+  });
+  return { ok: res.ok, error: res.error, response_code: res.responseCode };
+}
+
+export async function listRules(): Promise<Rule[]> {
+  const res = await notificationRuleClient.listRules({});
+  return res.rules.map(ruleFromProto);
+}
+
+export async function pauseRule(id: string): Promise<Rule> {
+  const res = await notificationRuleClient.pauseRule({ id });
+  return ruleFromProto(required(res.rule, "rule"));
+}
+
+export async function resumeRule(id: string): Promise<Rule> {
+  const res = await notificationRuleClient.resumeRule({ id });
+  return ruleFromProto(required(res.rule, "rule"));
+}
+
+export async function listMaintenanceWindows(): Promise<MaintenanceWindow[]> {
+  const res = await notificationMaintenanceWindowClient.listMaintenanceWindows({});
+  return res.maintenanceWindows.map(maintenanceWindowFromProto);
+}
+
+export interface MaintenanceWindowMutationInput {
+  id?: string;
+  scope: MaintenanceWindowScope;
+  starts_at: string;
+  ends_at: string | null;
+  comment: string;
+}
+
+export async function createMaintenanceWindow(input: MaintenanceWindowMutationInput): Promise<MaintenanceWindow> {
+  const res = await notificationMaintenanceWindowClient.createMaintenanceWindow({
+    scope: scopeToProto(input.scope),
+    startsAt: tsFromIso(input.starts_at),
+    endsAt: input.ends_at ? tsFromIso(input.ends_at) : undefined,
+    comment: input.comment,
+  });
+  return maintenanceWindowFromProto(required(res.maintenanceWindow, "maintenanceWindow"));
+}
+
+export async function updateMaintenanceWindow(
+  input: MaintenanceWindowMutationInput & { id: string },
+): Promise<MaintenanceWindow> {
+  const res = await notificationMaintenanceWindowClient.updateMaintenanceWindow({
+    id: input.id,
+    scope: scopeToProto(input.scope),
+    startsAt: tsFromIso(input.starts_at),
+    endsAt: input.ends_at ? tsFromIso(input.ends_at) : undefined,
+    comment: input.comment,
+  });
+  return maintenanceWindowFromProto(required(res.maintenanceWindow, "maintenanceWindow"));
+}
+
+export async function deleteMaintenanceWindow(id: string): Promise<void> {
+  await notificationMaintenanceWindowClient.deleteMaintenanceWindow({ id });
+}
+
+export interface HistoryPage {
+  notifications: NotificationHistoryEntry[];
+  has_more: boolean;
+}
+
+export async function listHistory(input: { before_id?: string; page_size?: number }): Promise<HistoryPage> {
+  const res = await notificationHistoryClient.listNotifications({
+    beforeId: input.before_id ?? "",
+    pageSize: input.page_size ?? 0,
+  });
+  return { notifications: res.notifications.map(historyFromProto), has_more: res.hasMore };
+}

--- a/client/src/protoFleet/features/notifications/components/ActiveNotificationsCard.tsx
+++ b/client/src/protoFleet/features/notifications/components/ActiveNotificationsCard.tsx
@@ -1,0 +1,13 @@
+import HistoryTable from "./HistoryTable";
+
+const ActiveNotificationsCard = () => (
+  <section className="flex flex-col gap-4 rounded-xl bg-surface-base p-6 dark:bg-core-primary-5">
+    <h3 className="text-heading-200">Active notifications</h3>
+    <HistoryTable
+      activeOnly
+      noDataElement={<div className="py-6 text-center text-text-primary-50">No active notifications.</div>}
+    />
+  </section>
+);
+
+export default ActiveNotificationsCard;

--- a/client/src/protoFleet/features/notifications/components/AddChannelModal.tsx
+++ b/client/src/protoFleet/features/notifications/components/AddChannelModal.tsx
@@ -1,0 +1,339 @@
+import { useCallback, useState } from "react";
+import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
+import { testChannel as testChannelApi } from "@/protoFleet/features/notifications/api/notificationsApi";
+import { useNotificationsStore } from "@/protoFleet/features/notifications/store/notificationsStore";
+import type {
+  Channel,
+  ChannelKind,
+  SlackConfig,
+  SmtpConfig,
+  WebhookConfig,
+} from "@/protoFleet/features/notifications/types";
+import { Alert } from "@/shared/assets/icons";
+import { variants } from "@/shared/components/Button";
+import Callout from "@/shared/components/Callout";
+import Input from "@/shared/components/Input";
+import Modal from "@/shared/components/Modal";
+import SegmentedControl from "@/shared/components/SegmentedControl";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+interface AddChannelModalProps {
+  open: boolean;
+  onDismiss: () => void;
+}
+
+const AddChannelModal = ({ open, onDismiss }: AddChannelModalProps) => {
+  const createChannel = useNotificationsStore((s) => s.createChannel);
+
+  const [kind, setKind] = useState<ChannelKind>("webhook");
+  const [name, setName] = useState("");
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [bearerHeader, setBearerHeader] = useState("");
+  const [slackWebhookUrl, setSlackWebhookUrl] = useState("");
+  const [smtpHost, setSmtpHost] = useState("");
+  const [smtpPort, setSmtpPort] = useState("");
+  const [smtpUsername, setSmtpUsername] = useState("");
+  const [smtpFrom, setSmtpFrom] = useState("");
+  const [smtpTo, setSmtpTo] = useState("");
+  const [smtpPassword, setSmtpPassword] = useState("");
+
+  const [errorMsg, setErrorMsg] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    if (!open) {
+      setKind("webhook");
+      setName("");
+      setWebhookUrl("");
+      setBearerHeader("");
+      setSlackWebhookUrl("");
+      setSmtpHost("");
+      setSmtpPort("");
+      setSmtpUsername("");
+      setSmtpFrom("");
+      setSmtpTo("");
+      setSmtpPassword("");
+      setErrorMsg("");
+      setSaving(false);
+    }
+  }
+
+  const clearError = () => setErrorMsg("");
+
+  const buildPayload = useCallback((): {
+    name: string;
+    kind: ChannelKind;
+    webhook: WebhookConfig | null;
+    smtp: SmtpConfig | null;
+    slack: SlackConfig | null;
+  } | null => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setErrorMsg("Add a name for this channel");
+      return null;
+    }
+    let webhook: WebhookConfig | null = null;
+    let smtp: SmtpConfig | null = null;
+    let slack: SlackConfig | null = null;
+    if (kind === "webhook") {
+      const url = webhookUrl.trim();
+      if (!url) {
+        setErrorMsg("Add a webhook URL");
+        return null;
+      }
+      webhook = { url, bearer_header: bearerHeader.trim() || null };
+    } else if (kind === "slack") {
+      const url = slackWebhookUrl.trim();
+      if (!url) {
+        setErrorMsg("Add a Slack webhook URL");
+        return null;
+      }
+      slack = { webhook_url: url };
+    } else {
+      const host = smtpHost.trim();
+      const port = parseInt(smtpPort, 10) || 587;
+      const to = smtpTo
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (!host || to.length === 0) {
+        setErrorMsg("Need a host and at least one To address");
+        return null;
+      }
+      smtp = {
+        host,
+        port,
+        username: smtpUsername.trim(),
+        from: smtpFrom.trim(),
+        to,
+        password: smtpPassword || undefined,
+      };
+    }
+    return { name: trimmedName, kind, webhook, smtp, slack };
+  }, [
+    name,
+    kind,
+    webhookUrl,
+    bearerHeader,
+    slackWebhookUrl,
+    smtpHost,
+    smtpPort,
+    smtpUsername,
+    smtpFrom,
+    smtpTo,
+    smtpPassword,
+  ]);
+
+  const handleSendTest = useCallback(async () => {
+    const payload = buildPayload();
+    if (!payload) return;
+    try {
+      const result = await testChannelApi(payload);
+      if (result.ok) {
+        pushToast({
+          message: `Test delivered (HTTP ${result.response_code})`,
+          status: STATUSES.success,
+        });
+      } else {
+        pushToast({
+          message: `Test failed (HTTP ${result.response_code}): ${result.error || "no detail"}`,
+          status: STATUSES.error,
+        });
+      }
+    } catch (error) {
+      pushToast({
+        message: getErrorMessage(error, "Test delivery failed"),
+        status: STATUSES.error,
+      });
+    }
+  }, [buildPayload]);
+
+  const handleSave = useCallback(async () => {
+    const payload = buildPayload();
+    if (!payload) return;
+    setSaving(true);
+    try {
+      const created: Channel = await createChannel(payload);
+      pushToast({ message: `Saved: ${created.name}`, status: STATUSES.success });
+      onDismiss();
+    } catch (error) {
+      pushToast({
+        message: getErrorMessage(error, "Failed to save channel"),
+        status: STATUSES.error,
+      });
+      setSaving(false);
+    }
+  }, [buildPayload, createChannel, onDismiss]);
+
+  const canTest =
+    kind === "webhook"
+      ? webhookUrl.trim().length > 0
+      : kind === "slack"
+        ? slackWebhookUrl.trim().length > 0
+        : smtpTo.trim().length > 0;
+
+  return (
+    <Modal
+      open={open}
+      onDismiss={onDismiss}
+      title="Add channel"
+      description="Pick a destination. Test the channel before saving so you don't ship a dead receiver into the live config."
+      buttons={[
+        ...(canTest
+          ? [
+              {
+                text: "Send test",
+                onClick: () => {
+                  void handleSendTest();
+                },
+                variant: variants.secondary,
+                dismissModalOnClick: false,
+                className: "animate-[fade-in_.3s_ease-in-out]",
+              },
+            ]
+          : []),
+        {
+          text: saving ? "Saving…" : "Save channel",
+          onClick: () => {
+            void handleSave();
+          },
+          variant: variants.primary,
+          dismissModalOnClick: false,
+          disabled: saving,
+        },
+      ]}
+      divider={false}
+    >
+      {errorMsg ? <Callout className="mb-6" intent="danger" prefixIcon={<Alert />} title={errorMsg} /> : null}
+
+      <div className="flex flex-col gap-4">
+        <SegmentedControl
+          segments={[
+            { key: "webhook", title: "Webhook" },
+            { key: "slack", title: "Slack" },
+            { key: "smtp", title: "SMTP (email)" },
+          ]}
+          initialSegmentKey={kind}
+          onSelect={(key) => {
+            setKind(key as ChannelKind);
+            clearError();
+          }}
+        />
+
+        <Input
+          id="channel-name"
+          label="Name"
+          initValue={name}
+          onChange={(value) => {
+            setName(value);
+            clearError();
+          }}
+          autoFocus
+        />
+
+        {kind === "webhook" ? (
+          <>
+            <Input
+              id="channel-webhook-url"
+              label="URL"
+              initValue={webhookUrl}
+              onChange={(value) => {
+                setWebhookUrl(value);
+                clearError();
+              }}
+            />
+            <Input
+              id="channel-webhook-bearer"
+              label="Bearer header (optional)"
+              type="password"
+              initValue={bearerHeader}
+              onChange={(value) => {
+                setBearerHeader(value);
+                clearError();
+              }}
+            />
+          </>
+        ) : kind === "slack" ? (
+          <Input
+            id="channel-slack-webhook-url"
+            label="Slack webhook URL"
+            type="password"
+            initValue={slackWebhookUrl}
+            onChange={(value) => {
+              setSlackWebhookUrl(value);
+              clearError();
+            }}
+          />
+        ) : (
+          <>
+            <div className="grid grid-cols-[1fr_120px] gap-4">
+              <Input
+                id="channel-smtp-host"
+                label="Host"
+                initValue={smtpHost}
+                onChange={(value) => {
+                  setSmtpHost(value);
+                  clearError();
+                }}
+              />
+              <Input
+                id="channel-smtp-port"
+                label="Port"
+                initValue={smtpPort}
+                onChange={(value) => {
+                  setSmtpPort(value);
+                  clearError();
+                }}
+              />
+            </div>
+            <Input
+              id="channel-smtp-username"
+              label="Username"
+              initValue={smtpUsername}
+              onChange={(value) => {
+                setSmtpUsername(value);
+                clearError();
+              }}
+            />
+            <Input
+              id="channel-smtp-password"
+              label="Password (optional)"
+              type="password"
+              initValue={smtpPassword}
+              onChange={(value) => {
+                setSmtpPassword(value);
+                clearError();
+              }}
+            />
+            <Input
+              id="channel-smtp-from"
+              label="From"
+              initValue={smtpFrom}
+              onChange={(value) => {
+                setSmtpFrom(value);
+                clearError();
+              }}
+            />
+            <Input
+              id="channel-smtp-to"
+              label="To (comma-separated)"
+              initValue={smtpTo}
+              onChange={(value) => {
+                setSmtpTo(value);
+                clearError();
+              }}
+            />
+          </>
+        )}
+
+        <p className="pt-2 text-200 text-text-primary-50">
+          Verify the destination before saving — Alertmanager doesn't let you test in place.
+        </p>
+      </div>
+    </Modal>
+  );
+};
+
+export default AddChannelModal;

--- a/client/src/protoFleet/features/notifications/components/AddMaintenanceWindowModal.tsx
+++ b/client/src/protoFleet/features/notifications/components/AddMaintenanceWindowModal.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useMemo, useState } from "react";
+import SinglePickerField from "./SinglePickerField";
+import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
+import {
+  MAINTENANCE_WINDOW_QUICK_OPTIONS,
+  MAINTENANCE_WINDOW_SCOPE_OPTIONS,
+  toLocalDatetimeValue,
+} from "@/protoFleet/features/notifications/lib/maintenanceWindowOptions";
+import { useNotificationsStore } from "@/protoFleet/features/notifications/store/notificationsStore";
+import type {
+  MaintenanceWindowScope,
+  MaintenanceWindowScopeKind,
+  MaintenanceWindowWithActive,
+} from "@/protoFleet/features/notifications/types";
+import { Alert } from "@/shared/assets/icons";
+import { variants } from "@/shared/components/Button";
+import Callout from "@/shared/components/Callout";
+import Input from "@/shared/components/Input";
+import Modal from "@/shared/components/Modal";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+interface AddMaintenanceWindowModalProps {
+  open: boolean;
+  editingMaintenanceWindow: MaintenanceWindowWithActive | null;
+  prefillRuleId?: string | null;
+  onDismiss: () => void;
+}
+
+const DEFAULT_QUICK = "4h";
+
+const computeEndsFromQuick = (quick: string): Date => {
+  const meta = MAINTENANCE_WINDOW_QUICK_OPTIONS.find((q) => q.id === quick);
+  const hours = meta?.hours ?? 4;
+  return new Date(Date.now() + hours * 3600 * 1000);
+};
+
+const AddMaintenanceWindowModal = ({
+  open,
+  editingMaintenanceWindow,
+  prefillRuleId,
+  onDismiss,
+}: AddMaintenanceWindowModalProps) => {
+  const rules = useNotificationsStore((s) => s.rules);
+  const createMaintenanceWindow = useNotificationsStore((s) => s.createMaintenanceWindow);
+  const updateMaintenanceWindow = useNotificationsStore((s) => s.updateMaintenanceWindow);
+
+  const isEditing = editingMaintenanceWindow != null;
+
+  const [scope, setScope] = useState<MaintenanceWindowScopeKind>("rule");
+  const [ruleId, setRuleId] = useState<string | null>(null);
+  const [quick, setQuick] = useState<string | null>(DEFAULT_QUICK);
+  const [starts, setStarts] = useState("");
+  const [ends, setEnds] = useState("");
+  const [comment, setComment] = useState("");
+  const [errorMsg, setErrorMsg] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const [syncedFor, setSyncedFor] = useState<string | null>(null);
+  const syncKey = open ? (editingMaintenanceWindow?.id ?? `__add__${prefillRuleId ?? ""}`) : null;
+  if (syncedFor !== syncKey) {
+    setSyncedFor(syncKey);
+    if (open) {
+      if (editingMaintenanceWindow) {
+        setScope(editingMaintenanceWindow.scope.kind);
+        setRuleId(editingMaintenanceWindow.scope.rule_id);
+        setQuick(null);
+        setStarts(toLocalDatetimeValue(new Date(editingMaintenanceWindow.starts_at)));
+        setEnds(
+          editingMaintenanceWindow.ends_at ? toLocalDatetimeValue(new Date(editingMaintenanceWindow.ends_at)) : "",
+        );
+        setComment(editingMaintenanceWindow.comment);
+        setErrorMsg("");
+      } else {
+        const now = new Date();
+        const end = computeEndsFromQuick(DEFAULT_QUICK);
+        setScope("rule");
+        setRuleId(prefillRuleId ?? rules[0]?.id ?? null);
+        setQuick(DEFAULT_QUICK);
+        setStarts(toLocalDatetimeValue(now));
+        setEnds(toLocalDatetimeValue(end));
+        setComment("");
+        setErrorMsg("");
+      }
+      setSaving(false);
+    }
+  }
+
+  const clearError = () => setErrorMsg("");
+
+  const ruleOptions = useMemo(() => rules.map((r) => ({ id: r.id, label: r.name })), [rules]);
+
+  const handleQuickChange = useCallback((next: string) => {
+    setQuick(next);
+    const now = new Date();
+    const end = computeEndsFromQuick(next);
+    setStarts(toLocalDatetimeValue(now));
+    setEnds(toLocalDatetimeValue(end));
+    clearError();
+  }, []);
+
+  // Hand-editing a datetime drops the quick-window preset to "Custom".
+  const handleStartsChange = (value: string) => {
+    setStarts(value);
+    setQuick(null);
+    clearError();
+  };
+  const handleEndsChange = (value: string) => {
+    setEnds(value);
+    setQuick(null);
+    clearError();
+  };
+
+  const handleSave = useCallback(async () => {
+    if (!starts || !ends) {
+      setErrorMsg("Pick a start and end time");
+      return;
+    }
+    if (new Date(ends) <= new Date(starts)) {
+      setErrorMsg("End must be after start");
+      return;
+    }
+    if (scope === "rule" && !ruleId) {
+      setErrorMsg("Pick a rule");
+      return;
+    }
+
+    // Non-rule scopes have no editor here; preserve the stored target so the server's scope validation passes.
+    const scopePayload: MaintenanceWindowScope =
+      isEditing && editingMaintenanceWindow && editingMaintenanceWindow.scope.kind !== "rule"
+        ? editingMaintenanceWindow.scope
+        : {
+            kind: scope,
+            rule_id: scope === "rule" ? ruleId : null,
+            group_id: null,
+            site_id: null,
+            device_ids: [],
+          };
+
+    const payload = {
+      scope: scopePayload,
+      starts_at: new Date(starts).toISOString(),
+      ends_at: new Date(ends).toISOString(),
+      comment: comment.trim(),
+    };
+
+    setSaving(true);
+    try {
+      if (isEditing && editingMaintenanceWindow) {
+        await updateMaintenanceWindow({ id: editingMaintenanceWindow.id, ...payload });
+        pushToast({ message: "Maintenance window updated", status: STATUSES.success });
+      } else {
+        await createMaintenanceWindow(payload);
+        pushToast({ message: "Maintenance window saved", status: STATUSES.success });
+      }
+      onDismiss();
+    } catch (error) {
+      pushToast({
+        message: getErrorMessage(error, "Failed to save maintenance window"),
+        status: STATUSES.error,
+      });
+      setSaving(false);
+    }
+  }, [
+    starts,
+    ends,
+    scope,
+    ruleId,
+    comment,
+    isEditing,
+    editingMaintenanceWindow,
+    createMaintenanceWindow,
+    updateMaintenanceWindow,
+    onDismiss,
+  ]);
+
+  return (
+    <Modal
+      open={open}
+      onDismiss={onDismiss}
+      title={isEditing ? "Edit maintenance window" : "Add maintenance window"}
+      description="Mute alerts during planned work. Suppressed events still record to the activity log so you can audit what would have fired."
+      buttons={[
+        {
+          text: saving ? "Saving…" : "Save maintenance window",
+          onClick: () => {
+            void handleSave();
+          },
+          variant: variants.primary,
+          dismissModalOnClick: false,
+          disabled: saving,
+        },
+      ]}
+      divider={false}
+    >
+      {errorMsg ? <Callout className="mb-6" intent="danger" prefixIcon={<Alert />} title={errorMsg} /> : null}
+
+      <div className="flex flex-col gap-4">
+        <div className="grid grid-cols-2 gap-4">
+          <SinglePickerField
+            id="maintenance-window-scope"
+            label="Maintenance window"
+            options={MAINTENANCE_WINDOW_SCOPE_OPTIONS}
+            value={scope}
+            onChange={(value) => {
+              setScope(value as MaintenanceWindowScopeKind);
+              clearError();
+            }}
+          />
+          {scope === "rule" ? (
+            <SinglePickerField
+              id="maintenance-window-rule"
+              label="Rule"
+              options={ruleOptions}
+              value={ruleId}
+              placeholder="Pick a rule"
+              emptyMessage="No rules provisioned yet."
+              onChange={(value) => {
+                setRuleId(value);
+                clearError();
+              }}
+            />
+          ) : null}
+        </div>
+
+        <SinglePickerField
+          id="maintenance-window-quick"
+          label="Quick window"
+          options={MAINTENANCE_WINDOW_QUICK_OPTIONS}
+          value={quick}
+          placeholder="Custom"
+          onChange={handleQuickChange}
+        />
+
+        <div className="grid grid-cols-2 gap-4">
+          <Input
+            id="maintenance-window-starts"
+            label="Starts"
+            type="datetime-local"
+            initValue={starts}
+            onChange={handleStartsChange}
+          />
+          <Input
+            id="maintenance-window-ends"
+            label="Ends"
+            type="datetime-local"
+            initValue={ends}
+            onChange={handleEndsChange}
+          />
+        </div>
+
+        <Input
+          id="maintenance-window-comment"
+          label="Reason"
+          initValue={comment}
+          onChange={(value) => {
+            setComment(value);
+            clearError();
+          }}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default AddMaintenanceWindowModal;

--- a/client/src/protoFleet/features/notifications/components/ChannelEditableCell.tsx
+++ b/client/src/protoFleet/features/notifications/components/ChannelEditableCell.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState } from "react";
+import { Edit } from "@/shared/assets/icons";
+
+interface ChannelEditableCellProps {
+  value: string;
+  placeholder: string;
+  ariaLabel: string;
+  onSave: (next: string) => void;
+  readOnly?: boolean;
+}
+
+const ChannelEditableCell = ({ value, placeholder, ariaLabel, onSave, readOnly = false }: ChannelEditableCellProps) => {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const commit = () => {
+    const next = draft.trim();
+    if (next && next !== value) onSave(next);
+    setEditing(false);
+  };
+
+  if (readOnly) {
+    return <span className="truncate">{value || placeholder}</span>;
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={draft}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        className="bg-surface-1 w-full rounded-md border border-border-5 px-2 py-1 text-300 text-text-primary outline-none focus:border-core-primary-fill"
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            setDraft(value);
+            setEditing(false);
+          }
+        }}
+      />
+    );
+  }
+
+  return (
+    <span className="group flex items-center gap-2">
+      <span className="truncate">{value}</span>
+      <button
+        type="button"
+        className="text-text-primary-50 opacity-0 transition-opacity group-hover:opacity-100 hover:text-text-primary"
+        title={`Edit ${ariaLabel}`}
+        aria-label={`Edit ${ariaLabel}`}
+        onClick={() => {
+          setDraft(value);
+          setEditing(true);
+        }}
+      >
+        <Edit />
+      </button>
+    </span>
+  );
+};
+
+export default ChannelEditableCell;

--- a/client/src/protoFleet/features/notifications/components/ChannelStatusBadge.tsx
+++ b/client/src/protoFleet/features/notifications/components/ChannelStatusBadge.tsx
@@ -1,0 +1,27 @@
+import clsx from "clsx";
+import type { ValidationState } from "@/protoFleet/features/notifications/types";
+
+interface ChannelStatusBadgeProps {
+  state: ValidationState;
+}
+
+const LABEL: Record<ValidationState, string> = {
+  ok: "Validated",
+  failed: "Failed",
+  pending: "Not tested",
+};
+
+const DOT_CLASS: Record<ValidationState, string> = {
+  ok: "bg-state-success-fill",
+  failed: "bg-state-danger-fill",
+  pending: "bg-border-20",
+};
+
+const ChannelStatusBadge = ({ state }: ChannelStatusBadgeProps) => (
+  <span className="inline-flex items-center gap-2 text-300 text-text-primary-50">
+    <span className={clsx("h-2 w-2 rounded-full", DOT_CLASS[state])} />
+    {LABEL[state]}
+  </span>
+);
+
+export default ChannelStatusBadge;

--- a/client/src/protoFleet/features/notifications/components/ChannelsSection.tsx
+++ b/client/src/protoFleet/features/notifications/components/ChannelsSection.tsx
@@ -1,0 +1,240 @@
+import { useCallback, useMemo, useState } from "react";
+import AddChannelModal from "./AddChannelModal";
+import ChannelEditableCell from "./ChannelEditableCell";
+import ChannelStatusBadge from "./ChannelStatusBadge";
+import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
+import { testChannel as testChannelApi } from "@/protoFleet/features/notifications/api/notificationsApi";
+import { useNotificationsStore } from "@/protoFleet/features/notifications/store/notificationsStore";
+import type { Channel } from "@/protoFleet/features/notifications/types";
+import { useHasPermission } from "@/protoFleet/store";
+import { Checkmark, Trash } from "@/shared/assets/icons";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import Header from "@/shared/components/Header";
+import List from "@/shared/components/List";
+import type { ColConfig, ColTitles, ListAction } from "@/shared/components/List/types";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+type ChannelColumns = "name" | "destination" | "status";
+
+const colTitles: ColTitles<ChannelColumns> = {
+  name: "Name",
+  destination: "Destination",
+  status: "Status",
+};
+
+const activeCols: ChannelColumns[] = ["name", "destination", "status"];
+
+const formatDestination = (c: Channel) => {
+  if (c.kind === "webhook") return c.webhook?.url ?? "";
+  if (c.kind === "slack") return c.has_secret ? "Slack webhook (hidden)" : "";
+  return (c.smtp?.to ?? []).join(", ");
+};
+
+const destinationPlaceholder = (c: Channel) => {
+  if (c.kind === "slack") return "https://hooks.slack.com/services/…";
+  return c.kind === "webhook" ? "https://hooks…" : "oncall@example.com";
+};
+
+const ChannelsSection = () => {
+  const channels = useNotificationsStore((s) => s.channels);
+  const updateChannel = useNotificationsStore((s) => s.updateChannel);
+  const removeChannel = useNotificationsStore((s) => s.removeChannel);
+  const canManage = useHasPermission("notification:manage");
+
+  const [showAddModal, setShowAddModal] = useState(false);
+
+  const handleSaveName = useCallback(
+    async (channel: Channel, next: string) => {
+      try {
+        await updateChannel({
+          id: channel.id,
+          name: next,
+          kind: channel.kind,
+          webhook: channel.webhook,
+          smtp: channel.smtp,
+          slack: channel.slack,
+        });
+        pushToast({ message: `Renamed: ${next}`, status: STATUSES.success });
+      } catch (error) {
+        pushToast({
+          message: getErrorMessage(error, "Failed to rename channel"),
+          status: STATUSES.error,
+        });
+      }
+    },
+    [updateChannel],
+  );
+
+  const handleSaveDestination = useCallback(
+    async (channel: Channel, next: string) => {
+      try {
+        const base = { id: channel.id, name: channel.name, kind: channel.kind };
+        const input =
+          channel.kind === "webhook"
+            ? { ...base, webhook: { url: next, bearer_header: null }, smtp: null, slack: null }
+            : channel.kind === "slack"
+              ? { ...base, webhook: null, smtp: null, slack: { webhook_url: next } }
+              : {
+                  ...base,
+                  webhook: null,
+                  slack: null,
+                  smtp: {
+                    host: channel.smtp?.host ?? "",
+                    port: channel.smtp?.port ?? 587,
+                    username: channel.smtp?.username ?? "",
+                    from: channel.smtp?.from ?? "",
+                    to: next
+                      .split(",")
+                      .map((s) => s.trim())
+                      .filter(Boolean),
+                  },
+                };
+        await updateChannel(input);
+        pushToast({ message: "Destination updated", status: STATUSES.success });
+      } catch (error) {
+        pushToast({
+          message: getErrorMessage(error, "Failed to update destination"),
+          status: STATUSES.error,
+        });
+      }
+    },
+    [updateChannel],
+  );
+
+  const handleTest = useCallback(async (channel: Channel) => {
+    try {
+      const result = await testChannelApi({
+        id: channel.id,
+        name: channel.name,
+        kind: channel.kind,
+        webhook: channel.webhook,
+        smtp: channel.smtp,
+        slack: channel.slack,
+      });
+      if (result.ok) {
+        pushToast({ message: "Test delivery sent", status: STATUSES.success });
+      } else {
+        pushToast({
+          message: `Test failed (HTTP ${result.response_code}): ${result.error || "no detail"}`,
+          status: STATUSES.error,
+        });
+      }
+    } catch (error) {
+      pushToast({
+        message: getErrorMessage(error, "Test delivery failed"),
+        status: STATUSES.error,
+      });
+    }
+  }, []);
+
+  const handleDelete = useCallback(
+    async (channel: Channel) => {
+      try {
+        await removeChannel(channel.id);
+        pushToast({ message: `Deleted channel "${channel.name}"`, status: STATUSES.success });
+      } catch (error) {
+        pushToast({
+          message: getErrorMessage(error, "Failed to delete channel"),
+          status: STATUSES.error,
+        });
+      }
+    },
+    [removeChannel],
+  );
+
+  const actions: ListAction<Channel>[] = useMemo(
+    () => [
+      {
+        title: "Test",
+        icon: <Checkmark />,
+        actionHandler: handleTest,
+      },
+      {
+        title: "Delete",
+        icon: <Trash />,
+        variant: "destructive",
+        actionHandler: handleDelete,
+      },
+    ],
+    [handleTest, handleDelete],
+  );
+
+  const colConfig: ColConfig<Channel, string, ChannelColumns> = useMemo(
+    () => ({
+      name: {
+        component: (channel) => (
+          <ChannelEditableCell
+            value={channel.name}
+            placeholder="Name"
+            ariaLabel="name"
+            readOnly={!canManage}
+            onSave={(next) => {
+              void handleSaveName(channel, next);
+            }}
+          />
+        ),
+        width: "w-64",
+      },
+      destination: {
+        component: (channel) => (
+          <ChannelEditableCell
+            value={formatDestination(channel)}
+            placeholder={destinationPlaceholder(channel)}
+            ariaLabel="destination"
+            readOnly={!canManage}
+            onSave={(next) => {
+              void handleSaveDestination(channel, next);
+            }}
+          />
+        ),
+        width: "w-96",
+        allowWrap: true,
+      },
+      status: {
+        component: (channel) => <ChannelStatusBadge state={channel.validation_state} />,
+        width: "w-40",
+      },
+    }),
+    [handleSaveName, handleSaveDestination, canManage],
+  );
+
+  return (
+    <section className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
+      <div className="flex items-center justify-between">
+        <Header title="Channels" titleSize="text-heading-200" />
+        {canManage ? (
+          <Button
+            variant={variants.secondary}
+            size={sizes.compact}
+            text="Add channel"
+            onClick={() => setShowAddModal(true)}
+          />
+        ) : null}
+      </div>
+      <p className="text-300 text-text-primary-50">
+        Webhook and email destinations for alert delivery. Saved channels are not yet attached to alert routing — "Test"
+        sends a synthetic alert directly to the destination, but live alerts won't deliver here until routing ships.
+      </p>
+
+      <List<Channel, string, ChannelColumns>
+        items={channels}
+        itemKey="id"
+        activeCols={activeCols}
+        colTitles={colTitles}
+        colConfig={colConfig}
+        total={channels.length}
+        itemName={{ singular: "channel", plural: "channels" }}
+        noDataElement={
+          <div className="py-10 text-center text-text-primary-50">
+            No channels yet — add an SMTP relay or webhook URL to start getting alerts.
+          </div>
+        }
+        actions={canManage ? actions : []}
+      />
+
+      <AddChannelModal open={showAddModal} onDismiss={() => setShowAddModal(false)} />
+    </section>
+  );
+};
+
+export default ChannelsSection;

--- a/client/src/protoFleet/features/notifications/components/HistorySection.tsx
+++ b/client/src/protoFleet/features/notifications/components/HistorySection.tsx
@@ -1,0 +1,20 @@
+import HistoryTable from "./HistoryTable";
+import Header from "@/shared/components/Header";
+
+const HistorySection = () => (
+  <section className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
+    <Header title="History" titleSize="text-heading-200" />
+    <p className="text-300 text-text-primary-50">
+      Chronological record of notifications delivered by the rule engine, most recent first.
+    </p>
+    <HistoryTable
+      noDataElement={
+        <div className="py-10 text-center text-text-primary-50">
+          No notifications delivered yet — alerts will appear here as they fire.
+        </div>
+      }
+    />
+  </section>
+);
+
+export default HistorySection;

--- a/client/src/protoFleet/features/notifications/components/HistoryTable.tsx
+++ b/client/src/protoFleet/features/notifications/components/HistoryTable.tsx
@@ -1,0 +1,153 @@
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
+import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
+import { useNotificationsStore } from "@/protoFleet/features/notifications/store/notificationsStore";
+import type { NotificationHistoryEntry } from "@/protoFleet/features/notifications/types";
+import { Alert } from "@/shared/assets/icons";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import Callout from "@/shared/components/Callout";
+import List from "@/shared/components/List";
+import type { ColConfig, ColTitles } from "@/shared/components/List/types";
+import ProgressCircular from "@/shared/components/ProgressCircular";
+
+type HistoryColumns = "alert" | "status" | "device" | "mac" | "received" | "summary";
+
+const colTitles: ColTitles<HistoryColumns> = {
+  alert: "Alert",
+  status: "Status",
+  device: "Device Name",
+  mac: "MAC Address",
+  received: "Received",
+  summary: "Summary",
+};
+
+const activeCols: HistoryColumns[] = ["alert", "status", "device", "mac", "received", "summary"];
+
+const StatusBadge = ({ status }: { status: NotificationHistoryEntry["status"] }) => (
+  <span className="inline-flex items-center gap-2 text-300 text-text-primary-50">
+    <span
+      className={clsx(
+        "h-2 w-2 rounded-full",
+        status === "resolved" ? "bg-intent-success-fill" : "bg-intent-critical-fill",
+      )}
+    />
+    {status === "resolved" ? "Resolved" : "Firing"}
+  </span>
+);
+
+const colConfig: ColConfig<NotificationHistoryEntry, string, HistoryColumns> = {
+  alert: {
+    component: (entry) => (
+      <span className="flex items-center gap-2">
+        <span className="text-emphasis-300 text-text-primary">{entry.alert_name}</span>
+        {entry.severity ? (
+          <span className="rounded bg-surface-5 px-2 py-0.5 text-200 text-text-primary-50">{entry.severity}</span>
+        ) : null}
+      </span>
+    ),
+    width: "w-64",
+  },
+  status: {
+    component: (entry) => <StatusBadge status={entry.status} />,
+    width: "w-32",
+  },
+  device: {
+    component: (entry) => <span className="text-text-primary-50">{entry.device_name || "—"}</span>,
+    width: "w-48",
+  },
+  mac: {
+    component: (entry) => <span className="text-text-primary-50">{entry.device_mac || "—"}</span>,
+    width: "w-44",
+  },
+  received: {
+    component: (entry) => <span className="text-text-primary-50">{new Date(entry.received_at).toLocaleString()}</span>,
+    width: "w-48",
+  },
+  summary: {
+    component: (entry) => <span className="text-text-primary-50">{entry.summary || "—"}</span>,
+    width: "w-80",
+    allowWrap: true,
+  },
+};
+
+const selectActive = (history: NotificationHistoryEntry[]): NotificationHistoryEntry[] => {
+  const latestByKey = new Map<string, NotificationHistoryEntry>();
+  for (const entry of history) {
+    const key = entry.fingerprint || entry.alert_name;
+    if (!latestByKey.has(key)) latestByKey.set(key, entry);
+  }
+  return [...latestByKey.values()].filter((entry) => entry.status === "firing");
+};
+
+interface HistoryTableProps {
+  activeOnly?: boolean;
+  noDataElement: ReactNode;
+}
+
+const HistoryTable = ({ activeOnly = false, noDataElement }: HistoryTableProps) => {
+  const history = useNotificationsStore((s) => s.history);
+  const historyHasMore = useNotificationsStore((s) => s.historyHasMore);
+  const historyLoading = useNotificationsStore((s) => s.historyLoading);
+  const refreshHistory = useNotificationsStore((s) => s.refreshHistory);
+  const loadMoreHistory = useNotificationsStore((s) => s.loadMoreHistory);
+
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void refreshHistory().catch((err: unknown) => {
+      setError(getErrorMessage(err, "Failed to load notification history"));
+    });
+  }, [refreshHistory]);
+
+  const handleLoadMore = useMemo(
+    () => () => {
+      void loadMoreHistory().catch((err: unknown) => {
+        setError(getErrorMessage(err, "Failed to load more notifications"));
+      });
+    },
+    [loadMoreHistory],
+  );
+
+  const entries = useMemo(() => (activeOnly ? selectActive(history) : history), [activeOnly, history]);
+
+  const isInitialLoad = historyLoading && history.length === 0;
+  const isLoadingMore = historyLoading && history.length > 0;
+
+  return (
+    <>
+      {error ? <Callout intent="danger" prefixIcon={<Alert />} title={error} /> : null}
+
+      {isInitialLoad ? (
+        <div className="flex justify-center py-10">
+          <ProgressCircular indeterminate />
+        </div>
+      ) : (
+        <List<NotificationHistoryEntry, string, HistoryColumns>
+          items={entries}
+          itemKey="id"
+          activeCols={activeCols}
+          colTitles={colTitles}
+          colConfig={colConfig}
+          noDataElement={noDataElement}
+        />
+      )}
+
+      {!activeOnly && historyHasMore ? (
+        <div className="flex justify-center">
+          <Button
+            variant={variants.secondary}
+            size={sizes.compact}
+            onClick={handleLoadMore}
+            loading={isLoadingMore}
+            disabled={isLoadingMore}
+          >
+            Load more
+          </Button>
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+export default HistoryTable;

--- a/client/src/protoFleet/features/notifications/components/MaintenanceWindowsSection.tsx
+++ b/client/src/protoFleet/features/notifications/components/MaintenanceWindowsSection.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useMemo, useState } from "react";
+import AddMaintenanceWindowModal from "./AddMaintenanceWindowModal";
+import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
+import { useNotificationsStore } from "@/protoFleet/features/notifications/store/notificationsStore";
+import type { MaintenanceWindowWithActive } from "@/protoFleet/features/notifications/types";
+import { useHasPermission } from "@/protoFleet/store";
+import { Edit, Stop } from "@/shared/assets/icons";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import Header from "@/shared/components/Header";
+import List from "@/shared/components/List";
+import type { ColConfig, ColTitles, ListAction } from "@/shared/components/List/types";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+type MaintenanceWindowColumns = "target" | "window" | "reason";
+
+const colTitles: ColTitles<MaintenanceWindowColumns> = {
+  target: "Target",
+  window: "Window",
+  reason: "Reason",
+};
+
+const activeCols: MaintenanceWindowColumns[] = ["target", "window", "reason"];
+
+const formatWindow = (maintenanceWindow: MaintenanceWindowWithActive): string => {
+  const start = new Date(maintenanceWindow.starts_at).toLocaleString();
+  const end = maintenanceWindow.ends_at ? new Date(maintenanceWindow.ends_at).toLocaleString() : "—";
+  return `${start} → ${end}`;
+};
+
+const MaintenanceWindowsSection = () => {
+  const maintenanceWindows = useNotificationsStore((s) => s.maintenanceWindows);
+  const rules = useNotificationsStore((s) => s.rules);
+  const removeMaintenanceWindow = useNotificationsStore((s) => s.removeMaintenanceWindow);
+  const canManage = useHasPermission("notification:manage");
+
+  const [showModal, setShowModal] = useState(false);
+  const [editingMaintenanceWindow, setEditingMaintenanceWindow] = useState<MaintenanceWindowWithActive | null>(null);
+
+  const sortedMaintenanceWindows = useMemo<MaintenanceWindowWithActive[]>(
+    () =>
+      maintenanceWindows
+        .slice()
+        .sort((a, b) => Number(b.active) - Number(a.active) || a.starts_at.localeCompare(b.starts_at)),
+    [maintenanceWindows],
+  );
+
+  const ruleNameById = useCallback((id: string) => rules.find((r) => r.id === id)?.name ?? id, [rules]);
+
+  const formatTarget = useCallback(
+    (maintenanceWindow: MaintenanceWindowWithActive): string => {
+      if (maintenanceWindow.scope.kind === "rule")
+        return maintenanceWindow.scope.rule_id ? ruleNameById(maintenanceWindow.scope.rule_id) : "—";
+      if (maintenanceWindow.scope.kind === "group") return `Group: ${maintenanceWindow.scope.group_id ?? "—"}`;
+      if (maintenanceWindow.scope.kind === "site") return `Site: ${maintenanceWindow.scope.site_id ?? "—"}`;
+      return `${(maintenanceWindow.scope.device_ids ?? []).length} devices`;
+    },
+    [ruleNameById],
+  );
+
+  const openAdd = () => {
+    setEditingMaintenanceWindow(null);
+    setShowModal(true);
+  };
+
+  const handleEdit = useCallback((maintenanceWindow: MaintenanceWindowWithActive) => {
+    setEditingMaintenanceWindow(maintenanceWindow);
+    setShowModal(true);
+  }, []);
+
+  const handleLift = useCallback(
+    async (maintenanceWindow: MaintenanceWindowWithActive) => {
+      try {
+        await removeMaintenanceWindow(maintenanceWindow.id);
+        pushToast({ message: "Maintenance window lifted", status: STATUSES.success });
+      } catch (error) {
+        pushToast({
+          message: getErrorMessage(error, "Failed to lift maintenance window"),
+          status: STATUSES.error,
+        });
+      }
+    },
+    [removeMaintenanceWindow],
+  );
+
+  const actions: ListAction<MaintenanceWindowWithActive>[] = useMemo(
+    () => [
+      {
+        title: "Edit",
+        icon: <Edit />,
+        actionHandler: handleEdit,
+      },
+      {
+        title: "Lift maintenance window",
+        icon: <Stop />,
+        variant: "destructive",
+        actionHandler: (maintenanceWindow) => {
+          void handleLift(maintenanceWindow);
+        },
+      },
+    ],
+    [handleEdit, handleLift],
+  );
+
+  const colConfig: ColConfig<MaintenanceWindowWithActive, string, MaintenanceWindowColumns> = useMemo(
+    () => ({
+      target: {
+        component: (maintenanceWindow) => (
+          <span className="flex items-center gap-2">
+            <span className="text-emphasis-300 text-text-primary">{formatTarget(maintenanceWindow)}</span>
+            {maintenanceWindow.active ? (
+              <span className="bg-state-success-fill/10 text-state-success-fill rounded px-2 py-0.5 text-200">
+                Active
+              </span>
+            ) : (
+              <span className="rounded bg-surface-5 px-2 py-0.5 text-200 text-text-primary-50">Expired</span>
+            )}
+          </span>
+        ),
+        width: "w-64",
+      },
+      window: {
+        component: (maintenanceWindow) => (
+          <span className="text-text-primary-50">{formatWindow(maintenanceWindow)}</span>
+        ),
+        width: "w-80",
+        allowWrap: true,
+      },
+      reason: {
+        component: (maintenanceWindow) => (
+          <span className="text-text-primary-50">{maintenanceWindow.comment || "No reason given"}</span>
+        ),
+        width: "w-64",
+        allowWrap: true,
+      },
+    }),
+    [formatTarget],
+  );
+
+  return (
+    <section className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
+      <div className="flex items-center justify-between">
+        <Header title="Maintenance Windows" titleSize="text-heading-200" />
+        {canManage ? (
+          <Button variant={variants.secondary} size={sizes.compact} text="Add maintenance window" onClick={openAdd} />
+        ) : null}
+      </div>
+      <p className="text-300 text-text-primary-50">
+        Temporary mutes that stop a rule from firing during a maintenance window or planned outage.
+      </p>
+
+      <List<MaintenanceWindowWithActive, string, MaintenanceWindowColumns>
+        items={sortedMaintenanceWindows}
+        itemKey="id"
+        activeCols={activeCols}
+        colTitles={colTitles}
+        colConfig={colConfig}
+        total={sortedMaintenanceWindows.length}
+        itemName={{ singular: "maintenance window", plural: "maintenance windows" }}
+        noDataElement={
+          <div className="py-10 text-center text-text-primary-50">
+            No maintenanceWindows right now — click Add maintenanceWindow to mute during planned work.
+          </div>
+        }
+        actions={canManage ? actions : []}
+      />
+
+      <AddMaintenanceWindowModal
+        open={showModal}
+        editingMaintenanceWindow={editingMaintenanceWindow}
+        onDismiss={() => {
+          setShowModal(false);
+          setEditingMaintenanceWindow(null);
+        }}
+      />
+    </section>
+  );
+};
+
+export default MaintenanceWindowsSection;

--- a/client/src/protoFleet/features/notifications/components/RulesSection.tsx
+++ b/client/src/protoFleet/features/notifications/components/RulesSection.tsx
@@ -1,0 +1,186 @@
+import { useCallback, useMemo, useState } from "react";
+import AddMaintenanceWindowModal from "./AddMaintenanceWindowModal";
+import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
+import { useNotificationsStore } from "@/protoFleet/features/notifications/store/notificationsStore";
+import type { Rule } from "@/protoFleet/features/notifications/types";
+import { useHasPermission } from "@/protoFleet/store";
+import { Pause, Play, Stop } from "@/shared/assets/icons";
+import Header from "@/shared/components/Header";
+import List from "@/shared/components/List";
+import type { ColConfig, ColTitles, ListAction } from "@/shared/components/List/types";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+type RuleColumns = "name" | "when" | "severity";
+
+const colTitles: ColTitles<RuleColumns> = {
+  name: "Name",
+  when: "When",
+  severity: "Severity",
+};
+
+const activeCols: RuleColumns[] = ["name", "when", "severity"];
+
+const formatRuleCondition = (rule: Rule): string => {
+  if (rule.summary) return rule.summary;
+  if (rule.duration_seconds > 0) return `fires after ${rule.duration_seconds}s`;
+  return "fires on first matching evaluation";
+};
+
+const RulesSection = () => {
+  const rules = useNotificationsStore((s) => s.rules);
+  const maintenanceWindows = useNotificationsStore((s) => s.maintenanceWindows);
+  const pauseRule = useNotificationsStore((s) => s.pauseRule);
+  const resumeRule = useNotificationsStore((s) => s.resumeRule);
+  const removeMaintenanceWindow = useNotificationsStore((s) => s.removeMaintenanceWindow);
+  const canManage = useHasPermission("notification:manage");
+
+  const [maintenanceWindowPrefillRuleId, setMaintenanceWindowPrefillRuleId] = useState<string | null>(null);
+  const [showMaintenanceWindowModal, setShowMaintenanceWindowModal] = useState(false);
+
+  const activeMaintenanceWindowByRule = useMemo(() => {
+    const map = new Map<string, string>();
+    maintenanceWindows.forEach((sil) => {
+      if (sil.active && sil.scope.kind === "rule" && sil.scope.rule_id) {
+        map.set(sil.scope.rule_id, sil.id);
+      }
+    });
+    return map;
+  }, [maintenanceWindows]);
+
+  const sortedRules = useMemo(
+    () =>
+      rules
+        .slice()
+        .sort(
+          (a, b) =>
+            Number(!a.enabled) - Number(!b.enabled) || a.group.localeCompare(b.group) || a.name.localeCompare(b.name),
+        ),
+    [rules],
+  );
+
+  const handleTogglePause = useCallback(
+    async (rule: Rule) => {
+      try {
+        if (rule.enabled) {
+          await pauseRule(rule.id);
+          pushToast({ message: `Paused: ${rule.name}`, status: STATUSES.success });
+        } else {
+          await resumeRule(rule.id);
+          pushToast({ message: `Resumed: ${rule.name}`, status: STATUSES.success });
+        }
+      } catch (error) {
+        pushToast({
+          message: getErrorMessage(error, "Failed to update rule"),
+          status: STATUSES.error,
+        });
+      }
+    },
+    [pauseRule, resumeRule],
+  );
+
+  const handleMaintenanceWindowOrLift = useCallback(
+    async (rule: Rule) => {
+      const activeMaintenanceWindowId = activeMaintenanceWindowByRule.get(rule.id);
+      if (activeMaintenanceWindowId) {
+        try {
+          await removeMaintenanceWindow(activeMaintenanceWindowId);
+          pushToast({ message: "Maintenance window lifted", status: STATUSES.success });
+        } catch (error) {
+          pushToast({
+            message: getErrorMessage(error, "Failed to lift maintenance window"),
+            status: STATUSES.error,
+          });
+        }
+      } else {
+        setMaintenanceWindowPrefillRuleId(rule.id);
+        setShowMaintenanceWindowModal(true);
+      }
+    },
+    [activeMaintenanceWindowByRule, removeMaintenanceWindow],
+  );
+
+  const actions: ListAction<Rule>[] = useMemo(
+    () => [
+      {
+        title: (rule) => (rule.enabled ? "Pause" : "Resume"),
+        icon: (rule) => (rule.enabled ? <Pause /> : <Play />),
+        actionHandler: (rule) => {
+          void handleTogglePause(rule);
+        },
+      },
+      {
+        title: (rule) =>
+          activeMaintenanceWindowByRule.has(rule.id) ? "Lift maintenance window" : "Maintenance window",
+        icon: <Stop />,
+        actionHandler: (rule) => {
+          void handleMaintenanceWindowOrLift(rule);
+        },
+      },
+    ],
+    [handleTogglePause, handleMaintenanceWindowOrLift, activeMaintenanceWindowByRule],
+  );
+
+  const colConfig: ColConfig<Rule, string, RuleColumns> = useMemo(
+    () => ({
+      name: {
+        component: (rule) => (
+          <span className="flex items-center gap-2">
+            <span className="text-emphasis-300 text-text-primary">{rule.name}</span>
+            {!rule.enabled ? (
+              <span className="rounded bg-surface-5 px-2 py-0.5 text-200 text-text-primary-50">Paused</span>
+            ) : null}
+          </span>
+        ),
+        width: "w-56",
+      },
+      when: {
+        component: (rule) => <span className="text-text-primary-50">{formatRuleCondition(rule)}</span>,
+        width: "w-[480px]",
+        allowWrap: true,
+      },
+      severity: {
+        component: (rule) => <span className="text-text-primary-50">{rule.severity || "—"}</span>,
+        width: "w-24",
+      },
+    }),
+    [],
+  );
+
+  return (
+    <section className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
+      <Header title="Rules" titleSize="text-heading-200" />
+      <p className="text-300 text-text-primary-50">
+        Provisioned conditions that decide when a notification fires. The rule set is managed by ops — pause one to
+        maintenanceWindow it indefinitely, or attach a maintenanceWindow to mute it for a finite maintenance window.
+      </p>
+
+      <List<Rule, string, RuleColumns>
+        items={sortedRules}
+        itemKey="id"
+        activeCols={activeCols}
+        colTitles={colTitles}
+        colConfig={colConfig}
+        total={sortedRules.length}
+        itemName={{ singular: "rule", plural: "rules" }}
+        noDataElement={
+          <div className="py-10 text-center text-text-primary-50">
+            No rules provisioned yet — ask your operator to deploy the Grafana alert-rule bundle.
+          </div>
+        }
+        actions={canManage ? actions : []}
+      />
+
+      <AddMaintenanceWindowModal
+        open={showMaintenanceWindowModal}
+        editingMaintenanceWindow={null}
+        prefillRuleId={maintenanceWindowPrefillRuleId}
+        onDismiss={() => {
+          setShowMaintenanceWindowModal(false);
+          setMaintenanceWindowPrefillRuleId(null);
+        }}
+      />
+    </section>
+  );
+};
+
+export default RulesSection;

--- a/client/src/protoFleet/features/notifications/components/SinglePickerField.tsx
+++ b/client/src/protoFleet/features/notifications/components/SinglePickerField.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from "react";
+import clsx from "clsx";
+import { ChevronDown } from "@/shared/assets/icons";
+import Popover, { PopoverProvider, usePopover } from "@/shared/components/Popover";
+import { minimalMargin } from "@/shared/components/Popover/constants";
+import Radio from "@/shared/components/Radio";
+import { type Position, positions } from "@/shared/constants";
+
+export interface PickerOption {
+  id: string;
+  label: string;
+}
+
+interface SinglePickerFieldProps {
+  id: string;
+  label: string;
+  options: PickerOption[];
+  value: string | null;
+  placeholder?: string;
+  emptyMessage?: string;
+  onChange: (value: string) => void;
+}
+
+const popoverViewportPadding = minimalMargin * 2;
+// Flip the list above the trigger only when there isn't this much room below.
+const minOpenBelowHeight = 240;
+
+const SinglePickerFieldContent = ({
+  id,
+  label,
+  options,
+  value,
+  placeholder = "Pick one",
+  emptyMessage = "No options",
+  onChange,
+}: SinglePickerFieldProps) => {
+  const [open, setOpen] = useState(false);
+  const { triggerRef, setPopoverRenderMode } = usePopover();
+  const listboxRef = useRef<HTMLDivElement>(null);
+  const [popoverPosition, setPopoverPosition] = useState<Position>(positions["bottom right"]);
+  const [triggerWidth, setTriggerWidth] = useState<number | undefined>();
+  const [popoverMaxHeight, setPopoverMaxHeight] = useState<number | undefined>();
+
+  const picked = options.find((o) => o.id === value) ?? null;
+  const displayLabel = picked?.label ?? placeholder;
+
+  useEffect(() => {
+    setPopoverRenderMode("portal-scrolling");
+  }, [setPopoverRenderMode]);
+
+  useEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const update = () => {
+      if (!triggerRef.current) return;
+      const rect = triggerRef.current.getBoundingClientRect();
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const spaceAbove = rect.top - popoverViewportPadding;
+      const spaceBelow = viewportHeight - rect.bottom - popoverViewportPadding;
+      const openAbove = spaceBelow < minOpenBelowHeight && spaceAbove > spaceBelow;
+      setTriggerWidth(rect.width);
+      setPopoverPosition(openAbove ? positions["top right"] : positions["bottom right"]);
+      setPopoverMaxHeight(Math.max(Math.floor(openAbove ? spaceAbove : spaceBelow), 0));
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.visualViewport?.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.visualViewport?.removeEventListener("resize", update);
+    };
+  }, [open, triggerRef]);
+
+  const pickAndClose = (next: string) => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <div ref={triggerRef}>
+        <button
+          id={id}
+          type="button"
+          aria-label={label}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          onClick={() => setOpen((prev) => !prev)}
+          className={clsx(
+            "peer flex h-14 w-full items-center justify-between rounded-lg pr-4 pl-4 text-left outline-hidden",
+            "transition duration-200 ease-in-out",
+            "bg-surface-base",
+            { "border border-border-5": !open },
+            { "border border-border-20 ring-4 ring-core-primary-5": open },
+          )}
+        >
+          <div className="flex min-w-0 flex-col pt-[18px]">
+            <span className="absolute top-[7px] text-200 text-text-primary-50">{label}</span>
+            <span className={clsx("truncate text-300", picked ? "text-text-primary" : "text-text-primary-50")}>
+              {displayLabel}
+            </span>
+          </div>
+          <ChevronDown
+            width="w-3"
+            className={clsx("shrink-0 text-text-primary-70 transition-transform", {
+              "rotate-180": open,
+            })}
+          />
+        </button>
+      </div>
+
+      {open ? (
+        <Popover
+          position={popoverPosition}
+          className="!w-auto !space-y-0 !rounded-xl border border-border-5 !bg-surface-elevated-base !p-0 !shadow-300 !backdrop-blur-none"
+          closePopover={() => setOpen(false)}
+          closeIgnoreSelectors={[`#${id}`]}
+        >
+          <div
+            ref={listboxRef}
+            className="max-h-[calc(100vh-2rem)] overflow-y-auto overscroll-contain p-1.5"
+            role="listbox"
+            aria-label={label}
+            style={{ minWidth: triggerWidth, maxHeight: popoverMaxHeight }}
+          >
+            {options.length === 0 ? (
+              <div className="rounded-xl p-3 text-text-primary-50">{emptyMessage}</div>
+            ) : (
+              options.map((option) => {
+                const active = option.id === value;
+                return (
+                  <div
+                    key={option.id}
+                    role="option"
+                    aria-selected={active}
+                    className={clsx(
+                      "flex cursor-pointer items-center gap-3 rounded-xl p-3 text-left select-none",
+                      "transition-[background-color] duration-200 ease-in-out",
+                      "text-text-primary hover:bg-core-primary-5",
+                    )}
+                    onClick={() => pickAndClose(option.id)}
+                  >
+                    <Radio selected={active} />
+                    <div className="min-w-0 grow">
+                      <div className="truncate text-emphasis-300">{option.label}</div>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </Popover>
+      ) : null}
+    </div>
+  );
+};
+
+const SinglePickerField = (props: SinglePickerFieldProps) => (
+  <PopoverProvider>
+    <SinglePickerFieldContent {...props} />
+  </PopoverProvider>
+);
+
+export default SinglePickerField;

--- a/client/src/protoFleet/features/notifications/lib/maintenanceWindowOptions.ts
+++ b/client/src/protoFleet/features/notifications/lib/maintenanceWindowOptions.ts
@@ -1,0 +1,23 @@
+import type { PickerOption } from "@/protoFleet/features/notifications/components/SinglePickerField";
+
+// Only add a scope option once its target picker exists: the server rejects an untargeted scope.
+export const MAINTENANCE_WINDOW_SCOPE_OPTIONS: PickerOption[] = [{ id: "rule", label: "A rule" }];
+
+export interface QuickWindowOption extends PickerOption {
+  hours: number;
+}
+
+export const MAINTENANCE_WINDOW_QUICK_OPTIONS: QuickWindowOption[] = [
+  { id: "1h", label: "1 hour", hours: 1 },
+  { id: "4h", label: "4 hours", hours: 4 },
+  { id: "8h", label: "8 hours", hours: 8 },
+  { id: "24h", label: "1 day", hours: 24 },
+  { id: "72h", label: "3 days", hours: 72 },
+];
+
+export const toLocalDatetimeValue = (date: Date): string => {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(
+    date.getHours(),
+  )}:${pad(date.getMinutes())}`;
+};

--- a/client/src/protoFleet/features/notifications/pages/Notifications.tsx
+++ b/client/src/protoFleet/features/notifications/pages/Notifications.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
+import ChannelsSection from "@/protoFleet/features/notifications/components/ChannelsSection";
+import HistorySection from "@/protoFleet/features/notifications/components/HistorySection";
+import MaintenanceWindowsSection from "@/protoFleet/features/notifications/components/MaintenanceWindowsSection";
+import RulesSection from "@/protoFleet/features/notifications/components/RulesSection";
+import { useNotificationsStore } from "@/protoFleet/features/notifications/store/notificationsStore";
+import Header from "@/shared/components/Header";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+const Notifications = () => {
+  const refresh = useNotificationsStore((s) => s.refresh);
+
+  useEffect(() => {
+    void refresh().catch((error) => {
+      pushToast({
+        message: getErrorMessage(error, "Failed to load notifications"),
+        status: STATUSES.error,
+      });
+    });
+  }, [refresh]);
+
+  return (
+    <div className="flex flex-col gap-6 pb-10">
+      <Header title="Notifications" titleSize="text-heading-300" />
+      <div className="flex flex-col gap-4">
+        <RulesSection />
+        <HistorySection />
+        <ChannelsSection />
+        <MaintenanceWindowsSection />
+      </div>
+    </div>
+  );
+};
+
+export default Notifications;

--- a/client/src/protoFleet/features/notifications/store/notificationsStore.ts
+++ b/client/src/protoFleet/features/notifications/store/notificationsStore.ts
@@ -1,0 +1,199 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import * as api from "@/protoFleet/features/notifications/api/notificationsApi";
+import type {
+  Channel,
+  MaintenanceWindow,
+  MaintenanceWindowScope,
+  MaintenanceWindowWithActive,
+  NotificationHistoryEntry,
+  Rule,
+} from "@/protoFleet/features/notifications/types";
+
+interface NotificationsState {
+  channels: Channel[];
+  rules: Rule[];
+  maintenanceWindows: MaintenanceWindowWithActive[];
+
+  history: NotificationHistoryEntry[];
+  historyHasMore: boolean;
+  historyLoading: boolean;
+
+  loading: boolean;
+  loaded: boolean;
+
+  refresh: () => Promise<void>;
+  refreshHistory: () => Promise<void>;
+  loadMoreHistory: () => Promise<void>;
+
+  createChannel: (input: api.ChannelMutationInput) => Promise<Channel>;
+  updateChannel: (input: api.ChannelMutationInput & { id: string }) => Promise<Channel>;
+  removeChannel: (id: string) => Promise<void>;
+
+  pauseRule: (id: string) => Promise<void>;
+  resumeRule: (id: string) => Promise<void>;
+
+  createMaintenanceWindow: (input: api.MaintenanceWindowMutationInput) => Promise<MaintenanceWindow>;
+  updateMaintenanceWindow: (input: api.MaintenanceWindowMutationInput & { id: string }) => Promise<MaintenanceWindow>;
+  removeMaintenanceWindow: (id: string) => Promise<void>;
+}
+
+const withActive = (s: MaintenanceWindow): MaintenanceWindowWithActive => {
+  const now = Date.now();
+  const start = new Date(s.starts_at).getTime();
+  const end = s.ends_at ? new Date(s.ends_at).getTime() : Infinity;
+  return { ...s, active: now >= start && now < end };
+};
+
+const upsertById = <T extends { id: string }>(list: T[], next: T): T[] => {
+  const idx = list.findIndex((item) => item.id === next.id);
+  if (idx < 0) return [next, ...list];
+  const copy = list.slice();
+  copy[idx] = next;
+  return copy;
+};
+
+const HISTORY_PAGE_SIZE = 50;
+
+export const useNotificationsStore = create<NotificationsState>()(
+  immer((set, get) => ({
+    channels: [],
+    rules: [],
+    maintenanceWindows: [],
+    history: [],
+    historyHasMore: false,
+    historyLoading: false,
+    loading: false,
+    loaded: false,
+
+    refresh: async () => {
+      set((state) => {
+        state.loading = true;
+      });
+      try {
+        const [channels, rules, maintenanceWindows] = await Promise.all([
+          api.listChannels(),
+          api.listRules(),
+          api.listMaintenanceWindows(),
+        ]);
+        set((state) => {
+          state.channels = channels;
+          state.rules = rules;
+          state.maintenanceWindows = maintenanceWindows.map(withActive);
+          state.loaded = true;
+        });
+      } finally {
+        set((state) => {
+          state.loading = false;
+        });
+      }
+    },
+
+    refreshHistory: async () => {
+      set((state) => {
+        state.historyLoading = true;
+      });
+      try {
+        const page = await api.listHistory({ page_size: HISTORY_PAGE_SIZE });
+        set((state) => {
+          state.history = page.notifications;
+          state.historyHasMore = page.has_more;
+        });
+      } finally {
+        set((state) => {
+          state.historyLoading = false;
+        });
+      }
+    },
+
+    loadMoreHistory: async () => {
+      const { history, historyHasMore, historyLoading } = get();
+      if (!historyHasMore || historyLoading || history.length === 0) return;
+      set((state) => {
+        state.historyLoading = true;
+      });
+      try {
+        const page = await api.listHistory({
+          before_id: history[history.length - 1].id,
+          page_size: HISTORY_PAGE_SIZE,
+        });
+        set((state) => {
+          state.history = [...state.history, ...page.notifications];
+          state.historyHasMore = page.has_more;
+        });
+      } finally {
+        set((state) => {
+          state.historyLoading = false;
+        });
+      }
+    },
+
+    createChannel: async (input) => {
+      const created = await api.createChannel(input);
+      set((state) => {
+        state.channels = upsertById(state.channels, created);
+      });
+      return created;
+    },
+
+    updateChannel: async (input) => {
+      const updated = await api.updateChannel(input);
+      set((state) => {
+        state.channels = upsertById(state.channels, updated);
+      });
+      return updated;
+    },
+
+    removeChannel: async (id) => {
+      await api.deleteChannel(id);
+      set((state) => {
+        state.channels = state.channels.filter((c) => c.id !== id);
+      });
+    },
+
+    pauseRule: async (id) => {
+      const updated = await api.pauseRule(id);
+      set((state) => {
+        state.rules = upsertById(state.rules, updated);
+      });
+    },
+
+    resumeRule: async (id) => {
+      const updated = await api.resumeRule(id);
+      set((state) => {
+        state.rules = upsertById(state.rules, updated);
+      });
+    },
+
+    createMaintenanceWindow: async (input) => {
+      const created = await api.createMaintenanceWindow(input);
+      set((state) => {
+        state.maintenanceWindows = upsertById(state.maintenanceWindows, withActive(created));
+      });
+      return created;
+    },
+
+    updateMaintenanceWindow: async (input) => {
+      const updated = await api.updateMaintenanceWindow(input);
+      set((state) => {
+        state.maintenanceWindows = upsertById(state.maintenanceWindows, withActive(updated));
+      });
+      return updated;
+    },
+
+    removeMaintenanceWindow: async (id) => {
+      await api.deleteMaintenanceWindow(id);
+      set((state) => {
+        state.maintenanceWindows = state.maintenanceWindows.filter((s) => s.id !== id);
+      });
+    },
+  })),
+);
+
+export const computeMaintenanceWindowActive = withActive;
+
+export type { MaintenanceWindowScope };
+
+export const selectChannels = (s: NotificationsState) => s.channels;
+export const selectRules = (s: NotificationsState) => s.rules;
+export const selectMaintenanceWindows = (s: NotificationsState) => s.maintenanceWindows;

--- a/client/src/protoFleet/features/notifications/types/index.ts
+++ b/client/src/protoFleet/features/notifications/types/index.ts
@@ -1,0 +1,97 @@
+export type ChannelKind = "webhook" | "smtp" | "slack";
+export type ValidationState = "ok" | "failed" | "pending";
+
+export interface WebhookConfig {
+  url: string;
+  bearer_header: string | null;
+}
+
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  username: string;
+  from: string;
+  to: string[];
+  // Write-only: present on requests, never on reads.
+  password?: string;
+}
+
+export interface SlackConfig {
+  // Write-only: reads return empty since the URL embeds a capability token; has_secret signals one is stored.
+  webhook_url?: string;
+}
+
+export interface Channel {
+  id: string;
+  organization_id: string;
+  name: string;
+  kind: ChannelKind;
+  webhook: WebhookConfig | null;
+  smtp: SmtpConfig | null;
+  slack: SlackConfig | null;
+  created_at: string;
+  updated_at: string;
+  validated_at: string | null;
+  validation_state: ValidationState;
+  validation_error?: string;
+  has_secret?: boolean;
+}
+
+export type RuleTemplate = "offline" | "temperature" | "hashrate" | "pool" | "command_failure" | "telemetry-poll" | "";
+
+export interface Rule {
+  id: string;
+  organization_id: string;
+  name: string;
+  template: RuleTemplate;
+  group: string;
+  severity: string;
+  summary: string;
+  description: string;
+  duration_seconds: number;
+  enabled: boolean;
+}
+
+export type MaintenanceWindowScopeKind = "rule" | "group" | "site" | "device";
+
+export interface MaintenanceWindowScope {
+  kind: MaintenanceWindowScopeKind;
+  rule_id: string | null;
+  group_id: string | null;
+  site_id: string | null;
+  device_ids: string[];
+}
+
+export interface MaintenanceWindow {
+  id: string;
+  organization_id: string;
+  scope: MaintenanceWindowScope;
+  starts_at: string;
+  ends_at: string | null;
+  comment: string;
+  created_by: string;
+  created_at: string;
+}
+
+export interface MaintenanceWindowWithActive extends MaintenanceWindow {
+  active: boolean;
+}
+
+export type NotificationHistoryStatus = "firing" | "resolved";
+
+export interface NotificationHistoryEntry {
+  id: string;
+  received_at: string;
+  alert_name: string;
+  status: NotificationHistoryStatus;
+  severity: string;
+  rule_group: string;
+  fingerprint: string;
+  device_id: string;
+  device_name: string;
+  device_mac: string;
+  template: string;
+  summary: string;
+  starts_at: string | null;
+  ends_at: string | null;
+}

--- a/client/src/protoFleet/features/settings/utils/permissionCatalog.ts
+++ b/client/src/protoFleet/features/settings/utils/permissionCatalog.ts
@@ -34,6 +34,7 @@ const RESOURCE_TO_GROUP: Record<string, string> = {
   curtailment: "curtailment",
   pool: "pool",
   schedule: "schedule",
+  notification: "notifications",
   fleetnode: "admin",
   serverlog: "admin",
   activity: "admin",
@@ -49,10 +50,11 @@ const GROUP_LABELS: Record<string, string> = {
   curtailment: "Curtailment",
   pool: "Mining pools",
   schedule: "Schedules",
+  notifications: "Notifications",
   admin: "Administration",
 };
 
-const GROUP_ORDER = ["fleet", "miner", "infrastructure", "curtailment", "pool", "schedule", "admin"];
+const GROUP_ORDER = ["fleet", "miner", "infrastructure", "curtailment", "pool", "schedule", "notifications", "admin"];
 
 /** True for catalog keys whose action segment is "read". */
 export const isReadKey = (key: string): boolean => key.endsWith(":read");

--- a/client/src/protoFleet/routePrefetch.ts
+++ b/client/src/protoFleet/routePrefetch.ts
@@ -39,6 +39,7 @@ export const importSettingsFirmware = () => import("@/protoFleet/features/settin
 export const importSettingsSchedules = () =>
   import("@/protoFleet/features/settings/components/Schedules/SchedulesPage");
 export const importSettingsCurtailment = () => import("@/protoFleet/features/settings/components/Curtailment");
+export const importSettingsNotifications = () => import("@/protoFleet/features/notifications/pages/Notifications");
 export const importSettingsApiKeys = () => import("@/protoFleet/features/settings/components/ApiKeys");
 export const importSiteDetailPage = () => import("@/protoFleet/features/sites/pages/SiteDetailPage");
 export const importSitesPage = () => import("@/protoFleet/features/sites/pages/SitesPage");
@@ -75,6 +76,7 @@ export const settingsRoutePrefetch: readonly RouteImporter[] = [
   importSettingsFirmware,
   importSettingsSchedules,
   importSettingsCurtailment,
+  importSettingsNotifications,
   importSettingsApiKeys,
   importServerLogsPage,
 ];

--- a/client/src/protoFleet/router.tsx
+++ b/client/src/protoFleet/router.tsx
@@ -31,6 +31,7 @@ import {
   importSettingsGeneral,
   importSettingsLayout,
   importSettingsMiningPools,
+  importSettingsNotifications,
   importSettingsRoles,
   importSettingsSchedules,
   importSettingsSitesPage,
@@ -78,6 +79,7 @@ const SettingsRoles = lazy(importSettingsRoles);
 const SettingsFirmware = lazy(importSettingsFirmware);
 const SettingsSchedules = lazy(importSettingsSchedules);
 const SettingsCurtailment = lazy(importSettingsCurtailment);
+const SettingsNotifications = lazy(importSettingsNotifications);
 const SettingsApiKeys = lazy(importSettingsApiKeys);
 const SiteDetailPage = lazy(importSiteDetailPage);
 const SitesPage = lazy(importSitesPage);
@@ -250,6 +252,12 @@ const router = createBrowserRouter([
     "/settings/curtailment",
     <SettingsLayout>
       <SettingsCurtailment />
+    </SettingsLayout>,
+  ),
+  createRoute(
+    "/settings/notifications",
+    <SettingsLayout>
+      <SettingsNotifications />
     </SettingsLayout>,
   ),
   createRoute(


### PR DESCRIPTION
**Stack 5/5** — base: `eden/notifications-4-server`

## 1. Summary

Adds the **Notifications settings UI** to the protoFleet client: a `/settings/notifications` page where operators view provisioned alert **Rules**, see delivered notification **History**, manage delivery **Channels** (webhook / Slack / SMTP), and schedule **Maintenance Windows** that mute rules during planned work. A dashboard "Active notifications" card surfaces currently-firing alerts. This is the user-facing front end for the notifications service shipped in #455; it talks to the `notifications.v1` Connect services via generated TypeScript clients.

The page is gated on `notification:read`; every mutation control (add / edit / test / delete / pause / resume / lift) is additionally hidden from users without `notification:manage`. This is defense-in-depth — the server enforces the same permissions.

## 2. How it works

The feature is a self-contained React module under `features/notifications/`, layered as **components → Zustand store → API module → generated Connect clients → fleet-api**.

- **API module (`notificationsApi.ts`)** is the single translation point between the protobuf wire contract (camelCase, `Timestamp`, enums) and the feature's snake_case view model. It exposes plain async functions (`listChannels`, `createChannel`, `testChannel`, `listRules`, `pauseRule`, `listMaintenanceWindows`, `createMaintenanceWindow`, `listHistory`, …) that call the four generated clients and map responses through `*FromProto` / `*ToProto` helpers. Secrets are write-only: reads never carry them back (a `has_secret` flag signals presence), and timestamps are converted to/from ISO strings.
- **Store (`notificationsStore.ts`)** is a Zustand cache. `refresh()` loads channels, rules, and maintenance windows in parallel; `refreshHistory()` / `loadMoreHistory()` paginate history independently via keyset (`before_id` = last loaded row's id, page size 50). Mutations call the API, then **merge the server's canonical row** back into the cache (`upsertById`). A derived `active` boolean is computed for each maintenance window at fetch/mutation time (not in render, to avoid `Date.now()` in render).
- **Page (`Notifications.tsx`)** mounts the four sections (Rules, History, Channels, Maintenance Windows) and triggers `refresh()` on mount; load errors surface as toasts.
- **Sections** read store slices and render `shared/List` tables. Row actions and "Add" buttons are conditionally rendered on `useHasPermission("notification:manage")`.

Primary flows:

- **Add channel + test** — `AddChannelModal` builds a typed payload per channel kind (webhook / Slack / SMTP), validates locally, optionally calls `testChannel` (server delivers a synthetic alert and returns ok/HTTP code), then `createChannel` persists it. Secret fields (webhook bearer header, Slack URL, SMTP password) use `type=password`.
- **Rules** are read-only (the Grafana YAML owns the set). Operators can only pause/resume a rule or attach/lift a maintenance window via the row kebab; the kebab flips between "Maintenance window" and "Lift" based on whether an active rule-scoped window already exists.
- **Maintenance window lifecycle** — `AddMaintenanceWindowModal` supports quick presets (1h/4h/8h/1d/3d) or custom `datetime-local` start/end. On save it sends scope + window + reason; for an existing non-rule (group/site/device) window it preserves the stored scope rather than overwriting with empty fields (the server's scope validation would reject those).
- **Dashboard card** — `ActiveNotificationsCard` renders only when the user has `notification:read` (avoids a guaranteed 403), and shows a `HistoryTable` in `activeOnly` mode. "Active" is **derived client-side**: dedupe the loaded history (newest-first) to one row per fingerprint, keep only `status === "firing"`.

## 3. Diagrams

### Component / data flow

```mermaid
flowchart TD
  subgraph UI["React feature (features/notifications)"]
    page["Notifications page"]
    rules["RulesSection"]
    hist["HistorySection / HistoryTable"]
    chan["ChannelsSection + AddChannelModal"]
    mw["MaintenanceWindowsSection + AddMaintenanceWindowModal"]
    card["ActiveNotificationsCard (Dashboard)"]
  end
  store["Zustand store (notificationsStore)"]
  api["API module (notificationsApi)"]
  clients["Generated Connect clients (clients.ts)"]
  server["fleet-api notifications.v1"]

  page --> rules & hist & chan & mw
  card --> hist
  rules & hist & chan & mw --> store
  store --> api --> clients --> server

  perm["useHasPermission('notification:manage')"] -.gates mutation controls.-> rules & chan & mw
  read["notification:read"] -.gates page + nav + card.-> page & card
```

### Maintenance window lifecycle (as reflected in the UI)

```mermaid
stateDiagram-v2
  [*] --> Active: "create (starts <= now < ends)"
  [*] --> Scheduled: "create (now < starts)"
  Scheduled --> Active: "clock reaches starts_at"
  Active --> Expired: "clock reaches ends_at"
  Active --> Lifted: "operator deletes / lifts"
  Scheduled --> Lifted: "operator deletes"
  Lifted --> [*]
  Expired --> [*]
  note right of Active
    'active' is precomputed in the store
    (now >= starts AND now < ends),
    not in render
  end note
```

### Sequence: add channel + test

```mermaid
sequenceDiagram
  actor Op as Operator
  participant M as AddChannelModal
  participant S as Store
  participant A as notificationsApi
  participant Srv as fleet-api

  Op->>M: fill name + destination
  Op->>M: click "Send test"
  M->>A: testChannel(payload)
  A->>Srv: ChannelService.TestChannel
  Srv-->>A: ok / error / HTTP code
  A-->>M: result
  M-->>Op: toast (delivered / failed)
  Op->>M: click "Save channel"
  M->>S: createChannel(payload)
  S->>A: createChannel
  A->>Srv: ChannelService.CreateChannel
  Srv-->>S: canonical Channel row
  S->>S: upsertById(channels)
  M-->>Op: toast "Saved"
```

## 4. Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| **Data / API layer** | | |
| `features/notifications/api/notificationsApi.ts` (new) | Proto ⇄ view-model translation; all list/create/update/delete/test/pause/resume/history calls | Single boundary with the wire contract; check enum/secret/timestamp mapping |
| `features/notifications/types/index.ts` (new) | snake_case view-model types mirroring the server handler | Source of truth for client shapes |
| `features/notifications/store/notificationsStore.ts` (new) | Zustand cache; parallel refresh, keyset history pagination, optimistic-merge mutations, derived `active` | Core state mechanism and pagination logic |
| `api/clients.ts` (modified) | Registers 4 generated notification Connect clients | Wiring only |
| **UI sections** | | |
| `pages/Notifications.tsx` (new) | Composes the four sections; `refresh()` on mount | Page entry point |
| `components/RulesSection.tsx` (new) | Read-only rules table; pause/resume + maintenance-window/lift row actions | Rule actions are mutation-gated |
| `components/HistorySection.tsx` + `HistoryTable.tsx` (new) | History table; `activeOnly` dedupe mode + load-more pagination | Note the active-alert derivation (see §5) |
| `components/ChannelsSection.tsx` (new) | Channels table; inline rename/re-target, test, delete | `canManage` gating; full-PUT update semantics |
| `components/AddChannelModal.tsx` (new) | Per-kind channel form + test-before-save; masked secret inputs | Validation + secret handling |
| `components/MaintenanceWindowsSection.tsx` (new) | Windows table; active/expired badges, edit/lift | Sorting + gating |
| `components/AddMaintenanceWindowModal.tsx` (new) | Create/edit window; quick presets, scope preservation on edit | Non-rule scope preservation fix |
| `components/ChannelEditableCell.tsx` (new) | Inline-edit cell; `readOnly` for non-managers | — |
| `components/ChannelStatusBadge.tsx`, `SinglePickerField.tsx` (new) | Validation badge; accessible single-select picker | Presentational |
| `components/ActiveNotificationsCard.tsx` (new) | Dashboard card wrapping `HistoryTable activeOnly` | — |
| `lib/maintenanceWindowOptions.ts` (new) | Scope/quick-window options + local datetime formatting | — |
| **Wiring** | | |
| `router.tsx`, `routePrefetch.ts`, `config/navItems.ts` (modified) | Route, lazy import + prefetch, nav entry (gated on `notification:read`) | Routing/nav |
| `features/dashboard/pages/Dashboard.tsx` (modified) | Mounts the card behind `notification:read` | Avoids guaranteed 403 |
| `features/settings/utils/permissionCatalog.ts` (modified) | Adds a "Notifications" permission group | Roles UI grouping |
| `api/generated/notifications/**` | Connect/protobuf bindings consumed here | **generated — skip** |

## 5. Key technical decisions & trade-offs

- **Optimistic cache merge of the server's canonical row** (vs. refetch-after-mutate): each mutation merges the returned row via `upsertById`, avoiding a full reload but trusting the server response shape.
- **History pagination is keyset** (`before_id`, page size 50) and **independent** of the rest of the feature's state, rather than offset paging or one combined fetch.
- **Active-alert view is derived client-side**, not a server query (see limitation below).
- **`active` flag precomputed in the store**, not in render — required because computing it needs `Date.now()`, which is lint-blocked in render.
- **Permission gating is UI-only defense-in-depth**: controls hidden via `useHasPermission("notification:manage")`; the server independently rejects unauthorized mutations.
- **Secrets are write-only and masked**: read responses never return secret values (a `has_secret` flag signals presence); secret inputs use `type=password`.
- **Maintenance-window scope is preserved on edit for non-rule scopes** (the modal only edits rule scope), avoiding wiping group/site/device targets that the server would then reject.
- **Channel updates send a full payload (PUT-style)** even for a rename; the server applies only the changed fields.
- **"Silences" renamed to "Maintenance Windows" throughout** — types, store, API, proto bindings, components, and user-facing labels.

## 6. Testing & validation

- Verified manually against the local dev stack: list/create/update/delete/test for channels; pause/resume and maintenance-window attach/lift for rules; window create/edit (quick + custom) and lift; history pagination; dashboard card.
- Permission gating verified for both `notification:read`-only and `notification:manage` users.
- Addressed prior review findings: masked secret inputs + mutation-control gating (security), and non-rule maintenance-window scope preservation on edit (connector).

**Not covered / known limitations:**
- The dashboard "Active notifications" card derives active alerts by deduping **only the first loaded history page** (default 50 rows). A still-firing alert older than that page can drop off the card. This needs an authoritative active-alert source server-side and is a **known follow-up**.
- Saved channels are **not yet attached to alert routing** — "Test" sends a synthetic alert directly to the destination, but live alerts won't deliver through configured channels until routing ships.
- No automated unit/E2E coverage added in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
