### PR TITLE
Self-heal stuck firing alerts with a read-side freshness gate

### DIFF
--- a/server/generated/sqlc/notification_history.sql.go
+++ b/server/generated/sqlc/notification_history.sql.go
@@ -109,12 +109,14 @@ LEFT JOIN device d
 LEFT JOIN discovered_device dd ON dd.id = d.discovered_device_id
 WHERE na.organization_id = $1
   AND na.status = 'firing'
+  AND na.received_at >= $2 -- drop alerts not re-asserted within the freshness window
 ORDER BY na.received_at DESC, na.history_id DESC
-LIMIT $2
+LIMIT $3
 `
 
 type ListActiveNotificationsParams struct {
 	OrganizationID int64
+	ActiveSince    time.Time
 	PageLimit      int32
 }
 
@@ -139,7 +141,7 @@ type ListActiveNotificationsRow struct {
 // notification_active table, which also retains resolved tombstones; device name/MAC are joined live
 // so they reflect current device records.
 func (q *Queries) ListActiveNotifications(ctx context.Context, arg ListActiveNotificationsParams) ([]ListActiveNotificationsRow, error) {
-	rows, err := q.query(ctx, q.listActiveNotificationsStmt, listActiveNotifications, arg.OrganizationID, arg.PageLimit)
+	rows, err := q.query(ctx, q.listActiveNotificationsStmt, listActiveNotifications, arg.OrganizationID, arg.ActiveSince, arg.PageLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/domain/stores/sqlstores/notification_history.go
+++ b/server/internal/domain/stores/sqlstores/notification_history.go
@@ -5,10 +5,14 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/block/proto-fleet/server/generated/sqlc"
 	"github.com/block/proto-fleet/server/internal/domain/notificationhistory"
 )
+
+// > Grafana repeat_interval (1h, notification-policies.yaml) with margin for one missed re-notify; keep in sync.
+const activeAlertStaleAfter = 135 * time.Minute
 
 type SQLNotificationHistoryStore struct {
 	SQLConnectionManager
@@ -95,6 +99,7 @@ func (s *SQLNotificationHistoryStore) ListActive(ctx context.Context, organizati
 	rows, err := s.GetQueries(ctx).ListActiveNotifications(ctx, sqlc.ListActiveNotificationsParams{
 		OrganizationID: organizationID,
 		PageLimit:      limit,
+		ActiveSince:    time.Now().Add(-activeAlertStaleAfter),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list active notifications: %w", err)

--- a/server/internal/domain/stores/sqlstores/notification_history_test.go
+++ b/server/internal/domain/stores/sqlstores/notification_history_test.go
@@ -1,0 +1,53 @@
+package sqlstores_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	"github.com/block/proto-fleet/server/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// insertNotification writes a notification_history row with an explicit received_at so the
+// notification_active_sync trigger populates notification_active.received_at deterministically;
+// received_at is the column the freshness gate filters on (starts_at/ends_at fall back to it).
+func insertNotification(t *testing.T, db *sql.DB, orgID int64, fingerprint, status string, receivedAt time.Time) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(), `
+		INSERT INTO notification_history
+			(received_at, alert_name, status, fingerprint, organization_id)
+		VALUES ($1, 'Metric Ingest Stalled', $2, $3, $4)`,
+		receivedAt, status, fingerprint, orgID,
+	)
+	require.NoError(t, err)
+}
+
+func TestNotificationHistoryStore_ListActive_FreshnessGate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	db := testContext.DatabaseService.DB
+	orgID := testContext.DatabaseService.CreateSuperAdminUser().OrganizationID
+	store := sqlstores.NewSQLNotificationHistoryStore(db)
+	now := time.Now()
+
+	insertNotification(t, db, orgID, "fresh-firing", "firing", now.Add(-30*time.Minute))
+	insertNotification(t, db, orgID, "stale-firing", "firing", now.Add(-3*time.Hour))
+	insertNotification(t, db, orgID, "resolved-alert", "resolved", now.Add(-30*time.Minute))
+
+	active, err := store.ListActive(t.Context(), orgID, 50)
+	require.NoError(t, err)
+
+	fingerprints := make([]string, 0, len(active))
+	for _, n := range active {
+		fingerprints = append(fingerprints, n.Fingerprint)
+	}
+	assert.Contains(t, fingerprints, "fresh-firing")
+	assert.NotContains(t, fingerprints, "stale-firing", "alert not re-asserted within the window should be hidden")
+	assert.NotContains(t, fingerprints, "resolved-alert", "resolved alert should not be active")
+}

--- a/server/sqlc/queries/notification_history.sql
+++ b/server/sqlc/queries/notification_history.sql
@@ -96,5 +96,6 @@ LEFT JOIN device d
 LEFT JOIN discovered_device dd ON dd.id = d.discovered_device_id
 WHERE na.organization_id = sqlc.arg('organization_id')
   AND na.status = 'firing'
+  AND na.received_at >= sqlc.arg('active_since') -- drop alerts not re-asserted within the freshness window
 ORDER BY na.received_at DESC, na.history_id DESC
 LIMIT sqlc.arg('page_limit');


### PR DESCRIPTION
Reviewable diff: +6/-0 across 2 files (excludes generated, test, and story files).

## Summary

A firing alert can stay in the **Active Alerts card forever** if its Grafana "resolved" notification is never delivered — e.g. a Grafana restart or a dropped webhook. `notification_active` is only mutated by inbound alertmanager-webhook events, so a single missed resolve latches the row in the UI permanently. (Observed: *Metric Ingest Stalled* fired 2026-06-24, Grafana restarted before the resolve was sent, and the row stayed "active" >24h despite ingest being healthy.)

This PR adds a **read-side freshness gate**: an alert is only shown as active if it was re-asserted recently. No schema change, no background job, no migration — and existing stuck rows self-heal on the next dashboard poll.

## How it works

The fix rests on an existing invariant in the alerting pipeline:

1. Grafana's notification policy has `repeat_interval: 1h`, so a **genuinely still-firing** alert is re-delivered to the webhook at least hourly.
2. Each delivery inserts a `notification_history` row, and the `notification_active_sync` trigger bumps `notification_active.received_at` on every repeat. So `received_at` is effectively a **"last heard firing" heartbeat**.
3. Therefore a firing row whose `received_at` is older than a safe multiple of `repeat_interval` means the resolve was missed — it should no longer count as active.

`ListActiveNotifications` now adds one predicate — `received_at >= active_since` — where the store passes `active_since = now() - 135m`. 135m is `> repeat_interval (1h)` with margin to tolerate one dropped re-notification, so a real alert is never hidden by a single missed repeat, while a stuck row drops off in ~2¼h.

The stale row stays in `notification_active` with `status='firing'` (only the read hides it); `ListActiveNotifications` is its sole reader, so this is harmless. Writing a synthetic "resolved" tombstone would be a separate, larger reconciler change and is intentionally out of scope.

```mermaid
flowchart LR
    G["Grafana<br/>repeat_interval=1h"] -->|"firing re-delivered hourly"| W["alertmanager webhook"]
    W -->|"INSERT row"| H["notification_history"]
    H -->|"sync trigger bumps received_at"| A["notification_active"]
    A -->|"ListActiveNotifications<br/>WHERE received_at >= now()-135m"| C["Active Alerts card"]
```

```mermaid
sequenceDiagram
    participant Grafana
    participant DB as notification_active
    participant Card as Active Alerts card
    Note over Grafana,Card: Healthy: re-notified hourly, received_at stays fresh
    Grafana->>DB: firing (received_at = T)
    Card->>DB: ListActive (received_at >= now()-135m) ✓ shown
    Note over Grafana,Card: Resolve missed (restart / dropped webhook)
    Grafana--xDB: resolve never arrives
    Card->>DB: 135m later: received_at < now()-135m ✗ hidden (self-heal)
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/sqlc/queries/notification_history.sql` | Added `AND na.received_at >= sqlc.arg('active_since')` to `ListActiveNotifications` | The one behavioral change; rides the existing partial index `idx_notification_active_org_recent` as a bounded range scan |
| `server/internal/domain/stores/sqlstores/notification_history.go` | New `activeAlertStaleAfter = 135 * time.Minute` const; `ListActive` passes `ActiveSince: time.Now().Add(-activeAlertStaleAfter)` | TTL owned internally — `ListActive` signature and all callers unchanged |
| `server/generated/sqlc/notification_history.sql.go` | Regenerated (`just gen`) — adds `ActiveSince` to params | generated — skip |
| `server/internal/domain/stores/sqlstores/notification_history_test.go` | New integration test for the freshness gate | Verifies fresh-shown / stale-hidden / resolved-hidden |

## Key technical decisions & trade-offs

- **Read-side gate over a reconciler/TTL job** — self-heals existing stuck rows immediately with zero new infrastructure; chosen over a background job that writes resolved tombstones (deferred as out of scope).
- **TTL coupled to `notification-policies.yaml` `repeat_interval`** — the constant carries a one-line comment to keep the two in sync; chosen over plumbing the YAML value into Go, which isn't worth it for a single read filter.
- **135m window** — strictly `> repeat_interval (1h)` with margin for one missed repeat; conservative enough that no real alert is hidden, tight enough to clear a stuck row in ~2¼h.
- **TTL derived inside the store** — keeps the `notificationhistory.Lister` interface and every caller unchanged, matching how peers in this package handle similar config.
- **Applies to all alert types** — the missed-resolve gap is general (device-offline, temperature, etc.), not ingest-specific, so the gate is uniform by design.

## Testing & validation

- **New integration test** (`TestNotificationHistoryStore_ListActive_FreshnessGate`): inserts firing rows via `notification_history` so the sync trigger populates `notification_active` realistically — a `-30m` firing row is returned, a `-3h` firing row is excluded, and a resolved row is excluded (regression).
- `go test ./internal/domain/stores/sqlstores/... ./internal/handlers/alerts/...` pass; `go vet` and `goimports` clean.
- `just gen` leaves no uncommitted generated diff.
- **Not covered**: no end-to-end test of the live Grafana re-notify loop (relies on the documented `repeat_interval` invariant). History is intentionally *not* rewritten to reflect resolution — the stale row remains `firing` in `notification_active`, only hidden from the read.
