### PR TITLE
Add curtailment settings E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -16,6 +16,7 @@ import { RacksPage } from "../pages/racks";
 import { ServerLogsPage } from "../pages/serverLogs";
 import { SettingsPage } from "../pages/settings";
 import { SettingsApiKeysPage } from "../pages/settingsApiKeys";
+import { SettingsCurtailmentPage } from "../pages/settingsCurtailment";
 import { SettingsFirmwarePage } from "../pages/settingsFirmware";
 import { SettingsPoolsPage } from "../pages/settingsPools";
 import { SettingsSchedulesPage } from "../pages/settingsSchedules";
@@ -33,6 +34,7 @@ type PageFixtures = {
   addMinersPage: AddMinersPage;
   settingsPage: SettingsPage;
   settingsFirmwarePage: SettingsFirmwarePage;
+  settingsCurtailmentPage: SettingsCurtailmentPage;
   settingsApiKeysPage: SettingsApiKeysPage;
   settingsSchedulesPage: SettingsSchedulesPage;
   settingsSecurityPage: SettingsSecurityPage;
@@ -75,6 +77,9 @@ export const test = base.extend<PageFixtures>({
   },
   settingsFirmwarePage: async ({ page, isMobile }, use) => {
     await use(new SettingsFirmwarePage(page, isMobile));
+  },
+  settingsCurtailmentPage: async ({ page, isMobile }, use) => {
+    await use(new SettingsCurtailmentPage(page, isMobile));
   },
   settingsApiKeysPage: async ({ page, isMobile }, use) => {
     await use(new SettingsApiKeysPage(page, isMobile));

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -211,6 +211,14 @@ export class BasePage {
     await expect(this.page).toHaveURL(/.*\/settings\/schedules/);
   }
 
+  async navigateToCurtailmentSettings() {
+    await this.clickNavigationMenuIfMobile();
+    await this.clickExpandSettingsIfMobile();
+    await this.navigateSettingsIfDesktop();
+    await this.page.getByTestId("secondary-nav").locator('a[href="/settings/curtailment"]').click();
+    await expect(this.page).toHaveURL(/.*\/settings\/curtailment/);
+  }
+
   async navigateToServerLogsSettings() {
     await this.clickNavigationMenuIfMobile();
     await this.clickExpandSettingsIfMobile();

--- a/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
+++ b/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
@@ -112,6 +112,7 @@ export class SettingsCurtailmentPage extends BasePage {
     const emptyState = this.page.getByText("No response profiles configured", { exact: true });
 
     await expect(this.page.getByRole("button", { name: "Create profile", exact: true })).toBeVisible();
+    await this.waitForLoadedSection(cards, emptyState, "curtailment-response-profiles-loading");
     await this.waitForStableCount(cards, emptyState);
   }
 
@@ -160,6 +161,7 @@ export class SettingsCurtailmentPage extends BasePage {
     const emptyState = this.page.getByText("No sources configured", { exact: true });
 
     await expect(this.page.getByRole("button", { name: "Add source", exact: true })).toBeVisible();
+    await this.waitForLoadedSection(rows, emptyState, "curtailment-sources-loading");
     await this.waitForStableCount(rows, emptyState);
   }
 
@@ -216,6 +218,17 @@ export class SettingsCurtailmentPage extends BasePage {
       const itemCountAfterDelay = await items.count();
       // eslint-disable-next-line playwright/prefer-to-have-count -- intentionally non-retrying: verifies count has stabilized
       expect(itemCountAfterDelay).toBe(itemCount);
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
+  }
+
+  private async waitForLoadedSection(items: Locator, emptyState: Locator, loadingTestId: string) {
+    await expect(this.page.getByTestId(loadingTestId)).toBeHidden();
+
+    await expect(async () => {
+      const itemCount = await items.count();
+      const isEmpty = await emptyState.isVisible().catch(() => false);
+
+      expect(itemCount > 0 || isEmpty).toBe(true);
     }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
   }
 }

--- a/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
+++ b/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
@@ -79,7 +79,7 @@ export class SettingsCurtailmentPage extends BasePage {
     await this.page.getByLabel("Port").fill(values.brokerPort);
     await this.page.getByLabel("Topic").fill(values.topic);
     await this.page.getByLabel("Username").fill(values.username);
-    await this.page.getByRole("textbox", { name: "Password", exact: true }).fill(values.password);
+    await this.page.locator("#source-password").fill(values.password);
   }
 
   async saveSource() {

--- a/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
+++ b/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
@@ -1,0 +1,221 @@
+import { expect, Locator } from "@playwright/test";
+import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
+import { BasePage } from "./base";
+
+export type ResponseProfileFormInput = {
+  name: string;
+  curtailBatchSize: string;
+  curtailBatchIntervalSec: string;
+  restoreBatchSize: string;
+  restoreBatchIntervalSec: string;
+};
+
+export type CurtailmentSourceFormInput = {
+  name: string;
+  brokerPrimaryHost: string;
+  brokerSecondaryHost: string;
+  brokerPort: string;
+  topic: string;
+  username: string;
+  password: string;
+};
+
+export class SettingsCurtailmentPage extends BasePage {
+  async validateCurtailmentPageOpened() {
+    await expect(this.page).toHaveURL(/.*\/settings\/curtailment/);
+    await expect(this.page.getByTestId("settings-curtailment-page")).toBeVisible();
+    await this.validateTitle("Curtailment");
+    await this.validateButtonIsVisible("Create profile");
+    await this.validateButtonIsVisible("Add source");
+  }
+
+  async openCreateResponseProfile() {
+    await this.clickButton("Create profile");
+    await expect(this.page.getByTestId("full-screen-two-pane-modal")).toBeVisible();
+    await expect(this.page.getByText("Create response profile")).toBeVisible();
+  }
+
+  async fillResponseProfile(values: ResponseProfileFormInput) {
+    await this.page.getByLabel("Profile name").fill(values.name);
+    await this.page.getByTestId("response-profile-curtail-batch-size").fill(values.curtailBatchSize);
+    await this.page.getByTestId("response-profile-curtail-batch-interval").fill(values.curtailBatchIntervalSec);
+    await this.page.getByTestId("response-profile-restore-batch-size").fill(values.restoreBatchSize);
+    await this.page.getByTestId("response-profile-restore-batch-interval").fill(values.restoreBatchIntervalSec);
+  }
+
+  async saveResponseProfile() {
+    await this.clickButton("Save profile");
+    await expect(this.page.getByTestId("full-screen-two-pane-modal")).toBeHidden();
+  }
+
+  async validateResponseProfileVisible(name: string) {
+    const card = this.getResponseProfileCard(name);
+    await expect(card).toBeVisible();
+    await expect(card.getByText("100% reduction", { exact: true })).toBeVisible();
+    await expect(card.getByText("Whole fleet", { exact: true })).toBeVisible();
+  }
+
+  async deleteResponseProfilesByPrefix(prefix: string) {
+    await this.waitForResponseProfilesToLoad();
+
+    const profileNames = await this.getResponseProfileNamesByPrefix(prefix);
+    for (const profileName of profileNames) {
+      await this.deleteResponseProfile(profileName);
+    }
+  }
+
+  async openAddSource() {
+    await this.clickButton("Add source");
+    await expect(this.page.getByTestId("curtailment-source-modal")).toBeVisible();
+    await expect(
+      this.page.getByTestId("curtailment-source-modal").getByText("Add source", { exact: true }),
+    ).toBeVisible();
+  }
+
+  async fillSource(values: CurtailmentSourceFormInput) {
+    await this.page.getByLabel("Configuration name").fill(values.name);
+    await this.page.getByLabel("Broker host 1").fill(values.brokerPrimaryHost);
+    await this.page.getByLabel("Broker host 2").fill(values.brokerSecondaryHost);
+    await this.page.getByLabel("Port").fill(values.brokerPort);
+    await this.page.getByLabel("Topic").fill(values.topic);
+    await this.page.getByLabel("Username").fill(values.username);
+    await this.page.getByRole("textbox", { name: "Password", exact: true }).fill(values.password);
+  }
+
+  async saveSource() {
+    await this.page.getByTestId("curtailment-source-modal").getByRole("button", { name: "Save", exact: true }).click();
+    await expect(this.page.getByTestId("curtailment-source-modal")).toBeHidden();
+  }
+
+  async validateSourceVisible(name: string) {
+    const row = this.getSourceRow(name);
+    await expect(row).toBeVisible();
+    await expect(row.getByText("-", { exact: true }).first()).toBeVisible();
+  }
+
+  async deleteSourcesByPrefix(prefix: string) {
+    await this.waitForSourcesToLoad();
+
+    const sourceNames = await this.getSourceNamesByPrefix(prefix);
+    for (const sourceName of sourceNames) {
+      await this.disableSource(sourceName);
+      await this.deleteSource(sourceName);
+    }
+  }
+
+  private getResponseProfileCard(name: string): Locator {
+    return this.page.getByTestId("response-profile-card").filter({ hasText: name });
+  }
+
+  private async waitForResponseProfilesToLoad() {
+    const cards = this.page.getByTestId("response-profile-card");
+    const emptyState = this.page.getByText("No response profiles configured", { exact: true });
+
+    await expect(this.page.getByRole("button", { name: "Create profile", exact: true })).toBeVisible();
+    await this.waitForStableCount(cards, emptyState);
+  }
+
+  private async getResponseProfileNamesByPrefix(prefix: string): Promise<string[]> {
+    const cards = await this.page.getByTestId("response-profile-card").all();
+    const profileNames: string[] = [];
+
+    for (const card of cards) {
+      const name = (await card.locator("div").first().textContent())?.trim();
+      if (name?.startsWith(prefix)) {
+        profileNames.push(name);
+      }
+    }
+
+    return profileNames;
+  }
+
+  private async deleteResponseProfile(name: string) {
+    const card = this.getResponseProfileCard(name);
+    await expect(card).toBeVisible();
+    await card.getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(this.page.getByText("Edit response profile")).toBeVisible();
+    await this.clickResponseProfileDelete();
+    await expect(this.page.getByTestId("full-screen-two-pane-modal")).toBeHidden();
+    await expect(card).toHaveCount(0);
+  }
+
+  private async clickResponseProfileDelete() {
+    if (this.isMobile) {
+      await this.page.getByTestId("overflow-menu-trigger").click();
+      await this.page.getByRole("button", { name: "Delete", exact: true }).click();
+      return;
+    }
+
+    await this.clickButton("Delete");
+  }
+
+  private getSourceRow(name: string): Locator {
+    return this.page.getByTestId("list-row").filter({
+      has: this.page.getByTestId("name").getByText(name, { exact: true }),
+    });
+  }
+
+  private async waitForSourcesToLoad() {
+    const rows = this.page.getByTestId("list-row");
+    const emptyState = this.page.getByText("No sources configured", { exact: true });
+
+    await expect(this.page.getByRole("button", { name: "Add source", exact: true })).toBeVisible();
+    await this.waitForStableCount(rows, emptyState);
+  }
+
+  private async getSourceNamesByPrefix(prefix: string): Promise<string[]> {
+    const rows = await this.page.getByTestId("list-row").all();
+    const sourceNames: string[] = [];
+
+    for (const row of rows) {
+      const name = (await row.getByTestId("name").textContent())?.trim();
+      if (name?.startsWith(prefix)) {
+        sourceNames.push(name);
+      }
+    }
+
+    return sourceNames;
+  }
+
+  private async deleteSource(name: string) {
+    const row = this.getSourceRow(name);
+    await expect(row).toBeVisible();
+    await row.click();
+    await expect(
+      this.page.getByTestId("curtailment-source-modal").getByText("Edit source", { exact: true }),
+    ).toBeVisible();
+    await this.page
+      .getByTestId("curtailment-source-modal")
+      .getByRole("button", { name: "Delete", exact: true })
+      .click();
+    await expect(this.page.getByTestId("curtailment-source-modal")).toBeHidden();
+    await expect(row).toHaveCount(0);
+  }
+
+  private async disableSource(name: string) {
+    const row = this.getSourceRow(name);
+    await expect(row).toBeVisible();
+
+    const enabledSwitch = row.locator('input[type="checkbox"]');
+    if (!(await enabledSwitch.isChecked())) {
+      return;
+    }
+
+    await row.locator('input[type="checkbox"] + span').click();
+    await expect(enabledSwitch).not.toBeChecked();
+  }
+
+  private async waitForStableCount(items: Locator, emptyState: Locator) {
+    if (await emptyState.isVisible().catch(() => false)) {
+      return;
+    }
+
+    await expect(async () => {
+      const itemCount = await items.count();
+      await new Promise((resolve) => setTimeout(resolve, DEFAULT_INTERVAL));
+      const itemCountAfterDelay = await items.count();
+      // eslint-disable-next-line playwright/prefer-to-have-count -- intentionally non-retrying: verifies count has stabilized
+      expect(itemCountAfterDelay).toBe(itemCount);
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
+  }
+}

--- a/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
+++ b/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
@@ -121,7 +121,7 @@ export class SettingsCurtailmentPage extends BasePage {
     const profileNames: string[] = [];
 
     for (const card of cards) {
-      const name = (await card.locator("div").first().textContent())?.trim();
+      const name = (await card.getByTestId("response-profile-name").textContent())?.trim();
       if (name?.startsWith(prefix)) {
         profileNames.push(name);
       }

--- a/client/e2eTests/protoFleet/spec/curtailmentSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailmentSettings.spec.ts
@@ -1,0 +1,159 @@
+import { testConfig } from "../config/test.config";
+import { expect, test } from "../fixtures/pageFixtures";
+import { CommonSteps } from "../helpers/commonSteps";
+import { generateRandomText } from "../helpers/testDataHelper";
+import { AuthPage } from "../pages/auth";
+import { MinersPage } from "../pages/miners";
+import { SettingsCurtailmentPage } from "../pages/settingsCurtailment";
+
+const RESPONSE_PROFILE_PREFIX = "curtailment_profile_e2e";
+const SOURCE_PREFIX = "curtailment_source_e2e";
+
+test.describe("Proto Fleet - Curtailment Settings", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test.afterEach("CLEANUP: Delete curtailment settings created during tests", async ({ browser }, testInfo) => {
+    const isMobile = testInfo.project.use?.isMobile ?? false;
+    const viewport = testInfo.project.use?.viewport;
+    const context = await browser.newContext({ baseURL: testConfig.baseUrl, viewport });
+
+    try {
+      const page = await context.newPage();
+      await page.goto("/");
+
+      const authPage = new AuthPage(page, isMobile);
+      const minersPage = new MinersPage(page, isMobile);
+      const settingsCurtailmentPage = new SettingsCurtailmentPage(page, isMobile);
+      const commonSteps = new CommonSteps(authPage, minersPage);
+
+      await commonSteps.loginAsAdmin();
+      await settingsCurtailmentPage.navigateToCurtailmentSettings();
+      await settingsCurtailmentPage.deleteSourcesByPrefix(SOURCE_PREFIX);
+      await settingsCurtailmentPage.deleteResponseProfilesByPrefix(RESPONSE_PROFILE_PREFIX);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("Create and delete curtailment response profiles and sources", async ({
+    commonSteps,
+    page,
+    settingsCurtailmentPage,
+  }) => {
+    const responseProfileName = generateRandomText(RESPONSE_PROFILE_PREFIX);
+    const sourceName = generateRandomText(SOURCE_PREFIX);
+    const sourceInput = {
+      name: sourceName,
+      brokerPrimaryHost: "127.0.0.1",
+      brokerSecondaryHost: "127.0.0.2",
+      brokerPort: "1883",
+      topic: `curtailment/e2e/${sourceName}/target`,
+      username: "curtailment-e2e",
+      password: "curtailment-e2e-password",
+    };
+
+    await test.step("Log in as admin", async () => {
+      await commonSteps.loginAsAdmin();
+    });
+
+    await test.step("Navigate to curtailment settings", async () => {
+      await settingsCurtailmentPage.navigateToCurtailmentSettings();
+      await settingsCurtailmentPage.validateCurtailmentPageOpened();
+    });
+
+    let createProfileRequest!: Awaited<ReturnType<typeof page.waitForRequest>>;
+
+    await test.step("Create a whole-fleet response profile", async () => {
+      await settingsCurtailmentPage.openCreateResponseProfile();
+      await settingsCurtailmentPage.fillResponseProfile({
+        name: responseProfileName,
+        curtailBatchSize: "25",
+        curtailBatchIntervalSec: "60",
+        restoreBatchSize: "10",
+        restoreBatchIntervalSec: "120",
+      });
+
+      [createProfileRequest] = await Promise.all([
+        page.waitForRequest(/CreateCurtailmentResponseProfile/),
+        settingsCurtailmentPage.saveResponseProfile(),
+      ]);
+    });
+
+    await test.step("Validate the response profile payload and card", async () => {
+      const requestBody = createProfileRequest.postDataJSON() as {
+        profileName?: string;
+        mode?: string;
+        strategy?: string;
+        level?: string;
+        priority?: string;
+        curtailBatchSize?: number;
+        curtailBatchIntervalSec?: number;
+        restoreBatchSize?: number;
+        restoreBatchIntervalSec?: number;
+        includeMaintenance?: boolean;
+        forceIncludeMaintenance?: boolean;
+      };
+
+      expect(createProfileRequest.method()).toBe("POST");
+      expect(requestBody.profileName).toBe(responseProfileName);
+      expect(requestBody.mode).toBe("CURTAILMENT_MODE_FULL_FLEET");
+      expect(requestBody.strategy).toBe("CURTAILMENT_STRATEGY_LEAST_EFFICIENT_FIRST");
+      expect(requestBody.level).toBe("CURTAILMENT_LEVEL_FULL");
+      expect(requestBody.priority).toBe("CURTAILMENT_PRIORITY_NORMAL");
+      expect(requestBody.curtailBatchSize).toBe(25);
+      expect(requestBody.curtailBatchIntervalSec).toBe(60);
+      expect(requestBody.restoreBatchSize).toBe(10);
+      expect(requestBody.restoreBatchIntervalSec).toBe(120);
+      expect(requestBody.includeMaintenance).toBe(true);
+      expect(requestBody.forceIncludeMaintenance).toBe(true);
+      await settingsCurtailmentPage.validateResponseProfileVisible(responseProfileName);
+    });
+
+    let createSourceRequest!: Awaited<ReturnType<typeof page.waitForRequest>>;
+
+    await test.step("Create an MQTT curtailment source", async () => {
+      await settingsCurtailmentPage.openAddSource();
+      await settingsCurtailmentPage.fillSource(sourceInput);
+
+      [createSourceRequest] = await Promise.all([
+        page.waitForRequest(/CreateMqttCurtailmentSource/),
+        settingsCurtailmentPage.saveSource(),
+      ]);
+    });
+
+    await test.step("Validate the source payload and row", async () => {
+      const requestBody = createSourceRequest.postDataJSON() as {
+        sourceName?: string;
+        topic?: string;
+        brokerPrimaryHost?: string;
+        brokerSecondaryHost?: string;
+        brokerPort?: number;
+        brokerTransport?: string;
+        mqttUsername?: string;
+        mqttPassword?: string;
+        payloadFormat?: string;
+        stalenessThresholdSec?: number;
+      };
+
+      expect(createSourceRequest.method()).toBe("POST");
+      expect(requestBody.sourceName).toBe(sourceName);
+      expect(requestBody.topic).toBe(sourceInput.topic);
+      expect(requestBody.brokerPrimaryHost).toBe(sourceInput.brokerPrimaryHost);
+      expect(requestBody.brokerSecondaryHost).toBe(sourceInput.brokerSecondaryHost);
+      expect(requestBody.brokerPort).toBe(Number(sourceInput.brokerPort));
+      expect(requestBody.brokerTransport).toBe("tcp");
+      expect(requestBody.mqttUsername).toBe(sourceInput.username);
+      expect(requestBody.mqttPassword).toBe(sourceInput.password);
+      expect(requestBody.payloadFormat).toBe("target_timestamp");
+      expect(requestBody.stalenessThresholdSec).toBe(240);
+      await settingsCurtailmentPage.validateSourceVisible(sourceName);
+    });
+
+    await test.step("Delete the created curtailment settings", async () => {
+      await settingsCurtailmentPage.deleteSourcesByPrefix(SOURCE_PREFIX);
+      await settingsCurtailmentPage.deleteResponseProfilesByPrefix(RESPONSE_PROFILE_PREFIX);
+    });
+  });
+});

--- a/client/e2eTests/protoFleet/spec/curtailmentSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailmentSettings.spec.ts
@@ -1,3 +1,4 @@
+import type { Page, Request, TestInfo } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
 import { CommonSteps } from "../helpers/commonSteps";
@@ -6,44 +7,157 @@ import { AuthPage } from "../pages/auth";
 import { MinersPage } from "../pages/miners";
 import { SettingsCurtailmentPage } from "../pages/settingsCurtailment";
 
-const RESPONSE_PROFILE_PREFIX = "curtailment_profile_e2e";
-const SOURCE_PREFIX = "curtailment_source_e2e";
+const RESPONSE_PROFILE_BASE_PREFIX = "curtailment_profile_e2e";
+const SOURCE_BASE_PREFIX = "curtailment_source_e2e";
+
+type CurtailmentRunPrefixes = {
+  responseProfilePrefix: string;
+  sourcePrefix: string;
+};
+
+type CreateResponseProfileRequestBody = {
+  profileName?: string;
+  mode?: string;
+  strategy?: string;
+  level?: string;
+  priority?: string;
+  curtailBatchSize?: number;
+  curtailBatchIntervalSec?: number;
+  restoreBatchSize?: number;
+  restoreBatchIntervalSec?: number;
+  includeMaintenance?: boolean;
+  forceIncludeMaintenance?: boolean;
+};
+
+type CreateSourceRequestBody = {
+  sourceName?: string;
+  topic?: string;
+  brokerPrimaryHost?: string;
+  brokerSecondaryHost?: string;
+  brokerPort?: number;
+  brokerTransport?: string;
+  mqttUsername?: string;
+  mqttPassword?: string;
+  payloadFormat?: string;
+  stalenessThresholdSec?: number;
+};
+
+const testRunPrefixes = new Map<string, CurtailmentRunPrefixes>();
+
+function getTestRunKey(testInfo: TestInfo): string {
+  return [testInfo.project.name, testInfo.testId, testInfo.workerIndex, testInfo.retry, testInfo.repeatEachIndex].join(
+    ":",
+  );
+}
+
+function getSafeProjectName(testInfo: TestInfo): string {
+  return (
+    testInfo.project.name
+      .replace(/[^a-zA-Z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .toLowerCase() || "project"
+  );
+}
+
+function createRunPrefixes(testInfo: TestInfo): CurtailmentRunPrefixes {
+  const runPrefix = `${getSafeProjectName(testInfo)}_${testInfo.workerIndex}_${testInfo.retry}`;
+
+  return {
+    responseProfilePrefix: generateRandomText(`${RESPONSE_PROFILE_BASE_PREFIX}_${runPrefix}`),
+    sourcePrefix: generateRandomText(`${SOURCE_BASE_PREFIX}_${runPrefix}`),
+  };
+}
+
+function getRunPrefixes(testInfo: TestInfo): CurtailmentRunPrefixes {
+  const prefixes = testRunPrefixes.get(getTestRunKey(testInfo));
+  if (!prefixes) {
+    throw new Error("Curtailment E2E run prefixes were not initialized.");
+  }
+
+  return prefixes;
+}
+
+function getRequestBody(request: Request): Record<string, unknown> {
+  try {
+    const requestBody = request.postDataJSON();
+    return typeof requestBody === "object" && requestBody !== null ? (requestBody as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function isCreateResponseProfileRequest(request: Request, profileName: string): boolean {
+  if (request.method() !== "POST" || !request.url().includes("CreateCurtailmentResponseProfile")) {
+    return false;
+  }
+
+  return getRequestBody(request).profileName === profileName;
+}
+
+function isCreateSourceRequest(request: Request, sourceName: string): boolean {
+  if (request.method() !== "POST" || !request.url().includes("CreateMqttCurtailmentSource")) {
+    return false;
+  }
+
+  return getRequestBody(request).sourceName === sourceName;
+}
+
+async function deleteCurtailmentSettingsCreatedForRun(page: Page, isMobile: boolean, prefixes: CurtailmentRunPrefixes) {
+  await page.goto("/");
+
+  const authPage = new AuthPage(page, isMobile);
+  const minersPage = new MinersPage(page, isMobile);
+  const settingsCurtailmentPage = new SettingsCurtailmentPage(page, isMobile);
+  const commonSteps = new CommonSteps(authPage, minersPage);
+
+  await commonSteps.loginAsAdmin();
+  await settingsCurtailmentPage.navigateToCurtailmentSettings();
+  await settingsCurtailmentPage.deleteSourcesByPrefix(prefixes.sourcePrefix);
+  await settingsCurtailmentPage.deleteResponseProfilesByPrefix(prefixes.responseProfilePrefix);
+}
 
 test.describe("Proto Fleet - Curtailment Settings", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testRunPrefixes.set(getTestRunKey(testInfo), createRunPrefixes(testInfo));
     await page.goto("/");
   });
 
-  test.afterEach("CLEANUP: Delete curtailment settings created during tests", async ({ browser }, testInfo) => {
+  test.afterEach("CLEANUP: Delete curtailment settings created during tests", async ({ browser, page }, testInfo) => {
     const isMobile = testInfo.project.use?.isMobile ?? false;
     const viewport = testInfo.project.use?.viewport;
-    const context = await browser.newContext({ baseURL: testConfig.baseUrl, viewport });
+    const runKey = getTestRunKey(testInfo);
+    const prefixes = testRunPrefixes.get(runKey);
+
+    if (!prefixes) {
+      return;
+    }
 
     try {
-      const page = await context.newPage();
-      await page.goto("/");
+      if (!page.isClosed()) {
+        await deleteCurtailmentSettingsCreatedForRun(page, isMobile, prefixes);
+        return;
+      }
 
-      const authPage = new AuthPage(page, isMobile);
-      const minersPage = new MinersPage(page, isMobile);
-      const settingsCurtailmentPage = new SettingsCurtailmentPage(page, isMobile);
-      const commonSteps = new CommonSteps(authPage, minersPage);
-
-      await commonSteps.loginAsAdmin();
-      await settingsCurtailmentPage.navigateToCurtailmentSettings();
-      await settingsCurtailmentPage.deleteSourcesByPrefix(SOURCE_PREFIX);
-      await settingsCurtailmentPage.deleteResponseProfilesByPrefix(RESPONSE_PROFILE_PREFIX);
+      const context = await browser.newContext({ baseURL: testConfig.baseUrl, viewport });
+      try {
+        const cleanupPage = await context.newPage();
+        await deleteCurtailmentSettingsCreatedForRun(cleanupPage, isMobile, prefixes);
+      } finally {
+        await context.close();
+      }
     } finally {
-      await context.close();
+      testRunPrefixes.delete(runKey);
     }
   });
 
-  test("Create and delete curtailment response profiles and sources", async ({
+  test("Create curtailment response profiles and sources", async ({
     commonSteps,
     page,
     settingsCurtailmentPage,
-  }) => {
-    const responseProfileName = generateRandomText(RESPONSE_PROFILE_PREFIX);
-    const sourceName = generateRandomText(SOURCE_PREFIX);
+  }, testInfo) => {
+    const { responseProfilePrefix, sourcePrefix } = getRunPrefixes(testInfo);
+    const responseProfileName = generateRandomText(responseProfilePrefix);
+    const sourceName = generateRandomText(sourcePrefix);
     const sourceInput = {
       name: sourceName,
       brokerPrimaryHost: "127.0.0.1",
@@ -76,25 +190,13 @@ test.describe("Proto Fleet - Curtailment Settings", () => {
       });
 
       [createProfileRequest] = await Promise.all([
-        page.waitForRequest(/CreateCurtailmentResponseProfile/),
+        page.waitForRequest((request) => isCreateResponseProfileRequest(request, responseProfileName)),
         settingsCurtailmentPage.saveResponseProfile(),
       ]);
     });
 
     await test.step("Validate the response profile payload and card", async () => {
-      const requestBody = createProfileRequest.postDataJSON() as {
-        profileName?: string;
-        mode?: string;
-        strategy?: string;
-        level?: string;
-        priority?: string;
-        curtailBatchSize?: number;
-        curtailBatchIntervalSec?: number;
-        restoreBatchSize?: number;
-        restoreBatchIntervalSec?: number;
-        includeMaintenance?: boolean;
-        forceIncludeMaintenance?: boolean;
-      };
+      const requestBody = createProfileRequest.postDataJSON() as CreateResponseProfileRequestBody;
 
       expect(createProfileRequest.method()).toBe("POST");
       expect(requestBody.profileName).toBe(responseProfileName);
@@ -118,24 +220,13 @@ test.describe("Proto Fleet - Curtailment Settings", () => {
       await settingsCurtailmentPage.fillSource(sourceInput);
 
       [createSourceRequest] = await Promise.all([
-        page.waitForRequest(/CreateMqttCurtailmentSource/),
+        page.waitForRequest((request) => isCreateSourceRequest(request, sourceName)),
         settingsCurtailmentPage.saveSource(),
       ]);
     });
 
     await test.step("Validate the source payload and row", async () => {
-      const requestBody = createSourceRequest.postDataJSON() as {
-        sourceName?: string;
-        topic?: string;
-        brokerPrimaryHost?: string;
-        brokerSecondaryHost?: string;
-        brokerPort?: number;
-        brokerTransport?: string;
-        mqttUsername?: string;
-        mqttPassword?: string;
-        payloadFormat?: string;
-        stalenessThresholdSec?: number;
-      };
+      const requestBody = createSourceRequest.postDataJSON() as CreateSourceRequestBody;
 
       expect(createSourceRequest.method()).toBe("POST");
       expect(requestBody.sourceName).toBe(sourceName);
@@ -149,11 +240,6 @@ test.describe("Proto Fleet - Curtailment Settings", () => {
       expect(requestBody.payloadFormat).toBe("target_timestamp");
       expect(requestBody.stalenessThresholdSec).toBe(240);
       await settingsCurtailmentPage.validateSourceVisible(sourceName);
-    });
-
-    await test.step("Delete the created curtailment settings", async () => {
-      await settingsCurtailmentPage.deleteSourcesByPrefix(SOURCE_PREFIX);
-      await settingsCurtailmentPage.deleteResponseProfilesByPrefix(RESPONSE_PROFILE_PREFIX);
     });
   });
 });

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -573,7 +573,7 @@ function SourcesEmptyState(): ReactElement {
 function SourcesLoadingState(): ReactElement {
   return (
     <div className="flex min-h-[220px] w-full items-center justify-center py-14">
-      <ProgressCircular indeterminate />
+      <ProgressCircular indeterminate dataTestId="curtailment-sources-loading" />
     </div>
   );
 }
@@ -605,7 +605,7 @@ function ResponseProfilesEmptyState(): ReactElement {
 function ResponseProfilesLoadingState(): ReactElement {
   return (
     <div className="flex min-h-[220px] w-full items-center justify-center py-14">
-      <ProgressCircular indeterminate />
+      <ProgressCircular indeterminate dataTestId="curtailment-response-profiles-loading" />
     </div>
   );
 }

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -638,6 +638,7 @@ function ResponseProfileCard({ profile, onEdit }: ResponseProfileCardProps): Rea
       headerClassName="items-start bg-surface-elevated-base px-6 pt-6 pb-0"
       titleClassName="truncate text-emphasis-300 leading-5 font-semibold text-text-primary"
       bodyClassName="px-6 pt-0 pb-1"
+      testId="response-profile-card"
       headerAction={
         <Button
           variant={variants.secondary}

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -631,7 +631,7 @@ type ResponseProfileCardProps = {
 function ResponseProfileCard({ profile, onEdit }: ResponseProfileCardProps): ReactElement {
   return (
     <Card
-      title={profile.name}
+      title={<span data-testid="response-profile-name">{profile.name}</span>}
       type={cardType.default}
       className="curtailment-response-profile-card bg-surface-elevated-base shadow-100"
       headerTone="neutral"

--- a/client/src/shared/components/Card/Card.tsx
+++ b/client/src/shared/components/Card/Card.tsx
@@ -12,6 +12,7 @@ interface CardProps {
   headerAction?: ReactNode;
   headerClassName?: string;
   headerTone?: "neutral" | "status";
+  testId?: string;
   titleClassName?: string;
 }
 
@@ -22,12 +23,13 @@ const Card = ({
   headerAction,
   headerClassName,
   headerTone = "status",
+  testId,
   title,
   titleClassName,
   type,
 }: CardProps) => {
   return (
-    <div className={clsx("rounded-xl shadow-50", className)}>
+    <div className={clsx("rounded-xl shadow-50", className)} data-testid={testId}>
       <div
         className={clsx(
           "flex items-center justify-between gap-4 rounded-t-xl px-4 py-2",


### PR DESCRIPTION
## Summary
- Add Settings > Curtailment E2E coverage for response profiles and MQTT sources
- Add a page object with deterministic cleanup for created curtailment settings

## Test plan
- [ ] Run the curtailment settings Playwright spec on desktop
- [ ] Run the curtailment settings Playwright spec on mobile
- [ ] Confirm Settings > Curtailment response profile cards and source rows render after creation