### PR TITLE
Tighten device metrics retention

### DIFF
--- a/server/migrations/000104_tighten_device_metrics_retention.down.sql
+++ b/server/migrations/000104_tighten_device_metrics_retention.down.sql
@@ -1,0 +1,2 @@
+SELECT remove_retention_policy('device_metrics', if_exists => true);
+SELECT add_retention_policy('device_metrics', INTERVAL '30 days');

--- a/server/migrations/000104_tighten_device_metrics_retention.up.sql
+++ b/server/migrations/000104_tighten_device_metrics_retention.up.sql
@@ -1,0 +1,3 @@
+SELECT remove_retention_policy('device_metrics', if_exists => true);
+SELECT add_retention_policy('device_metrics', INTERVAL '10 days',
+    schedule_interval => INTERVAL '1 hour');


### PR DESCRIPTION
Reviewable diff: +5/-0 across 2 files (excludes generated, test, and story files).

**Summary**
This PR reduces long-term Fleet database growth for large lab fleets by retaining raw `device_metrics` for 10 days instead of 30 days. It keeps telemetry compression, continuous aggregates, dashboard query routing, polling, APIs, and `miner_state_snapshots` retention unchanged. The 10-day raw window preserves a safety margin over the existing 7-day daily continuous aggregate refresh lookback while cutting the largest long-term raw metrics tail.

Expected storage impact:

| Basis | Estimate |
| --- | ---: |
| Observed compressed `device_metrics` day on the affected Pi | ~643 MB/day |
| Raw metrics history removed at steady state | ~20 compressed days |
| Estimated steady-state savings | ~12.6 GB |
| Estimated `device_metrics` steady state after this PR | ~12-15 GB instead of ~25-30 GB under the 5000 virtual-miner lab workload |

**How It Works**
The migration removes the current TimescaleDB retention policy for `device_metrics` and re-adds it with `drop_after = 10 days`. The new policy uses an explicit hourly `schedule_interval`, so cleanup can run close to the target retention age instead of drifting by TimescaleDB's default daily cadence. The rollback removes the 10-day policy and restores the previous 30-day raw metrics retention.

**Diagrams**
```mermaid
flowchart TD
  A["Telemetry inserts"] --> B["device_metrics raw hypertable"]
  B --> C["6h compression policy from prior PR"]
  C --> D["Compressed raw chunks remain queryable"]
  D --> E["10d retention policy"]
  E --> F["Chunks older than 10d are dropped"]
  B --> G["Continuous aggregate refresh policies"]
  G --> H["Hourly and daily aggregate history remains available"]
```

```mermaid
flowchart TD
  A["Migration up"] --> B["Remove existing device_metrics retention policy"]
  B --> C["Add 10d retention policy"]
  C --> D["Schedule retention job hourly"]
  E["Migration down"] --> F["Remove 10d retention policy"]
  F --> G["Restore 30d retention policy"]
```

**Areas of the Code Involved**
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/migrations/000104_tighten_device_metrics_retention.up.sql` | Replaces `device_metrics` raw retention with a 10-day policy and hourly schedule. | This is the only forward behavior change; reviewers should validate the retention window against aggregate refresh needs. |
| `server/migrations/000104_tighten_device_metrics_retention.down.sql` | Restores the previous 30-day raw retention policy. | Confirms rollback returns Fleet to the prior storage policy. |

**Key Technical Decisions & Trade-Offs**
- Retain 10 days of raw `device_metrics` instead of 30 days; this removes about 20 compressed days of raw metric history while keeping a margin over the 7-day daily aggregate refresh lookback.
- Leave `miner_state_snapshots` retention unchanged; uptime panels still read that table directly for long dashboard ranges.
- Do not change chunk intervals, polling, dashboard routing, APIs, or continuous aggregates; this keeps the PR migration-only and avoids user-facing behavior changes.
- Use an explicit hourly retention schedule; this makes the storage cap more predictable than TimescaleDB's default daily job cadence.

**Testing & Validation**
- `source bin/activate-hermit && PROTO_PYTHON_GEN_VENV=/Users/ankitg/dev/repos/proto-fleet/packages/proto-python-gen/.venv just gen`
- `source bin/activate-hermit && just lint`
- `cd server && source ../bin/activate-hermit && just test`
- Confirmed generation produced no generated-code diff for this policy-only migration.
