### PR TITLE
Multi-site UI hardening: optional rack zone, tab null states, create-new parent flows

### DIFF
--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -30,10 +30,6 @@ export class RacksPage extends BasePage {
     await this.page.locator("#rack-label").fill(label);
   }
 
-  async getGeneratedRackLabel(): Promise<string> {
-    return await this.page.locator("#rack-label").inputValue();
-  }
-
   async enableCustomRackLayout() {
     const columnsInput = this.page.locator("#rack-columns");
     if (!(await columnsInput.isDisabled())) {

--- a/client/e2eTests/protoFleet/spec/racks.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racks.spec.ts
@@ -686,6 +686,7 @@ test.describe("Racks", () => {
     await test.step("Create a new 9x9 rack and add all visible miners", async () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
+      await racksPage.inputRackLabel(RACK_LABEL);
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(NETWORK_RACK_COLUMNS);
       await racksPage.inputRows(NETWORK_RACK_ROWS);

--- a/client/e2eTests/protoFleet/spec/racks.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racks.spec.ts
@@ -19,6 +19,10 @@ import { SettingsPoolsPage } from "../pages/settingsPools";
 
 const VALID_POOL_URL = "stratum+tcp://mine.ocean.xyz:3334";
 const AUTOMATION_ZONE = "AutomationZone";
+// Racks no longer auto-generate a label from the zone, so tests type one
+// explicitly. The afterEach deletes all racks, so a shared constant is safe
+// for single-rack tests (no cross-test label collisions).
+const RACK_LABEL = "AutomationRack";
 const RACK_COLUMNS = 2;
 const RACK_ROWS = 2;
 const VALIDATION_RACK_COLUMNS = 1;
@@ -116,8 +120,8 @@ test.describe("Racks", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
 
-      rackLabel = await racksPage.getGeneratedRackLabel();
-      test.expect(rackLabel).toBeTruthy();
+      rackLabel = RACK_LABEL;
+      await racksPage.inputRackLabel(rackLabel);
 
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(RACK_COLUMNS);
@@ -168,6 +172,7 @@ test.describe("Racks", () => {
     await test.step("Create a new 2x2 rack", async () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
+      await racksPage.inputRackLabel(RACK_LABEL);
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(RACK_COLUMNS);
       await racksPage.inputRows(RACK_ROWS);
@@ -212,8 +217,8 @@ test.describe("Racks", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
 
-      rackLabel = await racksPage.getGeneratedRackLabel();
-      test.expect(rackLabel).toBeTruthy();
+      rackLabel = RACK_LABEL;
+      await racksPage.inputRackLabel(rackLabel);
 
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(LARGE_RACK_COLUMNS);
@@ -314,8 +319,8 @@ test.describe("Racks", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
 
-      rackLabel = await racksPage.getGeneratedRackLabel();
-      test.expect(rackLabel).toBeTruthy();
+      rackLabel = RACK_LABEL;
+      await racksPage.inputRackLabel(rackLabel);
 
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
@@ -403,8 +408,8 @@ test.describe("Racks", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
 
-      rackLabel = await racksPage.getGeneratedRackLabel();
-      test.expect(rackLabel).toBeTruthy();
+      rackLabel = RACK_LABEL;
+      await racksPage.inputRackLabel(rackLabel);
 
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(RACK_COLUMNS);
@@ -486,7 +491,8 @@ test.describe("Racks", () => {
 
           await racksPage.clickAddRackButton();
           await racksPage.inputZone(AUTOMATION_ZONE);
-          rackLabel = await racksPage.getGeneratedRackLabel();
+          rackLabel = RACK_LABEL;
+          await racksPage.inputRackLabel(rackLabel);
           await racksPage.enableCustomRackLayout();
           await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
           await racksPage.inputRows(OVERVIEW_RACK_ROWS);
@@ -558,7 +564,8 @@ test.describe("Racks", () => {
     await test.step("Create a rack with two assigned Proto rigs and open the overview security flow", async () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
-      rackLabel = await racksPage.getGeneratedRackLabel();
+      rackLabel = RACK_LABEL;
+      await racksPage.inputRackLabel(rackLabel);
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
       await racksPage.inputRows(OVERVIEW_RACK_ROWS);
@@ -598,7 +605,7 @@ test.describe("Racks", () => {
     await test.step("Create rack A-01 with three miners", async () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(zoneA);
-      test.expect(await racksPage.getGeneratedRackLabel()).toBe("A-01");
+      await racksPage.inputRackLabel("A-01");
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(RACK_COLUMNS);
       await racksPage.inputRows(RACK_ROWS);
@@ -614,7 +621,7 @@ test.describe("Racks", () => {
     await test.step("Create rack A-02 with two miners", async () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(zoneA);
-      test.expect(await racksPage.getGeneratedRackLabel()).toBe("A-02");
+      await racksPage.inputRackLabel("A-02");
       await racksPage.clickContinueFromRackSettings();
       await addSelectableMinersToSlots(racksPage, 2, [1, 2]);
       await racksPage.clickSaveRack();
@@ -627,7 +634,7 @@ test.describe("Racks", () => {
     await test.step("Create rack B-01 with one miner", async () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(zoneB);
-      test.expect(await racksPage.getGeneratedRackLabel()).toBe("B-01");
+      await racksPage.inputRackLabel("B-01");
       await racksPage.clickContinueFromRackSettings();
       await addSelectableMinersToSlots(racksPage, 1, [1]);
       await racksPage.clickSaveRack();
@@ -704,19 +711,13 @@ test.describe("Racks", () => {
     let generatedRackLabel = "";
     let selectedMiners: RackSelectorMiner[] = [];
 
-    await test.step("Validate required zone before continuing", async () => {
-      await racksPage.clickAddRackButton();
-      await racksPage.clickContinueFromRackSettings();
-      await racksPage.validateRackSettingsFieldError("rack-zone", "A zone is required");
-      await racksPage.validateTitleInModal("Rack settings");
-    });
-
     await test.step("Validate required label and invalid dimensions", async () => {
+      // Zone is optional now; the label is required and empty by default, so
+      // continuing without typing one surfaces the label error.
+      await racksPage.clickAddRackButton();
       await racksPage.inputZone(validationZone);
-      generatedRackLabel = await racksPage.getGeneratedRackLabel();
-      test.expect(generatedRackLabel).toBe("A-01");
+      generatedRackLabel = "A-01";
 
-      await racksPage.inputRackLabel("");
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(0);
       await racksPage.inputRows(13);

--- a/client/src/protoFleet/components/ParentPickerModal/ParentPickerModal.tsx
+++ b/client/src/protoFleet/components/ParentPickerModal/ParentPickerModal.tsx
@@ -5,7 +5,7 @@ import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { useSites } from "@/protoFleet/api/sites";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
-import { Alert, ArrowLeftCompact, ArrowRight } from "@/shared/assets/icons";
+import { Alert, ArrowLeftCompact, ArrowRight, Plus } from "@/shared/assets/icons";
 import Button, { sizes as buttonSizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Checkbox from "@/shared/components/Checkbox";
@@ -36,6 +36,13 @@ interface ParentPickerModalProps {
   description?: string;
   createNewLabel?: string;
   onCreateNew?: (name: string) => Promise<void>;
+  // Renders a "New …" button (e.g. "New rack") at the top of the picker
+  // instead of the inline name input. Clicking it hands off to the full
+  // creation flow (e.g. RackSettingsModal → ManageRackModal) with the
+  // current selection pre-seeded, rather than creating inline. Distinct
+  // from createNewLabel/onCreateNew, which the group flow still uses.
+  createNewLaunchLabel?: string;
+  onCreateNewLaunch?: () => void;
   onDismiss: () => void;
   onConfirm: (targetIds: bigint[]) => void | Promise<void>;
 }
@@ -58,6 +65,8 @@ const ParentPickerModal = ({
   description,
   createNewLabel,
   onCreateNew,
+  createNewLaunchLabel,
+  onCreateNewLaunch,
   onDismiss,
   onConfirm,
 }: ParentPickerModalProps) => {
@@ -318,6 +327,7 @@ const ParentPickerModal = ({
   }, []);
 
   const hasCreateNew = !!createNewLabel && !!onCreateNew;
+  const hasCreateNewLaunch = !!createNewLaunchLabel && !!onCreateNewLaunch;
   const trimmedNewName = newName.trim();
   const wantsCreateNew = hasCreateNew && createNewChecked && trimmedNewName.length > 0;
   const isUnchangedSingleSelection =
@@ -390,6 +400,18 @@ const ParentPickerModal = ({
         </div>
       ) : (
         <div>
+          {hasCreateNewLaunch ? (
+            <div className="mb-4 flex">
+              <Button
+                variant={variants.secondary}
+                size={buttonSizes.base}
+                prefixIcon={<Plus />}
+                text={createNewLaunchLabel}
+                onClick={onCreateNewLaunch}
+                testId="parent-picker-create-new"
+              />
+            </div>
+          ) : null}
           {hasCreateNew && hasAnyItems ? (
             <label className="mb-6 flex items-center gap-6">
               <Checkbox checked={createNewChecked} onChange={handleCreateNewToggle} />

--- a/client/src/protoFleet/features/buildings/components/BuildingModals/BuildingModals.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingModals/BuildingModals.test.tsx
@@ -44,6 +44,7 @@ const makeApi = (overrides: Partial<BuildingModalsApi> = {}): BuildingModalsApi 
   deleteTarget: null,
   saving: false,
   deleting: false,
+  manageUnassignedMinerCount: undefined,
   openDetailsCreate: vi.fn(),
   openDetailsEdit: vi.fn(),
   openManage: vi.fn(),

--- a/client/src/protoFleet/features/buildings/components/BuildingModals/BuildingModals.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingModals/BuildingModals.tsx
@@ -43,6 +43,7 @@ const BuildingModals = ({ modals, sites }: BuildingModalsProps) => {
           // fire on its own. Surface refreshBuildings here so host
           // caches (rack_count, layout) re-pull from the server.
           onSaved={modals.refreshBuildings}
+          unassignedMinerCount={modals.manageUnassignedMinerCount}
         />
       ) : null}
       {state.kind === "detailsCreate" ? (

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/BuildingRacksPane.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/BuildingRacksPane.tsx
@@ -31,6 +31,10 @@ interface BuildingRacksPaneProps {
   // empty-state copy so the operator can find their way to the bulk-add
   // surface even before any rack lands.
   onOpenManageRacks: () => void;
+  // Count of miners assigned directly to this building (no rack) — surfaced
+  // when the building is created from a bulk "New building" action seeded
+  // with loose miners. Interim representation pending a fuller design pass.
+  unassignedMinerCount?: number;
   saving?: boolean;
 }
 
@@ -150,6 +154,7 @@ const BuildingRacksPane = ({
   onSelectRack,
   onRemoveRack,
   onOpenManageRacks,
+  unassignedMinerCount,
   saving = false,
 }: BuildingRacksPaneProps) => {
   const isManual = assignmentMode === "manual";
@@ -209,6 +214,11 @@ const BuildingRacksPane = ({
             ))}
           </div>
         )}
+        {unassignedMinerCount ? (
+          <p className="text-200 text-text-primary-50" data-testid="manage-building-unassigned-miners">
+            {unassignedMinerCount} {unassignedMinerCount === 1 ? "miner" : "miners"} unassigned to a rack
+          </p>
+        ) : null}
       </section>
     </div>
   );

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
@@ -31,6 +31,10 @@ interface ManageBuildingModalProps {
   // sibling-building labels via listBuildingsBySite, so no
   // siblingBuildings prop is plumbed through.
   onSaved?: (updated: Building) => void;
+  // Count of miners assigned directly to this building (no rack), shown as a
+  // count line under the racks list. Set when the building was created from a
+  // bulk "New building" action seeded with loose miners.
+  unassignedMinerCount?: number;
 }
 
 const ManageBuildingModal = ({
@@ -41,6 +45,7 @@ const ManageBuildingModal = ({
   onEditDetails,
   onDeleteRequested,
   onSaved,
+  unassignedMinerCount,
 }: ManageBuildingModalProps) => {
   const { listBuildingRacks, assignRacksToBuilding } = useBuildings();
 
@@ -598,6 +603,7 @@ const ManageBuildingModal = ({
             onSelectRack={handleSelectRack}
             onRemoveRack={handleRemoveRack}
             onOpenManageRacks={() => setShowManageRacks(true)}
+            unassignedMinerCount={unassignedMinerCount}
             saving={isSaving}
           />
         }

--- a/client/src/protoFleet/features/buildings/hooks/useBuildingModals.ts
+++ b/client/src/protoFleet/features/buildings/hooks/useBuildingModals.ts
@@ -62,7 +62,12 @@ export interface BuildingModalsApi {
   // a parent-site context — the dropdown inside the modal collects it.
   openDetailsCreate: (siteId?: bigint, siteName?: string) => void;
   openDetailsEdit: (row: BuildingWithCounts, siteName?: string) => void;
-  openManage: (row: BuildingWithCounts, siteName?: string) => void;
+  // unassignedMinerCount surfaces the count-line in ManageBuildingModal when
+  // the building was created from a bulk "New building" action seeded with
+  // loose miners. Omitted by every normal edit caller → no count line.
+  openManage: (row: BuildingWithCounts, siteName?: string, unassignedMinerCount?: number) => void;
+  // Count carried alongside the manage state for the seeded-create flow.
+  manageUnassignedMinerCount: number | undefined;
   // Closes the topmost modal: drops details if details is stacked on manage,
   // otherwise collapses to none. Mirrors useSiteModals.dismiss.
   dismiss: () => void;
@@ -96,6 +101,10 @@ const useBuildingModals = ({
   const [deleteTarget, setDeleteTarget] = useState<BuildingWithCounts | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  // Set by openManage; read while the manage modal is open. Stale values
+  // while closed are harmless (the modal isn't rendered), and the next
+  // openManage overwrites — so no explicit reset is needed.
+  const [manageUnassignedMinerCount, setManageUnassignedMinerCount] = useState<number | undefined>(undefined);
 
   // Synchronous in-flight guard so the disabled-prop lag on the button
   // (setState batching) can't slip a double-click past us.
@@ -115,7 +124,8 @@ const useBuildingModals = ({
     setState({ kind: "detailsEdit", row, siteName, draft: buildingFormValuesFromBuilding(unwrap(row)) });
   }, []);
 
-  const openManage = useCallback((row: BuildingWithCounts, siteName?: string) => {
+  const openManage = useCallback((row: BuildingWithCounts, siteName?: string, unassignedMinerCount?: number) => {
+    setManageUnassignedMinerCount(unassignedMinerCount);
     setState({ kind: "manage", row, siteName });
   }, []);
 
@@ -299,6 +309,7 @@ const useBuildingModals = ({
     deleteTarget,
     saving,
     deleting,
+    manageUnassignedMinerCount,
     openDetailsCreate,
     openDetailsEdit,
     openManage,

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 import { create } from "@bufbuild/protobuf";
 
 import {
@@ -27,6 +27,18 @@ import { pushToast, STATUSES } from "@/shared/features/toaster";
 // Hoisted create-flow host. Mounted once in FleetLayout so any fleet tab can
 // launch a create flow in place — no cross-page navigation. Owns the rack +
 // building create modal stacks; the site flow extends this provider.
+
+// Matches the server-side max_items cap on AssignDevicesToSite/Building and
+// AssignRacksTo* — mirrors MinerReparentPicker.MAX_REASSIGN_BATCH. Checked
+// before creating the parent so an over-cap seed can't leave an orphaned
+// empty parent when the assignment RPC rejects.
+const MAX_REASSIGN_BATCH = 10000;
+
+const overBatchCap = (seed: { buildingIds?: bigint[]; rackIds?: bigint[]; minerIds?: string[] }): boolean =>
+  (seed.buildingIds?.length ?? 0) > MAX_REASSIGN_BATCH ||
+  (seed.rackIds?.length ?? 0) > MAX_REASSIGN_BATCH ||
+  (seed.minerIds?.length ?? 0) > MAX_REASSIGN_BATCH;
+
 const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sites: SiteWithCounts[] }) => {
   const [entitiesChangedAt, setEntitiesChangedAt] = useState(0);
   const bumpEntities = useCallback(() => setEntitiesChangedAt(Date.now()), []);
@@ -38,12 +50,31 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
   const [rackSettingsOpen, setRackSettingsOpen] = useState(false);
   const [rackFormData, setRackFormData] = useState<RackFormData | null>(null);
   const [rackSeed, setRackSeed] = useState<RackCreateSeed | null>(null);
+  // Holds a seed whose miners have a placement the new rack would clear,
+  // until the operator confirms; null when no confirmation is pending.
+  const [rackConflictSeed, setRackConflictSeed] = useState<RackCreateSeed | null>(null);
 
-  const launchCreateRack = useCallback((seed: RackCreateSeed) => {
+  const openRackSettings = useCallback((seed: RackCreateSeed) => {
     setRackSeed(seed);
     setRackFormData(null);
     setRackSettingsOpen(true);
   }, []);
+
+  const launchCreateRack = useCallback(
+    (seed: RackCreateSeed) => {
+      if (seed.conflictCount && seed.conflictCount > 0) {
+        setRackConflictSeed(seed);
+        return;
+      }
+      openRackSettings(seed);
+    },
+    [openRackSettings],
+  );
+
+  const confirmRackConflict = useCallback(() => {
+    if (rackConflictSeed) openRackSettings(rackConflictSeed);
+    setRackConflictSeed(null);
+  }, [rackConflictSeed, openRackSettings]);
 
   const closeRackFlow = useCallback(() => {
     setRackSettingsOpen(false);
@@ -71,8 +102,20 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
   // Holds a seed whose items have existing parents until the operator
   // confirms the move; null when no confirmation is pending.
   const [buildingConflictSeed, setBuildingConflictSeed] = useState<BuildingCreateSeed | null>(null);
+  // In-flight guard for the provider-owned building create. The `saving` prop
+  // lags a render behind the click (setState batching), so the ref is what
+  // actually blocks a double-click from dispatching two CreateBuilding calls.
+  const [creatingBuilding, setCreatingBuilding] = useState(false);
+  const creatingBuildingRef = useRef(false);
 
   const launchCreateBuilding = useCallback((seed: BuildingCreateSeed) => {
+    if (overBatchCap(seed)) {
+      pushToast({
+        message: `Can't add more than ${MAX_REASSIGN_BATCH} items at once. Filter the selection and try again.`,
+        status: STATUSES.error,
+      });
+      return;
+    }
     if (seed.conflictCount && seed.conflictCount > 0) {
       setBuildingConflictSeed(seed);
       return;
@@ -91,56 +134,66 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
   // mirroring the reparent confirm path) → open manage for positioning.
   const handleBuildingCreate = useCallback(
     async (values: Parameters<typeof createBuilding>[0]["values"], siteId: bigint) => {
-      const seed = buildingSeed;
-      const building = await new Promise<Building | null>((resolve) => {
-        void createBuilding({
-          values,
-          siteId,
-          onSuccess: (b) => resolve(b),
-          onError: (msg) => {
-            pushToast({ message: `Failed to create building: ${msg}`, status: STATUSES.error });
-            resolve(null);
-          },
-        });
-      });
-      if (!building) return;
-
-      if (seed && seed.rackIds.length > 0) {
-        await new Promise<void>((resolve) => {
-          void assignRacksToBuilding({
-            racks: seed.rackIds.map((rackId) => ({ rackId })),
-            targetBuildingId: building.id,
-            onSuccess: () => resolve(),
+      // Synchronous re-entry guard: a double-click reaches here twice before
+      // the `saving` prop re-renders, which would create duplicate buildings.
+      if (creatingBuildingRef.current) return;
+      creatingBuildingRef.current = true;
+      setCreatingBuilding(true);
+      try {
+        const seed = buildingSeed;
+        const building = await new Promise<Building | null>((resolve) => {
+          void createBuilding({
+            values,
+            siteId,
+            onSuccess: (b) => resolve(b),
             onError: (msg) => {
-              pushToast({ message: `Building created, but adding racks failed: ${msg}`, status: STATUSES.error });
-              resolve();
+              pushToast({ message: `Failed to create building: ${msg}`, status: STATUSES.error });
+              resolve(null);
             },
           });
         });
-      }
-      if (seed && seed.minerIds.length > 0) {
-        await new Promise<void>((resolve) => {
-          void assignDevicesToBuilding({
-            targetBuildingId: building.id,
-            deviceIdentifiers: seed.minerIds,
-            forceClearConflictingRackMembership: true,
-            onSuccess: () => resolve(),
-            onError: (msg) => {
-              pushToast({ message: `Building created, but adding miners failed: ${msg}`, status: STATUSES.error });
-              resolve();
-            },
-          });
-        });
-      }
+        if (!building) return;
 
-      bumpEntities();
-      setBuildingSeed(null);
-      const siteName = sites.find((s) => s.site?.id === siteId)?.site?.name;
-      buildingModals.openManage(
-        create(BuildingWithCountsSchema, { building, rackCount: BigInt(seed?.rackIds.length ?? 0) }),
-        siteName,
-        seed?.minerIds.length || undefined,
-      );
+        if (seed && seed.rackIds.length > 0) {
+          await new Promise<void>((resolve) => {
+            void assignRacksToBuilding({
+              racks: seed.rackIds.map((rackId) => ({ rackId })),
+              targetBuildingId: building.id,
+              onSuccess: () => resolve(),
+              onError: (msg) => {
+                pushToast({ message: `Building created, but adding racks failed: ${msg}`, status: STATUSES.error });
+                resolve();
+              },
+            });
+          });
+        }
+        if (seed && seed.minerIds.length > 0) {
+          await new Promise<void>((resolve) => {
+            void assignDevicesToBuilding({
+              targetBuildingId: building.id,
+              deviceIdentifiers: seed.minerIds,
+              forceClearConflictingRackMembership: true,
+              onSuccess: () => resolve(),
+              onError: (msg) => {
+                pushToast({ message: `Building created, but adding miners failed: ${msg}`, status: STATUSES.error });
+                resolve();
+              },
+            });
+          });
+        }
+
+        bumpEntities();
+        setBuildingSeed(null);
+        const siteName = sites.find((s) => s.site?.id === siteId)?.site?.name;
+        buildingModals.openManage(
+          create(BuildingWithCountsSchema, { building, rackCount: BigInt(seed?.rackIds.length ?? 0) }),
+          siteName,
+          seed?.minerIds.length || undefined,
+        );
+      } finally {
+        creatingBuildingRef.current = false;
+        setCreatingBuilding(false);
+      }
     },
     [buildingSeed, createBuilding, assignRacksToBuilding, assignDevicesToBuilding, bumpEntities, sites, buildingModals],
   );
@@ -153,8 +206,17 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
   const siteModals = useSiteModals({ refetchSites: bumpEntities });
   const [siteSeed, setSiteSeed] = useState<SiteCreateSeed | null>(null);
   const [siteConflictSeed, setSiteConflictSeed] = useState<SiteCreateSeed | null>(null);
+  const [creatingSite, setCreatingSite] = useState(false);
+  const creatingSiteRef = useRef(false);
 
   const launchCreateSite = useCallback((seed: SiteCreateSeed) => {
+    if (overBatchCap(seed)) {
+      pushToast({
+        message: `Can't add more than ${MAX_REASSIGN_BATCH} items at once. Filter the selection and try again.`,
+        status: STATUSES.error,
+      });
+      return;
+    }
     if (seed.conflictCount && seed.conflictCount > 0) {
       setSiteConflictSeed(seed);
       return;
@@ -171,66 +233,75 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
 
   const handleSiteCreate = useCallback(
     async (values: Parameters<typeof createSite>[0]["values"]) => {
-      const seed = siteSeed;
-      const site = await new Promise<Site | null>((resolve) => {
-        void createSite({
-          values,
-          onSuccess: (s) => resolve(s),
-          onError: (msg) => {
-            pushToast({ message: `Failed to create site: ${msg}`, status: STATUSES.error });
-            resolve(null);
-          },
+      // Synchronous re-entry guard against duplicate CreateSite on double-click.
+      if (creatingSiteRef.current) return;
+      creatingSiteRef.current = true;
+      setCreatingSite(true);
+      try {
+        const seed = siteSeed;
+        const site = await new Promise<Site | null>((resolve) => {
+          void createSite({
+            values,
+            onSuccess: (s) => resolve(s),
+            onError: (msg) => {
+              pushToast({ message: `Failed to create site: ${msg}`, status: STATUSES.error });
+              resolve(null);
+            },
+          });
         });
-      });
-      if (!site) return;
+        if (!site) return;
 
-      if (seed && seed.buildingIds.length > 0) {
-        await new Promise<void>((resolve) => {
-          void assignBuildingsToSite({
-            buildingIds: seed.buildingIds,
-            targetSiteId: site.id,
-            onSuccess: () => resolve(),
-            onError: (msg) => {
-              pushToast({ message: `Site created, but adding buildings failed: ${msg}`, status: STATUSES.error });
-              resolve();
-            },
+        if (seed && seed.buildingIds.length > 0) {
+          await new Promise<void>((resolve) => {
+            void assignBuildingsToSite({
+              buildingIds: seed.buildingIds,
+              targetSiteId: site.id,
+              onSuccess: () => resolve(),
+              onError: (msg) => {
+                pushToast({ message: `Site created, but adding buildings failed: ${msg}`, status: STATUSES.error });
+                resolve();
+              },
+            });
           });
-        });
-      }
-      if (seed && seed.rackIds.length > 0) {
-        await new Promise<void>((resolve) => {
-          void assignRacksToSite({
-            rackIds: seed.rackIds,
-            targetSiteId: site.id,
-            onSuccess: () => resolve(),
-            onError: (msg) => {
-              pushToast({ message: `Site created, but adding racks failed: ${msg}`, status: STATUSES.error });
-              resolve();
-            },
+        }
+        if (seed && seed.rackIds.length > 0) {
+          await new Promise<void>((resolve) => {
+            void assignRacksToSite({
+              rackIds: seed.rackIds,
+              targetSiteId: site.id,
+              onSuccess: () => resolve(),
+              onError: (msg) => {
+                pushToast({ message: `Site created, but adding racks failed: ${msg}`, status: STATUSES.error });
+                resolve();
+              },
+            });
           });
-        });
-      }
-      if (seed && seed.minerIds.length > 0) {
-        await new Promise<void>((resolve) => {
-          void assignDevicesToSite({
-            targetSiteId: site.id,
-            deviceIdentifiers: seed.minerIds,
-            forceClearConflictingRackMembership: true,
-            onSuccess: () => resolve(),
-            onError: (msg) => {
-              pushToast({ message: `Site created, but adding miners failed: ${msg}`, status: STATUSES.error });
-              resolve();
-            },
+        }
+        if (seed && seed.minerIds.length > 0) {
+          await new Promise<void>((resolve) => {
+            void assignDevicesToSite({
+              targetSiteId: site.id,
+              deviceIdentifiers: seed.minerIds,
+              forceClearConflictingRackMembership: true,
+              onSuccess: () => resolve(),
+              onError: (msg) => {
+                pushToast({ message: `Site created, but adding miners failed: ${msg}`, status: STATUSES.error });
+                resolve();
+              },
+            });
           });
-        });
-      }
+        }
 
-      bumpEntities();
-      setSiteSeed(null);
-      siteModals.openManageEdit(site, {
-        unassignedRackCount: seed?.rackIds.length || undefined,
-        unassignedMinerCount: seed?.minerIds.length || undefined,
-      });
+        bumpEntities();
+        setSiteSeed(null);
+        siteModals.openManageEdit(site, {
+          unassignedRackCount: seed?.rackIds.length || undefined,
+          unassignedMinerCount: seed?.minerIds.length || undefined,
+        });
+      } finally {
+        creatingSiteRef.current = false;
+        setCreatingSite(false);
+      }
     },
     [siteSeed, createSite, assignBuildingsToSite, assignRacksToSite, assignDevicesToSite, bumpEntities, siteModals],
   );
@@ -261,6 +332,18 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
           onSave={handleRackSaved}
         />
       ) : null}
+      {rackConflictSeed ? (
+        <Dialog
+          open
+          title="Move selected miners to a new rack?"
+          subtitle={`${rackConflictSeed.conflictCount} of the selected miners are currently in a site, building, or rack. A new rack has no site, so continuing will clear those placements.`}
+          onDismiss={() => setRackConflictSeed(null)}
+          buttons={[
+            { text: "Cancel", variant: variants.secondary, onClick: () => setRackConflictSeed(null) },
+            { text: "Continue", variant: variants.primary, onClick: confirmRackConflict },
+          ]}
+        />
+      ) : null}
       {buildingSeed ? (
         <BuildingSettingsModal
           open
@@ -269,7 +352,7 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
           sites={sites}
           onSave={handleBuildingCreate}
           onDismiss={closeBuildingSettings}
-          saving={buildingModals.saving}
+          saving={creatingBuilding || buildingModals.saving}
         />
       ) : null}
       <BuildingModals modals={buildingModals} sites={sites} />
@@ -292,7 +375,7 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
           initialValues={emptySiteFormValues()}
           onContinue={(values) => void handleSiteCreate(values)}
           onDismiss={closeSiteSettings}
-          saving={siteModals.saving}
+          saving={creatingSite || siteModals.saving}
         />
       ) : null}
       <SiteModals modals={siteModals} sites={sites} />

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -172,7 +172,7 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
             void assignDevicesToBuilding({
               targetBuildingId: building.id,
               deviceIdentifiers: seed.minerIds,
-              forceClearConflictingRackMembership: true,
+              forceClearConflictingRackMembership: seed.forceClearRackMembership ?? false,
               onSuccess: () => resolve(),
               onError: (msg) => {
                 pushToast({ message: `Building created, but adding miners failed: ${msg}`, status: STATUSES.error });
@@ -282,7 +282,7 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
             void assignDevicesToSite({
               targetSiteId: site.id,
               deviceIdentifiers: seed.minerIds,
-              forceClearConflictingRackMembership: true,
+              forceClearConflictingRackMembership: seed.forceClearRackMembership ?? false,
               onSuccess: () => resolve(),
               onError: (msg) => {
                 pushToast({ message: `Site created, but adding miners failed: ${msg}`, status: STATUSES.error });
@@ -336,7 +336,7 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
         <Dialog
           open
           title="Move selected miners to a new rack?"
-          subtitle={`${rackConflictSeed.conflictCount} of the selected miners are currently in a site, building, or rack. A new rack has no site, so continuing will clear those placements.`}
+          subtitle={`${rackConflictSeed.conflictCount} of the selected miners are already in a rack, building, or site. Creating this rack will move them into it and clear their previous placement.`}
           onDismiss={() => setRackConflictSeed(null)}
           buttons={[
             { text: "Cancel", variant: variants.secondary, onClick: () => setRackConflictSeed(null) },

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -1,0 +1,315 @@
+import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  type BuildingCreateSeed,
+  FleetCreateFlowContext,
+  type FleetCreateFlowContextValue,
+  type RackCreateSeed,
+  type SiteCreateSeed,
+} from "./context";
+import { emptyBuildingFormValues, useBuildings } from "@/protoFleet/api/buildings";
+import { type Building, BuildingWithCountsSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { type Site, type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { emptySiteFormValues, useSites } from "@/protoFleet/api/sites";
+import BuildingModals from "@/protoFleet/features/buildings/components/BuildingModals";
+import BuildingSettingsModal from "@/protoFleet/features/buildings/components/BuildingSettingsModal";
+import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
+import { ManageRackModal, type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal";
+import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
+import SiteModals from "@/protoFleet/features/sites/components/SiteModals";
+import SiteSettingsModal from "@/protoFleet/features/sites/components/SiteSettingsModal";
+import { useSiteModals } from "@/protoFleet/features/sites/hooks/useSiteModals";
+import { variants } from "@/shared/components/Button";
+import Dialog from "@/shared/components/Dialog";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+// Hoisted create-flow host. Mounted once in FleetLayout so any fleet tab can
+// launch a create flow in place — no cross-page navigation. Owns the rack +
+// building create modal stacks; the site flow extends this provider.
+const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sites: SiteWithCounts[] }) => {
+  const [entitiesChangedAt, setEntitiesChangedAt] = useState(0);
+  const bumpEntities = useCallback(() => setEntitiesChangedAt(Date.now()), []);
+
+  // Rack create flow. rackSettings drives RackSettingsModal; once the
+  // operator continues, rackFormData opens ManageRackModal seeded with the
+  // selected miners. rackSeed survives the settings step so the miners reach
+  // the manage modal.
+  const [rackSettingsOpen, setRackSettingsOpen] = useState(false);
+  const [rackFormData, setRackFormData] = useState<RackFormData | null>(null);
+  const [rackSeed, setRackSeed] = useState<RackCreateSeed | null>(null);
+
+  const launchCreateRack = useCallback((seed: RackCreateSeed) => {
+    setRackSeed(seed);
+    setRackFormData(null);
+    setRackSettingsOpen(true);
+  }, []);
+
+  const closeRackFlow = useCallback(() => {
+    setRackSettingsOpen(false);
+    setRackFormData(null);
+    setRackSeed(null);
+  }, []);
+
+  const handleRackSettingsContinue = useCallback((formData: RackFormData) => {
+    setRackSettingsOpen(false);
+    setRackFormData(formData);
+  }, []);
+
+  const handleRackSaved = useCallback(() => {
+    bumpEntities();
+    closeRackFlow();
+  }, [bumpEntities, closeRackFlow]);
+
+  // Building create flow. The settings step is hosted directly (not via the
+  // hook) so we can intercept create-success to assign the seed and chain
+  // into manage; the manage/edit/delete surfaces reuse a controller-owned
+  // useBuildingModals instance rendered through <BuildingModals>.
+  const { createBuilding, assignRacksToBuilding, assignDevicesToBuilding } = useBuildings();
+  const buildingModals = useBuildingModals({ refetchBuildings: bumpEntities });
+  const [buildingSeed, setBuildingSeed] = useState<BuildingCreateSeed | null>(null);
+  // Holds a seed whose items have existing parents until the operator
+  // confirms the move; null when no confirmation is pending.
+  const [buildingConflictSeed, setBuildingConflictSeed] = useState<BuildingCreateSeed | null>(null);
+
+  const launchCreateBuilding = useCallback((seed: BuildingCreateSeed) => {
+    if (seed.conflictCount && seed.conflictCount > 0) {
+      setBuildingConflictSeed(seed);
+      return;
+    }
+    setBuildingSeed(seed);
+  }, []);
+
+  const confirmBuildingConflict = useCallback(() => {
+    setBuildingSeed(buildingConflictSeed);
+    setBuildingConflictSeed(null);
+  }, [buildingConflictSeed]);
+
+  const closeBuildingSettings = useCallback(() => setBuildingSeed(null), []);
+
+  // create → assign seeded racks/miners (force-clearing prior memberships,
+  // mirroring the reparent confirm path) → open manage for positioning.
+  const handleBuildingCreate = useCallback(
+    async (values: Parameters<typeof createBuilding>[0]["values"], siteId: bigint) => {
+      const seed = buildingSeed;
+      const building = await new Promise<Building | null>((resolve) => {
+        void createBuilding({
+          values,
+          siteId,
+          onSuccess: (b) => resolve(b),
+          onError: (msg) => {
+            pushToast({ message: `Failed to create building: ${msg}`, status: STATUSES.error });
+            resolve(null);
+          },
+        });
+      });
+      if (!building) return;
+
+      if (seed && seed.rackIds.length > 0) {
+        await new Promise<void>((resolve) => {
+          void assignRacksToBuilding({
+            racks: seed.rackIds.map((rackId) => ({ rackId })),
+            targetBuildingId: building.id,
+            onSuccess: () => resolve(),
+            onError: (msg) => {
+              pushToast({ message: `Building created, but adding racks failed: ${msg}`, status: STATUSES.error });
+              resolve();
+            },
+          });
+        });
+      }
+      if (seed && seed.minerIds.length > 0) {
+        await new Promise<void>((resolve) => {
+          void assignDevicesToBuilding({
+            targetBuildingId: building.id,
+            deviceIdentifiers: seed.minerIds,
+            forceClearConflictingRackMembership: true,
+            onSuccess: () => resolve(),
+            onError: (msg) => {
+              pushToast({ message: `Building created, but adding miners failed: ${msg}`, status: STATUSES.error });
+              resolve();
+            },
+          });
+        });
+      }
+
+      bumpEntities();
+      setBuildingSeed(null);
+      const siteName = sites.find((s) => s.site?.id === siteId)?.site?.name;
+      buildingModals.openManage(
+        create(BuildingWithCountsSchema, { building, rackCount: BigInt(seed?.rackIds.length ?? 0) }),
+        siteName,
+        seed?.minerIds.length || undefined,
+      );
+    },
+    [buildingSeed, createBuilding, assignRacksToBuilding, assignDevicesToBuilding, bumpEntities, sites, buildingModals],
+  );
+
+  // Site create flow. Like building, the settings step is hosted directly so
+  // we can intercept continue → create → assign → manage. The manage step
+  // routes through edit mode (openManageEdit) because create mode gates
+  // building assignment until the site exists.
+  const { createSite, assignBuildingsToSite, assignRacksToSite, assignDevicesToSite } = useSites();
+  const siteModals = useSiteModals({ refetchSites: bumpEntities });
+  const [siteSeed, setSiteSeed] = useState<SiteCreateSeed | null>(null);
+  const [siteConflictSeed, setSiteConflictSeed] = useState<SiteCreateSeed | null>(null);
+
+  const launchCreateSite = useCallback((seed: SiteCreateSeed) => {
+    if (seed.conflictCount && seed.conflictCount > 0) {
+      setSiteConflictSeed(seed);
+      return;
+    }
+    setSiteSeed(seed);
+  }, []);
+
+  const confirmSiteConflict = useCallback(() => {
+    setSiteSeed(siteConflictSeed);
+    setSiteConflictSeed(null);
+  }, [siteConflictSeed]);
+
+  const closeSiteSettings = useCallback(() => setSiteSeed(null), []);
+
+  const handleSiteCreate = useCallback(
+    async (values: Parameters<typeof createSite>[0]["values"]) => {
+      const seed = siteSeed;
+      const site = await new Promise<Site | null>((resolve) => {
+        void createSite({
+          values,
+          onSuccess: (s) => resolve(s),
+          onError: (msg) => {
+            pushToast({ message: `Failed to create site: ${msg}`, status: STATUSES.error });
+            resolve(null);
+          },
+        });
+      });
+      if (!site) return;
+
+      if (seed && seed.buildingIds.length > 0) {
+        await new Promise<void>((resolve) => {
+          void assignBuildingsToSite({
+            buildingIds: seed.buildingIds,
+            targetSiteId: site.id,
+            onSuccess: () => resolve(),
+            onError: (msg) => {
+              pushToast({ message: `Site created, but adding buildings failed: ${msg}`, status: STATUSES.error });
+              resolve();
+            },
+          });
+        });
+      }
+      if (seed && seed.rackIds.length > 0) {
+        await new Promise<void>((resolve) => {
+          void assignRacksToSite({
+            rackIds: seed.rackIds,
+            targetSiteId: site.id,
+            onSuccess: () => resolve(),
+            onError: (msg) => {
+              pushToast({ message: `Site created, but adding racks failed: ${msg}`, status: STATUSES.error });
+              resolve();
+            },
+          });
+        });
+      }
+      if (seed && seed.minerIds.length > 0) {
+        await new Promise<void>((resolve) => {
+          void assignDevicesToSite({
+            targetSiteId: site.id,
+            deviceIdentifiers: seed.minerIds,
+            forceClearConflictingRackMembership: true,
+            onSuccess: () => resolve(),
+            onError: (msg) => {
+              pushToast({ message: `Site created, but adding miners failed: ${msg}`, status: STATUSES.error });
+              resolve();
+            },
+          });
+        });
+      }
+
+      bumpEntities();
+      setSiteSeed(null);
+      siteModals.openManageEdit(site, {
+        unassignedRackCount: seed?.rackIds.length || undefined,
+        unassignedMinerCount: seed?.minerIds.length || undefined,
+      });
+    },
+    [siteSeed, createSite, assignBuildingsToSite, assignRacksToSite, assignDevicesToSite, bumpEntities, siteModals],
+  );
+
+  const value = useMemo<FleetCreateFlowContextValue>(
+    () => ({ launchCreateRack, launchCreateBuilding, launchCreateSite, entitiesChangedAt }),
+    [launchCreateRack, launchCreateBuilding, launchCreateSite, entitiesChangedAt],
+  );
+
+  return (
+    <FleetCreateFlowContext.Provider value={value}>
+      {children}
+      {rackSettingsOpen ? (
+        <RackSettingsModal
+          show={rackSettingsOpen}
+          existingRacks={[]}
+          onDismiss={closeRackFlow}
+          onContinue={handleRackSettingsContinue}
+        />
+      ) : null}
+      {rackFormData ? (
+        <ManageRackModal
+          show={!!rackFormData}
+          rackSettings={rackFormData}
+          existingRacks={[]}
+          seededMinerIds={rackSeed?.minerIds}
+          onDismiss={closeRackFlow}
+          onSave={handleRackSaved}
+        />
+      ) : null}
+      {buildingSeed ? (
+        <BuildingSettingsModal
+          open
+          mode="create"
+          initialValues={emptyBuildingFormValues()}
+          sites={sites}
+          onSave={handleBuildingCreate}
+          onDismiss={closeBuildingSettings}
+          saving={buildingModals.saving}
+        />
+      ) : null}
+      <BuildingModals modals={buildingModals} sites={sites} />
+      {buildingConflictSeed ? (
+        <Dialog
+          open
+          title="Move selected items to a new building?"
+          subtitle={`${buildingConflictSeed.conflictCount} of the selected items already belong to another building or site. Continuing will move them into the new building.`}
+          onDismiss={() => setBuildingConflictSeed(null)}
+          buttons={[
+            { text: "Cancel", variant: variants.secondary, onClick: () => setBuildingConflictSeed(null) },
+            { text: "Continue", variant: variants.primary, onClick: confirmBuildingConflict },
+          ]}
+        />
+      ) : null}
+      {siteSeed ? (
+        <SiteSettingsModal
+          open
+          mode="create"
+          initialValues={emptySiteFormValues()}
+          onContinue={(values) => void handleSiteCreate(values)}
+          onDismiss={closeSiteSettings}
+          saving={siteModals.saving}
+        />
+      ) : null}
+      <SiteModals modals={siteModals} sites={sites} />
+      {siteConflictSeed ? (
+        <Dialog
+          open
+          title="Move selected items to a new site?"
+          subtitle={`${siteConflictSeed.conflictCount} of the selected items already belong to another site. Continuing will move them into the new site.`}
+          onDismiss={() => setSiteConflictSeed(null)}
+          buttons={[
+            { text: "Cancel", variant: variants.secondary, onClick: () => setSiteConflictSeed(null) },
+            { text: "Continue", variant: variants.primary, onClick: confirmSiteConflict },
+          ]}
+        />
+      ) : null}
+    </FleetCreateFlowContext.Provider>
+  );
+};
+
+export default FleetCreateFlowProvider;

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -28,20 +28,46 @@ import { pushToast, STATUSES } from "@/shared/features/toaster";
 // launch a create flow in place — no cross-page navigation. Owns the rack +
 // building create modal stacks; the site flow extends this provider.
 
-// Matches the server-side max_items cap on AssignDevicesToSite/Building and
-// AssignRacksTo* — mirrors MinerReparentPicker.MAX_REASSIGN_BATCH. Checked
-// before creating the parent so an over-cap seed can't leave an orphaned
-// empty parent when the assignment RPC rejects.
-const MAX_REASSIGN_BATCH = 10000;
+// Server-side max_items caps differ by assignment RPC: AssignBuildingsToSite /
+// AssignRacksToSite / AssignRacksToBuilding cap at 1000, while
+// AssignDevicesToSite/Building (miners) cap at 10000. Checked before creating
+// the parent so an over-cap seed can't leave an orphaned empty parent when the
+// assignment RPC rejects.
+const MAX_PARENT_BATCH = 1000;
+const MAX_DEVICE_BATCH = 10000;
 
-const overBatchCap = (seed: { buildingIds?: bigint[]; rackIds?: bigint[]; minerIds?: string[] }): boolean =>
-  (seed.buildingIds?.length ?? 0) > MAX_REASSIGN_BATCH ||
-  (seed.rackIds?.length ?? 0) > MAX_REASSIGN_BATCH ||
-  (seed.minerIds?.length ?? 0) > MAX_REASSIGN_BATCH;
+// Returns an operator-facing message when a seed exceeds the relevant cap, else
+// null. Per type so the message names the right limit and entity.
+const batchCapError = (seed: { buildingIds?: bigint[]; rackIds?: bigint[]; minerIds?: string[] }): string | null => {
+  if ((seed.buildingIds?.length ?? 0) > MAX_PARENT_BATCH)
+    return `Can't add more than ${MAX_PARENT_BATCH} buildings at once. Filter the selection and try again.`;
+  if ((seed.rackIds?.length ?? 0) > MAX_PARENT_BATCH)
+    return `Can't add more than ${MAX_PARENT_BATCH} racks at once. Filter the selection and try again.`;
+  if ((seed.minerIds?.length ?? 0) > MAX_DEVICE_BATCH)
+    return `Can't add more than ${MAX_DEVICE_BATCH} miners at once. Filter the selection and try again.`;
+  return null;
+};
 
-const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sites: SiteWithCounts[] }) => {
+const FleetCreateFlowProvider = ({
+  children,
+  sites,
+  refetchSites,
+}: {
+  children: ReactNode;
+  sites: SiteWithCounts[];
+  // FleetLayout's site-catalog refetch. Called after a site is created so the
+  // shared `sites` list (site column names, pickers) reflects the new site
+  // immediately, not just on the next poll.
+  refetchSites: () => void;
+}) => {
   const [entitiesChangedAt, setEntitiesChangedAt] = useState(0);
   const bumpEntities = useCallback(() => setEntitiesChangedAt(Date.now()), []);
+  // Refresh the shared site catalog AND pulse list pages — used by the site
+  // create/edit paths so the new site resolves everywhere right away.
+  const refreshSitesAndBump = useCallback(() => {
+    refetchSites();
+    bumpEntities();
+  }, [refetchSites, bumpEntities]);
 
   // Rack create flow. rackSettings drives RackSettingsModal; once the
   // operator continues, rackFormData opens ManageRackModal seeded with the
@@ -109,11 +135,9 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
   const creatingBuildingRef = useRef(false);
 
   const launchCreateBuilding = useCallback((seed: BuildingCreateSeed) => {
-    if (overBatchCap(seed)) {
-      pushToast({
-        message: `Can't add more than ${MAX_REASSIGN_BATCH} items at once. Filter the selection and try again.`,
-        status: STATUSES.error,
-      });
+    const capErr = batchCapError(seed);
+    if (capErr) {
+      pushToast({ message: capErr, status: STATUSES.error });
       return;
     }
     if (seed.conflictCount && seed.conflictCount > 0) {
@@ -203,18 +227,16 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
   // routes through edit mode (openManageEdit) because create mode gates
   // building assignment until the site exists.
   const { createSite, assignBuildingsToSite, assignRacksToSite, assignDevicesToSite } = useSites();
-  const siteModals = useSiteModals({ refetchSites: bumpEntities });
+  const siteModals = useSiteModals({ refetchSites: refreshSitesAndBump });
   const [siteSeed, setSiteSeed] = useState<SiteCreateSeed | null>(null);
   const [siteConflictSeed, setSiteConflictSeed] = useState<SiteCreateSeed | null>(null);
   const [creatingSite, setCreatingSite] = useState(false);
   const creatingSiteRef = useRef(false);
 
   const launchCreateSite = useCallback((seed: SiteCreateSeed) => {
-    if (overBatchCap(seed)) {
-      pushToast({
-        message: `Can't add more than ${MAX_REASSIGN_BATCH} items at once. Filter the selection and try again.`,
-        status: STATUSES.error,
-      });
+    const capErr = batchCapError(seed);
+    if (capErr) {
+      pushToast({ message: capErr, status: STATUSES.error });
       return;
     }
     if (seed.conflictCount && seed.conflictCount > 0) {
@@ -292,7 +314,7 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
           });
         }
 
-        bumpEntities();
+        refreshSitesAndBump();
         setSiteSeed(null);
         siteModals.openManageEdit(site, {
           unassignedRackCount: seed?.rackIds.length || undefined,
@@ -303,7 +325,15 @@ const FleetCreateFlowProvider = ({ children, sites }: { children: ReactNode; sit
         setCreatingSite(false);
       }
     },
-    [siteSeed, createSite, assignBuildingsToSite, assignRacksToSite, assignDevicesToSite, bumpEntities, siteModals],
+    [
+      siteSeed,
+      createSite,
+      assignBuildingsToSite,
+      assignRacksToSite,
+      assignDevicesToSite,
+      refreshSitesAndBump,
+      siteModals,
+    ],
   );
 
   const value = useMemo<FleetCreateFlowContextValue>(

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -52,6 +52,7 @@ const FleetCreateFlowProvider = ({
   children,
   sites,
   refetchSites,
+  notifyMinersChanged,
 }: {
   children: ReactNode;
   sites: SiteWithCounts[];
@@ -59,9 +60,19 @@ const FleetCreateFlowProvider = ({
   // shared `sites` list (site column names, pickers) reflects the new site
   // immediately, not just on the next poll.
   refetchSites: () => void;
+  // FleetLayout's Miners-tab refresh pulse. The Miners tab listens to
+  // minersChangedAt (not entitiesChangedAt), so a create flow launched from
+  // it must signal here for the moved miners' placement to refresh.
+  notifyMinersChanged: () => void;
 }) => {
   const [entitiesChangedAt, setEntitiesChangedAt] = useState(0);
-  const bumpEntities = useCallback(() => setEntitiesChangedAt(Date.now()), []);
+  // Bumping entities also refreshes the Miners tab: every create flow can move
+  // miners (rack seeds them; building/site direct-assign them), and the Miners
+  // tab refreshes off minersChangedAt rather than entitiesChangedAt.
+  const bumpEntities = useCallback(() => {
+    setEntitiesChangedAt(Date.now());
+    notifyMinersChanged();
+  }, [notifyMinersChanged]);
   // Refresh the shared site catalog AND pulse list pages — used by the site
   // create/edit paths so the new site resolves everywhere right away.
   const refreshSitesAndBump = useCallback(() => {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -20,6 +20,7 @@ import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/
 import SiteModals from "@/protoFleet/features/sites/components/SiteModals";
 import SiteSettingsModal from "@/protoFleet/features/sites/components/SiteSettingsModal";
 import { useSiteModals } from "@/protoFleet/features/sites/hooks/useSiteModals";
+import { useHasPermission } from "@/protoFleet/store";
 import { variants } from "@/shared/components/Button";
 import Dialog from "@/shared/components/Dialog";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
@@ -35,6 +36,14 @@ import { pushToast, STATUSES } from "@/shared/features/toaster";
 // assignment RPC rejects.
 const MAX_PARENT_BATCH = 1000;
 const MAX_DEVICE_BATCH = 10000;
+
+// A seed that moves racked miners into a new building/site sends
+// forceClearConflictingRackMembership, which the server gates on rack:manage.
+// "Add to building/site" is reachable with only site:manage, so without this
+// preflight a site-only operator would create the parent, then 403 on the
+// assignment — leaving an orphaned empty parent.
+const RACK_CLEAR_PERMISSION_MESSAGE =
+  "You need rack permissions to move these miners out of their racks. Remove the racked miners from the selection or ask an admin.";
 
 // Returns an operator-facing message when a seed exceeds the relevant cap, else
 // null. Per type so the message names the right limit and entity.
@@ -135,6 +144,10 @@ const FleetCreateFlowProvider = ({
   // useBuildingModals instance rendered through <BuildingModals>.
   const { createBuilding, assignRacksToBuilding, assignDevicesToBuilding } = useBuildings();
   const buildingModals = useBuildingModals({ refetchBuildings: bumpEntities });
+  // Gates the force-clear preflight below: a force-clearing device assignment
+  // needs rack:manage on the server, but the create flow is reachable with
+  // only site:manage.
+  const canManageRacks = useHasPermission("rack:manage");
   const [buildingSeed, setBuildingSeed] = useState<BuildingCreateSeed | null>(null);
   // Holds a seed whose items have existing parents until the operator
   // confirms the move; null when no confirmation is pending.
@@ -145,18 +158,27 @@ const FleetCreateFlowProvider = ({
   const [creatingBuilding, setCreatingBuilding] = useState(false);
   const creatingBuildingRef = useRef(false);
 
-  const launchCreateBuilding = useCallback((seed: BuildingCreateSeed) => {
-    const capErr = batchCapError(seed);
-    if (capErr) {
-      pushToast({ message: capErr, status: STATUSES.error });
-      return;
-    }
-    if (seed.conflictCount && seed.conflictCount > 0) {
-      setBuildingConflictSeed(seed);
-      return;
-    }
-    setBuildingSeed(seed);
-  }, []);
+  const launchCreateBuilding = useCallback(
+    (seed: BuildingCreateSeed) => {
+      const capErr = batchCapError(seed);
+      if (capErr) {
+        pushToast({ message: capErr, status: STATUSES.error });
+        return;
+      }
+      // Block before creating the parent: a force-clear assignment would 403
+      // for a site-only operator and strand an empty building.
+      if (seed.forceClearRackMembership && !canManageRacks) {
+        pushToast({ message: RACK_CLEAR_PERMISSION_MESSAGE, status: STATUSES.error });
+        return;
+      }
+      if (seed.conflictCount && seed.conflictCount > 0) {
+        setBuildingConflictSeed(seed);
+        return;
+      }
+      setBuildingSeed(seed);
+    },
+    [canManageRacks],
+  );
 
   const confirmBuildingConflict = useCallback(() => {
     setBuildingSeed(buildingConflictSeed);
@@ -244,18 +266,27 @@ const FleetCreateFlowProvider = ({
   const [creatingSite, setCreatingSite] = useState(false);
   const creatingSiteRef = useRef(false);
 
-  const launchCreateSite = useCallback((seed: SiteCreateSeed) => {
-    const capErr = batchCapError(seed);
-    if (capErr) {
-      pushToast({ message: capErr, status: STATUSES.error });
-      return;
-    }
-    if (seed.conflictCount && seed.conflictCount > 0) {
-      setSiteConflictSeed(seed);
-      return;
-    }
-    setSiteSeed(seed);
-  }, []);
+  const launchCreateSite = useCallback(
+    (seed: SiteCreateSeed) => {
+      const capErr = batchCapError(seed);
+      if (capErr) {
+        pushToast({ message: capErr, status: STATUSES.error });
+        return;
+      }
+      // Block before creating the parent: a force-clear assignment would 403
+      // for a site-only operator and strand an empty site.
+      if (seed.forceClearRackMembership && !canManageRacks) {
+        pushToast({ message: RACK_CLEAR_PERMISSION_MESSAGE, status: STATUSES.error });
+        return;
+      }
+      if (seed.conflictCount && seed.conflictCount > 0) {
+        setSiteConflictSeed(seed);
+        return;
+      }
+      setSiteSeed(seed);
+    },
+    [canManageRacks],
+  );
 
   const confirmSiteConflict = useCallback(() => {
     setSiteSeed(siteConflictSeed);

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/context.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/context.ts
@@ -1,0 +1,59 @@
+import { createContext, useContext } from "react";
+
+// Seeds carried into each create flow from a bulk / single-row "New …"
+// action. The selected items land in the new parent: position-seeded when
+// the item type matches the modal's grid (miners→rack), or assigned as
+// direct members + surfaced as a count line otherwise (option (i)).
+export interface RackCreateSeed {
+  minerIds: string[];
+}
+
+export interface BuildingCreateSeed {
+  // Racks position-seeded into the building grid (item type matches the
+  // modal's panel). Unplaced on entry, ready for aisle/position assignment.
+  rackIds: bigint[];
+  // Miners assigned directly to the building (no rack) — surfaced as the
+  // count line under the racks list (option (i)).
+  minerIds: string[];
+  // Number of selected items that already belong to another building/site.
+  // When > 0 a confirm dialog warns before entering the create flow,
+  // mirroring the reparent flow. The call site computes it from data it
+  // already holds (rack.buildingId, miner snapshots).
+  conflictCount?: number;
+}
+
+export interface SiteCreateSeed {
+  // Buildings position-seeded into the site (item type matches the panel).
+  buildingIds: bigint[];
+  // Racks/miners assigned directly to the site (no building) — surfaced as
+  // count lines under the buildings list (option (i)).
+  rackIds: bigint[];
+  minerIds: string[];
+  conflictCount?: number;
+}
+
+export interface FleetCreateFlowContextValue {
+  // Opens RackSettingsModal → ManageRackModal with the given miners
+  // pre-seeded into the rack's left pane for slot assignment.
+  launchCreateRack: (seed: RackCreateSeed) => void;
+  // Opens BuildingSettingsModal → ManageBuildingModal: on create the seeded
+  // racks/miners are assigned to the new building (force-clearing prior
+  // memberships), then the manage modal opens for rack positioning.
+  launchCreateBuilding: (seed: BuildingCreateSeed) => void;
+  // Opens SiteSettingsModal → ManageSiteModal (edit): on create the seeded
+  // buildings/racks/miners are assigned to the new site, then the manage
+  // modal opens for building management. Routes through edit mode because
+  // ManageSiteModal's create mode gates building assignment until the site
+  // exists.
+  launchCreateSite: (seed: SiteCreateSeed) => void;
+  // Bumps whenever a create flow commits, so list pages can refetch
+  // without the controller knowing which page is active.
+  entitiesChangedAt: number;
+}
+
+export const FleetCreateFlowContext = createContext<FleetCreateFlowContextValue | undefined>(undefined);
+
+// Returns undefined outside the provider (e.g. standalone routes that mount a
+// list page without the FleetLayout shell), so callers can hide the "New …"
+// affordance rather than crash.
+export const useFleetCreateFlow = (): FleetCreateFlowContextValue | undefined => useContext(FleetCreateFlowContext);

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/context.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/context.ts
@@ -6,6 +6,10 @@ import { createContext, useContext } from "react";
 // direct members + surfaced as a count line otherwise (option (i)).
 export interface RackCreateSeed {
   minerIds: string[];
+  // Number of selected miners that already have a site/building/rack
+  // placement. A new rack has no site, so those placements are cleared on
+  // save; when > 0 a confirm dialog warns first, mirroring the reparent flow.
+  conflictCount?: number;
 }
 
 export interface BuildingCreateSeed {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/context.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/context.ts
@@ -24,6 +24,11 @@ export interface BuildingCreateSeed {
   // mirroring the reparent flow. The call site computes it from data it
   // already holds (rack.buildingId, miner snapshots).
   conflictCount?: number;
+  // Whether the seeded miners include any currently in a rack. Only then is
+  // forceClearConflictingRackMembership set on the device assignment — the
+  // server requires rack:manage when that flag is on, so leaving it false for
+  // rack-less miners lets a site/building-only operator complete the flow.
+  forceClearRackMembership?: boolean;
 }
 
 export interface SiteCreateSeed {
@@ -34,6 +39,8 @@ export interface SiteCreateSeed {
   rackIds: bigint[];
   minerIds: string[];
   conflictCount?: number;
+  // See BuildingCreateSeed.forceClearRackMembership.
+  forceClearRackMembership?: boolean;
 }
 
 export interface FleetCreateFlowContextValue {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
@@ -308,7 +308,11 @@ const FleetLayout = () => {
         </TabStrip>
       </div>
       <div className="min-h-0 flex-1">
-        <FleetCreateFlowProvider sites={sites ?? []} refetchSites={fetchSites}>
+        <FleetCreateFlowProvider
+          sites={sites ?? []}
+          refetchSites={fetchSites}
+          notifyMinersChanged={notifyMinersChanged}
+        >
           {outlet}
         </FleetCreateFlowProvider>
       </div>

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
@@ -11,6 +11,7 @@ import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import { MULTI_SITE_ENABLED } from "@/protoFleet/constants/featureFlags";
 import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
+import FleetCreateFlowProvider from "@/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider";
 import FleetViewTabs from "@/protoFleet/features/fleetManagement/components/FleetViewTabs";
 import { type FleetTabId } from "@/protoFleet/features/fleetManagement/views/savedViews";
 import useFleetViews from "@/protoFleet/features/fleetManagement/views/useFleetViews";
@@ -306,7 +307,9 @@ const FleetLayout = () => {
           ))}
         </TabStrip>
       </div>
-      <div className="min-h-0 flex-1">{outlet}</div>
+      <div className="min-h-0 flex-1">
+        <FleetCreateFlowProvider sites={sites ?? []}>{outlet}</FleetCreateFlowProvider>
+      </div>
     </div>
   );
 };

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
@@ -308,7 +308,9 @@ const FleetLayout = () => {
         </TabStrip>
       </div>
       <div className="min-h-0 flex-1">
-        <FleetCreateFlowProvider sites={sites ?? []}>{outlet}</FleetCreateFlowProvider>
+        <FleetCreateFlowProvider sites={sites ?? []} refetchSites={fetchSites}>
+          {outlet}
+        </FleetCreateFlowProvider>
       </div>
     </div>
   );

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -69,6 +69,10 @@ interface ManageRackModalProps {
   rackSettings: RackFormData;
   existingRackId?: bigint;
   existingRacks: DeviceSet[];
+  // Pre-seeds the new rack's miner list (e.g. from a bulk "Add to rack →
+  // New rack" flow) so the selected miners land in the left pane ready
+  // for slot assignment. Ignored in edit mode (existingRackId set).
+  seededMinerIds?: string[];
   onDismiss: () => void;
   onSave: () => void;
   onDelete?: () => Promise<void> | void;
@@ -79,6 +83,7 @@ export default function ManageRackModal({
   rackSettings: initialRackSettings,
   existingRackId,
   existingRacks,
+  seededMinerIds,
   onDismiss,
   onSave,
   onDelete,
@@ -94,8 +99,10 @@ export default function ManageRackModal({
   const totalSlots = rackSettings.rows * rackSettings.columns;
   const numberingOrigin = orderIndexToOrigin(rackSettings.orderIndex);
 
-  // Core assignment state
-  const [rackMiners, setRackMiners] = useState<string[]>([]);
+  // Core assignment state. A new rack (no existingRackId) can be seeded
+  // with miners from a bulk "Add to rack → New rack" flow; edit mode
+  // ignores the seed and loads the rack's real membership below.
+  const [rackMiners, setRackMiners] = useState<string[]>(() => (existingRackId ? [] : (seededMinerIds ?? [])));
   const [slotAssignments, setSlotAssignments] = useState<Record<string, string>>({});
   const [assignmentMode, setAssignmentMode] = useState<AssignmentMode>("manual");
   const [manualAssignmentCache, setManualAssignmentCache] = useState<Record<string, string>>({});

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -408,6 +408,17 @@ export default function ManageRackModal({
 
   // Save handler — single atomic RPC
   const handleSave = useCallback(async () => {
+    // Capacity guard. handleManageMinersConfirm enforces this when miners are
+    // added through the sub-modal, but a seeded new rack (bulk "New rack")
+    // populates rackMiners directly and bypasses that path — saveRack accepts
+    // members beyond the slot count, so an over-fill would persist silently.
+    if (rackMiners.length > totalSlots) {
+      setErrorMsg(
+        `Cannot add ${rackMiners.length} miners with only ${totalSlots} available slots. Deselect some miners or update your rack settings.`,
+      );
+      return;
+    }
+
     setIsSaving(true);
     setErrorMsg("");
 
@@ -444,7 +455,7 @@ export default function ManageRackModal({
     } finally {
       setIsSaving(false);
     }
-  }, [existingRackId, rackSettings, rackMiners, activeAssignments, saveRack, onSave]);
+  }, [existingRackId, rackSettings, rackMiners, totalSlots, activeAssignments, saveRack, onSave]);
 
   if (!show) return null;
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
@@ -662,7 +662,7 @@ const MinerReparentPicker = ({
   const countMinersWithParent = (
     ids: string[],
     snapshots: Record<string, MinerStateSnapshot> | undefined,
-    target: "building" | "site",
+    target: ReparentKind,
   ): number => {
     if (!snapshots) return 0;
     return ids.filter((id) => {
@@ -671,15 +671,16 @@ const MinerReparentPicker = ({
       const hasRack = !!getMinerRackLabel(snapshot);
       const hasBuilding = !!getMinerBuildingLabel(snapshot);
       const hasSite = !!getMinerSiteLabel(snapshot);
+      // A new rack/site displaces any current placement; a new building
+      // displaces a current building or rack (a direct site is preserved).
       return target === "building" ? hasBuilding || hasRack : hasSite || hasBuilding || hasRack;
     }).length;
   };
 
   // "New …" hand-off: resolve the selection, close the picker, then open the
-  // hoisted create flow seeded with these miners. For rack, membership
-  // conflicts resolve at ManageRackModal save (atomic replace). For building,
-  // the miners are assigned directly with force-clear after create — the
-  // server-side clear mirrors the reparent confirm path.
+  // hoisted create flow seeded with these miners. Each kind pre-warns when the
+  // selection has placements the new parent would displace (conflictCount);
+  // the provider shows the confirm dialog before entering the create flow.
   const createNewLaunchLabel = createFlow
     ? kind === "rack"
       ? "New rack"
@@ -695,7 +696,7 @@ const MinerReparentPicker = ({
     const { ids, snapshots } = resolved;
     onClose();
     if (kind === "rack") {
-      createFlow.launchCreateRack({ minerIds: ids });
+      createFlow.launchCreateRack({ minerIds: ids, conflictCount: countMinersWithParent(ids, snapshots, "rack") });
     } else if (kind === "building") {
       createFlow.launchCreateBuilding({
         rackIds: [],

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
@@ -655,25 +655,21 @@ const MinerReparentPicker = ({
     return { ids: deviceIdentifiers, snapshots: miners };
   };
 
-  // Count selected miners that already belong to a parent the new entity
-  // would displace — drives the create-flow pre-warn dialog, mirroring the
-  // reparent flow. A building move conflicts with any current building/rack;
-  // a site move conflicts with any current site/building/rack.
-  const countMinersWithParent = (
+  // Count selected miners that already have ANY placement (site, building, or
+  // rack) — drives the create-flow pre-warn dialog, mirroring the reparent
+  // flow. Every "New …" target displaces an existing placement: a new
+  // rack/site re-stamps or clears it, and a new building cascades the
+  // building's site onto the miner (which can differ from the miner's current
+  // direct site), so a direct-site-only miner must warn here too.
+  const countMinersWithPlacement = (
     ids: string[],
     snapshots: Record<string, MinerStateSnapshot> | undefined,
-    target: ReparentKind,
   ): number => {
     if (!snapshots) return 0;
     return ids.filter((id) => {
       const snapshot = snapshots[id];
       if (!snapshot) return false;
-      const hasRack = !!getMinerRackLabel(snapshot);
-      const hasBuilding = !!getMinerBuildingLabel(snapshot);
-      const hasSite = !!getMinerSiteLabel(snapshot);
-      // A new rack/site displaces any current placement; a new building
-      // displaces a current building or rack (a direct site is preserved).
-      return target === "building" ? hasBuilding || hasRack : hasSite || hasBuilding || hasRack;
+      return !!getMinerSiteLabel(snapshot) || !!getMinerBuildingLabel(snapshot) || !!getMinerRackLabel(snapshot);
     }).length;
   };
 
@@ -701,12 +697,12 @@ const MinerReparentPicker = ({
     // operators aren't blocked.
     const racked = !!snapshots && ids.some((id) => !!snapshots[id] && !!getMinerRackLabel(snapshots[id]));
     if (kind === "rack") {
-      createFlow.launchCreateRack({ minerIds: ids, conflictCount: countMinersWithParent(ids, snapshots, "rack") });
+      createFlow.launchCreateRack({ minerIds: ids, conflictCount: countMinersWithPlacement(ids, snapshots) });
     } else if (kind === "building") {
       createFlow.launchCreateBuilding({
         rackIds: [],
         minerIds: ids,
-        conflictCount: countMinersWithParent(ids, snapshots, "building"),
+        conflictCount: countMinersWithPlacement(ids, snapshots),
         forceClearRackMembership: racked,
       });
     } else {
@@ -714,7 +710,7 @@ const MinerReparentPicker = ({
         buildingIds: [],
         rackIds: [],
         minerIds: ids,
-        conflictCount: countMinersWithParent(ids, snapshots, "site"),
+        conflictCount: countMinersWithPlacement(ids, snapshots),
         forceClearRackMembership: racked,
       });
     }

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
@@ -13,7 +13,12 @@ import {
 import { useSites } from "@/protoFleet/api/sites";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
-import { getMinerRackLabel } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
+import { useFleetCreateFlow } from "@/protoFleet/features/fleetManagement/components/FleetCreateFlow/context";
+import {
+  getMinerBuildingLabel,
+  getMinerRackLabel,
+  getMinerSiteLabel,
+} from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import { variants } from "@/shared/components/Button";
 import Dialog from "@/shared/components/Dialog";
 import { pushToast, removeToast, STATUSES, updateToast } from "@/shared/features/toaster";
@@ -225,6 +230,7 @@ const MinerReparentPicker = ({
   const { assignDevicesToSite } = useSites();
   const { assignDevicesToBuilding } = useBuildings();
   const { assignDevicesToRack, getDeviceSet, listRacks } = useDeviceSets();
+  const createFlow = useFleetCreateFlow();
   const [siteMoveConfirmation, setSiteMoveConfirmation] = useState<SiteMoveConfirmation | null>(null);
   const [siteMoveInFlight, setSiteMoveInFlight] = useState(false);
   const [buildingMoveConfirmation, setBuildingMoveConfirmation] = useState<BuildingMoveConfirmation | null>(null);
@@ -605,6 +611,107 @@ const MinerReparentPicker = ({
     settleDialog();
   };
 
+  // Resolve the operator's selection to a concrete id list plus the snapshots
+  // (for conflict counting). Subset mode already has both; all-mode paginates
+  // the snapshot endpoint behind a loading toast (same path as onConfirm).
+  // Returns null on abort / error / empty so callers can bail quietly.
+  const resolveSelectionIds = async (): Promise<{
+    ids: string[];
+    snapshots: Record<string, MinerStateSnapshot> | undefined;
+  } | null> => {
+    if (selectionMode === "all") {
+      const effectiveFilter = currentFilter ?? create(MinerListFilterSchema);
+      const loadingToast = pushToast({
+        message: "Loading selected miners…",
+        status: STATUSES.loading,
+        longRunning: true,
+      });
+      let ids: string[];
+      let snapshots: Record<string, MinerStateSnapshot>;
+      try {
+        const resolved = await resolveAllModeIds(effectiveFilter, abortRef.current?.signal);
+        if (abortRef.current?.signal.aborted) {
+          removeToast(loadingToast);
+          return null;
+        }
+        ids = resolved.ids;
+        snapshots = resolved.snapshots;
+      } catch (err) {
+        const message = err instanceof Error && err.message ? err.message : "Couldn't load selected miners. Try again.";
+        updateToast(loadingToast, { message, status: STATUSES.error });
+        return null;
+      }
+      removeToast(loadingToast);
+      if (ids.length === 0) {
+        pushToast({ message: "No miners selected.", status: STATUSES.queued });
+        return null;
+      }
+      return { ids, snapshots };
+    }
+    if (deviceIdentifiers.length === 0) {
+      pushToast({ message: "No miners selected.", status: STATUSES.queued });
+      return null;
+    }
+    return { ids: deviceIdentifiers, snapshots: miners };
+  };
+
+  // Count selected miners that already belong to a parent the new entity
+  // would displace — drives the create-flow pre-warn dialog, mirroring the
+  // reparent flow. A building move conflicts with any current building/rack;
+  // a site move conflicts with any current site/building/rack.
+  const countMinersWithParent = (
+    ids: string[],
+    snapshots: Record<string, MinerStateSnapshot> | undefined,
+    target: "building" | "site",
+  ): number => {
+    if (!snapshots) return 0;
+    return ids.filter((id) => {
+      const snapshot = snapshots[id];
+      if (!snapshot) return false;
+      const hasRack = !!getMinerRackLabel(snapshot);
+      const hasBuilding = !!getMinerBuildingLabel(snapshot);
+      const hasSite = !!getMinerSiteLabel(snapshot);
+      return target === "building" ? hasBuilding || hasRack : hasSite || hasBuilding || hasRack;
+    }).length;
+  };
+
+  // "New …" hand-off: resolve the selection, close the picker, then open the
+  // hoisted create flow seeded with these miners. For rack, membership
+  // conflicts resolve at ManageRackModal save (atomic replace). For building,
+  // the miners are assigned directly with force-clear after create — the
+  // server-side clear mirrors the reparent confirm path.
+  const createNewLaunchLabel = createFlow
+    ? kind === "rack"
+      ? "New rack"
+      : kind === "building"
+        ? "New building"
+        : "New site"
+    : undefined;
+
+  const handleCreateNewLaunch = async () => {
+    if (!createFlow) return;
+    const resolved = await resolveSelectionIds();
+    if (!resolved) return;
+    const { ids, snapshots } = resolved;
+    onClose();
+    if (kind === "rack") {
+      createFlow.launchCreateRack({ minerIds: ids });
+    } else if (kind === "building") {
+      createFlow.launchCreateBuilding({
+        rackIds: [],
+        minerIds: ids,
+        conflictCount: countMinersWithParent(ids, snapshots, "building"),
+      });
+    } else {
+      createFlow.launchCreateSite({
+        buildingIds: [],
+        rackIds: [],
+        minerIds: ids,
+        conflictCount: countMinersWithParent(ids, snapshots, "site"),
+      });
+    }
+  };
+
   const conflictRackLabels = siteMoveConfirmation ? Array.from(siteMoveConfirmation.conflictsByLabel.keys()) : [];
   const conflictCount = siteMoveConfirmation
     ? Array.from(siteMoveConfirmation.conflictsByLabel.values()).reduce((sum, list) => sum + list.length, 0)
@@ -623,6 +730,8 @@ const MinerReparentPicker = ({
             ? `${totalCount} miners`
             : sourceLabel
         }
+        createNewLaunchLabel={createNewLaunchLabel}
+        onCreateNewLaunch={createNewLaunchLabel ? () => void handleCreateNewLaunch() : undefined}
         onDismiss={onClose}
         // Returning a promise that only resolves after the dispatch
         // (including any cross-site confirm Dialog) completes keeps

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
@@ -695,6 +695,11 @@ const MinerReparentPicker = ({
     if (!resolved) return;
     const { ids, snapshots } = resolved;
     onClose();
+    // Whether any selected miner is in a rack — gates the device assignment's
+    // forceClearConflictingRackMembership (which the server treats as a
+    // rack:manage action). Rack-less miners leave it off so site/building-only
+    // operators aren't blocked.
+    const racked = !!snapshots && ids.some((id) => !!snapshots[id] && !!getMinerRackLabel(snapshots[id]));
     if (kind === "rack") {
       createFlow.launchCreateRack({ minerIds: ids, conflictCount: countMinersWithParent(ids, snapshots, "rack") });
     } else if (kind === "building") {
@@ -702,6 +707,7 @@ const MinerReparentPicker = ({
         rackIds: [],
         minerIds: ids,
         conflictCount: countMinersWithParent(ids, snapshots, "building"),
+        forceClearRackMembership: racked,
       });
     } else {
       createFlow.launchCreateSite({
@@ -709,6 +715,7 @@ const MinerReparentPicker = ({
         rackIds: [],
         minerIds: ids,
         conflictCount: countMinersWithParent(ids, snapshots, "site"),
+        forceClearRackMembership: racked,
       });
     }
   };

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -42,19 +42,6 @@ const coolingTypeOptions: SelectOption[] = [
   { value: String(RackCoolingType.IMMERSION), label: "Immersion" },
 ];
 
-function abbreviateZone(zone: string): string {
-  if (!zone.trim()) return "";
-  return zone
-    .trim()
-    .split(/\s+/)
-    .map((word) => {
-      const letters = word.replace(/[0-9]/g, "");
-      const digits = word.replace(/[^0-9]/g, "");
-      return (letters.charAt(0) || "").toUpperCase() + digits;
-    })
-    .join("");
-}
-
 const RackSettingsModal = ({
   show,
   existingRacks,
@@ -70,7 +57,6 @@ const RackSettingsModal = ({
   const { updateRack, listRackZones, listRackTypes } = useDeviceSets();
 
   const [label, setLabel] = useState(initialFormData?.label ?? rack?.label ?? "");
-  const [labelManuallyEdited, setLabelManuallyEdited] = useState(isEditMode || !!initialFormData?.label);
   const [zone, setZone] = useState(() => {
     if (initialFormData?.zone) return initialFormData.zone;
     if (rackInfo?.zone) return rackInfo.zone;
@@ -99,7 +85,6 @@ const RackSettingsModal = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
   const [labelError, setLabelError] = useState<string | undefined>();
-  const [zoneError, setZoneError] = useState<string | undefined>();
   const [columnsError, setColumnsError] = useState<string | undefined>();
   const [rowsError, setRowsError] = useState<string | undefined>();
 
@@ -135,21 +120,6 @@ const RackSettingsModal = ({
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount; initialFormData and rackInfo are initial values
   }, [listRackZones, listRackTypes]);
-
-  // Auto-generate label when zone changes
-  const autoLabel = useMemo(() => {
-    const abbr = abbreviateZone(zone);
-    if (!abbr) return "";
-    const trimmedZone = zone.trim();
-    const racksInZone = existingRacks.filter((r) => {
-      if (r.typeDetails.case !== "rackInfo") return false;
-      return r.typeDetails.value.zone === trimmedZone;
-    });
-    const nextNum = racksInZone.length + 1;
-    return `${abbr}-${String(nextNum).padStart(2, "0")}`;
-  }, [zone, existingRacks]);
-
-  const effectiveLabel = labelManuallyEdited ? label : autoLabel;
 
   const filteredSuggestions = useMemo(() => {
     if (!zone.trim()) return zoneSuggestions;
@@ -230,19 +200,14 @@ const RackSettingsModal = ({
 
   const handleSubmit = useCallback(() => {
     setLabelError(undefined);
-    setZoneError(undefined);
     setColumnsError(undefined);
     setRowsError(undefined);
     setErrorMsg("");
 
     let hasError = false;
 
-    if (!effectiveLabel.trim()) {
+    if (!label.trim()) {
       setLabelError("A label is required");
-      hasError = true;
-    }
-    if (!zone.trim()) {
-      setZoneError("A zone is required");
       hasError = true;
     }
     const colsNum = Number(columns);
@@ -259,7 +224,7 @@ const RackSettingsModal = ({
     if (hasError) return;
 
     const formData: RackFormData = {
-      label: effectiveLabel.trim(),
+      label: label.trim(),
       zone: zone.trim(),
       rows: rowsNum,
       columns: colsNum,
@@ -298,7 +263,7 @@ const RackSettingsModal = ({
       },
     });
   }, [
-    effectiveLabel,
+    label,
     zone,
     rows,
     columns,
@@ -340,10 +305,18 @@ const RackSettingsModal = ({
         <div className="flex flex-col gap-4 pt-1">
           {errorMsg ? <Callout intent="danger" prefixIcon={<Alert />} title={errorMsg} /> : null}
 
+          <Input
+            id="rack-label"
+            label="Label"
+            initValue={label}
+            onChange={(value) => setLabel(value)}
+            error={labelError}
+          />
+
           <div className="relative">
             <Input
               id="rack-zone"
-              label="Zone"
+              label="Zone (optional)"
               initValue={zone}
               inputRef={zoneInputRef}
               onChange={(value) => {
@@ -356,7 +329,6 @@ const RackSettingsModal = ({
                   setShowZoneSuggestions(false);
                 }
               }}
-              error={zoneError}
               autoComplete="off"
             />
             {showZoneSuggestions && filteredSuggestions.length > 0 ? (
@@ -388,17 +360,6 @@ const RackSettingsModal = ({
               </div>
             ) : null}
           </div>
-
-          <Input
-            id="rack-label"
-            label="Label"
-            initValue={effectiveLabel}
-            onChange={(value) => {
-              setLabel(value);
-              setLabelManuallyEdited(true);
-            }}
-            error={labelError}
-          />
 
           {rackTypes.length > 0 ? (
             <Select

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -10,6 +10,7 @@ import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1
 import { buildKnownSiteIds, useSites } from "@/protoFleet/api/sites";
 import { issueOptions } from "@/protoFleet/components/DeviceSetList";
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
+import NullState from "@/protoFleet/components/NullState";
 import {
   intersectSiteFilters,
   isMatchNoneSiteFilter,
@@ -20,6 +21,7 @@ import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import BuildingModals from "@/protoFleet/features/buildings/components/BuildingModals";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
+import { useFleetCreateFlow } from "@/protoFleet/features/fleetManagement/components/FleetCreateFlow/context";
 import {
   FILTER_URL_PARAM_KEYS,
   fleetListTelemetryRangesFromURL,
@@ -36,7 +38,7 @@ import {
   type TelemetryFilterKey,
 } from "@/protoFleet/features/fleetManagement/utils/telemetryFilterBounds";
 import { useHasPermission } from "@/protoFleet/store";
-import { Alert } from "@/shared/assets/icons";
+import { Alert, Building, Plus } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Header from "@/shared/components/Header";
@@ -200,6 +202,8 @@ const FleetBuildingsPage = () => {
             kind: "building" as const,
             id: building.building.id,
             name: building.building.name,
+            // Rides along for the "New site" conflict pre-warning.
+            siteId: building.building.siteId ?? 0n,
           },
         ];
       }),
@@ -265,7 +269,17 @@ const FleetBuildingsPage = () => {
 
   const { assignBuildingsToSite } = useSites();
   const [reparentTarget, setReparentTarget] = useState<BuildingWithCounts | null>(null);
+  const [bulkAddToSite, setBulkAddToSite] = useState(false);
   const handleAddBuildingToSite = useCallback((row: BuildingWithCounts) => setReparentTarget(row), []);
+
+  // Open the hoisted create flow in place when it commits a new entity.
+  const createFlow = useFleetCreateFlow();
+  const entitiesChangedAt = createFlow?.entitiesChangedAt ?? 0;
+  useEffect(() => {
+    if (entitiesChangedAt === 0) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- refetch on a cross-component create signal; external-sync pattern.
+    fetchBuildings();
+  }, [entitiesChangedAt, fetchBuildings]);
 
   const siteFilterOptions = useMemo(
     () => [
@@ -436,6 +450,15 @@ const FleetBuildingsPage = () => {
       <FleetGroupListActionBar
         selectedScopes={selectedBuildingScopes}
         kind="building"
+        bulkExtraActions={[
+          {
+            label: "Add to site",
+            icon: <Plus />,
+            testId: "fleet-bulk-building-actions-add-to-site",
+            onClick: () => setBulkAddToSite(true),
+            hidden: !canManageBuildings,
+          },
+        ]}
         onClearSelection={handleClearBuildingSelection}
         onSelectAllVisible={handleSelectAllVisibleBuildings}
         onActionBusyChange={setIsBulkActionBusy}
@@ -470,19 +493,23 @@ const FleetBuildingsPage = () => {
         </div>
       </FilterRow>
     ) : (
-      <FilterRow testId="fleet-buildings-page">
-        {filterControls}
-        <div className="flex flex-col items-start gap-3 rounded-xl border border-dashed border-border-5 p-6">
-          <Header title="No buildings yet" titleSize="text-heading-200" />
-          <p className="text-300 text-text-primary-70">
-            {!canManageBuildings
-              ? "No buildings have been added to this fleet yet."
-              : hasSites
-                ? "Add a building to start organizing racks."
-                : "Create a site first, then add buildings to organize racks."}
-          </p>
-        </div>
-      </FilterRow>
+      <NullState
+        icon={<Building width="w-5" />}
+        title="No buildings yet"
+        description={
+          !canManageBuildings
+            ? "No buildings have been added to this fleet yet."
+            : hasSites
+              ? "Add a building to start organizing racks."
+              : "Create a site first, then add buildings to organize racks."
+        }
+        action={
+          canManageBuildings ? (
+            <Button variant={variants.primary} onClick={handleAddBuilding} disabled={!hasSites} text="Add building" />
+          ) : undefined
+        }
+        testId="fleet-buildings-page"
+      />
     );
   } else if (visibleBuildings.length === 0) {
     pageContent = (
@@ -536,6 +563,18 @@ const FleetBuildingsPage = () => {
           selectionMode="single"
           sourceLabel={reparentTarget.building.name || "building"}
           currentParentId={reparentTarget.building.siteId}
+          createNewLaunchLabel={createFlow ? "New site" : undefined}
+          onCreateNewLaunch={
+            createFlow
+              ? () => {
+                  const building = reparentTarget.building;
+                  if (!building) return;
+                  const conflictCount = building.siteId !== undefined && building.siteId !== 0n ? 1 : 0;
+                  setReparentTarget(null);
+                  createFlow.launchCreateSite({ buildingIds: [building.id], rackIds: [], minerIds: [], conflictCount });
+                }
+              : undefined
+          }
           onDismiss={() => setReparentTarget(null)}
           onConfirm={(siteIds) =>
             new Promise<void>((resolve, reject) => {
@@ -557,6 +596,60 @@ const FleetBuildingsPage = () => {
                 },
                 onError: (msg) => {
                   pushToast({ message: `Couldn't move building: ${msg}`, status: STATUSES.error });
+                  reject(new Error(msg));
+                },
+              });
+            })
+          }
+        />
+      ) : null}
+      {bulkAddToSite ? (
+        <ParentPickerModal
+          kind="site"
+          show
+          selectionMode="single"
+          sourceLabel={
+            selectedBuildingScopes.length === 1
+              ? selectedBuildingScopes[0]!.name
+              : `${selectedBuildingScopes.length} buildings`
+          }
+          createNewLaunchLabel={createFlow ? "New site" : undefined}
+          onCreateNewLaunch={
+            createFlow
+              ? () => {
+                  const buildingIds = selectedBuildingScopes.map((scope) => scope.id);
+                  const conflictCount = selectedBuildingScopes.filter((scope) => scope.siteId !== 0n).length;
+                  setBulkAddToSite(false);
+                  setSelectedBuildingIds([]);
+                  createFlow.launchCreateSite({ buildingIds, rackIds: [], minerIds: [], conflictCount });
+                }
+              : undefined
+          }
+          onDismiss={() => setBulkAddToSite(false)}
+          onConfirm={(siteIds) =>
+            new Promise<void>((resolve, reject) => {
+              const targetSiteId = siteIds[0];
+              if (targetSiteId === undefined) {
+                resolve();
+                return;
+              }
+              const buildingIds = selectedBuildingScopes.map((scope) => scope.id);
+              const count = buildingIds.length;
+              void assignBuildingsToSite({
+                buildingIds,
+                targetSiteId,
+                onSuccess: () => {
+                  pushToast({
+                    message: `Moved ${count} ${count === 1 ? "building" : "buildings"} to selected site.`,
+                    status: STATUSES.success,
+                  });
+                  fetchBuildings();
+                  setBulkAddToSite(false);
+                  setSelectedBuildingIds([]);
+                  resolve();
+                },
+                onError: (msg) => {
+                  pushToast({ message: `Couldn't move buildings: ${msg}`, status: STATUSES.error });
                   reject(new Error(msg));
                 },
               });

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -493,23 +493,26 @@ const FleetBuildingsPage = () => {
         </div>
       </FilterRow>
     ) : (
-      <NullState
-        icon={<Building width="w-5" />}
-        title="No buildings yet"
-        description={
-          !canManageBuildings
-            ? "No buildings have been added to this fleet yet."
-            : hasSites
-              ? "Add a building to start organizing racks."
-              : "Create a site first, then add buildings to organize racks."
-        }
-        action={
-          canManageBuildings ? (
-            <Button variant={variants.primary} onClick={handleAddBuilding} disabled={!hasSites} text="Add building" />
-          ) : undefined
-        }
-        testId="fleet-buildings-page"
-      />
+      <>
+        {inlineErrors}
+        <NullState
+          icon={<Building width="w-5" />}
+          title="No buildings yet"
+          description={
+            !canManageBuildings
+              ? "No buildings have been added to this fleet yet."
+              : hasSites
+                ? "Add a building to start organizing racks."
+                : "Create a site first, then add buildings to organize racks."
+          }
+          action={
+            canManageBuildings ? (
+              <Button variant={variants.primary} onClick={handleAddBuilding} disabled={!hasSites} text="Add building" />
+            ) : undefined
+          }
+          testId="fleet-buildings-page"
+        />
+      </>
     );
   } else if (visibleBuildings.length === 0) {
     pageContent = (

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
@@ -337,17 +337,20 @@ const FleetSitesPage = () => {
   // the operator still needs the create CTA.
   if (!hasListFilters && displaySites.length === 0) {
     pageContent = (
-      <NullState
-        icon={<Site width="w-5" />}
-        title="No sites yet"
-        description="Create your first site to organize miners by location."
-        action={
-          canManageSites ? (
-            <Button variant={variants.primary} onClick={modals.openCreate} text="Add a site" />
-          ) : undefined
-        }
-        testId="fleet-sites-page"
-      />
+      <>
+        {inlineError}
+        <NullState
+          icon={<Site width="w-5" />}
+          title="No sites yet"
+          description="Create your first site to organize miners by location."
+          action={
+            canManageSites ? (
+              <Button variant={variants.primary} onClick={modals.openCreate} text="Add a site" />
+            ) : undefined
+          }
+          testId="fleet-sites-page"
+        />
+      </>
     );
   } else if (hasListFilters && displaySites.length === 0) {
     pageContent = (

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
@@ -8,6 +8,7 @@ import SiteList from "../components/SiteList";
 import { buildKnownSiteIds, useSites } from "@/protoFleet/api/sites";
 import { issueOptions } from "@/protoFleet/components/DeviceSetList";
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
+import NullState from "@/protoFleet/components/NullState";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import {
@@ -23,10 +24,9 @@ import {
   type TelemetryFilterKey,
 } from "@/protoFleet/features/fleetManagement/utils/telemetryFilterBounds";
 import SiteModals from "@/protoFleet/features/sites/components/SiteModals";
-import SitesEmptyState from "@/protoFleet/features/sites/components/SitesEmptyState";
 import { useSiteModals } from "@/protoFleet/features/sites/hooks/useSiteModals";
 import { useHasPermission } from "@/protoFleet/store";
-import { Alert } from "@/shared/assets/icons";
+import { Alert, Site } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Header from "@/shared/components/Header";
@@ -337,10 +337,17 @@ const FleetSitesPage = () => {
   // the operator still needs the create CTA.
   if (!hasListFilters && displaySites.length === 0) {
     pageContent = (
-      <FilterRow testId="fleet-sites-page">
-        {inlineError}
-        <SitesEmptyState onAddSite={canManageSites ? modals.openCreate : undefined} />
-      </FilterRow>
+      <NullState
+        icon={<Site width="w-5" />}
+        title="No sites yet"
+        description="Create your first site to organize miners by location."
+        action={
+          canManageSites ? (
+            <Button variant={variants.primary} onClick={modals.openCreate} text="Add a site" />
+          ) : undefined
+        }
+        testId="fleet-sites-page"
+      />
     );
   } else if (hasListFilters && displaySites.length === 0) {
     pageContent = (

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -27,6 +27,7 @@ import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
 import { MULTI_SITE_ENABLED } from "@/protoFleet/constants/featureFlags";
 import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
+import { useFleetCreateFlow } from "@/protoFleet/features/fleetManagement/components/FleetCreateFlow/context";
 import FleetGroupActionsMenu from "@/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu";
 import FleetGroupListActionBar from "@/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar";
 import { useOptionalFleetOutletContext } from "@/protoFleet/features/fleetManagement/components/FleetLayout";
@@ -364,6 +365,18 @@ const RacksPage = () => {
   useEffect(() => {
     fetchZones();
   }, [fetchZones]);
+
+  // Refetch when the hoisted create flow commits a new rack (or other
+  // entity) so this list reflects it without waiting for the next poll.
+  // entitiesChangedAt starts at 0 and only bumps post-create, so the
+  // initial mount is a no-op.
+  const createFlow = useFleetCreateFlow();
+  const entitiesChangedAt = createFlow?.entitiesChangedAt ?? 0;
+  useEffect(() => {
+    if (entitiesChangedAt === 0) return;
+    resetAndFetch();
+    fetchZones();
+  }, [entitiesChangedAt, resetAndFetch, fetchZones]);
 
   // One-shot load — org-scoped buildings are small + stable.
   useEffect(() => {
@@ -742,8 +755,11 @@ const RacksPage = () => {
         // Carry the rack's current building so the bulk Add-to-building
         // dispatch can drop no-op moves (a same-building request without a
         // grid position is treated server-side as an explicit unplace).
-        const buildingId = rack.typeDetails.case === "rackInfo" ? rack.typeDetails.value.buildingId : 0n;
-        return [{ kind: "rack" as const, id: rack.id, name: rack.label || "(unnamed)", buildingId }];
+        // siteId rides along for the "New site" conflict pre-warning.
+        const rackInfo = rack.typeDetails.case === "rackInfo" ? rack.typeDetails.value : undefined;
+        const buildingId = rackInfo?.buildingId ?? 0n;
+        const siteId = rackInfo?.siteId ?? 0n;
+        return [{ kind: "rack" as const, id: rack.id, name: rack.label || "(unnamed)", buildingId, siteId }];
       }),
     [racks],
   );
@@ -1284,6 +1300,25 @@ const RacksPage = () => {
           sourceLabel={
             selectedRackScopes.length === 1 ? selectedRackScopes[0]!.name : `${selectedRackScopes.length} racks`
           }
+          createNewLaunchLabel={
+            createFlow ? (bulkReparentKind === "building" ? "New building" : "New site") : undefined
+          }
+          onCreateNewLaunch={
+            createFlow
+              ? () => {
+                  const rackIds = selectedRackScopes.map((scope) => scope.id);
+                  setBulkReparentKind(null);
+                  setSelectedRackIds([]);
+                  if (bulkReparentKind === "building") {
+                    const conflictCount = selectedRackScopes.filter((scope) => scope.buildingId !== 0n).length;
+                    createFlow.launchCreateBuilding({ rackIds, minerIds: [], conflictCount });
+                  } else {
+                    const conflictCount = selectedRackScopes.filter((scope) => scope.siteId !== 0n).length;
+                    createFlow.launchCreateSite({ buildingIds: [], rackIds, minerIds: [], conflictCount });
+                  }
+                }
+              : undefined
+          }
           onDismiss={() => setBulkReparentKind(null)}
           onConfirm={(parentIds) =>
             new Promise<void>((resolve, reject) => {
@@ -1358,6 +1393,35 @@ const RacksPage = () => {
               ? reparentTarget.kind === "building"
                 ? reparentTarget.rack.typeDetails.value.buildingId
                 : reparentTarget.rack.typeDetails.value.siteId
+              : undefined
+          }
+          createNewLaunchLabel={
+            createFlow ? (reparentTarget.kind === "building" ? "New building" : "New site") : undefined
+          }
+          onCreateNewLaunch={
+            createFlow
+              ? () => {
+                  const rack = reparentTarget.rack;
+                  const targetKind = reparentTarget.kind;
+                  const rackInfo = rack.typeDetails.case === "rackInfo" ? rack.typeDetails.value : undefined;
+                  setReparentTarget(null);
+                  if (targetKind === "building") {
+                    const buildingId = rackInfo?.buildingId ?? 0n;
+                    createFlow.launchCreateBuilding({
+                      rackIds: [rack.id],
+                      minerIds: [],
+                      conflictCount: buildingId !== 0n ? 1 : 0,
+                    });
+                  } else {
+                    const siteId = rackInfo?.siteId ?? 0n;
+                    createFlow.launchCreateSite({
+                      buildingIds: [],
+                      rackIds: [rack.id],
+                      minerIds: [],
+                      conflictCount: siteId !== 0n ? 1 : 0,
+                    });
+                  }
+                }
               : undefined
           }
           onDismiss={() => setReparentTarget(null)}

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -1336,7 +1336,12 @@ const RacksPage = () => {
                     ).length;
                     createFlow.launchCreateBuilding({ rackIds, minerIds: [], conflictCount });
                   } else {
-                    const conflictCount = selectedRackScopes.filter((scope) => scope.siteId !== 0n).length;
+                    // A rack directly in another site OR in a building (whose
+                    // building_id AssignRacksToSite clears on the cross-site
+                    // move) is displaced — warn for both.
+                    const conflictCount = selectedRackScopes.filter(
+                      (scope) => scope.siteId !== 0n || scope.buildingId !== 0n,
+                    ).length;
                     createFlow.launchCreateSite({ buildingIds: [], rackIds, minerIds: [], conflictCount });
                   }
                 }
@@ -1438,11 +1443,14 @@ const RacksPage = () => {
                     });
                   } else {
                     const siteId = rackInfo?.siteId ?? 0n;
+                    const buildingId = rackInfo?.buildingId ?? 0n;
                     createFlow.launchCreateSite({
                       buildingIds: [],
                       rackIds: [rack.id],
                       minerIds: [],
-                      conflictCount: siteId !== 0n ? 1 : 0,
+                      // AssignRacksToSite clears building_id on the cross-site
+                      // move, so a building-held rack is displaced too.
+                      conflictCount: siteId !== 0n || buildingId !== 0n ? 1 : 0,
                     });
                   }
                 }

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -1310,7 +1310,11 @@ const RacksPage = () => {
                   setBulkReparentKind(null);
                   setSelectedRackIds([]);
                   if (bulkReparentKind === "building") {
-                    const conflictCount = selectedRackScopes.filter((scope) => scope.buildingId !== 0n).length;
+                    // A rack in another building OR directly in another site
+                    // will be moved into the new building's site.
+                    const conflictCount = selectedRackScopes.filter(
+                      (scope) => scope.buildingId !== 0n || scope.siteId !== 0n,
+                    ).length;
                     createFlow.launchCreateBuilding({ rackIds, minerIds: [], conflictCount });
                   } else {
                     const conflictCount = selectedRackScopes.filter((scope) => scope.siteId !== 0n).length;
@@ -1407,10 +1411,11 @@ const RacksPage = () => {
                   setReparentTarget(null);
                   if (targetKind === "building") {
                     const buildingId = rackInfo?.buildingId ?? 0n;
+                    const siteId = rackInfo?.siteId ?? 0n;
                     createFlow.launchCreateBuilding({
                       rackIds: [rack.id],
                       minerIds: [],
-                      conflictCount: buildingId !== 0n ? 1 : 0,
+                      conflictCount: buildingId !== 0n || siteId !== 0n ? 1 : 0,
                     });
                   } else {
                     const siteId = rackInfo?.siteId ?? 0n;

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -366,55 +366,74 @@ const RacksPage = () => {
     fetchZones();
   }, [fetchZones]);
 
-  // Refetch when the hoisted create flow commits a new rack (or other
-  // entity) so this list reflects it without waiting for the next poll.
-  // entitiesChangedAt starts at 0 and only bumps post-create, so the
-  // initial mount is a no-op.
   const createFlow = useFleetCreateFlow();
   const entitiesChangedAt = createFlow?.entitiesChangedAt ?? 0;
+
+  // Org-scoped parent catalogs powering the Site/Building columns + filter
+  // labels. Extracted into callbacks so the create-flow pulse can refresh
+  // them — a building/site created from this tab must resolve to a name
+  // immediately, not only after a remount.
+  const fetchBuildingCatalog = useCallback(
+    (signal?: AbortSignal) => {
+      if (!canReadSiteCatalog) return;
+      void listAllBuildings({
+        signal,
+        onSuccess: (buildings: BuildingWithCounts[]) => {
+          setAllBuildings(
+            buildings
+              .filter((b) => b.building !== undefined)
+              .map((b) => ({
+                id: b.building!.id.toString(),
+                label: b.building!.name,
+                siteId: (b.building!.siteId ?? 0n).toString(),
+              })),
+          );
+        },
+      });
+    },
+    [canReadSiteCatalog, listAllBuildings],
+  );
+
+  const fetchSiteCatalog = useCallback(
+    (signal?: AbortSignal) => {
+      if (!canReadSiteCatalog) return;
+      void listSites({
+        signal,
+        onSuccess: (sites: SiteWithCounts[]) => {
+          setAllSites(
+            sites.filter((s) => s.site !== undefined).map((s) => ({ id: s.site!.id.toString(), label: s.site!.name })),
+          );
+        },
+        onError: () => setAllSites((prev) => prev),
+      });
+    },
+    [canReadSiteCatalog, listSites],
+  );
+
+  // Refetch when the hoisted create flow commits a new entity so this list
+  // AND its parent-name catalogs reflect it without waiting for the next poll.
+  // entitiesChangedAt starts at 0 and only bumps post-create, so the initial
+  // mount is a no-op.
   useEffect(() => {
     if (entitiesChangedAt === 0) return;
     resetAndFetch();
     fetchZones();
-  }, [entitiesChangedAt, resetAndFetch, fetchZones]);
+    fetchBuildingCatalog();
+    fetchSiteCatalog();
+  }, [entitiesChangedAt, resetAndFetch, fetchZones, fetchBuildingCatalog, fetchSiteCatalog]);
 
-  // One-shot load — org-scoped buildings are small + stable.
+  // One-shot loads on mount — org-scoped catalogs are small + stable.
   useEffect(() => {
-    if (!canReadSiteCatalog) return;
-
     const controller = new AbortController();
-    void listAllBuildings({
-      signal: controller.signal,
-      onSuccess: (buildings: BuildingWithCounts[]) => {
-        setAllBuildings(
-          buildings
-            .filter((b) => b.building !== undefined)
-            .map((b) => ({
-              id: b.building!.id.toString(),
-              label: b.building!.name,
-              siteId: (b.building!.siteId ?? 0n).toString(),
-            })),
-        );
-      },
-    });
+    fetchBuildingCatalog(controller.signal);
     return () => controller.abort();
-  }, [canReadSiteCatalog, listAllBuildings]);
+  }, [fetchBuildingCatalog]);
 
   useEffect(() => {
-    if (!canReadSiteCatalog) return;
-
     const controller = new AbortController();
-    void listSites({
-      signal: controller.signal,
-      onSuccess: (sites: SiteWithCounts[]) => {
-        setAllSites(
-          sites.filter((s) => s.site !== undefined).map((s) => ({ id: s.site!.id.toString(), label: s.site!.name })),
-        );
-      },
-      onError: () => setAllSites((prev) => prev),
-    });
+    fetchSiteCatalog(controller.signal);
     return () => controller.abort();
-  }, [canReadSiteCatalog, listSites]);
+  }, [fetchSiteCatalog]);
 
   const siteNameById = useMemo(() => new Map((allSites ?? []).map((s) => [s.id, s.label])), [allSites]);
   const buildingNameById = useMemo(() => new Map(allBuildings.map((b) => [b.id, b.label])), [allBuildings]);

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
@@ -54,6 +54,11 @@ interface ManageSiteModalProps {
   // (e.g. a building deleted from the settings table) so the modal's local
   // list re-fetches without bouncing through unmount/remount.
   buildingsRefreshKey?: number;
+  // Counts of items assigned directly to this site (not via a building),
+  // shown as count lines under the buildings list. Set when the site was
+  // created from a bulk "New site" action seeded with loose racks/miners.
+  unassignedRackCount?: number;
+  unassignedMinerCount?: number;
 }
 
 // Row layout mirrors MinerRow from ManageRackModal: name + secondary line
@@ -150,6 +155,8 @@ const ManageSiteModal = ({
   onDismiss,
   saving = false,
   buildingsRefreshKey = 0,
+  unassignedRackCount,
+  unassignedMinerCount,
 }: ManageSiteModalProps) => {
   const { listBuildingsBySite } = useBuildings();
   // undefined = loading; [] = loaded-empty. Working set the operator edits
@@ -330,6 +337,16 @@ const ManageSiteModal = ({
                   ))}
                 </div>
               )}
+              {unassignedRackCount ? (
+                <p className="text-200 text-text-primary-50" data-testid="manage-site-unassigned-racks">
+                  {unassignedRackCount} {unassignedRackCount === 1 ? "rack" : "racks"} unassigned to a building
+                </p>
+              ) : null}
+              {unassignedMinerCount ? (
+                <p className="text-200 text-text-primary-50" data-testid="manage-site-unassigned-miners">
+                  {unassignedMinerCount} {unassignedMinerCount === 1 ? "miner" : "miners"} unassigned to a building
+                </p>
+              ) : null}
             </section>
           </div>
         }

--- a/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.test.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.test.tsx
@@ -16,6 +16,8 @@ const makeModals = (overrides: Partial<SiteModalsApi> = {}): SiteModalsApi => ({
   deleteTarget: null,
   saving: false,
   deleting: false,
+  manageUnassignedRackCount: undefined,
+  manageUnassignedMinerCount: undefined,
   openCreate: vi.fn(),
   openManageEdit: vi.fn(),
   requestDeleteCurrent: vi.fn(),

--- a/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.tsx
@@ -60,6 +60,8 @@ const SiteModals = ({ modals, sites, buildingsRefreshKey }: SiteModalsProps) => 
           onDismiss={modals.dismiss}
           saving={modals.saving}
           buildingsRefreshKey={buildingsRefreshKey}
+          unassignedRackCount={modals.manageUnassignedRackCount}
+          unassignedMinerCount={modals.manageUnassignedMinerCount}
         />
       ) : null}
       {state.kind === "detailsCreate" ? (

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
@@ -40,7 +40,12 @@ export interface SiteModalsApi {
   saving: boolean;
   deleting: boolean;
   openCreate: () => void;
-  openManageEdit: (site: Site) => void;
+  // unassigned*Count surface count-lines in ManageSiteModal when the site was
+  // created from a bulk "New site" action seeded with loose racks/miners.
+  // Omitted by normal edit callers → no count lines.
+  openManageEdit: (site: Site, opts?: { unassignedRackCount?: number; unassignedMinerCount?: number }) => void;
+  manageUnassignedRackCount: number | undefined;
+  manageUnassignedMinerCount: number | undefined;
   // Resolve a SiteWithCounts from the page's sites cache and open the
   // cascade dialog. The hook does the lookup so callers don't duplicate the
   // same id-matching logic.
@@ -73,6 +78,10 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
   const [deleteTarget, setDeleteTarget] = useState<SiteWithCounts | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  // Set by openManageEdit; read while the manage modal is open. Stale values
+  // while closed are harmless, and the next openManageEdit overwrites.
+  const [manageUnassignedRackCount, setManageUnassignedRackCount] = useState<number | undefined>(undefined);
+  const [manageUnassignedMinerCount, setManageUnassignedMinerCount] = useState<number | undefined>(undefined);
 
   // Synchronous in-flight guard for Save dispatches. setState batching means
   // the `saving` prop driving the button's `disabled` lags one render behind
@@ -96,9 +105,14 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
     setState({ kind: "detailsCreate", draft: emptySiteFormValues() });
   }, []);
 
-  const openManageEdit = useCallback((site: Site) => {
-    setState({ kind: "manageEdit", site, draft: siteFormValuesFromSite(site) });
-  }, []);
+  const openManageEdit = useCallback(
+    (site: Site, opts?: { unassignedRackCount?: number; unassignedMinerCount?: number }) => {
+      setManageUnassignedRackCount(opts?.unassignedRackCount);
+      setManageUnassignedMinerCount(opts?.unassignedMinerCount);
+      setState({ kind: "manageEdit", site, draft: siteFormValuesFromSite(site) });
+    },
+    [],
+  );
 
   const requestDeleteCurrent = useCallback((sites: SiteWithCounts[] | undefined) => {
     // Pulls the currently-edited site id from state and resolves the matching
@@ -350,6 +364,8 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
     deleteTarget,
     saving,
     deleting,
+    manageUnassignedRackCount,
+    manageUnassignedMinerCount,
     openCreate,
     openManageEdit,
     requestDeleteCurrent,

--- a/docs/plans/2026-06-23-bulk-create-new-parent-flows-tdd.md
+++ b/docs/plans/2026-06-23-bulk-create-new-parent-flows-tdd.md
@@ -1,0 +1,118 @@
+---
+title: "Multi-site UI hardening: create-new parent from bulk/row actions"
+date: 2026-06-23
+status: implementing
+type: tdd
+---
+
+# Multi-site UI hardening: create-new parent from bulk/row actions
+
+## Context
+
+Three tightening tasks land in one UI-hardening PR. Tasks 1–2 are done and
+type-check clean; this doc covers Task 3, which has the only real
+architecture.
+
+- **Task 1 (done):** `RackSettingsModal` — auto-labeler removed, label before
+  zone, zone optional.
+- **Task 2 (done):** `FleetSitesPage` / `FleetBuildingsPage` first-run empty
+  branch renders the shared `NullState` and skips the filter row, matching the
+  Racks tab.
+- **Task 3 (this doc):** every "Add to rack/building/site" picker — bulk **and**
+  single-row — gains a "New …" launch button that runs the existing creation
+  flow with the current selection pre-seeded.
+
+## Decisions (agreed)
+
+1. **Hoist the create flows into `FleetLayout`.** Rather than navigate between
+   pages to reach a create flow, a single controller mounted in `FleetLayout`
+   hosts the rack/building/site create modal stacks and exposes launch functions
+   via the fleet outlet context. Any tab launches them in place. Standalone
+   routes (no `FleetLayout` Outlet) read the launcher through
+   `useOptionalFleetOutletContext`; when absent, the "New …" button is hidden.
+2. **Option (i) for off-diagonal selections.** When the selected item type does
+   not match the target modal's position panel, the items are assigned to the
+   new parent as **direct members** (no position) and surfaced as a count line
+   under the left-panel list ("n miners unassigned to a rack", "n racks
+   unassigned to a building"). Richer naked-item UI is a deferred design pass.
+3. **Conflict warning reuse (B).** Before entering a create flow, run the same
+   membership-conflict detection as the normal reparent flow; if any selected
+   item already belongs to another parent, show the existing warn dialog and
+   only continue on confirm.
+
+## Seeding matrix
+
+| Source  | "New …"      | Lands on            | Seed                                              |
+| ------- | ------------ | ------------------- | ------------------------------------------------- |
+| Miners  | New rack     | `ManageRackModal`   | position-seed miners (slot assignment)            |
+| Racks   | New building | `ManageBuildingModal` | position-seed racks (aisle/position)            |
+| Buildings | New site   | `ManageSiteModal`   | position-seed buildings                           |
+| Miners  | New building | `ManageBuildingModal` | direct miners + count line                      |
+| Miners  | New site     | `ManageSiteModal`   | direct miners + count line                        |
+| Racks   | New site     | `ManageSiteModal`   | direct racks + count line                         |
+
+## Create→manage handoff (per entity)
+
+The handoff differs by modal because of how each persists:
+
+- **Rack — "seed then save at end."** `ManageRackModal` already supports a
+  no-`existingRackId` new mode and persists members + slots atomically on save.
+  Flow: `RackSettingsModal` → `ManageRackModal({ seededMinerIds })` → save.
+  (Seed prop added; done.)
+- **Building — "create then assign then manage."** `useBuildingModals.detailsCreate`
+  runs `CreateBuilding` and returns the new `Building` without opening manage.
+  Flow: conflict check → `detailsCreate` → `assignRacksToBuilding`
+  (+ direct miner assignment) → `openManage(newRow)` →
+  `ManageBuildingModal` loads the now-assigned racks for positioning + count line.
+- **Site — "create then assign then manage (edit mode)."** Constraint:
+  `ManageSiteModal` create mode **gates building assignment until the site
+  exists** (`useSiteModals.manageSave` create-path runs `CreateSite` with an
+  empty delta). So the seeded handoff cannot use create mode. Flow: conflict
+  check → `createSite` → `assignBuildingsToSite` (+ direct rack/miner
+  assignment) → `openManageEdit(newSite)` → `ManageSiteModal` (edit) loads the
+  assigned buildings + count line.
+
+## Components
+
+- **`ParentPickerModal` (done):** `onCreateNewLaunch` + `createNewLaunchLabel`
+  render the "New …" button; distinct from the group inline-name path.
+- **`FleetCreateFlowProvider`** (new, mounted in `FleetLayout`): owns dedicated
+  `useBuildingModals` / `useSiteModals` instances plus rack-create state, renders
+  `<BuildingModals>` / `<SiteModals>` / rack modals, and exposes:
+  - `launchCreateRack({ minerIds })`
+  - `launchCreateBuilding({ rackIds, minerIds })`
+  - `launchCreateSite({ buildingIds, rackIds, minerIds })`
+  These run the orchestration above (conflict check → create → assign → manage).
+- **Outlet context:** add the three launchers (optional) so pages/menus read
+  them via `useFleetOutletContext` and hide the button when undefined.
+- **Manage modal seed props:** `ManageRackModal.seededMinerIds` (done);
+  `ManageBuildingModal` direct-miner count line; `ManageSiteModal`
+  direct-rack/miner count line. Position-seed for building/site is achieved by
+  assigning before `openManage*`, so no extra seed prop is needed there — the
+  modal loads the freshly-assigned children.
+
+## Refresh coordination
+
+The controller's create instances are separate from each page's own
+`use*Modals`. After a create, refresh the active list: sites via FleetLayout's
+`fetchSites`; buildings/racks via a new outlet-context pulse
+(`fleetEntitiesChangedAt`) that list pages watch to refetch.
+
+## Wiring (all bulk + single-row)
+
+- Miners (`MinerReparentPicker`): "New rack/building/site" — resolve selection
+  (reuse all-mode resolver), conflict check, then call the matching launcher.
+- Racks (`RacksPage`): "New building/site" on bulk + single-row pickers.
+- Buildings (`FleetBuildingsPage`): "New site" on bulk + single-row; **add the
+  missing bulk "Add to site" action** (currently single-row only).
+
+## Test plan
+
+- Rack: bulk + row "New rack" from miners → settings → manage with seeded
+  miners; save persists membership.
+- Building: "New building" from racks → manage shows seeded racks; from miners →
+  count line; conflict dialog fires when a selected rack/miner has another parent.
+- Site: "New site" from buildings → manage (edit) shows assigned buildings; from
+  racks/miners → count line.
+- Standalone routes (no FleetLayout) hide the "New …" button.
+- Type-check + lint + targeted vitest for the controller and pickers.

--- a/docs/plans/2026-06-23-bulk-create-new-parent-flows-tdd.md
+++ b/docs/plans/2026-06-23-bulk-create-new-parent-flows-tdd.md
@@ -3,6 +3,7 @@ title: "Multi-site UI hardening: create-new parent from bulk/row actions"
 date: 2026-06-23
 status: implementing
 type: tdd
+tracker: https://github.com/block/proto-fleet/pull/551
 ---
 
 # Multi-site UI hardening: create-new parent from bulk/row actions

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -2055,6 +2055,15 @@ func (s *Service) replaceRackMembershipAndSlots(ctx context.Context, orgID, coll
 	// lockstep; its IS-DISTINCT-FROM-guarded queries no-op the column that
 	// didn't change, so cascadeCount stays accurate.
 	if len(deviceIdentifiers) > 0 {
+		// Clear any prior rack membership for these devices (excluding this
+		// rack) before adding them, so a device seeded from another rack
+		// MOVES here instead of tripping idx_one_rack_per_device. Mirrors
+		// AssignDevicesToRack's move semantics within the same transaction —
+		// no orphan window. A no-op for the edit flow, which never sends
+		// devices already sitting in a different rack.
+		if _, err := s.collectionStore.RemoveDevicesFromAnyRack(ctx, orgID, deviceIdentifiers, collectionID); err != nil {
+			return out, err
+		}
 		if _, err := s.collectionStore.AddDevicesToCollection(ctx, orgID, collectionID, deviceIdentifiers); err != nil {
 			return out, err
 		}

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -1720,6 +1720,25 @@ func (s *Service) SaveRack(ctx context.Context, req *pb.SaveRackRequest) (*pb.Sa
 			buildingChanged bool
 		)
 
+		// Canonical lock pre-pass, mirroring AssignDevicesToRack: lock the
+		// target plus every source rack the members currently sit in, in one
+		// ascending device_set.id order, BEFORE the per-path target lock and
+		// the replaceRackMembershipAndSlots deletes. This is what keeps the
+		// new RemoveDevicesFromAnyRack delete from deadlocking against a
+		// concurrent rack save moving devices the opposite way. targetRackID
+		// is 0 on the create path (the rack doesn't exist yet; it's created +
+		// locked below and sorts last by id). Guarded on a non-empty member
+		// set — an empty save removes members and touches no source racks.
+		if len(deviceIdentifiers) > 0 {
+			var lockTargetRackID int64
+			if req.CollectionId != nil {
+				lockTargetRackID = *req.CollectionId
+			}
+			if _, err := s.collectionStore.LockRacksForReparent(ctx, info.OrganizationID, deviceIdentifiers, lockTargetRackID); err != nil {
+				return nil, err
+			}
+		}
+
 		if isUpdate {
 			res, err := s.saveRackUpdate(ctx, info, req, rackInfo)
 			if err != nil {

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -1032,6 +1032,7 @@ func TestService_SaveRack_CreateNewRack(t *testing.T) {
 	mockStore.EXPECT().CreateRackExtension(gomock.Any(), gomock.Any()).
 		Return(nil)
 	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, int64(10)).Return(int64(0), nil)
+	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(10)).Return(int64(0), nil)
 	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, int64(10), deviceIDs).Return(int64(2), nil)
 	// A rack ALWAYS dictates member placement now — a site-less rack
 	// cascades nil/nil, stripping any member's direct site/building to
@@ -1088,6 +1089,7 @@ func TestService_SaveRack_UpdateExistingRack(t *testing.T) {
 	mockStore.EXPECT().UpdateRackInfo(gomock.Any(), collectionID, "Building A", int32(4), int32(8), int32(pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT), int32(pb.RackCoolingType_RACK_COOLING_TYPE_AIR), testOrgID).Return(nil)
 	mockStore.EXPECT().UpdateRackPlacement(gomock.Any(), collectionID, testOrgID, gomock.Nil(), gomock.Nil(), "Building A").Return(nil)
 	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, collectionID).Return(int64(2), nil)
+	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, collectionID).Return(int64(0), nil)
 	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, collectionID, deviceIDs).Return(int64(1), nil)
 	// Site-less rack now cascades nil/nil unconditionally — members can't
 	// keep a direct site/building the rack lacks.
@@ -1315,6 +1317,7 @@ func TestService_SaveRack_StoreErrorRollsBack(t *testing.T) {
 	mockStore.EXPECT().CreateRackExtension(gomock.Any(), gomock.Any()).
 		Return(nil)
 	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, int64(10)).Return(int64(0), nil)
+	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(10)).Return(int64(0), nil)
 	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, int64(10), deviceIDs).
 		Return(int64(0), fleeterror.NewInternalError("database error"))
 
@@ -1559,6 +1562,7 @@ func TestService_SaveRack_MoveBetweenBuildingsCascadesSite(t *testing.T) {
 	mockStore.EXPECT().UpdateRackPlacement(gomock.Any(), collectionID, testOrgID, gomock.Eq(&newSiteID), gomock.Eq(&newBuilding), "").Return(nil)
 
 	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, collectionID).Return(int64(1), nil)
+	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, collectionID).Return(int64(0), nil)
 	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, collectionID, deviceIDs).Return(int64(1), nil)
 	// Single cascade after membership replace: captures per-device
 	// priors on the FINAL member set, then rewrites differing devices.

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -1032,6 +1032,7 @@ func TestService_SaveRack_CreateNewRack(t *testing.T) {
 	mockStore.EXPECT().CreateRackExtension(gomock.Any(), gomock.Any()).
 		Return(nil)
 	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, int64(10)).Return(int64(0), nil)
+	mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, int64(0)).Return(nil, nil)
 	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(10)).Return(int64(0), nil)
 	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, int64(10), deviceIDs).Return(int64(2), nil)
 	// A rack ALWAYS dictates member placement now — a site-less rack
@@ -1089,6 +1090,7 @@ func TestService_SaveRack_UpdateExistingRack(t *testing.T) {
 	mockStore.EXPECT().UpdateRackInfo(gomock.Any(), collectionID, "Building A", int32(4), int32(8), int32(pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT), int32(pb.RackCoolingType_RACK_COOLING_TYPE_AIR), testOrgID).Return(nil)
 	mockStore.EXPECT().UpdateRackPlacement(gomock.Any(), collectionID, testOrgID, gomock.Nil(), gomock.Nil(), "Building A").Return(nil)
 	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, collectionID).Return(int64(2), nil)
+	mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, collectionID).Return(nil, nil)
 	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, collectionID).Return(int64(0), nil)
 	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, collectionID, deviceIDs).Return(int64(1), nil)
 	// Site-less rack now cascades nil/nil unconditionally — members can't
@@ -1317,6 +1319,7 @@ func TestService_SaveRack_StoreErrorRollsBack(t *testing.T) {
 	mockStore.EXPECT().CreateRackExtension(gomock.Any(), gomock.Any()).
 		Return(nil)
 	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, int64(10)).Return(int64(0), nil)
+	mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, int64(0)).Return(nil, nil)
 	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, int64(10)).Return(int64(0), nil)
 	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, int64(10), deviceIDs).
 		Return(int64(0), fleeterror.NewInternalError("database error"))
@@ -1562,6 +1565,7 @@ func TestService_SaveRack_MoveBetweenBuildingsCascadesSite(t *testing.T) {
 	mockStore.EXPECT().UpdateRackPlacement(gomock.Any(), collectionID, testOrgID, gomock.Eq(&newSiteID), gomock.Eq(&newBuilding), "").Return(nil)
 
 	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, collectionID).Return(int64(1), nil)
+	mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, collectionID).Return(nil, nil)
 	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, collectionID).Return(int64(0), nil)
 	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, collectionID, deviceIDs).Return(int64(1), nil)
 	// Single cascade after membership replace: captures per-device


### PR DESCRIPTION
Reviewable diff: +905/-84 across 18 files (excludes generated, test, and story files).

## Summary

Three multi-site UI hardening changes in one PR:

1. **Rack details form** no longer requires a zone, puts **Label before Zone**, and drops the auto-labeler that derived a rack name from the zone.
2. **Sites and Buildings tabs** show the same full-page null state as the Racks tab on first run (and hide the filter row) instead of a dashed inline box.
3. **Every "Add to rack / building / site" picker** — bulk and single-row — gains a **"New …"** button that runs the existing creation flow with the items you selected pre-seeded into the new parent, so you can create a parent and populate it in one motion. It also adds the previously-missing **bulk "Add to site"** action on the Buildings tab.

## How it works

### Rack form (Task 1)
`RackSettingsModal` previously generated a label from an abbreviated zone unless the operator typed one. That logic is removed; Label is a plain required field rendered first, Zone is an optional field rendered second. Existing zone autocomplete is unchanged.

### Tab null states (Task 2)
`FleetSitesPage` / `FleetBuildingsPage` previously rendered a dashed inline message inside the sticky `FilterRow` when empty. The first-run branch (no filters, zero entries) now early-returns the shared `NullState` component with a primary create CTA, and crucially does **not** render `FilterRow`/filter controls — matching the Racks tab. The active-filter and unassigned-scope branches are untouched (they keep the filter row so the operator can clear filters).

### Create-new parent flows (Task 3)
The reparent pickers (`ParentPickerModal`) all sit on pages mounted inside `FleetLayout`. Rather than navigate between pages to reach a creation flow, a single **`FleetCreateFlowProvider`** is mounted once in `FleetLayout`. It hosts the rack/building/site create modal stacks and exposes `launchCreateRack`, `launchCreateBuilding`, `launchCreateSite`, plus an `entitiesChangedAt` pulse, through React context (`useFleetCreateFlow`). On standalone routes that mount a list page without the shell, the hook returns `undefined` and the "New …" button is hidden.

`ParentPickerModal` gains an `onCreateNewLaunch` / `createNewLaunchLabel` pair that renders the "New …" button (distinct from the existing inline name-input path used by groups). Each call site wires the button to resolve its current selection and call the matching launcher.

The selected items land in the new parent two ways:

- **Position-seed** (item type matches the modal's grid): miners → new rack (slot assignment), racks → new building (aisle/position), buildings → new site.
- **Direct-member** (off-diagonal): miners → building/site, racks → site. The items are assigned directly (no position) and surfaced as a count line ("n miners unassigned to a rack", "n racks/miners unassigned to a building").

Per-entity handoff differs by how each modal persists:

- **Rack** uses `ManageRackModal`'s existing new-rack mode and saves members + slots atomically at the end (`seededMinerIds` initializes the left pane).
- **Building** creates the row, assigns the seeded racks/miners (force-clearing prior memberships), then opens `ManageBuildingModal` for positioning.
- **Site** creates the row, assigns seeded buildings/racks/miners, then opens `ManageSiteModal` in **edit** mode — create mode gates building assignment until the site exists, so the seeded flow can't use it.

Before entering a create flow, if any selected item already belongs to another parent the provider shows a confirm dialog, mirroring the normal reparent flow. Each call site computes the conflict count from data it already holds: racks/buildings from their `buildingId`/`siteId`, miners from their `placement` refs (site/building/rack) via the existing `minerPlacement` helpers. After a create commits, the provider bumps `entitiesChangedAt`; the active list page watches it and refetches.

```mermaid
flowchart TD
    A["Selection (miners / racks / buildings)"] --> B["ParentPickerModal — 'New …' button"]
    B --> C["useFleetCreateFlow.launchCreate*"]
    C --> D{"conflictCount > 0?"}
    D -->|"yes"| E["Confirm dialog (move from current parent?)"]
    D -->|"no"| F["Create settings step"]
    E -->|"continue"| F
    F --> G{"entity type"}
    G -->|"rack"| H["ManageRackModal — seed miners, save members+slots"]
    G -->|"building"| I["Create building, assign seed, open ManageBuildingModal"]
    G -->|"site"| J["Create site, assign seed, open ManageSiteModal (edit)"]
    H --> K["bump entitiesChangedAt → active list refetches"]
    I --> K
    J --> K
```

```mermaid
flowchart LR
    FL["FleetLayout"] --> P["FleetCreateFlowProvider (context)"]
    P --> O["Outlet: Miners / Racks / Buildings / Sites tabs"]
    O --> RP["ParentPickerModal (bulk + row)"]
    RP -->|"launchCreate*"| P
    P --> RM["Rack create stack"]
    P --> BM["BuildingModals (own useBuildingModals)"]
    P --> SM["SiteModals (own useSiteModals)"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `components/FleetCreateFlow/FleetCreateFlowProvider.tsx` (new) | Hosts all three create stacks; orchestrates create → assign → manage; conflict confirm dialogs | Core of Task 3 — the orchestration and force-clear-on-assign live here |
| `components/FleetCreateFlow/context.ts` (new) | Context, `useFleetCreateFlow`, seed types | Split out so the provider file only exports a component (fast-refresh) |
| `components/FleetLayout/FleetLayout.tsx` | Wraps `Outlet` in the provider, passes `sites` | Mount point; confirms every fleet tab is in scope |
| `components/ParentPickerModal/ParentPickerModal.tsx` | `onCreateNewLaunch`/`createNewLaunchLabel` button | Shared affordance; group inline-name path untouched |
| `MinerActionsMenu/MinerReparentPicker.tsx` | "New rack/building/site"; resolves selection + snapshots; computes miner conflict count from `placement` | Miner-sourced flows + all-mode selection resolution |
| `pages/RacksPage.tsx` | "New building/site" on bulk + row pickers; carries `siteId` on rack scope; refetch on pulse | Rack-sourced flows |
| `pages/FleetBuildingsPage.tsx` | New bulk "Add to site" action + bulk picker; "New site" on bulk + row; null state; refetch on pulse | Buildings-sourced flow + the parity fix |
| `pages/FleetSitesPage.tsx` | First-run `NullState`, drop `SitesEmptyState` | Task 2 |
| `components/RackSettingsModal.tsx` | Remove auto-labeler, reorder, optional zone | Task 1 (net −39 lines) |
| `ManageRackModal/ManageRackModal.tsx` | `seededMinerIds` for new-rack seeding | Rack handoff |
| `buildings/.../ManageBuildingModal.tsx`, `BuildingRacksPane.tsx` | `unassignedMinerCount` count line | Direct-member display |
| `buildings/hooks/useBuildingModals.ts`, `BuildingModals.tsx` | `openManage` carries `manageUnassignedMinerCount` | Threads count to the building manage modal |
| `sites/.../ManageSiteModal.tsx`, `SiteModals.tsx`, `hooks/useSiteModals.ts` | `unassignedRackCount`/`unassignedMinerCount` count lines via `openManageEdit` | Threads counts to the site manage modal |
| `docs/plans/2026-06-23-bulk-create-new-parent-flows-tdd.md` (new) | Design doc | Rationale + handoff constraints |

## Key technical decisions & trade-offs

- **Hoist create flows into `FleetLayout` via context** rather than navigate-with-router-state. Keeps each create flow centralized and lets any tab launch it in place; the cost is one provider mounting modal stacks for the whole shell.
- **Provider owns its own `useBuildingModals`/`useSiteModals` instances** (separate from each page's). Avoids disturbing existing edit/delete wiring; the shared hooks got small backward-compatible additions (`openManage`/`openManageEdit` accept optional count args) rather than invasive changes.
- **Site create→manage routes through edit mode**, because `ManageSiteModal` create mode gates building assignment until the site exists. Create the row, assign, then open edit.
- **Conflict pre-warn is server-pattern-consistent but computed client-side** from data already loaded (entity FKs / miner placement refs), so no extra fetch. Force-clear on assign matches the reparent "continue" path.
- **Count line is the interim representation** of naked direct-members in the building/site modals; a fuller design pass is explicitly deferred.

## Testing & validation

- `tsc --noEmit`, `eslint --max-warnings 0`, and `prettier` all clean on the changed files.
- Unit tests pass for the touched modal stacks and pickers (`BuildingModals`, `SiteModals`, `useBuildingModals`, `useSiteModals`, `ManageRackModal`, `ManageBuildingModal`, `ManageSiteModal`, `ParentPickerModal`, `MinerActionsMenu`, `FleetLayout`) — no regressions.
- **Not covered:** no new automated tests for the create-new flows themselves (manual dogfooding pending); end-to-end Playwright not run.
