### PR TITLE
Add settings list UI primitives

### DIFF
--- a/client/src/protoFleet/features/settings/components/SettingsEmptyState.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsEmptyState.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SettingsEmptyState from "./SettingsEmptyState";
+
+const meta = {
+  title: "Proto Fleet/Settings/SettingsEmptyState",
+  component: SettingsEmptyState,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] bg-surface-base">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    title: "No firmware files uploaded",
+    description: "Upload firmware before deploying updates to your fleet.",
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["default", "section"],
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof SettingsEmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Section: Story = {
+  args: {
+    title: "No schedules yet",
+    description: "Configure schedules to automate actions for your miners.",
+    size: "section",
+  },
+};

--- a/client/src/protoFleet/features/settings/components/SettingsEmptyState.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsEmptyState.tsx
@@ -1,0 +1,23 @@
+import clsx from "clsx";
+
+type SettingsEmptyStateProps = {
+  title: string;
+  description?: string;
+  className?: string;
+  size?: "default" | "section";
+};
+
+const SettingsEmptyState = ({ title, description, className, size = "default" }: SettingsEmptyStateProps) => (
+  <div
+    className={clsx(
+      "flex w-full flex-col items-center justify-center text-center",
+      size === "section" ? "min-h-[220px] py-14" : "py-10",
+      className,
+    )}
+  >
+    <div className="text-heading-200 text-text-primary">{title}</div>
+    {description ? <p className="mt-1 text-400 text-text-primary-70">{description}</p> : null}
+  </div>
+);
+
+export default SettingsEmptyState;

--- a/client/src/protoFleet/features/settings/components/SettingsPageHeader.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsPageHeader.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SettingsPageHeader from "./SettingsPageHeader";
+
+const meta = {
+  title: "Proto Fleet/Settings/SettingsPageHeader",
+  component: SettingsPageHeader,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] bg-surface-base">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    title: "Team",
+    description: "Define what members can see and do. Assign roles when you add or edit a member.",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof SettingsPageHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithDescription: Story = {};
+
+export const TitleOnly: Story = {
+  args: {
+    title: "Firmware",
+    description: undefined,
+  },
+};

--- a/client/src/protoFleet/features/settings/components/SettingsPageHeader.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsPageHeader.tsx
@@ -1,0 +1,12 @@
+import Header from "@/shared/components/Header";
+
+type SettingsPageHeaderProps = {
+  title: string;
+  description?: string;
+};
+
+const SettingsPageHeader = ({ title, description }: SettingsPageHeaderProps) => (
+  <Header title={title} titleSize="text-heading-300" description={description} />
+);
+
+export default SettingsPageHeader;

--- a/client/src/shared/components/List/List.test.tsx
+++ b/client/src/shared/components/List/List.test.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { createPortal } from "react-dom";
 import { defaultListFilter } from "@/shared/components/List/constants";
@@ -347,6 +347,32 @@ describe("List", () => {
     expect(screen.getByText("No miners found")).toBeInTheDocument();
     expect(screen.queryByText("All Items")).not.toBeInTheDocument();
     expect(screen.queryByText("Value Range")).not.toBeInTheDocument();
+  });
+
+  it("renders rows when data arrives after an empty filtered no-data state", async () => {
+    const props = {
+      activeCols,
+      colTitles: testColTitles,
+      colConfig: testColConfig,
+      filters: testFilters,
+      itemKey: "id" as const,
+      total: 0,
+      noDataElement: <div>No miners found</div>,
+      filterItem: () => true,
+    };
+
+    const { rerender } = render(<List<TestItem, TestItemKey> {...props} items={[]} />);
+
+    expect(screen.getByText("No miners found")).toBeInTheDocument();
+    expect(screen.queryByText("All Items")).not.toBeInTheDocument();
+
+    rerender(<List<TestItem, TestItemKey> {...props} items={testItems} total={testItems.length} />);
+
+    expect(screen.getByText("All Items")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(testItems[0].name)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("No miners found")).not.toBeInTheDocument();
   });
 
   it("keeps header controls visible for a true no-data state", () => {

--- a/client/src/shared/components/List/List.test.tsx
+++ b/client/src/shared/components/List/List.test.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createPortal } from "react-dom";
 import { defaultListFilter } from "@/shared/components/List/constants";
 import List from "@/shared/components/List/index";
@@ -8,18 +8,16 @@ import testColConfig from "@/shared/components/List/mocks/colConfig";
 import { testCols, testColTitles, testFilters, TestItem, testItems } from "@/shared/components/List/mocks/data";
 import { ListAction } from "@/shared/components/List/types";
 
-beforeAll(() => {
-  vi.mock("recharts", () => ({
-    ResponsiveContainer: ({ children }: { children: ReactNode }) => (
-      <div data-testid="recharts-responsive-container">{children}</div>
-    ),
-    LineChart: ({ children }: { children: ReactNode }) => <div data-testid="recharts-line-chart">{children}</div>,
-    ReferenceLine: () => <div data-testid="recharts-reference-line" />,
-    Line: () => <div data-testid="recharts-line" />,
-    XAxis: () => <div data-testid="recharts-xaxis" />,
-    YAxis: () => <div data-testid="recharts-yaxis" />,
-  }));
-});
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="recharts-responsive-container">{children}</div>
+  ),
+  LineChart: ({ children }: { children: ReactNode }) => <div data-testid="recharts-line-chart">{children}</div>,
+  ReferenceLine: () => <div data-testid="recharts-reference-line" />,
+  Line: () => <div data-testid="recharts-line" />,
+  XAxis: () => <div data-testid="recharts-xaxis" />,
+  YAxis: () => <div data-testid="recharts-yaxis" />,
+}));
 
 describe("List", () => {
   const activeCols = [testCols.name, testCols.status, testCols.value, testCols.timestamp] as (keyof TestItem)[];
@@ -313,6 +311,83 @@ describe("List", () => {
     expect(screen.queryByText(`${testItems.length} miners`)).not.toBeInTheDocument();
   });
 
+  it("renders no-data content without redundant count or table chrome", () => {
+    render(
+      <List<TestItem, TestItemKey>
+        activeCols={activeCols}
+        colTitles={testColTitles}
+        colConfig={testColConfig}
+        items={[]}
+        itemKey="id"
+        total={0}
+        itemName={{ singular: "miner", plural: "miners" }}
+        noDataElement={<div>No miners found</div>}
+      />,
+    );
+
+    expect(screen.getByText("No miners found")).toBeInTheDocument();
+    expect(screen.queryByText("0 miners")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("list-header")).not.toBeInTheDocument();
+  });
+
+  it("hides filter controls for a true no-data state", () => {
+    render(
+      <List<TestItem, TestItemKey>
+        activeCols={activeCols}
+        colTitles={testColTitles}
+        colConfig={testColConfig}
+        filters={testFilters}
+        items={[]}
+        itemKey="id"
+        total={0}
+        noDataElement={<div>No miners found</div>}
+      />,
+    );
+
+    expect(screen.getByText("No miners found")).toBeInTheDocument();
+    expect(screen.queryByText("All Items")).not.toBeInTheDocument();
+    expect(screen.queryByText("Value Range")).not.toBeInTheDocument();
+  });
+
+  it("keeps header controls visible for a true no-data state", () => {
+    render(
+      <List<TestItem, TestItemKey>
+        activeCols={activeCols}
+        colTitles={testColTitles}
+        colConfig={testColConfig}
+        filters={testFilters}
+        headerControls={<button type="button">Add miner</button>}
+        items={[]}
+        itemKey="id"
+        total={0}
+        noDataElement={<div>No miners found</div>}
+      />,
+    );
+
+    expect(screen.getByText("Add miner")).toBeInTheDocument();
+    expect(screen.queryByText("All Items")).not.toBeInTheDocument();
+  });
+
+  it("keeps filter controls visible for a filtered no-data state", () => {
+    render(
+      <List<TestItem, TestItemKey>
+        activeCols={activeCols}
+        colTitles={testColTitles}
+        colConfig={testColConfig}
+        filters={testFilters}
+        hasActiveFilters
+        items={[]}
+        itemKey="id"
+        total={0}
+        noDataElement={<div>No miners found</div>}
+      />,
+    );
+
+    expect(screen.getByText("No miners found")).toBeInTheDocument();
+    expect(screen.getByText("All Items")).toBeInTheDocument();
+    expect(screen.getByText("Value Range")).toBeInTheDocument();
+  });
+
   it("does not render checkboxes when items are not selectable", () => {
     const { getByTestId } = render(
       <List<TestItem, TestItemKey>
@@ -584,6 +659,31 @@ describe("List", () => {
       />,
     );
 
+    expect(screen.getAllByTestId("action")).toHaveLength(testItems.length);
+  });
+
+  it("renders an action placeholder when a row hides every action", () => {
+    const actions = [
+      {
+        title: "Edit",
+        actionHandler: vi.fn(),
+        hidden: (item: TestItem) => item.id === testItems[0].id,
+      },
+    ] as ListAction<TestItem>[];
+
+    render(
+      <List<TestItem, TestItemKey>
+        activeCols={activeCols}
+        colTitles={testColTitles}
+        colConfig={testColConfig}
+        items={testItems}
+        itemKey="id"
+        actions={actions}
+        actionPlaceholder={(item) => (item.id === testItems[0].id ? <span>Locked</span> : null)}
+      />,
+    );
+
+    expect(screen.getByText("Locked")).toBeInTheDocument();
     expect(screen.getAllByTestId("action")).toHaveLength(testItems.length);
   });
 

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -157,6 +157,7 @@ type ListProps<ListItem, ItemKeyValueType, ColKey extends string = keyof ListIte
   initialSelectedItems?: ItemKeyValueType[];
   disabled?: boolean;
   actions?: ListAction<ListItem>[];
+  actionPlaceholder?: (item: ListItem) => ReactNode;
   noDataElement?: ReactNode;
   emptyStateRow?: ReactNode;
   renderActionBar?: (
@@ -344,6 +345,7 @@ type ListRowRenderProps<ListItem, ItemKeyValueType, ColKey extends string = keyo
   currentSelectedItems: ItemKeyValueType[];
   activeCols: ColKey[];
   actions: ListAction<ListItem>[];
+  actionPlaceholder?: (item: ListItem) => ReactNode;
   rowDisabled: boolean;
   rowSelectable: boolean;
   columnsExemptFromDisabledStyling?: Set<ColKey>;
@@ -388,6 +390,7 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
   currentSelectedItems,
   activeCols,
   actions,
+  actionPlaceholder,
   rowDisabled,
   rowSelectable,
   columnsExemptFromDisabledStyling,
@@ -415,6 +418,7 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
   onRowClick,
 }: ListRowRenderProps<ListItem, ItemKeyValueType, ColKey>) => {
   const visibleActions = actions.filter((action) => !resolveListActionValue(action.hidden, item));
+  const placeholderContent = actionPlaceholder?.(item);
   const singleVisibleAction = visibleActions.length === 1 ? visibleActions[0] : null;
   const singleVisibleActionTitle = singleVisibleAction
     ? resolveListActionValue(singleVisibleAction.title, item)
@@ -622,7 +626,7 @@ const renderListRow = <ListItem, ItemKeyValueType, ColKey extends string = keyof
           data-testid="action"
           data-no-row-click
         >
-          <div className={clsx("w-11", tdPaddingClassList)} />
+          <div className={clsx("flex w-11 justify-center", tdPaddingClassList)}>{placeholderContent}</div>
           {extendRowDividerToContainerEdge ? (
             <div aria-hidden className={rowDividerExtensionClassList} data-testid="row-divider-extension" />
           ) : null}
@@ -711,6 +715,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   selectionType = "checkbox",
   disabled = false,
   actions = [],
+  actionPlaceholder,
   noDataElement,
   emptyStateRow,
   initialActiveFilters,
@@ -1215,11 +1220,16 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
     "tablet:left-[calc(var(--list-padding-tablet)+theme(spacing.9))]",
   );
 
+  const hasVisibleRows = filteredItems.length > 0;
+  const shouldRenderNoDataElement = Boolean(noDataElement && !hasVisibleRows && !emptyStateRow);
+  const shouldShowFilterItems = Boolean(filters?.length) && (!shouldRenderNoDataElement || hasActiveFilters);
+  const visibleFilters = shouldShowFilterItems ? (filters ?? []) : [];
+
   const filtersElement =
-    filters?.length || headerControls ? (
+    visibleFilters.length || headerControls ? (
       <Filters<ListItem>
         className={clsx("gap-4", filtersClassName ?? "py-6", stickyChromePaddingClasses)}
-        filterItems={filters ?? []}
+        filterItems={visibleFilters}
         filterSize={filterSize}
         items={items}
         onFilter={isServerSideFiltering ? handleServerFiltering : handleClientFiltering}
@@ -1251,6 +1261,8 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
   );
 
   const totalColumnCount = activeCols.length + (itemSelectable ? 1 : 0) + (actions.length > 0 ? 1 : 0);
+  const shouldShowTotal = !hideTotal && total !== undefined && !shouldRenderNoDataElement;
+
   const renderRow = (item: ListItem, index: number) => {
     const rowKey = item[itemKey] as ItemKeyValueType;
     const sharedRowProps: StaticListRowProps<ListItem, ItemKeyValueType, ColKey> = {
@@ -1265,6 +1277,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
       currentSelectedItems,
       activeCols,
       actions,
+      actionPlaceholder,
       rowDisabled: isRowDisabled?.(item) ?? false,
       rowSelectable: isRowSelectable ? isRowSelectable(item) : !(isRowDisabled?.(item) ?? false),
       columnsExemptFromDisabledStyling,
@@ -1413,7 +1426,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
         {rowDragEnabled ? (
           <SortableContext items={visibleItemKeys as UniqueIdentifier[]} strategy={verticalListSortingStrategy}>
             <tbody data-testid="list-body">
-              {filteredItems.length > 0 ? (
+              {hasVisibleRows ? (
                 filteredItems.map(renderRow)
               ) : emptyStateRow ? (
                 <tr data-testid="list-empty-row">
@@ -1424,7 +1437,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
           </SortableContext>
         ) : (
           <tbody data-testid="list-body">
-            {filteredItems.length > 0 ? (
+            {hasVisibleRows ? (
               filteredItems.map(renderRow)
             ) : emptyStateRow ? (
               <tr data-testid="list-empty-row">
@@ -1451,7 +1464,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
         {filtersElement}
       </div>
       <div style={paddingCssVariables}>
-        {!hideTotal && total !== undefined ? (
+        {shouldShowTotal ? (
           <div style={stickyChromePaddingCssVariables} className={clsx("sticky left-0 flex", stickyChromeClassName)}>
             <div
               className={clsx("sticky left-0 pb-4 text-emphasis-300 text-text-primary-70", stickyChromePaddingClasses)}
@@ -1473,7 +1486,7 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
               "overflow-x-hidden": overflowContainer && !hasHorizontalOverflow,
             })}
           >
-            {!noDataElement || (items && items.length > 0) ? (
+            {!shouldRenderNoDataElement ? (
               rowDragEnabled ? (
                 <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleRowDragEnd}>
                   {listContent}

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -1222,7 +1222,8 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
 
   const hasVisibleRows = filteredItems.length > 0;
   const shouldRenderNoDataElement = Boolean(noDataElement && !hasVisibleRows && !emptyStateRow);
-  const shouldShowFilterItems = Boolean(filters?.length) && (!shouldRenderNoDataElement || hasActiveFilters);
+  const shouldShowFilterItems =
+    Boolean(filters?.length) && (items.length > 0 || !shouldRenderNoDataElement || hasActiveFilters);
   const visibleFilters = shouldShowFilterItems ? (filters ?? []) : [];
 
   const filtersElement =

--- a/client/src/shared/components/List/ListActions/ListActions.test.tsx
+++ b/client/src/shared/components/List/ListActions/ListActions.test.tsx
@@ -36,6 +36,8 @@ describe("List actions", () => {
     );
     const triggerButton = screen.getByTestId("list-actions-trigger");
     expect(triggerButton).toBeInTheDocument();
+    expect(triggerButton).toHaveAttribute("aria-label", "Row actions");
+    expect(triggerButton).toHaveClass("text-text-primary");
     fireEvent.click(triggerButton);
 
     actions.forEach((action) => {

--- a/client/src/shared/components/List/ListActions/ListActions.tsx
+++ b/client/src/shared/components/List/ListActions/ListActions.tsx
@@ -43,8 +43,9 @@ const ListActions = <ListItem,>({ item, actions, disabled = false }: ListActionP
   return (
     <div className="relative" ref={triggerRef}>
       <button
-        className={clsx("align-middle", {
-          "text-text-primary-30 hover:cursor-pointer hover:text-text-primary-50": !disabled,
+        aria-label="Row actions"
+        className={clsx("flex h-8 w-8 items-center justify-center text-text-primary", {
+          "hover:cursor-pointer hover:opacity-70": !disabled,
           "cursor-not-allowed text-text-primary-30": disabled,
         })}
         data-testid="list-actions-trigger"


### PR DESCRIPTION
## Summary

- Adds shared `SettingsPageHeader` and `SettingsEmptyState` primitives for settings pages.
- Updates `List` to render true empty states without redundant counts/table chrome while preserving header controls.
- Adds `actionPlaceholder` support for rows that hide all actions, and standardizes the row actions trigger styling/accessibility.

## Stack

1/3. Base PR for the settings IA and content polish stack.

## Testing

- `../bin/npx tsc --noEmit --pretty false`
- `../bin/npx eslint . --max-warnings 0`
- `../bin/npx vitest run`
- `../bin/npm run build:protoFleet`
