### PR TITLE
fix(buildings): Add building CTA progresses to ManageBuildingModal

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -272,13 +272,23 @@ const FleetBuildingsPage = () => {
   );
 
   const buildingModals = useBuildingModals({ refetchBuildings: fetchBuildings });
+  const createFlow = useFleetCreateFlow();
 
   // Buildings-tab CTA opens the modal with no pre-filled site — the
   // Site dropdown inside BuildingSettingsModal collects the parent.
   // Site-context auto-fill belongs to /sites/:id, not this global tab.
+  //
+  // Route through the create flow (empty seed) so a freshly created building
+  // advances to ManageBuildingModal for rack/miner positioning. The plain
+  // openDetailsCreate path closes to "none" on save with no manage step, so
+  // it's only the fallback for standalone mounts without the flow provider.
   const handleAddBuilding = useCallback(() => {
+    if (createFlow) {
+      createFlow.launchCreateBuilding({ rackIds: [], minerIds: [], conflictCount: 0 });
+      return;
+    }
     buildingModals.openDetailsCreate();
-  }, [buildingModals]);
+  }, [createFlow, buildingModals]);
 
   const hasSites = (sites?.filter((s) => s.site !== undefined).length ?? 0) > 0;
   // CreateBuilding requires site:manage server-side.
@@ -308,7 +318,6 @@ const FleetBuildingsPage = () => {
   const handleAddBuildingToSite = useCallback((row: BuildingWithCounts) => setReparentTarget(row), []);
 
   // Open the hoisted create flow in place when it commits a new entity.
-  const createFlow = useFleetCreateFlow();
   const entitiesChangedAt = createFlow?.entitiesChangedAt ?? 0;
   useEffect(() => {
     if (entitiesChangedAt === 0) return;


### PR DESCRIPTION
Reviewable diff: +11/-2 across 1 files (excludes generated, test, and story files).

## Summary

The Buildings-tab **Add building** CTA dead-ended: after filling out the building settings modal and confirming, the modal closed instead of advancing to `ManageBuildingModal`, leaving no in-flow way to position racks/miners in the new building. This PR points that CTA at the shared `FleetCreateFlow` create pipeline (the same one the Racks page and miner-reparent picker already use), so creating a building from the global tab now ends in the manage step like every other create entry point.

## How it works

The root cause is which create path the CTA was wired to, not a behavioral regression in any one component. There are two create paths in the buildings feature:

- **Plain path** — `useBuildingModals.openDetailsCreate()` opens `BuildingSettingsModal`; on save its handler creates the building and collapses the modal state back to closed (`"none"`). No manage step. This is the path the Buildings tab was using.
- **Create flow** — `FleetCreateFlow.launchCreateBuilding(seed)` opens the same settings modal, but on save it creates the building, assigns any seeded racks/miners to it, then calls `openManage(...)` to advance to `ManageBuildingModal`. Until now only the Racks page and miner-reparent picker fed this path.

The fix changes `FleetBuildingsPage.handleAddBuilding` to call `createFlow.launchCreateBuilding({ rackIds: [], minerIds: [], conflictCount: 0 })` (an empty seed — the tab has no pre-selected items, and the modal's site dropdown still collects the parent site). The previous `openDetailsCreate()` call is retained only as a fallback for standalone mounts where the `FleetCreateFlow` provider is absent (`createFlow` is `undefined`).

```mermaid
flowchart TD
    CTA["Add building (Buildings tab)"] --> Check{"FleetCreateFlow<br/>provider present?"}
    Check -->|"yes"| Launch["launchCreateBuilding(empty seed)"]
    Check -->|"no (standalone mount)"| Plain["openDetailsCreate()"]
    Launch --> Settings["BuildingSettingsModal (create)"]
    Settings -->|"save"| Create["create building + assign seeded items"]
    Create --> Manage["ManageBuildingModal (position racks/miners)"]
    Plain --> Settings2["BuildingSettingsModal (create)"]
    Settings2 -->|"save"| Close["modal closes (no manage step)"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/.../fleetManagement/pages/FleetBuildingsPage.tsx` | Hoisted the `useFleetCreateFlow()` read above the handler; `handleAddBuilding` now prefers `launchCreateBuilding` and falls back to `openDetailsCreate` when no provider | Single behavioral change; confirm the fallback branch and the empty-seed shape |

## Key technical decisions & trade-offs

- **Reuse the existing create flow vs. add a manage step to the plain path** — routing through `launchCreateBuilding` makes all building-create entry points behave identically and keeps the create→assign→manage logic in one place, rather than duplicating an `openManage` transition into `useBuildingModals.detailsCreate`.
- **Keep `openDetailsCreate` as a fallback** — `useFleetCreateFlow()` returns `undefined` outside the provider (e.g. standalone routes), so the guard preserves a working create path there instead of crashing.

## Testing & validation

- `tsc --noEmit` clean; ESLint/Prettier clean on the changed file.
- 70 existing tests pass across the FleetCreateFlow and buildings suites.
- No new tests added — `FleetBuildingsPage` has no test file today, and the create→manage flow itself is already covered by the FleetCreateFlow suite. Not covered: an integration test asserting the CTA specifically reaches `ManageBuildingModal`.
