### PR TITLE
Improve mobile fleet layout spacing

### DIFF
--- a/client/src/protoFleet/components/AppLayout/AppLayout.test.tsx
+++ b/client/src/protoFleet/components/AppLayout/AppLayout.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import AppLayout from "./AppLayout";
 import type { CurtailmentPillEvent } from "@/protoFleet/components/PageHeader/CurtailmentPill";
 import type { UseSchedulePillDataResult } from "@/protoFleet/components/PageHeader/useSchedulePillData";
+import { useHasPermission } from "@/protoFleet/store";
 
 const mockUseWindowDimensions = vi.fn();
 const mockUseReactiveLocalStorage = vi.fn();
@@ -42,6 +43,10 @@ vi.mock("@/shared/hooks/useReactiveLocalStorage", () => ({
   useReactiveLocalStorage: () => mockUseReactiveLocalStorage(),
 }));
 
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: vi.fn(),
+}));
+
 const createSchedulePillData = (overrides: Partial<UseSchedulePillDataResult> = {}): UseSchedulePillDataResult => ({
   hasVisibleSchedules: false,
   pillSchedule: null,
@@ -62,14 +67,16 @@ const activeCurtailmentEvent: CurtailmentPillEvent = {
 describe("AppLayout", () => {
   beforeEach(() => {
     mockUseWindowDimensions.mockReturnValue({
+      width: 375,
       isPhone: true,
     });
     mockUseReactiveLocalStorage.mockReturnValue([false, vi.fn()]);
     mockUseCurtailmentPillData.mockReturnValue({ activeEvent: null });
     mockUseSchedulePillData.mockReturnValue(createSchedulePillData());
+    vi.mocked(useHasPermission).mockReturnValue(true);
   });
 
-  it("offsets the phone content when schedules make the header widgets visible", () => {
+  it("keeps the base phone content offset when the only schedule widget fits inline", () => {
     mockUseSchedulePillData.mockReturnValue(
       createSchedulePillData({
         hasVisibleSchedules: true,
@@ -84,10 +91,49 @@ describe("AppLayout", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("Body content").parentElement).toHaveClass("phone:top-[calc(theme(spacing.1)*12+57px)]");
+    expect(screen.getByText("Body content").parentElement).toHaveClass("phone:top-[calc(theme(spacing.1)*12)]");
   });
 
-  it("offsets the phone content when an active curtailment makes the header widgets visible", () => {
+  it("uses the two-widget phone content offset when all three header widgets are visible", () => {
+    mockUseReactiveLocalStorage.mockReturnValue([true, vi.fn()]);
+    mockUseCurtailmentPillData.mockReturnValue({ activeEvent: activeCurtailmentEvent });
+    mockUseSchedulePillData.mockReturnValue(
+      createSchedulePillData({
+        hasVisibleSchedules: true,
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <AppLayout>
+          <div>Body content</div>
+        </AppLayout>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Body content").parentElement).toHaveClass("phone:top-[calc(theme(spacing.1)*12+80px)]");
+  });
+
+  it("uses the single-widget phone content offset when one widget remains below the header", () => {
+    mockUseReactiveLocalStorage.mockReturnValue([true, vi.fn()]);
+    mockUseSchedulePillData.mockReturnValue(
+      createSchedulePillData({
+        hasVisibleSchedules: true,
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <AppLayout>
+          <div>Body content</div>
+        </AppLayout>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Body content").parentElement).toHaveClass("phone:top-[calc(theme(spacing.1)*12+40px)]");
+  });
+
+  it("keeps the base phone content offset when the only curtailment widget fits inline", () => {
     mockUseCurtailmentPillData.mockReturnValue({ activeEvent: activeCurtailmentEvent });
 
     render(
@@ -98,6 +144,21 @@ describe("AppLayout", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("Body content").parentElement).toHaveClass("phone:top-[calc(theme(spacing.1)*12+57px)]");
+    expect(screen.getByText("Body content").parentElement).toHaveClass("phone:top-[calc(theme(spacing.1)*12)]");
+  });
+
+  it("does not offset the phone content for active curtailment without read permission", () => {
+    vi.mocked(useHasPermission).mockReturnValue(false);
+    mockUseCurtailmentPillData.mockReturnValue({ activeEvent: activeCurtailmentEvent });
+
+    render(
+      <MemoryRouter>
+        <AppLayout>
+          <div>Body content</div>
+        </AppLayout>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Body content").parentElement).toHaveClass("phone:top-[calc(theme(spacing.1)*12)]");
   });
 });

--- a/client/src/protoFleet/components/AppLayout/AppLayout.test.tsx
+++ b/client/src/protoFleet/components/AppLayout/AppLayout.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import AppLayout from "./AppLayout";
 import type { CurtailmentPillEvent } from "@/protoFleet/components/PageHeader/CurtailmentPill";
 import type { UseSchedulePillDataResult } from "@/protoFleet/components/PageHeader/useSchedulePillData";
+import type { ScheduleListItem } from "@/protoFleet/api/useScheduleApi";
 import { useHasPermission } from "@/protoFleet/store";
 
 const mockUseWindowDimensions = vi.fn();
@@ -47,14 +48,32 @@ vi.mock("@/protoFleet/store", () => ({
   useHasPermission: vi.fn(),
 }));
 
-const createSchedulePillData = (overrides: Partial<UseSchedulePillDataResult> = {}): UseSchedulePillDataResult => ({
-  hasVisibleSchedules: false,
-  pillSchedule: null,
-  sections: [],
-  pendingScheduleId: null,
-  onToggleScheduleStatus: vi.fn(),
-  ...overrides,
-});
+const createPillSchedule = (): ScheduleListItem =>
+  ({
+    id: "1",
+    priority: 1,
+    name: "Night reboot",
+    targetSummary: "Applies to all miners",
+    scheduleSummary: "Weekdays · 10:00 PM",
+    nextRunSummary: "Runs tomorrow at 10:00 PM",
+    action: "sleep",
+    status: "active",
+    createdBy: "Review",
+    rawSchedule: {},
+  }) as ScheduleListItem;
+
+const createSchedulePillData = (overrides: Partial<UseSchedulePillDataResult> = {}): UseSchedulePillDataResult => {
+  const pillSchedule = overrides.pillSchedule ?? null;
+
+  return {
+    sections: [],
+    pendingScheduleId: null,
+    onToggleScheduleStatus: vi.fn(),
+    ...overrides,
+    pillSchedule,
+    hasVisibleSchedules: pillSchedule !== null,
+  };
+};
 
 const activeCurtailmentEvent: CurtailmentPillEvent = {
   reason: "Grid peak call",
@@ -79,7 +98,7 @@ describe("AppLayout", () => {
   it("keeps the base phone content offset when the only schedule widget fits inline", () => {
     mockUseSchedulePillData.mockReturnValue(
       createSchedulePillData({
-        hasVisibleSchedules: true,
+        pillSchedule: createPillSchedule(),
       }),
     );
 
@@ -99,7 +118,7 @@ describe("AppLayout", () => {
     mockUseCurtailmentPillData.mockReturnValue({ activeEvent: activeCurtailmentEvent });
     mockUseSchedulePillData.mockReturnValue(
       createSchedulePillData({
-        hasVisibleSchedules: true,
+        pillSchedule: createPillSchedule(),
       }),
     );
 
@@ -118,7 +137,7 @@ describe("AppLayout", () => {
     mockUseReactiveLocalStorage.mockReturnValue([true, vi.fn()]);
     mockUseSchedulePillData.mockReturnValue(
       createSchedulePillData({
-        hasVisibleSchedules: true,
+        pillSchedule: createPillSchedule(),
       }),
     );
 

--- a/client/src/protoFleet/components/AppLayout/AppLayout.test.tsx
+++ b/client/src/protoFleet/components/AppLayout/AppLayout.test.tsx
@@ -4,9 +4,9 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import AppLayout from "./AppLayout";
+import type { ScheduleListItem } from "@/protoFleet/api/useScheduleApi";
 import type { CurtailmentPillEvent } from "@/protoFleet/components/PageHeader/CurtailmentPill";
 import type { UseSchedulePillDataResult } from "@/protoFleet/components/PageHeader/useSchedulePillData";
-import type { ScheduleListItem } from "@/protoFleet/api/useScheduleApi";
 import { useHasPermission } from "@/protoFleet/store";
 
 const mockUseWindowDimensions = vi.fn();

--- a/client/src/protoFleet/components/AppLayout/AppLayout.tsx
+++ b/client/src/protoFleet/components/AppLayout/AppLayout.tsx
@@ -4,10 +4,19 @@ import clsx from "clsx";
 import NavigationMenu from "../NavigationMenu";
 import { ScheduleApiProvider } from "@/protoFleet/api/ScheduleApiProvider";
 import PageHeader from "@/protoFleet/components/PageHeader";
+import {
+  getPhoneHeaderWidgetOffsetClass,
+  getPhoneHeaderWidgetRowCount,
+  getVisibleHeaderWidgetCount,
+  PHONE_HEADER_WIDGET_HIDDEN_OFFSET_CLASS,
+  shouldInlineFirstPhoneHeaderWidget,
+  shouldStackPhoneHeaderWidgets,
+} from "@/protoFleet/components/PageHeader/headerWidgetLayout";
 import { useCurtailmentPillData } from "@/protoFleet/components/PageHeader/useCurtailmentPillData";
 import { useSchedulePillData } from "@/protoFleet/components/PageHeader/useSchedulePillData";
 import { primaryNavItems } from "@/protoFleet/config/navItems";
 import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
+import { useHasPermission } from "@/protoFleet/store";
 import { useReactiveLocalStorage } from "@/shared/hooks/useReactiveLocalStorage";
 import { useWindowDimensions } from "@/shared/hooks/useWindowDimensions";
 
@@ -23,10 +32,18 @@ const AppLayoutContent = ({ children }: Props) => {
   const schedulePillData = useSchedulePillData();
   const { activeEvent: activeCurtailmentEvent } = useCurtailmentPillData();
   const hasDismissedSetup = Boolean(dismissedSetup);
-  const hasActiveCurtailmentEvent = activeCurtailmentEvent !== null;
+  const canReadCurtailment = useHasPermission("curtailment:read");
+  const hasVisibleCurtailmentPill = activeCurtailmentEvent !== null && canReadCurtailment;
+  const headerWidgetCount = getVisibleHeaderWidgetCount({
+    hasDismissedSetup,
+    hasVisibleCurtailmentPill,
+    hasVisibleSchedules: schedulePillData.hasVisibleSchedules,
+  });
+  const inlineFirstPhoneWidget = isPhone && shouldInlineFirstPhoneHeaderWidget(headerWidgetCount);
+  const phoneRowWidgetCount = getPhoneHeaderWidgetRowCount(headerWidgetCount, inlineFirstPhoneWidget);
+  const stackPhoneWidgets = shouldStackPhoneHeaderWidgets(headerWidgetCount);
 
-  const showPhoneWidgets =
-    isPhone && (hasDismissedSetup || schedulePillData.hasVisibleSchedules || hasActiveCurtailmentEvent);
+  const showPhoneWidgets = isPhone && phoneRowWidgetCount > 0;
 
   return (
     <div className={clsx("absolute top-0 right-0 bottom-0 left-0", bgClass)}>
@@ -49,7 +66,9 @@ const AppLayoutContent = ({ children }: Props) => {
         className={clsx(
           "fixed top-[calc(theme(spacing.1)*12)] right-0 bottom-0 left-0 z-20 overflow-auto laptop:top-[calc(theme(spacing.1)*15)] laptop:left-16 desktop:left-50",
           bgClass,
-          showPhoneWidgets ? "phone:top-[calc(theme(spacing.1)*12+57px)]" : "phone:top-[calc(theme(spacing.1)*12)]",
+          showPhoneWidgets
+            ? getPhoneHeaderWidgetOffsetClass(phoneRowWidgetCount, stackPhoneWidgets)
+            : PHONE_HEADER_WIDGET_HIDDEN_OFFSET_CLASS,
         )}
       >
         {children}

--- a/client/src/protoFleet/components/PageHeader/LocationSelector/LocationSelector.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/LocationSelector/LocationSelector.test.tsx
@@ -14,9 +14,9 @@ describe("Location Selector", () => {
   });
 
   test("renders location name", () => {
-    const { queryByText, queryByTestId } = render(<LocationSelector loading={false} location={locationName} />);
+    const { getByText, queryByTestId } = render(<LocationSelector loading={false} location={locationName} />);
 
     expect(queryByTestId(skeletonTestId)).toBeNull();
-    expect(queryByText(locationName)).toBeInTheDocument();
+    expect(getByText(locationName)).toHaveClass("min-w-0", "truncate");
   });
 });

--- a/client/src/protoFleet/components/PageHeader/LocationSelector/LocationSelector.tsx
+++ b/client/src/protoFleet/components/PageHeader/LocationSelector/LocationSelector.tsx
@@ -7,7 +7,11 @@ interface LocationSelectorProps {
 
 const LocationSelector = ({ location, loading }: LocationSelectorProps) => {
   // TODO implement selector with options
-  return <div className="text-300 text-text-primary">{loading ? <SkeletonBar className="w-20" /> : location}</div>;
+  return (
+    <div className="min-w-0 truncate text-300 text-text-primary">
+      {loading ? <SkeletonBar className="w-20" /> : location}
+    </div>
+  );
 };
 
 export default LocationSelector;

--- a/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
@@ -127,6 +127,7 @@ describe("PageHeader", () => {
     const mobileWidgets = screen.getByTestId("page-header-mobile-widgets");
 
     expect(screen.getByTestId("page-header-location-area")).toHaveClass("min-w-0", "flex-1");
+    expect(screen.getByTestId("page-header-selector-area")).toHaveClass("min-w-0", "flex-1");
     expect(within(inlineWidgets).getByText("Curtailment pill")).toBeVisible();
     expect(inlineWidgets).toHaveClass("min-w-0");
     expect(inlineWidgets).not.toHaveClass("shrink-0");

--- a/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
@@ -126,10 +126,16 @@ describe("PageHeader", () => {
     const inlineWidgets = screen.getByTestId("page-header-inline-widgets");
     const mobileWidgets = screen.getByTestId("page-header-mobile-widgets");
 
-    expect(screen.getByTestId("page-header-location-area")).toHaveClass("min-w-0", "flex-1");
+    expect(screen.getByTestId("page-header-content")).toHaveClass(
+      "grid",
+      "grid-cols-[minmax(0,1fr)_minmax(0,min(15rem,45vw))]",
+    );
+    expect(screen.getByTestId("page-header-location-area")).toHaveClass("min-w-0");
+    expect(screen.getByTestId("page-header-location-area")).not.toHaveClass("flex-1");
     expect(screen.getByTestId("page-header-selector-area")).toHaveClass("min-w-0", "flex-1");
     expect(within(inlineWidgets).getByText("Curtailment pill")).toBeVisible();
-    expect(inlineWidgets).toHaveClass("min-w-0");
+    expect(inlineWidgets).toHaveClass("min-w-0", "overflow-hidden");
+    expect(inlineWidgets).not.toHaveClass("ml-3");
     expect(inlineWidgets).not.toHaveClass("shrink-0");
     expect(within(mobileWidgets).queryByText("Curtailment pill")).not.toBeInTheDocument();
     expect(within(mobileWidgets).getByText("Night reboot")).toBeVisible();

--- a/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import PageHeader from "./PageHeader";
 import type { UseSchedulePillDataResult } from "./useSchedulePillData";
@@ -78,6 +78,7 @@ describe("PageHeader", () => {
     vi.clearAllMocks();
     mockListSites.mockReturnValue(undefined);
     mockUseWindowDimensions.mockReturnValue({
+      width: 375,
       isPhone: true,
       isTablet: false,
     });
@@ -85,7 +86,7 @@ describe("PageHeader", () => {
     vi.mocked(useHasPermission).mockReturnValue(true);
   });
 
-  it("shows the phone widget row when schedules are available even if setup is not dismissed", () => {
+  it("shows the phone header widget when schedules are available even if setup is not dismissed", () => {
     const schedulePillData = createSchedulePillData({
       hasVisibleSchedules: true,
       pillSchedule: createPillSchedule("Night reboot"),
@@ -98,6 +99,40 @@ describe("PageHeader", () => {
     );
 
     expect(screen.getByText("Night reboot")).toBeVisible();
+  });
+
+  it("places the first phone widget in the top row and stacks the remaining widgets", () => {
+    mockUseReactiveLocalStorage.mockReturnValue([true, vi.fn()]);
+    const schedulePillData = createSchedulePillData({
+      hasVisibleSchedules: true,
+      pillSchedule: createPillSchedule("Night reboot"),
+    });
+
+    render(
+      <MemoryRouter>
+        <PageHeader
+          schedulePillData={schedulePillData}
+          activeCurtailmentEvent={{
+            reason: "Grid peak call",
+            state: "curtailing",
+            scopeLabel: "Whole fleet",
+            selectedMiners: 48,
+            estimatedReductionKw: 126.4,
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    const inlineWidgets = screen.getByTestId("page-header-inline-widgets");
+    const mobileWidgets = screen.getByTestId("page-header-mobile-widgets");
+
+    expect(within(inlineWidgets).getByText("Curtailment pill")).toBeVisible();
+    expect(within(mobileWidgets).queryByText("Curtailment pill")).not.toBeInTheDocument();
+    expect(within(mobileWidgets).getByText("Night reboot")).toBeVisible();
+    expect(within(mobileWidgets).getByText("Continue setup")).toBeVisible();
+    expect(mobileWidgets).toHaveClass("flex-col", "items-end", "gap-2");
+    expect(mobileWidgets).not.toHaveClass("gap-3");
+    expect(screen.getByTestId("phone-header-widget-row")).toHaveClass("h-[80px]");
   });
 
   it("keeps the phone widget row hidden when neither setup nor schedules need space", () => {

--- a/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
@@ -127,6 +127,8 @@ describe("PageHeader", () => {
     const mobileWidgets = screen.getByTestId("page-header-mobile-widgets");
 
     expect(within(inlineWidgets).getByText("Curtailment pill")).toBeVisible();
+    expect(inlineWidgets).toHaveClass("min-w-0");
+    expect(inlineWidgets).not.toHaveClass("shrink-0");
     expect(within(mobileWidgets).queryByText("Curtailment pill")).not.toBeInTheDocument();
     expect(within(mobileWidgets).getByText("Night reboot")).toBeVisible();
     expect(within(mobileWidgets).getByText("Continue setup")).toBeVisible();

--- a/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
@@ -145,6 +145,24 @@ describe("PageHeader", () => {
     expect(screen.getByTestId("phone-header-widget-row")).toHaveClass("h-[80px]");
   });
 
+  it("constrains the setup button when it is the inline phone widget", () => {
+    mockUseReactiveLocalStorage.mockReturnValue([true, vi.fn()]);
+
+    render(
+      <MemoryRouter>
+        <PageHeader schedulePillData={createSchedulePillData()} />
+      </MemoryRouter>,
+    );
+
+    const inlineWidgets = screen.getByTestId("page-header-inline-widgets");
+    const setupButton = within(inlineWidgets).getByRole("button", { name: "Continue setup" });
+    const setupLabel = within(setupButton).getByText("Continue setup");
+
+    expect(setupButton).toHaveClass("min-w-0", "max-w-full", "overflow-hidden");
+    expect(setupLabel).toHaveClass("truncate");
+    expect(screen.queryByTestId("phone-header-widget-row")).not.toBeInTheDocument();
+  });
+
   it("keeps the phone widget row hidden when neither setup nor schedules need space", () => {
     render(
       <MemoryRouter>

--- a/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
@@ -126,6 +126,7 @@ describe("PageHeader", () => {
     const inlineWidgets = screen.getByTestId("page-header-inline-widgets");
     const mobileWidgets = screen.getByTestId("page-header-mobile-widgets");
 
+    expect(screen.getByTestId("page-header-location-area")).toHaveClass("min-w-0", "flex-1");
     expect(within(inlineWidgets).getByText("Curtailment pill")).toBeVisible();
     expect(inlineWidgets).toHaveClass("min-w-0");
     expect(inlineWidgets).not.toHaveClass("shrink-0");

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -191,11 +191,13 @@ function PageHeader({
                 testId="navigation-menu-button"
               />
             ) : null}
-            {MULTI_SITE_ENABLED ? (
-              <SitePicker sites={sites} error={sitesError} onRetry={fetchSites} />
-            ) : (
-              <LocationSelector />
-            )}
+            <div className="min-w-0 flex-1" data-testid="page-header-selector-area">
+              {MULTI_SITE_ENABLED ? (
+                <SitePicker sites={sites} error={sitesError} onRetry={fetchSites} />
+              ) : (
+                <LocationSelector />
+              )}
+            </div>
           </div>
           {!isPhone && headerWidgetEnabled ? (
             <HeaderWidgets testId="page-header-desktop-widgets" widgets={headerWidgetKinds} {...headerWidgetsProps} />

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -93,11 +93,13 @@ function HeaderWidgets({
             return dismissedSetup ? (
               <Button
                 key={widget}
+                className="min-w-0 max-w-full overflow-hidden"
                 variant={variants.secondary}
                 size={sizes.compact}
-                text="Continue setup"
                 onClick={onContinueSetup}
-              />
+              >
+                <span className="block min-w-0 truncate">Continue setup</span>
+              </Button>
             ) : null;
         }
       })}

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -93,7 +93,7 @@ function HeaderWidgets({
             return dismissedSetup ? (
               <Button
                 key={widget}
-                className="min-w-0 max-w-full overflow-hidden"
+                className="max-w-full min-w-0 overflow-hidden"
                 variant={variants.secondary}
                 size={sizes.compact}
                 onClick={onContinueSetup}

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -180,8 +180,19 @@ function PageHeader({
   return (
     <>
       <div className="flex h-12 items-center laptop:h-15">
-        <div className="flex grow items-center px-4">
-          <div className="flex min-w-0 flex-1 items-center" data-testid="page-header-location-area">
+        <div
+          className={clsx(
+            "w-full px-4",
+            inlineFirstPhoneWidget
+              ? "grid grid-cols-[minmax(0,1fr)_minmax(0,min(15rem,45vw))] items-center gap-3"
+              : "flex grow items-center",
+          )}
+          data-testid="page-header-content"
+        >
+          <div
+            className={clsx("flex min-w-0 items-center", !inlineFirstPhoneWidget && "flex-1")}
+            data-testid="page-header-location-area"
+          >
             {isPhone || isTablet ? (
               <Pause
                 ariaExpanded={isMenuOpen}
@@ -204,7 +215,7 @@ function PageHeader({
           ) : null}
           {inlineFirstPhoneWidget ? (
             <HeaderWidgets
-              className="ml-3 min-w-0 justify-end"
+              className="min-w-0 justify-end overflow-hidden"
               testId="page-header-inline-widgets"
               widgets={phoneTopWidgetKinds}
               {...headerWidgetsProps}

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -202,7 +202,7 @@ function PageHeader({
           ) : null}
           {inlineFirstPhoneWidget ? (
             <HeaderWidgets
-              className="ml-3 shrink-0"
+              className="ml-3 min-w-0 justify-end"
               testId="page-header-inline-widgets"
               widgets={phoneTopWidgetKinds}
               {...headerWidgetsProps}

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -3,6 +3,13 @@ import clsx from "clsx";
 
 import CurtailmentPill from "./CurtailmentPill";
 import type { CurtailmentPillEvent } from "./curtailmentPillTypes";
+import {
+  getPhoneHeaderWidgetRowCount,
+  getPhoneHeaderWidgetRowHeightClass,
+  getVisibleHeaderWidgetCount,
+  shouldInlineFirstPhoneHeaderWidget,
+  shouldStackPhoneHeaderWidgets,
+} from "./headerWidgetLayout";
 import LocationSelector from "./LocationSelector";
 import SchedulePill from "./SchedulePill";
 import SitePicker from "./SitePicker";
@@ -26,41 +33,74 @@ interface PageHeaderProps {
 
 interface HeaderWidgetsProps {
   activeCurtailmentEvent: CurtailmentPillEvent | null;
+  align?: "start" | "end";
   canReadCurtailment: boolean;
   className?: string;
   dismissedSetup: boolean;
   onContinueSetup: () => void;
   schedulePillData: UseSchedulePillDataResult;
+  stacked?: boolean;
+  testId?: string;
+  widgets: HeaderWidgetKind[];
 }
 
 const headerWidgetEnabled = true;
+type HeaderWidgetKind = "curtailment" | "schedule" | "setup";
 
 function HeaderWidgets({
   activeCurtailmentEvent,
+  align = "start",
   canReadCurtailment,
   className,
   dismissedSetup,
   onContinueSetup,
   schedulePillData,
+  stacked = false,
+  testId,
+  widgets,
 }: HeaderWidgetsProps): ReactElement {
   const { pillSchedule, sections, pendingScheduleId, onToggleScheduleStatus } = schedulePillData;
+  const alignEnd = align === "end";
 
   return (
-    <div className={clsx("flex space-x-3", className)}>
-      {activeCurtailmentEvent && canReadCurtailment ? (
-        <CurtailmentPill event={activeCurtailmentEvent} detailsPath="/energy" />
-      ) : null}
-      {pillSchedule ? (
-        <SchedulePill
-          pillSchedule={pillSchedule}
-          sections={sections}
-          pendingScheduleId={pendingScheduleId}
-          onToggleScheduleStatus={onToggleScheduleStatus}
-        />
-      ) : null}
-      {dismissedSetup ? (
-        <Button variant={variants.secondary} size={sizes.compact} text="Continue setup" onClick={onContinueSetup} />
-      ) : null}
+    <div
+      className={clsx(
+        "flex",
+        stacked ? "flex-col gap-2" : "items-center gap-3",
+        alignEnd && !stacked && "justify-end",
+        stacked && (alignEnd ? "items-end" : "items-start"),
+        className,
+      )}
+      data-testid={testId}
+    >
+      {widgets.map((widget) => {
+        switch (widget) {
+          case "curtailment":
+            return activeCurtailmentEvent && canReadCurtailment ? (
+              <CurtailmentPill key={widget} event={activeCurtailmentEvent} detailsPath="/energy" />
+            ) : null;
+          case "schedule":
+            return pillSchedule ? (
+              <SchedulePill
+                key={widget}
+                pillSchedule={pillSchedule}
+                sections={sections}
+                pendingScheduleId={pendingScheduleId}
+                onToggleScheduleStatus={onToggleScheduleStatus}
+              />
+            ) : null;
+          case "setup":
+            return dismissedSetup ? (
+              <Button
+                key={widget}
+                variant={variants.secondary}
+                size={sizes.compact}
+                text="Continue setup"
+                onClick={onContinueSetup}
+              />
+            ) : null;
+        }
+      })}
     </div>
   );
 }
@@ -120,8 +160,22 @@ function PageHeader({
     schedulePillData,
   };
   const hasVisibleCurtailmentPill = activeCurtailmentEvent !== null && canReadCurtailment;
-  const showPhoneWidgets =
-    isPhone && (hasDismissedSetup || schedulePillData.hasVisibleSchedules || hasVisibleCurtailmentPill);
+  const headerWidgetKinds: HeaderWidgetKind[] = [
+    ...(hasVisibleCurtailmentPill ? (["curtailment"] as const) : []),
+    ...(schedulePillData.hasVisibleSchedules ? (["schedule"] as const) : []),
+    ...(hasDismissedSetup ? (["setup"] as const) : []),
+  ];
+  const headerWidgetCount = getVisibleHeaderWidgetCount({
+    hasDismissedSetup,
+    hasVisibleCurtailmentPill,
+    hasVisibleSchedules: schedulePillData.hasVisibleSchedules,
+  });
+  const inlineFirstPhoneWidget = isPhone && shouldInlineFirstPhoneHeaderWidget(headerWidgetCount);
+  const phoneTopWidgetKinds = inlineFirstPhoneWidget ? headerWidgetKinds.slice(0, 1) : [];
+  const phoneRowWidgetKinds = inlineFirstPhoneWidget ? headerWidgetKinds.slice(1) : headerWidgetKinds;
+  const phoneRowWidgetCount = getPhoneHeaderWidgetRowCount(headerWidgetCount, inlineFirstPhoneWidget);
+  const stackPhoneWidgets = shouldStackPhoneHeaderWidgets(headerWidgetCount);
+  const showPhoneWidgets = isPhone && phoneRowWidgetCount > 0;
 
   return (
     <>
@@ -143,12 +197,35 @@ function PageHeader({
               <LocationSelector />
             )}
           </div>
-          {!isPhone && headerWidgetEnabled ? <HeaderWidgets {...headerWidgetsProps} /> : null}
+          {!isPhone && headerWidgetEnabled ? (
+            <HeaderWidgets testId="page-header-desktop-widgets" widgets={headerWidgetKinds} {...headerWidgetsProps} />
+          ) : null}
+          {inlineFirstPhoneWidget ? (
+            <HeaderWidgets
+              className="ml-3 shrink-0"
+              testId="page-header-inline-widgets"
+              widgets={phoneTopWidgetKinds}
+              {...headerWidgetsProps}
+            />
+          ) : null}
         </div>
       </div>
       {showPhoneWidgets ? (
-        <div className={clsx("flex h-[57px] items-center", bgClass)}>
-          <HeaderWidgets className="ml-5" {...headerWidgetsProps} />
+        <div
+          className={clsx(
+            "flex items-start justify-end px-4",
+            getPhoneHeaderWidgetRowHeightClass(phoneRowWidgetCount, stackPhoneWidgets),
+            bgClass,
+          )}
+          data-testid="phone-header-widget-row"
+        >
+          <HeaderWidgets
+            align="end"
+            stacked={stackPhoneWidgets}
+            testId="page-header-mobile-widgets"
+            widgets={phoneRowWidgetKinds}
+            {...headerWidgetsProps}
+          />
         </div>
       ) : null}
     </>

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -181,7 +181,7 @@ function PageHeader({
     <>
       <div className="flex h-12 items-center laptop:h-15">
         <div className="flex grow items-center px-4">
-          <div className="flex grow items-center">
+          <div className="flex min-w-0 flex-1 items-center" data-testid="page-header-location-area">
             {isPhone || isTablet ? (
               <Pause
                 ariaExpanded={isMenuOpen}

--- a/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.test.tsx
@@ -30,4 +30,15 @@ describe("PageHeaderPopoverPill", () => {
 
     expect(screen.queryByText("Popover content")).not.toBeInTheDocument();
   });
+
+  it("allows the trigger label to truncate inside constrained header space", () => {
+    renderPageHeaderPopoverPill();
+
+    const trigger = screen.getByRole("button", { name: "Toggle details" });
+    const triggerWrapper = trigger.closest(".first-trigger");
+
+    expect(triggerWrapper).toHaveClass("min-w-0");
+    expect(trigger).toHaveClass("min-w-0", "max-w-full");
+    expect(screen.getByText("Details")).toHaveClass("min-w-0", "truncate");
+  });
 });

--- a/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeaderPopoverPill.tsx
@@ -38,17 +38,18 @@ function PageHeaderPopoverPillContent({
   }
 
   return (
-    <div className={`${triggerClassName} relative`} ref={triggerRef}>
+    <div className={`${triggerClassName} relative min-w-0`} ref={triggerRef}>
       <Button
         variant={variants.secondary}
         size={sizes.compact}
+        className="max-w-full min-w-0"
         ariaHasPopup={true}
         ariaExpanded={isPopoverOpen}
         ariaLabel={ariaLabel}
         onClick={handleTriggerClick}
         prefixIcon={<span className={clsx("h-2.5 w-2.5 rounded-full", dotClassName)} />}
       >
-        <span className="block max-w-56 truncate">{triggerLabel}</span>
+        <span className="block max-w-56 min-w-0 truncate">{triggerLabel}</span>
       </Button>
 
       {isPopoverOpen ? (

--- a/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.test.tsx
@@ -58,7 +58,10 @@ describe("SitePicker", () => {
   it("renders the retry affordance when ListSites failed", () => {
     const onRetry = vi.fn();
     renderPicker({ sites: [], error: "network down", onRetry });
-    expect(screen.getByTestId("site-picker-error")).toHaveTextContent("Sites unavailable");
+    const error = screen.getByTestId("site-picker-error");
+    expect(error).toHaveClass("max-w-full", "min-w-0");
+    expect(screen.getByText("Sites unavailable")).toHaveClass("min-w-0", "truncate");
+    expect(screen.getByTestId("site-picker-retry")).toHaveClass("shrink-0");
     fireEvent.click(screen.getByTestId("site-picker-retry"));
     expect(onRetry).toHaveBeenCalledTimes(1);
   });

--- a/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.test.tsx
@@ -68,6 +68,9 @@ describe("SitePicker", () => {
     renderPicker({ sites });
 
     const trigger = screen.getByTestId("site-picker-trigger");
+    const label = screen.getByText("All sites");
+    expect(trigger).toHaveClass("max-w-full", "min-w-0");
+    expect(label).toHaveClass("min-w-0", "truncate");
     expect(trigger).toHaveTextContent("All sites");
 
     fireEvent.click(trigger);

--- a/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
+++ b/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
@@ -120,16 +120,16 @@ const SitePicker = ({ sites, error, onRetry }: SitePickerProps) => {
     <>
       <button
         type="button"
-        className="hover:bg-surface-base-hover flex items-center gap-1 rounded-md px-2 py-1 text-300 text-text-primary focus-visible:underline"
+        className="hover:bg-surface-base-hover flex max-w-full min-w-0 items-center gap-1 rounded-md px-2 py-1 text-300 text-text-primary focus-visible:underline"
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-label="Active site"
         onClick={() => setIsOpen(true)}
         data-testid="site-picker-trigger"
       >
-        <span>{currentLabel}</span>
+        <span className="min-w-0 truncate">{currentLabel}</span>
         {/* Smaller, dimmed chevron matches the prototype's compact trigger affordance. */}
-        <ChevronDown className={clsx(iconSizes.xSmall, "opacity-70")} />
+        <ChevronDown className={clsx(iconSizes.xSmall, "shrink-0 opacity-70")} />
       </button>
       <Modal
         open={isOpen}

--- a/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
+++ b/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
@@ -62,12 +62,16 @@ const SitePicker = ({ sites, error, onRetry }: SitePickerProps) => {
   // shouldn't silently swallow the picker entirely.
   if (sites.length === 0 && error != null) {
     return (
-      <div className="flex items-center gap-2 text-300 text-text-primary-70" data-testid="site-picker-error">
-        <span>Sites unavailable</span>
+      <div
+        className="flex max-w-full min-w-0 items-center gap-2 text-300 text-text-primary-70"
+        data-testid="site-picker-error"
+      >
+        <span className="min-w-0 truncate">Sites unavailable</span>
         {onRetry ? (
           <Button
             variant={variants.secondary}
             size={sizes.compact}
+            className="shrink-0"
             text="Retry"
             onClick={onRetry}
             testId="site-picker-retry"

--- a/client/src/protoFleet/components/PageHeader/headerWidgetLayout.ts
+++ b/client/src/protoFleet/components/PageHeader/headerWidgetLayout.ts
@@ -1,0 +1,57 @@
+interface HeaderWidgetVisibility {
+  hasDismissedSetup: boolean;
+  hasVisibleCurtailmentPill: boolean;
+  hasVisibleSchedules: boolean;
+}
+
+export const PHONE_HEADER_WIDGET_ROW_OFFSET_CLASS = "phone:top-[calc(theme(spacing.1)*12+40px)]";
+export const PHONE_HEADER_WIDGET_STACK_TWO_OFFSET_CLASS = "phone:top-[calc(theme(spacing.1)*12+80px)]";
+export const PHONE_HEADER_WIDGET_STACK_THREE_OFFSET_CLASS = "phone:top-[calc(theme(spacing.1)*12+120px)]";
+export const PHONE_HEADER_WIDGET_HIDDEN_OFFSET_CLASS = "phone:top-[calc(theme(spacing.1)*12)]";
+export const PHONE_HEADER_WIDGET_ROW_HEIGHT_CLASS = "h-[40px]";
+export const PHONE_HEADER_WIDGET_STACK_TWO_HEIGHT_CLASS = "h-[80px]";
+export const PHONE_HEADER_WIDGET_STACK_THREE_HEIGHT_CLASS = "h-[120px]";
+
+export function getVisibleHeaderWidgetCount({
+  hasDismissedSetup,
+  hasVisibleCurtailmentPill,
+  hasVisibleSchedules,
+}: HeaderWidgetVisibility): number {
+  return Number(hasVisibleCurtailmentPill) + Number(hasVisibleSchedules) + Number(hasDismissedSetup);
+}
+
+export function shouldStackPhoneHeaderWidgets(widgetCount: number): boolean {
+  return widgetCount > 2;
+}
+
+export function shouldInlineFirstPhoneHeaderWidget(widgetCount: number): boolean {
+  return widgetCount > 0;
+}
+
+export function getPhoneHeaderWidgetRowCount(widgetCount: number, inlineFirstWidget: boolean): number {
+  if (!inlineFirstWidget) {
+    return widgetCount;
+  }
+
+  return Math.max(widgetCount - 1, 0);
+}
+
+export function getPhoneHeaderWidgetRowHeightClass(widgetCount: number, stackWidgets: boolean): string {
+  if (!stackWidgets) {
+    return PHONE_HEADER_WIDGET_ROW_HEIGHT_CLASS;
+  }
+
+  return widgetCount > 2 ? PHONE_HEADER_WIDGET_STACK_THREE_HEIGHT_CLASS : PHONE_HEADER_WIDGET_STACK_TWO_HEIGHT_CLASS;
+}
+
+export function getPhoneHeaderWidgetOffsetClass(widgetCount: number, stackWidgets: boolean): string {
+  if (widgetCount === 0) {
+    return PHONE_HEADER_WIDGET_HIDDEN_OFFSET_CLASS;
+  }
+
+  if (!stackWidgets) {
+    return PHONE_HEADER_WIDGET_ROW_OFFSET_CLASS;
+  }
+
+  return widgetCount > 2 ? PHONE_HEADER_WIDGET_STACK_THREE_OFFSET_CLASS : PHONE_HEADER_WIDGET_STACK_TWO_OFFSET_CLASS;
+}

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
@@ -60,8 +60,12 @@ const automationTableClassName = [
   "mb-2 w-full",
   "phone:table-fixed",
   "[&_thead_th]:text-text-primary-50",
-  "phone:[&_thead_th:last-child]:w-9",
-  "phone:[&_thead_th:last-child>div]:w-9",
+  "phone:[&_thead_th:last-child]:w-14",
+  "phone:[&_thead_th:last-child>div]:w-14",
+  "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:box-border",
+  "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:flex",
+  "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:justify-end",
+  "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:w-14",
 ].join(" ");
 
 const emptyAutomations: AutomationRule[] = [];
@@ -510,7 +514,7 @@ function createAutomationColConfig(
           <Switch checked={rule.enabled} setChecked={() => onToggle(rule.id)} disabled={updatingRuleIds.has(rule.id)} />
         </div>
       ),
-      width: "w-[6%] phone:w-9",
+      width: "w-[6%] phone:w-14",
     },
   };
 }

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.css
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.css
@@ -43,6 +43,12 @@
   min-height: 110px;
 }
 
+@media (max-width: 631px) {
+  .curtailment-response-profile-grid {
+    gap: 12px;
+  }
+}
+
 @media (min-width: 60rem) {
   .curtailment-response-profile-grid {
     grid-template-columns: repeat(auto-fill, minmax(min(100%, 18rem), calc((100% - 48px) / 3)));

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -107,8 +107,12 @@ const curtailmentSourcesTableClassName = [
   "mb-2 w-full",
   "phone:table-fixed",
   "[&_thead_th]:text-text-primary-50",
-  "phone:[&_thead_th:last-child]:w-9",
-  "phone:[&_thead_th:last-child>div]:w-9",
+  "phone:[&_thead_th:last-child]:w-14",
+  "phone:[&_thead_th:last-child>div]:w-14",
+  "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:box-border",
+  "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:flex",
+  "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:justify-end",
+  "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:w-14",
 ].join(" ");
 
 const sourceHealthDotClassName: Record<CurtailmentHealth, string> = {
@@ -1042,7 +1046,7 @@ function createCurtailmentSourceColConfig({
     },
     [curtailmentSourceCols.lastSignalUpdate]: {
       component: (source) => <span className="truncate text-text-primary">{source.lastSeen}</span>,
-      width: "w-[23.5%] phone:w-auto",
+      width: "w-[23.5%] phone:hidden",
     },
     [curtailmentSourceCols.health]: {
       component: (source) => (
@@ -1069,7 +1073,7 @@ function createCurtailmentSourceColConfig({
           />
         </div>
       ),
-      width: "w-[6%] phone:w-9",
+      width: "w-[6%] phone:w-14",
     },
   };
 }

--- a/client/src/shared/components/Button/Button.tsx
+++ b/client/src/shared/components/Button/Button.tsx
@@ -130,8 +130,8 @@ const Button = ({
     >
       {prefix}
       {(text || children) && prefix ? <div className={gap} /> : null}
-      <div className="flex flex-col">
-        <div className={clsx({ "mb-[2px] group-hover:mb-0": textOnly && textOnlyUnderlineOnHover })}>
+      <div className="flex min-w-0 flex-col">
+        <div className={clsx("min-w-0", { "mb-[2px] group-hover:mb-0": textOnly && textOnlyUnderlineOnHover })}>
           {text}
           {children}
         </div>


### PR DESCRIPTION
## Summary
- Keep mobile header pills aligned by moving the first visible pill into the top bar and stacking overflow pills with consistent spacing
- Tighten mobile response profile card spacing and preserve curtailment table headers/toggles on small screens

## Test plan
- [ ] Open ProtoFleet on a phone-sized viewport and confirm header pills align with even spacing
- [ ] Confirm curtailment response profile cards and Sources/Automations tables fit without clipping
- [ ] Confirm desktop header and curtailment settings layouts are unchanged

<img width="305" height="669" alt="image" src="https://github.com/user-attachments/assets/08068d6f-c5bf-4b5d-bbb6-f6d15c847f23" />
