### PR TITLE
fix(collection): restore canonical building→rack lock order in SaveRack

### DIFF
--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -1742,27 +1742,17 @@ func (s *Service) SaveRack(ctx context.Context, req *pb.SaveRackRequest) (*pb.Sa
 			buildingChanged bool
 		)
 
-		// Canonical lock pre-pass, mirroring AssignDevicesToRack: lock the
-		// target plus every source rack the members currently sit in, in one
-		// ascending device_set.id order, BEFORE the per-path target lock and
-		// the replaceRackMembershipAndSlots deletes. This is what keeps the
-		// new RemoveDevicesFromAnyRack delete from deadlocking against a
-		// concurrent rack save moving devices the opposite way. targetRackID
-		// is 0 on the create path (the rack doesn't exist yet; it's created +
-		// locked below and sorts last by id). Guarded on a non-empty member
-		// set — an empty save removes members and touches no source racks.
-		if len(deviceIdentifiers) > 0 {
-			var lockTargetRackID int64
-			if req.CollectionId != nil {
-				lockTargetRackID = *req.CollectionId
-			}
-			if _, err := s.collectionStore.LockRacksForReparent(ctx, info.OrganizationID, deviceIdentifiers, lockTargetRackID); err != nil {
-				return nil, err
-			}
-		}
-
+		// The rack-locking pre-pass (LockRacksForReparent) lives INSIDE the
+		// path helpers below, AFTER each resolves and locks the target
+		// site/building. That keeps the canonical site/building -> rack order
+		// (see resolveAndLockRackPlacement and AssignRacksToBuilding) while
+		// still acquiring every source + target rack in one ascending
+		// device_set.id set ahead of the per-target LockRackPlacementForWrite
+		// and the replaceRackMembershipAndSlots deletes — which is what keeps
+		// the RemoveDevicesFromAnyRack delete from deadlocking against a
+		// concurrent rack save moving devices the opposite way.
 		if isUpdate {
-			res, err := s.saveRackUpdate(ctx, info, req, rackInfo)
+			res, err := s.saveRackUpdate(ctx, info, req, rackInfo, deviceIdentifiers)
 			if err != nil {
 				return nil, err
 			}
@@ -1773,7 +1763,7 @@ func (s *Service) SaveRack(ctx context.Context, req *pb.SaveRackRequest) (*pb.Sa
 			siteChanged = res.siteChanged
 			buildingChanged = res.buildingChanged
 		} else {
-			res, err := s.saveRackCreate(ctx, info, req, rackInfo)
+			res, err := s.saveRackCreate(ctx, info, req, rackInfo, deviceIdentifiers)
 			if err != nil {
 				return nil, err
 			}
@@ -1938,9 +1928,34 @@ type saveRackCreatePathResult struct {
 
 // saveRackCreate runs the SaveRack create branch in-tx: resolve placement,
 // then insert device_set + device_set_rack rows.
-func (s *Service) saveRackCreate(ctx context.Context, info *session.Info, req *pb.SaveRackRequest, rackInfo *pb.RackInfo) (*saveRackCreatePathResult, error) {
+// lockSourceRacksForReparent locks every source rack the members currently
+// sit in, plus the target rack, in one ascending device_set.id FOR UPDATE
+// acquisition. Callers MUST invoke it AFTER the site/building lock (canonical
+// site/building -> rack order) but BEFORE the per-target
+// LockRackPlacementForWrite and the membership deletes — that ordering is
+// what keeps the RemoveDevicesFromAnyRack delete from deadlocking against a
+// concurrent rack save moving devices the opposite way. Pass targetRackID 0
+// on the create path: the rack doesn't exist yet, so it contributes no row
+// and sorts last. No-ops on an empty member set, which touches no source
+// racks.
+func (s *Service) lockSourceRacksForReparent(ctx context.Context, orgID int64, deviceIdentifiers []string, targetRackID int64) error {
+	if len(deviceIdentifiers) == 0 {
+		return nil
+	}
+	_, err := s.collectionStore.LockRacksForReparent(ctx, orgID, deviceIdentifiers, targetRackID)
+	return err
+}
+
+func (s *Service) saveRackCreate(ctx context.Context, info *session.Info, req *pb.SaveRackRequest, rackInfo *pb.RackInfo, deviceIdentifiers []string) (*saveRackCreatePathResult, error) {
 	newSiteID, newBuildingID, err := s.resolveAndLockRackPlacement(ctx, info.OrganizationID, rackInfo)
 	if err != nil {
+		return nil, err
+	}
+
+	// targetRackID 0: the rack doesn't exist yet, so the pre-pass locks only
+	// the source racks the members currently sit in (after the site/building
+	// lock above, before the membership writes below).
+	if err := s.lockSourceRacksForReparent(ctx, info.OrganizationID, deviceIdentifiers, 0); err != nil {
 		return nil, err
 	}
 
@@ -1988,7 +2003,7 @@ type saveRackUpdatePathResult struct {
 // saveRackUpdate runs the SaveRack update branch: validate ownership,
 // lock site/building/rack in canonical order, derive the final zone,
 // persist placement, and flag siteChanged for the downstream cascade.
-func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *pb.SaveRackRequest, rackInfo *pb.RackInfo) (*saveRackUpdatePathResult, error) {
+func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *pb.SaveRackRequest, rackInfo *pb.RackInfo, deviceIdentifiers []string) (*saveRackUpdatePathResult, error) {
 	collectionID := *req.CollectionId
 
 	belongs, err := s.collectionStore.CollectionBelongsToOrg(ctx, collectionID, info.OrganizationID)
@@ -2013,7 +2028,12 @@ func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *p
 	)
 	if rackPlacementOmitted(rackInfo) {
 		// Preserve current placement; skip site/building locks since the
-		// rack lock alone serializes the no-op cascade.
+		// rack lock alone serializes the no-op cascade. The source-rack
+		// pre-pass still runs (canonical: racks before the target placement
+		// row) so a member moved here from another rack can't deadlock.
+		if err := s.lockSourceRacksForReparent(ctx, info.OrganizationID, deviceIdentifiers, collectionID); err != nil {
+			return nil, err
+		}
 		current, err = s.collectionStore.LockRackPlacementForWrite(ctx, collectionID, info.OrganizationID)
 		if err != nil {
 			return nil, err
@@ -2021,10 +2041,14 @@ func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *p
 		newSiteID = current.SiteID
 		newBuildingID = current.BuildingID
 	} else {
-		// Placement intent supplied; resolve and lock site/building
-		// before the rack lock (canonical order).
+		// Placement intent supplied; resolve and lock site/building first,
+		// then every source + target rack in ascending device_set.id order,
+		// then the target placement row (canonical site/building -> rack).
 		newSiteID, newBuildingID, err = s.resolveAndLockRackPlacement(ctx, info.OrganizationID, rackInfo)
 		if err != nil {
+			return nil, err
+		}
+		if err := s.lockSourceRacksForReparent(ctx, info.OrganizationID, deviceIdentifiers, collectionID); err != nil {
 			return nil, err
 		}
 		current, err = s.collectionStore.LockRackPlacementForWrite(ctx, collectionID, info.OrganizationID)

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -1743,10 +1743,12 @@ func (s *Service) SaveRack(ctx context.Context, req *pb.SaveRackRequest) (*pb.Sa
 		)
 
 		// The rack-locking pre-pass (LockRacksForReparent) lives INSIDE the
-		// path helpers below, AFTER each resolves and locks the target
-		// site/building. That keeps the canonical site/building -> rack order
-		// (see resolveAndLockRackPlacement and AssignRacksToBuilding) while
-		// still acquiring every source + target rack in one ascending
+		// path helpers below rather than at the top of the tx. On a placement
+		// path it runs AFTER the target site/building lock, preserving the
+		// canonical site/building -> rack order (see resolveAndLockRackPlacement
+		// and AssignRacksToBuilding); on the omitted-placement update path there
+		// is no site/building lock and it is simply the first lock taken. Either
+		// way it acquires every source + target rack in one ascending
 		// device_set.id set ahead of the per-target LockRackPlacementForWrite
 		// and the replaceRackMembershipAndSlots deletes — which is what keeps
 		// the RemoveDevicesFromAnyRack delete from deadlocking against a
@@ -1926,18 +1928,18 @@ type saveRackCreatePathResult struct {
 	finalZone       string
 }
 
-// saveRackCreate runs the SaveRack create branch in-tx: resolve placement,
-// then insert device_set + device_set_rack rows.
 // lockSourceRacksForReparent locks every source rack the members currently
-// sit in, plus the target rack, in one ascending device_set.id FOR UPDATE
-// acquisition. Callers MUST invoke it AFTER the site/building lock (canonical
-// site/building -> rack order) but BEFORE the per-target
-// LockRackPlacementForWrite and the membership deletes — that ordering is
-// what keeps the RemoveDevicesFromAnyRack delete from deadlocking against a
-// concurrent rack save moving devices the opposite way. Pass targetRackID 0
-// on the create path: the rack doesn't exist yet, so it contributes no row
-// and sorts last. No-ops on an empty member set, which touches no source
-// racks.
+// sit in -- and, when targetRackID > 0, the target rack too -- in one
+// ascending device_set.id FOR UPDATE acquisition. It must run BEFORE the
+// per-target LockRackPlacementForWrite and the membership deletes; that
+// ordering is what keeps the RemoveDevicesFromAnyRack delete from deadlocking
+// against a concurrent rack save moving devices the opposite way. On a
+// placement path the caller takes the site/building lock first and calls this
+// after it, preserving the canonical site/building -> rack order; the
+// omitted-placement path takes no site/building lock, so this is simply its
+// first lock. targetRackID 0 (the create path, where the rack doesn't exist
+// yet) contributes no target row. No-ops on an empty member set, which
+// touches no source racks.
 func (s *Service) lockSourceRacksForReparent(ctx context.Context, orgID int64, deviceIdentifiers []string, targetRackID int64) error {
 	if len(deviceIdentifiers) == 0 {
 		return nil
@@ -1946,6 +1948,8 @@ func (s *Service) lockSourceRacksForReparent(ctx context.Context, orgID int64, d
 	return err
 }
 
+// saveRackCreate runs the SaveRack create branch in-tx: resolve placement,
+// then insert device_set + device_set_rack rows.
 func (s *Service) saveRackCreate(ctx context.Context, info *session.Info, req *pb.SaveRackRequest, rackInfo *pb.RackInfo, deviceIdentifiers []string) (*saveRackCreatePathResult, error) {
 	newSiteID, newBuildingID, err := s.resolveAndLockRackPlacement(ctx, info.OrganizationID, rackInfo)
 	if err != nil {
@@ -1953,8 +1957,8 @@ func (s *Service) saveRackCreate(ctx context.Context, info *session.Info, req *p
 	}
 
 	// targetRackID 0: the rack doesn't exist yet, so the pre-pass locks only
-	// the source racks the members currently sit in (after the site/building
-	// lock above, before the membership writes below).
+	// the source racks the members currently sit in. Runs after placement
+	// resolution above and before the membership writes below.
 	if err := s.lockSourceRacksForReparent(ctx, info.OrganizationID, deviceIdentifiers, 0); err != nil {
 		return nil, err
 	}

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -1653,7 +1653,9 @@ func TestService_SaveRack_locksBuildingBeforeRacks(t *testing.T) {
 	// Unordered scaffolding around the lock sequence.
 	mockStore.EXPECT().CollectionBelongsToOrg(gomock.Any(), collectionID, testOrgID).Return(true, nil)
 	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, collectionID).Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
-	mockStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, newBuilding).Return(&newSiteID, nil).Times(2)
+	// Call count left loose: this test pins the lock ordering, not how many
+	// times placement resolution reads building->site.
+	mockStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, newBuilding).Return(&newSiteID, nil).AnyTimes()
 	mockStore.EXPECT().UpdateCollection(gomock.Any(), testOrgID, collectionID, gomock.Any(), (*string)(nil)).Return(nil)
 	mockStore.EXPECT().UpdateRackInfo(gomock.Any(), collectionID, gomock.Any(), int32(4), int32(8), gomock.Any(), gomock.Any(), testOrgID).Return(nil)
 	mockStore.EXPECT().UpdateRackPlacement(gomock.Any(), collectionID, testOrgID, gomock.Eq(&newSiteID), gomock.Eq(&newBuilding), gomock.Any()).Return(nil)

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -1630,6 +1630,74 @@ func TestService_SaveRack_MoveBetweenBuildingsCascadesSite(t *testing.T) {
 	assert.Equal(t, int32(1), resp.SiteReassignedCount)
 }
 
+// TestService_SaveRack_locksBuildingBeforeRacks pins #555's lock-order
+// invariant: on the placement-update path SaveRack must lock the target
+// site/building FIRST, then acquire every source + target rack via
+// LockRacksForReparent, then the per-target LockRackPlacementForWrite.
+// Reversing this (locking racks before the building, as PR #551 did) risks
+// deadlock against AssignRacksToBuilding, which takes building → rack. The
+// rack pre-pass must still land BEFORE LockRackPlacementForWrite so the
+// original rack-vs-rack deadlock fix is preserved.
+func TestService_SaveRack_locksBuildingBeforeRacks(t *testing.T) {
+	deviceIDs := []string{"device-1"}
+	resolver := func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return deviceIDs, nil
+	}
+	svc, mockStore, mockSiteStore := newTestServiceWithSites(t, resolver)
+	ctx := testCtx(t)
+
+	collectionID := int64(42)
+	newBuilding := int64(80)
+	newSiteID := int64(8)
+
+	// Unordered scaffolding around the lock sequence.
+	mockStore.EXPECT().CollectionBelongsToOrg(gomock.Any(), collectionID, testOrgID).Return(true, nil)
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, collectionID).Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
+	mockStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, newBuilding).Return(&newSiteID, nil).Times(2)
+	mockStore.EXPECT().UpdateCollection(gomock.Any(), testOrgID, collectionID, gomock.Any(), (*string)(nil)).Return(nil)
+	mockStore.EXPECT().UpdateRackInfo(gomock.Any(), collectionID, gomock.Any(), int32(4), int32(8), gomock.Any(), gomock.Any(), testOrgID).Return(nil)
+	mockStore.EXPECT().UpdateRackPlacement(gomock.Any(), collectionID, testOrgID, gomock.Eq(&newSiteID), gomock.Eq(&newBuilding), gomock.Any()).Return(nil)
+	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, collectionID).Return(int64(0), nil)
+	mockStore.EXPECT().RemoveDevicesFromAnyRack(gomock.Any(), testOrgID, deviceIDs, collectionID).Return(int64(0), nil)
+	mockStore.EXPECT().AddDevicesToCollection(gomock.Any(), testOrgID, collectionID, deviceIDs).Return(int64(1), nil)
+	mockStore.EXPECT().GetDeviceSiteIDsByMembership(gomock.Any(), collectionID, testOrgID).Return(map[string]*int64{"device-1": &newSiteID}, nil)
+	mockStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), collectionID, testOrgID, gomock.Any()).Return(int64(0), nil)
+	mockStore.EXPECT().CascadeRackDeviceBuildings(gomock.Any(), collectionID, testOrgID, gomock.Any()).Return(int64(0), nil)
+	mockStore.EXPECT().GetRackSlots(gomock.Any(), collectionID, testOrgID).Return(nil, nil)
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, collectionID).
+		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack A", Type: pb.CollectionType_COLLECTION_TYPE_RACK, DeviceCount: 1}, nil)
+
+	// The invariant: site/building locks precede the rack pre-pass, which
+	// precedes the target placement-row lock.
+	gomock.InOrder(
+		mockSiteStore.EXPECT().LockSiteForWrite(gomock.Any(), testOrgID, newSiteID).Return(nil),
+		mockSiteStore.EXPECT().LockBuildingForWrite(gomock.Any(), testOrgID, newBuilding).Return(nil),
+		mockStore.EXPECT().LockRacksForReparent(gomock.Any(), testOrgID, deviceIDs, collectionID).Return(nil, nil),
+		mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), collectionID, testOrgID).
+			Return(interfaces.RackPlacement{SiteID: &newSiteID, BuildingID: &newBuilding}, nil),
+	)
+
+	rackInfo := &pb.RackInfo{
+		Rows:        4,
+		Columns:     8,
+		Zone:        "Zone A",
+		OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+		CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+		BuildingId:  &newBuilding,
+	}
+	_, err := svc.SaveRack(ctx, &pb.SaveRackRequest{
+		CollectionId: &collectionID,
+		Label:        "Rack A",
+		RackInfo:     rackInfo,
+		DeviceSelector: &commonpb.DeviceSelector{
+			SelectionType: &commonpb.DeviceSelector_DeviceList{
+				DeviceList: &commonpb.DeviceIdentifierList{DeviceIdentifiers: deviceIDs},
+			},
+		},
+	})
+	require.NoError(t, err)
+}
+
 // TestService_SaveRack_MoveToDirectUnderSite covers the variant where a
 // rack is moved out of any building and attached directly to a site.
 // Zone is still cleared (building boundary crossed) and the site lock


### PR DESCRIPTION
Reviewable diff: +50/-26 across 1 file (excludes generated, test, and story files).

## Summary

Fixes a deadlock risk in `SaveRack` (issue #555). Two concurrent rack operations could acquire the same building and rack rows in opposite orders and deadlock — Postgres aborts one with `40P01` (retryable, no data corruption). This PR restores a single, consistent lock order across the whole rack-write surface so the cycle can't form.

## How it works

A rack save runs inside one transaction. To move members safely it must take row locks on several things: the target **site/building** the rack is being placed in, every **rack** that currently holds the members (plus the target rack), and finally the target rack's **placement row** before rewriting membership.

The rest of the codebase always takes these in one canonical order — **building/site first, then racks** (`AssignRacksToBuilding`, `resolveAndLockRackPlacement`). PR #551, while fixing a separate rack-vs-rack deadlock, added a rack-locking pre-pass (`LockRacksForReparent`) at the **very top** of `SaveRack`'s transaction — i.e. *before* the building/site lock. That gave `SaveRack` the reverse order (**rack → building**). When a `SaveRack` that changes a rack's building ran concurrently with an `AssignRacksToBuilding` moving that same rack, each transaction held one of the two rows and waited on the other → deadlock.

The fix moves the rack pre-pass out of the top of the transaction and **into the create/update path helpers**, placing it *after* the site/building lock but *before* the per-target placement-row lock. A small `lockSourceRacksForReparent` helper centralizes that call (and its empty-member-set no-op guard) so all three branches — create, update-with-placement, and update-with-omitted-placement — acquire locks identically.

The resulting per-transaction order is now uniform everywhere:

**site → building → all racks (ascending `device_set.id`) → target placement row → membership deletes**

Because the rack set is still locked as one ascending-id batch *ahead of* the per-target placement lock, the original rack-vs-rack deadlock fix from #551 is preserved; only the building-vs-rack inversion is corrected.

## Diagrams

Lock acquisition order — before vs. after:

```mermaid
flowchart TB
    subgraph Before["Before (#551 — inverted)"]
        B1["LockRacksForReparent (racks)"] --> B2["resolveAndLockRackPlacement (building/site)"] --> B3["LockRackPlacementForWrite (target rack row)"]
    end
    subgraph After["After (this PR — canonical)"]
        A1["resolveAndLockRackPlacement (building/site)"] --> A2["lockSourceRacksForReparent (racks)"] --> A3["LockRackPlacementForWrite (target rack row)"]
    end
```

The deadlock this removes:

```mermaid
sequenceDiagram
    participant T1 as "SaveRack (move rack R → building B)"
    participant T2 as "AssignRacksToBuilding (move R → building B)"
    T1->>T1: lock rack R
    T2->>T2: lock building B
    T1-->>T2: wait for building B (held by T2)
    T2-->>T1: wait for rack R (held by T1)
    Note over T1,T2: cycle → Postgres aborts one (40P01)
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/collection/service.go` — `SaveRack` | Removed the top-of-transaction `LockRacksForReparent` pre-pass | This was the source of the inversion |
| `server/internal/domain/collection/service.go` — `saveRackCreate`, `saveRackUpdate` | Now take `deviceIdentifiers`; acquire the rack pre-pass after the building/site lock and before the placement-row lock | Confirm the ordering holds on all three branches (create, update-with-placement, update-omitted-placement) |
| `server/internal/domain/collection/service.go` — `lockSourceRacksForReparent` (new) | Helper wrapping `LockRacksForReparent` with the empty-member-set no-op guard | Single chokepoint for the rack-lock step; verify the `len == 0` short-circuit |
| `server/internal/domain/collection/service_test.go` | Added `TestService_SaveRack_locksBuildingBeforeRacks` | Pins the lock sequence via `gomock.InOrder` |

## Key technical decisions & trade-offs

- **Move the pre-pass into the path helpers vs. reordering at the top of the transaction.** The building/site lock is resolved *inside* `saveRackCreate`/`saveRackUpdate` (placement intent is path-specific), so the rack pre-pass has to live there too to sit after it. The alternative — hoisting placement resolution up to `SaveRack` — would duplicate the create/update placement logic.
- **Keep the rack batch ahead of the per-target placement lock.** Preserves #551's rack-vs-rack fix; the only behavioral change is where the building/site lock falls relative to the rack batch.
- **No schema or API change.** Pure lock-ordering fix; the deadlock was already retryable and non-corrupting, so there is no migration or data-repair concern.

## Testing & validation

- Added `TestService_SaveRack_locksBuildingBeforeRacks`, a `gomock.InOrder` test pinning `LockSiteForWrite → LockBuildingForWrite → LockRacksForReparent → LockRackPlacementForWrite`. Confirmed it **fails** when the order is re-inverted (i.e. it genuinely guards the invariant), then restored.
- `go test ./server/internal/domain/collection/ ./server/internal/domain/buildings/` — green.
- Existing `SaveRack` tests assert by argument rather than order, so they pass unchanged; the new test is what locks in the ordering contract.
- **Not covered:** no concurrent/integration test forcing a real Postgres deadlock — the guarantee rests on the unit-level lock-order invariant plus matching the order already used by `AssignRacksToBuilding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
