### PR TITLE
[codex] Test duplicate migration check

### DIFF
--- a/server/migrations/000090_duplicate_migration_check_test.down.sql
+++ b/server/migrations/000090_duplicate_migration_check_test.down.sql
@@ -1,0 +1,2 @@
+-- Deliberately duplicates migration version 000090 to verify CI catches it.
+SELECT 1;

--- a/server/migrations/000090_duplicate_migration_check_test.up.sql
+++ b/server/migrations/000090_duplicate_migration_check_test.up.sql
@@ -1,0 +1,2 @@
+-- Deliberately duplicates migration version 000090 to verify CI catches it.
+SELECT 1;


### PR DESCRIPTION
## Intentional failing test PR

This PR deliberately adds a duplicate migration version so we can verify the new Migration Hygiene check fails on PRs that touch `server/migrations/*.sql`.

Do not merge this PR.

## Expected failure

Migration version `000090` should have two `.up.sql` files and two `.down.sql` files after this branch is merged with `main`:

- `000090_allow_mqtt_reassert_off_pending_direction.up.sql`
- `000090_allow_mqtt_reassert_off_pending_direction.down.sql`
- `000090_duplicate_migration_check_test.up.sql`
- `000090_duplicate_migration_check_test.down.sql`

The expected failing check is `Migration Hygiene / Migration Hygiene` under PR Gate.