### PR TITLE
feat(fleet): expose default-password remediation UX

### DIFF
--- a/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
+++ b/client/e2eTests/protoFleet/spec/01-miningPools.spec.ts
@@ -48,9 +48,10 @@ test.describe("Mining Pools", () => {
 
         await commonSteps.goToMinersPage();
 
-        const amountOfMiners = await minersPage.getMinersCount();
-        if (amountOfMiners > 0) {
+        const totalMiners = await minersPage.getMinersCount();
+        if (totalMiners > 0) {
           await minersPage.clickSelectAllCheckbox();
+          const amountOfMiners = await minersPage.getSelectedMinersCount();
           await minersPage.clickActionsMenuButton();
           await minersPage.clickEditMiningPoolButton();
           await loginModal.loginAsAdmin();

--- a/client/src/protoFleet/api/useDefaultPasswordMiners.test.ts
+++ b/client/src/protoFleet/api/useDefaultPasswordMiners.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useDefaultPasswordMiners from "./useDefaultPasswordMiners";
+import useFleet from "./useFleet";
+import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+
+vi.mock("./useFleet");
+
+describe("useDefaultPasswordMiners", () => {
+  const mockUseFleetReturn = {
+    minerIds: [],
+    miners: {},
+    totalMiners: 0,
+    hasMore: false,
+    isLoading: false,
+    hasInitialLoadCompleted: true,
+    loadMore: vi.fn(),
+    currentPage: 0,
+    hasPreviousPage: false,
+    goToNextPage: vi.fn(),
+    goToPrevPage: vi.fn(),
+    refetch: vi.fn(),
+    refreshCurrentPage: vi.fn(),
+    updateMinerWorkerName: vi.fn(),
+    mergeMiners: vi.fn(),
+    availableModels: [],
+    availableFirmwareVersions: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFleet).mockReturnValue(mockUseFleetReturn);
+  });
+
+  it("calls useFleet with default-password pairing status", () => {
+    renderHook(() => useDefaultPasswordMiners());
+
+    expect(useFleet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        pageSize: 100,
+        pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+      }),
+    );
+  });
+
+  it("passes through custom options", () => {
+    renderHook(() => useDefaultPasswordMiners({ pageSize: 50, enabled: false }));
+
+    expect(useFleet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        pageSize: 50,
+        pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+      }),
+    );
+  });
+
+  it("returns the same result as useFleet", () => {
+    const { result } = renderHook(() => useDefaultPasswordMiners());
+
+    expect(result.current).toEqual(mockUseFleetReturn);
+  });
+});

--- a/client/src/protoFleet/api/useDefaultPasswordMiners.ts
+++ b/client/src/protoFleet/api/useDefaultPasswordMiners.ts
@@ -1,0 +1,37 @@
+import useFleet from "./useFleet";
+import {
+  MinerListFilter,
+  MinerStateSnapshot,
+  PairingStatus,
+} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+
+type UseDefaultPasswordMinersOptions = {
+  pageSize?: number;
+  filter?: MinerListFilter;
+  enabled?: boolean;
+};
+
+type UseDefaultPasswordMinersReturn = {
+  minerIds: string[];
+  miners: Record<string, MinerStateSnapshot>;
+  totalMiners: number;
+  hasMore: boolean;
+  isLoading: boolean;
+  hasInitialLoadCompleted: boolean;
+  loadMore: () => void;
+  refetch: () => void;
+  availableModels: string[];
+};
+
+const useDefaultPasswordMiners = (options: UseDefaultPasswordMinersOptions = {}): UseDefaultPasswordMinersReturn => {
+  const { pageSize = 100, filter, enabled = true } = options;
+
+  return useFleet({
+    enabled,
+    pageSize,
+    filter,
+    pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+  }) as UseDefaultPasswordMinersReturn;
+};
+
+export default useDefaultPasswordMiners;

--- a/client/src/protoFleet/components/StatusModal/StatusModal.tsx
+++ b/client/src/protoFleet/components/StatusModal/StatusModal.tsx
@@ -9,12 +9,12 @@ import {
   transformFleetErrorsToShared,
 } from "./utils";
 import { ComponentType as ErrorComponentType, type ErrorMessage } from "@/protoFleet/api/generated/errors/v1/errors_pb";
-import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { StartMiningRequestSchema } from "@/protoFleet/api/generated/minercommand/v1/command_pb";
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { useDeviceErrors } from "@/protoFleet/api/useDeviceErrors";
 import { useMinerCommand } from "@/protoFleet/api/useMinerCommand";
 import { createDeviceSelector } from "@/protoFleet/features/fleetManagement/utils/deviceSelector";
+import { needsAuthentication as needsAuthFn } from "@/protoFleet/features/fleetManagement/utils/pairingRemediation";
 
 import { variants } from "@/shared/components/Button";
 import { StatusModal as SharedStatusModal } from "@/shared/components/StatusModal";
@@ -138,16 +138,15 @@ const ProtoFleetStatusModal = ({
   const sharedErrors = useMemo(() => transformFleetErrorsToShared(groupedErrors), [groupedErrors]);
 
   // Determine status flags from DeviceStatus and PairingStatus
-  const needsAuthentication = miner?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED;
+  const needsAuthentication = miner ? needsAuthFn(miner.pairingStatus) : false;
   const isOffline = miner?.deviceStatus === DeviceStatus.OFFLINE;
-  // When authentication is needed, we can't trust INACTIVE (or MAINTENANCE) status
-  // (could be sleeping OR showing as inactive/maintenance because we can't authenticate)
+  // When authentication is needed we can't trust INACTIVE (or MAINTENANCE) status because telemetry is gated.
   const isSleeping =
     (miner?.deviceStatus === DeviceStatus.INACTIVE || miner?.deviceStatus === DeviceStatus.MAINTENANCE) &&
     !needsAuthentication;
   const needsMiningPool = miner?.deviceStatus === DeviceStatus.NEEDS_MINING_POOL;
 
-  // Compute summary using shared hook (replaces API-provided summary)
+  // Compute summary using shared hook (replaces API-provided summary).
   const summary = useMinerStatusSummary(sharedErrors, isSleeping, isOffline, needsAuthentication, needsMiningPool);
 
   // getMinerStatus function - returns complete data including config
@@ -166,17 +165,11 @@ const ProtoFleetStatusModal = ({
       other: transformErrorsForModal(groupedErrors.other || [], deviceId, onClickHandler),
     };
 
-    // Check if miner is sleeping (offline state in fleet context)
-    // Don't show wake button if authentication is needed (can't trust INACTIVE/MAINTENANCE status)
-    const isMinersleeping =
-      (miner?.deviceStatus === DeviceStatus.INACTIVE || miner?.deviceStatus === DeviceStatus.MAINTENANCE) &&
-      !needsAuthentication;
-
     // Build buttons
     const buttons = [];
 
     // Add wake miner button if miner is sleeping
-    if (isMinersleeping) {
+    if (isSleeping) {
       buttons.push({
         text: "Wake miner",
         variant: variants.secondary,
@@ -198,7 +191,7 @@ const ProtoFleetStatusModal = ({
         title: summary.title,
         subtitle: summary.subtitle,
         errors: errorsBySource,
-        isSleeping: isMinersleeping,
+        isSleeping,
         isOffline,
         needsAuthentication,
         needsMiningPool,
@@ -215,6 +208,7 @@ const ProtoFleetStatusModal = ({
     handleWakeMiner,
     handleClose,
     isOffline,
+    isSleeping,
     needsAuthentication,
     needsMiningPool,
   ]);

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
@@ -3,6 +3,7 @@ import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POLL_INTERVAL_MS } from "./constants";
 import Fleet from "./Fleet";
+import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
 const { mockMinerList, mockRefetchAuthNeededMiners, mockRefetchErrors } = vi.hoisted(() => ({
   mockMinerList: vi.fn(() => <div data-testid="miner-list">MinerList</div>),
@@ -49,15 +50,6 @@ vi.mock("@/protoFleet/api/useDeviceSets", () => ({
   useDeviceSets: vi.fn(() => ({
     listGroups: vi.fn(),
     listRacks: vi.fn(),
-  })),
-}));
-
-vi.mock("@/protoFleet/api/useAuthNeededMiners", () => ({
-  default: vi.fn(() => ({
-    totalMiners: 0,
-    refetch: mockRefetchAuthNeededMiners,
-    hasInitialLoadCompleted: true,
-    isLoading: false,
   })),
 }));
 
@@ -245,6 +237,12 @@ describe("Fleet - Component Integration", () => {
         pageSize: 50,
       }),
     );
+    expect(useFleet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageSize: 1,
+        pairingStatuses: [PairingStatus.AUTHENTICATION_NEEDED],
+      }),
+    );
   });
 
   it("shows the loading state during sort refetches even when miners are already present", async () => {
@@ -268,13 +266,24 @@ describe("Fleet - Component Integration", () => {
     const mockRefetch = vi.fn();
     const mockRefreshCurrentPage = vi.fn();
 
-    vi.mocked(useFleetModule.default).mockReturnValue(
-      createFleetMock({
-        minerIds: ["miner-1"],
-        totalMiners: 1,
-        refetch: mockRefetch,
-        refreshCurrentPage: mockRefreshCurrentPage,
-      }),
+    vi.mocked(useFleetModule.default).mockImplementation(
+      (options: { pageSize?: number; pairingStatuses?: PairingStatus[] } = {}) => {
+        if (
+          options.pairingStatuses?.length === 1 &&
+          options.pairingStatuses?.includes(PairingStatus.AUTHENTICATION_NEEDED)
+        ) {
+          return createFleetMock({ refetch: mockRefetchAuthNeededMiners });
+        }
+        if (options.pageSize === 1) {
+          return createFleetMock();
+        }
+        return createFleetMock({
+          minerIds: ["miner-1"],
+          totalMiners: 1,
+          refetch: mockRefetch,
+          refreshCurrentPage: mockRefreshCurrentPage,
+        });
+      },
     );
 
     renderFleet();

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -12,9 +12,9 @@ import type { DeviceSet } from "@/protoFleet/api/generated/device_set/v1/device_
 import {
   type MinerListFilter,
   MinerListFilterSchema,
+  PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { buildKnownSiteIds } from "@/protoFleet/api/sites";
-import useAuthNeededMiners from "@/protoFleet/api/useAuthNeededMiners";
 import { useDeviceErrors } from "@/protoFleet/api/useDeviceErrors";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import useExportMinerListCsv from "@/protoFleet/api/useExportMinerListCsv";
@@ -80,6 +80,8 @@ const applySiteScopeToMinerFilter = (
   };
 };
 
+const AUTH_NEEDED_PAIRING_STATUSES = [PairingStatus.AUTHENTICATION_NEEDED];
+
 const Fleet = () => {
   const navigate = useNavigate();
   const { listGroups, listRacks } = useDeviceSets();
@@ -133,21 +135,22 @@ const Fleet = () => {
     } as const;
   }, [currentSortConfig]);
 
-  // Count of miners requiring authentication. Refetched in the polling loop
-  // below so the bulk-action gate releases promptly after a fleet-wide auth
-  // resolves (otherwise the count is stale-positive until the next manual
-  // refresh). `hasInitialLoadCompleted` is sticky across refetches, so it
-  // alone can't tell us the count matches the current filter — combine with
-  // `isLoading` to gate while any refetch is in flight.
+  // Count of miners blocked from normal bulk selection. Refetched in the
+  // polling loop below so the bulk-action gate releases promptly after
+  // authentication remediation resolves (otherwise the count is stale-positive
+  // until the next manual refresh). `hasInitialLoadCompleted` is sticky across
+  // refetches, so it alone can't tell us the count matches the current filter —
+  // combine with `isLoading` to gate while any refetch is in flight.
   const {
     totalMiners: totalAuthNeededMiners,
     refetch: refetchAuthNeededMiners,
     hasInitialLoadCompleted: totalAuthNeededMinersInitialLoadCompleted,
     isLoading: totalAuthNeededMinersLoading,
-  } = useAuthNeededMiners({
+  } = useFleet({
     pageSize: 1,
     filter: currentFilter,
     enabled: !siteScopeMatchesNoRows,
+    pairingStatuses: AUTH_NEEDED_PAIRING_STATUSES,
   });
   const totalAuthNeededMinersFresh = totalAuthNeededMinersInitialLoadCompleted && !totalAuthNeededMinersLoading;
   const { exportCsv, isExportingCsv } = useExportMinerListCsv({

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.test.tsx
@@ -243,6 +243,13 @@ const buildPopoverActions = () => [
     actionHandler: vi.fn(),
     requiresConfirmation: false,
   },
+  {
+    action: settingsActions.security,
+    title: "Manage security",
+    icon: null,
+    actionHandler: vi.fn(),
+    requiresConfirmation: false,
+  },
 ];
 
 const makeMinerActions = () => ({
@@ -503,6 +510,36 @@ describe("FleetGroupActionsMenu", () => {
     expect(onActionComplete).toHaveBeenCalledOnce();
   });
 
+  it("allows normal scoped actions when scoped miners need a password change", async () => {
+    mockListMinerStateSnapshots.mockResolvedValueOnce({
+      miners: [{ deviceIdentifier: "miner-a", pairingStatus: PairingStatus.DEFAULT_PASSWORD }],
+      cursor: "",
+    });
+    const onActionComplete = vi.fn();
+
+    render(
+      <FleetGroupActionsMenu
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
+        ariaLabel="Actions for Alpha"
+        testIdPrefix="alpha"
+        onActionComplete={onActionComplete}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("alpha-trigger"));
+    fireEvent.click(screen.getByText("Reboot miners"));
+
+    await waitFor(() => {
+      const reboot = mockUseMinerActions.mock.results
+        .flatMap((result) => (result.value as ReturnType<typeof makeMinerActions>).popoverActions)
+        .find((entry) => entry.action === deviceActions.reboot);
+      expect(reboot?.actionHandler).toHaveBeenCalledTimes(1);
+    });
+    expect(mockPushToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("need authentication") }),
+    );
+    expect(onActionComplete).not.toHaveBeenCalled();
+  });
+
   it("allows unpair when scoped miners need authentication", async () => {
     mockListMinerStateSnapshots.mockResolvedValueOnce({
       miners: [{ deviceIdentifier: "miner-a", pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }],
@@ -528,6 +565,65 @@ describe("FleetGroupActionsMenu", () => {
     expect(mockPushToast).not.toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining("need authentication") }),
     );
+  });
+
+  it("allows manage security when scoped miners need a password change", async () => {
+    mockListMinerStateSnapshots.mockResolvedValueOnce({
+      miners: [{ deviceIdentifier: "miner-a", pairingStatus: PairingStatus.DEFAULT_PASSWORD }],
+      cursor: "",
+    });
+
+    render(
+      <FleetGroupActionsMenu
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
+        ariaLabel="Actions for Alpha"
+        testIdPrefix="alpha"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("alpha-trigger"));
+    fireEvent.click(screen.getByText("Manage security"));
+
+    await waitFor(() => {
+      const security = mockUseMinerActions.mock.results
+        .flatMap((result) => (result.value as ReturnType<typeof makeMinerActions>).popoverActions)
+        .find((entry) => entry.action === settingsActions.security);
+      expect(security?.actionHandler).toHaveBeenCalledTimes(1);
+    });
+    expect(mockPushToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("need authentication") }),
+    );
+  });
+
+  it("blocks manage security when scoped miners need authentication", async () => {
+    mockListMinerStateSnapshots.mockResolvedValueOnce({
+      miners: [{ deviceIdentifier: "miner-a", pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }],
+      cursor: "",
+    });
+    const onActionComplete = vi.fn();
+
+    render(
+      <FleetGroupActionsMenu
+        scopes={[{ kind: "building", id: 42n, name: "Alpha" }]}
+        ariaLabel="Actions for Alpha"
+        testIdPrefix="alpha"
+        onActionComplete={onActionComplete}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("alpha-trigger"));
+    fireEvent.click(screen.getByText("Manage security"));
+
+    await waitFor(() => {
+      expect(mockPushToast).toHaveBeenLastCalledWith({
+        message:
+          "Some miners in Alpha need authentication before this action can run. Unpair those miners or authenticate them first.",
+        status: "error",
+      });
+    });
+    const security = mockUseMinerActions.mock.results
+      .flatMap((result) => (result.value as ReturnType<typeof makeMinerActions>).popoverActions)
+      .find((entry) => entry.action === settingsActions.security);
+    expect(security?.actionHandler).not.toHaveBeenCalled();
+    expect(onActionComplete).toHaveBeenCalledOnce();
   });
 
   it("combines same-kind scopes into one snapshot filter and hides row-only extras", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupActionsMenu.tsx
@@ -8,7 +8,6 @@ import { fleetManagementClient } from "@/protoFleet/api/clients";
 import {
   MinerListFilterSchema,
   type MinerStateSnapshot,
-  PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import PoolSelectionPageWrapper from "@/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage";
 import { ACTION_PERMISSIONS } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/actionPermissions";
@@ -22,6 +21,7 @@ import {
 import MinerActionModalStack from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionModalStack";
 import { useMinerActions } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions";
 import { useBatchActions } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
+import { needsAuthentication } from "@/protoFleet/features/fleetManagement/utils/pairingRemediation";
 import { usePermissions } from "@/protoFleet/store";
 import {
   ChevronDown,
@@ -115,7 +115,12 @@ const MAX_MINERS = MAX_SNAPSHOT_PAGES * SNAPSHOT_PAGE_SIZE;
 const SCOPED_MINER_LOOKUP_PERMISSION = "miner:read";
 type ScopedMinerLookupResult = {
   deviceIdentifiers: string[];
-  includesUnauthenticatedMiner: boolean;
+  includesAuthenticationNeededMiner: boolean;
+};
+
+const isBlockedByCredentialState = (key: WiredActionKey, lookupResult: ScopedMinerLookupResult): boolean => {
+  if (key === deviceActions.unpair) return false;
+  return lookupResult.includesAuthenticationNeededMiner;
 };
 
 const pluralizeScopeKind = (kind: GroupScope["kind"], count: number) => {
@@ -204,6 +209,7 @@ const FleetGroupActionsMenu = ({
 
     const collected: string[] = [];
     const snapshotMap: Record<string, MinerStateSnapshot> = {};
+    let includesAuthenticationNeededMiner = false;
     const filterInit =
       scopeKind === "building"
         ? { buildingIds: scopeIds }
@@ -222,6 +228,7 @@ const FleetGroupActionsMenu = ({
       for (const miner of response.miners) {
         collected.push(miner.deviceIdentifier);
         snapshotMap[miner.deviceIdentifier] = miner;
+        if (needsAuthentication(miner.pairingStatus)) includesAuthenticationNeededMiner = true;
       }
       if (!response.cursor) {
         exhausted = true;
@@ -237,9 +244,7 @@ const FleetGroupActionsMenu = ({
     setMinerSnapshots(snapshotMap);
     return {
       deviceIdentifiers: collected,
-      includesUnauthenticatedMiner: Object.values(snapshotMap).some(
-        (miner) => miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED,
-      ),
+      includesAuthenticationNeededMiner,
     };
   }, [scopeIds, scopeKind, scopeLabel]);
 
@@ -284,7 +289,7 @@ const FleetGroupActionsMenu = ({
         onActionComplete?.();
         return;
       }
-      if (key !== deviceActions.unpair && lookupResult.includesUnauthenticatedMiner) {
+      if (isBlockedByCredentialState(key, lookupResult)) {
         pushToast({
           message: `Some miners in ${scopeLabel} need authentication before this action can run. Unpair those miners or authenticate them first.`,
           status: STATUSES.error,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
@@ -744,9 +744,34 @@ describe("MinerActionsMenu", () => {
 
       expect(unpair?.disabled).not.toBe(true);
       expect(reboot?.disabled).toBe(true);
-      expect(reboot?.disabledReason).toContain("authentication");
+      expect(reboot?.disabledReason).toContain("need authentication");
       expect(editPool?.disabled).toBe(true);
-      expect(editPool?.disabledReason).toContain("authentication");
+      expect(editPool?.disabledReason).toContain("need authentication");
+    });
+
+    test("leaves actions enabled when a DEFAULT_PASSWORD miner is selected", () => {
+      // Arrange
+      mockUseMinerActions.mockReturnValueOnce({
+        ...createMockMinerActionsReturn(null),
+        popoverActions: popoverActionsFixture,
+      });
+
+      // Act
+      render(
+        <MinerActionsMenu
+          selectedMiners={["miner-1", "miner-2"]}
+          selectionMode="subset"
+          totalCount={2}
+          miners={{
+            "miner-1": create(MinerStateSnapshotSchema, { pairingStatus: PairingStatus.DEFAULT_PASSWORD }),
+            "miner-2": create(MinerStateSnapshotSchema, { pairingStatus: PairingStatus.PAIRED }),
+          }}
+        />,
+      );
+
+      // Assert
+      const actions = readActions();
+      expect(actions.every((a) => a.disabled !== true)).toBe(true);
     });
 
     test("uses the parent override even when the miners map is empty (all-mode)", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -242,6 +242,9 @@ const MinerActionsMenu = ({
     }
     return selectedMinersWithStatus;
   }, [poolFilteredDeviceIds, selectedMinersWithStatus]);
+  const groupActionSelectedMinerIds = minerActionsResult.groupActionDeviceIds ?? selectedMiners;
+  const groupActionSelectionMode: SelectionMode = minerActionsResult.groupActionDeviceIds ? "subset" : selectionMode;
+  const groupActionDisplayCount = minerActionsResult.groupActionDeviceIds?.length ?? displayCount;
 
   const showQuickActions = !isPhone && !isTablet;
   const quickActions = useMemo(() => {
@@ -320,9 +323,9 @@ const MinerActionsMenu = ({
       />
       <MinerActionModalStack
         minerActions={minerActionsResult}
-        selectedMinerIds={selectedMiners}
-        selectionMode={selectionMode}
-        displayCount={displayCount}
+        selectedMinerIds={groupActionSelectedMinerIds}
+        selectionMode={groupActionSelectionMode}
+        displayCount={groupActionDisplayCount}
       />
       {/* The second AuthenticateFleetModal is specific to the worker-name
           flow, which only this menu hosts — keep it inline. */}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -312,7 +312,7 @@ const MinerActionsMenu = ({
       <PoolSelectionPageWrapper
         open={showPoolSelectionPage ? !!fleetCredentials : false}
         selectedMiners={poolMiners}
-        selectionMode={selectionMode}
+        selectionMode={poolFilteredDeviceIds ? "subset" : selectionMode}
         poolNeededCount={poolFilteredDeviceIds ? poolFilteredDeviceIds.length : totalCount}
         userUsername={fleetCredentials?.username}
         userPassword={fleetCredentials?.password}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -14,10 +14,10 @@ import type { SortConfig } from "@/protoFleet/api/generated/common/v1/sort_pb";
 import {
   type MinerListFilter,
   type MinerStateSnapshot,
-  PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import AuthenticateFleetModal from "@/protoFleet/features/auth/components/AuthenticateFleetModal";
 import { useBatchActions } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
+import { needsAuthentication } from "@/protoFleet/features/fleetManagement/utils/pairingRemediation";
 import { ChevronDown, Edit, MiningPools, Plus } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -85,7 +85,11 @@ const MinerActionsMenu = ({
     [selectedMiners],
   );
   const selectedIdsIncludeUnauthenticatedMiner = useMemo(
-    () => selectedMiners.some((id) => miners[id]?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED),
+    () =>
+      selectedMiners.some((id) => {
+        const status = miners[id]?.pairingStatus;
+        return status !== undefined && needsAuthentication(status);
+      }),
     [miners, selectedMiners],
   );
   const selectionIncludesUnauthenticatedMiner =
@@ -227,7 +231,7 @@ const MinerActionsMenu = ({
         : {
             ...action,
             disabled: true,
-            disabledReason: "Selection includes miners that need authentication.",
+            disabledReason: "Selection includes miners that need authentication before actions can run.",
           },
     );
   }, [permittedActions, selectionIncludesUnauthenticatedMiner]);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.test.tsx
@@ -1,8 +1,11 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
 
 import MinerReparentPicker from "./MinerReparentPicker";
 import { PerDeviceBuildingConflictReason } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { MinerListFilterSchema, PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 
 // Building-reparent flow only. The two-step force-clear confirm is the
 // part with branching logic: the server enumerates per-device conflicts,
@@ -92,8 +95,10 @@ const DIALOG_TITLE = "Move miners between buildings?";
 describe("MinerReparentPicker — building force-clear flow", () => {
   beforeEach(() => {
     mockAssignDevicesToBuilding.mockReset();
+    mockListMinerStateSnapshots.mockReset();
     mockPushToast.mockReset();
     mockPushToast.mockReturnValue(1);
+    mockListMinerStateSnapshots.mockResolvedValue({ miners: [], cursor: "" });
   });
 
   it("all-clearable conflicts open the confirm dialog; Continue re-dispatches with force=true", async () => {
@@ -140,6 +145,48 @@ describe("MinerReparentPicker — building force-clear flow", () => {
     );
     expect(screen.queryByText(DIALOG_TITLE)).not.toBeInTheDocument();
     expect(mockAssignDevicesToBuilding).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses selectable pairing statuses when resolving all-mode building moves", async () => {
+    mockListMinerStateSnapshots.mockResolvedValueOnce({
+      miners: [{ deviceIdentifier: "paired-miner" }, { deviceIdentifier: "default-password-miner" }],
+      cursor: "",
+    });
+    mockAssignDevicesToBuilding.mockImplementationOnce(({ onSuccess }) => {
+      onSuccess(2n, 2n);
+    });
+
+    render(
+      <MinerReparentPicker
+        kind="building"
+        deviceIdentifiers={["visible-page-miner"]}
+        selectionMode="all"
+        currentFilter={create(MinerListFilterSchema, { deviceStatus: [DeviceStatus.ERROR] })}
+        totalCount={2}
+        sourceLabel="2 miners"
+        successMessage={(count) => `Moved ${count} miner(s).`}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("pick-target"));
+
+    await waitFor(() => expect(mockAssignDevicesToBuilding).toHaveBeenCalledTimes(1));
+    expect(mockListMinerStateSnapshots).toHaveBeenCalledWith(
+      {
+        pageSize: 1000,
+        cursor: "",
+        filter: expect.objectContaining({
+          deviceStatus: [DeviceStatus.ERROR],
+          pairingStatuses: [PairingStatus.PAIRED, PairingStatus.DEFAULT_PASSWORD],
+        }),
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(mockAssignDevicesToBuilding.mock.calls[0][0].deviceIdentifiers).toEqual([
+      "paired-miner",
+      "default-password-miner",
+    ]);
   });
 });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
@@ -13,6 +13,7 @@ import {
 import { useSites } from "@/protoFleet/api/sites";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
+import { applyFleetSelectablePairingStatuses } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 import { variants } from "@/shared/components/Button";
 import Dialog from "@/shared/components/Dialog";
 import { pushToast, removeToast, STATUSES, updateToast } from "@/shared/features/toaster";
@@ -634,8 +635,7 @@ const MinerReparentPicker = ({
           let ids: string[];
           let snapshots: Record<string, MinerStateSnapshot> | undefined;
           if (selectionMode === "all") {
-            // Undefined filter = no URL filter params = full fleet.
-            const effectiveFilter = currentFilter ?? create(MinerListFilterSchema);
+            const effectiveFilter = applyFleetSelectablePairingStatuses(currentFilter);
             const loadingToast = pushToast({
               message: "Loading selected miners…",
               status: STATUSES.loading,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu.test.tsx
@@ -724,6 +724,33 @@ describe("SingleMinerActionsMenu", () => {
       expect(screen.queryByTestId("refreshStatus-popover-button")).not.toBeInTheDocument();
     });
 
+    it("keeps Manage security when allowSecurityAction is true (default-password remediation)", () => {
+      // Arrange
+      const actionsWithSecurity = [
+        ...allPopoverActions,
+        {
+          action: settingsActions.security,
+          title: "Manage security",
+          icon: null,
+          actionHandler: vi.fn(),
+          requiresConfirmation: false,
+        },
+      ] as any[];
+
+      // Act
+      renderWithActions(
+        { needsAuthentication: true, allowSecurityAction: true },
+        { popoverActions: actionsWithSecurity },
+      );
+      fireEvent.click(screen.getByTestId("single-miner-actions-menu-button"));
+
+      // Assert
+      expect(screen.getByText("Manage security")).toBeInTheDocument();
+      expect(screen.getByText("Unpair")).toBeInTheDocument();
+      expect(screen.queryByText("Reboot")).not.toBeInTheDocument();
+      expect(screen.queryByText("Edit pool")).not.toBeInTheDocument();
+    });
+
     it("does not disable the menu button when needsAuthentication is true", () => {
       renderWithActions({ needsAuthentication: true });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useManageSecurityFlow.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useManageSecurityFlow.ts
@@ -2,19 +2,17 @@ import { useCallback, useState } from "react";
 import { create } from "@bufbuild/protobuf";
 import { getLoadingMessage, minersMessage, settingsActions, SupportedAction } from "./constants";
 import { type MinerGroup } from "./ManageSecurity";
+import { fetchAllMinerSnapshots } from "@/protoFleet/api/fetchAllMinerSnapshots";
 import {
   type MinerListFilter,
+  MinerListFilterSchema,
   type MinerModelGroup,
   type MinerStateSnapshot,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
-import {
-  DeviceFilterSchema,
-  DeviceSelector,
-  DeviceSelectorSchema,
-  UpdateMinerPasswordResponse,
-} from "@/protoFleet/api/generated/minercommand/v1/command_pb";
+import { DeviceSelector, UpdateMinerPasswordResponse } from "@/protoFleet/api/generated/minercommand/v1/command_pb";
 import { minerTypes } from "@/protoFleet/features/fleetManagement/components/MinerList/constants";
 import { createDeviceSelector } from "@/protoFleet/features/fleetManagement/utils/deviceSelector";
+import { applyFleetSelectablePairingStatuses } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 import { type SelectionMode } from "@/shared/components/List";
 import { pushToast, STATUSES as TOAST_STATUSES } from "@/shared/features/toaster";
 
@@ -87,7 +85,7 @@ export interface SecurityActionsProps {
   showUpdatePasswordModal: boolean;
   hasThirdPartyMiners: boolean;
   handleFleetAuthenticated: (username: string, password: string) => void;
-  handlePasswordConfirm: (currentPassword: string, newPassword: string) => void;
+  handlePasswordConfirm: (currentPassword: string, newPassword: string) => void | Promise<void>;
   handlePasswordDismiss: () => void;
   handleAuthDismiss: () => void;
   showManageSecurityModal: boolean;
@@ -178,7 +176,7 @@ export const useManageSecurityFlow = ({
       if (selectionMode === "all") {
         // For "all" selection, query backend for accurate model groups across the full fleet
         try {
-          const groups = await getMinerModelGroups(currentFilter ?? null);
+          const groups = await getMinerModelGroups(applyFleetSelectablePairingStatuses(currentFilter));
           setMinerGroups(
             groups
               .filter((group) => securityModelGroupFilter?.(group) ?? true)
@@ -221,26 +219,33 @@ export const useManageSecurityFlow = ({
   }, [setCurrentAction, resetAuthState, onActionComplete]);
 
   const handlePasswordConfirm = useCallback(
-    (currentPassword: string, newPassword: string) => {
+    async (currentPassword: string, newPassword: string) => {
       let selectorToUse: DeviceSelector;
       let deviceIdsToUse: string[];
 
       if (selectionMode === "all" && currentGroupForUpdate) {
-        // For "all" selection, use a model-scoped all_devices selector so the command
-        // targets every fleet miner of this model, not just the visible page.
-        // Note: error_component_types filter has no equivalent in DeviceFilter and is not applied here.
-        selectorToUse = create(DeviceSelectorSchema, {
-          selectionType: {
-            case: "allDevices",
-            value: create(DeviceFilterSchema, {
-              models: [currentGroupForUpdate.model],
-              ...(currentGroupForUpdate.manufacturer ? { manufacturers: [currentGroupForUpdate.manufacturer] } : {}),
-              deviceStatus: currentFilter?.deviceStatus ?? [],
-              pairingStatus: currentFilter?.pairingStatuses ?? [],
-            }),
-          },
+        const scopedFilter = create(MinerListFilterSchema, {
+          ...applyFleetSelectablePairingStatuses(currentFilter),
+          models: [currentGroupForUpdate.model],
         });
-        deviceIdsToUse = currentGroupForUpdate.deviceIdentifiers;
+        const snapshots = await fetchAllMinerSnapshots(scopedFilter);
+        deviceIdsToUse = Object.values(snapshots)
+          .filter(
+            (miner) =>
+              miner.model === currentGroupForUpdate.model &&
+              (!currentGroupForUpdate.manufacturer || miner.manufacturer === currentGroupForUpdate.manufacturer),
+          )
+          .map((miner) => miner.deviceIdentifier);
+
+        if (deviceIdsToUse.length === 0) {
+          pushToast({
+            message: "No miners matched the selected filters.",
+            status: TOAST_STATUSES.error,
+          });
+          return;
+        }
+
+        selectorToUse = createDeviceSelector("subset", deviceIdsToUse);
       } else {
         const rawDeviceIds = currentGroupForUpdate
           ? currentGroupForUpdate.deviceIdentifiers

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useManageSecurityFlow.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useManageSecurityFlow.ts
@@ -19,8 +19,13 @@ import { type SelectionMode } from "@/shared/components/List";
 import { pushToast, STATUSES as TOAST_STATUSES } from "@/shared/features/toaster";
 
 type PendingActionCallback = (filteredSelector?: DeviceSelector, filteredDeviceIds?: string[]) => void;
+export type SecurityModelGroupFilter = (group: Pick<MinerModelGroup, "manufacturer" | "model" | "count">) => boolean;
 
-function groupMinersByModel(deviceIds: string[], miners: Record<string, MinerStateSnapshot>): MinerGroup[] {
+function groupMinersByModel(
+  deviceIds: string[],
+  miners: Record<string, MinerStateSnapshot>,
+  groupFilter?: SecurityModelGroupFilter,
+): MinerGroup[] {
   const groupMap = new Map<string, MinerGroup>();
 
   deviceIds.forEach((id) => {
@@ -32,6 +37,8 @@ function groupMinersByModel(deviceIds: string[], miners: Record<string, MinerSta
     const key = `${manufacturer}-${model}`;
 
     if (!groupMap.has(key)) {
+      if (groupFilter && !groupFilter({ manufacturer, model, count: 0 })) return;
+
       groupMap.set(key, {
         name: miner.name || model,
         model,
@@ -121,6 +128,7 @@ interface UseManageSecurityFlowParams {
   resetAuthState: () => void;
   miners?: Record<string, MinerStateSnapshot>;
   currentFilter?: MinerListFilter;
+  securityModelGroupFilter?: SecurityModelGroupFilter;
 }
 
 export const useManageSecurityFlow = ({
@@ -138,6 +146,7 @@ export const useManageSecurityFlow = ({
   resetAuthState,
   miners = {} as Record<string, MinerStateSnapshot>,
   currentFilter,
+  securityModelGroupFilter,
 }: UseManageSecurityFlowParams) => {
   const [showUpdatePasswordModal, setShowUpdatePasswordModal] = useState(false);
   const [securityFilteredDeviceIds, setSecurityFilteredDeviceIds] = useState<string[] | undefined>(undefined);
@@ -157,10 +166,10 @@ export const useManageSecurityFlow = ({
       const deviceIdsToUse = filteredDeviceIds ?? deviceIdentifiers;
       setSecurityFilteredDeviceIds(filteredDeviceIds);
       setCurrentAction(settingsActions.security);
-      setMinerGroups(groupMinersByModel(deviceIdsToUse, miners));
+      setMinerGroups(groupMinersByModel(deviceIdsToUse, miners, securityModelGroupFilter));
       setShowManageSecurityModal(true);
     });
-  }, [withCapabilityCheck, deviceIdentifiers, setCurrentAction, miners]);
+  }, [withCapabilityCheck, deviceIdentifiers, setCurrentAction, miners, securityModelGroupFilter]);
 
   // Called by useMinerActions once fleet auth completes with purpose="security".
   // Credentials are not needed here — they're read from the fleetCredentials param at confirm time.
@@ -171,17 +180,19 @@ export const useManageSecurityFlow = ({
         try {
           const groups = await getMinerModelGroups(currentFilter ?? null);
           setMinerGroups(
-            groups.map((g) => {
-              const isProto = g.manufacturer.toLowerCase() === minerTypes.protoRig;
-              return {
-                name: isProto ? `${g.manufacturer} ${g.model}`.trim() : g.model,
-                model: g.model,
-                manufacturer: g.manufacturer,
-                count: g.count,
-                deviceIdentifiers: [],
-                status: "pending" as const,
-              };
-            }),
+            groups
+              .filter((group) => securityModelGroupFilter?.(group) ?? true)
+              .map((g) => {
+                const isProto = g.manufacturer.toLowerCase() === minerTypes.protoRig;
+                return {
+                  name: isProto ? `${g.manufacturer} ${g.model}`.trim() : g.model,
+                  model: g.model,
+                  manufacturer: g.manufacturer,
+                  count: g.count,
+                  deviceIdentifiers: [],
+                  status: "pending" as const,
+                };
+              }),
           );
           setShowManageSecurityModal(true);
         } catch {
@@ -191,7 +202,7 @@ export const useManageSecurityFlow = ({
         await openSecurityModalViaCapabilityCheck();
       }
     },
-    [selectionMode, getMinerModelGroups, openSecurityModalViaCapabilityCheck, currentFilter],
+    [selectionMode, getMinerModelGroups, openSecurityModalViaCapabilityCheck, currentFilter, securityModelGroupFilter],
   );
 
   const handleUpdateGroup = useCallback((group: MinerGroup) => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useManageSecurityFlow.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useManageSecurityFlow.ts
@@ -129,6 +129,7 @@ interface UseManageSecurityFlowParams {
   miners?: Record<string, MinerStateSnapshot>;
   currentFilter?: MinerListFilter;
   securityModelGroupFilter?: SecurityModelGroupFilter;
+  useCurrentFilterForAllModePasswordUpdate?: boolean;
 }
 
 export const useManageSecurityFlow = ({
@@ -147,6 +148,7 @@ export const useManageSecurityFlow = ({
   miners = {} as Record<string, MinerStateSnapshot>,
   currentFilter,
   securityModelGroupFilter,
+  useCurrentFilterForAllModePasswordUpdate = false,
 }: UseManageSecurityFlowParams) => {
   const [showUpdatePasswordModal, setShowUpdatePasswordModal] = useState(false);
   const [securityFilteredDeviceIds, setSecurityFilteredDeviceIds] = useState<string[] | undefined>(undefined);
@@ -225,7 +227,19 @@ export const useManageSecurityFlow = ({
       let selectorToUse: DeviceSelector;
       let deviceIdsToUse: string[];
 
-      if (selectionMode === "all" && currentGroupForUpdate) {
+      if (selectionMode === "all" && currentGroupForUpdate && useCurrentFilterForAllModePasswordUpdate) {
+        selectorToUse = create(DeviceSelectorSchema, {
+          selectionType: {
+            case: "allDevices",
+            value: create(DeviceFilterSchema, {
+              models: currentFilter?.models ?? [],
+              deviceStatus: currentFilter?.deviceStatus ?? [],
+              pairingStatus: currentFilter?.pairingStatuses ?? [],
+            }),
+          },
+        });
+        deviceIdsToUse = currentGroupForUpdate.deviceIdentifiers;
+      } else if (selectionMode === "all" && currentGroupForUpdate) {
         // For "all" selection, use a model-scoped all_devices selector so the command
         // targets every fleet miner of this model, not just the visible page.
         // Note: error_component_types filter has no equivalent in DeviceFilter and is not applied here.
@@ -319,6 +333,7 @@ export const useManageSecurityFlow = ({
       startBatchOperation,
       setCurrentAction,
       currentFilter,
+      useCurrentFilterForAllModePasswordUpdate,
     ],
   );
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useManageSecurityFlow.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useManageSecurityFlow.ts
@@ -129,7 +129,6 @@ interface UseManageSecurityFlowParams {
   miners?: Record<string, MinerStateSnapshot>;
   currentFilter?: MinerListFilter;
   securityModelGroupFilter?: SecurityModelGroupFilter;
-  useCurrentFilterForAllModePasswordUpdate?: boolean;
 }
 
 export const useManageSecurityFlow = ({
@@ -148,7 +147,6 @@ export const useManageSecurityFlow = ({
   miners = {} as Record<string, MinerStateSnapshot>,
   currentFilter,
   securityModelGroupFilter,
-  useCurrentFilterForAllModePasswordUpdate = false,
 }: UseManageSecurityFlowParams) => {
   const [showUpdatePasswordModal, setShowUpdatePasswordModal] = useState(false);
   const [securityFilteredDeviceIds, setSecurityFilteredDeviceIds] = useState<string[] | undefined>(undefined);
@@ -227,19 +225,7 @@ export const useManageSecurityFlow = ({
       let selectorToUse: DeviceSelector;
       let deviceIdsToUse: string[];
 
-      if (selectionMode === "all" && currentGroupForUpdate && useCurrentFilterForAllModePasswordUpdate) {
-        selectorToUse = create(DeviceSelectorSchema, {
-          selectionType: {
-            case: "allDevices",
-            value: create(DeviceFilterSchema, {
-              models: currentFilter?.models ?? [],
-              deviceStatus: currentFilter?.deviceStatus ?? [],
-              pairingStatus: currentFilter?.pairingStatuses ?? [],
-            }),
-          },
-        });
-        deviceIdsToUse = currentGroupForUpdate.deviceIdentifiers;
-      } else if (selectionMode === "all" && currentGroupForUpdate) {
+      if (selectionMode === "all" && currentGroupForUpdate) {
         // For "all" selection, use a model-scoped all_devices selector so the command
         // targets every fleet miner of this model, not just the visible page.
         // Note: error_component_types filter has no equivalent in DeviceFilter and is not applied here.
@@ -333,7 +319,6 @@ export const useManageSecurityFlow = ({
       startBatchOperation,
       setCurrentAction,
       currentFilter,
-      useCurrentFilterForAllModePasswordUpdate,
     ],
   );
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -1211,6 +1211,10 @@ describe("useMinerActions", () => {
       const selector = calledWith.deleteMinersRequest.deviceSelector;
       expect(selector.selectionType.case).toBe("allDevices");
       expect(selector.selectionType.value.deviceStatus).toEqual([DeviceStatus.ERROR]);
+      expect(selector.selectionType.value.pairingStatuses).toEqual([
+        PairingStatus.PAIRED,
+        PairingStatus.DEFAULT_PASSWORD,
+      ]);
       expect(mockCompleteBatchOperation).toHaveBeenCalled();
       expect(toaster.updateToast).toHaveBeenCalledWith(
         expect.any(Number),
@@ -1252,7 +1256,48 @@ describe("useMinerActions", () => {
       const calledWith = mockDeleteMiners.mock.calls[0][0];
       const selector = calledWith.deleteMinersRequest.deviceSelector;
       expect(selector.selectionType.case).toBe("allDevices");
-      expect(selector.selectionType.value).toBeDefined();
+      expect(selector.selectionType.value.pairingStatuses).toEqual([
+        PairingStatus.PAIRED,
+        PairingStatus.DEFAULT_PASSWORD,
+      ]);
+    });
+
+    it("preserves explicit default-password filters for all-mode unpair", async () => {
+      mockDeleteMiners.mockImplementation(({ onSuccess }: any) => {
+        onSuccess({ deletedCount: 2 });
+      });
+
+      const activeFilter = createProto(MinerListFilterSchema, {
+        pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+      });
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [
+            { deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE },
+            { deviceIdentifier: "device-2", deviceStatus: DeviceStatus.ONLINE },
+          ],
+          selectionMode: "all",
+          totalCount: 2,
+          currentFilter: activeFilter,
+        }),
+      );
+
+      const deleteAction = result.current.popoverActions.find((a) => a.action === deviceActions.unpair);
+
+      act(() => {
+        deleteAction?.actionHandler();
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmation();
+      });
+
+      const calledWith = mockDeleteMiners.mock.calls[0][0];
+      const selector = calledWith.deleteMinersRequest.deviceSelector;
+      expect(selector.selectionType.case).toBe("allDevices");
+      expect(selector.selectionType.value.pairingStatuses).toEqual([PairingStatus.DEFAULT_PASSWORD]);
     });
 
     it("should use includeDevices selector in subset mode even with active filter", async () => {
@@ -2912,6 +2957,31 @@ describe("useMinerActions", () => {
       expect(group.manufacturer).toBe("Bitmain");
     });
 
+    it("filters all-mode security groups when a security model-group filter is provided", async () => {
+      mockGetMinerModelGroups.mockResolvedValue([
+        { model: "Rig", manufacturer: "Proto", count: 6 },
+        { model: "Rig", manufacturer: "Bitmain", count: 2 },
+      ]);
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
+          selectionMode: "all",
+          securityModelGroupFilter: (group) => group.manufacturer.toLowerCase() === "proto",
+        }),
+      );
+
+      await triggerSecurityAndAuthenticate(result);
+
+      expect(result.current.minerGroups).toHaveLength(1);
+      expect(result.current.minerGroups[0]).toMatchObject({
+        manufacturer: "Proto",
+        model: "Rig",
+        count: 6,
+      });
+    });
+
     it("falls back to capability check path when getMinerModelGroups throws", async () => {
       mockGetMinerModelGroups.mockRejectedValue(new Error("Network error"));
 
@@ -2934,19 +3004,47 @@ describe("useMinerActions", () => {
         efficiency: [],
         temperatureStatus: 0,
       } as unknown as MinerStateSnapshot;
+      testMiners["device-2"] = {
+        deviceIdentifier: "device-2",
+        manufacturer: "Bitmain",
+        model: "Rig",
+        name: "Bitmain Rig",
+        driverName: "antminer",
+        deviceStatus: 0,
+        pairingStatus: 0,
+        macAddress: "",
+        serialNumber: "",
+        ipAddress: "",
+        url: "",
+        firmwareVersion: "",
+        powerUsage: [],
+        temperature: [],
+        hashrate: [],
+        efficiency: [],
+        temperatureStatus: 0,
+      } as unknown as MinerStateSnapshot;
 
       const { result } = renderHook(() =>
         useMinerActions({
           ...batchOpsParams(),
-          selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
+          selectedMiners: [
+            { deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE },
+            { deviceIdentifier: "device-2", deviceStatus: DeviceStatus.ONLINE },
+          ],
           selectionMode: "all",
+          securityModelGroupFilter: (group) => group.manufacturer.toLowerCase() === "proto",
         }),
       );
 
       await triggerSecurityAndAuthenticate(result);
 
       expect(result.current.showManageSecurityModal).toBe(true);
-      expect(result.current.minerGroups.length).toBeGreaterThan(0);
+      expect(result.current.minerGroups).toHaveLength(1);
+      expect(result.current.minerGroups[0]).toMatchObject({
+        manufacturer: "proto",
+        model: "Rig",
+        count: 1,
+      });
     });
 
     it("uses allDevices selector with model and manufacturer filter in handlePasswordConfirm", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -3092,10 +3092,14 @@ describe("useMinerActions", () => {
       });
     });
 
-    it("uses allDevices selector with model and manufacturer filter in handlePasswordConfirm", async () => {
+    it("uses allDevices selector with model, manufacturer, and pairing filter in handlePasswordConfirm", async () => {
       mockGetMinerModelGroups.mockResolvedValue([{ model: "Rig", manufacturer: "Proto", count: 6 }]);
       mockUpdateMinerPassword.mockImplementation(({ onSuccess }: any) => {
         onSuccess({ batchIdentifier: "batch-security-all" });
+      });
+
+      const currentFilter = createProto(MinerListFilterSchema, {
+        pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
       });
 
       const { result } = renderHook(() =>
@@ -3103,6 +3107,7 @@ describe("useMinerActions", () => {
           ...batchOpsParams(),
           selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
           selectionMode: "all",
+          currentFilter,
         }),
       );
 
@@ -3120,44 +3125,7 @@ describe("useMinerActions", () => {
       expect(callArgs.deviceSelector.selectionType.case).toBe("allDevices");
       expect(callArgs.deviceSelector.selectionType.value.models).toEqual(["Rig"]);
       expect(callArgs.deviceSelector.selectionType.value.manufacturers).toEqual(["Proto"]);
-    });
-
-    it("can use the current filter directly for all-mode password updates", async () => {
-      mockGetMinerModelGroups.mockResolvedValue([{ model: "Rig", manufacturer: "Proto", count: 6 }]);
-      mockUpdateMinerPassword.mockImplementation(({ onSuccess }: any) => {
-        onSuccess({ batchIdentifier: "batch-security-all" });
-      });
-
-      const currentFilter = createProto(MinerListFilterSchema, {
-        models: ["Rig"],
-        pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
-      });
-
-      const { result } = renderHook(() =>
-        useMinerActions({
-          ...batchOpsParams(),
-          selectedMiners: [],
-          selectionMode: "all",
-          currentFilter,
-          securityUseCurrentFilterForAllModePasswordUpdate: true,
-        }),
-      );
-
-      await triggerSecurityAndAuthenticate(result);
-
-      const group = result.current.minerGroups[0];
-      await act(async () => {
-        result.current.handleUpdateGroup(group);
-      });
-      await act(async () => {
-        result.current.handlePasswordConfirm("oldpass", "newpass");
-      });
-
-      const callArgs = mockUpdateMinerPassword.mock.calls[0][0];
-      expect(callArgs.deviceSelector.selectionType.case).toBe("allDevices");
-      expect(callArgs.deviceSelector.selectionType.value.models).toEqual(["Rig"]);
       expect(callArgs.deviceSelector.selectionType.value.pairingStatus).toEqual([PairingStatus.DEFAULT_PASSWORD]);
-      expect(callArgs.deviceSelector.selectionType.value.manufacturers).toEqual([]);
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { create as createProto } from "@bufbuild/protobuf";
-import { deviceActions, performanceActions, settingsActions, type SupportedAction } from "./constants";
+import { deviceActions, groupActions, performanceActions, settingsActions, type SupportedAction } from "./constants";
 import { useMinerActions } from "./useMinerActions";
 import { CoolingMode } from "@/protoFleet/api/generated/common/v1/cooling_pb";
 import {
@@ -33,6 +33,7 @@ const mockDownloadLogs = vi.fn();
 const mockFirmwareUpdate = vi.fn();
 const mockGetCommandBatchLogBundle = vi.fn();
 const mockRenameSingleMiner = vi.fn();
+const mockListMinerStateSnapshots = vi.hoisted(() => vi.fn());
 const mockCheckCommandCapabilities = vi.fn(({ onSuccess }) => {
   // Default to all supported (no modal shown)
   onSuccess({
@@ -63,6 +64,12 @@ vi.mock("@/protoFleet/api/useMinerCommand", () => ({
     firmwareUpdate: mockFirmwareUpdate,
     getCommandBatchLogBundle: mockGetCommandBatchLogBundle,
   }),
+}));
+
+vi.mock("@/protoFleet/api/clients", () => ({
+  fleetManagementClient: {
+    listMinerStateSnapshots: mockListMinerStateSnapshots,
+  },
 }));
 
 const mockFetchCoolingMode = vi.fn(() => Promise.resolve(0)); // CoolingMode.UNSPECIFIED
@@ -116,6 +123,7 @@ describe("useMinerActions", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mockGetMinerModelGroups.mockResolvedValue([]);
+    mockListMinerStateSnapshots.mockResolvedValue({ miners: [], cursor: "" });
     testMiners = {};
   });
 
@@ -1854,6 +1862,51 @@ describe("useMinerActions", () => {
         PairingStatus.PAIRED,
         PairingStatus.DEFAULT_PASSWORD,
       ]);
+    });
+
+    it("resolves all-mode add-to-group actions to selectable device identifiers", async () => {
+      mockListMinerStateSnapshots.mockResolvedValueOnce({
+        miners: [
+          createProto(MinerStateSnapshotSchema, { deviceIdentifier: "paired-miner" }),
+          createProto(MinerStateSnapshotSchema, { deviceIdentifier: "default-password-miner" }),
+        ],
+        cursor: "",
+      });
+
+      const activeFilter = createProto(MinerListFilterSchema, {
+        deviceStatus: [DeviceStatus.ERROR],
+      });
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [{ deviceIdentifier: "page-miner", deviceStatus: DeviceStatus.ONLINE }],
+          selectionMode: "all",
+          totalCount: 2,
+          currentFilter: activeFilter,
+        }),
+      );
+
+      const addToGroupAction = result.current.popoverActions.find((a) => a.action === groupActions.addToGroup);
+
+      await act(async () => {
+        await addToGroupAction?.actionHandler();
+      });
+
+      expect(mockListMinerStateSnapshots).toHaveBeenCalledWith(
+        {
+          pageSize: 1000,
+          cursor: "",
+          filter: expect.objectContaining({
+            deviceStatus: [DeviceStatus.ERROR],
+            pairingStatuses: [PairingStatus.PAIRED, PairingStatus.DEFAULT_PASSWORD],
+          }),
+        },
+        { signal: undefined },
+      );
+      expect(result.current.groupActionDeviceIds).toEqual(["paired-miner", "default-password-miner"]);
+      expect(result.current.currentAction).toBe(groupActions.addToGroup);
+      expect(result.current.showAddToGroupModal).toBe(true);
     });
 
     it("should show unsupported miners modal with noneSupported flag when no miners support the action", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -120,11 +120,36 @@ describe("useMinerActions", () => {
     miners: testMiners,
   });
 
+  const makeSnapshot = (
+    deviceIdentifier: string,
+    overrides: Partial<Omit<MinerStateSnapshot, "$typeName" | "$unknown">> = {},
+  ) =>
+    createProto(MinerStateSnapshotSchema, {
+      deviceIdentifier,
+      manufacturer: "",
+      model: "",
+      name: "",
+      driverName: "",
+      deviceStatus: DeviceStatus.ONLINE,
+      pairingStatus: PairingStatus.PAIRED,
+      macAddress: "",
+      serialNumber: "",
+      ipAddress: "",
+      url: "",
+      firmwareVersion: "",
+      powerUsage: [],
+      temperature: [],
+      hashrate: [],
+      efficiency: [],
+      temperatureStatus: 0,
+      ...overrides,
+    });
+
   beforeEach(async () => {
     vi.clearAllMocks();
     mockGetMinerModelGroups.mockResolvedValue([]);
-    mockListMinerStateSnapshots.mockResolvedValue({ miners: [], cursor: "" });
     testMiners = {};
+    mockListMinerStateSnapshots.mockImplementation(async () => ({ miners: Object.values(testMiners), cursor: "" }));
   });
 
   describe("Basic hook initialization", () => {
@@ -382,7 +407,7 @@ describe("useMinerActions", () => {
   });
 
   describe("Blink LEDs action (immediate execution, no confirmation)", () => {
-    it("should call blinkLED API when blink action handler is called", () => {
+    it("should call blinkLED API when blink action handler is called", async () => {
       mockBlinkLED.mockImplementation(({ onSuccess }: any) => {
         onSuccess({ batchIdentifier: "batch-blink" });
       });
@@ -397,8 +422,8 @@ describe("useMinerActions", () => {
 
       const blinkAction = result.current.popoverActions.find((a) => a.action === deviceActions.blinkLEDs);
 
-      act(() => {
-        blinkAction?.actionHandler();
+      await act(async () => {
+        await blinkAction?.actionHandler();
       });
 
       expect(mockBlinkLED).toHaveBeenCalled();
@@ -409,7 +434,7 @@ describe("useMinerActions", () => {
       });
     });
 
-    it("should push loading toast when blink action is triggered", () => {
+    it("should push loading toast when blink action is triggered", async () => {
       mockBlinkLED.mockImplementation(({ onSuccess }: any) => {
         onSuccess({ batchIdentifier: "batch-blink" });
       });
@@ -424,8 +449,8 @@ describe("useMinerActions", () => {
 
       const blinkAction = result.current.popoverActions.find((a) => a.action === deviceActions.blinkLEDs);
 
-      act(() => {
-        blinkAction?.actionHandler();
+      await act(async () => {
+        await blinkAction?.actionHandler();
       });
 
       expect(toaster.pushToast).toHaveBeenCalledWith({
@@ -827,6 +852,71 @@ describe("useMinerActions", () => {
       expect(mockSetPowerTarget).toHaveBeenCalled();
     });
 
+    it("resolves all-mode command actions with the full active filter before dispatch", async () => {
+      mockSetPowerTarget.mockImplementation(({ onSuccess }: any) => {
+        onSuccess({ batchIdentifier: "batch-power" });
+      });
+      testMiners = {
+        "device-10": makeSnapshot("device-10"),
+        "device-20": makeSnapshot("device-20"),
+      };
+      const activeFilter = createProto(MinerListFilterSchema, {
+        deviceStatus: [DeviceStatus.ERROR],
+        siteIds: [10n],
+        buildingIds: [20n],
+        rackIds: [30n],
+        groupIds: [40n],
+        ipCidrs: ["172.16.0.0/16"],
+        firmwareVersions: ["2026.1"],
+      });
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [{ deviceIdentifier: "placeholder", deviceStatus: DeviceStatus.ONLINE }],
+          selectionMode: "all",
+          totalCount: 2,
+          currentFilter: activeFilter,
+        }),
+      );
+
+      const managePowerAction = result.current.popoverActions.find((a) => a.action === performanceActions.managePower);
+
+      await act(async () => {
+        await managePowerAction?.actionHandler();
+      });
+
+      expect(mockListMinerStateSnapshots).toHaveBeenCalledWith(
+        {
+          pageSize: 1000,
+          cursor: "",
+          filter: expect.objectContaining({
+            deviceStatus: [DeviceStatus.ERROR],
+            siteIds: [10n],
+            buildingIds: [20n],
+            rackIds: [30n],
+            groupIds: [40n],
+            ipCidrs: ["172.16.0.0/16"],
+            firmwareVersions: ["2026.1"],
+            pairingStatuses: [PairingStatus.PAIRED, PairingStatus.DEFAULT_PASSWORD],
+          }),
+        },
+        { signal: undefined },
+      );
+      expect(mockCheckCommandCapabilities.mock.calls[0][0].deviceSelector.selectionType.case).toBe("includeDevices");
+      expect(
+        mockCheckCommandCapabilities.mock.calls[0][0].deviceSelector.selectionType.value.deviceIdentifiers,
+      ).toEqual(["device-10", "device-20"]);
+
+      act(() => {
+        result.current.handleManagePowerConfirm(PerformanceMode.MAXIMUM_HASHRATE);
+      });
+
+      const setPowerTargetSelector = mockSetPowerTarget.mock.calls[0][0].deviceSelector;
+      expect(setPowerTargetSelector.selectionType.case).toBe("includeDevices");
+      expect(setPowerTargetSelector.selectionType.value.deviceIdentifiers).toEqual(["device-10", "device-20"]);
+    });
+
     it("should handle manage power dismiss", async () => {
       const onActionComplete = vi.fn();
 
@@ -1180,9 +1270,19 @@ describe("useMinerActions", () => {
       mockDeleteMiners.mockImplementation(({ onSuccess }: any) => {
         onSuccess({ deletedCount: 10 });
       });
+      testMiners = {
+        "device-1": makeSnapshot("device-1"),
+        "device-2": makeSnapshot("device-2"),
+      };
 
       const activeFilter = createProto(MinerListFilterSchema, {
         deviceStatus: [DeviceStatus.ERROR],
+        siteIds: [1n],
+        buildingIds: [2n],
+        rackIds: [3n],
+        groupIds: [4n],
+        ipCidrs: ["172.16.0.0/16"],
+        firmwareVersions: ["2026.1"],
       });
 
       const { result } = renderHook(() =>
@@ -1223,6 +1323,29 @@ describe("useMinerActions", () => {
         PairingStatus.PAIRED,
         PairingStatus.DEFAULT_PASSWORD,
       ]);
+      expect(selector.selectionType.value.siteIds).toEqual([1n]);
+      expect(selector.selectionType.value.buildingIds).toEqual([2n]);
+      expect(selector.selectionType.value.rackIds).toEqual([3n]);
+      expect(selector.selectionType.value.groupIds).toEqual([4n]);
+      expect(selector.selectionType.value.ipCidrs).toEqual(["172.16.0.0/16"]);
+      expect(selector.selectionType.value.firmwareVersions).toEqual(["2026.1"]);
+      expect(mockListMinerStateSnapshots).toHaveBeenCalledWith(
+        {
+          pageSize: 1000,
+          cursor: "",
+          filter: expect.objectContaining({
+            deviceStatus: [DeviceStatus.ERROR],
+            siteIds: [1n],
+            buildingIds: [2n],
+            rackIds: [3n],
+            groupIds: [4n],
+            ipCidrs: ["172.16.0.0/16"],
+            firmwareVersions: ["2026.1"],
+            pairingStatuses: [PairingStatus.PAIRED, PairingStatus.DEFAULT_PASSWORD],
+          }),
+        },
+        { signal: undefined },
+      );
       expect(mockCompleteBatchOperation).toHaveBeenCalled();
       expect(toaster.updateToast).toHaveBeenCalledWith(
         expect.any(Number),
@@ -1237,6 +1360,10 @@ describe("useMinerActions", () => {
       mockDeleteMiners.mockImplementation(({ onSuccess }: any) => {
         onSuccess({ deletedCount: 5 });
       });
+      testMiners = {
+        "device-1": makeSnapshot("device-1"),
+        "device-2": makeSnapshot("device-2"),
+      };
 
       const { result } = renderHook(() =>
         useMinerActions({
@@ -1274,6 +1401,10 @@ describe("useMinerActions", () => {
       mockDeleteMiners.mockImplementation(({ onSuccess }: any) => {
         onSuccess({ deletedCount: 2 });
       });
+      testMiners = {
+        "device-1": makeSnapshot("device-1"),
+        "device-2": makeSnapshot("device-2"),
+      };
 
       const activeFilter = createProto(MinerListFilterSchema, {
         pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
@@ -1820,6 +1951,10 @@ describe("useMinerActions", () => {
     });
 
     it("uses the selectable pairing filter for all-mode capability checks", async () => {
+      testMiners = {
+        "device-1": makeSnapshot("device-1"),
+        "device-2": makeSnapshot("device-2"),
+      };
       mockCheckCommandCapabilities.mockImplementationOnce(({ onSuccess }: any) => {
         onSuccess({
           allSupported: true,
@@ -1856,12 +1991,19 @@ describe("useMinerActions", () => {
       });
 
       const selector = mockCheckCommandCapabilities.mock.calls[0][0].deviceSelector;
-      expect(selector.selectionType.case).toBe("allDevices");
-      expect(selector.selectionType.value.deviceStatus).toEqual([DeviceStatus.ERROR]);
-      expect(selector.selectionType.value.pairingStatus).toEqual([
-        PairingStatus.PAIRED,
-        PairingStatus.DEFAULT_PASSWORD,
-      ]);
+      expect(selector.selectionType.case).toBe("includeDevices");
+      expect(selector.selectionType.value.deviceIdentifiers).toEqual(["device-1", "device-2"]);
+      expect(mockListMinerStateSnapshots).toHaveBeenCalledWith(
+        {
+          pageSize: 1000,
+          cursor: "",
+          filter: expect.objectContaining({
+            deviceStatus: [DeviceStatus.ERROR],
+            pairingStatuses: [PairingStatus.PAIRED, PairingStatus.DEFAULT_PASSWORD],
+          }),
+        },
+        { signal: undefined },
+      );
     });
 
     it("resolves all-mode add-to-group actions to selectable device identifiers", async () => {
@@ -3145,8 +3287,12 @@ describe("useMinerActions", () => {
       });
     });
 
-    it("uses allDevices selector with model, manufacturer, and pairing filter in handlePasswordConfirm", async () => {
+    it("resolves selected all-mode model group before handlePasswordConfirm dispatch", async () => {
       mockGetMinerModelGroups.mockResolvedValue([{ model: "Rig", manufacturer: "Proto", count: 6 }]);
+      testMiners = {
+        "device-1": makeSnapshot("device-1", { model: "Rig", manufacturer: "Proto" }),
+        "device-2": makeSnapshot("device-2", { model: "Rig", manufacturer: "Proto" }),
+      };
       mockUpdateMinerPassword.mockImplementation(({ onSuccess }: any) => {
         onSuccess({ batchIdentifier: "batch-security-all" });
       });
@@ -3175,10 +3321,19 @@ describe("useMinerActions", () => {
       });
 
       const callArgs = mockUpdateMinerPassword.mock.calls[0][0];
-      expect(callArgs.deviceSelector.selectionType.case).toBe("allDevices");
-      expect(callArgs.deviceSelector.selectionType.value.models).toEqual(["Rig"]);
-      expect(callArgs.deviceSelector.selectionType.value.manufacturers).toEqual(["Proto"]);
-      expect(callArgs.deviceSelector.selectionType.value.pairingStatus).toEqual([PairingStatus.DEFAULT_PASSWORD]);
+      expect(callArgs.deviceSelector.selectionType.case).toBe("includeDevices");
+      expect(callArgs.deviceSelector.selectionType.value.deviceIdentifiers).toEqual(["device-1", "device-2"]);
+      expect(mockListMinerStateSnapshots).toHaveBeenCalledWith(
+        {
+          pageSize: 1000,
+          cursor: "",
+          filter: expect.objectContaining({
+            models: ["Rig"],
+            pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+          }),
+        },
+        { signal: undefined },
+      );
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -1811,6 +1811,51 @@ describe("useMinerActions", () => {
       expect(result.current.unsupportedMinersInfo.unsupportedGroups).toHaveLength(1);
     });
 
+    it("uses the selectable pairing filter for all-mode capability checks", async () => {
+      mockCheckCommandCapabilities.mockImplementationOnce(({ onSuccess }: any) => {
+        onSuccess({
+          allSupported: true,
+          noneSupported: false,
+          supportedCount: 2,
+          unsupportedCount: 0,
+          totalCount: 2,
+          unsupportedGroups: [],
+          supportedDeviceIdentifiers: ["device-1", "device-2"],
+        });
+      });
+
+      const activeFilter = createProto(MinerListFilterSchema, {
+        deviceStatus: [DeviceStatus.ERROR],
+      });
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [
+            { deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE },
+            { deviceIdentifier: "device-2", deviceStatus: DeviceStatus.ONLINE },
+          ],
+          selectionMode: "all",
+          totalCount: 2,
+          currentFilter: activeFilter,
+        }),
+      );
+
+      const rebootAction = result.current.popoverActions.find((a) => a.action === deviceActions.reboot);
+
+      await act(async () => {
+        await rebootAction?.actionHandler();
+      });
+
+      const selector = mockCheckCommandCapabilities.mock.calls[0][0].deviceSelector;
+      expect(selector.selectionType.case).toBe("allDevices");
+      expect(selector.selectionType.value.deviceStatus).toEqual([DeviceStatus.ERROR]);
+      expect(selector.selectionType.value.pairingStatus).toEqual([
+        PairingStatus.PAIRED,
+        PairingStatus.DEFAULT_PASSWORD,
+      ]);
+    });
+
     it("should show unsupported miners modal with noneSupported flag when no miners support the action", async () => {
       mockCheckCommandCapabilities.mockImplementationOnce(({ onSuccess }: any) => {
         onSuccess({

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -3121,6 +3121,44 @@ describe("useMinerActions", () => {
       expect(callArgs.deviceSelector.selectionType.value.models).toEqual(["Rig"]);
       expect(callArgs.deviceSelector.selectionType.value.manufacturers).toEqual(["Proto"]);
     });
+
+    it("can use the current filter directly for all-mode password updates", async () => {
+      mockGetMinerModelGroups.mockResolvedValue([{ model: "Rig", manufacturer: "Proto", count: 6 }]);
+      mockUpdateMinerPassword.mockImplementation(({ onSuccess }: any) => {
+        onSuccess({ batchIdentifier: "batch-security-all" });
+      });
+
+      const currentFilter = createProto(MinerListFilterSchema, {
+        models: ["Rig"],
+        pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+      });
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [],
+          selectionMode: "all",
+          currentFilter,
+          securityUseCurrentFilterForAllModePasswordUpdate: true,
+        }),
+      );
+
+      await triggerSecurityAndAuthenticate(result);
+
+      const group = result.current.minerGroups[0];
+      await act(async () => {
+        result.current.handleUpdateGroup(group);
+      });
+      await act(async () => {
+        result.current.handlePasswordConfirm("oldpass", "newpass");
+      });
+
+      const callArgs = mockUpdateMinerPassword.mock.calls[0][0];
+      expect(callArgs.deviceSelector.selectionType.case).toBe("allDevices");
+      expect(callArgs.deviceSelector.selectionType.value.models).toEqual(["Rig"]);
+      expect(callArgs.deviceSelector.selectionType.value.pairingStatus).toEqual([PairingStatus.DEFAULT_PASSWORD]);
+      expect(callArgs.deviceSelector.selectionType.value.manufacturers).toEqual([]);
+    });
   });
 
   describe("Download Logs action", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -103,8 +103,6 @@ interface UseMinerActionsParams {
   onRefetchMiners?: () => void;
   /** Optional group filter for all-mode security flows that need narrower model groups than MinerListFilter supports. */
   securityModelGroupFilter?: SecurityModelGroupFilter;
-  /** When true, all-mode password updates use currentFilter directly instead of re-scoping to the clicked group. */
-  securityUseCurrentFilterForAllModePasswordUpdate?: boolean;
 }
 
 /**
@@ -274,7 +272,6 @@ export const useMinerActions = ({
   miners = {} as Record<string, MinerStateSnapshot>,
   onRefetchMiners,
   securityModelGroupFilter,
-  securityUseCurrentFilterForAllModePasswordUpdate,
 }: UseMinerActionsParams) => {
   const {
     startMining,
@@ -1018,7 +1015,6 @@ export const useMinerActions = ({
     miners,
     currentFilter: effectiveCurrentFilter,
     securityModelGroupFilter,
-    useCurrentFilterForAllModePasswordUpdate: securityUseCurrentFilterForAllModePasswordUpdate,
   });
 
   useEffect(() => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -14,7 +14,7 @@ import {
   SupportedAction,
 } from "./constants";
 import { useFleetAuthentication } from "./useFleetAuthentication";
-import { useManageSecurityFlow } from "./useManageSecurityFlow";
+import { type SecurityModelGroupFilter, useManageSecurityFlow } from "./useManageSecurityFlow";
 import { CoolingMode } from "@/protoFleet/api/generated/common/v1/cooling_pb";
 import { DeviceIdentifierListSchema } from "@/protoFleet/api/generated/common/v1/device_selector_pb";
 import {
@@ -22,7 +22,6 @@ import {
   type DeleteMinersResponse,
   DeviceSelectorSchema,
   type MinerListFilter,
-  MinerListFilterSchema,
   type MinerStateSnapshot,
   PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
@@ -58,6 +57,7 @@ import {
 } from "@/protoFleet/features/fleetManagement/components/BulkActions/types";
 import type { BatchOperationInput } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 import { createDeviceSelector } from "@/protoFleet/features/fleetManagement/utils/deviceSelector";
+import { applyFleetSelectablePairingStatuses } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 import {
   Fan,
   LEDIndicator,
@@ -101,6 +101,8 @@ interface UseMinerActionsParams {
   miners?: Record<string, MinerStateSnapshot>;
   /** Replaces store-based refetchMiners — called after unpair completes */
   onRefetchMiners?: () => void;
+  /** Optional group filter for all-mode security flows that need narrower model groups than MinerListFilter supports. */
+  securityModelGroupFilter?: SecurityModelGroupFilter;
 }
 
 /**
@@ -269,6 +271,7 @@ export const useMinerActions = ({
   removeDevicesFromBatch = noop as (batchIdentifier: string, deviceIds: string[]) => void,
   miners = {} as Record<string, MinerStateSnapshot>,
   onRefetchMiners,
+  securityModelGroupFilter,
 }: UseMinerActionsParams) => {
   const {
     startMining,
@@ -1008,6 +1011,7 @@ export const useMinerActions = ({
     resetAuthState,
     miners,
     currentFilter,
+    securityModelGroupFilter,
   });
 
   useEffect(() => {
@@ -1077,7 +1081,7 @@ export const useMinerActions = ({
             deviceSelector: create(DeviceSelectorSchema, {
               selectionType:
                 selectionMode === "all"
-                  ? { case: "allDevices", value: currentFilter ?? create(MinerListFilterSchema) }
+                  ? { case: "allDevices", value: applyFleetSelectablePairingStatuses(currentFilter) }
                   : {
                       case: "includeDevices",
                       value: create(DeviceIdentifierListSchema, { deviceIdentifiers: deviceIdsToUse }),

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -158,6 +158,11 @@ interface UnsupportedMinersState extends UnsupportedMinersInfo {
   pendingAction: PendingActionCallback | null;
 }
 
+interface ResolvedCommandScope {
+  deviceSelector: DeviceSelector;
+  deviceIdentifiers: string[];
+}
+
 const initialUnsupportedMinersState: UnsupportedMinersState = {
   visible: false,
   unsupportedGroups: [],
@@ -347,6 +352,40 @@ export const useMinerActions = ({
     });
   }, [selectionMode, deviceIdentifiers, effectiveAllModeFilter]);
 
+  const resolveCommandScope = useCallback(async (): Promise<ResolvedCommandScope | undefined> => {
+    if (selectionMode === "none" || !deviceSelector) return undefined;
+
+    if (selectionMode !== "all") {
+      return { deviceSelector, deviceIdentifiers };
+    }
+
+    try {
+      const snapshots = await fetchAllMinerSnapshots(effectiveAllModeFilter);
+      const resolvedDeviceIdentifiers = Object.keys(snapshots);
+
+      if (resolvedDeviceIdentifiers.length === 0) {
+        pushToast({
+          message: "No miners matched the selected filters.",
+          status: TOAST_STATUSES.error,
+        });
+        onActionComplete?.();
+        return undefined;
+      }
+
+      return {
+        deviceSelector: createDeviceSelector("subset", resolvedDeviceIdentifiers),
+        deviceIdentifiers: resolvedDeviceIdentifiers,
+      };
+    } catch {
+      pushToast({
+        message: "Unable to load the selected miners. Please try again.",
+        status: TOAST_STATUSES.error,
+      });
+      onActionComplete?.();
+      return undefined;
+    }
+  }, [selectionMode, deviceSelector, deviceIdentifiers, effectiveAllModeFilter, onActionComplete]);
+
   // Determine device status for power state actions
   const deviceStatus = useMemo(() => {
     if (selectedMiners.length === 0) return undefined;
@@ -360,16 +399,20 @@ export const useMinerActions = ({
   // Check for unsupported miners using server-side capability checking.
   // Returns a promise that resolves to true if the modal was shown.
   const checkAndShowUnsupportedMinersModal = useCallback(
-    async (action: SupportedAction, proceedAction: PendingActionCallback): Promise<boolean> => {
+    async (
+      action: SupportedAction,
+      proceedAction: PendingActionCallback,
+      commandScope: ResolvedCommandScope,
+    ): Promise<boolean> => {
       const metadata = actionCapabilityMetadata[action];
 
-      if (!metadata || metadata.commandType === CommandType.UNSPECIFIED || !deviceSelector) {
+      if (!metadata || metadata.commandType === CommandType.UNSPECIFIED) {
         return false;
       }
 
       return new Promise((resolve) => {
         checkCommandCapabilities({
-          deviceSelector,
+          deviceSelector: commandScope.deviceSelector,
           commandType: metadata.commandType,
           onSuccess: (result) => {
             if (result.allSupported) {
@@ -407,7 +450,7 @@ export const useMinerActions = ({
         });
       });
     },
-    [deviceSelector, checkCommandCapabilities, onActionComplete],
+    [checkCommandCapabilities, onActionComplete],
   );
 
   // Wraps checkAndShowUnsupportedMinersModal with the common proceed pattern:
@@ -419,12 +462,20 @@ export const useMinerActions = ({
       action: SupportedAction,
       onProceed: (filteredSelector?: DeviceSelector, filteredDeviceIds?: string[]) => void,
     ): Promise<void> => {
-      const modalShown = await checkAndShowUnsupportedMinersModal(action, onProceed);
+      const commandScope = await resolveCommandScope();
+      if (!commandScope) return;
+
+      const modalShown = await checkAndShowUnsupportedMinersModal(action, onProceed, commandScope);
       if (!modalShown) {
+        if (selectionMode === "all") {
+          onProceed(commandScope.deviceSelector, commandScope.deviceIdentifiers);
+          return;
+        }
+
         onProceed(undefined, undefined);
       }
     },
-    [checkAndShowUnsupportedMinersModal],
+    [checkAndShowUnsupportedMinersModal, resolveCommandScope, selectionMode],
   );
 
   // Handle continuing from unsupported miners modal
@@ -1028,12 +1079,20 @@ export const useMinerActions = ({
     async (filteredSelector?: DeviceSelector, filteredDeviceIds?: string[], actionOverride?: SupportedAction) => {
       // Use filtered selector/identifiers if provided (from unsupported miners modal),
       // otherwise use the default selector/identifiers for all selected miners
-      const selectorToUse = filteredSelector ?? deviceSelector;
-      const deviceIdsToUse = filteredDeviceIds ?? deviceIdentifiers;
+      let selectorToUse = filteredSelector;
+      let deviceIdsToUse = filteredDeviceIds;
+
+      if (!selectorToUse || !deviceIdsToUse) {
+        const commandScope = await resolveCommandScope();
+        if (!commandScope) return;
+        selectorToUse = commandScope.deviceSelector;
+        deviceIdsToUse = commandScope.deviceIdentifiers;
+      }
+
       // Use actionOverride when called from unsupported miners modal (where currentAction is null)
       const action = actionOverride ?? currentAction;
 
-      if (action === null || !selectorToUse) return;
+      if (action === null) return;
 
       // Handle device action API calls
       switch (action) {
@@ -1139,7 +1198,7 @@ export const useMinerActions = ({
     [
       currentAction,
       onActionComplete,
-      deviceSelector,
+      resolveCommandScope,
       selectionMode,
       startMining,
       stopMining,
@@ -1148,7 +1207,6 @@ export const useMinerActions = ({
       handleError,
       startBatchOperation,
       completeBatchOperation,
-      deviceIdentifiers,
       effectiveAllModeFilter,
       onRefetchMiners,
       executeBulkActionWithRetry,
@@ -1164,14 +1222,15 @@ export const useMinerActions = ({
 
   const popoverActions = useMemo(() => {
     // Device actions handlers
-    const handleBlinkLEDs = () => {
-      if (!deviceSelector) return;
+    const handleBlinkLEDs = async () => {
+      const commandScope = await resolveCommandScope();
+      if (!commandScope) return;
       setCurrentAction(deviceActions.blinkLEDs);
 
       executeBulkActionWithRetry({
         action: deviceActions.blinkLEDs,
-        deviceSelector,
-        deviceIdentifiers,
+        deviceSelector: commandScope.deviceSelector,
+        deviceIdentifiers: commandScope.deviceIdentifiers,
         loadingMessage: loadingMessages[deviceActions.blinkLEDs],
         runAction: ({ deviceSelector: selector, onSuccess, onError }) =>
           blinkLED({
@@ -1183,11 +1242,11 @@ export const useMinerActions = ({
     };
 
     const handleDownloadLogs = async () => {
-      if (!deviceSelector) return;
       onActionStart?.();
 
       await withCapabilityCheck(deviceActions.downloadLogs, (filteredSelector) => {
         const selectorToUse = filteredSelector ?? deviceSelector;
+        if (!selectorToUse) return;
 
         const id = pushToast({
           message: loadingMessages[deviceActions.downloadLogs],
@@ -1277,6 +1336,9 @@ export const useMinerActions = ({
 
     const handleReboot = async () => {
       onActionStart?.();
+      const commandScope = await resolveCommandScope();
+      if (!commandScope) return;
+
       // Check for unsupported miners first - only show confirmation dialog if all supported
       const modalShown = await checkAndShowUnsupportedMinersModal(
         deviceActions.reboot,
@@ -1285,6 +1347,7 @@ export const useMinerActions = ({
           // The confirmation dialog will not be shown, action executes directly
           handleConfirmation(filteredSelector, filteredDeviceIds, deviceActions.reboot);
         },
+        commandScope,
       );
       // Only show confirmation dialog if capability modal was not shown
       if (!modalShown) {
@@ -1294,11 +1357,15 @@ export const useMinerActions = ({
 
     const handleShutDown = async () => {
       onActionStart?.();
+      const commandScope = await resolveCommandScope();
+      if (!commandScope) return;
+
       const modalShown = await checkAndShowUnsupportedMinersModal(
         deviceActions.shutdown,
         (filteredSelector, filteredDeviceIds) => {
           handleConfirmation(filteredSelector, filteredDeviceIds, deviceActions.shutdown);
         },
+        commandScope,
       );
       if (!modalShown) {
         setCurrentAction(deviceActions.shutdown);
@@ -1307,11 +1374,15 @@ export const useMinerActions = ({
 
     const handleWakeUp = async () => {
       onActionStart?.();
+      const commandScope = await resolveCommandScope();
+      if (!commandScope) return;
+
       const modalShown = await checkAndShowUnsupportedMinersModal(
         deviceActions.wakeUp,
         (filteredSelector, filteredDeviceIds) => {
           handleConfirmation(filteredSelector, filteredDeviceIds, deviceActions.wakeUp);
         },
+        commandScope,
       );
       if (!modalShown) {
         setCurrentAction(deviceActions.wakeUp);
@@ -1608,6 +1679,7 @@ export const useMinerActions = ({
     withCapabilityCheck,
     checkAndShowUnsupportedMinersModal,
     handleConfirmation,
+    resolveCommandScope,
     deviceIdentifiers,
     selectionMode,
     selectedMiners,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -103,6 +103,8 @@ interface UseMinerActionsParams {
   onRefetchMiners?: () => void;
   /** Optional group filter for all-mode security flows that need narrower model groups than MinerListFilter supports. */
   securityModelGroupFilter?: SecurityModelGroupFilter;
+  /** When true, all-mode password updates use currentFilter directly instead of re-scoping to the clicked group. */
+  securityUseCurrentFilterForAllModePasswordUpdate?: boolean;
 }
 
 /**
@@ -272,6 +274,7 @@ export const useMinerActions = ({
   miners = {} as Record<string, MinerStateSnapshot>,
   onRefetchMiners,
   securityModelGroupFilter,
+  securityUseCurrentFilterForAllModePasswordUpdate,
 }: UseMinerActionsParams) => {
   const {
     startMining,
@@ -1015,6 +1018,7 @@ export const useMinerActions = ({
     miners,
     currentFilter: effectiveCurrentFilter,
     securityModelGroupFilter,
+    useCurrentFilterForAllModePasswordUpdate: securityUseCurrentFilterForAllModePasswordUpdate,
   });
 
   useEffect(() => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -330,17 +330,20 @@ export const useMinerActions = ({
     [selectedMiners, selectionMode, displayCount, miners, currentFilter],
   );
 
+  const effectiveAllModeFilter = useMemo(() => applyFleetSelectablePairingStatuses(currentFilter), [currentFilter]);
+  const effectiveCurrentFilter = selectionMode === "all" ? effectiveAllModeFilter : currentFilter;
+
   // Create device selector based on selection mode (undefined when nothing selected)
   const deviceSelector = useMemo(() => {
     if (selectionMode === "none") return undefined;
     if (selectionMode === "subset") return createDeviceSelector(selectionMode, deviceIdentifiers);
 
     return createDeviceSelector(selectionMode, deviceIdentifiers, {
-      deviceStatuses: currentFilter?.deviceStatus ?? [],
-      pairingStatuses: currentFilter?.pairingStatuses ?? [],
-      models: currentFilter?.models ?? [],
+      deviceStatuses: effectiveAllModeFilter.deviceStatus,
+      pairingStatuses: effectiveAllModeFilter.pairingStatuses,
+      models: effectiveAllModeFilter.models,
     });
-  }, [selectionMode, deviceIdentifiers, currentFilter]);
+  }, [selectionMode, deviceIdentifiers, effectiveAllModeFilter]);
 
   // Determine device status for power state actions
   const deviceStatus = useMemo(() => {
@@ -1010,7 +1013,7 @@ export const useMinerActions = ({
     fleetCredentials,
     resetAuthState,
     miners,
-    currentFilter,
+    currentFilter: effectiveCurrentFilter,
     securityModelGroupFilter,
   });
 
@@ -1081,7 +1084,7 @@ export const useMinerActions = ({
             deviceSelector: create(DeviceSelectorSchema, {
               selectionType:
                 selectionMode === "all"
-                  ? { case: "allDevices", value: applyFleetSelectablePairingStatuses(currentFilter) }
+                  ? { case: "allDevices", value: effectiveAllModeFilter }
                   : {
                       case: "includeDevices",
                       value: create(DeviceIdentifierListSchema, { deviceIdentifiers: deviceIdsToUse }),
@@ -1143,7 +1146,7 @@ export const useMinerActions = ({
       startBatchOperation,
       completeBatchOperation,
       deviceIdentifiers,
-      currentFilter,
+      effectiveAllModeFilter,
       onRefetchMiners,
       executeBulkActionWithRetry,
     ],

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -15,6 +15,7 @@ import {
 } from "./constants";
 import { useFleetAuthentication } from "./useFleetAuthentication";
 import { type SecurityModelGroupFilter, useManageSecurityFlow } from "./useManageSecurityFlow";
+import { fetchAllMinerSnapshots } from "@/protoFleet/api/fetchAllMinerSnapshots";
 import { CoolingMode } from "@/protoFleet/api/generated/common/v1/cooling_pb";
 import { DeviceIdentifierListSchema } from "@/protoFleet/api/generated/common/v1/device_selector_pb";
 import {
@@ -303,6 +304,7 @@ export const useMinerActions = ({
   const [coolingModeFilteredDeviceIds, setCoolingModeFilteredDeviceIds] = useState<string[] | undefined>(undefined);
   const [currentCoolingMode, setCurrentCoolingMode] = useState<CoolingMode | undefined>(undefined);
   const [showAddToGroupModal, setShowAddToGroupModal] = useState(false);
+  const [groupActionDeviceIds, setGroupActionDeviceIds] = useState<string[] | undefined>(undefined);
   const [showFirmwareUpdateModal, setShowFirmwareUpdateModal] = useState(false);
   const [firmwareUpdateFilteredSelector, setFirmwareUpdateFilteredSelector] = useState<DeviceSelector | undefined>();
   const [firmwareUpdateFilteredDeviceIds, setFirmwareUpdateFilteredDeviceIds] = useState<string[] | undefined>(
@@ -956,6 +958,7 @@ export const useMinerActions = ({
 
   const handleAddToGroupDismiss = useCallback(() => {
     setShowAddToGroupModal(false);
+    setGroupActionDeviceIds(undefined);
     setCurrentAction(null);
     onActionComplete?.();
   }, [onActionComplete]);
@@ -1366,10 +1369,31 @@ export const useMinerActions = ({
       startAuthentication("security");
     };
 
-    const handleAddToGroup = () => {
+    const handleAddToGroup = async () => {
+      onActionStart?.();
+      setGroupActionDeviceIds(undefined);
+
+      if (selectionMode === "all") {
+        try {
+          const snapshots = await fetchAllMinerSnapshots(effectiveAllModeFilter);
+          const filteredDeviceIds = Object.keys(snapshots);
+
+          if (filteredDeviceIds.length === 0) {
+            pushToast({ message: "No miners selected.", status: TOAST_STATUSES.error });
+            onActionComplete?.();
+            return;
+          }
+
+          setGroupActionDeviceIds(filteredDeviceIds);
+        } catch {
+          pushToast({ message: "Couldn't load selected miners. Try again.", status: TOAST_STATUSES.error });
+          onActionComplete?.();
+          return;
+        }
+      }
+
       setCurrentAction(groupActions.addToGroup);
       setShowAddToGroupModal(true);
-      onActionStart?.();
     };
 
     const handleFirmwareUpdate = async () => {
@@ -1578,6 +1602,7 @@ export const useMinerActions = ({
     displayCount,
     onActionStart,
     onActionComplete,
+    effectiveAllModeFilter,
     deviceSelector,
     deviceStatus,
     withCapabilityCheck,
@@ -1646,6 +1671,7 @@ export const useMinerActions = ({
     handleRenameConfirm,
     handleRenameDismiss,
     showAddToGroupModal,
+    groupActionDeviceIds,
     handleAddToGroupDismiss,
   };
 };

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -328,10 +328,16 @@ export const useMinerActions = ({
   );
 
   // Create device selector based on selection mode (undefined when nothing selected)
-  const deviceSelector = useMemo(
-    () => (selectionMode === "none" ? undefined : createDeviceSelector(selectionMode, deviceIdentifiers)),
-    [selectionMode, deviceIdentifiers],
-  );
+  const deviceSelector = useMemo(() => {
+    if (selectionMode === "none") return undefined;
+    if (selectionMode === "subset") return createDeviceSelector(selectionMode, deviceIdentifiers);
+
+    return createDeviceSelector(selectionMode, deviceIdentifiers, {
+      deviceStatuses: currentFilter?.deviceStatus ?? [],
+      pairingStatuses: currentFilter?.pairingStatuses ?? [],
+      models: currentFilter?.models ?? [],
+    });
+  }, [selectionMode, deviceIdentifiers, currentFilter]);
 
   // Determine device status for power state actions
   const deviceStatus = useMemo(() => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerIssues.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerIssues.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MinerIssues from "./MinerIssues";
+import {
+  type MinerStateSnapshot,
+  PairingStatus,
+} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+
+const createMiner = (overrides: Partial<MinerStateSnapshot> = {}): MinerStateSnapshot =>
+  ({
+    deviceIdentifier: "miner-1",
+    deviceStatus: 0,
+    pairingStatus: PairingStatus.PAIRED,
+    ...overrides,
+  }) as MinerStateSnapshot;
+
+describe("MinerIssues", () => {
+  it("does not show an issue for default-password miners without other issues", () => {
+    const { container } = render(
+      <MinerIssues miner={createMiner({ pairingStatus: PairingStatus.DEFAULT_PASSWORD })} errors={[]} errorsLoaded />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(/password/i)).not.toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerIssues.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerIssues.tsx
@@ -1,9 +1,10 @@
 import { ReactNode, useMemo } from "react";
 import { ComponentType as ErrorComponentType, type ErrorMessage } from "@/protoFleet/api/generated/errors/v1/errors_pb";
-import { DeviceStatus, PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import { DeviceStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { transformFleetErrorsToShared } from "@/protoFleet/components/StatusModal/utils";
 import { getComponentIcon } from "@/protoFleet/features/fleetManagement/components/MinerList/utils";
+import { needsAuthentication as needsAuthFn } from "@/protoFleet/features/fleetManagement/utils/pairingRemediation";
 import { Alert } from "@/shared/assets/icons";
 import SkeletonBar from "@/shared/components/SkeletonBar";
 import { useMinerIssues } from "@/shared/hooks/useStatusSummary";
@@ -61,7 +62,7 @@ const MinerIssues = ({ miner, errors, errorsLoaded, onClick }: MinerIssuesProps)
   const groupedErrors = useMemo(() => groupErrors(errors), [errors]);
 
   // Compute issue flags
-  const needsAuthentication = miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED;
+  const needsAuthentication = needsAuthFn(miner.pairingStatus);
   const needsMiningPool = deviceStatus === DeviceStatus.NEEDS_MINING_POOL;
   const isUpdating = deviceStatus === DeviceStatus.UPDATING;
   const isRebootRequired = deviceStatus === DeviceStatus.REBOOT_REQUIRED;

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.modalFlow.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.modalFlow.test.tsx
@@ -152,6 +152,22 @@ describe("MinerList modal flow orchestration", () => {
     expect(screen.queryByTestId("pool-selection-page")).not.toBeInTheDocument();
   });
 
+  it("opens fleet auth then pool selection for default-password miners that need pools", async () => {
+    const user = userEvent.setup();
+    minersById["miner-1"] = {
+      pairingStatus: PairingStatus.DEFAULT_PASSWORD,
+      deviceStatus: DeviceStatus.NEEDS_MINING_POOL,
+    };
+
+    renderMinerList();
+    await user.click(screen.getByTestId("open-status-flow"));
+
+    expect(screen.getByTestId("authenticate-fleet-modal")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("authenticate-fleet-success"));
+    expect(screen.getByTestId("pool-selection-page")).toBeInTheDocument();
+  });
+
   it("opens status modal for non-auth, non-pool miners and closes cleanly", async () => {
     const user = userEvent.setup();
     minersById["miner-1"] = {
@@ -165,5 +181,19 @@ describe("MinerList modal flow orchestration", () => {
 
     await user.click(screen.getByTestId("status-modal-close"));
     expect(screen.queryByTestId("status-modal")).not.toBeInTheDocument();
+  });
+
+  it("opens status modal for default-password miners without pool issues", async () => {
+    const user = userEvent.setup();
+    minersById["miner-1"] = {
+      pairingStatus: PairingStatus.DEFAULT_PASSWORD,
+      deviceStatus: DeviceStatus.ONLINE,
+    };
+
+    renderMinerList();
+    await user.click(screen.getByTestId("open-status-flow"));
+
+    expect(screen.getByTestId("status-modal")).toBeInTheDocument();
+    expect(screen.queryByTestId("authenticate-fleet-modal")).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
@@ -1064,7 +1064,7 @@ describe("MinerList", () => {
       await user.click(screen.getByTestId("mock-action-bar-select-all"));
 
       expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m2,m3");
-      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("true");
+      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("false");
       expect(screen.getByTestId("mock-miner-list-selection-count")).toHaveTextContent("2");
     });
 
@@ -1092,7 +1092,7 @@ describe("MinerList", () => {
       expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("false");
     });
 
-    it("flags all-mode selections as auth-needed while the fleet-wide count is unsettled (loading or refetching)", async () => {
+    it("does not flag all-mode selections as auth-needed while disabled counts settle", async () => {
       const user = userEvent.setup();
 
       renderMinerList({
@@ -1115,7 +1115,7 @@ describe("MinerList", () => {
       await user.click(screen.getByTestId("mock-action-bar-select-all"));
 
       expect(screen.getByTestId("mock-miner-list-selection-mode")).toHaveTextContent("all");
-      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("true");
+      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("false");
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
@@ -1029,17 +1029,18 @@ describe("MinerList", () => {
       },
     );
 
-    it("keeps authentication-needed miners selectable and flags the selection to the action bar", async () => {
+    it("keeps credential-remediation miners visible but only auth-needed miners non-selectable", async () => {
       const user = userEvent.setup();
 
       renderMinerList({
         title: "Miners",
-        minerIds: ["m1", "m2"],
+        minerIds: ["m1", "m2", "m3"],
         miners: {
           m1: createMinerSnapshot("m1", PairingStatus.AUTHENTICATION_NEEDED),
-          m2: createMinerSnapshot("m2"),
+          m2: createMinerSnapshot("m2", PairingStatus.DEFAULT_PASSWORD),
+          m3: createMinerSnapshot("m3"),
         },
-        totalMiners: 2,
+        totalMiners: 3,
         totalDisabledMiners: 1,
         currentPage: 0,
         onAddMiners: vi.fn(),
@@ -1047,15 +1048,24 @@ describe("MinerList", () => {
       });
 
       const rowCheckboxes = screen.getAllByTestId("checkbox");
-      await user.click(rowCheckboxes[0].querySelector("input[type='checkbox']") as HTMLInputElement);
+      const inputs = rowCheckboxes.map(
+        (checkbox) => checkbox.querySelector("input[type='checkbox']") as HTMLInputElement,
+      );
 
-      expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m1");
-      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("true");
+      expect(inputs[0]).toBeDisabled();
+      expect(inputs[1]).not.toBeDisabled();
+      expect(inputs[2]).not.toBeDisabled();
+
+      await user.click(inputs[1]);
+
+      expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m2");
+      expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("false");
 
       await user.click(screen.getByTestId("mock-action-bar-select-all"));
 
-      expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m1,m2");
+      expect(screen.getByTestId("mock-miner-list-selected-miners")).toHaveTextContent("m2,m3");
       expect(screen.getByTestId("mock-miner-list-selection-includes-unauth")).toHaveTextContent("true");
+      expect(screen.getByTestId("mock-miner-list-selection-count")).toHaveTextContent("2");
     });
 
     it("does not flag the selection as auth-needed when no selected miner needs authentication", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -272,7 +272,6 @@ const ScopedMinerListBody = ({
   overflowContainer,
   totalMiners,
   totalDisabledMiners,
-  totalDisabledMinersFresh,
   itemRef,
   hasActiveFilters,
   onAddMiners,
@@ -324,19 +323,17 @@ const ScopedMinerListBody = ({
     setSelectionMode("none");
   }, []);
 
-  // All-mode fails safe: when the auth-needed count hasn't settled yet, treat
-  // the selection as if it includes one (off-page auth-needed miners are
-  // otherwise invisible to the gate). Once the count is loaded, OR the
-  // fleet-wide count with a page-local check so the gate trips on visible
-  // rows even if the count refresh hasn't caught up.
+  // All-mode selection represents all selectable rows. Auth-needed rows are
+  // disabled and excluded from that scope, so they should not gate actions just
+  // because they exist outside the selected set.
   const selectedIncludesUnauthenticatedMiner = useMemo(
     () =>
       selectionMode === "all"
-        ? !totalDisabledMinersFresh || totalDisabledMiners > 0 || deviceItems.some(isRowDisabled)
+        ? false
         : selectedMinerIds.some((id) =>
             deviceItems.some((item) => item.deviceIdentifier === id && isRowDisabled(item)),
           ),
-    [deviceItems, isRowDisabled, selectedMinerIds, selectionMode, totalDisabledMiners, totalDisabledMinersFresh],
+    [deviceItems, isRowDisabled, selectedMinerIds, selectionMode],
   );
 
   return (

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -44,6 +44,8 @@ import {
   FILTER_URL_PARAM_KEYS,
   parseUrlToActiveFilters,
 } from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
+import { isFleetSelectablePairingStatus } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
+import { needsAuthentication } from "@/protoFleet/features/fleetManagement/utils/pairingRemediation";
 import { encodeSortToURL, parseSortFromURL } from "@/protoFleet/features/fleetManagement/utils/sortUrlParams";
 import {
   protoFieldForTelemetryKey,
@@ -112,7 +114,7 @@ type MinerListProps = {
    */
   totalUnfilteredMiners?: number;
   /**
-   * Total number of disabled miners (requiring authentication).
+   * Total number of disabled miners (requiring credential remediation).
    * Used to calculate selectable count: totalMiners - totalDisabledMiners
    */
   totalDisabledMiners?: number;
@@ -212,9 +214,6 @@ type MinerListProps = {
   onPairingCompleted?: () => void;
 };
 
-// Module-level so the `List`'s memoized helpers keep a stable identity.
-const ALL_ROWS_SELECTABLE = () => true;
-
 type ScopedMinerListBodyProps = {
   /**
    * Selection-scope identifier — when this changes, internal selection state resets.
@@ -311,7 +310,9 @@ const ScopedMinerListBody = ({
   }
   const sortableColumnsSet = useMemo(() => new Set(SORTABLE_COLUMNS), []);
 
-  const currentPageSelectableMinerIds = deviceItems.map((item) => item.deviceIdentifier);
+  const currentPageSelectableMinerIds = deviceItems
+    .filter((item) => !isRowDisabled(item))
+    .map((item) => item.deviceIdentifier);
 
   const handleSelectAllMiners = useCallback(() => {
     setSelectedMinerIds(currentPageSelectableMinerIds);
@@ -403,16 +404,13 @@ const ScopedMinerListBody = ({
         stickyChromeClassName={overflowContainer === false ? PAGE_SCROLL_CHROME_WIDTH : undefined}
         applyColumnWidthsToCells
         total={totalMiners}
-        // Every row is selectable; `totalSelectable = totalMiners` so action-bar
-        // copy and confirmation counts cover both paired and auth-needed miners.
-        totalDisabled={0}
+        totalDisabled={totalDisabledMiners}
         hideTotal
         itemName={{ singular: "miner", plural: "miners" }}
         itemRef={itemRef}
         initialActiveFilters={initialActiveFilters}
         onSelectionModeChange={setSelectionMode}
         isRowDisabled={isRowDisabled}
-        isRowSelectable={ALL_ROWS_SELECTABLE}
         columnsExemptFromDisabledStyling={new Set([minerCols.name, minerCols.status, minerCols.issues])}
         sortableColumns={sortableColumnsSet}
         currentSort={currentSort}
@@ -567,8 +565,15 @@ const MinerList = ({
     [minerIds, miners, errorsByDevice, batchStateVersion, refreshingMinerIds],
   );
 
+  // AUTHENTICATION_NEEDED rigs cannot be operated until credentials are fixed.
+  // DEFAULT_PASSWORD remains selectable; miner firmware handles operation gates.
   const disabledMinerIdSet = useMemo(
-    () => new Set(minerIds.filter((id) => miners[id]?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED)),
+    () =>
+      new Set(
+        minerIds.filter(
+          (id) => !isFleetSelectablePairingStatus(miners[id]?.pairingStatus ?? PairingStatus.UNSPECIFIED),
+        ),
+      ),
     [minerIds, miners],
   );
   const isRowDisabled = useCallback(
@@ -612,10 +617,10 @@ const MinerList = ({
       const miner = minersRef.current[deviceIdentifier];
       if (!miner) return;
 
-      const needsAuthentication = miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED;
+      const minerNeedsAuthentication = needsAuthentication(miner.pairingStatus);
       const needsMiningPool = miner.deviceStatus === DeviceStatus.NEEDS_MINING_POOL;
 
-      if (needsAuthentication) {
+      if (minerNeedsAuthentication) {
         setModalFlow({ kind: "authenticate-miners", deviceIdentifier });
         return;
       }

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerName.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerName.test.tsx
@@ -92,15 +92,15 @@ describe("MinerName", () => {
     expect(screen.queryByRole("button", { name: /view issues/i })).not.toBeInTheDocument();
   });
 
-  it("restricts row actions while keeping security available when password change is required", () => {
+  it("does not treat default-password miners as authentication-blocked", () => {
     const miner = createMockMiner({ pairingStatus: PairingStatus.DEFAULT_PASSWORD });
 
     render(<MinerName miner={miner} errors={[]} isActionLoading={false} onOpenStatusFlow={vi.fn()} />);
 
+    expect(screen.getByTitle("Test Miner")).not.toHaveClass("opacity-50");
     const lastCall = singleMinerActionsMenuMock.mock.calls[singleMinerActionsMenuMock.mock.calls.length - 1];
     expect(lastCall?.[0]).toMatchObject({
-      needsAuthentication: true,
-      allowSecurityAction: true,
+      needsAuthentication: false,
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerName.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerName.tsx
@@ -1,9 +1,9 @@
 import clsx from "clsx";
 import type { ErrorMessage } from "@/protoFleet/api/generated/errors/v1/errors_pb";
 import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
-import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import SingleMinerActionsMenu from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/SingleMinerActionsMenu";
+import { needsAuthentication as needsAuthFn } from "@/protoFleet/features/fleetManagement/utils/pairingRemediation";
 import { Alert } from "@/shared/assets/icons";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import { useNeedsAttention } from "@/shared/hooks/useNeedsAttention";
@@ -37,12 +37,10 @@ const MinerName = ({
   const name = miner.name || deviceIdentifier;
   const deviceStatus = miner.deviceStatus;
 
-  const needsAuthentication = miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED;
-  const needsPasswordChange = miner.pairingStatus === PairingStatus.DEFAULT_PASSWORD;
-  const actionsRestricted = needsAuthentication || needsPasswordChange;
+  const needsAuthentication = needsAuthFn(miner.pairingStatus);
   const needsMiningPool = deviceStatus === DeviceStatus.NEEDS_MINING_POOL;
   const hasFirmwareStatus = deviceStatus === DeviceStatus.UPDATING || deviceStatus === DeviceStatus.REBOOT_REQUIRED;
-  const needsAttention = useNeedsAttention(actionsRestricted, needsMiningPool, errors, false, hasFirmwareStatus);
+  const needsAttention = useNeedsAttention(needsAuthentication, needsMiningPool, errors, false, hasFirmwareStatus);
 
   return (
     <div className="grid w-full grid-cols-[1fr_auto] items-center gap-3">
@@ -67,8 +65,7 @@ const MinerName = ({
           deviceStatus={deviceStatus}
           minerName={name}
           workerName={miner.workerName}
-          needsAuthentication={actionsRestricted}
-          allowSecurityAction={needsPasswordChange}
+          needsAuthentication={needsAuthentication}
           miners={miners}
           onRefetchMiners={onRefetchMiners}
           onRefreshMinersComplete={onRefreshMinersComplete}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.test.tsx
@@ -242,11 +242,11 @@ describe("MinerStatus", () => {
       expect(screen.getByTestId("miner-status-indicator")).toHaveAttribute("data-status", "inactive");
     });
 
-    it("lets default-password remediation override sleeping status", async () => {
+    it("uses the sleeping status for default-password miners when telemetry says sleeping", async () => {
       const { useNeedsAttention } = await import("@/shared/hooks/useNeedsAttention");
       const { useMinerStatus } = await import("@/shared/hooks/useStatusSummary");
-      vi.mocked(useNeedsAttention).mockReturnValue(true);
-      vi.mocked(useMinerStatus).mockReturnValue("Needs attention");
+      vi.mocked(useNeedsAttention).mockReturnValue(false);
+      vi.mocked(useMinerStatus).mockReturnValue("Sleeping");
 
       const miner = createMockMiner({
         pairingStatus: PairingStatus.DEFAULT_PASSWORD,
@@ -255,8 +255,9 @@ describe("MinerStatus", () => {
 
       render(<MinerStatus miner={miner} errors={[]} activeBatches={[]} errorsLoaded />);
 
-      expect(useMinerStatus).toHaveBeenLastCalledWith(false, false, true);
-      expect(screen.getByText("Needs attention")).toBeInTheDocument();
+      expect(useNeedsAttention).toHaveBeenLastCalledWith(false, false, [], false, false);
+      expect(useMinerStatus).toHaveBeenLastCalledWith(false, true, false);
+      expect(screen.getByText("Sleeping")).toBeInTheDocument();
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerStatus.tsx
@@ -5,6 +5,7 @@ import { DeviceStatus, PairingStatus } from "@/protoFleet/api/generated/fleetman
 import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import type { BatchOperation } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 import { isActionLoading } from "@/protoFleet/features/fleetManagement/utils/batchStatusCheck";
+import { needsAuthentication as needsAuthFn } from "@/protoFleet/features/fleetManagement/utils/pairingRemediation";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import SkeletonBar from "@/shared/components/SkeletonBar";
 import StatusCircle, { statuses } from "@/shared/components/StatusCircle";
@@ -40,25 +41,23 @@ const MinerStatus = ({ miner, errors, activeBatches, errorsLoaded, isRefreshing,
   const deviceStatusFromStore = miner.deviceStatus;
 
   // Compute status flags
-  const needsAuthentication = miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED;
-  const needsPasswordChange = miner.pairingStatus === PairingStatus.DEFAULT_PASSWORD;
-  const needsRemediation = needsAuthentication || needsPasswordChange;
+  const needsAuthentication = needsAuthFn(miner.pairingStatus);
   const isPaired = miner.pairingStatus === PairingStatus.PAIRED;
   // Paired miners with UNSPECIFIED device_status (typically freshly paired, not yet polled)
   // are treated as offline — this matches the Fleet Health dashboard and Offline filter.
   const isOffline =
     deviceStatusFromStore === DeviceStatus.OFFLINE || (deviceStatusFromStore === DeviceStatus.UNSPECIFIED && isPaired);
-  // Password remediation should outrank a sleeping/maintenance device status.
+  // Authentication remediation should outrank a sleeping/maintenance device status.
   const isSleeping =
     (deviceStatusFromStore === DeviceStatus.INACTIVE || deviceStatusFromStore === DeviceStatus.MAINTENANCE) &&
-    !needsRemediation;
+    !needsAuthentication;
   const needsMiningPool = deviceStatusFromStore === DeviceStatus.NEEDS_MINING_POOL;
   const hasDeviceError = deviceStatusFromStore === DeviceStatus.ERROR;
   const isUpdating = deviceStatusFromStore === DeviceStatus.UPDATING;
   const isRebootRequired = deviceStatusFromStore === DeviceStatus.REBOOT_REQUIRED;
 
   const needsAttention = useNeedsAttention(
-    needsRemediation,
+    needsAuthentication,
     needsMiningPool,
     errors,
     hasDeviceError,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.test.tsx
@@ -110,4 +110,17 @@ describe("MinerWorkerName", () => {
     expect(screen.queryByText("worker-01")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
   });
+
+  it("shows a stored worker name while a default password is active", () => {
+    const miner = createMockMiner({
+      macAddress: "aa:bb:cc:dd:ee:ff",
+      workerName: "worker-01",
+      pairingStatus: PairingStatus.DEFAULT_PASSWORD,
+    });
+
+    render(<MinerWorkerName miner={miner} />);
+
+    expect(screen.getByText("worker-01")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Default worker name")).not.toBeInTheDocument();
+  });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerWorkerName.tsx
@@ -1,8 +1,6 @@
 import { INACTIVE_PLACEHOLDER } from "./constants";
-import {
-  type MinerStateSnapshot,
-  PairingStatus,
-} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import { type MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import { needsAuthentication } from "@/protoFleet/features/fleetManagement/utils/pairingRemediation";
 import Tooltip from "@/shared/components/Tooltip";
 import { positions } from "@/shared/constants";
 
@@ -26,7 +24,7 @@ const MinerWorkerName = ({ miner }: MinerWorkerNameProps) => {
   const normalizedWorkerName = normalizeWorkerName(miner.workerName);
   const isDefault = isDefaultWorkerName(normalizedWorkerName, miner.macAddress);
 
-  if (miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED) {
+  if (needsAuthentication(miner.pairingStatus)) {
     return null;
   }
 

--- a/client/src/protoFleet/features/fleetManagement/utils/deviceSelector.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/deviceSelector.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createDeviceSelector } from "./deviceSelector";
+import { DeviceStatus, PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
 describe("createDeviceSelector", () => {
   describe("when selectionMode is 'all'", () => {
@@ -20,6 +21,23 @@ describe("createDeviceSelector", () => {
       expect(result.selectionType.case).toBe("allDevices");
       if (result.selectionType.case === "allDevices") {
         expect(result.selectionType.value).toBeDefined();
+      }
+    });
+
+    it("includes filter criteria for all-device selectors", () => {
+      const result = createDeviceSelector("all", ["ignored-device"], {
+        deviceStatuses: [DeviceStatus.NEEDS_MINING_POOL],
+        pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+        models: ["Rig"],
+        manufacturers: ["Proto"],
+      });
+
+      expect(result.selectionType.case).toBe("allDevices");
+      if (result.selectionType.case === "allDevices") {
+        expect(result.selectionType.value?.deviceStatus).toEqual([DeviceStatus.NEEDS_MINING_POOL]);
+        expect(result.selectionType.value?.pairingStatus).toEqual([PairingStatus.DEFAULT_PASSWORD]);
+        expect(result.selectionType.value?.models).toEqual(["Rig"]);
+        expect(result.selectionType.value?.manufacturers).toEqual(["Proto"]);
       }
     });
   });

--- a/client/src/protoFleet/features/fleetManagement/utils/deviceSelector.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/deviceSelector.ts
@@ -10,7 +10,11 @@ import { type SelectionMode } from "@/shared/components/List";
 
 export interface DeviceFilterCriteria {
   deviceStatus?: DeviceStatus;
+  deviceStatuses?: DeviceStatus[];
   pairingStatus?: PairingStatus;
+  pairingStatuses?: PairingStatus[];
+  models?: string[];
+  manufacturers?: string[];
 }
 
 /**
@@ -32,8 +36,12 @@ export const createDeviceSelector = (
       selectionType: {
         case: "allDevices",
         value: create(DeviceFilterSchema, {
-          deviceStatus: filterCriteria?.deviceStatus ? [filterCriteria.deviceStatus] : [],
-          pairingStatus: filterCriteria?.pairingStatus ? [filterCriteria.pairingStatus] : [],
+          deviceStatus:
+            filterCriteria?.deviceStatuses ?? (filterCriteria?.deviceStatus ? [filterCriteria.deviceStatus] : []),
+          pairingStatus:
+            filterCriteria?.pairingStatuses ?? (filterCriteria?.pairingStatus ? [filterCriteria.pairingStatus] : []),
+          models: filterCriteria?.models ?? [],
+          manufacturers: filterCriteria?.manufacturers ?? [],
         }),
       },
     });

--- a/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.test.ts
@@ -59,7 +59,10 @@ describe("applyFleetSelectablePairingStatuses", () => {
       pairingStatuses: [PairingStatus.PAIRED, PairingStatus.AUTHENTICATION_NEEDED, PairingStatus.DEFAULT_PASSWORD],
     });
 
-    expect(applyFleetSelectablePairingStatuses(filter).pairingStatuses).toEqual([PairingStatus.PAIRED]);
+    expect(applyFleetSelectablePairingStatuses(filter).pairingStatuses).toEqual([
+      PairingStatus.PAIRED,
+      PairingStatus.DEFAULT_PASSWORD,
+    ]);
   });
 
   it("preserves an empty selectable intersection for explicit non-selectable filters", () => {
@@ -86,6 +89,6 @@ describe("isFleetSelectablePairingStatus", () => {
   it("returns true only for pairing statuses that can be selected in the miner list", () => {
     expect(isFleetSelectablePairingStatus(PairingStatus.PAIRED)).toBe(true);
     expect(isFleetSelectablePairingStatus(PairingStatus.AUTHENTICATION_NEEDED)).toBe(false);
-    expect(isFleetSelectablePairingStatus(PairingStatus.DEFAULT_PASSWORD)).toBe(false);
+    expect(isFleetSelectablePairingStatus(PairingStatus.DEFAULT_PASSWORD)).toBe(true);
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.test.ts
@@ -10,6 +10,8 @@ import {
 import {
   type MinerListFilter,
   MinerListFilterSchema,
+  NumericField,
+  NumericRangeFilterSchema,
   PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
@@ -73,15 +75,55 @@ describe("applyFleetSelectablePairingStatuses", () => {
     expect(applyFleetSelectablePairingStatuses(filter).pairingStatuses).toEqual([]);
   });
 
-  it("copies firmware and zone filters through so bulk actions respect them", () => {
+  it("preserves every active filter field and only changes pairing statuses", () => {
     const filter: MinerListFilter = create(MinerListFilterSchema, {
+      deviceStatus: [1],
+      errorComponentTypes: [1],
+      models: ["Rig"],
+      pairingStatuses: [PairingStatus.AUTHENTICATION_NEEDED, PairingStatus.DEFAULT_PASSWORD],
+      groupIds: [101n],
+      rackIds: [202n],
       firmwareVersions: ["v3.5.1"],
       zones: ["Austin, Building 1"],
+      numericRanges: [
+        create(NumericRangeFilterSchema, {
+          field: NumericField.HASHRATE_THS,
+          min: 90,
+          max: 110,
+          minInclusive: true,
+          maxInclusive: true,
+        }),
+      ],
+      ipCidrs: ["192.168.1.0/24"],
+      siteIds: [303n],
+      includeUnassigned: true,
+      buildingIds: [404n],
+      includeNoBuilding: true,
+      zoneKeys: [{ buildingId: 404n, zone: "A1" }],
+      includeNoRack: true,
     });
 
     const result = applyFleetSelectablePairingStatuses(filter);
-    expect(result.firmwareVersions).toEqual(["v3.5.1"]);
-    expect(result.zones).toEqual(["Austin, Building 1"]);
+    expect(result).toMatchObject({
+      deviceStatus: [1],
+      errorComponentTypes: [1],
+      models: ["Rig"],
+      pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+      groupIds: [101n],
+      rackIds: [202n],
+      firmwareVersions: ["v3.5.1"],
+      zones: ["Austin, Building 1"],
+      ipCidrs: ["192.168.1.0/24"],
+      siteIds: [303n],
+      includeUnassigned: true,
+      buildingIds: [404n],
+      includeNoBuilding: true,
+      zoneKeys: [{ buildingId: 404n, zone: "A1" }],
+      includeNoRack: true,
+    });
+    expect(result.numericRanges).toEqual(filter.numericRanges);
+    expect(result.numericRanges).not.toBe(filter.numericRanges);
+    expect(filter.pairingStatuses).toEqual([PairingStatus.AUTHENTICATION_NEEDED, PairingStatus.DEFAULT_PASSWORD]);
   });
 });
 

--- a/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.ts
@@ -11,7 +11,10 @@ export const FLEET_VISIBLE_PAIRING_STATUSES: PairingStatus[] = [
   PairingStatus.DEFAULT_PASSWORD,
 ];
 
-export const FLEET_SELECTABLE_PAIRING_STATUSES: PairingStatus[] = [PairingStatus.PAIRED];
+export const FLEET_SELECTABLE_PAIRING_STATUSES: PairingStatus[] = [
+  PairingStatus.PAIRED,
+  PairingStatus.DEFAULT_PASSWORD,
+];
 
 const fleetVisiblePairingStatusSet = new Set<number>(FLEET_VISIBLE_PAIRING_STATUSES);
 const fleetSelectablePairingStatusSet = new Set<number>(FLEET_SELECTABLE_PAIRING_STATUSES);

--- a/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.ts
@@ -1,4 +1,4 @@
-import { create } from "@bufbuild/protobuf";
+import { clone, create } from "@bufbuild/protobuf";
 import {
   type MinerListFilter,
   MinerListFilterSchema,
@@ -28,17 +28,10 @@ const applyAllowedPairingStatuses = (
   const pairingStatuses = requestedPairingStatuses.filter((status) => allowedPairingStatusSet.has(status));
   const hasExplicitPairingStatuses = requestedPairingStatuses.length > 0;
 
-  return create(MinerListFilterSchema, {
-    deviceStatus: filter?.deviceStatus ?? [],
-    errorComponentTypes: filter?.errorComponentTypes ?? [],
-    models: filter?.models ?? [],
-    pairingStatuses:
-      pairingStatuses.length > 0 || hasExplicitPairingStatuses ? pairingStatuses : [...allowedPairingStatuses],
-    groupIds: filter?.groupIds ?? [],
-    rackIds: filter?.rackIds ?? [],
-    firmwareVersions: filter?.firmwareVersions ?? [],
-    zones: filter?.zones ?? [],
-  });
+  const result = filter ? clone(MinerListFilterSchema, filter) : create(MinerListFilterSchema);
+  result.pairingStatuses =
+    pairingStatuses.length > 0 || hasExplicitPairingStatuses ? pairingStatuses : [...allowedPairingStatuses];
+  return result;
 };
 
 export const isFleetSelectablePairingStatus = (pairingStatus: PairingStatus): boolean =>

--- a/client/src/protoFleet/features/fleetManagement/utils/getMinerMeasurement.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/getMinerMeasurement.test.ts
@@ -122,6 +122,16 @@ describe("getMinerMeasurement", () => {
     expect(result).toHaveLength(0);
   });
 
+  it("returns measurement data when miner needs a password change", () => {
+    const hashrateData = [createMeasurement(100)];
+    const miner = createMinerSnapshot({
+      deviceStatus: DeviceStatus.ONLINE,
+      pairingStatus: PairingStatus.DEFAULT_PASSWORD,
+      hashrate: hashrateData,
+    });
+    expect(getMinerMeasurement(miner, hashrateGetter)).toEqual(hashrateData);
+  });
+
   it("returns stable empty array reference for needs-pool state", () => {
     const miner = createMinerSnapshot({
       deviceStatus: DeviceStatus.NEEDS_MINING_POOL,

--- a/client/src/protoFleet/features/fleetManagement/utils/getMinerMeasurement.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/getMinerMeasurement.ts
@@ -1,7 +1,7 @@
 import type { Measurement } from "@/protoFleet/api/generated/common/v1/measurement_pb";
 import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
-import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
+import { needsAuthentication } from "@/protoFleet/features/fleetManagement/utils/pairingRemediation";
 import { getLatestMeasurementWithData } from "@/shared/utils/measurementUtils";
 
 // Stable reference for empty measurement array (prevents infinite re-renders when used in components)
@@ -29,10 +29,10 @@ export function getMinerMeasurement(
     return null;
   }
 
-  // Show empty cell for devices with pool required or auth required status
+  // Empty cell when a pool or authentication is needed (telemetry gated).
+  // Default-password devices still report telemetry, so their metrics show.
   const needsPool = miner.deviceStatus === DeviceStatus.NEEDS_MINING_POOL;
-  const needsAuth = miner.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED;
-  if (needsPool || needsAuth) {
+  if (needsPool || needsAuthentication(miner.pairingStatus)) {
     return EMPTY_MEASUREMENT;
   }
 

--- a/client/src/protoFleet/features/fleetManagement/utils/pairingRemediation.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/pairingRemediation.ts
@@ -1,0 +1,9 @@
+import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+
+// Pairing remediation states differ in telemetry behavior:
+// AUTHENTICATION_NEEDED suppresses live metrics because bad credentials block telemetry;
+// DEFAULT_PASSWORD keeps telemetry flowing and is handled from Settings > Security.
+
+export const needsAuthentication = (status: PairingStatus): boolean => status === PairingStatus.AUTHENTICATION_NEEDED;
+
+export const needsPasswordChange = (status: PairingStatus): boolean => status === PairingStatus.DEFAULT_PASSWORD;

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.stories.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.stories.tsx
@@ -102,7 +102,7 @@ const CompleteSetupStory = ({ poolNeededCount, authNeededCount, isLoading = fals
   );
 };
 
-export const BothCards = () => <CompleteSetupStory poolNeededCount={6} authNeededCount={3} />;
+export const AllCards = () => <CompleteSetupStory poolNeededCount={6} authNeededCount={3} />;
 
 export const OnlyConfigurePools = () => <CompleteSetupStory poolNeededCount={14} authNeededCount={0} />;
 

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.test.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.test.tsx
@@ -112,7 +112,7 @@ describe("CompleteSetup", () => {
   };
 
   describe("Visibility conditions", () => {
-    it("does not render when no miners need pools and no miners need auth", () => {
+    it("does not render when no miners need pools or auth", () => {
       vi.mocked(usePoolNeededCount).mockReturnValue({
         poolNeededCount: 0,
         isLoading: false,
@@ -135,6 +135,13 @@ describe("CompleteSetup", () => {
       renderCompleteSetup();
 
       expect(screen.queryByText("Complete setup")).not.toBeInTheDocument();
+    });
+
+    it("does not render for default-password miners alone", () => {
+      renderCompleteSetup();
+
+      expect(screen.queryByText("Complete setup")).not.toBeInTheDocument();
+      expect(screen.queryByText("Update passwords")).not.toBeInTheDocument();
     });
 
     it("renders when miners need pools", () => {
@@ -172,7 +179,7 @@ describe("CompleteSetup", () => {
       expect(screen.getByText("2 miners need attention")).toBeInTheDocument();
     });
 
-    it("renders both cards when miners need pools and auth", () => {
+    it("renders all setup cards when miners need pools and auth", () => {
       vi.mocked(usePoolNeededCount).mockReturnValue({
         poolNeededCount: 3,
         isLoading: false,
@@ -199,6 +206,7 @@ describe("CompleteSetup", () => {
       expect(screen.getByText("3 miners")).toBeInTheDocument();
       expect(screen.getByText("Authenticate miners")).toBeInTheDocument();
       expect(screen.getByText("1 miner needs attention")).toBeInTheDocument();
+      expect(screen.queryByText("Update passwords")).not.toBeInTheDocument();
     });
 
     it("does not render when complete setup is dismissed", async () => {

--- a/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.test.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import FoundMiners from "./FoundMiners";
+import {
+  AuthenticationCapabilitiesSchema,
+  AuthenticationMethod,
+  MinerCapabilitiesSchema,
+} from "@/protoFleet/api/generated/capabilities/v1/capabilities_pb";
+import { DeviceSchema } from "@/protoFleet/api/generated/pairing/v1/pairing_pb";
+
+const miner = ({
+  manufacturer,
+  supportedMethods,
+}: {
+  manufacturer: string;
+  supportedMethods: AuthenticationMethod[];
+}) =>
+  create(DeviceSchema, {
+    deviceIdentifier: `${manufacturer}-${supportedMethods.join("-")}`,
+    ipAddress: "192.168.1.100",
+    model: "Rig",
+    manufacturer,
+    capabilities: create(MinerCapabilitiesSchema, {
+      authentication: create(AuthenticationCapabilitiesSchema, { supportedMethods }),
+    }),
+  });
+
+describe("FoundMiners", () => {
+  it("shows default-credential copy for Proto basic-auth miners", () => {
+    render(
+      <FoundMiners
+        miners={[miner({ manufacturer: "Proto", supportedMethods: [AuthenticationMethod.BASIC] })]}
+        deselectedMiners={[]}
+      />,
+    );
+
+    expect(screen.getByText("Authenticated with default username/password")).toBeInTheDocument();
+  });
+
+  it("does not infer default credentials from third-party basic-auth support", () => {
+    render(
+      <FoundMiners
+        miners={[miner({ manufacturer: "Bitmain", supportedMethods: [AuthenticationMethod.BASIC] })]}
+        deselectedMiners={[]}
+      />,
+    );
+
+    expect(screen.getByText("You will need to log in after setup")).toBeInTheDocument();
+  });
+
+  it("still shows auto-auth copy for asymmetric-key miners", () => {
+    render(
+      <FoundMiners
+        miners={[miner({ manufacturer: "FutureASIC", supportedMethods: [AuthenticationMethod.ASYMMETRIC_KEY] })]}
+        deselectedMiners={[]}
+      />,
+    );
+
+    expect(screen.getByText("Authenticated with default username/password")).toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import type { MinerWithModel } from "./types";
 import { AuthenticationMethod } from "@/protoFleet/api/generated/capabilities/v1/capabilities_pb";
 import { type Device } from "@/protoFleet/api/generated/pairing/v1/pairing_pb";
+import { minerTypes } from "@/protoFleet/features/fleetManagement/components/MinerList/constants";
 import { Fleet, LogoAlt } from "@/shared/assets/icons";
 import Divider from "@/shared/components/Divider";
 import Header from "@/shared/components/Header";
@@ -22,20 +23,6 @@ type MinersByModel = {
   [key: string]: MinersByModelItem;
 };
 
-class MinerKey {
-  manufacturer: string;
-  model: string;
-
-  constructor(manufacturer: string, model: string) {
-    this.manufacturer = manufacturer;
-    this.model = model;
-  }
-
-  toString(): string {
-    return `${this.manufacturer}:${this.model}`;
-  }
-}
-
 type MinersByModelItem = {
   model: string;
   manufacturer: string;
@@ -44,8 +31,10 @@ type MinersByModelItem = {
 };
 
 function isProtoRig(manufacturer: string): boolean {
-  return manufacturer === "Proto";
+  return manufacturer.toLowerCase() === minerTypes.protoRig;
 }
+
+const getMinerModelKey = (manufacturer: string, model: string) => `${manufacturer}:${model}`;
 
 function supportsAutoAuth(supportedMethods: AuthenticationMethod[]): boolean {
   // The server auto-pairs using the plugin's default credentials for both
@@ -105,12 +94,12 @@ const FoundMiners = ({ miners, deselectedMiners, isScanning, showSkeleton, class
     const _minersByModel: MinersByModel = {};
 
     miners.forEach((miner) => {
-      const minerKey = new MinerKey(miner.manufacturer || "unknown", miner.model || "unknown");
+      const minerKey = getMinerModelKey(miner.manufacturer || "unknown", miner.model || "unknown");
 
-      if (!_minersByModel[minerKey.toString()]) {
+      if (!_minersByModel[minerKey]) {
         const supportedMethods = miner.capabilities?.authentication?.supportedMethods || [];
 
-        _minersByModel[minerKey.toString()] = {
+        _minersByModel[minerKey] = {
           model: miner.model,
           manufacturer: miner.manufacturer || "unknown",
           supportedAuthenticationMethods: supportedMethods,
@@ -119,9 +108,9 @@ const FoundMiners = ({ miners, deselectedMiners, isScanning, showSkeleton, class
       } else if (
         // if miner is already in our state dont add it again
         // so that we dont have duplicates
-        !_minersByModel[minerKey.toString()].miners.find((m) => m.ipAddress === miner.ipAddress)
+        !_minersByModel[minerKey].miners.find((m) => m.ipAddress === miner.ipAddress)
       ) {
-        _minersByModel[minerKey.toString()].miners.push(miner);
+        _minersByModel[minerKey].miners.push(miner);
       }
     });
 

--- a/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.tsx
@@ -36,12 +36,10 @@ function isProtoRig(manufacturer: string): boolean {
 
 const getMinerModelKey = (manufacturer: string, model: string) => `${manufacturer}:${model}`;
 
-function supportsAutoAuth(supportedMethods: AuthenticationMethod[]): boolean {
-  // The server auto-pairs using the plugin's default credentials for both
-  // basic-auth (username/password) and asymmetric-key drivers.
+function supportsAutoAuth(manufacturer: string, supportedMethods: AuthenticationMethod[]): boolean {
   return (
     supportedMethods.includes(AuthenticationMethod.ASYMMETRIC_KEY) ||
-    supportedMethods.includes(AuthenticationMethod.BASIC)
+    (isProtoRig(manufacturer) && supportedMethods.includes(AuthenticationMethod.BASIC))
   );
 }
 
@@ -157,7 +155,7 @@ const FoundMiners = ({ miners, deselectedMiners, isScanning, showSkeleton, class
                     <div className="h-6 text-emphasis-300">
                       {model.manufacturer} {model.model}
                     </div>
-                    {supportsAutoAuth(model.supportedAuthenticationMethods) ? (
+                    {supportsAutoAuth(model.manufacturer, model.supportedAuthenticationMethods) ? (
                       <div className="text-200 text-text-primary-70">Authenticated with default username/password</div>
                     ) : (
                       <div className="text-200 text-text-primary-70">You will need to log in after setup</div>

--- a/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.tsx
+++ b/client/src/protoFleet/features/onboarding/components/Miners/FoundMiners.tsx
@@ -48,7 +48,12 @@ function isProtoRig(manufacturer: string): boolean {
 }
 
 function supportsAutoAuth(supportedMethods: AuthenticationMethod[]): boolean {
-  return supportedMethods.includes(AuthenticationMethod.ASYMMETRIC_KEY);
+  // The server auto-pairs using the plugin's default credentials for both
+  // basic-auth (username/password) and asymmetric-key drivers.
+  return (
+    supportedMethods.includes(AuthenticationMethod.ASYMMETRIC_KEY) ||
+    supportedMethods.includes(AuthenticationMethod.BASIC)
+  );
 }
 
 const SKELETON_INDICES = [0, 1, 2];

--- a/client/src/protoFleet/features/settings/components/Auth.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.test.tsx
@@ -212,7 +212,9 @@ describe("AuthenticationSettings", () => {
       await screen.findByText("64 miners are using default passwords");
       fireEvent.click(screen.getByTestId("default-password-update-button"));
 
-      expect(mockSecurityActionHandler).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(mockSecurityActionHandler).toHaveBeenCalledTimes(1);
+      });
       expect(screen.getByTestId("miner-action-modal-stack")).toHaveAttribute("data-display-count", "64");
 
       const useMinerActionsCalls = vi.mocked(useMinerActions).mock.calls;
@@ -236,6 +238,29 @@ describe("AuthenticationSettings", () => {
           create(MinerModelGroupSchema, { model: "Rig", manufacturer: "Bitmain", count: 1 }),
         ),
       ).toBe(false);
+    });
+
+    it("refreshes before opening security flow and skips stale zero-count updates", async () => {
+      let defaultPasswordGroupCalls = 0;
+      mockGetMinerModelGroups.mockImplementation(async (filter) => {
+        if (filter?.pairingStatuses?.includes(PairingStatus.DEFAULT_PASSWORD)) {
+          defaultPasswordGroupCalls += 1;
+          return defaultPasswordGroupCalls === 1 ? defaultPasswordModelGroups : [];
+        }
+
+        return totalModelGroups;
+      });
+
+      render(<AuthenticationSettings />);
+
+      await screen.findByText("64 miners are using default passwords");
+      fireEvent.click(screen.getByTestId("default-password-update-button"));
+
+      await waitFor(() => {
+        expect(screen.queryByText(/using default passwords/i)).not.toBeInTheDocument();
+      });
+      expect(mockRefetchDefaultPasswordMiners).toHaveBeenCalledTimes(1);
+      expect(mockSecurityActionHandler).not.toHaveBeenCalled();
     });
 
     it("refreshes default-password data after the security action completes", async () => {

--- a/client/src/protoFleet/features/settings/components/Auth.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.test.tsx
@@ -210,6 +210,25 @@ describe("AuthenticationSettings", () => {
       expect(screen.queryByTestId("default-password-update-button")).not.toBeInTheDocument();
     });
 
+    it("keeps the Devices card visible with retry when default-password counts fail to load", async () => {
+      mockGetMinerModelGroups.mockImplementationOnce(async () => {
+        throw new Error("unavailable");
+      });
+
+      render(<AuthenticationSettings />);
+
+      expect(await screen.findByTestId("default-password-load-error")).toBeInTheDocument();
+      expect(screen.getByText("Devices")).toBeInTheDocument();
+      expect(screen.queryByText("No Proto Rig miners found.")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("default-password-update-button")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Retry"));
+
+      expect(await screen.findByText("64 miners are using default passwords")).toBeInTheDocument();
+      expect(screen.queryByTestId("default-password-load-error")).not.toBeInTheDocument();
+      expect(screen.getByTestId("default-password-update-button")).toBeInTheDocument();
+    });
+
     it("starts the all-default-password security flow from the Devices card", async () => {
       render(<AuthenticationSettings />);
 

--- a/client/src/protoFleet/features/settings/components/Auth.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.test.tsx
@@ -1,7 +1,8 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
 import AuthenticationSettings from "./Auth";
-import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import { MinerModelGroupSchema, PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { useAuth } from "@/protoFleet/api/useAuth";
 import useDefaultPasswordMiners from "@/protoFleet/api/useDefaultPasswordMiners";
 import { useLogin } from "@/protoFleet/api/useLogin";
@@ -224,6 +225,16 @@ describe("AuthenticationSettings", () => {
           pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
         }),
       });
+      expect(
+        lastUseMinerActionsCall?.securityModelGroupFilter?.(
+          create(MinerModelGroupSchema, { model: "Rig", manufacturer: "Proto", count: 1 }),
+        ),
+      ).toBe(true);
+      expect(
+        lastUseMinerActionsCall?.securityModelGroupFilter?.(
+          create(MinerModelGroupSchema, { model: "Rig", manufacturer: "Bitmain", count: 1 }),
+        ),
+      ).toBe(false);
     });
 
     it("refreshes default-password data after the security action completes", async () => {

--- a/client/src/protoFleet/features/settings/components/Auth.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.test.tsx
@@ -1,12 +1,24 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AuthenticationSettings from "./Auth";
+import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { useAuth } from "@/protoFleet/api/useAuth";
+import useDefaultPasswordMiners from "@/protoFleet/api/useDefaultPasswordMiners";
 import { useLogin } from "@/protoFleet/api/useLogin";
+import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
+import { useMinerActions } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions";
 import { useUsername } from "@/protoFleet/store";
 
 vi.mock("@/protoFleet/api/useAuth");
+vi.mock("@/protoFleet/api/useDefaultPasswordMiners");
 vi.mock("@/protoFleet/api/useLogin");
+vi.mock("@/protoFleet/api/useMinerModelGroups");
+vi.mock("@/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions");
+vi.mock("@/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionModalStack", () => ({
+  default: ({ displayCount }: { displayCount?: number }) => (
+    <div data-testid="miner-action-modal-stack" data-display-count={displayCount ?? 0} />
+  ),
+}));
 vi.mock("@/protoFleet/store");
 vi.mock("@/shared/features/toaster");
 
@@ -14,8 +26,23 @@ const mockSetPassword = vi.fn();
 const mockUpdatePassword = vi.fn();
 const mockUpdateUsername = vi.fn();
 const mockLogin = vi.fn();
+const mockGetMinerModelGroups = vi.fn();
+const mockRefetchDefaultPasswordMiners = vi.fn();
+const mockSecurityActionHandler = vi.fn();
+
+const totalModelGroups = [
+  { model: "Rig", manufacturer: "Proto", count: 202 },
+  { model: "Antminer S21", manufacturer: "Bitmain", count: 78 },
+];
+
+const defaultPasswordModelGroups = [
+  { model: "Rig", manufacturer: "Proto", count: 64 },
+  { model: "Antminer S21", manufacturer: "Bitmain", count: 9 },
+];
 
 beforeEach(() => {
+  vi.clearAllMocks();
+
   vi.mocked(useAuth).mockReturnValue({
     setPassword: mockSetPassword,
     updatePassword: mockUpdatePassword,
@@ -24,9 +51,27 @@ beforeEach(() => {
   });
 
   vi.mocked(useLogin).mockReturnValue(mockLogin);
+  mockGetMinerModelGroups.mockImplementation(async (filter) =>
+    filter?.pairingStatuses?.includes(PairingStatus.DEFAULT_PASSWORD) ? defaultPasswordModelGroups : totalModelGroups,
+  );
+  vi.mocked(useMinerModelGroups).mockReturnValue({
+    getMinerModelGroups: mockGetMinerModelGroups,
+  });
+  vi.mocked(useDefaultPasswordMiners).mockReturnValue({
+    minerIds: [],
+    miners: {},
+    totalMiners: 64,
+    hasMore: false,
+    isLoading: false,
+    hasInitialLoadCompleted: true,
+    loadMore: vi.fn(),
+    refetch: mockRefetchDefaultPasswordMiners,
+    availableModels: [],
+  });
+  vi.mocked(useMinerActions).mockReturnValue({
+    popoverActions: [{ action: "security", actionHandler: mockSecurityActionHandler }],
+  } as unknown as ReturnType<typeof useMinerActions>);
   vi.mocked(useUsername).mockReturnValue("testuser");
-
-  vi.clearAllMocks();
 });
 
 describe("AuthenticationSettings", () => {
@@ -133,6 +178,70 @@ describe("AuthenticationSettings", () => {
       }
 
       expect(getByText("Account password required")).toBeInTheDocument();
+    });
+  });
+
+  describe("devices", () => {
+    it("renders Proto Rig total and default-password counts", async () => {
+      render(<AuthenticationSettings />);
+
+      expect(await screen.findByText("64 miners are using default passwords")).toBeInTheDocument();
+      expect(screen.getByText("Proto Rig")).toBeInTheDocument();
+      expect(screen.getByText("64 with default username/password")).toBeInTheDocument();
+      expect(screen.getByText("202 miners")).toBeInTheDocument();
+      expect(screen.queryByText("Antminer S21")).not.toBeInTheDocument();
+    });
+
+    it("hides the default-password callout when no Proto Rig miners use default passwords", async () => {
+      mockGetMinerModelGroups.mockImplementation(async (filter) =>
+        filter?.pairingStatuses?.includes(PairingStatus.DEFAULT_PASSWORD) ? [] : totalModelGroups,
+      );
+
+      render(<AuthenticationSettings />);
+
+      expect(await screen.findByText("Proto Rig")).toBeInTheDocument();
+      expect(screen.queryByText(/using default passwords/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/with default username\/password/i)).not.toBeInTheDocument();
+      expect(screen.queryByTestId("default-password-update-button")).not.toBeInTheDocument();
+    });
+
+    it("starts the all-default-password security flow from the Devices card", async () => {
+      render(<AuthenticationSettings />);
+
+      await screen.findByText("64 miners are using default passwords");
+      fireEvent.click(screen.getByTestId("default-password-update-button"));
+
+      expect(mockSecurityActionHandler).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("miner-action-modal-stack")).toHaveAttribute("data-display-count", "64");
+
+      const useMinerActionsCalls = vi.mocked(useMinerActions).mock.calls;
+      const lastUseMinerActionsCall = useMinerActionsCalls[useMinerActionsCalls.length - 1]?.[0];
+      expect(lastUseMinerActionsCall).toMatchObject({
+        selectionMode: "all",
+        totalCount: 64,
+        currentFilter: expect.objectContaining({
+          models: ["Rig"],
+          pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+        }),
+      });
+    });
+
+    it("refreshes default-password data after the security action completes", async () => {
+      render(<AuthenticationSettings />);
+
+      await screen.findByText("64 miners are using default passwords");
+      const callsBeforeCompletion = mockGetMinerModelGroups.mock.calls.length;
+      const useMinerActionsCalls = vi.mocked(useMinerActions).mock.calls;
+      const onActionComplete = useMinerActionsCalls[useMinerActionsCalls.length - 1]?.[0].onActionComplete;
+
+      await act(async () => {
+        onActionComplete?.();
+      });
+
+      expect(mockRefetchDefaultPasswordMiners).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(mockGetMinerModelGroups).toHaveBeenCalledTimes(callsBeforeCompletion + 2);
+      });
     });
   });
 });

--- a/client/src/protoFleet/features/settings/components/Auth.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.test.tsx
@@ -8,7 +8,7 @@ import useDefaultPasswordMiners from "@/protoFleet/api/useDefaultPasswordMiners"
 import { useLogin } from "@/protoFleet/api/useLogin";
 import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
 import { useMinerActions } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions";
-import { useUsername } from "@/protoFleet/store";
+import { useHasPermission, useUsername } from "@/protoFleet/store";
 
 vi.mock("@/protoFleet/api/useAuth");
 vi.mock("@/protoFleet/api/useDefaultPasswordMiners");
@@ -72,6 +72,7 @@ beforeEach(() => {
   vi.mocked(useMinerActions).mockReturnValue({
     popoverActions: [{ action: "security", actionHandler: mockSecurityActionHandler }],
   } as unknown as ReturnType<typeof useMinerActions>);
+  vi.mocked(useHasPermission).mockReturnValue(true);
   vi.mocked(useUsername).mockReturnValue("testuser");
 });
 
@@ -240,6 +241,16 @@ describe("AuthenticationSettings", () => {
           create(MinerModelGroupSchema, { model: "Rig", manufacturer: "Bitmain", count: 1 }),
         ),
       ).toBe(false);
+    });
+
+    it("hides the default-password update button without miner password permission", async () => {
+      vi.mocked(useHasPermission).mockReturnValue(false);
+
+      render(<AuthenticationSettings />);
+
+      expect(await screen.findByText("64 miners are using default passwords")).toBeInTheDocument();
+      expect(screen.queryByTestId("default-password-update-button")).not.toBeInTheDocument();
+      expect(mockSecurityActionHandler).not.toHaveBeenCalled();
     });
 
     it("refreshes default-password data after the security action completes", async () => {

--- a/client/src/protoFleet/features/settings/components/Auth.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.test.tsx
@@ -225,7 +225,6 @@ describe("AuthenticationSettings", () => {
       expect(lastUseMinerActionsCall).toMatchObject({
         selectionMode: "all",
         totalCount: 64,
-        securityUseCurrentFilterForAllModePasswordUpdate: true,
         currentFilter: expect.objectContaining({
           models: ["Rig"],
           pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
@@ -241,29 +240,6 @@ describe("AuthenticationSettings", () => {
           create(MinerModelGroupSchema, { model: "Rig", manufacturer: "Bitmain", count: 1 }),
         ),
       ).toBe(false);
-    });
-
-    it("refreshes before opening security flow and skips stale zero-count updates", async () => {
-      let defaultPasswordGroupCalls = 0;
-      mockGetMinerModelGroups.mockImplementation(async (filter) => {
-        if (filter?.pairingStatuses?.includes(PairingStatus.DEFAULT_PASSWORD)) {
-          defaultPasswordGroupCalls += 1;
-          return defaultPasswordGroupCalls === 1 ? defaultPasswordModelGroups : [];
-        }
-
-        return totalModelGroups;
-      });
-
-      render(<AuthenticationSettings />);
-
-      await screen.findByText("64 miners are using default passwords");
-      fireEvent.click(screen.getByTestId("default-password-update-button"));
-
-      await waitFor(() => {
-        expect(screen.queryByText(/using default passwords/i)).not.toBeInTheDocument();
-      });
-      expect(mockRefetchDefaultPasswordMiners).toHaveBeenCalledTimes(1);
-      expect(mockSecurityActionHandler).not.toHaveBeenCalled();
     });
 
     it("refreshes default-password data after the security action completes", async () => {

--- a/client/src/protoFleet/features/settings/components/Auth.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.test.tsx
@@ -193,14 +193,17 @@ describe("AuthenticationSettings", () => {
       expect(screen.queryByText("Antminer S21")).not.toBeInTheDocument();
     });
 
-    it("hides the default-password callout when no Proto Rig miners use default passwords", async () => {
+    it("hides the Devices card when no Proto Rig miners use default passwords", async () => {
       mockGetMinerModelGroups.mockImplementation(async (filter) =>
         filter?.pairingStatuses?.includes(PairingStatus.DEFAULT_PASSWORD) ? [] : totalModelGroups,
       );
 
       render(<AuthenticationSettings />);
 
-      expect(await screen.findByText("Proto Rig")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText("Devices")).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText("Proto Rig")).not.toBeInTheDocument();
       expect(screen.queryByText(/using default passwords/i)).not.toBeInTheDocument();
       expect(screen.queryByText(/with default username\/password/i)).not.toBeInTheDocument();
       expect(screen.queryByTestId("default-password-update-button")).not.toBeInTheDocument();

--- a/client/src/protoFleet/features/settings/components/Auth.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.test.tsx
@@ -220,6 +220,7 @@ describe("AuthenticationSettings", () => {
       expect(lastUseMinerActionsCall).toMatchObject({
         selectionMode: "all",
         totalCount: 64,
+        securityUseCurrentFilterForAllModePasswordUpdate: true,
         currentFilter: expect.objectContaining({
           models: ["Rig"],
           pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -146,13 +146,11 @@ const DevicesCard = ({
   rows,
   defaultPasswordCount,
   isLoading,
-  updateLoading,
   onUpdateClick,
 }: {
   rows: SecurityDeviceRow[];
   defaultPasswordCount: number;
   isLoading: boolean;
-  updateLoading: boolean;
   onUpdateClick: () => void;
 }) => {
   const hasDefaultPasswords = defaultPasswordCount > 0;
@@ -179,12 +177,7 @@ const DevicesCard = ({
                 </div>
                 <div className="min-w-0 truncate text-300">{defaultPasswordCalloutText}</div>
               </div>
-              <Button
-                variant="secondary"
-                testId="default-password-update-button"
-                onClick={onUpdateClick}
-                loading={updateLoading}
-              >
+              <Button variant="secondary" testId="default-password-update-button" onClick={onUpdateClick}>
                 Update
               </Button>
             </div>
@@ -223,7 +216,6 @@ const AuthenticationSettings = () => {
   const [usernameErrorMsg, setUsernameErrorMsg] = useState("");
   const [deviceRows, setDeviceRows] = useState<SecurityDeviceRow[]>([]);
   const [isLoadingDeviceRows, setIsLoadingDeviceRows] = useState(true);
-  const [isStartingDefaultPasswordUpdate, setIsStartingDefaultPasswordUpdate] = useState(false);
 
   // API error states
   const [authApiError, setAuthApiError] = useState<string | null>(null);
@@ -305,12 +297,9 @@ const AuthenticationSettings = () => {
     setIsLoadingDeviceRows(true);
 
     try {
-      const rows = await fetchDeviceRows();
-      setDeviceRows(rows);
-      return rows;
+      setDeviceRows(await fetchDeviceRows());
     } catch {
       setDeviceRows([]);
-      return [];
     } finally {
       setIsLoadingDeviceRows(false);
     }
@@ -329,33 +318,15 @@ const AuthenticationSettings = () => {
     miners: defaultPasswordMiners,
     onActionComplete: handleDefaultPasswordActionComplete,
     securityModelGroupFilter: isProtoGroup,
-    securityUseCurrentFilterForAllModePasswordUpdate: true,
   });
 
-  const handleUpdateDefaultPasswords = useCallback(async () => {
-    setIsStartingDefaultPasswordUpdate(true);
+  const handleUpdateDefaultPasswords = useCallback(() => {
+    const securityAction = defaultPasswordActions.popoverActions.find(
+      (action) => action.action === settingsActions.security,
+    );
 
-    try {
-      const latestRows = await refreshDeviceRows();
-      refetchDefaultPasswordMiners();
-
-      const latestDefaultPasswordCount = latestRows.reduce((total, row) => total + row.defaultPasswordCount, 0);
-      if (latestDefaultPasswordCount === 0) {
-        pushToast({
-          message: "No Proto Rig miners are using default passwords.",
-          status: TOAST_STATUSES.success,
-        });
-        return;
-      }
-
-      const securityAction = defaultPasswordActions.popoverActions.find(
-        (action) => action.action === settingsActions.security,
-      );
-      securityAction?.actionHandler();
-    } finally {
-      setIsStartingDefaultPasswordUpdate(false);
-    }
-  }, [defaultPasswordActions.popoverActions, refetchDefaultPasswordMiners, refreshDeviceRows]);
+    securityAction?.actionHandler();
+  }, [defaultPasswordActions.popoverActions]);
 
   // Reset form state when modal closes
   const [prevShowModal, setPrevShowModal] = useState(showModal);
@@ -576,7 +547,6 @@ const AuthenticationSettings = () => {
               rows={deviceRows}
               defaultPasswordCount={defaultPasswordCount}
               isLoading={isLoadingDeviceRows}
-              updateLoading={isStartingDefaultPasswordUpdate}
               onUpdateClick={handleUpdateDefaultPasswords}
             />
           ) : null}

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -146,11 +146,13 @@ const DevicesCard = ({
   rows,
   defaultPasswordCount,
   isLoading,
+  updateLoading,
   onUpdateClick,
 }: {
   rows: SecurityDeviceRow[];
   defaultPasswordCount: number;
   isLoading: boolean;
+  updateLoading: boolean;
   onUpdateClick: () => void;
 }) => {
   const hasDefaultPasswords = defaultPasswordCount > 0;
@@ -177,7 +179,12 @@ const DevicesCard = ({
                 </div>
                 <div className="min-w-0 truncate text-300">{defaultPasswordCalloutText}</div>
               </div>
-              <Button variant="secondary" testId="default-password-update-button" onClick={onUpdateClick}>
+              <Button
+                variant="secondary"
+                testId="default-password-update-button"
+                onClick={onUpdateClick}
+                loading={updateLoading}
+              >
                 Update
               </Button>
             </div>
@@ -216,6 +223,7 @@ const AuthenticationSettings = () => {
   const [usernameErrorMsg, setUsernameErrorMsg] = useState("");
   const [deviceRows, setDeviceRows] = useState<SecurityDeviceRow[]>([]);
   const [isLoadingDeviceRows, setIsLoadingDeviceRows] = useState(true);
+  const [isStartingDefaultPasswordUpdate, setIsStartingDefaultPasswordUpdate] = useState(false);
 
   // API error states
   const [authApiError, setAuthApiError] = useState<string | null>(null);
@@ -297,9 +305,12 @@ const AuthenticationSettings = () => {
     setIsLoadingDeviceRows(true);
 
     try {
-      setDeviceRows(await fetchDeviceRows());
+      const rows = await fetchDeviceRows();
+      setDeviceRows(rows);
+      return rows;
     } catch {
       setDeviceRows([]);
+      return [];
     } finally {
       setIsLoadingDeviceRows(false);
     }
@@ -321,13 +332,30 @@ const AuthenticationSettings = () => {
     securityUseCurrentFilterForAllModePasswordUpdate: true,
   });
 
-  const handleUpdateDefaultPasswords = useCallback(() => {
-    const securityAction = defaultPasswordActions.popoverActions.find(
-      (action) => action.action === settingsActions.security,
-    );
+  const handleUpdateDefaultPasswords = useCallback(async () => {
+    setIsStartingDefaultPasswordUpdate(true);
 
-    securityAction?.actionHandler();
-  }, [defaultPasswordActions.popoverActions]);
+    try {
+      const latestRows = await refreshDeviceRows();
+      refetchDefaultPasswordMiners();
+
+      const latestDefaultPasswordCount = latestRows.reduce((total, row) => total + row.defaultPasswordCount, 0);
+      if (latestDefaultPasswordCount === 0) {
+        pushToast({
+          message: "No Proto Rig miners are using default passwords.",
+          status: TOAST_STATUSES.success,
+        });
+        return;
+      }
+
+      const securityAction = defaultPasswordActions.popoverActions.find(
+        (action) => action.action === settingsActions.security,
+      );
+      securityAction?.actionHandler();
+    } finally {
+      setIsStartingDefaultPasswordUpdate(false);
+    }
+  }, [defaultPasswordActions.popoverActions, refetchDefaultPasswordMiners, refreshDeviceRows]);
 
   // Reset form state when modal closes
   const [prevShowModal, setPrevShowModal] = useState(showModal);
@@ -547,6 +575,7 @@ const AuthenticationSettings = () => {
             rows={deviceRows}
             defaultPasswordCount={defaultPasswordCount}
             isLoading={isLoadingDeviceRows}
+            updateLoading={isStartingDefaultPasswordUpdate}
             onUpdateClick={handleUpdateDefaultPasswords}
           />
 

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -1,11 +1,22 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import { create } from "@bufbuild/protobuf";
 import { AuthenticateRequestSchema } from "@/protoFleet/api/generated/auth/v1/auth_pb";
+import {
+  MinerListFilterSchema,
+  type MinerModelGroup,
+  PairingStatus,
+} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { useAuth } from "@/protoFleet/api/useAuth";
+import useDefaultPasswordMiners from "@/protoFleet/api/useDefaultPasswordMiners";
 import { useLogin } from "@/protoFleet/api/useLogin";
+import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
+import { settingsActions } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/constants";
+import MinerActionModalStack from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionModalStack";
+import { useMinerActions } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions";
+import { minerTypes } from "@/protoFleet/features/fleetManagement/components/MinerList/constants";
 import { useUsername } from "@/protoFleet/store";
-import { Alert } from "@/shared/assets/icons";
+import { Alert, LogoAlt } from "@/shared/assets/icons";
 import Button from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Header from "@/shared/components/Header";
@@ -14,6 +25,7 @@ import Modal from "@/shared/components/Modal";
 import Row from "@/shared/components/Row";
 import { PasswordStrengthMeter, WeakPasswordWarning } from "@/shared/components/Setup";
 import { isPasswordTooShort, isWeakPassword, passwordErrors } from "@/shared/components/Setup/authentication.constants";
+import SkeletonBar from "@/shared/components/SkeletonBar";
 import { pushToast, STATUSES as TOAST_STATUSES } from "@/shared/features/toaster";
 
 const AuthenticateForm = ({ onChange, apiError }: { onChange: (value: string) => void; apiError: string | null }) => {
@@ -54,11 +66,140 @@ const FormattedDate = ({ date, className, label }: { date: Date | null; classNam
   );
 };
 
+type SecurityDeviceRow = {
+  key: string;
+  name: string;
+  model: string;
+  manufacturer: string;
+  totalCount: number;
+  defaultPasswordCount: number;
+};
+
+const isProtoGroup = (group: MinerModelGroup) => group.manufacturer.toLowerCase() === minerTypes.protoRig;
+
+const getGroupKey = (group: Pick<MinerModelGroup, "manufacturer" | "model">) =>
+  `${group.manufacturer.toLowerCase()}::${group.model.toLowerCase()}`;
+
+const getGroupName = (group: Pick<MinerModelGroup, "manufacturer" | "model">) => {
+  if (group.manufacturer.toLowerCase() === minerTypes.protoRig) {
+    return group.model.toLowerCase().startsWith("proto") ? group.model : `Proto ${group.model}`.trim();
+  }
+
+  return group.model || "Unknown model";
+};
+
+const formatMinerCount = (count: number) => `${count} ${count === 1 ? "miner" : "miners"}`;
+
+const buildProtoDeviceRows = (
+  totalGroups: MinerModelGroup[],
+  defaultPasswordGroups: MinerModelGroup[],
+): SecurityDeviceRow[] => {
+  const rows = new Map<string, SecurityDeviceRow>();
+
+  totalGroups.filter(isProtoGroup).forEach((group) => {
+    rows.set(getGroupKey(group), {
+      key: getGroupKey(group),
+      name: getGroupName(group),
+      model: group.model,
+      manufacturer: group.manufacturer,
+      totalCount: group.count,
+      defaultPasswordCount: 0,
+    });
+  });
+
+  defaultPasswordGroups.filter(isProtoGroup).forEach((group) => {
+    const key = getGroupKey(group);
+    const existing = rows.get(key);
+
+    rows.set(key, {
+      key,
+      name: existing?.name ?? getGroupName(group),
+      model: group.model,
+      manufacturer: group.manufacturer,
+      totalCount: existing?.totalCount ?? group.count,
+      defaultPasswordCount: group.count,
+    });
+  });
+
+  return Array.from(rows.values()).sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const DeviceModelRow = ({ row }: { row: SecurityDeviceRow }) => (
+  <div className="grid grid-cols-[auto_1fr_auto] items-center gap-4 border-b border-border-5 py-4 last:border-b-0">
+    <div className="flex size-6 items-center justify-center text-text-primary">
+      <LogoAlt width="w-5" />
+    </div>
+    <div className="min-w-0">
+      <div className="truncate text-emphasis-300">{row.name}</div>
+      {row.defaultPasswordCount > 0 ? (
+        <div className="truncate text-300 text-text-primary-50">
+          {row.defaultPasswordCount} with default username/password
+        </div>
+      ) : null}
+    </div>
+    <div className="text-300 text-text-primary">{formatMinerCount(row.totalCount)}</div>
+  </div>
+);
+
+const DevicesCard = ({
+  rows,
+  defaultPasswordCount,
+  isLoading,
+  onUpdateClick,
+}: {
+  rows: SecurityDeviceRow[];
+  defaultPasswordCount: number;
+  isLoading: boolean;
+  onUpdateClick: () => void;
+}) => {
+  const hasDefaultPasswords = defaultPasswordCount > 0;
+  const defaultPasswordNoun = defaultPasswordCount === 1 ? "a default password" : "default passwords";
+  const defaultPasswordCalloutText = `${formatMinerCount(defaultPasswordCount)} ${
+    defaultPasswordCount === 1 ? "is" : "are"
+  } using ${defaultPasswordNoun}`;
+
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
+      <Header title="Devices" titleSize="text-heading-200" />
+      {isLoading && rows.length === 0 ? (
+        <div className="flex flex-col gap-4">
+          <SkeletonBar className="h-16 w-full" />
+          <SkeletonBar className="h-12 w-full" />
+        </div>
+      ) : (
+        <>
+          {hasDefaultPasswords ? (
+            <div className="flex items-center justify-between gap-4 rounded-xl border border-border-5 bg-surface-base px-4 py-3 shadow-50">
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="flex size-7 shrink-0 items-center justify-center">
+                  <Alert className="text-intent-critical-fill" width="w-5" />
+                </div>
+                <div className="min-w-0 truncate text-300">{defaultPasswordCalloutText}</div>
+              </div>
+              <Button variant="secondary" testId="default-password-update-button" onClick={onUpdateClick}>
+                Update
+              </Button>
+            </div>
+          ) : null}
+          <div>
+            {rows.length > 0 ? (
+              rows.map((row) => <DeviceModelRow key={row.key} row={row} />)
+            ) : (
+              <div className="py-4 text-300 text-text-primary-50">No Proto Rig miners found.</div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
 const AuthenticationSettings = () => {
   const username = useUsername();
 
   const { updatePassword, updateUsername, passwordLastUpdatedAt } = useAuth();
   const login = useLogin();
+  const { getMinerModelGroups } = useMinerModelGroups();
 
   const [showModal, setShowModal] = useState(false);
   const [updatingState, setUpdatingState] = useState<"password" | "username">();
@@ -72,12 +213,118 @@ const AuthenticationSettings = () => {
   const [passwordErrorMsg, setPasswordErrorMsg] = useState("");
   const [newUsername, setNewUsername] = useState("");
   const [usernameErrorMsg, setUsernameErrorMsg] = useState("");
+  const [deviceRows, setDeviceRows] = useState<SecurityDeviceRow[]>([]);
+  const [isLoadingDeviceRows, setIsLoadingDeviceRows] = useState(true);
 
   // API error states
   const [authApiError, setAuthApiError] = useState<string | null>(null);
   const [passwordUpdateApiError, setPasswordUpdateApiError] = useState<string | null>(null);
   const [usernameUpdateApiError, setUsernameUpdateApiError] = useState<string | null>(null);
   const [showWeakPasswordWarning, setShowWeakPasswordWarning] = useState(false);
+
+  const defaultPasswordGroupsFilter = useMemo(
+    () =>
+      create(MinerListFilterSchema, {
+        pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+      }),
+    [],
+  );
+
+  const protoModels = useMemo(() => deviceRows.map((row) => row.model), [deviceRows]);
+  const defaultPasswordActionFilter = useMemo(
+    () =>
+      create(MinerListFilterSchema, {
+        models: protoModels,
+        pairingStatuses: [PairingStatus.DEFAULT_PASSWORD],
+      }),
+    [protoModels],
+  );
+  const defaultPasswordMinerFilter = useMemo(
+    () =>
+      create(MinerListFilterSchema, {
+        models: protoModels,
+      }),
+    [protoModels],
+  );
+
+  const { miners: defaultPasswordMiners, refetch: refetchDefaultPasswordMiners } = useDefaultPasswordMiners({
+    enabled: protoModels.length > 0,
+    filter: defaultPasswordMinerFilter,
+    pageSize: 1,
+  });
+
+  const defaultPasswordCount = useMemo(
+    () => deviceRows.reduce((total, row) => total + row.defaultPasswordCount, 0),
+    [deviceRows],
+  );
+
+  const fetchDeviceRows = useCallback(async () => {
+    const [totalGroups, defaultPasswordGroups] = await Promise.all([
+      getMinerModelGroups(null),
+      getMinerModelGroups(defaultPasswordGroupsFilter),
+    ]);
+
+    return buildProtoDeviceRows(totalGroups, defaultPasswordGroups);
+  }, [defaultPasswordGroupsFilter, getMinerModelGroups]);
+
+  useEffect(() => {
+    let ignore = false;
+
+    void fetchDeviceRows()
+      .then((rows) => {
+        if (!ignore) {
+          setDeviceRows(rows);
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setDeviceRows([]);
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsLoadingDeviceRows(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [fetchDeviceRows]);
+
+  const refreshDeviceRows = useCallback(async () => {
+    setIsLoadingDeviceRows(true);
+
+    try {
+      setDeviceRows(await fetchDeviceRows());
+    } catch {
+      setDeviceRows([]);
+    } finally {
+      setIsLoadingDeviceRows(false);
+    }
+  }, [fetchDeviceRows]);
+
+  const handleDefaultPasswordActionComplete = useCallback(() => {
+    refetchDefaultPasswordMiners();
+    void refreshDeviceRows();
+  }, [refetchDefaultPasswordMiners, refreshDeviceRows]);
+
+  const defaultPasswordActions = useMinerActions({
+    selectedMiners: [],
+    selectionMode: "all",
+    totalCount: defaultPasswordCount,
+    currentFilter: defaultPasswordActionFilter,
+    miners: defaultPasswordMiners,
+    onActionComplete: handleDefaultPasswordActionComplete,
+  });
+
+  const handleUpdateDefaultPasswords = useCallback(() => {
+    const securityAction = defaultPasswordActions.popoverActions.find(
+      (action) => action.action === settingsActions.security,
+    );
+
+    securityAction?.actionHandler();
+  }, [defaultPasswordActions.popoverActions]);
 
   // Reset form state when modal closes
   const [prevShowModal, setPrevShowModal] = useState(showModal);
@@ -293,6 +540,13 @@ const AuthenticationSettings = () => {
             </div>
           </div>
 
+          <DevicesCard
+            rows={deviceRows}
+            defaultPasswordCount={defaultPasswordCount}
+            isLoading={isLoadingDeviceRows}
+            onUpdateClick={handleUpdateDefaultPasswords}
+          />
+
           <Modal
             open={showModal}
             buttons={[
@@ -410,6 +664,12 @@ const AuthenticationSettings = () => {
               </div>
             ) : null}
           </Modal>
+          <MinerActionModalStack
+            minerActions={defaultPasswordActions}
+            selectedMinerIds={[]}
+            selectionMode="all"
+            displayCount={defaultPasswordCount}
+          />
         </div>
       </div>
     </>

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -318,6 +318,7 @@ const AuthenticationSettings = () => {
     miners: defaultPasswordMiners,
     onActionComplete: handleDefaultPasswordActionComplete,
     securityModelGroupFilter: isProtoGroup,
+    securityUseCurrentFilterForAllModePasswordUpdate: true,
   });
 
   const handleUpdateDefaultPasswords = useCallback(() => {

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -15,7 +15,7 @@ import { settingsActions } from "@/protoFleet/features/fleetManagement/component
 import MinerActionModalStack from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionModalStack";
 import { useMinerActions } from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions";
 import { minerTypes } from "@/protoFleet/features/fleetManagement/components/MinerList/constants";
-import { useUsername } from "@/protoFleet/store";
+import { useHasPermission, useUsername } from "@/protoFleet/store";
 import { Alert, LogoAlt } from "@/shared/assets/icons";
 import Button from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
@@ -146,11 +146,13 @@ const DevicesCard = ({
   rows,
   defaultPasswordCount,
   isLoading,
+  canUpdateDefaultPasswords,
   onUpdateClick,
 }: {
   rows: SecurityDeviceRow[];
   defaultPasswordCount: number;
   isLoading: boolean;
+  canUpdateDefaultPasswords: boolean;
   onUpdateClick: () => void;
 }) => {
   const hasDefaultPasswords = defaultPasswordCount > 0;
@@ -177,9 +179,11 @@ const DevicesCard = ({
                 </div>
                 <div className="min-w-0 truncate text-300">{defaultPasswordCalloutText}</div>
               </div>
-              <Button variant="secondary" testId="default-password-update-button" onClick={onUpdateClick}>
-                Update
-              </Button>
+              {canUpdateDefaultPasswords ? (
+                <Button variant="secondary" testId="default-password-update-button" onClick={onUpdateClick}>
+                  Update
+                </Button>
+              ) : null}
             </div>
           ) : null}
           <div>
@@ -197,6 +201,7 @@ const DevicesCard = ({
 
 const AuthenticationSettings = () => {
   const username = useUsername();
+  const canUpdateDefaultPasswords = useHasPermission("miner:update_password");
 
   const { updatePassword, updateUsername, passwordLastUpdatedAt } = useAuth();
   const login = useLogin();
@@ -547,6 +552,7 @@ const AuthenticationSettings = () => {
               rows={deviceRows}
               defaultPasswordCount={defaultPasswordCount}
               isLoading={isLoadingDeviceRows}
+              canUpdateDefaultPasswords={canUpdateDefaultPasswords}
               onUpdateClick={handleUpdateDefaultPasswords}
             />
           ) : null}

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -146,13 +146,17 @@ const DevicesCard = ({
   rows,
   defaultPasswordCount,
   isLoading,
+  hasLoadError,
   canUpdateDefaultPasswords,
+  onRetry,
   onUpdateClick,
 }: {
   rows: SecurityDeviceRow[];
   defaultPasswordCount: number;
   isLoading: boolean;
+  hasLoadError: boolean;
   canUpdateDefaultPasswords: boolean;
+  onRetry: () => void;
   onUpdateClick: () => void;
 }) => {
   const hasDefaultPasswords = defaultPasswordCount > 0;
@@ -171,6 +175,17 @@ const DevicesCard = ({
         </div>
       ) : (
         <>
+          {hasLoadError ? (
+            <Callout
+              intent="danger"
+              prefixIcon={<Alert />}
+              title="Couldn't load device security status."
+              subtitle="Retry to check whether Proto Rig miners are using default passwords."
+              buttonText="Retry"
+              buttonOnClick={onRetry}
+              testId="default-password-load-error"
+            />
+          ) : null}
           {hasDefaultPasswords ? (
             <div className="flex items-center justify-between gap-4 rounded-xl border border-border-5 bg-surface-base px-4 py-3 shadow-50">
               <div className="flex min-w-0 items-center gap-3">
@@ -189,7 +204,7 @@ const DevicesCard = ({
           <div>
             {rows.length > 0 ? (
               rows.map((row) => <DeviceModelRow key={row.key} row={row} />)
-            ) : (
+            ) : hasLoadError ? null : (
               <div className="py-4 text-300 text-text-primary-50">No Proto Rig miners found.</div>
             )}
           </div>
@@ -221,6 +236,7 @@ const AuthenticationSettings = () => {
   const [usernameErrorMsg, setUsernameErrorMsg] = useState("");
   const [deviceRows, setDeviceRows] = useState<SecurityDeviceRow[]>([]);
   const [isLoadingDeviceRows, setIsLoadingDeviceRows] = useState(true);
+  const [hasDeviceRowsLoadError, setHasDeviceRowsLoadError] = useState(false);
 
   // API error states
   const [authApiError, setAuthApiError] = useState<string | null>(null);
@@ -280,11 +296,12 @@ const AuthenticationSettings = () => {
       .then((rows) => {
         if (!ignore) {
           setDeviceRows(rows);
+          setHasDeviceRowsLoadError(false);
         }
       })
       .catch(() => {
         if (!ignore) {
-          setDeviceRows([]);
+          setHasDeviceRowsLoadError(true);
         }
       })
       .finally(() => {
@@ -303,8 +320,9 @@ const AuthenticationSettings = () => {
 
     try {
       setDeviceRows(await fetchDeviceRows());
+      setHasDeviceRowsLoadError(false);
     } catch {
-      setDeviceRows([]);
+      setHasDeviceRowsLoadError(true);
     } finally {
       setIsLoadingDeviceRows(false);
     }
@@ -547,12 +565,14 @@ const AuthenticationSettings = () => {
             </div>
           </div>
 
-          {isLoadingDeviceRows || defaultPasswordCount > 0 ? (
+          {isLoadingDeviceRows || hasDeviceRowsLoadError || defaultPasswordCount > 0 ? (
             <DevicesCard
               rows={deviceRows}
               defaultPasswordCount={defaultPasswordCount}
               isLoading={isLoadingDeviceRows}
+              hasLoadError={hasDeviceRowsLoadError}
               canUpdateDefaultPasswords={canUpdateDefaultPasswords}
+              onRetry={refreshDeviceRows}
               onUpdateClick={handleUpdateDefaultPasswords}
             />
           ) : null}

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -75,7 +75,8 @@ type SecurityDeviceRow = {
   defaultPasswordCount: number;
 };
 
-const isProtoGroup = (group: MinerModelGroup) => group.manufacturer.toLowerCase() === minerTypes.protoRig;
+const isProtoGroup = (group: Pick<MinerModelGroup, "manufacturer">) =>
+  group.manufacturer.toLowerCase() === minerTypes.protoRig;
 
 const getGroupKey = (group: Pick<MinerModelGroup, "manufacturer" | "model">) =>
   `${group.manufacturer.toLowerCase()}::${group.model.toLowerCase()}`;
@@ -316,6 +317,7 @@ const AuthenticationSettings = () => {
     currentFilter: defaultPasswordActionFilter,
     miners: defaultPasswordMiners,
     onActionComplete: handleDefaultPasswordActionComplete,
+    securityModelGroupFilter: isProtoGroup,
   });
 
   const handleUpdateDefaultPasswords = useCallback(() => {

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -571,13 +571,15 @@ const AuthenticationSettings = () => {
             </div>
           </div>
 
-          <DevicesCard
-            rows={deviceRows}
-            defaultPasswordCount={defaultPasswordCount}
-            isLoading={isLoadingDeviceRows}
-            updateLoading={isStartingDefaultPasswordUpdate}
-            onUpdateClick={handleUpdateDefaultPasswords}
-          />
+          {isLoadingDeviceRows || defaultPasswordCount > 0 ? (
+            <DevicesCard
+              rows={deviceRows}
+              defaultPasswordCount={defaultPasswordCount}
+              isLoading={isLoadingDeviceRows}
+              updateLoading={isStartingDefaultPasswordUpdate}
+              onUpdateClick={handleUpdateDefaultPasswords}
+            />
+          ) : null}
 
           <Modal
             open={showModal}

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -504,7 +504,7 @@ func (s *SQLDeviceStore) GetMinerModelGroups(ctx context.Context, orgID int64, f
 	// Static sqlc query can't express numeric ranges, CIDR membership, or
 	// site filters; use the dynamic builder when any are active so the
 	// bulk-action modal counts match the filtered list.
-	if filter != nil && (len(filter.NumericRanges) > 0 || len(filter.IPCIDRs) > 0 || len(filter.SiteIDs) > 0 || filter.IncludeUnassigned || len(filter.BuildingIDs) > 0 || filter.IncludeNoBuilding || len(filter.ZoneKeys) > 0 || filter.IncludeNoRack) {
+	if filter != nil && (len(filter.PairingStatuses) > 0 || len(filter.NumericRanges) > 0 || len(filter.IPCIDRs) > 0 || len(filter.SiteIDs) > 0 || filter.IncludeUnassigned || len(filter.BuildingIDs) > 0 || filter.IncludeNoBuilding || len(filter.ZoneKeys) > 0 || filter.IncludeNoRack) {
 		return s.executeModelGroupsDynamicQuery(ctx, orgID, filter)
 	}
 

--- a/server/internal/domain/stores/sqlstores/get_miner_model_groups_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/get_miner_model_groups_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	collectionpb "github.com/block/proto-fleet/server/generated/grpc/collection/v1"
+	fm "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
 	pb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	"github.com/block/proto-fleet/server/generated/sqlc"
 	"github.com/block/proto-fleet/server/internal/domain/miner/models"
@@ -91,6 +92,13 @@ func TestGetMinerModelGroups_IncludesDefaultPasswordAndExcludesAuthNeeded(t *tes
 	require.NoError(t, err)
 	require.Len(t, dynamicGroups, 1)
 	assert.Equal(t, int32(2), dynamicGroups[0].Count, "dynamic filters must match the static password-update grouping")
+
+	defaultPasswordGroups, err := deviceStore.GetMinerModelGroups(ctx, user.OrganizationID, &stores.MinerFilter{
+		PairingStatuses: []fm.PairingStatus{fm.PairingStatus_PAIRING_STATUS_DEFAULT_PASSWORD},
+	})
+	require.NoError(t, err)
+	require.Len(t, defaultPasswordGroups, 1)
+	assert.Equal(t, int32(1), defaultPasswordGroups[0].Count, "pairing-status filters must narrow model-group counts")
 }
 
 // setDiscoveredDeviceModel patches discovered_device.model directly because


### PR DESCRIPTION
Reviewable diff: +455/-104 across 18 files (excludes generated, test, and story files).

## Summary

This PR moves default-password remediation out of setup, issue, and status surfaces and into Settings > Security. `DEFAULT_PASSWORD` remains visible and selectable in fleet lists, but it is no longer presented as an attention status, credential-blocked row, Complete Setup blocker, or command restriction.

**Stack:** This PR is stacked on [#480](https://github.com/block/proto-fleet/pull/480), which makes `DEFAULT_PASSWORD` a paired-like server state, keeps default-password rigs command-eligible, and aligns backend state classifiers so default-password miners are not counted as broken. The diff here is relative to #480 and is UI-only. [#477](https://github.com/block/proto-fleet/pull/477) is a separate stack branch from #480 for fleet-node enrollment/default-password propagation and is not required for this UI behavior.

## How it works

Settings > Security keeps the existing Account card and adds a Devices card for Proto rigs. The page fetches all model groups and default-password model groups with existing client APIs, filters both sets to `manufacturer.toLowerCase() === "proto"`, renders a Proto Rig row with total and default-password counts, and shows a top callout only when at least one Proto rig is using the default password.

The callout Update button reuses the existing `useMinerActions` password-update modal flow in `selectionMode: "all"`. The selector is scoped with model, manufacturer, and pairing-status filters so password update targets Proto rigs whose pairing status is `DEFAULT_PASSWORD`. When the flow completes, the Settings page refetches both total and default-password model groups.

Complete Setup now appears only for pool setup or authentication-needed setup. Fleet list, worker-name, miner-name, status modal, issue, and group-action surfaces treat only `AUTHENTICATION_NEEDED` as credential-blocked; default-password rigs use their normal device status/error display.

All-mode fleet actions use a shared selectable-row filter for `PAIRED` and `DEFAULT_PASSWORD`. This keeps action-bar counts, capability checks, command selectors, and all-mode Unpair aligned with what the UI actually lets operators select, while still excluding `AUTHENTICATION_NEEDED` rows from operational action scope.

```mermaid
flowchart TD
  A["Settings > Security"] --> B["useMinerModelGroups: all miners"]
  A --> C["useMinerModelGroups: DEFAULT_PASSWORD miners"]
  B --> D["Filter manufacturer = proto"]
  C --> D
  D --> E["Devices card: Proto Rig totals"]
  E --> F{"Default-password Proto count > 0?"}
  F -- "yes" --> G["Show callout and Update button"]
  F -- "no" --> H["Show row only"]
  G --> I["useMinerActions all-mode password update"]
  I --> J["Refetch counts on completion"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/settings/components/Auth.tsx` | Adds the Proto-only Devices card and launches the existing all-mode password update flow | Primary operator entry point for default-password remediation |
| `client/src/protoFleet/api/useDefaultPasswordMiners.*` | Adds focused default-password count/model-group fetching helper | Keeps Security page data loading reusable and testable |
| `client/src/protoFleet/features/onboarding/components/CompleteSetup` | Removes default-password card/polling/modal wiring | Keeps Complete Setup scoped to setup blockers only |
| `client/src/protoFleet/features/fleetManagement/components/MinerList/*` | Stops treating `DEFAULT_PASSWORD` as attention/credential-blocked and keeps all-mode selection scoped to selectable rows | Aligns list behavior, counts, and action gating with the product decision |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/*` | Applies the selectable all-mode pairing filter to capability checks, command selectors, Unpair, and Settings security grouping | Prevents selected default-password miners from being omitted and auth-needed miners from blocking valid bulk actions |
| `client/src/protoFleet/components/StatusModal` | Uses normal status/error summaries for default-password miners | Prevents remediation copy from appearing as status detail |
| `client/src/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu` | Blocks scoped group actions only for `AUTHENTICATION_NEEDED` devices | Keeps default-password rigs selectable now that the server does not gate commands |
| `client/src/protoFleet/features/fleetManagement/utils/*` | Keeps fleet-visible/selectable pairing filters and measurements aligned with default-password visibility | Prevents list/filter regressions |

## Key technical decisions & trade-offs

| Decision | Trade-off |
| --- | --- |
| Put remediation in Settings > Security instead of Complete Setup | Default passwords are managed as a security setting, not onboarding progress |
| Show only Proto Rig in v1 | Matches the current Proto-only default-password implementation |
| Reuse existing model-group and miner-action APIs | Avoids new backend API, proto, or migration work |
| Preserve fleet visibility and selection for `DEFAULT_PASSWORD` | Operators can manage rigs normally while using Settings for credential hygiene |
| Centralize all-mode selectable scope as `PAIRED + DEFAULT_PASSWORD` | Keeps UI counts and request selectors aligned while continuing to exclude auth-needed rows |

## Testing & validation

- `cd client && npm run lint`
- `cd client && npm run format:check`
- `cd client && npx vitest run src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx`
- `cd client && npx vitest run src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx src/protoFleet/features/settings/components/Auth.test.tsx`
- `cd client && npm run build:protoFleet`

No backend, proto, migration, or generated-code changes are included in this PR.
