### PR TITLE
Clarify default worker name display

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MinerWorkerName from "./MinerWorkerName";
+import {
+  type MinerStateSnapshot,
+  PairingStatus,
+} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+
+function createMockMiner(overrides: Partial<MinerStateSnapshot> = {}): MinerStateSnapshot {
+  return {
+    deviceIdentifier: "test-device",
+    name: "",
+    macAddress: "",
+    serialNumber: "",
+    powerUsage: [],
+    temperature: [],
+    hashrate: [],
+    efficiency: [],
+    ipAddress: "",
+    url: "",
+    deviceStatus: 0,
+    pairingStatus: PairingStatus.PAIRED,
+    model: "",
+    manufacturer: "",
+    temperatureStatus: 0,
+    firmwareVersion: "",
+    groupLabels: [],
+    rackLabel: "",
+    driverName: "",
+    workerName: "",
+    ...overrides,
+  } as MinerStateSnapshot;
+}
+
+describe("MinerWorkerName", () => {
+  const defaultWorkerNameHelpText =
+    "Fleet uses the miner MAC address when it cannot read a worker name from the miner. Use Update worker names to change it.";
+
+  it("renders a default marker when the worker name matches the MAC address", () => {
+    const miner = createMockMiner({
+      macAddress: "aa:bb:cc:dd:ee:ff",
+      workerName: "aa:bb:cc:dd:ee:ff",
+    });
+
+    render(<MinerWorkerName miner={miner} />);
+
+    expect(screen.getByText("aa:bb:cc:dd:ee:ff")).toBeInTheDocument();
+    expect(screen.getByLabelText("Default worker name")).toBeInTheDocument();
+  });
+
+  it("renders explanatory tooltip content for the default worker name icon", () => {
+    const miner = createMockMiner({
+      macAddress: "aa:bb:cc:dd:ee:ff",
+      workerName: "aa:bb:cc:dd:ee:ff",
+    });
+
+    render(<MinerWorkerName miner={miner} />);
+
+    expect(screen.getByLabelText("Default worker name")).toBeInTheDocument();
+    expect(screen.getByText(defaultWorkerNameHelpText)).toBeInTheDocument();
+  });
+
+  it("does not render a default marker for a custom worker name", () => {
+    const miner = createMockMiner({
+      macAddress: "aa:bb:cc:dd:ee:ff",
+      workerName: "worker-01",
+    });
+
+    render(<MinerWorkerName miner={miner} />);
+
+    expect(screen.getByText("worker-01")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
+  });
+
+  it("renders a default marker for a MAC-shaped worker name when the MAC field is unavailable", () => {
+    const miner = createMockMiner({
+      macAddress: "",
+      workerName: "02:00:00:4E:FC:D5",
+    });
+
+    render(<MinerWorkerName miner={miner} />);
+
+    expect(screen.getByText("02:00:00:4E:FC:D5")).toBeInTheDocument();
+    expect(screen.getByLabelText("Default worker name")).toBeInTheDocument();
+  });
+
+  it("renders the inactive placeholder without a default marker when the worker name is empty", () => {
+    const miner = createMockMiner({
+      macAddress: "aa:bb:cc:dd:ee:ff",
+      workerName: "",
+    });
+
+    render(<MinerWorkerName miner={miner} />);
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
+  });
+
+  it("hides a MAC-derived worker name when authentication is required", () => {
+    const miner = createMockMiner({
+      macAddress: "",
+      workerName: "02:00:00:4E:FC:D5",
+      pairingStatus: PairingStatus.AUTHENTICATION_NEEDED,
+    });
+
+    const { container } = render(<MinerWorkerName miner={miner} />);
+
+    expect(container.textContent).toBe("");
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
+    expect(screen.queryByText("02:00:00:4E:FC:D5")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
+  });
+
+  it("keeps a non-default stored worker name visible when authentication is required", () => {
+    const miner = createMockMiner({
+      macAddress: "aa:bb:cc:dd:ee:ff",
+      workerName: "worker-01",
+      pairingStatus: PairingStatus.AUTHENTICATION_NEEDED,
+    });
+
+    render(<MinerWorkerName miner={miner} />);
+
+    expect(screen.getByText("worker-01")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
@@ -72,18 +72,6 @@ describe("MinerWorkerName", () => {
     expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
   });
 
-  it("renders a default marker for a MAC-shaped worker name when the MAC field is unavailable", () => {
-    const miner = createMockMiner({
-      macAddress: "",
-      workerName: "02:00:00:4E:FC:D5",
-    });
-
-    render(<MinerWorkerName miner={miner} />);
-
-    expect(screen.getByText("02:00:00:4E:FC:D5")).toBeInTheDocument();
-    expect(screen.getByLabelText("Default worker name")).toBeInTheDocument();
-  });
-
   it("renders the inactive placeholder without a default marker when the worker name is empty", () => {
     const miner = createMockMiner({
       macAddress: "aa:bb:cc:dd:ee:ff",
@@ -96,7 +84,7 @@ describe("MinerWorkerName", () => {
     expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
   });
 
-  it("hides a MAC-derived worker name when authentication is required", () => {
+  it("renders an empty cell when authentication is required", () => {
     const miner = createMockMiner({
       macAddress: "",
       workerName: "02:00:00:4E:FC:D5",
@@ -111,16 +99,17 @@ describe("MinerWorkerName", () => {
     expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
   });
 
-  it("keeps a non-default stored worker name visible when authentication is required", () => {
+  it("hides a non-default stored worker name when authentication is required", () => {
     const miner = createMockMiner({
       macAddress: "aa:bb:cc:dd:ee:ff",
       workerName: "worker-01",
       pairingStatus: PairingStatus.AUTHENTICATION_NEEDED,
     });
 
-    render(<MinerWorkerName miner={miner} />);
+    const { container } = render(<MinerWorkerName miner={miner} />);
 
-    expect(screen.getByText("worker-01")).toBeInTheDocument();
+    expect(container.textContent).toBe("");
+    expect(screen.queryByText("worker-01")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
@@ -33,9 +33,6 @@ function createMockMiner(overrides: Partial<MinerStateSnapshot> = {}): MinerStat
 }
 
 describe("MinerWorkerName", () => {
-  const defaultWorkerNameHelpText =
-    "Fleet uses the miner MAC address when it cannot read a worker name from the miner. Use Update worker names to change it.";
-
   it("renders a default marker when the worker name matches the MAC address", () => {
     const miner = createMockMiner({
       macAddress: "aa:bb:cc:dd:ee:ff",
@@ -58,7 +55,7 @@ describe("MinerWorkerName", () => {
     render(<MinerWorkerName miner={miner} />);
 
     expect(screen.getByLabelText("Default worker name")).toBeInTheDocument();
-    expect(screen.getByText(defaultWorkerNameHelpText)).toBeInTheDocument();
+    expect(screen.getByText(/Fleet uses the miner MAC address/)).toBeInTheDocument();
   });
 
   it("does not render a default marker for a custom worker name", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
@@ -46,6 +46,7 @@ describe("MinerWorkerName", () => {
 
     expect(screen.getByText("aa:bb:cc:dd:ee:ff")).toBeInTheDocument();
     expect(screen.getByLabelText("Default worker name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Default worker name")).toHaveAttribute("data-no-row-click");
   });
 
   it("renders explanatory tooltip content for the default worker name icon", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
@@ -22,20 +22,21 @@ const isDefaultWorkerName = (workerName: string, macAddress: string | undefined)
 };
 
 const MinerWorkerName = ({ miner }: MinerWorkerNameProps) => {
-  const normalizedWorkerName = miner.workerName?.trim() ?? "";
-  const isDefault = isDefaultWorkerName(normalizeWorkerName(miner.workerName), miner.macAddress);
+  const trimmedWorkerName = miner.workerName?.trim() ?? "";
+  const normalizedWorkerName = normalizeWorkerName(miner.workerName);
+  const isDefault = isDefaultWorkerName(normalizedWorkerName, miner.macAddress);
 
   if (miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED) {
-    return <span />;
+    return null;
   }
 
-  if (!normalizedWorkerName) {
+  if (!trimmedWorkerName) {
     return <span>{INACTIVE_PLACEHOLDER}</span>;
   }
 
   return (
     <span className="flex min-w-0 items-center gap-1.5">
-      <span className="min-w-0 truncate">{normalizedWorkerName}</span>
+      <span className="min-w-0 truncate">{trimmedWorkerName}</span>
       {isDefault ? (
         <span className="shrink-0 text-text-primary-50" aria-label="Default worker name" data-no-row-click>
           <Tooltip

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
@@ -12,26 +12,20 @@ type MinerWorkerNameProps = {
 
 const DEFAULT_WORKER_NAME_HELP_TEXT =
   "Fleet uses the miner MAC address when it cannot read a worker name from the miner. Use Update worker names to change it.";
-const MAC_ADDRESS_WORKER_NAME_PATTERN = /^(?:[0-9a-f]{2}:){5}[0-9a-f]{2}$/i;
 
 const normalizeWorkerName = (value: string | undefined) => value?.trim().toLowerCase() ?? "";
 
 const isDefaultWorkerName = (workerName: string, macAddress: string | undefined) => {
   const normalizedMacAddress = normalizeWorkerName(macAddress);
 
-  return (
-    workerName !== "" &&
-    ((normalizedMacAddress !== "" && workerName === normalizedMacAddress) ||
-      MAC_ADDRESS_WORKER_NAME_PATTERN.test(workerName))
-  );
+  return workerName !== "" && normalizedMacAddress !== "" && workerName === normalizedMacAddress;
 };
 
 const MinerWorkerName = ({ miner }: MinerWorkerNameProps) => {
   const normalizedWorkerName = miner.workerName?.trim() ?? "";
   const isDefault = isDefaultWorkerName(normalizeWorkerName(miner.workerName), miner.macAddress);
-  const shouldHideWorkerName = miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED && isDefault;
 
-  if (shouldHideWorkerName) {
+  if (miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED) {
     return <span />;
   }
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
@@ -1,14 +1,59 @@
 import { INACTIVE_PLACEHOLDER } from "./constants";
-import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import {
+  type MinerStateSnapshot,
+  PairingStatus,
+} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import Tooltip from "@/shared/components/Tooltip";
+import { positions } from "@/shared/constants";
 
 type MinerWorkerNameProps = {
   miner: MinerStateSnapshot;
 };
 
+const DEFAULT_WORKER_NAME_HELP_TEXT =
+  "Fleet uses the miner MAC address when it cannot read a worker name from the miner. Use Update worker names to change it.";
+const MAC_ADDRESS_WORKER_NAME_PATTERN = /^(?:[0-9a-f]{2}:){5}[0-9a-f]{2}$/i;
+
+const normalizeWorkerName = (value: string | undefined) => value?.trim().toLowerCase() ?? "";
+
+const isDefaultWorkerName = (workerName: string, macAddress: string | undefined) => {
+  const normalizedMacAddress = normalizeWorkerName(macAddress);
+
+  return (
+    workerName !== "" &&
+    ((normalizedMacAddress !== "" && workerName === normalizedMacAddress) ||
+      MAC_ADDRESS_WORKER_NAME_PATTERN.test(workerName))
+  );
+};
+
 const MinerWorkerName = ({ miner }: MinerWorkerNameProps) => {
   const normalizedWorkerName = miner.workerName?.trim() ?? "";
+  const isDefault = isDefaultWorkerName(normalizeWorkerName(miner.workerName), miner.macAddress);
+  const shouldHideWorkerName = miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED && isDefault;
 
-  return <span>{normalizedWorkerName || INACTIVE_PLACEHOLDER}</span>;
+  if (shouldHideWorkerName) {
+    return <span />;
+  }
+
+  if (!normalizedWorkerName) {
+    return <span>{INACTIVE_PLACEHOLDER}</span>;
+  }
+
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      <span className="min-w-0 truncate">{normalizedWorkerName}</span>
+      {isDefault ? (
+        <span className="shrink-0 text-text-primary-50" aria-label="Default worker name">
+          <Tooltip
+            body={DEFAULT_WORKER_NAME_HELP_TEXT}
+            position={positions["bottom left"]}
+            icon="info"
+            widthClassName="w-72"
+          />
+        </span>
+      ) : null}
+    </span>
+  );
 };
 
 export default MinerWorkerName;

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
@@ -37,7 +37,7 @@ const MinerWorkerName = ({ miner }: MinerWorkerNameProps) => {
     <span className="flex min-w-0 items-center gap-1.5">
       <span className="min-w-0 truncate">{normalizedWorkerName}</span>
       {isDefault ? (
-        <span className="shrink-0 text-text-primary-50" aria-label="Default worker name">
+        <span className="shrink-0 text-text-primary-50" aria-label="Default worker name" data-no-row-click>
           <Tooltip
             body={DEFAULT_WORKER_NAME_HELP_TEXT}
             position={positions["bottom left"]}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/minerColConfig.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/minerColConfig.tsx
@@ -59,7 +59,8 @@ const createMinerColConfig = ({
   },
   [minerCols.workerName]: {
     component: (device: DeviceListItem) => <MinerWorkerName miner={device.miner} />,
-    width: "w-[120px]",
+    width: "w-[176px]",
+    allowOverflow: true,
   },
   [minerCols.model]: {
     component: (device: DeviceListItem) => <MinerModel miner={device.miner} />,

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -482,6 +482,12 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
         const isExempt = columnsExemptFromDisabledStyling?.has(row) ?? false;
         const columnWidthClass = colConfig[row]?.width;
         const allowWrap = colConfig[row]?.allowWrap ?? false;
+        const allowOverflow = colConfig[row]?.allowOverflow ?? false;
+        const overflowClass = allowOverflow
+          ? "overflow-visible"
+          : allowWrap
+            ? "overflow-hidden"
+            : "truncate overflow-hidden";
         const content = colConfig[row]?.component
           ? colConfig[row].component(item, currentSelectedItems)
           : typeof item === "object" && item !== null && row in item
@@ -508,7 +514,7 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
           >
             <div
               className={clsx(
-                allowWrap ? "overflow-hidden" : "truncate overflow-hidden",
+                overflowClass,
                 columnIndex === 1 && stickyFirstColumn ? "py-3 pr-2 pl-4 phone:pl-2" : tdPaddingClassList,
                 applyColumnWidthsToCells ? "box-border w-full" : columnWidthClass,
                 {

--- a/client/src/shared/components/List/types.ts
+++ b/client/src/shared/components/List/types.ts
@@ -11,6 +11,7 @@ export type ColConfig<ListItem, ItemKey, ColKey extends string = keyof ListItem 
     component?: (item: ListItem, selectedItems: ItemKey[]) => ReactNode;
     width: string;
     allowWrap?: boolean;
+    allowOverflow?: boolean;
   };
 };
 


### PR DESCRIPTION
## Summary
- Clarify MAC-derived worker names by showing an info tooltip for paired miners using the default fallback
<img width="1298" height="263" alt="image" src="https://github.com/user-attachments/assets/b2e28f9a-d5fa-4adb-a1eb-55df0e8291fe" />

- Show an empty Worker name cell for authentication-required miners until Fleet can authenticate and read the value
<img width="1315" height="517" alt="image" src="https://github.com/user-attachments/assets/1db89389-db71-47ee-9796-5b338196823f" />

- Allow the worker-name tooltip to escape the table cell without changing other columns

## Test plan
- [ ] Confirm paired miners with MAC-derived worker names show the info tooltip in the Worker name column
- [ ] Confirm authentication-required miners show an empty Worker name cell
- [ ] Confirm custom worker names still render without the default tooltip

Closes #83