### PR TITLE
Add stale MQTT automation recovery controls

### DIFF
--- a/client/src/protoFleet/api/curtailmentMappers.ts
+++ b/client/src/protoFleet/api/curtailmentMappers.ts
@@ -20,6 +20,8 @@ import type { CurtailmentHistoryEvent, CurtailmentPriority } from "@/protoFleet/
 import type { CurtailmentMode, CurtailmentSubmitValues } from "@/protoFleet/features/energy/CurtailmentStartModal";
 
 const wattsPerKilowatt = 1000;
+const automationExternalSource = "curtailment_automation";
+const automationSourceLabel = "MQTT automation";
 const estimatedReductionKwSnapshotKeys = ["estimated_reduction_kw", "estimatedReductionKw"] as const;
 const selectedCountSnapshotKeys = ["selected_count", "selectedCount"] as const;
 
@@ -142,8 +144,16 @@ export function mapCurtailmentPriority(priority: ProtoCurtailmentPriority): Curt
   }
 }
 
-function getSourceLabel(event: ProtoCurtailmentEvent): string {
-  return event.externalSource.trim() || "Manual";
+function isAutomationExternalSource(externalSource: string): boolean {
+  return externalSource === automationExternalSource;
+}
+
+function getSourceLabel(externalSource: string): string {
+  if (isAutomationExternalSource(externalSource)) {
+    return automationSourceLabel;
+  }
+
+  return externalSource || "Manual";
 }
 
 function hasSnapshotNumber(event: ProtoCurtailmentEvent, keys: readonly string[]): boolean {
@@ -179,11 +189,14 @@ function getObservedPowerSummary(event: ProtoCurtailmentEvent, estimatedReductio
 export function mapActiveCurtailmentEvent(event: ProtoCurtailmentEvent): ActiveCurtailmentEvent {
   const estimatedReductionKw = getCurtailmentEventEstimatedReductionKw(event);
   const observedPowerSummary = getObservedPowerSummary(event, estimatedReductionKw);
+  const externalSource = event.externalSource.trim();
 
   return {
     reason: event.reason || "Curtailment",
     state: mapCurtailmentEventState(event.state),
     scopeLabel: getCurtailmentEventScopeLabel(event),
+    sourceLabel: getSourceLabel(externalSource),
+    isAutomationOwned: isAutomationExternalSource(externalSource),
     endedAt: timestampToIsoString(event.endedAt),
     selectedMiners: getCurtailmentEventSelectedMinerCount(event),
     estimatedReductionKw,
@@ -197,6 +210,8 @@ export function mapActiveCurtailmentEvent(event: ProtoCurtailmentEvent): ActiveC
 }
 
 export function mapCurtailmentHistoryEvent(event: ProtoCurtailmentEvent): CurtailmentHistoryEvent {
+  const externalSource = event.externalSource.trim();
+
   return {
     id: event.eventUuid,
     reason: event.reason || "Curtailment",
@@ -207,7 +222,7 @@ export function mapCurtailmentHistoryEvent(event: ProtoCurtailmentEvent): Curtai
     estimatedReductionKw: getCurtailmentEventEstimatedReductionKw(event),
     targetMetricsAvailable: hasCurtailmentTargetMetrics(event),
     targetKw: getFixedKwTarget(event),
-    sourceLabel: getSourceLabel(event),
+    sourceLabel: getSourceLabel(externalSource),
     startedAt: timestampToIsoString(event.startedAt),
     endedAt: timestampToIsoString(event.endedAt),
     scheduledAt: timestampToIsoString(event.scheduledStartAt),

--- a/client/src/protoFleet/api/curtailmentMappers.ts
+++ b/client/src/protoFleet/api/curtailmentMappers.ts
@@ -21,7 +21,7 @@ import type { CurtailmentMode, CurtailmentSubmitValues } from "@/protoFleet/feat
 
 const wattsPerKilowatt = 1000;
 const automationExternalSource = "curtailment_automation";
-const automationSourceLabel = "MQTT automation";
+const automationSourceLabel = "Curtailment automation";
 const estimatedReductionKwSnapshotKeys = ["estimated_reduction_kw", "estimatedReductionKw"] as const;
 const selectedCountSnapshotKeys = ["selected_count", "selectedCount"] as const;
 

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -220,6 +220,32 @@ describe("useCurtailmentApi", () => {
     );
   });
 
+  it("maps MQTT automation ownership onto active and history events", async () => {
+    const activeEvent = curtailmentEvent({
+      externalSource: "curtailment_automation",
+    });
+    mockListActiveCurtailments.mockResolvedValueOnce({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [activeEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent).toEqual(
+      expect.objectContaining({
+        isAutomationOwned: true,
+        sourceLabel: "MQTT automation",
+      }),
+    );
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        sourceLabel: "MQTT automation",
+      }),
+    );
+  });
+
   it("clears cached active state when refresh loses curtailment read permission", async () => {
     const activeEvent = curtailmentEvent({ eventUuid: "curt-permission-loss" });
     applyActiveCurtailmentEvent(activeEvent, { mergeActiveEvents: true });
@@ -2031,6 +2057,32 @@ describe("useCurtailmentApi", () => {
       expect.objectContaining({
         id: "curt-1",
         state: "cancelled",
+      }),
+    );
+  });
+
+  it("admin terminates restoring events as failed", async () => {
+    const failedEvent = curtailmentEvent({
+      state: CurtailmentEventState.FAILED,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+    });
+    mockAdminTerminateEvent.mockResolvedValueOnce({ event: failedEvent });
+    mockListCurtailmentEvents.mockResolvedValue({ events: [failedEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.adminTerminateCurtailment("curt-1", {
+        reason: "Operator marked restore failed",
+        targetState: "failed",
+      });
+    });
+
+    expect(mockAdminTerminateEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventUuid: "curt-1",
+        reason: "Operator marked restore failed",
+        targetState: CurtailmentEventState.FAILED,
       }),
     );
   });

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -26,6 +26,7 @@ import { useCurtailmentApi } from "@/protoFleet/api/useCurtailmentApi";
 import type { CurtailmentSubmitValues } from "@/protoFleet/features/energy/CurtailmentStartModal";
 
 const {
+  mockAdminTerminateEvent,
   mockListActiveCurtailments,
   mockGetCurtailmentEvent,
   mockHandleAuthErrors,
@@ -34,6 +35,7 @@ const {
   mockStopCurtailment,
   mockUpdateCurtailment,
 } = vi.hoisted(() => ({
+  mockAdminTerminateEvent: vi.fn(),
   mockListActiveCurtailments: vi.fn(),
   mockGetCurtailmentEvent: vi.fn(),
   mockHandleAuthErrors: vi.fn(),
@@ -63,6 +65,7 @@ vi.mock("@/protoFleet/api/clients", () => ({
       listCurtailmentEvents: mockListCurtailmentEvents,
       startCurtailment: mockStartCurtailment,
       stopCurtailment: mockStopCurtailment,
+      adminTerminateEvent: mockAdminTerminateEvent,
       updateCurtailmentEvent: mockUpdateCurtailment,
     };
   })(),
@@ -1963,6 +1966,73 @@ describe("useCurtailmentApi", () => {
     expect(result.current.activeEvent?.state).toBe("restoring");
 
     window.removeEventListener(CURTAILMENT_CHANGED_EVENT, changedListener);
+  });
+
+  it("force stops curtailment when requested", async () => {
+    const restoringEvent = curtailmentEvent({
+      state: CurtailmentEventState.RESTORING,
+    });
+    mockStopCurtailment.mockResolvedValueOnce({ event: restoringEvent });
+    mockListActiveCurtailments.mockResolvedValue({ event: restoringEvent });
+    mockListCurtailmentEvents.mockResolvedValue({ events: [restoringEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.stopCurtailment("curt-1", { force: true });
+    });
+
+    expect(mockStopCurtailment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventUuid: "curt-1",
+        force: true,
+      }),
+    );
+    expect(result.current.activeEvent?.state).toBe("restoring");
+  });
+
+  it("admin terminates restoring events with a required reason", async () => {
+    const cancelledEvent = curtailmentEvent({
+      state: CurtailmentEventState.CANCELLED,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+    });
+    mockAdminTerminateEvent.mockResolvedValueOnce({ event: cancelledEvent });
+    mockListCurtailmentEvents.mockResolvedValue({ events: [cancelledEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await expect(
+        result.current.adminTerminateCurtailment("curt-1", {
+          reason: "   ",
+          targetState: "cancelled",
+        }),
+      ).rejects.toThrow("Enter a reason before terminating the event.");
+    });
+
+    expect(mockAdminTerminateEvent).not.toHaveBeenCalled();
+    expect(result.current.adminTerminateError).toBe("Enter a reason before terminating the event.");
+
+    await act(async () => {
+      await result.current.adminTerminateCurtailment("curt-1", {
+        reason: " Operator recovered stale source ",
+        targetState: "cancelled",
+      });
+    });
+
+    expect(mockAdminTerminateEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventUuid: "curt-1",
+        reason: "Operator recovered stale source",
+        targetState: CurtailmentEventState.CANCELLED,
+      }),
+    );
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-1",
+        state: "cancelled",
+      }),
+    );
   });
 
   it("starts full-fleet curtailment without fixed-kW mode params", async () => {

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -236,12 +236,12 @@ describe("useCurtailmentApi", () => {
     expect(result.current.activeEvent).toEqual(
       expect.objectContaining({
         isAutomationOwned: true,
-        sourceLabel: "MQTT automation",
+        sourceLabel: "Curtailment automation",
       }),
     );
     expect(result.current.historyEvents[0]).toEqual(
       expect.objectContaining({
-        sourceLabel: "MQTT automation",
+        sourceLabel: "Curtailment automation",
       }),
     );
   });

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -23,6 +23,7 @@ import {
   mapCurtailmentHistoryEvent,
 } from "@/protoFleet/api/curtailmentMappers";
 import {
+  AdminTerminateEventRequestSchema,
   CurtailmentEventSchema,
   GetCurtailmentEventRequestSchema,
   ListCurtailmentEventsRequestSchema,
@@ -76,15 +77,30 @@ interface CurtailmentHistoryPaginationState {
   pageTokens: (string | undefined)[];
 }
 
+export type AdminTerminateCurtailmentState = Extract<CurtailmentEventState, "cancelled" | "failed">;
+
+export interface AdminTerminateCurtailmentOptions {
+  reason: string;
+  targetState: AdminTerminateCurtailmentState;
+}
+
+export interface StopCurtailmentOptions {
+  force?: boolean;
+}
+
+export const adminTerminateReasonRequiredMessage = "Enter a reason before terminating the event.";
+
 export interface UseCurtailmentApiResult extends CurtailmentSnapshot {
   isLoading: boolean;
   isStarting: boolean;
   isUpdating: boolean;
   stoppingEventId: string | null;
+  adminTerminatingEventId: string | null;
   loadError: string | null;
   startError: string | null;
   updateError: string | null;
   stopError: string | null;
+  adminTerminateError: string | null;
   historyCurrentPage: number;
   historyHasNextPage: boolean;
   historyHasPreviousPage: boolean;
@@ -115,7 +131,11 @@ export interface UseCurtailmentApiResult extends CurtailmentSnapshot {
     values: CurtailmentSubmitValues,
     initialValues?: Partial<CurtailmentSubmitValues>,
   ) => Promise<ProtoCurtailmentEvent>;
-  stopCurtailment: (eventUuid: string) => Promise<ProtoCurtailmentEvent>;
+  stopCurtailment: (eventUuid: string, options?: StopCurtailmentOptions) => Promise<ProtoCurtailmentEvent>;
+  adminTerminateCurtailment: (
+    eventUuid: string,
+    options: AdminTerminateCurtailmentOptions,
+  ) => Promise<ProtoCurtailmentEvent>;
 }
 
 const curtailmentHistoryPageSize = 50;
@@ -153,6 +173,10 @@ const activeReconciliationHistoryStateFilters: CurtailmentEventState[] = [
   "failed",
 ];
 const vanishedRestoringUnreadableErrorCodes = new Set<Code>([Code.NotFound, Code.PermissionDenied]);
+const adminTerminateStateMap: Record<AdminTerminateCurtailmentState, ProtoCurtailmentEventState> = {
+  cancelled: ProtoCurtailmentEventState.CANCELLED,
+  failed: ProtoCurtailmentEventState.FAILED,
+};
 
 function isVanishedRestoringUnreadableError(error: unknown): boolean {
   return error instanceof ConnectError && vanishedRestoringUnreadableErrorCodes.has(error.code);
@@ -188,6 +212,10 @@ function mapHistoryStateFilters(stateFilters: readonly CurtailmentEventState[]):
   return normalizeHistoryStateFilters(stateFilters)
     .map(mapHistoryStateFilter)
     .filter((state) => state !== ProtoCurtailmentEventState.UNSPECIFIED);
+}
+
+function mapAdminTerminateState(targetState: AdminTerminateCurtailmentState): ProtoCurtailmentEventState {
+  return adminTerminateStateMap[targetState];
 }
 
 function getActiveSnapshotEvent(activeEvent: ProtoCurtailmentEvent | undefined): ActiveCurtailmentEvent | null {
@@ -559,10 +587,12 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
   const [isStarting, setIsStarting] = useState(false);
   const [updatingEventId, setUpdatingEventId] = useState<string | null>(null);
   const [stoppingEventId, setStoppingEventId] = useState<string | null>(null);
+  const [adminTerminatingEventId, setAdminTerminatingEventId] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [startError, setStartError] = useState<string | null>(null);
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [stopError, setStopError] = useState<string | null>(null);
+  const [adminTerminateError, setAdminTerminateError] = useState<string | null>(null);
   const [historyPagination, setHistoryPagination] =
     useState<CurtailmentHistoryPaginationState>(initialHistoryPagination);
   const [historyStatusFilters, setHistoryStatusFiltersState] = useState<CurtailmentEventState[]>([]);
@@ -1111,13 +1141,13 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
   );
 
   const stopCurtailment = useCallback(
-    async (eventUuid: string) => {
+    async (eventUuid: string, { force = false }: StopCurtailmentOptions = {}) => {
       setStoppingEventId(eventUuid);
       setStopError(null);
 
       try {
         const response = await curtailmentClient.stopCurtailment(
-          create(StopCurtailmentRequestSchema, { eventUuid, force: false }),
+          create(StopCurtailmentRequestSchema, { eventUuid, force }),
         );
         if (!response.event) {
           throw new Error("Stopped curtailment response was missing an event.");
@@ -1132,6 +1162,44 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
         throw resolvedError;
       } finally {
         setStoppingEventId((currentEventId) => (currentEventId === eventUuid ? null : currentEventId));
+      }
+    },
+    [applyEvent, handleFailure, refreshAfterMutation],
+  );
+
+  const adminTerminateCurtailment = useCallback(
+    async (eventUuid: string, { reason, targetState }: AdminTerminateCurtailmentOptions) => {
+      const trimmedReason = reason.trim();
+      if (!trimmedReason) {
+        const validationError = new Error(adminTerminateReasonRequiredMessage);
+        setAdminTerminateError(validationError.message);
+        throw validationError;
+      }
+
+      setAdminTerminatingEventId(eventUuid);
+      setAdminTerminateError(null);
+
+      try {
+        const response = await curtailmentClient.adminTerminateEvent(
+          create(AdminTerminateEventRequestSchema, {
+            eventUuid,
+            reason: trimmedReason,
+            targetState: mapAdminTerminateState(targetState),
+          }),
+        );
+        if (!response.event) {
+          throw new Error("Admin terminate response was missing an event.");
+        }
+
+        applyEvent(response.event);
+        await refreshAfterMutation();
+        return response.event;
+      } catch (error) {
+        const resolvedError = handleFailure(error, "Failed to terminate curtailment event.");
+        setAdminTerminateError(resolvedError.message);
+        throw resolvedError;
+      } finally {
+        setAdminTerminatingEventId((currentEventId) => (currentEventId === eventUuid ? null : currentEventId));
       }
     },
     [applyEvent, handleFailure, refreshAfterMutation],
@@ -1175,10 +1243,12 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       isStarting,
       isUpdating: updatingEventId !== null,
       stoppingEventId,
+      adminTerminatingEventId,
       loadError,
       startError,
       updateError,
       stopError,
+      adminTerminateError,
       historyCurrentPage: historyPagination.currentPage,
       historyHasNextPage: historyPagination.nextPageToken !== "",
       historyHasPreviousPage: historyPagination.currentPage > 0,
@@ -1194,10 +1264,14 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       dismissTerminalCurtailment,
       updateCurtailment,
       stopCurtailment,
+      adminTerminateCurtailment,
     }),
     [
       activeSnapshotFields,
       activeHistoryEvents,
+      adminTerminateCurtailment,
+      adminTerminateError,
+      adminTerminatingEventId,
       goToHistoryPage,
       historyEvents,
       historyPagination.currentPage,

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures.ts
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures.ts
@@ -5,6 +5,7 @@ export const curtailingCurtailmentEvent: ActiveCurtailmentEvent = {
   state: "active",
   scopeLabel: "Rockdale, TX",
   sourceLabel: "Manual",
+  isAutomationOwned: false,
   selectedMiners: 18,
   estimatedReductionKw: 60.2,
   targetKw: 60,

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures.ts
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.fixtures.ts
@@ -4,6 +4,7 @@ export const curtailingCurtailmentEvent: ActiveCurtailmentEvent = {
   reason: "ERCOT ERS obligation",
   state: "active",
   scopeLabel: "Rockdale, TX",
+  sourceLabel: "Manual",
   selectedMiners: 18,
   estimatedReductionKw: 60.2,
   targetKw: 60,

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -160,6 +160,7 @@ describe("ActiveCurtailmentStatus", () => {
   it("renders automation recovery context with force restore available", async () => {
     const user = userEvent.setup();
     const onRequestForceRestore = vi.fn();
+    const onRequestRestore = vi.fn();
 
     render(
       <ActiveCurtailmentStatus
@@ -169,16 +170,17 @@ describe("ActiveCurtailmentStatus", () => {
           sourceLabel: "MQTT automation",
         }}
         onRequestForceRestore={onRequestForceRestore}
-        onRequestRestore={vi.fn()}
+        onRequestRestore={onRequestRestore}
       />,
     );
 
     expect(screen.getByText("MQTT automation recovery")).toBeVisible();
     expect(screen.getByText(/Normal restore can be blocked while OFF demand remains asserted/)).toBeVisible();
-    expectActionButtonHidden("Restore");
 
+    await user.click(screen.getByRole("button", { name: "Restore" }));
     await user.click(screen.getByRole("button", { name: "Force restore" }));
 
+    expect(onRequestRestore).toHaveBeenCalledOnce();
     expect(onRequestForceRestore).toHaveBeenCalledOnce();
   });
 

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -167,14 +167,14 @@ describe("ActiveCurtailmentStatus", () => {
         event={{
           ...curtailedCurtailmentEvent,
           isAutomationOwned: true,
-          sourceLabel: "MQTT automation",
+          sourceLabel: "Curtailment automation",
         }}
         onRequestForceRestore={onRequestForceRestore}
         onRequestRestore={onRequestRestore}
       />,
     );
 
-    expect(screen.getByText("MQTT automation recovery")).toBeVisible();
+    expect(screen.getByText("Curtailment automation recovery")).toBeVisible();
     expect(screen.getByText(/Normal restore can be blocked while OFF demand remains asserted/)).toBeVisible();
 
     await user.click(screen.getByRole("button", { name: "Restore" }));
@@ -201,25 +201,25 @@ describe("ActiveCurtailmentStatus", () => {
     expectActionButtonHidden("Restore");
   });
 
-  it("renders admin terminate while restoring when recovery is available", async () => {
+  it("renders terminate recovery while restoring when recovery is available", async () => {
     const user = userEvent.setup();
-    const onRequestAdminTerminate = vi.fn();
+    const onRequestTerminateRecovery = vi.fn();
 
     render(
       <ActiveCurtailmentStatus
         event={{
           ...restoringCurtailmentEvent,
           isAutomationOwned: true,
-          sourceLabel: "MQTT automation",
+          sourceLabel: "Curtailment automation",
         }}
-        onRequestAdminTerminate={onRequestAdminTerminate}
+        onRequestTerminateRecovery={onRequestTerminateRecovery}
       />,
     );
 
-    expect(screen.getByText("MQTT automation recovery")).toBeVisible();
-    await user.click(screen.getByRole("button", { name: "Admin terminate" }));
+    expect(screen.getByText("Curtailment automation recovery")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Terminate recovery" }));
 
-    expect(onRequestAdminTerminate).toHaveBeenCalledOnce();
+    expect(onRequestTerminateRecovery).toHaveBeenCalledOnce();
   });
 
   it("counts released targets as restored during restoration", () => {

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx
@@ -157,6 +157,31 @@ describe("ActiveCurtailmentStatus", () => {
     expect(onRequestRestore).toHaveBeenCalledOnce();
   });
 
+  it("renders automation recovery context with force restore available", async () => {
+    const user = userEvent.setup();
+    const onRequestForceRestore = vi.fn();
+
+    render(
+      <ActiveCurtailmentStatus
+        event={{
+          ...curtailedCurtailmentEvent,
+          isAutomationOwned: true,
+          sourceLabel: "MQTT automation",
+        }}
+        onRequestForceRestore={onRequestForceRestore}
+        onRequestRestore={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("MQTT automation recovery")).toBeVisible();
+    expect(screen.getByText(/Normal restore can be blocked while OFF demand remains asserted/)).toBeVisible();
+    expectActionButtonHidden("Restore");
+
+    await user.click(screen.getByRole("button", { name: "Force restore" }));
+
+    expect(onRequestForceRestore).toHaveBeenCalledOnce();
+  });
+
   it("renders a restoring event without stop, restore, or manage actions", () => {
     render(<ActiveCurtailmentStatus event={restoringCurtailmentEvent} />);
 
@@ -172,6 +197,27 @@ describe("ActiveCurtailmentStatus", () => {
     expectActionButtonHidden("Manage");
     expectActionButtonHidden("Stop");
     expectActionButtonHidden("Restore");
+  });
+
+  it("renders admin terminate while restoring when recovery is available", async () => {
+    const user = userEvent.setup();
+    const onRequestAdminTerminate = vi.fn();
+
+    render(
+      <ActiveCurtailmentStatus
+        event={{
+          ...restoringCurtailmentEvent,
+          isAutomationOwned: true,
+          sourceLabel: "MQTT automation",
+        }}
+        onRequestAdminTerminate={onRequestAdminTerminate}
+      />,
+    );
+
+    expect(screen.getByText("MQTT automation recovery")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Admin terminate" }));
+
+    expect(onRequestAdminTerminate).toHaveBeenCalledOnce();
   });
 
   it("counts released targets as restored during restoration", () => {

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -49,21 +49,21 @@ interface ActiveCurtailmentStatusProps {
   event: ActiveCurtailmentEvent;
   className?: string;
   onDismissRestored?: () => void;
-  onRequestAdminTerminate?: () => void;
   onRequestEdit?: () => void;
   onRequestForceRestore?: () => void;
   onRequestRestore?: () => void;
   onRequestStop?: () => void;
+  onRequestTerminateRecovery?: () => void;
 }
 
 interface ActiveCurtailmentActionButtonsProps {
   displayState: ActiveCurtailmentDisplayState;
   onDismissRestored?: () => void;
-  onRequestAdminTerminate?: () => void;
   onRequestEdit?: () => void;
   onRequestForceRestore?: () => void;
   onRequestRestore?: () => void;
   onRequestStop?: () => void;
+  onRequestTerminateRecovery?: () => void;
 }
 
 interface SectionHeaderProps {
@@ -373,9 +373,9 @@ function getForceRestoreButton(onRequestForceRestore?: () => void): ReactElement
 function getActiveCurtailmentActionButton({
   displayState,
   onDismissRestored,
-  onRequestAdminTerminate,
   onRequestRestore,
   onRequestStop,
+  onRequestTerminateRecovery,
 }: ActiveCurtailmentActionButtonsProps): ReactElement | null {
   switch (displayState) {
     case "restored":
@@ -396,12 +396,12 @@ function getActiveCurtailmentActionButton({
         <Button variant={variants.danger} size={sizes.compact} text="Stop" onClick={onRequestStop} />
       ) : null;
     case "restoring":
-      return onRequestAdminTerminate ? (
+      return onRequestTerminateRecovery ? (
         <Button
           variant={variants.secondaryDanger}
           size={sizes.compact}
-          text="Admin terminate"
-          onClick={onRequestAdminTerminate}
+          text="Terminate recovery"
+          onClick={onRequestTerminateRecovery}
         />
       ) : null;
   }
@@ -410,18 +410,18 @@ function getActiveCurtailmentActionButton({
 function ActiveCurtailmentActionButtons({
   displayState,
   onDismissRestored,
-  onRequestAdminTerminate,
   onRequestEdit,
   onRequestForceRestore,
   onRequestRestore,
   onRequestStop,
+  onRequestTerminateRecovery,
 }: ActiveCurtailmentActionButtonsProps): ReactElement | null {
   const actionButton = getActiveCurtailmentActionButton({
     displayState,
     onDismissRestored,
-    onRequestAdminTerminate,
     onRequestRestore,
     onRequestStop,
+    onRequestTerminateRecovery,
   });
   const forceRestoreButton = forceRestorableDisplayStates.has(displayState)
     ? getForceRestoreButton(onRequestForceRestore)
@@ -468,11 +468,11 @@ export default function ActiveCurtailmentStatus({
   event,
   className,
   onDismissRestored,
-  onRequestAdminTerminate,
   onRequestEdit,
   onRequestForceRestore,
   onRequestRestore,
   onRequestStop,
+  onRequestTerminateRecovery,
 }: ActiveCurtailmentStatusProps): ReactElement {
   const targetKw = getTargetKw(event);
   const compliance = getMinerCompliance(event);
@@ -531,11 +531,11 @@ export default function ActiveCurtailmentStatus({
         <ActiveCurtailmentActionButtons
           displayState={displayState}
           onDismissRestored={onDismissRestored}
-          onRequestAdminTerminate={onRequestAdminTerminate}
           onRequestEdit={onRequestEdit}
           onRequestForceRestore={onRequestForceRestore}
           onRequestRestore={onRequestRestore}
           onRequestStop={onRequestStop}
+          onRequestTerminateRecovery={onRequestTerminateRecovery}
         />
 
         <div className="grid gap-3 tablet:pr-32">
@@ -568,7 +568,7 @@ export default function ActiveCurtailmentStatus({
 
         {event.isAutomationOwned ? (
           <div className="mt-6 rounded-lg bg-intent-warning-10 px-4 py-3 text-300 text-text-primary">
-            <div className="text-emphasis-300">MQTT automation recovery</div>
+            <div className="text-emphasis-300">Curtailment automation recovery</div>
             <div className="mt-1 text-text-primary-70">
               {event.sourceLabel} owns this event. Normal restore can be blocked while OFF demand remains asserted or
               the source is stale.

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -32,6 +32,8 @@ export interface ActiveCurtailmentEvent {
   reason: string;
   state: CurtailmentEventState;
   scopeLabel: string;
+  sourceLabel: string;
+  isAutomationOwned?: boolean;
   endedAt?: string;
   selectedMiners: number;
   estimatedReductionKw: number;
@@ -47,7 +49,9 @@ interface ActiveCurtailmentStatusProps {
   event: ActiveCurtailmentEvent;
   className?: string;
   onDismissRestored?: () => void;
+  onRequestAdminTerminate?: () => void;
   onRequestEdit?: () => void;
+  onRequestForceRestore?: () => void;
   onRequestRestore?: () => void;
   onRequestStop?: () => void;
 }
@@ -55,7 +59,9 @@ interface ActiveCurtailmentStatusProps {
 interface ActiveCurtailmentActionButtonsProps {
   displayState: ActiveCurtailmentDisplayState;
   onDismissRestored?: () => void;
+  onRequestAdminTerminate?: () => void;
   onRequestEdit?: () => void;
+  onRequestForceRestore?: () => void;
   onRequestRestore?: () => void;
   onRequestStop?: () => void;
 }
@@ -352,9 +358,22 @@ function formatActiveCurtailmentHeaderDetail(event: ActiveCurtailmentEvent): str
   return `${event.reason} (Applies to ${event.scopeLabel})`;
 }
 
+function getForceRestoreButton(onRequestForceRestore?: () => void): ReactElement | null {
+  return onRequestForceRestore ? (
+    <Button
+      variant={variants.secondaryDanger}
+      size={sizes.compact}
+      text="Force restore"
+      onClick={onRequestForceRestore}
+    />
+  ) : null;
+}
+
 function getActiveCurtailmentActionButton({
   displayState,
   onDismissRestored,
+  onRequestAdminTerminate,
+  onRequestForceRestore,
   onRequestRestore,
   onRequestStop,
 }: ActiveCurtailmentActionButtonsProps): ReactElement | null {
@@ -368,29 +387,46 @@ function getActiveCurtailmentActionButton({
     case "failed":
       return null;
     case "curtailed":
-      return onRequestRestore ? (
-        <Button variant={variants.primary} size={sizes.compact} text="Restore" onClick={onRequestRestore} />
-      ) : null;
+      return (
+        getForceRestoreButton(onRequestForceRestore) ??
+        (onRequestRestore ? (
+          <Button variant={variants.primary} size={sizes.compact} text="Restore" onClick={onRequestRestore} />
+        ) : null)
+      );
     case "pending":
     case "curtailing":
-      return onRequestStop ? (
-        <Button variant={variants.danger} size={sizes.compact} text="Stop" onClick={onRequestStop} />
-      ) : null;
+      return (
+        getForceRestoreButton(onRequestForceRestore) ??
+        (onRequestStop ? (
+          <Button variant={variants.danger} size={sizes.compact} text="Stop" onClick={onRequestStop} />
+        ) : null)
+      );
     case "restoring":
-      return null;
+      return onRequestAdminTerminate ? (
+        <Button
+          variant={variants.secondaryDanger}
+          size={sizes.compact}
+          text="Admin terminate"
+          onClick={onRequestAdminTerminate}
+        />
+      ) : null;
   }
 }
 
 function ActiveCurtailmentActionButtons({
   displayState,
   onDismissRestored,
+  onRequestAdminTerminate,
   onRequestEdit,
+  onRequestForceRestore,
   onRequestRestore,
   onRequestStop,
 }: ActiveCurtailmentActionButtonsProps): ReactElement | null {
   const actionButton = getActiveCurtailmentActionButton({
     displayState,
     onDismissRestored,
+    onRequestAdminTerminate,
+    onRequestForceRestore,
     onRequestRestore,
     onRequestStop,
   });
@@ -435,7 +471,9 @@ export default function ActiveCurtailmentStatus({
   event,
   className,
   onDismissRestored,
+  onRequestAdminTerminate,
   onRequestEdit,
+  onRequestForceRestore,
   onRequestRestore,
   onRequestStop,
 }: ActiveCurtailmentStatusProps): ReactElement {
@@ -496,7 +534,9 @@ export default function ActiveCurtailmentStatus({
         <ActiveCurtailmentActionButtons
           displayState={displayState}
           onDismissRestored={onDismissRestored}
+          onRequestAdminTerminate={onRequestAdminTerminate}
           onRequestEdit={onRequestEdit}
+          onRequestForceRestore={onRequestForceRestore}
           onRequestRestore={onRequestRestore}
           onRequestStop={onRequestStop}
         />
@@ -528,6 +568,16 @@ export default function ActiveCurtailmentStatus({
             </>
           )}
         </div>
+
+        {event.isAutomationOwned ? (
+          <div className="mt-6 rounded-lg bg-intent-warning-10 px-4 py-3 text-300 text-text-primary">
+            <div className="text-emphasis-300">MQTT automation recovery</div>
+            <div className="mt-1 text-text-primary-70">
+              {event.sourceLabel} owns this event. Normal restore can be blocked while OFF demand remains asserted or
+              the source is stale.
+            </div>
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -33,7 +33,7 @@ export interface ActiveCurtailmentEvent {
   state: CurtailmentEventState;
   scopeLabel: string;
   sourceLabel: string;
-  isAutomationOwned?: boolean;
+  isAutomationOwned: boolean;
   endedAt?: string;
   selectedMiners: number;
   estimatedReductionKw: number;
@@ -152,6 +152,7 @@ const displayStateLabels: Record<ActiveCurtailmentDisplayState, string> = {
 };
 
 const manageableDisplayStates = new Set<ActiveCurtailmentDisplayState>(["curtailed", "curtailing", "pending"]);
+const forceRestorableDisplayStates = new Set<ActiveCurtailmentDisplayState>(["curtailed", "curtailing", "pending"]);
 
 function SectionHeader({ title, children }: SectionHeaderProps): ReactElement {
   return (
@@ -373,7 +374,6 @@ function getActiveCurtailmentActionButton({
   displayState,
   onDismissRestored,
   onRequestAdminTerminate,
-  onRequestForceRestore,
   onRequestRestore,
   onRequestStop,
 }: ActiveCurtailmentActionButtonsProps): ReactElement | null {
@@ -387,20 +387,14 @@ function getActiveCurtailmentActionButton({
     case "failed":
       return null;
     case "curtailed":
-      return (
-        getForceRestoreButton(onRequestForceRestore) ??
-        (onRequestRestore ? (
-          <Button variant={variants.primary} size={sizes.compact} text="Restore" onClick={onRequestRestore} />
-        ) : null)
-      );
+      return onRequestRestore ? (
+        <Button variant={variants.primary} size={sizes.compact} text="Restore" onClick={onRequestRestore} />
+      ) : null;
     case "pending":
     case "curtailing":
-      return (
-        getForceRestoreButton(onRequestForceRestore) ??
-        (onRequestStop ? (
-          <Button variant={variants.danger} size={sizes.compact} text="Stop" onClick={onRequestStop} />
-        ) : null)
-      );
+      return onRequestStop ? (
+        <Button variant={variants.danger} size={sizes.compact} text="Stop" onClick={onRequestStop} />
+      ) : null;
     case "restoring":
       return onRequestAdminTerminate ? (
         <Button
@@ -426,13 +420,15 @@ function ActiveCurtailmentActionButtons({
     displayState,
     onDismissRestored,
     onRequestAdminTerminate,
-    onRequestForceRestore,
     onRequestRestore,
     onRequestStop,
   });
+  const forceRestoreButton = forceRestorableDisplayStates.has(displayState)
+    ? getForceRestoreButton(onRequestForceRestore)
+    : null;
   const showManageButton = Boolean(onRequestEdit && manageableDisplayStates.has(displayState));
 
-  if (!actionButton && !showManageButton) {
+  if (!actionButton && !forceRestoreButton && !showManageButton) {
     return null;
   }
 
@@ -442,6 +438,7 @@ function ActiveCurtailmentActionButtons({
         <Button variant={variants.secondary} size={sizes.compact} text="Manage" onClick={onRequestEdit} />
       ) : null}
       {actionButton}
+      {forceRestoreButton}
     </div>
   );
 }

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.test.tsx
@@ -525,6 +525,33 @@ describe("CurtailmentHistory", () => {
     expect(onManageActiveEvent).not.toHaveBeenCalled();
   });
 
+  it("selects restoring active row summaries for recovery", async () => {
+    const user = userEvent.setup();
+    const onSelectActiveEvent = vi.fn();
+    const restoringEvent = {
+      ...mockCurtailmentHistoryEvents[0],
+      id: "curt-restoring",
+      reason: "Restoring event",
+      state: "restoring" as const,
+    };
+
+    render(
+      <CurtailmentHistory
+        events={[restoringEvent]}
+        activeEventId="curt-restoring"
+        onSelectActiveEvent={onSelectActiveEvent}
+      />,
+    );
+
+    await user.click(screen.getByTestId("curtailment-history-row-curt-restoring"));
+
+    const modal = screen.getByTestId("modal");
+    await user.click(within(modal).getByRole("button", { name: "View active event" }));
+
+    expect(onSelectActiveEvent).toHaveBeenCalledWith(restoringEvent);
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+  });
+
   it("routes secondary active row actions from activeEventIds", async () => {
     const user = userEvent.setup();
     const onManageActiveEvent = vi.fn();

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -61,6 +61,11 @@ interface CurtailmentHistoryProps {
    */
   onManageActiveEvent?: (event: CurtailmentHistoryEvent) => void;
   /**
+   * Called from the detail modal for active restoring events that cannot be
+   * edited or stopped directly. The parent owns selecting/hydrating the event.
+   */
+  onSelectActiveEvent?: (event: CurtailmentHistoryEvent) => void;
+  /**
    * Called after the operator confirms stopping the active event. The parent
    * owns persistence. Return a promise only after an actual stop request
    * starts; a rejected promise re-enables retry controls.
@@ -84,6 +89,7 @@ interface CurtailmentSummaryModalProps {
   open: boolean;
   onDismiss: () => void;
   onManage?: () => void;
+  onSelectActive?: () => void;
   onStop?: () => void;
   stopDisabled?: boolean;
 }
@@ -107,6 +113,7 @@ interface CurtailmentSummaryModalButton {
 const defaultPageSize = 50;
 const stoppableEventStates = new Set<CurtailmentEventState>(["pending", "active"]);
 const manageableEventStates = new Set<CurtailmentEventState>(["pending", "active"]);
+const selectableEventStates = new Set<CurtailmentEventState>(["restoring"]);
 const rowInteractiveElementSelector =
   'button, a, input, select, textarea, [role="button"], [role="link"], [data-interactive]';
 const unavailableTargetMetricsLabel = "Target details unavailable";
@@ -245,6 +252,10 @@ function isActiveManageableEvent(event: CurtailmentHistoryEvent, activeEventIds:
   return activeEventIds.has(event.id) && manageableEventStates.has(event.state);
 }
 
+function isActiveSelectableEvent(event: CurtailmentHistoryEvent, activeEventIds: Set<string>): boolean {
+  return activeEventIds.has(event.id) && selectableEventStates.has(event.state);
+}
+
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   if (value === null || (typeof value !== "object" && typeof value !== "function")) {
     return false;
@@ -289,6 +300,7 @@ function CurtailmentSummaryModal({
   open,
   onDismiss,
   onManage,
+  onSelectActive,
   onStop,
   stopDisabled,
 }: CurtailmentSummaryModalProps): ReactElement {
@@ -315,6 +327,15 @@ function CurtailmentSummaryModal({
       text: "Manage",
       variant: variants.primary,
       onClick: onManage,
+      dismissModalOnClick: false,
+    });
+  }
+
+  if (onSelectActive) {
+    buttons.push({
+      text: "View active event",
+      variant: variants.primary,
+      onClick: onSelectActive,
       dismissModalOnClick: false,
     });
   }
@@ -451,6 +472,7 @@ function CurtailmentHistory({
   onStatusFilterChange,
   onStatusFiltersChange,
   onManageActiveEvent,
+  onSelectActiveEvent,
   onStopActiveEvent,
   onStopActiveEventRequested,
 }: CurtailmentHistoryProps): ReactElement {
@@ -622,6 +644,14 @@ function CurtailmentHistory({
         }
       : undefined;
 
+  const handleSelectActiveDetailEvent =
+    selectedDetailEvent && onSelectActiveEvent && isActiveSelectableEvent(selectedDetailEvent, activeEventIds)
+      ? () => {
+          setSelectedDetailEventId(undefined);
+          onSelectActiveEvent(selectedDetailEvent);
+        }
+      : undefined;
+
   const handleStopSelectedDetailEvent =
     selectedDetailEvent && onStopActiveEvent && isActiveStoppableEvent(selectedDetailEvent, activeEventIds)
       ? () => handleOpenStopConfirmation(selectedDetailEvent)
@@ -730,6 +760,7 @@ function CurtailmentHistory({
           open
           onDismiss={handleDismissSummary}
           onManage={handleManageSelectedDetailEvent}
+          onSelectActive={handleSelectActiveDetailEvent}
           onStop={handleStopSelectedDetailEvent}
           stopDisabled={pendingStopEventIds.has(selectedDetailEvent.id)}
         />

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -541,6 +541,37 @@ describe("CurtailmentManagementPanel", () => {
     );
   });
 
+  it("keeps admin terminate dialog open while submitting", async () => {
+    const user = userEvent.setup();
+    const restoringEvent = { ...activeEvent, state: "restoring" } satisfies ActiveCurtailmentEvent;
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent: restoringEvent,
+        activeEvents: [{ ...historyEvent, state: "restoring" }],
+        activeEventId: "curt-1",
+      }),
+    );
+
+    const { rerender } = render(<CurtailmentManagementPanel canAdminRecoverCurtailment />);
+
+    await user.click(screen.getByRole("button", { name: "Request admin terminate" }));
+    expect(screen.getByText("Admin terminate event?")).toBeInTheDocument();
+
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent: restoringEvent,
+        activeEvents: [{ ...historyEvent, state: "restoring" }],
+        activeEventId: "curt-1",
+        adminTerminatingEventId: "curt-1",
+      }),
+    );
+    rerender(<CurtailmentManagementPanel canAdminRecoverCurtailment />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.getByText("Admin terminate event?")).toBeInTheDocument();
+  });
+
   it("does not submit stale stop confirmations for events that are no longer active", async () => {
     const user = userEvent.setup();
     const staleEvent = { ...historyEvent, state: "active" } as CurtailmentHistoryEvent;

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -101,6 +101,7 @@ vi.mock("@/protoFleet/features/energy/CurtailmentHistory", () => ({
     selectedStatusFilters,
     onPageChange,
     onManageActiveEvent,
+    onSelectActiveEvent,
     onStatusFiltersChange,
     onStopActiveEvent,
     onStopActiveEventRequested,
@@ -113,6 +114,7 @@ vi.mock("@/protoFleet/features/energy/CurtailmentHistory", () => ({
     selectedStatusFilters?: string[];
     onPageChange?: (page: number) => void;
     onManageActiveEvent?: (event: CurtailmentHistoryEvent) => void;
+    onSelectActiveEvent?: (event: CurtailmentHistoryEvent) => void;
     onStatusFiltersChange?: (filters: string[]) => void;
     onStopActiveEvent?: (event: CurtailmentHistoryEvent) => void | Promise<unknown>;
     onStopActiveEventRequested?: (event: CurtailmentHistoryEvent) => void;
@@ -149,6 +151,11 @@ vi.mock("@/protoFleet/features/energy/CurtailmentHistory", () => ({
             </button>
           ) : null}
         </>
+      ) : null}
+      {onSelectActiveEvent && events[0] ? (
+        <button type="button" onClick={() => onSelectActiveEvent(events[0])}>
+          Select history event
+        </button>
       ) : null}
       {onStopActiveEvent ? (
         <button
@@ -553,6 +560,34 @@ describe("CurtailmentManagementPanel", () => {
     render(<CurtailmentManagementPanel enableRecover />);
 
     expect(screen.queryByRole("button", { name: "Request terminate recovery" })).not.toBeInTheDocument();
+  });
+
+  it("selects non-selected restoring history events for recovery", async () => {
+    const user = userEvent.setup();
+    const restoringHistoryEvent = {
+      ...historyEvent,
+      id: "curt-restoring",
+      state: "restoring",
+    } as CurtailmentHistoryEvent;
+    mocks.selectActiveCurtailment.mockResolvedValue({
+      activeEvent: { ...activeEvent, isAutomationOwned: true, state: "restoring" },
+      activeEventId: "curt-restoring",
+      activeEventFormValues: null,
+    });
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent,
+        activeEvents: [{ ...historyEvent, state: "active" }, restoringHistoryEvent],
+        activeEventId: "curt-1",
+        historyEvents: [restoringHistoryEvent],
+      }),
+    );
+
+    render(<CurtailmentManagementPanel enableRecover />);
+
+    await user.click(screen.getByRole("button", { name: "Select history event" }));
+
+    expect(mocks.selectActiveCurtailment).toHaveBeenCalledWith("curt-restoring", { signal: expect.any(AbortSignal) });
   });
 
   it("keeps terminate recovery dialog open while submitting", async () => {

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -45,18 +45,18 @@ vi.mock("react-router-dom", () => ({
 vi.mock("@/protoFleet/features/energy/ActiveCurtailmentStatus", () => ({
   default: ({
     onDismissRestored,
-    onRequestAdminTerminate,
     onRequestEdit,
     onRequestForceRestore,
     onRequestRestore,
     onRequestStop,
+    onRequestTerminateRecovery,
   }: {
     onDismissRestored?: () => void;
-    onRequestAdminTerminate?: () => void;
     onRequestEdit?: () => void;
     onRequestForceRestore?: () => void;
     onRequestRestore?: () => void;
     onRequestStop?: () => void;
+    onRequestTerminateRecovery?: () => void;
   }) => (
     <div data-testid="active-curtailment-status">
       <button type="button" onClick={onDismissRestored}>
@@ -82,9 +82,9 @@ vi.mock("@/protoFleet/features/energy/ActiveCurtailmentStatus", () => ({
           Request stop
         </button>
       ) : null}
-      {onRequestAdminTerminate ? (
-        <button type="button" onClick={onRequestAdminTerminate}>
-          Request admin terminate
+      {onRequestTerminateRecovery ? (
+        <button type="button" onClick={onRequestTerminateRecovery}>
+          Request terminate recovery
         </button>
       ) : null}
     </div>
@@ -481,7 +481,7 @@ describe("CurtailmentManagementPanel", () => {
       }),
     );
 
-    render(<CurtailmentManagementPanel canAdminRecoverCurtailment />);
+    render(<CurtailmentManagementPanel enableRecover />);
 
     await user.click(screen.getByRole("button", { name: "Request restore" }));
     expect(screen.getByRole("dialog", { name: "restore confirmation" })).toBeInTheDocument();
@@ -504,26 +504,26 @@ describe("CurtailmentManagementPanel", () => {
       }),
     );
 
-    render(<CurtailmentManagementPanel canAdminRecoverCurtailment={false} />);
+    render(<CurtailmentManagementPanel enableRecover={false} />);
 
     expect(screen.queryByRole("button", { name: "Request force restore" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Request admin terminate" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request terminate recovery" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Request restore" })).toBeInTheDocument();
   });
 
-  it("admin terminates restoring events with target state and required reason", async () => {
+  it("terminates automation-owned restoring events with target state and required reason", async () => {
     const user = userEvent.setup();
     mocks.useCurtailmentApi.mockReturnValue(
       createApiResult({
-        activeEvent: { ...activeEvent, state: "restoring" },
+        activeEvent: { ...activeEvent, isAutomationOwned: true, state: "restoring" },
         activeEvents: [{ ...historyEvent, state: "restoring" }],
         activeEventId: "curt-1",
       }),
     );
 
-    render(<CurtailmentManagementPanel canAdminRecoverCurtailment />);
+    render(<CurtailmentManagementPanel enableRecover />);
 
-    await user.click(screen.getByRole("button", { name: "Request admin terminate" }));
+    await user.click(screen.getByRole("button", { name: "Request terminate recovery" }));
     await user.click(screen.getByRole("button", { name: "Terminate event" }));
 
     expect(screen.getByText("Enter a reason before terminating the event.")).toBeInTheDocument();
@@ -541,9 +541,27 @@ describe("CurtailmentManagementPanel", () => {
     );
   });
 
-  it("keeps admin terminate dialog open while submitting", async () => {
+  it("hides terminate recovery for non-automation restoring events", () => {
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent: { ...activeEvent, isAutomationOwned: false, state: "restoring" },
+        activeEvents: [{ ...historyEvent, state: "restoring" }],
+        activeEventId: "curt-1",
+      }),
+    );
+
+    render(<CurtailmentManagementPanel enableRecover />);
+
+    expect(screen.queryByRole("button", { name: "Request terminate recovery" })).not.toBeInTheDocument();
+  });
+
+  it("keeps terminate recovery dialog open while submitting", async () => {
     const user = userEvent.setup();
-    const restoringEvent = { ...activeEvent, state: "restoring" } satisfies ActiveCurtailmentEvent;
+    const restoringEvent = {
+      ...activeEvent,
+      isAutomationOwned: true,
+      state: "restoring",
+    } satisfies ActiveCurtailmentEvent;
     mocks.useCurtailmentApi.mockReturnValue(
       createApiResult({
         activeEvent: restoringEvent,
@@ -552,10 +570,10 @@ describe("CurtailmentManagementPanel", () => {
       }),
     );
 
-    const { rerender } = render(<CurtailmentManagementPanel canAdminRecoverCurtailment />);
+    const { rerender } = render(<CurtailmentManagementPanel enableRecover />);
 
-    await user.click(screen.getByRole("button", { name: "Request admin terminate" }));
-    expect(screen.getByText("Admin terminate event?")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Request terminate recovery" }));
+    expect(screen.getByText("Terminate recovery event?")).toBeInTheDocument();
 
     mocks.useCurtailmentApi.mockReturnValue(
       createApiResult({
@@ -565,11 +583,11 @@ describe("CurtailmentManagementPanel", () => {
         adminTerminatingEventId: "curt-1",
       }),
     );
-    rerender(<CurtailmentManagementPanel canAdminRecoverCurtailment />);
+    rerender(<CurtailmentManagementPanel enableRecover />);
 
     fireEvent.keyDown(document, { key: "Escape" });
 
-    expect(screen.getByText("Admin terminate event?")).toBeInTheDocument();
+    expect(screen.getByText("Terminate recovery event?")).toBeInTheDocument();
   });
 
   it("does not submit stale stop confirmations for events that are no longer active", async () => {
@@ -1121,7 +1139,7 @@ describe("CurtailmentManagementPanel", () => {
       }),
     );
 
-    render(<CurtailmentManagementPanel canManageCurtailment={false} />);
+    render(<CurtailmentManagementPanel enableManage={false} />);
 
     expect(screen.getByTestId("active-curtailment-status")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Request edit" })).not.toBeInTheDocument();

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@/protoFleet/features/energy/CurtailmentStartModal";
 
 const mocks = vi.hoisted(() => ({
+  adminTerminateCurtailment: vi.fn(),
   dismissTerminalCurtailment: vi.fn(),
   goToHistoryPage: vi.fn(),
   navigate: vi.fn(),
@@ -29,6 +30,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/protoFleet/api/useCurtailmentApi", () => ({
+  adminTerminateReasonRequiredMessage: "Enter a reason before terminating the event.",
   useCurtailmentApi: () => mocks.useCurtailmentApi(),
 }));
 
@@ -43,12 +45,16 @@ vi.mock("react-router-dom", () => ({
 vi.mock("@/protoFleet/features/energy/ActiveCurtailmentStatus", () => ({
   default: ({
     onDismissRestored,
+    onRequestAdminTerminate,
     onRequestEdit,
+    onRequestForceRestore,
     onRequestRestore,
     onRequestStop,
   }: {
     onDismissRestored?: () => void;
+    onRequestAdminTerminate?: () => void;
     onRequestEdit?: () => void;
+    onRequestForceRestore?: () => void;
     onRequestRestore?: () => void;
     onRequestStop?: () => void;
   }) => (
@@ -61,6 +67,11 @@ vi.mock("@/protoFleet/features/energy/ActiveCurtailmentStatus", () => ({
           Request edit
         </button>
       ) : null}
+      {onRequestForceRestore ? (
+        <button type="button" onClick={onRequestForceRestore}>
+          Request force restore
+        </button>
+      ) : null}
       {onRequestRestore ? (
         <button type="button" onClick={onRequestRestore}>
           Request restore
@@ -69,6 +80,11 @@ vi.mock("@/protoFleet/features/energy/ActiveCurtailmentStatus", () => ({
       {onRequestStop ? (
         <button type="button" onClick={onRequestStop}>
           Request stop
+        </button>
+      ) : null}
+      {onRequestAdminTerminate ? (
+        <button type="button" onClick={onRequestAdminTerminate}>
+          Request admin terminate
         </button>
       ) : null}
     </div>
@@ -247,10 +263,12 @@ function createApiResult(overrides: Partial<UseCurtailmentApiResult> = {}): UseC
     isStarting: false,
     isUpdating: false,
     stoppingEventId: null,
+    adminTerminatingEventId: null,
     loadError: null,
     startError: null,
     updateError: null,
     stopError: null,
+    adminTerminateError: null,
     historyCurrentPage: 0,
     historyHasNextPage: false,
     historyHasPreviousPage: false,
@@ -266,6 +284,7 @@ function createApiResult(overrides: Partial<UseCurtailmentApiResult> = {}): UseC
       mocks.dismissTerminalCurtailment as UseCurtailmentApiResult["dismissTerminalCurtailment"],
     updateCurtailment: mocks.updateCurtailment as UseCurtailmentApiResult["updateCurtailment"],
     stopCurtailment: mocks.stopCurtailment as UseCurtailmentApiResult["stopCurtailment"],
+    adminTerminateCurtailment: mocks.adminTerminateCurtailment as UseCurtailmentApiResult["adminTerminateCurtailment"],
     ...overrides,
   };
 }
@@ -284,6 +303,7 @@ describe("CurtailmentManagementPanel", () => {
     mocks.setHistoryStatusFilters.mockResolvedValue(emptySnapshot);
     mocks.startCurtailment.mockResolvedValue({});
     mocks.stopCurtailment.mockResolvedValue({});
+    mocks.adminTerminateCurtailment.mockResolvedValue({});
     mocks.updateCurtailment.mockResolvedValue({});
     mocks.useCurtailmentApi.mockReturnValue(createApiResult());
     mocks.useCurtailmentResponseProfiles.mockReturnValue({
@@ -446,6 +466,71 @@ describe("CurtailmentManagementPanel", () => {
     await user.click(screen.getByRole("button", { name: "Stop history event" }));
 
     expect(mocks.stopCurtailment).toHaveBeenLastCalledWith("curt-1");
+  });
+
+  it("force restores automation-owned events only for admins", async () => {
+    const user = userEvent.setup();
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent: { ...activeEvent, isAutomationOwned: true },
+        activeEvents: [{ ...historyEvent, state: "active" }],
+        activeEventId: "curt-1",
+      }),
+    );
+
+    render(<CurtailmentManagementPanel canAdminRecoverCurtailment />);
+
+    await user.click(screen.getByRole("button", { name: "Request force restore" }));
+    expect(screen.getByRole("dialog", { name: "forceRestore confirmation" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Confirm confirmation" }));
+
+    await waitFor(() => expect(mocks.stopCurtailment).toHaveBeenCalledWith("curt-1", { force: true }));
+  });
+
+  it("hides force recovery controls from non-admin curtailment managers", () => {
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent: { ...activeEvent, isAutomationOwned: true },
+        activeEventId: "curt-1",
+      }),
+    );
+
+    render(<CurtailmentManagementPanel canAdminRecoverCurtailment={false} />);
+
+    expect(screen.queryByRole("button", { name: "Request force restore" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request admin terminate" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Request restore" })).toBeInTheDocument();
+  });
+
+  it("admin terminates restoring events with target state and required reason", async () => {
+    const user = userEvent.setup();
+    mocks.useCurtailmentApi.mockReturnValue(
+      createApiResult({
+        activeEvent: { ...activeEvent, isAutomationOwned: true, state: "restoring" },
+        activeEvents: [{ ...historyEvent, state: "restoring" }],
+        activeEventId: "curt-1",
+      }),
+    );
+
+    render(<CurtailmentManagementPanel canAdminRecoverCurtailment />);
+
+    await user.click(screen.getByRole("button", { name: "Request admin terminate" }));
+    await user.click(screen.getByRole("button", { name: "Terminate event" }));
+
+    expect(screen.getByText("Enter a reason before terminating the event.")).toBeInTheDocument();
+    expect(mocks.adminTerminateCurtailment).not.toHaveBeenCalled();
+
+    await user.click(screen.getByLabelText("Failed"));
+    await user.type(screen.getByRole("textbox", { name: "Reason" }), "Recovered from stale MQTT source");
+    await user.click(screen.getByRole("button", { name: "Terminate event" }));
+
+    await waitFor(() =>
+      expect(mocks.adminTerminateCurtailment).toHaveBeenCalledWith("curt-1", {
+        reason: "Recovered from stale MQTT source",
+        targetState: "failed",
+      }),
+    );
   });
 
   it("does not submit stale stop confirmations for events that are no longer active", async () => {

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -218,6 +218,9 @@ vi.mock("@/protoFleet/features/energy/CurtailmentStopConfirmationDialog", () => 
 const activeEvent = {
   reason: "Grid peak",
   state: "active",
+  scopeLabel: "Whole fleet",
+  sourceLabel: "Manual",
+  isAutomationOwned: false,
   selectedMiners: 2,
   targetKw: 5,
   estimatedReductionKw: 6.2,
@@ -480,6 +483,11 @@ describe("CurtailmentManagementPanel", () => {
 
     render(<CurtailmentManagementPanel canAdminRecoverCurtailment />);
 
+    await user.click(screen.getByRole("button", { name: "Request restore" }));
+    expect(screen.getByRole("dialog", { name: "restore confirmation" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Confirm confirmation" }));
+    await waitFor(() => expect(mocks.stopCurtailment).toHaveBeenCalledWith("curt-1"));
+
     await user.click(screen.getByRole("button", { name: "Request force restore" }));
     expect(screen.getByRole("dialog", { name: "forceRestore confirmation" })).toBeInTheDocument();
 
@@ -507,7 +515,7 @@ describe("CurtailmentManagementPanel", () => {
     const user = userEvent.setup();
     mocks.useCurtailmentApi.mockReturnValue(
       createApiResult({
-        activeEvent: { ...activeEvent, isAutomationOwned: true, state: "restoring" },
+        activeEvent: { ...activeEvent, state: "restoring" },
         activeEvents: [{ ...historyEvent, state: "restoring" }],
         activeEventId: "curt-1",
       }),

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -3,9 +3,9 @@ import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 
 import {
-  type AdminTerminateCurtailmentOptions,
-  type AdminTerminateCurtailmentState,
   adminTerminateReasonRequiredMessage,
+  type AdminTerminateCurtailmentOptions as TerminateRecoveryOptions,
+  type AdminTerminateCurtailmentState as TerminateRecoveryState,
   useCurtailmentApi,
 } from "@/protoFleet/api/useCurtailmentApi";
 import useCurtailmentResponseProfiles from "@/protoFleet/api/useCurtailmentResponseProfiles";
@@ -37,8 +37,8 @@ import Radio from "@/shared/components/Radio";
 import Textarea from "@/shared/components/Textarea";
 
 interface CurtailmentManagementPanelProps {
-  canAdminRecoverCurtailment?: boolean;
-  canManageCurtailment?: boolean;
+  enableManage?: boolean;
+  enableRecover?: boolean;
   className?: string;
 }
 
@@ -57,11 +57,11 @@ interface CurtailmentMessageProps {
   message: string;
 }
 
-interface AdminTerminateDialogProps {
+interface TerminateRecoveryDialogProps {
   error?: string | null;
   isSubmitting?: boolean;
   onCancel: () => void;
-  onConfirm: (options: AdminTerminateCurtailmentOptions) => void;
+  onConfirm: (options: TerminateRecoveryOptions) => void;
   open: boolean;
 }
 
@@ -73,7 +73,7 @@ const defaultResponseDeadlineMinutes = "15";
 const defaultMaxDurationSec = "900";
 const immediateRestoreBatchSize = "10000";
 
-const adminTerminateStateOptions: { label: string; value: AdminTerminateCurtailmentState }[] = [
+const terminateRecoveryStateOptions: { label: string; value: TerminateRecoveryState }[] = [
   { label: "Cancelled", value: "cancelled" },
   { label: "Failed", value: "failed" },
 ];
@@ -164,14 +164,14 @@ function CurtailmentMessage({ message }: CurtailmentMessageProps): ReactElement 
   );
 }
 
-function CurtailmentAdminTerminateDialog({
+function CurtailmentRecoveryTerminateDialog({
   error,
   isSubmitting = false,
   onCancel,
   onConfirm,
   open,
-}: AdminTerminateDialogProps): ReactElement {
-  const [targetState, setTargetState] = useState<AdminTerminateCurtailmentState>("cancelled");
+}: TerminateRecoveryDialogProps): ReactElement {
+  const [targetState, setTargetState] = useState<TerminateRecoveryState>("cancelled");
   const [reason, setReason] = useState("");
   const [reasonError, setReasonError] = useState<string | null>(null);
   const validationError = reasonError ?? error ?? null;
@@ -191,7 +191,7 @@ function CurtailmentAdminTerminateDialog({
   return (
     <Dialog
       open={open}
-      title="Admin terminate event?"
+      title="Terminate recovery event?"
       onDismiss={dismissDialog}
       icon={
         <DialogIcon intent="critical">
@@ -220,10 +220,10 @@ function CurtailmentAdminTerminateDialog({
         <fieldset className="grid gap-2">
           <legend className="text-emphasis-300">Target state</legend>
           <div className="flex flex-wrap gap-4">
-            {adminTerminateStateOptions.map((option) => (
+            {terminateRecoveryStateOptions.map((option) => (
               <label key={option.value} className="flex items-center gap-2">
                 <Radio
-                  name="admin-terminate-target-state"
+                  name="terminate-recovery-target-state"
                   value={option.value}
                   selected={targetState === option.value}
                   onChange={() => setTargetState(option.value)}
@@ -235,7 +235,7 @@ function CurtailmentAdminTerminateDialog({
           </div>
         </fieldset>
         <Textarea
-          id="admin-terminate-reason"
+          id="terminate-recovery-reason"
           label="Reason"
           initValue={reason}
           rows={3}
@@ -273,13 +273,13 @@ function canForceRestoreCurtailmentEvent(event: ActiveCurtailmentEvent): boolean
   return Boolean(event.isAutomationOwned && forceRestorableCurtailmentEventStates.has(event.state));
 }
 
-function canAdminTerminateCurtailmentEvent(event: Pick<ActiveCurtailmentEvent, "state">): boolean {
-  return event.state === "restoring";
+function canTerminateRecoveryCurtailmentEvent(event: ActiveCurtailmentEvent): boolean {
+  return Boolean(event.isAutomationOwned && event.state === "restoring");
 }
 
 function CurtailmentManagementPanel({
-  canAdminRecoverCurtailment = false,
-  canManageCurtailment = true,
+  enableManage = true,
+  enableRecover = false,
   className,
 }: CurtailmentManagementPanelProps): ReactElement {
   const navigate = useNavigate();
@@ -314,7 +314,7 @@ function CurtailmentManagementPanel({
     stopCurtailment,
     adminTerminateCurtailment,
   } = useCurtailmentApi();
-  const { responseProfiles } = useCurtailmentResponseProfiles(canManageCurtailment);
+  const { responseProfiles } = useCurtailmentResponseProfiles(enableManage);
   const responseProfileOptions = useMemo(
     () => responseProfiles.map(createCurtailmentResponseProfileOption),
     [responseProfiles],
@@ -323,27 +323,27 @@ function CurtailmentManagementPanel({
   const [modalMode, setModalMode] = useState<CurtailmentStartModalMode | null>(null);
   const [editSession, setEditSession] = useState<EditCurtailmentSession | null>(null);
   const [pendingStopConfirmation, setPendingStopConfirmation] = useState<PendingStopConfirmation | null>(null);
-  const [pendingAdminTerminateEventId, setPendingAdminTerminateEventId] = useState<string | null>(null);
+  const [pendingTerminateRecoveryEventId, setPendingTerminateRecoveryEventId] = useState<string | null>(null);
   const refreshAbortControllerRef = useRef<AbortController | null>(null);
   const activeRefreshAbortControllerRef = useRef<AbortController | null>(null);
   const manageSelectionAbortControllerRef = useRef<AbortController | null>(null);
   const manageSelectionRequestIdRef = useRef(0);
   const foregroundRefreshInFlightRef = useRef(false);
-  const canUseAdminRecovery = canManageCurtailment && canAdminRecoverCurtailment;
+  const canUseRecovery = enableManage && enableRecover;
   const recoveryStopError =
     stopError && activeEvent?.isAutomationOwned
       ? `${stopError} ${
-          canUseAdminRecovery
-            ? "Use Force restore to override active automation demand and minimum-duration guards."
-            : "Ask an admin to force restore if automation demand remains asserted or the source is stale."
+          canUseRecovery
+            ? "Stop or disable automation before Force restore if demand remains asserted."
+            : "Ask an admin to stop automation and force restore if demand remains asserted or the source is stale."
         }`
       : stopError;
   const errorMessage = startError ?? updateError ?? recoveryStopError ?? adminTerminateError ?? loadError;
   const isInitialLoading = isLoading && !activeEvent && historyEvents.length === 0;
   const isStopConfirmationSubmitting =
     pendingStopConfirmation !== null && stoppingEventId === pendingStopConfirmation.eventId;
-  const isAdminTerminateSubmitting =
-    pendingAdminTerminateEventId !== null && adminTerminatingEventId === pendingAdminTerminateEventId;
+  const isTerminateRecoverySubmitting =
+    pendingTerminateRecoveryEventId !== null && adminTerminatingEventId === pendingTerminateRecoveryEventId;
   const isEditingCurtailment = modalMode === "edit";
   const isModalSubmitting = isEditingCurtailment ? isUpdating : isStarting;
   const hasOngoingCurtailment = activeEvents.some((event) => nonTerminalActiveEventStates.has(event.state));
@@ -435,7 +435,7 @@ function CurtailmentManagementPanel({
   }, [cancelManageSelection]);
 
   const openEditModal = useCallback(() => {
-    if (!canManageCurtailment || !activeEvent || !activeEventId || !activeEventFormValues) {
+    if (!enableManage || !activeEvent || !activeEventId || !activeEventFormValues) {
       return;
     }
 
@@ -446,11 +446,11 @@ function CurtailmentManagementPanel({
       preview: createActiveCurtailmentPreview(activeEvent, activeEventFormValues),
     });
     setModalMode("edit");
-  }, [activeEvent, activeEventFormValues, activeEventId, canManageCurtailment, cancelManageSelection]);
+  }, [activeEvent, activeEventFormValues, activeEventId, enableManage, cancelManageSelection]);
 
   const openHistoryManageModal = useCallback(
     (event: CurtailmentHistoryEvent) => {
-      if (!canManageCurtailment) {
+      if (!enableManage) {
         return;
       }
 
@@ -509,36 +509,29 @@ function CurtailmentManagementPanel({
           }
         });
     },
-    [
-      activeEvent,
-      activeEventFormValues,
-      activeEventId,
-      canManageCurtailment,
-      cancelManageSelection,
-      selectActiveCurtailment,
-    ],
+    [activeEvent, activeEventFormValues, activeEventId, enableManage, cancelManageSelection, selectActiveCurtailment],
   );
 
   const openStopConfirmation = useCallback(
     (action: CurtailmentStopConfirmationAction, eventId = activeEventId) => {
-      if (!canManageCurtailment || !eventId) {
+      if (!enableManage || !eventId) {
         return;
       }
 
       cancelManageSelection();
       setPendingStopConfirmation({ action, eventId });
     },
-    [activeEventId, canManageCurtailment, cancelManageSelection],
+    [activeEventId, enableManage, cancelManageSelection],
   );
 
-  const openAdminTerminateConfirmation = useCallback(() => {
-    if (!canUseAdminRecovery || !activeEvent || !activeEventId || !canAdminTerminateCurtailmentEvent(activeEvent)) {
+  const openTerminateRecoveryConfirmation = useCallback(() => {
+    if (!canUseRecovery || !activeEvent || !activeEventId || !canTerminateRecoveryCurtailmentEvent(activeEvent)) {
       return;
     }
 
     cancelManageSelection();
-    setPendingAdminTerminateEventId(activeEventId);
-  }, [activeEvent, activeEventId, canUseAdminRecovery, cancelManageSelection]);
+    setPendingTerminateRecoveryEventId(activeEventId);
+  }, [activeEvent, activeEventId, canUseRecovery, cancelManageSelection]);
 
   const handleStartSubmit = useCallback(
     (values: CurtailmentSubmitValues) => {
@@ -598,14 +591,14 @@ function CurtailmentManagementPanel({
   );
 
   const handleConfirmStop = useCallback(() => {
-    if (!canManageCurtailment || !pendingStopConfirmation) {
+    if (!enableManage || !pendingStopConfirmation) {
       return;
     }
 
     const force = pendingStopConfirmation.action === "forceRestore";
     if (
       force &&
-      (!canUseAdminRecovery ||
+      (!canUseRecovery ||
         pendingStopConfirmation.eventId !== activeEventId ||
         !activeEvent ||
         !canForceRestoreCurtailmentEvent(activeEvent))
@@ -629,39 +622,32 @@ function CurtailmentManagementPanel({
     activeEvent,
     activeEventId,
     activeEvents,
-    canUseAdminRecovery,
-    canManageCurtailment,
+    canUseRecovery,
+    enableManage,
     pendingStopConfirmation,
     stopCurtailment,
   ]);
 
-  const handleConfirmAdminTerminate = useCallback(
-    (options: AdminTerminateCurtailmentOptions) => {
-      if (!canUseAdminRecovery || !pendingAdminTerminateEventId) {
+  const handleConfirmTerminateRecovery = useCallback(
+    (options: TerminateRecoveryOptions) => {
+      if (!canUseRecovery || !pendingTerminateRecoveryEventId) {
         return;
       }
 
-      const currentEvent =
-        pendingAdminTerminateEventId === activeEventId
-          ? activeEvent
-          : activeEvents.find((event) => event.id === pendingAdminTerminateEventId);
-      if (!currentEvent || !canAdminTerminateCurtailmentEvent(currentEvent)) {
-        setPendingAdminTerminateEventId(null);
+      if (
+        pendingTerminateRecoveryEventId !== activeEventId ||
+        !activeEvent ||
+        !canTerminateRecoveryCurtailmentEvent(activeEvent)
+      ) {
+        setPendingTerminateRecoveryEventId(null);
         return;
       }
 
-      void adminTerminateCurtailment(pendingAdminTerminateEventId, options)
-        .then(() => setPendingAdminTerminateEventId(null))
+      void adminTerminateCurtailment(pendingTerminateRecoveryEventId, options)
+        .then(() => setPendingTerminateRecoveryEventId(null))
         .catch(() => {});
     },
-    [
-      activeEvent,
-      activeEventId,
-      activeEvents,
-      adminTerminateCurtailment,
-      canUseAdminRecovery,
-      pendingAdminTerminateEventId,
-    ],
+    [activeEvent, activeEventId, adminTerminateCurtailment, canUseRecovery, pendingTerminateRecoveryEventId],
   );
 
   const handleEditStopCurtailment = useCallback(() => {
@@ -678,7 +664,7 @@ function CurtailmentManagementPanel({
     <section className={clsx("grid gap-6", className)}>
       <div className="flex items-center justify-between gap-4 phone:flex-col phone:items-stretch">
         <Header title="Curtailment" titleSize="text-heading-300" />
-        {canManageCurtailment ? (
+        {enableManage ? (
           <div className="flex items-center gap-2 phone:flex-col phone:items-stretch">
             <Button
               variant={variants.secondary}
@@ -711,19 +697,19 @@ function CurtailmentManagementPanel({
             <ActiveCurtailmentStatus
               event={activeEvent}
               onDismissRestored={dismissTerminalCurtailment}
-              onRequestAdminTerminate={
-                canUseAdminRecovery && canAdminTerminateCurtailmentEvent(activeEvent)
-                  ? openAdminTerminateConfirmation
+              onRequestTerminateRecovery={
+                canUseRecovery && canTerminateRecoveryCurtailmentEvent(activeEvent)
+                  ? openTerminateRecoveryConfirmation
                   : undefined
               }
-              onRequestEdit={canManageCurtailment ? openEditModal : undefined}
+              onRequestEdit={enableManage ? openEditModal : undefined}
               onRequestForceRestore={
-                canUseAdminRecovery && canForceRestoreCurtailmentEvent(activeEvent)
+                canUseRecovery && canForceRestoreCurtailmentEvent(activeEvent)
                   ? () => openStopConfirmation("forceRestore")
                   : undefined
               }
-              onRequestRestore={canManageCurtailment ? () => openStopConfirmation("restore") : undefined}
-              onRequestStop={canManageCurtailment ? () => openStopConfirmation("stopCurtailment") : undefined}
+              onRequestRestore={enableManage ? () => openStopConfirmation("restore") : undefined}
+              onRequestStop={enableManage ? () => openStopConfirmation("stopCurtailment") : undefined}
             />
           ) : null}
 
@@ -738,9 +724,9 @@ function CurtailmentManagementPanel({
             selectedStatusFilters={historyStatusFilters}
             onPageChange={handleHistoryPageChange}
             onStatusFiltersChange={handleHistoryStatusFiltersChange}
-            onManageActiveEvent={canManageCurtailment ? openHistoryManageModal : undefined}
-            onStopActiveEventRequested={canManageCurtailment ? cancelManageSelection : undefined}
-            onStopActiveEvent={canManageCurtailment ? handleHistoryStop : undefined}
+            onManageActiveEvent={enableManage ? openHistoryManageModal : undefined}
+            onStopActiveEventRequested={enableManage ? cancelManageSelection : undefined}
+            onStopActiveEvent={enableManage ? handleHistoryStop : undefined}
           />
         </>
       )}
@@ -769,13 +755,13 @@ function CurtailmentManagementPanel({
         />
       ) : null}
 
-      {pendingAdminTerminateEventId ? (
-        <CurtailmentAdminTerminateDialog
+      {pendingTerminateRecoveryEventId ? (
+        <CurtailmentRecoveryTerminateDialog
           open
           error={adminTerminateError}
-          isSubmitting={isAdminTerminateSubmitting}
-          onCancel={() => setPendingAdminTerminateEventId(null)}
-          onConfirm={handleConfirmAdminTerminate}
+          isSubmitting={isTerminateRecoverySubmitting}
+          onCancel={() => setPendingTerminateRecoveryEventId(null)}
+          onConfirm={handleConfirmTerminateRecovery}
         />
       ) : null}
     </section>

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -512,6 +512,23 @@ function CurtailmentManagementPanel({
     [activeEvent, activeEventFormValues, activeEventId, enableManage, cancelManageSelection, selectActiveCurtailment],
   );
 
+  const selectHistoryActiveEvent = useCallback(
+    (event: CurtailmentHistoryEvent) => {
+      cancelManageSelection();
+      const abortController = new AbortController();
+      manageSelectionAbortControllerRef.current = abortController;
+
+      void selectActiveCurtailment(event.id, { signal: abortController.signal })
+        .catch(() => {})
+        .finally(() => {
+          if (manageSelectionAbortControllerRef.current === abortController) {
+            manageSelectionAbortControllerRef.current = null;
+          }
+        });
+    },
+    [cancelManageSelection, selectActiveCurtailment],
+  );
+
   const openStopConfirmation = useCallback(
     (action: CurtailmentStopConfirmationAction, eventId = activeEventId) => {
       if (!enableManage || !eventId) {
@@ -725,6 +742,7 @@ function CurtailmentManagementPanel({
             onPageChange={handleHistoryPageChange}
             onStatusFiltersChange={handleHistoryStatusFiltersChange}
             onManageActiveEvent={enableManage ? openHistoryManageModal : undefined}
+            onSelectActiveEvent={canUseRecovery ? selectHistoryActiveEvent : undefined}
             onStopActiveEventRequested={enableManage ? cancelManageSelection : undefined}
             onStopActiveEvent={enableManage ? handleHistoryStop : undefined}
           />

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -186,12 +186,13 @@ function CurtailmentAdminTerminateDialog({
     setReasonError(null);
     onConfirm({ reason: trimmedReason, targetState });
   }, [onConfirm, reason, targetState]);
+  const dismissDialog = isSubmitting ? undefined : onCancel;
 
   return (
     <Dialog
       open={open}
       title="Admin terminate event?"
-      onDismiss={onCancel}
+      onDismiss={dismissDialog}
       icon={
         <DialogIcon intent="critical">
           <Alert />

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -2,7 +2,12 @@ import { type ReactElement, useCallback, useEffect, useMemo, useRef, useState } 
 import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 
-import { useCurtailmentApi } from "@/protoFleet/api/useCurtailmentApi";
+import {
+  type AdminTerminateCurtailmentOptions,
+  type AdminTerminateCurtailmentState,
+  adminTerminateReasonRequiredMessage,
+  useCurtailmentApi,
+} from "@/protoFleet/api/useCurtailmentApi";
 import useCurtailmentResponseProfiles from "@/protoFleet/api/useCurtailmentResponseProfiles";
 import ActiveCurtailmentStatus, {
   type ActiveCurtailmentEvent,
@@ -25,10 +30,14 @@ import type {
 } from "@/protoFleet/features/settings/components/Curtailment/types";
 import { Alert } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
+import Dialog, { DialogIcon } from "@/shared/components/Dialog";
 import Header from "@/shared/components/Header";
 import ProgressCircular from "@/shared/components/ProgressCircular";
+import Radio from "@/shared/components/Radio";
+import Textarea from "@/shared/components/Textarea";
 
 interface CurtailmentManagementPanelProps {
+  canAdminRecoverCurtailment?: boolean;
   canManageCurtailment?: boolean;
   className?: string;
 }
@@ -48,12 +57,26 @@ interface CurtailmentMessageProps {
   message: string;
 }
 
+interface AdminTerminateDialogProps {
+  error?: string | null;
+  isSubmitting?: boolean;
+  onCancel: () => void;
+  onConfirm: (options: AdminTerminateCurtailmentOptions) => void;
+  open: boolean;
+}
+
 const activeCurtailmentRefreshIntervalMs = 3_000;
 const nonTerminalActiveEventStates = new Set<CurtailmentEventState>(["pending", "active", "restoring"]);
 const updateableCurtailmentEventStates = new Set<CurtailmentEventState>(["pending", "active"]);
+const forceRestorableCurtailmentEventStates = new Set<CurtailmentEventState>(["pending", "active"]);
 const defaultResponseDeadlineMinutes = "15";
 const defaultMaxDurationSec = "900";
 const immediateRestoreBatchSize = "10000";
+
+const adminTerminateStateOptions: { label: string; value: AdminTerminateCurtailmentState }[] = [
+  { label: "Cancelled", value: "cancelled" },
+  { label: "Failed", value: "failed" },
+];
 
 function minutesToSeconds(value: string): string {
   const minutes = Number(value);
@@ -141,6 +164,95 @@ function CurtailmentMessage({ message }: CurtailmentMessageProps): ReactElement 
   );
 }
 
+function CurtailmentAdminTerminateDialog({
+  error,
+  isSubmitting = false,
+  onCancel,
+  onConfirm,
+  open,
+}: AdminTerminateDialogProps): ReactElement {
+  const [targetState, setTargetState] = useState<AdminTerminateCurtailmentState>("cancelled");
+  const [reason, setReason] = useState("");
+  const [reasonError, setReasonError] = useState<string | null>(null);
+  const validationError = reasonError ?? error ?? null;
+
+  const confirmTerminate = useCallback(() => {
+    const trimmedReason = reason.trim();
+    if (!trimmedReason) {
+      setReasonError(adminTerminateReasonRequiredMessage);
+      return;
+    }
+
+    setReasonError(null);
+    onConfirm({ reason: trimmedReason, targetState });
+  }, [onConfirm, reason, targetState]);
+
+  return (
+    <Dialog
+      open={open}
+      title="Admin terminate event?"
+      onDismiss={onCancel}
+      icon={
+        <DialogIcon intent="critical">
+          <Alert />
+        </DialogIcon>
+      }
+      buttons={[
+        {
+          text: "Cancel",
+          variant: variants.secondary,
+          onClick: onCancel,
+          disabled: isSubmitting,
+        },
+        {
+          text: "Terminate event",
+          variant: variants.danger,
+          onClick: confirmTerminate,
+          loading: isSubmitting,
+        },
+      ]}
+    >
+      <div className="grid gap-4 text-300 text-text-primary">
+        <p className="text-text-primary-70">
+          Only terminate after restore has started. This closes the event audit trail as cancelled or failed.
+        </p>
+        <fieldset className="grid gap-2">
+          <legend className="text-emphasis-300">Target state</legend>
+          <div className="flex flex-wrap gap-4">
+            {adminTerminateStateOptions.map((option) => (
+              <label key={option.value} className="flex items-center gap-2">
+                <Radio
+                  name="admin-terminate-target-state"
+                  value={option.value}
+                  selected={targetState === option.value}
+                  onChange={() => setTargetState(option.value)}
+                  disabled={isSubmitting}
+                />
+                <span>{option.label}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+        <Textarea
+          id="admin-terminate-reason"
+          label="Reason"
+          initValue={reason}
+          rows={3}
+          maxLength={256}
+          required
+          error={validationError ?? false}
+          onChange={(value) => {
+            setReason(value);
+            if (value.trim()) {
+              setReasonError(null);
+            }
+          }}
+        />
+      </div>
+    </Dialog>
+  );
+}
+
 function createActiveCurtailmentPreview(
   event: ActiveCurtailmentEvent,
   values: CurtailmentSubmitValues,
@@ -156,7 +268,16 @@ function canUpdateCurtailmentEvent(event: ActiveCurtailmentEvent): boolean {
   return updateableCurtailmentEventStates.has(event.state);
 }
 
+function canForceRestoreCurtailmentEvent(event: ActiveCurtailmentEvent): boolean {
+  return Boolean(event.isAutomationOwned && forceRestorableCurtailmentEventStates.has(event.state));
+}
+
+function canAdminTerminateCurtailmentEvent(event: Pick<ActiveCurtailmentEvent, "state">): boolean {
+  return event.state === "restoring";
+}
+
 function CurtailmentManagementPanel({
+  canAdminRecoverCurtailment = false,
   canManageCurtailment = true,
   className,
 }: CurtailmentManagementPanelProps): ReactElement {
@@ -171,10 +292,12 @@ function CurtailmentManagementPanel({
     isStarting,
     isUpdating,
     stoppingEventId,
+    adminTerminatingEventId,
     loadError,
     startError,
     updateError,
     stopError,
+    adminTerminateError,
     historyCurrentPage,
     historyHasNextPage,
     historyHasPreviousPage,
@@ -188,6 +311,7 @@ function CurtailmentManagementPanel({
     dismissTerminalCurtailment,
     updateCurtailment,
     stopCurtailment,
+    adminTerminateCurtailment,
   } = useCurtailmentApi();
   const { responseProfiles } = useCurtailmentResponseProfiles(canManageCurtailment);
   const responseProfileOptions = useMemo(
@@ -198,15 +322,27 @@ function CurtailmentManagementPanel({
   const [modalMode, setModalMode] = useState<CurtailmentStartModalMode | null>(null);
   const [editSession, setEditSession] = useState<EditCurtailmentSession | null>(null);
   const [pendingStopConfirmation, setPendingStopConfirmation] = useState<PendingStopConfirmation | null>(null);
+  const [pendingAdminTerminateEventId, setPendingAdminTerminateEventId] = useState<string | null>(null);
   const refreshAbortControllerRef = useRef<AbortController | null>(null);
   const activeRefreshAbortControllerRef = useRef<AbortController | null>(null);
   const manageSelectionAbortControllerRef = useRef<AbortController | null>(null);
   const manageSelectionRequestIdRef = useRef(0);
   const foregroundRefreshInFlightRef = useRef(false);
-  const errorMessage = startError ?? updateError ?? stopError ?? loadError;
+  const canUseAdminRecovery = canManageCurtailment && canAdminRecoverCurtailment;
+  const recoveryStopError =
+    stopError && activeEvent?.isAutomationOwned
+      ? `${stopError} ${
+          canUseAdminRecovery
+            ? "Use Force restore to override active automation demand and minimum-duration guards."
+            : "Ask an admin to force restore if automation demand remains asserted or the source is stale."
+        }`
+      : stopError;
+  const errorMessage = startError ?? updateError ?? recoveryStopError ?? adminTerminateError ?? loadError;
   const isInitialLoading = isLoading && !activeEvent && historyEvents.length === 0;
   const isStopConfirmationSubmitting =
     pendingStopConfirmation !== null && stoppingEventId === pendingStopConfirmation.eventId;
+  const isAdminTerminateSubmitting =
+    pendingAdminTerminateEventId !== null && adminTerminatingEventId === pendingAdminTerminateEventId;
   const isEditingCurtailment = modalMode === "edit";
   const isModalSubmitting = isEditingCurtailment ? isUpdating : isStarting;
   const hasOngoingCurtailment = activeEvents.some((event) => nonTerminalActiveEventStates.has(event.state));
@@ -394,6 +530,15 @@ function CurtailmentManagementPanel({
     [activeEventId, canManageCurtailment, cancelManageSelection],
   );
 
+  const openAdminTerminateConfirmation = useCallback(() => {
+    if (!canUseAdminRecovery || !activeEvent || !activeEventId || !canAdminTerminateCurtailmentEvent(activeEvent)) {
+      return;
+    }
+
+    cancelManageSelection();
+    setPendingAdminTerminateEventId(activeEventId);
+  }, [activeEvent, activeEventId, canUseAdminRecovery, cancelManageSelection]);
+
   const handleStartSubmit = useCallback(
     (values: CurtailmentSubmitValues) => {
       void startCurtailment(values)
@@ -456,16 +601,67 @@ function CurtailmentManagementPanel({
       return;
     }
 
+    const force = pendingStopConfirmation.action === "forceRestore";
+    if (
+      force &&
+      (!canUseAdminRecovery ||
+        pendingStopConfirmation.eventId !== activeEventId ||
+        !activeEvent ||
+        !canForceRestoreCurtailmentEvent(activeEvent))
+    ) {
+      setPendingStopConfirmation(null);
+      return;
+    }
+
     const currentEvent = activeEvents.find((event) => event.id === pendingStopConfirmation.eventId);
     if (!currentEvent || !nonTerminalActiveEventStates.has(currentEvent.state)) {
       setPendingStopConfirmation(null);
       return;
     }
 
-    void stopCurtailment(pendingStopConfirmation.eventId)
-      .then(() => setPendingStopConfirmation(null))
-      .catch(() => {});
-  }, [activeEvents, canManageCurtailment, pendingStopConfirmation, stopCurtailment]);
+    const stopPromise = force
+      ? stopCurtailment(pendingStopConfirmation.eventId, { force: true })
+      : stopCurtailment(pendingStopConfirmation.eventId);
+
+    void stopPromise.then(() => setPendingStopConfirmation(null)).catch(() => {});
+  }, [
+    activeEvent,
+    activeEventId,
+    activeEvents,
+    canUseAdminRecovery,
+    canManageCurtailment,
+    pendingStopConfirmation,
+    stopCurtailment,
+  ]);
+
+  const handleConfirmAdminTerminate = useCallback(
+    (options: AdminTerminateCurtailmentOptions) => {
+      if (!canUseAdminRecovery || !pendingAdminTerminateEventId) {
+        return;
+      }
+
+      const currentEvent =
+        pendingAdminTerminateEventId === activeEventId
+          ? activeEvent
+          : activeEvents.find((event) => event.id === pendingAdminTerminateEventId);
+      if (!currentEvent || !canAdminTerminateCurtailmentEvent(currentEvent)) {
+        setPendingAdminTerminateEventId(null);
+        return;
+      }
+
+      void adminTerminateCurtailment(pendingAdminTerminateEventId, options)
+        .then(() => setPendingAdminTerminateEventId(null))
+        .catch(() => {});
+    },
+    [
+      activeEvent,
+      activeEventId,
+      activeEvents,
+      adminTerminateCurtailment,
+      canUseAdminRecovery,
+      pendingAdminTerminateEventId,
+    ],
+  );
 
   const handleEditStopCurtailment = useCallback(() => {
     const editEventId = editSession?.eventId ?? activeEventId;
@@ -514,7 +710,17 @@ function CurtailmentManagementPanel({
             <ActiveCurtailmentStatus
               event={activeEvent}
               onDismissRestored={dismissTerminalCurtailment}
+              onRequestAdminTerminate={
+                canUseAdminRecovery && canAdminTerminateCurtailmentEvent(activeEvent)
+                  ? openAdminTerminateConfirmation
+                  : undefined
+              }
               onRequestEdit={canManageCurtailment ? openEditModal : undefined}
+              onRequestForceRestore={
+                canUseAdminRecovery && canForceRestoreCurtailmentEvent(activeEvent)
+                  ? () => openStopConfirmation("forceRestore")
+                  : undefined
+              }
               onRequestRestore={canManageCurtailment ? () => openStopConfirmation("restore") : undefined}
               onRequestStop={canManageCurtailment ? () => openStopConfirmation("stopCurtailment") : undefined}
             />
@@ -559,6 +765,16 @@ function CurtailmentManagementPanel({
           isSubmitting={isStopConfirmationSubmitting}
           onCancel={() => setPendingStopConfirmation(null)}
           onConfirm={handleConfirmStop}
+        />
+      ) : null}
+
+      {pendingAdminTerminateEventId ? (
+        <CurtailmentAdminTerminateDialog
+          open
+          error={adminTerminateError}
+          isSubmitting={isAdminTerminateSubmitting}
+          onCancel={() => setPendingAdminTerminateEventId(null)}
+          onConfirm={handleConfirmAdminTerminate}
         />
       ) : null}
     </section>

--- a/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.test.tsx
@@ -1,15 +1,33 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import CurtailmentStopConfirmationDialog from "@/protoFleet/features/energy/CurtailmentStopConfirmationDialog";
 
 describe("CurtailmentStopConfirmationDialog", () => {
-  it("warns that force restore overrides automation demand and duration guards", () => {
+  it("warns that force restore does not disable automation", () => {
     render(<CurtailmentStopConfirmationDialog open action="forceRestore" onCancel={vi.fn()} onConfirm={vi.fn()} />);
 
     expect(screen.getByText("Force restore automation event?")).toBeInTheDocument();
-    expect(screen.getByText(/overrides active automation demand and minimum-duration guards/i)).toBeInTheDocument();
-    expect(screen.getByText(/MQTT demand is still OFF or the source is stale/i)).toBeInTheDocument();
+    expect(screen.getByText(/bypasses restore guards for this event only/i)).toBeInTheDocument();
+    expect(screen.getByText(/stop or disable the automation first/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Force restore" })).toBeInTheDocument();
+  });
+
+  it("keeps force restore open while submitting", () => {
+    const onCancel = vi.fn();
+
+    render(
+      <CurtailmentStopConfirmationDialog
+        open
+        action="forceRestore"
+        isSubmitting
+        onCancel={onCancel}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onCancel).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import CurtailmentStopConfirmationDialog from "@/protoFleet/features/energy/CurtailmentStopConfirmationDialog";
+
+describe("CurtailmentStopConfirmationDialog", () => {
+  it("warns that force restore overrides automation demand and duration guards", () => {
+    render(<CurtailmentStopConfirmationDialog open action="forceRestore" onCancel={vi.fn()} onConfirm={vi.fn()} />);
+
+    expect(screen.getByText("Force restore automation event?")).toBeInTheDocument();
+    expect(screen.getByText(/overrides active automation demand and minimum-duration guards/i)).toBeInTheDocument();
+    expect(screen.getByText(/MQTT demand is still OFF or the source is stale/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Force restore" })).toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.tsx
@@ -4,7 +4,7 @@ import { Power, Stop } from "@/shared/assets/icons";
 import { type ButtonVariant, variants } from "@/shared/components/Button";
 import Dialog, { DialogIcon } from "@/shared/components/Dialog";
 
-export type CurtailmentStopConfirmationAction = "restore" | "stopCurtailment";
+export type CurtailmentStopConfirmationAction = "forceRestore" | "restore" | "stopCurtailment";
 
 interface CurtailmentStopConfirmationDialogProps {
   open: boolean;
@@ -24,6 +24,17 @@ interface StopDialogCopy {
 }
 
 function getStopDialogCopy(action: CurtailmentStopConfirmationAction): StopDialogCopy {
+  if (action === "forceRestore") {
+    return {
+      title: "Force restore automation event?",
+      body: "Force restore overrides active automation demand and minimum-duration guards. Miners will start restoring even if MQTT demand is still OFF or the source is stale.",
+      confirmText: "Force restore",
+      confirmVariant: variants.secondaryDanger,
+      icon: <Power />,
+      iconIntent: "critical",
+    };
+  }
+
   if (action === "restore") {
     return {
       title: "Restore power?",

--- a/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.tsx
@@ -27,7 +27,7 @@ function getStopDialogCopy(action: CurtailmentStopConfirmationAction): StopDialo
   if (action === "forceRestore") {
     return {
       title: "Force restore automation event?",
-      body: "Force restore overrides active automation demand and minimum-duration guards. Miners will start restoring even if MQTT demand is still OFF or the source is stale.",
+      body: "Force restore bypasses restore guards for this event only. If automation demand is still asserted, stop or disable the automation first so it does not curtail miners again.",
       confirmText: "Force restore",
       confirmVariant: variants.secondaryDanger,
       icon: <Power />,
@@ -64,12 +64,13 @@ function CurtailmentStopConfirmationDialog({
   onConfirm,
 }: CurtailmentStopConfirmationDialogProps): ReactElement {
   const copy = getStopDialogCopy(action);
+  const dismissDialog = isSubmitting ? undefined : onCancel;
 
   return (
     <Dialog
       open={open}
       title={copy.title}
-      onDismiss={onCancel}
+      onDismiss={dismissDialog}
       icon={<DialogIcon intent={copy.iconIntent}>{copy.icon}</DialogIcon>}
       buttons={[
         {

--- a/client/src/protoFleet/features/energy/pages/EnergyPage.test.tsx
+++ b/client/src/protoFleet/features/energy/pages/EnergyPage.test.tsx
@@ -11,15 +11,9 @@ vi.mock("@/protoFleet/store", () => ({
 }));
 
 vi.mock("@/protoFleet/features/energy/CurtailmentManagementPanel", () => ({
-  default: ({
-    canAdminRecoverCurtailment,
-    canManageCurtailment,
-  }: {
-    canAdminRecoverCurtailment?: boolean;
-    canManageCurtailment?: boolean;
-  }) => (
+  default: ({ enableManage, enableRecover }: { enableManage?: boolean; enableRecover?: boolean }) => (
     <div data-testid="curtailment-management-panel">
-      {String(canManageCurtailment)},{String(canAdminRecoverCurtailment)}
+      {String(enableManage)},{String(enableRecover)}
     </div>
   ),
 }));

--- a/client/src/protoFleet/features/energy/pages/EnergyPage.test.tsx
+++ b/client/src/protoFleet/features/energy/pages/EnergyPage.test.tsx
@@ -3,21 +3,31 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import EnergyPage from "@/protoFleet/features/energy/pages/EnergyPage";
-import { useHasPermission } from "@/protoFleet/store";
+import { useHasPermission, useRole } from "@/protoFleet/store";
 
 vi.mock("@/protoFleet/store", () => ({
   useHasPermission: vi.fn(),
+  useRole: vi.fn(),
 }));
 
 vi.mock("@/protoFleet/features/energy/CurtailmentManagementPanel", () => ({
-  default: ({ canManageCurtailment }: { canManageCurtailment?: boolean }) => (
-    <div data-testid="curtailment-management-panel">{String(canManageCurtailment)}</div>
+  default: ({
+    canAdminRecoverCurtailment,
+    canManageCurtailment,
+  }: {
+    canAdminRecoverCurtailment?: boolean;
+    canManageCurtailment?: boolean;
+  }) => (
+    <div data-testid="curtailment-management-panel">
+      {String(canManageCurtailment)},{String(canAdminRecoverCurtailment)}
+    </div>
   ),
 }));
 
 describe("EnergyPage", () => {
   beforeEach(() => {
     vi.mocked(useHasPermission).mockReset();
+    vi.mocked(useRole).mockReturnValue("FIELD_TECH");
   });
 
   it("passes curtailment manage permission to the management panel", () => {
@@ -31,7 +41,20 @@ describe("EnergyPage", () => {
 
     expect(useHasPermission).toHaveBeenCalledWith("curtailment:read");
     expect(useHasPermission).toHaveBeenCalledWith("curtailment:manage");
-    expect(screen.getByTestId("curtailment-management-panel")).toHaveTextContent("false");
+    expect(screen.getByTestId("curtailment-management-panel")).toHaveTextContent("false,false");
+  });
+
+  it("passes admin recovery access for admin managers", () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:read" || key === "curtailment:manage");
+    vi.mocked(useRole).mockReturnValue("ADMIN");
+
+    render(
+      <MemoryRouter>
+        <EnergyPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("curtailment-management-panel")).toHaveTextContent("true,true");
   });
 
   it("redirects without curtailment read permission", () => {

--- a/client/src/protoFleet/features/energy/pages/EnergyPage.test.tsx
+++ b/client/src/protoFleet/features/energy/pages/EnergyPage.test.tsx
@@ -57,6 +57,32 @@ describe("EnergyPage", () => {
     expect(screen.getByTestId("curtailment-management-panel")).toHaveTextContent("true,true");
   });
 
+  it("withholds admin recovery access when admin lacks curtailment manage permission", () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:read");
+    vi.mocked(useRole).mockReturnValue("ADMIN");
+
+    render(
+      <MemoryRouter>
+        <EnergyPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("curtailment-management-panel")).toHaveTextContent("false,false");
+  });
+
+  it("passes admin recovery access for super admin managers", () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:read" || key === "curtailment:manage");
+    vi.mocked(useRole).mockReturnValue("SUPER_ADMIN");
+
+    render(
+      <MemoryRouter>
+        <EnergyPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("curtailment-management-panel")).toHaveTextContent("true,true");
+  });
+
   it("redirects without curtailment read permission", () => {
     vi.mocked(useHasPermission).mockReturnValue(false);
 

--- a/client/src/protoFleet/features/energy/pages/EnergyPage.tsx
+++ b/client/src/protoFleet/features/energy/pages/EnergyPage.tsx
@@ -9,7 +9,7 @@ const EnergyPage = () => {
   const canReadCurtailment = useHasPermission("curtailment:read");
   const canManageCurtailment = useHasPermission("curtailment:manage");
   const role = useRole();
-  const canAdminRecoverCurtailment = canManageCurtailment && adminRecoveryRoles.has(role);
+  const canRecoverCurtailment = canManageCurtailment && adminRecoveryRoles.has(role);
 
   if (!canReadCurtailment) {
     return <Navigate to="/" replace />;
@@ -17,10 +17,7 @@ const EnergyPage = () => {
 
   return (
     <div className="p-6 laptop:p-10">
-      <CurtailmentManagementPanel
-        canManageCurtailment={canManageCurtailment}
-        canAdminRecoverCurtailment={canAdminRecoverCurtailment}
-      />
+      <CurtailmentManagementPanel enableManage={canManageCurtailment} enableRecover={canRecoverCurtailment} />
     </div>
   );
 };

--- a/client/src/protoFleet/features/energy/pages/EnergyPage.tsx
+++ b/client/src/protoFleet/features/energy/pages/EnergyPage.tsx
@@ -1,11 +1,15 @@
 import { Navigate } from "react-router-dom";
 
 import CurtailmentManagementPanel from "@/protoFleet/features/energy/CurtailmentManagementPanel";
-import { useHasPermission } from "@/protoFleet/store";
+import { useHasPermission, useRole } from "@/protoFleet/store";
+
+const adminRecoveryRoles = new Set(["ADMIN", "SUPER_ADMIN"]);
 
 const EnergyPage = () => {
   const canReadCurtailment = useHasPermission("curtailment:read");
   const canManageCurtailment = useHasPermission("curtailment:manage");
+  const role = useRole();
+  const canAdminRecoverCurtailment = canManageCurtailment && adminRecoveryRoles.has(role);
 
   if (!canReadCurtailment) {
     return <Navigate to="/" replace />;
@@ -13,7 +17,10 @@ const EnergyPage = () => {
 
   return (
     <div className="p-6 laptop:p-10">
-      <CurtailmentManagementPanel canManageCurtailment={canManageCurtailment} />
+      <CurtailmentManagementPanel
+        canManageCurtailment={canManageCurtailment}
+        canAdminRecoverCurtailment={canAdminRecoverCurtailment}
+      />
     </div>
   );
 };

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -23,6 +23,7 @@ import (
 // Action verb for requireAdminFromContext error messages on the legacy
 // admin-only override checks that run after the curtailment:manage gate.
 const actionSupplyOverrideFields = "supply curtailment override fields"
+const actionAdminTerminateEvents = "admin terminate curtailment events"
 const actionManageMqttSources = "manage MaestroOS curtailment sources"
 const listCurtailmentEventsDefaultPageSize int32 = 50
 const listCurtailmentEventsMaxPageSize int32 = 200
@@ -273,11 +274,14 @@ func (h *Handler) GetCurtailmentEvent(ctx context.Context, req *connect.Request[
 }
 
 // AdminTerminateEvent forces a non-terminal event to terminal. Paired
-// with SessionOnlyProcedures (see interceptors/config.go); the
-// curtailment:manage permission gate is the authoritative RBAC check.
+// with SessionOnlyProcedures (see interceptors/config.go); callers need
+// curtailment:manage for the event plus an Admin/SuperAdmin role.
 func (h *Handler) AdminTerminateEvent(ctx context.Context, req *connect.Request[pb.AdminTerminateEventRequest]) (*connect.Response[pb.AdminTerminateEventResponse], error) {
 	if h.service == nil {
 		if _, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{}); err != nil {
+			return nil, err
+		}
+		if err := requireAdminFromContext(ctx, actionAdminTerminateEvents); err != nil {
 			return nil, err
 		}
 		return nil, errCurtailmentNotImplemented("AdminTerminateEvent")
@@ -288,6 +292,9 @@ func (h *Handler) AdminTerminateEvent(ctx context.Context, req *connect.Request[
 	}
 	info, _, err := h.requireEventPermission(ctx, authz.PermCurtailmentManage, eventUUID)
 	if err != nil {
+		return nil, err
+	}
+	if err := requireAdminFromContext(ctx, actionAdminTerminateEvents); err != nil {
 		return nil, err
 	}
 	terminateReq, err := toAdminTerminateRequest(req.Msg, info)

--- a/server/internal/handlers/curtailment/handler_admin_terminate_test.go
+++ b/server/internal/handlers/curtailment/handler_admin_terminate_test.go
@@ -212,8 +212,7 @@ func TestHandler_AdminTerminateEvent_HappyPath(t *testing.T) {
 
 // TestHandler_AdminTerminateEvent_RejectsCallerWithoutCurtailmentManage:
 // the caller is denied when curtailment:manage is absent from their
-// effective permissions, regardless of role. RBAC is the authoritative
-// gate on this handler.
+// effective permissions, regardless of role.
 func TestHandler_AdminTerminateEvent_RejectsCallerWithoutCurtailmentManage(t *testing.T) {
 	t.Parallel()
 	eventUUID := uuid.New()
@@ -240,6 +239,34 @@ func TestHandler_AdminTerminateEvent_RejectsCallerWithoutCurtailmentManage(t *te
 	require.ErrorAs(t, err, &fleetErr)
 	assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
 	assert.Equal(t, 0, store.calls, "permission gate must fail before reaching the service")
+}
+
+func TestHandler_AdminTerminateEvent_RejectsNonAdminWithCurtailmentManage(t *testing.T) {
+	t.Parallel()
+	eventUUID := uuid.New()
+	store := &adminTerminateStubStore{
+		authEvent: &models.Event{
+			ID:        99,
+			EventUUID: eventUUID,
+			OrgID:     42,
+			State:     models.EventStateRestoring,
+		},
+	}
+	h := NewHandler(domainCurtailment.NewService(store))
+
+	_, err := h.AdminTerminateEvent(
+		adminTerminateSessionCtx(42, "OPERATOR"),
+		connect.NewRequest(&pb.AdminTerminateEventRequest{
+			EventUuid:   eventUUID.String(),
+			TargetState: pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_CANCELLED,
+			Reason:      "admin role gate test",
+		}),
+	)
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+	assert.Equal(t, 0, store.calls, "admin role gate must fail before reaching the service")
 }
 
 // TestHandler_AdminTerminateEvent_RejectsMissingSession: missing

--- a/server/internal/handlers/curtailment/handler_test.go
+++ b/server/internal/handlers/curtailment/handler_test.go
@@ -289,9 +289,8 @@ func TestHandler_RequestValidation(t *testing.T) {
 	})
 }
 
-// AdminTerminateEvent gates on PermCurtailmentManage; callers without
-// the permission see PermissionDenied; callers with it fall through to
-// the Unimplemented stub body.
+// AdminTerminateEvent gates on PermCurtailmentManage and Admin role; callers
+// without either are rejected before the Unimplemented stub body.
 func TestHandler_AdminTerminateEventPermissionGate(t *testing.T) {
 	t.Parallel()
 
@@ -304,12 +303,14 @@ func TestHandler_AdminTerminateEventPermissionGate(t *testing.T) {
 
 	cases := []struct {
 		name        string
+		role        string
 		permissions []string
 		wantCode    connect.Code
 	}{
-		{"caller without curtailment:manage is rejected", []string{authz.PermFleetRead}, connect.CodePermissionDenied},
-		{"empty permissions set is rejected", nil, connect.CodePermissionDenied},
-		{"caller with curtailment:manage reaches Unimplemented body", []string{authz.PermCurtailmentManage}, connect.CodeUnimplemented},
+		{"admin without curtailment:manage is rejected", domainAuth.AdminRoleName, []string{authz.PermFleetRead}, connect.CodePermissionDenied},
+		{"admin with empty permissions set is rejected", domainAuth.AdminRoleName, nil, connect.CodePermissionDenied},
+		{"non-admin with curtailment:manage is rejected", "OPERATOR", []string{authz.PermCurtailmentManage}, connect.CodePermissionDenied},
+		{"admin with curtailment:manage reaches Unimplemented body", domainAuth.AdminRoleName, []string{authz.PermCurtailmentManage}, connect.CodeUnimplemented},
 	}
 
 	for _, tc := range cases {
@@ -321,7 +322,7 @@ func TestHandler_AdminTerminateEventPermissionGate(t *testing.T) {
 				ScopeType:    authz.ScopeOrg,
 				Permissions:  tc.permissions,
 			}})
-			ctx := authn.SetInfo(t.Context(), &session.Info{})
+			ctx := authn.SetInfo(t.Context(), &session.Info{Role: tc.role})
 			ctx = middleware.WithEffectivePermissions(ctx, eff)
 
 			_, err := h.AdminTerminateEvent(ctx, req)


### PR DESCRIPTION
Reviewable diff: +457/-44 across 9 files (excludes generated, test, and story files).

## Summary
Operators can now recover stale or asserted-OFF curtailment automation from the Energy page without changing the normal restore path. Admin-capable users get a force-restore action for automation-owned active events, a way to focus non-selected restoring automation events from history, and a terminate-recovery dialog that can close restoring automation recovery as `CANCELLED` or `FAILED` with an audit reason. Non-admin users keep the existing manage/restore/stop controls only. Closes block/proto-fleet#528.

## How it works
The Energy page keeps the role decision at the page boundary: built-in `ADMIN` / `SUPER_ADMIN` users with `curtailment:manage` pass `enableRecover` into the curtailment panel, while ordinary managers only pass `enableManage`. The panel then exposes recovery actions only when the active event is automation-owned and in the right lifecycle state.

Active event mapping recognizes the reserved `curtailment_automation` source and surfaces it as `Curtailment automation`, so the active card can explain why normal restore may be blocked while demand is still asserted. Force restore sends `StopCurtailment(force=true)`, but the confirmation now makes clear that enabled automation can curtail again and should be stopped or disabled first when demand is still asserted.

Restoring automation-owned events can be recovered even when they are not the selected active card: the history detail modal offers `View active event` for active restoring rows, hydrating that event into the active card before showing `Terminate recovery`. Termination still uses the existing `AdminTerminateEvent` RPC with target state and required reason validation; the server enforces the Admin/SuperAdmin role gate for that RPC.

## Diagrams
```mermaid
flowchart TD
  A["Energy page loads curtailment data"] --> B{"Caller has curtailment:read?"}
  B -->|No| C["Redirect away"]
  B -->|Yes| D["Render curtailment panel"]
  D --> E{"Caller is Admin/SuperAdmin with curtailment:manage?"}
  E -->|No| F["Normal manage/restore/stop controls"]
  E -->|Yes| G["Recovery-capable controls"]
  G --> H{"Active event is automation-owned?"}
  H -->|Pending/active| I["Force restore confirmation"]
  H -->|Restoring| J["Terminate recovery dialog"]
  H -->|Other| F
```

```mermaid
flowchart TD
  A["History row is active and restoring"] --> B["Open curtailment detail"]
  B --> C["View active event"]
  C --> D["Hydrate selected active event"]
  D --> E{"Detailed event is automation-owned?"}
  E -->|Yes| F["Show Terminate recovery"]
  E -->|No| G["No recovery action"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/api/useCurtailmentApi.ts` | Adds force-stop options and admin terminate mutation wiring | Review request payloads, mutation errors, and active/history reconciliation |
| `client/src/protoFleet/api/curtailmentMappers.ts` | Marks automation-owned events and maps the display source to `Curtailment automation` | Review ownership detection and recovery copy inputs |
| `client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx` | Shows automation recovery context and recovery action buttons | Review state-specific visibility and operator copy |
| `client/src/protoFleet/features/energy/CurtailmentHistory.tsx` | Lets restoring active rows be selected into the active card for recovery | Review the non-selected restoring-event flow from history to active detail |
| `client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx` | Coordinates capability gates, force restore, active selection, terminate recovery, and dialogs | Review permission boundaries, stale-state guards, and async mutation behavior |
| `client/src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.tsx` | Clarifies that force restore does not disable automation | Review whether the warning matches the intended operator flow |
| `client/src/protoFleet/features/energy/pages/EnergyPage.tsx` | Keeps built-in role checks at the page boundary and passes capability props | Review role assumptions for `ADMIN` and `SUPER_ADMIN` |
| `server/internal/handlers/curtailment/handler.go` | Adds Admin/SuperAdmin role enforcement to `AdminTerminateEvent` | Review backend authorization parity for the privileged RPC |
| Client/server tests | Cover force payloads, role gates, recovery labels, stale guards, row selection, terminate validation, and backend admin enforcement | Review behavior coverage and any remaining gaps |

## Key technical decisions & trade-offs
| Decision | Trade-off |
| --- | --- |
| Reuse the reserved `curtailment_automation` source marker for this UI | Keeps this PR focused; a future explicit ownership field would reduce string coupling |
| Keep role-specific logic in `EnergyPage` and pass capability props into the panel | Avoids leaking role names into reusable panel APIs while preserving server-side Admin/SuperAdmin posture |
| Scope UI recovery actions to automation-owned events, but leave `AdminTerminateEvent` as the broader admin RPC | The UI stays focused on stale automation recovery while the backend keeps its existing last-resort admin contract |
| Select restoring rows into the active card before terminate recovery | Avoids destructive actions directly from list data and reuses detail hydration before showing recovery controls |
| Tell operators to stop/disable automation before force restore when demand is still asserted | Matches the intended operational flow without changing automation behavior in this PR |

## Testing & validation
- `npx vitest run src/protoFleet/api/useCurtailmentApi.test.ts src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx src/protoFleet/features/energy/CurtailmentHistory.test.tsx src/protoFleet/features/energy/ActiveCurtailmentStatus.test.tsx src/protoFleet/features/energy/CurtailmentStopConfirmationDialog.test.tsx src/protoFleet/features/energy/pages/EnergyPage.test.tsx`
- `go test ./internal/handlers/curtailment`
- Pre-push hooks ran `client-typecheck` on the latest pushes

No browser demo was captured because the recovery surface requires an authenticated admin session plus active/restoring curtailment fixtures.
