### PR TITLE
Rework settings IA and team roles

### DIFF
--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -149,7 +149,7 @@ export class BasePage {
     await this.clickNavigationMenuIfMobile();
     await this.clickExpandSettingsIfMobile();
     if (this.isMobile) {
-      await this.page.getByTestId("navigation-menu").locator('a[href="/settings/general"]').click();
+      await this.page.getByTestId("navigation-menu").locator('a[href="/settings/network"]').click();
     } else {
       await this.page.getByTestId("navigation-menu").locator('a[href="/settings"]').click();
     }
@@ -169,6 +169,22 @@ export class BasePage {
     await this.navigateSettingsIfDesktop();
     await this.page.getByTestId("secondary-nav").locator('a[href="/settings/security"]').click();
     await expect(this.page).toHaveURL(/.*\/settings\/security/);
+  }
+
+  async navigateToNetworkSettings() {
+    await this.clickNavigationMenuIfMobile();
+    await this.clickExpandSettingsIfMobile();
+    await this.navigateSettingsIfDesktop();
+    await this.page.getByTestId("secondary-nav").locator('a[href="/settings/network"]').click();
+    await expect(this.page).toHaveURL(/.*\/settings\/network/);
+  }
+
+  async navigateToPreferencesSettings() {
+    await this.clickNavigationMenuIfMobile();
+    await this.clickExpandSettingsIfMobile();
+    await this.navigateSettingsIfDesktop();
+    await this.page.getByTestId("secondary-nav").locator('a[href="/settings/preferences"]').click();
+    await expect(this.page).toHaveURL(/.*\/settings\/preferences/);
   }
 
   async navigateToTeamSettings() {
@@ -199,8 +215,8 @@ export class BasePage {
     await this.clickNavigationMenuIfMobile();
     await this.clickExpandSettingsIfMobile();
     await this.navigateSettingsIfDesktop();
-    await this.page.getByTestId("secondary-nav").locator('a[href="/settings/api-keys"]').click();
-    await expect(this.page).toHaveURL(/.*\/settings\/api-keys/);
+    await this.page.getByTestId("secondary-nav").locator('a[href="/settings/integrations"]').click();
+    await expect(this.page).toHaveURL(/.*\/settings\/integrations/);
   }
 
   async navigateToSchedulesSettings() {

--- a/client/e2eTests/protoFleet/pages/settingsApiKeys.ts
+++ b/client/e2eTests/protoFleet/pages/settingsApiKeys.ts
@@ -5,9 +5,7 @@ import { BasePage } from "./base";
 export class SettingsApiKeysPage extends BasePage {
   async waitForApiKeysListToLoad() {
     const rows = this.page.getByTestId("list-body").getByTestId("list-row");
-    const emptyState = this.page.getByText(
-      "No API keys yet. Create your first key to enable programmatic access to the Fleet API.",
-    );
+    const emptyState = this.page.getByText("No API keys yet", { exact: true });
 
     await expect(this.page.getByText("Loading API keys...")).toBeHidden();
     await expect(this.page.getByRole("button", { name: "Create API key" })).toBeVisible();

--- a/client/e2eTests/protoFleet/pages/settingsApiKeys.ts
+++ b/client/e2eTests/protoFleet/pages/settingsApiKeys.ts
@@ -36,8 +36,8 @@ export class SettingsApiKeysPage extends BasePage {
   }
 
   async validateApiKeysPageOpened() {
-    await expect(this.page).toHaveURL(/.*\/settings\/api-keys/);
-    await this.validateTitle("API Keys");
+    await expect(this.page).toHaveURL(/.*\/settings\/integrations/);
+    await this.validateTitle("Integrations");
     await this.validateButtonIsVisible("Create API key");
   }
 

--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -30,7 +30,7 @@ export class SettingsFirmwarePage extends BasePage {
   }
 
   async deleteAllFirmwareFilesIfAny() {
-    const emptyState = this.page.getByText("No firmware files uploaded.", { exact: true });
+    const emptyState = this.page.getByText("No firmware files uploaded", { exact: true });
     const firmwareRows = this.page.getByTestId("list-body").locator("tr");
     const loadingState = this.page.getByText("Loading firmware files...", { exact: true });
     const deleteAllButton = this.page.getByRole("button", { name: "Delete all", exact: true }).first();
@@ -55,7 +55,7 @@ export class SettingsFirmwarePage extends BasePage {
     const deleteAllDialog = this.page.getByTestId("delete-all-firmware-dialog");
     await deleteAllDialog.getByRole("button", { name: "Delete all" }).click();
     await expect(deleteAllDialog).toBeHidden();
-    await expect(deleteAllButton).toBeDisabled();
+    await expect(deleteAllButton).toBeHidden();
     await expect(emptyState).toBeVisible();
   }
 }

--- a/client/e2eTests/protoFleet/pages/settingsTeam.ts
+++ b/client/e2eTests/protoFleet/pages/settingsTeam.ts
@@ -20,7 +20,7 @@ export class SettingsTeamPage extends BasePage {
   }
 
   private async pickRoleFromOpenModal(roleLabel: string) {
-    await this.page.getByRole("button", { name: "Role" }).click();
+    await this.page.getByTestId("modal").getByRole("button", { name: "Role" }).click();
     // The Select option's accessible name is "<label> <description>"
     // (e.g. "Field Tech Field Tech role"), so we can't use `exact: true`
     // — match the role label as the visible text inside the option's

--- a/client/e2eTests/protoFleet/spec/apiKeysSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/apiKeysSettings.spec.ts
@@ -8,7 +8,7 @@ import { SettingsApiKeysPage } from "../pages/settingsApiKeys";
 
 const API_KEY_PREFIX = "e2e_api_key";
 
-test.describe("Proto Fleet - API Keys", () => {
+test.describe("Proto Fleet - Integrations", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
   });
@@ -42,7 +42,7 @@ test.describe("Proto Fleet - API Keys", () => {
       await commonSteps.loginAsAdmin();
     });
 
-    await test.step("Navigate to API Keys settings", async () => {
+    await test.step("Navigate to Integrations settings", async () => {
       await settingsApiKeysPage.navigateToApiKeysSettings();
       await settingsApiKeysPage.validateApiKeysPageOpened();
     });
@@ -77,7 +77,7 @@ test.describe("Proto Fleet - API Keys", () => {
       await commonSteps.loginAsAdmin();
     });
 
-    await test.step("Navigate to API Keys settings", async () => {
+    await test.step("Navigate to Integrations settings", async () => {
       await settingsApiKeysPage.navigateToApiKeysSettings();
       await settingsApiKeysPage.validateApiKeysPageOpened();
     });

--- a/client/e2eTests/protoFleet/spec/generalSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/generalSettings.spec.ts
@@ -23,7 +23,7 @@ test.describe("General Settings", () => {
       const commonSteps = new CommonSteps(authPage, minersPage);
 
       await commonSteps.loginAsAdmin();
-      await authPage.navigateToSettingsPage();
+      await authPage.navigateToPreferencesSettings();
 
       const currentTemperature = await settingsPage.getCurrentTemperatureFormat();
 
@@ -51,8 +51,8 @@ test.describe("General Settings", () => {
     let subnet = "";
     let gateway = "";
 
-    await test.step("Navigate to general settings and capture the network info response", async () => {
-      await authPage.navigateToSettingsPage();
+    await test.step("Navigate to network settings and capture the network info response", async () => {
+      await authPage.navigateToNetworkSettings();
       const response = await networkInfoResponsePromise;
       const body = await response.json();
 
@@ -70,8 +70,8 @@ test.describe("General Settings", () => {
   test("Set temperature format", async ({ authPage, settingsPage, minersPage, commonSteps }) => {
     await commonSteps.loginAsAdmin();
 
-    await test.step("Navigate to general settings", async () => {
-      await authPage.navigateToSettingsPage();
+    await test.step("Navigate to preferences settings", async () => {
+      await authPage.navigateToPreferencesSettings();
     });
 
     await test.step("Set temperature to Fahrenheit", async () => {
@@ -88,7 +88,7 @@ test.describe("General Settings", () => {
     });
 
     await test.step("Navigate back to settings", async () => {
-      await authPage.navigateToSettingsPage();
+      await authPage.navigateToPreferencesSettings();
     });
 
     await test.step("Change temperature format to Celsius", async () => {
@@ -121,8 +121,8 @@ test.describe("General Settings", () => {
       Dark: "dark",
     };
 
-    await test.step("Navigate to general settings and capture the current theme", async () => {
-      await authPage.navigateToSettingsPage();
+    await test.step("Navigate to preferences settings and capture the current theme", async () => {
+      await authPage.navigateToPreferencesSettings();
       originalTheme = await settingsPage.getCurrentTheme();
       targetTheme = targetThemeByCurrentTheme[originalTheme] ?? "Dark";
     });

--- a/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
+++ b/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
@@ -4,7 +4,7 @@ import { Link, useLocation } from "react-router-dom";
 import clsx from "clsx";
 import { useLogoutAction } from "@/protoFleet/api/useLogout";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
-import { NavItem, secondaryNavItems } from "@/protoFleet/config/navItems";
+import { isNavItemAllowedByPermissions, NavItem, secondaryNavItems } from "@/protoFleet/config/navItems";
 import { useNavFeatureEnabled } from "@/protoFleet/hooks/useNavFeatureEnabled";
 import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
 import { scopedPath, unscopedScopablePath } from "@/protoFleet/routing/siteScope";
@@ -32,13 +32,9 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
   const featureEnabled = useNavFeatureEnabled();
   const { activeSite } = useActiveSite({});
   const [settingsManuallyToggled, setSettingsManuallyToggled] = useState(false);
-  const hasPermission = useCallback(
-    (key: string | undefined) => key === undefined || permissions.includes(key),
-    [permissions],
-  );
   const visibleItems = useMemo(
-    () => items.filter((item) => hasPermission(item.requiredPermission)),
-    [items, hasPermission],
+    () => items.filter((item) => isNavItemAllowedByPermissions(item, permissions)),
+    [items, permissions],
   );
   const [showSettingsHover, setShowSettingsHover] = useState(false);
 
@@ -46,6 +42,28 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
 
   const homeItem = useMemo(() => items.find((item) => item.label === "Home"), [items]);
   const settingsItem = useMemo(() => items.find((item) => item.label === "Settings"), [items]);
+  const visibleSettingsItems = useMemo(
+    () =>
+      secondaryNavItems
+        .filter((nav) => nav.parent === "/settings")
+        .filter((nav) => isNavItemAllowedByPermissions(nav, permissions))
+        .filter((nav) => !nav.requiredFeature || featureEnabled[nav.requiredFeature]),
+    [featureEnabled, permissions],
+  );
+  const visibleSettingsGroups = useMemo(
+    () =>
+      visibleSettingsItems.reduce<Array<{ section?: string; items: typeof visibleSettingsItems }>>((groups, item) => {
+        const lastGroup = groups[groups.length - 1];
+        if (lastGroup && lastGroup.section === item.section) {
+          lastGroup.items.push(item);
+          return groups;
+        }
+
+        groups.push({ section: item.section, items: [item] });
+        return groups;
+      }, []),
+    [visibleSettingsItems],
+  );
 
   // Check if current page is a settings sub-item
   const isOnSettingsSubPage = useMemo(() => {
@@ -160,9 +178,7 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
           })}
 
           {/* On mobile/tablet: show expandable Settings menu */}
-          {(isPhone || isTablet) &&
-          settingsItem &&
-          secondaryNavItems.filter((nav) => nav.parent === "/settings").length > 0 ? (
+          {(isPhone || isTablet) && settingsItem && visibleSettingsItems.length > 0 ? (
             <>
               <li className="w-full">
                 <button
@@ -209,30 +225,33 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
                       y: -12,
                       transition: { duration: 0.3, ease: easeGentle },
                     }}
-                    className="flex w-full flex-col gap-3"
+                    className="flex w-full flex-col gap-5"
                   >
-                    {secondaryNavItems
-                      .filter((nav) => nav.parent === "/settings")
-                      .filter((nav) => hasPermission(nav.requiredPermission))
-                      .filter((nav) => !nav.requiredFeature || featureEnabled[nav.requiredFeature])
-                      .map((nav) => (
-                        <li key={nav.path} className="w-full">
-                          <Link
-                            to={nav.path}
-                            onClick={() => closeMenu?.()}
-                            aria-current={isCurrentPath(nav.path) ? "page" : undefined}
-                            className={clsx(
-                              "block rounded-lg px-9 py-1 text-emphasis-300 text-text-primary-70",
-                              "hover:cursor-pointer hover:bg-core-primary-5",
-                              {
-                                "bg-core-primary-5": isCurrentPath(nav.path),
-                              },
-                            )}
-                          >
-                            {nav.label}
-                          </Link>
-                        </li>
-                      ))}
+                    {visibleSettingsGroups.map((group, index) => (
+                      <div key={group.section ?? `settings-group-${index}`} className="flex w-full flex-col">
+                        {group.section ? (
+                          <div className="px-9 text-200 font-medium text-text-primary-50">{group.section}</div>
+                        ) : null}
+                        {group.items.map((nav) => (
+                          <li key={nav.path} className="w-full">
+                            <Link
+                              to={nav.path}
+                              onClick={() => closeMenu?.()}
+                              aria-current={isCurrentPath(nav.path) ? "page" : undefined}
+                              className={clsx(
+                                "block rounded-lg px-9 py-1 text-emphasis-300 text-text-primary-70",
+                                "hover:cursor-pointer hover:bg-core-primary-5",
+                                {
+                                  "bg-core-primary-5": isCurrentPath(nav.path),
+                                },
+                              )}
+                            >
+                              {nav.label}
+                            </Link>
+                          </li>
+                        ))}
+                      </div>
+                    ))}
                   </motion.div>
                 ) : null}
               </AnimatePresence>

--- a/client/src/protoFleet/components/NavigationMenu/NavigationMenu.stories.tsx
+++ b/client/src/protoFleet/components/NavigationMenu/NavigationMenu.stories.tsx
@@ -18,7 +18,7 @@ export default {
   argTypes: {},
   decorators: [
     (Story: ElementType) => (
-      <MemoryRouter initialEntries={["/settings/general"]}>
+      <MemoryRouter initialEntries={["/settings/network"]}>
         <Story />
       </MemoryRouter>
     ),

--- a/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
@@ -240,7 +240,7 @@ describe("PageHeader", () => {
     });
 
     render(
-      <MemoryRouter initialEntries={["/settings/general"]}>
+      <MemoryRouter initialEntries={["/settings/network"]}>
         <PageHeader
           schedulePillData={createSchedulePillData()}
           activeCurtailmentEvent={{

--- a/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.test.tsx
@@ -128,7 +128,7 @@ describe("SitePicker", () => {
 
   it("navigates to scoped Dashboard when selecting from a non-scopable path", () => {
     const sites = [makeSiteWithCounts(1n, "Austin")];
-    renderPicker({ sites }, ["/settings/general"]);
+    renderPicker({ sites }, ["/settings/network"]);
     fireEvent.click(screen.getByTestId("site-picker-trigger"));
     fireEvent.click(screen.getByTestId("site-picker-option-1"));
     expect(mockNavigate).toHaveBeenCalledWith("/austin/dashboard");

--- a/client/src/protoFleet/components/SecondaryNavigation/SecondaryNavigation.stories.tsx
+++ b/client/src/protoFleet/components/SecondaryNavigation/SecondaryNavigation.stories.tsx
@@ -17,7 +17,7 @@ export default {
   argTypes: {},
   decorators: [
     (Story: ElementType) => (
-      <MemoryRouter initialEntries={["/settings/general"]}>
+      <MemoryRouter initialEntries={["/settings/network"]}>
         <Story />
       </MemoryRouter>
     ),

--- a/client/src/protoFleet/components/SecondaryNavigation/SecondaryNavigation.test.tsx
+++ b/client/src/protoFleet/components/SecondaryNavigation/SecondaryNavigation.test.tsx
@@ -31,7 +31,7 @@ describe("Secondary Navigation", () => {
     );
 
     const navMenu = getByTestId("secondary-nav");
-    const navItems = navMenu.querySelectorAll("li");
+    const navItems = navMenu.querySelectorAll("a");
     expect(navItems.length).toBe(3);
   });
 
@@ -46,5 +46,22 @@ describe("Secondary Navigation", () => {
     await waitFor(() => {
       expect(currentItem).toHaveClass("bg-core-primary-5");
     });
+  });
+
+  it("renders section labels when provided", () => {
+    const { getByText } = render(
+      <MemoryRouter initialEntries={["/bar/foo"]}>
+        <SecondaryNavigation
+          items={[
+            { ...items[0], section: "Fleet" },
+            { ...items[1], section: "Fleet" },
+            { ...items[2], section: "Admin" },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(getByText("Fleet")).toBeInTheDocument();
+    expect(getByText("Admin")).toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/components/SecondaryNavigation/SecondaryNavigation.tsx
+++ b/client/src/protoFleet/components/SecondaryNavigation/SecondaryNavigation.tsx
@@ -1,7 +1,7 @@
 import { Link, useLocation } from "react-router-dom";
 import { clsx } from "clsx";
 
-import { type SecondaryNavItem } from "@/protoFleet/config/navItems";
+import { isNavItemAllowedByPermissions, type SecondaryNavItem } from "@/protoFleet/config/navItems";
 import { useNavFeatureEnabled } from "@/protoFleet/hooks/useNavFeatureEnabled";
 import { usePermissions } from "@/protoFleet/store";
 import { useWindowDimensions } from "@/shared/hooks/useWindowDimensions";
@@ -25,7 +25,7 @@ const SecondaryNavigation = ({ items }: SecondaryNavigationProps) => {
     const _pathname = stripLeadingSlash(pathname);
     const _parent = stripLeadingSlash(item.parent);
     const pathMatch = _pathname === _parent || _pathname.startsWith(`${_parent}/`);
-    const permissionMatch = !item.requiredPermission || permissions.includes(item.requiredPermission);
+    const permissionMatch = isNavItemAllowedByPermissions(item, permissions);
     const featureMatch = !item.requiredFeature || featureEnabled[item.requiredFeature];
     return pathMatch && permissionMatch && featureMatch;
   });
@@ -40,24 +40,44 @@ const SecondaryNavigation = ({ items }: SecondaryNavigationProps) => {
   // dont render anything
   if (visibleItems.length === 0) return null;
 
+  const visibleGroups = visibleItems.reduce<Array<{ section?: string; items: SecondaryNavItem[] }>>((groups, item) => {
+    const lastGroup = groups[groups.length - 1];
+    if (lastGroup && lastGroup.section === item.section) {
+      lastGroup.items.push(item);
+      return groups;
+    }
+
+    groups.push({ section: item.section, items: [item] });
+    return groups;
+  }, []);
+
   return (
     <nav aria-label="Settings">
       <ul
         data-testid="secondary-nav"
-        className="flex min-h-[calc(100vh-(--spacing(1))*15)] w-[176px] shrink-0 flex-col gap-3 px-3 pt-3 text-text-primary-70"
+        className="flex min-h-[calc(100vh-(--spacing(1))*15)] w-[176px] shrink-0 flex-col gap-8 px-3 pt-6 text-text-primary-70"
       >
-        {visibleItems.map((item) => {
+        {visibleGroups.map((group, groupIndex) => {
           return (
-            <li key={item.path}>
-              <Link
-                to={"/" + stripLeadingSlash(item.path)}
-                aria-current={isCurrentPath(item.path) ? "page" : undefined}
-                className={clsx("block rounded-lg px-2 py-1 text-emphasis-300 text-text-primary-70", {
-                  "bg-core-primary-5": isCurrentPath(item.path),
-                })}
-              >
-                {item.label}
-              </Link>
+            <li key={group.section ?? `group-${groupIndex}`}>
+              {group.section ? (
+                <div className="px-2 pb-2 text-300 font-medium text-text-primary-50">{group.section}</div>
+              ) : null}
+              <ul className="flex flex-col">
+                {group.items.map((item) => (
+                  <li key={item.path}>
+                    <Link
+                      to={"/" + stripLeadingSlash(item.path)}
+                      aria-current={isCurrentPath(item.path) ? "page" : undefined}
+                      className={clsx("block rounded-lg px-2 py-1 text-emphasis-300 text-text-primary-70", {
+                        "bg-core-primary-5": isCurrentPath(item.path),
+                      })}
+                    >
+                      {item.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </li>
           );
         })}

--- a/client/src/protoFleet/config/navItems.test.ts
+++ b/client/src/protoFleet/config/navItems.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { primaryNavItems, secondaryNavItems } from "./navItems";
+import {
+  getFirstAllowedSecondaryNavPath,
+  isNavItemAllowedByPermissions,
+  primaryNavItems,
+  secondaryNavItems,
+} from "./navItems";
 import { LightningAlt } from "@/shared/assets/icons";
 
 describe("primaryNavItems", () => {
@@ -18,17 +23,75 @@ describe("primaryNavItems", () => {
 });
 
 describe("secondaryNavItems", () => {
-  it("shows Curtailment above API Keys in settings navigation", () => {
+  it("groups settings navigation by product area", () => {
     const labels = secondaryNavItems.map((item) => item.label);
 
     expect(secondaryNavItems).toContainEqual(
       expect.objectContaining({
-        path: "/settings/curtailment",
-        label: "Curtailment",
+        path: "/settings/network",
+        label: "Network",
         parent: "/settings",
-        requiredPermission: "curtailment:manage",
+        section: "Fleet",
+        requiredPermission: "fleet:read",
       }),
     );
-    expect(labels.indexOf("Curtailment")).toBe(labels.indexOf("API Keys") - 1);
+    expect(secondaryNavItems).toContainEqual(
+      expect.objectContaining({
+        path: "/settings/preferences",
+        label: "Preferences",
+        parent: "/settings",
+        section: "Account",
+      }),
+    );
+    expect(labels.indexOf("Network")).toBeLessThan(labels.indexOf("Schedules"));
+    expect(labels.indexOf("Schedules")).toBeLessThan(labels.indexOf("Security"));
+    expect(labels.indexOf("Security")).toBeLessThan(labels.indexOf("Preferences"));
+  });
+
+  it("renames API key management to Integrations", () => {
+    expect(secondaryNavItems).toContainEqual(
+      expect.objectContaining({
+        path: "/settings/integrations",
+        label: "Integrations",
+        parent: "/settings",
+        section: "Admin",
+        requiredPermission: "apikey:manage",
+      }),
+    );
+  });
+
+  it("folds role management into the Team destination", () => {
+    expect(secondaryNavItems).toContainEqual(
+      expect.objectContaining({
+        path: "/settings/team",
+        label: "Team",
+        parent: "/settings",
+        section: "Admin",
+        requiredAnyPermission: ["user:read", "role:manage"],
+      }),
+    );
+    expect(secondaryNavItems.some((item) => item.path === "/settings/roles")).toBe(false);
+  });
+});
+
+describe("isNavItemAllowedByPermissions", () => {
+  it("supports any-permission destinations", () => {
+    const item = {
+      path: "/settings/team",
+      label: "Team",
+      parent: "/settings",
+      requiredAnyPermission: ["user:read", "role:manage"],
+    };
+
+    expect(isNavItemAllowedByPermissions(item, ["role:manage"])).toBe(true);
+    expect(isNavItemAllowedByPermissions(item, ["user:read"])).toBe(true);
+    expect(isNavItemAllowedByPermissions(item, ["apikey:manage"])).toBe(false);
+  });
+});
+
+describe("getFirstAllowedSecondaryNavPath", () => {
+  it("uses Network for fleet readers and skips it otherwise", () => {
+    expect(getFirstAllowedSecondaryNavPath(["fleet:read"])).toBe("/settings/network");
+    expect(getFirstAllowedSecondaryNavPath(["role:manage"])).not.toBe("/settings/network");
   });
 });

--- a/client/src/protoFleet/config/navItems.test.ts
+++ b/client/src/protoFleet/config/navItems.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  getFirstAllowedSecondaryNavPath,
-  isNavItemAllowedByPermissions,
-  primaryNavItems,
-  secondaryNavItems,
-} from "./navItems";
+import { getSettingsLandingPath, isNavItemAllowedByPermissions, primaryNavItems, secondaryNavItems } from "./navItems";
 import { LightningAlt } from "@/shared/assets/icons";
 
 describe("primaryNavItems", () => {
@@ -41,6 +36,15 @@ describe("secondaryNavItems", () => {
         label: "Preferences",
         parent: "/settings",
         section: "Account",
+      }),
+    );
+    expect(secondaryNavItems).toContainEqual(
+      expect.objectContaining({
+        path: "/settings/firmware",
+        label: "Firmware",
+        parent: "/settings",
+        section: "Fleet",
+        requiredPermission: "miner:firmware_update",
       }),
     );
     expect(labels.indexOf("Network")).toBeLessThan(labels.indexOf("Schedules"));
@@ -89,9 +93,10 @@ describe("isNavItemAllowedByPermissions", () => {
   });
 });
 
-describe("getFirstAllowedSecondaryNavPath", () => {
-  it("uses Network for fleet readers and skips it otherwise", () => {
-    expect(getFirstAllowedSecondaryNavPath(["fleet:read"])).toBe("/settings/network");
-    expect(getFirstAllowedSecondaryNavPath(["role:manage"])).not.toBe("/settings/network");
+describe("getSettingsLandingPath", () => {
+  it("uses Network for fleet readers and Preferences as the safe fallback", () => {
+    expect(getSettingsLandingPath(["fleet:read"])).toBe("/settings/network");
+    expect(getSettingsLandingPath(["role:manage"])).toBe("/settings/preferences");
+    expect(getSettingsLandingPath([])).toBe("/settings/preferences");
   });
 });

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -115,6 +115,7 @@ export const secondaryNavItems: SecondaryNavItem[] = [
     label: "Firmware",
     parent: "/settings",
     section: "Fleet",
+    requiredPermission: "miner:firmware_update",
   },
   {
     path: "/settings/schedules",
@@ -183,5 +184,13 @@ export const secondaryNavItems: SecondaryNavItem[] = [
   },
 ];
 
-export const getFirstAllowedSecondaryNavPath = (permissions: readonly string[]) =>
-  secondaryNavItems.find((item) => isNavItemAllowedByPermissions(item, permissions))?.path ?? "/settings/preferences";
+const defaultSettingsPath = "/settings/preferences";
+const preferredSettingsPath = "/settings/network";
+
+export const getSettingsLandingPath = (permissions: readonly string[]) => {
+  const preferredItem = secondaryNavItems.find((item) => item.path === preferredSettingsPath);
+
+  return preferredItem && isNavItemAllowedByPermissions(preferredItem, permissions)
+    ? preferredItem.path
+    : defaultSettingsPath;
+};

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -16,6 +16,7 @@ export interface NavItem {
   // filter via UserInfo.permissions. Entries without a requiredPermission
   // are visible to every authenticated user.
   requiredPermission?: string;
+  requiredAnyPermission?: string[];
   scopable?: boolean;
 }
 
@@ -23,7 +24,9 @@ export interface SecondaryNavItem {
   path: string;
   label: string;
   parent: string;
+  section?: "Fleet" | "Automation" | "Admin" | "Account";
   requiredPermission?: string;
+  requiredAnyPermission?: string[];
   // When set, the entry is shown only if the server reports this feature enabled.
   requiredFeature?: NavFeature;
   // Whether the page honors the topbar SitePicker selection as a soft default
@@ -33,6 +36,17 @@ export interface SecondaryNavItem {
   // is org-wide for now; scoping it is tracked with the Energy page in #521.
   siteAware?: boolean;
 }
+
+export const isNavItemAllowedByPermissions = (
+  item: Pick<NavItem | SecondaryNavItem, "requiredPermission" | "requiredAnyPermission">,
+  permissions: readonly string[],
+) => {
+  const hasRequiredPermission = !item.requiredPermission || permissions.includes(item.requiredPermission);
+  const hasAnyPermission =
+    !item.requiredAnyPermission || item.requiredAnyPermission.some((permission) => permissions.includes(permission));
+
+  return hasRequiredPermission && hasAnyPermission;
+};
 
 // Primary navigation items (shown in main nav menu)
 export const primaryNavItems: NavItem[] = [
@@ -79,35 +93,17 @@ export const primaryNavItems: NavItem[] = [
 // Secondary navigation items (shown in settings submenu)
 export const secondaryNavItems: SecondaryNavItem[] = [
   {
-    path: "/settings/general",
-    label: "General",
+    path: "/settings/network",
+    label: "Network",
     parent: "/settings",
-  },
-  {
-    path: "/settings/security",
-    label: "Security",
-    parent: "/settings",
-  },
-  {
-    path: "/settings/team",
-    label: "Team",
-    parent: "/settings",
-    // ListUsers is server-gated on user:read (held by ADMIN + SUPER_ADMIN
-    // but not FIELD_TECH). Without this gate the entry shows for every
-    // authenticated user even though the page can't load anything.
-    requiredPermission: "user:read",
-  },
-  {
-    path: "/settings/roles",
-    label: "Roles",
-    parent: "/settings",
-    // Roles management reads/writes are server-gated on role:manage.
-    requiredPermission: "role:manage",
+    section: "Fleet",
+    requiredPermission: "fleet:read",
   },
   {
     path: "/settings/mining-pools",
     label: "Pools",
     parent: "/settings",
+    section: "Fleet",
     // The Pools settings page is a management surface (Add / Edit /
     // Test / Delete with no read-only mode), so gate the nav on
     // pool:manage to match the page's capability rather than pool:read.
@@ -118,11 +114,13 @@ export const secondaryNavItems: SecondaryNavItem[] = [
     path: "/settings/firmware",
     label: "Firmware",
     parent: "/settings",
+    section: "Fleet",
   },
   {
     path: "/settings/schedules",
     label: "Schedules",
     parent: "/settings",
+    section: "Automation",
     // The Schedules settings page is a management surface (Add, edit,
     // pause, resume, delete, reorder; no view-only mode), so gate the
     // nav on schedule:manage to match the page's capability rather
@@ -134,18 +132,14 @@ export const secondaryNavItems: SecondaryNavItem[] = [
     path: "/settings/curtailment",
     label: "Curtailment",
     parent: "/settings",
+    section: "Automation",
     requiredPermission: "curtailment:manage",
-  },
-  {
-    path: "/settings/api-keys",
-    label: "API Keys",
-    parent: "/settings",
-    requiredPermission: "apikey:manage",
   },
   {
     path: "/settings/alerts",
     label: "Alerts",
     parent: "/settings",
+    section: "Automation",
     requiredPermission: "alert:read",
     // Needs the Grafana sidecar, which is off in the default deployment. Gated
     // at runtime so an operator enabling the sidecar surfaces the entry without
@@ -153,9 +147,41 @@ export const secondaryNavItems: SecondaryNavItem[] = [
     requiredFeature: "alerts",
   },
   {
+    path: "/settings/security",
+    label: "Security",
+    parent: "/settings",
+    section: "Admin",
+  },
+  {
+    path: "/settings/team",
+    label: "Team",
+    parent: "/settings",
+    section: "Admin",
+    // Team now owns member and role management. Show the entry when either
+    // surface is usable so role-only admins are not stranded after the merge.
+    requiredAnyPermission: ["user:read", "role:manage"],
+  },
+  {
+    path: "/settings/integrations",
+    label: "Integrations",
+    parent: "/settings",
+    section: "Admin",
+    requiredPermission: "apikey:manage",
+  },
+  {
     path: "/settings/server-logs",
     label: "Server Logs",
     parent: "/settings",
+    section: "Admin",
     requiredPermission: "serverlog:read",
   },
+  {
+    path: "/settings/preferences",
+    label: "Preferences",
+    parent: "/settings",
+    section: "Account",
+  },
 ];
+
+export const getFirstAllowedSecondaryNavPath = (permissions: readonly string[]) =>
+  secondaryNavItems.find((item) => isNavItemAllowedByPermissions(item, permissions))?.path ?? "/settings/preferences";

--- a/client/src/protoFleet/features/alerts/pages/Alerts.tsx
+++ b/client/src/protoFleet/features/alerts/pages/Alerts.tsx
@@ -6,8 +6,10 @@ import ChannelsSection from "@/protoFleet/features/alerts/components/ChannelsSec
 import HistorySection from "@/protoFleet/features/alerts/components/HistorySection";
 import MaintenanceWindowsSection from "@/protoFleet/features/alerts/components/MaintenanceWindowsSection";
 import RulesSection from "@/protoFleet/features/alerts/components/RulesSection";
-import Header from "@/shared/components/Header";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+const ALERTS_PAGE_DESCRIPTION = "Configure alert rules, notification channels, and maintenance windows.";
 
 const Alerts = () => {
   const alerts = useAlerts();
@@ -25,7 +27,7 @@ const Alerts = () => {
   return (
     <AlertsContext.Provider value={alerts}>
       <div className="flex flex-col gap-6 pb-10">
-        <Header title="Alerts" titleSize="text-heading-300" />
+        <SettingsPageHeader title="Alerts" description={ALERTS_PAGE_DESCRIPTION} />
         <div className="flex flex-col gap-4">
           <RulesSection />
           <HistorySection />

--- a/client/src/protoFleet/features/settings/components/AddTeamMemberModal.tsx
+++ b/client/src/protoFleet/features/settings/components/AddTeamMemberModal.tsx
@@ -215,7 +215,7 @@ const AddTeamMemberModal = ({ open, onDismiss, onSuccess }: AddTeamMemberModalPr
             <span className="text-200 text-text-primary-50">
               {isLoadingRoles
                 ? "Loading roles…"
-                : "The role sets what this member can see and do. Manage roles in Settings → Roles."}
+                : "The role sets what this member can see and do. Manage roles in Team → Roles."}
             </span>
           </div>
         </div>

--- a/client/src/protoFleet/features/settings/components/ApiKeys.tsx
+++ b/client/src/protoFleet/features/settings/components/ApiKeys.tsx
@@ -4,10 +4,11 @@ import { useApiKeys } from "@/protoFleet/api/useApiKeys";
 import type { ApiKeyItem } from "@/protoFleet/api/useApiKeys";
 import CreateApiKeyModal from "@/protoFleet/features/settings/components/CreateApiKeyModal";
 import RevokeApiKeyDialog from "@/protoFleet/features/settings/components/RevokeApiKeyDialog";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { useHasPermission } from "@/protoFleet/store";
 import { Trash } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
-import Header from "@/shared/components/Header";
 import List from "@/shared/components/List";
 import { ColConfig, ColTitles } from "@/shared/components/List/types";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
@@ -144,18 +145,22 @@ const ApiKeys = () => {
   // Redirect callers without apikey:manage away — placed after all
   // hooks to satisfy rules-of-hooks.
   if (!canManageApiKeys) {
-    return <Navigate to="/settings/general" replace />;
+    return <Navigate to="/settings/network" replace />;
   }
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <Header title="API Keys" titleSize="text-heading-300" />
+      <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
+        <SettingsPageHeader
+          title="Integrations"
+          description="Create and manage API keys for tools that integrate with Fleet."
+        />
         <Button
           variant={variants.primary}
           size={sizes.compact}
           text="Create API key"
           onClick={() => setShowCreateModal(true)}
+          className="shrink-0 phone:w-full"
         />
       </div>
 
@@ -171,9 +176,10 @@ const ApiKeys = () => {
           total={apiKeys.length}
           itemName={{ singular: "key", plural: "keys" }}
           noDataElement={
-            <div className="py-10 text-center text-text-primary-50">
-              No API keys yet. Create your first key to enable programmatic access to the Fleet API.
-            </div>
+            <SettingsEmptyState
+              title="No API keys yet"
+              description="Create your first key to enable programmatic access to the Fleet API."
+            />
           }
           actions={availableActions}
         />

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -4,6 +4,7 @@ import { create } from "@bufbuild/protobuf";
 import { AuthenticateRequestSchema } from "@/protoFleet/api/generated/auth/v1/auth_pb";
 import { useAuth } from "@/protoFleet/api/useAuth";
 import { useLogin } from "@/protoFleet/api/useLogin";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { useUsername } from "@/protoFleet/store";
 import { Alert } from "@/shared/assets/icons";
 import Button from "@/shared/components/Button";
@@ -235,9 +236,8 @@ const AuthenticationSettings = () => {
   return (
     <>
       <div className="flex flex-col gap-6">
-        <Header
+        <SettingsPageHeader
           title="Security"
-          titleSize="text-heading-300"
           description="Protect your mining fleet by managing system access, miner credentials, and team permissions."
         />
         <div className="flex flex-col gap-4">

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
@@ -99,7 +99,7 @@ describe("CurtailmentAutomationsContent", () => {
 
     expect(screen.getByText("Automations")).toBeVisible();
     expect(screen.getByRole("button", { name: "Create automation" })).toBeEnabled();
-    expect(screen.getByRole("columnheader", { name: "Name" })).toBeVisible();
+    expect(screen.getByRole("columnheader", { name: "Name" })).toHaveClass("text-text-primary");
     expect(screen.getByRole("columnheader", { name: "Condition" })).toBeVisible();
     expect(screen.getByRole("columnheader", { name: "Response profile" })).toBeVisible();
     expect(screen.getByRole("columnheader", { name: "Enabled" })).toBeInTheDocument();

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
@@ -8,6 +8,7 @@ import type {
   CurtailmentSource,
   ResponseProfile,
 } from "@/protoFleet/features/settings/components/Curtailment/types";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
 import { Info } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -59,7 +60,6 @@ const automationColumnsExemptFromDisabledStyling = new Set<AutomationColumn>([au
 const automationTableClassName = [
   "mb-2 w-full",
   "phone:table-fixed",
-  "[&_thead_th]:text-text-primary-50",
   "phone:[&_thead_th:last-child]:w-14",
   "phone:[&_thead_th:last-child>div]:w-14",
   "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:box-border",
@@ -259,10 +259,11 @@ function SectionHeader({ title, buttonText, onButtonClick, infoToggle }: Section
 
 function AutomationsEmptyState(): ReactElement {
   return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">No automations configured</div>
-      <p className="mt-1 text-400 text-text-primary-70">Add an automation to trigger a response profile.</p>
-    </div>
+    <SettingsEmptyState
+      size="section"
+      title="No automations configured"
+      description="Add an automation to trigger a response profile."
+    />
   );
 }
 
@@ -275,12 +276,7 @@ function AutomationsLoadingState(): ReactElement {
 }
 
 function AutomationsErrorState({ message }: { message: string }): ReactElement {
-  return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">Unable to load automations</div>
-      <p className="mt-1 text-400 text-text-primary-70">{message}</p>
-    </div>
-  );
+  return <SettingsEmptyState size="section" title="Unable to load automations" description={message} />;
 }
 
 function AutomationDependencyMessage({ children }: { children: string }): ReactElement {
@@ -706,7 +702,7 @@ export function CurtailmentAutomationsContent({
   }, [controlledAutomationRules, editingAutomationRule, onDeleteAutomation]);
 
   const isEditingAutomation = editingAutomationRule ? updatingRuleIds.has(editingAutomationRule.id) : false;
-  const automationsEmptyStateRow = getAutomationsEmptyState(loadError, isLoading);
+  const automationsNoDataElement = getAutomationsEmptyState(loadError, isLoading);
 
   return (
     <section
@@ -735,7 +731,7 @@ export function CurtailmentAutomationsContent({
         isRowDisabled={(rule) => !rule.enabled}
         columnsExemptFromDisabledStyling={automationColumnsExemptFromDisabledStyling}
         tableClassName={automationTableClassName}
-        emptyStateRow={automationsEmptyStateRow}
+        noDataElement={automationsNoDataElement}
         applyColumnWidthsToCells
         onRowClick={openEditAutomationModal}
       />

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -497,7 +497,7 @@ describe("CurtailmentSettingsPage", () => {
     mockAutomationRulesApi();
   });
 
-  it("renders the curtailment header, response profile cards, and sources table", () => {
+  it("renders the curtailment header and section null states", () => {
     vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
 
     render(
@@ -528,16 +528,11 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByRole("button", { name: "Create automation" })).toBeEnabled();
     expect(screen.queryByRole("button", { name: "Save settings" })).not.toBeInTheDocument();
     expect(document.querySelector(".curtailment-section-header__icon")).not.toBeInTheDocument();
-    const nameColumnHeaders = screen.getAllByRole("columnheader", { name: "Name" });
-    expect(nameColumnHeaders[0].closest("table")?.className).toContain("[&_thead_th]:text-text-primary-50");
-
-    for (const columnName of ["Last signal", "Updated", "Connection"]) {
-      expect(screen.getByRole("columnheader", { name: columnName })).toBeInTheDocument();
-    }
-    expect(screen.getByRole("columnheader", { name: "Condition" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Response profile" })).toBeInTheDocument();
-    expect(screen.getAllByRole("columnheader", { name: "Enabled" })).toHaveLength(2);
-    expect(nameColumnHeaders).toHaveLength(2);
+    expect(screen.getByText("No sources configured")).toBeVisible();
+    expect(screen.getByText("No automations configured")).toBeVisible();
+    expect(screen.queryByRole("columnheader", { name: "Name" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Condition" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Enabled" })).not.toBeInTheDocument();
     for (const profileColumnName of ["Target", "Scope", "Selection", "Restore", "Deadline"]) {
       expect(screen.queryByRole("columnheader", { name: profileColumnName })).not.toBeInTheDocument();
     }
@@ -546,7 +541,7 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.queryByRole("columnheader", { name: "Broker hosts" })).not.toBeInTheDocument();
     expect(screen.queryByText("Site Alpha MQTT")).not.toBeInTheDocument();
     expect(screen.queryByText("Site Beta MQTT")).not.toBeInTheDocument();
-    expect(screen.getAllByTestId("list-empty-row")).toHaveLength(2);
+    expect(screen.queryByTestId("list-empty-row")).not.toBeInTheDocument();
     expect(screen.getByText("No response profiles configured")).toBeVisible();
     expect(screen.getByText("Add a profile to reuse curtailment actions across automation rules.")).toBeVisible();
     expect(screen.getByText("No sources configured")).toBeVisible();

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -29,6 +29,8 @@ import {
   type ResponseProfile,
   type ResponseProfileFormValues,
 } from "@/protoFleet/features/settings/components/Curtailment/types";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useHasPermission } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -37,7 +39,6 @@ import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import { DismissibleCalloutWrapper, intents } from "@/shared/components/Callout";
 import Card, { cardType } from "@/shared/components/Card";
-import Header from "@/shared/components/Header";
 import Input from "@/shared/components/Input";
 import List from "@/shared/components/List";
 import type { ColConfig, ColTitles } from "@/shared/components/List/types";
@@ -113,7 +114,6 @@ const curtailmentSourceColumnsExemptFromDisabledStyling = new Set<CurtailmentSou
 const curtailmentSourcesTableClassName = [
   "mb-2 w-full",
   "phone:table-fixed",
-  "[&_thead_th]:text-text-primary-50",
   "phone:[&_thead_th:last-child]:w-14",
   "phone:[&_thead_th:last-child>div]:w-14",
   "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:box-border",
@@ -597,10 +597,11 @@ function SourcesInfoToggle(): ReactElement {
 
 function SourcesEmptyState(): ReactElement {
   return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">No sources configured</div>
-      <p className="mt-1 text-400 text-text-primary-70">Add a MaestroOS MQTT source to receive curtailment signals.</p>
-    </div>
+    <SettingsEmptyState
+      size="section"
+      title="No sources configured"
+      description="Add a MaestroOS MQTT source to receive curtailment signals."
+    />
   );
 }
 
@@ -617,22 +618,16 @@ type SourcesErrorStateProps = {
 };
 
 function SourcesErrorState({ message }: SourcesErrorStateProps): ReactElement {
-  return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">Unable to load sources</div>
-      <p className="mt-1 text-400 text-text-primary-70">{message}</p>
-    </div>
-  );
+  return <SettingsEmptyState size="section" title="Unable to load sources" description={message} />;
 }
 
 function ResponseProfilesEmptyState(): ReactElement {
   return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">No response profiles configured</div>
-      <p className="mt-1 text-400 text-text-primary-70">
-        Add a profile to reuse curtailment actions across automation rules.
-      </p>
-    </div>
+    <SettingsEmptyState
+      size="section"
+      title="No response profiles configured"
+      description="Add a profile to reuse curtailment actions across automation rules."
+    />
   );
 }
 
@@ -649,12 +644,7 @@ type ResponseProfilesErrorStateProps = {
 };
 
 function ResponseProfilesErrorState({ message }: ResponseProfilesErrorStateProps): ReactElement {
-  return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">Unable to load response profiles</div>
-      <p className="mt-1 text-400 text-text-primary-70">{message}</p>
-    </div>
-  );
+  return <SettingsEmptyState size="section" title="Unable to load response profiles" description={message} />;
 }
 
 type ResponseProfileCardProps = {
@@ -1483,11 +1473,11 @@ export function CurtailmentSettingsContent({
     [toggleSource, updatingSourceIds],
   );
 
-  const emptyStateRow = getSourcesEmptyState(loadSourcesError, isLoadingSources);
+  const noDataElement = getSourcesEmptyState(loadSourcesError, isLoadingSources);
 
   return (
     <div className="flex flex-col gap-14" data-testid="settings-curtailment-page">
-      <Header title="Curtailment" titleSize="text-heading-300" description={CURTAILMENT_PAGE_DESCRIPTION} />
+      <SettingsPageHeader title="Curtailment" description={CURTAILMENT_PAGE_DESCRIPTION} />
 
       <section className="curtailment-settings__section">
         <SectionHeader
@@ -1525,7 +1515,7 @@ export function CurtailmentSettingsContent({
           isRowDisabled={(source) => !source.enabled}
           columnsExemptFromDisabledStyling={curtailmentSourceColumnsExemptFromDisabledStyling}
           tableClassName={curtailmentSourcesTableClassName}
-          emptyStateRow={emptyStateRow}
+          noDataElement={noDataElement}
           applyColumnWidthsToCells
           onRowClick={openEditSourceModal}
         />
@@ -1896,7 +1886,7 @@ function CurtailmentSettingsPage(): ReactElement {
   );
 
   if (!canManageCurtailment) {
-    return <Navigate to="/settings/general" replace />;
+    return <Navigate to="/settings/network" replace />;
   }
 
   const effectiveSiteOptions = canLoadSiteOptions ? siteOptions : [];

--- a/client/src/protoFleet/features/settings/components/EditRoleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/EditRoleModal.tsx
@@ -168,7 +168,7 @@ const EditRoleModal = ({ open, userId, username, currentRoleName, onDismiss, onS
         <span className="text-200 text-text-primary-50">
           {isLoadingRoles
             ? "Loading roles…"
-            : "The role sets what this member can see and do. Manage roles in Settings → Roles."}
+            : "The role sets what this member can see and do. Manage roles in Team → Roles."}
         </span>
       </div>
     </Modal>

--- a/client/src/protoFleet/features/settings/components/Firmware.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.test.tsx
@@ -51,7 +51,8 @@ describe("Firmware", () => {
     const { getByText } = render(<Firmware />);
 
     await waitFor(() => {
-      expect(getByText("No firmware files uploaded.")).toBeInTheDocument();
+      expect(getByText("No firmware files uploaded")).toBeInTheDocument();
+      expect(getByText("Upload firmware before deploying updates to your fleet.")).toBeInTheDocument();
     });
   });
 
@@ -66,14 +67,13 @@ describe("Firmware", () => {
     });
   });
 
-  it("disables Delete all button when no files exist", async () => {
+  it("hides Delete all button when no files exist", async () => {
     mockListFirmwareFiles.mockResolvedValue([]);
 
-    const { getByText } = render(<Firmware />);
+    const { queryByText } = render(<Firmware />);
 
     await waitFor(() => {
-      const deleteAllButton = getByText("Delete all").closest("button");
-      expect(deleteAllButton).toBeDisabled();
+      expect(queryByText("Delete all")).not.toBeInTheDocument();
     });
   });
 

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -3,10 +3,11 @@ import { type FirmwareFileInfo, useFirmwareApi } from "@/protoFleet/api/useFirmw
 import DeleteAllFirmwareDialog from "@/protoFleet/features/settings/components/DeleteAllFirmwareDialog";
 import DeleteFirmwareDialog from "@/protoFleet/features/settings/components/DeleteFirmwareDialog";
 import FirmwareUploadDialog from "@/protoFleet/features/settings/components/FirmwareUploadDialog";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { Trash } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import { formatFileSize } from "@/shared/components/FileSizeValue";
-import Header from "@/shared/components/Header";
 import List from "@/shared/components/List";
 import { ColConfig, ColTitles } from "@/shared/components/List/types";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
@@ -43,6 +44,7 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
 };
 
 const activeCols: FirmwareColumns[] = ["filename", "uploadedAt", "size"];
+const FIRMWARE_PAGE_DESCRIPTION = "Upload and manage firmware files available to your fleet.";
 
 function toFileData(info: FirmwareFileInfo): FirmwareFileData {
   return {
@@ -157,22 +159,26 @@ const Firmware = () => {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <Header title="Firmware" titleSize="text-heading-300" />
-        <div className="flex gap-3">
+      <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
+        <SettingsPageHeader title="Firmware" description={FIRMWARE_PAGE_DESCRIPTION} />
+        <div className="flex shrink-0 gap-3 phone:w-full phone:flex-col">
           <Button
             variant={variants.primary}
             size={sizes.compact}
             text="Upload firmware"
             onClick={() => setShowUploadDialog(true)}
+            className="phone:w-full"
           />
-          <Button
-            variant={variants.danger}
-            size={sizes.compact}
-            text="Delete all"
-            onClick={() => setShowDeleteAllDialog(true)}
-            disabled={files.length === 0 || isDeletingAll}
-          />
+          {files.length > 0 ? (
+            <Button
+              variant={variants.danger}
+              size={sizes.compact}
+              text="Delete all"
+              onClick={() => setShowDeleteAllDialog(true)}
+              disabled={isDeletingAll}
+              className="phone:w-full"
+            />
+          ) : null}
         </div>
       </div>
 
@@ -187,7 +193,12 @@ const Firmware = () => {
           colConfig={colConfig}
           total={files.length}
           itemName={{ singular: "file", plural: "files" }}
-          noDataElement={<div className="py-10 text-center text-text-primary-50">No firmware files uploaded.</div>}
+          noDataElement={
+            <SettingsEmptyState
+              title="No firmware files uploaded"
+              description="Upload firmware before deploying updates to your fleet."
+            />
+          }
           actions={availableActions}
         />
       )}

--- a/client/src/protoFleet/features/settings/components/MiningPools.test.tsx
+++ b/client/src/protoFleet/features/settings/components/MiningPools.test.tsx
@@ -70,6 +70,10 @@ describe("MiningPools", () => {
 
       expect(screen.getAllByText("Pools").length).toBeGreaterThan(0);
       expect(screen.getByText(/No pools yet/)).toBeInTheDocument();
+      expect(screen.getByText("Add a pool to start assigning your miners.")).toBeInTheDocument();
+      expect(screen.queryByText("Name")).not.toBeInTheDocument();
+      expect(screen.queryByText("URL")).not.toBeInTheDocument();
+      expect(screen.queryByText("Username")).not.toBeInTheDocument();
       expect(screen.getByRole("button", { name: /add pool/i })).toBeInTheDocument();
     });
 

--- a/client/src/protoFleet/features/settings/components/MiningPools.tsx
+++ b/client/src/protoFleet/features/settings/components/MiningPools.tsx
@@ -8,9 +8,10 @@ import {
 } from "@/protoFleet/api/generated/pools/v1/pools_pb";
 import type { Pool } from "@/protoFleet/api/generated/pools/v1/pools_pb";
 import usePools from "@/protoFleet/api/usePools";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import Ellipsis from "@/shared/assets/icons/Ellipsis";
 import Button, { sizes, variants } from "@/shared/components/Button";
-import Header from "@/shared/components/Header";
 import { fleetUsernameHelperText } from "@/shared/components/MiningPools/PoolForm/constants";
 import PoolModal from "@/shared/components/MiningPools/PoolModal";
 import type { PoolInfo } from "@/shared/components/MiningPools/types";
@@ -96,18 +97,20 @@ const PoolRowMenu = ({
   onDelete,
 }: PoolRowMenuProps) => (
   <div className="relative" ref={triggerRef}>
-    <Button
-      variant="ghost"
-      size="compact"
+    <button
+      type="button"
+      className="flex h-8 w-8 items-center justify-center text-text-primary hover:cursor-pointer hover:opacity-70"
       onClick={(e) => {
         e.stopPropagation();
         setShowMenu(!showMenu);
       }}
-      ariaLabel="Options menu"
-      ariaHasPopup="menu"
-      ariaExpanded={showMenu}
-      prefixIcon={<Ellipsis />}
-    />
+      aria-label="Options menu"
+      aria-haspopup="menu"
+      aria-expanded={showMenu}
+      data-testid="pool-actions-trigger"
+    >
+      <Ellipsis />
+    </button>
     {showMenu ? (
       <Popover
         position={positions["top left"]}
@@ -434,7 +437,7 @@ const MiningPools = () => {
     <>
       <div className="flex flex-col gap-6">
         <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
-          <Header title="Pools" description="Add and manage the pools for your fleet." titleSize="text-heading-300" />
+          <SettingsPageHeader title="Pools" description="Add and manage the pools for your fleet." />
           <Button
             variant={variants.primary}
             size={sizes.compact}
@@ -446,43 +449,41 @@ const MiningPools = () => {
         </div>
 
         <div className="flex flex-col">
-          {/* Conditional header based on screen size */}
-          {isPhone || isTablet ? (
-            /* Mobile & Tablet: Card header */
-            <div className="grid grid-cols-2 border-b border-core-primary-10 py-3 text-emphasis-300 text-text-primary-50">
-              <div>Name</div>
-              <div className="flex items-center justify-between">
-                <div>Username</div>
-              </div>
-            </div>
-          ) : (
-            /* Desktop: Table header */
-            <div className="grid grid-cols-3 gap-1 text-emphasis-300 text-text-primary-50">
-              <Row>Name</Row>
-              <Row>URL</Row>
-              <Row>Username</Row>
-            </div>
-          )}
-
-          {/* Table body */}
-          <div>
-            {pools.length === 0 ? (
-              <div className="py-10 text-center text-text-primary-50">
-                No pools yet. Add a pool to start assigning your miners.
+          {pools.length > 0 ? (
+            isPhone || isTablet ? (
+              <div className="grid grid-cols-2 border-b border-core-primary-10 py-3 text-emphasis-300 text-text-primary">
+                <div>Name</div>
+                <div className="flex items-center justify-between">
+                  <div>Username</div>
+                </div>
               </div>
             ) : (
-              pools.map((pool) => (
-                <PoolRowInner
-                  key={pool.poolId.toString()}
-                  pool={pool}
-                  onEdit={handleEditPool}
-                  onTestConnection={handleTestConnection}
-                  onDelete={handleDeletePool}
-                  connectionStatus={connectionStatuses[pool.poolId.toString()] || "idle"}
-                />
-              ))
-            )}
-          </div>
+              <div className="grid grid-cols-3 gap-1 text-emphasis-300 text-text-primary">
+                <Row>Name</Row>
+                <Row>URL</Row>
+                <Row>Username</Row>
+              </div>
+            )
+          ) : null}
+
+          {pools.length === 0 ? (
+            <SettingsEmptyState
+              className="mt-6"
+              title="No pools yet"
+              description="Add a pool to start assigning your miners."
+            />
+          ) : (
+            pools.map((pool) => (
+              <PoolRowInner
+                key={pool.poolId.toString()}
+                pool={pool}
+                onEdit={handleEditPool}
+                onTestConnection={handleTestConnection}
+                onDelete={handleDeletePool}
+                connectionStatus={connectionStatuses[pool.poolId.toString()] || "idle"}
+              />
+            ))
+          )}
         </div>
       </div>
 

--- a/client/src/protoFleet/features/settings/components/Network.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Network.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import General from "./General";
+import Network from "./Network";
 
 vi.mock("@/protoFleet/api/useNetworkInfo", () => ({
   useNetworkInfo: vi.fn(() => ({
@@ -18,49 +18,27 @@ vi.mock("@/protoFleet/store", () => ({
   useSetTemperatureUnit: vi.fn(() => vi.fn()),
 }));
 
-vi.mock("@/shared/utils/version", () => ({
-  buildVersionInfo: {
-    version: "v1.2.3",
-    buildDate: "2025-01-01",
-    commit: "abc123",
-  },
-}));
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("General", () => {
+describe("Network", () => {
   it("renders page title", () => {
-    const { getByText } = render(<General />);
+    const { getByText } = render(<Network />);
 
-    expect(getByText("General")).toBeInTheDocument();
-  });
-
-  it("renders software version", () => {
-    const { getByText } = render(<General />);
-
-    expect(getByText("Proto Fleet v1.2.3")).toBeInTheDocument();
+    expect(getByText("Network")).toBeInTheDocument();
   });
 
   it("renders network details section", () => {
-    const { getByText } = render(<General />);
+    const { getByText } = render(<Network />);
 
     expect(getByText("Network details")).toBeInTheDocument();
     expect(getByText("Subnet mask")).toBeInTheDocument();
     expect(getByText("Gateway")).toBeInTheDocument();
   });
 
-  it("renders preferences section", () => {
-    const { getByText } = render(<General />);
-
-    expect(getByText("Preferences")).toBeInTheDocument();
-    expect(getByText("Theme")).toBeInTheDocument();
-    expect(getByText("Temperature")).toBeInTheDocument();
-  });
-
   it("displays network info values", () => {
-    const { getByText } = render(<General />);
+    const { getByText } = render(<Network />);
 
     expect(getByText("192.168.1.1")).toBeInTheDocument();
     expect(getByText("192.168.1.0/24")).toBeInTheDocument();

--- a/client/src/protoFleet/features/settings/components/Network.tsx
+++ b/client/src/protoFleet/features/settings/components/Network.tsx
@@ -1,0 +1,37 @@
+import { useNetworkInfo } from "@/protoFleet/api/useNetworkInfo";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
+import Header from "@/shared/components/Header";
+import Row from "@/shared/components/Row";
+import SkeletonBar from "@/shared/components/SkeletonBar";
+
+const SkeletonLoader = <SkeletonBar className="h-[22px] w-24" />;
+const NETWORK_PAGE_DESCRIPTION = "View network details for the selected fleet.";
+
+const Network = () => {
+  const { data: networkInfo } = useNetworkInfo();
+
+  return (
+    <>
+      <div className="flex flex-col gap-6">
+        <SettingsPageHeader title="Network" description={NETWORK_PAGE_DESCRIPTION} />
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
+            <Header title="Network details" titleSize="text-heading-200" />
+            <div>
+              <Row className="flex justify-between" divider>
+                <div className="text-300">Subnet mask</div>
+                <div className="text-300">{networkInfo?.subnet ?? SkeletonLoader}</div>
+              </Row>
+              <Row className="flex justify-between" divider={false}>
+                <div className="text-300">Gateway</div>
+                <div className="text-300">{networkInfo?.gateway ?? SkeletonLoader}</div>
+              </Row>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Network;

--- a/client/src/protoFleet/features/settings/components/OrgWideNotice.tsx
+++ b/client/src/protoFleet/features/settings/components/OrgWideNotice.tsx
@@ -6,8 +6,8 @@ interface OrgWideNoticeProps {
   className?: string;
 }
 
-// Settings mixes org-wide subpages (general, security, team, …) with two
-// site-aware ones (schedules, curtailment). The topbar SitePicker lives in the
+// Settings mixes org-wide subpages (preferences, security, team, …) with
+// site-aware ones (schedules today). The topbar SitePicker lives in the
 // global PageHeader and stays visible on every settings route, so an operator
 // with a single site selected could reasonably assume it filters this page.
 // This subtext makes the org-wide pages say so explicitly — the picker

--- a/client/src/protoFleet/features/settings/components/Preferences.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Preferences.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Preferences from "./Preferences";
+
+vi.mock("@/protoFleet/store", () => ({
+  useTheme: vi.fn(() => "system"),
+  useSetTheme: vi.fn(() => vi.fn()),
+  useTemperatureUnit: vi.fn(() => "C"),
+  useSetTemperatureUnit: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/shared/utils/version", () => ({
+  buildVersionInfo: {
+    version: "v1.2.3",
+    buildDate: "2025-01-01",
+    commit: "abc123",
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Preferences", () => {
+  it("renders page title", () => {
+    const { getByText } = render(<Preferences />);
+
+    expect(getByText("Preferences")).toBeInTheDocument();
+  });
+
+  it("renders display preferences", () => {
+    const { getByText } = render(<Preferences />);
+
+    expect(getByText("Display")).toBeInTheDocument();
+    expect(getByText("Theme")).toBeInTheDocument();
+    expect(getByText("Temperature")).toBeInTheDocument();
+  });
+
+  it("renders software version", () => {
+    const { getByText } = render(<Preferences />);
+
+    expect(getByText("Proto Fleet v1.2.3")).toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/settings/components/Preferences.tsx
+++ b/client/src/protoFleet/features/settings/components/Preferences.tsx
@@ -1,45 +1,30 @@
 import { useState } from "react";
-import { useNetworkInfo } from "@/protoFleet/api/useNetworkInfo";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { useSetTemperatureUnit, useSetTheme, useTemperatureUnit, useTheme } from "@/protoFleet/store";
 import Button from "@/shared/components/Button";
 import Header from "@/shared/components/Header";
 import Row from "@/shared/components/Row";
-import SkeletonBar from "@/shared/components/SkeletonBar";
 import { TemperatureUnitsSwitcher, ThemeSwitcher } from "@/shared/features/preferences";
 import { convertToSentenceCase } from "@/shared/utils/stringUtils";
 import { buildVersionInfo } from "@/shared/utils/version";
 
-const SkeletonLoader = <SkeletonBar className="h-[22px] w-24" />;
+const PREFERENCES_PAGE_DESCRIPTION = "Manage display and temperature preferences for your account.";
 
-const General = () => {
+const Preferences = () => {
   const [showThemeSwitcher, setShowThemeSwitcher] = useState(false);
   const [showTemperatureUnitsSwitcher, setShowTemperatureUnitsSwitcher] = useState(false);
   const theme = useTheme();
   const setTheme = useSetTheme();
   const temperatureUnit = useTemperatureUnit();
   const setTemperatureUnit = useSetTemperatureUnit();
-  const { data: networkInfo } = useNetworkInfo();
 
   return (
     <>
       <div className="flex flex-col gap-6">
-        <Header title="General" titleSize="text-heading-300" />
+        <SettingsPageHeader title="Preferences" description={PREFERENCES_PAGE_DESCRIPTION} />
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
-            <Header title="Network details" titleSize="text-heading-200" />
-            <div>
-              <Row className="flex justify-between" divider>
-                <div className="text-300">Subnet mask</div>
-                <div className="text-300">{networkInfo?.subnet ?? SkeletonLoader}</div>
-              </Row>
-              <Row className="flex justify-between" divider={false}>
-                <div className="text-300">Gateway</div>
-                <div className="text-300">{networkInfo?.gateway ?? SkeletonLoader}</div>
-              </Row>
-            </div>
-          </div>
-          <div className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
-            <Header title="Preferences" titleSize="text-heading-200" />
+            <Header title="Display" titleSize="text-heading-200" />
             <div>
               <Row className="flex justify-between" divider>
                 <div className="text-300">Theme</div>
@@ -79,4 +64,4 @@ const General = () => {
   );
 };
 
-export default General;
+export default Preferences;

--- a/client/src/protoFleet/features/settings/components/Roles.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Roles.test.tsx
@@ -1,0 +1,86 @@
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Roles from "./Roles";
+
+const permissionsMock = vi.hoisted(() => ({ current: [] as string[] }));
+const listRolesMock = vi.hoisted(() => vi.fn());
+const deleteRoleMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: (permission: string) => permissionsMock.current.includes(permission),
+}));
+
+vi.mock("@/protoFleet/api/useRoleManagement", () => ({
+  isImmutable: (role: { builtin: boolean }) => role.builtin === true,
+  useRoleManagement: () => ({
+    listRoles: listRolesMock,
+    deleteRole: deleteRoleMock,
+  }),
+}));
+
+vi.mock("@/protoFleet/features/settings/components/CreateEditRoleModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/protoFleet/features/settings/components/DeleteRoleDialog", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/shared/features/toaster", () => ({
+  pushToast: vi.fn(),
+  STATUSES: { error: "error", success: "success" },
+}));
+
+const renderRoles = () =>
+  render(
+    <MemoryRouter initialEntries={["/settings/team?tab=roles"]}>
+      <Routes>
+        <Route path="/settings/team" element={<Roles embedded />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("Roles", () => {
+  beforeEach(() => {
+    permissionsMock.current = ["role:manage"];
+    deleteRoleMock.mockReset();
+    listRolesMock.mockReset();
+    listRolesMock.mockImplementation(({ onSuccess, onFinally }) => {
+      onSuccess([
+        {
+          roleId: "admin",
+          name: "Admin",
+          description: "Full access",
+          permissions: ["fleet:read", "role:manage"],
+          builtin: true,
+          builtinKey: "ADMIN",
+          memberCount: 4,
+          updatedAt: new Date("2026-06-01T12:00:00Z"),
+        },
+      ]);
+      onFinally();
+    });
+  });
+
+  it("shows a popover explaining system default roles", async () => {
+    renderRoles();
+
+    await screen.findByTestId("system-role-lock");
+    const lockButton = screen.getByRole("button", { name: "System default role" });
+    expect(screen.queryByTestId("system-role-lock-popover")).not.toBeInTheDocument();
+
+    fireEvent.click(lockButton);
+
+    await waitFor(() => expect(screen.getByTestId("system-role-lock-popover")).toBeInTheDocument());
+    expect(
+      screen.getByText("This is a system default role. Built-in roles cannot be edited or deleted."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("system-role-lock-popover").querySelector(".popover-content")).toHaveClass("w-80");
+
+    fireEvent.mouseDown(document.body);
+
+    await waitFor(() => expect(screen.queryByTestId("system-role-lock-popover")).not.toBeInTheDocument());
+  });
+});

--- a/client/src/protoFleet/features/settings/components/Roles.tsx
+++ b/client/src/protoFleet/features/settings/components/Roles.tsx
@@ -3,16 +3,26 @@ import { Navigate } from "react-router-dom";
 import { isImmutable, type RoleItem, useRoleManagement } from "@/protoFleet/api/useRoleManagement";
 import CreateEditRoleModal from "@/protoFleet/features/settings/components/CreateEditRoleModal";
 import DeleteRoleDialog from "@/protoFleet/features/settings/components/DeleteRoleDialog";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
+import { formatRole } from "@/protoFleet/features/settings/utils/formatRole";
 import { useHasPermission } from "@/protoFleet/store";
 import { Edit, Lock, Trash } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
-import Header from "@/shared/components/Header";
 import List from "@/shared/components/List";
 import { ColConfig, ColTitles } from "@/shared/components/List/types";
+import Popover, { PopoverProvider, popoverSizes, usePopover } from "@/shared/components/Popover";
+import { positions } from "@/shared/constants";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
+import { classNameToSelectors } from "@/shared/utils/cssUtils";
 import { formatTimestamp } from "@/shared/utils/formatTimestamp";
 
 type RoleColumns = "name" | "permissions" | "members" | "updatedAt";
+
+type RolesProps = {
+  embedded?: boolean;
+  filtersClassName?: string;
+};
 
 const colTitles: ColTitles<RoleColumns> = {
   name: "Role",
@@ -22,8 +32,59 @@ const colTitles: ColTitles<RoleColumns> = {
 };
 
 const activeCols: RoleColumns[] = ["name", "permissions", "members", "updatedAt"];
+const systemDefaultRoleDescription = "This is a system default role. Built-in roles cannot be edited or deleted.";
+const systemDefaultRoleTriggerClassName = "system-default-role-lock-trigger";
 
-const Roles = () => {
+const SystemDefaultRoleLockContent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { triggerRef } = usePopover();
+  const closeIgnoreSelectors = classNameToSelectors(systemDefaultRoleTriggerClassName);
+
+  return (
+    <div
+      ref={triggerRef}
+      className={`${systemDefaultRoleTriggerClassName} relative inline-flex justify-center text-text-primary-50`}
+      data-testid="system-role-lock"
+    >
+      <button
+        type="button"
+        className="p-1 hover:cursor-pointer hover:text-text-primary"
+        aria-label="System default role"
+        aria-expanded={isOpen}
+        aria-haspopup="dialog"
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        <Lock width="w-5" />
+      </button>
+      {isOpen ? (
+        <Popover
+          position={positions["bottom left"]}
+          size={popoverSizes.normal}
+          offset={8}
+          freezePosition
+          className="!space-y-0"
+          closePopover={() => setIsOpen(false)}
+          closeIgnoreSelectors={closeIgnoreSelectors}
+          testId="system-role-lock-popover"
+        >
+          <p className="text-300 text-text-primary-70">{systemDefaultRoleDescription}</p>
+        </Popover>
+      ) : null}
+    </div>
+  );
+};
+
+const SystemDefaultRoleLock = () => (
+  <PopoverProvider>
+    <SystemDefaultRoleLockContent />
+  </PopoverProvider>
+);
+
+const CreateRoleButton = ({ onClick, className }: { onClick: () => void; className?: string }) => (
+  <Button variant={variants.primary} size={sizes.compact} text="Create role" onClick={onClick} className={className} />
+);
+
+const Roles = ({ embedded = false, filtersClassName }: RolesProps) => {
   const canManageRoles = useHasPermission("role:manage");
   const { listRoles, deleteRole } = useRoleManagement();
   const [roles, setRoles] = useState<RoleItem[]>([]);
@@ -82,25 +143,9 @@ const Roles = () => {
     () => ({
       name: {
         component: (role) => (
-          <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-core-primary-5 text-text-primary-70">
-              {role.builtin ? (
-                <Lock />
-              ) : (
-                <span className="text-300 font-semibold">{role.name.charAt(0).toUpperCase()}</span>
-              )}
-            </div>
-            <div className="flex min-w-0 flex-col">
-              <div className="flex items-center gap-2">
-                <span className="text-emphasis-300">{role.name}</span>
-                {role.builtin ? (
-                  <span className="rounded-full bg-core-primary-5 px-2 py-0.5 text-200 text-text-primary-50">
-                    Built-in
-                  </span>
-                ) : null}
-              </div>
-              <span className="truncate text-200 text-text-primary-50">{role.description}</span>
-            </div>
+          <div className="flex min-w-0 flex-col">
+            <span className="text-emphasis-300">{role.builtinKey ? formatRole(role.builtinKey) : role.name}</span>
+            <span className="truncate text-200 text-text-primary-50">{role.description}</span>
           </div>
         ),
         width: "w-96",
@@ -147,24 +192,20 @@ const Roles = () => {
 
   // Redirect users without role:manage — placed after hooks to satisfy rules-of-hooks.
   if (!canManageRoles) {
-    return <Navigate to="/settings/general" replace />;
+    return embedded ? null : <Navigate to="/settings/network" replace />;
   }
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <Header
-          title="Roles"
-          titleSize="text-heading-300"
-          subtitle="Define what members can see and do. Assign roles when you add or edit a member."
-        />
-        <Button
-          variant={variants.primary}
-          size={sizes.compact}
-          text="Create role"
-          onClick={() => setShowCreateModal(true)}
-        />
-      </div>
+      {!embedded ? (
+        <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
+          <SettingsPageHeader
+            title="Roles"
+            description="Define what members can see and do. Assign roles when you add or edit a member."
+          />
+          <CreateRoleButton onClick={() => setShowCreateModal(true)} className="shrink-0 phone:w-full" />
+        </div>
+      ) : null}
 
       {isLoading ? (
         <div className="text-center text-text-primary-50">Loading roles...</div>
@@ -177,10 +218,12 @@ const Roles = () => {
           colConfig={colConfig}
           total={roles.length}
           itemName={{ singular: "role", plural: "roles" }}
+          actionPlaceholder={(role) => (isImmutable(role) ? <SystemDefaultRoleLock /> : null)}
+          filtersClassName={filtersClassName}
+          stickyFirstColumn={false}
+          headerControls={embedded ? <CreateRoleButton onClick={() => setShowCreateModal(true)} /> : undefined}
           noDataElement={
-            <div className="py-10 text-center text-text-primary-50">
-              No roles yet. Create your first role to control member access.
-            </div>
+            <SettingsEmptyState title="No roles yet" description="Create your first role to control member access." />
           }
           actions={availableActions}
         />

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
@@ -100,6 +100,7 @@ describe("SchedulesPage", () => {
     await waitFor(() => expect(screen.getAllByText("Schedules")).toHaveLength(1));
     expect(screen.getByText(/No schedules yet/)).toBeVisible();
     expect(screen.getByRole("button", { name: "Add a schedule" })).toBeEnabled();
+    expect(screen.queryByText(/All times/)).not.toBeInTheDocument();
     expect(mockScheduleModal).not.toHaveBeenCalled();
   });
 
@@ -125,6 +126,7 @@ describe("SchedulesPage", () => {
     expect(screen.getByRole("columnheader", { name: "Name" })).toBeInTheDocument();
     expect(screen.getByText("Night sleep")).toBeVisible();
     expect(screen.getByText("Weekdays · 10:00 PM")).toBeVisible();
+    expect(screen.getByText(/All times/)).toBeVisible();
   });
 
   it("keeps only the priority, name, schedule, and row action columns in the phone table layout", async () => {

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
@@ -22,9 +22,10 @@ import {
 import type { ScheduleColumn } from "@/protoFleet/features/settings/components/Schedules/constants";
 import createScheduleColConfig from "@/protoFleet/features/settings/components/Schedules/scheduleColConfig";
 import ScheduleModal from "@/protoFleet/features/settings/components/Schedules/ScheduleModal";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { Edit, Pause, Play, Trash } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
-import Header from "@/shared/components/Header";
 import List from "@/shared/components/List";
 import type { ActiveFilters } from "@/shared/components/List/Filters/types";
 import type { ListAction, SortDirection } from "@/shared/components/List/types";
@@ -204,16 +205,15 @@ const SchedulesPage = () => {
     />
   ) : null;
 
-  const emptyStateRow = filtersActive ? (
-    <div className="flex flex-col items-center justify-center gap-1 py-12 text-center">
-      <p className="text-heading-200 text-text-primary">No schedules match those filters</p>
-      <p className="text-300 text-text-primary-70">
-        Try clearing one or more filters to see the rest of your schedules.
-      </p>
-    </div>
+  const noDataElement = filtersActive ? (
+    <SettingsEmptyState
+      title="No schedules match those filters"
+      description="Try clearing one or more filters to see the rest of your schedules."
+    />
   ) : (
-    <div className="py-10 text-center text-text-primary-50">No schedules yet. {SCHEDULE_EMPTY_STATE_DESCRIPTION}</div>
+    <SettingsEmptyState title="No schedules yet" description={SCHEDULE_EMPTY_STATE_DESCRIPTION} />
   );
+  const shouldShowTimezone = schedules.length > 0;
 
   if (isLoading || !hasCompletedInitialLoad) {
     return (
@@ -226,10 +226,10 @@ const SchedulesPage = () => {
   return (
     <div className="flex flex-col">
       <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
-        <Header title="Schedules" titleSize="text-heading-300" description={SCHEDULE_PAGE_DESCRIPTION} />
+        <SettingsPageHeader title="Schedules" description={SCHEDULE_PAGE_DESCRIPTION} />
         <Button
           variant={variants.primary}
-          size={sizes.base}
+          size={sizes.compact}
           text="Add a schedule"
           onClick={handleOpenCreateModal}
           className="shrink-0 phone:w-full"
@@ -249,7 +249,8 @@ const SchedulesPage = () => {
         filters={scheduleFilters}
         filterItem={matchesScheduleFilters}
         onFilterChange={setActiveFilters}
-        emptyStateRow={emptyStateRow}
+        hasActiveFilters={filtersActive}
+        noDataElement={noDataElement}
         sortableColumns={SORTABLE_COLUMNS}
         currentSort={currentSort}
         onSort={handleSort}
@@ -261,7 +262,7 @@ const SchedulesPage = () => {
         applyColumnWidthsToCells
         tableClassName={scheduleTableClassName}
       />
-      <div className="px-2 pb-2 text-200 text-text-primary-70">{timezoneLabel}</div>
+      {shouldShowTimezone ? <div className="px-2 pb-2 text-200 text-text-primary-70">{timezoneLabel}</div> : null}
 
       {scheduleModal}
     </div>

--- a/client/src/protoFleet/features/settings/components/SettingsLayout.test.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsLayout.test.tsx
@@ -2,6 +2,7 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { getFirstAllowedSecondaryNavPath } from "@/protoFleet/config/navItems";
 import SettingsLayout from "./SettingsLayout";
 
 const permissionsMock = vi.hoisted(() => ({ current: [] as string[] }));
@@ -41,10 +42,26 @@ const renderSettingsRoute = (initialPath: string) =>
           }
         />
         <Route
-          path="/settings/general"
+          path="/settings/network"
           element={
             <SettingsLayout>
-              <div data-testid="general-page">General</div>
+              <div data-testid="network-page">Network</div>
+            </SettingsLayout>
+          }
+        />
+        <Route
+          path="/settings/firmware"
+          element={
+            <SettingsLayout>
+              <div data-testid="firmware-page">Firmware</div>
+            </SettingsLayout>
+          }
+        />
+        <Route
+          path="/settings/preferences"
+          element={
+            <SettingsLayout>
+              <div data-testid="preferences-page">Preferences</div>
             </SettingsLayout>
           }
         />
@@ -64,18 +81,50 @@ const renderSettingsRoute = (initialPath: string) =>
 describe("SettingsLayout permission guard", () => {
   beforeEach(() => {
     permissionsMock.current = [];
+    activeSiteMock.current = { kind: "all" };
   });
 
   test("redirects protected settings routes before rendering their children", async () => {
     renderSettingsRoute("/settings/team");
 
-    await waitFor(() => expect(screen.getByTestId("location-probe").textContent).toBe("/settings/general"));
+    await waitFor(() =>
+      expect(screen.getByTestId("location-probe").textContent).toBe(getFirstAllowedSecondaryNavPath([])),
+    );
     expect(screen.queryByTestId("team-page")).not.toBeInTheDocument();
-    expect(screen.getByTestId("general-page")).toBeInTheDocument();
+    expect(screen.getByTestId("firmware-page")).toBeInTheDocument();
+  });
+
+  test("redirects Network when fleet read permission is missing", async () => {
+    permissionsMock.current = ["role:manage"];
+
+    renderSettingsRoute("/settings/network");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location-probe").textContent).toBe(getFirstAllowedSecondaryNavPath(["role:manage"])),
+    );
+    expect(screen.queryByTestId("network-page")).not.toBeInTheDocument();
+  });
+
+  test("renders Network when fleet read permission is present", () => {
+    permissionsMock.current = ["fleet:read"];
+
+    renderSettingsRoute("/settings/network");
+
+    expect(screen.getByTestId("location-probe").textContent).toBe("/settings/network");
+    expect(screen.getByTestId("network-page")).toBeInTheDocument();
   });
 
   test("renders protected settings routes when the org permission is present", () => {
     permissionsMock.current = ["user:read"];
+
+    renderSettingsRoute("/settings/team");
+
+    expect(screen.getByTestId("location-probe").textContent).toBe("/settings/team");
+    expect(screen.getByTestId("team-page")).toBeInTheDocument();
+  });
+
+  test("renders Team when only role management permission is present", () => {
+    permissionsMock.current = ["role:manage"];
 
     renderSettingsRoute("/settings/team");
 
@@ -91,19 +140,19 @@ describe("SettingsLayout org-wide notice", () => {
   });
 
   test("shows the org-wide notice on org-wide pages when a site is selected", () => {
-    renderSettingsRoute("/settings/general");
+    renderSettingsRoute("/settings/preferences");
 
     expect(screen.getByTestId("org-wide-notice")).toBeInTheDocument();
-    expect(screen.getByTestId("general-page")).toBeInTheDocument();
+    expect(screen.getByTestId("preferences-page")).toBeInTheDocument();
   });
 
   test("hides the org-wide notice when all sites is selected", () => {
     activeSiteMock.current = { kind: "all" };
 
-    renderSettingsRoute("/settings/general");
+    renderSettingsRoute("/settings/preferences");
 
     expect(screen.queryByTestId("org-wide-notice")).not.toBeInTheDocument();
-    expect(screen.getByTestId("general-page")).toBeInTheDocument();
+    expect(screen.getByTestId("preferences-page")).toBeInTheDocument();
   });
 
   test("hides the org-wide notice on site-aware pages", () => {

--- a/client/src/protoFleet/features/settings/components/SettingsLayout.test.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsLayout.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import SettingsLayout from "./SettingsLayout";
-import { getFirstAllowedSecondaryNavPath } from "@/protoFleet/config/navItems";
+import { getSettingsLandingPath } from "@/protoFleet/config/navItems";
 
 const permissionsMock = vi.hoisted(() => ({ current: [] as string[] }));
 const activeSiteMock = vi.hoisted(() => ({ current: { kind: "all" } as { kind: string; id?: string } }));
@@ -87,11 +87,10 @@ describe("SettingsLayout permission guard", () => {
   test("redirects protected settings routes before rendering their children", async () => {
     renderSettingsRoute("/settings/team");
 
-    await waitFor(() =>
-      expect(screen.getByTestId("location-probe").textContent).toBe(getFirstAllowedSecondaryNavPath([])),
-    );
+    await waitFor(() => expect(screen.getByTestId("location-probe").textContent).toBe(getSettingsLandingPath([])));
     expect(screen.queryByTestId("team-page")).not.toBeInTheDocument();
-    expect(screen.getByTestId("firmware-page")).toBeInTheDocument();
+    expect(screen.getByTestId("preferences-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("firmware-page")).not.toBeInTheDocument();
   });
 
   test("redirects Network when fleet read permission is missing", async () => {
@@ -100,9 +99,18 @@ describe("SettingsLayout permission guard", () => {
     renderSettingsRoute("/settings/network");
 
     await waitFor(() =>
-      expect(screen.getByTestId("location-probe").textContent).toBe(getFirstAllowedSecondaryNavPath(["role:manage"])),
+      expect(screen.getByTestId("location-probe").textContent).toBe(getSettingsLandingPath(["role:manage"])),
     );
     expect(screen.queryByTestId("network-page")).not.toBeInTheDocument();
+    expect(screen.getByTestId("preferences-page")).toBeInTheDocument();
+  });
+
+  test("redirects Firmware when firmware update permission is missing", async () => {
+    renderSettingsRoute("/settings/firmware");
+
+    await waitFor(() => expect(screen.getByTestId("location-probe").textContent).toBe(getSettingsLandingPath([])));
+    expect(screen.queryByTestId("firmware-page")).not.toBeInTheDocument();
+    expect(screen.getByTestId("preferences-page")).toBeInTheDocument();
   });
 
   test("renders Network when fleet read permission is present", () => {
@@ -112,6 +120,15 @@ describe("SettingsLayout permission guard", () => {
 
     expect(screen.getByTestId("location-probe").textContent).toBe("/settings/network");
     expect(screen.getByTestId("network-page")).toBeInTheDocument();
+  });
+
+  test("renders Firmware when firmware update permission is present", () => {
+    permissionsMock.current = ["miner:firmware_update"];
+
+    renderSettingsRoute("/settings/firmware");
+
+    expect(screen.getByTestId("location-probe").textContent).toBe("/settings/firmware");
+    expect(screen.getByTestId("firmware-page")).toBeInTheDocument();
   });
 
   test("renders protected settings routes when the org permission is present", () => {

--- a/client/src/protoFleet/features/settings/components/SettingsLayout.test.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsLayout.test.tsx
@@ -2,8 +2,8 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { getFirstAllowedSecondaryNavPath } from "@/protoFleet/config/navItems";
 import SettingsLayout from "./SettingsLayout";
+import { getFirstAllowedSecondaryNavPath } from "@/protoFleet/config/navItems";
 
 const permissionsMock = vi.hoisted(() => ({ current: [] as string[] }));
 const activeSiteMock = vi.hoisted(() => ({ current: { kind: "all" } as { kind: string; id?: string } }));

--- a/client/src/protoFleet/features/settings/components/SettingsLayout.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsLayout.tsx
@@ -2,7 +2,11 @@ import { ReactNode, useEffect } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import SecondaryNavigation from "@/protoFleet/components/SecondaryNavigation";
-import { secondaryNavItems } from "@/protoFleet/config/navItems";
+import {
+  getFirstAllowedSecondaryNavPath,
+  isNavItemAllowedByPermissions,
+  secondaryNavItems,
+} from "@/protoFleet/config/navItems";
 import OrgWideNotice from "@/protoFleet/features/settings/components/OrgWideNotice";
 import { settingsRoutePrefetch } from "@/protoFleet/routePrefetch";
 import { usePermissions } from "@/protoFleet/store";
@@ -20,9 +24,8 @@ const SettingsLayout = ({ children }: { children?: ReactNode }) => {
   const currentNavItem = secondaryNavItems.find(
     (item) => pathname === item.path || pathname.startsWith(`${item.path}/`),
   );
-  const requiredPermission = currentNavItem?.requiredPermission;
-  if (requiredPermission && !permissions.includes(requiredPermission)) {
-    return <Navigate to="/settings/general" replace />;
+  if (currentNavItem && !isNavItemAllowedByPermissions(currentNavItem, permissions)) {
+    return <Navigate to={getFirstAllowedSecondaryNavPath(permissions)} replace />;
   }
 
   // Org-wide pages (everything except schedules) deliberately ignore the

--- a/client/src/protoFleet/features/settings/components/SettingsLayout.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsLayout.tsx
@@ -2,11 +2,7 @@ import { ReactNode, useEffect } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import SecondaryNavigation from "@/protoFleet/components/SecondaryNavigation";
-import {
-  getFirstAllowedSecondaryNavPath,
-  isNavItemAllowedByPermissions,
-  secondaryNavItems,
-} from "@/protoFleet/config/navItems";
+import { getSettingsLandingPath, isNavItemAllowedByPermissions, secondaryNavItems } from "@/protoFleet/config/navItems";
 import OrgWideNotice from "@/protoFleet/features/settings/components/OrgWideNotice";
 import { settingsRoutePrefetch } from "@/protoFleet/routePrefetch";
 import { usePermissions } from "@/protoFleet/store";
@@ -25,7 +21,7 @@ const SettingsLayout = ({ children }: { children?: ReactNode }) => {
     (item) => pathname === item.path || pathname.startsWith(`${item.path}/`),
   );
   if (currentNavItem && !isNavItemAllowedByPermissions(currentNavItem, permissions)) {
-    return <Navigate to={getFirstAllowedSecondaryNavPath(permissions)} replace />;
+    return <Navigate to={getSettingsLandingPath(permissions)} replace />;
   }
 
   // Org-wide pages (everything except schedules) deliberately ignore the

--- a/client/src/protoFleet/features/settings/components/Team.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Team.test.tsx
@@ -1,0 +1,146 @@
+import { type ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Team from "./Team";
+
+const permissionsMock = vi.hoisted(() => ({ current: [] as string[] }));
+const listUsersMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: (permission: string) => permissionsMock.current.includes(permission),
+  useRole: () => "SUPER_ADMIN",
+  useUsername: () => "owner@example.com",
+}));
+
+vi.mock("@/protoFleet/api/useUserManagement", () => ({
+  useUserManagement: () => ({
+    listUsers: listUsersMock,
+    resetUserPassword: vi.fn(),
+    deactivateUser: vi.fn(),
+  }),
+}));
+
+vi.mock("@/protoFleet/features/settings/components/Roles", () => ({
+  default: () => <div data-testid="roles-panel">Roles panel</div>,
+}));
+
+vi.mock("@/protoFleet/features/settings/components/AddTeamMemberModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/protoFleet/features/settings/components/DeactivateUserDialog", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/protoFleet/features/settings/components/EditRoleModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/protoFleet/features/settings/components/ResetPasswordModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/shared/components/List", () => ({
+  default: ({
+    items,
+    itemName,
+    filters,
+    headerControls,
+    total,
+  }: {
+    items: unknown[];
+    itemName: { singular: string; plural: string };
+    filters?: { title: string }[];
+    headerControls?: ReactNode;
+    total?: number;
+  }) => {
+    const count = total ?? items.length;
+    return (
+      <div>
+        <div data-testid="members-toolbar">
+          {filters?.map((filter) => (
+            <button key={filter.title} type="button" data-testid={`member-filter-${filter.title}`}>
+              {filter.title}
+            </button>
+          ))}
+          {headerControls}
+        </div>
+        <div data-testid="members-list">{`${count} ${count === 1 ? itemName.singular : itemName.plural}`}</div>
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/shared/features/toaster", () => ({
+  pushToast: vi.fn(),
+  STATUSES: { error: "error", success: "success" },
+}));
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="location-probe">{`${location.pathname}${location.search}`}</div>;
+};
+
+const renderTeam = (initialEntry = "/settings/team") =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/settings/team" element={<Team />} />
+      </Routes>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+
+describe("Team", () => {
+  beforeEach(() => {
+    permissionsMock.current = ["user:read", "user:manage", "role:manage"];
+    listUsersMock.mockReset();
+    listUsersMock.mockImplementation(({ onSuccess, onFinally }) => {
+      onSuccess([
+        {
+          userId: "1",
+          username: "owner@example.com",
+          passwordUpdatedAt: null,
+          lastLoginAt: null,
+          role: "SUPER_ADMIN",
+          requiresPasswordChange: false,
+        },
+      ]);
+      onFinally();
+    });
+  });
+
+  it("defaults to members and can switch to roles", async () => {
+    renderTeam();
+
+    await waitFor(() => expect(screen.getByTestId("members-list").textContent).toBe("1 member"));
+    expect(screen.queryByTestId("segmented-control")).not.toBeInTheDocument();
+    expect(screen.getByTestId("team-tab-members")).toHaveAttribute("data-active", "true");
+    expect(screen.getByTestId("member-filter-Role")).toBeInTheDocument();
+    expect(screen.getByTestId("members-toolbar")).toContainElement(screen.getByText("Add team member"));
+
+    fireEvent.click(screen.getByTestId("team-tab-roles-activate"));
+
+    expect(screen.getByTestId("roles-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("team-tab-roles")).toHaveAttribute("data-active", "true");
+    expect(screen.getByTestId("location-probe").textContent).toBe("/settings/team?tab=roles");
+  });
+
+  it("deep-links to the roles tab", () => {
+    renderTeam("/settings/team?tab=roles");
+
+    expect(screen.getByTestId("roles-panel")).toBeInTheDocument();
+    expect(screen.queryByTestId("members-list")).not.toBeInTheDocument();
+  });
+
+  it("shows roles without loading members for role-only users", () => {
+    permissionsMock.current = ["role:manage"];
+
+    renderTeam();
+
+    expect(screen.getByTestId("roles-panel")).toBeInTheDocument();
+    expect(listUsersMock).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/protoFleet/features/settings/components/Team.tsx
+++ b/client/src/protoFleet/features/settings/components/Team.tsx
@@ -1,16 +1,21 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Navigate, useSearchParams } from "react-router-dom";
 import { useUserManagement } from "@/protoFleet/api/useUserManagement";
 import AddTeamMemberModal from "@/protoFleet/features/settings/components/AddTeamMemberModal";
 import DeactivateUserDialog from "@/protoFleet/features/settings/components/DeactivateUserDialog";
 import EditRoleModal from "@/protoFleet/features/settings/components/EditRoleModal";
 import ResetPasswordModal from "@/protoFleet/features/settings/components/ResetPasswordModal";
+import Roles from "@/protoFleet/features/settings/components/Roles";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { formatRole } from "@/protoFleet/features/settings/utils/formatRole";
 import { useHasPermission, useRole, useUsername } from "@/protoFleet/store";
 import { Edit, Lock, Trash } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
-import Header from "@/shared/components/Header";
 import List from "@/shared/components/List";
+import { type ActiveFilters, type FilterItem } from "@/shared/components/List/Filters/types";
 import { ColConfig, ColTitles } from "@/shared/components/List/types";
+import { TabStrip, TabStripItem } from "@/shared/components/Tab";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
 import { formatTimestamp } from "@/shared/utils/formatTimestamp";
 
@@ -24,6 +29,11 @@ type UserData = {
 };
 
 type UserColumns = "username" | "passwordUpdatedAt" | "lastLoginAt" | "role";
+type TeamTab = "members" | "roles";
+type TeamTabItem = {
+  key: TeamTab;
+  title: string;
+};
 
 const colTitles: ColTitles<UserColumns> = {
   username: "Username",
@@ -32,17 +42,28 @@ const colTitles: ColTitles<UserColumns> = {
   role: "Role",
 };
 
+const defaultMemberFilters: ActiveFilters = {
+  buttonFilters: ["all"],
+  dropdownFilters: {},
+  numericFilters: {},
+  textareaListFilters: {},
+};
+const tabbedListFiltersClassName = "pt-4 pb-3";
+
 const Team = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
   const { listUsers, resetUserPassword, deactivateUser } = useUserManagement();
+  const canReadTeamMembers = useHasPermission("user:read");
   // Gate the team-management UI on user:manage; the server's parity
   // check still bounds which roles a caller can assign at create or
   // update time.
   const canAddTeamMembers = useHasPermission("user:manage");
+  const canManageRoles = useHasPermission("role:manage");
   const currentUsername = useUsername();
   const currentRole = useRole();
   const callerIsOwner = currentRole === "SUPER_ADMIN";
   const [users, setUsers] = useState<UserData[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(canReadTeamMembers);
   const [showAddMemberModal, setShowAddMemberModal] = useState(false);
   const [resetPasswordUser, setResetPasswordUser] = useState<UserData | null>(null);
   const [resetPasswordTemp, setResetPasswordTemp] = useState<string | null>(null);
@@ -50,6 +71,36 @@ const Team = () => {
   const [deactivateUserData, setDeactivateUserData] = useState<UserData | null>(null);
   const [isDeactivating, setIsDeactivating] = useState(false);
   const [editRoleUser, setEditRoleUser] = useState<UserData | null>(null);
+  const [memberFilters, setMemberFilters] = useState<ActiveFilters>(defaultMemberFilters);
+  const requestedTab = searchParams.get("tab") === "roles" ? "roles" : "members";
+  const availableTabs = useMemo(
+    () =>
+      [
+        canReadTeamMembers ? ({ key: "members", title: "Members" } satisfies TeamTabItem) : null,
+        canManageRoles ? ({ key: "roles", title: "Roles" } satisfies TeamTabItem) : null,
+      ].filter((tab): tab is TeamTabItem => tab !== null),
+    [canManageRoles, canReadTeamMembers],
+  );
+  const activeTab = useMemo<TeamTab>(() => {
+    if (availableTabs.some((tab) => tab.key === requestedTab)) {
+      return requestedTab;
+    }
+
+    return (availableTabs[0]?.key as TeamTab | undefined) ?? "members";
+  }, [availableTabs, requestedTab]);
+  const handleTabSelect = useCallback(
+    (selectedKey: string) => {
+      const nextParams = new URLSearchParams(searchParams);
+      if (selectedKey === "roles") {
+        nextParams.set("tab", "roles");
+      } else {
+        nextParams.delete("tab");
+      }
+
+      setSearchParams(nextParams, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
 
   const fetchUsers = useCallback(() => {
     setIsLoading(true);
@@ -70,9 +121,11 @@ const Team = () => {
   }, [listUsers]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch on mount; setState inside async fetch is the external-sync pattern
-    fetchUsers();
-  }, [fetchUsers]);
+    if (canReadTeamMembers) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch on mount; setState inside async fetch is the external-sync pattern
+      fetchUsers();
+    }
+  }, [fetchUsers, canReadTeamMembers]);
 
   const colConfig: ColConfig<UserData, string, UserColumns> = useMemo(
     () => ({
@@ -110,6 +163,32 @@ const Team = () => {
   );
 
   const activeCols: UserColumns[] = ["username", "passwordUpdatedAt", "lastLoginAt", "role"];
+  const roleFilters = useMemo<FilterItem[]>(() => {
+    const roleOptions = Array.from(new Set(users.map((user) => user.role)))
+      .sort((a, b) => formatRole(a).localeCompare(formatRole(b)))
+      .map((role) => ({ id: role, label: formatRole(role) }));
+
+    return [
+      {
+        type: "dropdown",
+        title: "Role",
+        pluralTitle: "roles",
+        value: "role",
+        options: roleOptions,
+        defaultOptionIds: [],
+        showSelectAll: false,
+      },
+    ];
+  }, [users]);
+  const memberMatchesFilters = useCallback((user: UserData, filters: ActiveFilters) => {
+    const selectedRoles = filters.dropdownFilters.role ?? [];
+    return selectedRoles.length === 0 || selectedRoles.includes(user.role);
+  }, []);
+  const filteredMemberCount = useMemo(
+    () => users.filter((user) => memberMatchesFilters(user, memberFilters)).length,
+    [memberFilters, memberMatchesFilters, users],
+  );
+  const hasActiveMemberFilters = (memberFilters.dropdownFilters.role?.length ?? 0) > 0;
 
   const handleAddMemberSuccess = useCallback(() => {
     fetchUsers();
@@ -217,38 +296,70 @@ const Team = () => {
     ];
   }, [canAddTeamMembers, hideEditRoleFor, hideMemberMutationFor, handleResetPassword]);
 
+  if (availableTabs.length === 0) {
+    return <Navigate to="/settings/network" replace />;
+  }
+
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <Header title="Team" titleSize="text-heading-300" />
-        {canAddTeamMembers ? (
-          <Button
-            variant={variants.primary}
-            size={sizes.compact}
-            text="Add team member"
-            onClick={() => setShowAddMemberModal(true)}
-          />
-        ) : null}
-      </div>
+      <SettingsPageHeader
+        title="Team"
+        description="Define what members can see and do. Assign roles when you add or edit a member."
+      />
+      {availableTabs.length > 1 ? (
+        <TabStrip activeId={activeTab} onSelect={handleTabSelect} ariaLabel="Team sections">
+          {availableTabs.map((tab) => (
+            <TabStripItem key={tab.key} id={tab.key} label={tab.title} testId={`team-tab-${tab.key}`} />
+          ))}
+        </TabStrip>
+      ) : null}
 
-      {isLoading ? (
-        <div className="text-center text-text-primary-50">Loading team members...</div>
+      {activeTab === "members" ? (
+        <>
+          {isLoading ? (
+            <div className="text-center text-text-primary-50">Loading team members...</div>
+          ) : (
+            <List<UserData, string, UserColumns>
+              items={users}
+              itemKey="userId"
+              activeCols={activeCols}
+              colTitles={colTitles}
+              colConfig={colConfig}
+              filters={roleFilters}
+              filtersClassName={tabbedListFiltersClassName}
+              filterItem={memberMatchesFilters}
+              onFilterChange={setMemberFilters}
+              headerControls={
+                canAddTeamMembers ? (
+                  <Button
+                    variant={variants.primary}
+                    size={sizes.compact}
+                    text="Add team member"
+                    onClick={() => setShowAddMemberModal(true)}
+                  />
+                ) : null
+              }
+              total={filteredMemberCount}
+              totalUnfiltered={users.length}
+              hasActiveFilters={hasActiveMemberFilters}
+              itemName={{ singular: "member", plural: "members" }}
+              stickyFirstColumn={false}
+              noDataElement={
+                <SettingsEmptyState
+                  title={hasActiveMemberFilters ? "No members match those filters" : "No team members yet"}
+                  description={
+                    hasActiveMemberFilters
+                      ? "Try clearing one or more filters to see the rest of your members."
+                      : "Add your first member to start managing access."
+                  }
+                />
+              }
+              actions={availableActions}
+            />
+          )}
+        </>
       ) : (
-        <List<UserData, string, UserColumns>
-          items={users}
-          itemKey="userId"
-          activeCols={activeCols}
-          colTitles={colTitles}
-          colConfig={colConfig}
-          total={users.length}
-          itemName={{ singular: "member", plural: "members" }}
-          noDataElement={
-            <div className="py-10 text-center text-text-primary-50">
-              No team members found. Add your first member to get started.
-            </div>
-          }
-          actions={availableActions}
-        />
+        <Roles embedded filtersClassName={tabbedListFiltersClassName} />
       )}
 
       <AddTeamMemberModal

--- a/client/src/protoFleet/features/settings/index.ts
+++ b/client/src/protoFleet/features/settings/index.ts
@@ -2,10 +2,22 @@ import ApiKeys from "./components/ApiKeys";
 import Authentication from "./components/Auth";
 import Cooling from "./components/Cooling";
 import Firmware from "./components/Firmware";
-import General from "./components/General";
 import MiningPools from "./components/MiningPools";
+import Network from "./components/Network";
+import Preferences from "./components/Preferences";
 import Schedules from "./components/Schedules/SchedulesPage";
 import SettingsLayout from "./components/SettingsLayout";
 import Team from "./components/Team";
 
-export { ApiKeys, Authentication, Firmware, General, MiningPools, Cooling, Schedules, SettingsLayout, Team };
+export {
+  ApiKeys,
+  Authentication,
+  Firmware,
+  Network,
+  Preferences,
+  MiningPools,
+  Cooling,
+  Schedules,
+  SettingsLayout,
+  Team,
+};

--- a/client/src/protoFleet/routePrefetch.ts
+++ b/client/src/protoFleet/routePrefetch.ts
@@ -30,17 +30,17 @@ export const importMinersPage = () => import("@/protoFleet/features/onboarding/c
 export const importSecurityPage = () => import("@/protoFleet/features/onboarding/components/Security");
 export const importOnboardingSettingsPage = () => import("@/protoFleet/features/onboarding/components/Settings");
 export const importSettingsLayout = () => import("@/protoFleet/features/settings/components/SettingsLayout");
-export const importSettingsGeneral = () => import("@/protoFleet/features/settings/components/General");
+export const importSettingsNetwork = () => import("@/protoFleet/features/settings/components/Network");
+export const importSettingsPreferences = () => import("@/protoFleet/features/settings/components/Preferences");
 export const importSettingsAuth = () => import("@/protoFleet/features/settings/components/Auth");
 export const importSettingsMiningPools = () => import("@/protoFleet/features/settings/components/MiningPools");
 export const importSettingsTeam = () => import("@/protoFleet/features/settings/components/Team");
-export const importSettingsRoles = () => import("@/protoFleet/features/settings/components/Roles");
 export const importSettingsFirmware = () => import("@/protoFleet/features/settings/components/Firmware");
 export const importSettingsSchedules = () =>
   import("@/protoFleet/features/settings/components/Schedules/SchedulesPage");
 export const importSettingsCurtailment = () => import("@/protoFleet/features/settings/components/Curtailment");
 export const importSettingsAlerts = () => import("@/protoFleet/features/alerts/pages/Alerts");
-export const importSettingsApiKeys = () => import("@/protoFleet/features/settings/components/ApiKeys");
+export const importSettingsIntegrations = () => import("@/protoFleet/features/settings/components/ApiKeys");
 export const importSiteDetailPage = () => import("@/protoFleet/features/sites/pages/SiteDetailPage");
 export const importSitesPage = () => import("@/protoFleet/features/sites/pages/SitesPage");
 export const importBuildingPage = () => import("@/protoFleet/features/buildings/pages/BuildingPage");
@@ -64,20 +64,21 @@ export const globalRoutePrefetch: readonly RouteImporter[] = [
   importEnergyPage,
   importActivityPage,
   importSettingsLayout,
-  importSettingsGeneral,
+  importSettingsNetwork,
 ];
 
 // Settings sub-routes; SettingsLayout triggers this on mount so the rest of
 // the tab strip is warm by the time the user clicks across.
 export const settingsRoutePrefetch: readonly RouteImporter[] = [
+  importSettingsNetwork,
   importSettingsAuth,
   importSettingsMiningPools,
   importSettingsTeam,
-  importSettingsRoles,
   importSettingsFirmware,
   importSettingsSchedules,
   importSettingsCurtailment,
   importSettingsAlerts,
-  importSettingsApiKeys,
+  importSettingsIntegrations,
+  importSettingsPreferences,
   importServerLogsPage,
 ];

--- a/client/src/protoFleet/router.tsx
+++ b/client/src/protoFleet/router.tsx
@@ -26,14 +26,14 @@ import {
   importSecurityPage,
   importServerLogsPage,
   importSettingsAlerts,
-  importSettingsApiKeys,
   importSettingsAuth,
   importSettingsCurtailment,
   importSettingsFirmware,
-  importSettingsGeneral,
+  importSettingsIntegrations,
   importSettingsLayout,
   importSettingsMiningPools,
-  importSettingsRoles,
+  importSettingsNetwork,
+  importSettingsPreferences,
   importSettingsSchedules,
   importSettingsTeam,
   importSiteDetailPage,
@@ -41,6 +41,7 @@ import {
   importWelcomePage,
 } from "./routePrefetch";
 import { onboardingClient, sitesClient } from "@/protoFleet/api/clients";
+import { getFirstAllowedSecondaryNavPath } from "@/protoFleet/config/navItems";
 import {
   minersRedirectLoader,
   racksRedirectLoader,
@@ -77,16 +78,16 @@ const MinersPage = lazy(importMinersPage);
 const SecurityPage = lazy(importSecurityPage);
 const OnboardingSettingsPage = lazy(importOnboardingSettingsPage);
 const SettingsLayout = lazy(importSettingsLayout);
-const SettingsGeneral = lazy(importSettingsGeneral);
+const SettingsNetwork = lazy(importSettingsNetwork);
+const SettingsPreferences = lazy(importSettingsPreferences);
 const SettingsAuth = lazy(importSettingsAuth);
 const SettingsMiningPools = lazy(importSettingsMiningPools);
 const SettingsTeam = lazy(importSettingsTeam);
-const SettingsRoles = lazy(importSettingsRoles);
 const SettingsFirmware = lazy(importSettingsFirmware);
 const SettingsSchedules = lazy(importSettingsSchedules);
 const SettingsCurtailment = lazy(importSettingsCurtailment);
 const SettingsAlerts = lazy(importSettingsAlerts);
-const SettingsApiKeys = lazy(importSettingsApiKeys);
+const SettingsIntegrations = lazy(importSettingsIntegrations);
 const SiteDetailPage = lazy(importSiteDetailPage);
 const BuildingPage = lazy(importBuildingPage);
 const FleetLayout = lazy(importFleetLayout);
@@ -128,6 +129,9 @@ const welcomeLoader = async () => {
 };
 
 const appEntryLoader = () => redirect(appEntryPath(sanitizeActiveSite(useFleetStore.getState().ui.activeSite)));
+
+const settingsRedirectLoader = () =>
+  redirect(getFirstAllowedSecondaryNavPath(useFleetStore.getState().auth.permissions));
 
 // Group detail is canonical/unscoped, so a scoped URL like
 // /north/groups/team-a redirects to /groups/team-a while preserving the
@@ -268,12 +272,22 @@ const router = createBrowserRouter([
   // Settings routes
   {
     path: "/settings",
-    loader: () => redirect("/settings/general"),
+    loader: settingsRedirectLoader,
+  },
+  {
+    path: "/settings/general",
+    loader: settingsRedirectLoader,
   },
   createRoute(
-    "/settings/general",
+    "/settings/network",
     <SettingsLayout>
-      <SettingsGeneral />
+      <SettingsNetwork />
+    </SettingsLayout>,
+  ),
+  createRoute(
+    "/settings/preferences",
+    <SettingsLayout>
+      <SettingsPreferences />
     </SettingsLayout>,
   ),
   createRoute(
@@ -294,12 +308,10 @@ const router = createBrowserRouter([
       <SettingsTeam />
     </SettingsLayout>,
   ),
-  createRoute(
-    "/settings/roles",
-    <SettingsLayout>
-      <SettingsRoles />
-    </SettingsLayout>,
-  ),
+  {
+    path: "/settings/roles",
+    loader: () => redirect("/settings/team?tab=roles"),
+  },
   createRoute(
     "/settings/firmware",
     <SettingsLayout>
@@ -324,10 +336,14 @@ const router = createBrowserRouter([
       <SettingsAlerts />
     </SettingsLayout>,
   ),
+  {
+    path: "/settings/api-keys",
+    loader: () => redirect("/settings/integrations"),
+  },
   createRoute(
-    "/settings/api-keys",
+    "/settings/integrations",
     <SettingsLayout>
-      <SettingsApiKeys />
+      <SettingsIntegrations />
     </SettingsLayout>,
   ),
   createRoute(

--- a/client/src/protoFleet/router.tsx
+++ b/client/src/protoFleet/router.tsx
@@ -41,7 +41,7 @@ import {
   importWelcomePage,
 } from "./routePrefetch";
 import { onboardingClient, sitesClient } from "@/protoFleet/api/clients";
-import { getFirstAllowedSecondaryNavPath } from "@/protoFleet/config/navItems";
+import { getSettingsLandingPath } from "@/protoFleet/config/navItems";
 import {
   minersRedirectLoader,
   racksRedirectLoader,
@@ -130,8 +130,7 @@ const welcomeLoader = async () => {
 
 const appEntryLoader = () => redirect(appEntryPath(sanitizeActiveSite(useFleetStore.getState().ui.activeSite)));
 
-const settingsRedirectLoader = () =>
-  redirect(getFirstAllowedSecondaryNavPath(useFleetStore.getState().auth.permissions));
+const settingsRedirectLoader = () => redirect(getSettingsLandingPath(useFleetStore.getState().auth.permissions));
 
 // Group detail is canonical/unscoped, so a scoped URL like
 // /north/groups/team-a redirects to /groups/team-a while preserving the

--- a/client/src/protoFleet/routing/siteScope.test.tsx
+++ b/client/src/protoFleet/routing/siteScope.test.tsx
@@ -82,7 +82,7 @@ describe("siteScope routing helpers", () => {
     expect(unscopedScopablePath("/north-dc/groups/team-a")).toBe("/north-dc/groups/team-a");
     expect(unscopedScopablePath("/unassigned/activity")).toBe("/activity");
     expect(unscopedScopablePath("/unassigned/fleet/buildings")).toBe("/fleet/buildings");
-    expect(unscopedScopablePath("/settings/general")).toBe("/settings/general");
+    expect(unscopedScopablePath("/settings/network")).toBe("/settings/network");
   });
 
   it("detects scopable paths", () => {
@@ -109,7 +109,7 @@ describe("siteScope routing helpers", () => {
       slug: "north-dc",
     });
     expect(activeSiteFromScopablePath("/unassigned/fleet/miners")).toEqual({ kind: "unassigned" });
-    expect(activeSiteFromScopablePath("/settings/general")).toBeNull();
+    expect(activeSiteFromScopablePath("/settings/network")).toBeNull();
   });
 
   it("prefixes scopable paths while preserving search and hash", () => {
@@ -124,8 +124,8 @@ describe("siteScope routing helpers", () => {
   });
 
   it("does not prefix non-scopable paths", () => {
-    expect(scopedPath("/settings/general?tab=team", { kind: "site", id: "7", slug: "north-dc" })).toBe(
-      "/settings/general?tab=team",
+    expect(scopedPath("/settings/team?tab=roles", { kind: "site", id: "7", slug: "north-dc" })).toBe(
+      "/settings/team?tab=roles",
     );
   });
 
@@ -151,7 +151,7 @@ describe("siteScope routing helpers", () => {
       }),
     ).toBe("/north-dc/activity?type=event#top");
     expect(
-      scopeCurrentOrDashboardPath("/settings/general", "?tab=team", "#top", {
+      scopeCurrentOrDashboardPath("/settings/team", "?tab=roles", "#top", {
         kind: "site",
         id: "7",
         slug: "north-dc",

--- a/client/src/protoFleet/utils/fleetDownRedirect.test.ts
+++ b/client/src/protoFleet/utils/fleetDownRedirect.test.ts
@@ -32,11 +32,11 @@ describe("redirectFromFleetDown", () => {
   });
 
   it("redirects to the path from query parameter", () => {
-    window.location.search = "?from=%2Fsettings%2Fgeneral";
+    window.location.search = "?from=%2Fsettings%2Fnetwork";
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("/settings/general");
+    expect(window.location.href).toBe("/settings/network");
   });
 
   it("redirects to home page when no from parameter exists", () => {


### PR DESCRIPTION
## Summary

- Buckets settings navigation into Fleet, Automation, Admin, and Account sections.
- Splits General into Network and Preferences, renames API Keys to Integrations, and preserves legacy redirects.
- Consolidates Team and Roles into one Team settings view with Members/Roles tabs, role filtering, and built-in role lock affordances.

## Stack

2/3. Stacked on `codex/settings-list-primitives`.

## Testing

- `../bin/npx tsc --noEmit --pretty false`
- `../bin/npx eslint . --max-warnings 0`
- `../bin/npx vitest run`
- `../bin/npm run build:protoFleet`
