### PR TITLE
Add ProtoOS E2E coverage for no-pools callout suppression

### DIFF
--- a/client/e2eTests/protoOS/pages/home.ts
+++ b/client/e2eTests/protoOS/pages/home.ts
@@ -2,6 +2,17 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class HomePage extends BasePage {
+  async validateNoMiningPoolsCallout() {
+    const callout = this.page.getByTestId("callout");
+    await expect(callout).toBeVisible();
+    await expect(callout.getByText("No mining pools configured.")).toBeVisible();
+    await expect(callout.getByRole("button", { name: "Add mining pools" })).toBeVisible();
+  }
+
+  async clickAddMiningPoolsInCallout() {
+    await this.page.getByTestId("callout").getByRole("button", { name: "Add mining pools" }).click();
+  }
+
   async clickTab(tabName: string) {
     await this.page.getByTestId(`tab-${tabName}`).click();
   }

--- a/client/e2eTests/protoOS/pages/pools.ts
+++ b/client/e2eTests/protoOS/pages/pools.ts
@@ -2,6 +2,63 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class PoolsPage extends BasePage {
+  async clearAllPoolsViaApi() {
+    const response = await this.page.evaluate(async () => {
+      const authStorage = window.localStorage.getItem("proto-os-auth");
+      if (!authStorage) {
+        throw new Error("proto-os-auth is missing from localStorage");
+      }
+
+      const parsedStorage = JSON.parse(authStorage) as {
+        state?: {
+          auth?: {
+            authTokens?: {
+              accessToken?: {
+                value?: string;
+              };
+            };
+          };
+        };
+      };
+
+      const accessToken = parsedStorage.state?.auth?.authTokens?.accessToken?.value;
+      if (!accessToken) {
+        throw new Error("Access token is missing from proto-os-auth");
+      }
+
+      const request = await fetch("/api/v1/pools", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify([]),
+      });
+
+      return {
+        ok: request.ok,
+        status: request.status,
+        statusText: request.statusText,
+        body: await request.text(),
+      };
+    });
+
+    expect(
+      response.ok,
+      `Failed to clear pools: ${response.status} ${response.statusText} ${response.body}`,
+    ).toBeTruthy();
+  }
+
+  async validateNoPoolsEmptyState() {
+    await expect(this.page.getByText("Pools", { exact: true })).toBeVisible();
+    await expect(this.page.getByText("Add up to 3 pools for your miner.")).toBeVisible();
+    await expect(this.page.getByTestId("add-pool-button")).toBeVisible();
+  }
+
+  async validateNoMiningPoolsCalloutHidden() {
+    await expect(this.page.getByTestId("callout").getByText("No mining pools configured.")).toBeHidden();
+  }
+
   async validatePoolModalOpened() {
     await expect(this.page.getByTestId("modal")).toBeVisible();
   }

--- a/client/e2eTests/protoOS/spec/pools.spec.ts
+++ b/client/e2eTests/protoOS/spec/pools.spec.ts
@@ -98,4 +98,25 @@ test.describe("Mining pools", () => {
       await poolsPage.validatePoolRowDetails(2, poolName2, testConfig.pool.url);
     });
   });
+
+  test("Suppress no-pools global callout on the pools empty state page", async ({ homePage, poolsPage }) => {
+    await test.step("Clear configured pools through the authenticated API", async () => {
+      await poolsPage.clearAllPoolsViaApi();
+      await homePage.reloadPage();
+    });
+
+    await test.step("Validate the home page shows the global no-pools callout", async () => {
+      await homePage.validateTitle("Home");
+      await homePage.validateNoMiningPoolsCallout();
+    });
+
+    await test.step("Follow the callout CTA to mining pools settings", async () => {
+      await homePage.clickAddMiningPoolsInCallout();
+    });
+
+    await test.step("Validate the pools page shows its own empty state without the global callout", async () => {
+      await poolsPage.validateNoPoolsEmptyState();
+      await poolsPage.validateNoMiningPoolsCalloutHidden();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add ProtoOS E2E coverage for the route-sensitive no-pools global callout behavior
- verify the global no-pools banner appears on Home when pools are cleared
- verify the Pools page shows its own empty state while suppressing the global banner

## Testing
- ./node_modules/.bin/eslint e2eTests/protoOS/pages/home.ts e2eTests/protoOS/pages/pools.ts e2eTests/protoOS/spec/pools.spec.ts
- npx playwright test spec/00-onboarding.spec.ts --project=desktop
- npx playwright test spec/pools.spec.ts --project=desktop --grep "Suppress no-pools global callout"
- npx playwright test spec/pools.spec.ts --project=desktop
- npx playwright test spec/pools.spec.ts --project=mobile --grep "Suppress no-pools global callout"
