### PR TITLE
fix: keep bulk action status visible until completion

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -10,7 +10,10 @@ import {
   MinerStateSnapshotSchema,
   PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
-import { PerformanceMode } from "@/protoFleet/api/generated/minercommand/v1/command_pb";
+import {
+  CommandBatchUpdateStatus_CommandBatchUpdateStatusType,
+  PerformanceMode,
+} from "@/protoFleet/api/generated/minercommand/v1/command_pb";
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { Settings } from "@/shared/assets/icons";
 import * as toaster from "@/shared/features/toaster";
@@ -620,6 +623,7 @@ describe("useMinerActions", () => {
       mockStreamCommandBatchUpdates.mockImplementation(({ onStreamData }: any) => {
         onStreamData({
           status: {
+            commandBatchUpdateStatus: CommandBatchUpdateStatus_CommandBatchUpdateStatusType.FINISHED,
             commandBatchDeviceCount: {
               total: BigInt(successIds.length + failureIds.length),
               success: BigInt(successIds.length),
@@ -714,9 +718,55 @@ describe("useMinerActions", () => {
       expect(findRetryCall()).toBeUndefined();
     });
 
+    it("keeps completed counts in progress until the stream reports FINISHED", async () => {
+      let capturedOnStreamData: ((resp: any) => void) | undefined;
+      let capturedAbortController: AbortController | undefined;
+
+      stubActionSuccess(mockBlinkLED, "batch-blink");
+      mockStreamCommandBatchUpdates.mockImplementation(({ onStreamData, streamAbortController }: any) => {
+        capturedOnStreamData = onStreamData;
+        capturedAbortController = streamAbortController;
+        return new Promise<void>((resolve) => {
+          streamAbortController.signal.addEventListener("abort", () => resolve());
+        });
+      });
+
+      const { result } = renderFor(DeviceStatus.ONLINE);
+      const blinkAction = result.current.popoverActions.find((a) => a.action === deviceActions.blinkLEDs);
+
+      await act(async () => {
+        blinkAction?.actionHandler();
+      });
+
+      act(() => {
+        capturedOnStreamData?.({
+          status: {
+            commandBatchUpdateStatus: CommandBatchUpdateStatus_CommandBatchUpdateStatusType.PROCESSING,
+            commandBatchDeviceCount: {
+              total: BigInt(2),
+              success: BigInt(2),
+              failure: BigInt(0),
+              successDeviceIdentifiers: ["device-1", "device-2"],
+              failureDeviceIdentifiers: [],
+            },
+          },
+        });
+      });
+
+      expect(capturedAbortController?.signal.aborted).toBe(false);
+      expect(toaster.updateToast).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({
+          message: "Blinked LEDs 2 out of 2 miners",
+          status: toaster.STATUSES.loading,
+        }),
+      );
+      expect(mockCompleteBatchOperation).not.toHaveBeenCalledWith("batch-blink");
+    });
+
     // L3: all-fail path goes through removeToast(originalToastId) (not update)
     // before attaching Retry. This exercises that branch and confirms Retry is
-    // still offered (streamCompletedNormally is true when 0 + N === N).
+    // still offered when the stream reports a terminal state.
     it("attaches Retry when all devices fail", async () => {
       stubActionSuccess(mockReboot, "batch-reboot");
       stubPartialFailureStream([], ["device-1", "device-2"]);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -812,6 +812,45 @@ describe("useMinerActions", () => {
 
       expect(findRetryCall()).toBeUndefined();
       expect(toaster.pushToast).toHaveBeenCalledWith(expect.objectContaining({ status: toaster.STATUSES.error }));
+      expect(toaster.removeToast).toHaveBeenCalledWith(expect.any(Number));
+      expect(mockRemoveDevicesFromBatch).toHaveBeenCalledWith("batch-reboot", ["device-1"]);
+      expect(mockCompleteBatchOperation).not.toHaveBeenCalledWith("batch-reboot");
+    });
+
+    it("cleans up non-status-changing batches when the stream ends before FINISHED", async () => {
+      stubActionSuccess(mockBlinkLED, "batch-blink");
+      mockStreamCommandBatchUpdates.mockImplementation(({ onStreamData }: any) => {
+        onStreamData({
+          status: {
+            commandBatchUpdateStatus: CommandBatchUpdateStatus_CommandBatchUpdateStatusType.PROCESSING,
+            commandBatchDeviceCount: {
+              total: BigInt(2),
+              success: BigInt(1),
+              failure: BigInt(0),
+              successDeviceIdentifiers: ["device-1"],
+              failureDeviceIdentifiers: [],
+            },
+          },
+        });
+        return Promise.resolve();
+      });
+
+      const { result } = renderFor(DeviceStatus.ONLINE);
+      const blinkAction = result.current.popoverActions.find((a) => a.action === deviceActions.blinkLEDs);
+
+      await act(async () => {
+        blinkAction?.actionHandler();
+      });
+
+      expect(findRetryCall()).toBeUndefined();
+      expect(toaster.updateToast).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({
+          message: "Unable to confirm bulk action completion. Check miner status and try again.",
+          status: toaster.STATUSES.error,
+        }),
+      );
+      expect(mockCompleteBatchOperation).toHaveBeenCalledWith("batch-blink");
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -538,11 +538,15 @@ describe("useMinerActions", () => {
     const readSubsetIdsFromDirectSelector = (mockCall: any) =>
       mockCall[0].deviceSelector.selectionType.value.deviceIdentifiers;
 
-    const runConfirmFlow = (action: SupportedAction) => async (result: RenderHookResult) => {
+    const runPopoverAction = async (result: RenderHookResult, action: SupportedAction) => {
       const popoverAction = result.current.popoverActions.find((a) => a.action === action);
       await act(async () => {
         await popoverAction?.actionHandler();
       });
+    };
+
+    const runConfirmFlow = (action: SupportedAction) => async (result: RenderHookResult) => {
+      await runPopoverAction(result, action);
       await act(async () => {
         await result.current.handleConfirmation();
       });
@@ -589,12 +593,7 @@ describe("useMinerActions", () => {
         batchId: "batch-blink",
         deviceStatus: DeviceStatus.ONLINE,
         mock: mockBlinkLED,
-        dispatch: async (result) => {
-          const popoverAction = result.current.popoverActions.find((a) => a.action === deviceActions.blinkLEDs);
-          await act(async () => {
-            popoverAction?.actionHandler();
-          });
-        },
+        dispatch: (result) => runPopoverAction(result, deviceActions.blinkLEDs),
         getRetryDeviceIdentifiers: readSubsetIdsFromRequestArg("blinkLEDRequest"),
       },
       {
@@ -721,27 +720,57 @@ describe("useMinerActions", () => {
     it("keeps completed counts in progress until the stream reports FINISHED", async () => {
       let capturedOnStreamData: ((resp: any) => void) | undefined;
       let capturedAbortController: AbortController | undefined;
+      let streamSettled: Promise<void> | undefined;
 
       stubActionSuccess(mockBlinkLED, "batch-blink");
       mockStreamCommandBatchUpdates.mockImplementation(({ onStreamData, streamAbortController }: any) => {
         capturedOnStreamData = onStreamData;
         capturedAbortController = streamAbortController;
-        return new Promise<void>((resolve) => {
-          streamAbortController.signal.addEventListener("abort", () => resolve());
+        streamSettled = new Promise<void>((resolve) => {
+          streamAbortController.signal.addEventListener("abort", () => resolve(), { once: true });
         });
+        return streamSettled;
       });
 
       const { result } = renderFor(DeviceStatus.ONLINE);
-      const blinkAction = result.current.popoverActions.find((a) => a.action === deviceActions.blinkLEDs);
+      await runPopoverAction(result, deviceActions.blinkLEDs);
 
-      await act(async () => {
-        blinkAction?.actionHandler();
+      const completeProgressUpdate = {
+        status: {
+          commandBatchUpdateStatus: CommandBatchUpdateStatus_CommandBatchUpdateStatusType.PROCESSING,
+          commandBatchDeviceCount: {
+            total: BigInt(2),
+            success: BigInt(2),
+            failure: BigInt(0),
+            successDeviceIdentifiers: ["device-1", "device-2"],
+            failureDeviceIdentifiers: [],
+          },
+        },
+      };
+
+      act(() => {
+        capturedOnStreamData?.(completeProgressUpdate);
+        capturedOnStreamData?.(completeProgressUpdate);
       });
+
+      expect(capturedAbortController?.signal.aborted).toBe(false);
+      expect(toaster.updateToast).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({
+          message: "Blinked LEDs 2 out of 2 miners",
+          status: toaster.STATUSES.loading,
+        }),
+      );
+      const loadingProgressCalls = (toaster.updateToast as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call) => call[1]?.message === "Blinked LEDs 2 out of 2 miners" && call[1]?.status === toaster.STATUSES.loading,
+      );
+      expect(loadingProgressCalls).toHaveLength(1);
+      expect(mockCompleteBatchOperation).not.toHaveBeenCalledWith("batch-blink");
 
       act(() => {
         capturedOnStreamData?.({
           status: {
-            commandBatchUpdateStatus: CommandBatchUpdateStatus_CommandBatchUpdateStatusType.PROCESSING,
+            commandBatchUpdateStatus: CommandBatchUpdateStatus_CommandBatchUpdateStatusType.FINISHED,
             commandBatchDeviceCount: {
               total: BigInt(2),
               success: BigInt(2),
@@ -753,20 +782,11 @@ describe("useMinerActions", () => {
         });
       });
 
-      expect(capturedAbortController?.signal.aborted).toBe(false);
-      expect(toaster.updateToast).toHaveBeenCalledWith(
-        expect.any(Number),
-        expect.objectContaining({
-          message: "Blinked LEDs 2 out of 2 miners",
-          status: toaster.STATUSES.loading,
-        }),
-      );
-      expect(mockCompleteBatchOperation).not.toHaveBeenCalledWith("batch-blink");
+      await act(async () => {
+        await streamSettled;
+      });
     });
 
-    // L3: all-fail path goes through removeToast(originalToastId) (not update)
-    // before attaching Retry. This exercises that branch and confirms Retry is
-    // still offered when the stream reports a terminal state.
     it("attaches Retry when all devices fail", async () => {
       stubActionSuccess(mockReboot, "batch-reboot");
       stubPartialFailureStream([], ["device-1", "device-2"]);
@@ -777,9 +797,6 @@ describe("useMinerActions", () => {
       expect(findRetryCall()).toBeDefined();
     });
 
-    // L2: verify the error toast is still pushed on premature termination,
-    // even though Retry is suppressed. A regression that accidentally
-    // suppressed the error toast would be caught here.
     it("does not attach Retry but still shows error toast when the batch stream ends prematurely", async () => {
       stubActionSuccess(mockReboot, "batch-reboot");
       mockStreamCommandBatchUpdates.mockImplementation(({ onStreamData }: any) => {
@@ -836,11 +853,7 @@ describe("useMinerActions", () => {
       });
 
       const { result } = renderFor(DeviceStatus.ONLINE);
-      const blinkAction = result.current.popoverActions.find((a) => a.action === deviceActions.blinkLEDs);
-
-      await act(async () => {
-        blinkAction?.actionHandler();
-      });
+      await runPopoverAction(result, deviceActions.blinkLEDs);
 
       expect(findRetryCall()).toBeUndefined();
       expect(toaster.updateToast).toHaveBeenCalledWith(

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -268,6 +268,14 @@ const buildUnpairConfirmationSubtitle = (
 
 const noop = () => {};
 
+const statusChangingActions = new Set<SupportedAction>([
+  settingsActions.miningPool,
+  deviceActions.shutdown,
+  deviceActions.wakeUp,
+  deviceActions.reboot,
+  deviceActions.firmwareUpdate,
+]);
+
 export const useMinerActions = ({
   selectedMiners,
   selectionMode,
@@ -478,6 +486,18 @@ export const useMinerActions = ({
       // failure, unmount) cannot offer a retry against a still-in-flight batch.
       let streamCompletedNormally = false;
 
+      const removeReportedFailedDevices = () => {
+        if (failureDeviceIds.length > 0) {
+          removeDevicesFromBatch(batchIdentifier, failureDeviceIds);
+        }
+      };
+
+      const completeNonStatusChangingBatch = () => {
+        if (!statusChangingActions.has(action)) {
+          completeBatchOperation(batchIdentifier);
+        }
+      };
+
       streamCommandBatchUpdates({
         streamRequest: create(StreamCommandBatchUpdatesRequestSchema, {
           batchIdentifier,
@@ -526,6 +546,18 @@ export const useMinerActions = ({
         streamAbortController: streamAbortController,
       }).finally(() => {
         if (!streamCompletedNormally) {
+          if (successCount > 0 || !errorToastId) {
+            updateToast(originalToastId, {
+              message: "Unable to confirm bulk action completion. Check miner status and try again.",
+              status: TOAST_STATUSES.error,
+            });
+          } else {
+            removeToast(originalToastId);
+          }
+
+          onBatchComplete?.(successDeviceIds, failureDeviceIds);
+          removeReportedFailedDevices();
+          completeNonStatusChangingBatch();
           return;
         }
 
@@ -538,7 +570,7 @@ export const useMinerActions = ({
           removeToast(originalToastId);
         }
 
-        if (streamCompletedNormally && errorToastId && retryAction && failureDeviceIds.length > 0) {
+        if (errorToastId && retryAction && failureDeviceIds.length > 0) {
           const capturedToastId = errorToastId;
           const capturedFailureIds = [...failureDeviceIds];
           // Guard against rapid double-clicks on the Retry button: the toast
@@ -564,9 +596,7 @@ export const useMinerActions = ({
         onBatchComplete?.(successDeviceIds, failureDeviceIds);
 
         // Remove failed devices from batch (revert to their original status)
-        if (failureDeviceIds.length > 0) {
-          removeDevicesFromBatch(batchIdentifier, failureDeviceIds);
-        }
+        removeReportedFailedDevices();
 
         // Actions that change device status (reboot, shutdown, wake-up, pool, firmware)
         // are handled by hasReachedExpectedStatus — keep the batch active so the
@@ -574,16 +604,7 @@ export const useMinerActions = ({
         // (5 min) is the safety net. For actions that don't change status
         // (blink LEDs, cooling, security, etc.), complete the batch immediately
         // so the transient state clears.
-        const statusChangingActions = new Set<SupportedAction>([
-          settingsActions.miningPool,
-          deviceActions.shutdown,
-          deviceActions.wakeUp,
-          deviceActions.reboot,
-          deviceActions.firmwareUpdate,
-        ]);
-        if (!statusChangingActions.has(action)) {
-          completeBatchOperation(batchIdentifier);
-        }
+        completeNonStatusChangingBatch();
       });
     },
     [streamCommandBatchUpdates, removeDevicesFromBatch, completeBatchOperation],

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -57,6 +57,7 @@ import {
   type UnsupportedMinersInfo,
 } from "@/protoFleet/features/fleetManagement/components/BulkActions/types";
 import type { BatchOperationInput } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
+import { isStatusChangingBatchAction } from "@/protoFleet/features/fleetManagement/utils/batchStatusCheck";
 import { createDeviceSelector } from "@/protoFleet/features/fleetManagement/utils/deviceSelector";
 import {
   Fan,
@@ -74,7 +75,13 @@ import {
 } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
 import { type SelectionMode } from "@/shared/components/List";
-import { pushToast, removeToast, STATUSES as TOAST_STATUSES, updateToast } from "@/shared/features/toaster";
+import {
+  pushToast,
+  removeToast,
+  STATUSES as TOAST_STATUSES,
+  type ToastStatusType,
+  updateToast,
+} from "@/shared/features/toaster";
 import { downloadBlob } from "@/shared/utils/utility";
 
 export interface MinerSelection {
@@ -268,13 +275,7 @@ const buildUnpairConfirmationSubtitle = (
 
 const noop = () => {};
 
-const statusChangingActions = new Set<SupportedAction>([
-  settingsActions.miningPool,
-  deviceActions.shutdown,
-  deviceActions.wakeUp,
-  deviceActions.reboot,
-  deviceActions.firmwareUpdate,
-]);
+const bulkActionUnconfirmedMessage = "Unable to confirm bulk action completion. Check miner status and try again.";
 
 export const useMinerActions = ({
   selectedMiners,
@@ -481,10 +482,15 @@ export const useMinerActions = ({
       let totalCount = 0;
       let successDeviceIds: string[] = [];
       let failureDeviceIds: string[] = [];
-      // Only true when we've received results for every expected device. Guards
-      // the Retry action below so a premature stream termination (network/auth
-      // failure, unmount) cannot offer a retry against a still-in-flight batch.
-      let streamCompletedNormally = false;
+      let finishedReceived = false;
+      let lastOriginalToast: { message: string; status: ToastStatusType } | null = null;
+      let lastErrorMessage: string | null = null;
+
+      const updateOriginalToast = (message: string, status: ToastStatusType) => {
+        if (lastOriginalToast?.message === message && lastOriginalToast.status === status) return;
+        lastOriginalToast = { message, status };
+        updateToast(originalToastId, { message, status });
+      };
 
       const removeReportedFailedDevices = () => {
         if (failureDeviceIds.length > 0) {
@@ -493,7 +499,7 @@ export const useMinerActions = ({
       };
 
       const completeNonStatusChangingBatch = () => {
-        if (!statusChangingActions.has(action)) {
+        if (!isStatusChangingBatchAction(action)) {
           completeBatchOperation(batchIdentifier);
         }
       };
@@ -514,21 +520,23 @@ export const useMinerActions = ({
             CommandBatchUpdateStatus_CommandBatchUpdateStatusType.FINISHED;
 
           if (successCount > 0) {
-            updateToast(originalToastId, {
-              message: getSuccessMessage(action, `${successCount} out of ${totalCount} ${minersMessage}`),
-              status: isFinished ? TOAST_STATUSES.success : TOAST_STATUSES.loading,
-            });
+            updateOriginalToast(
+              getSuccessMessage(action, `${successCount} out of ${totalCount} ${minersMessage}`),
+              isFinished ? TOAST_STATUSES.success : TOAST_STATUSES.loading,
+            );
           }
 
           if (failureCount > 0) {
             const failureMsg = getFailureMessage(action, `${failureCount} out of ${totalCount} ${minersMessage}`);
             if (!errorToastId) {
+              lastErrorMessage = failureMsg;
               errorToastId = pushToast({
                 message: failureMsg,
                 status: TOAST_STATUSES.error,
                 longRunning: true,
               });
-            } else {
+            } else if (lastErrorMessage !== failureMsg) {
+              lastErrorMessage = failureMsg;
               updateToast(errorToastId, {
                 message: failureMsg,
                 status: TOAST_STATUSES.error,
@@ -539,18 +547,15 @@ export const useMinerActions = ({
           // Counts can reach the selected total before the server has finished
           // the whole batch. Only the explicit terminal stream status is final.
           if (isFinished) {
-            streamCompletedNormally = true;
+            finishedReceived = true;
             streamAbortController.abort();
           }
         },
         streamAbortController: streamAbortController,
       }).finally(() => {
-        if (!streamCompletedNormally) {
+        if (!finishedReceived) {
           if (successCount > 0 || !errorToastId) {
-            updateToast(originalToastId, {
-              message: "Unable to confirm bulk action completion. Check miner status and try again.",
-              status: TOAST_STATUSES.error,
-            });
+            updateOriginalToast(bulkActionUnconfirmedMessage, TOAST_STATUSES.error);
           } else {
             removeToast(originalToastId);
           }
@@ -562,10 +567,10 @@ export const useMinerActions = ({
         }
 
         if (successCount > 0) {
-          updateToast(originalToastId, {
-            message: getSuccessMessage(action, `${successCount} out of ${totalCount} ${minersMessage}`),
-            status: TOAST_STATUSES.success,
-          });
+          updateOriginalToast(
+            getSuccessMessage(action, `${successCount} out of ${totalCount} ${minersMessage}`),
+            TOAST_STATUSES.success,
+          );
         } else {
           removeToast(originalToastId);
         }

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -489,11 +489,14 @@ export const useMinerActions = ({
 
           successDeviceIds = response.status?.commandBatchDeviceCount?.successDeviceIdentifiers || [];
           failureDeviceIds = response.status?.commandBatchDeviceCount?.failureDeviceIdentifiers || [];
+          const isFinished =
+            response.status?.commandBatchUpdateStatus ===
+            CommandBatchUpdateStatus_CommandBatchUpdateStatusType.FINISHED;
 
           if (successCount > 0) {
             updateToast(originalToastId, {
               message: getSuccessMessage(action, `${successCount} out of ${totalCount} ${minersMessage}`),
-              status: TOAST_STATUSES.success,
+              status: isFinished ? TOAST_STATUSES.success : TOAST_STATUSES.loading,
             });
           }
 
@@ -513,15 +516,19 @@ export const useMinerActions = ({
             }
           }
 
-          // Close the stream when we've received results for all devices
-          // This triggers .finally() to clear loading states immediately
-          if (successCount + failureCount === totalCount && totalCount > 0) {
+          // Counts can reach the selected total before the server has finished
+          // the whole batch. Only the explicit terminal stream status is final.
+          if (isFinished) {
             streamCompletedNormally = true;
             streamAbortController.abort();
           }
         },
         streamAbortController: streamAbortController,
       }).finally(() => {
+        if (!streamCompletedNormally) {
+          return;
+        }
+
         if (successCount > 0) {
           updateToast(originalToastId, {
             message: getSuccessMessage(action, `${successCount} out of ${totalCount} ${minersMessage}`),

--- a/client/src/protoFleet/features/fleetManagement/utils/batchStatusCheck.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/batchStatusCheck.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { deviceActions, settingsActions } from "../components/MinerActionsMenu/constants";
-import { hasReachedExpectedStatus, isActionLoading } from "./batchStatusCheck";
+import { hasReachedExpectedStatus, isActionLoading, isStatusChangingBatchAction } from "./batchStatusCheck";
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import type { BatchOperation } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 
@@ -14,6 +14,22 @@ function createBatch(overrides: Partial<BatchOperation> = {}): BatchOperation {
     ...overrides,
   };
 }
+
+describe("isStatusChangingBatchAction", () => {
+  it("returns true for actions that remain active until status transitions", () => {
+    expect(isStatusChangingBatchAction(settingsActions.miningPool)).toBe(true);
+    expect(isStatusChangingBatchAction(deviceActions.shutdown)).toBe(true);
+    expect(isStatusChangingBatchAction(deviceActions.wakeUp)).toBe(true);
+    expect(isStatusChangingBatchAction(deviceActions.reboot)).toBe(true);
+    expect(isStatusChangingBatchAction(deviceActions.firmwareUpdate)).toBe(true);
+  });
+
+  it("returns false for transient actions", () => {
+    expect(isStatusChangingBatchAction(deviceActions.blinkLEDs)).toBe(false);
+    expect(isStatusChangingBatchAction(settingsActions.coolingMode)).toBe(false);
+    expect(isStatusChangingBatchAction("unknown-action")).toBe(false);
+  });
+});
 
 describe("hasReachedExpectedStatus", () => {
   describe("mining pool action", () => {

--- a/client/src/protoFleet/features/fleetManagement/utils/batchStatusCheck.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/batchStatusCheck.ts
@@ -2,6 +2,18 @@ import { deviceActions, settingsActions, statusColumnLoadingMessages } from "../
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import type { BatchOperation } from "@/protoFleet/features/fleetManagement/hooks/useBatchOperations";
 
+const statusChangingBatchActions = new Set<string>([
+  settingsActions.miningPool,
+  deviceActions.shutdown,
+  deviceActions.wakeUp,
+  deviceActions.reboot,
+  deviceActions.firmwareUpdate,
+]);
+
+export function isStatusChangingBatchAction(action: string): boolean {
+  return statusChangingBatchActions.has(action);
+}
+
 /**
  * Check if a device has reached the expected status for a given batch action.
  * This logic is shared between status polling and UI display.


### PR DESCRIPTION
Reviewable diff: +77/-32 across 2 files (excludes generated, test, and story files).

## Summary
Bulk action status callouts now stay in progress until the command batch stream reports its terminal `FINISHED` state. Before this change, large actions could show updated success counts and auto-dismiss while the backend batch was still processing, making partial progress look final. If the stream ends early, the UI now clears the long-running loading state and reconciles known batch bookkeeping instead of leaving the action stuck. Fixes #572.

## How it works
When an operator starts a streamed bulk action, ProtoFleet keeps listening to `StreamCommandBatchUpdates` and uses count updates only as progress. Success counts can update the callout copy, but the toast remains in a loading state while the stream status is still `PROCESSING`. Terminal `FINISHED` updates run the final success/failure path and can attach Retry for failed devices. Premature stream endings run a separate cleanup path: the loading toast is resolved, reported failed devices are removed from the active batch, callbacks run with the last known counts, and non-status-changing actions complete their transient batch state without offering Retry.

## Diagrams
```mermaid
flowchart TD
  A["Operator starts bulk action"] --> B["Server streams batch updates"]
  B --> C{"Stream outcome"}
  C -->|"PROCESSING with updated counts"| D["Update count text, keep loading callout visible"]
  D --> B
  C -->|"FINISHED"| E["Set final success or failure state"]
  E --> F["Run retry and terminal batch cleanup"]
  C -->|"Stream closes before FINISHED"| G["Resolve loading toast as unconfirmed"]
  G --> H["Clean reported failures and transient batch state"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx` | Generic streamed bulk action handling now gates terminal success/Retry on `COMMAND_BATCH_UPDATE_STATUS_TYPE_FINISHED`, while premature stream endings get their own cleanup path. Duplicate identical toast updates are skipped for repeated stream frames. | This is the operator-visible lifecycle fix and the reliability surface for interrupted streams. |
| `client/src/protoFleet/features/fleetManagement/utils/batchStatusCheck.ts` | Exposes the shared list of batch actions that remain active until miner status transitions. | Keeps stream cleanup and status-column loading semantics from drifting. |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx` | Adds regression coverage for completed counts during `PROCESSING`, terminal partial failures, premature stream cleanup, and duplicate progress frames. | Verifies the callout does not settle early, interrupted streams do not strand loading state, and Retry remains terminal-only. |
| `client/src/protoFleet/features/fleetManagement/utils/batchStatusCheck.test.ts` | Covers the shared status-changing action predicate. | Protects the shared action lifecycle contract used by UI cleanup and batch loading state. |

## Key technical decisions & trade-offs
- Treat the server's terminal stream status as authoritative instead of inferring completion from `success + failure === total`; this preserves visibility for batches whose result counts arrive before finalization.
- Keep interim success-count copy but render it as loading rather than success; operators still see progress without the grouped toaster auto-dismissing it as complete.
- Split terminal completion from premature cleanup; interrupted streams clear UI/bookkeeping state but do not offer Retry because the backend batch may still be in flight.
- Share the status-changing action predicate with batch status utilities instead of maintaining a second action list in the menu hook.

## Testing & validation
- `cd client && npm test -- --run src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx src/protoFleet/features/fleetManagement/utils/batchStatusCheck.test.ts` - 152 passed.
- `cd client && npm run lint`.
- `cd client && npx tsc --noEmit`.
- The local `npm clean-install` path hit registry tarball integrity errors, so validation reused the existing main-checkout `client/node_modules` via an ignored symlink in this worktree.
