### PR TITLE
Implement fleet-node paired device unpair

### DIFF
--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -261,6 +261,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.deleteMinerCredentialsByDeviceIDAndOrgIDStmt, err = db.PrepareContext(ctx, deleteMinerCredentialsByDeviceIDAndOrgID); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteMinerCredentialsByDeviceIDAndOrgID: %w", err)
 	}
+	if q.deleteMinerCredentialsForDeviceIdentifiersStmt, err = db.PrepareContext(ctx, deleteMinerCredentialsForDeviceIdentifiers); err != nil {
+		return nil, fmt.Errorf("error preparing query DeleteMinerCredentialsForDeviceIdentifiers: %w", err)
+	}
 	if q.deleteMinerCredentialsForFleetNodeStmt, err = db.PrepareContext(ctx, deleteMinerCredentialsForFleetNode); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteMinerCredentialsForFleetNode: %w", err)
 	}
@@ -1727,6 +1730,11 @@ func (q *Queries) Close() error {
 	if q.deleteMinerCredentialsByDeviceIDAndOrgIDStmt != nil {
 		if cerr := q.deleteMinerCredentialsByDeviceIDAndOrgIDStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing deleteMinerCredentialsByDeviceIDAndOrgIDStmt: %w", cerr)
+		}
+	}
+	if q.deleteMinerCredentialsForDeviceIdentifiersStmt != nil {
+		if cerr := q.deleteMinerCredentialsForDeviceIdentifiersStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing deleteMinerCredentialsForDeviceIdentifiersStmt: %w", cerr)
 		}
 	}
 	if q.deleteMinerCredentialsForFleetNodeStmt != nil {
@@ -3627,6 +3635,7 @@ type Queries struct {
 	deleteExpiredSessionsStmt                                  *sql.Stmt
 	deleteFleetNodeDevicePairingsStmt                          *sql.Stmt
 	deleteMinerCredentialsByDeviceIDAndOrgIDStmt               *sql.Stmt
+	deleteMinerCredentialsForDeviceIdentifiersStmt             *sql.Stmt
 	deleteMinerCredentialsForFleetNodeStmt                     *sql.Stmt
 	deleteOrganizationStmt                                     *sql.Stmt
 	deletePairingsForFleetNodeStmt                             *sql.Stmt
@@ -4068,6 +4077,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		deleteExpiredSessionsStmt:                                  q.deleteExpiredSessionsStmt,
 		deleteFleetNodeDevicePairingsStmt:                          q.deleteFleetNodeDevicePairingsStmt,
 		deleteMinerCredentialsByDeviceIDAndOrgIDStmt:               q.deleteMinerCredentialsByDeviceIDAndOrgIDStmt,
+		deleteMinerCredentialsForDeviceIdentifiersStmt:             q.deleteMinerCredentialsForDeviceIdentifiersStmt,
 		deleteMinerCredentialsForFleetNodeStmt:                     q.deleteMinerCredentialsForFleetNodeStmt,
 		deleteOrganizationStmt:                                     q.deleteOrganizationStmt,
 		deletePairingsForFleetNodeStmt:                             q.deletePairingsForFleetNodeStmt,

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -255,6 +255,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.deleteExpiredSessionsStmt, err = db.PrepareContext(ctx, deleteExpiredSessions); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteExpiredSessions: %w", err)
 	}
+	if q.deleteFleetNodeDevicePairingsStmt, err = db.PrepareContext(ctx, deleteFleetNodeDevicePairings); err != nil {
+		return nil, fmt.Errorf("error preparing query DeleteFleetNodeDevicePairings: %w", err)
+	}
 	if q.deleteMinerCredentialsByDeviceIDAndOrgIDStmt, err = db.PrepareContext(ctx, deleteMinerCredentialsByDeviceIDAndOrgID); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteMinerCredentialsByDeviceIDAndOrgID: %w", err)
 	}
@@ -1714,6 +1717,11 @@ func (q *Queries) Close() error {
 	if q.deleteExpiredSessionsStmt != nil {
 		if cerr := q.deleteExpiredSessionsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing deleteExpiredSessionsStmt: %w", cerr)
+		}
+	}
+	if q.deleteFleetNodeDevicePairingsStmt != nil {
+		if cerr := q.deleteFleetNodeDevicePairingsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing deleteFleetNodeDevicePairingsStmt: %w", cerr)
 		}
 	}
 	if q.deleteMinerCredentialsByDeviceIDAndOrgIDStmt != nil {
@@ -3617,6 +3625,7 @@ type Queries struct {
 	deleteCurtailmentResponseProfilesBySiteStmt                *sql.Stmt
 	deleteDisabledMQTTSourceConfigByOrgStmt                    *sql.Stmt
 	deleteExpiredSessionsStmt                                  *sql.Stmt
+	deleteFleetNodeDevicePairingsStmt                          *sql.Stmt
 	deleteMinerCredentialsByDeviceIDAndOrgIDStmt               *sql.Stmt
 	deleteMinerCredentialsForFleetNodeStmt                     *sql.Stmt
 	deleteOrganizationStmt                                     *sql.Stmt
@@ -4057,6 +4066,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		deleteCurtailmentResponseProfilesBySiteStmt:                q.deleteCurtailmentResponseProfilesBySiteStmt,
 		deleteDisabledMQTTSourceConfigByOrgStmt:                    q.deleteDisabledMQTTSourceConfigByOrgStmt,
 		deleteExpiredSessionsStmt:                                  q.deleteExpiredSessionsStmt,
+		deleteFleetNodeDevicePairingsStmt:                          q.deleteFleetNodeDevicePairingsStmt,
 		deleteMinerCredentialsByDeviceIDAndOrgIDStmt:               q.deleteMinerCredentialsByDeviceIDAndOrgIDStmt,
 		deleteMinerCredentialsForFleetNodeStmt:                     q.deleteMinerCredentialsForFleetNodeStmt,
 		deleteOrganizationStmt:                                     q.deleteOrganizationStmt,

--- a/server/generated/sqlc/device.sql.go
+++ b/server/generated/sqlc/device.sql.go
@@ -250,6 +250,28 @@ func (q *Queries) DeleteFleetNodeDevicePairings(ctx context.Context, arg DeleteF
 	return result.RowsAffected()
 }
 
+const deleteMinerCredentialsForDeviceIdentifiers = `-- name: DeleteMinerCredentialsForDeviceIdentifiers :execrows
+DELETE FROM miner_credentials mc
+USING device d
+WHERE mc.device_id = d.id
+  AND d.device_identifier = ANY($1::text[])
+  AND d.org_id = $2
+`
+
+type DeleteMinerCredentialsForDeviceIdentifiersParams struct {
+	DeviceIdentifiers []string
+	OrgID             int64
+}
+
+// Deletes miner credentials for devices that are being removed from the fleet.
+func (q *Queries) DeleteMinerCredentialsForDeviceIdentifiers(ctx context.Context, arg DeleteMinerCredentialsForDeviceIdentifiersParams) (int64, error) {
+	result, err := q.exec(ctx, q.deleteMinerCredentialsForDeviceIdentifiersStmt, deleteMinerCredentialsForDeviceIdentifiers, pq.Array(arg.DeviceIdentifiers), arg.OrgID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const getAllDeviceInfoForCapabilityCheck = `-- name: GetAllDeviceInfoForCapabilityCheck :many
 SELECT
     d.id,

--- a/server/generated/sqlc/device.sql.go
+++ b/server/generated/sqlc/device.sql.go
@@ -227,6 +227,30 @@ func (q *Queries) CountMinersByState(ctx context.Context, arg CountMinersByState
 	return i, err
 }
 
+const deleteFleetNodeDevicePairings = `-- name: DeleteFleetNodeDevicePairings :execrows
+DELETE FROM fleet_node_device fnd
+USING device d
+WHERE fnd.device_id = d.id
+  AND fnd.org_id = d.org_id
+  AND d.device_identifier = ANY($1::text[])
+  AND d.org_id = $2
+  AND d.deleted_at IS NULL
+`
+
+type DeleteFleetNodeDevicePairingsParams struct {
+	DeviceIdentifiers []string
+	OrgID             int64
+}
+
+// Deletes fleet-node ownership rows for devices that are being removed from the fleet.
+func (q *Queries) DeleteFleetNodeDevicePairings(ctx context.Context, arg DeleteFleetNodeDevicePairingsParams) (int64, error) {
+	result, err := q.exec(ctx, q.deleteFleetNodeDevicePairingsStmt, deleteFleetNodeDevicePairings, pq.Array(arg.DeviceIdentifiers), arg.OrgID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const getAllDeviceInfoForCapabilityCheck = `-- name: GetAllDeviceInfoForCapabilityCheck :many
 SELECT
     d.id,

--- a/server/generated/sqlc/device.sql.go
+++ b/server/generated/sqlc/device.sql.go
@@ -234,7 +234,6 @@ WHERE fnd.device_id = d.id
   AND fnd.org_id = d.org_id
   AND d.device_identifier = ANY($1::text[])
   AND d.org_id = $2
-  AND d.deleted_at IS NULL
 `
 
 type DeleteFleetNodeDevicePairingsParams struct {

--- a/server/internal/domain/fleetmanagement/service_test.go
+++ b/server/internal/domain/fleetmanagement/service_test.go
@@ -1513,6 +1513,66 @@ func TestService_GetMinerCoolingMode_ShouldDenyAccessToOtherOrgMiner(t *testing.
 
 // --- DeleteMiners tests ---
 
+func pairMinerToFleetNode(t *testing.T, db *sql.DB, orgID int64, deviceIdentifier string) int64 {
+	t.Helper()
+
+	var deviceID int64
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		SELECT id
+		FROM device
+		WHERE org_id = $1
+		  AND device_identifier = $2
+		  AND deleted_at IS NULL`,
+		orgID,
+		deviceIdentifier,
+	).Scan(&deviceID))
+
+	var fleetNodeID int64
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		INSERT INTO fleet_node (org_id, name, identity_pubkey, miner_signing_pubkey, enrollment_status)
+		VALUES ($1, $2, $3, $4, 'CONFIRMED')
+		RETURNING id`,
+		orgID,
+		"delete-miners-node-"+deviceIdentifier,
+		[]byte("identity-"+deviceIdentifier),
+		[]byte("miner-signing-"+deviceIdentifier),
+	).Scan(&fleetNodeID))
+
+	rows, err := sqlstores.NewSQLFleetNodePairingStore(db).PairDeviceToFleetNode(t.Context(), fleetNodeID, deviceID, orgID, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+
+	return deviceID
+}
+
+func requireNoFleetNodeDevicePairing(t *testing.T, db *sql.DB, deviceID int64) {
+	t.Helper()
+
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*)
+		FROM fleet_node_device
+		WHERE device_id = $1`,
+		deviceID,
+	).Scan(&count))
+	assert.Equal(t, 0, count)
+}
+
+func requireDeviceSoftDeleted(t *testing.T, db *sql.DB, orgID int64, deviceIdentifier string) {
+	t.Helper()
+
+	var deletedAt sql.NullTime
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		SELECT deleted_at
+		FROM device
+		WHERE org_id = $1
+		  AND device_identifier = $2`,
+		orgID,
+		deviceIdentifier,
+	).Scan(&deletedAt))
+	require.True(t, deletedAt.Valid, "device should be soft-deleted")
+}
+
 func TestService_DeleteMiners_ShouldSoftDeleteSpecificDevices(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
@@ -1547,6 +1607,42 @@ func TestService_DeleteMiners_ShouldSoftDeleteSpecificDevices(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, listResp.Miners, 1, "only 1 miner should remain after deleting 2")
 	assert.Equal(t, deviceIDs[2], listResp.Miners[0].DeviceIdentifier)
+}
+
+func TestService_DeleteMiners_ShouldCleanFleetNodePairingRows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	testUser := testContext.DatabaseService.CreateSuperAdminUser()
+
+	deviceIDs := testContext.DatabaseService.CreateTestMiners(testUser.OrganizationID, 1, "https://172.17.0.1:80")
+	deviceID := pairMinerToFleetNode(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[0])
+
+	ctx := testutil.MockAuthContextForTesting(t.Context(), testUser.DatabaseID, testUser.OrganizationID)
+	service := testContext.ServiceProvider.FleetManagementService
+
+	req := &pb.DeleteMinersRequest{
+		DeviceSelector: &pb.DeviceSelector{
+			SelectionType: &pb.DeviceSelector_IncludeDevices{
+				IncludeDevices: &commonv1.DeviceIdentifierList{
+					DeviceIdentifiers: deviceIDs,
+				},
+			},
+		},
+	}
+	resp, err := service.DeleteMiners(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(1), resp.DeletedCount)
+	requireDeviceSoftDeleted(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[0])
+	requireNoFleetNodeDevicePairing(t, testContext.ServiceProvider.DB, deviceID)
+
+	listResp, err := service.ListMinerStateSnapshots(ctx, &pb.ListMinerStateSnapshotsRequest{PageSize: 10})
+	require.NoError(t, err)
+	assert.Empty(t, listResp.Miners, "node-owned miner should be removed from the fleet list")
 }
 
 func TestService_DeleteMiners_ShouldRejectEmptyRequestWithoutFilter(t *testing.T) {
@@ -1684,6 +1780,40 @@ func TestService_DeleteMiners_ShouldDeleteAllPairedDevicesWithEmptyFilter(t *tes
 	assert.Equal(t, int32(3), resp.DeletedCount)
 
 	// Verify all miners are gone
+	listResp, err := service.ListMinerStateSnapshots(ctx, &pb.ListMinerStateSnapshotsRequest{PageSize: 10})
+	require.NoError(t, err)
+	assert.Empty(t, listResp.Miners, "no miners should remain after deleting all")
+}
+
+func TestService_DeleteMiners_ShouldIncludeFleetNodePairedDevicesWithAllSelector(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	testUser := testContext.DatabaseService.CreateSuperAdminUser()
+
+	deviceIDs := testContext.DatabaseService.CreateTestMiners(testUser.OrganizationID, 2, "https://172.17.0.1:80")
+	nodeOwnedDeviceID := pairMinerToFleetNode(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[1])
+
+	ctx := testutil.MockAuthContextForTesting(t.Context(), testUser.DatabaseID, testUser.OrganizationID)
+	service := testContext.ServiceProvider.FleetManagementService
+
+	req := &pb.DeleteMinersRequest{
+		DeviceSelector: &pb.DeviceSelector{
+			SelectionType: &pb.DeviceSelector_AllDevices{
+				AllDevices: &pb.MinerListFilter{},
+			},
+		},
+	}
+	resp, err := service.DeleteMiners(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(2), resp.DeletedCount)
+	requireDeviceSoftDeleted(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[1])
+	requireNoFleetNodeDevicePairing(t, testContext.ServiceProvider.DB, nodeOwnedDeviceID)
+
 	listResp, err := service.ListMinerStateSnapshots(ctx, &pb.ListMinerStateSnapshotsRequest{PageSize: 10})
 	require.NoError(t, err)
 	assert.Empty(t, listResp.Miners, "no miners should remain after deleting all")

--- a/server/internal/domain/fleetmanagement/service_test.go
+++ b/server/internal/domain/fleetmanagement/service_test.go
@@ -1529,13 +1529,12 @@ func pairMinerToFleetNode(t *testing.T, db *sql.DB, orgID int64, deviceIdentifie
 
 	var fleetNodeID int64
 	require.NoError(t, db.QueryRowContext(t.Context(), `
-		INSERT INTO fleet_node (org_id, name, identity_pubkey, miner_signing_pubkey, enrollment_status)
-		VALUES ($1, $2, $3, $4, 'CONFIRMED')
+		INSERT INTO fleet_node (org_id, name, identity_pubkey, enrollment_status)
+		VALUES ($1, $2, $3, 'CONFIRMED')
 		RETURNING id`,
 		orgID,
 		"delete-miners-node-"+deviceIdentifier,
 		[]byte("identity-"+deviceIdentifier),
-		[]byte("miner-signing-"+deviceIdentifier),
 	).Scan(&fleetNodeID))
 
 	rows, err := sqlstores.NewSQLFleetNodePairingStore(db).PairDeviceToFleetNode(t.Context(), fleetNodeID, deviceID, orgID, nil)
@@ -1543,6 +1542,61 @@ func pairMinerToFleetNode(t *testing.T, db *sql.DB, orgID int64, deviceIdentifie
 	require.Equal(t, int64(1), rows)
 
 	return deviceID
+}
+
+func createStaleFleetNodeDevicePairing(t *testing.T, db *sql.DB, orgID int64, deviceIdentifier string) int64 {
+	t.Helper()
+
+	var fleetNodeID int64
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		INSERT INTO fleet_node (org_id, name, identity_pubkey, enrollment_status)
+		VALUES ($1, $2, $3, 'CONFIRMED')
+		RETURNING id`,
+		orgID,
+		"stale-delete-miners-node-"+deviceIdentifier,
+		[]byte("stale-identity-"+deviceIdentifier),
+	).Scan(&fleetNodeID))
+
+	var discoveredDeviceID int64
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		INSERT INTO discovered_device (
+			org_id,
+			device_identifier,
+			driver_name,
+			ip_address,
+			port,
+			url_scheme,
+			is_active,
+			deleted_at
+		)
+		VALUES ($1, $2, 'proto', '172.17.99.1', '80', 'https', false, NOW())
+		RETURNING id`,
+		orgID,
+		deviceIdentifier,
+	).Scan(&discoveredDeviceID))
+
+	var staleDeviceID int64
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		INSERT INTO device (
+			org_id,
+			discovered_device_id,
+			device_identifier,
+			mac_address,
+			deleted_at
+		)
+		VALUES ($1, $2, $3, $4, NOW())
+		RETURNING id`,
+		orgID,
+		discoveredDeviceID,
+		deviceIdentifier,
+		"02:00:00:99:99:99",
+	).Scan(&staleDeviceID))
+
+	rows, err := sqlstores.NewSQLFleetNodePairingStore(db).PairDeviceToFleetNode(t.Context(), fleetNodeID, staleDeviceID, orgID, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+
+	return staleDeviceID
 }
 
 func requireNoFleetNodeDevicePairing(t *testing.T, db *sql.DB, deviceID int64) {
@@ -1643,6 +1697,39 @@ func TestService_DeleteMiners_ShouldCleanFleetNodePairingRows(t *testing.T) {
 	listResp, err := service.ListMinerStateSnapshots(ctx, &pb.ListMinerStateSnapshotsRequest{PageSize: 10})
 	require.NoError(t, err)
 	assert.Empty(t, listResp.Miners, "node-owned miner should be removed from the fleet list")
+}
+
+func TestService_DeleteMiners_ShouldCleanStaleFleetNodePairingRowsForRediscoveredDevice(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	testUser := testContext.DatabaseService.CreateSuperAdminUser()
+
+	deviceIDs := testContext.DatabaseService.CreateTestMiners(testUser.OrganizationID, 1, "https://172.17.0.1:80")
+	liveDeviceID := pairMinerToFleetNode(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[0])
+	staleDeviceID := createStaleFleetNodeDevicePairing(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[0])
+
+	ctx := testutil.MockAuthContextForTesting(t.Context(), testUser.DatabaseID, testUser.OrganizationID)
+	service := testContext.ServiceProvider.FleetManagementService
+
+	req := &pb.DeleteMinersRequest{
+		DeviceSelector: &pb.DeviceSelector{
+			SelectionType: &pb.DeviceSelector_IncludeDevices{
+				IncludeDevices: &commonv1.DeviceIdentifierList{
+					DeviceIdentifiers: deviceIDs,
+				},
+			},
+		},
+	}
+	resp, err := service.DeleteMiners(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(1), resp.DeletedCount)
+	requireNoFleetNodeDevicePairing(t, testContext.ServiceProvider.DB, liveDeviceID)
+	requireNoFleetNodeDevicePairing(t, testContext.ServiceProvider.DB, staleDeviceID)
 }
 
 func TestService_DeleteMiners_ShouldRejectEmptyRequestWithoutFilter(t *testing.T) {

--- a/server/internal/domain/fleetmanagement/service_test.go
+++ b/server/internal/domain/fleetmanagement/service_test.go
@@ -1612,6 +1612,32 @@ func requireNoFleetNodeDevicePairing(t *testing.T, db *sql.DB, deviceID int64) {
 	assert.Equal(t, 0, count)
 }
 
+func insertMinerCredentials(t *testing.T, db *sql.DB, deviceID int64) {
+	t.Helper()
+
+	_, err := db.ExecContext(t.Context(), `
+		INSERT INTO miner_credentials (device_id, username_enc, password_enc)
+		VALUES ($1, $2, $3)`,
+		deviceID,
+		"node-owned-username",
+		"node-owned-password",
+	)
+	require.NoError(t, err)
+}
+
+func requireNoMinerCredentials(t *testing.T, db *sql.DB, deviceID int64) {
+	t.Helper()
+
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*)
+		FROM miner_credentials
+		WHERE device_id = $1`,
+		deviceID,
+	).Scan(&count))
+	assert.Equal(t, 0, count)
+}
+
 func requireDeviceSoftDeleted(t *testing.T, db *sql.DB, orgID int64, deviceIdentifier string) {
 	t.Helper()
 
@@ -1673,6 +1699,7 @@ func TestService_DeleteMiners_ShouldCleanFleetNodePairingRows(t *testing.T) {
 
 	deviceIDs := testContext.DatabaseService.CreateTestMiners(testUser.OrganizationID, 1, "https://172.17.0.1:80")
 	deviceID := pairMinerToFleetNode(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[0])
+	insertMinerCredentials(t, testContext.ServiceProvider.DB, deviceID)
 
 	ctx := testutil.MockAuthContextForTesting(t.Context(), testUser.DatabaseID, testUser.OrganizationID)
 	service := testContext.ServiceProvider.FleetManagementService
@@ -1693,6 +1720,7 @@ func TestService_DeleteMiners_ShouldCleanFleetNodePairingRows(t *testing.T) {
 	assert.Equal(t, int32(1), resp.DeletedCount)
 	requireDeviceSoftDeleted(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[0])
 	requireNoFleetNodeDevicePairing(t, testContext.ServiceProvider.DB, deviceID)
+	requireNoMinerCredentials(t, testContext.ServiceProvider.DB, deviceID)
 
 	listResp, err := service.ListMinerStateSnapshots(ctx, &pb.ListMinerStateSnapshotsRequest{PageSize: 10})
 	require.NoError(t, err)
@@ -1710,6 +1738,8 @@ func TestService_DeleteMiners_ShouldCleanStaleFleetNodePairingRowsForRediscovere
 	deviceIDs := testContext.DatabaseService.CreateTestMiners(testUser.OrganizationID, 1, "https://172.17.0.1:80")
 	liveDeviceID := pairMinerToFleetNode(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[0])
 	staleDeviceID := createStaleFleetNodeDevicePairing(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[0])
+	insertMinerCredentials(t, testContext.ServiceProvider.DB, liveDeviceID)
+	insertMinerCredentials(t, testContext.ServiceProvider.DB, staleDeviceID)
 
 	ctx := testutil.MockAuthContextForTesting(t.Context(), testUser.DatabaseID, testUser.OrganizationID)
 	service := testContext.ServiceProvider.FleetManagementService
@@ -1730,6 +1760,8 @@ func TestService_DeleteMiners_ShouldCleanStaleFleetNodePairingRowsForRediscovere
 	assert.Equal(t, int32(1), resp.DeletedCount)
 	requireNoFleetNodeDevicePairing(t, testContext.ServiceProvider.DB, liveDeviceID)
 	requireNoFleetNodeDevicePairing(t, testContext.ServiceProvider.DB, staleDeviceID)
+	requireNoMinerCredentials(t, testContext.ServiceProvider.DB, liveDeviceID)
+	requireNoMinerCredentials(t, testContext.ServiceProvider.DB, staleDeviceID)
 }
 
 func TestService_DeleteMiners_ShouldRejectEmptyRequestWithoutFilter(t *testing.T) {

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -1318,6 +1318,13 @@ func (s *SQLDeviceStore) SoftDeleteDevices(ctx context.Context, deviceIdentifier
 			return 0, fleeterror.NewForbiddenError("access denied to one or more requested devices")
 		}
 
+		if _, err := q.DeleteMinerCredentialsForDeviceIdentifiers(ctx, sqlc.DeleteMinerCredentialsForDeviceIdentifiersParams{
+			DeviceIdentifiers: deviceIdentifiers,
+			OrgID:             orgID,
+		}); err != nil {
+			return 0, fleeterror.NewInternalErrorf("failed to delete miner credentials: %w", err)
+		}
+
 		if _, err := q.DeleteFleetNodeDevicePairings(ctx, sqlc.DeleteFleetNodeDevicePairingsParams{
 			DeviceIdentifiers: deviceIdentifiers,
 			OrgID:             orgID,

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -1318,6 +1318,13 @@ func (s *SQLDeviceStore) SoftDeleteDevices(ctx context.Context, deviceIdentifier
 			return 0, fleeterror.NewForbiddenError("access denied to one or more requested devices")
 		}
 
+		if _, err := q.DeleteFleetNodeDevicePairings(ctx, sqlc.DeleteFleetNodeDevicePairingsParams{
+			DeviceIdentifiers: deviceIdentifiers,
+			OrgID:             orgID,
+		}); err != nil {
+			return 0, fleeterror.NewInternalErrorf("failed to delete fleet node device pairings: %v", err)
+		}
+
 		count, err := q.SoftDeleteDevices(ctx, sqlc.SoftDeleteDevicesParams{
 			DeviceIdentifiers: deviceIdentifiers,
 			OrgID:             orgID,

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -1322,7 +1322,7 @@ func (s *SQLDeviceStore) SoftDeleteDevices(ctx context.Context, deviceIdentifier
 			DeviceIdentifiers: deviceIdentifiers,
 			OrgID:             orgID,
 		}); err != nil {
-			return 0, fleeterror.NewInternalErrorf("failed to delete fleet node device pairings: %v", err)
+			return 0, fleeterror.NewInternalErrorf("failed to delete fleet node device pairings: %w", err)
 		}
 
 		count, err := q.SoftDeleteDevices(ctx, sqlc.SoftDeleteDevicesParams{

--- a/server/sqlc/queries/device.sql
+++ b/server/sqlc/queries/device.sql
@@ -846,6 +846,16 @@ WHERE device_identifier = ANY(sqlc.arg('device_identifiers')::text[])
   AND org_id = sqlc.arg('org_id')
   AND deleted_at IS NULL;
 
+-- name: DeleteFleetNodeDevicePairings :execrows
+-- Deletes fleet-node ownership rows for devices that are being removed from the fleet.
+DELETE FROM fleet_node_device fnd
+USING device d
+WHERE fnd.device_id = d.id
+  AND fnd.org_id = d.org_id
+  AND d.device_identifier = ANY(sqlc.arg('device_identifiers')::text[])
+  AND d.org_id = sqlc.arg('org_id')
+  AND d.deleted_at IS NULL;
+
 -- name: SoftDeleteDiscoveredDevicesForDeletedDevices :exec
 -- Soft-deletes discovered_device records linked to the specified devices.
 UPDATE discovered_device dd SET deleted_at = NOW()

--- a/server/sqlc/queries/device.sql
+++ b/server/sqlc/queries/device.sql
@@ -846,6 +846,14 @@ WHERE device_identifier = ANY(sqlc.arg('device_identifiers')::text[])
   AND org_id = sqlc.arg('org_id')
   AND deleted_at IS NULL;
 
+-- name: DeleteMinerCredentialsForDeviceIdentifiers :execrows
+-- Deletes miner credentials for devices that are being removed from the fleet.
+DELETE FROM miner_credentials mc
+USING device d
+WHERE mc.device_id = d.id
+  AND d.device_identifier = ANY(sqlc.arg('device_identifiers')::text[])
+  AND d.org_id = sqlc.arg('org_id');
+
 -- name: DeleteFleetNodeDevicePairings :execrows
 -- Deletes fleet-node ownership rows for devices that are being removed from the fleet.
 DELETE FROM fleet_node_device fnd

--- a/server/sqlc/queries/device.sql
+++ b/server/sqlc/queries/device.sql
@@ -853,8 +853,7 @@ USING device d
 WHERE fnd.device_id = d.id
   AND fnd.org_id = d.org_id
   AND d.device_identifier = ANY(sqlc.arg('device_identifiers')::text[])
-  AND d.org_id = sqlc.arg('org_id')
-  AND d.deleted_at IS NULL;
+  AND d.org_id = sqlc.arg('org_id');
 
 -- name: SoftDeleteDiscoveredDevicesForDeletedDevices :exec
 -- Soft-deletes discovered_device records linked to the specified devices.


### PR DESCRIPTION
## Summary
- Make fleet-level unpair work for fleet-node-owned miners by cleaning `miner_credentials` and `fleet_node_device` rows inside the transactional `DeleteMiners` soft-delete path.
- Preserve the lower-level fleet-node admin detach-only RPC and avoid public API/proto changes while keeping node-owned miners out of direct cloud miner I/O.
- Add regressions so explicit and bulk unpair cover fleet-node paired devices, including stale ownership rows from rediscovered miners and stored encrypted credentials.

## Test Plan
- `DB_PASSWORD=fleet ../bin/go test ./internal/domain/fleetmanagement -run 'TestService_DeleteMiners'`
- `DB_PASSWORD=fleet ../bin/go test ./internal/handlers/fleetnode/admin -run 'Test(PairDeviceToFleetNode|UnpairDevice|ListFleetNodeDevices)'`
- `../bin/just lint` from `server/`
- `git diff --check`
- Regenerated sqlc from `server/sqlc/queries/device.sql`; generated files were not hand-edited.
