### PR TITLE
[codex] Complete fleet node discovery pairing flow

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -224,7 +224,7 @@ func start(config *Config) error {
 	fleetNodeEnrollmentStore := sqlstores.NewSQLFleetNodeEnrollmentStore(conn)
 	fleetNodeEnrollmentSvc := enrollment.NewService(fleetNodeEnrollmentStore, apiKeySvc, transactor, activitySvc)
 	fleetNodePairingStore := sqlstores.NewSQLFleetNodePairingStore(conn)
-	fleetNodePairingSvc := fleetnodepairing.NewService(fleetNodePairingStore, fleetNodeEnrollmentStore, transactor)
+	fleetNodePairingSvc := fleetnodepairing.NewService(fleetNodePairingStore, fleetNodeEnrollmentStore, transactor, deviceStore)
 	fleetNodeControlRegistry := control.NewRegistry()
 	fleetNodeDiscoverySvc := fleetnodediscovery.NewService(fleetNodeControlRegistry, fleetNodeEnrollmentSvc)
 	fleetNodeAuthStore := sqlstores.NewSQLFleetNodeAuthStore(conn)

--- a/server/cmd/fleetnode/pair.go
+++ b/server/cmd/fleetnode/pair.go
@@ -2,10 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/ed25519"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -47,18 +43,10 @@ type pairer interface {
 
 type pluginPairer struct {
 	manager *plugins.Manager
-	// minerSigningPubKey is the SPKI-DER base64 form of the node's miner-signing
-	// public key, matching token.Service.ExtractPublicKeyFromPrivateKey so a
-	// miner paired here trusts the JWTs the node signs at runtime.
-	minerSigningPubKey string
 }
 
-func newPluginPairer(manager *plugins.Manager, minerSigningPrivKeyHex string) (*pluginPairer, error) {
-	pub, err := minerSigningPublicKeySPKIBase64(minerSigningPrivKeyHex)
-	if err != nil {
-		return nil, err
-	}
-	return &pluginPairer{manager: manager, minerSigningPubKey: pub}, nil
+func newPluginPairer(manager *plugins.Manager, _ string) (*pluginPairer, error) {
+	return &pluginPairer{manager: manager}, nil
 }
 
 func (p *pluginPairer) Pair(ctx context.Context, target *pairingpb.FleetNodePairTarget, creds *pairingpb.Credentials) *pb.FleetNodePairResult {
@@ -85,9 +73,8 @@ func (p *pluginPairer) Pair(ctx context.Context, target *pairingpb.FleetNodePair
 		FirmwareVersion: target.GetFirmwareVersion(),
 	}
 
-	// Asymmetric-auth drivers (Proto) pair with the node's own miner-signing key;
-	// operator-supplied username/password covers basic-auth drivers.
-	if bundle, ok := secretBundleFor(plugin.Caps, p.minerSigningPubKey, creds); ok {
+	// Operator-supplied username/password covers basic-auth drivers.
+	if bundle, ok := secretBundleFor(creds); ok {
 		updated, pairErr := plugin.Driver.PairDevice(ctx, deviceInfo, bundle)
 		if pairErr != nil {
 			classifyNodePairError(pairErr, res)
@@ -120,14 +107,10 @@ func (p *pluginPairer) Pair(ctx context.Context, target *pairingpb.FleetNodePair
 	return res
 }
 
-// secretBundleFor returns the auth bundle for a driver: the node's miner-signing
-// key for asymmetric-auth drivers, supplied username/password otherwise. ok is
-// false when no credentials apply (the caller falls back to plugin defaults or
-// reports AUTH_NEEDED).
-func secretBundleFor(caps sdk.Capabilities, nodePubKey string, creds *pairingpb.Credentials) (sdk.SecretBundle, bool) {
-	if caps[sdk.CapabilityAsymmetricAuth] {
-		return sdk.SecretBundle{Version: "v1", Kind: sdk.APIKey{Key: nodePubKey}}, true
-	}
+// secretBundleFor returns an auth bundle when operator-supplied username/password
+// credentials apply. ok is false when the caller should fall back to plugin
+// defaults or report AUTH_NEEDED.
+func secretBundleFor(creds *pairingpb.Credentials) (sdk.SecretBundle, bool) {
 	if creds != nil && creds.Password != nil {
 		return sdk.SecretBundle{Version: "v1", Kind: sdk.UsernamePassword{Username: creds.GetUsername(), Password: creds.GetPassword()}}, true
 	}
@@ -164,30 +147,6 @@ func isNodeAuthFailure(err error) bool {
 	}
 	var sdkErr sdk.SDKError
 	return errors.As(err, &sdkErr) && sdkErr.Code == sdk.ErrCodeAuthenticationFailed
-}
-
-// minerSigningPublicKeySPKIBase64 derives the SPKI-DER base64 public key from a
-// hex-encoded ed25519 private key. It must produce the identical string to
-// token.Service.ExtractPublicKeyFromPrivateKey (pinned by a cross-check test) so
-// miners paired here trust the node's runtime JWTs.
-func minerSigningPublicKeySPKIBase64(privKeyHex string) (string, error) {
-	raw, err := hex.DecodeString(privKeyHex)
-	if err != nil {
-		return "", fmt.Errorf("decode miner signing private key: %w", err)
-	}
-	if len(raw) != ed25519.PrivateKeySize {
-		return "", fmt.Errorf("miner signing private key is %d bytes, want %d", len(raw), ed25519.PrivateKeySize)
-	}
-	priv := ed25519.PrivateKey(raw)
-	pub, ok := priv.Public().(ed25519.PublicKey)
-	if !ok {
-		return "", fmt.Errorf("miner signing key is not ed25519")
-	}
-	der, err := x509.MarshalPKIXPublicKey(pub)
-	if err != nil {
-		return "", fmt.Errorf("marshal miner signing public key: %w", err)
-	}
-	return base64.StdEncoding.EncodeToString(der), nil
 }
 
 // handlePairCommand pairs a batch of discovered devices and streams the results

--- a/server/cmd/fleetnode/pair_test.go
+++ b/server/cmd/fleetnode/pair_test.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/ed25519"
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"strings"
 	"testing"
@@ -18,7 +15,6 @@ import (
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
-	"github.com/block/proto-fleet/server/internal/domain/token"
 	"github.com/block/proto-fleet/server/internal/fleetnode/bootstrap"
 	sdk "github.com/block/proto-fleet/server/sdk/v1"
 )
@@ -45,73 +41,26 @@ func (s *stubPairer) Pair(_ context.Context, target *pairingpb.FleetNodePairTarg
 	}
 }
 
-func TestMinerSigningPublicKeySPKIBase64_MatchesTokenService(t *testing.T) {
-	// Arrange: a fresh ed25519 key, hex-encoded like bootstrap.State stores it.
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-	ts, err := token.NewService(token.Config{
-		ClientToken:                token.AuthTokenConfig{SecretKey: "0123456789abcdef0123456789abcdef", ExpirationPeriod: time.Minute},
-		MinerTokenExpirationPeriod: time.Minute,
-	})
-	require.NoError(t, err)
-	want, err := ts.ExtractPublicKeyFromPrivateKey(priv)
-	require.NoError(t, err)
-
-	// Act
-	got, err := minerSigningPublicKeySPKIBase64(hex.EncodeToString(priv))
-
-	// Assert: the node-derived key must equal the server's byte for byte, or a
-	// miner paired here would reject the JWTs the node signs at runtime.
-	require.NoError(t, err)
-	assert.Equal(t, want, got)
-}
-
-func TestMinerSigningPublicKeySPKIBase64_RejectsBadKey(t *testing.T) {
-	cases := []struct{ name, hexKey string }{
-		{name: "not hex", hexKey: "zzzz"},
-		{name: "wrong length", hexKey: "abcd"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Act
-			_, err := minerSigningPublicKeySPKIBase64(tc.hexKey)
-
-			// Assert
-			require.Error(t, err)
-		})
-	}
-}
-
 func TestSecretBundleFor(t *testing.T) {
 	pw := "secret"
 	cases := []struct {
 		name     string
-		caps     sdk.Capabilities
 		creds    *pairingpb.Credentials
 		wantOK   bool
 		wantKind any
 	}{
 		{
-			name:     "asymmetric uses node key",
-			caps:     sdk.Capabilities{sdk.CapabilityAsymmetricAuth: true},
-			wantOK:   true,
-			wantKind: sdk.APIKey{Key: "node-pub"},
-		},
-		{
 			name:     "basic auth uses supplied creds",
-			caps:     sdk.Capabilities{},
 			creds:    &pairingpb.Credentials{Username: "root", Password: &pw},
 			wantOK:   true,
 			wantKind: sdk.UsernamePassword{Username: "root", Password: "secret"},
 		},
 		{
-			name:   "no creds and not asymmetric falls through",
-			caps:   sdk.Capabilities{},
+			name:   "no creds falls through",
 			wantOK: false,
 		},
 		{
 			name:   "username without password falls through",
-			caps:   sdk.Capabilities{},
 			creds:  &pairingpb.Credentials{Username: "root"},
 			wantOK: false,
 		},
@@ -119,7 +68,7 @@ func TestSecretBundleFor(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Act
-			bundle, ok := secretBundleFor(tc.caps, "node-pub", tc.creds)
+			bundle, ok := secretBundleFor(tc.creds)
 
 			// Assert
 			assert.Equal(t, tc.wantOK, ok)

--- a/server/internal/domain/fleetnode/control/registry.go
+++ b/server/internal/domain/fleetnode/control/registry.go
@@ -71,11 +71,12 @@ var (
 	errDuplicateCommandID = errors.New("duplicate command_id in flight for fleet_node")
 )
 
-// CommandEvent is one message of a report-bearing command's result stream: exactly
-// one of Batch or Ack is set.
+// CommandEvent is one message of a report-bearing command's result stream:
+// exactly one of Batch, PairResults, or Ack is set.
 type CommandEvent struct {
-	Batch *pairingpb.DiscoverResponse
-	Ack   *gatewaypb.ControlAck
+	Batch       *pairingpb.DiscoverResponse
+	PairResults []*gatewaypb.FleetNodePairResult
+	Ack         *gatewaypb.ControlAck
 }
 
 // ReportScope reports whether a device discovered at (ipAddress, port) falls

--- a/server/internal/domain/fleetnode/control/stream.go
+++ b/server/internal/domain/fleetnode/control/stream.go
@@ -62,6 +62,12 @@ func (r *Registry) PublishBatch(fleetNodeID int64, commandID string, batch *pair
 	r.deliverEvent(fleetNodeID, commandID, CommandEvent{Batch: batch})
 }
 
+// PublishPairResults routes an agent pairing result batch to the in-flight
+// report-bearing command.
+func (r *Registry) PublishPairResults(fleetNodeID int64, commandID string, results []*gatewaypb.FleetNodePairResult) {
+	r.deliverEvent(fleetNodeID, commandID, CommandEvent{PairResults: results})
+}
+
 // AdmitReport reserves quota for deviceCount devices against the in-flight
 // report-bearing command. Returns errNoInFlightCommand if commandID isn't an
 // in-flight report-bearing command, or ErrReportQuotaExceeded past maxReportsPerCommand.

--- a/server/internal/domain/fleetnode/discovery/service.go
+++ b/server/internal/domain/fleetnode/discovery/service.go
@@ -181,12 +181,94 @@ func (s *Service) RunOnNode(ctx context.Context, fleetNodeID int64, req *pairing
 	}
 }
 
+// RunPairOnNode dispatches a pairing command to a single CONFIRMED node and
+// invokes onResults for each persisted pair-result batch the node reports.
+func (s *Service) RunPairOnNode(ctx context.Context, fleetNodeID int64, req *pairingpb.FleetNodePairRequest, onResults func([]*gatewaypb.FleetNodePairResult) error) error {
+	if len(req.GetTargets()) == 0 {
+		return fleeterror.NewInvalidArgumentError("pair request must include at least one target")
+	}
+	commandID := id.GenerateID()
+	payload, err := proto.Marshal(&pairingpb.AgentCommand{
+		Command: &pairingpb.AgentCommand_Pair{Pair: req},
+	})
+	if err != nil {
+		return fleeterror.NewInternalErrorf("marshal pair payload: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, DiscoverCommandTimeout)
+	defer cancel()
+
+	session, err := s.registry.Send(ctx, fleetNodeID, &gatewaypb.ControlCommand{
+		CommandId: commandID,
+		Payload:   payload,
+	}, nil)
+	if err != nil {
+		if errors.Is(err, control.ErrNoActiveStream) {
+			return fleeterror.NewFailedPreconditionError("fleet node has no active control stream")
+		}
+		return err
+	}
+	defer session.Close()
+
+	handleEvent := func(ev control.CommandEvent) (terminal bool, err error) {
+		switch {
+		case ev.PairResults != nil:
+			if sendErr := onResults(ev.PairResults); sendErr != nil {
+				return true, sendErr
+			}
+			return false, nil
+		case ev.Ack != nil:
+			if ev.Ack.GetCode() == gatewaypb.AckCode_ACK_CODE_PARTIAL {
+				slog.Warn("fleet node pairing completed partially",
+					"fleet_node_id", fleetNodeID, "detail", ev.Ack.GetErrorMessage())
+				return true, nil
+			}
+			if ev.Ack.GetCode() != gatewaypb.AckCode_ACK_CODE_OK || !ev.Ack.GetSucceeded() {
+				return true, commandAckFailure(ev.Ack, "pair")
+			}
+			return true, nil
+		default:
+			return false, nil
+		}
+	}
+
+	events := session.Events()
+	for {
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return connect.NewError(connect.CodeDeadlineExceeded, fmt.Errorf("pair command timed out after %s", DiscoverCommandTimeout))
+			}
+			return fleeterror.NewCanceledError()
+		case ev := <-events:
+			if terminal, err := handleEvent(ev); terminal {
+				return err
+			}
+		case <-session.Done():
+			for {
+				select {
+				case ev := <-events:
+					if terminal, err := handleEvent(ev); terminal {
+						return err
+					}
+				default:
+					return fleeterror.NewFailedPreconditionError("fleet node control stream closed before command completed")
+				}
+			}
+		}
+	}
+}
+
 // discoverAckFailure maps a non-OK ack to an operator-facing error, even when
 // error_message is empty. The structured AckCode drives the gRPC code so the
 // operator can tell a retryable condition (BUSY) and a capability gap
 // (AGENT_INCAPABLE) apart from a malformed request (BAD_REQUEST); anything else
 // is an opaque Internal failure.
 func discoverAckFailure(ack *gatewaypb.ControlAck) error {
+	return commandAckFailure(ack, "discovery")
+}
+
+func commandAckFailure(ack *gatewaypb.ControlAck, commandName string) error {
 	reason := ack.GetErrorMessage()
 	if reason == "" {
 		reason = "code " + ack.GetCode().String()
@@ -195,7 +277,7 @@ func discoverAckFailure(ack *gatewaypb.ControlAck) error {
 	// AckCode; everything outside these three is an opaque Internal failure.
 	code := ack.GetCode()
 	if code == gatewaypb.AckCode_ACK_CODE_BAD_REQUEST {
-		return fleeterror.NewInvalidArgumentErrorf("fleet node rejected discovery command: %s", reason)
+		return fleeterror.NewInvalidArgumentErrorf("fleet node rejected %s command: %s", commandName, reason)
 	}
 	if code == gatewaypb.AckCode_ACK_CODE_BUSY {
 		return fleeterror.NewPlainError(
@@ -204,9 +286,9 @@ func discoverAckFailure(ack *gatewaypb.ControlAck) error {
 		)
 	}
 	if code == gatewaypb.AckCode_ACK_CODE_AGENT_INCAPABLE {
-		return fleeterror.NewFailedPreconditionErrorf("fleet node cannot service this discovery request; try another node: %s", reason)
+		return fleeterror.NewFailedPreconditionErrorf("fleet node cannot service this %s request; try another node: %s", commandName, reason)
 	}
-	return fleeterror.NewInternalErrorf("fleet node reported discovery failure: %s", reason)
+	return fleeterror.NewInternalErrorf("fleet node reported %s failure: %s", commandName, reason)
 }
 
 func normalizeDiscoverRequest(in *pairingpb.DiscoverRequest) (*pairingpb.DiscoverRequest, error) {

--- a/server/internal/domain/fleetnode/pairing/service.go
+++ b/server/internal/domain/fleetnode/pairing/service.go
@@ -2,11 +2,15 @@ package pairing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 	"regexp"
 	"strconv"
 
+	fm "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
+	gatewaypb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/fleetnode/enrollment"
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -20,9 +24,13 @@ const (
 	clientErrUpsertDiscoveredDevice    = "discovery upsert failed"
 	clientErrLookupDeviceForPairing    = "device lookup failed"
 	clientErrLookupFleetNodeForPairing = "fleet node lookup failed"
+	statusPaired                       = "PAIRED"
+	statusAuthenticationNeeded         = "AUTHENTICATION_NEEDED"
+	statusFailed                       = "FAILED"
 )
 
 type Store interface {
+	DeviceIDByIdentifier(ctx context.Context, deviceIdentifier string, orgID int64) (int64, error)
 	PairDeviceToFleetNode(ctx context.Context, fleetNodeID, deviceID, orgID int64, assignedBy *int64) (int64, error)
 	TransferDiscoveredDeviceAttribution(ctx context.Context, fleetNodeID, deviceID, orgID int64) (int64, error)
 	DeviceHasActiveCloudPairing(ctx context.Context, deviceID, orgID int64) (bool, error)
@@ -37,10 +45,15 @@ type Service struct {
 	store           Store
 	enrollmentStore enrollment.AgentStore
 	transactor      stores.Transactor
+	deviceStore     stores.DeviceStore
 }
 
-func NewService(store Store, enrollmentStore enrollment.AgentStore, transactor stores.Transactor) *Service {
-	return &Service{store: store, enrollmentStore: enrollmentStore, transactor: transactor}
+func NewService(store Store, enrollmentStore enrollment.AgentStore, transactor stores.Transactor, deviceStore ...stores.DeviceStore) *Service {
+	s := &Service{store: store, enrollmentStore: enrollmentStore, transactor: transactor}
+	if len(deviceStore) > 0 {
+		s.deviceStore = deviceStore[0]
+	}
+	return s
 }
 
 func (s *Service) PairDevice(ctx context.Context, fleetNodeID, deviceID, orgID int64, assignedBy *int64) error {
@@ -132,6 +145,204 @@ func (s *Service) ListDiscoveredDevicesForFleetNode(ctx context.Context, orgID i
 		nextCursor = &last
 	}
 	return devices, nextCursor, nil
+}
+
+func (s *Service) PairTargetsForDiscoveredDevices(ctx context.Context, orgID, fleetNodeID int64, deviceIdentifiers []string, pairAll bool) ([]*pairingpb.FleetNodePairTarget, error) {
+	if fleetNodeID <= 0 {
+		return nil, fleeterror.NewInvalidArgumentError("fleet_node_id is required")
+	}
+	if !pairAll && len(deviceIdentifiers) == 0 {
+		return nil, fleeterror.NewInvalidArgumentError("device_identifiers must not be empty unless pair_all_unpaired is true")
+	}
+
+	devices, _, err := s.ListDiscoveredDevicesForFleetNode(ctx, orgID, &fleetNodeID, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	byIdentifier := make(map[string]FleetNodeDiscoveredDevice, len(devices))
+	for _, d := range devices {
+		byIdentifier[d.DeviceIdentifier] = d
+	}
+
+	selected := devices
+	if !pairAll {
+		selected = make([]FleetNodeDiscoveredDevice, 0, len(deviceIdentifiers))
+		seen := make(map[string]struct{}, len(deviceIdentifiers))
+		for _, id := range deviceIdentifiers {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			d, ok := byIdentifier[id]
+			if !ok {
+				return nil, fleeterror.NewInvalidArgumentErrorf("device_identifier %q is not available for pairing on this fleet node", id)
+			}
+			selected = append(selected, d)
+		}
+	}
+	if len(selected) == 0 {
+		return nil, fleeterror.NewFailedPreconditionError("no unpaired discovered devices are available for pairing")
+	}
+
+	targets := make([]*pairingpb.FleetNodePairTarget, 0, len(selected))
+	for _, d := range selected {
+		targets = append(targets, &pairingpb.FleetNodePairTarget{
+			DeviceIdentifier: d.DeviceIdentifier,
+			IpAddress:        d.IPAddress,
+			Port:             d.Port,
+			UrlScheme:        d.URLScheme,
+			DriverName:       d.DriverName,
+			Manufacturer:     d.Manufacturer,
+			FirmwareVersion:  d.FirmwareVersion,
+		})
+	}
+	return targets, nil
+}
+
+func (s *Service) ApplyPairResults(ctx context.Context, fleetNodeID, orgID int64, results []*gatewaypb.FleetNodePairResult) (accepted []*gatewaypb.FleetNodePairResult, rejected int64, err error) {
+	if s.deviceStore == nil {
+		return nil, 0, fleeterror.NewInternalError("fleet node pairing device store is not configured")
+	}
+	devices, _, err := s.ListDiscoveredDevicesForFleetNode(ctx, orgID, &fleetNodeID, nil, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	candidates := make(map[string]FleetNodeDiscoveredDevice, len(devices))
+	for _, d := range devices {
+		candidates[d.DeviceIdentifier] = d
+	}
+
+	accepted = make([]*gatewaypb.FleetNodePairResult, 0, len(results))
+	for _, res := range results {
+		if res == nil {
+			rejected++
+			continue
+		}
+		candidate, ok := candidates[res.GetDeviceIdentifier()]
+		if !ok {
+			rejected++
+			continue
+		}
+		if err := s.applyPairResult(ctx, fleetNodeID, orgID, candidate, res); err != nil {
+			if errors.Is(err, errPairResultRejected) {
+				rejected++
+				continue
+			}
+			return nil, 0, err
+		}
+		accepted = append(accepted, res)
+	}
+	return accepted, rejected, nil
+}
+
+var errPairResultRejected = errors.New("pair result rejected")
+
+func (s *Service) applyPairResult(ctx context.Context, fleetNodeID, orgID int64, candidate FleetNodeDiscoveredDevice, res *gatewaypb.FleetNodePairResult) error {
+	status, attachToNode, ok := statusForPairOutcome(res.GetOutcome())
+	if !ok {
+		return errPairResultRejected
+	}
+	device := deviceFromPairResult(candidate, res)
+	return s.transactor.RunInTx(ctx, func(ctx context.Context) error {
+		if err := s.upsertPairResultDevice(ctx, orgID, device); err != nil {
+			return err
+		}
+		if err := s.deviceStore.UpsertDevicePairing(ctx, device, orgID, status); err != nil {
+			return fleeterror.LogInternal(component, "upsert pair result status", clientErrPair, err)
+		}
+		if !attachToNode {
+			return nil
+		}
+		deviceID, err := s.store.DeviceIDByIdentifier(ctx, device.GetDeviceIdentifier(), orgID)
+		if err != nil {
+			return fleeterror.LogInternal(component, "lookup pair result device id", clientErrPair, err)
+		}
+		rows, err := s.store.PairDeviceToFleetNode(ctx, fleetNodeID, deviceID, orgID, nil)
+		if err != nil {
+			return fleeterror.LogInternal(component, "pair reported device", clientErrPair, err)
+		}
+		if rows == 0 {
+			return errPairResultRejected
+		}
+		if _, attrErr := s.store.TransferDiscoveredDeviceAttribution(ctx, fleetNodeID, deviceID, orgID); attrErr != nil {
+			return fleeterror.LogInternal(component, "transfer pair result attribution", clientErrPair, attrErr)
+		}
+		return nil
+	})
+}
+
+func (s *Service) upsertPairResultDevice(ctx context.Context, orgID int64, device *pairingpb.Device) error {
+	existing, err := s.deviceStore.GetDeviceByDeviceIdentifier(ctx, device.GetDeviceIdentifier(), orgID)
+	if err != nil {
+		if !fleeterror.IsNotFoundError(err) {
+			return fleeterror.LogInternal(component, "lookup pair result device", clientErrPair, err)
+		}
+		if err := s.deviceStore.InsertDevice(ctx, device, orgID, device.GetDeviceIdentifier()); err != nil {
+			return fleeterror.LogInternal(component, "insert pair result device", clientErrPair, err)
+		}
+		return nil
+	}
+	if device.GetMacAddress() == "" && device.GetSerialNumber() == "" {
+		return nil
+	}
+	if device.GetMacAddress() == "" {
+		device.MacAddress = existing.GetMacAddress()
+	}
+	if device.GetSerialNumber() == "" {
+		device.SerialNumber = existing.GetSerialNumber()
+	}
+	if err := s.deviceStore.UpdateDeviceInfo(ctx, device, orgID); err != nil {
+		return fleeterror.LogInternal(component, "update pair result device", clientErrPair, err)
+	}
+	return nil
+}
+
+func statusForPairOutcome(outcome gatewaypb.PairOutcome) (status string, attachToNode bool, ok bool) {
+	switch outcome {
+	case gatewaypb.PairOutcome_PAIR_OUTCOME_PAIRED:
+		return statusPaired, true, true
+	case gatewaypb.PairOutcome_PAIR_OUTCOME_AUTH_NEEDED:
+		return statusAuthenticationNeeded, false, true
+	case gatewaypb.PairOutcome_PAIR_OUTCOME_AUTH_FAILED, gatewaypb.PairOutcome_PAIR_OUTCOME_ERROR:
+		return statusFailed, false, true
+	default:
+		return "", false, false
+	}
+}
+
+func deviceFromPairResult(candidate FleetNodeDiscoveredDevice, res *gatewaypb.FleetNodePairResult) *pairingpb.Device {
+	return &pairingpb.Device{
+		DeviceIdentifier: candidate.DeviceIdentifier,
+		IpAddress:        candidate.IPAddress,
+		Port:             candidate.Port,
+		UrlScheme:        candidate.URLScheme,
+		DriverName:       candidate.DriverName,
+		Model:            coalesce(res.GetModel(), candidate.Model),
+		Manufacturer:     coalesce(res.GetManufacturer(), candidate.Manufacturer),
+		FirmwareVersion:  coalesce(res.GetFirmwareVersion(), candidate.FirmwareVersion),
+		SerialNumber:     res.GetSerialNumber(),
+		MacAddress:       res.GetMacAddress(),
+	}
+}
+
+func PairingStatusForOutcome(outcome gatewaypb.PairOutcome) fm.PairingStatus {
+	switch outcome {
+	case gatewaypb.PairOutcome_PAIR_OUTCOME_PAIRED:
+		return fm.PairingStatus_PAIRING_STATUS_PAIRED
+	case gatewaypb.PairOutcome_PAIR_OUTCOME_AUTH_NEEDED:
+		return fm.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED
+	case gatewaypb.PairOutcome_PAIR_OUTCOME_AUTH_FAILED, gatewaypb.PairOutcome_PAIR_OUTCOME_ERROR:
+		return fm.PairingStatus_PAIRING_STATUS_FAILED
+	default:
+		return fm.PairingStatus_PAIRING_STATUS_UNSPECIFIED
+	}
+}
+
+func coalesce(first, fallback string) string {
+	if first != "" {
+		return first
+	}
+	return fallback
 }
 
 // UpsertDiscoveredDevices validates the whole batch up front, then runs

--- a/server/internal/domain/stores/sqlstores/fleetnodepairing.go
+++ b/server/internal/domain/stores/sqlstores/fleetnodepairing.go
@@ -23,6 +23,17 @@ func (s *SQLFleetNodePairingStore) q(ctx context.Context) *sqlc.Queries {
 	return s.GetQueries(ctx)
 }
 
+func (s *SQLFleetNodePairingStore) DeviceIDByIdentifier(ctx context.Context, deviceIdentifier string, orgID int64) (int64, error) {
+	device, err := s.q(ctx).GetDeviceByDeviceIdentifier(ctx, sqlc.GetDeviceByDeviceIdentifierParams{
+		DeviceIdentifier: deviceIdentifier,
+		OrgID:            orgID,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return device.ID, nil
+}
+
 func (s *SQLFleetNodePairingStore) PairDeviceToFleetNode(ctx context.Context, fleetNodeID, deviceID, orgID int64, assignedBy *int64) (int64, error) {
 	return s.q(ctx).PairDeviceToFleetNode(ctx, sqlc.PairDeviceToFleetNodeParams{
 		FleetNodeID: fleetNodeID,

--- a/server/internal/handlers/fleetnode/admin/handler.go
+++ b/server/internal/handlers/fleetnode/admin/handler.go
@@ -8,6 +8,7 @@ import (
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1/fleetnodeadminv1connect"
+	gatewaypb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
@@ -153,6 +154,50 @@ func (h *Handler) ListFleetNodeDevices(ctx context.Context, req *connect.Request
 	return connect.NewResponse(resp), nil
 }
 
+func (h *Handler) ListFleetNodeDiscoveredDevices(ctx context.Context, req *connect.Request[pb.ListFleetNodeDiscoveredDevicesRequest]) (*connect.Response[pb.ListFleetNodeDiscoveredDevicesResponse], error) {
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetnodeRead, authz.ResourceContext{})
+	if err != nil {
+		return nil, err
+	}
+	var fleetNodeID *int64
+	if id := req.Msg.GetFleetNodeId(); id > 0 {
+		fleetNodeID = &id
+	}
+	var cursor *int64
+	if c := req.Msg.GetCursor(); c > 0 {
+		cursor = &c
+	}
+	var limit *int64
+	if l := req.Msg.GetLimit(); l > 0 {
+		v := int64(l)
+		limit = &v
+	}
+	devices, nextCursor, err := h.pairing.ListDiscoveredDevicesForFleetNode(ctx, info.OrganizationID, fleetNodeID, cursor, limit)
+	if err != nil {
+		return nil, err
+	}
+	resp := &pb.ListFleetNodeDiscoveredDevicesResponse{Devices: make([]*pb.FleetNodeDiscoveredDevice, 0, len(devices))}
+	if nextCursor != nil {
+		resp.NextCursor = *nextCursor
+	}
+	for _, d := range devices {
+		resp.Devices = append(resp.Devices, &pb.FleetNodeDiscoveredDevice{
+			FleetNodeId:      d.FleetNodeID,
+			DeviceIdentifier: d.DeviceIdentifier,
+			IpAddress:        d.IPAddress,
+			Port:             d.Port,
+			UrlScheme:        d.URLScheme,
+			DriverName:       d.DriverName,
+			Model:            d.Model,
+			Manufacturer:     d.Manufacturer,
+			FirmwareVersion:  d.FirmwareVersion,
+			LastSeen:         timestamppb.New(d.LastSeen),
+			PairingStatus:    d.PairingStatus,
+		})
+	}
+	return connect.NewResponse(resp), nil
+}
+
 // DiscoverOnFleetNode runs discovery on a single CONFIRMED node and streams the
 // node's device batches back to the operator. See discovery.RunOnNode for the
 // dispatch/drain loop.
@@ -181,6 +226,54 @@ func (h *Handler) DiscoverOnFleetNode(ctx context.Context, req *connect.Request[
 	return h.discovery.RunOnNode(ctx, fleetNodeID, discoverReq, func(batch *pairingpb.DiscoverResponse) error {
 		if sendErr := stream.Send(&pb.DiscoverOnFleetNodeResponse{Response: batch}); sendErr != nil {
 			return fleeterror.NewInternalErrorf("send batch to operator: %v", sendErr)
+		}
+		return nil
+	})
+}
+
+func (h *Handler) PairDiscoveredDevicesOnFleetNode(ctx context.Context, req *connect.Request[pb.PairDiscoveredDevicesOnFleetNodeRequest], stream *connect.ServerStream[pb.PairDiscoveredDevicesOnFleetNodeResponse]) error {
+	info, err := middleware.RequirePermission(ctx, authz.PermFleetnodeManage, authz.ResourceContext{})
+	if err != nil {
+		return err
+	}
+	if _, err := middleware.RequirePermission(ctx, authz.PermMinerPair, authz.ResourceContext{}); err != nil {
+		return err
+	}
+	fleetNodeID := req.Msg.GetFleetNodeId()
+	if fleetNodeID <= 0 {
+		return fleeterror.NewInvalidArgumentError("fleet_node_id is required")
+	}
+	if req.Msg.GetPairAllUnpaired() && len(req.Msg.GetDeviceIdentifiers()) > 0 {
+		return fleeterror.NewInvalidArgumentError("device_identifiers must be empty when pair_all_unpaired is true")
+	}
+
+	node, err := h.enrollment.GetFleetNodeByID(ctx, fleetNodeID, info.OrganizationID)
+	if err != nil {
+		return err
+	}
+	if node.EnrollmentStatus != enrollment.FleetNodeStatusConfirmed {
+		return fleeterror.NewFailedPreconditionError("fleet node is not CONFIRMED")
+	}
+
+	targets, err := h.pairing.PairTargetsForDiscoveredDevices(ctx, info.OrganizationID, fleetNodeID, req.Msg.GetDeviceIdentifiers(), req.Msg.GetPairAllUnpaired())
+	if err != nil {
+		return err
+	}
+	pairReq := &pairingpb.FleetNodePairRequest{
+		Targets:     targets,
+		Credentials: req.Msg.GetCredentials(),
+	}
+	return h.discovery.RunPairOnNode(ctx, fleetNodeID, pairReq, func(results []*gatewaypb.FleetNodePairResult) error {
+		resp := &pb.PairDiscoveredDevicesOnFleetNodeResponse{Results: make([]*pb.DevicePairingResult, 0, len(results))}
+		for _, r := range results {
+			resp.Results = append(resp.Results, &pb.DevicePairingResult{
+				DeviceIdentifier: r.GetDeviceIdentifier(),
+				PairingStatus:    pairing.PairingStatusForOutcome(r.GetOutcome()),
+				Error:            r.GetErrorMessage(),
+			})
+		}
+		if sendErr := stream.Send(resp); sendErr != nil {
+			return fleeterror.NewInternalErrorf("send pair results to operator: %v", sendErr)
 		}
 		return nil
 	})

--- a/server/internal/handlers/fleetnode/admin/handler_discover_test.go
+++ b/server/internal/handlers/fleetnode/admin/handler_discover_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	fm "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1/fleetnodeadminv1connect"
 	gatewaypb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
@@ -80,6 +81,58 @@ func TestDiscoverOnFleetNode_StreamsBatchesAndStopsOnAck(t *testing.T) {
 	require.NoError(t, resp.Close())
 	require.Len(t, devices, 1)
 	assert.Equal(t, "auto:abc", devices[0].GetDeviceIdentifier())
+	<-agentDone
+}
+
+func TestPairDiscoveredDevicesOnFleetNode_StreamsPairResults(t *testing.T) {
+	// Arrange
+	h := newPairingHarness(t)
+	fleetNodeID := h.createFleetNode(t, "admin-pair-discovered")
+	h.insertDiscoveredDeviceForFleetNode(t, fleetNodeID, "auto:pair-1")
+	stream := h.registry.Register(fleetNodeID)
+	defer stream.Unregister()
+	client := startAdminServer(t, h)
+
+	agentDone := make(chan struct{})
+	go func() {
+		defer close(agentDone)
+		select {
+		case cmd, ok := <-stream.Outgoing:
+			if !ok {
+				return
+			}
+			var env pairingpb.AgentCommand
+			require.NoError(t, proto.Unmarshal(cmd.GetPayload(), &env))
+			require.Len(t, env.GetPair().GetTargets(), 1)
+			assert.Equal(t, "auto:pair-1", env.GetPair().GetTargets()[0].GetDeviceIdentifier())
+
+			h.registry.PublishPairResults(fleetNodeID, cmd.GetCommandId(), []*gatewaypb.FleetNodePairResult{{
+				DeviceIdentifier: "auto:pair-1",
+				Outcome:          gatewaypb.PairOutcome_PAIR_OUTCOME_PAIRED,
+			}})
+			stream.PublishAck(&gatewaypb.ControlAck{CommandId: cmd.GetCommandId(), Succeeded: true, Code: gatewaypb.AckCode_ACK_CODE_OK})
+		case <-time.After(2 * time.Second):
+			t.Errorf("agent goroutine timed out waiting for command")
+		}
+	}()
+
+	// Act
+	resp, err := client.PairDiscoveredDevicesOnFleetNode(context.Background(), connect.NewRequest(&pb.PairDiscoveredDevicesOnFleetNodeRequest{
+		FleetNodeId:       fleetNodeID,
+		DeviceIdentifiers: []string{"auto:pair-1"},
+	}))
+	require.NoError(t, err)
+
+	// Assert
+	var results []*pb.DevicePairingResult
+	for resp.Receive() {
+		results = append(results, resp.Msg().GetResults()...)
+	}
+	require.NoError(t, resp.Err())
+	require.NoError(t, resp.Close())
+	require.Len(t, results, 1)
+	assert.Equal(t, "auto:pair-1", results[0].GetDeviceIdentifier())
+	assert.Equal(t, fm.PairingStatus_PAIRING_STATUS_PAIRED, results[0].GetPairingStatus())
 	<-agentDone
 }
 
@@ -601,7 +654,7 @@ func startAdminServerWithRole(t *testing.T, h *pairingHarness, role string) flee
 	t.Helper()
 	var perms []string
 	if role == "ADMIN" || role == "SUPER_ADMIN" {
-		perms = []string{authz.PermFleetnodeManage, authz.PermFleetnodeRead}
+		perms = []string{authz.PermFleetnodeManage, authz.PermFleetnodeRead, authz.PermMinerPair}
 	}
 	injector := sessionInjector{role: role, orgID: h.orgID, userID: 1, perms: perms}
 	mux := http.NewServeMux()

--- a/server/internal/handlers/fleetnode/admin/handler_pairing_test.go
+++ b/server/internal/handlers/fleetnode/admin/handler_pairing_test.go
@@ -55,7 +55,8 @@ func newPairingHarness(t *testing.T) *pairingHarness {
 	enrollmentStore := sqlstores.NewSQLFleetNodeEnrollmentStore(db)
 	enrollmentSvc := enrollment.NewService(enrollmentStore, apiKeySvc, transactor, nil)
 	pairingStore := sqlstores.NewSQLFleetNodePairingStore(db)
-	pairingSvc := pairing.NewService(pairingStore, enrollmentStore, transactor)
+	deviceStore := sqlstores.NewSQLDeviceStore(db)
+	pairingSvc := pairing.NewService(pairingStore, enrollmentStore, transactor, deviceStore)
 
 	registry := control.NewRegistry()
 	discoverySvc := discovery.NewService(registry, enrollmentSvc)
@@ -82,7 +83,7 @@ func (h *pairingHarness) ctxWithPerms(perms ...string) context.Context {
 }
 
 func (h *pairingHarness) adminCtx() context.Context {
-	return h.ctxWithPerms(authz.PermFleetnodeManage, authz.PermFleetnodeRead)
+	return h.ctxWithPerms(authz.PermFleetnodeManage, authz.PermFleetnodeRead, authz.PermMinerPair)
 }
 
 func (h *pairingHarness) viewerCtx() context.Context {
@@ -123,6 +124,14 @@ func (h *pairingHarness) insertDevice(t *testing.T) int64 {
 	return devID
 }
 
+func (h *pairingHarness) insertDiscoveredDeviceForFleetNode(t *testing.T, fleetNodeID int64, identifier string) {
+	t.Helper()
+	_, err := h.db.Exec(`INSERT INTO discovered_device (org_id, device_identifier, ip_address, port, url_scheme, driver_name, model, manufacturer, firmware_version, is_active, discovered_by_fleet_node_id)
+		VALUES ($1, $2, '10.0.0.25', '4028', 'http', 'virtual', 'S21', 'Bitmain', 'v1', TRUE, $3)`,
+		h.orgID, identifier, fleetNodeID)
+	require.NoError(t, err)
+}
+
 func TestPairDeviceToFleetNode_HappyPath(t *testing.T) {
 	// Arrange
 	h := newPairingHarness(t)
@@ -140,6 +149,24 @@ func TestPairDeviceToFleetNode_HappyPath(t *testing.T) {
 	var paired int
 	require.NoError(t, h.db.QueryRow(`SELECT COUNT(*) FROM fleet_node_device WHERE fleet_node_id = $1 AND device_id = $2`, fleetNodeID, deviceID).Scan(&paired))
 	assert.Equal(t, 1, paired)
+}
+
+func TestListFleetNodeDiscoveredDevices_HappyPath(t *testing.T) {
+	// Arrange
+	h := newPairingHarness(t)
+	fleetNodeID := h.createFleetNode(t, "admin-list-discovered")
+	h.insertDiscoveredDeviceForFleetNode(t, fleetNodeID, "auto:list-1")
+
+	// Act
+	resp, err := h.handler.ListFleetNodeDiscoveredDevices(h.adminCtx(), connect.NewRequest(&pb.ListFleetNodeDiscoveredDevicesRequest{FleetNodeId: fleetNodeID}))
+
+	// Assert
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GetDevices(), 1)
+	got := resp.Msg.GetDevices()[0]
+	assert.Equal(t, fleetNodeID, got.GetFleetNodeId())
+	assert.Equal(t, "auto:list-1", got.GetDeviceIdentifier())
+	assert.Equal(t, "virtual", got.GetDriverName())
 }
 
 func TestPairDeviceToFleetNode_RequiresAdminSession(t *testing.T) {

--- a/server/internal/handlers/fleetnode/gateway/handler.go
+++ b/server/internal/handlers/fleetnode/gateway/handler.go
@@ -157,6 +157,42 @@ func (h *Handler) ReportDiscoveredDevices(ctx context.Context, req *connect.Requ
 	}), nil
 }
 
+func (h *Handler) ReportPairedDevices(ctx context.Context, req *connect.Request[pb.ReportPairedDevicesRequest]) (*connect.Response[pb.ReportPairedDevicesResponse], error) {
+	subject, err := auth.GetSubject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	commandID := req.Msg.GetCommandId()
+	if commandID == "" {
+		return nil, fleeterror.NewFailedPreconditionError("pair report requires a command_id from a server-issued ControlCommand")
+	}
+	in := req.Msg.GetResults()
+	if admitErr := h.registry.AdmitReport(subject.FleetNodeID, commandID, len(in)); admitErr != nil {
+		if errors.Is(admitErr, control.ErrReportQuotaExceeded) {
+			return nil, connect.NewError(connect.CodeResourceExhausted, admitErr)
+		}
+		return nil, fleeterror.NewFailedPreconditionError("pair report does not match an in-flight server-issued command")
+	}
+	accepted, rejected, err := h.pairing.ApplyPairResults(ctx, subject.FleetNodeID, subject.OrgID, in)
+	if err != nil {
+		return nil, err
+	}
+	if rejected > 0 {
+		slog.Warn("fleet node reported pair results that were dropped",
+			"fleet_node_id", subject.FleetNodeID,
+			"org_id", subject.OrgID,
+			"rejected", rejected,
+		)
+	}
+	if len(accepted) > 0 {
+		h.registry.PublishPairResults(subject.FleetNodeID, commandID, accepted)
+	}
+	return connect.NewResponse(&pb.ReportPairedDevicesResponse{
+		AcceptedCount: int64(len(accepted)),
+		RejectedCount: rejected,
+	}), nil
+}
+
 func toPairingDevice(d *pb.DiscoveredDeviceReport) *pairingpb.Device {
 	return &pairingpb.Device{
 		DeviceIdentifier: d.GetDeviceIdentifier(),

--- a/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
@@ -59,7 +59,8 @@ func newControlHarness(t *testing.T) *controlHarness {
 	authStore := sqlstores.NewSQLFleetNodeAuthStore(db)
 	authSvc := auth.NewService(authStore, enrollmentStore, apiKeySvc)
 	pairingStore := sqlstores.NewSQLFleetNodePairingStore(db)
-	pairingSvc := pairing.NewService(pairingStore, enrollmentStore, transactor)
+	deviceStore := sqlstores.NewSQLDeviceStore(db)
+	pairingSvc := pairing.NewService(pairingStore, enrollmentStore, transactor, deviceStore)
 	registry := control.NewRegistry()
 
 	pubKey, _, _ := ed25519.GenerateKey(rand.Reader)

--- a/server/internal/handlers/fleetnode/gateway/handler_discovery_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_discovery_test.go
@@ -92,6 +92,57 @@ func TestReportDiscoveredDevices_PublishesBatchToInFlightCommand(t *testing.T) {
 	}
 }
 
+func TestReportPairedDevices_PersistsAndPublishesAcceptedResults(t *testing.T) {
+	// Arrange
+	h := newControlHarness(t)
+	subject := &auth.Subject{FleetNodeID: h.fleetNodeID, OrgID: 1, Name: "agent-pair-report"}
+	_, err := h.db.Exec(`INSERT INTO discovered_device (org_id, device_identifier, ip_address, port, url_scheme, driver_name, is_active, discovered_by_fleet_node_id)
+		VALUES (1, 'auto:paired-1', '10.0.0.80', '4028', 'http', 'virtual', TRUE, $1)`, h.fleetNodeID)
+	require.NoError(t, err)
+
+	stream := h.registry.Register(h.fleetNodeID)
+	defer stream.Unregister()
+	session, err := h.registry.Send(context.Background(), h.fleetNodeID, &pb.ControlCommand{CommandId: "pair-cmd"}, nil)
+	require.NoError(t, err)
+	defer session.Close()
+	<-stream.Outgoing
+
+	ctx := authn.SetInfo(context.Background(), subject)
+
+	// Act
+	resp, err := h.handler.ReportPairedDevices(ctx, connect.NewRequest(&pb.ReportPairedDevicesRequest{
+		CommandId: "pair-cmd",
+		Results: []*pb.FleetNodePairResult{{
+			DeviceIdentifier: "auto:paired-1",
+			Outcome:          pb.PairOutcome_PAIR_OUTCOME_PAIRED,
+			SerialNumber:     "sn-paired-1",
+			MacAddress:       "aa:bb:cc:00:10:01",
+		}},
+	}))
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), resp.Msg.GetAcceptedCount())
+	select {
+	case ev := <-session.Events():
+		require.Len(t, ev.PairResults, 1)
+		assert.Equal(t, "auto:paired-1", ev.PairResults[0].GetDeviceIdentifier())
+	case <-time.After(time.Second):
+		t.Fatal("expected pair results on events channel")
+	}
+
+	var pairedRows int
+	require.NoError(t, h.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM fleet_node_device fnd
+		JOIN device d ON d.id = fnd.device_id
+		JOIN device_pairing dp ON dp.device_id = d.id
+		WHERE fnd.fleet_node_id = $1
+		  AND d.device_identifier = 'auto:paired-1'
+		  AND dp.pairing_status = 'PAIRED'`, h.fleetNodeID).Scan(&pairedRows))
+	assert.Equal(t, 1, pairedRows)
+}
+
 // A partially-accepted report must only forward accepted devices to the
 // operator. Rejected rows (e.g. ownership conflicts) must not surface,
 // since the operator-facing batch is a trust signal — the DB already

--- a/server/internal/handlers/fleetnode/gateway/handler_heartbeat_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_heartbeat_test.go
@@ -53,7 +53,8 @@ func newHeartbeatHandler(t *testing.T) (*gateway.Handler, *sql.DB, int64) {
 	require.NoError(t, err)
 
 	pairingStore := sqlstores.NewSQLFleetNodePairingStore(db)
-	pairingSvc := pairing.NewService(pairingStore, enrollmentStore, transactor)
+	deviceStore := sqlstores.NewSQLDeviceStore(db)
+	pairingSvc := pairing.NewService(pairingStore, enrollmentStore, transactor, deviceStore)
 
 	return gateway.NewHandler(enrollmentSvc, authSvc, pairingSvc, control.NewRegistry()), db, agent.ID
 }


### PR DESCRIPTION
## Summary

Completes the server-side fleet-node discovery/pairing flow so discovered devices can be listed, paired through a node over ControlStream, reported back by the node, persisted into normal device state, and streamed back to the operator.

## Changes

- Implements `ListFleetNodeDiscoveredDevices` in the fleet-node admin handler.
- Implements `PairDiscoveredDevicesOnFleetNode` using the existing ControlStream command path.
- Implements gateway `ReportPairedDevices` and routes accepted pair results back to the waiting admin stream.
- Extends report-bearing control events to carry pair-result batches.
- Persists pair outcomes into device state:
  - `PAIRED` creates/updates the device, marks pairing `PAIRED`, and attaches it to `fleet_node_device`.
  - `AUTH_NEEDED` marks `AUTHENTICATION_NEEDED`.
  - `AUTH_FAILED` and non-auth `ERROR` mark `FAILED`.
- Removes agent-side asymmetric-key pairing behavior; pairing now uses supplied username/password, plugin defaults, or reports auth-needed.
- Adds focused tests around discovered listing, pair-result streaming, gateway persistence, and the simplified agent pairer.

## Validation

- `bin/go test ./server/cmd/fleetnode ./server/internal/domain/fleetnode/discovery ./server/internal/domain/fleetnode/control -count=1`
- `bin/go test ./server/cmd/fleetd ./server/internal/domain/fleetnode/pairing -run TestUpsertDiscoveredDevices_CountsAreNotDoubledOnTxRetry -count=1`
- `bin/go test ./server/internal/handlers/fleetnode/admin ./server/internal/handlers/fleetnode/gateway -run '^$'`
- `git diff --check`

## Notes

- Full DB-backed handler/domain tests could not run locally because Postgres rejected the configured `fleet` credentials.
- `just gen` / `_client-init` could not run because npm repeatedly returned corrupted tarballs with `EINTEGRITY`; no proto source changes are included in this PR, so generated files were not needed.