### PR TITLE
Preserve site scope from detail pages

### DIFF
--- a/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.test.tsx
@@ -1,7 +1,7 @@
 // SitePicker now persists its selection via the Zustand UI slice (org-wide,
 // not per-username localStorage). The persistence contract is covered by
 // useActiveSite.test.ts; these tests focus on render shapes, modal options,
-// the new error/retry affordance, and the useNavigate handoff to /fleet/sites.
+// the new error/retry affordance, and the useNavigate handoff to scoped /fleet/sites.
 import { MemoryRouter } from "react-router-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -132,11 +132,22 @@ describe("SitePicker", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/1/dashboard");
   });
 
-  it("navigates to /fleet/sites via react-router when Manage sites is clicked", () => {
+  it("navigates to /fleet/sites via react-router when Manage sites is clicked from all-sites", () => {
     const sites = [makeSiteWithCounts(1n, "Austin")];
     renderPicker({ sites });
     fireEvent.click(screen.getByTestId("site-picker-trigger"));
     fireEvent.click(screen.getByTestId("site-picker-manage-sites"));
     expect(mockNavigate).toHaveBeenCalledWith("/fleet/sites");
+  });
+
+  it("preserves the selected site when Manage sites is clicked from an unscoped page", () => {
+    const sites = [makeSiteWithCounts(1n, "Austin")];
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "1" };
+    });
+    renderPicker({ sites }, ["/sites/7"]);
+    fireEvent.click(screen.getByTestId("site-picker-trigger"));
+    fireEvent.click(screen.getByTestId("site-picker-manage-sites"));
+    expect(mockNavigate).toHaveBeenCalledWith("/1/fleet/sites");
   });
 });

--- a/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
+++ b/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx";
 import { type ActiveSite, useActiveSite } from "./useActiveSite";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { buildKnownSiteIds } from "@/protoFleet/api/sites";
-import { scopedPath, scopeCurrentOrDashboardPath } from "@/protoFleet/routing/siteScope";
+import { scopeCurrentOrDashboardPath, scopedPath } from "@/protoFleet/routing/siteScope";
 import { ChevronDown } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { sizes, variants } from "@/shared/components/Button";

--- a/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
+++ b/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx";
 import { type ActiveSite, useActiveSite } from "./useActiveSite";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { buildKnownSiteIds } from "@/protoFleet/api/sites";
-import { scopeCurrentOrDashboardPath } from "@/protoFleet/routing/siteScope";
+import { scopedPath, scopeCurrentOrDashboardPath } from "@/protoFleet/routing/siteScope";
 import { ChevronDown } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -156,7 +156,7 @@ const SitePicker = ({ sites, error, onRetry }: SitePickerProps) => {
             // for full site management rather than carrying its own actions.
             onClick: () => {
               setIsOpen(false);
-              navigate("/fleet/sites");
+              navigate(scopedPath("/fleet/sites", activeSite));
             },
             testId: "site-picker-manage-sites",
           },

--- a/client/src/protoFleet/components/SingleMinerWrapper/SingleMinerWrapper.tsx
+++ b/client/src/protoFleet/components/SingleMinerWrapper/SingleMinerWrapper.tsx
@@ -1,14 +1,20 @@
 import { ReactNode, useEffect } from "react";
 import { Link, useParams } from "react-router-dom";
 import { singleMinerRoutePrefetch } from "@/protoFleet/routePrefetch";
+import { scopedPath } from "@/protoFleet/routing/siteScope";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 // eslint-disable-next-line no-restricted-imports -- Fleet shell hosts the protoOS single-miner experience
 import { MinerHostingProvider } from "@/protoOS/contexts/MinerHostingContext";
 import { DismissCircleDark } from "@/shared/assets/icons";
 import { prefetchRoutes } from "@/shared/utils/prefetchRoutes";
 
 const CloseButton = ({ id }: { id: string }) => {
+  const activeSite = useFleetStore((state) => state.ui.activeSite);
   return (
-    <Link className="flex flex-row items-center gap-1 pl-2 text-300 text-text-primary-70" to={"/miners"}>
+    <Link
+      className="flex flex-row items-center gap-1 pl-2 text-300 text-text-primary-70"
+      to={scopedPath("/fleet/miners", activeSite)}
+    >
       <DismissCircleDark />
       {id}
     </Link>

--- a/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from "react-router-dom";
 
+import { scopedPath } from "@/protoFleet/routing/siteScope";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 import { ChevronDown } from "@/shared/assets/icons";
 import Button, { variants } from "@/shared/components/Button";
 import Header from "@/shared/components/Header";
@@ -21,6 +23,7 @@ interface BuildingPageHeaderProps {
 // its building filter chip.
 const BuildingPageHeader = ({ label, buildingId, onEditBuilding }: BuildingPageHeaderProps) => {
   const navigate = useNavigate();
+  const activeSite = useFleetStore((state) => state.ui.activeSite);
   return (
     <Header
       title={label}
@@ -28,19 +31,19 @@ const BuildingPageHeader = ({ label, buildingId, onEditBuilding }: BuildingPageH
       inline
       icon={<ChevronDown className="rotate-90" />}
       iconAriaLabel="Back to sites"
-      iconOnClick={() => navigate("/sites")}
+      iconOnClick={() => navigate(scopedPath("/fleet/sites", activeSite))}
     >
       <div className="ml-3 flex items-center gap-3">
         <Button
           variant={variants.secondary}
-          onClick={() => navigate(`/racks?building=${buildingId}`)}
+          onClick={() => navigate(scopedPath(`/fleet/racks?building=${buildingId}`, activeSite))}
           testId="building-page-view-racks"
         >
           View racks
         </Button>
         <Button
           variant={variants.secondary}
-          onClick={() => navigate(`/miners?building=${buildingId}`)}
+          onClick={() => navigate(scopedPath(`/fleet/miners?building=${buildingId}`, activeSite))}
           testId="building-page-view-miners"
         >
           View miners

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
@@ -1,0 +1,153 @@
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import BuildingPage from "./BuildingPage";
+import { type Building, type BuildingRack, BuildingSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
+
+const getBuildingMock = vi.hoisted(() => vi.fn());
+const listBuildingRacksMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/protoFleet/api/buildings", () => ({
+  useBuildings: () => ({
+    getBuilding: getBuildingMock,
+    listBuildingRacks: listBuildingRacksMock,
+  }),
+}));
+
+vi.mock("@/protoFleet/api/useBuildingStats", () => ({
+  useBuildingStats: () => ({
+    stats: {
+      deviceIdentifiers: [],
+      rackCount: 0,
+      deviceCount: 0,
+      reportingCount: 0,
+      hashrateReportingCount: 0,
+      efficiencyReportingCount: 0,
+      powerReportingCount: 0,
+      totalHashrateThs: 0,
+      avgEfficiencyJth: 0,
+      totalPowerKw: 0,
+      hashingCount: 0,
+      brokenCount: 0,
+      offlineCount: 0,
+      sleepingCount: 0,
+    },
+    error: null,
+    hasLoaded: true,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/protoFleet/api/useComponentErrors", () => ({
+  useComponentErrors: () => ({
+    controlBoardErrors: 0,
+    fanErrors: 0,
+    hashboardErrors: 0,
+    psuErrors: 0,
+  }),
+}));
+
+vi.mock("@/protoFleet/api/useTelemetryMetrics", () => ({
+  useTelemetryMetrics: () => ({ data: { metrics: [] } }),
+}));
+
+vi.mock("@/protoFleet/features/buildings/components/BuildingModals", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/protoFleet/features/buildings/hooks/useBuildingModals", () => ({
+  useBuildingModals: () => ({
+    openManage: vi.fn(),
+  }),
+}));
+
+vi.mock("@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection", () => ({
+  DeviceSetPerformanceSection: () => <div>Performance section</div>,
+}));
+
+vi.mock("@/shared/hooks/useStickyState", () => ({
+  useStickyState: () => ({
+    refs: {
+      vertical: {
+        start: { current: null },
+        end: { current: null },
+      },
+    },
+  }),
+}));
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="location-probe">{`${location.pathname}${location.search}`}</div>;
+};
+
+const renderPage = (initialEntry = "/buildings/123") =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/buildings/:id" element={<BuildingPage />} />
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("BuildingPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = DEFAULT_ACTIVE_SITE;
+    });
+    getBuildingMock.mockImplementation(({ onSuccess }: { onSuccess: (building: Building | undefined) => void }) =>
+      onSuccess(
+        create(BuildingSchema, {
+          id: 123n,
+          name: "Building A",
+          siteId: 8n,
+        }),
+      ),
+    );
+    listBuildingRacksMock.mockImplementation(({ onSuccess }: { onSuccess: (racks: BuildingRack[]) => void }) =>
+      onSuccess([]),
+    );
+  });
+
+  it("preserves the selected site when leaving building detail for miners", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "8" };
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId("building-page-view-miners")).toBeVisible());
+    fireEvent.click(screen.getByTestId("building-page-view-miners"));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/8/fleet/miners?building=123");
+  });
+
+  it("preserves the selected site when leaving building detail for racks", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "8" };
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId("building-page-view-racks")).toBeVisible());
+    fireEvent.click(screen.getByTestId("building-page-view-racks"));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/8/fleet/racks?building=123");
+  });
+
+  it("uses all-sites fleet routes when all-sites is selected", async () => {
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId("building-page-view-miners")).toBeVisible());
+    fireEvent.click(screen.getByTestId("building-page-view-miners"));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/fleet/miners?building=123");
+  });
+});

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -16,7 +16,9 @@ import { useTelemetryMetrics } from "@/protoFleet/api/useTelemetryMetrics";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
+import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
 import Header from "@/shared/components/Header";
@@ -53,6 +55,7 @@ const BuildingPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { getBuilding, listBuildingRacks } = useBuildings();
+  const activeSite = useFleetStore((state) => state.ui.activeSite);
 
   const buildingId = useMemo(() => parseBigIntId(id), [id]);
 
@@ -107,7 +110,7 @@ const BuildingPage = () => {
     refetchBuildings: () => {
       if (buildingId !== null) fetchBuilding(buildingId);
     },
-    onDeleteFromManage: () => navigate("/sites"),
+    onDeleteFromManage: () => navigate(scopedPath("/fleet/sites", activeSite)),
   });
 
   useEffect(() => {
@@ -192,8 +195,8 @@ const BuildingPage = () => {
       <div className="flex flex-col gap-6 p-10 phone:p-6" data-testid="building-page-not-found">
         <Header title="Building not found" titleSize="text-heading-300" />
         <p className="text-300 text-text-primary-70">
-          Either the building has been deleted or the URL is invalid. Return to <Link to="/sites">/sites</Link> to find
-          your building.
+          Either the building has been deleted or the URL is invalid. Return to{" "}
+          <Link to={scopedPath("/fleet/sites", activeSite)}>/sites</Link> to find your building.
         </p>
       </div>
     );
@@ -288,6 +291,7 @@ const BuildingPage = () => {
               hashboardErrors={hashboardErrors}
               psuErrors={psuErrors}
               extraFilterParams={buildingFilterParam}
+              activeSite={activeSite}
             />
           </div>
         </section>

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -196,7 +196,7 @@ const BuildingPage = () => {
         <Header title="Building not found" titleSize="text-heading-300" />
         <p className="text-300 text-text-primary-70">
           Either the building has been deleted or the URL is invalid. Return to{" "}
-          <Link to={scopedPath("/fleet/sites", activeSite)}>/sites</Link> to find your building.
+          <Link to={scopedPath("/fleet/sites", activeSite)}>Fleet sites</Link> to find your building.
         </p>
       </div>
     );

--- a/client/src/protoFleet/features/dashboard/components/FleetHealth/FleetHealth.test.tsx
+++ b/client/src/protoFleet/features/dashboard/components/FleetHealth/FleetHealth.test.tsx
@@ -234,6 +234,24 @@ describe("FleetHealth", () => {
     expect(screen.getByText("3 miners")).toBeInTheDocument();
   });
 
+  it("preserves the selected site in clickable miner status links", () => {
+    renderWithRouter(
+      <FleetHealth
+        fleetSize={50}
+        healthyMiners={30}
+        needsAttentionMiners={10}
+        offlineMiners={7}
+        sleepingMiners={3}
+        extraFilterParams="rack=7"
+        activeSite={{ kind: "site", id: "8" }}
+      />,
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", expect.stringContaining("/8/fleet/miners?"));
+    expect(links[0]).toHaveAttribute("href", expect.stringContaining("rack=7"));
+  });
+
   it("renders mdash for all stats when counts are null (loaded but no data)", () => {
     renderWithRouter(
       <FleetHealth

--- a/client/src/protoFleet/features/dashboard/components/FleetHealth/FleetHealth.tsx
+++ b/client/src/protoFleet/features/dashboard/components/FleetHealth/FleetHealth.tsx
@@ -5,6 +5,8 @@ import ChartWidget from "../ChartWidget/ChartWidget";
 import { MinerListFilterSchema } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { encodeFilterToURL } from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
+import { scopedPath } from "@/protoFleet/routing/siteScope";
+import { type ActiveSite, DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { Triangle } from "@/shared/assets/icons";
 import CompositionBar, { type Segment } from "@/shared/components/CompositionBar";
 import SkeletonBar from "@/shared/components/SkeletonBar";
@@ -52,6 +54,7 @@ interface FleetHealthProps {
   extraFilterParams?: string;
   /** Link URL for the total miners count (e.g., "/miners?group=123") */
   totalMinersLink?: string;
+  activeSite?: ActiveSite;
 }
 
 const FleetHealth = ({
@@ -63,6 +66,7 @@ const FleetHealth = ({
   title = "Your fleet",
   extraFilterParams,
   totalMinersLink,
+  activeSite = DEFAULT_ACTIVE_SITE,
 }: FleetHealthProps) => {
   // undefined = still loading (show skeleton), null = loaded but no data (show mdash)
   const isLoading =
@@ -141,7 +145,7 @@ const FleetHealth = ({
       }
       return {
         ...segment,
-        filterUrl: `/miners?${params.toString()}`,
+        filterUrl: scopedPath(`/fleet/miners?${params.toString()}`, activeSite),
         percentage: segment.count !== undefined ? Math.round((segment.count / totalMiners) * 100) : undefined,
       };
     });
@@ -154,6 +158,7 @@ const FleetHealth = ({
     isLoading,
     hasNoData,
     extraFilterParams,
+    activeSite,
   ]);
 
   // Extract basic segments for CompositionBar (without extra props)

--- a/client/src/protoFleet/features/dashboard/components/FleetHealth/FleetHealth.tsx
+++ b/client/src/protoFleet/features/dashboard/components/FleetHealth/FleetHealth.tsx
@@ -52,7 +52,7 @@ interface FleetHealthProps {
   title?: string;
   /** Extra URL search params to append to miner list links (e.g., "group=123") */
   extraFilterParams?: string;
-  /** Link URL for the total miners count (e.g., "/miners?group=123") */
+  /** Link URL for the total miners count (e.g., "/fleet/miners?group=123" or a scoped variant) */
   totalMinersLink?: string;
   activeSite?: ActiveSite;
 }

--- a/client/src/protoFleet/features/fleetManagement/components/RackHealthModule/RackHealthModule.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackHealthModule/RackHealthModule.tsx
@@ -13,6 +13,8 @@ import type {
   SlotHealthState,
 } from "@/protoFleet/features/fleetManagement/components/RackDetailGrid/types";
 import { encodeFilterToURL } from "@/protoFleet/features/fleetManagement/utils/filterUrlParams";
+import { scopedPath } from "@/protoFleet/routing/siteScope";
+import { type ActiveSite, DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { Triangle } from "@/shared/assets/icons";
 import SkeletonBar from "@/shared/components/SkeletonBar";
 import { useNavigate } from "@/shared/hooks/useNavigate";
@@ -29,15 +31,16 @@ interface RackHealthModuleProps {
   offlineCount?: number | null;
   sleepingCount?: number | null;
   rackFilterParam?: string;
+  activeSite?: ActiveSite;
 }
 
-function buildFilterUrl(statuses: DeviceStatus[], rackFilterParam?: string): string {
+function buildFilterUrl(statuses: DeviceStatus[], rackFilterParam: string | undefined, activeSite: ActiveSite): string {
   const filter = create(MinerListFilterSchema, { deviceStatus: statuses });
   const params = encodeFilterToURL(filter);
   if (rackFilterParam) {
     new URLSearchParams(rackFilterParam).forEach((value, key) => params.set(key, value));
   }
-  return `/miners?${params.toString()}`;
+  return scopedPath(`/fleet/miners?${params.toString()}`, activeSite);
 }
 
 const formatCount = (count: number): string => {
@@ -55,6 +58,7 @@ export const RackHealthModule = ({
   offlineCount,
   sleepingCount,
   rackFilterParam,
+  activeSite = DEFAULT_ACTIVE_SITE,
 }: RackHealthModuleProps) => {
   const navigate = useNavigate();
 
@@ -82,7 +86,7 @@ export const RackHealthModule = ({
         count: hashing,
         showButton: true,
         buttonVariant: "secondary",
-        onClick: () => navigate(buildFilterUrl([DeviceStatus.ONLINE], rackFilterParam)),
+        onClick: () => navigate(buildFilterUrl([DeviceStatus.ONLINE], rackFilterParam, activeSite)),
       },
       {
         key: "sleeping",
@@ -92,7 +96,7 @@ export const RackHealthModule = ({
         count: sleeping,
         showButton: true,
         buttonVariant: "secondary",
-        onClick: () => navigate(buildFilterUrl([DeviceStatus.INACTIVE], rackFilterParam)),
+        onClick: () => navigate(buildFilterUrl([DeviceStatus.INACTIVE], rackFilterParam, activeSite)),
       },
       {
         key: "needsAttention",
@@ -108,6 +112,7 @@ export const RackHealthModule = ({
             buildFilterUrl(
               [DeviceStatus.ERROR, DeviceStatus.NEEDS_MINING_POOL, DeviceStatus.UPDATING, DeviceStatus.REBOOT_REQUIRED],
               rackFilterParam,
+              activeSite,
             ),
           ),
       },
@@ -119,10 +124,10 @@ export const RackHealthModule = ({
         count: offline,
         showButton: true,
         buttonVariant: "secondary",
-        onClick: () => navigate(buildFilterUrl([DeviceStatus.OFFLINE], rackFilterParam)),
+        onClick: () => navigate(buildFilterUrl([DeviceStatus.OFFLINE], rackFilterParam, activeSite)),
       },
     ];
-  }, [hashingCount, sleepingCount, needsAttentionCount, offlineCount, rackFilterParam, navigate]);
+  }, [hashingCount, sleepingCount, needsAttentionCount, offlineCount, rackFilterParam, activeSite, navigate]);
 
   return (
     <div className="flex w-full flex-col overflow-hidden rounded-xl bg-surface-base laptop:flex-row dark:bg-core-primary-5">

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -24,7 +24,9 @@ import { SLOT_STATUS_MAP } from "@/protoFleet/features/fleetManagement/utils/rac
 import DeviceSetActionsMenu from "@/protoFleet/features/groupManagement/components/DeviceSetActionsMenu";
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
+import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 import { ChevronDown } from "@/shared/assets/icons";
 import Button, { variants } from "@/shared/components/Button";
 import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
@@ -47,6 +49,7 @@ const ALL_AGGREGATION_TYPES: AggregationType[] = [AggregationType.AVERAGE, Aggre
 const RackOverviewPage = () => {
   const { rackId: rackIdParam } = useParams<{ rackId: string }>();
   const navigate = useNavigate();
+  const activeSite = useFleetStore((state) => state.ui.activeSite);
 
   // Rack resolution state
   const [rack, setRack] = useState<DeviceSet | null>(null);
@@ -281,10 +284,13 @@ const RackOverviewPage = () => {
             inline
             icon={<ChevronDown className="rotate-90" />}
             iconAriaLabel="Back to racks"
-            iconOnClick={() => navigate("/racks")}
+            iconOnClick={() => navigate(scopedPath("/fleet/racks", activeSite))}
           >
             <div className="ml-3 flex items-center gap-3">
-              <Button variant={variants.secondary} onClick={() => navigate(`/miners?rack=${rack?.id}`)}>
+              <Button
+                variant={variants.secondary}
+                onClick={() => navigate(scopedPath(`/fleet/miners?rack=${rack?.id}`, activeSite))}
+              >
                 View miners
               </Button>
               <Button
@@ -330,6 +336,7 @@ const RackOverviewPage = () => {
               offlineCount={stateCounts?.offlineCount ?? (isEmptyRack ? 0 : statsLoaded ? null : undefined)}
               sleepingCount={stateCounts?.sleepingCount ?? (isEmptyRack ? 0 : statsLoaded ? null : undefined)}
               rackFilterParam={rack ? `rack=${rack.id}` : undefined}
+              activeSite={activeSite}
             />
             <FleetErrors
               controlBoardErrors={controlBoardErrors}
@@ -337,6 +344,7 @@ const RackOverviewPage = () => {
               hashboardErrors={hashboardErrors}
               psuErrors={psuErrors}
               extraFilterParams={rack ? `rack=${rack.id}` : undefined}
+              activeSite={activeSite}
             />
           </div>
         </section>
@@ -427,7 +435,7 @@ const RackOverviewPage = () => {
                 deviceSetId: rack.id,
                 onSuccess: () => {
                   pushToast({ message: "Rack deleted", status: STATUSES.success });
-                  navigate("/racks");
+                  navigate(scopedPath("/fleet/racks", activeSite));
                   resolve();
                 },
                 onError: (msg) => {

--- a/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
@@ -245,7 +245,8 @@ const GroupOverviewPage = () => {
               offlineMiners={stateCounts?.offlineCount ?? (isEmptyGroup ? 0 : statsLoaded ? null : undefined)}
               sleepingMiners={stateCounts?.sleepingCount ?? (isEmptyGroup ? 0 : statsLoaded ? null : undefined)}
               extraFilterParams={group ? `group=${group.id}` : undefined}
-              totalMinersLink={group ? `/miners?group=${group.id}` : undefined}
+              totalMinersLink={group ? scopedPath(`/fleet/miners?group=${group.id}`, activeSite) : undefined}
+              activeSite={activeSite}
             />
             <FleetErrors
               controlBoardErrors={controlBoardErrors}
@@ -253,6 +254,7 @@ const GroupOverviewPage = () => {
               hashboardErrors={hashboardErrors}
               psuErrors={psuErrors}
               extraFilterParams={group ? `group=${group.id}` : undefined}
+              activeSite={activeSite}
             />
           </div>
         </section>

--- a/client/src/protoFleet/features/kpis/components/FleetErrors/FleetErrors.test.tsx
+++ b/client/src/protoFleet/features/kpis/components/FleetErrors/FleetErrors.test.tsx
@@ -39,10 +39,29 @@ describe("FleetErrors", () => {
 
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(4);
-    expect(links[0]).toHaveAttribute("href", "/miners?issues=control-board");
-    expect(links[1]).toHaveAttribute("href", "/miners?issues=fans");
-    expect(links[2]).toHaveAttribute("href", "/miners?issues=hash-boards");
-    expect(links[3]).toHaveAttribute("href", "/miners?issues=psu");
+    expect(links[0]).toHaveAttribute("href", "/fleet/miners?issues=control-board");
+    expect(links[1]).toHaveAttribute("href", "/fleet/miners?issues=fans");
+    expect(links[2]).toHaveAttribute("href", "/fleet/miners?issues=hash-boards");
+    expect(links[3]).toHaveAttribute("href", "/fleet/miners?issues=psu");
+  });
+
+  it("preserves the selected site when building scoped hardware issue links", () => {
+    render(
+      <BrowserRouter>
+        <FleetErrors
+          controlBoardErrors={1}
+          fanErrors={2}
+          hashboardErrors={3}
+          psuErrors={4}
+          extraFilterParams="building=123"
+          activeSite={{ kind: "site", id: "8" }}
+        />
+      </BrowserRouter>,
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", "/8/fleet/miners?issues=control-board&building=123");
+    expect(links[1]).toHaveAttribute("href", "/8/fleet/miners?issues=fans&building=123");
   });
 
   it("does not render as links when error counts are zero", () => {

--- a/client/src/protoFleet/features/kpis/components/FleetErrors/FleetErrors.tsx
+++ b/client/src/protoFleet/features/kpis/components/FleetErrors/FleetErrors.tsx
@@ -1,4 +1,6 @@
 import ComponentErrors from "../ComponentErrors";
+import { scopedPath } from "@/protoFleet/routing/siteScope";
+import { type ActiveSite, DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import ControlBoard from "@/shared/assets/icons/ControlBoard";
 import Fan from "@/shared/assets/icons/Fan";
 import Hashboard from "@/shared/assets/icons/Hashboard";
@@ -11,6 +13,7 @@ type FleetErrorsProps = {
   psuErrors?: number;
   className?: string;
   extraFilterParams?: string;
+  activeSite?: ActiveSite;
 };
 
 const FleetErrors = ({
@@ -20,8 +23,10 @@ const FleetErrors = ({
   psuErrors,
   className,
   extraFilterParams,
+  activeSite = DEFAULT_ACTIVE_SITE,
 }: FleetErrorsProps) => {
   const suffix = extraFilterParams ? `&${extraFilterParams}` : "";
+  const minerIssuesHref = (issue: string) => scopedPath(`/fleet/miners?issues=${issue}${suffix}`, activeSite);
   return (
     <div className={className}>
       <div className="grid grid-cols-1 gap-1 tablet:grid-cols-2 laptop:grid-cols-4">
@@ -29,20 +34,20 @@ const FleetErrors = ({
           icon={<ControlBoard />}
           heading="Control Boards"
           errorCount={controlBoardErrors}
-          href={`/miners?issues=control-board${suffix}`}
+          href={minerIssuesHref("control-board")}
         />
-        <ComponentErrors icon={<Fan />} heading="Fans" errorCount={fanErrors} href={`/miners?issues=fans${suffix}`} />
+        <ComponentErrors icon={<Fan />} heading="Fans" errorCount={fanErrors} href={minerIssuesHref("fans")} />
         <ComponentErrors
           icon={<Hashboard />}
           heading="Hashboards"
           errorCount={hashboardErrors}
-          href={`/miners?issues=hash-boards${suffix}`}
+          href={minerIssuesHref("hash-boards")}
         />
         <ComponentErrors
           icon={<LightningAlt />}
           heading="Power supplies"
           errorCount={psuErrors}
-          href={`/miners?issues=psu${suffix}`}
+          href={minerIssuesHref("psu")}
         />
       </div>
     </div>

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 
 import SiteDetailPage from "./SiteDetailPage";
-import { type SiteWithCounts, SiteSchema, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { SiteSchema, type SiteWithCounts, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
@@ -1,0 +1,93 @@
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import SiteDetailPage from "./SiteDetailPage";
+import { type SiteWithCounts, SiteSchema, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
+
+const listSitesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/protoFleet/api/sites", async () => {
+  const actual = await vi.importActual<typeof import("@/protoFleet/api/sites")>("@/protoFleet/api/sites");
+  return {
+    ...actual,
+    useSites: () => ({
+      listSites: listSitesMock,
+    }),
+  };
+});
+
+vi.mock("@/protoFleet/features/sites/components/SiteModals", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/protoFleet/features/sites/hooks/useSiteModals", () => ({
+  useSiteModals: () => ({
+    openManageEdit: vi.fn(),
+  }),
+}));
+
+vi.mock("@/protoFleet/features/buildings/components/BuildingModals", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/protoFleet/features/buildings/hooks/useBuildingModals", () => ({
+  useBuildingModals: () => ({
+    openDetailsCreate: vi.fn(),
+    openDetailsEdit: vi.fn(),
+  }),
+}));
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="location-probe">{`${location.pathname}${location.search}`}</div>;
+};
+
+const makeSite = (id: bigint, name: string) =>
+  create(SiteWithCountsSchema, {
+    site: create(SiteSchema, {
+      id,
+      name,
+      country: "US",
+    }),
+    deviceCount: 0n,
+    buildingCount: 0n,
+    rackCount: 0n,
+  });
+
+const renderPage = (initialEntry = "/sites/7") =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/sites/:id" element={<SiteDetailPage />} />
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("SiteDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = DEFAULT_ACTIVE_SITE;
+    });
+    listSitesMock.mockImplementation(({ onSuccess }: { onSuccess: (sites: SiteWithCounts[]) => void }) =>
+      onSuccess([makeSite(7n, "Dallas"), makeSite(8n, "Austin")]),
+    );
+  });
+
+  it("preserves the selected site when a site detail mismatch redirects back to Fleet", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "8" };
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toHaveTextContent("/8/fleet"));
+  });
+});

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -9,6 +9,7 @@ import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import BuildingModals from "@/protoFleet/features/buildings/components/BuildingModals";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
 import { formatSiteAddress } from "@/protoFleet/features/sites/formatAddress";
+import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useHasPermission } from "@/protoFleet/store";
 import { Alert } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -59,7 +60,7 @@ const SiteDetailPage = () => {
   useEffect(() => {
     if (activeSite.kind !== "site") return;
     if (activeSite.id === targetId) return;
-    navigate("/fleet", { replace: true });
+    navigate(scopedPath("/fleet", activeSite), { replace: true });
   }, [activeSite, navigate, targetId]);
 
   const site = useMemo(() => {
@@ -114,7 +115,7 @@ const SiteDetailPage = () => {
           variant={variants.primary}
           size={sizes.compact}
           text="Back to sites"
-          onClick={() => navigate("/fleet/sites")}
+          onClick={() => navigate(scopedPath("/fleet/sites", activeSite))}
           testId="site-detail-back"
         />
       </div>


### PR DESCRIPTION
Reviewable diff: +65/-26 across 10 files (excludes generated, test, and story files).

**Summary**
This PR preserves the active SitePicker scope when operators leave canonical unscoped detail pages and return to scopable ProtoFleet sections. Detail URLs such as `/buildings/:id`, `/racks/:rackId`, `/miners/:id/*`, and `/sites/:id` remain canonical and unscoped, but their escape hatches now route through scoped Fleet paths when the user has a selected site.

**How it works**
Detail-page actions read the stored active site selection and wrap outbound Fleet destinations with `scopedPath`. Shared summary widgets that build miner-list links now accept an optional `activeSite`, defaulting to all-sites for existing dashboard callers while allowing building, rack, and group detail pages to preserve selected-site scope. Site detail mismatch redirects also use `scopedPath("/fleet", activeSite)`, so switching from `/sites/7` while site 8 is selected lands on `/8/fleet` instead of dropping the user to all-sites.

```mermaid
flowchart LR
  A["Unscoped detail page"] --> B["Read stored activeSite"]
  B --> C["scopedPath('/fleet/...', activeSite)"]
  C --> D{"activeSite"}
  D -->|all-sites| E["/fleet/..."]
  D -->|site 8| F["/8/fleet/..."]
  D -->|unassigned| G["/unassigned/fleet/..."]
```

```mermaid
sequenceDiagram
  participant User
  participant Detail as "Detail page"
  participant Store as "SitePicker store"
  participant Router as "React Router"
  User->>Detail: Click "View miners"
  Detail->>Store: Read activeSite
  Detail->>Router: navigate(scopedPath("/fleet/miners?...", activeSite))
  Router-->>User: Scoped Fleet list with filters preserved
```

**Areas of the code involved**
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/buildings/` | Building detail header, delete exit, not-found link, and component-error links now route through scoped Fleet paths. | Covers the primary issue examples for `/buildings/:id` leaving to miners/racks. |
| `client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx` | Rack detail back, view-miners, delete, rack-health, and hardware-error links preserve active site. | Extends the same unscoped-detail behavior to rack details. |
| `client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx` | Site mismatch redirect and back-to-sites button use scoped Fleet paths. | Covers the required `/sites/7` with selected site 8 redirect case. |
| `client/src/protoFleet/components/SingleMinerWrapper/SingleMinerWrapper.tsx` | Single-miner close link returns to scoped Fleet miners. | Keeps `/miners/:id/*` detail pages canonical while preserving scope on exit. |
| `client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx` | Manage-sites action preserves active scope. | Prevents unscoped/settings-page SitePicker usage from forcing all-sites. |
| `client/src/protoFleet/features/dashboard/components/FleetHealth/`, `features/kpis/components/FleetErrors/`, `features/fleetManagement/components/RackHealthModule/` | Shared widgets accept optional `activeSite` and default to all-sites. | Keeps dashboard behavior stable while enabling detail pages to opt into scoped links. |
| `*.test.tsx` | Added building and site detail coverage; updated shared widget/SitePicker expectations. | Protects selected-site and all-sites navigation behavior. |

**Key technical decisions & trade-offs**
| Decision | Trade-off |
| --- | --- |
| Keep detail routes unscoped and scope only outbound Fleet destinations. | Avoids applying SitePicker filters to entity detail visibility while preserving user context on exit. |
| Pass `activeSite` into shared link-building widgets. | Slightly expands widget props, but avoids hidden store reads in reusable dashboard components. |
| Default shared widgets to all-sites. | Existing dashboard and all-sites behavior stays unchanged unless a detail page opts in. |
| Keep explicit `site=` query deep links all-sites through existing redirect-loader behavior. | Intentional all-sites filtered links remain available and documented by existing loader tests. |

**Testing & validation**
- `git diff --check`
- Before rebasing onto merged PR #516, targeted Vitest passed for `BuildingPage`, `SiteDetailPage`, `FleetErrors`, `FleetHealth`, `SitePicker`, and `RackOverviewPage` (`6` files, `36` tests).
- Post-rebase lint/typecheck and Vitest reruns were blocked by the local client dependency install: `client/node_modules` points at another checkout with missing packages, and `npx` registry fetches are blocked by the dependency-confusion policy. CI should provide the fresh post-push validation.
