### PR TITLE
Add reviewable diff line to PR descriptions

### DIFF
--- a/.claude/commands/pr-describe.md
+++ b/.claude/commands/pr-describe.md
@@ -73,11 +73,12 @@ describe what the code does, not the decisions made getting there.
      path.
    - **Current-branch path:** run
      `git diff "origin/<base>...HEAD" --numstat`.
-   - Exclude generated files (`**/generated/**`, `*.pb.go`, `*.pb.ts`), test
-     files (`*_test.go`, `*.test.*`, `*.spec.*`, `__tests__/**`, `tests/**`,
-     `test/**`), and story files (`*.stories.*`, `*.story.*`, `stories/**`)
-     before summing. For renamed paths, exclude the row if either the old or
-     new path matches an excluded pattern.
+   - Exclude generated files (`**/generated/**`, `*.pb.go`, `*.pb.ts`,
+     `client/src/protoOS/api/generatedApi.ts`), test files (`*_test.go`,
+     `*.test.*`, `*.spec.*`, `__tests__/**`, `tests/**`, `test/**`), and story
+     files (`*.stories.*`, `*.story.*`, `stories/**`) before summing. For
+     renamed paths, exclude the row if either the old or new path matches an
+     excluded pattern.
    - Sum the remaining numeric additions and deletions, and count the remaining
      files. Ignore binary-only rows with `-` additions/deletions in the line
      totals; if non-excluded binary files remain, append `; <N> binary files

--- a/.claude/commands/pr-describe.md
+++ b/.claude/commands/pr-describe.md
@@ -64,6 +64,27 @@ describe what the code does, not the decisions made getting there.
    From the file list, identify which subsystems are touched (`server/`,
    `client/`, `plugin/`, `proto/`, `migrations/`, `packages/proto-python-gen/`).
 
+   Also compute the reviewable line diff from the same diff scope so reviewers
+   can gauge PR size without counting generated or review-light files:
+
+   - **Numbered-PR path:** save the PR patch from
+     `gh pr diff <number> -R <owner>/<repo> --patch` to a temp file and run
+     `git apply --numstat /path/to/tmp.patch` to get added/deleted lines by
+     path.
+   - **Current-branch path:** run
+     `git diff "origin/<base>...HEAD" --numstat`.
+   - Exclude generated files (`**/generated/**`, `*.pb.go`, `*.pb.ts`), test
+     files (`*_test.go`, `*.test.*`, `*.spec.*`, `__tests__/**`, `tests/**`,
+     `test/**`), and story files (`*.stories.*`, `*.story.*`, `stories/**`)
+     before summing. For renamed paths, exclude the row if either the old or
+     new path matches an excluded pattern.
+   - Sum the remaining numeric additions and deletions, and count the remaining
+     files. Ignore binary-only rows with `-` additions/deletions in the line
+     totals; if non-excluded binary files remain, append `; <N> binary files
+     have no line count` to the reviewable diff line.
+   - Record the result as:
+     `Reviewable diff: +<additions>/-<deletions> across <files> files (excludes generated, test, and story files).`
+
    If the target is part of a series (step 1), also read each ancestor PR's description
    (`gh pr view <number> --json title,body,url`, adding `-R` on the numbered-PR
    path) and extract the load-bearing context this PR depends on: the contracts,
@@ -82,7 +103,10 @@ describe what the code does, not the decisions made getting there.
 
 3. Draft the description in this structure:
 
-   1. **Summary** — 2-4 sentences: what this PR delivers and why it exists.
+   1. `Reviewable diff: +<additions>/-<deletions> across <files> files
+      (excludes generated, test, and story files).` — the reviewable line diff
+      from step 2. This must be the first line of the PR description.
+   2. **Summary** — 2-4 sentences: what this PR delivers and why it exists.
       Lead with the user- or operator-facing capability, not the implementation.
       If the PR is part of a series (step 1), follow the summary with a short
       **Stack** note: the full chain with PR numbers/links (ancestors down to
@@ -95,24 +119,24 @@ describe what the code does, not the decisions made getting there.
       what is intentionally out of scope here and where the remaining work
       lands, drawn from descendant PRs, the plan docs, this conversation, and
       any tracking issues (later phases may not be open as PRs yet).
-   2. **How it works** — the end-to-end mechanism in plain language. Walk the
+   3. **How it works** — the end-to-end mechanism in plain language. Walk the
       primary flow(s) step by step (who triggers it, what crosses each boundary,
       where state is persisted, what comes back). Assume the reader does not
       know Go/TS idioms; explain workflows and mechanisms, not syntax.
-   3. **Diagrams** — include mermaid diagrams in fenced code blocks labeled `mermaid` so
+   4. **Diagrams** — include mermaid diagrams in fenced code blocks labeled `mermaid` so
       they render on GitHub. At minimum a component/flow diagram of the main
       path; add a state or sequence diagram where lifecycle or ordering matters.
       Keep syntax GitHub-safe: quote labels containing special characters, avoid
       fragile edge styles (e.g. dotted/labelled edges that GitHub mis-renders).
-   4. **Areas of the code involved** — a table so reviewers know where to focus:
+   5. **Areas of the code involved** — a table so reviewers know where to focus:
       `| Area / package / file | What changed | Why it matters for review |`.
       Group by subsystem. Call out new vs. modified files, and flag generated
       code (`**/generated/**`, `*.pb.go`, `*.pb.ts`) as "generated — skip".
-   5. **Key technical decisions & trade-offs** — bullet the choices a reviewer
+   6. **Key technical decisions & trade-offs** — bullet the choices a reviewer
       should scrutinize: new abstractions, data-model/migration changes,
       security or validation boundaries, backward-compat or rollout concerns.
       One line each: the decision and the alternative it was chosen over.
-   6. **Testing & validation** — how correctness was verified (tests added,
+   7. **Testing & validation** — how correctness was verified (tests added,
       manual checks, migrations run) and what is explicitly NOT covered.
 
 4. Apply the result against the target resolved in step 1:

--- a/.claude/commands/pr-describe.md
+++ b/.claude/commands/pr-describe.md
@@ -103,9 +103,7 @@ describe what the code does, not the decisions made getting there.
 
 3. Draft the description in this structure:
 
-   1. `Reviewable diff: +<additions>/-<deletions> across <files> files
-      (excludes generated, test, and story files).` — the reviewable line diff
-      from step 2. This must be the first line of the PR description.
+   1. `Reviewable diff: +<additions>/-<deletions> across <files> files (excludes generated, test, and story files).` — the reviewable line diff from step 2. This must be the first line of the PR description.
    2. **Summary** — 2-4 sentences: what this PR delivers and why it exists.
       Lead with the user- or operator-facing capability, not the implementation.
       If the PR is part of a series (step 1), follow the summary with a short

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,13 @@ architecture and technical decisions **without reading the low-level code**.
 Inspect the actual diff, commits, and changed files first; describe what the
 code does, not the decisions made getting there. Structure it as:
 
-1. **Summary** — 2-4 sentences: what this PR delivers and why. Lead with the
+1. `Reviewable diff: +<additions>/-<deletions> across <files> files (excludes generated, test, and story files).`
+   The line count comes from the PR diff after excluding generated files
+   (`**/generated/**`, `*.pb.go`, `*.pb.ts`), test files (`*_test.go`,
+   `*.test.*`, `*.spec.*`, `__tests__/**`, `tests/**`, `test/**`), and story
+   files (`*.stories.*`, `*.story.*`, `stories/**`). Put this line first,
+   above Summary.
+2. **Summary** — 2-4 sentences: what this PR delivers and why. Lead with the
    user- or operator-facing capability, not the implementation. For a PR in a
    series (stacked on a parent, has descendant PRs, or marked `N/M`), add a
    short *Stack* note: the full chain with PR links (ancestors, this PR, and any
@@ -93,23 +99,23 @@ code does, not the decisions made getting there. Structure it as:
    a reviewer needs to judge this change, and what is intentionally out of scope
    here and where the remaining work lands (from descendant PRs, the plan docs,
    or tracking issues, since later phases may not be open as PRs yet).
-2. **How it works** — the end-to-end mechanism in plain language. Walk the
+3. **How it works** — the end-to-end mechanism in plain language. Walk the
    primary flow(s): who triggers it, what crosses each boundary, where state
    is persisted, what comes back. Explain workflows, not language syntax.
-3. **Diagrams** — mermaid in fenced code blocks labeled `mermaid` so they render on
+4. **Diagrams** — mermaid in fenced code blocks labeled `mermaid` so they render on
    GitHub. At least a component/flow diagram of the main path; add a state or
    sequence diagram where lifecycle or ordering matters. Keep syntax
    GitHub-safe: quote labels with special characters, avoid fragile edge styles.
-4. **Areas of the code involved** — a table mapping each changed area to its
+5. **Areas of the code involved** — a table mapping each changed area to its
    role so reviewers know where to focus: `| Area / package / file | What
    changed | Why it matters for review |`. Group by subsystem (`proto/`,
    `server/`, domain logic, migrations, `client/`, `plugin/`); flag generated
    code as "generated — skip".
-5. **Key technical decisions & trade-offs** — the choices a reviewer should
+6. **Key technical decisions & trade-offs** — the choices a reviewer should
    scrutinize (new abstractions, data-model/migration changes, security or
    validation boundaries, backward-compat or rollout concerns). One line each:
    the decision and the alternative it was chosen over.
-6. **Testing & validation** — how correctness was verified and what is
+7. **Testing & validation** — how correctness was verified and what is
    explicitly not covered.
 
 Keep it concise: tables and diagrams over long paragraphs, no filler praise,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,10 +86,11 @@ code does, not the decisions made getting there. Structure it as:
 
 1. `Reviewable diff: +<additions>/-<deletions> across <files> files (excludes generated, test, and story files).`
    The line count comes from the PR diff after excluding generated files
-   (`**/generated/**`, `*.pb.go`, `*.pb.ts`), test files (`*_test.go`,
+   (`**/generated/**`, `*.pb.go`, `*.pb.ts`,
+   `client/src/protoOS/api/generatedApi.ts`), test files (`*_test.go`,
    `*.test.*`, `*.spec.*`, `__tests__/**`, `tests/**`, `test/**`), and story
-   files (`*.stories.*`, `*.story.*`, `stories/**`). Put this line first,
-   above Summary.
+   files (`*.stories.*`, `*.story.*`, `stories/**`). Put this line first, above
+   Summary.
 2. **Summary** — 2-4 sentences: what this PR delivers and why. Lead with the
    user- or operator-facing capability, not the implementation. For a PR in a
    series (stacked on a parent, has descendant PRs, or marked `N/M`), add a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,15 +113,18 @@ Prefixes:
 ### Pull Requests
 
 Write the description so a reviewer can judge the architecture and technical
-decisions without reading the low-level code. Use the six-part structure
+decisions without reading the low-level code. Start with the reviewable line
+diff, then use the remaining structure
 documented in the **PR descriptions** section of [AGENTS.md](./AGENTS.md):
-Summary, How it works, Diagrams (mermaid, so they render on GitHub), Areas of
-the code involved, Key technical decisions & trade-offs, and Testing &
-validation. Scale each section to the change — a one-line fix does not need a
-diagram, a new subsystem does.
+Reviewable diff, Summary, How it works, Diagrams (mermaid, so they render on
+GitHub), Areas of the code involved, Key technical decisions & trade-offs, and
+Testing & validation. Scale each section to the change — a one-line fix does
+not need a diagram, a new subsystem does.
 
 ```bash
-gh pr create --title "Brief description" --body "## Summary
+gh pr create --title "Brief description" --body "Reviewable diff: +<additions>/-<deletions> across <files> files (excludes generated, test, and story files).
+
+## Summary
 - What this delivers and why
 
 ## How it works


### PR DESCRIPTION
Reviewable diff: +51/-18 across 3 files (excludes generated, test, and story files).

## Summary
This PR makes `/pr-describe` put a computed reviewable line-diff count at the top of generated PR descriptions. It also updates the repo-wide contributor and agent guidance so humans, Claude commands, and Codex skills all agree that `Reviewable diff` comes before `Summary` and that known generated outputs are excluded.

## How it works
For numbered PRs, `/pr-describe` now instructs agents to save the GitHub PR patch and run `git apply --numstat` to collect additions and deletions by path. For current-branch PRs, it uses `git diff "origin/<base>...HEAD" --numstat` from the resolved base. The command filters generated, test, and story paths before summing additions, deletions, and file count, then places the resulting `Reviewable diff` line before the Summary section.

The repo docs mirror that ordering so the canonical PR description standard no longer conflicts with the command. `CONTRIBUTING.md` points human contributors at the same first-line reviewable diff convention and updates its `gh pr create` example. The generated-file exclusions include the ProtoOS generated API client, which does not live under a `generated/` directory.

## Diagrams

```mermaid
flowchart TD
  A["PR diff scope"] --> B["Collect numstat by path"]
  B --> C["Exclude generated, test, and story files"]
  C --> D["Sum reviewable additions, deletions, and files"]
  D --> E["Place Reviewable diff above Summary"]
  E --> F["AGENTS.md and CONTRIBUTING.md standard"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.claude/commands/pr-describe.md` | Adds instructions for computing the reviewable line diff, makes the full example a single inline code span, and excludes `client/src/protoOS/api/generatedApi.ts` from reviewable totals. | This is the command contract future `/pr-describe` runs will follow when drafting or updating PR bodies. |
| `AGENTS.md` | Updates the canonical PR description structure so `Reviewable diff` is first and Summary is second, with matching generated-file exclusions. | Keeps agent-facing repo guidance aligned with the command behavior. |
| `CONTRIBUTING.md` | Updates human contributor PR guidance and the sample `gh pr create` body. | Keeps the human-facing workflow consistent with the agent-facing standard. |

## Key technical decisions & trade-offs
- Use diff-scoped numstat instead of a separate file scan so the metric matches the exact PR scope being described.
- Filter generated, test, and story files before summing so the top-line size reflects the main review burden.
- Update both agent and human guidance so the new first-line requirement is applied consistently.
- Call out the ProtoOS generated API client explicitly because it is generated without matching the generic `**/generated/**` pattern.

## Testing & validation
- Ran `git diff --check`.
