### PR TITLE
Polish settings content states

### DIFF
--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -30,7 +30,7 @@ export class SettingsFirmwarePage extends BasePage {
   }
 
   async deleteAllFirmwareFilesIfAny() {
-    const emptyState = this.page.getByText("No firmware files uploaded.", { exact: true });
+    const emptyState = this.page.getByText("No firmware files uploaded", { exact: true });
     const firmwareRows = this.page.getByTestId("list-body").locator("tr");
     const loadingState = this.page.getByText("Loading firmware files...", { exact: true });
     const deleteAllButton = this.page.getByRole("button", { name: "Delete all", exact: true }).first();

--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -55,7 +55,7 @@ export class SettingsFirmwarePage extends BasePage {
     const deleteAllDialog = this.page.getByTestId("delete-all-firmware-dialog");
     await deleteAllDialog.getByRole("button", { name: "Delete all" }).click();
     await expect(deleteAllDialog).toBeHidden();
-    await expect(deleteAllButton).toBeDisabled();
+    await expect(deleteAllButton).toBeHidden();
     await expect(emptyState).toBeVisible();
   }
 }

--- a/client/src/protoFleet/features/alerts/pages/Alerts.tsx
+++ b/client/src/protoFleet/features/alerts/pages/Alerts.tsx
@@ -6,8 +6,10 @@ import ChannelsSection from "@/protoFleet/features/alerts/components/ChannelsSec
 import HistorySection from "@/protoFleet/features/alerts/components/HistorySection";
 import MaintenanceWindowsSection from "@/protoFleet/features/alerts/components/MaintenanceWindowsSection";
 import RulesSection from "@/protoFleet/features/alerts/components/RulesSection";
-import Header from "@/shared/components/Header";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+const ALERTS_PAGE_DESCRIPTION = "Configure alert rules, notification channels, and maintenance windows.";
 
 const Alerts = () => {
   const alerts = useAlerts();
@@ -25,7 +27,7 @@ const Alerts = () => {
   return (
     <AlertsContext.Provider value={alerts}>
       <div className="flex flex-col gap-6 pb-10">
-        <Header title="Alerts" titleSize="text-heading-300" />
+        <SettingsPageHeader title="Alerts" description={ALERTS_PAGE_DESCRIPTION} />
         <div className="flex flex-col gap-4">
           <RulesSection />
           <HistorySection />

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -4,6 +4,7 @@ import { create } from "@bufbuild/protobuf";
 import { AuthenticateRequestSchema } from "@/protoFleet/api/generated/auth/v1/auth_pb";
 import { useAuth } from "@/protoFleet/api/useAuth";
 import { useLogin } from "@/protoFleet/api/useLogin";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { useUsername } from "@/protoFleet/store";
 import { Alert } from "@/shared/assets/icons";
 import Button from "@/shared/components/Button";
@@ -235,9 +236,8 @@ const AuthenticationSettings = () => {
   return (
     <>
       <div className="flex flex-col gap-6">
-        <Header
+        <SettingsPageHeader
           title="Security"
-          titleSize="text-heading-300"
           description="Protect your mining fleet by managing system access, miner credentials, and team permissions."
         />
         <div className="flex flex-col gap-4">

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
@@ -99,7 +99,7 @@ describe("CurtailmentAutomationsContent", () => {
 
     expect(screen.getByText("Automations")).toBeVisible();
     expect(screen.getByRole("button", { name: "Create automation" })).toBeEnabled();
-    expect(screen.getByRole("columnheader", { name: "Name" })).toBeVisible();
+    expect(screen.getByRole("columnheader", { name: "Name" })).toHaveClass("text-text-primary");
     expect(screen.getByRole("columnheader", { name: "Condition" })).toBeVisible();
     expect(screen.getByRole("columnheader", { name: "Response profile" })).toBeVisible();
     expect(screen.getByRole("columnheader", { name: "Enabled" })).toBeInTheDocument();

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
@@ -8,6 +8,7 @@ import type {
   CurtailmentSource,
   ResponseProfile,
 } from "@/protoFleet/features/settings/components/Curtailment/types";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
 import { Info } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -59,7 +60,6 @@ const automationColumnsExemptFromDisabledStyling = new Set<AutomationColumn>([au
 const automationTableClassName = [
   "mb-2 w-full",
   "phone:table-fixed",
-  "[&_thead_th]:text-text-primary-50",
   "phone:[&_thead_th:last-child]:w-14",
   "phone:[&_thead_th:last-child>div]:w-14",
   "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:box-border",
@@ -259,10 +259,11 @@ function SectionHeader({ title, buttonText, onButtonClick, infoToggle }: Section
 
 function AutomationsEmptyState(): ReactElement {
   return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">No automations configured</div>
-      <p className="mt-1 text-400 text-text-primary-70">Add an automation to trigger a response profile.</p>
-    </div>
+    <SettingsEmptyState
+      size="section"
+      title="No automations configured"
+      description="Add an automation to trigger a response profile."
+    />
   );
 }
 
@@ -275,12 +276,7 @@ function AutomationsLoadingState(): ReactElement {
 }
 
 function AutomationsErrorState({ message }: { message: string }): ReactElement {
-  return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">Unable to load automations</div>
-      <p className="mt-1 text-400 text-text-primary-70">{message}</p>
-    </div>
-  );
+  return <SettingsEmptyState size="section" title="Unable to load automations" description={message} />;
 }
 
 function AutomationDependencyMessage({ children }: { children: string }): ReactElement {
@@ -706,7 +702,7 @@ export function CurtailmentAutomationsContent({
   }, [controlledAutomationRules, editingAutomationRule, onDeleteAutomation]);
 
   const isEditingAutomation = editingAutomationRule ? updatingRuleIds.has(editingAutomationRule.id) : false;
-  const automationsEmptyStateRow = getAutomationsEmptyState(loadError, isLoading);
+  const automationsNoDataElement = getAutomationsEmptyState(loadError, isLoading);
 
   return (
     <section
@@ -735,7 +731,7 @@ export function CurtailmentAutomationsContent({
         isRowDisabled={(rule) => !rule.enabled}
         columnsExemptFromDisabledStyling={automationColumnsExemptFromDisabledStyling}
         tableClassName={automationTableClassName}
-        emptyStateRow={automationsEmptyStateRow}
+        noDataElement={automationsNoDataElement}
         applyColumnWidthsToCells
         onRowClick={openEditAutomationModal}
       />

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -497,7 +497,7 @@ describe("CurtailmentSettingsPage", () => {
     mockAutomationRulesApi();
   });
 
-  it("renders the curtailment header, response profile cards, and sources table", () => {
+  it("renders the curtailment header and section null states", () => {
     vi.mocked(useHasPermission).mockImplementation((key) => key === "curtailment:manage");
 
     render(
@@ -528,16 +528,11 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.getByRole("button", { name: "Create automation" })).toBeEnabled();
     expect(screen.queryByRole("button", { name: "Save settings" })).not.toBeInTheDocument();
     expect(document.querySelector(".curtailment-section-header__icon")).not.toBeInTheDocument();
-    const nameColumnHeaders = screen.getAllByRole("columnheader", { name: "Name" });
-    expect(nameColumnHeaders[0].closest("table")?.className).toContain("[&_thead_th]:text-text-primary-50");
-
-    for (const columnName of ["Last signal", "Updated", "Connection"]) {
-      expect(screen.getByRole("columnheader", { name: columnName })).toBeInTheDocument();
-    }
-    expect(screen.getByRole("columnheader", { name: "Condition" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Response profile" })).toBeInTheDocument();
-    expect(screen.getAllByRole("columnheader", { name: "Enabled" })).toHaveLength(2);
-    expect(nameColumnHeaders).toHaveLength(2);
+    expect(screen.getByText("No sources configured")).toBeVisible();
+    expect(screen.getByText("No automations configured")).toBeVisible();
+    expect(screen.queryByRole("columnheader", { name: "Name" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Condition" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Enabled" })).not.toBeInTheDocument();
     for (const profileColumnName of ["Target", "Scope", "Selection", "Restore", "Deadline"]) {
       expect(screen.queryByRole("columnheader", { name: profileColumnName })).not.toBeInTheDocument();
     }
@@ -546,7 +541,7 @@ describe("CurtailmentSettingsPage", () => {
     expect(screen.queryByRole("columnheader", { name: "Broker hosts" })).not.toBeInTheDocument();
     expect(screen.queryByText("Site Alpha MQTT")).not.toBeInTheDocument();
     expect(screen.queryByText("Site Beta MQTT")).not.toBeInTheDocument();
-    expect(screen.getAllByTestId("list-empty-row")).toHaveLength(2);
+    expect(screen.queryByTestId("list-empty-row")).not.toBeInTheDocument();
     expect(screen.getByText("No response profiles configured")).toBeVisible();
     expect(screen.getByText("Add a profile to reuse curtailment actions across automation rules.")).toBeVisible();
     expect(screen.getByText("No sources configured")).toBeVisible();

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -29,6 +29,8 @@ import {
   type ResponseProfile,
   type ResponseProfileFormValues,
 } from "@/protoFleet/features/settings/components/Curtailment/types";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useHasPermission } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -37,7 +39,6 @@ import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import { DismissibleCalloutWrapper, intents } from "@/shared/components/Callout";
 import Card, { cardType } from "@/shared/components/Card";
-import Header from "@/shared/components/Header";
 import Input from "@/shared/components/Input";
 import List from "@/shared/components/List";
 import type { ColConfig, ColTitles } from "@/shared/components/List/types";
@@ -113,7 +114,6 @@ const curtailmentSourceColumnsExemptFromDisabledStyling = new Set<CurtailmentSou
 const curtailmentSourcesTableClassName = [
   "mb-2 w-full",
   "phone:table-fixed",
-  "[&_thead_th]:text-text-primary-50",
   "phone:[&_thead_th:last-child]:w-14",
   "phone:[&_thead_th:last-child>div]:w-14",
   "phone:[&_tbody_td[data-testid=enabled]:last-child>div:first-child]:box-border",
@@ -597,10 +597,11 @@ function SourcesInfoToggle(): ReactElement {
 
 function SourcesEmptyState(): ReactElement {
   return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">No sources configured</div>
-      <p className="mt-1 text-400 text-text-primary-70">Add a MaestroOS MQTT source to receive curtailment signals.</p>
-    </div>
+    <SettingsEmptyState
+      size="section"
+      title="No sources configured"
+      description="Add a MaestroOS MQTT source to receive curtailment signals."
+    />
   );
 }
 
@@ -617,22 +618,16 @@ type SourcesErrorStateProps = {
 };
 
 function SourcesErrorState({ message }: SourcesErrorStateProps): ReactElement {
-  return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">Unable to load sources</div>
-      <p className="mt-1 text-400 text-text-primary-70">{message}</p>
-    </div>
-  );
+  return <SettingsEmptyState size="section" title="Unable to load sources" description={message} />;
 }
 
 function ResponseProfilesEmptyState(): ReactElement {
   return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">No response profiles configured</div>
-      <p className="mt-1 text-400 text-text-primary-70">
-        Add a profile to reuse curtailment actions across automation rules.
-      </p>
-    </div>
+    <SettingsEmptyState
+      size="section"
+      title="No response profiles configured"
+      description="Add a profile to reuse curtailment actions across automation rules."
+    />
   );
 }
 
@@ -649,12 +644,7 @@ type ResponseProfilesErrorStateProps = {
 };
 
 function ResponseProfilesErrorState({ message }: ResponseProfilesErrorStateProps): ReactElement {
-  return (
-    <div className="flex min-h-[220px] w-full flex-col items-center justify-center py-14 text-center">
-      <div className="text-heading-200 text-text-primary">Unable to load response profiles</div>
-      <p className="mt-1 text-400 text-text-primary-70">{message}</p>
-    </div>
-  );
+  return <SettingsEmptyState size="section" title="Unable to load response profiles" description={message} />;
 }
 
 type ResponseProfileCardProps = {
@@ -1483,11 +1473,11 @@ export function CurtailmentSettingsContent({
     [toggleSource, updatingSourceIds],
   );
 
-  const emptyStateRow = getSourcesEmptyState(loadSourcesError, isLoadingSources);
+  const noDataElement = getSourcesEmptyState(loadSourcesError, isLoadingSources);
 
   return (
     <div className="flex flex-col gap-14" data-testid="settings-curtailment-page">
-      <Header title="Curtailment" titleSize="text-heading-300" description={CURTAILMENT_PAGE_DESCRIPTION} />
+      <SettingsPageHeader title="Curtailment" description={CURTAILMENT_PAGE_DESCRIPTION} />
 
       <section className="curtailment-settings__section">
         <SectionHeader
@@ -1525,7 +1515,7 @@ export function CurtailmentSettingsContent({
           isRowDisabled={(source) => !source.enabled}
           columnsExemptFromDisabledStyling={curtailmentSourceColumnsExemptFromDisabledStyling}
           tableClassName={curtailmentSourcesTableClassName}
-          emptyStateRow={emptyStateRow}
+          noDataElement={noDataElement}
           applyColumnWidthsToCells
           onRowClick={openEditSourceModal}
         />
@@ -1896,7 +1886,7 @@ function CurtailmentSettingsPage(): ReactElement {
   );
 
   if (!canManageCurtailment) {
-    return <Navigate to="/settings/general" replace />;
+    return <Navigate to="/settings/network" replace />;
   }
 
   const effectiveSiteOptions = canLoadSiteOptions ? siteOptions : [];

--- a/client/src/protoFleet/features/settings/components/Firmware.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.test.tsx
@@ -51,7 +51,8 @@ describe("Firmware", () => {
     const { getByText } = render(<Firmware />);
 
     await waitFor(() => {
-      expect(getByText("No firmware files uploaded.")).toBeInTheDocument();
+      expect(getByText("No firmware files uploaded")).toBeInTheDocument();
+      expect(getByText("Upload firmware before deploying updates to your fleet.")).toBeInTheDocument();
     });
   });
 
@@ -66,14 +67,13 @@ describe("Firmware", () => {
     });
   });
 
-  it("disables Delete all button when no files exist", async () => {
+  it("hides Delete all button when no files exist", async () => {
     mockListFirmwareFiles.mockResolvedValue([]);
 
-    const { getByText } = render(<Firmware />);
+    const { queryByText } = render(<Firmware />);
 
     await waitFor(() => {
-      const deleteAllButton = getByText("Delete all").closest("button");
-      expect(deleteAllButton).toBeDisabled();
+      expect(queryByText("Delete all")).not.toBeInTheDocument();
     });
   });
 

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -3,10 +3,11 @@ import { type FirmwareFileInfo, useFirmwareApi } from "@/protoFleet/api/useFirmw
 import DeleteAllFirmwareDialog from "@/protoFleet/features/settings/components/DeleteAllFirmwareDialog";
 import DeleteFirmwareDialog from "@/protoFleet/features/settings/components/DeleteFirmwareDialog";
 import FirmwareUploadDialog from "@/protoFleet/features/settings/components/FirmwareUploadDialog";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { Trash } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import { formatFileSize } from "@/shared/components/FileSizeValue";
-import Header from "@/shared/components/Header";
 import List from "@/shared/components/List";
 import { ColConfig, ColTitles } from "@/shared/components/List/types";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
@@ -43,6 +44,7 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
 };
 
 const activeCols: FirmwareColumns[] = ["filename", "uploadedAt", "size"];
+const FIRMWARE_PAGE_DESCRIPTION = "Upload and manage firmware files available to your fleet.";
 
 function toFileData(info: FirmwareFileInfo): FirmwareFileData {
   return {
@@ -157,22 +159,26 @@ const Firmware = () => {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <Header title="Firmware" titleSize="text-heading-300" />
-        <div className="flex gap-3">
+      <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
+        <SettingsPageHeader title="Firmware" description={FIRMWARE_PAGE_DESCRIPTION} />
+        <div className="flex shrink-0 gap-3 phone:w-full phone:flex-col">
           <Button
             variant={variants.primary}
             size={sizes.compact}
             text="Upload firmware"
             onClick={() => setShowUploadDialog(true)}
+            className="phone:w-full"
           />
-          <Button
-            variant={variants.danger}
-            size={sizes.compact}
-            text="Delete all"
-            onClick={() => setShowDeleteAllDialog(true)}
-            disabled={files.length === 0 || isDeletingAll}
-          />
+          {files.length > 0 ? (
+            <Button
+              variant={variants.danger}
+              size={sizes.compact}
+              text="Delete all"
+              onClick={() => setShowDeleteAllDialog(true)}
+              disabled={isDeletingAll}
+              className="phone:w-full"
+            />
+          ) : null}
         </div>
       </div>
 
@@ -187,7 +193,12 @@ const Firmware = () => {
           colConfig={colConfig}
           total={files.length}
           itemName={{ singular: "file", plural: "files" }}
-          noDataElement={<div className="py-10 text-center text-text-primary-50">No firmware files uploaded.</div>}
+          noDataElement={
+            <SettingsEmptyState
+              title="No firmware files uploaded"
+              description="Upload firmware before deploying updates to your fleet."
+            />
+          }
           actions={availableActions}
         />
       )}

--- a/client/src/protoFleet/features/settings/components/MiningPools.test.tsx
+++ b/client/src/protoFleet/features/settings/components/MiningPools.test.tsx
@@ -70,6 +70,10 @@ describe("MiningPools", () => {
 
       expect(screen.getAllByText("Pools").length).toBeGreaterThan(0);
       expect(screen.getByText(/No pools yet/)).toBeInTheDocument();
+      expect(screen.getByText("Add a pool to start assigning your miners.")).toBeInTheDocument();
+      expect(screen.queryByText("Name")).not.toBeInTheDocument();
+      expect(screen.queryByText("URL")).not.toBeInTheDocument();
+      expect(screen.queryByText("Username")).not.toBeInTheDocument();
       expect(screen.getByRole("button", { name: /add pool/i })).toBeInTheDocument();
     });
 

--- a/client/src/protoFleet/features/settings/components/MiningPools.tsx
+++ b/client/src/protoFleet/features/settings/components/MiningPools.tsx
@@ -8,9 +8,10 @@ import {
 } from "@/protoFleet/api/generated/pools/v1/pools_pb";
 import type { Pool } from "@/protoFleet/api/generated/pools/v1/pools_pb";
 import usePools from "@/protoFleet/api/usePools";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import Ellipsis from "@/shared/assets/icons/Ellipsis";
 import Button, { sizes, variants } from "@/shared/components/Button";
-import Header from "@/shared/components/Header";
 import { fleetUsernameHelperText } from "@/shared/components/MiningPools/PoolForm/constants";
 import PoolModal from "@/shared/components/MiningPools/PoolModal";
 import type { PoolInfo } from "@/shared/components/MiningPools/types";
@@ -96,18 +97,20 @@ const PoolRowMenu = ({
   onDelete,
 }: PoolRowMenuProps) => (
   <div className="relative" ref={triggerRef}>
-    <Button
-      variant="ghost"
-      size="compact"
+    <button
+      type="button"
+      className="flex h-8 w-8 items-center justify-center text-text-primary hover:cursor-pointer hover:opacity-70"
       onClick={(e) => {
         e.stopPropagation();
         setShowMenu(!showMenu);
       }}
-      ariaLabel="Options menu"
-      ariaHasPopup="menu"
-      ariaExpanded={showMenu}
-      prefixIcon={<Ellipsis />}
-    />
+      aria-label="Options menu"
+      aria-haspopup="menu"
+      aria-expanded={showMenu}
+      data-testid="pool-actions-trigger"
+    >
+      <Ellipsis />
+    </button>
     {showMenu ? (
       <Popover
         position={positions["top left"]}
@@ -434,7 +437,7 @@ const MiningPools = () => {
     <>
       <div className="flex flex-col gap-6">
         <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
-          <Header title="Pools" description="Add and manage the pools for your fleet." titleSize="text-heading-300" />
+          <SettingsPageHeader title="Pools" description="Add and manage the pools for your fleet." />
           <Button
             variant={variants.primary}
             size={sizes.compact}
@@ -446,43 +449,41 @@ const MiningPools = () => {
         </div>
 
         <div className="flex flex-col">
-          {/* Conditional header based on screen size */}
-          {isPhone || isTablet ? (
-            /* Mobile & Tablet: Card header */
-            <div className="grid grid-cols-2 border-b border-core-primary-10 py-3 text-emphasis-300 text-text-primary-50">
-              <div>Name</div>
-              <div className="flex items-center justify-between">
-                <div>Username</div>
-              </div>
-            </div>
-          ) : (
-            /* Desktop: Table header */
-            <div className="grid grid-cols-3 gap-1 text-emphasis-300 text-text-primary-50">
-              <Row>Name</Row>
-              <Row>URL</Row>
-              <Row>Username</Row>
-            </div>
-          )}
-
-          {/* Table body */}
-          <div>
-            {pools.length === 0 ? (
-              <div className="py-10 text-center text-text-primary-50">
-                No pools yet. Add a pool to start assigning your miners.
+          {pools.length > 0 ? (
+            isPhone || isTablet ? (
+              <div className="grid grid-cols-2 border-b border-core-primary-10 py-3 text-emphasis-300 text-text-primary">
+                <div>Name</div>
+                <div className="flex items-center justify-between">
+                  <div>Username</div>
+                </div>
               </div>
             ) : (
-              pools.map((pool) => (
-                <PoolRowInner
-                  key={pool.poolId.toString()}
-                  pool={pool}
-                  onEdit={handleEditPool}
-                  onTestConnection={handleTestConnection}
-                  onDelete={handleDeletePool}
-                  connectionStatus={connectionStatuses[pool.poolId.toString()] || "idle"}
-                />
-              ))
-            )}
-          </div>
+              <div className="grid grid-cols-3 gap-1 text-emphasis-300 text-text-primary">
+                <Row>Name</Row>
+                <Row>URL</Row>
+                <Row>Username</Row>
+              </div>
+            )
+          ) : null}
+
+          {pools.length === 0 ? (
+            <SettingsEmptyState
+              className="mt-6"
+              title="No pools yet"
+              description="Add a pool to start assigning your miners."
+            />
+          ) : (
+            pools.map((pool) => (
+              <PoolRowInner
+                key={pool.poolId.toString()}
+                pool={pool}
+                onEdit={handleEditPool}
+                onTestConnection={handleTestConnection}
+                onDelete={handleDeletePool}
+                connectionStatus={connectionStatuses[pool.poolId.toString()] || "idle"}
+              />
+            ))
+          )}
         </div>
       </div>
 

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.test.tsx
@@ -100,6 +100,7 @@ describe("SchedulesPage", () => {
     await waitFor(() => expect(screen.getAllByText("Schedules")).toHaveLength(1));
     expect(screen.getByText(/No schedules yet/)).toBeVisible();
     expect(screen.getByRole("button", { name: "Add a schedule" })).toBeEnabled();
+    expect(screen.queryByText(/All times/)).not.toBeInTheDocument();
     expect(mockScheduleModal).not.toHaveBeenCalled();
   });
 
@@ -125,6 +126,7 @@ describe("SchedulesPage", () => {
     expect(screen.getByRole("columnheader", { name: "Name" })).toBeInTheDocument();
     expect(screen.getByText("Night sleep")).toBeVisible();
     expect(screen.getByText("Weekdays · 10:00 PM")).toBeVisible();
+    expect(screen.getByText(/All times/)).toBeVisible();
   });
 
   it("keeps only the priority, name, schedule, and row action columns in the phone table layout", async () => {

--- a/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/SchedulesPage.tsx
@@ -22,9 +22,10 @@ import {
 import type { ScheduleColumn } from "@/protoFleet/features/settings/components/Schedules/constants";
 import createScheduleColConfig from "@/protoFleet/features/settings/components/Schedules/scheduleColConfig";
 import ScheduleModal from "@/protoFleet/features/settings/components/Schedules/ScheduleModal";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { Edit, Pause, Play, Trash } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
-import Header from "@/shared/components/Header";
 import List from "@/shared/components/List";
 import type { ActiveFilters } from "@/shared/components/List/Filters/types";
 import type { ListAction, SortDirection } from "@/shared/components/List/types";
@@ -204,16 +205,15 @@ const SchedulesPage = () => {
     />
   ) : null;
 
-  const emptyStateRow = filtersActive ? (
-    <div className="flex flex-col items-center justify-center gap-1 py-12 text-center">
-      <p className="text-heading-200 text-text-primary">No schedules match those filters</p>
-      <p className="text-300 text-text-primary-70">
-        Try clearing one or more filters to see the rest of your schedules.
-      </p>
-    </div>
+  const noDataElement = filtersActive ? (
+    <SettingsEmptyState
+      title="No schedules match those filters"
+      description="Try clearing one or more filters to see the rest of your schedules."
+    />
   ) : (
-    <div className="py-10 text-center text-text-primary-50">No schedules yet. {SCHEDULE_EMPTY_STATE_DESCRIPTION}</div>
+    <SettingsEmptyState title="No schedules yet" description={SCHEDULE_EMPTY_STATE_DESCRIPTION} />
   );
+  const shouldShowTimezone = schedules.length > 0;
 
   if (isLoading || !hasCompletedInitialLoad) {
     return (
@@ -226,10 +226,10 @@ const SchedulesPage = () => {
   return (
     <div className="flex flex-col">
       <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
-        <Header title="Schedules" titleSize="text-heading-300" description={SCHEDULE_PAGE_DESCRIPTION} />
+        <SettingsPageHeader title="Schedules" description={SCHEDULE_PAGE_DESCRIPTION} />
         <Button
           variant={variants.primary}
-          size={sizes.base}
+          size={sizes.compact}
           text="Add a schedule"
           onClick={handleOpenCreateModal}
           className="shrink-0 phone:w-full"
@@ -249,7 +249,8 @@ const SchedulesPage = () => {
         filters={scheduleFilters}
         filterItem={matchesScheduleFilters}
         onFilterChange={setActiveFilters}
-        emptyStateRow={emptyStateRow}
+        hasActiveFilters={filtersActive}
+        noDataElement={noDataElement}
         sortableColumns={SORTABLE_COLUMNS}
         currentSort={currentSort}
         onSort={handleSort}
@@ -261,7 +262,7 @@ const SchedulesPage = () => {
         applyColumnWidthsToCells
         tableClassName={scheduleTableClassName}
       />
-      <div className="px-2 pb-2 text-200 text-text-primary-70">{timezoneLabel}</div>
+      {shouldShowTimezone ? <div className="px-2 pb-2 text-200 text-text-primary-70">{timezoneLabel}</div> : null}
 
       {scheduleModal}
     </div>

--- a/client/src/shared/components/List/List.test.tsx
+++ b/client/src/shared/components/List/List.test.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { createPortal } from "react-dom";
 import { defaultListFilter } from "@/shared/components/List/constants";
@@ -347,6 +347,32 @@ describe("List", () => {
     expect(screen.getByText("No miners found")).toBeInTheDocument();
     expect(screen.queryByText("All Items")).not.toBeInTheDocument();
     expect(screen.queryByText("Value Range")).not.toBeInTheDocument();
+  });
+
+  it("renders rows when data arrives after an empty filtered no-data state", async () => {
+    const props = {
+      activeCols,
+      colTitles: testColTitles,
+      colConfig: testColConfig,
+      filters: testFilters,
+      itemKey: "id" as const,
+      total: 0,
+      noDataElement: <div>No miners found</div>,
+      filterItem: () => true,
+    };
+
+    const { rerender } = render(<List<TestItem, TestItemKey> {...props} items={[]} />);
+
+    expect(screen.getByText("No miners found")).toBeInTheDocument();
+    expect(screen.queryByText("All Items")).not.toBeInTheDocument();
+
+    rerender(<List<TestItem, TestItemKey> {...props} items={testItems} total={testItems.length} />);
+
+    expect(screen.getByText("All Items")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(testItems[0].name)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("No miners found")).not.toBeInTheDocument();
   });
 
   it("keeps header controls visible for a true no-data state", () => {

--- a/client/src/shared/components/List/List.tsx
+++ b/client/src/shared/components/List/List.tsx
@@ -1222,7 +1222,8 @@ const List = <ListItem, ItemKeyValueType, ColKey extends string = keyof ListItem
 
   const hasVisibleRows = filteredItems.length > 0;
   const shouldRenderNoDataElement = Boolean(noDataElement && !hasVisibleRows && !emptyStateRow);
-  const shouldShowFilterItems = Boolean(filters?.length) && (!shouldRenderNoDataElement || hasActiveFilters);
+  const shouldShowFilterItems =
+    Boolean(filters?.length) && (items.length > 0 || !shouldRenderNoDataElement || hasActiveFilters);
   const visibleFilters = shouldShowFilterItems ? (filters ?? []) : [];
 
   const filtersElement =


### PR DESCRIPTION
## Summary

- Applies shared settings headers and empty states across Alerts, Security, Firmware, Schedules, Pools, and Curtailment.
- Standardizes settings list spacing, table chrome, column header color, and action/ellipsis presentation.
- Removes empty-state clutter such as redundant counts, table headers, firmware delete-all CTA, and schedule timezone text.

## Stack

3/3. Stacked on `codex/settings-ia-team-roles`.

## Testing

- `../bin/npx tsc --noEmit --pretty false`
- `../bin/npx eslint . --max-warnings 0`
- `../bin/npx vitest run`
- `../bin/npm run build:protoFleet`
