### PR TITLE
fix(fleet): single page scroll container with pinned chrome and headers

### DIFF
--- a/client/src/protoFleet/components/AppLayout/AppLayout.tsx
+++ b/client/src/protoFleet/components/AppLayout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import clsx from "clsx";
 
 import NavigationMenu from "../NavigationMenu";
@@ -45,6 +45,24 @@ const AppLayoutContent = ({ children }: Props) => {
 
   const showPhoneWidgets = isPhone && phoneRowWidgetCount > 0;
 
+  // Publish the scroll container's vertical-scrollbar width as
+  // `--content-scroll-gutter`. Page-scroll sticky chrome (see
+  // PAGE_SCROLL_CHROME_WIDTH) sizes itself with `100vw`, which counts that
+  // gutter while the client area does not — subtracting it keeps the chrome
+  // pinned all the way to the end of a horizontal scroll. Resolves to 0 for
+  // overlay scrollbars. Re-measured when the scroll area resizes (the gutter
+  // appears/disappears as content overflows or the viewport changes).
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const update = () => el.style.setProperty("--content-scroll-gutter", `${el.offsetWidth - el.clientWidth}px`);
+    update();
+    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : undefined;
+    observer?.observe(el);
+    return () => observer?.disconnect();
+  }, []);
+
   return (
     <div className={clsx("absolute top-0 right-0 bottom-0 left-0", bgClass)}>
       <div className="fixed top-0 z-50 h-fit w-0 laptop:w-16 desktop:w-50">
@@ -63,6 +81,7 @@ const AppLayoutContent = ({ children }: Props) => {
       </div>
 
       <div
+        ref={scrollRef}
         className={clsx(
           "fixed top-[calc(theme(spacing.1)*12)] right-0 bottom-0 left-0 z-20 overflow-auto laptop:top-[calc(theme(spacing.1)*15)] laptop:left-16 desktop:left-50",
           bgClass,

--- a/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
@@ -9,6 +9,7 @@ import { ChevronDown } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import List, { type SelectionMode } from "@/shared/components/List";
 import { type SortDirection } from "@/shared/components/List/types";
+import { type Breakpoint } from "@/shared/constants/breakpoints";
 
 export type DeviceSetListItem = {
   id: string;
@@ -50,6 +51,18 @@ type DeviceSetListProps = {
   emptyStateRow?: ReactNode;
   selectedIds?: string[];
   onSelectedIdsChange?: (ids: string[]) => void;
+  /**
+   * Left padding for row content, applied inside cells so row dividers still
+   * span the full table width. Use this instead of wrapping the list in a
+   * horizontally-padded container (which leaves white gaps beside the rules).
+   */
+  paddingLeft?: Partial<Record<Breakpoint, string>>;
+  /**
+   * When false, the list does not create its own scroll container — the page
+   * scrolls instead and the sticky header pins to the page. See List's
+   * `overflowContainer`.
+   */
+  overflowContainer?: boolean;
 };
 
 const DeviceSetList = ({
@@ -75,6 +88,8 @@ const DeviceSetList = ({
   emptyStateRow,
   selectedIds,
   onSelectedIdsChange,
+  paddingLeft,
+  overflowContainer,
 }: DeviceSetListProps) => {
   const topRef = useRef<HTMLDivElement>(null);
   const temperatureUnit = useTemperatureUnit();
@@ -118,6 +133,8 @@ const DeviceSetList = ({
     getDefaultSortDirection,
     onRowClick,
     emptyStateRow,
+    paddingLeft,
+    overflowContainer,
   };
   const pagination = shouldRenderPagination ? (
     <div className="sticky left-0 flex flex-col items-center gap-4 py-6">

--- a/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/DeviceSetList.tsx
@@ -1,9 +1,11 @@
 import { type ReactNode, useCallback, useMemo, useRef } from "react";
+import clsx from "clsx";
 
 import { DEFAULT_PAGE_SIZE, deviceSetColTitles, type DeviceSetColumn } from "./constants";
 import { createDeviceSetColConfig } from "./deviceSetColConfig";
 import { getDefaultSortDirection, SORTABLE_COLUMNS } from "./sortConfig";
 import type { DeviceSet, DeviceSetStats } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import { useTemperatureUnit } from "@/protoFleet/store";
 import { ChevronDown } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -137,7 +139,14 @@ const DeviceSetList = ({
     overflowContainer,
   };
   const pagination = shouldRenderPagination ? (
-    <div className="sticky left-0 flex flex-col items-center gap-4 py-6">
+    // In page-scroll mode pin to the viewport so the centered Prev/Next don't
+    // stretch across the full table (and off-screen) under the w-max subtree.
+    <div
+      className={clsx(
+        "sticky left-0 flex flex-col items-center gap-4 py-6",
+        overflowContainer === false && PAGE_SCROLL_CHROME_WIDTH,
+      )}
+    >
       <span className="text-300 text-text-primary">
         Showing {firstItemIndex}–{lastItemIndex} of {total} {itemName.plural}
       </span>

--- a/client/src/protoFleet/constants/layout.ts
+++ b/client/src/protoFleet/constants/layout.ts
@@ -1,0 +1,27 @@
+/**
+ * Page-scroll chrome width.
+ *
+ * In the Fleet shell the page (AppLayout's scroll container) is the single
+ * scroll container for BOTH axes. Wide tables scroll the page horizontally,
+ * so any chrome that should stay pinned to the left edge during that scroll
+ * (filter rows, headers, counts, action bars) needs:
+ *
+ *   1. `sticky left-0` — pin to the scroll port's left edge, and
+ *   2. an explicit viewport-minus-sidebar width — so the element is narrower
+ *      than its (max-content) containing block and therefore has room to
+ *      slide. Without the width it fills the containing block and can't move,
+ *      so it scrolls away with the table.
+ *
+ * The subtracted amounts mirror AppLayout's sidebar offsets (`laptop:left-16`
+ * = 64px, `desktop:left-50` = 200px); phone has no inline sidebar. We also
+ * subtract `--content-scroll-gutter` — the vertical scrollbar width that
+ * `100vw` counts but the scroll container's client area does not. Without it
+ * the chrome is one-scrollbar too wide and over-travels (~15px) at the far end
+ * of a horizontal scroll. AppLayout measures and publishes that variable; it
+ * resolves to 0 for overlay scrollbars.
+ *
+ * Pair this with a `w-max min-w-full` ancestor so the containing block grows
+ * to the table width.
+ */
+export const PAGE_SCROLL_CHROME_WIDTH =
+  "w-[calc(100vw-var(--content-scroll-gutter,0px))] laptop:w-[calc(100vw-theme(spacing.1)*16-var(--content-scroll-gutter,0px))] desktop:w-[calc(100vw-theme(spacing.1)*50-var(--content-scroll-gutter,0px))]";

--- a/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.tsx
@@ -174,6 +174,9 @@ const BuildingList = ({
     onRowClick: handleRowClick,
     emptyStateRow,
     paddingLeft: { phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" },
+    // See SiteList: page-scroll mode so the sticky header isn't trapped in a
+    // nested scroll container inside the Fleet shell.
+    overflowContainer: false,
   };
 
   if (selectedIds !== undefined && onSelectedIdsChange !== undefined) {

--- a/client/src/protoFleet/features/fleetManagement/components/FilterRow/FilterRow.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FilterRow/FilterRow.tsx
@@ -1,17 +1,24 @@
 import { type ReactNode } from "react";
 import clsx from "clsx";
 
+import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
+
 interface FilterRowProps {
   children: ReactNode;
   className?: string;
   testId?: string;
 }
 
-// Sticky-left + opaque background keep the band pinned during horizontal
-// scroll inside the list area beneath it.
+// Sticky-left + opaque background keep the band pinned during horizontal page
+// scroll. The explicit viewport width (PAGE_SCROLL_CHROME_WIDTH) gives it room
+// to slide within the max-content page subtree instead of scrolling away.
 const FilterRow = ({ children, className, testId }: FilterRowProps) => (
   <div
-    className={clsx("sticky left-0 z-10 flex flex-col gap-4 bg-surface-base px-6 pt-10 laptop:px-10", className)}
+    className={clsx(
+      "sticky left-0 z-10 flex flex-col gap-4 bg-surface-base px-6 pt-10 laptop:px-10",
+      PAGE_SCROLL_CHROME_WIDTH,
+      className,
+    )}
     data-testid={testId}
   >
     {children}

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -254,6 +254,8 @@ const Fleet = () => {
             laptop: "40px",
             desktop: "40px",
           }}
+          // Fleet shell owns the scroll: page scrolls, sticky header pins to it.
+          overflowContainer={false}
           onAddMiners={() => setShowAddMinersModal(true)}
           loading={!hasInitialLoadCompleted}
           pageSize={MINERS_PAGE_SIZE}

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import clsx from "clsx";
 import { Code } from "@connectrpc/connect";
 
 import { type FleetOutletContext } from "./outletContext";
@@ -8,6 +9,7 @@ import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_p
 import { buildKnownSiteIds, useSites } from "@/protoFleet/api/sites";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import { MULTI_SITE_ENABLED } from "@/protoFleet/constants/featureFlags";
+import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import FleetViewTabs from "@/protoFleet/features/fleetManagement/components/FleetViewTabs";
 import { type FleetTabId } from "@/protoFleet/features/fleetManagement/views/savedViews";
@@ -222,8 +224,16 @@ const FleetLayout = () => {
   const viewTabs = <FleetViewTabs viewsState={viewsState} currentTab={currentTab} filterContext={viewFilterContext} />;
 
   return (
-    <div className="flex h-full flex-col" data-testid="fleet-layout">
-      <div className="sticky left-0 z-10 flex flex-col gap-4 bg-surface-base px-6 pt-6 laptop:px-10">
+    // w-max + min-w-full: the subtree grows to the widest tab content (a wide
+    // table), which is what gives the sticky-left chrome below room to slide.
+    // min-w-full keeps it at least viewport-wide when content is narrow.
+    <div className="flex h-full w-max min-w-full flex-col" data-testid="fleet-layout">
+      <div
+        className={clsx(
+          "sticky left-0 z-10 flex flex-col gap-4 bg-surface-base px-6 pt-6 laptop:px-10",
+          PAGE_SCROLL_CHROME_WIDTH,
+        )}
+      >
         <div className="flex items-baseline justify-between gap-4">
           <h1 className="text-heading-300 text-text-primary">Fleet</h1>
           <div className="laptop:hidden">{viewTabs}</div>

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -432,10 +432,17 @@ const ScopedMinerListBody = ({
 
       {shouldRenderPagination ? (
         <div
-          className={clsx("sticky left-0 flex flex-col items-center gap-4 pt-6", {
-            "pb-24": selectionMode !== "none",
-            "pb-6": selectionMode === "none",
-          })}
+          className={clsx(
+            "sticky left-0 flex flex-col items-center gap-4 pt-6",
+            // Under the page's w-max subtree this auto-width sticky bar would
+            // stretch to the table and center Prev/Next off-screen; pin it to
+            // the viewport like the rest of the page-scroll chrome.
+            overflowContainer === false && PAGE_SCROLL_CHROME_WIDTH,
+            {
+              "pb-24": selectionMode !== "none",
+              "pb-6": selectionMode === "none",
+            },
+          )}
           data-testid="miners-pagination"
         >
           <span className="text-300 text-text-primary">

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -31,6 +31,7 @@ import {
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
 import { ProtoFleetStatusModal } from "@/protoFleet/components/StatusModal";
+import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import AuthenticateFleetModal from "@/protoFleet/features/auth/components/AuthenticateFleetModal";
 import { AuthenticateMiners } from "@/protoFleet/features/auth/components/AuthenticateMiners";
 import PoolSelectionPageWrapper from "@/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage";
@@ -97,6 +98,13 @@ type MinerListProps = {
   batchStateVersion?: number;
   listClassName?: string;
   paddingLeft?: Partial<Record<Breakpoint, string>>;
+  /**
+   * When false, the list does not create its own scroll container — the page
+   * scrolls instead and the sticky header pins to the page. The Fleet shell
+   * passes false; embedded usages (modals, panels) keep the default bounded
+   * scroll. See List's `overflowContainer`.
+   */
+  overflowContainer?: boolean;
   onAddMiners: () => void;
   totalMiners?: number;
   /**
@@ -222,6 +230,7 @@ type ScopedMinerListBodyProps = {
   initialActiveFilters: ActiveFilters;
   listClassName?: string;
   paddingLeft?: Partial<Record<Breakpoint, string>>;
+  overflowContainer?: boolean;
   totalMiners?: number;
   totalDisabledMiners: number;
   totalDisabledMinersFresh: boolean;
@@ -261,6 +270,7 @@ const ScopedMinerListBody = ({
   initialActiveFilters,
   listClassName,
   paddingLeft,
+  overflowContainer,
   totalMiners,
   totalDisabledMiners,
   totalDisabledMinersFresh,
@@ -389,6 +399,8 @@ const ScopedMinerListBody = ({
         tableClassName="mb-4 inline-table w-max !min-w-fit !table-fixed"
         paddingLeft={paddingLeft}
         paddingRight={paddingLeft}
+        overflowContainer={overflowContainer}
+        stickyChromeClassName={overflowContainer === false ? PAGE_SCROLL_CHROME_WIDTH : undefined}
         applyColumnWidthsToCells
         total={totalMiners}
         // Every row is selectable; `totalSelectable = totalMiners` so action-bar
@@ -463,6 +475,7 @@ const MinerList = ({
   batchStateVersion,
   listClassName,
   paddingLeft,
+  overflowContainer,
   onAddMiners,
   totalMiners,
   totalUnfilteredMiners,
@@ -1061,11 +1074,22 @@ const MinerList = ({
 
   return (
     <>
-      <div ref={topRef} className="sticky left-0 px-6 pt-6 laptop:px-10 laptop:pt-10">
+      <div
+        ref={topRef}
+        className={clsx(
+          "sticky left-0 px-6 pt-6 laptop:px-10 laptop:pt-10",
+          overflowContainer === false && PAGE_SCROLL_CHROME_WIDTH,
+        )}
+      >
         {title ? <h2 className="text-heading-300">{title}</h2> : null}
       </div>
 
-      <div className="sticky left-0 px-6 text-300 text-text-primary-70 laptop:px-10">
+      <div
+        className={clsx(
+          "sticky left-0 px-6 text-300 text-text-primary-70 laptop:px-10",
+          overflowContainer === false && PAGE_SCROLL_CHROME_WIDTH,
+        )}
+      >
         {hasActiveFilters && totalUnfilteredMiners !== undefined && totalMiners !== totalUnfilteredMiners
           ? `${totalMiners} of ${totalUnfilteredMiners} miners`
           : `${totalMiners ?? 0} miners`}
@@ -1086,6 +1110,7 @@ const MinerList = ({
           initialActiveFilters={initialActiveFilters}
           listClassName={listClassName}
           paddingLeft={paddingLeft}
+          overflowContainer={overflowContainer}
           totalMiners={totalMiners}
           totalDisabledMiners={totalDisabledMiners}
           totalDisabledMinersFresh={totalDisabledMinersFresh}

--- a/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.tsx
@@ -147,6 +147,12 @@ const SiteList = ({ sites, emptyStateRow, onEditSite, selectedIds, onSelectedIds
     onRowClick: handleRowClick,
     emptyStateRow,
     paddingLeft: { phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" },
+    // Page-scroll mode: the Fleet shell is the single scroll container. An
+    // overflow wrapper here would trap the sticky <thead> in a nested scroll
+    // context (overflow-x:* computes overflow-y to auto), so the header would
+    // not stick to the page. Let wide tables scroll the page horizontally
+    // instead — the sticky-left chrome (FilterRow, header) is built for that.
+    overflowContainer: false,
   };
 
   if (selectedIds !== undefined && onSelectedIdsChange !== undefined) {

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useSearchParams } from "react-router-dom";
+import clsx from "clsx";
 
 import { useBuildings } from "@/protoFleet/api/buildings";
 import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
@@ -19,6 +20,7 @@ import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEm
 import NullState from "@/protoFleet/components/NullState";
 import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
 import { MULTI_SITE_ENABLED } from "@/protoFleet/constants/featureFlags";
+import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import FleetGroupActionsMenu from "@/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu";
 import FleetGroupListActionBar from "@/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar";
@@ -763,7 +765,7 @@ const RacksPage = () => {
 
   return (
     <div>
-      <div className="sticky left-0 z-3 px-6 pt-6 laptop:px-10 laptop:pt-10">
+      <div className={clsx("sticky left-0 z-3 px-6 pt-6 laptop:px-10 laptop:pt-10", PAGE_SCROLL_CHROME_WIDTH)}>
         {insideFleetShell ? null : <h1 className="pb-4 text-heading-300 text-text-primary">Racks</h1>}
         <div className="flex flex-col gap-2 pb-6">
           {/* Action button — full-width on tablet/phone */}
@@ -844,7 +846,12 @@ const RacksPage = () => {
         <Callout className="mx-6 mb-4 laptop:mx-10" intent="danger" prefixIcon={<Alert />} title={error} />
       ) : null}
       {racksViewMode === "list" ? (
-        <div className="overflow-x-auto p-6 pt-0 laptop:p-10 laptop:pt-0">
+        // No horizontal padding or overflow wrapper here: that inset the table
+        // (white gaps beside the row rules) and added a second scroll
+        // container. Row content is indented via DeviceSetList's paddingLeft
+        // so the rules still span the full width, and the page is the single
+        // scroll container.
+        <div className="pb-6 laptop:pb-10">
           <DeviceSetList
             deviceSets={racks}
             statsMap={statsMap}
@@ -867,6 +874,8 @@ const RacksPage = () => {
             emptyStateRow={emptyStateRow}
             selectedIds={selectedRackIds}
             onSelectedIdsChange={handleSelectedRackIdsChange}
+            paddingLeft={{ phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" }}
+            overflowContainer={false}
           />
         </div>
       ) : (

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -1411,7 +1411,11 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
             )}
           </div>
           {renderActionBar ? (
-            <div className={stickyChromeClassName ? clsx("sticky left-0", stickyChromeClassName) : "w-full"}>
+            // No sticky/width treatment here: action bars position themselves
+            // (e.g. MinerListActionBar is `fixed`). Wrapping a fixed bar in a
+            // sticky div creates a stacking context that traps its popovers
+            // below the page chrome.
+            <div className="w-full">
               {renderActionBar(currentSelectedItems, clearSelection, currentSelectionMode, totalSelectable)}
             </div>
           ) : null}

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -169,6 +169,13 @@ type ListProps<ListItem, ItemKeyValueType, ColKey extends string = keyof ListIte
   paddingLeft?: Partial<Record<Breakpoint, string>>;
   paddingRight?: Partial<Record<Breakpoint, string>>;
   overflowContainer?: boolean;
+  /**
+   * Extra classes for the sticky-left chrome (filter row, count, action bar).
+   * Used in page-scroll mode to give them an explicit viewport width so they
+   * stay pinned while the table scrolls the page horizontally. Left empty for
+   * bounded lists, where the chrome never moves.
+   */
+  stickyChromeClassName?: string;
   stickyBgColor?: string;
   total?: number;
   /**
@@ -696,6 +703,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   paddingLeft,
   paddingRight,
   overflowContainer = true,
+  stickyChromeClassName,
   stickyBgColor = "bg-surface-base",
   total,
   totalDisabled = 0,
@@ -1371,12 +1379,12 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
 
   return (
     <>
-      <div style={paddingCssVariables} className="sticky left-0 z-3">
+      <div style={paddingCssVariables} className={clsx("sticky left-0 z-3", stickyChromeClassName)}>
         {filtersElement}
       </div>
       <div style={paddingCssVariables}>
         {!hideTotal && total !== undefined ? (
-          <div className="sticky left-0 flex">
+          <div className={clsx("sticky left-0 flex", stickyChromeClassName)}>
             <div className={clsx("sticky left-0 pb-4 text-emphasis-300 text-text-primary-70", paddingClasses)}>
               {total} {total === 1 ? itemName.singular : itemName.plural}
             </div>
@@ -1403,7 +1411,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
             )}
           </div>
           {renderActionBar ? (
-            <div className="w-full">
+            <div className={stickyChromeClassName ? clsx("sticky left-0", stickyChromeClassName) : "w-full"}>
               {renderActionBar(currentSelectedItems, clearSelection, currentSelectionMode, totalSelectable)}
             </div>
           ) : null}


### PR DESCRIPTION
## What this does

Folding the Sites / Buildings / Racks / Miners lists into one tabbed Fleet page nested each list inside its own scroll container. That regressed scrolling: lists scrolled independently of the page, the sticky table headers stopped pinning, and the racks list had white gutters beside its row rules.

This branch makes the **Fleet shell the single scroll container** for both axes and reworks the sticky chrome to live correctly inside that one scroll context.

## Architectural changes

- **One scroll container.** Lists render in page-scroll mode (`overflowContainer={false}`) so they no longer create a nested scroll box. The sticky table `<thead>` now pins to the page rather than to a trapped inner container (an `overflow-x` wrapper implicitly becomes an `overflow-y` scroller, which is what was capturing the header).
- **Full-width row rules.** Row indentation moved from a horizontally-padded wrapper into cell padding, so dividers span the full table width instead of leaving gutters.
- **Pinned chrome during horizontal scroll.** Headers, filter rows, counts, and action bars are sticky-left with an explicit viewport width so they have room to slide within the page's `max-content` subtree instead of scrolling away. AppLayout measures the scrollbar gutter once and publishes it as a CSS variable that the chrome width subtracts, so pinning stays exact at the end of a horizontal scroll (and resolves to 0 for overlay scrollbars).

## Non-goals / deferred

- No changes to list data, columns, filtering, or pagination — layout only.
- Embedded/bounded list usages (modals, panels) keep their internal scroll; only the Fleet shell switches to page-scroll.
- The scrollbar gutter re-measures on resize but not on a runtime overlay↔classic scrollbar toggle (e.g. plugging in a mouse on macOS) without a layout change; deferred as a minor edge case.