### PR TITLE
Add site-scoped response profile controls

### DIFF
--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -165,7 +165,7 @@ const siteResponseProfiles: CurtailmentResponseProfileOption[] = [
       ...responseProfiles[0].values,
       scopeType: "site",
       scopeId: "Austin, TX",
-      siteId: "austin-tx",
+      siteId: "101",
       deviceSetIds: [],
       deviceIdentifiers: [],
       includeMaintenance: false,
@@ -456,7 +456,7 @@ describe("CurtailmentStartModal", () => {
         responseProfileId: "customPlan",
         scopeType: "site",
         scopeId: "Austin, TX",
-        siteId: "austin-tx",
+        siteId: "101",
         deviceSetIds: [],
         deviceIdentifiers: [],
       }),
@@ -498,6 +498,50 @@ describe("CurtailmentStartModal", () => {
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         responseProfileId: "missing-site-id-shed",
+        scopeType: "wholeOrg",
+        scopeId: "whole-org",
+        siteId: "",
+        deviceSetIds: [],
+        deviceIdentifiers: [],
+      }),
+    );
+  });
+
+  it("normalizes a site-scoped response profile with an invalid site id to whole fleet", async () => {
+    const user = userEvent.setup();
+    const malformedSiteResponseProfiles: CurtailmentResponseProfileOption[] = [
+      {
+        id: "invalid-site-id-shed",
+        label: "Invalid site id shed",
+        values: {
+          ...responseProfiles[0].values,
+          scopeType: "site",
+          scopeId: "Austin, TX",
+          siteId: "austin-tx",
+          deviceSetIds: [],
+          deviceIdentifiers: [],
+          includeMaintenance: false,
+        },
+      },
+    ];
+    const { onSubmit } = renderModal({
+      initialValues: { ...configuredValues, includeMaintenance: false },
+      responseProfiles: malformedSiteResponseProfiles,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Profile" }));
+    await user.click(screen.getByText("Invalid site id shed"));
+
+    expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Invalid site id shed");
+    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Run curtailment" }));
+    expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
+    await confirmCurtailment(user);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseProfileId: "invalid-site-id-shed",
         scopeType: "wholeOrg",
         scopeId: "whole-org",
         siteId: "",
@@ -704,6 +748,62 @@ describe("CurtailmentStartModal", () => {
         siteId: "101",
         scopeType: "site",
         scopeId: "Austin, TX",
+      }),
+    );
+  });
+
+  it("renders a missing saved site as a disabled fallback row", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      variant: "responseProfile",
+      siteOptions: [{ id: "102", name: "Denver, CO" }],
+      initialValues: {
+        ...configuredValues,
+        scopeType: "site",
+        scopeId: "Austin, TX",
+        siteId: "101",
+        includeMaintenance: false,
+      },
+    });
+
+    expect(screen.getByTestId("response-profile-scope-site-101")).toBeDisabled();
+    expect(screen.getByTestId("response-profile-scope-site-101")).toHaveTextContent("Saved site");
+    expect(screen.getByTestId("response-profile-scope-site-102")).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: "Save profile" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteId: "101",
+        scopeType: "site",
+        scopeId: "Austin, TX",
+      }),
+    );
+  });
+
+  it("normalizes an invalid response profile initial site id before saving", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      variant: "responseProfile",
+      initialValues: {
+        ...configuredValues,
+        scopeType: "site",
+        scopeId: "Austin, TX",
+        siteId: "austin-tx",
+        includeMaintenance: false,
+      },
+    });
+
+    expect(screen.getByTestId("response-profile-scope-whole-fleet")).toBeInTheDocument();
+    expect(screen.queryByTestId("response-profile-scope-site-austin-tx")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Save profile" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteId: "",
+        scopeType: "wholeOrg",
+        scopeId: "whole-org",
       }),
     );
   });

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -636,7 +636,7 @@ describe("CurtailmentStartModal", () => {
     );
   });
 
-  it("does not preserve hidden site scope when site scope is disabled", async () => {
+  it("preserves hidden site scope when site scope is disabled", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
       variant: "responseProfile",
@@ -650,16 +650,16 @@ describe("CurtailmentStartModal", () => {
       },
     });
 
-    expect(screen.queryByTestId("response-profile-scope-site-101")).not.toBeInTheDocument();
+    expect(screen.getByTestId("response-profile-scope-site-101")).toBeDisabled();
     expect(screen.getByTestId("response-profile-scope-whole-fleet")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Save profile" }));
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
-        siteId: "",
-        scopeType: "wholeOrg",
-        scopeId: "whole-org",
+        siteId: "101",
+        scopeType: "site",
+        scopeId: "Austin, TX",
       }),
     );
   });

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -508,6 +508,7 @@ describe("CurtailmentStartModal", () => {
     });
     const { onSubmit } = renderModal({
       variant: "responseProfile",
+      siteOptions,
       initialValues: {
         ...configuredValues,
         scopeType: "site",
@@ -625,12 +626,41 @@ describe("CurtailmentStartModal", () => {
     renderModal({
       variant: "responseProfile",
       initialValues: configuredValues,
+      siteScopeEnabled: false,
       siteScopeDisabledReason: "Site scope is not available for the current user.",
     });
 
     expect(screen.getByTestId("response-profile-scope-site-unavailable")).toBeDisabled();
     expect(screen.getByTestId("response-profile-scope-site-unavailable")).toHaveTextContent(
       "Site scope is not available for the current user.",
+    );
+  });
+
+  it("does not preserve hidden site scope when site scope is disabled", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      variant: "responseProfile",
+      siteScopeEnabled: false,
+      initialValues: {
+        ...configuredValues,
+        scopeType: "site",
+        scopeId: "Austin, TX",
+        siteId: "101",
+        includeMaintenance: false,
+      },
+    });
+
+    expect(screen.queryByTestId("response-profile-scope-site-101")).not.toBeInTheDocument();
+    expect(screen.getByTestId("response-profile-scope-whole-fleet")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Save profile" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteId: "",
+        scopeType: "wholeOrg",
+        scopeId: "whole-org",
+      }),
     );
   });
 
@@ -740,6 +770,7 @@ describe("CurtailmentStartModal", () => {
     const { onSubmit } = renderModal({
       variant: "responseProfile",
       responseProfileMode: "edit",
+      siteOptions,
       onDeleteResponseProfile,
       onTestCurtailment,
       initialValues: {

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -766,8 +766,10 @@ describe("CurtailmentStartModal", () => {
       },
     });
 
-    expect(screen.getByTestId("response-profile-scope-site-101")).toBeDisabled();
-    expect(screen.getByTestId("response-profile-scope-site-101")).toHaveTextContent("Saved site");
+    const savedSiteRow = screen.getByTestId("response-profile-scope-site-101");
+    expect(savedSiteRow).toBeDisabled();
+    expect(savedSiteRow).toHaveTextContent("Saved site");
+    expect(within(savedSiteRow).getByRole("radio")).toBeChecked();
     expect(screen.getByTestId("response-profile-scope-site-102")).toBeEnabled();
 
     await user.click(screen.getByRole("button", { name: "Save profile" }));

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -9,6 +9,7 @@ import CurtailmentStartModal, {
   type CurtailmentFormValues,
   type CurtailmentPlanPreview,
   type CurtailmentResponseProfileOption,
+  type CurtailmentSiteOption,
 } from "@/protoFleet/features/energy/CurtailmentStartModal";
 
 type MockFullScreenTwoPaneModalProps = Pick<
@@ -170,6 +171,11 @@ const siteResponseProfiles: CurtailmentResponseProfileOption[] = [
       includeMaintenance: false,
     },
   },
+];
+
+const siteOptions: CurtailmentSiteOption[] = [
+  { id: "101", name: "Austin, TX" },
+  { id: "102", name: "Denver, CO" },
 ];
 
 const scopeLessResponseProfiles: CurtailmentResponseProfileOption[] = [
@@ -413,7 +419,7 @@ describe("CurtailmentStartModal", () => {
     );
   });
 
-  it("ignores unsupported site scope from response profiles in create mode", async () => {
+  it("preserves site scope from response profiles in live curtailment create mode", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
       initialValues: { ...configuredValues, includeMaintenance: false },
@@ -428,19 +434,19 @@ describe("CurtailmentStartModal", () => {
     await user.click(screen.getByText("Austin site shed"));
 
     expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Austin site shed");
-    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Site\s+Austin, TX/ })).toBeInTheDocument();
 
     await user.clear(screen.getByLabelText("Fixed target reduction (kW)"));
     await user.type(screen.getByLabelText("Fixed target reduction (kW)"), "75");
 
     expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Custom plan");
-    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Site\s+Austin, TX/ })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Run curtailment" }));
     expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This will curtail miners across the fleet immediately. Schedules stay suppressed until miners are restored.",
+        "This will curtail miners in Austin, TX immediately. Schedules stay suppressed until miners are restored.",
       ),
     ).toBeInTheDocument();
     await confirmCurtailment(user);
@@ -448,9 +454,9 @@ describe("CurtailmentStartModal", () => {
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         responseProfileId: "customPlan",
-        scopeType: "wholeOrg",
-        scopeId: "whole-org",
-        siteId: "",
+        scopeType: "site",
+        scopeId: "Austin, TX",
+        siteId: "austin-tx",
         deviceSetIds: [],
         deviceIdentifiers: [],
       }),
@@ -523,7 +529,8 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByLabelText("Profile name")).toHaveValue("Grid peak - ERCOT 4CP signal");
     expect(screen.queryByLabelText("Reason")).not.toBeInTheDocument();
     expect(screen.queryByText("No miners match this curtailment.")).not.toBeInTheDocument();
-    expect(screen.queryByText("Apply to")).not.toBeInTheDocument();
+    expect(screen.getByText("Apply to")).toBeInTheDocument();
+    expect(screen.getByTestId("response-profile-scope-site-101")).toHaveTextContent("Austin, TX");
     expect(screen.queryByRole("button", { name: /Miners\s+Select/ })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Min duration (sec)")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Max duration (sec)")).not.toBeInTheDocument();
@@ -545,7 +552,7 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This will save the profile, then trigger curtailment for the whole fleet. Schedules stay suppressed until miners are restored.",
+        "This will save the profile, then trigger curtailment for miners in Austin, TX. Schedules stay suppressed until miners are restored.",
       ),
     ).toBeInTheDocument();
     expect(onTestCurtailment).not.toHaveBeenCalled();
@@ -553,14 +560,14 @@ describe("CurtailmentStartModal", () => {
     expect(onTestCurtailment).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: "Grid peak - ERCOT 4CP signal",
-        siteId: "",
+        siteId: "101",
         curtailmentMode: "fullFleet",
         curtailBatchSize: "8",
         curtailBatchIntervalSec: "30",
         restoreBatchSize: "10",
         restoreIntervalSec: "120",
-        scopeType: "wholeOrg",
-        scopeId: "whole-org",
+        scopeType: "site",
+        scopeId: "Austin, TX",
         deviceSetIds: [],
         deviceIdentifiers: [],
         includeMaintenance: true,
@@ -573,17 +580,57 @@ describe("CurtailmentStartModal", () => {
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: "Grid peak - ERCOT 4CP signal",
-        siteId: "",
+        siteId: "101",
         curtailBatchSize: "8",
         curtailBatchIntervalSec: "30",
         restoreBatchSize: "10",
         restoreIntervalSec: "120",
-        scopeType: "wholeOrg",
-        scopeId: "whole-org",
+        scopeType: "site",
+        scopeId: "Austin, TX",
         deviceSetIds: [],
         deviceIdentifiers: [],
         includeMaintenance: true,
       }),
+    );
+  });
+
+  it("selects site scope when creating a response profile", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      variant: "responseProfile",
+      initialValues: {
+        ...configuredValues,
+        includeMaintenance: false,
+      },
+      siteOptions,
+    });
+
+    expect(screen.getByTestId("response-profile-scope-whole-fleet")).toHaveTextContent("Whole fleet");
+    await user.click(screen.getByTestId("response-profile-scope-site-102"));
+
+    await user.click(screen.getByRole("button", { name: "Save profile" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteId: "102",
+        scopeType: "site",
+        scopeId: "Denver, CO",
+        deviceSetIds: [],
+        deviceIdentifiers: [],
+      }),
+    );
+  });
+
+  it("disables site scope when it is unavailable for the current user", () => {
+    renderModal({
+      variant: "responseProfile",
+      initialValues: configuredValues,
+      siteScopeDisabledReason: "Site scope is not available for the current user.",
+    });
+
+    expect(screen.getByTestId("response-profile-scope-site-unavailable")).toBeDisabled();
+    expect(screen.getByTestId("response-profile-scope-site-unavailable")).toHaveTextContent(
+      "Site scope is not available for the current user.",
     );
   });
 
@@ -650,7 +697,7 @@ describe("CurtailmentStartModal", () => {
 
     expect(
       screen.getByText(
-        "This will save the profile, then trigger curtailment for miners across the fleet. Schedules stay suppressed until miners are restored.",
+        "This will save the profile, then trigger curtailment for miners in all sites. Schedules stay suppressed until miners are restored.",
       ),
     ).toBeInTheDocument();
   });
@@ -727,7 +774,8 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByTestId("response-profile-restore-batch-size")).toHaveValue("10000");
     expect(screen.getByTestId("response-profile-restore-batch-interval")).toHaveValue("0");
     expect(screen.queryByTestId("response-profile-post-event-cooldown")).not.toBeInTheDocument();
-    expect(screen.queryByText("Apply to")).not.toBeInTheDocument();
+    expect(screen.getByText("Apply to")).toBeInTheDocument();
+    expect(screen.getByTestId("response-profile-scope-site-102")).toHaveTextContent("Denver, CO");
     expect(screen.queryByRole("button", { name: /Miners\s+Select/ })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Delete" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Run curtailment" })).toBeEnabled();
@@ -778,6 +826,36 @@ describe("CurtailmentStartModal", () => {
 
     await user.click(screen.getByRole("button", { name: "Delete" }));
     expect(onDeleteResponseProfile).toHaveBeenCalledOnce();
+  });
+
+  it("can switch a site-scoped response profile back to whole fleet", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      variant: "responseProfile",
+      responseProfileMode: "edit",
+      siteOptions,
+      initialValues: {
+        ...configuredValues,
+        reason: "Site Alpha 500 kW",
+        scopeType: "site",
+        scopeId: "Austin, TX",
+        siteId: "101",
+        includeMaintenance: false,
+      },
+    });
+
+    await user.click(screen.getByTestId("response-profile-scope-whole-fleet"));
+    await user.click(screen.getByRole("button", { name: "Save profile" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteId: "",
+        scopeType: "wholeOrg",
+        scopeId: "whole-org",
+        deviceSetIds: [],
+        deviceIdentifiers: [],
+      }),
+    );
   });
 
   it("renders edit mode with the full plan visible and locked where fields are not updateable", async () => {

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -463,6 +463,50 @@ describe("CurtailmentStartModal", () => {
     );
   });
 
+  it("normalizes a site-scoped response profile without a site id to whole fleet", async () => {
+    const user = userEvent.setup();
+    const malformedSiteResponseProfiles: CurtailmentResponseProfileOption[] = [
+      {
+        id: "missing-site-id-shed",
+        label: "Missing site id shed",
+        values: {
+          ...responseProfiles[0].values,
+          scopeType: "site",
+          scopeId: "Missing site",
+          siteId: "   ",
+          deviceSetIds: [],
+          deviceIdentifiers: [],
+          includeMaintenance: false,
+        },
+      },
+    ];
+    const { onSubmit } = renderModal({
+      initialValues: { ...configuredValues, includeMaintenance: false },
+      responseProfiles: malformedSiteResponseProfiles,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Profile" }));
+    await user.click(screen.getByText("Missing site id shed"));
+
+    expect(screen.getByRole("button", { name: "Profile" })).toHaveTextContent("Missing site id shed");
+    expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Run curtailment" }));
+    expect(screen.getByText("Run curtailment?")).toBeInTheDocument();
+    await confirmCurtailment(user);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseProfileId: "missing-site-id-shed",
+        scopeType: "wholeOrg",
+        scopeId: "whole-org",
+        siteId: "",
+        deviceSetIds: [],
+        deviceIdentifiers: [],
+      }),
+    );
+  });
+
   it("preserves the selected target when a response profile option has no scope values", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
@@ -512,7 +556,7 @@ describe("CurtailmentStartModal", () => {
       initialValues: {
         ...configuredValues,
         scopeType: "site",
-        scopeId: "Austin, TX",
+        scopeId: "Stale Austin label",
         siteId: "101",
         curtailmentMode: "fullFleet",
         targetKw: "",

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -818,16 +818,12 @@ function CurtailmentStartModalContent({
     [siteOptions, values.siteId],
   );
   const effectiveValues = useMemo(() => {
-    if (values.scopeType === "site" && !canSelectSiteScope) {
-      return withWholeFleetScope(values);
-    }
-
     if (values.scopeType === "site" && selectedSiteOption) {
       return withSiteScope(values, selectedSiteOption.id, selectedSiteOption.name);
     }
 
     return values;
-  }, [canSelectSiteScope, selectedSiteOption, values]);
+  }, [selectedSiteOption, values]);
   const unsupportedDeviceSetPreviewError = getUnsupportedDeviceSetPreviewError(effectiveValues);
   const controlledPreviewValue = preview
     ? createCurtailmentPlanPreview(effectiveValues, {
@@ -939,8 +935,23 @@ function CurtailmentStartModalContent({
       text: siteOption.name,
       subtext: "Site",
       isSelected: effectiveValues.scopeType === "site" && effectiveValues.siteId === siteOption.id,
+      disabled: !canSelectSiteScope,
       "data-testid": `response-profile-scope-site-${siteOption.id}`,
     }));
+    const currentSiteId = values.scopeType === "site" ? values.siteId : undefined;
+    const shouldShowCurrentSiteFallback =
+      currentSiteId !== undefined && !responseProfileSiteOptionByRowId.has(getSiteScopeRowId(currentSiteId));
+
+    if (shouldShowCurrentSiteFallback) {
+      siteRows.push({
+        id: getSiteScopeRowId(currentSiteId),
+        text: values.scopeId || `Site ${currentSiteId}`,
+        subtext: siteScopeDisabledReason ?? "Saved site",
+        isSelected: true,
+        disabled: true,
+        "data-testid": `response-profile-scope-site-${currentSiteId}`,
+      });
+    }
 
     if (siteRows.length === 0 && (isSiteScopeLoading || siteScopeDisabledReason)) {
       siteRows.push({
@@ -964,11 +975,16 @@ function CurtailmentStartModalContent({
       ...siteRows,
     ];
   }, [
+    canSelectSiteScope,
     effectiveValues.scopeType,
     effectiveValues.siteId,
     isSiteScopeLoading,
+    responseProfileSiteOptionByRowId,
     responseProfileSiteOptions,
     siteScopeDisabledReason,
+    values.scopeId,
+    values.scopeType,
+    values.siteId,
   ]);
   const responseProfileSelectOptions = useMemo(
     () => [

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -194,6 +194,10 @@ const curtailmentModeOptions = [
 ];
 const wholeFleetScopeRowId = "whole-org";
 const getSiteScopeRowId = (siteId: string) => `site:${siteId}`;
+const getPopulatedSiteScopeId = (siteId?: string): string | undefined => {
+  const normalizedSiteId = siteId?.trim();
+  return normalizedSiteId ? normalizedSiteId : undefined;
+};
 
 function withWholeFleetScope(values: CurtailmentFormValues): CurtailmentFormValues {
   return {
@@ -218,8 +222,10 @@ function withSiteScope(values: CurtailmentFormValues, siteId: string, siteName?:
 }
 
 function withResponseProfileScope(values: CurtailmentFormValues): CurtailmentFormValues {
-  if (values.scopeType === "site" && values.siteId) {
-    return withSiteScope(values, values.siteId, values.scopeId);
+  const siteId = getPopulatedSiteScopeId(values.siteId);
+
+  if (values.scopeType === "site" && siteId) {
+    return withSiteScope(values, siteId, values.scopeId);
   }
 
   return withWholeFleetScope(values);
@@ -266,9 +272,10 @@ function withSelectedResponseProfileValues(
     return nextValues;
   }
 
+  const siteId = getPopulatedSiteScopeId(responseProfileValues.siteId);
   const scopeType =
     responseProfileValues.scopeType ??
-    (responseProfileValues.siteId
+    (siteId
       ? "site"
       : responseProfileValues.deviceSetIds?.length
         ? "deviceSet"
@@ -276,8 +283,12 @@ function withSelectedResponseProfileValues(
           ? "explicitMiners"
           : "wholeOrg");
 
-  if (scopeType === "site" && responseProfileValues.siteId) {
-    return withSiteScope(nextValues, responseProfileValues.siteId, responseProfileValues.scopeId);
+  if (scopeType === "site") {
+    if (siteId) {
+      return withSiteScope(nextValues, siteId, responseProfileValues.scopeId);
+    }
+
+    return withWholeFleetScope(nextValues);
   }
 
   if (scopeType === "deviceSet") {
@@ -813,9 +824,10 @@ function CurtailmentStartModalContent({
   }, [editedFields, localErrors]);
   const effectiveErrors = { ...errors, ...visibleLocalErrors };
   const canSelectSiteScope = siteScopeEnabled && !siteScopeDisabledReason;
+  const selectedSiteId = getPopulatedSiteScopeId(values.siteId);
   const selectedSiteOption = useMemo(
-    () => siteOptions.find((option) => option.id === values.siteId),
-    [siteOptions, values.siteId],
+    () => (selectedSiteId ? siteOptions.find((option) => option.id === selectedSiteId) : undefined),
+    [siteOptions, selectedSiteId],
   );
   const effectiveValues = useMemo(() => {
     if (values.scopeType === "site" && selectedSiteOption) {
@@ -913,18 +925,18 @@ function CurtailmentStartModalContent({
       return [];
     }
 
-    if (!values.siteId || selectedSiteOption || (!isSiteScopeLoading && siteOptions.length === 0)) {
+    if (!selectedSiteId || selectedSiteOption || (!isSiteScopeLoading && siteOptions.length === 0)) {
       return siteOptions;
     }
 
     return [
       ...siteOptions,
       {
-        id: values.siteId,
-        name: values.scopeId || `Site ${values.siteId}`,
+        id: selectedSiteId,
+        name: values.scopeId || `Site ${selectedSiteId}`,
       },
     ];
-  }, [canSelectSiteScope, isSiteScopeLoading, selectedSiteOption, siteOptions, values.scopeId, values.siteId]);
+  }, [canSelectSiteScope, isSiteScopeLoading, selectedSiteId, selectedSiteOption, siteOptions, values.scopeId]);
   const responseProfileSiteOptionByRowId = useMemo(
     () => new Map(responseProfileSiteOptions.map((siteOption) => [getSiteScopeRowId(siteOption.id), siteOption])),
     [responseProfileSiteOptions],
@@ -938,7 +950,7 @@ function CurtailmentStartModalContent({
       disabled: !canSelectSiteScope,
       "data-testid": `response-profile-scope-site-${siteOption.id}`,
     }));
-    const currentSiteId = values.scopeType === "site" ? values.siteId : undefined;
+    const currentSiteId = values.scopeType === "site" ? selectedSiteId : undefined;
     const shouldShowCurrentSiteFallback =
       currentSiteId !== undefined && !responseProfileSiteOptionByRowId.has(getSiteScopeRowId(currentSiteId));
 
@@ -981,10 +993,10 @@ function CurtailmentStartModalContent({
     isSiteScopeLoading,
     responseProfileSiteOptionByRowId,
     responseProfileSiteOptions,
+    selectedSiteId,
     siteScopeDisabledReason,
     values.scopeId,
     values.scopeType,
-    values.siteId,
   ]);
   const responseProfileSelectOptions = useMemo(
     () => [
@@ -1183,7 +1195,7 @@ function CurtailmentStartModalContent({
   });
 
   const confirmMaintenanceInclusion = () => {
-    const nextValues = resetResponseProfileSelection({ ...values, includeMaintenance: true });
+    const nextValues = resetResponseProfileSelection({ ...effectiveValues, includeMaintenance: true });
 
     setMaintenanceInclusionConfirmed(true);
     setValues(nextValues);

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -9,6 +9,7 @@ import {
   curtailmentNumericFieldLimits,
   parseOptionalUint32Field,
 } from "@/protoFleet/features/energy/curtailmentNumericFields";
+import { parseCurtailmentSiteId } from "@/protoFleet/features/energy/curtailmentRequestBuilders";
 import {
   createCurtailmentPlanPreview,
   getUnsupportedDeviceSetPreviewError,
@@ -194,9 +195,14 @@ const curtailmentModeOptions = [
 ];
 const wholeFleetScopeRowId = "whole-org";
 const getSiteScopeRowId = (siteId: string) => `site:${siteId}`;
-const getPopulatedSiteScopeId = (siteId?: string): string | undefined => {
+const getValidSiteScopeId = (siteId?: string): string | undefined => {
   const normalizedSiteId = siteId?.trim();
-  return normalizedSiteId ? normalizedSiteId : undefined;
+  if (!normalizedSiteId) {
+    return undefined;
+  }
+
+  const parsedSiteId = parseCurtailmentSiteId(normalizedSiteId);
+  return parsedSiteId?.toString() === normalizedSiteId ? normalizedSiteId : undefined;
 };
 
 function withWholeFleetScope(values: CurtailmentFormValues): CurtailmentFormValues {
@@ -222,7 +228,7 @@ function withSiteScope(values: CurtailmentFormValues, siteId: string, siteName?:
 }
 
 function withResponseProfileScope(values: CurtailmentFormValues): CurtailmentFormValues {
-  const siteId = getPopulatedSiteScopeId(values.siteId);
+  const siteId = getValidSiteScopeId(values.siteId);
 
   if (values.scopeType === "site" && siteId) {
     return withSiteScope(values, siteId, values.scopeId);
@@ -272,7 +278,7 @@ function withSelectedResponseProfileValues(
     return nextValues;
   }
 
-  const siteId = getPopulatedSiteScopeId(responseProfileValues.siteId);
+  const siteId = getValidSiteScopeId(responseProfileValues.siteId);
   const scopeType =
     responseProfileValues.scopeType ??
     (siteId
@@ -824,7 +830,7 @@ function CurtailmentStartModalContent({
   }, [editedFields, localErrors]);
   const effectiveErrors = { ...errors, ...visibleLocalErrors };
   const canSelectSiteScope = siteScopeEnabled && !siteScopeDisabledReason;
-  const selectedSiteId = getPopulatedSiteScopeId(values.siteId);
+  const selectedSiteId = getValidSiteScopeId(values.siteId);
   const selectedSiteOption = useMemo(
     () => (selectedSiteId ? siteOptions.find((option) => option.id === selectedSiteId) : undefined),
     [siteOptions, selectedSiteId],
@@ -925,18 +931,8 @@ function CurtailmentStartModalContent({
       return [];
     }
 
-    if (!selectedSiteId || selectedSiteOption || (!isSiteScopeLoading && siteOptions.length === 0)) {
-      return siteOptions;
-    }
-
-    return [
-      ...siteOptions,
-      {
-        id: selectedSiteId,
-        name: values.scopeId || `Site ${selectedSiteId}`,
-      },
-    ];
-  }, [canSelectSiteScope, isSiteScopeLoading, selectedSiteId, selectedSiteOption, siteOptions, values.scopeId]);
+    return siteOptions;
+  }, [canSelectSiteScope, siteOptions]);
   const responseProfileSiteOptionByRowId = useMemo(
     () => new Map(responseProfileSiteOptions.map((siteOption) => [getSiteScopeRowId(siteOption.id), siteOption])),
     [responseProfileSiteOptions],

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -103,6 +103,7 @@ interface CurtailmentStartModalProps {
   initialValues?: Partial<CurtailmentFormValues>;
   responseProfiles?: CurtailmentResponseProfileOption[];
   siteOptions?: CurtailmentSiteOption[];
+  siteScopeEnabled?: boolean;
   isSiteScopeLoading?: boolean;
   siteScopeDisabledReason?: string;
   errors?: CurtailmentFormErrors;
@@ -740,6 +741,7 @@ function CurtailmentStartModalContent({
   initialValues,
   responseProfiles = [],
   siteOptions = [],
+  siteScopeEnabled = true,
   isSiteScopeLoading = false,
   siteScopeDisabledReason,
   errors,
@@ -810,9 +812,25 @@ function CurtailmentStartModalContent({
     return visibleErrors;
   }, [editedFields, localErrors]);
   const effectiveErrors = { ...errors, ...visibleLocalErrors };
-  const unsupportedDeviceSetPreviewError = getUnsupportedDeviceSetPreviewError(values);
+  const canSelectSiteScope = siteScopeEnabled && !siteScopeDisabledReason;
+  const selectedSiteOption = useMemo(
+    () => siteOptions.find((option) => option.id === values.siteId),
+    [siteOptions, values.siteId],
+  );
+  const effectiveValues = useMemo(() => {
+    if (values.scopeType === "site" && !canSelectSiteScope) {
+      return withWholeFleetScope(values);
+    }
+
+    if (values.scopeType === "site" && selectedSiteOption) {
+      return withSiteScope(values, selectedSiteOption.id, selectedSiteOption.name);
+    }
+
+    return values;
+  }, [canSelectSiteScope, selectedSiteOption, values]);
+  const unsupportedDeviceSetPreviewError = getUnsupportedDeviceSetPreviewError(effectiveValues);
   const controlledPreviewValue = preview
-    ? createCurtailmentPlanPreview(values, {
+    ? createCurtailmentPlanPreview(effectiveValues, {
         selectedMinerCount: preview.selectedMinerCount,
         targetKw: preview.targetKw,
         estimatedReductionKw: preview.estimatedReductionKw,
@@ -824,7 +842,7 @@ function CurtailmentStartModalContent({
       : undefined;
   const apiPreview = useCurtailmentPlanPreview({
     open,
-    values,
+    values: effectiveValues,
     disabled: isLiveCurtailmentEditMode || controlledPreview !== undefined,
   });
   const previewState = getPreviewState({
@@ -842,8 +860,11 @@ function CurtailmentStartModalContent({
   const hasEditableChanges = !isLiveCurtailmentEditMode || hasEditableCurtailmentChanges(values, initialFormValues);
   const isSubmitDisabled = isBusy || hasBlockingSubmitPreviewState || hasExternalFormError || !hasEditableChanges;
   const displayedPreviewState = isResponseProfileVariant ? responseProfilePreviewState(previewState) : previewState;
-  const selectedMinerIds = getSelectedMinerIds(values);
-  const applyToTarget = getApplyToTarget(values, isLiveCurtailmentEditMode || values.scopeType === "site");
+  const selectedMinerIds = getSelectedMinerIds(effectiveValues);
+  const applyToTarget = getApplyToTarget(
+    effectiveValues,
+    isLiveCurtailmentEditMode || effectiveValues.scopeType === "site",
+  );
   const isFullFleetMode = values.curtailmentMode === "fullFleet";
   const curtailmentBehaviorSubtext = isLiveCurtailmentEditMode
     ? undefined
@@ -891,12 +912,12 @@ function CurtailmentStartModalContent({
       : "Close curtailment planner";
   const primaryButtonText = isResponseProfileVariant ? "Save profile" : isEditMode ? "Save" : "Run curtailment";
   const shouldShowResponseProfileSelector = !isResponseProfileVariant && !isEditMode;
-  const selectedSiteOption = useMemo(
-    () => siteOptions.find((option) => option.id === values.siteId),
-    [siteOptions, values.siteId],
-  );
   const responseProfileSiteOptions = useMemo(() => {
-    if (!values.siteId || selectedSiteOption) {
+    if (!canSelectSiteScope) {
+      return [];
+    }
+
+    if (!values.siteId || selectedSiteOption || (!isSiteScopeLoading && siteOptions.length === 0)) {
       return siteOptions;
     }
 
@@ -907,7 +928,7 @@ function CurtailmentStartModalContent({
         name: values.scopeId || `Site ${values.siteId}`,
       },
     ];
-  }, [selectedSiteOption, siteOptions, values.scopeId, values.siteId]);
+  }, [canSelectSiteScope, isSiteScopeLoading, selectedSiteOption, siteOptions, values.scopeId, values.siteId]);
   const responseProfileSiteOptionByRowId = useMemo(
     () => new Map(responseProfileSiteOptions.map((siteOption) => [getSiteScopeRowId(siteOption.id), siteOption])),
     [responseProfileSiteOptions],
@@ -917,7 +938,7 @@ function CurtailmentStartModalContent({
       id: getSiteScopeRowId(siteOption.id),
       text: siteOption.name,
       subtext: "Site",
-      isSelected: values.scopeType === "site" && values.siteId === siteOption.id,
+      isSelected: effectiveValues.scopeType === "site" && effectiveValues.siteId === siteOption.id,
       "data-testid": `response-profile-scope-site-${siteOption.id}`,
     }));
 
@@ -937,12 +958,18 @@ function CurtailmentStartModalContent({
         id: wholeFleetScopeRowId,
         text: "Whole fleet",
         subtext: "All miners in the fleet",
-        isSelected: values.scopeType !== "site",
+        isSelected: effectiveValues.scopeType !== "site",
         "data-testid": "response-profile-scope-whole-fleet",
       },
       ...siteRows,
     ];
-  }, [isSiteScopeLoading, responseProfileSiteOptions, siteScopeDisabledReason, values.scopeType, values.siteId]);
+  }, [
+    effectiveValues.scopeType,
+    effectiveValues.siteId,
+    isSiteScopeLoading,
+    responseProfileSiteOptions,
+    siteScopeDisabledReason,
+  ]);
   const responseProfileSelectOptions = useMemo(
     () => [
       { value: customResponseProfileId, label: "Custom plan" },
@@ -1070,11 +1097,11 @@ function CurtailmentStartModalContent({
     }
 
     if (!isResponseProfileVariant && !isEditMode) {
-      requestCurtailmentConfirmation("run", values);
+      requestCurtailmentConfirmation("run", effectiveValues);
       return;
     }
 
-    onSubmit(values);
+    onSubmit(effectiveValues);
   };
 
   const requestResponseProfileCurtailment = () => {
@@ -1097,7 +1124,7 @@ function CurtailmentStartModalContent({
       return;
     }
 
-    requestCurtailmentConfirmation("test", values);
+    requestCurtailmentConfirmation("test", effectiveValues);
   };
 
   const buttons: NonNullable<FullScreenTwoPaneModalProps["buttons"]> = [];

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -23,7 +23,8 @@ import Input from "@/shared/components/Input";
 import Popover, { PopoverProvider, popoverSizes, usePopover } from "@/shared/components/Popover";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import Select from "@/shared/components/Select";
-import { positions } from "@/shared/constants";
+import SelectRowList from "@/shared/components/SelectRowList";
+import { positions, selectTypes } from "@/shared/constants";
 
 export type CurtailmentPriority = "normal" | "emergency";
 export type CurtailmentScopeType = "wholeOrg" | "site" | "deviceSet" | "explicitMiners";
@@ -64,6 +65,11 @@ export interface CurtailmentResponseProfileOption {
   values: Partial<Omit<CurtailmentFormValues, "responseProfileId">>;
 }
 
+export interface CurtailmentSiteOption {
+  id: string;
+  name: string;
+}
+
 export interface CurtailmentPlanPreview {
   selectedMinerCount: number;
   targetKw: number;
@@ -96,6 +102,9 @@ interface CurtailmentStartModalProps {
   responseProfileMode?: ResponseProfileModalMode;
   initialValues?: Partial<CurtailmentFormValues>;
   responseProfiles?: CurtailmentResponseProfileOption[];
+  siteOptions?: CurtailmentSiteOption[];
+  isSiteScopeLoading?: boolean;
+  siteScopeDisabledReason?: string;
   errors?: CurtailmentFormErrors;
   preview?: CurtailmentPlanPreview;
   previewError?: string;
@@ -137,6 +146,14 @@ interface ApplyToTarget {
 
 type ParsedNumberField = { parsed?: number; error?: string };
 type EditableCurtailmentField = "reason" | "restoreIntervalSec";
+type ResponseProfileScopeRow = {
+  id: string;
+  text: string;
+  subtext: string;
+  isSelected: boolean;
+  disabled?: boolean;
+  "data-testid": string;
+};
 
 export const customResponseProfileId = "customPlan";
 const responseProfileDescription = "Saved configurations that define how much power to shed and how to restore it.";
@@ -174,6 +191,8 @@ const curtailmentModeOptions = [
   { value: "fixedKwReduction", label: "Fixed kW reduction" },
   { value: "fullFleet", label: "Full shutdown" },
 ];
+const wholeFleetScopeRowId = "whole-org";
+const getSiteScopeRowId = (siteId: string) => `site:${siteId}`;
 
 function withWholeFleetScope(values: CurtailmentFormValues): CurtailmentFormValues {
   return {
@@ -186,18 +205,20 @@ function withWholeFleetScope(values: CurtailmentFormValues): CurtailmentFormValu
   };
 }
 
-function withResponseProfileScope(
-  values: CurtailmentFormValues,
-  responseProfileMode: ResponseProfileModalMode,
-): CurtailmentFormValues {
-  if (responseProfileMode === "edit" && values.scopeType === "site" && values.siteId) {
-    return {
-      ...values,
-      scopeType: "site",
-      scopeId: values.scopeId ?? `Site ${values.siteId}`,
-      deviceSetIds: [],
-      deviceIdentifiers: [],
-    };
+function withSiteScope(values: CurtailmentFormValues, siteId: string, siteName?: string): CurtailmentFormValues {
+  return {
+    ...values,
+    scopeType: "site",
+    scopeId: siteName || `Site ${siteId}`,
+    siteId,
+    deviceSetIds: [],
+    deviceIdentifiers: [],
+  };
+}
+
+function withResponseProfileScope(values: CurtailmentFormValues): CurtailmentFormValues {
+  if (values.scopeType === "site" && values.siteId) {
+    return withSiteScope(values, values.siteId, values.scopeId);
   }
 
   return withWholeFleetScope(values);
@@ -254,7 +275,11 @@ function withSelectedResponseProfileValues(
           ? "explicitMiners"
           : "wholeOrg");
 
-  if (scopeType === "site" || scopeType === "deviceSet") {
+  if (scopeType === "site" && responseProfileValues.siteId) {
+    return withSiteScope(nextValues, responseProfileValues.siteId, responseProfileValues.scopeId);
+  }
+
+  if (scopeType === "deviceSet") {
     return withWholeFleetScope(nextValues);
   }
 
@@ -279,14 +304,13 @@ function isCurtailmentMode(value: string): value is CurtailmentMode {
 function getInitialValues(
   initialValues?: Partial<CurtailmentFormValues>,
   variant: CurtailmentStartModalVariant = "curtailment",
-  responseProfileMode: ResponseProfileModalMode = "create",
 ): CurtailmentFormValues {
   const values = {
     ...defaultValues,
     ...initialValues,
   };
 
-  return variant === "responseProfile" ? withResponseProfileScope(values, responseProfileMode) : values;
+  return variant === "responseProfile" ? withResponseProfileScope(values) : values;
 }
 
 function parseRequiredPositiveNumberField(value: string, fieldLabel: string): ParsedNumberField {
@@ -715,6 +739,9 @@ function CurtailmentStartModalContent({
   responseProfileMode = "create",
   initialValues,
   responseProfiles = [],
+  siteOptions = [],
+  isSiteScopeLoading = false,
+  siteScopeDisabledReason,
   errors,
   preview,
   previewError,
@@ -723,9 +750,7 @@ function CurtailmentStartModalContent({
   isTestingCurtailment = false,
   isDeleting = false,
 }: CurtailmentStartModalProps): ReactElement {
-  const [initialFormValues] = useState<CurtailmentFormValues>(() =>
-    getInitialValues(initialValues, variant, responseProfileMode),
-  );
+  const [initialFormValues] = useState<CurtailmentFormValues>(() => getInitialValues(initialValues, variant));
   const [values, setValues] = useState<CurtailmentFormValues>(() => initialFormValues);
   const [showMaintenanceConfirmation, setShowMaintenanceConfirmation] = useState(false);
   const [maintenanceInclusionConfirmed, setMaintenanceInclusionConfirmed] = useState(false);
@@ -818,7 +843,7 @@ function CurtailmentStartModalContent({
   const isSubmitDisabled = isBusy || hasBlockingSubmitPreviewState || hasExternalFormError || !hasEditableChanges;
   const displayedPreviewState = isResponseProfileVariant ? responseProfilePreviewState(previewState) : previewState;
   const selectedMinerIds = getSelectedMinerIds(values);
-  const applyToTarget = getApplyToTarget(values, isLiveCurtailmentEditMode);
+  const applyToTarget = getApplyToTarget(values, isLiveCurtailmentEditMode || values.scopeType === "site");
   const isFullFleetMode = values.curtailmentMode === "fullFleet";
   const curtailmentBehaviorSubtext = isLiveCurtailmentEditMode
     ? undefined
@@ -866,6 +891,58 @@ function CurtailmentStartModalContent({
       : "Close curtailment planner";
   const primaryButtonText = isResponseProfileVariant ? "Save profile" : isEditMode ? "Save" : "Run curtailment";
   const shouldShowResponseProfileSelector = !isResponseProfileVariant && !isEditMode;
+  const selectedSiteOption = useMemo(
+    () => siteOptions.find((option) => option.id === values.siteId),
+    [siteOptions, values.siteId],
+  );
+  const responseProfileSiteOptions = useMemo(() => {
+    if (!values.siteId || selectedSiteOption) {
+      return siteOptions;
+    }
+
+    return [
+      ...siteOptions,
+      {
+        id: values.siteId,
+        name: values.scopeId || `Site ${values.siteId}`,
+      },
+    ];
+  }, [selectedSiteOption, siteOptions, values.scopeId, values.siteId]);
+  const responseProfileSiteOptionByRowId = useMemo(
+    () => new Map(responseProfileSiteOptions.map((siteOption) => [getSiteScopeRowId(siteOption.id), siteOption])),
+    [responseProfileSiteOptions],
+  );
+  const responseProfileScopeRows = useMemo(() => {
+    const siteRows: ResponseProfileScopeRow[] = responseProfileSiteOptions.map((siteOption) => ({
+      id: getSiteScopeRowId(siteOption.id),
+      text: siteOption.name,
+      subtext: "Site",
+      isSelected: values.scopeType === "site" && values.siteId === siteOption.id,
+      "data-testid": `response-profile-scope-site-${siteOption.id}`,
+    }));
+
+    if (siteRows.length === 0 && (isSiteScopeLoading || siteScopeDisabledReason)) {
+      siteRows.push({
+        id: "site-unavailable",
+        text: "Site",
+        subtext: isSiteScopeLoading ? "Loading sites..." : (siteScopeDisabledReason ?? "Site scope unavailable"),
+        isSelected: false,
+        disabled: true,
+        "data-testid": "response-profile-scope-site-unavailable",
+      });
+    }
+
+    return [
+      {
+        id: wholeFleetScopeRowId,
+        text: "Whole fleet",
+        subtext: "All miners in the fleet",
+        isSelected: values.scopeType !== "site",
+        "data-testid": "response-profile-scope-whole-fleet",
+      },
+      ...siteRows,
+    ];
+  }, [isSiteScopeLoading, responseProfileSiteOptions, siteScopeDisabledReason, values.scopeType, values.siteId]);
   const responseProfileSelectOptions = useMemo(
     () => [
       { value: customResponseProfileId, label: "Custom plan" },
@@ -899,6 +976,24 @@ function CurtailmentStartModalContent({
       ...withSelectedResponseProfileValues(current, responseProfile.values),
       responseProfileId: responseProfile.id,
     }));
+  };
+
+  const handleResponseProfileScopeChange = (scopeRowId: string, isSelected: boolean) => {
+    if (!isSelected) {
+      return;
+    }
+
+    if (scopeRowId === wholeFleetScopeRowId) {
+      updateValues(withWholeFleetScope);
+      return;
+    }
+
+    const siteOption = responseProfileSiteOptionByRowId.get(scopeRowId);
+    if (!siteOption) {
+      return;
+    }
+
+    updateValues((current) => withSiteScope(current, siteOption.id, siteOption.name));
   };
 
   const handleMinerSelection = (deviceIdentifiers: string[]) => {
@@ -1079,16 +1174,25 @@ function CurtailmentStartModalContent({
               </div>
             ) : null}
             {isResponseProfileVariant ? (
-              <Section title="Profile" subtext={responseProfileDescription}>
-                <Input
-                  id={nameFieldId}
-                  label={nameFieldLabel}
-                  initValue={values.reason}
-                  type="text"
-                  error={effectiveErrors.reason}
-                  onChange={(value) => updateValue("reason", value)}
-                />
-              </Section>
+              <>
+                <Section title="Profile" subtext={responseProfileDescription}>
+                  <Input
+                    id={nameFieldId}
+                    label={nameFieldLabel}
+                    initValue={values.reason}
+                    type="text"
+                    error={effectiveErrors.reason}
+                    onChange={(value) => updateValue("reason", value)}
+                  />
+                </Section>
+                <Section title="Apply to" subtext="Scope this response profile to the whole fleet or one site.">
+                  <SelectRowList
+                    selectRows={responseProfileScopeRows}
+                    type={selectTypes.radio}
+                    onChange={handleResponseProfileScopeChange}
+                  />
+                </Section>
+              </>
             ) : (
               <div className="grid gap-3">
                 {shouldShowResponseProfileSelector ? (

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -2,6 +2,8 @@ import { MemoryRouter } from "react-router-dom";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { useSites } from "@/protoFleet/api/sites";
 import { useCurtailmentApi } from "@/protoFleet/api/useCurtailmentApi";
 import useCurtailmentAutomationRules from "@/protoFleet/api/useCurtailmentAutomationRules";
 import useCurtailmentResponseProfiles from "@/protoFleet/api/useCurtailmentResponseProfiles";
@@ -35,6 +37,10 @@ vi.mock("react-router-dom", async () => {
 
 vi.mock("@/protoFleet/store", () => ({
   useHasPermission: vi.fn(),
+}));
+
+vi.mock("@/protoFleet/api/sites", () => ({
+  useSites: vi.fn(),
 }));
 
 vi.mock("@/protoFleet/api/useMqttCurtailmentSources", () => ({
@@ -342,6 +348,7 @@ const updateAutomationRuleMock = vi.fn();
 const setAutomationRuleEnabledMock = vi.fn();
 const deleteAutomationRuleMock = vi.fn();
 const startCurtailmentMock = vi.fn();
+const listSitesMock = vi.fn();
 
 const mockResponseProfilesApi = (overrides: Partial<ReturnType<typeof useCurtailmentResponseProfiles>> = {}) => {
   vi.mocked(useCurtailmentResponseProfiles).mockReturnValue({
@@ -434,10 +441,27 @@ function confirmCurtailmentAction(name = "Run curtailment"): void {
   fireEvent.click(within(screen.getByTestId("curtailment-run-confirmation")).getByRole("button", { name }));
 }
 
+function makeSiteWithCounts(id: bigint, name: string): SiteWithCounts {
+  return { site: { id, name } } as SiteWithCounts;
+}
+
+function mockSitesApi() {
+  vi.mocked(useSites).mockReturnValue({
+    listSites: listSitesMock,
+  } as Partial<ReturnType<typeof useSites>> as ReturnType<typeof useSites>);
+  listSitesMock.mockImplementation(
+    ({ onSuccess, onFinally }: { onSuccess?: (sites: SiteWithCounts[]) => void; onFinally?: () => void } = {}) => {
+      onSuccess?.([makeSiteWithCounts(101n, "Austin, TX"), makeSiteWithCounts(102n, "Denver, CO")]);
+      onFinally?.();
+    },
+  );
+}
+
 describe("CurtailmentSettingsPage", () => {
   beforeEach(() => {
     vi.mocked(useHasPermission).mockReset();
     vi.mocked(useMqttCurtailmentSources).mockReset();
+    vi.mocked(useSites).mockReset();
     vi.mocked(useCurtailmentResponseProfiles).mockReset();
     vi.mocked(useCurtailmentAutomationRules).mockReset();
     vi.mocked(useCurtailmentApi).mockReset();
@@ -462,12 +486,14 @@ describe("CurtailmentSettingsPage", () => {
     setAutomationRuleEnabledMock.mockReset();
     deleteAutomationRuleMock.mockReset();
     startCurtailmentMock.mockReset();
+    listSitesMock.mockReset();
     startCurtailmentMock.mockResolvedValue({});
     vi.mocked(useCurtailmentApi).mockReturnValue({
       startCurtailment: startCurtailmentMock,
     } as Partial<ReturnType<typeof useCurtailmentApi>> as ReturnType<typeof useCurtailmentApi>);
     mockResponseProfilesApi();
     mockSourcesApi();
+    mockSitesApi();
     mockAutomationRulesApi();
   });
 
@@ -572,7 +598,6 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByText("Create response profile")).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Profile name"), { target: { value: "Emergency full shed" } });
     expect(screen.getByRole("checkbox", { name: "Include miners in maintenance" })).toBeChecked();
-    expect(screen.queryByText("Apply to")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Miners\s+Select/ })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Min duration (sec)")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Max duration (sec)")).not.toBeInTheDocument();
@@ -604,6 +629,45 @@ describe("CurtailmentSettingsPage", () => {
       message: "Response profile added",
       status: "success",
     });
+  });
+
+  it("creates a site-scoped response profile through the API hook", async () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage" || key === "site:read");
+    createResponseProfileMock.mockResolvedValue({
+      ...testResponseProfiles[0],
+      scope: "Austin, TX",
+      formValues: {
+        ...testResponseProfiles[0].formValues!,
+        siteId: "101",
+        siteName: "Austin, TX",
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create profile" }));
+    await waitFor(() => expect(screen.getByTestId("response-profile-scope-site-101")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("response-profile-scope-site-101"));
+    fireEvent.change(screen.getByLabelText("Profile name"), { target: { value: "Austin emergency shed" } });
+    fireEvent.change(screen.getByTestId("response-profile-curtail-batch-size"), { target: { value: "25" } });
+    fireEvent.change(screen.getByTestId("response-profile-curtail-batch-interval"), { target: { value: "60" } });
+    fireEvent.change(screen.getByTestId("response-profile-restore-batch-size"), { target: { value: "10" } });
+    fireEvent.change(screen.getByTestId("response-profile-restore-batch-interval"), { target: { value: "120" } });
+    fireEvent.click(getEnabledButton("Save profile"));
+
+    await waitFor(() =>
+      expect(createResponseProfileMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Austin emergency shed",
+          siteId: "101",
+          siteName: "Austin, TX",
+        }),
+      ),
+    );
   });
 
   it("keeps the response profile modal open and shows create failures", async () => {
@@ -719,7 +783,6 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByTestId("response-profile-restore-batch-size")).toHaveValue("10000");
     expect(screen.getByTestId("response-profile-restore-batch-interval")).toHaveValue("0");
     expect(screen.queryByTestId("response-profile-post-event-cooldown")).not.toBeInTheDocument();
-    expect(screen.queryByText("Apply to")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Miners\s+Select/ })).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Profile name"), { target: { value: "Site Alpha 750 kW" } });
@@ -774,7 +837,7 @@ describe("CurtailmentSettingsPage", () => {
     expect(within(getResponseProfileCard("Site scoped profile")).getByText("Site 101")).toBeVisible();
 
     fireEvent.click(within(getResponseProfileCard("Site scoped profile")).getByRole("button", { name: "Edit" }));
-    expect(screen.queryByText("Apply to")).not.toBeInTheDocument();
+    expect(screen.getByText("Apply to")).toBeInTheDocument();
     fireEvent.click(getEnabledButton("Save profile"));
 
     await waitFor(() =>
@@ -896,7 +959,6 @@ describe("CurtailmentSettingsPage", () => {
     expect(within(getResponseProfileCard("Targeted miners")).getByText("Whole fleet")).toBeVisible();
 
     fireEvent.click(within(getResponseProfileCard("Targeted miners")).getByRole("button", { name: "Edit" }));
-    expect(screen.queryByText("Apply to")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Miners\s+3 miners/ })).not.toBeInTheDocument();
     fireEvent.click(getEnabledButton("Save profile"));
 
@@ -957,7 +1019,6 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByLabelText("Profile name")).toHaveValue("");
     expect(screen.getByRole("button", { name: "Curtailment mode" })).toHaveTextContent("Full shutdown");
     expect(screen.queryByLabelText("Fixed target reduction (kW)")).not.toBeInTheDocument();
-    expect(screen.queryByText("Apply to")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Miners\s+Select/ })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Min duration (sec)")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Max duration (sec)")).not.toBeInTheDocument();
@@ -1005,7 +1066,6 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByTestId("response-profile-curtail-batch-interval")).toHaveValue("30");
     expect(screen.getByTestId("response-profile-restore-batch-size")).toHaveValue("10000");
     expect(screen.getByTestId("response-profile-restore-batch-interval")).toHaveValue("0");
-    expect(screen.queryByText("Apply to")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Miners\s+Select/ })).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Profile name"), { target: { value: "Site Alpha 750 kW" } });

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -21,7 +21,8 @@ import type {
 import { useHasPermission } from "@/protoFleet/store";
 import { pushToast } from "@/shared/features/toaster";
 
-const { mockNavigate, mockUseCurtailmentPlanPreview } = vi.hoisted(() => ({
+const { mockMultiSiteEnabled, mockNavigate, mockUseCurtailmentPlanPreview } = vi.hoisted(() => ({
+  mockMultiSiteEnabled: { value: true },
   mockNavigate: vi.fn(),
   mockUseCurtailmentPlanPreview: vi.fn(),
 }));
@@ -37,6 +38,12 @@ vi.mock("react-router-dom", async () => {
 
 vi.mock("@/protoFleet/store", () => ({
   useHasPermission: vi.fn(),
+}));
+
+vi.mock("@/protoFleet/constants/featureFlags", () => ({
+  get MULTI_SITE_ENABLED() {
+    return mockMultiSiteEnabled.value;
+  },
 }));
 
 vi.mock("@/protoFleet/api/sites", () => ({
@@ -459,6 +466,7 @@ function mockSitesApi() {
 
 describe("CurtailmentSettingsPage", () => {
   beforeEach(() => {
+    mockMultiSiteEnabled.value = true;
     vi.mocked(useHasPermission).mockReset();
     vi.mocked(useMqttCurtailmentSources).mockReset();
     vi.mocked(useSites).mockReset();
@@ -668,6 +676,24 @@ describe("CurtailmentSettingsPage", () => {
         }),
       ),
     );
+  });
+
+  it("does not expose site scope when the multi-site flag is off", () => {
+    mockMultiSiteEnabled.value = false;
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage" || key === "site:read");
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create profile" }));
+
+    expect(listSitesMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("response-profile-scope-site-101")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("response-profile-scope-site-unavailable")).not.toBeInTheDocument();
+    expect(screen.getByTestId("response-profile-scope-whole-fleet")).toBeInTheDocument();
   });
 
   it("keeps the response profile modal open and shows create failures", async () => {

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -878,19 +878,11 @@ describe("CurtailmentSettingsPage", () => {
     );
   });
 
-  it("saves an existing site-scoped response profile as whole fleet when the multi-site flag is off", async () => {
+  it("preserves an existing site-scoped response profile when the multi-site flag is off", async () => {
     mockMultiSiteEnabled.value = false;
     vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage" || key === "site:read");
     mockResponseProfilesApi({ responseProfiles: [siteScopedResponseProfile] });
-    updateResponseProfileMock.mockResolvedValue({
-      ...siteScopedResponseProfile,
-      scope: "Whole fleet",
-      formValues: {
-        ...siteScopedResponseProfile.formValues!,
-        siteId: "",
-        siteName: "",
-      },
-    });
+    updateResponseProfileMock.mockResolvedValue(siteScopedResponseProfile);
 
     render(
       <MemoryRouter>
@@ -899,15 +891,15 @@ describe("CurtailmentSettingsPage", () => {
     );
 
     fireEvent.click(within(getResponseProfileCard("Site scoped profile")).getByRole("button", { name: "Edit" }));
-    expect(screen.queryByTestId("response-profile-scope-site-101")).not.toBeInTheDocument();
+    expect(screen.getByTestId("response-profile-scope-site-101")).toBeDisabled();
     fireEvent.click(getEnabledButton("Save profile"));
 
     await waitFor(() =>
       expect(updateResponseProfileMock).toHaveBeenCalledWith(
         "site-scoped-profile",
         expect.objectContaining({
-          siteId: "",
-          siteName: "",
+          siteId: "101",
+          siteName: "Site 101",
         }),
       ),
     );

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -850,7 +850,7 @@ describe("CurtailmentSettingsPage", () => {
   });
 
   it("preserves site scope when saving an API response profile", async () => {
-    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage" || key === "site:read");
     mockResponseProfilesApi({ responseProfiles: [siteScopedResponseProfile] });
     updateResponseProfileMock.mockResolvedValue(siteScopedResponseProfile);
 
@@ -863,6 +863,7 @@ describe("CurtailmentSettingsPage", () => {
     expect(within(getResponseProfileCard("Site scoped profile")).getByText("Site 101")).toBeVisible();
 
     fireEvent.click(within(getResponseProfileCard("Site scoped profile")).getByRole("button", { name: "Edit" }));
+    await waitFor(() => expect(screen.getByTestId("response-profile-scope-site-101")).toBeInTheDocument());
     expect(screen.getByText("Apply to")).toBeInTheDocument();
     fireEvent.click(getEnabledButton("Save profile"));
 
@@ -871,7 +872,42 @@ describe("CurtailmentSettingsPage", () => {
         "site-scoped-profile",
         expect.objectContaining({
           siteId: "101",
-          siteName: "Site 101",
+          siteName: "Austin, TX",
+        }),
+      ),
+    );
+  });
+
+  it("saves an existing site-scoped response profile as whole fleet when the multi-site flag is off", async () => {
+    mockMultiSiteEnabled.value = false;
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage" || key === "site:read");
+    mockResponseProfilesApi({ responseProfiles: [siteScopedResponseProfile] });
+    updateResponseProfileMock.mockResolvedValue({
+      ...siteScopedResponseProfile,
+      scope: "Whole fleet",
+      formValues: {
+        ...siteScopedResponseProfile.formValues!,
+        siteId: "",
+        siteName: "",
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(within(getResponseProfileCard("Site scoped profile")).getByRole("button", { name: "Edit" }));
+    expect(screen.queryByTestId("response-profile-scope-site-101")).not.toBeInTheDocument();
+    fireEvent.click(getEnabledButton("Save profile"));
+
+    await waitFor(() =>
+      expect(updateResponseProfileMock).toHaveBeenCalledWith(
+        "site-scoped-profile",
+        expect.objectContaining({
+          siteId: "",
+          siteName: "",
         }),
       ),
     );

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -10,6 +10,7 @@ import useCurtailmentResponseProfiles, {
   getResponseProfileScopeLabelForActionType,
 } from "@/protoFleet/api/useCurtailmentResponseProfiles";
 import useMqttCurtailmentSources from "@/protoFleet/api/useMqttCurtailmentSources";
+import { MULTI_SITE_ENABLED } from "@/protoFleet/constants/featureFlags";
 import CurtailmentStartModal, {
   type CurtailmentFormValues,
   type CurtailmentSiteOption,
@@ -1602,7 +1603,7 @@ function CurtailmentSettingsPage(): ReactElement {
   const [isLoadingSiteOptions, setIsLoadingSiteOptions] = useState(false);
   const [siteOptionsLoadError, setSiteOptionsLoadError] = useState<string | null>(null);
   const siteOptionsAbortControllerRef = useRef<AbortController | null>(null);
-  const canLoadSiteOptions = canManageCurtailment && canReadSiteCatalog;
+  const canLoadSiteOptions = MULTI_SITE_ENABLED && canManageCurtailment && canReadSiteCatalog;
   const {
     responseProfiles,
     isLoading: isLoadingResponseProfiles,
@@ -1876,9 +1877,11 @@ function CurtailmentSettingsPage(): ReactElement {
   }
 
   const effectiveSiteOptions = canLoadSiteOptions ? siteOptions : [];
-  const siteScopeDisabledReason = canReadSiteCatalog
-    ? (siteOptionsLoadError ?? undefined)
-    : "Site scope is not available for the current user.";
+  const siteScopeDisabledReason = MULTI_SITE_ENABLED
+    ? canReadSiteCatalog
+      ? (siteOptionsLoadError ?? undefined)
+      : "Site scope is not available for the current user."
+    : undefined;
 
   return (
     <CurtailmentSettingsContent

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -1562,6 +1562,7 @@ export function CurtailmentSettingsContent({
         responseProfileMode={responseProfileModalMode}
         initialValues={responseProfileCurtailmentInitialValues}
         siteOptions={siteOptions}
+        siteScopeEnabled={siteOptions.length > 0 || isLoadingSiteOptions}
         isSiteScopeLoading={isLoadingSiteOptions}
         siteScopeDisabledReason={siteScopeDisabledReason}
         actionError={responseProfileActionError}

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -1,7 +1,9 @@
-import { type KeyboardEvent, type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
+import { type KeyboardEvent, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useNavigate } from "react-router-dom";
 import clsx from "clsx";
 
+import type { SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { useSites } from "@/protoFleet/api/sites";
 import { useCurtailmentApi } from "@/protoFleet/api/useCurtailmentApi";
 import useCurtailmentAutomationRules from "@/protoFleet/api/useCurtailmentAutomationRules";
 import useCurtailmentResponseProfiles, {
@@ -10,6 +12,7 @@ import useCurtailmentResponseProfiles, {
 import useMqttCurtailmentSources from "@/protoFleet/api/useMqttCurtailmentSources";
 import CurtailmentStartModal, {
   type CurtailmentFormValues,
+  type CurtailmentSiteOption,
   type CurtailmentSubmitValues,
   type ResponseProfileModalMode,
 } from "@/protoFleet/features/energy/CurtailmentStartModal";
@@ -222,6 +225,17 @@ function getResponseProfileScopeSummary(values: ResponseProfileFormValues): stri
   return values.siteId
     ? values.siteName || `Site ${values.siteId}`
     : getResponseProfileScopeLabelForActionType(values.actionType);
+}
+
+function createSiteOptions(sites: SiteWithCounts[]): CurtailmentSiteOption[] {
+  return sites
+    .flatMap((siteWithCounts) => {
+      const site = siteWithCounts.site;
+      const id = site?.id ? site.id.toString() : "";
+
+      return id ? [{ id, name: site?.name || `Site ${id}` }] : [];
+    })
+    .sort((left, right) => left.name.localeCompare(right.name, undefined, { sensitivity: "base" }));
 }
 
 function secondsToDeadlineMinutes(value: string): string {
@@ -1135,6 +1149,10 @@ type CurtailmentSettingsContentProps = {
   updatingResponseProfileIds?: ReadonlySet<string>;
   updatingSourceIds?: ReadonlySet<string>;
   updatingAutomationRuleIds?: ReadonlySet<string>;
+  siteOptions?: CurtailmentSiteOption[];
+  isLoadingSiteOptions?: boolean;
+  siteScopeDisabledReason?: string;
+  onResponseProfileModalOpen?: () => void;
   onCreateResponseProfile?: (values: ResponseProfileFormValues) => Promise<ResponseProfile | void>;
   onUpdateResponseProfile?: (
     profile: ResponseProfile,
@@ -1195,6 +1213,10 @@ export function CurtailmentSettingsContent({
   updatingResponseProfileIds = emptyUpdatingResponseProfileIds,
   updatingSourceIds = emptyUpdatingSourceIds,
   updatingAutomationRuleIds = emptyUpdatingAutomationRuleIds,
+  siteOptions = [],
+  isLoadingSiteOptions = false,
+  siteScopeDisabledReason,
+  onResponseProfileModalOpen,
   onCreateResponseProfile,
   onUpdateResponseProfile,
   onTestResponseProfileCurtailment,
@@ -1243,16 +1265,21 @@ export function CurtailmentSettingsContent({
   const isEditingSource = editingSource ? updatingSourceIds.has(editingSource.id) : false;
 
   const openCreateResponseProfileModal = useCallback(() => {
+    onResponseProfileModalOpen?.();
     setResponseProfileActionError(null);
     setEditingResponseProfile(null);
     setIsResponseProfileModalOpen(true);
-  }, []);
+  }, [onResponseProfileModalOpen]);
 
-  const openEditResponseProfileModal = useCallback((profile: ResponseProfile) => {
-    setResponseProfileActionError(null);
-    setEditingResponseProfile(profile);
-    setIsResponseProfileModalOpen(true);
-  }, []);
+  const openEditResponseProfileModal = useCallback(
+    (profile: ResponseProfile) => {
+      onResponseProfileModalOpen?.();
+      setResponseProfileActionError(null);
+      setEditingResponseProfile(profile);
+      setIsResponseProfileModalOpen(true);
+    },
+    [onResponseProfileModalOpen],
+  );
 
   const closeResponseProfileModal = useCallback(() => {
     setResponseProfileActionError(null);
@@ -1533,6 +1560,9 @@ export function CurtailmentSettingsContent({
         variant="responseProfile"
         responseProfileMode={responseProfileModalMode}
         initialValues={responseProfileCurtailmentInitialValues}
+        siteOptions={siteOptions}
+        isSiteScopeLoading={isLoadingSiteOptions}
+        siteScopeDisabledReason={siteScopeDisabledReason}
         actionError={responseProfileActionError}
         onDismiss={closeResponseProfileModal}
         onSubmit={handleResponseProfileModalSubmit}
@@ -1563,9 +1593,16 @@ export function CurtailmentSettingsContent({
 
 function CurtailmentSettingsPage(): ReactElement {
   const canManageCurtailment = useHasPermission("curtailment:manage");
+  const canReadSiteCatalog = useHasPermission("site:read");
   const navigate = useNavigate();
+  const { listSites } = useSites();
   const { startCurtailment } = useCurtailmentApi();
   const [isTestingResponseProfileCurtailment, setIsTestingResponseProfileCurtailment] = useState(false);
+  const [siteOptions, setSiteOptions] = useState<CurtailmentSiteOption[]>([]);
+  const [isLoadingSiteOptions, setIsLoadingSiteOptions] = useState(false);
+  const [siteOptionsLoadError, setSiteOptionsLoadError] = useState<string | null>(null);
+  const siteOptionsAbortControllerRef = useRef<AbortController | null>(null);
+  const canLoadSiteOptions = canManageCurtailment && canReadSiteCatalog;
   const {
     responseProfiles,
     isLoading: isLoadingResponseProfiles,
@@ -1600,6 +1637,44 @@ function CurtailmentSettingsPage(): ReactElement {
     setAutomationRuleEnabled,
     deleteAutomationRule,
   } = useCurtailmentAutomationRules(canManageCurtailment);
+
+  const ensureSiteOptionsLoaded = useCallback(() => {
+    if (!canLoadSiteOptions || isLoadingSiteOptions || (siteOptions.length > 0 && !siteOptionsLoadError)) {
+      return;
+    }
+
+    siteOptionsAbortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    siteOptionsAbortControllerRef.current = abortController;
+    const { signal } = abortController;
+
+    setIsLoadingSiteOptions(true);
+    setSiteOptionsLoadError(null);
+    void listSites({
+      signal,
+      onSuccess: (sites) => {
+        if (!signal.aborted) {
+          setSiteOptions(createSiteOptions(sites));
+        }
+      },
+      onError: (message) => {
+        if (!signal.aborted) {
+          setSiteOptionsLoadError(message);
+        }
+      },
+      onFinally: () => {
+        if (!signal.aborted) {
+          setIsLoadingSiteOptions(false);
+        }
+      },
+    });
+  }, [canLoadSiteOptions, isLoadingSiteOptions, listSites, siteOptions.length, siteOptionsLoadError]);
+
+  useEffect(() => {
+    return () => {
+      siteOptionsAbortControllerRef.current?.abort();
+    };
+  }, []);
 
   useEffect(() => {
     if (!loadError) {
@@ -1800,6 +1875,11 @@ function CurtailmentSettingsPage(): ReactElement {
     return <Navigate to="/settings/general" replace />;
   }
 
+  const effectiveSiteOptions = canLoadSiteOptions ? siteOptions : [];
+  const siteScopeDisabledReason = canReadSiteCatalog
+    ? (siteOptionsLoadError ?? undefined)
+    : "Site scope is not available for the current user.";
+
   return (
     <CurtailmentSettingsContent
       responseProfiles={responseProfiles}
@@ -1819,6 +1899,10 @@ function CurtailmentSettingsPage(): ReactElement {
       updatingResponseProfileIds={updatingProfileIds}
       updatingSourceIds={updatingSourceIds}
       updatingAutomationRuleIds={updatingAutomationRuleIds}
+      siteOptions={effectiveSiteOptions}
+      isLoadingSiteOptions={canLoadSiteOptions ? isLoadingSiteOptions : false}
+      siteScopeDisabledReason={siteScopeDisabledReason}
+      onResponseProfileModalOpen={ensureSiteOptionsLoaded}
       onCreateResponseProfile={handleCreateResponseProfile}
       onUpdateResponseProfile={handleUpdateResponseProfile}
       onTestResponseProfileCurtailment={handleTestResponseProfileCurtailment}

--- a/client/src/shared/components/SelectRowList/SelectRow.tsx
+++ b/client/src/shared/components/SelectRowList/SelectRow.tsx
@@ -81,11 +81,11 @@ const SelectRow = ({
               "cursor-pointer": !disabled,
               "cursor-not-allowed opacity-[0.4]": disabled,
               "border border-border-20": isRadio && !isSelected,
-              "bg-core-accent-fill": isRadio && isSelected && !disabled,
+              "bg-core-accent-fill": isRadio && isSelected,
             })}
             disabled={disabled}
             type={type}
-            checked={isSelected ? !disabled : false}
+            checked={isSelected}
             onChange={handleChange}
           />
           <div

--- a/docs/plans/2026-06-24-site-scoped-curtailment-response-profiles-plan.md
+++ b/docs/plans/2026-06-24-site-scoped-curtailment-response-profiles-plan.md
@@ -1,0 +1,121 @@
+---
+title: "Site-scoped curtailment response profiles"
+date: 2026-06-24
+status: draft
+type: plan
+---
+
+# Site-scoped curtailment response profiles
+
+## Summary
+
+Add site-scoped curtailment by wiring the existing backend/API support into
+response profile creation and editing. Backend proto, persistence, validation,
+automation, and event scope translation already support `site_id`, so the
+minimum footprint is frontend-only unless tests expose a gap.
+
+Energy page event lists can remain org-level for now; event details already
+distinguish `whole_org` vs `site`.
+
+## Key Changes
+
+- Add a site selector to the response profile modal for both create and edit
+  flows.
+- Default remains `Whole fleet`.
+- Site options come from the existing sites API.
+- Preserve an existing `Site <id>` fallback while editing if site options have
+  not loaded.
+- Preserve valid site scope in response profile create mode instead of coercing
+  it to whole-org.
+- Preserve site scope when selecting a site-scoped response profile for live
+  curtailment.
+- Keep response profiles scoped only to `Whole fleet` or `Site` in this change.
+
+## Implementation Notes
+
+- Use the existing `useSites` client API to build sorted site options from
+  `SiteWithCounts.site.id/name`.
+- Pass site options into `CurtailmentStartModal` from the settings curtailment
+  page/content.
+- In response profile variant, render a compact `Apply to`/scope section with
+  `Whole fleet` and each available site.
+- If site scope is not available to the current user, disable the `Site` option
+  and keep `Whole fleet` selectable.
+- On whole-fleet selection, clear `siteId`, `siteName`, device sets, and
+  explicit miner identifiers.
+- On site selection, set `scopeType: "site"`, `siteId`, `siteName`, and clear
+  unsupported miner/device-set fields.
+- Leave backend, proto, sqlc, migrations, and generated files unchanged unless
+  verification shows a missing backend path.
+
+## Test Plan
+
+- Update `CurtailmentStartModal.test.tsx` so response profile create shows the
+  scope selector, site selection submits `siteId/siteName`, and test-curtailment
+  preview/confirmation uses the selected site.
+- Update edit-mode tests so the modal preserves existing site scope and can
+  switch to another site or whole fleet.
+- Add an edit-mode test where the initial response profile has `siteId` but
+  site options are still empty/loading, asserting the modal displays
+  `Site <id>` and preserves that site on save.
+- Update unavailable-site-scope tests so the modal disables `Site` and leaves
+  `Whole fleet` selectable for the current user.
+- Update live curtailment profile-selection tests so selecting a site-scoped
+  response profile preserves `scopeType: "site"`.
+- Update `CurtailmentSettingsPage.test.tsx` to mock sites and verify creating a
+  response profile with a selected site persists the site fields.
+- Keep existing API hook tests for create/update payloads with `site`; add only
+  if coverage gaps appear.
+- Run targeted client tests:
+
+```sh
+npm test -- CurtailmentStartModal.test.tsx CurtailmentSettingsPage.test.tsx useCurtailmentResponseProfiles.test.tsx
+```
+
+## Assumptions
+
+- Site selector is required for both create and edit.
+- Energy page active/history queries remain org-level in this pass.
+- API persists the site by ID; site name is UI display metadata and may fall
+  back to `Site <id>`.
+- Existing backend permission checks for optional site context are sufficient
+  for this change.
+
+## Deferred / Open Questions
+
+### From 2026-06-24 review
+
+- **Site selector data source has an unresolved permission dependency** —
+  Implementation Notes / Assumptions (P2, feasibility, confidence 75)
+
+  Fresh `ADMIN` roles get both `site:read` and `curtailment:manage` by
+  default, but custom roles or operator-revoked Admin permissions can still
+  leave a curtailment manager without `site:read`. Decide whether the site
+  selector should require `site:read`, degrade gracefully, or get its options
+  from a curtailment-authorized source.
+
+- **Plan does not require server-side verification of site authorization for
+  submitted site IDs** — Implementation Notes / Test Plan / Assumptions (P2,
+  security-lens, adversarial, confidence 100)
+
+  The frontend change submits site IDs for response profile creation, editing,
+  and live curtailment. Add an explicit verification gate for invalid, deleted,
+  cross-org, and unauthorized site IDs across create, update, live curtailment,
+  automation execution, and event translation so site scope cannot be silently
+  dropped, broadened, or misapplied.
+
+- **Plan commits to a UI path before stating the operator outcome** — Premise
+  challenge (P2, product-lens, confidence 75)
+
+  The plan adds a site selector to response profile create/edit flows, but does
+  not state the operator pain, workflow failure, or success outcome this solves.
+  Capture the intended operator outcome so implementation can be judged against
+  the product need, not just the technical `site_id` path.
+
+- **Org-level event lists may undercut trust in site-scoped actions** —
+  Strategic consequences (P2, product-lens, adversarial, confidence 100)
+
+  The plan leaves Energy page active/history queries org-level while adding
+  site-scoped response profile selection. Decide what evidence would make that
+  unacceptable, or where operators should verify scope without drilling into
+  individual event details.


### PR DESCRIPTION
Reviewable diff: +412/-48 across 4 files (excludes generated, test, and story files).

## Summary
Operators can now save curtailment response profiles for either the whole fleet or a single site, then preserve that site scope when running live curtailment from the profile. Whole fleet remains the default, and site scope follows the existing `VITE_MULTI_SITE_ENABLED` rollout flag plus `site:read` access so the selector is only exposed when the site catalog can be used safely. This update also addresses review feedback by making malformed site-scoped profile values normalize explicitly, ensuring the maintenance-confirmation path uses the same normalized site scope as direct submission, and keeping preserved disabled site rows visibly selected.

## How it works
The settings page lazily loads site options through the existing sites API when the response profile modal opens and multi-site site selection is available. In response-profile mode, the curtailment modal renders an `Apply to` selector for `Whole fleet` or one loaded site; whole fleet clears site/device/miner scope values, while site scope sets `scopeType: "site"`, `siteId`, and the display label. If an existing profile already has site scope but the selector is hidden, loading, or unavailable, the modal preserves that saved site as a disabled fallback row, keeps it visibly selected, and submits the payload site-scoped unless the operator explicitly chooses whole fleet. Live curtailment profile selection now preserves site-scoped profile values, and confirmation flows submit the normalized effective scope.

## Diagrams
```mermaid
flowchart TD
  Settings["Settings: Response profiles"] --> Open["Open create/edit modal"]
  Open --> Gate{"Multi-site flag and site:read?"}
  Gate -->|"No"| Disabled["Show whole fleet plus any saved site as disabled fallback"]
  Gate -->|"Yes"| LoadSites["Load sites through existing sites API"]
  LoadSites --> Selector["Render Apply to selector"]
  Selector --> WholeFleet["Whole fleet selected"]
  Selector --> Site["Site selected or preserved"]
  WholeFleet --> SaveWhole["Save profile without site_id"]
  Site --> SaveSite["Save profile with site_id"]
  SaveSite --> Run["Live curtailment profile selection keeps site scope"]
```

```mermaid
sequenceDiagram
  participant Operator
  participant Settings
  participant Modal
  participant CurtailmentAPI
  Operator->>Settings: Open response profile modal
  Settings->>Settings: Load site options when allowed
  Settings->>Modal: Pass site options and saved profile scope
  Operator->>Modal: Select whole fleet or site
  Modal->>Settings: Submit normalized response profile values
  Settings->>CurtailmentAPI: Create/update profile with optional site_id
```

## Areas Of The Code Involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `docs/plans/2026-06-24-site-scoped-curtailment-response-profiles-plan.md` | Captures the implementation plan and scope boundaries. | Confirms this PR stays frontend-only and relies on existing response-profile/site payload support. |
| `client/src/protoFleet/features/energy/CurtailmentStartModal.tsx` | Adds response-profile scope controls, effective site-scope normalization, malformed-site guards, hidden-site preservation, and site-scoped live profile selection. | Main behavior surface for create/edit/save/run flows and the reviewed edge cases. |
| `client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx` | Loads site options on modal open when the multi-site flag and `site:read` permission allow it, then maps modal submit values back to response-profile form values. | Keeps site selection aligned with rollout/access gates and avoids a page-load sites call. |
| `client/src/shared/components/SelectRowList/SelectRow.tsx` | Keeps disabled selected radio rows checked and visually selected. | Ensures preserved site-scoped fallback rows do not look unselected while still submitting their saved site scope. |
| `client/src/protoFleet/**/Curtailment*.test.tsx` | Covers site selection, disabled/gated site scope, hidden saved-site preservation, malformed site data, maintenance confirmation normalization, settings persistence, live curtailment preservation, and disabled selected fallback rows. | Reviewers can validate behavior without relying on manual UI inspection. |

## Key Technical Decisions & Trade-Offs
- Reused `MULTI_SITE_ENABLED` instead of adding a curtailment-specific flag; this keeps response-profile site scope aligned with the existing multi-site rollout.
- Reused `useSites` for site labels instead of adding a curtailment-specific site endpoint; this keeps the change frontend-only, with site choices disabled/unavailable for users without `site:read`.
- Loaded site options when the response profile modal opens instead of on page mount; this avoids unnecessary work for users who only view settings.
- Preserved hidden or unavailable existing site scope instead of broadening it to whole fleet; this avoids changing blast radius during unrelated edits or site catalog failures.
- Kept disabled selected rows visibly selected instead of rendering saved-site fallback scope as unchecked; this preserves native input semantics and avoids a curtailment-specific one-off presentation.
- Treated `scopeType: "site"` without a populated `siteId` as malformed UI state and normalized it explicitly to whole fleet; valid persisted site scopes still preserve their site.
- Kept backend, proto, sqlc, migrations, and generated files unchanged because existing API payloads already support `site_id`.

## Testing & Validation
- `npm test -- CurtailmentStartModal.test.tsx CurtailmentSettingsPage.test.tsx` (81 tests)
- `npm test -- CurtailmentStartModal.test.tsx` (45 tests)
- `client-typecheck` via pre-push hook
- `git diff --check 6ad1b00d1399f8fa69e9706218c5c126f9770007`

## Post-Deploy Validation
- With `VITE_MULTI_SITE_ENABLED=true` and `site:read`, create a site-scoped response profile, confirm the site label appears on the card, edit it without losing scope, and run live curtailment from that profile.
- With the flag off or without `site:read`, confirm new site choices are unavailable and existing site-scoped profiles keep their saved site if edited.
- Watch for response-profile create/update or start-curtailment client errors around site-scoped payloads during the first deploy window.
