### PR TITLE
Relax fake rig default-password gates

### DIFF
--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -573,38 +573,33 @@ func NewRESTApiHandler(state *MinerState) *RESTApiHandler {
 //     /network, /pairing/info, POST /pairing/auth-key.
 //   - Discovery reads (device-online check, no auth): /hardware, /hardware/psus,
 //     /hashboards, /power-supplies.
-//   - Reads/telemetry (auth required, NOT default-password-gated): /mining (GET),
-//     /hashrate, /temperature, /power, /efficiency, /errors, /telemetry,
-//     /timeseries, /system/logs, plus /auth/change-password and /pools. The
-//     default password does not block reading telemetry; operators can see a rig
-//     before changing its password.
-//   - Mutating operations: auth required AND blocked while default_password_active
-//     (mining start/stop/tuning, PUT /mining/target, PUT /cooling, reboot, locate,
-//     firmware update, power-supplies/update, network PUT, etc.).
+//   - DEFAULT_PASSWORD_BLOCKED_ROUTES: PUT /system/unlock.
+//   - Everything else: auth requirements still apply, but default_password_active
+//     does not block the route.
 func (h *RESTApiHandler) RegisterRoutes(mux *http.ServeMux) {
-	// Pools: auth required, exempt from the default-password gate per firmware.
+	// Pools: auth required, not blocked by default_password_active per firmware.
 	// Fleet onboarding configures pools before the operator changes the password.
 	mux.HandleFunc("/api/v1/pools", h.requireBearerAuth(h.handlePools))
 	mux.HandleFunc("/api/v1/pools/", h.requireBearerAuth(h.handlePoolByID))
 	mux.HandleFunc("/api/v1/pools/test-connection", h.requireBearerAuth(h.handleTestPoolConnection))
 
 	// Auth flow. login/refresh/set-password are fully public; change-password
-	// requires auth but bypasses the default-password gate (it's the path OUT
-	// of that state). logout is authenticated and gated like any other route.
+	// and logout require auth but are not blocked by default_password_active.
 	mux.HandleFunc("/api/v1/auth/login", h.handleLogin)
-	mux.HandleFunc("/api/v1/auth/logout", h.requireBearerAuth(h.requirePasswordChanged(h.handleLogout)))
+	mux.HandleFunc("/api/v1/auth/logout", h.requireBearerAuth(h.handleLogout))
 	mux.HandleFunc("/api/v1/auth/refresh", h.handleRefresh)
 	mux.HandleFunc("/api/v1/auth/password", h.handleSetPassword)
 	mux.HandleFunc("/api/v1/auth/change-password", h.requireBearerAuth(h.handleChangePassword))
 
 	// System — GET public for the read-only status endpoints; mutating verbs
-	// (PUT, DELETE) require auth and are default-password-gated.
+	// (PUT, DELETE) require auth. Only PUT /system/unlock is blocked while
+	// default_password_active.
 	mux.HandleFunc("/api/v1/system", h.handleSystem)
 	mux.HandleFunc("/api/v1/system/status", h.handleSystemStatus)
 	mux.HandleFunc("/api/v1/system/secure", h.handleSecureStatus)
 	mux.HandleFunc(
 		"/api/v1/system/ssh",
-		h.requireBearerAuthMethods(h.requirePasswordChangedMethods(h.handleSSH, http.MethodPut), http.MethodPut),
+		h.requireBearerAuthMethods(h.handleSSH, http.MethodPut),
 	)
 	mux.HandleFunc(
 		"/api/v1/system/unlock",
@@ -612,32 +607,24 @@ func (h *RESTApiHandler) RegisterRoutes(mux *http.ServeMux) {
 	)
 	mux.HandleFunc(
 		"/api/v1/system/tag",
-		h.requireBearerAuthMethods(
-			h.requirePasswordChangedMethods(h.handleTag, http.MethodPut, http.MethodDelete),
-			http.MethodPut, http.MethodDelete,
-		),
+		h.requireBearerAuthMethods(h.handleTag, http.MethodPut, http.MethodDelete),
 	)
 	mux.HandleFunc(
 		"/api/v1/system/telemetry",
-		h.requireBearerAuthMethods(h.requirePasswordChangedMethods(h.handleTelemetryConfig, http.MethodPut), http.MethodPut),
+		h.requireBearerAuthMethods(h.handleTelemetryConfig, http.MethodPut),
 	)
-	mux.HandleFunc("/api/v1/system/reboot", h.requireBearerAuth(h.requirePasswordChanged(h.handleReboot)))
-	mux.HandleFunc("/api/v1/system/locate", h.requireBearerAuth(h.requirePasswordChanged(h.handleLocate)))
-	// Logs are a read — not gated behind the default password.
+	mux.HandleFunc("/api/v1/system/reboot", h.requireBearerAuth(h.handleReboot))
+	mux.HandleFunc("/api/v1/system/locate", h.requireBearerAuth(h.handleLocate))
 	mux.HandleFunc("/api/v1/system/logs", h.requireBearerAuth(h.handleLogs))
-	mux.HandleFunc("/api/v1/system/update", h.requireBearerAuth(h.requirePasswordChanged(h.handleUpdate)))
-	mux.HandleFunc("/api/v1/system/update/check", h.requireBearerAuth(h.requirePasswordChanged(h.handleUpdateCheck)))
+	mux.HandleFunc("/api/v1/system/update", h.requireBearerAuth(h.handleUpdate))
+	mux.HandleFunc("/api/v1/system/update/check", h.requireBearerAuth(h.handleUpdateCheck))
 
-	// Mining — GET status is a read (ungated); start/stop/tuning and the PUT on
-	// /mining/target are mutating and stay gated behind the default password.
+	// Mining
 	mux.HandleFunc("/api/v1/mining", h.requireBearerAuth(h.handleMining))
-	mux.HandleFunc(
-		"/api/v1/mining/target",
-		h.requireBearerAuth(h.requirePasswordChangedMethods(h.handleMiningTarget, http.MethodPut)),
-	)
-	mux.HandleFunc("/api/v1/mining/tuning", h.requireBearerAuth(h.requirePasswordChanged(h.handleMiningTuning)))
-	mux.HandleFunc("/api/v1/mining/start", h.requireBearerAuth(h.requirePasswordChanged(h.handleMiningStart)))
-	mux.HandleFunc("/api/v1/mining/stop", h.requireBearerAuth(h.requirePasswordChanged(h.handleMiningStop)))
+	mux.HandleFunc("/api/v1/mining/target", h.requireBearerAuth(h.handleMiningTarget))
+	mux.HandleFunc("/api/v1/mining/tuning", h.requireBearerAuth(h.handleMiningTuning))
+	mux.HandleFunc("/api/v1/mining/start", h.requireBearerAuth(h.handleMiningStart))
+	mux.HandleFunc("/api/v1/mining/stop", h.requireBearerAuth(h.handleMiningStop))
 
 	// Hardware discovery endpoints are public; detailed hashboard stats remain
 	// authenticated under /hashboards/{hb_sn} but are not default-password-gated.
@@ -646,7 +633,7 @@ func (h *RESTApiHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/hashboards", h.requireDeviceOnline(h.handleHashboards))
 	mux.HandleFunc("/api/v1/hashboards/", h.requireBearerAuth(h.handleHashboardByID))
 
-	// Telemetry data — reads, auth required but not default-password-gated.
+	// Telemetry data
 	mux.HandleFunc("/api/v1/hashrate", h.requireBearerAuth(h.handleHashrate))
 	mux.HandleFunc("/api/v1/hashrate/", h.requireBearerAuth(h.handleHashrateByID))
 	mux.HandleFunc("/api/v1/temperature", h.requireBearerAuth(h.handleTemperature))
@@ -656,40 +643,33 @@ func (h *RESTApiHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/efficiency", h.requireBearerAuth(h.handleEfficiency))
 	mux.HandleFunc("/api/v1/efficiency/", h.requireBearerAuth(h.handleEfficiencyByID))
 
-	// PSUs — discovery read is public; the update is mutating and stays gated.
+	// PSUs — discovery read is public; the update requires auth.
 	mux.HandleFunc("/api/v1/power-supplies", h.requireDeviceOnline(h.handlePowerSupplies))
-	mux.HandleFunc("/api/v1/power-supplies/update", h.requireBearerAuth(h.requirePasswordChanged(h.handlePowerSuppliesUpdate)))
+	mux.HandleFunc("/api/v1/power-supplies/update", h.requireBearerAuth(h.handlePowerSuppliesUpdate))
 
-	// Cooling — GET read ungated; PUT is mutating and stays gated.
-	mux.HandleFunc(
-		"/api/v1/cooling",
-		h.requireBearerAuth(h.requirePasswordChangedMethods(h.handleCooling, http.MethodPut)),
-	)
+	// Cooling
+	mux.HandleFunc("/api/v1/cooling", h.requireBearerAuth(h.handleCooling))
 
-	// Network — GET public; PUT requires auth and is default-password-gated.
+	// Network — GET public; PUT requires auth.
 	mux.HandleFunc(
 		"/api/v1/network",
-		h.requireBearerAuthMethods(h.requirePasswordChangedMethods(h.handleNetwork, http.MethodPut), http.MethodPut),
+		h.requireBearerAuthMethods(h.handleNetwork, http.MethodPut),
 	)
 
-	// Errors — read, not default-password-gated.
+	// Errors
 	mux.HandleFunc("/api/v1/errors", h.requireBearerAuth(h.handleErrors))
 
-	// Telemetry — reads, not default-password-gated.
+	// Telemetry
 	mux.HandleFunc("/api/v1/telemetry", h.requireBearerAuth(h.handleTelemetry))
 	mux.HandleFunc("/api/v1/timeseries", h.requireBearerAuth(h.handleTimeseries))
 
 	// Pairing — GET /info and POST /auth-key are public (POST's handler has
 	// internal auth logic for key rotation). DELETE requires auth and is
-	// default-password-gated, per firmware. Fleet unpair paths must tolerate
-	// a 403 from a never-rotated device.
+	// not blocked by default_password_active.
 	mux.HandleFunc("/api/v1/pairing/info", h.handlePairingInfo)
 	mux.HandleFunc(
 		"/api/v1/pairing/auth-key",
-		h.requireBearerAuthMethods(
-			h.requirePasswordChangedMethods(h.handlePairingAuthKey, http.MethodDelete),
-			http.MethodDelete,
-		),
+		h.requireBearerAuthMethods(h.handlePairingAuthKey, http.MethodDelete),
 	)
 }
 
@@ -824,19 +804,6 @@ func (h *RESTApiHandler) requirePasswordChangedMethods(next http.HandlerFunc, me
 			return
 		}
 
-		if h.state.IsDefaultPasswordActive() {
-			h.writeError(w, http.StatusForbidden, "DEFAULT_PASSWORD_ACTIVE", "Default password must be changed before accessing this resource")
-			return
-		}
-
-		next(w, r)
-	}
-}
-
-// requirePasswordChanged returns 403 when the device still has the default
-// password, matching the Proto firmware's default-password lockout behavior.
-func (h *RESTApiHandler) requirePasswordChanged(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
 		if h.state.IsDefaultPasswordActive() {
 			h.writeError(w, http.StatusForbidden, "DEFAULT_PASSWORD_ACTIVE", "Default password must be changed before accessing this resource")
 			return
@@ -2777,10 +2744,6 @@ func (h *RESTApiHandler) handlePairingAuthKey(w http.ResponseWriter, r *http.Req
 		if existing := h.state.GetAuthKey(); existing != "" {
 			if !h.isAuthorized(r) {
 				h.writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authentication required for key rotation")
-				return
-			}
-			if h.state.IsDefaultPasswordActive() {
-				h.writeError(w, http.StatusForbidden, "DEFAULT_PASSWORD_ACTIVE", "Default password must be changed before accessing this resource")
 				return
 			}
 		}

--- a/server/fake-proto-rig/rest_api_handler_test.go
+++ b/server/fake-proto-rig/rest_api_handler_test.go
@@ -246,11 +246,10 @@ func TestProtectedRouteAcceptsIssuedBearerToken(t *testing.T) {
 	}
 }
 
-func TestPoolsExemptFromDefaultPasswordGate(t *testing.T) {
-	// Firmware's DEFAULT_PASSWORD_EXEMPT_PREFIXES includes /api/v1/pools so
-	// Fleet can provision pool settings before the operator changes the
-	// factory password. Authenticated pool requests must succeed even while
-	// default_password_active is true.
+func TestPoolsAllowedWhenDefaultPasswordActive(t *testing.T) {
+	// Firmware blocks only PUT /system/unlock while the default password is
+	// active, so Fleet can provision pool settings before the operator changes
+	// the factory password.
 	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
 	state.SeedDefaultPassword("defaultPass123")
 	state.AddPool(&Pool{Idx: 0, Url: "stratum+tcp://pool.example.com:3333", Username: "worker"})
@@ -290,16 +289,13 @@ func TestPoolsExemptFromDefaultPasswordGate(t *testing.T) {
 			mux.ServeHTTP(rr, req)
 
 			if rr.Code == http.StatusForbidden {
-				t.Fatalf("expected pools to be exempt from default-password gate, got 403; body=%s", rr.Body.String())
+				t.Fatalf("expected pools to be allowed while default password is active, got 403; body=%s", rr.Body.String())
 			}
 		})
 	}
 }
 
-func TestMutatingRequestsBlockedWhenDefaultPasswordActive(t *testing.T) {
-	// Mutating operations stay gated while default_password_active is true, but
-	// telemetry/read endpoints are not gated — operators can see a rig before
-	// changing its factory password.
+func TestAuthenticatedRequestsAllowedWhenDefaultPasswordActive(t *testing.T) {
 	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
 	state.SeedDefaultPassword("defaultPass123")
 	h := NewRESTApiHandler(state)
@@ -312,24 +308,66 @@ func TestMutatingRequestsBlockedWhenDefaultPasswordActive(t *testing.T) {
 	mux.ServeHTTP(loginRR, loginReq)
 
 	var tokens AuthTokens
-	_ = json.Unmarshal(loginRR.Body.Bytes(), &tokens)
-
-	// Mutating op: blocked.
-	mutateRR := httptest.NewRecorder()
-	mutateReq := httptest.NewRequest(http.MethodPost, "/api/v1/mining/start", nil)
-	mutateReq.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
-	mux.ServeHTTP(mutateRR, mutateReq)
-	if mutateRR.Code != http.StatusForbidden {
-		t.Fatalf("expected 403 on mutating route, got %d; body=%s", mutateRR.Code, mutateRR.Body.String())
+	if err := json.Unmarshal(loginRR.Body.Bytes(), &tokens); err != nil {
+		t.Fatalf("failed to unmarshal auth tokens: %v; body=%s", err, loginRR.Body.String())
 	}
 
-	// Telemetry read: not blocked.
-	readRR := httptest.NewRecorder()
-	readReq := httptest.NewRequest(http.MethodGet, "/api/v1/mining", nil)
-	readReq.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
-	mux.ServeHTTP(readRR, readReq)
-	if readRR.Code == http.StatusForbidden {
-		t.Fatalf("expected telemetry read to be allowed under default password, got 403; body=%s", readRR.Body.String())
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		body       string
+		wantStatus int
+	}{
+		{name: "mining status", method: http.MethodGet, path: "/api/v1/mining", wantStatus: http.StatusOK},
+		{name: "cooling status", method: http.MethodGet, path: "/api/v1/cooling", wantStatus: http.StatusOK},
+		{name: "network update", method: http.MethodPut, path: "/api/v1/network", wantStatus: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+			mux.ServeHTTP(rr, req)
+
+			if rr.Code == http.StatusForbidden {
+				t.Fatalf("expected %s %s to be allowed while default password is active, got 403; body=%s", tt.method, tt.path, rr.Body.String())
+			}
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("expected %d, got %d; body=%s", tt.wantStatus, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestSystemUnlockBlockedWhenDefaultPasswordActive(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	state.SeedDefaultPassword("defaultPass123")
+	h := NewRESTApiHandler(state)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	loginReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"password":"defaultPass123"}`))
+	loginRR := httptest.NewRecorder()
+	mux.ServeHTTP(loginRR, loginReq)
+
+	var tokens AuthTokens
+	if err := json.Unmarshal(loginRR.Body.Bytes(), &tokens); err != nil {
+		t.Fatalf("failed to unmarshal auth tokens: %v; body=%s", err, loginRR.Body.String())
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/unlock", nil)
+	req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusForbidden, rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "DEFAULT_PASSWORD_ACTIVE") {
+		t.Fatalf("expected DEFAULT_PASSWORD_ACTIVE response, got body=%s", rr.Body.String())
 	}
 }
 
@@ -1489,6 +1527,30 @@ func TestHandlePairingAuthKey_POST_RotationAcceptsIssuedBearerToken(t *testing.T
 	}
 }
 
+func TestHandlePairingAuthKey_POST_RotationAllowedWhenDefaultPasswordActive(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	state.SeedDefaultPassword("defaultPass123")
+	state.SetAuthKey("existing-key")
+	state.SetAccessToken("issued-bearer")
+	h := NewRESTApiHandler(state)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/pairing/auth-key",
+		strings.NewReader(`{"public_key":"new-key"}`))
+	req.Header.Set("Authorization", "Bearer issued-bearer")
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	if state.GetAuthKey() != "new-key" {
+		t.Fatalf("expected auth key %q, got %q", "new-key", state.GetAuthKey())
+	}
+}
+
 func TestHandlePairingAuthKey_POST_RotationAcceptsPairedJWT(t *testing.T) {
 	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
 
@@ -1545,12 +1607,9 @@ func TestHandlePairingAuthKey_DELETE_RequiresAuth(t *testing.T) {
 	}
 }
 
-func TestHandlePairingAuthKey_DELETE_BlockedWhenDefaultPasswordActive(t *testing.T) {
-	// Firmware does NOT exempt DELETE /pairing/auth-key from the default-password
-	// gate — it's not in DEFAULT_PASSWORD_EXEMPT_PREFIXES. So Fleet unpair against
-	// a never-rotated device returns 403. Callers must tolerate this (and
-	// ideally surface the remediation state) rather than assume revocation
-	// always succeeds.
+func TestHandlePairingAuthKey_DELETE_AllowedWhenDefaultPasswordActive(t *testing.T) {
+	// Firmware no longer blocks pairing auth-key deletion while the default
+	// password is active; DELETE remains authenticated.
 	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
 	state.SeedDefaultPassword("defaultPass123")
 	state.SetAuthKey("existing-key")
@@ -1565,11 +1624,20 @@ func TestHandlePairingAuthKey_DELETE_BlockedWhenDefaultPasswordActive(t *testing
 	req.Header.Set("Authorization", "Bearer issued-bearer")
 	mux.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("expected %d, got %d; body=%s", http.StatusForbidden, rr.Code, rr.Body.String())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusOK, rr.Code, rr.Body.String())
 	}
-	if state.GetAuthKey() != "existing-key" {
-		t.Fatalf("expected auth key to remain, got %q", state.GetAuthKey())
+	if state.GetAuthKey() != "" {
+		t.Fatalf("expected auth key to be cleared, got %q", state.GetAuthKey())
+	}
+	if state.GetPassword() != "" {
+		t.Fatal("expected password to be cleared")
+	}
+	if state.GetAccessToken() != "" {
+		t.Fatal("expected access token to be cleared")
+	}
+	if state.GetRefreshToken() != "" {
+		t.Fatal("expected refresh token to be cleared")
 	}
 }
 


### PR DESCRIPTION
Reviewable diff: +31/-68 across 1 file (excludes generated, test, and story files).

## Summary

This PR updates the fake Proto Rig to match the latest `miner-firmware` default-password lockout behavior. Operators and Fleet flows can now use normal authenticated fake-rig endpoints while `default_password_active` is true, with the lockout retained only for the high-risk `PUT /api/v1/system/unlock` endpoint.

The change keeps bearer-token authentication intact. It only removes the extra default-password gate from routes that current firmware no longer blocks.

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/fake-proto-rig/rest_api_handler.go` | Replaced broad default-password route wrappers with normal auth wrappers, leaving `requirePasswordChangedMethods` only on `PUT /system/unlock`; removed the stale pairing rotation default-password check. | This is the behavior change reviewers should inspect against current firmware: authentication remains, but default-password lockout is no longer global or mutating-route-wide. |
| `server/fake-proto-rig/rest_api_handler_test.go` | Updated default-password tests to prove representative authenticated routes, pairing rotation, and pairing deletion are allowed while `PUT /system/unlock` is still blocked. | These tests encode the firmware contract the fake rig should preserve for Fleet and ProtoOS development flows. |

## Key technical decisions & trade-offs

- Use the firmware-style one-route blocklist instead of the previous mutating-route gate model; this keeps the fake aligned with current `miner-firmware` behavior rather than a transitional local approximation.
- Preserve all existing bearer-auth requirements instead of making routes public; this relaxes only the default-password overlay, not the authentication boundary.
- Keep the fake rig’s existing simple default-password state model instead of adding firmware’s secure-system cache; `default_password_active` remains the fake’s local proxy for the one remaining blocked path.
- Keep pairing rotation auth in the handler but remove its default-password check; that mirrors firmware’s split where REST remains reachable and downstream pairing logic owns rotation authorization.

## Testing & validation

- `cd server/fake-proto-rig && GOWORK=off go test ./...`

Not covered here: full plugin contract tests and ProtoOS/Fleet E2E suites. The changed surface is isolated to fake-rig REST route gating and is covered by focused handler tests.
