### PR TITLE
[codex] Add fleet reparent E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -6,8 +6,10 @@ import { ActivityPage } from "../pages/activity";
 import { AddMinersPage } from "../pages/addMiners";
 import { AuthPage } from "../pages/auth";
 import { LoginModalComponent } from "../pages/components/loginModal";
+import { ParentPickerModalComponent } from "../pages/components/parentPickerModal";
 import { EditPoolPage } from "../pages/editPool";
 import { EnergyPage } from "../pages/energy";
+import { FleetLocationsPage } from "../pages/fleetLocations";
 import { GroupsPage } from "../pages/groups";
 import { HomePage } from "../pages/home";
 import { MinersPage } from "../pages/miners";
@@ -27,6 +29,7 @@ type PageFixtures = {
   activityPage: ActivityPage;
   authPage: AuthPage;
   homePage: HomePage;
+  fleetLocationsPage: FleetLocationsPage;
   minersPage: MinersPage;
   groupsPage: GroupsPage;
   racksPage: RacksPage;
@@ -44,6 +47,7 @@ type PageFixtures = {
   energyPage: EnergyPage;
   newPoolModal: NewPoolModalPage;
   loginModal: LoginModalComponent;
+  parentPickerModal: ParentPickerModalComponent;
   commonSteps: CommonSteps;
 };
 
@@ -56,6 +60,9 @@ export const test = base.extend<PageFixtures>({
   },
   homePage: async ({ page, isMobile }, use) => {
     await use(new HomePage(page, isMobile));
+  },
+  fleetLocationsPage: async ({ page, isMobile }, use) => {
+    await use(new FleetLocationsPage(page, isMobile));
   },
   minersPage: async ({ page, isMobile }, use) => {
     await use(new MinersPage(page, isMobile));
@@ -107,6 +114,9 @@ export const test = base.extend<PageFixtures>({
   },
   loginModal: async ({ page, isMobile }, use) => {
     await use(new LoginModalComponent(page, isMobile));
+  },
+  parentPickerModal: async ({ page, isMobile }, use) => {
+    await use(new ParentPickerModalComponent(page, isMobile));
   },
   commonSteps: async ({ authPage, minersPage }, use) => {
     await use(new CommonSteps(authPage, minersPage));

--- a/client/e2eTests/protoFleet/pages/components/parentPickerModal.ts
+++ b/client/e2eTests/protoFleet/pages/components/parentPickerModal.ts
@@ -1,0 +1,29 @@
+import { expect } from "@playwright/test";
+import { BasePage } from "../base";
+
+export class ParentPickerModalComponent extends BasePage {
+  private modal() {
+    return this.page.getByTestId("modal");
+  }
+
+  async validateTitleMatches(title: RegExp) {
+    await expect(this.modal()).toContainText(title);
+  }
+
+  async selectOption(name: string) {
+    const option = this.modal().locator("label").filter({ hasText: name }).first();
+    await expect(option).toBeVisible();
+    await option.click();
+  }
+
+  async clickSave() {
+    await this.clickIn("Save", "modal");
+  }
+
+  async continueSiteMoveIfVisible() {
+    const dialogTitle = this.page.getByText("Move miners between sites?", { exact: true });
+    if (await dialogTitle.isVisible().catch(() => false)) {
+      await this.page.getByRole("button", { name: "Continue", exact: true }).click();
+    }
+  }
+}

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -69,10 +69,13 @@ export class FleetLocationsPage extends BasePage {
     const overflowTrigger = this.page.getByTestId("overflow-menu-trigger");
     if (await overflowTrigger.isVisible().catch(() => false)) {
       await overflowTrigger.click();
-      await this.page.getByText("Edit details", { exact: true }).click();
-    } else {
-      await this.page.getByRole("button", { name: "Edit details", exact: true }).click();
     }
+    const editDetailsButton = await this.getVisibleButton("Edit details");
+    if (!editDetailsButton) {
+      throw new Error('Expected to find a visible "Edit details" button.');
+    }
+
+    await editDetailsButton.click();
     await expect(this.page.getByTestId("site-settings-modal")).toBeVisible();
     await this.page.getByTestId("site-settings-modal-delete").click();
     await expect(this.page.getByTestId("site-delete-dialog")).toBeVisible();
@@ -98,12 +101,19 @@ export class FleetLocationsPage extends BasePage {
     }
 
     await buildingRow.click();
-    const overflowTrigger = this.page.getByTestId("overflow-menu-trigger");
-    if (await overflowTrigger.isVisible().catch(() => false)) {
-      await overflowTrigger.click();
-      await this.page.getByText("Delete building", { exact: true }).click();
+    const buildingSettingsModal = this.page.getByTestId("building-settings-modal");
+    await buildingSettingsModal.waitFor({ state: "visible", timeout: 3000 }).catch(() => null);
+
+    if (await buildingSettingsModal.isVisible().catch(() => false)) {
+      await this.page.getByTestId("building-settings-modal-delete").click();
     } else {
-      await this.page.getByTestId("manage-building-delete").click();
+      const overflowTrigger = this.page.getByTestId("overflow-menu-trigger");
+      if (await overflowTrigger.isVisible().catch(() => false)) {
+        await overflowTrigger.click();
+        await this.page.getByText("Delete building", { exact: true }).click();
+      } else {
+        await this.page.getByTestId("manage-building-delete").click();
+      }
     }
     await expect(this.page.getByTestId("building-delete-dialog")).toBeVisible();
     await this.page.getByTestId("building-delete-dialog-confirm").click();
@@ -118,5 +128,19 @@ export class FleetLocationsPage extends BasePage {
 
   private getSingleSiteBuildingRow(buildingName: string): Locator {
     return this.page.getByTestId("site-settings-single-view").getByRole("button").filter({ hasText: buildingName });
+  }
+
+  private async getVisibleButton(name: string): Promise<Locator | null> {
+    const buttons = this.page.getByRole("button", { name, exact: true });
+    const count = await buttons.count();
+
+    for (let i = 0; i < count; i++) {
+      const button = buttons.nth(i);
+      if (await button.isVisible().catch(() => false)) {
+        return button;
+      }
+    }
+
+    return null;
   }
 }

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -66,7 +66,13 @@ export class FleetLocationsPage extends BasePage {
     await row.click();
     await expect(this.page.getByTestId("site-settings-single-view")).toBeVisible();
     await this.page.getByTestId("site-settings-manage").click();
-    await this.page.getByRole("button", { name: "Edit details", exact: true }).click();
+    const overflowTrigger = this.page.getByTestId("overflow-menu-trigger");
+    if (await overflowTrigger.isVisible().catch(() => false)) {
+      await overflowTrigger.click();
+      await this.page.getByText("Edit details", { exact: true }).click();
+    } else {
+      await this.page.getByRole("button", { name: "Edit details", exact: true }).click();
+    }
     await expect(this.page.getByTestId("site-settings-modal")).toBeVisible();
     await this.page.getByTestId("site-settings-modal-delete").click();
     await expect(this.page.getByTestId("site-delete-dialog")).toBeVisible();

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -1,0 +1,71 @@
+import { expect, type Locator } from "@playwright/test";
+import { BasePage } from "./base";
+
+export class FleetLocationsPage extends BasePage {
+  async navigateToSitesPage() {
+    await this.page.goto("/settings/sites");
+    await expect(this.page).toHaveURL(/.*\/settings\/sites/);
+    await expect(this.page.getByTestId("settings-sites-page")).toBeVisible();
+  }
+
+  async createSite(siteName: string): Promise<string> {
+    await this.page.getByRole("button", { name: "Add a site", exact: true }).first().click();
+    await expect(this.page.getByText("Site settings", { exact: true })).toBeVisible();
+    await this.page.locator("#site-settings-name").fill(siteName);
+    await this.page.getByRole("button", { name: "Continue", exact: true }).click();
+    await this.page.getByTestId("manage-site-modal-save").last().click();
+    await this.validateTextInToast(`Site "${siteName}" created`);
+    const row = this.getSiteRow(siteName);
+    await expect(row).toBeVisible();
+    const testId = await row.getAttribute("data-testid");
+
+    if (!testId) {
+      throw new Error(`Could not read site row test id for "${siteName}".`);
+    }
+
+    return testId.replace("sites-all-table-row-", "");
+  }
+
+  async openSiteSettings(siteName: string) {
+    await this.getSiteRow(siteName).click();
+    const siteSettingsView = this.page.getByTestId("site-settings-single-view");
+    await expect(siteSettingsView).toBeVisible();
+    await expect(siteSettingsView).toContainText(siteName);
+  }
+
+  async returnToAllSites() {
+    await this.page.getByTestId("site-settings-back-to-all").click();
+    await expect(this.page.getByTestId("sites-all-table")).toBeVisible();
+  }
+
+  async createBuildingInSelectedSite(buildingName: string): Promise<string> {
+    await expect(this.page.getByTestId("site-settings-single-view")).toBeVisible();
+    await this.page.getByTestId("site-settings-add-building").click();
+    await expect(this.page.getByText("Building settings", { exact: true })).toBeVisible();
+    await this.page.locator("#building-settings-name").fill(buildingName);
+    await this.page.getByTestId("building-settings-modal-save").click();
+    await this.validateTextInToast(`Building "${buildingName}" created`);
+    const row = this.getSingleSiteBuildingRow(buildingName);
+    await expect(row).toBeVisible();
+    const testId = await row.getAttribute("data-testid");
+
+    if (!testId) {
+      throw new Error(`Could not read building row test id for "${buildingName}".`);
+    }
+
+    return testId.replace("site-settings-building-row-", "");
+  }
+
+  private async selectOption(testId: string, optionLabel: string) {
+    await this.page.getByTestId(testId).click();
+    await this.page.getByRole("option", { name: optionLabel, exact: true }).click();
+  }
+
+  private getSiteRow(siteName: string): Locator {
+    return this.page.getByTestId("sites-all-table").getByRole("button").filter({ hasText: siteName }).first();
+  }
+
+  private getSingleSiteBuildingRow(buildingName: string): Locator {
+    return this.page.getByTestId("site-settings-single-view").getByRole("button").filter({ hasText: buildingName });
+  }
+}

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -56,11 +56,6 @@ export class FleetLocationsPage extends BasePage {
     return testId.replace("site-settings-building-row-", "");
   }
 
-  private async selectOption(testId: string, optionLabel: string) {
-    await this.page.getByTestId(testId).click();
-    await this.page.getByRole("option", { name: optionLabel, exact: true }).click();
-  }
-
   private getSiteRow(siteName: string): Locator {
     return this.page.getByTestId("sites-all-table").getByRole("button").filter({ hasText: siteName }).first();
   }

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -56,6 +56,26 @@ export class FleetLocationsPage extends BasePage {
     return testId.replace("site-settings-building-row-", "");
   }
 
+  async deleteSiteByNameIfVisible(siteName: string): Promise<boolean> {
+    await this.navigateToSitesPage();
+    const row = this.getSiteRow(siteName);
+    if (!(await row.isVisible().catch(() => false))) {
+      return false;
+    }
+
+    await row.click();
+    await expect(this.page.getByTestId("site-settings-single-view")).toBeVisible();
+    await this.page.getByTestId("site-settings-manage").click();
+    await this.page.getByRole("button", { name: "Edit details", exact: true }).click();
+    await expect(this.page.getByTestId("site-settings-modal")).toBeVisible();
+    await this.page.getByTestId("site-settings-modal-delete").click();
+    await expect(this.page.getByTestId("site-delete-dialog")).toBeVisible();
+    await this.page.getByTestId("site-delete-dialog-confirm").click();
+    await this.validateTextInToast(`Site "${siteName}" deleted`);
+    await expect(this.getSiteRow(siteName)).toHaveCount(0);
+    return true;
+  }
+
   private getSiteRow(siteName: string): Locator {
     return this.page.getByTestId("sites-all-table").getByRole("button").filter({ hasText: siteName }).first();
   }

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -82,6 +82,36 @@ export class FleetLocationsPage extends BasePage {
     return true;
   }
 
+  async deleteBuildingInSiteByNameIfVisible(siteName: string, buildingName: string): Promise<boolean> {
+    await this.navigateToSitesPage();
+    const siteRow = this.getSiteRow(siteName);
+    if (!(await siteRow.isVisible().catch(() => false))) {
+      return false;
+    }
+
+    await siteRow.click();
+    await expect(this.page.getByTestId("site-settings-single-view")).toBeVisible();
+
+    const buildingRow = this.getSingleSiteBuildingRow(buildingName);
+    if (!(await buildingRow.isVisible().catch(() => false))) {
+      return false;
+    }
+
+    await buildingRow.click();
+    const overflowTrigger = this.page.getByTestId("overflow-menu-trigger");
+    if (await overflowTrigger.isVisible().catch(() => false)) {
+      await overflowTrigger.click();
+      await this.page.getByText("Delete building", { exact: true }).click();
+    } else {
+      await this.page.getByTestId("manage-building-delete").click();
+    }
+    await expect(this.page.getByTestId("building-delete-dialog")).toBeVisible();
+    await this.page.getByTestId("building-delete-dialog-confirm").click();
+    await this.validateTextInToast(`Building "${buildingName}" deleted`);
+    await expect(this.getSingleSiteBuildingRow(buildingName)).toHaveCount(0);
+    return true;
+  }
+
   private getSiteRow(siteName: string): Locator {
     return this.page.getByTestId("sites-all-table").getByRole("button").filter({ hasText: siteName }).first();
   }

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -13,7 +13,7 @@ export class FleetLocationsPage extends BasePage {
     await expect(this.page.getByText("Site settings", { exact: true })).toBeVisible();
     await this.page.locator("#site-settings-name").fill(siteName);
     await this.page.getByRole("button", { name: "Continue", exact: true }).click();
-    await this.page.getByTestId("manage-site-modal-save").last().click();
+    await this.page.locator('[data-testid="manage-site-modal-save"]:visible').click();
     await this.validateTextInToast(`Site "${siteName}" created`);
     const row = this.getSiteRow(siteName);
     await expect(row).toBeVisible();

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -211,6 +211,11 @@ export class MinersPage extends BasePage {
     const minerRow = await this.getMinerRowByIp(ipAddress);
     await minerRow.getByTestId(`single-miner-actions-menu-button`).click();
   }
+
+  async clickMinerActionMenuItem(actionLabel: string) {
+    await this.page.getByText(actionLabel, { exact: true }).click();
+  }
+
   async clickMinerCheckbox(ipAddress: string) {
     const minerRow = await this.getMinerRowByIp(ipAddress);
     await minerRow.locator(`//input[@type='checkbox']`).click();

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -510,6 +510,29 @@ export class RacksPage extends BasePage {
     await this.page.getByText(actionLabel, { exact: true }).click();
   }
 
+  async deleteRackByNameIfVisible(label: string): Promise<boolean> {
+    await this.navigateToRacksPage();
+    await this.tryAction(() => this.clickViewList());
+    await this.waitForRackListToLoad();
+
+    const row = this.getRackListRow(label);
+    if (!(await row.isVisible().catch(() => false))) {
+      return false;
+    }
+
+    await this.openRackFromList(label);
+    await this.clickEditRack();
+    await this.clickDeleteRack();
+    await this.clickDeleteConfirm();
+    await this.validateRackDeletedToast();
+
+    await this.navigateToRacksPage();
+    await this.tryAction(() => this.clickViewList());
+    await this.waitForRackListToLoad();
+    await expect(this.getRackListRow(label)).toHaveCount(0);
+    return true;
+  }
+
   async validateRackBuilding(label: string, buildingName: string) {
     await expect(this.getRackListRow(label).getByTestId("building")).toHaveText(buildingName);
   }

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -316,11 +316,47 @@ export class RacksPage extends BasePage {
   }
 
   async clickViewList() {
-    await this.clickButton("View list");
+    const emptyState = this.page.getByText("You haven't set up any racks");
+    await expect(async () => {
+      const viewListButton = await this.getVisibleButton("View list");
+      const isEmptyStateVisible = await emptyState.isVisible().catch(() => false);
+      expect(Boolean(viewListButton) || isEmptyStateVisible).toBe(true);
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
+
+    const viewListButton = await this.getVisibleButton("View list");
+    if (viewListButton) {
+      await viewListButton.click();
+      return;
+    }
+
+    if (await emptyState.isVisible().catch(() => false)) {
+      return;
+    }
+
+    throw new Error('Expected to find a visible "View list" button or empty rack state.');
   }
 
   async clickViewGrid() {
-    await this.clickButton("View grid");
+    const viewGridButton = await this.getVisibleButton("View grid");
+    if (!viewGridButton) {
+      throw new Error('Expected to find a visible "View grid" button.');
+    }
+
+    await viewGridButton.click();
+  }
+
+  private async getVisibleButton(name: string): Promise<Locator | null> {
+    const buttons = this.page.getByRole("button", { name, exact: true });
+    const count = await buttons.count();
+
+    for (let i = 0; i < count; i++) {
+      const button = buttons.nth(i);
+      if (await button.isVisible().catch(() => false)) {
+        return button;
+      }
+    }
+
+    return null;
   }
 
   private async getVisibleAddFilterTrigger(): Promise<Locator> {

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -316,33 +316,42 @@ export class RacksPage extends BasePage {
   }
 
   async clickViewList() {
-    const emptyState = this.page.getByText("You haven't set up any racks");
-    await expect(async () => {
-      const viewListButton = await this.getVisibleButton("View list");
-      const isEmptyStateVisible = await emptyState.isVisible().catch(() => false);
-      expect(Boolean(viewListButton) || isEmptyStateVisible).toBe(true);
-    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
-
     const viewListButton = await this.getVisibleButton("View list");
     if (viewListButton) {
       await viewListButton.click();
       return;
     }
 
-    if (await emptyState.isVisible().catch(() => false)) {
+    const viewGridButton = await this.getVisibleButton("View grid");
+    if (viewGridButton) {
       return;
     }
 
-    throw new Error('Expected to find a visible "View list" button or empty rack state.');
+    const emptyState = this.page.getByText("You haven't set up any racks");
+    const listRows = this.page.getByTestId("list-row");
+    await expect(async () => {
+      const isEmptyStateVisible = await emptyState.isVisible().catch(() => false);
+      const rowCount = await listRows.count().catch(() => 0);
+      expect(isEmptyStateVisible || rowCount > 0).toBe(true);
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
   }
 
   async clickViewGrid() {
-    const viewGridButton = await this.getVisibleButton("View grid");
-    if (!viewGridButton) {
-      throw new Error('Expected to find a visible "View grid" button.');
+    const viewListButton = await this.getVisibleButton("View list");
+    if (viewListButton) {
+      return;
     }
 
-    await viewGridButton.click();
+    const viewGridButton = await this.getVisibleButton("View grid");
+    if (viewGridButton) {
+      await viewGridButton.click();
+      return;
+    }
+
+    const rackCards = this.page.getByTestId("rack-card");
+    await expect(async () => {
+      expect(await rackCards.count().catch(() => 0)).toBeGreaterThan(0);
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
   }
 
   private async getVisibleButton(name: string): Promise<Locator | null> {

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -485,10 +485,37 @@ export class RacksPage extends BasePage {
     await expect(row.getByTestId("miners")).toHaveText(String(miners));
   }
 
+  async createEmptyRack(label: string, zone: string, columns: number = 1, rows: number = 1) {
+    await this.clickAddRackButton();
+    await this.inputZone(zone);
+    await this.inputRackLabel(label);
+    await this.enableCustomRackLayout();
+    await this.inputColumns(columns);
+    await this.inputRows(rows);
+    await this.clickContinueFromRackSettings();
+    await this.clickSaveRack();
+    await this.validateRackToast(label);
+  }
+
   async openRackFromList(label: string) {
     const row = this.getRackListRow(label);
     await expect(row).toBeVisible();
     await row.getByTestId("name").getByRole("button", { name: label, exact: true }).click();
+  }
+
+  async clickRackRowAction(label: string, actionLabel: string) {
+    const row = this.getRackListRow(label);
+    await expect(row).toBeVisible();
+    await row.locator('[data-testid$="-actions-trigger"]').click();
+    await this.page.getByText(actionLabel, { exact: true }).click();
+  }
+
+  async validateRackBuilding(label: string, buildingName: string) {
+    await expect(this.getRackListRow(label).getByTestId("building")).toHaveText(buildingName);
+  }
+
+  async validateRackSite(label: string, siteName: string) {
+    await expect(this.getRackListRow(label).getByTestId("site")).toHaveText(siteName);
   }
 
   async clickEditRack() {

--- a/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
@@ -10,6 +10,7 @@ import { RacksPage } from "../pages/racks";
 const RACK_ZONE = "Automation Zone";
 
 type ReparentCleanupState = {
+  buildings: Array<{ siteName: string; buildingName: string }>;
   rackNames: string[];
   siteNames: string[];
 };
@@ -18,13 +19,17 @@ test.describe("Fleet reparent flows", () => {
   let cleanupState: ReparentCleanupState;
 
   test.beforeEach(async ({ page, commonSteps }) => {
-    cleanupState = { rackNames: [], siteNames: [] };
+    cleanupState = { buildings: [], rackNames: [], siteNames: [] };
     await page.goto("/");
     await commonSteps.loginAsAdmin();
   });
 
   test.afterEach("CLEANUP: Delete created reparent test data", async ({ browser }, testInfo) => {
-    if (cleanupState.rackNames.length === 0 && cleanupState.siteNames.length === 0) {
+    if (
+      cleanupState.rackNames.length === 0 &&
+      cleanupState.buildings.length === 0 &&
+      cleanupState.siteNames.length === 0
+    ) {
       return;
     }
 
@@ -45,12 +50,16 @@ test.describe("Fleet reparent flows", () => {
 
       await commonSteps.loginAsAdmin();
 
-      for (const siteName of [...cleanupState.siteNames].reverse()) {
-        await fleetLocationsPage.deleteSiteByNameIfVisible(siteName);
-      }
-
       for (const rackName of [...cleanupState.rackNames].reverse()) {
         await racksPage.deleteRackByNameIfVisible(rackName);
+      }
+
+      for (const { siteName, buildingName } of [...cleanupState.buildings].reverse()) {
+        await fleetLocationsPage.deleteBuildingInSiteByNameIfVisible(siteName, buildingName);
+      }
+
+      for (const siteName of [...cleanupState.siteNames].reverse()) {
+        await fleetLocationsPage.deleteSiteByNameIfVisible(siteName);
       }
     } finally {
       await context.close();
@@ -77,6 +86,10 @@ test.describe("Fleet reparent flows", () => {
       await fleetLocationsPage.openSiteSettings(siteName);
       sourceBuildingId = await fleetLocationsPage.createBuildingInSelectedSite(sourceBuildingName);
       targetBuildingId = await fleetLocationsPage.createBuildingInSelectedSite(targetBuildingName);
+      cleanupState.buildings.push(
+        { siteName, buildingName: sourceBuildingName },
+        { siteName, buildingName: targetBuildingName },
+      );
 
       await racksPage.navigateToRacksPage();
       await racksPage.createEmptyRack(rackName, RACK_ZONE);

--- a/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
@@ -1,0 +1,127 @@
+import { test } from "../fixtures/pageFixtures";
+import { generateRandomText } from "../helpers/testDataHelper";
+
+const RACK_ZONE = "Automation Zone";
+
+test.describe("Fleet reparent flows", () => {
+  test.beforeEach(async ({ page, commonSteps }) => {
+    await page.goto("/");
+    await commonSteps.loginAsAdmin();
+  });
+
+  test("Move a rack to a building from the Racks tab", async ({
+    fleetLocationsPage,
+    page,
+    parentPickerModal,
+    racksPage,
+  }) => {
+    const siteName = generateRandomText("reparent_rack_site");
+    const sourceBuildingName = generateRandomText("reparent_source_building");
+    const targetBuildingName = generateRandomText("reparent_target_building");
+    const rackName = generateRandomText("reparent_rack");
+    let sourceBuildingId = "";
+    let targetBuildingId = "";
+
+    await test.step("Create a site, two buildings, and an empty rack", async () => {
+      await fleetLocationsPage.navigateToSitesPage();
+      await fleetLocationsPage.createSite(siteName);
+      await fleetLocationsPage.openSiteSettings(siteName);
+      sourceBuildingId = await fleetLocationsPage.createBuildingInSelectedSite(sourceBuildingName);
+      targetBuildingId = await fleetLocationsPage.createBuildingInSelectedSite(targetBuildingName);
+
+      await racksPage.navigateToRacksPage();
+      await racksPage.createEmptyRack(rackName, RACK_ZONE);
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+      await racksPage.validateRackRow(rackName, RACK_ZONE, 0);
+    });
+
+    await test.step("Move the rack to the target building", async () => {
+      await racksPage.clickRackRowAction(rackName, "Add to building");
+      await parentPickerModal.validateTitleMatches(/Add .* to a building/);
+      await parentPickerModal.selectOption(targetBuildingName);
+      await parentPickerModal.clickSave();
+    });
+
+    await test.step("Validate the rack appears under the target building and not under the source building", async () => {
+      await racksPage.validateTextInToast(`Moved "${rackName}" to selected building.`);
+
+      await page.goto(`/racks?building=${targetBuildingId}`);
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+      await racksPage.validateRackRow(rackName, RACK_ZONE, 0);
+
+      await page.goto(`/racks?building=${sourceBuildingId}`);
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad();
+      test.expect(await racksPage.listRackNames()).not.toContain(rackName);
+    });
+  });
+
+  test("Assign a single miner to a site from the Miners tab", async ({
+    fleetLocationsPage,
+    minersPage,
+    parentPickerModal,
+  }) => {
+    const siteName = generateRandomText("reparent_miner_site");
+    let minerName = "";
+
+    await test.step("Create a target site and capture a miner to move", async () => {
+      await fleetLocationsPage.navigateToSitesPage();
+      await fleetLocationsPage.createSite(siteName);
+
+      await minersPage.navigateToMinersPage();
+      await minersPage.waitForMinersTitle();
+      await minersPage.waitForMinersListToLoad();
+    });
+
+    const minerIp = await minersPage.getMinerIpAddressByIndex(0);
+    minerName = (await minersPage.getMinerNameByIndex(0)).trim();
+
+    await test.step("Move one miner into the site", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickMinerActionMenuItem("Add to site");
+      await parentPickerModal.validateTitleMatches(/Add .* to a site/);
+      await parentPickerModal.selectOption(siteName);
+      await parentPickerModal.clickSave();
+      await parentPickerModal.continueSiteMoveIfVisible();
+    });
+
+    await test.step("Validate the operator sees a successful move confirmation", async () => {
+      await minersPage.validateTextInToast(`Moved "${minerName}" to selected site.`);
+    });
+  });
+
+  test("Assign a single miner to a rack from the Miners tab", async ({ minersPage, parentPickerModal, racksPage }) => {
+    const rackName = generateRandomText("reparent_target_rack");
+
+    await test.step("Create an empty rack and capture a miner to move", async () => {
+      await racksPage.navigateToRacksPage();
+      await racksPage.createEmptyRack(rackName, RACK_ZONE);
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+      await racksPage.validateRackRow(rackName, RACK_ZONE, 0);
+
+      await minersPage.navigateToMinersPage();
+      await minersPage.waitForMinersTitle();
+      await minersPage.waitForMinersListToLoad();
+    });
+
+    const minerIp = await minersPage.getMinerIpAddressByIndex(1);
+
+    await test.step("Move one miner into the rack", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickMinerActionMenuItem("Add to rack");
+      await parentPickerModal.validateTitleMatches(/Add .* to a rack/);
+      await parentPickerModal.selectOption(rackName);
+      await parentPickerModal.clickSave();
+    });
+
+    await test.step("Validate the rack miner count increases for the selected rack", async () => {
+      await racksPage.navigateToRacksPage();
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+      await racksPage.validateRackRow(rackName, RACK_ZONE, 1);
+    });
+  });
+});

--- a/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
@@ -106,6 +106,7 @@ test.describe("Fleet reparent flows", () => {
       await racksPage.validateTextInToast(`Moved "${rackName}" to selected building.`);
 
       await page.goto(`/racks?building=${sourceBuildingId}`);
+      await racksPage.validateRacksPageOpened();
       await racksPage.clickViewList();
       await racksPage.waitForRackListToLoad({ allowEmpty: false });
       await racksPage.validateRackRow(rackName, RACK_ZONE, 0);
@@ -122,11 +123,13 @@ test.describe("Fleet reparent flows", () => {
       await racksPage.validateTextInToast(`Moved "${rackName}" to selected building.`);
 
       await page.goto(`/racks?building=${targetBuildingId}`);
+      await racksPage.validateRacksPageOpened();
       await racksPage.clickViewList();
       await racksPage.waitForRackListToLoad({ allowEmpty: false });
       test.expect(await racksPage.listRackNames()).toContain(rackName);
 
       await page.goto(`/racks?building=${sourceBuildingId}`);
+      await racksPage.validateRacksPageOpened();
       await racksPage.clickViewList();
       await racksPage.waitForRackListToLoad();
       test.expect(await racksPage.listRackNames()).not.toContain(rackName);

--- a/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
@@ -1,12 +1,60 @@
+import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
+import { CommonSteps } from "../helpers/commonSteps";
 import { generateRandomText } from "../helpers/testDataHelper";
+import { AuthPage } from "../pages/auth";
+import { FleetLocationsPage } from "../pages/fleetLocations";
+import { MinersPage } from "../pages/miners";
+import { RacksPage } from "../pages/racks";
 
 const RACK_ZONE = "Automation Zone";
 
+type ReparentCleanupState = {
+  rackNames: string[];
+  siteNames: string[];
+};
+
 test.describe("Fleet reparent flows", () => {
+  let cleanupState: ReparentCleanupState;
+
   test.beforeEach(async ({ page, commonSteps }) => {
+    cleanupState = { rackNames: [], siteNames: [] };
     await page.goto("/");
     await commonSteps.loginAsAdmin();
+  });
+
+  test.afterEach("CLEANUP: Delete created reparent test data", async ({ browser }, testInfo) => {
+    if (cleanupState.rackNames.length === 0 && cleanupState.siteNames.length === 0) {
+      return;
+    }
+
+    const context = await browser.newContext({
+      baseURL: testConfig.baseUrl,
+      viewport: testInfo.project.use?.viewport,
+    });
+
+    try {
+      const page = await context.newPage();
+      await page.goto("/");
+
+      const authPage = new AuthPage(page, testInfo.project.use?.isMobile ?? false);
+      const minersPage = new MinersPage(page, testInfo.project.use?.isMobile ?? false);
+      const commonSteps = new CommonSteps(authPage, minersPage);
+      const fleetLocationsPage = new FleetLocationsPage(page, testInfo.project.use?.isMobile ?? false);
+      const racksPage = new RacksPage(page, testInfo.project.use?.isMobile ?? false);
+
+      await commonSteps.loginAsAdmin();
+
+      for (const siteName of [...cleanupState.siteNames].reverse()) {
+        await fleetLocationsPage.deleteSiteByNameIfVisible(siteName);
+      }
+
+      for (const rackName of [...cleanupState.rackNames].reverse()) {
+        await racksPage.deleteRackByNameIfVisible(rackName);
+      }
+    } finally {
+      await context.close();
+    }
   });
 
   test("Move a rack to a building from the Racks tab", async ({
@@ -25,6 +73,7 @@ test.describe("Fleet reparent flows", () => {
     await test.step("Create a site, two buildings, and an empty rack", async () => {
       await fleetLocationsPage.navigateToSitesPage();
       await fleetLocationsPage.createSite(siteName);
+      cleanupState.siteNames.push(siteName);
       await fleetLocationsPage.openSiteSettings(siteName);
       sourceBuildingId = await fleetLocationsPage.createBuildingInSelectedSite(sourceBuildingName);
       targetBuildingId = await fleetLocationsPage.createBuildingInSelectedSite(targetBuildingName);
@@ -82,6 +131,7 @@ test.describe("Fleet reparent flows", () => {
     await test.step("Create a target site and capture a miner to move", async () => {
       await fleetLocationsPage.navigateToSitesPage();
       await fleetLocationsPage.createSite(siteName);
+      cleanupState.siteNames.push(siteName);
 
       await minersPage.navigateToMinersPage();
       await minersPage.waitForMinersTitle();
@@ -111,6 +161,7 @@ test.describe("Fleet reparent flows", () => {
     await test.step("Create an empty rack and capture a miner to move", async () => {
       await racksPage.navigateToRacksPage();
       await racksPage.createEmptyRack(rackName, RACK_ZONE);
+      cleanupState.rackNames.push(rackName);
       await racksPage.clickViewList();
       await racksPage.waitForRackListToLoad({ allowEmpty: false });
       await racksPage.validateRackRow(rackName, RACK_ZONE, 0);

--- a/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/fleetReparent.spec.ts
@@ -36,7 +36,20 @@ test.describe("Fleet reparent flows", () => {
       await racksPage.validateRackRow(rackName, RACK_ZONE, 0);
     });
 
-    await test.step("Move the rack to the target building", async () => {
+    await test.step("Assign the rack to the source building", async () => {
+      await racksPage.clickRackRowAction(rackName, "Add to building");
+      await parentPickerModal.validateTitleMatches(/Add .* to a building/);
+      await parentPickerModal.selectOption(sourceBuildingName);
+      await parentPickerModal.clickSave();
+      await racksPage.validateTextInToast(`Moved "${rackName}" to selected building.`);
+
+      await page.goto(`/racks?building=${sourceBuildingId}`);
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+      await racksPage.validateRackRow(rackName, RACK_ZONE, 0);
+    });
+
+    await test.step("Move the rack from the source building to the target building", async () => {
       await racksPage.clickRackRowAction(rackName, "Add to building");
       await parentPickerModal.validateTitleMatches(/Add .* to a building/);
       await parentPickerModal.selectOption(targetBuildingName);
@@ -49,7 +62,7 @@ test.describe("Fleet reparent flows", () => {
       await page.goto(`/racks?building=${targetBuildingId}`);
       await racksPage.clickViewList();
       await racksPage.waitForRackListToLoad({ allowEmpty: false });
-      await racksPage.validateRackRow(rackName, RACK_ZONE, 0);
+      test.expect(await racksPage.listRackNames()).toContain(rackName);
 
       await page.goto(`/racks?building=${sourceBuildingId}`);
       await racksPage.clickViewList();


### PR DESCRIPTION
## Summary
- add Proto Fleet E2E coverage for reachable fleet reparent flows
- cover rack-to-building moves through the racks UI with user-visible verification
- cover miner-to-site and miner-to-rack moves with UI-first assertions and shared picker helpers

## Validation
- `export PATH=/Users/edgars/.nvm/versions/node/v24.11.1/bin:$PATH; PW_UI_NO_DEPS=1 npx playwright test spec/fleetReparent.spec.ts --project=desktop`
