### PR TITLE
Add fleet group bulk actions

### DIFF
--- a/client/src/protoFleet/components/DeviceSetList/DeviceSetList.test.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/DeviceSetList.test.tsx
@@ -70,6 +70,27 @@ describe("DeviceSetList", () => {
     expect(onSort).toHaveBeenCalledWith("issues", "desc");
   });
 
+  it("shows controlled row checkboxes when selection props are supplied", () => {
+    const deviceSet = createMockDeviceSet(7n, "Rack A");
+    const stats = createMockStats(7n);
+    const onSelectedIdsChange = vi.fn();
+
+    render(
+      <DeviceSetList
+        {...defaultProps}
+        deviceSets={[deviceSet]}
+        statsMap={new Map([[7n, stats]])}
+        selectedIds={[]}
+        onSelectedIdsChange={onSelectedIdsChange}
+      />,
+    );
+
+    const checkbox = screen.getByTestId("list-body").querySelector("input[type='checkbox']") as HTMLInputElement;
+    fireEvent.click(checkbox);
+
+    expect(onSelectedIdsChange).toHaveBeenCalledWith(["7"]);
+  });
+
   describe("emptyStateRow prop", () => {
     it("renders empty state row when items are empty and emptyStateRow is provided", () => {
       render(

--- a/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
@@ -7,7 +7,7 @@ import type { DeviceSet, DeviceSetStats } from "@/protoFleet/api/generated/devic
 import { useTemperatureUnit } from "@/protoFleet/store";
 import { ChevronDown } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
-import List from "@/shared/components/List";
+import List, { type SelectionMode } from "@/shared/components/List";
 import { type SortDirection } from "@/shared/components/List/types";
 
 export type DeviceSetListItem = {
@@ -48,6 +48,8 @@ type DeviceSetListProps = {
   onPrevPage?: () => void;
   onRowClick?: (item: DeviceSetListItem, index: number) => void;
   emptyStateRow?: ReactNode;
+  selectedIds?: string[];
+  onSelectedIdsChange?: (ids: string[]) => void;
 };
 
 const DeviceSetList = ({
@@ -71,6 +73,8 @@ const DeviceSetList = ({
   onPrevPage,
   onRowClick,
   emptyStateRow,
+  selectedIds,
+  onSelectedIdsChange,
 }: DeviceSetListProps) => {
   const topRef = useRef<HTMLDivElement>(null);
   const temperatureUnit = useTemperatureUnit();
@@ -98,6 +102,64 @@ const DeviceSetList = ({
   const firstItemIndex = currentPage * pageSize + 1;
   const lastItemIndex = currentPage * pageSize + deviceSets.length;
   const shouldRenderPagination = !loading && total !== undefined && total > 0;
+  const selectionMode: SelectionMode = selectedIds && selectedIds.length > 0 ? "subset" : "none";
+  const handleSelectionModeChange = useCallback(() => undefined, []);
+  const isRowSelectable = useCallback((item: DeviceSetListItem) => item.deviceSet.id !== 0n, []);
+
+  if (selectedIds !== undefined && onSelectedIdsChange !== undefined) {
+    return (
+      <>
+        <div ref={topRef} />
+        <List<DeviceSetListItem, string, DeviceSetColumn>
+          activeCols={columns}
+          colTitles={deviceSetColTitles}
+          colConfig={colConfig}
+          items={items}
+          itemKey="id"
+          itemSelectable
+          customSelectedItems={selectedIds}
+          customSetSelectedItems={onSelectedIdsChange}
+          customSelectionMode={selectionMode}
+          onSelectionModeChange={handleSelectionModeChange}
+          pageScopedSelection
+          isRowSelectable={isRowSelectable}
+          hideTotal
+          sortableColumns={SORTABLE_COLUMNS}
+          currentSort={currentSort}
+          onSort={onSort}
+          getDefaultSortDirection={getDefaultSortDirection}
+          onRowClick={onRowClick}
+          emptyStateRow={emptyStateRow}
+        />
+
+        {shouldRenderPagination ? (
+          <div className="sticky left-0 flex flex-col items-center gap-4 py-6">
+            <span className="text-300 text-text-primary">
+              Showing {firstItemIndex}–{lastItemIndex} of {total} {itemName.plural}
+            </span>
+            <div className="flex gap-3">
+              <Button
+                variant={variants.secondary}
+                size={sizes.compact}
+                ariaLabel="Previous page"
+                prefixIcon={<ChevronDown className="rotate-90" />}
+                onClick={handlePrevPage}
+                disabled={!hasPreviousPage}
+              />
+              <Button
+                variant={variants.secondary}
+                size={sizes.compact}
+                ariaLabel="Next page"
+                prefixIcon={<ChevronDown className="rotate-270" />}
+                onClick={handleNextPage}
+                disabled={!hasNextPage}
+              />
+            </div>
+          </div>
+        ) : null}
+      </>
+    );
+  }
 
   return (
     <>

--- a/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
@@ -102,20 +102,56 @@ const DeviceSetList = ({
   const firstItemIndex = currentPage * pageSize + 1;
   const lastItemIndex = currentPage * pageSize + deviceSets.length;
   const shouldRenderPagination = !loading && total !== undefined && total > 0;
-  const selectionMode: SelectionMode = selectedIds && selectedIds.length > 0 ? "subset" : "none";
   const handleSelectionModeChange = useCallback(() => undefined, []);
   const isRowSelectable = useCallback((item: DeviceSetListItem) => item.deviceSet.id !== 0n, []);
 
+  const commonListProps = {
+    activeCols: columns,
+    colTitles: deviceSetColTitles,
+    colConfig,
+    items,
+    itemKey: "id" as const,
+    hideTotal: true,
+    sortableColumns: SORTABLE_COLUMNS,
+    currentSort,
+    onSort,
+    getDefaultSortDirection,
+    onRowClick,
+    emptyStateRow,
+  };
+  const pagination = shouldRenderPagination ? (
+    <div className="sticky left-0 flex flex-col items-center gap-4 py-6">
+      <span className="text-300 text-text-primary">
+        Showing {firstItemIndex}–{lastItemIndex} of {total} {itemName.plural}
+      </span>
+      <div className="flex gap-3">
+        <Button
+          variant={variants.secondary}
+          size={sizes.compact}
+          ariaLabel="Previous page"
+          prefixIcon={<ChevronDown className="rotate-90" />}
+          onClick={handlePrevPage}
+          disabled={!hasPreviousPage}
+        />
+        <Button
+          variant={variants.secondary}
+          size={sizes.compact}
+          ariaLabel="Next page"
+          prefixIcon={<ChevronDown className="rotate-270" />}
+          onClick={handleNextPage}
+          disabled={!hasNextPage}
+        />
+      </div>
+    </div>
+  ) : null;
+
   if (selectedIds !== undefined && onSelectedIdsChange !== undefined) {
+    const selectionMode: SelectionMode = selectedIds.length > 0 ? "subset" : "none";
     return (
       <>
         <div ref={topRef} />
         <List<DeviceSetListItem, string, DeviceSetColumn>
-          activeCols={columns}
-          colTitles={deviceSetColTitles}
-          colConfig={colConfig}
-          items={items}
-          itemKey="id"
+          {...commonListProps}
           itemSelectable
           customSelectedItems={selectedIds}
           customSetSelectedItems={onSelectedIdsChange}
@@ -123,40 +159,8 @@ const DeviceSetList = ({
           onSelectionModeChange={handleSelectionModeChange}
           pageScopedSelection
           isRowSelectable={isRowSelectable}
-          hideTotal
-          sortableColumns={SORTABLE_COLUMNS}
-          currentSort={currentSort}
-          onSort={onSort}
-          getDefaultSortDirection={getDefaultSortDirection}
-          onRowClick={onRowClick}
-          emptyStateRow={emptyStateRow}
         />
-
-        {shouldRenderPagination ? (
-          <div className="sticky left-0 flex flex-col items-center gap-4 py-6">
-            <span className="text-300 text-text-primary">
-              Showing {firstItemIndex}–{lastItemIndex} of {total} {itemName.plural}
-            </span>
-            <div className="flex gap-3">
-              <Button
-                variant={variants.secondary}
-                size={sizes.compact}
-                ariaLabel="Previous page"
-                prefixIcon={<ChevronDown className="rotate-90" />}
-                onClick={handlePrevPage}
-                disabled={!hasPreviousPage}
-              />
-              <Button
-                variant={variants.secondary}
-                size={sizes.compact}
-                ariaLabel="Next page"
-                prefixIcon={<ChevronDown className="rotate-270" />}
-                onClick={handleNextPage}
-                disabled={!hasNextPage}
-              />
-            </div>
-          </div>
-        ) : null}
+        {pagination}
       </>
     );
   }
@@ -164,46 +168,8 @@ const DeviceSetList = ({
   return (
     <>
       <div ref={topRef} />
-      <List<DeviceSetListItem, string, DeviceSetColumn>
-        activeCols={columns}
-        colTitles={deviceSetColTitles}
-        colConfig={colConfig}
-        items={items}
-        itemKey="id"
-        hideTotal
-        sortableColumns={SORTABLE_COLUMNS}
-        currentSort={currentSort}
-        onSort={onSort}
-        getDefaultSortDirection={getDefaultSortDirection}
-        onRowClick={onRowClick}
-        emptyStateRow={emptyStateRow}
-      />
-
-      {shouldRenderPagination ? (
-        <div className="sticky left-0 flex flex-col items-center gap-4 py-6">
-          <span className="text-300 text-text-primary">
-            Showing {firstItemIndex}–{lastItemIndex} of {total} {itemName.plural}
-          </span>
-          <div className="flex gap-3">
-            <Button
-              variant={variants.secondary}
-              size={sizes.compact}
-              ariaLabel="Previous page"
-              prefixIcon={<ChevronDown className="rotate-90" />}
-              onClick={handlePrevPage}
-              disabled={!hasPreviousPage}
-            />
-            <Button
-              variant={variants.secondary}
-              size={sizes.compact}
-              ariaLabel="Next page"
-              prefixIcon={<ChevronDown className="rotate-270" />}
-              onClick={handleNextPage}
-              disabled={!hasNextPage}
-            />
-          </div>
-        </div>
-      ) : null}
+      <List<DeviceSetListItem, string, DeviceSetColumn> {...commonListProps} />
+      {pagination}
     </>
   );
 };

--- a/client/src/protoFleet/features/fleetManagement/components/ActionBar/ActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ActionBar/ActionBar.tsx
@@ -9,6 +9,10 @@ interface ActionBarProps {
   className?: string;
   /** IDs of currently selected items (used for count display in "subset" mode) */
   selectedItems: string[];
+  itemNoun?: {
+    singular: string;
+    plural: string;
+  };
   /**
    * How items were selected:
    * - "all": user clicked "Select All" with no filters (targets entire fleet)
@@ -30,6 +34,7 @@ interface ActionBarProps {
 const ActionBar = ({
   className,
   selectedItems,
+  itemNoun = { singular: "miner", plural: "miners" },
   selectionMode = "subset",
   totalCount,
   selectionControls,
@@ -46,8 +51,8 @@ const ActionBar = ({
 
   const selectionText = useMemo(() => {
     const count = selectionMode === "all" ? (totalCount ?? selectedItems.length) : selectedItems.length;
-    return `${count} miner${count === 1 ? "" : "s"} selected`;
-  }, [selectionMode, selectedItems.length, totalCount]);
+    return `${count} ${count === 1 ? itemNoun.singular : itemNoun.plural} selected`;
+  }, [itemNoun.plural, itemNoun.singular, selectionMode, selectedItems.length, totalCount]);
 
   const handleClose = () => {
     setShow(false);

--- a/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.test.tsx
@@ -97,7 +97,15 @@ const PathProbe = () => {
 
 type EditBuildingCallback = (building: BuildingWithCounts) => void;
 
-const renderList = ({ onEditBuilding }: { onEditBuilding?: EditBuildingCallback } = {}) =>
+const renderList = ({
+  onEditBuilding,
+  selectedIds,
+  onSelectedIdsChange,
+}: {
+  onEditBuilding?: EditBuildingCallback;
+  selectedIds?: string[];
+  onSelectedIdsChange?: (ids: string[]) => void;
+} = {}) =>
   render(
     <MemoryRouter initialEntries={["/fleet/buildings"]}>
       <Routes>
@@ -109,6 +117,8 @@ const renderList = ({ onEditBuilding }: { onEditBuilding?: EditBuildingCallback 
                 buildings={[makeBuilding(42, "Alpha", 7)]}
                 sites={[makeSite(7, "North")]}
                 onEditBuilding={onEditBuilding}
+                selectedIds={selectedIds}
+                onSelectedIdsChange={onSelectedIdsChange}
               />
               <PathProbe />
             </>
@@ -178,5 +188,15 @@ describe("BuildingList row actions menu", () => {
     renderList();
     fireEvent.click(trigger());
     expect(screen.queryByText("Edit building")).not.toBeInTheDocument();
+  });
+
+  it("shows controlled row checkboxes when selection props are supplied", () => {
+    const onSelectedIdsChange = vi.fn();
+    renderList({ selectedIds: [], onSelectedIdsChange });
+
+    const checkbox = screen.getByTestId("list-body").querySelector("input[type='checkbox']") as HTMLInputElement;
+    fireEvent.click(checkbox);
+
+    expect(onSelectedIdsChange).toHaveBeenCalledWith(["42"]);
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.tsx
@@ -163,49 +163,40 @@ const BuildingList = ({
   );
 
   const handleRowClick = useCallback((item: BuildingListItem) => navigate(`/buildings/${item.id}`), [navigate]);
-  const selectableSelectionMode: SelectionMode = selectedIds && selectedIds.length > 0 ? "subset" : "none";
-  const handleSelectionModeChange = useCallback(() => undefined, []);
   const isSelectableBuilding = useCallback((item: BuildingListItem) => {
     const buildingId = item.building.building?.id;
     return buildingId !== undefined && buildingId !== 0n;
   }, []);
+  const handleSelectionModeChange = useCallback(() => undefined, []);
+  const commonProps = {
+    activeCols: ACTIVE_COLS,
+    colTitles: COL_TITLES,
+    colConfig,
+    items,
+    itemKey: "id" as const,
+    hideTotal: true,
+    onRowClick: handleRowClick,
+    emptyStateRow,
+    paddingLeft: { phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" },
+  };
 
   if (selectedIds !== undefined && onSelectedIdsChange !== undefined) {
+    const selectionMode: SelectionMode = selectedIds.length > 0 ? "subset" : "none";
     return (
       <List<BuildingListItem, string, BuildingColumn>
-        activeCols={ACTIVE_COLS}
-        colTitles={COL_TITLES}
-        colConfig={colConfig}
-        items={items}
-        itemKey="id"
+        {...commonProps}
         itemSelectable
         customSelectedItems={selectedIds}
         customSetSelectedItems={onSelectedIdsChange}
-        customSelectionMode={selectableSelectionMode}
+        customSelectionMode={selectionMode}
         onSelectionModeChange={handleSelectionModeChange}
         pageScopedSelection
         isRowSelectable={isSelectableBuilding}
-        hideTotal
-        onRowClick={handleRowClick}
-        emptyStateRow={emptyStateRow}
-        paddingLeft={{ phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" }}
       />
     );
   }
 
-  return (
-    <List<BuildingListItem, string, BuildingColumn>
-      activeCols={ACTIVE_COLS}
-      colTitles={COL_TITLES}
-      colConfig={colConfig}
-      items={items}
-      itemKey="id"
-      hideTotal
-      onRowClick={handleRowClick}
-      emptyStateRow={emptyStateRow}
-      paddingLeft={{ phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" }}
-    />
-  );
+  return <List<BuildingListItem, string, BuildingColumn> {...commonProps} />;
 };
 
 export default BuildingList;

--- a/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.tsx
@@ -6,7 +6,7 @@ import { type RowAction } from "../RowActionsMenu";
 import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { ArrowRight, Edit, Plus } from "@/shared/assets/icons";
-import List from "@/shared/components/List";
+import List, { type SelectionMode } from "@/shared/components/List";
 import { type ColConfig, type ColTitles } from "@/shared/components/List/types";
 
 type BuildingListItem = {
@@ -58,9 +58,19 @@ interface BuildingListProps {
   emptyStateRow?: ReactNode;
   onEditBuilding?: (building: BuildingWithCounts) => void;
   onAddBuildingToSite?: (building: BuildingWithCounts) => void;
+  selectedIds?: string[];
+  onSelectedIdsChange?: (ids: string[]) => void;
 }
 
-const BuildingList = ({ buildings, sites, emptyStateRow, onEditBuilding, onAddBuildingToSite }: BuildingListProps) => {
+const BuildingList = ({
+  buildings,
+  sites,
+  emptyStateRow,
+  onEditBuilding,
+  onAddBuildingToSite,
+  selectedIds,
+  onSelectedIdsChange,
+}: BuildingListProps) => {
   const navigate = useNavigate();
 
   const siteNameById = useMemo(() => {
@@ -126,7 +136,7 @@ const BuildingList = ({ buildings, sites, emptyStateRow, onEditBuilding, onAddBu
               <span className="truncate text-emphasis-300">{buildingName}</span>
               {buildingId !== undefined && buildingId !== 0n ? (
                 <FleetGroupActionsMenu
-                  scope={{ kind: "building", id: buildingId, name: buildingName }}
+                  scopes={[{ kind: "building", id: buildingId, name: buildingName }]}
                   ariaLabel={`Actions for ${buildingName}`}
                   testIdPrefix={`building-list-row-${item.id}-actions`}
                   extraActions={buildExtraActions(item)}
@@ -153,6 +163,35 @@ const BuildingList = ({ buildings, sites, emptyStateRow, onEditBuilding, onAddBu
   );
 
   const handleRowClick = useCallback((item: BuildingListItem) => navigate(`/buildings/${item.id}`), [navigate]);
+  const selectableSelectionMode: SelectionMode = selectedIds && selectedIds.length > 0 ? "subset" : "none";
+  const handleSelectionModeChange = useCallback(() => undefined, []);
+  const isSelectableBuilding = useCallback((item: BuildingListItem) => {
+    const buildingId = item.building.building?.id;
+    return buildingId !== undefined && buildingId !== 0n;
+  }, []);
+
+  if (selectedIds !== undefined && onSelectedIdsChange !== undefined) {
+    return (
+      <List<BuildingListItem, string, BuildingColumn>
+        activeCols={ACTIVE_COLS}
+        colTitles={COL_TITLES}
+        colConfig={colConfig}
+        items={items}
+        itemKey="id"
+        itemSelectable
+        customSelectedItems={selectedIds}
+        customSetSelectedItems={onSelectedIdsChange}
+        customSelectionMode={selectableSelectionMode}
+        onSelectionModeChange={handleSelectionModeChange}
+        pageScopedSelection
+        isRowSelectable={isSelectableBuilding}
+        hideTotal
+        onRowClick={handleRowClick}
+        emptyStateRow={emptyStateRow}
+        paddingLeft={{ phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" }}
+      />
+    );
+  }
 
   return (
     <List<BuildingListItem, string, BuildingColumn>

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
@@ -26,6 +26,7 @@ const {
   mockPushToast,
   mockRemoveToast,
   mockUpdateToast,
+  mockUsePermissions,
 } = vi.hoisted(() => ({
   mockListMinerStateSnapshots: vi.fn(),
   mockUseMinerActions: vi.fn(),
@@ -45,6 +46,7 @@ const {
   mockPushToast: vi.fn(),
   mockRemoveToast: vi.fn(),
   mockUpdateToast: vi.fn(),
+  mockUsePermissions: vi.fn(),
 }));
 
 vi.mock("@/shared/components/Popover", () => ({
@@ -93,36 +95,11 @@ vi.mock(import("@/shared/features/toaster"), async (importOriginal) => {
   };
 });
 
-// Grant every permission the menu consults so the wired entries
-// render in tests. Production filtering is verified by the live
-// permission catalog plus the server gate; the menu's job here is
-// only to surface what the role can invoke. Partial-mock so the
-// surrounding store hooks (useAuthErrors, useBatch*, ...) stay live.
 vi.mock(import("@/protoFleet/store"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    usePermissions: () => [
-      "miner:read",
-      "miner:blink_led",
-      "miner:download_logs",
-      "miner:firmware_update",
-      "miner:reboot",
-      "miner:stop_mining",
-      "miner:start_mining",
-      "miner:delete",
-      "miner:set_power_target",
-      "miner:set_cooling_mode",
-      "miner:rename",
-      "miner:update_worker_names",
-      "miner:update_password",
-      "miner:update_pools",
-      "pool:read",
-      "rack:read",
-      "rack:manage",
-      "site:read",
-      "site:manage",
-    ],
+    usePermissions: () => mockUsePermissions(),
   };
 });
 
@@ -168,6 +145,28 @@ vi.mock("../BulkActions/UnsupportedMinersModal", () => ({ default: () => null })
 
 // eslint-disable-next-line import-x/order -- import must come after vi.mock calls
 import FleetGroupActionsMenu from "./FleetGroupActionsMenu";
+
+const DEFAULT_PERMISSIONS = [
+  "miner:read",
+  "miner:blink_led",
+  "miner:download_logs",
+  "miner:firmware_update",
+  "miner:reboot",
+  "miner:stop_mining",
+  "miner:start_mining",
+  "miner:delete",
+  "miner:set_power_target",
+  "miner:set_cooling_mode",
+  "miner:rename",
+  "miner:update_worker_names",
+  "miner:update_password",
+  "miner:update_pools",
+  "pool:read",
+  "rack:read",
+  "rack:manage",
+  "site:read",
+  "site:manage",
+] as const;
 
 const buildPopoverActions = () => [
   {
@@ -278,6 +277,7 @@ const makeMinerActions = () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockUsePermissions.mockReturnValue([...DEFAULT_PERMISSIONS]);
   mockPushToast.mockReturnValue(1);
   mockListMinerStateSnapshots.mockResolvedValue({
     miners: [{ deviceIdentifier: "miner-a" }, { deviceIdentifier: "miner-b" }, { deviceIdentifier: "miner-c" }],
@@ -311,6 +311,31 @@ describe("FleetGroupActionsMenu", () => {
     ]) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
+  });
+
+  it("hides scoped miner actions without miner read but keeps row extras", () => {
+    mockUsePermissions.mockReturnValue(DEFAULT_PERMISSIONS.filter((permission) => permission !== "miner:read"));
+    const onViewRacks = vi.fn();
+
+    render(
+      <FleetGroupActionsMenu
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
+        ariaLabel="Actions for Alpha"
+        testIdPrefix="alpha"
+        extraActions={[{ label: "View racks", onClick: onViewRacks }]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("alpha-trigger"));
+
+    expect(screen.getByText("View racks")).toBeInTheDocument();
+    expect(screen.queryByText("Reboot miners")).not.toBeInTheDocument();
+    expect(screen.queryByText("Add to group")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("View racks"));
+
+    expect(onViewRacks).toHaveBeenCalledOnce();
+    expect(mockListMinerStateSnapshots).not.toHaveBeenCalled();
   });
 
   it("fires the hook's Sleep handler after the device IDs land", async () => {
@@ -556,5 +581,24 @@ describe("FleetGroupActionsMenu", () => {
         }),
       );
     });
+  });
+
+  it("hides bulk controls without miner read", () => {
+    mockUsePermissions.mockReturnValue(DEFAULT_PERMISSIONS.filter((permission) => permission !== "miner:read"));
+
+    render(
+      <FleetGroupActionsMenu
+        scopes={[
+          { kind: "rack", id: 11n, name: "Rack A" },
+          { kind: "rack", id: 12n, name: "Rack B" },
+        ]}
+        ariaLabel="Bulk actions for selected racks"
+        testIdPrefix="racks"
+        presentation="bulk"
+      />,
+    );
+
+    expect(screen.queryByTestId(`racks-quick-${deviceActions.reboot}`)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("racks-trigger")).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { deviceActions, performanceActions, settingsActions } from "../MinerActionsMenu/constants";
+import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
 // Hoisted mocks — vi.mock factories are pulled above the file's top
 // level, so the mock fns they capture must come from vi.hoisted.
@@ -236,6 +237,13 @@ const buildPopoverActions = () => [
     actionHandler: vi.fn(),
     requiresConfirmation: false,
   },
+  {
+    action: deviceActions.unpair,
+    title: "Unpair",
+    icon: null,
+    actionHandler: vi.fn(),
+    requiresConfirmation: false,
+  },
 ];
 
 const makeMinerActions = () => ({
@@ -436,6 +444,65 @@ describe("FleetGroupActionsMenu", () => {
     expect(mockListMinerStateSnapshots).not.toHaveBeenCalled();
     expect(onActionStart).toHaveBeenCalledOnce();
     expect(onActionComplete).toHaveBeenCalledOnce();
+  });
+
+  it("blocks non-unpair actions when scoped miners need authentication", async () => {
+    mockListMinerStateSnapshots.mockResolvedValueOnce({
+      miners: [{ deviceIdentifier: "miner-a", pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }],
+      cursor: "",
+    });
+    const onActionComplete = vi.fn();
+
+    render(
+      <FleetGroupActionsMenu
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
+        ariaLabel="Actions for Alpha"
+        testIdPrefix="alpha"
+        onActionComplete={onActionComplete}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("alpha-trigger"));
+    fireEvent.click(screen.getByText("Reboot miners"));
+
+    await waitFor(() => {
+      expect(mockPushToast).toHaveBeenLastCalledWith({
+        message:
+          "Some miners in Alpha need authentication before this action can run. Unpair those miners or authenticate them first.",
+        status: "error",
+      });
+    });
+    const reboot = mockUseMinerActions.mock.results
+      .flatMap((result) => (result.value as ReturnType<typeof makeMinerActions>).popoverActions)
+      .find((entry) => entry.action === deviceActions.reboot);
+    expect(reboot?.actionHandler).not.toHaveBeenCalled();
+    expect(onActionComplete).toHaveBeenCalledOnce();
+  });
+
+  it("allows unpair when scoped miners need authentication", async () => {
+    mockListMinerStateSnapshots.mockResolvedValueOnce({
+      miners: [{ deviceIdentifier: "miner-a", pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }],
+      cursor: "",
+    });
+
+    render(
+      <FleetGroupActionsMenu
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
+        ariaLabel="Actions for Alpha"
+        testIdPrefix="alpha"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("alpha-trigger"));
+    fireEvent.click(screen.getByText("Unpair miners"));
+
+    await waitFor(() => {
+      const unpair = mockUseMinerActions.mock.results
+        .flatMap((result) => (result.value as ReturnType<typeof makeMinerActions>).popoverActions)
+        .find((entry) => entry.action === deviceActions.unpair);
+      expect(unpair?.actionHandler).toHaveBeenCalledTimes(1);
+    });
+    expect(mockPushToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("need authentication") }),
+    );
   });
 
   it("combines same-kind scopes into one snapshot filter and hides row-only extras", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
@@ -22,6 +22,9 @@ const {
   mockHandleFleetAuthenticated,
   mockHandleMiningPoolError,
   mockHandleMiningPoolWarning,
+  mockPushToast,
+  mockRemoveToast,
+  mockUpdateToast,
 } = vi.hoisted(() => ({
   mockListMinerStateSnapshots: vi.fn(),
   mockUseMinerActions: vi.fn(),
@@ -38,6 +41,9 @@ const {
   mockHandleFleetAuthenticated: vi.fn(),
   mockHandleMiningPoolError: vi.fn(),
   mockHandleMiningPoolWarning: vi.fn(),
+  mockPushToast: vi.fn(),
+  mockRemoveToast: vi.fn(),
+  mockUpdateToast: vi.fn(),
 }));
 
 vi.mock("@/shared/components/Popover", () => ({
@@ -75,6 +81,16 @@ vi.mock("@/protoFleet/features/fleetManagement/hooks/useBatchOperations", () => 
     removeDevicesFromBatch: vi.fn(),
   }),
 }));
+
+vi.mock(import("@/shared/features/toaster"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    pushToast: mockPushToast,
+    removeToast: mockRemoveToast,
+    updateToast: mockUpdateToast,
+  };
+});
 
 // Grant every permission the menu consults so the wired entries
 // render in tests. Production filtering is verified by the live
@@ -254,6 +270,7 @@ const makeMinerActions = () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockPushToast.mockReturnValue(1);
   mockListMinerStateSnapshots.mockResolvedValue({
     miners: [{ deviceIdentifier: "miner-a" }, { deviceIdentifier: "miner-b" }, { deviceIdentifier: "miner-c" }],
     cursor: "",
@@ -265,7 +282,7 @@ describe("FleetGroupActionsMenu", () => {
   it("renders the wired bulk actions plus extras", () => {
     render(
       <FleetGroupActionsMenu
-        scope={{ kind: "building", id: 42n, name: "Alpha" }}
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
         ariaLabel="Actions for Alpha"
         testIdPrefix="alpha"
         extraActions={[{ label: "View racks", onClick: vi.fn() }]}
@@ -291,7 +308,7 @@ describe("FleetGroupActionsMenu", () => {
   it("fires the hook's Sleep handler after the device IDs land", async () => {
     render(
       <FleetGroupActionsMenu
-        scope={{ kind: "building", id: 42n, name: "Alpha" }}
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
         ariaLabel="Actions for Alpha"
         testIdPrefix="alpha"
       />,
@@ -320,7 +337,7 @@ describe("FleetGroupActionsMenu", () => {
   it("Site scope filters listMinerStateSnapshots by siteIds", async () => {
     render(
       <FleetGroupActionsMenu
-        scope={{ kind: "site", id: 7n, name: "North" }}
+        scopes={[{ kind: "site", id: 7n, name: "North" }]}
         ariaLabel="Actions for North"
         testIdPrefix="north"
       />,
@@ -337,11 +354,11 @@ describe("FleetGroupActionsMenu", () => {
     });
   });
 
-  it("toasts when the scope has no miners and skips the dispatch", async () => {
+  it("warns when the scope has no miners and skips the dispatch", async () => {
     mockListMinerStateSnapshots.mockResolvedValueOnce({ miners: [], cursor: "" });
     render(
       <FleetGroupActionsMenu
-        scope={{ kind: "building", id: 42n, name: "Alpha" }}
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
         ariaLabel="Actions for Alpha"
         testIdPrefix="alpha"
       />,
@@ -356,6 +373,63 @@ describe("FleetGroupActionsMenu", () => {
         .flatMap((result) => (result.value as ReturnType<typeof makeMinerActions>).popoverActions)
         .find((entry) => entry.action === deviceActions.shutdown);
       expect(fired?.actionHandler).not.toHaveBeenCalled();
+    });
+    expect(mockPushToast).toHaveBeenLastCalledWith({
+      message: "Building Alpha contains no miners.",
+      status: "error",
+    });
+  });
+
+  it("combines same-kind scopes into one snapshot filter and hides row-only extras", async () => {
+    render(
+      <FleetGroupActionsMenu
+        scopes={[
+          { kind: "site", id: 7n, name: "North" },
+          { kind: "site", id: 8n, name: "South" },
+        ]}
+        ariaLabel="Bulk actions for selected sites"
+        testIdPrefix="sites"
+        extraActions={[{ label: "View site", onClick: vi.fn() }]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("sites-trigger"));
+    expect(screen.queryByText("View site")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Reboot miners"));
+
+    await waitFor(() => {
+      expect(mockListMinerStateSnapshots).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: expect.objectContaining({ siteIds: [7n, 8n] }),
+        }),
+      );
+    });
+  });
+
+  it("renders Reboot and More controls in bulk presentation", async () => {
+    render(
+      <FleetGroupActionsMenu
+        scopes={[
+          { kind: "rack", id: 11n, name: "Rack A" },
+          { kind: "rack", id: 12n, name: "Rack B" },
+        ]}
+        ariaLabel="Bulk actions for selected racks"
+        testIdPrefix="racks"
+        presentation="bulk"
+      />,
+    );
+
+    expect(screen.getByTestId(`racks-quick-${deviceActions.reboot}`)).toHaveTextContent("Reboot");
+    expect(screen.getByTestId("racks-trigger")).toHaveTextContent("More");
+
+    fireEvent.click(screen.getByTestId(`racks-quick-${deviceActions.reboot}`));
+
+    await waitFor(() => {
+      expect(mockListMinerStateSnapshots).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: expect.objectContaining({ rackIds: [11n, 12n] }),
+        }),
+      );
     });
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
@@ -356,11 +356,13 @@ describe("FleetGroupActionsMenu", () => {
 
   it("warns when the scope has no miners and skips the dispatch", async () => {
     mockListMinerStateSnapshots.mockResolvedValueOnce({ miners: [], cursor: "" });
+    const onActionComplete = vi.fn();
     render(
       <FleetGroupActionsMenu
         scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
         ariaLabel="Actions for Alpha"
         testIdPrefix="alpha"
+        onActionComplete={onActionComplete}
       />,
     );
     fireEvent.click(screen.getByTestId("alpha-trigger"));
@@ -378,6 +380,62 @@ describe("FleetGroupActionsMenu", () => {
       message: "Building Alpha contains no miners.",
       status: "error",
     });
+    expect(onActionComplete).toHaveBeenCalledOnce();
+  });
+
+  it("starts the action boundary before loading scoped miners", async () => {
+    let resolveLookup: (value: { miners: { deviceIdentifier: string }[]; cursor: string }) => void = () => {};
+    mockListMinerStateSnapshots.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveLookup = resolve;
+      }),
+    );
+    const onActionStart = vi.fn();
+    const onActionComplete = vi.fn();
+
+    render(
+      <FleetGroupActionsMenu
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
+        ariaLabel="Actions for Alpha"
+        testIdPrefix="alpha"
+        onActionStart={onActionStart}
+        onActionComplete={onActionComplete}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("alpha-trigger"));
+    fireEvent.click(screen.getByText("Sleep miners"));
+
+    expect(onActionStart).toHaveBeenCalledOnce();
+    expect(onActionComplete).not.toHaveBeenCalled();
+
+    resolveLookup({ miners: [], cursor: "" });
+
+    await waitFor(() => {
+      expect(onActionComplete).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("fails fast when no scopes are selected", async () => {
+    const onActionStart = vi.fn();
+    const onActionComplete = vi.fn();
+    render(
+      <FleetGroupActionsMenu
+        scopes={[]}
+        ariaLabel="Bulk actions for selected sites"
+        testIdPrefix="empty"
+        onActionStart={onActionStart}
+        onActionComplete={onActionComplete}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("empty-trigger"));
+    fireEvent.click(screen.getByText("Sleep miners"));
+
+    await waitFor(() => {
+      expect(mockUpdateToast).toHaveBeenCalledWith(1, { message: "No fleet groups selected.", status: "error" });
+    });
+    expect(mockListMinerStateSnapshots).not.toHaveBeenCalled();
+    expect(onActionStart).toHaveBeenCalledOnce();
+    expect(onActionComplete).toHaveBeenCalledOnce();
   });
 
   it("combines same-kind scopes into one snapshot filter and hides row-only extras", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
@@ -8,6 +8,7 @@ import { fleetManagementClient } from "@/protoFleet/api/clients";
 import {
   MinerListFilterSchema,
   type MinerStateSnapshot,
+  PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import PoolSelectionPageWrapper from "@/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage";
 import { ACTION_PERMISSIONS } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions";
@@ -106,6 +107,10 @@ const ACTION_ICON: Record<WiredActionKey, ReactElement> = {
 const MAX_SNAPSHOT_PAGES = 50;
 const SNAPSHOT_PAGE_SIZE = 1000;
 const MAX_MINERS = MAX_SNAPSHOT_PAGES * SNAPSHOT_PAGE_SIZE;
+type ScopedMinerLookupResult = {
+  deviceIdentifiers: string[];
+  includesUnauthenticatedMiner: boolean;
+};
 
 const pluralizeScopeKind = (kind: GroupScope["kind"], count: number) => {
   if (count === 1) return kind;
@@ -182,7 +187,7 @@ const FleetGroupActionsMenu = ({
     return allowed;
   }, [permissions]);
 
-  const fetchDeviceIds = useCallback(async (): Promise<string[]> => {
+  const fetchDeviceIds = useCallback(async (): Promise<ScopedMinerLookupResult> => {
     if (scopeIds.length === 0) {
       throw new Error("No fleet groups selected.");
     }
@@ -220,7 +225,12 @@ const FleetGroupActionsMenu = ({
     idsLoadedRef.current = true;
     setIds(collected);
     setMinerSnapshots(snapshotMap);
-    return collected;
+    return {
+      deviceIdentifiers: collected,
+      includesUnauthenticatedMiner: Object.values(snapshotMap).some(
+        (miner) => miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED,
+      ),
+    };
   }, [scopeIds, scopeKind, scopeLabel]);
 
   useEffect(() => {
@@ -247,9 +257,9 @@ const FleetGroupActionsMenu = ({
         status: STATUSES.loading,
         longRunning: true,
       });
-      let deviceIdentifiers: string[];
+      let lookupResult: ScopedMinerLookupResult;
       try {
-        deviceIdentifiers = await fetchDeviceIds();
+        lookupResult = await fetchDeviceIds();
       } catch (err) {
         const message = err instanceof Error && err.message ? err.message : `Couldn't load miners for ${scopeLabel}.`;
         updateToast(loadingToast, { message, status: STATUSES.error });
@@ -259,8 +269,16 @@ const FleetGroupActionsMenu = ({
       }
       removeToast(loadingToast);
       setIsBusy(false);
-      if (deviceIdentifiers.length === 0) {
+      if (lookupResult.deviceIdentifiers.length === 0) {
         pushToast({ message: emptyScopeMessage, status: STATUSES.error });
+        onActionComplete?.();
+        return;
+      }
+      if (key !== deviceActions.unpair && lookupResult.includesUnauthenticatedMiner) {
+        pushToast({
+          message: `Some miners in ${scopeLabel} need authentication before this action can run. Unpair those miners or authenticate them first.`,
+          status: STATUSES.error,
+        });
         onActionComplete?.();
         return;
       }

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
@@ -107,6 +107,7 @@ const ACTION_ICON: Record<WiredActionKey, ReactElement> = {
 const MAX_SNAPSHOT_PAGES = 50;
 const SNAPSHOT_PAGE_SIZE = 1000;
 const MAX_MINERS = MAX_SNAPSHOT_PAGES * SNAPSHOT_PAGE_SIZE;
+const SCOPED_MINER_LOOKUP_PERMISSION = "miner:read";
 type ScopedMinerLookupResult = {
   deviceIdentifiers: string[];
   includesUnauthenticatedMiner: boolean;
@@ -171,10 +172,13 @@ const FleetGroupActionsMenu = ({
   });
   const permissions = usePermissions();
 
-  // Mirrors `usePermittedActions` from MinerActionsMenu so read-only
-  // roles don't see entries that would 403 on click. Server enforces.
+  // Mirrors `usePermittedActions` from MinerActionsMenu so roles don't
+  // see entries that would 403 on click. Group actions also require
+  // miner:read up front because every wired entry first resolves the
+  // scoped descendants via ListMinerStateSnapshots. Server enforces.
   const permittedKeys = useMemo(() => {
     const allowed = new Set<WiredActionKey>();
+    if (!permissions.includes(SCOPED_MINER_LOOKUP_PERMISSION)) return allowed;
     const lookup: Record<string, string | readonly string[] | undefined> = ACTION_PERMISSIONS;
     const hasAll = (required: string | readonly string[] | undefined): boolean => {
       if (required === undefined) return true;

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
@@ -183,6 +183,10 @@ const FleetGroupActionsMenu = ({
   }, [permissions]);
 
   const fetchDeviceIds = useCallback(async (): Promise<string[]> => {
+    if (scopeIds.length === 0) {
+      throw new Error("No fleet groups selected.");
+    }
+
     const collected: string[] = [];
     const snapshotMap: Record<string, MinerStateSnapshot> = {};
     const filterInit =
@@ -224,15 +228,20 @@ const FleetGroupActionsMenu = ({
     if (ids.length === 0) return;
     if (firedTickRef.current === pendingAction.tick) return;
     const entry = minerActions.popoverActions.find((action) => action.action === pendingAction.key);
-    if (!entry) return;
+    if (!entry) {
+      firedTickRef.current = pendingAction.tick;
+      onActionComplete?.();
+      return;
+    }
     firedTickRef.current = pendingAction.tick;
     void entry.actionHandler();
-  }, [pendingAction, ids, minerActions.popoverActions]);
+  }, [pendingAction, ids, minerActions.popoverActions, onActionComplete]);
 
   const handleTrigger = useCallback(
     async (key: WiredActionKey) => {
       if (isBusy) return;
       setIsBusy(true);
+      onActionStart?.();
       const loadingToast = pushToast({
         message: `Loading miners in ${scopeLabel}…`,
         status: STATUSES.loading,
@@ -245,18 +254,20 @@ const FleetGroupActionsMenu = ({
         const message = err instanceof Error && err.message ? err.message : `Couldn't load miners for ${scopeLabel}.`;
         updateToast(loadingToast, { message, status: STATUSES.error });
         setIsBusy(false);
+        onActionComplete?.();
         return;
       }
       removeToast(loadingToast);
       setIsBusy(false);
       if (deviceIdentifiers.length === 0) {
         pushToast({ message: emptyScopeMessage, status: STATUSES.error });
+        onActionComplete?.();
         return;
       }
       tickRef.current += 1;
       setPendingAction({ key, tick: tickRef.current });
     },
-    [emptyScopeMessage, fetchDeviceIds, isBusy, scopeLabel],
+    [emptyScopeMessage, fetchDeviceIds, isBusy, onActionComplete, onActionStart, scopeLabel],
   );
 
   const clearPendingAction = useCallback(() => {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
@@ -23,6 +23,7 @@ import { useMinerActions } from "@/protoFleet/features/fleetManagement/component
 import { useBatchActions } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 import { usePermissions } from "@/protoFleet/store";
 import {
+  ChevronDown,
   Lock,
   MiningPools,
   Play,
@@ -34,6 +35,8 @@ import {
   Terminal,
   Unpair,
 } from "@/shared/assets/icons";
+import { iconSizes } from "@/shared/assets/icons/constants";
+import Button, { sizes, variants } from "@/shared/components/Button";
 import { pushToast, removeToast, STATUSES, updateToast } from "@/shared/features/toaster";
 
 export type GroupScope = {
@@ -43,11 +46,14 @@ export type GroupScope = {
 };
 
 interface FleetGroupActionsMenuProps {
-  scope: GroupScope;
+  scopes: GroupScope[];
   ariaLabel: string;
   testIdPrefix?: string;
   // Rendered between the wired top + bottom bulk clusters.
   extraActions?: RowAction[];
+  onActionStart?: () => void;
+  onActionComplete?: () => void;
+  presentation?: "row" | "bulk";
 }
 
 const TOP_WIRED_KEYS = [
@@ -101,7 +107,35 @@ const MAX_SNAPSHOT_PAGES = 50;
 const SNAPSHOT_PAGE_SIZE = 1000;
 const MAX_MINERS = MAX_SNAPSHOT_PAGES * SNAPSHOT_PAGE_SIZE;
 
-const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = [] }: FleetGroupActionsMenuProps) => {
+const pluralizeScopeKind = (kind: GroupScope["kind"], count: number) => {
+  if (count === 1) return kind;
+  return kind === "site" ? "sites" : kind === "building" ? "buildings" : "racks";
+};
+
+const capitalizeScopeKind = (kind: GroupScope["kind"]) => kind.charAt(0).toUpperCase() + kind.slice(1);
+
+const FleetGroupActionsMenu = ({
+  scopes,
+  ariaLabel,
+  testIdPrefix,
+  extraActions = [],
+  onActionStart,
+  onActionComplete,
+  presentation = "row",
+}: FleetGroupActionsMenuProps) => {
+  const scopeKind = scopes[0]?.kind ?? "site";
+  const scopeIds = useMemo(() => scopes.map((scope) => scope.id), [scopes]);
+  const scopeLabel = useMemo(
+    () => (scopes.length === 1 ? scopes[0]?.name : `${scopes.length} ${pluralizeScopeKind(scopeKind, scopes.length)}`),
+    [scopeKind, scopes],
+  );
+  const emptyScopeMessage = useMemo(
+    () =>
+      scopes.length === 1
+        ? `${capitalizeScopeKind(scopeKind)} ${scopeLabel} contains no miners.`
+        : `${scopeLabel} contain no miners.`,
+    [scopeKind, scopeLabel, scopes.length],
+  );
   // Scoped miners — fetched lazily on first action click, re-fetched
   // each click to catch membership changes from unpair / assignment.
   const [ids, setIds] = useState<string[]>([]);
@@ -127,6 +161,8 @@ const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = 
     completeBatchOperation,
     removeDevicesFromBatch,
     miners: minerSnapshots,
+    onActionStart,
+    onActionComplete,
   });
   const permissions = usePermissions();
 
@@ -150,11 +186,11 @@ const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = 
     const collected: string[] = [];
     const snapshotMap: Record<string, MinerStateSnapshot> = {};
     const filterInit =
-      scope.kind === "building"
-        ? { buildingIds: [scope.id] }
-        : scope.kind === "rack"
-          ? { rackIds: [scope.id] }
-          : { siteIds: [scope.id] };
+      scopeKind === "building"
+        ? { buildingIds: scopeIds }
+        : scopeKind === "rack"
+          ? { rackIds: scopeIds }
+          : { siteIds: scopeIds };
     const filter = create(MinerListFilterSchema, filterInit);
     let cursor = "";
     let exhausted = false;
@@ -175,13 +211,13 @@ const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = 
       cursor = response.cursor;
     }
     if (!exhausted) {
-      throw new Error(`Too many miners in ${scope.name} (over ${MAX_MINERS}). Filter the list and try again.`);
+      throw new Error(`Too many miners in ${scopeLabel} (over ${MAX_MINERS}). Filter the list and try again.`);
     }
     idsLoadedRef.current = true;
     setIds(collected);
     setMinerSnapshots(snapshotMap);
     return collected;
-  }, [scope.id, scope.kind, scope.name]);
+  }, [scopeIds, scopeKind, scopeLabel]);
 
   useEffect(() => {
     if (!pendingAction) return;
@@ -198,7 +234,7 @@ const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = 
       if (isBusy) return;
       setIsBusy(true);
       const loadingToast = pushToast({
-        message: `Loading miners in ${scope.name}…`,
+        message: `Loading miners in ${scopeLabel}…`,
         status: STATUSES.loading,
         longRunning: true,
       });
@@ -206,7 +242,7 @@ const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = 
       try {
         deviceIdentifiers = await fetchDeviceIds();
       } catch (err) {
-        const message = err instanceof Error && err.message ? err.message : `Couldn't load miners for ${scope.name}.`;
+        const message = err instanceof Error && err.message ? err.message : `Couldn't load miners for ${scopeLabel}.`;
         updateToast(loadingToast, { message, status: STATUSES.error });
         setIsBusy(false);
         return;
@@ -214,13 +250,13 @@ const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = 
       removeToast(loadingToast);
       setIsBusy(false);
       if (deviceIdentifiers.length === 0) {
-        pushToast({ message: `No miners in ${scope.name}.`, status: STATUSES.queued });
+        pushToast({ message: emptyScopeMessage, status: STATUSES.error });
         return;
       }
       tickRef.current += 1;
       setPendingAction({ key, tick: tickRef.current });
     },
-    [fetchDeviceIds, isBusy, scope.name],
+    [emptyScopeMessage, fetchDeviceIds, isBusy, scopeLabel],
   );
 
   const clearPendingAction = useCallback(() => {
@@ -272,7 +308,10 @@ const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = 
 
   const topWiredEntries = useMemo(() => TOP_WIRED_KEYS.filter(keepEntry), [keepEntry]);
   const bottomWiredEntries = useMemo(() => BOTTOM_WIRED_KEYS.filter(keepEntry), [keepEntry]);
-  const visibleExtraActions = useMemo(() => extraActions.filter((entry) => !entry.hidden), [extraActions]);
+  const visibleExtraActions = useMemo(
+    () => (scopes.length > 1 ? [] : extraActions.filter((entry) => !entry.hidden)),
+    [extraActions, scopes.length],
+  );
 
   // Cluster boundary rules: divider between top↔extras and (when no
   // extras) top↔bottom; never between extras↔bottom so Edit and
@@ -323,14 +362,38 @@ const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = 
     return entries;
   }, [topWiredEntries, visibleExtraActions, bottomWiredEntries, handleTrigger, testIdPrefix]);
 
+  const testIdBase = testIdPrefix ?? "fleet-group-actions";
+
   return (
     <>
-      <RowActionsMenu
-        actions={rowActions}
-        ariaLabel={ariaLabel}
-        testIdPrefix={testIdPrefix ?? "fleet-group-actions"}
-        disabled={isBusy}
-      />
+      {presentation === "bulk" ? (
+        <div className="flex flex-wrap justify-start gap-3">
+          {keepEntry(deviceActions.reboot) ? (
+            <Button
+              className="bg-grayscale-white-10! text-grayscale-white-90!"
+              size={sizes.compact}
+              variant={variants.secondary}
+              testId={`${testIdBase}-quick-${deviceActions.reboot}`}
+              disabled={isBusy}
+              onClick={() => void handleTrigger(deviceActions.reboot)}
+            >
+              Reboot
+            </Button>
+          ) : null}
+          <RowActionsMenu
+            actions={rowActions}
+            ariaLabel={ariaLabel}
+            testIdPrefix={testIdBase}
+            triggerLabel="More"
+            triggerClassName="bg-grayscale-white-10! text-grayscale-white-90!"
+            triggerVariant={variants.secondary}
+            triggerSuffixIcon={<ChevronDown width={iconSizes.xSmall} />}
+            disabled={isBusy}
+          />
+        </div>
+      ) : (
+        <RowActionsMenu actions={rowActions} ariaLabel={ariaLabel} testIdPrefix={testIdBase} disabled={isBusy} />
+      )}
       <UnsupportedMinersModal
         open={minerActions.unsupportedMinersInfo.visible}
         unsupportedGroups={minerActions.unsupportedMinersInfo.unsupportedGroups}
@@ -353,7 +416,7 @@ const FleetGroupActionsMenu = ({ scope, ariaLabel, testIdPrefix, extraActions = 
               actionConfirmation={action.confirmation!}
               onConfirmation={handleConfirmClick}
               onCancel={handleCancelClick}
-              testId={`${testIdPrefix ?? "fleet-group-actions"}-${action.action}-confirm`}
+              testId={`${testIdBase}-${action.action}-confirm`}
             />
           );
         })}

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.test.tsx
@@ -1,8 +1,9 @@
+import { type ComponentProps } from "react";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
-import FleetGroupListActionBar from "./FleetGroupListActionBar";
 import { type GroupScope } from "./FleetGroupActionsMenu";
+import FleetGroupListActionBar from "./FleetGroupListActionBar";
 
 const { mockSetActionBarVisible } = vi.hoisted(() => ({ mockSetActionBarVisible: vi.fn() }));
 
@@ -29,10 +30,7 @@ vi.mock("./FleetGroupActionsMenu", async (importOriginal) => {
   };
 });
 
-const renderBar = (
-  scopes: GroupScope[],
-  overrides: Partial<React.ComponentProps<typeof FleetGroupListActionBar>> = {},
-) =>
+const renderBar = (scopes: GroupScope[], overrides: Partial<ComponentProps<typeof FleetGroupListActionBar>> = {}) =>
   render(
     <FleetGroupListActionBar
       selectedScopes={scopes}

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.test.tsx
@@ -17,8 +17,17 @@ vi.mock("./FleetGroupActionsMenu", async (importOriginal) => {
   const actual = (await importOriginal()) as object;
   return {
     ...actual,
-    default: ({ onActionStart, onActionComplete }: { onActionStart?: () => void; onActionComplete?: () => void }) => (
+    default: ({
+      scopes,
+      onActionStart,
+      onActionComplete,
+    }: {
+      scopes: { id: bigint }[];
+      onActionStart?: () => void;
+      onActionComplete?: () => void;
+    }) => (
       <div>
+        <span data-testid="stub-scope-count">{scopes.length}</span>
         <button data-testid="stub-start" onClick={onActionStart}>
           start
         </button>
@@ -67,20 +76,42 @@ describe("FleetGroupListActionBar", () => {
   });
 
   test("hides the bar while an action is running and restores it on complete", () => {
+    const onActionBusyChange = vi.fn();
     mockSetActionBarVisible.mockClear();
-    const { getByTestId } = renderBar(scopes(2));
+    const { getByTestId } = renderBar(scopes(2), { onActionBusyChange });
 
     mockSetActionBarVisible.mockClear();
     fireEvent.click(getByTestId("stub-start"));
     expect(mockSetActionBarVisible).toHaveBeenLastCalledWith(false);
+    expect(onActionBusyChange).toHaveBeenLastCalledWith(true);
 
     mockSetActionBarVisible.mockClear();
     fireEvent.click(getByTestId("stub-complete"));
     expect(mockSetActionBarVisible).toHaveBeenLastCalledWith(true);
+    expect(onActionBusyChange).toHaveBeenLastCalledWith(false);
+  });
+
+  test("keeps the last selected scopes while an action is running", () => {
+    const { getByTestId, queryByTestId, rerender } = renderBar(scopes(2));
+
+    fireEvent.click(getByTestId("stub-start"));
+    rerender(
+      <FleetGroupListActionBar
+        selectedScopes={[]}
+        kind="site"
+        onClearSelection={vi.fn()}
+        onSelectAllVisible={vi.fn()}
+      />,
+    );
+    expect(getByTestId("stub-scope-count")).toHaveTextContent("2");
+
+    fireEvent.click(getByTestId("stub-complete"));
+    expect(queryByTestId("stub-scope-count")).not.toBeInTheDocument();
   });
 
   test("does not re-show the bar on action complete after unmount", () => {
-    const { getByTestId, unmount } = renderBar(scopes(2));
+    const onActionBusyChange = vi.fn();
+    const { getByTestId, unmount } = renderBar(scopes(2), { onActionBusyChange });
 
     fireEvent.click(getByTestId("stub-start"));
     const completeButton = getByTestId("stub-complete");
@@ -89,6 +120,7 @@ describe("FleetGroupListActionBar", () => {
     mockSetActionBarVisible.mockClear();
     fireEvent.click(completeButton);
     expect(mockSetActionBarVisible).not.toHaveBeenCalledWith(true);
+    expect(onActionBusyChange).toHaveBeenLastCalledWith(false);
   });
 
   test("Select all visible fires the callback", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import FleetGroupListActionBar from "./FleetGroupListActionBar";
+import { type GroupScope } from "./FleetGroupActionsMenu";
+
+const { mockSetActionBarVisible } = vi.hoisted(() => ({ mockSetActionBarVisible: vi.fn() }));
+
+vi.mock("@/protoFleet/store", () => ({
+  useSetActionBarVisible: () => mockSetActionBarVisible,
+}));
+
+// FleetGroupActionsMenu pulls in batch hooks / RPC wiring that aren't relevant
+// here — exercise the renderActions lifecycle directly via a stub.
+vi.mock("./FleetGroupActionsMenu", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    default: ({ onActionStart, onActionComplete }: { onActionStart?: () => void; onActionComplete?: () => void }) => (
+      <div>
+        <button data-testid="stub-start" onClick={onActionStart}>
+          start
+        </button>
+        <button data-testid="stub-complete" onClick={onActionComplete}>
+          complete
+        </button>
+      </div>
+    ),
+  };
+});
+
+const renderBar = (
+  scopes: GroupScope[],
+  overrides: Partial<React.ComponentProps<typeof FleetGroupListActionBar>> = {},
+) =>
+  render(
+    <FleetGroupListActionBar
+      selectedScopes={scopes}
+      kind="site"
+      onClearSelection={vi.fn()}
+      onSelectAllVisible={vi.fn()}
+      {...overrides}
+    />,
+  );
+
+const scopes = (count: number): GroupScope[] =>
+  Array.from({ length: count }, (_, i) => ({ kind: "site" as const, id: BigInt(i + 1), name: `Site ${i + 1}` }));
+
+describe("FleetGroupListActionBar", () => {
+  test("sets global toaster push-up on mount and clears it on unmount", () => {
+    mockSetActionBarVisible.mockClear();
+    const { unmount } = renderBar(scopes(2));
+
+    expect(mockSetActionBarVisible).toHaveBeenCalledWith(true);
+
+    mockSetActionBarVisible.mockClear();
+    unmount();
+    expect(mockSetActionBarVisible).toHaveBeenLastCalledWith(false);
+  });
+
+  test("renders selected count using the kind's plural noun", () => {
+    const { getByText } = renderBar(scopes(3));
+    expect(getByText("3 sites selected")).toBeInTheDocument();
+  });
+
+  test("uses singular noun when exactly one scope is selected", () => {
+    const { getByText } = renderBar(scopes(1));
+    expect(getByText("1 site selected")).toBeInTheDocument();
+  });
+
+  test("hides the bar while an action is running and restores it on complete", () => {
+    mockSetActionBarVisible.mockClear();
+    const { getByTestId } = renderBar(scopes(2));
+
+    mockSetActionBarVisible.mockClear();
+    fireEvent.click(getByTestId("stub-start"));
+    expect(mockSetActionBarVisible).toHaveBeenLastCalledWith(false);
+
+    mockSetActionBarVisible.mockClear();
+    fireEvent.click(getByTestId("stub-complete"));
+    expect(mockSetActionBarVisible).toHaveBeenLastCalledWith(true);
+  });
+
+  test("does not re-show the bar on action complete after unmount", () => {
+    const { getByTestId, unmount } = renderBar(scopes(2));
+
+    fireEvent.click(getByTestId("stub-start"));
+    const completeButton = getByTestId("stub-complete");
+
+    unmount();
+    mockSetActionBarVisible.mockClear();
+    fireEvent.click(completeButton);
+    expect(mockSetActionBarVisible).not.toHaveBeenCalledWith(true);
+  });
+
+  test("Select all visible fires the callback", () => {
+    const onSelectAllVisible = vi.fn();
+    const { getByTestId } = renderBar(scopes(1), { onSelectAllVisible });
+    fireEvent.click(getByTestId("select-all-visible-sites-button"));
+    expect(onSelectAllVisible).toHaveBeenCalledOnce();
+  });
+
+  test("Select none fires the clear-selection callback", () => {
+    const onClearSelection = vi.fn();
+    const { getByTestId } = renderBar(scopes(1), { onClearSelection });
+    fireEvent.click(getByTestId("select-none-sites-button"));
+    expect(onClearSelection).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import FleetGroupActionsMenu, { type GroupScope } from "./FleetGroupActionsMenu";
 import ActionBar from "@/protoFleet/features/fleetManagement/components/ActionBar";
@@ -26,17 +26,34 @@ const FleetGroupListActionBar = ({
 }: FleetGroupListActionBarProps) => {
   const setActionBarVisible = useSetActionBarVisible();
   const selectedIds = useMemo(() => selectedScopes.map((scope) => scope.id.toString()), [selectedScopes]);
-  const selectedCountRef = useRef(selectedIds.length);
   const pluralKind = PLURAL_KIND[kind];
+  // Tracks whether the bar is still mounted so a late-arriving onActionComplete
+  // can't resurrect the global toaster push-up after the user navigated away.
+  const mountedRef = useRef(true);
+  // Tracks current selection length so onActionComplete reflects the latest
+  // count, not a value captured when the action was dispatched.
+  const selectedCountRef = useRef(selectedIds.length);
+  selectedCountRef.current = selectedIds.length;
 
   useEffect(() => {
-    selectedCountRef.current = selectedIds.length;
     setActionBarVisible(selectedIds.length > 0);
   }, [selectedIds.length, setActionBarVisible]);
 
   useEffect(() => {
-    return () => setActionBarVisible(false);
+    return () => {
+      mountedRef.current = false;
+      setActionBarVisible(false);
+    };
   }, [setActionBarVisible]);
+
+  const handleActionComplete = useCallback(
+    (setHidden: (hidden: boolean) => void) => {
+      setHidden(false);
+      if (!mountedRef.current) return;
+      setActionBarVisible(selectedCountRef.current > 0);
+    },
+    [setActionBarVisible],
+  );
 
   return (
     <ActionBar
@@ -81,10 +98,7 @@ const FleetGroupListActionBar = ({
             setHidden(true);
             setActionBarVisible(false);
           }}
-          onActionComplete={() => {
-            setHidden(false);
-            setActionBarVisible(selectedCountRef.current > 0);
-          }}
+          onActionComplete={() => handleActionComplete(setHidden)}
         />
       )}
     />

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo, useRef } from "react";
+
+import FleetGroupActionsMenu, { type GroupScope } from "./FleetGroupActionsMenu";
+import ActionBar from "@/protoFleet/features/fleetManagement/components/ActionBar";
+import { useSetActionBarVisible } from "@/protoFleet/store";
+import Button, { sizes, variants } from "@/shared/components/Button";
+
+interface FleetGroupListActionBarProps {
+  selectedScopes: GroupScope[];
+  kind: "site" | "building" | "rack";
+  onClearSelection: () => void;
+  onSelectAllVisible: () => void;
+}
+
+const PLURAL_KIND: Record<FleetGroupListActionBarProps["kind"], string> = {
+  site: "sites",
+  building: "buildings",
+  rack: "racks",
+};
+
+const FleetGroupListActionBar = ({
+  selectedScopes,
+  kind,
+  onClearSelection,
+  onSelectAllVisible,
+}: FleetGroupListActionBarProps) => {
+  const setActionBarVisible = useSetActionBarVisible();
+  const selectedIds = useMemo(() => selectedScopes.map((scope) => scope.id.toString()), [selectedScopes]);
+  const selectedCountRef = useRef(selectedIds.length);
+  const pluralKind = PLURAL_KIND[kind];
+
+  useEffect(() => {
+    selectedCountRef.current = selectedIds.length;
+    setActionBarVisible(selectedIds.length > 0);
+  }, [selectedIds.length, setActionBarVisible]);
+
+  useEffect(() => {
+    return () => setActionBarVisible(false);
+  }, [setActionBarVisible]);
+
+  return (
+    <ActionBar
+      className="fixed right-0 bottom-4 left-0 z-20 laptop:left-16 desktop:left-50"
+      selectedItems={selectedIds}
+      selectionMode="subset"
+      itemNoun={{ singular: kind, plural: pluralKind }}
+      onClose={onClearSelection}
+      selectionControls={
+        <>
+          <Button
+            className="py-1"
+            size={sizes.textOnly}
+            variant={variants.textOnly}
+            textColor="text-core-accent-fill"
+            textOnlyUnderlineOnHover={false}
+            testId={`select-all-visible-${pluralKind}-button`}
+            onClick={onSelectAllVisible}
+          >
+            Select all visible
+          </Button>
+          <Button
+            className="py-1"
+            size={sizes.textOnly}
+            variant={variants.textOnly}
+            textColor="text-core-accent-fill"
+            textOnlyUnderlineOnHover={false}
+            testId={`select-none-${pluralKind}-button`}
+            onClick={onClearSelection}
+          >
+            Select none
+          </Button>
+        </>
+      }
+      renderActions={(setHidden) => (
+        <FleetGroupActionsMenu
+          scopes={selectedScopes}
+          ariaLabel={`Bulk actions for selected ${pluralKind}`}
+          testIdPrefix={`fleet-bulk-${kind}-actions`}
+          presentation="bulk"
+          onActionStart={() => {
+            setHidden(true);
+            setActionBarVisible(false);
+          }}
+          onActionComplete={() => {
+            setHidden(false);
+            setActionBarVisible(selectedCountRef.current > 0);
+          }}
+        />
+      )}
+    />
+  );
+};
+
+export default FleetGroupListActionBar;

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import FleetGroupActionsMenu, { type GroupScope } from "./FleetGroupActionsMenu";
 import ActionBar from "@/protoFleet/features/fleetManagement/components/ActionBar";
@@ -10,6 +10,7 @@ interface FleetGroupListActionBarProps {
   kind: "site" | "building" | "rack";
   onClearSelection: () => void;
   onSelectAllVisible: () => void;
+  onActionBusyChange?: (busy: boolean) => void;
 }
 
 const PLURAL_KIND: Record<FleetGroupListActionBarProps["kind"], string> = {
@@ -23,9 +24,17 @@ const FleetGroupListActionBar = ({
   kind,
   onClearSelection,
   onSelectAllVisible,
+  onActionBusyChange,
 }: FleetGroupListActionBarProps) => {
   const setActionBarVisible = useSetActionBarVisible();
-  const selectedIds = useMemo(() => selectedScopes.map((scope) => scope.id.toString()), [selectedScopes]);
+  const [isActionBusy, setIsActionBusy] = useState(false);
+  const lastSelectedScopesRef = useRef(selectedScopes);
+  if (selectedScopes.length > 0) {
+    lastSelectedScopesRef.current = selectedScopes;
+  }
+  const activeSelectedScopes =
+    selectedScopes.length > 0 || !isActionBusy ? selectedScopes : lastSelectedScopesRef.current;
+  const selectedIds = useMemo(() => activeSelectedScopes.map((scope) => scope.id.toString()), [activeSelectedScopes]);
   const pluralKind = PLURAL_KIND[kind];
   // Tracks whether the bar is still mounted so a late-arriving onActionComplete
   // can't resurrect the global toaster push-up after the user navigated away.
@@ -43,16 +52,19 @@ const FleetGroupListActionBar = ({
     return () => {
       mountedRef.current = false;
       setActionBarVisible(false);
+      onActionBusyChange?.(false);
     };
-  }, [setActionBarVisible]);
+  }, [onActionBusyChange, setActionBarVisible]);
 
   const handleActionComplete = useCallback(
     (setHidden: (hidden: boolean) => void) => {
+      setIsActionBusy(false);
+      onActionBusyChange?.(false);
       setHidden(false);
       if (!mountedRef.current) return;
       setActionBarVisible(selectedCountRef.current > 0);
     },
-    [setActionBarVisible],
+    [onActionBusyChange, setActionBarVisible],
   );
 
   return (
@@ -90,11 +102,13 @@ const FleetGroupListActionBar = ({
       }
       renderActions={(setHidden) => (
         <FleetGroupActionsMenu
-          scopes={selectedScopes}
+          scopes={activeSelectedScopes}
           ariaLabel={`Bulk actions for selected ${pluralKind}`}
           testIdPrefix={`fleet-bulk-${kind}-actions`}
           presentation="bulk"
           onActionStart={() => {
+            setIsActionBusy(true);
+            onActionBusyChange?.(true);
             setHidden(true);
             setActionBarVisible(false);
           }}

--- a/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.tsx
@@ -2,7 +2,7 @@ import { Fragment, type ReactNode, useCallback, useEffect, useState } from "reac
 
 import { Ellipsis } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
-import Button, { sizes, variants } from "@/shared/components/Button";
+import Button, { type ButtonVariant, sizes, variants } from "@/shared/components/Button";
 import Divider from "@/shared/components/Divider";
 import Popover, { PopoverProvider, popoverSizes, usePopover } from "@/shared/components/Popover";
 import Row from "@/shared/components/Row";
@@ -27,6 +27,10 @@ interface RowActionsMenuProps {
   // Falls back to `${testIdPrefix}-trigger` / `row-actions-menu-trigger`.
   triggerTestId?: string;
   disabled?: boolean;
+  triggerLabel?: string;
+  triggerClassName?: string;
+  triggerVariant?: ButtonVariant;
+  triggerSuffixIcon?: ReactNode;
 }
 
 const RowActionsMenu = ({
@@ -35,6 +39,10 @@ const RowActionsMenu = ({
   testIdPrefix,
   triggerTestId,
   disabled,
+  triggerLabel,
+  triggerClassName,
+  triggerVariant,
+  triggerSuffixIcon,
 }: RowActionsMenuProps) => (
   <PopoverProvider>
     <RowActionsMenuInner
@@ -43,6 +51,10 @@ const RowActionsMenu = ({
       testIdPrefix={testIdPrefix}
       triggerTestId={triggerTestId}
       disabled={disabled}
+      triggerLabel={triggerLabel}
+      triggerClassName={triggerClassName}
+      triggerVariant={triggerVariant}
+      triggerSuffixIcon={triggerSuffixIcon}
     />
   </PopoverProvider>
 );
@@ -53,8 +65,21 @@ const RowActionsMenuInner = ({
   testIdPrefix,
   triggerTestId,
   disabled,
+  triggerLabel,
+  triggerClassName,
+  triggerVariant,
+  triggerSuffixIcon,
 }: Required<Pick<RowActionsMenuProps, "actions" | "ariaLabel">> &
-  Pick<RowActionsMenuProps, "testIdPrefix" | "triggerTestId" | "disabled">) => {
+  Pick<
+    RowActionsMenuProps,
+    | "testIdPrefix"
+    | "triggerTestId"
+    | "disabled"
+    | "triggerLabel"
+    | "triggerClassName"
+    | "triggerVariant"
+    | "triggerSuffixIcon"
+  >) => {
   const { triggerRef, setPopoverRenderMode } = usePopover();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -83,15 +108,20 @@ const RowActionsMenuInner = ({
   return (
     <div className="relative" ref={triggerRef}>
       <Button
-        className="-my-[10px] !p-[14px]"
+        className={triggerClassName ?? "-my-[10px] !p-[14px]"}
         size={sizes.compact}
-        variant={variants.textOnly}
-        prefixIcon={<Ellipsis width={iconSizes.small} className="text-text-primary-70" />}
+        variant={triggerVariant ?? variants.textOnly}
+        prefixIcon={triggerLabel ? undefined : <Ellipsis width={iconSizes.small} className="text-text-primary-70" />}
+        suffixIcon={triggerSuffixIcon}
         ariaLabel={ariaLabel}
+        ariaHasPopup="menu"
+        ariaExpanded={open}
         testId={resolvedTriggerTestId}
         disabled={disabled}
         onClick={() => setIsOpen((prev) => !prev)}
-      />
+      >
+        {triggerLabel}
+      </Button>
       {open ? (
         <Popover
           className="!space-y-0 !rounded-2xl px-0 pt-2 pb-1"

--- a/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.test.tsx
@@ -93,7 +93,15 @@ const PathProbe = () => {
 
 type EditSiteCallback = (site: Site) => void;
 
-const renderList = ({ onEditSite }: { onEditSite?: EditSiteCallback } = {}) =>
+const renderList = ({
+  onEditSite,
+  selectedIds,
+  onSelectedIdsChange,
+}: {
+  onEditSite?: EditSiteCallback;
+  selectedIds?: string[];
+  onSelectedIdsChange?: (ids: string[]) => void;
+} = {}) =>
   render(
     <MemoryRouter initialEntries={["/fleet/sites"]}>
       <Routes>
@@ -101,7 +109,12 @@ const renderList = ({ onEditSite }: { onEditSite?: EditSiteCallback } = {}) =>
           path="/fleet/sites"
           element={
             <>
-              <SiteList sites={[makeSite(7, "North")]} onEditSite={onEditSite} />
+              <SiteList
+                sites={[makeSite(7, "North")]}
+                onEditSite={onEditSite}
+                selectedIds={selectedIds}
+                onSelectedIdsChange={onSelectedIdsChange}
+              />
               <PathProbe />
             </>
           }
@@ -179,5 +192,15 @@ describe("SiteList row actions menu", () => {
     renderList();
     fireEvent.click(trigger());
     expect(screen.queryByText("Edit site")).not.toBeInTheDocument();
+  });
+
+  it("shows controlled row checkboxes when selection props are supplied", () => {
+    const onSelectedIdsChange = vi.fn();
+    renderList({ selectedIds: [], onSelectedIdsChange });
+
+    const checkbox = screen.getByTestId("list-body").querySelector("input[type='checkbox']") as HTMLInputElement;
+    fireEvent.click(checkbox);
+
+    expect(onSelectedIdsChange).toHaveBeenCalledWith(["7"]);
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.tsx
@@ -124,49 +124,40 @@ const SiteList = ({ sites, emptyStateRow, onEditSite, selectedIds, onSelectedIds
   );
 
   const handleRowClick = useCallback((item: SiteListItem) => navigate(`/sites/${item.id}`), [navigate]);
-  const selectableSelectionMode: SelectionMode = selectedIds && selectedIds.length > 0 ? "subset" : "none";
-  const handleSelectionModeChange = useCallback(() => undefined, []);
   const isSelectableSite = useCallback((item: SiteListItem) => {
     const siteId = item.site.site?.id;
     return siteId !== undefined && siteId !== 0n;
   }, []);
+  const handleSelectionModeChange = useCallback(() => undefined, []);
+  const commonProps = {
+    activeCols: ACTIVE_COLS,
+    colTitles: COL_TITLES,
+    colConfig,
+    items,
+    itemKey: "id" as const,
+    hideTotal: true,
+    onRowClick: handleRowClick,
+    emptyStateRow,
+    paddingLeft: { phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" },
+  };
 
   if (selectedIds !== undefined && onSelectedIdsChange !== undefined) {
+    const selectionMode: SelectionMode = selectedIds.length > 0 ? "subset" : "none";
     return (
       <List<SiteListItem, string, SiteColumn>
-        activeCols={ACTIVE_COLS}
-        colTitles={COL_TITLES}
-        colConfig={colConfig}
-        items={items}
-        itemKey="id"
+        {...commonProps}
         itemSelectable
         customSelectedItems={selectedIds}
         customSetSelectedItems={onSelectedIdsChange}
-        customSelectionMode={selectableSelectionMode}
+        customSelectionMode={selectionMode}
         onSelectionModeChange={handleSelectionModeChange}
         pageScopedSelection
         isRowSelectable={isSelectableSite}
-        hideTotal
-        onRowClick={handleRowClick}
-        emptyStateRow={emptyStateRow}
-        paddingLeft={{ phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" }}
       />
     );
   }
 
-  return (
-    <List<SiteListItem, string, SiteColumn>
-      activeCols={ACTIVE_COLS}
-      colTitles={COL_TITLES}
-      colConfig={colConfig}
-      items={items}
-      itemKey="id"
-      hideTotal
-      onRowClick={handleRowClick}
-      emptyStateRow={emptyStateRow}
-      paddingLeft={{ phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" }}
-    />
-  );
+  return <List<SiteListItem, string, SiteColumn> {...commonProps} />;
 };
 
 export default SiteList;

--- a/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.tsx
@@ -5,7 +5,7 @@ import FleetGroupActionsMenu from "../FleetGroupActionsMenu";
 import { type RowAction } from "../RowActionsMenu";
 import { type Site, type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { ArrowRight, Edit } from "@/shared/assets/icons";
-import List from "@/shared/components/List";
+import List, { type SelectionMode } from "@/shared/components/List";
 import { type ColConfig, type ColTitles } from "@/shared/components/List/types";
 
 type SiteListItem = {
@@ -43,9 +43,11 @@ interface SiteListProps {
   sites: SiteWithCounts[];
   emptyStateRow?: ReactNode;
   onEditSite?: (site: Site) => void;
+  selectedIds?: string[];
+  onSelectedIdsChange?: (ids: string[]) => void;
 }
 
-const SiteList = ({ sites, emptyStateRow, onEditSite }: SiteListProps) => {
+const SiteList = ({ sites, emptyStateRow, onEditSite, selectedIds, onSelectedIdsChange }: SiteListProps) => {
   const navigate = useNavigate();
 
   const items: SiteListItem[] = useMemo(
@@ -96,7 +98,7 @@ const SiteList = ({ sites, emptyStateRow, onEditSite }: SiteListProps) => {
               <span className="truncate text-emphasis-300">{siteName}</span>
               {siteId !== undefined && siteId !== 0n ? (
                 <FleetGroupActionsMenu
-                  scope={{ kind: "site", id: siteId, name: siteName }}
+                  scopes={[{ kind: "site", id: siteId, name: siteName }]}
                   ariaLabel={`Actions for ${siteName}`}
                   testIdPrefix={`site-list-row-${item.id}-actions`}
                   extraActions={buildExtraActions(item)}
@@ -122,6 +124,35 @@ const SiteList = ({ sites, emptyStateRow, onEditSite }: SiteListProps) => {
   );
 
   const handleRowClick = useCallback((item: SiteListItem) => navigate(`/sites/${item.id}`), [navigate]);
+  const selectableSelectionMode: SelectionMode = selectedIds && selectedIds.length > 0 ? "subset" : "none";
+  const handleSelectionModeChange = useCallback(() => undefined, []);
+  const isSelectableSite = useCallback((item: SiteListItem) => {
+    const siteId = item.site.site?.id;
+    return siteId !== undefined && siteId !== 0n;
+  }, []);
+
+  if (selectedIds !== undefined && onSelectedIdsChange !== undefined) {
+    return (
+      <List<SiteListItem, string, SiteColumn>
+        activeCols={ACTIVE_COLS}
+        colTitles={COL_TITLES}
+        colConfig={colConfig}
+        items={items}
+        itemKey="id"
+        itemSelectable
+        customSelectedItems={selectedIds}
+        customSetSelectedItems={onSelectedIdsChange}
+        customSelectionMode={selectableSelectionMode}
+        onSelectionModeChange={handleSelectionModeChange}
+        pageScopedSelection
+        isRowSelectable={isSelectableSite}
+        hideTotal
+        onRowClick={handleRowClick}
+        emptyStateRow={emptyStateRow}
+        paddingLeft={{ phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" }}
+      />
+    );
+  }
 
   return (
     <List<SiteListItem, string, SiteColumn>

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 
 import BuildingList from "../components/BuildingList";
 import FilterRow from "../components/FilterRow";
+import FleetGroupListActionBar from "../components/FleetGroupActionsMenu/FleetGroupListActionBar";
 import { useFleetOutletContext } from "../components/FleetLayout";
 import { useBuildings } from "@/protoFleet/api/buildings";
 import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
@@ -28,6 +29,7 @@ const FleetBuildingsPage = () => {
   const { listAllBuildings } = useBuildings();
   const [buildings, setBuildings] = useState<BuildingWithCounts[] | undefined>(undefined);
   const [buildingsError, setBuildingsError] = useState<string | null>(null);
+  const [selectedBuildingIds, setSelectedBuildingIds] = useState<string[]>([]);
 
   // Returning the promise lets usePoll schedule the next tick from response
   // completion (not from request start) so slow responses can't overlap.
@@ -85,6 +87,29 @@ const FleetBuildingsPage = () => {
     }
     return buildings.filter((b) => (b.building?.siteId ?? 0n).toString() === activeSite.id);
   }, [buildings, activeSite, urlSiteIds]);
+  const visibleBuildingScopes = useMemo(
+    () =>
+      visibleBuildings.flatMap((building) => {
+        if (!building.building || building.building.id === 0n) return [];
+        return [
+          {
+            kind: "building" as const,
+            id: building.building.id,
+            name: building.building.name,
+          },
+        ];
+      }),
+    [visibleBuildings],
+  );
+  const selectedBuildingScopes = useMemo(() => {
+    const selected = new Set(selectedBuildingIds);
+    return visibleBuildingScopes.filter((building) => selected.has(building.id.toString()));
+  }, [selectedBuildingIds, visibleBuildingScopes]);
+  const handleSelectAllVisibleBuildings = useCallback(
+    () => setSelectedBuildingIds(visibleBuildingScopes.map((building) => building.id.toString())),
+    [visibleBuildingScopes],
+  );
+  const handleClearBuildingSelection = useCallback(() => setSelectedBuildingIds([]), []);
 
   const buildingModals = useBuildingModals({ refetchBuildings: fetchBuildings });
 
@@ -231,8 +256,18 @@ const FleetBuildingsPage = () => {
           sites={sites}
           onEditBuilding={canManageBuildings ? openEditBuilding : undefined}
           onAddBuildingToSite={canManageBuildings ? handleAddBuildingToSite : undefined}
+          selectedIds={selectedBuildingIds}
+          onSelectedIdsChange={setSelectedBuildingIds}
         />
       </div>
+      {selectedBuildingScopes.length > 0 ? (
+        <FleetGroupListActionBar
+          selectedScopes={selectedBuildingScopes}
+          kind="building"
+          onClearSelection={handleClearBuildingSelection}
+          onSelectAllVisible={handleSelectAllVisibleBuildings}
+        />
+      ) : null}
       <BuildingModals modals={buildingModals} sites={sites} />
       {reparentTarget?.building ? (
         <ParentPickerModal

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import BuildingList from "../components/BuildingList";
@@ -199,94 +199,102 @@ const FleetBuildingsPage = () => {
     />
   ) : null;
 
-  if (buildings.length === 0) {
-    return (
-      <>
-        <FilterRow testId="fleet-buildings-page">
-          <div className="flex items-center justify-end">{addBuildingButton}</div>
-          <div className="flex flex-col items-start gap-3 rounded-xl border border-dashed border-border-5 p-6">
-            <Header title="No buildings yet" titleSize="text-heading-200" />
-            <p className="text-300 text-text-primary-70">
-              {!canManageBuildings
-                ? "No buildings have been added to this fleet yet."
-                : hasSites
-                  ? "Add a building to start organizing racks."
-                  : "Create a site first, then add buildings to organize racks."}
-            </p>
-          </div>
-        </FilterRow>
-        <BuildingModals modals={buildingModals} sites={sites} />
-      </>
-    );
-  }
+  const inlineErrors = (
+    <>
+      {sitesError ? (
+        <Callout
+          intent="danger"
+          prefixIcon={<Alert />}
+          title="Couldn't load sites for the Site column"
+          subtitle={sitesError}
+          buttonText="Retry"
+          buttonOnClick={refetchSites}
+          testId="fleet-buildings-sites-error"
+        />
+      ) : null}
+      {buildingsError ? (
+        <Callout
+          intent="danger"
+          prefixIcon={<Alert />}
+          title="Couldn't refresh buildings"
+          subtitle={buildingsError}
+          buttonText="Retry"
+          buttonOnClick={fetchBuildings}
+          testId="fleet-buildings-inline-error"
+        />
+      ) : null}
+    </>
+  );
 
-  if (visibleBuildings.length === 0) {
+  const bulkActionBar =
+    selectedBuildingScopes.length > 0 || isBulkActionBusy ? (
+      <FleetGroupListActionBar
+        selectedScopes={selectedBuildingScopes}
+        kind="building"
+        onClearSelection={handleClearBuildingSelection}
+        onSelectAllVisible={handleSelectAllVisibleBuildings}
+        onActionBusyChange={setIsBulkActionBusy}
+      />
+    ) : null;
+
+  let pageContent: ReactNode;
+  if (buildings.length === 0) {
+    pageContent = (
+      <FilterRow testId="fleet-buildings-page">
+        <div className="flex items-center justify-end">{addBuildingButton}</div>
+        <div className="flex flex-col items-start gap-3 rounded-xl border border-dashed border-border-5 p-6">
+          <Header title="No buildings yet" titleSize="text-heading-200" />
+          <p className="text-300 text-text-primary-70">
+            {!canManageBuildings
+              ? "No buildings have been added to this fleet yet."
+              : hasSites
+                ? "Add a building to start organizing racks."
+                : "Create a site first, then add buildings to organize racks."}
+          </p>
+        </div>
+      </FilterRow>
+    );
+  } else if (visibleBuildings.length === 0) {
     const message =
       activeSite.kind === "unassigned"
         ? "No buildings without a site. Switch the picker to All Sites to see every building."
         : "No buildings in this site yet.";
-    return (
+    pageContent = (
+      <FilterRow testId="fleet-buildings-page">
+        <div className="flex items-center justify-end">{addBuildingButton}</div>
+        <div
+          className="rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
+          data-testid="fleet-buildings-filter-empty"
+        >
+          {message}
+        </div>
+      </FilterRow>
+    );
+  } else {
+    pageContent = (
       <>
         <FilterRow testId="fleet-buildings-page">
+          {inlineErrors}
           <div className="flex items-center justify-end">{addBuildingButton}</div>
-          <div
-            className="rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
-            data-testid="fleet-buildings-filter-empty"
-          >
-            {message}
-          </div>
         </FilterRow>
-        <BuildingModals modals={buildingModals} sites={sites} />
+        <div className={LIST_WRAPPER}>
+          <BuildingList
+            buildings={visibleBuildings}
+            sites={sites}
+            onEditBuilding={canManageBuildings ? openEditBuilding : undefined}
+            onAddBuildingToSite={canManageBuildings ? handleAddBuildingToSite : undefined}
+            selectedIds={selectedBuildingIds}
+            onSelectedIdsChange={handleSelectedBuildingIdsChange}
+          />
+        </div>
       </>
     );
   }
 
   return (
     <>
-      <FilterRow testId="fleet-buildings-page">
-        {sitesError ? (
-          <Callout
-            intent="danger"
-            prefixIcon={<Alert />}
-            title="Couldn't load sites for the Site column"
-            subtitle={sitesError}
-            buttonText="Retry"
-            buttonOnClick={refetchSites}
-            testId="fleet-buildings-sites-error"
-          />
-        ) : null}
-        {buildingsError ? (
-          <Callout
-            intent="danger"
-            prefixIcon={<Alert />}
-            title="Couldn't refresh buildings"
-            subtitle={buildingsError}
-            buttonText="Retry"
-            buttonOnClick={fetchBuildings}
-            testId="fleet-buildings-inline-error"
-          />
-        ) : null}
-        <div className="flex items-center justify-end">{addBuildingButton}</div>
-      </FilterRow>
-      <div className={LIST_WRAPPER}>
-        <BuildingList
-          buildings={visibleBuildings}
-          sites={sites}
-          onEditBuilding={canManageBuildings ? openEditBuilding : undefined}
-          onAddBuildingToSite={canManageBuildings ? handleAddBuildingToSite : undefined}
-          selectedIds={selectedBuildingIds}
-          onSelectedIdsChange={handleSelectedBuildingIdsChange}
-        />
-      </div>
-      {selectedBuildingScopes.length > 0 || isBulkActionBusy ? (
-        <FleetGroupListActionBar
-          selectedScopes={selectedBuildingScopes}
-          kind="building"
-          onClearSelection={handleClearBuildingSelection}
-          onSelectAllVisible={handleSelectAllVisibleBuildings}
-          onActionBusyChange={setIsBulkActionBusy}
-        />
-      ) : null}
+      {pageContent}
+      {bulkActionBar}
       <BuildingModals modals={buildingModals} sites={sites} />
       {reparentTarget?.building ? (
         <ParentPickerModal

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -30,6 +30,7 @@ const FleetBuildingsPage = () => {
   const [buildings, setBuildings] = useState<BuildingWithCounts[] | undefined>(undefined);
   const [buildingsError, setBuildingsError] = useState<string | null>(null);
   const [selectedBuildingIds, setSelectedBuildingIds] = useState<string[]>([]);
+  const [isBulkActionBusy, setIsBulkActionBusy] = useState(false);
 
   // Returning the promise lets usePoll schedule the next tick from response
   // completion (not from request start) so slow responses can't overlap.
@@ -120,6 +121,13 @@ const FleetBuildingsPage = () => {
     [visibleBuildingScopes],
   );
   const handleClearBuildingSelection = useCallback(() => setSelectedBuildingIds([]), []);
+  const handleSelectedBuildingIdsChange = useCallback(
+    (ids: string[]) => {
+      if (isBulkActionBusy) return;
+      setSelectedBuildingIds(ids);
+    },
+    [isBulkActionBusy],
+  );
 
   const buildingModals = useBuildingModals({ refetchBuildings: fetchBuildings });
 
@@ -267,15 +275,16 @@ const FleetBuildingsPage = () => {
           onEditBuilding={canManageBuildings ? openEditBuilding : undefined}
           onAddBuildingToSite={canManageBuildings ? handleAddBuildingToSite : undefined}
           selectedIds={selectedBuildingIds}
-          onSelectedIdsChange={setSelectedBuildingIds}
+          onSelectedIdsChange={handleSelectedBuildingIdsChange}
         />
       </div>
-      {selectedBuildingScopes.length > 0 ? (
+      {selectedBuildingScopes.length > 0 || isBulkActionBusy ? (
         <FleetGroupListActionBar
           selectedScopes={selectedBuildingScopes}
           kind="building"
           onClearSelection={handleClearBuildingSelection}
           onSelectAllVisible={handleSelectAllVisibleBuildings}
+          onActionBusyChange={setIsBulkActionBusy}
         />
       ) : null}
       <BuildingModals modals={buildingModals} sites={sites} />

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import BuildingList from "../components/BuildingList";
@@ -105,6 +105,16 @@ const FleetBuildingsPage = () => {
     const selected = new Set(selectedBuildingIds);
     return visibleBuildingScopes.filter((building) => selected.has(building.id.toString()));
   }, [selectedBuildingIds, visibleBuildingScopes]);
+  useEffect(() => {
+    const visible = new Set(visibleBuildingScopes.map((building) => building.id.toString()));
+    // Keep selection scoped to the active site / URL filter even when the
+    // filtered-empty branch below unmounts BuildingList.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- selection mirrors externally controlled visible rows.
+    setSelectedBuildingIds((prev) => {
+      const next = prev.filter((id) => visible.has(id));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [visibleBuildingScopes]);
   const handleSelectAllVisibleBuildings = useCallback(
     () => setSelectedBuildingIds(visibleBuildingScopes.map((building) => building.id.toString())),
     [visibleBuildingScopes],

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
@@ -1,6 +1,7 @@
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
 
 import FilterRow from "../components/FilterRow";
+import FleetGroupListActionBar from "../components/FleetGroupActionsMenu/FleetGroupListActionBar";
 import { useFleetOutletContext } from "../components/FleetLayout";
 import SiteList from "../components/SiteList";
 import { buildKnownSiteIds } from "@/protoFleet/api/sites";
@@ -18,6 +19,7 @@ const LIST_WRAPPER = "pt-6";
 
 const FleetSitesPage = () => {
   const { sites, sitesError, sitesLoaded, refetchSites } = useFleetOutletContext();
+  const [selectedSiteIds, setSelectedSiteIds] = useState<string[]>([]);
 
   const knownSiteIds = useMemo(() => buildKnownSiteIds(sites), [sites]);
   const { activeSite } = useActiveSite({ knownSiteIds });
@@ -25,6 +27,23 @@ const FleetSitesPage = () => {
   const canManageSites = useHasPermission("site:manage");
 
   const modals = useSiteModals({ refetchSites });
+  const visibleSiteScopes = useMemo(
+    () =>
+      sites?.flatMap((site) => {
+        if (!site.site || site.site.id === 0n) return [];
+        return [{ kind: "site" as const, id: site.site.id, name: site.site.name }];
+      }) ?? [],
+    [sites],
+  );
+  const selectedSiteScopes = useMemo(() => {
+    const selected = new Set(selectedSiteIds);
+    return visibleSiteScopes.filter((site) => selected.has(site.id.toString()));
+  }, [selectedSiteIds, visibleSiteScopes]);
+  const handleSelectAllVisibleSites = useCallback(
+    () => setSelectedSiteIds(visibleSiteScopes.map((site) => site.id.toString())),
+    [visibleSiteScopes],
+  );
+  const handleClearSiteSelection = useCallback(() => setSelectedSiteIds([]), []);
 
   if (sites === undefined) {
     return (
@@ -133,8 +152,21 @@ const FleetSitesPage = () => {
         {addSiteButton}
       </FilterRow>
       <div className={LIST_WRAPPER}>
-        <SiteList sites={sites} onEditSite={canManageSites ? modals.openManageEdit : undefined} />
+        <SiteList
+          sites={sites}
+          onEditSite={canManageSites ? modals.openManageEdit : undefined}
+          selectedIds={selectedSiteIds}
+          onSelectedIdsChange={setSelectedSiteIds}
+        />
       </div>
+      {selectedSiteScopes.length > 0 ? (
+        <FleetGroupListActionBar
+          selectedScopes={selectedSiteScopes}
+          kind="site"
+          onClearSelection={handleClearSiteSelection}
+          onSelectAllVisible={handleSelectAllVisibleSites}
+        />
+      ) : null}
       <SiteModals modals={modals} sites={sites} />
     </>
   );

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
@@ -20,6 +20,7 @@ const LIST_WRAPPER = "pt-6";
 const FleetSitesPage = () => {
   const { sites, sitesError, sitesLoaded, refetchSites } = useFleetOutletContext();
   const [selectedSiteIds, setSelectedSiteIds] = useState<string[]>([]);
+  const [isBulkActionBusy, setIsBulkActionBusy] = useState(false);
 
   const knownSiteIds = useMemo(() => buildKnownSiteIds(sites), [sites]);
   const { activeSite } = useActiveSite({ knownSiteIds });
@@ -55,6 +56,13 @@ const FleetSitesPage = () => {
     [visibleSiteScopes],
   );
   const handleClearSiteSelection = useCallback(() => setSelectedSiteIds([]), []);
+  const handleSelectedSiteIdsChange = useCallback(
+    (ids: string[]) => {
+      if (isBulkActionBusy) return;
+      setSelectedSiteIds(ids);
+    },
+    [isBulkActionBusy],
+  );
 
   if (sites === undefined) {
     return (
@@ -167,15 +175,16 @@ const FleetSitesPage = () => {
           sites={sites}
           onEditSite={canManageSites ? modals.openManageEdit : undefined}
           selectedIds={selectedSiteIds}
-          onSelectedIdsChange={setSelectedSiteIds}
+          onSelectedIdsChange={handleSelectedSiteIdsChange}
         />
       </div>
-      {selectedSiteScopes.length > 0 ? (
+      {selectedSiteScopes.length > 0 || isBulkActionBusy ? (
         <FleetGroupListActionBar
           selectedScopes={selectedSiteScopes}
           kind="site"
           onClearSelection={handleClearSiteSelection}
           onSelectAllVisible={handleSelectAllVisibleSites}
+          onActionBusyChange={setIsBulkActionBusy}
         />
       ) : null}
       <SiteModals modals={modals} sites={sites} />

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 
 import FilterRow from "../components/FilterRow";
 import FleetGroupListActionBar from "../components/FleetGroupActionsMenu/FleetGroupListActionBar";
@@ -39,6 +39,17 @@ const FleetSitesPage = () => {
     const selected = new Set(selectedSiteIds);
     return visibleSiteScopes.filter((site) => selected.has(site.id.toString()));
   }, [selectedSiteIds, visibleSiteScopes]);
+  useEffect(() => {
+    const visible =
+      activeSite.kind === "all" ? new Set(visibleSiteScopes.map((site) => site.id.toString())) : new Set<string>();
+    // Keep selection scoped to the active SitePicker branch, including
+    // branches below that unmount SiteList.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- selection mirrors externally controlled visible rows.
+    setSelectedSiteIds((prev) => {
+      const next = prev.filter((id) => visible.has(id));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [activeSite.kind, visibleSiteScopes]);
   const handleSelectAllVisibleSites = useCallback(
     () => setSelectedSiteIds(visibleSiteScopes.map((site) => site.id.toString())),
     [visibleSiteScopes],

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
@@ -103,55 +103,6 @@ const FleetSitesPage = () => {
       />
     ) : null;
 
-  // Empty state always wins over the picker branches below: after the
-  // last site is deleted the stale "site"-kind picker can't reset
-  // (useActiveSite skips its validator when knownSiteIds is empty), and
-  // the operator still needs the create CTA.
-  if (sites.length === 0) {
-    return (
-      <>
-        <FilterRow testId="fleet-sites-page">
-          {inlineError}
-          <SitesEmptyState onAddSite={canManageSites ? modals.openCreate : undefined} />
-        </FilterRow>
-        <SiteModals modals={modals} sites={sites} />
-      </>
-    );
-  }
-
-  // Transitional placeholder while FleetLayout's redirect effect fires —
-  // avoids briefly showing the All-Sites list under a single-site picker.
-  if (activeSite.kind === "site") {
-    return (
-      <>
-        <FilterRow testId="fleet-sites-page">
-          {inlineError}
-          <div className="text-300 text-text-primary-70" data-testid="fleet-sites-redirecting">
-            Loading…
-          </div>
-        </FilterRow>
-        <SiteModals modals={modals} sites={sites} />
-      </>
-    );
-  }
-
-  if (activeSite.kind === "unassigned") {
-    return (
-      <>
-        <FilterRow testId="fleet-sites-page">
-          {inlineError}
-          <div
-            className="rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
-            data-testid="fleet-sites-unassigned-note"
-          >
-            &quot;Unassigned&quot; filters miners, not sites. Switch the picker to All Sites to see every site.
-          </div>
-        </FilterRow>
-        <SiteModals modals={modals} sites={sites} />
-      </>
-    );
-  }
-
   const addSiteButton: ReactNode = canManageSites ? (
     <div className="flex items-center justify-end">
       <Button
@@ -164,29 +115,75 @@ const FleetSitesPage = () => {
     </div>
   ) : null;
 
-  return (
-    <>
+  const bulkActionBar =
+    selectedSiteScopes.length > 0 || isBulkActionBusy ? (
+      <FleetGroupListActionBar
+        selectedScopes={selectedSiteScopes}
+        kind="site"
+        onClearSelection={handleClearSiteSelection}
+        onSelectAllVisible={handleSelectAllVisibleSites}
+        onActionBusyChange={setIsBulkActionBusy}
+      />
+    ) : null;
+
+  let pageContent: ReactNode;
+  // Empty state always wins over the picker branches below: after the
+  // last site is deleted the stale "site"-kind picker can't reset
+  // (useActiveSite skips its validator when knownSiteIds is empty), and
+  // the operator still needs the create CTA.
+  if (sites.length === 0) {
+    pageContent = (
       <FilterRow testId="fleet-sites-page">
         {inlineError}
-        {addSiteButton}
+        <SitesEmptyState onAddSite={canManageSites ? modals.openCreate : undefined} />
       </FilterRow>
-      <div className={LIST_WRAPPER}>
-        <SiteList
-          sites={sites}
-          onEditSite={canManageSites ? modals.openManageEdit : undefined}
-          selectedIds={selectedSiteIds}
-          onSelectedIdsChange={handleSelectedSiteIdsChange}
-        />
-      </div>
-      {selectedSiteScopes.length > 0 || isBulkActionBusy ? (
-        <FleetGroupListActionBar
-          selectedScopes={selectedSiteScopes}
-          kind="site"
-          onClearSelection={handleClearSiteSelection}
-          onSelectAllVisible={handleSelectAllVisibleSites}
-          onActionBusyChange={setIsBulkActionBusy}
-        />
-      ) : null}
+    );
+  } else if (activeSite.kind === "site") {
+    // Transitional placeholder while FleetLayout's redirect effect fires —
+    // avoids briefly showing the All-Sites list under a single-site picker.
+    pageContent = (
+      <FilterRow testId="fleet-sites-page">
+        {inlineError}
+        <div className="text-300 text-text-primary-70" data-testid="fleet-sites-redirecting">
+          Loading…
+        </div>
+      </FilterRow>
+    );
+  } else if (activeSite.kind === "unassigned") {
+    pageContent = (
+      <FilterRow testId="fleet-sites-page">
+        {inlineError}
+        <div
+          className="rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
+          data-testid="fleet-sites-unassigned-note"
+        >
+          &quot;Unassigned&quot; filters miners, not sites. Switch the picker to All Sites to see every site.
+        </div>
+      </FilterRow>
+    );
+  } else {
+    pageContent = (
+      <>
+        <FilterRow testId="fleet-sites-page">
+          {inlineError}
+          {addSiteButton}
+        </FilterRow>
+        <div className={LIST_WRAPPER}>
+          <SiteList
+            sites={sites}
+            onEditSite={canManageSites ? modals.openManageEdit : undefined}
+            selectedIds={selectedSiteIds}
+            onSelectedIdsChange={handleSelectedSiteIdsChange}
+          />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {pageContent}
+      {bulkActionBar}
       <SiteModals modals={modals} sites={sites} />
     </>
   );

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -17,6 +17,7 @@ import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
 import { MULTI_SITE_ENABLED } from "@/protoFleet/constants/featureFlags";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import FleetGroupActionsMenu from "@/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu";
+import FleetGroupListActionBar from "@/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar";
 import { ManageRackModal, type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal";
 import { RackCard } from "@/protoFleet/features/fleetManagement/components/RackCard";
 import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
@@ -86,6 +87,7 @@ const RacksPage = () => {
   // for the empty-filter sentinel below.
   const [allBuildingsLoaded, setAllBuildingsLoaded] = useState(false);
   const [allSites, setAllSites] = useState<{ id: string; label: string }[]>([]);
+  const [selectedRackIds, setSelectedRackIds] = useState<string[]>([]);
 
   // listDeviceSets has no native siteIds filter, so we resolve
   // site → buildings client-side and pipe through buildingIds.
@@ -290,6 +292,23 @@ const RacksPage = () => {
     selectedZones.length > 0 ||
     selectedIssues.length > 0 ||
     urlSiteIds.size > 0;
+  const visibleRackScopes = useMemo(
+    () =>
+      racks.flatMap((rack) => {
+        if (rack.id === 0n) return [];
+        return [{ kind: "rack" as const, id: rack.id, name: rack.label || "(unnamed)" }];
+      }),
+    [racks],
+  );
+  const selectedRackScopes = useMemo(() => {
+    const selected = new Set(selectedRackIds);
+    return visibleRackScopes.filter((rack) => selected.has(rack.id.toString()));
+  }, [selectedRackIds, visibleRackScopes]);
+  const handleSelectAllVisibleRacks = useCallback(
+    () => setSelectedRackIds(visibleRackScopes.map((rack) => rack.id.toString())),
+    [visibleRackScopes],
+  );
+  const handleClearRackSelection = useCallback(() => setSelectedRackIds([]), []);
 
   const handleClearFilters = useCallback(() => {
     // Snapshot before state changes — these flags drive the "ride the
@@ -429,7 +448,7 @@ const RacksPage = () => {
           </button>
           {rack.id !== undefined && rack.id !== 0n ? (
             <FleetGroupActionsMenu
-              scope={{ kind: "rack", id: rack.id, name: label }}
+              scopes={[{ kind: "rack", id: rack.id, name: label }]}
               ariaLabel={`Actions for ${label}`}
               testIdPrefix={`rack-list-row-${rack.id.toString()}-actions`}
               extraActions={buildRackExtraActions(rack)}
@@ -655,6 +674,8 @@ const RacksPage = () => {
             onNextPage={handleNextPage}
             onPrevPage={handlePrevPage}
             emptyStateRow={emptyStateRow}
+            selectedIds={selectedRackIds}
+            onSelectedIdsChange={setSelectedRackIds}
           />
         </div>
       ) : (
@@ -720,6 +741,14 @@ const RacksPage = () => {
           ) : null}
         </div>
       )}
+      {selectedRackScopes.length > 0 ? (
+        <FleetGroupListActionBar
+          selectedScopes={selectedRackScopes}
+          kind="rack"
+          onClearSelection={handleClearRackSelection}
+          onSelectAllVisible={handleSelectAllVisibleRacks}
+        />
+      ) : null}
       {showRackSettingsModal ? (
         <RackSettingsModal
           show={showRackSettingsModal}

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -88,6 +88,7 @@ const RacksPage = () => {
   const [allBuildingsLoaded, setAllBuildingsLoaded] = useState(false);
   const [allSites, setAllSites] = useState<{ id: string; label: string }[]>([]);
   const [selectedRackIds, setSelectedRackIds] = useState<string[]>([]);
+  const [isBulkActionBusy, setIsBulkActionBusy] = useState(false);
 
   // listDeviceSets has no native siteIds filter, so we resolve
   // site → buildings client-side and pipe through buildingIds.
@@ -310,6 +311,13 @@ const RacksPage = () => {
     [visibleRackScopes],
   );
   const handleClearRackSelection = useCallback(() => setSelectedRackIds([]), []);
+  const handleSelectedRackIdsChange = useCallback(
+    (ids: string[]) => {
+      if (isBulkActionBusy) return;
+      setSelectedRackIds(ids);
+    },
+    [isBulkActionBusy],
+  );
 
   const handleClearFilters = useCallback(() => {
     setSelectedRackIds([]);
@@ -704,7 +712,7 @@ const RacksPage = () => {
             onPrevPage={handleRackPrevPage}
             emptyStateRow={emptyStateRow}
             selectedIds={selectedRackIds}
-            onSelectedIdsChange={setSelectedRackIds}
+            onSelectedIdsChange={handleSelectedRackIdsChange}
           />
         </div>
       ) : (
@@ -770,12 +778,13 @@ const RacksPage = () => {
           ) : null}
         </div>
       )}
-      {selectedRackScopes.length > 0 ? (
+      {selectedRackScopes.length > 0 || isBulkActionBusy ? (
         <FleetGroupListActionBar
           selectedScopes={selectedRackScopes}
           kind="rack"
           onClearSelection={handleClearRackSelection}
           onSelectAllVisible={handleSelectAllVisibleRacks}
+          onActionBusyChange={setIsBulkActionBusy}
         />
       ) : null}
       {showRackSettingsModal ? (

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -241,6 +241,7 @@ const RacksPage = () => {
 
   const handleFilterChange = useCallback(
     (key: string, values: string[]) => {
+      setSelectedRackIds([]);
       if (key === "zone") {
         setSelectedZones(values);
         selectedZonesRef.current = values;
@@ -311,6 +312,7 @@ const RacksPage = () => {
   const handleClearRackSelection = useCallback(() => setSelectedRackIds([]), []);
 
   const handleClearFilters = useCallback(() => {
+    setSelectedRackIds([]);
     // Snapshot before state changes — these flags drive the "ride the
     // URL-change effect" branch below.
     const hadBuildingFilter = selectedBuildingIdStrings.length > 0;
@@ -498,13 +500,40 @@ const RacksPage = () => {
   }, [hasCompletedInitialFetch, isModalOpen, refreshCurrentPage]);
 
   // Sort dropdown handler for grid view
+  const handleRackSort: typeof handleSort = useCallback(
+    (field, direction) => {
+      setSelectedRackIds([]);
+      handleSort(field, direction);
+    },
+    [handleSort],
+  );
+
   const handleSortSelect = useCallback(
     (selected: string[]) => {
       const nextSort = getNextSortFromSelection(selected, currentSort);
-      handleSort(nextSort.field, nextSort.direction);
+      handleRackSort(nextSort.field, nextSort.direction);
     },
-    [currentSort, handleSort],
+    [currentSort, handleRackSort],
   );
+
+  const handleRacksViewModeSelect = useCallback(
+    (key: string) => {
+      const nextViewMode = key === "list" ? "list" : "grid";
+      if (nextViewMode === "grid") setSelectedRackIds([]);
+      setRacksViewMode(nextViewMode);
+    },
+    [setRacksViewMode],
+  );
+
+  const handleRackNextPage = useCallback(() => {
+    setSelectedRackIds([]);
+    handleNextPage();
+  }, [handleNextPage]);
+
+  const handleRackPrevPage = useCallback(() => {
+    setSelectedRackIds([]);
+    handlePrevPage();
+  }, [handlePrevPage]);
 
   // Grid pagination
   const firstItemIndex = currentPage * DEFAULT_PAGE_SIZE + 1;
@@ -592,7 +621,7 @@ const RacksPage = () => {
                 { key: "list", title: "View list" },
               ]}
               initialSegmentKey={racksViewMode}
-              onSelect={(key) => setRacksViewMode(key as "grid" | "list")}
+              onSelect={handleRacksViewModeSelect}
             />
           </div>
           {/* Desktop layout — single row with toggle + filters left, buttons right */}
@@ -605,7 +634,7 @@ const RacksPage = () => {
                 { key: "list", title: "View list" },
               ]}
               initialSegmentKey={racksViewMode}
-              onSelect={(key) => setRacksViewMode(key as "grid" | "list")}
+              onSelect={handleRacksViewModeSelect}
             />
             <FilterChipsBar
               filters={filterChipsBarFilters}
@@ -663,7 +692,7 @@ const RacksPage = () => {
             renderBuilding={renderBuilding}
             columns={insideFleetShell && MULTI_SITE_ENABLED ? RACK_COLUMNS_FLEET : RACK_COLUMNS_STANDALONE}
             currentSort={currentSort}
-            onSort={handleSort}
+            onSort={handleRackSort}
             itemName={{ singular: "rack", plural: "racks" }}
             total={totalCount}
             loading={isLoading}
@@ -671,8 +700,8 @@ const RacksPage = () => {
             currentPage={currentPage}
             hasPreviousPage={currentPage > 0}
             hasNextPage={hasNextPage}
-            onNextPage={handleNextPage}
-            onPrevPage={handlePrevPage}
+            onNextPage={handleRackNextPage}
+            onPrevPage={handleRackPrevPage}
             emptyStateRow={emptyStateRow}
             selectedIds={selectedRackIds}
             onSelectedIdsChange={setSelectedRackIds}
@@ -725,7 +754,7 @@ const RacksPage = () => {
                   size={sizes.compact}
                   ariaLabel="Previous page"
                   prefixIcon={<ChevronDown className="rotate-90" />}
-                  onClick={handlePrevPage}
+                  onClick={handleRackPrevPage}
                   disabled={currentPage === 0}
                 />
                 <Button
@@ -733,7 +762,7 @@ const RacksPage = () => {
                   size={sizes.compact}
                   ariaLabel="Next page"
                   prefixIcon={<ChevronDown className="rotate-270" />}
-                  onClick={handleNextPage}
+                  onClick={handleRackNextPage}
                   disabled={!hasNextPage}
                 />
               </div>

--- a/docs/plans/2026-06-04-370-fleet-multi-select-bulk-actions-plan.md
+++ b/docs/plans/2026-06-04-370-fleet-multi-select-bulk-actions-plan.md
@@ -1,0 +1,331 @@
+---
+title: "Fleet Sites + Buildings multi-select & bulk actions"
+date: 2026-06-04
+status: draft
+type: plan
+tracker: https://github.com/block/proto-fleet/issues/370
+---
+
+# Fleet Sites + Buildings multi-select & bulk actions
+
+## Context
+
+#368 shipped the `/fleet` tab scaffold (Sites / Buildings / Racks /
+Miners). #369 (PR [#412](https://github.com/block/proto-fleet/pull/412),
+merged 2026-06-11) shipped the per-row ellipsis menu pattern on the
+Sites, Buildings, and Racks tabs via a unified `FleetGroupActionsMenu`.
+
+The Miners tab already has a polished multi-select + bulk-action UX:
+row checkboxes feed `MinerList`'s `selectedMiners` state, which renders
+a bottom-fixed `MinerListActionBar` (built on the shared `ActionBar`
+shell) hosting `MinerActionsMenu`.
+
+This task (#370) ports that same UX to the Sites and Buildings tabs.
+
+## Mechanical parity with Miners-tab bulk
+
+The two flows are mechanically identical end-to-end except for two
+boundary conditions:
+
+| Stage | Miners tab | Sites/Buildings tab |
+| --- | --- | --- |
+| Selection source | Row checkboxes → `selectedMiners: string[]` | Row checkboxes → `selectedScopes: GroupScope[]` |
+| **Device-id resolution** | **Direct from selection** | **Lazy fetch:** `listMinerStateSnapshots({filter: {siteIds | buildingIds: scopes.map(s => s.id)}})` paginates and collects the union (existing logic in `FleetGroupActionsMenu.fetchDeviceIds`, just generalized to id arrays) |
+| Selection-mode semantics | Supports `"all"` (fleet-wide via `currentFilter`) and `"subset"` | `"subset"` only — ids are always materialized upfront |
+| Action handler hook | `useMinerActions` | `useMinerActions` (same hook) |
+| Batch RPC dispatch | `useBatchActions` → `startBatchOperation` / `completeBatchOperation` | `useBatchActions` (same) |
+| Confirmation dialog | `BulkActionConfirmDialog` | `BulkActionConfirmDialog` (same) |
+| Unsupported-miners gate | `UnsupportedMinersModal` | `UnsupportedMinersModal` (same) |
+| Modal stack | `MinerActionModalStack` | `MinerActionModalStack` (same — already used by `FleetGroupActionsMenu`) |
+| Pool selection flow | `PoolSelectionPageWrapper` | `PoolSelectionPageWrapper` (same) |
+| Permission gating | `usePermittedActions` + `ACTION_PERMISSIONS` | Same (already implemented in `FleetGroupActionsMenu` via `permittedKeys`) |
+| Toast lifecycle | `useBatchActions` toasts + manual loading toast | Same (already implemented) |
+| Bar shell | `ActionBar` (shared) | `ActionBar` (shared — reuse) |
+| Bar position | `fixed right-0 bottom-4 left-0 z-20 laptop:left-16 desktop:left-50` | Same |
+| Global toaster push-up | `setActionBarVisible(true)` from Zustand UI slice | Same — reuse `useSetActionBarVisible` |
+| Set hidden during modal flows | `onActionStart` / `onActionComplete` → `setHidden(true/false)` | Same — needs to be added to `FleetGroupActionsMenu` (see Approach) |
+
+**Action-set delta** (J10): Sites and Buildings tabs do NOT surface
+`rename`, `updateWorkerNames`, or the per-row "View *" / "Edit *"
+extras in the bulk menu. They expose only the top-wired + bottom-wired
+clusters that `FleetGroupActionsMenu` already renders for the per-row
+case: sleep / wake / reboot / download logs / manage power / update
+firmware / edit pool / add-to-group / manage security / unpair.
+
+That leaves only **one** structural difference: id resolution is
+filter-aggregated rather than selection-direct. Everything downstream
+(modals, confirmations, toasts, RPCs, permission gates, ActionBar shell)
+is the same code path.
+
+## Goal
+
+Operator on `/fleet/sites` or `/fleet/buildings`:
+
+1. Checks one or more rows.
+2. Bottom-fixed `ActionBar` slides in — same shell as Miners tab.
+3. Picks an action via `FleetGroupActionsMenu`.
+4. Confirmation dialog announces affected miner count across the
+   union of descendants.
+5. Action fans out via a single `listMinerStateSnapshots` call
+   filtered by the combined id set, then runs the existing
+   `useMinerActions` flow.
+
+## Scope
+
+### In scope
+
+- Row-checkbox column on `SiteList` and `BuildingList` (leftmost),
+  via `List`'s existing `customSelectedItems` + `customSelectionMode`
+  controlled props.
+- Selection state owned by the page (`FleetSitesPage`,
+  `FleetBuildingsPage`). Id-keyed; pruned against current visible
+  items on each poll (borrow `MinerList`'s effect).
+- Bottom-fixed `ActionBar` rendered when `selection.length > 0`.
+  Hosts `FleetGroupActionsMenu` in `renderActions`.
+- `Select all visible` / `Select none` controls in `selectionControls`.
+- Extend `FleetGroupActionsMenu`:
+  - prop rename `scope: GroupScope` → `scopes: GroupScope[]`
+    (same kind for all entries), or accept `scopes` alongside `scope`
+    with one acting as a one-element shim;
+  - filter construction uses `scopes.map(s => s.id)`;
+  - toast/dialog labels: `scopeLabel = scopes.length === 1 ?
+    scopes[0].name : "${n} ${pluralize(kind, n)}"`;
+  - new `onActionStart` / `onActionComplete` props, forwarded to
+    `useMinerActions` (mirrors `MinerActionsMenu`);
+  - host-supplied `extraActions` continue to render for the single-scope
+    case; multi-scope bar calls with `extraActions = []`.
+- Extend shared `ActionBar`:
+  - parameterize the noun in `selectionText` (currently hardcoded
+    "miner"/"miners"). Add an optional `itemNoun: { singular: string,
+    plural: string }` prop with default `{singular: "miner", plural:
+    "miners"}` for backward-compat.
+- Update existing `FleetGroupActionsMenu.test.tsx` for the
+  array-of-scopes path (single-scope continues to pass via length-1
+  array).
+- Playwright E2E: select 2 sites on `/fleet/sites` → reboot → confirm
+  → assert toast + fake-rig receives the union device set.
+
+### Out of scope
+
+- Adding actions beyond the existing top/bottom wired clusters
+  (no rename, no worker-names).
+- Mixed-kind selection (one site + one building); `scopes[]` requires
+  same `kind`. Sites tab can only produce site scopes and vice versa.
+- `"all"` selection mode for sites/buildings; we always materialize
+  ids from the picked scopes.
+- Quick-action shortcuts in the bar (reboot/blink/etc.). Phase 2 if
+  operators ask.
+- Saved views, list/grid toggle.
+
+## Approach
+
+### Selection wiring (mirrors `MinerList`)
+
+`SiteList` gains controlled-selection props:
+
+```ts
+selectedIds?: string[];
+onSelectedIdsChange?: (ids: string[]) => void;
+```
+
+Pass-through to `List` as `customSelectedItems` /
+`customSelectionMode`. When `selectedIds === undefined` the checkbox
+column is hidden — the existing per-row `FleetGroupActionsMenu`
+continues to work standalone. `BuildingList` is identical.
+
+`FleetSitesPage` / `FleetBuildingsPage` own a `useState<string[]>`
+for selection and prune it against the visible item set on each poll
+(`MinerList` already has this pattern; copy it).
+
+### Bottom-fixed ActionBar (mirrors `MinerListActionBar`)
+
+New `FleetGroupListActionBar` component, modeled directly on
+`MinerListActionBar.tsx`:
+
+```tsx
+<ActionBar
+  className="fixed right-0 bottom-4 left-0 z-20 laptop:left-16 desktop:left-50"
+  selectedItems={selectedIds}
+  selectionMode="subset"
+  itemNoun={{ singular: kind, plural: pluralKind }}  // "site"/"sites" or "building"/"buildings"
+  onClose={onClearSelection}
+  selectionControls={<SelectAllVisible /><SelectNone />}
+  renderActions={(setHidden) => (
+    <FleetGroupActionsMenu
+      scopes={selectedScopes}
+      ariaLabel={...}
+      testIdPrefix="fleet-bulk-actions"
+      onActionStart={() => { setHidden(true); setActionBarVisible(false); }}
+      onActionComplete={() => { setHidden(false); setActionBarVisible(true); }}
+    />
+  )}
+/>
+```
+
+The bar's `useSetActionBarVisible(selection.length > 0)` effect mirrors
+`MinerListActionBar`, including the cleanup on unmount, so the
+global toaster pushes up the same way it does on /miners.
+
+Page renders the bar conditionally — same JSX shape as how
+`MinerList.tsx` mounts `MinerListActionBar` only when selection > 0.
+
+### `FleetGroupActionsMenu` multi-scope extension
+
+Prop shape change (single `scope` → `scopes: GroupScope[]` with
+`scopes.length >= 1`):
+
+```ts
+interface FleetGroupActionsMenuProps {
+  scopes: GroupScope[];           // same kind across all entries
+  ariaLabel: string;
+  testIdPrefix?: string;
+  extraActions?: RowAction[];     // ignored when scopes.length > 1
+  onActionStart?: () => void;
+  onActionComplete?: () => void;
+}
+```
+
+Inside, build the filter from id arrays:
+
+```ts
+const ids = scopes.map((s) => s.id);
+const kind = scopes[0].kind;
+const filterInit =
+  kind === "building" ? { buildingIds: ids }
+  : kind === "rack"   ? { rackIds: ids }
+  :                     { siteIds: ids };
+```
+
+`scopeLabel` replaces the existing `scope.name` references in the
+loading toast and error path:
+
+```ts
+const scopeLabel = scopes.length === 1
+  ? scopes[0].name
+  : `${scopes.length} ${pluralize(kind, scopes.length)}`;
+```
+
+Existing single-scope call sites in `SiteList` / `BuildingList` /
+`RacksPage` migrate to `scopes={[scope]}` — one-line change per
+caller.
+
+Forward `onActionStart` / `onActionComplete` into
+`useMinerActions({...})` so the bar can hide-during-modal exactly
+like `MinerListActionBar` does.
+
+### `ActionBar` noun parameterization
+
+Today's hardcoded "miner"/"miners" in `selectionText` becomes:
+
+```ts
+const noun = itemNoun ?? { singular: "miner", plural: "miners" };
+const selectionText = `${count} ${count === 1 ? noun.singular : noun.plural} selected`;
+```
+
+No other call sites change (default keeps Miners-tab behavior).
+
+## File-level breakdown
+
+Modified:
+
+- `features/fleetManagement/components/ActionBar/ActionBar.tsx`
+  — add optional `itemNoun` prop; default to current `"miner"/"miners"`.
+- `features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx`
+  — `scope` → `scopes`; multi-scope filter construction; `scopeLabel`
+  helper; `onActionStart` / `onActionComplete` forwarded to
+  `useMinerActions`; skip `extraActions` when `scopes.length > 1`.
+- `features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx`
+  — migrate fixtures to `scopes={[…]}`; add multi-scope cases.
+- `features/fleetManagement/components/SiteList/SiteList.tsx`
+  — accept `selectedIds` / `onSelectedIdsChange`; pass to `List`;
+  update single-scope call site to `scopes={[scope]}`.
+- `features/fleetManagement/components/BuildingList/BuildingList.tsx`
+  — same.
+- `features/rackManagement/pages/RacksPage.tsx`
+  (and rack row consumers) — update existing single-scope call site
+  to `scopes={[scope]}`. **No bulk on Racks in this PR.**
+- `features/fleetManagement/pages/FleetSitesPage.tsx`
+  — selection state; mount `FleetGroupListActionBar` when count > 0.
+- `features/fleetManagement/pages/FleetBuildingsPage.tsx`
+  — same.
+
+New:
+
+- `features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.tsx`
+  — direct analog of `MinerListActionBar`. Hosts `FleetGroupActionsMenu`
+  in `renderActions`; wires `Select all visible` / `Clear` /
+  `useSetActionBarVisible` lifecycle.
+- `features/fleetManagement/components/FleetGroupActionsMenu/pluralize.ts`
+  (or inline) — `pluralize("site", n)` → `"site" | "sites"`, ditto
+  building, rack.
+
+Tests:
+
+- `SiteList.test.tsx` / `BuildingList.test.tsx` — checkbox column
+  toggles with `selectedIds`; absent when prop omitted.
+- `FleetSitesPage.test.tsx` / `FleetBuildingsPage.test.tsx` — bar
+  mounts at selection ≥ 1; Add CTA still visible (separate slot);
+  Select all / Clear behavior.
+- `FleetGroupListActionBar.test.tsx` — wires the menu with `scopes`;
+  `onActionStart` flips `setHidden`; `onActionComplete` restores.
+- `ActionBar.test.tsx` — add a case for `itemNoun` override
+  ("3 sites selected").
+
+E2E (`client/e2eTests/protoFleet/spec/`):
+
+- `multiSite.spec.ts` (new): select two sites on `/fleet/sites` →
+  open bottom bar → reboot → confirm → assert fake-proto-rig
+  received the union device set.
+
+## Risks
+
+- **Visible-set prune mid-selection.** Selection must drop ids that
+  disappear from the visible list (site deleted, picker switched).
+  Copy the `MinerList` effect verbatim.
+- **`scopes` mixed-kind misuse.** Defensive: derive `kind` from
+  `scopes[0]` and console-warn on mismatch in dev. Sites tab and
+  Buildings tab cannot mix; not a real production risk.
+- **Two ActionBars at once.** Only one `/fleet/*` tab renders at a
+  time, so `setActionBarVisible` collisions can't happen. Tab swap
+  unmounts the bar via the cleanup effect.
+- **50k miner cap on bulk.** Already enforced inside
+  `FleetGroupActionsMenu.fetchDeviceIds`. The union across multiple
+  scopes can plausibly hit the cap; existing error toast applies
+  ("Too many miners… filter the list and try again"). No new code
+  needed.
+- **ActionBar noun churn.** Adding `itemNoun` touches a shared
+  component; default preserves current behavior for `MinerListActionBar`.
+  Snapshot/test coverage on `ActionBar.test.tsx` should catch
+  regressions.
+
+## Test plan
+
+- Unit: list checkbox plumbing; page bar mount/unmount; `scopes` →
+  filter-arg shape; pluralization; `onActionStart`/`onActionComplete`
+  hide/restore.
+- Integration: `FleetGroupListActionBar` end-to-end with
+  `useMinerActions` mocked → asserts `listMinerStateSnapshots` called
+  with correct id array; confirmation dialog text shows union miner
+  count.
+- E2E: 2-site bulk reboot via fake-proto-rig.
+
+## Rollout
+
+Behind `MULTI_SITE_ENABLED` — Sites + Buildings tabs are already
+gated. No new flag.
+
+## Open questions
+
+1. **Select-all semantics.** Sites/Buildings tabs aren't paginated
+   server-side, so "Select all visible" == "Select all matching".
+   Mirror MinerListActionBar's labels for consistency. If pagination
+   lands later, revisit `selectionMode: "all"` parity.
+2. **Quick actions in the bar.** Miners-tab bar has quick-action
+   buttons (reboot/blink/manage-power) at the laptop+ breakpoint.
+   Defer for Sites/Buildings unless operator feedback pushes for them
+   — top-wired actions are already one click away in the popover.
+3. **Edit single selection.** When `scopes.length === 1` on the bulk
+   bar, should we still surface "Edit site" / "View site"? Current
+   plan says no (matches Miners-tab bar — single-row uses ellipsis
+   menu for navigation; bulk bar is action-only). Worth confirming
+   with design.

--- a/docs/plans/2026-06-04-370-fleet-multi-select-bulk-actions-plan.md
+++ b/docs/plans/2026-06-04-370-fleet-multi-select-bulk-actions-plan.md
@@ -242,8 +242,7 @@ Modified:
 - `features/fleetManagement/components/BuildingList/BuildingList.tsx`
   — same.
 - `features/rackManagement/pages/RacksPage.tsx`
-  (and rack row consumers) — update existing single-scope call site
-  to `scopes={[scope]}`. **No bulk on Racks in this PR.**
+  (and rack row consumers) — update existing single-scope call site to `scopes={[scope]}` and add rack multi-select + bulk actions via `FleetGroupListActionBar`.
 - `features/fleetManagement/pages/FleetSitesPage.tsx`
   — selection state; mount `FleetGroupListActionBar` when count > 0.
 - `features/fleetManagement/pages/FleetBuildingsPage.tsx`


### PR DESCRIPTION
## 1. Summary

This PR adds multi-select bulk actions to the Fleet Sites, Buildings, and Racks tabs so operators can act on all descendant miners for several selected groups at once. It brings those group tabs closer to the existing Miners-tab bulk workflow: selecting rows opens a bottom action bar, choosing an action resolves the affected miners, and the existing miner action/confirmation flows do the dispatch. The change is client-only and does not alter server APIs, protobufs, database schema, or generated code.

## 2. How it works

1. The operator selects sites, buildings, or racks from the corresponding Fleet tab. The page owns the selected group IDs, passes them into the list as controlled row selection, and derives `GroupScope` objects containing the group kind, ID, and display name.
2. When at least one visible group is selected, the page mounts `FleetGroupListActionBar`, a bottom-fixed action bar that shows the selected group count, Select all visible / Select none controls, a quick Reboot button, and a More menu.
3. `FleetGroupActionsMenu` is shared by row menus and bulk menus. Row menus pass one scope plus row-only navigation/edit actions; bulk menus pass multiple scopes and suppress row-only extras. Wired group actions require both their action-specific permission and `miner:read`, because every wired group action first needs to resolve descendant miners.
4. When the operator chooses a group action, the action bar enters a busy boundary. During that boundary, row-selection updates are ignored and the action bar keeps the last non-empty scope snapshot alive, so a slow miner lookup cannot be cancelled accidentally by unchecking rows or by the list rerendering.
5. The group action menu lazily resolves descendant miners with `listMinerStateSnapshots`, using one combined filter for the selected kind: `siteIds`, `buildingIds`, or `rackIds`. Results are paginated up to 50,000 miners and converted into both selected miner IDs and a snapshot map.
6. Before dispatch, the menu validates the lookup result: empty groups show an error, an empty scope list fails fast, oversized groups fail with a filter-down message, and groups containing unauthenticated miners block every action except Unpair.
7. Valid actions then flow into the existing `useMinerActions`, `useBatchActions`, confirmation dialogs, unsupported-miner modal, pool-selection flow, and miner modal stack. The server-side miner action APIs and permission enforcement remain unchanged.
8. Selection is pruned when the visible group set changes. SitePicker branches, building filters, rack filters, grid/list transitions, sorting, and pagination cannot leave stale group IDs selected when the rows are no longer visible.

## 3. Diagrams

```mermaid
flowchart TD
  Operator["Operator selects groups"] --> Page["Fleet tab page owns selected group IDs"]
  Page --> List["SiteList / BuildingList / DeviceSetList controlled selection"]
  Page --> Scopes["Derive visible selected GroupScope objects"]
  Scopes --> Bar["FleetGroupListActionBar"]
  Bar --> Menu["FleetGroupActionsMenu in bulk presentation"]
  Menu --> PermissionGate["Require miner:read and action permission"]
  PermissionGate --> Lookup["listMinerStateSnapshots with siteIds / buildingIds / rackIds"]
  Lookup --> Validate["Validate empty, oversized, unauthenticated, permissions"]
  Validate --> MinerActions["useMinerActions with selected descendant miners"]
  MinerActions --> ExistingFlows["Existing confirmations, modals, pool flow, batch operations"]
  ExistingFlows --> Server["Existing miner action RPCs"]
```

```mermaid
sequenceDiagram
  participant Operator
  participant Page as "Fleet page"
  participant Bar as "FleetGroupListActionBar"
  participant Menu as "FleetGroupActionsMenu"
  participant API as "listMinerStateSnapshots"
  participant Actions as "useMinerActions"

  Operator->>Page: Select visible groups
  Page->>Bar: Mount with selected scopes
  Operator->>Menu: Choose visible group action
  Menu->>Menu: Hide lookup-backed actions without miner:read
  Menu->>Bar: onActionStart
  Bar->>Page: Mark bulk action busy
  Bar->>Bar: Keep last non-empty scope snapshot
  Page->>Page: Ignore row-selection updates while busy
  Menu->>API: Fetch descendant miner snapshots
  API-->>Menu: Miner IDs and pairing/capability state
  Menu->>Menu: Validate empty / auth-needed / size limits
  alt Valid action
    Menu->>Actions: Set selected miners and trigger action
    Actions-->>Operator: Confirmation/modal/action feedback
  else Invalid action
    Menu-->>Operator: Error toast
  end
  Menu->>Bar: onActionComplete
  Bar->>Page: Clear busy state
```

```mermaid
stateDiagram-v2
  [*] --> NoSelection
  NoSelection --> Selected: "Rows selected"
  Selected --> LookupBusy: "Action clicked"
  LookupBusy --> Selected: "Lookup fails or blocked"
  LookupBusy --> ExistingMinerFlow: "Lookup passes"
  ExistingMinerFlow --> Selected: "Modal dismissed or action completes"
  Selected --> NoSelection: "Selection cleared or visible rows pruned"
  LookupBusy --> LookupBusy: "Selection changes ignored"
```

## 4. Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| **Client / Fleet group bulk actions** |  |  |
| `client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar.tsx` (new) | Adds the shared bottom action bar for selected sites/buildings/racks; owns action-bar visibility, select controls, busy lifecycle, and frozen scope snapshot while a lookup/action is in flight. | This is the main new UI abstraction and lifecycle boundary for group bulk actions. Review busy-state behavior and how it prevents accidental unmount during lookup. |
| `client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx` | Extends the row group menu from one scope to one-or-many scopes, adds bulk presentation, gates lookup-backed actions on `miner:read` plus action permissions, resolves descendant miners lazily, validates empty/oversized/auth-needed cases, and forwards into existing miner action flows. | This is the main behavioral path. Review permission filtering, filter construction, pagination cap, validation, and reuse of existing miner action machinery. |
| `client/src/protoFleet/features/fleetManagement/components/ActionBar/ActionBar.tsx` | Adds configurable singular/plural item nouns so the shared bar can say sites/buildings/racks instead of only miners. | Small shared UI change; confirm existing miner action bar copy remains unchanged by default. |
| `client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.tsx` | Adds trigger customization for the bulk More button: label, styling, suffix icon, and disabled state. | Enables one menu component to serve row ellipsis menus and the bulk action bar without a separate menu implementation. |
| **Client / Fleet pages** |  |  |
| `client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx` | Owns selected site IDs, derives selected site scopes, mounts the group action bar, prunes selection when SitePicker branches hide the list, and freezes selection changes while a bulk action is busy. | Review page-level ownership and cleanup rules because this is what prevents stale selections and mid-lookup unmounts. |
| `client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx` | Owns selected building IDs, derives selected building scopes, mounts the group action bar, prunes selection against active site/URL filters, and freezes selection changes while busy. | Review interaction between active SitePicker, `?site=` deep links, filtered-empty branches, and selection cleanup. |
| `client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx` | Owns selected rack IDs for list view, derives selected rack scopes, mounts the group action bar, clears selection on page/filter/view/sort transitions, and freezes selection changes while busy. | Review list/grid behavior and pagination/filter cleanup, since racks can switch views while selection exists. |
| **Client / selectable lists** |  |  |
| `client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.tsx` | Adds optional controlled selection props and selectable rows while keeping row action menus and navigation extras intact. | Review that selection is opt-in and row menus continue to work for non-bulk usage. |
| `client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.tsx` | Adds optional controlled selection props and selectable rows while preserving building row navigation/edit/add-to-site extras. | Same selection contract as SiteList; review selectable row constraints and preserved row actions. |
| `client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx` | Adds optional controlled selection props for rack rows in the shared device-set list. | DeviceSetList is reused outside racks; review that selection remains opt-in and default callers are unchanged. |
| **Client tests** |  |  |
| `FleetGroupActionsMenu.test.tsx` | Expands coverage for multi-scope filters, bulk presentation, lookup lifecycle, empty scopes, empty groups, auth-needed blocking, and Unpair exception. | Primary behavior tests for the new dispatch path. |
| `FleetGroupListActionBar.test.tsx` (new) | Covers selected-count copy, toaster/action-bar visibility, busy callbacks, frozen scope snapshot, unmount safety, and select controls. | Validates the ordering/lifecycle logic that keeps the menu alive during lookup. |
| `SiteList.test.tsx`, `BuildingList.test.tsx`, `DeviceSetList.test.tsx` | Add controlled-selection callback coverage for each selectable list. | Confirms list-level selection wiring without depending on page integration. |
| **Docs** |  |  |
| `docs/plans/2026-06-04-370-fleet-multi-select-bulk-actions-plan.md` (new) | Adds the implementation plan for the feature. | Reviewer can use this for background, but the code path above is the source of truth. |
| **Generated code / server / database / proto** | No files changed. | No generated code to review; no API/schema/migration compatibility concerns introduced by this PR. |

## 5. Key technical decisions & trade-offs

- Reuse existing miner action flows after descendant lookup instead of creating separate site/building/rack RPC action paths.
- Resolve descendant miners lazily on action click instead of maintaining live descendant miner selections while the operator checks group rows.
- Require `miner:read` before exposing lookup-backed group actions instead of rendering controls that predictably 403 on the descendant-miner lookup.
- Use one combined `siteIds` / `buildingIds` / `rackIds` filter per action instead of issuing one miner query per selected group.
- Cap lookup pagination at 50 pages / 50,000 miners instead of allowing unbounded client-side action fanout.
- Block non-Unpair actions when any descendant miner needs authentication instead of dispatching and letting downstream RPCs fail later.
- Freeze selection and keep the last non-empty scope snapshot during lookup instead of letting row checkbox changes unmount the active action menu.
- Keep group bulk selection page-scoped and materialized (`subset`) instead of adding fleet-wide `all` selection for groups.
- Suppress row-only extras in multi-select bulk menus instead of adapting navigation/edit actions to ambiguous multi-group selections.
- Extend shared UI primitives (`ActionBar`, `RowActionsMenu`, selectable lists) narrowly instead of introducing parallel one-off group-bulk components.

## 6. Testing & validation

Validated locally:

- `npm test -- FleetGroupActionsMenu.test.tsx FleetGroupListActionBar.test.tsx --run`
- `npm run lint`
- `npm run format:check`
- `npx tsc --noEmit`

Automated coverage added/updated:

- Group action menu tests for single-scope and multi-scope filter construction, bulk Reboot/More rendering, `miner:read` gating, empty scope handling, empty group handling, action-start/action-complete lifecycle, auth-needed blocking, and Unpair allowance.
- Group action bar tests for selection count copy, global toaster push-up lifecycle, hide/restore while actions run, frozen selected scopes during lookup, unmount safety, Select all visible, and Select none.
- List tests for controlled selection callback wiring in Sites, Buildings, and Racks.

Not covered in this PR:

- No new Playwright E2E for the complete group bulk action flow.
- No backend, protobuf, generated-code, migration, or plugin tests because those layers are not changed.