### PR TITLE
Route discovered pairing through fleet nodes

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -601,7 +601,7 @@ func start(config *Config) error {
 
 	mux.Handle(authv1connect.NewAuthServiceHandler(auth.NewHandler(authSvc), li))
 	mux.Handle(onboardingv1connect.NewOnboardingServiceHandler(onboarding.NewHandler(authSvc, onboardingSvc), li))
-	mux.Handle(pairingv1connect.NewPairingServiceHandler(pairing.NewHandler(pairingSvc, fleetNodeDiscoverySvc), li))
+	mux.Handle(pairingv1connect.NewPairingServiceHandler(pairing.NewHandler(pairingSvc, fleetNodeDiscoverySvc, fleetNodePairingSvc), li))
 	mux.Handle(networkinfov1connect.NewNetworkInfoServiceHandler(networkinfo.NewHandler(pairingSvc), li))
 	mux.Handle(fleetmanagementv1connect.NewFleetManagementServiceHandler(fleetmanagement.NewHandler(fleetMgmtSvc), li))
 	mux.Handle(minercommandv1connect.NewMinerCommandServiceHandler(command.NewHandler(commandSvc), li))

--- a/server/generated/sqlc/fleetnodepairing.sql.go
+++ b/server/generated/sqlc/fleetnodepairing.sql.go
@@ -156,79 +156,94 @@ func (q *Queries) ListFleetNodeDevices(ctx context.Context, arg ListFleetNodeDev
 }
 
 const listFleetNodeDiscoveredDevices = `-- name: ListFleetNodeDiscoveredDevices :many
-SELECT DISTINCT ON (dd.id)
-       dd.id,
-       dd.org_id,
-       dd.device_identifier,
-       dd.discovered_by_fleet_node_id,
-       dd.ip_address,
-       dd.port,
-       dd.url_scheme,
-       dd.driver_name,
-       dd.model,
-       dd.manufacturer,
-       dd.firmware_version,
-       dd.last_seen,
-       COALESCE(dp.pairing_status::text, '')::text AS pairing_status
-FROM discovered_device dd
-LEFT JOIN device d ON d.discovered_device_id = dd.id AND d.deleted_at IS NULL
-LEFT JOIN device_pairing dp ON dp.device_id = d.id
-WHERE dd.org_id = $1
-  AND dd.is_active = TRUE
-  AND dd.deleted_at IS NULL
-  AND dd.discovered_by_fleet_node_id IS NOT NULL
-  AND NOT EXISTS (
-      SELECT 1
-      FROM device db
-      JOIN fleet_node_device fnd ON fnd.device_id = db.id AND fnd.org_id = dd.org_id
-      WHERE (db.discovered_device_id = dd.id
-             OR (db.device_identifier = dd.device_identifier AND db.org_id = dd.org_id))
-        AND db.deleted_at IS NULL
-  )
-  AND NOT EXISTS (
-      SELECT 1
-      FROM device dpd
-      JOIN device_pairing dpp ON dpp.device_id = dpd.id
-      WHERE (dpd.discovered_device_id = dd.id
-             OR (dpd.device_identifier = dd.device_identifier AND dpd.org_id = dd.org_id))
-        AND dpd.deleted_at IS NULL
-        AND dpp.pairing_status IN ('PAIRED', 'DEFAULT_PASSWORD')
-  )
-  AND ($2::bigint IS NULL OR dd.discovered_by_fleet_node_id = $2::bigint)
-  -- pair-all without operator credentials can't satisfy AUTHENTICATION_NEEDED rows
-  -- (they were already attempted and need credentials). Excluding them keeps a
-  -- capped first page from filling with unsatisfiable rows and starving
-  -- never-attempted devices on re-issue for nodes with more than ` + "`" + `limit` + "`" + `
-  -- candidates. NULL/false keeps them (listing for display, and pair-all WITH
-  -- credentials, which can retry them).
-  AND (
-    NOT COALESCE($3::bool, FALSE)
-    OR NOT EXISTS (
-      SELECT 1
-      FROM device adn
-      JOIN device_pairing adp ON adp.device_id = adn.id
-      WHERE (adn.discovered_device_id = dd.id
-             OR (adn.device_identifier = dd.device_identifier AND adn.org_id = dd.org_id))
-        AND adn.deleted_at IS NULL
-        AND adp.pairing_status = 'AUTHENTICATION_NEEDED'
+WITH candidate AS (
+  SELECT DISTINCT ON (dd.id)
+         dd.id,
+         dd.org_id,
+         dd.device_identifier,
+         dd.discovered_by_fleet_node_id,
+         dd.ip_address,
+         dd.port,
+         dd.url_scheme,
+         dd.driver_name,
+         dd.model,
+         dd.manufacturer,
+         dd.firmware_version,
+         dd.last_seen,
+         COALESCE(dp.pairing_status::text, '')::text AS pairing_status
+  FROM discovered_device dd
+  LEFT JOIN device d ON (
+      d.discovered_device_id = dd.id
+      OR (d.device_identifier = dd.device_identifier AND d.org_id = dd.org_id)
     )
-  )
-  -- Explicit pairing passes the requested identifiers so only those rows are
-  -- scanned, not the whole org. NULL = no filter (listing + pair-all); an empty
-  -- non-nil array matches nothing (explicit selection of none).
-  AND ($4::text[] IS NULL OR dd.device_identifier = ANY($4::text[]))
-  AND ($5::bigint IS NULL OR dd.id > $5::bigint)
-ORDER BY dd.id ASC, d.id DESC NULLS LAST
-LIMIT $6::bigint
+    AND d.deleted_at IS NULL
+  LEFT JOIN device_pairing dp ON dp.device_id = d.id
+  WHERE dd.org_id = $1
+    AND dd.is_active = TRUE
+    AND dd.deleted_at IS NULL
+    AND dd.discovered_by_fleet_node_id IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM device db
+        JOIN fleet_node_device fnd ON fnd.device_id = db.id AND fnd.org_id = dd.org_id
+        WHERE (db.discovered_device_id = dd.id
+               OR (db.device_identifier = dd.device_identifier AND db.org_id = dd.org_id))
+          AND db.deleted_at IS NULL
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM device dpd
+        JOIN device_pairing dpp ON dpp.device_id = dpd.id
+        WHERE (dpd.discovered_device_id = dd.id
+               OR (dpd.device_identifier = dd.device_identifier AND dpd.org_id = dd.org_id))
+          AND dpd.deleted_at IS NULL
+          AND dpp.pairing_status IN ('PAIRED', 'DEFAULT_PASSWORD')
+    )
+    AND ($4::bigint IS NULL OR dd.discovered_by_fleet_node_id = $4::bigint)
+    -- pair-all without operator credentials can't satisfy AUTHENTICATION_NEEDED rows
+    -- (they were already attempted and need credentials). Excluding them keeps a
+    -- capped first page from filling with unsatisfiable rows and starving
+    -- never-attempted devices on re-issue for nodes with more than ` + "`" + `limit` + "`" + `
+    -- candidates. NULL/false keeps them (listing for display, and pair-all WITH
+    -- credentials, which can retry them).
+    AND (
+      NOT COALESCE($5::bool, FALSE)
+      OR NOT EXISTS (
+        SELECT 1
+        FROM device adn
+        JOIN device_pairing adp ON adp.device_id = adn.id
+        WHERE (adn.discovered_device_id = dd.id
+               OR (adn.device_identifier = dd.device_identifier AND adn.org_id = dd.org_id))
+          AND adn.deleted_at IS NULL
+          AND adp.pairing_status = 'AUTHENTICATION_NEEDED'
+      )
+    )
+    -- Explicit pairing passes the requested identifiers so only those rows are
+    -- scanned, not the whole org. NULL = no filter (listing + pair-all); an empty
+    -- non-nil array matches nothing (explicit selection of none).
+    AND ($6::text[] IS NULL OR dd.device_identifier = ANY($6::text[]))
+    AND ($7::text[] IS NULL OR COALESCE(dd.model, '') = ANY($7::text[]))
+    AND ($8::text[] IS NULL OR COALESCE(dd.manufacturer, '') = ANY($8::text[]))
+    AND ($9::bigint IS NULL OR dd.id > $9::bigint)
+  ORDER BY dd.id ASC, d.id DESC NULLS LAST
+)
+SELECT id, org_id, device_identifier, discovered_by_fleet_node_id, ip_address, port, url_scheme, driver_name, model, manufacturer, firmware_version, last_seen, pairing_status
+FROM candidate
+WHERE ($2::text[] IS NULL OR pairing_status = ANY($2::text[]))
+ORDER BY id ASC
+LIMIT $3::bigint
 `
 
 type ListFleetNodeDiscoveredDevicesParams struct {
 	OrgID             int64
+	PairingStatuses   []string
+	Limit             sql.NullInt64
 	FleetNodeID       sql.NullInt64
 	ExcludeAuthNeeded sql.NullBool
 	Identifiers       []string
+	Models            []string
+	Manufacturers     []string
 	CursorID          sql.NullInt64
-	Limit             sql.NullInt64
 }
 
 type ListFleetNodeDiscoveredDevicesRow struct {
@@ -264,11 +279,14 @@ type ListFleetNodeDiscoveredDevicesRow struct {
 func (q *Queries) ListFleetNodeDiscoveredDevices(ctx context.Context, arg ListFleetNodeDiscoveredDevicesParams) ([]ListFleetNodeDiscoveredDevicesRow, error) {
 	rows, err := q.query(ctx, q.listFleetNodeDiscoveredDevicesStmt, listFleetNodeDiscoveredDevices,
 		arg.OrgID,
+		pq.Array(arg.PairingStatuses),
+		arg.Limit,
 		arg.FleetNodeID,
 		arg.ExcludeAuthNeeded,
 		pq.Array(arg.Identifiers),
+		pq.Array(arg.Models),
+		pq.Array(arg.Manufacturers),
 		arg.CursorID,
-		arg.Limit,
 	)
 	if err != nil {
 		return nil, err
@@ -406,19 +424,21 @@ ON CONFLICT (org_id, device_identifier) WHERE deleted_at IS NULL DO UPDATE SET
     last_seen = CURRENT_TIMESTAMP,
     is_active = TRUE
 WHERE (
-    discovered_device.discovered_by_fleet_node_id IS NULL
-    OR discovered_device.discovered_by_fleet_node_id = EXCLUDED.discovered_by_fleet_node_id
+    discovered_device.discovered_by_fleet_node_id = EXCLUDED.discovered_by_fleet_node_id
     -- The attributing node was revoked (soft-deleted), so a replacement node may
     -- reclaim its rows (otherwise a re-scan of the same stable mac:/serial: device
     -- is rejected forever). Attribution moves to the reporter ($10), staying
     -- non-NULL, so cloud-exclusion (discovered_by_fleet_node_id IS NULL) is never
     -- widened. Cloud-paired and live-cross-node rows remain blocked below.
-    OR NOT EXISTS (
+    OR (
+      discovered_device.discovered_by_fleet_node_id IS NOT NULL
+      AND NOT EXISTS (
       SELECT 1
       FROM fleet_node fn
       WHERE fn.id = discovered_device.discovered_by_fleet_node_id
         AND fn.org_id = discovered_device.org_id
         AND fn.deleted_at IS NULL
+      )
     )
   )
   AND NOT EXISTS (
@@ -472,12 +492,12 @@ type UpsertDiscoveredDeviceFromFleetNodeParams struct {
 }
 
 // 0 rows on conflict signals rejection. A remote report must not redirect the
-// endpoint/credentials of a miner the cloud actively dials, so the update is
-// blocked when the row is promoted to a cloud-paired device (device_pairing
-// PAIRED/DEFAULT_PASSWORD) or one paired to a different fleet node. Bare promoted devices and
-// devices paired to the reporting node itself stay refreshable, subject to the
-// attribution guard. The agent synthesizes a stable per-device identifier
-// (mac:/serial:, else auto:<hash>), so a re-scan reuses the same row.
+// endpoint/credentials of a miner the cloud owns, so the update is blocked
+// unless the row is already attributed to this fleet node or to a revoked node
+// that can be reclaimed. Devices paired to the reporting node itself stay
+// refreshable, subject to the attribution guard. The agent synthesizes a stable
+// per-device identifier (mac:/serial:, else auto:<hash>), so a re-scan reuses
+// the same row.
 func (q *Queries) UpsertDiscoveredDeviceFromFleetNode(ctx context.Context, arg UpsertDiscoveredDeviceFromFleetNodeParams) (int64, error) {
 	result, err := q.exec(ctx, q.upsertDiscoveredDeviceFromFleetNodeStmt, upsertDiscoveredDeviceFromFleetNode,
 		arg.OrgID,

--- a/server/internal/domain/fleetnode/pairing/integration_test.go
+++ b/server/internal/domain/fleetnode/pairing/integration_test.go
@@ -322,7 +322,7 @@ func TestUpsertDiscoveredDevices_RefreshesUnpairedDeviceFromOriginatingNode(t *t
 	nodeID := createFleetNode(t, enrollment, orgID, "node-refresh")
 	var ddID int64
 	require.NoError(t, db.QueryRow(`INSERT INTO discovered_device (org_id, device_identifier, ip_address, port, url_scheme, driver_name, is_active, discovered_by_fleet_node_id)
-		VALUES ($1, 'unpaired-shared', '10.0.0.60', '80', 'http', 'virtual', TRUE, NULL) RETURNING id`, orgID).Scan(&ddID))
+		VALUES ($1, 'unpaired-shared', '10.0.0.60', '80', 'http', 'virtual', TRUE, $2) RETURNING id`, orgID, nodeID).Scan(&ddID))
 	_, err := db.Exec(`INSERT INTO device (device_identifier, mac_address, serial_number, org_id, discovered_device_id)
 		VALUES ($1, $2, $3, $4, $5)`,
 		fmt.Sprintf("local-dev-%d", ddID),
@@ -344,6 +344,36 @@ func TestUpsertDiscoveredDevices_RefreshesUnpairedDeviceFromOriginatingNode(t *t
 	var ip string
 	require.NoError(t, db.QueryRow(`SELECT ip_address FROM discovered_device WHERE id = $1`, ddID).Scan(&ip))
 	assert.Equal(t, "10.0.0.99", ip, "originating node must be able to refresh an unpaired device row")
+}
+
+func TestUpsertDiscoveredDevices_RejectsClaimingCloudDiscoveredBareDevice(t *testing.T) {
+	// Arrange: a cloud-origin discovered row has no fleet-node attribution and
+	// no active pairing yet. A fleet node must not be able to take ownership of
+	// that identifier because generic Pair requests route credentials by the DB
+	// attribution.
+	ctx := t.Context()
+	db, orgID, pairing, enrollment := setupPairingTest(t)
+	fleetNodeID := createFleetNode(t, enrollment, orgID, "node-cloud-bare-claim")
+	var ddID int64
+	require.NoError(t, db.QueryRow(`INSERT INTO discovered_device (org_id, device_identifier, ip_address, port, url_scheme, driver_name, is_active, discovered_by_fleet_node_id)
+		VALUES ($1, 'cloud-bare-shared', '10.0.0.60', '80', 'http', 'virtual', TRUE, NULL) RETURNING id`, orgID).Scan(&ddID))
+
+	// Act
+	acceptedIdx, rejected, err := pairing.UpsertDiscoveredDevices(ctx, fleetNodeID, orgID, []fleetnodepairing.DiscoveredDeviceReport{
+		{DeviceIdentifier: "cloud-bare-shared", IPAddress: "10.0.0.99", Port: "80", URLScheme: "http", DriverName: "virtual"},
+	})
+
+	// Assert: rejected; cloud-origin endpoint and attribution remain untouched.
+	require.NoError(t, err)
+	assert.Empty(t, acceptedIdx)
+	assert.Equal(t, int64(1), rejected)
+	var (
+		ip         string
+		attributed sql.NullInt64
+	)
+	require.NoError(t, db.QueryRow(`SELECT ip_address, discovered_by_fleet_node_id FROM discovered_device WHERE id = $1`, ddID).Scan(&ip, &attributed))
+	assert.Equal(t, "10.0.0.60", ip)
+	assert.False(t, attributed.Valid)
 }
 
 func TestUpsertDiscoveredDevices_BatchValidationErrorRollsBack(t *testing.T) {

--- a/server/internal/domain/fleetnode/pairing/models.go
+++ b/server/internal/domain/fleetnode/pairing/models.go
@@ -10,6 +10,7 @@ import (
 // canonical constants so the two pairing paths can't drift.
 const (
 	StatusPaired               = domainpairing.StatusPaired
+	StatusUnpaired             = domainpairing.StatusUnpaired
 	StatusAuthenticationNeeded = domainpairing.StatusAuthenticationNeeded
 	StatusDefaultPassword      = domainpairing.StatusDefaultPassword
 	StatusFailed               = domainpairing.StatusFailed

--- a/server/internal/domain/fleetnode/pairing/pair_discovered.go
+++ b/server/internal/domain/fleetnode/pairing/pair_discovered.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log/slog"
 
+	fleetmanagementv1 "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
 	gatewaypb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	minercommandv1 "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	minermodels "github.com/block/proto-fleet/server/internal/domain/miner/models"
@@ -14,10 +16,10 @@ import (
 	"github.com/block/proto-fleet/server/internal/infrastructure/secrets"
 )
 
-// maxPairBatch caps targets per pair command, matching FleetNodePairRequest.targets
+// MaxPairBatch caps targets per pair command, matching FleetNodePairRequest.targets
 // max_items so a pair_all on a huge fleet can't balloon one ControlCommand; the
 // operator re-issues for the remainder (paired devices drop from the listing).
-const maxPairBatch = 1024
+const MaxPairBatch = 1024
 
 // ResolvePairTargets returns the pairable targets for a batch request. It draws
 // from the not-yet-paired devices the node discovered (the listing already
@@ -30,7 +32,7 @@ func (s *Service) ResolvePairTargets(ctx context.Context, fleetNodeID, orgID int
 		limit *int64
 	)
 	if pairAllUnpaired {
-		l := int64(maxPairBatch)
+		l := int64(MaxPairBatch)
 		limit = &l
 	} else {
 		// Non-nil (even empty) so the SQL filter means "only these", not "all".
@@ -45,23 +47,108 @@ func (s *Service) ResolvePairTargets(ctx context.Context, fleetNodeID, orgID int
 	// the node's secretBundleFor); explicit selection still targets them.
 	usableCredentials := credentials != nil && credentials.Password != nil
 	excludeAuthNeeded := pairAllUnpaired && !usableCredentials
-	candidates, err := s.store.ListFleetNodeDiscoveredDevices(ctx, orgID, &fleetNodeID, ids, nil, limit, excludeAuthNeeded)
+	candidates, err := s.store.ListFleetNodeDiscoveredDevices(ctx, orgID, &fleetNodeID, FleetNodeDiscoveredDeviceFilter{
+		Identifiers:       ids,
+		Limit:             limit,
+		ExcludeAuthNeeded: excludeAuthNeeded,
+	})
 	if err != nil {
 		return nil, fleeterror.LogInternal(component, "list pair candidates", clientErrList, err)
 	}
-	targets := make([]*pairingpb.FleetNodePairTarget, 0, len(candidates))
-	for _, c := range candidates {
+	return pairTargetsFromDiscoveredDevices(candidates), nil
+}
+
+// ResolvePairTargetsByFilterPage returns pairable node-discovered targets that
+// match the DeviceFilter shape PairingService.Pair accepts for allDevices
+// requests. nextCursor is non-nil when another page may exist. Fleet-node-
+// discovered rows do not have every fleet-list attribute, so this intentionally
+// supports only filters represented in the discovered-device table/listing.
+// Unsupported/unsatisfiable filters return no targets so the caller can safely
+// leave those requests to the server-local pairing path.
+func (s *Service) ResolvePairTargetsByFilterPage(ctx context.Context, fleetNodeID, orgID int64, filter *minercommandv1.DeviceFilter, credentials *pairingpb.Credentials, cursorID *int64) ([]*pairingpb.FleetNodePairTarget, *int64, error) {
+	if filter == nil || unsupportedFleetNodePairFilter(filter) {
+		return nil, nil, nil
+	}
+	statuses, supported := pairingStatusFilterValues(filter.GetPairingStatus())
+	if !supported {
+		return nil, nil, nil
+	}
+
+	usableCredentials := credentials != nil && credentials.Password != nil
+	excludeAuthNeeded := !usableCredentials
+	limit := int64(MaxPairBatch)
+	candidates, err := s.store.ListFleetNodeDiscoveredDevices(ctx, orgID, &fleetNodeID, FleetNodeDiscoveredDeviceFilter{
+		PairingStatuses:   statuses,
+		Models:            nonEmptyStrings(filter.GetModels()),
+		Manufacturers:     nonEmptyStrings(filter.GetManufacturers()),
+		CursorID:          cursorID,
+		Limit:             &limit,
+		ExcludeAuthNeeded: excludeAuthNeeded,
+	})
+	if err != nil {
+		return nil, nil, fleeterror.LogInternal(component, "list pair candidates", clientErrList, err)
+	}
+	var nextCursor *int64
+	if len(candidates) == MaxPairBatch {
+		last := candidates[len(candidates)-1].ID
+		nextCursor = &last
+	}
+	return pairTargetsFromDiscoveredDevices(candidates), nextCursor, nil
+}
+
+func nonEmptyStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
+func unsupportedFleetNodePairFilter(filter *minercommandv1.DeviceFilter) bool {
+	return len(filter.GetDeviceStatus()) > 0
+}
+
+func pairTargetsFromDiscoveredDevices(devices []FleetNodeDiscoveredDevice) []*pairingpb.FleetNodePairTarget {
+	targets := make([]*pairingpb.FleetNodePairTarget, 0, len(devices))
+	for _, d := range devices {
 		targets = append(targets, &pairingpb.FleetNodePairTarget{
-			DeviceIdentifier: c.DeviceIdentifier,
-			IpAddress:        c.IPAddress,
-			Port:             c.Port,
-			UrlScheme:        c.URLScheme,
-			DriverName:       c.DriverName,
-			Manufacturer:     c.Manufacturer,
-			FirmwareVersion:  c.FirmwareVersion,
+			DeviceIdentifier: d.DeviceIdentifier,
+			IpAddress:        d.IPAddress,
+			Port:             d.Port,
+			UrlScheme:        d.URLScheme,
+			DriverName:       d.DriverName,
+			Manufacturer:     d.Manufacturer,
+			FirmwareVersion:  d.FirmwareVersion,
 		})
 	}
-	return targets, nil
+	return targets
+}
+
+func pairingStatusFilterValues(statuses []fleetmanagementv1.PairingStatus) ([]string, bool) {
+	if len(statuses) == 0 {
+		return nil, false
+	}
+	out := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		switch status { //nolint:exhaustive // Unsupported pairing statuses intentionally fail closed.
+		case fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED:
+			out = append(out, StatusAuthenticationNeeded)
+		case fleetmanagementv1.PairingStatus_PAIRING_STATUS_UNPAIRED:
+			out = append(out, "", StatusUnpaired)
+		case fleetmanagementv1.PairingStatus_PAIRING_STATUS_FAILED:
+			out = append(out, StatusFailed)
+		case fleetmanagementv1.PairingStatus_PAIRING_STATUS_UNSPECIFIED,
+			fleetmanagementv1.PairingStatus_PAIRING_STATUS_PAIRED,
+			fleetmanagementv1.PairingStatus_PAIRING_STATUS_PENDING,
+			fleetmanagementv1.PairingStatus_PAIRING_STATUS_DEFAULT_PASSWORD:
+			continue
+		default:
+			return nil, false
+		}
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
 }
 
 // PersistFleetNodePairResult records one device's reported pairing outcome in a

--- a/server/internal/domain/fleetnode/pairing/pair_discovered_internal_test.go
+++ b/server/internal/domain/fleetnode/pairing/pair_discovered_internal_test.go
@@ -1,0 +1,410 @@
+package pairing
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fleetmanagementv1 "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
+	minercommandv1 "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
+	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
+)
+
+func TestPairingStatusFilterSet(t *testing.T) {
+	got, supported := pairingStatusFilterValues(nil)
+	require.False(t, supported)
+	assert.Nil(t, got)
+
+	got, supported = pairingStatusFilterValues([]fleetmanagementv1.PairingStatus{
+		fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED,
+		fleetmanagementv1.PairingStatus_PAIRING_STATUS_UNPAIRED,
+		fleetmanagementv1.PairingStatus_PAIRING_STATUS_FAILED,
+	})
+
+	require.True(t, supported)
+	assert.Equal(t, []string{StatusAuthenticationNeeded, "", StatusUnpaired, StatusFailed}, got)
+
+	got, supported = pairingStatusFilterValues([]fleetmanagementv1.PairingStatus{
+		fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED,
+		fleetmanagementv1.PairingStatus_PAIRING_STATUS_PAIRED,
+	})
+	require.True(t, supported)
+	assert.Equal(t, []string{StatusAuthenticationNeeded}, got)
+
+	got, supported = pairingStatusFilterValues([]fleetmanagementv1.PairingStatus{
+		fleetmanagementv1.PairingStatus_PAIRING_STATUS_PAIRED,
+	})
+	assert.False(t, supported)
+	assert.Nil(t, got)
+
+	got, supported = pairingStatusFilterValues([]fleetmanagementv1.PairingStatus{
+		fleetmanagementv1.PairingStatus(999),
+	})
+	assert.False(t, supported)
+	assert.Nil(t, got)
+}
+
+type pagingPairTargetStore struct {
+	Store
+	devices []FleetNodeDiscoveredDevice
+	calls   []pagingPairTargetCall
+}
+
+type pagingPairTargetCall struct {
+	filter FleetNodeDiscoveredDeviceFilter
+}
+
+func (s *pagingPairTargetStore) ListFleetNodeDiscoveredDevices(_ context.Context, _ int64, _ *int64, filter FleetNodeDiscoveredDeviceFilter) ([]FleetNodeDiscoveredDevice, error) {
+	s.calls = append(s.calls, pagingPairTargetCall{filter: copyFleetNodeDiscoveredDeviceFilter(filter)})
+	filtered := make([]FleetNodeDiscoveredDevice, 0, len(s.devices))
+	for _, device := range s.devices {
+		if filter.ExcludeAuthNeeded && device.PairingStatus == StatusAuthenticationNeeded {
+			continue
+		}
+		if filter.Identifiers != nil && !slices.Contains(filter.Identifiers, device.DeviceIdentifier) {
+			continue
+		}
+		if filter.PairingStatuses != nil && !slices.Contains(filter.PairingStatuses, device.PairingStatus) {
+			continue
+		}
+		if filter.Models != nil && !slices.Contains(filter.Models, device.Model) {
+			continue
+		}
+		if filter.Manufacturers != nil && !slices.Contains(filter.Manufacturers, device.Manufacturer) {
+			continue
+		}
+		filtered = append(filtered, device)
+	}
+	start := 0
+	if filter.CursorID != nil {
+		for start < len(filtered) && filtered[start].ID <= *filter.CursorID {
+			start++
+		}
+	}
+	end := len(filtered)
+	if filter.Limit != nil && start+int(*filter.Limit) < end {
+		end = start + int(*filter.Limit)
+	}
+	return filtered[start:end], nil
+}
+
+func copyFleetNodeDiscoveredDeviceFilter(filter FleetNodeDiscoveredDeviceFilter) FleetNodeDiscoveredDeviceFilter {
+	return FleetNodeDiscoveredDeviceFilter{
+		Identifiers:       slices.Clone(filter.Identifiers),
+		PairingStatuses:   slices.Clone(filter.PairingStatuses),
+		Models:            slices.Clone(filter.Models),
+		Manufacturers:     slices.Clone(filter.Manufacturers),
+		CursorID:          copyInt64(filter.CursorID),
+		Limit:             copyInt64(filter.Limit),
+		ExcludeAuthNeeded: filter.ExcludeAuthNeeded,
+	}
+}
+
+func copyInt64(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
+}
+
+func TestResolvePairTargetsByFilterPagePassesSupportedFiltersToStore(t *testing.T) {
+	devices := make([]FleetNodeDiscoveredDevice, 0, MaxPairBatch+2)
+	for i := 1; i <= MaxPairBatch+1; i++ {
+		devices = append(devices, FleetNodeDiscoveredDevice{
+			ID:               int64(i),
+			DeviceIdentifier: "mac:skip",
+			IPAddress:        "10.0.0.1",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "M30",
+			PairingStatus:    StatusAuthenticationNeeded,
+		})
+	}
+	devices[len(devices)-1].DeviceIdentifier = "mac:match"
+	devices[len(devices)-1].Model = "S19"
+	devices[len(devices)-1].Manufacturer = "Bitmain"
+	store := &pagingPairTargetStore{devices: devices}
+	service := NewService(store, nil, nil)
+	pw := "pw"
+
+	targets, _, err := service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED},
+		Models:        []string{"S19"},
+		Manufacturers: []string{"Bitmain"},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"mac:match"}, internalTargetIdentifiers(targets))
+	require.Len(t, store.calls, 1)
+	assert.Equal(t, []string{StatusAuthenticationNeeded}, store.calls[0].filter.PairingStatuses)
+	assert.Equal(t, []string{"S19"}, store.calls[0].filter.Models)
+	assert.Equal(t, []string{"Bitmain"}, store.calls[0].filter.Manufacturers)
+	assert.Nil(t, store.calls[0].filter.CursorID)
+	assert.Equal(t, int64(MaxPairBatch), *store.calls[0].filter.Limit)
+	assert.False(t, store.calls[0].filter.ExcludeAuthNeeded)
+}
+
+func TestResolvePairTargetsByFilterPageNormalizesEmptyModelManufacturerFilters(t *testing.T) {
+	store := &pagingPairTargetStore{devices: []FleetNodeDiscoveredDevice{{
+		ID:               1,
+		DeviceIdentifier: "mac:authneeded",
+		IPAddress:        "10.0.0.1",
+		Port:             "80",
+		URLScheme:        "http",
+		Model:            "S19",
+		Manufacturer:     "Bitmain",
+		PairingStatus:    StatusAuthenticationNeeded,
+	}}}
+	service := NewService(store, nil, nil)
+	pw := "pw"
+
+	targets, _, err := service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED},
+		Models:        []string{},
+		Manufacturers: []string{},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mac:authneeded"}, internalTargetIdentifiers(targets))
+	require.Len(t, store.calls, 1)
+	assert.Nil(t, store.calls[0].filter.Models)
+	assert.Nil(t, store.calls[0].filter.Manufacturers)
+}
+
+func TestResolvePairTargetsByFilterPageReturnsCursorAtBatchLimit(t *testing.T) {
+	devices := make([]FleetNodeDiscoveredDevice, 0, MaxPairBatch+1)
+	for i := 1; i <= MaxPairBatch+1; i++ {
+		devices = append(devices, FleetNodeDiscoveredDevice{
+			ID:               int64(i),
+			DeviceIdentifier: "mac:page",
+			IPAddress:        "10.0.0.1",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "S19",
+		})
+	}
+	devices[MaxPairBatch].DeviceIdentifier = "mac:last"
+	store := &pagingPairTargetStore{devices: devices}
+	service := NewService(store, nil, nil)
+	pw := "pw"
+
+	targets, nextCursor, err := service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_UNPAIRED},
+		Models:        []string{"S19"},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	require.NoError(t, err)
+	require.Len(t, targets, MaxPairBatch)
+	require.NotNil(t, nextCursor)
+	assert.Equal(t, int64(MaxPairBatch), *nextCursor)
+
+	targets, nextCursor, err = service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_UNPAIRED},
+		Models:        []string{"S19"},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nextCursor)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mac:last"}, internalTargetIdentifiers(targets))
+	assert.Nil(t, nextCursor)
+	require.Len(t, store.calls, 2)
+	require.NotNil(t, store.calls[1].filter.CursorID)
+	assert.Equal(t, int64(MaxPairBatch), *store.calls[1].filter.CursorID)
+}
+
+func TestResolvePairTargetsByFilterRejectsUnsupportedDeviceStatus(t *testing.T) {
+	store := &pagingPairTargetStore{devices: []FleetNodeDiscoveredDevice{{
+		ID:               1,
+		DeviceIdentifier: "mac:authneeded",
+		IPAddress:        "10.0.0.1",
+		Port:             "80",
+		URLScheme:        "http",
+		Model:            "S19",
+		PairingStatus:    StatusAuthenticationNeeded,
+	}}}
+	service := NewService(store, nil, nil)
+	pw := "pw"
+
+	targets, _, err := service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{
+		DeviceStatus:  []fleetmanagementv1.DeviceStatus{fleetmanagementv1.DeviceStatus_DEVICE_STATUS_ONLINE},
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED},
+		Models:        []string{"S19"},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, targets)
+	assert.Empty(t, store.calls, "unsupported filters should stay on the cloud path without listing fleet-node targets")
+}
+
+func TestResolvePairTargetsByFilterRejectsUnsupportedPairingStatus(t *testing.T) {
+	store := &pagingPairTargetStore{devices: []FleetNodeDiscoveredDevice{{
+		ID:               1,
+		DeviceIdentifier: "mac:paired",
+		IPAddress:        "10.0.0.1",
+		Port:             "80",
+		URLScheme:        "http",
+		Model:            "S19",
+		PairingStatus:    StatusPaired,
+	}}}
+	service := NewService(store, nil, nil)
+	pw := "pw"
+
+	targets, _, err := service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_PAIRED},
+		Models:        []string{"S19"},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, targets)
+	assert.Empty(t, store.calls, "unsupported pairing statuses should not widen the fleet-node filter")
+}
+
+func TestResolvePairTargetsByFilterEmptyAllDevicesStaysCloudOnly(t *testing.T) {
+	store := &pagingPairTargetStore{devices: []FleetNodeDiscoveredDevice{
+		{
+			ID:               1,
+			DeviceIdentifier: "mac:authneeded",
+			IPAddress:        "10.0.0.1",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "S19",
+			PairingStatus:    StatusAuthenticationNeeded,
+		},
+		{
+			ID:               2,
+			DeviceIdentifier: "mac:failed",
+			IPAddress:        "10.0.0.2",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "S19",
+			PairingStatus:    StatusFailed,
+		},
+	}}
+	service := NewService(store, nil, nil)
+	pw := "pw"
+
+	targets, _, err := service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, targets)
+	assert.Empty(t, store.calls)
+}
+
+func TestResolvePairTargetsByFilterUnpairedMatchesStoredUnpairedStatus(t *testing.T) {
+	store := &pagingPairTargetStore{devices: []FleetNodeDiscoveredDevice{
+		{
+			ID:               1,
+			DeviceIdentifier: "mac:no-row",
+			IPAddress:        "10.0.0.1",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "S19",
+			PairingStatus:    "",
+		},
+		{
+			ID:               2,
+			DeviceIdentifier: "mac:stored-unpaired",
+			IPAddress:        "10.0.0.2",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "S19",
+			PairingStatus:    StatusUnpaired,
+		},
+	}}
+	service := NewService(store, nil, nil)
+	pw := "pw"
+
+	targets, _, err := service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_UNPAIRED},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mac:no-row", "mac:stored-unpaired"}, internalTargetIdentifiers(targets))
+	require.Len(t, store.calls, 1)
+	assert.Equal(t, []string{"", StatusUnpaired}, store.calls[0].filter.PairingStatuses)
+}
+
+func TestResolvePairTargetsByFilterMixedPairableAndImpossibleStatusesRoutesPairableSubset(t *testing.T) {
+	store := &pagingPairTargetStore{devices: []FleetNodeDiscoveredDevice{
+		{
+			ID:               1,
+			DeviceIdentifier: "mac:authneeded",
+			IPAddress:        "10.0.0.1",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "S19",
+			PairingStatus:    StatusAuthenticationNeeded,
+		},
+		{
+			ID:               2,
+			DeviceIdentifier: "mac:failed",
+			IPAddress:        "10.0.0.2",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "S19",
+			PairingStatus:    StatusFailed,
+		},
+	}}
+	service := NewService(store, nil, nil)
+	pw := "pw"
+
+	targets, _, err := service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{
+			fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED,
+			fleetmanagementv1.PairingStatus_PAIRING_STATUS_PAIRED,
+		},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mac:authneeded"}, internalTargetIdentifiers(targets))
+	require.Len(t, store.calls, 1)
+	assert.Equal(t, []string{StatusAuthenticationNeeded}, store.calls[0].filter.PairingStatuses)
+}
+
+func TestResolvePairTargetsByFilterExcludesAuthNeededWithoutPassword(t *testing.T) {
+	store := &pagingPairTargetStore{devices: []FleetNodeDiscoveredDevice{
+		{
+			ID:               1,
+			DeviceIdentifier: "mac:authneeded",
+			IPAddress:        "10.0.0.1",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "S19",
+			PairingStatus:    StatusAuthenticationNeeded,
+		},
+		{
+			ID:               2,
+			DeviceIdentifier: "mac:unpaired",
+			IPAddress:        "10.0.0.2",
+			Port:             "80",
+			URLScheme:        "http",
+			Model:            "S19",
+			PairingStatus:    "",
+		},
+	}}
+	service := NewService(store, nil, nil)
+
+	targets, _, err := service.ResolvePairTargetsByFilterPage(t.Context(), 10, 20, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{
+			fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED,
+			fleetmanagementv1.PairingStatus_PAIRING_STATUS_UNPAIRED,
+		},
+		Models: []string{"S19"},
+	}, &pairingpb.Credentials{Username: "root"}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mac:unpaired"}, internalTargetIdentifiers(targets))
+	require.Len(t, store.calls, 1)
+	assert.True(t, store.calls[0].filter.ExcludeAuthNeeded)
+}
+
+func internalTargetIdentifiers(targets []*pairingpb.FleetNodePairTarget) []string {
+	out := make([]string, 0, len(targets))
+	for _, target := range targets {
+		out = append(out, target.GetDeviceIdentifier())
+	}
+	return out
+}

--- a/server/internal/domain/fleetnode/pairing/pair_discovered_test.go
+++ b/server/internal/domain/fleetnode/pairing/pair_discovered_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	fleetmanagementv1 "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
 	gatewaypb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	minercommandv1 "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	fleetnodepairing "github.com/block/proto-fleet/server/internal/domain/fleetnode/pairing"
 	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
@@ -753,6 +755,40 @@ func TestResolvePairTargets_AuthNeededExclusionSurvivesDivergedLinkage(t *testin
 	assert.Contains(t, targetIdentifiers(withCreds), "mac:an-diverged")
 }
 
+func TestResolvePairTargetsByFilter_AuthNeededIncludesDivergedLinkage(t *testing.T) {
+	// Arrange: an AUTHENTICATION_NEEDED device whose discovery row was soft-deleted
+	// and re-created by the node under the same identifier. A status-filtered
+	// pair-all with credentials must still see the live device's status even though
+	// it is linked to the deleted discovery row.
+	ctx := t.Context()
+	db, orgID, pairing, enrollment := setupPairingTest(t)
+	node := createFleetNode(t, enrollment, orgID, "node-filter-an-diverged")
+	upsertNodeDiscovered(t, pairing, orgID, node, "mac:filter-an-diverged")
+	var oldDD int64
+	require.NoError(t, db.QueryRow(
+		`SELECT id FROM discovered_device WHERE org_id=$1 AND device_identifier=$2 AND deleted_at IS NULL`,
+		orgID, "mac:filter-an-diverged").Scan(&oldDD))
+	var dev int64
+	require.NoError(t, db.QueryRow(
+		`INSERT INTO device (device_identifier, mac_address, serial_number, org_id, discovered_device_id)
+		 VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+		"mac:filter-an-diverged", "aa:bb:cc:00:fd:01", "sn-fd", orgID, oldDD).Scan(&dev))
+	setPairingStatus(t, db, dev, "AUTHENTICATION_NEEDED")
+	_, err := db.Exec(`UPDATE discovered_device SET deleted_at = now() WHERE id = $1`, oldDD)
+	require.NoError(t, err)
+	upsertNodeDiscovered(t, pairing, orgID, node, "mac:filter-an-diverged")
+
+	// Act
+	pw := "pw"
+	targets, _, err := pairing.ResolvePairTargetsByFilterPage(ctx, node, orgID, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mac:filter-an-diverged"}, targetIdentifiers(targets))
+}
+
 func TestResolvePairTargets_PairAllExcludesAuthNeededWithoutCredentials(t *testing.T) {
 	// Arrange: one never-attempted device and one AUTHENTICATION_NEEDED device.
 	ctx := t.Context()
@@ -790,6 +826,36 @@ func TestResolvePairTargets_PairAllExcludesAuthNeededWithoutCredentials(t *testi
 	withCreds, err := pairing.ResolvePairTargets(ctx, node, orgID, nil, true, &pairingpb.Credentials{Username: "root", Password: &pw})
 	require.NoError(t, err)
 	assert.Contains(t, targetIdentifiers(withCreds), "mac:authneeded")
+}
+
+func TestResolvePairTargetsByFilter_AuthenticationNeeded(t *testing.T) {
+	// Arrange: a bulk auth-needed filter must retry only auth-needed rows, not
+	// every unpaired row discovered by the node.
+	ctx := t.Context()
+	db, orgID, pairing, enrollment := setupPairingTest(t)
+	node := createFleetNode(t, enrollment, orgID, "node-resolve-filter-authneeded")
+	upsertNodeDiscovered(t, pairing, orgID, node, "mac:new")
+	upsertNodeDiscovered(t, pairing, orgID, node, "mac:authneeded")
+	var ddID int64
+	require.NoError(t, db.QueryRow(
+		`SELECT id FROM discovered_device WHERE org_id=$1 AND device_identifier=$2 AND deleted_at IS NULL`,
+		orgID, "mac:authneeded").Scan(&ddID))
+	var devID int64
+	require.NoError(t, db.QueryRow(
+		`INSERT INTO device (device_identifier, mac_address, serial_number, org_id, discovered_device_id)
+		 VALUES ($1, 'aa:bb:cc:00:af:01', 'sn-af', $2, $3) RETURNING id`,
+		"mac:authneeded", orgID, ddID).Scan(&devID))
+	setPairingStatus(t, db, devID, "AUTHENTICATION_NEEDED")
+
+	// Act
+	pw := "pw"
+	targets, _, err := pairing.ResolvePairTargetsByFilterPage(ctx, node, orgID, &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED},
+	}, &pairingpb.Credentials{Username: "root", Password: &pw}, nil)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mac:authneeded"}, targetIdentifiers(targets))
 }
 
 func targetIdentifiers(targets []*pairingpb.FleetNodePairTarget) []string {

--- a/server/internal/domain/fleetnode/pairing/pair_dispatch.go
+++ b/server/internal/domain/fleetnode/pairing/pair_dispatch.go
@@ -29,6 +29,12 @@ var PairCommandTimeout = 12 * time.Minute
 // persisting even if the operator disconnects), bounded by PairCommandTimeout. We
 // don't abort the node on cancel -- half-paired miners with no cloud record is worse.
 func (s *Service) PairOnNode(ctx context.Context, fleetNodeID int64, targets []*pairingpb.FleetNodePairTarget, credentials *pairingpb.Credentials, orgID int64, assignedBy *int64, onResults func([]*gatewaypb.FleetNodePairResult) error) error {
+	if len(targets) == 0 {
+		return fleeterror.NewInvalidArgumentError("pair command requires at least one target")
+	}
+	if len(targets) > MaxPairBatch {
+		return fleeterror.NewInvalidArgumentErrorf("pair command target count %d exceeds maximum %d", len(targets), MaxPairBatch)
+	}
 	if s.dispatcher == nil {
 		return fleeterror.NewInternalError("fleet node pairing dispatch is not configured")
 	}

--- a/server/internal/domain/fleetnode/pairing/pair_dispatch_internal_test.go
+++ b/server/internal/domain/fleetnode/pairing/pair_dispatch_internal_test.go
@@ -1,0 +1,21 @@
+package pairing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+)
+
+func TestPairOnNodeRejectsOversizedBatchBeforeDispatch(t *testing.T) {
+	targets := make([]*pairingpb.FleetNodePairTarget, MaxPairBatch+1)
+	for i := range targets {
+		targets[i] = &pairingpb.FleetNodePairTarget{DeviceIdentifier: "mac:device"}
+	}
+
+	err := (&Service{}).PairOnNode(t.Context(), 1, targets, nil, 1, nil, nil)
+
+	assert.True(t, fleeterror.IsInvalidArgumentError(err))
+}

--- a/server/internal/domain/fleetnode/pairing/service.go
+++ b/server/internal/domain/fleetnode/pairing/service.go
@@ -31,10 +31,20 @@ type Store interface {
 	DeviceHasActivePairing(ctx context.Context, deviceID, orgID int64) (bool, error)
 	UnpairDevice(ctx context.Context, deviceID, orgID int64) (int64, error)
 	ListFleetNodeDevices(ctx context.Context, orgID int64, fleetNodeID *int64) ([]FleetNodeDevice, error)
-	ListFleetNodeDiscoveredDevices(ctx context.Context, orgID int64, fleetNodeID *int64, identifiers []string, cursorID, limit *int64, excludeAuthNeeded bool) ([]FleetNodeDiscoveredDevice, error)
+	ListFleetNodeDiscoveredDevices(ctx context.Context, orgID int64, fleetNodeID *int64, filter FleetNodeDiscoveredDeviceFilter) ([]FleetNodeDiscoveredDevice, error)
 	UpsertDiscoveredDeviceFromFleetNode(ctx context.Context, orgID int64, fleetNodeID int64, report DiscoveredDeviceReport) (int64, error)
 	DeviceExistsInOrg(ctx context.Context, deviceID, orgID int64) (bool, error)
 	GetDeviceIDByDeviceIdentifier(ctx context.Context, identifier string) (int64, error)
+}
+
+type FleetNodeDiscoveredDeviceFilter struct {
+	Identifiers       []string
+	PairingStatuses   []string
+	Models            []string
+	Manufacturers     []string
+	CursorID          *int64
+	Limit             *int64
+	ExcludeAuthNeeded bool
 }
 
 type Service struct {
@@ -187,7 +197,10 @@ func (s *Service) ListDevicesForFleetNode(ctx context.Context, fleetNodeID, orgI
 // and more rows may remain.
 func (s *Service) ListDiscoveredDevicesForFleetNode(ctx context.Context, orgID int64, fleetNodeID, cursorID, limit *int64) ([]FleetNodeDiscoveredDevice, *int64, error) {
 	// The operator listing surfaces AUTHENTICATION_NEEDED rows for display/retry.
-	devices, err := s.store.ListFleetNodeDiscoveredDevices(ctx, orgID, fleetNodeID, nil, cursorID, limit, false)
+	devices, err := s.store.ListFleetNodeDiscoveredDevices(ctx, orgID, fleetNodeID, FleetNodeDiscoveredDeviceFilter{
+		CursorID: cursorID,
+		Limit:    limit,
+	})
 	if err != nil {
 		return nil, nil, fleeterror.LogInternal(component, "list discovered devices", clientErrList, err)
 	}

--- a/server/internal/domain/pairing/service.go
+++ b/server/internal/domain/pairing/service.go
@@ -12,6 +12,7 @@ import (
 
 	"connectrpc.com/connect"
 	capabilitiespb "github.com/block/proto-fleet/server/generated/grpc/capabilities/v1"
+	fleetmanagementv1 "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
 	commandpb "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
 	"github.com/block/proto-fleet/server/internal/domain/discoverylimits"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
@@ -1154,14 +1155,7 @@ func (s *Service) resolveDeviceIdentifiers(ctx context.Context, selector *comman
 
 	switch x := selector.SelectionType.(type) {
 	case *commandpb.DeviceSelector_AllDevices:
-		filter := x.AllDevices
-		minerFilter := &interfaces.MinerFilter{}
-
-		if filter != nil && len(filter.PairingStatus) > 0 {
-			minerFilter.PairingStatuses = filter.PairingStatus
-		}
-
-		return s.deviceStore.GetDeviceIdentifiersByOrgWithFilter(ctx, orgID, minerFilter)
+		return s.deviceStore.GetDeviceIdentifiersByOrgWithFilter(ctx, orgID, minerFilterFromPairDeviceFilter(x.AllDevices))
 
 	case *commandpb.DeviceSelector_IncludeDevices:
 		if x.IncludeDevices == nil || len(x.IncludeDevices.DeviceIdentifiers) == 0 {
@@ -1174,7 +1168,61 @@ func (s *Service) resolveDeviceIdentifiers(ctx context.Context, selector *comman
 	}
 }
 
+func minerFilterFromPairDeviceFilter(filter *commandpb.DeviceFilter) *interfaces.MinerFilter {
+	minerFilter := &interfaces.MinerFilter{}
+	if filter == nil {
+		return minerFilter
+	}
+	minerFilter.PairingStatuses = filter.PairingStatus
+	minerFilter.ModelNames = filter.Models
+	minerFilter.ManufacturerNames = filter.Manufacturers
+	if len(filter.DeviceStatus) > 0 {
+		minerFilter.DeviceStatusFilter = make([]models.MinerStatus, 0, len(filter.DeviceStatus))
+		for _, status := range filter.DeviceStatus {
+			minerFilter.DeviceStatusFilter = append(minerFilter.DeviceStatusFilter, deviceStatusFilterToMinerStatus(status))
+		}
+	}
+	return minerFilter
+}
+
+func deviceStatusFilterToMinerStatus(status fleetmanagementv1.DeviceStatus) models.MinerStatus {
+	//nolint:exhaustive // Unknown or unspecified device statuses map to UNKNOWN.
+	switch status {
+	case fleetmanagementv1.DeviceStatus_DEVICE_STATUS_ONLINE:
+		return models.MinerStatusActive
+	case fleetmanagementv1.DeviceStatus_DEVICE_STATUS_OFFLINE:
+		return models.MinerStatusOffline
+	case fleetmanagementv1.DeviceStatus_DEVICE_STATUS_MAINTENANCE:
+		return models.MinerStatusMaintenance
+	case fleetmanagementv1.DeviceStatus_DEVICE_STATUS_ERROR:
+		return models.MinerStatusError
+	case fleetmanagementv1.DeviceStatus_DEVICE_STATUS_INACTIVE:
+		return models.MinerStatusInactive
+	case fleetmanagementv1.DeviceStatus_DEVICE_STATUS_NEEDS_MINING_POOL:
+		return models.MinerStatusNeedsMiningPool
+	case fleetmanagementv1.DeviceStatus_DEVICE_STATUS_UPDATING:
+		return models.MinerStatusUpdating
+	case fleetmanagementv1.DeviceStatus_DEVICE_STATUS_REBOOT_REQUIRED:
+		return models.MinerStatusRebootRequired
+	default:
+		return models.MinerStatusUnknown
+	}
+}
+
 func (s *Service) PairDevices(ctx context.Context, r *pb.PairRequest) (*pb.PairResponse, error) {
+	return s.pairDevices(ctx, r, false)
+}
+
+// PairDevicesAllowAllFailed preserves the normal PairDevices behavior except
+// that a selector with concrete device matches but zero successful pairings
+// returns those failed IDs instead of a unary error. The mixed fleet-node/cloud
+// handler uses this only after at least one remote pairing has already succeeded,
+// so the client receives one partial-success response for the whole request.
+func (s *Service) PairDevicesAllowAllFailed(ctx context.Context, r *pb.PairRequest) (*pb.PairResponse, error) {
+	return s.pairDevices(ctx, r, true)
+}
+
+func (s *Service) pairDevices(ctx context.Context, r *pb.PairRequest, allowAllFailed bool) (*pb.PairResponse, error) {
 	info, err := session.GetInfo(ctx)
 	if err != nil {
 		return nil, err
@@ -1312,6 +1360,11 @@ func (s *Service) PairDevices(ctx context.Context, r *pb.PairRequest) (*pb.PairR
 				return nil, fleeterror.NewPlainError("pairing deadline exceeded", connect.CodeDeadlineExceeded).WithCallerStackTrace()
 			}
 			return nil, fleeterror.NewCanceledError()
+		}
+		if allowAllFailed {
+			return &pb.PairResponse{
+				FailedDeviceIds: failedIDs,
+			}, nil
 		}
 		return nil, fleeterror.NewInternalError("Failed to pair any devices")
 	}

--- a/server/internal/domain/pairing/service_internal_test.go
+++ b/server/internal/domain/pairing/service_internal_test.go
@@ -7,8 +7,12 @@ import (
 	"testing"
 
 	"connectrpc.com/authn"
+	commonv1 "github.com/block/proto-fleet/server/generated/grpc/common/v1"
+	fleetmanagementv1 "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
+	minercommandv1 "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
 	pb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	minermodels "github.com/block/proto-fleet/server/internal/domain/miner/models"
 	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -79,6 +83,63 @@ func TestHandleAuthenticationRequiredPairing_PreservesExistingWorkerName(t *test
 
 	err := service.handleAuthenticationRequiredPairing(t.Context(), discoveredDevice)
 	require.NoError(t, err)
+}
+
+func TestResolveDeviceIdentifiers_AllDevicesPassesFullFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDeviceStore := mocks.NewMockDeviceStore(ctrl)
+	service := &Service{deviceStore: mockDeviceStore}
+	ctx := mockSessionContext(t.Context(), 1, 42)
+	selector := &minercommandv1.DeviceSelector{
+		SelectionType: &minercommandv1.DeviceSelector_AllDevices{AllDevices: &minercommandv1.DeviceFilter{
+			DeviceStatus:  []fleetmanagementv1.DeviceStatus{fleetmanagementv1.DeviceStatus_DEVICE_STATUS_ONLINE},
+			PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED},
+			Models:        []string{"S19"},
+			Manufacturers: []string{"Bitmain"},
+		}},
+	}
+
+	mockDeviceStore.EXPECT().
+		GetDeviceIdentifiersByOrgWithFilter(gomock.Any(), int64(42), gomock.AssignableToTypeOf(&stores.MinerFilter{})).
+		DoAndReturn(func(_ context.Context, _ int64, filter *stores.MinerFilter) ([]string, error) {
+			require.Equal(t, []minermodels.MinerStatus{minermodels.MinerStatusActive}, filter.DeviceStatusFilter)
+			require.Equal(t, []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED}, filter.PairingStatuses)
+			require.Equal(t, []string{"S19"}, filter.ModelNames)
+			require.Equal(t, []string{"Bitmain"}, filter.ManufacturerNames)
+			return []string{"mac:cloud"}, nil
+		})
+
+	ids, err := service.resolveDeviceIdentifiers(ctx, selector, 42)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"mac:cloud"}, ids)
+}
+
+func TestPairDevicesAllowAllFailedReturnsCanceledError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDiscoveredDeviceStore := mocks.NewMockDiscoveredDeviceStore(ctrl)
+	service := &Service{discoveredDeviceStore: mockDiscoveredDeviceStore}
+	ctx, cancel := context.WithCancel(mockSessionContext(t.Context(), 1, 42))
+	cancel()
+
+	mockDiscoveredDeviceStore.EXPECT().
+		GetDevice(gomock.Any(), discoverymodels.DeviceOrgIdentifier{DeviceIdentifier: "mac:canceled", OrgID: 42}).
+		Return(nil, fleeterror.NewNotFoundError("not found"))
+
+	resp, err := service.PairDevicesAllowAllFailed(ctx, &pb.PairRequest{
+		DeviceSelector: &minercommandv1.DeviceSelector{
+			SelectionType: &minercommandv1.DeviceSelector_IncludeDevices{
+				IncludeDevices: &commonv1.DeviceIdentifierList{DeviceIdentifiers: []string{"mac:canceled"}},
+			},
+		},
+	})
+
+	require.Nil(t, resp)
+	require.True(t, fleeterror.IsCanceledError(err))
 }
 
 func TestCanonicalCIDR(t *testing.T) {

--- a/server/internal/domain/stores/interfaces/device.go
+++ b/server/internal/domain/stores/interfaces/device.go
@@ -58,6 +58,7 @@ type MinerFilter struct {
 	PairingStatuses     []fm.PairingStatus // Changed from single value to slice
 	DeviceStatusFilter  []mm.MinerStatus
 	ModelNames          []string                          // Filter by device model names (e.g., "S21 XP", "M60")
+	ManufacturerNames   []string                          // Filter by device manufacturer names (e.g., "Bitmain", "MicroBT")
 	ErrorComponentTypes []diagnosticsmodels.ComponentType // Filter devices by component types that have errors
 	GroupIDs            []int64                           // Filter by group membership (OR logic: match any group)
 	RackIDs             []int64                           // Filter by rack membership (OR logic: match any rack)

--- a/server/internal/domain/stores/sqlstores/device_filters.go
+++ b/server/internal/domain/stores/sqlstores/device_filters.go
@@ -18,6 +18,8 @@ type minerFilterParams struct {
 	statusValues              []string
 	modelFilter               sql.NullString
 	modelValues               []string
+	manufacturerFilter        sql.NullString
+	manufacturerValues        []string
 	pairingStatusFilter       sql.NullString
 	pairingStatusValues       []string
 	needsAttentionFilter      bool
@@ -93,6 +95,12 @@ func buildMinerFilterParams(filter *stores.MinerFilter) minerFilterParams {
 	if len(filter.ModelNames) > 0 {
 		fp.modelFilter = sql.NullString{Valid: true}
 		fp.modelValues = filter.ModelNames
+	}
+
+	// Manufacturer filter
+	if len(filter.ManufacturerNames) > 0 {
+		fp.manufacturerFilter = sql.NullString{Valid: true}
+		fp.manufacturerValues = filter.ManufacturerNames
 	}
 
 	// Pairing status filter
@@ -226,6 +234,12 @@ func appendFilterSQL(sb *strings.Builder, args []any, argNum int, orgID int64, f
 	if fp.modelFilter.Valid {
 		fmt.Fprintf(sb, " AND discovered_device.model = ANY($%d::text[])", argNum)
 		args = append(args, pq.Array(fp.modelValues))
+		argNum++
+	}
+
+	if fp.manufacturerFilter.Valid {
+		fmt.Fprintf(sb, " AND discovered_device.manufacturer = ANY($%d::text[])", argNum)
+		args = append(args, pq.Array(fp.manufacturerValues))
 		argNum++
 	}
 

--- a/server/internal/domain/stores/sqlstores/device_filters_test.go
+++ b/server/internal/domain/stores/sqlstores/device_filters_test.go
@@ -80,6 +80,7 @@ func TestBuildMinerFilterParams_CombinedFilters(t *testing.T) {
 	filter := &stores.MinerFilter{
 		DeviceStatusFilter: []minermodels.MinerStatus{minermodels.MinerStatusActive},
 		ModelNames:         []string{"S21 XP"},
+		ManufacturerNames:  []string{"Bitmain"},
 		PairingStatuses:    []fm.PairingStatus{fm.PairingStatus_PAIRING_STATUS_PAIRED},
 	}
 
@@ -87,6 +88,7 @@ func TestBuildMinerFilterParams_CombinedFilters(t *testing.T) {
 
 	assert.True(t, params.statusFilter.Valid)
 	assert.True(t, params.modelFilter.Valid)
+	assert.True(t, params.manufacturerFilter.Valid)
 	assert.True(t, params.pairingStatusFilter.Valid)
 }
 
@@ -209,6 +211,8 @@ func TestAppendFilterSQL_CombinedFilters(t *testing.T) {
 		pairingStatusValues: []string{"PAIRED"},
 		modelFilter:         validNullString(),
 		modelValues:         []string{"S21 XP"},
+		manufacturerFilter:  validNullString(),
+		manufacturerValues:  []string{"Bitmain"},
 		statusFilter:        validNullString(),
 		statusValues:        []string{"ACTIVE"},
 	}
@@ -218,9 +222,10 @@ func TestAppendFilterSQL_CombinedFilters(t *testing.T) {
 
 	assert.Contains(t, sb.String(), "pairing_status")
 	assert.Contains(t, sb.String(), "discovered_device.model")
+	assert.Contains(t, sb.String(), "discovered_device.manufacturer")
 	assert.Contains(t, sb.String(), "device_status.status")
-	assert.Len(t, resultArgs, 5) // initial + pairing + model + status + orgID
-	assert.Equal(t, 6, resultArgNum)
+	assert.Len(t, resultArgs, 6) // initial + pairing + model + manufacturer + status + orgID
+	assert.Equal(t, 7, resultArgNum)
 }
 
 func TestAppendFilterSQL_ArgNumbersIncrement(t *testing.T) {

--- a/server/internal/domain/stores/sqlstores/fleetnodepairing.go
+++ b/server/internal/domain/stores/sqlstores/fleetnodepairing.go
@@ -83,14 +83,17 @@ func (s *SQLFleetNodePairingStore) ListFleetNodeDevices(ctx context.Context, org
 	return out, nil
 }
 
-func (s *SQLFleetNodePairingStore) ListFleetNodeDiscoveredDevices(ctx context.Context, orgID int64, fleetNodeID *int64, identifiers []string, cursorID, limit *int64, excludeAuthNeeded bool) ([]pairing.FleetNodeDiscoveredDevice, error) {
+func (s *SQLFleetNodePairingStore) ListFleetNodeDiscoveredDevices(ctx context.Context, orgID int64, fleetNodeID *int64, filter pairing.FleetNodeDiscoveredDeviceFilter) ([]pairing.FleetNodeDiscoveredDevice, error) {
 	rows, err := s.q(ctx).ListFleetNodeDiscoveredDevices(ctx, sqlc.ListFleetNodeDiscoveredDevicesParams{
 		OrgID:             orgID,
 		FleetNodeID:       ptrToNullInt64(fleetNodeID),
-		Identifiers:       identifiers,
-		CursorID:          ptrToNullInt64(cursorID),
-		Limit:             ptrToNullInt64(limit),
-		ExcludeAuthNeeded: sql.NullBool{Bool: excludeAuthNeeded, Valid: excludeAuthNeeded},
+		Identifiers:       filter.Identifiers,
+		CursorID:          ptrToNullInt64(filter.CursorID),
+		Limit:             ptrToNullInt64(filter.Limit),
+		ExcludeAuthNeeded: sql.NullBool{Bool: filter.ExcludeAuthNeeded, Valid: filter.ExcludeAuthNeeded},
+		PairingStatuses:   filter.PairingStatuses,
+		Models:            filter.Models,
+		Manufacturers:     filter.Manufacturers,
 	})
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/pairing/handler.go
+++ b/server/internal/handlers/pairing/handler.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"sync"
 
+	commonv1 "github.com/block/proto-fleet/server/generated/grpc/common/v1"
+	gatewaypb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	minercommandv1 "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/fleetnode/discovery"
+	fleetnodepairing "github.com/block/proto-fleet/server/internal/domain/fleetnode/pairing"
 	"github.com/block/proto-fleet/server/internal/domain/nmaptarget"
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 
@@ -24,15 +29,28 @@ type Handler struct {
 	// discovery fans the "Scan your network" nmap action out to connected fleet
 	// nodes; nil disables fan-out (cloud-only discovery).
 	discovery *discovery.Service
+	// fleetNodePairing lets the existing PairingService API route selected
+	// fleet-node-discovered devices through ControlStream while keeping clients
+	// agnostic to the pairing mechanism.
+	fleetNodePairing *fleetnodepairing.Service
 }
 
 var _ pairingv1connect.PairingServiceHandler = &Handler{}
 
+type fleetNodePairRoute struct {
+	allDevices       bool
+	routedExplicit   map[string]struct{}
+	routedAllDevices map[string]struct{}
+	remoteSucceeded  bool
+	remoteErr        error
+}
+
 // NewHandler creates a new instance of Handler
-func NewHandler(pairingSvc *pairing.Service, discoverySvc *discovery.Service) *Handler {
+func NewHandler(pairingSvc *pairing.Service, discoverySvc *discovery.Service, fleetNodePairingSvc *fleetnodepairing.Service) *Handler {
 	return &Handler{
-		pairingSvc: pairingSvc,
-		discovery:  discoverySvc,
+		pairingSvc:       pairingSvc,
+		discovery:        discoverySvc,
+		fleetNodePairing: fleetNodePairingSvc,
 	}
 }
 
@@ -152,13 +170,318 @@ func callerCanManageFleetNodes(ctx context.Context) bool {
 
 // Pair implements pairingv1connect.PairingServiceHandler.
 func (h *Handler) Pair(ctx context.Context, r *connect.Request[pb.PairRequest]) (*connect.Response[pb.PairResponse], error) {
-	if _, err := middleware.RequirePermission(ctx, authz.PermMinerPair, authz.ResourceContext{}); err != nil {
+	info, err := middleware.RequirePermission(ctx, authz.PermMinerPair, authz.ResourceContext{})
+	if err != nil {
 		return nil, err
 	}
+
+	if resp, route, err := h.pairFleetNodeDevices(ctx, info.OrganizationID, info.UserID, r.Msg); err != nil {
+		return nil, err
+	} else if route.allDevices {
+		var (
+			cloudResp *pb.PairResponse
+			err       error
+		)
+		if route.remoteSucceeded {
+			cloudResp, err = h.pairingSvc.PairDevicesAllowAllFailed(ctx, r.Msg)
+		} else {
+			cloudResp, err = h.pairingSvc.PairDevices(ctx, r.Msg)
+		}
+		if err != nil {
+			return handleAllDevicesCloudPairError(resp, route, err)
+		}
+		resp.FailedDeviceIds = mergeAllDevicesPairFailures(resp.GetFailedDeviceIds(), cloudResp.GetFailedDeviceIds(), route)
+		return connect.NewResponse(resp), nil
+	} else if len(route.routedExplicit) > 0 {
+		remaining := remainingSelectedDeviceIdentifiers(r.Msg.GetDeviceSelector(), route.routedExplicit)
+		if len(remaining) == 0 {
+			if !route.remoteSucceeded && route.remoteErr != nil {
+				return nil, route.remoteErr
+			}
+			if routedTargetsFailed(resp, route, route.routedExplicit) {
+				return nil, fleeterror.NewInternalError("Failed to pair any devices")
+			}
+			return connect.NewResponse(resp), nil
+		}
+		cloudReq := &pb.PairRequest{
+			Credentials:    r.Msg.GetCredentials(),
+			DeviceSelector: includeDevicesSelector(remaining),
+		}
+		var (
+			cloudResp *pb.PairResponse
+			err       error
+		)
+		if route.remoteSucceeded {
+			cloudResp, err = h.pairingSvc.PairDevicesAllowAllFailed(ctx, cloudReq)
+		} else {
+			cloudResp, err = h.pairingSvc.PairDevices(ctx, cloudReq)
+		}
+		if err != nil {
+			return handleExplicitCloudPairError(route, err)
+		}
+		resp.FailedDeviceIds = sortedKeys(setFromSlice(append(resp.FailedDeviceIds, cloudResp.GetFailedDeviceIds()...)))
+		return connect.NewResponse(resp), nil
+	}
+
 	resp, err := h.pairingSvc.PairDevices(ctx, r.Msg)
 	if err != nil {
 		return nil, err
 	}
 
 	return connect.NewResponse(resp), nil
+}
+
+func handleExplicitCloudPairError(route fleetNodePairRoute, err error) (*connect.Response[pb.PairResponse], error) {
+	if !route.remoteSucceeded && route.remoteErr != nil {
+		return nil, route.remoteErr
+	}
+	return nil, err
+}
+
+func (h *Handler) pairFleetNodeDevices(ctx context.Context, orgID, userID int64, req *pb.PairRequest) (*pb.PairResponse, fleetNodePairRoute, error) {
+	route := fleetNodePairRoute{
+		routedExplicit:   map[string]struct{}{},
+		routedAllDevices: map[string]struct{}{},
+	}
+	resp := &pb.PairResponse{}
+	if h.discovery == nil || h.fleetNodePairing == nil || !callerCanManageFleetNodes(ctx) {
+		return resp, route, nil
+	}
+
+	selected := selectedDeviceIdentifiers(req.GetDeviceSelector())
+	allDevicesFilter := allDevicesFilter(req.GetDeviceSelector())
+	if len(selected) == 0 && allDevicesFilter == nil {
+		return resp, route, nil
+	}
+
+	nodeIDs, err := h.discovery.ConfirmedConnectedNodeIDs(ctx, orgID)
+	if err != nil {
+		slog.Warn("skipping fleet node pairing route", "error", err)
+		return resp, route, nil
+	}
+	if len(nodeIDs) == 0 {
+		return resp, route, nil
+	}
+
+	pending := setFromSlice(selected)
+	sortedSelected := sortedKeys(pending)
+	failed := map[string]struct{}{}
+	for _, nodeID := range nodeIDs {
+		if allDevicesFilter != nil {
+			if err := h.pairAllMatchingFleetNodeDevices(ctx, nodeID, orgID, userID, allDevicesFilter, req, &route, failed); err != nil {
+				return nil, fleetNodePairRoute{}, err
+			}
+			continue
+		}
+
+		targetIDs := pendingSortedIdentifiers(sortedSelected, pending)
+		for start := 0; start < len(targetIDs); start += fleetnodepairing.MaxPairBatch {
+			end := start + fleetnodepairing.MaxPairBatch
+			if end > len(targetIDs) {
+				end = len(targetIDs)
+			}
+			targets, err := h.fleetNodePairing.ResolvePairTargets(ctx, nodeID, orgID, targetIDs[start:end], false, req.GetCredentials())
+			if err != nil {
+				return nil, fleetNodePairRoute{}, err
+			}
+			if len(targets) == 0 {
+				continue
+			}
+			recordFleetNodePairTargets(targets, false, route.routedExplicit, route.routedAllDevices, failed, pending)
+			if err := h.pairFleetNodeTargetBatch(ctx, nodeID, orgID, userID, req, targets, false, &route, failed); err != nil {
+				slog.Warn("fleet node pairing command failed; returning failed targets in pair response",
+					"fleet_node_id", nodeID, "error", err)
+				if route.remoteErr == nil {
+					route.remoteErr = err
+				}
+				break
+			}
+		}
+		if len(pending) == 0 {
+			break
+		}
+	}
+
+	resp.FailedDeviceIds = sortedKeys(failed)
+	return resp, route, nil
+}
+
+func (h *Handler) pairAllMatchingFleetNodeDevices(ctx context.Context, nodeID, orgID, userID int64, allDevicesFilter *minercommandv1.DeviceFilter, req *pb.PairRequest, route *fleetNodePairRoute, failed map[string]struct{}) error {
+	var cursorID *int64
+	for {
+		targets, nextCursor, err := h.fleetNodePairing.ResolvePairTargetsByFilterPage(ctx, nodeID, orgID, allDevicesFilter, req.GetCredentials(), cursorID)
+		if err != nil {
+			return err
+		}
+		if len(targets) == 0 {
+			return nil
+		}
+		recordFleetNodePairTargets(targets, true, route.routedExplicit, route.routedAllDevices, failed, nil)
+		if err := h.pairFleetNodeTargetBatch(ctx, nodeID, orgID, userID, req, targets, true, route, failed); err != nil {
+			slog.Warn("fleet node pairing command failed; returning failed targets in pair response",
+				"fleet_node_id", nodeID, "error", err)
+			if route.remoteErr == nil {
+				route.remoteErr = err
+			}
+			return nil
+		}
+		cursorID = nextCursor
+		if cursorID == nil {
+			return nil
+		}
+	}
+}
+
+func recordFleetNodePairTargets(targets []*pb.FleetNodePairTarget, allDevices bool, routedExplicit, routedAllDevices, failed, pending map[string]struct{}) {
+	for _, target := range targets {
+		id := target.GetDeviceIdentifier()
+		if allDevices {
+			routedAllDevices[id] = struct{}{}
+		} else {
+			routedExplicit[id] = struct{}{}
+		}
+		failed[id] = struct{}{}
+		if pending != nil {
+			delete(pending, id)
+		}
+	}
+}
+
+func (h *Handler) pairFleetNodeTargetBatch(ctx context.Context, nodeID, orgID, userID int64, req *pb.PairRequest, targets []*pb.FleetNodePairTarget, allDevices bool, route *fleetNodePairRoute, failed map[string]struct{}) error {
+	route.allDevices = route.allDevices || allDevices
+	assignedBy := userID
+	return h.fleetNodePairing.PairOnNode(ctx, nodeID, targets, req.GetCredentials(), orgID, &assignedBy, func(results []*gatewaypb.FleetNodePairResult) error {
+		for _, result := range results {
+			id := result.GetDeviceIdentifier()
+			if _, ok := failed[id]; !ok {
+				continue
+			}
+			if result.GetOutcome() == gatewaypb.PairOutcome_PAIR_OUTCOME_PAIRED {
+				delete(failed, id)
+				route.remoteSucceeded = true
+			} else {
+				failed[id] = struct{}{}
+			}
+		}
+		return nil
+	})
+}
+
+func mergeAllDevicesPairFailures(remoteFailedIDs, cloudFailedIDs []string, route fleetNodePairRoute) []string {
+	failed := setFromSlice(remoteFailedIDs)
+	for _, id := range cloudFailedIDs {
+		if _, routed := route.routedAllDevices[id]; routed {
+			if _, remoteFailed := failed[id]; !remoteFailed {
+				continue
+			}
+		}
+		failed[id] = struct{}{}
+	}
+	return sortedKeys(failed)
+}
+
+func routedTargetsFailed(resp *pb.PairResponse, route fleetNodePairRoute, routed map[string]struct{}) bool {
+	return !route.remoteSucceeded && route.remoteErr == nil && len(routed) > 0 && len(resp.GetFailedDeviceIds()) > 0
+}
+
+func handleAllDevicesCloudPairError(resp *pb.PairResponse, route fleetNodePairRoute, err error) (*connect.Response[pb.PairResponse], error) {
+	if isNoCloudPairTargetsError(err) {
+		if route.remoteSucceeded {
+			slog.Warn("cloud pairing matched no devices after fleet node pairing succeeded; returning partial fleet node result",
+				"error", err)
+			return connect.NewResponse(resp), nil
+		}
+		if routedTargetsFailed(resp, route, route.routedAllDevices) {
+			slog.Warn("cloud pairing matched no devices after all fleet node pairing attempts failed",
+				"error", err)
+			return nil, fleeterror.NewInternalError("Failed to pair any devices")
+		}
+	}
+	if route.remoteSucceeded {
+		slog.Warn("cloud pairing failed after fleet node pairing succeeded",
+			"error", err)
+		return nil, err
+	}
+	if route.remoteErr != nil {
+		return nil, route.remoteErr
+	}
+	return nil, err
+}
+
+func isNoCloudPairTargetsError(err error) bool {
+	var fleetErr fleeterror.FleetError
+	return errors.As(err, &fleetErr) &&
+		fleetErr.GRPCCode == connect.CodeInvalidArgument &&
+		fleetErr.DebugMessage == "no devices match the selector"
+}
+
+func selectedDeviceIdentifiers(selector *minercommandv1.DeviceSelector) []string {
+	selection := selector.GetIncludeDevices()
+	if selection == nil {
+		return nil
+	}
+	return selection.GetDeviceIdentifiers()
+}
+
+func allDevicesFilter(selector *minercommandv1.DeviceSelector) *minercommandv1.DeviceFilter {
+	if selector == nil {
+		return nil
+	}
+	allDevices := selector.GetAllDevices()
+	if allDevices == nil {
+		return nil
+	}
+	return allDevices
+}
+
+func remainingSelectedDeviceIdentifiers(selector *minercommandv1.DeviceSelector, routed map[string]struct{}) []string {
+	selected := selectedDeviceIdentifiers(selector)
+	if len(selected) == 0 {
+		return nil
+	}
+	remaining := make([]string, 0, len(selected))
+	for _, id := range selected {
+		if _, ok := routed[id]; !ok {
+			remaining = append(remaining, id)
+		}
+	}
+	return remaining
+}
+
+func pendingSortedIdentifiers(sortedSelected []string, pending map[string]struct{}) []string {
+	if len(pending) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(pending))
+	for _, id := range sortedSelected {
+		if _, ok := pending[id]; ok {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func includeDevicesSelector(deviceIdentifiers []string) *minercommandv1.DeviceSelector {
+	return &minercommandv1.DeviceSelector{
+		SelectionType: &minercommandv1.DeviceSelector_IncludeDevices{
+			IncludeDevices: &commonv1.DeviceIdentifierList{DeviceIdentifiers: deviceIdentifiers},
+		},
+	}
+}
+
+func setFromSlice(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	slices.Sort(out)
+	return out
 }

--- a/server/internal/handlers/pairing/handler_internal_test.go
+++ b/server/internal/handlers/pairing/handler_internal_test.go
@@ -2,12 +2,19 @@ package pairing
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"connectrpc.com/authn"
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 
+	commonv1 "github.com/block/proto-fleet/server/generated/grpc/common/v1"
+	fleetmanagementv1 "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
+	minercommandv1 "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
+	pb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/handlers/middleware"
 )
@@ -71,4 +78,197 @@ func TestCallerCanManageFleetNodes(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestSelectedDeviceIdentifiers_IncludeDevices(t *testing.T) {
+	selector := &minercommandv1.DeviceSelector{
+		SelectionType: &minercommandv1.DeviceSelector_IncludeDevices{
+			IncludeDevices: &commonv1.DeviceIdentifierList{DeviceIdentifiers: []string{"mac:a", "mac:b"}},
+		},
+	}
+
+	assert.Equal(t, []string{"mac:a", "mac:b"}, selectedDeviceIdentifiers(selector))
+}
+
+func TestSelectedDeviceIdentifiers_NonIncludeDevices(t *testing.T) {
+	selector := &minercommandv1.DeviceSelector{
+		SelectionType: &minercommandv1.DeviceSelector_AllDevices{AllDevices: &minercommandv1.DeviceFilter{}},
+	}
+
+	assert.Nil(t, selectedDeviceIdentifiers(selector))
+}
+
+func TestRemainingSelectedDeviceIdentifiers(t *testing.T) {
+	selector := includeDevicesSelector([]string{"cloud", "node", "other-node"})
+	routed := map[string]struct{}{
+		"node":       {},
+		"other-node": {},
+	}
+
+	assert.Equal(t, []string{"cloud"}, remainingSelectedDeviceIdentifiers(selector, routed))
+}
+
+func TestPendingSortedIdentifiers(t *testing.T) {
+	sortedSelected := []string{"alpha", "bravo", "charlie"}
+	pending := map[string]struct{}{
+		"alpha":   {},
+		"charlie": {},
+	}
+
+	assert.Equal(t, []string{"alpha", "charlie"}, pendingSortedIdentifiers(sortedSelected, pending))
+
+	delete(pending, "alpha")
+	assert.Equal(t, []string{"charlie"}, pendingSortedIdentifiers(sortedSelected, pending))
+
+	delete(pending, "charlie")
+	assert.Nil(t, pendingSortedIdentifiers(sortedSelected, pending))
+}
+
+func TestAllDevicesFilter(t *testing.T) {
+	filter := &minercommandv1.DeviceFilter{
+		PairingStatus: []fleetmanagementv1.PairingStatus{fleetmanagementv1.PairingStatus_PAIRING_STATUS_AUTHENTICATION_NEEDED},
+	}
+	selector := &minercommandv1.DeviceSelector{
+		SelectionType: &minercommandv1.DeviceSelector_AllDevices{AllDevices: filter},
+	}
+
+	assert.Same(t, filter, allDevicesFilter(selector))
+	assert.Nil(t, allDevicesFilter(&minercommandv1.DeviceSelector{
+		SelectionType: &minercommandv1.DeviceSelector_IncludeDevices{IncludeDevices: &commonv1.DeviceIdentifierList{}},
+	}))
+	assert.NotNil(t, allDevicesFilter(&minercommandv1.DeviceSelector{
+		SelectionType: &minercommandv1.DeviceSelector_AllDevices{AllDevices: &minercommandv1.DeviceFilter{}},
+	}))
+	assert.Nil(t, allDevicesFilter(includeDevicesSelector([]string{"mac:a"})))
+}
+
+func TestMergeAllDevicesPairFailuresSuppressesCloudFailuresForRemoteSuccess(t *testing.T) {
+	route := fleetNodePairRoute{
+		routedAllDevices: map[string]struct{}{
+			"remote-ok":     {},
+			"remote-failed": {},
+		},
+	}
+
+	got := mergeAllDevicesPairFailures(
+		[]string{"remote-failed"},
+		[]string{"cloud-failed", "remote-ok", "remote-failed"},
+		route,
+	)
+
+	assert.Equal(t, []string{"cloud-failed", "remote-failed"}, got)
+}
+
+func TestMergeAllDevicesPairFailuresKeepsCloudFailuresForCloudOnlyDevices(t *testing.T) {
+	route := fleetNodePairRoute{routedAllDevices: map[string]struct{}{}}
+
+	got := mergeAllDevicesPairFailures(nil, []string{"cloud-failed"}, route)
+
+	assert.Equal(t, []string{"cloud-failed"}, got)
+}
+
+func TestRoutedTargetsFailed(t *testing.T) {
+	routed := map[string]struct{}{"remote-failed": {}}
+
+	assert.True(t, routedTargetsFailed(
+		&pb.PairResponse{FailedDeviceIds: []string{"remote-failed"}},
+		fleetNodePairRoute{},
+		routed,
+	))
+
+	assert.False(t, routedTargetsFailed(
+		&pb.PairResponse{FailedDeviceIds: []string{"remote-failed"}},
+		fleetNodePairRoute{remoteSucceeded: true},
+		routed,
+	))
+
+	assert.False(t, routedTargetsFailed(
+		&pb.PairResponse{FailedDeviceIds: []string{"remote-failed"}},
+		fleetNodePairRoute{remoteErr: errors.New("dispatch failed")},
+		routed,
+	))
+
+	assert.False(t, routedTargetsFailed(
+		&pb.PairResponse{},
+		fleetNodePairRoute{},
+		routed,
+	))
+}
+
+func TestHandleAllDevicesCloudPairErrorRemoteOnlyFailures(t *testing.T) {
+	resp, err := handleAllDevicesCloudPairError(
+		&pb.PairResponse{FailedDeviceIds: []string{"remote-failed"}},
+		fleetNodePairRoute{routedAllDevices: map[string]struct{}{"remote-failed": {}}},
+		fleeterror.NewInvalidArgumentError("no devices match the selector"),
+	)
+
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to pair any devices")
+}
+
+func TestHandleAllDevicesCloudPairErrorReturnsPartialRemoteSuccess(t *testing.T) {
+	resp, err := handleAllDevicesCloudPairError(
+		&pb.PairResponse{FailedDeviceIds: []string{"remote-failed"}},
+		fleetNodePairRoute{
+			routedAllDevices: map[string]struct{}{
+				"remote-ok":     {},
+				"remote-failed": {},
+			},
+			remoteSucceeded: true,
+		},
+		fleeterror.NewInvalidArgumentError("no devices match the selector"),
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"remote-failed"}, resp.Msg.GetFailedDeviceIds())
+}
+
+func TestHandleAllDevicesCloudPairErrorReturnsCloudFailureAfterRemoteSuccess(t *testing.T) {
+	resp, err := handleAllDevicesCloudPairError(
+		&pb.PairResponse{FailedDeviceIds: []string{"remote-failed"}},
+		fleetNodePairRoute{
+			routedAllDevices: map[string]struct{}{
+				"remote-ok":     {},
+				"remote-failed": {},
+			},
+			remoteSucceeded: true,
+		},
+		fleeterror.NewInternalError("cloud pairing failed"),
+	)
+
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cloud pairing failed")
+}
+
+func TestHandleExplicitCloudPairErrorReturnsCloudFailureAfterRemoteSuccess(t *testing.T) {
+	cloudErr := fleeterror.NewInternalError("telemetry scheduler failed")
+
+	resp, err := handleExplicitCloudPairError(
+		fleetNodePairRoute{remoteSucceeded: true},
+		cloudErr,
+	)
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, cloudErr)
+}
+
+func TestHandleExplicitCloudPairErrorReturnsRemoteFailureWhenRemoteNeverSucceeded(t *testing.T) {
+	remoteErr := errors.New("fleet node dispatch failed")
+	cloudErr := fleeterror.NewInternalError("cloud failed")
+
+	resp, err := handleExplicitCloudPairError(
+		fleetNodePairRoute{remoteErr: remoteErr},
+		cloudErr,
+	)
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, remoteErr)
+}
+
+func TestIsNoCloudPairTargetsError(t *testing.T) {
+	assert.True(t, isNoCloudPairTargetsError(fleeterror.NewInvalidArgumentError("no devices match the selector")))
+	assert.False(t, isNoCloudPairTargetsError(fleeterror.NewInvalidArgumentError("include_devices selector requires at least one device identifier")))
+	assert.False(t, isNoCloudPairTargetsError(connect.NewError(connect.CodeInvalidArgument, errors.New("no devices match the selector"))))
 }

--- a/server/internal/testutil/infrastructure_provider.go
+++ b/server/internal/testutil/infrastructure_provider.go
@@ -54,8 +54,8 @@ func NewInfrastructureProvider(t *testing.T, serviceProvider *ServiceProvider, a
 	authHandler := auth.NewHandler(serviceProvider.AuthService)
 	mux.Handle(authv1connect.NewAuthServiceHandler(authHandler, interceptorsOption))
 
-	// nil discovery service: no fleet node fan-out in this test harness.
-	pairingHandler := pairing.NewHandler(serviceProvider.PairingService, nil)
+	// nil fleet node services: no fleet node discovery/pairing fan-out in this test harness.
+	pairingHandler := pairing.NewHandler(serviceProvider.PairingService, nil, nil)
 	mux.Handle(pairingv1connect.NewPairingServiceHandler(pairingHandler, interceptorsOption))
 
 	onboardingHandler := onboarding.NewHandler(serviceProvider.AuthService, serviceProvider.OnboardingService)

--- a/server/sqlc/queries/fleetnodepairing.sql
+++ b/server/sqlc/queries/fleetnodepairing.sql
@@ -1,11 +1,11 @@
 -- name: UpsertDiscoveredDeviceFromFleetNode :execrows
 -- 0 rows on conflict signals rejection. A remote report must not redirect the
--- endpoint/credentials of a miner the cloud actively dials, so the update is
--- blocked when the row is promoted to a cloud-paired device (device_pairing
--- PAIRED/DEFAULT_PASSWORD) or one paired to a different fleet node. Bare promoted devices and
--- devices paired to the reporting node itself stay refreshable, subject to the
--- attribution guard. The agent synthesizes a stable per-device identifier
--- (mac:/serial:, else auto:<hash>), so a re-scan reuses the same row.
+-- endpoint/credentials of a miner the cloud owns, so the update is blocked
+-- unless the row is already attributed to this fleet node or to a revoked node
+-- that can be reclaimed. Devices paired to the reporting node itself stay
+-- refreshable, subject to the attribution guard. The agent synthesizes a stable
+-- per-device identifier (mac:/serial:, else auto:<hash>), so a re-scan reuses
+-- the same row.
 INSERT INTO discovered_device (
     org_id,
     device_identifier,
@@ -32,19 +32,21 @@ ON CONFLICT (org_id, device_identifier) WHERE deleted_at IS NULL DO UPDATE SET
     last_seen = CURRENT_TIMESTAMP,
     is_active = TRUE
 WHERE (
-    discovered_device.discovered_by_fleet_node_id IS NULL
-    OR discovered_device.discovered_by_fleet_node_id = EXCLUDED.discovered_by_fleet_node_id
+    discovered_device.discovered_by_fleet_node_id = EXCLUDED.discovered_by_fleet_node_id
     -- The attributing node was revoked (soft-deleted), so a replacement node may
     -- reclaim its rows (otherwise a re-scan of the same stable mac:/serial: device
     -- is rejected forever). Attribution moves to the reporter ($10), staying
     -- non-NULL, so cloud-exclusion (discovered_by_fleet_node_id IS NULL) is never
     -- widened. Cloud-paired and live-cross-node rows remain blocked below.
-    OR NOT EXISTS (
+    OR (
+      discovered_device.discovered_by_fleet_node_id IS NOT NULL
+      AND NOT EXISTS (
       SELECT 1
       FROM fleet_node fn
       WHERE fn.id = discovered_device.discovered_by_fleet_node_id
         AND fn.org_id = discovered_device.org_id
         AND fn.deleted_at IS NULL
+      )
     )
   )
   AND NOT EXISTS (
@@ -179,67 +181,79 @@ ORDER BY fnd.assigned_at DESC, fnd.device_id ASC;
 -- the d.id DESC tie-breaker yields one deterministic row per discovered device
 -- (the latest live device's pairing_status). Paginates by ascending id; a NULL
 -- limit returns all rows (the pairing batch path needs every candidate).
-SELECT DISTINCT ON (dd.id)
-       dd.id,
-       dd.org_id,
-       dd.device_identifier,
-       dd.discovered_by_fleet_node_id,
-       dd.ip_address,
-       dd.port,
-       dd.url_scheme,
-       dd.driver_name,
-       dd.model,
-       dd.manufacturer,
-       dd.firmware_version,
-       dd.last_seen,
-       COALESCE(dp.pairing_status::text, '')::text AS pairing_status
-FROM discovered_device dd
-LEFT JOIN device d ON d.discovered_device_id = dd.id AND d.deleted_at IS NULL
-LEFT JOIN device_pairing dp ON dp.device_id = d.id
-WHERE dd.org_id = $1
-  AND dd.is_active = TRUE
-  AND dd.deleted_at IS NULL
-  AND dd.discovered_by_fleet_node_id IS NOT NULL
-  AND NOT EXISTS (
-      SELECT 1
-      FROM device db
-      JOIN fleet_node_device fnd ON fnd.device_id = db.id AND fnd.org_id = dd.org_id
-      WHERE (db.discovered_device_id = dd.id
-             OR (db.device_identifier = dd.device_identifier AND db.org_id = dd.org_id))
-        AND db.deleted_at IS NULL
-  )
-  AND NOT EXISTS (
-      SELECT 1
-      FROM device dpd
-      JOIN device_pairing dpp ON dpp.device_id = dpd.id
-      WHERE (dpd.discovered_device_id = dd.id
-             OR (dpd.device_identifier = dd.device_identifier AND dpd.org_id = dd.org_id))
-        AND dpd.deleted_at IS NULL
-        AND dpp.pairing_status IN ('PAIRED', 'DEFAULT_PASSWORD')
-  )
-  AND (sqlc.narg('fleet_node_id')::bigint IS NULL OR dd.discovered_by_fleet_node_id = sqlc.narg('fleet_node_id')::bigint)
-  -- pair-all without operator credentials can't satisfy AUTHENTICATION_NEEDED rows
-  -- (they were already attempted and need credentials). Excluding them keeps a
-  -- capped first page from filling with unsatisfiable rows and starving
-  -- never-attempted devices on re-issue for nodes with more than `limit`
-  -- candidates. NULL/false keeps them (listing for display, and pair-all WITH
-  -- credentials, which can retry them).
-  AND (
-    NOT COALESCE(sqlc.narg('exclude_auth_needed')::bool, FALSE)
-    OR NOT EXISTS (
-      SELECT 1
-      FROM device adn
-      JOIN device_pairing adp ON adp.device_id = adn.id
-      WHERE (adn.discovered_device_id = dd.id
-             OR (adn.device_identifier = dd.device_identifier AND adn.org_id = dd.org_id))
-        AND adn.deleted_at IS NULL
-        AND adp.pairing_status = 'AUTHENTICATION_NEEDED'
+WITH candidate AS (
+  SELECT DISTINCT ON (dd.id)
+         dd.id,
+         dd.org_id,
+         dd.device_identifier,
+         dd.discovered_by_fleet_node_id,
+         dd.ip_address,
+         dd.port,
+         dd.url_scheme,
+         dd.driver_name,
+         dd.model,
+         dd.manufacturer,
+         dd.firmware_version,
+         dd.last_seen,
+         COALESCE(dp.pairing_status::text, '')::text AS pairing_status
+  FROM discovered_device dd
+  LEFT JOIN device d ON (
+      d.discovered_device_id = dd.id
+      OR (d.device_identifier = dd.device_identifier AND d.org_id = dd.org_id)
     )
-  )
-  -- Explicit pairing passes the requested identifiers so only those rows are
-  -- scanned, not the whole org. NULL = no filter (listing + pair-all); an empty
-  -- non-nil array matches nothing (explicit selection of none).
-  AND (sqlc.narg('identifiers')::text[] IS NULL OR dd.device_identifier = ANY(sqlc.narg('identifiers')::text[]))
-  AND (sqlc.narg('cursor_id')::bigint IS NULL OR dd.id > sqlc.narg('cursor_id')::bigint)
-ORDER BY dd.id ASC, d.id DESC NULLS LAST
+    AND d.deleted_at IS NULL
+  LEFT JOIN device_pairing dp ON dp.device_id = d.id
+  WHERE dd.org_id = $1
+    AND dd.is_active = TRUE
+    AND dd.deleted_at IS NULL
+    AND dd.discovered_by_fleet_node_id IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM device db
+        JOIN fleet_node_device fnd ON fnd.device_id = db.id AND fnd.org_id = dd.org_id
+        WHERE (db.discovered_device_id = dd.id
+               OR (db.device_identifier = dd.device_identifier AND db.org_id = dd.org_id))
+          AND db.deleted_at IS NULL
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM device dpd
+        JOIN device_pairing dpp ON dpp.device_id = dpd.id
+        WHERE (dpd.discovered_device_id = dd.id
+               OR (dpd.device_identifier = dd.device_identifier AND dpd.org_id = dd.org_id))
+          AND dpd.deleted_at IS NULL
+          AND dpp.pairing_status IN ('PAIRED', 'DEFAULT_PASSWORD')
+    )
+    AND (sqlc.narg('fleet_node_id')::bigint IS NULL OR dd.discovered_by_fleet_node_id = sqlc.narg('fleet_node_id')::bigint)
+    -- pair-all without operator credentials can't satisfy AUTHENTICATION_NEEDED rows
+    -- (they were already attempted and need credentials). Excluding them keeps a
+    -- capped first page from filling with unsatisfiable rows and starving
+    -- never-attempted devices on re-issue for nodes with more than `limit`
+    -- candidates. NULL/false keeps them (listing for display, and pair-all WITH
+    -- credentials, which can retry them).
+    AND (
+      NOT COALESCE(sqlc.narg('exclude_auth_needed')::bool, FALSE)
+      OR NOT EXISTS (
+        SELECT 1
+        FROM device adn
+        JOIN device_pairing adp ON adp.device_id = adn.id
+        WHERE (adn.discovered_device_id = dd.id
+               OR (adn.device_identifier = dd.device_identifier AND adn.org_id = dd.org_id))
+          AND adn.deleted_at IS NULL
+          AND adp.pairing_status = 'AUTHENTICATION_NEEDED'
+      )
+    )
+    -- Explicit pairing passes the requested identifiers so only those rows are
+    -- scanned, not the whole org. NULL = no filter (listing + pair-all); an empty
+    -- non-nil array matches nothing (explicit selection of none).
+    AND (sqlc.narg('identifiers')::text[] IS NULL OR dd.device_identifier = ANY(sqlc.narg('identifiers')::text[]))
+    AND (sqlc.narg('models')::text[] IS NULL OR COALESCE(dd.model, '') = ANY(sqlc.narg('models')::text[]))
+    AND (sqlc.narg('manufacturers')::text[] IS NULL OR COALESCE(dd.manufacturer, '') = ANY(sqlc.narg('manufacturers')::text[]))
+    AND (sqlc.narg('cursor_id')::bigint IS NULL OR dd.id > sqlc.narg('cursor_id')::bigint)
+  ORDER BY dd.id ASC, d.id DESC NULLS LAST
+)
+SELECT *
+FROM candidate
+WHERE (sqlc.narg('pairing_statuses')::text[] IS NULL OR pairing_status = ANY(sqlc.narg('pairing_statuses')::text[]))
+ORDER BY id ASC
 LIMIT sqlc.narg('limit')::bigint;


### PR DESCRIPTION
Reviewable diff: +310/-25 across 5 files (excludes generated, test, and story files).

## Summary

This PR lets operators complete pairing through the existing `PairingService` API when devices were discovered by connected fleet nodes instead of by the cloud server. The client remains mechanism-agnostic: selected discovered devices and bulk auth-needed pairing requests use the same API shape they already send today. Mixed fleets are handled in one request: fleet-node-discovered matches route through ControlStream, and cloud/server-local matches continue through the existing cloud pairing path.

## How it works

1. The client sends the existing `PairingService.Pair` request, either with explicit `includeDevices` IDs or an `allDevices` filter such as `AUTHENTICATION_NEEDED`.
2. The pairing handler checks `miner:pair` and only attempts fleet-node routing when the caller also has `fleetnode:manage`, matching the existing remote discovery/admin pairing boundary.
3. For `includeDevices`, the server resolves the selected IDs against DB rows attributed to confirmed connected fleet nodes, then dispatches only those resolved targets to their owning node.
4. For filtered `allDevices`, the fleetnode pairing domain pages node-discovered pairable rows from the DB, applies the request's pairing-status/model/manufacturer filter, and caps the matching target batch to the fleetnode pair-command limit.
5. Resolved fleetnode targets are paired with `PairOnNode` over ControlStream. The fleetnode gateway remains the authoritative persistence path when the node reports pair results.
6. The handler collects persisted pair outcomes from the command callback and then runs the existing cloud `PairDevices` path for cloud-owned matches. If cloud fallback fails after remote pairing already succeeded, the RPC returns the partial fleet-node result instead of reporting total failure after mutation.
7. Fleet-node discovery upserts only refresh rows already attributed to that node, or rows attributed to a revoked node that can be reclaimed. Cloud-origin discovered rows cannot be claimed by a fleet node just by reporting the same identifier.

## Diagrams

```mermaid
flowchart TD
  Client["ProtoFleet client"] --> PairAPI["PairingService.Pair"]
  PairAPI --> Authz["miner:pair plus fleetnode:manage for remote routing"]
  Authz --> Selector{"Selector type"}
  Selector --> Include["includeDevices IDs"]
  Selector --> AllDevices["allDevices filter"]
  Include --> ResolveIDs["Resolve selected DB rows by discovered_by_fleet_node_id"]
  AllDevices --> ResolveFilter["Page and filter node-discovered DB rows"]
  ResolveIDs --> Remote["PairOnNode via ControlStream"]
  ResolveFilter --> Remote
  Remote --> Gateway["Fleetnode gateway persists reported pair results"]
  PairAPI --> Cloud["Existing cloud PairDevices path"]
  Gateway --> Response["Combined failed_device_ids"]
  Cloud --> Response
```

```mermaid
sequenceDiagram
  participant UI as ProtoFleet UI
  participant Pairing as PairingService handler
  participant Discovery as Fleetnode discovery service
  participant NodePairing as Fleetnode pairing service
  participant Node as Fleet node agent
  participant Gateway as Fleetnode gateway
  participant Cloud as Cloud pairing path

  UI->>Pairing: Pair(includeDevices or allDevices filter)
  Pairing->>Pairing: Require miner:pair
  Pairing->>Pairing: Soft-check fleetnode:manage
  Pairing->>Discovery: ConfirmedConnectedNodeIDs(org)
  Pairing->>NodePairing: Resolve selected IDs or page filter-matched targets from DB
  NodePairing->>Node: ControlStream pair command
  Node->>Gateway: ReportPairedDevices(command results)
  Gateway-->>NodePairing: Publish persisted pair outcomes
  NodePairing-->>Pairing: Result batches
  Pairing->>Cloud: Pair cloud/server-local matches when needed
  Pairing-->>UI: PairResponse(failed_device_ids)
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/handlers/pairing/handler.go` | Routes explicit selected IDs and filtered `allDevices` requests through fleetnode pairing when DB-attributed targets exist; merges remote and cloud failures into one response and preserves partial success after remote mutation. | Main behavior change. Review authorization, selector handling, fallback behavior, and result aggregation. |
| `server/internal/domain/fleetnode/pairing/pair_discovered.go` | Adds filter-aware target resolution for fleet-node-discovered rows, pages DB candidates with the existing cursor/limit, and shares target construction for explicit and filtered selectors. | Ensures bulk auth-needed requests pair matching node-discovered rows without materializing an uncapped discovered-device list. |
| `server/sqlc/queries/fleetnodepairing.sql` | Tightens discovery upsert ownership so a fleet node can refresh its own rows or reclaim revoked-node rows, but cannot claim a cloud-origin bare row by identifier collision. | Protects the server-side routing boundary used by generic `Pair` requests. |
| `server/cmd/fleetd/main.go` | Passes the fleetnode pairing service into the existing pairing handler. | Wires production `PairingService.Pair` to the fleetnode pairing domain path. |
| `server/internal/testutil/infrastructure_provider.go` | Updates test harness construction with nil fleetnode services for cloud-only test contexts. | Keeps existing harnesses explicit about not exercising fleetnode fan-out. |
| `server/generated/sqlc/fleetnodepairing.sql.go` | Generated from the SQL query change. | Generated code; reviewers can skip beyond verifying it matches the source query. |
| `server/internal/handlers/pairing/handler_internal_test.go` | Adds selector helper and partial-success coverage for explicit and filtered all-devices routing. | Locks in which request shapes the handler routes remotely and how mixed-route errors are reported. |
| `server/internal/domain/fleetnode/pairing/pair_discovered_internal_test.go` | Adds non-DB tests for pairing-status/model/manufacturer filtering and paged resolver behavior. | Covers filter semantics locally without requiring Postgres. |
| `server/internal/domain/fleetnode/pairing/pair_discovered_test.go` | Adds a DB-backed resolver test for auth-needed fleetnode rows. | Verifies in CI that bulk auth-needed resolution does not include never-attempted node discoveries. |
| `server/internal/domain/fleetnode/pairing/integration_test.go` | Adds a DB-backed regression test for rejecting cloud-origin row claims by fleet-node discovery reports. | Verifies the ownership guard that prevents cross-origin routing by identifier collision. |

## Key technical decisions & trade-offs

- Keep the client on `PairingService` instead of calling fleetnode admin RPCs directly, so discovery and pairing mechanisms stay hidden behind the server API.
- Resolve fleetnode ownership from the server DB (`discovered_by_fleet_node_id`) plus connected-node filtering, not by querying agents during target selection.
- Support filtered `allDevices` only when the request carries a pairing-status filter; unfiltered broad selectors stay on the existing cloud behavior.
- Page fleetnode discovered candidates before applying in-memory filter logic, so the resolver never materializes an uncapped node-discovered list for one pairing request.
- Treat cloud fallback as an additive merge after successful fleet-node pairing, so clients do not receive a failed RPC after the server already mutated remote-paired devices.
- Refuse fleet-node discovery takeovers of cloud-origin rows, choosing a stricter ownership boundary over allowing identifier-based refresh of unattributed rows.

## Testing & validation

- `PATH="$PWD/bin:$PATH" go test ./server/internal/domain/fleetnode/pairing -run 'TestPairingStatusFilterSet|TestFleetNodeDiscoveredDeviceMatchesFilter|TestResolvePairTargetsByFilterPagesDiscoveredCandidates' -count=1`
- `PATH="$PWD/bin:$PATH" go test ./server/internal/handlers/pairing ./server/internal/domain/fleetnode/discovery ./server/cmd/fleetnode ./server/cmd/fleetd -count=1`
- `git diff --check`

Also attempted the DB-backed pairing package tests locally. They are blocked in this workspace by Postgres auth before test logic runs (`user=fleet` password authentication failed); the DB-backed resolver and ownership-regression tests are included for CI coverage.
