### PR TITLE
[codex] Add reparent E2E scenarios

### DIFF
--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -284,19 +284,12 @@ jobs:
           rm -rf blob-report playwright-report test-results
           mkdir -p blob-report
 
-          if [ "$MATRIX_SPEC" = "minersReparent.spec.ts" ]; then
-            PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${MATRIX_PROJECT}-${SPEC_NAME}.zip" \
-            PWTEST_BLOB_DO_NOT_REMOVE=1 \
-            PW_UI_NO_DEPS=1 \
-            npx playwright test --project="$MATRIX_PROJECT" --reporter=blob "spec/$MATRIX_SPEC"
-          else
-            # The viewport-matched setup project (setup-$MATRIX_PROJECT):
-            # onboarding + pools + auth storageState runs automatically before
-            # the target via project `dependencies`.
-            PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${MATRIX_PROJECT}-${SPEC_NAME}.zip" \
-            PWTEST_BLOB_DO_NOT_REMOVE=1 \
-            npx playwright test --project="$MATRIX_PROJECT" --reporter=blob "spec/$MATRIX_SPEC"
-          fi
+          # The viewport-matched setup project (setup-$MATRIX_PROJECT):
+          # onboarding + pools + auth storageState runs automatically before
+          # the target via project `dependencies`.
+          PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${MATRIX_PROJECT}-${SPEC_NAME}.zip" \
+          PWTEST_BLOB_DO_NOT_REMOVE=1 \
+          npx playwright test --project="$MATRIX_PROJECT" --reporter=blob "spec/$MATRIX_SPEC"
 
           echo "Blob reports created:"
           find blob-report -maxdepth 2 -type f -print | sort || true

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -284,12 +284,19 @@ jobs:
           rm -rf blob-report playwright-report test-results
           mkdir -p blob-report
 
-          # The viewport-matched setup project (setup-$MATRIX_PROJECT):
-          # onboarding + pools + auth storageState runs automatically before
-          # the target via project `dependencies`.
-          PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${MATRIX_PROJECT}-${SPEC_NAME}.zip" \
-          PWTEST_BLOB_DO_NOT_REMOVE=1 \
-          npx playwright test --project="$MATRIX_PROJECT" --reporter=blob "spec/$MATRIX_SPEC"
+          if [ "$MATRIX_SPEC" = "minersReparent.spec.ts" ]; then
+            PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${MATRIX_PROJECT}-${SPEC_NAME}.zip" \
+            PWTEST_BLOB_DO_NOT_REMOVE=1 \
+            PW_UI_NO_DEPS=1 \
+            npx playwright test --project="$MATRIX_PROJECT" --reporter=blob "spec/$MATRIX_SPEC"
+          else
+            # The viewport-matched setup project (setup-$MATRIX_PROJECT):
+            # onboarding + pools + auth storageState runs automatically before
+            # the target via project `dependencies`.
+            PLAYWRIGHT_BLOB_OUTPUT_FILE="blob-report/${MATRIX_PROJECT}-${SPEC_NAME}.zip" \
+            PWTEST_BLOB_DO_NOT_REMOVE=1 \
+            npx playwright test --project="$MATRIX_PROJECT" --reporter=blob "spec/$MATRIX_SPEC"
+          fi
 
           echo "Blob reports created:"
           find blob-report -maxdepth 2 -type f -print | sort || true

--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -9,6 +9,7 @@ import { AuthPage } from "../pages/auth";
 import { LoginModalComponent } from "../pages/components/loginModal";
 import { EditPoolPage } from "../pages/editPool";
 import { EnergyPage } from "../pages/energy";
+import { FleetLocationsPage } from "../pages/fleetLocations";
 import { GroupsPage } from "../pages/groups";
 import { HomePage } from "../pages/home";
 import { MinersPage } from "../pages/miners";
@@ -44,6 +45,7 @@ type PageFixtures = {
   alertsPage: AlertsPage;
   editPoolPage: EditPoolPage;
   energyPage: EnergyPage;
+  fleetLocationsPage: FleetLocationsPage;
   newPoolModal: NewPoolModalPage;
   loginModal: LoginModalComponent;
   commonSteps: CommonSteps;
@@ -106,6 +108,9 @@ export const test = base.extend<PageFixtures>({
   },
   energyPage: async ({ page, isMobile }, use) => {
     await use(new EnergyPage(page, isMobile));
+  },
+  fleetLocationsPage: async ({ page, isMobile }, use) => {
+    await use(new FleetLocationsPage(page, isMobile));
   },
   newPoolModal: async ({ page, isMobile }, use) => {
     await use(new NewPoolModalPage(page, isMobile));

--- a/client/e2eTests/protoFleet/helpers/reparentHelpers.ts
+++ b/client/e2eTests/protoFleet/helpers/reparentHelpers.ts
@@ -1,0 +1,242 @@
+import { expect, type Page, type Response as PlaywrightResponse } from "@playwright/test";
+import { type MinersPage } from "../pages/miners";
+import { type RacksPage } from "../pages/racks";
+import { type CommonSteps } from "./commonSteps";
+
+const LIST_MINERS_RESPONSE = "ListMinerStateSnapshots";
+const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
+
+type PlacementRefSnapshot = {
+  label?: string;
+};
+
+type VisibleMinerSnapshot = {
+  deviceIdentifier?: string;
+  ipAddress: string;
+  rackPosition?: string;
+  placement?: {
+    site?: PlacementRefSnapshot;
+    rack?: PlacementRefSnapshot;
+  };
+};
+
+export type ReparentMiner = {
+  deviceIdentifier?: string;
+  ipAddress: string;
+  originalRackLabel?: string;
+  originalRackPosition?: string;
+  originalSiteLabel?: string;
+};
+
+export async function installAllSitesInitScript(page: Page) {
+  await page.addInitScript(
+    ({ storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          state: {
+            ui: {
+              activeSite: { kind: "all" },
+            },
+          },
+          version: 0,
+        }),
+      );
+    },
+    { storageKey: ACTIVE_SITE_STORAGE_KEY },
+  );
+}
+
+export async function captureMovableMiner({
+  page,
+  commonSteps,
+  minersPage,
+}: {
+  page: Page;
+  commonSteps: CommonSteps;
+  minersPage: MinersPage;
+}): Promise<ReparentMiner> {
+  const snapshots = await loadVisibleMiners({ page, commonSteps });
+  const ipAddresses = await minersPage.getVisibleMinerIpAddresses();
+
+  for (const ipAddress of ipAddresses) {
+    if (!(await minersPage.hasBlankBuildingAndRack(ipAddress))) {
+      continue;
+    }
+
+    if (await minersPage.hasAuthenticationRequiredIssue(ipAddress)) {
+      continue;
+    }
+
+    const snapshot = snapshots.find((candidate) => candidate.ipAddress === ipAddress);
+    return {
+      deviceIdentifier: snapshot?.deviceIdentifier,
+      ipAddress,
+      originalSiteLabel: normalizePlacementLabel(await minersPage.getMinerColumnText(ipAddress, "site")),
+      originalRackLabel: snapshot?.placement?.rack?.label,
+      originalRackPosition: snapshot?.rackPosition,
+    };
+  }
+
+  throw new Error("Expected at least one visible miner without building or rack placement for reparent coverage");
+}
+
+export function expectSingleDeviceIdentifier(actual: string[] | undefined, expected?: string) {
+  if (expected) {
+    expect(actual).toEqual([expected]);
+    return;
+  }
+
+  expect(actual).toHaveLength(1);
+}
+
+export async function restoreMinerPlacementIfNeeded({
+  page,
+  minersPage,
+  racksPage,
+  miner,
+}: {
+  page: Page;
+  minersPage: MinersPage;
+  racksPage: RacksPage;
+  miner: ReparentMiner | undefined;
+}) {
+  if (!miner) {
+    return;
+  }
+
+  if (!miner.originalRackLabel) {
+    await restoreMinerSiteIfNeeded({ page, minersPage, miner });
+    return;
+  }
+
+  await restoreMinerSiteIfNeeded({ page, minersPage, miner });
+
+  if (miner.originalRackPosition) {
+    await restoreMinerRackSlotIfNeeded({ page, racksPage, miner });
+    return;
+  }
+
+  await restoreMinerRackIfNeeded({ page, minersPage, miner });
+}
+
+async function loadVisibleMiners({
+  page,
+  commonSteps,
+}: {
+  page: Page;
+  commonSteps: CommonSteps;
+}): Promise<VisibleMinerSnapshot[]> {
+  const responsePromise = new Promise<VisibleMinerSnapshot[]>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      page.off("response", handleResponse);
+      resolve([]);
+    }, 10000);
+
+    const handleResponse = async (response: PlaywrightResponse) => {
+      if (response.request().method() !== "POST" || !response.url().includes(LIST_MINERS_RESPONSE)) {
+        return;
+      }
+
+      try {
+        const body = (await response.json()) as {
+          miners?: VisibleMinerSnapshot[];
+          snapshots?: VisibleMinerSnapshot[];
+        };
+        const snapshots = body.snapshots ?? body.miners ?? [];
+        if (snapshots.length === 0) {
+          return;
+        }
+
+        clearTimeout(timeoutId);
+        page.off("response", handleResponse);
+        resolve(snapshots);
+      } catch (error) {
+        clearTimeout(timeoutId);
+        page.off("response", handleResponse);
+        reject(error);
+      }
+    };
+
+    page.on("response", handleResponse);
+  });
+
+  await commonSteps.goToMinersPage();
+  return await responsePromise;
+}
+
+function normalizePlacementLabel(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized || normalized === "—") {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+async function restoreMinerSiteIfNeeded({
+  page,
+  minersPage,
+  miner,
+}: {
+  page: Page;
+  minersPage: MinersPage;
+  miner: ReparentMiner;
+}) {
+  if (!miner.originalSiteLabel) {
+    return;
+  }
+
+  await page.goto("/fleet/miners");
+  await minersPage.waitForMinersListToLoad();
+  await minersPage.clickMinerCheckbox(miner.ipAddress);
+  await minersPage.validateActionBarMinerCount(1);
+  await minersPage.assignSelectedMinersToSite(miner.originalSiteLabel);
+}
+
+async function restoreMinerRackSlotIfNeeded({
+  page,
+  racksPage,
+  miner,
+}: {
+  page: Page;
+  racksPage: RacksPage;
+  miner: ReparentMiner;
+}) {
+  if (!miner.originalRackLabel || !miner.originalRackPosition) {
+    return;
+  }
+
+  const slotNumber = Number(miner.originalRackPosition);
+  if (Number.isNaN(slotNumber)) {
+    throw new Error(`Could not parse original rack position "${miner.originalRackPosition}"`);
+  }
+
+  await page.goto("/fleet/racks");
+  await racksPage.clickViewList();
+  await racksPage.waitForRackListToLoad({ allowEmpty: false });
+  await racksPage.openRackFromList(miner.originalRackLabel);
+  await racksPage.clickRackOverviewEmptySlot(slotNumber);
+  await racksPage.assignSearchMinerByIpAddress(miner.ipAddress);
+  await racksPage.validateRackOverviewAssignedSlots([slotNumber]);
+}
+
+async function restoreMinerRackIfNeeded({
+  page,
+  minersPage,
+  miner,
+}: {
+  page: Page;
+  minersPage: MinersPage;
+  miner: ReparentMiner;
+}) {
+  if (!miner.originalRackLabel) {
+    return;
+  }
+
+  await page.goto("/fleet/miners");
+  await minersPage.waitForMinersListToLoad();
+  await minersPage.clickMinerCheckbox(miner.ipAddress);
+  await minersPage.validateActionBarMinerCount(1);
+  await minersPage.assignSelectedMinersToRack(miner.originalRackLabel);
+}

--- a/client/e2eTests/protoFleet/helpers/reparentHelpers.ts
+++ b/client/e2eTests/protoFleet/helpers/reparentHelpers.ts
@@ -11,7 +11,7 @@ type PlacementRefSnapshot = {
 };
 
 type VisibleMinerSnapshot = {
-  deviceIdentifier?: string;
+  deviceIdentifier: string;
   ipAddress: string;
   rackPosition?: string;
   placement?: {
@@ -21,7 +21,7 @@ type VisibleMinerSnapshot = {
 };
 
 export type ReparentMiner = {
-  deviceIdentifier?: string;
+  deviceIdentifier: string;
   ipAddress: string;
   originalRackLabel?: string;
   originalRackPosition?: string;
@@ -69,25 +69,24 @@ export async function captureMovableMiner({
     }
 
     const snapshot = snapshots.find((candidate) => candidate.ipAddress === ipAddress);
+    if (!snapshot) {
+      continue;
+    }
+
     return {
-      deviceIdentifier: snapshot?.deviceIdentifier,
+      deviceIdentifier: snapshot.deviceIdentifier,
       ipAddress,
       originalSiteLabel: normalizePlacementLabel(await minersPage.getMinerColumnText(ipAddress, "site")),
-      originalRackLabel: snapshot?.placement?.rack?.label,
-      originalRackPosition: snapshot?.rackPosition,
+      originalRackLabel: snapshot.placement?.rack?.label,
+      originalRackPosition: snapshot.rackPosition,
     };
   }
 
   throw new Error("Expected at least one visible miner without building or rack placement for reparent coverage");
 }
 
-export function expectSingleDeviceIdentifier(actual: string[] | undefined, expected?: string) {
-  if (expected) {
-    expect(actual).toEqual([expected]);
-    return;
-  }
-
-  expect(actual).toHaveLength(1);
+export function expectSingleDeviceIdentifier(actual: string[] | undefined, expected: string) {
+  expect(actual).toEqual([expected]);
 }
 
 export async function restoreMinerPlacementIfNeeded({
@@ -130,7 +129,7 @@ async function loadVisibleMiners({
   const responsePromise = new Promise<VisibleMinerSnapshot[]>((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       page.off("response", handleResponse);
-      resolve([]);
+      reject(new Error(`Timed out waiting for ${LIST_MINERS_RESPONSE}`));
     }, 10000);
 
     const handleResponse = async (response: PlaywrightResponse) => {

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -33,7 +33,7 @@ export class FleetLocationsPage extends BasePage {
     await this.clickAddSiteButton();
     await this.page.getByTestId("site-settings-name-input").fill(name);
     await this.page.getByTestId("site-settings-modal-continue").click();
-    await this.waitForModalToClose("site-settings-modal");
+    await this.waitForPageOverlayToClose("site-settings-modal");
 
     const saveSiteButton = this.page.locator('[data-testid="manage-site-modal-save"]:visible');
     await expect(saveSiteButton).toBeVisible();
@@ -65,7 +65,7 @@ export class FleetLocationsPage extends BasePage {
     await this.page.getByRole("option", { name: siteName, exact: true }).click();
     await this.page.getByTestId("building-settings-name-input").fill(buildingName);
     await this.page.getByTestId("building-settings-modal-save").click();
-    await this.waitForModalToClose("building-settings-modal");
+    await this.waitForPageOverlayToClose("building-settings-modal");
 
     const row = this.getListRowByName(buildingName);
     await expect(row).toBeVisible();
@@ -183,8 +183,11 @@ export class FleetLocationsPage extends BasePage {
     return this.page.locator("div.fixed.inset-0.z-60");
   }
 
-  private async waitForModalToClose(testId: string) {
+  private async waitForPageOverlayToClose(testId: string) {
     await expect(this.page.getByTestId(testId)).toHaveCount(0);
+    await expect(
+      this.page.locator("div.fixed.top-0.left-0.flex.h-screen.w-screen.justify-center.bg-grayscale-gray-5"),
+    ).toHaveCount(0);
   }
 
   private async openRowActions(name: string) {

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -1,0 +1,213 @@
+import { expect } from "@playwright/test";
+import { BasePage } from "./base";
+
+type Scope = "site" | "building" | "rack";
+
+export class FleetLocationsPage extends BasePage {
+  async navigateToSitesPage() {
+    await this.page.goto("/fleet/sites");
+    await expect(this.page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
+    await expect(this.page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
+    await expect(this.page.getByTestId("fleet-sites-page")).toBeVisible();
+    await this.selectAllSitesIfNeeded();
+
+    const sitePickerTrigger = this.page.getByTestId("site-picker-trigger");
+    if (await sitePickerTrigger.isVisible().catch(() => false)) {
+      await this.page.goto("/fleet/sites");
+      await expect(this.page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
+      await expect(this.page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
+      await expect(this.page.getByTestId("fleet-sites-page")).toBeVisible();
+      await expect(sitePickerTrigger).toContainText("All sites");
+    }
+  }
+
+  async navigateToBuildingsPage() {
+    await this.navigateToSitesPage();
+    await this.page.goto("/fleet/buildings");
+    await expect(this.page).toHaveURL(/\/fleet\/buildings(?:[?#].*)?$/);
+    await expect(this.page.getByTestId("fleet-buildings-page")).toBeVisible();
+  }
+
+  async createSite(name: string): Promise<bigint> {
+    await this.navigateToSitesPage();
+    await this.clickAddSiteButton();
+    await this.page.getByTestId("site-settings-name-input").fill(name);
+    await this.page.getByTestId("site-settings-modal-continue").click();
+
+    const saveSiteButton = this.page.locator('[data-testid="manage-site-modal-save"]:visible');
+    await expect(saveSiteButton).toBeVisible();
+    await saveSiteButton.click();
+
+    const row = this.getListRowByName(name);
+    await expect(row).toBeVisible();
+    return await this.getScopeIdFromRowName(name, "site");
+  }
+
+  async deleteSite(name: string) {
+    await this.navigateToSitesPage();
+    await this.openRowActions(name);
+    await this.clickRowAction("Edit site");
+    await this.clickManageSiteDelete();
+
+    const confirmDeleteButton = this.page.getByTestId("site-delete-dialog-confirm");
+    await expect(confirmDeleteButton).toBeVisible();
+    await confirmDeleteButton.click({ trial: true });
+    await confirmDeleteButton.click();
+    await expect(this.getListRowByName(name)).toHaveCount(0);
+  }
+
+  async createBuilding(siteName: string, buildingName: string): Promise<bigint> {
+    await this.navigateToBuildingsPage();
+    await this.clickAddBuildingButton();
+    await this.page.getByTestId("building-settings-site-select").click();
+    await this.page.getByRole("option", { name: siteName, exact: true }).click();
+    await this.page.getByTestId("building-settings-name-input").fill(buildingName);
+    await this.page.getByTestId("building-settings-modal-save").click();
+
+    const row = this.getListRowByName(buildingName);
+    await expect(row).toBeVisible();
+    return await this.getScopeIdFromRowName(buildingName, "building");
+  }
+
+  async deleteBuilding(name: string) {
+    await this.navigateToBuildingsPage();
+    await this.openRowActions(name);
+    await this.clickRowAction("Edit building");
+    await this.clickManageBuildingDelete();
+
+    const confirmDeleteButton = this.page.getByTestId("building-delete-dialog-confirm");
+    await expect(confirmDeleteButton).toBeVisible();
+    await confirmDeleteButton.click({ trial: true });
+    await confirmDeleteButton.click();
+    await expect(this.getListRowByName(name)).toHaveCount(0);
+  }
+
+  async validateSiteMinerCount(siteName: string, expectedCount: number) {
+    await this.navigateToSitesPage();
+    await expect(this.getListRowByName(siteName).getByTestId("miners")).toHaveText(String(expectedCount));
+  }
+
+  private getListRowByName(name: string) {
+    return this.page
+      .getByTestId("list-row")
+      .filter({ has: this.page.getByTestId("name").getByText(name, { exact: true }) })
+      .first();
+  }
+
+  private async selectAllSitesIfNeeded() {
+    const sitePickerTrigger = this.page.getByTestId("site-picker-trigger");
+    if (!(await sitePickerTrigger.isVisible().catch(() => false))) {
+      await expect(this.page.getByTestId("fleet-sites-page")).toBeVisible();
+      return;
+    }
+
+    const currentLabel = (await sitePickerTrigger.textContent())?.trim();
+    if (currentLabel === "All sites") {
+      return;
+    }
+
+    await sitePickerTrigger.click();
+    const allSitesOption = this.page.getByTestId("site-picker-option-all");
+    await expect(allSitesOption).toBeVisible();
+    await allSitesOption.click();
+    await expect(sitePickerTrigger).toContainText("All sites");
+  }
+
+  private async clickAddSiteButton() {
+    const headerAddSiteButton = this.page.getByTestId("fleet-sites-add");
+    if (await headerAddSiteButton.isVisible().catch(() => false)) {
+      await headerAddSiteButton.click();
+      return;
+    }
+
+    const emptyStateAddSiteButton = this.page.getByRole("button", { name: "Add a site", exact: true });
+    await expect(emptyStateAddSiteButton).toBeVisible();
+    await emptyStateAddSiteButton.click();
+  }
+
+  private async clickAddBuildingButton() {
+    const headerAddBuildingButton = this.page.getByTestId("fleet-buildings-add");
+    if (await headerAddBuildingButton.isVisible().catch(() => false)) {
+      await headerAddBuildingButton.click();
+      return;
+    }
+
+    const emptyStateAddBuildingButton = this.page.getByRole("button", { name: "Add building", exact: true });
+    await expect(emptyStateAddBuildingButton).toBeVisible();
+    await emptyStateAddBuildingButton.click();
+  }
+
+  private async clickManageSiteDelete() {
+    const manageSiteDeleteButton = this.page.locator('[data-testid="manage-site-modal-delete"]:visible');
+    if (await manageSiteDeleteButton.isVisible().catch(() => false)) {
+      await manageSiteDeleteButton.click();
+      return;
+    }
+
+    const siteSettingsDeleteButton = this.page.locator('[data-testid="site-settings-modal-delete"]:visible');
+    if (await siteSettingsDeleteButton.isVisible().catch(() => false)) {
+      await siteSettingsDeleteButton.click();
+      return;
+    }
+
+    const overflowMenu = await this.openFullScreenOverflowMenu();
+    const deleteSiteAction = overflowMenu.getByText("Delete site", { exact: true });
+    if (await deleteSiteAction.isVisible().catch(() => false)) {
+      await deleteSiteAction.click();
+      return;
+    }
+
+    await overflowMenu.getByText("Site settings", { exact: true }).click();
+    await expect(siteSettingsDeleteButton).toBeVisible();
+    await siteSettingsDeleteButton.click();
+  }
+
+  private async clickManageBuildingDelete() {
+    const deleteButton = this.page.locator('[data-testid="manage-building-delete"]:visible');
+    if (await deleteButton.isVisible().catch(() => false)) {
+      await deleteButton.click();
+      return;
+    }
+
+    const overflowMenu = await this.openFullScreenOverflowMenu();
+    await overflowMenu.getByText("Delete building", { exact: true }).click();
+  }
+
+  private async openFullScreenOverflowMenu() {
+    const overflowTrigger = this.page.getByTestId("full-screen-two-pane-modal").getByTestId("overflow-menu-trigger");
+    await expect(overflowTrigger).toBeVisible();
+    await overflowTrigger.click();
+    return this.page.locator("div.fixed.inset-0.z-60");
+  }
+
+  private async openRowActions(name: string) {
+    const row = this.getListRowByName(name);
+    await expect(row).toBeVisible();
+    await row.locator('button[data-testid$="-actions-trigger"]').first().click();
+  }
+
+  private async clickRowAction(label: string) {
+    await this.page.getByText(label, { exact: true }).click();
+  }
+
+  private async getScopeIdFromRowName(name: string, scope: Scope): Promise<bigint> {
+    const row = this.getListRowByName(name);
+    await expect(row).toBeVisible();
+
+    const trigger = row.locator('button[data-testid$="-actions-trigger"]').first();
+    await expect(trigger).toBeVisible();
+
+    const testId = await trigger.getAttribute("data-testid");
+    const pattern =
+      scope === "rack"
+        ? /^rack-list-row-(\d+)-actions-trigger$/
+        : new RegExp(`^${scope}-list-row-(\\d+)-actions-trigger$`);
+    const capturedId = testId?.match(pattern)?.[1];
+
+    if (!capturedId) {
+      throw new Error(`Could not parse ${scope} id from row action trigger: ${testId ?? "missing test id"}`);
+    }
+
+    return BigInt(capturedId);
+  }
+}

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -190,6 +190,10 @@ export class FleetLocationsPage extends BasePage {
     ).toHaveCount(0);
   }
 
+  private async waitForModalToClose(testId: string) {
+    await expect(this.page.getByTestId(testId)).toHaveCount(0);
+  }
+
   private async openRowActions(name: string) {
     const row = this.getListRowByName(name);
     await expect(row).toBeVisible();

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -33,11 +33,12 @@ export class FleetLocationsPage extends BasePage {
     await this.clickAddSiteButton();
     await this.page.getByTestId("site-settings-name-input").fill(name);
     await this.page.getByTestId("site-settings-modal-continue").click();
+    await this.waitForModalToClose("site-settings-modal");
 
     const saveSiteButton = this.page.locator('[data-testid="manage-site-modal-save"]:visible');
     await expect(saveSiteButton).toBeVisible();
     await saveSiteButton.click();
-    await this.waitForFullScreenModalToClose();
+    await this.waitForModalToClose("full-screen-two-pane-modal");
 
     const row = this.getListRowByName(name);
     await expect(row).toBeVisible();
@@ -64,7 +65,7 @@ export class FleetLocationsPage extends BasePage {
     await this.page.getByRole("option", { name: siteName, exact: true }).click();
     await this.page.getByTestId("building-settings-name-input").fill(buildingName);
     await this.page.getByTestId("building-settings-modal-save").click();
-    await this.waitForFullScreenModalToClose();
+    await this.waitForModalToClose("building-settings-modal");
 
     const row = this.getListRowByName(buildingName);
     await expect(row).toBeVisible();
@@ -182,8 +183,8 @@ export class FleetLocationsPage extends BasePage {
     return this.page.locator("div.fixed.inset-0.z-60");
   }
 
-  private async waitForFullScreenModalToClose() {
-    await expect(this.page.getByTestId("full-screen-two-pane-modal")).toBeHidden();
+  private async waitForModalToClose(testId: string) {
+    await expect(this.page.getByTestId(testId)).toBeHidden();
   }
 
   private async openRowActions(name: string) {

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -184,7 +184,7 @@ export class FleetLocationsPage extends BasePage {
   }
 
   private async waitForModalToClose(testId: string) {
-    await expect(this.page.getByTestId(testId)).toBeHidden();
+    await expect(this.page.getByTestId(testId)).toHaveCount(0);
   }
 
   private async openRowActions(name: string) {

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -33,7 +33,7 @@ export class FleetLocationsPage extends BasePage {
     await this.clickAddSiteButton();
     await this.page.getByTestId("site-settings-name-input").fill(name);
     await this.page.getByTestId("site-settings-modal-continue").click();
-    await this.waitForPageOverlayToClose("site-settings-modal");
+    await this.waitForModalToClose("site-settings-modal");
 
     const saveSiteButton = this.page.locator('[data-testid="manage-site-modal-save"]:visible');
     await expect(saveSiteButton).toBeVisible();

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -37,6 +37,7 @@ export class FleetLocationsPage extends BasePage {
     const saveSiteButton = this.page.locator('[data-testid="manage-site-modal-save"]:visible');
     await expect(saveSiteButton).toBeVisible();
     await saveSiteButton.click();
+    await this.waitForFullScreenModalToClose();
 
     const row = this.getListRowByName(name);
     await expect(row).toBeVisible();
@@ -63,6 +64,7 @@ export class FleetLocationsPage extends BasePage {
     await this.page.getByRole("option", { name: siteName, exact: true }).click();
     await this.page.getByTestId("building-settings-name-input").fill(buildingName);
     await this.page.getByTestId("building-settings-modal-save").click();
+    await this.waitForFullScreenModalToClose();
 
     const row = this.getListRowByName(buildingName);
     await expect(row).toBeVisible();
@@ -178,6 +180,10 @@ export class FleetLocationsPage extends BasePage {
     await expect(overflowTrigger).toBeVisible();
     await overflowTrigger.click();
     return this.page.locator("div.fixed.inset-0.z-60");
+  }
+
+  private async waitForFullScreenModalToClose() {
+    await expect(this.page.getByTestId("full-screen-two-pane-modal")).toBeHidden();
   }
 
   private async openRowActions(name: string) {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -294,10 +294,13 @@ export class MinersPage extends BasePage {
     await this.page.getByTestId("add-to-site-popover-button").click();
     await this.selectParentPickerTarget(siteName);
 
+    const parentPickerModal = this.page.getByTestId("modal");
     const continueButton = this.page.getByRole("button", { name: "Continue", exact: true });
-    if (await continueButton.isVisible().catch(() => false)) {
+    if (await continueButton.isVisible({ timeout: 3000 }).catch(() => false)) {
       await continueButton.click();
     }
+
+    await expect(parentPickerModal).toBeHidden();
   }
 
   async assignSelectedMinersToRack(rackLabel: string) {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -207,6 +207,52 @@ export class MinersPage extends BasePage {
     await expect(columnLocator.getByTestId(iconId)).toBeVisible();
   }
 
+  async getMinerColumnText(ipAddress: string, columnTestId: string): Promise<string | undefined> {
+    const minerRow = await this.getMinerRowByIp(ipAddress);
+    const text = await minerRow
+      .getByTestId(columnTestId)
+      .textContent()
+      .catch(() => null);
+    return text?.trim() || undefined;
+  }
+
+  async getVisibleMinerIpAddresses(): Promise<string[]> {
+    const rows = this.page.getByTestId("list-body").locator("tr");
+    const rowCount = await rows.count();
+    const ipAddresses: string[] = [];
+
+    for (let i = 0; i < rowCount; i++) {
+      const ipAddress = (
+        await rows
+          .nth(i)
+          .getByTestId("ipAddress")
+          .textContent()
+          .catch(() => null)
+      )?.trim();
+      if (ipAddress) {
+        ipAddresses.push(ipAddress);
+      }
+    }
+
+    return ipAddresses;
+  }
+
+  async hasBlankBuildingAndRack(ipAddress: string): Promise<boolean> {
+    const building = await this.getMinerColumnText(ipAddress, "building");
+    const rack = await this.getMinerColumnText(ipAddress, "rack");
+    return this.isBlankListCell(building) && this.isBlankListCell(rack);
+  }
+
+  async hasAuthenticationRequiredIssue(ipAddress: string): Promise<boolean> {
+    const minerRow = await this.getMinerRowByIp(ipAddress);
+    return (
+      (await minerRow
+        .getByRole("button", { name: "Authentication required", exact: true })
+        .count()
+        .catch(() => 0)) > 0
+    );
+  }
+
   async clickMinerThreeDotsButton(ipAddress: string) {
     const minerRow = await this.getMinerRowByIp(ipAddress);
     await minerRow.getByTestId(`single-miner-actions-menu-button`).click();
@@ -241,6 +287,23 @@ export class MinersPage extends BasePage {
 
   async clickActionsMenuButton() {
     await this.page.getByTestId("actions-menu-button").click();
+  }
+
+  async assignSelectedMinersToSite(siteName: string) {
+    await this.clickActionsMenuButton();
+    await this.page.getByTestId("add-to-site-popover-button").click();
+    await this.selectParentPickerTarget(siteName);
+
+    const continueButton = this.page.getByRole("button", { name: "Continue", exact: true });
+    if (await continueButton.isVisible().catch(() => false)) {
+      await continueButton.click();
+    }
+  }
+
+  async assignSelectedMinersToRack(rackLabel: string) {
+    await this.clickActionsMenuButton();
+    await this.page.getByTestId("add-to-rack-popover-button").click();
+    await this.selectParentPickerTarget(rackLabel);
   }
 
   async clickBlinkLEDsButton() {
@@ -1428,5 +1491,15 @@ export class MinersPage extends BasePage {
 
   async clickCloseStatusModal() {
     await this.clickIn("Done", "modal");
+  }
+
+  private isBlankListCell(value: string | undefined): boolean {
+    return value === undefined || value === "" || value === "—";
+  }
+
+  private async selectParentPickerTarget(label: string) {
+    const modal = this.page.getByTestId("modal");
+    await modal.getByText(label, { exact: true }).click();
+    await modal.getByRole("button", { name: "Save", exact: true }).click();
   }
 }

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -276,6 +276,32 @@ export class RacksPage extends BasePage {
       .click();
   }
 
+  async createRack({
+    columns,
+    label,
+    rows,
+    zone,
+  }: {
+    columns: number;
+    label: string;
+    rows: number;
+    zone: string;
+  }): Promise<bigint> {
+    await this.navigateToRacksPage();
+    await this.clickAddRackButton();
+    await this.inputZone(zone);
+    await this.inputRackLabel(label);
+    await this.enableCustomRackLayout();
+    await this.inputColumns(columns);
+    await this.inputRows(rows);
+    await this.clickContinueFromRackSettings();
+    await this.clickSaveRack();
+    await this.validateRackToast(label);
+    await this.clickViewList();
+    await this.waitForRackListToLoad({ allowEmpty: false });
+    return await this.getRackId(label);
+  }
+
   async clickViewMiners() {
     await this.clickButton("View miners");
     await expect(this.page).toHaveURL(/.*\/miners/);
@@ -484,10 +510,55 @@ export class RacksPage extends BasePage {
     await expect(row.getByTestId("miners")).toHaveText(String(miners));
   }
 
+  async validateRackPlacementRow(label: string, siteName: string, buildingName: string) {
+    const row = this.getRackListRow(label);
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("site")).toHaveText(siteName);
+    await expect(row.getByTestId("building")).toHaveText(buildingName);
+  }
+
+  async validateRackMembershipRow(label: string, siteName: string, minerCount: number) {
+    const row = this.getRackListRow(label);
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("miners")).toHaveText(String(minerCount));
+    await expect(row.getByTestId("site")).toHaveText(siteName);
+  }
+
   async openRackFromList(label: string) {
     const row = this.getRackListRow(label);
     await expect(row).toBeVisible();
     await row.getByTestId("name").getByRole("button", { name: label, exact: true }).click();
+  }
+
+  async assignRackToSiteFromList(label: string, siteName: string) {
+    await this.navigateToRacksPage();
+    await this.clickViewList();
+    await this.waitForRackListToLoad({ allowEmpty: false });
+    await this.openRackActionsFromList(label);
+    await this.page.getByText("Add to site", { exact: true }).click();
+    await this.selectParentPickerTarget(siteName);
+  }
+
+  async assignRackToBuildingFromList(label: string, buildingName: string) {
+    await this.navigateToRacksPage();
+    await this.clickViewList();
+    await this.waitForRackListToLoad({ allowEmpty: false });
+    await this.openRackActionsFromList(label);
+    await this.page.getByText("Add to building", { exact: true }).click();
+    await this.selectParentPickerTarget(buildingName);
+  }
+
+  async deleteRackByLabelIfVisible(label: string) {
+    await this.navigateToRacksPage();
+    await this.tryAction(() => this.clickViewList());
+    if (!(await this.tryAction(() => this.openRackFromList(label)))) {
+      return;
+    }
+
+    await this.clickEditRack();
+    await this.clickDeleteRack();
+    await this.clickDeleteConfirm();
+    await this.tryAction(() => this.validateRackDeletedToast());
   }
 
   async clickEditRack() {
@@ -635,5 +706,33 @@ export class RacksPage extends BasePage {
       .getByTestId("list-row")
       .filter({ has: this.page.getByTestId("name").getByRole("button", { name: label, exact: true }) })
       .first();
+  }
+
+  private async openRackActionsFromList(label: string) {
+    const row = this.getRackListRow(label);
+    await expect(row).toBeVisible();
+    await row.locator('button[data-testid$="-actions-trigger"]').first().click();
+  }
+
+  private async selectParentPickerTarget(label: string) {
+    const modal = this.page.getByTestId("modal");
+    await modal.getByText(label, { exact: true }).click();
+    await modal.getByRole("button", { name: "Save", exact: true }).click();
+  }
+
+  private async getRackId(label: string): Promise<bigint> {
+    const row = this.getRackListRow(label);
+    await expect(row).toBeVisible();
+
+    const trigger = row.locator('button[data-testid$="-actions-trigger"]').first();
+    await expect(trigger).toBeVisible();
+
+    const testId = await trigger.getAttribute("data-testid");
+    const capturedId = testId?.match(/^rack-list-row-(\d+)-actions-trigger$/)?.[1];
+    if (!capturedId) {
+      throw new Error(`Could not parse rack id from row action trigger: ${testId ?? "missing test id"}`);
+    }
+
+    return BigInt(capturedId);
   }
 }

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -270,7 +270,10 @@ export class RacksPage extends BasePage {
   }
 
   async clickSaveRack() {
-    await this.clickButton("Save");
+    await this.page
+      .getByTestId("full-screen-two-pane-modal")
+      .getByRole("button", { name: "Save", disabled: false, exact: true })
+      .click();
   }
 
   async clickViewMiners() {

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -8,15 +8,21 @@ import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fle
 
 type SiteManagementMode = "fleet";
 
+type PlacementRefSnapshot = {
+  id?: string;
+  label?: string;
+};
+
 type VisibleMinerSnapshot = {
   deviceIdentifier: string;
   ipAddress: string;
-  name: string;
   pairingStatus: PairingStatus;
-  rackLabel: string;
   rackPosition: string;
-  siteId?: string;
-  siteLabel: string;
+  placement?: {
+    site?: PlacementRefSnapshot;
+    building?: PlacementRefSnapshot;
+    rack?: PlacementRefSnapshot;
+  };
 };
 
 const LIST_MINERS_RESPONSE = "ListMinerStateSnapshots";
@@ -30,6 +36,13 @@ function getListRowByName(page: Page, name: string) {
   return page
     .getByTestId("list-row")
     .filter({ has: page.getByTestId("name").getByText(name, { exact: true }) })
+    .first();
+}
+
+function getMinerRowByIp(page: Page, ipAddress: string) {
+  return page
+    .getByTestId("list-row")
+    .filter({ has: page.getByText(ipAddress, { exact: true }) })
     .first();
 }
 
@@ -54,9 +67,7 @@ async function resetActiveSiteSelection(page: Page) {
 
 async function selectAllSitesIfNeeded(page: Page) {
   const sitePickerTrigger = page.getByTestId("site-picker-trigger");
-  if (!(await sitePickerTrigger.isVisible().catch(() => false))) {
-    return;
-  }
+  await test.expect(sitePickerTrigger).toBeVisible();
 
   const currentLabel = (await sitePickerTrigger.textContent())?.trim();
   if (currentLabel === "All sites") {
@@ -82,6 +93,8 @@ async function openSitesManagementPage(page: Page, mode: SiteManagementMode) {
   await selectAllSitesIfNeeded(page);
   await page.goto("/fleet/sites");
   await test.expect(page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
+  await test.expect(page.getByTestId("site-picker-trigger")).toContainText("All sites");
+  await test.expect(page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
   await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
 }
 
@@ -166,8 +179,9 @@ async function clickRowAction(page: Page, label: string) {
 }
 
 async function selectParentPickerTarget(page: Page, label: string) {
-  await page.getByText(label, { exact: true }).click();
-  await page.getByTestId("modal").getByRole("button", { name: "Save", exact: true }).click();
+  const modal = page.getByTestId("modal");
+  await modal.getByText(label, { exact: true }).click();
+  await modal.getByRole("button", { name: "Save", exact: true }).click();
 }
 
 async function continueDialogIfVisible(page: Page, title: string) {
@@ -223,18 +237,45 @@ async function loadVisibleMiners({
   return await responsePromise;
 }
 
-function pickUnrackedPairedMiner(miners: VisibleMinerSnapshot[]): VisibleMinerSnapshot {
-  const candidate =
-    miners.find((miner) => miner.pairingStatus === PairingStatus.PAIRED && miner.rackLabel === "") ??
-    miners.find((miner) => miner.rackLabel === "") ??
-    miners.find((miner) => miner.pairingStatus === PairingStatus.PAIRED) ??
-    miners[0];
+function isBlankListCell(value: string | null | undefined): boolean {
+  const normalized = value?.trim();
+  return normalized === undefined || normalized === "" || normalized === "—";
+}
 
-  if (!candidate) {
-    throw new Error("Expected at least one visible miner for reparent coverage");
+async function isMinerSafeToRestore(page: Page, miner: VisibleMinerSnapshot): Promise<boolean> {
+  const row = getMinerRowByIp(page, miner.ipAddress);
+  if (!(await row.isVisible().catch(() => false))) {
+    return false;
   }
 
-  return candidate;
+  const buildingText = await row
+    .getByTestId("building")
+    .textContent()
+    .catch(() => null);
+  const rackText = await row
+    .getByTestId("rack")
+    .textContent()
+    .catch(() => null);
+  return isBlankListCell(buildingText) && isBlankListCell(rackText);
+}
+
+async function pickUnrackedPairedMiner(page: Page, miners: VisibleMinerSnapshot[]): Promise<VisibleMinerSnapshot> {
+  for (const miner of miners) {
+    if (miner.pairingStatus !== PairingStatus.PAIRED) {
+      continue;
+    }
+    if (await isMinerSafeToRestore(page, miner)) {
+      return miner;
+    }
+  }
+
+  for (const miner of miners) {
+    if (await isMinerSafeToRestore(page, miner)) {
+      return miner;
+    }
+  }
+
+  throw new Error("Expected at least one visible miner without building or rack placement for reparent coverage");
 }
 
 async function createSite(page: Page, name: string, mode: SiteManagementMode): Promise<bigint> {
@@ -259,7 +300,10 @@ async function deleteSite(page: Page, name: string, mode: SiteManagementMode) {
   await openRowActions(page, name);
   await clickRowAction(page, "Edit site");
   await clickManageSiteDelete(page);
-  await page.getByTestId("site-delete-dialog-confirm").click();
+  const confirmDeleteButton = page.getByTestId("site-delete-dialog-confirm");
+  await test.expect(confirmDeleteButton).toBeVisible();
+  await confirmDeleteButton.click({ trial: true });
+  await confirmDeleteButton.click();
   await test.expect(getListRowByName(page, name)).toHaveCount(0);
 }
 
@@ -292,7 +336,10 @@ async function deleteBuilding(page: Page, siteName: string, name: string, mode: 
   await openRowActions(page, name);
   await clickRowAction(page, "Edit building");
   await clickManageBuildingDelete(page);
-  await page.getByTestId("building-delete-dialog-confirm").click();
+  const confirmDeleteButton = page.getByTestId("building-delete-dialog-confirm");
+  await test.expect(confirmDeleteButton).toBeVisible();
+  await confirmDeleteButton.click({ trial: true });
+  await confirmDeleteButton.click();
   await test.expect(getListRowByName(page, name)).toHaveCount(0);
 }
 
@@ -594,6 +641,22 @@ async function deleteSiteIfCreated({
 
 test.describe("Miners reparent", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(
+      ({ storageKey }) => {
+        localStorage.setItem(
+          storageKey,
+          JSON.stringify({
+            state: {
+              ui: {
+                activeSite: { kind: "all" },
+              },
+            },
+            version: 0,
+          }),
+        );
+      },
+      { storageKey: ACTIVE_SITE_STORAGE_KEY },
+    );
     await page.goto("/");
   });
 
@@ -669,10 +732,17 @@ test.describe("Miners reparent", () => {
 
     try {
       const snapshots = await loadVisibleMiners({ page, commonSteps });
-      const miner = pickUnrackedPairedMiner(snapshots);
+      const miner = await pickUnrackedPairedMiner(page, snapshots);
+      const minerRow = getMinerRowByIp(page, miner.ipAddress);
       minerIp = miner.ipAddress;
-      originalSiteLabel = miner.siteLabel || undefined;
-      originalRackLabel = miner.rackLabel || undefined;
+      originalSiteLabel =
+        (
+          await minerRow
+            .getByTestId("site")
+            .textContent()
+            .catch(() => null)
+        )?.trim() || undefined;
+      originalRackLabel = miner.placement?.rack?.label || undefined;
       originalRackPosition = miner.rackPosition || undefined;
 
       const targetSiteId = await createSite(page, targetSiteName, siteManagementMode);
@@ -737,10 +807,17 @@ test.describe("Miners reparent", () => {
 
     try {
       const snapshots = await loadVisibleMiners({ page, commonSteps });
-      const miner = pickUnrackedPairedMiner(snapshots);
+      const miner = await pickUnrackedPairedMiner(page, snapshots);
+      const minerRow = getMinerRowByIp(page, miner.ipAddress);
       minerIp = miner.ipAddress;
-      originalSiteLabel = miner.siteLabel || undefined;
-      originalRackLabel = miner.rackLabel || undefined;
+      originalSiteLabel =
+        (
+          await minerRow
+            .getByTestId("site")
+            .textContent()
+            .catch(() => null)
+        )?.trim() || undefined;
+      originalRackLabel = miner.placement?.rack?.label || undefined;
       originalRackPosition = miner.rackPosition || undefined;
 
       await createSite(page, targetSiteName, siteManagementMode);

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -1,0 +1,763 @@
+import { type Page, type Response as PlaywrightResponse } from "@playwright/test";
+import { test } from "../fixtures/pageFixtures";
+import { type CommonSteps } from "../helpers/commonSteps";
+import { generateRandomText } from "../helpers/testDataHelper";
+import { type MinersPage } from "../pages/miners";
+import { type RacksPage } from "../pages/racks";
+import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+
+type SiteManagementMode = "fleet" | "legacy";
+
+type VisibleMinerSnapshot = {
+  deviceIdentifier: string;
+  ipAddress: string;
+  name: string;
+  pairingStatus: PairingStatus;
+  rackLabel: string;
+  siteId?: string;
+  siteLabel: string;
+};
+
+const LIST_MINERS_RESPONSE = "ListMinerStateSnapshots";
+const ASSIGN_DEVICES_TO_SITE = "AssignDevicesToSite";
+const ASSIGN_DEVICES_TO_RACK = "AssignDevicesToRack";
+const ASSIGN_RACKS_TO_BUILDING = "AssignRacksToBuilding";
+const TEMP_ZONE = "ReparentAutomationZone";
+const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
+
+function getListRowByName(page: Page, name: string) {
+  return page
+    .getByTestId("list-row")
+    .filter({ has: page.getByTestId("name").getByText(name, { exact: true }) })
+    .first();
+}
+
+function getLegacySiteRowByName(page: Page, name: string) {
+  return page
+    .locator('button[data-testid^="sites-all-table-row-"]')
+    .filter({ has: page.getByText(name, { exact: true }) })
+    .first();
+}
+
+function getLegacyBuildingRowByName(page: Page, name: string) {
+  return page
+    .locator('[data-testid^="site-settings-building-row-"]')
+    .filter({ has: page.getByText(name, { exact: true }) })
+    .first();
+}
+
+async function resetActiveSiteSelection(page: Page) {
+  await page.evaluate(
+    ({ storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          state: {
+            ui: {
+              activeSite: { kind: "all" },
+            },
+          },
+          version: 0,
+        }),
+      );
+    },
+    { storageKey: ACTIVE_SITE_STORAGE_KEY },
+  );
+}
+
+async function detectSiteManagementMode(page: Page): Promise<SiteManagementMode> {
+  await resetActiveSiteSelection(page);
+  await page.goto("/fleet/racks");
+  await test.expect(page).toHaveURL(/\/fleet\/racks(?:[?#].*)?$/);
+
+  const sitesTab = page.getByRole("tab", { name: "Sites", exact: true });
+  return (await sitesTab.isVisible().catch(() => false)) ? "fleet" : "legacy";
+}
+
+async function openSitesManagementPage(page: Page, mode: SiteManagementMode) {
+  await resetActiveSiteSelection(page);
+
+  if (mode === "fleet") {
+    await page.goto("/fleet/sites");
+    await test.expect(page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
+    await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
+    return;
+  }
+
+  await page.goto("/settings/sites");
+  await test.expect(page).toHaveURL(/\/settings\/sites(?:[?#].*)?$/);
+  await test.expect(page.getByTestId("settings-sites-page")).toBeVisible();
+}
+
+async function openBuildingsManagementPage(page: Page, mode: SiteManagementMode) {
+  if (mode !== "fleet") {
+    throw new Error("Legacy ProtoFleet does not expose a standalone buildings management page");
+  }
+
+  await resetActiveSiteSelection(page);
+  await page.goto("/fleet/buildings");
+  await test.expect(page).toHaveURL(/\/fleet\/buildings(?:[?#].*)?$/);
+  await test.expect(page.getByTestId("fleet-buildings-page")).toBeVisible();
+}
+
+async function openLegacySiteSettings(page: Page, siteName: string) {
+  await openSitesManagementPage(page, "legacy");
+
+  const row = getLegacySiteRowByName(page, siteName);
+  await test.expect(row).toBeVisible();
+  await row.click();
+
+  await test.expect(page.getByTestId("site-settings-single-view")).toBeVisible();
+  await test.expect(page.getByText(siteName, { exact: true })).toBeVisible();
+}
+
+async function getScopeIdFromRowName(page: Page, name: string, scope: "site" | "building" | "rack"): Promise<bigint> {
+  const row = getListRowByName(page, name);
+  await test.expect(row).toBeVisible();
+
+  const trigger = row.locator('button[data-testid$="-actions-trigger"]').first();
+  await test.expect(trigger).toBeVisible();
+
+  const testId = await trigger.getAttribute("data-testid");
+  const pattern =
+    scope === "rack"
+      ? /^rack-list-row-(\d+)-actions-trigger$/
+      : new RegExp(`^${scope}-list-row-(\\d+)-actions-trigger$`);
+  const capturedId = testId?.match(pattern)?.[1];
+  if (!capturedId) {
+    throw new Error(`Could not parse ${scope} id from row action trigger: ${testId ?? "missing test id"}`);
+  }
+
+  return BigInt(capturedId);
+}
+
+async function getLegacySiteIdFromName(page: Page, name: string): Promise<bigint> {
+  const row = getLegacySiteRowByName(page, name);
+  await test.expect(row).toBeVisible();
+
+  const testId = await row.getAttribute("data-testid");
+  const capturedId = testId?.match(/^sites-all-table-row-(\d+)$/)?.[1];
+  if (!capturedId) {
+    throw new Error(`Could not parse site id from settings sites row: ${testId ?? "missing test id"}`);
+  }
+
+  return BigInt(capturedId);
+}
+
+async function getLegacyBuildingIdFromName(page: Page, name: string): Promise<bigint> {
+  const row = getLegacyBuildingRowByName(page, name);
+  await test.expect(row).toBeVisible();
+
+  const testId = await row.getAttribute("data-testid");
+  const capturedId = testId?.match(/^site-settings-building-row-(\d+)$/)?.[1];
+  if (!capturedId) {
+    throw new Error(`Could not parse building id from site settings row: ${testId ?? "missing test id"}`);
+  }
+
+  return BigInt(capturedId);
+}
+
+async function openRowActions(page: Page, name: string) {
+  const row = getListRowByName(page, name);
+  await test.expect(row).toBeVisible();
+  await row.locator('button[data-testid$="-actions-trigger"]').first().click();
+}
+
+async function clickRowAction(page: Page, label: string) {
+  await page.getByText(label, { exact: true }).click();
+}
+
+async function selectParentPickerTarget(page: Page, label: string) {
+  await page.getByText(label, { exact: true }).click();
+  await page.getByTestId("modal").getByRole("button", { name: "Save", exact: true }).click();
+}
+
+async function continueDialogIfVisible(page: Page, title: string) {
+  const dialog = page.getByText(title, { exact: true });
+  if (await dialog.isVisible().catch(() => false)) {
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+  }
+}
+
+async function loadVisibleMiners({
+  page,
+  commonSteps,
+}: {
+  page: Page;
+  commonSteps: CommonSteps;
+}): Promise<VisibleMinerSnapshot[]> {
+  const responsePromise = new Promise<VisibleMinerSnapshot[]>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      page.off("response", handleResponse);
+      resolve([]);
+    }, 10000);
+
+    const handleResponse = async (response: PlaywrightResponse) => {
+      if (response.request().method() !== "POST" || !response.url().includes(LIST_MINERS_RESPONSE)) {
+        return;
+      }
+
+      try {
+        const body = (await response.json()) as {
+          miners?: VisibleMinerSnapshot[];
+          snapshots?: VisibleMinerSnapshot[];
+        };
+        const snapshots = body.snapshots ?? body.miners ?? [];
+        if (snapshots.length === 0) {
+          return;
+        }
+
+        clearTimeout(timeoutId);
+        page.off("response", handleResponse);
+        resolve(snapshots);
+      } catch (error) {
+        clearTimeout(timeoutId);
+        page.off("response", handleResponse);
+        reject(error);
+      }
+    };
+
+    page.on("response", handleResponse);
+  });
+
+  await commonSteps.goToMinersPage();
+
+  return await responsePromise;
+}
+
+function pickUnrackedPairedMiner(miners: VisibleMinerSnapshot[]): VisibleMinerSnapshot {
+  const candidate =
+    miners.find((miner) => miner.pairingStatus === PairingStatus.PAIRED && miner.rackLabel === "") ??
+    miners.find((miner) => miner.rackLabel === "") ??
+    miners.find((miner) => miner.pairingStatus === PairingStatus.PAIRED) ??
+    miners[0];
+
+  if (!candidate) {
+    throw new Error("Expected at least one visible miner for reparent coverage");
+  }
+
+  return candidate;
+}
+
+async function createSite(page: Page, name: string, mode: SiteManagementMode): Promise<bigint> {
+  await openSitesManagementPage(page, mode);
+
+  if (mode === "fleet") {
+    const addSiteButton = page.getByTestId("fleet-sites-add");
+    await test.expect(addSiteButton).toBeVisible();
+    await addSiteButton.click();
+    await page.getByTestId("site-settings-name-input").fill(name);
+    await page.getByTestId("site-settings-modal-continue").click();
+    const saveSiteButton = page.locator('[data-testid="manage-site-modal-save"]:visible');
+    await test.expect(saveSiteButton).toBeVisible();
+    await saveSiteButton.click();
+
+    await test.expect(page.getByTestId("toaster-container").getByText(`Site "${name}" created`)).toBeVisible();
+    return await getScopeIdFromRowName(page, name, "site");
+  }
+
+  await page.getByTestId("sites-page-header-add").click();
+  await page.getByTestId("site-settings-name-input").fill(name);
+  await page.getByTestId("site-settings-modal-continue").click();
+  const saveSiteButton = page.locator('[data-testid="manage-site-modal-save"]:visible');
+  await test.expect(saveSiteButton).toBeVisible();
+  await saveSiteButton.click();
+
+  return await getLegacySiteIdFromName(page, name);
+}
+
+async function deleteSite(page: Page, name: string, mode: SiteManagementMode) {
+  if (mode === "fleet") {
+    await openSitesManagementPage(page, mode);
+    await openRowActions(page, name);
+    await clickRowAction(page, "Edit site");
+    await page.locator('[data-testid="manage-site-modal-edit-details"]:visible').click();
+    await page.locator('[data-testid="site-settings-modal-delete"]:visible').click();
+    await page.getByTestId("site-delete-dialog-confirm").click();
+    await test.expect(page.getByTestId("toaster-container").getByText(`Site "${name}" deleted`)).toBeVisible();
+    return;
+  }
+
+  await openLegacySiteSettings(page, name);
+  await page.getByTestId("site-settings-manage").click();
+  await page.locator('[data-testid="manage-site-modal-edit-details"]:visible').click();
+  await page.locator('[data-testid="site-settings-modal-delete"]:visible').click();
+  await page.getByTestId("site-delete-dialog-confirm").click();
+  await openSitesManagementPage(page, "legacy");
+  await test
+    .expect(
+      page
+        .locator('button[data-testid^="sites-all-table-row-"]')
+        .filter({ has: page.getByText(name, { exact: true }) }),
+    )
+    .toHaveCount(0);
+}
+
+async function createBuilding(
+  page: Page,
+  siteName: string,
+  buildingName: string,
+  mode: SiteManagementMode,
+): Promise<bigint> {
+  if (mode === "fleet") {
+    await openBuildingsManagementPage(page, mode);
+
+    const addBuildingButton = page.getByTestId("fleet-buildings-add");
+    await test.expect(addBuildingButton).toBeVisible();
+    await addBuildingButton.click();
+    await page.getByTestId("building-settings-site-select").click();
+    await page.getByRole("option", { name: siteName, exact: true }).click();
+    await page.getByTestId("building-settings-name-input").fill(buildingName);
+    await page.getByTestId("building-settings-modal-save").click();
+
+    await test
+      .expect(page.getByTestId("toaster-container").getByText(`Building "${buildingName}" created`))
+      .toBeVisible();
+    return await getScopeIdFromRowName(page, buildingName, "building");
+  }
+
+  await openLegacySiteSettings(page, siteName);
+  await page.getByTestId("site-settings-add-building").click();
+  await test.expect(page.getByTestId("building-settings-modal")).toBeVisible();
+  await page.getByTestId("building-settings-name-input").fill(buildingName);
+  await page.getByTestId("building-settings-modal-save").click();
+
+  return await getLegacyBuildingIdFromName(page, buildingName);
+}
+
+async function deleteBuilding(page: Page, siteName: string, name: string, mode: SiteManagementMode) {
+  if (mode === "fleet") {
+    await openBuildingsManagementPage(page, mode);
+    await openRowActions(page, name);
+    await clickRowAction(page, "Edit building");
+    await page.getByTestId("manage-building-delete").click();
+    await page.getByTestId("building-delete-dialog-confirm").click();
+    await test.expect(page.getByTestId("toaster-container").getByText(`Building "${name}" deleted`)).toBeVisible();
+    return;
+  }
+
+  await openLegacySiteSettings(page, siteName);
+  const row = getLegacyBuildingRowByName(page, name);
+  await test.expect(row).toBeVisible();
+  await row.click();
+  await page.getByTestId("building-settings-modal-delete").click();
+  await page.getByTestId("building-delete-dialog-confirm").click();
+  await test
+    .expect(
+      page.locator('[data-testid^="site-settings-building-row-"]').filter({
+        has: page.getByText(name, { exact: true }),
+      }),
+    )
+    .toHaveCount(0);
+}
+
+async function createRack({
+  page,
+  racksPage,
+  label,
+  zone,
+}: {
+  page: Page;
+  racksPage: RacksPage;
+  label: string;
+  zone: string;
+}): Promise<bigint> {
+  await racksPage.navigateToRacksPage();
+  await racksPage.clickAddRackButton();
+  await racksPage.inputZone(zone);
+  await racksPage.inputRackLabel(label);
+  await racksPage.clickContinueFromRackSettings();
+  await racksPage.clickSaveRack();
+  await racksPage.validateRackToast(label);
+  await racksPage.clickViewList();
+  await racksPage.waitForRackListToLoad({ allowEmpty: false });
+  return await getScopeIdFromRowName(page, label, "rack");
+}
+
+async function assignRackToSite(page: Page, rackLabel: string, siteName: string) {
+  await page.goto("/fleet/racks");
+  await page.getByRole("button", { name: "View list", exact: true }).click();
+  await openRowActions(page, rackLabel);
+  await clickRowAction(page, "Add to site");
+  await selectParentPickerTarget(page, siteName);
+}
+
+async function assignRackToBuilding(page: Page, rackLabel: string, buildingName: string) {
+  await page.goto("/fleet/racks");
+  await page.getByRole("button", { name: "View list", exact: true }).click();
+  await openRowActions(page, rackLabel);
+  await clickRowAction(page, "Add to building");
+  await selectParentPickerTarget(page, buildingName);
+}
+
+async function moveSingleMinerToSite({
+  page,
+  minersPage,
+  minerIp,
+  siteName,
+}: {
+  page: Page;
+  minersPage: MinersPage;
+  minerIp: string;
+  siteName: string;
+}) {
+  await minersPage.clickMinerCheckbox(minerIp);
+  await minersPage.validateActionBarMinerCount(1);
+  await minersPage.clickActionsMenuButton();
+  await page.getByTestId("add-to-site-popover-button").click();
+  await selectParentPickerTarget(page, siteName);
+  await continueDialogIfVisible(page, "Move miners between sites?");
+}
+
+async function moveSingleMinerToRack({
+  page,
+  minersPage,
+  minerIp,
+  rackLabel,
+}: {
+  page: Page;
+  minersPage: MinersPage;
+  minerIp: string;
+  rackLabel: string;
+}) {
+  await minersPage.clickMinerCheckbox(minerIp);
+  await minersPage.validateActionBarMinerCount(1);
+  await minersPage.clickActionsMenuButton();
+  await page.getByTestId("add-to-rack-popover-button").click();
+  await selectParentPickerTarget(page, rackLabel);
+}
+
+async function assertSiteMinerCount({
+  page,
+  siteName,
+  mode,
+  expectedCount,
+}: {
+  page: Page;
+  siteName: string;
+  mode: SiteManagementMode;
+  expectedCount: number;
+}) {
+  await openSitesManagementPage(page, mode);
+
+  if (mode === "fleet") {
+    const row = getListRowByName(page, siteName);
+    await test.expect(row.getByTestId("miners")).toHaveText(String(expectedCount));
+    return;
+  }
+
+  const row = getLegacySiteRowByName(page, siteName);
+  await test.expect(row).toContainText(`${expectedCount} miners`);
+}
+
+async function assertRackPlacementForMode({
+  row,
+  mode,
+  siteName,
+  buildingName,
+}: {
+  row: ReturnType<typeof getListRowByName>;
+  mode: SiteManagementMode;
+  siteName: string;
+  buildingName: string;
+}) {
+  await test.expect(row).toBeVisible();
+
+  if (mode !== "fleet") {
+    return;
+  }
+
+  await test.expect(row.getByTestId("site")).toHaveText(siteName);
+  await test.expect(row.getByTestId("building")).toHaveText(buildingName);
+}
+
+async function assertRackMembershipForMode({
+  row,
+  mode,
+  targetSiteName,
+}: {
+  row: ReturnType<typeof getListRowByName>;
+  mode: SiteManagementMode;
+  targetSiteName: string;
+}) {
+  await test.expect(row).toBeVisible();
+  await test.expect(row.getByTestId("miners")).toHaveText("1");
+
+  if (mode !== "fleet") {
+    return;
+  }
+
+  await test.expect(row.getByTestId("site")).toHaveText(targetSiteName);
+}
+
+async function restoreMinerSiteIfNeeded({
+  page,
+  minersPage,
+  minerIp,
+  originalSiteLabel,
+}: {
+  page: Page;
+  minersPage: MinersPage;
+  minerIp: string;
+  originalSiteLabel?: string;
+}) {
+  if (!originalSiteLabel) {
+    return;
+  }
+
+  await page.goto("/fleet/miners");
+  await minersPage.waitForMinersListToLoad();
+  await moveSingleMinerToSite({ page, minersPage, minerIp, siteName: originalSiteLabel });
+}
+
+async function deleteRackIfCreated({
+  racksPage,
+  created,
+  rackLabel,
+}: {
+  racksPage: RacksPage;
+  created: boolean;
+  rackLabel: string;
+}) {
+  if (!created) {
+    return;
+  }
+
+  await racksPage.navigateToRacksPage();
+  await racksPage.tryAction(() => racksPage.clickViewList());
+  if (!(await racksPage.tryAction(() => racksPage.openRackFromList(rackLabel)))) {
+    return;
+  }
+
+  await racksPage.clickEditRack();
+  await racksPage.clickDeleteRack();
+  await racksPage.clickDeleteConfirm();
+  await racksPage.tryAction(() => racksPage.validateRackDeletedToast());
+}
+
+async function deleteBuildingIfCreated({
+  page,
+  created,
+  siteName,
+  buildingName,
+  mode,
+}: {
+  page: Page;
+  created: boolean;
+  siteName: string;
+  buildingName: string;
+  mode: SiteManagementMode;
+}) {
+  if (!created) {
+    return;
+  }
+
+  await deleteBuilding(page, siteName, buildingName, mode);
+}
+
+async function deleteSiteIfCreated({
+  page,
+  created,
+  siteName,
+  mode,
+}: {
+  page: Page;
+  created: boolean;
+  siteName: string;
+  mode: SiteManagementMode;
+}) {
+  if (!created) {
+    return;
+  }
+
+  await deleteSite(page, siteName, mode);
+}
+
+test.describe("Miners reparent", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("Move a rack to a building from the Racks tab", async ({ page, commonSteps, racksPage }) => {
+    await commonSteps.loginAsAdmin();
+
+    const siteManagementMode = await detectSiteManagementMode(page);
+    const siteName = generateRandomText("reparent_site");
+    const buildingName = generateRandomText("reparent_building");
+    const rackLabel = generateRandomText("reparent_rack");
+
+    let createdSite = false;
+    let createdBuilding = false;
+    let createdRack = false;
+
+    try {
+      await createSite(page, siteName, siteManagementMode);
+      createdSite = true;
+      const buildingId = await createBuilding(page, siteName, buildingName, siteManagementMode);
+      createdBuilding = true;
+      const rackId = await createRack({ page, racksPage, label: rackLabel, zone: TEMP_ZONE });
+      createdRack = true;
+
+      const requestPromise = page.waitForRequest(new RegExp(ASSIGN_RACKS_TO_BUILDING));
+      const responsePromise = page.waitForResponse(new RegExp(ASSIGN_RACKS_TO_BUILDING));
+
+      await test.step("Move the rack into the target building", async () => {
+        await assignRackToBuilding(page, rackLabel, buildingName);
+      });
+
+      await test.step("Validate the rack move request and resulting row placement", async () => {
+        const request = await requestPromise;
+        const response = await responsePromise;
+        const body = request.postDataJSON() as {
+          targetBuildingId?: string;
+          racks: Array<{ rackId?: string }>;
+        };
+
+        test.expect(String(body.targetBuildingId)).toBe(buildingId.toString());
+        test.expect(body.racks).toHaveLength(1);
+        test.expect(String(body.racks[0]?.rackId)).toBe(rackId.toString());
+        test.expect(response.status()).toBe(200);
+
+        await racksPage.navigateToRacksPage();
+        await racksPage.clickViewList();
+        await racksPage.waitForRackListToLoad({ allowEmpty: false });
+        const row = getListRowByName(page, rackLabel);
+        await assertRackPlacementForMode({ row, mode: siteManagementMode, siteName, buildingName });
+      });
+    } finally {
+      await deleteRackIfCreated({ racksPage, created: createdRack, rackLabel });
+      await deleteBuildingIfCreated({
+        page,
+        created: createdBuilding,
+        siteName,
+        buildingName,
+        mode: siteManagementMode,
+      });
+      await deleteSiteIfCreated({ page, created: createdSite, siteName, mode: siteManagementMode });
+    }
+  });
+
+  test("Assign a single miner to a site from the Miners tab", async ({ page, commonSteps, minersPage }) => {
+    await commonSteps.loginAsAdmin();
+
+    const siteManagementMode = await detectSiteManagementMode(page);
+    const targetSiteName = generateRandomText("miner_site");
+    let createdSite = false;
+    let originalSiteLabel: string | undefined;
+
+    try {
+      const snapshots = await loadVisibleMiners({ page, commonSteps });
+      const miner = pickUnrackedPairedMiner(snapshots);
+      originalSiteLabel = miner.siteLabel || undefined;
+
+      const targetSiteId = await createSite(page, targetSiteName, siteManagementMode);
+      createdSite = true;
+
+      const requestPromise = page.waitForRequest(new RegExp(ASSIGN_DEVICES_TO_SITE));
+      const responsePromise = page.waitForResponse(new RegExp(ASSIGN_DEVICES_TO_SITE));
+
+      await page.goto("/fleet/miners");
+      await minersPage.waitForMinersListToLoad();
+
+      await test.step("Move one unracked miner into the target site", async () => {
+        await moveSingleMinerToSite({ page, minersPage, minerIp: miner.ipAddress, siteName: targetSiteName });
+      });
+
+      await test.step("Validate the request and the target site miner count", async () => {
+        const request = await requestPromise;
+        const response = await responsePromise;
+        const body = request.postDataJSON() as {
+          targetSiteId?: string;
+          deviceIdentifiers?: string[];
+        };
+
+        test.expect(String(body.targetSiteId)).toBe(targetSiteId.toString());
+        test.expect(body.deviceIdentifiers).toEqual([miner.deviceIdentifier]);
+        test.expect(response.status()).toBe(200);
+
+        await assertSiteMinerCount({
+          page,
+          siteName: targetSiteName,
+          mode: siteManagementMode,
+          expectedCount: 1,
+        });
+      });
+
+      await restoreMinerSiteIfNeeded({
+        page,
+        minersPage,
+        minerIp: miner.ipAddress,
+        originalSiteLabel,
+      });
+    } finally {
+      await deleteSiteIfCreated({ page, created: createdSite, siteName: targetSiteName, mode: siteManagementMode });
+    }
+  });
+
+  test("Assign a single miner to a rack from the Miners tab", async ({ page, commonSteps, minersPage, racksPage }) => {
+    await commonSteps.loginAsAdmin();
+
+    const siteManagementMode = await detectSiteManagementMode(page);
+    const targetSiteName = generateRandomText("rack_site");
+    const rackLabel = generateRandomText("miner_rack");
+
+    let createdSite = false;
+    let createdRack = false;
+    let originalSiteLabel: string | undefined;
+
+    try {
+      const snapshots = await loadVisibleMiners({ page, commonSteps });
+      const miner = pickUnrackedPairedMiner(snapshots);
+      originalSiteLabel = miner.siteLabel || undefined;
+
+      await createSite(page, targetSiteName, siteManagementMode);
+      createdSite = true;
+      const rackId = await createRack({ page, racksPage, label: rackLabel, zone: TEMP_ZONE });
+      createdRack = true;
+      await assignRackToSite(page, rackLabel, targetSiteName);
+
+      const requestPromise = page.waitForRequest(new RegExp(ASSIGN_DEVICES_TO_RACK));
+      const responsePromise = page.waitForResponse(new RegExp(ASSIGN_DEVICES_TO_RACK));
+
+      await page.goto("/fleet/miners");
+      await minersPage.waitForMinersListToLoad();
+
+      await test.step("Move one unracked miner into the target rack", async () => {
+        await moveSingleMinerToRack({ page, minersPage, minerIp: miner.ipAddress, rackLabel });
+      });
+
+      await test.step("Validate the request and target rack miner count", async () => {
+        const request = await requestPromise;
+        const response = await responsePromise;
+        const body = request.postDataJSON() as {
+          targetRackId?: string;
+          deviceSelector?: {
+            deviceList?: {
+              deviceIdentifiers?: string[];
+            };
+          };
+        };
+
+        test.expect(String(body.targetRackId)).toBe(rackId.toString());
+        test.expect(body.deviceSelector?.deviceList?.deviceIdentifiers).toEqual([miner.deviceIdentifier]);
+        test.expect(response.status()).toBe(200);
+
+        await racksPage.navigateToRacksPage();
+        await racksPage.clickViewList();
+        await racksPage.waitForRackListToLoad({ allowEmpty: false });
+        const row = getListRowByName(page, rackLabel);
+        await assertRackMembershipForMode({ row, mode: siteManagementMode, targetSiteName });
+      });
+
+      await restoreMinerSiteIfNeeded({
+        page,
+        minersPage,
+        minerIp: miner.ipAddress,
+        originalSiteLabel,
+      });
+    } finally {
+      await deleteRackIfCreated({ racksPage, created: createdRack, rackLabel });
+      await deleteSiteIfCreated({ page, created: createdSite, siteName: targetSiteName, mode: siteManagementMode });
+    }
+  });
+});

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -139,6 +139,7 @@ test.describe("Miners reparent", () => {
 
     try {
       miner = await captureMovableMiner({ page, commonSteps, minersPage });
+      const selectedMiner = miner;
       const targetSiteId = await fleetLocationsPage.createSite(targetSiteName);
       createdSite = true;
 
@@ -149,7 +150,7 @@ test.describe("Miners reparent", () => {
       await minersPage.waitForMinersListToLoad();
 
       await test.step("Move one miner into the target site", async () => {
-        await minersPage.clickMinerCheckbox(miner.ipAddress);
+        await minersPage.clickMinerCheckbox(selectedMiner.ipAddress);
         await minersPage.validateActionBarMinerCount(1);
         await minersPage.assignSelectedMinersToSite(targetSiteName);
       });
@@ -163,7 +164,7 @@ test.describe("Miners reparent", () => {
         };
 
         test.expect(String(body.targetSiteId)).toBe(targetSiteId.toString());
-        expectSingleDeviceIdentifier(body.deviceIdentifiers, miner.deviceIdentifier);
+        expectSingleDeviceIdentifier(body.deviceIdentifiers, selectedMiner.deviceIdentifier);
         test.expect(response.status()).toBe(200);
 
         await fleetLocationsPage.validateSiteMinerCount(targetSiteName, 1);
@@ -190,6 +191,7 @@ test.describe("Miners reparent", () => {
 
     try {
       miner = await captureMovableMiner({ page, commonSteps, minersPage });
+      const selectedMiner = miner;
       const targetSiteId = await fleetLocationsPage.createSite(targetSiteName);
       createdSite = true;
       const rackId = await racksPage.createRack({
@@ -227,7 +229,7 @@ test.describe("Miners reparent", () => {
       await minersPage.waitForMinersListToLoad();
 
       await test.step("Move one miner into the target rack", async () => {
-        await minersPage.clickMinerCheckbox(miner.ipAddress);
+        await minersPage.clickMinerCheckbox(selectedMiner.ipAddress);
         await minersPage.validateActionBarMinerCount(1);
         await minersPage.assignSelectedMinersToRack(rackLabel);
       });
@@ -245,7 +247,10 @@ test.describe("Miners reparent", () => {
         };
 
         test.expect(String(body.targetRackId)).toBe(rackId.toString());
-        expectSingleDeviceIdentifier(body.deviceSelector?.deviceList?.deviceIdentifiers, miner.deviceIdentifier);
+        expectSingleDeviceIdentifier(
+          body.deviceSelector?.deviceList?.deviceIdentifiers,
+          selectedMiner.deviceIdentifier,
+        );
         test.expect(response.status()).toBe(200);
 
         await racksPage.navigateToRacksPage();

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -25,10 +25,16 @@ type VisibleMinerSnapshot = {
   };
 };
 
+type VisibleMinerCandidate = Pick<
+  VisibleMinerSnapshot,
+  "ipAddress" | "deviceIdentifier" | "rackPosition" | "placement"
+>;
+
 const LIST_MINERS_RESPONSE = "ListMinerStateSnapshots";
 const ASSIGN_DEVICES_TO_SITE = "AssignDevicesToSite";
 const ASSIGN_DEVICES_TO_RACK = "AssignDevicesToRack";
 const ASSIGN_RACKS_TO_BUILDING = "AssignRacksToBuilding";
+const ASSIGN_RACKS_TO_SITE = "AssignRacksToSite";
 const TEMP_ZONE = "ReparentAutomationZone";
 const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
 
@@ -94,6 +100,18 @@ async function clickAddSiteButton(page: Page) {
   const emptyStateAddSiteButton = page.getByRole("button", { name: "Add a site", exact: true });
   await test.expect(emptyStateAddSiteButton).toBeVisible();
   await emptyStateAddSiteButton.click();
+}
+
+async function clickAddBuildingButton(page: Page) {
+  const headerAddBuildingButton = page.getByTestId("fleet-buildings-add");
+  if (await headerAddBuildingButton.isVisible().catch(() => false)) {
+    await headerAddBuildingButton.click();
+    return;
+  }
+
+  const emptyStateAddBuildingButton = page.getByRole("button", { name: "Add building", exact: true });
+  await test.expect(emptyStateAddBuildingButton).toBeVisible();
+  await emptyStateAddBuildingButton.click();
 }
 
 async function detectSiteManagementMode(page: Page): Promise<SiteManagementMode> {
@@ -268,12 +286,7 @@ function normalizePlacementLabel(value: string | null | undefined): string | und
   return isBlankListCell(value) ? undefined : value?.trim();
 }
 
-async function isMinerSafeToRestore(page: Page, miner: VisibleMinerSnapshot): Promise<boolean> {
-  const row = getMinerRowByIp(page, miner.ipAddress);
-  if (!(await row.isVisible().catch(() => false))) {
-    return false;
-  }
-
+async function rowHasBlankBuildingAndRack(row: ReturnType<typeof getMinerRowByIp>): Promise<boolean> {
   const buildingText = await row
     .getByTestId("building")
     .textContent()
@@ -285,20 +298,44 @@ async function isMinerSafeToRestore(page: Page, miner: VisibleMinerSnapshot): Pr
   return isBlankListCell(buildingText) && isBlankListCell(rackText);
 }
 
-async function pickUnrackedPairedMiner(page: Page, miners: VisibleMinerSnapshot[]): Promise<VisibleMinerSnapshot> {
-  for (const miner of miners) {
-    if (miner.pairingStatus !== PairingStatus.PAIRED) {
+async function hasAuthenticationRequiredIssue(row: ReturnType<typeof getMinerRowByIp>): Promise<boolean> {
+  return (
+    (await row
+      .getByRole("button", { name: "Authentication required", exact: true })
+      .count()
+      .catch(() => 0)) > 0
+  );
+}
+
+async function pickUnrackedPairedMiner(page: Page, miners: VisibleMinerSnapshot[]): Promise<VisibleMinerCandidate> {
+  const rows = page.getByTestId("list-body").locator("tr");
+  const rowCount = await rows.count();
+
+  for (let index = 0; index < rowCount; index++) {
+    const row = rows.nth(index);
+    const ipAddress = normalizePlacementLabel(
+      await row
+        .getByTestId("ipAddress")
+        .textContent()
+        .catch(() => null),
+    );
+    if (!ipAddress) {
       continue;
     }
-    if (await isMinerSafeToRestore(page, miner)) {
-      return miner;
-    }
-  }
 
-  for (const miner of miners) {
-    if (await isMinerSafeToRestore(page, miner)) {
+    if (!(await rowHasBlankBuildingAndRack(getMinerRowByIp(page, ipAddress)))) {
+      continue;
+    }
+    if (await hasAuthenticationRequiredIssue(getMinerRowByIp(page, ipAddress))) {
+      continue;
+    }
+
+    const miner = miners.find((snapshot) => snapshot.ipAddress === ipAddress);
+    if (miner) {
       return miner;
     }
+
+    return { ipAddress };
   }
 
   throw new Error("Expected at least one visible miner without building or rack placement for reparent coverage");
@@ -339,10 +376,7 @@ async function createBuilding(
 ): Promise<bigint> {
   void mode;
   await openBuildingsManagementPage(page, "fleet");
-
-  const addBuildingButton = page.getByTestId("fleet-buildings-add");
-  await test.expect(addBuildingButton).toBeVisible();
-  await addBuildingButton.click();
+  await clickAddBuildingButton(page);
   await page.getByTestId("building-settings-site-select").click();
   await page.getByRole("option", { name: siteName, exact: true }).click();
   await page.getByTestId("building-settings-name-input").fill(buildingName);
@@ -382,6 +416,9 @@ async function createRack({
   await racksPage.clickAddRackButton();
   await racksPage.inputZone(zone);
   await racksPage.inputRackLabel(label);
+  await racksPage.enableCustomRackLayout();
+  await racksPage.inputColumns(2);
+  await racksPage.inputRows(2);
   await racksPage.clickContinueFromRackSettings();
   await racksPage.clickSaveRack();
   await racksPage.validateRackToast(label);
@@ -489,6 +526,15 @@ async function assertRackMembershipForMode({
   await test.expect(row.getByTestId("miners")).toHaveText("1");
   void mode;
   await test.expect(row.getByTestId("site")).toHaveText(targetSiteName);
+}
+
+function expectSingleDeviceIdentifier(actual: string[] | undefined, expected?: string) {
+  if (expected) {
+    test.expect(actual).toEqual([expected]);
+    return;
+  }
+
+  test.expect(actual).toHaveLength(1);
 }
 
 async function restoreMinerSiteIfNeeded({
@@ -790,7 +836,7 @@ test.describe("Miners reparent", () => {
         };
 
         test.expect(String(body.targetSiteId)).toBe(targetSiteId.toString());
-        test.expect(body.deviceIdentifiers).toEqual([miner.deviceIdentifier]);
+        expectSingleDeviceIdentifier(body.deviceIdentifiers, miner.deviceIdentifier);
         test.expect(response.status()).toBe(200);
 
         await assertSiteMinerCount({
@@ -846,7 +892,11 @@ test.describe("Miners reparent", () => {
       createdSite = true;
       const rackId = await createRack({ page, racksPage, label: rackLabel, zone: TEMP_ZONE });
       createdRack = true;
+      const rackSiteRequestPromise = page.waitForRequest(new RegExp(ASSIGN_RACKS_TO_SITE));
+      const rackSiteResponsePromise = page.waitForResponse(new RegExp(ASSIGN_RACKS_TO_SITE));
       await assignRackToSite(page, rackLabel, targetSiteName);
+      await rackSiteRequestPromise;
+      await rackSiteResponsePromise;
 
       const requestPromise = page.waitForRequest(new RegExp(ASSIGN_DEVICES_TO_RACK));
       const responsePromise = page.waitForResponse(new RegExp(ASSIGN_DEVICES_TO_RACK));
@@ -871,7 +921,7 @@ test.describe("Miners reparent", () => {
         };
 
         test.expect(String(body.targetRackId)).toBe(rackId.toString());
-        test.expect(body.deviceSelector?.deviceList?.deviceIdentifiers).toEqual([miner.deviceIdentifier]);
+        expectSingleDeviceIdentifier(body.deviceSelector?.deviceList?.deviceIdentifiers, miner.deviceIdentifier);
         test.expect(response.status()).toBe(200);
 
         await racksPage.navigateToRacksPage();

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -67,7 +67,11 @@ async function resetActiveSiteSelection(page: Page) {
 
 async function selectAllSitesIfNeeded(page: Page) {
   const sitePickerTrigger = page.getByTestId("site-picker-trigger");
-  await test.expect(sitePickerTrigger).toBeVisible();
+  if (!(await sitePickerTrigger.isVisible().catch(() => false))) {
+    await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
+    await test.expect(page.getByTestId("fleet-sites-add")).toBeVisible();
+    return;
+  }
 
   const currentLabel = (await sitePickerTrigger.textContent())?.trim();
   if (currentLabel === "All sites") {
@@ -90,12 +94,19 @@ async function detectSiteManagementMode(page: Page): Promise<SiteManagementMode>
 async function openSitesManagementPage(page: Page, mode: SiteManagementMode) {
   void mode;
   await page.goto("/fleet/sites");
-  await selectAllSitesIfNeeded(page);
-  await page.goto("/fleet/sites");
   await test.expect(page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
-  await test.expect(page.getByTestId("site-picker-trigger")).toContainText("All sites");
   await test.expect(page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
   await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
+  await selectAllSitesIfNeeded(page);
+
+  const sitePickerTrigger = page.getByTestId("site-picker-trigger");
+  if (await sitePickerTrigger.isVisible().catch(() => false)) {
+    await page.goto("/fleet/sites");
+    await test.expect(page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
+    await test.expect(page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
+    await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
+    await test.expect(sitePickerTrigger).toContainText("All sites");
+  }
 }
 
 async function openBuildingsManagementPage(page: Page, mode: SiteManagementMode) {
@@ -240,6 +251,10 @@ async function loadVisibleMiners({
 function isBlankListCell(value: string | null | undefined): boolean {
   const normalized = value?.trim();
   return normalized === undefined || normalized === "" || normalized === "—";
+}
+
+function normalizePlacementLabel(value: string | null | undefined): string | undefined {
+  return isBlankListCell(value) ? undefined : value?.trim();
 }
 
 async function isMinerSafeToRestore(page: Page, miner: VisibleMinerSnapshot): Promise<boolean> {
@@ -735,13 +750,12 @@ test.describe("Miners reparent", () => {
       const miner = await pickUnrackedPairedMiner(page, snapshots);
       const minerRow = getMinerRowByIp(page, miner.ipAddress);
       minerIp = miner.ipAddress;
-      originalSiteLabel =
-        (
-          await minerRow
-            .getByTestId("site")
-            .textContent()
-            .catch(() => null)
-        )?.trim() || undefined;
+      originalSiteLabel = normalizePlacementLabel(
+        await minerRow
+          .getByTestId("site")
+          .textContent()
+          .catch(() => null),
+      );
       originalRackLabel = miner.placement?.rack?.label || undefined;
       originalRackPosition = miner.rackPosition || undefined;
 
@@ -810,13 +824,12 @@ test.describe("Miners reparent", () => {
       const miner = await pickUnrackedPairedMiner(page, snapshots);
       const minerRow = getMinerRowByIp(page, miner.ipAddress);
       minerIp = miner.ipAddress;
-      originalSiteLabel =
-        (
-          await minerRow
-            .getByTestId("site")
-            .textContent()
-            .catch(() => null)
-        )?.trim() || undefined;
+      originalSiteLabel = normalizePlacementLabel(
+        await minerRow
+          .getByTestId("site")
+          .textContent()
+          .catch(() => null),
+      );
       originalRackLabel = miner.placement?.rack?.label || undefined;
       originalRackPosition = miner.rackPosition || undefined;
 

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -25,10 +25,12 @@ type VisibleMinerSnapshot = {
   };
 };
 
-type VisibleMinerCandidate = Pick<
-  VisibleMinerSnapshot,
-  "ipAddress" | "deviceIdentifier" | "rackPosition" | "placement"
->;
+type VisibleMinerCandidate = {
+  ipAddress: string;
+  deviceIdentifier?: string;
+  rackPosition?: string;
+  placement?: VisibleMinerSnapshot["placement"];
+};
 
 const LIST_MINERS_RESPONSE = "ListMinerStateSnapshots";
 const ASSIGN_DEVICES_TO_SITE = "AssignDevicesToSite";

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -6,7 +6,7 @@ import { type MinersPage } from "../pages/miners";
 import { type RacksPage } from "../pages/racks";
 import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
-type SiteManagementMode = "fleet" | "legacy";
+type SiteManagementMode = "fleet";
 
 type VisibleMinerSnapshot = {
   deviceIdentifier: string;
@@ -33,20 +33,6 @@ function getListRowByName(page: Page, name: string) {
     .first();
 }
 
-function getLegacySiteRowByName(page: Page, name: string) {
-  return page
-    .locator('button[data-testid^="sites-all-table-row-"]')
-    .filter({ has: page.getByText(name, { exact: true }) })
-    .first();
-}
-
-function getLegacyBuildingRowByName(page: Page, name: string) {
-  return page
-    .locator('[data-testid^="site-settings-building-row-"]')
-    .filter({ has: page.getByText(name, { exact: true }) })
-    .first();
-}
-
 async function resetActiveSiteSelection(page: Page) {
   await page.evaluate(
     ({ storageKey }) => {
@@ -66,63 +52,87 @@ async function resetActiveSiteSelection(page: Page) {
   );
 }
 
-async function detectSiteManagementMode(page: Page): Promise<SiteManagementMode> {
-  await resetActiveSiteSelection(page);
-  await page.goto("/fleet/racks");
-  await test.expect(page).toHaveURL(/\/fleet\/racks(?:[?#].*)?$/);
-
-  const sitesTab = page.getByRole("tab", { name: "Sites", exact: true });
-  return (await sitesTab.isVisible().catch(() => false)) ? "fleet" : "legacy";
-}
-
-async function openSitesManagementPage(page: Page, mode: SiteManagementMode) {
-  await resetActiveSiteSelection(page);
-
-  if (mode === "fleet") {
-    await page.goto("/fleet/sites");
-    await test.expect(page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
-    await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
+async function selectAllSitesIfNeeded(page: Page) {
+  const sitePickerTrigger = page.getByTestId("site-picker-trigger");
+  if (!(await sitePickerTrigger.isVisible().catch(() => false))) {
     return;
   }
 
-  await page.goto("/settings/sites");
-  await test.expect(page).toHaveURL(/\/settings\/sites(?:[?#].*)?$/);
-  await test.expect(page.getByTestId("settings-sites-page")).toBeVisible();
+  const currentLabel = (await sitePickerTrigger.textContent())?.trim();
+  if (currentLabel === "All sites") {
+    return;
+  }
+
+  await sitePickerTrigger.click();
+  const allSitesOption = page.getByTestId("site-picker-option-all");
+  await test.expect(allSitesOption).toBeVisible();
+  await allSitesOption.click();
+  await test.expect(sitePickerTrigger).toContainText("All sites");
+}
+
+async function detectSiteManagementMode(page: Page): Promise<SiteManagementMode> {
+  await resetActiveSiteSelection(page);
+  await openSitesManagementPage(page, "fleet");
+  return "fleet";
+}
+
+async function openSitesManagementPage(page: Page, mode: SiteManagementMode) {
+  void mode;
+  await page.goto("/fleet/sites");
+  await selectAllSitesIfNeeded(page);
+  await page.goto("/fleet/sites");
+  await test.expect(page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
+  await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
 }
 
 async function openBuildingsManagementPage(page: Page, mode: SiteManagementMode) {
-  if (mode !== "fleet") {
-    throw new Error("Legacy ProtoFleet does not expose a standalone buildings management page");
-  }
-
-  await resetActiveSiteSelection(page);
+  await openSitesManagementPage(page, mode);
   await page.goto("/fleet/buildings");
   await test.expect(page).toHaveURL(/\/fleet\/buildings(?:[?#].*)?$/);
   await test.expect(page.getByTestId("fleet-buildings-page")).toBeVisible();
 }
 
-async function openLegacySiteSettings(page: Page, siteName: string) {
-  await openSitesManagementPage(page, "legacy");
-
-  const row = getLegacySiteRowByName(page, siteName);
-  await test.expect(row).toBeVisible();
-  await row.click();
-
-  await test.expect(page.getByTestId("site-settings-single-view")).toBeVisible();
-  await test.expect(page.getByText(siteName, { exact: true })).toBeVisible();
-}
-
-async function clickManageSiteEditDetails(page: Page) {
-  const editDetailsButton = page.locator('[data-testid="manage-site-modal-edit-details"]:visible');
-  if (await editDetailsButton.isVisible().catch(() => false)) {
-    await editDetailsButton.click();
-    return;
-  }
-
+async function openFullScreenOverflowMenu(page: Page) {
   const overflowTrigger = page.getByTestId("full-screen-two-pane-modal").getByTestId("overflow-menu-trigger");
   await test.expect(overflowTrigger).toBeVisible();
   await overflowTrigger.click();
-  await page.locator("div.fixed.inset-0.z-60").getByText("Edit details", { exact: true }).click();
+  return page.locator("div.fixed.inset-0.z-60");
+}
+
+async function clickManageSiteDelete(page: Page) {
+  const manageSiteDeleteButton = page.locator('[data-testid="manage-site-modal-delete"]:visible');
+  if (await manageSiteDeleteButton.isVisible().catch(() => false)) {
+    await manageSiteDeleteButton.click();
+    return;
+  }
+
+  const siteSettingsDeleteButton = page.locator('[data-testid="site-settings-modal-delete"]:visible');
+  if (await siteSettingsDeleteButton.isVisible().catch(() => false)) {
+    await siteSettingsDeleteButton.click();
+    return;
+  }
+
+  const overflowMenu = await openFullScreenOverflowMenu(page);
+  const deleteSiteAction = overflowMenu.getByText("Delete site", { exact: true });
+  if (await deleteSiteAction.isVisible().catch(() => false)) {
+    await deleteSiteAction.click();
+    return;
+  }
+
+  await overflowMenu.getByText("Site settings", { exact: true }).click();
+  await test.expect(siteSettingsDeleteButton).toBeVisible();
+  await siteSettingsDeleteButton.click();
+}
+
+async function clickManageBuildingDelete(page: Page) {
+  const deleteButton = page.locator('[data-testid="manage-building-delete"]:visible');
+  if (await deleteButton.isVisible().catch(() => false)) {
+    await deleteButton.click();
+    return;
+  }
+
+  const overflowMenu = await openFullScreenOverflowMenu(page);
+  await overflowMenu.getByText("Delete building", { exact: true }).click();
 }
 
 async function getScopeIdFromRowName(page: Page, name: string, scope: "site" | "building" | "rack"): Promise<bigint> {
@@ -140,32 +150,6 @@ async function getScopeIdFromRowName(page: Page, name: string, scope: "site" | "
   const capturedId = testId?.match(pattern)?.[1];
   if (!capturedId) {
     throw new Error(`Could not parse ${scope} id from row action trigger: ${testId ?? "missing test id"}`);
-  }
-
-  return BigInt(capturedId);
-}
-
-async function getLegacySiteIdFromName(page: Page, name: string): Promise<bigint> {
-  const row = getLegacySiteRowByName(page, name);
-  await test.expect(row).toBeVisible();
-
-  const testId = await row.getAttribute("data-testid");
-  const capturedId = testId?.match(/^sites-all-table-row-(\d+)$/)?.[1];
-  if (!capturedId) {
-    throw new Error(`Could not parse site id from settings sites row: ${testId ?? "missing test id"}`);
-  }
-
-  return BigInt(capturedId);
-}
-
-async function getLegacyBuildingIdFromName(page: Page, name: string): Promise<bigint> {
-  const row = getLegacyBuildingRowByName(page, name);
-  await test.expect(row).toBeVisible();
-
-  const testId = await row.getAttribute("data-testid");
-  const capturedId = testId?.match(/^site-settings-building-row-(\d+)$/)?.[1];
-  if (!capturedId) {
-    throw new Error(`Could not parse building id from site settings row: ${testId ?? "missing test id"}`);
   }
 
   return BigInt(capturedId);
@@ -255,56 +239,28 @@ function pickUnrackedPairedMiner(miners: VisibleMinerSnapshot[]): VisibleMinerSn
 
 async function createSite(page: Page, name: string, mode: SiteManagementMode): Promise<bigint> {
   await openSitesManagementPage(page, mode);
-
-  if (mode === "fleet") {
-    const addSiteButton = page.getByTestId("fleet-sites-add");
-    await test.expect(addSiteButton).toBeVisible();
-    await addSiteButton.click();
-    await page.getByTestId("site-settings-name-input").fill(name);
-    await page.getByTestId("site-settings-modal-continue").click();
-    const saveSiteButton = page.locator('[data-testid="manage-site-modal-save"]:visible');
-    await test.expect(saveSiteButton).toBeVisible();
-    await saveSiteButton.click();
-
-    await test.expect(page.getByTestId("toaster-container").getByText(`Site "${name}" created`)).toBeVisible();
-    return await getScopeIdFromRowName(page, name, "site");
-  }
-
-  await page.getByTestId("sites-page-header-add").click();
+  const addSiteButton = page.getByTestId("fleet-sites-add");
+  await test.expect(addSiteButton).toBeVisible();
+  await addSiteButton.click();
   await page.getByTestId("site-settings-name-input").fill(name);
   await page.getByTestId("site-settings-modal-continue").click();
   const saveSiteButton = page.locator('[data-testid="manage-site-modal-save"]:visible');
   await test.expect(saveSiteButton).toBeVisible();
   await saveSiteButton.click();
 
-  return await getLegacySiteIdFromName(page, name);
+  const row = getListRowByName(page, name);
+  await test.expect(row).toBeVisible();
+  return await getScopeIdFromRowName(page, name, "site");
 }
 
 async function deleteSite(page: Page, name: string, mode: SiteManagementMode) {
-  if (mode === "fleet") {
-    await openSitesManagementPage(page, mode);
-    await openRowActions(page, name);
-    await clickRowAction(page, "Edit site");
-    await clickManageSiteEditDetails(page);
-    await page.locator('[data-testid="site-settings-modal-delete"]:visible').click();
-    await page.getByTestId("site-delete-dialog-confirm").click();
-    await test.expect(page.getByTestId("toaster-container").getByText(`Site "${name}" deleted`)).toBeVisible();
-    return;
-  }
-
-  await openLegacySiteSettings(page, name);
-  await page.getByTestId("site-settings-manage").click();
-  await clickManageSiteEditDetails(page);
-  await page.locator('[data-testid="site-settings-modal-delete"]:visible').click();
+  void mode;
+  await openSitesManagementPage(page, "fleet");
+  await openRowActions(page, name);
+  await clickRowAction(page, "Edit site");
+  await clickManageSiteDelete(page);
   await page.getByTestId("site-delete-dialog-confirm").click();
-  await openSitesManagementPage(page, "legacy");
-  await test
-    .expect(
-      page
-        .locator('button[data-testid^="sites-all-table-row-"]')
-        .filter({ has: page.getByText(name, { exact: true }) }),
-    )
-    .toHaveCount(0);
+  await test.expect(getListRowByName(page, name)).toHaveCount(0);
 }
 
 async function createBuilding(
@@ -313,56 +269,31 @@ async function createBuilding(
   buildingName: string,
   mode: SiteManagementMode,
 ): Promise<bigint> {
-  if (mode === "fleet") {
-    await openBuildingsManagementPage(page, mode);
+  void mode;
+  await openBuildingsManagementPage(page, "fleet");
 
-    const addBuildingButton = page.getByTestId("fleet-buildings-add");
-    await test.expect(addBuildingButton).toBeVisible();
-    await addBuildingButton.click();
-    await page.getByTestId("building-settings-site-select").click();
-    await page.getByRole("option", { name: siteName, exact: true }).click();
-    await page.getByTestId("building-settings-name-input").fill(buildingName);
-    await page.getByTestId("building-settings-modal-save").click();
-
-    await test
-      .expect(page.getByTestId("toaster-container").getByText(`Building "${buildingName}" created`))
-      .toBeVisible();
-    return await getScopeIdFromRowName(page, buildingName, "building");
-  }
-
-  await openLegacySiteSettings(page, siteName);
-  await page.getByTestId("site-settings-add-building").click();
-  await test.expect(page.getByTestId("building-settings-modal")).toBeVisible();
+  const addBuildingButton = page.getByTestId("fleet-buildings-add");
+  await test.expect(addBuildingButton).toBeVisible();
+  await addBuildingButton.click();
+  await page.getByTestId("building-settings-site-select").click();
+  await page.getByRole("option", { name: siteName, exact: true }).click();
   await page.getByTestId("building-settings-name-input").fill(buildingName);
   await page.getByTestId("building-settings-modal-save").click();
 
-  return await getLegacyBuildingIdFromName(page, buildingName);
+  const row = getListRowByName(page, buildingName);
+  await test.expect(row).toBeVisible();
+  return await getScopeIdFromRowName(page, buildingName, "building");
 }
 
 async function deleteBuilding(page: Page, siteName: string, name: string, mode: SiteManagementMode) {
-  if (mode === "fleet") {
-    await openBuildingsManagementPage(page, mode);
-    await openRowActions(page, name);
-    await clickRowAction(page, "Edit building");
-    await page.getByTestId("manage-building-delete").click();
-    await page.getByTestId("building-delete-dialog-confirm").click();
-    await test.expect(page.getByTestId("toaster-container").getByText(`Building "${name}" deleted`)).toBeVisible();
-    return;
-  }
-
-  await openLegacySiteSettings(page, siteName);
-  const row = getLegacyBuildingRowByName(page, name);
-  await test.expect(row).toBeVisible();
-  await row.click();
-  await page.getByTestId("building-settings-modal-delete").click();
+  void siteName;
+  void mode;
+  await openBuildingsManagementPage(page, "fleet");
+  await openRowActions(page, name);
+  await clickRowAction(page, "Edit building");
+  await clickManageBuildingDelete(page);
   await page.getByTestId("building-delete-dialog-confirm").click();
-  await test
-    .expect(
-      page.locator('[data-testid^="site-settings-building-row-"]').filter({
-        has: page.getByText(name, { exact: true }),
-      }),
-    )
-    .toHaveCount(0);
+  await test.expect(getListRowByName(page, name)).toHaveCount(0);
 }
 
 async function createRack({
@@ -453,15 +384,8 @@ async function assertSiteMinerCount({
   expectedCount: number;
 }) {
   await openSitesManagementPage(page, mode);
-
-  if (mode === "fleet") {
-    const row = getListRowByName(page, siteName);
-    await test.expect(row.getByTestId("miners")).toHaveText(String(expectedCount));
-    return;
-  }
-
-  const row = getLegacySiteRowByName(page, siteName);
-  await test.expect(row).toContainText(`${expectedCount} miners`);
+  const row = getListRowByName(page, siteName);
+  await test.expect(row.getByTestId("miners")).toHaveText(String(expectedCount));
 }
 
 async function assertRackPlacementForMode({
@@ -476,11 +400,7 @@ async function assertRackPlacementForMode({
   buildingName: string;
 }) {
   await test.expect(row).toBeVisible();
-
-  if (mode !== "fleet") {
-    return;
-  }
-
+  void mode;
   await test.expect(row.getByTestId("site")).toHaveText(siteName);
   await test.expect(row.getByTestId("building")).toHaveText(buildingName);
 }
@@ -496,11 +416,7 @@ async function assertRackMembershipForMode({
 }) {
   await test.expect(row).toBeVisible();
   await test.expect(row.getByTestId("miners")).toHaveText("1");
-
-  if (mode !== "fleet") {
-    return;
-  }
-
+  void mode;
   await test.expect(row.getByTestId("site")).toHaveText(targetSiteName);
 }
 

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -1,857 +1,77 @@
-import { type Page, type Response as PlaywrightResponse } from "@playwright/test";
-import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
-import { type CommonSteps } from "../helpers/commonSteps";
+import {
+  captureMovableMiner,
+  expectSingleDeviceIdentifier,
+  installAllSitesInitScript,
+  type ReparentMiner,
+  restoreMinerPlacementIfNeeded,
+} from "../helpers/reparentHelpers";
 import { generateRandomText } from "../helpers/testDataHelper";
-import { type AddMinersPage } from "../pages/addMiners";
-import { type AuthPage } from "../pages/auth";
-import { type HomePage } from "../pages/home";
-import { type MinersPage } from "../pages/miners";
-import { type RacksPage } from "../pages/racks";
-import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
-type SiteManagementMode = "fleet";
-
-type PlacementRefSnapshot = {
-  id?: string;
-  label?: string;
-};
-
-type VisibleMinerSnapshot = {
-  deviceIdentifier: string;
-  ipAddress: string;
-  pairingStatus: PairingStatus;
-  rackPosition: string;
-  placement?: {
-    site?: PlacementRefSnapshot;
-    building?: PlacementRefSnapshot;
-    rack?: PlacementRefSnapshot;
-  };
-};
-
-type VisibleMinerCandidate = {
-  ipAddress: string;
-  deviceIdentifier?: string;
-  rackPosition?: string;
-  placement?: VisibleMinerSnapshot["placement"];
-};
-
-const LIST_MINERS_RESPONSE = "ListMinerStateSnapshots";
 const ASSIGN_DEVICES_TO_SITE = "AssignDevicesToSite";
 const ASSIGN_DEVICES_TO_RACK = "AssignDevicesToRack";
 const ASSIGN_RACKS_TO_BUILDING = "AssignRacksToBuilding";
 const ASSIGN_RACKS_TO_SITE = "AssignRacksToSite";
 const TEMP_ZONE = "ReparentAutomationZone";
-const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
-const EXPECTED_FAKE_NETWORK_MINER_COUNT = 14;
-
-function getListRowByName(page: Page, name: string) {
-  return page
-    .getByTestId("list-row")
-    .filter({ has: page.getByTestId("name").getByText(name, { exact: true }) })
-    .first();
-}
-
-function getMinerRowByIp(page: Page, ipAddress: string) {
-  return page
-    .getByTestId("list-row")
-    .filter({ has: page.getByText(ipAddress, { exact: true }) })
-    .first();
-}
-
-async function resetActiveSiteSelection(page: Page) {
-  await page.evaluate(
-    ({ storageKey }) => {
-      localStorage.setItem(
-        storageKey,
-        JSON.stringify({
-          state: {
-            ui: {
-              activeSite: { kind: "all" },
-            },
-          },
-          version: 0,
-        }),
-      );
-    },
-    { storageKey: ACTIVE_SITE_STORAGE_KEY },
-  );
-}
-
-async function ensureAdminSession({
-  page,
-  authPage,
-  commonSteps,
-}: {
-  page: Page;
-  authPage: AuthPage;
-  commonSteps: CommonSteps;
-}) {
-  await page.goto("/");
-
-  if (await authPage.isAlreadyLoggedIn()) {
-    return;
-  }
-
-  const createCredentialsPrompt = page.getByText("Create your username and password", { exact: true });
-  if (await createCredentialsPrompt.isVisible().catch(() => false)) {
-    await authPage.inputUsername(testConfig.users.admin.username);
-    await authPage.inputPassword(testConfig.users.admin.password);
-    await authPage.clickContinue();
-    await authPage.validateLoggedIn();
-    return;
-  }
-
-  await commonSteps.loginAsAdmin();
-}
-
-async function ensureFleetInventory({
-  authPage,
-  addMinersPage,
-  minersPage,
-}: {
-  authPage: AuthPage;
-  addMinersPage: AddMinersPage;
-  minersPage: MinersPage;
-}) {
-  await minersPage.navigateToMinersPage();
-  if (await minersPage.tryAction(() => minersPage.waitForMinersListToLoad(), 3000)) {
-    return;
-  }
-
-  await authPage.clickGetStarted();
-  await addMinersPage.clickFindMinersInNetwork();
-  await addMinersPage.waitForExpectedNetworkMinerCount(EXPECTED_FAKE_NETWORK_MINER_COUNT);
-  await addMinersPage.clickContinueWithXMiners(EXPECTED_FAKE_NETWORK_MINER_COUNT);
-  await minersPage.waitForMinersListToLoad();
-}
-
-async function ensureAuthenticatedMovableMiners({
-  page,
-  homePage,
-  minersPage,
-}: {
-  page: Page;
-  homePage: HomePage;
-  minersPage: MinersPage;
-}) {
-  const authenticatedMinerCheckboxes = page.locator(
-    '[data-testid="list-body"] tr input[type="checkbox"]:not([disabled])',
-  );
-  if ((await authenticatedMinerCheckboxes.count().catch(() => 0)) > 0) {
-    return;
-  }
-
-  await page.goto("/dashboard");
-
-  const authenticateButton = page.getByRole("button", { name: "Authenticate", exact: true });
-  if (!(await authenticateButton.isVisible().catch(() => false))) {
-    throw new Error("Expected at least one authenticated miner or an authentication prompt on the dashboard");
-  }
-
-  await homePage.clickAuthenticateMinersButton();
-  await homePage.validateAuthenticateMinersModalTitle();
-  await homePage.clickShowMinersButton();
-
-  const miners = await homePage.getListOfMinersToAuthenticate();
-
-  if (miners.some((miner) => miner.includes("S19 XP"))) {
-    await homePage.inputMinerAuthUsername("root19");
-    await homePage.inputMinerAuthPassword("root19");
-    await homePage.clickAuthenticateMinersConfirmButton();
-    await homePage.tryAction(() => homePage.clickCalloutButton());
-  }
-
-  if (miners.some((miner) => miner.includes("S21 XP"))) {
-    await homePage.inputMinerAuthUsername("root21");
-    await homePage.inputMinerAuthPassword("root21");
-    await homePage.clickAuthenticateMinersConfirmButton();
-    await homePage.tryAction(() => homePage.clickCalloutButton());
-  }
-
-  if (miners.some((miner) => miner.includes("S17 XP"))) {
-    await homePage.inputMinerAuthUsername("root17");
-    await homePage.inputMinerAuthPassword("root17");
-    await homePage.clickAuthenticateMinersConfirmButton();
-    await homePage.tryAction(() => homePage.clickCalloutButton());
-  }
-
-  await page.goto("/fleet/miners");
-  await minersPage.waitForMinersListToLoad();
-
-  if ((await authenticatedMinerCheckboxes.count().catch(() => 0)) === 0) {
-    throw new Error("Expected at least one authenticated miner after standalone reparent setup");
-  }
-}
-
-async function selectAllSitesIfNeeded(page: Page) {
-  const sitePickerTrigger = page.getByTestId("site-picker-trigger");
-  if (!(await sitePickerTrigger.isVisible().catch(() => false))) {
-    await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
-    return;
-  }
-
-  const currentLabel = (await sitePickerTrigger.textContent())?.trim();
-  if (currentLabel === "All sites") {
-    return;
-  }
-
-  await sitePickerTrigger.click();
-  const allSitesOption = page.getByTestId("site-picker-option-all");
-  await test.expect(allSitesOption).toBeVisible();
-  await allSitesOption.click();
-  await test.expect(sitePickerTrigger).toContainText("All sites");
-}
-
-async function clickAddSiteButton(page: Page) {
-  const headerAddSiteButton = page.getByTestId("fleet-sites-add");
-  if (await headerAddSiteButton.isVisible().catch(() => false)) {
-    await headerAddSiteButton.click();
-    return;
-  }
-
-  const emptyStateAddSiteButton = page.getByRole("button", { name: "Add a site", exact: true });
-  await test.expect(emptyStateAddSiteButton).toBeVisible();
-  await emptyStateAddSiteButton.click();
-}
-
-async function clickAddBuildingButton(page: Page) {
-  const headerAddBuildingButton = page.getByTestId("fleet-buildings-add");
-  if (await headerAddBuildingButton.isVisible().catch(() => false)) {
-    await headerAddBuildingButton.click();
-    return;
-  }
-
-  const emptyStateAddBuildingButton = page.getByRole("button", { name: "Add building", exact: true });
-  await test.expect(emptyStateAddBuildingButton).toBeVisible();
-  await emptyStateAddBuildingButton.click();
-}
-
-async function detectSiteManagementMode(page: Page): Promise<SiteManagementMode> {
-  await resetActiveSiteSelection(page);
-  await openSitesManagementPage(page, "fleet");
-  return "fleet";
-}
-
-async function openSitesManagementPage(page: Page, mode: SiteManagementMode) {
-  void mode;
-  await page.goto("/fleet/sites");
-  await test.expect(page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
-  await test.expect(page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
-  await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
-  await selectAllSitesIfNeeded(page);
-
-  const sitePickerTrigger = page.getByTestId("site-picker-trigger");
-  if (await sitePickerTrigger.isVisible().catch(() => false)) {
-    await page.goto("/fleet/sites");
-    await test.expect(page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
-    await test.expect(page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
-    await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
-    await test.expect(sitePickerTrigger).toContainText("All sites");
-  }
-}
-
-async function openBuildingsManagementPage(page: Page, mode: SiteManagementMode) {
-  await openSitesManagementPage(page, mode);
-  await page.goto("/fleet/buildings");
-  await test.expect(page).toHaveURL(/\/fleet\/buildings(?:[?#].*)?$/);
-  await test.expect(page.getByTestId("fleet-buildings-page")).toBeVisible();
-}
-
-async function openFullScreenOverflowMenu(page: Page) {
-  const overflowTrigger = page.getByTestId("full-screen-two-pane-modal").getByTestId("overflow-menu-trigger");
-  await test.expect(overflowTrigger).toBeVisible();
-  await overflowTrigger.click();
-  return page.locator("div.fixed.inset-0.z-60");
-}
-
-async function clickManageSiteDelete(page: Page) {
-  const manageSiteDeleteButton = page.locator('[data-testid="manage-site-modal-delete"]:visible');
-  if (await manageSiteDeleteButton.isVisible().catch(() => false)) {
-    await manageSiteDeleteButton.click();
-    return;
-  }
-
-  const siteSettingsDeleteButton = page.locator('[data-testid="site-settings-modal-delete"]:visible');
-  if (await siteSettingsDeleteButton.isVisible().catch(() => false)) {
-    await siteSettingsDeleteButton.click();
-    return;
-  }
-
-  const overflowMenu = await openFullScreenOverflowMenu(page);
-  const deleteSiteAction = overflowMenu.getByText("Delete site", { exact: true });
-  if (await deleteSiteAction.isVisible().catch(() => false)) {
-    await deleteSiteAction.click();
-    return;
-  }
-
-  await overflowMenu.getByText("Site settings", { exact: true }).click();
-  await test.expect(siteSettingsDeleteButton).toBeVisible();
-  await siteSettingsDeleteButton.click();
-}
-
-async function clickManageBuildingDelete(page: Page) {
-  const deleteButton = page.locator('[data-testid="manage-building-delete"]:visible');
-  if (await deleteButton.isVisible().catch(() => false)) {
-    await deleteButton.click();
-    return;
-  }
-
-  const overflowMenu = await openFullScreenOverflowMenu(page);
-  await overflowMenu.getByText("Delete building", { exact: true }).click();
-}
-
-async function getScopeIdFromRowName(page: Page, name: string, scope: "site" | "building" | "rack"): Promise<bigint> {
-  const row = getListRowByName(page, name);
-  await test.expect(row).toBeVisible();
-
-  const trigger = row.locator('button[data-testid$="-actions-trigger"]').first();
-  await test.expect(trigger).toBeVisible();
-
-  const testId = await trigger.getAttribute("data-testid");
-  const pattern =
-    scope === "rack"
-      ? /^rack-list-row-(\d+)-actions-trigger$/
-      : new RegExp(`^${scope}-list-row-(\\d+)-actions-trigger$`);
-  const capturedId = testId?.match(pattern)?.[1];
-  if (!capturedId) {
-    throw new Error(`Could not parse ${scope} id from row action trigger: ${testId ?? "missing test id"}`);
-  }
-
-  return BigInt(capturedId);
-}
-
-async function openRowActions(page: Page, name: string) {
-  const row = getListRowByName(page, name);
-  await test.expect(row).toBeVisible();
-  await row.locator('button[data-testid$="-actions-trigger"]').first().click();
-}
-
-async function clickRowAction(page: Page, label: string) {
-  await page.getByText(label, { exact: true }).click();
-}
-
-async function selectParentPickerTarget(page: Page, label: string) {
-  const modal = page.getByTestId("modal");
-  await modal.getByText(label, { exact: true }).click();
-  await modal.getByRole("button", { name: "Save", exact: true }).click();
-}
-
-async function continueDialogIfVisible(page: Page, title: string) {
-  const dialog = page.getByText(title, { exact: true });
-  if (await dialog.isVisible().catch(() => false)) {
-    await page.getByRole("button", { name: "Continue", exact: true }).click();
-  }
-}
-
-async function loadVisibleMiners({
-  page,
-  commonSteps,
-}: {
-  page: Page;
-  commonSteps: CommonSteps;
-}): Promise<VisibleMinerSnapshot[]> {
-  const responsePromise = new Promise<VisibleMinerSnapshot[]>((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      page.off("response", handleResponse);
-      resolve([]);
-    }, 10000);
-
-    const handleResponse = async (response: PlaywrightResponse) => {
-      if (response.request().method() !== "POST" || !response.url().includes(LIST_MINERS_RESPONSE)) {
-        return;
-      }
-
-      try {
-        const body = (await response.json()) as {
-          miners?: VisibleMinerSnapshot[];
-          snapshots?: VisibleMinerSnapshot[];
-        };
-        const snapshots = body.snapshots ?? body.miners ?? [];
-        if (snapshots.length === 0) {
-          return;
-        }
-
-        clearTimeout(timeoutId);
-        page.off("response", handleResponse);
-        resolve(snapshots);
-      } catch (error) {
-        clearTimeout(timeoutId);
-        page.off("response", handleResponse);
-        reject(error);
-      }
-    };
-
-    page.on("response", handleResponse);
-  });
-
-  await commonSteps.goToMinersPage();
-
-  return await responsePromise;
-}
-
-function isBlankListCell(value: string | null | undefined): boolean {
-  const normalized = value?.trim();
-  return normalized === undefined || normalized === "" || normalized === "—";
-}
-
-function normalizePlacementLabel(value: string | null | undefined): string | undefined {
-  return isBlankListCell(value) ? undefined : value?.trim();
-}
-
-async function rowHasBlankBuildingAndRack(row: ReturnType<typeof getMinerRowByIp>): Promise<boolean> {
-  const buildingText = await row
-    .getByTestId("building")
-    .textContent()
-    .catch(() => null);
-  const rackText = await row
-    .getByTestId("rack")
-    .textContent()
-    .catch(() => null);
-  return isBlankListCell(buildingText) && isBlankListCell(rackText);
-}
-
-async function hasAuthenticationRequiredIssue(row: ReturnType<typeof getMinerRowByIp>): Promise<boolean> {
-  return (
-    (await row
-      .getByRole("button", { name: "Authentication required", exact: true })
-      .count()
-      .catch(() => 0)) > 0
-  );
-}
-
-async function pickUnrackedPairedMiner(page: Page, miners: VisibleMinerSnapshot[]): Promise<VisibleMinerCandidate> {
-  const rows = page.getByTestId("list-body").locator("tr");
-  const rowCount = await rows.count();
-
-  for (let index = 0; index < rowCount; index++) {
-    const row = rows.nth(index);
-    const ipAddress = normalizePlacementLabel(
-      await row
-        .getByTestId("ipAddress")
-        .textContent()
-        .catch(() => null),
-    );
-    if (!ipAddress) {
-      continue;
-    }
-
-    if (!(await rowHasBlankBuildingAndRack(getMinerRowByIp(page, ipAddress)))) {
-      continue;
-    }
-    if (await hasAuthenticationRequiredIssue(getMinerRowByIp(page, ipAddress))) {
-      continue;
-    }
-
-    const miner = miners.find((snapshot) => snapshot.ipAddress === ipAddress);
-    if (miner) {
-      return miner;
-    }
-
-    return { ipAddress };
-  }
-
-  throw new Error("Expected at least one visible miner without building or rack placement for reparent coverage");
-}
-
-async function createSite(page: Page, name: string, mode: SiteManagementMode): Promise<bigint> {
-  await openSitesManagementPage(page, mode);
-  await clickAddSiteButton(page);
-  await page.getByTestId("site-settings-name-input").fill(name);
-  await page.getByTestId("site-settings-modal-continue").click();
-  const saveSiteButton = page.locator('[data-testid="manage-site-modal-save"]:visible');
-  await test.expect(saveSiteButton).toBeVisible();
-  await saveSiteButton.click();
-
-  const row = getListRowByName(page, name);
-  await test.expect(row).toBeVisible();
-  return await getScopeIdFromRowName(page, name, "site");
-}
-
-async function deleteSite(page: Page, name: string, mode: SiteManagementMode) {
-  void mode;
-  await openSitesManagementPage(page, "fleet");
-  await openRowActions(page, name);
-  await clickRowAction(page, "Edit site");
-  await clickManageSiteDelete(page);
-  const confirmDeleteButton = page.getByTestId("site-delete-dialog-confirm");
-  await test.expect(confirmDeleteButton).toBeVisible();
-  await confirmDeleteButton.click({ trial: true });
-  await confirmDeleteButton.click();
-  await test.expect(getListRowByName(page, name)).toHaveCount(0);
-}
-
-async function createBuilding(
-  page: Page,
-  siteName: string,
-  buildingName: string,
-  mode: SiteManagementMode,
-): Promise<bigint> {
-  void mode;
-  await openBuildingsManagementPage(page, "fleet");
-  await clickAddBuildingButton(page);
-  await page.getByTestId("building-settings-site-select").click();
-  await page.getByRole("option", { name: siteName, exact: true }).click();
-  await page.getByTestId("building-settings-name-input").fill(buildingName);
-  await page.getByTestId("building-settings-modal-save").click();
-
-  const row = getListRowByName(page, buildingName);
-  await test.expect(row).toBeVisible();
-  return await getScopeIdFromRowName(page, buildingName, "building");
-}
-
-async function deleteBuilding(page: Page, siteName: string, name: string, mode: SiteManagementMode) {
-  void siteName;
-  void mode;
-  await openBuildingsManagementPage(page, "fleet");
-  await openRowActions(page, name);
-  await clickRowAction(page, "Edit building");
-  await clickManageBuildingDelete(page);
-  const confirmDeleteButton = page.getByTestId("building-delete-dialog-confirm");
-  await test.expect(confirmDeleteButton).toBeVisible();
-  await confirmDeleteButton.click({ trial: true });
-  await confirmDeleteButton.click();
-  await test.expect(getListRowByName(page, name)).toHaveCount(0);
-}
-
-async function createRack({
-  page,
-  racksPage,
-  label,
-  zone,
-}: {
-  page: Page;
-  racksPage: RacksPage;
-  label: string;
-  zone: string;
-}): Promise<bigint> {
-  await racksPage.navigateToRacksPage();
-  await racksPage.clickAddRackButton();
-  await racksPage.inputZone(zone);
-  await racksPage.inputRackLabel(label);
-  await racksPage.enableCustomRackLayout();
-  await racksPage.inputColumns(2);
-  await racksPage.inputRows(2);
-  await racksPage.clickContinueFromRackSettings();
-  await racksPage.clickSaveRack();
-  await racksPage.validateRackToast(label);
-  await racksPage.clickViewList();
-  await racksPage.waitForRackListToLoad({ allowEmpty: false });
-  return await getScopeIdFromRowName(page, label, "rack");
-}
-
-async function assignRackToSite(page: Page, rackLabel: string, siteName: string) {
-  await page.goto("/fleet/racks");
-  await page.getByRole("button", { name: "View list", exact: true }).click();
-  await openRowActions(page, rackLabel);
-  await clickRowAction(page, "Add to site");
-  await selectParentPickerTarget(page, siteName);
-}
-
-async function assignRackToBuilding(page: Page, rackLabel: string, buildingName: string) {
-  await page.goto("/fleet/racks");
-  await page.getByRole("button", { name: "View list", exact: true }).click();
-  await openRowActions(page, rackLabel);
-  await clickRowAction(page, "Add to building");
-  await selectParentPickerTarget(page, buildingName);
-}
-
-async function moveSingleMinerToSite({
-  page,
-  minersPage,
-  minerIp,
-  siteName,
-}: {
-  page: Page;
-  minersPage: MinersPage;
-  minerIp: string;
-  siteName: string;
-}) {
-  await minersPage.clickMinerCheckbox(minerIp);
-  await minersPage.validateActionBarMinerCount(1);
-  await minersPage.clickActionsMenuButton();
-  await page.getByTestId("add-to-site-popover-button").click();
-  await selectParentPickerTarget(page, siteName);
-  await continueDialogIfVisible(page, "Move miners between sites?");
-}
-
-async function moveSingleMinerToRack({
-  page,
-  minersPage,
-  minerIp,
-  rackLabel,
-}: {
-  page: Page;
-  minersPage: MinersPage;
-  minerIp: string;
-  rackLabel: string;
-}) {
-  await minersPage.clickMinerCheckbox(minerIp);
-  await minersPage.validateActionBarMinerCount(1);
-  await minersPage.clickActionsMenuButton();
-  await page.getByTestId("add-to-rack-popover-button").click();
-  await selectParentPickerTarget(page, rackLabel);
-}
-
-async function assertSiteMinerCount({
-  page,
-  siteName,
-  mode,
-  expectedCount,
-}: {
-  page: Page;
-  siteName: string;
-  mode: SiteManagementMode;
-  expectedCount: number;
-}) {
-  await openSitesManagementPage(page, mode);
-  const row = getListRowByName(page, siteName);
-  await test.expect(row.getByTestId("miners")).toHaveText(String(expectedCount));
-}
-
-async function assertRackPlacementForMode({
-  row,
-  mode,
-  siteName,
-  buildingName,
-}: {
-  row: ReturnType<typeof getListRowByName>;
-  mode: SiteManagementMode;
-  siteName: string;
-  buildingName: string;
-}) {
-  await test.expect(row).toBeVisible();
-  void mode;
-  await test.expect(row.getByTestId("site")).toHaveText(siteName);
-  await test.expect(row.getByTestId("building")).toHaveText(buildingName);
-}
-
-async function assertRackMembershipForMode({
-  row,
-  mode,
-  targetSiteName,
-}: {
-  row: ReturnType<typeof getListRowByName>;
-  mode: SiteManagementMode;
-  targetSiteName: string;
-}) {
-  await test.expect(row).toBeVisible();
-  await test.expect(row.getByTestId("miners")).toHaveText("1");
-  void mode;
-  await test.expect(row.getByTestId("site")).toHaveText(targetSiteName);
-}
-
-function expectSingleDeviceIdentifier(actual: string[] | undefined, expected?: string) {
-  if (expected) {
-    test.expect(actual).toEqual([expected]);
-    return;
-  }
-
-  test.expect(actual).toHaveLength(1);
-}
-
-async function restoreMinerSiteIfNeeded({
-  page,
-  minersPage,
-  minerIp,
-  originalSiteLabel,
-}: {
-  page: Page;
-  minersPage: MinersPage;
-  minerIp: string;
-  originalSiteLabel?: string;
-}) {
-  if (!originalSiteLabel) {
-    return;
-  }
-
-  await page.goto("/fleet/miners");
-  await minersPage.waitForMinersListToLoad();
-  await moveSingleMinerToSite({ page, minersPage, minerIp, siteName: originalSiteLabel });
-}
-
-async function restoreMinerRackSlotIfNeeded({
-  page,
-  racksPage,
-  minerIp,
-  originalRackLabel,
-  originalRackPosition,
-}: {
-  page: Page;
-  racksPage: RacksPage;
-  minerIp: string;
-  originalRackLabel?: string;
-  originalRackPosition?: string;
-}) {
-  if (!originalRackLabel || !originalRackPosition) {
-    return;
-  }
-
-  const slotNumber = Number(originalRackPosition);
-  if (Number.isNaN(slotNumber)) {
-    throw new Error(`Could not parse original rack position "${originalRackPosition}"`);
-  }
-
-  await page.goto("/fleet/racks");
-  await racksPage.clickViewList();
-  await racksPage.waitForRackListToLoad({ allowEmpty: false });
-  await racksPage.openRackFromList(originalRackLabel);
-  await racksPage.clickRackOverviewEmptySlot(slotNumber);
-  await racksPage.assignSearchMinerByIpAddress(minerIp);
-  await racksPage.validateRackOverviewAssignedSlots([slotNumber]);
-}
-
-async function restoreMinerRackIfNeeded({
-  page,
-  minersPage,
-  minerIp,
-  originalRackLabel,
-}: {
-  page: Page;
-  minersPage: MinersPage;
-  minerIp: string;
-  originalRackLabel?: string;
-}) {
-  if (!originalRackLabel) {
-    return;
-  }
-
-  await page.goto("/fleet/miners");
-  await minersPage.waitForMinersListToLoad();
-  await moveSingleMinerToRack({ page, minersPage, minerIp, rackLabel: originalRackLabel });
-}
-
-async function restoreMinerPlacementIfNeeded({
-  page,
-  minersPage,
-  racksPage,
-  minerIp,
-  originalSiteLabel,
-  originalRackLabel,
-  originalRackPosition,
-}: {
-  page: Page;
-  minersPage: MinersPage;
-  racksPage: RacksPage;
-  minerIp: string;
-  originalSiteLabel?: string;
-  originalRackLabel?: string;
-  originalRackPosition?: string;
-}) {
-  if (!originalRackLabel) {
-    await restoreMinerSiteIfNeeded({ page, minersPage, minerIp, originalSiteLabel });
-    return;
-  }
-
-  await restoreMinerSiteIfNeeded({ page, minersPage, minerIp, originalSiteLabel });
-
-  if (originalRackPosition) {
-    await restoreMinerRackSlotIfNeeded({
-      page,
-      racksPage,
-      minerIp,
-      originalRackLabel,
-      originalRackPosition,
-    });
-    return;
-  }
-
-  await restoreMinerRackIfNeeded({ page, minersPage, minerIp, originalRackLabel });
-}
+const RACK_COLUMNS = 2;
+const RACK_ROWS = 2;
 
 async function deleteRackIfCreated({
-  racksPage,
   created,
   rackLabel,
+  racksPage,
 }: {
-  racksPage: RacksPage;
   created: boolean;
   rackLabel: string;
+  racksPage: { deleteRackByLabelIfVisible(label: string): Promise<void> };
 }) {
   if (!created) {
     return;
   }
 
-  await racksPage.navigateToRacksPage();
-  await racksPage.tryAction(() => racksPage.clickViewList());
-  if (!(await racksPage.tryAction(() => racksPage.openRackFromList(rackLabel)))) {
-    return;
-  }
-
-  await racksPage.clickEditRack();
-  await racksPage.clickDeleteRack();
-  await racksPage.clickDeleteConfirm();
-  await racksPage.tryAction(() => racksPage.validateRackDeletedToast());
+  await racksPage.deleteRackByLabelIfVisible(rackLabel);
 }
 
 async function deleteBuildingIfCreated({
-  page,
-  created,
-  siteName,
   buildingName,
-  mode,
+  created,
+  fleetLocationsPage,
 }: {
-  page: Page;
-  created: boolean;
-  siteName: string;
   buildingName: string;
-  mode: SiteManagementMode;
+  created: boolean;
+  fleetLocationsPage: { deleteBuilding(name: string): Promise<void> };
 }) {
   if (!created) {
     return;
   }
 
-  await deleteBuilding(page, siteName, buildingName, mode);
+  await fleetLocationsPage.deleteBuilding(buildingName);
 }
 
 async function deleteSiteIfCreated({
-  page,
   created,
+  fleetLocationsPage,
   siteName,
-  mode,
 }: {
-  page: Page;
   created: boolean;
+  fleetLocationsPage: { deleteSite(name: string): Promise<void> };
   siteName: string;
-  mode: SiteManagementMode;
 }) {
   if (!created) {
     return;
   }
 
-  await deleteSite(page, siteName, mode);
+  await fleetLocationsPage.deleteSite(siteName);
 }
 
 test.describe("Miners reparent", () => {
-  test.use({ storageState: { cookies: [], origins: [] } });
-
-  test.beforeEach(async ({ page, authPage, addMinersPage, commonSteps, homePage, minersPage }) => {
-    await page.addInitScript(
-      ({ storageKey }) => {
-        localStorage.setItem(
-          storageKey,
-          JSON.stringify({
-            state: {
-              ui: {
-                activeSite: { kind: "all" },
-              },
-            },
-            version: 0,
-          }),
-        );
-      },
-      { storageKey: ACTIVE_SITE_STORAGE_KEY },
-    );
-
-    await ensureAdminSession({ page, authPage, commonSteps });
-    await ensureFleetInventory({ authPage, addMinersPage, minersPage });
-    await ensureAuthenticatedMovableMiners({ page, homePage, minersPage });
+  test.beforeEach(async ({ page, commonSteps }) => {
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+    await commonSteps.loginAsAdmin();
   });
 
-  test("Move a rack to a building from the Racks tab", async ({ page, commonSteps, racksPage }) => {
-    await commonSteps.loginAsAdmin();
-
-    const siteManagementMode = await detectSiteManagementMode(page);
+  test("Move a rack to a building from the Racks tab", async ({ page, fleetLocationsPage, racksPage }) => {
     const siteName = generateRandomText("reparent_site");
     const buildingName = generateRandomText("reparent_building");
     const rackLabel = generateRandomText("reparent_rack");
@@ -861,18 +81,23 @@ test.describe("Miners reparent", () => {
     let createdRack = false;
 
     try {
-      await createSite(page, siteName, siteManagementMode);
+      await fleetLocationsPage.createSite(siteName);
       createdSite = true;
-      const buildingId = await createBuilding(page, siteName, buildingName, siteManagementMode);
+      const buildingId = await fleetLocationsPage.createBuilding(siteName, buildingName);
       createdBuilding = true;
-      const rackId = await createRack({ page, racksPage, label: rackLabel, zone: TEMP_ZONE });
+      const rackId = await racksPage.createRack({
+        columns: RACK_COLUMNS,
+        label: rackLabel,
+        rows: RACK_ROWS,
+        zone: TEMP_ZONE,
+      });
       createdRack = true;
 
       const requestPromise = page.waitForRequest(new RegExp(ASSIGN_RACKS_TO_BUILDING));
       const responsePromise = page.waitForResponse(new RegExp(ASSIGN_RACKS_TO_BUILDING));
 
       await test.step("Move the rack into the target building", async () => {
-        await assignRackToBuilding(page, rackLabel, buildingName);
+        await racksPage.assignRackToBuildingFromList(rackLabel, buildingName);
       });
 
       await test.step("Validate the rack move request and resulting row placement", async () => {
@@ -891,48 +116,30 @@ test.describe("Miners reparent", () => {
         await racksPage.navigateToRacksPage();
         await racksPage.clickViewList();
         await racksPage.waitForRackListToLoad({ allowEmpty: false });
-        const row = getListRowByName(page, rackLabel);
-        await assertRackPlacementForMode({ row, mode: siteManagementMode, siteName, buildingName });
+        await racksPage.validateRackPlacementRow(rackLabel, siteName, buildingName);
       });
     } finally {
-      await deleteRackIfCreated({ racksPage, created: createdRack, rackLabel });
-      await deleteBuildingIfCreated({
-        page,
-        created: createdBuilding,
-        siteName,
-        buildingName,
-        mode: siteManagementMode,
-      });
-      await deleteSiteIfCreated({ page, created: createdSite, siteName, mode: siteManagementMode });
+      await deleteRackIfCreated({ created: createdRack, rackLabel, racksPage });
+      await deleteBuildingIfCreated({ buildingName, created: createdBuilding, fleetLocationsPage });
+      await deleteSiteIfCreated({ created: createdSite, fleetLocationsPage, siteName });
     }
   });
 
-  test("Assign a single miner to a site from the Miners tab", async ({ page, commonSteps, minersPage, racksPage }) => {
-    await commonSteps.loginAsAdmin();
-
-    const siteManagementMode = await detectSiteManagementMode(page);
+  test("Assign a single miner to a site from the Miners tab", async ({
+    page,
+    commonSteps,
+    fleetLocationsPage,
+    minersPage,
+    racksPage,
+  }) => {
     const targetSiteName = generateRandomText("miner_site");
+
     let createdSite = false;
-    let minerIp = "";
-    let originalSiteLabel: string | undefined;
-    let originalRackLabel: string | undefined;
-    let originalRackPosition: string | undefined;
+    let miner: ReparentMiner | undefined;
 
     try {
-      const snapshots = await loadVisibleMiners({ page, commonSteps });
-      const miner = await pickUnrackedPairedMiner(page, snapshots);
-      const minerRow = getMinerRowByIp(page, miner.ipAddress);
-      minerIp = miner.ipAddress;
-      originalSiteLabel = normalizePlacementLabel(
-        await minerRow
-          .getByTestId("site")
-          .textContent()
-          .catch(() => null),
-      );
-      originalRackLabel = miner.placement?.rack?.label || undefined;
-      originalRackPosition = miner.rackPosition || undefined;
-
-      const targetSiteId = await createSite(page, targetSiteName, siteManagementMode);
+      miner = await captureMovableMiner({ page, commonSteps, minersPage });
+      const targetSiteId = await fleetLocationsPage.createSite(targetSiteName);
       createdSite = true;
 
       const requestPromise = page.waitForRequest(new RegExp(ASSIGN_DEVICES_TO_SITE));
@@ -942,7 +149,9 @@ test.describe("Miners reparent", () => {
       await minersPage.waitForMinersListToLoad();
 
       await test.step("Move one miner into the target site", async () => {
-        await moveSingleMinerToSite({ page, minersPage, minerIp: miner.ipAddress, siteName: targetSiteName });
+        await minersPage.clickMinerCheckbox(miner.ipAddress);
+        await minersPage.validateActionBarMinerCount(1);
+        await minersPage.assignSelectedMinersToSite(targetSiteName);
       });
 
       await test.step("Validate the request and the target site miner count", async () => {
@@ -957,64 +166,59 @@ test.describe("Miners reparent", () => {
         expectSingleDeviceIdentifier(body.deviceIdentifiers, miner.deviceIdentifier);
         test.expect(response.status()).toBe(200);
 
-        await assertSiteMinerCount({
-          page,
-          siteName: targetSiteName,
-          mode: siteManagementMode,
-          expectedCount: 1,
-        });
+        await fleetLocationsPage.validateSiteMinerCount(targetSiteName, 1);
       });
     } finally {
-      await restoreMinerPlacementIfNeeded({
-        page,
-        minersPage,
-        racksPage,
-        minerIp,
-        originalSiteLabel,
-        originalRackLabel,
-        originalRackPosition,
-      });
-      await deleteSiteIfCreated({ page, created: createdSite, siteName: targetSiteName, mode: siteManagementMode });
+      await restoreMinerPlacementIfNeeded({ page, minersPage, racksPage, miner });
+      await deleteSiteIfCreated({ created: createdSite, fleetLocationsPage, siteName: targetSiteName });
     }
   });
 
-  test("Assign a single miner to a rack from the Miners tab", async ({ page, commonSteps, minersPage, racksPage }) => {
-    await commonSteps.loginAsAdmin();
-
-    const siteManagementMode = await detectSiteManagementMode(page);
+  test("Assign a single miner to a rack from the Miners tab", async ({
+    page,
+    commonSteps,
+    fleetLocationsPage,
+    minersPage,
+    racksPage,
+  }) => {
     const targetSiteName = generateRandomText("rack_site");
     const rackLabel = generateRandomText("miner_rack");
 
     let createdSite = false;
     let createdRack = false;
-    let minerIp = "";
-    let originalSiteLabel: string | undefined;
-    let originalRackLabel: string | undefined;
-    let originalRackPosition: string | undefined;
+    let miner: ReparentMiner | undefined;
 
     try {
-      const snapshots = await loadVisibleMiners({ page, commonSteps });
-      const miner = await pickUnrackedPairedMiner(page, snapshots);
-      const minerRow = getMinerRowByIp(page, miner.ipAddress);
-      minerIp = miner.ipAddress;
-      originalSiteLabel = normalizePlacementLabel(
-        await minerRow
-          .getByTestId("site")
-          .textContent()
-          .catch(() => null),
-      );
-      originalRackLabel = miner.placement?.rack?.label || undefined;
-      originalRackPosition = miner.rackPosition || undefined;
-
-      await createSite(page, targetSiteName, siteManagementMode);
+      miner = await captureMovableMiner({ page, commonSteps, minersPage });
+      const targetSiteId = await fleetLocationsPage.createSite(targetSiteName);
       createdSite = true;
-      const rackId = await createRack({ page, racksPage, label: rackLabel, zone: TEMP_ZONE });
+      const rackId = await racksPage.createRack({
+        columns: RACK_COLUMNS,
+        label: rackLabel,
+        rows: RACK_ROWS,
+        zone: TEMP_ZONE,
+      });
       createdRack = true;
+
       const rackSiteRequestPromise = page.waitForRequest(new RegExp(ASSIGN_RACKS_TO_SITE));
       const rackSiteResponsePromise = page.waitForResponse(new RegExp(ASSIGN_RACKS_TO_SITE));
-      await assignRackToSite(page, rackLabel, targetSiteName);
-      await rackSiteRequestPromise;
-      await rackSiteResponsePromise;
+
+      await test.step("Move the rack into the target site", async () => {
+        await racksPage.assignRackToSiteFromList(rackLabel, targetSiteName);
+      });
+
+      await test.step("Validate the rack-to-site request", async () => {
+        const request = await rackSiteRequestPromise;
+        const response = await rackSiteResponsePromise;
+        const body = request.postDataJSON() as {
+          rackIds?: string[];
+          targetSiteId?: string;
+        };
+
+        test.expect(body.rackIds).toEqual([rackId.toString()]);
+        test.expect(String(body.targetSiteId)).toBe(targetSiteId.toString());
+        test.expect(response.status()).toBe(200);
+      });
 
       const requestPromise = page.waitForRequest(new RegExp(ASSIGN_DEVICES_TO_RACK));
       const responsePromise = page.waitForResponse(new RegExp(ASSIGN_DEVICES_TO_RACK));
@@ -1023,19 +227,21 @@ test.describe("Miners reparent", () => {
       await minersPage.waitForMinersListToLoad();
 
       await test.step("Move one miner into the target rack", async () => {
-        await moveSingleMinerToRack({ page, minersPage, minerIp: miner.ipAddress, rackLabel });
+        await minersPage.clickMinerCheckbox(miner.ipAddress);
+        await minersPage.validateActionBarMinerCount(1);
+        await minersPage.assignSelectedMinersToRack(rackLabel);
       });
 
       await test.step("Validate the request and target rack miner count", async () => {
         const request = await requestPromise;
         const response = await responsePromise;
         const body = request.postDataJSON() as {
-          targetRackId?: string;
           deviceSelector?: {
             deviceList?: {
               deviceIdentifiers?: string[];
             };
           };
+          targetRackId?: string;
         };
 
         test.expect(String(body.targetRackId)).toBe(rackId.toString());
@@ -1045,21 +251,12 @@ test.describe("Miners reparent", () => {
         await racksPage.navigateToRacksPage();
         await racksPage.clickViewList();
         await racksPage.waitForRackListToLoad({ allowEmpty: false });
-        const row = getListRowByName(page, rackLabel);
-        await assertRackMembershipForMode({ row, mode: siteManagementMode, targetSiteName });
+        await racksPage.validateRackMembershipRow(rackLabel, targetSiteName, 1);
       });
     } finally {
-      await restoreMinerPlacementIfNeeded({
-        page,
-        minersPage,
-        racksPage,
-        minerIp,
-        originalSiteLabel,
-        originalRackLabel,
-        originalRackPosition,
-      });
-      await deleteRackIfCreated({ racksPage, created: createdRack, rackLabel });
-      await deleteSiteIfCreated({ page, created: createdSite, siteName: targetSiteName, mode: siteManagementMode });
+      await restoreMinerPlacementIfNeeded({ page, minersPage, racksPage, miner });
+      await deleteRackIfCreated({ created: createdRack, rackLabel, racksPage });
+      await deleteSiteIfCreated({ created: createdSite, fleetLocationsPage, siteName: targetSiteName });
     }
   });
 });

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -69,7 +69,6 @@ async function selectAllSitesIfNeeded(page: Page) {
   const sitePickerTrigger = page.getByTestId("site-picker-trigger");
   if (!(await sitePickerTrigger.isVisible().catch(() => false))) {
     await test.expect(page.getByTestId("fleet-sites-page")).toBeVisible();
-    await test.expect(page.getByTestId("fleet-sites-add")).toBeVisible();
     return;
   }
 
@@ -83,6 +82,18 @@ async function selectAllSitesIfNeeded(page: Page) {
   await test.expect(allSitesOption).toBeVisible();
   await allSitesOption.click();
   await test.expect(sitePickerTrigger).toContainText("All sites");
+}
+
+async function clickAddSiteButton(page: Page) {
+  const headerAddSiteButton = page.getByTestId("fleet-sites-add");
+  if (await headerAddSiteButton.isVisible().catch(() => false)) {
+    await headerAddSiteButton.click();
+    return;
+  }
+
+  const emptyStateAddSiteButton = page.getByRole("button", { name: "Add a site", exact: true });
+  await test.expect(emptyStateAddSiteButton).toBeVisible();
+  await emptyStateAddSiteButton.click();
 }
 
 async function detectSiteManagementMode(page: Page): Promise<SiteManagementMode> {
@@ -295,9 +306,7 @@ async function pickUnrackedPairedMiner(page: Page, miners: VisibleMinerSnapshot[
 
 async function createSite(page: Page, name: string, mode: SiteManagementMode): Promise<bigint> {
   await openSitesManagementPage(page, mode);
-  const addSiteButton = page.getByTestId("fleet-sites-add");
-  await test.expect(addSiteButton).toBeVisible();
-  await addSiteButton.click();
+  await clickAddSiteButton(page);
   await page.getByTestId("site-settings-name-input").fill(name);
   await page.getByTestId("site-settings-modal-continue").click();
   const saveSiteButton = page.locator('[data-testid="manage-site-modal-save"]:visible');

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -14,6 +14,7 @@ type VisibleMinerSnapshot = {
   name: string;
   pairingStatus: PairingStatus;
   rackLabel: string;
+  rackPosition: string;
   siteId?: string;
   siteLabel: string;
 };
@@ -109,6 +110,19 @@ async function openLegacySiteSettings(page: Page, siteName: string) {
 
   await test.expect(page.getByTestId("site-settings-single-view")).toBeVisible();
   await test.expect(page.getByText(siteName, { exact: true })).toBeVisible();
+}
+
+async function clickManageSiteEditDetails(page: Page) {
+  const editDetailsButton = page.locator('[data-testid="manage-site-modal-edit-details"]:visible');
+  if (await editDetailsButton.isVisible().catch(() => false)) {
+    await editDetailsButton.click();
+    return;
+  }
+
+  const overflowTrigger = page.getByTestId("full-screen-two-pane-modal").getByTestId("overflow-menu-trigger");
+  await test.expect(overflowTrigger).toBeVisible();
+  await overflowTrigger.click();
+  await page.locator("div.fixed.inset-0.z-60").getByText("Edit details", { exact: true }).click();
 }
 
 async function getScopeIdFromRowName(page: Page, name: string, scope: "site" | "building" | "rack"): Promise<bigint> {
@@ -271,7 +285,7 @@ async function deleteSite(page: Page, name: string, mode: SiteManagementMode) {
     await openSitesManagementPage(page, mode);
     await openRowActions(page, name);
     await clickRowAction(page, "Edit site");
-    await page.locator('[data-testid="manage-site-modal-edit-details"]:visible').click();
+    await clickManageSiteEditDetails(page);
     await page.locator('[data-testid="site-settings-modal-delete"]:visible').click();
     await page.getByTestId("site-delete-dialog-confirm").click();
     await test.expect(page.getByTestId("toaster-container").getByText(`Site "${name}" deleted`)).toBeVisible();
@@ -280,7 +294,7 @@ async function deleteSite(page: Page, name: string, mode: SiteManagementMode) {
 
   await openLegacySiteSettings(page, name);
   await page.getByTestId("site-settings-manage").click();
-  await page.locator('[data-testid="manage-site-modal-edit-details"]:visible').click();
+  await clickManageSiteEditDetails(page);
   await page.locator('[data-testid="site-settings-modal-delete"]:visible').click();
   await page.getByTestId("site-delete-dialog-confirm").click();
   await openSitesManagementPage(page, "legacy");
@@ -510,6 +524,95 @@ async function restoreMinerSiteIfNeeded({
   await moveSingleMinerToSite({ page, minersPage, minerIp, siteName: originalSiteLabel });
 }
 
+async function restoreMinerRackSlotIfNeeded({
+  page,
+  racksPage,
+  minerIp,
+  originalRackLabel,
+  originalRackPosition,
+}: {
+  page: Page;
+  racksPage: RacksPage;
+  minerIp: string;
+  originalRackLabel?: string;
+  originalRackPosition?: string;
+}) {
+  if (!originalRackLabel || !originalRackPosition) {
+    return;
+  }
+
+  const slotNumber = Number(originalRackPosition);
+  if (Number.isNaN(slotNumber)) {
+    throw new Error(`Could not parse original rack position "${originalRackPosition}"`);
+  }
+
+  await page.goto("/fleet/racks");
+  await racksPage.clickViewList();
+  await racksPage.waitForRackListToLoad({ allowEmpty: false });
+  await racksPage.openRackFromList(originalRackLabel);
+  await racksPage.clickRackOverviewEmptySlot(slotNumber);
+  await racksPage.assignSearchMinerByIpAddress(minerIp);
+  await racksPage.validateRackOverviewAssignedSlots([slotNumber]);
+}
+
+async function restoreMinerRackIfNeeded({
+  page,
+  minersPage,
+  minerIp,
+  originalRackLabel,
+}: {
+  page: Page;
+  minersPage: MinersPage;
+  minerIp: string;
+  originalRackLabel?: string;
+}) {
+  if (!originalRackLabel) {
+    return;
+  }
+
+  await page.goto("/fleet/miners");
+  await minersPage.waitForMinersListToLoad();
+  await moveSingleMinerToRack({ page, minersPage, minerIp, rackLabel: originalRackLabel });
+}
+
+async function restoreMinerPlacementIfNeeded({
+  page,
+  minersPage,
+  racksPage,
+  minerIp,
+  originalSiteLabel,
+  originalRackLabel,
+  originalRackPosition,
+}: {
+  page: Page;
+  minersPage: MinersPage;
+  racksPage: RacksPage;
+  minerIp: string;
+  originalSiteLabel?: string;
+  originalRackLabel?: string;
+  originalRackPosition?: string;
+}) {
+  if (!originalRackLabel) {
+    await restoreMinerSiteIfNeeded({ page, minersPage, minerIp, originalSiteLabel });
+    return;
+  }
+
+  await restoreMinerSiteIfNeeded({ page, minersPage, minerIp, originalSiteLabel });
+
+  if (originalRackPosition) {
+    await restoreMinerRackSlotIfNeeded({
+      page,
+      racksPage,
+      minerIp,
+      originalRackLabel,
+      originalRackPosition,
+    });
+    return;
+  }
+
+  await restoreMinerRackIfNeeded({ page, minersPage, minerIp, originalRackLabel });
+}
+
 async function deleteRackIfCreated({
   racksPage,
   created,
@@ -637,18 +740,24 @@ test.describe("Miners reparent", () => {
     }
   });
 
-  test("Assign a single miner to a site from the Miners tab", async ({ page, commonSteps, minersPage }) => {
+  test("Assign a single miner to a site from the Miners tab", async ({ page, commonSteps, minersPage, racksPage }) => {
     await commonSteps.loginAsAdmin();
 
     const siteManagementMode = await detectSiteManagementMode(page);
     const targetSiteName = generateRandomText("miner_site");
     let createdSite = false;
+    let minerIp = "";
     let originalSiteLabel: string | undefined;
+    let originalRackLabel: string | undefined;
+    let originalRackPosition: string | undefined;
 
     try {
       const snapshots = await loadVisibleMiners({ page, commonSteps });
       const miner = pickUnrackedPairedMiner(snapshots);
+      minerIp = miner.ipAddress;
       originalSiteLabel = miner.siteLabel || undefined;
+      originalRackLabel = miner.rackLabel || undefined;
+      originalRackPosition = miner.rackPosition || undefined;
 
       const targetSiteId = await createSite(page, targetSiteName, siteManagementMode);
       createdSite = true;
@@ -659,7 +768,7 @@ test.describe("Miners reparent", () => {
       await page.goto("/fleet/miners");
       await minersPage.waitForMinersListToLoad();
 
-      await test.step("Move one unracked miner into the target site", async () => {
+      await test.step("Move one miner into the target site", async () => {
         await moveSingleMinerToSite({ page, minersPage, minerIp: miner.ipAddress, siteName: targetSiteName });
       });
 
@@ -682,14 +791,16 @@ test.describe("Miners reparent", () => {
           expectedCount: 1,
         });
       });
-
-      await restoreMinerSiteIfNeeded({
+    } finally {
+      await restoreMinerPlacementIfNeeded({
         page,
         minersPage,
-        minerIp: miner.ipAddress,
+        racksPage,
+        minerIp,
         originalSiteLabel,
+        originalRackLabel,
+        originalRackPosition,
       });
-    } finally {
       await deleteSiteIfCreated({ page, created: createdSite, siteName: targetSiteName, mode: siteManagementMode });
     }
   });
@@ -703,12 +814,18 @@ test.describe("Miners reparent", () => {
 
     let createdSite = false;
     let createdRack = false;
+    let minerIp = "";
     let originalSiteLabel: string | undefined;
+    let originalRackLabel: string | undefined;
+    let originalRackPosition: string | undefined;
 
     try {
       const snapshots = await loadVisibleMiners({ page, commonSteps });
       const miner = pickUnrackedPairedMiner(snapshots);
+      minerIp = miner.ipAddress;
       originalSiteLabel = miner.siteLabel || undefined;
+      originalRackLabel = miner.rackLabel || undefined;
+      originalRackPosition = miner.rackPosition || undefined;
 
       await createSite(page, targetSiteName, siteManagementMode);
       createdSite = true;
@@ -722,7 +839,7 @@ test.describe("Miners reparent", () => {
       await page.goto("/fleet/miners");
       await minersPage.waitForMinersListToLoad();
 
-      await test.step("Move one unracked miner into the target rack", async () => {
+      await test.step("Move one miner into the target rack", async () => {
         await moveSingleMinerToRack({ page, minersPage, minerIp: miner.ipAddress, rackLabel });
       });
 
@@ -748,14 +865,16 @@ test.describe("Miners reparent", () => {
         const row = getListRowByName(page, rackLabel);
         await assertRackMembershipForMode({ row, mode: siteManagementMode, targetSiteName });
       });
-
-      await restoreMinerSiteIfNeeded({
+    } finally {
+      await restoreMinerPlacementIfNeeded({
         page,
         minersPage,
-        minerIp: miner.ipAddress,
+        racksPage,
+        minerIp,
         originalSiteLabel,
+        originalRackLabel,
+        originalRackPosition,
       });
-    } finally {
       await deleteRackIfCreated({ racksPage, created: createdRack, rackLabel });
       await deleteSiteIfCreated({ page, created: createdSite, siteName: targetSiteName, mode: siteManagementMode });
     }

--- a/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersReparent.spec.ts
@@ -1,7 +1,11 @@
 import { type Page, type Response as PlaywrightResponse } from "@playwright/test";
+import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { type CommonSteps } from "../helpers/commonSteps";
 import { generateRandomText } from "../helpers/testDataHelper";
+import { type AddMinersPage } from "../pages/addMiners";
+import { type AuthPage } from "../pages/auth";
+import { type HomePage } from "../pages/home";
 import { type MinersPage } from "../pages/miners";
 import { type RacksPage } from "../pages/racks";
 import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
@@ -39,6 +43,7 @@ const ASSIGN_RACKS_TO_BUILDING = "AssignRacksToBuilding";
 const ASSIGN_RACKS_TO_SITE = "AssignRacksToSite";
 const TEMP_ZONE = "ReparentAutomationZone";
 const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
+const EXPECTED_FAKE_NETWORK_MINER_COUNT = 14;
 
 function getListRowByName(page: Page, name: string) {
   return page
@@ -71,6 +76,112 @@ async function resetActiveSiteSelection(page: Page) {
     },
     { storageKey: ACTIVE_SITE_STORAGE_KEY },
   );
+}
+
+async function ensureAdminSession({
+  page,
+  authPage,
+  commonSteps,
+}: {
+  page: Page;
+  authPage: AuthPage;
+  commonSteps: CommonSteps;
+}) {
+  await page.goto("/");
+
+  if (await authPage.isAlreadyLoggedIn()) {
+    return;
+  }
+
+  const createCredentialsPrompt = page.getByText("Create your username and password", { exact: true });
+  if (await createCredentialsPrompt.isVisible().catch(() => false)) {
+    await authPage.inputUsername(testConfig.users.admin.username);
+    await authPage.inputPassword(testConfig.users.admin.password);
+    await authPage.clickContinue();
+    await authPage.validateLoggedIn();
+    return;
+  }
+
+  await commonSteps.loginAsAdmin();
+}
+
+async function ensureFleetInventory({
+  authPage,
+  addMinersPage,
+  minersPage,
+}: {
+  authPage: AuthPage;
+  addMinersPage: AddMinersPage;
+  minersPage: MinersPage;
+}) {
+  await minersPage.navigateToMinersPage();
+  if (await minersPage.tryAction(() => minersPage.waitForMinersListToLoad(), 3000)) {
+    return;
+  }
+
+  await authPage.clickGetStarted();
+  await addMinersPage.clickFindMinersInNetwork();
+  await addMinersPage.waitForExpectedNetworkMinerCount(EXPECTED_FAKE_NETWORK_MINER_COUNT);
+  await addMinersPage.clickContinueWithXMiners(EXPECTED_FAKE_NETWORK_MINER_COUNT);
+  await minersPage.waitForMinersListToLoad();
+}
+
+async function ensureAuthenticatedMovableMiners({
+  page,
+  homePage,
+  minersPage,
+}: {
+  page: Page;
+  homePage: HomePage;
+  minersPage: MinersPage;
+}) {
+  const authenticatedMinerCheckboxes = page.locator(
+    '[data-testid="list-body"] tr input[type="checkbox"]:not([disabled])',
+  );
+  if ((await authenticatedMinerCheckboxes.count().catch(() => 0)) > 0) {
+    return;
+  }
+
+  await page.goto("/dashboard");
+
+  const authenticateButton = page.getByRole("button", { name: "Authenticate", exact: true });
+  if (!(await authenticateButton.isVisible().catch(() => false))) {
+    throw new Error("Expected at least one authenticated miner or an authentication prompt on the dashboard");
+  }
+
+  await homePage.clickAuthenticateMinersButton();
+  await homePage.validateAuthenticateMinersModalTitle();
+  await homePage.clickShowMinersButton();
+
+  const miners = await homePage.getListOfMinersToAuthenticate();
+
+  if (miners.some((miner) => miner.includes("S19 XP"))) {
+    await homePage.inputMinerAuthUsername("root19");
+    await homePage.inputMinerAuthPassword("root19");
+    await homePage.clickAuthenticateMinersConfirmButton();
+    await homePage.tryAction(() => homePage.clickCalloutButton());
+  }
+
+  if (miners.some((miner) => miner.includes("S21 XP"))) {
+    await homePage.inputMinerAuthUsername("root21");
+    await homePage.inputMinerAuthPassword("root21");
+    await homePage.clickAuthenticateMinersConfirmButton();
+    await homePage.tryAction(() => homePage.clickCalloutButton());
+  }
+
+  if (miners.some((miner) => miner.includes("S17 XP"))) {
+    await homePage.inputMinerAuthUsername("root17");
+    await homePage.inputMinerAuthPassword("root17");
+    await homePage.clickAuthenticateMinersConfirmButton();
+    await homePage.tryAction(() => homePage.clickCalloutButton());
+  }
+
+  await page.goto("/fleet/miners");
+  await minersPage.waitForMinersListToLoad();
+
+  if ((await authenticatedMinerCheckboxes.count().catch(() => 0)) === 0) {
+    throw new Error("Expected at least one authenticated miner after standalone reparent setup");
+  }
 }
 
 async function selectAllSitesIfNeeded(page: Page) {
@@ -712,7 +823,9 @@ async function deleteSiteIfCreated({
 }
 
 test.describe("Miners reparent", () => {
-  test.beforeEach(async ({ page }) => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeEach(async ({ page, authPage, addMinersPage, commonSteps, homePage, minersPage }) => {
     await page.addInitScript(
       ({ storageKey }) => {
         localStorage.setItem(
@@ -729,7 +842,10 @@ test.describe("Miners reparent", () => {
       },
       { storageKey: ACTIVE_SITE_STORAGE_KEY },
     );
-    await page.goto("/");
+
+    await ensureAdminSession({ page, authPage, commonSteps });
+    await ensureFleetInventory({ authPage, addMinersPage, minersPage });
+    await ensureAuthenticatedMovableMiners({ page, homePage, minersPage });
   });
 
   test("Move a rack to a building from the Racks tab", async ({ page, commonSteps, racksPage }) => {


### PR DESCRIPTION
Reviewable diff: +0/-0 across 0 files (excludes generated, test, and story files).

## Summary
This PR adds ProtoFleet E2E coverage for three reparent workflows that operators can trigger from the existing Fleet surfaces: moving a rack to a building, assigning a miner to a site, and assigning a miner to a rack. The spec verifies the network requests and resulting UI state for each flow, while also handling the local dev configuration where multi-site Fleet tabs may be disabled and the legacy sites/settings routes remain the stable management surface.

## How it works
The new Playwright spec provisions temporary sites, buildings, and racks as needed, performs the reparent action from the Racks or Miners tab, then validates the request payload sent to the backend and the resulting placement state visible in the app. For local environments where `VITE_MULTI_SITE_ENABLED` is off, setup and cleanup use the legacy `/settings/sites` and related site-scoped building surfaces, but the user actions under test still happen from the Fleet Racks and Miners tabs.

## Diagrams
```mermaid
flowchart LR
  A["Create temporary site/building/rack state"] --> B["Open Fleet Racks or Miners tab"]
  B --> C["Trigger reparent action from row/menu UI"]
  C --> D["Select target in ParentPickerModal"]
  D --> E["Capture assign request payload"]
  E --> F["Assert resulting placement in UI"]
  F --> G["Clean up temporary state"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/minersReparent.spec.ts` | Added a new Playwright spec covering rack-to-building, miner-to-site, and miner-to-rack reparent flows, plus environment-aware setup/cleanup helpers. | This is the full behavior change in the PR; reviewers can focus on scenario selection, assertions, and local-environment compatibility. |

## Key technical decisions & trade-offs
- The spec validates request payloads and final visible state instead of depending on transient toast copy, because the local legacy surfaces do not render every success toast consistently.
- Setup and cleanup branch between Fleet multi-site pages and legacy settings pages so the scenarios stay runnable in both local dev modes instead of requiring a flag-specific environment.
- The miner fixture selection prefers an unracked paired miner when available, but falls back to any visible miner so the scenarios remain executable against the current local seed data.

## Testing & validation
- `./node_modules/.bin/eslint e2eTests/protoFleet/spec/minersReparent.spec.ts`
- `PW_UI_NO_DEPS=1 npx playwright test spec/minersReparent.spec.ts --project=desktop`
- Not covered: mobile/browser-matrix runs and the broader ProtoFleet E2E suite.
