### PR TITLE
Add site detail building summary grid

### DIFF
--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.stories.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.stories.tsx
@@ -1,0 +1,342 @@
+import { useEffect } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { create } from "@bufbuild/protobuf";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import SiteDetailPage from "./SiteDetailPage";
+import { buildingsClient, sitesClient } from "@/protoFleet/api/clients";
+import {
+  BuildingSchema,
+  BuildingWithCountsSchema,
+  type GetBuildingStatsResponse,
+  GetBuildingStatsResponseSchema,
+  ListBuildingsResponseSchema,
+} from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import {
+  GetSiteStatsResponseSchema,
+  ListSitesResponseSchema,
+  SiteSchema,
+  SiteWithCountsSchema,
+} from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { useFleetStore } from "@/protoFleet/store";
+
+const SITE_ID = 1n;
+
+interface BuildingFixture {
+  id: number;
+  name: string;
+  rackCount: number;
+  deviceCount: number;
+  hashingCount: number;
+  brokenCount: number;
+  offlineCount: number;
+  sleepingCount: number;
+  powerKw?: number;
+}
+
+interface SiteDetailScenario {
+  name: string;
+  city: string;
+  state: string;
+  address: string;
+  postalCode: string;
+  powerCapacityMw: number;
+  buildings: BuildingFixture[];
+}
+
+type ScenarioKey = "mixed" | "single" | "dense" | "longNames" | "empty";
+
+interface SiteDetailStoryProps {
+  scenario: ScenarioKey;
+  frameClassName?: string;
+}
+
+const mixedBuildings: BuildingFixture[] = [
+  {
+    id: 101,
+    name: "Building Alpha",
+    rackCount: 24,
+    deviceCount: 1728,
+    hashingCount: 1694,
+    brokenCount: 12,
+    offlineCount: 6,
+    sleepingCount: 16,
+    powerKw: 12_000,
+  },
+  {
+    id: 102,
+    name: "Building Beta",
+    rackCount: 20,
+    deviceCount: 1440,
+    hashingCount: 1280,
+    brokenCount: 82,
+    offlineCount: 38,
+    sleepingCount: 40,
+    powerKw: 10_500,
+  },
+  {
+    id: 103,
+    name: "Immersion Hall C",
+    rackCount: 18,
+    deviceCount: 1296,
+    hashingCount: 1128,
+    brokenCount: 42,
+    offlineCount: 18,
+    sleepingCount: 108,
+    powerKw: 14_000,
+  },
+  {
+    id: 104,
+    name: "Building Delta",
+    rackCount: 18,
+    deviceCount: 1296,
+    hashingCount: 1296,
+    brokenCount: 0,
+    offlineCount: 0,
+    sleepingCount: 0,
+    powerKw: 8_500,
+  },
+];
+
+const denseBuildings: BuildingFixture[] = Array.from({ length: 18 }, (_, index) => {
+  const id = 201 + index;
+  const deviceCount = 960 + (index % 4) * 120;
+  const brokenCount = index % 5 === 0 ? 56 : index % 3 === 0 ? 18 : 4;
+  const offlineCount = index % 6 === 0 ? 34 : index % 4 === 0 ? 12 : 0;
+  const sleepingCount = index % 7 === 0 ? 84 : index % 2 === 0 ? 24 : 8;
+  return {
+    id,
+    name: `Building ${String.fromCharCode(65 + index)}`,
+    rackCount: 12 + (index % 5),
+    deviceCount,
+    hashingCount: Math.max(deviceCount - brokenCount - offlineCount - sleepingCount, 0),
+    brokenCount,
+    offlineCount,
+    sleepingCount,
+    powerKw: 6_800 + index * 220,
+  };
+});
+
+const longNameBuildings: BuildingFixture[] = [
+  "Northwest Immersion Conversion Hall - Phase 2",
+  "Building Alpha West Wing Auxiliary Power Room",
+  "Temporary Container Yard 4 - South Fence Line",
+  "High-Density Air-Cooled Expansion Building",
+  "Legacy Miners Rework and Burn-In Facility",
+  "Operations Spares and Quarantine Hall",
+].map((name, index) => ({
+  id: 301 + index,
+  name,
+  rackCount: 10 + index,
+  deviceCount: 720 + index * 96,
+  hashingCount: 680 + index * 72,
+  brokenCount: index % 2 === 0 ? 16 : 3,
+  offlineCount: index % 3 === 0 ? 22 : 0,
+  sleepingCount: index % 2 === 1 ? 46 : 8,
+  powerKw: 5_400 + index * 530,
+}));
+
+const SCENARIOS: Record<ScenarioKey, SiteDetailScenario> = {
+  mixed: {
+    name: "Austin North",
+    city: "Austin",
+    state: "TX",
+    address: "4100 Metric Blvd",
+    postalCode: "78758",
+    powerCapacityMw: 48,
+    buildings: mixedBuildings,
+  },
+  single: {
+    name: "Austin Single Hall",
+    city: "Austin",
+    state: "TX",
+    address: "4100 Metric Blvd",
+    postalCode: "78758",
+    powerCapacityMw: 16,
+    buildings: [mixedBuildings[0]],
+  },
+  dense: {
+    name: "Austin Dense Site",
+    city: "Austin",
+    state: "TX",
+    address: "4100 Metric Blvd",
+    postalCode: "78758",
+    powerCapacityMw: 120,
+    buildings: denseBuildings,
+  },
+  longNames: {
+    name: "Reno Expansion Yard",
+    city: "Reno",
+    state: "NV",
+    address: "1190 Industrial Way",
+    postalCode: "89502",
+    powerCapacityMw: 64,
+    buildings: longNameBuildings,
+  },
+  empty: {
+    name: "Austin Empty Site",
+    city: "Austin",
+    state: "TX",
+    address: "4100 Metric Blvd",
+    postalCode: "78758",
+    powerCapacityMw: 20,
+    buildings: [],
+  },
+};
+
+const makeBuilding = (fixture: BuildingFixture) =>
+  create(BuildingWithCountsSchema, {
+    building: create(BuildingSchema, {
+      id: BigInt(fixture.id),
+      siteId: SITE_ID,
+      name: fixture.name,
+      aisles: 4,
+      racksPerAisle: Math.ceil(fixture.rackCount / 4),
+      powerKw: fixture.powerKw ?? 0,
+    }),
+    rackCount: BigInt(fixture.rackCount),
+    deviceCount: BigInt(fixture.deviceCount),
+  });
+
+const makeBuildingStats = (fixture: BuildingFixture): GetBuildingStatsResponse =>
+  create(GetBuildingStatsResponseSchema, {
+    buildingId: BigInt(fixture.id),
+    rackCount: fixture.rackCount,
+    deviceCount: fixture.deviceCount,
+    reportingCount: fixture.deviceCount,
+    hashingCount: fixture.hashingCount,
+    brokenCount: fixture.brokenCount,
+    offlineCount: fixture.offlineCount,
+    sleepingCount: fixture.sleepingCount,
+  });
+
+const sum = (buildings: BuildingFixture[], selector: (building: BuildingFixture) => number) =>
+  buildings.reduce((total, building) => total + selector(building), 0);
+
+const installMocks = (scenario: SiteDetailScenario) => {
+  const siteBuildings = scenario.buildings.map(makeBuilding);
+  const buildingStatsById = new Map(
+    scenario.buildings.map((building) => [String(building.id), makeBuildingStats(building)]),
+  );
+  const deviceCount = sum(scenario.buildings, (building) => building.deviceCount);
+  const rackCount = sum(scenario.buildings, (building) => building.rackCount);
+  const hashingCount = sum(scenario.buildings, (building) => building.hashingCount);
+  const brokenCount = sum(scenario.buildings, (building) => building.brokenCount);
+  const offlineCount = sum(scenario.buildings, (building) => building.offlineCount);
+  const sleepingCount = sum(scenario.buildings, (building) => building.sleepingCount);
+  const totalPowerKw = sum(scenario.buildings, (building) => building.powerKw ?? 0);
+
+  const site = create(SiteWithCountsSchema, {
+    site: create(SiteSchema, {
+      id: SITE_ID,
+      name: scenario.name,
+      locationCity: scenario.city,
+      locationState: scenario.state,
+      address: scenario.address,
+      postalCode: scenario.postalCode,
+      country: "US",
+      powerCapacityMw: scenario.powerCapacityMw,
+    }),
+    buildingCount: BigInt(scenario.buildings.length),
+    rackCount: BigInt(rackCount),
+    deviceCount: BigInt(deviceCount),
+  });
+
+  useFleetStore.setState((state) => {
+    state.auth.permissions = ["site:read", "site:manage"];
+    state.auth.authLoading = false;
+    state.auth.isAuthenticated = true;
+    state.ui.activeSite = { kind: "site", id: SITE_ID.toString() };
+  });
+
+  (sitesClient as any).listSites = async () => create(ListSitesResponseSchema, { sites: [site] });
+  (sitesClient as any).getSiteStats = async () =>
+    create(GetSiteStatsResponseSchema, {
+      siteId: SITE_ID,
+      buildingCount: scenario.buildings.length,
+      rackCount,
+      deviceCount,
+      reportingCount: deviceCount,
+      totalHashrateThs: hashingCount * 95,
+      totalPowerKw,
+      avgEfficiencyJth: deviceCount > 0 ? 27.9 : 0,
+      hashingCount,
+      brokenCount,
+      offlineCount,
+      sleepingCount,
+      hashrateReportingCount: deviceCount,
+      efficiencyReportingCount: deviceCount,
+      powerReportingCount: deviceCount,
+    });
+  (buildingsClient as any).listBuildings = async () =>
+    create(ListBuildingsResponseSchema, { buildings: siteBuildings });
+  (buildingsClient as any).getBuildingStats = async ({ buildingId }: { buildingId: bigint }) =>
+    buildingStatsById.get(buildingId.toString()) ?? create(GetBuildingStatsResponseSchema, { buildingId });
+};
+
+const SiteDetailStory = ({ scenario = "mixed", frameClassName }: SiteDetailStoryProps) => {
+  const selectedScenario = SCENARIOS[scenario];
+  installMocks(selectedScenario);
+
+  useEffect(() => {
+    installMocks(selectedScenario);
+  }, [selectedScenario]);
+
+  const story = (
+    <MemoryRouter initialEntries={[`/sites/${SITE_ID.toString()}`]}>
+      <Routes>
+        <Route path="/sites/:id" element={<SiteDetailPage />} />
+        <Route path="/buildings/:id" element={<div className="p-10 text-300">Building detail route</div>} />
+        <Route path="/fleet" element={<div className="p-10 text-300">Fleet route</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  return frameClassName ? <div className={frameClassName}>{story}</div> : story;
+};
+
+const meta: Meta<typeof SiteDetailStory> = {
+  title: "Proto Fleet/Sites/SiteDetailPage",
+  component: SiteDetailStory,
+  parameters: {
+    layout: "fullscreen",
+    withRouter: false,
+  },
+  argTypes: {
+    frameClassName: { table: { disable: true } },
+    scenario: {
+      control: "radio",
+      options: ["mixed", "single", "dense", "longNames", "empty"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SiteDetailStory>;
+
+export const Default: Story = {
+  args: { scenario: "mixed" },
+};
+
+export const SingleBuilding: Story = {
+  args: { scenario: "single" },
+};
+
+export const DenseBuildingSet: Story = {
+  args: { scenario: "dense" },
+};
+
+export const LongBuildingNames: Story = {
+  args: { scenario: "longNames" },
+};
+
+export const EmptySite: Story = {
+  args: { scenario: "empty" },
+};
+
+export const NarrowWidth: Story = {
+  args: {
+    scenario: "dense",
+    frameClassName: "mx-auto min-h-screen max-w-[560px] border-x border-border-5 bg-surface-5",
+  },
+};

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -3,10 +3,13 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import SiteModals from "../components/SiteModals";
 import { useSiteModals } from "../hooks/useSiteModals";
+import { useBuildings } from "@/protoFleet/api/buildings";
+import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { buildKnownSiteIds, parseBigIntId, useSites } from "@/protoFleet/api/sites";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import BuildingModals from "@/protoFleet/features/buildings/components/BuildingModals";
+import BuildingSummaryCard from "@/protoFleet/features/buildings/components/BuildingSummaryCard";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
 import { formatSiteAddress } from "@/protoFleet/features/sites/formatAddress";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
@@ -23,9 +26,12 @@ const SiteDetailPage = () => {
   const targetId = idParam ?? "";
 
   const { listSites } = useSites();
+  const { listBuildingsBySite } = useBuildings();
   const [sites, setSites] = useState<SiteWithCounts[] | undefined>(undefined);
   const [sitesLoaded, setSitesLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [buildings, setBuildings] = useState<{ siteId: string; rows: BuildingWithCounts[] } | undefined>(undefined);
+  const [buildingsError, setBuildingsError] = useState<{ siteId: string; message: string } | null>(null);
 
   const fetchSites = useCallback(() => {
     const controller = new AbortController();
@@ -45,6 +51,29 @@ const SiteDetailPage = () => {
     });
     return () => controller.abort();
   }, [listSites]);
+
+  const fetchBuildings = useCallback(
+    (siteId: bigint) => {
+      const siteIdText = siteId.toString();
+      const controller = new AbortController();
+      void listBuildingsBySite({
+        siteId,
+        signal: controller.signal,
+        onSuccess: (rows) => {
+          setBuildings({ siteId: siteIdText, rows });
+          setBuildingsError(null);
+        },
+        onError: (msg) => {
+          setBuildingsError({ siteId: siteIdText, message: msg });
+          // Keep any last-good building rows visible through transient
+          // refresh failures, matching the site detail refresh behavior.
+          setBuildings((prev) => (prev?.siteId === siteIdText ? prev : { siteId: siteIdText, rows: [] }));
+        },
+      });
+      return () => controller.abort();
+    },
+    [listBuildingsBySite],
+  );
 
   // Bump retryCounter to re-run the effect so the cleanup AbortController
   // stays owned by useEffect and isn't leaked by an imperative call.
@@ -79,6 +108,16 @@ const SiteDetailPage = () => {
   // the same refresh signal used for direct building mutations.
   const modals = useSiteModals({ refetchSites: fetchSites, refetchBuildings });
   const buildingModals = useBuildingModals({ refetchBuildings });
+
+  const siteId = site?.site?.id;
+  const siteIdText = siteId?.toString();
+  const visibleBuildings = buildings && buildings.siteId === siteIdText ? buildings.rows : undefined;
+  const visibleBuildingsError = buildingsError && buildingsError.siteId === siteIdText ? buildingsError.message : null;
+
+  useEffect(() => {
+    if (siteId === undefined) return undefined;
+    return fetchBuildings(siteId);
+  }, [fetchBuildings, siteId, buildingsRefreshKey]);
 
   if (sites === undefined) {
     return (
@@ -165,7 +204,39 @@ const SiteDetailPage = () => {
               />
             ) : null}
           </div>
-          <PlaceholderBlock label="Buildings grid — coming soon" className="h-40" />
+          {visibleBuildingsError ? (
+            <Callout
+              intent="danger"
+              prefixIcon={<Alert />}
+              title="Couldn't load buildings"
+              subtitle={visibleBuildingsError}
+              buttonText="Retry"
+              buttonOnClick={() => {
+                if (site.site) setBuildingsRefreshKey((n) => n + 1);
+              }}
+              testId="site-detail-buildings-error"
+            />
+          ) : null}
+          <div className="rounded-[24px] border border-border-5 bg-surface-base p-6 shadow-300 tablet:p-8 laptop:p-10">
+            {visibleBuildings === undefined ? (
+              <div className="text-200 text-text-primary-50">Loading buildings…</div>
+            ) : visibleBuildings.length === 0 ? (
+              <div
+                className="rounded-2xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
+                data-testid="site-detail-buildings-empty"
+              >
+                No buildings in this site yet.
+              </div>
+            ) : (
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(12rem,1fr))] gap-4">
+                {visibleBuildings.map((building) => (
+                  <div key={(building.building?.id ?? 0n).toString()} className="min-w-0">
+                    <BuildingSummaryCard building={building} />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
       <SiteModals modals={modals} sites={sites} buildingsRefreshKey={buildingsRefreshKey} />

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -190,7 +190,6 @@ const SiteDetailPage = () => {
           ) : null}
         </div>
         <PlaceholderBlock label="Metrics row — coming soon" className="h-20" />
-        <PlaceholderBlock label="Details table — coming soon" className="h-40" />
         <div className="flex flex-col gap-4">
           <div className="flex items-center justify-between">
             <Header title="Buildings" titleSize="text-heading-200" />
@@ -238,6 +237,7 @@ const SiteDetailPage = () => {
             )}
           </div>
         </div>
+        <PlaceholderBlock label="Details table — coming soon" className="h-40" />
       </div>
       <SiteModals modals={modals} sites={sites} buildingsRefreshKey={buildingsRefreshKey} />
       <BuildingModals modals={buildingModals} sites={sites} />


### PR DESCRIPTION
## Summary

- Populate the site detail buildings module with child `BuildingSummaryCard` tiles.
- Wrap the module in the rounded panel container and use normalized auto-fill grid tracks.
- Add SiteDetailPage Storybook variants for default, single, dense, long-name, empty, and narrow-width states.

## Test Plan

- `npm run lint`
- `npx tsc --noEmit`
