### PR TITLE
Curtailment: show site names for site-scoped displays

### DIFF
--- a/client/src/protoFleet/api/curtailmentMappers.ts
+++ b/client/src/protoFleet/api/curtailmentMappers.ts
@@ -5,6 +5,7 @@ import {
   CurtailmentMode as ProtoCurtailmentMode,
   CurtailmentPriority as ProtoCurtailmentPriority,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
+import { getSiteDisplayName, type SiteNameById } from "@/protoFleet/api/siteNames";
 import type { ActiveCurtailmentEvent } from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
 import {
   getActiveCurtailmentDisplayState,
@@ -28,6 +29,10 @@ const selectedCountSnapshotKeys = ["selected_count", "selectedCount"] as const;
 interface ObservedPowerSummary {
   observedReductionKw: number;
   remainingPowerKw?: number;
+}
+
+interface CurtailmentMapperOptions {
+  siteNameById?: SiteNameById;
 }
 
 export function timestampToIsoString(timestamp?: Timestamp): string | undefined {
@@ -69,16 +74,19 @@ function mapCurtailmentModeToFormValue(event: ProtoCurtailmentEvent): Curtailmen
 
 function mapCurtailmentEventScopeToFormValues(
   event: ProtoCurtailmentEvent,
+  options: CurtailmentMapperOptions = {},
 ): Pick<CurtailmentSubmitValues, "scopeType" | "scopeId" | "siteId" | "deviceSetIds" | "deviceIdentifiers"> {
   switch (event.scope.case) {
-    case "site":
+    case "site": {
+      const siteId = event.scope.value.siteId.toString();
       return {
         scopeType: "site",
-        scopeId: `site-${event.scope.value.siteId.toString()}`,
-        siteId: event.scope.value.siteId.toString(),
+        scopeId: getSiteDisplayName(siteId, options.siteNameById),
+        siteId,
         deviceSetIds: [],
         deviceIdentifiers: [],
       };
+    }
     case "deviceIdentifiers":
       return {
         scopeType: "explicitMiners",
@@ -107,13 +115,16 @@ function mapCurtailmentEventScopeToFormValues(
   }
 }
 
-export function mapCurtailmentEventToFormValues(event: ProtoCurtailmentEvent): CurtailmentSubmitValues {
+export function mapCurtailmentEventToFormValues(
+  event: ProtoCurtailmentEvent,
+  options: CurtailmentMapperOptions = {},
+): CurtailmentSubmitValues {
   const fixedKwTarget = getFixedKwTarget(event);
   const fixedKwTolerance = getFixedKwTolerance(event);
   const hasCurtailBatchSize = (event.curtailBatchSize ?? 0) > 0;
 
   return {
-    ...mapCurtailmentEventScopeToFormValues(event),
+    ...mapCurtailmentEventScopeToFormValues(event, options),
     responseProfileId: "customPlan",
     curtailmentMode: mapCurtailmentModeToFormValue(event),
     minerSelectionStrategy: "leastEfficientFirst",
@@ -186,7 +197,10 @@ function getObservedPowerSummary(event: ProtoCurtailmentEvent, estimatedReductio
   };
 }
 
-export function mapActiveCurtailmentEvent(event: ProtoCurtailmentEvent): ActiveCurtailmentEvent {
+export function mapActiveCurtailmentEvent(
+  event: ProtoCurtailmentEvent,
+  options: CurtailmentMapperOptions = {},
+): ActiveCurtailmentEvent {
   const estimatedReductionKw = getCurtailmentEventEstimatedReductionKw(event);
   const observedPowerSummary = getObservedPowerSummary(event, estimatedReductionKw);
   const externalSource = event.externalSource.trim();
@@ -194,7 +208,7 @@ export function mapActiveCurtailmentEvent(event: ProtoCurtailmentEvent): ActiveC
   return {
     reason: event.reason || "Curtailment",
     state: mapCurtailmentEventState(event.state),
-    scopeLabel: getCurtailmentEventScopeLabel(event),
+    scopeLabel: getCurtailmentEventScopeLabel(event, options.siteNameById),
     sourceLabel: getSourceLabel(externalSource),
     isAutomationOwned: isAutomationExternalSource(externalSource),
     endedAt: timestampToIsoString(event.endedAt),
@@ -209,7 +223,10 @@ export function mapActiveCurtailmentEvent(event: ProtoCurtailmentEvent): ActiveC
   };
 }
 
-export function mapCurtailmentHistoryEvent(event: ProtoCurtailmentEvent): CurtailmentHistoryEvent {
+export function mapCurtailmentHistoryEvent(
+  event: ProtoCurtailmentEvent,
+  options: CurtailmentMapperOptions = {},
+): CurtailmentHistoryEvent {
   const externalSource = event.externalSource.trim();
 
   return {
@@ -217,7 +234,7 @@ export function mapCurtailmentHistoryEvent(event: ProtoCurtailmentEvent): Curtai
     reason: event.reason || "Curtailment",
     state: mapCurtailmentEventState(event.state),
     priority: mapCurtailmentPriority(event.priority),
-    scopeLabel: getCurtailmentEventScopeLabel(event),
+    scopeLabel: getCurtailmentEventScopeLabel(event, options.siteNameById),
     selectedMiners: getCurtailmentEventSelectedMinerCount(event),
     estimatedReductionKw: getCurtailmentEventEstimatedReductionKw(event),
     targetMetricsAvailable: hasCurtailmentTargetMetrics(event),
@@ -230,8 +247,11 @@ export function mapCurtailmentHistoryEvent(event: ProtoCurtailmentEvent): Curtai
   };
 }
 
-export function mapActiveCurtailmentHistoryEvent(event: ProtoCurtailmentEvent): CurtailmentHistoryEvent {
-  const historyEvent = mapCurtailmentHistoryEvent(event);
+export function mapActiveCurtailmentHistoryEvent(
+  event: ProtoCurtailmentEvent,
+  options: CurtailmentMapperOptions = {},
+): CurtailmentHistoryEvent {
+  const historyEvent = mapCurtailmentHistoryEvent(event, options);
 
   if (!isActiveCurtailmentEventState(historyEvent.state)) {
     return historyEvent;
@@ -239,7 +259,7 @@ export function mapActiveCurtailmentHistoryEvent(event: ProtoCurtailmentEvent): 
 
   return {
     ...historyEvent,
-    displayState: getActiveCurtailmentDisplayState(mapActiveCurtailmentEvent(event), {
+    displayState: getActiveCurtailmentDisplayState(mapActiveCurtailmentEvent(event, options), {
       dispatchStartedAsCurtailing: true,
     }),
   };

--- a/client/src/protoFleet/api/siteNames.ts
+++ b/client/src/protoFleet/api/siteNames.ts
@@ -1,0 +1,27 @@
+import type { SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+
+export type SiteNameById = ReadonlyMap<string, string>;
+
+export function buildSiteNameById(sites: readonly SiteWithCounts[] | undefined): Map<string, string> {
+  const siteNameById = new Map<string, string>();
+
+  for (const { site } of sites ?? []) {
+    const siteId = site?.id?.toString() ?? "0";
+    const siteName = site?.name?.trim() ?? "";
+
+    if (siteId !== "0" && siteName) {
+      siteNameById.set(siteId, siteName);
+    }
+  }
+
+  return siteNameById;
+}
+
+export function getSiteDisplayName(siteId: bigint | string, siteNameById?: SiteNameById): string {
+  const siteIdText = siteId.toString().trim();
+  if (!siteIdText || siteIdText === "0") {
+    return "";
+  }
+
+  return siteNameById?.get(siteIdText)?.trim() || `Site ${siteIdText}`;
+}

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -20,6 +20,7 @@ import {
   CurtailmentTargetSchema,
   CurtailmentTargetState,
   FixedKwParamsSchema,
+  ScopeSiteSchema,
   ScopeWholeOrgSchema,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import { useCurtailmentApi } from "@/protoFleet/api/useCurtailmentApi";
@@ -335,6 +336,69 @@ describe("useCurtailmentApi", () => {
       }),
     );
     expect(result.current.activeEvent?.targetKw).toBeUndefined();
+  });
+
+  it("uses loaded site names for site-scoped active and history events", async () => {
+    const siteScopedEvent = curtailmentEvent({
+      scope: {
+        case: "site",
+        value: create(ScopeSiteSchema, { siteId: 101n }),
+      },
+    });
+    mockListActiveCurtailments.mockResolvedValueOnce({ event: siteScopedEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [siteScopedEvent], nextPageToken: "" });
+    const siteNameById = new Map([["101", "Austin, TX"]]);
+
+    const { result } = renderHook(() => useCurtailmentApi({ siteNameById }));
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent).toEqual(
+      expect.objectContaining({
+        scopeLabel: "Austin, TX",
+      }),
+    );
+    expect(result.current.activeEventFormValues).toEqual(
+      expect.objectContaining({
+        scopeType: "site",
+        scopeId: "Austin, TX",
+        siteId: "101",
+      }),
+    );
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        scopeLabel: "Austin, TX",
+      }),
+    );
+  });
+
+  it("falls back to Site id labels for site-scoped events without a loaded site name", async () => {
+    const siteScopedEvent = curtailmentEvent({
+      scope: {
+        case: "site",
+        value: create(ScopeSiteSchema, { siteId: 101n }),
+      },
+    });
+    mockListActiveCurtailments.mockResolvedValueOnce({ event: siteScopedEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [siteScopedEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent?.scopeLabel).toBe("Site 101");
+    expect(result.current.activeEventFormValues).toEqual(
+      expect.objectContaining({
+        scopeType: "site",
+        scopeId: "Site 101",
+        siteId: "101",
+      }),
+    );
+    expect(result.current.historyEvents[0]?.scopeLabel).toBe("Site 101");
   });
 
   it("estimates observed reduction from confirmed targets when telemetry is absent", async () => {

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -32,6 +32,7 @@ import {
   StopCurtailmentRequestSchema,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import { assertNotAborted, isAbortError, isAuthOrPermissionError, toError } from "@/protoFleet/api/requestErrors";
+import type { SiteNameById } from "@/protoFleet/api/siteNames";
 import type { ActiveCurtailmentEvent } from "@/protoFleet/features/energy/ActiveCurtailmentStatus";
 import {
   type CurtailmentEventState,
@@ -51,6 +52,10 @@ export interface RefreshCurtailmentOptions {
   historyPage?: number;
   includeActive?: boolean;
   signal?: AbortSignal;
+}
+
+export interface UseCurtailmentApiOptions {
+  siteNameById?: SiteNameById;
 }
 
 interface CurtailmentSnapshot {
@@ -218,7 +223,10 @@ function mapAdminTerminateState(targetState: AdminTerminateCurtailmentState): Pr
   return adminTerminateStateMap[targetState];
 }
 
-function getActiveSnapshotEvent(activeEvent: ProtoCurtailmentEvent | undefined): ActiveCurtailmentEvent | null {
+function getActiveSnapshotEvent(
+  activeEvent: ProtoCurtailmentEvent | undefined,
+  siteNameById?: SiteNameById,
+): ActiveCurtailmentEvent | null {
   if (!activeEvent) {
     return null;
   }
@@ -228,18 +236,20 @@ function getActiveSnapshotEvent(activeEvent: ProtoCurtailmentEvent | undefined):
     return null;
   }
 
-  return mapActiveCurtailmentEvent(activeEvent);
+  return mapActiveCurtailmentEvent(activeEvent, { siteNameById });
 }
 
 function getActiveSnapshotFields(
   activeEvent: ProtoCurtailmentEvent | undefined,
+  siteNameById?: SiteNameById,
 ): Omit<CurtailmentSnapshot, "activeEvents" | "historyEvents"> {
-  const nextActiveEvent = getActiveSnapshotEvent(activeEvent);
+  const nextActiveEvent = getActiveSnapshotEvent(activeEvent, siteNameById);
 
   return {
     activeEvent: nextActiveEvent,
     activeEventId: activeEvent && nextActiveEvent ? activeEvent.eventUuid : null,
-    activeEventFormValues: activeEvent && nextActiveEvent ? mapCurtailmentEventToFormValues(activeEvent) : null,
+    activeEventFormValues:
+      activeEvent && nextActiveEvent ? mapCurtailmentEventToFormValues(activeEvent, { siteNameById }) : null,
   };
 }
 
@@ -253,8 +263,9 @@ function markInjectedActiveHistoryEvent(event: CurtailmentHistoryEvent): Curtail
 function getActiveHistoryEvent(
   activeEvent: ProtoCurtailmentEvent,
   historyEvents: CurtailmentHistoryEvent[],
+  siteNameById?: SiteNameById,
 ): CurtailmentHistoryEvent {
-  const mappedActiveEvent = mapActiveCurtailmentHistoryEvent(activeEvent);
+  const mappedActiveEvent = mapActiveCurtailmentHistoryEvent(activeEvent, { siteNameById });
   const matchingHistoryEvent = historyEvents.find((event) => event.id === mappedActiveEvent.id);
 
   if (!matchingHistoryEvent) {
@@ -389,10 +400,11 @@ function getActiveHistoryEvents(
   selectedActiveEvent: ProtoCurtailmentEvent | undefined,
   historyEvents: CurtailmentHistoryEvent[],
   stateFilters: readonly CurtailmentEventState[] = [],
+  siteNameById?: SiteNameById,
 ): CurtailmentHistoryEvent[] {
   return getActiveEventInputs(activeEvents, selectedActiveEvent)
     .filter((event) => shouldIncludeActiveEventInHistory(event, stateFilters))
-    .map((event) => getActiveHistoryEvent(event, historyEvents));
+    .map((event) => getActiveHistoryEvent(event, historyEvents, siteNameById));
 }
 
 function createSnapshot(
@@ -401,9 +413,10 @@ function createSnapshot(
   historyEvents: ProtoCurtailmentEvent[],
   stateFilters: readonly CurtailmentEventState[] = [],
   includeActiveInHistory = true,
+  siteNameById?: SiteNameById,
 ): CurtailmentSnapshot {
-  const nextHistoryEvents = historyEvents.map(mapCurtailmentHistoryEvent);
-  const activeHistoryEvents = getActiveHistoryEvents(activeEvents, activeEvent, nextHistoryEvents);
+  const nextHistoryEvents = historyEvents.map((event) => mapCurtailmentHistoryEvent(event, { siteNameById }));
+  const activeHistoryEvents = getActiveHistoryEvents(activeEvents, activeEvent, nextHistoryEvents, [], siteNameById);
 
   if (includeActiveInHistory && activeHistoryEvents.length > 0) {
     const filteredActiveHistoryEvents = getActiveHistoryEvents(
@@ -411,10 +424,11 @@ function createSnapshot(
       activeEvent,
       nextHistoryEvents,
       stateFilters,
+      siteNameById,
     );
     const filteredActiveEventIds = new Set(filteredActiveHistoryEvents.map((event) => event.id));
     return {
-      ...getActiveSnapshotFields(activeEvent),
+      ...getActiveSnapshotFields(activeEvent, siteNameById),
       activeEvents: activeHistoryEvents,
       historyEvents: [
         ...filteredActiveHistoryEvents,
@@ -424,7 +438,7 @@ function createSnapshot(
   }
 
   return {
-    ...getActiveSnapshotFields(activeEvent),
+    ...getActiveSnapshotFields(activeEvent, siteNameById),
     activeEvents: activeHistoryEvents,
     historyEvents: nextHistoryEvents,
   };
@@ -533,12 +547,19 @@ function getHistoryEventsWithActiveEvent(
   selectedActiveEvent: ProtoCurtailmentEvent | undefined,
   stateFilters: readonly CurtailmentEventState[],
   currentPage: number,
+  siteNameById?: SiteNameById,
 ): CurtailmentHistoryEvent[] {
   if (currentPage !== 0) {
     return events;
   }
 
-  const activeHistoryEvents = getActiveHistoryEvents(activeEvents, selectedActiveEvent, events, stateFilters);
+  const activeHistoryEvents = getActiveHistoryEvents(
+    activeEvents,
+    selectedActiveEvent,
+    events,
+    stateFilters,
+    siteNameById,
+  );
   if (activeHistoryEvents.length === 0) {
     return removeInjectedActiveHistoryEvent(events);
   }
@@ -553,11 +574,12 @@ function getHistoryEventsWithActiveEvent(
 function upsertHistoryEvent(
   events: CurtailmentHistoryEvent[],
   event: ProtoCurtailmentEvent,
+  siteNameById?: SiteNameById,
 ): CurtailmentHistoryEvent[] {
   const state = mapCurtailmentEventState(event.state);
   const mappedEvent = visibleActiveCurtailmentEventStates.has(state)
-    ? mapActiveCurtailmentHistoryEvent(event)
-    : mapCurtailmentHistoryEvent(event);
+    ? mapActiveCurtailmentHistoryEvent(event, { siteNameById })
+    : mapCurtailmentHistoryEvent(event, { siteNameById });
   return [mappedEvent, ...events.filter((currentEvent) => currentEvent.id !== mappedEvent.id)];
 }
 
@@ -578,7 +600,8 @@ function getSafeNextPageToken(
   return nextPageToken === currentPageToken || seenPageTokens.has(nextPageToken) ? "" : nextPageToken;
 }
 
-export function useCurtailmentApi(): UseCurtailmentApiResult {
+export function useCurtailmentApi(options: UseCurtailmentApiOptions = {}): UseCurtailmentApiResult {
+  const { siteNameById } = options;
   const { handleAuthErrors } = useAuthErrors();
   const activeCurtailmentEvent = useActiveCurtailmentEvent();
   const activeCurtailmentEvents = useActiveCurtailmentEvents();
@@ -643,7 +666,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       });
       activeReconciliationSnapshotRef.current = activeSnapshot;
       const nextActiveSnapshotEvent = activeSnapshot.event;
-      const nextActiveEvent = getActiveSnapshotEvent(nextActiveSnapshotEvent);
+      const nextActiveEvent = getActiveSnapshotEvent(nextActiveSnapshotEvent, siteNameById);
       const activeStatusFilters = historyStatusFiltersRef.current;
       const shouldUpdateHistoryPage =
         historyPaginationRef.current.currentPage === 0 &&
@@ -656,16 +679,19 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
           activeSnapshot.event,
           current.historyEvents,
           activeStatusFilters,
+          siteNameById,
         ),
         activeEventId: nextActiveSnapshotEvent && nextActiveEvent ? nextActiveSnapshotEvent.eventUuid : null,
         activeEventFormValues:
-          nextActiveSnapshotEvent && nextActiveEvent ? mapCurtailmentEventToFormValues(nextActiveSnapshotEvent) : null,
+          nextActiveSnapshotEvent && nextActiveEvent
+            ? mapCurtailmentEventToFormValues(nextActiveSnapshotEvent, { siteNameById })
+            : null,
         historyEvents: shouldUpdateHistoryPage
-          ? upsertHistoryEvent(current.historyEvents, event)
+          ? upsertHistoryEvent(current.historyEvents, event, siteNameById)
           : current.historyEvents,
       }));
     },
-    [updateSnapshot],
+    [siteNameById, updateSnapshot],
   );
 
   const listCurtailmentEventsPage = useCallback(
@@ -905,6 +931,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
             historyPageResponse.events,
             stateFilters,
             historyPage === 0,
+            siteNameById,
           );
           if (requestId !== latestRefreshRequestIdRef.current) {
             return previewSnapshot;
@@ -950,7 +977,14 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
           const nextSnapshot =
             activeEvent === previewActiveEvent && preservedRestoringEvents.length === 0
               ? previewSnapshot
-              : createSnapshot(activeEvent, activeEvents, historyPageResponse.events, stateFilters, historyPage === 0);
+              : createSnapshot(
+                  activeEvent,
+                  activeEvents,
+                  historyPageResponse.events,
+                  stateFilters,
+                  historyPage === 0,
+                  siteNameById,
+                );
 
           const nextPageTokens = currentPagination.pageTokens.slice(0, historyPage + 1);
           nextPageTokens[historyPage] = pageToken || undefined;
@@ -988,6 +1022,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       getHistoryEventsForActiveReconciliation,
       handleFailure,
       listCurtailmentEventsPage,
+      siteNameById,
       updateHistoryPagination,
       updateSnapshot,
     ],
@@ -1051,7 +1086,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
       try {
         const activeSnapshot = await selectActiveCurtailmentEvent(eventUuid, { signal });
         activeReconciliationSnapshotRef.current = activeSnapshot;
-        const activeSnapshotFields = getActiveSnapshotFields(activeSnapshot.event);
+        const activeSnapshotFields = getActiveSnapshotFields(activeSnapshot.event, siteNameById);
         const activeStatusFilters = historyStatusFiltersRef.current;
         updateSnapshot((current) => ({
           ...current,
@@ -1061,6 +1096,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
             activeSnapshot.event,
             current.historyEvents,
             activeStatusFilters,
+            siteNameById,
           ),
           historyEvents: getHistoryEventsWithActiveEvent(
             current.historyEvents,
@@ -1068,6 +1104,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
             activeSnapshot.event,
             activeStatusFilters,
             historyPaginationRef.current.currentPage,
+            siteNameById,
           ),
         }));
         setLoadError(null);
@@ -1085,7 +1122,7 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
         throw resolvedError;
       }
     },
-    [handleFailure, updateSnapshot],
+    [handleFailure, siteNameById, updateSnapshot],
   );
 
   const startCurtailment = useCallback(
@@ -1209,10 +1246,14 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
     activeReconciliationSnapshotRef.current = dismissActiveCurtailmentEvent(activeCurtailmentEvent?.eventUuid);
   }, [activeCurtailmentEvent]);
 
-  const activeSnapshotFields = useMemo(() => getActiveSnapshotFields(activeCurtailmentEvent), [activeCurtailmentEvent]);
+  const activeSnapshotFields = useMemo(
+    () => getActiveSnapshotFields(activeCurtailmentEvent, siteNameById),
+    [activeCurtailmentEvent, siteNameById],
+  );
   const activeHistoryEvents = useMemo(
-    () => getActiveHistoryEvents(activeCurtailmentEvents, activeCurtailmentEvent, snapshot.historyEvents),
-    [activeCurtailmentEvent, activeCurtailmentEvents, snapshot.historyEvents],
+    () =>
+      getActiveHistoryEvents(activeCurtailmentEvents, activeCurtailmentEvent, snapshot.historyEvents, [], siteNameById),
+    [activeCurtailmentEvent, activeCurtailmentEvents, siteNameById, snapshot.historyEvents],
   );
   const historyStatusFilter = historyStatusFilters[0];
   const historyEvents = useMemo(
@@ -1223,12 +1264,14 @@ export function useCurtailmentApi(): UseCurtailmentApiResult {
         activeCurtailmentEvent,
         historyStatusFilters,
         historyPagination.currentPage,
+        siteNameById,
       ),
     [
       activeCurtailmentEvent,
       activeCurtailmentEvents,
       historyPagination.currentPage,
       historyStatusFilters,
+      siteNameById,
       snapshot.historyEvents,
     ],
   );

--- a/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
+++ b/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
@@ -235,7 +235,7 @@ describe("useCurtailmentResponseProfiles", () => {
         useCurtailmentResponseProfiles(true, { siteNameById }),
       {
         initialProps: {
-          siteNameById: undefined,
+          siteNameById: undefined as Map<string, string> | undefined,
         },
       },
     );

--- a/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
+++ b/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 
@@ -225,6 +225,35 @@ describe("useCurtailmentResponseProfiles", () => {
         siteName: "Austin, TX",
       }),
     });
+  });
+
+  it("remaps loaded profiles when site names arrive without refetching profiles", async () => {
+    mockListCurtailmentResponseProfiles.mockResolvedValueOnce({ profiles: [apiProfile()] });
+
+    const { result, rerender } = renderHook(
+      ({ siteNameById }: { siteNameById?: Map<string, string> }) =>
+        useCurtailmentResponseProfiles(true, { siteNameById }),
+      {
+        initialProps: {
+          siteNameById: undefined,
+        },
+      },
+    );
+
+    await waitFor(() => expect(result.current.responseProfiles[0]?.scope).toBe("Site 101"));
+
+    rerender({
+      siteNameById: new Map([["101", "Austin, TX"]]),
+    });
+
+    expect(result.current.responseProfiles[0]).toMatchObject({
+      scope: "Austin, TX",
+      formValues: expect.objectContaining({
+        siteId: "101",
+        siteName: "Austin, TX",
+      }),
+    });
+    expect(mockListCurtailmentResponseProfiles).toHaveBeenCalledTimes(1);
   });
 
   it("treats default zero curtail batch intervals as unset without a batch size", async () => {

--- a/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
+++ b/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
@@ -208,6 +208,25 @@ describe("useCurtailmentResponseProfiles", () => {
     });
   });
 
+  it("uses loaded site names for site-scoped API profiles", async () => {
+    mockListCurtailmentResponseProfiles.mockResolvedValueOnce({ profiles: [apiProfile()] });
+    const siteNameById = new Map([["101", "Austin, TX"]]);
+
+    const { result } = renderHook(() => useCurtailmentResponseProfiles(false, { siteNameById }));
+
+    await act(async () => {
+      await result.current.listResponseProfiles();
+    });
+
+    expect(result.current.responseProfiles[0]).toMatchObject({
+      scope: "Austin, TX",
+      formValues: expect.objectContaining({
+        siteId: "101",
+        siteName: "Austin, TX",
+      }),
+    });
+  });
+
   it("treats default zero curtail batch intervals as unset without a batch size", async () => {
     mockListCurtailmentResponseProfiles.mockResolvedValueOnce({
       profiles: [apiProfile({ curtailBatchSize: 0, curtailBatchIntervalSec: 0 })],

--- a/client/src/protoFleet/api/useCurtailmentResponseProfiles.ts
+++ b/client/src/protoFleet/api/useCurtailmentResponseProfiles.ts
@@ -17,6 +17,7 @@ import {
   UpdateCurtailmentResponseProfileRequestSchema,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import { assertNotAborted, isAbortError, toError } from "@/protoFleet/api/requestErrors";
+import { getSiteDisplayName, type SiteNameById } from "@/protoFleet/api/siteNames";
 import type {
   ResponseProfile,
   ResponseProfileFormValues,
@@ -38,6 +39,10 @@ export type UseCurtailmentResponseProfilesResult = {
   updateResponseProfile: (profileId: string, values: ResponseProfileFormValues) => Promise<ResponseProfile>;
   deleteResponseProfile: (profileId: string) => Promise<void>;
 };
+
+interface UseCurtailmentResponseProfilesOptions {
+  siteNameById?: SiteNameById;
+}
 
 function numberToInputValue(value: number | undefined): string {
   return value && Number.isFinite(value) && value > 0 ? value.toString() : "";
@@ -81,10 +86,20 @@ function getPersistedResponseProfileFormValues(values: ResponseProfileFormValues
   };
 }
 
-function mapApiResponseProfile(profile: ApiCurtailmentResponseProfile): ResponseProfile {
+function getResponseProfileSiteName(
+  siteId: string,
+  cachedFormValues?: ResponseProfileFormValues,
+  siteNameById?: SiteNameById,
+): string {
+  const loadedSiteName = siteNameById?.get(siteId)?.trim();
+  const cachedSiteName = cachedFormValues?.siteName.trim();
+  return loadedSiteName || cachedSiteName || getSiteDisplayName(siteId);
+}
+
+function mapApiResponseProfile(profile: ApiCurtailmentResponseProfile, siteNameById?: SiteNameById): ResponseProfile {
   const cachedFormValues = sessionFormValuesByProfileId.get(profile.profileId.toString());
   const siteId = profile.site?.siteId ? profile.site.siteId.toString() : "";
-  const siteName = siteId ? cachedFormValues?.siteName || `Site ${siteId}` : "";
+  const siteName = siteId ? getResponseProfileSiteName(siteId, cachedFormValues, siteNameById) : "";
   const fixedKw = profile.modeParams.case === "fixedKw" ? profile.modeParams.value.targetKw : undefined;
   const actionType: ResponseProfileFormValues["actionType"] =
     profile.mode === CurtailmentMode.FIXED_KW ? "fixedKwReduction" : "fullFleet";
@@ -216,7 +231,11 @@ function buildResponseProfilePayload(values: ResponseProfileFormValues) {
   };
 }
 
-export default function useCurtailmentResponseProfiles(enabled = true): UseCurtailmentResponseProfilesResult {
+export default function useCurtailmentResponseProfiles(
+  enabled = true,
+  options: UseCurtailmentResponseProfilesOptions = {},
+): UseCurtailmentResponseProfilesResult {
+  const { siteNameById } = options;
   const { handleAuthErrors } = useAuthErrors();
   const [apiProfiles, setApiProfiles] = useState<ApiCurtailmentResponseProfile[]>([]);
   const [isLoading, setIsLoading] = useState(enabled);
@@ -226,7 +245,10 @@ export default function useCurtailmentResponseProfiles(enabled = true): UseCurta
   const [createError, setCreateError] = useState<string | null>(null);
   const hasLoadedProfilesRef = useRef(false);
 
-  const responseProfiles = useMemo(() => apiProfiles.map((profile) => mapApiResponseProfile(profile)), [apiProfiles]);
+  const responseProfiles = useMemo(
+    () => apiProfiles.map((profile) => mapApiResponseProfile(profile, siteNameById)),
+    [apiProfiles, siteNameById],
+  );
 
   const handleFailure = useCallback(
     (error: unknown, fallbackMessage: string): Error => {
@@ -238,8 +260,8 @@ export default function useCurtailmentResponseProfiles(enabled = true): UseCurta
   );
 
   const mapProfile = useCallback(
-    (profile: ApiCurtailmentResponseProfile): ResponseProfile => mapApiResponseProfile(profile),
-    [],
+    (profile: ApiCurtailmentResponseProfile): ResponseProfile => mapApiResponseProfile(profile, siteNameById),
+    [siteNameById],
   );
 
   const listResponseProfiles = useCallback(

--- a/client/src/protoFleet/api/useCurtailmentResponseProfiles.ts
+++ b/client/src/protoFleet/api/useCurtailmentResponseProfiles.ts
@@ -236,6 +236,8 @@ export default function useCurtailmentResponseProfiles(
   options: UseCurtailmentResponseProfilesOptions = {},
 ): UseCurtailmentResponseProfilesResult {
   const { siteNameById } = options;
+  const siteNameByIdRef = useRef<SiteNameById | undefined>(siteNameById);
+  siteNameByIdRef.current = siteNameById;
   const { handleAuthErrors } = useAuthErrors();
   const [apiProfiles, setApiProfiles] = useState<ApiCurtailmentResponseProfile[]>([]);
   const [isLoading, setIsLoading] = useState(enabled);
@@ -282,7 +284,7 @@ export default function useCurtailmentResponseProfiles(
         setApiProfiles(response.profiles);
         hasLoadedProfilesRef.current = true;
         setLoadError(null);
-        return response.profiles.map(mapProfile);
+        return response.profiles.map((profile) => mapApiResponseProfile(profile, siteNameByIdRef.current));
       } catch (error) {
         if (isAbortError(error, signal)) {
           throw error;
@@ -297,7 +299,7 @@ export default function useCurtailmentResponseProfiles(
         }
       }
     },
-    [handleFailure, mapProfile],
+    [handleFailure],
   );
 
   useEffect(() => {

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   adminTerminateCurtailment: vi.fn(),
   dismissTerminalCurtailment: vi.fn(),
   goToHistoryPage: vi.fn(),
+  listSites: vi.fn(),
   navigate: vi.fn(),
   refreshCurtailment: vi.fn(),
   selectActiveCurtailment: vi.fn(),
@@ -25,17 +26,28 @@ const mocks = vi.hoisted(() => ({
   stopCurtailment: vi.fn(),
   submitValues: { reason: "Grid peak" },
   updateCurtailment: vi.fn(),
+  useHasPermission: vi.fn(),
   useCurtailmentApi: vi.fn(),
   useCurtailmentResponseProfiles: vi.fn(),
 }));
 
 vi.mock("@/protoFleet/api/useCurtailmentApi", () => ({
   adminTerminateReasonRequiredMessage: "Enter a reason before terminating the event.",
-  useCurtailmentApi: () => mocks.useCurtailmentApi(),
+  useCurtailmentApi: (options?: unknown) => mocks.useCurtailmentApi(options),
 }));
 
 vi.mock("@/protoFleet/api/useCurtailmentResponseProfiles", () => ({
-  default: () => mocks.useCurtailmentResponseProfiles(),
+  default: (...args: unknown[]) => mocks.useCurtailmentResponseProfiles(...args),
+}));
+
+vi.mock("@/protoFleet/api/sites", () => ({
+  useSites: () => ({
+    listSites: mocks.listSites,
+  }),
+}));
+
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: (key: string) => mocks.useHasPermission(key),
 }));
 
 vi.mock("react-router-dom", () => ({
@@ -302,6 +314,10 @@ function createApiResult(overrides: Partial<UseCurtailmentApiResult> = {}): UseC
 describe("CurtailmentManagementPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.listSites.mockImplementation(({ onSuccess, onFinally } = {}) => {
+      onSuccess?.([{ site: { id: 101n, name: "Austin, TX" } }]);
+      onFinally?.();
+    });
     mocks.refreshCurtailment.mockResolvedValue(emptySnapshot);
     mocks.goToHistoryPage.mockResolvedValue(emptySnapshot);
     mocks.selectActiveCurtailment.mockResolvedValue({
@@ -315,6 +331,7 @@ describe("CurtailmentManagementPanel", () => {
     mocks.stopCurtailment.mockResolvedValue({});
     mocks.adminTerminateCurtailment.mockResolvedValue({});
     mocks.updateCurtailment.mockResolvedValue({});
+    mocks.useHasPermission.mockReturnValue(false);
     mocks.useCurtailmentApi.mockReturnValue(createApiResult());
     mocks.useCurtailmentResponseProfiles.mockReturnValue({
       responseProfiles: [],
@@ -327,6 +344,26 @@ describe("CurtailmentManagementPanel", () => {
       createResponseProfile: vi.fn(),
       updateResponseProfile: vi.fn(),
       deleteResponseProfile: vi.fn(),
+    });
+  });
+
+  it("loads site names and passes them to curtailment hooks when the operator can read sites", async () => {
+    mocks.useHasPermission.mockImplementation((key: string) => key === "site:read");
+
+    render(<CurtailmentManagementPanel />);
+
+    await waitFor(() => expect(mocks.listSites).toHaveBeenCalled());
+    await waitFor(() => {
+      const latestApiCall = mocks.useCurtailmentApi.mock.calls[mocks.useCurtailmentApi.mock.calls.length - 1];
+      const latestResponseProfileCall =
+        mocks.useCurtailmentResponseProfiles.mock.calls[mocks.useCurtailmentResponseProfiles.mock.calls.length - 1];
+      const apiOptions = latestApiCall?.[0] as { siteNameById?: Map<string, string> } | undefined;
+      const responseProfileOptions = latestResponseProfileCall?.[1] as
+        | { siteNameById?: Map<string, string> }
+        | undefined;
+
+      expect(apiOptions?.siteNameById?.get("101")).toBe("Austin, TX");
+      expect(responseProfileOptions?.siteNameById?.get("101")).toBe("Austin, TX");
     });
   });
 

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -2,6 +2,8 @@ import { type ReactElement, useCallback, useEffect, useMemo, useRef, useState } 
 import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 
+import { buildSiteNameById } from "@/protoFleet/api/siteNames";
+import { useSites } from "@/protoFleet/api/sites";
 import {
   adminTerminateReasonRequiredMessage,
   type AdminTerminateCurtailmentOptions as TerminateRecoveryOptions,
@@ -28,6 +30,7 @@ import type {
   ResponseProfile,
   ResponseProfileFormValues,
 } from "@/protoFleet/features/settings/components/Curtailment/types";
+import { useHasPermission } from "@/protoFleet/store";
 import { Alert } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Dialog, { DialogIcon } from "@/shared/components/Dialog";
@@ -283,6 +286,27 @@ function CurtailmentManagementPanel({
   className,
 }: CurtailmentManagementPanelProps): ReactElement {
   const navigate = useNavigate();
+  const canReadSiteCatalog = useHasPermission("site:read");
+  const { listSites } = useSites();
+  const [loadedSiteNameById, setLoadedSiteNameById] = useState(() => new Map<string, string>());
+  useEffect(() => {
+    if (!canReadSiteCatalog) {
+      return undefined;
+    }
+
+    const abortController = new AbortController();
+    void listSites({
+      signal: abortController.signal,
+      onSuccess: (sites) => {
+        if (!abortController.signal.aborted) {
+          setLoadedSiteNameById(buildSiteNameById(sites));
+        }
+      },
+    });
+
+    return () => abortController.abort();
+  }, [canReadSiteCatalog, listSites]);
+  const siteNameById = canReadSiteCatalog ? loadedSiteNameById : undefined;
   const {
     activeEvent,
     activeEvents,
@@ -313,8 +337,8 @@ function CurtailmentManagementPanel({
     updateCurtailment,
     stopCurtailment,
     adminTerminateCurtailment,
-  } = useCurtailmentApi();
-  const { responseProfiles } = useCurtailmentResponseProfiles(enableManage);
+  } = useCurtailmentApi({ siteNameById });
+  const { responseProfiles } = useCurtailmentResponseProfiles(enableManage, { siteNameById });
   const responseProfileOptions = useMemo(
     () => responseProfiles.map(createCurtailmentResponseProfileOption),
     [responseProfiles],

--- a/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
+++ b/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
@@ -3,6 +3,7 @@ import {
   CurtailmentEventState as ProtoCurtailmentEventState,
   CurtailmentTargetState as ProtoCurtailmentTargetState,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
+import { getSiteDisplayName, type SiteNameById } from "@/protoFleet/api/siteNames";
 
 export const curtailmentEventStateConfigs = {
   pending: {
@@ -293,12 +294,12 @@ export function getCurtailmentEventObservedReductionKw(
     : getEstimatedObservedReductionKw(event, estimatedReductionKw);
 }
 
-export function getCurtailmentEventScopeLabel(event: ProtoCurtailmentEvent): string {
+export function getCurtailmentEventScopeLabel(event: ProtoCurtailmentEvent, siteNameById?: SiteNameById): string {
   switch (event.scope.case) {
     case "wholeOrg":
       return "Whole fleet";
     case "site":
-      return `Site ${event.scope.value.siteId.toString()}`;
+      return getSiteDisplayName(event.scope.value.siteId, siteNameById);
     case "deviceSetIds":
       return `${event.scope.value.deviceSetIds.length.toLocaleString()} device sets`;
     case "deviceIdentifiers": {

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -667,6 +667,49 @@ describe("CurtailmentSettingsPage", () => {
     }
   });
 
+  it("does not auto-retry site name loading after ListSites succeeds with no sites", async () => {
+    vi.useFakeTimers();
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage" || key === "site:read");
+    vi.mocked(useCurtailmentResponseProfiles).mockImplementation(() => ({
+      responseProfiles: [siteScopedResponseProfile],
+      isLoading: false,
+      isCreating: false,
+      updatingProfileIds: new Set<string>(),
+      loadError: null,
+      createError: null,
+      listResponseProfiles: vi.fn(),
+      createResponseProfile: createResponseProfileMock,
+      updateResponseProfile: updateResponseProfileMock,
+      deleteResponseProfile: deleteResponseProfileMock,
+    }));
+    listSitesMock.mockImplementation(
+      ({ onSuccess, onFinally }: { onSuccess?: (sites: SiteWithCounts[]) => void; onFinally?: () => void } = {}) => {
+        onSuccess?.([]);
+        onFinally?.();
+      },
+    );
+
+    try {
+      render(
+        <MemoryRouter>
+          <CurtailmentSettingsPage />
+        </MemoryRouter>,
+      );
+
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+      expect(listSitesMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+      expect(listSitesMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("creates a response profile through the API hook", async () => {
     vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
     createResponseProfileMock.mockResolvedValue(testResponseProfiles[0]);

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
@@ -507,7 +507,7 @@ describe("CurtailmentSettingsPage", () => {
     );
 
     expect(useHasPermission).toHaveBeenCalledWith("curtailment:manage");
-    expect(useCurtailmentResponseProfiles).toHaveBeenCalledWith(true);
+    expect(useCurtailmentResponseProfiles).toHaveBeenCalledWith(true, { siteNameById: undefined });
     expect(useMqttCurtailmentSources).toHaveBeenCalledWith(true);
     expect(useCurtailmentAutomationRules).toHaveBeenCalledWith(true);
     expect(screen.getByTestId("settings-curtailment-page")).toBeVisible();
@@ -582,6 +582,89 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByText("Emergency full shed")).toBeVisible();
     expect(screen.getByText("100% reduction")).toBeVisible();
     expect(within(getResponseProfileCard("Emergency full shed")).getByText("Whole fleet")).toBeVisible();
+  });
+
+  it("loads site names for site-scoped response profile cards after reload", async () => {
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage" || key === "site:read");
+    vi.mocked(useCurtailmentResponseProfiles).mockImplementation((_enabled, options) => {
+      const siteName = options?.siteNameById?.get("101") ?? "Site 101";
+
+      return {
+        responseProfiles: [
+          {
+            ...siteScopedResponseProfile,
+            scope: siteName,
+            formValues: {
+              ...siteScopedResponseProfile.formValues!,
+              siteName,
+            },
+          },
+        ],
+        isLoading: false,
+        isCreating: false,
+        updatingProfileIds: new Set<string>(),
+        loadError: null,
+        createError: null,
+        listResponseProfiles: vi.fn(),
+        createResponseProfile: createResponseProfileMock,
+        updateResponseProfile: updateResponseProfileMock,
+        deleteResponseProfile: deleteResponseProfileMock,
+      };
+    });
+
+    render(
+      <MemoryRouter>
+        <CurtailmentSettingsPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(listSitesMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(within(getResponseProfileCard("Site scoped profile")).getByText("Austin, TX")).toBeVisible(),
+    );
+  });
+
+  it("does not auto-retry site name loading after ListSites fails", async () => {
+    vi.useFakeTimers();
+    vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage" || key === "site:read");
+    vi.mocked(useCurtailmentResponseProfiles).mockImplementation(() => ({
+      responseProfiles: [siteScopedResponseProfile],
+      isLoading: false,
+      isCreating: false,
+      updatingProfileIds: new Set<string>(),
+      loadError: null,
+      createError: null,
+      listResponseProfiles: vi.fn(),
+      createResponseProfile: createResponseProfileMock,
+      updateResponseProfile: updateResponseProfileMock,
+      deleteResponseProfile: deleteResponseProfileMock,
+    }));
+    listSitesMock.mockImplementation(
+      ({ onError, onFinally }: { onError?: (message: string) => void; onFinally?: () => void } = {}) => {
+        onError?.("network down");
+        onFinally?.();
+      },
+    );
+
+    try {
+      render(
+        <MemoryRouter>
+          <CurtailmentSettingsPage />
+        </MemoryRouter>,
+      );
+
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+      expect(listSitesMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+      expect(listSitesMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("creates a response profile through the API hook", async () => {
@@ -1530,7 +1613,7 @@ describe("CurtailmentSettingsPage", () => {
     );
 
     expect(useHasPermission).toHaveBeenCalledWith("curtailment:manage");
-    expect(useCurtailmentResponseProfiles).toHaveBeenCalledWith(false);
+    expect(useCurtailmentResponseProfiles).toHaveBeenCalledWith(false, { siteNameById: undefined });
     expect(useMqttCurtailmentSources).toHaveBeenCalledWith(false);
     expect(useCurtailmentAutomationRules).toHaveBeenCalledWith(false);
     expect(screen.queryByTestId("settings-curtailment-page")).not.toBeInTheDocument();

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -1604,6 +1604,13 @@ function CurtailmentSettingsPage(): ReactElement {
   const [siteOptionsLoadError, setSiteOptionsLoadError] = useState<string | null>(null);
   const siteOptionsAbortControllerRef = useRef<AbortController | null>(null);
   const canLoadSiteOptions = canManageCurtailment && canReadSiteCatalog;
+  const siteNameById = useMemo(() => {
+    if (!canLoadSiteOptions) {
+      return undefined;
+    }
+
+    return new Map(siteOptions.map(({ id, name }) => [id, name]));
+  }, [canLoadSiteOptions, siteOptions]);
   const {
     responseProfiles,
     isLoading: isLoadingResponseProfiles,
@@ -1613,7 +1620,7 @@ function CurtailmentSettingsPage(): ReactElement {
     createResponseProfile,
     updateResponseProfile,
     deleteResponseProfile,
-  } = useCurtailmentResponseProfiles(canManageCurtailment);
+  } = useCurtailmentResponseProfiles(canManageCurtailment, { siteNameById });
   const {
     sources,
     isLoading,
@@ -1676,6 +1683,20 @@ function CurtailmentSettingsPage(): ReactElement {
       siteOptionsAbortControllerRef.current?.abort();
     };
   }, []);
+
+  const hasSiteScopedResponseProfiles = useMemo(
+    () => responseProfiles.some((profile) => Boolean(profile.formValues?.siteId.trim())),
+    [responseProfiles],
+  );
+
+  useEffect(() => {
+    if (!hasSiteScopedResponseProfiles || siteOptionsLoadError) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(ensureSiteOptionsLoaded, 0);
+    return () => window.clearTimeout(timeoutId);
+  }, [ensureSiteOptionsLoaded, hasSiteScopedResponseProfiles, siteOptionsLoadError]);
 
   useEffect(() => {
     if (!loadError) {

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -1601,6 +1601,7 @@ function CurtailmentSettingsPage(): ReactElement {
   const [isTestingResponseProfileCurtailment, setIsTestingResponseProfileCurtailment] = useState(false);
   const [siteOptions, setSiteOptions] = useState<CurtailmentSiteOption[]>([]);
   const [isLoadingSiteOptions, setIsLoadingSiteOptions] = useState(false);
+  const [hasLoadedSiteOptions, setHasLoadedSiteOptions] = useState(false);
   const [siteOptionsLoadError, setSiteOptionsLoadError] = useState<string | null>(null);
   const siteOptionsAbortControllerRef = useRef<AbortController | null>(null);
   const canLoadSiteOptions = canManageCurtailment && canReadSiteCatalog;
@@ -1647,7 +1648,7 @@ function CurtailmentSettingsPage(): ReactElement {
   } = useCurtailmentAutomationRules(canManageCurtailment);
 
   const ensureSiteOptionsLoaded = useCallback(() => {
-    if (!canLoadSiteOptions || isLoadingSiteOptions || (siteOptions.length > 0 && !siteOptionsLoadError)) {
+    if (!canLoadSiteOptions || isLoadingSiteOptions || (hasLoadedSiteOptions && !siteOptionsLoadError)) {
       return;
     }
 
@@ -1663,6 +1664,7 @@ function CurtailmentSettingsPage(): ReactElement {
       onSuccess: (sites) => {
         if (!signal.aborted) {
           setSiteOptions(createSiteOptions(sites));
+          setHasLoadedSiteOptions(true);
         }
       },
       onError: (message) => {
@@ -1676,7 +1678,7 @@ function CurtailmentSettingsPage(): ReactElement {
         }
       },
     });
-  }, [canLoadSiteOptions, isLoadingSiteOptions, listSites, siteOptions.length, siteOptionsLoadError]);
+  }, [canLoadSiteOptions, hasLoadedSiteOptions, isLoadingSiteOptions, listSites, siteOptionsLoadError]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
Reviewable diff: +213/-51 across 7 files (excludes generated, test, and story files).

## Summary
Site-scoped curtailment events and response profiles now show human-readable site names anywhere the client can resolve them from the site catalog. Operators still get deterministic fallback labels when a saved curtailment scope references a site id that is unavailable to the current user or cannot be loaded. This also fixes the follow-up reload behavior so response profiles are remapped when site names arrive without repeatedly refetching profiles, and settings no longer auto-retries site loading after an error or an empty site list. Closes #564.

## How it works
The energy curtailment panel and settings page load the site catalog through the existing `ListSites` endpoint when the current user has `site:read`, then build a `siteNameById` lookup shared with curtailment display mappers and response profile mapping. Site-scoped events and profiles carry their persisted site id across the API boundary; the client only changes the display label from the raw id/fallback to the resolved site name when available.

Response profiles keep the API payloads in state and remap those profiles when the site-name lookup changes, so late-arriving site names update the UI without triggering a response-profile refetch loop. The settings page separately tracks whether the site catalog has loaded successfully, which keeps empty successful results from looking like an unloaded state and stops automatic retries after a site-load failure while leaving explicit modal-triggered retries available.

## Diagrams
```mermaid
flowchart TD
  SitesApi["Sites API: ListSites"] --> Lookup["siteNameById lookup"]
  Lookup --> EnergyPanel["Energy curtailment panel"]
  Lookup --> SettingsPage["Curtailment settings page"]
  EnergyPanel --> EventMapper["Curtailment event mappers"]
  SettingsPage --> ProfileHook["Response profile hook"]
  EventMapper --> EventUi["Active event and history labels"]
  ProfileHook --> ProfileUi["Response profile cards"]
  EventUi --> Fallback["Fallback: Site <id>"]
  ProfileUi --> Fallback
```

```mermaid
sequenceDiagram
  participant Settings as Curtailment Settings
  participant Profiles as Response profiles hook
  participant Sites as Sites API
  Settings->>Profiles: List response profiles
  Profiles-->>Settings: Site ids with fallback labels
  Settings->>Sites: ListSites when site-scoped profiles exist
  Sites-->>Settings: Site names, empty result, or error
  Settings->>Profiles: Update siteNameById lookup
  Profiles-->>Settings: Remapped profile display without profile refetch
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/api/siteNames.ts` | Added shared site-name lookup and fallback helpers. | Centralizes the label behavior for site-scoped curtailment displays. |
| `client/src/protoFleet/api/curtailmentMappers.ts` | Maps site-scoped event display names through `siteNameById`. | Makes active/history curtailment event labels human-readable when names are known. |
| `client/src/protoFleet/api/useCurtailmentApi.ts` | Loads sites when allowed and passes the lookup into event mapping. | Carries site names into the energy page without changing backend contracts. |
| `client/src/protoFleet/api/useCurtailmentResponseProfiles.ts` | Maps profile display labels through the lookup and remaps local API payloads when names arrive. | Updates profile cards after site loading without a profile refetch loop. |
| `client/src/protoFleet/features/energy/*` | Threads resolved site labels into active event, history, and display utility output. | Keeps the operator-facing energy page consistent for site-scoped events. |
| `client/src/protoFleet/features/settings/components/Curtailment/*` | Tracks successful site-catalog loading separately from `siteOptions.length` and stops automatic retry loops. | Handles empty site catalogs and load failures predictably while still supporting manual retry paths. |
| Client tests | Added/updated tests for event labels, profile remapping, hidden/missing sites, and site-load retry behavior. | Covers the display-name behavior and the reload-loop regressions this PR addresses. |

## Key technical decisions & trade-offs
| Decision | Trade-off |
| --- | --- |
| Resolve site names client-side through `ListSites`. | Avoids backend/proto/API churn for a display-only issue, but labels depend on the viewer's `site:read` access and catalog load success. |
| Preserve fallback labels for unknown or unauthorized site ids. | Keeps saved site-scoped records visible instead of hiding them, but cannot show a name the client cannot resolve. |
| Remap stored response-profile API payloads when `siteNameById` changes. | Avoids refetch loops and stale labels, at the cost of keeping raw profile payloads alongside mapped UI models. |
| Track `hasLoadedSiteOptions` separately from list length. | Correctly treats an empty site catalog as loaded, but requires explicit state instead of deriving load status from `siteOptions.length`. |
| Stop automatic retries after site-load errors. | Prevents tight retry loops; operators can still trigger a deliberate retry through the existing modal flow. |

## Testing & validation
- `cd client && npx eslint src/protoFleet/api/curtailmentMappers.ts src/protoFleet/api/siteNames.ts src/protoFleet/api/useCurtailmentApi.ts src/protoFleet/api/useCurtailmentResponseProfiles.ts src/protoFleet/features/energy/CurtailmentManagementPanel.tsx src/protoFleet/features/energy/curtailmentDisplayUtils.ts src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx --max-warnings 0`
- `cd client && npm test -- src/protoFleet/api/useCurtailmentApi.test.ts src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx`
- Not covered: a full client typecheck or backend test suite, since this PR is scoped to client-side display mapping and retry behavior.
