### PR TITLE
Add opt-in virtual miners for stress testing

### DIFF
--- a/.claude/commands/pr-describe.md
+++ b/.claude/commands/pr-describe.md
@@ -126,7 +126,10 @@ describe what the code does, not the decisions made getting there.
       they render on GitHub. At minimum a component/flow diagram of the main
       path; add a state or sequence diagram where lifecycle or ordering matters.
       Keep syntax GitHub-safe: quote labels containing special characters, avoid
-      fragile edge styles (e.g. dotted/labelled edges that GitHub mis-renders).
+      fragile edge styles (e.g. dotted/labelled edges that GitHub mis-renders),
+      and use explicit node IDs with bracketed labels (`A["Label"] --> B["Other"]`).
+      Do not use bare quoted string nodes (`"Label" --> "Other"`); GitHub's
+      Mermaid parser rejects that form in flowcharts.
    5. **Areas of the code involved** — a table so reviewers know where to focus:
       `| Area / package / file | What changed | Why it matters for review |`.
       Group by subsystem. Call out new vs. modified files, and flag generated

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -181,7 +181,9 @@ jobs:
           echo "Building Go plugins for ${{ matrix.arch }}..."
           go build -o server/proto-plugin-${{ matrix.arch }} ./plugin/proto
           go build -o server/antminer-plugin-${{ matrix.arch }} ./plugin/antminer
-          chmod +x server/proto-plugin-* server/antminer-plugin-*
+          go build -o server/virtual-plugin-${{ matrix.arch }} ./plugin/virtual
+          cp plugin/virtual/config.json server/virtual-plugin.json
+          chmod +x server/proto-plugin-* server/antminer-plugin-* server/virtual-plugin-*
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -204,6 +206,8 @@ jobs:
             fleetd-${{ matrix.arch }} \
             proto-plugin-${{ matrix.arch }} \
             antminer-plugin-${{ matrix.arch }} \
+            virtual-plugin-${{ matrix.arch }} \
+            virtual-plugin.json \
             asicrs-plugin-${{ matrix.arch }} \
             asicrs-config.yaml \
             version.txt
@@ -420,6 +424,7 @@ jobs:
           mv fleetd-${{ matrix.arch }} fleetd
           mv proto-plugin-${{ matrix.arch }} proto-plugin
           mv antminer-plugin-${{ matrix.arch }} antminer-plugin
+          mv virtual-plugin-${{ matrix.arch }} virtual-plugin
           mv asicrs-plugin-${{ matrix.arch }} asicrs-plugin
           cd ../..
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,10 @@ code does, not the decisions made getting there. Structure it as:
 4. **Diagrams** — mermaid in fenced code blocks labeled `mermaid` so they render on
    GitHub. At least a component/flow diagram of the main path; add a state or
    sequence diagram where lifecycle or ordering matters. Keep syntax
-   GitHub-safe: quote labels with special characters, avoid fragile edge styles.
+   GitHub-safe: quote labels with special characters, avoid fragile edge styles,
+   and use explicit node IDs with bracketed labels (`A["Label"] --> B["Other"]`).
+   Do not use bare quoted string nodes (`"Label" --> "Other"`); GitHub's Mermaid
+   parser rejects that form in flowcharts.
 5. **Areas of the code involved** — a table mapping each changed area to its
    role so reviewers know where to focus: `| Area / package / file | What
    changed | Why it matters for review |`. Group by subsystem (`proto/`,

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -76,6 +76,7 @@ VIRTUAL_MINER_BASELINE_VARIANCE_PERCENT=10
 
 Virtual miners simulate both network latency and miner processing latency. The
 default miner-internal latency is 200-500ms, with occasional 5-8s outliers.
+Generation is capped at 50,000 virtual miners per plugin process.
 
 ## Uninstalling Proto Fleet
 

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -53,6 +53,30 @@ The script will:
 - Preserve existing configuration files if present
 - Run the deployment script automatically
 
+## Optional Virtual Miners
+
+Deployment bundles include the virtual miner plugin for stress testing, but it
+is disabled by default and is not loaded during a regular fleet install. To
+enable it, set `ENABLE_VIRTUAL_MINERS=true` in the deployment `.env` file and
+rerun `./run-fleet.sh`.
+
+The bundled `server/virtual-plugin.json` generates 1000 miners by default in
+the `10.255.x.x` range; discover them from ProtoFleet with IP List discovery
+starting at `10.255.0.2`.
+
+For larger curtailment stress tests, add generation overrides to `.env`:
+
+```bash
+ENABLE_VIRTUAL_MINERS=true
+VIRTUAL_MINER_COUNT=5000
+VIRTUAL_MINER_IP_START=10.255.0.2
+VIRTUAL_MINER_SERIAL_PREFIX=VM
+VIRTUAL_MINER_BASELINE_VARIANCE_PERCENT=10
+```
+
+Virtual miners simulate both network latency and miner processing latency. The
+default miner-internal latency is 200-500ms, with occasional 5-8s outliers.
+
 ## Uninstalling Proto Fleet
 
 ```bash

--- a/deployment-files/docker-compose.yaml
+++ b/deployment-files/docker-compose.yaml
@@ -17,6 +17,12 @@ services:
       SESSION_COOKIE_SECURE: "${SESSION_COOKIE_SECURE:-true}"
       PLUGINS_DIR: "/app/plugins"
       PLUGINS_ENABLED: "true"
+      ENABLE_VIRTUAL_MINERS: "${ENABLE_VIRTUAL_MINERS:-false}"
+      VIRTUAL_MINER_CONFIG: "/app/plugins/virtual-plugin.json"
+      VIRTUAL_MINER_COUNT: "${VIRTUAL_MINER_COUNT:-}"
+      VIRTUAL_MINER_IP_START: "${VIRTUAL_MINER_IP_START:-}"
+      VIRTUAL_MINER_SERIAL_PREFIX: "${VIRTUAL_MINER_SERIAL_PREFIX:-}"
+      VIRTUAL_MINER_BASELINE_VARIANCE_PERCENT: "${VIRTUAL_MINER_BASELINE_VARIANCE_PERCENT:-}"
     depends_on:
       timescaledb:
         condition: service_healthy

--- a/deployment-files/server/Dockerfile
+++ b/deployment-files/server/Dockerfile
@@ -8,9 +8,10 @@ COPY fleetd /app/
 
 RUN mkdir -p /app/plugins
 COPY proto-plugin antminer-plugin asicrs-plugin asicrs-config.yaml /app/plugins/
+COPY virtual-plugin virtual-plugin.json /app/optional-plugins/
 
-RUN chmod 755 /app/fleetd /app/plugins/*-plugin
+RUN chmod 755 /app/fleetd /app/plugins/*-plugin /app/optional-plugins/virtual-plugin
 
 EXPOSE 4000
 
-CMD ["/app/fleetd"]
+CMD ["sh", "-c", "case \"${ENABLE_VIRTUAL_MINERS:-false}\" in true|1|yes|YES|on|ON) cp /app/optional-plugins/virtual-plugin /app/optional-plugins/virtual-plugin.json /app/plugins/ ;; esac; exec /app/fleetd"]

--- a/docs/solutions/best-practices/github-safe-mermaid-pr-descriptions-2026-06-22.md
+++ b/docs/solutions/best-practices/github-safe-mermaid-pr-descriptions-2026-06-22.md
@@ -1,0 +1,67 @@
+---
+title: GitHub-safe Mermaid diagrams in PR descriptions
+date: 2026-06-22
+category: docs/solutions/best-practices
+module: documentation
+problem_type: pr_description_rendering
+component: pr_descriptions
+symptoms:
+  - "GitHub PR description shows 'Unable to render rich display'"
+  - "Mermaid parse error near a quoted flowchart node label"
+root_cause: mermaid_syntax_incompatibility
+resolution_type: documentation_guardrail
+severity: medium
+related_components:
+  - AGENTS.md
+  - .claude/commands/pr-describe.md
+tags: [github, mermaid, pr-description, diagrams, agent-guidance]
+---
+
+# GitHub-safe Mermaid diagrams in PR descriptions
+
+## Problem
+
+GitHub's Mermaid renderer rejects flowcharts that use bare quoted strings as
+node identifiers:
+
+```mermaid
+flowchart TD
+  "Release artifact build" --> "Server tarball includes virtual-plugin and config"
+```
+
+That form can produce a PR description error like:
+
+```text
+Unable to render rich display
+Parse error ... got 'STR'
+```
+
+## Solution
+
+Use stable node IDs with bracketed quoted labels:
+
+```mermaid
+flowchart TD
+  A["Release artifact build"] --> B["Server tarball includes virtual-plugin and config"]
+```
+
+For labels with punctuation, paths, environment variables, or spaces, keep the
+text inside the bracketed label and keep the node ID simple:
+
+```mermaid
+flowchart TD
+  Start["ENABLE_VIRTUAL_MINERS=true"] --> Copy["Copy /app/optional-plugins into /app/plugins"]
+  Copy --> Loader["Fleet API plugin loader"]
+```
+
+## Prevention
+
+- In PR descriptions, never write flowchart edges between bare quoted strings
+  like `"Label" --> "Other"`.
+- Always use explicit node IDs plus bracketed labels:
+  `A["Label"] --> B["Other"]`.
+- Keep IDs alphanumeric and short (`A`, `Build`, `PluginLoader`); put all
+  reviewer-facing text in the label.
+- If editing `.claude/commands/pr-describe.md` or `AGENTS.md`, preserve this
+  rule in the PR-description diagram guidance.
+

--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ rebuild-plugin name:
       ;;
     virtual)
       (cd plugin/virtual && GOOS=linux GOARCH=arm64 go build -o ../../server/plugins/virtual-plugin .)
-      cp plugin/virtual/config.json server/plugins/
+      cp plugin/virtual/config.json server/plugins/virtual-plugin.json
       chmod +x server/plugins/virtual-plugin
       ;;
     asicrs)
@@ -312,6 +312,7 @@ _build-go-plugins-native outdir: _go-work-sync
   ANT_BIN={{outdir}}/antminer-plugin
   PLATFORM_MARKER={{outdir}}/.go-plugins-platform
   WANT_PLATFORM="native"
+  rm -f {{outdir}}/virtual-plugin {{outdir}}/virtual-plugin.json {{outdir}}/config.json
   if [ -f "$PROTO_BIN" ] && [ -f "$ANT_BIN" ] \
      && [ -f "$PLATFORM_MARKER" ] && [ "$(cat "$PLATFORM_MARKER")" = "$WANT_PLATFORM" ] \
      && [ -z "$(find $SOURCES -newer "$PROTO_BIN" -type f 2>/dev/null | head -1)" ] \
@@ -335,6 +336,7 @@ _build-go-plugins-cross goos goarch outdir: _go-work-sync
   ANT_BIN={{outdir}}/antminer-plugin
   PLATFORM_MARKER={{outdir}}/.go-plugins-platform
   WANT_PLATFORM="{{goos}}/{{goarch}}"
+  rm -f {{outdir}}/virtual-plugin {{outdir}}/virtual-plugin.json {{outdir}}/config.json
   if [ -f "$PROTO_BIN" ] && [ -f "$ANT_BIN" ] \
      && [ -f "$PLATFORM_MARKER" ] && [ "$(cat "$PLATFORM_MARKER")" = "$WANT_PLATFORM" ] \
      && [ -z "$(find $SOURCES -newer "$PROTO_BIN" -type f 2>/dev/null | head -1)" ] \
@@ -356,8 +358,11 @@ _build-go-plugins-multi-arch: _go-work-sync
   mkdir -p deployment-files/server
   (cd plugin/proto && GOOS=linux GOARCH=amd64 go build -o ../../deployment-files/server/proto-plugin-amd64 .)
   (cd plugin/antminer && GOOS=linux GOARCH=amd64 go build -o ../../deployment-files/server/antminer-plugin-amd64 .)
+  (cd plugin/virtual && GOOS=linux GOARCH=amd64 go build -o ../../deployment-files/server/virtual-plugin-amd64 .)
   (cd plugin/proto && GOOS=linux GOARCH=arm64 go build -o ../../deployment-files/server/proto-plugin-arm64 .)
   (cd plugin/antminer && GOOS=linux GOARCH=arm64 go build -o ../../deployment-files/server/antminer-plugin-arm64 .)
+  (cd plugin/virtual && GOOS=linux GOARCH=arm64 go build -o ../../deployment-files/server/virtual-plugin-arm64 .)
+  cp plugin/virtual/config.json deployment-files/server/virtual-plugin.json
   chmod +x deployment-files/server/*-plugin-*
 
 _asicrs-build outdir="server/plugins":

--- a/plugin/virtual/README.md
+++ b/plugin/virtual/README.md
@@ -83,7 +83,7 @@ Generate a fleet of miners with randomized but realistic telemetry:
 }
 ```
 
-- **count**: Number of miners to generate
+- **count**: Number of miners to generate, capped at 50,000 per plugin process
 - **serial_prefix**: Prefix for serial numbers (e.g., "VM" → "VM0001")
 - **ip_start**: First IP address (increments sequentially)
 - **baseline_variance_percent**: Random variance applied to telemetry values (±%)
@@ -177,8 +177,9 @@ To test with thousands of miners from a source checkout:
 3. Use IP List discovery starting at `10.255.0.2`
 
 For an installed deployment, set `ENABLE_VIRTUAL_MINERS=true` and
-`VIRTUAL_MINER_COUNT` in `.env`, then rerun `./run-fleet.sh`. The virtual IP
-range supports roughly 65,000 configured miners, so curtailment stress tests
-can exercise batches well beyond the default 1000-miner config.
+`VIRTUAL_MINER_COUNT` in `.env`, then rerun `./run-fleet.sh`. Generation is
+capped at 50,000 miners per plugin process, so curtailment stress tests can
+exercise batches well beyond the default 1000-miner config without allowing
+accidental oversized startup allocations.
 
 Discovery time depends on count, system load, and timeout settings.

--- a/plugin/virtual/README.md
+++ b/plugin/virtual/README.md
@@ -18,6 +18,11 @@ A simulated miner plugin for testing and demonstration purposes. Virtual miners 
 
 4. Pair discovered miners (any credentials work, or use defaults: `virtual`/`virtual`).
 
+Installed deployment bundles also include `virtual-plugin` for stress testing,
+but regular installs do not load it. For deployed fleets, set
+`ENABLE_VIRTUAL_MINERS=true` and `VIRTUAL_MINER_COUNT` in the deployment
+`.env`, then rerun `./run-fleet.sh`.
+
 ## IP Address Range
 
 Virtual miners use the reserved `10.255.x.x` IP range to avoid conflicts with real network devices:
@@ -84,6 +89,16 @@ Generate a fleet of miners with randomized but realistic telemetry:
 - **baseline_variance_percent**: Random variance applied to telemetry values (±%)
 - **profiles**: Miner profiles with weighted selection (weights are relative)
 
+Deployment installs can override the generation settings without editing JSON:
+
+```bash
+ENABLE_VIRTUAL_MINERS=true
+VIRTUAL_MINER_COUNT=5000
+VIRTUAL_MINER_IP_START=10.255.0.2
+VIRTUAL_MINER_SERIAL_PREFIX=VM
+VIRTUAL_MINER_BASELINE_VARIANCE_PERCENT=10
+```
+
 ### Manual Configuration
 
 Define specific miners individually:
@@ -121,12 +136,49 @@ Virtual miners support all standard device capabilities:
 - **Cooling modes**: Air and immersion cooling
 - **Telemetry**: Hashrate, power, temperature, fan speed, efficiency, per-board stats, PSU stats
 
+## Latency Simulation
+
+Virtual miners simulate both network and miner-internal latency. Defaults are:
+
+- Network latency: 5-50ms, with 1% outliers from 250-1000ms
+- Miner-internal latency: 200-500ms, with 1% outliers from 5-8s
+
+You can override latency per profile or miner:
+
+```json
+{
+  "behavior": {
+    "network_latency": {
+      "enabled": true,
+      "min_ms": 5,
+      "max_ms": 50,
+      "outlier_probability": 0.01,
+      "outlier_min_ms": 250,
+      "outlier_max_ms": 1000
+    },
+    "internal_latency": {
+      "enabled": true,
+      "min_ms": 200,
+      "max_ms": 500,
+      "outlier_probability": 0.01,
+      "outlier_min_ms": 5000,
+      "outlier_max_ms": 8000
+    }
+  }
+}
+```
+
 ## Testing Large Fleets
 
-To test with 1000+ miners:
+To test with thousands of miners from a source checkout:
 
-1. Set `"count": 1000` in config.json
+1. Set `"count"` in config.json
 2. Rebuild and restart: `just build-virtual-plugin && cd server && just rebuild-fleet-api`
-3. Use IP List discovery with range: `10.255.0.2` - `10.255.3.234` (for 1000 miners)
+3. Use IP List discovery starting at `10.255.0.2`
 
-Discovery of 1000 miners takes approximately 2-5 minutes depending on system load and timeout settings.
+For an installed deployment, set `ENABLE_VIRTUAL_MINERS=true` and
+`VIRTUAL_MINER_COUNT` in `.env`, then rerun `./run-fleet.sh`. The virtual IP
+range supports roughly 65,000 configured miners, so curtailment stress tests
+can exercise batches well beyond the default 1000-miner config.
+
+Discovery time depends on count, system load, and timeout settings.

--- a/plugin/virtual/internal/config/config.go
+++ b/plugin/virtual/internal/config/config.go
@@ -26,6 +26,9 @@ const (
 	defaultBaselineVariancePercent = 10.0
 	// Temperature varies less than other metrics because it's more stable in real miners
 	tempVarianceDivisor = 2.0
+	// maxGeneratedMinerCount prevents accidental startup allocations that can
+	// OOM the virtual plugin while still supporting large stress-test fleets.
+	maxGeneratedMinerCount = 50000
 
 	// Environment overrides used by deployed installs.
 	envMinerCount              = "VIRTUAL_MINER_COUNT"
@@ -138,7 +141,7 @@ type GenerateConfig struct {
 	// IPStart is the starting IP address (e.g., "10.255.0.2")
 	IPStart string `json:"ip_start"`
 	// BaselineVariancePercent adds per-miner variance to baseline metrics (0-50)
-	BaselineVariancePercent float64 `json:"baseline_variance_percent"`
+	BaselineVariancePercent *float64 `json:"baseline_variance_percent"`
 	// Profiles defines miner templates to use; if empty, uses default profile
 	Profiles []MinerProfile `json:"profiles"`
 }
@@ -206,7 +209,7 @@ func applyEnvironmentOverrides(cfg *Config) error {
 		if err != nil || variance < 0 || variance > 50 {
 			return fmt.Errorf("%s must be a number between 0 and 50", envBaselineVariancePercent)
 		}
-		ensureGenerateConfig(cfg).BaselineVariancePercent = variance
+		ensureGenerateConfig(cfg).BaselineVariancePercent = &variance
 	}
 	return nil
 }
@@ -229,15 +232,18 @@ func generateMiners(gen *GenerateConfig) ([]VirtualMinerConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid ip_start: %w", err)
 	}
+	if err := validateGenerateConfig(gen, thirdOctet, fourthOctet); err != nil {
+		return nil, err
+	}
 
 	// Set defaults
 	prefix := gen.SerialPrefix
 	if prefix == "" {
 		prefix = "VM"
 	}
-	variancePercent := gen.BaselineVariancePercent
-	if variancePercent <= 0 {
-		variancePercent = defaultBaselineVariancePercent
+	variancePercent := defaultBaselineVariancePercent
+	if gen.BaselineVariancePercent != nil {
+		variancePercent = *gen.BaselineVariancePercent
 	}
 
 	// Build profile selector
@@ -294,6 +300,29 @@ func generateMiners(gen *GenerateConfig) ([]VirtualMinerConfig, error) {
 	return miners, nil
 }
 
+func validateGenerateConfig(gen *GenerateConfig, thirdOctet, fourthOctet int) error {
+	if gen.Count > maxGeneratedMinerCount {
+		return fmt.Errorf("count must be <= %d", maxGeneratedMinerCount)
+	}
+	availableIPs := generatedMinerIPCapacity(thirdOctet, fourthOctet)
+	if gen.Count > availableIPs {
+		return fmt.Errorf("count %d exceeds available virtual IP addresses from %s (%d available)", gen.Count, virtualIPStart(thirdOctet, fourthOctet), availableIPs)
+	}
+	if gen.BaselineVariancePercent != nil && (*gen.BaselineVariancePercent < 0 || *gen.BaselineVariancePercent > 50) {
+		return fmt.Errorf("baseline_variance_percent must be between 0 and 50")
+	}
+	return nil
+}
+
+func generatedMinerIPCapacity(thirdOctet, fourthOctet int) int {
+	hostsPerThirdOctet := maxHostOctet - minHostOctet + 1
+	return (maxThirdOctet-thirdOctet)*hostsPerThirdOctet + (maxHostOctet - fourthOctet + 1)
+}
+
+func virtualIPStart(thirdOctet, fourthOctet int) string {
+	return fmt.Sprintf("%d.%d.%d.%d", virtualIPFirstOctet, virtualIPSecondOctet, thirdOctet, fourthOctet)
+}
+
 // parseVirtualIP extracts third and fourth octets from a 10.255.x.y IP.
 func parseVirtualIP(ip string) (thirdOctet, fourthOctet int, err error) {
 	if ip == "" {
@@ -308,6 +337,10 @@ func parseVirtualIP(ip string) (thirdOctet, fourthOctet int, err error) {
 
 	if first != virtualIPFirstOctet || second != virtualIPSecondOctet {
 		return 0, 0, fmt.Errorf("IP must be in 10.255.x.x range: %s", ip)
+	}
+
+	if thirdOctet < 0 || thirdOctet > maxThirdOctet {
+		return 0, 0, fmt.Errorf("third octet must be 0-%d: %s", maxThirdOctet, ip)
 	}
 
 	if fourthOctet < minHostOctet || fourthOctet > maxHostOctet {

--- a/plugin/virtual/internal/config/config.go
+++ b/plugin/virtual/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -25,6 +26,12 @@ const (
 	defaultBaselineVariancePercent = 10.0
 	// Temperature varies less than other metrics because it's more stable in real miners
 	tempVarianceDivisor = 2.0
+
+	// Environment overrides used by deployed installs.
+	envMinerCount              = "VIRTUAL_MINER_COUNT"
+	envMinerSerialPrefix       = "VIRTUAL_MINER_SERIAL_PREFIX"
+	envMinerIPStart            = "VIRTUAL_MINER_IP_START"
+	envBaselineVariancePercent = "VIRTUAL_MINER_BASELINE_VARIANCE_PERCENT"
 )
 
 // BehaviorConfig defines runtime behavior settings for a virtual miner.
@@ -33,8 +40,28 @@ type BehaviorConfig struct {
 	HashrateVariancePercent float64 `json:"hashrate_variance_percent"`
 	// TempVarianceC controls temperature fluctuation in Celsius.
 	TempVarianceC float64 `json:"temp_variance_c"`
+	// NetworkLatency simulates transport overhead between Fleet and the miner.
+	NetworkLatency LatencyConfig `json:"network_latency"`
+	// InternalLatency simulates time spent inside the miner processing a request.
+	InternalLatency LatencyConfig `json:"internal_latency"`
 	// ErrorInjection controls simulated error conditions.
 	ErrorInjection ErrorInjectionConfig `json:"error_injection"`
+}
+
+// LatencyConfig controls simulated latency in milliseconds.
+type LatencyConfig struct {
+	// Enabled controls whether this latency component is sampled. Nil means use defaults.
+	Enabled *bool `json:"enabled,omitempty"`
+	// MinMS is the lower bound for normal latency in milliseconds.
+	MinMS int `json:"min_ms"`
+	// MaxMS is the upper bound for normal latency in milliseconds.
+	MaxMS int `json:"max_ms"`
+	// OutlierProbability is the chance (0-1) of sampling from the outlier range.
+	OutlierProbability float64 `json:"outlier_probability"`
+	// OutlierMinMS is the lower bound for outlier latency in milliseconds.
+	OutlierMinMS int `json:"outlier_min_ms"`
+	// OutlierMaxMS is the upper bound for outlier latency in milliseconds.
+	OutlierMaxMS int `json:"outlier_max_ms"`
 }
 
 // ErrorInjectionConfig allows simulation of error conditions.
@@ -136,6 +163,10 @@ func LoadFromFile(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
+	if err := applyEnvironmentOverrides(&cfg); err != nil {
+		return nil, err
+	}
+
 	// Generate miners if configured
 	if cfg.Generate != nil && cfg.Generate.Count > 0 {
 		generated, err := generateMiners(cfg.Generate)
@@ -154,6 +185,37 @@ func LoadFromFile(path string) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+func applyEnvironmentOverrides(cfg *Config) error {
+	if countText, ok := os.LookupEnv(envMinerCount); ok && countText != "" {
+		count, err := strconv.Atoi(countText)
+		if err != nil || count < 0 {
+			return fmt.Errorf("%s must be a non-negative integer", envMinerCount)
+		}
+		ensureGenerateConfig(cfg).Count = count
+	}
+	if serialPrefix, ok := os.LookupEnv(envMinerSerialPrefix); ok && serialPrefix != "" {
+		ensureGenerateConfig(cfg).SerialPrefix = serialPrefix
+	}
+	if ipStart, ok := os.LookupEnv(envMinerIPStart); ok && ipStart != "" {
+		ensureGenerateConfig(cfg).IPStart = ipStart
+	}
+	if varianceText, ok := os.LookupEnv(envBaselineVariancePercent); ok && varianceText != "" {
+		variance, err := strconv.ParseFloat(varianceText, 64)
+		if err != nil || variance < 0 || variance > 50 {
+			return fmt.Errorf("%s must be a number between 0 and 50", envBaselineVariancePercent)
+		}
+		ensureGenerateConfig(cfg).BaselineVariancePercent = variance
+	}
+	return nil
+}
+
+func ensureGenerateConfig(cfg *Config) *GenerateConfig {
+	if cfg.Generate == nil {
+		cfg.Generate = &GenerateConfig{}
+	}
+	return cfg.Generate
 }
 
 // generateMiners creates miners based on the generation config.
@@ -419,6 +481,100 @@ func validateAndSetDefaults(m *VirtualMinerConfig) error {
 	if m.Behavior.TempVarianceC == 0 {
 		m.Behavior.TempVarianceC = 3.0
 	}
+	if err := validateAndSetLatencyDefaults("network_latency", &m.Behavior.NetworkLatency, defaultNetworkLatency()); err != nil {
+		return err
+	}
+	if err := validateAndSetLatencyDefaults("internal_latency", &m.Behavior.InternalLatency, defaultInternalLatency()); err != nil {
+		return err
+	}
 
 	return nil
+}
+
+func validateAndSetLatencyDefaults(name string, latency *LatencyConfig, defaults LatencyConfig) error {
+	if latency.Enabled != nil && !*latency.Enabled {
+		return nil
+	}
+	if latency.Enabled == nil && latency.MinMS == 0 && latency.MaxMS == 0 &&
+		latency.OutlierProbability == 0 && latency.OutlierMinMS == 0 && latency.OutlierMaxMS == 0 {
+		*latency = defaults
+		return nil
+	}
+
+	if latency.Enabled == nil {
+		latency.Enabled = boolPtr(true)
+	}
+	if latency.MinMS < 0 || latency.MaxMS < 0 || latency.OutlierMinMS < 0 || latency.OutlierMaxMS < 0 {
+		return fmt.Errorf("%s latency values must be non-negative", name)
+	}
+	if latency.MaxMS == 0 {
+		latency.MaxMS = latency.MinMS
+	}
+	if latency.MaxMS < latency.MinMS {
+		return fmt.Errorf("%s max_ms must be greater than or equal to min_ms", name)
+	}
+	if latency.OutlierProbability < 0 || latency.OutlierProbability > 1 {
+		return fmt.Errorf("%s outlier_probability must be between 0 and 1", name)
+	}
+	if latency.OutlierProbability > 0 {
+		if latency.OutlierMinMS == 0 {
+			latency.OutlierMinMS = defaults.OutlierMinMS
+		}
+		if latency.OutlierMaxMS == 0 {
+			latency.OutlierMaxMS = latency.OutlierMinMS
+		}
+		if latency.OutlierMaxMS < latency.OutlierMinMS {
+			return fmt.Errorf("%s outlier_max_ms must be greater than or equal to outlier_min_ms", name)
+		}
+	}
+	return nil
+}
+
+func defaultNetworkLatency() LatencyConfig {
+	return LatencyConfig{
+		Enabled:            boolPtr(true),
+		MinMS:              5,
+		MaxMS:              50,
+		OutlierProbability: 0.01,
+		OutlierMinMS:       250,
+		OutlierMaxMS:       1000,
+	}
+}
+
+func defaultInternalLatency() LatencyConfig {
+	return LatencyConfig{
+		Enabled:            boolPtr(true),
+		MinMS:              200,
+		MaxMS:              500,
+		OutlierProbability: 0.01,
+		OutlierMinMS:       5000,
+		OutlierMaxMS:       8000,
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+// Sample returns a latency duration from this config. It is safe to call with
+// zero-value latency configs; those sample as no latency.
+func (l LatencyConfig) Sample(rng *rand.Rand) time.Duration {
+	if l.Enabled != nil && !*l.Enabled {
+		return 0
+	}
+	if l.MaxMS <= 0 {
+		return 0
+	}
+	if rng == nil {
+		rng = rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 3))
+	}
+
+	minMS, maxMS := l.MinMS, l.MaxMS
+	if l.OutlierProbability > 0 && rng.Float64() < l.OutlierProbability && l.OutlierMaxMS > 0 {
+		minMS, maxMS = l.OutlierMinMS, l.OutlierMaxMS
+	}
+	if maxMS <= minMS {
+		return time.Duration(minMS) * time.Millisecond
+	}
+	return time.Duration(minMS+rng.IntN(maxMS-minMS+1)) * time.Millisecond
 }

--- a/plugin/virtual/internal/config/config_test.go
+++ b/plugin/virtual/internal/config/config_test.go
@@ -51,10 +51,70 @@ func TestLoadFromFile_DefaultLatencyProfile(t *testing.T) {
 	assert.Equal(t, 8000, miner.Behavior.InternalLatency.OutlierMaxMS)
 }
 
+func TestLoadFromFile_ExplicitZeroBaselineVariancePreserved(t *testing.T) {
+	path := writeConfig(t, Config{
+		Generate: &GenerateConfig{
+			Count:                   1,
+			IPStart:                 "10.255.0.2",
+			BaselineVariancePercent: float64Ptr(0),
+			Profiles: []MinerProfile{{
+				Weight:              1,
+				Model:               "Exact",
+				Manufacturer:        "Virtual",
+				Hashboards:          3,
+				ASICsPerBoard:       76,
+				FanCount:            4,
+				BaselineHashrateTHS: 125,
+				BaselinePowerW:      3100,
+				BaselineTempC:       67,
+				FanRPMMin:           3000,
+				FanRPMMax:           5000,
+			}},
+		},
+	})
+
+	cfg, err := LoadFromFile(path)
+
+	require.NoError(t, err)
+	require.Len(t, cfg.Miners, 1)
+	assert.Equal(t, 125.0, cfg.Miners[0].BaselineHashrateTHS)
+	assert.Equal(t, 3100.0, cfg.Miners[0].BaselinePowerW)
+	assert.Equal(t, 67.0, cfg.Miners[0].BaselineTempC)
+}
+
+func TestLoadFromFile_RejectsGeneratedMinerCountAboveOperationalLimit(t *testing.T) {
+	t.Setenv(envMinerCount, "50001")
+
+	path := writeConfig(t, Config{
+		Generate: &GenerateConfig{Count: 1, IPStart: "10.255.0.2"},
+	})
+
+	_, err := LoadFromFile(path)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "count must be <= 50000")
+}
+
+func TestLoadFromFile_RejectsGeneratedMinerCountBeyondVirtualIPRange(t *testing.T) {
+	path := writeConfig(t, Config{
+		Generate: &GenerateConfig{Count: 2, IPStart: "10.255.255.254"},
+	})
+
+	_, err := LoadFromFile(path)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "count 2 exceeds available virtual IP addresses")
+	assert.Contains(t, err.Error(), "1 available")
+}
+
 func TestLatencyConfig_SampleZeroValueHasNoLatency(t *testing.T) {
 	var latency LatencyConfig
 
 	assert.Equal(t, time.Duration(0), latency.Sample(nil))
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
 }
 
 func writeConfig(t *testing.T, cfg Config) string {

--- a/plugin/virtual/internal/config/config_test.go
+++ b/plugin/virtual/internal/config/config_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFromFile_EnvironmentOverridesGeneratedMiners(t *testing.T) {
+	t.Setenv(envMinerCount, "3")
+	t.Setenv(envMinerSerialPrefix, "LOAD")
+	t.Setenv(envMinerIPStart, "10.255.4.10")
+	t.Setenv(envBaselineVariancePercent, "12")
+
+	path := writeConfig(t, Config{
+		Generate: &GenerateConfig{Count: 1, SerialPrefix: "VM", IPStart: "10.255.0.2"},
+	})
+
+	cfg, err := LoadFromFile(path)
+
+	require.NoError(t, err)
+	require.Len(t, cfg.Miners, 3)
+	assert.Equal(t, "LOAD0001", cfg.Miners[0].SerialNumber)
+	assert.Equal(t, "10.255.4.10", cfg.Miners[0].IPAddress)
+	assert.Equal(t, "10.255.4.12", cfg.Miners[2].IPAddress)
+}
+
+func TestLoadFromFile_DefaultLatencyProfile(t *testing.T) {
+	path := writeConfig(t, Config{
+		Miners: []VirtualMinerConfig{{
+			SerialNumber: "VM001",
+			IPAddress:    "10.255.0.2",
+		}},
+	})
+
+	cfg, err := LoadFromFile(path)
+
+	require.NoError(t, err)
+	require.Len(t, cfg.Miners, 1)
+	miner := cfg.Miners[0]
+	assert.Equal(t, 5, miner.Behavior.NetworkLatency.MinMS)
+	assert.Equal(t, 50, miner.Behavior.NetworkLatency.MaxMS)
+	assert.Equal(t, 200, miner.Behavior.InternalLatency.MinMS)
+	assert.Equal(t, 500, miner.Behavior.InternalLatency.MaxMS)
+	assert.Equal(t, 5000, miner.Behavior.InternalLatency.OutlierMinMS)
+	assert.Equal(t, 8000, miner.Behavior.InternalLatency.OutlierMaxMS)
+}
+
+func TestLatencyConfig_SampleZeroValueHasNoLatency(t *testing.T) {
+	var latency LatencyConfig
+
+	assert.Equal(t, time.Duration(0), latency.Sample(nil))
+}
+
+func writeConfig(t *testing.T, cfg Config) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+	return path
+}

--- a/plugin/virtual/internal/device/device.go
+++ b/plugin/virtual/internal/device/device.go
@@ -4,6 +4,7 @@ package device
 import (
 	"context"
 	"log/slog"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -23,6 +24,7 @@ type Device struct {
 	deviceInfo sdk.DeviceInfo
 	config     *config.VirtualMinerConfig
 	simulator  *virtual.Simulator
+	latencyRNG *rand.Rand
 
 	// Simulated state
 	isMining        bool
@@ -38,7 +40,8 @@ type Device struct {
 	lastStatus   *sdk.DeviceMetrics
 	lastStatusAt time.Time
 
-	mutex sync.Mutex
+	mutex     sync.Mutex
+	latencyMu sync.Mutex
 }
 
 // New creates a new virtual device instance.
@@ -48,6 +51,7 @@ func New(id string, deviceInfo sdk.DeviceInfo, cfg *config.VirtualMinerConfig) *
 		deviceInfo:      deviceInfo,
 		config:          cfg,
 		simulator:       virtual.NewSimulator(cfg),
+		latencyRNG:      rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 1)),
 		isMining:        true, // Start in mining state by default
 		coolingMode:     sdk.CoolingModeAirCooled,
 		performanceMode: sdk.PerformanceModeMaximumHashrate,
@@ -61,7 +65,10 @@ func (d *Device) ID() string {
 }
 
 // DescribeDevice implements sdk.DeviceCore.
-func (d *Device) DescribeDevice(_ context.Context) (sdk.DeviceInfo, sdk.Capabilities, error) {
+func (d *Device) DescribeDevice(ctx context.Context) (sdk.DeviceInfo, sdk.Capabilities, error) {
+	if err := d.waitForLatency(ctx, false); err != nil {
+		return sdk.DeviceInfo{}, nil, err
+	}
 	return d.deviceInfo, sdk.Capabilities{
 		sdk.CapabilityPollingHost:       true,
 		sdk.CapabilityReboot:            true,
@@ -84,7 +91,11 @@ func (d *Device) DescribeDevice(_ context.Context) (sdk.DeviceInfo, sdk.Capabili
 }
 
 // Status implements sdk.DeviceCore.
-func (d *Device) Status(_ context.Context) (sdk.DeviceMetrics, error) {
+func (d *Device) Status(ctx context.Context) (sdk.DeviceMetrics, error) {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return sdk.DeviceMetrics{}, err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -108,7 +119,11 @@ func (d *Device) Close(_ context.Context) error {
 }
 
 // StartMining implements sdk.DeviceControl.
-func (d *Device) StartMining(_ context.Context) error {
+func (d *Device) StartMining(ctx context.Context) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -120,7 +135,11 @@ func (d *Device) StartMining(_ context.Context) error {
 }
 
 // StopMining implements sdk.DeviceControl.
-func (d *Device) StopMining(_ context.Context) error {
+func (d *Device) StopMining(ctx context.Context) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -132,13 +151,20 @@ func (d *Device) StopMining(_ context.Context) error {
 }
 
 // BlinkLED implements sdk.DeviceControl.
-func (d *Device) BlinkLED(_ context.Context) error {
+func (d *Device) BlinkLED(ctx context.Context) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
 	slog.Info("Virtual miner LED blink triggered", "device_id", d.id)
 	return nil
 }
 
 // Reboot implements sdk.DeviceControl.
-func (d *Device) Reboot(_ context.Context) error {
+func (d *Device) Reboot(ctx context.Context) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -155,9 +181,12 @@ func (d *Device) Reboot(_ context.Context) error {
 }
 
 // Curtail honors FULL and rejects reserved levels.
-func (d *Device) Curtail(_ context.Context, req sdk.CurtailRequest) error {
+func (d *Device) Curtail(ctx context.Context, req sdk.CurtailRequest) error {
 	if req.Level != sdk.CurtailLevelFull {
 		return sdk.NewErrCurtailCapabilityNotSupported(d.id, int32(req.Level))
+	}
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
 	}
 
 	d.mutex.Lock()
@@ -175,7 +204,11 @@ func (d *Device) Curtail(_ context.Context, req sdk.CurtailRequest) error {
 }
 
 // Uncurtail clears curtailment; duplicate calls are no-ops.
-func (d *Device) Uncurtail(_ context.Context, _ sdk.UncurtailRequest) error {
+func (d *Device) Uncurtail(ctx context.Context, _ sdk.UncurtailRequest) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -201,7 +234,11 @@ func (d *Device) clearCurtailmentStateLocked() {
 }
 
 // GetCoolingMode implements sdk.DeviceConfiguration.
-func (d *Device) GetCoolingMode(_ context.Context) (sdk.CoolingMode, error) {
+func (d *Device) GetCoolingMode(ctx context.Context) (sdk.CoolingMode, error) {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return sdk.CoolingModeUnspecified, err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -209,7 +246,11 @@ func (d *Device) GetCoolingMode(_ context.Context) (sdk.CoolingMode, error) {
 }
 
 // SetCoolingMode implements sdk.DeviceConfiguration.
-func (d *Device) SetCoolingMode(_ context.Context, mode sdk.CoolingMode) error {
+func (d *Device) SetCoolingMode(ctx context.Context, mode sdk.CoolingMode) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -219,7 +260,11 @@ func (d *Device) SetCoolingMode(_ context.Context, mode sdk.CoolingMode) error {
 }
 
 // SetPowerTarget implements sdk.DeviceConfiguration.
-func (d *Device) SetPowerTarget(_ context.Context, mode sdk.PerformanceMode) error {
+func (d *Device) SetPowerTarget(ctx context.Context, mode sdk.PerformanceMode) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -229,7 +274,11 @@ func (d *Device) SetPowerTarget(_ context.Context, mode sdk.PerformanceMode) err
 }
 
 // UpdateMiningPools implements sdk.DeviceConfiguration.
-func (d *Device) UpdateMiningPools(_ context.Context, pools []sdk.MiningPoolConfig) error {
+func (d *Device) UpdateMiningPools(ctx context.Context, pools []sdk.MiningPoolConfig) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -239,7 +288,11 @@ func (d *Device) UpdateMiningPools(_ context.Context, pools []sdk.MiningPoolConf
 }
 
 // GetMiningPools implements sdk.DeviceConfiguration.
-func (d *Device) GetMiningPools(_ context.Context) ([]sdk.ConfiguredPool, error) {
+func (d *Device) GetMiningPools(ctx context.Context) ([]sdk.ConfiguredPool, error) {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return nil, err
+	}
+
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -255,24 +308,36 @@ func (d *Device) GetMiningPools(_ context.Context) ([]sdk.ConfiguredPool, error)
 }
 
 // UpdateMinerPassword implements sdk.DeviceConfiguration.
-func (d *Device) UpdateMinerPassword(_ context.Context, _, _ string) error {
+func (d *Device) UpdateMinerPassword(ctx context.Context, _, _ string) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
 	slog.Info("Virtual miner password update requested (no-op)", "device_id", d.id)
 	return nil
 }
 
 // DownloadLogs implements sdk.DeviceMaintenance.
-func (d *Device) DownloadLogs(_ context.Context, _ *time.Time, _ string) (string, bool, error) {
+func (d *Device) DownloadLogs(ctx context.Context, _ *time.Time, _ string) (string, bool, error) {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return "", false, err
+	}
 	return "Virtual miner log data - no actual logs available", false, nil
 }
 
 // FirmwareUpdate implements sdk.DeviceMaintenance.
-func (d *Device) FirmwareUpdate(_ context.Context, _ sdk.FirmwareFile) error {
+func (d *Device) FirmwareUpdate(ctx context.Context, _ sdk.FirmwareFile) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
 	slog.Info("Virtual miner firmware update requested (no-op)", "device_id", d.id)
 	return nil
 }
 
 // Unpair implements sdk.DeviceMaintenance.
-func (d *Device) Unpair(_ context.Context) error {
+func (d *Device) Unpair(ctx context.Context) error {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return err
+	}
 	slog.Info("Virtual miner unpaired", "device_id", d.id)
 	return nil
 }
@@ -280,11 +345,40 @@ func (d *Device) Unpair(_ context.Context) error {
 // GetErrors implements sdk.DeviceErrorReporting.
 // Virtual miners report errors based on error injection configuration.
 // Currently returns an empty list - error injection affects telemetry health status instead.
-func (d *Device) GetErrors(_ context.Context) (sdk.DeviceErrors, error) {
+func (d *Device) GetErrors(ctx context.Context) (sdk.DeviceErrors, error) {
+	if err := d.waitForLatency(ctx, true); err != nil {
+		return sdk.DeviceErrors{}, err
+	}
 	return sdk.DeviceErrors{
 		DeviceID: d.id,
 		Errors:   []sdk.DeviceError{},
 	}, nil
+}
+
+func (d *Device) waitForLatency(ctx context.Context, includeInternal bool) error {
+	delay := d.sampleLatency(includeInternal)
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (d *Device) sampleLatency(includeInternal bool) time.Duration {
+	d.latencyMu.Lock()
+	defer d.latencyMu.Unlock()
+
+	delay := d.config.Behavior.NetworkLatency.Sample(d.latencyRNG)
+	if includeInternal {
+		delay += d.config.Behavior.InternalLatency.Sample(d.latencyRNG)
+	}
+	return delay
 }
 
 // TryBatchStatus implements sdk.DeviceOptional.

--- a/plugin/virtual/internal/device/device_test.go
+++ b/plugin/virtual/internal/device/device_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,4 +121,23 @@ func TestDevice_ManualMiningControlClearsCurtailmentState(t *testing.T) {
 	require.NoError(t, d.StopMining(context.Background()))
 	assert.Equal(t, sdk.CurtailLevelUnspecified, d.curtailLevel)
 	assert.Nil(t, d.preCurtailMiningActive)
+}
+
+func TestDevice_CurtailHonorsContextDuringLatency(t *testing.T) {
+	d := newTestDevice(t)
+	enabled := true
+	d.config.Behavior.InternalLatency = config.LatencyConfig{
+		Enabled: &enabled,
+		MinMS:   50,
+		MaxMS:   50,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	err := d.Curtail(ctx, sdk.CurtailRequest{Level: sdk.CurtailLevelFull})
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.True(t, d.isMining, "timed-out curtailment should not mutate mining state")
+	assert.Equal(t, sdk.CurtailLevelUnspecified, d.curtailLevel)
 }

--- a/plugin/virtual/internal/driver/driver.go
+++ b/plugin/virtual/internal/driver/driver.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/block/proto-fleet/plugin/virtual/internal/config"
 	"github.com/block/proto-fleet/plugin/virtual/internal/device"
@@ -41,6 +43,8 @@ type Driver struct {
 	minersByIP     map[string]*config.VirtualMinerConfig
 	sv2ByMakeModel map[modelKey]bool
 	mutex          sync.RWMutex
+	latencyMu      sync.Mutex
+	latencyRNG     *rand.Rand
 }
 
 type modelKey struct{ manufacturer, model string }
@@ -71,6 +75,7 @@ func New(configPath string) (*Driver, error) {
 		devices:        make(map[string]sdk.Device),
 		minersByIP:     minersByIP,
 		sv2ByMakeModel: sv2ByMakeModel,
+		latencyRNG:     rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 2)),
 	}, nil
 }
 
@@ -132,7 +137,7 @@ func (d *Driver) GetCapabilitiesForModel(_ context.Context, manufacturer, model 
 }
 
 // DiscoverDevice implements sdk.Driver.
-func (d *Driver) DiscoverDevice(_ context.Context, ipAddress, port string) (sdk.DeviceInfo, error) {
+func (d *Driver) DiscoverDevice(ctx context.Context, ipAddress, port string) (sdk.DeviceInfo, error) {
 	// Only handle IPs in the virtual range
 	if !strings.HasPrefix(ipAddress, virtualIPPrefix) {
 		return sdk.DeviceInfo{}, fmt.Errorf("not a virtual miner IP: %s", ipAddress)
@@ -151,6 +156,9 @@ func (d *Driver) DiscoverDevice(_ context.Context, ipAddress, port string) (sdk.
 	if !exists {
 		return sdk.DeviceInfo{}, fmt.Errorf("no virtual miner configured at %s", ipAddress)
 	}
+	if err := d.waitForLatency(ctx, minerCfg, false); err != nil {
+		return sdk.DeviceInfo{}, err
+	}
 
 	slog.Info("Discovered virtual miner", "serial", minerCfg.SerialNumber, "ip", ipAddress)
 
@@ -167,7 +175,7 @@ func (d *Driver) DiscoverDevice(_ context.Context, ipAddress, port string) (sdk.
 }
 
 // PairDevice implements sdk.Driver.
-func (d *Driver) PairDevice(_ context.Context, deviceInfo sdk.DeviceInfo, _ sdk.SecretBundle) (sdk.DeviceInfo, error) {
+func (d *Driver) PairDevice(ctx context.Context, deviceInfo sdk.DeviceInfo, _ sdk.SecretBundle) (sdk.DeviceInfo, error) {
 	// Look up miner config to get full device info (MAC, serial, etc.)
 	d.mutex.RLock()
 	minerCfg, exists := d.minersByIP[deviceInfo.Host]
@@ -175,6 +183,9 @@ func (d *Driver) PairDevice(_ context.Context, deviceInfo sdk.DeviceInfo, _ sdk.
 
 	if !exists {
 		return sdk.DeviceInfo{}, fmt.Errorf("no virtual miner configured at %s", deviceInfo.Host)
+	}
+	if err := d.waitForLatency(ctx, minerCfg, true); err != nil {
+		return sdk.DeviceInfo{}, err
 	}
 
 	slog.Info("Paired virtual miner", "serial", minerCfg.SerialNumber, "mac", minerCfg.MacAddress)
@@ -219,4 +230,37 @@ func (d *Driver) NewDevice(_ context.Context, deviceID string, deviceInfo sdk.De
 // Returns default credentials for virtual miners to enable auto-authentication during pairing.
 func (d *Driver) GetDefaultCredentials(_ context.Context, _, _ string) []sdk.UsernamePassword {
 	return defaultCredentials
+}
+
+func (d *Driver) waitForLatency(ctx context.Context, minerCfg *config.VirtualMinerConfig, includeInternal bool) error {
+	delay := d.sampleLatency(minerCfg, includeInternal)
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (d *Driver) sampleLatency(minerCfg *config.VirtualMinerConfig, includeInternal bool) time.Duration {
+	if minerCfg == nil {
+		return 0
+	}
+
+	d.latencyMu.Lock()
+	defer d.latencyMu.Unlock()
+	if d.latencyRNG == nil {
+		d.latencyRNG = rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 2))
+	}
+
+	delay := minerCfg.Behavior.NetworkLatency.Sample(d.latencyRNG)
+	if includeInternal {
+		delay += minerCfg.Behavior.InternalLatency.Sample(d.latencyRNG)
+	}
+	return delay
 }

--- a/plugin/virtual/main.go
+++ b/plugin/virtual/main.go
@@ -19,13 +19,18 @@ import (
 	"github.com/hashicorp/go-plugin"
 )
 
+const (
+	configEnvVar           = "VIRTUAL_MINER_CONFIG"
+	defaultConfigFileName  = "config.json"
+	deployedConfigFileName = "virtual-plugin.json"
+)
+
 func main() {
-	// Config file is in the same directory as the plugin binary
 	execPath, err := os.Executable()
 	if err != nil {
 		log.Fatalf("Failed to get executable path: %v", err)
 	}
-	configPath := filepath.Join(filepath.Dir(execPath), "config.json")
+	configPath := resolveConfigPath(filepath.Dir(execPath))
 
 	// Create the plugin driver
 	virtualDriver, err := driver.New(configPath)
@@ -41,4 +46,17 @@ func main() {
 		},
 		GRPCServer: plugin.DefaultGRPCServer,
 	})
+}
+
+func resolveConfigPath(execDir string) string {
+	if configPath := os.Getenv(configEnvVar); configPath != "" {
+		return configPath
+	}
+
+	deployedConfigPath := filepath.Join(execDir, deployedConfigFileName)
+	if _, err := os.Stat(deployedConfigPath); err == nil {
+		return deployedConfigPath
+	}
+
+	return filepath.Join(execDir, defaultConfigFileName)
 }

--- a/plugin/virtual/main.go
+++ b/plugin/virtual/main.go
@@ -4,7 +4,8 @@
 // Virtual miners don't require any network hardware and can be configured via JSON.
 //
 // Usage:
-//  1. Place config.json in the same directory as the plugin binary
+//  1. Set VIRTUAL_MINER_CONFIG, place virtual-plugin.json next to the deployed
+//     binary, or place config.json next to a local development binary.
 //  2. Use IP List discovery mode with IPs from the 10.255.x.x range
 //  3. Pair discovered virtual miners (any credentials work)
 package main


### PR DESCRIPTION
Reviewable diff: +511/-33 across 13 files (excludes generated, test, and story files).

## Summary
This PR makes virtual miners available for deployment-based stress testing without loading them in regular fleet installs. Operators can opt in by setting `ENABLE_VIRTUAL_MINERS=true`, then scale generated virtual miners with `VIRTUAL_MINER_COUNT` and related `.env` overrides. Virtual miners also now simulate request latency, including 200-500ms miner-internal delays with occasional 5-8s outliers, so curtailment tests across thousands of miners exercise more realistic command timing. It also tightens PR-description Mermaid guidance so future diagrams use GitHub-renderable node syntax.

## How it works
Release builds now package `virtual-plugin` and `virtual-plugin.json` alongside the server artifacts. The deployment server image copies normal production plugins into `/app/plugins`, while virtual assets land in `/app/optional-plugins`; container startup copies those optional files into `/app/plugins` only when `ENABLE_VIRTUAL_MINERS` is truthy. The virtual plugin reads its config from `VIRTUAL_MINER_CONFIG`, applies optional generation overrides from environment variables, and samples network plus internal latency before discovery, pairing, status, and command operations. PR-description guidance now explicitly requires Mermaid flowcharts to use stable node IDs with bracketed labels, which avoids GitHub's parse failure on bare quoted string nodes.

## Diagrams
```mermaid
flowchart TD
  A["Release artifact build"] --> B["Server tarball includes virtual-plugin and config"]
  C["Server Docker image"] --> D["Production plugins in /app/plugins"]
  C --> E["Virtual plugin in /app/optional-plugins"]
  F["ENABLE_VIRTUAL_MINERS=true"] --> G["Copy virtual plugin into /app/plugins at startup"]
  H["ENABLE_VIRTUAL_MINERS=false"] --> I["Fleet starts without virtual plugin loaded"]
  G --> J["Fleet API plugin loader"]
  D --> J
  J --> K["Loads executable files from /app/plugins"]
```

```mermaid
sequenceDiagram
  participant Fleet as Fleet command worker
  participant Plugin as Virtual plugin
  participant Miner as Virtual miner state
  Fleet->>Plugin: Curtail, status, or pair request
  Plugin->>Plugin: Sample network latency
  Plugin->>Plugin: Sample internal miner latency
  Plugin->>Miner: Apply or read simulated state
  Miner-->>Plugin: Metrics or command result
  Plugin-->>Fleet: Response or context timeout
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/proto-fleet-artifact-build.yml` | Packages `virtual-plugin` and `virtual-plugin.json` into server/deployment artifacts. | Confirms stress-test assets ship with releases. |
| `deployment-files/server/Dockerfile` | Keeps real plugins in `/app/plugins`, stores virtual assets in `/app/optional-plugins`, and copies them only when enabled. | Main opt-in safety boundary for regular installs. |
| `deployment-files/docker-compose.yaml` | Adds `ENABLE_VIRTUAL_MINERS` and virtual generation env passthrough. | Lets installed deployments opt in without rebuilding. |
| `justfile` | Keeps normal plugin builds free of stale virtual plugin files; explicit `build-virtual-plugin` still builds virtual. | Prevents local regular fleets from accidentally loading virtual miners after stress tests. |
| `plugin/virtual/internal/config` | Adds env overrides and latency config/defaults. | Controls large generated fleets and latency behavior. |
| `plugin/virtual/internal/driver` | Adds latency to discovery and pairing. | Makes scanner/pairing stress tests experience simulated request cost. |
| `plugin/virtual/internal/device` | Adds latency to status and command paths with context cancellation. | Curtailment command workers see realistic miner-side delays and timeout behavior. |
| `plugin/virtual/main.go` | Resolves deployed config path via env or `virtual-plugin.json`. | Allows release-packaged config to live beside the optional plugin. |
| `deployment-files/README.md`, `plugin/virtual/README.md` | Documents opt-in deployment flow and latency defaults. | Gives operators the stress-test knobs without making them default behavior. |
| `AGENTS.md`, `.claude/commands/pr-describe.md`, `docs/solutions/best-practices/github-safe-mermaid-pr-descriptions-2026-06-22.md` | Requires GitHub-safe Mermaid node IDs and records the rendering failure mode. | Prevents future generated PR descriptions from using bare quoted string nodes that GitHub cannot render. |
| `plugin/virtual/internal/*_test.go` | Adds coverage for env overrides, latency defaults, and cancellation during delayed curtailment. | Pins the new opt-in and latency behavior. |

## Key technical decisions & trade-offs
| Decision | Alternative considered |
| --- | --- |
| Ship virtual plugin as an optional artifact instead of loading it by default. | Always include it in `/app/plugins`, which would make regular installs discover virtual miners unintentionally. |
| Use startup-time copy into `/app/plugins` for opt-in loading. | Teach the plugin manager to understand optional plugins, which would be a broader server change. |
| Apply latency inside the virtual plugin driver/device methods. | Add latency in fleet command infrastructure, which would affect real miner paths and obscure plugin behavior. |
| Use environment overrides for generated fleet size. | Require editing JSON inside the deployment bundle for every stress-test run. |
| Add explicit Mermaid syntax guidance to agent docs and solution docs. | Rely on individual agent memory, which would not protect future PR descriptions. |

## Testing & validation
- `go test ./...` from `plugin/virtual`
- `go test ./internal/domain/plugins ./sdk/v1` from `server`
- `git diff --check`

Not run locally:
- Windows installer tests because `dotnet` is not installed in this environment.
- Multi-arch plugin release build because local Go is `1.25.1` while `go.work` requires `1.25.4`.
