### PR TITLE
Prevent large pairing API proxy timeouts

### DIFF
--- a/client/nginx.runner-protofleet.conf
+++ b/client/nginx.runner-protofleet.conf
@@ -8,6 +8,21 @@ server {
     try_files $uri $uri/ /index.html;
   }
 
+  # Pair is a unary RPC that can wait for multiple fleet-node batches before
+  # sending response bytes. Keep the extended timeout scoped to this RPC so
+  # idle server-streaming calls under /api-proxy/ keep the default proxy budget.
+  location = /api-proxy/pairing.v1.PairingService/Pair {
+    proxy_pass http://127.0.0.1:4000/pairing.v1.PairingService/Pair;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+    proxy_read_timeout 75m;
+    proxy_send_timeout 75m;
+    client_max_body_size 64m;
+  }
+
   # Match Vite proxy behavior used by ProtoFleet.
   location /api-proxy/ {
     proxy_pass http://127.0.0.1:4000/;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -112,13 +112,19 @@ export default defineConfig(({ mode, command }) => {
   let proxies;
   if (mode === "protoFleet") {
     const proxyUrl = env.FLEET_PROXY_URL || process.env.FLEET_PROXY_URL || "http://localhost:4000";
+    const apiProxyConfig = {
+      target: proxyUrl,
+      rewrite: (path: string) => path.replace(/^\/api-proxy/, ""),
+      changeOrigin: true,
+      secure: false,
+    };
     proxies = {
-      "/api-proxy": {
-        target: proxyUrl,
-        rewrite: (path: string) => path.replace(/^\/api-proxy/, ""),
-        changeOrigin: true,
-        secure: false,
+      "/api-proxy/pairing.v1.PairingService/Pair": {
+        ...apiProxyConfig,
+        timeout: 4_500_000,
+        proxyTimeout: 4_500_000,
       },
+      "/api-proxy": apiProxyConfig,
     };
   } else {
     // For ProtoOS: Use PROXY_URL from .env file

--- a/deployment-files/client/nginx.http.conf
+++ b/deployment-files/client/nginx.http.conf
@@ -8,6 +8,21 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Pair is a unary RPC that can wait for multiple fleet-node batches before
+    # sending response bytes. Keep the extended timeout scoped to this RPC so
+    # idle server-streaming calls under /api-proxy/ keep the default proxy budget.
+    location = /api-proxy/pairing.v1.PairingService/Pair {
+        proxy_pass http://localhost:4000/pairing.v1.PairingService/Pair;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 75m;
+        proxy_send_timeout 75m;
+        client_max_body_size 64m;
+    }
+
     # For WebSocket/stream support
     location /api-proxy/ {
         proxy_pass http://localhost:4000/;

--- a/deployment-files/client/nginx.https.conf
+++ b/deployment-files/client/nginx.https.conf
@@ -29,6 +29,21 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Pair is a unary RPC that can wait for multiple fleet-node batches before
+    # sending response bytes. Keep the extended timeout scoped to this RPC so
+    # idle server-streaming calls under /api-proxy/ keep the default proxy budget.
+    location = /api-proxy/pairing.v1.PairingService/Pair {
+        proxy_pass http://localhost:4000/pairing.v1.PairingService/Pair;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 75m;
+        proxy_send_timeout 75m;
+        client_max_body_size 64m;
+    }
+
     # For WebSocket/stream support
     location /api-proxy/ {
         proxy_pass http://localhost:4000/;


### PR DESCRIPTION
Reviewable diff: +56/-5 across 4 files (excludes generated, test, and story files).

## Summary
- Prevents large or fleet-node-routed add-miners pairing requests from being cut off by the frontend proxy before the backend Pair RPC returns.
- Gives only the unary `/pairing.v1.PairingService/Pair` proxy path a 75 minute / 4,500,000 ms budget, covering the reported 5,000-miner case where five full 1,024-device batches can each wait up to `PairCommandTimeout = 12 * time.Minute`.
- Keeps the general `/api-proxy/` route on the normal proxy idle budget so server-streaming RPCs do not inherit the long Pair timeout.
- Fixes #569.

## How it works
`PairingService.Pair` is a unary RPC that travels through `/api-proxy/`. For fleet-node-routed Pair requests, the handler can process multiple batches before sending any response bytes: explicit selections are chunked by `MaxPairBatch`, and pair-all requests page through matching devices. Each `PairOnNode` batch can wait up to `PairCommandTimeout` before returning.

This change adds an exact nginx location for `/api-proxy/pairing.v1.PairingService/Pair` and a matching first Vite proxy entry for that path. Those Pair-specific routes use the 75 minute timeout; the catch-all `/api-proxy/` route remains the fallback for streaming and other RPCs without the extended idle window. The PR keeps the Pair API synchronous; a durable async pairing job/progress API remains the structural answer for arbitrarily larger fleets.

```mermaid
flowchart TD
  A["User starts large add-miners pairing"] --> B["/api-proxy/pairing.v1.PairingService/Pair"]
  B --> C["75 minute Pair-only proxy budget"]
  C --> D["fleetd PairingService Pair unary RPC"]
  D --> E["Handler resolves routed fleet-node targets"]
  E --> F["Up to five full 1,024-device batches for the 5,000-miner case"]
  F --> G["Each PairOnNode waits up to 12 minutes"]
  G --> H["Backend returns Pair response"]
  H --> I["UI shows success or partial-success state"]
  J["Other /api-proxy streaming RPCs"] --> K["Default proxy idle budget"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `deployment-files/client/nginx.http.conf` | Adds an exact Pair RPC location with `75m` read/send timeouts; leaves catch-all `/api-proxy/` without extended timeouts. | Covers the HTTP deployment proxy path while avoiding a broad idle window for streaming RPCs. |
| `deployment-files/client/nginx.https.conf` | Same exact Pair RPC location and catch-all behavior for HTTPS. | Keeps HTTPS packaged deployments aligned with HTTP deployments. |
| `client/nginx.runner-protofleet.conf` | Same exact Pair RPC location and catch-all behavior for the runner nginx config. | Keeps the real-miner/runner nginx path aligned with packaged deployment config. |
| `client/vite.config.ts` | Adds a first, Pair-specific dev proxy entry with `4_500_000` ms `timeout`/`proxyTimeout`; the general `/api-proxy` entry remains the fallback. | Keeps local dev behavior aligned with nginx while avoiding long timeouts for streaming dev proxy calls. |

## Key technical decisions & trade-offs
- Scope the long timeout to the Pair unary RPC instead of applying it to all `/api-proxy/` traffic.
- Size the Pair-only budget for the reported 5,000-miner synchronous request instead of only one or two fleet-node batches.
- Keep Pair synchronous in this PR instead of adding an async job/progress API, limiting scope to the proxy timeout failure.

## Testing & validation
- `npm exec -- eslint vite.config.ts --max-warnings 0`
- `npm exec -- tsc --noEmit`
- `docker run --rm -v deployment-files/client/nginx.http.conf:/etc/nginx/conf.d/default.conf:ro nginx:alpine nginx -t`
- `docker run --rm -v client/nginx.runner-protofleet.conf:/etc/nginx/conf.d/default.conf:ro nginx:alpine nginx -t`
- `docker run --rm -v deployment-files/client/nginx.https.conf:/etc/nginx/conf.d/default.conf:ro -v <temp-cert-dir>:/etc/nginx/ssl:ro nginx:alpine nginx -t`

Not covered locally: manual 5,000-miner browser reproduction.
