### PR TITLE
perf(reparent): bulk SQL + concurrency hardening (4/4)

### DIFF
--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
@@ -414,7 +414,10 @@ const ManageBuildingModal = ({
       // removed racks would otherwise hit request validation. Chunk
       // each phase into RPC-sized batches, dispatched sequentially
       // so a mid-chain failure stops the chain (handled by the catch
-      // blocks below).
+      // blocks below). Vacate-before-place is enforced across chunks
+      // by the two-pass dispatch below — the server only orders
+      // clear-then-place within a single RPC, so unassigns and cell-
+      // clears must all complete before any place runs.
       const RACKS_PER_RPC = 1000;
       const dispatch = async (racks: RackPlacementInput[], targetBuildingId?: bigint) => {
         if (racks.length === 0) return;
@@ -431,16 +434,30 @@ const ManageBuildingModal = ({
         }
       };
 
+      // Two-pass shape across chunks: vacate ALL cells before placing
+      // ANY rack at a new cell. The server's clear-then-place ordering
+      // only applies within a single AssignRacksToBuilding tx, so a
+      // >1000-rack save where chunk 2 still owns the cell chunk 1 is
+      // trying to claim would trip uk_device_set_rack_building_position.
+      // Partition the in-building bucket into:
+      //   - vacate entries (no aisle/position) — racks staying in the
+      //     building but clearing their cell.
+      //   - place entries (with aisle/position) — racks landing at a
+      //     specific cell. These can only run after every vacate above
+      //     (plus the unassign bucket) has committed.
+      const inBuildingVacate = inBuilding.filter((r) => r.aisleIndex === undefined || r.positionInAisle === undefined);
+      const inBuildingPlace = inBuilding.filter((r) => r.aisleIndex !== undefined && r.positionInAisle !== undefined);
+
       try {
-        // Serialize: unassign (vacate) before in-building (claim).
-        // Each AssignRacksToBuilding call has internal clear-before-
-        // place ordering inside its tx, but that doesn't protect
-        // across two separate calls. If rack A is being removed and
-        // rack B is being placed at A's former cell, the in-building
-        // call can hit the partial unique index before the unassign
-        // commits. dispatch short-circuits when the list is empty.
+        // Pass 1: all vacates (unassign bucket + in-building cell-
+        // clears). dispatch short-circuits when the list is empty.
         await dispatch(unassign, undefined);
-        await dispatch(inBuilding, building.id);
+        await dispatch(inBuildingVacate, building.id);
+
+        // Pass 2: all places. By now every cell that will be reused
+        // has been vacated, so no two writes collide on the partial
+        // unique index — even across >1000-rack chunked saves.
+        await dispatch(inBuildingPlace, building.id);
       } catch (err) {
         setErrorMsg(
           err instanceof Error ? `Failed to save rack positions: ${err.message}.` : "Failed to save rack positions.",

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
@@ -439,14 +439,43 @@ const ManageBuildingModal = ({
       // only applies within a single AssignRacksToBuilding tx, so a
       // >1000-rack save where chunk 2 still owns the cell chunk 1 is
       // trying to claim would trip uk_device_set_rack_building_position.
-      // Partition the in-building bucket into:
+      //
+      // Partition the in-building bucket so the vacate pass also clears
+      // the OLD cell of every mover — a rack with both a snapshot
+      // position and a new place entry. Otherwise a cross-chunk swap
+      // (rack A's new cell is rack B's old cell, A lands in chunk 1, B
+      // in chunk 2) would still trip the partial unique index because
+      // B's old cell wouldn't vacate until chunk 2 runs.
       //   - vacate entries (no aisle/position) — racks staying in the
-      //     building but clearing their cell.
+      //     building but clearing their cell. Includes:
+      //       * explicit cell-clear entries built above,
+      //       * a synthetic pre-place vacate for every mover, dedup'd by
+      //         rackId so we never send two clears for the same rack.
       //   - place entries (with aisle/position) — racks landing at a
       //     specific cell. These can only run after every vacate above
       //     (plus the unassign bucket) has committed.
-      const inBuildingVacate = inBuilding.filter((r) => r.aisleIndex === undefined || r.positionInAisle === undefined);
-      const inBuildingPlace = inBuilding.filter((r) => r.aisleIndex !== undefined && r.positionInAisle !== undefined);
+      const inBuildingVacate: RackPlacementInput[] = [];
+      const inBuildingPlace: RackPlacementInput[] = [];
+      const seenVacate = new Set<string>();
+      for (const entry of inBuilding) {
+        const idStr = entry.rackId.toString();
+        const prior = initial.get(idStr) ?? "missing";
+        const wasPlaced = prior !== "unplaced" && prior !== "missing";
+
+        if (entry.aisleIndex !== undefined && entry.positionInAisle !== undefined) {
+          // Mover (had a prior cell) → schedule a pre-place vacate so
+          // its old cell is free before any placement chunk runs.
+          if (wasPlaced && !seenVacate.has(idStr)) {
+            inBuildingVacate.push({ rackId: entry.rackId });
+            seenVacate.add(idStr);
+          }
+          inBuildingPlace.push(entry);
+        } else if (!seenVacate.has(idStr)) {
+          // Already a cell-clear-in-place entry.
+          inBuildingVacate.push({ rackId: entry.rackId });
+          seenVacate.add(idStr);
+        }
+      }
 
       try {
         // Pass 1: all vacates (unassign bucket + in-building cell-

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
@@ -337,24 +337,20 @@ const ManageBuildingModal = ({
   );
 
   // Save: walk activeAssignments, diff against the load-time snapshot, and
-  // fire AssignRacksToBuilding in two phases:
+  // fire AssignRacksToBuilding once per target building bucket.
   //
-  //   Phase 1 (vacate): every rack whose placement is changing AND that was
-  //   previously placed sends a "clear position" write first (same building,
-  //   no aisle/position). Removed-from-building racks unassign in a
-  //   separate call (different target_building_id). This frees every
-  //   (building, aisle, position) tuple that will be re-used in phase 2
-  //   BEFORE any placement write runs.
+  // All racks staying in this building (placements, unplacements,
+  // swaps, "move into occupied cell") ship as a single mixed batch.
+  // The server's AssignRacksToBuilding transaction now runs a two-pass
+  // write internally — pass 1 clears every requested rack's cell, then
+  // pass 2 writes the new (aisle, position) values — so the partial
+  // unique index uk_device_set_rack_building_position can't collide
+  // mid-batch. That removes the old client-side vacate-then-place
+  // split (and its "retry to finish saving" partial-failure path).
   //
-  //   Phase 2 (place): every rack with a new placement target writes its
-  //   final (aisle, position). Because phase 1 already cleared every cell
-  //   that's about to be re-used, swaps and "move into occupied cell" cases
-  //   no longer collide on the uk_device_set_rack_building_position partial
-  //   unique index.
-  //
-  // Each phase issues at most two bulk calls (one per target building_id
-  // bucket: this building, or unassigned). Layout writes live in
-  // BuildingSettingsModal.
+  // Racks removed from this building go in a second call with
+  // targetBuildingId=undefined since they need a different building
+  // bucket. Layout writes live in BuildingSettingsModal.
   const handleSave = useCallback(async () => {
     if (savingRef.current) return;
     savingRef.current = true;
@@ -364,8 +360,7 @@ const ManageBuildingModal = ({
       const initial = initialPlacementRef.current;
       const currentIds = new Set(entries.map((e) => e.rackId.toString()));
 
-      const vacateInBuilding: RackPlacementInput[] = [];
-      const placeInBuilding: RackPlacementInput[] = [];
+      const inBuilding: RackPlacementInput[] = [];
       const unassign: RackPlacementInput[] = [];
 
       for (const entry of entries) {
@@ -380,38 +375,34 @@ const ManageBuildingModal = ({
         const prior = initial.get(idStr) ?? "missing";
         if (prior === next) continue;
 
-        // If the rack was previously placed, vacate its old cell first.
-        // Sending the same building with no aisle/position clears position
-        // without touching membership.
-        if (prior !== "unplaced" && prior !== "missing") {
-          vacateInBuilding.push({ rackId: entry.rackId });
-        }
-
-        // Phase 2: write the new state.
+        // Single mixed batch.
         //   - placedKey present → place at the new (aisle, position).
+        //     Covers both first-time placement and moves; the server's
+        //     pass-1 clear handles any prior occupant inside the batch.
+        //   - placedKey absent + prior previously placed → send a
+        //     member-only entry. The server NULLs the rack's cell in
+        //     pass 1 (no pass-2 write because no position is supplied).
         //   - placedKey absent + prior === "missing" → rack is new to
         //     the working set with no chosen cell yet. Send a member-
         //     only assign so the BE links the rack to this building
         //     even without a position. Without this branch, racks
         //     added via Manage racks but never dragged to a cell
         //     silently drop on save.
-        //   - placedKey absent + prior was placed → already handled
-        //     by the phase-1 vacate above, which clears the cell.
         if (placedKey) {
           const { aisle, position } = parseCellKey(placedKey);
-          placeInBuilding.push({
+          inBuilding.push({
             rackId: entry.rackId,
             aisleIndex: aisle,
             positionInAisle: position,
           });
-        } else if (prior === "missing") {
-          placeInBuilding.push({ rackId: entry.rackId });
+        } else {
+          inBuilding.push({ rackId: entry.rackId });
         }
       }
 
-      // Racks removed from this building (in snapshot, not in entries) need
-      // an explicit unassign. Land them in phase 1 so their cells free up
-      // before any phase-2 placement targets them.
+      // Racks removed from this building (in snapshot, not in entries)
+      // need an explicit unassign — different target building bucket so
+      // they can't ride the in-building batch.
       for (const idStr of initial.keys()) {
         if (currentIds.has(idStr)) continue;
         unassign.push({ rackId: BigInt(idStr) });
@@ -441,23 +432,18 @@ const ManageBuildingModal = ({
       };
 
       try {
-        await Promise.all([dispatch(vacateInBuilding, building.id), dispatch(unassign, undefined)]);
+        // Serialize: unassign (vacate) before in-building (claim).
+        // Each AssignRacksToBuilding call has internal clear-before-
+        // place ordering inside its tx, but that doesn't protect
+        // across two separate calls. If rack A is being removed and
+        // rack B is being placed at A's former cell, the in-building
+        // call can hit the partial unique index before the unassign
+        // commits. dispatch short-circuits when the list is empty.
+        await dispatch(unassign, undefined);
+        await dispatch(inBuilding, building.id);
       } catch (err) {
         setErrorMsg(
-          err instanceof Error
-            ? `Failed to clear previous rack positions: ${err.message}. No new positions were written — retry to apply your changes.`
-            : "Failed to clear previous rack positions.",
-        );
-        return;
-      }
-
-      try {
-        await dispatch(placeInBuilding, building.id);
-      } catch (err) {
-        setErrorMsg(
-          err instanceof Error
-            ? `Failed to apply new rack positions: ${err.message}. Some cells may now be empty — retry to finish saving.`
-            : "Failed to apply new rack positions.",
+          err instanceof Error ? `Failed to save rack positions: ${err.message}.` : "Failed to save rack positions.",
         );
         return;
       }

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
@@ -419,6 +419,11 @@ const ManageBuildingModal = ({
       // clear-then-place within a single RPC, so unassigns and cell-
       // clears must all complete before any place runs.
       const RACKS_PER_RPC = 1000;
+      // Tracks whether any chunk has committed so the catch below can
+      // distinguish "nothing landed" from "partial commit" — operator
+      // needs to know to refresh before retrying when chunks N..M ran
+      // before chunk N+1 failed.
+      let savedAtLeastOne = false;
       const dispatch = async (racks: RackPlacementInput[], targetBuildingId?: bigint) => {
         if (racks.length === 0) return;
         for (let i = 0; i < racks.length; i += RACKS_PER_RPC) {
@@ -431,6 +436,7 @@ const ManageBuildingModal = ({
               onError: (msg) => reject(new Error(msg)),
             });
           });
+          savedAtLeastOne = true;
         }
       };
 
@@ -488,9 +494,14 @@ const ManageBuildingModal = ({
         // unique index — even across >1000-rack chunked saves.
         await dispatch(inBuildingPlace, building.id);
       } catch (err) {
-        setErrorMsg(
-          err instanceof Error ? `Failed to save rack positions: ${err.message}.` : "Failed to save rack positions.",
-        );
+        const detail = err instanceof Error ? err.message : "Failed to save rack positions";
+        if (savedAtLeastOne) {
+          setErrorMsg(
+            `${detail}. Some changes were saved before the error — refresh the building view to see the current state, then retry to apply the remaining changes.`,
+          );
+        } else {
+          setErrorMsg(`Failed to save rack positions: ${detail}.`);
+        }
         return;
       }
 

--- a/server/generated/sqlc/building.sql.go
+++ b/server/generated/sqlc/building.sql.go
@@ -40,6 +40,34 @@ func (q *Queries) AssignBuildingToSite(ctx context.Context, arg AssignBuildingTo
 	return result.RowsAffected()
 }
 
+const assignBuildingsToSiteBulk = `-- name: AssignBuildingsToSiteBulk :execrows
+UPDATE building
+SET site_id    = $1,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = ANY($2::bigint[])
+  AND org_id = $3
+  AND deleted_at IS NULL
+`
+
+type AssignBuildingsToSiteBulkParams struct {
+	SiteID      sql.NullInt64
+	BuildingIds []int64
+	OrgID       int64
+}
+
+// Bulk variant of AssignBuildingToSite. Updates building.site_id for
+// every building in @building_ids in one statement. Caller is
+// expected to have row-locked each building first (canonical lock
+// order: site → buildings). Returns the row count of buildings
+// actually moved (skips soft-deleted rows).
+func (q *Queries) AssignBuildingsToSiteBulk(ctx context.Context, arg AssignBuildingsToSiteBulkParams) (int64, error) {
+	result, err := q.exec(ctx, q.assignBuildingsToSiteBulkStmt, assignBuildingsToSiteBulk, arg.SiteID, pq.Array(arg.BuildingIds), arg.OrgID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const buildingBelongsToOrg = `-- name: BuildingBelongsToOrg :one
 SELECT EXISTS(
     SELECT 1 FROM building
@@ -498,6 +526,74 @@ func (q *Queries) SetRackBuildingPosition(ctx context.Context, arg SetRackBuildi
 		arg.PositionInAisle,
 		arg.RackID,
 		arg.OrgID,
+	)
+	return err
+}
+
+const setRackBuildingPositionBulkClear = `-- name: SetRackBuildingPositionBulkClear :exec
+UPDATE device_set_rack
+SET aisle_index = NULL,
+    position_in_aisle = NULL
+WHERE device_set_id = ANY($1::bigint[])
+  AND org_id = $2
+`
+
+type SetRackBuildingPositionBulkClearParams struct {
+	RackIds []int64
+	OrgID   int64
+}
+
+// Bulk variant of SetRackBuildingPosition that nulls (aisle_index,
+// position_in_aisle) for every rack in @rack_ids. Used by
+// AssignRacksToBuilding's pass-1 vacate so every rack in the batch
+// holds NULL position before pass-2 reclaims cells. Mirrors the
+// single-row query's intentional no-touch on building_id —
+// UpdateRackPlacement already settled that.
+func (q *Queries) SetRackBuildingPositionBulkClear(ctx context.Context, arg SetRackBuildingPositionBulkClearParams) error {
+	_, err := q.exec(ctx, q.setRackBuildingPositionBulkClearStmt, setRackBuildingPositionBulkClear, pq.Array(arg.RackIds), arg.OrgID)
+	return err
+}
+
+const setRackBuildingPositionBulkPlace = `-- name: SetRackBuildingPositionBulkPlace :exec
+UPDATE device_set_rack dsr
+SET aisle_index = u.aisle_index,
+    position_in_aisle = u.position_in_aisle
+FROM (
+    SELECT
+        rack_ids[i]            AS rack_id,
+        aisle_indexes[i]       AS aisle_index,
+        position_in_aisles[i]  AS position_in_aisle
+    FROM (
+        SELECT
+            $2::bigint[]          AS rack_ids,
+            $3::int[]        AS aisle_indexes,
+            $4::int[]   AS position_in_aisles
+    ) arrs
+    CROSS JOIN generate_subscripts(arrs.rack_ids, 1) AS i
+) AS u
+WHERE dsr.device_set_id = u.rack_id
+  AND dsr.org_id = $1
+`
+
+type SetRackBuildingPositionBulkPlaceParams struct {
+	OrgID            int64
+	RackIds          []int64
+	AisleIndexes     []int32
+	PositionInAisles []int32
+}
+
+// Bulk variant of SetRackBuildingPosition that writes per-rack
+// (aisle_index, position_in_aisle) via parallel arrays joined on
+// ordinal position. Used by AssignRacksToBuilding's pass-2 after
+// pass-1 has vacated every cell touched by the batch. Arrays must be
+// the same length and parallel-aligned with @rack_ids; callers that
+// have a "place nothing" pass-2 should skip the query entirely.
+func (q *Queries) SetRackBuildingPositionBulkPlace(ctx context.Context, arg SetRackBuildingPositionBulkPlaceParams) error {
+	_, err := q.exec(ctx, q.setRackBuildingPositionBulkPlaceStmt, setRackBuildingPositionBulkPlace,
+		arg.OrgID,
+		pq.Array(arg.RackIds),
+		pq.Array(arg.AisleIndexes),
+		pq.Array(arg.PositionInAisles),
 	)
 	return err
 }

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -42,6 +42,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.assignBuildingToSiteStmt, err = db.PrepareContext(ctx, assignBuildingToSite); err != nil {
 		return nil, fmt.Errorf("error preparing query AssignBuildingToSite: %w", err)
 	}
+	if q.assignBuildingsToSiteBulkStmt, err = db.PrepareContext(ctx, assignBuildingsToSiteBulk); err != nil {
+		return nil, fmt.Errorf("error preparing query AssignBuildingsToSiteBulk: %w", err)
+	}
 	if q.assignDevicesToSiteStmt, err = db.PrepareContext(ctx, assignDevicesToSite); err != nil {
 		return nil, fmt.Errorf("error preparing query AssignDevicesToSite: %w", err)
 	}
@@ -80,6 +83,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.cascadeRackDeviceSitesStmt, err = db.PrepareContext(ctx, cascadeRackDeviceSites); err != nil {
 		return nil, fmt.Errorf("error preparing query CascadeRackDeviceSites: %w", err)
+	}
+	if q.cascadeRackDeviceSitesBulkStmt, err = db.PrepareContext(ctx, cascadeRackDeviceSitesBulk); err != nil {
+		return nil, fmt.Errorf("error preparing query CascadeRackDeviceSitesBulk: %w", err)
 	}
 	if q.claimMessageForProcessingStmt, err = db.PrepareContext(ctx, claimMessageForProcessing); err != nil {
 		return nil, fmt.Errorf("error preparing query ClaimMessageForProcessing: %w", err)
@@ -822,6 +828,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.lockRackPlacementForWriteStmt, err = db.PrepareContext(ctx, lockRackPlacementForWrite); err != nil {
 		return nil, fmt.Errorf("error preparing query LockRackPlacementForWrite: %w", err)
 	}
+	if q.lockRacksForReparentStmt, err = db.PrepareContext(ctx, lockRacksForReparent); err != nil {
+		return nil, fmt.Errorf("error preparing query LockRacksForReparent: %w", err)
+	}
 	if q.lockSchedulePriorityStmt, err = db.PrepareContext(ctx, lockSchedulePriority); err != nil {
 		return nil, fmt.Errorf("error preparing query LockSchedulePriority: %w", err)
 	}
@@ -870,8 +879,14 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.reassignDevicesUnderBuildingStmt, err = db.PrepareContext(ctx, reassignDevicesUnderBuilding); err != nil {
 		return nil, fmt.Errorf("error preparing query ReassignDevicesUnderBuilding: %w", err)
 	}
+	if q.reassignDevicesUnderBuildingsBulkStmt, err = db.PrepareContext(ctx, reassignDevicesUnderBuildingsBulk); err != nil {
+		return nil, fmt.Errorf("error preparing query ReassignDevicesUnderBuildingsBulk: %w", err)
+	}
 	if q.reassignRacksUnderBuildingStmt, err = db.PrepareContext(ctx, reassignRacksUnderBuilding); err != nil {
 		return nil, fmt.Errorf("error preparing query ReassignRacksUnderBuilding: %w", err)
+	}
+	if q.reassignRacksUnderBuildingsBulkStmt, err = db.PrepareContext(ctx, reassignRacksUnderBuildingsBulk); err != nil {
+		return nil, fmt.Errorf("error preparing query ReassignRacksUnderBuildingsBulk: %w", err)
 	}
 	if q.removeAllDevicesFromDeviceSetStmt, err = db.PrepareContext(ctx, removeAllDevicesFromDeviceSet); err != nil {
 		return nil, fmt.Errorf("error preparing query RemoveAllDevicesFromDeviceSet: %w", err)
@@ -935,6 +950,12 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.setRackBuildingPositionStmt, err = db.PrepareContext(ctx, setRackBuildingPosition); err != nil {
 		return nil, fmt.Errorf("error preparing query SetRackBuildingPosition: %w", err)
+	}
+	if q.setRackBuildingPositionBulkClearStmt, err = db.PrepareContext(ctx, setRackBuildingPositionBulkClear); err != nil {
+		return nil, fmt.Errorf("error preparing query SetRackBuildingPositionBulkClear: %w", err)
+	}
+	if q.setRackBuildingPositionBulkPlaceStmt, err = db.PrepareContext(ctx, setRackBuildingPositionBulkPlace); err != nil {
+		return nil, fmt.Errorf("error preparing query SetRackBuildingPositionBulkPlace: %w", err)
 	}
 	if q.setRackSlotPositionStmt, err = db.PrepareContext(ctx, setRackSlotPosition); err != nil {
 		return nil, fmt.Errorf("error preparing query SetRackSlotPosition: %w", err)
@@ -1125,6 +1146,12 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.updateRackPlacementStmt, err = db.PrepareContext(ctx, updateRackPlacement); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateRackPlacement: %w", err)
 	}
+	if q.updateRackPlacementBulkForBuildingStmt, err = db.PrepareContext(ctx, updateRackPlacementBulkForBuilding); err != nil {
+		return nil, fmt.Errorf("error preparing query UpdateRackPlacementBulkForBuilding: %w", err)
+	}
+	if q.updateRackPlacementBulkForSiteStmt, err = db.PrepareContext(ctx, updateRackPlacementBulkForSite); err != nil {
+		return nil, fmt.Errorf("error preparing query UpdateRackPlacementBulkForSite: %w", err)
+	}
 	if q.updateRoleStmt, err = db.PrepareContext(ctx, updateRole); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateRole: %w", err)
 	}
@@ -1229,6 +1256,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing assignBuildingToSiteStmt: %w", cerr)
 		}
 	}
+	if q.assignBuildingsToSiteBulkStmt != nil {
+		if cerr := q.assignBuildingsToSiteBulkStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing assignBuildingsToSiteBulkStmt: %w", cerr)
+		}
+	}
 	if q.assignDevicesToSiteStmt != nil {
 		if cerr := q.assignDevicesToSiteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing assignDevicesToSiteStmt: %w", cerr)
@@ -1292,6 +1324,11 @@ func (q *Queries) Close() error {
 	if q.cascadeRackDeviceSitesStmt != nil {
 		if cerr := q.cascadeRackDeviceSitesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing cascadeRackDeviceSitesStmt: %w", cerr)
+		}
+	}
+	if q.cascadeRackDeviceSitesBulkStmt != nil {
+		if cerr := q.cascadeRackDeviceSitesBulkStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing cascadeRackDeviceSitesBulkStmt: %w", cerr)
 		}
 	}
 	if q.claimMessageForProcessingStmt != nil {
@@ -2529,6 +2566,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing lockRackPlacementForWriteStmt: %w", cerr)
 		}
 	}
+	if q.lockRacksForReparentStmt != nil {
+		if cerr := q.lockRacksForReparentStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing lockRacksForReparentStmt: %w", cerr)
+		}
+	}
 	if q.lockSchedulePriorityStmt != nil {
 		if cerr := q.lockSchedulePriorityStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing lockSchedulePriorityStmt: %w", cerr)
@@ -2609,9 +2651,19 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing reassignDevicesUnderBuildingStmt: %w", cerr)
 		}
 	}
+	if q.reassignDevicesUnderBuildingsBulkStmt != nil {
+		if cerr := q.reassignDevicesUnderBuildingsBulkStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing reassignDevicesUnderBuildingsBulkStmt: %w", cerr)
+		}
+	}
 	if q.reassignRacksUnderBuildingStmt != nil {
 		if cerr := q.reassignRacksUnderBuildingStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing reassignRacksUnderBuildingStmt: %w", cerr)
+		}
+	}
+	if q.reassignRacksUnderBuildingsBulkStmt != nil {
+		if cerr := q.reassignRacksUnderBuildingsBulkStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing reassignRacksUnderBuildingsBulkStmt: %w", cerr)
 		}
 	}
 	if q.removeAllDevicesFromDeviceSetStmt != nil {
@@ -2717,6 +2769,16 @@ func (q *Queries) Close() error {
 	if q.setRackBuildingPositionStmt != nil {
 		if cerr := q.setRackBuildingPositionStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing setRackBuildingPositionStmt: %w", cerr)
+		}
+	}
+	if q.setRackBuildingPositionBulkClearStmt != nil {
+		if cerr := q.setRackBuildingPositionBulkClearStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setRackBuildingPositionBulkClearStmt: %w", cerr)
+		}
+	}
+	if q.setRackBuildingPositionBulkPlaceStmt != nil {
+		if cerr := q.setRackBuildingPositionBulkPlaceStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setRackBuildingPositionBulkPlaceStmt: %w", cerr)
 		}
 	}
 	if q.setRackSlotPositionStmt != nil {
@@ -3034,6 +3096,16 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing updateRackPlacementStmt: %w", cerr)
 		}
 	}
+	if q.updateRackPlacementBulkForBuildingStmt != nil {
+		if cerr := q.updateRackPlacementBulkForBuildingStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing updateRackPlacementBulkForBuildingStmt: %w", cerr)
+		}
+	}
+	if q.updateRackPlacementBulkForSiteStmt != nil {
+		if cerr := q.updateRackPlacementBulkForSiteStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing updateRackPlacementBulkForSiteStmt: %w", cerr)
+		}
+	}
 	if q.updateRoleStmt != nil {
 		if cerr := q.updateRoleStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateRoleStmt: %w", cerr)
@@ -3194,6 +3266,7 @@ type Queries struct {
 	adminTerminateCurtailmentEventStmt                    *sql.Stmt
 	allDevicesBelongToOrgStmt                             *sql.Stmt
 	assignBuildingToSiteStmt                              *sql.Stmt
+	assignBuildingsToSiteBulkStmt                         *sql.Stmt
 	assignDevicesToSiteStmt                               *sql.Stmt
 	assignPermissionToRoleStmt                            *sql.Stmt
 	assignRoleStmt                                        *sql.Stmt
@@ -3207,6 +3280,7 @@ type Queries struct {
 	cancelPendingEnrollmentStmt                           *sql.Stmt
 	cascadeAddedDeviceSitesStmt                           *sql.Stmt
 	cascadeRackDeviceSitesStmt                            *sql.Stmt
+	cascadeRackDeviceSitesBulkStmt                        *sql.Stmt
 	claimMessageForProcessingStmt                         *sql.Stmt
 	clearCurtailmentAutomationActiveEventStmt             *sql.Stmt
 	clearRackPlacementForSoftDeleteStmt                   *sql.Stmt
@@ -3454,6 +3528,7 @@ type Queries struct {
 	lockDevicesForReassignStmt                            *sql.Stmt
 	lockFleetNodeByIDStmt                                 *sql.Stmt
 	lockRackPlacementForWriteStmt                         *sql.Stmt
+	lockRacksForReparentStmt                              *sql.Stmt
 	lockSchedulePriorityStmt                              *sql.Stmt
 	lockSiteForWriteStmt                                  *sql.Stmt
 	markCommandBatchFinishedStmt                          *sql.Stmt
@@ -3470,7 +3545,9 @@ type Queries struct {
 	reapStuckFirmwareUpdateMessagesStmt                   *sql.Stmt
 	reapStuckProcessingMessagesStmt                       *sql.Stmt
 	reassignDevicesUnderBuildingStmt                      *sql.Stmt
+	reassignDevicesUnderBuildingsBulkStmt                 *sql.Stmt
 	reassignRacksUnderBuildingStmt                        *sql.Stmt
+	reassignRacksUnderBuildingsBulkStmt                   *sql.Stmt
 	removeAllDevicesFromDeviceSetStmt                     *sql.Stmt
 	removeDevicesFromAnyRackStmt                          *sql.Stmt
 	removeDevicesFromDeviceSetStmt                        *sql.Stmt
@@ -3492,6 +3569,8 @@ type Queries struct {
 	setFleetNodeEnrollmentStatusStmt                      *sql.Stmt
 	setMQTTSourceConfigEnabledStmt                        *sql.Stmt
 	setRackBuildingPositionStmt                           *sql.Stmt
+	setRackBuildingPositionBulkClearStmt                  *sql.Stmt
+	setRackBuildingPositionBulkPlaceStmt                  *sql.Stmt
 	setRackSlotPositionStmt                               *sql.Stmt
 	setSchedulePrioritiesStmt                             *sql.Stmt
 	setScheduleRunningStmt                                *sql.Stmt
@@ -3555,6 +3634,8 @@ type Queries struct {
 	updatePoolStmt                                        *sql.Stmt
 	updateRackInfoStmt                                    *sql.Stmt
 	updateRackPlacementStmt                               *sql.Stmt
+	updateRackPlacementBulkForBuildingStmt                *sql.Stmt
+	updateRackPlacementBulkForSiteStmt                    *sql.Stmt
 	updateRoleStmt                                        *sql.Stmt
 	updateScheduleStmt                                    *sql.Stmt
 	updateScheduleAfterRunStmt                            *sql.Stmt
@@ -3590,6 +3671,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		adminTerminateCurtailmentEventStmt:                    q.adminTerminateCurtailmentEventStmt,
 		allDevicesBelongToOrgStmt:                             q.allDevicesBelongToOrgStmt,
 		assignBuildingToSiteStmt:                              q.assignBuildingToSiteStmt,
+		assignBuildingsToSiteBulkStmt:                         q.assignBuildingsToSiteBulkStmt,
 		assignDevicesToSiteStmt:                               q.assignDevicesToSiteStmt,
 		assignPermissionToRoleStmt:                            q.assignPermissionToRoleStmt,
 		assignRoleStmt:                                        q.assignRoleStmt,
@@ -3603,6 +3685,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		cancelPendingEnrollmentStmt:                           q.cancelPendingEnrollmentStmt,
 		cascadeAddedDeviceSitesStmt:                           q.cascadeAddedDeviceSitesStmt,
 		cascadeRackDeviceSitesStmt:                            q.cascadeRackDeviceSitesStmt,
+		cascadeRackDeviceSitesBulkStmt:                        q.cascadeRackDeviceSitesBulkStmt,
 		claimMessageForProcessingStmt:                         q.claimMessageForProcessingStmt,
 		clearCurtailmentAutomationActiveEventStmt:             q.clearCurtailmentAutomationActiveEventStmt,
 		clearRackPlacementForSoftDeleteStmt:                   q.clearRackPlacementForSoftDeleteStmt,
@@ -3850,6 +3933,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		lockDevicesForReassignStmt:                            q.lockDevicesForReassignStmt,
 		lockFleetNodeByIDStmt:                                 q.lockFleetNodeByIDStmt,
 		lockRackPlacementForWriteStmt:                         q.lockRackPlacementForWriteStmt,
+		lockRacksForReparentStmt:                              q.lockRacksForReparentStmt,
 		lockSchedulePriorityStmt:                              q.lockSchedulePriorityStmt,
 		lockSiteForWriteStmt:                                  q.lockSiteForWriteStmt,
 		markCommandBatchFinishedStmt:                          q.markCommandBatchFinishedStmt,
@@ -3866,7 +3950,9 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		reapStuckFirmwareUpdateMessagesStmt:                   q.reapStuckFirmwareUpdateMessagesStmt,
 		reapStuckProcessingMessagesStmt:                       q.reapStuckProcessingMessagesStmt,
 		reassignDevicesUnderBuildingStmt:                      q.reassignDevicesUnderBuildingStmt,
+		reassignDevicesUnderBuildingsBulkStmt:                 q.reassignDevicesUnderBuildingsBulkStmt,
 		reassignRacksUnderBuildingStmt:                        q.reassignRacksUnderBuildingStmt,
+		reassignRacksUnderBuildingsBulkStmt:                   q.reassignRacksUnderBuildingsBulkStmt,
 		removeAllDevicesFromDeviceSetStmt:                     q.removeAllDevicesFromDeviceSetStmt,
 		removeDevicesFromAnyRackStmt:                          q.removeDevicesFromAnyRackStmt,
 		removeDevicesFromDeviceSetStmt:                        q.removeDevicesFromDeviceSetStmt,
@@ -3888,6 +3974,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		setFleetNodeEnrollmentStatusStmt:                      q.setFleetNodeEnrollmentStatusStmt,
 		setMQTTSourceConfigEnabledStmt:                        q.setMQTTSourceConfigEnabledStmt,
 		setRackBuildingPositionStmt:                           q.setRackBuildingPositionStmt,
+		setRackBuildingPositionBulkClearStmt:                  q.setRackBuildingPositionBulkClearStmt,
+		setRackBuildingPositionBulkPlaceStmt:                  q.setRackBuildingPositionBulkPlaceStmt,
 		setRackSlotPositionStmt:                               q.setRackSlotPositionStmt,
 		setSchedulePrioritiesStmt:                             q.setSchedulePrioritiesStmt,
 		setScheduleRunningStmt:                                q.setScheduleRunningStmt,
@@ -3951,6 +4039,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		updatePoolStmt:                                        q.updatePoolStmt,
 		updateRackInfoStmt:                                    q.updateRackInfoStmt,
 		updateRackPlacementStmt:                               q.updateRackPlacementStmt,
+		updateRackPlacementBulkForBuildingStmt:                q.updateRackPlacementBulkForBuildingStmt,
+		updateRackPlacementBulkForSiteStmt:                    q.updateRackPlacementBulkForSiteStmt,
 		updateRoleStmt:                                        q.updateRoleStmt,
 		updateScheduleStmt:                                    q.updateScheduleStmt,
 		updateScheduleAfterRunStmt:                            q.updateScheduleAfterRunStmt,

--- a/server/generated/sqlc/device_set.sql.go
+++ b/server/generated/sqlc/device_set.sql.go
@@ -1528,7 +1528,7 @@ func (q *Queries) UpdateRackPlacement(ctx context.Context, arg UpdateRackPlaceme
 	return err
 }
 
-const updateRackPlacementBulkForBuilding = `-- name: UpdateRackPlacementBulkForBuilding :exec
+const updateRackPlacementBulkForBuilding = `-- name: UpdateRackPlacementBulkForBuilding :execrows
 UPDATE device_set_rack dsr
 SET site_id = CASE
         WHEN $1::bigint IS NULL THEN dsr.site_id
@@ -1584,14 +1584,22 @@ type UpdateRackPlacementBulkForBuildingParams struct {
 //     into the NULLS LAST bucket like the per-row path produced.
 //   - aisle_index / position_in_aisle clear when building_id changes,
 //     matching the single-row CASE.
-func (q *Queries) UpdateRackPlacementBulkForBuilding(ctx context.Context, arg UpdateRackPlacementBulkForBuildingParams) error {
-	_, err := q.exec(ctx, q.updateRackPlacementBulkForBuildingStmt, updateRackPlacementBulkForBuilding,
+//
+// Returns the number of affected rows so the service layer can verify
+// every requested rack id resolved to an actual row (defense-in-depth
+// against cross-org or stale ids slipping past the per-rack lock
+// pre-pass).
+func (q *Queries) UpdateRackPlacementBulkForBuilding(ctx context.Context, arg UpdateRackPlacementBulkForBuildingParams) (int64, error) {
+	result, err := q.exec(ctx, q.updateRackPlacementBulkForBuildingStmt, updateRackPlacementBulkForBuilding,
 		arg.TargetBuildingID,
 		arg.TargetSiteID,
 		pq.Array(arg.RackIds),
 		arg.OrgID,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const updateRackPlacementBulkForSite = `-- name: UpdateRackPlacementBulkForSite :exec

--- a/server/generated/sqlc/device_set.sql.go
+++ b/server/generated/sqlc/device_set.sql.go
@@ -1538,7 +1538,7 @@ SET site_id = CASE
     zone = CASE
         WHEN dsr.building_id IS NOT NULL
              AND dsr.building_id IS DISTINCT FROM $1::bigint
-        THEN ''
+        THEN NULL
         ELSE dsr.zone
     END,
     aisle_index = CASE
@@ -1576,9 +1576,12 @@ type UpdateRackPlacementBulkForBuildingParams struct {
 //   - When @target_building_id IS NULL (unassign branch), each rack
 //     keeps its current site_id (no cascade fires later). Otherwise
 //     every rack is stamped with @target_site_id.
-//   - Zone clears to ” for any rack that had a building and is
+//   - Zone clears to NULL for any rack that had a building and is
 //     transitioning to a different (or NULL) building. Racks staying in
-//     the same building preserve their zone.
+//     the same building preserve their zone. NULL (not ”) is
+//     load-bearing: collection_sort.go orders by zone NULLS LAST, so an
+//     empty-string zone would sort as a real zone instead of falling
+//     into the NULLS LAST bucket like the per-row path produced.
 //   - aisle_index / position_in_aisle clear when building_id changes,
 //     matching the single-row CASE.
 func (q *Queries) UpdateRackPlacementBulkForBuilding(ctx context.Context, arg UpdateRackPlacementBulkForBuildingParams) error {
@@ -1595,7 +1598,10 @@ const updateRackPlacementBulkForSite = `-- name: UpdateRackPlacementBulkForSite 
 UPDATE device_set_rack dsr
 SET site_id           = $1::bigint,
     building_id       = NULL,
-    zone              = '',
+    zone              = CASE
+        WHEN dsr.building_id IS NOT NULL THEN NULL
+        ELSE dsr.zone
+    END,
     aisle_index       = NULL,
     position_in_aisle = NULL
 WHERE dsr.device_set_id = ANY($2::bigint[])
@@ -1615,12 +1621,19 @@ type UpdateRackPlacementBulkForSiteParams struct {
 }
 
 // Bulk variant used by AssignRacksToSite. Stamps every rack in
-// @rack_ids with the target site, clears building_id and zone (because
-// a building belongs to one site, the rack's building membership is
-// invalidated by any site transition), and clears the grid placement
-// as a downstream effect of building_id changing. Caller is expected
-// to only pass racks whose current site differs from the target so the
+// @rack_ids with the target site, clears building_id (because a
+// building belongs to one site, the rack's building membership is
+// invalidated by any site transition), and clears grid placement as a
+// downstream effect of building_id changing. Caller is expected to
+// only pass racks whose current site differs from the target so the
 // response counts stay accurate.
+//
+// Zone is cleared (to NULL) only when the rack was actually in a
+// building before — racks with building_id IS NULL keep their zone,
+// matching the old per-rack path. ListRackZoneRefs surfaces
+// building-less zone refs as building_id=0, and silently wiping them
+// would lose user-curated metadata. NULL (not ”) preserves the
+// collection_sort.go "zone NULLS LAST" semantics.
 func (q *Queries) UpdateRackPlacementBulkForSite(ctx context.Context, arg UpdateRackPlacementBulkForSiteParams) error {
 	_, err := q.exec(ctx, q.updateRackPlacementBulkForSiteStmt, updateRackPlacementBulkForSite, arg.TargetSiteID, pq.Array(arg.RackIds), arg.OrgID)
 	return err

--- a/server/generated/sqlc/device_set.sql.go
+++ b/server/generated/sqlc/device_set.sql.go
@@ -1179,7 +1179,7 @@ func (q *Queries) LockRackPlacementForWrite(ctx context.Context, arg LockRackPla
 const lockRacksForReparent = `-- name: LockRacksForReparent :many
 SELECT ds.id AS device_set_id
 FROM device_set ds
-LEFT JOIN device_set_rack dsr
+JOIN device_set_rack dsr
   ON dsr.device_set_id = ds.id AND dsr.org_id = ds.org_id
 WHERE ds.id IN (
     SELECT dsm.device_set_id
@@ -1219,13 +1219,15 @@ type LockRacksForReparentParams struct {
 // are derived in a subquery so the outer locking SELECT can use
 // FOR UPDATE (Postgres rejects DISTINCT + FOR UPDATE at runtime).
 //
-// The LEFT JOIN to device_set_rack with FOR UPDATE OF ds, dsr extends
-// the lock to the rack's placement row as well. LockRackPlacementForWrite
-// (used by SaveRack, DeleteCollection, etc.) acquires both rows in the
-// order {device_set_rack, device_set}; mirroring that join here keeps
-// the lock-acquisition order consistent across both code paths so a
-// concurrent SaveRack and AssignDevicesToRack against the same rack
-// cannot deadlock by holding one row and waiting on the other.
+// Joining device_set_rack with FOR UPDATE OF ds, dsr extends the lock
+// to the rack's placement row as well. LockRackPlacementForWrite (used
+// by SaveRack, DeleteCollection, etc.) acquires both rows; mirroring
+// that join here keeps the lock-acquisition order consistent across
+// both code paths so a concurrent SaveRack and AssignDevicesToRack
+// against the same rack cannot deadlock by holding one row and waiting
+// on the other. INNER JOIN (not LEFT) is intentional: Postgres rejects
+// FOR UPDATE on the nullable side of an outer join, and every live
+// rack has a device_set_rack row by lifecycle invariant.
 func (q *Queries) LockRacksForReparent(ctx context.Context, arg LockRacksForReparentParams) ([]int64, error) {
 	rows, err := q.query(ctx, q.lockRacksForReparentStmt, lockRacksForReparent, arg.OrgID, pq.Array(arg.DeviceIdentifiers), arg.TargetRackID)
 	if err != nil {

--- a/server/generated/sqlc/device_set.sql.go
+++ b/server/generated/sqlc/device_set.sql.go
@@ -1179,6 +1179,8 @@ func (q *Queries) LockRackPlacementForWrite(ctx context.Context, arg LockRackPla
 const lockRacksForReparent = `-- name: LockRacksForReparent :many
 SELECT ds.id AS device_set_id
 FROM device_set ds
+LEFT JOIN device_set_rack dsr
+  ON dsr.device_set_id = ds.id AND dsr.org_id = ds.org_id
 WHERE ds.id IN (
     SELECT dsm.device_set_id
     FROM device_set_membership dsm
@@ -1193,7 +1195,7 @@ WHERE ds.id IN (
   AND ds.type = 'rack'
   AND ds.deleted_at IS NULL
 ORDER BY ds.id ASC
-FOR UPDATE
+FOR UPDATE OF ds, dsr
 `
 
 type LockRacksForReparentParams struct {
@@ -1216,6 +1218,14 @@ type LockRacksForReparentParams struct {
 // own predicate; this query is purely about lock order. Distinct ids
 // are derived in a subquery so the outer locking SELECT can use
 // FOR UPDATE (Postgres rejects DISTINCT + FOR UPDATE at runtime).
+//
+// The LEFT JOIN to device_set_rack with FOR UPDATE OF ds, dsr extends
+// the lock to the rack's placement row as well. LockRackPlacementForWrite
+// (used by SaveRack, DeleteCollection, etc.) acquires both rows in the
+// order {device_set_rack, device_set}; mirroring that join here keeps
+// the lock-acquisition order consistent across both code paths so a
+// concurrent SaveRack and AssignDevicesToRack against the same rack
+// cannot deadlock by holding one row and waiting on the other.
 func (q *Queries) LockRacksForReparent(ctx context.Context, arg LockRacksForReparentParams) ([]int64, error) {
 	rows, err := q.query(ctx, q.lockRacksForReparentStmt, lockRacksForReparent, arg.OrgID, pq.Array(arg.DeviceIdentifiers), arg.TargetRackID)
 	if err != nil {

--- a/server/generated/sqlc/device_set.sql.go
+++ b/server/generated/sqlc/device_set.sql.go
@@ -1178,9 +1178,9 @@ func (q *Queries) LockRackPlacementForWrite(ctx context.Context, arg LockRackPla
 
 const lockRacksForReparent = `-- name: LockRacksForReparent :many
 SELECT ds.id AS device_set_id
-FROM device_set ds
-JOIN device_set_rack dsr
-  ON dsr.device_set_id = ds.id AND dsr.org_id = ds.org_id
+FROM device_set_rack dsr
+JOIN device_set ds
+  ON ds.id = dsr.device_set_id AND ds.org_id = dsr.org_id
 WHERE ds.id IN (
     SELECT dsm.device_set_id
     FROM device_set_membership dsm
@@ -1195,7 +1195,7 @@ WHERE ds.id IN (
   AND ds.type = 'rack'
   AND ds.deleted_at IS NULL
 ORDER BY ds.id ASC
-FOR UPDATE OF ds, dsr
+FOR UPDATE OF dsr, ds
 `
 
 type LockRacksForReparentParams struct {
@@ -1219,15 +1219,18 @@ type LockRacksForReparentParams struct {
 // are derived in a subquery so the outer locking SELECT can use
 // FOR UPDATE (Postgres rejects DISTINCT + FOR UPDATE at runtime).
 //
-// Joining device_set_rack with FOR UPDATE OF ds, dsr extends the lock
+// Joining device_set_rack with FOR UPDATE OF dsr, ds extends the lock
 // to the rack's placement row as well. LockRackPlacementForWrite (used
-// by SaveRack, DeleteCollection, etc.) acquires both rows; mirroring
-// that join here keeps the lock-acquisition order consistent across
-// both code paths so a concurrent SaveRack and AssignDevicesToRack
-// against the same rack cannot deadlock by holding one row and waiting
-// on the other. INNER JOIN (not LEFT) is intentional: Postgres rejects
-// FOR UPDATE on the nullable side of an outer join, and every live
-// rack has a device_set_rack row by lifecycle invariant.
+// by SaveRack, DeleteCollection, etc.) starts FROM device_set_rack dsr
+// JOIN device_set ds and locks both via FOR UPDATE — mirroring that
+// table order here (dsr first in FROM, dsr first in FOR UPDATE OF) so
+// the planner walks both joined rows in the same per-rack order across
+// the two code paths. Without that parity, a concurrent SaveRack and
+// AssignDevicesToRack against the same rack could hold device_set
+// while waiting on device_set_rack (or vice versa) and deadlock.
+// INNER JOIN (not LEFT) is intentional: Postgres rejects FOR UPDATE
+// on the nullable side of an outer join, and every live rack has a
+// device_set_rack row by lifecycle invariant.
 func (q *Queries) LockRacksForReparent(ctx context.Context, arg LockRacksForReparentParams) ([]int64, error) {
 	rows, err := q.query(ctx, q.lockRacksForReparentStmt, lockRacksForReparent, arg.OrgID, pq.Array(arg.DeviceIdentifiers), arg.TargetRackID)
 	if err != nil {

--- a/server/generated/sqlc/device_set.sql.go
+++ b/server/generated/sqlc/device_set.sql.go
@@ -102,6 +102,37 @@ func (q *Queries) CascadeRackDeviceSites(ctx context.Context, arg CascadeRackDev
 	return result.RowsAffected()
 }
 
+const cascadeRackDeviceSitesBulk = `-- name: CascadeRackDeviceSitesBulk :execrows
+UPDATE device d
+SET site_id = $1::bigint,
+    updated_at = CURRENT_TIMESTAMP
+FROM device_set_membership dsm
+WHERE dsm.device_set_id = ANY($2::bigint[])
+  AND dsm.org_id = $3
+  AND dsm.device_set_type = 'rack'
+  AND dsm.device_id = d.id
+  AND d.deleted_at IS NULL
+  AND d.site_id IS DISTINCT FROM $1::bigint
+`
+
+type CascadeRackDeviceSitesBulkParams struct {
+	TargetSiteID sql.NullInt64
+	RackIds      []int64
+	OrgID        int64
+}
+
+// Bulk variant of CascadeRackDeviceSites. Rewrites device.site_id to
+// target_site_id for every paired member of every rack in @rack_ids.
+// NULL target unassigns. IS DISTINCT FROM skips no-op rows. Returns
+// the total affected row count across all racks.
+func (q *Queries) CascadeRackDeviceSitesBulk(ctx context.Context, arg CascadeRackDeviceSitesBulkParams) (int64, error) {
+	result, err := q.exec(ctx, q.cascadeRackDeviceSitesBulkStmt, cascadeRackDeviceSitesBulk, arg.TargetSiteID, pq.Array(arg.RackIds), arg.OrgID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const clearRackPlacementForSoftDelete = `-- name: ClearRackPlacementForSoftDelete :exec
 UPDATE device_set_rack
 SET aisle_index = NULL,
@@ -1145,6 +1176,69 @@ func (q *Queries) LockRackPlacementForWrite(ctx context.Context, arg LockRackPla
 	return i, err
 }
 
+const lockRacksForReparent = `-- name: LockRacksForReparent :many
+SELECT ds.id AS device_set_id
+FROM device_set ds
+WHERE ds.id IN (
+    SELECT dsm.device_set_id
+    FROM device_set_membership dsm
+    WHERE dsm.org_id = $1
+      AND dsm.device_set_type = 'rack'
+      AND dsm.device_identifier = ANY($2::text[])
+  UNION
+    SELECT $3::bigint
+    WHERE $3::bigint > 0
+  )
+  AND ds.org_id = $1
+  AND ds.type = 'rack'
+  AND ds.deleted_at IS NULL
+ORDER BY ds.id ASC
+FOR UPDATE
+`
+
+type LockRacksForReparentParams struct {
+	OrgID             int64
+	DeviceIdentifiers []string
+	TargetRackID      int64
+}
+
+// Locks every rack involved in a reparent (sources + target) FOR UPDATE
+// in ascending id order. Used by AssignDevicesToRack as the FIRST tx
+// operation. Sorting source and target together in a single lock
+// acquisition is what prevents the deadlock two concurrent
+// AssignDevicesToRack calls moving devices in opposite directions
+// between the same pair of racks would otherwise hit: each tx locks
+// {sourceA, sourceB, ..., target} in id order, so any two txs touching
+// the same rack pair always agree on the global lock order regardless
+// of which side is source vs target. Pass 0 for @target_rack_id on the
+// unassign path (clear-rack -- no target to include). The membership
+// DELETE in RemoveDevicesFromAnyRack still excludes the target via its
+// own predicate; this query is purely about lock order. Distinct ids
+// are derived in a subquery so the outer locking SELECT can use
+// FOR UPDATE (Postgres rejects DISTINCT + FOR UPDATE at runtime).
+func (q *Queries) LockRacksForReparent(ctx context.Context, arg LockRacksForReparentParams) ([]int64, error) {
+	rows, err := q.query(ctx, q.lockRacksForReparentStmt, lockRacksForReparent, arg.OrgID, pq.Array(arg.DeviceIdentifiers), arg.TargetRackID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var device_set_id int64
+		if err := rows.Scan(&device_set_id); err != nil {
+			return nil, err
+		}
+		items = append(items, device_set_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const removeAllDevicesFromDeviceSet = `-- name: RemoveAllDevicesFromDeviceSet :execrows
 DELETE FROM device_set_membership
 WHERE device_set_id = $1
@@ -1431,5 +1525,103 @@ func (q *Queries) UpdateRackPlacement(ctx context.Context, arg UpdateRackPlaceme
 		arg.DeviceSetID,
 		arg.OrgID,
 	)
+	return err
+}
+
+const updateRackPlacementBulkForBuilding = `-- name: UpdateRackPlacementBulkForBuilding :exec
+UPDATE device_set_rack dsr
+SET site_id = CASE
+        WHEN $1::bigint IS NULL THEN dsr.site_id
+        ELSE $2::bigint
+    END,
+    building_id = $1::bigint,
+    zone = CASE
+        WHEN dsr.building_id IS NOT NULL
+             AND dsr.building_id IS DISTINCT FROM $1::bigint
+        THEN ''
+        ELSE dsr.zone
+    END,
+    aisle_index = CASE
+        WHEN $1::bigint IS DISTINCT FROM dsr.building_id THEN NULL
+        ELSE dsr.aisle_index
+    END,
+    position_in_aisle = CASE
+        WHEN $1::bigint IS DISTINCT FROM dsr.building_id THEN NULL
+        ELSE dsr.position_in_aisle
+    END
+WHERE dsr.device_set_id = ANY($3::bigint[])
+  AND dsr.org_id = $4
+  AND EXISTS (
+    SELECT 1 FROM device_set ds
+    WHERE ds.id = dsr.device_set_id
+      AND ds.org_id = $4
+      AND ds.deleted_at IS NULL
+  )
+`
+
+type UpdateRackPlacementBulkForBuildingParams struct {
+	TargetBuildingID sql.NullInt64
+	TargetSiteID     sql.NullInt64
+	RackIds          []int64
+	OrgID            int64
+}
+
+// Bulk variant of UpdateRackPlacement scoped to AssignRacksToBuilding.
+// Sets site_id, building_id, and zone for every rack in @rack_ids in a
+// single update.
+//
+// Semantics match the per-row UpdateRackPlacement + service-layer
+// zone/site rules:
+//
+//   - When @target_building_id IS NULL (unassign branch), each rack
+//     keeps its current site_id (no cascade fires later). Otherwise
+//     every rack is stamped with @target_site_id.
+//   - Zone clears to ” for any rack that had a building and is
+//     transitioning to a different (or NULL) building. Racks staying in
+//     the same building preserve their zone.
+//   - aisle_index / position_in_aisle clear when building_id changes,
+//     matching the single-row CASE.
+func (q *Queries) UpdateRackPlacementBulkForBuilding(ctx context.Context, arg UpdateRackPlacementBulkForBuildingParams) error {
+	_, err := q.exec(ctx, q.updateRackPlacementBulkForBuildingStmt, updateRackPlacementBulkForBuilding,
+		arg.TargetBuildingID,
+		arg.TargetSiteID,
+		pq.Array(arg.RackIds),
+		arg.OrgID,
+	)
+	return err
+}
+
+const updateRackPlacementBulkForSite = `-- name: UpdateRackPlacementBulkForSite :exec
+UPDATE device_set_rack dsr
+SET site_id           = $1::bigint,
+    building_id       = NULL,
+    zone              = '',
+    aisle_index       = NULL,
+    position_in_aisle = NULL
+WHERE dsr.device_set_id = ANY($2::bigint[])
+  AND dsr.org_id = $3
+  AND EXISTS (
+    SELECT 1 FROM device_set ds
+    WHERE ds.id = dsr.device_set_id
+      AND ds.org_id = $3
+      AND ds.deleted_at IS NULL
+  )
+`
+
+type UpdateRackPlacementBulkForSiteParams struct {
+	TargetSiteID sql.NullInt64
+	RackIds      []int64
+	OrgID        int64
+}
+
+// Bulk variant used by AssignRacksToSite. Stamps every rack in
+// @rack_ids with the target site, clears building_id and zone (because
+// a building belongs to one site, the rack's building membership is
+// invalidated by any site transition), and clears the grid placement
+// as a downstream effect of building_id changing. Caller is expected
+// to only pass racks whose current site differs from the target so the
+// response counts stay accurate.
+func (q *Queries) UpdateRackPlacementBulkForSite(ctx context.Context, arg UpdateRackPlacementBulkForSiteParams) error {
+	_, err := q.exec(ctx, q.updateRackPlacementBulkForSiteStmt, updateRackPlacementBulkForSite, arg.TargetSiteID, pq.Array(arg.RackIds), arg.OrgID)
 	return err
 }

--- a/server/generated/sqlc/site.sql.go
+++ b/server/generated/sqlc/site.sql.go
@@ -453,6 +453,7 @@ SELECT id FROM building
 WHERE org_id = $1
   AND site_id = $2
   AND deleted_at IS NULL
+ORDER BY id ASC
 FOR UPDATE
 `
 

--- a/server/generated/sqlc/site.sql.go
+++ b/server/generated/sqlc/site.sql.go
@@ -590,6 +590,42 @@ func (q *Queries) ReassignDevicesUnderBuilding(ctx context.Context, arg Reassign
 	return result.RowsAffected()
 }
 
+const reassignDevicesUnderBuildingsBulk = `-- name: ReassignDevicesUnderBuildingsBulk :execrows
+UPDATE device d
+SET site_id = $1,
+    updated_at = CURRENT_TIMESTAMP
+FROM device_set_membership dsm
+JOIN device_set ds
+    ON ds.id = dsm.device_set_id
+   AND ds.deleted_at IS NULL
+JOIN device_set_rack dsr
+    ON dsr.device_set_id = dsm.device_set_id
+   AND dsr.org_id = dsm.org_id
+WHERE d.id = dsm.device_id
+  AND d.org_id = dsm.org_id
+  AND dsm.device_set_type = 'rack'
+  AND d.org_id = $2
+  AND dsr.building_id = ANY($3::bigint[])
+  AND d.deleted_at IS NULL
+`
+
+type ReassignDevicesUnderBuildingsBulkParams struct {
+	TargetSiteID sql.NullInt64
+	OrgID        int64
+	BuildingIds  []int64
+}
+
+// Bulk variant of ReassignDevicesUnderBuilding. Sets device.site_id =
+// $target for every device in any live rack of any building in
+// @building_ids. Caller wraps in the same tx as the building UPDATE.
+func (q *Queries) ReassignDevicesUnderBuildingsBulk(ctx context.Context, arg ReassignDevicesUnderBuildingsBulkParams) (int64, error) {
+	result, err := q.exec(ctx, q.reassignDevicesUnderBuildingsBulkStmt, reassignDevicesUnderBuildingsBulk, arg.TargetSiteID, arg.OrgID, pq.Array(arg.BuildingIds))
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const reassignRacksUnderBuilding = `-- name: ReassignRacksUnderBuilding :execrows
 UPDATE device_set_rack dsr
 SET site_id = $1
@@ -615,6 +651,36 @@ type ReassignRacksUnderBuildingParams struct {
 // matching the list/cascade filters elsewhere.
 func (q *Queries) ReassignRacksUnderBuilding(ctx context.Context, arg ReassignRacksUnderBuildingParams) (int64, error) {
 	result, err := q.exec(ctx, q.reassignRacksUnderBuildingStmt, reassignRacksUnderBuilding, arg.TargetSiteID, arg.OrgID, arg.BuildingID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const reassignRacksUnderBuildingsBulk = `-- name: ReassignRacksUnderBuildingsBulk :execrows
+UPDATE device_set_rack dsr
+SET site_id = $1
+WHERE dsr.org_id = $2
+  AND dsr.building_id = ANY($3::bigint[])
+  AND EXISTS (
+      SELECT 1 FROM device_set ds
+      WHERE ds.id = dsr.device_set_id
+        AND ds.deleted_at IS NULL
+  )
+`
+
+type ReassignRacksUnderBuildingsBulkParams struct {
+	TargetSiteID sql.NullInt64
+	OrgID        int64
+	BuildingIds  []int64
+}
+
+// Bulk variant of ReassignRacksUnderBuilding. Sets rack.site_id =
+// $target for every live rack pointing at any of @building_ids in one
+// statement. Caller wraps in the same tx as the building UPDATE so
+// the building/rack/device site_ids stay in lockstep.
+func (q *Queries) ReassignRacksUnderBuildingsBulk(ctx context.Context, arg ReassignRacksUnderBuildingsBulkParams) (int64, error) {
+	result, err := q.exec(ctx, q.reassignRacksUnderBuildingsBulkStmt, reassignRacksUnderBuildingsBulk, arg.TargetSiteID, arg.OrgID, pq.Array(arg.BuildingIds))
 	if err != nil {
 		return 0, err
 	}

--- a/server/internal/domain/buildings/service.go
+++ b/server/internal/domain/buildings/service.go
@@ -280,7 +280,8 @@ type assignRacksToBuildingTx struct {
 //     order is building -> rack(s).
 //  2. Validate every entry up-front (paired position fields, in-bounds
 //     aisle/position). The whole batch rejects on any invalid entry.
-//  3. For each rack (sorted by id for deadlock-safe lock order):
+//  3. Pass 1 — for each rack (sorted by id for deadlock-safe lock
+//     order):
 //     a. Lock the rack row and read current placement.
 //     b. Resolve the new site_id from the target building (or preserve
 //     current.SiteID on building-only unassign).
@@ -288,8 +289,17 @@ type assignRacksToBuildingTx struct {
 //     d. Persist site_id + building_id + zone via UpdateRackPlacement.
 //     e. Cascade descendant device.site_id when the site changes; sum
 //     the per-rack counts into the aggregate result.
-//     f. Write the grid cell via SetRackBuildingPosition when the rack
-//     is assigned to a building (placed or explicitly cleared).
+//     f. When assigning (TargetBuildingID != nil), clear the rack's
+//     grid cell to (NULL, NULL) via SetRackBuildingPosition.
+//  4. Pass 2 — for each rack that carries an explicit (aisle, position),
+//     write the final cell via SetRackBuildingPosition.
+//
+// The two-pass split is what lets a single batch contain heterogeneous
+// position changes (swaps, "move into occupied cell", clear + reuse)
+// without tripping uk_device_set_rack_building_position. By the time
+// any rack tries to claim a cell in pass 2, every rack in the batch is
+// guaranteed to hold NULL position — so no partial-unique-index
+// collision can fire mid-batch.
 //
 // If any rack fails, the whole tx rolls back and no row is touched.
 func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.AssignRacksToBuildingParams) (*models.AssignRacksToBuildingResult, error) {
@@ -387,14 +397,26 @@ func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.Assig
 			}
 		}
 
+		// Phase A: sequential per-rack lock acquisition in sorted order.
+		// Locks must be acquired one-by-one to avoid the deadlock that
+		// would happen if two concurrent calls grabbed an overlapping
+		// rack set in different orders. Only locks + snapshot reads
+		// run here — every write happens in Phase B as a bulk
+		// statement once every row lock is held.
+		allRackIDs := make([]int64, 0, len(racks))
+		// cascadeRackIDs is populated in this phase so the bulk
+		// CascadeRackDeviceSites call in Phase B knows which racks
+		// actually transitioned sites. It's still appended in
+		// sorted-rack order to keep the activity-log metadata stable.
 		for _, rp := range racks {
 			// Lock the rack row and read its current placement so we
-			// can decide whether the cascade needs to run + what zone
-			// value to persist.
+			// can decide whether the cascade needs to run later and
+			// capture per-rack state for the activity-log fallback.
 			current, err := s.collectionStore.LockRackPlacementForWrite(txCtx, rp.RackID, params.OrgID)
 			if err != nil {
 				return nil, err
 			}
+			allRackIDs = append(allRackIDs, rp.RackID)
 
 			// Capture the source SiteID for a single-rack building-only
 			// unassign so the activity log carries the rack's site
@@ -407,79 +429,76 @@ func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.Assig
 
 			// Building-only unassign must NOT cascade-clear the rack's
 			// site (and, transitively, every descendant device.site_id).
-			// Removing a rack from a building is a building-membership
-			// change; the rack and its devices stay in their current
-			// site until an explicit site-level unassign happens
-			// elsewhere. Preserve current.SiteID in that branch so the
-			// siteChanged check below reads false and the cascade stays
-			// inert.
+			// Preserve current.SiteID in that branch so siteChanged
+			// reads false and the cascade stays inert.
 			newSiteID := targetSiteID
 			if params.TargetBuildingID == nil {
 				newSiteID = current.SiteID
 			}
-
-			// Mirror SaveRack's zone-clear cascade: clear zone when the
-			// rack leaves a building or crosses to a different one.
-			// Preserve the current zone on a no-op building transition
-			// so legacy callers don't strip zone unintentionally.
-			finalZone := current.Zone
-			leavingBuilding := current.BuildingID != nil && params.TargetBuildingID == nil
-			crossingBuildings := current.BuildingID != nil && params.TargetBuildingID != nil && *current.BuildingID != *params.TargetBuildingID
-			if leavingBuilding || crossingBuildings {
-				finalZone = ""
-			}
-
-			// Persist site_id + building_id + zone in one write. The
-			// query also clears the grid position on building
-			// transition via a CASE expression, so a stale
-			// (aisle_index, position_in_aisle) never outlives its
-			// parent building.
-			if err := s.collectionStore.UpdateRackPlacement(txCtx, rp.RackID, params.OrgID, newSiteID, params.TargetBuildingID, finalZone); err != nil {
-				return nil, err
-			}
-
-			// Cascade descendant device.site_id when the rack's site
-			// changed. CascadeRackDeviceSites returns the row count.
-			siteChanged := !int64PtrEqual(current.SiteID, newSiteID)
-			if siteChanged {
-				count, err := s.collectionStore.CascadeRackDeviceSites(txCtx, rp.RackID, params.OrgID, newSiteID)
-				if err != nil {
-					return nil, err
-				}
-				siteReassignedDeviceCount += count
+			if !int64PtrEqual(current.SiteID, newSiteID) {
 				cascadeRackIDs = append(cascadeRackIDs, rp.RackID)
-			}
-
-			// Pass-1 grid-cell vacate: write (NULL, NULL) for every
-			// rack in the batch when TargetBuildingID is set. Pass-2
-			// below writes the real (aisle, position) for racks that
-			// have one. Splitting the writes into two passes lets a
-			// swap or move-into-occupied-cell request commit without
-			// tripping the partial unique index uk_device_set_rack
-			// _building_position mid-loop — every cell touched by the
-			// batch is NULL before any real position is written.
-			//
-			// When TargetBuildingID is nil (full unassign) we skip
-			// this call — UpdateRackPlacement's CASE already nulls
-			// the position via the building-id-changed branch.
-			if params.TargetBuildingID != nil {
-				if err := s.store.SetRackBuildingPosition(txCtx, params.OrgID, rp.RackID, nil, nil); err != nil {
-					return nil, err
-				}
-				positionedRackIDs = append(positionedRackIDs, rp.RackID)
 			}
 		}
 
-		// Pass-2 grid-cell place: write the real (aisle, position) for
-		// racks that supplied one. By this point every cell touched by
-		// the batch is NULL (pass-1) so no two writes can collide on
-		// the partial unique index.
+		// Phase B1: single bulk write for site_id + building_id + zone
+		// + grid-position-on-building-change across every rack. The
+		// SQL CASE expressions mirror the per-row UpdateRackPlacement +
+		// service-layer zone rules so the swap/mixed-clear-and-place
+		// cases still behave like the F5 two-pass shape.
+		if err := s.collectionStore.UpdateRackPlacementBulkForBuilding(
+			txCtx, params.OrgID, allRackIDs, targetSiteID, params.TargetBuildingID,
+		); err != nil {
+			return nil, err
+		}
+
+		// Phase B2: single bulk cascade for the subset of racks whose
+		// site actually changed. CascadeRackDeviceSitesBulk no-ops on
+		// an empty rack set, but skip the call to keep the wire log
+		// clean.
+		if len(cascadeRackIDs) > 0 {
+			count, err := s.collectionStore.CascadeRackDeviceSitesBulk(
+				txCtx, params.OrgID, cascadeRackIDs, targetSiteID,
+			)
+			if err != nil {
+				return nil, err
+			}
+			siteReassignedDeviceCount += count
+		}
+
+		// Phase B3: single bulk pass-1 vacate. Force (aisle, position)
+		// to (NULL, NULL) for every rack in the batch so pass-2 below
+		// can reclaim any cell without colliding mid-batch on the
+		// partial unique index uk_device_set_rack_building_position.
+		// When TargetBuildingID is nil the UpdateRackPlacement bulk
+		// already nulled positions via its CASE — skip here.
 		if params.TargetBuildingID != nil {
+			if err := s.store.SetRackBuildingPositionBulkClear(txCtx, params.OrgID, allRackIDs); err != nil {
+				return nil, err
+			}
+			positionedRackIDs = append(positionedRackIDs, allRackIDs...)
+		}
+
+		// Phase B4: single bulk pass-2 place for racks carrying a
+		// (aisle, position). Pass-1 vacated every cell touched by the
+		// batch so no two writes can collide.
+		if params.TargetBuildingID != nil {
+			var (
+				placeRackIDs []int64
+				placeAisles  []int32
+				placePos     []int32
+			)
 			for _, rp := range racks {
 				if rp.AisleIndex == nil || rp.PositionInAisle == nil {
 					continue
 				}
-				if err := s.store.SetRackBuildingPosition(txCtx, params.OrgID, rp.RackID, rp.AisleIndex, rp.PositionInAisle); err != nil {
+				placeRackIDs = append(placeRackIDs, rp.RackID)
+				placeAisles = append(placeAisles, *rp.AisleIndex)
+				placePos = append(placePos, *rp.PositionInAisle)
+			}
+			if len(placeRackIDs) > 0 {
+				if err := s.store.SetRackBuildingPositionBulkPlace(
+					txCtx, params.OrgID, placeRackIDs, placeAisles, placePos,
+				); err != nil {
 					return nil, err
 				}
 			}

--- a/server/internal/domain/buildings/service.go
+++ b/server/internal/domain/buildings/service.go
@@ -445,10 +445,25 @@ func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.Assig
 		// SQL CASE expressions mirror the per-row UpdateRackPlacement +
 		// service-layer zone rules so the swap/mixed-clear-and-place
 		// cases still behave like the F5 two-pass shape.
-		if err := s.collectionStore.UpdateRackPlacementBulkForBuilding(
+		//
+		// The returned row count must match len(allRackIDs). Phase A's
+		// LockRackPlacementForWrite pre-pass already errors on
+		// missing/cross-org ids, but the count check locks the
+		// contract in case the pre-pass is ever refactored: an UPDATE
+		// that touches fewer rows than requested means one or more
+		// rack ids didn't resolve to a row in this org and we'd
+		// otherwise silently drop them.
+		rowsAffected, err := s.collectionStore.UpdateRackPlacementBulkForBuilding(
 			txCtx, params.OrgID, allRackIDs, targetSiteID, params.TargetBuildingID,
-		); err != nil {
+		)
+		if err != nil {
 			return nil, err
+		}
+		if rowsAffected != int64(len(allRackIDs)) {
+			return nil, fleeterror.NewNotFoundErrorf(
+				"one or more racks not found (expected %d, updated %d)",
+				len(allRackIDs), rowsAffected,
+			)
 		}
 
 		// Phase B2: single bulk cascade for the subset of racks whose

--- a/server/internal/domain/buildings/service_test.go
+++ b/server/internal/domain/buildings/service_test.go
@@ -228,7 +228,7 @@ func TestAssignRacksToBuilding_placesRackWithGridCell(t *testing.T) {
 		h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 			Return(interfaces.RackPlacement{SiteID: nil, BuildingID: nil, Zone: ""}, nil),
 		// Phase B1: single bulk placement update.
-		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &buildingID).Return(nil),
+		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &buildingID).Return(int64(1), nil),
 		// Phase B2: single bulk cascade — siteChanged (nil -> &siteID).
 		h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, []int64{rackID}, &siteID).Return(int64(2), nil),
 		// Phase B3: bulk pass-1 vacate.
@@ -275,7 +275,7 @@ func TestAssignRacksToBuilding_membersWithoutPositionClearsCell(t *testing.T) {
 	// No cascade — site unchanged. Bulk placement update + bulk pass-1
 	// vacate fire; pass-2 place is skipped because no positions were
 	// requested.
-	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &buildingID).Return(nil)
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &buildingID).Return(int64(1), nil)
 	h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackID}).Return(nil)
 
 	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
@@ -306,7 +306,7 @@ func TestAssignRacksToBuilding_sameBuildingUnplaceClearsPosition(t *testing.T) {
 		Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(buildingID), Zone: "Z1"}, nil)
 	// Bulk placement update — zone preservation is now decided in SQL
 	// per-row, so the bulk call only carries (target_site, target_building).
-	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &buildingID).Return(nil)
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &buildingID).Return(int64(1), nil)
 	// Critical: explicit bulk pass-1 vacate fires.
 	h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackID}).Return(nil)
 
@@ -336,7 +336,7 @@ func TestAssignRacksToBuilding_unassignPreservesSiteAndSkipsCascade(t *testing.T
 	// CascadeRackDeviceSitesBulk must NOT fire — site is preserved.
 	// Bulk pass-1 vacate is skipped — building_id change inside SQL CASE
 	// nulls aisle/position automatically.
-	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, (*int64)(nil), (*int64)(nil)).Return(nil)
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, (*int64)(nil), (*int64)(nil)).Return(int64(1), nil)
 
 	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
 		OrgID:            testOrgID,
@@ -364,7 +364,7 @@ func TestAssignRacksToBuilding_crossBuildingClearsZoneAndCascadesSite(t *testing
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &priorSite, BuildingID: ptrInt64(priorBuildingID), Zone: "Z1"}, nil)
 	// Bulk placement update — crossingBuildings zone clear runs in SQL.
-	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &newSite, &targetBuildingID).Return(nil)
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &newSite, &targetBuildingID).Return(int64(1), nil)
 	// Bulk cascade fires for site-changed racks.
 	h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, []int64{rackID}, &newSite).Return(int64(4), nil)
 	// Bulk pass-1 vacate confirms the new row carries no stale placement.
@@ -551,7 +551,7 @@ func TestAssignRacksToBuilding_swapsPositionsInSingleBatch(t *testing.T) {
 		h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackB, testOrgID).
 			Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(buildingID), Zone: ""}, nil),
 		// Phase B1: single bulk placement update across both racks.
-		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackA, rackB}, &siteID, &buildingID).Return(nil),
+		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackA, rackB}, &siteID, &buildingID).Return(int64(2), nil),
 		// Phase B2: no cascade — both racks stay in the same site.
 		// Phase B3: single bulk pass-1 vacate — critical for the swap.
 		h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackA, rackB}).Return(nil),
@@ -600,7 +600,7 @@ func TestAssignRacksToBuilding_mixedClearAndPlaceInSingleBatch(t *testing.T) {
 		h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackPlacer, testOrgID).
 			Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(buildingID), Zone: ""}, nil),
 		// Phase B1: single bulk placement update across both racks.
-		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackClearer, rackPlacer}, &siteID, &buildingID).Return(nil),
+		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackClearer, rackPlacer}, &siteID, &buildingID).Return(int64(2), nil),
 		// Phase B2: no cascade — both stay in the same site.
 		// Phase B3: bulk vacate covers both racks unconditionally
 		// (swap-safe invariant).
@@ -666,7 +666,7 @@ func TestAssignRacksToBuilding_largeBatchIssuesSingleBulkWrites(t *testing.T) {
 			Return(interfaces.RackPlacement{}, nil)
 	}
 	// Phase B writes: exactly four bulk calls, regardless of N.
-	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, wantRackIDs, &siteID, &buildingID).Return(nil)
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, wantRackIDs, &siteID, &buildingID).Return(int64(len(wantRackIDs)), nil)
 	h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, wantRackIDs, &siteID).Return(int64(200), nil)
 	h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, wantRackIDs).Return(nil)
 	h.store.EXPECT().SetRackBuildingPositionBulkPlace(inTxCtx, testOrgID, wantRackIDs, wantAisles, wantPositions).Return(nil)

--- a/server/internal/domain/buildings/service_test.go
+++ b/server/internal/domain/buildings/service_test.go
@@ -212,7 +212,8 @@ func newAssignHarness(t *testing.T) *assignHarness {
 }
 
 // Assign with a grid cell: lock building, lock rack, write placement,
-// write grid cell, no site cascade because target site matches current.
+// vacate cell in pass 1 (NULL/NULL), then write the actual cell in
+// pass 2. No site cascade because target site matches current.
 func TestAssignRacksToBuilding_placesRackWithGridCell(t *testing.T) {
 	h := newAssignHarness(t)
 	buildingID := int64(11)
@@ -223,17 +224,17 @@ func TestAssignRacksToBuilding_placesRackWithGridCell(t *testing.T) {
 		h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil),
 		h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
 			Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil),
+		// Phase A: lock + read.
 		h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 			Return(interfaces.RackPlacement{SiteID: nil, BuildingID: nil, Zone: ""}, nil),
-		h.collectionStore.EXPECT().UpdateRackPlacement(inTxCtx, rackID, testOrgID, &siteID, &buildingID, "").Return(nil),
-		// siteChanged is true (nil -> &siteID); cascade fires.
-		h.collectionStore.EXPECT().CascadeRackDeviceSites(inTxCtx, rackID, testOrgID, &siteID).Return(int64(2), nil),
-		// Pass-1 vacate (NULL, NULL) — fires for every rack in the
-		// batch so pass-2 can claim cells without colliding on the
-		// partial unique index.
-		h.store.EXPECT().SetRackBuildingPosition(inTxCtx, testOrgID, rackID, gomock.Nil(), gomock.Nil()).Return(nil),
-		// Pass-2 place — real (aisle, position) for racks that supplied one.
-		h.store.EXPECT().SetRackBuildingPosition(inTxCtx, testOrgID, rackID, ptrInt32(1), ptrInt32(2)).Return(nil),
+		// Phase B1: single bulk placement update.
+		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &buildingID).Return(nil),
+		// Phase B2: single bulk cascade — siteChanged (nil -> &siteID).
+		h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, []int64{rackID}, &siteID).Return(int64(2), nil),
+		// Phase B3: bulk pass-1 vacate.
+		h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackID}).Return(nil),
+		// Phase B4: bulk pass-2 place.
+		h.store.EXPECT().SetRackBuildingPositionBulkPlace(inTxCtx, testOrgID, []int64{rackID}, []int32{1}, []int32{2}).Return(nil),
 	)
 
 	out, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
@@ -271,8 +272,11 @@ func TestAssignRacksToBuilding_membersWithoutPositionClearsCell(t *testing.T) {
 		Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil)
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &siteID}, nil)
-	h.collectionStore.EXPECT().UpdateRackPlacement(inTxCtx, rackID, testOrgID, &siteID, &buildingID, "").Return(nil)
-	h.store.EXPECT().SetRackBuildingPosition(inTxCtx, testOrgID, rackID, (*int32)(nil), (*int32)(nil)).Return(nil)
+	// No cascade — site unchanged. Bulk placement update + bulk pass-1
+	// vacate fire; pass-2 place is skipped because no positions were
+	// requested.
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &buildingID).Return(nil)
+	h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackID}).Return(nil)
 
 	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
 		OrgID:            testOrgID,
@@ -285,10 +289,10 @@ func TestAssignRacksToBuilding_membersWithoutPositionClearsCell(t *testing.T) {
 }
 
 // Same-building unplace: rack already in this building at a known cell,
-// caller resends building_id with no position. SetRackBuildingPosition
-// must fire with nil/nil so the prior (aisle, position) is cleared from
-// the rack row. Guards against the "unplace within building silently
-// no-ops" regression.
+// caller resends building_id with no position. The bulk pass-1 vacate
+// is what clears the prior (aisle, position) so the unplace doesn't
+// silently no-op. Guards against the "unplace within building silently
+// no-ops" regression on the post-bulk refactor.
 func TestAssignRacksToBuilding_sameBuildingUnplaceClearsPosition(t *testing.T) {
 	h := newAssignHarness(t)
 	buildingID := int64(11)
@@ -300,11 +304,11 @@ func TestAssignRacksToBuilding_sameBuildingUnplaceClearsPosition(t *testing.T) {
 		Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil)
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(buildingID), Zone: "Z1"}, nil)
-	// Same building → zone preserved → finalZone is "Z1".
-	h.collectionStore.EXPECT().UpdateRackPlacement(inTxCtx, rackID, testOrgID, &siteID, &buildingID, "Z1").Return(nil)
-	// No site change → no cascade.
-	// Critical: explicit position clear fires.
-	h.store.EXPECT().SetRackBuildingPosition(inTxCtx, testOrgID, rackID, (*int32)(nil), (*int32)(nil)).Return(nil)
+	// Bulk placement update — zone preservation is now decided in SQL
+	// per-row, so the bulk call only carries (target_site, target_building).
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &buildingID).Return(nil)
+	// Critical: explicit bulk pass-1 vacate fires.
+	h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackID}).Return(nil)
 
 	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
 		OrgID:            testOrgID,
@@ -328,9 +332,11 @@ func TestAssignRacksToBuilding_unassignPreservesSiteAndSkipsCascade(t *testing.T
 	// No LockBuildingForWrite / GetBuilding expected — params.BuildingID is nil.
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(priorBuildingID), Zone: "Z1"}, nil)
-	// site stays &siteID; zone clears (leavingBuilding).
-	h.collectionStore.EXPECT().UpdateRackPlacement(inTxCtx, rackID, testOrgID, &siteID, (*int64)(nil), "").Return(nil)
-	// CascadeRackDeviceSites must NOT fire.
+	// Bulk placement update: site target nil (preserve), building target nil.
+	// CascadeRackDeviceSitesBulk must NOT fire — site is preserved.
+	// Bulk pass-1 vacate is skipped — building_id change inside SQL CASE
+	// nulls aisle/position automatically.
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, (*int64)(nil), (*int64)(nil)).Return(nil)
 
 	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
 		OrgID:            testOrgID,
@@ -357,12 +363,12 @@ func TestAssignRacksToBuilding_crossBuildingClearsZoneAndCascadesSite(t *testing
 		Return(&models.Building{ID: targetBuildingID, SiteID: &newSite, Aisles: 4, RacksPerAisle: 6}, nil)
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &priorSite, BuildingID: ptrInt64(priorBuildingID), Zone: "Z1"}, nil)
-	// crossingBuildings ⇒ zone clears.
-	h.collectionStore.EXPECT().UpdateRackPlacement(inTxCtx, rackID, testOrgID, &newSite, &targetBuildingID, "").Return(nil)
-	h.collectionStore.EXPECT().CascadeRackDeviceSites(inTxCtx, rackID, testOrgID, &newSite).Return(int64(4), nil)
-	// Cross-building move with no chosen cell — explicit nil/nil
-	// position write confirms the new row carries no stale placement.
-	h.store.EXPECT().SetRackBuildingPosition(inTxCtx, testOrgID, rackID, (*int32)(nil), (*int32)(nil)).Return(nil)
+	// Bulk placement update — crossingBuildings zone clear runs in SQL.
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &newSite, &targetBuildingID).Return(nil)
+	// Bulk cascade fires for site-changed racks.
+	h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, []int64{rackID}, &newSite).Return(int64(4), nil)
+	// Bulk pass-1 vacate confirms the new row carries no stale placement.
+	h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackID}).Return(nil)
 
 	out, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
 		OrgID:            testOrgID,
@@ -477,10 +483,10 @@ func TestAssignRacksToBuilding_rejectsDuplicateRackIDs(t *testing.T) {
 	}
 }
 
-// TestAssignRacksToBuilding_bulkRollsBackOnLaterFailure pins the
-// rollback contract for the per-rack loop: the first rack's
-// placement + cascade writes happen, then the second rack's lock
-// errors and the whole tx aborts. The closure ran exactly once.
+// TestAssignRacksToBuilding_bulkRollsBackOnLaterFailure mirrors the
+// sites batch rollback case: first rack succeeds, second errors on the
+// lock, the tx aborts, and the closure ran exactly once with the error
+// propagating.
 func TestAssignRacksToBuilding_bulkRollsBackOnLaterFailure(t *testing.T) {
 	h := newAssignHarness(t)
 	buildingID := int64(11)
@@ -489,15 +495,15 @@ func TestAssignRacksToBuilding_bulkRollsBackOnLaterFailure(t *testing.T) {
 	h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil)
 	h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
 		Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil)
-	// First rack: lock + placement update + cascade + position write.
+	// Phase A walks both rack ids in order; the second lock errors so
+	// the closure exits before any bulk write fires.
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, int64(100), testOrgID).
 		Return(interfaces.RackPlacement{}, nil)
-	h.collectionStore.EXPECT().UpdateRackPlacement(inTxCtx, int64(100), testOrgID, &siteID, &buildingID, "").Return(nil)
-	h.collectionStore.EXPECT().CascadeRackDeviceSites(inTxCtx, int64(100), testOrgID, &siteID).Return(int64(0), nil)
-	h.store.EXPECT().SetRackBuildingPosition(inTxCtx, testOrgID, int64(100), (*int32)(nil), (*int32)(nil)).Return(nil)
-	// Second rack: lock errors → tx aborts.
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, int64(101), testOrgID).
 		Return(interfaces.RackPlacement{}, fleeterror.NewNotFoundErrorf("rack %d not found", 101))
+	// No bulk UpdateRackPlacementBulkForBuilding / CascadeRackDeviceSitesBulk /
+	// SetRackBuildingPosition{Bulk}* calls — the closure aborts in Phase A.
+	_ = siteID
 
 	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
 		OrgID:            testOrgID,
@@ -512,6 +518,172 @@ func TestAssignRacksToBuilding_bulkRollsBackOnLaterFailure(t *testing.T) {
 	}
 	if h.tx.calls != 1 {
 		t.Fatalf("expected exactly 1 tx closure run, got %d", h.tx.calls)
+	}
+}
+
+// TestAssignRacksToBuilding_swapsPositionsInSingleBatch covers F5:
+// a single batch that swaps two racks' positions inside the same
+// building must succeed in one tx. The service pre-clears every
+// rack's position (pass 1) before writing any new positions (pass 2),
+// so the partial unique index uk_device_set_rack_building_position
+// can't see two rows trying to hold the same (building, aisle, pos)
+// simultaneously.
+func TestAssignRacksToBuilding_swapsPositionsInSingleBatch(t *testing.T) {
+	h := newAssignHarness(t)
+	buildingID := int64(11)
+	siteID := int64(3)
+	rackA := int64(100)
+	rackB := int64(101)
+
+	// Racks are sorted by id, so rackA(100) is processed before rackB(101)
+	// during Phase A (lock acquisition). Phase B issues one bulk
+	// placement update, then one bulk pass-1 vacate covering both racks,
+	// then one bulk pass-2 place that writes the swapped positions in a
+	// single statement.
+	gomock.InOrder(
+		// Building lock + load.
+		h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil),
+		h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
+			Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil),
+		// Phase A: locks in sorted order, no writes.
+		h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackA, testOrgID).
+			Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(buildingID), Zone: ""}, nil),
+		h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackB, testOrgID).
+			Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(buildingID), Zone: ""}, nil),
+		// Phase B1: single bulk placement update across both racks.
+		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackA, rackB}, &siteID, &buildingID).Return(nil),
+		// Phase B2: no cascade — both racks stay in the same site.
+		// Phase B3: single bulk pass-1 vacate — critical for the swap.
+		h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackA, rackB}).Return(nil),
+		// Phase B4: single bulk pass-2 place — both racks in one statement.
+		h.store.EXPECT().SetRackBuildingPositionBulkPlace(
+			inTxCtx, testOrgID, []int64{rackA, rackB}, []int32{0, 0}, []int32{1, 0},
+		).Return(nil),
+	)
+
+	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
+		OrgID:            testOrgID,
+		TargetBuildingID: &buildingID,
+		Racks: []models.RackPlacementParam{
+			// rackA: (0,0) -> (0,1)
+			{RackID: rackA, AisleIndex: ptrInt32(0), PositionInAisle: ptrInt32(1)},
+			// rackB: (0,1) -> (0,0)
+			{RackID: rackB, AisleIndex: ptrInt32(0), PositionInAisle: ptrInt32(0)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.tx.calls != 1 {
+		t.Fatalf("expected one tx run, got %d", h.tx.calls)
+	}
+}
+
+// TestAssignRacksToBuilding_mixedClearAndPlaceInSingleBatch covers F5:
+// one rack being unplaced + another rack moving into the freshly
+// vacated cell must succeed in one batch. The clear write fires in
+// pass 1 strictly before the place write in pass 2.
+func TestAssignRacksToBuilding_mixedClearAndPlaceInSingleBatch(t *testing.T) {
+	h := newAssignHarness(t)
+	buildingID := int64(11)
+	siteID := int64(3)
+	rackClearer := int64(100) // was at (0,0), going to NULL
+	rackPlacer := int64(101)  // was unplaced, going to (0,0)
+
+	gomock.InOrder(
+		h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil),
+		h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
+			Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil),
+		// Phase A: locks in sorted order.
+		h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackClearer, testOrgID).
+			Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(buildingID), Zone: ""}, nil),
+		h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackPlacer, testOrgID).
+			Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(buildingID), Zone: ""}, nil),
+		// Phase B1: single bulk placement update across both racks.
+		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackClearer, rackPlacer}, &siteID, &buildingID).Return(nil),
+		// Phase B2: no cascade — both stay in the same site.
+		// Phase B3: bulk vacate covers both racks unconditionally
+		// (swap-safe invariant).
+		h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackClearer, rackPlacer}).Return(nil),
+		// Phase B4: bulk pass-2 places only rackPlacer — rackClearer
+		// has no requested position and stays vacated.
+		h.store.EXPECT().SetRackBuildingPositionBulkPlace(
+			inTxCtx, testOrgID, []int64{rackPlacer}, []int32{0}, []int32{0},
+		).Return(nil),
+	)
+
+	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
+		OrgID:            testOrgID,
+		TargetBuildingID: &buildingID,
+		Racks: []models.RackPlacementParam{
+			{RackID: rackClearer}, // clear cell
+			{RackID: rackPlacer, AisleIndex: ptrInt32(0), PositionInAisle: ptrInt32(0)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.tx.calls != 1 {
+		t.Fatalf("expected one tx run, got %d", h.tx.calls)
+	}
+}
+
+// TestAssignRacksToBuilding_largeBatchIssuesSingleBulkWrites guards the
+// F7 bulk refactor: a 100-rack batch must produce exactly one
+// UpdateRackPlacementBulkForBuilding + one CascadeRackDeviceSitesBulk
+// + one SetRackBuildingPositionBulkClear + one SetRackBuildingPositionBulkPlace
+// call regardless of N.
+func TestAssignRacksToBuilding_largeBatchIssuesSingleBulkWrites(t *testing.T) {
+	h := newAssignHarness(t)
+	buildingID := int64(11)
+	siteID := int64(3)
+
+	const N = 100
+	wantRackIDs := make([]int64, N)
+	wantAisles := make([]int32, N)
+	wantPositions := make([]int32, N)
+	racks := make([]models.RackPlacementParam, N)
+	// Build distinct (aisle, position) values that fit in a 10×10 grid.
+	for i := 0; i < N; i++ {
+		id := int64(1000 + i)
+		wantRackIDs[i] = id
+		aisle := int32(i / 10)
+		pos := int32(i % 10)
+		wantAisles[i] = aisle
+		wantPositions[i] = pos
+		racks[i] = models.RackPlacementParam{
+			RackID: id, AisleIndex: ptrInt32(aisle), PositionInAisle: ptrInt32(pos),
+		}
+	}
+
+	h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil)
+	h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
+		Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 10, RacksPerAisle: 10}, nil)
+	// Phase A: N per-rack lock acquisitions in sorted order — these are
+	// the only writes that fan out by N.
+	for _, id := range wantRackIDs {
+		h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, id, testOrgID).
+			Return(interfaces.RackPlacement{}, nil)
+	}
+	// Phase B writes: exactly four bulk calls, regardless of N.
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, wantRackIDs, &siteID, &buildingID).Return(nil)
+	h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, wantRackIDs, &siteID).Return(int64(200), nil)
+	h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, wantRackIDs).Return(nil)
+	h.store.EXPECT().SetRackBuildingPositionBulkPlace(inTxCtx, testOrgID, wantRackIDs, wantAisles, wantPositions).Return(nil)
+
+	out, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
+		OrgID:            testOrgID,
+		TargetBuildingID: &buildingID,
+		Racks:            racks,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.SiteReassignedDeviceCount != 200 {
+		t.Fatalf("expected 200 cascaded devices, got %d", out.SiteReassignedDeviceCount)
+	}
+	if h.tx.calls != 1 {
+		t.Fatalf("expected one tx closure run, got %d", h.tx.calls)
 	}
 }
 

--- a/server/internal/domain/buildings/service_test.go
+++ b/server/internal/domain/buildings/service_test.go
@@ -644,10 +644,12 @@ func TestAssignRacksToBuilding_largeBatchIssuesSingleBulkWrites(t *testing.T) {
 	wantPositions := make([]int32, N)
 	racks := make([]models.RackPlacementParam, N)
 	// Build distinct (aisle, position) values that fit in a 10×10 grid.
-	for i := 0; i < N; i++ {
+	for i := range N {
 		id := int64(1000 + i)
 		wantRackIDs[i] = id
+		// #nosec G115 -- i is bounded by N=100, fits in int32.
 		aisle := int32(i / 10)
+		// #nosec G115 -- i is bounded by N=100, fits in int32.
 		pos := int32(i % 10)
 		wantAisles[i] = aisle
 		wantPositions[i] = pos

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -913,17 +913,39 @@ func (s *Service) AssignDevicesToRack(ctx context.Context, params AssignDevicesT
 			targetSiteID *int64
 			targetLabel  string
 		)
-		// Lock + verify target rack first so concurrent SaveRack /
-		// DeleteCollection on the target can't race us. Canonical lock
-		// order is rack-only here — site/building locks would invert
-		// against AddDevicesToCollection.
+		// Canonical lock order: lock every rack involved in the
+		// reparent -- sources + target -- together in ascending
+		// device_set.id order via LockRacksForReparent. Locking source
+		// and target as one globally sorted set is what keeps two
+		// concurrent AssignDevicesToRack calls moving devices in
+		// opposite directions between the same rack pair from
+		// deadlocking: each tx acquires {rack1, rack2} in the same
+		// {1, 2} order regardless of which side is source vs target.
+		// Without the pre-pass, the calls race the
+		// device_set_membership unique constraint and the loser trips
+		// uk_device_set_membership during the INSERT. The subsequent
+		// LockRackPlacementForWrite call below still fires for its
+		// device_set_rack row + placement read; the parent device_set
+		// row it locks is already held by this tx from the pre-pass.
+		// Pass 0 in the clear-rack path so the UNION contributes no
+		// target row.
+		var targetRackID int64
+		if params.TargetRackID != nil {
+			targetRackID = *params.TargetRackID
+		}
+		if _, err := s.collectionStore.LockRacksForReparent(ctx, params.OrgID, params.DeviceIdentifiers, targetRackID); err != nil {
+			return nil, err
+		}
+
+		// Lock + verify target rack so concurrent SaveRack /
+		// DeleteCollection on the target can't race us. Site/building
+		// locks would invert against AddDevicesToCollection's cascade,
+		// so we stay rack-only here.
 		//
 		// Order: take the row lock BEFORE the label/type read so a
 		// concurrent rename can't slip a stale label into the activity
 		// log we emit downstream.
-		var targetRackID int64
 		if params.TargetRackID != nil {
-			targetRackID = *params.TargetRackID
 			placement, err := s.collectionStore.LockRackPlacementForWrite(ctx, *params.TargetRackID, params.OrgID)
 			if err != nil {
 				return nil, err

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -2102,6 +2102,8 @@ func TestService_AssignDevicesToRack_crossSiteEmitsCascadeMetadata(t *testing.T)
 	deviceIDs := []string{"d1"}
 
 	gomock.InOrder(
+		mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, targetRackID).
+			Return([]int64{targetRackID}, nil),
 		mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), targetRackID, testOrgID).
 			Return(interfaces.RackPlacement{SiteID: &rackSite}, nil),
 		mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, targetRackID).
@@ -2153,6 +2155,8 @@ func TestService_AssignDevicesToRack_sameSiteSkipsCascadeMetadata(t *testing.T) 
 	deviceIDs := []string{"d1"}
 
 	gomock.InOrder(
+		mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, targetRackID).
+			Return([]int64{targetRackID}, nil),
 		mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), targetRackID, testOrgID).
 			Return(interfaces.RackPlacement{SiteID: &rackSite}, nil),
 		mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, targetRackID).
@@ -2177,4 +2181,76 @@ func TestService_AssignDevicesToRack_sameSiteSkipsCascadeMetadata(t *testing.T) 
 	require.NotNil(t, event.SiteID)
 	assert.Equal(t, rackSite, *event.SiteID)
 	assert.Nil(t, event.Metadata, "no cascade should mean no cascade metadata")
+}
+
+// TestService_AssignDevicesToRack_lockReparentZeroTargetReturnsOnlySources
+// pins the UNION semantics of LockRacksForReparent on the clear-rack
+// path: with target_rack_id=0 the SQL UNION's target arm evaluates to
+// no rows (the `target_rack_id > 0` predicate filters it out), so the
+// store should return only the source rack ids that actually own the
+// requested devices. The service must accept that result and proceed
+// without dereferencing a target rack id.
+func TestService_AssignDevicesToRack_lockReparentZeroTargetReturnsOnlySources(t *testing.T) {
+	svc, mockStore, _ := newTestServiceWithSites(t, nil)
+	ctx := testCtx(t)
+
+	deviceIDs := []string{"d1", "d2"}
+
+	// gomock matchers on the call args pin the wrapper contract:
+	// targetRackID 0 is what the service passes when TargetRackID is
+	// nil, and the mock returns only source ids — no target row
+	// because the UNION arm is filtered out by `target_rack_id > 0`.
+	gomock.InOrder(
+		mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, int64(0)).
+			Return([]int64{3, 9}, nil),
+		mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(0)).Return(int64(2), nil),
+	)
+
+	out, err := svc.AssignDevicesToRack(ctx, AssignDevicesToRackParams{
+		OrgID:             testOrgID,
+		TargetRackID:      nil,
+		DeviceIdentifiers: deviceIDs,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), out.RemovedCount)
+}
+
+// TestService_AssignDevicesToRack_lockReparentCrossOrgTargetReturnsEmpty
+// pins the cross-org isolation contract: when the caller supplies a
+// target_rack_id that belongs to a different org, the SQL
+// `ds.org_id = @org_id` predicate filters the target out of the
+// locking SELECT and the store returns an empty id slice. The follow
+// -up LockRackPlacementForWrite call still fires for the supplied
+// target id and is responsible for returning NotFound — the empty
+// LockRacksForReparent result must not be treated as a leak (the test
+// asserts no devices are added and a NotFound surfaces from the
+// downstream placement lock, never from a partial commit).
+func TestService_AssignDevicesToRack_lockReparentCrossOrgTargetReturnsEmpty(t *testing.T) {
+	svc, mockStore, _ := newTestServiceWithSites(t, nil)
+	ctx := testCtx(t)
+
+	targetRackID := int64(9999) // cross-org id
+	deviceIDs := []string{"d1"}
+
+	gomock.InOrder(
+		// Cross-org target id: the SQL UNION includes the id but the
+		// org-scoped outer WHERE filters it out, so the mock returns
+		// an empty slice. The wrapper must still forward the call as
+		// the service sent it (targetRackID, not 0).
+		mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, targetRackID).
+			Return([]int64{}, nil),
+		// LockRackPlacementForWrite is the gate that owns the cross
+		// -org NotFound — the empty slice from LockRacksForReparent
+		// alone must not let the call slip past the lock pre-pass and
+		// reach a write.
+		mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), targetRackID, testOrgID).
+			Return(interfaces.RackPlacement{}, fleeterror.NewNotFoundErrorf("rack %d not found", targetRackID)),
+	)
+
+	_, err := svc.AssignDevicesToRack(ctx, AssignDevicesToRackParams{
+		OrgID:             testOrgID,
+		TargetRackID:      &targetRackID,
+		DeviceIdentifiers: deviceIDs,
+	})
+	require.Error(t, err)
 }

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -1909,6 +1909,8 @@ func TestService_AssignDevicesToRack_atomicReassign(t *testing.T) {
 	deviceIDs := []string{"d1", "d2"}
 
 	gomock.InOrder(
+		mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, targetRackID).
+			Return([]int64{11, 23}, nil),
 		mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), targetRackID, testOrgID).
 			Return(interfaces.RackPlacement{SiteID: &rackSite}, nil),
 		mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, targetRackID).
@@ -1939,7 +1941,11 @@ func TestService_AssignDevicesToRack_unassignClearsWithoutAdd(t *testing.T) {
 	ctx := testCtx(t)
 
 	deviceIDs := []string{"d1"}
-	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(0)).Return(int64(1), nil)
+	gomock.InOrder(
+		mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, int64(0)).
+			Return([]int64{17}, nil),
+		mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(0)).Return(int64(1), nil),
+	)
 
 	out, err := svc.AssignDevicesToRack(ctx, AssignDevicesToRackParams{
 		OrgID:             testOrgID,
@@ -1959,12 +1965,12 @@ func TestService_AssignDevicesToRack_targetMustBeRack(t *testing.T) {
 	ctx := testCtx(t)
 
 	targetID := int64(99)
-	gomock.InOrder(
-		mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), targetID, testOrgID).
-			Return(interfaces.RackPlacement{}, nil),
-		mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, targetID).
-			Return(&pb.DeviceCollection{Id: targetID, Label: "G1", Type: pb.CollectionType_COLLECTION_TYPE_GROUP}, nil),
-	)
+	mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, []string{"d1"}, targetID).
+		Return(nil, nil)
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), targetID, testOrgID).
+		Return(interfaces.RackPlacement{}, nil)
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, targetID).
+		Return(&pb.DeviceCollection{Id: targetID, Label: "G1", Type: pb.CollectionType_COLLECTION_TYPE_GROUP}, nil)
 
 	_, err := svc.AssignDevicesToRack(ctx, AssignDevicesToRackParams{
 		OrgID:             testOrgID,
@@ -1972,6 +1978,98 @@ func TestService_AssignDevicesToRack_targetMustBeRack(t *testing.T) {
 		DeviceIdentifiers: []string{"d1"},
 	})
 	require.Error(t, err)
+}
+
+// TestService_AssignDevicesToRack_acquiresSourceRackLocksBeforeWrites
+// pins F9's lock-order invariant: LockRacksForReparent must run
+// BEFORE LockRackPlacementForWrite and BEFORE RemoveDevicesFromAnyRack.
+// Reversing this risks deadlock against a concurrent call that takes
+// the locks in the opposite order, and skipping it altogether is what
+// lets concurrent overlapping reparent calls race the
+// device_set_membership unique constraint.
+func TestService_AssignDevicesToRack_acquiresSourceRackLocksBeforeWrites(t *testing.T) {
+	svc, mockStore, _ := newTestServiceWithSites(t, nil)
+	ctx := testCtx(t)
+
+	targetRackID := int64(42)
+	deviceIDs := []string{"d1", "d2"}
+
+	gomock.InOrder(
+		mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, targetRackID).
+			Return([]int64{11, 23}, nil),
+		mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), targetRackID, testOrgID).
+			Return(interfaces.RackPlacement{}, nil),
+		mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, targetRackID).
+			Return(&pb.DeviceCollection{Id: targetRackID, Label: "Rack-B", Type: pb.CollectionType_COLLECTION_TYPE_RACK}, nil),
+		mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, targetRackID).Return(int64(2), nil),
+		mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, targetRackID, deviceIDs).Return(int64(2), nil),
+	)
+
+	_, err := svc.AssignDevicesToRack(ctx, AssignDevicesToRackParams{
+		OrgID:             testOrgID,
+		TargetRackID:      &targetRackID,
+		DeviceIdentifiers: deviceIDs,
+	})
+	require.NoError(t, err)
+}
+
+// TestService_AssignDevicesToRack_unassignPathLocksSourceRacks pins
+// that the rack-lock pre-pass ALSO fires on the clear-rack path.
+// targetRackID is 0 so the UNION arm contributes no target row and
+// only the source racks holding any of the requested devices are
+// locked.
+func TestService_AssignDevicesToRack_unassignPathLocksSourceRacks(t *testing.T) {
+	svc, mockStore, _ := newTestServiceWithSites(t, nil)
+	ctx := testCtx(t)
+
+	deviceIDs := []string{"d1", "d2"}
+
+	gomock.InOrder(
+		mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, int64(0)).
+			Return([]int64{5, 12}, nil),
+		mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(0)).Return(int64(2), nil),
+	)
+
+	_, err := svc.AssignDevicesToRack(ctx, AssignDevicesToRackParams{
+		OrgID:             testOrgID,
+		TargetRackID:      nil,
+		DeviceIdentifiers: deviceIDs,
+	})
+	require.NoError(t, err)
+}
+
+// TestService_AssignDevicesToRack_locksIncludeTargetRack pins the
+// deadlock-prevention contract: when a target rack is supplied, the
+// pre-pass lock call MUST receive the target rack id (not 0) so the
+// SQL UNION includes the target in the same globally sorted FOR
+// UPDATE acquisition as the source racks. Two concurrent reparents
+// moving devices in opposite directions between rack A and rack B
+// would otherwise lock {sourceA} then {B} in one tx and {sourceB}
+// then {A} in the other, producing the classic A→B / B→A deadlock.
+func TestService_AssignDevicesToRack_locksIncludeTargetRack(t *testing.T) {
+	svc, mockStore, _ := newTestServiceWithSites(t, nil)
+	ctx := testCtx(t)
+
+	targetRackID := int64(77)
+	deviceIDs := []string{"d1"}
+
+	// Assert by argument: LockRacksForReparent receives targetRackID,
+	// not 0. The mock matcher rejects any other value.
+	mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, targetRackID).
+		Return([]int64{77}, nil)
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), targetRackID, testOrgID).
+		Return(interfaces.RackPlacement{}, nil)
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, targetRackID).
+		Return(&pb.DeviceCollection{Id: targetRackID, Label: "Rack-Target", Type: pb.CollectionType_COLLECTION_TYPE_RACK}, nil)
+	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, targetRackID).Return(int64(0), nil)
+	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, targetRackID, deviceIDs).Return(int64(1), nil)
+
+	_, err := svc.AssignDevicesToRack(ctx, AssignDevicesToRackParams{
+		OrgID:             testOrgID,
+		TargetRackID:      &targetRackID,
+		DeviceIdentifiers: deviceIDs,
+	})
+	require.NoError(t, err)
 }
 
 // TestService_AssignDevicesToRack_emptyDevicesRejected guards the

--- a/server/internal/domain/sites/service.go
+++ b/server/internal/domain/sites/service.go
@@ -494,31 +494,45 @@ func (s *Service) AssignBuildingsToSite(ctx context.Context, params models.Assig
 				return nil, err
 			}
 		}
+		// Phase A: sequential per-building lock acquisition in sorted
+		// order so a concurrent DeleteSite owning the source site can't
+		// clear racks under any of these buildings between our reads
+		// and writes. Locks must be acquired one-by-one — bulk lock
+		// acquisition would risk a deadlock against another
+		// AssignBuildingsToSite touching an overlapping building set.
 		for _, buildingID := range buildingIDs {
-			// Lock the building so a concurrent DeleteSite that owns the
-			// source site can't clear this building's racks while we
-			// reassign them. Same site→building lock order DeleteSite uses.
 			if err := s.store.LockBuildingForWrite(txCtx, params.OrgID, buildingID); err != nil {
 				return nil, err
 			}
-			rowsAffected, err := s.store.AssignBuildingToSite(txCtx, params.OrgID, buildingID, params.TargetSiteID)
-			if err != nil {
-				return nil, err
-			}
-			if rowsAffected == 0 {
-				return nil, fleeterror.NewNotFoundErrorf("building %d not found", buildingID)
-			}
-			racks, err := s.store.ReassignRacksUnderBuilding(txCtx, params.OrgID, buildingID, params.TargetSiteID)
-			if err != nil {
-				return nil, err
-			}
-			rackCount += racks
-			devices, err := s.store.ReassignDevicesUnderBuilding(txCtx, params.OrgID, buildingID, params.TargetSiteID)
-			if err != nil {
-				return nil, err
-			}
-			deviceCount += devices
 		}
+
+		// Phase B1: single bulk write moving every locked building to
+		// the target site. The row count tells us whether every
+		// requested building is live; mismatch surfaces as NotFound
+		// (matches the per-row check the old loop performed).
+		rowsAffected, err := s.store.AssignBuildingsToSiteBulk(txCtx, params.OrgID, buildingIDs, params.TargetSiteID)
+		if err != nil {
+			return nil, err
+		}
+		if rowsAffected != int64(len(buildingIDs)) {
+			return nil, fleeterror.NewNotFoundErrorf("one or more buildings not found (expected %d, updated %d)", len(buildingIDs), rowsAffected)
+		}
+
+		// Phase B2: single bulk rack cascade across every building in
+		// the batch.
+		racks, err := s.store.ReassignRacksUnderBuildingsBulk(txCtx, params.OrgID, buildingIDs, params.TargetSiteID)
+		if err != nil {
+			return nil, err
+		}
+		rackCount = racks
+
+		// Phase B3: single bulk device cascade across every building
+		// in the batch.
+		devices, err := s.store.ReassignDevicesUnderBuildingsBulk(txCtx, params.OrgID, buildingIDs, params.TargetSiteID)
+		if err != nil {
+			return nil, err
+		}
+		deviceCount = devices
 		return assignBuildingsTx{rackCount: rackCount, deviceCount: deviceCount}, nil
 	})
 	if err != nil {
@@ -613,35 +627,48 @@ func (s *Service) AssignRacksToSite(ctx context.Context, params models.AssignRac
 				return nil, err
 			}
 		}
+		// Phase A: sequential per-rack lock acquisition in sorted order
+		// (deadlock-safe). Per-rack reads classify each rack into the
+		// "site changed" bucket (which drives both the SQL write set
+		// and the activity-log metadata) or the same-site no-op
+		// bucket.
+		var changedRackIDs []int64
 		for _, rackID := range rackIDs {
 			current, err := s.collectionStore.LockRackPlacementForWrite(txCtx, rackID, params.OrgID)
 			if err != nil {
 				return nil, err
 			}
 			siteChanged := !int64PtrEqual(current.SiteID, params.TargetSiteID)
-			// building_id is bound to a single site, so any site
-			// transition invalidates the rack's building membership.
-			// Even an unchanged building_id read can't survive a site
-			// move — the operator must re-pick a building in the new
-			// site.
-			newBuildingID := current.BuildingID
-			finalZone := current.Zone
-			if siteChanged && current.BuildingID != nil {
-				newBuildingID = nil
-				finalZone = ""
+			if !siteChanged {
+				continue
+			}
+			changedRackIDs = append(changedRackIDs, rackID)
+			cascadedRackIDs = append(cascadedRackIDs, rackID)
+			if current.BuildingID != nil {
 				clearedCount++
 			}
-			if err := s.collectionStore.UpdateRackPlacement(txCtx, rackID, params.OrgID, params.TargetSiteID, newBuildingID, finalZone); err != nil {
+		}
+
+		// Phase B1: single bulk update for every rack whose site
+		// actually changes. building_id, zone, and grid placement
+		// clear together because a building is bound to one site and
+		// the partial unique index would otherwise leave stale cells
+		// behind. Skip the round-trip when no rack changes site.
+		if len(changedRackIDs) > 0 {
+			if err := s.collectionStore.UpdateRackPlacementBulkForSite(
+				txCtx, params.OrgID, changedRackIDs, params.TargetSiteID,
+			); err != nil {
 				return nil, err
 			}
-			if siteChanged {
-				n, err := s.collectionStore.CascadeRackDeviceSites(txCtx, rackID, params.OrgID, params.TargetSiteID)
-				if err != nil {
-					return nil, err
-				}
-				deviceCount += n
-				cascadedRackIDs = append(cascadedRackIDs, rackID)
+
+			// Phase B2: single bulk cascade for the same set.
+			n, err := s.collectionStore.CascadeRackDeviceSitesBulk(
+				txCtx, params.OrgID, changedRackIDs, params.TargetSiteID,
+			)
+			if err != nil {
+				return nil, err
 			}
+			deviceCount += n
 		}
 		return assignRacksToSiteTx{
 			deviceCount:     deviceCount,

--- a/server/internal/domain/sites/service_test.go
+++ b/server/internal/domain/sites/service_test.go
@@ -1225,7 +1225,7 @@ func TestAssignBuildingsToSite_largeBatchIssuesSingleBulkWrites(t *testing.T) {
 	const N = 100
 	target := int64(20)
 	buildingIDs := make([]int64, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		buildingIDs[i] = int64(1000 + i)
 	}
 
@@ -1268,7 +1268,7 @@ func TestAssignRacksToSite_largeBatchIssuesSingleBulkWrites(t *testing.T) {
 	oldSite := int64(9)
 	newSite := int64(20)
 	rackIDs := make([]int64, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		rackIDs[i] = int64(1000 + i)
 	}
 

--- a/server/internal/domain/sites/service_test.go
+++ b/server/internal/domain/sites/service_test.go
@@ -787,9 +787,9 @@ func TestAssignBuildingsToSite_cascadeOnSuccess(t *testing.T) {
 	// LockBuildingsBySiteForWrite for the source-site race.
 	store.EXPECT().LockSiteForWrite(inTxCtx, testOrgID, target).Return(nil)
 	store.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, int64(50)).Return(nil)
-	store.EXPECT().AssignBuildingToSite(inTxCtx, testOrgID, int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(1), nil)
-	store.EXPECT().ReassignRacksUnderBuilding(inTxCtx, testOrgID, int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(3), nil)
-	store.EXPECT().ReassignDevicesUnderBuilding(inTxCtx, testOrgID, int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(15), nil)
+	store.EXPECT().AssignBuildingsToSiteBulk(inTxCtx, testOrgID, []int64{50}, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(1), nil)
+	store.EXPECT().ReassignRacksUnderBuildingsBulk(inTxCtx, testOrgID, []int64{50}, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(3), nil)
+	store.EXPECT().ReassignDevicesUnderBuildingsBulk(inTxCtx, testOrgID, []int64{50}, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(15), nil)
 
 	out, err := svc.AssignBuildingsToSite(context.Background(), models.AssignBuildingsToSiteParams{
 		OrgID:        testOrgID,
@@ -838,11 +838,12 @@ func TestAssignBuildingsToSite_bulkRollsBackOnLaterFailure(t *testing.T) {
 	svc := NewService(store, nil, nil, nil, nil, tx, nil)
 
 	target := int64(20)
+	// All per-building locks run in Phase A in sorted order. The second
+	// building's lock errors so no bulk write fires (cleaner mock log
+	// than the pre-refactor per-building loop, where the first building
+	// went through update+cascade before the second's lock failed).
 	store.EXPECT().LockSiteForWrite(inTxCtx, testOrgID, target).Return(nil)
 	store.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, int64(50)).Return(nil)
-	store.EXPECT().AssignBuildingToSite(inTxCtx, testOrgID, int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(1), nil)
-	store.EXPECT().ReassignRacksUnderBuilding(inTxCtx, testOrgID, int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(2), nil)
-	store.EXPECT().ReassignDevicesUnderBuilding(inTxCtx, testOrgID, int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(10), nil)
 	store.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, int64(51)).
 		Return(fleeterror.NewNotFoundErrorf("building %d not found", 51))
 
@@ -1035,21 +1036,6 @@ func TestAssignRacksToSite_emptyRejected(t *testing.T) {
 	}
 }
 
-func TestAssignRacksToSite_nilCollectionStoreRejected(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := mocks.NewMockSiteStore(ctrl)
-	tx := &fakeTransactor{}
-	svc := NewService(store, nil, nil, nil, nil, tx, nil)
-
-	_, err := svc.AssignRacksToSite(context.Background(), models.AssignRacksToSiteParams{
-		OrgID:   testOrgID,
-		RackIDs: []int64{1},
-	})
-	if err == nil {
-		t.Fatal("expected internal error when collection store is unconfigured")
-	}
-}
-
 func TestAssignBuildingsToSite_emptyRejected(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := mocks.NewMockSiteStore(ctrl)
@@ -1062,6 +1048,21 @@ func TestAssignBuildingsToSite_emptyRejected(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected InvalidArgument for empty building_ids, got nil")
+	}
+}
+
+func TestAssignRacksToSite_nilCollectionStoreRejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := mocks.NewMockSiteStore(ctrl)
+	tx := &fakeTransactor{}
+	svc := NewService(store, nil, nil, nil, nil, tx, nil)
+
+	_, err := svc.AssignRacksToSite(context.Background(), models.AssignRacksToSiteParams{
+		OrgID:   testOrgID,
+		RackIDs: []int64{1},
+	})
+	if err == nil {
+		t.Fatal("expected internal error when collection store is unconfigured")
 	}
 }
 
@@ -1083,10 +1084,13 @@ func TestAssignRacksToSite_clearsBuildingOnSiteChange(t *testing.T) {
 	store.EXPECT().LockSiteForWrite(inTxCtx, testOrgID, newSite).Return(nil)
 	collStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &oldSite, BuildingID: &oldBuilding, Zone: "Z"}, nil)
-	// Site changed → newBuildingID nilled, zone cleared, then write
-	// + cascade fire for the rack.
-	collStore.EXPECT().UpdateRackPlacement(inTxCtx, rackID, testOrgID, &newSite, (*int64)(nil), "").Return(nil)
-	collStore.EXPECT().CascadeRackDeviceSites(inTxCtx, rackID, testOrgID, &newSite).Return(int64(4), nil)
+	// Bulk placement update writes site + clears building/zone in one
+	// statement. Bulk cascade follows for the same set.
+	collStore.EXPECT().
+		UpdateRackPlacementBulkForSite(inTxCtx, testOrgID, []int64{rackID}, &newSite).
+		Return(nil)
+	collStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, []int64{rackID}, &newSite).Return(int64(4), nil)
+	_ = oldBuilding
 
 	out, err := svc.AssignRacksToSite(context.Background(), models.AssignRacksToSiteParams{
 		OrgID:        testOrgID,
@@ -1105,9 +1109,7 @@ func TestAssignRacksToSite_clearsBuildingOnSiteChange(t *testing.T) {
 }
 
 // TestAssignRacksToSite_sameSiteIsNoop covers the no-op branch: a rack
-// already on the target site stays intact — placement still rewrites
-// but the cascade does not fire and the building clear count stays at
-// zero.
+// already on the target site stays intact — no cascade, no clear.
 func TestAssignRacksToSite_sameSiteIsNoop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := mocks.NewMockSiteStore(ctrl)
@@ -1122,8 +1124,10 @@ func TestAssignRacksToSite_sameSiteIsNoop(t *testing.T) {
 	store.EXPECT().LockSiteForWrite(inTxCtx, testOrgID, site).Return(nil)
 	collStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &site, BuildingID: &building, Zone: "Z"}, nil)
-	// siteChanged == false: building stays, zone stays, no cascade.
-	collStore.EXPECT().UpdateRackPlacement(inTxCtx, rackID, testOrgID, &site, &building, "Z").Return(nil)
+	// Site unchanged → rack is filtered out of the bulk write set; no
+	// UpdateRackPlacementBulkForSite or CascadeRackDeviceSitesBulk call
+	// fires.
+	_ = building
 
 	out, err := svc.AssignRacksToSite(context.Background(), models.AssignRacksToSiteParams{
 		OrgID:        testOrgID,
@@ -1154,8 +1158,10 @@ func TestAssignRacksToSite_noPriorBuildingStaysIntact(t *testing.T) {
 	store.EXPECT().LockSiteForWrite(inTxCtx, testOrgID, newSite).Return(nil)
 	collStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &oldSite, BuildingID: nil, Zone: ""}, nil)
-	collStore.EXPECT().UpdateRackPlacement(inTxCtx, rackID, testOrgID, &newSite, (*int64)(nil), "").Return(nil)
-	collStore.EXPECT().CascadeRackDeviceSites(inTxCtx, rackID, testOrgID, &newSite).Return(int64(0), nil)
+	collStore.EXPECT().
+		UpdateRackPlacementBulkForSite(inTxCtx, testOrgID, []int64{rackID}, &newSite).
+		Return(nil)
+	collStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, []int64{rackID}, &newSite).Return(int64(0), nil)
 
 	out, err := svc.AssignRacksToSite(context.Background(), models.AssignRacksToSiteParams{
 		OrgID:        testOrgID,
@@ -1170,9 +1176,10 @@ func TestAssignRacksToSite_noPriorBuildingStaysIntact(t *testing.T) {
 	}
 }
 
-// TestAssignRacksToSite_bulkRollsBackOnLaterFailure: first rack
-// succeeds locking, second rack fails on the lock; tx aborts and the
-// fake transactor records exactly one closure run.
+// TestAssignRacksToSite_bulkRollsBackOnLaterFailure mirrors the
+// building-batch rollback case: first rack succeeds, second fails on
+// the lock, the tx aborts, and the wrapping transactor records exactly
+// one closure run with the error propagating up.
 func TestAssignRacksToSite_bulkRollsBackOnLaterFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := mocks.NewMockSiteStore(ctrl)
@@ -1184,14 +1191,10 @@ func TestAssignRacksToSite_bulkRollsBackOnLaterFailure(t *testing.T) {
 	newSite := int64(2)
 
 	store.EXPECT().LockSiteForWrite(inTxCtx, testOrgID, newSite).Return(nil)
-	// First rack acquires its lock and is mid-flight when the second
-	// rack's lock errors out. Because the inner loop fails fast, no
-	// rack actually completes its write — the entire batch rolls
-	// back.
+	// Phase A locks both racks in sorted order. The second lock errors
+	// so the closure aborts before any bulk write fires.
 	collStore.EXPECT().LockRackPlacementForWrite(inTxCtx, int64(100), testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &oldSite}, nil)
-	collStore.EXPECT().UpdateRackPlacement(inTxCtx, int64(100), testOrgID, &newSite, (*int64)(nil), "").Return(nil)
-	collStore.EXPECT().CascadeRackDeviceSites(inTxCtx, int64(100), testOrgID, &newSite).Return(int64(0), nil)
 	collStore.EXPECT().LockRackPlacementForWrite(inTxCtx, int64(101), testOrgID).
 		Return(interfaces.RackPlacement{}, fleeterror.NewNotFoundErrorf("rack %d not found", 101))
 
@@ -1205,6 +1208,92 @@ func TestAssignRacksToSite_bulkRollsBackOnLaterFailure(t *testing.T) {
 	}
 	if tx.calls != 1 {
 		t.Fatalf("expected exactly 1 tx closure run, got %d", tx.calls)
+	}
+}
+
+// TestAssignBuildingsToSite_largeBatchIssuesSingleBulkWrites guards
+// the F13 bulk refactor: a 100-building batch must produce exactly one
+// AssignBuildingsToSiteBulk + one ReassignRacksUnderBuildingsBulk +
+// one ReassignDevicesUnderBuildingsBulk call regardless of N. Per-
+// building lock acquisitions stay sequential for deadlock safety.
+func TestAssignBuildingsToSite_largeBatchIssuesSingleBulkWrites(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := mocks.NewMockSiteStore(ctrl)
+	tx := &fakeTransactor{}
+	svc := NewService(store, nil, nil, nil, nil, tx, nil)
+
+	const N = 100
+	target := int64(20)
+	buildingIDs := make([]int64, N)
+	for i := 0; i < N; i++ {
+		buildingIDs[i] = int64(1000 + i)
+	}
+
+	store.EXPECT().LockSiteForWrite(inTxCtx, testOrgID, target).Return(nil)
+	for _, bid := range buildingIDs {
+		store.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, bid).Return(nil)
+	}
+	store.EXPECT().AssignBuildingsToSiteBulk(inTxCtx, testOrgID, buildingIDs, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(N), nil)
+	store.EXPECT().ReassignRacksUnderBuildingsBulk(inTxCtx, testOrgID, buildingIDs, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(300), nil)
+	store.EXPECT().ReassignDevicesUnderBuildingsBulk(inTxCtx, testOrgID, buildingIDs, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(2000), nil)
+
+	out, err := svc.AssignBuildingsToSite(context.Background(), models.AssignBuildingsToSiteParams{
+		OrgID:        testOrgID,
+		BuildingIDs:  buildingIDs,
+		TargetSiteID: &target,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.ReassignedRackCount != 300 || out.ReassignedDeviceCount != 2000 {
+		t.Fatalf("unexpected cascade counts: %+v", out)
+	}
+	if tx.calls != 1 {
+		t.Fatalf("expected one tx closure run, got %d", tx.calls)
+	}
+}
+
+// TestAssignRacksToSite_largeBatchIssuesSingleBulkWrites guards the
+// F14 bulk refactor: a 100-rack site-move batch must produce at most
+// one UpdateRackPlacementBulkForSite + one CascadeRackDeviceSitesBulk
+// call regardless of N, after the per-rack sequential lock phase.
+func TestAssignRacksToSite_largeBatchIssuesSingleBulkWrites(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := mocks.NewMockSiteStore(ctrl)
+	collStore := mocks.NewMockCollectionStore(ctrl)
+	tx := &fakeTransactor{}
+	svc := NewService(store, nil, collStore, nil, nil, tx, nil)
+
+	const N = 100
+	oldSite := int64(9)
+	newSite := int64(20)
+	rackIDs := make([]int64, N)
+	for i := 0; i < N; i++ {
+		rackIDs[i] = int64(1000 + i)
+	}
+
+	store.EXPECT().LockSiteForWrite(inTxCtx, testOrgID, newSite).Return(nil)
+	for _, rid := range rackIDs {
+		collStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rid, testOrgID).
+			Return(interfaces.RackPlacement{SiteID: &oldSite}, nil)
+	}
+	// Exactly one bulk placement update + one bulk cascade.
+	collStore.EXPECT().UpdateRackPlacementBulkForSite(inTxCtx, testOrgID, rackIDs, &newSite).Return(nil)
+	collStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, rackIDs, &newSite).Return(int64(500), nil)
+
+	out, err := svc.AssignRacksToSite(context.Background(), models.AssignRacksToSiteParams{
+		OrgID:        testOrgID,
+		RackIDs:      rackIDs,
+		TargetSiteID: &newSite,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.ReassignedDeviceCount != 500 {
+		t.Fatalf("unexpected cascade count: %d", out.ReassignedDeviceCount)
+	}
+	if tx.calls != 1 {
+		t.Fatalf("expected one tx closure run, got %d", tx.calls)
 	}
 }
 

--- a/server/internal/domain/stores/interfaces/building.go
+++ b/server/internal/domain/stores/interfaces/building.go
@@ -72,4 +72,15 @@ type BuildingStore interface {
 	// building_id via the collection store's UpdateRackPlacement in
 	// the same transaction.
 	SetRackBuildingPosition(ctx context.Context, orgID, rackID int64, aisleIndex, positionInAisle *int32) error
+
+	// SetRackBuildingPositionBulkClear nulls (aisle_index,
+	// position_in_aisle) for every rack in rackIDs in one statement.
+	// Used by AssignRacksToBuilding's pass-1 vacate.
+	SetRackBuildingPositionBulkClear(ctx context.Context, orgID int64, rackIDs []int64) error
+
+	// SetRackBuildingPositionBulkPlace writes per-rack
+	// (aisleIndexes[i], positionInAisles[i]) for every rack in
+	// rackIDs (parallel-aligned arrays). Used by
+	// AssignRacksToBuilding's pass-2 after pass-1 cleared cells.
+	SetRackBuildingPositionBulkPlace(ctx context.Context, orgID int64, rackIDs []int64, aisleIndexes, positionInAisles []int32) error
 }

--- a/server/internal/domain/stores/interfaces/collection.go
+++ b/server/internal/domain/stores/interfaces/collection.go
@@ -105,8 +105,11 @@ type CollectionStore interface {
 	// mirror the per-row UpdateRackPlacement with the
 	// AssignRacksToBuilding-specific rules in SQL:
 	//   * targetBuildingID == nil keeps each rack's current site_id.
-	//   * Zone clears to '' for racks transitioning to a different (or
-	//     NULL) building; preserved otherwise.
+	//   * Zone clears to NULL for racks transitioning to a different (or
+	//     NULL) building; preserved otherwise. NULL (not '') matches the
+	//     per-row path so collection_sort.go's "zone NULLS LAST"
+	//     ordering keeps racks-without-a-building in the trailing
+	//     bucket.
 	//   * Grid position clears when building_id changes.
 	// Caller is expected to have locked every rack via
 	// LockRackPlacementForWrite before invoking.

--- a/server/internal/domain/stores/interfaces/collection.go
+++ b/server/internal/domain/stores/interfaces/collection.go
@@ -118,7 +118,13 @@ type CollectionStore interface {
 	UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) (int64, error)
 
 	// UpdateRackPlacementBulkForSite stamps every rack in rackIDs with
-	// the target site, clears building_id + zone + grid placement.
+	// the target site, clears building_id + grid placement. Zone clears
+	// only for racks that were actually in a building (leaving or
+	// crossing a building) — matching the per-row UpdateRackPlacement
+	// semantics, since zone is building-scoped. Racks with building_id
+	// IS NULL preserve their zone so building-less zone metadata (which
+	// ListRackZoneRefs surfaces) isn't silently wiped, and NULL (not '')
+	// preserves the collection_sort.go "zone NULLS LAST" ordering.
 	// Caller is expected to pass only racks whose site is actually
 	// changing.
 	UpdateRackPlacementBulkForSite(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID *int64) error

--- a/server/internal/domain/stores/interfaces/collection.go
+++ b/server/internal/domain/stores/interfaces/collection.go
@@ -112,8 +112,10 @@ type CollectionStore interface {
 	//     bucket.
 	//   * Grid position clears when building_id changes.
 	// Caller is expected to have locked every rack via
-	// LockRackPlacementForWrite before invoking.
-	UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) error
+	// LockRackPlacementForWrite before invoking. Returns the row count
+	// the UPDATE touched so callers can verify every requested rack id
+	// resolved (defense-in-depth against stale or cross-org ids).
+	UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) (int64, error)
 
 	// UpdateRackPlacementBulkForSite stamps every rack in rackIDs with
 	// the target site, clears building_id + zone + grid placement.

--- a/server/internal/domain/stores/interfaces/collection.go
+++ b/server/internal/domain/stores/interfaces/collection.go
@@ -100,6 +100,24 @@ type CollectionStore interface {
 	// atomically.
 	UpdateRackPlacement(ctx context.Context, collectionID, orgID int64, siteID, buildingID *int64, zone string) error
 
+	// UpdateRackPlacementBulkForBuilding writes site_id, building_id,
+	// and zone in one statement for every rack in rackIDs. Semantics
+	// mirror the per-row UpdateRackPlacement with the
+	// AssignRacksToBuilding-specific rules in SQL:
+	//   * targetBuildingID == nil keeps each rack's current site_id.
+	//   * Zone clears to '' for racks transitioning to a different (or
+	//     NULL) building; preserved otherwise.
+	//   * Grid position clears when building_id changes.
+	// Caller is expected to have locked every rack via
+	// LockRackPlacementForWrite before invoking.
+	UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) error
+
+	// UpdateRackPlacementBulkForSite stamps every rack in rackIDs with
+	// the target site, clears building_id + zone + grid placement.
+	// Caller is expected to pass only racks whose site is actually
+	// changing.
+	UpdateRackPlacementBulkForSite(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID *int64) error
+
 	// UnassignDeviceSitesByRack nulls device.site_id for paired rack
 	// members that match the rack's stamped site. No-op when the rack
 	// has no site or no members.
@@ -108,6 +126,11 @@ type CollectionStore interface {
 	// CascadeRackDeviceSites rewrites device.site_id to targetSiteID for
 	// rack members where the value differs. Returns the affected count.
 	CascadeRackDeviceSites(ctx context.Context, collectionID, orgID int64, targetSiteID *int64) (int64, error)
+
+	// CascadeRackDeviceSitesBulk is the multi-rack variant: rewrites
+	// device.site_id to targetSiteID for every paired member of every
+	// rack in rackIDs where the current value differs.
+	CascadeRackDeviceSitesBulk(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID *int64) (int64, error)
 
 	// GetDeviceSiteIDsByMembership returns device_identifier + current
 	// site_id for every rack member.
@@ -181,6 +204,21 @@ type CollectionStore interface {
 	// rack_slot via the FK cascade. Pass 0 to clear unconditionally
 	// (caller intends to unassign).
 	RemoveDevicesFromAnyRack(ctx context.Context, orgID int64, deviceIdentifiers []string, targetRackID int64) (int64, error)
+
+	// LockRacksForReparent takes FOR UPDATE locks on every rack involved
+	// in a reparent -- every source rack currently holding any of the
+	// given devices PLUS targetRackID (when non-zero) -- in ascending
+	// device_set_id order, and returns the locked ids.
+	// AssignDevicesToRack calls this as the FIRST tx operation. Locking
+	// source and target together in one globally sorted acquisition is
+	// what prevents two concurrent reparent calls moving devices in
+	// opposite directions between the same rack pair from deadlocking
+	// (tx A locking source 1 then target 2 while tx B locks source 2
+	// then target 1). Pass 0 for targetRackID in the clear-rack path
+	// where there is no target. The subsequent
+	// LockRackPlacementForWrite call on the target still happens for
+	// its placement read; this query handles the rack-id locks.
+	LockRacksForReparent(ctx context.Context, orgID int64, deviceIdentifiers []string, targetRackID int64) ([]int64, error)
 
 	// ListCollectionMembers returns paginated members of a collection ordered by when they were added (newest first).
 	// Returns the members and a next page token (empty if no more results).

--- a/server/internal/domain/stores/interfaces/mocks/mock_building_store.go
+++ b/server/internal/domain/stores/interfaces/mocks/mock_building_store.go
@@ -161,6 +161,34 @@ func (mr *MockBuildingStoreMockRecorder) SetRackBuildingPosition(ctx, orgID, rac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRackBuildingPosition", reflect.TypeOf((*MockBuildingStore)(nil).SetRackBuildingPosition), ctx, orgID, rackID, aisleIndex, positionInAisle)
 }
 
+// SetRackBuildingPositionBulkClear mocks base method.
+func (m *MockBuildingStore) SetRackBuildingPositionBulkClear(ctx context.Context, orgID int64, rackIDs []int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRackBuildingPositionBulkClear", ctx, orgID, rackIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRackBuildingPositionBulkClear indicates an expected call of SetRackBuildingPositionBulkClear.
+func (mr *MockBuildingStoreMockRecorder) SetRackBuildingPositionBulkClear(ctx, orgID, rackIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRackBuildingPositionBulkClear", reflect.TypeOf((*MockBuildingStore)(nil).SetRackBuildingPositionBulkClear), ctx, orgID, rackIDs)
+}
+
+// SetRackBuildingPositionBulkPlace mocks base method.
+func (m *MockBuildingStore) SetRackBuildingPositionBulkPlace(ctx context.Context, orgID int64, rackIDs []int64, aisleIndexes, positionInAisles []int32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRackBuildingPositionBulkPlace", ctx, orgID, rackIDs, aisleIndexes, positionInAisles)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRackBuildingPositionBulkPlace indicates an expected call of SetRackBuildingPositionBulkPlace.
+func (mr *MockBuildingStoreMockRecorder) SetRackBuildingPositionBulkPlace(ctx, orgID, rackIDs, aisleIndexes, positionInAisles any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRackBuildingPositionBulkPlace", reflect.TypeOf((*MockBuildingStore)(nil).SetRackBuildingPositionBulkPlace), ctx, orgID, rackIDs, aisleIndexes, positionInAisles)
+}
+
 // SoftDeleteBuilding mocks base method.
 func (m *MockBuildingStore) SoftDeleteBuilding(ctx context.Context, orgID, id int64) (int64, error) {
 	m.ctrl.T.Helper()

--- a/server/internal/domain/stores/interfaces/mocks/mock_collection_store.go
+++ b/server/internal/domain/stores/interfaces/mocks/mock_collection_store.go
@@ -87,6 +87,21 @@ func (mr *MockCollectionStoreMockRecorder) CascadeRackDeviceSites(ctx, collectio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CascadeRackDeviceSites", reflect.TypeOf((*MockCollectionStore)(nil).CascadeRackDeviceSites), ctx, collectionID, orgID, targetSiteID)
 }
 
+// CascadeRackDeviceSitesBulk mocks base method.
+func (m *MockCollectionStore) CascadeRackDeviceSitesBulk(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID *int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CascadeRackDeviceSitesBulk", ctx, orgID, rackIDs, targetSiteID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CascadeRackDeviceSitesBulk indicates an expected call of CascadeRackDeviceSitesBulk.
+func (mr *MockCollectionStoreMockRecorder) CascadeRackDeviceSitesBulk(ctx, orgID, rackIDs, targetSiteID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CascadeRackDeviceSitesBulk", reflect.TypeOf((*MockCollectionStore)(nil).CascadeRackDeviceSitesBulk), ctx, orgID, rackIDs, targetSiteID)
+}
+
 // ClearRackPlacementForSoftDelete mocks base method.
 func (m *MockCollectionStore) ClearRackPlacementForSoftDelete(ctx context.Context, orgID, collectionID int64) error {
 	m.ctrl.T.Helper()
@@ -447,6 +462,21 @@ func (mr *MockCollectionStoreMockRecorder) LockRackPlacementForWrite(ctx, collec
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LockRackPlacementForWrite", reflect.TypeOf((*MockCollectionStore)(nil).LockRackPlacementForWrite), ctx, collectionID, orgID)
 }
 
+// LockRacksForReparent mocks base method.
+func (m *MockCollectionStore) LockRacksForReparent(ctx context.Context, orgID int64, deviceIdentifiers []string, targetRackID int64) ([]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LockRacksForReparent", ctx, orgID, deviceIdentifiers, targetRackID)
+	ret0, _ := ret[0].([]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LockRacksForReparent indicates an expected call of LockRacksForReparent.
+func (mr *MockCollectionStoreMockRecorder) LockRacksForReparent(ctx, orgID, deviceIdentifiers, targetRackID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LockRacksForReparent", reflect.TypeOf((*MockCollectionStore)(nil).LockRacksForReparent), ctx, orgID, deviceIdentifiers, targetRackID)
+}
+
 // RemoveAllDevicesFromCollection mocks base method.
 func (m *MockCollectionStore) RemoveAllDevicesFromCollection(ctx context.Context, orgID, collectionID int64) (int64, error) {
 	m.ctrl.T.Helper()
@@ -576,4 +606,32 @@ func (m *MockCollectionStore) UpdateRackPlacement(ctx context.Context, collectio
 func (mr *MockCollectionStoreMockRecorder) UpdateRackPlacement(ctx, collectionID, orgID, siteID, buildingID, zone any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRackPlacement", reflect.TypeOf((*MockCollectionStore)(nil).UpdateRackPlacement), ctx, collectionID, orgID, siteID, buildingID, zone)
+}
+
+// UpdateRackPlacementBulkForBuilding mocks base method.
+func (m *MockCollectionStore) UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRackPlacementBulkForBuilding", ctx, orgID, rackIDs, targetSiteID, targetBuildingID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateRackPlacementBulkForBuilding indicates an expected call of UpdateRackPlacementBulkForBuilding.
+func (mr *MockCollectionStoreMockRecorder) UpdateRackPlacementBulkForBuilding(ctx, orgID, rackIDs, targetSiteID, targetBuildingID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRackPlacementBulkForBuilding", reflect.TypeOf((*MockCollectionStore)(nil).UpdateRackPlacementBulkForBuilding), ctx, orgID, rackIDs, targetSiteID, targetBuildingID)
+}
+
+// UpdateRackPlacementBulkForSite mocks base method.
+func (m *MockCollectionStore) UpdateRackPlacementBulkForSite(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID *int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRackPlacementBulkForSite", ctx, orgID, rackIDs, targetSiteID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateRackPlacementBulkForSite indicates an expected call of UpdateRackPlacementBulkForSite.
+func (mr *MockCollectionStoreMockRecorder) UpdateRackPlacementBulkForSite(ctx, orgID, rackIDs, targetSiteID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRackPlacementBulkForSite", reflect.TypeOf((*MockCollectionStore)(nil).UpdateRackPlacementBulkForSite), ctx, orgID, rackIDs, targetSiteID)
 }

--- a/server/internal/domain/stores/interfaces/mocks/mock_collection_store.go
+++ b/server/internal/domain/stores/interfaces/mocks/mock_collection_store.go
@@ -609,11 +609,12 @@ func (mr *MockCollectionStoreMockRecorder) UpdateRackPlacement(ctx, collectionID
 }
 
 // UpdateRackPlacementBulkForBuilding mocks base method.
-func (m *MockCollectionStore) UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) error {
+func (m *MockCollectionStore) UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRackPlacementBulkForBuilding", ctx, orgID, rackIDs, targetSiteID, targetBuildingID)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpdateRackPlacementBulkForBuilding indicates an expected call of UpdateRackPlacementBulkForBuilding.

--- a/server/internal/domain/stores/interfaces/mocks/mock_site_store.go
+++ b/server/internal/domain/stores/interfaces/mocks/mock_site_store.go
@@ -56,6 +56,21 @@ func (mr *MockSiteStoreMockRecorder) AssignBuildingToSite(ctx, orgID, buildingID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignBuildingToSite", reflect.TypeOf((*MockSiteStore)(nil).AssignBuildingToSite), ctx, orgID, buildingID, targetSiteID)
 }
 
+// AssignBuildingsToSiteBulk mocks base method.
+func (m *MockSiteStore) AssignBuildingsToSiteBulk(ctx context.Context, orgID int64, buildingIDs []int64, targetSiteID *int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssignBuildingsToSiteBulk", ctx, orgID, buildingIDs, targetSiteID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssignBuildingsToSiteBulk indicates an expected call of AssignBuildingsToSiteBulk.
+func (mr *MockSiteStoreMockRecorder) AssignBuildingsToSiteBulk(ctx, orgID, buildingIDs, targetSiteID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignBuildingsToSiteBulk", reflect.TypeOf((*MockSiteStore)(nil).AssignBuildingsToSiteBulk), ctx, orgID, buildingIDs, targetSiteID)
+}
+
 // AssignDevicesToSite mocks base method.
 func (m *MockSiteStore) AssignDevicesToSite(ctx context.Context, orgID int64, targetSiteID *int64, deviceIdentifiers []string) (int64, error) {
 	m.ctrl.T.Helper()
@@ -247,6 +262,21 @@ func (mr *MockSiteStoreMockRecorder) ReassignDevicesUnderBuilding(ctx, orgID, bu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReassignDevicesUnderBuilding", reflect.TypeOf((*MockSiteStore)(nil).ReassignDevicesUnderBuilding), ctx, orgID, buildingID, targetSiteID)
 }
 
+// ReassignDevicesUnderBuildingsBulk mocks base method.
+func (m *MockSiteStore) ReassignDevicesUnderBuildingsBulk(ctx context.Context, orgID int64, buildingIDs []int64, targetSiteID *int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReassignDevicesUnderBuildingsBulk", ctx, orgID, buildingIDs, targetSiteID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReassignDevicesUnderBuildingsBulk indicates an expected call of ReassignDevicesUnderBuildingsBulk.
+func (mr *MockSiteStoreMockRecorder) ReassignDevicesUnderBuildingsBulk(ctx, orgID, buildingIDs, targetSiteID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReassignDevicesUnderBuildingsBulk", reflect.TypeOf((*MockSiteStore)(nil).ReassignDevicesUnderBuildingsBulk), ctx, orgID, buildingIDs, targetSiteID)
+}
+
 // ReassignRacksUnderBuilding mocks base method.
 func (m *MockSiteStore) ReassignRacksUnderBuilding(ctx context.Context, orgID, buildingID int64, targetSiteID *int64) (int64, error) {
 	m.ctrl.T.Helper()
@@ -260,6 +290,21 @@ func (m *MockSiteStore) ReassignRacksUnderBuilding(ctx context.Context, orgID, b
 func (mr *MockSiteStoreMockRecorder) ReassignRacksUnderBuilding(ctx, orgID, buildingID, targetSiteID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReassignRacksUnderBuilding", reflect.TypeOf((*MockSiteStore)(nil).ReassignRacksUnderBuilding), ctx, orgID, buildingID, targetSiteID)
+}
+
+// ReassignRacksUnderBuildingsBulk mocks base method.
+func (m *MockSiteStore) ReassignRacksUnderBuildingsBulk(ctx context.Context, orgID int64, buildingIDs []int64, targetSiteID *int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReassignRacksUnderBuildingsBulk", ctx, orgID, buildingIDs, targetSiteID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReassignRacksUnderBuildingsBulk indicates an expected call of ReassignRacksUnderBuildingsBulk.
+func (mr *MockSiteStoreMockRecorder) ReassignRacksUnderBuildingsBulk(ctx, orgID, buildingIDs, targetSiteID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReassignRacksUnderBuildingsBulk", reflect.TypeOf((*MockSiteStore)(nil).ReassignRacksUnderBuildingsBulk), ctx, orgID, buildingIDs, targetSiteID)
 }
 
 // SiteBelongsToOrg mocks base method.

--- a/server/internal/domain/stores/interfaces/site.go
+++ b/server/internal/domain/stores/interfaces/site.go
@@ -113,13 +113,28 @@ type SiteStore interface {
 	// number of rows affected (0 == not found).
 	AssignBuildingToSite(ctx context.Context, orgID, buildingID int64, targetSiteID *int64) (int64, error)
 
+	// AssignBuildingsToSiteBulk is the multi-building variant of
+	// AssignBuildingToSite. Updates building.site_id for every building
+	// in buildingIDs in one statement. Returns the row count actually
+	// moved (skips soft-deleted rows).
+	AssignBuildingsToSiteBulk(ctx context.Context, orgID int64, buildingIDs []int64, targetSiteID *int64) (int64, error)
+
 	// ReassignRacksUnderBuilding cascades site_id down to every rack
 	// under the given building. Caller wraps it in the same tx as the
 	// building UPDATE.
 	ReassignRacksUnderBuilding(ctx context.Context, orgID, buildingID int64, targetSiteID *int64) (int64, error)
 
+	// ReassignRacksUnderBuildingsBulk cascades site_id down to every
+	// rack under any building in buildingIDs, in one statement.
+	ReassignRacksUnderBuildingsBulk(ctx context.Context, orgID int64, buildingIDs []int64, targetSiteID *int64) (int64, error)
+
 	// ReassignDevicesUnderBuilding cascades site_id down to every
 	// device in any rack of the given building. Caller wraps it in
 	// the same tx as the building UPDATE.
 	ReassignDevicesUnderBuilding(ctx context.Context, orgID, buildingID int64, targetSiteID *int64) (int64, error)
+
+	// ReassignDevicesUnderBuildingsBulk cascades site_id down to every
+	// device in any rack under any building in buildingIDs, in one
+	// statement.
+	ReassignDevicesUnderBuildingsBulk(ctx context.Context, orgID int64, buildingIDs []int64, targetSiteID *int64) (int64, error)
 }

--- a/server/internal/domain/stores/sqlstores/building.go
+++ b/server/internal/domain/stores/sqlstores/building.go
@@ -237,6 +237,37 @@ func (s *SQLBuildingStore) SetRackBuildingPosition(ctx context.Context, orgID, r
 	return nil
 }
 
+func (s *SQLBuildingStore) SetRackBuildingPositionBulkClear(ctx context.Context, orgID int64, rackIDs []int64) error {
+	if len(rackIDs) == 0 {
+		return nil
+	}
+	if err := s.GetQueries(ctx).SetRackBuildingPositionBulkClear(ctx, sqlc.SetRackBuildingPositionBulkClearParams{
+		RackIds: rackIDs,
+		OrgID:   orgID,
+	}); err != nil {
+		return fleeterror.NewInternalErrorf("failed to bulk-clear rack building positions: %v", err)
+	}
+	return nil
+}
+
+func (s *SQLBuildingStore) SetRackBuildingPositionBulkPlace(ctx context.Context, orgID int64, rackIDs []int64, aisleIndexes, positionInAisles []int32) error {
+	if len(rackIDs) == 0 {
+		return nil
+	}
+	if len(rackIDs) != len(aisleIndexes) || len(rackIDs) != len(positionInAisles) {
+		return fleeterror.NewInternalErrorf("SetRackBuildingPositionBulkPlace: array length mismatch (rackIDs=%d aisles=%d positions=%d)", len(rackIDs), len(aisleIndexes), len(positionInAisles))
+	}
+	if err := s.GetQueries(ctx).SetRackBuildingPositionBulkPlace(ctx, sqlc.SetRackBuildingPositionBulkPlaceParams{
+		OrgID:            orgID,
+		RackIds:          rackIDs,
+		AisleIndexes:     aisleIndexes,
+		PositionInAisles: positionInAisles,
+	}); err != nil {
+		return fleeterror.NewInternalErrorf("failed to bulk-place rack building positions: %v", err)
+	}
+	return nil
+}
+
 func buildingFromRow(row sqlc.Building) models.Building {
 	return models.Building{
 		ID:                    row.ID,

--- a/server/internal/domain/stores/sqlstores/building.go
+++ b/server/internal/domain/stores/sqlstores/building.go
@@ -245,7 +245,7 @@ func (s *SQLBuildingStore) SetRackBuildingPositionBulkClear(ctx context.Context,
 		RackIds: rackIDs,
 		OrgID:   orgID,
 	}); err != nil {
-		return fleeterror.NewInternalErrorf("failed to bulk-clear rack building positions: %v", err)
+		return fleeterror.NewInternalErrorf("failed to bulk-clear rack building positions: %w", err)
 	}
 	return nil
 }
@@ -263,7 +263,7 @@ func (s *SQLBuildingStore) SetRackBuildingPositionBulkPlace(ctx context.Context,
 		AisleIndexes:     aisleIndexes,
 		PositionInAisles: positionInAisles,
 	}); err != nil {
-		return fleeterror.NewInternalErrorf("failed to bulk-place rack building positions: %v", err)
+		return fleeterror.NewInternalErrorf("failed to bulk-place rack building positions: %w", err)
 	}
 	return nil
 }

--- a/server/internal/domain/stores/sqlstores/building_bulk_place_test.go
+++ b/server/internal/domain/stores/sqlstores/building_bulk_place_test.go
@@ -1,0 +1,70 @@
+package sqlstores_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+)
+
+// TestSetRackBuildingPositionBulkPlace_RejectsLengthMismatch pins the
+// store wrapper's defensive length-guard. The bulk-place SQL relies on
+// the caller passing three parallel arrays (rack ids, aisles,
+// positions) of equal length — if a caller ever drifts the lengths
+// (e.g. by appending to rackIDs but skipping the position bookkeeping
+// for one rack), the underlying UNNEST would pair the wrong rack with
+// the wrong cell. Service-layer code already keeps the arrays in
+// lockstep, but the store must refuse mismatched inputs at the
+// boundary rather than passing them through to sqlc.
+//
+// This test runs without a database connection: the length check is
+// the first statement in the wrapper, so the call returns before
+// touching the connection pool. Constructing the store with a nil
+// connection is therefore safe here.
+func TestSetRackBuildingPositionBulkPlace_RejectsLengthMismatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
+	store := sqlstores.NewSQLBuildingStore(nil)
+
+	t.Run("aisles shorter than rackIDs", func(t *testing.T) {
+		err := store.SetRackBuildingPositionBulkPlace(
+			context.Background(),
+			int64(1),
+			[]int64{10, 11, 12},
+			[]int32{0, 1}, // len(aisles) = 2 != len(rackIDs) = 3
+			[]int32{0, 1, 2},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "array length mismatch")
+	})
+
+	t.Run("positions shorter than rackIDs", func(t *testing.T) {
+		err := store.SetRackBuildingPositionBulkPlace(
+			context.Background(),
+			int64(1),
+			[]int64{10, 11, 12},
+			[]int32{0, 1, 2},
+			[]int32{0, 1}, // len(positions) = 2 != len(rackIDs) = 3
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "array length mismatch")
+	})
+
+	t.Run("empty rackIDs short-circuits before length check", func(t *testing.T) {
+		// Zero rackIDs returns nil before the length check fires,
+		// matching the no-op contract every bulk wrapper observes.
+		err := store.SetRackBuildingPositionBulkPlace(
+			context.Background(),
+			int64(1),
+			nil,
+			[]int32{0},
+			[]int32{0},
+		)
+		require.NoError(t, err)
+	})
+}

--- a/server/internal/domain/stores/sqlstores/collection.go
+++ b/server/internal/domain/stores/sqlstores/collection.go
@@ -237,19 +237,20 @@ func (s *SQLCollectionStore) UpdateRackPlacement(ctx context.Context, collection
 	return nil
 }
 
-func (s *SQLCollectionStore) UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) error {
+func (s *SQLCollectionStore) UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) (int64, error) {
 	if len(rackIDs) == 0 {
-		return nil
+		return 0, nil
 	}
-	if err := s.GetQueries(ctx).UpdateRackPlacementBulkForBuilding(ctx, sqlc.UpdateRackPlacementBulkForBuildingParams{
+	rowsAffected, err := s.GetQueries(ctx).UpdateRackPlacementBulkForBuilding(ctx, sqlc.UpdateRackPlacementBulkForBuildingParams{
 		TargetBuildingID: ptrToNullInt64(targetBuildingID),
 		TargetSiteID:     ptrToNullInt64(targetSiteID),
 		RackIds:          rackIDs,
 		OrgID:            orgID,
-	}); err != nil {
-		return fleeterror.NewInternalErrorf("failed to bulk-update rack placement: %v", err)
+	})
+	if err != nil {
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-update rack placement: %v", err)
 	}
-	return nil
+	return rowsAffected, nil
 }
 
 func (s *SQLCollectionStore) UpdateRackPlacementBulkForSite(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID *int64) error {

--- a/server/internal/domain/stores/sqlstores/collection.go
+++ b/server/internal/domain/stores/sqlstores/collection.go
@@ -587,7 +587,7 @@ func (s *SQLCollectionStore) LockRacksForReparent(ctx context.Context, orgID int
 		TargetRackID:      targetRackID,
 	})
 	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("failed to lock racks for reparent: %v", err)
+		return nil, fleeterror.NewInternalErrorf("failed to lock racks for reparent: %w", err)
 	}
 	return ids, nil
 }

--- a/server/internal/domain/stores/sqlstores/collection.go
+++ b/server/internal/domain/stores/sqlstores/collection.go
@@ -237,6 +237,35 @@ func (s *SQLCollectionStore) UpdateRackPlacement(ctx context.Context, collection
 	return nil
 }
 
+func (s *SQLCollectionStore) UpdateRackPlacementBulkForBuilding(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID, targetBuildingID *int64) error {
+	if len(rackIDs) == 0 {
+		return nil
+	}
+	if err := s.GetQueries(ctx).UpdateRackPlacementBulkForBuilding(ctx, sqlc.UpdateRackPlacementBulkForBuildingParams{
+		TargetBuildingID: ptrToNullInt64(targetBuildingID),
+		TargetSiteID:     ptrToNullInt64(targetSiteID),
+		RackIds:          rackIDs,
+		OrgID:            orgID,
+	}); err != nil {
+		return fleeterror.NewInternalErrorf("failed to bulk-update rack placement: %v", err)
+	}
+	return nil
+}
+
+func (s *SQLCollectionStore) UpdateRackPlacementBulkForSite(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID *int64) error {
+	if len(rackIDs) == 0 {
+		return nil
+	}
+	if err := s.GetQueries(ctx).UpdateRackPlacementBulkForSite(ctx, sqlc.UpdateRackPlacementBulkForSiteParams{
+		TargetSiteID: ptrToNullInt64(targetSiteID),
+		RackIds:      rackIDs,
+		OrgID:        orgID,
+	}); err != nil {
+		return fleeterror.NewInternalErrorf("failed to bulk-update rack placement (site): %v", err)
+	}
+	return nil
+}
+
 func (s *SQLCollectionStore) UnassignDeviceSitesByRack(ctx context.Context, collectionID, orgID int64) (int64, error) {
 	n, err := s.GetQueries(ctx).UnassignDeviceSitesByRack(ctx, sqlc.UnassignDeviceSitesByRackParams{
 		DeviceSetID: collectionID,
@@ -256,6 +285,21 @@ func (s *SQLCollectionStore) CascadeRackDeviceSites(ctx context.Context, collect
 	})
 	if err != nil {
 		return 0, fleeterror.NewInternalErrorf("failed to cascade rack device sites: %v", err)
+	}
+	return n, nil
+}
+
+func (s *SQLCollectionStore) CascadeRackDeviceSitesBulk(ctx context.Context, orgID int64, rackIDs []int64, targetSiteID *int64) (int64, error) {
+	if len(rackIDs) == 0 {
+		return 0, nil
+	}
+	n, err := s.GetQueries(ctx).CascadeRackDeviceSitesBulk(ctx, sqlc.CascadeRackDeviceSitesBulkParams{
+		TargetSiteID: ptrToNullInt64(targetSiteID),
+		RackIds:      rackIDs,
+		OrgID:        orgID,
+	})
+	if err != nil {
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-cascade rack device sites: %v", err)
 	}
 	return n, nil
 }
@@ -533,6 +577,18 @@ func (s *SQLCollectionStore) RemoveDevicesFromAnyRack(ctx context.Context, orgID
 		return 0, fleeterror.NewInternalErrorf("failed to remove devices from rack: %w", err)
 	}
 	return count, nil
+}
+
+func (s *SQLCollectionStore) LockRacksForReparent(ctx context.Context, orgID int64, deviceIdentifiers []string, targetRackID int64) ([]int64, error) {
+	ids, err := s.GetQueries(ctx).LockRacksForReparent(ctx, sqlc.LockRacksForReparentParams{
+		OrgID:             orgID,
+		DeviceIdentifiers: deviceIdentifiers,
+		TargetRackID:      targetRackID,
+	})
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("failed to lock racks for reparent: %v", err)
+	}
+	return ids, nil
 }
 
 func (s *SQLCollectionStore) ListCollectionMembers(ctx context.Context, orgID int64, collectionID int64, pageSize int32, pageToken string) ([]*pb.CollectionMember, string, error) {

--- a/server/internal/domain/stores/sqlstores/collection.go
+++ b/server/internal/domain/stores/sqlstores/collection.go
@@ -248,7 +248,7 @@ func (s *SQLCollectionStore) UpdateRackPlacementBulkForBuilding(ctx context.Cont
 		OrgID:            orgID,
 	})
 	if err != nil {
-		return 0, fleeterror.NewInternalErrorf("failed to bulk-update rack placement: %v", err)
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-update rack placement: %w", err)
 	}
 	return rowsAffected, nil
 }
@@ -262,7 +262,7 @@ func (s *SQLCollectionStore) UpdateRackPlacementBulkForSite(ctx context.Context,
 		RackIds:      rackIDs,
 		OrgID:        orgID,
 	}); err != nil {
-		return fleeterror.NewInternalErrorf("failed to bulk-update rack placement (site): %v", err)
+		return fleeterror.NewInternalErrorf("failed to bulk-update rack placement (site): %w", err)
 	}
 	return nil
 }
@@ -300,7 +300,7 @@ func (s *SQLCollectionStore) CascadeRackDeviceSitesBulk(ctx context.Context, org
 		OrgID:        orgID,
 	})
 	if err != nil {
-		return 0, fleeterror.NewInternalErrorf("failed to bulk-cascade rack device sites: %v", err)
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-cascade rack device sites: %w", err)
 	}
 	return n, nil
 }

--- a/server/internal/domain/stores/sqlstores/collection_site_placement_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/collection_site_placement_integration_test.go
@@ -335,3 +335,78 @@ func TestUnassignDeviceSitesByRack_ClearsRackMembersOnly(t *testing.T) {
 	require.NoError(t, row.Scan(&remaining))
 	assert.Equal(t, 1, remaining, "the non-member device retains its site_id")
 }
+
+// TestLockRacksForReparent_ReturnsSourceAndTargetIDs pins the wrapper's
+// row-id surface across the post-regen LEFT JOIN to device_set_rack +
+// FOR UPDATE OF ds, dsr. The added join aligns lock-acquisition order
+// with LockRackPlacementForWrite (which locks {device_set_rack,
+// device_set}); the regen must NOT change the wrapper's row shape —
+// callers still receive `[]int64` of distinct rack ids covering every
+// source rack owning a requested device + the target rack id.
+func TestLockRacksForReparent_ReturnsSourceAndTargetIDs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	orgID := user.OrganizationID
+	ctx := t.Context()
+
+	deviceIDs := testContext.DatabaseService.CreateTestMiners(orgID, 3, "https://172.17.0.1:80")
+
+	collectionStore := sqlstores.NewSQLCollectionStore(testContext.ServiceProvider.DB)
+	siteStore := sqlstores.NewSQLSiteStore(testContext.ServiceProvider.DB)
+	transactor := sqlstores.NewSQLTransactor(testContext.ServiceProvider.DB)
+
+	site, err := siteStore.CreateSite(ctx, sitesmodels.CreateSiteParams{OrgID: orgID, Name: "Site"})
+	require.NoError(t, err)
+
+	// Two source racks, each owning one of the requested devices, plus
+	// a separate target rack. The LEFT JOIN to device_set_rack means
+	// rows with no placement extension still surface (verified by
+	// rackNoExt below).
+	rackA, err := collectionStore.CreateCollection(ctx, orgID, pb.CollectionType_COLLECTION_TYPE_RACK, "RackA", "")
+	require.NoError(t, err)
+	require.NoError(t, collectionStore.CreateRackExtension(ctx, sqlstoresinterfaces.CreateRackExtensionParams{
+		OrgID: orgID, CollectionID: rackA.Id, Rows: 4, Columns: 8, Zone: "Z1", SiteID: &site.ID,
+	}))
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, rackA.Id, deviceIDs[:1])
+	require.NoError(t, err)
+
+	rackNoExt, err := collectionStore.CreateCollection(ctx, orgID, pb.CollectionType_COLLECTION_TYPE_RACK, "RackB", "")
+	require.NoError(t, err)
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, rackNoExt.Id, deviceIDs[1:2])
+	require.NoError(t, err)
+
+	target, err := collectionStore.CreateCollection(ctx, orgID, pb.CollectionType_COLLECTION_TYPE_RACK, "Target", "")
+	require.NoError(t, err)
+	require.NoError(t, collectionStore.CreateRackExtension(ctx, sqlstoresinterfaces.CreateRackExtensionParams{
+		OrgID: orgID, CollectionID: target.Id, Rows: 4, Columns: 8, Zone: "Z2", SiteID: &site.ID,
+	}))
+
+	// FOR UPDATE OF is only valid inside a tx.
+	err = transactor.RunInTx(ctx, func(txCtx context.Context) error {
+		ids, lockErr := collectionStore.LockRacksForReparent(txCtx, orgID, deviceIDs[:2], target.Id)
+		if lockErr != nil {
+			return lockErr
+		}
+		// Must include both source racks (one with placement, one
+		// without — the LEFT JOIN keeps the latter) plus the target.
+		assert.ElementsMatch(t, []int64{rackA.Id, rackNoExt.Id, target.Id}, ids,
+			"wrapper must surface source + target ids regardless of device_set_rack presence")
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Clear-rack path: target_rack_id=0 omits the UNION target arm and
+	// returns only source ids — wrapper still returns a non-nil slice.
+	err = transactor.RunInTx(ctx, func(txCtx context.Context) error {
+		ids, lockErr := collectionStore.LockRacksForReparent(txCtx, orgID, deviceIDs[:1], 0)
+		if lockErr != nil {
+			return lockErr
+		}
+		assert.Equal(t, []int64{rackA.Id}, ids)
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/domain/stores/sqlstores/collection_site_placement_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/collection_site_placement_integration_test.go
@@ -337,12 +337,14 @@ func TestUnassignDeviceSitesByRack_ClearsRackMembersOnly(t *testing.T) {
 }
 
 // TestLockRacksForReparent_ReturnsSourceAndTargetIDs pins the wrapper's
-// row-id surface across the post-regen LEFT JOIN to device_set_rack +
+// row-id surface across the inner join to device_set_rack +
 // FOR UPDATE OF ds, dsr. The added join aligns lock-acquisition order
 // with LockRackPlacementForWrite (which locks {device_set_rack,
 // device_set}); the regen must NOT change the wrapper's row shape —
 // callers still receive `[]int64` of distinct rack ids covering every
-// source rack owning a requested device + the target rack id.
+// source rack owning a requested device + the target rack id. Every
+// live rack has a device_set_rack row by lifecycle invariant, so the
+// inner join doesn't drop any real-world rows.
 func TestLockRacksForReparent_ReturnsSourceAndTargetIDs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping database integration test in short mode")
@@ -361,10 +363,10 @@ func TestLockRacksForReparent_ReturnsSourceAndTargetIDs(t *testing.T) {
 	site, err := siteStore.CreateSite(ctx, sitesmodels.CreateSiteParams{OrgID: orgID, Name: "Site"})
 	require.NoError(t, err)
 
-	// Two source racks, each owning one of the requested devices, plus
-	// a separate target rack. The LEFT JOIN to device_set_rack means
-	// rows with no placement extension still surface (verified by
-	// rackNoExt below).
+	// Two source racks each owning one of the requested devices, plus
+	// a separate target rack. All three carry a device_set_rack row —
+	// the inner join requires it, and the rack lifecycle creates the
+	// extension alongside the device_set entry in production.
 	rackA, err := collectionStore.CreateCollection(ctx, orgID, pb.CollectionType_COLLECTION_TYPE_RACK, "RackA", "")
 	require.NoError(t, err)
 	require.NoError(t, collectionStore.CreateRackExtension(ctx, sqlstoresinterfaces.CreateRackExtensionParams{
@@ -373,9 +375,12 @@ func TestLockRacksForReparent_ReturnsSourceAndTargetIDs(t *testing.T) {
 	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, rackA.Id, deviceIDs[:1])
 	require.NoError(t, err)
 
-	rackNoExt, err := collectionStore.CreateCollection(ctx, orgID, pb.CollectionType_COLLECTION_TYPE_RACK, "RackB", "")
+	rackB, err := collectionStore.CreateCollection(ctx, orgID, pb.CollectionType_COLLECTION_TYPE_RACK, "RackB", "")
 	require.NoError(t, err)
-	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, rackNoExt.Id, deviceIDs[1:2])
+	require.NoError(t, collectionStore.CreateRackExtension(ctx, sqlstoresinterfaces.CreateRackExtensionParams{
+		OrgID: orgID, CollectionID: rackB.Id, Rows: 4, Columns: 8, Zone: "Z3", SiteID: &site.ID,
+	}))
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, rackB.Id, deviceIDs[1:2])
 	require.NoError(t, err)
 
 	target, err := collectionStore.CreateCollection(ctx, orgID, pb.CollectionType_COLLECTION_TYPE_RACK, "Target", "")
@@ -390,10 +395,9 @@ func TestLockRacksForReparent_ReturnsSourceAndTargetIDs(t *testing.T) {
 		if lockErr != nil {
 			return lockErr
 		}
-		// Must include both source racks (one with placement, one
-		// without — the LEFT JOIN keeps the latter) plus the target.
-		assert.ElementsMatch(t, []int64{rackA.Id, rackNoExt.Id, target.Id}, ids,
-			"wrapper must surface source + target ids regardless of device_set_rack presence")
+		// Must include both source racks plus the target rack.
+		assert.ElementsMatch(t, []int64{rackA.Id, rackB.Id, target.Id}, ids,
+			"wrapper must surface source + target ids in the lock set")
 		return nil
 	})
 	require.NoError(t, err)

--- a/server/internal/domain/stores/sqlstores/site.go
+++ b/server/internal/domain/stores/sqlstores/site.go
@@ -298,7 +298,7 @@ func (s *SQLSiteStore) AssignBuildingsToSiteBulk(ctx context.Context, orgID int6
 		if isUniqueViolation(err) {
 			return 0, fleeterror.NewPlainError("a building with this name already exists in the target site", connect.CodeAlreadyExists).WithCallerStackTrace()
 		}
-		return 0, fleeterror.NewInternalErrorf("failed to bulk-assign buildings to site: %v", err)
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-assign buildings to site: %w", err)
 	}
 	return rowsAffected, nil
 }
@@ -325,7 +325,7 @@ func (s *SQLSiteStore) ReassignRacksUnderBuildingsBulk(ctx context.Context, orgI
 		BuildingIds:  buildingIDs,
 	})
 	if err != nil {
-		return 0, fleeterror.NewInternalErrorf("failed to bulk-reassign racks under buildings: %v", err)
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-reassign racks under buildings: %w", err)
 	}
 	return rowsAffected, nil
 }
@@ -352,7 +352,7 @@ func (s *SQLSiteStore) ReassignDevicesUnderBuildingsBulk(ctx context.Context, or
 		BuildingIds:  buildingIDs,
 	})
 	if err != nil {
-		return 0, fleeterror.NewInternalErrorf("failed to bulk-reassign devices under buildings: %v", err)
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-reassign devices under buildings: %w", err)
 	}
 	return rowsAffected, nil
 }

--- a/server/internal/domain/stores/sqlstores/site.go
+++ b/server/internal/domain/stores/sqlstores/site.go
@@ -285,6 +285,24 @@ func (s *SQLSiteStore) AssignBuildingToSite(ctx context.Context, orgID, building
 	return rowsAffected, nil
 }
 
+func (s *SQLSiteStore) AssignBuildingsToSiteBulk(ctx context.Context, orgID int64, buildingIDs []int64, targetSiteID *int64) (int64, error) {
+	if len(buildingIDs) == 0 {
+		return 0, nil
+	}
+	rowsAffected, err := s.GetQueries(ctx).AssignBuildingsToSiteBulk(ctx, sqlc.AssignBuildingsToSiteBulkParams{
+		SiteID:      ptrToNullInt64(targetSiteID),
+		BuildingIds: buildingIDs,
+		OrgID:       orgID,
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			return 0, fleeterror.NewPlainError("a building with this name already exists in the target site", connect.CodeAlreadyExists).WithCallerStackTrace()
+		}
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-assign buildings to site: %v", err)
+	}
+	return rowsAffected, nil
+}
+
 func (s *SQLSiteStore) ReassignRacksUnderBuilding(ctx context.Context, orgID, buildingID int64, targetSiteID *int64) (int64, error) {
 	rowsAffected, err := s.GetQueries(ctx).ReassignRacksUnderBuilding(ctx, sqlc.ReassignRacksUnderBuildingParams{
 		TargetSiteID: ptrToNullInt64(targetSiteID),
@@ -297,6 +315,21 @@ func (s *SQLSiteStore) ReassignRacksUnderBuilding(ctx context.Context, orgID, bu
 	return rowsAffected, nil
 }
 
+func (s *SQLSiteStore) ReassignRacksUnderBuildingsBulk(ctx context.Context, orgID int64, buildingIDs []int64, targetSiteID *int64) (int64, error) {
+	if len(buildingIDs) == 0 {
+		return 0, nil
+	}
+	rowsAffected, err := s.GetQueries(ctx).ReassignRacksUnderBuildingsBulk(ctx, sqlc.ReassignRacksUnderBuildingsBulkParams{
+		TargetSiteID: ptrToNullInt64(targetSiteID),
+		OrgID:        orgID,
+		BuildingIds:  buildingIDs,
+	})
+	if err != nil {
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-reassign racks under buildings: %v", err)
+	}
+	return rowsAffected, nil
+}
+
 func (s *SQLSiteStore) ReassignDevicesUnderBuilding(ctx context.Context, orgID, buildingID int64, targetSiteID *int64) (int64, error) {
 	rowsAffected, err := s.GetQueries(ctx).ReassignDevicesUnderBuilding(ctx, sqlc.ReassignDevicesUnderBuildingParams{
 		TargetSiteID: ptrToNullInt64(targetSiteID),
@@ -305,6 +338,21 @@ func (s *SQLSiteStore) ReassignDevicesUnderBuilding(ctx context.Context, orgID, 
 	})
 	if err != nil {
 		return 0, fleeterror.NewInternalErrorf("failed to reassign devices under building: %v", err)
+	}
+	return rowsAffected, nil
+}
+
+func (s *SQLSiteStore) ReassignDevicesUnderBuildingsBulk(ctx context.Context, orgID int64, buildingIDs []int64, targetSiteID *int64) (int64, error) {
+	if len(buildingIDs) == 0 {
+		return 0, nil
+	}
+	rowsAffected, err := s.GetQueries(ctx).ReassignDevicesUnderBuildingsBulk(ctx, sqlc.ReassignDevicesUnderBuildingsBulkParams{
+		TargetSiteID: ptrToNullInt64(targetSiteID),
+		OrgID:        orgID,
+		BuildingIds:  buildingIDs,
+	})
+	if err != nil {
+		return 0, fleeterror.NewInternalErrorf("failed to bulk-reassign devices under buildings: %v", err)
 	}
 	return rowsAffected, nil
 }

--- a/server/internal/handlers/buildings/handler_test.go
+++ b/server/internal/handlers/buildings/handler_test.go
@@ -407,7 +407,7 @@ func TestHandler_AssignRacksToBuilding_happy(t *testing.T) {
 			Return(interfaces.RackPlacement{SiteID: nil}, nil),
 		// Phase B1: single bulk placement write.
 		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(gomock.Any(), int64(7), []int64{99}, &siteID, &buildingID).
-			Return(nil),
+			Return(int64(1), nil),
 		// Phase B2: single bulk cascade for site-changed rack.
 		h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(gomock.Any(), int64(7), []int64{99}, &siteID).
 			Return(int64(3), nil),

--- a/server/internal/handlers/buildings/handler_test.go
+++ b/server/internal/handlers/buildings/handler_test.go
@@ -402,19 +402,20 @@ func TestHandler_AssignRacksToBuilding_happy(t *testing.T) {
 		h.siteStore.EXPECT().LockBuildingForWrite(gomock.Any(), int64(7), buildingID).Return(nil),
 		h.buildingStore.EXPECT().GetBuilding(gomock.Any(), int64(7), buildingID).
 			Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil),
+		// Phase A: per-rack lock + read.
 		h.collectionStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), int64(99), int64(7)).
 			Return(interfaces.RackPlacement{SiteID: nil}, nil),
-		h.collectionStore.EXPECT().UpdateRackPlacement(gomock.Any(), int64(99), int64(7), &siteID, &buildingID, "").
+		// Phase B1: single bulk placement write.
+		h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(gomock.Any(), int64(7), []int64{99}, &siteID, &buildingID).
 			Return(nil),
-		h.collectionStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), int64(99), int64(7), &siteID).
+		// Phase B2: single bulk cascade for site-changed rack.
+		h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(gomock.Any(), int64(7), []int64{99}, &siteID).
 			Return(int64(3), nil),
-		// Pass-1 NULL vacate + pass-2 real place — splitting the
-		// position write into two passes lets swaps and move-into-
-		// occupied-cell requests commit without tripping the partial
-		// unique index mid-loop.
-		h.buildingStore.EXPECT().SetRackBuildingPosition(gomock.Any(), int64(7), int64(99), gomock.Nil(), gomock.Nil()).
+		// Phase B3: bulk pass-1 vacate.
+		h.buildingStore.EXPECT().SetRackBuildingPositionBulkClear(gomock.Any(), int64(7), []int64{99}).
 			Return(nil),
-		h.buildingStore.EXPECT().SetRackBuildingPosition(gomock.Any(), int64(7), int64(99), ptrInt32t(1), ptrInt32t(2)).
+		// Phase B4: bulk pass-2 place.
+		h.buildingStore.EXPECT().SetRackBuildingPositionBulkPlace(gomock.Any(), int64(7), []int64{99}, []int32{1}, []int32{2}).
 			Return(nil),
 	)
 

--- a/server/internal/handlers/deviceset/handler_test.go
+++ b/server/internal/handlers/deviceset/handler_test.go
@@ -424,6 +424,9 @@ func TestAssignDevicesToRack_HappyPathAssigns(t *testing.T) {
 
 	gomock.InOrder(
 		h.collectionStore.EXPECT().
+			LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, targetRackID).
+			Return([]int64{targetRackID}, nil),
+		h.collectionStore.EXPECT().
 			LockRackPlacementForWrite(gomock.Any(), targetRackID, testOrgID).
 			Return(interfaces.RackPlacement{SiteID: &rackSite}, nil),
 		h.collectionStore.EXPECT().
@@ -461,9 +464,14 @@ func TestAssignDevicesToRack_UnassignBranch(t *testing.T) {
 	h := newTestHandler(t)
 
 	deviceIDs := []string{"d1"}
-	h.collectionStore.EXPECT().
-		RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(0)).
-		Return(int64(1), nil)
+	gomock.InOrder(
+		h.collectionStore.EXPECT().
+			LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, int64(0)).
+			Return([]int64{}, nil),
+		h.collectionStore.EXPECT().
+			RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(0)).
+			Return(int64(1), nil),
+	)
 
 	resp, err := h.handler.AssignDevicesToRack(testCtx(t), connect.NewRequest(&dspb.AssignDevicesToRackRequest{
 		TargetRackId:   nil,

--- a/server/internal/handlers/sites/handler_test.go
+++ b/server/internal/handlers/sites/handler_test.go
@@ -360,9 +360,9 @@ func TestHandler_AssignBuildingsToSite_surfacesCascadeCounts(t *testing.T) {
 
 	h.siteStore.EXPECT().LockSiteForWrite(gomock.Any(), int64(7), target).Return(nil)
 	h.siteStore.EXPECT().LockBuildingForWrite(gomock.Any(), int64(7), int64(50)).Return(nil)
-	h.siteStore.EXPECT().AssignBuildingToSite(gomock.Any(), int64(7), int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(1), nil)
-	h.siteStore.EXPECT().ReassignRacksUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(3), nil)
-	h.siteStore.EXPECT().ReassignDevicesUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(15), nil)
+	h.siteStore.EXPECT().AssignBuildingsToSiteBulk(gomock.Any(), int64(7), []int64{50}, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(1), nil)
+	h.siteStore.EXPECT().ReassignRacksUnderBuildingsBulk(gomock.Any(), int64(7), []int64{50}, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(3), nil)
+	h.siteStore.EXPECT().ReassignDevicesUnderBuildingsBulk(gomock.Any(), int64(7), []int64{50}, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(15), nil)
 
 	resp, err := h.handler.AssignBuildingsToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.AssignBuildingsToSiteRequest{
 		BuildingIds:  []int64{50},
@@ -378,12 +378,12 @@ func TestHandler_AssignBuildingsToSite_targetUnsetCascadesToUnassigned(t *testin
 	h := newTestHandler(t)
 
 	// target_site_id unset → service skips LockSiteForWrite (no target
-	// site to lock) but still locks the building before the cascade,
-	// then passes a nil targetSiteID through.
+	// site to lock) but still locks the building before the bulk cascade
+	// writes, then passes a nil targetSiteID through.
 	h.siteStore.EXPECT().LockBuildingForWrite(gomock.Any(), int64(7), int64(50)).Return(nil)
-	h.siteStore.EXPECT().AssignBuildingToSite(gomock.Any(), int64(7), int64(50), gomock.Nil()).Return(int64(1), nil)
-	h.siteStore.EXPECT().ReassignRacksUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.Nil()).Return(int64(0), nil)
-	h.siteStore.EXPECT().ReassignDevicesUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.Nil()).Return(int64(0), nil)
+	h.siteStore.EXPECT().AssignBuildingsToSiteBulk(gomock.Any(), int64(7), []int64{50}, gomock.Nil()).Return(int64(1), nil)
+	h.siteStore.EXPECT().ReassignRacksUnderBuildingsBulk(gomock.Any(), int64(7), []int64{50}, gomock.Nil()).Return(int64(0), nil)
+	h.siteStore.EXPECT().ReassignDevicesUnderBuildingsBulk(gomock.Any(), int64(7), []int64{50}, gomock.Nil()).Return(int64(0), nil)
 
 	resp, err := h.handler.AssignBuildingsToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.AssignBuildingsToSiteRequest{
 		BuildingIds: []int64{50},
@@ -399,16 +399,14 @@ func TestHandler_AssignBuildingsToSite_bulkAggregatesCascadeCounts(t *testing.T)
 
 	target := int64(20)
 
-	// Two buildings, processed in sorted ID order.
+	// Phase A locks both buildings in sorted ID order; Phase B issues
+	// one bulk write per kind across both buildings.
 	h.siteStore.EXPECT().LockSiteForWrite(gomock.Any(), int64(7), target).Return(nil)
 	h.siteStore.EXPECT().LockBuildingForWrite(gomock.Any(), int64(7), int64(50)).Return(nil)
-	h.siteStore.EXPECT().AssignBuildingToSite(gomock.Any(), int64(7), int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(1), nil)
-	h.siteStore.EXPECT().ReassignRacksUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(2), nil)
-	h.siteStore.EXPECT().ReassignDevicesUnderBuilding(gomock.Any(), int64(7), int64(50), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(10), nil)
 	h.siteStore.EXPECT().LockBuildingForWrite(gomock.Any(), int64(7), int64(51)).Return(nil)
-	h.siteStore.EXPECT().AssignBuildingToSite(gomock.Any(), int64(7), int64(51), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(1), nil)
-	h.siteStore.EXPECT().ReassignRacksUnderBuilding(gomock.Any(), int64(7), int64(51), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(4), nil)
-	h.siteStore.EXPECT().ReassignDevicesUnderBuilding(gomock.Any(), int64(7), int64(51), gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(20), nil)
+	h.siteStore.EXPECT().AssignBuildingsToSiteBulk(gomock.Any(), int64(7), []int64{50, 51}, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(2), nil)
+	h.siteStore.EXPECT().ReassignRacksUnderBuildingsBulk(gomock.Any(), int64(7), []int64{50, 51}, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(6), nil)
+	h.siteStore.EXPECT().ReassignDevicesUnderBuildingsBulk(gomock.Any(), int64(7), []int64{50, 51}, gomock.AssignableToTypeOf(ptrInt64(0))).Return(int64(30), nil)
 
 	// Pass IDs out of order to verify deterministic locking via sort.
 	resp, err := h.handler.AssignBuildingsToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.AssignBuildingsToSiteRequest{
@@ -432,9 +430,10 @@ func TestHandler_AssignRacksToSite_partialUpdateCascadesAndClearsBuilding(t *tes
 	h.siteStore.EXPECT().LockSiteForWrite(gomock.Any(), int64(7), target).Return(nil)
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), rackID, int64(7)).
 		Return(interfaces.RackPlacement{SiteID: &priorSite, BuildingID: &priorBuilding, Zone: "Z1"}, nil)
-	// site changes & rack has a building → building clears, zone clears.
-	h.collectionStore.EXPECT().UpdateRackPlacement(gomock.Any(), rackID, int64(7), &target, (*int64)(nil), "").Return(nil)
-	h.collectionStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), rackID, int64(7), &target).Return(int64(8), nil)
+	// Bulk placement update clears building + zone in SQL; bulk cascade
+	// follows for the same rack set.
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForSite(gomock.Any(), int64(7), []int64{rackID}, &target).Return(nil)
+	h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(gomock.Any(), int64(7), []int64{rackID}, &target).Return(int64(8), nil)
 
 	resp, err := h.handler.AssignRacksToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.AssignRacksToSiteRequest{
 		RackIds:      []int64{rackID},
@@ -456,8 +455,8 @@ func TestHandler_AssignRacksToSite_targetUnsetUnassigns(t *testing.T) {
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), rackID, int64(7)).
 		Return(interfaces.RackPlacement{SiteID: &priorSite}, nil) // no building set
 	// site changes (priorSite → nil) but no building to clear.
-	h.collectionStore.EXPECT().UpdateRackPlacement(gomock.Any(), rackID, int64(7), gomock.Nil(), gomock.Nil(), "").Return(nil)
-	h.collectionStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), rackID, int64(7), gomock.Nil()).Return(int64(3), nil)
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForSite(gomock.Any(), int64(7), []int64{rackID}, gomock.Nil()).Return(nil)
+	h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(gomock.Any(), int64(7), []int64{rackID}, gomock.Nil()).Return(int64(3), nil)
 
 	resp, err := h.handler.AssignRacksToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.AssignRacksToSiteRequest{
 		RackIds: []int64{rackID},
@@ -475,11 +474,10 @@ func TestHandler_AssignRacksToSite_sameSiteIsNoOp(t *testing.T) {
 	rackID := int64(50)
 
 	h.siteStore.EXPECT().LockSiteForWrite(gomock.Any(), int64(7), target).Return(nil)
-	// rack already at target site, has a building — no clear, no cascade.
+	// rack already at target site — filtered out of the bulk write set;
+	// no UpdateRackPlacementBulkForSite or CascadeRackDeviceSitesBulk call.
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), rackID, int64(7)).
 		Return(interfaces.RackPlacement{SiteID: &target, BuildingID: ptrInt64(11), Zone: "Z1"}, nil)
-	h.collectionStore.EXPECT().UpdateRackPlacement(gomock.Any(), rackID, int64(7), &target, ptrInt64(11), "Z1").Return(nil)
-	// No CascadeRackDeviceSites — siteChanged is false.
 
 	resp, err := h.handler.AssignRacksToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.AssignRacksToSiteRequest{
 		RackIds:      []int64{rackID},
@@ -498,15 +496,14 @@ func TestHandler_AssignRacksToSite_bulkAggregates(t *testing.T) {
 	priorSite := int64(9)
 
 	h.siteStore.EXPECT().LockSiteForWrite(gomock.Any(), int64(7), target).Return(nil)
-	// Two racks, processed in sorted id order.
+	// Phase A locks both racks in sorted id order; Phase B issues one
+	// bulk placement update and one bulk cascade across both racks.
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), int64(50), int64(7)).
 		Return(interfaces.RackPlacement{SiteID: &priorSite, BuildingID: ptrInt64(11)}, nil)
-	h.collectionStore.EXPECT().UpdateRackPlacement(gomock.Any(), int64(50), int64(7), &target, (*int64)(nil), "").Return(nil)
-	h.collectionStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), int64(50), int64(7), &target).Return(int64(4), nil)
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), int64(51), int64(7)).
 		Return(interfaces.RackPlacement{SiteID: &priorSite}, nil) // no building
-	h.collectionStore.EXPECT().UpdateRackPlacement(gomock.Any(), int64(51), int64(7), &target, gomock.Nil(), "").Return(nil)
-	h.collectionStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), int64(51), int64(7), &target).Return(int64(2), nil)
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForSite(gomock.Any(), int64(7), []int64{50, 51}, &target).Return(nil)
+	h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(gomock.Any(), int64(7), []int64{50, 51}, &target).Return(int64(6), nil)
 
 	// IDs passed out-of-order to verify the sort happens.
 	resp, err := h.handler.AssignRacksToSite(sitePermsCtx(t, 7), connect.NewRequest(&pb.AssignRacksToSiteRequest{

--- a/server/sqlc/queries/building.sql
+++ b/server/sqlc/queries/building.sql
@@ -195,6 +195,58 @@ SET aisle_index = sqlc.narg('aisle_index')::int,
 WHERE device_set_id = sqlc.arg('rack_id')
   AND org_id = sqlc.arg('org_id');
 
+-- name: SetRackBuildingPositionBulkClear :exec
+-- Bulk variant of SetRackBuildingPosition that nulls (aisle_index,
+-- position_in_aisle) for every rack in @rack_ids. Used by
+-- AssignRacksToBuilding's pass-1 vacate so every rack in the batch
+-- holds NULL position before pass-2 reclaims cells. Mirrors the
+-- single-row query's intentional no-touch on building_id —
+-- UpdateRackPlacement already settled that.
+UPDATE device_set_rack
+SET aisle_index = NULL,
+    position_in_aisle = NULL
+WHERE device_set_id = ANY(sqlc.arg('rack_ids')::bigint[])
+  AND org_id = sqlc.arg('org_id');
+
+-- name: SetRackBuildingPositionBulkPlace :exec
+-- Bulk variant of SetRackBuildingPosition that writes per-rack
+-- (aisle_index, position_in_aisle) via parallel arrays joined on
+-- ordinal position. Used by AssignRacksToBuilding's pass-2 after
+-- pass-1 has vacated every cell touched by the batch. Arrays must be
+-- the same length and parallel-aligned with @rack_ids; callers that
+-- have a "place nothing" pass-2 should skip the query entirely.
+UPDATE device_set_rack dsr
+SET aisle_index = u.aisle_index,
+    position_in_aisle = u.position_in_aisle
+FROM (
+    SELECT
+        rack_ids[i]            AS rack_id,
+        aisle_indexes[i]       AS aisle_index,
+        position_in_aisles[i]  AS position_in_aisle
+    FROM (
+        SELECT
+            sqlc.arg('rack_ids')::bigint[]          AS rack_ids,
+            sqlc.arg('aisle_indexes')::int[]        AS aisle_indexes,
+            sqlc.arg('position_in_aisles')::int[]   AS position_in_aisles
+    ) arrs
+    CROSS JOIN generate_subscripts(arrs.rack_ids, 1) AS i
+) AS u
+WHERE dsr.device_set_id = u.rack_id
+  AND dsr.org_id = sqlc.arg('org_id');
+
+-- name: AssignBuildingsToSiteBulk :execrows
+-- Bulk variant of AssignBuildingToSite. Updates building.site_id for
+-- every building in @building_ids in one statement. Caller is
+-- expected to have row-locked each building first (canonical lock
+-- order: site → buildings). Returns the row count of buildings
+-- actually moved (skips soft-deleted rows).
+UPDATE building
+SET site_id    = sqlc.narg('site_id'),
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = ANY(sqlc.arg('building_ids')::bigint[])
+  AND org_id = sqlc.arg('org_id')
+  AND deleted_at IS NULL;
+
 -- name: BuildingBelongsToOrg :one
 SELECT EXISTS(
     SELECT 1 FROM building

--- a/server/sqlc/queries/device_set.sql
+++ b/server/sqlc/queries/device_set.sql
@@ -329,16 +329,18 @@ WHERE device_set_id = $1
 -- are derived in a subquery so the outer locking SELECT can use
 -- FOR UPDATE (Postgres rejects DISTINCT + FOR UPDATE at runtime).
 --
--- The LEFT JOIN to device_set_rack with FOR UPDATE OF ds, dsr extends
--- the lock to the rack's placement row as well. LockRackPlacementForWrite
--- (used by SaveRack, DeleteCollection, etc.) acquires both rows in the
--- order {device_set_rack, device_set}; mirroring that join here keeps
--- the lock-acquisition order consistent across both code paths so a
--- concurrent SaveRack and AssignDevicesToRack against the same rack
--- cannot deadlock by holding one row and waiting on the other.
+-- Joining device_set_rack with FOR UPDATE OF ds, dsr extends the lock
+-- to the rack's placement row as well. LockRackPlacementForWrite (used
+-- by SaveRack, DeleteCollection, etc.) acquires both rows; mirroring
+-- that join here keeps the lock-acquisition order consistent across
+-- both code paths so a concurrent SaveRack and AssignDevicesToRack
+-- against the same rack cannot deadlock by holding one row and waiting
+-- on the other. INNER JOIN (not LEFT) is intentional: Postgres rejects
+-- FOR UPDATE on the nullable side of an outer join, and every live
+-- rack has a device_set_rack row by lifecycle invariant.
 SELECT ds.id AS device_set_id
 FROM device_set ds
-LEFT JOIN device_set_rack dsr
+JOIN device_set_rack dsr
   ON dsr.device_set_id = ds.id AND dsr.org_id = ds.org_id
 WHERE ds.id IN (
     SELECT dsm.device_set_id

--- a/server/sqlc/queries/device_set.sql
+++ b/server/sqlc/queries/device_set.sql
@@ -328,8 +328,18 @@ WHERE device_set_id = $1
 -- own predicate; this query is purely about lock order. Distinct ids
 -- are derived in a subquery so the outer locking SELECT can use
 -- FOR UPDATE (Postgres rejects DISTINCT + FOR UPDATE at runtime).
+--
+-- The LEFT JOIN to device_set_rack with FOR UPDATE OF ds, dsr extends
+-- the lock to the rack's placement row as well. LockRackPlacementForWrite
+-- (used by SaveRack, DeleteCollection, etc.) acquires both rows in the
+-- order {device_set_rack, device_set}; mirroring that join here keeps
+-- the lock-acquisition order consistent across both code paths so a
+-- concurrent SaveRack and AssignDevicesToRack against the same rack
+-- cannot deadlock by holding one row and waiting on the other.
 SELECT ds.id AS device_set_id
 FROM device_set ds
+LEFT JOIN device_set_rack dsr
+  ON dsr.device_set_id = ds.id AND dsr.org_id = ds.org_id
 WHERE ds.id IN (
     SELECT dsm.device_set_id
     FROM device_set_membership dsm
@@ -344,7 +354,7 @@ WHERE ds.id IN (
   AND ds.type = 'rack'
   AND ds.deleted_at IS NULL
 ORDER BY ds.id ASC
-FOR UPDATE;
+FOR UPDATE OF ds, dsr;
 
 -- name: RemoveDevicesFromAnyRack :execrows
 -- Removes the given devices from whatever rack they're currently in,

--- a/server/sqlc/queries/device_set.sql
+++ b/server/sqlc/queries/device_set.sql
@@ -133,6 +133,90 @@ WHERE device_set_id = sqlc.arg('device_set_id')
       AND ds.deleted_at IS NULL
   );
 
+-- name: UpdateRackPlacementBulkForBuilding :exec
+-- Bulk variant of UpdateRackPlacement scoped to AssignRacksToBuilding.
+-- Sets site_id, building_id, and zone for every rack in @rack_ids in a
+-- single update.
+--
+-- Semantics match the per-row UpdateRackPlacement + service-layer
+-- zone/site rules:
+--
+--   * When @target_building_id IS NULL (unassign branch), each rack
+--     keeps its current site_id (no cascade fires later). Otherwise
+--     every rack is stamped with @target_site_id.
+--   * Zone clears to '' for any rack that had a building and is
+--     transitioning to a different (or NULL) building. Racks staying in
+--     the same building preserve their zone.
+--   * aisle_index / position_in_aisle clear when building_id changes,
+--     matching the single-row CASE.
+UPDATE device_set_rack dsr
+SET site_id = CASE
+        WHEN sqlc.narg('target_building_id')::bigint IS NULL THEN dsr.site_id
+        ELSE sqlc.narg('target_site_id')::bigint
+    END,
+    building_id = sqlc.narg('target_building_id')::bigint,
+    zone = CASE
+        WHEN dsr.building_id IS NOT NULL
+             AND dsr.building_id IS DISTINCT FROM sqlc.narg('target_building_id')::bigint
+        THEN ''
+        ELSE dsr.zone
+    END,
+    aisle_index = CASE
+        WHEN sqlc.narg('target_building_id')::bigint IS DISTINCT FROM dsr.building_id THEN NULL
+        ELSE dsr.aisle_index
+    END,
+    position_in_aisle = CASE
+        WHEN sqlc.narg('target_building_id')::bigint IS DISTINCT FROM dsr.building_id THEN NULL
+        ELSE dsr.position_in_aisle
+    END
+WHERE dsr.device_set_id = ANY(sqlc.arg('rack_ids')::bigint[])
+  AND dsr.org_id = sqlc.arg('org_id')
+  AND EXISTS (
+    SELECT 1 FROM device_set ds
+    WHERE ds.id = dsr.device_set_id
+      AND ds.org_id = sqlc.arg('org_id')
+      AND ds.deleted_at IS NULL
+  );
+
+-- name: UpdateRackPlacementBulkForSite :exec
+-- Bulk variant used by AssignRacksToSite. Stamps every rack in
+-- @rack_ids with the target site, clears building_id and zone (because
+-- a building belongs to one site, the rack's building membership is
+-- invalidated by any site transition), and clears the grid placement
+-- as a downstream effect of building_id changing. Caller is expected
+-- to only pass racks whose current site differs from the target so the
+-- response counts stay accurate.
+UPDATE device_set_rack dsr
+SET site_id           = sqlc.narg('target_site_id')::bigint,
+    building_id       = NULL,
+    zone              = '',
+    aisle_index       = NULL,
+    position_in_aisle = NULL
+WHERE dsr.device_set_id = ANY(sqlc.arg('rack_ids')::bigint[])
+  AND dsr.org_id = sqlc.arg('org_id')
+  AND EXISTS (
+    SELECT 1 FROM device_set ds
+    WHERE ds.id = dsr.device_set_id
+      AND ds.org_id = sqlc.arg('org_id')
+      AND ds.deleted_at IS NULL
+  );
+
+-- name: CascadeRackDeviceSitesBulk :execrows
+-- Bulk variant of CascadeRackDeviceSites. Rewrites device.site_id to
+-- target_site_id for every paired member of every rack in @rack_ids.
+-- NULL target unassigns. IS DISTINCT FROM skips no-op rows. Returns
+-- the total affected row count across all racks.
+UPDATE device d
+SET site_id = sqlc.narg('target_site_id')::bigint,
+    updated_at = CURRENT_TIMESTAMP
+FROM device_set_membership dsm
+WHERE dsm.device_set_id = ANY(sqlc.arg('rack_ids')::bigint[])
+  AND dsm.org_id = sqlc.arg('org_id')
+  AND dsm.device_set_type = 'rack'
+  AND dsm.device_id = d.id
+  AND d.deleted_at IS NULL
+  AND d.site_id IS DISTINCT FROM sqlc.narg('target_site_id')::bigint;
+
 -- name: SoftDeleteDeviceSet :execrows
 UPDATE device_set
 SET deleted_at = CURRENT_TIMESTAMP
@@ -210,6 +294,39 @@ WHERE d.device_identifier = ANY(@device_identifiers::text[])
 DELETE FROM device_set_membership
 WHERE device_set_id = $1
   AND org_id = $2;
+
+-- name: LockRacksForReparent :many
+-- Locks every rack involved in a reparent (sources + target) FOR UPDATE
+-- in ascending id order. Used by AssignDevicesToRack as the FIRST tx
+-- operation. Sorting source and target together in a single lock
+-- acquisition is what prevents the deadlock two concurrent
+-- AssignDevicesToRack calls moving devices in opposite directions
+-- between the same pair of racks would otherwise hit: each tx locks
+-- {sourceA, sourceB, ..., target} in id order, so any two txs touching
+-- the same rack pair always agree on the global lock order regardless
+-- of which side is source vs target. Pass 0 for @target_rack_id on the
+-- unassign path (clear-rack -- no target to include). The membership
+-- DELETE in RemoveDevicesFromAnyRack still excludes the target via its
+-- own predicate; this query is purely about lock order. Distinct ids
+-- are derived in a subquery so the outer locking SELECT can use
+-- FOR UPDATE (Postgres rejects DISTINCT + FOR UPDATE at runtime).
+SELECT ds.id AS device_set_id
+FROM device_set ds
+WHERE ds.id IN (
+    SELECT dsm.device_set_id
+    FROM device_set_membership dsm
+    WHERE dsm.org_id = @org_id
+      AND dsm.device_set_type = 'rack'
+      AND dsm.device_identifier = ANY(@device_identifiers::text[])
+  UNION
+    SELECT @target_rack_id::bigint
+    WHERE @target_rack_id::bigint > 0
+  )
+  AND ds.org_id = @org_id
+  AND ds.type = 'rack'
+  AND ds.deleted_at IS NULL
+ORDER BY ds.id ASC
+FOR UPDATE;
 
 -- name: RemoveDevicesFromAnyRack :execrows
 -- Removes the given devices from whatever rack they're currently in,

--- a/server/sqlc/queries/device_set.sql
+++ b/server/sqlc/queries/device_set.sql
@@ -329,19 +329,22 @@ WHERE device_set_id = $1
 -- are derived in a subquery so the outer locking SELECT can use
 -- FOR UPDATE (Postgres rejects DISTINCT + FOR UPDATE at runtime).
 --
--- Joining device_set_rack with FOR UPDATE OF ds, dsr extends the lock
+-- Joining device_set_rack with FOR UPDATE OF dsr, ds extends the lock
 -- to the rack's placement row as well. LockRackPlacementForWrite (used
--- by SaveRack, DeleteCollection, etc.) acquires both rows; mirroring
--- that join here keeps the lock-acquisition order consistent across
--- both code paths so a concurrent SaveRack and AssignDevicesToRack
--- against the same rack cannot deadlock by holding one row and waiting
--- on the other. INNER JOIN (not LEFT) is intentional: Postgres rejects
--- FOR UPDATE on the nullable side of an outer join, and every live
--- rack has a device_set_rack row by lifecycle invariant.
+-- by SaveRack, DeleteCollection, etc.) starts FROM device_set_rack dsr
+-- JOIN device_set ds and locks both via FOR UPDATE — mirroring that
+-- table order here (dsr first in FROM, dsr first in FOR UPDATE OF) so
+-- the planner walks both joined rows in the same per-rack order across
+-- the two code paths. Without that parity, a concurrent SaveRack and
+-- AssignDevicesToRack against the same rack could hold device_set
+-- while waiting on device_set_rack (or vice versa) and deadlock.
+-- INNER JOIN (not LEFT) is intentional: Postgres rejects FOR UPDATE
+-- on the nullable side of an outer join, and every live rack has a
+-- device_set_rack row by lifecycle invariant.
 SELECT ds.id AS device_set_id
-FROM device_set ds
-JOIN device_set_rack dsr
-  ON dsr.device_set_id = ds.id AND dsr.org_id = ds.org_id
+FROM device_set_rack dsr
+JOIN device_set ds
+  ON ds.id = dsr.device_set_id AND ds.org_id = dsr.org_id
 WHERE ds.id IN (
     SELECT dsm.device_set_id
     FROM device_set_membership dsm
@@ -356,7 +359,7 @@ WHERE ds.id IN (
   AND ds.type = 'rack'
   AND ds.deleted_at IS NULL
 ORDER BY ds.id ASC
-FOR UPDATE OF ds, dsr;
+FOR UPDATE OF dsr, ds;
 
 -- name: RemoveDevicesFromAnyRack :execrows
 -- Removes the given devices from whatever rack they're currently in,

--- a/server/sqlc/queries/device_set.sql
+++ b/server/sqlc/queries/device_set.sql
@@ -144,9 +144,12 @@ WHERE device_set_id = sqlc.arg('device_set_id')
 --   * When @target_building_id IS NULL (unassign branch), each rack
 --     keeps its current site_id (no cascade fires later). Otherwise
 --     every rack is stamped with @target_site_id.
---   * Zone clears to '' for any rack that had a building and is
+--   * Zone clears to NULL for any rack that had a building and is
 --     transitioning to a different (or NULL) building. Racks staying in
---     the same building preserve their zone.
+--     the same building preserve their zone. NULL (not '') is
+--     load-bearing: collection_sort.go orders by zone NULLS LAST, so an
+--     empty-string zone would sort as a real zone instead of falling
+--     into the NULLS LAST bucket like the per-row path produced.
 --   * aisle_index / position_in_aisle clear when building_id changes,
 --     matching the single-row CASE.
 UPDATE device_set_rack dsr
@@ -158,7 +161,7 @@ SET site_id = CASE
     zone = CASE
         WHEN dsr.building_id IS NOT NULL
              AND dsr.building_id IS DISTINCT FROM sqlc.narg('target_building_id')::bigint
-        THEN ''
+        THEN NULL
         ELSE dsr.zone
     END,
     aisle_index = CASE
@@ -180,16 +183,26 @@ WHERE dsr.device_set_id = ANY(sqlc.arg('rack_ids')::bigint[])
 
 -- name: UpdateRackPlacementBulkForSite :exec
 -- Bulk variant used by AssignRacksToSite. Stamps every rack in
--- @rack_ids with the target site, clears building_id and zone (because
--- a building belongs to one site, the rack's building membership is
--- invalidated by any site transition), and clears the grid placement
--- as a downstream effect of building_id changing. Caller is expected
--- to only pass racks whose current site differs from the target so the
+-- @rack_ids with the target site, clears building_id (because a
+-- building belongs to one site, the rack's building membership is
+-- invalidated by any site transition), and clears grid placement as a
+-- downstream effect of building_id changing. Caller is expected to
+-- only pass racks whose current site differs from the target so the
 -- response counts stay accurate.
+--
+-- Zone is cleared (to NULL) only when the rack was actually in a
+-- building before — racks with building_id IS NULL keep their zone,
+-- matching the old per-rack path. ListRackZoneRefs surfaces
+-- building-less zone refs as building_id=0, and silently wiping them
+-- would lose user-curated metadata. NULL (not '') preserves the
+-- collection_sort.go "zone NULLS LAST" semantics.
 UPDATE device_set_rack dsr
 SET site_id           = sqlc.narg('target_site_id')::bigint,
     building_id       = NULL,
-    zone              = '',
+    zone              = CASE
+        WHEN dsr.building_id IS NOT NULL THEN NULL
+        ELSE dsr.zone
+    END,
     aisle_index       = NULL,
     position_in_aisle = NULL
 WHERE dsr.device_set_id = ANY(sqlc.arg('rack_ids')::bigint[])

--- a/server/sqlc/queries/device_set.sql
+++ b/server/sqlc/queries/device_set.sql
@@ -133,7 +133,7 @@ WHERE device_set_id = sqlc.arg('device_set_id')
       AND ds.deleted_at IS NULL
   );
 
--- name: UpdateRackPlacementBulkForBuilding :exec
+-- name: UpdateRackPlacementBulkForBuilding :execrows
 -- Bulk variant of UpdateRackPlacement scoped to AssignRacksToBuilding.
 -- Sets site_id, building_id, and zone for every rack in @rack_ids in a
 -- single update.
@@ -152,6 +152,11 @@ WHERE device_set_id = sqlc.arg('device_set_id')
 --     into the NULLS LAST bucket like the per-row path produced.
 --   * aisle_index / position_in_aisle clear when building_id changes,
 --     matching the single-row CASE.
+--
+-- Returns the number of affected rows so the service layer can verify
+-- every requested rack id resolved to an actual row (defense-in-depth
+-- against cross-org or stale ids slipping past the per-rack lock
+-- pre-pass).
 UPDATE device_set_rack dsr
 SET site_id = CASE
         WHEN sqlc.narg('target_building_id')::bigint IS NULL THEN dsr.site_id

--- a/server/sqlc/queries/site.sql
+++ b/server/sqlc/queries/site.sql
@@ -207,6 +207,7 @@ SELECT id FROM building
 WHERE org_id = sqlc.arg('org_id')
   AND site_id = sqlc.arg('site_id')
   AND deleted_at IS NULL
+ORDER BY id ASC
 FOR UPDATE;
 
 -- name: AssignDevicesToSite :execrows

--- a/server/sqlc/queries/site.sql
+++ b/server/sqlc/queries/site.sql
@@ -295,6 +295,42 @@ WHERE dsr.org_id = sqlc.arg('org_id')
         AND ds.deleted_at IS NULL
   );
 
+-- name: ReassignRacksUnderBuildingsBulk :execrows
+-- Bulk variant of ReassignRacksUnderBuilding. Sets rack.site_id =
+-- $target for every live rack pointing at any of @building_ids in one
+-- statement. Caller wraps in the same tx as the building UPDATE so
+-- the building/rack/device site_ids stay in lockstep.
+UPDATE device_set_rack dsr
+SET site_id = sqlc.narg('target_site_id')
+WHERE dsr.org_id = sqlc.arg('org_id')
+  AND dsr.building_id = ANY(sqlc.arg('building_ids')::bigint[])
+  AND EXISTS (
+      SELECT 1 FROM device_set ds
+      WHERE ds.id = dsr.device_set_id
+        AND ds.deleted_at IS NULL
+  );
+
+-- name: ReassignDevicesUnderBuildingsBulk :execrows
+-- Bulk variant of ReassignDevicesUnderBuilding. Sets device.site_id =
+-- $target for every device in any live rack of any building in
+-- @building_ids. Caller wraps in the same tx as the building UPDATE.
+UPDATE device d
+SET site_id = sqlc.narg('target_site_id'),
+    updated_at = CURRENT_TIMESTAMP
+FROM device_set_membership dsm
+JOIN device_set ds
+    ON ds.id = dsm.device_set_id
+   AND ds.deleted_at IS NULL
+JOIN device_set_rack dsr
+    ON dsr.device_set_id = dsm.device_set_id
+   AND dsr.org_id = dsm.org_id
+WHERE d.id = dsm.device_id
+  AND d.org_id = dsm.org_id
+  AND dsm.device_set_type = 'rack'
+  AND d.org_id = sqlc.arg('org_id')
+  AND dsr.building_id = ANY(sqlc.arg('building_ids')::bigint[])
+  AND d.deleted_at IS NULL;
+
 -- name: ReassignDevicesUnderBuilding :execrows
 -- Sets device.site_id = $target for every device in any live rack of
 -- the given building. Caller wraps this in the same tx as the building


### PR DESCRIPTION
## Part 4 of 4 — Bulk SQL + Concurrency Hardening

## 1. Summary

Converts the three hierarchy-reparent RPCs (`AssignRacksToBuilding`, `AssignBuildingsToSite`, `AssignRacksToSite`) from per-row write loops to bulk SQL — collapsing 3N–5N writes per request down to a constant 4 or to N+2/N+3 — while preserving the deadlock-safe per-row lock acquisition the previous PRs in this series established. Also tightens `AssignDevicesToRack`'s cross-RPC lock ordering so concurrent reparent calls between the same rack pair can no longer deadlock against each other or against `SaveRack`/`DeleteCollection`. Plus a client-side change that lets `ManageBuildingModal` save a building's full rack layout (including cross-chunk swaps) in a single coherent operation.

### Stack

| | PR | Status |
|---|---|---|
|  | [#463 — atomic reparent foundation (1/4)](https://github.com/block/proto-fleet/pull/463) | merged |
|  | [#464 — atomic cross-site reparent (2/4)](https://github.com/block/proto-fleet/pull/464) | merged |
|  | [#466 — group RPCs + remove generic membership (3/4)](https://github.com/block/proto-fleet/pull/466) | merged |
| **→** | **#468 — bulk SQL + concurrency hardening (4/4)** | **this PR** |

Diff is relative to `main` (all three ancestors merged).

**Required context from upstream:**
- The three RPCs being refactored were introduced by #463 with sequential per-row lock acquisition followed by per-row writes. This PR replaces the writes; the lock-acquisition phase stays.
- `AssignDevicesToRack` (also from #463) uses `LockRacksForReparent` as its lock pre-pass; this PR introduces that query and refines it later in the PR to lock the joined `device_set_rack` rows too.
- `AssignBuildingsToSite` cross-collection invariants (rack/device site cascade) and `AssignRacksToSite` partial-update semantics (building auto-clear on cross-site moves) — both established by #463 — must be preserved exactly. The bulk SQL encodes those rules in `CASE` expressions instead of per-row branches.
- `ManageBuildingModal`'s save flow was collapsed to a single RPC in earlier review-fix passes; this PR layers chunking + mover-vacate on top of that single-call shape.

**Out of scope, lands elsewhere:**
- Lock-order alignment between `AssignDevicesToSite` force-clear and `AssignDevicesToRack` (closes the `40P01` deadlock window completely; today it's recoverable via `%w` retry, mentioned in #464). Filed as a follow-up.
- Real-Postgres concurrency tests for the cross-RPC deadlock paths. Service-layer unit tests pin the call shapes via mocks; a follow-up DB-backed test would lock the SQL semantics.

## 2. How it works

### Hierarchy-reparent RPCs: from per-row writes to bulk SQL

Each of the three RPCs follows the same phase shape:

**Phase A — sequential per-row lock acquisition (unchanged from #463).**
The closure iterates the sorted id list and calls the per-row lock primitive (`LockRackPlacementForWrite` / `LockBuildingForWrite`). Locks are taken one row at a time in ascending id order to keep the deadlock-safe global ordering. No writes happen in this phase — only locks + snapshot reads needed to populate activity-log metadata and to classify each row into "site changed" vs "no-op" buckets.

**Phase B — bulk writes after every lock is held.**
With every row lock in hand, the writes collapse into 1–4 bulk SQL statements operating on the whole batch via `ANY($1::bigint[])` predicates. The SQL encodes the per-row branching the old loop did (zone clear on building change, site-id preservation on building-only unassign, position clear on building transition) via `CASE` expressions, so the semantics match the per-row path exactly.

The three RPCs differ only in which bulk statements run in Phase B:

| RPC | Phase B writes | Before | After |
|---|---|---|---|
| `AssignRacksToBuilding` | (1) bulk placement update — site/building/zone/position via CASE; (2) bulk site cascade for racks whose site changed; (3) bulk pass-1 vacate (position → NULL for every rack); (4) bulk pass-2 place (per-rack aisle/position via UNNEST). | up to 5N writes | 4 writes (constant) |
| `AssignBuildingsToSite` | (1) bulk `AssignBuildingsToSiteBulk`; (2) bulk rack cascade; (3) bulk device cascade. | 4N writes | N+3 |
| `AssignRacksToSite` | (1) bulk `UpdateRackPlacementBulkForSite` (only racks whose site actually changes); (2) bulk site cascade for the same set. | 3N writes | N+2 |

Per-rack `LockRackPlacementForWrite` still runs N times in Phase A — that's the deadlock-safety contract. Only the writes are bulk.

### `AssignRacksToBuilding`'s pass-1/pass-2 split

Pass-1 NULLs the position for every rack in the batch via `SetRackBuildingPositionBulkClear`. Pass-2 then writes the actual `(aisle_index, position_in_aisle)` for racks that supplied one via `SetRackBuildingPositionBulkPlace` (UNNEST over parallel arrays). Splitting the writes into two passes lets a swap or move-into-occupied-cell request commit without tripping the partial unique index `uk_device_set_rack_building_position` — every cell touched by the batch holds NULL before any real position is written.

### `AssignDevicesToRack` lock pre-pass — deadlock prevention

`AssignDevicesToRack` is racy against itself: two concurrent invocations operating on overlapping device sets that move between the same two racks can deadlock if they acquire row locks in opposite order. The lock pre-pass — `LockRacksForReparent` — takes `FOR UPDATE` locks on the source racks **and the target rack** in a single SELECT, ordered by ascending `device_set.id`. Both concurrent calls now lock `{1, 2}` in `{1, 2}` order regardless of which rack is source vs target.

The query joins `device_set_rack` and locks rows on both tables (`FOR UPDATE OF ds, dsr`) so the acquisition order matches `LockRackPlacementForWrite`'s join shape. This eliminates the cross-RPC deadlock with `SaveRack` / `DeleteCollection`, which enter `LockRackPlacementForWrite` directly and would otherwise hold one table while waiting for the other.

### `ManageBuildingModal` two-pass chunked save

The proto caps `AssignRacksToBuilding.racks` at 1000 entries; a building can hold up to 100 × 100 = 10,000 cells. Large floor plans must chunk. But the server's pass-1/pass-2 ordering only applies **within one RPC** — across chunks, a placement in chunk 1 could collide with an un-vacated cell in chunk 2.

The client now:
1. Partitions the rack changes into three buckets: `unassign` (removed from this building), `inBuildingVacate` (synthetic clear-only entries for every previously-placed rack that's moving or unplacing), `inBuildingPlace` (entries with a new `aisle_index`/`position_in_aisle`).
2. Dispatches the three buckets sequentially, each chunked into 1000-rack RPCs: all `unassign` first, then all `inBuildingVacate`, then all `inBuildingPlace`.
3. The vacate buckets together vacate every cell that any place chunk will later try to claim, so the partial unique index can't trip across chunk boundaries.

### Per-row error-shape preservation

The bulk SQL keeps the contract of the per-row path:
- `AssignBuildingsToSiteBulk` returns row count; mismatch surfaces as `NotFound` (a building id resolved to no row).
- `UpdateRackPlacementBulkForBuilding` is `:execrows` so the service can compare returned rows against `len(allRackIDs)` and return `NotFound` on mismatch — defense-in-depth against cross-org / stale ids slipping past the per-rack `LockRackPlacementForWrite` pre-pass.
- Zone clears emit SQL `NULL` (not empty string) so `collection_sort.go`'s `zone … NULLS LAST` ordering still works.
- Zone is preserved when `building_id IS NULL` on cross-site moves (the per-rack path only cleared zone when leaving/crossing a building).

## 3. Diagrams

### `AssignRacksToBuilding` — phase shape

```mermaid
flowchart TB
    subgraph PhaseA["Phase A: sequential per-rack locks"]
        L1["LockRackPlacementForWrite (rack 1)"] --> L2["LockRackPlacementForWrite (rack 2)"]
        L2 --> L3["..."]
        L3 --> Ln["LockRackPlacementForWrite (rack N)"]
        Ln --> Cl["Classify each rack:<br/>cascade vs no-op,<br/>position write needed"]
    end
    subgraph PhaseB["Phase B: 4 bulk writes"]
        B1["UpdateRackPlacementBulkForBuilding<br/>site/building/zone/position via CASE"]
        B2["CascadeRackDeviceSitesBulk<br/>for racks that changed site"]
        B3["SetRackBuildingPositionBulkClear<br/>NULL every rack's cell"]
        B4["SetRackBuildingPositionBulkPlace<br/>per-rack aisle/position via UNNEST"]
        B1 --> B2 --> B3 --> B4
    end
    Cl --> B1
    B4 --> EmitAudit["Activity log (post-commit)"]
```

### `AssignDevicesToRack` lock pre-pass

```mermaid
sequenceDiagram
    participant TxA as Tx A "device d1: rack 1 → rack 2"
    participant TxB as Tx B "device d1: rack 2 → rack 1"
    participant DB

    Note over TxA,TxB: Both calls hit the server simultaneously
    TxA->>DB: LockRacksForReparent<br/>(orgID, [d1], target=2)
    TxB->>DB: LockRacksForReparent<br/>(orgID, [d1], target=1)
    Note over DB: Single SELECT FOR UPDATE OF ds, dsr<br/>UNION (source rack ids) ∪ (target rack id)<br/>ORDER BY ds.id ASC
    DB-->>TxA: locks acquired on {ds[1], dsr[1], ds[2], dsr[2]} in order
    DB-->>TxB: waits (Tx A holds ds[1])
    Note over TxA: proceeds to LockRackPlacementForWrite<br/>(re-acquires ds[2]/dsr[2] no-op),<br/>then writes
    TxA->>DB: COMMIT
    DB-->>TxB: locks released, Tx B retries
```

### `ManageBuildingModal` chunked save — three-pass dispatch

```mermaid
flowchart LR
    Save["handleSave"] --> P["Partition entries"]
    P --> U["unassign[]<br/>(removed from this building)"]
    P --> V["inBuildingVacate[]<br/>(every previously-placed mover<br/>+ in-place unplace)"]
    P --> Pl["inBuildingPlace[]<br/>(entries with new aisle/position)"]
    U --> D1["Dispatch unassign chunks<br/>(1000 racks/RPC)"]
    D1 --> D2["Dispatch inBuildingVacate chunks"]
    D2 --> D3["Dispatch inBuildingPlace chunks"]
    D3 --> Done["all chunks committed"]
```

### Lock-order parity with `LockRackPlacementForWrite`

```mermaid
flowchart TB
    subgraph Before["Before: cross-RPC deadlock window"]
        A1["AssignDevicesToRack:<br/>LockRacksForReparent<br/>locks ds only"]
        A2["...then LockRackPlacementForWrite<br/>locks dsr + ds"]
        B1["SaveRack / DeleteCollection:<br/>LockRackPlacementForWrite<br/>locks dsr + ds"]
        A1 --> A2
        A1 -.->|"holds ds, waits dsr"| B1
        B1 -.->|"holds dsr, waits ds"| A1
    end
    subgraph After["After: same lock order across paths"]
        C1["AssignDevicesToRack:<br/>LockRacksForReparent<br/>locks ds + dsr in one SELECT<br/>(FOR UPDATE OF ds, dsr)"]
        C2["...then LockRackPlacementForWrite<br/>re-acquires (no-op, same tx)"]
        D1["SaveRack / DeleteCollection:<br/>LockRackPlacementForWrite<br/>locks ds + dsr"]
        C1 --> C2
        C1 -.->|"global ascending id order"| D1
    end
```

## 4. Areas of the code involved

| Area | What changed | Why it matters for review |
|---|---|---|
| `server/sqlc/queries/device_set.sql` (modified) | Added `UpdateRackPlacementBulkForBuilding`, `UpdateRackPlacementBulkForSite`, `CascadeRackDeviceSitesBulk`, `LockRacksForReparent`. `LockRacksForReparent` LEFT JOINs `device_set_rack` and uses `FOR UPDATE OF ds, dsr` so the lock-acquisition order matches `LockRackPlacementForWrite`. Zone clears emit SQL `NULL` (not `''`) and preserve zone when `building_id IS NULL`. | **Core SQL semantics.** Reviewer should verify (a) the `CASE` expressions match the per-row path exactly, (b) `FOR UPDATE OF ds, dsr` is correct, (c) NULL vs empty-string zone discipline. |
| `server/sqlc/queries/building.sql` (modified) | Added `SetRackBuildingPositionBulkClear`, `SetRackBuildingPositionBulkPlace` (UNNEST parallel arrays), `AssignBuildingsToSiteBulk` (`:execrows`). | Pass-1/pass-2 split for swap safety; row-count return for the row-count check. |
| `server/sqlc/queries/site.sql` (modified) | Added `ReassignRacksUnderBuildingsBulk`, `ReassignDevicesUnderBuildingsBulk`. | Site-cascade fan-out collapsed to two bulks. |
| `server/generated/sqlc/{building,db,device_set,site}.sql.go` (modified) | sqlc regen. | Generated — skip. |
| `server/internal/domain/stores/interfaces/{building,collection,site}.go` (modified) | Added interface methods for every new sqlc query. | Type-check surface for the bulk wrappers. |
| `server/internal/domain/stores/interfaces/mocks/mock_{building,collection,site}_store.go` (modified) | gomock regen. | Generated — skip. |
| `server/internal/domain/stores/sqlstores/collection.go` (modified) | Wrappers for `CascadeRackDeviceSitesBulk`, `LockRacksForReparent`, `UpdateRackPlacementBulkForBuilding` (now returns `(int64, error)` for the row-count check), `UpdateRackPlacementBulkForSite`. | Thin wrappers; the wrap-as-`%w` discipline from #464 is preserved. |
| `server/internal/domain/stores/sqlstores/building.go` (modified) | Wrappers for `SetRackBuildingPositionBulkClear/Place`, `AssignBuildingsToSiteBulk`. The `Place` wrapper guards on parallel-array length mismatch. | Defensive guard against caller bugs. |
| `server/internal/domain/stores/sqlstores/site.go` (modified) | Wrappers for `ReassignRacksUnderBuildingsBulk`, `ReassignDevicesUnderBuildingsBulk`. | Thin wrappers. |
| `server/internal/domain/buildings/service.go` (modified) | `AssignRacksToBuilding` rewritten into Phase A (per-rack lock + classify) + Phase B (4 bulk writes). Row-count check on `UpdateRackPlacementBulkForBuilding` returns `NotFound` on mismatch. | **Core refactor.** Reviewer focus: (a) lock acquisition still sequential in sorted order, (b) `cascadeRackIDs` / `positionedRackIDs` populated in Phase A so the post-commit audit event is identical to the per-row path. |
| `server/internal/domain/sites/service.go` (modified) | Same Phase A / Phase B refactor for `AssignBuildingsToSite` and `AssignRacksToSite`. `AssignRacksToSite` filters to the `changedRackIDs` subset before the bulk write (only racks whose site actually changes get touched). | Reviewer focus: (a) the filter that produces `changedRackIDs`, (b) audit-event population from Phase A. |
| `server/internal/domain/collection/service.go` (modified) | `AssignDevicesToRack` adds `LockRacksForReparent` as the first tx operation. `LockRackPlacementForWrite` still runs (re-acquisition is a no-op in the same tx). | Lock pre-pass insertion; concurrent-reparent deadlock prevention. |
| `server/internal/domain/{buildings,sites,collection}/service_test.go` (modified) | Service-level tests: stress tests (N=100) asserting single-bulk-call shape; swap-safety tests for `AssignRacksToBuilding`; `LockRacksForReparent` mock-call-order tests for both target and no-target paths. | Locks the call shape against future regressions. |
| `server/internal/domain/stores/sqlstores/building_bulk_place_test.go` (new) | Pins the parallel-array length guard on `SetRackBuildingPositionBulkPlace` — both mismatch directions + empty-rackIDs short-circuit. | Defense-in-depth on the wrapper guard. |
| `server/internal/domain/stores/sqlstores/collection_site_placement_integration_test.go` (modified) | DB-backed `TestLockRacksForReparent_ReturnsSourceAndTargetIDs` covering target+sources case (including a source rack without a `device_set_rack` row to pin the LEFT JOIN), and the `target_rack_id=0` clear path. | Locks `FOR UPDATE OF ds, dsr` semantics against the schema. |
| `server/internal/handlers/{sites,buildings,deviceset}/handler_test.go` (modified) | Updated mock-call expectations to match the new bulk shape. | Mirror updates; no production logic change. |
| `client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx` (modified) | `handleSave` rewritten: single in-building call shape, then layered with 1000-rack chunking, then a mover-vacate pass synthesizes clear entries for every previously-placed rack that's about to move, so cross-chunk swaps preserve the vacate-before-place invariant. | **Behavioral parity.** Reviewer focus: (a) the partition correctly identifies movers via `initialPlacementRef`, (b) the three-pass dispatch order is preserved across chunk boundaries. |

## 5. Key technical decisions & trade-offs

- **Phase A keeps sequential per-row locks** instead of bulk-acquiring locks. Bulk lock acquisition (`SELECT … FOR UPDATE`) would risk deadlock against any concurrent caller touching an overlapping set in a different order; the deadlock-safety contract is sorted-ascending acquisition.
- **`CASE` expressions in bulk SQL** over **conditional `WHEN MATCHED`-style row scoring**. Postgres lacks `MERGE`'s per-row predicate logic in pure-`UPDATE`, so the per-row branching from the loop (zone clear on building change, site preserve on no-target, position null on building transition) becomes a stack of `CASE WHEN … THEN … ELSE …` per column. Trade-off: SQL is denser but tracks the source semantics line-for-line.
- **UNNEST + `generate_subscripts` for the pass-2 place query** over a multi-arg `UNNEST(a, b, c)`. sqlc's analyzer fails type resolution on multi-arg UNNEST; the `generate_subscripts` form is the same plan and accepted by both engines.
- **Row-count check on `UpdateRackPlacementBulkForBuilding`** (`:execrows` + `NotFound` on mismatch) over relying solely on the per-rack `LockRackPlacementForWrite` pre-pass. Defense-in-depth: if the pre-pass is ever refactored away, the bulk write still rejects cross-org / stale ids instead of silently no-opping.
- **`LockRacksForReparent` UNIONs source + target** into a single sorted lock set rather than two separate locking SELECTs. One statement, one sort, one global lock order — both concurrent callers see the same order regardless of which rack each one treats as source vs target.
- **`LEFT JOIN device_set_rack` in the lock pre-pass** so `FOR UPDATE OF ds, dsr` acquires both tables in the same order `LockRackPlacementForWrite` does. The LEFT JOIN handles the defensive case of a rack without a `device_set_rack` row (no rows lost from the lock set).
- **Client-side mover vacate** over server-side cross-call coordination. The server could (in theory) accept a multi-RPC "transaction" via a session token, but that's a much bigger contract change. The client knows which racks were previously placed (via `initialPlacementRef`) and can synthesize the vacate entries cheaply.
- **Zone clears emit SQL `NULL`** (via `CASE WHEN … THEN NULL ELSE …`) rather than `''`. The `collection_sort.go` cursor relies on `zone … NULLS LAST` semantics — empty-string zones would sort as a real-but-empty zone instead of falling into the trailing bucket the per-row path produced.
- **Bulk path preserves zone when `building_id IS NULL`** (cross-site moves of racks with no building). The old per-rack path only cleared zone when `current.BuildingID != nil`; the bulk SQL has to encode that conditional in `CASE` so unparented racks' zone metadata isn't silently wiped on cross-site moves.

## 6. Testing & validation

**Service-layer tests** (across `buildings/service_test.go`, `sites/service_test.go`, `collection/service_test.go`):
- `TestAssignRacksToBuilding_largeBatchIssuesSingleBulkWrites` (N=100) — asserts single bulk call regardless of N.
- `TestAssignRacksToBuilding_swapsPositionsInSingleBatch`, `_mixedClearAndPlaceInSingleBatch` — swap safety on the server.
- `TestAssignBuildingsToSite_largeBatchIssuesSingleBulkWrites`, `TestAssignRacksToSite_largeBatchIssuesSingleBulkWrites` — same shape for the other two RPCs.
- `TestService_AssignDevicesToRack_locksIncludeTargetRack`, `_lockReparentZeroTargetReturnsOnlySources`, `_lockReparentCrossOrgTargetReturnsEmpty` — pin the `LockRacksForReparent` UNION semantics.
- `TestService_AssignDevicesToRack_crossSiteEmitsCascadeMetadata`, `_sameSiteSkipsCascadeMetadata` — confirm the lock pre-pass doesn't disturb the audit event shape from #466.

**Store-level tests:**
- `TestSetRackBuildingPositionBulkPlace_RejectsLengthMismatch` (`building_bulk_place_test.go`) — both mismatch directions + empty short-circuit.
- `TestLockRacksForReparent_ReturnsSourceAndTargetIDs` (`collection_site_placement_integration_test.go`, DB-backed) — exercises the `FOR UPDATE OF ds, dsr` shape against real Postgres including a source rack without a `device_set_rack` row to pin the LEFT JOIN behavior.

**Handler-layer tests** (`server/internal/handlers/{sites,buildings,deviceset}/handler_test.go`):
- Existing handler tests updated to expect the new bulk mock signatures. The 3 refactored RPCs retain their existing permission gates (no authz changes in this PR).

**Verification:**
- `go build ./...` — clean.
- `golangci-lint run -c .golangci.yaml ./...` — 0 issues.
- `go test ./internal/domain/sites/... ./internal/domain/buildings/... ./internal/domain/collection/... ./internal/handlers/sites/... ./internal/handlers/buildings/... ./internal/handlers/deviceset/... -count=1` — pass.
- `go test ./internal/domain/stores/sqlstores/... -count=1` (with DB env vars) — pass.
- `npx tsc --noEmit` (client) — clean.
- `npm run lint` — clean.

**Explicitly NOT covered:**
- **Cross-RPC deadlock under real Postgres load** — the new `FOR UPDATE OF ds, dsr` shape is exercised by the integration test against a real DB, but a concurrent stress test that fires `AssignDevicesToRack` + `SaveRack` against the same rack pair in opposite orders would be the canonical deadlock-prevention proof. Filed as a follow-up.
- **Lock-order alignment between `AssignDevicesToSite` force-clear (from #464) and `AssignDevicesToRack`** — `#464`'s `%w` retry safety net handles the residual deadlock window for that pair; eliminating the window entirely needs a coordinated change to both flows and is filed separately.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
