### PR TITLE
Use blue indicator for sleeping miners

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.test.tsx
@@ -217,6 +217,18 @@ describe("MinerStatus", () => {
 
       expect(screen.getByText("Needs attention")).toBeInTheDocument();
     });
+
+    it("should use the pending indicator for sleeping miners", async () => {
+      const { useMinerStatus } = await import("@/shared/hooks/useStatusSummary");
+      vi.mocked(useMinerStatus).mockReturnValue("Sleeping");
+
+      const miner = createMockMiner({ deviceStatus: DeviceStatus.INACTIVE });
+
+      render(<MinerStatus miner={miner} errors={[]} activeBatches={[]} errorsLoaded />);
+
+      expect(screen.getByText("Sleeping")).toBeInTheDocument();
+      expect(screen.getByTestId("miner-status-indicator")).toHaveAttribute("data-status", "pending");
+    });
   });
 
   describe("Status after pool assignment", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.test.tsx
@@ -229,6 +229,18 @@ describe("MinerStatus", () => {
       expect(screen.getByText("Sleeping")).toBeInTheDocument();
       expect(screen.getByTestId("miner-status-indicator")).toHaveAttribute("data-status", "sleeping");
     });
+
+    it("should use the inactive indicator for offline miners", async () => {
+      const { useMinerStatus } = await import("@/shared/hooks/useStatusSummary");
+      vi.mocked(useMinerStatus).mockReturnValue("Offline");
+
+      const miner = createMockMiner({ deviceStatus: DeviceStatus.OFFLINE });
+
+      render(<MinerStatus miner={miner} errors={[]} activeBatches={[]} errorsLoaded />);
+
+      expect(screen.getByText("Offline")).toBeInTheDocument();
+      expect(screen.getByTestId("miner-status-indicator")).toHaveAttribute("data-status", "inactive");
+    });
   });
 
   describe("Status after pool assignment", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.test.tsx
@@ -218,7 +218,7 @@ describe("MinerStatus", () => {
       expect(screen.getByText("Needs attention")).toBeInTheDocument();
     });
 
-    it("should use the pending indicator for sleeping miners", async () => {
+    it("should use the sleeping indicator for sleeping miners", async () => {
       const { useMinerStatus } = await import("@/shared/hooks/useStatusSummary");
       vi.mocked(useMinerStatus).mockReturnValue("Sleeping");
 
@@ -227,7 +227,7 @@ describe("MinerStatus", () => {
       render(<MinerStatus miner={miner} errors={[]} activeBatches={[]} errorsLoaded />);
 
       expect(screen.getByText("Sleeping")).toBeInTheDocument();
-      expect(screen.getByTestId("miner-status-indicator")).toHaveAttribute("data-status", "pending");
+      expect(screen.getByTestId("miner-status-indicator")).toHaveAttribute("data-status", "sleeping");
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.tsx
@@ -71,7 +71,10 @@ const MinerStatus = ({ miner, errors, activeBatches, errorsLoaded, isRefreshing,
   // Priority: (offline | sleeping) > needs attention > normal
   // Note: isSleeping is already filtered to exclude auth-needed devices
   const circleStatus = useMemo(() => {
-    if (isOffline || isSleeping) {
+    if (isSleeping) {
+      return statuses.pending;
+    }
+    if (isOffline) {
       return statuses.sleeping;
     }
     if (needsAttention) {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.tsx
@@ -68,14 +68,14 @@ const MinerStatus = ({ miner, errors, activeBatches, errorsLoaded, isRefreshing,
   const status = useMinerStatus(isOffline, isSleeping, needsAttention);
 
   // Determine StatusCircle visual indicator based on flags
-  // Priority: (offline | sleeping) > needs attention > normal
+  // Priority: sleeping > offline > needs attention > normal
   // Note: isSleeping is already filtered to exclude auth-needed devices
   const circleStatus = useMemo(() => {
     if (isSleeping) {
-      return statuses.pending;
+      return statuses.sleeping;
     }
     if (isOffline) {
-      return statuses.sleeping;
+      return statuses.inactive;
     }
     if (needsAttention) {
       return statuses.error;

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.tsx
@@ -68,14 +68,14 @@ const MinerStatus = ({ miner, errors, activeBatches, errorsLoaded, isRefreshing,
   const status = useMinerStatus(isOffline, isSleeping, needsAttention);
 
   // Determine StatusCircle visual indicator based on flags
-  // Priority: sleeping > offline > needs attention > normal
+  // Priority: offline > sleeping > needs attention > normal
   // Note: isSleeping is already filtered to exclude auth-needed devices
   const circleStatus = useMemo(() => {
-    if (isSleeping) {
-      return statuses.sleeping;
-    }
     if (isOffline) {
       return statuses.inactive;
+    }
+    if (isSleeping) {
+      return statuses.sleeping;
     }
     if (needsAttention) {
       return statuses.error;

--- a/client/src/shared/components/StatusCircle/StatusCircle.tsx
+++ b/client/src/shared/components/StatusCircle/StatusCircle.tsx
@@ -9,7 +9,7 @@ const statusColors = {
   warning: "text-intent-warning-fill",
   inactive: "text-grayscale-gray-50",
   pending: "text-intent-info-fill",
-  sleeping: "text-core-primary-20",
+  sleeping: "text-intent-info-fill",
 };
 
 const StatusCircle = ({


### PR DESCRIPTION
## Summary
- Show sleeping miners with the same blue status indicator used while waking
- Preserve the grey indicator for offline miners

## Test plan
- [ ] Open the miners table with a sleeping miner and confirm its status dot is blue
- [ ] Confirm offline miners still use the grey status dot
- [ ] Confirm MinerStatus unit coverage remains green

<img width="1006" height="589" alt="image" src="https://github.com/user-attachments/assets/bc085021-f7a4-4a61-82f3-e2a941929015" />
