### PR TITLE
feat(curtailment): enforce whole-fleet OFF policy

### DIFF
--- a/server/cmd/fleetd/config.go
+++ b/server/cmd/fleetd/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/block/proto-fleet/server/internal/domain/command"
+	curtailmentReconciler "github.com/block/proto-fleet/server/internal/domain/curtailment/reconciler"
 	"github.com/block/proto-fleet/server/internal/domain/diagnostics"
 	"github.com/block/proto-fleet/server/internal/domain/ipscanner"
 	"github.com/block/proto-fleet/server/internal/domain/plugins"
@@ -31,22 +32,23 @@ type HTTPConfig struct {
 type Config struct {
 	Mode string `help:"Execution mode" enum:"server,agent,combined" default:"combined" env:"MODE"`
 
-	DB             db.Config              `embed:"" prefix:"db-" envprefix:"DB_"`
-	Log            logging.Config         `embed:"" prefix:"logging-" envprefix:"LOG_"`
-	HTTP           HTTPConfig             `embed:"" prefix:"http-" envprefix:"HTTP_"`
-	Auth           token.Config           `embed:"" prefix:"auth-" envprefix:"AUTH_"`
-	Session        session.Config         `embed:"" prefix:"session-" envprefix:"SESSION_"`
-	Pools          pools.Config           `embed:"" prefix:"pools-" envprefix:"POOLS_"`
-	Encrypt        encrypt.Config         `embed:"" prefix:"encrypt-" envprefix:"ENCRYPT_"`
-	Command        command.Config         `embed:"" prefix:"fleet-command-" envprefix:"FLEET_COMMAND_"`
-	Queue          queue.Config           `embed:"" prefix:"fleet-queue-" envprefix:"FLEET_QUEUE_"`
-	TimescaleDB    timescaledb.Config     `embed:"" prefix:"timescaledb-" envprefix:"TIMESCALEDB_"`
-	Telemetry      telemetry.Config       `embed:"" prefix:"telemetry-" envprefix:"TELEMETRY_"`
-	Scheduler      scheduler.Config       `embed:"" prefix:"scheduler-" envprefix:"SCHEDULER_"`
-	Plugins        plugins.Config         `embed:"" prefix:"plugins-" envprefix:"PLUGINS_"`
-	IPScanner      ipscanner.Config       `embed:"" prefix:"ipscanner-" envprefix:"IPSCANNER_"`
-	Diagnostics    diagnostics.Config     `embed:"" prefix:"diagnostics-" envprefix:"DIAGNOSTICS_"`
-	Files          files.Config           `embed:"" prefix:"files-" envprefix:"FILES_"`
-	FleetTelemetry fleet_telemetry.Config `embed:"" prefix:"fleet-telemetry-" envprefix:"FLEET_TELEMETRY_"`
-	Metrics        metrics.Config         `embed:"" prefix:"metrics-" envprefix:"FLEET_METRICS_"`
+	DB             db.Config                    `embed:"" prefix:"db-" envprefix:"DB_"`
+	Log            logging.Config               `embed:"" prefix:"logging-" envprefix:"LOG_"`
+	HTTP           HTTPConfig                   `embed:"" prefix:"http-" envprefix:"HTTP_"`
+	Auth           token.Config                 `embed:"" prefix:"auth-" envprefix:"AUTH_"`
+	Session        session.Config               `embed:"" prefix:"session-" envprefix:"SESSION_"`
+	Pools          pools.Config                 `embed:"" prefix:"pools-" envprefix:"POOLS_"`
+	Encrypt        encrypt.Config               `embed:"" prefix:"encrypt-" envprefix:"ENCRYPT_"`
+	Command        command.Config               `embed:"" prefix:"fleet-command-" envprefix:"FLEET_COMMAND_"`
+	Curtailment    curtailmentReconciler.Config `embed:"" prefix:"curtailment-" envprefix:"CURTAILMENT_"`
+	Queue          queue.Config                 `embed:"" prefix:"fleet-queue-" envprefix:"FLEET_QUEUE_"`
+	TimescaleDB    timescaledb.Config           `embed:"" prefix:"timescaledb-" envprefix:"TIMESCALEDB_"`
+	Telemetry      telemetry.Config             `embed:"" prefix:"telemetry-" envprefix:"TELEMETRY_"`
+	Scheduler      scheduler.Config             `embed:"" prefix:"scheduler-" envprefix:"SCHEDULER_"`
+	Plugins        plugins.Config               `embed:"" prefix:"plugins-" envprefix:"PLUGINS_"`
+	IPScanner      ipscanner.Config             `embed:"" prefix:"ipscanner-" envprefix:"IPSCANNER_"`
+	Diagnostics    diagnostics.Config           `embed:"" prefix:"diagnostics-" envprefix:"DIAGNOSTICS_"`
+	Files          files.Config                 `embed:"" prefix:"files-" envprefix:"FILES_"`
+	FleetTelemetry fleet_telemetry.Config       `embed:"" prefix:"fleet-telemetry-" envprefix:"FLEET_TELEMETRY_"`
+	Metrics        metrics.Config               `embed:"" prefix:"metrics-" envprefix:"FLEET_METRICS_"`
 }

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -482,7 +482,7 @@ func start(config *Config) error {
 		}
 	}()
 
-	curtailmentRec := curtailmentReconciler.New(curtailmentReconciler.Config{}, curtailmentStore, commandSvc, curtailmentReconciler.WithMetrics(curtailmentMetrics))
+	curtailmentRec := curtailmentReconciler.New(config.Curtailment, curtailmentStore, commandSvc, curtailmentReconciler.WithMetrics(curtailmentMetrics))
 	if err := curtailmentRec.Start(context.Background()); err != nil {
 		return fmt.Errorf("failed to start curtailment reconciler: %w", err)
 	}

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -232,6 +232,165 @@ func (q *Queries) BumpCurtailmentTargetRetry(ctx context.Context, arg BumpCurtai
 	return result.RowsAffected()
 }
 
+const claimClosedLoopFullFleetTargets = `-- name: ClaimClosedLoopFullFleetTargets :many
+WITH locked_event AS MATERIALIZED (
+    SELECT id
+    FROM curtailment_event
+    WHERE id = $2
+      AND state IN ('pending', 'active')
+      AND mode = 'FULL_FLEET'
+      AND loop_type = 'closed'
+    FOR UPDATE
+)
+INSERT INTO curtailment_target (
+    curtailment_event_id,
+    device_identifier,
+    target_type,
+    state,
+    desired_state,
+    baseline_power_w,
+    selector_rationale_jsonb
+)
+SELECT
+    locked_event.id,
+    t.device_identifier,
+    t.target_type,
+    'dispatching',
+    t.desired_state,
+    t.baseline_power_w,
+    t.selector_rationale_jsonb
+FROM locked_event
+JOIN jsonb_to_recordset($1::JSONB) AS t(
+    device_identifier         TEXT,
+    target_type               TEXT,
+    state                     TEXT,
+    desired_state             TEXT,
+    baseline_power_w          NUMERIC(12,3),
+    selector_rationale_jsonb  JSONB
+) ON TRUE
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM curtailment_target existing
+    WHERE existing.curtailment_event_id = locked_event.id
+      AND existing.device_identifier = t.device_identifier
+)
+ON CONFLICT DO NOTHING
+RETURNING curtailment_target.curtailment_event_id, curtailment_target.device_identifier, curtailment_target.target_type, curtailment_target.state, curtailment_target.desired_state, curtailment_target.baseline_power_w, curtailment_target.added_at, curtailment_target.released_at, curtailment_target.last_dispatched_at, curtailment_target.last_batch_uuid, curtailment_target.observed_power_w, curtailment_target.observed_at, curtailment_target.confirmed_at, curtailment_target.retry_count, curtailment_target.last_error, curtailment_target.selector_rationale_jsonb, curtailment_target.curtail_state, curtailment_target.curtail_dispatched_at, curtailment_target.curtail_batch_uuid, curtailment_target.curtail_completed_at, curtailment_target.curtail_retry_count, curtailment_target.curtail_failure_count, curtailment_target.curtail_last_error, curtailment_target.restore_state, curtailment_target.restore_started_at, curtailment_target.restore_dispatched_at, curtailment_target.restore_batch_uuid, curtailment_target.restore_completed_at, curtailment_target.restore_retry_count, curtailment_target.restore_failure_count, curtailment_target.restore_last_error
+`
+
+type ClaimClosedLoopFullFleetTargetsParams struct {
+	TargetsJsonb       json.RawMessage
+	CurtailmentEventID int64
+}
+
+// Closed-loop FULL_FLEET dispatch claim. Locks the parent event so
+// Stop/AdminTerminate and dynamic target claims serialize on lifecycle state.
+// Same-event duplicates and cross-event target conflicts are no-ops; the
+// reconciler retries on a later tick if a conflicting event resolves.
+func (q *Queries) ClaimClosedLoopFullFleetTargets(ctx context.Context, arg ClaimClosedLoopFullFleetTargetsParams) ([]CurtailmentTarget, error) {
+	rows, err := q.query(ctx, q.claimClosedLoopFullFleetTargetsStmt, claimClosedLoopFullFleetTargets, arg.TargetsJsonb, arg.CurtailmentEventID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CurtailmentTarget
+	for rows.Next() {
+		var i CurtailmentTarget
+		if err := rows.Scan(
+			&i.CurtailmentEventID,
+			&i.DeviceIdentifier,
+			&i.TargetType,
+			&i.State,
+			&i.DesiredState,
+			&i.BaselinePowerW,
+			&i.AddedAt,
+			&i.ReleasedAt,
+			&i.LastDispatchedAt,
+			&i.LastBatchUuid,
+			&i.ObservedPowerW,
+			&i.ObservedAt,
+			&i.ConfirmedAt,
+			&i.RetryCount,
+			&i.LastError,
+			&i.SelectorRationaleJsonb,
+			&i.CurtailState,
+			&i.CurtailDispatchedAt,
+			&i.CurtailBatchUuid,
+			&i.CurtailCompletedAt,
+			&i.CurtailRetryCount,
+			&i.CurtailFailureCount,
+			&i.CurtailLastError,
+			&i.RestoreState,
+			&i.RestoreStartedAt,
+			&i.RestoreDispatchedAt,
+			&i.RestoreBatchUuid,
+			&i.RestoreCompletedAt,
+			&i.RestoreRetryCount,
+			&i.RestoreFailureCount,
+			&i.RestoreLastError,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const countCurtailmentScopeConflicts = `-- name: CountCurtailmentScopeConflicts :one
+SELECT count(*)::BIGINT
+FROM curtailment_event
+WHERE org_id = $1
+  AND state IN ('pending', 'active', 'restoring')
+  AND $2::TEXT = 'FULL_FLEET'
+  AND $3::TEXT = 'closed'
+  AND (
+    (
+      $4::TEXT = 'whole_org'
+      AND scope_type IN ('whole_org', 'site')
+    )
+    OR (
+      $4::TEXT = 'site'
+      AND (
+        scope_type = 'whole_org'
+        OR (
+          scope_type = 'site'
+          AND scope_jsonb->>'site_id' = $5::TEXT
+        )
+      )
+    )
+  )
+`
+
+type CountCurtailmentScopeConflictsParams struct {
+	OrgID     int64
+	Mode      string
+	LoopType  string
+	ScopeType string
+	SiteID    string
+}
+
+// Hierarchy for currently supported scopes: org > site.
+// A new whole-org event conflicts with existing whole-org or site events.
+// A new site event conflicts with existing whole-org or same-site events.
+func (q *Queries) CountCurtailmentScopeConflicts(ctx context.Context, arg CountCurtailmentScopeConflictsParams) (int64, error) {
+	row := q.queryRow(ctx, q.countCurtailmentScopeConflictsStmt, countCurtailmentScopeConflicts,
+		arg.OrgID,
+		arg.Mode,
+		arg.LoopType,
+		arg.ScopeType,
+		arg.SiteID,
+	)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const curtailmentEventHasInFlightTargets = `-- name: CurtailmentEventHasInFlightTargets :one
 SELECT EXISTS (
     SELECT 1
@@ -756,6 +915,7 @@ INSERT INTO curtailment_event (
     idempotency_key,
     reason,
     scheduled_start_at,
+    started_at,
     ended_at,
     created_by_user_id,
     effective_batch_size
@@ -790,7 +950,8 @@ INSERT INTO curtailment_event (
     $28,
     $29,
     $30,
-    $31
+    $31,
+    $32
 )
 RETURNING id, event_uuid, created_at, updated_at
 `
@@ -824,6 +985,7 @@ type InsertCurtailmentEventParams struct {
 	IdempotencyKey          sql.NullString
 	Reason                  string
 	ScheduledStartAt        sql.NullTime
+	StartedAt               sql.NullTime
 	EndedAt                 sql.NullTime
 	CreatedByUserID         int64
 	EffectiveBatchSize      sql.NullInt32
@@ -868,6 +1030,7 @@ func (q *Queries) InsertCurtailmentEvent(ctx context.Context, arg InsertCurtailm
 		arg.IdempotencyKey,
 		arg.Reason,
 		arg.ScheduledStartAt,
+		arg.StartedAt,
 		arg.EndedAt,
 		arg.CreatedByUserID,
 		arg.EffectiveBatchSize,
@@ -889,6 +1052,22 @@ JOIN curtailment_event ce ON ce.id = ct.curtailment_event_id
 WHERE ce.org_id = $1
     AND ce.state IN ('pending', 'active', 'restoring')
     AND ct.state NOT IN ('resolved', 'restore_failed', 'released')
+UNION
+SELECT d.device_identifier
+FROM curtailment_event ce
+JOIN device d ON d.org_id = ce.org_id
+    AND d.deleted_at IS NULL
+    AND (
+        ce.scope_type = 'whole_org'
+        OR (
+            ce.scope_type = 'site'
+            AND d.site_id = (ce.scope_jsonb->>'site_id')::BIGINT
+        )
+    )
+WHERE ce.org_id = $1
+    AND ce.state IN ('pending', 'active', 'restoring')
+    AND ce.mode = 'FULL_FLEET'
+    AND ce.loop_type = 'closed'
 `
 
 // Devices locked in a non-terminal event; excluded from candidates to
@@ -1031,6 +1210,41 @@ func (q *Queries) ListActiveCurtailmentEvents(ctx context.Context, orgID int64) 
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listActiveCurtailmentTargetDevicesByOrg = `-- name: ListActiveCurtailmentTargetDevicesByOrg :many
+SELECT DISTINCT ct.device_identifier
+FROM curtailment_target ct
+JOIN curtailment_event ce ON ce.id = ct.curtailment_event_id
+WHERE ce.org_id = $1
+    AND ce.state IN ('pending', 'active', 'restoring')
+    AND ct.state NOT IN ('resolved', 'restore_failed', 'released')
+`
+
+// Devices with concrete non-terminal target rows; used by closed-loop
+// admission to skip miners already owned by other events without excluding
+// the current targetless scope watcher.
+func (q *Queries) ListActiveCurtailmentTargetDevicesByOrg(ctx context.Context, orgID int64) ([]string, error) {
+	rows, err := q.query(ctx, q.listActiveCurtailmentTargetDevicesByOrgStmt, listActiveCurtailmentTargetDevicesByOrg, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var device_identifier string
+		if err := rows.Scan(&device_identifier); err != nil {
+			return nil, err
+		}
+		items = append(items, device_identifier)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -1635,6 +1849,17 @@ func (q *Queries) ListRecentlyResolvedCurtailedDevicesByOrg(ctx context.Context,
 		return nil, err
 	}
 	return items, nil
+}
+
+const lockCurtailmentScopeForWrite = `-- name: LockCurtailmentScopeForWrite :exec
+SELECT pg_advisory_xact_lock(hashtextextended('curtailment_scope:' || $1::text, 0))
+`
+
+// Serialize hierarchy start checks by org so conflict detection and event
+// insertion happen under one database-backed critical section.
+func (q *Queries) LockCurtailmentScopeForWrite(ctx context.Context, orgID string) error {
+	_, err := q.exec(ctx, q.lockCurtailmentScopeForWriteStmt, lockCurtailmentScopeForWrite, orgID)
+	return err
 }
 
 const resetCurtailmentTargetsForRecurtail = `-- name: ResetCurtailmentTargetsForRecurtail :one

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -347,6 +347,8 @@ SELECT count(*)::BIGINT
 FROM curtailment_event
 WHERE org_id = $1
   AND state IN ('pending', 'active', 'restoring')
+  AND mode = 'FULL_FLEET'
+  AND loop_type = 'closed'
   AND $2::TEXT = 'FULL_FLEET'
   AND $3::TEXT = 'closed'
   AND (

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -105,6 +105,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.cascadeRackDeviceSitesBulkStmt, err = db.PrepareContext(ctx, cascadeRackDeviceSitesBulk); err != nil {
 		return nil, fmt.Errorf("error preparing query CascadeRackDeviceSitesBulk: %w", err)
 	}
+	if q.claimClosedLoopFullFleetTargetsStmt, err = db.PrepareContext(ctx, claimClosedLoopFullFleetTargets); err != nil {
+		return nil, fmt.Errorf("error preparing query ClaimClosedLoopFullFleetTargets: %w", err)
+	}
 	if q.claimMessageForProcessingStmt, err = db.PrepareContext(ctx, claimMessageForProcessing); err != nil {
 		return nil, fmt.Errorf("error preparing query ClaimMessageForProcessing: %w", err)
 	}
@@ -161,6 +164,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.countCurtailmentAutomationRulesByResponseProfileStmt, err = db.PrepareContext(ctx, countCurtailmentAutomationRulesByResponseProfile); err != nil {
 		return nil, fmt.Errorf("error preparing query CountCurtailmentAutomationRulesByResponseProfile: %w", err)
+	}
+	if q.countCurtailmentScopeConflictsStmt, err = db.PrepareContext(ctx, countCurtailmentScopeConflicts); err != nil {
+		return nil, fmt.Errorf("error preparing query CountCurtailmentScopeConflicts: %w", err)
 	}
 	if q.countDevicesWithErrorsStmt, err = db.PrepareContext(ctx, countDevicesWithErrors); err != nil {
 		return nil, fmt.Errorf("error preparing query CountDevicesWithErrors: %w", err)
@@ -717,6 +723,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listActiveCurtailmentEventsStmt, err = db.PrepareContext(ctx, listActiveCurtailmentEvents); err != nil {
 		return nil, fmt.Errorf("error preparing query ListActiveCurtailmentEvents: %w", err)
 	}
+	if q.listActiveCurtailmentTargetDevicesByOrgStmt, err = db.PrepareContext(ctx, listActiveCurtailmentTargetDevicesByOrg); err != nil {
+		return nil, fmt.Errorf("error preparing query ListActiveCurtailmentTargetDevicesByOrg: %w", err)
+	}
 	if q.listActiveOrganizationIDsStmt, err = db.PrepareContext(ctx, listActiveOrganizationIDs); err != nil {
 		return nil, fmt.Errorf("error preparing query ListActiveOrganizationIDs: %w", err)
 	}
@@ -869,6 +878,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.lockBuildingsBySiteForWriteStmt, err = db.PrepareContext(ctx, lockBuildingsBySiteForWrite); err != nil {
 		return nil, fmt.Errorf("error preparing query LockBuildingsBySiteForWrite: %w", err)
+	}
+	if q.lockCurtailmentScopeForWriteStmt, err = db.PrepareContext(ctx, lockCurtailmentScopeForWrite); err != nil {
+		return nil, fmt.Errorf("error preparing query LockCurtailmentScopeForWrite: %w", err)
 	}
 	if q.lockDevicesForReassignStmt, err = db.PrepareContext(ctx, lockDevicesForReassign); err != nil {
 		return nil, fmt.Errorf("error preparing query LockDevicesForReassign: %w", err)
@@ -1427,6 +1439,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing cascadeRackDeviceSitesBulkStmt: %w", cerr)
 		}
 	}
+	if q.claimClosedLoopFullFleetTargetsStmt != nil {
+		if cerr := q.claimClosedLoopFullFleetTargetsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing claimClosedLoopFullFleetTargetsStmt: %w", cerr)
+		}
+	}
 	if q.claimMessageForProcessingStmt != nil {
 		if cerr := q.claimMessageForProcessingStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing claimMessageForProcessingStmt: %w", cerr)
@@ -1520,6 +1537,11 @@ func (q *Queries) Close() error {
 	if q.countCurtailmentAutomationRulesByResponseProfileStmt != nil {
 		if cerr := q.countCurtailmentAutomationRulesByResponseProfileStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing countCurtailmentAutomationRulesByResponseProfileStmt: %w", cerr)
+		}
+	}
+	if q.countCurtailmentScopeConflictsStmt != nil {
+		if cerr := q.countCurtailmentScopeConflictsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing countCurtailmentScopeConflictsStmt: %w", cerr)
 		}
 	}
 	if q.countDevicesWithErrorsStmt != nil {
@@ -2447,6 +2469,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listActiveCurtailmentEventsStmt: %w", cerr)
 		}
 	}
+	if q.listActiveCurtailmentTargetDevicesByOrgStmt != nil {
+		if cerr := q.listActiveCurtailmentTargetDevicesByOrgStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listActiveCurtailmentTargetDevicesByOrgStmt: %w", cerr)
+		}
+	}
 	if q.listActiveOrganizationIDsStmt != nil {
 		if cerr := q.listActiveOrganizationIDsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listActiveOrganizationIDsStmt: %w", cerr)
@@ -2700,6 +2727,11 @@ func (q *Queries) Close() error {
 	if q.lockBuildingsBySiteForWriteStmt != nil {
 		if cerr := q.lockBuildingsBySiteForWriteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing lockBuildingsBySiteForWriteStmt: %w", cerr)
+		}
+	}
+	if q.lockCurtailmentScopeForWriteStmt != nil {
+		if cerr := q.lockCurtailmentScopeForWriteStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing lockCurtailmentScopeForWriteStmt: %w", cerr)
 		}
 	}
 	if q.lockDevicesForReassignStmt != nil {
@@ -3463,6 +3495,7 @@ type Queries struct {
 	cascadeRackDeviceBuildingsBulkStmt                         *sql.Stmt
 	cascadeRackDeviceSitesStmt                                 *sql.Stmt
 	cascadeRackDeviceSitesBulkStmt                             *sql.Stmt
+	claimClosedLoopFullFleetTargetsStmt                        *sql.Stmt
 	claimMessageForProcessingStmt                              *sql.Stmt
 	clearCurtailmentAutomationActiveEventStmt                  *sql.Stmt
 	clearDeviceBuildingsByBuildingStmt                         *sql.Stmt
@@ -3482,6 +3515,7 @@ type Queries struct {
 	countComponentsWithErrorsStmt                              *sql.Stmt
 	countCurtailmentAutomationRulesByMQTTSourceStmt            *sql.Stmt
 	countCurtailmentAutomationRulesByResponseProfileStmt       *sql.Stmt
+	countCurtailmentScopeConflictsStmt                         *sql.Stmt
 	countDevicesWithErrorsStmt                                 *sql.Stmt
 	countErrorsStmt                                            *sql.Stmt
 	countMinersByStateStmt                                     *sql.Stmt
@@ -3667,6 +3701,7 @@ type Queries struct {
 	isDeviceOwnedByFleetNodeStmt                               *sql.Stmt
 	listActiveCurtailedDevicesByOrgStmt                        *sql.Stmt
 	listActiveCurtailmentEventsStmt                            *sql.Stmt
+	listActiveCurtailmentTargetDevicesByOrgStmt                *sql.Stmt
 	listActiveOrganizationIDsStmt                              *sql.Stmt
 	listActivityLogsStmt                                       *sql.Stmt
 	listApiKeysByOrganizationStmt                              *sql.Stmt
@@ -3718,6 +3753,7 @@ type Queries struct {
 	lockAndCountOrgScopeSuperAdminsStmt                        *sql.Stmt
 	lockBuildingForWriteStmt                                   *sql.Stmt
 	lockBuildingsBySiteForWriteStmt                            *sql.Stmt
+	lockCurtailmentScopeForWriteStmt                           *sql.Stmt
 	lockDevicesForReassignStmt                                 *sql.Stmt
 	lockFleetNodeByIDStmt                                      *sql.Stmt
 	lockRackPlacementForWriteStmt                              *sql.Stmt
@@ -3890,6 +3926,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		cascadeRackDeviceBuildingsBulkStmt:                         q.cascadeRackDeviceBuildingsBulkStmt,
 		cascadeRackDeviceSitesStmt:                                 q.cascadeRackDeviceSitesStmt,
 		cascadeRackDeviceSitesBulkStmt:                             q.cascadeRackDeviceSitesBulkStmt,
+		claimClosedLoopFullFleetTargetsStmt:                        q.claimClosedLoopFullFleetTargetsStmt,
 		claimMessageForProcessingStmt:                              q.claimMessageForProcessingStmt,
 		clearCurtailmentAutomationActiveEventStmt:                  q.clearCurtailmentAutomationActiveEventStmt,
 		clearDeviceBuildingsByBuildingStmt:                         q.clearDeviceBuildingsByBuildingStmt,
@@ -3909,6 +3946,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		countComponentsWithErrorsStmt:                              q.countComponentsWithErrorsStmt,
 		countCurtailmentAutomationRulesByMQTTSourceStmt:            q.countCurtailmentAutomationRulesByMQTTSourceStmt,
 		countCurtailmentAutomationRulesByResponseProfileStmt:       q.countCurtailmentAutomationRulesByResponseProfileStmt,
+		countCurtailmentScopeConflictsStmt:                         q.countCurtailmentScopeConflictsStmt,
 		countDevicesWithErrorsStmt:                                 q.countDevicesWithErrorsStmt,
 		countErrorsStmt:                                            q.countErrorsStmt,
 		countMinersByStateStmt:                                     q.countMinersByStateStmt,
@@ -4094,6 +4132,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		isDeviceOwnedByFleetNodeStmt:                               q.isDeviceOwnedByFleetNodeStmt,
 		listActiveCurtailedDevicesByOrgStmt:                        q.listActiveCurtailedDevicesByOrgStmt,
 		listActiveCurtailmentEventsStmt:                            q.listActiveCurtailmentEventsStmt,
+		listActiveCurtailmentTargetDevicesByOrgStmt:                q.listActiveCurtailmentTargetDevicesByOrgStmt,
 		listActiveOrganizationIDsStmt:                              q.listActiveOrganizationIDsStmt,
 		listActivityLogsStmt:                                       q.listActivityLogsStmt,
 		listApiKeysByOrganizationStmt:                              q.listApiKeysByOrganizationStmt,
@@ -4145,6 +4184,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		lockAndCountOrgScopeSuperAdminsStmt:                        q.lockAndCountOrgScopeSuperAdminsStmt,
 		lockBuildingForWriteStmt:                                   q.lockBuildingForWriteStmt,
 		lockBuildingsBySiteForWriteStmt:                            q.lockBuildingsBySiteForWriteStmt,
+		lockCurtailmentScopeForWriteStmt:                           q.lockCurtailmentScopeForWriteStmt,
 		lockDevicesForReassignStmt:                                 q.lockDevicesForReassignStmt,
 		lockFleetNodeByIDStmt:                                      q.lockFleetNodeByIDStmt,
 		lockRackPlacementForWriteStmt:                              q.lockRackPlacementForWriteStmt,

--- a/server/internal/domain/curtailment/automation.go
+++ b/server/internal/domain/curtailment/automation.go
@@ -306,6 +306,10 @@ func (s *AutomationService) handleRuleOff(ctx context.Context, rule *models.Auto
 		return err
 	}
 	startReq := startRequestFromAutomationProfile(rule, profile, signal)
+	if startReq.Mode == models.ModeFullFleet {
+		startReq.AllowUnbounded = true
+		startReq.MaxDurationSeconds = nil
+	}
 	plan, err := s.curtailment.Start(ctx, startReq)
 	if err != nil {
 		return err

--- a/server/internal/domain/curtailment/automation.go
+++ b/server/internal/domain/curtailment/automation.go
@@ -500,7 +500,6 @@ func startRequestFromAutomationProfile(rule *models.AutomationRule, profile *mod
 			Strategy:                profile.Strategy,
 			Level:                   profile.Level,
 			Priority:                profile.Priority,
-			BypassCooldown:          true,
 			TargetKW:                targetKW,
 			ToleranceKW:             toleranceKW,
 			IncludeMaintenance:      profile.IncludeMaintenance,

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -296,6 +296,8 @@ func TestAutomationService_HandleMQTTSignal_OffStartsCurtailmentFromResponseProf
 		h.curtailments.lastInsertEvent.Reason,
 	)
 	assert.Equal(t, models.SourceActorAutomation, h.curtailments.lastInsertEvent.SourceActorType)
+	assert.True(t, h.curtailments.lastInsertEvent.AllowUnbounded)
+	assert.Nil(t, h.curtailments.lastInsertEvent.MaxDurationSeconds)
 	assert.Equal(t, h.source.ServiceUserID, h.curtailments.lastInsertEvent.CreatedByUserID)
 	assert.Equal(t, automationExternalSource, *h.curtailments.lastInsertEvent.ExternalSource)
 	assert.Equal(t, "9001", *h.curtailments.lastInsertEvent.ExternalReference)

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -30,6 +30,7 @@ func TestAutomationService_CreateValidatesSourceAndProfile(t *testing.T) {
 			MQTTSourceID:      h.source.ID,
 			ResponseProfileID: h.profile.ID,
 		},
+		CanUseAdminControls: true,
 	})
 
 	require.NoError(t, err)
@@ -100,6 +101,12 @@ func TestAutomationService_CreateRejectsAdminOnlyProfileWithoutAdminControls(t *
 		mutate func(*models.ResponseProfile)
 	}{
 		{
+			name: "full fleet automation",
+			mutate: func(profile *models.ResponseProfile) {
+				profile.Mode = models.ModeFullFleet
+			},
+		},
+		{
 			name: "force maintenance",
 			mutate: func(profile *models.ResponseProfile) {
 				profile.IncludeMaintenance = true
@@ -125,6 +132,7 @@ func TestAutomationService_CreateRejectsAdminOnlyProfileWithoutAdminControls(t *
 			t.Parallel()
 
 			h := newAutomationHarness(t)
+			h.profile.Mode = models.ModeFixedKw
 			tc.mutate(h.profile)
 
 			_, err := h.automation.Create(t.Context(), SaveAutomationRuleRequest{
@@ -201,6 +209,7 @@ func TestAutomationService_UpdateRejectsWhenRuleOwnsActiveEvent(t *testing.T) {
 			MQTTSourceID:      h.source.ID,
 			ResponseProfileID: h.profile.ID,
 		},
+		CanUseAdminControls: true,
 	})
 
 	require.Error(t, err)

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -322,9 +322,10 @@ func TestAutomationService_HandleMQTTSignal_OffBypassesPostRestoreCooldown(t *te
 	assert.Equal(t, 0, h.curtailments.cooldownCalls)
 	assert.Equal(t, 1, h.curtailments.insertEventCalls)
 	assert.Equal(t, models.PriorityNormal, h.curtailments.lastInsertEvent.Priority)
-	require.Len(t, h.curtailments.lastInsertTargets, 2)
-	assert.Equal(t, "miner-a", h.curtailments.lastInsertTargets[0].DeviceIdentifier)
-	assert.Equal(t, "miner-b", h.curtailments.lastInsertTargets[1].DeviceIdentifier)
+	assert.Equal(t, models.ModeFullFleet, h.curtailments.lastInsertEvent.Mode)
+	assert.Equal(t, models.LoopTypeClosed, h.curtailments.lastInsertEvent.LoopType)
+	assert.Empty(t, h.curtailments.lastInsertTargets,
+		"closed-loop full_fleet claims per-miner targets at dispatch time")
 }
 
 func TestAutomationService_HandleMQTTSignal_RepeatedOffNoopsWhenEventIsActive(t *testing.T) {

--- a/server/internal/domain/curtailment/models/models.go
+++ b/server/internal/domain/curtailment/models/models.go
@@ -284,6 +284,7 @@ type InsertEventParams struct {
 	IdempotencyKey          *string
 	Reason                  string
 	ScheduledStartAt        *time.Time
+	StartedAt               *time.Time
 	// EndedAt is set only when an event is inserted already terminal — a
 	// vacuously-COMPLETED FULL_FLEET start with no eligible targets — so the
 	// completion time is recorded; the reconciler/restorer set it otherwise.

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -346,7 +346,7 @@ func (r *Reconciler) dispatchPending(ctx context.Context, ev *models.Event) {
 	r.maybeMarkActive(ctx, ev, targets)
 }
 
-// dispatchPendingCurtailBatches drains pending-event Curtail work in command
+// dispatchPendingCurtailBatches drains retryable Curtail work in command
 // batches. Orphaned DISPATCHING rows from an interrupted prior tick are
 // recovered before fresh PENDING rows. curtail_batch_size=NULL dispatches all
 // remaining targets; a positive interval paces fresh pending batches.
@@ -563,14 +563,13 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 	return true
 }
 
-// recordDispatchFailure bumps retry_count; transitions to RestoreFailed
-// at MaxRetries so the event can still proceed. On non-race-loss write
-// failure, falls back to BumpTargetRetry so the budget still advances
-// across ticks even when the rich state-change UPDATE can't land.
+// recordDispatchFailure bumps retry_count. Restore targets transition to
+// RestoreFailed at MaxRetries so the event can complete; curtail targets stay
+// retryable while OFF remains asserted, with retry_count surfacing the alert.
 func (r *Reconciler) recordDispatchFailure(ctx context.Context, ev *models.Event, t *models.Target, errMsg string, nonTerminalFailureState models.TargetState) {
 	newRetry := t.RetryCount + 1
 	state := nonTerminalFailureState
-	if newRetry >= r.maxRetriesForTarget(t) {
+	if r.retryBudgetTerminalizes(t, newRetry) {
 		state = models.TargetStateRestoreFailed
 	}
 	params := interfaces.UpdateCurtailmentTargetStateParams{
@@ -590,9 +589,8 @@ func (r *Reconciler) recordDispatchFailure(ctx context.Context, ev *models.Event
 	}
 	slog.Error("curtailment reconciler: target update after dispatch failure failed",
 		"event_id", ev.ID, "device", t.DeviceIdentifier, "error", err)
-	// Fallback: advance retry budget only. State stays at the prior value
-	// (next tick re-issues the dispatch); MaxRetries → RESTORE_FAILED
-	// escalation lands on the next successful UpdateTargetState.
+	// Fallback: advance retry budget only. State stays at the prior value;
+	// terminal restore escalation lands on the next successful UpdateTargetState.
 	if bumpErr := r.store.BumpTargetRetry(ctx, ev.ID, t.DeviceIdentifier); bumpErr != nil {
 		if !errors.Is(bumpErr, interfaces.ErrCurtailmentEventStateRaceLoss) {
 			r.metrics.IncTargetWriteFailure()
@@ -605,10 +603,18 @@ func (r *Reconciler) recordDispatchFailure(ctx context.Context, ev *models.Event
 }
 
 func (r *Reconciler) maxRetriesForTarget(t *models.Target) int32 {
-	if t != nil && t.DesiredState == models.DesiredStateCurtailed {
+	if isCurtailRetryTarget(t) {
 		return r.cfg.CurtailMaxRetries
 	}
 	return r.cfg.MaxRetries
+}
+
+func (r *Reconciler) retryBudgetTerminalizes(t *models.Target, retryCount int32) bool {
+	return t == nil || (!isCurtailRetryTarget(t) && retryCount >= r.maxRetriesForTarget(t))
+}
+
+func isCurtailRetryTarget(t *models.Target) bool {
+	return t != nil && (t.DesiredState == "" || t.DesiredState == models.DesiredStateCurtailed)
 }
 
 // candidatesByDeviceID indexes a candidate slice by device identifier for
@@ -655,7 +661,6 @@ func (r *Reconciler) observeActive(ctx context.Context, ev *models.Event) {
 		return
 	}
 	cmdCtx := reconcilerCommandContext(ctx, ev.OrgID, ev.CreatedByUserID)
-	r.confirmDispatched(ctx, ev, targets)
 	if len(targets) > 0 {
 		deviceIDs := make([]string, 0, len(targets))
 		for _, t := range targets {
@@ -678,21 +683,18 @@ func (r *Reconciler) observeActive(ctx context.Context, ev *models.Event) {
 					// Re-entry: drifted-then-redispatched, waiting on confirmation.
 					r.confirmOneDispatched(cmdCtx, ev, t, candByID[t.DeviceIdentifier], models.TargetStateDispatched)
 				case models.TargetStateDispatching:
-					// Orphan from an interrupted prior tick; redispatch.
-					if t.RetryCount >= r.maxRetriesForTarget(t) {
-						// Escalate via recordDispatchFailure so the target reaches
-						// the terminal state. Skipping with `continue` would leave
-						// the row pinned in DISPATCHING after BumpTargetRetry's
-						// fallback path bumped retry_count past MaxRetries without
-						// a state transition.
+					// Orphan from an interrupted prior tick; redispatched after
+					// observation in batch-aware order.
+					if r.retryBudgetTerminalizes(t, t.RetryCount) {
+						// Escalate restore targets instead of leaving the row pinned
+						// in DISPATCHING after retry_count passes MaxRetries.
 						r.recordDispatchFailure(cmdCtx, ev, t,
 							"retry budget exhausted from interrupted dispatch",
 							models.TargetStateDispatching)
 						continue
 					}
-					r.dispatchOneCurtail(cmdCtx, ev, t, models.TargetStateDispatching)
 				case models.TargetStateDrifted:
-					if t.RetryCount >= r.maxRetriesForTarget(t) {
+					if r.retryBudgetTerminalizes(t, t.RetryCount) {
 						// Symmetric to the DISPATCHING arm: a Drifted target whose
 						// retry budget was bumped past MaxRetries by the
 						// BumpTargetRetry fallback must terminalize, not loop.
@@ -706,9 +708,10 @@ func (r *Reconciler) observeActive(ctx context.Context, ev *models.Event) {
 					models.TargetStateResolved, models.TargetStateReleased,
 					models.TargetStateRestoreFailed:
 					// Pending rows are handled by the active closed-loop dispatch pass
-					// above. Terminal states are restorer-owned.
+					// below. Terminal states are restorer-owned.
 				}
 			}
+			r.dispatchPendingCurtailBatches(cmdCtx, ev, targets)
 		}
 	}
 	claimed := r.claimClosedLoopFullFleetTargets(ctx, ev, targets)
@@ -747,7 +750,7 @@ func (r *Reconciler) claimClosedLoopFullFleetTargets(ctx context.Context, ev *mo
 	targets, _ := curtailment.BuildFullFleetAdmissionTargets(
 		candidates,
 		ev.IncludeMaintenance && ev.ForceIncludeMaintenance,
-		orgConfig.CandidateMinPowerW,
+		candidateMinPowerWForEvent(ev, orgConfig.CandidateMinPowerW),
 	)
 	targets = excludeExistingTargetParams(targets, existingTargets)
 	activeDevices, err := r.store.ListActiveCurtailmentTargetDevices(ctx, ev.OrgID)
@@ -783,6 +786,19 @@ func hasInFlightCurtailDispatch(targets []*models.Target) bool {
 		}
 	}
 	return false
+}
+
+func candidateMinPowerWForEvent(ev *models.Event, fallback int32) int32 {
+	if ev == nil || len(ev.DecisionSnapshotJSON) == 0 {
+		return fallback
+	}
+	var snapshot struct {
+		CandidateMinPowerW int32 `json:"candidate_min_power_w"`
+	}
+	if err := json.Unmarshal(ev.DecisionSnapshotJSON, &snapshot); err != nil || snapshot.CandidateMinPowerW <= 0 {
+		return fallback
+	}
+	return snapshot.CandidateMinPowerW
 }
 
 func excludeExistingTargetParams(targets []models.InsertTargetParams, existingTargets []*models.Target) []models.InsertTargetParams {
@@ -868,10 +884,7 @@ func (r *Reconciler) confirmOneDispatched(ctx context.Context, ev *models.Event,
 					"timeout_sec", r.cfg.CurtailDispatchTimeoutSec)
 				r.recordDispatchFailure(ctx, ev, t,
 					"curtail telemetry timeout",
-					nonTerminalState)
-				if t.State != models.TargetStateRestoreFailed {
-					r.dispatchOneCurtail(ctx, ev, t, nonTerminalState)
-				}
+					models.TargetStateDispatching)
 			}
 		}
 		return
@@ -933,8 +946,9 @@ func (r *Reconciler) checkDrift(ctx context.Context, ev *models.Event, t *models
 		if params.ObservedPowerW != nil {
 			t.ObservedPowerW = params.ObservedPowerW
 		}
-		// Budget exhausted: stay Drifted (matches observeActive's drift arm).
-		if t.RetryCount >= r.maxRetriesForTarget(t) {
+		// Restore targets terminalize at budget; curtail targets keep retrying
+		// while OFF is asserted.
+		if r.retryBudgetTerminalizes(t, t.RetryCount) {
 			return
 		}
 		r.dispatchOneCurtail(ctx, ev, t, models.TargetStateDrifted)

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -760,7 +760,7 @@ func (r *Reconciler) claimClosedLoopFullFleetTargets(ctx context.Context, ev *mo
 	if len(targets) == 0 {
 		return nil
 	}
-	if batchSize := curtailBatchSizeForEvent(ev, len(targets)); int32(len(targets)) > batchSize {
+	if batchSize := curtailBatchSizeForEvent(ev, len(targets)); len(targets) > int(batchSize) {
 		targets = targets[:batchSize]
 	}
 	claimed, err := r.store.ClaimClosedLoopFullFleetTargets(ctx, ev.ID, targets)
@@ -844,6 +844,8 @@ func listCandidatesParamsForEventScope(ev *models.Event) (interfaces.ListCandida
 			return interfaces.ListCandidatesParams{}, false
 		}
 		return interfaces.ListCandidatesParams{SiteID: &scope.SiteID}, true
+	case models.ScopeTypeDeviceSets, models.ScopeTypeDeviceList:
+		return interfaces.ListCandidatesParams{}, false
 	default:
 		return interfaces.ListCandidatesParams{}, false
 	}

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -5,6 +5,7 @@ package reconciler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -30,15 +31,17 @@ const (
 	// bypass recognize reconciler self-traffic.
 	reconcilerActorName = "curtailment-reconciler"
 
-	defaultTickInterval           = 30 * time.Second
-	defaultShutdownDeadline       = 10 * time.Second
-	defaultMaxRetries       int32 = 3
+	defaultTickInterval            = 30 * time.Second
+	defaultShutdownDeadline        = 10 * time.Second
+	defaultMaxRetries        int32 = 10
+	defaultCurtailMaxRetries int32 = 50
 
 	// 0.5: power_w > baseline*factor is drifted; catches partial restore.
 	defaultDriftThresholdFactor = 0.5
 
-	// 10× tick interval; ages out restore-phase targets via retry budget.
-	defaultRestoreDispatchTimeoutSec = 300
+	// Per-target telemetry confirmation timeouts; both burn retry budget.
+	defaultCurtailDispatchTimeoutSec = 5
+	defaultRestoreDispatchTimeoutSec = 30
 )
 
 // CommandDispatcher is the subset of command.Service the reconciler needs;
@@ -50,13 +53,17 @@ type CommandDispatcher interface {
 
 // Config carries runtime tunables. Zero-valued fields use defaults.
 type Config struct {
-	TickInterval         time.Duration
+	TickInterval         time.Duration `help:"Interval between curtailment reconciler ticks. Zero uses the default; values below 1s are rejected." default:"0s" env:"TICK_INTERVAL"`
 	ShutdownDeadline     time.Duration
 	MaxRetries           int32
+	CurtailMaxRetries    int32
 	DriftThresholdFactor float64
+	// CurtailDispatchTimeoutSec ages out curtail-phase targets stuck in
+	// Dispatched without confirming telemetry (burns retry budget).
+	CurtailDispatchTimeoutSec int `help:"Seconds a curtail target may stay dispatched without telemetry confirmation before consuming retry budget. Zero uses the default; positive values must be at least 1." default:"0" env:"CURTAIL_DISPATCH_TIMEOUT_SEC"`
 	// RestoreDispatchTimeoutSec ages out restore-phase targets stuck in
 	// Dispatched without confirming telemetry (burns retry budget).
-	RestoreDispatchTimeoutSec int
+	RestoreDispatchTimeoutSec int `help:"Seconds a restore target may stay dispatched without telemetry confirmation before consuming retry budget. Zero uses the default." default:"0" env:"RESTORE_DISPATCH_TIMEOUT_SEC"`
 }
 
 func (c Config) withDefaults() Config {
@@ -69,8 +76,14 @@ func (c Config) withDefaults() Config {
 	if c.MaxRetries <= 0 {
 		c.MaxRetries = defaultMaxRetries
 	}
+	if c.CurtailMaxRetries <= 0 {
+		c.CurtailMaxRetries = defaultCurtailMaxRetries
+	}
 	if c.DriftThresholdFactor <= 0 {
 		c.DriftThresholdFactor = defaultDriftThresholdFactor
+	}
+	if c.CurtailDispatchTimeoutSec == 0 {
+		c.CurtailDispatchTimeoutSec = defaultCurtailDispatchTimeoutSec
 	}
 	if c.RestoreDispatchTimeoutSec <= 0 {
 		c.RestoreDispatchTimeoutSec = defaultRestoreDispatchTimeoutSec
@@ -133,6 +146,12 @@ func (r *Reconciler) Start(_ context.Context) error {
 	}
 	if r.cmd == nil {
 		return fmt.Errorf("curtailment reconciler: command dispatcher is required")
+	}
+	if r.cfg.TickInterval < time.Second {
+		return fmt.Errorf("curtailment reconciler: tick_interval must be at least 1s, got %s", r.cfg.TickInterval)
+	}
+	if r.cfg.CurtailDispatchTimeoutSec < 1 {
+		return fmt.Errorf("curtailment reconciler: curtail_dispatch_timeout_sec must be at least 1, got %d", r.cfg.CurtailDispatchTimeoutSec)
 	}
 
 	r.mu.Lock()
@@ -297,8 +316,15 @@ func (r *Reconciler) dispatchPending(ctx context.Context, ev *models.Event) {
 		return
 	}
 	if len(targets) == 0 {
-		// Service.Start rejects empty plans; zero targets is a contract
-		// violation needing manual recovery.
+		if isClosedLoopFullFleet(ev) {
+			now := r.now()
+			if err := r.store.UpdateEventState(ctx, ev.ID, ev.State, models.EventStateActive, &now, nil); err != nil {
+				r.logEventStateUpdateError(ev, "pending→active(empty closed-loop)", err)
+			}
+			return
+		}
+		// Service.Start rejects empty open-loop plans; zero targets is a
+		// contract violation needing manual recovery.
 		slog.Error("curtailment reconciler: pending event has no targets",
 			"event_id", ev.ID, "event_uuid", ev.EventUUID)
 		return
@@ -521,6 +547,7 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 			if !errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
 				slog.Error("curtailment reconciler: target dispatch update failed",
 					"event_id", ev.ID, "device", t.DeviceIdentifier, "error", err)
+				r.recordDispatchFailure(ctx, ev, t, err.Error(), nonTerminalFailureState)
 			}
 			continue
 		}
@@ -543,7 +570,7 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 func (r *Reconciler) recordDispatchFailure(ctx context.Context, ev *models.Event, t *models.Target, errMsg string, nonTerminalFailureState models.TargetState) {
 	newRetry := t.RetryCount + 1
 	state := nonTerminalFailureState
-	if newRetry >= r.cfg.MaxRetries {
+	if newRetry >= r.maxRetriesForTarget(t) {
 		state = models.TargetStateRestoreFailed
 	}
 	params := interfaces.UpdateCurtailmentTargetStateParams{
@@ -575,6 +602,13 @@ func (r *Reconciler) recordDispatchFailure(ctx context.Context, ev *models.Event
 		return
 	}
 	t.RetryCount = newRetry
+}
+
+func (r *Reconciler) maxRetriesForTarget(t *models.Target) int32 {
+	if t != nil && t.DesiredState == models.DesiredStateCurtailed {
+		return r.cfg.CurtailMaxRetries
+	}
+	return r.cfg.MaxRetries
 }
 
 // candidatesByDeviceID indexes a candidate slice by device identifier for
@@ -612,71 +646,206 @@ func (r *Reconciler) observeActive(ctx context.Context, ev *models.Event) {
 			"event_id", ev.ID, "error", err)
 		return
 	}
-	if len(targets) == 0 {
-		return
-	}
-
 	if r.enforceMaxDuration(ctx, ev, targets) {
 		return
 	}
-
-	deviceIDs := make([]string, 0, len(targets))
-	for _, t := range targets {
-		deviceIDs = append(deviceIDs, t.DeviceIdentifier)
-	}
-	cands, err := r.store.ListCandidates(ctx, interfaces.ListCandidatesParams{
-		OrgID:             ev.OrgID,
-		DeviceIdentifiers: deviceIDs,
-	})
-	if err != nil {
-		slog.Error("curtailment reconciler: list candidates (drift) failed",
-			"event_id", ev.ID, "error", err)
-		return
-	}
-	candByID := candidatesByDeviceID(cands)
 
 	// Per-tick liveness check; per-target race closure is in dispatchOneCurtail.
 	if !r.eventStillDispatchable(ctx, ev) {
 		return
 	}
 	cmdCtx := reconcilerCommandContext(ctx, ev.OrgID, ev.CreatedByUserID)
-	for _, t := range targets {
-		switch t.State {
-		case models.TargetStateConfirmed:
-			r.checkDrift(cmdCtx, ev, t, candByID[t.DeviceIdentifier])
-		case models.TargetStateDispatched:
-			// Re-entry: drifted-then-redispatched, waiting on confirmation.
-			r.confirmOneDispatched(cmdCtx, ev, t, candByID[t.DeviceIdentifier], models.TargetStateDispatched)
-		case models.TargetStateDispatching:
-			// Orphan from an interrupted prior tick; redispatch.
-			if t.RetryCount >= r.cfg.MaxRetries {
-				// Escalate via recordDispatchFailure so the target reaches
-				// the terminal state. Skipping with `continue` would leave
-				// the row pinned in DISPATCHING after BumpTargetRetry's
-				// fallback path bumped retry_count past MaxRetries without
-				// a state transition.
-				r.recordDispatchFailure(cmdCtx, ev, t,
-					"retry budget exhausted from interrupted dispatch",
-					models.TargetStateDispatching)
-				continue
-			}
-			r.dispatchOneCurtail(cmdCtx, ev, t, models.TargetStateDispatching)
-		case models.TargetStateDrifted:
-			if t.RetryCount >= r.cfg.MaxRetries {
-				// Symmetric to the DISPATCHING arm: a Drifted target whose
-				// retry budget was bumped past MaxRetries by the
-				// BumpTargetRetry fallback must terminalize, not loop.
-				r.recordDispatchFailure(cmdCtx, ev, t,
-					"retry budget exhausted on drifted target",
-					models.TargetStateDrifted)
-				continue
-			}
-			r.dispatchOneCurtail(cmdCtx, ev, t, models.TargetStateDrifted)
-		case models.TargetStatePending,
-			models.TargetStateResolved, models.TargetStateReleased,
-			models.TargetStateRestoreFailed:
-			// Pending unreachable on active; terminal states are restorer-owned.
+	r.confirmDispatched(ctx, ev, targets)
+	if len(targets) > 0 {
+		deviceIDs := make([]string, 0, len(targets))
+		for _, t := range targets {
+			deviceIDs = append(deviceIDs, t.DeviceIdentifier)
 		}
+		cands, err := r.store.ListCandidates(ctx, interfaces.ListCandidatesParams{
+			OrgID:             ev.OrgID,
+			DeviceIdentifiers: deviceIDs,
+		})
+		if err != nil {
+			slog.Error("curtailment reconciler: list candidates (drift) failed",
+				"event_id", ev.ID, "error", err)
+		} else {
+			candByID := candidatesByDeviceID(cands)
+			for _, t := range targets {
+				switch t.State {
+				case models.TargetStateConfirmed:
+					r.checkDrift(cmdCtx, ev, t, candByID[t.DeviceIdentifier])
+				case models.TargetStateDispatched:
+					// Re-entry: drifted-then-redispatched, waiting on confirmation.
+					r.confirmOneDispatched(cmdCtx, ev, t, candByID[t.DeviceIdentifier], models.TargetStateDispatched)
+				case models.TargetStateDispatching:
+					// Orphan from an interrupted prior tick; redispatch.
+					if t.RetryCount >= r.maxRetriesForTarget(t) {
+						// Escalate via recordDispatchFailure so the target reaches
+						// the terminal state. Skipping with `continue` would leave
+						// the row pinned in DISPATCHING after BumpTargetRetry's
+						// fallback path bumped retry_count past MaxRetries without
+						// a state transition.
+						r.recordDispatchFailure(cmdCtx, ev, t,
+							"retry budget exhausted from interrupted dispatch",
+							models.TargetStateDispatching)
+						continue
+					}
+					r.dispatchOneCurtail(cmdCtx, ev, t, models.TargetStateDispatching)
+				case models.TargetStateDrifted:
+					if t.RetryCount >= r.maxRetriesForTarget(t) {
+						// Symmetric to the DISPATCHING arm: a Drifted target whose
+						// retry budget was bumped past MaxRetries by the
+						// BumpTargetRetry fallback must terminalize, not loop.
+						r.recordDispatchFailure(cmdCtx, ev, t,
+							"retry budget exhausted on drifted target",
+							models.TargetStateDrifted)
+						continue
+					}
+					r.dispatchOneCurtail(cmdCtx, ev, t, models.TargetStateDrifted)
+				case models.TargetStatePending,
+					models.TargetStateResolved, models.TargetStateReleased,
+					models.TargetStateRestoreFailed:
+					// Pending rows are handled by the active closed-loop dispatch pass
+					// above. Terminal states are restorer-owned.
+				}
+			}
+		}
+	}
+	claimed := r.claimClosedLoopFullFleetTargets(ctx, ev, targets)
+	r.dispatchClaimedCurtailTargets(cmdCtx, ev, claimed)
+}
+
+func (r *Reconciler) claimClosedLoopFullFleetTargets(ctx context.Context, ev *models.Event, existingTargets []*models.Target) []*models.Target {
+	if !isClosedLoopFullFleet(ev) || (ev.State != models.EventStatePending && ev.State != models.EventStateActive) {
+		return nil
+	}
+	if curtailBatchIntervalActive(ev) && !r.curtailBatchIntervalElapsed(ev, existingTargets) {
+		return nil
+	}
+	if hasInFlightCurtailDispatch(existingTargets) {
+		return nil
+	}
+	params, ok := listCandidatesParamsForEventScope(ev)
+	if !ok {
+		slog.Warn("curtailment reconciler: unsupported closed-loop full-fleet scope",
+			"event_id", ev.ID, "scope_type", ev.ScopeType)
+		return nil
+	}
+	params.OrgID = ev.OrgID
+	candidates, err := r.store.ListCandidates(ctx, params)
+	if err != nil {
+		slog.Error("curtailment reconciler: list candidates (full_fleet admission) failed",
+			"event_id", ev.ID, "error", err)
+		return nil
+	}
+	orgConfig, err := r.store.GetOrgConfig(ctx, ev.OrgID)
+	if err != nil {
+		slog.Error("curtailment reconciler: get org config (full_fleet admission) failed",
+			"event_id", ev.ID, "error", err)
+		return nil
+	}
+	targets, _ := curtailment.BuildFullFleetAdmissionTargets(
+		candidates,
+		ev.IncludeMaintenance && ev.ForceIncludeMaintenance,
+		orgConfig.CandidateMinPowerW,
+	)
+	targets = excludeExistingTargetParams(targets, existingTargets)
+	activeDevices, err := r.store.ListActiveCurtailmentTargetDevices(ctx, ev.OrgID)
+	if err != nil {
+		slog.Error("curtailment reconciler: list active devices (full_fleet admission) failed",
+			"event_id", ev.ID, "error", err)
+		return nil
+	}
+	targets = excludeDeviceIdentifiers(targets, activeDevices)
+	if len(targets) == 0 {
+		return nil
+	}
+	if batchSize := curtailBatchSizeForEvent(ev, len(targets)); int32(len(targets)) > batchSize {
+		targets = targets[:batchSize]
+	}
+	claimed, err := r.store.ClaimClosedLoopFullFleetTargets(ctx, ev.ID, targets)
+	if err != nil {
+		slog.Error("curtailment reconciler: claim full_fleet targets failed",
+			"event_id", ev.ID, "candidate_count", len(targets), "error", err)
+		return nil
+	}
+	if len(claimed) > 0 {
+		slog.Info("curtailment reconciler: claimed full_fleet targets",
+			"event_id", ev.ID, "claimed", len(claimed))
+	}
+	return claimed
+}
+
+func hasInFlightCurtailDispatch(targets []*models.Target) bool {
+	for _, target := range targets {
+		if target.DesiredState == models.DesiredStateCurtailed && target.State == models.TargetStateDispatching {
+			return true
+		}
+	}
+	return false
+}
+
+func excludeExistingTargetParams(targets []models.InsertTargetParams, existingTargets []*models.Target) []models.InsertTargetParams {
+	if len(targets) == 0 || len(existingTargets) == 0 {
+		return targets
+	}
+	existing := make(map[string]struct{}, len(existingTargets))
+	for _, target := range existingTargets {
+		existing[target.DeviceIdentifier] = struct{}{}
+	}
+	filtered := targets[:0]
+	for _, target := range targets {
+		if _, ok := existing[target.DeviceIdentifier]; ok {
+			continue
+		}
+		filtered = append(filtered, target)
+	}
+	return filtered
+}
+
+func excludeDeviceIdentifiers(targets []models.InsertTargetParams, deviceIdentifiers []string) []models.InsertTargetParams {
+	if len(targets) == 0 || len(deviceIdentifiers) == 0 {
+		return targets
+	}
+	excluded := make(map[string]struct{}, len(deviceIdentifiers))
+	for _, deviceIdentifier := range deviceIdentifiers {
+		excluded[deviceIdentifier] = struct{}{}
+	}
+	filtered := targets[:0]
+	for _, target := range targets {
+		if _, ok := excluded[target.DeviceIdentifier]; ok {
+			continue
+		}
+		filtered = append(filtered, target)
+	}
+	return filtered
+}
+
+func (r *Reconciler) dispatchClaimedCurtailTargets(ctx context.Context, ev *models.Event, claimed []*models.Target) {
+	if len(claimed) == 0 {
+		return
+	}
+	_ = r.dispatchCurtailBatch(ctx, ev, claimed, models.TargetStateDispatching)
+}
+
+func isClosedLoopFullFleet(ev *models.Event) bool {
+	return ev != nil && ev.Mode == models.ModeFullFleet && ev.LoopType == models.LoopTypeClosed
+}
+
+func listCandidatesParamsForEventScope(ev *models.Event) (interfaces.ListCandidatesParams, bool) {
+	switch ev.ScopeType {
+	case models.ScopeTypeWholeOrg, "":
+		return interfaces.ListCandidatesParams{}, true
+	case models.ScopeTypeSite:
+		var scope struct {
+			SiteID int64 `json:"site_id"`
+		}
+		if err := json.Unmarshal(ev.ScopeJSON, &scope); err != nil || scope.SiteID <= 0 {
+			return interfaces.ListCandidatesParams{}, false
+		}
+		return interfaces.ListCandidatesParams{SiteID: &scope.SiteID}, true
+	default:
+		return interfaces.ListCandidatesParams{}, false
 	}
 }
 
@@ -689,6 +858,20 @@ func (r *Reconciler) confirmOneDispatched(ctx context.Context, ev *models.Event,
 		return
 	}
 	if !isCurtailed(c.LatestPowerW, t.BaselinePowerW, c.LatestHashRateHS, r.cfg.DriftThresholdFactor, true) {
+		if t.LastDispatchedAt != nil && r.cfg.CurtailDispatchTimeoutSec > 0 {
+			timeout := time.Duration(r.cfg.CurtailDispatchTimeoutSec) * time.Second
+			if r.now().Sub(*t.LastDispatchedAt) > timeout {
+				slog.Info("curtailment reconciler: curtail telemetry timeout aging initiated",
+					"event_id", ev.ID, "device", t.DeviceIdentifier,
+					"timeout_sec", r.cfg.CurtailDispatchTimeoutSec)
+				r.recordDispatchFailure(ctx, ev, t,
+					"curtail telemetry timeout",
+					nonTerminalState)
+				if t.State != models.TargetStateRestoreFailed {
+					r.dispatchOneCurtail(ctx, ev, t, nonTerminalState)
+				}
+			}
+		}
 		return
 	}
 	now := r.now()
@@ -749,7 +932,7 @@ func (r *Reconciler) checkDrift(ctx context.Context, ev *models.Event, t *models
 			t.ObservedPowerW = params.ObservedPowerW
 		}
 		// Budget exhausted: stay Drifted (matches observeActive's drift arm).
-		if t.RetryCount >= r.cfg.MaxRetries {
+		if t.RetryCount >= r.maxRetriesForTarget(t) {
 			return
 		}
 		r.dispatchOneCurtail(ctx, ev, t, models.TargetStateDrifted)
@@ -984,6 +1167,9 @@ func isFinite(v float64) bool {
 // caller skips further active-phase work this tick. AllowUnbounded events
 // and events without started_at short-circuit out.
 func (r *Reconciler) enforceMaxDuration(ctx context.Context, ev *models.Event, targets []*models.Target) bool {
+	if ev.Mode == models.ModeFullFleet && ev.SourceActorType == models.SourceActorAutomation {
+		return false
+	}
 	if ev.AllowUnbounded || ev.MaxDurationSeconds == nil || *ev.MaxDurationSeconds <= 0 {
 		return false
 	}
@@ -1346,6 +1532,7 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 			if !errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
 				slog.Error("curtailment reconciler: restore dispatch state update failed",
 					"event_id", ev.ID, "device", t.DeviceIdentifier, "error", err)
+				r.recordDispatchFailure(ctx, ev, t, err.Error(), models.TargetStatePending)
 			}
 			continue
 		}

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -1167,9 +1167,6 @@ func isFinite(v float64) bool {
 // caller skips further active-phase work this tick. AllowUnbounded events
 // and events without started_at short-circuit out.
 func (r *Reconciler) enforceMaxDuration(ctx context.Context, ev *models.Event, targets []*models.Target) bool {
-	if ev.Mode == models.ModeFullFleet && ev.SourceActorType == models.SourceActorAutomation {
-		return false
-	}
 	if ev.AllowUnbounded || ev.MaxDurationSeconds == nil || *ev.MaxDurationSeconds <= 0 {
 		return false
 	}

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -33,6 +33,8 @@ type fakeStore struct {
 	events           []*models.Event
 	targetsByEventID map[int64][]*models.Target
 	candidates       []*models.Candidate
+	orgConfig        *models.OrgConfig
+	activeDevices    []string
 
 	listEventsErr      error
 	listEventsCalls    int
@@ -52,10 +54,13 @@ type fakeStore struct {
 	bumpTargetRetryErr   error
 
 	listTargetsByEventCalls int
+	claimTargetsCalls       int
+	claimedTargetParams     []models.InsertTargetParams
 
-	heartbeatCalls        int
-	lastHeartbeatActive   int32
-	lastHeartbeatTickUUID uuid.UUID
+	heartbeatCalls           int
+	lastHeartbeatActive      int32
+	lastHeartbeatTickUUID    uuid.UUID
+	lastListCandidatesSiteID *int64
 
 	// BeginRestoreTransition captures, exercised by max_duration tests.
 	beginRestoreCalls       int
@@ -77,14 +82,23 @@ func newFakeStore() *fakeStore {
 	}
 }
 
-func (f *fakeStore) GetOrgConfig(context.Context, int64) (*models.OrgConfig, error) {
-	panic("GetOrgConfig not exercised")
+func (f *fakeStore) GetOrgConfig(_ context.Context, orgID int64) (*models.OrgConfig, error) {
+	if f.orgConfig != nil {
+		return f.orgConfig, nil
+	}
+	return &models.OrgConfig{
+		OrgID:              orgID,
+		CandidateMinPowerW: 1500,
+	}, nil
 }
 func (f *fakeStore) UpdateOrgConfigPostEventCooldown(context.Context, int64, int32) (*models.OrgConfig, error) {
 	panic("UpdateOrgConfigPostEventCooldown not exercised")
 }
 func (f *fakeStore) ListActiveCurtailedDevices(context.Context, int64) ([]string, error) {
-	panic("ListActiveCurtailedDevices not exercised")
+	return append([]string(nil), f.activeDevices...), nil
+}
+func (f *fakeStore) ListActiveCurtailmentTargetDevices(context.Context, int64) ([]string, error) {
+	return append([]string(nil), f.activeDevices...), nil
 }
 func (f *fakeStore) ListRecentlyResolvedCurtailedDevices(context.Context, int64, int32) ([]string, error) {
 	panic("ListRecentlyResolvedCurtailedDevices not exercised")
@@ -108,6 +122,32 @@ func (f *fakeStore) ListActiveEvents(context.Context, int64) ([]*models.Event, e
 }
 func (f *fakeStore) InsertEventWithTargets(context.Context, models.InsertEventParams, []models.InsertTargetParams) (*models.InsertEventResult, error) {
 	panic("InsertEventWithTargets not exercised")
+}
+func (f *fakeStore) ClaimClosedLoopFullFleetTargets(_ context.Context, eventID int64, targets []models.InsertTargetParams) ([]*models.Target, error) {
+	f.claimTargetsCalls++
+	f.claimedTargetParams = append([]models.InsertTargetParams(nil), targets...)
+	existing := map[string]struct{}{}
+	for _, t := range f.targetsByEventID[eventID] {
+		existing[t.DeviceIdentifier] = struct{}{}
+	}
+	var claimed []*models.Target
+	for _, target := range targets {
+		if _, ok := existing[target.DeviceIdentifier]; ok {
+			continue
+		}
+		row := &models.Target{
+			CurtailmentEventID: eventID,
+			DeviceIdentifier:   target.DeviceIdentifier,
+			TargetType:         target.TargetType,
+			State:              models.TargetStateDispatching,
+			DesiredState:       target.DesiredState,
+			BaselinePowerW:     target.BaselinePowerW,
+		}
+		f.targetsByEventID[eventID] = append(f.targetsByEventID[eventID], row)
+		claimed = append(claimed, row)
+		existing[target.DeviceIdentifier] = struct{}{}
+	}
+	return claimed, nil
 }
 func (f *fakeStore) GetHeartbeat(context.Context) (*models.Heartbeat, error) {
 	panic("GetHeartbeat not exercised")
@@ -144,6 +184,10 @@ func (f *fakeStore) GetTargetRollupByEvent(context.Context, int64, uuid.UUID) (*
 }
 
 func (f *fakeStore) ListCandidates(_ context.Context, params interfaces.ListCandidatesParams) ([]*models.Candidate, error) {
+	if params.SiteID != nil {
+		siteID := *params.SiteID
+		f.lastListCandidatesSiteID = &siteID
+	}
 	if len(params.DeviceIdentifiers) == 0 {
 		return f.candidates, nil
 	}
@@ -527,6 +571,7 @@ func newReconcilerForTest(store *fakeStore, disp *fakeDispatcher) *Reconciler {
 		TickInterval:         time.Hour, // tests drive runTick directly
 		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
+		CurtailMaxRetries:    3,
 		DriftThresholdFactor: 0.5,
 	}, store, disp)
 	r.now = func() time.Time { return time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC) }
@@ -633,6 +678,211 @@ func TestReconciler_PendingDispatchesLargeEventInBoundedBatches(t *testing.T) {
 	for _, target := range store.targetsByEventID[eventID] {
 		assert.Equal(t, models.TargetStateDispatched, target.State)
 	}
+}
+
+func TestReconciler_PendingClosedLoopFullFleetWithoutTargetsMarksActive(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	store.events = []*models.Event{
+		{
+			ID:        eventID,
+			EventUUID: eventUUID,
+			OrgID:     1,
+			State:     models.EventStatePending,
+			Mode:      models.ModeFullFleet,
+			LoopType:  models.LoopTypeClosed,
+			ScopeType: models.ScopeTypeWholeOrg,
+		},
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	assert.Equal(t, 0, disp.curtailCalls)
+	assert.Equal(t, models.EventStateActive, store.updateEventLast[eventID],
+		"empty closed-loop full_fleet pending event should become an active watcher")
+}
+
+func TestReconciler_ActiveClosedLoopFullFleetAdmitsAndDispatchesNewTarget(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	store.events = []*models.Event{
+		{
+			ID:              eventID,
+			EventUUID:       eventUUID,
+			OrgID:           1,
+			State:           models.EventStateActive,
+			Mode:            models.ModeFullFleet,
+			LoopType:        models.LoopTypeClosed,
+			ScopeType:       models.ScopeTypeWholeOrg,
+			CreatedByUserID: 99,
+		},
+	}
+	driver := "antminer"
+	now := time.Now()
+	store.candidates = []*models.Candidate{
+		{
+			DeviceIdentifier: "miner-new",
+			DriverName:       &driver,
+			DeviceStatus:     "ACTIVE",
+			PairingStatus:    "PAIRED",
+			LatestMetricsAt:  &now,
+			LatestPowerW:     ptrFloat64(100),
+			LatestHashRateHS: ptrFloat64(100),
+			AvgEfficiencyJH:  ptrFloat64(40),
+		},
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	assert.Equal(t, 1, store.claimTargetsCalls)
+	require.Len(t, store.targetsByEventID[eventID], 1)
+	target := store.targetsByEventID[eventID][0]
+	assert.Equal(t, "miner-new", target.DeviceIdentifier)
+	assert.Nil(t, target.BaselinePowerW, "below-floor full_fleet target should use hash confirmation fallback")
+	assert.Equal(t, 1, disp.curtailCalls)
+	assert.ElementsMatch(t, []string{"miner-new"}, disp.curtailLastIDs)
+	assert.Equal(t, models.TargetStateDispatched, target.State)
+}
+
+func TestReconciler_ActiveClosedLoopFullFleetClaimsOnlyOneCurtailBatch(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	batchSize := int32(2)
+	store.events = []*models.Event{
+		{
+			ID:               eventID,
+			EventUUID:        eventUUID,
+			OrgID:            1,
+			State:            models.EventStateActive,
+			Mode:             models.ModeFullFleet,
+			LoopType:         models.LoopTypeClosed,
+			ScopeType:        models.ScopeTypeWholeOrg,
+			CurtailBatchSize: &batchSize,
+			CreatedByUserID:  99,
+		},
+	}
+	driver := "antminer"
+	now := time.Now()
+	for _, id := range []string{"miner-a", "miner-b", "miner-c"} {
+		store.candidates = append(store.candidates, &models.Candidate{
+			DeviceIdentifier: id,
+			DriverName:       &driver,
+			DeviceStatus:     "ACTIVE",
+			PairingStatus:    "PAIRED",
+			LatestMetricsAt:  &now,
+			LatestPowerW:     ptrFloat64(3000),
+			LatestHashRateHS: ptrFloat64(100),
+			AvgEfficiencyJH:  ptrFloat64(40),
+		})
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	assert.Equal(t, 1, store.claimTargetsCalls)
+	require.Len(t, store.claimedTargetParams, 2,
+		"dynamic claims must respect curtail_batch_size before inserting DISPATCHING rows")
+	assert.Equal(t, 1, disp.curtailCalls)
+	assert.Len(t, disp.curtailLastIDs, 2)
+	assert.Len(t, store.targetsByEventID[eventID], 2)
+}
+
+func TestReconciler_ActiveClosedLoopFullFleetSkipsConflictsBeforeBatchLimit(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	batchSize := int32(2)
+	store.events = []*models.Event{
+		{
+			ID:               eventID,
+			EventUUID:        eventUUID,
+			OrgID:            1,
+			State:            models.EventStateActive,
+			Mode:             models.ModeFullFleet,
+			LoopType:         models.LoopTypeClosed,
+			ScopeType:        models.ScopeTypeWholeOrg,
+			CurtailBatchSize: &batchSize,
+			CreatedByUserID:  99,
+		},
+	}
+	driver := "antminer"
+	now := time.Now()
+	for _, id := range []string{"conflict-a", "conflict-b", "miner-c", "miner-d"} {
+		store.candidates = append(store.candidates, &models.Candidate{
+			DeviceIdentifier: id,
+			DriverName:       &driver,
+			DeviceStatus:     "ACTIVE",
+			PairingStatus:    "PAIRED",
+			LatestMetricsAt:  &now,
+			LatestPowerW:     ptrFloat64(3000),
+			LatestHashRateHS: ptrFloat64(100),
+			AvgEfficiencyJH:  ptrFloat64(40),
+		})
+	}
+	store.activeDevices = []string{"conflict-a", "conflict-b"}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	require.Len(t, store.claimedTargetParams, 2)
+	assert.Equal(t, "miner-c", store.claimedTargetParams[0].DeviceIdentifier)
+	assert.Equal(t, "miner-d", store.claimedTargetParams[1].DeviceIdentifier)
+	assert.ElementsMatch(t, []string{"miner-c", "miner-d"}, disp.curtailLastIDs)
+}
+
+func TestReconciler_ActiveClosedLoopFullFleetUsesPersistedSiteScope(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	siteID := int64(77)
+	store.events = []*models.Event{
+		{
+			ID:              eventID,
+			EventUUID:       eventUUID,
+			OrgID:           1,
+			State:           models.EventStateActive,
+			Mode:            models.ModeFullFleet,
+			LoopType:        models.LoopTypeClosed,
+			ScopeType:       models.ScopeTypeSite,
+			ScopeJSON:       []byte(`{"site_id":77}`),
+			CreatedByUserID: 99,
+		},
+	}
+	driver := "antminer"
+	now := time.Now()
+	store.candidates = []*models.Candidate{
+		{
+			DeviceIdentifier: "site-miner",
+			DriverName:       &driver,
+			DeviceStatus:     "ACTIVE",
+			PairingStatus:    "PAIRED",
+			LatestMetricsAt:  &now,
+			LatestPowerW:     ptrFloat64(3000),
+			LatestHashRateHS: ptrFloat64(100),
+		},
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	require.NotNil(t, store.lastListCandidatesSiteID)
+	assert.Equal(t, siteID, *store.lastListCandidatesSiteID)
+	assert.ElementsMatch(t, []string{"site-miner"}, disp.curtailLastIDs)
 }
 
 func TestReconciler_DispatchingFailureDoesNotRetryAgainAsPendingInSameTick(t *testing.T) {
@@ -1608,6 +1858,40 @@ func TestReconciler_MissingCandidateDuringConfirmConsumesRetryBudget(t *testing.
 	assert.Contains(t, *final.LastError, "candidate row missing")
 }
 
+func TestReconciler_CurtailConfirmationTimeoutConsumesRetryBudget(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	dispatchedAt := time.Date(2026, 5, 7, 11, 59, 40, 0, time.UTC)
+	store.events = []*models.Event{
+		{ID: eventID, EventUUID: eventUUID, OrgID: 1, State: models.EventStatePending},
+	}
+	store.targetsByEventID[eventID] = []*models.Target{
+		{
+			CurtailmentEventID: eventID,
+			DeviceIdentifier:   "slow-confirm",
+			State:              models.TargetStateDispatched,
+			LastDispatchedAt:   &dispatchedAt,
+			BaselinePowerW:     ptrFloat64(3000),
+			RetryCount:         0,
+		},
+	}
+	store.candidates = []*models.Candidate{
+		{DeviceIdentifier: "slow-confirm", LatestPowerW: ptrFloat64(3000), LatestHashRateHS: ptrFloat64(100)},
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	final := store.targetsByEventID[eventID][0]
+	assert.Equal(t, models.TargetStateDispatched, final.State)
+	assert.Equal(t, int32(1), final.RetryCount)
+	assert.Nil(t, final.LastError, "successful redispatch clears the transient timeout error")
+	assert.Equal(t, 1, disp.curtailCalls, "timed-out curtail target should be retried")
+}
+
 // Mirror of MissingCandidateDuringConfirm for the drift path: a
 // vanished candidate burns retry budget toward RestoreFailed.
 func TestReconciler_MissingCandidateDuringDriftConsumesRetryBudget(t *testing.T) {
@@ -2099,6 +2383,41 @@ func TestReconciler_StartIdempotency(t *testing.T) {
 	require.NoError(t, r.Stop())
 	// Second Stop is a no-op too; verify no panic / goroutine deadlock.
 	require.NoError(t, r.Stop())
+}
+
+func TestReconciler_StartRejectsSubSecondTickInterval(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+	r := New(Config{TickInterval: 500 * time.Millisecond, ShutdownDeadline: time.Second}, store, disp)
+
+	err := r.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tick_interval must be at least 1s")
+}
+
+func TestReconciler_StartRejectsInvalidCurtailDispatchTimeout(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+	r := New(Config{
+		TickInterval:              time.Hour,
+		ShutdownDeadline:          time.Second,
+		CurtailDispatchTimeoutSec: -1,
+	}, store, disp)
+
+	err := r.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "curtail_dispatch_timeout_sec must be at least 1")
+}
+
+func TestReconciler_ConfigDefaultsDispatchTimeouts(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+	r := New(Config{TickInterval: time.Hour, ShutdownDeadline: time.Second}, store, disp)
+
+	assert.Equal(t, int32(10), r.cfg.MaxRetries)
+	assert.Equal(t, int32(50), r.cfg.CurtailMaxRetries)
+	assert.Equal(t, 5, r.cfg.CurtailDispatchTimeoutSec)
+	assert.Equal(t, 30, r.cfg.RestoreDispatchTimeoutSec)
 }
 
 // --- isCurtailed unit tests ---

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -752,6 +752,51 @@ func TestReconciler_ActiveClosedLoopFullFleetAdmitsAndDispatchesNewTarget(t *tes
 	assert.Equal(t, models.TargetStateDispatched, target.State)
 }
 
+func TestReconciler_ActiveClosedLoopFullFleetUsesPersistedCandidateFloor(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	store.orgConfig = &models.OrgConfig{OrgID: 1, CandidateMinPowerW: 1500}
+	store.events = []*models.Event{
+		{
+			ID:                   eventID,
+			EventUUID:            eventUUID,
+			OrgID:                1,
+			State:                models.EventStateActive,
+			Mode:                 models.ModeFullFleet,
+			LoopType:             models.LoopTypeClosed,
+			ScopeType:            models.ScopeTypeWholeOrg,
+			DecisionSnapshotJSON: []byte(`{"candidate_min_power_w":500}`),
+			CreatedByUserID:      99,
+		},
+	}
+	driver := "antminer"
+	now := time.Now()
+	store.candidates = []*models.Candidate{
+		{
+			DeviceIdentifier: "miner-low",
+			DriverName:       &driver,
+			DeviceStatus:     "ACTIVE",
+			PairingStatus:    "PAIRED",
+			LatestMetricsAt:  &now,
+			LatestPowerW:     ptrFloat64(800),
+			LatestHashRateHS: ptrFloat64(100),
+			AvgEfficiencyJH:  ptrFloat64(40),
+		},
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	require.Len(t, store.targetsByEventID[eventID], 1)
+	target := store.targetsByEventID[eventID][0]
+	require.NotNil(t, target.BaselinePowerW,
+		"dynamic admission must use the floor resolved at Start, not a later org default")
+	assert.Equal(t, 800.0, *target.BaselinePowerW)
+}
+
 func TestReconciler_ActiveClosedLoopFullFleetClaimsOnlyOneCurtailBatch(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
@@ -1415,9 +1460,9 @@ func TestReconciler_RecoversOrphanedDispatchingTargetOnActiveEvent(t *testing.T)
 // terminalize on the next tick rather than loop forever in DISPATCHING.
 // The recordDispatchFailure fallback (BumpTargetRetry on writeTargetState
 // failure) can leave a target in DISPATCHING with a bumped retry count,
-// so observeActive must escalate exhausted orphans through the same
-// helper to reach RESTORE_FAILED.
-func TestReconciler_ObserveActive_ExhaustedDispatchingOrphanEscalates(t *testing.T) {
+// so observeActive must keep curtailed targets retryable even after the alert
+// threshold is reached.
+func TestReconciler_ObserveActive_ExhaustedCurtailDispatchingOrphanKeepsRetrying(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
 
@@ -1443,14 +1488,12 @@ func TestReconciler_ObserveActive_ExhaustedDispatchingOrphanEscalates(t *testing
 	r := newReconcilerForTest(store, disp)
 	r.runTick(context.Background())
 
-	assert.Equal(t, 0, disp.curtailCalls,
-		"exhausted DISPATCHING orphan must not be redispatched")
+	assert.Equal(t, 1, disp.curtailCalls,
+		"curtailment retry threshold surfaces an alert but does not abandon an asserted OFF policy")
 	final := store.targetsByEventID[eventID][0]
-	assert.Equal(t, models.TargetStateRestoreFailed, final.State,
-		"exhausted DISPATCHING orphan must escalate to RESTORE_FAILED via recordDispatchFailure")
-	assert.Equal(t, int32(4), final.RetryCount,
-		"recordDispatchFailure bumps retry_count once more on escalation")
-	require.NotNil(t, final.LastError, "escalation records a last_error")
+	assert.Equal(t, models.TargetStateDispatched, final.State)
+	assert.Equal(t, int32(3), final.RetryCount)
+	assert.Nil(t, final.LastError, "successful redispatch clears the alert error")
 }
 
 // A race-loss on the orphan-redispatch pre-write must not fire Curtail
@@ -1620,9 +1663,9 @@ func TestReconciler_DriftDetectionRetriesDispatch(t *testing.T) {
 // A Drifted target whose retry_count already sits at MaxRetries must
 // escalate to the terminal state rather than loop in Drifted. Mirrors
 // the DISPATCHING arm: BumpTargetRetry's fallback can bump retry_count
-// past the budget without a state transition, so observeActive routes
-// exhausted Drifted through recordDispatchFailure to reach RESTORE_FAILED.
-func TestReconciler_RetryExhaustedDriftedEscalatesToRestoreFailed(t *testing.T) {
+// past the alert threshold without a state transition, so observeActive keeps
+// curtailed Drifted targets retryable while OFF is asserted.
+func TestReconciler_RetryExhaustedCurtailDriftedKeepsRetrying(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
 
@@ -1638,14 +1681,12 @@ func TestReconciler_RetryExhaustedDriftedEscalatesToRestoreFailed(t *testing.T) 
 	r := newReconcilerForTest(store, disp)
 	r.runTick(context.Background())
 
-	assert.Equal(t, 0, disp.curtailCalls,
-		"exhausted Drifted target must not be re-dispatched")
+	assert.Equal(t, 1, disp.curtailCalls,
+		"curtailment retry threshold surfaces an alert but does not abandon an asserted OFF policy")
 	final := store.targetsByEventID[eventID][0]
-	assert.Equal(t, models.TargetStateRestoreFailed, final.State,
-		"exhausted Drifted target must escalate to RESTORE_FAILED via recordDispatchFailure")
-	assert.Equal(t, int32(4), final.RetryCount,
-		"recordDispatchFailure bumps retry_count once more on escalation")
-	require.NotNil(t, final.LastError, "escalation records a last_error")
+	assert.Equal(t, models.TargetStateDispatched, final.State)
+	assert.Equal(t, int32(3), final.RetryCount)
+	assert.Nil(t, final.LastError, "successful redispatch clears the alert error")
 }
 
 func TestReconciler_PerEventErrorIsolation(t *testing.T) {
@@ -1886,10 +1927,55 @@ func TestReconciler_CurtailConfirmationTimeoutConsumesRetryBudget(t *testing.T) 
 	r.runTick(context.Background())
 
 	final := store.targetsByEventID[eventID][0]
-	assert.Equal(t, models.TargetStateDispatched, final.State)
+	assert.Equal(t, models.TargetStateDispatching, final.State)
 	assert.Equal(t, int32(1), final.RetryCount)
-	assert.Nil(t, final.LastError, "successful redispatch clears the transient timeout error")
-	assert.Equal(t, 1, disp.curtailCalls, "timed-out curtail target should be retried")
+	require.NotNil(t, final.LastError)
+	assert.Contains(t, *final.LastError, "curtail telemetry timeout")
+	assert.Equal(t, 0, disp.curtailCalls, "timeout retry should wait for the batch-aware dispatch path")
+}
+
+func TestReconciler_ActiveCurtailConfirmationTimeoutRespectsBatchLimit(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	batchSize := int32(1)
+	dispatchedAt := time.Date(2026, 5, 7, 11, 59, 40, 0, time.UTC)
+	store.events = []*models.Event{
+		{
+			ID:                      eventID,
+			EventUUID:               eventUUID,
+			OrgID:                   1,
+			State:                   models.EventStateActive,
+			CurtailBatchSize:        &batchSize,
+			CurtailBatchIntervalSec: 60,
+		},
+	}
+	for _, id := range []string{"slow-a", "slow-b"} {
+		store.targetsByEventID[eventID] = append(store.targetsByEventID[eventID], &models.Target{
+			CurtailmentEventID: eventID,
+			DeviceIdentifier:   id,
+			State:              models.TargetStateDispatched,
+			DesiredState:       models.DesiredStateCurtailed,
+			LastDispatchedAt:   &dispatchedAt,
+			BaselinePowerW:     ptrFloat64(3000),
+		})
+		store.candidates = append(store.candidates, &models.Candidate{
+			DeviceIdentifier: id,
+			LatestPowerW:     ptrFloat64(3000),
+			LatestHashRateHS: ptrFloat64(100),
+		})
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	require.Equal(t, 1, disp.curtailCalls, "timed-out retries must drain through the configured batch limit")
+	require.Len(t, disp.curtailCallIDs, 1)
+	assert.Len(t, disp.curtailCallIDs[0], 1)
+	assert.Equal(t, int32(1), store.targetsByEventID[eventID][0].RetryCount)
+	assert.Equal(t, int32(1), store.targetsByEventID[eventID][1].RetryCount)
 }
 
 // Mirror of MissingCandidateDuringConfirm for the drift path: a
@@ -1948,11 +2034,10 @@ func TestReconciler_DispatchEmptyBatchKeepsTargetPending(t *testing.T) {
 	assert.Equal(t, int32(1), final.RetryCount, "empty batch counts toward retry budget")
 }
 
-// TestReconciler_DispatchFailureExhaustionMarksRestoreFailedAndEventActive:
-// after MaxRetries dispatch failures the target moves to RestoreFailed; the
-// event then promotes to active because every other target has confirmed
-// (here: a single failing target → completed_with_failures).
-func TestReconciler_DispatchFailureExhaustionTransitionsTerminal(t *testing.T) {
+// TestReconciler_DispatchFailureExhaustionKeepsCurtailRetrying:
+// after CurtailMaxRetries dispatch failures the target remains retryable while
+// the curtailment demand is asserted; retry_count is the operator alert.
+func TestReconciler_DispatchFailureExhaustionKeepsCurtailRetrying(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{curtailErr: errors.New("queue down")}
 
@@ -1976,12 +2061,11 @@ func TestReconciler_DispatchFailureExhaustionTransitionsTerminal(t *testing.T) {
 	assert.Equal(t, models.TargetStatePending, store.targetsByEventID[eventID][0].State)
 	assert.Equal(t, int32(2), store.targetsByEventID[eventID][0].RetryCount)
 
-	// Tick 3 hits MaxRetries=3 and promotes the target to RestoreFailed; the
-	// event has no confirmed target so it transitions to completed_with_failures.
+	// Tick 3 hits CurtailMaxRetries=3 but stays pending for the next retry.
 	r.runTick(context.Background())
-	assert.Equal(t, models.TargetStateRestoreFailed, store.targetsByEventID[eventID][0].State)
+	assert.Equal(t, models.TargetStatePending, store.targetsByEventID[eventID][0].State)
 	assert.Equal(t, int32(3), store.targetsByEventID[eventID][0].RetryCount)
-	assert.Equal(t, models.EventStateCompletedWithFailures, store.updateEventLast[eventID])
+	assert.Empty(t, store.updateEventLast[eventID])
 }
 
 // TestReconciler_PendingPromotesActiveWithMixedTerminalTargets: a confirmed
@@ -2150,16 +2234,17 @@ func TestReconciler_DriftFailedRedispatchConsumesOneBudgetPerAttempt(t *testing.
 	assert.Equal(t, models.TargetStateDrifted, final.State)
 	assert.Equal(t, int32(2), final.RetryCount)
 
-	// Tick 3: drifted → redispatch fails → RetryCount=3 hits cap → RestoreFailed.
+	// Tick 3: drifted → redispatch fails → RetryCount=3 reaches the alert
+	// threshold but stays retryable while OFF is asserted.
 	r.runTick(context.Background())
 	final = store.targetsByEventID[eventID][0]
-	assert.Equal(t, models.TargetStateRestoreFailed, final.State)
+	assert.Equal(t, models.TargetStateDrifted, final.State)
 	assert.Equal(t, int32(3), final.RetryCount)
 
-	// Exactly 3 dispatch attempts — not 6. Each cycle consumes one budget slot,
+	// Exactly 3 dispatch attempts — not 6. Each cycle consumes one alert slot,
 	// not two. (Old bug: checkDrift bumped retry, then recordDispatchFailure
 	// bumped again, halving the effective budget.)
-	assert.Equal(t, 3, disp.curtailCalls, "MaxRetries=3 should map to exactly 3 dispatch attempts")
+	assert.Equal(t, 3, disp.curtailCalls, "CurtailMaxRetries=3 should map to exactly 3 alert-counted attempts")
 }
 
 // TestReconciler_DriftFailedRedispatchStaysDriftedNotPending: when an

--- a/server/internal/domain/curtailment/reconciler/restore_test.go
+++ b/server/internal/domain/curtailment/reconciler/restore_test.go
@@ -219,6 +219,37 @@ func TestReconciler_Restoring_ClaimDispatchesUncurtailBatch(t *testing.T) {
 		"batched Uncurtail targets must share a single batch_uuid")
 }
 
+func TestReconciler_Restoring_PostCommandStateWriteFailureConsumesRetry(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	r := newReconcilerForTest(store, disp)
+	eventID := int64(32)
+	store.events = []*models.Event{{
+		ID:        eventID,
+		EventUUID: uuid.New(),
+		OrgID:     1,
+		State:     models.EventStateRestoring,
+	}}
+	store.targetsByEventID[eventID] = []*models.Target{
+		{CurtailmentEventID: eventID, DeviceIdentifier: "m1", State: models.TargetStatePending, DesiredState: models.DesiredStateActive, BaselinePowerW: ptrFloat64(3000)},
+	}
+	store.updateTargetStateHook = func(_ string, params interfaces.UpdateCurtailmentTargetStateParams, call int) error {
+		if call == 2 && params.State == models.TargetStateDispatched {
+			return errors.New("post-command write failed")
+		}
+		return nil
+	}
+
+	r.runTick(context.Background())
+
+	final := store.targetsByEventID[eventID][0]
+	assert.Equal(t, models.TargetStatePending, final.State)
+	assert.Equal(t, int32(1), final.RetryCount)
+	require.NotNil(t, final.LastError)
+	assert.Contains(t, *final.LastError, "post-command write failed")
+}
+
 func TestReconciler_Restoring_InFlightGateBlocksClaim(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
@@ -797,7 +828,7 @@ func TestReconciler_Restoring_DispatchedAgesOutToRestoreFailed(t *testing.T) {
 	disp := &fakeDispatcher{}
 
 	r := newReconcilerForTest(store, disp)
-	// Dispatched 10 minutes ago — well past the 5-minute default timeout.
+	// Dispatched 10 minutes ago — well past the 30-second default timeout.
 	lastDispatch := r.now().Add(-10 * time.Minute)
 	eventID := int64(60)
 	store.events = []*models.Event{{
@@ -846,8 +877,8 @@ func TestReconciler_Restoring_DispatchedWithinTimeoutDoesNotFail(t *testing.T) {
 	disp := &fakeDispatcher{}
 
 	r := newReconcilerForTest(store, disp)
-	// Dispatched 1 minute ago — well under the 5-minute default timeout.
-	lastDispatch := r.now().Add(-1 * time.Minute)
+	// Dispatched recently — under the 30-second default timeout.
+	lastDispatch := r.now().Add(-10 * time.Second)
 	eventID := int64(61)
 	store.events = []*models.Event{{
 		ID:        eventID,

--- a/server/internal/domain/curtailment/response_profile.go
+++ b/server/internal/domain/curtailment/response_profile.go
@@ -193,6 +193,9 @@ func validateResponseProfileBehavior(profile models.ResponseProfile, canUseAdmin
 	if profile.Mode == models.ModeFullFleet && (profile.TargetKW != nil || profile.ToleranceKW != nil) {
 		return fleeterror.NewInvalidArgumentError("target_kw and tolerance_kw must be unset for FULL_FLEET response profiles")
 	}
+	if responseProfileRequiresAdminControls(profile) && !canUseAdminControls {
+		return fleeterror.NewForbiddenError("only admins can save response profiles with admin-only controls")
+	}
 	if profile.TargetKW != nil && math.IsInf(*profile.TargetKW, 0) {
 		return fleeterror.NewInvalidArgumentErrorf("target_kw must be finite, got %v", *profile.TargetKW)
 	}

--- a/server/internal/domain/curtailment/response_profile.go
+++ b/server/internal/domain/curtailment/response_profile.go
@@ -281,7 +281,8 @@ func validateResponseProfileBehavior(profile models.ResponseProfile, canUseAdmin
 }
 
 func responseProfileRequiresAdminControls(profile models.ResponseProfile) bool {
-	return profile.ForceIncludeMaintenance ||
+	return profile.Mode == models.ModeFullFleet ||
+		profile.ForceIncludeMaintenance ||
 		profile.CurtailBatchIntervalSec > nonAdminRestoreBatchIntervalMax ||
 		profile.RestoreBatchIntervalSec > nonAdminRestoreBatchIntervalMax
 }

--- a/server/internal/domain/curtailment/response_profile_test.go
+++ b/server/internal/domain/curtailment/response_profile_test.go
@@ -239,6 +239,13 @@ func TestResponseProfileService_CreateRejectsNonAdminOverrides(t *testing.T) {
 				profile.ForceIncludeMaintenance = true
 			},
 		},
+		{
+			name: "full fleet mode",
+			mutate: func(profile *models.ResponseProfile) {
+				profile.Mode = models.ModeFullFleet
+				profile.TargetKW = nil
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/server/internal/domain/curtailment/selector.go
+++ b/server/internal/domain/curtailment/selector.go
@@ -71,6 +71,9 @@ type Plan struct {
 	InsufficientLoadDetail *modes.InsufficientLoadDetail
 	// EventUUID is set by Service.Start after persisting; nil for Preview.
 	EventUUID *uuid.UUID
+	// StartedAt is set by Service.Start for events inserted already active;
+	// echoed in the Start response so it matches the stamped row.
+	StartedAt *time.Time
 	// EndedAt is set by Service.Start only when an event is persisted already
 	// terminal (an empty FULL_FLEET start); echoed in the Start response so it
 	// matches the stamped row. nil otherwise.

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -1549,6 +1549,8 @@ func isClosedLoopFullFleetStart(scope Scope, mode models.Mode) bool {
 	switch scope.Type {
 	case models.ScopeTypeWholeOrg, models.ScopeTypeSite, "":
 		return true
+	case models.ScopeTypeDeviceSets, models.ScopeTypeDeviceList:
+		return false
 	default:
 		return false
 	}

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -33,15 +33,12 @@ type Scope struct {
 
 // PreviewRequest is the service-level shape of a Preview call.
 type PreviewRequest struct {
-	OrgID    int64
-	Scope    Scope
-	Mode     models.Mode     // must be ModeFixedKw
-	Strategy models.Strategy // default StrategyLeastEfficientFirst
-	Level    models.Level    // must be LevelFull
-	Priority models.Priority // PriorityNormal or PriorityEmergency (cooldown bypass)
-	// BypassCooldown lets trusted internal callers skip post-event cooldown
-	// without changing the persisted priority/audit value on the event.
-	BypassCooldown             bool
+	OrgID                      int64
+	Scope                      Scope
+	Mode                       models.Mode     // must be ModeFixedKw
+	Strategy                   models.Strategy // default StrategyLeastEfficientFirst
+	Level                      models.Level    // must be LevelFull
+	Priority                   models.Priority // PriorityNormal or PriorityEmergency
 	TargetKW                   float64
 	ToleranceKW                float64
 	IncludeMaintenance         bool
@@ -253,10 +250,10 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 		now := time.Now().UTC()
 		eventParams.EndedAt = &now
 	}
-	// Carry the stamped completion time into the Plan so the synchronous Start
-	// response matches the persisted row (otherwise a later Get/List shows
-	// ended_at but the Start response does not).
+	// Carry stamped lifecycle times into the Plan so the synchronous Start
+	// response matches the persisted row (otherwise a later Get/List diverges).
 	plan.EndedAt = eventParams.EndedAt
+	plan.StartedAt = eventParams.StartedAt
 
 	result, err := s.store.InsertEventWithTargets(ctx, eventParams, targetParams)
 	if err != nil {
@@ -935,23 +932,11 @@ func (s *Service) runSelector(ctx context.Context, req PreviewRequest) (*Plan, i
 		minPowerW = *req.CandidateMinPowerWOverride
 	}
 
-	// EMERGENCY and trusted automation starts skip post_event_cooldown_sec.
-	bypassCooldown := req.Priority == models.PriorityEmergency || req.BypassCooldown
-
 	activeDevices, err := s.store.ListActiveCurtailedDevices(ctx, req.OrgID)
 	if err != nil {
 		return nil, 0, nil, err
 	}
 	activeSet := toStringSet(activeDevices)
-
-	cooldownSet := map[string]struct{}{}
-	if !bypassCooldown {
-		cd, err := s.store.ListRecentlyResolvedCurtailedDevices(ctx, req.OrgID, orgConfig.PostEventCooldownSec)
-		if err != nil {
-			return nil, 0, nil, err
-		}
-		cooldownSet = toStringSet(cd)
-	}
 
 	candidateFilter.OrgID = req.OrgID
 	candidates, err := s.store.ListCandidates(ctx, candidateFilter)
@@ -975,7 +960,6 @@ func (s *Service) runSelector(ctx context.Context, req PreviewRequest) (*Plan, i
 	eligible, preFiltered, summary := classifyCandidates(candidates, classifyOpts{
 		IncludeMaintenance: req.IncludeMaintenance && req.ForceIncludeMaintenance,
 		ActiveEventDevices: activeSet,
-		CooldownDevices:    cooldownSet,
 		CandidateMinPowerW: minPowerW,
 	})
 
@@ -1254,7 +1238,6 @@ func resolveScope(s Scope) (interfaces.ListCandidatesParams, error) {
 type classifyOpts struct {
 	IncludeMaintenance bool
 	ActiveEventDevices map[string]struct{}
-	CooldownDevices    map[string]struct{}
 	CandidateMinPowerW int32
 }
 
@@ -1326,11 +1309,6 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 		if !hasNonNegativeFiniteFloat(c.LatestPowerW) || !hasNonNegativeFiniteFloat(c.LatestHashRateHS) {
 			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipStaleTelemetry})
 			summary.ExcludedStale++
-			continue
-		}
-		if _, cooled := opts.CooldownDevices[c.DeviceIdentifier]; cooled {
-			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipCooldown})
-			summary.ExcludedCooldown++
 			continue
 		}
 		// Non-finite avg_efficiency breaks sort transitivity; rank last.

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -187,8 +187,9 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 		// Defense-in-depth; FIXED_KW's validator + selector prevent this.
 		return nil, fleeterror.NewInvalidArgumentError("no targets selected")
 	}
-	// FULL_FLEET with a genuinely empty scope is valid (nothing curtailable ==
-	// vacuously off); it persists directly COMPLETED with no targets below.
+	// FULL_FLEET with a genuinely empty scope is valid (nothing currently
+	// curtailable). Closed-loop scopes persist an active watcher so newly
+	// eligible miners can be admitted while the event is asserted.
 	// runSelector rejects the unsafe non-empty/all-skipped case before this
 	// point so automation cannot interpret "nothing actionable curtailed" as
 	// satisfied.
@@ -984,47 +985,7 @@ func (s *Service) runSelector(ctx context.Context, req PreviewRequest) (*Plan, i
 	}
 
 	plan := BuildPlan(eligible, preFiltered, minPowerW, mode)
-	if req.Mode == models.ModeFullFleet && len(plan.Selected) == 0 && len(plan.Skipped) > 0 {
-		detail := fullFleetAllSkippedDetail(plan.Skipped, minPowerW)
-		plan.Outcome = modes.OutcomeInsufficientLoad
-		plan.InsufficientLoadDetail = &detail
-	}
 	return &plan, minPowerW, orgConfig, nil
-}
-
-func fullFleetAllSkippedDetail(skipped []SkippedDevice, minPowerW int32) modes.InsufficientLoadDetail {
-	detail := modes.InsufficientLoadDetail{CandidateMinPowerW: minPowerW}
-	for _, skip := range skipped {
-		switch skip.Reason {
-		case SkipBelowThreshold:
-			detail.ExcludedBelowThreshold++
-		case SkipPhantomLoadNoHash:
-			detail.ExcludedPhantomLoad++
-		case SkipPowerTelemetryUnreliable:
-			detail.ExcludedDeadMonitor++
-		case SkipUnreachableResidualLoad:
-			detail.ExcludedOffline++
-		case SkipMaintenance:
-			detail.ExcludedMaintenance++
-		case SkipUpdating:
-			detail.ExcludedUpdating++
-		case SkipRebootRequired:
-			detail.ExcludedRebootRequired++
-		case SkipStaleTelemetry:
-			detail.ExcludedStale++
-		case SkipNonActionableStatus:
-			detail.ExcludedNonActionable++
-		case SkipPairing:
-			detail.ExcludedPairing++
-		case SkipCooldown:
-			detail.ExcludedCooldown++
-		case SkipActiveEvent:
-			detail.ExcludedActiveEvent++
-		case SkipCurtailFullUnsupported:
-			detail.ExcludedCapabilityMiss++
-		}
-	}
-	return detail
 }
 
 // buildMode constructs the selection mode from the request. FULL_FLEET takes
@@ -1472,7 +1433,7 @@ func buildInsertParams(req StartRequest, plan *Plan, minPowerW int32) (models.In
 	event := models.InsertEventParams{
 		EventUUID:               uuid.New(),
 		OrgID:                   req.OrgID,
-		State:                   eventStartState(mode, len(plan.Selected)),
+		State:                   eventStartState(req.Scope, mode, len(plan.Selected)),
 		Mode:                    mode,
 		Strategy:                models.StrategyLeastEfficientFirst,
 		Level:                   models.LevelFull,
@@ -1507,8 +1468,26 @@ func buildInsertParams(req StartRequest, plan *Plan, minPowerW int32) (models.In
 		event.ScopeType = models.ScopeTypeWholeOrg
 	}
 
-	targets := make([]models.InsertTargetParams, len(plan.Selected))
-	for i, sel := range plan.Selected {
+	if isClosedLoopFullFleetStart(req.Scope, mode) {
+		event.LoopType = models.LoopTypeClosed
+	}
+	if event.State == models.EventStateActive && event.StartedAt == nil {
+		now := time.Now().UTC()
+		event.StartedAt = &now
+	}
+
+	var targets []models.InsertTargetParams
+	if !isClosedLoopFullFleetStart(req.Scope, mode) {
+		targets = BuildInsertTargetParams(plan.Selected, mode, minPowerW)
+	}
+	return event, targets, nil
+}
+
+// BuildInsertTargetParams converts selected devices into miner target rows.
+// Reconciler dynamic admission reuses the same baseline semantics as Start.
+func BuildInsertTargetParams(selected []SelectedDevice, mode models.Mode, minPowerW int32) []models.InsertTargetParams {
+	targets := make([]models.InsertTargetParams, len(selected))
+	for i, sel := range selected {
 		var baseline *float64
 		if shouldPersistBaselinePowerW(mode, sel.PowerW, minPowerW) {
 			v := sel.PowerW
@@ -1522,7 +1501,22 @@ func buildInsertParams(req StartRequest, plan *Plan, minPowerW int32) (models.In
 			BaselinePowerW:   baseline,
 		}
 	}
-	return event, targets, nil
+	return targets
+}
+
+// BuildFullFleetAdmissionTargets applies the same full-fleet eligibility and
+// baseline policy used by Start, for reconciler closed-loop admission.
+func BuildFullFleetAdmissionTargets(
+	candidates []*models.Candidate,
+	includeMaintenance bool,
+	minPowerW int32,
+) ([]models.InsertTargetParams, []SkippedDevice) {
+	eligible, skipped, _ := classifyCandidates(candidates, classifyOpts{
+		IncludeMaintenance: includeMaintenance,
+		CandidateMinPowerW: minPowerW,
+	})
+	plan := BuildPlan(eligible, skipped, minPowerW, modes.FullFleet{})
+	return BuildInsertTargetParams(plan.Selected, models.ModeFullFleet, minPowerW), plan.Skipped
 }
 
 func shouldPersistBaselinePowerW(mode models.Mode, powerW float64, minPowerW int32) bool {
@@ -1535,15 +1529,29 @@ func shouldPersistBaselinePowerW(mode models.Mode, powerW float64, minPowerW int
 	return true
 }
 
-// eventStartState is the state a freshly-built event is inserted with. A
-// FULL_FLEET event with no eligible targets is vacuously complete on arrival
-// (nothing to curtail or restore); everything else starts PENDING and the
-// reconciler drives it.
-func eventStartState(mode models.Mode, targetCount int) models.EventState {
+// eventStartState is the state a freshly-built event is inserted with.
+// Closed-loop FULL_FLEET starts as an active command policy; the reconciler
+// claims per-miner targets only when it is about to dispatch.
+func eventStartState(scope Scope, mode models.Mode, targetCount int) models.EventState {
+	if isClosedLoopFullFleetStart(scope, mode) {
+		return models.EventStateActive
+	}
 	if mode == models.ModeFullFleet && targetCount == 0 {
 		return models.EventStateCompleted
 	}
 	return models.EventStatePending
+}
+
+func isClosedLoopFullFleetStart(scope Scope, mode models.Mode) bool {
+	if mode != models.ModeFullFleet {
+		return false
+	}
+	switch scope.Type {
+	case models.ScopeTypeWholeOrg, models.ScopeTypeSite, "":
+		return true
+	default:
+		return false
+	}
 }
 
 // marshalScopeJSON renders the request scope as the JSONB column value.

--- a/server/internal/domain/curtailment/service_start_fullfleet_test.go
+++ b/server/internal/domain/curtailment/service_start_fullfleet_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 )
 
-// FULL_FLEET curtails every eligible miner regardless of target_kw and persists
-// the event with mode=FULL_FLEET in the normal PENDING lifecycle.
+// FULL_FLEET selects every eligible miner regardless of target_kw and persists
+// a closed-loop event; the reconciler claims per-miner rows at dispatch time.
 func TestService_Start_FullFleet_CurtailsAllEligible(t *testing.T) {
 	t.Parallel()
 	const orgID = int64(1)
@@ -32,8 +32,9 @@ func TestService_Start_FullFleet_CurtailsAllEligible(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, plan.Selected, 2, "full_fleet curtails every eligible miner")
 	assert.Equal(t, models.ModeFullFleet, store.lastInsertEvent.Mode)
-	assert.Equal(t, models.EventStatePending, store.lastInsertEvent.State)
-	assert.Len(t, store.lastInsertTargets, 2)
+	assert.Equal(t, models.LoopTypeClosed, store.lastInsertEvent.LoopType)
+	assert.Equal(t, models.EventStateActive, store.lastInsertEvent.State)
+	assert.Empty(t, store.lastInsertTargets)
 }
 
 func TestService_Start_FullFleet_CurtailsLowPowerAndZeroHashrateMiners(t *testing.T) {
@@ -58,12 +59,8 @@ func TestService_Start_FullFleet_CurtailsLowPowerAndZeroHashrateMiners(t *testin
 		"full_fleet still ranks by efficiency when selecting all eligible miners")
 	assert.Equal(t, "low-power-hashing", plan.Selected[1].DeviceIdentifier)
 	assert.Empty(t, plan.Skipped)
-	require.Len(t, store.lastInsertTargets, 2)
-	require.NotNil(t, store.lastInsertTargets[0].BaselinePowerW,
-		"above-floor full_fleet targets keep a power baseline")
-	assert.InDelta(t, 2000, *store.lastInsertTargets[0].BaselinePowerW, 0.001)
-	assert.Nil(t, store.lastInsertTargets[1].BaselinePowerW,
-		"below-floor full_fleet targets confirm via hash-rate fallback")
+	assert.Empty(t, store.lastInsertTargets,
+		"closed-loop full_fleet claims per-miner rows at dispatch time")
 }
 
 func TestService_Preview_FullFleet_SkipsMissingTelemetrySamples(t *testing.T) {
@@ -104,9 +101,9 @@ func TestService_Preview_FullFleet_SkipsMissingTelemetrySamples(t *testing.T) {
 	}
 }
 
-// The empty-eligible case is the chosen behavior: persist a vacuously COMPLETED
-// event with no targets, not an insufficient-load rejection.
-func TestService_Start_FullFleet_NoEligibleMinersPersistsCompleted(t *testing.T) {
+// The empty-eligible case persists an active closed-loop watcher so newly
+// eligible miners can be admitted while the signal remains asserted.
+func TestService_Start_FullFleet_NoEligibleMinersPersistsActiveWatcher(t *testing.T) {
 	t.Parallel()
 	const orgID = int64(1)
 	store := newFakeStore()
@@ -122,13 +119,14 @@ func TestService_Start_FullFleet_NoEligibleMinersPersistsCompleted(t *testing.T)
 	require.NoError(t, err, "empty full_fleet is valid, not an insufficient-load rejection")
 	assert.Empty(t, plan.Selected)
 	assert.Equal(t, models.ModeFullFleet, store.lastInsertEvent.Mode)
-	assert.Equal(t, models.EventStateCompleted, store.lastInsertEvent.State,
-		"nothing eligible == vacuously complete on arrival")
-	assert.NotNil(t, store.lastInsertEvent.EndedAt, "a completed-empty event records its completion time")
-	assert.Empty(t, store.lastInsertTargets, "a completed-empty event has no targets")
+	assert.Equal(t, models.LoopTypeClosed, store.lastInsertEvent.LoopType)
+	assert.Equal(t, models.EventStateActive, store.lastInsertEvent.State,
+		"nothing currently eligible still needs an active enforcement window")
+	assert.NotNil(t, store.lastInsertEvent.StartedAt, "active watcher records when enforcement began")
+	assert.Empty(t, store.lastInsertTargets, "an empty watcher starts with no targets")
 }
 
-func TestService_Preview_FullFleet_AllSkippedReturnsInsufficientDetail(t *testing.T) {
+func TestService_Preview_FullFleet_AllSkippedReturnsTargetReachedWithSkips(t *testing.T) {
 	t.Parallel()
 	const orgID = int64(1)
 	store := newFakeStore()
@@ -146,19 +144,14 @@ func TestService_Preview_FullFleet_AllSkippedReturnsInsufficientDetail(t *testin
 
 	plan, err := svc.Preview(t.Context(), req)
 	require.NoError(t, err)
-	require.NotNil(t, plan.InsufficientLoadDetail)
-	assert.Equal(t, modes.OutcomeInsufficientLoad, plan.Outcome)
+	require.Nil(t, plan.InsufficientLoadDetail)
+	assert.Equal(t, modes.OutcomeTargetReached, plan.Outcome)
 	assert.Empty(t, plan.Selected)
 	assert.Len(t, plan.Skipped, 3)
-	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedOffline)
-	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedUpdating)
-	assert.Equal(t, int32(1), plan.InsufficientLoadDetail.ExcludedStale)
-	assert.Zero(t, plan.InsufficientLoadDetail.ExcludedBelowThreshold)
-	assert.Equal(t, int32(1500), plan.InsufficientLoadDetail.CandidateMinPowerW)
 	assert.Zero(t, store.insertEventCalls, "Preview must not persist")
 }
 
-func TestService_Start_FullFleet_AllSkippedDoesNotPersist(t *testing.T) {
+func TestService_Start_FullFleet_AllSkippedPersistsActiveWatcher(t *testing.T) {
 	t.Parallel()
 	const orgID = int64(1)
 	store := newFakeStore()
@@ -174,11 +167,37 @@ func TestService_Start_FullFleet_AllSkippedDoesNotPersist(t *testing.T) {
 	req.TargetKW = 0
 
 	plan, err := svc.Start(t.Context(), req)
-	require.NoError(t, err, "all-skipped full_fleet surfaces via Plan, not as a service error")
-	require.NotNil(t, plan.InsufficientLoadDetail)
-	assert.Equal(t, modes.OutcomeInsufficientLoad, plan.Outcome)
-	assert.Nil(t, plan.EventUUID, "no event must be persisted when no miner was actionable")
-	assert.Zero(t, store.insertEventCalls, "all-skipped full_fleet must not persist a completed event")
+	require.NoError(t, err)
+	require.Nil(t, plan.InsufficientLoadDetail)
+	assert.Equal(t, modes.OutcomeTargetReached, plan.Outcome)
+	assert.NotNil(t, plan.EventUUID, "closed-loop full_fleet persists a watcher even when no miner is actionable yet")
+	assert.Equal(t, 1, store.insertEventCalls)
+	assert.Equal(t, models.LoopTypeClosed, store.lastInsertEvent.LoopType)
+	assert.Equal(t, models.EventStateActive, store.lastInsertEvent.State)
+	assert.Empty(t, store.lastInsertTargets)
+}
+
+func TestService_Start_FullFleet_DeviceListNoTargetsPersistsCompleted(t *testing.T) {
+	t.Parallel()
+	const orgID = int64(1)
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.candidatesByOrg[orgID] = []*models.Candidate{
+		miner("offline-device", "OFFLINE", "PAIRED", 0, 0),
+	}
+	svc := NewService(store)
+	req := validStartRequest(orgID)
+	req.Scope = Scope{Type: models.ScopeTypeDeviceList, DeviceIdentifiers: []string{"offline-device"}}
+	req.Mode = models.ModeFullFleet
+	req.TargetKW = 0
+
+	plan, err := svc.Start(t.Context(), req)
+	require.NoError(t, err)
+	assert.Empty(t, plan.Selected)
+	assert.Equal(t, models.LoopTypeOpen, store.lastInsertEvent.LoopType)
+	assert.Equal(t, models.EventStateCompleted, store.lastInsertEvent.State)
+	assert.NotNil(t, store.lastInsertEvent.EndedAt)
+	assert.Empty(t, store.lastInsertTargets)
 }
 
 func TestService_Start_FullFleet_MixedSelectedAndSkippedPersists(t *testing.T) {
@@ -203,8 +222,9 @@ func TestService_Start_FullFleet_MixedSelectedAndSkippedPersists(t *testing.T) {
 	assert.Equal(t, "eligible", plan.Selected[0].DeviceIdentifier)
 	assert.Len(t, plan.Skipped, 1)
 	assert.Equal(t, 1, store.insertEventCalls)
-	assert.Equal(t, models.EventStatePending, store.lastInsertEvent.State)
-	assert.Len(t, store.lastInsertTargets, 1)
+	assert.Equal(t, models.LoopTypeClosed, store.lastInsertEvent.LoopType)
+	assert.Equal(t, models.EventStateActive, store.lastInsertEvent.State)
+	assert.Empty(t, store.lastInsertTargets)
 }
 
 // FIXED_KW still requires a positive target_kw; FULL_FLEET does not.

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -161,6 +161,10 @@ func (f *fakeStore) ListActiveCurtailedDevices(_ context.Context, orgID int64) (
 	return append([]string(nil), f.activeDevicesByOrg[orgID]...), nil
 }
 
+func (f *fakeStore) ListActiveCurtailmentTargetDevices(context.Context, int64) ([]string, error) {
+	panic("ListActiveCurtailmentTargetDevices not exercised")
+}
+
 func (f *fakeStore) ListRecentlyResolvedCurtailedDevices(_ context.Context, orgID int64, cooldownSec int32) ([]string, error) {
 	f.cooldownCalls++
 	f.lastCooldownOrgID = orgID
@@ -481,8 +485,10 @@ func (f *fakeStore) InsertEventWithTargets(
 	event models.InsertEventParams,
 	targets []models.InsertTargetParams,
 ) (*models.InsertEventResult, error) {
-	// Mirror the SQL store: only a terminal event may have zero targets.
-	if len(targets) == 0 && !event.State.IsTerminal() {
+	// Mirror the SQL store: only terminal or closed-loop full-fleet events may
+	// have zero targets.
+	if len(targets) == 0 && !event.State.IsTerminal() &&
+		!(event.Mode == models.ModeFullFleet && event.LoopType == models.LoopTypeClosed) {
 		return nil, fleeterror.NewInvalidArgumentError(
 			"InsertEventWithTargets requires a non-empty targets slice for a non-terminal event",
 		)
@@ -499,6 +505,10 @@ func (f *fakeStore) InsertEventWithTargets(
 		ID:        id,
 		EventUUID: event.EventUUID,
 	}, nil
+}
+
+func (f *fakeStore) ClaimClosedLoopFullFleetTargets(context.Context, int64, []models.InsertTargetParams) ([]*models.Target, error) {
+	panic("ClaimClosedLoopFullFleetTargets not exercised")
 }
 
 // --- helpers ---

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -954,7 +954,7 @@ func TestService_Preview_MaintenancePairAdmitsMiners(t *testing.T) {
 
 // --- cooldown ---
 
-func TestService_Preview_NormalPriority_AppliesCooldown(t *testing.T) {
+func TestService_Preview_NormalPriority_DoesNotApplyCooldown(t *testing.T) {
 	t.Parallel()
 
 	const orgID = int64(1)
@@ -972,20 +972,12 @@ func TestService_Preview_NormalPriority_AppliesCooldown(t *testing.T) {
 	plan, err := svc.Preview(t.Context(), req)
 	require.NoError(t, err)
 
-	require.Equal(t, 1, store.cooldownCalls, "NORMAL priority must consult cooldown")
-	assert.Equal(t, int32(600), store.lastCooldownSec, "cooldown sec must come from org config")
-
-	// recent miner gets skipped with cooldown reason; ok miner is selected.
-	reasons := map[string]SkipReason{}
-	for _, s := range plan.Skipped {
-		reasons[s.DeviceIdentifier] = s.Reason
-	}
-	assert.Equal(t, SkipCooldown, reasons["recent"])
+	assert.Zero(t, store.cooldownCalls, "curtailment should not be gated by cooldown")
 	require.Len(t, plan.Selected, 1)
-	assert.Equal(t, "ok", plan.Selected[0].DeviceIdentifier)
+	assert.Equal(t, "recent", plan.Selected[0].DeviceIdentifier)
 }
 
-func TestService_Preview_EmergencyPriority_BypassesCooldown(t *testing.T) {
+func TestService_Preview_EmergencyPriority_DoesNotConsultCooldown(t *testing.T) {
 	t.Parallel()
 
 	const orgID = int64(1)
@@ -1003,7 +995,7 @@ func TestService_Preview_EmergencyPriority_BypassesCooldown(t *testing.T) {
 	plan, err := svc.Preview(t.Context(), req)
 	require.NoError(t, err)
 
-	assert.Zero(t, store.cooldownCalls, "EMERGENCY must skip the cooldown lookup entirely")
+	assert.Zero(t, store.cooldownCalls, "cooldown lookup is not part of selection")
 	require.Len(t, plan.Selected, 1, "recent miner is admitted under EMERGENCY")
 	assert.Equal(t, "recent", plan.Selected[0].DeviceIdentifier)
 }
@@ -1089,8 +1081,6 @@ func TestService_Preview_PassesCallerOrgIDToEveryStoreCall(t *testing.T) {
 	store.orgConfigByOrg[otherOrg] = defaultOrgConfig(otherOrg)
 	store.activeDevicesByOrg[callerOrg] = []string{"caller-locked"}
 	store.activeDevicesByOrg[otherOrg] = []string{"other-locked"}
-	store.cooldownDevicesByOrg[callerOrg] = []string{"caller-cooldown"}
-	store.cooldownDevicesByOrg[otherOrg] = []string{"other-cooldown"}
 	store.candidatesByOrg[callerOrg] = []*models.Candidate{minerWithEff("caller-miner", 3000, 100, 40)}
 	store.candidatesByOrg[otherOrg] = []*models.Candidate{minerWithEff("other-miner", 3000, 100, 40)}
 
@@ -1099,7 +1089,6 @@ func TestService_Preview_PassesCallerOrgIDToEveryStoreCall(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, callerOrg, store.lastActiveDevicesOrgID, "active-event lookup must use caller's org_id")
-	assert.Equal(t, callerOrg, store.lastCooldownOrgID, "cooldown lookup must use caller's org_id")
 	assert.Equal(t, callerOrg, store.lastListCandidatesOrgID, "candidate listing must use caller's org_id")
 
 	// Plan must contain only the caller's devices — no leakage from otherOrg.

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -154,6 +154,7 @@ type CurtailmentStore interface {
 
 	// Selector exclusion sets — org-scoped device IDs subtracted from candidates.
 	ListActiveCurtailedDevices(ctx context.Context, orgID int64) ([]string, error)
+	ListActiveCurtailmentTargetDevices(ctx context.Context, orgID int64) ([]string, error)
 	ListRecentlyResolvedCurtailedDevices(ctx context.Context, orgID int64, cooldownSec int32) ([]string, error)
 	SiteBelongsToOrg(ctx context.Context, orgID, siteID int64) (bool, error)
 
@@ -203,6 +204,12 @@ type CurtailmentStore interface {
 		event models.InsertEventParams,
 		targets []models.InsertTargetParams,
 	) (*models.InsertEventResult, error)
+
+	// ClaimClosedLoopFullFleetTargets inserts missing closed-loop FULL_FLEET
+	// targets as DISPATCHING while the parent event is still pending/active.
+	// Existing same-event rows and cross-event conflicts are skipped so
+	// reconciliation can retry later.
+	ClaimClosedLoopFullFleetTargets(ctx context.Context, eventID int64, targets []models.InsertTargetParams) ([]*models.Target, error)
 
 	// Heartbeat singleton row used by liveness alerts.
 	GetHeartbeat(ctx context.Context) (*models.Heartbeat, error)

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -110,6 +110,14 @@ func (s *SQLCurtailmentStore) ListActiveCurtailedDevices(ctx context.Context, or
 	return devices, nil
 }
 
+func (s *SQLCurtailmentStore) ListActiveCurtailmentTargetDevices(ctx context.Context, orgID int64) ([]string, error) {
+	devices, err := s.GetQueries(ctx).ListActiveCurtailmentTargetDevicesByOrg(ctx, orgID)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("failed to list active curtailment target devices: %v", err)
+	}
+	return devices, nil
+}
+
 func (s *SQLCurtailmentStore) ListRecentlyResolvedCurtailedDevices(ctx context.Context, orgID int64, cooldownSec int32) ([]string, error) {
 	devices, err := s.GetQueries(ctx).ListRecentlyResolvedCurtailedDevicesByOrg(ctx, sqlc.ListRecentlyResolvedCurtailedDevicesByOrgParams{
 		OrgID:       orgID,
@@ -624,15 +632,43 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 	event models.InsertEventParams,
 	targets []models.InsertTargetParams,
 ) (*models.InsertEventResult, error) {
-	// A terminal event (a vacuously-COMPLETED FULL_FLEET start with nothing
-	// eligible) legitimately has no targets; a non-terminal event with none is
-	// a caller bug.
-	if len(targets) == 0 && !event.State.IsTerminal() {
+	// A closed-loop FULL_FLEET event may begin as a targetless active watcher.
+	// Other non-terminal events with no targets are caller bugs.
+	if len(targets) == 0 && !event.State.IsTerminal() && !isClosedLoopFullFleetInsert(event) {
 		return nil, fleeterror.NewInvalidArgumentError(
 			"InsertEventWithTargets requires a non-empty targets slice for a non-terminal event",
 		)
 	}
-	return db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (*models.InsertEventResult, error) {
+	replayRace := false
+	result, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (*models.InsertEventResult, error) {
+		if usesHierarchicalCurtailmentScope(event) {
+			if err := q.LockCurtailmentScopeForWrite(ctx, strconv.FormatInt(event.OrgID, 10)); err != nil {
+				return nil, fleeterror.NewInternalErrorf("failed to lock curtailment scope: %v", err)
+			}
+			if replay, err := lookupReplayEventInTx(ctx, q, event); err != nil {
+				return nil, err
+			} else if replay != nil {
+				replayRace = true
+				return nil, nil
+			}
+			scopeSiteID, err := hierarchicalScopeSiteID(event)
+			if err != nil {
+				return nil, err
+			}
+			conflicts, err := q.CountCurtailmentScopeConflicts(ctx, sqlc.CountCurtailmentScopeConflictsParams{
+				OrgID:     event.OrgID,
+				Mode:      string(event.Mode),
+				LoopType:  string(event.LoopType),
+				ScopeType: string(event.ScopeType),
+				SiteID:    scopeSiteID,
+			})
+			if err != nil {
+				return nil, fleeterror.NewInternalErrorf("failed to check curtailment scope conflicts: %v", err)
+			}
+			if conflicts > 0 {
+				return nil, fleeterror.NewAlreadyExistsError("a non-terminal curtailment event already owns this scope")
+			}
+		}
 		row, err := q.InsertCurtailmentEvent(ctx, sqlc.InsertCurtailmentEventParams{
 			EventUuid:               event.EventUUID,
 			OrgID:                   event.OrgID,
@@ -662,6 +698,7 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 			IdempotencyKey:          ptrToNullString(event.IdempotencyKey),
 			Reason:                  event.Reason,
 			ScheduledStartAt:        ptrToNullTime(event.ScheduledStartAt),
+			StartedAt:               ptrToNullTime(event.StartedAt),
 			EndedAt:                 ptrToNullTime(event.EndedAt),
 			CreatedByUserID:         event.CreatedByUserID,
 			EffectiveBatchSize:      sql.NullInt32{Int32: event.EffectiveBatchSize, Valid: true},
@@ -672,7 +709,8 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 				switch pgErr.ConstraintName {
 				case idempotencyKeyUniqueIndex, externalReferenceUniqueIndex:
 					// Replay path: caller re-issues the matching lookup.
-					return nil, interfaces.ErrCurtailmentReplayRaceLoss
+					replayRace = true
+					return nil, nil
 				}
 				// Unknown constraint: sanitize the response and log the
 				// name server-side so it doesn't leak through %v.
@@ -682,36 +720,38 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 			}
 			return nil, fleeterror.NewInternalErrorf("failed to insert curtailment event: %v", err)
 		}
-		payload, err := buildBulkTargetPayload(targets)
-		if err != nil {
-			return nil, fleeterror.NewInternalErrorf(
-				"failed to encode curtailment target payload: %v", err,
-			)
-		}
-		inserted, err := q.BulkInsertCurtailmentTargets(ctx, sqlc.BulkInsertCurtailmentTargetsParams{
-			CurtailmentEventID: row.ID,
-			TargetsJsonb:       payload,
-		})
-		if err != nil {
-			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgErr.Code == pgErrCodeUniqueViolation &&
-				pgErr.ConstraintName == deviceNonTerminalUniqueIndex {
-				// The device-exclusivity index rejected a target: another
-				// non-terminal event already curtails one of these devices
-				// (selector/insert race). Return a FleetError directly —
-				// WithTransaction converts plain sentinels to Internal.
-				return nil, fleeterror.NewAlreadyExistsError(
-					"one or more selected devices are already in a non-terminal curtailment; retry",
+		if len(targets) > 0 {
+			payload, err := buildBulkTargetPayload(targets)
+			if err != nil {
+				return nil, fleeterror.NewInternalErrorf(
+					"failed to encode curtailment target payload: %v", err,
 				)
 			}
-			return nil, fleeterror.NewInternalErrorf("failed to bulk insert curtailment targets: %v", err)
-		}
-		if inserted != int64(len(targets)) {
-			// jsonb_to_recordset silently drops rows that fail column-type
-			// cast; bail so the tx rolls back instead of partial fanout.
-			return nil, fleeterror.NewInternalErrorf(
-				"bulk insert wrote %d targets, expected %d", inserted, len(targets),
-			)
+			inserted, err := q.BulkInsertCurtailmentTargets(ctx, sqlc.BulkInsertCurtailmentTargetsParams{
+				CurtailmentEventID: row.ID,
+				TargetsJsonb:       payload,
+			})
+			if err != nil {
+				var pgErr *pgconn.PgError
+				if errors.As(err, &pgErr) && pgErr.Code == pgErrCodeUniqueViolation &&
+					pgErr.ConstraintName == deviceNonTerminalUniqueIndex {
+					// The device-exclusivity index rejected a target: another
+					// non-terminal event already curtails one of these devices
+					// (selector/insert race). Return a FleetError directly —
+					// WithTransaction converts plain sentinels to Internal.
+					return nil, fleeterror.NewAlreadyExistsError(
+						"one or more selected devices are already in a non-terminal curtailment; retry",
+					)
+				}
+				return nil, fleeterror.NewInternalErrorf("failed to bulk insert curtailment targets: %v", err)
+			}
+			if inserted != int64(len(targets)) {
+				// jsonb_to_recordset silently drops rows that fail column-type
+				// cast; bail so the tx rolls back instead of partial fanout.
+				return nil, fleeterror.NewInternalErrorf(
+					"bulk insert wrote %d targets, expected %d", inserted, len(targets),
+				)
+			}
 		}
 		return &models.InsertEventResult{
 			ID:        row.ID,
@@ -720,6 +760,68 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 			UpdatedAt: row.UpdatedAt,
 		}, nil
 	})
+	if replayRace {
+		return nil, interfaces.ErrCurtailmentReplayRaceLoss
+	}
+	return result, err
+}
+
+func isClosedLoopFullFleetInsert(event models.InsertEventParams) bool {
+	return event.Mode == models.ModeFullFleet && event.LoopType == models.LoopTypeClosed
+}
+
+func usesHierarchicalCurtailmentScope(event models.InsertEventParams) bool {
+	if event.State.IsTerminal() {
+		return false
+	}
+	switch event.ScopeType {
+	case models.ScopeTypeWholeOrg, models.ScopeTypeSite:
+		return true
+	default:
+		return false
+	}
+}
+
+func hierarchicalScopeSiteID(event models.InsertEventParams) (string, error) {
+	if event.ScopeType != models.ScopeTypeSite {
+		return "", nil
+	}
+	var scope struct {
+		SiteID int64 `json:"site_id"`
+	}
+	if err := json.Unmarshal(event.ScopeJSON, &scope); err != nil || scope.SiteID <= 0 {
+		return "", fleeterror.NewInternalErrorf("invalid site scope for closed-loop curtailment event")
+	}
+	return strconv.FormatInt(scope.SiteID, 10), nil
+}
+
+func lookupReplayEventInTx(ctx context.Context, q *sqlc.Queries, event models.InsertEventParams) (*models.Event, error) {
+	if event.IdempotencyKey != nil {
+		row, err := q.GetCurtailmentEventByIdempotencyKey(ctx, sqlc.GetCurtailmentEventByIdempotencyKeyParams{
+			OrgID:          event.OrgID,
+			IdempotencyKey: sql.NullString{String: *event.IdempotencyKey, Valid: true},
+		})
+		if err == nil {
+			return convertEventRow(row), nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, fleeterror.NewInternalErrorf("failed to replay-check curtailment event by idempotency_key: %v", err)
+		}
+	}
+	if event.ExternalSource != nil && event.ExternalReference != nil {
+		row, err := q.GetCurtailmentEventByExternalReference(ctx, sqlc.GetCurtailmentEventByExternalReferenceParams{
+			OrgID:             event.OrgID,
+			ExternalSource:    sql.NullString{String: *event.ExternalSource, Valid: true},
+			ExternalReference: sql.NullString{String: *event.ExternalReference, Valid: true},
+		})
+		if err == nil {
+			return convertEventRow(row), nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, fleeterror.NewInternalErrorf("failed to replay-check curtailment event by external reference: %v", err)
+		}
+	}
+	return nil, nil
 }
 
 func (s *SQLCurtailmentStore) GetEventByUUID(ctx context.Context, orgID int64, eventUUID uuid.UUID) (*models.Event, error) {
@@ -1285,6 +1387,30 @@ func (s *SQLCurtailmentStore) BeginRestoreTransition(
 			return nil, fleeterror.NewInternalErrorf("failed to begin curtailment restoration: %v", err)
 		}
 
+		rollup, err := q.GetCurtailmentTargetRollupByEvent(ctx, sqlc.GetCurtailmentTargetRollupByEventParams{
+			OrgID:     orgID,
+			EventUuid: eventUUID,
+		})
+		if err != nil {
+			return nil, fleeterror.NewInternalErrorf("failed to get curtailment target rollup before restore: %v", err)
+		}
+		if rollup.Total == 0 {
+			now := time.Now().UTC()
+			if rows, err := q.UpdateCurtailmentEventState(ctx, sqlc.UpdateCurtailmentEventStateParams{
+				ID:            current.ID,
+				ExpectedState: string(models.EventStateRestoring),
+				State:         string(models.EventStateCompleted),
+				EndedAt:       sql.NullTime{Time: now, Valid: true},
+			}); err != nil {
+				return nil, fleeterror.NewInternalErrorf("failed to complete empty curtailment event: %v", err)
+			} else if rows == 0 {
+				return nil, interfaces.ErrCurtailmentEventStateRaceLoss
+			}
+			updated.State = string(models.EventStateCompleted)
+			updated.EndedAt = sql.NullTime{Time: now, Valid: true}
+			return convertEventRow(updated), nil
+		}
+
 		if err := q.ResetCurtailmentTargetsForRestore(ctx, current.ID); err != nil {
 			return nil, fleeterror.NewInternalErrorf("failed to reset curtailment targets for restore: %v", err)
 		}
@@ -1397,6 +1523,28 @@ func (s *SQLCurtailmentStore) BeginRecurtailTransition(
 
 		return convertEventRow(updated), nil
 	})
+}
+
+func (s *SQLCurtailmentStore) ClaimClosedLoopFullFleetTargets(ctx context.Context, eventID int64, targets []models.InsertTargetParams) ([]*models.Target, error) {
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	payload, err := buildBulkTargetPayload(targets)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("failed to encode curtailment target payload: %v", err)
+	}
+	rows, err := s.GetQueries(ctx).ClaimClosedLoopFullFleetTargets(ctx, sqlc.ClaimClosedLoopFullFleetTargetsParams{
+		CurtailmentEventID: eventID,
+		TargetsJsonb:       payload,
+	})
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("failed to claim curtailment targets: %v", err)
+	}
+	claimed := make([]*models.Target, len(rows))
+	for i, row := range rows {
+		claimed[i] = convertTargetRow(row)
+	}
+	return claimed, nil
 }
 
 func (s *SQLCurtailmentStore) GetHeartbeat(ctx context.Context) (*models.Heartbeat, error) {

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -777,6 +777,8 @@ func usesHierarchicalCurtailmentScope(event models.InsertEventParams) bool {
 	switch event.ScopeType {
 	case models.ScopeTypeWholeOrg, models.ScopeTypeSite:
 		return true
+	case models.ScopeTypeDeviceSets, models.ScopeTypeDeviceList:
+		return false
 	default:
 		return false
 	}

--- a/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
@@ -174,7 +174,7 @@ func TestSQLCurtailmentStore_ClosedLoopScopeHierarchyConflicts(t *testing.T) {
 	siteB, err := siteStore.CreateSite(ctx, sitesmodels.CreateSiteParams{OrgID: user.OrganizationID, Name: "site-b"})
 	require.NoError(t, err)
 
-	_, err = store.InsertEventWithTargets(
+	wholeOrg, err := store.InsertEventWithTargets(
 		ctx,
 		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeWholeOrg, 0, "whole-org"),
 		nil,
@@ -189,7 +189,7 @@ func TestSQLCurtailmentStore_ClosedLoopScopeHierarchyConflicts(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsAlreadyExistsError(err), "org watcher must block site starts, got %v", err)
 
-	_, err = db.ExecContext(ctx, `UPDATE curtailment_event SET state = 'completed', ended_at = NOW() WHERE org_id = $1`, user.OrganizationID)
+	_, err = store.BeginRestoreTransition(ctx, user.OrganizationID, wholeOrg.EventUUID, interfaces.BeginRestoreTransitionParams{})
 	require.NoError(t, err)
 
 	_, err = store.InsertEventWithTargets(

--- a/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
@@ -2,7 +2,9 @@ package sqlstores_test
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,8 @@ import (
 
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	sitesmodels "github.com/block/proto-fleet/server/internal/domain/sites/models"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
@@ -153,6 +157,166 @@ func TestSQLCurtailmentStore_BeginRecurtailTransition_ReopensResolvedTarget(t *t
 	assert.False(t, lastError.Valid)
 }
 
+func TestSQLCurtailmentStore_ClosedLoopScopeHierarchyConflicts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	db := testContext.DatabaseService.DB
+	ctx := t.Context()
+	store := sqlstores.NewSQLCurtailmentStore(db)
+	siteStore := sqlstores.NewSQLSiteStore(db)
+
+	siteA, err := siteStore.CreateSite(ctx, sitesmodels.CreateSiteParams{OrgID: user.OrganizationID, Name: "site-a"})
+	require.NoError(t, err)
+	siteB, err := siteStore.CreateSite(ctx, sitesmodels.CreateSiteParams{OrgID: user.OrganizationID, Name: "site-b"})
+	require.NoError(t, err)
+
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeWholeOrg, 0, "whole-org"),
+		nil,
+	)
+	require.NoError(t, err)
+
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeSite, siteA.ID, "site-a-blocked-by-org"),
+		nil,
+	)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsAlreadyExistsError(err), "org watcher must block site starts, got %v", err)
+
+	_, err = db.ExecContext(ctx, `UPDATE curtailment_event SET state = 'completed', ended_at = NOW() WHERE org_id = $1`, user.OrganizationID)
+	require.NoError(t, err)
+
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeSite, siteA.ID, "site-a"),
+		nil,
+	)
+	require.NoError(t, err)
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeSite, siteA.ID, "same-site-blocked"),
+		nil,
+	)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsAlreadyExistsError(err), "same-site watcher must conflict, got %v", err)
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeSite, siteB.ID, "site-b-allowed"),
+		nil,
+	)
+	require.NoError(t, err)
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeWholeOrg, 0, "org-blocked-by-site"),
+		nil,
+	)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsAlreadyExistsError(err), "site watcher must block org starts, got %v", err)
+}
+
+func TestSQLCurtailmentStore_ClosedLoopScopeConflictPreservesIdempotentReplay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	store := sqlstores.NewSQLCurtailmentStore(testContext.DatabaseService.DB)
+
+	event := curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeWholeOrg, 0, "idempotent")
+	idempotencyKey := "closed-loop-idempotent"
+	event.IdempotencyKey = &idempotencyKey
+	_, err := store.InsertEventWithTargets(ctx, event, nil)
+	require.NoError(t, err)
+
+	replay := curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeWholeOrg, 0, "idempotent-replay")
+	replay.IdempotencyKey = &idempotencyKey
+	_, err = store.InsertEventWithTargets(ctx, replay, nil)
+	require.ErrorIs(t, err, interfaces.ErrCurtailmentReplayRaceLoss)
+}
+
+func TestSQLCurtailmentStore_ClaimClosedLoopFullFleetTargets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	store := sqlstores.NewSQLCurtailmentStore(testContext.DatabaseService.DB)
+
+	source, err := store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeWholeOrg, 0, "claim-source"),
+		nil,
+	)
+	require.NoError(t, err)
+
+	claimed, err := store.ClaimClosedLoopFullFleetTargets(ctx, source.ID, []models.InsertTargetParams{
+		curtailmentStoreTestTarget("claim-a", models.TargetStatePending, models.DesiredStateCurtailed),
+		curtailmentStoreTestTarget("claim-b", models.TargetStatePending, models.DesiredStateCurtailed),
+	})
+	require.NoError(t, err)
+	require.Len(t, claimed, 2)
+	assert.Equal(t, models.TargetStateDispatching, claimed[0].State)
+	assert.Equal(t, models.TargetStateDispatching, claimed[1].State)
+
+	claimed, err = store.ClaimClosedLoopFullFleetTargets(ctx, source.ID, []models.InsertTargetParams{
+		curtailmentStoreTestTarget("claim-a", models.TargetStatePending, models.DesiredStateCurtailed),
+		curtailmentStoreTestTarget("claim-b", models.TargetStatePending, models.DesiredStateCurtailed),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, claimed, "same-event duplicates should no-op")
+
+	other, err := store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreTestEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.EventStateActive, "claim-other"),
+		[]models.InsertTargetParams{curtailmentStoreTestTarget("claim-conflict", models.TargetStateConfirmed, models.DesiredStateCurtailed)},
+	)
+	require.NoError(t, err)
+	require.NotZero(t, other.ID)
+
+	claimed, err = store.ClaimClosedLoopFullFleetTargets(ctx, source.ID, []models.InsertTargetParams{
+		curtailmentStoreTestTarget("claim-conflict", models.TargetStatePending, models.DesiredStateCurtailed),
+		curtailmentStoreTestTarget("claim-c", models.TargetStatePending, models.DesiredStateCurtailed),
+	})
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+	assert.Equal(t, "claim-c", claimed[0].DeviceIdentifier)
+}
+
+func TestSQLCurtailmentStore_BeginRestoreTransition_CompletesTargetlessClosedLoopEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	store := sqlstores.NewSQLCurtailmentStore(testContext.DatabaseService.DB)
+
+	eventUUID := uuid.New()
+	_, err := store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, eventUUID, models.ScopeTypeWholeOrg, 0, "empty-restore"),
+		nil,
+	)
+	require.NoError(t, err)
+
+	got, err := store.BeginRestoreTransition(ctx, user.OrganizationID, eventUUID, interfaces.BeginRestoreTransitionParams{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, models.EventStateCompleted, got.State)
+	assert.NotNil(t, got.EndedAt)
+}
+
 func curtailmentStoreTestEvent(
 	orgID int64,
 	userID int64,
@@ -182,6 +346,47 @@ func curtailmentStoreTestEvent(
 		SourceActorType:         models.SourceActorWebhook,
 		SourceActorID:           &sourceActorID,
 		Reason:                  "recurtail integration test",
+		CreatedByUserID:         userID,
+		EffectiveBatchSize:      10,
+	}
+}
+
+func curtailmentStoreClosedLoopFullFleetEvent(
+	orgID int64,
+	userID int64,
+	eventUUID uuid.UUID,
+	scopeType models.ScopeType,
+	siteID int64,
+	sourceActorID string,
+) models.InsertEventParams {
+	scopeJSON := []byte(`{}`)
+	if scopeType == models.ScopeTypeSite {
+		scopeJSON = []byte(fmt.Sprintf(`{"site_id":%d}`, siteID))
+	}
+	startedAt := time.Now().UTC()
+	return models.InsertEventParams{
+		EventUUID:               eventUUID,
+		OrgID:                   orgID,
+		State:                   models.EventStateActive,
+		Mode:                    models.ModeFullFleet,
+		Strategy:                models.StrategyLeastEfficientFirst,
+		Level:                   models.LevelFull,
+		Priority:                models.PriorityNormal,
+		LoopType:                models.LoopTypeClosed,
+		ScopeType:               scopeType,
+		ScopeJSON:               scopeJSON,
+		ModeParamsJSON:          []byte(`{}`),
+		RestoreBatchSize:        10,
+		RestoreBatchIntervalSec: 0,
+		MinCurtailedDurationSec: 0,
+		AllowUnbounded:          false,
+		IncludeMaintenance:      false,
+		ForceIncludeMaintenance: false,
+		DecisionSnapshotJSON:    []byte(`{}`),
+		SourceActorType:         models.SourceActorWebhook,
+		SourceActorID:           &sourceActorID,
+		Reason:                  "closed-loop integration test",
+		StartedAt:               &startedAt,
 		CreatedByUserID:         userID,
 		EffectiveBatchSize:      10,
 	}

--- a/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
@@ -220,6 +220,32 @@ func TestSQLCurtailmentStore_ClosedLoopScopeHierarchyConflicts(t *testing.T) {
 	assert.True(t, fleeterror.IsAlreadyExistsError(err), "site watcher must block org starts, got %v", err)
 }
 
+func TestSQLCurtailmentStore_FixedKwDoesNotBlockClosedLoopScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	store := sqlstores.NewSQLCurtailmentStore(testContext.DatabaseService.DB)
+
+	fixedKw := curtailmentStoreTestEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.EventStateActive, "fixed-kw")
+	fixedKw.ScopeType = models.ScopeTypeWholeOrg
+	fixedKw.ScopeJSON = []byte(`{}`)
+	_, err := store.InsertEventWithTargets(ctx, fixedKw, []models.InsertTargetParams{
+		curtailmentStoreTestTarget("fixed-kw-miner", models.TargetStateConfirmed, models.DesiredStateCurtailed),
+	})
+	require.NoError(t, err)
+
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.ScopeTypeWholeOrg, 0, "full-fleet-after-fixed-kw"),
+		nil,
+	)
+	require.NoError(t, err, "fixed-kW target ownership should not block a closed-loop full-fleet scope")
+}
+
 func TestSQLCurtailmentStore_ClosedLoopScopeConflictPreservesIdempotentReplay(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database integration test in short mode")

--- a/server/internal/handlers/curtailment/handler_admin_terminate_test.go
+++ b/server/internal/handlers/curtailment/handler_admin_terminate_test.go
@@ -65,6 +65,9 @@ func (s *adminTerminateStubStore) UpdateOrgConfigPostEventCooldown(context.Conte
 func (s *adminTerminateStubStore) ListActiveCurtailedDevices(context.Context, int64) ([]string, error) {
 	panic("ListActiveCurtailedDevices not exercised by AdminTerminate handler tests")
 }
+func (s *adminTerminateStubStore) ListActiveCurtailmentTargetDevices(context.Context, int64) ([]string, error) {
+	panic("ListActiveCurtailmentTargetDevices not exercised by AdminTerminate handler tests")
+}
 func (s *adminTerminateStubStore) ListRecentlyResolvedCurtailedDevices(context.Context, int64, int32) ([]string, error) {
 	panic("ListRecentlyResolvedCurtailedDevices not exercised by AdminTerminate handler tests")
 }
@@ -76,6 +79,9 @@ func (s *adminTerminateStubStore) ListCandidates(context.Context, interfaces.Lis
 }
 func (s *adminTerminateStubStore) InsertEventWithTargets(context.Context, models.InsertEventParams, []models.InsertTargetParams) (*models.InsertEventResult, error) {
 	panic("InsertEventWithTargets not exercised by AdminTerminate handler tests")
+}
+func (s *adminTerminateStubStore) ClaimClosedLoopFullFleetTargets(context.Context, int64, []models.InsertTargetParams) ([]*models.Target, error) {
+	panic("ClaimClosedLoopFullFleetTargets not exercised by AdminTerminate handler tests")
 }
 func (s *adminTerminateStubStore) GetEventByUUID(_ context.Context, _ int64, eventUUID uuid.UUID) (*models.Event, error) {
 	if s.authEvent != nil {

--- a/server/internal/handlers/curtailment/handler_list_test.go
+++ b/server/internal/handlers/curtailment/handler_list_test.go
@@ -74,6 +74,9 @@ func (s *listStubStore) UpdateOrgConfigPostEventCooldown(context.Context, int64,
 func (s *listStubStore) ListActiveCurtailedDevices(context.Context, int64) ([]string, error) {
 	panic("ListActiveCurtailedDevices not exercised by List handler tests")
 }
+func (s *listStubStore) ListActiveCurtailmentTargetDevices(context.Context, int64) ([]string, error) {
+	panic("ListActiveCurtailmentTargetDevices not exercised by List handler tests")
+}
 func (s *listStubStore) ListRecentlyResolvedCurtailedDevices(context.Context, int64, int32) ([]string, error) {
 	panic("ListRecentlyResolvedCurtailedDevices not exercised by List handler tests")
 }
@@ -85,6 +88,9 @@ func (s *listStubStore) ListCandidates(context.Context, interfaces.ListCandidate
 }
 func (s *listStubStore) InsertEventWithTargets(context.Context, models.InsertEventParams, []models.InsertTargetParams) (*models.InsertEventResult, error) {
 	panic("InsertEventWithTargets not exercised by List handler tests")
+}
+func (s *listStubStore) ClaimClosedLoopFullFleetTargets(context.Context, int64, []models.InsertTargetParams) ([]*models.Target, error) {
+	panic("ClaimClosedLoopFullFleetTargets not exercised by List handler tests")
 }
 func (s *listStubStore) GetEventByUUID(_ context.Context, orgID int64, eventUUID uuid.UUID) (*models.Event, error) {
 	s.lastGetOrgID = orgID

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -310,6 +310,7 @@ func TestHandler_StartCurtailment_RequiresCurtailmentManage(t *testing.T) {
 		wantMode    models.Mode
 		wantCode    connect.Code
 		wantPersist bool
+		wantTargets int
 	}{
 		{
 			name:        "fixed kw whole org without manage is rejected",
@@ -351,6 +352,7 @@ func TestHandler_StartCurtailment_RequiresCurtailmentManage(t *testing.T) {
 			permissions: []string{authz.PermCurtailmentManage},
 			wantMode:    models.ModeFixedKw,
 			wantPersist: true,
+			wantTargets: 1,
 		},
 		{
 			name: "full fleet whole org with manage can start",
@@ -361,6 +363,7 @@ func TestHandler_StartCurtailment_RequiresCurtailmentManage(t *testing.T) {
 			permissions: []string{authz.PermCurtailmentManage},
 			wantMode:    models.ModeFullFleet,
 			wantPersist: true,
+			wantTargets: 0,
 		},
 	}
 
@@ -387,7 +390,7 @@ func TestHandler_StartCurtailment_RequiresCurtailmentManage(t *testing.T) {
 			if tc.wantPersist {
 				require.NoError(t, err)
 				assert.Equal(t, tc.wantMode, store.lastEvent.Mode)
-				assert.Len(t, store.lastTargets, 1)
+				assert.Len(t, store.lastTargets, tc.wantTargets)
 				return
 			}
 
@@ -525,7 +528,7 @@ func TestHandler_StartCurtailment_InsufficientLoadSurfacesAsInvalidArgument(t *t
 	assert.Empty(t, store.lastTargets)
 }
 
-func TestHandler_StartCurtailment_FullFleetAllSkippedSurfacesSkippedReasons(t *testing.T) {
+func TestHandler_StartCurtailment_FullFleetAllSkippedReturnsActiveWatcher(t *testing.T) {
 	t.Parallel()
 
 	store := newStartStubStore()
@@ -546,15 +549,13 @@ func TestHandler_StartCurtailment_FullFleetAllSkippedSurfacesSkippedReasons(t *t
 	req.Mode = pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET
 	req.ModeParams = nil
 
-	_, err := h.StartCurtailment(ctx, connect.NewRequest(req))
-	require.Error(t, err)
-	var fleetErr fleeterror.FleetError
-	require.ErrorAs(t, err, &fleetErr)
-	assert.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
-	assert.Contains(t, err.Error(), "insufficient curtailable load")
-	assert.Contains(t, err.Error(), "unreachable_residual_load=1")
-	assert.Contains(t, err.Error(), "updating=1")
-	assert.Empty(t, store.lastTargets, "all-skipped full_fleet must not persist a completed event")
+	resp, err := h.StartCurtailment(ctx, connect.NewRequest(req))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.GetEvent())
+	assert.Equal(t, pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_ACTIVE, resp.Msg.GetEvent().GetState())
+	assert.Empty(t, resp.Msg.GetEvent().GetTargets())
+	assert.Equal(t, int32(0), resp.Msg.GetEvent().GetTargetRollup().GetTotal())
+	assert.Empty(t, store.lastTargets)
 }
 
 // TestHandler_StartCurtailment_RejectsMissingSession pins the auth gate:

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -66,6 +66,9 @@ func (s *startStubStore) UpdateOrgConfigPostEventCooldown(_ context.Context, org
 func (s *startStubStore) ListActiveCurtailedDevices(_ context.Context, _ int64) ([]string, error) {
 	return nil, nil
 }
+func (s *startStubStore) ListActiveCurtailmentTargetDevices(context.Context, int64) ([]string, error) {
+	panic("ListActiveCurtailmentTargetDevices not exercised by handler Start tests")
+}
 
 func (s *startStubStore) ListRecentlyResolvedCurtailedDevices(_ context.Context, _ int64, _ int32) ([]string, error) {
 	return nil, nil
@@ -90,6 +93,9 @@ func (s *startStubStore) InsertEventWithTargets(
 		ID:        1,
 		EventUUID: event.EventUUID,
 	}, nil
+}
+func (s *startStubStore) ClaimClosedLoopFullFleetTargets(context.Context, int64, []models.InsertTargetParams) ([]*models.Target, error) {
+	panic("ClaimClosedLoopFullFleetTargets not exercised by handler Start tests")
 }
 
 // --- panic stubs for surface the handler-level tests don't reach ---

--- a/server/internal/handlers/curtailment/handler_stop_test.go
+++ b/server/internal/handlers/curtailment/handler_stop_test.go
@@ -44,6 +44,9 @@ func (s *stopStubStore) UpdateOrgConfigPostEventCooldown(context.Context, int64,
 func (s *stopStubStore) ListActiveCurtailedDevices(context.Context, int64) ([]string, error) {
 	panic("ListActiveCurtailedDevices not exercised by Stop handler tests")
 }
+func (s *stopStubStore) ListActiveCurtailmentTargetDevices(context.Context, int64) ([]string, error) {
+	panic("ListActiveCurtailmentTargetDevices not exercised by Stop handler tests")
+}
 func (s *stopStubStore) ListRecentlyResolvedCurtailedDevices(context.Context, int64, int32) ([]string, error) {
 	panic("ListRecentlyResolvedCurtailedDevices not exercised by Stop handler tests")
 }
@@ -55,6 +58,9 @@ func (s *stopStubStore) ListCandidates(context.Context, interfaces.ListCandidate
 }
 func (s *stopStubStore) InsertEventWithTargets(context.Context, models.InsertEventParams, []models.InsertTargetParams) (*models.InsertEventResult, error) {
 	panic("InsertEventWithTargets not exercised by Stop handler tests")
+}
+func (s *stopStubStore) ClaimClosedLoopFullFleetTargets(context.Context, int64, []models.InsertTargetParams) ([]*models.Target, error) {
+	panic("ClaimClosedLoopFullFleetTargets not exercised by Stop handler tests")
 }
 func (s *stopStubStore) GetEventByUUID(_ context.Context, _ int64, _ uuid.UUID) (*models.Event, error) {
 	if s.getEventErr != nil {

--- a/server/internal/handlers/curtailment/handler_update_test.go
+++ b/server/internal/handlers/curtailment/handler_update_test.go
@@ -125,6 +125,9 @@ func (s *updateStubStore) UpdateOrgConfigPostEventCooldown(context.Context, int6
 func (s *updateStubStore) ListActiveCurtailedDevices(context.Context, int64) ([]string, error) {
 	panic("ListActiveCurtailedDevices not exercised by Update handler tests")
 }
+func (s *updateStubStore) ListActiveCurtailmentTargetDevices(context.Context, int64) ([]string, error) {
+	panic("ListActiveCurtailmentTargetDevices not exercised by Update handler tests")
+}
 func (s *updateStubStore) ListRecentlyResolvedCurtailedDevices(context.Context, int64, int32) ([]string, error) {
 	panic("ListRecentlyResolvedCurtailedDevices not exercised by Update handler tests")
 }
@@ -136,6 +139,9 @@ func (s *updateStubStore) ListCandidates(context.Context, interfaces.ListCandida
 }
 func (s *updateStubStore) InsertEventWithTargets(context.Context, models.InsertEventParams, []models.InsertTargetParams) (*models.InsertEventResult, error) {
 	panic("InsertEventWithTargets not exercised by Update handler tests")
+}
+func (s *updateStubStore) ClaimClosedLoopFullFleetTargets(context.Context, int64, []models.InsertTargetParams) ([]*models.Target, error) {
+	panic("ClaimClosedLoopFullFleetTargets not exercised by Update handler tests")
 }
 func (s *updateStubStore) ListActiveEvents(context.Context, int64) ([]*models.Event, error) {
 	panic("ListActiveEvents not exercised by Update handler tests")

--- a/server/internal/handlers/curtailment/translate.go
+++ b/server/internal/handlers/curtailment/translate.go
@@ -282,6 +282,9 @@ func toStartResponse(plan *curtailment.Plan, req *pb.StartCurtailmentRequest) *p
 	if plan.EventUUID != nil {
 		event.EventUuid = plan.EventUUID.String()
 	}
+	if plan.StartedAt != nil {
+		event.StartedAt = timestamppb.New(*plan.StartedAt)
+	}
 	if plan.EndedAt != nil {
 		event.EndedAt = timestamppb.New(*plan.EndedAt)
 	}

--- a/server/internal/handlers/curtailment/translate.go
+++ b/server/internal/handlers/curtailment/translate.go
@@ -233,21 +233,34 @@ func toStartScope(msg *pb.StartCurtailmentRequest) (curtailment.Scope, error) {
 	}
 }
 
-// startResponseState mirrors the persisted state for the synchronous Start
-// response: a FULL_FLEET event with nothing eligible is COMPLETED on arrival;
-// everything else is PENDING and the reconciler drives it.
-func startResponseState(mode pb.CurtailmentMode, selected int) pb.CurtailmentEventState {
-	if mode == pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET && selected == 0 {
+// startResponseState mirrors the persisted state for the synchronous Start response.
+func startResponseState(req *pb.StartCurtailmentRequest, selected int) pb.CurtailmentEventState {
+	if isClosedLoopFullFleetStartResponse(req) {
+		return pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_ACTIVE
+	}
+	if req.GetMode() == pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET && selected == 0 {
 		return pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_COMPLETED
 	}
 	return pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_PENDING
+}
+
+func isClosedLoopFullFleetStartResponse(req *pb.StartCurtailmentRequest) bool {
+	if req.GetMode() != pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET {
+		return false
+	}
+	switch req.GetScope().(type) {
+	case *pb.StartCurtailmentRequest_WholeOrg, *pb.StartCurtailmentRequest_Site:
+		return true
+	default:
+		return false
+	}
 }
 
 // toStartResponse renders a newly persisted Plan + request as the
 // response. Idempotent replays render from the persisted event row.
 func toStartResponse(plan *curtailment.Plan, req *pb.StartCurtailmentRequest) *pb.StartCurtailmentResponse {
 	event := &pb.CurtailmentEvent{
-		State:                   startResponseState(req.GetMode(), len(plan.Selected)),
+		State:                   startResponseState(req, len(plan.Selected)),
 		Mode:                    requestModeProto(req.GetMode()),
 		Strategy:                pb.CurtailmentStrategy_CURTAILMENT_STRATEGY_LEAST_EFFICIENT_FIRST,
 		Level:                   pb.CurtailmentLevel_CURTAILMENT_LEVEL_FULL,
@@ -288,20 +301,23 @@ func toStartResponse(plan *curtailment.Plan, req *pb.StartCurtailmentRequest) *p
 		event.ModeParams = &pb.CurtailmentEvent_FixedKw{FixedKw: fk}
 	}
 
-	// All targets are PENDING at Start; reconciler updates them in-place.
-	targets := make([]*pb.CurtailmentTarget, len(plan.Selected))
-	for i, sel := range plan.Selected {
-		t := &pb.CurtailmentTarget{
-			DeviceIdentifier: sel.DeviceIdentifier,
-			TargetType:       "miner",
-			State:            pb.CurtailmentTargetState_CURTAILMENT_TARGET_STATE_PENDING,
-			DesiredState:     pb.CurtailmentTargetDesiredState_CURTAILMENT_TARGET_DESIRED_STATE_CURTAILED,
+	var targets []*pb.CurtailmentTarget
+	if !isClosedLoopFullFleetStartResponse(req) {
+		// Open-loop starts persist targets immediately; reconciler updates them in-place.
+		targets = make([]*pb.CurtailmentTarget, len(plan.Selected))
+		for i, sel := range plan.Selected {
+			t := &pb.CurtailmentTarget{
+				DeviceIdentifier: sel.DeviceIdentifier,
+				TargetType:       "miner",
+				State:            pb.CurtailmentTargetState_CURTAILMENT_TARGET_STATE_PENDING,
+				DesiredState:     pb.CurtailmentTargetDesiredState_CURTAILMENT_TARGET_DESIRED_STATE_CURTAILED,
+			}
+			if sel.PowerW > 0 {
+				v := sel.PowerW
+				t.BaselinePowerW = &v
+			}
+			targets[i] = t
 		}
-		if sel.PowerW > 0 {
-			v := sel.PowerW
-			t.BaselinePowerW = &v
-		}
-		targets[i] = t
 	}
 	event.Targets = targets
 	rollup := lenToInt32Saturating(len(targets))

--- a/server/internal/handlers/curtailment/translate_fullfleet_test.go
+++ b/server/internal/handlers/curtailment/translate_fullfleet_test.go
@@ -77,7 +77,9 @@ func TestPopulateEventModeParams_FullFleet(t *testing.T) {
 func TestToStartResponse_ClosedLoopFullFleetReturnsActiveTargetlessEvent(t *testing.T) {
 	t.Parallel()
 
+	startedAt := time.Date(2026, 6, 4, 11, 0, 0, 0, time.UTC)
 	plan := &curtailment.Plan{
+		StartedAt: &startedAt,
 		Selected: []curtailment.SelectedDevice{
 			{DeviceIdentifier: "miner-a", PowerW: 3000},
 		},
@@ -92,6 +94,8 @@ func TestToStartResponse_ClosedLoopFullFleetReturnsActiveTargetlessEvent(t *test
 	assert.Equal(t, pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_ACTIVE, event.GetState())
 	assert.Empty(t, event.GetTargets())
 	assert.Equal(t, int32(0), event.GetTargetRollup().GetTotal())
+	require.NotNil(t, event.GetStartedAt())
+	assert.Equal(t, plan.StartedAt.Unix(), event.GetStartedAt().AsTime().Unix())
 	assert.Nil(t, event.GetEndedAt())
 }
 

--- a/server/internal/handlers/curtailment/translate_fullfleet_test.go
+++ b/server/internal/handlers/curtailment/translate_fullfleet_test.go
@@ -74,17 +74,37 @@ func TestPopulateEventModeParams_FullFleet(t *testing.T) {
 	assert.Nil(t, out.GetFixedKw())
 }
 
-// An empty FULL_FLEET start persists a COMPLETED event with a stamped ended_at;
-// the synchronous Start response must carry that completion time too, so it
-// agrees with a later Get/List.
-func TestToStartResponse_FullFleetEmptyCarriesEndedAt(t *testing.T) {
+func TestToStartResponse_ClosedLoopFullFleetReturnsActiveTargetlessEvent(t *testing.T) {
+	t.Parallel()
+
+	plan := &curtailment.Plan{
+		Selected: []curtailment.SelectedDevice{
+			{DeviceIdentifier: "miner-a", PowerW: 3000},
+		},
+	}
+	req := &pb.StartCurtailmentRequest{
+		Mode:  pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET,
+		Scope: &pb.StartCurtailmentRequest_WholeOrg{WholeOrg: &pb.ScopeWholeOrg{}},
+	}
+
+	event := toStartResponse(plan, req).GetEvent()
+	require.NotNil(t, event)
+	assert.Equal(t, pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_ACTIVE, event.GetState())
+	assert.Empty(t, event.GetTargets())
+	assert.Equal(t, int32(0), event.GetTargetRollup().GetTotal())
+	assert.Nil(t, event.GetEndedAt())
+}
+
+// Device-list FULL_FLEET remains an open-loop snapshot. Empty snapshots complete
+// on arrival and the synchronous Start response must carry the completion time.
+func TestToStartResponse_DeviceListFullFleetEmptyCarriesEndedAt(t *testing.T) {
 	t.Parallel()
 
 	endedAt := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	plan := &curtailment.Plan{EndedAt: &endedAt} // no Selected -> empty full_fleet
 	req := &pb.StartCurtailmentRequest{
 		Mode:  pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET,
-		Scope: &pb.StartCurtailmentRequest_WholeOrg{WholeOrg: &pb.ScopeWholeOrg{}},
+		Scope: &pb.StartCurtailmentRequest_DeviceIdentifiers{DeviceIdentifiers: &pb.ScopeDeviceList{DeviceIdentifiers: []string{"miner-a"}}},
 	}
 
 	event := toStartResponse(plan, req).GetEvent()

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -73,6 +73,33 @@ FROM curtailment_target ct
 JOIN curtailment_event ce ON ce.id = ct.curtailment_event_id
 WHERE ce.org_id = sqlc.arg('org_id')
     AND ce.state IN ('pending', 'active', 'restoring')
+    AND ct.state NOT IN ('resolved', 'restore_failed', 'released')
+UNION
+SELECT d.device_identifier
+FROM curtailment_event ce
+JOIN device d ON d.org_id = ce.org_id
+    AND d.deleted_at IS NULL
+    AND (
+        ce.scope_type = 'whole_org'
+        OR (
+            ce.scope_type = 'site'
+            AND d.site_id = (ce.scope_jsonb->>'site_id')::BIGINT
+        )
+    )
+WHERE ce.org_id = sqlc.arg('org_id')
+    AND ce.state IN ('pending', 'active', 'restoring')
+    AND ce.mode = 'FULL_FLEET'
+    AND ce.loop_type = 'closed';
+
+-- name: ListActiveCurtailmentTargetDevicesByOrg :many
+-- Devices with concrete non-terminal target rows; used by closed-loop
+-- admission to skip miners already owned by other events without excluding
+-- the current targetless scope watcher.
+SELECT DISTINCT ct.device_identifier
+FROM curtailment_target ct
+JOIN curtailment_event ce ON ce.id = ct.curtailment_event_id
+WHERE ce.org_id = sqlc.arg('org_id')
+    AND ce.state IN ('pending', 'active', 'restoring')
     AND ct.state NOT IN ('resolved', 'restore_failed', 'released');
 
 -- name: ListRecentlyResolvedCurtailedDevicesByOrg :many
@@ -122,6 +149,7 @@ INSERT INTO curtailment_event (
     idempotency_key,
     reason,
     scheduled_start_at,
+    started_at,
     ended_at,
     created_by_user_id,
     effective_batch_size
@@ -154,6 +182,7 @@ INSERT INTO curtailment_event (
     sqlc.narg('idempotency_key'),
     sqlc.arg('reason'),
     sqlc.narg('scheduled_start_at'),
+    sqlc.narg('started_at'),
     sqlc.narg('ended_at'),
     sqlc.arg('created_by_user_id'),
     sqlc.arg('effective_batch_size')
@@ -454,6 +483,87 @@ FROM jsonb_to_recordset(sqlc.arg('targets_jsonb')::JSONB) AS t(
     baseline_power_w          NUMERIC(12,3),
     selector_rationale_jsonb  JSONB
 );
+
+-- name: LockCurtailmentScopeForWrite :exec
+-- Serialize hierarchy start checks by org so conflict detection and event
+-- insertion happen under one database-backed critical section.
+SELECT pg_advisory_xact_lock(hashtextextended('curtailment_scope:' || sqlc.arg('org_id')::text, 0));
+
+-- name: CountCurtailmentScopeConflicts :one
+-- Hierarchy for currently supported scopes: org > site.
+-- A new whole-org event conflicts with existing whole-org or site events.
+-- A new site event conflicts with existing whole-org or same-site events.
+SELECT count(*)::BIGINT
+FROM curtailment_event
+WHERE org_id = sqlc.arg('org_id')
+  AND state IN ('pending', 'active', 'restoring')
+  AND sqlc.arg('mode')::TEXT = 'FULL_FLEET'
+  AND sqlc.arg('loop_type')::TEXT = 'closed'
+  AND (
+    (
+      sqlc.arg('scope_type')::TEXT = 'whole_org'
+      AND scope_type IN ('whole_org', 'site')
+    )
+    OR (
+      sqlc.arg('scope_type')::TEXT = 'site'
+      AND (
+        scope_type = 'whole_org'
+        OR (
+          scope_type = 'site'
+          AND scope_jsonb->>'site_id' = sqlc.arg('site_id')::TEXT
+        )
+      )
+    )
+  );
+
+-- name: ClaimClosedLoopFullFleetTargets :many
+-- Closed-loop FULL_FLEET dispatch claim. Locks the parent event so
+-- Stop/AdminTerminate and dynamic target claims serialize on lifecycle state.
+-- Same-event duplicates and cross-event target conflicts are no-ops; the
+-- reconciler retries on a later tick if a conflicting event resolves.
+WITH locked_event AS MATERIALIZED (
+    SELECT id
+    FROM curtailment_event
+    WHERE id = sqlc.arg('curtailment_event_id')
+      AND state IN ('pending', 'active')
+      AND mode = 'FULL_FLEET'
+      AND loop_type = 'closed'
+    FOR UPDATE
+)
+INSERT INTO curtailment_target (
+    curtailment_event_id,
+    device_identifier,
+    target_type,
+    state,
+    desired_state,
+    baseline_power_w,
+    selector_rationale_jsonb
+)
+SELECT
+    locked_event.id,
+    t.device_identifier,
+    t.target_type,
+    'dispatching',
+    t.desired_state,
+    t.baseline_power_w,
+    t.selector_rationale_jsonb
+FROM locked_event
+JOIN jsonb_to_recordset(sqlc.arg('targets_jsonb')::JSONB) AS t(
+    device_identifier         TEXT,
+    target_type               TEXT,
+    state                     TEXT,
+    desired_state             TEXT,
+    baseline_power_w          NUMERIC(12,3),
+    selector_rationale_jsonb  JSONB
+) ON TRUE
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM curtailment_target existing
+    WHERE existing.curtailment_event_id = locked_event.id
+      AND existing.device_identifier = t.device_identifier
+)
+ON CONFLICT DO NOTHING
+RETURNING curtailment_target.*;
 
 -- name: ListCurtailmentTargetsByEvent :many
 -- Org-scoped via the join.

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -497,6 +497,8 @@ SELECT count(*)::BIGINT
 FROM curtailment_event
 WHERE org_id = sqlc.arg('org_id')
   AND state IN ('pending', 'active', 'restoring')
+  AND mode = 'FULL_FLEET'
+  AND loop_type = 'closed'
   AND sqlc.arg('mode')::TEXT = 'FULL_FLEET'
   AND sqlc.arg('loop_type')::TEXT = 'closed'
   AND (


### PR DESCRIPTION
Reviewable diff: +716/-227 across 12 files (excludes generated, test, and story files).

## Summary

Whole-fleet curtailment now remains active as an asserted command policy and continuously claims eligible miners while OFF is active, instead of depending on a frozen start-time target set. This builds on #512's selector fix: low-power and zero-hash eligible miners can be targeted, while missing or invalid telemetry remains excluded.

Closes #498.

## How it works

Supported whole-org and site `FULL_FLEET` starts are persisted as closed-loop active event windows. The event owns the policy scope; the reconciler computes the live eligible scope each tick and claims per-miner targets immediately before dispatching curtail commands.

A database-backed org > site hierarchy prevents overlapping whole-fleet policies for supported scopes: org-scoped events block site starts in that org, site-scoped events block the same site and org starts, and different sites remain independent. Concrete target rows still provide per-miner conflict protection for overlapping device-list or other non-hierarchical scopes.

```mermaid
flowchart TB
    start["Start FULL_FLEET"] --> scopeCheck{"Org/site scope conflict?"}
    scopeCheck -->|"yes"| reject["Reject start"]
    scopeCheck -->|"no"| event["Persist closed-loop event"]
    event --> tick["Reconciler tick"]
    tick --> candidates["Read live eligible scope"]
    candidates --> conflicts["Exclude existing target rows"]
    conflicts --> claim["Claim next batch as DISPATCHING"]
    claim --> dispatch["Send Curtail"]
    dispatch --> confirm["Confirm via telemetry"]
```

Restore stays target-row based. Since dynamic rows are created at claim time, restore only sees miners Proto Fleet actually attempted to curtail. Targetless active watchers complete directly on stop.

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/sqlc/queries/curtailment.sql` | Adds hierarchy checks, target-row ownership lookup, closed-loop target claim query, and insert `started_at`. | Review the database concurrency contract and scope/target ownership semantics. |
| `server/internal/domain/stores/sqlstores/curtailment.go` | Serializes scope checks, preserves idempotent replay, claims dynamic targets, and completes targetless stops. | This is the durable event/target state boundary. |
| `server/internal/domain/curtailment/reconciler/` | Adds closed-loop scope sweeps, batch-limited target claims, per-target curtail/restore timeouts, and split retry budgets. | Review event progress, retry behavior, and command dispatch safety. |
| `server/internal/domain/curtailment/service.go` | Starts supported full-fleet events as active closed-loop windows without initial target rows and removes cooldown as a curtailment gate. | Review the lifecycle transition from frozen target set to command policy. |
| `server/internal/domain/curtailment/response_profile.go` | Treats full-fleet response profiles as admin-only at save time, not only at automation binding time. | Prevents non-admin profile mutation into an admin-only automation path. |
| `server/cmd/fleetd/` | Wires curtailment reconciler runtime config. | Operators can tune tick/timeout behavior through existing config patterns. |
| `server/internal/handlers/curtailment/*_test.go` | Updates handler test stubs and Start response translation coverage. | Keeps handler packages compiling and response state/timestamps coherent. |
| `server/generated/sqlc/` | Generated from sqlc query source. | Generated - skip except to confirm it matches source. |

## Key technical decisions & trade-offs

- **Claim before command:** target rows are created as `DISPATCHING` immediately before command dispatch, preserving per-miner ownership while avoiding future-intent rows.
- **Hierarchy is org > site only:** building scope is not implemented here; future building scope can extend the same hierarchy rule.
- **Automation full-fleet is explicitly unbounded:** automation-owned full-fleet OFF clears max duration and sets `allow_unbounded`, so the OFF signal is the lifecycle authority. This is intentional: a max-duration restore while OFF is still asserted could re-enable miners during an active curtailment demand. Full-fleet automation/profile creation is admin-gated; this PR does not add an automatic stale-source restore watchdog, so stale-source/operator visibility remains the residual mitigation rather than automatic restore.
- **Cooldown no longer gates curtailment:** post-event cooldown is not applied to Preview/Start or dynamic admission. This is intentional because Fleet should not suppress a valid back-to-back curtailment demand; active event/device ownership still prevents concurrent double-control.
- **Curtail retry budget is an alert threshold, not abandonment:** curtail targets keep retrying while curtailment is asserted, even after `CurtailMaxRetries`. Retry count/last error surface the per-miner problem to operators. Restore remains phase-specific and terminalizes after the restore retry budget so events can conclude.
- **Device-list full-fleet remains an open-loop snapshot:** only whole-org/site full-fleet starts become closed-loop watchers. Device-list/device-set full-fleet starts do not gain live membership semantics in this PR; an empty explicit snapshot can complete as a no-op audit result rather than becoming an enforcement policy.
- **Dynamic admission uses persisted selector policy:** newly claimed full-fleet targets use the `candidate_min_power_w` captured at event start, not a later org-config value.
- **100k dispatch capacity is deferred:** this PR fixes correctness and lifecycle semantics; throughput scaling remains separate capacity work.

## Codex review decision notes

The latest Codex Security Review flagged four behavior changes. They are expected for this PR and documented above so reviewers can explicitly agree or disagree with the product direction:

- Full-fleet automation bypasses max duration: expected for MQTT OFF authority; admin gating and operator visibility are the control points.
- Post-event cooldown is not enforced: expected; Fleet should allow immediate back-to-back curtailment demands.
- Device-list full-fleet can complete as a zero-target no-op: expected for open-loop snapshot scopes; only whole-org/site scopes are closed-loop watchers.
- Curtail failures do not terminalize after retry budget: expected while curtailment is asserted; retry budget surfaces alerts, while restore budget remains terminal.

## Testing & validation

- `go test ./internal/domain/curtailment ./internal/domain/curtailment/reconciler ./internal/handlers/curtailment ./cmd/fleetd`
- `go test ./internal/domain/stores/sqlstores -run '^$'`
- `DB_NAME=fleet DB_ADDRESS=127.0.0.1:5432 DB_USERNAME=fleet DB_PASSWORD=fleet DB_SSL_MODE=disable go test ./internal/domain/stores/sqlstores -run 'TestSQLCurtailmentStore_(ClosedLoopScopeHierarchyConflicts|ClosedLoopScopeConflictPreservesIdempotentReplay|ClaimClosedLoopFullFleetTargets|BeginRestoreTransition_CompletesTargetlessClosedLoopEvent)'`
- `git diff --check`
- Pre-push `server-lint`
