### PR TITLE
[codex] Add buildings E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -9,6 +9,7 @@ import { AuthPage } from "../pages/auth";
 import { LoginModalComponent } from "../pages/components/loginModal";
 import { EditPoolPage } from "../pages/editPool";
 import { EnergyPage } from "../pages/energy";
+import { FleetLocationsPage } from "../pages/fleetLocations";
 import { GroupsPage } from "../pages/groups";
 import { HomePage } from "../pages/home";
 import { MinersPage } from "../pages/miners";
@@ -44,6 +45,7 @@ type PageFixtures = {
   alertsPage: AlertsPage;
   editPoolPage: EditPoolPage;
   energyPage: EnergyPage;
+  fleetLocationsPage: FleetLocationsPage;
   newPoolModal: NewPoolModalPage;
   loginModal: LoginModalComponent;
   commonSteps: CommonSteps;
@@ -106,6 +108,9 @@ export const test = base.extend<PageFixtures>({
   },
   energyPage: async ({ page, isMobile }, use) => {
     await use(new EnergyPage(page, isMobile));
+  },
+  fleetLocationsPage: async ({ page, isMobile }, use) => {
+    await use(new FleetLocationsPage(page, isMobile));
   },
   newPoolModal: async ({ page, isMobile }, use) => {
     await use(new NewPoolModalPage(page, isMobile));

--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -179,7 +179,7 @@ export async function assignRackToBuilding(
   buildingName: string,
   buildingId: bigint,
 ) {
-  await test.step("Move the rack into the building from the racks tab", async () => {
+  await test.step(`Assign rack to building "${buildingName}" from the racks tab`, async () => {
     const requestPromise = page.waitForRequest(new RegExp(ASSIGN_RACKS_TO_BUILDING));
     const responsePromise = page.waitForResponse(new RegExp(ASSIGN_RACKS_TO_BUILDING));
 
@@ -193,6 +193,32 @@ export async function assignRackToBuilding(
     };
 
     test.expect(String(body.targetBuildingId)).toBe(buildingId.toString());
+    test.expect(body.racks).toHaveLength(1);
+    test.expect(String(body.racks[0]?.rackId)).toBe(rackId.toString());
+    test.expect(response.status()).toBe(200);
+  });
+}
+
+export async function removeRackFromBuilding(
+  page: Page,
+  fleetLocationsPage: FleetLocationsPage,
+  buildingName: string,
+  rackId: bigint,
+) {
+  await test.step(`Remove rack from building "${buildingName}" from the buildings tab`, async () => {
+    const requestPromise = page.waitForRequest(new RegExp(ASSIGN_RACKS_TO_BUILDING));
+    const responsePromise = page.waitForResponse(new RegExp(ASSIGN_RACKS_TO_BUILDING));
+
+    await fleetLocationsPage.removeRackFromBuilding(buildingName, rackId);
+
+    const request = await requestPromise;
+    const response = await responsePromise;
+    const body = request.postDataJSON() as {
+      targetBuildingId?: string;
+      racks: Array<{ rackId?: string }>;
+    };
+
+    test.expect(body.targetBuildingId).toBeUndefined();
     test.expect(body.racks).toHaveLength(1);
     test.expect(String(body.racks[0]?.rackId)).toBe(rackId.toString());
     test.expect(response.status()).toBe(200);
@@ -214,28 +240,93 @@ export async function validateBuildingPlacementAcrossTabs({
   scenario: BuildingsScenarioData;
   selectedMinerIps: string[];
 }) {
-  await test.step("Validate the sites tab shows the correct counts", async () => {
-    await fleetLocationsPage.validateSiteRowCounts(scenario.siteName, {
+  await validateSiteAndBuildingCounts(fleetLocationsPage, {
+    siteName: scenario.siteName,
+    siteCounts: {
       buildings: 1,
       racks: 1,
       miners: 2,
-    });
+    },
+    buildings: [
+      {
+        buildingName: scenario.buildingName,
+        racks: 1,
+        miners: 2,
+      },
+    ],
+  });
+
+  await validateRackAndMinerPlacementAcrossTabs({
+    page,
+    minersPage,
+    racksPage,
+    siteName: scenario.siteName,
+    buildingName: scenario.buildingName,
+    rackLabel: scenario.rackLabel,
+    selectedMinerIps,
+  });
+}
+
+export async function validateSiteAndBuildingCounts(
+  fleetLocationsPage: FleetLocationsPage,
+  {
+    siteName,
+    siteCounts,
+    buildings,
+  }: {
+    siteName: string;
+    siteCounts: {
+      buildings: number;
+      racks: number;
+      miners: number;
+    };
+    buildings: Array<{
+      buildingName: string;
+      racks: number;
+      miners: number;
+    }>;
+  },
+) {
+  await test.step("Validate the sites tab shows the correct counts", async () => {
+    await fleetLocationsPage.validateSiteRowCounts(siteName, siteCounts);
   });
 
   await test.step("Validate the buildings tab shows the correct counts", async () => {
-    await fleetLocationsPage.validateBuildingRowCounts(scenario.buildingName, {
-      siteName: scenario.siteName,
-      racks: 1,
-      miners: 2,
-    });
+    for (const building of buildings) {
+      await fleetLocationsPage.validateBuildingRowCounts(building.buildingName, {
+        siteName,
+        racks: building.racks,
+        miners: building.miners,
+      });
+    }
   });
+}
+
+export async function validateRackAndMinerPlacementAcrossTabs({
+  page,
+  minersPage,
+  racksPage,
+  siteName,
+  buildingName,
+  rackLabel,
+  selectedMinerIps,
+}: {
+  page: Page;
+  minersPage: MinersPage;
+  racksPage: RacksPage;
+  siteName: string;
+  buildingName?: string;
+  rackLabel: string;
+  selectedMinerIps: string[];
+}) {
+  const expectedBuildingName = buildingName ?? "";
 
   await test.step("Validate the racks tab shows the building placement", async () => {
     await racksPage.navigateToRacksPage();
     await racksPage.clickViewList();
     await racksPage.waitForRackListToLoad({ allowEmpty: false });
-    await racksPage.validateRackRow(scenario.rackLabel, TEMP_ZONE, 2);
-    await racksPage.validateRackPlacementRow(scenario.rackLabel, scenario.siteName, scenario.buildingName);
+    await racksPage.validateRackMinerCount(rackLabel, 2);
+    await racksPage.validateRackPlacementRow(rackLabel, siteName, expectedBuildingName);
   });
 
   await test.step("Validate the miners tab shows the building placement for both miners", async () => {
@@ -244,9 +335,9 @@ export async function validateBuildingPlacementAcrossTabs({
     await minersPage.waitForMinersListToLoad();
 
     for (const ipAddress of selectedMinerIps) {
-      test.expect(await minersPage.getMinerColumnText(ipAddress, "site")).toBe(scenario.siteName);
-      test.expect(await minersPage.getMinerColumnText(ipAddress, "building")).toBe(scenario.buildingName);
-      test.expect(await minersPage.getMinerColumnText(ipAddress, "rack")).toBe(scenario.rackLabel);
+      test.expect(await minersPage.getMinerColumnText(ipAddress, "site")).toBe(siteName);
+      test.expect(await minersPage.getMinerColumnText(ipAddress, "building")).toBe(expectedBuildingName);
+      test.expect(await minersPage.getMinerColumnText(ipAddress, "rack")).toBe(rackLabel);
     }
   });
 }

--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -1,0 +1,252 @@
+import { type Browser, type Page, type TestInfo } from "@playwright/test";
+import { testConfig } from "../config/test.config";
+import { test } from "../fixtures/pageFixtures";
+import { AuthPage } from "../pages/auth";
+import { FleetLocationsPage } from "../pages/fleetLocations";
+import { MinersPage } from "../pages/miners";
+import { RacksPage } from "../pages/racks";
+import { CommonSteps } from "./commonSteps";
+import { addSelectableMinersToSlots } from "./racksHelpers";
+import { generateRandomText } from "./testDataHelper";
+
+const ASSIGN_RACKS_TO_BUILDING = "AssignRacksToBuilding";
+const AUTOMATION_SITE_PREFIX = "automation_buildings_site";
+const AUTOMATION_BUILDING_PREFIX = "automation_buildings_building";
+const AUTOMATION_RACK_PREFIX = "automation_buildings_rack";
+const TEMP_ZONE = "AutomationBuildingsZone";
+const RACK_COLUMNS = 2;
+const RACK_ROWS = 2;
+const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
+
+type BuildingsCleanupFleetLocationsPage = Pick<
+  FleetLocationsPage,
+  "deleteBuildingByNameIfVisible" | "deleteSiteByNameIfVisible" | "listBuildingNames" | "listSiteNames"
+>;
+
+type BuildingsCleanupRacksPage = Pick<
+  RacksPage,
+  | "clickViewList"
+  | "deleteRackByLabelIfVisible"
+  | "listRackNames"
+  | "navigateToRacksPage"
+  | "tryAction"
+  | "waitForRackListToLoad"
+>;
+
+export type BuildingsScenarioData = {
+  siteName: string;
+  buildingName: string;
+  rackLabel: string;
+};
+
+export function createBuildingsScenarioData(): BuildingsScenarioData {
+  return {
+    siteName: generateRandomText(AUTOMATION_SITE_PREFIX),
+    buildingName: generateRandomText(AUTOMATION_BUILDING_PREFIX),
+    rackLabel: generateRandomText(AUTOMATION_RACK_PREFIX),
+  };
+}
+
+async function installAllSitesInitScript(page: Page) {
+  await page.addInitScript(
+    ({ storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          state: {
+            ui: {
+              activeSite: { kind: "all" },
+            },
+          },
+          version: 0,
+        }),
+      );
+    },
+    { storageKey: ACTIVE_SITE_STORAGE_KEY },
+  );
+}
+
+async function cleanupAutomationFixtures(
+  fleetLocationsPage: BuildingsCleanupFleetLocationsPage,
+  racksPage: BuildingsCleanupRacksPage,
+) {
+  await racksPage.navigateToRacksPage();
+  await racksPage.tryAction(() => racksPage.clickViewList());
+  await racksPage.waitForRackListToLoad();
+
+  const rackNames = (await racksPage.listRackNames()).filter((name) => name.startsWith(AUTOMATION_RACK_PREFIX));
+  for (const rackName of rackNames) {
+    await racksPage.deleteRackByLabelIfVisible(rackName);
+  }
+
+  const buildingNames = (await fleetLocationsPage.listBuildingNames()).filter((name) =>
+    name.startsWith(AUTOMATION_BUILDING_PREFIX),
+  );
+  for (const buildingName of buildingNames) {
+    await fleetLocationsPage.deleteBuildingByNameIfVisible(buildingName);
+  }
+
+  const siteNames = (await fleetLocationsPage.listSiteNames()).filter((name) =>
+    name.startsWith(AUTOMATION_SITE_PREFIX),
+  );
+  for (const siteName of siteNames) {
+    await fleetLocationsPage.deleteSiteByNameIfVisible(siteName);
+  }
+}
+
+async function cleanupAutomationBuildings(browser: Browser, testInfo: TestInfo) {
+  const isMobile = testInfo.project.use?.isMobile ?? false;
+  const context = await browser.newContext({
+    baseURL: testConfig.baseUrl,
+    viewport: testInfo.project.use?.viewport,
+  });
+
+  try {
+    const page = await context.newPage();
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+
+    const authPage = new AuthPage(page, isMobile);
+    const minersPage = new MinersPage(page, isMobile);
+    const racksPage = new RacksPage(page, isMobile);
+    const fleetLocationsPage = new FleetLocationsPage(page, isMobile);
+    const commonSteps = new CommonSteps(authPage, minersPage);
+
+    await commonSteps.loginAsAdmin();
+    await cleanupAutomationFixtures(fleetLocationsPage, racksPage);
+  } finally {
+    await context.close();
+  }
+}
+
+export function useBuildingsHooks() {
+  test.beforeEach(async ({ page, commonSteps, fleetLocationsPage, racksPage }) => {
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+    await commonSteps.loginAsAdmin();
+    await cleanupAutomationFixtures(fleetLocationsPage, racksPage);
+  });
+
+  test.afterEach("CLEANUP: Delete automation buildings fixtures", async ({ browser }, testInfo) => {
+    await cleanupAutomationBuildings(browser, testInfo);
+  });
+}
+
+export async function createSiteAndBuilding(
+  fleetLocationsPage: FleetLocationsPage,
+  scenario: BuildingsScenarioData,
+): Promise<number> {
+  return await test.step("Create a site and building", async () => {
+    await fleetLocationsPage.createSite(scenario.siteName);
+    return await fleetLocationsPage.createBuilding(scenario.siteName, scenario.buildingName);
+  });
+}
+
+export async function createRackWithAssignedMiners(
+  racksPage: RacksPage,
+  rackLabel: string,
+): Promise<{ rackId: number; selectedMinerIps: string[] }> {
+  return await test.step("Create a rack with two miners assigned", async () => {
+    await racksPage.navigateToRacksPage();
+    await racksPage.clickAddRackButton();
+    await racksPage.inputZone(TEMP_ZONE);
+    await racksPage.inputRackLabel(rackLabel);
+    await racksPage.enableCustomRackLayout();
+    await racksPage.inputColumns(RACK_COLUMNS);
+    await racksPage.inputRows(RACK_ROWS);
+    await racksPage.clickContinueFromRackSettings();
+
+    const selectedMinerIps = (await addSelectableMinersToSlots(racksPage, 2, [1, 2])).map((miner) => miner.ipAddress);
+    test.expect(selectedMinerIps).toHaveLength(2);
+
+    await racksPage.clickSaveRack();
+    await racksPage.validateRackToast(rackLabel);
+    await racksPage.clickViewList();
+    await racksPage.waitForRackListToLoad({ allowEmpty: false });
+
+    return {
+      rackId: await racksPage.getRackIdByLabel(rackLabel),
+      selectedMinerIps,
+    };
+  });
+}
+
+export async function assignRackToBuilding(
+  page: Page,
+  racksPage: RacksPage,
+  rackLabel: string,
+  rackId: number,
+  buildingName: string,
+  buildingId: number,
+) {
+  await test.step("Move the rack into the building from the racks tab", async () => {
+    const requestPromise = page.waitForRequest(new RegExp(ASSIGN_RACKS_TO_BUILDING));
+    const responsePromise = page.waitForResponse(new RegExp(ASSIGN_RACKS_TO_BUILDING));
+
+    await racksPage.assignRackToBuildingFromList(rackLabel, buildingName);
+
+    const request = await requestPromise;
+    const response = await responsePromise;
+    const body = request.postDataJSON() as {
+      targetBuildingId?: string;
+      racks: Array<{ rackId?: string }>;
+    };
+
+    test.expect(String(body.targetBuildingId)).toBe(buildingId.toString());
+    test.expect(body.racks).toHaveLength(1);
+    test.expect(String(body.racks[0]?.rackId)).toBe(rackId.toString());
+    test.expect(response.status()).toBe(200);
+  });
+}
+
+export async function validateBuildingPlacementAcrossTabs({
+  page,
+  fleetLocationsPage,
+  minersPage,
+  racksPage,
+  scenario,
+  selectedMinerIps,
+}: {
+  page: Page;
+  fleetLocationsPage: FleetLocationsPage;
+  minersPage: MinersPage;
+  racksPage: RacksPage;
+  scenario: BuildingsScenarioData;
+  selectedMinerIps: string[];
+}) {
+  await test.step("Validate the sites tab shows the correct counts", async () => {
+    await fleetLocationsPage.validateSiteRowCounts(scenario.siteName, {
+      buildings: 1,
+      racks: 1,
+      miners: 2,
+    });
+  });
+
+  await test.step("Validate the buildings tab shows the correct counts", async () => {
+    await fleetLocationsPage.validateBuildingRowCounts(scenario.buildingName, {
+      siteName: scenario.siteName,
+      racks: 1,
+      miners: 2,
+    });
+  });
+
+  await test.step("Validate the racks tab shows the building placement", async () => {
+    await racksPage.navigateToRacksPage();
+    await racksPage.clickViewList();
+    await racksPage.waitForRackListToLoad({ allowEmpty: false });
+    await racksPage.validateRackRow(scenario.rackLabel, TEMP_ZONE, 2);
+    await racksPage.validateRackPlacementRow(scenario.rackLabel, scenario.siteName, scenario.buildingName);
+  });
+
+  await test.step("Validate the miners tab shows the building placement for both miners", async () => {
+    await page.goto("/fleet/miners");
+    await minersPage.waitForMinersTitle();
+    await minersPage.waitForMinersListToLoad();
+
+    for (const ipAddress of selectedMinerIps) {
+      test.expect(await minersPage.getMinerColumnText(ipAddress, "site")).toBe(scenario.siteName);
+      test.expect(await minersPage.getMinerColumnText(ipAddress, "building")).toBe(scenario.buildingName);
+      test.expect(await minersPage.getMinerColumnText(ipAddress, "rack")).toBe(scenario.rackLabel);
+    }
+  });
+}

--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -335,9 +335,9 @@ export async function validateRackAndMinerPlacementAcrossTabs({
     await minersPage.waitForMinersListToLoad();
 
     for (const ipAddress of selectedMinerIps) {
-      test.expect(await minersPage.getMinerColumnText(ipAddress, "site")).toBe(siteName);
-      test.expect(await minersPage.getMinerColumnText(ipAddress, "building")).toBe(expectedBuildingName);
-      test.expect(await minersPage.getMinerColumnText(ipAddress, "rack")).toBe(rackLabel);
+      await test.expect.poll(() => minersPage.getMinerColumnText(ipAddress, "site")).toBe(siteName);
+      await test.expect.poll(() => minersPage.getMinerColumnText(ipAddress, "building")).toBe(expectedBuildingName);
+      await test.expect.poll(() => minersPage.getMinerColumnText(ipAddress, "rack")).toBe(rackLabel);
     }
   });
 }

--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -135,7 +135,7 @@ export function useBuildingsHooks() {
 export async function createSiteAndBuilding(
   fleetLocationsPage: FleetLocationsPage,
   scenario: BuildingsScenarioData,
-): Promise<number> {
+): Promise<bigint> {
   return await test.step("Create a site and building", async () => {
     await fleetLocationsPage.createSite(scenario.siteName);
     return await fleetLocationsPage.createBuilding(scenario.siteName, scenario.buildingName);
@@ -145,7 +145,7 @@ export async function createSiteAndBuilding(
 export async function createRackWithAssignedMiners(
   racksPage: RacksPage,
   rackLabel: string,
-): Promise<{ rackId: number; selectedMinerIps: string[] }> {
+): Promise<{ rackId: bigint; selectedMinerIps: string[] }> {
   return await test.step("Create a rack with two miners assigned", async () => {
     await racksPage.navigateToRacksPage();
     await racksPage.clickAddRackButton();
@@ -175,9 +175,9 @@ export async function assignRackToBuilding(
   page: Page,
   racksPage: RacksPage,
   rackLabel: string,
-  rackId: number,
+  rackId: bigint,
   buildingName: string,
-  buildingId: number,
+  buildingId: bigint,
 ) {
   await test.step("Move the rack into the building from the racks tab", async () => {
     const requestPromise = page.waitForRequest(new RegExp(ASSIGN_RACKS_TO_BUILDING));

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -1,0 +1,276 @@
+import { expect } from "@playwright/test";
+import { BasePage } from "./base";
+
+type Scope = "site" | "building";
+
+export class FleetLocationsPage extends BasePage {
+  async navigateToSitesPage() {
+    await this.navigateToFleetPage();
+    await this.page.getByTestId("fleet-tab-sites-activate").click();
+    await expect(this.page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
+    await expect(this.page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
+    await expect(this.page.getByTestId("fleet-sites-page")).toBeVisible();
+    await this.selectAllSitesIfNeeded();
+  }
+
+  async navigateToBuildingsPage() {
+    await this.navigateToSitesPage();
+    await this.page.getByTestId("fleet-tab-buildings-activate").click();
+    await expect(this.page).toHaveURL(/\/fleet\/buildings(?:[?#].*)?$/);
+    await expect(this.page.getByTestId("fleet-buildings-page")).toBeVisible();
+  }
+
+  async createSite(name: string): Promise<bigint> {
+    await this.navigateToSitesPage();
+    await this.clickAddSiteButton();
+    await this.page.getByTestId("site-settings-name-input").fill(name);
+    await this.page.getByTestId("site-settings-modal-continue").click();
+    await this.waitForModalToClose("site-settings-modal");
+
+    const saveSiteButton = this.page.locator('[data-testid="manage-site-modal-save"]:visible');
+    await expect(saveSiteButton).toBeVisible();
+    await saveSiteButton.click();
+    await this.waitForModalToClose("full-screen-two-pane-modal");
+
+    const row = this.getListRowByName(name);
+    await expect(row).toBeVisible();
+    return await this.getScopeIdFromRowName(name, "site");
+  }
+
+  async createBuilding(siteName: string, buildingName: string): Promise<bigint> {
+    await this.navigateToBuildingsPage();
+    await this.clickAddBuildingButton();
+    await this.page.getByTestId("building-settings-site-select").click();
+    await this.page.getByRole("option", { name: siteName, exact: true }).click();
+    await this.page.getByTestId("building-settings-name-input").fill(buildingName);
+    await this.page.getByTestId("building-settings-modal-save").click();
+
+    await expect(this.page.getByTestId("building-settings-modal")).toHaveCount(0);
+
+    const fullScreenModal = this.page.getByTestId("full-screen-two-pane-modal");
+    if (await fullScreenModal.isVisible().catch(() => false)) {
+      await fullScreenModal.getByTestId("header-icon-button").click();
+      await expect(fullScreenModal).toHaveCount(0);
+    }
+
+    const row = this.getListRowByName(buildingName);
+    await expect(row).toBeVisible();
+    return await this.getScopeIdFromRowName(buildingName, "building");
+  }
+
+  async deleteSite(name: string) {
+    await this.navigateToSitesPage();
+    await this.openRowActions(name);
+    await this.clickRowAction("Edit site");
+    await this.clickManageSiteDelete();
+
+    const confirmDeleteButton = this.page.getByTestId("site-delete-dialog-confirm");
+    await expect(confirmDeleteButton).toBeVisible();
+    await confirmDeleteButton.click({ trial: true });
+    await confirmDeleteButton.click();
+    await expect(this.getListRowByName(name)).toHaveCount(0);
+  }
+
+  async deleteBuilding(name: string) {
+    await this.navigateToBuildingsPage();
+    await this.openRowActions(name);
+    await this.clickRowAction("Edit building");
+    await this.clickManageBuildingDelete();
+
+    const confirmDeleteButton = this.page.getByTestId("building-delete-dialog-confirm");
+    await expect(confirmDeleteButton).toBeVisible();
+    await confirmDeleteButton.click({ trial: true });
+    await confirmDeleteButton.click();
+    await expect(this.getListRowByName(name)).toHaveCount(0);
+  }
+
+  async deleteSiteByNameIfVisible(name: string) {
+    await this.navigateToSitesPage();
+    if (
+      !(await this.getListRowByName(name)
+        .isVisible()
+        .catch(() => false))
+    ) {
+      return;
+    }
+
+    await this.deleteSite(name);
+  }
+
+  async deleteBuildingByNameIfVisible(name: string) {
+    await this.navigateToBuildingsPage();
+    if (
+      !(await this.getListRowByName(name)
+        .isVisible()
+        .catch(() => false))
+    ) {
+      return;
+    }
+
+    await this.deleteBuilding(name);
+  }
+
+  async listSiteNames(): Promise<string[]> {
+    await this.navigateToSitesPage();
+    return await this.listVisibleRowNames();
+  }
+
+  async listBuildingNames(): Promise<string[]> {
+    await this.navigateToBuildingsPage();
+    return await this.listVisibleRowNames();
+  }
+
+  async validateSiteRowCounts(
+    siteName: string,
+    expected: {
+      buildings: number;
+      racks: number;
+      miners: number;
+    },
+  ) {
+    await this.navigateToSitesPage();
+    const row = this.getListRowByName(siteName);
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("buildings")).toHaveText(String(expected.buildings));
+    await expect(row.getByTestId("racks")).toHaveText(String(expected.racks));
+    await expect(row.getByTestId("miners")).toHaveText(String(expected.miners));
+  }
+
+  async validateBuildingRowCounts(
+    buildingName: string,
+    expected: {
+      siteName: string;
+      racks: number;
+      miners: number;
+    },
+  ) {
+    await this.navigateToBuildingsPage();
+    const row = this.getListRowByName(buildingName);
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("site")).toHaveText(expected.siteName);
+    await expect(row.getByTestId("racks")).toHaveText(String(expected.racks));
+    await expect(row.getByTestId("miners")).toHaveText(String(expected.miners));
+  }
+
+  private getListRowByName(name: string) {
+    return this.page
+      .getByTestId("list-row")
+      .filter({ has: this.page.getByTestId("name").getByText(name, { exact: true }) })
+      .first();
+  }
+
+  private async listVisibleRowNames(): Promise<string[]> {
+    const nameCells = this.page.getByTestId("list-row").getByTestId("name");
+    const count = await nameCells.count();
+    const names: string[] = [];
+
+    for (let i = 0; i < count; i++) {
+      names.push((await nameCells.nth(i).innerText()).trim());
+    }
+
+    return names;
+  }
+
+  private async selectAllSitesIfNeeded() {
+    const sitePickerTrigger = this.page.getByTestId("site-picker-trigger");
+    if (!(await sitePickerTrigger.isVisible().catch(() => false))) {
+      await expect(this.page.getByTestId("fleet-sites-page")).toBeVisible();
+      return;
+    }
+
+    const currentLabel = (await sitePickerTrigger.textContent())?.trim();
+    if (currentLabel === "All sites") {
+      return;
+    }
+
+    await sitePickerTrigger.click();
+    const allSitesOption = this.page.getByTestId("site-picker-option-all");
+    await expect(allSitesOption).toBeVisible();
+    await allSitesOption.click();
+    await expect(sitePickerTrigger).toContainText("All sites");
+  }
+
+  private async clickAddSiteButton() {
+    const headerAddSiteButton = this.page.getByTestId("fleet-sites-add");
+    if (await headerAddSiteButton.isVisible().catch(() => false)) {
+      await headerAddSiteButton.click();
+      return;
+    }
+
+    const emptyStateAddSiteButton = this.page.getByRole("button", { name: "Add a site", exact: true });
+    await expect(emptyStateAddSiteButton).toBeVisible();
+    await emptyStateAddSiteButton.click();
+  }
+
+  private async clickAddBuildingButton() {
+    const headerAddBuildingButton = this.page.getByTestId("fleet-buildings-add");
+    if (await headerAddBuildingButton.isVisible().catch(() => false)) {
+      await headerAddBuildingButton.click();
+      return;
+    }
+
+    const emptyStateAddBuildingButton = this.page.getByRole("button", { name: "Add building", exact: true });
+    await expect(emptyStateAddBuildingButton).toBeVisible();
+    await emptyStateAddBuildingButton.click();
+  }
+
+  private async clickManageSiteDelete() {
+    const manageSiteDeleteButton = this.page.locator('[data-testid="manage-site-modal-delete"]:visible');
+    if (await manageSiteDeleteButton.isVisible().catch(() => false)) {
+      await manageSiteDeleteButton.click();
+      return;
+    }
+
+    const overflowMenu = await this.openFullScreenOverflowMenu();
+    await overflowMenu.getByText("Delete site", { exact: true }).click();
+  }
+
+  private async clickManageBuildingDelete() {
+    const deleteButton = this.page.locator('[data-testid="manage-building-delete"]:visible');
+    if (await deleteButton.isVisible().catch(() => false)) {
+      await deleteButton.click();
+      return;
+    }
+
+    const overflowMenu = await this.openFullScreenOverflowMenu();
+    await overflowMenu.getByText("Delete building", { exact: true }).click();
+  }
+
+  private async openFullScreenOverflowMenu() {
+    const overflowTrigger = this.page.getByTestId("full-screen-two-pane-modal").getByTestId("overflow-menu-trigger");
+    await expect(overflowTrigger).toBeVisible();
+    await overflowTrigger.click();
+    return this.page.locator("div.fixed.inset-0.z-60");
+  }
+
+  private async waitForModalToClose(testId: string) {
+    await expect(this.page.getByTestId(testId)).toHaveCount(0);
+  }
+
+  private async openRowActions(name: string) {
+    const row = this.getListRowByName(name);
+    await expect(row).toBeVisible();
+    await row.locator('button[data-testid$="-actions-trigger"]').first().click();
+  }
+
+  private async clickRowAction(label: string) {
+    await this.page.getByText(label, { exact: true }).click();
+  }
+
+  private async getScopeIdFromRowName(name: string, scope: Scope): Promise<bigint> {
+    const row = this.getListRowByName(name);
+    await expect(row).toBeVisible();
+
+    const trigger = row.locator('button[data-testid$="-actions-trigger"]').first();
+    await expect(trigger).toBeVisible();
+
+    const testId = await trigger.getAttribute("data-testid");
+    const capturedId = testId?.match(new RegExp(`^${scope}-list-row-(\\d+)-actions-trigger$`))?.[1];
+
+    if (!capturedId) {
+      throw new Error(`Could not parse ${scope} id from row action trigger: ${testId ?? "missing test id"}`);
+    }
+
+    return BigInt(capturedId);
+  }
+}

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -27,7 +27,9 @@ export class FleetLocationsPage extends BasePage {
     await this.page.getByTestId("site-settings-modal-continue").click();
     await this.waitForModalToClose("site-settings-modal");
 
-    const saveSiteButton = this.page.locator('[data-testid="manage-site-modal-save"]:visible');
+    const saveSiteButton = this.page.getByTestId(
+      this.isMobile ? "manage-site-modal-save-mobile" : "manage-site-modal-save",
+    );
     await expect(saveSiteButton).toBeVisible();
     await saveSiteButton.click();
     await this.waitForModalToClose("full-screen-two-pane-modal");
@@ -238,43 +240,42 @@ export class FleetLocationsPage extends BasePage {
   }
 
   private async clickManageSiteDelete() {
-    const manageSiteDeleteButton = this.page.locator('[data-testid="manage-site-modal-delete"]:visible');
-    if (await manageSiteDeleteButton.isVisible().catch(() => false)) {
-      await manageSiteDeleteButton.click();
+    if (!this.isMobile) {
+      await this.page.getByTestId("manage-site-modal-delete").click();
       return;
     }
 
     const overflowMenu = await this.openFullScreenOverflowMenu();
-    await overflowMenu.getByText("Delete site", { exact: true }).click();
+    await overflowMenu.getByTestId("manage-site-modal-delete-overflow-item").click();
   }
 
   private async clickManageBuildingDelete() {
-    const deleteButton = this.page.locator('[data-testid="manage-building-delete"]:visible');
-    if (await deleteButton.isVisible().catch(() => false)) {
-      await deleteButton.click();
+    if (!this.isMobile) {
+      await this.page.getByTestId("manage-building-delete").click();
       return;
     }
 
     const overflowMenu = await this.openFullScreenOverflowMenu();
-    await overflowMenu.getByText("Delete building", { exact: true }).click();
+    await overflowMenu.getByTestId("manage-building-delete-overflow-item").click();
   }
 
   private async clickManageBuildingEditDetails(scope = this.page.getByTestId("full-screen-two-pane-modal")) {
-    const editDetailsButton = scope.locator('button[data-testid="manage-building-edit-details"]:visible');
-    if (await editDetailsButton.isVisible().catch(() => false)) {
-      await editDetailsButton.click();
+    if (!this.isMobile) {
+      await scope.getByTestId("manage-building-edit-details").click();
       return;
     }
 
     const overflowMenu = await this.openFullScreenOverflowMenu();
-    await overflowMenu.getByText("Building settings", { exact: true }).click();
+    await overflowMenu.getByTestId("manage-building-edit-details-overflow-item").click();
   }
 
   private async openFullScreenOverflowMenu() {
     const overflowTrigger = this.page.getByTestId("full-screen-two-pane-modal").getByTestId("overflow-menu-trigger");
     await expect(overflowTrigger).toBeVisible();
     await overflowTrigger.click();
-    return this.page.locator("div.fixed.inset-0.z-60");
+    const overflowMenu = this.page.getByTestId("full-screen-overflow-sheet");
+    await expect(overflowMenu).toBeVisible();
+    return overflowMenu;
   }
 
   private async closeFullScreenModalIfVisible() {
@@ -294,7 +295,7 @@ export class FleetLocationsPage extends BasePage {
   private async openRowActions(name: string) {
     const row = this.getListRowByName(name);
     await expect(row).toBeVisible();
-    await row.locator('button[data-testid$="-actions-trigger"]').first().click();
+    await row.getByRole("button", { name: `Actions for ${name}`, exact: true }).click();
   }
 
   private async clickRowAction(label: string) {
@@ -313,14 +314,14 @@ export class FleetLocationsPage extends BasePage {
     testId: "manage-building-save",
     scope = this.page.getByTestId("full-screen-two-pane-modal"),
   ) {
-    await scope.locator(`button[data-testid="${testId}"]:visible`).click();
+    await scope.getByTestId(this.isMobile ? `${testId}-mobile` : testId).click();
   }
 
   private async getScopeIdFromRowName(name: string, scope: Scope): Promise<bigint> {
     const row = this.getListRowByName(name);
     await expect(row).toBeVisible();
 
-    const trigger = row.locator('button[data-testid$="-actions-trigger"]').first();
+    const trigger = row.getByRole("button", { name: `Actions for ${name}`, exact: true });
     await expect(trigger).toBeVisible();
 
     const testId = await trigger.getAttribute("data-testid");

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -73,8 +73,7 @@ export class FleetLocationsPage extends BasePage {
 
   async deleteBuilding(name: string) {
     await this.navigateToBuildingsPage();
-    await this.openRowActions(name);
-    await this.clickRowAction("Edit building");
+    await this.openManageBuildingFromList(name);
     await this.clickManageBuildingDelete();
 
     const confirmDeleteButton = this.page.getByTestId("building-delete-dialog-confirm");
@@ -82,6 +81,30 @@ export class FleetLocationsPage extends BasePage {
     await confirmDeleteButton.click({ trial: true });
     await confirmDeleteButton.click();
     await expect(this.getListRowByName(name)).toHaveCount(0);
+  }
+
+  async renameBuilding(currentName: string, nextName: string) {
+    await this.navigateToBuildingsPage();
+    const fullScreenModal = await this.openManageBuildingFromList(currentName);
+    await this.clickManageBuildingEditDetails(fullScreenModal);
+
+    const settingsModal = this.page.getByTestId("building-settings-modal");
+    await expect(settingsModal).toBeVisible();
+    await settingsModal.getByTestId("building-settings-name-input").fill(nextName);
+    await settingsModal.getByTestId("building-settings-modal-save").click();
+    await this.waitForModalToClose("building-settings-modal");
+
+    await this.closeFullScreenModalIfVisible();
+    await expect(this.getListRowByName(nextName)).toBeVisible();
+    await expect(this.getListRowByName(currentName)).toHaveCount(0);
+  }
+
+  async removeRackFromBuilding(buildingName: string, rackId: bigint) {
+    await this.navigateToBuildingsPage();
+    const fullScreenModal = await this.openManageBuildingFromList(buildingName);
+    await fullScreenModal.getByTestId(`manage-building-remove-rack-${rackId.toString()}`).click();
+    await this.clickVisibleManageBuildingAction("manage-building-save", fullScreenModal);
+    await this.waitForModalToClose("full-screen-two-pane-modal");
   }
 
   async deleteSiteByNameIfVisible(name: string) {
@@ -236,11 +259,32 @@ export class FleetLocationsPage extends BasePage {
     await overflowMenu.getByText("Delete building", { exact: true }).click();
   }
 
+  private async clickManageBuildingEditDetails(scope = this.page.getByTestId("full-screen-two-pane-modal")) {
+    const editDetailsButton = scope.locator('button[data-testid="manage-building-edit-details"]:visible');
+    if (await editDetailsButton.isVisible().catch(() => false)) {
+      await editDetailsButton.click();
+      return;
+    }
+
+    const overflowMenu = await this.openFullScreenOverflowMenu();
+    await overflowMenu.getByText("Building settings", { exact: true }).click();
+  }
+
   private async openFullScreenOverflowMenu() {
     const overflowTrigger = this.page.getByTestId("full-screen-two-pane-modal").getByTestId("overflow-menu-trigger");
     await expect(overflowTrigger).toBeVisible();
     await overflowTrigger.click();
     return this.page.locator("div.fixed.inset-0.z-60");
+  }
+
+  private async closeFullScreenModalIfVisible() {
+    const fullScreenModal = this.page.getByTestId("full-screen-two-pane-modal");
+    if (!(await fullScreenModal.isVisible().catch(() => false))) {
+      return;
+    }
+
+    await fullScreenModal.getByTestId("header-icon-button").click();
+    await expect(fullScreenModal).toHaveCount(0);
   }
 
   private async waitForModalToClose(testId: string) {
@@ -255,6 +299,21 @@ export class FleetLocationsPage extends BasePage {
 
   private async clickRowAction(label: string) {
     await this.page.getByText(label, { exact: true }).click();
+  }
+
+  private async openManageBuildingFromList(name: string) {
+    await this.openRowActions(name);
+    await this.clickRowAction("Edit building");
+    const fullScreenModal = this.page.getByTestId("full-screen-two-pane-modal");
+    await expect(fullScreenModal).toBeVisible();
+    return fullScreenModal;
+  }
+
+  private async clickVisibleManageBuildingAction(
+    testId: "manage-building-save",
+    scope = this.page.getByTestId("full-screen-two-pane-modal"),
+  ) {
+    await scope.locator(`button[data-testid="${testId}"]:visible`).click();
   }
 
   private async getScopeIdFromRowName(name: string, scope: Scope): Promise<bigint> {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -201,6 +201,15 @@ export class MinersPage extends BasePage {
     await expect(columnLocator).toHaveText(expectedValue);
   }
 
+  async getMinerColumnText(ipAddress: string, columnTestId: string): Promise<string | undefined> {
+    const minerRow = await this.getMinerRowByIp(ipAddress);
+    const text = await minerRow
+      .getByTestId(columnTestId)
+      .textContent()
+      .catch(() => null);
+    return text?.trim() || undefined;
+  }
+
   async validateMinerIcon(minerIp: string, columnTestId: string, iconId: IssueIconId) {
     const minerRow = await this.getMinerRowByIp(minerIp);
     const columnLocator = minerRow.locator(`//td[@data-testid='${columnTestId}']`);

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -201,13 +201,13 @@ export class MinersPage extends BasePage {
     await expect(columnLocator).toHaveText(expectedValue);
   }
 
-  async getMinerColumnText(ipAddress: string, columnTestId: string): Promise<string | undefined> {
+  async getMinerColumnText(ipAddress: string, columnTestId: string): Promise<string> {
     const minerRow = await this.getMinerRowByIp(ipAddress);
     const text = await minerRow
       .getByTestId(columnTestId)
       .textContent()
       .catch(() => null);
-    return text?.trim() || undefined;
+    return text?.trim() ?? "";
   }
 
   async validateMinerIcon(minerIp: string, columnTestId: string, iconId: IssueIconId) {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -393,7 +393,7 @@ export class MinersPage extends BasePage {
   }
 
   async clickBulkWorkerNameSave() {
-    await this.page.locator('[data-testid="bulk-worker-name-save-button"]:visible').click();
+    await this.bulkWorkerNameSaveButton().click();
   }
 
   async validateBulkWorkerNameModalOpened() {
@@ -401,7 +401,7 @@ export class MinersPage extends BasePage {
   }
 
   async validateBulkWorkerNameSaveLabel(expectedLabel: string) {
-    await expect(this.page.locator('[data-testid="bulk-worker-name-save-button"]:visible')).toHaveText(expectedLabel);
+    await expect(this.bulkWorkerNameSaveButton()).toHaveText(expectedLabel);
   }
 
   async closeBulkWorkerNameModal() {
@@ -740,7 +740,7 @@ export class MinersPage extends BasePage {
   }
 
   async clickBulkRenameSave() {
-    await this.page.getByTestId("bulk-rename-save-button").filter({ visible: true }).click();
+    await this.bulkRenameSaveButton().click();
   }
 
   async selectBulkRenameSeparator(separatorId: string) {
@@ -1267,6 +1267,16 @@ export class MinersPage extends BasePage {
 
   private kebabPopover(): Locator {
     return this.page.getByTestId("fleet-view-tabs-kebab-popover");
+  }
+
+  private bulkWorkerNameSaveButton(): Locator {
+    return this.page.getByTestId(
+      this.isMobile ? "bulk-worker-name-save-button-mobile" : "bulk-worker-name-save-button",
+    );
+  }
+
+  private bulkRenameSaveButton(): Locator {
+    return this.page.getByTestId(this.isMobile ? "bulk-rename-save-button-mobile" : "bulk-rename-save-button");
   }
 
   private async openViewsPopover() {

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -481,10 +481,55 @@ export class RacksPage extends BasePage {
     await expect(row.getByTestId("miners")).toHaveText(String(miners));
   }
 
+  async validateRackPlacementRow(label: string, siteName: string, buildingName: string) {
+    const row = this.getRackListRow(label);
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("site")).toHaveText(siteName);
+    await expect(row.getByTestId("building")).toHaveText(buildingName);
+  }
+
   async openRackFromList(label: string) {
     const row = this.getRackListRow(label);
     await expect(row).toBeVisible();
     await row.getByTestId("name").getByRole("button", { name: label, exact: true }).click();
+  }
+
+  async getRackIdByLabel(label: string): Promise<bigint> {
+    const row = this.getRackListRow(label);
+    await expect(row).toBeVisible();
+
+    const trigger = row.locator('button[data-testid$="-actions-trigger"]').first();
+    await expect(trigger).toBeVisible();
+
+    const testId = await trigger.getAttribute("data-testid");
+    const capturedId = testId?.match(/^rack-list-row-(\d+)-actions-trigger$/)?.[1];
+    if (!capturedId) {
+      throw new Error(`Could not parse rack id from row action trigger: ${testId ?? "missing test id"}`);
+    }
+
+    return BigInt(capturedId);
+  }
+
+  async assignRackToBuildingFromList(label: string, buildingName: string) {
+    await this.navigateToRacksPage();
+    await this.clickViewList();
+    await this.waitForRackListToLoad({ allowEmpty: false });
+    await this.openRackActionsFromList(label);
+    await this.page.getByText("Add to building", { exact: true }).click();
+    await this.selectParentPickerTarget(buildingName);
+  }
+
+  async deleteRackByLabelIfVisible(label: string) {
+    await this.navigateToRacksPage();
+    await this.tryAction(() => this.clickViewList());
+    if (!(await this.tryAction(() => this.openRackFromList(label)))) {
+      return;
+    }
+
+    await this.clickEditRack();
+    await this.clickDeleteRack();
+    await this.clickDeleteConfirm();
+    await this.tryAction(() => this.validateRackDeletedToast());
   }
 
   async clickEditRack() {
@@ -632,5 +677,17 @@ export class RacksPage extends BasePage {
       .getByTestId("list-row")
       .filter({ has: this.page.getByTestId("name").getByRole("button", { name: label, exact: true }) })
       .first();
+  }
+
+  private async openRackActionsFromList(label: string) {
+    const row = this.getRackListRow(label);
+    await expect(row).toBeVisible();
+    await row.locator('button[data-testid$="-actions-trigger"]').first().click();
+  }
+
+  private async selectParentPickerTarget(label: string) {
+    const modal = this.page.getByTestId("modal");
+    await modal.getByText(label, { exact: true }).click();
+    await modal.getByRole("button", { name: "Save", exact: true }).click();
   }
 }

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -504,7 +504,7 @@ export class RacksPage extends BasePage {
     const row = this.getRackListRow(label);
     await expect(row).toBeVisible();
 
-    const trigger = row.locator('button[data-testid$="-actions-trigger"]').first();
+    const trigger = row.getByRole("button", { name: `Actions for ${label}`, exact: true });
     await expect(trigger).toBeVisible();
 
     const testId = await trigger.getAttribute("data-testid");
@@ -688,12 +688,16 @@ export class RacksPage extends BasePage {
   private async openRackActionsFromList(label: string) {
     const row = this.getRackListRow(label);
     await expect(row).toBeVisible();
-    await row.locator('button[data-testid$="-actions-trigger"]').first().click();
+    await row.getByRole("button", { name: `Actions for ${label}`, exact: true }).click();
   }
 
   private async selectParentPickerTarget(label: string) {
     const modal = this.page.getByTestId("modal");
+    await expect(modal).toBeVisible();
     await modal.getByText(label, { exact: true }).click();
-    await modal.getByRole("button", { name: "Save", exact: true }).click();
+    const saveButton = modal.getByRole("button", { name: "Save", exact: true });
+    await expect(saveButton).toBeVisible();
+    await saveButton.click();
+    await expect(modal).toHaveCount(0);
   }
 }

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -481,7 +481,13 @@ export class RacksPage extends BasePage {
     await expect(row.getByTestId("miners")).toHaveText(String(miners));
   }
 
-  async validateRackPlacementRow(label: string, siteName: string, buildingName: string) {
+  async validateRackMinerCount(label: string, miners: number) {
+    const row = this.getRackListRow(label);
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("miners")).toHaveText(String(miners));
+  }
+
+  async validateRackPlacementRow(label: string, siteName: string, buildingName = "") {
     const row = this.getRackListRow(label);
     await expect(row).toBeVisible();
     await expect(row.getByTestId("site")).toHaveText(siteName);

--- a/client/e2eTests/protoFleet/spec/buildings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/buildings.spec.ts
@@ -4,8 +4,11 @@ import {
   createBuildingsScenarioData,
   createRackWithAssignedMiners,
   createSiteAndBuilding,
+  removeRackFromBuilding,
   useBuildingsHooks,
   validateBuildingPlacementAcrossTabs,
+  validateRackAndMinerPlacementAcrossTabs,
+  validateSiteAndBuildingCounts,
 } from "../helpers/buildingsTestSetup";
 
 test.describe("Buildings", () => {
@@ -28,6 +31,137 @@ test.describe("Buildings", () => {
       minersPage,
       racksPage,
       scenario,
+      selectedMinerIps,
+    });
+  });
+
+  test("Move a rack between buildings and then unassign it", async ({
+    page,
+    fleetLocationsPage,
+    minersPage,
+    racksPage,
+  }) => {
+    const siteName = createBuildingsScenarioData().siteName;
+    const buildingA = createBuildingsScenarioData().buildingName;
+    const buildingB = createBuildingsScenarioData().buildingName;
+    const rackLabel = createBuildingsScenarioData().rackLabel;
+
+    await fleetLocationsPage.createSite(siteName);
+    const buildingAId = await fleetLocationsPage.createBuilding(siteName, buildingA);
+    const buildingBId = await fleetLocationsPage.createBuilding(siteName, buildingB);
+    const { rackId, selectedMinerIps } = await createRackWithAssignedMiners(racksPage, rackLabel);
+
+    await assignRackToBuilding(page, racksPage, rackLabel, rackId, buildingA, buildingAId);
+    await assignRackToBuilding(page, racksPage, rackLabel, rackId, buildingB, buildingBId);
+
+    await validateSiteAndBuildingCounts(fleetLocationsPage, {
+      siteName,
+      siteCounts: {
+        buildings: 2,
+        racks: 1,
+        miners: 2,
+      },
+      buildings: [
+        { buildingName: buildingA, racks: 0, miners: 0 },
+        { buildingName: buildingB, racks: 1, miners: 2 },
+      ],
+    });
+    await validateRackAndMinerPlacementAcrossTabs({
+      page,
+      minersPage,
+      racksPage,
+      siteName,
+      buildingName: buildingB,
+      rackLabel,
+      selectedMinerIps,
+    });
+
+    await removeRackFromBuilding(page, fleetLocationsPage, buildingB, rackId);
+
+    await validateSiteAndBuildingCounts(fleetLocationsPage, {
+      siteName,
+      siteCounts: {
+        buildings: 2,
+        racks: 1,
+        miners: 2,
+      },
+      buildings: [
+        { buildingName: buildingA, racks: 0, miners: 0 },
+        { buildingName: buildingB, racks: 0, miners: 0 },
+      ],
+    });
+    await validateRackAndMinerPlacementAcrossTabs({
+      page,
+      minersPage,
+      racksPage,
+      siteName,
+      rackLabel,
+      selectedMinerIps,
+    });
+  });
+
+  test("Rename a building and propagate the new name across fleet tabs", async ({
+    page,
+    fleetLocationsPage,
+    minersPage,
+    racksPage,
+  }) => {
+    const scenario = createBuildingsScenarioData();
+    const renamedBuilding = createBuildingsScenarioData().buildingName;
+    const buildingId = await createSiteAndBuilding(fleetLocationsPage, scenario);
+    const { rackId, selectedMinerIps } = await createRackWithAssignedMiners(racksPage, scenario.rackLabel);
+
+    await assignRackToBuilding(page, racksPage, scenario.rackLabel, rackId, scenario.buildingName, buildingId);
+    await fleetLocationsPage.renameBuilding(scenario.buildingName, renamedBuilding);
+
+    await validateSiteAndBuildingCounts(fleetLocationsPage, {
+      siteName: scenario.siteName,
+      siteCounts: {
+        buildings: 1,
+        racks: 1,
+        miners: 2,
+      },
+      buildings: [{ buildingName: renamedBuilding, racks: 1, miners: 2 }],
+    });
+    await validateRackAndMinerPlacementAcrossTabs({
+      page,
+      minersPage,
+      racksPage,
+      siteName: scenario.siteName,
+      buildingName: renamedBuilding,
+      rackLabel: scenario.rackLabel,
+      selectedMinerIps,
+    });
+  });
+
+  test("Delete a building with an assigned rack and keep the rack on the site", async ({
+    page,
+    fleetLocationsPage,
+    minersPage,
+    racksPage,
+  }) => {
+    const scenario = createBuildingsScenarioData();
+    const buildingId = await createSiteAndBuilding(fleetLocationsPage, scenario);
+    const { rackId, selectedMinerIps } = await createRackWithAssignedMiners(racksPage, scenario.rackLabel);
+
+    await assignRackToBuilding(page, racksPage, scenario.rackLabel, rackId, scenario.buildingName, buildingId);
+    await fleetLocationsPage.deleteBuilding(scenario.buildingName);
+
+    await validateSiteAndBuildingCounts(fleetLocationsPage, {
+      siteName: scenario.siteName,
+      siteCounts: {
+        buildings: 0,
+        racks: 1,
+        miners: 2,
+      },
+      buildings: [],
+    });
+    await validateRackAndMinerPlacementAcrossTabs({
+      page,
+      minersPage,
+      racksPage,
+      siteName: scenario.siteName,
+      rackLabel: scenario.rackLabel,
       selectedMinerIps,
     });
   });

--- a/client/e2eTests/protoFleet/spec/buildings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/buildings.spec.ts
@@ -1,0 +1,34 @@
+import { test } from "../fixtures/pageFixtures";
+import {
+  assignRackToBuilding,
+  createBuildingsScenarioData,
+  createRackWithAssignedMiners,
+  createSiteAndBuilding,
+  useBuildingsHooks,
+  validateBuildingPlacementAcrossTabs,
+} from "../helpers/buildingsTestSetup";
+
+test.describe("Buildings", () => {
+  useBuildingsHooks();
+
+  test("Create a site, building, rack, and miners flow across fleet tabs", async ({
+    page,
+    fleetLocationsPage,
+    minersPage,
+    racksPage,
+  }) => {
+    const scenario = createBuildingsScenarioData();
+    const buildingId = await createSiteAndBuilding(fleetLocationsPage, scenario);
+    const { rackId, selectedMinerIps } = await createRackWithAssignedMiners(racksPage, scenario.rackLabel);
+
+    await assignRackToBuilding(page, racksPage, scenario.rackLabel, rackId, scenario.buildingName, buildingId);
+    await validateBuildingPlacementAcrossTabs({
+      page,
+      fleetLocationsPage,
+      minersPage,
+      racksPage,
+      scenario,
+      selectedMinerIps,
+    });
+  });
+});

--- a/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
+++ b/client/src/protoFleet/components/FullScreenTwoPaneModal/FullScreenTwoPaneModal.tsx
@@ -48,14 +48,16 @@ const OverflowActionSheet = ({ overflowButtons, onClose }: { overflowButtons: Bu
   const dangerItems = overflowButtons.filter((b) => isDangerVariant(b.variant));
 
   return (
-    <div className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-5">
+    <div className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-5" data-testid="full-screen-overflow-sheet">
       <div
         ref={sheetRef}
+        data-testid="full-screen-overflow-sheet-content"
         className="w-full rounded-t-2xl bg-surface-elevated-base px-6 pt-2 pb-[max(env(safe-area-inset-bottom),16px)]"
       >
         {nonDangerItems.map((button, index) => (
           <Row
             key={`${button.text}-${index}`}
+            testId={button.testId ? `${button.testId}-overflow-item` : undefined}
             className={clsx("text-emphasis-300 text-text-primary", button.disabled && "pointer-events-none opacity-40")}
             onClick={
               button.disabled
@@ -76,6 +78,7 @@ const OverflowActionSheet = ({ overflowButtons, onClose }: { overflowButtons: Bu
         {dangerItems.map((button, index) => (
           <Row
             key={`danger-${button.text}-${index}`}
+            testId={button.testId ? `${button.testId}-overflow-item` : undefined}
             className={clsx(
               "text-emphasis-300 text-intent-critical-fill",
               button.disabled && "pointer-events-none opacity-40",
@@ -159,7 +162,10 @@ const FullScreenTwoPaneModal = ({
   }
 
   if (primaryButton) {
-    mobileButtons.push(primaryButton);
+    mobileButtons.push({
+      ...primaryButton,
+      testId: primaryButton.testId ? `${primaryButton.testId}-mobile` : undefined,
+    });
   }
 
   const effectiveOnDismiss = isBusy ? undefined : onDismiss;

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
@@ -60,9 +60,7 @@ describe("ManageSiteModal", () => {
       />,
     );
 
-    // FullScreenTwoPaneModal renders the button twice (laptop + mobile);
-    // click the first instance.
-    fireEvent.click(screen.getAllByTestId("manage-site-modal-save")[0]);
+    fireEvent.click(screen.getByTestId("manage-site-modal-save"));
 
     await waitFor(() => expect(onSave).toHaveBeenCalled());
     await waitFor(() => expect(onDismiss).toHaveBeenCalled());
@@ -85,7 +83,7 @@ describe("ManageSiteModal", () => {
       />,
     );
 
-    expect(screen.getAllByTestId("manage-site-modal-save")[0]).toBeDisabled();
+    expect(screen.getByTestId("manage-site-modal-save")).toBeDisabled();
   });
 
   it("Site settings fires the parent callback", () => {
@@ -144,7 +142,7 @@ describe("ManageSiteModal", () => {
     expect(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]).toBeEnabled();
     expect(screen.getAllByTestId("manage-site-modal-empty-state-add")[0]).toBeEnabled();
     // Save is allowed immediately (creates the site with an empty building set).
-    expect(screen.getAllByTestId("manage-site-modal-save")[0]).toBeEnabled();
+    expect(screen.getByTestId("manage-site-modal-save")).toBeEnabled();
   });
 
   it("shows comma-separated meta on each corner of the preview", () => {


### PR DESCRIPTION
Reviewable diff: +599/-0 across 5 files (excludes generated, test, and story files).

## Summary
This PR adds end-to-end coverage for the new fleet buildings flow in Proto Fleet. The new scenario creates a site, creates a building under that site, creates a rack with two miners, assigns the rack to the building from the racks tab, and then verifies the resulting placement and counts across the sites, buildings, racks, and miners tabs.

It also adds focused page-object and helper support for fleet locations so the spec reads as a short scenario outline rather than a large block of UI mechanics.

## How it works
The test suite now exposes a `fleetLocationsPage` fixture and a dedicated `FleetLocationsPage` page object for the sites and buildings tabs. That page object owns the create, delete, list, and validation flows for sites and buildings, including the current modal behavior after a building is saved.

A shared `buildingsTestSetup` helper installs the "All sites" local-storage state, cleans up automation-created sites, buildings, and racks before and after each run, creates the rack with selected miners, captures the rack-to-building assignment request, and validates the resulting placement across the fleet tabs. The spec itself then just orchestrates the user flow: create site and building, create rack, assign rack, and verify the resulting state.

## Diagrams
```mermaid
flowchart TD
  A["Create site"] --> B["Create building for site"]
  B --> C["Create rack with two miners"]
  C --> D["Assign rack to building from racks tab"]
  D --> E["Assert AssignRacksToBuilding payload"]
  E --> F["Validate sites counts"]
  E --> G["Validate buildings counts"]
  E --> H["Validate rack site/building placement"]
  E --> I["Validate miners site/building/rack columns"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/fixtures/pageFixtures.ts` | Added a `fleetLocationsPage` fixture. | Makes the new fleet locations page object available to specs using the existing fixture pattern. |
| `client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts` | Added buildings-specific setup, cleanup, rack assignment, and cross-tab validation helpers. | Concentrates scenario mechanics and cleanup in one place so the spec stays readable and repeatable. |
| `client/e2eTests/protoFleet/pages/fleetLocations.ts` | Added a page object for the sites and buildings tabs, including create/delete flows and row validations. | This is the main abstraction for the new buildings E2E coverage and contains the modal-handling logic that makes the test deterministic. |
| `client/e2eTests/protoFleet/pages/racks.ts` | Added rack placement validation, rack-id extraction, list-based building assignment, and rack cleanup helpers. | Covers the rack-side interactions that connect racks to buildings and lets the test verify the correct entity was assigned. |
| `client/e2eTests/protoFleet/pages/miners.ts` | Added a helper to read miner column text by row. | Supports direct assertions that miners show the expected site, building, and rack after assignment. |
| `client/e2eTests/protoFleet/spec/buildings.spec.ts` | Added the buildings end-to-end scenario. | Test coverage only; verifies the full user-visible flow end to end. |

## Key technical decisions & trade-offs
- Added a dedicated `FleetLocationsPage` instead of keeping sites/buildings logic inline in the spec so selectors and modal differences stay in one place.
- Added a `buildingsTestSetup` helper instead of top-of-file spec utilities so the scenario remains easy to scan while keeping cleanup deterministic.
- Asserted the `AssignRacksToBuilding` request payload in addition to the UI state so the test catches wrong-entity assignments that could still produce a valid 200 response.
- Cleanup targets automation-prefixed sites, buildings, and racks instead of deleting everything so repeated local and CI runs stay narrow and safer.

## Testing & validation
- `./node_modules/.bin/eslint e2eTests/protoFleet/helpers/buildingsTestSetup.ts e2eTests/protoFleet/spec/buildings.spec.ts e2eTests/protoFleet/fixtures/pageFixtures.ts e2eTests/protoFleet/pages/fleetLocations.ts e2eTests/protoFleet/pages/racks.ts e2eTests/protoFleet/pages/miners.ts`
- `env PW_UI_NO_DEPS=1 ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/buildings.spec.ts --project=desktop --grep "Create a site, building, rack, and miners flow across fleet tabs"`
- `env PW_UI_NO_DEPS=1 ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/buildings.spec.ts --project=desktop`
- `./node_modules/.bin/tsc --noEmit`
- `git push origin codex/proto-fleet-buildings --set-upstream` (server-side `client-typecheck` hook)

Not covered in this PR: additional buildings scenarios beyond the initial happy-path flow.
