### PR TITLE
perf(server-test): clone a migrated template DB per test

### DIFF
--- a/server/cmd/fleetnode/telemetry.go
+++ b/server/cmd/fleetnode/telemetry.go
@@ -260,15 +260,18 @@ type telemetryDeviceCloser interface {
 }
 
 func closeTelemetryDeviceAsync(device telemetryDeviceCloser) bool {
+	// Capture the channel so the worker releases the exact slot it acquired,
+	// even if telemetryDeviceCloseTokens is reassigned later (tests swap it).
+	tokens := telemetryDeviceCloseTokens
 	select {
-	case telemetryDeviceCloseTokens <- struct{}{}:
+	case tokens <- struct{}{}:
 	default:
 		slog.Warn("telemetry device close worker capacity is exhausted; closing synchronously")
 		closeTelemetryDevice(device)
 		return false
 	}
 	go func() {
-		defer func() { <-telemetryDeviceCloseTokens }()
+		defer func() { <-tokens }()
 		closeTelemetryDevice(device)
 	}()
 	return true

--- a/server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go
+++ b/server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,9 +96,20 @@ func writeHeartbeat(t *testing.T, db *sql.DB, orgID int64, age time.Duration) {
 		VALUES ($1, 'fleet_telemetry_poll_total', $2, 1)`,
 		time.Now().Add(-age), fmt.Sprintf("%d", orgID))
 	require.NoError(t, err)
+
 	// NULL bounds refresh the whole eligible range; CALL must not run in a tx.
-	_, err = db.ExecContext(ctx,
-		`CALL refresh_continuous_aggregate('fleet_telemetry_poll_heartbeat', NULL, NULL)`)
+	// The cagg has a 30s background refresh policy (migration 000082); this
+	// manual refresh can collide with the scheduled one and fail with SQLSTATE
+	// 55P03 ("concurrent refresh"). That conflict is transient, so retry it.
+	const maxAttempts = 10
+	for attempt := 1; ; attempt++ {
+		_, err = db.ExecContext(ctx,
+			`CALL refresh_continuous_aggregate('fleet_telemetry_poll_heartbeat', NULL, NULL)`)
+		if err == nil || attempt == maxAttempts || !strings.Contains(err.Error(), "55P03") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	require.NoError(t, err)
 }
 

--- a/server/internal/testutil/database_setup.go
+++ b/server/internal/testutil/database_setup.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,13 +15,75 @@ import (
 	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 )
 
+// templateOnce builds a fully-migrated template database exactly once per test
+// process. Each subsequent test then provisions its own isolated database as a
+// fast `CREATE DATABASE ... TEMPLATE` file-copy instead of replaying every
+// migration, which is the dominant per-test cost. Building the template only
+// once also means the lock-heavy TimescaleDB continuous-aggregate DDL runs once
+// per process rather than once per test, removing the concurrent-migration
+// deadlock surface the retry logic below exists to absorb.
+var (
+	templateOnce sync.Once
+	templateName string
+	templateErr  error
+)
+
 // GetTestDB creates a test database connection and returns a sql.DB ref for testing.
 // The database connection will be closed when the test completes.
 func GetTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 
-	// Parse the DB config from environment variables the same way we would when
-	// running the server.
+	config := parseTestDBConfig(t)
+	adminConfig := config
+	adminConfig.Name = "postgres"
+
+	// When the caller pins DB_NAME to a real database we migrate it in place;
+	// otherwise we generate a unique name and clone the migrated template.
+	useGeneratedName := config.Name == "" || config.Name == "fleet"
+
+	dbName := config.Name
+	if useGeneratedName {
+		dbName = generateTestDBName(t.Name())
+	}
+
+	testDBConfig := config
+	testDBConfig.Name = dbName
+
+	var conn *sql.DB
+	if useGeneratedName {
+		// Fast path: clone a once-migrated template instead of running every
+		// migration for this test's database.
+		template, err := ensureTemplateDB(t, config, adminConfig)
+		assert.NoError(t, err)
+
+		createTestDatabaseFromTemplate(t, &adminConfig, dbName, template)
+
+		conn, err = db.ConnectToDatabase(&testDBConfig)
+		assert.NoError(t, err)
+	} else {
+		// Pinned DB_NAME: create the database and migrate it in place.
+		createEmptyTestDatabase(t, &adminConfig, dbName)
+
+		var err error
+		// Connect and run migrations with retry on deadlock.
+		// TimescaleDB continuous aggregate DDL acquires instance-level catalog
+		// locks that can deadlock when parallel tests migrate concurrently. On
+		// failure we drop and recreate the database for a clean slate (avoids
+		// golang-migrate dirty flag issues).
+		conn, err = connectAndMigrateWithRetry(t, &testDBConfig, &adminConfig, dbName)
+		assert.NoError(t, err)
+	}
+
+	registerTestDatabaseCleanup(t, conn, &adminConfig, dbName)
+
+	return conn
+}
+
+// parseTestDBConfig reads the DB config from environment variables the same way
+// the server does when it starts.
+func parseTestDBConfig(t *testing.T) db.Config {
+	t.Helper()
+
 	cli := struct {
 		DB db.Config `envprefix:"DB_" embed:""`
 	}{}
@@ -27,57 +91,90 @@ func GetTestDB(t *testing.T) *sql.DB {
 	assert.NoError(t, err)
 	_, err = parser.Parse(nil)
 	assert.NoError(t, err)
-	config := cli.DB
-	dbName := config.Name
-	if dbName == "" || dbName == "fleet" {
-		// If the DB name is not set, or is the default name, generate a unique name
-		dbName = generateTestDBName(t.Name())
-	}
+	return cli.DB
+}
 
-	// Connect to PostgreSQL without selecting a database to create our test database
-	// Connect to the default "postgres" database first
-	adminConfig := config
-	adminConfig.Name = "postgres"
-	conn, err := db.ConnectToDatabase(&adminConfig)
+// ensureTemplateDB builds (once per process) a fully-migrated template database
+// and returns its name. The migrator connection is closed before returning so
+// that CREATE DATABASE ... TEMPLATE, which requires no active sessions on the
+// source, succeeds.
+func ensureTemplateDB(t *testing.T, config db.Config, adminConfig db.Config) (string, error) {
+	t.Helper()
+
+	templateOnce.Do(func() {
+		name := generateTemplateDBName()
+
+		createEmptyTestDatabase(t, &adminConfig, name)
+
+		templateConfig := config
+		templateConfig.Name = name
+		conn, err := connectAndMigrateWithRetry(t, &templateConfig, &adminConfig, name)
+		if err != nil {
+			templateErr = err
+			return
+		}
+		// Close before cloning: CREATE DATABASE ... TEMPLATE fails if any
+		// session is connected to the template.
+		if err := conn.Close(); err != nil {
+			templateErr = fmt.Errorf("closing template connection: %w", err)
+			return
+		}
+		terminateConnections(t, &adminConfig, name)
+
+		templateName = name
+	})
+
+	return templateName, templateErr
+}
+
+// createEmptyTestDatabase drops any existing database of the given name and
+// creates a fresh empty one.
+func createEmptyTestDatabase(t *testing.T, adminConfig *db.Config, dbName string) {
+	t.Helper()
+
+	conn, err := db.ConnectToDatabase(adminConfig)
 	assert.NoError(t, err)
+	defer conn.Close()
 
-	// Drop existing connections to the test database if any
-	_, _ = conn.ExecContext(t.Context(), fmt.Sprintf(`
-		SELECT pg_terminate_backend(pg_stat_activity.pid)
-		FROM pg_stat_activity
-		WHERE pg_stat_activity.datname = '%s'
-		AND pid <> pg_backend_pid()
-	`, dbName))
-
-	// Create the test database
+	terminateConnectionsVia(t, conn, dbName)
 	_, err = conn.ExecContext(t.Context(), fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
 	assert.NoError(t, err)
 	_, err = conn.ExecContext(t.Context(), fmt.Sprintf("CREATE DATABASE %s", dbName))
 	assert.NoError(t, err)
-	conn.Close()
+}
 
-	// Connect and run migrations with retry on deadlock.
-	// TimescaleDB continuous aggregate DDL acquires instance-level catalog locks
-	// that can deadlock when parallel tests migrate concurrently. On failure we
-	// drop and recreate the database for a clean slate (avoids golang-migrate
-	// dirty flag issues).
-	testDBConfig := config
-	testDBConfig.Name = dbName
-	conn, err = connectAndMigrateWithRetry(t, &testDBConfig, &adminConfig, dbName)
+// createTestDatabaseFromTemplate drops any existing database of the given name
+// and creates a fresh one as a copy of the migrated template.
+func createTestDatabaseFromTemplate(t *testing.T, adminConfig *db.Config, dbName, template string) {
+	t.Helper()
+
+	conn, err := db.ConnectToDatabase(adminConfig)
 	assert.NoError(t, err)
+	defer conn.Close()
 
-	// Clean up the database when the test is done
+	terminateConnectionsVia(t, conn, dbName)
+	_, err = conn.ExecContext(t.Context(), fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
+	assert.NoError(t, err)
+	_, err = conn.ExecContext(t.Context(), fmt.Sprintf("CREATE DATABASE %s TEMPLATE %s", dbName, template))
+	assert.NoError(t, err)
+}
+
+// registerTestDatabaseCleanup closes the connection and drops the database when
+// the test finishes.
+func registerTestDatabaseCleanup(t *testing.T, conn *sql.DB, adminConfig *db.Config, dbName string) {
+	t.Helper()
+
 	t.Cleanup(func() {
 		err := conn.Close()
 		assert.NoError(t, err, "error closing db connection")
-		// Reconnect to the default "postgres" database to drop the test database
-		conn, err = db.ConnectToDatabase(&adminConfig)
-		assert.NoError(t, err, "error connecting to PostgreSQL")
-		defer conn.Close()
 
-		// Terminate any remaining connections to the test database
+		adminConn, err := db.ConnectToDatabase(adminConfig)
+		assert.NoError(t, err, "error connecting to PostgreSQL")
+		defer adminConn.Close()
+
+		// Terminate any remaining connections to the test database.
 		// nolint: usetesting
-		_, _ = conn.ExecContext(context.Background(), fmt.Sprintf(`
+		_, _ = adminConn.ExecContext(context.Background(), fmt.Sprintf(`
 			SELECT pg_terminate_backend(pg_stat_activity.pid)
 			FROM pg_stat_activity
 			WHERE pg_stat_activity.datname = '%s'
@@ -85,11 +182,33 @@ func GetTestDB(t *testing.T) *sql.DB {
 		`, dbName))
 
 		// nolint: usetesting
-		_, err = conn.ExecContext(context.Background(), fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
+		_, err = adminConn.ExecContext(context.Background(), fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
 		assert.NoError(t, err, "error dropping test database")
 	})
+}
 
-	return conn
+// terminateConnections opens an admin connection and terminates all other
+// sessions connected to the given database.
+func terminateConnections(t *testing.T, adminConfig *db.Config, dbName string) {
+	t.Helper()
+
+	conn, err := db.ConnectToDatabase(adminConfig)
+	assert.NoError(t, err)
+	defer conn.Close()
+	terminateConnectionsVia(t, conn, dbName)
+}
+
+// terminateConnectionsVia terminates all other sessions connected to the given
+// database using an existing admin connection.
+func terminateConnectionsVia(t *testing.T, conn *sql.DB, dbName string) {
+	t.Helper()
+
+	_, _ = conn.ExecContext(t.Context(), fmt.Sprintf(`
+		SELECT pg_terminate_backend(pg_stat_activity.pid)
+		FROM pg_stat_activity
+		WHERE pg_stat_activity.datname = '%s'
+		AND pid <> pg_backend_pid()
+	`, dbName))
 }
 
 const (
@@ -169,6 +288,13 @@ func recreateTestDatabase(t *testing.T, adminConfig *db.Config, dbName string) {
 	assert.NoError(t, err)
 	_, err = adminConn.ExecContext(t.Context(), fmt.Sprintf("CREATE DATABASE %s", dbName))
 	assert.NoError(t, err)
+}
+
+// generateTemplateDBName creates a per-process template database name. The PID
+// keeps it unique across the test binaries that `go test` runs concurrently, so
+// each process owns its own template on the shared instance.
+func generateTemplateDBName() string {
+	return fmt.Sprintf("fleet_test_template_%d", os.Getpid())
 }
 
 // generateTestDBName creates a unique database name that includes part of the test name for readability.


### PR DESCRIPTION
## Summary

Cuts the **Server Checks / Test** job's dominant cost. The test step (~363s on CI) is gated by DB-backed packages that each rebuilt their database from scratch: every test ran `CREATE DATABASE` + replayed all ~99 migrations (~0.5-0.7s each). `domain/stores/sqlstores` alone does this ~143 times → ~227s, and it is the single-package floor for the whole job.

This builds **one migrated template database per test process** and provisions each test's database as a fast `CREATE DATABASE ... TEMPLATE` file-copy, skipping the per-test migration replay entirely.

## Mechanism

`testutil.GetTestDB` (the single entry point all DB-backed tests funnel through, directly or via `NewDatabaseService` / `InitializeDBServiceInfrastructure`) now:

1. Builds a fully-migrated template database **once per process** (`sync.Once`), keyed by PID so the concurrent `go test` package processes each own their template on the shared instance. The migrator connection is closed before any clone, since `CREATE DATABASE ... TEMPLATE` requires no sessions on the source.
2. Provisions each test database as `CREATE DATABASE <unique> TEMPLATE <template>` instead of running migrations.

Per-test isolation is **unchanged** — every test still gets its own physical database with a unique name. The lock-heavy TimescaleDB continuous-aggregate DDL now runs once per process instead of once per test, which *removes* the concurrent-migration deadlock surface the existing retry logic guards against. The pinned-`DB_NAME` path (non-default) keeps the migrate-in-place behavior.

## Measured impact (local, warm TimescaleDB)

| Package | Before | After |
|---|---|---|
| `domain/authz` | 14.6s | **3.6s** |
| `domain/stores/sqlstores` | ~80s | **17.7s** |
| `domain/fleetmanagement` | (CI 98s) | 10.4s |
| `domain/fleetnode/pairing` | (CI 113s) | 6.7s |
| `domain/command` | (CI 58s) | 11.7s |

CI's slowest package (`sqlstores`, 227s) should drop well under 100s, pulling the whole Test job down with it. Local numbers are on a fast disk; CI ratios will differ but the per-test migration replay — the dominant cost — is eliminated either way.

## Two pre-existing flakes fixed along the way

Stress-running the full suite (and CI on a sibling branch) surfaced two **pre-existing** races, unrelated to the DB change but worth fixing so the faster suite stays green:

- **`fix(fleetnode)`** — `closeTelemetryDeviceAsync` acquired a slot on the global token channel but its release goroutine re-read the global at exit. Benign in production (the global never changes) but tests swap it, so a slow goroutine from one test could drain the next test's token and break its assertion under load. Now captures the channel locally. Root-caused to the adjacent `TestCloseTelemetryDeviceAsyncDoesNotBlock` → `...WhenCloseWorkersAreExhausted` ordering.
- **`test(timescaledb)`** — `fleet_telemetry_poll_heartbeat` has a 30s background refresh policy (migration 000082); the ingest-stalled-rule test's manual `refresh_continuous_aggregate` can collide with the scheduled one and fail with `SQLSTATE 55P03`. The helper now retries that transient conflict.

## Verification

- Full server suite (`go test ./... -skip ./generated/...`) run **13x** with all three changes: 0 failures, 0 telemetry flakes.
- `go vet`, `golangci-lint` (0 issues), and `golangci-lint fmt --diff` all clean on the changed packages.
- Each fix root-caused from source, not guessed.

## Notes

- Independent of [#602](https://github.com/block/proto-fleet/pull/602) (which caches the TimescaleDB image in the same job) — different files, mergeable in any order. Together they target the build/startup and the test-execution halves of the Server Test job.
- Follow-up (not in this PR): adding `t.Parallel()` to the DB-backed tests now that the template removes the per-test migration cost; with isolated per-test DBs this is safe but touches many files and should be its own change (and needs the `generateTestDBName` entropy widened first).
