### PR TITLE
Multi-site UI hardening round 2: site-create building staging, SitePicker refresh, per-tab counts

### DIFF
--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -133,6 +133,10 @@ function PageHeader({
   const { listSites } = useSites();
   const [sites, setSites] = useState<SiteWithCounts[] | undefined>(MULTI_SITE_ENABLED ? undefined : []);
   const [sitesError, setSitesError] = useState<string | null>(null);
+  // Bumped by the site create / rename / delete flows on pages and modals
+  // below this header. Watching it lets the picker pick up a just-created
+  // site without a full page reload.
+  const sitesRevision = useFleetStore((state) => state.ui.sitesRevision);
 
   const fetchSites = useCallback(() => {
     const controller = new AbortController();
@@ -153,7 +157,7 @@ function PageHeader({
   useEffect(() => {
     if (!MULTI_SITE_ENABLED) return;
     return fetchSites();
-  }, [fetchSites]);
+  }, [fetchSites, sitesRevision]);
 
   const handleCompleteSetup = () => {
     setDismissedSetup(false);

--- a/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BuildingList/BuildingList.tsx
@@ -70,6 +70,10 @@ interface BuildingListProps {
   selectedIds?: string[];
   onSelectedIdsChange?: (ids: string[]) => void;
   activeSite?: ActiveSite;
+  // Unfiltered building total for the count line; when filters are active and
+  // it differs from the displayed count, the line reads "X of Y buildings".
+  totalUnfiltered?: number;
+  hasActiveFilters?: boolean;
 }
 
 const BuildingList = ({
@@ -81,6 +85,8 @@ const BuildingList = ({
   selectedIds,
   onSelectedIdsChange,
   activeSite,
+  totalUnfiltered,
+  hasActiveFilters,
 }: BuildingListProps) => {
   const navigate = useNavigate();
   const temperatureUnit = useTemperatureUnit();
@@ -180,7 +186,10 @@ const BuildingList = ({
     colConfig,
     items,
     itemKey: "id" as const,
-    hideTotal: true,
+    total: items.length,
+    totalUnfiltered,
+    hasActiveFilters,
+    itemName: { singular: "building", plural: "buildings" },
     onRowClick: handleRowClick,
     emptyStateRow,
     paddingLeft: { phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" },

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -21,6 +21,7 @@ import SiteModals from "@/protoFleet/features/sites/components/SiteModals";
 import SiteSettingsModal from "@/protoFleet/features/sites/components/SiteSettingsModal";
 import { useSiteModals } from "@/protoFleet/features/sites/hooks/useSiteModals";
 import { useHasPermission } from "@/protoFleet/store";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 import { variants } from "@/shared/components/Button";
 import Dialog from "@/shared/components/Dialog";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
@@ -83,11 +84,15 @@ const FleetCreateFlowProvider = ({
     notifyMinersChanged();
   }, [notifyMinersChanged]);
   // Refresh the shared site catalog AND pulse list pages — used by the site
-  // create/edit paths so the new site resolves everywhere right away.
+  // create/edit paths so the new site resolves everywhere right away. Also
+  // bumps the header SitePicker's refresh signal so a site created via the
+  // bulk "New site" seeded flow shows up there without a reload.
+  const bumpSitesRevision = useFleetStore((state) => state.ui.bumpSitesRevision);
   const refreshSitesAndBump = useCallback(() => {
     refetchSites();
     bumpEntities();
-  }, [refetchSites, bumpEntities]);
+    bumpSitesRevision();
+  }, [refetchSites, bumpEntities, bumpSitesRevision]);
 
   // Rack create flow. rackSettings drives RackSettingsModal; once the
   // operator continues, rackFormData opens ManageRackModal seeded with the

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.test.tsx
@@ -170,12 +170,14 @@ describe("MinerList", () => {
 
   describe("miner count subtitle", () => {
     it("shows total miner count", () => {
+      // loading must be false: the count line now renders inside the List
+      // (beneath the filter row), which mounts once the initial load completes.
       renderMinerList({
         title: "Miners",
         minerIds: [],
         totalMiners: 14,
         onAddMiners: vi.fn(),
-        loading: true,
+        loading: false,
       });
 
       expect(screen.getByText("14 miners")).toBeInTheDocument();
@@ -189,7 +191,7 @@ describe("MinerList", () => {
           totalMiners: 5,
           totalUnfilteredMiners: 14,
           onAddMiners: vi.fn(),
-          loading: true,
+          loading: false,
         },
         ["/?status=hashing"],
       );
@@ -205,7 +207,7 @@ describe("MinerList", () => {
           totalMiners: 14,
           totalUnfilteredMiners: 14,
           onAddMiners: vi.fn(),
-          loading: true,
+          loading: false,
         },
         ["/?status=hashing"],
       );

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -243,6 +243,7 @@ type ScopedMinerListBodyProps = {
   paddingLeft?: Partial<Record<Breakpoint, string>>;
   overflowContainer?: boolean;
   totalMiners?: number;
+  totalUnfilteredMiners?: number;
   totalDisabledMiners: number;
   totalDisabledMinersFresh: boolean;
   itemRef?: (itemKey: string, element: HTMLTableRowElement | null) => void;
@@ -283,6 +284,7 @@ const ScopedMinerListBody = ({
   paddingLeft,
   overflowContainer,
   totalMiners,
+  totalUnfilteredMiners,
   totalDisabledMiners,
   totalDisabledMinersFresh,
   itemRef,
@@ -408,16 +410,20 @@ const ScopedMinerListBody = ({
         )}
         containerClassName={listClassName}
         tableClassName="mb-4 inline-table w-max !min-w-fit !table-fixed"
+        // Match the sibling fleet tabs (Sites/Buildings/Racks), whose filter
+        // row sits in a pt-6 laptop:pt-10 … pb-6 container. The List default
+        // (py-6) made the Miners filter row start higher than the others.
+        filtersClassName="pt-6 pb-6 laptop:pt-10"
         paddingLeft={paddingLeft}
         paddingRight={paddingLeft}
         overflowContainer={overflowContainer}
         stickyChromeClassName={overflowContainer === false ? PAGE_SCROLL_CHROME_WIDTH : undefined}
         applyColumnWidthsToCells
         total={totalMiners}
+        totalUnfiltered={totalUnfilteredMiners}
         // Every row is selectable; `totalSelectable = totalMiners` so action-bar
         // copy and confirmation counts cover both paired and auth-needed miners.
         totalDisabled={0}
-        hideTotal
         itemName={{ singular: "miner", plural: "miners" }}
         itemRef={itemRef}
         initialActiveFilters={initialActiveFilters}
@@ -1146,25 +1152,20 @@ const MinerList = ({
 
   return (
     <>
+      {/* Scroll anchor for pagination. When a title is present (standalone
+          /miners) it renders an <h2> with the page's top padding; in the fleet
+          shell there's no title, so it collapses to a zero-height anchor rather
+          than an empty padded band above the filter row (which made the Miners
+          tab sit lower than the other fleet tabs). */}
       <div
         ref={topRef}
         className={clsx(
-          "sticky left-0 px-6 pt-6 laptop:px-10 laptop:pt-10",
+          "sticky left-0 px-6 laptop:px-10",
+          title && "pt-6 laptop:pt-10",
           overflowContainer === false && PAGE_SCROLL_CHROME_WIDTH,
         )}
       >
         {title ? <h2 className="text-heading-300">{title}</h2> : null}
-      </div>
-
-      <div
-        className={clsx(
-          "sticky left-0 px-6 text-300 text-text-primary-70 laptop:px-10",
-          overflowContainer === false && PAGE_SCROLL_CHROME_WIDTH,
-        )}
-      >
-        {hasActiveFilters && totalUnfilteredMiners !== undefined && totalMiners !== totalUnfilteredMiners
-          ? `${totalMiners} of ${totalUnfilteredMiners} miners`
-          : `${totalMiners ?? 0} miners`}
       </div>
 
       {loading ? (
@@ -1184,6 +1185,7 @@ const MinerList = ({
           paddingLeft={paddingLeft}
           overflowContainer={overflowContainer}
           totalMiners={totalMiners}
+          totalUnfilteredMiners={totalUnfilteredMiners}
           totalDisabledMiners={totalDisabledMiners}
           totalDisabledMinersFresh={totalDisabledMinersFresh}
           itemRef={itemRef}

--- a/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/SiteList/SiteList.tsx
@@ -62,9 +62,21 @@ interface SiteListProps {
   onEditSite?: (site: Site) => void;
   selectedIds?: string[];
   onSelectedIdsChange?: (ids: string[]) => void;
+  // Unfiltered site total for the count line; when filters are active and it
+  // differs from the displayed count, the line reads "X of Y sites".
+  totalUnfiltered?: number;
+  hasActiveFilters?: boolean;
 }
 
-const SiteList = ({ sites, emptyStateRow, onEditSite, selectedIds, onSelectedIdsChange }: SiteListProps) => {
+const SiteList = ({
+  sites,
+  emptyStateRow,
+  onEditSite,
+  selectedIds,
+  onSelectedIdsChange,
+  totalUnfiltered,
+  hasActiveFilters,
+}: SiteListProps) => {
   const navigate = useNavigate();
   const temperatureUnit = useTemperatureUnit();
 
@@ -143,7 +155,10 @@ const SiteList = ({ sites, emptyStateRow, onEditSite, selectedIds, onSelectedIds
     colConfig,
     items,
     itemKey: "id" as const,
-    hideTotal: true,
+    total: items.length,
+    totalUnfiltered,
+    hasActiveFilters,
+    itemName: { singular: "site", plural: "sites" },
     onRowClick: handleRowClick,
     emptyStateRow,
     paddingLeft: { phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" },

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -175,6 +175,28 @@ const FleetBuildingsPage = () => {
     enabled: canReadBuildings,
   });
 
+  // Unfiltered building count for the "X of Y buildings" line. Only needed
+  // when filters are active (otherwise the displayed count already is the
+  // total). Fetched with the path/site scope alone — no issue/telemetry/`?site=`
+  // filters — mirroring how the Miners tab sources its unfiltered denominator.
+  const scopeOnlyFilter = useMemo(() => siteFilterFromActive(activeSite), [activeSite]);
+  const [totalUnfilteredBuildings, setTotalUnfilteredBuildings] = useState<number | undefined>(undefined);
+  useEffect(() => {
+    // Only consumed while filters are active (the count line otherwise shows
+    // the displayed total). Skip the fetch when filters are off and leave the
+    // last value — it's ignored, and a scope change re-runs this effect.
+    if (!canReadBuildings || !hasActiveFilters) return;
+    const controller = new AbortController();
+    void listBuildings({
+      siteIds: scopeOnlyFilter.siteIds,
+      includeUnassigned: scopeOnlyFilter.includeUnassigned,
+      signal: controller.signal,
+      onSuccess: (rows) => setTotalUnfilteredBuildings(rows.length),
+      onError: () => setTotalUnfilteredBuildings(undefined),
+    });
+    return () => controller.abort();
+  }, [canReadBuildings, hasActiveFilters, scopeOnlyFilter, listBuildings]);
+
   // Drop the previous scope's rows the moment the site filter changes so
   // the now-mismatched buildings can't render (or be selected/edited)
   // under the new scope during the in-flight refetch. Resetting to
@@ -543,6 +565,8 @@ const FleetBuildingsPage = () => {
           <BuildingList
             buildings={visibleBuildings}
             sites={sites}
+            totalUnfiltered={totalUnfilteredBuildings}
+            hasActiveFilters={hasActiveFilters}
             onEditBuilding={canManageBuildings ? openEditBuilding : undefined}
             onAddBuildingToSite={canManageBuildings ? handleAddBuildingToSite : undefined}
             selectedIds={selectedBuildingIds}

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -134,6 +134,16 @@ const FleetBuildingsPage = () => {
     listFilterKeyRef.current = listFilterKey;
   }, [listFilterKey]);
 
+  // Unfiltered building count for the "X of Y buildings" line — the path/site
+  // scope alone, no issue/telemetry/`?site=` filters. Fetched alongside the
+  // filtered list inside fetchBuildings (below) so the denominator refreshes on
+  // exactly the same triggers as the rows it's compared against: poll ticks,
+  // filter/scope changes, create-flow pulses, and modal mutations. Its own
+  // request-id guard rejects out-of-order count responses.
+  const scopeOnlyFilter = useMemo(() => siteFilterFromActive(activeSite), [activeSite]);
+  const [totalUnfilteredBuildings, setTotalUnfilteredBuildings] = useState<number | undefined>(undefined);
+  const unfilteredCountRequestIdRef = useRef(0);
+
   // Returning the promise lets usePoll schedule the next tick from response
   // completion (not from request start) so slow responses can't overlap.
   const fetchBuildings = useCallback(() => {
@@ -143,6 +153,23 @@ const FleetBuildingsPage = () => {
       setBuildings([]);
       setBuildingsError(null);
       return Promise.resolve();
+    }
+
+    // Refresh the unfiltered denominator on the same beat as the filtered list.
+    // Only needed while filters are active (otherwise the displayed count is
+    // already the total).
+    if (hasActiveFilters && !isMatchNoneSiteFilter(scopeOnlyFilter)) {
+      const countRequestId = ++unfilteredCountRequestIdRef.current;
+      void listBuildings({
+        siteIds: scopeOnlyFilter.siteIds,
+        includeUnassigned: scopeOnlyFilter.includeUnassigned,
+        onSuccess: (rows) => {
+          if (countRequestId === unfilteredCountRequestIdRef.current) setTotalUnfilteredBuildings(rows.length);
+        },
+        onError: () => {
+          if (countRequestId === unfilteredCountRequestIdRef.current) setTotalUnfilteredBuildings(undefined);
+        },
+      });
     }
 
     return listBuildings({
@@ -163,7 +190,15 @@ const FleetBuildingsPage = () => {
         setBuildings((prev) => prev ?? []);
       },
     });
-  }, [listBuildings, requestSiteFilter, errorComponentTypes, telemetryRanges, listFilterKey]);
+  }, [
+    listBuildings,
+    requestSiteFilter,
+    errorComponentTypes,
+    telemetryRanges,
+    listFilterKey,
+    hasActiveFilters,
+    scopeOnlyFilter,
+  ]);
 
   // Gate the poll on site:read — same gate FleetLayout uses to redirect.
   const canReadBuildings = useHasPermission("site:read");
@@ -174,28 +209,6 @@ const FleetBuildingsPage = () => {
     pollIntervalMs: POLL_INTERVAL_MS,
     enabled: canReadBuildings,
   });
-
-  // Unfiltered building count for the "X of Y buildings" line. Only needed
-  // when filters are active (otherwise the displayed count already is the
-  // total). Fetched with the path/site scope alone — no issue/telemetry/`?site=`
-  // filters — mirroring how the Miners tab sources its unfiltered denominator.
-  const scopeOnlyFilter = useMemo(() => siteFilterFromActive(activeSite), [activeSite]);
-  const [totalUnfilteredBuildings, setTotalUnfilteredBuildings] = useState<number | undefined>(undefined);
-  useEffect(() => {
-    // Only consumed while filters are active (the count line otherwise shows
-    // the displayed total). Skip the fetch when filters are off and leave the
-    // last value — it's ignored, and a scope change re-runs this effect.
-    if (!canReadBuildings || !hasActiveFilters) return;
-    const controller = new AbortController();
-    void listBuildings({
-      siteIds: scopeOnlyFilter.siteIds,
-      includeUnassigned: scopeOnlyFilter.includeUnassigned,
-      signal: controller.signal,
-      onSuccess: (rows) => setTotalUnfilteredBuildings(rows.length),
-      onError: () => setTotalUnfilteredBuildings(undefined),
-    });
-    return () => controller.abort();
-  }, [canReadBuildings, hasActiveFilters, scopeOnlyFilter, listBuildings]);
 
   // Drop the previous scope's rows the moment the site filter changes so
   // the now-mismatched buildings can't render (or be selected/edited)

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
@@ -393,6 +393,8 @@ const FleetSitesPage = () => {
         <div className={LIST_WRAPPER}>
           <SiteList
             sites={displaySites}
+            totalUnfiltered={sites?.length}
+            hasActiveFilters={hasListFilters}
             onEditSite={canManageSites ? modals.openManageEdit : undefined}
             selectedIds={selectedSiteIds}
             onSelectedIdsChange={handleSelectedSiteIdsChange}

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -781,6 +781,11 @@ const RacksPage = () => {
     // value — it's ignored, and a scope change re-runs this effect.
     if (!hasActiveFilters) return;
     let cancelled = false;
+    // `racks` is in the deps as the list-refresh signal: its reference changes
+    // whenever the rack list refetches (poll, resetAndFetch, create/delete/move),
+    // so this cheap pageSize:1 count stays in sync with `totalCount` instead of
+    // going stale until the filter/scope changes. The count itself is
+    // page-independent, so re-running it on pagination is harmless.
     void listRacks({
       pageSize: 1,
       siteIds: activeSiteFilter.siteIds,
@@ -795,7 +800,7 @@ const RacksPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [hasActiveFilters, activeSiteFilter, listRacks]);
+  }, [hasActiveFilters, activeSiteFilter, listRacks, racks]);
   const visibleRackScopes = useMemo(
     () =>
       racks.flatMap((rack) => {

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -61,6 +61,7 @@ import Callout from "@/shared/components/Callout";
 import Dialog from "@/shared/components/Dialog";
 import DropdownFilter from "@/shared/components/List/Filters/DropdownFilter";
 import FilterChipsBar, { type FilterChipsBarNumericFilter } from "@/shared/components/List/Filters/FilterChipsBar";
+import { formatListCountLabel } from "@/shared/components/List/listCountLabel";
 import { SORT_ASC, SORT_DESC, type SortDirection } from "@/shared/components/List/types";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import SegmentedControl from "@/shared/components/SegmentedControl";
@@ -767,6 +768,34 @@ const RacksPage = () => {
     selectedZones.length > 0 ||
     selectedIssues.length > 0 ||
     telemetryRanges.length > 0;
+
+  // Unfiltered rack count for the "X of Y racks" line. `totalCount` from the
+  // list hook is the filtered total; this fetches the path-scope total (no
+  // zone/building/issue/`?site=`/telemetry filters) so the count line can show
+  // a denominator, mirroring the Miners tab. Only fetched while filters are
+  // active — otherwise the displayed count already is the total.
+  const [totalUnfilteredRacks, setTotalUnfilteredRacks] = useState<number | undefined>(undefined);
+  useEffect(() => {
+    // Only consumed while filters are active (the count line otherwise shows
+    // `totalCount`). Skip the fetch when filters are off and leave the last
+    // value — it's ignored, and a scope change re-runs this effect.
+    if (!hasActiveFilters) return;
+    let cancelled = false;
+    void listRacks({
+      pageSize: 1,
+      siteIds: activeSiteFilter.siteIds,
+      includeUnassigned: activeSiteFilter.includeUnassigned,
+      onSuccess: (_sets, _token, total) => {
+        if (!cancelled) setTotalUnfilteredRacks(total);
+      },
+      onError: () => {
+        if (!cancelled) setTotalUnfilteredRacks(undefined);
+      },
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [hasActiveFilters, activeSiteFilter, listRacks]);
   const visibleRackScopes = useMemo(
     () =>
       racks.flatMap((rack) => {
@@ -1186,6 +1215,20 @@ const RacksPage = () => {
             ) : null}
           </div>
         </div>
+      </div>
+      <div
+        className={clsx(
+          "sticky left-0 px-6 pb-4 text-emphasis-300 text-text-primary-70 laptop:px-10",
+          PAGE_SCROLL_CHROME_WIDTH,
+        )}
+        data-testid="racks-count-label"
+      >
+        {formatListCountLabel(totalCount, {
+          unfilteredTotal: totalUnfilteredRacks,
+          hasActiveFilters,
+          singular: "rack",
+          plural: "racks",
+        })}
       </div>
       {error ? (
         <Callout className="mx-6 mb-4 laptop:mx-10" intent="danger" prefixIcon={<Alert />} title={error} />

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
@@ -124,7 +124,7 @@ describe("ManageSiteModal", () => {
     expect(onDeleteRequested).toHaveBeenCalled();
   });
 
-  it("create mode prompts to save the site before adding buildings", () => {
+  it("create mode lets buildings be staged before the site is saved", () => {
     render(
       <ManageSiteModal
         open
@@ -137,9 +137,14 @@ describe("ManageSiteModal", () => {
       />,
     );
 
-    expect(screen.getByText("Save the site first to add buildings.")).toBeInTheDocument();
-    // Manage buildings is disabled until the site exists.
-    expect(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]).toBeDisabled();
+    // No "save first" gate — the empty working set renders the same
+    // add-buildings affordance as edit mode, and Manage buildings is enabled.
+    expect(screen.queryByText("Save the site first to add buildings.")).not.toBeInTheDocument();
+    expect(screen.getByText("No buildings added to this site")).toBeInTheDocument();
+    expect(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]).toBeEnabled();
+    expect(screen.getAllByTestId("manage-site-modal-empty-state-add")[0]).toBeEnabled();
+    // Save is allowed immediately (creates the site with an empty building set).
+    expect(screen.getAllByTestId("manage-site-modal-save")[0]).toBeEnabled();
   });
 
   it("shows comma-separated meta on each corner of the preview", () => {

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
@@ -198,9 +198,13 @@ const ManageSiteModal = ({
     return () => controller.abort();
   }, [shouldFetchBuildings, fetchSiteId, listBuildingsBySite, buildingsRefreshKey]);
 
-  // Create mode never fetches, so its working set is empty by construction.
+  // Create mode never fetches (there's no persisted site yet) but still keeps
+  // a working set: buildings the operator stages via the picker before the
+  // first Save, which the host then assigns to the freshly-created site.
+  // `entries` starts undefined there, so fall back to an empty (loaded, not
+  // loading) list rather than the edit-mode loading skeleton.
   const displayEntries: BuildingEntry[] | undefined = useMemo(
-    () => (shouldFetchBuildings ? entries : []),
+    () => (shouldFetchBuildings ? entries : (entries ?? [])),
     [shouldFetchBuildings, entries],
   );
   const sortedEntries = useMemo(
@@ -282,8 +286,10 @@ const ManageSiteModal = ({
             text: "Manage buildings",
             variant: variants.secondary,
             onClick: () => setShowManageBuildings(true),
-            // Create mode has no persisted site to assign buildings to yet.
-            disabled: saving || mode === "create" || sortedEntries === undefined,
+            // Enabled in both modes — create stages buildings into the working
+            // set and assigns them on the first Save. Only blocked while the
+            // edit-mode list is still loading (sortedEntries undefined).
+            disabled: saving || sortedEntries === undefined,
             testId: "manage-site-modal-manage-buildings",
           },
           {
@@ -305,11 +311,7 @@ const ManageSiteModal = ({
                 title={`${buildingCount} ${buildingCount === 1 ? "building" : "buildings"}`}
                 titleSize="text-heading-100"
               />
-              {mode === "create" ? (
-                <div className="rounded-xl border border-dashed border-border-5 p-4 text-300 text-text-primary-50">
-                  Save the site first to add buildings.
-                </div>
-              ) : sortedEntries === undefined ? (
+              {sortedEntries === undefined ? (
                 <div className="text-300 text-text-primary-50">Loading…</div>
               ) : sortedEntries.length === 0 ? (
                 <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-50">
@@ -387,10 +389,13 @@ const ManageSiteModal = ({
         }
       />
 
-      {showManageBuildings && site ? (
+      {showManageBuildings ? (
+        // siteId 0n in create mode (no persisted site yet): the picker treats
+        // every unassigned building as eligible and disables buildings already
+        // in another site, which is exactly the create-time rule.
         <ManageBuildingsModal
           open={showManageBuildings}
-          siteId={site.id}
+          siteId={site?.id ?? 0n}
           initialSelectedBuildingIds={currentBuildingIds}
           onDismiss={() => setShowManageBuildings(false)}
           onConfirm={handleManageBuildingsConfirm}

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
@@ -158,9 +158,36 @@ describe("useSiteModals", () => {
     await waitFor(() => {
       expect(sitesClient.createSite).toHaveBeenCalledTimes(1);
     });
-    // Create never touches the buildings RPC — building management is gated
-    // until the site exists.
+    // With no staged buildings the create skips the buildings RPC entirely.
     expect(sitesClient.assignBuildingsToSite).not.toHaveBeenCalled();
+    expect(saveResult?.closeOnSuccess).toBe(true);
+    expect(refetchSites).toHaveBeenCalled();
+  });
+
+  it("manageSave on manageCreate assigns staged buildings to the new site", async () => {
+    const { create: createResp } = makeSiteResponse(7n, "North DC");
+    vi.mocked(sitesClient.createSite).mockResolvedValue(createResp);
+    vi.mocked(sitesClient.assignBuildingsToSite).mockResolvedValue(
+      create(AssignBuildingsToSiteResponseSchema, { reassignedRackCount: 0n, reassignedDeviceCount: 0n }),
+    );
+    const refetchSites = vi.fn();
+    const { result } = renderHook(() => useSiteModals({ refetchSites }));
+    act(() => result.current.openCreate());
+    act(() => result.current.detailsContinueCreate({ ...emptySiteFormValues(), name: "North DC" }));
+
+    let saveResult: { closeOnSuccess: boolean } | null | undefined;
+    await act(async () => {
+      saveResult = await result.current.manageSave({ added: [11n, 12n], removed: [] });
+    });
+
+    await waitFor(() => {
+      expect(sitesClient.createSite).toHaveBeenCalledTimes(1);
+    });
+    // Staged buildings are assigned to the freshly-created site (id 7).
+    expect(sitesClient.assignBuildingsToSite).toHaveBeenCalledWith(
+      { buildingIds: [11n, 12n], targetSiteId: 7n },
+      expect.anything(),
+    );
     expect(saveResult?.closeOnSuccess).toBe(true);
     expect(refetchSites).toHaveBeenCalled();
   });

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
@@ -64,10 +64,10 @@ export interface SiteModalsApi {
   // ManageSiteModal handlers
   manageEditDetails: () => void;
   // Persists building-membership changes accumulated in the manage modal.
-  // In create mode the delta is empty (building management is gated until
-  // the site exists) and this just runs CreateSite. In edit mode it applies
-  // the delta via AssignBuildingsToSite. Returns whether the modal should
-  // close on success, or null if the save failed.
+  // In create mode this runs CreateSite, then assigns any buildings the
+  // operator staged (the delta's `added`) to the new site. In edit mode it
+  // applies the delta via AssignBuildingsToSite. Returns whether the modal
+  // should close on success, or null if the save failed.
   manageSave: (delta: { added: bigint[]; removed: bigint[] }) => Promise<{ closeOnSuccess: boolean } | null>;
   // SiteDeleteDialog handlers
   deleteConfirm: () => Promise<void>;
@@ -100,6 +100,10 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
   const { createSite, updateSite, deleteSite, assignBuildingsToSite } = useSites();
   const setActiveSite = useFleetStore((store) => store.ui.setActiveSite);
   const activeSite = useFleetStore((store) => store.ui.activeSite);
+  // Signals the PageHeader's SitePicker (which fetches sites once on mount and
+  // can't see this page's refetchSites) to refresh after a site is created,
+  // renamed, or deleted.
+  const bumpSitesRevision = useFleetStore((store) => store.ui.bumpSitesRevision);
 
   const openCreate = useCallback(() => {
     setState({ kind: "detailsCreate", draft: emptySiteFormValues() });
@@ -193,6 +197,7 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
               status: STATUSES.success,
             });
             refetchSites();
+            bumpSitesRevision();
             // Functional setState so a mid-flight dismiss (state transition
             // back to manageEdit or none) can't be silently overwritten by a
             // stale onSuccess closure.
@@ -214,7 +219,7 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
         });
       });
     },
-    [updateSite, refetchSites],
+    [updateSite, refetchSites, bumpSitesRevision],
   );
 
   const manageEditDetails = useCallback(() => {
@@ -233,36 +238,72 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
     async (delta: { added: bigint[]; removed: bigint[] }) => {
       if (savingRef.current) return null;
 
-      // Create flow: the manage modal gates building management until the
-      // site exists, so the delta is empty here — just persist the site.
-      // The modal closes on success; the operator reopens to add buildings.
+      // Create flow: persist the site, then assign any buildings the operator
+      // staged in the manage modal before the site existed. `added` carries
+      // those buildings (the working set started empty, so there's never a
+      // `removed`); they're assigned to the freshly-created site's id. The two
+      // steps are sequenced explicitly (rather than chained through
+      // createSite's onFinally) so the saving guard stays held across both —
+      // an async onSuccess would otherwise release it the moment the building
+      // assign awaited.
       if (state.kind === "manageCreate") {
         const draft = state.draft;
         savingRef.current = true;
         setSaving(true);
-        const result = await new Promise<{ closeOnSuccess: boolean } | null>((resolve) => {
-          void createSite({
-            values: draft,
-            onSuccess: (site, warnings) => {
-              pushToast({
-                message:
-                  warnings.length > 0 ? `Site "${site.name}" created with warnings` : `Site "${site.name}" created`,
-                status: STATUSES.success,
-              });
-              refetchSites();
-              resolve({ closeOnSuccess: true });
-            },
-            onError: (msg) => {
-              pushToast({ message: `Failed to create site: ${msg}`, status: STATUSES.error });
-              resolve(null);
-            },
-            onFinally: () => {
-              savingRef.current = false;
-              setSaving(false);
-            },
+        try {
+          const created = await new Promise<{ site: Site; warnings: string[] } | null>((resolve) => {
+            void createSite({
+              values: draft,
+              onSuccess: (site, warnings) => resolve({ site, warnings }),
+              onError: (msg) => {
+                pushToast({ message: `Failed to create site: ${msg}`, status: STATUSES.error });
+                resolve(null);
+              },
+            });
           });
-        });
-        return result;
+          if (!created) return null;
+
+          // The site is committed past this point. A subsequent
+          // AssignBuildingsToSite failure must not read as a failed create —
+          // surface a partial-success warning and still close, matching the
+          // bulk "New site" seeded flow in FleetCreateFlowProvider.
+          let buildingsFailed: string | null = null;
+          if (delta.added.length > 0) {
+            await new Promise<void>((resolve) => {
+              void assignBuildingsToSite({
+                buildingIds: delta.added,
+                targetSiteId: created.site.id,
+                onSuccess: () => resolve(),
+                onError: (msg) => {
+                  buildingsFailed = msg;
+                  resolve();
+                },
+              });
+            });
+          }
+
+          pushToast(
+            buildingsFailed
+              ? {
+                  message: `Site "${created.site.name}" created, but adding buildings failed: ${buildingsFailed}`,
+                  status: STATUSES.error,
+                }
+              : {
+                  message:
+                    created.warnings.length > 0
+                      ? `Site "${created.site.name}" created with warnings`
+                      : `Site "${created.site.name}" created`,
+                  status: STATUSES.success,
+                },
+          );
+          refetchSites();
+          refetchBuildings?.();
+          bumpSitesRevision();
+          return { closeOnSuccess: true };
+        } finally {
+          savingRef.current = false;
+          setSaving(false);
+        }
       }
 
       // Edit flow: site details are owned by SiteSettingsModal, so the
@@ -321,7 +362,7 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
 
       return null;
     },
-    [state, createSite, assignBuildingsToSite, refetchSites, refetchBuildings],
+    [state, createSite, assignBuildingsToSite, refetchSites, refetchBuildings, bumpSitesRevision],
   );
 
   const deleteConfirm = useCallback(async () => {
@@ -344,6 +385,7 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
             setActiveSite({ kind: "all" });
           }
           refetchSites();
+          bumpSitesRevision();
           setDeleteTarget(null);
           // Edit-flow callers come from manageEditEditingDetails or
           // manageEdit; the deleted site is gone so we collapse the stack.
@@ -357,7 +399,7 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
         onFinally: () => setDeleting(false),
       });
     });
-  }, [deleteTarget, deleteSite, refetchSites, activeSite, setActiveSite]);
+  }, [deleteTarget, deleteSite, refetchSites, activeSite, setActiveSite, bumpSitesRevision]);
 
   return {
     state,

--- a/client/src/protoFleet/store/slices/uiSlice.ts
+++ b/client/src/protoFleet/store/slices/uiSlice.ts
@@ -25,6 +25,13 @@ export interface UISlice {
   racksViewMode: RacksViewMode;
   isActionBarVisible: boolean;
   activeSite: ActiveSite;
+  // Monotonic counter bumped whenever the org's site list changes (create /
+  // rename / delete). The PageHeader's SitePicker fetches sites once on mount
+  // and holds them in local state, so it has no other way to learn a site was
+  // just created from a page or modal below it; watching this nonce lets it
+  // refetch without coupling to every mutation site. Not persisted — it's an
+  // in-memory refresh signal, not a preference.
+  sitesRevision: number;
 
   // Actions
   setTheme: (theme: Theme) => void;
@@ -36,6 +43,7 @@ export interface UISlice {
   setRacksViewMode: (mode: RacksViewMode) => void;
   setActionBarVisible: (visible: boolean) => void;
   setActiveSite: (next: ActiveSite) => void;
+  bumpSitesRevision: () => void;
 }
 
 // =============================================================================
@@ -53,6 +61,7 @@ export const createUISlice: StateCreator<FleetStore, [["zustand/immer", never]],
   racksViewMode: "grid",
   isActionBarVisible: false,
   activeSite: DEFAULT_ACTIVE_SITE,
+  sitesRevision: 0,
 
   // Actions
   setTheme: (theme) =>
@@ -98,5 +107,10 @@ export const createUISlice: StateCreator<FleetStore, [["zustand/immer", never]],
   setActiveSite: (next) =>
     set((state) => {
       state.ui.activeSite = next;
+    }),
+
+  bumpSitesRevision: () =>
+    set((state) => {
+      state.ui.sitesRevision += 1;
     }),
 });

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -36,6 +36,7 @@ import Checkbox from "@/shared/components/Checkbox";
 import Filters from "@/shared/components/List/Filters";
 import { ActiveFilters, FilterItem } from "@/shared/components/List/Filters/types";
 import ListActions from "@/shared/components/List/ListActions";
+import { formatListCountLabel } from "@/shared/components/List/listCountLabel";
 import {
   ColConfig,
   ColTitles,
@@ -166,6 +167,14 @@ type ListProps<ListItem, ItemKeyValueType, ColKey extends string = keyof ListIte
   ) => ReactNode;
   containerClassName?: string;
   tableClassName?: string;
+  /**
+   * Overrides the filter row's default `py-6` vertical padding. The `gap-4`
+   * spacing and the horizontal list padding are always applied; only the
+   * top/bottom padding is replaced. Lets a page-scroll consumer (e.g. the
+   * Miners tab) line its filter row up with sibling tabs that render their
+   * filter row in a `pt-10 … pb-6` container outside the List.
+   */
+  filtersClassName?: string;
   paddingLeft?: Partial<Record<Breakpoint, string>>;
   paddingRight?: Partial<Record<Breakpoint, string>>;
   overflowContainer?: boolean;
@@ -191,6 +200,14 @@ type ListProps<ListItem, ItemKeyValueType, ColKey extends string = keyof ListIte
     singular: string;
     plural: string;
   };
+  /**
+   * Unfiltered total for the current scope. When provided alongside an active
+   * filter set (`hasActiveFilters`), the built-in count line reads "X of Y
+   * nouns" once the filtered `total` diverges from this value; otherwise it
+   * falls back to the plain "X nouns" form. Leave unset for lists that have no
+   * meaningful unfiltered denominator.
+   */
+  totalUnfiltered?: number;
   initialActiveFilters?: ActiveFilters;
   /**
    * When true, suppresses the built-in item count display below the filter bar.
@@ -700,12 +717,14 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   renderActionBar,
   containerClassName = "",
   tableClassName,
+  filtersClassName,
   paddingLeft,
   paddingRight,
   overflowContainer = true,
   stickyChromeClassName,
   stickyBgColor = "bg-surface-base",
   total,
+  totalUnfiltered,
   totalDisabled = 0,
   itemName = { singular: "item", plural: "items" },
   itemRef,
@@ -1175,7 +1194,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   const filtersElement =
     filters?.length || headerControls ? (
       <Filters<ListItem>
-        className={clsx("gap-4 py-6", paddingClasses)}
+        className={clsx("gap-4", filtersClassName ?? "py-6", paddingClasses)}
         filterItems={filters ?? []}
         filterSize={filterSize}
         items={items}
@@ -1411,7 +1430,12 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
         {!hideTotal && total !== undefined ? (
           <div className={clsx("sticky left-0 flex", stickyChromeClassName)}>
             <div className={clsx("sticky left-0 pb-4 text-emphasis-300 text-text-primary-70", paddingClasses)}>
-              {total} {total === 1 ? itemName.singular : itemName.plural}
+              {formatListCountLabel(total, {
+                unfilteredTotal: totalUnfiltered,
+                hasActiveFilters,
+                singular: itemName.singular,
+                plural: itemName.plural,
+              })}
             </div>
           </div>
         ) : null}

--- a/client/src/shared/components/List/listCountLabel.test.ts
+++ b/client/src/shared/components/List/listCountLabel.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { formatListCountLabel } from "./listCountLabel";
+
+describe("formatListCountLabel", () => {
+  it("renders the plain count when no filters are active", () => {
+    expect(formatListCountLabel(14, { singular: "miner", plural: "miners" })).toBe("14 miners");
+  });
+
+  it("singularizes the plain count", () => {
+    expect(formatListCountLabel(1, { singular: "site", plural: "sites" })).toBe("1 site");
+  });
+
+  it("renders 'X of Y' when filters are active and counts differ", () => {
+    expect(
+      formatListCountLabel(5, { unfilteredTotal: 14, hasActiveFilters: true, singular: "miner", plural: "miners" }),
+    ).toBe("5 of 14 miners");
+  });
+
+  it("singularizes the denominator in the 'X of Y' form", () => {
+    expect(
+      formatListCountLabel(0, { unfilteredTotal: 1, hasActiveFilters: true, singular: "rack", plural: "racks" }),
+    ).toBe("0 of 1 rack");
+  });
+
+  it("falls back to the plain count when filters are active but counts match", () => {
+    expect(
+      formatListCountLabel(14, {
+        unfilteredTotal: 14,
+        hasActiveFilters: true,
+        singular: "building",
+        plural: "buildings",
+      }),
+    ).toBe("14 buildings");
+  });
+
+  it("falls back to the plain count when the unfiltered total is unknown", () => {
+    expect(formatListCountLabel(5, { hasActiveFilters: true, singular: "rack", plural: "racks" })).toBe("5 racks");
+  });
+});

--- a/client/src/shared/components/List/listCountLabel.ts
+++ b/client/src/shared/components/List/listCountLabel.ts
@@ -1,0 +1,21 @@
+// Shared formatter for the "X nouns" / "X of Y nouns" count line that sits
+// beneath a list's filter row. When filters are active and the filtered count
+// differs from the unfiltered total, it reads "X of Y nouns"; otherwise just
+// "X nouns". Used by the List component's built-in total and by pages that
+// render their own count line (e.g. the Racks grid, which isn't a List).
+export interface ListCountLabelOptions {
+  // Unfiltered total for the current scope. Omit when unknown — the label then
+  // always renders the plain "X nouns" form.
+  unfilteredTotal?: number;
+  hasActiveFilters?: boolean;
+  singular: string;
+  plural: string;
+}
+
+export const formatListCountLabel = (total: number, options: ListCountLabelOptions): string => {
+  const { unfilteredTotal, hasActiveFilters, singular, plural } = options;
+  if (hasActiveFilters && unfilteredTotal !== undefined && total !== unfilteredTotal) {
+    return `${total} of ${unfilteredTotal} ${unfilteredTotal === 1 ? singular : plural}`;
+  }
+  return `${total} ${total === 1 ? singular : plural}`;
+};


### PR DESCRIPTION
Reviewable diff: +274/-64 across 13 files (excludes generated, test, and story files).

## Summary

A round of small multi-site UI hardening fixes, all client-only. Operators can now stage buildings into a new site during creation (instead of being forced to save first and reopen), a newly created site appears in the header site picker without a page reload, and the Sites / Buildings / Racks tabs gain the same "X" / "X of Y" count line the Miners tab already had, rendered beneath the filter row. Also aligns the Miners filter-row spacing with the other fleet tabs.

## How it works

**1. Stage buildings during site creation.** Previously the create flow gated building management ("Save the site first to add buildings"), so an operator had to create the site, then reopen it to add buildings — inconsistent with rack creation, which lets you stage members before the first save. `ManageSiteModal` now keeps a building working set in create mode (seeded empty, same picker as edit mode) using `siteId = 0n`, which the picker already treats as "every unassigned building is eligible, other-site buildings disabled." On Save, `useSiteModals.manageSave` runs `CreateSite`, then assigns the staged buildings to the new site's id via `AssignBuildingsToSite`. The two calls are sequenced explicitly under one in-flight guard; a building-assign failure after the site is created surfaces a partial-success toast and still closes (the site exists), matching the existing bulk "New site" seeded flow.

**2. Site picker refresh without reload.** The header `SitePicker` fetches sites once on mount and holds them in local state, with no connection to the create/edit flows that live below it in the tree. A non-persisted `sitesRevision` counter was added to the Zustand UI slice and bumped on every site create / rename / delete (in `useSiteModals`, and in `FleetCreateFlowProvider` for the bulk seeded path). `PageHeader` watches the counter and refetches its site list when it changes. The counter is an in-memory refresh signal, not cached RPC data, so it is excluded from persistence.

**3. Per-tab count lines beneath the filter row.** The shared `List` component already rendered a total line below its filter row but only as `"{total} {noun}"`. A new `formatListCountLabel` helper produces `"5 of 14 miners"` when filters are active and the filtered count differs from the unfiltered total, else `"14 miners"`. `List` gained an optional `totalUnfiltered` prop that feeds the helper; consumers that don't pass it are unchanged. Miners now renders the count via this built-in line (dropping its custom div that sat above the filter row). Sites uses the in-memory unfiltered list length as the denominator (free). Buildings and Racks fetch a scope-only unfiltered count (path/site scope, no issue/telemetry/`?site=` filters) only while filters are active, mirroring how Miners sources its denominator; Racks renders a page-level label under its filter chips because its grid view is not a `List`.

**4. Miners filter-row spacing.** The Miners filter row (rendered inside `List` via the `Filters` element) used `py-6`, while the sibling tabs use `pt-10` (laptop) on top and `pb-6` on the bottom. Added an opt-in `filtersClassName` prop to `List` that replaces only the default `py-6`; Miners passes `pt-6 pb-6 laptop:pt-10`. The Miners `topRef` scroll anchor now drops its padding when there is no page title (the fleet shell), so it no longer renders an empty band above the filter row.

## Diagrams

Site-create building staging + save:

```mermaid
flowchart TD
    A["Operator: New site"] --> B["SiteSettingsModal (details)"]
    B --> C["ManageSiteModal (create mode)"]
    C --> D["Stage buildings via picker (working set, siteId 0n)"]
    D --> E["Save"]
    E --> F["useSiteModals.manageSave"]
    F --> G["CreateSite"]
    G --> H{"Staged buildings?"}
    H -->|yes| I["AssignBuildingsToSite(added, newSiteId)"]
    H -->|no| J["Done"]
    I --> J
    J --> K["refetchSites + bumpSitesRevision"]
```

Site picker refresh signal:

```mermaid
flowchart LR
    A["Create / rename / delete site"] --> B["bumpSitesRevision() (UI slice)"]
    B --> C["sitesRevision++"]
    C --> D["PageHeader effect re-runs"]
    D --> E["listSites() refetch"]
    E --> F["SitePicker shows new site"]
```

Count line resolution (per tab):

```mermaid
flowchart TD
    A["formatListCountLabel(total, opts)"] --> B{"hasActiveFilters AND unfilteredTotal set AND total != unfilteredTotal?"}
    B -->|yes| C["'X of Y nouns'"]
    B -->|no| D["'X nouns'"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
|---|---|---|
| `shared/components/List/listCountLabel.ts` (new) | Pure formatter for `"X" / "X of Y nouns"` | Shared by `List` and the Racks page label |
| `shared/components/List/List.tsx` | New `totalUnfiltered` prop (feeds count line); new opt-in `filtersClassName` prop (replaces default `py-6`) | Both additive/optional — confirm existing consumers (Schedules, Groups, AuthenticateMiners, pickers) are unaffected |
| `protoFleet/store/slices/uiSlice.ts` | Added non-persisted `sitesRevision` + `bumpSitesRevision()` | Confirm it is not added to persistence partialize |
| `components/PageHeader/PageHeader.tsx` | Refetch sites when `sitesRevision` changes | The new cross-tree refresh path |
| `features/sites/hooks/useSiteModals.ts` | Create flow assigns staged buildings after CreateSite; bumps `sitesRevision` on create/rename/delete | Largest logic change (+74/-32); review the create-then-assign sequencing and partial-failure handling |
| `features/sites/components/ManageSiteModal/ManageSiteModal.tsx` | Create mode keeps a building working set; picker opens with `siteId 0n`; removed the "save first" gate | Create-mode building staging |
| `features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx` | `refreshSitesAndBump` also bumps `sitesRevision` | Covers the bulk "New site" path |
| `features/fleetManagement/components/SiteList/SiteList.tsx`, `pages/FleetSitesPage.tsx` | Enable count line; unfiltered denominator = in-memory site list length | Free denominator (no extra fetch) |
| `features/fleetManagement/components/BuildingList/BuildingList.tsx`, `pages/FleetBuildingsPage.tsx` | Enable count line; scope-only unfiltered count fetched when filters active | Review the conditional fetch effect |
| `features/fleetManagement/pages/RacksPage.tsx` | Page-level count label under filter chips; scope-only unfiltered count via `pageSize:1` listRacks | Grid view is not a `List`, hence page-level label |
| `features/fleetManagement/components/MinerList/MinerList.tsx` | Count moved into the `List` line; `filtersClassName` spacing; `topRef` collapses when no title | Confirm the count still shows after initial load |

## Key technical decisions & trade-offs

- **`sitesRevision` nonce in the UI store** rather than lifting the site list into shared state or a query cache. It is a UI refresh signal (not cached RPC data), keeping the store's role as UI-only intact and avoiding a larger refactor of how `PageHeader` and the fleet pages each fetch sites.
- **Create-then-assign for site creation** is two non-atomic RPCs (`CreateSite` then `AssignBuildingsToSite`). On assign failure the site still exists, so it reports partial success rather than failing the whole operation — consistent with the existing bulk seeded flow. Alternative (a single transactional RPC) would require a server change and is out of scope.
- **Buildings/Racks unfiltered count via a separate scope-only fetch**, gated to when filters are active. Sites gets its denominator for free from the in-memory list; Buildings/Racks are server-filtered with no client-side unfiltered set, so a small count query is the cheapest correct denominator.
- **Opt-in `List` props (`totalUnfiltered`, `filtersClassName`)** instead of changing `List` defaults, since several unrelated lists render filter rows and a count and would otherwise shift.
- **Count hidden during the Miners initial load** (it now lives in the `List`, which mounts after load). `loading` is only true until the first load completes, so the count shows persistently afterward — consistent with the other tabs, which show their count with the loaded list.

## Testing & validation

- Unit test for `formatListCountLabel` (plain/singular/`X of Y`/denominator-singular/match/unknown-total cases).
- Updated `useSiteModals` tests: create with no staged buildings skips the assign RPC; create with staged buildings assigns them to the new site id.
- Updated `ManageSiteModal` test: create mode exposes the add-buildings affordance and enables Save (replacing the old "save first" gate assertion).
- Updated 3 Miners count-subtitle tests to render the loaded state (count now lives in the `List`).
- Full client `tsc` clean, ESLint clean, Prettier clean. Targeted Vitest sweep across List / fleetManagement / sites / store / PageHeader / DeviceSetList: 1112 passing (1 skipped).
- Not covered by automated tests: the exact filter-row spacing/visual alignment (verified manually) and the Buildings/Racks unfiltered-count fetch behavior (logic is straightforward; relies on existing list APIs).
