### PR TITLE
Use HealthBar in fleet list health columns

### DIFF
--- a/client/src/protoFleet/components/DeviceSetList/deviceSetColConfig.tsx
+++ b/client/src/protoFleet/components/DeviceSetList/deviceSetColConfig.tsx
@@ -3,19 +3,13 @@ import type { ReactNode } from "react";
 import { deviceSetCols, type DeviceSetColumn } from "./constants";
 import type { DeviceSetListItem } from "./DeviceSetList";
 import StatCell from "./StatCell";
-import CompositionBar, { type Segment } from "@/shared/components/CompositionBar";
+import { HealthBar } from "@/protoFleet/components/HealthBar";
 import { type ColConfig } from "@/shared/components/List/types";
 import type { TemperatureUnit } from "@/shared/features/preferences";
 import { getDisplayValue } from "@/shared/utils/stringUtils";
 import { formatTempRange } from "@/shared/utils/telemetryFormat";
 
 const INACTIVE_PLACEHOLDER = "—";
-
-const HEALTH_COLOR_MAP = {
-  OK: "bg-core-primary-fill",
-  CRITICAL: "bg-intent-critical-fill",
-  NA: "bg-core-accent-fill",
-};
 
 type CreateDeviceSetColConfigParams = {
   renderName: (item: DeviceSetListItem) => ReactNode;
@@ -111,16 +105,14 @@ const createDeviceSetColConfig = ({
   [deviceSetCols.health]: {
     component: (item: DeviceSetListItem) => {
       if (!item.stats || item.stats.deviceCount === 0) return <span>{INACTIVE_PLACEHOLDER}</span>;
-      const { hashingCount, brokenCount, offlineCount, sleepingCount } = item.stats;
-      const segments: Segment[] = [
-        { name: "Healthy", status: "OK", count: hashingCount },
-        { name: "Needs Attention", status: "CRITICAL", count: brokenCount },
-        { name: "Offline", status: "NA", count: offlineCount + sleepingCount },
-      ];
-
       return (
         <div className="w-34">
-          <CompositionBar segments={segments} height={6} gap={0.25} colorMap={HEALTH_COLOR_MAP} />
+          <HealthBar
+            healthy={item.stats.hashingCount}
+            needsAttention={item.stats.brokenCount}
+            offline={item.stats.offlineCount}
+            sleeping={item.stats.sleepingCount}
+          />
         </div>
       );
     },

--- a/client/src/protoFleet/features/fleetManagement/components/BuildingList/buildingColConfig.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BuildingList/buildingColConfig.tsx
@@ -4,8 +4,8 @@ import { Link } from "react-router-dom";
 import { buildingTabHref } from "../../utils/fleetTabLinks";
 import type { BuildingColumn, BuildingListItem } from "./BuildingList";
 import StatCell from "@/protoFleet/components/DeviceSetList/StatCell";
+import { HealthBar } from "@/protoFleet/components/HealthBar";
 import type { ActiveSite } from "@/protoFleet/store/types/activeSite";
-import CompositionBar, { type Segment } from "@/shared/components/CompositionBar";
 import { type ColConfig } from "@/shared/components/List/types";
 import type { TemperatureUnit } from "@/shared/features/preferences";
 import {
@@ -16,12 +16,6 @@ import {
 } from "@/shared/utils/telemetryFormat";
 
 const INACTIVE_PLACEHOLDER = "—";
-
-const HEALTH_COLOR_MAP = {
-  OK: "bg-core-primary-fill",
-  CRITICAL: "bg-intent-critical-fill",
-  NA: "bg-core-accent-fill",
-};
 
 const stopRowClick = (event: MouseEvent) => event.stopPropagation();
 
@@ -114,14 +108,14 @@ export const createBuildingColConfig = (
   health: {
     component: (item) => {
       if (!item.stats || item.stats.deviceCount === 0) return <span>{INACTIVE_PLACEHOLDER}</span>;
-      const segments: Segment[] = [
-        { name: "Healthy", status: "OK", count: item.stats.hashingCount },
-        { name: "Needs Attention", status: "CRITICAL", count: item.stats.brokenCount },
-        { name: "Offline", status: "NA", count: item.stats.offlineCount + item.stats.sleepingCount },
-      ];
       return (
         <div className="w-34">
-          <CompositionBar segments={segments} height={6} gap={0.25} colorMap={HEALTH_COLOR_MAP} />
+          <HealthBar
+            healthy={item.stats.hashingCount}
+            needsAttention={item.stats.brokenCount}
+            offline={item.stats.offlineCount}
+            sleeping={item.stats.sleepingCount}
+          />
         </div>
       );
     },

--- a/client/src/protoFleet/features/fleetManagement/components/SiteList/siteColConfig.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/SiteList/siteColConfig.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { siteTabHref } from "../../utils/fleetTabLinks";
 import type { SiteColumn, SiteListItem } from "./SiteList";
 import StatCell from "@/protoFleet/components/DeviceSetList/StatCell";
-import CompositionBar, { type Segment } from "@/shared/components/CompositionBar";
+import { HealthBar } from "@/protoFleet/components/HealthBar";
 import { type ColConfig } from "@/shared/components/List/types";
 import type { TemperatureUnit } from "@/shared/features/preferences";
 import {
@@ -15,12 +15,6 @@ import {
 } from "@/shared/utils/telemetryFormat";
 
 const INACTIVE_PLACEHOLDER = "—";
-
-const HEALTH_COLOR_MAP = {
-  OK: "bg-core-primary-fill",
-  CRITICAL: "bg-intent-critical-fill",
-  NA: "bg-core-accent-fill",
-};
 
 const stopRowClick = (event: MouseEvent) => event.stopPropagation();
 
@@ -116,14 +110,14 @@ export const createSiteColConfig = (
   health: {
     component: (item) => {
       if (!item.stats || item.stats.deviceCount === 0) return <span>{INACTIVE_PLACEHOLDER}</span>;
-      const segments: Segment[] = [
-        { name: "Healthy", status: "OK", count: item.stats.hashingCount },
-        { name: "Needs Attention", status: "CRITICAL", count: item.stats.brokenCount },
-        { name: "Offline", status: "NA", count: item.stats.offlineCount + item.stats.sleepingCount },
-      ];
       return (
         <div className="w-34">
-          <CompositionBar segments={segments} height={6} gap={0.25} colorMap={HEALTH_COLOR_MAP} />
+          <HealthBar
+            healthy={item.stats.hashingCount}
+            needsAttention={item.stats.brokenCount}
+            offline={item.stats.offlineCount}
+            sleeping={item.stats.sleepingCount}
+          />
         </div>
       );
     },


### PR DESCRIPTION
Reviewable diff: +21/-41 across 3 files (excludes generated, test, and story files).

**Summary**
This updates the fleet list health columns to use the shared Proto Fleet `HealthBar` component. Sites, buildings, racks, and groups now render the same status distribution visual used by the newer health surfaces, including separate offline and sleeping segments.

**How it works**
The existing list column configs still read health counts from `FleetListStats` and `DeviceSetStats`. Instead of converting those counts into `CompositionBar` segments, each health cell now passes `hashingCount`, `brokenCount`, `offlineCount`, and `sleepingCount` directly into `HealthBar`. Rack and group list views share `DeviceSetList`, so the shared `DeviceSetList` health column covers both pages.

**Diagrams**
```mermaid
flowchart LR
  Stats["FleetListStats / DeviceSetStats"] --> Columns["Site, Building, DeviceSet column configs"]
  Columns --> HealthBar["HealthBar"]
  HealthBar --> Lists["Site, building, rack, and group list health cells"]
```

**Areas of the code involved**
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/fleetManagement/components/SiteList/siteColConfig.tsx` | Replaced `CompositionBar` health rendering with `HealthBar`. | Applies the shared health visual to site rows. |
| `client/src/protoFleet/features/fleetManagement/components/BuildingList/buildingColConfig.tsx` | Replaced `CompositionBar` health rendering with `HealthBar`. | Applies the shared health visual to building rows. |
| `client/src/protoFleet/components/DeviceSetList/deviceSetColConfig.tsx` | Replaced `CompositionBar` health rendering with `HealthBar`. | Applies the shared health visual to rack and group rows through their shared list component. |

**Key technical decisions & trade-offs**
| Decision | Alternative |
| --- | --- |
| Pass the existing count fields directly to `HealthBar`. | Keep a separate `CompositionBar` mapping for list health columns. |
| Keep existing empty and missing-stat placeholder behavior. | Render an empty health bar for rows with no devices or no stats. |

**Testing & validation**
- `npm run lint`
- `npx tsc --noEmit`
- `npx vitest run src/protoFleet/components/DeviceSetList/DeviceSetList.test.tsx`
- Storybook smoke check for `Proto Fleet/HealthBar` docs at `http://localhost:6006/?path=/docs/proto-fleet-healthbar--docs` with no browser console errors.
