### PR TITLE
test(server): make test-DB setup resilient to transient server restarts

### DIFF
--- a/server/internal/testutil/database_setup.go
+++ b/server/internal/testutil/database_setup.go
@@ -98,7 +98,29 @@ const (
 
 	pgInternalError                   = "XX000"
 	timescaleTupleConcurrentlyDeleted = "tuple concurrently deleted"
+
+	// serverReadyTimeout bounds how long we wait for the database server to
+	// start accepting connections again after a transient restart before a
+	// migration retry.
+	serverReadyTimeout  = 30 * time.Second
+	serverReadyInterval = 250 * time.Millisecond
 )
+
+// transientServerErrors are substrings of errors emitted while the database
+// server itself is restarting/recovering — e.g. a crash under heavy concurrent
+// migration load that `restart: always` brings back within a second or two.
+// Under the per-test-database model one such restart otherwise cascades into
+// dozens of unrelated failures; retrying once the server is back lets each test
+// survive the blip instead.
+var transientServerErrors = []string{
+	"57P03", // cannot_connect_now: "the database system is not yet accepting connections"
+	"the database system is starting up",
+	"the database system is shutting down",
+	"the database system is in recovery mode",
+	"bad connection",
+	"connection is already closed",
+	"connection reset by peer",
+}
 
 // connectAndMigrateWithRetry wraps db.ConnectAndMigrate with retry logic for
 // deadlocks caused by concurrent TimescaleDB catalog operations across test
@@ -124,7 +146,10 @@ func connectAndMigrateWithRetry(
 			return nil, lastErr
 		}
 
-		t.Logf("migration deadlock (attempt %d/%d), retrying: %v", attempt, migrationMaxRetries, lastErr)
+		t.Logf("retryable migration error (attempt %d/%d), retrying: %v", attempt, migrationMaxRetries, lastErr)
+		// A transient server restart leaves the server briefly unavailable;
+		// wait for it before recreating so the admin DDL below does not fail.
+		waitForServerReady(t, adminConfig)
 		recreateTestDatabase(t, adminConfig, dbName)
 
 		delay := time.Duration(attempt) * migrationRetryBaseDelay
@@ -145,9 +170,49 @@ func isRetryableMigrationError(err error) bool {
 		return true
 	}
 	msg := err.Error()
-	return strings.Contains(msg, db.PGDeadlockDetected) ||
+	if strings.Contains(msg, db.PGDeadlockDetected) ||
 		strings.Contains(msg, db.PGSerializationFailure) ||
-		(strings.Contains(msg, pgInternalError) && strings.Contains(msg, timescaleTupleConcurrentlyDeleted))
+		(strings.Contains(msg, pgInternalError) && strings.Contains(msg, timescaleTupleConcurrentlyDeleted)) {
+		return true
+	}
+	return isTransientServerError(msg)
+}
+
+// isTransientServerError reports whether the error came from the database server
+// being temporarily unavailable (restarting/recovering) rather than from the
+// migration itself.
+func isTransientServerError(msg string) bool {
+	for _, s := range transientServerErrors {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// waitForServerReady blocks until the database server accepts a query on the
+// admin database, or serverReadyTimeout elapses. This bridges the brief window
+// after a transient server restart so the admin DDL used to recreate a test
+// database before a migration retry runs against a live server.
+func waitForServerReady(t *testing.T, adminConfig *db.Config) {
+	t.Helper()
+
+	conn, err := db.ConnectToDatabase(adminConfig)
+	if err != nil {
+		return // best effort; the subsequent admin op surfaces a real failure
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(serverReadyTimeout)
+	for {
+		ctx, cancel := context.WithTimeout(t.Context(), serverReadyInterval)
+		_, pingErr := conn.ExecContext(ctx, "SELECT 1")
+		cancel()
+		if pingErr == nil || time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(serverReadyInterval)
+	}
 }
 
 // recreateTestDatabase drops and recreates a test database via the admin connection.

--- a/server/internal/testutil/database_setup_test.go
+++ b/server/internal/testutil/database_setup_test.go
@@ -41,6 +41,34 @@ func TestIsRetryableMigrationError(t *testing.T) {
 			err:  errors.New("migration failed: ERROR: syntax error (SQLSTATE 42601)"),
 			want: false,
 		},
+		{
+			name: "unique violation is not retried",
+			err:  errors.New("migration failed: ERROR: duplicate key value (SQLSTATE 23505)"),
+			want: false,
+		},
+		// Transient server restart/recovery: a TimescaleDB crash under
+		// concurrent-migration load comes back within a second or two, so these
+		// retry rather than cascade into a job-wide failure.
+		{
+			name: "server not yet accepting connections (57P03)",
+			err:  errors.New("failed to connect: FATAL: the database system is not yet accepting connections (SQLSTATE 57P03)"),
+			want: true,
+		},
+		{
+			name: "bad connection mid-migration",
+			err:  errors.New("failed to run migrations: CREATE INDEX CONCURRENTLY foo (details: driver: bad connection)"),
+			want: true,
+		},
+		{
+			name: "connection already closed",
+			err:  errors.New("sql: connection is already closed in line 0: SELECT pg_advisory_unlock($1)"),
+			want: true,
+		},
+		{
+			name: "server starting up",
+			err:  errors.New("FATAL: the database system is starting up"),
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes the class of CI failure where a single TimescaleDB restart cascades into dozens of unrelated server-test failures in one job (seen on [run 28268597367](https://github.com/block/proto-fleet/actions/runs/28268597367)).

## What happened

Every server test creates its own database and replays all migrations. Under heavy concurrent load the TimescaleDB container can crash — in the failing run, a `CREATE INDEX CONCURRENTLY` lost its connection — and `restart: always` brings it back ~1-2s later. During that window:

- in-flight migrations fail with `driver: bad connection` / `connection is already closed`
- every new connection fails with `the database system is not yet accepting connections (SQLSTATE 57P03)`

`connectAndMigrateWithRetry` only retried deadlock/serialization errors, so ~71 tests that happened to touch the DB during recovery failed, even though the server was healthy again seconds later.

## Fix

In `testutil` (test infrastructure only — no production code):

- Treat transient server-restart errors as retryable: `57P03`, "starting up" / "shutting down" / "in recovery mode", `bad connection`, `connection is already closed`, `connection reset by peer`.
- Before recreating the test database for a retry, `waitForServerReady` polls the admin DB until it accepts connections again (bounded at 30s), so the recreate DDL runs against a live server instead of failing during recovery.
- Genuine errors (syntax, constraint violations, generic internal errors) are still **not** retried, so real regressions fail fast.

## Verification

- New table-test cases in `database_setup_test.go` pin the classification using the exact error strings from the failing run; syntax/constraint errors stay non-retryable.
- `go vet ./...`, `golangci-lint`, `gofmt` clean; a DB-backed package (`fleetnode/pairing`) still passes.

## Note

This is a resilience mitigation. The deeper fix is to stop replaying all migrations per test (a migrated-template clone, run once per process), which would largely remove the concurrent-migration load that triggers the crash — worth revisiting separately.
