### PR TITLE
Add fleet tab filter UI

### DIFF
--- a/.github/workflows/migration-hygiene.yml
+++ b/.github/workflows/migration-hygiene.yml
@@ -34,8 +34,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch --no-tags --depth=1 origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
-          changed_files="$(git diff --name-only "origin/$BASE_REF"...HEAD -- server/migrations)"
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if ! changed_files="$(git diff --name-only "origin/${BASE_REF}"...HEAD -- server/migrations 2>/tmp/migration-diff.err)"; then
+            cat /tmp/migration-diff.err >&2
+            echo "No merge base found for origin/${BASE_REF}...HEAD; falling back to a direct tree diff."
+            changed_files="$(git diff --name-only "origin/${BASE_REF}" HEAD -- server/migrations)"
+          fi
 
           if printf '%s\n' "$changed_files" | grep -Eq '^server/migrations/[0-9]{6}_.+\.sql$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
@@ -4,14 +4,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POLL_INTERVAL_MS } from "./constants";
 import Fleet from "./Fleet";
 
-const { mockMinerList, mockRefetchAuthNeededMiners, mockRefetchErrors, mockListAllBuildings, mockUseHasPermission } =
-  vi.hoisted(() => ({
-    mockMinerList: vi.fn(() => <div data-testid="miner-list">MinerList</div>),
-    mockRefetchAuthNeededMiners: vi.fn(),
-    mockRefetchErrors: vi.fn(),
-    mockListAllBuildings: vi.fn(),
-    mockUseHasPermission: vi.fn((_permission: string) => true),
-  }));
+const {
+  mockMinerList,
+  mockRefetchAuthNeededMiners,
+  mockRefetchErrors,
+  mockListAllBuildings,
+  mockUseHasPermission,
+  mockFleetOutletContext,
+} = vi.hoisted(() => ({
+  mockMinerList: vi.fn(() => <div data-testid="miner-list">MinerList</div>),
+  mockRefetchAuthNeededMiners: vi.fn(),
+  mockRefetchErrors: vi.fn(),
+  mockListAllBuildings: vi.fn(),
+  mockUseHasPermission: vi.fn((_permission: string) => true),
+  mockFleetOutletContext: {
+    sites: [],
+    sitesError: null,
+    sitesLoaded: true,
+    siteCatalogAccessGranted: true,
+    refetchSites: vi.fn(),
+    notifyPairingCompleted: vi.fn(),
+    minersChangedAt: 0,
+    publishViewFilterContext: vi.fn(),
+  },
+}));
 
 // Mock all dependencies
 vi.mock("@/protoFleet/api/useFleet", () => ({
@@ -82,15 +98,7 @@ vi.mock("@/protoFleet/features/fleetManagement/components/MinerList", () => ({
 // Fleet now reads pairing/refetch coordination from FleetLayout's outlet
 // context; stub the hook so the component can mount without a real layout.
 vi.mock("@/protoFleet/features/fleetManagement/components/FleetLayout", () => ({
-  useFleetOutletContext: () => ({
-    sites: [],
-    sitesError: null,
-    sitesLoaded: true,
-    refetchSites: vi.fn(),
-    notifyPairingCompleted: vi.fn(),
-    minersChangedAt: 0,
-    publishViewFilterContext: vi.fn(),
-  }),
+  useFleetOutletContext: () => mockFleetOutletContext,
 }));
 
 vi.mock("@/protoFleet/features/onboarding/components/Miners", () => ({
@@ -134,6 +142,13 @@ describe("Fleet - Polling", () => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.useFakeTimers();
+    Object.assign(mockFleetOutletContext, {
+      sites: [],
+      sitesError: null,
+      sitesLoaded: true,
+      siteCatalogAccessGranted: true,
+      minersChangedAt: 0,
+    });
 
     mockRefreshCurrentPage = vi.fn();
   });
@@ -300,8 +315,9 @@ describe("Fleet - Component Integration", () => {
     expect(mockRefetch).not.toHaveBeenCalled();
   });
 
-  it("does not request building filter labels without site read permission", async () => {
-    mockUseHasPermission.mockImplementation((permission: string) => permission !== "site:read");
+  it("does not request building filter labels until org-scoped site catalog access is confirmed", async () => {
+    mockUseHasPermission.mockImplementation(() => true);
+    mockFleetOutletContext.siteCatalogAccessGranted = false;
 
     renderFleet();
 

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
@@ -10,7 +10,7 @@ const { mockMinerList, mockRefetchAuthNeededMiners, mockRefetchErrors, mockListA
     mockRefetchAuthNeededMiners: vi.fn(),
     mockRefetchErrors: vi.fn(),
     mockListAllBuildings: vi.fn(),
-    mockUseHasPermission: vi.fn(() => true),
+    mockUseHasPermission: vi.fn((_permission: string) => true),
   }));
 
 // Mock all dependencies

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
@@ -4,11 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POLL_INTERVAL_MS } from "./constants";
 import Fleet from "./Fleet";
 
-const { mockMinerList, mockRefetchAuthNeededMiners, mockRefetchErrors } = vi.hoisted(() => ({
-  mockMinerList: vi.fn(() => <div data-testid="miner-list">MinerList</div>),
-  mockRefetchAuthNeededMiners: vi.fn(),
-  mockRefetchErrors: vi.fn(),
-}));
+const { mockMinerList, mockRefetchAuthNeededMiners, mockRefetchErrors, mockListAllBuildings, mockUseHasPermission } =
+  vi.hoisted(() => ({
+    mockMinerList: vi.fn(() => <div data-testid="miner-list">MinerList</div>),
+    mockRefetchAuthNeededMiners: vi.fn(),
+    mockRefetchErrors: vi.fn(),
+    mockListAllBuildings: vi.fn(),
+    mockUseHasPermission: vi.fn(() => true),
+  }));
 
 // Mock all dependencies
 vi.mock("@/protoFleet/api/useFleet", () => ({
@@ -41,8 +44,15 @@ vi.mock("@/protoFleet/store", () => ({
   useCompleteBatchOperation: vi.fn(() => vi.fn()),
   useRemoveDevicesFromBatch: vi.fn(() => vi.fn()),
   useCleanupStaleBatches: vi.fn(() => vi.fn()),
+  useHasPermission: mockUseHasPermission,
   getActiveBatches: vi.fn(() => []),
   getAllBatches: vi.fn(() => []),
+}));
+
+vi.mock("@/protoFleet/api/buildings", () => ({
+  useBuildings: vi.fn(() => ({
+    listAllBuildings: mockListAllBuildings,
+  })),
 }));
 
 vi.mock("@/protoFleet/api/useDeviceSets", () => ({
@@ -227,6 +237,7 @@ describe("Fleet - Component Integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockMinerList.mockClear();
+    mockUseHasPermission.mockReturnValue(true);
   });
 
   it("should render MinerList component", () => {
@@ -287,5 +298,13 @@ describe("Fleet - Component Integration", () => {
     expect(mockRefetchErrors).toHaveBeenCalledTimes(1);
     expect(mockRefetchAuthNeededMiners).toHaveBeenCalledTimes(1);
     expect(mockRefetch).not.toHaveBeenCalled();
+  });
+
+  it("does not request building filter labels without site read permission", async () => {
+    mockUseHasPermission.mockImplementation((permission: string) => permission !== "site:read");
+
+    renderFleet();
+
+    expect(mockListAllBuildings).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -42,6 +42,7 @@ import { encodeSortToURL, parseSortFromURL } from "@/protoFleet/features/fleetMa
 import type { FilterLabelSource } from "@/protoFleet/features/fleetManagement/views/viewSummary";
 import Miners from "@/protoFleet/features/onboarding/components/Miners";
 import { isPathScopable } from "@/protoFleet/routing/siteScope";
+import { useHasPermission } from "@/protoFleet/store";
 import ErrorBoundary from "@/shared/components/ErrorBoundary";
 import { SORT_ASC, SORT_DESC } from "@/shared/components/List/types";
 
@@ -97,6 +98,11 @@ const Fleet = () => {
     [activeSite],
   );
   const [availableBuildings, setAvailableBuildings] = useState<FilterLabelSource[]>([]);
+  const canReadBuildings = useHasPermission("site:read");
+  const readableAvailableBuildings = useMemo(
+    () => (canReadBuildings ? availableBuildings : []),
+    [availableBuildings, canReadBuildings],
+  );
 
   useEffect(() => {
     listGroups({
@@ -109,6 +115,9 @@ const Fleet = () => {
         setAvailableRacks(deviceSets);
       },
     });
+    if (!canReadBuildings) {
+      return;
+    }
     listAllBuildings({
       onSuccess: (buildings) => {
         setAvailableBuildings(
@@ -118,7 +127,7 @@ const Fleet = () => {
         );
       },
     });
-  }, [listGroups, listRacks, listAllBuildings]);
+  }, [listGroups, listRacks, listAllBuildings, canReadBuildings]);
 
   const { pathname } = useLocation();
   const insideFleetShell = isPathScopable(pathname);
@@ -285,8 +294,13 @@ const Fleet = () => {
   // (mounted in the top tab strip) can show human-readable labels for any
   // group/rack ids referenced by an active filter.
   useEffect(() => {
-    publishViewFilterContext({ availableGroups, availableRacks, availableBuildings, availableSites });
-  }, [publishViewFilterContext, availableGroups, availableRacks, availableBuildings, availableSites]);
+    publishViewFilterContext({
+      availableGroups,
+      availableRacks,
+      availableBuildings: readableAvailableBuildings,
+      availableSites,
+    });
+  }, [publishViewFilterContext, availableGroups, availableRacks, readableAvailableBuildings, availableSites]);
 
   const refetchAll = useCallback(() => {
     refetch();
@@ -367,7 +381,7 @@ const Fleet = () => {
           availableGroups={availableGroups}
           availableRacks={availableRacks}
           availableSites={availableSites}
-          availableBuildings={availableBuildings}
+          availableBuildings={readableAvailableBuildings}
           currentFilter={currentFilter}
           currentSortConfig={currentSortConfig}
           onExportCsv={siteScopeMatchesNoRows ? () => undefined : exportCsv}

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { create } from "@bufbuild/protobuf";
 import { POLL_INTERVAL_MS } from "./constants";
+import { useBuildings } from "@/protoFleet/api/buildings";
 import {
   type SortConfig,
   SortConfigSchema,
@@ -38,6 +39,7 @@ import { hasReachedExpectedStatus } from "@/protoFleet/features/fleetManagement/
 import { parseFilterFromURL } from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
 import { FLEET_VISIBLE_PAIRING_STATUSES } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 import { encodeSortToURL, parseSortFromURL } from "@/protoFleet/features/fleetManagement/utils/sortUrlParams";
+import type { FilterLabelSource } from "@/protoFleet/features/fleetManagement/views/viewSummary";
 import Miners from "@/protoFleet/features/onboarding/components/Miners";
 import { isPathScopable } from "@/protoFleet/routing/siteScope";
 import ErrorBoundary from "@/shared/components/ErrorBoundary";
@@ -83,15 +85,18 @@ const applySiteScopeToMinerFilter = (
 const Fleet = () => {
   const navigate = useNavigate();
   const { listGroups, listRacks } = useDeviceSets();
+  const { listAllBuildings } = useBuildings();
   const [availableGroups, setAvailableGroups] = useState<DeviceSet[]>([]);
   const [availableRacks, setAvailableRacks] = useState<DeviceSet[]>([]);
-  const { sites, sitesLoaded } = useFleetOutletContext();
+  const { sites, sitesLoaded, notifyPairingCompleted, minersChangedAt, publishViewFilterContext } =
+    useFleetOutletContext();
   const knownSiteIds = useMemo(() => (sitesLoaded ? buildKnownSiteIds(sites) : undefined), [sites, sitesLoaded]);
   const { activeSite } = useActiveSite({ knownSiteIds });
   const { siteIds: activeSiteIds, includeUnassigned: activeIncludeUnassigned } = useMemo(
     () => siteFilterFromActive(activeSite),
     [activeSite],
   );
+  const [availableBuildings, setAvailableBuildings] = useState<FilterLabelSource[]>([]);
 
   useEffect(() => {
     listGroups({
@@ -104,7 +109,16 @@ const Fleet = () => {
         setAvailableRacks(deviceSets);
       },
     });
-  }, [listGroups, listRacks]);
+    listAllBuildings({
+      onSuccess: (buildings) => {
+        setAvailableBuildings(
+          buildings
+            .filter((row) => row.building !== undefined)
+            .map((row) => ({ id: row.building!.id.toString(), label: row.building!.name })),
+        );
+      },
+    });
+  }, [listGroups, listRacks, listAllBuildings]);
 
   const { pathname } = useLocation();
   const insideFleetShell = isPathScopable(pathname);
@@ -259,14 +273,20 @@ const Fleet = () => {
   // Chrome-level coordination: CompleteSetup lives in FleetLayout and pulses
   // these timestamps. We forward our pairing completion up, and refetch when
   // an in-banner flow (e.g. pool assignment) signals the miner list is stale.
-  const { notifyPairingCompleted, minersChangedAt, publishViewFilterContext } = useFleetOutletContext();
+  const availableSites = useMemo<FilterLabelSource[]>(
+    () =>
+      (sites ?? [])
+        .filter((row) => row.site !== undefined)
+        .map((row) => ({ id: row.site!.id.toString(), label: row.site!.name })),
+    [sites],
+  );
 
   // Push our DeviceSet metadata up to FleetLayout so the saved-view modal
   // (mounted in the top tab strip) can show human-readable labels for any
   // group/rack ids referenced by an active filter.
   useEffect(() => {
-    publishViewFilterContext({ availableGroups, availableRacks });
-  }, [publishViewFilterContext, availableGroups, availableRacks]);
+    publishViewFilterContext({ availableGroups, availableRacks, availableBuildings, availableSites });
+  }, [publishViewFilterContext, availableGroups, availableRacks, availableBuildings, availableSites]);
 
   const refetchAll = useCallback(() => {
     refetch();
@@ -346,6 +366,8 @@ const Fleet = () => {
           availableFirmwareVersions={availableFirmwareVersions}
           availableGroups={availableGroups}
           availableRacks={availableRacks}
+          availableSites={availableSites}
+          availableBuildings={availableBuildings}
           currentFilter={currentFilter}
           currentSortConfig={currentSortConfig}
           onExportCsv={siteScopeMatchesNoRows ? () => undefined : exportCsv}

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -42,7 +42,6 @@ import { encodeSortToURL, parseSortFromURL } from "@/protoFleet/features/fleetMa
 import type { FilterLabelSource } from "@/protoFleet/features/fleetManagement/views/viewSummary";
 import Miners from "@/protoFleet/features/onboarding/components/Miners";
 import { isPathScopable } from "@/protoFleet/routing/siteScope";
-import { useHasPermission } from "@/protoFleet/store";
 import ErrorBoundary from "@/shared/components/ErrorBoundary";
 import { SORT_ASC, SORT_DESC } from "@/shared/components/List/types";
 
@@ -89,8 +88,14 @@ const Fleet = () => {
   const { listAllBuildings } = useBuildings();
   const [availableGroups, setAvailableGroups] = useState<DeviceSet[]>([]);
   const [availableRacks, setAvailableRacks] = useState<DeviceSet[]>([]);
-  const { sites, sitesLoaded, notifyPairingCompleted, minersChangedAt, publishViewFilterContext } =
-    useFleetOutletContext();
+  const {
+    sites,
+    sitesLoaded,
+    siteCatalogAccessGranted,
+    notifyPairingCompleted,
+    minersChangedAt,
+    publishViewFilterContext,
+  } = useFleetOutletContext();
   const knownSiteIds = useMemo(() => (sitesLoaded ? buildKnownSiteIds(sites) : undefined), [sites, sitesLoaded]);
   const { activeSite } = useActiveSite({ knownSiteIds });
   const { siteIds: activeSiteIds, includeUnassigned: activeIncludeUnassigned } = useMemo(
@@ -98,10 +103,9 @@ const Fleet = () => {
     [activeSite],
   );
   const [availableBuildings, setAvailableBuildings] = useState<FilterLabelSource[]>([]);
-  const canReadBuildings = useHasPermission("site:read");
   const readableAvailableBuildings = useMemo(
-    () => (canReadBuildings ? availableBuildings : []),
-    [availableBuildings, canReadBuildings],
+    () => (siteCatalogAccessGranted ? availableBuildings : []),
+    [availableBuildings, siteCatalogAccessGranted],
   );
 
   useEffect(() => {
@@ -115,9 +119,11 @@ const Fleet = () => {
         setAvailableRacks(deviceSets);
       },
     });
-    if (!canReadBuildings) {
-      return;
-    }
+  }, [listGroups, listRacks]);
+
+  useEffect(() => {
+    if (!siteCatalogAccessGranted) return;
+
     listAllBuildings({
       onSuccess: (buildings) => {
         setAvailableBuildings(
@@ -127,7 +133,7 @@ const Fleet = () => {
         );
       },
     });
-  }, [listGroups, listRacks, listAllBuildings, canReadBuildings]);
+  }, [listAllBuildings, siteCatalogAccessGranted]);
 
   const { pathname } = useLocation();
   const insideFleetShell = isPathScopable(pathname);

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
@@ -116,6 +116,7 @@ const FleetLayout = () => {
   const pathScope = useMemo(() => rawPathScope ?? activeSite, [rawPathScope, activeSite]);
 
   const sitesAccessBlocked = !canReadSites || sitesPermissionDenied;
+  const siteCatalogAccessGranted = canReadSites && sitesLoaded && !sitesPermissionDenied;
 
   // Source of truth for "which tabs are reachable right now." Hide-rule
   // changes only need to touch this filter; the redirect effect, the tab
@@ -240,12 +241,22 @@ const FleetLayout = () => {
       sites,
       sitesError,
       sitesLoaded,
+      siteCatalogAccessGranted,
       refetchSites: fetchSites,
       notifyPairingCompleted,
       minersChangedAt,
       publishViewFilterContext,
     }),
-    [sites, sitesError, sitesLoaded, fetchSites, notifyPairingCompleted, minersChangedAt, publishViewFilterContext],
+    [
+      sites,
+      sitesError,
+      sitesLoaded,
+      siteCatalogAccessGranted,
+      fetchSites,
+      notifyPairingCompleted,
+      minersChangedAt,
+      publishViewFilterContext,
+    ],
   );
 
   // Mobile docks the views selector beside the Fleet heading to keep the

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/outletContext.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/outletContext.ts
@@ -11,6 +11,10 @@ export interface FleetOutletContext {
   // distinguishes "never seen data" (show full-page error) from
   // "seen data and a later poll failed" (preserve last-good content).
   sitesLoaded: boolean;
+  // True only after FleetLayout has proven org-scoped site catalog access via
+  // a successful ListSites response. A flat site:read permission can be true
+  // for site-scoped-only users while org-scoped catalog RPCs are still denied.
+  siteCatalogAccessGranted: boolean;
   refetchSites: () => void;
   // Pairing coordination between the Miners tab and the chrome-level
   // CompleteSetup banner. Miners → CompleteSetup: call `notifyPairingCompleted`

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -43,6 +43,8 @@ import {
   encodeFilterToURL,
   FILTER_URL_PARAM_KEYS,
   parseUrlToActiveFilters,
+  UNASSIGNED_FILTER_OPTION,
+  UNASSIGNED_URL_VALUE,
 } from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
 import { encodeSortToURL, parseSortFromURL } from "@/protoFleet/features/fleetManagement/utils/sortUrlParams";
 import {
@@ -51,6 +53,7 @@ import {
   type TelemetryFilterKey,
 } from "@/protoFleet/features/fleetManagement/utils/telemetryFilterBounds";
 import { VIEW_URL_PARAM } from "@/protoFleet/features/fleetManagement/views/savedViews";
+import type { FilterLabelSource } from "@/protoFleet/features/fleetManagement/views/viewSummary";
 import { useUsername } from "@/protoFleet/store";
 
 import { ChevronDown, LogoAlt, Plus, Slider } from "@/shared/assets/icons";
@@ -188,6 +191,14 @@ type MinerListProps = {
    * Available racks for the rack filter dropdown.
    */
   availableRacks?: DeviceSet[];
+  /**
+   * Available sites for the site filter dropdown.
+   */
+  availableSites?: FilterLabelSource[];
+  /**
+   * Available buildings for the building filter dropdown.
+   */
+  availableBuildings?: FilterLabelSource[];
   /**
    * Exports the full paired miner list as CSV.
    */
@@ -502,6 +513,8 @@ const MinerList = ({
   availableFirmwareVersions = [],
   availableGroups = [],
   availableRacks = [],
+  availableSites = [],
+  availableBuildings = [],
   onExportCsv,
   exportCsvLoading = false,
   currentFilter,
@@ -793,13 +806,37 @@ const MinerList = ({
     [availableGroups],
   );
 
+  const sitesFilter: DropdownFilterItem = useMemo(
+    () => ({
+      type: "dropdown",
+      title: "Sites",
+      pluralTitle: "sites",
+      value: "site",
+      options: [...availableSites, UNASSIGNED_FILTER_OPTION],
+      defaultOptionIds: [],
+    }),
+    [availableSites],
+  );
+
+  const buildingsFilter: DropdownFilterItem = useMemo(
+    () => ({
+      type: "dropdown",
+      title: "Buildings",
+      pluralTitle: "buildings",
+      value: "building",
+      options: [...availableBuildings, UNASSIGNED_FILTER_OPTION],
+      defaultOptionIds: [],
+    }),
+    [availableBuildings],
+  );
+
   const racksFilter: DropdownFilterItem = useMemo(
     () => ({
       type: "dropdown",
       title: "Racks",
       pluralTitle: "racks",
       value: "rack",
-      options: availableRacks.map((r) => ({ id: String(r.id), label: r.label })),
+      options: [...availableRacks.map((r) => ({ id: String(r.id), label: r.label })), UNASSIGNED_FILTER_OPTION],
       defaultOptionIds: [],
     }),
     [availableRacks],
@@ -871,6 +908,8 @@ const MinerList = ({
           { ...issuesFilter, showGroupDivider: true },
           modelFilter,
           { ...firmwareFilter, showGroupDivider: true },
+          sitesFilter,
+          buildingsFilter,
           racksFilter,
           zonesFilter,
           { ...groupsFilter, showGroupDivider: true },
@@ -887,6 +926,8 @@ const MinerList = ({
       issuesFilter,
       modelFilter,
       groupsFilter,
+      sitesFilter,
+      buildingsFilter,
       racksFilter,
       firmwareFilter,
       zonesFilter,
@@ -962,14 +1003,22 @@ const MinerList = ({
       const rackFilters = filters.dropdownFilters.rack;
       if (rackFilters && rackFilters.length > 0) {
         rackFilters.forEach((id) => {
-          minerFilter.rackIds.push(BigInt(id));
+          if (id === UNASSIGNED_URL_VALUE) {
+            minerFilter.includeNoRack = true;
+          } else {
+            minerFilter.rackIds.push(BigInt(id));
+          }
         });
       }
 
       const buildingFilters = filters.dropdownFilters.building;
       if (buildingFilters && buildingFilters.length > 0) {
         buildingFilters.forEach((id) => {
-          minerFilter.buildingIds.push(BigInt(id));
+          if (id === UNASSIGNED_URL_VALUE) {
+            minerFilter.includeNoBuilding = true;
+          } else {
+            minerFilter.buildingIds.push(BigInt(id));
+          }
         });
       }
 
@@ -980,7 +1029,11 @@ const MinerList = ({
       const siteFilters = filters.dropdownFilters.site;
       if (siteFilters && siteFilters.length > 0) {
         siteFilters.forEach((id) => {
-          minerFilter.siteIds.push(BigInt(id));
+          if (id === UNASSIGNED_URL_VALUE) {
+            minerFilter.includeUnassigned = true;
+          } else {
+            minerFilter.siteIds.push(BigInt(id));
+          }
         });
       }
 

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -8,6 +8,8 @@ import { useFleetOutletContext } from "../components/FleetLayout";
 import { useBuildings } from "@/protoFleet/api/buildings";
 import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { buildKnownSiteIds, useSites } from "@/protoFleet/api/sites";
+import { issueOptions } from "@/protoFleet/components/DeviceSetList";
+import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
 import {
   intersectSiteFilters,
   isMatchNoneSiteFilter,
@@ -18,20 +20,59 @@ import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import BuildingModals from "@/protoFleet/features/buildings/components/BuildingModals";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
+import {
+  FILTER_URL_PARAM_KEYS,
+  fleetListTelemetryRangesFromURL,
+  issueComponentTypesFromURL,
+  parseIdFilterValuesFromURL,
+  parseUrlToActiveFilters,
+  setTelemetryNumericFilterURLParams,
+  UNASSIGNED_FILTER_OPTION,
+  UNASSIGNED_URL_VALUE,
+} from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
+import {
+  TELEMETRY_FILTER_BOUNDS,
+  TELEMETRY_FILTER_KEYS,
+  type TelemetryFilterKey,
+} from "@/protoFleet/features/fleetManagement/utils/telemetryFilterBounds";
 import { useHasPermission } from "@/protoFleet/store";
 import { Alert } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Header from "@/shared/components/Header";
+import FilterChipsBar, { type FilterChipsBarNumericFilter } from "@/shared/components/List/Filters/FilterChipsBar";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
 import { usePoll } from "@/shared/hooks/usePoll";
+import type { NumericRangeValue } from "@/shared/utils/filterValidation";
 
 const LIST_WRAPPER = "pt-6";
+
+const TELEMETRY_FILTER_CHIPS: FilterChipsBarNumericFilter[] = TELEMETRY_FILTER_KEYS.map((key) => ({
+  key,
+  title: TELEMETRY_FILTER_BOUNDS[key].label,
+  bounds: TELEMETRY_FILTER_BOUNDS[key],
+}));
 
 const FleetBuildingsPage = () => {
   const { sites, sitesError, sitesLoaded, refetchSites } = useFleetOutletContext();
 
   const { listBuildings } = useBuildings();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const errorComponentTypes = useMemo(() => issueComponentTypesFromURL(searchParams), [searchParams]);
+  const telemetryRanges = useMemo(() => fleetListTelemetryRangesFromURL(searchParams), [searchParams]);
+  const selectedNumericValues = useMemo(() => parseUrlToActiveFilters(searchParams).numericFilters, [searchParams]);
+  const selectedIssues = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          searchParams
+            .getAll("issues")
+            .map((v) => v.trim())
+            .filter(Boolean),
+        ),
+      ),
+    [searchParams],
+  );
   const [buildings, setBuildings] = useState<BuildingWithCounts[] | undefined>(undefined);
   const [buildingsError, setBuildingsError] = useState<string | null>(null);
   const [selectedBuildingIds, setSelectedBuildingIds] = useState<string[]>([]);
@@ -42,45 +83,61 @@ const FleetBuildingsPage = () => {
 
   // `?site=<id>` deep links filter the list without changing the path
   // scope. Scope and filter compose below.
-  const [searchParams] = useSearchParams();
+  const urlSiteFilter = useMemo(() => parseIdFilterValuesFromURL(searchParams, "site"), [searchParams]);
   const urlSiteIds = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          searchParams
-            .getAll("site")
-            .map((value) => value.trim())
-            .filter((value) => value !== "" && /^\d+$/.test(value)),
-        ),
-      ),
-    [searchParams],
+    () => urlSiteFilter.values.filter((value) => value !== UNASSIGNED_URL_VALUE),
+    [urlSiteFilter],
   );
+  const hasActiveFilters = urlSiteFilter.values.length > 0 || selectedIssues.length > 0 || telemetryRanges.length > 0;
 
   // Path scope ∩ `?site=` filter. Both empty + false → server returns every
   // building in the org (rendered straight through, no client filter).
   const requestSiteFilter = useMemo(() => {
     return intersectSiteFilters(siteFilterFromActive(activeSite), {
       siteIds: urlSiteIds.map((id) => BigInt(id)),
-      includeUnassigned: false,
+      includeUnassigned: urlSiteFilter.includeUnassigned,
     });
-  }, [urlSiteIds, activeSite]);
+  }, [urlSiteFilter.includeUnassigned, urlSiteIds, activeSite]);
   const requestSiteFilterMatchesNoRows = isMatchNoneSiteFilter(requestSiteFilter);
 
-  // Latest scope, read at response time. usePoll has no per-request
-  // cancellation, so a slow ListBuildings for a previous scope can resolve
-  // after a newer one; comparing the captured scope against this ref lets
-  // the stale (out-of-order) response be ignored instead of clobbering the
-  // current scope's rows.
-  const requestSiteFilterRef = useRef(requestSiteFilter);
+  // usePoll keeps fetchData in a ref and doesn't re-run on its identity
+  // change, so a site/filter switch wouldn't refetch until the next poll
+  // tick. Feed the full request filter as `params` (a stable string key) so
+  // the poll effect restarts immediately when the active site or filter URL
+  // changes.
+  const listFilterKey = useMemo(() => {
+    const telemetryKey = telemetryRanges
+      .map(
+        (range) =>
+          `${range.field}:${range.min ?? ""}:${range.max ?? ""}:${range.minInclusive ? "1" : "0"}:${range.maxInclusive ? "1" : "0"}`,
+      )
+      .join(",");
+    return [
+      requestSiteFilter.siteIds.map(String).join(","),
+      requestSiteFilter.includeUnassigned ? "1" : "0",
+      requestSiteFilter.matchNone ? "1" : "0",
+      errorComponentTypes.join(","),
+      telemetryKey,
+    ].join("|");
+  }, [requestSiteFilter, errorComponentTypes, telemetryRanges]);
+
+  // Latest request key/id, read at response time. usePoll has no
+  // per-request cancellation, and manual modal refreshes can overlap an
+  // in-flight poll, so a slow ListBuildings response can resolve after a
+  // newer one. The key rejects old filters; the request id rejects older
+  // same-filter refreshes.
+  const listFilterKeyRef = useRef(listFilterKey);
+  const listRequestIdRef = useRef(0);
   useEffect(() => {
-    requestSiteFilterRef.current = requestSiteFilter;
-  }, [requestSiteFilter]);
+    listFilterKeyRef.current = listFilterKey;
+  }, [listFilterKey]);
 
   // Returning the promise lets usePoll schedule the next tick from response
   // completion (not from request start) so slow responses can't overlap.
   const fetchBuildings = useCallback(() => {
-    const requestedFilter = requestSiteFilter; // captured for the staleness check
-    if (isMatchNoneSiteFilter(requestedFilter)) {
+    const requestedFilterKey = listFilterKey; // captured for the staleness check
+    const requestId = ++listRequestIdRef.current;
+    if (isMatchNoneSiteFilter(requestSiteFilter)) {
       setBuildings([]);
       setBuildingsError(null);
       return Promise.resolve();
@@ -89,35 +146,28 @@ const FleetBuildingsPage = () => {
     return listBuildings({
       siteIds: requestSiteFilter.siteIds,
       includeUnassigned: requestSiteFilter.includeUnassigned,
+      errorComponentTypes,
+      telemetryRanges,
       onSuccess: (rows) => {
-        if (requestSiteFilterRef.current !== requestedFilter) return; // scope changed mid-flight
+        if (requestId !== listRequestIdRef.current || listFilterKeyRef.current !== requestedFilterKey) return;
         setBuildings(rows);
         setBuildingsError(null);
       },
       onError: (msg) => {
-        if (requestSiteFilterRef.current !== requestedFilter) return; // scope changed mid-flight
+        if (requestId !== listRequestIdRef.current || listFilterKeyRef.current !== requestedFilterKey) return;
         setBuildingsError(msg);
         // Preserve last-good list across transient errors; only fall to []
         // on the initial-load failure path.
         setBuildings((prev) => prev ?? []);
       },
     });
-  }, [listBuildings, requestSiteFilter]);
+  }, [listBuildings, requestSiteFilter, errorComponentTypes, telemetryRanges, listFilterKey]);
 
   // Gate the poll on site:read — same gate FleetLayout uses to redirect.
   const canReadBuildings = useHasPermission("site:read");
-  // usePoll keeps fetchData in a ref and doesn't re-run on its identity
-  // change, so a site-filter switch wouldn't refetch until the next poll
-  // tick. Feed the filter as `params` (a stable string key) so the poll
-  // effect restarts immediately when the active site changes.
-  const siteFilterKey = useMemo(
-    () =>
-      `${requestSiteFilter.siteIds.map(String).join(",")}|${requestSiteFilter.includeUnassigned}|${requestSiteFilter.matchNone ?? false}`,
-    [requestSiteFilter],
-  );
   usePoll({
     fetchData: fetchBuildings,
-    params: siteFilterKey,
+    params: listFilterKey,
     poll: true,
     pollIntervalMs: POLL_INTERVAL_MS,
     enabled: canReadBuildings,
@@ -128,15 +178,15 @@ const FleetBuildingsPage = () => {
   // under the new scope during the in-flight refetch. Resetting to
   // `undefined` surfaces the Loading… state until the scoped response
   // lands; usePoll's params change fires that fetch immediately.
-  const prevSiteFilterKey = useRef(siteFilterKey);
+  const prevListFilterKey = useRef(listFilterKey);
   useEffect(() => {
-    if (prevSiteFilterKey.current !== siteFilterKey) {
-      prevSiteFilterKey.current = siteFilterKey;
+    if (prevListFilterKey.current !== listFilterKey) {
+      prevListFilterKey.current = listFilterKey;
       // eslint-disable-next-line react-hooks/set-state-in-effect -- clearing stale cross-scope rows; external-sync pattern.
       setBuildings(requestSiteFilterMatchesNoRows ? [] : undefined);
       setSelectedBuildingIds([]);
     }
-  }, [requestSiteFilterMatchesNoRows, siteFilterKey]);
+  }, [listFilterKey, requestSiteFilterMatchesNoRows]);
 
   // Server-side filter already scoped the list to the active site /
   // URL deep-link; just pass through.
@@ -217,6 +267,94 @@ const FleetBuildingsPage = () => {
   const [reparentTarget, setReparentTarget] = useState<BuildingWithCounts | null>(null);
   const handleAddBuildingToSite = useCallback((row: BuildingWithCounts) => setReparentTarget(row), []);
 
+  const siteFilterOptions = useMemo(
+    () => [
+      ...(sites ?? [])
+        .filter((site) => site.site !== undefined)
+        .map((site) => ({ id: site.site!.id.toString(), label: site.site!.name })),
+      UNASSIGNED_FILTER_OPTION,
+    ],
+    [sites],
+  );
+
+  const filterChipsBarFilters = useMemo(
+    () => [
+      {
+        key: "issues",
+        title: "Issues",
+        pluralTitle: "issues",
+        options: issueOptions,
+        selectedValues: selectedIssues,
+        showGroupDivider: true,
+      },
+      {
+        key: "site",
+        title: "Sites",
+        pluralTitle: "sites",
+        options: siteFilterOptions,
+        selectedValues: urlSiteFilter.values,
+        showGroupDivider: true,
+      },
+    ],
+    [selectedIssues, siteFilterOptions, urlSiteFilter.values],
+  );
+
+  const writeMultiParam = useCallback(
+    (key: string, values: string[]) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete(key);
+          values.forEach((value) => {
+            const trimmed = value.trim();
+            if (trimmed) next.append(key, trimmed);
+          });
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleFilterChange = useCallback(
+    (key: string, values: string[]) => {
+      if (key === "site") {
+        writeMultiParam("site", values);
+        return;
+      }
+      if (key === "issues") {
+        writeMultiParam("issues", values);
+      }
+    },
+    [writeMultiParam],
+  );
+
+  const handleNumericFilterChange = useCallback(
+    (key: string, value: NumericRangeValue) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          setTelemetryNumericFilterURLParams(next, key as TelemetryFilterKey, value);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleClearFilters = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        FILTER_URL_PARAM_KEYS.forEach((key) => next.delete(key));
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
   if (buildings === undefined || sites === undefined) {
     return (
       <FilterRow>
@@ -251,6 +389,20 @@ const FleetBuildingsPage = () => {
       testId="fleet-buildings-add"
     />
   ) : null;
+
+  const filterControls = (
+    <div className="flex flex-row flex-wrap items-center gap-2">
+      <FilterChipsBar
+        filters={filterChipsBarFilters}
+        onChange={handleFilterChange}
+        numericFilters={TELEMETRY_FILTER_CHIPS}
+        selectedNumericValues={selectedNumericValues}
+        onNumericChange={handleNumericFilterChange}
+        onClearAll={handleClearFilters}
+      />
+      <div className="ml-auto">{addBuildingButton}</div>
+    </div>
+  );
 
   const inlineErrors = (
     <>
@@ -298,10 +450,28 @@ const FleetBuildingsPage = () => {
     requestSiteFilter.siteIds.length > 0 || requestSiteFilter.includeUnassigned || requestSiteFilterMatchesNoRows;
 
   let pageContent: ReactNode;
-  if (buildings.length === 0 && !hasSiteFilter) {
-    pageContent = (
+  if (buildings.length === 0) {
+    pageContent = hasActiveFilters ? (
       <FilterRow testId="fleet-buildings-page">
-        <div className="flex items-center justify-end">{addBuildingButton}</div>
+        {inlineErrors}
+        {filterControls}
+        <NoFilterResultsEmptyState hasActiveFilters onClearFilters={handleClearFilters} />
+      </FilterRow>
+    ) : hasSiteFilter ? (
+      <FilterRow testId="fleet-buildings-page">
+        {filterControls}
+        <div
+          className="rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
+          data-testid="fleet-buildings-filter-empty"
+        >
+          {activeSite.kind === "unassigned"
+            ? "No buildings without a site. Switch the picker to All Sites to see every building."
+            : "No buildings in this site yet."}
+        </div>
+      </FilterRow>
+    ) : (
+      <FilterRow testId="fleet-buildings-page">
+        {filterControls}
         <div className="flex flex-col items-start gap-3 rounded-xl border border-dashed border-border-5 p-6">
           <Header title="No buildings yet" titleSize="text-heading-200" />
           <p className="text-300 text-text-primary-70">
@@ -315,19 +485,21 @@ const FleetBuildingsPage = () => {
       </FilterRow>
     );
   } else if (visibleBuildings.length === 0) {
-    const message =
-      activeSite.kind === "unassigned"
-        ? "No buildings without a site. Switch the picker to All Sites to see every building."
-        : "No buildings in this site yet.";
     pageContent = (
       <FilterRow testId="fleet-buildings-page">
-        <div className="flex items-center justify-end">{addBuildingButton}</div>
-        <div
-          className="rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
-          data-testid="fleet-buildings-filter-empty"
-        >
-          {message}
-        </div>
+        {filterControls}
+        {hasActiveFilters ? (
+          <NoFilterResultsEmptyState hasActiveFilters onClearFilters={handleClearFilters} />
+        ) : (
+          <div
+            className="rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
+            data-testid="fleet-buildings-filter-empty"
+          >
+            {activeSite.kind === "unassigned"
+              ? "No buildings without a site. Switch the picker to All Sites to see every building."
+              : "No buildings in this site yet."}
+          </div>
+        )}
       </FilterRow>
     );
   } else {
@@ -335,7 +507,7 @@ const FleetBuildingsPage = () => {
       <>
         <FilterRow testId="fleet-buildings-page">
           {inlineErrors}
-          <div className="flex items-center justify-end">{addBuildingButton}</div>
+          {filterControls}
         </FilterRow>
         <div className={LIST_WRAPPER}>
           <BuildingList

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
@@ -1,11 +1,27 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import FilterRow from "../components/FilterRow";
 import FleetGroupListActionBar from "../components/FleetGroupActionsMenu/FleetGroupListActionBar";
 import { useFleetOutletContext } from "../components/FleetLayout";
 import SiteList from "../components/SiteList";
-import { buildKnownSiteIds } from "@/protoFleet/api/sites";
+import { buildKnownSiteIds, useSites } from "@/protoFleet/api/sites";
+import { issueOptions } from "@/protoFleet/components/DeviceSetList";
+import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
+import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
+import {
+  FILTER_URL_PARAM_KEYS,
+  fleetListTelemetryRangesFromURL,
+  issueComponentTypesFromURL,
+  parseUrlToActiveFilters,
+  setTelemetryNumericFilterURLParams,
+} from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
+import {
+  TELEMETRY_FILTER_BOUNDS,
+  TELEMETRY_FILTER_KEYS,
+  type TelemetryFilterKey,
+} from "@/protoFleet/features/fleetManagement/utils/telemetryFilterBounds";
 import SiteModals from "@/protoFleet/features/sites/components/SiteModals";
 import SitesEmptyState from "@/protoFleet/features/sites/components/SitesEmptyState";
 import { useSiteModals } from "@/protoFleet/features/sites/hooks/useSiteModals";
@@ -14,27 +30,145 @@ import { Alert } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Header from "@/shared/components/Header";
+import FilterChipsBar, { type FilterChipsBarNumericFilter } from "@/shared/components/List/Filters/FilterChipsBar";
+import { usePoll } from "@/shared/hooks/usePoll";
+import type { NumericRangeValue } from "@/shared/utils/filterValidation";
 
 const LIST_WRAPPER = "pt-6";
 
+const TELEMETRY_FILTER_CHIPS: FilterChipsBarNumericFilter[] = TELEMETRY_FILTER_KEYS.map((key) => ({
+  key,
+  title: TELEMETRY_FILTER_BOUNDS[key].label,
+  bounds: TELEMETRY_FILTER_BOUNDS[key],
+}));
+
 const FleetSitesPage = () => {
   const { sites, sitesError, sitesLoaded, refetchSites } = useFleetOutletContext();
+  const { listSites } = useSites();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const errorComponentTypes = useMemo(() => issueComponentTypesFromURL(searchParams), [searchParams]);
+  const telemetryRanges = useMemo(() => fleetListTelemetryRangesFromURL(searchParams), [searchParams]);
+  const selectedNumericValues = useMemo(() => parseUrlToActiveFilters(searchParams).numericFilters, [searchParams]);
+  const selectedIssues = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          searchParams
+            .getAll("issues")
+            .map((v) => v.trim())
+            .filter(Boolean),
+        ),
+      ),
+    [searchParams],
+  );
+  const hasListFilters = errorComponentTypes.length > 0 || telemetryRanges.length > 0;
+  const [filteredSites, setFilteredSites] = useState<typeof sites>(undefined);
+  const [filteredSitesError, setFilteredSitesError] = useState<string | null>(null);
+  const [filteredSitesLoaded, setFilteredSitesLoaded] = useState(false);
   const [selectedSiteIds, setSelectedSiteIds] = useState<string[]>([]);
   const [isBulkActionBusy, setIsBulkActionBusy] = useState(false);
 
   const knownSiteIds = useMemo(() => (sitesLoaded ? buildKnownSiteIds(sites) : undefined), [sites, sitesLoaded]);
   const { activeSite } = useActiveSite({ knownSiteIds });
+  // Filtered sites use the same site:read gate as FleetLayout's unfiltered
+  // cache, but keep their own cache because the request shape is URL-driven.
+  const canReadSites = useHasPermission("site:read");
   // CreateSite + UpdateSite require site:manage server-side.
   const canManageSites = useHasPermission("site:manage");
 
-  const modals = useSiteModals({ refetchSites });
+  const filteredSitesKey = useMemo(() => {
+    const telemetryKey = telemetryRanges
+      .map(
+        (range) =>
+          `${range.field}:${range.min ?? ""}:${range.max ?? ""}:${range.minInclusive ? "1" : "0"}:${range.maxInclusive ? "1" : "0"}`,
+      )
+      .join(",");
+    return [errorComponentTypes.join(","), telemetryKey].join("|");
+  }, [errorComponentTypes, telemetryRanges]);
+
+  const filteredSitesKeyRef = useRef(filteredSitesKey);
+  const filteredSitesRequestIdRef = useRef(0);
+  useEffect(() => {
+    filteredSitesKeyRef.current = filteredSitesKey;
+  }, [filteredSitesKey]);
+
+  const fetchFilteredSites = useCallback(() => {
+    const requestedFilterKey = filteredSitesKey;
+    const requestId = ++filteredSitesRequestIdRef.current;
+    return listSites({
+      errorComponentTypes,
+      telemetryRanges,
+      onSuccess: (rows) => {
+        if (requestId !== filteredSitesRequestIdRef.current || filteredSitesKeyRef.current !== requestedFilterKey) {
+          return;
+        }
+        setFilteredSites(rows);
+        setFilteredSitesError(null);
+        setFilteredSitesLoaded(true);
+      },
+      onError: (msg) => {
+        if (requestId !== filteredSitesRequestIdRef.current || filteredSitesKeyRef.current !== requestedFilterKey) {
+          return;
+        }
+        setFilteredSitesError(msg);
+        setFilteredSites((prev) => prev ?? []);
+      },
+    });
+  }, [listSites, errorComponentTypes, telemetryRanges, filteredSitesKey]);
+
+  const previousFilteredSitesKey = useRef(filteredSitesKey);
+  useEffect(() => {
+    if (!hasListFilters) {
+      previousFilteredSitesKey.current = filteredSitesKey;
+      /* eslint-disable react-hooks/set-state-in-effect -- clear the filtered-only cache when URL list filters are removed */
+      setFilteredSites(undefined);
+      setFilteredSitesError(null);
+      setFilteredSitesLoaded(false);
+      setSelectedSiteIds([]);
+      /* eslint-enable react-hooks/set-state-in-effect */
+      return;
+    }
+    if (previousFilteredSitesKey.current === filteredSitesKey) return;
+    previousFilteredSitesKey.current = filteredSitesKey;
+    /* eslint-disable react-hooks/set-state-in-effect -- hide stale filtered rows while the new filtered poll request loads */
+    setFilteredSites(undefined);
+    setFilteredSitesError(null);
+    setFilteredSitesLoaded(false);
+    setSelectedSiteIds([]);
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [hasListFilters, filteredSitesKey]);
+
+  usePoll({
+    fetchData: fetchFilteredSites,
+    params: filteredSitesKey,
+    poll: true,
+    pollIntervalMs: POLL_INTERVAL_MS,
+    enabled: canReadSites && hasListFilters,
+  });
+
+  const handleModalRefreshSites = useCallback(() => {
+    refetchSites();
+    if (hasListFilters) void fetchFilteredSites();
+  }, [fetchFilteredSites, hasListFilters, refetchSites]);
+  const modals = useSiteModals({ refetchSites: handleModalRefreshSites });
+
+  const displaySites = hasListFilters ? filteredSites : sites;
+  const displaySitesError = hasListFilters ? filteredSitesError : sitesError;
+  const displaySitesLoaded = hasListFilters ? filteredSitesLoaded : sitesLoaded;
+  const handleRetrySites = useCallback(() => {
+    if (hasListFilters) {
+      void fetchFilteredSites();
+      return;
+    }
+    refetchSites();
+  }, [fetchFilteredSites, hasListFilters, refetchSites]);
   const visibleSiteScopes = useMemo(
     () =>
-      sites?.flatMap((site) => {
+      displaySites?.flatMap((site) => {
         if (!site.site || site.site.id === 0n) return [];
         return [{ kind: "site" as const, id: site.site.id, name: site.site.name }];
       }) ?? [],
-    [sites],
+    [displaySites],
   );
   const selectedSiteScopes = useMemo(() => {
     const selected = new Set(selectedSiteIds);
@@ -64,7 +198,65 @@ const FleetSitesPage = () => {
     [isBulkActionBusy],
   );
 
-  if (sites === undefined) {
+  const handleClearFilters = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        FILTER_URL_PARAM_KEYS.forEach((key) => next.delete(key));
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  const filterChipsBarFilters = useMemo(
+    () => [
+      {
+        key: "issues",
+        title: "Issues",
+        pluralTitle: "issues",
+        options: issueOptions,
+        selectedValues: selectedIssues,
+        showGroupDivider: true,
+      },
+    ],
+    [selectedIssues],
+  );
+
+  const handleFilterChange = useCallback(
+    (key: string, values: string[]) => {
+      if (key !== "issues") return;
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("issues");
+          values.forEach((value) => {
+            const trimmed = value.trim();
+            if (trimmed) next.append("issues", trimmed);
+          });
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleNumericFilterChange = useCallback(
+    (key: string, value: NumericRangeValue) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          setTelemetryNumericFilterURLParams(next, key as TelemetryFilterKey, value);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  if (displaySites === undefined) {
     return (
       <FilterRow>
         <div className="text-300 text-text-primary-70">Loading…</div>
@@ -74,16 +266,16 @@ const FleetSitesPage = () => {
 
   // Full-page error only when the initial call never succeeded; later
   // failures surface inline so last-good content stays visible.
-  if (sitesError && !sitesLoaded) {
+  if (displaySitesError && !displaySitesLoaded) {
     return (
       <FilterRow testId="fleet-sites-error">
         <Header title="Couldn't load sites" titleSize="text-heading-200" />
-        <p className="text-300 text-text-primary-70">{sitesError}</p>
+        <p className="text-300 text-text-primary-70">{displaySitesError}</p>
         <Button
           variant={variants.secondary}
           size={sizes.compact}
           text="Retry"
-          onClick={refetchSites}
+          onClick={handleRetrySites}
           testId="fleet-sites-retry"
         />
       </FilterRow>
@@ -91,29 +283,41 @@ const FleetSitesPage = () => {
   }
 
   const inlineError =
-    sitesError && sitesLoaded ? (
+    displaySitesError && displaySitesLoaded ? (
       <Callout
         intent="danger"
         prefixIcon={<Alert />}
         title="Couldn't refresh sites"
-        subtitle={sitesError}
+        subtitle={displaySitesError}
         buttonText="Retry"
-        buttonOnClick={refetchSites}
+        buttonOnClick={handleRetrySites}
         testId="fleet-sites-inline-error"
       />
     ) : null;
 
   const addSiteButton: ReactNode = canManageSites ? (
-    <div className="flex items-center justify-end">
-      <Button
-        variant={variants.secondary}
-        size={sizes.compact}
-        text="Add site"
-        onClick={modals.openCreate}
-        testId="fleet-sites-add"
-      />
-    </div>
+    <Button
+      variant={variants.secondary}
+      size={sizes.compact}
+      text="Add site"
+      onClick={modals.openCreate}
+      testId="fleet-sites-add"
+    />
   ) : null;
+
+  const filterControls = (
+    <div className="flex flex-row flex-wrap items-center gap-2">
+      <FilterChipsBar
+        filters={filterChipsBarFilters}
+        onChange={handleFilterChange}
+        numericFilters={TELEMETRY_FILTER_CHIPS}
+        selectedNumericValues={selectedNumericValues}
+        onNumericChange={handleNumericFilterChange}
+        onClearAll={handleClearFilters}
+      />
+      <div className="ml-auto">{addSiteButton}</div>
+    </div>
+  );
 
   const bulkActionBar =
     selectedSiteScopes.length > 0 || isBulkActionBusy ? (
@@ -131,11 +335,19 @@ const FleetSitesPage = () => {
   // last site is deleted the stale "site"-kind picker can't reset
   // (useActiveSite skips its validator when knownSiteIds is empty), and
   // the operator still needs the create CTA.
-  if (sites.length === 0) {
+  if (!hasListFilters && displaySites.length === 0) {
     pageContent = (
       <FilterRow testId="fleet-sites-page">
         {inlineError}
         <SitesEmptyState onAddSite={canManageSites ? modals.openCreate : undefined} />
+      </FilterRow>
+    );
+  } else if (hasListFilters && displaySites.length === 0) {
+    pageContent = (
+      <FilterRow testId="fleet-sites-page">
+        {inlineError}
+        {filterControls}
+        <NoFilterResultsEmptyState hasActiveFilters onClearFilters={handleClearFilters} />
       </FilterRow>
     );
   } else if (activeSite.kind === "site") {
@@ -166,11 +378,11 @@ const FleetSitesPage = () => {
       <>
         <FilterRow testId="fleet-sites-page">
           {inlineError}
-          {addSiteButton}
+          {filterControls}
         </FilterRow>
         <div className={LIST_WRAPPER}>
           <SiteList
-            sites={sites}
+            sites={displaySites}
             onEditSite={canManageSites ? modals.openManageEdit : undefined}
             selectedIds={selectedSiteIds}
             onSelectedIdsChange={handleSelectedSiteIdsChange}
@@ -184,7 +396,7 @@ const FleetSitesPage = () => {
     <>
       {pageContent}
       {bulkActionBar}
-      <SiteModals modals={modals} sites={sites} />
+      <SiteModals modals={modals} sites={sites ?? []} />
     </>
   );
 };

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -235,7 +235,6 @@ const RacksPage = () => {
   const getSiteFilter = useCallback(() => effectiveSiteFilterRef.current, []);
   const getSiteIds = useCallback(() => effectiveSiteFilterRef.current.siteIds, []);
   const getIncludeUnassigned = useCallback(() => effectiveSiteFilterRef.current.includeUnassigned, []);
-  const includeUnassigned = effectiveSiteFilter.includeUnassigned;
 
   // ManageRackModal state
   const [manageRackFormData, setManageRackFormData] = useState<RackFormData | null>(null);
@@ -584,17 +583,9 @@ const RacksPage = () => {
     [setSearchParams],
   );
 
-  // Refetch on resolved building-filter change (explicit only now — site
-  // scoping moved to the server-side site_ids filter below).
-  // useDeviceSetListState reads the ref; this effect just kicks pagination.
+  // Resolved building-filter key used by the combined URL-filter refetch below.
+  // Site scoping moved to the server-side site_ids filter.
   const effectiveBuildingKey = useMemo(() => selectedBuildingIds.map(String).join(","), [selectedBuildingIds]);
-  const prevBuildingKey = useRef<string | null>(null);
-  useEffect(() => {
-    if (prevBuildingKey.current !== null && prevBuildingKey.current !== effectiveBuildingKey) {
-      resetAndFetch();
-    }
-    prevBuildingKey.current = effectiveBuildingKey;
-  }, [effectiveBuildingKey, resetAndFetch]);
 
   const writeMultiParam = useCallback(
     (key: string, values: string[]) => {
@@ -614,8 +605,6 @@ const RacksPage = () => {
     [setSearchParams],
   );
 
-  // Refetch on resolved site-filter change (URL `?site=` or SitePicker
-  // selection). Same ref-read pattern as the building effect above.
   const effectiveSiteKey = useMemo(
     () =>
       `${effectiveSiteFilter.siteIds.map(String).join(",")}|${effectiveSiteFilter.includeUnassigned}|${effectiveSiteFilter.matchNone ?? false}`,
@@ -629,10 +618,9 @@ const RacksPage = () => {
       // (Out-of-order list responses are already dropped by
       // useDeviceSetListState's request-id guard, so rows can't go stale.)
       setSelectedRackIds([]);
-      resetAndFetch();
     }
     prevSiteKey.current = effectiveSiteKey;
-  }, [effectiveSiteKey, resetAndFetch]);
+  }, [effectiveSiteKey]);
 
   const handleFilterChange = useCallback(
     (key: string, values: string[]) => {
@@ -671,8 +659,8 @@ const RacksPage = () => {
     [setSearchParams],
   );
 
-  // Refetch when any URL-derived filter input changes. Building, zone, and
-  // issues are combined into a single effect so a navigation that updates
+  // Refetch when any URL-derived filter input changes. Site, building, zone,
+  // and issues are combined into a single effect so a navigation that updates
   // more than one of them (e.g. "Clear filters" or activating a saved view)
   // produces one fetch, not several.
   //
@@ -683,23 +671,14 @@ const RacksPage = () => {
   const filterFetchKey = useMemo(
     () =>
       JSON.stringify([
-        selectedSiteValues,
-        includeUnassigned,
+        effectiveSiteKey,
         effectiveBuildingKey,
         includeNoBuilding,
         selectedZones,
         selectedIssues,
         telemetryRanges,
       ]),
-    [
-      selectedSiteValues,
-      includeUnassigned,
-      effectiveBuildingKey,
-      includeNoBuilding,
-      selectedZones,
-      selectedIssues,
-      telemetryRanges,
-    ],
+    [effectiveSiteKey, effectiveBuildingKey, includeNoBuilding, selectedZones, selectedIssues, telemetryRanges],
   );
   const prevFilterFetchKey = useRef<string | null>(null);
   useEffect(() => {

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -33,11 +33,22 @@ import { useOptionalFleetOutletContext } from "@/protoFleet/features/fleetManage
 import { ManageRackModal, type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal";
 import { RackCard } from "@/protoFleet/features/fleetManagement/components/RackCard";
 import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
+import { BUILDING_URL_PARAM } from "@/protoFleet/features/fleetManagement/utils/buildingFilterUrl";
 import {
-  BUILDING_URL_PARAM,
-  parseBuildingIdsFromParams,
-} from "@/protoFleet/features/fleetManagement/utils/buildingFilterUrl";
+  FILTER_URL_PARAM_KEYS,
+  fleetListTelemetryRangesFromURL,
+  parseIdFilterValuesFromURL,
+  parseUrlToActiveFilters,
+  setTelemetryNumericFilterURLParams,
+  UNASSIGNED_FILTER_OPTION,
+  UNASSIGNED_URL_VALUE,
+} from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
 import { mapRackToCardProps } from "@/protoFleet/features/fleetManagement/utils/rackCardMapper";
+import {
+  TELEMETRY_FILTER_BOUNDS,
+  TELEMETRY_FILTER_KEYS,
+  type TelemetryFilterKey,
+} from "@/protoFleet/features/fleetManagement/utils/telemetryFilterBounds";
 import { useDeviceSetListState } from "@/protoFleet/hooks/useDeviceSetListState";
 import { isPathScopable } from "@/protoFleet/routing/siteScope";
 import { useHasPermission } from "@/protoFleet/store";
@@ -48,13 +59,14 @@ import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Dialog from "@/shared/components/Dialog";
 import DropdownFilter from "@/shared/components/List/Filters/DropdownFilter";
-import FilterChipsBar from "@/shared/components/List/Filters/FilterChipsBar";
+import FilterChipsBar, { type FilterChipsBarNumericFilter } from "@/shared/components/List/Filters/FilterChipsBar";
 import { SORT_ASC, SORT_DESC, type SortDirection } from "@/shared/components/List/types";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import SegmentedControl from "@/shared/components/SegmentedControl";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
 import useMeasure from "@/shared/hooks/useMeasure";
 import { useNavigate } from "@/shared/hooks/useNavigate";
+import type { NumericRangeValue } from "@/shared/utils/filterValidation";
 
 const RACK_COLUMNS_FLEET: DeviceSetColumn[] = [
   "name",
@@ -95,6 +107,12 @@ const siteClearSubtitle = (labels: string[], rackCount: number, unresolved: bool
   const more = labels.length > 3 ? ` and ${labels.length - 3} other building(s)` : "";
   return `${rackCount} of the selected ${rackNoun} ${isAre} currently in ${labelSummary}${more}, which belong${labels.length === 1 ? "s" : ""} to a different site. Continuing will clear the rack ${labels.length === 1 ? "from that building" : "from those buildings"} before moving to the selected site.`;
 };
+
+const TELEMETRY_FILTER_CHIPS: FilterChipsBarNumericFilter[] = TELEMETRY_FILTER_KEYS.map((key) => ({
+  key,
+  title: TELEMETRY_FILTER_BOUNDS[key].label,
+  bounds: TELEMETRY_FILTER_BOUNDS[key],
+}));
 
 const RacksPage = () => {
   const navigate = useNavigate();
@@ -169,41 +187,55 @@ const RacksPage = () => {
   const { activeSite } = useActiveSite({ knownSiteIds });
   const activeSiteFilter = useMemo(() => siteFilterFromActive(activeSite), [activeSite]);
 
-  // `?site=` URL deep links carry one or more comma-separated site IDs.
-  // They are a list filter, not the active view scope.
-  const urlSiteIds = useMemo(
-    () =>
-      new Set(
-        searchParams
-          .getAll("site")
-          .flatMap((raw) => raw.split(","))
-          .map((value) => value.trim())
-          .filter((value) => value !== "" && /^\d+$/.test(value)),
-      ),
-    [searchParams],
+  const selectedSiteFilter = useMemo(() => parseIdFilterValuesFromURL(searchParams, "site"), [searchParams]);
+  const selectedSiteValues = selectedSiteFilter.values;
+  const selectedSiteIds = useMemo(
+    () => selectedSiteValues.filter((value) => value !== UNASSIGNED_URL_VALUE).map((value) => BigInt(value)),
+    [selectedSiteValues],
   );
+  const telemetryRanges = useMemo(() => fleetListTelemetryRangesFromURL(searchParams), [searchParams]);
+  const selectedNumericValues = useMemo(() => parseUrlToActiveFilters(searchParams).numericFilters, [searchParams]);
 
-  const selectedBuildingIds = useMemo(() => parseBuildingIdsFromParams(searchParams), [searchParams]);
-  const selectedBuildingIdStrings = useMemo(() => selectedBuildingIds.map(String), [selectedBuildingIds]);
+  const selectedBuildingFilter = useMemo(() => parseIdFilterValuesFromURL(searchParams, "building"), [searchParams]);
+  const selectedBuildingValues = selectedBuildingFilter.values;
+  const selectedBuildingIds = useMemo(
+    () => selectedBuildingValues.filter((value) => value !== UNASSIGNED_URL_VALUE).map((value) => BigInt(value)),
+    [selectedBuildingValues],
+  );
+  const selectedBuildingIdStrings = selectedBuildingValues;
+  const includeNoBuilding = selectedBuildingFilter.includeUnassigned;
   const effectiveBuildingIdsRef = useRef<bigint[]>(selectedBuildingIds);
   useEffect(() => {
     effectiveBuildingIdsRef.current = selectedBuildingIds;
   }, [selectedBuildingIds]);
   const getBuildingIds = useCallback(() => effectiveBuildingIdsRef.current, []);
+  const includeNoBuildingRef = useRef(includeNoBuilding);
+  useEffect(() => {
+    includeNoBuildingRef.current = includeNoBuilding;
+  }, [includeNoBuilding]);
+  const getIncludeNoBuilding = useCallback(() => includeNoBuildingRef.current, []);
+  const telemetryRangesRef = useRef(telemetryRanges);
+  useEffect(() => {
+    telemetryRangesRef.current = telemetryRanges;
+  }, [telemetryRanges]);
+  const getTelemetryRanges = useCallback(() => telemetryRangesRef.current, []);
 
   // Effective site filter: path scope ∩ `?site=` list filter. When neither
   // is set the filter is empty and the server returns every rack in the org.
   const effectiveSiteFilter = useMemo(() => {
     return intersectSiteFilters(activeSiteFilter, {
-      siteIds: Array.from(urlSiteIds, (id) => BigInt(id)),
-      includeUnassigned: false,
+      siteIds: selectedSiteIds,
+      includeUnassigned: selectedSiteFilter.includeUnassigned,
     });
-  }, [urlSiteIds, activeSiteFilter]);
+  }, [activeSiteFilter, selectedSiteIds, selectedSiteFilter.includeUnassigned]);
   const effectiveSiteFilterRef = useRef(effectiveSiteFilter);
   useEffect(() => {
     effectiveSiteFilterRef.current = effectiveSiteFilter;
   }, [effectiveSiteFilter]);
   const getSiteFilter = useCallback(() => effectiveSiteFilterRef.current, []);
+  const getSiteIds = useCallback(() => effectiveSiteFilterRef.current.siteIds, []);
+  const getIncludeUnassigned = useCallback(() => effectiveSiteFilterRef.current.includeUnassigned, []);
+  const includeUnassigned = effectiveSiteFilter.includeUnassigned;
 
   // ManageRackModal state
   const [manageRackFormData, setManageRackFormData] = useState<RackFormData | null>(null);
@@ -263,6 +295,10 @@ const RacksPage = () => {
     getBuildingIds,
     getSiteFilter,
     getInitialRackSort,
+    getSiteIds,
+    getIncludeUnassigned,
+    getIncludeNoBuilding,
+    getTelemetryRanges,
   );
 
   // Propagate external URL sort changes (saved view activation, deep-link
@@ -536,7 +572,9 @@ const RacksPage = () => {
           next.delete(BUILDING_URL_PARAM);
           ids.forEach((id) => {
             const trimmed = id.trim();
-            if (trimmed && /^\d+$/.test(trimmed)) next.append(BUILDING_URL_PARAM, trimmed);
+            if (trimmed === UNASSIGNED_URL_VALUE || (trimmed && /^\d+$/.test(trimmed))) {
+              next.append(BUILDING_URL_PARAM, trimmed);
+            }
           });
           return next;
         },
@@ -607,11 +645,30 @@ const RacksPage = () => {
         writeMultiParam("issues", values);
         return;
       }
+      if (key === "site") {
+        writeMultiParam("site", values);
+        return;
+      }
       if (key === "building") {
         setBuildingFilter(values);
       }
     },
     [setBuildingFilter, writeMultiParam],
+  );
+
+  const handleNumericFilterChange = useCallback(
+    (key: string, value: NumericRangeValue) => {
+      setSelectedRackIds([]);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          setTelemetryNumericFilterURLParams(next, key as TelemetryFilterKey, value);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
   );
 
   // Refetch when any URL-derived filter input changes. Building, zone, and
@@ -624,8 +681,25 @@ const RacksPage = () => {
   // like "DC1, Row A" — can't collide with a different selection that
   // happens to produce the same joined output.
   const filterFetchKey = useMemo(
-    () => JSON.stringify([effectiveBuildingKey, selectedZones, selectedIssues]),
-    [effectiveBuildingKey, selectedZones, selectedIssues],
+    () =>
+      JSON.stringify([
+        selectedSiteValues,
+        includeUnassigned,
+        effectiveBuildingKey,
+        includeNoBuilding,
+        selectedZones,
+        selectedIssues,
+        telemetryRanges,
+      ]),
+    [
+      selectedSiteValues,
+      includeUnassigned,
+      effectiveBuildingKey,
+      includeNoBuilding,
+      selectedZones,
+      selectedIssues,
+      telemetryRanges,
+    ],
   );
   const prevFilterFetchKey = useRef<string | null>(null);
   useEffect(() => {
@@ -638,35 +712,45 @@ const RacksPage = () => {
   const filterChipsBarFilters = useMemo(
     () => [
       {
-        key: "building",
-        title: "Building",
-        pluralTitle: "buildings",
-        options: allBuildings,
-        selectedValues: selectedBuildingIdStrings,
-      },
-      {
-        key: "zone",
-        title: "Zone",
-        pluralTitle: "zones",
-        options: allZones,
-        selectedValues: selectedZones,
-      },
-      {
         key: "issues",
         title: "Issues",
         pluralTitle: "issues",
         options: issueOptions,
         selectedValues: selectedIssues,
+        showGroupDivider: true,
+      },
+      {
+        key: "site",
+        title: "Sites",
+        pluralTitle: "sites",
+        options: [...allSites, UNASSIGNED_FILTER_OPTION],
+        selectedValues: selectedSiteValues,
+      },
+      {
+        key: "building",
+        title: "Buildings",
+        pluralTitle: "buildings",
+        options: [...allBuildings, UNASSIGNED_FILTER_OPTION],
+        selectedValues: selectedBuildingIdStrings,
+      },
+      {
+        key: "zone",
+        title: "Zones",
+        pluralTitle: "zones",
+        options: allZones,
+        selectedValues: selectedZones,
+        showGroupDivider: true,
       },
     ],
-    [allBuildings, selectedBuildingIdStrings, allZones, selectedZones, selectedIssues],
+    [allSites, selectedSiteValues, allBuildings, selectedBuildingIdStrings, allZones, selectedZones, selectedIssues],
   );
 
   const hasActiveFilters =
+    selectedSiteValues.length > 0 ||
     selectedBuildingIdStrings.length > 0 ||
     selectedZones.length > 0 ||
     selectedIssues.length > 0 ||
-    urlSiteIds.size > 0;
+    telemetryRanges.length > 0;
   const visibleRackScopes = useMemo(
     () =>
       racks.flatMap((rack) => {
@@ -702,18 +786,16 @@ const RacksPage = () => {
     // batch into one history entry (react-router resolves the prev against
     // the current location, not a value set by an earlier call this render).
     const hadAny =
+      selectedSiteValues.length > 0 ||
       selectedBuildingIdStrings.length > 0 ||
-      urlSiteIds.size > 0 ||
       selectedZones.length > 0 ||
-      selectedIssues.length > 0;
+      selectedIssues.length > 0 ||
+      telemetryRanges.length > 0;
     if (hadAny) {
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
-          next.delete("site");
-          next.delete(BUILDING_URL_PARAM);
-          next.delete("zone");
-          next.delete("issues");
+          FILTER_URL_PARAM_KEYS.forEach((key) => next.delete(key));
           return next;
         },
         { replace: true },
@@ -722,7 +804,15 @@ const RacksPage = () => {
       // No URL transition → manually kick the refetch (URL effects skip).
       resetAndFetch();
     }
-  }, [resetAndFetch, selectedBuildingIdStrings, selectedIssues, selectedZones, setSearchParams, urlSiteIds]);
+  }, [
+    resetAndFetch,
+    selectedBuildingIdStrings,
+    selectedIssues,
+    selectedSiteValues,
+    selectedZones,
+    setSearchParams,
+    telemetryRanges,
+  ]);
 
   const emptyStateRow: ReactNode = useMemo(() => {
     if (isLoading || totalCount > 0) return undefined;
@@ -851,20 +941,20 @@ const RacksPage = () => {
 
   const renderSite = useCallback(
     (item: DeviceSetListItem) => {
-      if (item.deviceSet.typeDetails.case !== "rackInfo") return <span>—</span>;
+      if (item.deviceSet.typeDetails.case !== "rackInfo") return <span />;
       const siteId = item.deviceSet.typeDetails.value.siteId;
-      if (siteId === undefined) return <span>—</span>;
-      return <span>{siteNameById.get(siteId.toString()) ?? "—"}</span>;
+      if (siteId === undefined) return <span />;
+      return <span>{siteNameById.get(siteId.toString()) ?? ""}</span>;
     },
     [siteNameById],
   );
 
   const renderBuilding = useCallback(
     (item: DeviceSetListItem) => {
-      if (item.deviceSet.typeDetails.case !== "rackInfo") return <span>—</span>;
+      if (item.deviceSet.typeDetails.case !== "rackInfo") return <span />;
       const buildingId = item.deviceSet.typeDetails.value.buildingId;
-      if (buildingId === undefined) return <span>—</span>;
-      return <span>{buildingNameById.get(buildingId.toString()) ?? "—"}</span>;
+      if (buildingId === undefined) return <span />;
+      return <span>{buildingNameById.get(buildingId.toString()) ?? ""}</span>;
     },
     [buildingNameById],
   );
@@ -1033,6 +1123,9 @@ const RacksPage = () => {
             <FilterChipsBar
               filters={filterChipsBarFilters}
               onChange={handleFilterChange}
+              numericFilters={TELEMETRY_FILTER_CHIPS}
+              selectedNumericValues={selectedNumericValues}
+              onNumericChange={handleNumericFilterChange}
               onClearAll={handleClearFilters}
             />
             {racksViewMode === "grid" ? (
@@ -1058,6 +1151,9 @@ const RacksPage = () => {
             <FilterChipsBar
               filters={filterChipsBarFilters}
               onChange={handleFilterChange}
+              numericFilters={TELEMETRY_FILTER_CHIPS}
+              selectedNumericValues={selectedNumericValues}
+              onNumericChange={handleNumericFilterChange}
               onClearAll={handleClearFilters}
             />
             {racksViewMode === "grid" ? (

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -723,7 +723,7 @@ const RacksPage = () => {
         key: "site",
         title: "Sites",
         pluralTitle: "sites",
-        options: [...allSites, UNASSIGNED_FILTER_OPTION],
+        options: [...(allSites ?? []), UNASSIGNED_FILTER_OPTION],
         selectedValues: selectedSiteValues,
       },
       {

--- a/client/src/protoFleet/features/fleetManagement/utils/filterUrlParams.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/filterUrlParams.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { create } from "@bufbuild/protobuf";
-import { encodeFilterToURL, parseFilterFromURL, parseUrlToActiveFilters } from "./filterUrlParams";
+import {
+  encodeFilterToURL,
+  parseFilterFromURL,
+  parseUrlToActiveFilters,
+  UNASSIGNED_URL_VALUE,
+} from "./filterUrlParams";
 import {
   MinerListFilterSchema,
   NumericField,
@@ -288,6 +293,42 @@ describe("filterUrlParams", () => {
       const filter = parseFilterFromURL(params);
 
       expect(filter?.rackIds).toEqual([]);
+    });
+  });
+
+  describe("unassigned placement filters", () => {
+    it("encodes include flags as the null URL sentinel", () => {
+      const filter = create(MinerListFilterSchema, {
+        rackIds: [10n],
+        buildingIds: [20n],
+        siteIds: [30n],
+        includeNoRack: true,
+        includeNoBuilding: true,
+        includeUnassigned: true,
+      });
+
+      const params = encodeFilterToURL(filter);
+
+      expect(params.getAll("rack")).toEqual(["10", UNASSIGNED_URL_VALUE]);
+      expect(params.getAll("building")).toEqual(["20", UNASSIGNED_URL_VALUE]);
+      expect(params.getAll("site")).toEqual(["30", UNASSIGNED_URL_VALUE]);
+    });
+
+    it("parses the null URL sentinel into include flags and active dropdown values", () => {
+      const params = new URLSearchParams("rack=10&rack=null&building=20&building=null&site=30&site=null");
+
+      const filter = parseFilterFromURL(params);
+      const activeFilters = parseUrlToActiveFilters(params);
+
+      expect(filter?.rackIds).toEqual([10n]);
+      expect(filter?.includeNoRack).toBe(true);
+      expect(filter?.buildingIds).toEqual([20n]);
+      expect(filter?.includeNoBuilding).toBe(true);
+      expect(filter?.siteIds).toEqual([30n]);
+      expect(filter?.includeUnassigned).toBe(true);
+      expect(activeFilters.dropdownFilters.rack).toEqual(["10", UNASSIGNED_URL_VALUE]);
+      expect(activeFilters.dropdownFilters.building).toEqual(["20", UNASSIGNED_URL_VALUE]);
+      expect(activeFilters.dropdownFilters.site).toEqual(["30", UNASSIGNED_URL_VALUE]);
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/utils/filterUrlParams.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/filterUrlParams.ts
@@ -1,6 +1,14 @@
 import { create } from "@bufbuild/protobuf";
 import { componentIssues, deviceStatusFilterStates } from "../components/MinerList/constants";
-import { protoFieldForTelemetryKey, type TelemetryFilterKey } from "./telemetryFilterBounds";
+import {
+  fleetListTelemetryFieldForTelemetryKey,
+  protoFieldForTelemetryKey,
+  type TelemetryFilterKey,
+} from "./telemetryFilterBounds";
+import {
+  type FleetListTelemetryRangeFilter,
+  FleetListTelemetryRangeFilterSchema,
+} from "@/protoFleet/api/generated/common/v1/fleet_list_stats_pb";
 import { ComponentType } from "@/protoFleet/api/generated/errors/v1/errors_pb";
 import {
   DeviceStatus,
@@ -25,11 +33,25 @@ const URL_PARAMS = {
   SUBNET: "subnet",
 } as const;
 
+export const UNASSIGNED_URL_VALUE = "null";
+export const UNASSIGNED_FILTER_OPTION = { id: UNASSIGNED_URL_VALUE, label: "Unassigned" };
+
 // Telemetry numeric filters use `${key}_min` / `${key}_max` URL params, one
 // pair per field. Missing key = unbounded on that side.
 const NUMERIC_KEYS: TelemetryFilterKey[] = ["hashrate", "efficiency", "power", "temperature"];
 const numericMinParam = (key: TelemetryFilterKey) => `${key}_min`;
 const numericMaxParam = (key: TelemetryFilterKey) => `${key}_max`;
+
+export const setTelemetryNumericFilterURLParams = (
+  params: URLSearchParams,
+  key: TelemetryFilterKey,
+  value: NumericRangeValue,
+): void => {
+  params.delete(numericMinParam(key));
+  params.delete(numericMaxParam(key));
+  if (value.min !== undefined) params.set(numericMinParam(key), String(value.min));
+  if (value.max !== undefined) params.set(numericMaxParam(key), String(value.max));
+};
 
 export const FILTER_URL_PARAM_KEYS: readonly string[] = [
   ...Object.values(URL_PARAMS),
@@ -89,6 +111,85 @@ const getMulti = (params: URLSearchParams, key: string): string[] => params.getA
 // values are guaranteed to not contain commas (enum strings, numeric IDs).
 const getMultiLegacy = (params: URLSearchParams, key: string): string[] =>
   params.getAll(key).flatMap((raw) => raw.split(",").filter((piece) => piece !== ""));
+
+const parseIdBucketValues = (params: URLSearchParams, key: string): { ids: bigint[]; includeUnassigned: boolean } => {
+  const ids: bigint[] = [];
+  let includeUnassigned = false;
+  getMultiLegacy(params, key).forEach((raw) => {
+    const trimmed = raw.trim();
+    if (trimmed === UNASSIGNED_URL_VALUE) {
+      includeUnassigned = true;
+      return;
+    }
+    if (trimmed && /^\d+$/.test(trimmed)) {
+      ids.push(BigInt(trimmed));
+    }
+  });
+  return { ids, includeUnassigned };
+};
+
+export const parseIdFilterValuesFromURL = (
+  params: URLSearchParams,
+  key: "site" | "building" | "rack" | "group",
+): { values: string[]; includeUnassigned: boolean } => {
+  const values: string[] = [];
+  let includeUnassigned = false;
+  getMultiLegacy(params, key).forEach((raw) => {
+    const trimmed = raw.trim();
+    if (trimmed === UNASSIGNED_URL_VALUE) {
+      includeUnassigned = true;
+      values.push(UNASSIGNED_URL_VALUE);
+      return;
+    }
+    if (trimmed && /^\d+$/.test(trimmed)) values.push(trimmed);
+  });
+  return { values: Array.from(new Set(values)), includeUnassigned };
+};
+
+export const issueComponentTypesFromValues = (issueValues: string[]): ComponentType[] => {
+  const out: ComponentType[] = [];
+  issueValues.forEach((issue) => {
+    switch (issue) {
+      case componentIssues.controlBoard:
+        out.push(ComponentType.CONTROL_BOARD);
+        break;
+      case componentIssues.fans:
+        out.push(ComponentType.FAN);
+        break;
+      case componentIssues.hashBoards:
+        out.push(ComponentType.HASH_BOARD);
+        break;
+      case componentIssues.psu:
+        out.push(ComponentType.PSU);
+        break;
+    }
+  });
+  return out;
+};
+
+export const issueComponentTypesFromURL = (params: URLSearchParams): ComponentType[] =>
+  issueComponentTypesFromValues(getMultiLegacy(params, URL_PARAMS.ISSUES));
+
+export const fleetListTelemetryRangesFromActiveFilters = (filters: ActiveFilters): FleetListTelemetryRangeFilter[] => {
+  const ranges: FleetListTelemetryRangeFilter[] = [];
+  Object.entries(filters.numericFilters).forEach(([key, value]) => {
+    if (value.min === undefined && value.max === undefined) return;
+    const field = fleetListTelemetryFieldForTelemetryKey[key as TelemetryFilterKey];
+    if (field === undefined) return;
+    const range = create(FleetListTelemetryRangeFilterSchema, {
+      field,
+      minInclusive: true,
+      maxInclusive: true,
+    });
+    if (value.min !== undefined) range.min = value.min;
+    if (value.max !== undefined) range.max = value.max;
+    ranges.push(range);
+  });
+  return ranges;
+};
+
+export const fleetListTelemetryRangesFromURL = (params: URLSearchParams): FleetListTelemetryRangeFilter[] =>
+  fleetListTelemetryRangesFromActiveFilters(parseUrlToActiveFilters(params));
 
 /**
  * Encodes a MinerListFilter to URL search parameters
@@ -150,16 +251,22 @@ export function encodeFilterToURL(filter: MinerListFilter): URLSearchParams {
     setMulti(params, URL_PARAMS.GROUP, filter.groupIds.map(String).sort());
   }
 
-  if (filter.rackIds.length > 0) {
-    setMulti(params, URL_PARAMS.RACK, filter.rackIds.map(String).sort());
+  if (filter.rackIds.length > 0 || filter.includeNoRack) {
+    const rackValues = filter.rackIds.map(String);
+    if (filter.includeNoRack) rackValues.push(UNASSIGNED_URL_VALUE);
+    setMulti(params, URL_PARAMS.RACK, rackValues.sort());
   }
 
-  if (filter.buildingIds.length > 0) {
-    setMulti(params, URL_PARAMS.BUILDING, filter.buildingIds.map(String).sort());
+  if (filter.buildingIds.length > 0 || filter.includeNoBuilding) {
+    const buildingValues = filter.buildingIds.map(String);
+    if (filter.includeNoBuilding) buildingValues.push(UNASSIGNED_URL_VALUE);
+    setMulti(params, URL_PARAMS.BUILDING, buildingValues.sort());
   }
 
-  if (filter.siteIds.length > 0) {
-    setMulti(params, URL_PARAMS.SITE, filter.siteIds.map(String).sort());
+  if (filter.siteIds.length > 0 || filter.includeUnassigned) {
+    const siteValues = filter.siteIds.map(String);
+    if (filter.includeUnassigned) siteValues.push(UNASSIGNED_URL_VALUE);
+    setMulti(params, URL_PARAMS.SITE, siteValues.sort());
   }
 
   if (filter.firmwareVersions.length > 0) {
@@ -219,22 +326,7 @@ export function parseFilterFromURL(params: URLSearchParams): MinerListFilter | u
     }
   });
 
-  getMultiLegacy(params, URL_PARAMS.ISSUES).forEach((issue) => {
-    switch (issue) {
-      case componentIssues.controlBoard:
-        filter.errorComponentTypes.push(ComponentType.CONTROL_BOARD);
-        break;
-      case componentIssues.fans:
-        filter.errorComponentTypes.push(ComponentType.FAN);
-        break;
-      case componentIssues.hashBoards:
-        filter.errorComponentTypes.push(ComponentType.HASH_BOARD);
-        break;
-      case componentIssues.psu:
-        filter.errorComponentTypes.push(ComponentType.PSU);
-        break;
-    }
-  });
+  filter.errorComponentTypes.push(...issueComponentTypesFromURL(params));
 
   getMultiLegacy(params, URL_PARAMS.MODEL).forEach((model) => {
     if (model) filter.models.push(model);
@@ -247,26 +339,17 @@ export function parseFilterFromURL(params: URLSearchParams): MinerListFilter | u
     }
   });
 
-  getMultiLegacy(params, URL_PARAMS.RACK).forEach((id) => {
-    const trimmed = id.trim();
-    if (trimmed && /^\d+$/.test(trimmed)) {
-      filter.rackIds.push(BigInt(trimmed));
-    }
-  });
+  const rackBucket = parseIdBucketValues(params, URL_PARAMS.RACK);
+  filter.rackIds.push(...rackBucket.ids);
+  filter.includeNoRack = rackBucket.includeUnassigned;
 
-  getMultiLegacy(params, URL_PARAMS.BUILDING).forEach((id) => {
-    const trimmed = id.trim();
-    if (trimmed && /^\d+$/.test(trimmed)) {
-      filter.buildingIds.push(BigInt(trimmed));
-    }
-  });
+  const buildingBucket = parseIdBucketValues(params, URL_PARAMS.BUILDING);
+  filter.buildingIds.push(...buildingBucket.ids);
+  filter.includeNoBuilding = buildingBucket.includeUnassigned;
 
-  getMultiLegacy(params, URL_PARAMS.SITE).forEach((id) => {
-    const trimmed = id.trim();
-    if (trimmed && /^\d+$/.test(trimmed)) {
-      filter.siteIds.push(BigInt(trimmed));
-    }
-  });
+  const siteBucket = parseIdBucketValues(params, URL_PARAMS.SITE);
+  filter.siteIds.push(...siteBucket.ids);
+  filter.includeUnassigned = siteBucket.includeUnassigned;
 
   getMulti(params, URL_PARAMS.FIRMWARE).forEach((value) => {
     if (value) filter.firmwareVersions.push(value);
@@ -356,25 +439,19 @@ export function parseUrlToActiveFilters(params: URLSearchParams): ActiveFilters 
     activeFilters.dropdownFilters.group = Array.from(new Set(groupValues));
   }
 
-  const rackValues = getMultiLegacy(params, URL_PARAMS.RACK)
-    .map((value) => value.trim())
-    .filter((value) => value !== "" && /^\d+$/.test(value));
+  const rackValues = parseIdFilterValuesFromURL(params, URL_PARAMS.RACK).values;
   if (rackValues.length > 0) {
-    activeFilters.dropdownFilters.rack = Array.from(new Set(rackValues));
+    activeFilters.dropdownFilters.rack = rackValues;
   }
 
-  const buildingValues = getMultiLegacy(params, URL_PARAMS.BUILDING)
-    .map((value) => value.trim())
-    .filter((value) => value !== "" && /^\d+$/.test(value));
+  const buildingValues = parseIdFilterValuesFromURL(params, URL_PARAMS.BUILDING).values;
   if (buildingValues.length > 0) {
-    activeFilters.dropdownFilters.building = Array.from(new Set(buildingValues));
+    activeFilters.dropdownFilters.building = buildingValues;
   }
 
-  const siteValues = getMultiLegacy(params, URL_PARAMS.SITE)
-    .map((value) => value.trim())
-    .filter((value) => value !== "" && /^\d+$/.test(value));
+  const siteValues = parseIdFilterValuesFromURL(params, URL_PARAMS.SITE).values;
   if (siteValues.length > 0) {
-    activeFilters.dropdownFilters.site = Array.from(new Set(siteValues));
+    activeFilters.dropdownFilters.site = siteValues;
   }
 
   const firmwareValues = getMulti(params, URL_PARAMS.FIRMWARE).filter((v) => v !== "");

--- a/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.test.ts
@@ -10,6 +10,8 @@ import {
 import {
   type MinerListFilter,
   MinerListFilterSchema,
+  NumericField,
+  NumericRangeFilterSchema,
   PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
@@ -70,15 +72,31 @@ describe("applyFleetSelectablePairingStatuses", () => {
     expect(applyFleetSelectablePairingStatuses(filter).pairingStatuses).toEqual([]);
   });
 
-  it("copies firmware and zone filters through so bulk actions respect them", () => {
+  it("copies server-side filters through so bulk actions respect the current filtered set", () => {
     const filter: MinerListFilter = create(MinerListFilterSchema, {
+      siteIds: [200n],
+      includeUnassigned: true,
+      buildingIds: [100n],
+      includeNoBuilding: true,
+      rackIds: [10n],
+      includeNoRack: true,
       firmwareVersions: ["v3.5.1"],
       zones: ["Austin, Building 1"],
+      numericRanges: [create(NumericRangeFilterSchema, { field: NumericField.POWER_KW, min: 2 })],
+      ipCidrs: ["192.168.2.0/24"],
     });
 
     const result = applyFleetSelectablePairingStatuses(filter);
+    expect(result.siteIds).toEqual([200n]);
+    expect(result.includeUnassigned).toBe(true);
+    expect(result.buildingIds).toEqual([100n]);
+    expect(result.includeNoBuilding).toBe(true);
+    expect(result.rackIds).toEqual([10n]);
+    expect(result.includeNoRack).toBe(true);
     expect(result.firmwareVersions).toEqual(["v3.5.1"]);
     expect(result.zones).toEqual(["Austin, Building 1"]);
+    expect(result.numericRanges).toEqual([create(NumericRangeFilterSchema, { field: NumericField.POWER_KW, min: 2 })]);
+    expect(result.ipCidrs).toEqual(["192.168.2.0/24"]);
   });
 });
 

--- a/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.ts
@@ -33,8 +33,16 @@ const applyAllowedPairingStatuses = (
       pairingStatuses.length > 0 || hasExplicitPairingStatuses ? pairingStatuses : [...allowedPairingStatuses],
     groupIds: filter?.groupIds ?? [],
     rackIds: filter?.rackIds ?? [],
+    includeNoRack: filter?.includeNoRack ?? false,
+    siteIds: filter?.siteIds ?? [],
+    includeUnassigned: filter?.includeUnassigned ?? false,
+    buildingIds: filter?.buildingIds ?? [],
+    includeNoBuilding: filter?.includeNoBuilding ?? false,
     firmwareVersions: filter?.firmwareVersions ?? [],
     zones: filter?.zones ?? [],
+    zoneKeys: filter?.zoneKeys ?? [],
+    numericRanges: filter?.numericRanges ?? [],
+    ipCidrs: filter?.ipCidrs ?? [],
   });
 };
 

--- a/client/src/protoFleet/features/fleetManagement/utils/telemetryFilterBounds.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/telemetryFilterBounds.ts
@@ -1,3 +1,4 @@
+import { FleetListTelemetryField } from "@/protoFleet/api/generated/common/v1/fleet_list_stats_pb";
 import { NumericField } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import type { NumericRangeBounds } from "@/shared/utils/filterValidation";
 
@@ -19,6 +20,8 @@ export const TELEMETRY_FILTER_BOUNDS = {
 } as const satisfies Record<string, NumericRangeBounds & { label: string }>;
 
 export type TelemetryFilterKey = keyof typeof TELEMETRY_FILTER_BOUNDS;
+
+export const TELEMETRY_FILTER_KEYS: readonly TelemetryFilterKey[] = ["hashrate", "temperature", "efficiency", "power"];
 
 /**
  * Maps a `NumericField` proto enum value to the matching bounds entry, or
@@ -55,4 +58,11 @@ export const protoFieldForTelemetryKey: Record<TelemetryFilterKey, NumericField>
   efficiency: NumericField.EFFICIENCY_JTH,
   power: NumericField.POWER_KW,
   temperature: NumericField.TEMPERATURE_C,
+};
+
+export const fleetListTelemetryFieldForTelemetryKey: Record<TelemetryFilterKey, FleetListTelemetryField> = {
+  hashrate: FleetListTelemetryField.HASHRATE_THS,
+  efficiency: FleetListTelemetryField.EFFICIENCY_JTH,
+  power: FleetListTelemetryField.POWER_KW,
+  temperature: FleetListTelemetryField.TEMPERATURE_C,
 };

--- a/client/src/protoFleet/features/fleetManagement/views/savedViews.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/savedViews.test.ts
@@ -46,9 +46,19 @@ describe("savedViews helpers", () => {
       expect(canonicalizeSearchParams("status=offline&zone=DC1&sort=name", "racks")).toBe("sort=name&zone=DC1");
     });
 
-    it("returns empty on tabs without a saveable surface", () => {
-      expect(canonicalizeSearchParams("zone=DC1&sort=name", "buildings")).toBe("");
-      expect(canonicalizeSearchParams("anything=goes", "sites")).toBe("");
+    it("scopes filter keys to the active tab — buildings retain site, issue, and telemetry state", () => {
+      expect(
+        canonicalizeSearchParams(
+          "zone=DC1&sort=name&site=7&site=null&issues=fan&hashrate_min=10&temperature_max=90",
+          "buildings",
+        ),
+      ).toBe("hashrate_min=10&issues=fan&site=7&site=null&temperature_max=90");
+    });
+
+    it("scopes filter keys to the active tab — sites retain issue and telemetry state", () => {
+      expect(canonicalizeSearchParams("site=7&issues=psu&power_max=4.2&sort=name", "sites")).toBe(
+        "issues=psu&power_max=4.2",
+      );
     });
   });
 
@@ -163,11 +173,11 @@ describe("savedViews helpers", () => {
   });
 
   describe("misc", () => {
-    it("TABS_WITH_SAVEABLE_STATE covers miners + racks", () => {
+    it("TABS_WITH_SAVEABLE_STATE covers every fleet tab with URL-backed filters", () => {
       expect(TABS_WITH_SAVEABLE_STATE.has("miners")).toBe(true);
       expect(TABS_WITH_SAVEABLE_STATE.has("racks")).toBe(true);
-      expect(TABS_WITH_SAVEABLE_STATE.has("buildings")).toBe(false);
-      expect(TABS_WITH_SAVEABLE_STATE.has("sites")).toBe(false);
+      expect(TABS_WITH_SAVEABLE_STATE.has("buildings")).toBe(true);
+      expect(TABS_WITH_SAVEABLE_STATE.has("sites")).toBe(true);
     });
 
     it("isSavedViewsRecordDefault detects empty record", () => {

--- a/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
@@ -23,9 +23,10 @@ const MINER_FILTER_KEYS: readonly string[] = [
   "status",
   "issues",
   "model",
+  "site",
+  "building",
   "group",
   "rack",
-  "building",
   "firmware",
   "zone",
   "subnet",
@@ -36,8 +37,15 @@ const MINER_FILTER_KEYS: readonly string[] = [
 // (grid/list segmented control), and `sort`/`dir`. `site` is a multi-site
 // deep-link shortcut; the rest are page filters / view-mode toggles operators
 // can capture into a saved view. Sort is shared by the grid dropdown and the
-// list column headers — both write to the same `?sort=&dir=` URL state.
-const RACK_FILTER_KEYS: readonly string[] = ["building", "site", "zone", "issues", "display"];
+// list column headers - both write to the same `?sort=&dir=` URL state.
+const TELEMETRY_FILTER_KEYS: readonly string[] = Object.keys(TELEMETRY_FILTER_BOUNDS).flatMap((key) => [
+  `${key}_min`,
+  `${key}_max`,
+]);
+
+const RACK_FILTER_KEYS: readonly string[] = ["building", "site", "zone", "issues", "display", ...TELEMETRY_FILTER_KEYS];
+const BUILDING_FILTER_KEYS: readonly string[] = ["site", "issues", ...TELEMETRY_FILTER_KEYS];
+const SITE_FILTER_KEYS: readonly string[] = ["issues", ...TELEMETRY_FILTER_KEYS];
 
 const SORT_KEYS: readonly string[] = ["sort", "dir"];
 
@@ -50,8 +58,8 @@ const SORT_KEYS: readonly string[] = ["sort", "dir"];
 const FILTER_AND_SORT_KEYS_BY_TAB: Record<FleetTabId, ReadonlySet<string>> = {
   miners: new Set([...MINER_FILTER_KEYS, ...SORT_KEYS]),
   racks: new Set([...RACK_FILTER_KEYS, ...SORT_KEYS]),
-  buildings: new Set<string>(),
-  sites: new Set<string>(),
+  buildings: new Set(BUILDING_FILTER_KEYS),
+  sites: new Set(SITE_FILTER_KEYS),
 };
 
 /** Tabs that expose a save-worthy filter/sort surface. Used to gate "+ New view". */

--- a/client/src/protoFleet/features/fleetManagement/views/viewSummary.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/viewSummary.test.ts
@@ -46,8 +46,14 @@ describe("summarizeFilters", () => {
     expect(result).toContainEqual({ key: "firmware", label: "Firmware", values: ["1.0.5"] });
   });
 
-  it("looks up group and rack ids against available device sets", () => {
-    const result = summarizeFilters(new URLSearchParams("group=1&group=2&rack=10"), "miners", ctx);
+  it("looks up site, building, group, and rack ids against available labels", () => {
+    const result = summarizeFilters(
+      new URLSearchParams("site=200&building=100&group=1&group=2&rack=10"),
+      "miners",
+      ctx,
+    );
+    expect(result).toContainEqual({ key: "site", label: "Sites", values: ["Houston"] });
+    expect(result).toContainEqual({ key: "building", label: "Buildings", values: ["DC1"] });
     expect(result).toContainEqual({ key: "group", label: "Groups", values: ["Site A", "Site B"] });
     expect(result).toContainEqual({ key: "rack", label: "Racks", values: ["R1"] });
   });
@@ -67,13 +73,31 @@ describe("summarizeFilters", () => {
     expect(result).toContainEqual({ key: "site", label: "Sites", values: ["Houston"] });
   });
 
+  it("renders issue and telemetry filters on the racks tab", () => {
+    const result = summarizeFilters(new URLSearchParams("issues=psu&hashrate_min=10"), "racks", ctx);
+    expect(result).toContainEqual({ key: "issues", label: "Issues", values: ["PSU"] });
+    expect(result).toContainEqual({ key: "hashrate", label: "Hashrate", values: ["≥ 10 TH/s"] });
+  });
+
   it("ignores miner-only filter keys on the racks tab", () => {
     expect(summarizeFilters(new URLSearchParams("status=offline&model=S21"), "racks", ctx)).toEqual([]);
   });
 
-  it("returns empty for tabs without a filter surface (buildings, sites)", () => {
-    expect(summarizeFilters(new URLSearchParams("anything=goes"), "buildings", ctx)).toEqual([]);
-    expect(summarizeFilters(new URLSearchParams("anything=goes"), "sites", ctx)).toEqual([]);
+  it("renders site, issue, and telemetry filters on the buildings tab", () => {
+    const result = summarizeFilters(
+      new URLSearchParams("site=200&site=null&issues=fans&temperature_max=85"),
+      "buildings",
+      ctx,
+    );
+    expect(result).toContainEqual({ key: "issues", label: "Issues", values: ["Fans"] });
+    expect(result).toContainEqual({ key: "site", label: "Sites", values: ["Houston", "Unassigned"] });
+    expect(result).toContainEqual({ key: "temperature", label: "Temperature", values: ["≤ 85 °C"] });
+  });
+
+  it("renders issue and telemetry filters on the sites tab", () => {
+    const result = summarizeFilters(new URLSearchParams("issues=psu&power_max=4.2"), "sites", ctx);
+    expect(result).toContainEqual({ key: "issues", label: "Issues", values: ["PSU"] });
+    expect(result).toContainEqual({ key: "power", label: "Power", values: ["≤ 4.2 kW"] });
   });
 });
 
@@ -103,9 +127,7 @@ describe("summarizeSort", () => {
     });
   });
 
-  it("ignores sort params on tabs that don't own sort", () => {
-    // Cross-tab navigation can leave `?sort=` behind; tabs without a sort
-    // UI must not surface it as a saveable setting.
+  it("ignores inert sort params on sites and buildings", () => {
     expect(summarizeSort(new URLSearchParams("sort=name&dir=asc"), "buildings")).toBeUndefined();
     expect(summarizeSort(new URLSearchParams("sort=name&dir=asc"), "sites")).toBeUndefined();
   });

--- a/client/src/protoFleet/features/fleetManagement/views/viewSummary.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/viewSummary.ts
@@ -1,4 +1,5 @@
 import type { DeviceSet } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { UNASSIGNED_URL_VALUE } from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
 import {
   TELEMETRY_FILTER_BOUNDS,
   type TelemetryFilterKey,
@@ -79,12 +80,12 @@ const lookupDeviceSetLabels = (ids: string[], deviceSets: DeviceSet[]): string[]
   deviceSets.forEach((set) => {
     labelById.set(String(set.id), set.label);
   });
-  return ids.map((id) => labelById.get(id) ?? `#${id}`);
+  return ids.map((id) => (id === UNASSIGNED_URL_VALUE ? "Unassigned" : (labelById.get(id) ?? `#${id}`)));
 };
 
 const lookupNamedLabels = (ids: string[], items: FilterLabelSource[]): string[] => {
   const labelById = new Map<string, string>(items.map((item) => [item.id, item.label]));
-  return ids.map((id) => labelById.get(id) ?? `#${id}`);
+  return ids.map((id) => (id === UNASSIGNED_URL_VALUE ? "Unassigned" : (labelById.get(id) ?? `#${id}`)));
 };
 
 const dedupedSorted = (params: URLSearchParams, key: string): string[] =>
@@ -92,49 +93,13 @@ const dedupedSorted = (params: URLSearchParams, key: string): string[] =>
     .filter((value) => value !== "")
     .sort();
 
-const summarizeMinerFilters = (params: URLSearchParams, context: FilterSummaryContext): FilterSummaryEntry[] => {
-  const entries: FilterSummaryEntry[] = [];
-
-  const statusValues = dedupedSorted(params, "status").map((value) => STATUS_LABELS[value] ?? value);
-  if (statusValues.length) entries.push({ key: "status", label: "Status", values: statusValues });
-
+const summarizeIssueFilters = (params: URLSearchParams): FilterSummaryEntry[] => {
   const issueValues = dedupedSorted(params, "issues").map((value) => ISSUE_LABELS[value] ?? value);
-  if (issueValues.length) entries.push({ key: "issues", label: "Issues", values: issueValues });
+  return issueValues.length ? [{ key: "issues", label: "Issues", values: issueValues }] : [];
+};
 
-  const modelValues = dedupedSorted(params, "model");
-  if (modelValues.length) entries.push({ key: "model", label: "Model", values: modelValues });
-
-  const groupValues = dedupedSorted(params, "group");
-  if (groupValues.length) {
-    entries.push({
-      key: "group",
-      label: "Groups",
-      values: lookupDeviceSetLabels(groupValues, context.availableGroups),
-    });
-  }
-
-  const rackValues = dedupedSorted(params, "rack");
-  if (rackValues.length) {
-    entries.push({ key: "rack", label: "Racks", values: lookupDeviceSetLabels(rackValues, context.availableRacks) });
-  }
-
-  const buildingValues = dedupedSorted(params, "building");
-  if (buildingValues.length) {
-    entries.push({
-      key: "building",
-      label: "Buildings",
-      values: lookupNamedLabels(buildingValues, context.availableBuildings),
-    });
-  }
-
-  const firmwareValues = dedupedSorted(params, "firmware");
-  if (firmwareValues.length) entries.push({ key: "firmware", label: "Firmware", values: firmwareValues });
-
-  const zoneValues = dedupedSorted(params, "zone");
-  if (zoneValues.length) entries.push({ key: "zone", label: "Zone", values: zoneValues });
-
-  // Numeric range filters: render as a single value, e.g. "50 TH/s - 200 TH/s"
-  // or "≥ 50 TH/s". Mirrors the chip text so the summary reads the same way.
+const summarizeTelemetryFilters = (params: URLSearchParams): FilterSummaryEntry[] => {
+  const entries: FilterSummaryEntry[] = [];
   (Object.keys(TELEMETRY_FILTER_BOUNDS) as TelemetryFilterKey[]).forEach((key) => {
     const bounds = TELEMETRY_FILTER_BOUNDS[key];
     const minRaw = params.get(`${key}_min`);
@@ -152,6 +117,55 @@ const summarizeMinerFilters = (params: URLSearchParams, context: FilterSummaryCo
     if (!summary) return;
     entries.push({ key, label: bounds.label, values: [summary] });
   });
+  return entries;
+};
+
+const summarizeMinerFilters = (params: URLSearchParams, context: FilterSummaryContext): FilterSummaryEntry[] => {
+  const entries: FilterSummaryEntry[] = [];
+
+  const statusValues = dedupedSorted(params, "status").map((value) => STATUS_LABELS[value] ?? value);
+  if (statusValues.length) entries.push({ key: "status", label: "Status", values: statusValues });
+
+  entries.push(...summarizeIssueFilters(params));
+
+  const modelValues = dedupedSorted(params, "model");
+  if (modelValues.length) entries.push({ key: "model", label: "Model", values: modelValues });
+
+  const firmwareValues = dedupedSorted(params, "firmware");
+  if (firmwareValues.length) entries.push({ key: "firmware", label: "Firmware", values: firmwareValues });
+
+  const siteValues = dedupedSorted(params, "site");
+  if (siteValues.length) {
+    entries.push({ key: "site", label: "Sites", values: lookupNamedLabels(siteValues, context.availableSites) });
+  }
+
+  const buildingValues = dedupedSorted(params, "building");
+  if (buildingValues.length) {
+    entries.push({
+      key: "building",
+      label: "Buildings",
+      values: lookupNamedLabels(buildingValues, context.availableBuildings),
+    });
+  }
+
+  const rackValues = dedupedSorted(params, "rack");
+  if (rackValues.length) {
+    entries.push({ key: "rack", label: "Racks", values: lookupDeviceSetLabels(rackValues, context.availableRacks) });
+  }
+
+  const zoneValues = dedupedSorted(params, "zone");
+  if (zoneValues.length) entries.push({ key: "zone", label: "Zone", values: zoneValues });
+
+  const groupValues = dedupedSorted(params, "group");
+  if (groupValues.length) {
+    entries.push({
+      key: "group",
+      label: "Groups",
+      values: lookupDeviceSetLabels(groupValues, context.availableGroups),
+    });
+  }
+
+  entries.push(...summarizeTelemetryFilters(params));
 
   // Subnet (CIDR list) filter — single chip-style value, "N subnets" when more
   // than one entry, the literal CIDR when exactly one.
@@ -170,6 +184,13 @@ const summarizeMinerFilters = (params: URLSearchParams, context: FilterSummaryCo
 const summarizeRackFilters = (params: URLSearchParams, context: FilterSummaryContext): FilterSummaryEntry[] => {
   const entries: FilterSummaryEntry[] = [];
 
+  entries.push(...summarizeIssueFilters(params));
+
+  const siteValues = dedupedSorted(params, "site");
+  if (siteValues.length) {
+    entries.push({ key: "site", label: "Sites", values: lookupNamedLabels(siteValues, context.availableSites) });
+  }
+
   const buildingValues = dedupedSorted(params, "building");
   if (buildingValues.length) {
     entries.push({
@@ -179,16 +200,34 @@ const summarizeRackFilters = (params: URLSearchParams, context: FilterSummaryCon
     });
   }
 
+  const zoneValues = dedupedSorted(params, "zone");
+  if (zoneValues.length) entries.push({ key: "zone", label: "Zone", values: zoneValues });
+
+  entries.push(...summarizeTelemetryFilters(params));
+
+  return entries;
+};
+
+const summarizeBuildingFilters = (params: URLSearchParams, context: FilterSummaryContext): FilterSummaryEntry[] => {
+  const entries: FilterSummaryEntry[] = [];
+
+  entries.push(...summarizeIssueFilters(params));
+
   const siteValues = dedupedSorted(params, "site");
   if (siteValues.length) {
     entries.push({ key: "site", label: "Sites", values: lookupNamedLabels(siteValues, context.availableSites) });
   }
 
-  const zoneValues = dedupedSorted(params, "zone");
-  if (zoneValues.length) entries.push({ key: "zone", label: "Zone", values: zoneValues });
+  entries.push(...summarizeTelemetryFilters(params));
 
-  const issueValues = dedupedSorted(params, "issues").map((value) => ISSUE_LABELS[value] ?? value);
-  if (issueValues.length) entries.push({ key: "issues", label: "Issues", values: issueValues });
+  return entries;
+};
+
+const summarizeSiteFilters = (params: URLSearchParams): FilterSummaryEntry[] => {
+  const entries: FilterSummaryEntry[] = [];
+
+  entries.push(...summarizeIssueFilters(params));
+  entries.push(...summarizeTelemetryFilters(params));
 
   return entries;
 };
@@ -204,17 +243,15 @@ export const summarizeFilters = (
     case "racks":
       return summarizeRackFilters(params, context);
     case "buildings":
+      return summarizeBuildingFilters(params, context);
     case "sites":
-      // No filter surface in URL yet on these tabs.
-      return [];
+      return summarizeSiteFilters(params);
   }
 };
 
 /**
- * Tabs that own `sort`/`dir` URL params. Other tabs may carry those keys as
- * cross-navigation residue; surfacing them as a "sort summary" would offer
- * an "Include sort" toggle that silently drops on save because the tab's
- * canonicalization whitelist excludes the keys.
+ * Tabs that own `sort`/`dir` URL params and persist those keys into saved
+ * views. Tabs outside this set may carry cross-navigation residue.
  */
 const TABS_WITH_SORT: ReadonlySet<FleetTabId> = new Set(["miners", "racks"]);
 

--- a/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode, useCallback, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import type { DeviceSet } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
@@ -11,6 +11,17 @@ import {
 } from "@/protoFleet/components/DeviceSetList";
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
 import NullState from "@/protoFleet/components/NullState";
+import {
+  FILTER_URL_PARAM_KEYS,
+  fleetListTelemetryRangesFromURL,
+  parseUrlToActiveFilters,
+  setTelemetryNumericFilterURLParams,
+} from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
+import {
+  TELEMETRY_FILTER_BOUNDS,
+  TELEMETRY_FILTER_KEYS,
+  type TelemetryFilterKey,
+} from "@/protoFleet/features/fleetManagement/utils/telemetryFilterBounds";
 import GroupModal from "@/protoFleet/features/groupManagement/components/GroupModal";
 import GroupNameCell from "@/protoFleet/features/groupManagement/components/GroupsTable/GroupNameCell";
 import { useDeviceSetListState } from "@/protoFleet/hooks/useDeviceSetListState";
@@ -20,20 +31,48 @@ import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { Alert, Groups } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
-import FilterChipsBar from "@/shared/components/List/Filters/FilterChipsBar";
+import FilterChipsBar, { type FilterChipsBarNumericFilter } from "@/shared/components/List/Filters/FilterChipsBar";
 import ProgressCircular from "@/shared/components/ProgressCircular";
+import type { NumericRangeValue } from "@/shared/utils/filterValidation";
 
 const GROUPS_PAGE_SIZE = 50;
+
+const TELEMETRY_FILTER_CHIPS: FilterChipsBarNumericFilter[] = TELEMETRY_FILTER_KEYS.map((key) => ({
+  key,
+  title: TELEMETRY_FILTER_BOUNDS[key].label,
+  bounds: TELEMETRY_FILTER_BOUNDS[key],
+}));
 
 const GroupsPage = () => {
   const navigate = useNavigate();
   const activeSite = useRouteSiteScope() ?? DEFAULT_ACTIVE_SITE;
+  const [searchParams, setSearchParams] = useSearchParams();
   const { listGroups } = useDeviceSets();
   const [showGroupModal, setShowGroupModal] = useState(false);
   const [editGroup, setEditGroup] = useState<DeviceSet | null>(null);
-  const [selectedIssues, setSelectedIssues] = useState<string[]>([]);
+  const selectedIssues = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          searchParams
+            .getAll("issues")
+            .map((v) => v.trim())
+            .filter(Boolean),
+        ),
+      ),
+    [searchParams],
+  );
+  const telemetryRanges = useMemo(() => fleetListTelemetryRangesFromURL(searchParams), [searchParams]);
+  const selectedNumericValues = useMemo(() => parseUrlToActiveFilters(searchParams).numericFilters, [searchParams]);
+  const telemetryRangesRef = useRef(telemetryRanges);
+  useEffect(() => {
+    telemetryRangesRef.current = telemetryRanges;
+  }, [telemetryRanges]);
+  const getTelemetryRanges = useCallback(() => telemetryRangesRef.current, []);
 
   const { selectedIssuesRef, getErrorComponentTypes } = useIssueFilter();
+  // eslint-disable-next-line react-hooks/refs -- intentional render-time sync so the initial list fetch reads URL-restored filters
+  selectedIssuesRef.current = selectedIssues;
 
   const {
     deviceSets: groups,
@@ -49,16 +88,51 @@ const GroupsPage = () => {
     handleNextPage,
     handlePrevPage,
     resetAndFetch,
-  } = useDeviceSetListState(listGroups, GROUPS_PAGE_SIZE, getErrorComponentTypes);
+  } = useDeviceSetListState(
+    listGroups,
+    GROUPS_PAGE_SIZE,
+    getErrorComponentTypes,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    getTelemetryRanges,
+  );
 
   const handleFilterChange = useCallback(
     (key: string, values: string[]) => {
       if (key !== "issues") return;
-      setSelectedIssues(values);
-      selectedIssuesRef.current = values;
-      resetAndFetch();
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("issues");
+          values.forEach((value) => {
+            const trimmed = value.trim();
+            if (trimmed) next.append("issues", trimmed);
+          });
+          return next;
+        },
+        { replace: true },
+      );
     },
-    [resetAndFetch, selectedIssuesRef],
+    [setSearchParams],
+  );
+
+  const handleNumericFilterChange = useCallback(
+    (key: string, value: NumericRangeValue) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          setTelemetryNumericFilterURLParams(next, key as TelemetryFilterKey, value);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
   );
 
   const filterChipsBarFilters = useMemo(
@@ -69,18 +143,36 @@ const GroupsPage = () => {
         pluralTitle: "issues",
         options: issueOptions,
         selectedValues: selectedIssues,
+        showGroupDivider: true,
       },
     ],
     [selectedIssues],
   );
 
-  const hasActiveFilters = selectedIssues.length > 0;
+  const hasActiveFilters = selectedIssues.length > 0 || telemetryRanges.length > 0;
+
+  const filterFetchKey = useMemo(
+    () => JSON.stringify([selectedIssues, telemetryRanges]),
+    [selectedIssues, telemetryRanges],
+  );
+  const prevFilterFetchKey = useRef<string | null>(null);
+  useEffect(() => {
+    if (prevFilterFetchKey.current !== null && prevFilterFetchKey.current !== filterFetchKey) {
+      resetAndFetch();
+    }
+    prevFilterFetchKey.current = filterFetchKey;
+  }, [filterFetchKey, resetAndFetch]);
 
   const handleClearFilters = useCallback(() => {
-    setSelectedIssues([]);
-    selectedIssuesRef.current = [];
-    resetAndFetch();
-  }, [resetAndFetch, selectedIssuesRef]);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        FILTER_URL_PARAM_KEYS.forEach((key) => next.delete(key));
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
 
   const emptyStateRow: ReactNode = useMemo(() => {
     if (isLoading || totalCount > 0) return undefined;
@@ -140,7 +232,7 @@ const GroupsPage = () => {
     );
   }
 
-  const hasGroups = groups.length > 0 || hasEverLoaded;
+  const hasGroups = groups.length > 0 || hasEverLoaded || hasActiveFilters;
 
   return (
     <>
@@ -163,6 +255,9 @@ const GroupsPage = () => {
               <FilterChipsBar
                 filters={filterChipsBarFilters}
                 onChange={handleFilterChange}
+                numericFilters={TELEMETRY_FILTER_CHIPS}
+                selectedNumericValues={selectedNumericValues}
+                onNumericChange={handleNumericFilterChange}
                 onClearAll={handleClearFilters}
               />
               <Button

--- a/client/src/protoFleet/hooks/useDeviceSetListState.ts
+++ b/client/src/protoFleet/hooks/useDeviceSetListState.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { create } from "@bufbuild/protobuf";
 
+import type { FleetListTelemetryRangeFilter } from "@/protoFleet/api/generated/common/v1/fleet_list_stats_pb";
 import {
   SortDirection as ProtoSortDirection,
   type SortConfig,
@@ -52,6 +53,10 @@ export function useDeviceSetListState(
   getBuildingIds?: () => bigint[],
   getSiteFilter?: () => DeviceSetSiteFilter,
   initialSort?: () => { field: DeviceSetColumn; direction: SortDirection },
+  getSiteIds?: () => bigint[],
+  getIncludeUnassigned?: () => boolean,
+  getIncludeNoBuilding?: () => boolean,
+  getTelemetryRanges?: () => FleetListTelemetryRangeFilter[],
 ) {
   const { getDeviceSetStats } = useDeviceSets();
   const [deviceSets, setDeviceSets] = useState<DeviceSet[]>([]);
@@ -112,7 +117,10 @@ export function useDeviceSetListState(
       const requestId = ++listRequestId.current;
       setIsLoading(true);
       setError(null);
-      const siteFilter = getSiteFilter?.() ?? { siteIds: [], includeUnassigned: false };
+      const siteFilter = getSiteFilter?.() ?? {
+        siteIds: getSiteIds?.() ?? [],
+        includeUnassigned: getIncludeUnassigned?.() ?? false,
+      };
       if (siteFilter.matchNone) {
         setHasCompletedInitialFetch(true);
         setDeviceSets([]);
@@ -130,8 +138,10 @@ export function useDeviceSetListState(
         errorComponentTypes: getErrorComponentTypes?.() ?? [],
         zones: getZones?.() ?? [],
         buildingIds: getBuildingIds?.() ?? [],
+        includeNoBuilding: getIncludeNoBuilding?.() ?? false,
         siteIds: siteFilter.siteIds,
         includeUnassigned: siteFilter.includeUnassigned,
+        telemetryRanges: getTelemetryRanges?.() ?? [],
         onSuccess: (items, nextPageToken, total) => {
           if (requestId !== listRequestId.current) return;
           if (total > 0) setHasEverLoaded(true);
@@ -159,7 +169,19 @@ export function useDeviceSetListState(
         },
       });
     },
-    [listFn, pageSize, fetchStats, getErrorComponentTypes, getZones, getBuildingIds, getSiteFilter],
+    [
+      listFn,
+      pageSize,
+      fetchStats,
+      getErrorComponentTypes,
+      getZones,
+      getBuildingIds,
+      getSiteFilter,
+      getSiteIds,
+      getIncludeUnassigned,
+      getIncludeNoBuilding,
+      getTelemetryRanges,
+    ],
   );
 
   const resetAndFetch = useCallback(() => {

--- a/client/src/shared/components/List/Filters/FilterChipsBar.tsx
+++ b/client/src/shared/components/List/Filters/FilterChipsBar.tsx
@@ -2,8 +2,12 @@ import { type ReactNode, useCallback, useState } from "react";
 
 import { type DropdownOption } from "./DropdownFilter";
 import FilterChip from "./FilterChip";
+import ModalFilterChip from "./ModalFilterChip";
 import NestedDropdownFilter, { type FilterCategory } from "./NestedDropdownFilter";
+import NumericRangeModal from "./NumericRangeModal";
 import { Plus } from "@/shared/assets/icons";
+import { formatNumericRangeCondition } from "@/shared/utils/filterChipFormatting";
+import type { NumericRangeBounds, NumericRangeValue } from "@/shared/utils/filterValidation";
 
 export type FilterChipsBarFilter = {
   key: string;
@@ -11,11 +15,22 @@ export type FilterChipsBarFilter = {
   pluralTitle?: string;
   options: DropdownOption[];
   selectedValues: string[];
+  showGroupDivider?: boolean;
+};
+
+export type FilterChipsBarNumericFilter = {
+  key: string;
+  title: string;
+  bounds: NumericRangeBounds;
+  showGroupDivider?: boolean;
 };
 
 type FilterChipsBarProps = {
   filters: FilterChipsBarFilter[];
   onChange: (key: string, selectedValues: string[]) => void;
+  numericFilters?: FilterChipsBarNumericFilter[];
+  selectedNumericValues?: Record<string, NumericRangeValue>;
+  onNumericChange?: (key: string, value: NumericRangeValue) => void;
   onClearAll?: () => void;
   triggerLabel?: string;
   triggerPrefixIcon?: ReactNode;
@@ -25,6 +40,9 @@ type FilterChipsBarProps = {
 const FilterChipsBar = ({
   filters,
   onChange,
+  numericFilters = [],
+  selectedNumericValues = {},
+  onNumericChange,
   onClearAll,
   triggerLabel = "Add Filter",
   triggerPrefixIcon = <Plus width="w-3" />,
@@ -33,21 +51,40 @@ const FilterChipsBar = ({
   // Tracking the open chip keeps it mounted while the user toggles its last selection off
   // — otherwise the chip unmounts mid-interaction and takes its popover with it.
   const [openChipKey, setOpenChipKey] = useState<string | null>(null);
+  const [editingNumericKey, setEditingNumericKey] = useState<string | null>(null);
 
   const fallbackClearAll = useCallback(() => {
     filters.forEach((f) => {
       if (f.selectedValues.length > 0) onChange(f.key, []);
     });
+    numericFilters.forEach((f) => {
+      const value = selectedNumericValues[f.key];
+      if (value?.min !== undefined || value?.max !== undefined) onNumericChange?.(f.key, {});
+    });
     setOpenChipKey(null);
-  }, [filters, onChange]);
+    setEditingNumericKey(null);
+  }, [filters, numericFilters, onChange, onNumericChange, selectedNumericValues]);
 
-  const categories: FilterCategory[] = filters.map((f) => ({
-    kind: "checkbox",
-    key: f.key,
-    label: f.title,
-    options: f.options,
-    selectedValues: f.selectedValues,
-  }));
+  const categories: FilterCategory[] = [
+    ...filters.map((f) => ({
+      kind: "checkbox" as const,
+      key: f.key,
+      label: f.title,
+      options: f.options,
+      selectedValues: f.selectedValues,
+      showGroupDivider: f.showGroupDivider,
+    })),
+    ...numericFilters.map((f) => ({
+      kind: "numericRange" as const,
+      key: f.key,
+      label: f.title,
+      bounds: f.bounds,
+      value: selectedNumericValues[f.key] ?? {},
+      showGroupDivider: f.showGroupDivider,
+    })),
+  ];
+
+  const editingNumeric = editingNumericKey ? numericFilters.find((f) => f.key === editingNumericKey) : undefined;
 
   return (
     <>
@@ -74,19 +111,40 @@ const FilterChipsBar = ({
           />
         ) : null,
       )}
+      {numericFilters.map((f) => {
+        const value = selectedNumericValues[f.key];
+        const condition = value ? formatNumericRangeCondition(value, f.bounds.unit) : "";
+        return condition ? (
+          <ModalFilterChip
+            key={f.key}
+            filterValue={f.key}
+            typeLabel={f.title}
+            condition={condition}
+            onEdit={() => setEditingNumericKey(f.key)}
+            onClear={() => onNumericChange?.(f.key, {})}
+          />
+        ) : null;
+      })}
       <NestedDropdownFilter
         testId={triggerTestId}
         label={triggerLabel}
         prefixIcon={triggerPrefixIcon}
         categories={categories}
         onCheckboxChange={onChange}
-        onRequestEdit={() => {
-          // FilterChipsBar is checkbox-only; the trigger drilldown closes via
-          // onCheckboxChange. onRequestEdit is reachable in theory but no path
-          // here exposes a numeric/textareaList category, so a no-op is fine.
-        }}
+        onRequestEdit={setEditingNumericKey}
         onClearAll={onClearAll ?? fallbackClearAll}
       />
+      {editingNumeric ? (
+        <NumericRangeModal
+          open
+          categoryKey={editingNumeric.key}
+          label={editingNumeric.title}
+          bounds={editingNumeric.bounds}
+          initialValue={selectedNumericValues[editingNumeric.key] ?? {}}
+          onApply={(value) => onNumericChange?.(editingNumeric.key, value)}
+          onClose={() => setEditingNumericKey(null)}
+        />
+      ) : null}
     </>
   );
 };

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -218,7 +218,7 @@ func start(config *Config) error {
 	userStore := sqlstores.NewSQLUserStore(conn)
 	poolStore := sqlstores.NewSQLPoolStore(conn, encryptSvc)
 	deviceStore := sqlstores.NewSQLDeviceStore(conn)
-	collectionStore := sqlstores.NewSQLCollectionStore(conn)
+	collectionStore := sqlstores.NewSQLCollectionStore(conn, config.TimescaleDB.MaxAge)
 	activityStore := sqlstores.NewSQLActivityStore(conn)
 	notificationHistoryStore := sqlstores.NewSQLNotificationHistoryStore(conn)
 

--- a/server/internal/domain/stores/sqlstores/collection.go
+++ b/server/internal/domain/stores/sqlstores/collection.go
@@ -24,12 +24,18 @@ var _ interfaces.CollectionStore = &SQLCollectionStore{}
 // SQLCollectionStore implements CollectionStore using PostgreSQL via sqlc.
 type SQLCollectionStore struct {
 	SQLConnectionManager
+	collectionTelemetryMaxAge time.Duration
 }
 
 // NewSQLCollectionStore creates a new SQLCollectionStore.
-func NewSQLCollectionStore(conn *sql.DB) *SQLCollectionStore {
+func NewSQLCollectionStore(conn *sql.DB, telemetryMaxAge ...time.Duration) *SQLCollectionStore {
+	maxAge := defaultCollectionTelemetryMaxAge
+	if len(telemetryMaxAge) > 0 {
+		maxAge = telemetryMaxAge[0]
+	}
 	return &SQLCollectionStore{
-		SQLConnectionManager: NewSQLConnectionManager(conn),
+		SQLConnectionManager:      NewSQLConnectionManager(conn),
+		collectionTelemetryMaxAge: maxAge,
 	}
 }
 
@@ -466,14 +472,14 @@ func (s *SQLCollectionStore) ListCollections(ctx context.Context, orgID int64, c
 
 	// Count total
 	var totalCount int32
-	countQuery, countArgs := buildCollectionCountQuery(orgID, collectionType, filter)
+	countQuery, countArgs := buildCollectionCountQueryWithTelemetryMaxAge(orgID, collectionType, filter, s.collectionTelemetryMaxAge)
 	if err := s.conn.QueryRowContext(ctx, countQuery, countArgs...).Scan(&totalCount); err != nil {
 		return nil, "", 0, fleeterror.NewInternalErrorf("failed to count collections: %v", err)
 	}
 
 	// Build list query
 	fetchLimit := pageSize + 1
-	query, args := buildCollectionListQuery(orgID, collectionType, cursor, sortField, sortDir, fetchLimit, filter)
+	query, args := buildCollectionListQueryWithTelemetryMaxAge(orgID, collectionType, cursor, sortField, sortDir, fetchLimit, filter, s.collectionTelemetryMaxAge)
 
 	sqlRows, err := s.conn.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/server/internal/domain/stores/sqlstores/collection_sort.go
+++ b/server/internal/domain/stores/sqlstores/collection_sort.go
@@ -3,6 +3,7 @@ package sqlstores
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/lib/pq"
 
@@ -11,13 +12,14 @@ import (
 )
 
 const (
-	collectionSortFieldName        = "name"
-	collectionSortFieldDeviceCount = "device_count"
-	collectionSortFieldIssueCount  = "issue_count"
-	collectionSortFieldZone        = "zone"
-	collectionSortDirASC           = "ASC"
-	collectionSortDirDESC          = "DESC"
-	collectionIssueCountExpr       = "MAX(COALESCE(issue_counts.issue_count, 0))::int"
+	collectionSortFieldName          = "name"
+	collectionSortFieldDeviceCount   = "device_count"
+	collectionSortFieldIssueCount    = "issue_count"
+	collectionSortFieldZone          = "zone"
+	collectionSortDirASC             = "ASC"
+	collectionSortDirDESC            = "DESC"
+	collectionIssueCountExpr         = "MAX(COALESCE(issue_counts.issue_count, 0))::int"
+	defaultCollectionTelemetryMaxAge = 24 * time.Hour
 )
 
 var collectionIssueCountJoin = fmt.Sprintf(`LEFT JOIN (
@@ -42,7 +44,8 @@ var collectionIssueCountJoin = fmt.Sprintf(`LEFT JOIN (
 ) issue_counts ON issue_counts.device_set_id = dc.id
 `, actionablePairingStatusesExpr("dp_issue"), actionableErrorSeveritiesExpr("e"), actionableErrorComponentTypesExpr("e"))
 
-var collectionTelemetryStatsJoin = fmt.Sprintf(`LEFT JOIN (
+func collectionTelemetryStatsJoin(maxAgeArg int) string {
+	return fmt.Sprintf(`LEFT JOIN (
 	SELECT
 		dcm_stats.device_set_id,
 		COUNT(lm.hash_rate_hs) FILTER (WHERE isfinite(lm.hash_rate_hs) AND lm.hash_rate_hs >= 0)::int AS hashrate_reporting_count,
@@ -67,14 +70,15 @@ var collectionTelemetryStatsJoin = fmt.Sprintf(`LEFT JOIN (
 			dm.temp_c
 		FROM device_metrics dm
 		WHERE dm.device_identifier = d_stats.device_identifier
-			AND dm.time > NOW() - INTERVAL '`+telemetryFreshnessWindow+`'
+			AND dm.time > NOW() - ($%d::double precision * INTERVAL '1 second')
 		ORDER BY dm.time DESC
 		LIMIT 1
 	) lm ON TRUE
 	WHERE dcm_stats.org_id = $1
 	GROUP BY dcm_stats.device_set_id
 ) telemetry_stats ON telemetry_stats.device_set_id = dc.id
-`, actionablePairingStatusesExpr("dp_stats"))
+`, actionablePairingStatusesExpr("dp_stats"), maxAgeArg)
+}
 
 // resolveCollectionSort converts a SortConfig into a canonical field name and SQL direction.
 // Defaults to name ASC when unspecified.
@@ -109,6 +113,10 @@ func resolveCollectionSort(sort *stores.SortConfig) (field, dir string) {
 
 // buildCollectionCountQuery returns the SQL and args for counting collections.
 func buildCollectionCountQuery(orgID int64, collectionType pb.CollectionType, filter *stores.DeviceSetFilter) (string, []any) {
+	return buildCollectionCountQueryWithTelemetryMaxAge(orgID, collectionType, filter, defaultCollectionTelemetryMaxAge)
+}
+
+func buildCollectionCountQueryWithTelemetryMaxAge(orgID int64, collectionType pb.CollectionType, filter *stores.DeviceSetFilter, telemetryMaxAge time.Duration) (string, []any) {
 	var sb strings.Builder
 	args := []any{orgID}
 	argNum := 2
@@ -133,7 +141,9 @@ func buildCollectionCountQuery(orgID int64, collectionType pb.CollectionType, fi
 	}
 	if needsTelemetryFilter {
 		sb.WriteString("\n")
-		sb.WriteString(collectionTelemetryStatsJoin)
+		sb.WriteString(collectionTelemetryStatsJoin(argNum))
+		args = append(args, telemetryMaxAge.Seconds())
+		argNum++
 	}
 
 	sb.WriteString(" WHERE dc.org_id = $1 AND dc.deleted_at IS NULL")
@@ -286,6 +296,10 @@ func collectionTelemetryRangeColumns(field stores.NumericFilterField) (countColu
 // buildCollectionListQuery generates a dynamic SQL query for listing collections
 // with sort and cursor-based keyset pagination.
 func buildCollectionListQuery(orgID int64, collectionType pb.CollectionType, cursor *collectionCursor, sortField, sortDir string, limit int32, filter *stores.DeviceSetFilter) (string, []any) {
+	return buildCollectionListQueryWithTelemetryMaxAge(orgID, collectionType, cursor, sortField, sortDir, limit, filter, defaultCollectionTelemetryMaxAge)
+}
+
+func buildCollectionListQueryWithTelemetryMaxAge(orgID int64, collectionType pb.CollectionType, cursor *collectionCursor, sortField, sortDir string, limit int32, filter *stores.DeviceSetFilter, telemetryMaxAge time.Duration) (string, []any) {
 	var sb strings.Builder
 	args := []any{orgID}
 	argNum := 2
@@ -311,7 +325,9 @@ LEFT JOIN building b ON b.id = dcr.building_id AND b.org_id = dc.org_id AND b.de
 		sb.WriteString(collectionIssueCountJoin)
 	}
 	if filter != nil && len(filter.TelemetryRanges) > 0 {
-		sb.WriteString(collectionTelemetryStatsJoin)
+		sb.WriteString(collectionTelemetryStatsJoin(argNum))
+		args = append(args, telemetryMaxAge.Seconds())
+		argNum++
 	}
 	sb.WriteString(`
 WHERE dc.org_id = $1 AND dc.deleted_at IS NULL`)

--- a/server/internal/domain/stores/sqlstores/collection_sort_test.go
+++ b/server/internal/domain/stores/sqlstores/collection_sort_test.go
@@ -2,6 +2,7 @@ package sqlstores
 
 import (
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 
@@ -261,6 +262,7 @@ func TestBuildCollectionCountQuery_ErrorComponentTypes(t *testing.T) {
 func TestBuildCollectionListQuery_TelemetryRanges(t *testing.T) {
 	minTemp := 40.0
 	maxTemp := 80.0
+	telemetryMaxAge := 3*time.Hour + 15*time.Minute
 	filter := &stores.DeviceSetFilter{TelemetryRanges: []stores.NumericRange{{
 		Field:        stores.NumericFilterFieldTemperatureC,
 		Min:          &minTemp,
@@ -268,17 +270,20 @@ func TestBuildCollectionListQuery_TelemetryRanges(t *testing.T) {
 		MinInclusive: true,
 	}}}
 
-	query, args := buildCollectionListQuery(1, pb.CollectionType_COLLECTION_TYPE_GROUP, nil, "name", "ASC", 51, filter)
+	query, args := buildCollectionListQueryWithTelemetryMaxAge(1, pb.CollectionType_COLLECTION_TYPE_GROUP, nil, "name", "ASC", 51, filter, telemetryMaxAge)
 
 	assert.Contains(t, query, "telemetry_stats ON telemetry_stats.device_set_id = dc.id")
+	assert.Contains(t, query, "dm.time > NOW() - ($2::double precision * INTERVAL '1 second')")
+	assert.NotContains(t, query, "10 minutes")
 	assert.Contains(t, query, "COALESCE(telemetry_stats.temperature_reporting_count, 0) > 0")
-	assert.Contains(t, query, "telemetry_stats.min_temperature_c >= $3")
-	assert.Contains(t, query, "telemetry_stats.max_temperature_c < $4")
-	assert.Len(t, args, 5)
+	assert.Contains(t, query, "telemetry_stats.min_temperature_c >= $4")
+	assert.Contains(t, query, "telemetry_stats.max_temperature_c < $5")
+	assert.Len(t, args, 6)
 	assert.Equal(t, int64(1), args[0])
-	assert.Equal(t, minTemp, args[2])
-	assert.Equal(t, maxTemp, args[3])
-	assert.Equal(t, int32(51), args[4])
+	assert.Equal(t, telemetryMaxAge.Seconds(), args[1])
+	assert.Equal(t, minTemp, args[3])
+	assert.Equal(t, maxTemp, args[4])
+	assert.Equal(t, int32(51), args[5])
 }
 
 func TestBuildCollectionListQuery_TelemetryStatsFilterInvalidValues(t *testing.T) {
@@ -315,9 +320,11 @@ func TestBuildCollectionCountQuery_IssueAndTelemetryFiltersKeepArgumentOrder(t *
 
 	query, args := buildCollectionCountQuery(1, pb.CollectionType_COLLECTION_TYPE_UNSPECIFIED, filter)
 
-	assert.Contains(t, query, "e.component_type = ANY($2::int[])")
+	assert.Contains(t, query, "dm.time > NOW() - ($2::double precision * INTERVAL '1 second')")
+	assert.Contains(t, query, "e.component_type = ANY($3::int[])")
 	assert.Contains(t, query, "COALESCE(telemetry_stats.power_reporting_count, 0) > 0")
-	assert.Contains(t, query, "telemetry_stats.total_power_kw > $3")
-	assert.Equal(t, pq.Array(errorTypes), args[1])
-	assert.Equal(t, minPower, args[2])
+	assert.Contains(t, query, "telemetry_stats.total_power_kw > $4")
+	assert.Equal(t, defaultCollectionTelemetryMaxAge.Seconds(), args[1])
+	assert.Equal(t, pq.Array(errorTypes), args[2])
+	assert.Equal(t, minPower, args[3])
 }


### PR DESCRIPTION
Reviewable diff: +1142/-275 across 13 files (excludes generated, test, and story files).

**Summary**
This PR adds the fleet tab UI layer for Issue 491 on top of the placement/filter foundation. It brings issue and telemetry filters to Sites, Buildings, Racks, and Groups, keeps filter grouping/order consistent with Miners, and persists the relevant per-tab URL state through saved views. It is stacked on the foundation PR; the diff is relative to `issue-491-placement-refs`.

Stack: #526 (`issue-491-placement-refs`) -> this PR (#527, `issue-491-fleet-list-filters`). #526 provides the RPC contract, placement refs, and server-side list filtering; this PR intentionally focuses on URL/UI/saved-view behavior.

**How it works**
Each fleet tab parses its relevant URL params into request filters, renders matching filter controls/chips, and sends issue/telemetry/site/building/rack/zone/group filters through the client API adapters added upstream. Unassigned selections use the URL sentinel value and render as “Unassigned” in controls while preserving blank cells in list rows.

Saved views now canonicalize state per tab, so only filters, display mode, and sort params owned by that tab are saved/restored. Sites and Buildings use filtered caches when issue/telemetry filters are active, and the polling paths carry stable filter keys plus request guards so stale in-flight responses cannot overwrite newer filter results.

**Diagrams**
```mermaid
flowchart LR
  URL["URL search params"] --> Parse["filterUrlParams + telemetry bounds"]
  Parse --> Tabs["Sites / Buildings / Racks / Groups pages"]
  Tabs --> API["Client API adapters from #526"]
  API --> Server["List RPCs"]
  Tabs --> Chips["FilterChipsBar"]
  URL --> Views["Saved view canonicalization"]
  Views --> URL
```

**Areas of the code involved**
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `FleetSitesPage.tsx`, `FleetBuildingsPage.tsx`, `RacksPage.tsx`, `GroupsPage.tsx` | Adds tab-specific filters, empty states, refresh keys, and stale-response guards | Primary user-facing behavior |
| `MinerList.tsx` | Adds site/building/rack unassigned-aware filter controls to Miners | Keeps Miners filter grouping/order aligned with the new tabs |
| `filterUrlParams.ts`, `telemetryFilterBounds.ts`, `fleetVisiblePairingFilter.ts` | Encodes/decodes filter URL state and telemetry option metadata | Shared URL contract for filters and saved views |
| `savedViews.ts`, `viewSummary.ts` | Canonicalizes per-tab filter/sort/display state and summaries | Prevents inert params from being saved on tabs that do not own them |
| `FilterChipsBar.tsx` | Supports consistent grouping/dividers for the filter controls | Keeps filter layout consistent across tabs |
| `useDeviceSetListState.ts` | Guards paginated device-set requests against stale filter responses | Prevents old requests from replacing newer filtered data |

**Key technical decisions & trade-offs**
| Decision | Trade-off |
| --- | --- |
| Use URL params as the source of filter state | Deep-linkable and saveable over more local component state |
| Save only tab-owned params in custom views | Avoids misleading saved-view summaries over preserving unrelated URL residue |
| Put `Unassigned` last in filter options while serializing with sentinel values | User-friendly control order while keeping server predicates explicit |
| Add request-key guards around filtered list fetches | Slightly more state bookkeeping to avoid stale async overwrites |

**Testing & validation**
- `npm test -- --run src/protoFleet/features/fleetManagement/utils/filterUrlParams.test.ts src/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter.test.ts src/protoFleet/features/fleetManagement/views/savedViews.test.ts src/protoFleet/features/fleetManagement/views/viewSummary.test.ts src/protoFleet/features/fleetManagement/components/MinerList/minerTableColumnPreferences.test.ts src/protoFleet/features/fleetManagement/components/MinerActionsMenu/bulkRenamePreview.test.ts`
- `./client/node_modules/.bin/tsc --noEmit -p client/tsconfig.json`
- `go test ./server/internal/domain/fleetlistfilter ./server/internal/domain/stores/sqlstores -run 'TestBuildCollection(List|Count)Query|TestApply|TestAppendFilterSQL|TestBuildMinerFilterParams|TestListStats|TestFilter'`