### PR TITLE
feat(deployment): add dockerized HA lab install

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -15,6 +15,7 @@ global: &global
   - scripts/**
   - deployment-files/docker-compose*.{yml,yaml}
   - deployment-files/*.sh
+  - deployment-files/ha/**
   - deployment-files/scripts/**
 
 proto:

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -347,20 +347,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - name: Build TimescaleDB image
+      - name: Build TimescaleDB images
         run: |
-          docker buildx build \
-            -t proto-fleet-timescaledb:latest \
-            --output type=docker,dest=timescaledb-${{ matrix.arch }}.tar \
-            server/timescaledb
+          docker build -t proto-fleet-timescaledb:latest server/timescaledb
+          docker save proto-fleet-timescaledb:latest > timescaledb-${{ matrix.arch }}.tar
           gzip -9 timescaledb-${{ matrix.arch }}.tar
           echo "${{ matrix.arch }} image size: $(du -h timescaledb-${{ matrix.arch }}.tar.gz | cut -f1)"
+
+          docker build -f server/timescaledb/Dockerfile.ha -t proto-fleet-timescaledb-ha:latest server/timescaledb
+          docker save proto-fleet-timescaledb-ha:latest > timescaledb-ha-${{ matrix.arch }}.tar
+          gzip -9 timescaledb-ha-${{ matrix.arch }}.tar
+          echo "${{ matrix.arch }} HA image size: $(du -h timescaledb-ha-${{ matrix.arch }}.tar.gz | cut -f1)"
 
       - name: Upload TimescaleDB image artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: proto-fleet-timescaledb-${{ matrix.arch }}
-          path: timescaledb-${{ matrix.arch }}.tar.gz
+          path: |
+            timescaledb-${{ matrix.arch }}.tar.gz
+            timescaledb-ha-${{ matrix.arch }}.tar.gz
           retention-days: ${{ inputs.retention_days }}
 
   build-proto-fleet:
@@ -442,15 +447,20 @@ jobs:
           cp deployment-files/server/Dockerfile deployment/server/
           cp deployment-files/docker-compose.yaml deployment/
           cp deployment-files/docker-compose.notifications.yaml deployment/
+          cp deployment-files/docker-compose.ha.yaml deployment/
+          cp deployment-files/docker-compose.ha-monitor.yaml deployment/
+          cp deployment-files/docker-compose.ha-data.yaml deployment/
           cp -a server/monitoring deployment/server/
           cp server/docker-compose.base.yaml deployment/server/
           cp deployment-files/run-fleet.sh deployment/
           cp deployment-files/uninstall.sh deployment/
+          cp -r deployment-files/ha deployment/
           cp -r deployment-files/scripts deployment/
-          chmod +x deployment/run-fleet.sh deployment/uninstall.sh deployment/scripts/*.sh
+          chmod +x deployment/run-fleet.sh deployment/uninstall.sh deployment/ha/*.sh deployment/scripts/*.sh
 
           mkdir -p deployment/images
           cp /tmp/timescaledb-images/timescaledb-${{ matrix.arch }}.tar.gz deployment/images/timescaledb.tar.gz
+          cp /tmp/timescaledb-images/timescaledb-ha-${{ matrix.arch }}.tar.gz deployment/images/timescaledb-ha.tar.gz
 
       - name: Create version file
         run: |

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -22,13 +22,24 @@ The `install.sh` script sets up the Proto Fleet server components.
 ### Proto Fleet Installation Options
 
 ```bash
-Usage: install.sh [VERSION]
+Usage: install.sh [VERSION] [options]
 
 If you omit VERSION or pass "latest", installs the latest GitHub release.
 Pass "nightly" to install the latest successful nightly prerelease.
 You can override by doing, e.g.:
   install.sh v0.1.0-beta-5
   install.sh nightly
+
+HA options:
+  --ha-role monitor|data
+  --ha-cluster NAME
+  --ha-node-host HOST
+  --ha-node-name NAME
+  --ha-monitor-host HOST
+  --ha-monitor-url URL
+  --ha-initial-primary
+  --ha-join-primary-host HOST
+  --expected-config-fingerprint HASH
 ```
 
 Examples:
@@ -52,6 +63,43 @@ The script will:
 - Download and extract the specified version
 - Preserve existing configuration files if present
 - Run the deployment script automatically
+
+### Raspberry Pi HA lab installs
+
+HA mode is a Linux-only lab path for 3 Raspberry Pis where PostgreSQL remains
+Dockerized. It runs a Dockerized `pg_auto_failover` monitor on one Pi and one
+Dockerized TimescaleDB data node on each Fleet Pi. Fleet starts only on the
+data node whose local DB container is primary.
+
+Start with the full runbook in `ha/README.md`. Minimal command shapes:
+
+```bash
+./install.sh latest \
+  --ha-role monitor \
+  --ha-cluster fleet-ha \
+  --ha-node-host pi-3.local
+```
+
+```bash
+./install.sh latest \
+  --ha-role data \
+  --ha-cluster fleet-ha \
+  --ha-node-host pi-1.local \
+  --ha-monitor-host pi-3.local \
+  --ha-initial-primary
+```
+
+```bash
+./install.sh latest \
+  --ha-role data \
+  --ha-cluster fleet-ha \
+  --ha-node-host pi-2.local \
+  --ha-monitor-host pi-3.local \
+  --ha-join-primary-host pi-1.local \
+  --expected-config-fingerprint <fingerprint-from-pi-1>
+```
+
+HA mode validates existing config and secrets; it does not copy or create them.
 
 ## Uninstalling Proto Fleet
 

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -66,10 +66,15 @@ The script will:
 
 ### Raspberry Pi HA lab installs
 
-HA mode is a Linux-only lab path for 3 Raspberry Pis where PostgreSQL remains
-Dockerized. It runs a Dockerized `pg_auto_failover` monitor on one Pi and one
-Dockerized TimescaleDB data node on each Fleet Pi. Fleet starts only on the
-data node whose local DB container is primary.
+HA mode is a lab path where PostgreSQL remains Dockerized. The intended
+production topology is 3 Raspberry Pis, but macOS is supported for local lab
+testing when Docker Desktop host networking is enabled. The HA stack runs a
+Dockerized `pg_auto_failover` monitor and Dockerized TimescaleDB data nodes.
+Fleet starts only on the data node whose local DB container is primary.
+
+On macOS, systemd is unavailable, so `fleet-follows-primary.timer` is not
+installed. Run `ha/fleet-follows-primary.sh` manually for local role changes,
+or rely on the Linux data node's timer when testing failover to a Pi.
 
 Start with the full runbook in `ha/README.md`. Minimal command shapes:
 

--- a/deployment-files/docker-compose.ha-data.yaml
+++ b/deployment-files/docker-compose.ha-data.yaml
@@ -1,0 +1,37 @@
+services:
+  fleet-ha-db:
+    image: proto-fleet-timescaledb-ha:latest
+    pull_policy: never
+    container_name: fleet-ha-db
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      HA_ROLE: "data"
+      HA_NODE_NAME: "${HA_NODE_NAME:?HA_NODE_NAME is required}"
+      HA_NODE_HOST: "${HA_NODE_HOST:?HA_NODE_HOST is required}"
+      HA_MONITOR_URL: "${HA_MONITOR_URL:?HA_MONITOR_URL is required}"
+      HA_AUTH_METHOD: "${HA_AUTH_METHOD:-trust}"
+      HA_SSL_SELF_SIGNED: "${HA_SSL_SELF_SIGNED:-false}"
+      POSTGRES_DB: "${DB_NAME:-fleet}"
+      POSTGRES_USER: "${DB_USERNAME:-fleet}"
+      POSTGRES_PASSWORD: "${DB_PASSWORD:?DB_PASSWORD is required}"
+      PGPORT: "${PGPORT:-5432}"
+      TS_TUNE_MAX_CONNS: "${TS_TUNE_MAX_CONNS:-300}"
+      TS_TUNE_MAX_BG_WORKERS: "${TS_TUNE_MAX_BG_WORKERS:-8}"
+    volumes:
+      - fleet-ha-db-data:/home/postgres/pgdata/data
+    healthcheck:
+      test: [ "CMD-SHELL", "psql -U ${DB_USERNAME:-fleet} -d ${DB_NAME:-fleet} -c 'SELECT 1' > /dev/null 2>&1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
+        compress: "true"
+
+volumes:
+  fleet-ha-db-data:

--- a/deployment-files/docker-compose.ha-monitor.yaml
+++ b/deployment-files/docker-compose.ha-monitor.yaml
@@ -1,0 +1,24 @@
+services:
+  fleet-ha-monitor:
+    image: proto-fleet-timescaledb-ha:latest
+    pull_policy: never
+    container_name: fleet-ha-monitor
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      HA_ROLE: "monitor"
+      HA_NODE_HOST: "${HA_NODE_HOST:?HA_NODE_HOST is required}"
+      HA_AUTH_METHOD: "${HA_AUTH_METHOD:-trust}"
+      HA_SSL_SELF_SIGNED: "${HA_SSL_SELF_SIGNED:-false}"
+      PGPORT: "${PGPORT:-5432}"
+    volumes:
+      - fleet-ha-monitor-data:/home/postgres/pgdata/data
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
+        compress: "true"
+
+volumes:
+  fleet-ha-monitor-data:

--- a/deployment-files/docker-compose.ha.yaml
+++ b/deployment-files/docker-compose.ha.yaml
@@ -22,6 +22,12 @@ services:
       PLUGINS_ENABLED: "true"
     restart: always
     network_mode: host
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:4000/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
     logging:
       driver: "json-file"
       options:
@@ -33,7 +39,8 @@ services:
     build:
       context: ./client
     depends_on:
-      - fleet-api
+      fleet-api:
+        condition: service_healthy
     restart: always
     network_mode: host
     volumes:

--- a/deployment-files/docker-compose.ha.yaml
+++ b/deployment-files/docker-compose.ha.yaml
@@ -1,0 +1,46 @@
+x-extends:
+  file: ./server/docker-compose.base.yaml
+
+services:
+  fleet-api:
+    extends:
+      file: ./server/docker-compose.base.yaml
+      service: fleet-api
+    build:
+      context: ./server
+    environment:
+      LOG_LEVEL: "INFO"
+      AUTH_CLIENT_SECRET_KEY: "${AUTH_CLIENT_SECRET_KEY}"
+      DB_NAME: "${DB_NAME:-fleet}"
+      DB_ADDRESS: "127.0.0.1:5432"
+      DB_USERNAME: "${DB_USERNAME:-fleet}"
+      DB_PASSWORD: "${DB_PASSWORD}"
+      DB_SSL_MODE: "disable"
+      ENCRYPT_SERVICE_MASTER_KEY: "${ENCRYPT_SERVICE_MASTER_KEY}"
+      SESSION_COOKIE_SECURE: "${SESSION_COOKIE_SECURE:-true}"
+      PLUGINS_DIR: "/app/plugins"
+      PLUGINS_ENABLED: "true"
+    restart: always
+    network_mode: host
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "5"
+        compress: "true"
+
+  fleet-client:
+    build:
+      context: ./client
+    depends_on:
+      - fleet-api
+    restart: always
+    network_mode: host
+    volumes:
+      - ./ssl:/etc/nginx/ssl:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "5"
+        compress: "true"

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -17,6 +17,13 @@ Fleet runs on exactly one data node: the node whose local `fleet-ha-db`
 container is the writable primary. The standby data node keeps its DB container
 running, but `fleet-api` and `fleet-client` stay stopped.
 
+The local follower also acts as a Fleet watchdog on the confirmed primary. If
+`fleet-api` fails its Docker healthcheck, the follower restarts Fleet once. If
+Fleet still does not become healthy, the follower stops local Fleet and the
+local `fleet-ha-db` container so `pg_auto_failover` can promote the standby.
+This app-triggered failover only runs when the monitor currently confirms the
+local node is primary.
+
 `pi-3` is not in the steady-state curtailment path. If `pi-3` goes down, the
 already-active Fleet node keeps running, but no new automatic failover can be
 confirmed until the monitor returns.
@@ -145,6 +152,7 @@ Pass criteria:
 - One data node is primary.
 - One data node is standby.
 - Fleet runs only on the primary.
+- `fleet-api` reports healthy on the primary.
 
 ## Validate Extensions And Migrations
 
@@ -207,6 +215,26 @@ Capture:
 | MQTT source active |  |
 | First curtailment dispatch succeeds |  |
 
+## Active Fleet Failure Gate
+
+With active curtailment load running on the primary:
+
+1. Confirm the current primary with `./ha/status.sh`.
+2. Inject a Fleet failure on the primary, for example by blocking or stopping
+   `fleet-api` so its healthcheck becomes unhealthy.
+3. Wait for `fleet-follows-primary.timer` to restart Fleet once.
+4. If Fleet does not recover, confirm the primary's local `fleet-ha-db`
+   container is stopped by the follower.
+5. Confirm `pg_auto_failover` promotes the standby.
+6. Confirm Fleet starts on the promoted node and curtailment dispatch resumes.
+
+Pass criteria:
+
+- A transient Fleet failure recovers locally with one restart.
+- A persistent Fleet failure triggers DB failover instead of leaving the
+  unhealthy primary active.
+- No tested case starts Fleet on both data nodes.
+
 ## Monitor Failure Gate
 
 On `pi-3`:
@@ -222,6 +250,8 @@ Pass criteria:
 - Active curtailment continues.
 - Standby Fleet does not start.
 - No automatic failover occurs while the monitor is unavailable.
+- App-triggered failover does not stop the primary DB while the monitor is
+  unavailable.
 
 Restart:
 
@@ -236,8 +266,20 @@ docker start fleet-ha-monitor
 ./ha/status.sh --json
 ./ha/fleet-control.sh start
 ./ha/fleet-control.sh stop
+./ha/fleet-control.sh restart
 systemctl status fleet-follows-primary.timer
 journalctl -u fleet-follows-primary.service -n 100
+```
+
+Tunable watchdog settings live in `.env` or `ha/ha.env`:
+
+```bash
+FLEET_HA_HEALTH_URL=http://127.0.0.1:4000/health
+FLEET_HA_HEALTH_TIMEOUT=3
+FLEET_HA_RESTART_WAIT_SECONDS=20
+FLEET_HA_APP_FAILOVER_ENABLED=true
+FLEET_HA_APP_FAILOVER_COOLDOWN_SECONDS=300
+FLEET_HA_DB_STOP_TIMEOUT=10
 ```
 
 ## Deferred From V1

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -1,7 +1,9 @@
 # Proto Fleet Docker HA Lab Runbook
 
 This is the fast HA path for on-prem curtailment deployments where PostgreSQL
-and TimescaleDB stay in Docker.
+and TimescaleDB stay in Docker. The intended production topology is Raspberry
+Pi OS, but macOS is supported for local lab testing when Docker Desktop host
+networking is enabled.
 
 ## Topology
 
@@ -18,6 +20,12 @@ running, but `fleet-api` and `fleet-client` stay stopped.
 `pi-3` is not in the steady-state curtailment path. If `pi-3` goes down, the
 already-active Fleet node keeps running, but no new automatic failover can be
 confirmed until the monitor returns.
+
+For a local-machine-plus-one-Pi smoke test, the local machine may run the
+monitor and one data node while the Pi runs the second data node. On macOS,
+systemd is unavailable, so the local machine does not get an automatic
+`fleet-follows-primary.timer`; run `./ha/fleet-follows-primary.sh` manually if
+you need Fleet to follow a local role change.
 
 ## Lab Baseline
 
@@ -39,6 +47,9 @@ Pass criteria:
 - `getconf PAGESIZE` returns `4096`.
 - Docker and Docker Compose work.
 - `pi-1`, `pi-2`, and `pi-3` resolve each other by hostname.
+
+On macOS lab hosts, also confirm Docker Desktop host networking is enabled
+before running HA containers.
 
 ## Image Validation
 

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -1,0 +1,241 @@
+# Proto Fleet Docker HA Lab Runbook
+
+This is the fast HA path for on-prem curtailment deployments where PostgreSQL
+and TimescaleDB stay in Docker.
+
+## Topology
+
+| Node | Role |
+| --- | --- |
+| `pi-1` | Fleet + HA TimescaleDB data node |
+| `pi-2` | Fleet + HA TimescaleDB data node |
+| `pi-3` | `pg_auto_failover` monitor |
+
+Fleet runs on exactly one data node: the node whose local `fleet-ha-db`
+container is the writable primary. The standby data node keeps its DB container
+running, but `fleet-api` and `fleet-client` stay stopped.
+
+`pi-3` is not in the steady-state curtailment path. If `pi-3` goes down, the
+already-active Fleet node keeps running, but no new automatic failover can be
+confirmed until the monitor returns.
+
+## Lab Baseline
+
+Run on all three Pis:
+
+```bash
+cat /etc/os-release
+uname -m
+getconf PAGESIZE
+docker version
+docker compose version
+hostname -f
+hostname -I
+```
+
+Pass criteria:
+
+- Raspberry Pi OS 64-bit.
+- `getconf PAGESIZE` returns `4096`.
+- Docker and Docker Compose work.
+- `pi-1`, `pi-2`, and `pi-3` resolve each other by hostname.
+
+## Image Validation
+
+The release bundle includes:
+
+```text
+images/timescaledb-ha.tar.gz
+```
+
+After install, validate the loaded image:
+
+```bash
+docker run --rm proto-fleet-timescaledb-ha:latest pg_autoctl --version
+docker run --rm proto-fleet-timescaledb-ha:latest postgres --version
+```
+
+Every Pi must load the same image ID.
+
+## Install The Monitor On `pi-3`
+
+```bash
+./install.sh latest \
+  --ha-role monitor \
+  --ha-cluster fleet-ha \
+  --ha-node-host pi-3.local
+```
+
+Validate:
+
+```bash
+docker logs fleet-ha-monitor
+docker exec -u postgres fleet-ha-monitor pg_autoctl show state --pgdata /home/postgres/pgdata/data
+```
+
+Pass criteria:
+
+- `fleet-ha-monitor` is running.
+- `pg_autoctl show state` works.
+- Logs do not show an auth loop.
+
+## Install Data Node A On `pi-1`
+
+Before running the HA installer, put the production `.env`, SSL files, plugin
+config, and curtailment/MQTT config in place. HA mode validates these files; it
+does not create or copy secrets.
+
+```bash
+./install.sh latest \
+  --ha-role data \
+  --ha-cluster fleet-ha \
+  --ha-node-host pi-1.local \
+  --ha-monitor-host pi-3.local \
+  --ha-initial-primary
+```
+
+Capture the config fingerprint:
+
+```bash
+./ha/status.sh
+```
+
+or:
+
+```bash
+./ha/config-fingerprint.sh
+```
+
+Validate:
+
+```bash
+docker logs fleet-ha-db
+docker exec -u postgres fleet-ha-db pg_autoctl show state --pgdata /home/postgres/pgdata/data
+docker exec -u postgres fleet-ha-db psql -U "${DB_USERNAME:-fleet}" -d "${DB_NAME:-fleet}" -c "select pg_is_in_recovery();"
+```
+
+## Install Data Node B On `pi-2`
+
+Copy the same `.env`, SSL files, plugin config, and curtailment/MQTT config to
+`pi-2`. Use the fingerprint from `pi-1`.
+
+```bash
+./install.sh latest \
+  --ha-role data \
+  --ha-cluster fleet-ha \
+  --ha-node-host pi-2.local \
+  --ha-monitor-host pi-3.local \
+  --ha-join-primary-host pi-1.local \
+  --expected-config-fingerprint <fingerprint-from-pi-1>
+```
+
+Pass criteria:
+
+- One data node is primary.
+- One data node is standby.
+- Fleet runs only on the primary.
+
+## Validate Extensions And Migrations
+
+On the current primary:
+
+```bash
+docker exec -u postgres fleet-ha-db psql -U "${DB_USERNAME:-fleet}" -d "${DB_NAME:-fleet}" -c "create extension if not exists timescaledb;"
+docker exec -u postgres fleet-ha-db psql -U "${DB_USERNAME:-fleet}" -d "${DB_NAME:-fleet}" -c "create extension if not exists timescaledb_toolkit;"
+docker exec -u postgres fleet-ha-db psql -U "${DB_USERNAME:-fleet}" -d "${DB_NAME:-fleet}" -c "create extension if not exists vector;"
+```
+
+Then verify Fleet has run migrations and the standby received the schema.
+
+## Manual Failover Gate
+
+Before relying on automation:
+
+1. Confirm the current primary with `./ha/status.sh`.
+2. Stop Fleet on the primary: `./ha/fleet-control.sh stop`.
+3. Trigger a controlled `pg_auto_failover` switchover.
+4. Confirm the other DB container becomes primary.
+5. Start Fleet on the new primary: `./ha/fleet-control.sh start`.
+6. Confirm curtailment dispatch works.
+7. Confirm Fleet remains stopped on the old primary.
+
+Pass criteria:
+
+- Fleet works after DB promotion.
+- No dual Fleet writers.
+- No manual DB repair required.
+
+## Active Data-Node Failure Gate
+
+With active curtailment load running:
+
+1. Record `T0`.
+2. Kill or power off the active data-node Pi.
+3. Watch promotion from `pi-3` or the standby.
+4. Wait for `fleet-follows-primary.timer` to start Fleet on the promoted node.
+5. Record the first successful curtailment dispatch as `T_dispatch`.
+
+Pass gate:
+
+```text
+T_dispatch - T0 <= 60 seconds
+```
+
+Run 10 trials. All 10 must pass.
+
+Capture:
+
+| Event | Timestamp |
+| --- | --- |
+| Failure injected |  |
+| Monitor detects failure |  |
+| Standby promotes |  |
+| DB writable on promoted node |  |
+| Fleet start begins |  |
+| Fleet health responds |  |
+| MQTT source active |  |
+| First curtailment dispatch succeeds |  |
+
+## Monitor Failure Gate
+
+On `pi-3`:
+
+```bash
+docker stop fleet-ha-monitor
+```
+
+Then trigger curtailment while active Fleet and active DB continue running.
+
+Pass criteria:
+
+- Active curtailment continues.
+- Standby Fleet does not start.
+- No automatic failover occurs while the monitor is unavailable.
+
+Restart:
+
+```bash
+docker start fleet-ha-monitor
+```
+
+## Useful Commands
+
+```bash
+./ha/status.sh
+./ha/status.sh --json
+./ha/fleet-control.sh start
+./ha/fleet-control.sh stop
+systemctl status fleet-follows-primary.timer
+journalctl -u fleet-follows-primary.service -n 100
+```
+
+## Deferred From V1
+
+- VIP/load balancer.
+- Grafana/notifications HA.
+- Automatic failback.
+- Windows installer HA.
+- Native PostgreSQL install.
+- Patroni or the full TimescaleDB HA image.
+- Secret copying.
+- Docker Swarm or Kubernetes.

--- a/deployment-files/ha/config-fingerprint.sh
+++ b/deployment-files/ha/config-fingerprint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$script_dir/lib.sh"
+
+verbose=false
+
+if [ "${1:-}" = "--verbose" ]; then
+  verbose=true
+fi
+
+[ -f "$project_root/.env" ] || die "missing .env"
+
+files=(
+  ".env"
+  "ssl/cert.pem"
+  "ssl/key.pem"
+  "server/asicrs-config.yaml"
+  "server/proto-plugin"
+  "server/antminer-plugin"
+  "server/asicrs-plugin"
+)
+
+manifest=""
+for rel in "${files[@]}"; do
+  path="$project_root/$rel"
+  if [ -f "$path" ]; then
+    digest=$(sha256_file "$path")
+    manifest="${manifest}${digest}  ${rel}"$'\n'
+  fi
+done
+
+fingerprint=$(printf '%s' "$manifest" | LC_ALL=C sort | sha256_stream)
+
+if [ "$verbose" = "true" ]; then
+  printf '%s' "$manifest" | LC_ALL=C sort >&2
+fi
+
+printf '%s\n' "$fingerprint"

--- a/deployment-files/ha/fleet-control.sh
+++ b/deployment-files/ha/fleet-control.sh
@@ -7,7 +7,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'EOF'
-Usage: ha/fleet-control.sh start|stop|status
+Usage: ha/fleet-control.sh start|stop|restart|status
 EOF
 }
 
@@ -22,6 +22,9 @@ case "$action" in
     ;;
   stop)
     compose_with_env "${compose_args[@]}" stop fleet-api fleet-client
+    ;;
+  restart)
+    compose_with_env "${compose_args[@]}" restart fleet-api fleet-client
     ;;
   status)
     compose_with_env "${compose_args[@]}" ps fleet-api fleet-client

--- a/deployment-files/ha/fleet-control.sh
+++ b/deployment-files/ha/fleet-control.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$script_dir/lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: ha/fleet-control.sh start|stop|status
+EOF
+}
+
+action="${1:-}"
+[ -n "$action" ] || { usage; exit 1; }
+
+compose_args=(-f "$project_root/docker-compose.ha.yaml")
+
+case "$action" in
+  start)
+    compose_with_env "${compose_args[@]}" up -d --wait --wait-timeout "${FLEET_HA_WAIT_TIMEOUT:-120}" fleet-api fleet-client
+    ;;
+  stop)
+    compose_with_env "${compose_args[@]}" stop fleet-api fleet-client
+    ;;
+  status)
+    compose_with_env "${compose_args[@]}" ps fleet-api fleet-client
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/deployment-files/ha/fleet-follows-primary.service.in
+++ b/deployment-files/ha/fleet-follows-primary.service.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Start Proto Fleet only on the local HA database primary
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=__PROJECT_ROOT__
+ExecStart=__PROJECT_ROOT__/ha/fleet-follows-primary.sh

--- a/deployment-files/ha/fleet-follows-primary.sh
+++ b/deployment-files/ha/fleet-follows-primary.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$script_dir/lib.sh"
+
+load_env
+
+PGDATA="${PGDATA:-/home/postgres/pgdata/data}"
+DB_NAME="${DB_NAME:-fleet}"
+DB_USERNAME="${DB_USERNAME:-fleet}"
+LAST_PRIMARY_FILE="$ha_state_dir/last-confirmed-primary"
+
+mkdir -p "$ha_state_dir"
+
+fleet_running() {
+  compose_with_env -f "$project_root/docker-compose.ha.yaml" ps --status running -q fleet-api | grep -q .
+}
+
+start_fleet() {
+  "$script_dir/fleet-control.sh" start
+}
+
+stop_fleet() {
+  "$script_dir/fleet-control.sh" stop
+}
+
+local_db_primary() {
+  docker exec -u postgres fleet-ha-db \
+    psql -U "$DB_USERNAME" -d "$DB_NAME" -tAc "select not pg_is_in_recovery();" 2>/dev/null \
+    | tr -d '[:space:]' \
+    | grep -qi '^t'
+}
+
+monitor_confirms_primary() {
+  local state
+  state=$(docker exec -u postgres fleet-ha-db pg_autoctl show state --pgdata "$PGDATA" 2>/dev/null || true)
+  [ -n "$state" ] || return 1
+
+  printf '%s\n' "$state" \
+    | grep -F "${HA_NODE_NAME:-$HA_NODE_HOST}" \
+    | grep -Eiq 'primary|single'
+}
+
+last_confirmed_this_host() {
+  [ -f "$LAST_PRIMARY_FILE" ] || return 1
+  [ "$(cat "$LAST_PRIMARY_FILE")" = "${HA_NODE_HOST:-}" ]
+}
+
+if local_db_primary; then
+  if monitor_confirms_primary; then
+    printf '%s' "$HA_NODE_HOST" > "$LAST_PRIMARY_FILE"
+    start_fleet
+    exit 0
+  fi
+
+  if fleet_running && last_confirmed_this_host; then
+    log "monitor unavailable or inconclusive; keeping Fleet running on last confirmed primary"
+    exit 0
+  fi
+
+  log "local DB is primary but monitor did not confirm; leaving Fleet stopped"
+  stop_fleet
+  exit 0
+fi
+
+log "local DB is not primary; stopping Fleet"
+stop_fleet

--- a/deployment-files/ha/fleet-follows-primary.sh
+++ b/deployment-files/ha/fleet-follows-primary.sh
@@ -11,11 +11,65 @@ PGDATA="${PGDATA:-/home/postgres/pgdata/data}"
 DB_NAME="${DB_NAME:-fleet}"
 DB_USERNAME="${DB_USERNAME:-fleet}"
 LAST_PRIMARY_FILE="$ha_state_dir/last-confirmed-primary"
+LAST_FLEET_RESTART_FILE="$ha_state_dir/last-fleet-restart-at"
+LAST_APP_FAILOVER_FILE="$ha_state_dir/last-app-failover-at"
+FLEET_HA_HEALTH_URL="${FLEET_HA_HEALTH_URL:-http://127.0.0.1:4000/health}"
+FLEET_HA_HEALTH_TIMEOUT="${FLEET_HA_HEALTH_TIMEOUT:-3}"
+FLEET_HA_RESTART_WAIT_SECONDS="${FLEET_HA_RESTART_WAIT_SECONDS:-20}"
+FLEET_HA_APP_FAILOVER_COOLDOWN_SECONDS="${FLEET_HA_APP_FAILOVER_COOLDOWN_SECONDS:-300}"
+FLEET_HA_APP_FAILOVER_ENABLED="${FLEET_HA_APP_FAILOVER_ENABLED:-true}"
 
 mkdir -p "$ha_state_dir"
 
 fleet_running() {
   compose_with_env -f "$project_root/docker-compose.ha.yaml" ps --status running -q fleet-api | grep -q .
+}
+
+fleet_api_container_id() {
+  compose_with_env -f "$project_root/docker-compose.ha.yaml" ps -q fleet-api 2>/dev/null || true
+}
+
+fleet_health_status() {
+  local container_id status
+  container_id=$(fleet_api_container_id)
+  if [ -z "$container_id" ]; then
+    printf 'missing'
+    return 0
+  fi
+
+  status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)
+  printf '%s' "${status:-unknown}"
+}
+
+http_health_probe() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsS --max-time "$FLEET_HA_HEALTH_TIMEOUT" "$FLEET_HA_HEALTH_URL" >/dev/null
+    return
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    wget -q --timeout="$FLEET_HA_HEALTH_TIMEOUT" --tries=1 -O /dev/null "$FLEET_HA_HEALTH_URL"
+    return
+  fi
+
+  return 1
+}
+
+fleet_healthy() {
+  local status
+  status=$(fleet_health_status)
+  case "$status" in
+    healthy)
+      return 0
+      ;;
+    running)
+      http_health_probe
+      return
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 start_fleet() {
@@ -24,6 +78,40 @@ start_fleet() {
 
 stop_fleet() {
   "$script_dir/fleet-control.sh" stop
+}
+
+restart_fleet() {
+  "$script_dir/fleet-control.sh" restart
+}
+
+now_seconds() {
+  date +%s
+}
+
+marker_within_cooldown() {
+  local marker_file="$1"
+  local cooldown_seconds="$2"
+  local now last
+
+  [ -f "$marker_file" ] || return 1
+  now=$(now_seconds)
+  last=$(cat "$marker_file" 2>/dev/null || printf '0')
+  [ "$last" -gt 0 ] 2>/dev/null || return 1
+  [ $((now - last)) -lt "$cooldown_seconds" ]
+}
+
+wait_for_fleet_health() {
+  local deadline
+  deadline=$(( $(now_seconds) + FLEET_HA_RESTART_WAIT_SECONDS ))
+
+  while [ "$(now_seconds)" -le "$deadline" ]; do
+    if fleet_healthy; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  return 1
 }
 
 local_db_primary() {
@@ -48,22 +136,104 @@ last_confirmed_this_host() {
   [ "$(cat "$LAST_PRIMARY_FILE")" = "${HA_NODE_HOST:-}" ]
 }
 
+app_failover_enabled() {
+  case "$FLEET_HA_APP_FAILOVER_ENABLED" in
+    true|TRUE|1|yes|YES)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+trigger_app_failover() {
+  if ! app_failover_enabled; then
+    log "Fleet is unhealthy after restart; app-triggered failover is disabled"
+    return 1
+  fi
+
+  if marker_within_cooldown "$LAST_APP_FAILOVER_FILE" "$FLEET_HA_APP_FAILOVER_COOLDOWN_SECONDS"; then
+    log "Fleet is unhealthy after restart; app-triggered failover is in cooldown"
+    return 1
+  fi
+
+  if ! monitor_confirms_primary; then
+    log "Fleet is unhealthy after restart, but monitor no longer confirms this node as primary; not stopping DB"
+    return 1
+  fi
+
+  log "Fleet is unhealthy after restart; stopping local Fleet and DB to trigger pg_auto_failover promotion"
+  stop_fleet || true
+  if docker stop -t "${FLEET_HA_DB_STOP_TIMEOUT:-10}" fleet-ha-db; then
+    now_seconds > "$LAST_APP_FAILOVER_FILE"
+    rm -f "$LAST_FLEET_RESTART_FILE"
+  else
+    log "failed to stop local DB container; app-triggered failover was not started"
+    return 1
+  fi
+}
+
+watchdog_fleet() {
+  local status
+
+  if ! fleet_running; then
+    log "local DB is primary; starting Fleet"
+    if ! start_fleet; then
+      log "Fleet start did not complete cleanly; will re-check on the next follower run"
+    fi
+    return 0
+  fi
+
+  if fleet_healthy; then
+    rm -f "$LAST_FLEET_RESTART_FILE"
+    return 0
+  fi
+
+  status=$(fleet_health_status)
+  if [ "$status" = "starting" ]; then
+    log "Fleet healthcheck is still starting"
+    return 0
+  fi
+
+  if [ -f "$LAST_FLEET_RESTART_FILE" ]; then
+    log "Fleet is still unhealthy after a watchdog restart"
+    trigger_app_failover
+    return 0
+  fi
+
+  log "Fleet health is $status; restarting Fleet before failover"
+  now_seconds > "$LAST_FLEET_RESTART_FILE"
+  restart_fleet || true
+
+  if wait_for_fleet_health; then
+    log "Fleet recovered after watchdog restart"
+    rm -f "$LAST_FLEET_RESTART_FILE"
+    return 0
+  fi
+
+  trigger_app_failover
+}
+
 if local_db_primary; then
   if monitor_confirms_primary; then
     printf '%s' "$HA_NODE_HOST" > "$LAST_PRIMARY_FILE"
-    start_fleet
+    watchdog_fleet
     exit 0
   fi
 
   if fleet_running && last_confirmed_this_host; then
     log "monitor unavailable or inconclusive; keeping Fleet running on last confirmed primary"
+    watchdog_fleet
     exit 0
   fi
 
   log "local DB is primary but monitor did not confirm; leaving Fleet stopped"
+  rm -f "$LAST_FLEET_RESTART_FILE"
   stop_fleet
   exit 0
 fi
 
 log "local DB is not primary; stopping Fleet"
+rm -f "$LAST_FLEET_RESTART_FILE"
 stop_fleet

--- a/deployment-files/ha/fleet-follows-primary.timer.in
+++ b/deployment-files/ha/fleet-follows-primary.timer.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Proto Fleet HA primary follower
+
+[Timer]
+OnBootSec=20s
+OnUnitActiveSec=5s
+AccuracySec=1s
+Unit=fleet-follows-primary.service
+
+[Install]
+WantedBy=timers.target

--- a/deployment-files/ha/install-ha-node.sh
+++ b/deployment-files/ha/install-ha-node.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$script_dir/lib.sh"
+
+HA_ROLE=""
+HA_CLUSTER="fleet-ha"
+HA_NODE_NAME=""
+HA_NODE_HOST=""
+HA_MONITOR_HOST=""
+HA_MONITOR_URL=""
+HA_JOIN_PRIMARY_HOST=""
+HA_INITIAL_PRIMARY=false
+EXPECTED_CONFIG_FINGERPRINT=""
+PGPORT="${PGPORT:-5432}"
+HA_AUTH_METHOD="${HA_AUTH_METHOD:-trust}"
+HA_SSL_SELF_SIGNED="${HA_SSL_SELF_SIGNED:-false}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ha/install-ha-node.sh --role monitor --node-host HOST [--cluster NAME]
+  ha/install-ha-node.sh --role data --node-host HOST --monitor-host HOST [--node-name NAME] [--initial-primary]
+  ha/install-ha-node.sh --role data --node-host HOST --monitor-host HOST --join-primary-host HOST --expected-config-fingerprint HASH
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --role) HA_ROLE="${2:-}"; shift 2 ;;
+    --cluster) HA_CLUSTER="${2:-}"; shift 2 ;;
+    --node-name) HA_NODE_NAME="${2:-}"; shift 2 ;;
+    --node-host) HA_NODE_HOST="${2:-}"; shift 2 ;;
+    --monitor-host) HA_MONITOR_HOST="${2:-}"; shift 2 ;;
+    --monitor-url) HA_MONITOR_URL="${2:-}"; shift 2 ;;
+    --join-primary-host) HA_JOIN_PRIMARY_HOST="${2:-}"; shift 2 ;;
+    --initial-primary) HA_INITIAL_PRIMARY=true; shift ;;
+    --expected-config-fingerprint) EXPECTED_CONFIG_FINGERPRINT="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ "$HA_ROLE" = "monitor" ] || [ "$HA_ROLE" = "data" ] || die "--role must be monitor or data"
+[ -n "$HA_NODE_HOST" ] || die "--node-host is required"
+
+if [ -z "$HA_NODE_NAME" ]; then
+  HA_NODE_NAME="${HA_NODE_HOST%%.*}"
+fi
+
+if [ "$HA_ROLE" = "data" ]; then
+  [ -n "$HA_MONITOR_HOST" ] || [ -n "$HA_MONITOR_URL" ] || die "--monitor-host or --monitor-url is required for data nodes"
+  if [ -z "$HA_MONITOR_URL" ]; then
+    HA_MONITOR_URL="postgres://autoctl_node@${HA_MONITOR_HOST}:${PGPORT}/pg_auto_failover"
+  fi
+  if [ -n "$HA_JOIN_PRIMARY_HOST" ] && [ -z "$EXPECTED_CONFIG_FINGERPRINT" ]; then
+    die "--expected-config-fingerprint is required when joining a standby data node"
+  fi
+fi
+
+"$script_dir/preflight.sh" --role "$HA_ROLE"
+
+if [ "$HA_ROLE" = "data" ]; then
+  current_fingerprint=$("$script_dir/config-fingerprint.sh")
+  if [ -n "$EXPECTED_CONFIG_FINGERPRINT" ] && [ "$current_fingerprint" != "$EXPECTED_CONFIG_FINGERPRINT" ]; then
+    die "config fingerprint mismatch: expected $EXPECTED_CONFIG_FINGERPRINT, got $current_fingerprint"
+  fi
+  log "config fingerprint: $current_fingerprint"
+fi
+
+image_tar="$project_root/images/timescaledb-ha.tar.gz"
+if [ -f "$image_tar" ]; then
+  log "loading HA TimescaleDB image from $image_tar"
+  gzip -dc "$image_tar" | docker load
+elif ! docker image inspect proto-fleet-timescaledb-ha:latest >/dev/null 2>&1; then
+  die "proto-fleet-timescaledb-ha:latest is not loaded and $image_tar is missing"
+fi
+
+write_ha_env
+
+case "$HA_ROLE" in
+  monitor)
+    log "starting HA monitor container"
+    compose_with_env -f "$project_root/docker-compose.ha-monitor.yaml" up -d
+    ;;
+  data)
+    log "starting HA data container"
+    compose_with_env -f "$project_root/docker-compose.ha-data.yaml" up -d --wait --wait-timeout "${FLEET_HA_DB_WAIT_TIMEOUT:-180}"
+    "$script_dir/install-systemd-follower.sh"
+    ;;
+esac
+
+log "HA $HA_ROLE install completed"

--- a/deployment-files/ha/install-systemd-follower.sh
+++ b/deployment-files/ha/install-systemd-follower.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$script_dir/lib.sh"
+
+if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
+  warn "systemd is not available; run ha/fleet-follows-primary.sh manually or install your own scheduler"
+  exit 0
+fi
+
+sudo_cmd=()
+if [ "$(id -u)" -ne 0 ]; then
+  command -v sudo >/dev/null 2>&1 || die "sudo is required to install systemd units"
+  sudo_cmd=(sudo)
+fi
+
+escaped_root=$(printf '%s' "$project_root" | sed 's/[\/&]/\\&/g')
+
+sed "s/__PROJECT_ROOT__/$escaped_root/g" "$script_dir/fleet-follows-primary.service.in" \
+  | "${sudo_cmd[@]}" tee /etc/systemd/system/fleet-follows-primary.service >/dev/null
+
+sed "s/__PROJECT_ROOT__/$escaped_root/g" "$script_dir/fleet-follows-primary.timer.in" \
+  | "${sudo_cmd[@]}" tee /etc/systemd/system/fleet-follows-primary.timer >/dev/null
+
+"${sudo_cmd[@]}" systemctl daemon-reload
+"${sudo_cmd[@]}" systemctl enable --now fleet-follows-primary.timer
+
+log "installed and started fleet-follows-primary.timer"

--- a/deployment-files/ha/install-systemd-follower.sh
+++ b/deployment-files/ha/install-systemd-follower.sh
@@ -6,7 +6,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$script_dir/lib.sh"
 
 if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
-  warn "systemd is not available; run ha/fleet-follows-primary.sh manually or install your own scheduler"
+  warn "systemd is not available; run ha/fleet-follows-primary.sh manually or rely on the Linux peer's timer"
   exit 0
 fi
 

--- a/deployment-files/ha/lib.sh
+++ b/deployment-files/ha/lib.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+ha_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd "$ha_dir/.." && pwd)"
+ha_env_file="$ha_dir/ha.env"
+ha_state_dir="$ha_dir/state"
+
+log() {
+  echo "ha: $*"
+}
+
+warn() {
+  echo "ha warning: $*" >&2
+}
+
+die() {
+  echo "ha error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+load_env() {
+  if [ -f "$project_root/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$project_root/.env"
+    set +a
+  fi
+
+  if [ -f "$ha_env_file" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$ha_env_file"
+    set +a
+  fi
+}
+
+docker_compose() {
+  docker compose "$@"
+}
+
+compose_with_env() {
+  load_env
+  docker_compose "$@"
+}
+
+first_host_ip() {
+  hostname -I 2>/dev/null | awk '{print $1}'
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    die "sha256sum or shasum is required"
+  fi
+}
+
+sha256_stream() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  else
+    die "sha256sum or shasum is required"
+  fi
+}
+
+write_ha_env() {
+  mkdir -p "$ha_dir"
+  umask 077
+  cat > "$ha_env_file" <<EOF
+HA_ROLE=${HA_ROLE}
+HA_CLUSTER=${HA_CLUSTER:-fleet-ha}
+HA_NODE_NAME=${HA_NODE_NAME:-}
+HA_NODE_HOST=${HA_NODE_HOST}
+HA_MONITOR_HOST=${HA_MONITOR_HOST:-}
+HA_MONITOR_URL=${HA_MONITOR_URL:-}
+HA_AUTH_METHOD=${HA_AUTH_METHOD:-trust}
+HA_SSL_SELF_SIGNED=${HA_SSL_SELF_SIGNED:-false}
+PGPORT=${PGPORT:-5432}
+EOF
+}

--- a/deployment-files/ha/preflight.sh
+++ b/deployment-files/ha/preflight.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$script_dir/lib.sh"
+
+role=""
+
+usage() {
+  cat <<'EOF'
+Usage: ha/preflight.sh --role monitor|data
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --role)
+      role="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ "$role" = "monitor" ] || [ "$role" = "data" ] || die "--role must be monitor or data"
+
+require_command docker
+docker compose version >/dev/null 2>&1 || die "docker compose is required"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  die "HA installs are supported on Linux only"
+fi
+
+case "$(uname -m)" in
+  aarch64|arm64|x86_64|amd64) ;;
+  *) die "unsupported architecture: $(uname -m)" ;;
+esac
+
+page_size=$(getconf PAGESIZE)
+if [ "$page_size" != "4096" ]; then
+  die "system page size is $page_size; HA requires 4096-byte pages"
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  die "docker daemon is not reachable"
+fi
+
+if [ ! -f "$project_root/docker-compose.ha-${role}.yaml" ]; then
+  die "missing docker-compose.ha-${role}.yaml"
+fi
+
+if [ "$role" = "data" ]; then
+  [ -f "$project_root/docker-compose.ha.yaml" ] || die "missing docker-compose.ha.yaml"
+  [ -f "$project_root/.env" ] || die "missing .env; HA data nodes validate existing config and do not create secrets"
+  chmod 600 "$project_root/.env" 2>/dev/null || true
+fi
+
+log "preflight passed for $role"

--- a/deployment-files/ha/preflight.sh
+++ b/deployment-files/ha/preflight.sh
@@ -34,18 +34,28 @@ done
 require_command docker
 docker compose version >/dev/null 2>&1 || die "docker compose is required"
 
-if [ "$(uname -s)" != "Linux" ]; then
-  die "HA installs are supported on Linux only"
-fi
+os_type=$(uname -s)
+case "$os_type" in
+  Linux|Darwin) ;;
+  *) die "HA installs are supported on Linux and macOS only" ;;
+esac
 
 case "$(uname -m)" in
   aarch64|arm64|x86_64|amd64) ;;
   *) die "unsupported architecture: $(uname -m)" ;;
 esac
 
-page_size=$(getconf PAGESIZE)
-if [ "$page_size" != "4096" ]; then
-  die "system page size is $page_size; HA requires 4096-byte pages"
+if [ "$os_type" = "Linux" ]; then
+  page_size=$(getconf PAGESIZE)
+  if [ "$page_size" != "4096" ]; then
+    die "system page size is $page_size; HA requires 4096-byte pages"
+  fi
+fi
+
+if [ "$os_type" = "Darwin" ]; then
+  warn "macOS HA installs are for local lab testing only"
+  warn "Docker Desktop host networking must be enabled for --network host"
+  warn "systemd is unavailable on macOS; Fleet follower automation must run manually or on the Linux data node"
 fi
 
 if ! docker info >/dev/null 2>&1; then

--- a/deployment-files/ha/status.sh
+++ b/deployment-files/ha/status.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$script_dir/lib.sh"
+
+json=false
+if [ "${1:-}" = "--json" ]; then
+  json=true
+fi
+
+load_env
+
+PGDATA="${PGDATA:-/home/postgres/pgdata/data}"
+DB_NAME="${DB_NAME:-fleet}"
+DB_USERNAME="${DB_USERNAME:-fleet}"
+host_ip="$(first_host_ip)"
+api_url="http://${host_ip:-127.0.0.1}:4000"
+
+db_role="unknown"
+if docker ps --format '{{.Names}}' | grep -qx 'fleet-ha-db'; then
+  if docker exec -u postgres fleet-ha-db psql -U "$DB_USERNAME" -d "$DB_NAME" -tAc "select pg_is_in_recovery();" 2>/dev/null | tr -d '[:space:]' | grep -qi '^f'; then
+    db_role="primary"
+  elif docker exec -u postgres fleet-ha-db psql -U "$DB_USERNAME" -d "$DB_NAME" -tAc "select pg_is_in_recovery();" 2>/dev/null | tr -d '[:space:]' | grep -qi '^t'; then
+    db_role="standby"
+  fi
+fi
+
+monitor_reachable="false"
+cluster_state=""
+if docker ps --format '{{.Names}}' | grep -qx 'fleet-ha-db'; then
+  if cluster_state=$(docker exec -u postgres fleet-ha-db pg_autoctl show state --pgdata "$PGDATA" 2>/dev/null); then
+    monitor_reachable="true"
+  fi
+elif docker ps --format '{{.Names}}' | grep -qx 'fleet-ha-monitor'; then
+  if cluster_state=$(docker exec -u postgres fleet-ha-monitor pg_autoctl show state --pgdata "$PGDATA" 2>/dev/null); then
+    monitor_reachable="true"
+  fi
+fi
+
+fleet_state="stopped"
+if compose_with_env -f "$project_root/docker-compose.ha.yaml" ps --status running -q fleet-api 2>/dev/null | grep -q .; then
+  fleet_state="running"
+fi
+
+fingerprint="unavailable"
+if [ -f "$project_root/.env" ]; then
+  fingerprint=$("$script_dir/config-fingerprint.sh" 2>/dev/null || printf 'unavailable')
+fi
+
+last_confirmed_primary=""
+if [ -f "$ha_state_dir/last-confirmed-primary" ]; then
+  last_confirmed_primary=$(cat "$ha_state_dir/last-confirmed-primary")
+fi
+
+if [ "$json" = "true" ]; then
+  cat <<EOF
+{"node_host":"${HA_NODE_HOST:-}","db_role":"$db_role","monitor_reachable":$monitor_reachable,"fleet_state":"$fleet_state","active_api_url":"$api_url","config_fingerprint":"$fingerprint","last_confirmed_primary":"$last_confirmed_primary"}
+EOF
+  exit 0
+fi
+
+cat <<EOF
+Node host:              ${HA_NODE_HOST:-unknown}
+Local DB role:          $db_role
+Monitor reachable:      $monitor_reachable
+Fleet state:            $fleet_state
+Active API URL:         $api_url
+Config fingerprint:     $fingerprint
+Last confirmed primary: ${last_confirmed_primary:-none}
+
+Cluster state:
+${cluster_state:-unavailable}
+EOF

--- a/deployment-files/ha/status.sh
+++ b/deployment-files/ha/status.sh
@@ -44,6 +44,12 @@ if compose_with_env -f "$project_root/docker-compose.ha.yaml" ps --status runnin
   fleet_state="running"
 fi
 
+fleet_health="missing"
+fleet_container_id=$(compose_with_env -f "$project_root/docker-compose.ha.yaml" ps -q fleet-api 2>/dev/null || true)
+if [ -n "$fleet_container_id" ]; then
+  fleet_health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$fleet_container_id" 2>/dev/null || printf 'unknown')
+fi
+
 fingerprint="unavailable"
 if [ -f "$project_root/.env" ]; then
   fingerprint=$("$script_dir/config-fingerprint.sh" 2>/dev/null || printf 'unavailable')
@@ -56,7 +62,7 @@ fi
 
 if [ "$json" = "true" ]; then
   cat <<EOF
-{"node_host":"${HA_NODE_HOST:-}","db_role":"$db_role","monitor_reachable":$monitor_reachable,"fleet_state":"$fleet_state","active_api_url":"$api_url","config_fingerprint":"$fingerprint","last_confirmed_primary":"$last_confirmed_primary"}
+{"node_host":"${HA_NODE_HOST:-}","db_role":"$db_role","monitor_reachable":$monitor_reachable,"fleet_state":"$fleet_state","fleet_health":"$fleet_health","active_api_url":"$api_url","config_fingerprint":"$fingerprint","last_confirmed_primary":"$last_confirmed_primary"}
 EOF
   exit 0
 fi
@@ -66,6 +72,7 @@ Node host:              ${HA_NODE_HOST:-unknown}
 Local DB role:          $db_role
 Monitor reachable:      $monitor_reachable
 Fleet state:            $fleet_state
+Fleet health:           $fleet_health
 Active API URL:         $api_url
 Config fingerprint:     $fingerprint
 Last confirmed primary: ${last_confirmed_primary:-none}

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -177,7 +177,7 @@ extract_and_cd() {
 
 usage() {
   cat <<EOF
-Usage: install.sh [VERSION]
+Usage: install.sh [VERSION] [options]
 
 If you omit VERSION or pass "latest", installs the latest GitHub release.
 Pass "nightly" to install the latest successful nightly prerelease.
@@ -185,6 +185,17 @@ You can override by doing, e.g.:
   install.sh v0.1.0-beta-5
   install.sh nightly
   install.sh nightly-20260424-68712dfabc12
+
+HA options:
+  --ha-role monitor|data
+  --ha-cluster NAME
+  --ha-node-host HOST
+  --ha-node-name NAME
+  --ha-monitor-host HOST
+  --ha-monitor-url URL
+  --ha-initial-primary
+  --ha-join-primary-host HOST
+  --expected-config-fingerprint HASH
 EOF
   exit 1
 }
@@ -266,9 +277,82 @@ check_page_size() {
   fi
 }
 
-# show help for -h/--help
-if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
-  usage
+VERSION_ARG="latest"
+VERSION_ARG_SET=0
+HA_ROLE=""
+HA_CLUSTER=""
+HA_NODE_HOST=""
+HA_NODE_NAME=""
+HA_MONITOR_HOST=""
+HA_MONITOR_URL=""
+HA_INITIAL_PRIMARY=0
+HA_JOIN_PRIMARY_HOST=""
+EXPECTED_CONFIG_FINGERPRINT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      ;;
+    --ha-role)
+      HA_ROLE="${2:-}"
+      shift 2
+      ;;
+    --ha-cluster)
+      HA_CLUSTER="${2:-}"
+      shift 2
+      ;;
+    --ha-node-host)
+      HA_NODE_HOST="${2:-}"
+      shift 2
+      ;;
+    --ha-node-name)
+      HA_NODE_NAME="${2:-}"
+      shift 2
+      ;;
+    --ha-monitor-host)
+      HA_MONITOR_HOST="${2:-}"
+      shift 2
+      ;;
+    --ha-monitor-url)
+      HA_MONITOR_URL="${2:-}"
+      shift 2
+      ;;
+    --ha-initial-primary)
+      HA_INITIAL_PRIMARY=1
+      shift
+      ;;
+    --ha-join-primary-host)
+      HA_JOIN_PRIMARY_HOST="${2:-}"
+      shift 2
+      ;;
+    --expected-config-fingerprint)
+      EXPECTED_CONFIG_FINGERPRINT="${2:-}"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    --*)
+      echo "❌ Unknown option: $1" >&2
+      usage
+      ;;
+    *)
+      if [ "$VERSION_ARG_SET" = "1" ]; then
+        echo "❌ Unexpected extra version argument: $1" >&2
+        usage
+      fi
+      VERSION_ARG="$1"
+      VERSION_ARG_SET=1
+      shift
+      ;;
+  esac
+done
+
+if [ -n "$HA_ROLE" ] && [ "$HA_ROLE" != "monitor" ] && [ "$HA_ROLE" != "data" ]; then
+  echo "❌ --ha-role must be monitor or data" >&2
+  exit 1
 fi
 
 check_page_size
@@ -276,7 +360,7 @@ check_page_size
 GITHUB_RELEASES_URL="https://github.com/block/proto-fleet/releases"
 
 # determine version and tarball name
-case "${1:-latest}" in
+case "${VERSION_ARG:-latest}" in
   latest)
     VERSION=$(resolve_latest_version)
     echo "🔖 Latest version is ${VERSION}"
@@ -286,7 +370,7 @@ case "${1:-latest}" in
     echo "🔖 Latest nightly version is ${VERSION}"
     ;;
   *)
-    VERSION="$1"
+    VERSION="$VERSION_ARG"
     ;;
 esac
 
@@ -448,4 +532,17 @@ done
 echo "✅ Plugin binaries validated"
 
 echo "🔧 Running deployment script..."
-./run-fleet.sh
+if [ -n "$HA_ROLE" ]; then
+  HA_ARGS=(--role "$HA_ROLE")
+  [ -n "$HA_CLUSTER" ] && HA_ARGS+=(--cluster "$HA_CLUSTER")
+  [ -n "$HA_NODE_HOST" ] && HA_ARGS+=(--node-host "$HA_NODE_HOST")
+  [ -n "$HA_NODE_NAME" ] && HA_ARGS+=(--node-name "$HA_NODE_NAME")
+  [ -n "$HA_MONITOR_HOST" ] && HA_ARGS+=(--monitor-host "$HA_MONITOR_HOST")
+  [ -n "$HA_MONITOR_URL" ] && HA_ARGS+=(--monitor-url "$HA_MONITOR_URL")
+  [ "$HA_INITIAL_PRIMARY" = "1" ] && HA_ARGS+=(--initial-primary)
+  [ -n "$HA_JOIN_PRIMARY_HOST" ] && HA_ARGS+=(--join-primary-host "$HA_JOIN_PRIMARY_HOST")
+  [ -n "$EXPECTED_CONFIG_FINGERPRINT" ] && HA_ARGS+=(--expected-config-fingerprint "$EXPECTED_CONFIG_FINGERPRINT")
+  ./ha/install-ha-node.sh "${HA_ARGS[@]}"
+else
+  ./run-fleet.sh
+fi

--- a/deployment-files/server/Dockerfile
+++ b/deployment-files/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.22.0
 
-RUN apk add --no-cache nmap gcompat
+RUN apk add --no-cache nmap gcompat wget
 
 WORKDIR /app
 

--- a/server/timescaledb/Dockerfile.ha
+++ b/server/timescaledb/Dockerfile.ha
@@ -1,0 +1,28 @@
+# Proto Fleet TimescaleDB HA image.
+#
+# This intentionally layers only pg_auto_failover onto the existing lightweight
+# Proto Fleet TimescaleDB image. The single-node image and entrypoint stay
+# unchanged; HA containers use docker-entrypoint-ha.sh and run pg_autoctl.
+
+FROM proto-fleet-timescaledb:latest
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PG_MAJOR=18
+
+USER root
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        pg-auto-failover-cli \
+        postgresql-${PG_MAJOR}-auto-failover; \
+    sed -i "s/^shared_preload_libraries = 'timescaledb'/shared_preload_libraries = 'timescaledb,pgautofailover'/" \
+        /usr/share/postgresql/${PG_MAJOR}/postgresql.conf.sample; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY docker-entrypoint-ha.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint-ha.sh
+
+ENTRYPOINT ["docker-entrypoint-ha.sh"]
+CMD ["pg_autoctl", "run", "--pgdata", "/home/postgres/pgdata/data"]

--- a/server/timescaledb/README.md
+++ b/server/timescaledb/README.md
@@ -95,6 +95,22 @@ you need reproducible builds.
 docker build -t proto-fleet/timescaledb:latest server/timescaledb/
 ```
 
+### HA lab variant
+
+Dockerized HA installs build a second image on top of the normal image:
+
+```bash
+docker build -t proto-fleet-timescaledb:latest server/timescaledb/
+docker build -f server/timescaledb/Dockerfile.ha \
+  -t proto-fleet-timescaledb-ha:latest \
+  server/timescaledb/
+```
+
+The HA image keeps the same PostgreSQL, TimescaleDB, Toolkit, pgvector, and
+`timescaledb-tune` stack, but adds `pg_auto_failover` and uses
+`docker-entrypoint-ha.sh` so `pg_autoctl` owns the PostgreSQL process. The
+single-node image and entrypoint remain unchanged.
+
 ## Usage
 
 This image is referenced as a build target in `docker-compose.base.yaml`:

--- a/server/timescaledb/docker-entrypoint-ha.sh
+++ b/server/timescaledb/docker-entrypoint-ha.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+PGDATA="${PGDATA:-/home/postgres/pgdata/data}"
+PGPORT="${PGPORT:-5432}"
+HA_AUTH_METHOD="${HA_AUTH_METHOD:-trust}"
+HA_SSL_SELF_SIGNED="${HA_SSL_SELF_SIGNED:-false}"
+POSTGRES_DB="${POSTGRES_DB:-fleet}"
+POSTGRES_USER="${POSTGRES_USER:-fleet}"
+
+log() {
+    echo "Proto Fleet HA DB: $*"
+}
+
+die() {
+    echo "Proto Fleet HA DB error: $*" >&2
+    exit 1
+}
+
+require_env() {
+    local name="$1"
+    if [ -z "${!name:-}" ]; then
+        die "$name is required"
+    fi
+}
+
+append_once() {
+    local file="$1"
+    local line="$2"
+    grep -qxF "$line" "$file" 2>/dev/null || echo "$line" >> "$file"
+}
+
+ensure_shared_preload_libraries() {
+    local file="$1"
+    local desired="shared_preload_libraries = 'timescaledb,pgautofailover'"
+
+    if grep -q '^shared_preload_libraries' "$file" 2>/dev/null; then
+        sed -i "s/^shared_preload_libraries.*/$desired/" "$file"
+    else
+        echo "$desired" >> "$file"
+    fi
+}
+
+tune_postgres() {
+    [ -f "$PGDATA/postgresql.conf" ] || return 0
+
+    ensure_shared_preload_libraries "$PGDATA/postgresql.conf"
+    append_once "$PGDATA/postgresql.conf" "listen_addresses = '*'"
+
+    if [ -n "${NO_TS_TUNE:-}" ] || ! command -v timescaledb-tune >/dev/null 2>&1; then
+        return 0
+    fi
+
+    local tune_flags=""
+    [ -n "${TS_TUNE_MEMORY:-}" ] && tune_flags="$tune_flags --memory=$TS_TUNE_MEMORY"
+    [ -n "${TS_TUNE_NUM_CPUS:-}" ] && tune_flags="$tune_flags --cpus=$TS_TUNE_NUM_CPUS"
+    [ -n "${TS_TUNE_MAX_CONNS:-}" ] && tune_flags="$tune_flags --max-conns=$TS_TUNE_MAX_CONNS"
+    [ -n "${TS_TUNE_MAX_BG_WORKERS:-}" ] && tune_flags="$tune_flags --max-bg-workers=$TS_TUNE_MAX_BG_WORKERS"
+
+    log "running timescaledb-tune"
+    # shellcheck disable=SC2086
+    timescaledb-tune --quiet --yes \
+        --conf-path="$PGDATA/postgresql.conf" \
+        --pg-version="${PG_MAJOR:-18}" \
+        $tune_flags || true
+}
+
+ssl_flags=()
+if [ "$HA_SSL_SELF_SIGNED" = "true" ]; then
+    ssl_flags=(--ssl-self-signed)
+elif [ "$HA_SSL_SELF_SIGNED" = "false" ]; then
+    ssl_flags=(--no-ssl)
+else
+    die "HA_SSL_SELF_SIGNED must be true or false"
+fi
+
+if [ "$(id -u)" = "0" ]; then
+    pgdata_parent="$(dirname "$PGDATA")"
+    mkdir -p "$PGDATA" "$pgdata_parent/backup" /var/run/postgresql
+    chown -R postgres:postgres "$pgdata_parent" /var/run/postgresql 2>/dev/null || true
+    chmod 700 "$PGDATA"
+    exec gosu postgres "$0" "$@"
+fi
+
+mkdir -p "$PGDATA"
+
+if [ -z "${HA_ROLE:-}" ] && [ "$#" -gt 0 ]; then
+    if [ "$1" != "pg_autoctl" ] || [ "${2:-}" != "run" ]; then
+        exec "$@"
+    fi
+fi
+
+case "${HA_ROLE:-}" in
+    monitor)
+        require_env HA_NODE_HOST
+        if [ ! -f "$PGDATA/pg_autoctl.cfg" ]; then
+            log "initializing pg_auto_failover monitor at $HA_NODE_HOST:$PGPORT"
+            pg_autoctl create monitor \
+                --pgdata "$PGDATA" \
+                --pgport "$PGPORT" \
+                --hostname "$HA_NODE_HOST" \
+                --auth "$HA_AUTH_METHOD" \
+                "${ssl_flags[@]}"
+        fi
+        exec pg_autoctl run --pgdata "$PGDATA"
+        ;;
+
+    data)
+        require_env HA_NODE_NAME
+        require_env HA_NODE_HOST
+        require_env HA_MONITOR_URL
+        if [ ! -f "$PGDATA/pg_autoctl.cfg" ]; then
+            log "initializing pg_auto_failover data node $HA_NODE_NAME at $HA_NODE_HOST:$PGPORT"
+            pg_autoctl create postgres \
+                --pgdata "$PGDATA" \
+                --pgport "$PGPORT" \
+                --listen "*" \
+                --hostname "$HA_NODE_HOST" \
+                --name "$HA_NODE_NAME" \
+                --username "$POSTGRES_USER" \
+                --dbname "$POSTGRES_DB" \
+                --monitor "$HA_MONITOR_URL" \
+                --auth "$HA_AUTH_METHOD" \
+                --pg-hba-lan \
+                "${ssl_flags[@]}"
+            tune_postgres
+        fi
+        exec pg_autoctl run --pgdata "$PGDATA"
+        ;;
+
+    "")
+        die "HA_ROLE is required and must be monitor or data"
+        ;;
+
+    *)
+        die "unknown HA_ROLE: $HA_ROLE"
+        ;;
+esac


### PR DESCRIPTION
## Summary

This PR adds a lab-ready HA deployment path for on-prem Fleet installs where PostgreSQL/TimescaleDB remains Dockerized. Operators can run a three-Pi topology with a Dockerized `pg_auto_failover` monitor, two Dockerized TimescaleDB data nodes, and Fleet automatically started only on the node whose local DB container is primary.

The existing single-node install remains the default. HA mode is explicitly scoped as a Raspberry Pi lab path for validating curtailment recovery before we decide whether to productize it further.

## How it works

The release bundle now includes a second DB image tarball, `images/timescaledb-ha.tar.gz`, built from the existing lightweight TimescaleDB image plus `pg_auto_failover`. The HA image uses a separate entrypoint so `pg_autoctl` owns PostgreSQL lifecycle in monitor or data-node mode, while the original single-node DB image and entrypoint stay unchanged.

`install.sh` accepts HA flags and routes HA installs into `deployment/ha/install-ha-node.sh`. Monitor installs start only the monitor compose file. Data-node installs validate local config/secrets, load the HA DB image, start the local DB keeper container, and install a systemd timer that runs every 5 seconds. The timer checks the local DB role plus monitor-confirmed primary state before starting Fleet through the Fleet-only HA compose file.

```mermaid
flowchart LR
  subgraph "pi-3"
    M["fleet-ha-monitor\npg_auto_failover monitor"]
  end

  subgraph "pi-1"
    D1["fleet-ha-db\ndata node"]
    F1["fleet-api + fleet-client\nstarted only if local DB is primary"]
    T1["fleet-follows-primary.timer"]
  end

  subgraph "pi-2"
    D2["fleet-ha-db\ndata node"]
    F2["fleet-api + fleet-client\nstopped while local DB is standby"]
    T2["fleet-follows-primary.timer"]
  end

  M --> D1
  M --> D2
  D1 <--> D2
  T1 --> D1
  T1 --> F1
  T2 --> D2
  T2 --> F2
```

```mermaid
sequenceDiagram
  participant Monitor as "pi-3 monitor"
  participant OldPrimary as "old primary data node"
  participant Standby as "standby data node"
  participant Follower as "fleet-follows-primary"
  participant Fleet as "Fleet containers"

  OldPrimary--xMonitor: "active data-node failure"
  Monitor->>Standby: "assign primary"
  Standby->>Standby: "Postgres becomes writable"
  Follower->>Standby: "confirm local DB primary"
  Follower->>Monitor: "confirm node is primary"
  Follower->>Fleet: "start fleet-api and fleet-client"
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/timescaledb/` | Adds `Dockerfile.ha` and an HA entrypoint that runs `pg_autoctl` in monitor/data mode | This is the core lifecycle boundary: `pg_autoctl` must own Postgres in HA mode |
| `deployment-files/docker-compose.ha*.yaml` | Adds separate compose files for Fleet-only, monitor, and data-node runtimes | Keeps HA mode from subtracting services from the existing single-node compose stack |
| `deployment-files/ha/` | Adds preflight, install, status, config fingerprinting, Fleet control, and systemd follower scripts | Defines the operator surface and the safety logic that prevents dual Fleet writers |
| `deployment-files/install.sh` | Adds HA flags and routes HA installs to the HA installer | Preserves the default single-node install path while enabling scripted HA lab installs |
| `.github/workflows/proto-fleet-artifact-build.yml` | Builds and packages the HA DB image tarball alongside the existing DB image | Ensures downloaded release bundles can run HA mode without a source checkout |
| `.github/path-filters.yml` | Includes `deployment-files/ha/**` in global CI path filters | Ensures HA script changes trigger deployment-related checks |
| `deployment-files/README.md`, `server/timescaledb/README.md`, `deployment-files/ha/README.md` | Documents HA install commands, lab gates, and image behavior | Gives operators the exact validation path before relying on automatic failover |

## Key technical decisions & trade-offs

| Decision | Alternative | Why |
| --- | --- | --- |
| Add a small HA DB image variant | Run native host Postgres | The requirement is Dockerized Postgres, and `pg_autoctl` needs to own the Postgres process inside the container |
| Keep HA compose files separate | Layer an override on the existing compose file | Separate files avoid brittle attempts to remove the single-node `timescaledb` dependency |
| Use a local systemd follower timer | Build a separate orchestrator service | A 5-second one-shot timer is easier to inspect, restart, and disable during lab testing |
| Validate config parity by fingerprint | Copy secrets between Pis | HA mode avoids secret distribution and fails fast on mismatched standby config |
| Keep monitor outage from starting stopped Fleet | Let any writable DB start Fleet without monitor confirmation | This preserves curtailment on the last confirmed primary while reducing split-brain risk |

## Testing & validation

Validated locally:

- `bash -n deployment-files/install.sh deployment-files/ha/*.sh server/timescaledb/docker-entrypoint-ha.sh`
- YAML parsing for HA compose files, workflow YAML, and path filters
- `docker compose config` for monitor, data-node, and Fleet-only HA compose in a release-like temp directory
- Built the existing DB image and the HA DB image locally
- Verified `pg_autoctl --version` and `postgres --version` through the HA image
- Smoke-tested a local monitor plus two local data-node containers; `pg_autoctl show state` reported one primary and one secondary

Not covered here:

- Three-Raspberry-Pi lab validation
- Active curtailment RTO <= 60 seconds
- Real power-loss and network-partition behavior
- Full release workflow run in GitHub Actions

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5_Codex](https://img.shields.io/badge/GPT_5_Codex-000000)
