### PR TITLE
Harden ProtoFleet E2E fleet tab navigation

### DIFF
--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -1,6 +1,8 @@
 import { expect, Page } from "@playwright/test";
 import { DEFAULT_TIMEOUT, testConfig } from "../config/test.config";
 
+const FLEET_TAB_ROUTE = /.*\/fleet\/(?:sites|buildings|racks|miners)(?:[/?#].*)?$/;
+
 export class BasePage {
   constructor(
     protected page: Page,
@@ -115,7 +117,8 @@ export class BasePage {
   async navigateToFleetPage() {
     await this.clickNavigationMenuIfMobile();
     await this.page.getByTestId("navigation-menu").locator('a[href="/fleet"]').click();
-    await expect(this.page).toHaveURL(/.*\/fleet/);
+    await expect(this.page.getByTestId("fleet-layout")).toBeVisible();
+    await expect(this.page).toHaveURL(FLEET_TAB_ROUTE);
   }
 
   async navigateToMinersPage() {


### PR DESCRIPTION
## Summary
- Wait for FleetLayout to resolve bare `/fleet` routes before E2E helpers activate Fleet tabs.
- Avoids racing the default tab redirect when shared setup navigates from `/fleet` to Miners.

## Test plan
- `cd client && npx eslint e2eTests/protoFleet/pages/base.ts`
- `cd client && npx tsc --noEmit`
- Attempted `cd client/e2eTests/protoFleet && npx playwright test spec/00-onboarding.spec.ts --project=setup-desktop --grep "Validate null states"`, but local Chromium was not installed.