### PR TITLE
refactor(sites): align ManageSiteModal with building/rack modal pattern

### DIFF
--- a/client/src/protoFleet/features/sites/components/ManageBuildingsModal/ManageBuildingsModal.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageBuildingsModal/ManageBuildingsModal.tsx
@@ -1,0 +1,247 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { buildBuildingPickerItem, type BuildingPickerItem } from "./buildingPickerItem";
+import { computeBuildingSelectionDelta } from "./buildingSelectionDelta";
+import { useBuildings } from "@/protoFleet/api/buildings";
+import { useSites } from "@/protoFleet/api/sites";
+import { ChevronDown } from "@/shared/assets/icons";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import List from "@/shared/components/List";
+import type { ColConfig, ColTitles } from "@/shared/components/List/types";
+import Modal, { ModalSelectAllFooter } from "@/shared/components/Modal";
+import ProgressCircular from "@/shared/components/ProgressCircular";
+
+type BuildingPickerColumn = "name" | "site" | "status";
+
+interface ManageBuildingsModalProps {
+  open: boolean;
+  // Parent site context drives the eligibility split.
+  siteId: bigint;
+  // Building IDs currently in the site's working set. The modal seeds its
+  // selection with these so the operator sees current state and can add /
+  // remove in one flow.
+  initialSelectedBuildingIds: bigint[];
+  onDismiss: () => void;
+  // Returns the delta against initialSelectedBuildingIds: `added` is the
+  // newly-checked buildings (id + label so the caller can render without a
+  // separate lookup); `removed` is the seeded ids the operator unchecked.
+  // Untouched buildings are in neither list — the caller leaves them as-is.
+  onConfirm: (delta: { added: { buildingId: bigint; label: string }[]; removed: bigint[] }) => void;
+}
+
+const PAGE_SIZE = 25;
+
+const colTitles: ColTitles<BuildingPickerColumn> = {
+  name: "Name",
+  site: "Site",
+  status: "Status",
+};
+
+const colConfig: ColConfig<BuildingPickerItem, string, BuildingPickerColumn> = {
+  name: {
+    component: (item) => <span>{item.label || "(unnamed building)"}</span>,
+    width: "min-w-32",
+  },
+  site: {
+    component: (item) => <span>{item.siteLabel}</span>,
+    width: "min-w-32",
+  },
+  status: {
+    component: (item) => <span>{item.statusLabel}</span>,
+    width: "min-w-32",
+  },
+};
+
+const activeCols: BuildingPickerColumn[] = ["name", "site", "status"];
+
+const ManageBuildingsModal = ({
+  open,
+  siteId,
+  initialSelectedBuildingIds,
+  onDismiss,
+  onConfirm,
+}: ManageBuildingsModalProps) => {
+  const { listAllBuildings } = useBuildings();
+  const { listSites } = useSites();
+  const [items, setItems] = useState<BuildingPickerItem[] | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedItems, setSelectedItems] = useState<string[]>(() =>
+    initialSelectedBuildingIds.map((id) => id.toString()),
+  );
+  const [page, setPage] = useState(0);
+  // Self-fetched site id → display label map for the Site column. Falls
+  // back to "—" via buildBuildingPickerItem when an id is missing.
+  const [siteMap, setSiteMap] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void listSites({
+      onSuccess: (rows) => {
+        if (cancelled) return;
+        const out: Record<string, string> = {};
+        for (const row of rows) {
+          const s = row.site;
+          if (s) out[s.id.toString()] = s.name;
+        }
+        setSiteMap(out);
+      },
+      // Silent on error — the Site column degrades to "—" but the picker
+      // still functions.
+      onError: () => {
+        if (!cancelled) setSiteMap({});
+      },
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, listSites]);
+
+  // Fetch the full building list and build picker items. Cross-site
+  // eligibility is computed per-row in buildBuildingPickerItem so the
+  // operator sees the org-wide list with ineligible buildings rendered
+  // disabled. Conditional mount guarantees fresh state per open.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void listAllBuildings({
+      onSuccess: (rows) => {
+        if (cancelled) return;
+        const out: BuildingPickerItem[] = [];
+        for (const row of rows) {
+          const item = buildBuildingPickerItem(row, siteId, siteMap);
+          if (item) out.push(item);
+        }
+        out.sort((a, b) => a.label.localeCompare(b.label));
+        setItems(out);
+      },
+      onError: (msg) => {
+        if (cancelled) return;
+        setError(msg);
+        setItems([]);
+      },
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, siteId, siteMap, listAllBuildings]);
+
+  const isRowDisabled = useCallback((item: BuildingPickerItem) => item.disabled, []);
+
+  // Client-side pagination — List consumes a flat array, so we slice here.
+  const pageItems = useMemo(() => {
+    if (!items) return [];
+    const start = page * PAGE_SIZE;
+    return items.slice(start, start + PAGE_SIZE);
+  }, [items, page]);
+  const totalItems = items?.length ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
+  const hasPreviousPage = page > 0;
+  const hasNextPage = page < totalPages - 1;
+
+  const handleConfirm = useCallback(() => {
+    if (!items) return;
+    onConfirm(computeBuildingSelectionDelta(items, initialSelectedBuildingIds, selectedItems));
+  }, [items, selectedItems, initialSelectedBuildingIds, onConfirm]);
+
+  const handleSelectAll = useCallback(() => {
+    if (!items) return;
+    // Select-all promotes the *eligible* set (excluding disabled rows).
+    setSelectedItems(items.filter((b) => !b.disabled).map((b) => b.id));
+  }, [items]);
+
+  const handleSelectNone = useCallback(() => setSelectedItems([]), []);
+
+  return (
+    <Modal
+      open={open}
+      title="Select buildings"
+      size="large"
+      className="flex !h-[calc(100vh-(--spacing(32)))] max-h-[calc(100vh-(--spacing(32)))] flex-col !overflow-hidden"
+      bodyClassName="flex flex-1 min-h-0 flex-col overflow-hidden"
+      onDismiss={onDismiss}
+      divider={false}
+      testId="manage-buildings-modal"
+      buttons={[
+        {
+          text: "Continue",
+          variant: "primary",
+          onClick: handleConfirm,
+          dismissModalOnClick: false,
+          testId: "manage-buildings-modal-confirm",
+        },
+      ]}
+    >
+      <div className="flex h-full min-h-0 flex-col">
+        {error ? (
+          <div className="py-6 text-300 text-intent-critical-fill" data-testid="manage-buildings-modal-error">
+            {error}
+          </div>
+        ) : items === undefined ? (
+          <div className="flex flex-1 items-center justify-center py-12">
+            <ProgressCircular indeterminate />
+          </div>
+        ) : (
+          <>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <List<BuildingPickerItem, string, BuildingPickerColumn>
+                activeCols={activeCols}
+                colTitles={colTitles}
+                colConfig={colConfig}
+                items={pageItems}
+                itemKey="id"
+                itemSelectable
+                selectionType="checkbox"
+                customSelectedItems={selectedItems}
+                customSetSelectedItems={setSelectedItems}
+                preserveOffPageSelection
+                isRowDisabled={isRowDisabled}
+                itemName={{ singular: "building", plural: "buildings" }}
+                hideTotal
+                containerClassName="min-h-0"
+                overflowContainer
+                stickyBgColor="bg-surface-elevated-base"
+                footerContent={
+                  totalItems > PAGE_SIZE ? (
+                    <div className="flex flex-col items-center gap-4 py-6">
+                      <span className="text-300 text-text-primary">
+                        Showing {page * PAGE_SIZE + 1}–{page * PAGE_SIZE + pageItems.length} of {totalItems} buildings
+                      </span>
+                      <div className="flex gap-3">
+                        <Button
+                          variant={variants.secondary}
+                          size={sizes.compact}
+                          ariaLabel="Previous page"
+                          prefixIcon={<ChevronDown className="rotate-90" />}
+                          onClick={() => setPage((p) => Math.max(0, p - 1))}
+                          disabled={!hasPreviousPage}
+                        />
+                        <Button
+                          variant={variants.secondary}
+                          size={sizes.compact}
+                          ariaLabel="Next page"
+                          prefixIcon={<ChevronDown className="rotate-270" />}
+                          onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                          disabled={!hasNextPage}
+                        />
+                      </div>
+                    </div>
+                  ) : null
+                }
+              />
+            </div>
+            <div className="shrink-0">
+              <ModalSelectAllFooter
+                label={`${selectedItems.length} ${selectedItems.length === 1 ? "building" : "buildings"} selected`}
+                onSelectAll={handleSelectAll}
+                onSelectNone={handleSelectNone}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default ManageBuildingsModal;

--- a/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingPickerItem.ts
+++ b/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingPickerItem.ts
@@ -1,0 +1,37 @@
+// Row-shape + eligibility builder for ManageBuildingsModal. Classifies a
+// BuildingWithCounts against the site eligibility rules (in-this-site /
+// in-another-site / unassigned) and renders Name + Site + Status columns.
+// Mirrors rackPickerItem so the building picker stays visually consistent
+// with the rack picker.
+
+import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+
+export interface BuildingPickerItem {
+  id: string;
+  label: string;
+  siteLabel: string;
+  statusLabel: string;
+  disabled: boolean;
+}
+
+export const buildBuildingPickerItem = (
+  row: BuildingWithCounts,
+  currentSiteId: bigint,
+  siteLabels: Record<string, string>,
+): BuildingPickerItem | null => {
+  const building = row.building;
+  if (!building) return null;
+  const siteId = building.siteId;
+  const inThisSite = siteId !== undefined && siteId !== 0n && siteId === currentSiteId;
+  // Buildings under a *different* site are ineligible because moving them
+  // across sites cascades site_id down to every rack + device — a heavier
+  // operator decision than this picker should make implicitly. The picker
+  // only adds buildings that already share this site or are unassigned.
+  const inOtherSite = siteId !== undefined && siteId !== 0n && siteId !== currentSiteId;
+  // Ineligible-but-visible: buildings in another site render disabled so
+  // the operator sees why they can't be added.
+  const disabled = inOtherSite;
+  const statusLabel = inOtherSite ? "In another site" : inThisSite ? "In this site" : "Unassigned";
+  const siteLabel = siteId === undefined || siteId === 0n ? "—" : (siteLabels[siteId.toString()] ?? "—");
+  return { id: building.id.toString(), label: building.name, siteLabel, statusLabel, disabled };
+};

--- a/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingSelectionDelta.test.ts
+++ b/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingSelectionDelta.test.ts
@@ -53,6 +53,16 @@ describe("computeBuildingSelectionDelta", () => {
     expect(out.added).toEqual([{ buildingId: 1n, label: "B-1" }]);
   });
 
+  it("does not remove a disabled seeded id (reassigned to another site since seeding)", () => {
+    // Building 2 was in this site when the working set was seeded, but has
+    // since been reassigned elsewhere, so the picker renders it disabled.
+    // "Select none" must not emit it as removed — that would unassign it
+    // from the other site.
+    const items = [eligible("1"), disabledItem("2")];
+    const out = computeBuildingSelectionDelta(items, [1n, 2n], []);
+    expect(out.removed).toEqual([1n]);
+  });
+
   it("mixed delta: one add + one remove + one untouched-missing", () => {
     const items = [eligible("1"), eligible("3"), eligible("4")];
     const out = computeBuildingSelectionDelta(items, [1n, 3n, 99n], ["1", "4"]);

--- a/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingSelectionDelta.test.ts
+++ b/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingSelectionDelta.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { type BuildingPickerItem } from "./buildingPickerItem";
+import { computeBuildingSelectionDelta } from "./buildingSelectionDelta";
+
+const eligible = (id: string, label = `B-${id}`): BuildingPickerItem => ({
+  id,
+  label,
+  siteLabel: "—",
+  statusLabel: "Unassigned",
+  disabled: false,
+});
+
+const disabledItem = (id: string, label = `B-${id}`): BuildingPickerItem => ({
+  id,
+  label,
+  siteLabel: "Other",
+  statusLabel: "In another site",
+  disabled: true,
+});
+
+describe("computeBuildingSelectionDelta", () => {
+  it("returns empty delta when nothing changed", () => {
+    const items = [eligible("1"), eligible("2")];
+    const out = computeBuildingSelectionDelta(items, [1n, 2n], ["1", "2"]);
+    expect(out.added).toEqual([]);
+    expect(out.removed).toEqual([]);
+  });
+
+  it("classifies newly-checked ids as added with labels", () => {
+    const items = [eligible("1"), eligible("2", "Building-2")];
+    const out = computeBuildingSelectionDelta(items, [1n], ["1", "2"]);
+    expect(out.added).toEqual([{ buildingId: 2n, label: "Building-2" }]);
+    expect(out.removed).toEqual([]);
+  });
+
+  it("classifies seeded-and-now-unchecked ids as removed", () => {
+    const items = [eligible("1"), eligible("2"), eligible("3")];
+    const out = computeBuildingSelectionDelta(items, [1n, 2n, 3n], ["1", "3"]);
+    expect(out.added).toEqual([]);
+    expect(out.removed).toEqual([2n]);
+  });
+
+  it("preserves seeded ids missing from items (race / paging gap)", () => {
+    const items = [eligible("1")];
+    const out = computeBuildingSelectionDelta(items, [1n, 99n], ["1"]);
+    expect(out.removed).toEqual([]);
+  });
+
+  it("does not add disabled-row ids even if selectedItems lists them", () => {
+    const items = [eligible("1"), disabledItem("2")];
+    const out = computeBuildingSelectionDelta(items, [], ["1", "2"]);
+    expect(out.added).toEqual([{ buildingId: 1n, label: "B-1" }]);
+  });
+
+  it("mixed delta: one add + one remove + one untouched-missing", () => {
+    const items = [eligible("1"), eligible("3"), eligible("4")];
+    const out = computeBuildingSelectionDelta(items, [1n, 3n, 99n], ["1", "4"]);
+    expect(out.added).toEqual([{ buildingId: 4n, label: "B-4" }]);
+    expect(out.removed).toEqual([3n]); // 99n stays — missing from items
+  });
+});

--- a/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingSelectionDelta.ts
+++ b/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingSelectionDelta.ts
@@ -1,0 +1,50 @@
+// Pure delta computation for ManageBuildingsModal so the "seeded id missing
+// from items is preserved" invariant can be unit-tested. Mirrors
+// computeRackSelectionDelta: a seeded id absent from the listed items is
+// left untouched (we can't tell deselection from a paging / race gap), so
+// the caller never accidentally unassigns a building the response omitted.
+
+import { type BuildingPickerItem } from "./buildingPickerItem";
+
+export interface BuildingSelectionDelta {
+  added: { buildingId: bigint; label: string }[];
+  removed: bigint[];
+}
+
+// Compute the delta between the seeded selection (initial) and the
+// operator's checked state (selectedItemIds) given the picker's current
+// items list.
+//
+//   added: ids the operator just checked. Skipped when the item is
+//   disabled or absent from items.
+//
+//   removed: seeded ids the operator unchecked. Skipped when the id is
+//   absent from items — that means we don't actually know whether the
+//   operator deselected it or whether listBuildings didn't return it. The
+//   safe default is to leave it alone so the caller preserves membership.
+export const computeBuildingSelectionDelta = (
+  items: BuildingPickerItem[],
+  initialSelectedBuildingIds: bigint[],
+  selectedItemIds: string[],
+): BuildingSelectionDelta => {
+  const initialSet = new Set(initialSelectedBuildingIds.map((id) => id.toString()));
+  const selectedSet = new Set(selectedItemIds);
+
+  const added: { buildingId: bigint; label: string }[] = [];
+  for (const id of selectedItemIds) {
+    if (initialSet.has(id)) continue;
+    const item = items.find((b) => b.id === id);
+    if (!item || item.disabled) continue;
+    added.push({ buildingId: BigInt(id), label: item.label });
+  }
+
+  const removed: bigint[] = [];
+  for (const id of initialSelectedBuildingIds) {
+    if (selectedSet.has(id.toString())) continue;
+    const seedItem = items.find((b) => b.id === id.toString());
+    if (!seedItem) continue;
+    removed.push(id);
+  }
+
+  return { added, removed };
+};

--- a/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingSelectionDelta.ts
+++ b/client/src/protoFleet/features/sites/components/ManageBuildingsModal/buildingSelectionDelta.ts
@@ -22,6 +22,10 @@ export interface BuildingSelectionDelta {
 //   absent from items — that means we don't actually know whether the
 //   operator deselected it or whether listBuildings didn't return it. The
 //   safe default is to leave it alone so the caller preserves membership.
+//   Also skipped when the seeded item is now disabled: a building that was
+//   reassigned to another site since the working set was seeded renders
+//   ineligible, and "Select none" must not emit it as removed — doing so
+//   would unassign it from that other site.
 export const computeBuildingSelectionDelta = (
   items: BuildingPickerItem[],
   initialSelectedBuildingIds: bigint[],
@@ -42,7 +46,7 @@ export const computeBuildingSelectionDelta = (
   for (const id of initialSelectedBuildingIds) {
     if (selectedSet.has(id.toString())) continue;
     const seedItem = items.find((b) => b.id === id.toString());
-    if (!seedItem) continue;
+    if (!seedItem || seedItem.disabled) continue;
     removed.push(id);
   }
 

--- a/client/src/protoFleet/features/sites/components/ManageBuildingsModal/index.ts
+++ b/client/src/protoFleet/features/sites/components/ManageBuildingsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ManageBuildingsModal";

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
@@ -68,6 +68,26 @@ describe("ManageSiteModal", () => {
     await waitFor(() => expect(onDismiss).toHaveBeenCalled());
   });
 
+  it("disables Save in edit mode until the building list has loaded", () => {
+    // No seed → listBuildingsBySite never calls onSuccess, so the working
+    // set stays in the loading (undefined) state.
+    const site = create(SiteSchema, { id: 7n, name: "East DC" });
+    render(
+      <ManageSiteModal
+        open
+        mode="edit"
+        site={site}
+        draft={draft({ name: "East DC" })}
+        onSave={vi.fn()}
+        onEditDetails={noop}
+        onDeleteRequested={noop}
+        onDismiss={noop}
+      />,
+    );
+
+    expect(screen.getAllByTestId("manage-site-modal-save")[0]).toBeDisabled();
+  });
+
   it("Site settings fires the parent callback", () => {
     const onEditDetails = vi.fn();
     render(

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
@@ -1,18 +1,37 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 
 import ManageSiteModal from "./ManageSiteModal";
+import { BuildingSchema, BuildingWithCountsSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { SiteSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { emptySiteFormValues, type SiteFormValues } from "@/protoFleet/api/sites";
 
+// Per-test seeding for the building fetch. listBuildingsBySite invokes the
+// caller's onSuccess synchronously with whatever rows the test queued.
+const { listBuildingsBySiteMock } = vi.hoisted(() => ({ listBuildingsBySiteMock: vi.fn() }));
+
 vi.mock("@/protoFleet/api/buildings", () => ({
   useBuildings: () => ({
-    listBuildingsBySite: vi.fn().mockResolvedValue(undefined),
+    listBuildingsBySite: listBuildingsBySiteMock,
     listAllBuildings: vi.fn(),
     getBuilding: vi.fn(),
   }),
 }));
+
+const seedBuildings = (rows: { id: bigint; name: string; siteId: bigint; rackCount: bigint }[]) => {
+  listBuildingsBySiteMock.mockImplementation((args?: { onSuccess?: (rows: unknown[]) => void }) => {
+    args?.onSuccess?.(
+      rows.map((r) =>
+        create(BuildingWithCountsSchema, {
+          building: create(BuildingSchema, { id: r.id, name: r.name, siteId: r.siteId }),
+          rackCount: r.rackCount,
+        }),
+      ),
+    );
+    return Promise.resolve(undefined);
+  });
+};
 
 const draft = (overrides: Partial<SiteFormValues> = {}): SiteFormValues => ({
   ...emptySiteFormValues(),
@@ -20,24 +39,23 @@ const draft = (overrides: Partial<SiteFormValues> = {}): SiteFormValues => ({
   ...overrides,
 });
 
+const noop = () => undefined;
+
 describe("ManageSiteModal", () => {
+  beforeEach(() => listBuildingsBySiteMock.mockReset());
+
   it("invokes onSave and closes when the save reports closeOnSuccess", async () => {
-    const onSave = vi.fn().mockResolvedValue({
-      canonicalNetworkConfig: "10.0.0.0/24",
-      warnings: [],
-      closeOnSuccess: true,
-    });
+    const onSave = vi.fn().mockResolvedValue({ closeOnSuccess: true });
     const onDismiss = vi.fn();
-    const onNetworkConfigChange = vi.fn();
 
     render(
       <ManageSiteModal
         open
         mode="create"
-        draft={draft({ networkConfig: "10.0.0.0/24" })}
+        draft={draft()}
         onSave={onSave}
-        onEditDetails={() => undefined}
-        onNetworkConfigChange={onNetworkConfigChange}
+        onEditDetails={noop}
+        onDeleteRequested={noop}
         onDismiss={onDismiss}
       />,
     );
@@ -50,37 +68,7 @@ describe("ManageSiteModal", () => {
     await waitFor(() => expect(onDismiss).toHaveBeenCalled());
   });
 
-  it("renders a warning Callout and replaces the textarea with the canonical value", async () => {
-    const onSave = vi.fn().mockResolvedValue({
-      canonicalNetworkConfig: "10.0.0.0/24\n",
-      warnings: ["overlaps with site East DC"],
-      closeOnSuccess: false,
-    });
-    const onDismiss = vi.fn();
-    const onNetworkConfigChange = vi.fn();
-
-    render(
-      <ManageSiteModal
-        open
-        mode="create"
-        draft={draft({ networkConfig: "10.0.0.0/24" })}
-        onSave={onSave}
-        onEditDetails={() => undefined}
-        onNetworkConfigChange={onNetworkConfigChange}
-        onDismiss={onDismiss}
-      />,
-    );
-
-    // FullScreenTwoPaneModal renders the button twice (laptop + mobile);
-    // click the first instance.
-    fireEvent.click(screen.getAllByTestId("manage-site-modal-save")[0]);
-
-    await waitFor(() => expect(screen.getByTestId("manage-site-modal-warnings")).toBeInTheDocument());
-    expect(onNetworkConfigChange).toHaveBeenCalledWith("10.0.0.0/24\n");
-    expect(onDismiss).not.toHaveBeenCalled();
-  });
-
-  it("Edit details fires the parent callback", () => {
+  it("Site settings fires the parent callback", () => {
     const onEditDetails = vi.fn();
     render(
       <ManageSiteModal
@@ -89,13 +77,49 @@ describe("ManageSiteModal", () => {
         draft={draft()}
         onSave={() => Promise.resolve(null)}
         onEditDetails={onEditDetails}
-        onNetworkConfigChange={() => undefined}
-        onDismiss={() => undefined}
+        onDeleteRequested={noop}
+        onDismiss={noop}
       />,
     );
 
     fireEvent.click(screen.getAllByTestId("manage-site-modal-edit-details")[0]);
     expect(onEditDetails).toHaveBeenCalled();
+  });
+
+  it("Delete site fires onDeleteRequested", () => {
+    const onDeleteRequested = vi.fn();
+    render(
+      <ManageSiteModal
+        open
+        mode="create"
+        draft={draft()}
+        onSave={() => Promise.resolve(null)}
+        onEditDetails={noop}
+        onDeleteRequested={onDeleteRequested}
+        onDismiss={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByTestId("manage-site-modal-delete")[0]);
+    expect(onDeleteRequested).toHaveBeenCalled();
+  });
+
+  it("create mode prompts to save the site before adding buildings", () => {
+    render(
+      <ManageSiteModal
+        open
+        mode="create"
+        draft={draft()}
+        onSave={() => Promise.resolve(null)}
+        onEditDetails={noop}
+        onDeleteRequested={noop}
+        onDismiss={noop}
+      />,
+    );
+
+    expect(screen.getByText("Save the site first to add buildings.")).toBeInTheDocument();
+    // Manage buildings is disabled until the site exists.
+    expect(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]).toBeDisabled();
   });
 
   it("shows comma-separated meta on each corner of the preview", () => {
@@ -118,12 +142,40 @@ describe("ManageSiteModal", () => {
           powerCapacityMw: 5,
         })}
         onSave={() => Promise.resolve(null)}
-        onEditDetails={() => undefined}
-        onNetworkConfigChange={() => undefined}
-        onDismiss={() => undefined}
+        onEditDetails={noop}
+        onDeleteRequested={noop}
+        onDismiss={noop}
       />,
     );
     expect(screen.getByText("East DC, Boston, MA")).toBeInTheDocument();
     expect(screen.getByText("5 MW, 0 buildings")).toBeInTheDocument();
+  });
+
+  it("renders rack count as a subtitle and kebab-removes a building from the working set", () => {
+    seedBuildings([{ id: 1n, name: "Building A", siteId: 7n, rackCount: 3n }]);
+    const site = create(SiteSchema, { id: 7n, name: "East DC" });
+    render(
+      <ManageSiteModal
+        open
+        mode="edit"
+        site={site}
+        draft={draft({ name: "East DC" })}
+        onSave={() => Promise.resolve(null)}
+        onEditDetails={noop}
+        onDeleteRequested={noop}
+        onDismiss={noop}
+      />,
+    );
+
+    // Rack count renders as the row subtitle (not a trailing column).
+    expect(screen.getByTestId("manage-site-modal-building-row-1")).toBeInTheDocument();
+    expect(screen.getByText("3 racks")).toBeInTheDocument();
+
+    // Open the kebab and remove — the row drops from the list locally.
+    fireEvent.click(screen.getByTestId("manage-site-modal-building-menu-1"));
+    fireEvent.click(screen.getByTestId("manage-site-modal-remove-building-1"));
+    expect(screen.queryByTestId("manage-site-modal-building-row-1")).not.toBeInTheDocument();
+    // Empty state takes over once the last building is removed.
+    expect(screen.getByText("No buildings added to this site")).toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
@@ -283,7 +283,11 @@ const ManageSiteModal = ({
             text: saving ? "Saving…" : "Save",
             variant: variants.primary,
             onClick: handleSave,
-            disabled: saving,
+            // Block Save until the edit-mode building list has loaded.
+            // handleSave diffs the working set against initialIdsRef; firing
+            // it while entries are still undefined would diff against an empty
+            // (or stale) working set and unassign buildings on save.
+            disabled: buildingsBusy,
             testId: "manage-site-modal-save",
           },
         ]}

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
@@ -1,19 +1,34 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import ManageBuildingsModal from "../ManageBuildingsModal";
 import { useBuildings } from "@/protoFleet/api/buildings";
 import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { type Site } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { type SiteFormValues } from "@/protoFleet/api/sites";
 import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
 import { formatSiteAddress } from "@/protoFleet/features/sites/formatAddress";
-import { Alert } from "@/shared/assets/icons";
+import { Ellipsis } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
-import Callout, { intents } from "@/shared/components/Callout";
 import Header from "@/shared/components/Header";
 import PlaceholderBlock from "@/shared/components/PlaceholderBlock";
-import Textarea from "@/shared/components/Textarea";
+import { useEscapeDismiss } from "@/shared/hooks/useEscapeDismiss";
 
 export type ManageSiteModalMode = "create" | "edit";
+
+// One building in the modal's working set. Seeded from the server fetch and
+// mutated locally by the Manage buildings picker; persisted on Save.
+interface BuildingEntry {
+  buildingId: bigint;
+  label: string;
+  rackCount: bigint;
+}
+
+// Net membership change between the load-time snapshot and the working set,
+// computed on Save and applied by the host via AssignBuildingsToSite.
+export interface BuildingMembershipDelta {
+  added: bigint[];
+  removed: bigint[];
+}
 
 interface ManageSiteModalProps {
   open: boolean;
@@ -23,30 +38,106 @@ interface ManageSiteModalProps {
   // header off; in create mode there is no row yet so the preview uses the
   // draft values directly.
   site?: Site;
-  // Persisted at save time. Returns the canonical site + warnings so the
-  // modal can refresh the textarea + surface the Callout without owning
-  // the network call itself.
-  onSave: () => Promise<{
-    canonicalNetworkConfig: string;
-    warnings: string[];
-    closeOnSuccess: boolean;
-  } | null>;
+  // Persisted at save time. In edit mode the delta is applied via
+  // AssignBuildingsToSite; in create mode the host first creates the site
+  // (the delta is empty since building management is gated until the site
+  // exists). Returns whether the modal should close on success.
+  onSave: (delta: BuildingMembershipDelta) => Promise<{ closeOnSuccess: boolean } | null>;
+  // Opens SiteSettingsModal stacked on top to edit name / address / etc.
   onEditDetails: () => void;
-  // Bubbles draft.networkConfig edits back to the parent state so a round-
-  // trip through SiteSettingsModal preserves the textarea contents.
-  onNetworkConfigChange: (value: string) => void;
+  // Opens the cascade delete dialog (edit) or discards the pending create.
+  // Mirrors ManageBuildingModal's header Delete CTA.
+  onDeleteRequested: () => void;
   onDismiss: () => void;
   saving?: boolean;
-  // Building-table CTAs. Wired by the host page so the building modal stack
-  // shares a single useBuildingModals instance across ManageSiteModal and
-  // the settings page table.
-  onAddBuilding?: () => void;
-  onEditBuilding?: (row: BuildingWithCounts) => void;
   // Refresh signal — bumped by the host whenever the building cache changes
-  // (post-create / post-delete) so the modal's local list re-fetches without
-  // bouncing through unmount/remount.
+  // (e.g. a building deleted from the settings table) so the modal's local
+  // list re-fetches without bouncing through unmount/remount.
   buildingsRefreshKey?: number;
 }
+
+// Row layout mirrors MinerRow from ManageRackModal: name + secondary line
+// stack on the left, a kebab menu on the right. Buildings have no placement
+// state, so there's no leading icon column or row selection — the only row
+// action is "Remove building", which drops it from the site's working set
+// (the building itself is not deleted).
+const BuildingRow = ({
+  buildingId,
+  label,
+  rackCount,
+  saving,
+  onRemove,
+}: {
+  buildingId: bigint;
+  label: string;
+  rackCount: bigint;
+  saving: boolean;
+  onRemove: (buildingId: bigint) => void;
+}) => {
+  const [showMenu, setShowMenu] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const handleRemove = useCallback(() => {
+    setShowMenu(false);
+    onRemove(buildingId);
+  }, [buildingId, onRemove]);
+
+  useEscapeDismiss(showMenu ? () => setShowMenu(false) : undefined);
+
+  return (
+    <div
+      className="flex items-center px-3 py-3"
+      data-testid={`manage-site-modal-building-row-${buildingId.toString()}`}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-300 text-text-primary">{label || "(unnamed building)"}</div>
+        <div className="truncate text-300 text-text-primary-50">
+          {rackCount.toString()} {rackCount === 1n ? "rack" : "racks"}
+        </div>
+      </div>
+
+      <div className="relative shrink-0" ref={menuRef}>
+        <button
+          type="button"
+          aria-label="Building options"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-text-primary-70 hover:cursor-pointer"
+          disabled={saving}
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowMenu((prev) => !prev);
+          }}
+          data-testid={`manage-site-modal-building-menu-${buildingId.toString()}`}
+        >
+          <Ellipsis width="w-4" />
+        </button>
+        {showMenu ? (
+          <>
+            <div
+              className="fixed inset-0 z-20"
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowMenu(false);
+              }}
+            />
+            <div className="absolute top-full right-0 z-30 mt-1 w-44 rounded-xl border border-border-5 bg-surface-elevated-base py-1 shadow-300">
+              <button
+                type="button"
+                className="w-full px-4 py-2 text-left text-300 text-text-primary hover:bg-surface-2"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRemove();
+                }}
+                data-testid={`manage-site-modal-remove-building-${buildingId.toString()}`}
+              >
+                Remove building
+              </button>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+};
 
 const ManageSiteModal = ({
   open,
@@ -55,21 +146,24 @@ const ManageSiteModal = ({
   site,
   onSave,
   onEditDetails,
-  onNetworkConfigChange,
+  onDeleteRequested,
   onDismiss,
   saving = false,
-  onAddBuilding,
-  onEditBuilding,
   buildingsRefreshKey = 0,
 }: ManageSiteModalProps) => {
   const { listBuildingsBySite } = useBuildings();
-  const [buildings, setBuildings] = useState<BuildingWithCounts[] | undefined>(undefined);
-  const [warnings, setWarnings] = useState<string[]>([]);
+  // undefined = loading; [] = loaded-empty. Working set the operator edits
+  // via the picker before Save.
+  const [entries, setEntries] = useState<BuildingEntry[] | undefined>(undefined);
+  const [showManageBuildings, setShowManageBuildings] = useState(false);
+
+  // Snapshot of the building ids present at load time so Save can diff the
+  // working set into add / remove buckets for AssignBuildingsToSite.
+  const initialIdsRef = useRef<Set<string>>(new Set());
 
   // Only fetch when edit mode has a persisted site; create mode renders an
-  // empty-state placeholder until the first Save lands a row. Skipping the
-  // effect entirely for the no-fetch branches keeps the setState-in-effect
-  // lint clean and avoids triggering a re-render to clear buildings.
+  // empty working set until the first Save lands a row. Skipping the effect
+  // for the no-fetch branches keeps the setState-in-effect lint clean.
   const shouldFetchBuildings = open && mode === "edit" && site !== undefined;
   const fetchSiteId = shouldFetchBuildings ? site.id : undefined;
   useEffect(() => {
@@ -78,187 +172,210 @@ const ManageSiteModal = ({
     void listBuildingsBySite({
       siteId: fetchSiteId,
       signal: controller.signal,
-      onSuccess: setBuildings,
-      onError: () => setBuildings([]),
+      onSuccess: (rows: BuildingWithCounts[]) => {
+        const seeded: BuildingEntry[] = rows
+          .filter((r) => r.building)
+          .map((r) => ({
+            buildingId: r.building?.id ?? 0n,
+            label: r.building?.name ?? "(unnamed)",
+            rackCount: r.rackCount,
+          }));
+        setEntries(seeded);
+        initialIdsRef.current = new Set(seeded.map((e) => e.buildingId.toString()));
+      },
+      onError: () => {
+        setEntries([]);
+        initialIdsRef.current = new Set();
+      },
     });
     return () => controller.abort();
   }, [shouldFetchBuildings, fetchSiteId, listBuildingsBySite, buildingsRefreshKey]);
 
-  // Buildings render as "no buildings" in the non-fetch branches so the
-  // operator never sees a stale list from a previous open. The preview
-  // grid uses this derived value directly.
-  const displayBuildings: BuildingWithCounts[] | undefined = shouldFetchBuildings ? buildings : [];
+  // Create mode never fetches, so its working set is empty by construction.
+  const displayEntries: BuildingEntry[] | undefined = useMemo(
+    () => (shouldFetchBuildings ? entries : []),
+    [shouldFetchBuildings, entries],
+  );
+  const sortedEntries = useMemo(
+    () => (displayEntries ? [...displayEntries].sort((a, b) => a.label.localeCompare(b.label)) : undefined),
+    [displayEntries],
+  );
 
   const previewTitle = (site?.name || draft.name || "Untitled site").trim();
   const previewLocation = useMemo(() => formatSiteAddress(draft) || "—", [draft]);
   const previewCapacity = draft.powerCapacityMw > 0 ? `${draft.powerCapacityMw} MW` : "—";
-  const buildingCount = displayBuildings?.length ?? 0;
+  const buildingCount = sortedEntries?.length ?? 0;
+  const currentBuildingIds = useMemo(() => (displayEntries ?? []).map((e) => e.buildingId), [displayEntries]);
 
-  const handleSave = async () => {
-    const result = await onSave();
-    // Refresh warnings only after a resolved save — clearing them before the
-    // await would wipe a still-relevant warning if the next request errors.
-    if (!result) return;
-    setWarnings(result.warnings);
-    if (result.canonicalNetworkConfig !== draft.networkConfig) {
-      onNetworkConfigChange(result.canonicalNetworkConfig);
-    }
-    if (result.closeOnSuccess) {
-      onDismiss();
-    }
+  // Picker confirm — apply the delta against the working set. `added` joins
+  // entries without disturbing existing rows; `removed` drops only those
+  // entries. Buildings in neither list are untouched, so a seeded building
+  // the picker's listBuildings response omitted (race / paging gap) is
+  // preserved. Mirrors ManageBuildingModal.handleManageRacksConfirm.
+  const handleManageBuildingsConfirm = (delta: {
+    added: { buildingId: bigint; label: string }[];
+    removed: bigint[];
+  }) => {
+    const removedSet = new Set(delta.removed.map((id) => id.toString()));
+    setEntries((prev) => {
+      const kept = (prev ?? []).filter((e) => !removedSet.has(e.buildingId.toString()));
+      const knownIds = new Set(kept.map((e) => e.buildingId.toString()));
+      const newcomers: BuildingEntry[] = [];
+      for (const a of delta.added) {
+        if (knownIds.has(a.buildingId.toString())) continue;
+        newcomers.push({ buildingId: a.buildingId, label: a.label, rackCount: 0n });
+      }
+      return [...kept, ...newcomers];
+    });
+    setShowManageBuildings(false);
   };
 
+  // Kebab "Remove building" — drop it from the working set. Persisted on
+  // Save as a `removed` delta entry, which moves the building to
+  // "Unassigned" (the building itself is not deleted).
+  const handleRemoveBuilding = useCallback((buildingId: bigint) => {
+    setEntries((prev) => (prev ?? []).filter((e) => e.buildingId !== buildingId));
+  }, []);
+
+  const handleSave = async () => {
+    const initial = initialIdsRef.current;
+    const current = new Set((displayEntries ?? []).map((e) => e.buildingId.toString()));
+    const added = [...current].filter((id) => !initial.has(id)).map((id) => BigInt(id));
+    const removed = [...initial].filter((id) => !current.has(id)).map((id) => BigInt(id));
+    const result = await onSave({ added, removed });
+    if (!result) return;
+    if (result.closeOnSuccess) onDismiss();
+  };
+
+  const buildingsBusy = saving || sortedEntries === undefined;
+
   return (
-    <FullScreenTwoPaneModal
-      open={open}
-      title="Manage Site"
-      onDismiss={onDismiss}
-      isBusy={saving}
-      buttons={[
-        {
-          text: "Edit details",
-          variant: variants.secondary,
-          onClick: onEditDetails,
-          disabled: saving,
-          testId: "manage-site-modal-edit-details",
-        },
-        {
-          text: saving ? "Saving…" : "Save",
-          variant: variants.primary,
-          onClick: handleSave,
-          disabled: saving,
-          testId: "manage-site-modal-save",
-        },
-      ]}
-      abovePanes={
-        warnings.length > 0 ? (
-          <div className="mb-4 px-6 laptop:px-10" data-testid="manage-site-modal-warnings">
-            <Callout
-              intent={intents.warning}
-              prefixIcon={<Alert />}
-              title="Network config saved with warnings"
-              subtitle={warnings.join(" ")}
-            />
-          </div>
-        ) : null
-      }
-      primaryPane={
-        <div className="flex flex-col gap-6 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
-          <section className="flex flex-col gap-2">
-            <Header title="Network" titleSize="text-heading-100" />
-            {/* Textarea (not Input) because the server contract is a
-                newline-separated CIDR/IP list — a single-line input would
-                silently strip newlines on type and paste. */}
-            <Textarea
-              id="manage-site-network-config"
-              label="Network"
-              initValue={draft.networkConfig}
-              onChange={(v) => onNetworkConfigChange(v)}
-              rows={6}
-              maxLength={16384}
-              disabled={saving}
-              testId="manage-site-network-config-input"
-            />
-          </section>
-
-          <section className="flex flex-col gap-2" data-testid="manage-site-modal-buildings-section">
-            <div className="flex items-center justify-between">
-              <Header title="Buildings" titleSize="text-heading-100" />
-              <Button
-                variant={variants.secondary}
-                size={sizes.compact}
-                text="Add building"
-                onClick={onAddBuilding ?? (() => undefined)}
-                disabled={!onAddBuilding || saving || mode === "create"}
-                testId="manage-site-modal-add-building"
+    <>
+      <FullScreenTwoPaneModal
+        open={open}
+        title="Manage Site"
+        onDismiss={onDismiss}
+        isBusy={saving}
+        buttons={[
+          {
+            text: "Delete site",
+            variant: variants.secondaryDanger,
+            onClick: onDeleteRequested,
+            disabled: saving,
+            testId: "manage-site-modal-delete",
+          },
+          {
+            text: "Site settings",
+            variant: variants.secondary,
+            onClick: onEditDetails,
+            disabled: saving,
+            testId: "manage-site-modal-edit-details",
+          },
+          {
+            text: "Manage buildings",
+            variant: variants.secondary,
+            onClick: () => setShowManageBuildings(true),
+            // Create mode has no persisted site to assign buildings to yet.
+            disabled: saving || mode === "create" || sortedEntries === undefined,
+            testId: "manage-site-modal-manage-buildings",
+          },
+          {
+            text: saving ? "Saving…" : "Save",
+            variant: variants.primary,
+            onClick: handleSave,
+            disabled: saving,
+            testId: "manage-site-modal-save",
+          },
+        ]}
+        primaryPane={
+          <div className="flex flex-col gap-6 pr-6 pb-6 laptop:pr-10 laptop:pb-10">
+            <section className="flex flex-col gap-3" data-testid="manage-site-modal-buildings-section">
+              <Header
+                title={`${buildingCount} ${buildingCount === 1 ? "building" : "buildings"}`}
+                titleSize="text-heading-100"
               />
-            </div>
-            {mode === "create" ? (
-              <div className="rounded-xl border border-dashed border-border-5 p-4 text-300 text-text-primary-50">
-                Save the site first to add buildings.
-              </div>
-            ) : displayBuildings === undefined ? (
-              <div className="text-300 text-text-primary-50">Loading…</div>
-            ) : displayBuildings.length === 0 ? (
-              <div className="text-300 text-text-primary-50">No buildings in this site yet.</div>
-            ) : (
-              <ul className="flex flex-col" data-testid="manage-site-modal-buildings-list">
-                {displayBuildings.map((b) => {
-                  const id = (b.building?.id ?? 0n).toString();
-                  const name = b.building?.name ?? "(unnamed)";
-                  const rackCount = b.rackCount.toString();
-                  const clickable = !!onEditBuilding;
-                  return (
-                    <li
-                      key={id}
-                      role={clickable ? "button" : undefined}
-                      tabIndex={clickable ? 0 : undefined}
-                      className={`flex h-12 items-center justify-between gap-3 border-b border-border-5 ${
-                        clickable ? "hover:bg-surface-base-hover cursor-pointer" : ""
-                      }`}
-                      onClick={clickable ? () => onEditBuilding?.(b) : undefined}
-                      onKeyDown={
-                        clickable
-                          ? (e) => {
-                              if (e.key === "Enter" || e.key === " ") {
-                                e.preventDefault();
-                                onEditBuilding?.(b);
-                              }
-                            }
-                          : undefined
-                      }
-                      data-testid={`manage-site-modal-building-row-${id}`}
-                    >
-                      <span className="truncate text-emphasis-300">{name}</span>
-                      <span className="shrink-0 text-300 text-text-primary-50">{rackCount} racks</span>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </section>
-        </div>
-      }
-      secondaryPane={
-        <div className="flex h-full min-h-0 flex-col">
-          {/* Negative ml escapes wrapper laptop:pl-6 → labels land 20px from pane edge. */}
-          <div className="flex shrink-0 items-start justify-between gap-4 pt-5 pr-5 pl-5 laptop:-ml-6 laptop:pl-5">
-            <span className="min-w-0 truncate text-300 text-text-primary-50">
-              {[previewTitle, previewLocation].filter((s) => s && s !== "—").join(", ") || previewTitle}
-            </span>
-            <span className="shrink-0 truncate text-300 text-text-primary-50">
-              {[previewCapacity, `${buildingCount} ${buildingCount === 1 ? "building" : "buildings"}`]
-                .filter((s) => s && s !== "—")
-                .join(", ")}
-            </span>
-          </div>
-
-          {/* Center the FPO building tiles both axes inside the remaining
-              space so the preview reads as a centered floor plan. Real
-              BuildingCard component lands in #263. */}
-          <div className="flex flex-1 items-center justify-center p-5">
-            <div className="flex flex-wrap justify-center gap-3" data-testid="manage-site-modal-building-grid">
-              {displayBuildings === undefined ? (
-                <PlaceholderBlock label="Loading buildings…" className="h-20 w-[120px]" />
-              ) : displayBuildings.length === 0 ? (
-                <PlaceholderBlock
-                  label={mode === "create" ? "No buildings yet" : "No buildings in this site"}
-                  className="h-20 w-[120px]"
-                />
+              {mode === "create" ? (
+                <div className="rounded-xl border border-dashed border-border-5 p-4 text-300 text-text-primary-50">
+                  Save the site first to add buildings.
+                </div>
+              ) : sortedEntries === undefined ? (
+                <div className="text-300 text-text-primary-50">Loading…</div>
+              ) : sortedEntries.length === 0 ? (
+                <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-50">
+                  <span>No buildings added to this site</span>
+                  <Button
+                    variant={variants.primary}
+                    size={sizes.compact}
+                    text="Add buildings"
+                    onClick={() => setShowManageBuildings(true)}
+                    disabled={buildingsBusy}
+                    testId="manage-site-modal-empty-state-add"
+                  />
+                </div>
               ) : (
-                displayBuildings.map((b) => (
+                <div className="flex flex-col divide-y divide-border-5" data-testid="manage-site-modal-buildings-list">
+                  {sortedEntries.map((b) => (
+                    <BuildingRow
+                      key={b.buildingId.toString()}
+                      buildingId={b.buildingId}
+                      label={b.label}
+                      rackCount={b.rackCount}
+                      saving={saving}
+                      onRemove={handleRemoveBuilding}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+        }
+        secondaryPane={
+          <div className="flex h-full min-h-0 flex-col">
+            {/* Negative ml escapes wrapper laptop:pl-6 → labels land 20px from pane edge. */}
+            <div className="flex shrink-0 items-start justify-between gap-4 pt-5 pr-5 pl-5 laptop:-ml-6 laptop:pl-5">
+              <span className="min-w-0 truncate text-300 text-text-primary-50">
+                {[previewTitle, previewLocation].filter((s) => s && s !== "—").join(", ") || previewTitle}
+              </span>
+              <span className="shrink-0 truncate text-300 text-text-primary-50">
+                {[previewCapacity, `${buildingCount} ${buildingCount === 1 ? "building" : "buildings"}`]
+                  .filter((s) => s && s !== "—")
+                  .join(", ")}
+              </span>
+            </div>
+
+            {/* Center the FPO building tiles both axes inside the remaining
+                space so the preview reads as a centered floor plan. Real
+                BuildingCard component lands in #263. */}
+            <div className="flex flex-1 items-center justify-center p-5">
+              <div className="flex flex-wrap justify-center gap-3" data-testid="manage-site-modal-building-grid">
+                {sortedEntries === undefined ? (
+                  <PlaceholderBlock label="Loading buildings…" className="h-20 w-[120px]" />
+                ) : sortedEntries.length === 0 ? (
                   <PlaceholderBlock
-                    key={(b.building?.id ?? 0n).toString()}
-                    label={b.building?.name ?? "(unnamed)"}
+                    label={mode === "create" ? "No buildings yet" : "No buildings in this site"}
                     className="h-20 w-[120px]"
                   />
-                ))
-              )}
+                ) : (
+                  sortedEntries.map((b) => (
+                    <PlaceholderBlock key={b.buildingId.toString()} label={b.label} className="h-20 w-[120px]" />
+                  ))
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      }
-    />
+        }
+      />
+
+      {showManageBuildings && site ? (
+        <ManageBuildingsModal
+          open={showManageBuildings}
+          siteId={site.id}
+          initialSelectedBuildingIds={currentBuildingIds}
+          onDismiss={() => setShowManageBuildings(false)}
+          onConfirm={handleManageBuildingsConfirm}
+        />
+      ) : null}
+    </>
   );
 };
 

--- a/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.test.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.test.tsx
@@ -25,7 +25,6 @@ const makeModals = (overrides: Partial<SiteModalsApi> = {}): SiteModalsApi => ({
   detailsContinueCreate: vi.fn(),
   detailsSaveEdit: vi.fn(),
   manageEditDetails: vi.fn(),
-  manageNetworkConfigChange: vi.fn(),
   manageSave: vi.fn().mockResolvedValue(null),
   deleteConfirm: vi.fn().mockResolvedValue(undefined),
   ...overrides,

--- a/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.tsx
@@ -44,6 +44,12 @@ const SiteModals = ({ modals, sites, buildingsRefreshKey }: SiteModalsProps) => 
           later in the DOM and naturally stacks on top at the same z-50. */}
       {showManage && manageDraft ? (
         <ManageSiteModal
+          // Key on the site id so switching directly between sites (or
+          // create → edit) remounts the modal with a fresh building working
+          // set + load-time snapshot, instead of briefly rendering the prior
+          // site's entries until the new fetch resolves. Mirrors how the host
+          // keys ManageBuildingModal on building.id.
+          key={manageSite ? manageSite.id.toString() : "create"}
           open
           mode={manageMode}
           draft={manageDraft}

--- a/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.tsx
@@ -1,24 +1,21 @@
 import ManageSiteModal from "../ManageSiteModal";
 import SiteDeleteDialog from "../SiteDeleteDialog";
 import SiteSettingsModal from "../SiteSettingsModal";
-import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { type useSiteModals } from "@/protoFleet/features/sites/hooks/useSiteModals";
 
 interface SiteModalsProps {
   modals: ReturnType<typeof useSiteModals>;
   // SiteWithCounts cache from the host page. Used to resolve the cascade
-  // dialog target when Delete is clicked inside SiteSettingsModal (edit mode).
+  // dialog target when Delete is clicked from ManageSiteModal or
+  // SiteSettingsModal (edit mode).
   sites: SiteWithCounts[] | undefined;
-  // Pass-through for the ManageSiteModal buildings table. Provided by the
-  // host page so the building modal stack shares its useBuildingModals
-  // instance with the page-level buildings table.
-  onAddBuilding?: (siteId: bigint, siteName?: string) => void;
-  onEditBuilding?: (row: BuildingWithCounts, siteName?: string) => void;
+  // Refresh signal for the manage modal's building list — bumped by the
+  // host's useBuildingModals on any building mutation made elsewhere.
   buildingsRefreshKey?: number;
 }
 
-const SiteModals = ({ modals, sites, onAddBuilding, onEditBuilding, buildingsRefreshKey }: SiteModalsProps) => {
+const SiteModals = ({ modals, sites, buildingsRefreshKey }: SiteModalsProps) => {
   const { state, deleteTarget } = modals;
   const showManage =
     state.kind === "manageCreate" ||
@@ -26,11 +23,11 @@ const SiteModals = ({ modals, sites, onAddBuilding, onEditBuilding, buildingsRef
     state.kind === "manageCreateEditingDetails" ||
     state.kind === "manageEditEditingDetails";
 
-  // Delete in create-flow stacked state discards the pending create; edit-flow
-  // routes through requestDeleteCurrent which opens the cascade dialog from
-  // the page-level cache.
+  // Delete in the create flow (whether or not details is stacked) discards
+  // the pending create; edit-flow routes through requestDeleteCurrent which
+  // opens the cascade dialog from the page-level cache.
   const handleDelete = () => {
-    if (state.kind === "manageCreateEditingDetails") {
+    if (state.kind === "manageCreate" || state.kind === "manageCreateEditingDetails") {
       modals.cancelAll();
       return;
     }
@@ -53,11 +50,9 @@ const SiteModals = ({ modals, sites, onAddBuilding, onEditBuilding, buildingsRef
           site={manageSite}
           onSave={modals.manageSave}
           onEditDetails={modals.manageEditDetails}
-          onNetworkConfigChange={modals.manageNetworkConfigChange}
+          onDeleteRequested={handleDelete}
           onDismiss={modals.dismiss}
           saving={modals.saving}
-          onAddBuilding={onAddBuilding && manageSite ? () => onAddBuilding(manageSite.id, manageSite.name) : undefined}
-          onEditBuilding={onEditBuilding && manageSite ? (row) => onEditBuilding(row, manageSite.name) : undefined}
           buildingsRefreshKey={buildingsRefreshKey}
         />
       ) : null}

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
@@ -170,8 +170,9 @@ describe("useSiteModals", () => {
       create(AssignBuildingsToSiteResponseSchema, { reassignedRackCount: 0n, reassignedDeviceCount: 0n }),
     );
     const refetchSites = vi.fn();
+    const refetchBuildings = vi.fn();
     const site = create(SiteSchema, { id: 3n, name: "North DC" });
-    const { result } = renderHook(() => useSiteModals({ refetchSites }));
+    const { result } = renderHook(() => useSiteModals({ refetchSites, refetchBuildings }));
     act(() => result.current.openManageEdit(site));
 
     let saveResult: { closeOnSuccess: boolean } | null | undefined;
@@ -193,6 +194,8 @@ describe("useSiteModals", () => {
     );
     expect(saveResult?.closeOnSuccess).toBe(true);
     expect(refetchSites).toHaveBeenCalled();
+    // Membership changed building rows, so the building table refresh fires too.
+    expect(refetchBuildings).toHaveBeenCalled();
   });
 
   it("manageSave on manageEdit with an empty delta closes without an RPC", async () => {

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
@@ -5,6 +5,7 @@ import { create } from "@bufbuild/protobuf";
 import { useSiteModals } from "./useSiteModals";
 import { sitesClient } from "@/protoFleet/api/clients";
 import {
+  AssignBuildingsToSiteResponseSchema,
   type CreateSiteResponse,
   CreateSiteResponseSchema,
   type DeleteSiteResponse,
@@ -24,6 +25,7 @@ vi.mock("@/protoFleet/api/clients", () => ({
     updateSite: vi.fn(),
     deleteSite: vi.fn(),
     assignDevicesToSite: vi.fn(),
+    assignBuildingsToSite: vi.fn(),
   },
 }));
 
@@ -79,11 +81,9 @@ describe("useSiteModals", () => {
     });
   });
 
-  it("detailsContinueCreate carries existing networkConfig through to manageCreate", () => {
+  it("detailsContinueCreate round-trips manageCreate ↔ details preserving edited fields", () => {
     const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }));
     act(() => result.current.openCreate());
-    // Simulate the operator typing network config in ManageSiteModal first,
-    // then re-entering details: detailsContinueCreate must preserve it.
     act(() =>
       result.current.detailsContinueCreate({
         ...emptySiteFormValues(),
@@ -91,10 +91,8 @@ describe("useSiteModals", () => {
         locationCity: "Chicago",
         locationState: "IL",
         powerCapacityMw: 5,
-        networkConfig: "(unused — initial empty)",
       }),
     );
-    act(() => result.current.manageNetworkConfigChange("10.0.0.0/24"));
     act(() => result.current.manageEditDetails());
     expect(result.current.state.kind).toBe("manageCreateEditingDetails");
     act(() =>
@@ -104,13 +102,12 @@ describe("useSiteModals", () => {
         locationCity: "Chicago",
         locationState: "IL",
         powerCapacityMw: 5,
-        networkConfig: "",
       }),
     );
     expect(result.current.state.kind).toBe("manageCreate");
     if (result.current.state.kind === "manageCreate") {
-      expect(result.current.state.draft.networkConfig).toBe("10.0.0.0/24");
       expect(result.current.state.draft.name).toBe("North DC 2");
+      expect(result.current.state.draft.powerCapacityMw).toBe(5);
     }
   });
 
@@ -139,7 +136,7 @@ describe("useSiteModals", () => {
     expect(result.current.state.kind).toBe("manageEdit");
   });
 
-  it("manageSave on manageCreate transitions to manageEdit on success (prevents duplicate CreateSite on re-save)", async () => {
+  it("manageSave on manageCreate runs CreateSite and reports closeOnSuccess", async () => {
     const { create: createResp } = makeSiteResponse(7n, "North DC", "10.0.0.0/24");
     vi.mocked(sitesClient.createSite).mockResolvedValue(createResp);
     const refetchSites = vi.fn();
@@ -155,25 +152,60 @@ describe("useSiteModals", () => {
 
     let saveResult: { closeOnSuccess: boolean } | null | undefined;
     await act(async () => {
-      saveResult = await result.current.manageSave();
+      saveResult = await result.current.manageSave({ added: [], removed: [] });
     });
 
     await waitFor(() => {
       expect(sitesClient.createSite).toHaveBeenCalledTimes(1);
     });
+    // Create never touches the buildings RPC — building management is gated
+    // until the site exists.
+    expect(sitesClient.assignBuildingsToSite).not.toHaveBeenCalled();
     expect(saveResult?.closeOnSuccess).toBe(true);
     expect(refetchSites).toHaveBeenCalled();
-    expect(result.current.state.kind).toBe("manageEdit");
+  });
 
-    // Second Save must call updateSite, not createSite again — proves the
-    // transition to manageEdit happens on the first success.
-    const { update: updateResp } = makeSiteResponse(7n, "North DC", "10.0.0.0/24");
-    vi.mocked(sitesClient.updateSite).mockResolvedValue(updateResp);
+  it("manageSave on manageEdit applies the building delta via AssignBuildingsToSite", async () => {
+    vi.mocked(sitesClient.assignBuildingsToSite).mockResolvedValue(
+      create(AssignBuildingsToSiteResponseSchema, { reassignedRackCount: 0n, reassignedDeviceCount: 0n }),
+    );
+    const refetchSites = vi.fn();
+    const site = create(SiteSchema, { id: 3n, name: "North DC" });
+    const { result } = renderHook(() => useSiteModals({ refetchSites }));
+    act(() => result.current.openManageEdit(site));
+
+    let saveResult: { closeOnSuccess: boolean } | null | undefined;
     await act(async () => {
-      await result.current.manageSave();
+      saveResult = await result.current.manageSave({ added: [10n], removed: [20n] });
     });
-    expect(sitesClient.createSite).toHaveBeenCalledTimes(1);
-    expect(sitesClient.updateSite).toHaveBeenCalledTimes(1);
+
+    // Two calls: removed → "Unassigned" (no target), added → this site.
+    await waitFor(() => {
+      expect(sitesClient.assignBuildingsToSite).toHaveBeenCalledTimes(2);
+    });
+    expect(sitesClient.assignBuildingsToSite).toHaveBeenCalledWith(
+      { buildingIds: [20n], targetSiteId: undefined },
+      expect.anything(),
+    );
+    expect(sitesClient.assignBuildingsToSite).toHaveBeenCalledWith(
+      { buildingIds: [10n], targetSiteId: 3n },
+      expect.anything(),
+    );
+    expect(saveResult?.closeOnSuccess).toBe(true);
+    expect(refetchSites).toHaveBeenCalled();
+  });
+
+  it("manageSave on manageEdit with an empty delta closes without an RPC", async () => {
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }));
+    act(() => result.current.openManageEdit(create(SiteSchema, { id: 3n, name: "North DC" })));
+
+    let saveResult: { closeOnSuccess: boolean } | null | undefined;
+    await act(async () => {
+      saveResult = await result.current.manageSave({ added: [], removed: [] });
+    });
+
+    expect(sitesClient.assignBuildingsToSite).not.toHaveBeenCalled();
+    expect(saveResult?.closeOnSuccess).toBe(true);
   });
 
   it("detailsSaveEdit refreshes manage with server-canonical site on success", async () => {

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
@@ -25,6 +25,10 @@ export type SiteModalState =
 
 interface UseSiteModalsOptions {
   refetchSites: () => void;
+  // Bumps the page's building-refresh signal so any sibling building list
+  // (e.g. SiteSettingsSingleView's table) re-fetches after a membership
+  // change. Optional so hosts without a building table can omit it.
+  refetchBuildings?: () => void;
 }
 
 export interface SiteModalsApi {
@@ -64,7 +68,7 @@ export interface SiteModalsApi {
   deleteConfirm: () => Promise<void>;
 }
 
-const useSiteModals = ({ refetchSites }: UseSiteModalsOptions): SiteModalsApi => {
+const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions): SiteModalsApi => {
   const [state, setState] = useState<SiteModalState>({ kind: "none" });
   const [deleteTarget, setDeleteTarget] = useState<SiteWithCounts | null>(null);
   const [saving, setSaving] = useState(false);
@@ -282,10 +286,18 @@ const useSiteModals = ({ refetchSites }: UseSiteModalsOptions): SiteModalsApi =>
           } catch (err) {
             const detail = err instanceof Error ? err.message : "Failed to save buildings";
             pushToast({ message: `Failed to save site: ${detail}`, status: STATUSES.error });
+            // The two AssignBuildingsToSite calls aren't atomic across each
+            // other: the `removed` batch may have already cascaded buildings
+            // out of the site before the `added` batch failed. Refresh so the
+            // counts + building table reflect what actually committed rather
+            // than the now-stale pre-save view.
+            refetchSites();
+            refetchBuildings?.();
             return null;
           }
           pushToast({ message: `Site "${name}" saved`, status: STATUSES.success });
           refetchSites();
+          refetchBuildings?.();
           return { closeOnSuccess: true };
         } finally {
           savingRef.current = false;
@@ -295,7 +307,7 @@ const useSiteModals = ({ refetchSites }: UseSiteModalsOptions): SiteModalsApi =>
 
       return null;
     },
-    [state, createSite, assignBuildingsToSite, refetchSites],
+    [state, createSite, assignBuildingsToSite, refetchSites, refetchBuildings],
   );
 
   const deleteConfirm = useCallback(async () => {

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
@@ -54,12 +54,12 @@ export interface SiteModalsApi {
   detailsSaveEdit: (values: SiteFormValues) => Promise<void>;
   // ManageSiteModal handlers
   manageEditDetails: () => void;
-  manageNetworkConfigChange: (value: string) => void;
-  manageSave: () => Promise<{
-    canonicalNetworkConfig: string;
-    warnings: string[];
-    closeOnSuccess: boolean;
-  } | null>;
+  // Persists building-membership changes accumulated in the manage modal.
+  // In create mode the delta is empty (building management is gated until
+  // the site exists) and this just runs CreateSite. In edit mode it applies
+  // the delta via AssignBuildingsToSite. Returns whether the modal should
+  // close on success, or null if the save failed.
+  manageSave: (delta: { added: bigint[]; removed: bigint[] }) => Promise<{ closeOnSuccess: boolean } | null>;
   // SiteDeleteDialog handlers
   deleteConfirm: () => Promise<void>;
 }
@@ -84,7 +84,7 @@ const useSiteModals = ({ refetchSites }: UseSiteModalsOptions): SiteModalsApi =>
     stateRef.current = state;
   }, [state]);
 
-  const { createSite, updateSite, deleteSite } = useSites();
+  const { createSite, updateSite, deleteSite, assignBuildingsToSite } = useSites();
   const setActiveSite = useFleetStore((store) => store.ui.setActiveSite);
   const activeSite = useFleetStore((store) => store.ui.activeSite);
 
@@ -211,116 +211,92 @@ const useSiteModals = ({ refetchSites }: UseSiteModalsOptions): SiteModalsApi =>
     });
   }, []);
 
-  const manageNetworkConfigChange = useCallback((value: string) => {
-    setState((prev) => {
-      if (prev.kind === "manageCreate" || prev.kind === "manageCreateEditingDetails") {
-        return { ...prev, draft: { ...prev.draft, networkConfig: value } };
-      }
-      if (prev.kind === "manageEdit" || prev.kind === "manageEditEditingDetails") {
-        return { ...prev, draft: { ...prev.draft, networkConfig: value } };
-      }
-      return prev;
-    });
-  }, []);
+  const manageSave = useCallback(
+    async (delta: { added: bigint[]; removed: bigint[] }) => {
+      if (savingRef.current) return null;
 
-  const manageSave = useCallback(async () => {
-    if (savingRef.current) return null;
-
-    if (state.kind === "manageCreate") {
-      const draft = state.draft;
-      savingRef.current = true;
-      setSaving(true);
-      const result = await new Promise<{
-        canonicalNetworkConfig: string;
-        warnings: string[];
-        closeOnSuccess: boolean;
-      } | null>((resolve) => {
-        void createSite({
-          values: draft,
-          onSuccess: (site, warnings) => {
-            pushToast({
-              message:
-                warnings.length > 0 ? `Site "${site.name}" created with warnings` : `Site "${site.name}" created`,
-              status: STATUSES.success,
-            });
-            refetchSites();
-            // Transition to manageEdit so a follow-up Save calls UpdateSite
-            // (idempotent) instead of re-running CreateSite with the same
-            // payload and producing a duplicate site row.
-            setState({ kind: "manageEdit", site, draft: siteFormValuesFromSite(site) });
-            resolve({
-              canonicalNetworkConfig: site.networkConfig,
-              warnings,
-              // When warnings are present we keep the modal open so the
-              // operator can review the canonical text + warning copy. The
-              // state has flipped to manageEdit, so any follow-up Save runs
-              // UpdateSite — safe.
-              closeOnSuccess: warnings.length === 0,
-            });
-          },
-          onError: (msg) => {
-            pushToast({ message: `Failed to create site: ${msg}`, status: STATUSES.error });
-            resolve(null);
-          },
-          onFinally: () => {
-            savingRef.current = false;
-            setSaving(false);
-          },
+      // Create flow: the manage modal gates building management until the
+      // site exists, so the delta is empty here — just persist the site.
+      // The modal closes on success; the operator reopens to add buildings.
+      if (state.kind === "manageCreate") {
+        const draft = state.draft;
+        savingRef.current = true;
+        setSaving(true);
+        const result = await new Promise<{ closeOnSuccess: boolean } | null>((resolve) => {
+          void createSite({
+            values: draft,
+            onSuccess: (site, warnings) => {
+              pushToast({
+                message:
+                  warnings.length > 0 ? `Site "${site.name}" created with warnings` : `Site "${site.name}" created`,
+                status: STATUSES.success,
+              });
+              refetchSites();
+              resolve({ closeOnSuccess: true });
+            },
+            onError: (msg) => {
+              pushToast({ message: `Failed to create site: ${msg}`, status: STATUSES.error });
+              resolve(null);
+            },
+            onFinally: () => {
+              savingRef.current = false;
+              setSaving(false);
+            },
+          });
         });
-        // TODO(phase-1b #199): once the miner picker ships, follow this
-        // CreateSite call with `assignDevicesToSite({ targetSiteId: site.id,
-        // deviceIdentifiers: pendingDeviceIds })` inside the onSuccess branch
-        // (and gate setSaving(false) on the inner onFinally). Partial-failure
-        // toast wording is already drafted in PR #292 review.
-      });
-      return result;
-    }
+        return result;
+      }
 
-    if (state.kind === "manageEdit") {
-      const draft = state.draft;
-      const id = state.site.id;
-      savingRef.current = true;
-      setSaving(true);
-      const result = await new Promise<{
-        canonicalNetworkConfig: string;
-        warnings: string[];
-        closeOnSuccess: boolean;
-      } | null>((resolve) => {
-        void updateSite({
-          id,
-          values: draft,
-          onSuccess: (site, warnings) => {
-            pushToast({
-              message: warnings.length > 0 ? `Site "${site.name}" saved with warnings` : `Site "${site.name}" saved`,
-              status: STATUSES.success,
+      // Edit flow: site details are owned by SiteSettingsModal, so the
+      // manage modal's Save only persists building membership. A no-op
+      // delta (operator opened Save without changes) closes silently.
+      if (state.kind === "manageEdit") {
+        if (delta.added.length === 0 && delta.removed.length === 0) {
+          return { closeOnSuccess: true };
+        }
+        const id = state.site.id;
+        const name = state.site.name;
+        savingRef.current = true;
+        setSaving(true);
+        try {
+          // `added` moves buildings into this site; `removed` moves them to
+          // "Unassigned" (targetSiteId unset). Both cascade site_id down to
+          // racks + devices server-side. Run sequentially so a mid-chain
+          // failure surfaces without a half-applied toast.
+          const dispatch = (buildingIds: bigint[], targetSiteId?: bigint) =>
+            new Promise<void>((resolve, reject) => {
+              if (buildingIds.length === 0) {
+                resolve();
+                return;
+              }
+              void assignBuildingsToSite({
+                buildingIds,
+                targetSiteId,
+                onSuccess: () => resolve(),
+                onError: (msg) => reject(new Error(msg)),
+              });
             });
-            refetchSites();
-            // Refresh the draft so the operator sees the server's canonical
-            // values reflected in the manage preview.
-            setState((prev) =>
-              prev.kind === "manageEdit" ? { kind: "manageEdit", site, draft: siteFormValuesFromSite(site) } : prev,
-            );
-            resolve({
-              canonicalNetworkConfig: site.networkConfig,
-              warnings,
-              closeOnSuccess: warnings.length === 0,
-            });
-          },
-          onError: (msg) => {
-            pushToast({ message: `Failed to save site: ${msg}`, status: STATUSES.error });
-            resolve(null);
-          },
-          onFinally: () => {
-            savingRef.current = false;
-            setSaving(false);
-          },
-        });
-      });
-      return result;
-    }
+          try {
+            await dispatch(delta.removed, undefined);
+            await dispatch(delta.added, id);
+          } catch (err) {
+            const detail = err instanceof Error ? err.message : "Failed to save buildings";
+            pushToast({ message: `Failed to save site: ${detail}`, status: STATUSES.error });
+            return null;
+          }
+          pushToast({ message: `Site "${name}" saved`, status: STATUSES.success });
+          refetchSites();
+          return { closeOnSuccess: true };
+        } finally {
+          savingRef.current = false;
+          setSaving(false);
+        }
+      }
 
-    return null;
-  }, [state, createSite, updateSite, refetchSites]);
+      return null;
+    },
+    [state, createSite, assignBuildingsToSite, refetchSites],
+  );
 
   const deleteConfirm = useCallback(async () => {
     if (!deleteTarget) return;
@@ -371,7 +347,6 @@ const useSiteModals = ({ refetchSites }: UseSiteModalsOptions): SiteModalsApi =>
     detailsContinueCreate,
     detailsSaveEdit,
     manageEditDetails,
-    manageNetworkConfigChange,
     manageSave,
     deleteConfirm,
   };

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -166,13 +166,7 @@ const SiteDetailPage = () => {
           <PlaceholderBlock label="Buildings grid — coming soon" className="h-40" />
         </div>
       </div>
-      <SiteModals
-        modals={modals}
-        sites={sites}
-        onAddBuilding={(siteId, siteName) => buildingModals.openDetailsCreate(siteId, siteName)}
-        onEditBuilding={(row, siteName) => buildingModals.openDetailsEdit(row, siteName)}
-        buildingsRefreshKey={buildingsRefreshKey}
-      />
+      <SiteModals modals={modals} sites={sites} buildingsRefreshKey={buildingsRefreshKey} />
       <BuildingModals modals={buildingModals} sites={sites} />
     </>
   );

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -72,11 +72,12 @@ const SiteDetailPage = () => {
   // UpdateSite + CreateBuilding require site:manage server-side.
   const canManageSites = useHasPermission("site:manage");
 
-  const modals = useSiteModals({ refetchSites: fetchSites });
   const [buildingsRefreshKey, setBuildingsRefreshKey] = useState(0);
-  const buildingModals = useBuildingModals({
-    refetchBuildings: () => setBuildingsRefreshKey((n) => n + 1),
-  });
+  const refetchBuildings = useCallback(() => setBuildingsRefreshKey((n) => n + 1), []);
+  // Membership saves in ManageSiteModal also affect building rows, so share
+  // the same refresh signal used for direct building mutations.
+  const modals = useSiteModals({ refetchSites: fetchSites, refetchBuildings });
+  const buildingModals = useBuildingModals({ refetchBuildings });
 
   if (sites === undefined) {
     return (

--- a/client/src/shared/components/List/List.test.tsx
+++ b/client/src/shared/components/List/List.test.tsx
@@ -1015,6 +1015,44 @@ describe("List", () => {
     expect(customSetSelectedItems).toHaveBeenCalledWith([testItems[2].id]);
   });
 
+  it("keeps off-page selections when a row check fills the current page (preserveOffPageSelection)", () => {
+    const customSetSelectedItems = vi.fn();
+    const pageOneItems = [testItems[0], testItems[1]];
+    // item1 already selected on this page + item3 selected off-page. Checking
+    // item2 makes the page "full" — without the fix that flips to "all" mode
+    // and the sync effect rewrites selection to just the page keys, dropping
+    // item3.
+    const selectedAcrossPages = [testItems[0].id, testItems[2].id];
+
+    render(
+      <List<TestItem, TestItemKey>
+        activeCols={activeCols}
+        colTitles={testColTitles}
+        colConfig={testColConfig}
+        items={pageOneItems}
+        itemKey="id"
+        itemSelectable
+        customSelectedItems={selectedAcrossPages}
+        customSetSelectedItems={customSetSelectedItems}
+        preserveOffPageSelection
+      />,
+    );
+
+    const rowCheckboxes = Array.from(
+      screen.getByTestId("list-body").querySelectorAll("input[type='checkbox']"),
+    ) as HTMLInputElement[];
+    // Check the second row (item2).
+    fireEvent.click(rowCheckboxes[1]);
+
+    // Every write keeps the off-page item3 — it is never dropped.
+    for (const call of customSetSelectedItems.mock.calls) {
+      expect(call[0]).toContain(testItems[2].id);
+    }
+    expect(customSetSelectedItems).toHaveBeenLastCalledWith(
+      expect.arrayContaining([testItems[0].id, testItems[1].id, testItems[2].id]),
+    );
+  });
+
   it("does not show the header checkbox as partially checked for off-page selections", () => {
     render(
       <List<TestItem, TestItemKey>

--- a/client/src/shared/components/List/List.test.tsx
+++ b/client/src/shared/components/List/List.test.tsx
@@ -953,6 +953,68 @@ describe("List", () => {
     expect(customSetSelectedItems).not.toHaveBeenCalled();
   });
 
+  it("merges the current page into selection on header select-all when preserveOffPageSelection is true", () => {
+    const customSetSelectedItems = vi.fn();
+    const pageOneItems = [testItems[0], testItems[1]];
+    // item3 is selected but lives on another page (not in items).
+    const selectedAcrossPages = [testItems[2].id];
+
+    render(
+      <List<TestItem, TestItemKey>
+        activeCols={activeCols}
+        colTitles={testColTitles}
+        colConfig={testColConfig}
+        items={pageOneItems}
+        itemKey="id"
+        itemSelectable
+        customSelectedItems={selectedAcrossPages}
+        customSetSelectedItems={customSetSelectedItems}
+        preserveOffPageSelection
+      />,
+    );
+
+    const selectAllCheckbox = screen
+      .getByTestId("list-header")
+      .querySelector("input[type='checkbox']") as HTMLInputElement;
+    fireEvent.click(selectAllCheckbox);
+
+    // Page keys are added without dropping the off-page selection (item3).
+    expect(customSetSelectedItems).toHaveBeenCalledWith(
+      expect.arrayContaining([testItems[2].id, testItems[0].id, testItems[1].id]),
+    );
+    expect(customSetSelectedItems.mock.calls[0][0]).toHaveLength(3);
+  });
+
+  it("removes only the current page from selection on header deselect when preserveOffPageSelection is true", () => {
+    const customSetSelectedItems = vi.fn();
+    const pageOneItems = [testItems[0], testItems[1]];
+    // All of page one plus an off-page selection.
+    const selectedAcrossPages = [testItems[0].id, testItems[1].id, testItems[2].id];
+
+    render(
+      <List<TestItem, TestItemKey>
+        activeCols={activeCols}
+        colTitles={testColTitles}
+        colConfig={testColConfig}
+        items={pageOneItems}
+        itemKey="id"
+        itemSelectable
+        customSelectedItems={selectedAcrossPages}
+        customSetSelectedItems={customSetSelectedItems}
+        preserveOffPageSelection
+      />,
+    );
+
+    const selectAllCheckbox = screen
+      .getByTestId("list-header")
+      .querySelector("input[type='checkbox']") as HTMLInputElement;
+    // Page-one items are all selected, so the header checkbox is checked;
+    // clicking it clears just this page and keeps the off-page item3.
+    fireEvent.click(selectAllCheckbox);
+
+    expect(customSetSelectedItems).toHaveBeenCalledWith([testItems[2].id]);
+  });
+
   it("does not show the header checkbox as partially checked for off-page selections", () => {
     render(
       <List<TestItem, TestItemKey>

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -902,7 +902,12 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
     const newMode =
       newSelectedItems.length === 0
         ? "none"
-        : pageScopedSelection
+        : // Paginated lists pass one page as `items`, so "all" here only
+          // means "all of this page". Promoting to "all" mode lets the
+          // sync effect rewrite the controlled selection with just the
+          // current-page keys, dropping off-page selections the parent
+          // holds. Stay in "subset" so cross-page selections survive.
+          pageScopedSelection || preserveOffPageSelection
           ? "subset"
           : allItemsSelected && !hasActiveFilters
             ? "all"
@@ -986,8 +991,12 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
     const currentItemKeys = new Set(items.map((item) => item[itemKey] as ItemKeyValueType));
     const currentSelected = currentSelectedItems;
 
-    // In "all" mode, ensure all selectable current items are selected (handles Load More)
-    if (currentSelectionMode === "all") {
+    // In "all" mode, ensure all selectable current items are selected (handles Load More).
+    // Skipped under preserveOffPageSelection: there `items` is only the current
+    // page, so rewriting the selection to the page's keys would drop the
+    // parent's off-page selections. Those consumers never enter "all" mode via
+    // the row/header paths, but guard here too in case mode is driven externally.
+    if (currentSelectionMode === "all" && !preserveOffPageSelection) {
       const allSelectableItemKeys = selectableItems.map((item) => item[itemKey] as ItemKeyValueType);
       const currentSelectedSet = new Set(currentSelected);
       const needsUpdate = allSelectableItemKeys.some((key) => !currentSelectedSet.has(key));

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -785,6 +785,22 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   }, [customSetSelectedItems, onSelectionModeChange]);
 
   const handleSelectAll = (checked: boolean) => {
+    // Paginated lists pass only the current page as `items`, so the header
+    // checkbox can only see this page. When the parent manages selection
+    // across pages (preserveOffPageSelection), replacing the selection with
+    // just this page would silently drop off-page selections. Instead toggle
+    // only this page's keys into / out of the existing selection.
+    if (preserveOffPageSelection) {
+      const pageKeys = getSelectableItems(filteredItems).map((item) => item[itemKey] as ItemKeyValueType);
+      const next = checked
+        ? Array.from(new Set([...currentSelectedItems, ...pageKeys]))
+        : currentSelectedItems.filter((key) => !pageKeys.includes(key));
+      customSetSelectedItems ? customSetSelectedItems(next) : setSelectedItems(next);
+      const newMode = next.length === 0 ? "none" : "subset";
+      setSelectionMode(newMode);
+      onSelectionModeChange?.(newMode);
+      return;
+    }
     if (checked) {
       // Select only filtered items (respects both client-side and server-side filters)
       const selectableItems = getSelectableItems(filteredItems);


### PR DESCRIPTION
## Summary

ManageSiteModal previously let operators **create** buildings inline — an inconsistency with ManageBuildingModal and ManageRacksModal, where the modal manages *membership* of existing children rather than creating them. This branch refactors ManageSiteModal to follow that shared pattern.

The modal is now a building-membership surface: a four-button header (Delete site / Site settings / Manage buildings / Save), a left-pane building list styled to match the miner list (rack count as a subtitle, a kebab "Remove building" action, count heading, and an empty-state callout). A new `ManageBuildingsModal` picker — the building analog of `ManageRacksModal` — lets operators add existing org buildings to the site with cross-site eligibility gating. Add/remove edits accumulate in a local working set and persist on Save through the existing `AssignBuildingsToSite` RPC (added → this site, removed → Unassigned); the network-config input and its warnings path are dropped, and site details remain owned by SiteSettingsModal.

## Non-goals / deferred

- **No building creation or deletion** from this modal — "Remove building" reassigns a building to Unassigned, it does not delete it; creation stays on the settings page.
- **Create flow unchanged**: building management is gated until the site exists ("Save the site first to add buildings"), so create-mode Save still just persists the site.
- The `networkConfig` field stays in the data model (no longer FE-editable); fully removing it is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)