### PR TITLE
Device Offline alerts only unreachable; gate Temp High on freshness

### DIFF
--- a/server/internal/domain/telemetry/broadcaster_metrics.go
+++ b/server/internal/domain/telemetry/broadcaster_metrics.go
@@ -194,21 +194,9 @@ func hashingRatio(observedTHs, expectedTHs float64) float64 {
 	return 0
 }
 
-// isOnlineStatus reports whether a MinerStatus should map to fleet_device_online=1.
+// isOnlineStatus maps a MinerStatus to fleet_device_online=1; only a truly-unreachable device (MinerStatusOffline) is offline, so error/unknown devices stay online.
 func isOnlineStatus(status mm.MinerStatus) bool {
-	switch status {
-	case mm.MinerStatusOffline, mm.MinerStatusError, mm.MinerStatusUnknown:
-		return false
-
-	case mm.MinerStatusActive,
-		mm.MinerStatusInactive,
-		mm.MinerStatusMaintenance,
-		mm.MinerStatusNeedsMiningPool,
-		mm.MinerStatusUpdating,
-		mm.MinerStatusRebootRequired:
-		return true
-	}
-	return false
+	return status != mm.MinerStatusOffline
 }
 
 // temperatureAggregate is the per-sensor-kind result of walking a DeviceMetrics value.

--- a/server/internal/domain/telemetry/broadcaster_metrics_test.go
+++ b/server/internal/domain/telemetry/broadcaster_metrics_test.go
@@ -267,19 +267,26 @@ func TestObserverDoesNotEmitPoolGaugeFromHealth(t *testing.T) {
 	}
 }
 
-// an unreachable device must produce fleet_device_online=0
+// only a truly-unreachable device (MinerStatusOffline) emits fleet_device_online=0; error/unknown devices are still reachable and stay online=1.
 func TestObserverEmitsExplicitZeroOnOffline(t *testing.T) {
-	rec := &recordingEmitter{}
-	obs := newMetricsObserver(rec)
-
-	obs.onDeviceStatus(context.Background(), 1, 0, "virtual", "v-1", mm.MinerStatusOffline)
-	obs.onDeviceStatus(context.Background(), 1, 0, "virtual", "v-1", mm.MinerStatusError)
-	obs.onDeviceStatus(context.Background(), 1, 0, "virtual", "v-1", mm.MinerStatusActive)
-
-	require.Len(t, rec.online, 3)
-	require.False(t, rec.online[0].online, "offline must emit 0")
-	require.False(t, rec.online[1].online, "error must emit 0")
-	require.True(t, rec.online[2].online, "active must emit 1")
+	cases := []struct {
+		status mm.MinerStatus
+		online bool
+	}{
+		{mm.MinerStatusOffline, false},
+		{mm.MinerStatusError, true},
+		{mm.MinerStatusUnknown, true},
+		{mm.MinerStatusActive, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.status.String(), func(t *testing.T) {
+			rec := &recordingEmitter{}
+			obs := newMetricsObserver(rec)
+			obs.onDeviceStatus(context.Background(), 1, 0, "virtual", "v-1", tc.status)
+			require.Len(t, rec.online, 1)
+			require.Equal(t, tc.online, rec.online[0].online)
+		})
+	}
 }
 
 // exercises the success/failure branch of the telemetry-poll counter.

--- a/server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go
+++ b/server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go
@@ -15,10 +15,8 @@ import (
 // ruleFile is the provisioned Grafana rules file relative to this package.
 const ruleFile = "../../../monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml"
 
-// loadIngestStalledRuleSQL extracts the live rawSql for the "Metric Ingest
-// Stalled" rule from the provisioning file so this test exercises the exact
-// query operators run, not a copy that can drift from it.
-func loadIngestStalledRuleSQL(t *testing.T) string {
+// loadRuleSQL returns the live rawSql for the named rule from the provisioning file, asserting it contains mustContain so tests run the exact deployed query, not a copy that can drift.
+func loadRuleSQL(t *testing.T, title, mustContain string) string {
 	t.Helper()
 	raw, err := os.ReadFile(ruleFile)
 	require.NoError(t, err)
@@ -39,16 +37,21 @@ func loadIngestStalledRuleSQL(t *testing.T) string {
 
 	for _, g := range doc.Groups {
 		for _, r := range g.Rules {
-			if r.Title == "Metric Ingest Stalled" {
+			if r.Title == title {
 				require.NotEmpty(t, r.Data, "rule has no data block")
 				sql := r.Data[0].Model.RawSQL
-				require.Contains(t, sql, "fleet_pollable_device_presence")
+				require.Contains(t, sql, mustContain)
 				return sql
 			}
 		}
 	}
-	t.Fatal(`rule "Metric Ingest Stalled" not found in provisioning file`)
+	t.Fatalf("rule %q not found in provisioning file", title)
 	return ""
+}
+
+// loadIngestStalledRuleSQL extracts the live rawSql for the "Metric Ingest Stalled" rule.
+func loadIngestStalledRuleSQL(t *testing.T) string {
+	return loadRuleSQL(t, "Metric Ingest Stalled", "fleet_pollable_device_presence")
 }
 
 // seedOrg inserts organization -> discovered_device -> device -> device_pairing

--- a/server/internal/infrastructure/timescaledb/temperature_rule_test.go
+++ b/server/internal/infrastructure/timescaledb/temperature_rule_test.go
@@ -1,0 +1,91 @@
+package timescaledb_test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/block/proto-fleet/server/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// loadTemperatureHighRuleSQL extracts the live rawSql for the "Device Temperature High" rule.
+func loadTemperatureHighRuleSQL(t *testing.T) string {
+	return loadRuleSQL(t, "Device Temperature High", "fleet_device_temperature_max_celsius")
+}
+
+// writeTempSample lands one fleet_device_temperature_max_celsius sample for a device/sensor kind at the given age.
+func writeTempSample(t *testing.T, db *sql.DB, org, device, kind string, value float64, age time.Duration) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(), `
+		INSERT INTO notification_metric_sample (time, metric, organization_id, device_id, sensor_kind, value)
+		VALUES ($1, 'fleet_device_temperature_max_celsius', $2, $3, $4, $5)`,
+		time.Now().Add(-age), org, device, kind, value)
+	require.NoError(t, err)
+}
+
+// runTempRule executes the rule SQL and returns device_id -> latest_temp for the devices it reports as firing.
+func runTempRule(t *testing.T, db *sql.DB, rawSQL string) map[string]float64 {
+	t.Helper()
+	rows, err := db.QueryContext(t.Context(), rawSQL)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	out := map[string]float64{}
+	for rows.Next() {
+		var org, device string
+		var latestTemp float64
+		require.NoError(t, rows.Scan(&org, &device, &latestTemp))
+		out[device] = latestTemp
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// TestDeviceTemperatureHighRule_Freshness covers the freshness gate: only a device still reporting a hot sample fires; one whose hot reading went stale drops out.
+func TestDeviceTemperatureHighRule_Freshness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	db := testutil.GetTestDB(t)
+	rawSQL := loadTemperatureHighRuleSQL(t)
+
+	const org = "temp-test-org"
+	hotFresh := fmt.Sprintf("%s-hot-fresh", org)
+	hotStale := fmt.Sprintf("%s-hot-stale", org)
+	coolFresh := fmt.Sprintf("%s-cool-fresh", org)
+
+	// Reporting now and over the threshold: must fire.
+	writeTempSample(t, db, org, hotFresh, "chip", 95, 10*time.Second)
+	// Hot but last reported 5 minutes ago: inside the 10-minute scan window, but the freshness gate must drop it.
+	writeTempSample(t, db, org, hotStale, "chip", 95, 5*time.Minute)
+	// Reporting now but below the threshold: must not fire.
+	writeTempSample(t, db, org, coolFresh, "chip", 68, 10*time.Second)
+
+	got := runTempRule(t, db, rawSQL)
+
+	require.Contains(t, got, hotFresh, "a device reporting a fresh hot reading must fire")
+	require.InDelta(t, 95.0, got[hotFresh], 1e-9)
+	require.NotContains(t, got, hotStale, "a stale hot reading must not keep the rule firing")
+	require.NotContains(t, got, coolFresh, "a fresh sub-threshold reading must not fire")
+}
+
+// TestDeviceTemperatureHighRule_FreshAcrossKinds covers per-kind freshness: a device whose hot kind went stale must not fire even when a cooler kind is still fresh.
+func TestDeviceTemperatureHighRule_FreshAcrossKinds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	db := testutil.GetTestDB(t)
+	rawSQL := loadTemperatureHighRuleSQL(t)
+
+	const org = "temp-kinds-org"
+	device := fmt.Sprintf("%s-dev", org)
+
+	// Hot chip reading is stale, cool board reading is fresh: the stale hot kind must be filtered out so the device does not fire.
+	writeTempSample(t, db, org, device, "chip", 95, 5*time.Minute)
+	writeTempSample(t, db, org, device, "board", 60, 10*time.Second)
+
+	got := runTempRule(t, db, rawSQL)
+	require.NotContains(t, got, device, "a stale hot kind must not fire while only a cool kind is fresh")
+}

--- a/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
+++ b/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
@@ -118,7 +118,8 @@ groups:
                         organization_id,
                         device_id,
                         sensor_kind,
-                        last(value, time) AS latest_temp
+                        last(value, time) AS latest_temp,
+                        max(time) AS last_sample_time
                     FROM notification_metric_sample
                     WHERE metric = 'fleet_device_temperature_max_celsius'
                       AND time > NOW() - INTERVAL '10 minutes'
@@ -129,6 +130,8 @@ groups:
                     device_id,
                     max(latest_temp) AS latest_temp
                 FROM latest_per_kind
+                -- Freshness gate: ignore a kind whose newest sample is stale, so a device that stopped reporting (e.g. went offline while hot) can't keep this firing on a reading it can no longer confirm — the Device Offline rule covers that case.
+                WHERE last_sample_time > NOW() - INTERVAL '2 minutes'
                 GROUP BY organization_id, device_id
                 HAVING max(latest_temp) > 90
           - refId: B


### PR DESCRIPTION
Reviewable diff: +6/-15 across 2 files (excludes generated, test, and story files).

## Summary

Two related alert-quality fixes so operators stop seeing contradictory or stuck alerts on miners that are faulted but still reachable:

- **Device Offline** now fires only for genuinely unreachable miners, not for ones that are reachable-but-faulted (Error) or unauthenticated (Unknown).
- **Device Temperature High** now fires only on a *fresh* reading, so a miner that stops reporting can't keep the alert latched on its last hot sample.

The trigger was a miner stuck in `Error` (overheating but still polling) that simultaneously showed Device Offline + Temperature High, and the alerts never cleared because each was evaluating data that no longer meant what the rule assumed.

## How it works

**Background.** Each miner emits two independent signals into the `notification_metric_sample` hypertable: a `fleet_device_online` gauge (0/1, written on every status change) and `fleet_device_temperature_max_celsius` (written only on a successful telemetry poll). Grafana evaluates the provisioned rules against that table every 30s.

**Change 1 — Device Offline scope.** The gauge value is decided by `isOnlineStatus`, which previously mapped three statuses to `online=0`: `Offline`, `Error`, and `Unknown`. But only `Offline` means "the telemetry pipeline could not reach the device." An `Error` miner answered the poll and is still streaming telemetry (it's just in critical health); an `Unknown` miner answered too (it failed auth). Mapping those to `0` made the Device Offline rule fire for reachable miners — and because they keep polling, the gauge stayed at `0` and the alert never resolved. The fix maps only `MinerStatusOffline` to `online=0`. This mirrors the existing hashrate behavior right beside it, where the stale-clear also keys on `MinerStatusOffline` only ("an Error/Critical device still reports telemetry and must keep alerting").

**Change 2 — Temperature freshness gate.** The temperature rule took the latest reading per sensor kind within a 10-minute window and fired if any exceeded 90°C. It never checked that the latest reading was *recent*. When a hot miner stopped reporting, its final >90°C sample lingered in the window and kept the alert firing on a value the fleet could no longer confirm. Unlike hashrate (which is reset to a safe value at emission time when a device goes offline), temperature has no natural "safe value" to emit, so the gate lives in the rule: the query now also computes the newest sample time per kind and ignores any kind whose newest sample is older than 2 minutes. A still-reporting hot miner keeps firing; one that went quiet drops out and is covered by the Device Offline rule instead.

```mermaid
flowchart TD
    A["Miner status poll"] --> B{"isOnlineStatus(status)"}
    B -->|"MinerStatusOffline only"| C["fleet_device_online = 0"]
    B -->|"Error / Unknown / Active / ..."| D["fleet_device_online = 1"]
    C --> E["Device Offline rule fires"]

    F["Successful telemetry poll"] --> G["fleet_device_temperature_max_celsius<br/>per sensor_kind"]
    G --> H["Temperature High rule (every 30s)"]
    H --> I{"newest sample per kind<br/>within 2 minutes?"}
    I -->|"no — stale, device went quiet"| J["kind dropped: no alert"]
    I -->|"yes — fresh"| K{"max latest temp > 90C?"}
    K -->|"yes"| L["Device Temperature High fires"]
    K -->|"no"| M["no alert"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
|---|---|---|
| `server/internal/domain/telemetry/broadcaster_metrics.go` | `isOnlineStatus` reduced to `status != MinerStatusOffline` | Changes the meaning of the `fleet_device_online` contract gauge; confirm Error/Unknown-as-online is the intended semantics |
| `server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml` | Device Temperature High rule: adds `max(time)` per kind and a `WHERE last_sample_time > NOW() - INTERVAL '2 minutes'` gate | The behavioral core of change 2; verify the 2-minute threshold and per-kind filtering |
| `server/internal/domain/telemetry/broadcaster_metrics_test.go` | `TestObserverEmitsExplicitZeroOnOffline` rewritten as a status-keyed, table-driven test (Error/Unknown now assert online=1) | Locks in the new mapping for all four statuses |
| `server/internal/infrastructure/timescaledb/temperature_rule_test.go` | **New** integration test loading the live rule SQL; covers fresh-hot fires, stale-hot drops, and per-kind freshness | Guards the freshness gate against drift; runs the exact deployed query |
| `server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go` | Extracted shared `loadRuleSQL(t, title, mustContain)` helper (de-dup with the new test) | Pure refactor, no behavior change |

## Key technical decisions & trade-offs

- **`fleet_device_online` semantics widened to "reachable", not "healthy".** Error/Unknown miners now report `online=1`. They remain covered by their own health, temperature, and hashrate rules — Device Offline is no longer their catch-all. Chosen over filtering status inside the rule SQL, which would require exporting raw status as a separate series and would fork the definition across every consumer (dashboards, org-authored rules).
- **Freshness gate lives in the rule, not at emission.** Hashrate resets to a safe `1.0` on offline; temperature has no equivalent safe value, so the rule gates on sample age instead. This leaves the four default rules with three different staleness strategies by design: Offline treats staleness *as* the signal, Hashrate clears at emission, Temperature gates in-query.
- **2-minute threshold** is a SQL literal, consistent with the other interval literals in this file. It covers ~2 emission cycles (≤1-minute poll interval) — wide enough to absorb jitter, short enough that a quiet miner clears promptly.

## Testing & validation

- `go build ./...` clean; `go vet` clean on the touched packages.
- New TimescaleDB integration tests run the **live** rule SQL pulled from the provisioning YAML (so they can't drift from what's deployed) and pass against a local Timescale instance: fresh-hot fires, stale-hot is dropped, and a stale hot kind does not fire while only a cool kind is fresh.
- `TestObserverEmitsExplicitZeroOnOffline` passes for all four status sub-cases (offline→0; error/unknown/active→1).
- **Not covered:** the end-to-end Grafana evaluation/notification path is unchanged and not re-tested here; only the rule query and the metric emission are validated.
