### PR TITLE
Add breadcrumbs to fleet detail pages

### DIFF
--- a/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
@@ -2,62 +2,76 @@ import { useNavigate } from "react-router-dom";
 
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
-import { ChevronDown } from "@/shared/assets/icons";
+import Breadcrumb, { type BreadcrumbSibling } from "@/shared/components/Breadcrumb";
 import Button, { variants } from "@/shared/components/Button";
 import Header from "@/shared/components/Header";
 
 interface BuildingPageHeaderProps {
   label: string;
   buildingId: string;
+  siteId?: string;
+  siteName?: string;
+  buildingSiblings?: BreadcrumbSibling[];
   // Opens ManageBuildingModal. Optional so callers that don't need the
   // editing surface (e.g. error states, loading) can omit it; the button
   // disables when no handler is wired.
   onEditBuilding?: () => void;
 }
 
-// Mirrors RackOverviewPage's header: chevron-left back button, heading-300
-// title, and a cluster of three secondary buttons. "View miners" and "View
+// Mirrors RackOverviewPage's header: breadcrumb, heading-300 title, and a
+// cluster of three secondary buttons. "View miners" and "View
 // racks" link to their respective lists with the `building` URL filter — the
 // singular key parsed by filterUrlParams.ts (mirroring the existing `group`
 // and `rack` singular keys). RacksPage parses the same param to pre-select
 // its building filter chip.
-const BuildingPageHeader = ({ label, buildingId, onEditBuilding }: BuildingPageHeaderProps) => {
+const BuildingPageHeader = ({
+  label,
+  buildingId,
+  siteId,
+  siteName,
+  buildingSiblings,
+  onEditBuilding,
+}: BuildingPageHeaderProps) => {
   const navigate = useNavigate();
   const activeSite = useFleetStore((state) => state.ui.activeSite);
+  const currentSegment = {
+    label,
+    siblings: buildingSiblings && buildingSiblings.length > 1 ? buildingSiblings : undefined,
+  };
+  const breadcrumbSegments = siteId
+    ? [{ label: "Sites", to: "/fleet/sites" }, { label: siteName ?? "Site", to: `/sites/${siteId}` }, currentSegment]
+    : [{ label: "Buildings", to: "/fleet/buildings" }, currentSegment];
+
   return (
-    <Header
-      title={label}
-      titleSize="text-heading-300"
-      inline
-      icon={<ChevronDown className="rotate-90" />}
-      iconAriaLabel="Back to sites"
-      iconOnClick={() => navigate(scopedPath("/fleet/sites", activeSite))}
-    >
-      <div className="ml-3 flex items-center gap-3">
-        <Button
-          variant={variants.secondary}
-          onClick={() => navigate(scopedPath(`/fleet/racks?building=${buildingId}`, activeSite))}
-          testId="building-page-view-racks"
-        >
-          View racks
-        </Button>
-        <Button
-          variant={variants.secondary}
-          onClick={() => navigate(scopedPath(`/fleet/miners?building=${buildingId}`, activeSite))}
-          testId="building-page-view-miners"
-        >
-          View miners
-        </Button>
-        <Button
-          variant={variants.secondary}
-          onClick={onEditBuilding ?? (() => undefined)}
-          disabled={!onEditBuilding}
-          testId="building-page-edit"
-        >
-          Edit building
-        </Button>
-      </div>
-    </Header>
+    <div className="flex flex-col gap-3">
+      <Breadcrumb segments={breadcrumbSegments} testId="building-page-breadcrumb" />
+      <Header title={label} titleSize="text-heading-300" inline>
+        <div className="ml-3 flex items-center gap-3">
+          <Button
+            variant={variants.secondary}
+            onClick={() => navigate(scopedPath(`/fleet/racks?building=${buildingId}`, activeSite))}
+            testId="building-page-view-racks"
+          >
+            View racks
+          </Button>
+          <Button
+            variant={variants.secondary}
+            onClick={() => navigate(scopedPath(`/fleet/miners?building=${buildingId}`, activeSite))}
+            testId="building-page-view-miners"
+          >
+            View miners
+          </Button>
+          <Button
+            variant={variants.secondary}
+            onClick={onEditBuilding ?? (() => undefined)}
+            disabled={!onEditBuilding}
+            testId="building-page-edit"
+          >
+            Edit building
+          </Button>
+        </div>
+      </Header>
+    </div>
   );
 };
 

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
@@ -4,19 +4,39 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 
 import BuildingPage from "./BuildingPage";
-import { type Building, type BuildingRack, BuildingSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import {
+  type Building,
+  type BuildingRack,
+  BuildingSchema,
+  type BuildingWithCounts,
+  BuildingWithCountsSchema,
+} from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { SiteSchema, type SiteWithCounts, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 
 const getBuildingMock = vi.hoisted(() => vi.fn());
+const listAllBuildingsMock = vi.hoisted(() => vi.fn());
 const listBuildingRacksMock = vi.hoisted(() => vi.fn());
+const listSitesMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/protoFleet/api/buildings", () => ({
   useBuildings: () => ({
     getBuilding: getBuildingMock,
+    listAllBuildings: listAllBuildingsMock,
     listBuildingRacks: listBuildingRacksMock,
   }),
 }));
+
+vi.mock("@/protoFleet/api/sites", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/protoFleet/api/sites")>();
+  return {
+    ...actual,
+    useSites: () => ({
+      listSites: listSitesMock,
+    }),
+  };
+});
 
 vi.mock("@/protoFleet/api/useBuildingStats", () => ({
   useBuildingStats: () => ({
@@ -135,8 +155,29 @@ describe("BuildingPage", () => {
         }),
       ),
     );
+    listAllBuildingsMock.mockImplementation(({ onSuccess }: { onSuccess: (buildings: BuildingWithCounts[]) => void }) =>
+      onSuccess([
+        create(BuildingWithCountsSchema, {
+          building: create(BuildingSchema, {
+            id: 123n,
+            name: "Building A",
+            siteId: 8n,
+          }),
+        }),
+      ]),
+    );
     listBuildingRacksMock.mockImplementation(({ onSuccess }: { onSuccess: (racks: BuildingRack[]) => void }) =>
       onSuccess([]),
+    );
+    listSitesMock.mockImplementation(({ onSuccess }: { onSuccess: (sites: SiteWithCounts[]) => void }) =>
+      onSuccess([
+        create(SiteWithCountsSchema, {
+          site: create(SiteSchema, {
+            id: 8n,
+            name: "Austin",
+          }),
+        }),
+      ]),
     );
   });
 

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -8,9 +8,14 @@ import BuildingPageHeader from "../components/BuildingPageHeader";
 import { BuildingRackGrid } from "../components/BuildingRackGrid";
 import { useBuildingModals } from "../hooks/useBuildingModals";
 import { useBuildings } from "@/protoFleet/api/buildings";
-import { type Building, BuildingWithCountsSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import {
+  type Building,
+  type BuildingWithCounts,
+  BuildingWithCountsSchema,
+} from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { AggregationType, MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
-import { parseBigIntId } from "@/protoFleet/api/sites";
+import { parseBigIntId, useSites } from "@/protoFleet/api/sites";
 import { useBuildingStats } from "@/protoFleet/api/useBuildingStats";
 import { useComponentErrors } from "@/protoFleet/api/useComponentErrors";
 import { useTelemetryMetrics } from "@/protoFleet/api/useTelemetryMetrics";
@@ -55,7 +60,8 @@ type FetchOutcome =
 const BuildingPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { getBuilding, listBuildingRacks } = useBuildings();
+  const { getBuilding, listAllBuildings, listBuildingRacks } = useBuildings();
+  const { listSites } = useSites();
   const activeSite = useFleetStore((state) => state.ui.activeSite);
 
   const buildingId = useMemo(() => parseBigIntId(id), [id]);
@@ -67,6 +73,8 @@ const BuildingPage = () => {
   // Parallel-fetched rack count keyed by buildingId so it can't race a
   // navigation. Used to populate the cascade-delete dialog's count copy.
   const [rackCountResponse, setRackCountResponse] = useState<{ id: bigint; count: bigint } | undefined>(undefined);
+  const [sites, setSites] = useState<SiteWithCounts[]>([]);
+  const [allBuildings, setAllBuildings] = useState<BuildingWithCounts[]>([]);
   const inflightControllerRef = useRef<AbortController | null>(null);
   const racksInflightRef = useRef<AbortController | null>(null);
 
@@ -101,6 +109,21 @@ const BuildingPage = () => {
     },
     [getBuilding, listBuildingRacks],
   );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void listSites({
+      signal: controller.signal,
+      onSuccess: setSites,
+      onError: () => setSites([]),
+    });
+    void listAllBuildings({
+      signal: controller.signal,
+      onSuccess: setAllBuildings,
+      onError: () => setAllBuildings([]),
+    });
+    return () => controller.abort();
+  }, [listAllBuildings, listSites]);
 
   useEffect(() => {
     if (buildingId === null) return;
@@ -182,6 +205,11 @@ const BuildingPage = () => {
 
   const effectiveOutcome: FetchOutcome | "loading" | "invalid" =
     buildingId === null ? "invalid" : response && response.id === buildingId ? response.outcome : "loading";
+  const siteNameById = useMemo(
+    () =>
+      new Map(sites.filter((row) => row.site !== undefined).map((row) => [row.site!.id.toString(), row.site!.name])),
+    [sites],
+  );
 
   if (effectiveOutcome === "loading") {
     return (
@@ -227,6 +255,15 @@ const BuildingPage = () => {
   const label = effectiveBuilding.name || "(unnamed building)";
   const idForHeader = effectiveBuilding.id.toString();
   const buildingFilterParam = `building=${effectiveBuilding.id.toString()}`;
+  const siteIdForHeader = effectiveBuilding.siteId?.toString();
+  const buildingSiblings = allBuildings
+    .filter((row) => row.building !== undefined)
+    .filter((row) => (row.building!.siteId ?? 0n) === (effectiveBuilding.siteId ?? 0n))
+    .map((row) => ({
+      label: row.building!.name || "(unnamed building)",
+      to: `/buildings/${row.building!.id.toString()}`,
+      isActive: row.building!.id === effectiveBuilding.id,
+    }));
 
   // Edit/Delete require the rack count to render an accurate cascade
   // warning ("deleting this building will unassign N racks"). Prefer the
@@ -252,7 +289,14 @@ const BuildingPage = () => {
     <div className="h-full" data-testid="building-page">
       <div className="flex flex-col">
         <div className="p-6 pb-0 laptop:p-10 laptop:pb-0">
-          <BuildingPageHeader label={label} buildingId={idForHeader} onEditBuilding={handleEditBuilding} />
+          <BuildingPageHeader
+            label={label}
+            buildingId={idForHeader}
+            siteId={siteIdForHeader}
+            siteName={siteIdForHeader ? siteNameById.get(siteIdForHeader) : undefined}
+            buildingSiblings={buildingSiblings}
+            onEditBuilding={handleEditBuilding}
+          />
         </div>
 
         {/* Stats fetch failure on initial load — surface it inline so the

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
@@ -2,6 +2,7 @@ import { MemoryRouter } from "react-router-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
+import userEvent from "@testing-library/user-event";
 
 import RackOverviewPage from "./RackOverviewPage";
 import { DeviceSetSchema } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
@@ -125,20 +126,29 @@ const rack = create(DeviceSetSchema, {
   },
 });
 
-function mockResolvedRackPageData(deviceSet = rack): void {
+function mockResolvedRackPageData(
+  deviceSet = rack,
+  options: {
+    allBuildings?: unknown[];
+    sites?: unknown[];
+    allRacks?: unknown[];
+  } = {},
+): void {
   mockUseParams.mockReturnValue({ rackId: "7" });
   mockUseBuildings.mockReturnValue({
-    listAllBuildings: ({ onSuccess }: { onSuccess: (buildings: unknown[]) => void }) => onSuccess([]),
+    listAllBuildings: ({ onSuccess }: { onSuccess: (buildings: unknown[]) => void }) =>
+      onSuccess(options.allBuildings ?? []),
   });
   mockUseDeviceSets.mockReturnValue({
     getDeviceSet: ({ onSuccess }: { onSuccess: (resolvedDeviceSet: typeof rack) => void }) => onSuccess(deviceSet),
     listGroupMembers: ({ onSuccess }: { onSuccess: (deviceIds: string[]) => void }) => onSuccess([]),
     assignDevicesToRack: vi.fn(),
+    listRacks: ({ onSuccess }: { onSuccess: (racks: unknown[]) => void }) => onSuccess(options.allRacks ?? [deviceSet]),
     setRackSlotPosition: vi.fn(),
     deleteGroup: vi.fn(),
   });
   mockUseSites.mockReturnValue({
-    listSites: ({ onSuccess }: { onSuccess: (sites: unknown[]) => void }) => onSuccess([]),
+    listSites: ({ onSuccess }: { onSuccess: (sites: unknown[]) => void }) => onSuccess(options.sites ?? []),
   });
   mockUseDeviceSetStateCounts.mockReturnValue({
     stateCounts: {
@@ -213,5 +223,65 @@ describe("RackOverviewPage", () => {
     await waitFor(() => expect(screen.getAllByText(rackName).length).toBeGreaterThan(0));
 
     expect(screen.queryByText(rackZone)).not.toBeInTheDocument();
+  });
+
+  it("renders a switcher on the current rack breadcrumb item when other racks exist", async () => {
+    const rackInBuilding = create(DeviceSetSchema, {
+      id: 7n,
+      label: rackName,
+      typeDetails: {
+        case: "rackInfo",
+        value: {
+          rows: 6,
+          columns: 5,
+          zone: rackZone,
+          buildingId: 11n,
+        },
+      },
+    });
+    const siblingRackName = "Rack BA-Z01-R02";
+    const siblingRack = create(DeviceSetSchema, {
+      id: 8n,
+      label: siblingRackName,
+      typeDetails: {
+        case: "rackInfo",
+        value: {
+          rows: 6,
+          columns: 5,
+          zone: rackZone,
+        },
+      },
+    });
+
+    mockResolvedRackPageData(rackInBuilding, {
+      allBuildings: [
+        {
+          building: {
+            id: 11n,
+            siteId: 22n,
+            name: "Building A",
+          },
+        },
+      ],
+      sites: [
+        {
+          site: {
+            id: 22n,
+            name: "Denver",
+          },
+        },
+      ],
+      allRacks: [rackInBuilding, siblingRack],
+    });
+
+    const user = userEvent.setup();
+    renderRackOverviewPage();
+
+    const switcher = await screen.findByTestId("rack-page-breadcrumb-switcher");
+    expect(switcher).toHaveTextContent(rackName);
+
+    await user.click(switcher);
+
+    expect(screen.getByTestId(`rack-page-breadcrumb-menu-item-${siblingRackName}`)).toBeVisible();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
@@ -6,6 +6,8 @@ import userEvent from "@testing-library/user-event";
 
 import RackOverviewPage from "./RackOverviewPage";
 import { DeviceSetSchema } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 
 const mockUseParams = vi.fn();
 const mockNavigate = vi.fn();
@@ -15,6 +17,7 @@ const mockUseDeviceSetStateCounts = vi.fn();
 const mockUseSites = vi.fn();
 const mockUseTelemetryMetrics = vi.fn();
 const mockUseComponentErrors = vi.fn();
+const listRacksMock = vi.hoisted(() => vi.fn());
 
 const rackName = "Rack BA-Z01-R01";
 const rackZone = "Building A";
@@ -135,6 +138,9 @@ function mockResolvedRackPageData(
   } = {},
 ): void {
   mockUseParams.mockReturnValue({ rackId: "7" });
+  listRacksMock.mockImplementation(({ onSuccess }: { onSuccess: (racks: unknown[]) => void }) =>
+    onSuccess(options.allRacks ?? [deviceSet]),
+  );
   mockUseBuildings.mockReturnValue({
     listAllBuildings: ({ onSuccess }: { onSuccess: (buildings: unknown[]) => void }) =>
       onSuccess(options.allBuildings ?? []),
@@ -143,7 +149,7 @@ function mockResolvedRackPageData(
     getDeviceSet: ({ onSuccess }: { onSuccess: (resolvedDeviceSet: typeof rack) => void }) => onSuccess(deviceSet),
     listGroupMembers: ({ onSuccess }: { onSuccess: (deviceIds: string[]) => void }) => onSuccess([]),
     assignDevicesToRack: vi.fn(),
-    listRacks: ({ onSuccess }: { onSuccess: (racks: unknown[]) => void }) => onSuccess(options.allRacks ?? [deviceSet]),
+    listRacks: listRacksMock,
     setRackSlotPosition: vi.fn(),
     deleteGroup: vi.fn(),
   });
@@ -187,6 +193,9 @@ function renderRackOverviewPage() {
 describe("RackOverviewPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = DEFAULT_ACTIVE_SITE;
+    });
     mockResolvedRackPageData();
   });
 
@@ -279,9 +288,20 @@ describe("RackOverviewPage", () => {
 
     const switcher = await screen.findByTestId("rack-page-breadcrumb-switcher");
     expect(switcher).toHaveTextContent(rackName);
+    expect(listRacksMock).toHaveBeenCalledWith(expect.objectContaining({ buildingIds: [11n] }));
 
     await user.click(switcher);
 
     expect(screen.getByTestId(`rack-page-breadcrumb-menu-item-${siblingRackName}`)).toBeVisible();
+  });
+
+  it("preserves active fleet scope on the unparented rack list breadcrumb", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "unassigned" };
+    });
+
+    renderRackOverviewPage();
+
+    expect(await screen.findByTestId("rack-page-breadcrumb-link-0")).toHaveAttribute("href", "/unassigned/fleet/racks");
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
@@ -1,3 +1,4 @@
+import { MemoryRouter } from "react-router-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
@@ -7,8 +8,10 @@ import { DeviceSetSchema } from "@/protoFleet/api/generated/device_set/v1/device
 
 const mockUseParams = vi.fn();
 const mockNavigate = vi.fn();
+const mockUseBuildings = vi.fn();
 const mockUseDeviceSets = vi.fn();
 const mockUseDeviceSetStateCounts = vi.fn();
+const mockUseSites = vi.fn();
 const mockUseTelemetryMetrics = vi.fn();
 const mockUseComponentErrors = vi.fn();
 
@@ -25,6 +28,14 @@ vi.mock("react-router-dom", async () => {
 
 vi.mock("@/protoFleet/api/useDeviceSets", () => ({
   useDeviceSets: () => mockUseDeviceSets(),
+}));
+
+vi.mock("@/protoFleet/api/buildings", () => ({
+  useBuildings: () => mockUseBuildings(),
+}));
+
+vi.mock("@/protoFleet/api/sites", () => ({
+  useSites: () => mockUseSites(),
 }));
 
 vi.mock("@/protoFleet/api/useDeviceSetStateCounts", () => ({
@@ -116,12 +127,18 @@ const rack = create(DeviceSetSchema, {
 
 function mockResolvedRackPageData(deviceSet = rack): void {
   mockUseParams.mockReturnValue({ rackId: "7" });
+  mockUseBuildings.mockReturnValue({
+    listAllBuildings: ({ onSuccess }: { onSuccess: (buildings: unknown[]) => void }) => onSuccess([]),
+  });
   mockUseDeviceSets.mockReturnValue({
     getDeviceSet: ({ onSuccess }: { onSuccess: (resolvedDeviceSet: typeof rack) => void }) => onSuccess(deviceSet),
     listGroupMembers: ({ onSuccess }: { onSuccess: (deviceIds: string[]) => void }) => onSuccess([]),
     assignDevicesToRack: vi.fn(),
     setRackSlotPosition: vi.fn(),
     deleteGroup: vi.fn(),
+  });
+  mockUseSites.mockReturnValue({
+    listSites: ({ onSuccess }: { onSuccess: (sites: unknown[]) => void }) => onSuccess([]),
   });
   mockUseDeviceSetStateCounts.mockReturnValue({
     stateCounts: {
@@ -149,6 +166,14 @@ function mockResolvedRackPageData(deviceSet = rack): void {
   });
 }
 
+function renderRackOverviewPage() {
+  return render(
+    <MemoryRouter>
+      <RackOverviewPage />
+    </MemoryRouter>,
+  );
+}
+
 describe("RackOverviewPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -156,13 +181,15 @@ describe("RackOverviewPage", () => {
   });
 
   it("renders the rack zone as a subtitle under the rack name", async () => {
-    render(<RackOverviewPage />);
+    renderRackOverviewPage();
 
-    await waitFor(() => expect(screen.getByText(rackName)).toBeVisible());
+    await waitFor(() => expect(screen.getAllByText(rackName).length).toBeGreaterThan(0));
 
     const zone = screen.getByText(rackZone);
     expect(zone).toBeVisible();
     expect(zone.className).toContain("text-text-primary");
+    expect(screen.getByTestId("rack-page-breadcrumb")).toBeVisible();
+    expect(screen.queryByTestId("header-icon-button")).not.toBeInTheDocument();
   });
 
   it("does not render a subtitle when the rack zone is empty", async () => {
@@ -181,9 +208,9 @@ describe("RackOverviewPage", () => {
 
     mockResolvedRackPageData(rackWithoutZone);
 
-    render(<RackOverviewPage />);
+    renderRackOverviewPage();
 
-    await waitFor(() => expect(screen.getByText(rackName)).toBeVisible());
+    await waitFor(() => expect(screen.getAllByText(rackName).length).toBeGreaterThan(0));
 
     expect(screen.queryByText(rackZone)).not.toBeInTheDocument();
   });

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -31,7 +31,7 @@ import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
-import Breadcrumb, { type BreadcrumbSegment } from "@/shared/components/Breadcrumb";
+import Breadcrumb, { type BreadcrumbSegment, type BreadcrumbSibling } from "@/shared/components/Breadcrumb";
 import Button, { variants } from "@/shared/components/Button";
 import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
 import Header from "@/shared/components/Header";
@@ -60,6 +60,7 @@ const RackOverviewPage = () => {
   const [memberDeviceIds, setMemberDeviceIds] = useState<string[] | null>(null);
   const [sites, setSites] = useState<SiteWithCounts[]>([]);
   const [allBuildings, setAllBuildings] = useState<BuildingWithCounts[]>([]);
+  const [rackSiblingState, setRackSiblingState] = useState<{ key: string; siblings: BreadcrumbSibling[] } | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [resolveError, setResolveError] = useState<string | null>(null);
@@ -68,7 +69,8 @@ const RackOverviewPage = () => {
   const sleepActionRef = useRef<(() => void) | null>(null);
   const actionActiveRef = useRef(false);
 
-  const { getDeviceSet, listGroupMembers, assignDevicesToRack, setRackSlotPosition, deleteGroup } = useDeviceSets();
+  const { getDeviceSet, listGroupMembers, assignDevicesToRack, setRackSlotPosition, deleteGroup, listRacks } =
+    useDeviceSets();
   const { listAllBuildings } = useBuildings();
   const { listSites } = useSites();
 
@@ -213,6 +215,39 @@ const RackOverviewPage = () => {
       ),
     [allBuildings],
   );
+  const rackBuildingId = rackInfo?.buildingId?.toString();
+  const rackBuilding = rackBuildingId ? buildingById.get(rackBuildingId) : undefined;
+  const rackSiteId = rackInfo?.siteId?.toString() ?? rackBuilding?.siteId?.toString();
+  const rackSiblingKey = rack?.id.toString() ?? "";
+  const currentRackSiblings = rackSiblingState?.key === rackSiblingKey ? rackSiblingState.siblings : [];
+
+  useEffect(() => {
+    if (!rack || !rackInfo) return;
+
+    let cancelled = false;
+    const currentSiblingKey = rackSiblingKey;
+    const applySiblings = (siblings: BreadcrumbSibling[]) => {
+      if (!cancelled) setRackSiblingState({ key: currentSiblingKey, siblings });
+    };
+    const currentRackId = rack.id;
+    void listRacks({
+      onSuccess: (racks) =>
+        applySiblings(
+          racks
+            .filter((candidate) => candidate.typeDetails.case === "rackInfo")
+            .map((candidate) => ({
+              label: candidate.label || "Rack",
+              to: `/racks/${candidate.id.toString()}`,
+              isActive: candidate.id === currentRackId,
+            })),
+        ),
+      onError: () => applySiblings([]),
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [listRacks, rack, rackInfo, rackSiblingKey]);
 
   const duration = useDuration();
   const setDuration = useSetDuration();
@@ -307,9 +342,6 @@ const RackOverviewPage = () => {
     );
   }
 
-  const rackBuildingId = rackInfo?.buildingId?.toString();
-  const rackBuilding = rackBuildingId ? buildingById.get(rackBuildingId) : undefined;
-  const rackSiteId = rackInfo?.siteId?.toString() ?? rackBuilding?.siteId?.toString();
   const rackBreadcrumbSegments: BreadcrumbSegment[] = [];
   if (rackSiteId) {
     rackBreadcrumbSegments.push({ label: "Sites", to: "/fleet/sites" });
@@ -326,7 +358,10 @@ const RackOverviewPage = () => {
       to: rackSiteId ? `/racks?site=${rackSiteId}` : "/fleet/racks",
     });
   }
-  rackBreadcrumbSegments.push({ label: rack?.label ?? "Rack" });
+  rackBreadcrumbSegments.push({
+    label: rack?.label ?? "Rack",
+    siblings: currentRackSiblings.length > 1 ? currentRackSiblings : undefined,
+  });
 
   return (
     <div className="h-full">

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -3,13 +3,17 @@ import { useParams } from "react-router-dom";
 
 import { create } from "@bufbuild/protobuf";
 
+import { useBuildings } from "@/protoFleet/api/buildings";
+import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import {
   type DeviceSet,
   type RackCoolingType,
   type RackOrderIndex,
   RackSlotPositionSchema,
 } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { AggregationType, MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
+import { useSites } from "@/protoFleet/api/sites";
 import { useComponentErrors } from "@/protoFleet/api/useComponentErrors";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import { useDeviceSetStateCounts } from "@/protoFleet/api/useDeviceSetStateCounts";
@@ -27,7 +31,7 @@ import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
-import { ChevronDown } from "@/shared/assets/icons";
+import Breadcrumb, { type BreadcrumbSegment } from "@/shared/components/Breadcrumb";
 import Button, { variants } from "@/shared/components/Button";
 import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
 import Header from "@/shared/components/Header";
@@ -54,6 +58,8 @@ const RackOverviewPage = () => {
   // Rack resolution state
   const [rack, setRack] = useState<DeviceSet | null>(null);
   const [memberDeviceIds, setMemberDeviceIds] = useState<string[] | null>(null);
+  const [sites, setSites] = useState<SiteWithCounts[]>([]);
+  const [allBuildings, setAllBuildings] = useState<BuildingWithCounts[]>([]);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [resolveError, setResolveError] = useState<string | null>(null);
@@ -63,6 +69,8 @@ const RackOverviewPage = () => {
   const actionActiveRef = useRef(false);
 
   const { getDeviceSet, listGroupMembers, assignDevicesToRack, setRackSlotPosition, deleteGroup } = useDeviceSets();
+  const { listAllBuildings } = useBuildings();
+  const { listSites } = useSites();
 
   // Request versioning to guard against stale resolution callbacks
   const resolveVersionRef = useRef(0);
@@ -141,6 +149,21 @@ const RackOverviewPage = () => {
     [getDeviceSet, listGroupMembers],
   );
 
+  useEffect(() => {
+    const controller = new AbortController();
+    void listSites({
+      signal: controller.signal,
+      onSuccess: setSites,
+      onError: () => setSites([]),
+    });
+    void listAllBuildings({
+      signal: controller.signal,
+      onSuccess: setAllBuildings,
+      onError: () => setAllBuildings([]),
+    });
+    return () => controller.abort();
+  }, [listAllBuildings, listSites]);
+
   // Initial resolution from URL param
   useEffect(() => {
     if (!rackIdParam) {
@@ -176,6 +199,20 @@ const RackOverviewPage = () => {
   const cols = rackInfo?.columns ?? 1;
   const orderIndex = rackInfo?.orderIndex;
   const numberingOrigin = orderIndex !== undefined ? orderIndexToOrigin(orderIndex) : "bottom-left";
+  const siteNameById = useMemo(
+    () =>
+      new Map(sites.filter((row) => row.site !== undefined).map((row) => [row.site!.id.toString(), row.site!.name])),
+    [sites],
+  );
+  const buildingById = useMemo(
+    () =>
+      new Map(
+        allBuildings
+          .filter((row) => row.building !== undefined)
+          .map((row) => [row.building!.id.toString(), row.building!]),
+      ),
+    [allBuildings],
+  );
 
   const duration = useDuration();
   const setDuration = useSetDuration();
@@ -270,11 +307,33 @@ const RackOverviewPage = () => {
     );
   }
 
+  const rackBuildingId = rackInfo?.buildingId?.toString();
+  const rackBuilding = rackBuildingId ? buildingById.get(rackBuildingId) : undefined;
+  const rackSiteId = rackInfo?.siteId?.toString() ?? rackBuilding?.siteId?.toString();
+  const rackBreadcrumbSegments: BreadcrumbSegment[] = [];
+  if (rackSiteId) {
+    rackBreadcrumbSegments.push({ label: "Sites", to: "/fleet/sites" });
+    rackBreadcrumbSegments.push({ label: siteNameById.get(rackSiteId) ?? "Site", to: `/sites/${rackSiteId}` });
+    if (rackBuildingId) {
+      rackBreadcrumbSegments.push({
+        label: rackBuilding?.name || "Building",
+        to: `/buildings/${rackBuildingId}`,
+      });
+    }
+  } else {
+    rackBreadcrumbSegments.push({
+      label: "Racks",
+      to: rackSiteId ? `/racks?site=${rackSiteId}` : "/fleet/racks",
+    });
+  }
+  rackBreadcrumbSegments.push({ label: rack?.label ?? "Rack" });
+
   return (
     <div className="h-full">
       <div className="flex flex-col">
         {/* Header */}
         <div className="p-6 pb-0 laptop:p-10 laptop:pb-0">
+          <Breadcrumb segments={rackBreadcrumbSegments} testId="rack-page-breadcrumb" />
           <Header
             title={rack?.label ?? ""}
             titleSize="text-heading-300"
@@ -282,9 +341,7 @@ const RackOverviewPage = () => {
             subtitleSize="text-300"
             subtitleClassName="text-text-primary"
             inline
-            icon={<ChevronDown className="rotate-90" />}
-            iconAriaLabel="Back to racks"
-            iconOnClick={() => navigate(scopedPath("/fleet/racks", activeSite))}
+            className="mt-3"
           >
             <div className="ml-3 flex items-center gap-3">
               <Button

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -230,7 +230,14 @@ const RackOverviewPage = () => {
       if (!cancelled) setRackSiblingState({ key: currentSiblingKey, siblings });
     };
     const currentRackId = rack.id;
+    const siblingScope =
+      rackInfo.buildingId !== undefined
+        ? { buildingIds: [rackInfo.buildingId] }
+        : rackSiteId
+          ? { siteIds: [BigInt(rackSiteId)] }
+          : { includeUnassigned: true };
     void listRacks({
+      ...siblingScope,
       onSuccess: (racks) =>
         applySiblings(
           racks
@@ -247,7 +254,7 @@ const RackOverviewPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [listRacks, rack, rackInfo, rackSiblingKey]);
+  }, [listRacks, rack, rackInfo, rackSiblingKey, rackSiteId]);
 
   const duration = useDuration();
   const setDuration = useSetDuration();
@@ -355,7 +362,7 @@ const RackOverviewPage = () => {
   } else {
     rackBreadcrumbSegments.push({
       label: "Racks",
-      to: rackSiteId ? `/racks?site=${rackSiteId}` : "/fleet/racks",
+      to: scopedPath("/fleet/racks", activeSite),
     });
   }
   rackBreadcrumbSegments.push({

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
@@ -2,13 +2,21 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
+import userEvent from "@testing-library/user-event";
 
 import SiteDetailPage from "./SiteDetailPage";
 import { SiteSchema, type SiteWithCounts, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 
+const listBuildingsBySiteMock = vi.hoisted(() => vi.fn());
 const listSitesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/protoFleet/api/buildings", () => ({
+  useBuildings: () => ({
+    listBuildingsBySite: listBuildingsBySiteMock,
+  }),
+}));
 
 vi.mock("@/protoFleet/api/sites", async () => {
   const actual = await vi.importActual<typeof import("@/protoFleet/api/sites")>("@/protoFleet/api/sites");
@@ -48,11 +56,12 @@ const LocationProbe = () => {
   return <div data-testid="location-probe">{`${location.pathname}${location.search}`}</div>;
 };
 
-const makeSite = (id: bigint, name: string) =>
+const makeSite = (id: bigint, name: string, slug = name.toLowerCase()) =>
   create(SiteWithCountsSchema, {
     site: create(SiteSchema, {
       id,
       name,
+      slug,
       country: "US",
     }),
     deviceCount: 0n,
@@ -79,6 +88,9 @@ describe("SiteDetailPage", () => {
     listSitesMock.mockImplementation(({ onSuccess }: { onSuccess: (sites: SiteWithCounts[]) => void }) =>
       onSuccess([makeSite(7n, "Dallas"), makeSite(8n, "Austin")]),
     );
+    listBuildingsBySiteMock.mockImplementation(({ onSuccess }: { onSuccess: (buildings: []) => void }) =>
+      onSuccess([]),
+    );
   });
 
   it("preserves the selected site when a site detail mismatch redirects back to Fleet", async () => {
@@ -89,5 +101,21 @@ describe("SiteDetailPage", () => {
     renderPage();
 
     await waitFor(() => expect(screen.getByTestId("location-probe")).toHaveTextContent("/austin/fleet"));
+  });
+
+  it("updates active site before navigating to a breadcrumb sibling site", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "7", slug: "dallas" };
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByTestId("site-detail-breadcrumb-switcher"));
+    await user.click(screen.getByTestId("site-detail-breadcrumb-menu-item-Austin"));
+
+    await waitFor(() => expect(screen.getByTestId("site-detail-breadcrumb-switcher")).toHaveTextContent("Austin"));
+    expect(screen.queryByTestId("location-probe")).not.toBeInTheDocument();
+    expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "8", slug: "austin" });
   });
 });

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import SiteModals from "../components/SiteModals";
@@ -33,6 +33,7 @@ const SiteDetailPage = () => {
   const [error, setError] = useState<string | null>(null);
   const [buildings, setBuildings] = useState<{ siteId: string; rows: BuildingWithCounts[] } | undefined>(undefined);
   const [buildingsError, setBuildingsError] = useState<{ siteId: string; message: string } | null>(null);
+  const breadcrumbSiteSelectionRef = useRef<string | null>(null);
 
   const fetchSites = useCallback(() => {
     const controller = new AbortController();
@@ -86,10 +87,14 @@ const SiteDetailPage = () => {
   // Bounce to /fleet when SitePicker switches to a different specific
   // site — "All sites" / "Unassigned" don't conflict with this view.
   const knownSiteIds = useMemo(() => (sitesLoaded ? buildKnownSiteIds(sites) : undefined), [sites, sitesLoaded]);
-  const { activeSite } = useActiveSite({ knownSiteIds });
+  const { activeSite, setActiveSite } = useActiveSite({ knownSiteIds });
   useEffect(() => {
     if (activeSite.kind !== "site") return;
-    if (activeSite.id === targetId) return;
+    if (activeSite.id === targetId) {
+      breadcrumbSiteSelectionRef.current = null;
+      return;
+    }
+    if (breadcrumbSiteSelectionRef.current === activeSite.id) return;
     navigate(scopedPath("/fleet", activeSite), { replace: true });
   }, [activeSite, navigate, targetId]);
 
@@ -162,11 +167,21 @@ const SiteDetailPage = () => {
   const address = formatSiteAddress(site.site);
   const siteSiblings = sites
     .filter((row) => row.site !== undefined)
-    .map((row) => ({
-      label: row.site!.name,
-      to: `/sites/${row.site!.id.toString()}`,
-      isActive: row.site!.id === site.site!.id,
-    }));
+    .map((row) => {
+      const siblingSite = row.site!;
+      const siblingId = siblingSite.id.toString();
+      return {
+        label: siblingSite.name,
+        to: `/sites/${siblingId}`,
+        isActive: siblingSite.id === site.site!.id,
+        onSelect: siblingSite.slug
+          ? () => {
+              breadcrumbSiteSelectionRef.current = siblingId;
+              setActiveSite({ kind: "site", id: siblingId, slug: siblingSite.slug });
+            }
+          : undefined,
+      };
+    });
 
   return (
     <>

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -15,6 +15,7 @@ import { formatSiteAddress } from "@/protoFleet/features/sites/formatAddress";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useHasPermission } from "@/protoFleet/store";
 import { Alert } from "@/shared/assets/icons";
+import Breadcrumb from "@/shared/components/Breadcrumb";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Header from "@/shared/components/Header";
@@ -148,20 +149,24 @@ const SiteDetailPage = () => {
   if (!site || !site.site) {
     return (
       <div className="flex flex-col gap-6 p-10 phone:p-6">
+        <Breadcrumb
+          segments={[{ label: "Sites", to: "/fleet/sites" }, { label: "Site not found" }]}
+          testId="site-detail-breadcrumb"
+        />
         <Header title="Site not found" titleSize="text-heading-200" />
         <p className="text-300 text-text-primary-70">No site matches id {targetId}.</p>
-        <Button
-          variant={variants.primary}
-          size={sizes.compact}
-          text="Back to sites"
-          onClick={() => navigate(scopedPath("/fleet/sites", activeSite))}
-          testId="site-detail-back"
-        />
       </div>
     );
   }
 
   const address = formatSiteAddress(site.site);
+  const siteSiblings = sites
+    .filter((row) => row.site !== undefined)
+    .map((row) => ({
+      label: row.site!.name,
+      to: `/sites/${row.site!.id.toString()}`,
+      isActive: row.site!.id === site.site!.id,
+    }));
 
   return (
     <>
@@ -177,6 +182,13 @@ const SiteDetailPage = () => {
             testId="site-detail-inline-error"
           />
         ) : null}
+        <Breadcrumb
+          segments={[
+            { label: "Sites", to: "/fleet/sites" },
+            { label: site.site.name, siblings: siteSiblings.length > 1 ? siteSiblings : undefined },
+          ]}
+          testId="site-detail-breadcrumb"
+        />
         <div className="flex items-start justify-between gap-4">
           <Header title={site.site.name} titleSize="text-heading-300" subtitle={address || undefined} />
           {canManageSites ? (

--- a/client/src/shared/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/client/src/shared/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -22,9 +22,10 @@ export default meta;
 type Story = StoryObj<BreadcrumbProps>;
 
 export const SiteLevel: Story = {
-  name: "Site (single level with switcher)",
+  name: "Site detail",
   args: {
     segments: [
+      { label: "Sites", to: "/fleet/sites" },
       {
         label: "Denver",
         siblings: [
@@ -40,9 +41,10 @@ export const SiteLevel: Story = {
 };
 
 export const BuildingLevel: Story = {
-  name: "Building (site link + building switcher)",
+  name: "Building detail",
   args: {
     segments: [
+      { label: "Sites", to: "/fleet/sites" },
       { label: "Denver", to: "/sites/3" },
       {
         label: "Building 3",
@@ -58,9 +60,10 @@ export const BuildingLevel: Story = {
 };
 
 export const RackLevel: Story = {
-  name: "Rack (site + building links, rack switcher)",
+  name: "Rack detail",
   args: {
     segments: [
+      { label: "Sites", to: "/fleet/sites" },
       { label: "Denver", to: "/sites/3" },
       { label: "Building 3", to: "/buildings/3" },
       {
@@ -81,6 +84,6 @@ export const RackLevel: Story = {
 export const NoSiblings: Story = {
   name: "No sibling switcher",
   args: {
-    segments: [{ label: "Denver", to: "/sites/3" }, { label: "Building 3" }],
+    segments: [{ label: "Sites", to: "/fleet/sites" }, { label: "Denver", to: "/sites/3" }, { label: "Building 3" }],
   },
 };

--- a/client/src/shared/components/Breadcrumb/Breadcrumb.tsx
+++ b/client/src/shared/components/Breadcrumb/Breadcrumb.tsx
@@ -95,7 +95,7 @@ const Breadcrumb = ({ segments, testId = "breadcrumb" }: BreadcrumbProps) => {
         const hasSiblings = isLast && seg.siblings && seg.siblings.length > 0;
 
         return (
-          <Fragment key={i}>
+          <Fragment key={`${seg.label}-${i}`}>
             {i > 0 ? <span className="text-text-primary-70">/</span> : null}
             {!isLast && seg.to ? (
               <Link
@@ -162,7 +162,7 @@ const SiblingMenu = forwardRef<HTMLDivElement, SiblingMenuProps>(
         role="menu"
         data-testid={testId}
         onKeyDown={onKeyDown}
-        className="absolute top-full left-0 z-30 mt-1.5 max-h-72 min-w-44 overflow-y-auto rounded-2xl border border-border-5 bg-surface-elevated-base p-1.5 shadow-300"
+        className="absolute top-full left-0 z-30 mt-1.5 max-h-72 min-w-44 overflow-y-auto rounded-lg border border-border-5 bg-surface-elevated-base p-1.5 shadow-300"
       >
         {siblings.map((sib) => (
           <button

--- a/client/src/shared/components/Breadcrumb/Breadcrumb.tsx
+++ b/client/src/shared/components/Breadcrumb/Breadcrumb.tsx
@@ -18,6 +18,7 @@ export interface BreadcrumbSibling {
   label: string;
   to: string;
   isActive: boolean;
+  onSelect?: () => void;
 }
 
 /** Only the last segment may carry `siblings` — earlier segments are ancestor links. */
@@ -54,10 +55,11 @@ const Breadcrumb = ({ segments, testId = "breadcrumb" }: BreadcrumbProps) => {
   }, [menuOpen]);
 
   const handleSelect = useCallback(
-    (to: string) => {
+    (sibling: BreadcrumbSibling) => {
       setMenuOpen(false);
       triggerRef.current?.focus();
-      navigate(to);
+      sibling.onSelect?.();
+      navigate(sibling.to);
     },
     [navigate],
   );
@@ -147,7 +149,7 @@ const Breadcrumb = ({ segments, testId = "breadcrumb" }: BreadcrumbProps) => {
 
 interface SiblingMenuProps {
   siblings: BreadcrumbSibling[];
-  onSelect: (to: string) => void;
+  onSelect: (sibling: BreadcrumbSibling) => void;
   onDismiss: () => void;
   onKeyDown: (e: ReactKeyboardEvent) => void;
   testId: string;
@@ -170,7 +172,7 @@ const SiblingMenu = forwardRef<HTMLDivElement, SiblingMenuProps>(
             type="button"
             role="menuitem"
             tabIndex={-1}
-            onClick={() => onSelect(sib.to)}
+            onClick={() => onSelect(sib)}
             className={clsx(
               "flex w-full items-center gap-3 rounded-lg p-3 text-left text-300 hover:bg-surface-5",
               sib.isActive ? "font-medium text-text-primary" : "text-text-primary",


### PR DESCRIPTION
**Summary**

Adds a shared Breadcrumb component for hierarchical navigation across ProtoFleet detail surfaces. The component supports linked ancestor segments plus an optional current-segment sibling switcher, which lets follow-up detail pages replace one-off back buttons with consistent location context.

**How it works**

Callers pass an ordered `segments` array. Non-current segments with `to` render as React Router links, while the current segment renders as text or as a button-backed switcher when `siblings` are supplied. The switcher handles click-away dismissal, Escape dismissal, keyboard navigation, and selection through `useNavigate`.

**Diagrams**

```mermaid
flowchart LR
  caller["Detail page or story"] --> breadcrumb["Breadcrumb"]
  breadcrumb --> ancestors["Ancestor links"]
  breadcrumb --> current["Current segment"]
  current --> switcher["Optional sibling switcher"]
  switcher --> navigate["React Router navigate"]
```

**Areas of the code involved**

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/shared/components/Breadcrumb/` | New component, index export, and Storybook stories | Reusable navigation primitive used by the follow-up detail-view PRs |

**Key technical decisions & trade-offs**

| Decision | Trade-off |
| --- | --- |
| Keep the component data-driven via `segments` | Callers own fetching labels/siblings, keeping the shared component UI-only |
| Allow only the current segment to expose siblings | Keeps keyboard and menu behavior narrow and predictable |

**Testing & validation**

- Storybook checked locally for site, building, and rack breadcrumb shapes.
- Targeted ESLint passed for the component files.
- Full `client-typecheck` is currently blocked by unrelated infra/maintenance TypeScript errors already present on the parent branch.
