### PR TITLE
fix(settings): repair settings page broken by stale MULTI_SITE_ENABLED reference

### DIFF
--- a/client/src/protoFleet/features/settings/components/SettingsLayout.test.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsLayout.test.tsx
@@ -5,17 +5,10 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import SettingsLayout from "./SettingsLayout";
 
 const permissionsMock = vi.hoisted(() => ({ current: [] as string[] }));
-const featureFlagsMock = vi.hoisted(() => ({ multiSite: false }));
 const activeSiteMock = vi.hoisted(() => ({ current: { kind: "all" } as { kind: string; id?: string } }));
 
 vi.mock("@/protoFleet/store", () => ({
   usePermissions: () => permissionsMock.current,
-}));
-
-vi.mock("@/protoFleet/constants/featureFlags", () => ({
-  get MULTI_SITE_ENABLED() {
-    return featureFlagsMock.multiSite;
-  },
 }));
 
 vi.mock("@/protoFleet/components/PageHeader/SitePicker", () => ({
@@ -71,7 +64,6 @@ const renderSettingsRoute = (initialPath: string) =>
 describe("SettingsLayout permission guard", () => {
   beforeEach(() => {
     permissionsMock.current = [];
-    featureFlagsMock.multiSite = false;
   });
 
   test("redirects protected settings routes before rendering their children", async () => {
@@ -95,13 +87,10 @@ describe("SettingsLayout permission guard", () => {
 describe("SettingsLayout org-wide notice", () => {
   beforeEach(() => {
     permissionsMock.current = [];
-    featureFlagsMock.multiSite = false;
     activeSiteMock.current = { kind: "site", id: "7" };
   });
 
   test("shows the org-wide notice on org-wide pages when a site is selected", () => {
-    featureFlagsMock.multiSite = true;
-
     renderSettingsRoute("/settings/general");
 
     expect(screen.getByTestId("org-wide-notice")).toBeInTheDocument();
@@ -109,7 +98,6 @@ describe("SettingsLayout org-wide notice", () => {
   });
 
   test("hides the org-wide notice when all sites is selected", () => {
-    featureFlagsMock.multiSite = true;
     activeSiteMock.current = { kind: "all" };
 
     renderSettingsRoute("/settings/general");
@@ -119,21 +107,11 @@ describe("SettingsLayout org-wide notice", () => {
   });
 
   test("hides the org-wide notice on site-aware pages", () => {
-    featureFlagsMock.multiSite = true;
     permissionsMock.current = ["schedule:manage"];
 
     renderSettingsRoute("/settings/schedules");
 
     expect(screen.queryByTestId("org-wide-notice")).not.toBeInTheDocument();
     expect(screen.getByTestId("schedules-page")).toBeInTheDocument();
-  });
-
-  test("hides the org-wide notice when multi-site is disabled", () => {
-    featureFlagsMock.multiSite = false;
-
-    renderSettingsRoute("/settings/general");
-
-    expect(screen.queryByTestId("org-wide-notice")).not.toBeInTheDocument();
-    expect(screen.getByTestId("general-page")).toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/settings/components/SettingsLayout.tsx
+++ b/client/src/protoFleet/features/settings/components/SettingsLayout.tsx
@@ -3,7 +3,6 @@ import { Navigate, useLocation } from "react-router-dom";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import SecondaryNavigation from "@/protoFleet/components/SecondaryNavigation";
 import { secondaryNavItems } from "@/protoFleet/config/navItems";
-import { MULTI_SITE_ENABLED } from "@/protoFleet/constants/featureFlags";
 import OrgWideNotice from "@/protoFleet/features/settings/components/OrgWideNotice";
 import { settingsRoutePrefetch } from "@/protoFleet/routePrefetch";
 import { usePermissions } from "@/protoFleet/store";
@@ -32,8 +31,7 @@ const SettingsLayout = ({ children }: { children?: ReactNode }) => {
   // a filter). With "all sites" there's nothing to clarify, so we stay quiet.
   // Also require a matched settings tab — an unmatched route shouldn't claim to
   // be org-wide.
-  const showOrgWideNotice =
-    MULTI_SITE_ENABLED && activeSite.kind === "site" && currentNavItem !== undefined && !currentNavItem.siteAware;
+  const showOrgWideNotice = activeSite.kind === "site" && currentNavItem !== undefined && !currentNavItem.siteAware;
 
   return (
     <>


### PR DESCRIPTION
## Summary

The settings page was throwing on load because `SettingsLayout` still imported the `MULTI_SITE_ENABLED` feature flag, which was deleted when multi-site shipped permanently (#562). A later PR (#552) reintroduced the dangling import, so the module failed to resolve and the page crashed.

This change removes the dead flag dependency and treats multi-site as the permanent baseline: the org-wide notice now keys solely off the active site selection (shown when a single site is selected on an org-wide tab). The test suite drops the obsolete flag mock and the now-meaningless "multi-site disabled" case while preserving coverage of the notice's real triggers.

## Non-goals / deferred

No behavioral change to multi-site itself and no broader audit of other consumers of the removed flag (none remain in `src/`); this is a targeted repair of the regression.