### PR TITLE
Add rack grid to building detail page

### DIFF
--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/protoFleet/api/useBuildingStats", () => ({
   useBuildingStats: () => ({
     stats: {
       deviceIdentifiers: [],
-      rackCount: 0,
+      rackCount: 2,
       deviceCount: 0,
       reportingCount: 0,
       hashrateReportingCount: 0,
@@ -35,6 +35,28 @@ vi.mock("@/protoFleet/api/useBuildingStats", () => ({
       brokenCount: 0,
       offlineCount: 0,
       sleepingCount: 0,
+      rackHealth: [
+        {
+          rackId: 1n,
+          rackLabel: "R01",
+          aisleIndex: 0,
+          positionInAisle: 0,
+          hashingCount: 8,
+          brokenCount: 0,
+          offlineCount: 0,
+          sleepingCount: 0,
+        },
+        {
+          rackId: 2n,
+          rackLabel: "R02",
+          aisleIndex: 0,
+          positionInAisle: 1,
+          hashingCount: 6,
+          brokenCount: 1,
+          offlineCount: 0,
+          sleepingCount: 0,
+        },
+      ],
     },
     error: null,
     hasLoaded: true,
@@ -108,6 +130,8 @@ describe("BuildingPage", () => {
           id: 123n,
           name: "Building A",
           siteId: 8n,
+          aisles: 1,
+          racksPerAisle: 2,
         }),
       ),
     );
@@ -140,6 +164,15 @@ describe("BuildingPage", () => {
     fireEvent.click(screen.getByTestId("building-page-view-racks"));
 
     expect(screen.getByTestId("location-probe")).toHaveTextContent("/austin/fleet/racks?building=123");
+  });
+
+  it("renders the building rack grid from building stats", async () => {
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId("building-rack-grid")).toBeVisible());
+
+    expect(screen.getByTestId("building-rack-grid-tile-R01")).toBeVisible();
+    expect(screen.getByTestId("building-rack-grid-tile-R02")).toBeVisible();
   });
 
   it("uses all-sites fleet routes when all-sites is selected", async () => {

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -5,6 +5,7 @@ import { create } from "@bufbuild/protobuf";
 import BuildingMetricsRow from "../components/BuildingMetricsRow";
 import BuildingModals from "../components/BuildingModals";
 import BuildingPageHeader from "../components/BuildingPageHeader";
+import { BuildingRackGrid } from "../components/BuildingRackGrid";
 import { useBuildingModals } from "../hooks/useBuildingModals";
 import { useBuildings } from "@/protoFleet/api/buildings";
 import { type Building, BuildingWithCountsSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
@@ -281,10 +282,21 @@ const BuildingPage = () => {
           <BuildingMetricsRow powerCapacityKw={effectiveBuilding.powerKw} stats={stats} />
         </section>
 
-        {/* Diagnostics: rack-health module (FPO) + component health */}
+        {/* Diagnostics: building rack grid + component health */}
         <section className="p-6 laptop:p-10">
-          <div className="flex flex-col gap-1">
-            <PlaceholderBlock label="Rack health module — #264" className="h-64" />
+          <div className="flex flex-col gap-6">
+            {stats ? (
+              <BuildingRackGrid
+                rackHealth={stats.rackHealth}
+                aisles={effectiveBuilding.aisles}
+                racksPerAisle={effectiveBuilding.racksPerAisle}
+              />
+            ) : (
+              <PlaceholderBlock
+                label={statsError ? "Rack health unavailable" : "Loading rack health…"}
+                className="h-64"
+              />
+            )}
             <FleetErrors
               controlBoardErrors={controlBoardErrors}
               fanErrors={fanErrors}


### PR DESCRIPTION
Reviewable diff: +15/-3 across 1 file (excludes generated, test, and story files).

**Summary**

This PR replaces the building detail page's rack-health FPO with the existing `BuildingRackGrid`, so operators can see the building's rack layout and per-rack health directly on `/buildings/:id`. The page now reuses the `rackHealth` data already returned by `GetBuildingStats`, keeping the change client-only and focused on the detail view.

**How it works**

`BuildingPage` already loads the building snapshot and polls `GetBuildingStats` for metrics, device identifiers, and rack health. When stats are available, the page passes `stats.rackHealth` plus the building's `aisles` and `racksPerAisle` layout dimensions into `BuildingRackGrid`. While stats are still loading or unavailable, the existing placeholder surface remains in place so the diagnostics section does not flash an empty rack grid before the stats request resolves.

**Diagrams**

```mermaid
flowchart TD
  A["Operator opens /buildings/:id"] --> B["BuildingPage loads building"]
  B --> C["useBuildingStats polls GetBuildingStats"]
  C --> D["BuildingRackGrid renders rackHealth by layout"]
  C --> E["FleetErrors renders component issue counts"]
```

**Areas of the code involved**

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/buildings/pages/BuildingPage.tsx` | Imports and renders `BuildingRackGrid` from `GetBuildingStats.rackHealth`, with a loading/unavailable fallback. | This is the operator-facing behavior change on the building detail page. |
| `client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx` | Adds rack-health fixture data and verifies the detail page renders rack grid tiles. | Covers the page-level integration between building stats and the rack grid. |

**Key technical decisions & trade-offs**

| Decision | Trade-off |
| --- | --- |
| Reuse `GetBuildingStats.rackHealth` instead of adding a new page fetch. | Keeps the change client-only and avoids duplicating rack-health data loading. |
| Keep the placeholder when stats are not loaded. | Avoids rendering the grid's empty state before the first stats response proves the building has no racks. |

**Testing & validation**

- `NODE_OPTIONS=--localstorage-file=/Users/jmarr/Documents/Codex/2026-06-25/lets-spin-up-another-pr-that/work/proto-fleet-building-rack-grid/client/.node-localstorage ./node_modules/.bin/vitest run src/protoFleet/features/buildings/pages/BuildingPage.test.tsx`
- `./node_modules/.bin/prettier --check src/protoFleet/features/buildings/pages/BuildingPage.tsx src/protoFleet/features/buildings/pages/BuildingPage.test.tsx`
- `./node_modules/.bin/eslint src/protoFleet/features/buildings/pages/BuildingPage.tsx src/protoFleet/features/buildings/pages/BuildingPage.test.tsx --max-warnings 0`
- Pre-push hook with Hermit active passed `check-push-org`, `server-lint`, and `client-typecheck`.
