### PR TITLE
Reduce raw metrics retention with hierarchical daily aggregates

### DIFF
--- a/server/generated/sqlc/models.go
+++ b/server/generated/sqlc/models.go
@@ -647,13 +647,17 @@ type DeviceMetricsHourly struct {
 	AvgHashRate      float64
 	MaxHashRate      sql.NullFloat64
 	MinHashRate      sql.NullFloat64
+	HashRatePoints   int64
 	AvgTemp          float64
 	MaxTemp          sql.NullFloat64
 	MinTemp          sql.NullFloat64
+	TempPoints       int64
 	AvgFanRpm        float64
 	AvgPower         float64
 	TotalPower       sql.NullFloat64
+	PowerPoints      int64
 	AvgEfficiency    float64
+	EfficiencyPoints int64
 	DataPoints       int64
 }
 

--- a/server/generated/sqlc/telemetry.sql.go
+++ b/server/generated/sqlc/telemetry.sql.go
@@ -81,13 +81,17 @@ SELECT
     COALESCE(avg_hash_rate, 0) AS avg_hash_rate,
     max_hash_rate,
     min_hash_rate,
+    hash_rate_points,
     COALESCE(avg_temp, 0) AS avg_temp,
     max_temp,
     min_temp,
+    temp_points,
     COALESCE(avg_fan_rpm, 0) AS avg_fan_rpm,
     COALESCE(avg_power, 0) AS avg_power,
     total_power,
+    power_points,
     COALESCE(avg_efficiency, 0) AS avg_efficiency,
+    efficiency_points,
     data_points
 FROM device_metrics_hourly
 WHERE bucket >= $1
@@ -117,13 +121,17 @@ func (q *Queries) GetAllDeviceMetricsHourlyAggregates(ctx context.Context, arg G
 			&i.AvgHashRate,
 			&i.MaxHashRate,
 			&i.MinHashRate,
+			&i.HashRatePoints,
 			&i.AvgTemp,
 			&i.MaxTemp,
 			&i.MinTemp,
+			&i.TempPoints,
 			&i.AvgFanRpm,
 			&i.AvgPower,
 			&i.TotalPower,
+			&i.PowerPoints,
 			&i.AvgEfficiency,
+			&i.EfficiencyPoints,
 			&i.DataPoints,
 		); err != nil {
 			return nil, err
@@ -441,13 +449,17 @@ SELECT
     COALESCE(avg_hash_rate, 0) AS avg_hash_rate,
     max_hash_rate,
     min_hash_rate,
+    hash_rate_points,
     COALESCE(avg_temp, 0) AS avg_temp,
     max_temp,
     min_temp,
+    temp_points,
     COALESCE(avg_fan_rpm, 0) AS avg_fan_rpm,
     COALESCE(avg_power, 0) AS avg_power,
     total_power,
+    power_points,
     COALESCE(avg_efficiency, 0) AS avg_efficiency,
+    efficiency_points,
     data_points
 FROM device_metrics_hourly
 WHERE device_identifier = ANY($3::text[])
@@ -478,13 +490,17 @@ func (q *Queries) GetDeviceMetricsHourlyAggregates(ctx context.Context, arg GetD
 			&i.AvgHashRate,
 			&i.MaxHashRate,
 			&i.MinHashRate,
+			&i.HashRatePoints,
 			&i.AvgTemp,
 			&i.MaxTemp,
 			&i.MinTemp,
+			&i.TempPoints,
 			&i.AvgFanRpm,
 			&i.AvgPower,
 			&i.TotalPower,
+			&i.PowerPoints,
 			&i.AvgEfficiency,
+			&i.EfficiencyPoints,
 			&i.DataPoints,
 		); err != nil {
 			return nil, err

--- a/server/migrations/000103_rebuild_daily_aggregates_from_hourly.down.sql
+++ b/server/migrations/000103_rebuild_daily_aggregates_from_hourly.down.sql
@@ -1,0 +1,101 @@
+SELECT remove_retention_policy('device_metrics', if_exists => true);
+SELECT add_retention_policy('device_metrics', INTERVAL '8 days',
+    schedule_interval => INTERVAL '6 hours');
+
+SELECT remove_continuous_aggregate_policy('device_metrics_daily', if_exists => true);
+SELECT remove_continuous_aggregate_policy('device_metrics_hourly', if_exists => true);
+SELECT remove_continuous_aggregate_policy('device_status_daily', if_exists => true);
+
+DROP INDEX IF EXISTS idx_device_metrics_daily_device;
+DROP INDEX IF EXISTS idx_device_metrics_hourly_device;
+DROP INDEX IF EXISTS idx_device_status_daily_device;
+
+DROP MATERIALIZED VIEW IF EXISTS device_metrics_daily;
+DROP MATERIALIZED VIEW IF EXISTS device_metrics_hourly;
+DROP MATERIALIZED VIEW IF EXISTS device_status_daily;
+
+CREATE MATERIALIZED VIEW device_metrics_hourly
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 hour', time) AS bucket,
+    device_identifier,
+    AVG(hash_rate_hs) AS avg_hash_rate,
+    MAX(hash_rate_hs) AS max_hash_rate,
+    MIN(hash_rate_hs) AS min_hash_rate,
+    AVG(temp_c) AS avg_temp,
+    MAX(temp_c) AS max_temp,
+    MIN(temp_c) AS min_temp,
+    AVG(fan_rpm) AS avg_fan_rpm,
+    AVG(power_w) AS avg_power,
+    SUM(power_w) AS total_power,
+    AVG(efficiency_jh) AS avg_efficiency,
+    COUNT(*) AS data_points
+FROM device_metrics
+GROUP BY bucket, device_identifier
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('device_metrics_hourly',
+    start_offset => INTERVAL '1 day',
+    end_offset => INTERVAL '1 hour',
+    schedule_interval => INTERVAL '30 minutes');
+
+CREATE INDEX idx_device_metrics_hourly_device
+    ON device_metrics_hourly(device_identifier, bucket DESC);
+
+CREATE MATERIALIZED VIEW device_metrics_daily
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_identifier,
+    AVG(hash_rate_hs) AS avg_hash_rate,
+    MAX(hash_rate_hs) AS max_hash_rate,
+    MIN(hash_rate_hs) AS min_hash_rate,
+    AVG(temp_c) AS avg_temp,
+    MAX(temp_c) AS max_temp,
+    MIN(temp_c) AS min_temp,
+    AVG(power_w) AS avg_power,
+    AVG(efficiency_jh) AS avg_efficiency,
+    COUNT(*) AS data_points
+FROM device_metrics
+GROUP BY bucket, device_identifier
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('device_metrics_daily',
+    start_offset => INTERVAL '7 days',
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '6 hours');
+
+CREATE INDEX idx_device_metrics_daily_device
+    ON device_metrics_daily(device_identifier, bucket DESC);
+
+CREATE MATERIALIZED VIEW device_status_daily
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_identifier,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c < 0 THEN 1 ELSE 0 END)::int AS temp_below_0,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 0 AND temp_c < 10 THEN 1 ELSE 0 END)::int AS temp_0_10,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 10 AND temp_c < 20 THEN 1 ELSE 0 END)::int AS temp_10_20,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 20 AND temp_c < 30 THEN 1 ELSE 0 END)::int AS temp_20_30,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 30 AND temp_c < 40 THEN 1 ELSE 0 END)::int AS temp_30_40,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 40 AND temp_c < 50 THEN 1 ELSE 0 END)::int AS temp_40_50,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 50 AND temp_c < 60 THEN 1 ELSE 0 END)::int AS temp_50_60,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 60 AND temp_c < 70 THEN 1 ELSE 0 END)::int AS temp_60_70,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 70 AND temp_c < 80 THEN 1 ELSE 0 END)::int AS temp_70_80,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 80 AND temp_c < 90 THEN 1 ELSE 0 END)::int AS temp_80_90,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 90 AND temp_c < 100 THEN 1 ELSE 0 END)::int AS temp_90_100,
+    SUM(CASE WHEN temp_c IS NOT NULL AND temp_c >= 100 THEN 1 ELSE 0 END)::int AS temp_100_plus,
+    SUM(CASE WHEN health = 'health_healthy_active' THEN 1 ELSE 0 END)::int AS hashing_count,
+    SUM(CASE WHEN health IS NULL OR health != 'health_healthy_active' THEN 1 ELSE 0 END)::int AS not_hashing_count,
+    COUNT(*)::int AS data_points
+FROM device_metrics
+GROUP BY bucket, device_identifier
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('device_status_daily',
+    start_offset => INTERVAL '7 days',
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '6 hours');
+
+CREATE INDEX idx_device_status_daily_device
+    ON device_status_daily(device_identifier, bucket DESC);

--- a/server/migrations/000103_rebuild_daily_aggregates_from_hourly.up.sql
+++ b/server/migrations/000103_rebuild_daily_aggregates_from_hourly.up.sql
@@ -1,0 +1,105 @@
+SELECT remove_continuous_aggregate_policy('device_metrics_daily', if_exists => true);
+SELECT remove_continuous_aggregate_policy('device_metrics_hourly', if_exists => true);
+SELECT remove_continuous_aggregate_policy('device_status_daily', if_exists => true);
+
+DROP INDEX IF EXISTS idx_device_metrics_daily_device;
+DROP INDEX IF EXISTS idx_device_metrics_hourly_device;
+DROP INDEX IF EXISTS idx_device_status_daily_device;
+
+DROP MATERIALIZED VIEW IF EXISTS device_metrics_daily;
+DROP MATERIALIZED VIEW IF EXISTS device_metrics_hourly;
+DROP MATERIALIZED VIEW IF EXISTS device_status_daily;
+
+CREATE MATERIALIZED VIEW device_metrics_hourly
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 hour', time) AS bucket,
+    device_identifier,
+    AVG(hash_rate_hs) AS avg_hash_rate,
+    MAX(hash_rate_hs) AS max_hash_rate,
+    MIN(hash_rate_hs) AS min_hash_rate,
+    COUNT(hash_rate_hs)::bigint AS hash_rate_points,
+    AVG(temp_c) AS avg_temp,
+    MAX(temp_c) AS max_temp,
+    MIN(temp_c) AS min_temp,
+    COUNT(temp_c)::bigint AS temp_points,
+    AVG(fan_rpm) AS avg_fan_rpm,
+    AVG(power_w) AS avg_power,
+    SUM(power_w) AS total_power,
+    COUNT(power_w)::bigint AS power_points,
+    AVG(efficiency_jh) AS avg_efficiency,
+    COUNT(efficiency_jh)::bigint AS efficiency_points,
+    COUNT(*) AS data_points
+FROM device_metrics
+GROUP BY bucket, device_identifier
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('device_metrics_hourly',
+    start_offset => INTERVAL '1 day',
+    end_offset => INTERVAL '1 hour',
+    schedule_interval => INTERVAL '30 minutes');
+
+CREATE INDEX idx_device_metrics_hourly_device
+    ON device_metrics_hourly(device_identifier, bucket DESC);
+
+CREATE MATERIALIZED VIEW device_metrics_daily
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day', bucket) AS bucket,
+    device_identifier,
+    (SUM(avg_hash_rate * hash_rate_points)::double precision / NULLIF(SUM(hash_rate_points), 0)::double precision)::double precision AS avg_hash_rate,
+    MAX(max_hash_rate) AS max_hash_rate,
+    MIN(min_hash_rate) AS min_hash_rate,
+    (SUM(avg_temp * temp_points)::double precision / NULLIF(SUM(temp_points), 0)::double precision)::double precision AS avg_temp,
+    MAX(max_temp) AS max_temp,
+    MIN(min_temp) AS min_temp,
+    (SUM(avg_power * power_points)::double precision / NULLIF(SUM(power_points), 0)::double precision)::double precision AS avg_power,
+    (SUM(avg_efficiency * efficiency_points)::double precision / NULLIF(SUM(efficiency_points), 0)::double precision)::double precision AS avg_efficiency,
+    SUM(data_points)::bigint AS data_points
+FROM device_metrics_hourly
+GROUP BY 1, device_identifier
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('device_metrics_daily',
+    start_offset => INTERVAL '7 days',
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '6 hours');
+
+CREATE INDEX idx_device_metrics_daily_device
+    ON device_metrics_daily(device_identifier, bucket DESC);
+
+CREATE MATERIALIZED VIEW device_status_daily
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day', bucket) AS bucket,
+    device_identifier,
+    SUM(temp_below_0)::int AS temp_below_0,
+    SUM(temp_0_10)::int AS temp_0_10,
+    SUM(temp_10_20)::int AS temp_10_20,
+    SUM(temp_20_30)::int AS temp_20_30,
+    SUM(temp_30_40)::int AS temp_30_40,
+    SUM(temp_40_50)::int AS temp_40_50,
+    SUM(temp_50_60)::int AS temp_50_60,
+    SUM(temp_60_70)::int AS temp_60_70,
+    SUM(temp_70_80)::int AS temp_70_80,
+    SUM(temp_80_90)::int AS temp_80_90,
+    SUM(temp_90_100)::int AS temp_90_100,
+    SUM(temp_100_plus)::int AS temp_100_plus,
+    SUM(hashing_count)::int AS hashing_count,
+    SUM(not_hashing_count)::int AS not_hashing_count,
+    SUM(data_points)::int AS data_points
+FROM device_status_hourly
+GROUP BY 1, device_identifier
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('device_status_daily',
+    start_offset => INTERVAL '7 days',
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '6 hours');
+
+CREATE INDEX idx_device_status_daily_device
+    ON device_status_daily(device_identifier, bucket DESC);
+
+SELECT remove_retention_policy('device_metrics', if_exists => true);
+SELECT add_retention_policy('device_metrics', INTERVAL '3 days',
+    schedule_interval => INTERVAL '6 hours');

--- a/server/sqlc/queries/telemetry.sql
+++ b/server/sqlc/queries/telemetry.sql
@@ -191,13 +191,17 @@ SELECT
     COALESCE(avg_hash_rate, 0) AS avg_hash_rate,
     max_hash_rate,
     min_hash_rate,
+    hash_rate_points,
     COALESCE(avg_temp, 0) AS avg_temp,
     max_temp,
     min_temp,
+    temp_points,
     COALESCE(avg_fan_rpm, 0) AS avg_fan_rpm,
     COALESCE(avg_power, 0) AS avg_power,
     total_power,
+    power_points,
     COALESCE(avg_efficiency, 0) AS avg_efficiency,
+    efficiency_points,
     data_points
 FROM device_metrics_hourly
 WHERE device_identifier = ANY(sqlc.arg('device_identifiers')::text[])
@@ -234,13 +238,17 @@ SELECT
     COALESCE(avg_hash_rate, 0) AS avg_hash_rate,
     max_hash_rate,
     min_hash_rate,
+    hash_rate_points,
     COALESCE(avg_temp, 0) AS avg_temp,
     max_temp,
     min_temp,
+    temp_points,
     COALESCE(avg_fan_rpm, 0) AS avg_fan_rpm,
     COALESCE(avg_power, 0) AS avg_power,
     total_power,
+    power_points,
     COALESCE(avg_efficiency, 0) AS avg_efficiency,
+    efficiency_points,
     data_points
 FROM device_metrics_hourly
 WHERE bucket >= $1


### PR DESCRIPTION
Reviewable diff: +214/-0 across 3 files (excludes generated, test, and story files).

**Summary**
This stacked PR reduces raw `device_metrics` retention from 8 days to 3 days while keeping Fleet's longer-range dashboard metric and status views backed by daily aggregates. Daily `device_metrics_daily` and `device_status_daily` are rebuilt as hierarchical continuous aggregates over the hourly aggregate layer instead of raw `device_metrics`, so their 7-day refresh lookback no longer requires 7 days of raw samples. The hourly metrics aggregate gains per-field count columns so daily weighted averages preserve raw `AVG()` semantics for nullable metric fields.

**Stack**
- Parent: [#616 Tighten telemetry storage lifecycle policies](https://github.com/block/proto-fleet/pull/616)
- This PR: Reduce raw metrics retention with hierarchical daily aggregates

This diff is relative to `ankitg/timescale-retention-compression`. The parent PR adds the storage lifecycle foundation and snapshot uptime rollups; this PR only changes the metrics/status daily aggregate source and then lowers raw `device_metrics` retention.

With this PR on top of #616, the observed 5000-virtual-miner lab steady-state estimate becomes:

| Storage area | Estimated steady state |
| --- | ---: |
| `device_metrics` raw | 5-12 GB |
| Metrics/status hourly + daily aggregates | 2-6 GB |
| Raw `miner_state_snapshots` | 1-4 GB |
| Snapshot hourly/daily rollups | 1-3 GB |
| Other Postgres/WAL/etc. | 1-4 GB |
| Timescale volume total | 10-29 GB |
| Whole 58 GB Pi root partition used | 23-40 GB |
| Whole 58 GB Pi root partition free | 18-35 GB |

**How It Works**
The migration drops the existing daily metric/status continuous aggregate policies and views, then rebuilds `device_metrics_hourly` with additional per-field count columns. Those counts let `device_metrics_daily` compute exact weighted daily averages from hourly rows, while preserving the existing hourly query shape through regenerated sqlc bindings.

`device_metrics_daily` is recreated from `device_metrics_hourly`, and `device_status_daily` is recreated from `device_status_hourly`. Their refresh policies still use a 7-day lookback, but that lookback now reads retained hourly aggregates instead of raw telemetry. After the daily aggregate dependency is moved off raw data, the migration replaces the raw `device_metrics` retention policy with a 3-day window and the same explicit 6-hour job schedule. The down migration restores the prior raw-sourced hourly/daily aggregate definitions and the parent PR's 8-day raw retention.

**Diagrams**
```mermaid
flowchart TD
  A["Raw device_metrics"] --> B["device_metrics_hourly"]
  B --> C["device_metrics_daily"]
  A --> D["device_status_hourly"]
  D --> E["device_status_daily"]
  F["1h and 24h charts"] --> A
  G["24h-10d dashboard ranges"] --> B
  H[">10d dashboard ranges"] --> C
  I["3d raw retention"] --> A
```

```mermaid
flowchart TD
  A["Migration up"] --> B["Drop daily aggregate policies and views"]
  B --> C["Rebuild hourly metrics with per-field counts"]
  C --> D["Rebuild daily metrics from hourly metrics"]
  D --> E["Rebuild daily status from hourly status"]
  E --> F["Set raw device_metrics retention to 3 days"]
```

**Areas Of The Code Involved**
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/migrations/000103_rebuild_daily_aggregates_from_hourly.up.sql` | Rebuilds daily metrics/status aggregates from hourly aggregates and lowers raw `device_metrics` retention to 3 days. | This is the production storage reduction; reviewers should verify aggregate definitions and retention ordering. |
| `server/migrations/000103_rebuild_daily_aggregates_from_hourly.down.sql` | Restores raw-sourced daily aggregates and 8-day raw retention. | This is the rollback path to the parent PR behavior. |
| `server/sqlc/queries/telemetry.sql` | Selects the new hourly metrics count columns so generated hourly row scans remain aligned with the view shape. | Keeps existing hourly dashboard query code compatible with the rebuilt hourly aggregate. |
| `server/generated/sqlc/*` | Regenerated bindings for the hourly aggregate view shape. | Generated — skip except to confirm it matches the SQL source. |

**Key Technical Decisions & Trade-Offs**
- Use hierarchical continuous aggregates for daily metrics/status: chosen over shortening daily refresh lookback because it preserves late-refresh behavior without retaining 8 days of raw samples.
- Add per-field hourly metric counts: chosen so daily averages remain weighted by non-null source samples instead of by total row count.
- Keep 3 days of raw `device_metrics`: chosen to cover raw 1h/24h dashboards plus hourly aggregate refresh slack; the trade-off is late raw telemetry older than 3 days will not be incorporated into hourly aggregates.
- Leave hourly aggregate retention unchanged: the daily aggregate 7-day refresh now depends on hourly aggregate history, and existing 3-month hourly retention already covers that contract.

**Testing & Validation**
- Ran `source bin/activate-hermit && PROTO_PYTHON_GEN_VENV=/Users/ankitg/dev/repos/proto-fleet/packages/proto-python-gen/.venv just gen`.
- Ran `cd server && DB_PASSWORD=fleet go test ./internal/infrastructure/timescaledb -run 'TestTelemetryStore_GetCombinedMetrics_DataSourceSelection|TestTelemetryStore_UptimeStatusCountsFrom(Hourly|Daily)Rollups' -count=1`.
- Ran `source bin/activate-hermit && just lint`.
- Ran `cd server && source ../bin/activate-hermit && just test`.
- Not covered: live 5000-miner benchmark of continuous aggregate refresh runtime and dashboard latency after the 3-day retention policy is active.
