### PR TITLE
Add fleetnode manual UI test setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,6 @@ tests/
 
 server/e2e/
 server/testing/
-server/plugins/
 server/out/
 server/fake-antminer/
 server/docs/

--- a/justfile
+++ b/justfile
@@ -167,6 +167,87 @@ mqtt-sim-down:
 mqtt-sim-logs:
   just mqtt-sim-logs
 
+# start backend, an enrolled fleet node, isolated fake miners, and the ProtoFleet client for manual UI testing
+fleetnode-ui-test-up:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  just build-plugins-docker
+  cd server
+  COMPOSE=(docker compose -f docker-compose.yaml -f docker-compose.fleetnode-ui-test.yaml)
+  DEFAULT_FAKE_MINERS=(
+    fake-proto-rig
+    fake-antminer
+    fake-antminer-high-temp
+    fake-antminer-hw-errors
+    fake-antminer-board-dead
+    fake-antminer-pool-issues
+    fake-antminer-rejected-shares
+    proto-sim
+    antminer-sim
+  )
+  "${COMPOSE[@]}" stop "${DEFAULT_FAKE_MINERS[@]}" >/dev/null 2>&1 || true
+  "${COMPOSE[@]}" rm -f "${DEFAULT_FAKE_MINERS[@]}" >/dev/null 2>&1 || true
+  "${COMPOSE[@]}" up -d --build timescaledb fleet-api ui-test-proto-rig ui-test-antminer
+  for _ in $(seq 1 90); do
+    if curl -fsS \
+      -H 'Content-Type: application/json' \
+      -d '{}' \
+      http://localhost:4000/onboarding.v1.OnboardingService/GetFleetInitStatus >/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+  curl -fsS \
+    -H 'Content-Type: application/json' \
+    -d '{}' \
+    http://localhost:4000/onboarding.v1.OnboardingService/GetFleetInitStatus >/dev/null
+  "${COMPOSE[@]}" run --rm \
+    -e FLEET_ADMIN_USERNAME \
+    -e FLEET_ADMIN_PASSWORD \
+    --entrypoint /app/fleetnode-ui-test fleetnode-ui-test \
+    --api-url=http://fleet-api:4000 \
+    --node-server-url=http://fleet-api:4000 \
+    --state-dir=/state
+  "${COMPOSE[@]}" up -d --build fleetnode-ui-test
+  cd ../client
+  GIT_VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+  BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "development")
+  echo "ProtoFleet UI: http://localhost:5173"
+  echo "Fleet node UI-test services are running; use 'just fleetnode-ui-test-down' to stop them."
+  VITE_VERSION="$GIT_VERSION" \
+  VITE_BUILD_DATE="$BUILD_DATE" \
+  VITE_COMMIT="$GIT_COMMIT" \
+  VITE_NOTIFICATIONS_ENABLED=false \
+  npm run dev:protoFleet
+
+# follow logs for the fleetnode manual UI-test stack
+fleetnode-ui-test-logs:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd server
+  docker compose -f docker-compose.yaml -f docker-compose.fleetnode-ui-test.yaml logs -f \
+    fleet-api fleetnode-ui-test ui-test-proto-rig ui-test-antminer
+
+# stop the fleetnode manual UI-test stack
+fleetnode-ui-test-down:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd server
+  docker compose -f docker-compose.yaml -f docker-compose.fleetnode-ui-test.yaml down
+
+# remove fleetnode UI-test containers and fleetnode state for a clean re-enrollment
+fleetnode-ui-test-reset:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd server
+  COMPOSE=(docker compose -f docker-compose.yaml -f docker-compose.fleetnode-ui-test.yaml)
+  "${COMPOSE[@]}" stop fleetnode-ui-test ui-test-proto-rig ui-test-antminer || true
+  "${COMPOSE[@]}" rm -f fleetnode-ui-test ui-test-proto-rig ui-test-antminer || true
+  PROJECT="${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}"
+  docker volume rm "${PROJECT}_fleetnode-ui-test-state" >/dev/null 2>&1 || true
+  echo "Fleet node UI-test state reset."
+
 # --- Dependency management ---
 
 # update all Go dependencies across workspace

--- a/server/Dockerfile.fleetnode.dev
+++ b/server/Dockerfile.fleetnode.dev
@@ -1,0 +1,25 @@
+FROM golang:1.25.4-alpine AS build
+
+RUN apk add --no-cache git
+ENV GOWORK=off
+
+WORKDIR /src
+COPY . .
+
+WORKDIR /src/server
+RUN go build -o /out/fleetnode ./cmd/fleetnode \
+ && go build -o /out/fleetnode-ui-test ./devtools/fleetnodeuitest
+
+FROM alpine:3.22
+
+RUN apk add --no-cache ca-certificates nmap
+
+WORKDIR /app
+COPY --from=build /out/fleetnode /app/fleetnode
+COPY --from=build /out/fleetnode-ui-test /app/fleetnode-ui-test
+COPY server/plugins /app/plugins
+RUN chmod -R a+rX /app/plugins
+
+ENV PATH="/app:${PATH}"
+
+ENTRYPOINT ["/app/fleetnode"]

--- a/server/cmd/fleetnode/README.md
+++ b/server/cmd/fleetnode/README.md
@@ -48,6 +48,15 @@ When a server-issued `DiscoverRequest` arrives in `NmapModeRequest` form, the ag
 
 The target is validated against a strict grammar before invocation: bare IPv4/IPv6, CIDR, `A.B.C.D-N` range, or hostname. Leading dashes, whitespace, and shell metacharacters are rejected — this defends against a compromised server crafting a target like `-iL/etc/passwd` that nmap would otherwise interpret as a flag. See `validateNmapTarget` in [nmap.go](nmap.go).
 
+For automatic "local subnet" discovery commands, the server sends the reserved `fleetnode-local-subnet` target and the agent chooses what to scan. By default it detects the host's local private IPv4 subnet. On multi-NIC, NAT, or containerized hosts, set the subnet explicitly:
+
+```bash
+fleetnode run --local-discovery-subnet=10.90.0.0/24
+FLEETNODE_LOCAL_DISCOVERY_SUBNET=10.90.0.0/24 fleetnode run
+```
+
+The configured subnet is validated the same way as an auto-detected local subnet: it must be a private IPv4 CIDR and no broader than the supported nmap scan-size limit.
+
 ## Control stream
 
 `run` opens a bidirectional `ControlStream` over the gateway:
@@ -104,6 +113,14 @@ go test ./server/cmd/fleetnode -race -count=1
 ```
 
 [fake_gateway_test.go](fake_gateway_test.go) provides an in-process h2c gateway for handler tests. Pair the agent with a local server via `just dev` (see [server/README.md](../../README.md)).
+
+For manual end-to-end UI testing of fleet-node discovery and pairing, run from the repository root:
+
+```bash
+just fleetnode-ui-test-up
+```
+
+This starts the backend, isolated fake miners, an enrolled fleet node with `FLEETNODE_LOCAL_DISCOVERY_SUBNET=10.90.0.0/24`, and the ProtoFleet client. On a fresh dev database it creates `admin` / `Pass123!`; if your local database already has a different admin user, run with `FLEET_ADMIN_USERNAME` and `FLEET_ADMIN_PASSWORD` set. In the UI, use Fleet → Miners → Add miners → Scan network. The fake miners live on a Docker network that only the fleet node can reach, so the existing UI exercises the fleet-node routing path without cloud discovery competing for the same rows. Stop the stack with `just fleetnode-ui-test-down`; reset the fleetnode state with `just fleetnode-ui-test-reset`.
 
 ## Troubleshooting
 

--- a/server/cmd/fleetnode/nmap.go
+++ b/server/cmd/fleetnode/nmap.go
@@ -42,6 +42,9 @@ func (r *RunCmd) detectLocalSubnets() ([]string, error) {
 	if r.localSubnets != nil {
 		return r.localSubnets()
 	}
+	if configured := strings.TrimSpace(r.LocalDiscoverySubnet); configured != "" {
+		return []string{configured}, nil
+	}
 	info, err := networking.GetLocalNetworkInfo()
 	if err != nil {
 		return nil, fmt.Errorf("get local network info: %w", err)

--- a/server/cmd/fleetnode/nmap_test.go
+++ b/server/cmd/fleetnode/nmap_test.go
@@ -270,6 +270,26 @@ func TestBuildNmapOptions_LocalSubnetTarget_UsesDetectedCIDRs(t *testing.T) {
 	assert.False(t, slices.Contains(args, nmaptarget.LocalSubnetTarget), "sentinel must not reach nmap as a literal target: %v", args)
 }
 
+func TestBuildNmapOptions_LocalSubnetTarget_UsesConfiguredCIDR(t *testing.T) {
+	// Arrange: configured CIDR should take precedence over host detection.
+	r := &RunCmd{
+		nmapPath:             "/usr/bin/nmap",
+		discoverer:           &stubDiscoverer{},
+		LocalDiscoverySubnet: "10.90.0.0/24",
+	}
+	req := &pairingpb.NmapModeRequest{Target: nmaptarget.LocalSubnetTarget, Ports: []string{"4028"}}
+
+	// Act
+	opts, err := r.buildNmapOptions(context.Background(), req, req.Ports)
+	require.NoError(t, err)
+	scanner, err := nmap.NewScanner(context.Background(), opts...)
+	require.NoError(t, err)
+
+	// Assert
+	args := scanner.Args()
+	assert.True(t, slices.Contains(args, "10.90.0.0/24"), "expected configured subnet in argv: %v", args)
+}
+
 func TestBuildNmapOptions_LocalSubnetTarget_RejectsUnscannableSubnet(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -301,6 +321,24 @@ func TestBuildNmapOptions_LocalSubnetTarget_RejectsUnscannableSubnet(t *testing.
 			assert.Equal(t, pb.AckCode_ACK_CODE_AGENT_INCAPABLE, ce.code)
 		})
 	}
+}
+
+func TestBuildNmapOptions_LocalSubnetTarget_RejectsConfiguredUnscannableSubnet(t *testing.T) {
+	// Arrange
+	r := &RunCmd{
+		nmapPath:             "/usr/bin/nmap",
+		discoverer:           &stubDiscoverer{},
+		LocalDiscoverySubnet: "172.16.0.0/12",
+	}
+	req := &pairingpb.NmapModeRequest{Target: nmaptarget.LocalSubnetTarget, Ports: []string{"4028"}}
+
+	// Act
+	_, err := r.buildNmapOptions(context.Background(), req, req.Ports)
+
+	// Assert
+	var ce *commandError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, pb.AckCode_ACK_CODE_AGENT_INCAPABLE, ce.code)
 }
 
 func TestBuildNmapOptions_LocalSubnetTarget_NoSubnetIsAgentIncapable(t *testing.T) {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -25,7 +25,8 @@ const (
 )
 
 type RunCmd struct {
-	HeartbeatInterval time.Duration `name:"heartbeat-interval" default:"30s" help:"interval between UploadHeartbeat calls"`
+	HeartbeatInterval    time.Duration `name:"heartbeat-interval" default:"30s" help:"interval between UploadHeartbeat calls"`
+	LocalDiscoverySubnet string        `name:"local-discovery-subnet" env:"FLEETNODE_LOCAL_DISCOVERY_SUBNET" help:"CIDR to scan for automatic local-subnet discovery instead of detecting the host subnet"`
 
 	now           func() time.Time                                                         `kong:"-"`
 	clientFactory func(serverURL string, tokenSource func() string) (gatewayClient, error) `kong:"-"`

--- a/server/devtools/fleetnodeuitest/main.go
+++ b/server/devtools/fleetnodeuitest/main.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"connectrpc.com/connect"
+
+	authv1 "github.com/block/proto-fleet/server/generated/grpc/auth/v1"
+	"github.com/block/proto-fleet/server/generated/grpc/auth/v1/authv1connect"
+	fleetnodeadminv1 "github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetnodeadmin/v1/fleetnodeadminv1connect"
+	onboardingv1 "github.com/block/proto-fleet/server/generated/grpc/onboarding/v1"
+	"github.com/block/proto-fleet/server/generated/grpc/onboarding/v1/onboardingv1connect"
+	"github.com/block/proto-fleet/server/internal/fleetnode/bootstrap"
+)
+
+type config struct {
+	apiURL        string
+	nodeServerURL string
+	stateDir      string
+	nodeName      string
+	adminUsername string
+	adminPassword string
+	allowInsecure bool
+	timeout       time.Duration
+}
+
+type refreshFunc func(context.Context, *bootstrap.State) error
+
+func main() {
+	cfg := parseFlags()
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+
+	if err := ensureFleetNode(ctx, cfg); err != nil {
+		cancel()
+		fmt.Fprintf(os.Stderr, "fleetnode-ui-test enroll failed: %v\n", err)
+		os.Exit(1)
+	}
+	cancel()
+}
+
+func parseFlags() config {
+	cfg := config{}
+	flag.StringVar(&cfg.apiURL, "api-url", envOrDefault("FLEET_API_URL", "http://localhost:4000"), "Fleet API URL reachable by this helper")
+	flag.StringVar(&cfg.nodeServerURL, "node-server-url", envOrDefault("FLEETNODE_SERVER_URL", ""), "Fleet API URL persisted into fleetnode state")
+	flag.StringVar(&cfg.stateDir, "state-dir", envOrDefault("FLEETNODE_STATE_DIR", "/state"), "fleetnode state directory")
+	flag.StringVar(&cfg.nodeName, "node-name", envOrDefault("FLEETNODE_NAME", "ui-test-fleetnode"), "fleet node name")
+	flag.StringVar(&cfg.adminUsername, "admin-username", envOrDefault("FLEET_ADMIN_USERNAME", "admin"), "dev admin username")
+	flag.StringVar(&cfg.adminPassword, "admin-password", envOrDefault("FLEET_ADMIN_PASSWORD", "Pass123!"), "dev admin password")
+	flag.BoolVar(&cfg.allowInsecure, "allow-insecure-transport", envOrDefault("FLEETNODE_ALLOW_INSECURE_TRANSPORT", "true") == "true", "allow http:// fleetnode server URLs")
+	flag.DurationVar(&cfg.timeout, "timeout", 60*time.Second, "overall enrollment timeout")
+	flag.Parse()
+	if cfg.nodeServerURL == "" {
+		cfg.nodeServerURL = cfg.apiURL
+	}
+	return cfg
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func ensureFleetNode(ctx context.Context, cfg config) error {
+	reused, err := ensureUsableState(ctx, cfg.stateDir, cfg.apiURL, cfg.nodeServerURL, cfg.allowInsecure, bootstrap.Refresh)
+	if err != nil {
+		return err
+	}
+	if reused {
+		fmt.Printf("reusing enrolled fleet node state at %s\n", bootstrap.StatePath(cfg.stateDir))
+		return nil
+	}
+
+	cookie, err := ensureSessionCookie(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	adminClient := fleetnodeadminv1connect.NewFleetNodeAdminServiceClient(http.DefaultClient, cfg.apiURL)
+	if err := revokeExistingFleetNodesByName(ctx, adminClient, cookie, cfg.nodeName); err != nil {
+		return err
+	}
+
+	codeReq := connect.NewRequest(&fleetnodeadminv1.CreateEnrollmentCodeRequest{})
+	codeReq.Header().Set("Cookie", cookie)
+	codeResp, err := adminClient.CreateEnrollmentCode(ctx, codeReq)
+	if err != nil {
+		return fmt.Errorf("create enrollment code: %w", err)
+	}
+
+	result, err := bootstrap.Register(ctx, bootstrap.RegisterParams{
+		ServerURL:              cfg.apiURL,
+		Name:                   cfg.nodeName,
+		Code:                   codeResp.Msg.GetCode(),
+		AllowInsecureTransport: cfg.allowInsecure,
+	})
+	if err != nil {
+		return fmt.Errorf("register fleet node: %w", err)
+	}
+
+	confirmReq := connect.NewRequest(&fleetnodeadminv1.ConfirmFleetNodeRequest{
+		FleetNodeId: result.State.FleetNodeID,
+	})
+	confirmReq.Header().Set("Cookie", cookie)
+	confirmResp, err := adminClient.ConfirmFleetNode(ctx, confirmReq)
+	if err != nil {
+		return fmt.Errorf("confirm fleet node: %w", err)
+	}
+
+	if err := bootstrap.CompleteEnrollment(ctx, result.State, confirmResp.Msg.GetApiKey()); err != nil {
+		return fmt.Errorf("complete fleet node enrollment: %w", err)
+	}
+
+	result.State.ServerURL = cfg.nodeServerURL
+	result.State.AllowInsecureTransport = cfg.allowInsecure
+	if err := bootstrap.SaveState(bootstrap.StatePath(cfg.stateDir), result.State); err != nil {
+		return fmt.Errorf("save fleet node state: %w", err)
+	}
+	fmt.Printf("enrolled fleet_node_id=%d name=%q state=%s\n", result.State.FleetNodeID, cfg.nodeName, bootstrap.StatePath(cfg.stateDir))
+	return nil
+}
+
+func revokeExistingFleetNodesByName(ctx context.Context, adminClient fleetnodeadminv1connect.FleetNodeAdminServiceClient, cookie, nodeName string) error {
+	listReq := connect.NewRequest(&fleetnodeadminv1.ListFleetNodesRequest{})
+	listReq.Header().Set("Cookie", cookie)
+	listResp, err := adminClient.ListFleetNodes(ctx, listReq)
+	if err != nil {
+		return fmt.Errorf("list fleet nodes before enrollment: %w", err)
+	}
+
+	for _, node := range listResp.Msg.GetFleetNodes() {
+		if node.GetName() != nodeName || node.GetEnrollmentStatus() == fleetnodeadminv1.FleetNodeEnrollmentStatus_FLEET_NODE_ENROLLMENT_STATUS_REVOKED {
+			continue
+		}
+		revokeReq := connect.NewRequest(&fleetnodeadminv1.RevokeFleetNodeRequest{
+			FleetNodeId: node.GetFleetNodeId(),
+		})
+		revokeReq.Header().Set("Cookie", cookie)
+		if _, err := adminClient.RevokeFleetNode(ctx, revokeReq); err != nil {
+			return fmt.Errorf("revoke existing fleet node %d (%q): %w", node.GetFleetNodeId(), nodeName, err)
+		}
+		fmt.Printf("revoked existing fleet_node_id=%d name=%q before re-enrollment\n", node.GetFleetNodeId(), nodeName)
+	}
+	return nil
+}
+
+func ensureUsableState(ctx context.Context, stateDir, apiURL, nodeServerURL string, allowInsecure bool, refresh refreshFunc) (bool, error) {
+	statePath := bootstrap.StatePath(stateDir)
+	st, exists, err := bootstrap.LoadState(statePath)
+	if err != nil {
+		return false, err
+	}
+	if !exists || st.FleetNodeID == 0 || st.APIKey == "" {
+		return false, nil
+	}
+
+	candidate := *st
+	candidate.ServerURL = apiURL
+	candidate.AllowInsecureTransport = allowInsecure
+	stateReusable := refresh(ctx, &candidate) == nil
+	if !stateReusable {
+		return false, nil
+	}
+
+	candidate.ServerURL = nodeServerURL
+	candidate.AllowInsecureTransport = allowInsecure
+	if err := bootstrap.SaveState(statePath, &candidate); err != nil {
+		return false, fmt.Errorf("save refreshed fleet node state: %w", err)
+	}
+	return true, nil
+}
+
+func ensureSessionCookie(ctx context.Context, cfg config) (string, error) {
+	onboardingClient := onboardingv1connect.NewOnboardingServiceClient(http.DefaultClient, cfg.apiURL)
+	initResp, err := onboardingClient.GetFleetInitStatus(ctx, connect.NewRequest(&onboardingv1.GetFleetInitStatusRequest{}))
+	if err != nil {
+		return "", fmt.Errorf("get fleet init status: %w", err)
+	}
+	if initResp.Msg.GetStatus() == nil || !initResp.Msg.GetStatus().GetAdminCreated() {
+		_, err := onboardingClient.CreateAdminLogin(ctx, connect.NewRequest(&onboardingv1.CreateAdminLoginRequest{
+			Username: cfg.adminUsername,
+			Password: cfg.adminPassword,
+		}))
+		if err != nil {
+			return "", fmt.Errorf("create admin login: %w", err)
+		}
+	}
+
+	authClient := authv1connect.NewAuthServiceClient(http.DefaultClient, cfg.apiURL)
+	authResp, err := authClient.Authenticate(ctx, connect.NewRequest(&authv1.AuthenticateRequest{
+		Username: cfg.adminUsername,
+		Password: cfg.adminPassword,
+	}))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeUnauthenticated {
+			return "", fmt.Errorf("authenticate admin %q: %w. If this dev database already has an admin, rerun with FLEET_ADMIN_USERNAME and FLEET_ADMIN_PASSWORD set to that user's credentials, or reset the dev database before using the default admin credentials", cfg.adminUsername, err)
+		}
+		return "", fmt.Errorf("authenticate admin: %w", err)
+	}
+	rawCookie := authResp.Header().Get("Set-Cookie")
+	if rawCookie == "" {
+		return "", fmt.Errorf("authenticate admin: missing Set-Cookie header")
+	}
+	cookie, err := http.ParseSetCookie(rawCookie)
+	if err != nil {
+		return "", fmt.Errorf("parse session cookie: %w", err)
+	}
+	return fmt.Sprintf("%s=%s", cookie.Name, cookie.Value), nil
+}

--- a/server/docker-compose.fleetnode-ui-test.yaml
+++ b/server/docker-compose.fleetnode-ui-test.yaml
@@ -1,0 +1,88 @@
+services:
+  fleet-api:
+    platform: linux/arm64
+    ports: !override
+      - "127.0.0.1:4000:4000"
+
+  fleetnode-ui-test:
+    platform: linux/arm64
+    build:
+      context: ..
+      dockerfile: server/Dockerfile.fleetnode.dev
+    command: ["--state-dir=/state", "run"]
+    environment:
+      FLEETNODE_LOCAL_DISCOVERY_SUBNET: "10.90.0.0/24"
+      PROTO_MINER_PORT: "8080"
+    volumes:
+      - fleetnode-ui-test-state:/state
+    depends_on:
+      - fleet-api
+      - ui-test-proto-rig
+      - ui-test-antminer
+    networks:
+      - fleet-network
+      - fleetnode-miner-network
+    restart: unless-stopped
+
+  ui-test-proto-rig:
+    build:
+      context: ..
+      dockerfile: server/fake-proto-rig/Dockerfile
+    environment:
+      HTTP_PORT: "8080"
+      SERIAL_NUMBER: "UI-TEST-PROTO-001"
+      FAKE_RIG_PASSWORD: "proto"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    expose:
+      - 8080
+    networks:
+      fleetnode-miner-network:
+        ipv4_address: 10.90.0.10
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+
+  ui-test-antminer:
+    build:
+      context: ./fake-antminer
+      dockerfile: Dockerfile
+    environment:
+      MINER_TYPE: "Antminer S19 UI Test"
+      SERIAL_NUMBER: "UI-TEST-ANTMINER-001"
+      MAC_ADDRESS: "02:42:0a:5a:00:20"
+      FIRMWARE_VERSION: "Antminer S19 XP 140Th 15/01/2023 10:30:25"
+      IP_ADDRESS: "10.90.0.20"
+      GATEWAY: "10.90.0.1"
+      DNS_SERVERS: ""
+      USERNAME: "root"
+      PASSWORD: "root"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:80/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    expose:
+      - 4028
+      - 80
+    networks:
+      fleetnode-miner-network:
+        ipv4_address: 10.90.0.20
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+
+volumes:
+  fleetnode-ui-test-state:
+
+networks:
+  fleetnode-miner-network:
+    driver: bridge
+    internal: true
+    ipam:
+      config:
+        - subnet: "10.90.0.0/24"
+          gateway: "10.90.0.1"

--- a/server/fake-antminer/main.go
+++ b/server/fake-antminer/main.go
@@ -37,11 +37,11 @@ func main() {
 		SerialNumber:    serialNumber,
 		MacAddress:      macAddress,
 		FirmwareVersion: firmwareVersion,
-		IPAddress:       getOutboundIP().String(),
+		IPAddress:       getIPAddr(),
 		Hostname:        "antminer-" + serialNumber,
-		NetMask:         "255.255.255.0",
-		Gateway:         "192.168.2.1",
-		DNSServers:      "8.8.8.8",
+		NetMask:         getEnv("NETMASK", "255.255.255.0"),
+		Gateway:         getEnv("GATEWAY", "192.168.2.1"),
+		DNSServers:      getEnvAllowEmpty("DNS_SERVERS", "8.8.8.8"),
 		HashRate:        110.0,
 		Temperature:     45.0,
 		Pools: []Pool{
@@ -211,6 +211,13 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
+func getEnvAllowEmpty(key, fallback string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return fallback
+}
+
 // validateConfig validates the configuration parameters
 func validateConfig(minerType, serialNumber, macAddress string) error {
 	if minerType == "" {
@@ -229,16 +236,39 @@ func validateConfig(minerType, serialNumber, macAddress string) error {
 	return nil
 }
 
-// getOutboundIP gets the preferred outbound IP of this machine
+func getIPAddr() string {
+	if ip := getEnv("IP_ADDRESS", ""); ip != "" {
+		return ip
+	}
+	return getOutboundIP().String()
+}
+
+// getOutboundIP gets the preferred outbound IP of this machine.
+// If the container has no outbound route, fall back to the first non-loopback
+// IPv4 address so fake miners can run on internal-only Docker networks.
 func getOutboundIP() net.IP {
 	conn, err := net.Dial("udp", "8.8.8.8:80")
-	if err != nil {
-		log.Fatal(err)
+	if err == nil {
+		defer conn.Close()
+		localAddr := conn.LocalAddr().(*net.UDPAddr)
+		return localAddr.IP
 	}
-	defer conn.Close()
 
-	localAddr := conn.LocalAddr().(*net.UDPAddr)
-	return localAddr.IP
+	addrs, addrErr := net.InterfaceAddrs()
+	if addrErr != nil {
+		log.Fatalf("failed to determine local IP after outbound probe failed: %v", addrErr)
+	}
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || ipNet.IP.IsLoopback() {
+			continue
+		}
+		if ip := ipNet.IP.To4(); ip != nil {
+			return ip
+		}
+	}
+	log.Fatalf("failed to determine local IP after outbound probe failed: %v", err)
+	return nil
 }
 
 // Helper function to generate a standardized error response


### PR DESCRIPTION
Reviewable diff: +432/-11 across 8 files (excludes generated, test, and story files).

## Summary

This PR gives developers a one-command manual test setup for the real ProtoFleet miner discovery and pairing flow through a connected fleet node. It starts isolated fake miners that only the fleet node can reach, enrolls or reuses a local fleet-node state volume, and launches the existing ProtoFleet UI so reviewers can test Add miners / authenticate miners exactly as an operator would.

The fleet node local-subnet override is also promoted to a supported runtime feature for multi-NIC, NAT, and containerized hosts instead of remaining an ad hoc test seam.

## How it works

A developer runs `just fleetnode-ui-test-up` from the repository root. The recipe builds the existing Docker plugin artifacts, starts the backend plus fake miners, waits for the API to accept onboarding calls, runs a helper container that creates or reuses an enrolled fleet-node state file, starts the fleet node daemon, then runs `npm run dev:protoFleet` in the foreground.

The compose overlay creates a miner-only Docker network at `10.90.0.0/24`. The UI-test fleet node is attached to both the normal server network and the miner-only network, while `fleet-api` stays off the miner network. When the UI triggers network scan or pairing through the existing flow, the backend routes fleet-node-discovered targets through the connected node; cloud discovery cannot independently see those isolated miners.

For runtime discovery, `fleetnode run` now accepts `--local-discovery-subnet`, `FLEETNODE_LOCAL_DISCOVERY_SUBNET`, or YAML config. When the server sends the `fleetnode-local-subnet` sentinel, the agent scans the configured CIDR if present, otherwise it keeps the existing host subnet auto-detection behavior. The configured CIDR uses the same private IPv4 and maximum scan-size validation as detected subnets.

## Diagrams

```mermaid
flowchart TD
  Dev["Developer runs just fleetnode-ui-test-up"] --> Compose["Compose starts backend and isolated fake miners"]
  Compose --> Helper["Enrollment helper creates or reuses /state/state.yaml"]
  Helper --> Node["fleetnode-ui-test runs fleetnode daemon"]
  Node --> Control["Fleet node connects to fleet-api ControlStream"]
  Dev --> UI["Developer uses existing ProtoFleet Add miners flow"]
  UI --> API["fleet-api receives scan or pair request"]
  API --> Control
  Control --> Node
  Node --> Miners["Fake miners on 10.90.0.0/24 miner-only network"]
  Miners --> Node
  Node --> API
  API --> UI
```

```mermaid
flowchart LR
  API["fleet-api linux/arm64 on fleet-network only"] --> ServerNet["fleet-network"]
  Node["fleetnode-ui-test linux/arm64"] --> ServerNet
  Node --> MinerNet["fleetnode-miner-network 10.90.0.0/24"]
  Proto["ui-test-proto-rig :8080"] --> MinerNet
  Antminer["ui-test-antminer :80/:4028"] --> MinerNet
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/cmd/fleetnode/run.go`, `server/cmd/fleetnode/nmap.go` | Adds the local-discovery subnet runtime option and uses it for the `fleetnode-local-subnet` sentinel before falling back to auto-detection. | This is the production-facing behavior and validation boundary for the new operator feature. |
| `server/cmd/fleetnode/README.md` | Documents the subnet override and the manual UI test workflow. | Reviewers can check that the feature is described as an operator tool, not a test-only hack. |
| `server/devtools/fleetnodeuitest/` | Adds an idempotent helper that creates an admin session, enrolls/confirms/completes the fleet node, or refreshes existing usable state. | This is test-only scaffolding for local manual validation, so it intentionally has no unit tests. |
| `server/docker-compose.fleetnode-ui-test.yaml` | Adds the dual-network fleet node and miner-only fake miner topology, sets `PROTO_MINER_PORT=8080` for node-side Proto discovery, pins plugin-loading services to `linux/arm64`, and pins fake miner network metadata. | This prevents cloud discovery from competing with fleet-node discovery while keeping the plugin binaries and plugin-loading containers on the same architecture. |
| `server/fake-antminer/main.go` | Allows fake Antminer network identity to come from env and falls back to interface inspection when outbound IP probing is unavailable. | The fake Antminer can now boot on internal-only Docker networks, where dialing `8.8.8.8` is intentionally impossible. |
| `server/Dockerfile.fleetnode.dev` | Builds a dev image containing both `fleetnode` and the UI-test enrollment helper, with `nmap` installed. | The daemon and helper run in the same compose service/volume shape the test setup depends on. |
| `justfile` | Adds `fleetnode-ui-test-up`, `fleetnode-ui-test-logs`, `fleetnode-ui-test-down`, and `fleetnode-ui-test-reset`, and passes existing dev admin creds into the helper. | This is the developer entry point and cleanup surface for the manual test flow. |
| `server/cmd/fleetnode/nmap_test.go` | Covers subnet override behavior and validation rejection for the supported runtime option. | These tests protect production-facing scan target behavior while avoiding tests for the local test harness. |

## Key technical decisions & trade-offs

- The UI remains mechanism-agnostic: the existing Add miners and authentication flows are reused instead of adding fleet-node-specific UI.
- The subnet override is supported through CLI, env, and config rather than only compose wiring, because multi-NIC/NAT/container hosts need the same control outside local testing.
- `fleet-api` is intentionally kept off the miner-only network instead of disabling cloud discovery in code, so the manual setup validates the routing boundary with network isolation.
- Enrollment is handled by a dev helper over existing onboarding/admin/bootstrap RPCs rather than new production APIs.
- Fake miners are configured to run on an internal-only network, including ports and self-reported network identity, so the manual harness tests fleet-node reachability instead of accidental host/cloud reachability.
- The plugin-loading UI-test services are pinned to `linux/arm64` to match the existing `build-plugins-docker` output; this is the smallest fix, with amd64 Docker hosts relying on emulation instead of adding a new arch-aware plugin build path in this PR.
- `fleetnode-ui-test-up` leaves backend services running after the foreground client exits; explicit `down` and `reset` commands make teardown and state reset deliberate.

## Testing & validation

- `go test ./cmd/fleetnode ./internal/domain/fleetnode/discovery`
- `GOWORK=off go test ./...` from `server/fake-antminer`
- `docker compose -f docker-compose.yaml -f docker-compose.fleetnode-ui-test.yaml config`
- Rendered compose config includes `platform: linux/arm64` for `fleet-api` and `fleetnode-ui-test`.
- `docker compose -f docker-compose.yaml -f docker-compose.fleetnode-ui-test.yaml up -d --build --force-recreate ui-test-antminer fleetnode-ui-test`
- From inside `fleetnode-ui-test`, verified `nmap -p 4028,80,8080 10.90.0.10 10.90.0.20` sees Proto on `8080` and Antminer on `80`/`4028`.
- `just --dry-run fleetnode-ui-test-up`
- `just --dry-run fleetnode-ui-test-reset`

Not run successfully: `golangci-lint run -c .golangci.yaml ./cmd/fleetnode ./devtools/fleetnodeuitest` exits before linting because the local `golangci-lint` binary does not recognize the configured `modernize` linter.
