### PR TITLE
Tighten telemetry compression policies

### DIFF
--- a/server/migrations/000101_tighten_telemetry_compression.down.sql
+++ b/server/migrations/000101_tighten_telemetry_compression.down.sql
@@ -1,0 +1,5 @@
+SELECT remove_compression_policy('device_metrics', if_exists => true);
+SELECT add_compression_policy('device_metrics', INTERVAL '7 days');
+
+SELECT remove_compression_policy('miner_state_snapshots', if_exists => true);
+SELECT add_compression_policy('miner_state_snapshots', INTERVAL '7 days');

--- a/server/migrations/000101_tighten_telemetry_compression.up.sql
+++ b/server/migrations/000101_tighten_telemetry_compression.up.sql
@@ -1,0 +1,7 @@
+SELECT remove_compression_policy('device_metrics', if_exists => true);
+SELECT add_compression_policy('device_metrics', INTERVAL '6 hours',
+    schedule_interval => INTERVAL '1 hour');
+
+SELECT remove_compression_policy('miner_state_snapshots', if_exists => true);
+SELECT add_compression_policy('miner_state_snapshots', INTERVAL '6 hours',
+    schedule_interval => INTERVAL '1 hour');


### PR DESCRIPTION
Reviewable diff: +12/-0 across 2 files (excludes generated, test, and story files).

**Summary**
This PR reduces Timescale hot storage for large lab fleets by compressing the two highest-volume telemetry hypertables sooner, without changing retention, polling, dashboard query routing, APIs, or supported dashboard durations. `device_metrics` and `miner_state_snapshots` now compress chunks after 6 hours, and their compression background jobs run hourly instead of relying on TimescaleDB's default cadence. Raw rows remain retained and queryable; this only changes when eligible chunks move to compressed storage. Refs block/proto-fleet#614; observability work remains out of scope.

Expected storage impact:

A manual check on the affected Raspberry Pi lab server compressed one eligible `device_metrics` chunk from 8564 MB to 643 MB, a 13.3x reduction that freed about 7.7 GB from that chunk.

| Hypertable | Previous hot uncompressed window | New effective hot uncompressed window | Observed lab result |
| --- | ---: | ---: | --- |
| `device_metrics` | roughly 7-8 days | roughly 6-30 hours because chunks are 1 day | 8564 MB -> 643 MB for one eligible chunk, 13.3x smaller and about 7.7 GB saved |
| `miner_state_snapshots` | roughly 7-14 days | roughly 6 hours-7 days because chunks are 7 days | Not yet measured on the large active chunk; only a smaller 460 MB chunk was immediately eligible in the lab |

**How It Works**
A new migration removes the existing compression policies for `device_metrics` and `miner_state_snapshots`, then re-adds them with `compress_after => 6 hours` and an explicit hourly `schedule_interval`. TimescaleDB still compresses at chunk granularity, so this does not rewrite active rows individually or drop any data. The rollback migration removes those policies and restores the previous 7-day compression age for both hypertables.

**Diagrams**
```mermaid
flowchart TD
  A["Telemetry writes"] --> B["device_metrics raw hypertable"]
  C["State snapshot writes"] --> D["miner_state_snapshots raw hypertable"]
  B --> E["Hourly compression job after 6h"]
  D --> F["Hourly compression job after 6h"]
  E --> G["Compressed chunks remain queryable"]
  F --> G
  H["Dashboard queries"] --> B
  H --> D
```

```mermaid
flowchart TD
  A["Migration up"] --> B["Remove existing compression policies"]
  B --> C["Add 6h compression policies"]
  C --> D["Set hourly compression schedules"]
  D --> E["Timescale background jobs compress eligible chunks"]
```

**Areas Of The Code Involved**
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/migrations/000101_tighten_telemetry_compression.up.sql` | Replaces compression policies for `device_metrics` and `miner_state_snapshots` with 6-hour compression and hourly job schedules. | This is the production storage behavior change; reviewers should verify it does not alter retention or query paths. |
| `server/migrations/000101_tighten_telemetry_compression.down.sql` | Restores the previous 7-day compression age for both hypertables. | This is the rollback path if compressed-chunk query latency is unacceptable. |

**Key Technical Decisions & Trade-Offs**
- Change compression only: chosen over retention or aggregate rewrites to keep all user-facing data and dashboard behavior intact.
- Use 6-hour compression: chosen over 24-hour compression for larger disk savings; the trade-off is that 24h dashboard queries may sometimes read compressed `device_metrics` chunks.
- Add explicit hourly schedules: chosen to avoid TimescaleDB's default job cadence delaying compression by up to a day.
- Avoid manual `compress_chunk(...)` backfill: chosen to keep migration runtime and temporary disk pressure low; background jobs compress eligible chunks gradually.

**Testing & Validation**
- Ran `source bin/activate-hermit && PROTO_PYTHON_GEN_VENV=/Users/ankitg/dev/repos/proto-fleet/packages/proto-python-gen/.venv just gen`; no generated files changed for this policy-only migration.
- Ran `source bin/activate-hermit && just lint`.
- Ran `cd server && source ../bin/activate-hermit && just test`.
- Not covered: live 5000-virtual-miner benchmark of 24h dashboard latency over compressed raw chunks; that remains the recommended lab validation after deploy.

