### PR TITLE
fix: cap rack/building membership at grid capacity (#560)

### DIFF
--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
@@ -358,6 +358,23 @@ const ManageBuildingModal = ({
   // bucket. Layout writes live in BuildingSettingsModal.
   const handleSave = useCallback(async () => {
     if (savingRef.current) return;
+
+    // Capacity guard — mirrors ManageRackModal's slot check and the
+    // server's AssignRacksToBuilding cap. A building holds at most
+    // aisles×racks_per_aisle racks (placed or unplaced); reject before
+    // dispatch so an over-capacity working set never reaches the RPC.
+    // `entries` is the racks staying in this building (removed ones are
+    // already filtered out). Skipped when the grid is unconfigured
+    // (capacity 0): racks can be staged before a layout is set.
+    const capacity = aislesNum * racksPerAisleNum;
+    if (capacity > 0 && entries.length > capacity) {
+      setErrorMsg(
+        `This building has ${capacity} rack positions (${aislesNum} aisles × ${racksPerAisleNum} per aisle), ` +
+          `but ${entries.length} racks are assigned. Remove some racks or increase the layout.`,
+      );
+      return;
+    }
+
     savingRef.current = true;
     setErrorMsg("");
     setIsSaving(true);
@@ -517,7 +534,7 @@ const ManageBuildingModal = ({
       savingRef.current = false;
       setIsSaving(false);
     }
-  }, [building, rackToCell, entries, assignRacksToBuilding, onSaved, onDismiss]);
+  }, [building, rackToCell, entries, aislesNum, racksPerAisleNum, assignRacksToBuilding, onSaved, onDismiss]);
 
   if (!open) return null;
 

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -38,6 +38,17 @@ import { pushToast, STATUSES } from "@/shared/features/toaster";
 const MAX_PARENT_BATCH = 1000;
 const MAX_DEVICE_BATCH = 10000;
 
+// Absolute upper bound on a rack's miner capacity: 12×12, the largest
+// layout RackSettingsModal allows (rows/columns each clamp 1–12, matching
+// the server's maxRackDimension). The rack create flow seeds the new rack
+// with the operator's current miner selection, which in all-selection mode
+// resolves to the full fleet (capped only at MAX_DEVICE_BATCH). Without a
+// gate here, an oversized seed renders one MinersPane row per miner and
+// freezes the browser long before the save-time capacity guard fires. Cap
+// at the absolute max before ManageRackModal mounts — the exact
+// chosen-capacity check still runs at save once rows×columns are picked.
+const MAX_RACK_CAPACITY = 144;
+
 // A seed that moves racked miners into a new building/site sends
 // forceClearConflictingRackMembership, which the server gates on rack:manage.
 // "Add to building/site" is reachable with only site:manage, so without this
@@ -113,6 +124,13 @@ const FleetCreateFlowProvider = ({
 
   const launchCreateRack = useCallback(
     (seed: RackCreateSeed) => {
+      if ((seed.minerIds?.length ?? 0) > MAX_RACK_CAPACITY) {
+        pushToast({
+          message: `A rack holds at most ${MAX_RACK_CAPACITY} miners. Filter the selection and try again.`,
+          status: STATUSES.error,
+        });
+        return;
+      }
       if (seed.conflictCount && seed.conflictCount > 0) {
         setRackConflictSeed(seed);
         return;

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -217,6 +217,22 @@ const FleetCreateFlowProvider = ({
       // Synchronous re-entry guard: a double-click reaches here twice before
       // the `saving` prop re-renders, which would create duplicate buildings.
       if (creatingBuildingRef.current) return;
+
+      // Preflight seeded racks against the chosen layout BEFORE creating the
+      // building. The server's AssignRacksToBuilding now rejects an
+      // over-capacity assign; without this guard the building is created and
+      // then stranded with its racks unassigned (the assign failure only
+      // toasts). Net-new == every seeded rack since the building is brand
+      // new. Skipped at capacity 0 (unconfigured layout) — staging is allowed.
+      const rackCapacity = values.aisles * values.racksPerAisle;
+      if (buildingSeed && rackCapacity > 0 && buildingSeed.rackIds.length > rackCapacity) {
+        pushToast({
+          message: `This ${values.aisles}×${values.racksPerAisle} layout holds ${rackCapacity} rack(s), but ${buildingSeed.rackIds.length} are selected. Reduce the selection or increase the layout.`,
+          status: STATUSES.error,
+        });
+        return;
+      }
+
       creatingBuildingRef.current = true;
       setCreatingBuilding(true);
       try {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -47,7 +47,7 @@ const MAX_DEVICE_BATCH = 10000;
 // freezes the browser long before the save-time capacity guard fires. Cap
 // at the absolute max before ManageRackModal mounts — the exact
 // chosen-capacity check still runs at save once rows×columns are picked.
-const MAX_RACK_CAPACITY = 144;
+const MAX_RACK_CAPACITY = 12 * 12;
 
 // A seed that moves racked miners into a new building/site sends
 // forceClearConflictingRackMembership, which the server gates on rack:manage.

--- a/server/generated/sqlc/building.sql.go
+++ b/server/generated/sqlc/building.sql.go
@@ -308,6 +308,32 @@ func (q *Queries) ClearDeviceBuildingsOnSiteMismatch(ctx context.Context, arg Cl
 	return result.RowsAffected()
 }
 
+const countRacksInBuilding = `-- name: CountRacksInBuilding :one
+SELECT COUNT(*)::bigint AS rack_count
+FROM device_set_rack dsr
+JOIN device_set ds ON ds.id = dsr.device_set_id
+WHERE dsr.org_id = $1
+  AND dsr.building_id = $2
+  AND ds.deleted_at IS NULL
+`
+
+type CountRacksInBuildingParams struct {
+	OrgID      int64
+	BuildingID sql.NullInt64
+}
+
+// Total live racks currently assigned to a building (placed or
+// unplaced — membership, not grid occupancy). Used by
+// AssignRacksToBuilding's capacity guard to reject a batch that would
+// push the building over its aisles×racks_per_aisle grid. Matches
+// ListBuildingRacks' filter so the count and the list agree.
+func (q *Queries) CountRacksInBuilding(ctx context.Context, arg CountRacksInBuildingParams) (int64, error) {
+	row := q.queryRow(ctx, q.countRacksInBuildingStmt, countRacksInBuilding, arg.OrgID, arg.BuildingID)
+	var rack_count int64
+	err := row.Scan(&rack_count)
+	return rack_count, err
+}
+
 const createBuilding = `-- name: CreateBuilding :one
 INSERT INTO building (
     org_id,

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -183,6 +183,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.countRacksBySiteStmt, err = db.PrepareContext(ctx, countRacksBySite); err != nil {
 		return nil, fmt.Errorf("error preparing query CountRacksBySite: %w", err)
 	}
+	if q.countRacksInBuildingStmt, err = db.PrepareContext(ctx, countRacksInBuilding); err != nil {
+		return nil, fmt.Errorf("error preparing query CountRacksInBuilding: %w", err)
+	}
 	if q.createApiKeyStmt, err = db.PrepareContext(ctx, createApiKey); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateApiKey: %w", err)
 	}
@@ -1615,6 +1618,11 @@ func (q *Queries) Close() error {
 	if q.countRacksBySiteStmt != nil {
 		if cerr := q.countRacksBySiteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing countRacksBySiteStmt: %w", cerr)
+		}
+	}
+	if q.countRacksInBuildingStmt != nil {
+		if cerr := q.countRacksInBuildingStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing countRacksInBuildingStmt: %w", cerr)
 		}
 	}
 	if q.createApiKeyStmt != nil {
@@ -3649,6 +3657,7 @@ type Queries struct {
 	countMinersByStateStmt                                     *sql.Stmt
 	countOrgScopeSuperAdminsExcludingUserStmt                  *sql.Stmt
 	countRacksBySiteStmt                                       *sql.Stmt
+	countRacksInBuildingStmt                                   *sql.Stmt
 	createApiKeyStmt                                           *sql.Stmt
 	createBuildingStmt                                         *sql.Stmt
 	createCommandBatchLogStmt                                  *sql.Stmt
@@ -4096,6 +4105,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		countMinersByStateStmt:                                     q.countMinersByStateStmt,
 		countOrgScopeSuperAdminsExcludingUserStmt:                  q.countOrgScopeSuperAdminsExcludingUserStmt,
 		countRacksBySiteStmt:                                       q.countRacksBySiteStmt,
+		countRacksInBuildingStmt:                                   q.countRacksInBuildingStmt,
 		createApiKeyStmt:                                           q.createApiKeyStmt,
 		createBuildingStmt:                                         q.createBuildingStmt,
 		createCommandBatchLogStmt:                                  q.createCommandBatchLogStmt,

--- a/server/internal/domain/buildings/service.go
+++ b/server/internal/domain/buildings/service.go
@@ -232,7 +232,7 @@ func (s *Service) UpdateBuilding(ctx context.Context, params models.UpdateParams
 			return err
 		}
 		// Bounds-shrink validation only runs when at least one
-		// dimension is being reduced; growth never orphans rows.
+		// dimension is being reduced; growth never orphans PLACED rows.
 		// Uses ListRacksOutsideBuildingBounds (unbounded by design)
 		// instead of the paged ListBuildingRacks so a tail row past
 		// the page-size cap can't silently bypass the guard.
@@ -248,23 +248,25 @@ func (s *Service) UpdateBuilding(ctx context.Context, params models.UpdateParams
 					r.RackLabel, *r.AisleIndex+1, *r.PositionInAisle+1, params.Aisles, params.RacksPerAisle,
 				)
 			}
-			// The orphan scan above only catches PLACED racks outside the
-			// new bounds; unplaced members slip past it. Bound total
-			// membership too, so shrinking below the rack count can't leave
-			// the building over capacity (the same invariant
-			// AssignRacksToBuilding enforces). Skipped when the new grid is
-			// unconfigured (capacity 0).
-			if capacity := gridCapacity(params.Aisles, params.RacksPerAisle); capacity > 0 {
-				members, err := s.store.CountRacksInBuilding(txCtx, params.OrgID, params.ID)
-				if err != nil {
-					return err
-				}
-				if members > capacity {
-					return fleeterror.NewInvalidArgumentErrorf(
-						"cannot shrink layout: building has %d racks but the new %d aisles × %d racks-per-aisle grid holds only %d; unassign some racks first",
-						members, params.Aisles, params.RacksPerAisle, capacity,
-					)
-				}
+		}
+		// Total-membership cap. Runs on ANY positive-capacity layout edit, not
+		// just shrinks: the orphan scan above only catches PLACED racks, and a
+		// building staged while unconfigured (capacity 0, where
+		// AssignRacksToBuilding skips the cap) can accumulate unplaced members
+		// and then be given its FIRST positive layout — a growth, not a shrink
+		// — that the grid can't hold. Bound total members against the new grid
+		// here so that path can't persist an over-capacity building. Skipped
+		// when the new grid is still unconfigured (capacity 0).
+		if capacity := gridCapacity(params.Aisles, params.RacksPerAisle); capacity > 0 {
+			members, err := s.store.CountRacksInBuilding(txCtx, params.OrgID, params.ID)
+			if err != nil {
+				return err
+			}
+			if members > capacity {
+				return fleeterror.NewInvalidArgumentErrorf(
+					"cannot apply layout: building has %d racks but the new %d aisles × %d racks-per-aisle grid holds only %d; unassign some racks first",
+					members, params.Aisles, params.RacksPerAisle, capacity,
+				)
 			}
 		}
 		updated, err := s.store.UpdateBuilding(txCtx, params)

--- a/server/internal/domain/buildings/service.go
+++ b/server/internal/domain/buildings/service.go
@@ -248,6 +248,24 @@ func (s *Service) UpdateBuilding(ctx context.Context, params models.UpdateParams
 					r.RackLabel, *r.AisleIndex+1, *r.PositionInAisle+1, params.Aisles, params.RacksPerAisle,
 				)
 			}
+			// The orphan scan above only catches PLACED racks outside the
+			// new bounds; unplaced members slip past it. Bound total
+			// membership too, so shrinking below the rack count can't leave
+			// the building over capacity (the same invariant
+			// AssignRacksToBuilding enforces). Skipped when the new grid is
+			// unconfigured (capacity 0).
+			if capacity := gridCapacity(params.Aisles, params.RacksPerAisle); capacity > 0 {
+				members, err := s.store.CountRacksInBuilding(txCtx, params.OrgID, params.ID)
+				if err != nil {
+					return err
+				}
+				if members > capacity {
+					return fleeterror.NewInvalidArgumentErrorf(
+						"cannot shrink layout: building has %d racks but the new %d aisles × %d racks-per-aisle grid holds only %d; unassign some racks first",
+						members, params.Aisles, params.RacksPerAisle, capacity,
+					)
+				}
+			}
 		}
 		updated, err := s.store.UpdateBuilding(txCtx, params)
 		if err != nil {
@@ -578,8 +596,7 @@ func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.Assig
 		// max_items, and the per-cell check above still rejects placement
 		// into a 0-cell grid.
 		if targetBuilding != nil {
-			capacity := int64(targetBuilding.Aisles) * int64(targetBuilding.RacksPerAisle)
-			if capacity > 0 {
+			if capacity := gridCapacity(targetBuilding.Aisles, targetBuilding.RacksPerAisle); capacity > 0 {
 				existing, err := s.store.CountRacksInBuilding(txCtx, params.OrgID, *params.TargetBuildingID)
 				if err != nil {
 					return nil, err
@@ -770,6 +787,17 @@ func validateLayoutBounds(aisles, racksPerAisle int32) error {
 		return fleeterror.NewInvalidArgumentErrorf("racks_per_aisle must be ≤ %d (got %d)", layoutDimensionMax, racksPerAisle)
 	}
 	return nil
+}
+
+// gridCapacity is the number of rack positions a building's grid holds.
+// 0 means the layout is unconfigured (aisles or racks_per_aisle still 0):
+// there is no geometric limit to enforce yet, so callers treat 0 as
+// "unbounded" and skip the membership cap. A building has no "floating
+// beyond capacity" state once a grid exists — every write path that grows
+// membership (AssignRacksToBuilding, the SaveRack placement path, and a
+// shrinking UpdateBuilding) bounds total members against this.
+func gridCapacity(aisles, racksPerAisle int32) int64 {
+	return int64(aisles) * int64(racksPerAisle)
 }
 
 func int64PtrEqual(a, b *int64) bool {

--- a/server/internal/domain/buildings/service.go
+++ b/server/internal/domain/buildings/service.go
@@ -430,7 +430,11 @@ func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.Assig
 			// the site-cascade set because a same-site building change
 			// (move within one site) hits buildings but not sites.
 			cascadeBuildingRackIDs []int64
-			positionedRackIDs      []int64
+			// Net-new members for the capacity guard: batch racks whose
+			// building_id differs from the target (i.e. not already in
+			// this building). Counted only when assigning to a target.
+			netNewBuildingMembers int
+			positionedRackIDs     []int64
 			// For a building-only unassign (TargetBuildingID == nil), capture
 			// the source site so the activity log preserves "the site this
 			// rack lives in" instead of nil. clearSourceSite holds the single
@@ -531,6 +535,9 @@ func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.Assig
 			// (nil on building-only unassign).
 			if !int64PtrEqual(current.BuildingID, params.TargetBuildingID) {
 				cascadeBuildingRackIDs = append(cascadeBuildingRackIDs, rp.RackID)
+				if params.TargetBuildingID != nil {
+					netNewBuildingMembers++
+				}
 				// Placing a previously site-less rack into a site-less
 				// building. The site gate above misses this (nil->nil,
 				// siteChanged false), but the building cascade below stamps
@@ -551,6 +558,39 @@ func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.Assig
 		// whole batch shares one (see clearSourceSite above).
 		if params.TargetBuildingID == nil && !clearSourceAmbiguous {
 			fallbackSiteID = clearSourceSite
+		}
+
+		// Capacity guard. The per-cell bound check above only constrains
+		// PLACED racks; this bounds total MEMBERSHIP (placed + unplaced)
+		// against the building's grid. A building holds at most
+		// aisles×racks_per_aisle racks — there is no "floating beyond
+		// capacity" state — so reject a batch whose net-new members would
+		// push membership past that ceiling, mirroring SaveRack's miner
+		// cap. Runs inside the tx after the building lock + per-rack reads
+		// so the count can't race a concurrent assign. Skipped on
+		// building-only unassign (no target, membership only shrinks).
+		//
+		// capacity == 0 means the grid isn't configured yet (aisles or
+		// racks_per_aisle still 0 — both are optional at create). Racks
+		// can be staged in an unconfigured building; there's no geometric
+		// limit to enforce until a layout exists, so guard only once the
+		// grid is set. A single batch is still bounded by the proto's
+		// max_items, and the per-cell check above still rejects placement
+		// into a 0-cell grid.
+		if targetBuilding != nil {
+			capacity := int64(targetBuilding.Aisles) * int64(targetBuilding.RacksPerAisle)
+			if capacity > 0 {
+				existing, err := s.store.CountRacksInBuilding(txCtx, params.OrgID, *params.TargetBuildingID)
+				if err != nil {
+					return nil, err
+				}
+				if resulting := existing + int64(netNewBuildingMembers); resulting > capacity {
+					return nil, fleeterror.NewInvalidArgumentErrorf(
+						"cannot assign racks: building has %d positions (%d aisles × %d racks per aisle) but %d racks would be assigned",
+						capacity, targetBuilding.Aisles, targetBuilding.RacksPerAisle, resulting,
+					)
+				}
+			}
 		}
 
 		// Phase B1: single bulk write for site_id + building_id + zone

--- a/server/internal/domain/buildings/service_test.go
+++ b/server/internal/domain/buildings/service_test.go
@@ -863,6 +863,38 @@ func TestUpdateBuilding_rejectsShrinkBelowMemberCount(t *testing.T) {
 	}
 }
 
+// Giving an unconfigured (0×0) building its FIRST positive layout is a
+// growth, not a shrink — so the orphan scan is skipped — but racks staged
+// while capacity was 0 can still exceed the new grid. The membership cap
+// must run here too, not just on shrinks.
+func TestUpdateBuilding_rejectsFirstLayoutBelowMemberCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := mocks.NewMockBuildingStore(ctrl)
+	siteStore := mocks.NewMockSiteStore(ctrl)
+	tx := &fakeTransactor{}
+	svc := NewService(store, siteStore, nil, nil, nil, tx, nil)
+
+	siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, int64(11)).Return(nil)
+	// Building is unconfigured (0×0) and was allowed to stage 2 racks.
+	store.EXPECT().GetBuilding(inTxCtx, testOrgID, int64(11)).
+		Return(&models.Building{ID: 11, Aisles: 0, RacksPerAisle: 0}, nil)
+	// No orphan scan — 0→1 on each dimension is growth, not shrink.
+	store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, int64(11)).Return(int64(2), nil)
+	// UpdateBuilding must NOT run — the membership cap rejects the 1-cell grid.
+
+	_, err := svc.UpdateBuilding(context.Background(), models.UpdateParams{
+		OrgID:                 testOrgID,
+		ID:                    11,
+		Name:                  "configured",
+		Aisles:                1,
+		RacksPerAisle:         1,
+		DefaultRackOrderIndex: models.RackOrderIndexBottomLeft,
+	})
+	if !fleeterror.IsInvalidArgumentError(err) {
+		t.Fatalf("expected InvalidArgument for first layout below member count, got %v", err)
+	}
+}
+
 // Service-edge bounds cap mirrors the proto buf.validate cap. Defense
 // in depth for non-proto callers (sdk / agent-native paths) that
 // bypass the wire validator.
@@ -896,10 +928,10 @@ func TestCreateBuilding_rejectsLayoutAbove100(t *testing.T) {
 	}
 }
 
-// Layout growth (or no-shrink layout edit) must skip the
-// ListBuildingRacks bounds-scan entirely; that path used to fire
-// no scan at all, so the test pins the new behavior to the shrink
-// branch only.
+// Layout growth must skip the placed-rack bounds-scan (growth never
+// orphans a placed rack), but the total-membership cap still runs on any
+// positive-capacity edit — so the count query fires while
+// ListRacksOutsideBuildingBounds does not.
 func TestUpdateBuilding_growthSkipsBoundsScan(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := mocks.NewMockBuildingStore(ctrl)
@@ -910,7 +942,9 @@ func TestUpdateBuilding_growthSkipsBoundsScan(t *testing.T) {
 	siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, int64(11)).Return(nil)
 	store.EXPECT().GetBuilding(inTxCtx, testOrgID, int64(11)).
 		Return(&models.Building{ID: 11, Aisles: 2, RacksPerAisle: 4}, nil)
-	// No ListBuildingRacks expected — growth path.
+	// No ListRacksOutsideBuildingBounds expected — growth doesn't orphan
+	// placed racks. The membership cap still counts: 0 members ≤ 30-cell grid.
+	store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, int64(11)).Return(int64(0), nil)
 	store.EXPECT().UpdateBuilding(inTxCtx, gomock.AssignableToTypeOf(models.UpdateParams{})).
 		Return(&models.Building{ID: 11, Aisles: 5, RacksPerAisle: 6}, nil)
 

--- a/server/internal/domain/buildings/service_test.go
+++ b/server/internal/domain/buildings/service_test.go
@@ -224,6 +224,8 @@ func TestAssignRacksToBuilding_placesRackWithGridCell(t *testing.T) {
 	rackID := int64(99)
 	siteID := int64(3)
 
+	// Capacity guard reads current membership (unordered vs the chain below).
+	h.store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, buildingID).Return(int64(0), nil)
 	gomock.InOrder(
 		h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil),
 		h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
@@ -276,6 +278,7 @@ func TestAssignRacksToBuilding_membersWithoutPositionClearsCell(t *testing.T) {
 	h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil)
 	h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
 		Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil)
+	h.store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, buildingID).Return(int64(0), nil)
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &siteID}, nil)
 	// No site cascade — site unchanged. Building cascade DOES fire
@@ -310,6 +313,7 @@ func TestAssignRacksToBuilding_sameBuildingUnplaceClearsPosition(t *testing.T) {
 	h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil)
 	h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
 		Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil)
+	h.store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, buildingID).Return(int64(0), nil)
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(buildingID), Zone: "Z1"}, nil)
 	// Bulk placement update — zone preservation is now decided in SQL
@@ -372,6 +376,7 @@ func TestAssignRacksToBuilding_crossBuildingClearsZoneAndCascadesSite(t *testing
 	h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, targetBuildingID).Return(nil)
 	h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, targetBuildingID).
 		Return(&models.Building{ID: targetBuildingID, SiteID: &newSite, Aisles: 4, RacksPerAisle: 6}, nil)
+	h.store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, targetBuildingID).Return(int64(0), nil)
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &priorSite, BuildingID: ptrInt64(priorBuildingID), Zone: "Z1"}, nil)
 	// Bulk placement update — crossingBuildings zone clear runs in SQL.
@@ -423,6 +428,67 @@ func TestAssignRacksToBuilding_rejectsOutOfBoundsAisle(t *testing.T) {
 }
 
 // Position pairing: aisle_index set, position_in_aisle absent.
+// Capacity guard: a batch whose net-new members would push the
+// building past aisles×racks_per_aisle is rejected after the per-rack
+// reads but before any write. Mirrors SaveRack's miner cap — a building
+// holds no racks beyond its grid.
+func TestAssignRacksToBuilding_rejectsOverCapacity(t *testing.T) {
+	h := newAssignHarness(t)
+	buildingID := int64(11)
+	rackID := int64(99)
+
+	h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil)
+	// 1×1 grid = 1 slot, already holding 1 rack.
+	h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
+		Return(&models.Building{ID: buildingID, Aisles: 1, RacksPerAisle: 1}, nil)
+	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
+		Return(interfaces.RackPlacement{}, nil) // no current building → net-new member
+	h.store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, buildingID).Return(int64(1), nil)
+	// No Phase B writes — the closure aborts at the capacity check.
+
+	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
+		OrgID:            testOrgID,
+		TargetBuildingID: &buildingID,
+		Racks:            []models.RackPlacementParam{{RackID: rackID}},
+	})
+	if !fleeterror.IsInvalidArgumentError(err) {
+		t.Fatalf("expected InvalidArgument for over-capacity assign, got %v", err)
+	}
+}
+
+// A building with no configured grid (aisles/racks_per_aisle still 0)
+// has no geometric limit yet, so the capacity guard is skipped and
+// CountRacksInBuilding is never called. Racks can be staged before the
+// layout is set.
+func TestAssignRacksToBuilding_skipsCapacityWhenGridUnconfigured(t *testing.T) {
+	h := newAssignHarness(t)
+	buildingID := int64(11)
+	rackID := int64(99)
+
+	h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil)
+	// Aisles/RacksPerAisle default to 0 → capacity 0 → guard skipped.
+	h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
+		Return(&models.Building{ID: buildingID}, nil)
+	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
+		Return(interfaces.RackPlacement{SiteID: nil, BuildingID: nil}, nil)
+	// No CountRacksInBuilding expectation — it must not be called.
+	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, (*int64)(nil), &buildingID).Return(int64(1), nil)
+	// Site-less building + site-less rack: the site cascade still fires
+	// with a nil target to keep member device.site_id in lockstep.
+	h.collectionStore.EXPECT().CascadeRackDeviceSitesBulk(inTxCtx, testOrgID, []int64{rackID}, gomock.Nil()).Return(int64(0), nil)
+	h.collectionStore.EXPECT().CascadeRackDeviceBuildingsBulk(inTxCtx, testOrgID, []int64{rackID}, &buildingID).Return(int64(0), nil)
+	h.store.EXPECT().SetRackBuildingPositionBulkClear(inTxCtx, testOrgID, []int64{rackID}).Return(nil)
+
+	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
+		OrgID:            testOrgID,
+		TargetBuildingID: &buildingID,
+		Racks:            []models.RackPlacementParam{{RackID: rackID}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error assigning to unconfigured building: %v", err)
+	}
+}
+
 func TestAssignRacksToBuilding_rejectsHalfSetPosition(t *testing.T) {
 	h := newAssignHarness(t)
 	_, err := h.svc.AssignRacksToBuilding(context.Background(), models.AssignRacksToBuildingParams{
@@ -548,6 +614,8 @@ func TestAssignRacksToBuilding_swapsPositionsInSingleBatch(t *testing.T) {
 	rackA := int64(100)
 	rackB := int64(101)
 
+	// Capacity guard reads current membership (unordered vs the chain below).
+	h.store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, buildingID).Return(int64(0), nil)
 	// Racks are sorted by id, so rackA(100) is processed before rackB(101)
 	// during Phase A (lock acquisition). Phase B issues one bulk
 	// placement update, then one bulk pass-1 vacate covering both racks,
@@ -603,6 +671,8 @@ func TestAssignRacksToBuilding_mixedClearAndPlaceInSingleBatch(t *testing.T) {
 	rackClearer := int64(100) // was at (0,0), going to NULL
 	rackPlacer := int64(101)  // was unplaced, going to (0,0)
 
+	// Capacity guard reads current membership (unordered vs the chain below).
+	h.store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, buildingID).Return(int64(0), nil)
 	gomock.InOrder(
 		h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil),
 		h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
@@ -674,6 +744,8 @@ func TestAssignRacksToBuilding_largeBatchIssuesSingleBulkWrites(t *testing.T) {
 	h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, buildingID).Return(nil)
 	h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, buildingID).
 		Return(&models.Building{ID: buildingID, SiteID: &siteID, Aisles: 10, RacksPerAisle: 10}, nil)
+	// Empty building → all 100 net-new members fit the 10×10 grid exactly.
+	h.store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, buildingID).Return(int64(0), nil)
 	// Phase A: N per-rack lock acquisitions in sorted order — these are
 	// the only writes that fan out by N.
 	for _, id := range wantRackIDs {
@@ -1275,6 +1347,7 @@ func TestAssignRacksToBuilding_sameSiteCascadesBuilding(t *testing.T) {
 	h.siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, targetBuildingID).Return(nil)
 	h.store.EXPECT().GetBuilding(inTxCtx, testOrgID, targetBuildingID).
 		Return(&models.Building{ID: targetBuildingID, SiteID: &siteID, Aisles: 4, RacksPerAisle: 6}, nil)
+	h.store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, targetBuildingID).Return(int64(0), nil)
 	h.collectionStore.EXPECT().LockRackPlacementForWrite(inTxCtx, rackID, testOrgID).
 		Return(interfaces.RackPlacement{SiteID: &siteID, BuildingID: ptrInt64(priorBuildingID), Zone: "Z1"}, nil)
 	h.collectionStore.EXPECT().UpdateRackPlacementBulkForBuilding(inTxCtx, testOrgID, []int64{rackID}, &siteID, &targetBuildingID).Return(int64(1), nil)

--- a/server/internal/domain/buildings/service_test.go
+++ b/server/internal/domain/buildings/service_test.go
@@ -830,6 +830,39 @@ func TestUpdateBuilding_rejectsShrinkThatOrphansPlacement(t *testing.T) {
 	}
 }
 
+// A shrink can pass the placed-rack orphan scan (all excess members are
+// unplaced) yet still leave total membership over the new grid. The
+// membership cap catches that, mirroring AssignRacksToBuilding.
+func TestUpdateBuilding_rejectsShrinkBelowMemberCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := mocks.NewMockBuildingStore(ctrl)
+	siteStore := mocks.NewMockSiteStore(ctrl)
+	tx := &fakeTransactor{}
+	svc := NewService(store, siteStore, nil, nil, nil, tx, nil)
+
+	siteStore.EXPECT().LockBuildingForWrite(inTxCtx, testOrgID, int64(11)).Return(nil)
+	store.EXPECT().GetBuilding(inTxCtx, testOrgID, int64(11)).
+		Return(&models.Building{ID: 11, Aisles: 5, RacksPerAisle: 6}, nil)
+	// No placed racks fall outside the new 1×1 bounds…
+	store.EXPECT().ListRacksOutsideBuildingBounds(inTxCtx, testOrgID, int64(11), int32(1), int32(1)).
+		Return([]models.BuildingRack{}, nil)
+	// …but the building still holds 3 (unplaced) members, over the 1-cell grid.
+	store.EXPECT().CountRacksInBuilding(inTxCtx, testOrgID, int64(11)).Return(int64(3), nil)
+	// UpdateBuilding must NOT be called when the membership cap rejects.
+
+	_, err := svc.UpdateBuilding(context.Background(), models.UpdateParams{
+		OrgID:                 testOrgID,
+		ID:                    11,
+		Name:                  "shrunk",
+		Aisles:                1,
+		RacksPerAisle:         1,
+		DefaultRackOrderIndex: models.RackOrderIndexBottomLeft,
+	})
+	if !fleeterror.IsInvalidArgumentError(err) {
+		t.Fatalf("expected InvalidArgument for shrink below member count, got %v", err)
+	}
+}
+
 // Service-edge bounds cap mirrors the proto buf.validate cap. Defense
 // in depth for non-proto callers (sdk / agent-native paths) that
 // bypass the wire validator.

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -168,6 +168,43 @@ func (s *Service) resolveAndLockRackPlacement(ctx context.Context, orgID int64, 
 	return siteID, buildingID, nil
 }
 
+// enforceBuildingRackCapacity rejects placing a rack into buildingID when
+// the building's grid (aisles×racks_per_aisle) is already full. netNew is
+// the count of racks newly joining the building: 1 for a create or a
+// move-in, 0 for a re-save that keeps the rack in the same building.
+//
+// A building has no "floating beyond capacity" state, so SaveRack — which
+// also writes device_set_rack.building_id via rack_info.building_id — must
+// honor the same cap that buildings.AssignRacksToBuilding enforces;
+// otherwise the assign-side guard is bypassable through the rack save path.
+// Skipped when buildingStore is unwired (placement-less test harnesses) or
+// the grid is unconfigured (capacity 0). Must run in-tx after the building
+// is locked (resolveAndLockRackPlacement) so the count can't race.
+func (s *Service) enforceBuildingRackCapacity(ctx context.Context, orgID, buildingID int64, netNew int) error {
+	if s.buildingStore == nil || netNew <= 0 {
+		return nil
+	}
+	b, err := s.buildingStore.GetBuilding(ctx, orgID, buildingID)
+	if err != nil {
+		return err
+	}
+	capacity := int64(b.Aisles) * int64(b.RacksPerAisle)
+	if capacity <= 0 {
+		return nil
+	}
+	existing, err := s.buildingStore.CountRacksInBuilding(ctx, orgID, buildingID)
+	if err != nil {
+		return err
+	}
+	if resulting := existing + int64(netNew); resulting > capacity {
+		return fleeterror.NewInvalidArgumentErrorf(
+			"cannot assign racks: building has %d positions (%d aisles × %d racks per aisle) but %d racks would be assigned",
+			capacity, b.Aisles, b.RacksPerAisle, resulting,
+		)
+	}
+	return nil
+}
+
 // rackPlacementOmitted reports whether the caller omitted placement intent
 // (both ids nil). Explicit zero (unassign) returns false.
 func rackPlacementOmitted(rackInfo *pb.RackInfo) bool {
@@ -1727,7 +1764,7 @@ func (s *Service) SaveRack(ctx context.Context, req *pb.SaveRackRequest) (*pb.Sa
 	// write never persists more miners than the rack can ever hold.
 	if capacity := int(rackInfo.Rows) * int(rackInfo.Columns); len(deviceIdentifiers) > capacity {
 		return nil, fleeterror.NewInvalidArgumentErrorf(
-			"cannot assign %d miners to a rack with %d slots (%d×%d)",
+			"cannot assign %d miners to a rack with %d slot(s) (%d×%d)",
 			len(deviceIdentifiers), capacity, rackInfo.Rows, rackInfo.Columns,
 		)
 	}
@@ -1969,6 +2006,13 @@ func (s *Service) saveRackCreate(ctx context.Context, info *session.Info, req *p
 		return nil, err
 	}
 
+	// A brand-new rack placed into a building is always a net-new member.
+	if newBuildingID != nil {
+		if err := s.enforceBuildingRackCapacity(ctx, info.OrganizationID, *newBuildingID, 1); err != nil {
+			return nil, err
+		}
+	}
+
 	// targetRackID 0: the rack doesn't exist yet, so the pre-pass locks only
 	// the source racks the members currently sit in. Runs after placement
 	// resolution above and before the membership writes below.
@@ -2070,6 +2114,17 @@ func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *p
 		}
 		current, err = s.collectionStore.LockRackPlacementForWrite(ctx, collectionID, info.OrganizationID)
 		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Capacity guard: only a move INTO a different building is a net-new
+	// member. A re-save that keeps the rack in its current building (or the
+	// omitted-placement branch, where newBuildingID == current.BuildingID)
+	// is net-zero and must not be rejected just because the building is
+	// already at capacity.
+	if newBuildingID != nil && !int64PtrEqual(current.BuildingID, newBuildingID) {
+		if err := s.enforceBuildingRackCapacity(ctx, info.OrganizationID, *newBuildingID, 1); err != nil {
 			return nil, err
 		}
 	}

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -1719,6 +1719,19 @@ func (s *Service) SaveRack(ctx context.Context, req *pb.SaveRackRequest) (*pb.Sa
 		return nil, err
 	}
 
+	// Capacity guard. A rack has no "floating" members — every miner is
+	// expected to occupy a slot — so membership is bounded by the grid
+	// (rows×columns, each 1..maxRackDimension, validated above). Reject an
+	// over-capacity selection here, after the selector resolves (an
+	// all-mode selector can resolve to the full fleet), so the membership
+	// write never persists more miners than the rack can ever hold.
+	if capacity := int(rackInfo.Rows) * int(rackInfo.Columns); len(deviceIdentifiers) > capacity {
+		return nil, fleeterror.NewInvalidArgumentErrorf(
+			"cannot assign %d miners to a rack with %d slots (%d×%d)",
+			len(deviceIdentifiers), capacity, rackInfo.Rows, rackInfo.Columns,
+		)
+	}
+
 	// Build a set of resolved device IDs for slot assignment validation.
 	deviceSet := make(map[string]struct{}, len(deviceIdentifiers))
 	for _, id := range deviceIdentifiers {

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -1227,6 +1227,37 @@ func TestService_SaveRack_ValidationErrors(t *testing.T) {
 	}
 }
 
+// Capacity guard: more resolved members than rows×columns is rejected
+// after the selector resolves but before any write. A rack has no
+// floating members — every miner needs a slot — so an oversized
+// (e.g. all-mode) selection can't persist.
+func TestService_SaveRack_RejectsOverCapacity(t *testing.T) {
+	resolver := func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return []string{"device-1", "device-2"}, nil
+	}
+	svc, _, _ := newTestServiceWithResolver(t, resolver)
+	ctx := testCtx(t)
+
+	_, err := svc.SaveRack(ctx, &pb.SaveRackRequest{
+		Label: "Rack",
+		// 1×1 = 1 slot, but the selector resolves to 2 devices.
+		RackInfo: &pb.RackInfo{
+			Rows: 1, Columns: 1,
+			OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+			CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+		},
+		DeviceSelector: &commonpb.DeviceSelector{
+			SelectionType: &commonpb.DeviceSelector_DeviceList{
+				DeviceList: &commonpb.DeviceIdentifierList{DeviceIdentifiers: []string{"device-1", "device-2"}},
+			},
+		},
+	})
+
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsInvalidArgumentError(err))
+	assert.Contains(t, err.Error(), "cannot assign 2 miners to a rack with 1 slots")
+}
+
 func TestService_SaveRack_SlotAssignmentReferencesUnknownDevice(t *testing.T) {
 	resolver := func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
 		return []string{"device-1"}, nil

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -8,6 +8,7 @@ import (
 	commonpb "github.com/block/proto-fleet/server/generated/grpc/common/v1"
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	buildingsmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	minerModels "github.com/block/proto-fleet/server/internal/domain/miner/models"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -1255,7 +1256,50 @@ func TestService_SaveRack_RejectsOverCapacity(t *testing.T) {
 
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsInvalidArgumentError(err))
-	assert.Contains(t, err.Error(), "cannot assign 2 miners to a rack with 1 slots")
+	assert.Contains(t, err.Error(), "cannot assign 2 miners to a rack with 1 slot(s)")
+}
+
+// Building capacity guard on the SaveRack placement path: creating a rack
+// into a building that's already at grid capacity is rejected, so the
+// AssignRacksToBuilding cap can't be bypassed through rack_info.building_id.
+func TestService_SaveRack_RejectsCreateIntoFullBuilding(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockCollectionStore(ctrl)
+	mockSiteStore := mocks.NewMockSiteStore(ctrl)
+	mockBuildingStore := mocks.NewMockBuildingStore(ctrl)
+	mockTransactor := mocks.NewMockTransactor(ctrl)
+	mockTransactor.EXPECT().RunInTxWithResult(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, fn func(context.Context) (any, error)) (any, error) { return fn(ctx) },
+	).AnyTimes()
+	resolver := func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return []string{}, nil
+	}
+	svc := NewService(mockStore, &mockDeviceQueryer{}, mockSiteStore, mockBuildingStore, mockTransactor, resolver, nil, newStubActivityService(ctrl))
+	ctx := testCtx(t)
+
+	buildingID := int64(7)
+	// resolveAndLockRackPlacement peeks then re-reads the building's site
+	// under the lock; the building is site-less here.
+	mockStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, buildingID).Return(nil, nil).Times(2)
+	mockSiteStore.EXPECT().LockBuildingForWrite(gomock.Any(), testOrgID, buildingID).Return(nil)
+	// 1×1 building already holding its single rack → full.
+	mockBuildingStore.EXPECT().GetBuilding(gomock.Any(), testOrgID, buildingID).
+		Return(&buildingsmodels.Building{ID: buildingID, Aisles: 1, RacksPerAisle: 1}, nil)
+	mockBuildingStore.EXPECT().CountRacksInBuilding(gomock.Any(), testOrgID, buildingID).Return(int64(1), nil)
+	// CreateCollection must NOT run — the closure aborts at the cap.
+
+	_, err := svc.SaveRack(ctx, &pb.SaveRackRequest{
+		Label: "New rack",
+		RackInfo: &pb.RackInfo{
+			Rows: 2, Columns: 2, Zone: "Z1",
+			BuildingId:  &buildingID,
+			OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+			CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+		},
+	})
+	if !fleeterror.IsInvalidArgumentError(err) {
+		t.Fatalf("expected InvalidArgument creating a rack into a full building, got %v", err)
+	}
 }
 
 func TestService_SaveRack_SlotAssignmentReferencesUnknownDevice(t *testing.T) {

--- a/server/internal/domain/stores/interfaces/building.go
+++ b/server/internal/domain/stores/interfaces/building.go
@@ -63,6 +63,13 @@ type BuildingStore interface {
 	// page token (empty when the caller has reached the last page).
 	ListBuildingRacks(ctx context.Context, orgID, buildingID int64, pageSize int32, pageToken string) ([]models.BuildingRack, string, error)
 
+	// CountRacksInBuilding returns the number of live racks currently
+	// assigned to the building (placed or unplaced — membership, not
+	// grid occupancy). Used by AssignRacksToBuilding's capacity guard
+	// to reject a batch that would push membership past the building's
+	// aisles×racks_per_aisle grid.
+	CountRacksInBuilding(ctx context.Context, orgID, buildingID int64) (int64, error)
+
 	// ListRacksOutsideBuildingBounds returns racks whose grid
 	// position would fall outside the proposed (aisles,
 	// racksPerAisle) layout. Unbounded by design — used by

--- a/server/internal/domain/stores/interfaces/mocks/mock_building_store.go
+++ b/server/internal/domain/stores/interfaces/mocks/mock_building_store.go
@@ -161,6 +161,21 @@ func (mr *MockBuildingStoreMockRecorder) ClearDeviceBuildingsOnSiteMismatch(ctx,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearDeviceBuildingsOnSiteMismatch", reflect.TypeOf((*MockBuildingStore)(nil).ClearDeviceBuildingsOnSiteMismatch), ctx, orgID, deviceIdentifiers, targetSiteID)
 }
 
+// CountRacksInBuilding mocks base method.
+func (m *MockBuildingStore) CountRacksInBuilding(ctx context.Context, orgID, buildingID int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountRacksInBuilding", ctx, orgID, buildingID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountRacksInBuilding indicates an expected call of CountRacksInBuilding.
+func (mr *MockBuildingStoreMockRecorder) CountRacksInBuilding(ctx, orgID, buildingID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountRacksInBuilding", reflect.TypeOf((*MockBuildingStore)(nil).CountRacksInBuilding), ctx, orgID, buildingID)
+}
+
 // CreateBuilding mocks base method.
 func (m *MockBuildingStore) CreateBuilding(ctx context.Context, params models.CreateParams) (*models.Building, error) {
 	m.ctrl.T.Helper()

--- a/server/internal/domain/stores/sqlstores/building.go
+++ b/server/internal/domain/stores/sqlstores/building.go
@@ -215,9 +215,12 @@ func (s *SQLBuildingStore) ListBuildingRacks(ctx context.Context, orgID, buildin
 }
 
 func (s *SQLBuildingStore) CountRacksInBuilding(ctx context.Context, orgID, buildingID int64) (int64, error) {
+	// This method always targets a concrete building, so bind the id
+	// explicitly rather than via zeroToNullInt64 — a 0 mapped to NULL would
+	// silently return a 0 count and bypass the capacity guard.
 	count, err := s.GetQueries(ctx).CountRacksInBuilding(ctx, sqlc.CountRacksInBuildingParams{
 		OrgID:      orgID,
-		BuildingID: zeroToNullInt64(buildingID),
+		BuildingID: sql.NullInt64{Int64: buildingID, Valid: true},
 	})
 	if err != nil {
 		return 0, fleeterror.NewInternalErrorf("failed to count racks in building: %v", err)

--- a/server/internal/domain/stores/sqlstores/building.go
+++ b/server/internal/domain/stores/sqlstores/building.go
@@ -214,6 +214,17 @@ func (s *SQLBuildingStore) ListBuildingRacks(ctx context.Context, orgID, buildin
 	return out, nextPageToken, nil
 }
 
+func (s *SQLBuildingStore) CountRacksInBuilding(ctx context.Context, orgID, buildingID int64) (int64, error) {
+	count, err := s.GetQueries(ctx).CountRacksInBuilding(ctx, sqlc.CountRacksInBuildingParams{
+		OrgID:      orgID,
+		BuildingID: zeroToNullInt64(buildingID),
+	})
+	if err != nil {
+		return 0, fleeterror.NewInternalErrorf("failed to count racks in building: %v", err)
+	}
+	return count, nil
+}
+
 func (s *SQLBuildingStore) ListRacksOutsideBuildingBounds(ctx context.Context, orgID, buildingID int64, newAisles, newRacksPerAisle int32) ([]models.BuildingRack, error) {
 	rows, err := s.GetQueries(ctx).ListRacksOutsideBuildingBounds(ctx, sqlc.ListRacksOutsideBuildingBoundsParams{
 		OrgID:            orgID,

--- a/server/internal/handlers/buildings/handler_test.go
+++ b/server/internal/handlers/buildings/handler_test.go
@@ -470,6 +470,8 @@ func TestHandler_AssignRacksToBuilding_happy(t *testing.T) {
 	buildingID := int64(11)
 	siteID := int64(3)
 
+	// Capacity guard reads current membership (unordered vs the chain below).
+	h.buildingStore.EXPECT().CountRacksInBuilding(gomock.Any(), int64(7), buildingID).Return(int64(0), nil)
 	gomock.InOrder(
 		h.siteStore.EXPECT().LockBuildingForWrite(gomock.Any(), int64(7), buildingID).Return(nil),
 		h.buildingStore.EXPECT().GetBuilding(gomock.Any(), int64(7), buildingID).

--- a/server/sqlc/queries/building.sql
+++ b/server/sqlc/queries/building.sql
@@ -185,6 +185,19 @@ WHERE dsr.org_id = sqlc.arg('org_id')
 ORDER BY ds.label, dsr.device_set_id
 LIMIT sqlc.arg('limit_n')::int;
 
+-- name: CountRacksInBuilding :one
+-- Total live racks currently assigned to a building (placed or
+-- unplaced — membership, not grid occupancy). Used by
+-- AssignRacksToBuilding's capacity guard to reject a batch that would
+-- push the building over its aisles×racks_per_aisle grid. Matches
+-- ListBuildingRacks' filter so the count and the list agree.
+SELECT COUNT(*)::bigint AS rack_count
+FROM device_set_rack dsr
+JOIN device_set ds ON ds.id = dsr.device_set_id
+WHERE dsr.org_id = sqlc.arg('org_id')
+  AND dsr.building_id = sqlc.arg('building_id')
+  AND ds.deleted_at IS NULL;
+
 -- name: ListRacksOutsideBuildingBounds :many
 -- Returns the first rack row whose (aisle_index, position_in_aisle)
 -- would fall outside the proposed (aisles, racks_per_aisle) layout.


### PR DESCRIPTION
Reviewable diff: +241/-3 across 8 files (excludes generated, test, and story files).

## Summary

Fixes #560: launching **New rack** from an all-selection seeded the new rack with the operator's entire miner selection (capped only at ~50k), and `MinersPane` rendered one row per seeded miner — freezing the browser long before the save-time capacity check ran. A rack holds at most 144 miners (12×12).

This adds a pre-mount cap on the rack create flow (the immediate fix) and, for consistency, enforces that membership can't exceed grid capacity on **both** racks and buildings — at the server (authoritative) and in the client UI (fast-fail). Previously the server allowed over-capacity membership for both surfaces; only the rack edit modal rejected it, and only at save time.

## How it works

There are two independent grids, each with a fixed capacity:
- A **rack** holds at most `rows × columns` miners (each dimension 1–12, so ≤ 144). A member can be unplaced (no slot), but total membership can't exceed the number of slots — there's no "more miners than positions" state.
- A **building** holds `aisles × racks_per_aisle` racks. A rack *can* be a member without a grid position ("unplaced"/floating), which supports staging racks before the layout is configured.

The change closes the gap at three points along the assignment path:

1. **Rack create seed (client, the #560 freeze).** When the operator picks "New rack" from a selection, the flow now checks the seed size before opening any modal. A seed larger than 144 is rejected with a toast, so the unbounded list never renders. The exact `rows×columns` check still runs later at save once the operator picks the rack's dimensions.

2. **Rack save (server `SaveRack`).** After the device selector resolves to a concrete identifier list (an all-mode selector can expand to the full fleet), the handler rejects when the resolved count exceeds `rows × columns`, before persisting membership.

3. **Building rack assignment (server `AssignRacksToBuilding` + client save).** The server counts the building's current rack members and rejects when `existing + net-new` would exceed `aisles × racks_per_aisle`. This runs inside the existing transaction, after the building and rack rows are locked, so the count can't race a concurrent assignment. The client's building save applies the same check inline before dispatching. When a building's grid is unconfigured (capacity 0), the cap is skipped so racks can still be staged before a layout exists — a single batch is still bounded by the existing 1000-item RPC cap.

```mermaid
flowchart TD
    subgraph Rack["Rack membership"]
        A["New rack from selection"] --> B{"seed > 144?"}
        B -->|yes| C["toast + abort (client)"]
        B -->|no| D["RackSettingsModal: pick rows×cols"]
        D --> E["SaveRack"]
        E --> F{"devices > rows×cols?"}
        F -->|yes| G["InvalidArgument (server)"]
        F -->|no| H["persist membership"]
    end
    subgraph Building["Building rack membership"]
        I["Assign racks to building"] --> J{"capacity configured?"}
        J -->|"capacity 0"| K["skip check (staging allowed)"]
        J -->|"capacity > 0"| L{"existing + net-new > aisles×racks_per_aisle?"}
        L -->|yes| M["InvalidArgument (server) / inline error (client)"]
        L -->|no| N["persist assignment"]
        K --> N
    end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/.../FleetCreateFlow/FleetCreateFlowProvider.tsx` | `launchCreateRack` rejects a seed > `MAX_RACK_CAPACITY` (144) before opening the modal | The actual #560 fix; mirrors the existing `batchCapError` gate on the building/site paths |
| `client/.../ManageBuildingModal/ManageBuildingModal.tsx` | `handleSave` rejects an over-capacity working set inline before dispatch | Client-side parity with the server building cap |
| `server/internal/domain/collection/service.go` | `SaveRack` rejects resolved `len(devices) > rows×columns` | Authoritative rack cap; runs after selector resolution |
| `server/internal/domain/buildings/service.go` | `AssignRacksToBuilding` rejects `existing + net-new > capacity`; net-new counted in the lock loop; skipped when capacity 0 | Authoritative building cap; review the in-transaction placement and the unconfigured-grid carve-out |
| `server/sqlc/queries/building.sql` | New `CountRacksInBuilding` query | Counts live members (placed + unplaced), matching `ListBuildingRacks`' filter |
| `server/internal/domain/stores/sqlstores/building.go` | Store wrapper for `CountRacksInBuilding` | Thin delegation |
| `server/internal/domain/stores/interfaces/building.go` | Interface method added | Boundary contract |
| `server/internal/domain/stores/interfaces/mocks/mock_building_store.go` | Regenerated mock (mockgen) | Generated — skip |
| `server/generated/sqlc/building.sql.go`, `db.go` | Regenerated sqlc | Generated — skip |

## Key technical decisions & trade-offs

- **Pre-mount cap at the absolute max (144), exact check at save.** The rack's dimensions aren't chosen until after the create flow opens, so the client gates on the geometric maximum; the precise `rows×columns` check stays at save. Chosen over computing capacity earlier (not yet known) or relying solely on the save-time check (too late — the freeze already happened).
- **Building cap is skipped when the grid is unconfigured (capacity 0).** Building layout is optional and there is an existing, tested flow of staging racks before a layout is set; enforcing capacity 0 = reject-all would break it and make layout mandatory. Racks differ — their layout is always set — so they are always capped. This keeps both surfaces consistent on the real invariant ("can't exceed a configured grid") without changing the staging workflow.
- **Building count runs inside the existing transaction, after row locks.** Prevents a concurrent assignment from racing the capacity check. Net-new members are derived from the per-rack reads already performed in the lock loop, so no extra round trips beyond the single count query.

## Testing & validation

- Server: `buildings` and `collection` suites pass, including new tests — `TestAssignRacksToBuilding_rejectsOverCapacity`, `TestAssignRacksToBuilding_skipsCapacityWhenGridUnconfigured`, and `TestService_SaveRack_RejectsOverCapacity`. Existing `AssignRacksToBuilding` tests updated to expect the new `CountRacksInBuilding` call. `go vet` clean; `golangci-lint` reports 0 issues across touched packages.
- Client: `tsc --noEmit` clean; existing FleetCreateFlow + ManageBuildingModal tests pass; ESLint clean; Prettier applied.
- Not covered: no new client component tests for the two UI guards — neither component has an existing test harness, and the invariant is enforced authoritatively server-side with tests. The UI checks are thin fast-fails layered on top.

