### PR TITLE
fix: defer group action menu miner loading

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -789,7 +789,8 @@ describe("useMinerActions", () => {
       expect(onActionStart).toHaveBeenCalled();
     });
 
-    it("ignores manage power capability continuations after the action lifecycle key changes", async () => {
+    it("ignores manage power capability continuations after cancel", async () => {
+      // Arrange
       let resolveCapabilityCheck: (() => void) | undefined;
       mockCheckCommandCapabilities.mockImplementationOnce(({ onSuccess }: any) => {
         resolveCapabilityCheck = () =>
@@ -804,35 +805,73 @@ describe("useMinerActions", () => {
           });
       });
 
-      const { result, rerender } = renderHook(
-        ({ actionLifecycleKey }: { actionLifecycleKey: string }) =>
-          useMinerActions({
-            ...batchOpsParams(),
-            selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
-            selectionMode: "subset",
-            actionLifecycleKey,
-          }),
-        {
-          initialProps: { actionLifecycleKey: "target-a:1" },
-        },
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
+          selectionMode: "subset",
+        }),
       );
 
       const managePowerAction = result.current.popoverActions.find((a) => a.action === performanceActions.managePower);
-      let actionPromise = Promise.resolve();
 
+      // Act
       act(() => {
-        actionPromise = Promise.resolve(managePowerAction?.actionHandler()).then(() => undefined);
+        managePowerAction?.actionHandler();
       });
-
-      rerender({ actionLifecycleKey: "target-b:2" });
-
+      act(() => {
+        result.current.handleCancel();
+      });
       await act(async () => {
         resolveCapabilityCheck?.();
-        await actionPromise;
       });
 
+      // Assert
       expect(result.current.showManagePowerModal).toBe(false);
       expect(result.current.currentAction).toBeNull();
+    });
+
+    it("ignores manage power capability continuations after another action starts", async () => {
+      // Arrange
+      let resolveCapabilityCheck: (() => void) | undefined;
+      mockCheckCommandCapabilities.mockImplementationOnce(({ onSuccess }: any) => {
+        resolveCapabilityCheck = () =>
+          onSuccess({
+            allSupported: true,
+            noneSupported: false,
+            supportedCount: 1,
+            unsupportedCount: 0,
+            totalCount: 1,
+            unsupportedGroups: [],
+            supportedDeviceIdentifiers: [],
+          });
+      });
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
+          selectionMode: "subset",
+        }),
+      );
+
+      const managePowerAction = result.current.popoverActions.find((a) => a.action === performanceActions.managePower);
+      const blinkAction = result.current.popoverActions.find((a) => a.action === deviceActions.blinkLEDs);
+
+      // Act
+      act(() => {
+        managePowerAction?.actionHandler();
+      });
+      act(() => {
+        blinkAction?.actionHandler();
+      });
+      await act(async () => {
+        resolveCapabilityCheck?.();
+      });
+
+      // Assert
+      expect(result.current.showManagePowerModal).toBe(false);
+      expect(result.current.currentAction).toBe(deviceActions.blinkLEDs);
     });
 
     it("should handle manage power confirm and call API", async () => {
@@ -1439,25 +1478,6 @@ describe("useMinerActions", () => {
       });
 
       expect(onActionComplete).toHaveBeenCalled();
-    });
-
-    it("should skip onActionComplete when handleCancel is internal-only", () => {
-      const onActionComplete = vi.fn();
-
-      const { result } = renderHook(() =>
-        useMinerActions({
-          ...batchOpsParams(),
-          selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
-          selectionMode: "subset",
-          onActionComplete,
-        }),
-      );
-
-      act(() => {
-        result.current.handleCancel({ notifyComplete: false });
-      });
-
-      expect(onActionComplete).not.toHaveBeenCalled();
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -789,6 +789,52 @@ describe("useMinerActions", () => {
       expect(onActionStart).toHaveBeenCalled();
     });
 
+    it("ignores manage power capability continuations after the action lifecycle key changes", async () => {
+      let resolveCapabilityCheck: (() => void) | undefined;
+      mockCheckCommandCapabilities.mockImplementationOnce(({ onSuccess }: any) => {
+        resolveCapabilityCheck = () =>
+          onSuccess({
+            allSupported: true,
+            noneSupported: false,
+            supportedCount: 1,
+            unsupportedCount: 0,
+            totalCount: 1,
+            unsupportedGroups: [],
+            supportedDeviceIdentifiers: [],
+          });
+      });
+
+      const { result, rerender } = renderHook(
+        ({ actionLifecycleKey }: { actionLifecycleKey: string }) =>
+          useMinerActions({
+            ...batchOpsParams(),
+            selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
+            selectionMode: "subset",
+            actionLifecycleKey,
+          }),
+        {
+          initialProps: { actionLifecycleKey: "target-a:1" },
+        },
+      );
+
+      const managePowerAction = result.current.popoverActions.find((a) => a.action === performanceActions.managePower);
+      let actionPromise = Promise.resolve();
+
+      act(() => {
+        actionPromise = Promise.resolve(managePowerAction?.actionHandler()).then(() => undefined);
+      });
+
+      rerender({ actionLifecycleKey: "target-b:2" });
+
+      await act(async () => {
+        resolveCapabilityCheck?.();
+        await actionPromise;
+      });
+
+      expect(result.current.showManagePowerModal).toBe(false);
+      expect(result.current.currentAction).toBeNull();
+    });
+
     it("should handle manage power confirm and call API", async () => {
       mockSetPowerTarget.mockImplementation(({ onSuccess }: any) => {
         onSuccess({ batchIdentifier: "batch-power" });
@@ -1393,6 +1439,25 @@ describe("useMinerActions", () => {
       });
 
       expect(onActionComplete).toHaveBeenCalled();
+    });
+
+    it("should skip onActionComplete when handleCancel is internal-only", () => {
+      const onActionComplete = vi.fn();
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
+          selectionMode: "subset",
+          onActionComplete,
+        }),
+      );
+
+      act(() => {
+        result.current.handleCancel({ notifyComplete: false });
+      });
+
+      expect(onActionComplete).not.toHaveBeenCalled();
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -103,13 +103,7 @@ interface UseMinerActionsParams {
   onRefetchMiners?: () => void;
   /** Allows callers to gate unsupported-miner continuation behind another confirmation. */
   onUnsupportedMinersContinue?: (continuation: UnsupportedMinersContinuation) => boolean;
-  /** Changes when the caller's action target changes; stale async continuations are ignored. */
-  actionLifecycleKey?: string;
 }
-
-type CancelOptions = {
-  notifyComplete?: boolean;
-};
 
 /**
  * Metadata for actions that require capability checking.
@@ -282,7 +276,6 @@ export const useMinerActions = ({
   onActionStart,
   onActionComplete,
   onUnsupportedMinersContinue,
-  actionLifecycleKey,
   startBatchOperation = noop as (batch: BatchOperationInput) => void,
   completeBatchOperation = noop as (batchIdentifier: string) => void,
   removeDevicesFromBatch = noop as (batchIdentifier: string, deviceIds: string[]) => void,
@@ -308,14 +301,11 @@ export const useMinerActions = ({
   const { fetchCoolingMode } = useMinerCoolingMode();
   const { getMinerModelGroups } = useMinerModelGroups();
   const { renameSingleMiner } = useRenameMiners();
-  const actionLifecycleKeyRef = useRef(actionLifecycleKey);
-  actionLifecycleKeyRef.current = actionLifecycleKey;
-
-  const getCurrentActionLifecycleKey = useCallback(() => actionLifecycleKeyRef.current, []);
-  const isActionLifecycleCurrent = useCallback(
-    (startedKey: string | undefined) => startedKey === undefined || actionLifecycleKeyRef.current === startedKey,
-    [],
-  );
+  // Incremented whenever a new action starts or the current one is cancelled.
+  // Async continuations (capability checks, cooling-mode fetches) capture the
+  // epoch when their action starts and bail if it has moved on, so a
+  // superseded action cannot mutate state that belongs to a newer one.
+  const actionEpochRef = useRef(0);
 
   const [currentAction, setCurrentAction] = useState<SupportedAction | null>(null);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
@@ -373,23 +363,20 @@ export const useMinerActions = ({
   // Check for unsupported miners using server-side capability checking.
   // Returns a promise that resolves to true if the modal was shown.
   const checkAndShowUnsupportedMinersModal = useCallback(
-    async (
-      action: SupportedAction,
-      proceedAction: PendingActionCallback,
-      lifecycleKey = getCurrentActionLifecycleKey(),
-    ): Promise<boolean> => {
+    async (action: SupportedAction, proceedAction: PendingActionCallback): Promise<boolean> => {
       const metadata = actionCapabilityMetadata[action];
 
       if (!metadata || metadata.commandType === CommandType.UNSPECIFIED || !deviceSelector) {
         return false;
       }
 
+      const epoch = actionEpochRef.current;
       return new Promise((resolve) => {
         checkCommandCapabilities({
           deviceSelector,
           commandType: metadata.commandType,
           onSuccess: (result) => {
-            if (!isActionLifecycleCurrent(lifecycleKey)) {
+            if (epoch !== actionEpochRef.current) {
               resolve(true);
               return;
             }
@@ -412,7 +399,7 @@ export const useMinerActions = ({
             resolve(true);
           },
           onError: () => {
-            if (!isActionLifecycleCurrent(lifecycleKey)) {
+            if (epoch !== actionEpochRef.current) {
               resolve(true);
               return;
             }
@@ -435,13 +422,7 @@ export const useMinerActions = ({
         });
       });
     },
-    [
-      deviceSelector,
-      checkCommandCapabilities,
-      getCurrentActionLifecycleKey,
-      isActionLifecycleCurrent,
-      onActionComplete,
-    ],
+    [deviceSelector, checkCommandCapabilities, onActionComplete],
   );
 
   // Wraps checkAndShowUnsupportedMinersModal with the common proceed pattern:
@@ -453,18 +434,18 @@ export const useMinerActions = ({
       action: SupportedAction,
       onProceed: (filteredSelector?: DeviceSelector, filteredDeviceIds?: string[]) => void,
     ): Promise<void> => {
-      const lifecycleKey = getCurrentActionLifecycleKey();
+      const epoch = actionEpochRef.current;
       const guardedOnProceed = (filteredSelector?: DeviceSelector, filteredDeviceIds?: string[]) => {
-        if (!isActionLifecycleCurrent(lifecycleKey)) return;
+        if (epoch !== actionEpochRef.current) return;
         onProceed(filteredSelector, filteredDeviceIds);
       };
-      const modalShown = await checkAndShowUnsupportedMinersModal(action, guardedOnProceed, lifecycleKey);
-      if (!isActionLifecycleCurrent(lifecycleKey)) return;
+      const modalShown = await checkAndShowUnsupportedMinersModal(action, guardedOnProceed);
+      if (epoch !== actionEpochRef.current) return;
       if (!modalShown) {
         guardedOnProceed(undefined, undefined);
       }
     },
-    [checkAndShowUnsupportedMinersModal, getCurrentActionLifecycleKey, isActionLifecycleCurrent],
+    [checkAndShowUnsupportedMinersModal],
   );
 
   // Handle continuing from unsupported miners modal
@@ -1212,31 +1193,27 @@ export const useMinerActions = ({
     ],
   );
 
-  const handleCancel = useCallback(
-    (options?: CancelOptions) => {
-      setCurrentAction(null);
-      setShowPoolSelectionPage(false);
-      setPoolFilteredDeviceIds(undefined);
-      setShowManagePowerModal(false);
-      setFilteredSelectorForPowerModal(undefined);
-      setManagePowerFilteredDeviceIds(undefined);
-      setShowCoolingModeModal(false);
-      setCoolingModeFilteredSelector(undefined);
-      setCoolingModeFilteredDeviceIds(undefined);
-      setCurrentCoolingMode(undefined);
-      setShowFirmwareUpdateModal(false);
-      setFirmwareUpdateFilteredSelector(undefined);
-      setFirmwareUpdateFilteredDeviceIds(undefined);
-      setShowAddToGroupModal(false);
-      setShowRenameDialog(false);
-      setUnsupportedMinersInfo(initialUnsupportedMinersState);
-      resetAuthState();
-      if (options?.notifyComplete !== false) {
-        onActionComplete?.();
-      }
-    },
-    [resetAuthState, onActionComplete],
-  );
+  const handleCancel = useCallback(() => {
+    ++actionEpochRef.current;
+    setCurrentAction(null);
+    setShowPoolSelectionPage(false);
+    setPoolFilteredDeviceIds(undefined);
+    setShowManagePowerModal(false);
+    setFilteredSelectorForPowerModal(undefined);
+    setManagePowerFilteredDeviceIds(undefined);
+    setShowCoolingModeModal(false);
+    setCoolingModeFilteredSelector(undefined);
+    setCoolingModeFilteredDeviceIds(undefined);
+    setCurrentCoolingMode(undefined);
+    setShowFirmwareUpdateModal(false);
+    setFirmwareUpdateFilteredSelector(undefined);
+    setFirmwareUpdateFilteredDeviceIds(undefined);
+    setShowAddToGroupModal(false);
+    setShowRenameDialog(false);
+    setUnsupportedMinersInfo(initialUnsupportedMinersState);
+    resetAuthState();
+    onActionComplete?.();
+  }, [resetAuthState, onActionComplete]);
 
   const popoverActions = useMemo(() => {
     // Device actions handlers
@@ -1352,7 +1329,7 @@ export const useMinerActions = ({
     };
 
     const handleReboot = async () => {
-      const lifecycleKey = getCurrentActionLifecycleKey();
+      const epoch = actionEpochRef.current;
       onActionStart?.();
       // Check for unsupported miners first - only show confirmation dialog if all supported
       const modalShown = await checkAndShowUnsupportedMinersModal(
@@ -1362,9 +1339,8 @@ export const useMinerActions = ({
           // The confirmation dialog will not be shown, action executes directly
           handleConfirmation(filteredSelector, filteredDeviceIds, deviceActions.reboot);
         },
-        lifecycleKey,
       );
-      if (!isActionLifecycleCurrent(lifecycleKey)) return;
+      if (epoch !== actionEpochRef.current) return;
       // Only show confirmation dialog if capability modal was not shown
       if (!modalShown) {
         setCurrentAction(deviceActions.reboot);
@@ -1372,32 +1348,30 @@ export const useMinerActions = ({
     };
 
     const handleShutDown = async () => {
-      const lifecycleKey = getCurrentActionLifecycleKey();
+      const epoch = actionEpochRef.current;
       onActionStart?.();
       const modalShown = await checkAndShowUnsupportedMinersModal(
         deviceActions.shutdown,
         (filteredSelector, filteredDeviceIds) => {
           handleConfirmation(filteredSelector, filteredDeviceIds, deviceActions.shutdown);
         },
-        lifecycleKey,
       );
-      if (!isActionLifecycleCurrent(lifecycleKey)) return;
+      if (epoch !== actionEpochRef.current) return;
       if (!modalShown) {
         setCurrentAction(deviceActions.shutdown);
       }
     };
 
     const handleWakeUp = async () => {
-      const lifecycleKey = getCurrentActionLifecycleKey();
+      const epoch = actionEpochRef.current;
       onActionStart?.();
       const modalShown = await checkAndShowUnsupportedMinersModal(
         deviceActions.wakeUp,
         (filteredSelector, filteredDeviceIds) => {
           handleConfirmation(filteredSelector, filteredDeviceIds, deviceActions.wakeUp);
         },
-        lifecycleKey,
       );
-      if (!isActionLifecycleCurrent(lifecycleKey)) return;
+      if (epoch !== actionEpochRef.current) return;
       if (!modalShown) {
         setCurrentAction(deviceActions.wakeUp);
       }
@@ -1430,16 +1404,15 @@ export const useMinerActions = ({
     };
 
     const handleCoolingMode = async () => {
-      const lifecycleKey = getCurrentActionLifecycleKey();
+      const epoch = actionEpochRef.current;
       onActionStart?.();
 
       // For single miner, fetch current cooling mode for prepopulation
       if (selectedMiners.length === 1) {
         const mode = await fetchCoolingMode(selectedMiners[0].deviceIdentifier);
-        if (!isActionLifecycleCurrent(lifecycleKey)) return;
+        if (epoch !== actionEpochRef.current) return;
         setCurrentCoolingMode(mode);
       } else {
-        if (!isActionLifecycleCurrent(lifecycleKey)) return;
         setCurrentCoolingMode(undefined);
       }
 
@@ -1558,7 +1531,7 @@ export const useMinerActions = ({
           ? [wakeUpAction] // Single miner asleep: show wake up only
           : [sleepAction]; // Single miner active: show sleep only
 
-    return [
+    const actions: BulkAction<SupportedAction>[] = [
       // Device actions - ordered per design specifications
       ...powerStateActions, // Sleep/Wake up at top
       {
@@ -1659,7 +1632,17 @@ export const useMinerActions = ({
           testId: "unpair-confirm-button",
         },
       },
-    ] as BulkAction<SupportedAction>[];
+    ];
+
+    // Every action starts a new epoch so async continuations of a superseded
+    // action bail instead of mutating the newer flow's state.
+    return actions.map((action) => ({
+      ...action,
+      actionHandler: () => {
+        ++actionEpochRef.current;
+        action.actionHandler();
+      },
+    }));
   }, [
     blinkLED,
     downloadLogs,
@@ -1671,11 +1654,9 @@ export const useMinerActions = ({
     onActionComplete,
     deviceSelector,
     deviceStatus,
-    getCurrentActionLifecycleKey,
     withCapabilityCheck,
     checkAndShowUnsupportedMinersModal,
     handleConfirmation,
-    isActionLifecycleCurrent,
     deviceIdentifiers,
     selectionMode,
     selectedMiners,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -103,7 +103,13 @@ interface UseMinerActionsParams {
   onRefetchMiners?: () => void;
   /** Allows callers to gate unsupported-miner continuation behind another confirmation. */
   onUnsupportedMinersContinue?: (continuation: UnsupportedMinersContinuation) => boolean;
+  /** Changes when the caller's action target changes; stale async continuations are ignored. */
+  actionLifecycleKey?: string;
 }
+
+type CancelOptions = {
+  notifyComplete?: boolean;
+};
 
 /**
  * Metadata for actions that require capability checking.
@@ -276,6 +282,7 @@ export const useMinerActions = ({
   onActionStart,
   onActionComplete,
   onUnsupportedMinersContinue,
+  actionLifecycleKey,
   startBatchOperation = noop as (batch: BatchOperationInput) => void,
   completeBatchOperation = noop as (batchIdentifier: string) => void,
   removeDevicesFromBatch = noop as (batchIdentifier: string, deviceIds: string[]) => void,
@@ -301,6 +308,14 @@ export const useMinerActions = ({
   const { fetchCoolingMode } = useMinerCoolingMode();
   const { getMinerModelGroups } = useMinerModelGroups();
   const { renameSingleMiner } = useRenameMiners();
+  const actionLifecycleKeyRef = useRef(actionLifecycleKey);
+  actionLifecycleKeyRef.current = actionLifecycleKey;
+
+  const getCurrentActionLifecycleKey = useCallback(() => actionLifecycleKeyRef.current, []);
+  const isActionLifecycleCurrent = useCallback(
+    (startedKey: string | undefined) => startedKey === undefined || actionLifecycleKeyRef.current === startedKey,
+    [],
+  );
 
   const [currentAction, setCurrentAction] = useState<SupportedAction | null>(null);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
@@ -358,7 +373,11 @@ export const useMinerActions = ({
   // Check for unsupported miners using server-side capability checking.
   // Returns a promise that resolves to true if the modal was shown.
   const checkAndShowUnsupportedMinersModal = useCallback(
-    async (action: SupportedAction, proceedAction: PendingActionCallback): Promise<boolean> => {
+    async (
+      action: SupportedAction,
+      proceedAction: PendingActionCallback,
+      lifecycleKey = getCurrentActionLifecycleKey(),
+    ): Promise<boolean> => {
       const metadata = actionCapabilityMetadata[action];
 
       if (!metadata || metadata.commandType === CommandType.UNSPECIFIED || !deviceSelector) {
@@ -370,6 +389,11 @@ export const useMinerActions = ({
           deviceSelector,
           commandType: metadata.commandType,
           onSuccess: (result) => {
+            if (!isActionLifecycleCurrent(lifecycleKey)) {
+              resolve(true);
+              return;
+            }
+
             if (result.allSupported) {
               resolve(false);
               return;
@@ -388,6 +412,11 @@ export const useMinerActions = ({
             resolve(true);
           },
           onError: () => {
+            if (!isActionLifecycleCurrent(lifecycleKey)) {
+              resolve(true);
+              return;
+            }
+
             if (action === deviceActions.firmwareUpdate) {
               pushToast({
                 message: "Unable to verify firmware update support for the selected miners. Please try again.",
@@ -406,7 +435,13 @@ export const useMinerActions = ({
         });
       });
     },
-    [deviceSelector, checkCommandCapabilities, onActionComplete],
+    [
+      deviceSelector,
+      checkCommandCapabilities,
+      getCurrentActionLifecycleKey,
+      isActionLifecycleCurrent,
+      onActionComplete,
+    ],
   );
 
   // Wraps checkAndShowUnsupportedMinersModal with the common proceed pattern:
@@ -418,12 +453,18 @@ export const useMinerActions = ({
       action: SupportedAction,
       onProceed: (filteredSelector?: DeviceSelector, filteredDeviceIds?: string[]) => void,
     ): Promise<void> => {
-      const modalShown = await checkAndShowUnsupportedMinersModal(action, onProceed);
+      const lifecycleKey = getCurrentActionLifecycleKey();
+      const guardedOnProceed = (filteredSelector?: DeviceSelector, filteredDeviceIds?: string[]) => {
+        if (!isActionLifecycleCurrent(lifecycleKey)) return;
+        onProceed(filteredSelector, filteredDeviceIds);
+      };
+      const modalShown = await checkAndShowUnsupportedMinersModal(action, guardedOnProceed, lifecycleKey);
+      if (!isActionLifecycleCurrent(lifecycleKey)) return;
       if (!modalShown) {
-        onProceed(undefined, undefined);
+        guardedOnProceed(undefined, undefined);
       }
     },
-    [checkAndShowUnsupportedMinersModal],
+    [checkAndShowUnsupportedMinersModal, getCurrentActionLifecycleKey, isActionLifecycleCurrent],
   );
 
   // Handle continuing from unsupported miners modal
@@ -625,8 +666,12 @@ export const useMinerActions = ({
             handleSuccess(action, toastId, batchIdentifier, undefined, (failedIds) => {
               execute(createDeviceSelector("subset", failedIds), failedIds, pushLoadingToast());
             });
+            onActionComplete?.();
           },
-          onError: (error) => handleError(toastId, error),
+          onError: (error) => {
+            handleError(toastId, error);
+            onActionComplete?.();
+          },
         });
       };
 
@@ -1167,12 +1212,31 @@ export const useMinerActions = ({
     ],
   );
 
-  const handleCancel = useCallback(() => {
-    setCurrentAction(null);
-    setShowPoolSelectionPage(false);
-    resetAuthState();
-    onActionComplete?.();
-  }, [resetAuthState, onActionComplete]);
+  const handleCancel = useCallback(
+    (options?: CancelOptions) => {
+      setCurrentAction(null);
+      setShowPoolSelectionPage(false);
+      setPoolFilteredDeviceIds(undefined);
+      setShowManagePowerModal(false);
+      setFilteredSelectorForPowerModal(undefined);
+      setManagePowerFilteredDeviceIds(undefined);
+      setShowCoolingModeModal(false);
+      setCoolingModeFilteredSelector(undefined);
+      setCoolingModeFilteredDeviceIds(undefined);
+      setCurrentCoolingMode(undefined);
+      setShowFirmwareUpdateModal(false);
+      setFirmwareUpdateFilteredSelector(undefined);
+      setFirmwareUpdateFilteredDeviceIds(undefined);
+      setShowAddToGroupModal(false);
+      setShowRenameDialog(false);
+      setUnsupportedMinersInfo(initialUnsupportedMinersState);
+      resetAuthState();
+      if (options?.notifyComplete !== false) {
+        onActionComplete?.();
+      }
+    },
+    [resetAuthState, onActionComplete],
+  );
 
   const popoverActions = useMemo(() => {
     // Device actions handlers
@@ -1288,6 +1352,7 @@ export const useMinerActions = ({
     };
 
     const handleReboot = async () => {
+      const lifecycleKey = getCurrentActionLifecycleKey();
       onActionStart?.();
       // Check for unsupported miners first - only show confirmation dialog if all supported
       const modalShown = await checkAndShowUnsupportedMinersModal(
@@ -1297,7 +1362,9 @@ export const useMinerActions = ({
           // The confirmation dialog will not be shown, action executes directly
           handleConfirmation(filteredSelector, filteredDeviceIds, deviceActions.reboot);
         },
+        lifecycleKey,
       );
+      if (!isActionLifecycleCurrent(lifecycleKey)) return;
       // Only show confirmation dialog if capability modal was not shown
       if (!modalShown) {
         setCurrentAction(deviceActions.reboot);
@@ -1305,26 +1372,32 @@ export const useMinerActions = ({
     };
 
     const handleShutDown = async () => {
+      const lifecycleKey = getCurrentActionLifecycleKey();
       onActionStart?.();
       const modalShown = await checkAndShowUnsupportedMinersModal(
         deviceActions.shutdown,
         (filteredSelector, filteredDeviceIds) => {
           handleConfirmation(filteredSelector, filteredDeviceIds, deviceActions.shutdown);
         },
+        lifecycleKey,
       );
+      if (!isActionLifecycleCurrent(lifecycleKey)) return;
       if (!modalShown) {
         setCurrentAction(deviceActions.shutdown);
       }
     };
 
     const handleWakeUp = async () => {
+      const lifecycleKey = getCurrentActionLifecycleKey();
       onActionStart?.();
       const modalShown = await checkAndShowUnsupportedMinersModal(
         deviceActions.wakeUp,
         (filteredSelector, filteredDeviceIds) => {
           handleConfirmation(filteredSelector, filteredDeviceIds, deviceActions.wakeUp);
         },
+        lifecycleKey,
       );
+      if (!isActionLifecycleCurrent(lifecycleKey)) return;
       if (!modalShown) {
         setCurrentAction(deviceActions.wakeUp);
       }
@@ -1357,13 +1430,16 @@ export const useMinerActions = ({
     };
 
     const handleCoolingMode = async () => {
+      const lifecycleKey = getCurrentActionLifecycleKey();
       onActionStart?.();
 
       // For single miner, fetch current cooling mode for prepopulation
       if (selectedMiners.length === 1) {
         const mode = await fetchCoolingMode(selectedMiners[0].deviceIdentifier);
+        if (!isActionLifecycleCurrent(lifecycleKey)) return;
         setCurrentCoolingMode(mode);
       } else {
+        if (!isActionLifecycleCurrent(lifecycleKey)) return;
         setCurrentCoolingMode(undefined);
       }
 
@@ -1595,9 +1671,11 @@ export const useMinerActions = ({
     onActionComplete,
     deviceSelector,
     deviceStatus,
+    getCurrentActionLifecycleKey,
     withCapabilityCheck,
     checkAndShowUnsupportedMinersModal,
     handleConfirmation,
+    isActionLifecycleCurrent,
     deviceIdentifiers,
     selectionMode,
     selectedMiners,

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.test.tsx
@@ -14,7 +14,9 @@ const {
   mockListGroupMembers,
   mockFetchAllMinerSnapshots,
   mockUnsupportedMinersModal,
+  mockPushToast,
 } = vi.hoisted(() => ({
+  mockPushToast: vi.fn(),
   mockUseMinerActions: vi.fn(),
   mockBulkActionsPopover: vi.fn(
     ({
@@ -170,6 +172,11 @@ vi.mock("@/shared/components/Popover", () => ({
 
 vi.mock("@/shared/hooks/useClickOutside", () => ({
   useClickOutside: vi.fn(),
+}));
+
+vi.mock("@/shared/features/toaster", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/features/toaster")>()),
+  pushToast: mockPushToast,
 }));
 
 describe("DeviceSetActionsMenu", () => {
@@ -798,8 +805,8 @@ describe("DeviceSetActionsMenu", () => {
   });
 
   it("clears an open scoped confirmation when the target scope changes", async () => {
+    // Arrange
     const actionHandler = vi.fn();
-    const handleCancel = vi.fn();
     const actionActiveRef = { current: false };
     mockUseMinerActions.mockReturnValue({
       ...defaultMinerActions(),
@@ -811,7 +818,6 @@ describe("DeviceSetActionsMenu", () => {
           requiresConfirmation: false,
         },
       ],
-      handleCancel,
     });
 
     const { rerender } = render(
@@ -842,22 +848,17 @@ describe("DeviceSetActionsMenu", () => {
       />,
     );
 
+    // Assert
     await waitFor(() => {
       expect(screen.queryByTestId("group-actions-dialog")).not.toBeInTheDocument();
       expect(actionActiveRef.current).toBe(false);
     });
-    expect(handleCancel).toHaveBeenCalledWith({ notifyComplete: false });
     expect(actionHandler).not.toHaveBeenCalled();
   });
 
-  it("silently cancels local action state when an inactive row target changes", async () => {
-    const handleCancel = vi.fn();
+  it("does not notify completion when an inactive row target changes", () => {
+    // Arrange
     const onActionComplete = vi.fn();
-    mockUseMinerActions.mockReturnValue({
-      ...defaultMinerActions(),
-      handleCancel,
-    });
-
     const { rerender } = render(
       <DeviceSetActionsMenu
         memberDeviceIds={["site-1-miner"]}
@@ -868,6 +869,7 @@ describe("DeviceSetActionsMenu", () => {
       />,
     );
 
+    // Act
     rerender(
       <DeviceSetActionsMenu
         memberDeviceIds={["site-2-miner"]}
@@ -878,9 +880,8 @@ describe("DeviceSetActionsMenu", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(handleCancel).toHaveBeenCalledWith({ notifyComplete: false });
-    });
+    // Assert
+    expect(screen.getByLabelText("Device set actions")).toBeInTheDocument();
     expect(onActionComplete).not.toHaveBeenCalled();
   });
 
@@ -1082,18 +1083,22 @@ describe("DeviceSetActionsMenu", () => {
         expect.objectContaining({ deviceSetId: 1n, siteIds: [2n], includeUnassigned: false }),
       );
     });
+
+    // Assert: no replay, a toast explains why, and the action stays clickable
+    // on reopen since member data is fetched fresh on every attempt.
+    await waitFor(() => {
+      expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ message: "No miners in Site 2." }));
+    });
     expect(shutdownHandler).not.toHaveBeenCalled();
 
     fireEvent.click(menuButton);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("shutdown-popover-button")).toBeDisabled();
-    });
+    expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
   });
 
-  it("revalidates an empty scoped member cache when reopening the same target", async () => {
+  it("runs a scoped action once a previously empty scope gains miners", async () => {
+    // Arrange
     const shutdownHandler = vi.fn();
-    const memberResponses = [[], ["new-miner"], ["new-miner"]];
+    const memberResponses = [[], ["new-miner"]];
     mockUseMinerActions.mockImplementation(() => ({
       ...defaultMinerActions(),
       popoverActions: [
@@ -1124,6 +1129,7 @@ describe("DeviceSetActionsMenu", () => {
       />,
     );
 
+    // Act: the first attempt hits an empty scope and does not replay
     const menuButton = screen.getByLabelText("Device set actions");
     fireEvent.click(menuButton);
     fireEvent.click(screen.getByTestId("shutdown-popover-button"));
@@ -1133,110 +1139,23 @@ describe("DeviceSetActionsMenu", () => {
     });
     expect(shutdownHandler).not.toHaveBeenCalled();
 
+    // Act: the second attempt fetches fresh data and finds the new miner
     fireEvent.click(menuButton);
-
-    await waitFor(() => {
-      expect(mockListGroupMembers).toHaveBeenCalledTimes(2);
-      expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
-    });
-
+    expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
     fireEvent.click(screen.getByTestId("shutdown-popover-button"));
 
     await waitFor(() => {
-      expect(mockListGroupMembers).toHaveBeenCalledTimes(3);
+      expect(mockListGroupMembers).toHaveBeenCalledTimes(2);
       expect(screen.getByTestId("group-actions-dialog")).toHaveTextContent("miners in Site 2");
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
 
+    // Assert
     expect(shutdownHandler).toHaveBeenCalledTimes(1);
   });
 
-  it("ignores stale empty-cache revalidation after an action fetch starts", async () => {
-    const shutdownHandler = vi.fn();
-    let refreshEmptyMembers: (() => void) | undefined;
-    let memberFetchCall = 0;
-    mockUseMinerActions.mockImplementation(() => ({
-      ...defaultMinerActions(),
-      popoverActions: [
-        {
-          action: "shutdown",
-          title: "Sleep",
-          actionHandler: shutdownHandler,
-          requiresConfirmation: false,
-        },
-      ],
-    }));
-    mockListGroupMembers.mockImplementation(
-      ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
-        memberFetchCall += 1;
-        if (memberFetchCall === 1) {
-          onSuccess?.([]);
-          onFinally?.();
-          return;
-        }
-        if (memberFetchCall === 2) {
-          refreshEmptyMembers = () => {
-            onSuccess?.([]);
-            onFinally?.();
-          };
-          return;
-        }
-        onSuccess?.(["action-miner"]);
-        onFinally?.();
-      },
-    );
-    mockFetchAllMinerSnapshots.mockResolvedValue({
-      "action-miner": { deviceIdentifier: "action-miner" },
-    });
-
-    render(
-      <DeviceSetActionsMenu
-        deviceSetId={1n}
-        onEdit={vi.fn()}
-        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
-        activeSiteLabel="Site 2"
-      />,
-    );
-
-    const menuButton = screen.getByLabelText("Device set actions");
-    fireEvent.click(menuButton);
-    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
-
-    await waitFor(() => {
-      expect(mockListGroupMembers).toHaveBeenCalledTimes(1);
-    });
-    expect(shutdownHandler).not.toHaveBeenCalled();
-
-    fireEvent.click(menuButton);
-
-    await waitFor(() => {
-      expect(mockListGroupMembers).toHaveBeenCalledTimes(2);
-      expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
-    });
-
-    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
-
-    await waitFor(() => {
-      expect(mockListGroupMembers).toHaveBeenCalledTimes(3);
-      expect(screen.getByTestId("group-actions-dialog")).toHaveTextContent("miners in Site 2");
-    });
-
-    act(() => {
-      refreshEmptyMembers?.();
-    });
-
-    await waitFor(() => {
-      expect(mockUseMinerActions).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          selectedMiners: [{ deviceIdentifier: "action-miner" }],
-        }),
-      );
-      expect(screen.getByTestId("group-actions-dialog")).toBeInTheDocument();
-    });
-  });
-
-  it("does not reuse an empty scoped member cache after the target site changes", async () => {
+  it("fetches fresh members for the new site after the target site changes", async () => {
     const shutdownHandler = vi.fn();
     mockUseMinerActions.mockImplementation(() => ({
       ...defaultMinerActions(),
@@ -1276,6 +1195,7 @@ describe("DeviceSetActionsMenu", () => {
       />,
     );
 
+    // Act: an attempt in site 1 finds no scoped miners
     const menuButton = screen.getByLabelText("Device set actions");
     fireEvent.click(menuButton);
     fireEvent.click(screen.getByTestId("shutdown-popover-button"));
@@ -1285,13 +1205,9 @@ describe("DeviceSetActionsMenu", () => {
         expect.objectContaining({ deviceSetId: 1n, siteIds: [1n], includeUnassigned: false }),
       );
     });
+    expect(shutdownHandler).not.toHaveBeenCalled();
 
-    fireEvent.click(menuButton);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("shutdown-popover-button")).toBeDisabled();
-    });
-
+    // Act: the site scope changes and a new attempt targets the new site
     rerender(
       <DeviceSetActionsMenu
         deviceSetId={1n}
@@ -1301,10 +1217,7 @@ describe("DeviceSetActionsMenu", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
-    });
-
+    fireEvent.click(screen.getByLabelText("Device set actions"));
     fireEvent.click(screen.getByTestId("shutdown-popover-button"));
 
     await waitFor(() => {

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.test.tsx
@@ -3,48 +3,58 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import DeviceSetActionsMenu from "./DeviceSetActionsMenu";
 
+type UnsupportedMinersModalMockProps = {
+  onDismiss: () => void;
+};
+
 // Hoisted mocks
-const { mockUseMinerActions, mockBulkActionsPopover, mockListGroupMembers, mockFetchAllMinerSnapshots } = vi.hoisted(
-  () => ({
-    mockUseMinerActions: vi.fn(),
-    mockBulkActionsPopover: vi.fn(
-      ({
-        actions,
-        beforeEach: beforeEachAction,
-      }: {
-        actions: Array<{
-          action: string;
-          title: string;
-          actionHandler: () => void;
-          requiresConfirmation: boolean;
-          disabled?: boolean;
-          disabledReason?: string;
-          confirmation?: {
-            subtitle?: string;
-          };
-        }>;
-        beforeEach: (requiresConfirmation: boolean) => void;
-      }) => (
-        <div data-testid="group-actions-popover">
-          {actions.map((action) => (
-            <button
-              key={action.action}
-              data-testid={`${action.action}-popover-button`}
-              onClick={() => {
-                beforeEachAction(action.requiresConfirmation);
-                action.actionHandler();
-              }}
-            >
-              {action.title}
-            </button>
-          ))}
-        </div>
-      ),
+const {
+  mockUseMinerActions,
+  mockBulkActionsPopover,
+  mockListGroupMembers,
+  mockFetchAllMinerSnapshots,
+  mockUnsupportedMinersModal,
+} = vi.hoisted(() => ({
+  mockUseMinerActions: vi.fn(),
+  mockBulkActionsPopover: vi.fn(
+    ({
+      actions,
+      beforeEach: beforeEachAction,
+    }: {
+      actions: Array<{
+        action: string;
+        title: string;
+        actionHandler: () => void;
+        requiresConfirmation: boolean;
+        disabled?: boolean;
+        disabledReason?: string;
+        confirmation?: {
+          subtitle?: string;
+        };
+      }>;
+      beforeEach: (requiresConfirmation: boolean) => void;
+    }) => (
+      <div data-testid="group-actions-popover">
+        {actions.map((action) => (
+          <button
+            key={action.action}
+            data-testid={`${action.action}-popover-button`}
+            disabled={action.disabled}
+            onClick={() => {
+              beforeEachAction(action.requiresConfirmation);
+              action.actionHandler();
+            }}
+          >
+            {action.title}
+          </button>
+        ))}
+      </div>
     ),
-    mockListGroupMembers: vi.fn(),
-    mockFetchAllMinerSnapshots: vi.fn(),
-  }),
-);
+  ),
+  mockListGroupMembers: vi.fn(),
+  mockFetchAllMinerSnapshots: vi.fn(),
+  mockUnsupportedMinersModal: vi.fn((_props: UnsupportedMinersModalMockProps) => null),
+}));
 
 const defaultMinerActions = () => ({
   currentAction: null,
@@ -122,7 +132,7 @@ vi.mock("@/protoFleet/features/fleetManagement/components/BulkActions/BulkAction
 }));
 
 vi.mock("@/protoFleet/features/fleetManagement/components/BulkActions/UnsupportedMinersModal", () => ({
-  default: () => null,
+  default: (props: UnsupportedMinersModalMockProps) => mockUnsupportedMinersModal(props),
 }));
 
 vi.mock("@/protoFleet/features/fleetManagement/components/ActionBar/SettingsWidget/PoolSelectionPage", () => ({
@@ -168,6 +178,7 @@ describe("DeviceSetActionsMenu", () => {
     mockUseMinerActions.mockImplementation(defaultMinerActions);
     mockListGroupMembers.mockImplementation(() => undefined);
     mockFetchAllMinerSnapshots.mockResolvedValue({});
+    mockUnsupportedMinersModal.mockImplementation(() => null);
   });
 
   it("renders 'View group' action when onView is provided", () => {
@@ -341,6 +352,53 @@ describe("DeviceSetActionsMenu", () => {
       disabled: true,
       disabledReason: "No miners in Site 2.",
     });
+    expect(screen.getByTestId("shutdown-popover-button")).toBeDisabled();
+  });
+
+  it("keeps scoped bulk actions enabled while scoped member ids are unknown", async () => {
+    mockUseMinerActions.mockReturnValue({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: vi.fn(),
+          requiresConfirmation: true,
+          confirmation: {
+            title: "Sleep miners?",
+            subtitle: "These miners will go to sleep and stop hashing.",
+            confirmAction: { title: "Sleep" },
+          },
+        },
+      ],
+    });
+
+    render(
+      <DeviceSetActionsMenu
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+        deviceSetLabel="Group A"
+        totalMemberCount={30}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Device set actions"));
+
+    await waitFor(() => {
+      expect(mockBulkActionsPopover).toHaveBeenCalled();
+    });
+
+    const latestCall = mockBulkActionsPopover.mock.calls[mockBulkActionsPopover.mock.calls.length - 1]?.[0] as {
+      actions: Array<{ action: string; disabled?: boolean; disabledReason?: string }>;
+    };
+    const sleepAction = latestCall.actions.find((action) => action.action === "shutdown");
+    expect(sleepAction?.disabled).toBeUndefined();
+    expect(sleepAction?.disabledReason).toBeUndefined();
+    expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
+    expect(mockListGroupMembers).not.toHaveBeenCalled();
+    expect(mockFetchAllMinerSnapshots).not.toHaveBeenCalled();
   });
 
   it("does not add scoped confirmation copy on canonical detail pages", async () => {
@@ -450,124 +508,882 @@ describe("DeviceSetActionsMenu", () => {
     expect(continueAction).toHaveBeenCalledTimes(1);
   });
 
-  it("shows loading immediately on open when fresh data is required", () => {
-    mockFetchAllMinerSnapshots.mockReturnValue(new Promise(() => {}));
+  it("clears scoped warning state when unsupported miners are dismissed", async () => {
+    const handleUnsupportedMinersDismiss = vi.fn();
+    const actionActiveRef = { current: false };
+    mockUseMinerActions.mockReturnValue({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: vi.fn(),
+          requiresConfirmation: true,
+          confirmation: {
+            title: "Sleep miners?",
+            subtitle: "These miners will go to sleep and stop hashing.",
+            confirmAction: { title: "Sleep" },
+          },
+        },
+      ],
+      handleUnsupportedMinersDismiss,
+    });
 
-    const { container } = render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
+    render(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["d1", "d2"]}
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+        actionActiveRef={actionActiveRef}
+      />,
+    );
 
     fireEvent.click(screen.getByLabelText("Device set actions"));
 
-    expect(screen.queryByTestId("group-actions-popover")).not.toBeInTheDocument();
-    expect(container.querySelector("svg.animate-spin")).not.toBeNull();
-  });
-
-  it("aborts the member-fetch signal on close and creates a fresh signal on reopen", async () => {
-    mockFetchAllMinerSnapshots.mockReturnValue(new Promise(() => {}));
-
-    render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
-
-    const button = screen.getByLabelText("Device set actions");
-    fireEvent.click(button);
-
     await waitFor(() => {
-      expect(mockListGroupMembers).toHaveBeenCalledTimes(1);
+      expect(mockBulkActionsPopover).toHaveBeenCalled();
     });
 
-    const firstRequest = mockListGroupMembers.mock.calls[0][0] as { signal: AbortSignal };
-    expect(firstRequest.signal.aborted).toBe(false);
-
-    fireEvent.click(button);
-    await waitFor(() => {
-      expect(firstRequest.signal.aborted).toBe(true);
-    });
-
-    fireEvent.click(button);
-    await waitFor(() => {
-      expect(mockListGroupMembers).toHaveBeenCalledTimes(2);
-    });
-
-    const secondRequest = mockListGroupMembers.mock.calls[1][0] as { signal: AbortSignal };
-    expect(firstRequest.signal.aborted).toBe(true);
-    expect(secondRequest.signal.aborted).toBe(false);
-  });
-
-  it("ignores stale callbacks from a prior open", async () => {
-    const memberRequests: Array<{
-      signal: AbortSignal;
-      onSuccess?: (ids: string[]) => void;
-      onFinally?: () => void;
-    }> = [];
-
-    mockListGroupMembers.mockImplementation((request: unknown) => {
-      memberRequests.push(request as (typeof memberRequests)[number]);
-    });
-
-    render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
-
-    const button = screen.getByLabelText("Device set actions");
-    fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(mockListGroupMembers).toHaveBeenCalledTimes(1);
-    });
-
-    fireEvent.click(button);
-    await waitFor(() => {
-      expect(memberRequests[0].signal.aborted).toBe(true);
-    });
-
-    fireEvent.click(button);
-    await waitFor(() => {
-      expect(mockListGroupMembers).toHaveBeenCalledTimes(2);
-    });
+    const latestHookArgs = mockUseMinerActions.mock.calls[mockUseMinerActions.mock.calls.length - 1]?.[0] as {
+      onUnsupportedMinersContinue: (continuation: { action: string; continueAction: () => void }) => boolean;
+    };
 
     act(() => {
-      memberRequests[0].onSuccess?.(["stale-device"]);
-      memberRequests[0].onFinally?.();
-    });
-
-    expect(screen.queryByTestId("group-actions-popover")).not.toBeInTheDocument();
-
-    act(() => {
-      memberRequests[1].onSuccess?.(["fresh-device"]);
-      memberRequests[1].onFinally?.();
+      latestHookArgs.onUnsupportedMinersContinue({
+        action: "shutdown",
+        continueAction: vi.fn(),
+      });
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("group-actions-popover")).toBeInTheDocument();
+      expect(screen.getByTestId("group-actions-dialog")).toBeInTheDocument();
+      expect(actionActiveRef.current).toBe(true);
     });
 
-    // Directly verify the version-counter guard: useMinerActions must never have been
-    // handed the stale member, and its latest call must reflect the fresh member.
-    expect(mockUseMinerActions).not.toHaveBeenCalledWith(
-      expect.objectContaining({ selectedMiners: [{ deviceIdentifier: "stale-device" }] }),
+    expect(mockUnsupportedMinersModal).toHaveBeenCalled();
+    const latestUnsupportedProps =
+      mockUnsupportedMinersModal.mock.calls[mockUnsupportedMinersModal.mock.calls.length - 1][0];
+    act(() => {
+      latestUnsupportedProps.onDismiss();
+    });
+
+    expect(handleUnsupportedMinersDismiss).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByTestId("group-actions-dialog")).not.toBeInTheDocument();
+      expect(actionActiveRef.current).toBe(false);
+    });
+  });
+
+  it("opens immediately without fetching group members or miner snapshots", () => {
+    const onEdit = vi.fn();
+    const onView = vi.fn();
+
+    render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={onEdit} onView={onView} />);
+
+    fireEvent.click(screen.getByLabelText("Device set actions"));
+
+    expect(screen.getByTestId("group-actions-popover")).toBeInTheDocument();
+    expect(screen.getByTestId("view-group-popover-button")).toHaveTextContent("View group");
+    expect(screen.getByTestId("edit-group-popover-button")).toHaveTextContent("Edit group");
+    expect(mockListGroupMembers).not.toHaveBeenCalled();
+    expect(mockFetchAllMinerSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("fetches group members and snapshots only after a miner action is chosen", async () => {
+    const shutdownHandler = vi.fn();
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: shutdownHandler,
+          requiresConfirmation: false,
+        },
+      ],
+    }));
+    mockListGroupMembers.mockImplementation(
+      ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
+        onSuccess?.(["d1", "d2"]);
+        onFinally?.();
+      },
     );
+    mockFetchAllMinerSnapshots.mockResolvedValue({
+      d1: { deviceIdentifier: "d1" },
+      d2: { deviceIdentifier: "d2" },
+    });
+
+    render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
+
+    fireEvent.click(screen.getByLabelText("Device set actions"));
+
+    expect(mockListGroupMembers).not.toHaveBeenCalled();
+    expect(mockFetchAllMinerSnapshots).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(shutdownHandler).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockListGroupMembers).toHaveBeenCalledWith(expect.objectContaining({ deviceSetId: 1n }));
+    expect(mockFetchAllMinerSnapshots).toHaveBeenCalledWith({ groupIds: [1n] }, expect.any(AbortSignal));
     expect(mockUseMinerActions).toHaveBeenLastCalledWith(
-      expect.objectContaining({ selectedMiners: [{ deviceIdentifier: "fresh-device" }] }),
+      expect.objectContaining({
+        miners: expect.objectContaining({ d1: expect.anything(), d2: expect.anything() }),
+        selectedMiners: [{ deviceIdentifier: "d1" }, { deviceIdentifier: "d2" }],
+      }),
     );
   });
 
-  it("passes a non-aborted signal to fetchAllMinerSnapshots on open", async () => {
-    let capturedSignal: AbortSignal | undefined;
-    mockFetchAllMinerSnapshots.mockImplementation((_filter: unknown, signal?: AbortSignal) => {
-      capturedSignal = signal;
-      return new Promise(() => {});
-    });
+  it("replays a prop-member action against the member ids captured before snapshot fetch completes", async () => {
+    type SnapshotResolve = (value: Record<string, unknown>) => void;
+    let resolveSnapshots: SnapshotResolve | undefined;
+    const handledDeviceIds: string[][] = [];
+    mockUseMinerActions.mockImplementation(
+      ({ selectedMiners }: { selectedMiners: Array<{ deviceIdentifier: string }> }) => ({
+        ...defaultMinerActions(),
+        popoverActions: [
+          {
+            action: "shutdown",
+            title: "Sleep",
+            actionHandler: () => {
+              handledDeviceIds.push(selectedMiners.map((miner) => miner.deviceIdentifier));
+            },
+            requiresConfirmation: false,
+          },
+        ],
+      }),
+    );
+    mockFetchAllMinerSnapshots.mockImplementation(
+      () =>
+        new Promise<Record<string, unknown>>((resolve) => {
+          resolveSnapshots = resolve;
+        }),
+    );
 
-    render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
+    const { rerender } = render(
+      <DeviceSetActionsMenu memberDeviceIds={["before"]} deviceSetId={1n} onEdit={vi.fn()} />,
+    );
 
     fireEvent.click(screen.getByLabelText("Device set actions"));
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
 
     await waitFor(() => {
-      expect(mockFetchAllMinerSnapshots).toHaveBeenCalledTimes(1);
+      expect(resolveSnapshots).toBeDefined();
     });
 
-    expect(capturedSignal).toBeDefined();
-    expect(capturedSignal!.aborted).toBe(false);
+    rerender(<DeviceSetActionsMenu memberDeviceIds={["after"]} deviceSetId={1n} onEdit={vi.fn()} />);
+
+    await act(async () => {
+      resolveSnapshots?.({
+        before: { deviceIdentifier: "before" },
+        after: { deviceIdentifier: "after" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(handledDeviceIds).toEqual([["before"]]);
+    });
+    expect(mockListGroupMembers).not.toHaveBeenCalled();
   });
 
-  it("aborts the snapshot-fetch signal on close and creates a fresh signal on reopen", async () => {
+  it("keeps captured prop member ids active through scoped confirmation after prop refreshes", async () => {
+    type SnapshotResolve = (value: Record<string, unknown>) => void;
+    let resolveSnapshots: SnapshotResolve | undefined;
+    const handledDeviceIds: string[][] = [];
+    const actionActiveRef = { current: false };
+    mockUseMinerActions.mockImplementation(
+      ({
+        selectedMiners,
+        onActionComplete,
+      }: {
+        selectedMiners: Array<{ deviceIdentifier: string }>;
+        onActionComplete?: () => void;
+      }) => ({
+        ...defaultMinerActions(),
+        popoverActions: [
+          {
+            action: "shutdown",
+            title: "Sleep",
+            actionHandler: () => {
+              handledDeviceIds.push(selectedMiners.map((miner) => miner.deviceIdentifier));
+              onActionComplete?.();
+            },
+            requiresConfirmation: false,
+          },
+        ],
+      }),
+    );
+    mockFetchAllMinerSnapshots.mockImplementation(
+      () =>
+        new Promise<Record<string, unknown>>((resolve) => {
+          resolveSnapshots = resolve;
+        }),
+    );
+
+    const { rerender } = render(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["before"]}
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+        actionActiveRef={actionActiveRef}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Device set actions"));
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(resolveSnapshots).toBeDefined();
+      expect(actionActiveRef.current).toBe(true);
+    });
+
+    rerender(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["after-fetch-start"]}
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+        actionActiveRef={actionActiveRef}
+      />,
+    );
+
+    await act(async () => {
+      resolveSnapshots?.({
+        before: { deviceIdentifier: "before" },
+        "after-fetch-start": { deviceIdentifier: "after-fetch-start" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("group-actions-dialog")).toHaveTextContent("all 1 miner");
+    });
+    expect(mockUseMinerActions).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selectedMiners: [{ deviceIdentifier: "before" }],
+      }),
+    );
+
+    rerender(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["after-confirm-open"]}
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+        actionActiveRef={actionActiveRef}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockUseMinerActions).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          selectedMiners: [{ deviceIdentifier: "before" }],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(handledDeviceIds).toEqual([["before"]]);
+    await waitFor(() => {
+      expect(actionActiveRef.current).toBe(false);
+    });
+  });
+
+  it("clears an open scoped confirmation when the target scope changes", async () => {
+    const actionHandler = vi.fn();
+    const handleCancel = vi.fn();
+    const actionActiveRef = { current: false };
+    mockUseMinerActions.mockReturnValue({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "blink-leds",
+          title: "Blink LEDs",
+          actionHandler,
+          requiresConfirmation: false,
+        },
+      ],
+      handleCancel,
+    });
+
+    const { rerender } = render(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["site-1-miner"]}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "1", slug: "site-1" }}
+        activeSiteLabel="Site 1"
+        actionActiveRef={actionActiveRef}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Device set actions"));
+    fireEvent.click(screen.getByTestId("blink-leds-popover-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("group-actions-dialog")).toHaveTextContent("miners in Site 1");
+      expect(actionActiveRef.current).toBe(true);
+    });
+
+    rerender(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["site-2-miner"]}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+        actionActiveRef={actionActiveRef}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("group-actions-dialog")).not.toBeInTheDocument();
+      expect(actionActiveRef.current).toBe(false);
+    });
+    expect(handleCancel).toHaveBeenCalledWith({ notifyComplete: false });
+    expect(actionHandler).not.toHaveBeenCalled();
+  });
+
+  it("silently cancels local action state when an inactive row target changes", async () => {
+    const handleCancel = vi.fn();
+    const onActionComplete = vi.fn();
+    mockUseMinerActions.mockReturnValue({
+      ...defaultMinerActions(),
+      handleCancel,
+    });
+
+    const { rerender } = render(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["site-1-miner"]}
+        onEdit={vi.fn()}
+        onActionComplete={onActionComplete}
+        activeSite={{ kind: "site", id: "1", slug: "site-1" }}
+        activeSiteLabel="Site 1"
+      />,
+    );
+
+    rerender(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["site-2-miner"]}
+        onEdit={vi.fn()}
+        onActionComplete={onActionComplete}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(handleCancel).toHaveBeenCalledWith({ notifyComplete: false });
+    });
+    expect(onActionComplete).not.toHaveBeenCalled();
+  });
+
+  it("ignores stale action-complete callbacks from an older prepared action", async () => {
+    const completionCallbacks: Array<() => void> = [];
+    const selectedMinerCalls: string[][] = [];
+    const onActionComplete = vi.fn();
+    mockUseMinerActions.mockImplementation(
+      ({
+        selectedMiners,
+        onActionComplete: completeAction,
+      }: {
+        selectedMiners: Array<{ deviceIdentifier: string }>;
+        onActionComplete?: () => void;
+      }) => {
+        selectedMinerCalls.push(selectedMiners.map((miner) => miner.deviceIdentifier));
+        return {
+          ...defaultMinerActions(),
+          popoverActions: [
+            {
+              action: "blink-leds",
+              title: "Blink LEDs",
+              actionHandler: () => {
+                if (completeAction) completionCallbacks.push(completeAction);
+              },
+              requiresConfirmation: false,
+            },
+          ],
+        };
+      },
+    );
+    mockFetchAllMinerSnapshots.mockResolvedValue({ "rack-miner": { deviceIdentifier: "rack-miner" } });
+
+    const { rerender } = render(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["first-miner"]}
+        deviceSetId={1n}
+        deviceSetType="rack"
+        onEdit={vi.fn()}
+        onActionComplete={onActionComplete}
+      />,
+    );
+
+    const menuButton = screen.getByLabelText("Device set actions");
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByTestId("blink-leds-popover-button"));
+
+    await waitFor(() => {
+      expect(completionCallbacks).toHaveLength(1);
+      expect(selectedMinerCalls[selectedMinerCalls.length - 1]).toEqual(["first-miner"]);
+    });
+
+    rerender(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["second-miner"]}
+        deviceSetId={1n}
+        deviceSetType="rack"
+        onEdit={vi.fn()}
+        onActionComplete={onActionComplete}
+      />,
+    );
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByTestId("blink-leds-popover-button"));
+
+    await waitFor(() => {
+      expect(completionCallbacks).toHaveLength(2);
+      expect(selectedMinerCalls[selectedMinerCalls.length - 1]).toEqual(["second-miner"]);
+    });
+
+    rerender(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["refreshed-prop-miner"]}
+        deviceSetId={1n}
+        deviceSetType="rack"
+        onEdit={vi.fn()}
+        onActionComplete={onActionComplete}
+      />,
+    );
+
+    await act(async () => {
+      completionCallbacks[0]();
+    });
+
+    expect(onActionComplete).toHaveBeenCalledTimes(1);
+    expect(selectedMinerCalls[selectedMinerCalls.length - 1]).toEqual(["second-miner"]);
+  });
+
+  it("clears stale warning state when a non-confirming action supersedes a pending confirming action", async () => {
+    type SnapshotResolve = (value: Record<string, unknown>) => void;
+    let resolveFirstSnapshots: SnapshotResolve | undefined;
+    let snapshotCall = 0;
+    const actionActiveRef = { current: false };
+    mockUseMinerActions.mockImplementation(({ onActionComplete }: { onActionComplete?: () => void }) => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: vi.fn(),
+          requiresConfirmation: true,
+          confirmation: {
+            title: "Sleep miners?",
+            subtitle: "These miners will go to sleep and stop hashing.",
+            confirmAction: { title: "Sleep" },
+          },
+        },
+        {
+          action: "download-logs",
+          title: "Download logs",
+          actionHandler: () => {
+            onActionComplete?.();
+          },
+          requiresConfirmation: false,
+        },
+      ],
+    }));
+    mockFetchAllMinerSnapshots.mockImplementation(() => {
+      snapshotCall += 1;
+      if (snapshotCall === 1) {
+        return new Promise<Record<string, unknown>>((resolve) => {
+          resolveFirstSnapshots = resolve;
+        });
+      }
+      return Promise.resolve({ "rack-miner": { deviceIdentifier: "rack-miner" } });
+    });
+
+    render(
+      <DeviceSetActionsMenu
+        memberDeviceIds={["rack-miner"]}
+        deviceSetId={1n}
+        deviceSetType="rack"
+        onEdit={vi.fn()}
+        actionActiveRef={actionActiveRef}
+      />,
+    );
+
+    const menuButton = screen.getByLabelText("Device set actions");
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(resolveFirstSnapshots).toBeDefined();
+      expect(actionActiveRef.current).toBe(true);
+    });
+
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByTestId("download-logs-popover-button"));
+
+    await waitFor(() => {
+      expect(actionActiveRef.current).toBe(false);
+    });
+    expect(screen.queryByTestId("group-actions-dialog")).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveFirstSnapshots?.({ "rack-miner": { deviceIdentifier: "rack-miner" } });
+    });
+
+    expect(screen.queryByTestId("group-actions-dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not replay a scoped action when the lazy member fetch returns no scoped miners", async () => {
+    const shutdownHandler = vi.fn();
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: shutdownHandler,
+          requiresConfirmation: false,
+        },
+      ],
+    }));
+    mockListGroupMembers.mockImplementation(
+      ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
+        onSuccess?.([]);
+        onFinally?.();
+      },
+    );
+    mockFetchAllMinerSnapshots.mockResolvedValue({});
+
+    render(
+      <DeviceSetActionsMenu
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+      />,
+    );
+
+    const menuButton = screen.getByLabelText("Device set actions");
+    fireEvent.click(menuButton);
+    expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(mockListGroupMembers).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceSetId: 1n, siteIds: [2n], includeUnassigned: false }),
+      );
+    });
+    expect(shutdownHandler).not.toHaveBeenCalled();
+
+    fireEvent.click(menuButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("shutdown-popover-button")).toBeDisabled();
+    });
+  });
+
+  it("revalidates an empty scoped member cache when reopening the same target", async () => {
+    const shutdownHandler = vi.fn();
+    const memberResponses = [[], ["new-miner"], ["new-miner"]];
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: shutdownHandler,
+          requiresConfirmation: false,
+        },
+      ],
+    }));
+    mockListGroupMembers.mockImplementation(
+      ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
+        onSuccess?.(memberResponses.shift() ?? []);
+        onFinally?.();
+      },
+    );
+    mockFetchAllMinerSnapshots.mockResolvedValue({
+      "new-miner": { deviceIdentifier: "new-miner" },
+    });
+
+    render(
+      <DeviceSetActionsMenu
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+      />,
+    );
+
+    const menuButton = screen.getByLabelText("Device set actions");
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(mockListGroupMembers).toHaveBeenCalledTimes(1);
+    });
+    expect(shutdownHandler).not.toHaveBeenCalled();
+
+    fireEvent.click(menuButton);
+
+    await waitFor(() => {
+      expect(mockListGroupMembers).toHaveBeenCalledTimes(2);
+      expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(mockListGroupMembers).toHaveBeenCalledTimes(3);
+      expect(screen.getByTestId("group-actions-dialog")).toHaveTextContent("miners in Site 2");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(shutdownHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores stale empty-cache revalidation after an action fetch starts", async () => {
+    const shutdownHandler = vi.fn();
+    let refreshEmptyMembers: (() => void) | undefined;
+    let memberFetchCall = 0;
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: shutdownHandler,
+          requiresConfirmation: false,
+        },
+      ],
+    }));
+    mockListGroupMembers.mockImplementation(
+      ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
+        memberFetchCall += 1;
+        if (memberFetchCall === 1) {
+          onSuccess?.([]);
+          onFinally?.();
+          return;
+        }
+        if (memberFetchCall === 2) {
+          refreshEmptyMembers = () => {
+            onSuccess?.([]);
+            onFinally?.();
+          };
+          return;
+        }
+        onSuccess?.(["action-miner"]);
+        onFinally?.();
+      },
+    );
+    mockFetchAllMinerSnapshots.mockResolvedValue({
+      "action-miner": { deviceIdentifier: "action-miner" },
+    });
+
+    render(
+      <DeviceSetActionsMenu
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+      />,
+    );
+
+    const menuButton = screen.getByLabelText("Device set actions");
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(mockListGroupMembers).toHaveBeenCalledTimes(1);
+    });
+    expect(shutdownHandler).not.toHaveBeenCalled();
+
+    fireEvent.click(menuButton);
+
+    await waitFor(() => {
+      expect(mockListGroupMembers).toHaveBeenCalledTimes(2);
+      expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(mockListGroupMembers).toHaveBeenCalledTimes(3);
+      expect(screen.getByTestId("group-actions-dialog")).toHaveTextContent("miners in Site 2");
+    });
+
+    act(() => {
+      refreshEmptyMembers?.();
+    });
+
+    await waitFor(() => {
+      expect(mockUseMinerActions).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          selectedMiners: [{ deviceIdentifier: "action-miner" }],
+        }),
+      );
+      expect(screen.getByTestId("group-actions-dialog")).toBeInTheDocument();
+    });
+  });
+
+  it("does not reuse an empty scoped member cache after the target site changes", async () => {
+    const shutdownHandler = vi.fn();
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: shutdownHandler,
+          requiresConfirmation: false,
+        },
+      ],
+    }));
+    mockListGroupMembers.mockImplementation(
+      ({
+        siteIds,
+        onSuccess,
+        onFinally,
+      }: {
+        siteIds?: bigint[];
+        onSuccess?: (ids: string[]) => void;
+        onFinally?: () => void;
+      }) => {
+        onSuccess?.(siteIds?.[0] === 1n ? [] : ["site-2-miner"]);
+        onFinally?.();
+      },
+    );
+    mockFetchAllMinerSnapshots.mockImplementation((filter: { siteIds?: bigint[] }) =>
+      Promise.resolve(filter.siteIds?.[0] === 1n ? {} : { "site-2-miner": { deviceIdentifier: "site-2-miner" } }),
+    );
+
+    const { rerender } = render(
+      <DeviceSetActionsMenu
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "1", slug: "site-1" }}
+        activeSiteLabel="Site 1"
+      />,
+    );
+
+    const menuButton = screen.getByLabelText("Device set actions");
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(mockListGroupMembers).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceSetId: 1n, siteIds: [1n], includeUnassigned: false }),
+      );
+    });
+
+    fireEvent.click(menuButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("shutdown-popover-button")).toBeDisabled();
+    });
+
+    rerender(
+      <DeviceSetActionsMenu
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("shutdown-popover-button")).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(mockListGroupMembers).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceSetId: 1n, siteIds: [2n], includeUnassigned: false }),
+      );
+    });
+    expect(mockUseMinerActions).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        miners: expect.objectContaining({ "site-2-miner": expect.anything() }),
+        selectedMiners: [{ deviceIdentifier: "site-2-miner" }],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("group-actions-dialog")).toHaveTextContent("miners in Site 2");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(shutdownHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes a rackIds filter when a rack miner action is chosen", async () => {
+    const rebootHandler = vi.fn();
+    let capturedFilter: unknown;
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "reboot",
+          title: "Reboot",
+          actionHandler: rebootHandler,
+          requiresConfirmation: false,
+        },
+      ],
+    }));
+    mockListGroupMembers.mockImplementation(
+      ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
+        onSuccess?.(["rack-device"]);
+        onFinally?.();
+      },
+    );
+    mockFetchAllMinerSnapshots.mockImplementation((filter: unknown) => {
+      capturedFilter = filter;
+      return Promise.resolve({ "rack-device": { deviceIdentifier: "rack-device" } });
+    });
+
+    render(<DeviceSetActionsMenu deviceSetId={7n} deviceSetType="rack" onEdit={vi.fn()} />);
+
+    fireEvent.click(screen.getByLabelText("Device set actions"));
+    fireEvent.click(screen.getByTestId("reboot-popover-button"));
+
+    await waitFor(() => {
+      expect(rebootHandler).toHaveBeenCalledTimes(1);
+    });
+
+    expect(capturedFilter).toEqual({ rackIds: [7n] });
+  });
+
+  it("aborts an in-flight action fetch when another action fetch starts", async () => {
     const signals: AbortSignal[] = [];
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: vi.fn(),
+          requiresConfirmation: false,
+        },
+      ],
+    }));
+    mockListGroupMembers.mockImplementation(
+      ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
+        onSuccess?.(["d1"]);
+        onFinally?.();
+      },
+    );
     mockFetchAllMinerSnapshots.mockImplementation((_filter: unknown, signal?: AbortSignal) => {
       if (signal) signals.push(signal);
       return new Promise(() => {});
@@ -577,18 +1393,15 @@ describe("DeviceSetActionsMenu", () => {
 
     const button = screen.getByLabelText("Device set actions");
     fireEvent.click(button);
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
 
     await waitFor(() => {
       expect(signals).toHaveLength(1);
     });
-    expect(signals[0].aborted).toBe(false);
 
     fireEvent.click(button);
-    await waitFor(() => {
-      expect(signals[0].aborted).toBe(true);
-    });
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
 
-    fireEvent.click(button);
     await waitFor(() => {
       expect(signals).toHaveLength(2);
     });
@@ -597,34 +1410,46 @@ describe("DeviceSetActionsMenu", () => {
     expect(signals[1].aborted).toBe(false);
   });
 
-  it("ignores stale snapshot resolutions from a prior open", async () => {
+  it("ignores stale action fetch resolutions", async () => {
     type SnapshotResolve = (value: Record<string, unknown>) => void;
     const resolvers: SnapshotResolve[] = [];
-
-    mockFetchAllMinerSnapshots.mockImplementation(() => {
-      return new Promise<Record<string, unknown>>((resolve) => {
-        resolvers.push(resolve);
-      });
-    });
-
+    const shutdownHandler = vi.fn();
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: shutdownHandler,
+          requiresConfirmation: false,
+        },
+      ],
+    }));
     mockListGroupMembers.mockImplementation(
       ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
         onSuccess?.(["d1"]);
         onFinally?.();
       },
     );
+    mockFetchAllMinerSnapshots.mockImplementation(
+      () =>
+        new Promise<Record<string, unknown>>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
 
     render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
 
     const button = screen.getByLabelText("Device set actions");
     fireEvent.click(button);
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
 
     await waitFor(() => {
       expect(resolvers).toHaveLength(1);
     });
 
     fireEvent.click(button);
-    fireEvent.click(button);
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
 
     await waitFor(() => {
       expect(resolvers).toHaveLength(2);
@@ -634,143 +1459,125 @@ describe("DeviceSetActionsMenu", () => {
       resolvers[0]({ stale: {} });
     });
 
+    expect(mockUseMinerActions).not.toHaveBeenCalledWith(expect.objectContaining({ miners: { stale: {} } }));
+    expect(shutdownHandler).not.toHaveBeenCalled();
+
     act(() => {
       resolvers[1]({ fresh: {} });
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("group-actions-popover")).toBeInTheDocument();
+      expect(shutdownHandler).toHaveBeenCalledTimes(1);
     });
-
     expect(mockUseMinerActions).toHaveBeenLastCalledWith(expect.objectContaining({ miners: { fresh: {} } }));
   });
 
-  it("does not show spinner after close when deviceSetId becomes undefined", async () => {
-    mockFetchAllMinerSnapshots.mockReturnValue(new Promise(() => {}));
-
-    const { rerender, container } = render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
-
-    const button = screen.getByLabelText("Device set actions");
-    fireEvent.click(button);
-
-    expect(container.querySelector("svg.animate-spin")).not.toBeNull();
-
-    fireEvent.click(button);
-
-    rerender(<DeviceSetActionsMenu deviceSetId={undefined} onEdit={vi.fn()} />);
-
-    fireEvent.click(screen.getByLabelText("Device set actions"));
-
-    expect(container.querySelector("svg.animate-spin")).toBeNull();
-    expect(screen.queryByTestId("group-actions-popover")).toBeInTheDocument();
-  });
-
-  it("passes a rackIds filter to fetchAllMinerSnapshots when deviceSetType is 'rack'", async () => {
-    let capturedFilter: unknown;
-    mockFetchAllMinerSnapshots.mockImplementation((filter: unknown) => {
-      capturedFilter = filter;
-      return new Promise(() => {});
-    });
-
-    render(<DeviceSetActionsMenu deviceSetId={7n} deviceSetType="rack" onEdit={vi.fn()} />);
-
-    fireEvent.click(screen.getByLabelText("Device set actions"));
-
-    await waitFor(() => {
-      expect(mockFetchAllMinerSnapshots).toHaveBeenCalledTimes(1);
-    });
-
-    expect(capturedFilter).toEqual({ rackIds: [7n] });
-  });
-
-  it("aborts and re-fetches when deviceSetId changes while menu is open", async () => {
-    const snapshotCalls: Array<{ filter: unknown; signal?: AbortSignal }> = [];
-    mockFetchAllMinerSnapshots.mockImplementation((filter: unknown, signal?: AbortSignal) => {
-      snapshotCalls.push({ filter, signal });
-      return new Promise(() => {});
-    });
-
-    const { rerender } = render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
-
-    fireEvent.click(screen.getByLabelText("Device set actions"));
-
-    await waitFor(() => {
-      expect(snapshotCalls).toHaveLength(1);
-    });
-    expect(snapshotCalls[0].filter).toEqual({ groupIds: [1n] });
-    expect(snapshotCalls[0].signal?.aborted).toBe(false);
-    expect(mockListGroupMembers).toHaveBeenCalledTimes(1);
-    expect(mockListGroupMembers.mock.calls[0][0]).toMatchObject({ deviceSetId: 1n });
-
-    rerender(<DeviceSetActionsMenu deviceSetId={2n} onEdit={vi.fn()} />);
-
-    await waitFor(() => {
-      expect(snapshotCalls).toHaveLength(2);
-    });
-
-    expect(snapshotCalls[0].signal?.aborted).toBe(true);
-    expect(snapshotCalls[1].filter).toEqual({ groupIds: [2n] });
-    expect(snapshotCalls[1].signal?.aborted).toBe(false);
-    expect(mockListGroupMembers).toHaveBeenCalledTimes(2);
-    expect(mockListGroupMembers.mock.calls[1][0]).toMatchObject({ deviceSetId: 2n });
-  });
-
-  it("preserves fetched data across a popover action click (programmatic close)", async () => {
-    mockFetchAllMinerSnapshots.mockResolvedValueOnce({
-      d1: { deviceIdentifier: "d1" },
-      d2: { deviceIdentifier: "d2" },
-    });
+  it("aborts and ignores an in-flight action fetch when the target scope changes", async () => {
+    type SnapshotResolve = (value: Record<string, unknown>) => void;
+    const signals: AbortSignal[] = [];
+    const resolvers: SnapshotResolve[] = [];
+    const shutdownHandler = vi.fn();
+    const actionActiveRef = { current: false };
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: shutdownHandler,
+          requiresConfirmation: false,
+        },
+      ],
+    }));
     mockListGroupMembers.mockImplementation(
       ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
-        onSuccess?.(["d1", "d2"]);
+        onSuccess?.(["old-scope-miner"]);
         onFinally?.();
       },
     );
-
-    render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
-
-    fireEvent.click(screen.getByLabelText("Device set actions"));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("group-actions-popover")).toBeInTheDocument();
+    mockFetchAllMinerSnapshots.mockImplementation((_filter: unknown, signal?: AbortSignal) => {
+      if (signal) signals.push(signal);
+      return new Promise<Record<string, unknown>>((resolve) => {
+        resolvers.push(resolve);
+      });
     });
 
-    // Clicking a popover action triggers beforeEach → setIsOpen(false); this is the
-    // same programmatic-close path used by confirmation/modal flows. The fetched
-    // members/snapshots must survive so downstream handlers (captured via hook
-    // closures) see the correct selection rather than an empty one.
-    fireEvent.click(screen.getByTestId("edit-group-popover-button"));
+    const { rerender } = render(
+      <DeviceSetActionsMenu
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "1", slug: "site-1" }}
+        activeSiteLabel="Site 1"
+        actionActiveRef={actionActiveRef}
+      />,
+    );
 
-    expect(mockUseMinerActions).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        miners: expect.objectContaining({ d1: expect.anything(), d2: expect.anything() }),
-        selectedMiners: [{ deviceIdentifier: "d1" }, { deviceIdentifier: "d2" }],
-      }),
+    fireEvent.click(screen.getByLabelText("Device set actions"));
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
+
+    await waitFor(() => {
+      expect(signals).toHaveLength(1);
+      expect(actionActiveRef.current).toBe(true);
+    });
+
+    rerender(
+      <DeviceSetActionsMenu
+        deviceSetId={1n}
+        onEdit={vi.fn()}
+        activeSite={{ kind: "site", id: "2", slug: "site-2" }}
+        activeSiteLabel="Site 2"
+        actionActiveRef={actionActiveRef}
+      />,
+    );
+
+    expect(signals[0].aborted).toBe(true);
+    await waitFor(() => {
+      expect(actionActiveRef.current).toBe(false);
+    });
+
+    await act(async () => {
+      resolvers[0]({ "old-scope-miner": {} });
+    });
+
+    expect(shutdownHandler).not.toHaveBeenCalled();
+    expect(mockUseMinerActions).not.toHaveBeenCalledWith(
+      expect.objectContaining({ miners: { "old-scope-miner": {} } }),
     );
   });
 
-  it("clears stale data on close so reopening without deviceSetId shows no stale actions", async () => {
-    mockFetchAllMinerSnapshots.mockResolvedValueOnce({
-      stale1: { deviceIdentifier: "stale1" },
-      stale2: { deviceIdentifier: "stale2" },
-    });
+  it("clears stale data on reopen without a deviceSetId", async () => {
+    const shutdownHandler = vi.fn();
+    mockUseMinerActions.mockImplementation(() => ({
+      ...defaultMinerActions(),
+      popoverActions: [
+        {
+          action: "shutdown",
+          title: "Sleep",
+          actionHandler: shutdownHandler,
+          requiresConfirmation: false,
+        },
+      ],
+    }));
     mockListGroupMembers.mockImplementation(
       ({ onSuccess, onFinally }: { onSuccess?: (ids: string[]) => void; onFinally?: () => void }) => {
         onSuccess?.(["stale1", "stale2"]);
         onFinally?.();
       },
     );
+    mockFetchAllMinerSnapshots.mockResolvedValueOnce({
+      stale1: { deviceIdentifier: "stale1" },
+      stale2: { deviceIdentifier: "stale2" },
+    });
 
     const { rerender } = render(<DeviceSetActionsMenu deviceSetId={1n} onEdit={vi.fn()} />);
 
     const button = screen.getByLabelText("Device set actions");
     fireEvent.click(button);
+    fireEvent.click(screen.getByTestId("shutdown-popover-button"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("group-actions-popover")).toBeInTheDocument();
+      expect(shutdownHandler).toHaveBeenCalledTimes(1);
     });
-
-    // Confirm the first open surfaced the fetched data to useMinerActions
     expect(mockUseMinerActions).toHaveBeenLastCalledWith(
       expect.objectContaining({
         miners: expect.objectContaining({ stale1: expect.anything() }),
@@ -778,12 +1585,9 @@ describe("DeviceSetActionsMenu", () => {
       }),
     );
 
-    fireEvent.click(button);
-
     rerender(<DeviceSetActionsMenu deviceSetId={undefined} onEdit={vi.fn()} />);
     fireEvent.click(screen.getByLabelText("Device set actions"));
 
-    // After close + reopen without a deviceSetId, the previous fetch's data must not leak
     expect(mockUseMinerActions).toHaveBeenLastCalledWith(expect.objectContaining({ miners: {}, selectedMiners: [] }));
   });
 });

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
@@ -32,24 +32,25 @@ import Button, { type ButtonVariant, sizes, variants } from "@/shared/components
 import { type SelectionMode } from "@/shared/components/List";
 import { PopoverProvider, usePopover } from "@/shared/components/Popover";
 import { positions } from "@/shared/constants";
+import { pushToast, STATUSES as TOAST_STATUSES } from "@/shared/features/toaster";
 import { useClickOutside } from "@/shared/hooks/useClickOutside";
 
 type DeviceSetActionType = SupportedAction | "edit-group" | "view-group";
 type DeviceSetType = "group" | "rack";
-type TargetCachedMemberIds = {
-  targetKey: string;
-  ids: string[];
-};
-type TargetCachedMiners = {
-  targetKey: string;
+
+/**
+ * Member IDs and miner snapshots fetched when an action was chosen, frozen so
+ * later prop or membership changes cannot retarget an in-progress flow. The id
+ * identifies one prepare→run flow; completions carrying an older id are ignored.
+ */
+type PreparedAction = {
+  id: number;
+  action: DeviceSetActionType;
+  memberDeviceIds: string[];
   miners: Record<string, MinerStateSnapshot>;
 };
-type PreparedActionTarget = {
-  memberDeviceIds: string[];
-  targetKey: string;
-  version: number;
-  tick: number;
-};
+
+const noMiners: Record<string, MinerStateSnapshot> = {};
 
 interface DeviceSetActionsMenuProps {
   memberDeviceIds?: string[];
@@ -81,9 +82,24 @@ interface DeviceSetActionsMenuProps {
 }
 
 const DeviceSetActionsMenu = (props: DeviceSetActionsMenuProps) => {
+  const { deviceSetId, deviceSetType = "group", activeSite } = props;
+  const isScopedGroupAction = deviceSetType === "group" && activeSite !== undefined && activeSite.kind !== "all";
+  const siteScopeFilter =
+    isScopedGroupAction && activeSite ? siteFilterFromActive(activeSite) : { siteIds: [], includeUnassigned: false };
+  // Remount on target change: every dialog, fetch, and in-flight continuation
+  // belongs to one group/rack + site scope, so switching targets resets them
+  // wholesale instead of guarding each async path individually.
+  const targetKey = [
+    deviceSetType,
+    deviceSetId?.toString() ?? "",
+    isScopedGroupAction ? "scoped" : "unscoped",
+    siteScopeFilter.includeUnassigned ? "unassigned" : "assigned",
+    siteScopeFilter.siteIds.join(","),
+  ].join(":");
+
   return (
     <PopoverProvider>
-      <DeviceSetActionsMenuInner {...props} />
+      <DeviceSetActionsMenuInner key={targetKey} {...props} />
     </PopoverProvider>
   );
 };
@@ -119,53 +135,16 @@ const DeviceSetActionsMenuInner = ({
     if (!isScopedGroupAction || !activeSite) return "";
     return activeSite.kind === "unassigned" ? "unassigned miners" : (activeSiteLabel ?? `site ${activeSite.id}`);
   }, [activeSite, activeSiteLabel, isScopedGroupAction]);
-  const actionTargetKey = useMemo(
-    () =>
-      [
-        deviceSetType,
-        deviceSetId?.toString() ?? "",
-        isScopedGroupAction ? "scoped" : "unscoped",
-        siteScopeFilter.includeUnassigned ? "unassigned" : "assigned",
-        siteScopeFilter.siteIds.join(","),
-      ].join(":"),
-    [deviceSetId, deviceSetType, isScopedGroupAction, siteScopeFilter.includeUnassigned, siteScopeFilter.siteIds],
-  );
-  const actionTargetKeyRef = useRef(actionTargetKey);
-  const previousActionTargetKeyRef = useRef(actionTargetKey);
-  actionTargetKeyRef.current = actionTargetKey;
 
-  // Lazy-fetched member IDs for table context (when deviceSetId is provided but memberDeviceIds aren't)
-  const [fetchedMemberIds, setFetchedMemberIds] = useState<TargetCachedMemberIds | null>(null);
   const { listGroupMembers } = useDeviceSets();
 
-  // Lazy-fetched miner snapshots for firmware model checks
-  const [fetchedMiners, setFetchedMiners] = useState<TargetCachedMiners | null>(null);
-
-  const fetchVersionRef = useRef(0);
-  const fetchAbortRef = useRef<AbortController | null>(null);
   const propMemberDeviceIdsRef = useRef(propMemberDeviceIds);
-  const memberDeviceIdsRef = useRef<string[]>([]);
-  // Keep the ref in sync with the latest prop without re-running the fetch
-  // effect when only this prop changes (parents sometimes pass a new array
+  // Keep the ref in sync with the latest prop without re-creating the fetch
+  // callbacks when only this prop changes (parents sometimes pass a new array
   // reference on every render).
   useEffect(() => {
     propMemberDeviceIdsRef.current = propMemberDeviceIds;
   }, [propMemberDeviceIds]);
-
-  const cachedMemberIdsForTarget = useMemo(
-    () => (fetchedMemberIds?.targetKey === actionTargetKey ? fetchedMemberIds.ids : null),
-    [actionTargetKey, fetchedMemberIds],
-  );
-  const cachedMinersForTarget = useMemo(
-    () => (fetchedMiners?.targetKey === actionTargetKey ? fetchedMiners.miners : {}),
-    [actionTargetKey, fetchedMiners],
-  );
-  const memberDeviceIds = useMemo(
-    () => propMemberDeviceIds ?? cachedMemberIdsForTarget ?? [],
-    [propMemberDeviceIds, cachedMemberIdsForTarget],
-  );
-  memberDeviceIdsRef.current = memberDeviceIds;
-  const memberDeviceIdsLoaded = propMemberDeviceIds !== undefined || cachedMemberIdsForTarget !== null;
 
   useEffect(() => {
     setPopoverRenderMode("portal-fixed");
@@ -181,180 +160,61 @@ const DeviceSetActionsMenuInner = ({
     ignoreSelectors: [".popover-content"],
   });
 
-  const refreshEmptyMemberCache = useCallback(
-    (targetKey: string, id: bigint, version: number) => {
-      const controller = new AbortController();
-      let resolved = false;
-      const resolveOnce = (ids: string[]) => {
-        if (
-          resolved ||
-          controller.signal.aborted ||
-          targetKey !== actionTargetKeyRef.current ||
-          version !== fetchVersionRef.current
-        ) {
-          return;
-        }
-        resolved = true;
-        setFetchedMemberIds({ targetKey, ids });
-        if (ids.length === 0) {
-          setFetchedMiners({ targetKey, miners: {} });
-        }
-      };
-
-      listGroupMembers({
-        deviceSetId: id,
-        siteIds: siteScopeFilter.siteIds,
-        includeUnassigned: siteScopeFilter.includeUnassigned,
-        signal: controller.signal,
-        onSuccess: resolveOnce,
-        onError: () => resolveOnce([]),
-        onFinally: () => resolveOnce([]),
-      });
-
-      return controller;
-    },
-    [listGroupMembers, siteScopeFilter.includeUnassigned, siteScopeFilter.siteIds],
-  );
-
   const handleOpen = useCallback(() => {
-    const opening = !isOpen;
-
-    if (opening && !deviceSetId) {
-      setFetchedMemberIds(null);
-      setFetchedMiners(null);
-    } else if (opening && propMemberDeviceIds === undefined && deviceSetId && cachedMemberIdsForTarget?.length === 0) {
-      const targetKey = actionTargetKeyRef.current;
-      const version = fetchVersionRef.current;
-      setFetchedMemberIds(null);
-      setFetchedMiners(null);
-      refreshEmptyMemberCache(targetKey, deviceSetId, version);
-    }
-
-    setIsOpen(opening);
-  }, [cachedMemberIdsForTarget, deviceSetId, isOpen, propMemberDeviceIds, refreshEmptyMemberCache]);
+    setIsOpen((open) => !open);
+  }, []);
 
   const scopedActionsRef = useRef<BulkAction<DeviceSetActionType>[]>([]);
   const [showWarnDialog, setShowWarnDialog] = useState(false);
   const [pendingScopedAction, setPendingScopedAction] = useState<BulkAction<DeviceSetActionType> | null>(null);
-  const [pendingPreparedAction, setPendingPreparedAction] = useState<
-    | (PreparedActionTarget & {
-        action: DeviceSetActionType;
-        tick: number;
-      })
-    | null
-  >(null);
-  const [activePreparedAction, setActivePreparedAction] = useState<PreparedActionTarget | null>(null);
-  const [isPreparingAction, setIsPreparingAction] = useState(false);
-  const pendingPreparedActionForTarget =
-    pendingPreparedAction?.targetKey === actionTargetKey && pendingPreparedAction.version === fetchVersionRef.current
-      ? pendingPreparedAction
-      : null;
-  const activePreparedActionForTarget =
-    activePreparedAction?.targetKey === actionTargetKey && activePreparedAction.version === fetchVersionRef.current
-      ? activePreparedAction
-      : null;
-  const actionMemberDeviceIds =
-    activePreparedActionForTarget?.memberDeviceIds ??
-    pendingPreparedActionForTarget?.memberDeviceIds ??
-    memberDeviceIds;
-  const actionMemberDeviceIdsLoaded =
-    activePreparedActionForTarget !== null || pendingPreparedActionForTarget !== null || memberDeviceIdsLoaded;
+  const [pendingUnsupportedContinuation, setPendingUnsupportedContinuation] = useState<{
+    continueAction: () => void;
+  } | null>(null);
+
+  // Member data is fetched when an action is chosen, not when the menu opens,
+  // so the popover renders instantly and the data is fresh at the moment it
+  // matters.
+  const [preparedAction, setPreparedAction] = useState<PreparedAction | null>(null);
+  const [isPreparing, setIsPreparing] = useState(false);
+  const prepareIdRef = useRef(0);
+  const prepareAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => () => prepareAbortRef.current?.abort(), []);
+
+  const actionMemberDeviceIds = useMemo(
+    () => preparedAction?.memberDeviceIds ?? propMemberDeviceIds ?? [],
+    [preparedAction, propMemberDeviceIds],
+  );
+  const actionMemberDeviceIdsLoaded = preparedAction !== null || propMemberDeviceIds !== undefined;
   const selectedMinersWithStatus = useMemo(
     () => actionMemberDeviceIds.map((id) => ({ deviceIdentifier: id })),
     [actionMemberDeviceIds],
   );
-  const preparedActionTickRef = useRef(0);
-  const [pendingUnsupportedContinuation, setPendingUnsupportedContinuation] = useState<{
-    continueAction: () => void;
-  } | null>(null);
-  const preparedActionFlowActive =
-    isPreparingAction || pendingPreparedActionForTarget !== null || activePreparedActionForTarget !== null;
-  const preparedActionLifecycleTarget = activePreparedActionForTarget ?? pendingPreparedActionForTarget;
-  const actionLifecycleKey = preparedActionLifecycleTarget
-    ? `${preparedActionLifecycleTarget.targetKey}:${preparedActionLifecycleTarget.version}:${preparedActionLifecycleTarget.tick}`
-    : actionTargetKey;
 
-  const clearPreparedActionTarget = useCallback(() => {
-    setPendingPreparedAction(null);
-    setActivePreparedAction(null);
-    setIsPreparingAction(false);
+  const clearPreparedActionState = useCallback(() => {
+    ++prepareIdRef.current;
+    prepareAbortRef.current?.abort();
+    prepareAbortRef.current = null;
+    setIsPreparing(false);
+    setPreparedAction(null);
   }, []);
 
-  const clearMatchingPreparedActionTarget = useCallback(
-    (target: PreparedActionTarget | null) => {
-      if (!target) {
-        clearPreparedActionTarget();
-        return;
-      }
-
-      const matchesTarget = (candidate: PreparedActionTarget | null) =>
-        candidate?.targetKey === target.targetKey &&
-        candidate.version === target.version &&
-        candidate.tick === target.tick;
-
-      setPendingPreparedAction((current) => (matchesTarget(current) ? null : current));
-      setActivePreparedAction((current) => (matchesTarget(current) ? null : current));
-      if (target.version === fetchVersionRef.current) {
-        setIsPreparingAction(false);
-      }
-    },
-    [clearPreparedActionTarget],
-  );
-
-  const resetLocalPreparedActionState = useCallback(() => {
+  const resetActionFlowState = useCallback(() => {
     setPendingScopedAction(null);
     setPendingUnsupportedContinuation(null);
     setShowWarnDialog(false);
-    clearPreparedActionTarget();
-  }, [clearPreparedActionTarget]);
+    clearPreparedActionState();
+  }, [clearPreparedActionState]);
 
-  useEffect(() => {
-    return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional ref mutation in cleanup
-      ++fetchVersionRef.current;
-      fetchAbortRef.current?.abort();
-      fetchAbortRef.current = null;
-      resetLocalPreparedActionState();
-    };
-  }, [actionTargetKey, resetLocalPreparedActionState]);
-
-  const handlePreparedActionComplete = useCallback(() => {
-    clearMatchingPreparedActionTarget(preparedActionLifecycleTarget);
-    onActionComplete?.();
-  }, [clearMatchingPreparedActionTarget, onActionComplete, preparedActionLifecycleTarget]);
-
-  const handlePreparedActionCancel = useCallback(() => {
-    clearPreparedActionTarget();
-  }, [clearPreparedActionTarget]);
-
-  const setPendingPreparedTarget = useCallback(
-    (target: Omit<PreparedActionTarget, "tick"> & { action: DeviceSetActionType }) => {
-      preparedActionTickRef.current += 1;
-      setPendingPreparedAction({
-        ...target,
-        tick: preparedActionTickRef.current,
-      });
-    },
-    [],
-  );
-
-  const setActivePreparedTarget = useCallback((target: PreparedActionTarget) => {
-    setActivePreparedAction(target);
-  }, []);
-
-  const clearPendingPreparedAction = useCallback(() => {
-    setPendingPreparedAction(null);
-  }, []);
-
-  const markPreparingAction = useCallback(() => {
-    setIsPreparingAction(true);
-  }, []);
-
-  const clearPreparingActionForVersion = useCallback((version: number) => {
-    if (version === fetchVersionRef.current) {
-      setIsPreparingAction(false);
+  // Toast onClose callbacks capture this at registration, so a completion from
+  // an earlier flow clears only its own prepared action, never a newer one.
+  const preparedActionId = preparedAction?.id;
+  const handleActionComplete = useCallback(() => {
+    if (preparedActionId !== undefined) {
+      setPreparedAction((current) => (current?.id === preparedActionId ? null : current));
     }
-  }, []);
+    onActionComplete?.();
+  }, [onActionComplete, preparedActionId]);
 
   const {
     currentAction,
@@ -396,9 +256,8 @@ const DeviceSetActionsMenuInner = ({
     startBatchOperation: batchOps.startBatchOperation,
     completeBatchOperation: batchOps.completeBatchOperation,
     removeDevicesFromBatch: batchOps.removeDevicesFromBatch,
-    miners: cachedMinersForTarget,
-    actionLifecycleKey,
-    onActionComplete: handlePreparedActionComplete,
+    miners: preparedAction?.miners ?? noMiners,
+    onActionComplete: handleActionComplete,
     onUnsupportedMinersContinue: ({ action, continueAction }) => {
       if (!isScopedGroupAction) return false;
       const scopedAction = scopedActionsRef.current.find((candidate) => candidate.action === action);
@@ -411,20 +270,12 @@ const DeviceSetActionsMenuInner = ({
     },
   });
 
-  useEffect(() => {
-    if (previousActionTargetKeyRef.current === actionTargetKey) return;
-    previousActionTargetKeyRef.current = actionTargetKey;
-    queueMicrotask(() => {
-      handleCancel({ notifyComplete: false });
-      resetLocalPreparedActionState();
-    });
-  }, [actionTargetKey, handleCancel, resetLocalPreparedActionState]);
-
   // Keep actionActiveRef in sync so the parent can pause polling during action flows
   useEffect(() => {
     if (actionActiveRef) {
       actionActiveRef.current =
-        preparedActionFlowActive ||
+        isPreparing ||
+        preparedAction !== null ||
         currentAction !== null ||
         showWarnDialog ||
         unsupportedMinersInfo.visible ||
@@ -438,7 +289,8 @@ const DeviceSetActionsMenuInner = ({
   }, [
     actionActiveRef,
     currentAction,
-    preparedActionFlowActive,
+    isPreparing,
+    preparedAction,
     showAuthenticateFleetModal,
     showCoolingModeModal,
     showManagePowerModal,
@@ -579,63 +431,36 @@ const DeviceSetActionsMenuInner = ({
     async (action: DeviceSetActionType) => {
       if (action === "edit-group" || action === "view-group") return;
 
+      const id = ++prepareIdRef.current;
+
       const filter = getSnapshotFilter();
       if (!deviceSetId || !filter) {
-        setPendingPreparedTarget({
-          action,
-          memberDeviceIds: memberDeviceIdsRef.current,
-          targetKey: actionTargetKeyRef.current,
-          version: fetchVersionRef.current,
-        });
+        setPreparedAction({ id, action, memberDeviceIds: propMemberDeviceIdsRef.current ?? [], miners: noMiners });
         return;
       }
 
-      const version = ++fetchVersionRef.current;
-      const targetKey = actionTargetKeyRef.current;
-      markPreparingAction();
-      fetchAbortRef.current?.abort();
+      setIsPreparing(true);
+      prepareAbortRef.current?.abort();
       const controller = new AbortController();
-      fetchAbortRef.current = controller;
-      const isCurrent = () =>
-        version === fetchVersionRef.current && !controller.signal.aborted && targetKey === actionTargetKeyRef.current;
-
-      if (!propMemberDeviceIdsRef.current) {
-        setFetchedMemberIds(null);
-      }
-      setFetchedMiners(null);
+      prepareAbortRef.current = controller;
 
       const [ids, miners] = await Promise.all([
         fetchMemberIdsForAction(deviceSetId, controller.signal),
         fetchAllMinerSnapshots(filter, controller.signal).catch(() => ({})),
       ]);
 
-      if (!isCurrent()) {
-        clearPreparingActionForVersion(version);
+      // A newer prepare or a cancel superseded this fetch; whoever did now owns the state.
+      if (id !== prepareIdRef.current || controller.signal.aborted) return;
+
+      setIsPreparing(false);
+      if (isScopedGroupAction && ids.length === 0) {
+        setShowWarnDialog(false);
+        pushToast({ message: `No miners in ${siteScopeLabel}.`, status: TOAST_STATUSES.error });
         return;
       }
-
-      if (!propMemberDeviceIdsRef.current) {
-        setFetchedMemberIds({ targetKey, ids });
-      }
-      setFetchedMiners({ targetKey, miners });
-      clearPreparingActionForVersion(version);
-      if (isScopedGroupAction && ids.length === 0) return;
-      setPendingPreparedTarget({
-        action,
-        memberDeviceIds: ids,
-        targetKey,
-        version,
-      });
+      setPreparedAction({ id, action, memberDeviceIds: ids, miners });
     },
-    [
-      clearPreparingActionForVersion,
-      deviceSetId,
-      fetchMemberIdsForAction,
-      getSnapshotFilter,
-      isScopedGroupAction,
-      markPreparingAction,
-      setPendingPreparedTarget,
-    ],
+    [deviceSetId, fetchMemberIdsForAction, getSnapshotFilter, isScopedGroupAction, siteScopeLabel],
   );
 
   // Expose the sleep action handler to the parent via ref
@@ -686,8 +511,8 @@ const DeviceSetActionsMenuInner = ({
     setPendingScopedAction(null);
     setShowWarnDialog(false);
     handleCancel();
-    handlePreparedActionCancel();
-  }, [handleCancel, handlePreparedActionCancel]);
+    clearPreparedActionState();
+  }, [handleCancel, clearPreparedActionState]);
 
   const scopedGroupPopoverActions = useMemo(() => {
     if (!isScopedGroupAction) return groupPopoverActions;
@@ -746,54 +571,21 @@ const DeviceSetActionsMenuInner = ({
     scopedActionsRef.current = scopedGroupPopoverActions;
   }, [scopedGroupPopoverActions]);
 
+  // Run the chosen action once its frozen member IDs/snapshots have rendered
+  // into useMinerActions. Runs at most once per prepared action.
+  const replayedIdRef = useRef(0);
   useEffect(() => {
-    if (!pendingPreparedAction) return;
-    if (
-      pendingPreparedAction.targetKey !== actionTargetKey ||
-      pendingPreparedAction.version !== fetchVersionRef.current
-    ) {
+    if (!preparedAction || replayedIdRef.current === preparedAction.id) return;
+    replayedIdRef.current = preparedAction.id;
+    const action = scopedGroupPopoverActions.find((candidate) => candidate.action === preparedAction.action);
+    if (!action || action.disabled) {
       queueMicrotask(() => {
-        clearPendingPreparedAction();
+        setPreparedAction((current) => (current?.id === preparedAction.id ? null : current));
       });
       return;
     }
-    const action = scopedGroupPopoverActions.find((candidate) => candidate.action === pendingPreparedAction.action);
-    if (action?.disabled) {
-      queueMicrotask(() => {
-        clearPendingPreparedAction();
-      });
-      return;
-    }
-    if (!action) {
-      queueMicrotask(() => {
-        clearPendingPreparedAction();
-      });
-      return;
-    }
-
-    queueMicrotask(() => {
-      if (
-        pendingPreparedAction.targetKey !== actionTargetKeyRef.current ||
-        pendingPreparedAction.version !== fetchVersionRef.current
-      ) {
-        return;
-      }
-      setActivePreparedTarget({
-        memberDeviceIds: pendingPreparedAction.memberDeviceIds,
-        targetKey: pendingPreparedAction.targetKey,
-        version: pendingPreparedAction.version,
-        tick: pendingPreparedAction.tick,
-      });
-      clearPendingPreparedAction();
-      action.actionHandler();
-    });
-  }, [
-    actionTargetKey,
-    clearPendingPreparedAction,
-    pendingPreparedAction,
-    scopedGroupPopoverActions,
-    setActivePreparedTarget,
-  ]);
+    action.actionHandler();
+  }, [preparedAction, scopedGroupPopoverActions]);
 
   const displayedGroupPopoverActions = useMemo(
     () =>
@@ -818,9 +610,9 @@ const DeviceSetActionsMenuInner = ({
   }, [handleUnsupportedMinersContinue]);
 
   const handleUnsupportedMinersDismissWithReset = useCallback(() => {
-    resetLocalPreparedActionState();
+    resetActionFlowState();
     handleUnsupportedMinersDismiss();
-  }, [handleUnsupportedMinersDismiss, resetLocalPreparedActionState]);
+  }, [handleUnsupportedMinersDismiss, resetActionFlowState]);
 
   return (
     <>

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx
@@ -31,12 +31,25 @@ import { iconSizes } from "@/shared/assets/icons/constants";
 import Button, { type ButtonVariant, sizes, variants } from "@/shared/components/Button";
 import { type SelectionMode } from "@/shared/components/List";
 import { PopoverProvider, usePopover } from "@/shared/components/Popover";
-import ProgressCircular from "@/shared/components/ProgressCircular";
 import { positions } from "@/shared/constants";
 import { useClickOutside } from "@/shared/hooks/useClickOutside";
 
 type DeviceSetActionType = SupportedAction | "edit-group" | "view-group";
 type DeviceSetType = "group" | "rack";
+type TargetCachedMemberIds = {
+  targetKey: string;
+  ids: string[];
+};
+type TargetCachedMiners = {
+  targetKey: string;
+  miners: Record<string, MinerStateSnapshot>;
+};
+type PreparedActionTarget = {
+  memberDeviceIds: string[];
+  targetKey: string;
+  version: number;
+  tick: number;
+};
 
 interface DeviceSetActionsMenuProps {
   memberDeviceIds?: string[];
@@ -106,18 +119,32 @@ const DeviceSetActionsMenuInner = ({
     if (!isScopedGroupAction || !activeSite) return "";
     return activeSite.kind === "unassigned" ? "unassigned miners" : (activeSiteLabel ?? `site ${activeSite.id}`);
   }, [activeSite, activeSiteLabel, isScopedGroupAction]);
+  const actionTargetKey = useMemo(
+    () =>
+      [
+        deviceSetType,
+        deviceSetId?.toString() ?? "",
+        isScopedGroupAction ? "scoped" : "unscoped",
+        siteScopeFilter.includeUnassigned ? "unassigned" : "assigned",
+        siteScopeFilter.siteIds.join(","),
+      ].join(":"),
+    [deviceSetId, deviceSetType, isScopedGroupAction, siteScopeFilter.includeUnassigned, siteScopeFilter.siteIds],
+  );
+  const actionTargetKeyRef = useRef(actionTargetKey);
+  const previousActionTargetKeyRef = useRef(actionTargetKey);
+  actionTargetKeyRef.current = actionTargetKey;
 
   // Lazy-fetched member IDs for table context (when deviceSetId is provided but memberDeviceIds aren't)
-  const [fetchedMemberIds, setFetchedMemberIds] = useState<string[] | null>(null);
-  const [fetchingMembers, setFetchingMembers] = useState(false);
+  const [fetchedMemberIds, setFetchedMemberIds] = useState<TargetCachedMemberIds | null>(null);
   const { listGroupMembers } = useDeviceSets();
 
   // Lazy-fetched miner snapshots for firmware model checks
-  const [fetchedMiners, setFetchedMiners] = useState<Record<string, MinerStateSnapshot>>({});
-  const [fetchingMiners, setFetchingMiners] = useState(false);
+  const [fetchedMiners, setFetchedMiners] = useState<TargetCachedMiners | null>(null);
 
   const fetchVersionRef = useRef(0);
+  const fetchAbortRef = useRef<AbortController | null>(null);
   const propMemberDeviceIdsRef = useRef(propMemberDeviceIds);
+  const memberDeviceIdsRef = useRef<string[]>([]);
   // Keep the ref in sync with the latest prop without re-running the fetch
   // effect when only this prop changes (parents sometimes pass a new array
   // reference on every render).
@@ -125,10 +152,20 @@ const DeviceSetActionsMenuInner = ({
     propMemberDeviceIdsRef.current = propMemberDeviceIds;
   }, [propMemberDeviceIds]);
 
-  const memberDeviceIds = useMemo(
-    () => propMemberDeviceIds ?? fetchedMemberIds ?? [],
-    [propMemberDeviceIds, fetchedMemberIds],
+  const cachedMemberIdsForTarget = useMemo(
+    () => (fetchedMemberIds?.targetKey === actionTargetKey ? fetchedMemberIds.ids : null),
+    [actionTargetKey, fetchedMemberIds],
   );
+  const cachedMinersForTarget = useMemo(
+    () => (fetchedMiners?.targetKey === actionTargetKey ? fetchedMiners.miners : {}),
+    [actionTargetKey, fetchedMiners],
+  );
+  const memberDeviceIds = useMemo(
+    () => propMemberDeviceIds ?? cachedMemberIdsForTarget ?? [],
+    [propMemberDeviceIds, cachedMemberIdsForTarget],
+  );
+  memberDeviceIdsRef.current = memberDeviceIds;
+  const memberDeviceIdsLoaded = propMemberDeviceIds !== undefined || cachedMemberIdsForTarget !== null;
 
   useEffect(() => {
     setPopoverRenderMode("portal-fixed");
@@ -144,122 +181,180 @@ const DeviceSetActionsMenuInner = ({
     ignoreSelectors: [".popover-content"],
   });
 
-  const handleOpen = useCallback(() => {
-    const opening = !isOpen;
-
-    if (opening) {
-      if (deviceSetId) {
-        setFetchedMiners({});
-        setFetchingMiners(true);
-
-        if (!propMemberDeviceIds) {
-          setFetchedMemberIds(null);
-          setFetchingMembers(true);
-        } else {
-          setFetchingMembers(false);
+  const refreshEmptyMemberCache = useCallback(
+    (targetKey: string, id: bigint, version: number) => {
+      const controller = new AbortController();
+      let resolved = false;
+      const resolveOnce = (ids: string[]) => {
+        if (
+          resolved ||
+          controller.signal.aborted ||
+          targetKey !== actionTargetKeyRef.current ||
+          version !== fetchVersionRef.current
+        ) {
+          return;
         }
-      } else {
-        // No deviceSetId: the fetch effect will bail out, so clear any stale
-        // data from a prior open so the menu does not show a previous group's
-        // members/snapshots.
-        setFetchedMemberIds(null);
-        setFetchedMiners({});
-      }
-    }
+        resolved = true;
+        setFetchedMemberIds({ targetKey, ids });
+        if (ids.length === 0) {
+          setFetchedMiners({ targetKey, miners: {} });
+        }
+      };
 
-    setIsOpen(opening);
-  }, [isOpen, deviceSetId, propMemberDeviceIds]);
-
-  // Fetch member IDs and miner snapshots when the menu opens.
-  // Always refetch on open so membership changes are picked up.
-  // A version counter prevents stale callbacks from updating state after
-  // the effect re-fires (e.g. close/re-open, deviceSetId change).
-  useEffect(() => {
-    if (!isOpen || !deviceSetId) return;
-
-    const version = ++fetchVersionRef.current;
-    const controller = new AbortController();
-    const isCurrent = () => version === fetchVersionRef.current;
-
-    /* eslint-disable react-hooks/set-state-in-effect -- fetch members + miners on open; setState inside async callbacks is the external-sync pattern */
-    if (!propMemberDeviceIdsRef.current) {
-      setFetchedMemberIds(null);
-      setFetchingMembers(true);
       listGroupMembers({
-        deviceSetId,
+        deviceSetId: id,
         siteIds: siteScopeFilter.siteIds,
         includeUnassigned: siteScopeFilter.includeUnassigned,
         signal: controller.signal,
-        onSuccess: (ids) => {
-          if (isCurrent()) setFetchedMemberIds(ids);
-        },
-        onFinally: () => {
-          if (isCurrent()) setFetchingMembers(false);
-        },
+        onSuccess: resolveOnce,
+        onError: () => resolveOnce([]),
+        onFinally: () => resolveOnce([]),
       });
-    } else {
-      setFetchingMembers(false);
+
+      return controller;
+    },
+    [listGroupMembers, siteScopeFilter.includeUnassigned, siteScopeFilter.siteIds],
+  );
+
+  const handleOpen = useCallback(() => {
+    const opening = !isOpen;
+
+    if (opening && !deviceSetId) {
+      setFetchedMemberIds(null);
+      setFetchedMiners(null);
+    } else if (opening && propMemberDeviceIds === undefined && deviceSetId && cachedMemberIdsForTarget?.length === 0) {
+      const targetKey = actionTargetKeyRef.current;
+      const version = fetchVersionRef.current;
+      setFetchedMemberIds(null);
+      setFetchedMiners(null);
+      refreshEmptyMemberCache(targetKey, deviceSetId, version);
     }
 
-    const filter = (() => {
-      if (deviceSetType === "rack") {
-        return { rackIds: [deviceSetId] };
-      }
-      if (!isScopedGroupAction) {
-        return { groupIds: [deviceSetId] };
-      }
-      return {
-        groupIds: [deviceSetId],
-        siteIds: siteScopeFilter.siteIds,
-        includeUnassigned: siteScopeFilter.includeUnassigned,
-      };
-    })();
-    setFetchedMiners({});
-    setFetchingMiners(true);
-    /* eslint-enable react-hooks/set-state-in-effect */
-    fetchAllMinerSnapshots(filter, controller.signal)
-      .then((map) => {
-        if (isCurrent()) setFetchedMiners(map);
-      })
-      .catch(() => {
-        // Non-critical — firmware update will show a warning instead
-      })
-      .finally(() => {
-        if (isCurrent()) setFetchingMiners(false);
-      });
+    setIsOpen(opening);
+  }, [cachedMemberIdsForTarget, deviceSetId, isOpen, propMemberDeviceIds, refreshEmptyMemberCache]);
 
-    return () => {
-      // Invalidate version so stale callbacks are rejected.
-      // Data state (fetchedMemberIds/fetchedMiners) is deliberately preserved
-      // here so that programmatic closes during confirmation/modal flows do
-      // not empty the selection that downstream handlers rely on. Stale data
-      // is cleared in handleOpen when reopening without a deviceSetId.
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional ref mutation in cleanup
-      ++fetchVersionRef.current;
-      controller.abort();
-      setFetchingMembers(false);
-      setFetchingMiners(false);
-    };
-  }, [
-    isOpen,
-    deviceSetId,
-    deviceSetType,
-    isScopedGroupAction,
-    listGroupMembers,
-    siteScopeFilter.includeUnassigned,
-    siteScopeFilter.siteIds,
-  ]);
-
-  const selectedMinersWithStatus = useMemo(
-    () => memberDeviceIds.map((id) => ({ deviceIdentifier: id })),
-    [memberDeviceIds],
-  );
   const scopedActionsRef = useRef<BulkAction<DeviceSetActionType>[]>([]);
   const [showWarnDialog, setShowWarnDialog] = useState(false);
   const [pendingScopedAction, setPendingScopedAction] = useState<BulkAction<DeviceSetActionType> | null>(null);
+  const [pendingPreparedAction, setPendingPreparedAction] = useState<
+    | (PreparedActionTarget & {
+        action: DeviceSetActionType;
+        tick: number;
+      })
+    | null
+  >(null);
+  const [activePreparedAction, setActivePreparedAction] = useState<PreparedActionTarget | null>(null);
+  const [isPreparingAction, setIsPreparingAction] = useState(false);
+  const pendingPreparedActionForTarget =
+    pendingPreparedAction?.targetKey === actionTargetKey && pendingPreparedAction.version === fetchVersionRef.current
+      ? pendingPreparedAction
+      : null;
+  const activePreparedActionForTarget =
+    activePreparedAction?.targetKey === actionTargetKey && activePreparedAction.version === fetchVersionRef.current
+      ? activePreparedAction
+      : null;
+  const actionMemberDeviceIds =
+    activePreparedActionForTarget?.memberDeviceIds ??
+    pendingPreparedActionForTarget?.memberDeviceIds ??
+    memberDeviceIds;
+  const actionMemberDeviceIdsLoaded =
+    activePreparedActionForTarget !== null || pendingPreparedActionForTarget !== null || memberDeviceIdsLoaded;
+  const selectedMinersWithStatus = useMemo(
+    () => actionMemberDeviceIds.map((id) => ({ deviceIdentifier: id })),
+    [actionMemberDeviceIds],
+  );
+  const preparedActionTickRef = useRef(0);
   const [pendingUnsupportedContinuation, setPendingUnsupportedContinuation] = useState<{
     continueAction: () => void;
   } | null>(null);
+  const preparedActionFlowActive =
+    isPreparingAction || pendingPreparedActionForTarget !== null || activePreparedActionForTarget !== null;
+  const preparedActionLifecycleTarget = activePreparedActionForTarget ?? pendingPreparedActionForTarget;
+  const actionLifecycleKey = preparedActionLifecycleTarget
+    ? `${preparedActionLifecycleTarget.targetKey}:${preparedActionLifecycleTarget.version}:${preparedActionLifecycleTarget.tick}`
+    : actionTargetKey;
+
+  const clearPreparedActionTarget = useCallback(() => {
+    setPendingPreparedAction(null);
+    setActivePreparedAction(null);
+    setIsPreparingAction(false);
+  }, []);
+
+  const clearMatchingPreparedActionTarget = useCallback(
+    (target: PreparedActionTarget | null) => {
+      if (!target) {
+        clearPreparedActionTarget();
+        return;
+      }
+
+      const matchesTarget = (candidate: PreparedActionTarget | null) =>
+        candidate?.targetKey === target.targetKey &&
+        candidate.version === target.version &&
+        candidate.tick === target.tick;
+
+      setPendingPreparedAction((current) => (matchesTarget(current) ? null : current));
+      setActivePreparedAction((current) => (matchesTarget(current) ? null : current));
+      if (target.version === fetchVersionRef.current) {
+        setIsPreparingAction(false);
+      }
+    },
+    [clearPreparedActionTarget],
+  );
+
+  const resetLocalPreparedActionState = useCallback(() => {
+    setPendingScopedAction(null);
+    setPendingUnsupportedContinuation(null);
+    setShowWarnDialog(false);
+    clearPreparedActionTarget();
+  }, [clearPreparedActionTarget]);
+
+  useEffect(() => {
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional ref mutation in cleanup
+      ++fetchVersionRef.current;
+      fetchAbortRef.current?.abort();
+      fetchAbortRef.current = null;
+      resetLocalPreparedActionState();
+    };
+  }, [actionTargetKey, resetLocalPreparedActionState]);
+
+  const handlePreparedActionComplete = useCallback(() => {
+    clearMatchingPreparedActionTarget(preparedActionLifecycleTarget);
+    onActionComplete?.();
+  }, [clearMatchingPreparedActionTarget, onActionComplete, preparedActionLifecycleTarget]);
+
+  const handlePreparedActionCancel = useCallback(() => {
+    clearPreparedActionTarget();
+  }, [clearPreparedActionTarget]);
+
+  const setPendingPreparedTarget = useCallback(
+    (target: Omit<PreparedActionTarget, "tick"> & { action: DeviceSetActionType }) => {
+      preparedActionTickRef.current += 1;
+      setPendingPreparedAction({
+        ...target,
+        tick: preparedActionTickRef.current,
+      });
+    },
+    [],
+  );
+
+  const setActivePreparedTarget = useCallback((target: PreparedActionTarget) => {
+    setActivePreparedAction(target);
+  }, []);
+
+  const clearPendingPreparedAction = useCallback(() => {
+    setPendingPreparedAction(null);
+  }, []);
+
+  const markPreparingAction = useCallback(() => {
+    setIsPreparingAction(true);
+  }, []);
+
+  const clearPreparingActionForVersion = useCallback((version: number) => {
+    if (version === fetchVersionRef.current) {
+      setIsPreparingAction(false);
+    }
+  }, []);
 
   const {
     currentAction,
@@ -301,8 +396,9 @@ const DeviceSetActionsMenuInner = ({
     startBatchOperation: batchOps.startBatchOperation,
     completeBatchOperation: batchOps.completeBatchOperation,
     removeDevicesFromBatch: batchOps.removeDevicesFromBatch,
-    miners: fetchedMiners,
-    onActionComplete,
+    miners: cachedMinersForTarget,
+    actionLifecycleKey,
+    onActionComplete: handlePreparedActionComplete,
     onUnsupportedMinersContinue: ({ action, continueAction }) => {
       if (!isScopedGroupAction) return false;
       const scopedAction = scopedActionsRef.current.find((candidate) => candidate.action === action);
@@ -315,12 +411,43 @@ const DeviceSetActionsMenuInner = ({
     },
   });
 
+  useEffect(() => {
+    if (previousActionTargetKeyRef.current === actionTargetKey) return;
+    previousActionTargetKeyRef.current = actionTargetKey;
+    queueMicrotask(() => {
+      handleCancel({ notifyComplete: false });
+      resetLocalPreparedActionState();
+    });
+  }, [actionTargetKey, handleCancel, resetLocalPreparedActionState]);
+
   // Keep actionActiveRef in sync so the parent can pause polling during action flows
   useEffect(() => {
     if (actionActiveRef) {
-      actionActiveRef.current = currentAction !== null;
+      actionActiveRef.current =
+        preparedActionFlowActive ||
+        currentAction !== null ||
+        showWarnDialog ||
+        unsupportedMinersInfo.visible ||
+        showPoolSelectionPage ||
+        showManagePowerModal ||
+        showCoolingModeModal ||
+        showAuthenticateFleetModal ||
+        showUpdatePasswordModal ||
+        showManageSecurityModal;
     }
-  }, [actionActiveRef, currentAction]);
+  }, [
+    actionActiveRef,
+    currentAction,
+    preparedActionFlowActive,
+    showAuthenticateFleetModal,
+    showCoolingModeModal,
+    showManagePowerModal,
+    showManageSecurityModal,
+    showPoolSelectionPage,
+    showUpdatePasswordModal,
+    showWarnDialog,
+    unsupportedMinersInfo.visible,
+  ]);
 
   // Customize actions for group context:
   // 1. Filter out "Add to group" (already in a group)
@@ -378,7 +505,7 @@ const DeviceSetActionsMenuInner = ({
 
   const scopedActionSummary = useMemo(() => {
     if (!isScopedGroupAction) return "";
-    const scopedCount = memberDeviceIds.length;
+    const scopedCount = actionMemberDeviceIds.length;
     const totalCount = totalMemberCount ?? scopedCount;
     const groupLabel = deviceSetLabel ?? "this group";
     const scopeLabel = activeSite?.kind === "unassigned" ? "unassigned miners" : `miners in ${siteScopeLabel}`;
@@ -387,7 +514,14 @@ const DeviceSetActionsMenuInner = ({
         ? `all ${scopedCount} ${scopedCount === 1 ? "miner" : "miners"} in ${groupLabel}`
         : `${scopedCount} of the ${totalCount} miners in ${groupLabel}`;
     return `This action only applies to ${scopeLabel}, ${countSummary}`;
-  }, [activeSite?.kind, deviceSetLabel, isScopedGroupAction, memberDeviceIds.length, siteScopeLabel, totalMemberCount]);
+  }, [
+    actionMemberDeviceIds.length,
+    activeSite?.kind,
+    deviceSetLabel,
+    isScopedGroupAction,
+    siteScopeLabel,
+    totalMemberCount,
+  ]);
 
   const scopedActionSubtitle = useCallback(
     (subtitle?: string) => {
@@ -399,6 +533,111 @@ const DeviceSetActionsMenuInner = ({
     [scopedActionSummary],
   );
 
+  const getSnapshotFilter = useCallback(() => {
+    if (!deviceSetId) return undefined;
+    if (deviceSetType === "rack") {
+      return { rackIds: [deviceSetId] };
+    }
+    if (!isScopedGroupAction) {
+      return { groupIds: [deviceSetId] };
+    }
+    return {
+      groupIds: [deviceSetId],
+      siteIds: siteScopeFilter.siteIds,
+      includeUnassigned: siteScopeFilter.includeUnassigned,
+    };
+  }, [deviceSetId, deviceSetType, isScopedGroupAction, siteScopeFilter.includeUnassigned, siteScopeFilter.siteIds]);
+
+  const fetchMemberIdsForAction = useCallback(
+    (deviceSetId: bigint, signal: AbortSignal) => {
+      const propIds = propMemberDeviceIdsRef.current;
+      if (propIds) return Promise.resolve(propIds);
+
+      return new Promise<string[]>((resolve) => {
+        let resolved = false;
+        const resolveOnce = (ids: string[]) => {
+          if (resolved) return;
+          resolved = true;
+          resolve(ids);
+        };
+
+        listGroupMembers({
+          deviceSetId,
+          siteIds: siteScopeFilter.siteIds,
+          includeUnassigned: siteScopeFilter.includeUnassigned,
+          signal,
+          onSuccess: resolveOnce,
+          onError: () => resolveOnce([]),
+          onFinally: () => resolveOnce([]),
+        });
+      });
+    },
+    [listGroupMembers, siteScopeFilter.includeUnassigned, siteScopeFilter.siteIds],
+  );
+
+  const prepareAndRunAction = useCallback(
+    async (action: DeviceSetActionType) => {
+      if (action === "edit-group" || action === "view-group") return;
+
+      const filter = getSnapshotFilter();
+      if (!deviceSetId || !filter) {
+        setPendingPreparedTarget({
+          action,
+          memberDeviceIds: memberDeviceIdsRef.current,
+          targetKey: actionTargetKeyRef.current,
+          version: fetchVersionRef.current,
+        });
+        return;
+      }
+
+      const version = ++fetchVersionRef.current;
+      const targetKey = actionTargetKeyRef.current;
+      markPreparingAction();
+      fetchAbortRef.current?.abort();
+      const controller = new AbortController();
+      fetchAbortRef.current = controller;
+      const isCurrent = () =>
+        version === fetchVersionRef.current && !controller.signal.aborted && targetKey === actionTargetKeyRef.current;
+
+      if (!propMemberDeviceIdsRef.current) {
+        setFetchedMemberIds(null);
+      }
+      setFetchedMiners(null);
+
+      const [ids, miners] = await Promise.all([
+        fetchMemberIdsForAction(deviceSetId, controller.signal),
+        fetchAllMinerSnapshots(filter, controller.signal).catch(() => ({})),
+      ]);
+
+      if (!isCurrent()) {
+        clearPreparingActionForVersion(version);
+        return;
+      }
+
+      if (!propMemberDeviceIdsRef.current) {
+        setFetchedMemberIds({ targetKey, ids });
+      }
+      setFetchedMiners({ targetKey, miners });
+      clearPreparingActionForVersion(version);
+      if (isScopedGroupAction && ids.length === 0) return;
+      setPendingPreparedTarget({
+        action,
+        memberDeviceIds: ids,
+        targetKey,
+        version,
+      });
+    },
+    [
+      clearPreparingActionForVersion,
+      deviceSetId,
+      fetchMemberIdsForAction,
+      getSnapshotFilter,
+      isScopedGroupAction,
+      markPreparingAction,
+      setPendingPreparedTarget,
+    ],
+  );
+
   // Expose the sleep action handler to the parent via ref
   useEffect(() => {
     if (!sleepActionRef) return;
@@ -406,17 +645,19 @@ const DeviceSetActionsMenuInner = ({
     if (sleepAction) {
       sleepActionRef.current = () => {
         setShowWarnDialog(sleepAction.requiresConfirmation);
-        sleepAction.actionHandler();
+        void prepareAndRunAction(deviceActions.shutdown);
       };
     } else {
       sleepActionRef.current = null;
     }
-  }, [sleepActionRef, popoverActions]);
+  }, [sleepActionRef, popoverActions, prepareAndRunAction]);
 
   const handlePopoverAction = useCallback((requiresConfirmation: boolean) => {
     setIsOpen(false);
-    if (requiresConfirmation) {
-      setShowWarnDialog(true);
+    setShowWarnDialog(requiresConfirmation);
+    if (!requiresConfirmation) {
+      setPendingScopedAction(null);
+      setPendingUnsupportedContinuation(null);
     }
   }, []);
 
@@ -445,7 +686,8 @@ const DeviceSetActionsMenuInner = ({
     setPendingScopedAction(null);
     setShowWarnDialog(false);
     handleCancel();
-  }, [handleCancel]);
+    handlePreparedActionCancel();
+  }, [handleCancel, handlePreparedActionCancel]);
 
   const scopedGroupPopoverActions = useMemo(() => {
     if (!isScopedGroupAction) return groupPopoverActions;
@@ -455,7 +697,7 @@ const DeviceSetActionsMenuInner = ({
         return action;
       }
 
-      if (memberDeviceIds.length === 0) {
+      if (actionMemberDeviceIdsLoaded && actionMemberDeviceIds.length === 0) {
         return {
           ...action,
           disabled: true,
@@ -477,7 +719,7 @@ const DeviceSetActionsMenuInner = ({
         ...action,
         requiresConfirmation: true,
         confirmation: {
-          title: `${action.title} ${memberDeviceIds.length} ${memberDeviceIds.length === 1 ? "miner" : "miners"}?`,
+          title: `${action.title} ${actionMemberDeviceIds.length} ${actionMemberDeviceIds.length === 1 ? "miner" : "miners"}?`,
           subtitle: scopedActionSubtitle(),
           confirmAction: {
             title: action.title,
@@ -487,14 +729,86 @@ const DeviceSetActionsMenuInner = ({
         },
         actionHandler: () => {
           setPendingScopedAction(action);
+          setShowWarnDialog(true);
         },
       };
     });
-  }, [groupPopoverActions, isScopedGroupAction, memberDeviceIds.length, scopedActionSubtitle, siteScopeLabel]);
+  }, [
+    groupPopoverActions,
+    actionMemberDeviceIds.length,
+    actionMemberDeviceIdsLoaded,
+    isScopedGroupAction,
+    scopedActionSubtitle,
+    siteScopeLabel,
+  ]);
 
   useEffect(() => {
     scopedActionsRef.current = scopedGroupPopoverActions;
   }, [scopedGroupPopoverActions]);
+
+  useEffect(() => {
+    if (!pendingPreparedAction) return;
+    if (
+      pendingPreparedAction.targetKey !== actionTargetKey ||
+      pendingPreparedAction.version !== fetchVersionRef.current
+    ) {
+      queueMicrotask(() => {
+        clearPendingPreparedAction();
+      });
+      return;
+    }
+    const action = scopedGroupPopoverActions.find((candidate) => candidate.action === pendingPreparedAction.action);
+    if (action?.disabled) {
+      queueMicrotask(() => {
+        clearPendingPreparedAction();
+      });
+      return;
+    }
+    if (!action) {
+      queueMicrotask(() => {
+        clearPendingPreparedAction();
+      });
+      return;
+    }
+
+    queueMicrotask(() => {
+      if (
+        pendingPreparedAction.targetKey !== actionTargetKeyRef.current ||
+        pendingPreparedAction.version !== fetchVersionRef.current
+      ) {
+        return;
+      }
+      setActivePreparedTarget({
+        memberDeviceIds: pendingPreparedAction.memberDeviceIds,
+        targetKey: pendingPreparedAction.targetKey,
+        version: pendingPreparedAction.version,
+        tick: pendingPreparedAction.tick,
+      });
+      clearPendingPreparedAction();
+      action.actionHandler();
+    });
+  }, [
+    actionTargetKey,
+    clearPendingPreparedAction,
+    pendingPreparedAction,
+    scopedGroupPopoverActions,
+    setActivePreparedTarget,
+  ]);
+
+  const displayedGroupPopoverActions = useMemo(
+    () =>
+      scopedGroupPopoverActions.map((action) => {
+        if (action.action === "edit-group" || action.action === "view-group") return action;
+        if (action.disabled) return action;
+        return {
+          ...action,
+          actionHandler: () => {
+            void prepareAndRunAction(action.action);
+          },
+        };
+      }),
+    [prepareAndRunAction, scopedGroupPopoverActions],
+  );
 
   // Keep the base confirmation hidden while the unsupported-miners modal is active.
   // Scoped unsupported continuations can re-open the scoped confirmation after Continue.
@@ -502,6 +816,11 @@ const DeviceSetActionsMenuInner = ({
     setShowWarnDialog(false);
     handleUnsupportedMinersContinue();
   }, [handleUnsupportedMinersContinue]);
+
+  const handleUnsupportedMinersDismissWithReset = useCallback(() => {
+    resetLocalPreparedActionState();
+    handleUnsupportedMinersDismiss();
+  }, [handleUnsupportedMinersDismiss, resetLocalPreparedActionState]);
 
   return (
     <>
@@ -514,21 +833,13 @@ const DeviceSetActionsMenuInner = ({
           onClick={handleOpen}
         />
         {isOpen ? (
-          fetchingMembers || fetchingMiners ? (
-            <div
-              className={`popover-content absolute right-0 z-10 flex items-center justify-center rounded-2xl bg-surface-overlay p-6 shadow-elevation-200 ${popoverClassName ?? ""}`}
-            >
-              <ProgressCircular indeterminate />
-            </div>
-          ) : (
-            <BulkActionsPopover<DeviceSetActionType>
-              actions={scopedGroupPopoverActions}
-              beforeEach={handlePopoverAction}
-              testId="group-actions-popover"
-              position={positions["bottom right"]}
-              className={popoverClassName ?? "!space-y-0 !rounded-2xl px-0 pt-2 pb-1"}
-            />
-          )
+          <BulkActionsPopover<DeviceSetActionType>
+            actions={displayedGroupPopoverActions}
+            beforeEach={handlePopoverAction}
+            testId="group-actions-popover"
+            position={positions["bottom right"]}
+            className={popoverClassName ?? "!space-y-0 !rounded-2xl px-0 pt-2 pb-1"}
+          />
         ) : null}
       </div>
 
@@ -538,7 +849,7 @@ const DeviceSetActionsMenuInner = ({
         totalUnsupportedCount={unsupportedMinersInfo.totalUnsupportedCount}
         noneSupported={unsupportedMinersInfo.noneSupported}
         onContinue={handleUnsupportedMinersContinueWithReset}
-        onDismiss={handleUnsupportedMinersDismiss}
+        onDismiss={handleUnsupportedMinersDismissWithReset}
       />
       {/* Confirmation dialogs */}
       {scopedGroupPopoverActions
@@ -565,7 +876,7 @@ const DeviceSetActionsMenuInner = ({
         open={showPoolSelectionPage ? !!fleetCredentials : false}
         selectedMiners={poolMiners}
         selectionMode={"subset" as SelectionMode}
-        poolNeededCount={poolFilteredDeviceIds ? poolFilteredDeviceIds.length : memberDeviceIds.length}
+        poolNeededCount={poolFilteredDeviceIds ? poolFilteredDeviceIds.length : actionMemberDeviceIds.length}
         userUsername={fleetCredentials?.username}
         userPassword={fleetCredentials?.password}
         onSuccess={handleMiningPoolSuccess}


### PR DESCRIPTION
Reviewable diff: +540/-151 across 2 files (excludes generated, test, and story files).

## Summary
The `/groups` row actions menu now opens immediately for large groups because it no longer fetches every group member snapshot before rendering the popover. Member IDs and miner snapshots are resolved only after an operator chooses a miner action, so View/Edit and action discovery stay responsive even for virtual-fleet-sized groups. Scoped rows keep actions enabled while membership is unknown, then disable only after a lazy fetch confirms the active scope has no miners, and action flows cancel cleanly when the target scope changes or unsupported-miner modals are dismissed.

Fixes #570

## How it works
`DeviceSetActionsMenu` now treats popover open as a local UI toggle. The menu renders from existing `useMinerActions` action metadata plus View/Edit actions without starting the expensive member/snapshot preparation. When a miner-scoped action is selected, `prepareAndRunAction` aborts any stale preparation, fetches current member IDs and snapshots with the right group/rack/site filter, freezes the resolved member ID list, updates `useMinerActions` inputs, then replays the selected action after React re-renders with the frozen IDs and fresh snapshots.

Prepared member IDs are kept active through the action lifecycle, including confirmation dialogs, auth/modals, and pool-selection flows, and are cleared on cancel, target changes, unsupported-miner dismissal, or action completion. `actionActiveRef` is raised during preparation/fetch and visible action flows so parent polling can pause only while the operator-facing flow is active. The action preparation carries a target key and fetch version; cached member IDs and miner snapshots are stored with that target key so a loaded-empty result for one site/group cannot disable or count actions for a later site/group. If the same target previously loaded empty, opening the menu expires and revalidates that empty member cache; the revalidation is version-guarded so it cannot overwrite a newer action fetch.

Bulk command handoff in `useMinerActions` now signals completion as soon as the backend accepts the batch, or immediately on API failure, instead of relying only on long-running toast closure. That lets the row/rack action wrapper release prepared action state while command status continues through the normal batch/toast path.

## Diagrams
```mermaid
flowchart TD
  A["Operator opens /groups row menu"] --> B["Render local View/Edit and miner action rows"]
  B --> C["No expensive group member or snapshot preparation"]
  C --> D["Operator chooses a miner action"]
  D --> E["Fetch member IDs and miner snapshots for the selected group scope"]
  E --> F["Confirm target/version is still current"]
  F --> G["Cache IDs/snapshots under current target key"]
  G --> H["Freeze resolved member IDs for pending replay"]
  H --> I["Update useMinerActions inputs"]
  I --> J["Replay selected action with frozen IDs/fresh snapshots"]
  J --> K["Keep frozen IDs active until cancel, target change, dismiss, or completion"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.tsx` | Moved member/snapshot loading from menu-open effect to action-click preparation, with unknown-vs-empty member state, target-keyed caches, version-guarded empty-cache revalidation on reopen, active prepared member IDs through confirmation/modal lifecycle, abort/stale guards, target-change cancellation, unsupported-dismiss cleanup, and action replay after state update. | This is the latency fix for the `/groups` menu shown in the screenshot and prevents scoped actions from being disabled, counted, paused, or dispatched from stale site/group/member data. |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx` | Signals `onActionComplete` immediately when retry-capable bulk commands hand off successfully or fail before batch creation, and accepts an action lifecycle key that guards post-await modal/auth continuations. | Releases wrapper-level prepared action state without waiting for a long-running toast to close, while preventing stale async action continuations from reopening modals or dispatching after the target scope changes. |
| `client/src/protoFleet/features/groupManagement/components/DeviceSetActionsMenu.test.tsx`, `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx` | Replaced spinner-on-open expectations with tests for instant open, deferred fetch, filter selection, loaded-empty scoped disables, same-target empty-cache refresh, stale refresh suppression after action fetch, cache invalidation after target changes, prop-member freeze through async prep and confirmation, aborting stale fetches, unsupported-dismiss cleanup, target-change confirmation cancellation, stale result suppression, stale warning cleanup, stale completion suppression, and lifecycle-key-guarded capability continuations. | Locks the behavior that large groups do not block menu rendering or dispatch actions/modal continuations against stale scopes. |

## Key technical decisions & trade-offs
- Deferred existing client-side lookups instead of changing command selector protos/server APIs; this fixes menu responsiveness without a generated-code/API migration.
- Kept fresh member/snapshot resolution before each miner action so action execution still sees current group membership and model/auth data.
- Preserved an unknown member state for scoped rows so actions remain clickable until a lazy fetch proves the active scope is empty.
- Stored lazy-fetched members and snapshots with the action target key rather than relying on cross-target cached arrays.
- Revalidated loaded-empty same-target member caches on reopen so groups are not stuck disabled if miners are added while the row remains mounted.
- Guarded empty-cache revalidation by fetch version so older revalidations cannot overwrite newer action preparation results.
- Kept frozen prepared member IDs active until cancel/completion so parent polling or prop refreshes cannot change selected miners between click, confirmation, and modal completion.
- Treated target-scope changes and stale completions as cancellation boundaries, preventing stale confirmations, modal flows, or toast-close callbacks from retargeting commands.

## Testing & validation
- `npm run test -- DeviceSetActionsMenu.test.tsx --run`
- `npm run test -- useMinerActions.test.tsx --run`
- `npm run lint`
- `npm run format:check`
- `npx tsc --noEmit`
- `npm run build:protoFleet`
- Not covered: live browser timing against the STL virtual fleet; unit tests verify that opening the menu performs no member/snapshot fetch.