### PR TITLE
fix(client): guard PageHeader ListSites behind site:read (#563)

### DIFF
--- a/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.test.tsx
@@ -285,4 +285,31 @@ describe("PageHeader", () => {
     expect(screen.queryByText("Curtailment pill")).not.toBeInTheDocument();
     expect(mockCurtailmentPill).not.toHaveBeenCalled();
   });
+
+  it("skips the ListSites fetch and hides the SitePicker without site read permission", () => {
+    vi.mocked(useHasPermission).mockImplementation((permission) => permission !== "site:read");
+
+    render(
+      <MemoryRouter>
+        <PageHeader schedulePillData={createSchedulePillData()} />
+      </MemoryRouter>,
+    );
+
+    expect(useHasPermission).toHaveBeenCalledWith("site:read");
+    expect(mockListSites).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("site-picker-trigger")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("site-picker-error")).not.toBeInTheDocument();
+  });
+
+  it("fetches sites when the user has site read permission", () => {
+    vi.mocked(useHasPermission).mockReturnValue(true);
+
+    render(
+      <MemoryRouter>
+        <PageHeader schedulePillData={createSchedulePillData()} />
+      </MemoryRouter>,
+    );
+
+    expect(mockListSites).toHaveBeenCalledTimes(1);
+  });
 });

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -126,6 +126,9 @@ function PageHeader({
   const [dismissedSetup, setDismissedSetup] = useReactiveLocalStorage<boolean>("completeSetupDismissed");
   const hasDismissedSetup = Boolean(dismissedSetup);
   const canReadCurtailment = useHasPermission("curtailment:read");
+  // ListSites is server-gated on org-scoped site:read; without it we skip the
+  // fetch and hide the picker so non-site readers keep a clean header.
+  const canReadSites = useHasPermission("site:read");
 
   // Sites are fetched once on mount and held here so the SitePicker doesn't
   // re-fire ListSites on every route change. `undefined` means "still
@@ -133,7 +136,7 @@ function PageHeader({
   // picker hides itself unless `sitesError` is non-null, in which case it
   // shows the retry affordance).
   const { listSites } = useSites();
-  const [sites, setSites] = useState<SiteWithCounts[] | undefined>(undefined);
+  const [sites, setSites] = useState<SiteWithCounts[] | undefined>(canReadSites ? undefined : []);
   const [sitesError, setSitesError] = useState<string | null>(null);
   // Bumped by the site create / rename / delete flows on pages and modals
   // below this header. Watching it lets the picker pick up a just-created
@@ -157,8 +160,9 @@ function PageHeader({
   }, [listSites]);
 
   useEffect(() => {
+    if (!canReadSites) return;
     return fetchSites();
-  }, [fetchSites, sitesRevision]);
+  }, [canReadSites, fetchSites, sitesRevision]);
 
   const handleCompleteSetup = () => {
     setDismissedSetup(false);
@@ -215,7 +219,9 @@ function PageHeader({
               />
             ) : null}
             <div className="min-w-0 flex-1" data-testid="page-header-selector-area">
-              {isDashboard ? null : <SitePicker sites={sites} error={sitesError} onRetry={fetchSites} />}
+              {isDashboard || !canReadSites ? null : (
+                <SitePicker sites={sites} error={sitesError} onRetry={fetchSites} />
+              )}
             </div>
           </div>
           {!isPhone && headerWidgetEnabled ? (


### PR DESCRIPTION
## Summary

`PageHeader` is mounted by `AppLayout` on every authenticated page, so its `ListSites` fetch ran for all users regardless of permission. Since `ListSites` is server-gated on org-scoped `site:read`, roles without it (e.g. `FIELD_TECH`) hit `PermissionDenied` and saw `SitePicker`'s "Sites unavailable" retry affordance in the top bar everywhere — inconsistent with `FleetLayout`, which already hides site-backed UI for the same case.

## What this accomplishes

This makes the global header permission-aware so its behavior matches the rest of the app: the header now treats `site:read` as a precondition for the whole site-picker surface rather than discovering the denial via a failed RPC. It adopts the same gating pattern `FleetLayout` already uses — gate on `useHasPermission("site:read")`, skip the fetch when blocked, seed an empty site list instead of a loading state, and hide the picker — so non-site readers get a clean header and no spurious permission-denied call fires on navigation.

## Non-goals / deferred

- No server-side or RBAC changes; this is purely client-side header behavior.
- Does not unify `PageHeader` and `FleetLayout` into a shared sites/permission hook — the duplication is left in place intentionally to keep the change scoped. `PageHeader` also keeps its simpler model (no polling or last-good/`PermissionDenied` tracking), since it no longer issues the call when blocked.

## Testing

eslint, prettier, and `tsc --noEmit` clean on the changed files; `PageHeader.test.tsx` passes 10/10, including new cases asserting `ListSites` is skipped and the picker is hidden without `site:read`, and that the fetch fires when granted.