### PR TITLE
feat: add Breadcrumb shared component with sibling switcher

### DIFF
--- a/client/src/shared/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/client/src/shared/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -81,9 +81,6 @@ export const RackLevel: Story = {
 export const NoSiblings: Story = {
   name: "No sibling switcher",
   args: {
-    segments: [
-      { label: "Denver", to: "/sites/3" },
-      { label: "Building 3" },
-    ],
+    segments: [{ label: "Denver", to: "/sites/3" }, { label: "Building 3" }],
   },
 };

--- a/client/src/shared/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/client/src/shared/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import Breadcrumb from "./Breadcrumb";
+import type { BreadcrumbProps } from "./Breadcrumb";
+
+const meta: Meta<BreadcrumbProps> = {
+  title: "Shared/Breadcrumb",
+  component: Breadcrumb,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Hierarchical breadcrumb navigation. Ancestor segments render as links; the last segment can include a sibling switcher dropdown.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<BreadcrumbProps>;
+
+export const SiteLevel: Story = {
+  name: "Site (single level with switcher)",
+  args: {
+    segments: [
+      {
+        label: "Denver",
+        siblings: [
+          { label: "Reno", to: "/sites/1", isActive: false },
+          { label: "Austin", to: "/sites/2", isActive: false },
+          { label: "Denver", to: "/sites/3", isActive: true },
+          { label: "Miami", to: "/sites/4", isActive: false },
+          { label: "Marfa", to: "/sites/5", isActive: false },
+        ],
+      },
+    ],
+  },
+};
+
+export const BuildingLevel: Story = {
+  name: "Building (site link + building switcher)",
+  args: {
+    segments: [
+      { label: "Denver", to: "/sites/3" },
+      {
+        label: "Building 3",
+        siblings: [
+          { label: "Building 1", to: "/buildings/1", isActive: false },
+          { label: "Building 2", to: "/buildings/2", isActive: false },
+          { label: "Building 3", to: "/buildings/3", isActive: true },
+          { label: "Building 4", to: "/buildings/4", isActive: false },
+        ],
+      },
+    ],
+  },
+};
+
+export const RackLevel: Story = {
+  name: "Rack (site + building links, rack switcher)",
+  args: {
+    segments: [
+      { label: "Denver", to: "/sites/3" },
+      { label: "Building 3", to: "/buildings/3" },
+      {
+        label: "R05",
+        siblings: [
+          { label: "R01", to: "/racks/1", isActive: false },
+          { label: "R02", to: "/racks/2", isActive: false },
+          { label: "R03", to: "/racks/3", isActive: false },
+          { label: "R04", to: "/racks/4", isActive: false },
+          { label: "R05", to: "/racks/5", isActive: true },
+          { label: "R06", to: "/racks/6", isActive: false },
+        ],
+      },
+    ],
+  },
+};
+
+export const NoSiblings: Story = {
+  name: "No sibling switcher",
+  args: {
+    segments: [
+      { label: "Denver", to: "/sites/3" },
+      { label: "Building 3" },
+    ],
+  },
+};

--- a/client/src/shared/components/Breadcrumb/Breadcrumb.tsx
+++ b/client/src/shared/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,135 @@
+import { Fragment, useCallback, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import clsx from "clsx";
+
+import { ChevronDown } from "@/shared/assets/icons";
+import { iconSizes } from "@/shared/assets/icons/constants";
+import { useEscapeDismiss } from "@/shared/hooks/useEscapeDismiss";
+
+export interface BreadcrumbSibling {
+  label: string;
+  to: string;
+  isActive: boolean;
+}
+
+export interface BreadcrumbSegment {
+  label: string;
+  to?: string;
+  siblings?: BreadcrumbSibling[];
+}
+
+export interface BreadcrumbProps {
+  segments: BreadcrumbSegment[];
+  testId?: string;
+}
+
+const Breadcrumb = ({ segments, testId = "breadcrumb" }: BreadcrumbProps) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const navigate = useNavigate();
+
+  useEscapeDismiss(menuOpen ? () => setMenuOpen(false) : undefined);
+
+  const handleSelect = useCallback(
+    (to: string) => {
+      setMenuOpen(false);
+      navigate(to);
+    },
+    [navigate],
+  );
+
+  return (
+    <nav className="flex items-center gap-2 text-300" data-testid={testId} aria-label="Breadcrumb">
+      {segments.map((seg, i) => {
+        const isLast = i === segments.length - 1;
+        const hasSiblings = isLast && seg.siblings && seg.siblings.length > 0;
+
+        return (
+          <Fragment key={i}>
+            {i > 0 ? <span className="text-text-primary-70">/</span> : null}
+            {!isLast && seg.to ? (
+              <Link
+                to={seg.to}
+                className="text-text-primary underline hover:opacity-80"
+                data-testid={`${testId}-link-${i}`}
+              >
+                {seg.label}
+              </Link>
+            ) : hasSiblings ? (
+              <span className="relative">
+                <button
+                  ref={triggerRef}
+                  type="button"
+                  onClick={() => setMenuOpen((prev) => !prev)}
+                  className="inline-flex items-center gap-1 text-text-primary hover:text-text-primary-70"
+                  data-testid={`${testId}-switcher`}
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen}
+                >
+                  <span>{seg.label}</span>
+                  <ChevronDown width={iconSizes.xSmall} />
+                </button>
+                {menuOpen ? (
+                  <SiblingMenu
+                    siblings={seg.siblings!}
+                    onSelect={handleSelect}
+                    onDismiss={() => setMenuOpen(false)}
+                    testId={`${testId}-menu`}
+                  />
+                ) : null}
+              </span>
+            ) : (
+              <span className="text-text-primary" data-testid={`${testId}-current`}>
+                {seg.label}
+              </span>
+            )}
+          </Fragment>
+        );
+      })}
+    </nav>
+  );
+};
+
+interface SiblingMenuProps {
+  siblings: BreadcrumbSibling[];
+  onSelect: (to: string) => void;
+  onDismiss: () => void;
+  testId: string;
+}
+
+const SiblingMenu = ({ siblings, onSelect, onDismiss, testId }: SiblingMenuProps) => (
+  <>
+    <div className="fixed inset-0 z-20" role="presentation" onClick={onDismiss} />
+    <div
+      role="menu"
+      data-testid={testId}
+      className="absolute top-full left-0 z-30 mt-1.5 max-h-72 min-w-44 overflow-y-auto rounded-2xl border border-border-5 bg-surface-elevated-base p-1.5 shadow-300"
+    >
+      {siblings.map((sib) => (
+        <button
+          key={sib.to}
+          type="button"
+          role="menuitem"
+          onClick={() => onSelect(sib.to)}
+          className={clsx(
+            "flex w-full items-center gap-3 rounded-lg p-3 text-left text-300 hover:bg-surface-5",
+            sib.isActive ? "font-medium text-text-primary" : "text-text-primary",
+          )}
+          data-testid={`${testId}-item-${sib.label}`}
+        >
+          <span
+            className={clsx(
+              "flex size-5 shrink-0 items-center justify-center rounded-full border-[1.5px]",
+              sib.isActive ? "border-transparent bg-intent-warning-fill" : "border-border-20",
+            )}
+          >
+            {sib.isActive ? <span className="size-2.5 rounded-full bg-white" /> : null}
+          </span>
+          <span className="truncate">{sib.label}</span>
+        </button>
+      ))}
+    </div>
+  </>
+);
+
+export default Breadcrumb;

--- a/client/src/shared/components/Breadcrumb/Breadcrumb.tsx
+++ b/client/src/shared/components/Breadcrumb/Breadcrumb.tsx
@@ -1,4 +1,12 @@
-import { Fragment, useCallback, useRef, useState } from "react";
+import {
+  forwardRef,
+  Fragment,
+  type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { Link, useNavigate } from "react-router-dom";
 import clsx from "clsx";
 
@@ -12,6 +20,7 @@ export interface BreadcrumbSibling {
   isActive: boolean;
 }
 
+/** Only the last segment may carry `siblings` — earlier segments are ancestor links. */
 export interface BreadcrumbSegment {
   label: string;
   to?: string;
@@ -26,17 +35,58 @@ export interface BreadcrumbProps {
 const Breadcrumb = ({ segments, testId = "breadcrumb" }: BreadcrumbProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
 
-  useEscapeDismiss(menuOpen ? () => setMenuOpen(false) : undefined);
+  useEscapeDismiss(
+    menuOpen
+      ? () => {
+          setMenuOpen(false);
+          triggerRef.current?.focus();
+        }
+      : undefined,
+  );
+
+  useEffect(() => {
+    if (!menuOpen || !menuRef.current) return;
+    const firstItem = menuRef.current.querySelector<HTMLButtonElement>("[role='menuitem']");
+    firstItem?.focus();
+  }, [menuOpen]);
 
   const handleSelect = useCallback(
     (to: string) => {
       setMenuOpen(false);
+      triggerRef.current?.focus();
       navigate(to);
     },
     [navigate],
   );
+
+  const handleMenuKeyDown = useCallback((e: ReactKeyboardEvent) => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const items = Array.from(menu.querySelectorAll<HTMLButtonElement>("[role='menuitem']"));
+    const idx = items.indexOf(e.target as HTMLButtonElement);
+    if (idx < 0) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      items[(idx + 1) % items.length].focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      items[(idx - 1 + items.length) % items.length].focus();
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      items[0].focus();
+    } else if (e.key === "End") {
+      e.preventDefault();
+      items[items.length - 1].focus();
+    } else if (e.key === "Tab") {
+      e.preventDefault();
+      setMenuOpen(false);
+      triggerRef.current?.focus();
+    }
+  }, []);
 
   return (
     <nav className="flex items-center gap-2 text-300" data-testid={testId} aria-label="Breadcrumb">
@@ -71,9 +121,14 @@ const Breadcrumb = ({ segments, testId = "breadcrumb" }: BreadcrumbProps) => {
                 </button>
                 {menuOpen ? (
                   <SiblingMenu
+                    ref={menuRef}
                     siblings={seg.siblings!}
                     onSelect={handleSelect}
-                    onDismiss={() => setMenuOpen(false)}
+                    onDismiss={() => {
+                      setMenuOpen(false);
+                      triggerRef.current?.focus();
+                    }}
+                    onKeyDown={handleMenuKeyDown}
                     testId={`${testId}-menu`}
                   />
                 ) : null}
@@ -94,42 +149,50 @@ interface SiblingMenuProps {
   siblings: BreadcrumbSibling[];
   onSelect: (to: string) => void;
   onDismiss: () => void;
+  onKeyDown: (e: ReactKeyboardEvent) => void;
   testId: string;
 }
 
-const SiblingMenu = ({ siblings, onSelect, onDismiss, testId }: SiblingMenuProps) => (
-  <>
-    <div className="fixed inset-0 z-20" role="presentation" onClick={onDismiss} />
-    <div
-      role="menu"
-      data-testid={testId}
-      className="absolute top-full left-0 z-30 mt-1.5 max-h-72 min-w-44 overflow-y-auto rounded-2xl border border-border-5 bg-surface-elevated-base p-1.5 shadow-300"
-    >
-      {siblings.map((sib) => (
-        <button
-          key={sib.to}
-          type="button"
-          role="menuitem"
-          onClick={() => onSelect(sib.to)}
-          className={clsx(
-            "flex w-full items-center gap-3 rounded-lg p-3 text-left text-300 hover:bg-surface-5",
-            sib.isActive ? "font-medium text-text-primary" : "text-text-primary",
-          )}
-          data-testid={`${testId}-item-${sib.label}`}
-        >
-          <span
+const SiblingMenu = forwardRef<HTMLDivElement, SiblingMenuProps>(
+  ({ siblings, onSelect, onDismiss, onKeyDown, testId }, ref) => (
+    <>
+      <div className="fixed inset-0 z-20" role="presentation" onClick={onDismiss} />
+      <div
+        ref={ref}
+        role="menu"
+        data-testid={testId}
+        onKeyDown={onKeyDown}
+        className="absolute top-full left-0 z-30 mt-1.5 max-h-72 min-w-44 overflow-y-auto rounded-2xl border border-border-5 bg-surface-elevated-base p-1.5 shadow-300"
+      >
+        {siblings.map((sib) => (
+          <button
+            key={sib.to}
+            type="button"
+            role="menuitem"
+            tabIndex={-1}
+            onClick={() => onSelect(sib.to)}
             className={clsx(
-              "flex size-5 shrink-0 items-center justify-center rounded-full border-[1.5px]",
-              sib.isActive ? "border-transparent bg-intent-warning-fill" : "border-border-20",
+              "flex w-full items-center gap-3 rounded-lg p-3 text-left text-300 hover:bg-surface-5",
+              sib.isActive ? "font-medium text-text-primary" : "text-text-primary",
             )}
+            data-testid={`${testId}-item-${sib.label}`}
           >
-            {sib.isActive ? <span className="size-2.5 rounded-full bg-white" /> : null}
-          </span>
-          <span className="truncate">{sib.label}</span>
-        </button>
-      ))}
-    </div>
-  </>
+            <span
+              className={clsx(
+                "flex size-5 shrink-0 items-center justify-center rounded-full border-[1.5px]",
+                sib.isActive ? "border-transparent bg-intent-warning-fill" : "border-border-20",
+              )}
+            >
+              {sib.isActive ? <span className="size-2.5 rounded-full bg-white" /> : null}
+            </span>
+            <span className="truncate">{sib.label}</span>
+          </button>
+        ))}
+      </div>
+    </>
+  ),
 );
+
+SiblingMenu.displayName = "SiblingMenu";
 
 export default Breadcrumb;

--- a/client/src/shared/components/Breadcrumb/index.ts
+++ b/client/src/shared/components/Breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export { default as Breadcrumb } from "./Breadcrumb";
+export type { BreadcrumbProps, BreadcrumbSegment, BreadcrumbSibling } from "./Breadcrumb";

--- a/client/src/shared/components/Breadcrumb/index.ts
+++ b/client/src/shared/components/Breadcrumb/index.ts
@@ -1,2 +1,4 @@
-export { default as Breadcrumb } from "./Breadcrumb";
+import Breadcrumb from "./Breadcrumb";
+
+export default Breadcrumb;
 export type { BreadcrumbProps, BreadcrumbSegment, BreadcrumbSibling } from "./Breadcrumb";


### PR DESCRIPTION
## Summary

- Adds a shared `Breadcrumb` component (`client/src/shared/components/Breadcrumb/`)
- Ancestor segments render as links; the last segment supports a sibling switcher dropdown for navigating between peers (e.g. switching between racks in the same building)
- Includes Storybook stories covering site, building, rack, and no-switcher variants

## Test plan

- [ ] `npm run storybook` — verify Shared/Breadcrumb stories render (SiteLevel, BuildingLevel, RackLevel, NoSiblings)
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)