### PR TITLE
Don't fire Metric Ingest Stalled on a fresh install

### DIFF
--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -780,19 +780,20 @@ provision_grafana_db_role() {
 
     # `up --wait` only confirms containers are running, not that
     # fleet-api has finished its migration pass. Poll for every object
-    # the Grafana alert rules read — the raw hypertable AND the
-    # fleet_telemetry_poll_heartbeat continuous aggregate the
-    # protofleet-ingest-stalled rule queries.
-    echo "Waiting for notification_metric_sample and fleet_telemetry_poll_heartbeat to be available…"
+    # the Grafana alert rules read — the raw hypertable, the
+    # fleet_telemetry_poll_heartbeat continuous aggregate, and the
+    # fleet_pollable_device_presence view the protofleet-ingest-stalled
+    # rule queries.
+    echo "Waiting for notification_metric_sample, fleet_telemetry_poll_heartbeat and fleet_pollable_device_presence to be available…"
     for attempt in $(seq 1 60); do
         objects_check=$(docker compose "${COMPOSE_FILES[@]}" exec -T timescaledb \
-            bash -c "psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -tAc \"SELECT to_regclass('public.notification_metric_sample') IS NOT NULL AND to_regclass('public.fleet_telemetry_poll_heartbeat') IS NOT NULL\"" \
+            bash -c "psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -tAc \"SELECT to_regclass('public.notification_metric_sample') IS NOT NULL AND to_regclass('public.fleet_telemetry_poll_heartbeat') IS NOT NULL AND to_regclass('public.fleet_pollable_device_presence') IS NOT NULL\"" \
             2>/dev/null | tr -d '[:space:]')
         if [ "$objects_check" = "t" ]; then
             break
         fi
         if [ "$attempt" -eq 60 ]; then
-            echo "Warning: notification_metric_sample / fleet_telemetry_poll_heartbeat did not appear; Grafana role not provisioned (datasource will fail until fleet-api migrations finish)." >&2
+            echo "Warning: notification_metric_sample / fleet_telemetry_poll_heartbeat / fleet_pollable_device_presence did not appear; Grafana role not provisioned (datasource will fail until fleet-api migrations finish)." >&2
             return 1
         fi
         sleep 2
@@ -892,11 +893,14 @@ GRANT CONNECT ON DATABASE "${db_name}" TO "${grafana_user}";
 GRANT USAGE ON SCHEMA public TO "${grafana_user}";
 GRANT SELECT ON notification_metric_sample TO "${grafana_user}";
 GRANT SELECT ON fleet_telemetry_poll_heartbeat TO "${grafana_user}";
+-- Owner-privilege view: grafana_ro reads the boolean without grants on device/device_pairing.
+GRANT SELECT ON fleet_pollable_device_presence TO "${grafana_user}";
 
 -- smoke check
 SET ROLE "${grafana_user}";
 SELECT 1 FROM notification_metric_sample LIMIT 0;
 SELECT 1 FROM fleet_telemetry_poll_heartbeat LIMIT 0;
+SELECT 1 FROM fleet_pollable_device_presence LIMIT 0;
 RESET ROLE;
 SQL
 }

--- a/server/generated/sqlc/models.go
+++ b/server/generated/sqlc/models.go
@@ -832,7 +832,7 @@ type FleetNodeSession struct {
 }
 
 type FleetPollableDevicePresence struct {
-	HasPollableDevice bool
+	OrganizationID string
 }
 
 type FleetTelemetryPollHeartbeat struct {

--- a/server/generated/sqlc/models.go
+++ b/server/generated/sqlc/models.go
@@ -831,6 +831,10 @@ type FleetNodeSession struct {
 	CreatedAt   time.Time
 }
 
+type FleetPollableDevicePresence struct {
+	HasPollableDevice bool
+}
+
 type FleetTelemetryPollHeartbeat struct {
 	Bucket         interface{}
 	OrganizationID string

--- a/server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go
+++ b/server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go
@@ -1,0 +1,166 @@
+package timescaledb_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/block/proto-fleet/server/internal/testutil"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// ruleFile is the provisioned Grafana rules file relative to this package.
+const ruleFile = "../../../monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml"
+
+// loadIngestStalledRuleSQL extracts the live rawSql for the "Metric Ingest
+// Stalled" rule from the provisioning file so this test exercises the exact
+// query operators run, not a copy that can drift from it.
+func loadIngestStalledRuleSQL(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(ruleFile)
+	require.NoError(t, err)
+
+	var doc struct {
+		Groups []struct {
+			Rules []struct {
+				Title string `yaml:"title"`
+				Data  []struct {
+					Model struct {
+						RawSQL string `yaml:"rawSql"`
+					} `yaml:"model"`
+				} `yaml:"data"`
+			} `yaml:"rules"`
+		} `yaml:"groups"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+
+	for _, g := range doc.Groups {
+		for _, r := range g.Rules {
+			if r.Title == "Metric Ingest Stalled" {
+				require.NotEmpty(t, r.Data, "rule has no data block")
+				sql := r.Data[0].Model.RawSQL
+				require.Contains(t, sql, "fleet_pollable_device_presence")
+				return sql
+			}
+		}
+	}
+	t.Fatal(`rule "Metric Ingest Stalled" not found in provisioning file`)
+	return ""
+}
+
+// seedOrg inserts organization -> discovered_device -> device -> device_pairing
+// so the org appears in fleet_pollable_device_presence when status is a pollable
+// pairing ('PAIRED'/'DEFAULT_PASSWORD'). Returns the organization's bigint id.
+func seedOrg(t *testing.T, db *sql.DB, i int, status string) int64 {
+	t.Helper()
+	ctx := t.Context()
+	slug := fmt.Sprintf("ingest-test-%d", i)
+
+	var orgID int64
+	require.NoError(t, db.QueryRowContext(ctx, `
+		INSERT INTO organization (org_id, name)
+		VALUES ($1, $1) RETURNING id`, slug).Scan(&orgID))
+
+	var discID int64
+	require.NoError(t, db.QueryRowContext(ctx, `
+		INSERT INTO discovered_device (org_id, device_identifier, driver_name, ip_address, port, url_scheme)
+		VALUES ($1, $2, 'antminer', '10.0.0.1', '80', 'http') RETURNING id`, orgID, slug).Scan(&discID))
+
+	var deviceID int64
+	require.NoError(t, db.QueryRowContext(ctx, `
+		INSERT INTO device (device_identifier, mac_address, org_id, discovered_device_id)
+		VALUES ($1, $2, $3, $4) RETURNING id`,
+		slug+"-dev", fmt.Sprintf("02:00:00:00:00:%02x", i), orgID, discID).Scan(&deviceID))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO device_pairing (device_id, pairing_status, paired_at)
+		VALUES ($1, $2::pairing_status_enum, now())`, deviceID, status)
+	require.NoError(t, err)
+	return orgID
+}
+
+// writeHeartbeat lands one fleet_telemetry_poll_total sample for orgID at the
+// given age and materializes the continuous aggregate the rule reads.
+func writeHeartbeat(t *testing.T, db *sql.DB, orgID int64, age time.Duration) {
+	t.Helper()
+	ctx := t.Context()
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO notification_metric_sample (time, metric, organization_id, value)
+		VALUES ($1, 'fleet_telemetry_poll_total', $2, 1)`,
+		time.Now().Add(-age), fmt.Sprintf("%d", orgID))
+	require.NoError(t, err)
+	// NULL bounds refresh the whole eligible range; CALL must not run in a tx.
+	_, err = db.ExecContext(ctx,
+		`CALL refresh_continuous_aggregate('fleet_telemetry_poll_heartbeat', NULL, NULL)`)
+	require.NoError(t, err)
+}
+
+// runRule executes the rule SQL and returns organization_id -> staleness_seconds.
+func runRule(t *testing.T, db *sql.DB, rawSQL string) map[string]float64 {
+	t.Helper()
+	rows, err := db.QueryContext(t.Context(), rawSQL)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	out := map[string]float64{}
+	for rows.Next() {
+		var org string
+		var staleness float64
+		require.NoError(t, rows.Scan(&org, &staleness))
+		out[org] = staleness
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// TestMetricIngestStalledRule_PerOrg covers the multi-org behaviour the rule
+// must get right: a healthy org stays Normal, an org with pollable miners but no
+// heartbeat fires per-org (cold-start) even while a peer is healthy, and an org
+// whose miners were removed is dropped from evaluation despite leftover stale
+// heartbeat rows.
+func TestMetricIngestStalledRule_PerOrg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	db := testutil.GetTestDB(t)
+	rawSQL := loadIngestStalledRuleSQL(t)
+
+	healthy := seedOrg(t, db, 0, "PAIRED")   // pollable, fresh heartbeat
+	coldStart := seedOrg(t, db, 1, "PAIRED") // pollable, no heartbeat
+	removed := seedOrg(t, db, 2, "UNPAIRED") // not pollable, but stale heartbeat lingers
+
+	writeHeartbeat(t, db, healthy, 2*time.Minute)
+	writeHeartbeat(t, db, removed, 30*time.Minute)
+
+	got := runRule(t, db, rawSQL)
+
+	healthyOrg := fmt.Sprint(healthy)
+	require.Contains(t, got, healthyOrg)
+	require.Less(t, got[healthyOrg], 300.0, "healthy org should be below the staleness threshold")
+
+	require.Contains(t, got, fmt.Sprint(coldStart))
+	require.Equal(t, 1e9, got[fmt.Sprint(coldStart)], "org with no heartbeat must read as stale via COALESCE")
+
+	require.NotContains(t, got, fmt.Sprint(removed), "non-pollable org's stale heartbeat must be suppressed")
+	require.NotContains(t, got, "", "global sentinel must not appear while pollable miners exist")
+}
+
+// TestMetricIngestStalledRule_NoPollableMiners covers the fresh/emptied fleet:
+// with no pollable miners anywhere the rule returns only the healthy sentinel,
+// even when stale heartbeat rows from removed miners remain.
+func TestMetricIngestStalledRule_NoPollableMiners(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	db := testutil.GetTestDB(t)
+	rawSQL := loadIngestStalledRuleSQL(t)
+
+	removed := seedOrg(t, db, 0, "UNPAIRED")
+	writeHeartbeat(t, db, removed, 30*time.Minute)
+
+	got := runRule(t, db, rawSQL)
+	require.Equal(t, map[string]float64{"": 0}, got, "expected only the healthy global sentinel")
+}

--- a/server/migrations/000096_fleet_pollable_device_presence.down.sql
+++ b/server/migrations/000096_fleet_pollable_device_presence.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS fleet_pollable_device_presence;

--- a/server/migrations/000096_fleet_pollable_device_presence.up.sql
+++ b/server/migrations/000096_fleet_pollable_device_presence.up.sql
@@ -1,13 +1,11 @@
--- Owner-privilege boolean view for the protofleet-ingest-stalled alert: mirrors GetAllPairedDeviceIdentifiers (device.sql) so grafana_ro can gate on paired-device presence without SELECT on device/device_pairing (pairing_token).
+-- Per-org presence of cloud-dialed paired devices for the protofleet-ingest-stalled alert: mirrors GetAllPairedDeviceIdentifiers (device.sql) so grafana_ro gates per-org without SELECT on device/device_pairing (pairing_token). org_id cast to text to match the heartbeat organization_id label.
 CREATE VIEW fleet_pollable_device_presence AS
-SELECT EXISTS (
-    SELECT 1
-    FROM device d
-    JOIN device_pairing dp ON d.id = dp.device_id
-    WHERE dp.pairing_status IN ('PAIRED', 'DEFAULT_PASSWORD')
-        AND d.deleted_at IS NULL
-        AND NOT EXISTS (
-            SELECT 1 FROM fleet_node_device fnd
-            WHERE fnd.device_id = d.id AND fnd.org_id = d.org_id
-        )
-) AS has_pollable_device;
+SELECT DISTINCT d.org_id::text AS organization_id
+FROM device d
+JOIN device_pairing dp ON d.id = dp.device_id
+WHERE dp.pairing_status IN ('PAIRED', 'DEFAULT_PASSWORD')
+    AND d.deleted_at IS NULL
+    AND NOT EXISTS (
+        SELECT 1 FROM fleet_node_device fnd
+        WHERE fnd.device_id = d.id AND fnd.org_id = d.org_id
+    );

--- a/server/migrations/000096_fleet_pollable_device_presence.up.sql
+++ b/server/migrations/000096_fleet_pollable_device_presence.up.sql
@@ -1,0 +1,13 @@
+-- Owner-privilege boolean view for the protofleet-ingest-stalled alert: mirrors GetAllPairedDeviceIdentifiers (device.sql) so grafana_ro can gate on paired-device presence without SELECT on device/device_pairing (pairing_token).
+CREATE VIEW fleet_pollable_device_presence AS
+SELECT EXISTS (
+    SELECT 1
+    FROM device d
+    JOIN device_pairing dp ON d.id = dp.device_id
+    WHERE dp.pairing_status IN ('PAIRED', 'DEFAULT_PASSWORD')
+        AND d.deleted_at IS NULL
+        AND NOT EXISTS (
+            SELECT 1 FROM fleet_node_device fnd
+            WHERE fnd.device_id = d.id AND fnd.org_id = d.org_id
+        )
+) AS has_pollable_device;

--- a/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
+++ b/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
@@ -171,9 +171,9 @@ groups:
         title: Metric Ingest Stalled
         condition: B
         # Edge cases (full rationale in commit/PR):
-        # Per-org: only orgs with current pollable miners are evaluated, so removing an org's miners stops its stale heartbeat from firing.
+        # Driven from presence + LEFT JOIN heartbeat: every org with pollable miners is evaluated; a missing bucket (cold-start / aged out) reads as stale and fires even if other orgs are healthy.
+        # Per-org: removing an org's miners drops it from presence, so its stale heartbeat stops firing while other orgs are unaffected.
         # No pollable miners anywhere: UNION ALL sentinel returns a healthy row so noData can't fire on a fresh/emptied fleet.
-        # Paired miners but ingest broken (cold-start or >24h stall): no sentinel, empty heartbeat falls through to noData=Alerting.
         # Heartbeat lag (~1.5m from 30s refresh + 1m end_offset) is absorbed by the 5m threshold and 5m `for`.
         data:
           - refId: A
@@ -186,13 +186,14 @@ groups:
               format: table
               rawSql: |
                 SELECT
-                    h.organization_id,
-                    extract(epoch from now() - max(h.bucket))::float8 AS staleness_seconds
-                FROM fleet_telemetry_poll_heartbeat h
-                WHERE h.bucket > NOW() - INTERVAL '24 hours'
-                    -- Skip orgs with no current pollable miners so their stale buckets can't fire for up to 24h after removal.
-                    AND h.organization_id IN (SELECT organization_id FROM fleet_pollable_device_presence)
-                GROUP BY h.organization_id
+                    p.organization_id,
+                    -- No bucket for a pollable org (cold-start or aged out) reads as stale so it fires per-org, not only when every org is missing.
+                    COALESCE(extract(epoch from now() - max(h.bucket))::float8, 1e9) AS staleness_seconds
+                FROM fleet_pollable_device_presence p
+                LEFT JOIN fleet_telemetry_poll_heartbeat h
+                    ON h.organization_id = p.organization_id
+                    AND h.bucket > NOW() - INTERVAL '24 hours'
+                GROUP BY p.organization_id
                 UNION ALL
                 -- No pollable miners anywhere: nothing to ingest, so emit a healthy sentinel instead of tripping noData.
                 SELECT '', 0::float8
@@ -219,8 +220,8 @@ groups:
         annotations:
           summary: "Proto Fleet metric ingest has stalled."
           description: |
-            No samples have been written to notification_metric_sample for
-            organization {{ $labels.organization_id }} in the last five
-            minutes, despite that org having emitted samples in the past
-            day. Either fleet-api is down or the in-process metrics writer
-            is wedged. Alerts cannot fire until ingest resumes.
+            No telemetry-poll samples have been ingested for organization
+            {{ $labels.organization_id }} in the last five minutes, even
+            though it has pollable miners. Either fleet-api is down or the
+            in-process metrics writer is wedged. Alerts cannot fire until
+            ingest resumes.

--- a/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
+++ b/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
@@ -171,7 +171,8 @@ groups:
         title: Metric Ingest Stalled
         condition: B
         # Edge cases (full rationale in commit/PR):
-        # No paired miners: UNION ALL sentinel returns a healthy row so noData can't fire on a fresh install.
+        # Per-org: only orgs with current pollable miners are evaluated, so removing an org's miners stops its stale heartbeat from firing.
+        # No pollable miners anywhere: UNION ALL sentinel returns a healthy row so noData can't fire on a fresh/emptied fleet.
         # Paired miners but ingest broken (cold-start or >24h stall): no sentinel, empty heartbeat falls through to noData=Alerting.
         # Heartbeat lag (~1.5m from 30s refresh + 1m end_offset) is absorbed by the 5m threshold and 5m `for`.
         data:
@@ -185,15 +186,17 @@ groups:
               format: table
               rawSql: |
                 SELECT
-                    organization_id,
-                    extract(epoch from now() - max(bucket))::float8 AS staleness_seconds
-                FROM fleet_telemetry_poll_heartbeat
-                WHERE bucket > NOW() - INTERVAL '24 hours'
-                GROUP BY organization_id
+                    h.organization_id,
+                    extract(epoch from now() - max(h.bucket))::float8 AS staleness_seconds
+                FROM fleet_telemetry_poll_heartbeat h
+                WHERE h.bucket > NOW() - INTERVAL '24 hours'
+                    -- Skip orgs with no current pollable miners so their stale buckets can't fire for up to 24h after removal.
+                    AND h.organization_id IN (SELECT organization_id FROM fleet_pollable_device_presence)
+                GROUP BY h.organization_id
                 UNION ALL
-                -- No paired miners: nothing to ingest, so emit a healthy sentinel instead of tripping noData.
+                -- No pollable miners anywhere: nothing to ingest, so emit a healthy sentinel instead of tripping noData.
                 SELECT '', 0::float8
-                WHERE NOT (SELECT has_pollable_device FROM fleet_pollable_device_presence)
+                WHERE NOT EXISTS (SELECT 1 FROM fleet_pollable_device_presence)
           - refId: B
             datasourceUid: __expr__
             model:

--- a/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
+++ b/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
@@ -170,21 +170,10 @@ groups:
       - uid: protofleet-ingest-stalled
         title: Metric Ingest Stalled
         condition: B
-        # Edge cases:
-        #   - Fresh deploy with no samples ever emitted → the inner
-        #     SELECT returns no orgs; Grafana falls through to
-        #     noDataState=Alerting and emits an unscoped instance.
-        #     That's acceptable; "no org is emitting metrics yet" is
-        #     fundamentally global.
-        #   - Ingest stalled globally for >24h → ditto: every active
-        #     org ages out of the inner SELECT, the query returns no
-        #     rows, noDataState=Alerting fires a single global alert.
-        #     By that point operators have had 24h of per-org alerts
-        #     and this fallback is informational.
-        #   - Heartbeat lag: the aggregate refreshes every 30s with a
-        #     1m end_offset, so observed staleness can run up to ~1.5m
-        #     ahead of true ingest staleness. The 5m threshold and 5m
-        #     `for` clause absorb that lag.
+        # Edge cases (full rationale in commit/PR):
+        # Fresh install / no paired miners: UNION ALL sentinel returns a healthy row so noData can't fire.
+        # Ingest stalled >24h: older rows remain in retention, sentinel suppressed, noData fires as before.
+        # Heartbeat lag (~1.5m from 30s refresh + 1m end_offset) is absorbed by the 5m threshold and 5m `for`.
         data:
           - refId: A
             relativeTimeRange:
@@ -201,6 +190,10 @@ groups:
                 FROM fleet_telemetry_poll_heartbeat
                 WHERE bucket > NOW() - INTERVAL '24 hours'
                 GROUP BY organization_id
+                UNION ALL
+                -- Fresh install / no paired miners: nothing ever ingested, so emit a healthy sentinel instead of tripping noData.
+                SELECT '', 0::float8
+                WHERE NOT EXISTS (SELECT 1 FROM fleet_telemetry_poll_heartbeat)
           - refId: B
             datasourceUid: __expr__
             model:

--- a/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
+++ b/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
@@ -171,8 +171,8 @@ groups:
         title: Metric Ingest Stalled
         condition: B
         # Edge cases (full rationale in commit/PR):
-        # Fresh install / no paired miners: UNION ALL sentinel returns a healthy row so noData can't fire.
-        # Ingest stalled >24h: older rows remain in retention, sentinel suppressed, noData fires as before.
+        # No paired miners: UNION ALL sentinel returns a healthy row so noData can't fire on a fresh install.
+        # Paired miners but ingest broken (cold-start or >24h stall): no sentinel, empty heartbeat falls through to noData=Alerting.
         # Heartbeat lag (~1.5m from 30s refresh + 1m end_offset) is absorbed by the 5m threshold and 5m `for`.
         data:
           - refId: A
@@ -191,9 +191,9 @@ groups:
                 WHERE bucket > NOW() - INTERVAL '24 hours'
                 GROUP BY organization_id
                 UNION ALL
-                -- Fresh install / no paired miners: nothing ever ingested, so emit a healthy sentinel instead of tripping noData.
+                -- No paired miners: nothing to ingest, so emit a healthy sentinel instead of tripping noData.
                 SELECT '', 0::float8
-                WHERE NOT EXISTS (SELECT 1 FROM fleet_telemetry_poll_heartbeat)
+                WHERE NOT (SELECT has_pollable_device FROM fleet_pollable_device_presence)
           - refId: B
             datasourceUid: __expr__
             model:


### PR DESCRIPTION
## Summary

The `Metric Ingest Stalled` Grafana rule false-fires on every fresh install / any fleet with no paired miners: with nothing to poll, no `fleet_telemetry_poll_total` samples are written, the `fleet_telemetry_poll_heartbeat` aggregate is empty, and the rule's `noDataState: Alerting` path fires. This reworks the rule so it arms exactly when telemetry *should* be flowing — driven by which orgs currently have pollable miners — and adds a regression test.

## How it works

A new `fleet_pollable_device_presence` view returns the set of `organization_id`s that currently have a cloud-dialed paired miner. It mirrors `GetAllPairedDeviceIdentifiers` (PAIRED/DEFAULT_PASSWORD, not deleted, not fleet-node-owned) and is an **owner-privilege** view, so the least-privilege `grafana_ro` role reads it without any grant on `device`/`device_pairing` (which holds `pairing_token`).

The alert query is **driven from that view** and `LEFT JOIN`s recent heartbeat rows:

```sql
SELECT p.organization_id,
       COALESCE(extract(epoch from now() - max(h.bucket))::float8, 1e9) AS staleness_seconds
FROM fleet_pollable_device_presence p
LEFT JOIN fleet_telemetry_poll_heartbeat h
    ON h.organization_id = p.organization_id
    AND h.bucket > NOW() - INTERVAL '24 hours'
GROUP BY p.organization_id
UNION ALL
SELECT '', 0::float8
WHERE NOT EXISTS (SELECT 1 FROM fleet_pollable_device_presence)
```

Every org with pollable miners yields a row; a missing bucket (cold-start or aged-out) coalesces to a large staleness and fires **per org**, independent of other orgs. The global sentinel keeps the rule Normal only when nothing is pollable anywhere.

## Diagrams

```mermaid
flowchart TD
    P{any pollable miners?} -->|no| S[sentinel row staleness 0 -> Normal]
    P -->|yes| L[for each pollable org: LEFT JOIN heartbeat]
    L --> M{recent bucket?}
    M -->|yes, fresh| N[low staleness -> Normal]
    M -->|stale gt 5m| F[fire]
    M -->|none / aged out| C[COALESCE 1e9 -> fire]
```

## Behavior matrix

| Scenario | Result |
|---|---|
| No miners anywhere (fresh / emptied fleet) | Normal (sentinel) |
| Org with healthy ingest | Normal |
| Org with miners, ingest broken (cold-start or >24h) | Alerting — even if a peer org is healthy |
| Org B's miners removed, org A active | B dropped from eval (no false fire), A unaffected |

## Areas of the code involved

- `server/migrations/000096_fleet_pollable_device_presence.{up,down}.sql` — the new view.
- `server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml` — the reworked `protofleet-ingest-stalled` query + description.
- `deployment-files/run-fleet.sh` — `GRANT SELECT` on the view for `grafana_ro` and a readiness-poll/smoke-check entry.
- `server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go` — regression test.
- `server/generated/sqlc/models.go` — regenerated (`just gen`).

## Key technical decisions & trade-offs

- **Gate on pollable-device presence, not heartbeat history.** Keying off "no heartbeat rows" masks a genuine cold-start ingest failure when devices *are* paired. Presence is the correct expected-ingest signal.
- **Owner-privilege view, not a table grant.** `grafana_ro` is deliberately scoped (SELECT only on the two metric objects). The view exposes just `organization_id`s via the owner's privileges, so `device_pairing.pairing_token` stays unexposed.
- **Driven from presence + `LEFT JOIN`.** Filtering a heartbeat-driven query would drop cold-start orgs (no row) and only `noData` would catch them — which fails the moment any other org is healthy. Driving from presence guarantees a per-org evaluation row.
- **Sentinel only for the global-empty case**, so an emptied fleet goes Normal while a partially-emptied fleet still evaluates its remaining orgs.

## Testing & validation

- `just lint` → 0 issues (buf, eslint, golangci-lint).
- New integration test (`testutil.GetTestDB`, skipped in short mode) loads the rule's `rawSql` **from the YAML** (no drift) and asserts: healthy org Normal, cold-start org fires while a peer is healthy, removed org suppressed despite stale heartbeat, and the global sentinel-only case. Both cases pass against a real migrated TimescaleDB.
- Verified live on the dev stack across iterations: migration applies (version 96), the rule evaluates Normal with no devices, and the exact two-org scenario fires correctly.
- Addressed three rounds of Codex security-review findings (cold-start masking, additive sentinel not suppressing stale rows, heartbeat-driven query dropping cold-start orgs); the final round reports Risk: NONE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
