### PR TITLE
feat(sites): build out the site detail page body (#373)

### DIFF
--- a/client/src/protoFleet/features/sites/components/SiteMetricsRow.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteMetricsRow.tsx
@@ -25,11 +25,14 @@ interface SiteMetricsRowProps {
   buildingCount: number;
   // `undefined` while metrics are still loading; the children render skeletons.
   metrics: SiteMetricsRowMetrics | undefined;
+  // Tile size. Defaults to the large `default` Metric scale used on the Sites
+  // list; the site detail page passes `compact` for its tighter header strip.
+  variant?: "default" | "compact";
   testId?: string;
 }
 
-// Five metrics in the per-site header: Location, Hashrate, Power (used /
-// capacity MW), Efficiency, Buildings. The shared Metric primitive
+// Five metrics in the per-site header: Location, Buildings, Hashrate, Power
+// (used / capacity MW), Efficiency. The shared Metric primitive
 // handles the skeleton vs em-dash vs value rendering so all five tiles
 // stay aligned during loading.
 const SiteMetricsRow = ({
@@ -38,6 +41,7 @@ const SiteMetricsRow = ({
   powerCapacityMw,
   buildingCount,
   metrics,
+  variant = "default",
   testId,
 }: SiteMetricsRowProps) => {
   const location = formatLocation(locationCity, locationState);
@@ -57,11 +61,11 @@ const SiteMetricsRow = ({
       className="grid grid-cols-2 gap-6 tablet:grid-cols-3 laptop:grid-cols-5"
       data-testid={testId ?? "site-metrics-row"}
     >
-      <Metric label="Location" value={location} testId="site-metric-location" />
-      <Metric label="Hashrate" value={hashrate} testId="site-metric-hashrate" />
-      <Metric label="Power" value={power} testId="site-metric-power" />
-      <Metric label="Efficiency" value={efficiency} testId="site-metric-efficiency" />
-      <Metric label="Buildings" value={String(buildingCount)} testId="site-metric-buildings" />
+      <Metric label="Location" value={location} variant={variant} testId="site-metric-location" />
+      <Metric label="Buildings" value={String(buildingCount)} variant={variant} testId="site-metric-buildings" />
+      <Metric label="Hashrate" value={hashrate} variant={variant} testId="site-metric-hashrate" />
+      <Metric label="Power" value={power} variant={variant} testId="site-metric-power" />
+      <Metric label="Efficiency" value={efficiency} variant={variant} testId="site-metric-efficiency" />
     </div>
   );
 };

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
@@ -28,6 +28,24 @@ vi.mock("@/protoFleet/api/sites", async () => {
   };
 });
 
+const useTelemetryMetricsMock = vi.hoisted(() => vi.fn((_options: unknown) => ({ data: { metrics: [] } })));
+
+vi.mock("@/protoFleet/api/useTelemetryMetrics", () => ({
+  useTelemetryMetrics: (options: unknown) => useTelemetryMetricsMock(options),
+}));
+
+const useSiteStatsMock = vi.hoisted(() =>
+  vi.fn((_options: unknown) => ({ stats: undefined, error: null, refetch: vi.fn() })),
+);
+
+vi.mock("@/protoFleet/api/useSiteStats", () => ({
+  useSiteStats: (options: unknown) => useSiteStatsMock(options),
+}));
+
+vi.mock("@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection", () => ({
+  DeviceSetPerformanceSection: () => <div data-testid="device-set-performance-section">Performance charts</div>,
+}));
+
 vi.mock("@/protoFleet/features/sites/components/SiteModals", () => ({
   __esModule: true,
   default: () => null,
@@ -101,6 +119,26 @@ describe("SiteDetailPage", () => {
     renderPage();
 
     await waitFor(() => expect(screen.getByTestId("location-probe")).toHaveTextContent("/austin/fleet"));
+  });
+
+  it("renders the metrics row scoped to the resolved site", async () => {
+    renderPage("/sites/7");
+
+    expect(await screen.findByTestId("site-detail-metrics-row")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(useSiteStatsMock).toHaveBeenCalledWith(expect.objectContaining({ siteId: 7n, enabled: true })),
+    );
+  });
+
+  it("renders the performance section scoped to the resolved site", async () => {
+    renderPage("/sites/7");
+
+    expect(await screen.findByTestId("site-detail-performance")).toBeInTheDocument();
+    expect(screen.getByTestId("device-set-performance-section")).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(useTelemetryMetricsMock).toHaveBeenCalledWith(expect.objectContaining({ siteIds: [7n], enabled: true })),
+    );
   });
 
   it("updates active site before navigating to a breadcrumb sibling site", async () => {

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
@@ -102,6 +102,9 @@ describe("SiteDetailPage", () => {
     vi.clearAllMocks();
     useFleetStore.setState((state) => {
       state.ui.activeSite = DEFAULT_ACTIVE_SITE;
+      // Reset per-test so the performance section's fleet:read gate starts
+      // from a known (denied) baseline; tests opt in explicitly.
+      state.auth.permissions = [];
     });
     listSitesMock.mockImplementation(({ onSuccess }: { onSuccess: (sites: SiteWithCounts[]) => void }) =>
       onSuccess([makeSite(7n, "Dallas"), makeSite(8n, "Austin")]),
@@ -130,7 +133,11 @@ describe("SiteDetailPage", () => {
     );
   });
 
-  it("renders the performance section scoped to the resolved site", async () => {
+  it("renders the performance section scoped to the resolved site for fleet:read operators", async () => {
+    useFleetStore.setState((state) => {
+      state.auth.permissions = ["fleet:read"];
+    });
+
     renderPage("/sites/7");
 
     expect(await screen.findByTestId("site-detail-performance")).toBeInTheDocument();
@@ -139,6 +146,19 @@ describe("SiteDetailPage", () => {
     await waitFor(() =>
       expect(useTelemetryMetricsMock).toHaveBeenCalledWith(expect.objectContaining({ siteIds: [7n], enabled: true })),
     );
+  });
+
+  it("hides the performance section and disables telemetry without fleet:read", async () => {
+    // Site-scoped operators (site:read only) can load the metrics row but
+    // GetCombinedMetrics requires org-default fleet:read, so the section is
+    // gated and the telemetry fetch must stay disabled rather than poll a
+    // request the server will deny.
+    renderPage("/sites/7");
+
+    // Metrics row still renders for the site-scoped operator.
+    expect(await screen.findByTestId("site-detail-metrics-row")).toBeInTheDocument();
+    expect(screen.queryByTestId("site-detail-performance")).not.toBeInTheDocument();
+    expect(useTelemetryMetricsMock).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
   });
 
   it("updates active site before navigating to a breadcrumb sibling site", async () => {

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -1,25 +1,42 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
+import SiteMetricsRow from "../components/SiteMetricsRow";
 import SiteModals from "../components/SiteModals";
 import { useSiteModals } from "../hooks/useSiteModals";
 import { useBuildings } from "@/protoFleet/api/buildings";
 import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { AggregationType, MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { buildKnownSiteIds, parseBigIntId, useSites } from "@/protoFleet/api/sites";
+import { useSiteStats } from "@/protoFleet/api/useSiteStats";
+import { useTelemetryMetrics } from "@/protoFleet/api/useTelemetryMetrics";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
+import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import BuildingModals from "@/protoFleet/features/buildings/components/BuildingModals";
 import BuildingSummaryCard from "@/protoFleet/features/buildings/components/BuildingSummaryCard";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
-import { formatSiteAddress } from "@/protoFleet/features/sites/formatAddress";
+import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
-import { useHasPermission } from "@/protoFleet/store";
+import { useDuration, useHasPermission, useSetDuration } from "@/protoFleet/store";
 import { Alert } from "@/shared/assets/icons";
 import Breadcrumb from "@/shared/components/Breadcrumb";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
+import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
 import Header from "@/shared/components/Header";
-import PlaceholderBlock from "@/shared/components/PlaceholderBlock";
+
+// Same measurement / aggregation slate the group, rack, and building overview
+// pages use, so the performance charts render identically across surfaces.
+const ALL_MEASUREMENT_TYPES: MeasurementType[] = [
+  MeasurementType.HASHRATE,
+  MeasurementType.POWER,
+  MeasurementType.TEMPERATURE,
+  MeasurementType.EFFICIENCY,
+  MeasurementType.UPTIME,
+];
+
+const ALL_AGGREGATION_TYPES: AggregationType[] = [AggregationType.AVERAGE, AggregationType.MIN, AggregationType.MAX];
 
 const SiteDetailPage = () => {
   const navigate = useNavigate();
@@ -125,6 +142,38 @@ const SiteDetailPage = () => {
     return fetchBuildings(siteId);
   }, [fetchBuildings, siteId, buildingsRefreshKey]);
 
+  // Server-rolled metrics for the header strip (hashrate / power / efficiency
+  // + building count). Scope is server-side: every device whose site_id
+  // matches, racked or site-direct, so the row matches the miner list.
+  const {
+    stats: siteStats,
+    error: siteStatsError,
+    refetch: refetchSiteStats,
+  } = useSiteStats({ siteId: siteId ?? 0n, enabled: siteId !== undefined, pollIntervalMs: POLL_INTERVAL_MS });
+
+  // Performance charts — mirrors the group/rack/building overview pages, but
+  // scopes telemetry by site rather than by explicit device-set membership.
+  // GetCombinedMetrics expands the site into its devices server-side, so no
+  // separate member-id fetch is needed here.
+  const duration = useDuration();
+  const setDuration = useSetDuration();
+  const telemetrySiteIds = useMemo(() => (siteId !== undefined ? [siteId] : []), [siteId]);
+  const telemetryOptions = useMemo(
+    () => ({
+      siteIds: telemetrySiteIds,
+      measurementTypes: ALL_MEASUREMENT_TYPES,
+      aggregations: ALL_AGGREGATION_TYPES,
+      duration,
+      enabled: siteId !== undefined,
+      pollIntervalMs: POLL_INTERVAL_MS,
+    }),
+    [telemetrySiteIds, duration, siteId],
+  );
+  const { data: telemetryData } = useTelemetryMetrics(telemetryOptions);
+  // `undefined` while the first response is in flight (skeletons); a defined
+  // (possibly empty) array once it lands, so empty sites show "No data".
+  const metrics = telemetryData?.metrics;
+
   if (sites === undefined) {
     return (
       <div className="flex flex-col gap-6 p-10 phone:p-6">
@@ -164,7 +213,6 @@ const SiteDetailPage = () => {
     );
   }
 
-  const address = formatSiteAddress(site.site);
   const siteSiblings = sites
     .filter((row) => row.site !== undefined)
     .map((row) => {
@@ -205,7 +253,7 @@ const SiteDetailPage = () => {
           testId="site-detail-breadcrumb"
         />
         <div className="flex items-start justify-between gap-4">
-          <Header title={site.site.name} titleSize="text-heading-300" subtitle={address || undefined} />
+          <Header title={site.site.name} titleSize="text-heading-300" />
           {canManageSites ? (
             <Button
               variant={variants.primary}
@@ -216,7 +264,28 @@ const SiteDetailPage = () => {
             />
           ) : null}
         </div>
-        <PlaceholderBlock label="Metrics row — coming soon" className="h-20" />
+        <div className="flex flex-col gap-4">
+          {siteStatsError ? (
+            <Callout
+              intent="danger"
+              prefixIcon={<Alert />}
+              title="Couldn't load site metrics"
+              subtitle={siteStatsError}
+              buttonText="Retry"
+              buttonOnClick={() => refetchSiteStats()}
+              testId="site-detail-metrics-error"
+            />
+          ) : null}
+          <SiteMetricsRow
+            locationCity={site.site.locationCity}
+            locationState={site.site.locationState}
+            powerCapacityMw={site.site.powerCapacityMw}
+            buildingCount={siteStats?.buildingCount ?? Number(site.buildingCount)}
+            metrics={siteStats}
+            variant="compact"
+            testId="site-detail-metrics-row"
+          />
+        </div>
         <div className="flex flex-col gap-4">
           <div className="flex items-center justify-between">
             <Header title="Buildings" titleSize="text-heading-200" />
@@ -243,7 +312,7 @@ const SiteDetailPage = () => {
               testId="site-detail-buildings-error"
             />
           ) : null}
-          <div className="rounded-[24px] border border-border-5 bg-surface-base p-6 shadow-300 tablet:p-8 laptop:p-10">
+          <div className="rounded-xl bg-surface-base p-10 dark:bg-core-primary-5 phone:p-6">
             {visibleBuildings === undefined ? (
               <div className="text-200 text-text-primary-50">Loading buildings…</div>
             ) : visibleBuildings.length === 0 ? (
@@ -264,7 +333,65 @@ const SiteDetailPage = () => {
             )}
           </div>
         </div>
-        <PlaceholderBlock label="Details table — coming soon" className="h-40" />
+        <div className="flex flex-col gap-4" data-testid="site-detail-performance">
+          <div className="flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between">
+            <div className="tablet:flex-1">
+              <Header title="Performance" titleSize="text-heading-200" />
+            </div>
+            <div className="flex items-center gap-6 text-200 text-core-primary-50">
+              <div className="flex items-center gap-2">
+                <svg width="24" height="4">
+                  <line
+                    x1="0"
+                    y1="2"
+                    x2="24"
+                    y2="2"
+                    stroke="var(--color-core-primary-fill)"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                  />
+                </svg>
+                <span>Site</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <svg width="24" height="4">
+                  <line
+                    x1="0"
+                    y1="2"
+                    x2="24"
+                    y2="2"
+                    stroke="var(--color-core-primary-50)"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    strokeDasharray="1 6"
+                    strokeOpacity="0.5"
+                  />
+                </svg>
+                <span>Max</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <svg width="24" height="4">
+                  <line
+                    x1="0"
+                    y1="2"
+                    x2="24"
+                    y2="2"
+                    stroke="var(--color-intent-critical-fill)"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    strokeDasharray="1 6"
+                    strokeOpacity="0.5"
+                  />
+                </svg>
+                <span>Min</span>
+              </div>
+            </div>
+            <div className="flex items-center tablet:flex-1 tablet:justify-end">
+              <DurationSelector duration={duration} durations={fleetDurations} onSelect={setDuration} />
+            </div>
+          </div>
+          <DeviceSetPerformanceSection duration={duration} metrics={metrics} />
+        </div>
       </div>
       <SiteModals modals={modals} sites={sites} buildingsRefreshKey={buildingsRefreshKey} />
       <BuildingModals modals={buildingModals} sites={sites} />

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -125,6 +125,16 @@ const SiteDetailPage = () => {
   // UpdateSite + CreateBuilding require site:manage server-side.
   const canManageSites = useHasPermission("site:manage");
 
+  // The performance charts hit TelemetryService.GetCombinedMetrics, whose
+  // handler requires org-default `fleet:read` (an empty ResourceContext — it
+  // is NOT site-scoped, unlike GetSiteStats which authorizes the metrics row
+  // against the requested SiteID). A site-scoped operator can therefore reach
+  // this page and load the metrics row but would be denied the telemetry call,
+  // leaving the charts stuck loading. `useHasPermission` reads that same
+  // org-default authority, so gate the whole section on it: skip the fetch and
+  // hide the charts unless GetCombinedMetrics would actually succeed.
+  const canReadFleet = useHasPermission("fleet:read");
+
   const [buildingsRefreshKey, setBuildingsRefreshKey] = useState(0);
   const refetchBuildings = useCallback(() => setBuildingsRefreshKey((n) => n + 1), []);
   // Membership saves in ManageSiteModal also affect building rows, so share
@@ -164,10 +174,10 @@ const SiteDetailPage = () => {
       measurementTypes: ALL_MEASUREMENT_TYPES,
       aggregations: ALL_AGGREGATION_TYPES,
       duration,
-      enabled: siteId !== undefined,
+      enabled: siteId !== undefined && canReadFleet,
       pollIntervalMs: POLL_INTERVAL_MS,
     }),
-    [telemetrySiteIds, duration, siteId],
+    [telemetrySiteIds, duration, siteId, canReadFleet],
   );
   const { data: telemetryData } = useTelemetryMetrics(telemetryOptions);
   // `undefined` while the first response is in flight (skeletons); a defined
@@ -333,65 +343,67 @@ const SiteDetailPage = () => {
             )}
           </div>
         </div>
-        <div className="flex flex-col gap-4" data-testid="site-detail-performance">
-          <div className="flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between">
-            <div className="tablet:flex-1">
-              <Header title="Performance" titleSize="text-heading-200" />
-            </div>
-            <div className="flex items-center gap-6 text-200 text-core-primary-50">
-              <div className="flex items-center gap-2">
-                <svg width="24" height="4">
-                  <line
-                    x1="0"
-                    y1="2"
-                    x2="24"
-                    y2="2"
-                    stroke="var(--color-core-primary-fill)"
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                  />
-                </svg>
-                <span>Site</span>
+        {canReadFleet ? (
+          <div className="flex flex-col gap-4" data-testid="site-detail-performance">
+            <div className="flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between">
+              <div className="tablet:flex-1">
+                <Header title="Performance" titleSize="text-heading-200" />
               </div>
-              <div className="flex items-center gap-2">
-                <svg width="24" height="4">
-                  <line
-                    x1="0"
-                    y1="2"
-                    x2="24"
-                    y2="2"
-                    stroke="var(--color-core-primary-50)"
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                    strokeDasharray="1 6"
-                    strokeOpacity="0.5"
-                  />
-                </svg>
-                <span>Max</span>
+              <div className="flex items-center gap-6 text-200 text-core-primary-50">
+                <div className="flex items-center gap-2">
+                  <svg width="24" height="4">
+                    <line
+                      x1="0"
+                      y1="2"
+                      x2="24"
+                      y2="2"
+                      stroke="var(--color-core-primary-fill)"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                  <span>Site</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <svg width="24" height="4">
+                    <line
+                      x1="0"
+                      y1="2"
+                      x2="24"
+                      y2="2"
+                      stroke="var(--color-core-primary-50)"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeDasharray="1 6"
+                      strokeOpacity="0.5"
+                    />
+                  </svg>
+                  <span>Max</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <svg width="24" height="4">
+                    <line
+                      x1="0"
+                      y1="2"
+                      x2="24"
+                      y2="2"
+                      stroke="var(--color-intent-critical-fill)"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeDasharray="1 6"
+                      strokeOpacity="0.5"
+                    />
+                  </svg>
+                  <span>Min</span>
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <svg width="24" height="4">
-                  <line
-                    x1="0"
-                    y1="2"
-                    x2="24"
-                    y2="2"
-                    stroke="var(--color-intent-critical-fill)"
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                    strokeDasharray="1 6"
-                    strokeOpacity="0.5"
-                  />
-                </svg>
-                <span>Min</span>
+              <div className="flex items-center tablet:flex-1 tablet:justify-end">
+                <DurationSelector duration={duration} durations={fleetDurations} onSelect={setDuration} />
               </div>
             </div>
-            <div className="flex items-center tablet:flex-1 tablet:justify-end">
-              <DurationSelector duration={duration} durations={fleetDurations} onSelect={setDuration} />
-            </div>
+            <DeviceSetPerformanceSection duration={duration} metrics={metrics} />
           </div>
-          <DeviceSetPerformanceSection duration={duration} metrics={metrics} />
-        </div>
+        ) : null}
       </div>
       <SiteModals modals={modals} sites={sites} buildingsRefreshKey={buildingsRefreshKey} />
       <BuildingModals modals={buildingModals} sites={sites} />

--- a/client/src/shared/components/Metric/Metric.tsx
+++ b/client/src/shared/components/Metric/Metric.tsx
@@ -4,8 +4,8 @@ import clsx from "clsx";
 import SkeletonBar from "@/shared/components/SkeletonBar";
 
 // `default` is the large standalone metric (text-heading-300, roomy gap).
-// `compact` is the tighter, smaller-value variant for dense cards: a
-// text-300 value sitting close under its label.
+// `compact` is the tighter variant for dense cards and metric rows: a
+// text-emphasis-400 value sitting close under its label.
 type MetricVariant = "default" | "compact";
 
 interface MetricProps {
@@ -24,7 +24,7 @@ interface MetricProps {
 
 const Metric = ({ label, value, valueSize, variant = "default", testId, className }: MetricProps) => {
   const compact = variant === "compact";
-  const resolvedValueSize = valueSize ?? (compact ? "text-300" : "text-heading-300");
+  const resolvedValueSize = valueSize ?? (compact ? "text-emphasis-400" : "text-heading-300");
 
   return (
     <div className={clsx("flex flex-col", compact ? "gap-0.5" : "gap-1", className)} data-testid={testId}>


### PR DESCRIPTION
Reviewable diff: +149/-18 across 3 files (excludes generated, test, and story files).

## Summary

Turns `/sites/:id` from a placeholder shell into a real operational page. Operators now see a site-scoped metrics row (Location, Buildings, Hashrate, Power, Efficiency) at the top and a site-scoped Performance section (hashrate / temperature / efficiency / power time-series charts with a duration selector) below the buildings grid — the same treatment group, rack, and building detail pages already have. The FPO "metrics row" and "details table" placeholders and the redundant address subheading are removed.

## How it works

The page resolves the site from the `:id` URL param against the already-loaded sites list (unchanged from before). Two read paths then hang off the resolved `siteId`, both scoped **server-side** so the client never enumerates the site's devices itself:

1. **Metrics row** — `useSiteStats(siteId)` calls `GetSiteStats`, which rolls up hashrate/power/efficiency and a building count across every device whose `site_id` matches (racked or site-direct). The response is passed straight into the existing `SiteMetricsRow`. Building count prefers the fresh stat and falls back to the initial `ListSites` count on first paint. The hook polls, so the row stays live; a fetch failure surfaces an inline retry callout instead of leaving the tiles in a skeleton.
2. **Performance charts** — `useTelemetryMetrics({ siteIds: [siteId] })` calls `GetCombinedMetrics` with a site filter, so the RPC expands the site into its devices server-side. The returned metrics feed the shared `DeviceSetPerformanceSection`. `undefined` while the first response is in flight renders skeletons; a defined-but-empty array renders "No data".

Both hooks are declared unconditionally before the page's loading/not-found early returns and are gated by `enabled: siteId !== undefined`, so they no-op until the site resolves.

```mermaid
flowchart TD
    URL["/sites/:id"] --> Resolve["Resolve site from sites list"]
    Resolve --> SiteId["siteId"]
    SiteId --> Stats["useSiteStats -> GetSiteStats"]
    SiteId --> Telem["useTelemetryMetrics siteIds -> GetCombinedMetrics"]
    Stats --> Row["SiteMetricsRow (compact)"]
    Telem --> Perf["DeviceSetPerformanceSection"]
    Resolve --> Buildings["Buildings grid (existing fetch)"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/.../sites/pages/SiteDetailPage.tsx` | Adds the `useSiteStats` + `useTelemetryMetrics` wiring, the metrics-row block, and the Performance section; removes both placeholders, the address subheading, and aligns the buildings card to the flat chart-card style | Primary change — confirm hooks are unconditional, `enabled`-gated, and that `siteIds`/poll scoping is correct |
| `client/.../sites/components/SiteMetricsRow.tsx` | Adds a `variant` prop (forwarded to each `Metric`); reorders tiles so Buildings is second | Shared component — also rendered on the Sites list page, which keeps the `default` variant |
| `client/src/shared/components/Metric/Metric.tsx` | `compact` variant value now renders at `text-emphasis-400` (was `text-300`) | Shared primitive — also affects the dashboard `SiteCard`, the only other `compact` consumer |
| `client/.../sites/pages/SiteDetailPage.test.tsx` | Mocks `useSiteStats` / `useTelemetryMetrics` / `DeviceSetPerformanceSection`; adds metrics-row and performance-section coverage | Test only |

## Key technical decisions & trade-offs

- **Site scoping is server-side (`siteIds` filter / `GetSiteStats`)** rather than fetching member device IDs client-side as the group/rack pages do — chosen because a site has no device-set membership to enumerate, and the RPCs already support a site filter; avoids a client-side paginate-and-aggregate pass.
- **`compact` variant value bumped to `text-emphasis-400` globally** rather than adding a one-off `valueSize` override on the site row — keeps the variant the single source of truth, at the cost of also restyling the dashboard `SiteCard` values (intended).
- **Buildings card restyled to match the chart cards** (`rounded-xl`, no border, no `shadow-300`, dark-mode bg) so the only "cards" on the page share one recipe.
- **Deferred / non-goals:** the Details table (PUE / gateway / notes), network-config editing on the site modal, and drag-to-reorder on the building grid remain out of scope per issue #373, pending their backend and design follow-ups.

## Testing & validation

- Client unit tests (`SiteDetailPage.test.tsx`, `SiteMetricsRow.test.tsx`) pass — added assertions that the metrics row and performance section render and are scoped to the resolved `siteId` (`siteIds: [7n]`, `enabled: true`).
- `tsc --noEmit`, ESLint, and Prettier are clean on the changed files.
- Not covered: live rendering against real telemetry/stats responses and visual/dark-mode regression of the restyled buildings card were not automated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
