### PR TITLE
fix(curtailment): allow full-fleet low-power targets

### DIFF
--- a/server/internal/domain/curtailment/modes/fixed_kw.go
+++ b/server/internal/domain/curtailment/modes/fixed_kw.go
@@ -42,6 +42,12 @@ func NewFixedKw(targetKW, toleranceKW float64, summary InsufficientLoadDetail) (
 	}, nil
 }
 
+// RequiresDualSignalTelemetry keeps fixed-kW accounting grounded in measurable
+// curtailment load.
+func (*FixedKw) RequiresDualSignalTelemetry() bool {
+	return true
+}
+
 // Select implements Mode. Three branches per the design:
 //
 //  1. Target reached: walk candidates accumulating; stop after the first

--- a/server/internal/domain/curtailment/modes/full_fleet.go
+++ b/server/internal/domain/curtailment/modes/full_fleet.go
@@ -9,6 +9,10 @@ type FullFleet struct{}
 // Select implements Mode: take all ranked candidates in dispatch order and sum
 // their power. Empty input yields an empty Selected with OutcomeTargetReached
 // (RealizedReductionW 0) — never OutcomeInsufficientLoad.
+func (FullFleet) RequiresDualSignalTelemetry() bool {
+	return false
+}
+
 func (FullFleet) Select(ranked []Candidate) Result {
 	selected := make([]Candidate, len(ranked))
 	copy(selected, ranked)

--- a/server/internal/domain/curtailment/modes/mode.go
+++ b/server/internal/domain/curtailment/modes/mode.go
@@ -71,5 +71,6 @@ type Result struct {
 // Mode applies mode-specific selection to a ranked candidate list.
 // Implementations MUST be pure: no I/O, no time, no shared state.
 type Mode interface {
+	RequiresDualSignalTelemetry() bool
 	Select(ranked []Candidate) Result
 }

--- a/server/internal/domain/curtailment/selector.go
+++ b/server/internal/domain/curtailment/selector.go
@@ -43,8 +43,8 @@ type CandidateInput struct {
 	// PowerW is the latest power_w sample; used by both the dual-signal
 	// filter and realized-kW accumulation.
 	PowerW float64
-	// HashRateHS is the latest hash_rate_hs sample; dual-signal filter
-	// requires > 0 to admit.
+	// HashRateHS is the latest hash_rate_hs sample; fixed-kW's dual-signal
+	// filter requires > 0 to admit.
 	HashRateHS float64
 	// AvgEfficiencyJH is the hourly j/h aggregate used for ranking. nil =
 	// unknown efficiency, ranked last (avoids COALESCE-to-zero artifact).
@@ -106,8 +106,8 @@ type SelectedDevice struct {
 	EfficiencyJH     float64
 }
 
-// BuildPlan runs the selection pipeline (dual-signal filter, rank by
-// worst avg_efficiency first, hand off to the mode for the stop condition).
+// BuildPlan runs the selection pipeline (mode-specific eligibility filter, rank
+// by worst avg_efficiency first, hand off to the mode for the stop condition).
 // `preFiltered` carries upstream skips (status/pairing/cooldown/capability)
 // through to the Plan's Skipped list unchanged.
 //
@@ -132,36 +132,40 @@ func BuildPlan(
 	}
 
 	eligible := make([]CandidateInput, 0, len(inputs))
-	for _, c := range inputs {
-		switch {
-		case c.PowerW < float64(candidateMinPowerW) && c.HashRateHS <= 0:
-			// Both signals fail — most likely a fully-idle/dead miner.
-			// Skip below_threshold which carries the most actionable
-			// diagnostic for ops (lower the floor for S9/S15 fleets).
-			skipped = append(skipped, SkippedDevice{
-				DeviceIdentifier: c.DeviceIdentifier,
-				Reason:           SkipBelowThreshold,
-			})
-			dualSignalCounts.belowThreshold++
-		case c.PowerW < float64(candidateMinPowerW):
-			// Hashing but power reads near zero: dead/broken AC monitor.
-			// Curtailing succeeds but reconciler can't verify.
-			skipped = append(skipped, SkippedDevice{
-				DeviceIdentifier: c.DeviceIdentifier,
-				Reason:           SkipPowerTelemetryUnreliable,
-			})
-			dualSignalCounts.deadMonitor++
-		case c.HashRateHS <= 0:
-			// Drawing power but not hashing: phantom load — no real
-			// hashrate to lose, fictional kW reduction.
-			skipped = append(skipped, SkippedDevice{
-				DeviceIdentifier: c.DeviceIdentifier,
-				Reason:           SkipPhantomLoadNoHash,
-			})
-			dualSignalCounts.phantomLoad++
-		default:
-			eligible = append(eligible, c)
+	if mode.RequiresDualSignalTelemetry() {
+		for _, c := range inputs {
+			switch {
+			case c.PowerW < float64(candidateMinPowerW) && c.HashRateHS <= 0:
+				// Both signals fail — most likely a fully-idle/dead miner.
+				// Skip below_threshold which carries the most actionable
+				// diagnostic for ops (lower the floor for S9/S15 fleets).
+				skipped = append(skipped, SkippedDevice{
+					DeviceIdentifier: c.DeviceIdentifier,
+					Reason:           SkipBelowThreshold,
+				})
+				dualSignalCounts.belowThreshold++
+			case c.PowerW < float64(candidateMinPowerW):
+				// Hashing but power reads near zero: dead/broken AC monitor.
+				// Curtailing succeeds but reconciler can't verify.
+				skipped = append(skipped, SkippedDevice{
+					DeviceIdentifier: c.DeviceIdentifier,
+					Reason:           SkipPowerTelemetryUnreliable,
+				})
+				dualSignalCounts.deadMonitor++
+			case c.HashRateHS <= 0:
+				// Drawing power but not hashing: phantom load — no real
+				// hashrate to lose, fictional kW reduction.
+				skipped = append(skipped, SkippedDevice{
+					DeviceIdentifier: c.DeviceIdentifier,
+					Reason:           SkipPhantomLoadNoHash,
+				})
+				dualSignalCounts.phantomLoad++
+			default:
+				eligible = append(eligible, c)
+			}
 		}
+	} else {
+		eligible = append(eligible, inputs...)
 	}
 
 	// Stable worst-J/H-first rank; unknowns last; equal-efficiency input

--- a/server/internal/domain/curtailment/selector_test.go
+++ b/server/internal/domain/curtailment/selector_test.go
@@ -19,6 +19,10 @@ type fakeMode struct {
 	result   modes.Result
 }
 
+func (f *fakeMode) RequiresDualSignalTelemetry() bool {
+	return true
+}
+
 func (f *fakeMode) Select(ranked []modes.Candidate) modes.Result {
 	f.captured = make([]modes.Candidate, len(ranked))
 	copy(f.captured, ranked)
@@ -68,6 +72,45 @@ func TestBuildPlan_DualSignalFilter_BelowThreshold(t *testing.T) {
 
 	require.Len(t, plan.Skipped, 1)
 	assert.Equal(t, SkipBelowThreshold, plan.Skipped[0].Reason)
+}
+
+func TestBuildPlan_FullFleetBypassesDualSignalFilter(t *testing.T) {
+	t.Parallel()
+
+	inputs := []CandidateInput{
+		{DeviceIdentifier: "low-power-hashing", PowerW: 100, HashRateHS: 100, AvgEfficiencyJH: eff(40)},
+		{DeviceIdentifier: "not-yet-hashing", PowerW: 2000, HashRateHS: 0, AvgEfficiencyJH: eff(35)},
+		{DeviceIdentifier: "idle-low-power", PowerW: 5, HashRateHS: 0, AvgEfficiencyJH: nil},
+	}
+
+	plan := BuildPlan(inputs, nil, 1500, modes.FullFleet{})
+
+	assert.Empty(t, plan.Skipped)
+	require.Len(t, plan.Selected, 3)
+	assert.Equal(t, "low-power-hashing", plan.Selected[0].DeviceIdentifier)
+	assert.Equal(t, "not-yet-hashing", plan.Selected[1].DeviceIdentifier)
+	assert.Equal(t, "idle-low-power", plan.Selected[2].DeviceIdentifier)
+	assert.Equal(t, modes.OutcomeTargetReached, plan.Outcome)
+}
+
+func TestBuildPlan_FixedKwStillAppliesDualSignalFilter(t *testing.T) {
+	t.Parallel()
+
+	inputs := []CandidateInput{
+		{DeviceIdentifier: "eligible", PowerW: 3000, HashRateHS: 100, AvgEfficiencyJH: eff(40)},
+		{DeviceIdentifier: "low-power-hashing", PowerW: 100, HashRateHS: 100, AvgEfficiencyJH: eff(35)},
+		{DeviceIdentifier: "not-yet-hashing", PowerW: 2000, HashRateHS: 0, AvgEfficiencyJH: eff(30)},
+	}
+	mode, err := modes.NewFixedKw(1, 0, modes.InsufficientLoadDetail{CandidateMinPowerW: 1500})
+	require.NoError(t, err)
+
+	plan := BuildPlan(inputs, nil, 1500, mode)
+
+	require.Len(t, plan.Selected, 1)
+	assert.Equal(t, "eligible", plan.Selected[0].DeviceIdentifier)
+	require.Len(t, plan.Skipped, 2)
+	assert.Equal(t, SkipPowerTelemetryUnreliable, plan.Skipped[0].Reason)
+	assert.Equal(t, SkipPhantomLoadNoHash, plan.Skipped[1].Reason)
 }
 
 func TestBuildPlan_PreFilteredSkippedAreForwarded(t *testing.T) {

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -1360,9 +1360,9 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 			summary.ExcludedStale++
 			continue
 		}
-		// Missing/non-finite power or hash samples cannot prove the miner is
-		// observable after dispatch; treat them as stale telemetry.
-		if !hasFiniteFloat(c.LatestPowerW) || !hasFiniteFloat(c.LatestHashRateHS) {
+		// Missing, non-finite, or negative power/hash samples cannot prove the
+		// miner is observable after dispatch; treat them as stale telemetry.
+		if !hasNonNegativeFiniteFloat(c.LatestPowerW) || !hasNonNegativeFiniteFloat(c.LatestHashRateHS) {
 			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipStaleTelemetry})
 			summary.ExcludedStale++
 			continue
@@ -1421,8 +1421,8 @@ func derefFloat(p *float64) float64 {
 	return *p
 }
 
-func hasFiniteFloat(p *float64) bool {
-	return p != nil && isFiniteFloat(p)
+func hasNonNegativeFiniteFloat(p *float64) bool {
+	return p != nil && isFiniteFloat(p) && *p >= 0
 }
 
 // isFiniteFloat returns true for nil pointers; otherwise checks the
@@ -1510,7 +1510,7 @@ func buildInsertParams(req StartRequest, plan *Plan, minPowerW int32) (models.In
 	targets := make([]models.InsertTargetParams, len(plan.Selected))
 	for i, sel := range plan.Selected {
 		var baseline *float64
-		if sel.PowerW > 0 {
+		if shouldPersistBaselinePowerW(mode, sel.PowerW, minPowerW) {
 			v := sel.PowerW
 			baseline = &v
 		}
@@ -1523,6 +1523,16 @@ func buildInsertParams(req StartRequest, plan *Plan, minPowerW int32) (models.In
 		}
 	}
 	return event, targets, nil
+}
+
+func shouldPersistBaselinePowerW(mode models.Mode, powerW float64, minPowerW int32) bool {
+	if powerW <= 0 {
+		return false
+	}
+	if mode == models.ModeFullFleet && powerW < float64(minPowerW) {
+		return false
+	}
+	return true
 }
 
 // eventStartState is the state a freshly-built event is inserted with. A

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -1360,8 +1360,9 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 			summary.ExcludedStale++
 			continue
 		}
-		// NaN/Inf would slip past the dual-signal filter; treat as stale.
-		if !isFiniteFloat(c.LatestPowerW) || !isFiniteFloat(c.LatestHashRateHS) {
+		// Missing/non-finite power or hash samples cannot prove the miner is
+		// observable after dispatch; treat them as stale telemetry.
+		if !hasFiniteFloat(c.LatestPowerW) || !hasFiniteFloat(c.LatestHashRateHS) {
 			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipStaleTelemetry})
 			summary.ExcludedStale++
 			continue
@@ -1418,6 +1419,10 @@ func derefFloat(p *float64) float64 {
 		return 0
 	}
 	return *p
+}
+
+func hasFiniteFloat(p *float64) bool {
+	return p != nil && isFiniteFloat(p)
 }
 
 // isFiniteFloat returns true for nil pointers; otherwise checks the

--- a/server/internal/domain/curtailment/service_start_fullfleet_test.go
+++ b/server/internal/domain/curtailment/service_start_fullfleet_test.go
@@ -58,7 +58,12 @@ func TestService_Start_FullFleet_CurtailsLowPowerAndZeroHashrateMiners(t *testin
 		"full_fleet still ranks by efficiency when selecting all eligible miners")
 	assert.Equal(t, "low-power-hashing", plan.Selected[1].DeviceIdentifier)
 	assert.Empty(t, plan.Skipped)
-	assert.Len(t, store.lastInsertTargets, 2)
+	require.Len(t, store.lastInsertTargets, 2)
+	require.NotNil(t, store.lastInsertTargets[0].BaselinePowerW,
+		"above-floor full_fleet targets keep a power baseline")
+	assert.InDelta(t, 2000, *store.lastInsertTargets[0].BaselinePowerW, 0.001)
+	assert.Nil(t, store.lastInsertTargets[1].BaselinePowerW,
+		"below-floor full_fleet targets confirm via hash-rate fallback")
 }
 
 func TestService_Preview_FullFleet_SkipsMissingTelemetrySamples(t *testing.T) {
@@ -71,8 +76,16 @@ func TestService_Preview_FullFleet_SkipsMissingTelemetrySamples(t *testing.T) {
 	missingPower.LatestPowerW = nil
 	missingHash := miner("missing-hash", "ACTIVE", "PAIRED", 100, 0)
 	missingHash.LatestHashRateHS = nil
+	negativePower := miner("negative-power", "ACTIVE", "PAIRED", -1, 100)
+	negativeHash := miner("negative-hash", "ACTIVE", "PAIRED", 100, -1)
 	measuredZero := minerWithEff("measured-zero", 0, 0, 40)
-	store.candidatesByOrg[orgID] = []*models.Candidate{missingPower, missingHash, measuredZero}
+	store.candidatesByOrg[orgID] = []*models.Candidate{
+		missingPower,
+		missingHash,
+		negativePower,
+		negativeHash,
+		measuredZero,
+	}
 
 	svc := NewService(store)
 	req := validRequest(orgID)
@@ -85,9 +98,10 @@ func TestService_Preview_FullFleet_SkipsMissingTelemetrySamples(t *testing.T) {
 	require.Len(t, plan.Selected, 1)
 	assert.Equal(t, "measured-zero", plan.Selected[0].DeviceIdentifier,
 		"measured zero values are valid for full_fleet; missing samples are not")
-	require.Len(t, plan.Skipped, 2)
-	assert.Equal(t, SkipStaleTelemetry, plan.Skipped[0].Reason)
-	assert.Equal(t, SkipStaleTelemetry, plan.Skipped[1].Reason)
+	require.Len(t, plan.Skipped, 4)
+	for _, skipped := range plan.Skipped {
+		assert.Equal(t, SkipStaleTelemetry, skipped.Reason)
+	}
 }
 
 // The empty-eligible case is the chosen behavior: persist a vacuously COMPLETED

--- a/server/internal/domain/curtailment/service_start_fullfleet_test.go
+++ b/server/internal/domain/curtailment/service_start_fullfleet_test.go
@@ -36,6 +36,31 @@ func TestService_Start_FullFleet_CurtailsAllEligible(t *testing.T) {
 	assert.Len(t, store.lastInsertTargets, 2)
 }
 
+func TestService_Start_FullFleet_CurtailsLowPowerAndZeroHashrateMiners(t *testing.T) {
+	t.Parallel()
+	const orgID = int64(1)
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.candidatesByOrg[orgID] = []*models.Candidate{
+		minerWithEff("low-power-hashing", 100, 100, 40),
+		minerWithEff("not-yet-hashing", 2000, 0, 45),
+	}
+	svc := NewService(store)
+	req := validStartRequest(orgID)
+	req.Scope = Scope{Type: models.ScopeTypeWholeOrg}
+	req.Mode = models.ModeFullFleet
+	req.TargetKW = 0
+
+	plan, err := svc.Start(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, plan.Selected, 2)
+	assert.Equal(t, "not-yet-hashing", plan.Selected[0].DeviceIdentifier,
+		"full_fleet still ranks by efficiency when selecting all eligible miners")
+	assert.Equal(t, "low-power-hashing", plan.Selected[1].DeviceIdentifier)
+	assert.Empty(t, plan.Skipped)
+	assert.Len(t, store.lastInsertTargets, 2)
+}
+
 // The empty-eligible case is the chosen behavior: persist a vacuously COMPLETED
 // event with no targets, not an insufficient-load rejection.
 func TestService_Start_FullFleet_NoEligibleMinersPersistsCompleted(t *testing.T) {
@@ -69,7 +94,6 @@ func TestService_Preview_FullFleet_AllSkippedReturnsInsufficientDetail(t *testin
 		miner("offline", "OFFLINE", "PAIRED", 0, 0),
 		miner("updating", "UPDATING", "PAIRED", 0, 0),
 		staleMiner("stale"),
-		miner("below-floor", "ACTIVE", "PAIRED", 100, 0),
 	}
 	svc := NewService(store)
 	req := validRequest(orgID)
@@ -82,11 +106,11 @@ func TestService_Preview_FullFleet_AllSkippedReturnsInsufficientDetail(t *testin
 	require.NotNil(t, plan.InsufficientLoadDetail)
 	assert.Equal(t, modes.OutcomeInsufficientLoad, plan.Outcome)
 	assert.Empty(t, plan.Selected)
-	assert.Len(t, plan.Skipped, 4)
+	assert.Len(t, plan.Skipped, 3)
 	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedOffline)
 	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedUpdating)
 	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedStale)
-	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedBelowThreshold)
+	assert.Zero(t, plan.InsufficientLoadDetail.ExcludedBelowThreshold)
 	assert.Equal(t, int32(1500), plan.InsufficientLoadDetail.CandidateMinPowerW)
 	assert.Zero(t, store.insertEventCalls, "Preview must not persist")
 }

--- a/server/internal/domain/curtailment/service_start_fullfleet_test.go
+++ b/server/internal/domain/curtailment/service_start_fullfleet_test.go
@@ -61,6 +61,35 @@ func TestService_Start_FullFleet_CurtailsLowPowerAndZeroHashrateMiners(t *testin
 	assert.Len(t, store.lastInsertTargets, 2)
 }
 
+func TestService_Preview_FullFleet_SkipsMissingTelemetrySamples(t *testing.T) {
+	t.Parallel()
+	const orgID = int64(1)
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+
+	missingPower := miner("missing-power", "ACTIVE", "PAIRED", 0, 100)
+	missingPower.LatestPowerW = nil
+	missingHash := miner("missing-hash", "ACTIVE", "PAIRED", 100, 0)
+	missingHash.LatestHashRateHS = nil
+	measuredZero := minerWithEff("measured-zero", 0, 0, 40)
+	store.candidatesByOrg[orgID] = []*models.Candidate{missingPower, missingHash, measuredZero}
+
+	svc := NewService(store)
+	req := validRequest(orgID)
+	req.Scope = Scope{Type: models.ScopeTypeWholeOrg}
+	req.Mode = models.ModeFullFleet
+	req.TargetKW = 0
+
+	plan, err := svc.Preview(t.Context(), req)
+	require.NoError(t, err)
+	require.Len(t, plan.Selected, 1)
+	assert.Equal(t, "measured-zero", plan.Selected[0].DeviceIdentifier,
+		"measured zero values are valid for full_fleet; missing samples are not")
+	require.Len(t, plan.Skipped, 2)
+	assert.Equal(t, SkipStaleTelemetry, plan.Skipped[0].Reason)
+	assert.Equal(t, SkipStaleTelemetry, plan.Skipped[1].Reason)
+}
+
 // The empty-eligible case is the chosen behavior: persist a vacuously COMPLETED
 // event with no targets, not an insufficient-load rejection.
 func TestService_Start_FullFleet_NoEligibleMinersPersistsCompleted(t *testing.T) {


### PR DESCRIPTION
Reviewable diff: +66/-36 across 5 files (excludes generated, test, and story files).

## Summary

Whole-fleet shutdown no longer silently drops otherwise eligible miners just because their measured power is below the fixed-kW candidate floor or their measured hashrate is zero. Fixed-kW curtailment keeps the dual-signal telemetry gate for kW accounting, while full-fleet curtailment still rejects missing, non-finite, or negative telemetry so only observable miners enter the lifecycle.

Closes #499.

## How it works

The curtailment mode now declares whether it requires dual-signal telemetry. `FIXED_KW` opts in, so below-floor, no-hash, and contradictory telemetry still stay out of target-kW accounting. `FULL_FLEET` opts out of that threshold/hashrate gate, but classification still requires present finite non-negative power and hashrate samples.

Below-floor full-fleet targets are selected, but their low power reading is not persisted as `baseline_power_w`. That keeps confirmation from trusting a known-unreliable power baseline and lets the existing hashrate fallback confirm the target when hashrate drops to zero.

```mermaid
flowchart TB
    A["Candidate list"] --> B["Classify shared eligibility"]
    B --> C{"Telemetry present, finite, non-negative?"}
    C -->|"no"| D["Skip as stale telemetry"]
    C -->|"yes"| E{"Mode requires dual-signal telemetry?"}
    E -->|"FIXED_KW"| F["Apply min-power and positive-hash gates"]
    E -->|"FULL_FLEET"| G["Keep measured low-power or zero-hash candidates"]
    F --> H["Rank and select"]
    G --> H
    H --> I{"FULL_FLEET below floor?"}
    I -->|"yes"| J["Persist target without power baseline"]
    I -->|"no"| K["Persist normal target baseline"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/curtailment/modes/` | Modes now declare whether they require dual-signal telemetry. | Review that the mode boundary forces each mode to choose its telemetry policy. |
| `server/internal/domain/curtailment/selector.go` | The dual-signal filter runs only for modes that require it. | This is the direct #499 behavior change for full-fleet selection. |
| `server/internal/domain/curtailment/service.go` | Shared classification rejects missing/non-finite/negative telemetry and omits below-floor full-fleet power baselines. | Review that full-fleet can include measured low-power miners without creating unverifiable power-baseline targets. |
| `server/internal/domain/curtailment/*_test.go` | Added full-fleet inclusion, missing telemetry, baseline, and fixed-kW preservation coverage. | Review that the change stays scoped to #499 and does not implement #498 lifecycle work. |

## Key technical decisions & trade-offs

- Full-fleet bypasses the fixed-kW min-power/hashrate gate, but not the shared pairing, status, driver, stale telemetry, maintenance, cooldown, or active-event filters.
- Missing, non-finite, and negative power/hash telemetry still skip as `stale_telemetry`; measured zero values are valid for full-fleet shutdown.
- Below-floor full-fleet targets omit `baseline_power_w` so confirmation can use the existing hashrate fallback instead of a known-unreliable power baseline.
- Fixed-kW keeps the current dual-signal filter because target-kW accounting still depends on measurable load.

## Testing & validation

- `go test ./internal/domain/curtailment -run 'TestBuildPlan|TestService_(Start|Preview)_FullFleet'`
- `go test ./internal/domain/curtailment`
- `go test ./internal/domain/curtailment ./internal/domain/curtailment/modes`
- Pre-push `server-lint`
- PR Gate and Codex Security Review are green on the latest branch state.
