### PR TITLE
Tighten telemetry storage lifecycle policies

### DIFF
--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -567,6 +567,12 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getMinerStateCountsByDeviceIDsStmt, err = db.PrepareContext(ctx, getMinerStateCountsByDeviceIDs); err != nil {
 		return nil, fmt.Errorf("error preparing query GetMinerStateCountsByDeviceIDs: %w", err)
 	}
+	if q.getMinerStateSnapshotDailyRollupsStmt, err = db.PrepareContext(ctx, getMinerStateSnapshotDailyRollups); err != nil {
+		return nil, fmt.Errorf("error preparing query GetMinerStateSnapshotDailyRollups: %w", err)
+	}
+	if q.getMinerStateSnapshotHourlyRollupsStmt, err = db.PrepareContext(ctx, getMinerStateSnapshotHourlyRollups); err != nil {
+		return nil, fmt.Errorf("error preparing query GetMinerStateSnapshotHourlyRollups: %w", err)
+	}
 	if q.getMinerStateSnapshotsStmt, err = db.PrepareContext(ctx, getMinerStateSnapshots); err != nil {
 		return nil, fmt.Errorf("error preparing query GetMinerStateSnapshots: %w", err)
 	}
@@ -2257,6 +2263,16 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getMinerStateCountsByDeviceIDsStmt: %w", cerr)
 		}
 	}
+	if q.getMinerStateSnapshotDailyRollupsStmt != nil {
+		if cerr := q.getMinerStateSnapshotDailyRollupsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getMinerStateSnapshotDailyRollupsStmt: %w", cerr)
+		}
+	}
+	if q.getMinerStateSnapshotHourlyRollupsStmt != nil {
+		if cerr := q.getMinerStateSnapshotHourlyRollupsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getMinerStateSnapshotHourlyRollupsStmt: %w", cerr)
+		}
+	}
 	if q.getMinerStateSnapshotsStmt != nil {
 		if cerr := q.getMinerStateSnapshotsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getMinerStateSnapshotsStmt: %w", cerr)
@@ -3777,6 +3793,8 @@ type Queries struct {
 	getMinerCredentialsByDeviceIDStmt                          *sql.Stmt
 	getMinerModelGroupsStmt                                    *sql.Stmt
 	getMinerStateCountsByDeviceIDsStmt                         *sql.Stmt
+	getMinerStateSnapshotDailyRollupsStmt                      *sql.Stmt
+	getMinerStateSnapshotHourlyRollupsStmt                     *sql.Stmt
 	getMinerStateSnapshotsStmt                                 *sql.Stmt
 	getOfflineDevicesStmt                                      *sql.Stmt
 	getOpenErrorByDedupKeyStmt                                 *sql.Stmt
@@ -4224,6 +4242,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getMinerCredentialsByDeviceIDStmt:                          q.getMinerCredentialsByDeviceIDStmt,
 		getMinerModelGroupsStmt:                                    q.getMinerModelGroupsStmt,
 		getMinerStateCountsByDeviceIDsStmt:                         q.getMinerStateCountsByDeviceIDsStmt,
+		getMinerStateSnapshotDailyRollupsStmt:                      q.getMinerStateSnapshotDailyRollupsStmt,
+		getMinerStateSnapshotHourlyRollupsStmt:                     q.getMinerStateSnapshotHourlyRollupsStmt,
 		getMinerStateSnapshotsStmt:                                 q.getMinerStateSnapshotsStmt,
 		getOfflineDevicesStmt:                                      q.getOfflineDevicesStmt,
 		getOpenErrorByDedupKeyStmt:                                 q.getOpenErrorByDedupKeyStmt,

--- a/server/generated/sqlc/miner_state_snapshots.sql.go
+++ b/server/generated/sqlc/miner_state_snapshots.sql.go
@@ -13,6 +13,142 @@ import (
 	"github.com/lib/pq"
 )
 
+const getMinerStateSnapshotDailyRollups = `-- name: GetMinerStateSnapshotDailyRollups :many
+SELECT
+    bucket,
+    SUM(CASE WHEN state = 3 THEN 1 ELSE 0 END)::int AS hashing_count,
+    SUM(CASE WHEN state = 2 THEN 1 ELSE 0 END)::int AS broken_count,
+    SUM(CASE WHEN state = 0 THEN 1 ELSE 0 END)::int AS offline_count,
+    SUM(CASE WHEN state = 1 THEN 1 ELSE 0 END)::int AS sleeping_count
+FROM miner_state_snapshot_daily
+WHERE org_id = $1
+  AND bucket >= $2
+  AND bucket <= $3
+  AND ($4::text IS NULL
+       OR device_identifier = ANY($5::text[]))
+GROUP BY bucket
+ORDER BY bucket ASC
+`
+
+type GetMinerStateSnapshotDailyRollupsParams struct {
+	OrgID                   int64
+	StartTime               time.Time
+	EndTime                 time.Time
+	DeviceIdentifiersFilter sql.NullString
+	DeviceIdentifierValues  []string
+}
+
+type GetMinerStateSnapshotDailyRollupsRow struct {
+	Bucket        time.Time
+	HashingCount  int32
+	BrokenCount   int32
+	OfflineCount  int32
+	SleepingCount int32
+}
+
+func (q *Queries) GetMinerStateSnapshotDailyRollups(ctx context.Context, arg GetMinerStateSnapshotDailyRollupsParams) ([]GetMinerStateSnapshotDailyRollupsRow, error) {
+	rows, err := q.query(ctx, q.getMinerStateSnapshotDailyRollupsStmt, getMinerStateSnapshotDailyRollups,
+		arg.OrgID,
+		arg.StartTime,
+		arg.EndTime,
+		arg.DeviceIdentifiersFilter,
+		pq.Array(arg.DeviceIdentifierValues),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetMinerStateSnapshotDailyRollupsRow
+	for rows.Next() {
+		var i GetMinerStateSnapshotDailyRollupsRow
+		if err := rows.Scan(
+			&i.Bucket,
+			&i.HashingCount,
+			&i.BrokenCount,
+			&i.OfflineCount,
+			&i.SleepingCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getMinerStateSnapshotHourlyRollups = `-- name: GetMinerStateSnapshotHourlyRollups :many
+SELECT
+    bucket,
+    SUM(CASE WHEN state = 3 THEN 1 ELSE 0 END)::int AS hashing_count,
+    SUM(CASE WHEN state = 2 THEN 1 ELSE 0 END)::int AS broken_count,
+    SUM(CASE WHEN state = 0 THEN 1 ELSE 0 END)::int AS offline_count,
+    SUM(CASE WHEN state = 1 THEN 1 ELSE 0 END)::int AS sleeping_count
+FROM miner_state_snapshot_hourly
+WHERE org_id = $1
+  AND bucket >= $2
+  AND bucket <= $3
+  AND ($4::text IS NULL
+       OR device_identifier = ANY($5::text[]))
+GROUP BY bucket
+ORDER BY bucket ASC
+`
+
+type GetMinerStateSnapshotHourlyRollupsParams struct {
+	OrgID                   int64
+	StartTime               time.Time
+	EndTime                 time.Time
+	DeviceIdentifiersFilter sql.NullString
+	DeviceIdentifierValues  []string
+}
+
+type GetMinerStateSnapshotHourlyRollupsRow struct {
+	Bucket        time.Time
+	HashingCount  int32
+	BrokenCount   int32
+	OfflineCount  int32
+	SleepingCount int32
+}
+
+func (q *Queries) GetMinerStateSnapshotHourlyRollups(ctx context.Context, arg GetMinerStateSnapshotHourlyRollupsParams) ([]GetMinerStateSnapshotHourlyRollupsRow, error) {
+	rows, err := q.query(ctx, q.getMinerStateSnapshotHourlyRollupsStmt, getMinerStateSnapshotHourlyRollups,
+		arg.OrgID,
+		arg.StartTime,
+		arg.EndTime,
+		arg.DeviceIdentifiersFilter,
+		pq.Array(arg.DeviceIdentifierValues),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetMinerStateSnapshotHourlyRollupsRow
+	for rows.Next() {
+		var i GetMinerStateSnapshotHourlyRollupsRow
+		if err := rows.Scan(
+			&i.Bucket,
+			&i.HashingCount,
+			&i.BrokenCount,
+			&i.OfflineCount,
+			&i.SleepingCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getMinerStateSnapshots = `-- name: GetMinerStateSnapshots :many
 WITH per_device_bucket AS (
     SELECT DISTINCT ON (time_bucket($1::text::interval, time), device_identifier)
@@ -94,43 +230,84 @@ func (q *Queries) GetMinerStateSnapshots(ctx context.Context, arg GetMinerStateS
 }
 
 const insertMinerStateSnapshot = `-- name: InsertMinerStateSnapshot :exec
-INSERT INTO miner_state_snapshots (time, org_id, site_id, device_identifier, state)
+WITH snapshot_rows AS (
+    SELECT
+        $1::timestamptz AS time,
+        d.org_id,
+        d.site_id,
+        d.device_identifier,
+        CASE
+            WHEN ds.status = 'OFFLINE'
+                 OR (ds.status IS NULL AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED'))
+                THEN 0
+            WHEN ds.status IN ('MAINTENANCE', 'INACTIVE')
+                 AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED')
+                THEN 1
+            WHEN ds.status IN ('ERROR', 'NEEDS_MINING_POOL', 'UPDATING', 'REBOOT_REQUIRED')
+                 OR dp.pairing_status IN ('AUTHENTICATION_NEEDED')
+                 OR open_errors.device_id IS NOT NULL
+                THEN 2
+            WHEN ds.status = 'ACTIVE'
+                 AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED')
+                 AND open_errors.device_id IS NULL
+                THEN 3
+            ELSE 4
+        END AS state
+    FROM device d
+    JOIN discovered_device dd ON d.discovered_device_id = dd.id
+    JOIN device_pairing     dp ON d.id = dp.device_id
+    LEFT JOIN device_status ds ON d.id = ds.device_id
+    LEFT JOIN (
+        SELECT DISTINCT device_id
+        FROM errors
+        WHERE closed_at IS NULL
+          AND severity IN (1, 2, 3, 4)
+    ) open_errors ON d.id = open_errors.device_id
+    WHERE d.deleted_at IS NULL
+      AND dd.is_active = TRUE
+      AND dd.deleted_at IS NULL
+      AND dp.pairing_status IN ('PAIRED', 'AUTHENTICATION_NEEDED', 'DEFAULT_PASSWORD')
+),
+inserted_raw AS (
+    INSERT INTO miner_state_snapshots (time, org_id, site_id, device_identifier, state)
+    SELECT time, org_id, site_id, device_identifier, state
+    FROM snapshot_rows
+    ON CONFLICT (time, device_identifier) DO NOTHING
+    RETURNING time, org_id, site_id, device_identifier, state
+),
+upsert_hourly AS (
+    INSERT INTO miner_state_snapshot_hourly (bucket, sample_time, org_id, site_id, device_identifier, state)
+    SELECT
+        time_bucket('1 hour', time)::timestamptz,
+        time,
+        org_id,
+        site_id,
+        device_identifier,
+        state
+    FROM inserted_raw
+    ON CONFLICT (bucket, device_identifier) DO UPDATE SET
+        sample_time = EXCLUDED.sample_time,
+        org_id = EXCLUDED.org_id,
+        site_id = EXCLUDED.site_id,
+        state = EXCLUDED.state
+    WHERE miner_state_snapshot_hourly.sample_time <= EXCLUDED.sample_time
+    RETURNING 1
+)
+INSERT INTO miner_state_snapshot_daily (bucket, sample_time, org_id, site_id, device_identifier, state)
 SELECT
-    $1::timestamptz,
-    d.org_id,
-    d.site_id,
-    d.device_identifier,
-    CASE
-        WHEN ds.status = 'OFFLINE'
-             OR (ds.status IS NULL AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED'))
-            THEN 0
-        WHEN ds.status IN ('MAINTENANCE', 'INACTIVE')
-             AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED')
-            THEN 1
-        WHEN ds.status IN ('ERROR', 'NEEDS_MINING_POOL', 'UPDATING', 'REBOOT_REQUIRED')
-             OR dp.pairing_status IN ('AUTHENTICATION_NEEDED')
-             OR open_errors.device_id IS NOT NULL
-            THEN 2
-        WHEN ds.status = 'ACTIVE'
-             AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED')
-             AND open_errors.device_id IS NULL
-            THEN 3
-        ELSE 4
-    END
-FROM device d
-JOIN discovered_device dd ON d.discovered_device_id = dd.id
-JOIN device_pairing     dp ON d.id = dp.device_id
-LEFT JOIN device_status ds ON d.id = ds.device_id
-LEFT JOIN (
-    SELECT DISTINCT device_id
-    FROM errors
-    WHERE closed_at IS NULL
-      AND severity IN (1, 2, 3, 4)
-) open_errors ON d.id = open_errors.device_id
-WHERE d.deleted_at IS NULL
-  AND dd.is_active = TRUE
-  AND dd.deleted_at IS NULL
-  AND dp.pairing_status IN ('PAIRED', 'AUTHENTICATION_NEEDED', 'DEFAULT_PASSWORD')
+    time_bucket('1 day', time)::timestamptz,
+    time,
+    org_id,
+    site_id,
+    device_identifier,
+    state
+FROM inserted_raw
+ON CONFLICT (bucket, device_identifier) DO UPDATE SET
+    sample_time = EXCLUDED.sample_time,
+    org_id = EXCLUDED.org_id,
+    site_id = EXCLUDED.site_id,
+    state = EXCLUDED.state
+WHERE miner_state_snapshot_daily.sample_time <= EXCLUDED.sample_time
 `
 
 // CASE bucket order must match CountMinersByState (device.sql) — the chart

--- a/server/generated/sqlc/models.go
+++ b/server/generated/sqlc/models.go
@@ -860,6 +860,24 @@ type MinerStateSnapshot struct {
 	SiteID           sql.NullInt64
 }
 
+type MinerStateSnapshotDaily struct {
+	Bucket           time.Time
+	SampleTime       time.Time
+	OrgID            int64
+	SiteID           sql.NullInt64
+	DeviceIdentifier string
+	State            int16
+}
+
+type MinerStateSnapshotHourly struct {
+	Bucket           time.Time
+	SampleTime       time.Time
+	OrgID            int64
+	SiteID           sql.NullInt64
+	DeviceIdentifier string
+	State            int16
+}
+
 type NotificationActive struct {
 	OrganizationID int64
 	AlertKey       string

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -599,7 +599,7 @@ func (s *TimescaleTelemetryStore) getCombinedMetricsFromHourly(ctx context.Conte
 	metrics := s.aggregateHourlyRows(rows, query.MeasurementTypes, query.AggregationTypes)
 
 	tempCounts := s.getTemperatureCountsFromHourlyAggregates(ctx, query.DeviceIDs, startTime, endTime)
-	uptimeCounts := s.uptimeCountsForQuery(ctx, query, startTime, endTime, hourlyBucketDuration)
+	uptimeCounts := s.getUptimeStatusCountsFromHourlyRollups(ctx, query.OrganizationID, query.DeviceIDs, startTime, endTime)
 
 	return models.CombinedMetric{
 		Metrics:                 metrics,
@@ -647,7 +647,7 @@ func (s *TimescaleTelemetryStore) getCombinedMetricsFromDaily(ctx context.Contex
 	metrics := s.aggregateDailyRows(rows, query.MeasurementTypes, query.AggregationTypes)
 
 	tempCounts := s.getTemperatureCountsFromDailyAggregates(ctx, query.DeviceIDs, startTime, endTime)
-	uptimeCounts := s.uptimeCountsForQuery(ctx, query, startTime, endTime, dailyBucketDuration)
+	uptimeCounts := s.getUptimeStatusCountsFromDailyRollups(ctx, query.OrganizationID, query.DeviceIDs, startTime, endTime)
 
 	return models.CombinedMetric{
 		Metrics:                 metrics,
@@ -657,10 +657,9 @@ func (s *TimescaleTelemetryStore) getCombinedMetricsFromDaily(ctx context.Contex
 }
 
 // uptimeCountsForQuery returns nil when OrganizationID is unset so callers
-// without session context can't leak another org's counts. Callers pass the
-// same start/end used for the surrounding metric query so uptime bars line up
-// with metric bars (notably: hourly/daily callers pass a range normalized to
-// complete buckets, not the raw request range).
+// without session context can't leak another org's counts. Raw callers pass
+// the same start/end used for the surrounding metric query so uptime bars line
+// up with metric bars.
 func (s *TimescaleTelemetryStore) uptimeCountsForQuery(ctx context.Context, query models.CombinedMetricsQuery, startTime, endTime time.Time, bucketDuration time.Duration) []models.UptimeStatusCount {
 	if query.OrganizationID == 0 {
 		return nil
@@ -1260,6 +1259,100 @@ func (s *TimescaleTelemetryStore) getUptimeStatusCountsFromSnapshots(
 	rows, err := s.queries.GetMinerStateSnapshots(ctx, params)
 	if err != nil {
 		s.logger.Error("failed to query miner state snapshots",
+			slog.Int64("org_id", orgID),
+			slog.String("error", err.Error()))
+		return nil
+	}
+
+	if len(rows) == 0 {
+		return nil
+	}
+
+	result := make([]models.UptimeStatusCount, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, models.UptimeStatusCount{
+			Timestamp:       row.Bucket,
+			HashingCount:    row.HashingCount,
+			BrokenCount:     row.BrokenCount,
+			NotHashingCount: row.OfflineCount + row.SleepingCount,
+		})
+	}
+	return result
+}
+
+func (s *TimescaleTelemetryStore) getUptimeStatusCountsFromHourlyRollups(
+	ctx context.Context,
+	orgID int64,
+	deviceIDs []models.DeviceIdentifier,
+	startTime, endTime time.Time,
+) []models.UptimeStatusCount {
+	if orgID == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.config.QueryTimeout)
+	defer cancel()
+
+	params := sqlc.GetMinerStateSnapshotHourlyRollupsParams{
+		OrgID:     orgID,
+		StartTime: startTime,
+		EndTime:   endTime,
+	}
+	if len(deviceIDs) > 0 {
+		params.DeviceIdentifiersFilter = sql.NullString{String: "1", Valid: true}
+		params.DeviceIdentifierValues = deviceIDsToStrings(deviceIDs)
+	}
+
+	rows, err := s.queries.GetMinerStateSnapshotHourlyRollups(ctx, params)
+	if err != nil {
+		s.logger.Error("failed to query miner state snapshot hourly rollups",
+			slog.Int64("org_id", orgID),
+			slog.String("error", err.Error()))
+		return nil
+	}
+
+	if len(rows) == 0 {
+		return nil
+	}
+
+	result := make([]models.UptimeStatusCount, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, models.UptimeStatusCount{
+			Timestamp:       row.Bucket,
+			HashingCount:    row.HashingCount,
+			BrokenCount:     row.BrokenCount,
+			NotHashingCount: row.OfflineCount + row.SleepingCount,
+		})
+	}
+	return result
+}
+
+func (s *TimescaleTelemetryStore) getUptimeStatusCountsFromDailyRollups(
+	ctx context.Context,
+	orgID int64,
+	deviceIDs []models.DeviceIdentifier,
+	startTime, endTime time.Time,
+) []models.UptimeStatusCount {
+	if orgID == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.config.QueryTimeout)
+	defer cancel()
+
+	params := sqlc.GetMinerStateSnapshotDailyRollupsParams{
+		OrgID:     orgID,
+		StartTime: startTime,
+		EndTime:   endTime,
+	}
+	if len(deviceIDs) > 0 {
+		params.DeviceIdentifiersFilter = sql.NullString{String: "1", Valid: true}
+		params.DeviceIdentifierValues = deviceIDsToStrings(deviceIDs)
+	}
+
+	rows, err := s.queries.GetMinerStateSnapshotDailyRollups(ctx, params)
+	if err != nil {
+		s.logger.Error("failed to query miner state snapshot daily rollups",
 			slog.Int64("org_id", orgID),
 			slog.String("error", err.Error()))
 		return nil

--- a/server/internal/infrastructure/timescaledb/telemetry_store_uptime_rollup_test.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store_uptime_rollup_test.go
@@ -1,0 +1,115 @@
+package timescaledb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
+	"github.com/block/proto-fleet/server/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelemetryStore_UptimeStatusCountsFromHourlyRollups(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := testutil.GetTestDB(t)
+	store, err := NewTelemetryStore(db, DefaultConfig())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	orgID := time.Now().UnixNano()
+	bucket := time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+	t.Cleanup(func() {
+		cleanupMinerStateRollups(t, db, orgID)
+	})
+
+	insertMinerStateHourlyRollup(t, db, orgID, bucket, "uptime-rollup-hourly-1", 3)
+	insertMinerStateHourlyRollup(t, db, orgID, bucket, "uptime-rollup-hourly-2", 0)
+	insertMinerStateHourlyRollup(t, db, orgID, bucket.Add(time.Hour), "uptime-rollup-hourly-1", 2)
+
+	counts := store.getUptimeStatusCountsFromHourlyRollups(ctx, orgID, nil, bucket, bucket.Add(time.Hour))
+	require.Len(t, counts, 2)
+	assert.Equal(t, int32(1), counts[0].HashingCount)
+	assert.Equal(t, int32(1), counts[0].NotHashingCount)
+	assert.Equal(t, int32(0), counts[0].BrokenCount)
+	assert.Equal(t, int32(0), counts[1].HashingCount)
+	assert.Equal(t, int32(0), counts[1].NotHashingCount)
+	assert.Equal(t, int32(1), counts[1].BrokenCount)
+
+	filtered := store.getUptimeStatusCountsFromHourlyRollups(
+		ctx,
+		orgID,
+		[]models.DeviceIdentifier{"uptime-rollup-hourly-1"},
+		bucket,
+		bucket,
+	)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, int32(1), filtered[0].HashingCount)
+	assert.Equal(t, int32(0), filtered[0].NotHashingCount)
+}
+
+func TestTelemetryStore_UptimeStatusCountsFromDailyRollups(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := testutil.GetTestDB(t)
+	store, err := NewTelemetryStore(db, DefaultConfig())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	orgID := time.Now().UnixNano()
+	bucket := time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC)
+	t.Cleanup(func() {
+		cleanupMinerStateRollups(t, db, orgID)
+	})
+
+	insertMinerStateDailyRollup(t, db, orgID, bucket, "uptime-rollup-daily-1", 1)
+	insertMinerStateDailyRollup(t, db, orgID, bucket, "uptime-rollup-daily-2", 2)
+	insertMinerStateDailyRollup(t, db, orgID, bucket, "uptime-rollup-daily-3", 3)
+
+	counts := store.getUptimeStatusCountsFromDailyRollups(ctx, orgID, nil, bucket, bucket)
+	require.Len(t, counts, 1)
+	assert.Equal(t, int32(1), counts[0].HashingCount)
+	assert.Equal(t, int32(1), counts[0].NotHashingCount)
+	assert.Equal(t, int32(1), counts[0].BrokenCount)
+}
+
+func insertMinerStateHourlyRollup(t *testing.T, db *sql.DB, orgID int64, bucket time.Time, deviceIdentifier string, state int16) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO miner_state_snapshot_hourly (bucket, sample_time, org_id, device_identifier, state)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (bucket, device_identifier) DO UPDATE SET
+			sample_time = EXCLUDED.sample_time,
+			org_id = EXCLUDED.org_id,
+			state = EXCLUDED.state`,
+		bucket, bucket.Add(59*time.Minute), orgID, deviceIdentifier, state)
+	require.NoError(t, err)
+}
+
+func insertMinerStateDailyRollup(t *testing.T, db *sql.DB, orgID int64, bucket time.Time, deviceIdentifier string, state int16) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO miner_state_snapshot_daily (bucket, sample_time, org_id, device_identifier, state)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (bucket, device_identifier) DO UPDATE SET
+			sample_time = EXCLUDED.sample_time,
+			org_id = EXCLUDED.org_id,
+			state = EXCLUDED.state`,
+		bucket, bucket.Add(23*time.Hour), orgID, deviceIdentifier, state)
+	require.NoError(t, err)
+}
+
+func cleanupMinerStateRollups(t *testing.T, db *sql.DB, orgID int64) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `DELETE FROM miner_state_snapshot_hourly WHERE org_id = $1`, orgID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(context.Background(), `DELETE FROM miner_state_snapshot_daily WHERE org_id = $1`, orgID)
+	require.NoError(t, err)
+}

--- a/server/migrations/000101_tighten_telemetry_lifecycle.down.sql
+++ b/server/migrations/000101_tighten_telemetry_lifecycle.down.sql
@@ -1,0 +1,11 @@
+SELECT remove_retention_policy('device_metrics', if_exists => true);
+SELECT add_retention_policy('device_metrics', INTERVAL '30 days');
+
+SELECT remove_compression_policy('device_metrics', if_exists => true);
+SELECT add_compression_policy('device_metrics', INTERVAL '7 days');
+
+SELECT remove_retention_policy('miner_state_snapshots', if_exists => true);
+SELECT add_retention_policy('miner_state_snapshots', INTERVAL '1 year');
+
+SELECT remove_compression_policy('miner_state_snapshots', if_exists => true);
+SELECT add_compression_policy('miner_state_snapshots', INTERVAL '7 days');

--- a/server/migrations/000101_tighten_telemetry_lifecycle.down.sql
+++ b/server/migrations/000101_tighten_telemetry_lifecycle.down.sql
@@ -1,11 +1,15 @@
 SELECT remove_retention_policy('device_metrics', if_exists => true);
-SELECT add_retention_policy('device_metrics', INTERVAL '30 days');
+SELECT add_retention_policy('device_metrics', INTERVAL '30 days',
+    schedule_interval => INTERVAL '6 hours');
 
 SELECT remove_compression_policy('device_metrics', if_exists => true);
-SELECT add_compression_policy('device_metrics', INTERVAL '7 days');
+SELECT add_compression_policy('device_metrics', INTERVAL '7 days',
+    schedule_interval => INTERVAL '1 hour');
 
 SELECT remove_retention_policy('miner_state_snapshots', if_exists => true);
-SELECT add_retention_policy('miner_state_snapshots', INTERVAL '1 year');
+SELECT add_retention_policy('miner_state_snapshots', INTERVAL '1 year',
+    schedule_interval => INTERVAL '6 hours');
 
 SELECT remove_compression_policy('miner_state_snapshots', if_exists => true);
-SELECT add_compression_policy('miner_state_snapshots', INTERVAL '7 days');
+SELECT add_compression_policy('miner_state_snapshots', INTERVAL '7 days',
+    schedule_interval => INTERVAL '1 hour');

--- a/server/migrations/000101_tighten_telemetry_lifecycle.up.sql
+++ b/server/migrations/000101_tighten_telemetry_lifecycle.up.sql
@@ -1,11 +1,11 @@
 SELECT remove_retention_policy('device_metrics', if_exists => true);
-SELECT add_retention_policy('device_metrics', INTERVAL '36 hours');
+SELECT add_retention_policy('device_metrics', INTERVAL '8 days');
 
 SELECT remove_compression_policy('device_metrics', if_exists => true);
 SELECT add_compression_policy('device_metrics', INTERVAL '6 hours');
 
 SELECT remove_retention_policy('miner_state_snapshots', if_exists => true);
-SELECT add_retention_policy('miner_state_snapshots', INTERVAL '7 days');
+SELECT add_retention_policy('miner_state_snapshots', INTERVAL '1 year');
 
 SELECT remove_compression_policy('miner_state_snapshots', if_exists => true);
 SELECT add_compression_policy('miner_state_snapshots', INTERVAL '6 hours');

--- a/server/migrations/000101_tighten_telemetry_lifecycle.up.sql
+++ b/server/migrations/000101_tighten_telemetry_lifecycle.up.sql
@@ -1,11 +1,15 @@
 SELECT remove_retention_policy('device_metrics', if_exists => true);
-SELECT add_retention_policy('device_metrics', INTERVAL '8 days');
+SELECT add_retention_policy('device_metrics', INTERVAL '8 days',
+    schedule_interval => INTERVAL '6 hours');
 
 SELECT remove_compression_policy('device_metrics', if_exists => true);
-SELECT add_compression_policy('device_metrics', INTERVAL '6 hours');
+SELECT add_compression_policy('device_metrics', INTERVAL '6 hours',
+    schedule_interval => INTERVAL '1 hour');
 
 SELECT remove_retention_policy('miner_state_snapshots', if_exists => true);
-SELECT add_retention_policy('miner_state_snapshots', INTERVAL '1 year');
+SELECT add_retention_policy('miner_state_snapshots', INTERVAL '1 year',
+    schedule_interval => INTERVAL '6 hours');
 
 SELECT remove_compression_policy('miner_state_snapshots', if_exists => true);
-SELECT add_compression_policy('miner_state_snapshots', INTERVAL '6 hours');
+SELECT add_compression_policy('miner_state_snapshots', INTERVAL '6 hours',
+    schedule_interval => INTERVAL '1 hour');

--- a/server/migrations/000101_tighten_telemetry_lifecycle.up.sql
+++ b/server/migrations/000101_tighten_telemetry_lifecycle.up.sql
@@ -1,0 +1,11 @@
+SELECT remove_retention_policy('device_metrics', if_exists => true);
+SELECT add_retention_policy('device_metrics', INTERVAL '36 hours');
+
+SELECT remove_compression_policy('device_metrics', if_exists => true);
+SELECT add_compression_policy('device_metrics', INTERVAL '6 hours');
+
+SELECT remove_retention_policy('miner_state_snapshots', if_exists => true);
+SELECT add_retention_policy('miner_state_snapshots', INTERVAL '7 days');
+
+SELECT remove_compression_policy('miner_state_snapshots', if_exists => true);
+SELECT add_compression_policy('miner_state_snapshots', INTERVAL '6 hours');

--- a/server/migrations/000102_create_miner_state_snapshot_rollups.down.sql
+++ b/server/migrations/000102_create_miner_state_snapshot_rollups.down.sql
@@ -1,0 +1,11 @@
+SELECT remove_retention_policy('miner_state_snapshots', if_exists => true);
+SELECT add_retention_policy('miner_state_snapshots', INTERVAL '1 year',
+    schedule_interval => INTERVAL '6 hours');
+
+SELECT remove_retention_policy('miner_state_snapshot_daily', if_exists => true);
+SELECT remove_compression_policy('miner_state_snapshot_daily', if_exists => true);
+DROP TABLE IF EXISTS miner_state_snapshot_daily;
+
+SELECT remove_retention_policy('miner_state_snapshot_hourly', if_exists => true);
+SELECT remove_compression_policy('miner_state_snapshot_hourly', if_exists => true);
+DROP TABLE IF EXISTS miner_state_snapshot_hourly;

--- a/server/migrations/000102_create_miner_state_snapshot_rollups.up.sql
+++ b/server/migrations/000102_create_miner_state_snapshot_rollups.up.sql
@@ -1,0 +1,117 @@
+CREATE TABLE miner_state_snapshot_hourly (
+    bucket            TIMESTAMPTZ NOT NULL,
+    sample_time       TIMESTAMPTZ NOT NULL,
+    org_id            BIGINT      NOT NULL,
+    site_id           BIGINT,
+    device_identifier TEXT        NOT NULL,
+    state             SMALLINT    NOT NULL,
+
+    PRIMARY KEY (bucket, device_identifier)
+);
+
+SELECT create_hypertable('miner_state_snapshot_hourly', by_range('bucket', INTERVAL '7 days'));
+
+CREATE INDEX idx_miner_state_snapshot_hourly_org_bucket
+    ON miner_state_snapshot_hourly (org_id, bucket DESC);
+CREATE INDEX idx_miner_state_snapshot_hourly_org_site_bucket
+    ON miner_state_snapshot_hourly (org_id, site_id, bucket DESC);
+
+ALTER TABLE miner_state_snapshot_hourly SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_identifier',
+    timescaledb.compress_orderby = 'bucket DESC'
+);
+
+INSERT INTO miner_state_snapshot_hourly (
+    bucket,
+    sample_time,
+    org_id,
+    site_id,
+    device_identifier,
+    state
+)
+SELECT bucket, sample_time, org_id, site_id, device_identifier, state
+FROM (
+    SELECT DISTINCT ON (time_bucket('1 hour', time), device_identifier)
+        time_bucket('1 hour', time)::timestamptz AS bucket,
+        time AS sample_time,
+        org_id,
+        site_id,
+        device_identifier,
+        state
+    FROM miner_state_snapshots
+    WHERE time >= now() - INTERVAL '14 days'
+    ORDER BY time_bucket('1 hour', time), device_identifier, time DESC
+) latest
+ON CONFLICT (bucket, device_identifier) DO UPDATE SET
+    sample_time = EXCLUDED.sample_time,
+    org_id = EXCLUDED.org_id,
+    site_id = EXCLUDED.site_id,
+    state = EXCLUDED.state
+WHERE miner_state_snapshot_hourly.sample_time <= EXCLUDED.sample_time;
+
+SELECT add_compression_policy('miner_state_snapshot_hourly', INTERVAL '7 days',
+    schedule_interval => INTERVAL '1 hour');
+SELECT add_retention_policy('miner_state_snapshot_hourly', INTERVAL '14 days',
+    schedule_interval => INTERVAL '6 hours');
+
+CREATE TABLE miner_state_snapshot_daily (
+    bucket            TIMESTAMPTZ NOT NULL,
+    sample_time       TIMESTAMPTZ NOT NULL,
+    org_id            BIGINT      NOT NULL,
+    site_id           BIGINT,
+    device_identifier TEXT        NOT NULL,
+    state             SMALLINT    NOT NULL,
+
+    PRIMARY KEY (bucket, device_identifier)
+);
+
+SELECT create_hypertable('miner_state_snapshot_daily', by_range('bucket', INTERVAL '30 days'));
+
+CREATE INDEX idx_miner_state_snapshot_daily_org_bucket
+    ON miner_state_snapshot_daily (org_id, bucket DESC);
+CREATE INDEX idx_miner_state_snapshot_daily_org_site_bucket
+    ON miner_state_snapshot_daily (org_id, site_id, bucket DESC);
+
+ALTER TABLE miner_state_snapshot_daily SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_identifier',
+    timescaledb.compress_orderby = 'bucket DESC'
+);
+
+INSERT INTO miner_state_snapshot_daily (
+    bucket,
+    sample_time,
+    org_id,
+    site_id,
+    device_identifier,
+    state
+)
+SELECT bucket, sample_time, org_id, site_id, device_identifier, state
+FROM (
+    SELECT DISTINCT ON (time_bucket('1 day', time), device_identifier)
+        time_bucket('1 day', time)::timestamptz AS bucket,
+        time AS sample_time,
+        org_id,
+        site_id,
+        device_identifier,
+        state
+    FROM miner_state_snapshots
+    WHERE time >= now() - INTERVAL '400 days'
+    ORDER BY time_bucket('1 day', time), device_identifier, time DESC
+) latest
+ON CONFLICT (bucket, device_identifier) DO UPDATE SET
+    sample_time = EXCLUDED.sample_time,
+    org_id = EXCLUDED.org_id,
+    site_id = EXCLUDED.site_id,
+    state = EXCLUDED.state
+WHERE miner_state_snapshot_daily.sample_time <= EXCLUDED.sample_time;
+
+SELECT add_compression_policy('miner_state_snapshot_daily', INTERVAL '7 days',
+    schedule_interval => INTERVAL '1 hour');
+SELECT add_retention_policy('miner_state_snapshot_daily', INTERVAL '400 days',
+    schedule_interval => INTERVAL '6 hours');
+
+SELECT remove_retention_policy('miner_state_snapshots', if_exists => true);
+SELECT add_retention_policy('miner_state_snapshots', INTERVAL '3 days',
+    schedule_interval => INTERVAL '6 hours');

--- a/server/sqlc/queries/miner_state_snapshots.sql
+++ b/server/sqlc/queries/miner_state_snapshots.sql
@@ -6,43 +6,84 @@
 -- enum values). The read query sums only 0..3, so unknown rows don't
 -- contribute to any chart bucket — matching CountMinersByState, which also
 -- excludes non-ACTIVE/non-bucketed statuses from every count.
-INSERT INTO miner_state_snapshots (time, org_id, site_id, device_identifier, state)
+WITH snapshot_rows AS (
+    SELECT
+        sqlc.arg('time')::timestamptz AS time,
+        d.org_id,
+        d.site_id,
+        d.device_identifier,
+        CASE
+            WHEN ds.status = 'OFFLINE'
+                 OR (ds.status IS NULL AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED'))
+                THEN 0
+            WHEN ds.status IN ('MAINTENANCE', 'INACTIVE')
+                 AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED')
+                THEN 1
+            WHEN ds.status IN ('ERROR', 'NEEDS_MINING_POOL', 'UPDATING', 'REBOOT_REQUIRED')
+                 OR dp.pairing_status IN ('AUTHENTICATION_NEEDED')
+                 OR open_errors.device_id IS NOT NULL
+                THEN 2
+            WHEN ds.status = 'ACTIVE'
+                 AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED')
+                 AND open_errors.device_id IS NULL
+                THEN 3
+            ELSE 4
+        END AS state
+    FROM device d
+    JOIN discovered_device dd ON d.discovered_device_id = dd.id
+    JOIN device_pairing     dp ON d.id = dp.device_id
+    LEFT JOIN device_status ds ON d.id = ds.device_id
+    LEFT JOIN (
+        SELECT DISTINCT device_id
+        FROM errors
+        WHERE closed_at IS NULL
+          AND severity IN (1, 2, 3, 4)
+    ) open_errors ON d.id = open_errors.device_id
+    WHERE d.deleted_at IS NULL
+      AND dd.is_active = TRUE
+      AND dd.deleted_at IS NULL
+      AND dp.pairing_status IN ('PAIRED', 'AUTHENTICATION_NEEDED', 'DEFAULT_PASSWORD')
+),
+inserted_raw AS (
+    INSERT INTO miner_state_snapshots (time, org_id, site_id, device_identifier, state)
+    SELECT time, org_id, site_id, device_identifier, state
+    FROM snapshot_rows
+    ON CONFLICT (time, device_identifier) DO NOTHING
+    RETURNING time, org_id, site_id, device_identifier, state
+),
+upsert_hourly AS (
+    INSERT INTO miner_state_snapshot_hourly (bucket, sample_time, org_id, site_id, device_identifier, state)
+    SELECT
+        time_bucket('1 hour', time)::timestamptz,
+        time,
+        org_id,
+        site_id,
+        device_identifier,
+        state
+    FROM inserted_raw
+    ON CONFLICT (bucket, device_identifier) DO UPDATE SET
+        sample_time = EXCLUDED.sample_time,
+        org_id = EXCLUDED.org_id,
+        site_id = EXCLUDED.site_id,
+        state = EXCLUDED.state
+    WHERE miner_state_snapshot_hourly.sample_time <= EXCLUDED.sample_time
+    RETURNING 1
+)
+INSERT INTO miner_state_snapshot_daily (bucket, sample_time, org_id, site_id, device_identifier, state)
 SELECT
-    sqlc.arg('time')::timestamptz,
-    d.org_id,
-    d.site_id,
-    d.device_identifier,
-    CASE
-        WHEN ds.status = 'OFFLINE'
-             OR (ds.status IS NULL AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED'))
-            THEN 0
-        WHEN ds.status IN ('MAINTENANCE', 'INACTIVE')
-             AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED')
-            THEN 1
-        WHEN ds.status IN ('ERROR', 'NEEDS_MINING_POOL', 'UPDATING', 'REBOOT_REQUIRED')
-             OR dp.pairing_status IN ('AUTHENTICATION_NEEDED')
-             OR open_errors.device_id IS NOT NULL
-            THEN 2
-        WHEN ds.status = 'ACTIVE'
-             AND dp.pairing_status NOT IN ('AUTHENTICATION_NEEDED')
-             AND open_errors.device_id IS NULL
-            THEN 3
-        ELSE 4
-    END
-FROM device d
-JOIN discovered_device dd ON d.discovered_device_id = dd.id
-JOIN device_pairing     dp ON d.id = dp.device_id
-LEFT JOIN device_status ds ON d.id = ds.device_id
-LEFT JOIN (
-    SELECT DISTINCT device_id
-    FROM errors
-    WHERE closed_at IS NULL
-      AND severity IN (1, 2, 3, 4)
-) open_errors ON d.id = open_errors.device_id
-WHERE d.deleted_at IS NULL
-  AND dd.is_active = TRUE
-  AND dd.deleted_at IS NULL
-  AND dp.pairing_status IN ('PAIRED', 'AUTHENTICATION_NEEDED', 'DEFAULT_PASSWORD');
+    time_bucket('1 day', time)::timestamptz,
+    time,
+    org_id,
+    site_id,
+    device_identifier,
+    state
+FROM inserted_raw
+ON CONFLICT (bucket, device_identifier) DO UPDATE SET
+    sample_time = EXCLUDED.sample_time,
+    org_id = EXCLUDED.org_id,
+    site_id = EXCLUDED.site_id,
+    state = EXCLUDED.state
+WHERE miner_state_snapshot_daily.sample_time <= EXCLUDED.sample_time;
 
 -- name: GetMinerStateSnapshots :many
 -- DISTINCT ON keeps one state per device per bucket so summed counts always
@@ -67,5 +108,37 @@ SELECT
     SUM(CASE WHEN state = 0 THEN 1 ELSE 0 END)::int AS offline_count,
     SUM(CASE WHEN state = 1 THEN 1 ELSE 0 END)::int AS sleeping_count
 FROM per_device_bucket
+GROUP BY bucket
+ORDER BY bucket ASC;
+
+-- name: GetMinerStateSnapshotHourlyRollups :many
+SELECT
+    bucket,
+    SUM(CASE WHEN state = 3 THEN 1 ELSE 0 END)::int AS hashing_count,
+    SUM(CASE WHEN state = 2 THEN 1 ELSE 0 END)::int AS broken_count,
+    SUM(CASE WHEN state = 0 THEN 1 ELSE 0 END)::int AS offline_count,
+    SUM(CASE WHEN state = 1 THEN 1 ELSE 0 END)::int AS sleeping_count
+FROM miner_state_snapshot_hourly
+WHERE org_id = sqlc.arg('org_id')
+  AND bucket >= sqlc.arg('start_time')
+  AND bucket <= sqlc.arg('end_time')
+  AND (sqlc.narg('device_identifiers_filter')::text IS NULL
+       OR device_identifier = ANY(sqlc.arg('device_identifier_values')::text[]))
+GROUP BY bucket
+ORDER BY bucket ASC;
+
+-- name: GetMinerStateSnapshotDailyRollups :many
+SELECT
+    bucket,
+    SUM(CASE WHEN state = 3 THEN 1 ELSE 0 END)::int AS hashing_count,
+    SUM(CASE WHEN state = 2 THEN 1 ELSE 0 END)::int AS broken_count,
+    SUM(CASE WHEN state = 0 THEN 1 ELSE 0 END)::int AS offline_count,
+    SUM(CASE WHEN state = 1 THEN 1 ELSE 0 END)::int AS sleeping_count
+FROM miner_state_snapshot_daily
+WHERE org_id = sqlc.arg('org_id')
+  AND bucket >= sqlc.arg('start_time')
+  AND bucket <= sqlc.arg('end_time')
+  AND (sqlc.narg('device_identifiers_filter')::text IS NULL
+       OR device_identifier = ANY(sqlc.arg('device_identifier_values')::text[]))
 GROUP BY bucket
 ORDER BY bucket ASC;


### PR DESCRIPTION
Reviewable diff: +366/-42 across 6 files (excludes generated, test, and story files).

**Summary**
This PR reduces Timescale disk pressure for large lab fleets while preserving Fleet's telemetry polling cadence, raw 1h/24h charts, daily aggregate refresh behavior, and 30d/90d/1y uptime views. Raw `device_metrics` retention moves from 30 days to 8 days so the existing 7-day daily continuous-aggregate lookback remains covered. Uptime history now has hourly and daily per-device rollup tables, letting raw `miner_state_snapshots` drop from 1 year to 3 days without truncating UptimePanel history. `device_metrics` and raw snapshots compress after 6 hours with hourly compression jobs; retention jobs run every 6 hours. Refs block/proto-fleet#614; observability and alerting work from that issue is intentionally out of scope for this PR.

For the observed 5000-virtual-miner lab load, the expected steady state is now meaningfully lower than the functionality-preserving 1-year raw snapshot plan. Raw metrics are still the dominant cost because daily metrics/status aggregates currently require the 7-day raw lookback:

| Storage area | Estimated steady state |
| --- | ---: |
| `device_metrics` | 12-28 GB |
| Raw `miner_state_snapshots` | 1-4 GB |
| Snapshot hourly/daily rollups | 1-3 GB |
| Other Postgres/WAL/etc. | 1-4 GB |
| Timescale volume total | 15-39 GB |
| Whole 58 GB Pi root partition used | 28-47 GB |
| Whole 58 GB Pi root partition free | 11-30 GB |

The estimate assumes the observed heavy virtual-miner write rate, roughly 8-11 GB/day of uncompressed `device_metrics` during the high-volume period, 6-hour compression, hourly compression jobs, 6-hour retention jobs, and materially useful Timescale compression ratios. Further large savings should come from decoupling daily `device_metrics`/`device_status` aggregates from raw `device_metrics`, so raw metrics can safely move from 8 days toward a 36-72 hour window.

**How It Works**
The first migration replaces the Timescale lifecycle policies for the existing high-volume telemetry hypertables. `device_metrics` keeps raw samples for 8 days and compresses chunks after 6 hours; compressed chunks remain queryable, and existing daily continuous aggregate refresh jobs keep their 7-day source-data lookback. Raw `miner_state_snapshots` initially keeps 1 year while compression moves to 6 hours.

The second migration creates `miner_state_snapshot_hourly` and `miner_state_snapshot_daily` hypertables. Each stores the latest known state per device per bucket, backfilled from existing raw snapshots before the raw snapshot retention policy is shortened. The snapshot writer now inserts the raw snapshot and upserts the matching hourly/daily rollup rows in the same sqlc operation. Dashboard uptime reads continue using raw snapshots for short-range raw queries, but hourly aggregate ranges read the hourly rollup and daily aggregate ranges read the daily rollup. After the rollups exist and are backfilled, raw `miner_state_snapshots` retention drops to 3 days.

**Diagrams**
```mermaid
flowchart TD
  A["Snapshot scheduler"] --> B["Insert raw miner_state_snapshots"]
  B --> C["Upsert current hourly device-state rollup"]
  B --> D["Upsert current daily device-state rollup"]
  E["Raw dashboard range"] --> B
  F["24h-10d dashboard range"] --> C
  G[">10d dashboard range"] --> D
  H["3d raw snapshot retention"] --> B
  I["14d hourly rollup retention"] --> C
  J["400d daily rollup retention"] --> D
```

```mermaid
flowchart TD
  A["Fleet telemetry poller"] --> B["Raw samples in device_metrics"]
  B --> C["Hourly 6h compression policy"]
  C --> D["Compressed raw chunks remain queryable"]
  B --> E["6-hourly 8d retention policy"]
  E --> F["Older raw chunks dropped"]
  G["1h and 24h metric charts"] --> B
  H["Daily metrics/status aggregate refresh jobs"] --> B
  H --> I["7d lookback remains covered"]
```

**Areas Of The Code Involved**
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/migrations/000101_tighten_telemetry_lifecycle.*.sql` | Sets lifecycle policies for raw metrics and snapshots with explicit job schedules. | Preserves the raw metrics aggregate contract and bounds compression/retention scheduler lag. |
| `server/migrations/000102_create_miner_state_snapshot_rollups.*.sql` | Adds hourly/daily snapshot rollup hypertables, backfills them, sets rollup retention, then shortens raw snapshot retention to 3 days. | This is the substantial snapshot disk-saving mechanism; reviewers should check backfill ordering and rollback behavior. |
| `server/sqlc/queries/miner_state_snapshots.sql` | Snapshot insertion now also upserts hourly/daily rollups; new rollup read queries support uptime counts. | This keeps long-range uptime data available after raw snapshot rows expire. |
| `server/internal/infrastructure/timescaledb/telemetry_store.go` | Routes uptime counts to raw snapshots for raw ranges, hourly rollups for hourly ranges, and daily rollups for daily ranges. | This preserves UptimePanel behavior across all supported dashboard durations. |
| `server/generated/sqlc/*` | Regenerated sqlc bindings for new rollup tables and queries. | Generated — skip except to confirm it matches the SQL source. |
| `server/internal/infrastructure/timescaledb/telemetry_store_uptime_rollup_test.go` | Adds coverage for hourly/daily rollup uptime count aggregation and device filtering. | Confirms the new long-range uptime source returns the same count shape the dashboard expects. |

**Key Technical Decisions & Trade-Offs**
- Keep polling unchanged: avoids trading disk savings for stale alerts, slower curtailment confirmation, or lower chart freshness.
- Retain raw `device_metrics` for 8 days: chosen to preserve the existing 7-day daily continuous-aggregate refresh lookback plus bucket slack; reducing this further needs a metrics aggregate architecture change.
- Add explicit snapshot rollup tables instead of Timescale continuous aggregates: chosen so inserts update the rollups immediately and migration backfill can happen before raw retention drops.
- Retain raw `miner_state_snapshots` for 3 days: chosen to keep short-range raw uptime available with operational slack while moving long-range uptime to compact rollups.
- Keep hourly snapshot rollups for 14 days and daily rollups for 400 days: chosen to cover the dashboard's hourly and 1-year views with retention slack.
- Exclude observability from this PR: the storage lifecycle fix can ship independently while alerting/dashboard work remains tracked in the issue.

**Testing & Validation**
- Ran `source bin/activate-hermit && PROTO_PYTHON_GEN_VENV=/Users/ankitg/dev/repos/proto-fleet/packages/proto-python-gen/.venv just gen`.
- Ran `source bin/activate-hermit && just lint`.
- Ran `cd server && DB_PASSWORD=fleet go test ./internal/infrastructure/timescaledb -run 'TestTelemetryStore_UptimeStatusCountsFrom(Hourly|Daily)Rollups' -count=1`.
- Ran `cd server && source ../bin/activate-hermit && just test`.
- Not covered: live 5000-miner benchmark of 24-hour dashboard latency over compressed raw chunks; that remains a follow-up validation item from block/proto-fleet#614.
