### PR TITLE
fix(curtailment): update MQTT source runtime health

### DIFF
--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -605,7 +605,7 @@ func (s *Subscriber) recordRuntimeStatus(update RuntimeStatusUpdate) {
 		}
 	}
 	state := RuntimeStateRunning
-	if running == 0 {
+	if subscribed == 0 {
 		state = RuntimeStateStarting
 		if lastError != "" {
 			state = RuntimeStateError

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -36,6 +36,10 @@ type RuntimeStatusUpdate struct {
 
 type RuntimeStatusReporter func(RuntimeStatusUpdate)
 
+type runtimeStatusReportingMQTTClient interface {
+	SetRuntimeStatusReporter(reporter func(connected bool, subscribed bool, err error))
+}
+
 const (
 	brokerTransportTCP = "tcp"
 	brokerTransportTLS = "tls"

--- a/server/internal/domain/curtailment/mqttingest/subscriber_test.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber_test.go
@@ -2,6 +2,7 @@ package mqttingest
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
@@ -77,6 +78,71 @@ func (c *countingClient) Disconnect(time.Duration) {
 	}
 }
 
+type runtimeStatusClientRegistry struct {
+	mu      sync.Mutex
+	clients map[string]*runtimeStatusClient
+}
+
+func newRuntimeStatusClientRegistry() *runtimeStatusClientRegistry {
+	return &runtimeStatusClientRegistry{
+		clients: make(map[string]*runtimeStatusClient),
+	}
+}
+
+func (r *runtimeStatusClientRegistry) newClient() MQTTClient {
+	return &runtimeStatusClient{reg: r}
+}
+
+func (r *runtimeStatusClientRegistry) register(host string, client *runtimeStatusClient) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.clients[host] = client
+}
+
+func (r *runtimeStatusClientRegistry) report(t *testing.T, host string, connected bool, subscribed bool, err error) {
+	t.Helper()
+	var client *runtimeStatusClient
+	require.Eventually(t, func() bool {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		client = r.clients[host]
+		return client != nil
+	}, 2*time.Second, 10*time.Millisecond, "broker client %s was not registered", host)
+	client.report(connected, subscribed, err)
+}
+
+type runtimeStatusClient struct {
+	reg      *runtimeStatusClientRegistry
+	mu       sync.Mutex
+	reporter func(connected bool, subscribed bool, err error)
+}
+
+func (c *runtimeStatusClient) Connect(_ context.Context, host string, _ int32, _ string, _ string, _ string, _ string) error {
+	c.reg.register(host, c)
+	return nil
+}
+
+func (c *runtimeStatusClient) Subscribe(_ context.Context, _ string, _ func(payload []byte, receivedAt time.Time)) error {
+	return nil
+}
+
+func (c *runtimeStatusClient) Disconnect(time.Duration) {}
+
+func (c *runtimeStatusClient) SetRuntimeStatusReporter(reporter func(connected bool, subscribed bool, err error)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reporter = reporter
+}
+
+func (c *runtimeStatusClient) report(connected bool, subscribed bool, err error) {
+	c.mu.Lock()
+	reporter := c.reporter
+	c.mu.Unlock()
+	if reporter != nil {
+		reporter(connected, subscribed, err)
+	}
+}
+
 func (f *fakeSourceStore) setSources(sources ...SourceConfig) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -109,6 +175,20 @@ func requireRunningBrokers(t *testing.T, s *Subscriber, sourceID int64, want int
 		status := s.SourceRuntimeStatus(sourceID)
 		return status.State == RuntimeStateRunning && status.RunningBrokerCount == want
 	}, 2*time.Second, 10*time.Millisecond, "source %d never reported %d running brokers", sourceID, want)
+}
+
+func requireRuntimeStatus(t *testing.T, s *Subscriber, sourceID int64, state RuntimeState, running int, subscribed int) RuntimeStatus {
+	t.Helper()
+	var status RuntimeStatus
+	require.Eventually(t, func() bool {
+		status = s.SourceRuntimeStatus(sourceID)
+		return status.State == state &&
+			status.RunningBrokerCount == running &&
+			status.SubscribedBrokerCount == subscribed
+	}, 2*time.Second, 10*time.Millisecond,
+		"source %d never reported state=%v running=%d subscribed=%d",
+		sourceID, state, running, subscribed)
+	return status
 }
 
 func TestSubscriber_ReconcileStartsAndStopsWorkers(t *testing.T) {
@@ -208,4 +288,40 @@ func TestSubscriber_QuiesceSourceStopsOnlyTargetSource(t *testing.T) {
 	running := s.SourceRuntimeStatus(second.ID)
 	assert.Equal(t, RuntimeStateRunning, running.State)
 	assert.Equal(t, 2, running.RunningBrokerCount)
+}
+
+func TestSubscriber_RuntimeStatusTracksBrokerDisconnectAndReconnect(t *testing.T) {
+	t.Parallel()
+
+	src := reconcileTestSource(1, "maestro")
+	store := newFakeSourceStore(src)
+	reg := newRuntimeStatusClientRegistry()
+	s, err := NewSubscriber(Config{
+		Store:            store,
+		NewClient:        reg.newClient,
+		Decryptor:        passthroughDecryptor{},
+		Logger:           slog.New(slog.DiscardHandler),
+		ShutdownDeadline: 2 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.Start(context.Background()))
+	defer s.Stop()
+
+	requireRuntimeStatus(t, s, src.ID, RuntimeStateRunning, 2, 2)
+
+	reg.report(t, src.BrokerPrimaryHost, false, false, errors.New("primary broker lost"))
+	status := requireRuntimeStatus(t, s, src.ID, RuntimeStateRunning, 1, 1)
+	assert.Equal(t, "primary broker lost", status.LastError)
+
+	reg.report(t, src.BrokerSecondaryHost, false, false, errors.New("secondary broker lost"))
+	status = requireRuntimeStatus(t, s, src.ID, RuntimeStateError, 0, 0)
+	assert.NotEmpty(t, status.LastError)
+
+	reg.report(t, src.BrokerPrimaryHost, true, true, nil)
+	status = requireRuntimeStatus(t, s, src.ID, RuntimeStateRunning, 1, 1)
+	assert.Equal(t, "secondary broker lost", status.LastError)
+
+	reg.report(t, src.BrokerSecondaryHost, true, true, nil)
+	status = requireRuntimeStatus(t, s, src.ID, RuntimeStateRunning, 2, 2)
+	assert.Empty(t, status.LastError)
 }

--- a/server/internal/domain/curtailment/mqttingest/subscriber_test.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber_test.go
@@ -325,3 +325,52 @@ func TestSubscriber_RuntimeStatusTracksBrokerDisconnectAndReconnect(t *testing.T
 	status = requireRuntimeStatus(t, s, src.ID, RuntimeStateRunning, 2, 2)
 	assert.Empty(t, status.LastError)
 }
+
+func TestSubscriber_RuntimeStatusTreatsConnectedUnsubscribedErrorsAsError(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewSubscriber(Config{
+		Store:     newFakeSourceStore(),
+		NewClient: func() MQTTClient { return &countingClient{} },
+		Decryptor: passthroughDecryptor{},
+		Logger:    slog.New(slog.DiscardHandler),
+	})
+	require.NoError(t, err)
+
+	s.recordRuntimeStatus(RuntimeStatusUpdate{
+		SourceID:   1,
+		Broker:     "primary",
+		Connected:  true,
+		Subscribed: false,
+		Error:      "mqttclient: resubscribe \"curtailment/source\": subscription rejected",
+	})
+	status := s.SourceRuntimeStatus(1)
+	assert.Equal(t, RuntimeStateError, status.State)
+	assert.Equal(t, 1, status.RunningBrokerCount)
+	assert.Zero(t, status.SubscribedBrokerCount)
+	assert.Contains(t, status.LastError, "subscription rejected")
+
+	s.recordRuntimeStatus(RuntimeStatusUpdate{
+		SourceID:   1,
+		Broker:     "secondary",
+		Connected:  true,
+		Subscribed: false,
+		Error:      "mqttclient: resubscribe \"curtailment/source\": not authorized",
+	})
+	status = s.SourceRuntimeStatus(1)
+	assert.Equal(t, RuntimeStateError, status.State)
+	assert.Equal(t, 2, status.RunningBrokerCount)
+	assert.Zero(t, status.SubscribedBrokerCount)
+
+	s.recordRuntimeStatus(RuntimeStatusUpdate{
+		SourceID:   1,
+		Broker:     "primary",
+		Connected:  true,
+		Subscribed: true,
+	})
+	status = s.SourceRuntimeStatus(1)
+	assert.Equal(t, RuntimeStateRunning, status.State)
+	assert.Equal(t, 2, status.RunningBrokerCount)
+	assert.Equal(t, 1, status.SubscribedBrokerCount)
+	assert.Contains(t, status.LastError, "not authorized")
+}

--- a/server/internal/domain/curtailment/mqttingest/worker.go
+++ b/server/internal/domain/curtailment/mqttingest/worker.go
@@ -231,6 +231,7 @@ func jitterRetryDelay(base time.Duration, rng *rand.Rand) time.Duration {
 }
 
 func (w *sourceWorker) connectAndSubscribe(ctx context.Context, client MQTTClient, host string, messages chan<- observation, subscriptions chan<- struct{}) {
+	w.attachRuntimeStatusReporter(ctx, client, host)
 	retryEvery := w.startupRetryEvery()
 	rng := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // jitter only; not security-sensitive
 	for {
@@ -274,6 +275,29 @@ func (w *sourceWorker) connectAndSubscribe(ctx context.Context, client MQTTClien
 		}
 		return
 	}
+}
+
+func (w *sourceWorker) attachRuntimeStatusReporter(ctx context.Context, client MQTTClient, host string) {
+	reportingClient, ok := client.(runtimeStatusReportingMQTTClient)
+	if !ok {
+		return
+	}
+	reportingClient.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
+		if ctx.Err() != nil {
+			return
+		}
+		errorMessage := ""
+		if err != nil {
+			errorMessage = err.Error()
+		}
+		w.reportRuntimeStatus(RuntimeStatusUpdate{
+			SourceID:   w.source.ID,
+			Broker:     host,
+			Connected:  connected,
+			Subscribed: subscribed,
+			Error:      errorMessage,
+		})
+	})
 }
 
 func (w *sourceWorker) connectAndSubscribeOnce(ctx context.Context, client MQTTClient, host string, messages chan<- observation) error {

--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -191,18 +191,13 @@ func (c *Client) reportConnectionLostStatus(client connectionStateClient, err er
 
 func (c *Client) reportReconnectStatus(ctx context.Context, client reconnectClient) {
 	sequence := c.nextStatusSequence()
-	c.reportReconnectStatusWithTimeoutForSequence(ctx, client, reconnectSubscribeTimeout, sequence)
-}
-
-func (c *Client) reportReconnectStatusWithTimeout(ctx context.Context, client reconnectClient, timeout time.Duration) {
-	sequence := c.nextStatusSequence()
-	c.reportReconnectStatusWithTimeoutForSequence(ctx, client, timeout, sequence)
-}
-
-func (c *Client) reportReconnectStatusWithTimeoutForSequence(ctx context.Context, client reconnectClient, timeout time.Duration, sequence uint64) {
-	replayCtx, cancel := context.WithTimeout(ctx, timeout)
+	replayCtx, cancel := context.WithTimeout(ctx, reconnectSubscribeTimeout)
 	defer cancel()
-	err := c.replaySubscriptions(replayCtx, client)
+	c.reportReconnectStatusForSequence(replayCtx, client, sequence)
+}
+
+func (c *Client) reportReconnectStatusForSequence(ctx context.Context, client reconnectClient, sequence uint64) {
+	err := c.replaySubscriptions(ctx, client)
 	if c.statusSequence.Load() != sequence {
 		return
 	}

--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -19,6 +19,7 @@ import (
 const subscribeQoS byte = 1
 const maxPayloadBytes = 1024
 const reconnectSubscribeTimeout = 10 * time.Second
+const subscribeFailureCode byte = 0x80
 
 const (
 	transportTCP = "tcp"
@@ -31,10 +32,20 @@ type Client struct {
 	client         paho.Client
 	subscriptions  map[string]paho.MessageHandler
 	statusReporter func(connected bool, subscribed bool, err error)
+	statusSequence atomic.Uint64
 }
 
 type subscriptionClient interface {
 	Subscribe(topic string, qos byte, callback paho.MessageHandler) paho.Token
+}
+
+type connectionStateClient interface {
+	IsConnectionOpen() bool
+}
+
+type reconnectClient interface {
+	subscriptionClient
+	connectionStateClient
 }
 
 type routeClient interface {
@@ -75,8 +86,8 @@ func (c *Client) Connect(ctx context.Context, host string, port int32, transport
 		if initialConnectComplete.Load() {
 			c.reportReconnectStatus(ctx, client)
 		}
-	}, func(_ paho.Client, err error) {
-		c.reportRuntimeStatus(false, false, normalizeConnectionLostError(err))
+	}, func(client paho.Client, err error) {
+		c.reportConnectionLostStatus(client, err)
 	})
 
 	client := paho.NewClient(opts)
@@ -90,7 +101,7 @@ func (c *Client) Connect(ctx context.Context, host string, port int32, transport
 	c.client = client
 	c.mu.Unlock()
 	for topic, handler := range c.subscriptionSnapshot() {
-		if err := waitToken(ctx, client.Subscribe(topic, subscribeQoS, handler)); err != nil {
+		if err := waitSubscribeToken(ctx, topic, client.Subscribe(topic, subscribeQoS, handler)); err != nil {
 			client.Disconnect(0)
 			c.mu.Lock()
 			if c.client == client {
@@ -144,7 +155,7 @@ func (c *Client) Subscribe(ctx context.Context, topic string, handler func(paylo
 	c.mu.Unlock()
 
 	token := client.Subscribe(topic, subscribeQoS, messageHandler)
-	if err := waitToken(ctx, token); err != nil {
+	if err := waitSubscribeToken(ctx, topic, token); err != nil {
 		return fmt.Errorf("mqttclient: subscribe %q: %w", topic, err)
 	}
 	return nil
@@ -159,23 +170,59 @@ func (c *Client) reportRuntimeStatus(connected bool, subscribed bool, err error)
 	}
 }
 
-func (c *Client) reportReconnectStatus(ctx context.Context, client subscriptionClient) {
-	c.reportReconnectStatusWithTimeout(ctx, client, reconnectSubscribeTimeout)
+func (c *Client) nextStatusSequence() uint64 {
+	return c.statusSequence.Add(1)
 }
 
-func (c *Client) reportReconnectStatusWithTimeout(ctx context.Context, client subscriptionClient, timeout time.Duration) {
-	replayCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	if err := c.replaySubscriptions(replayCtx, client); err != nil {
-		c.reportRuntimeStatus(true, false, err)
+func (c *Client) reportRuntimeStatusForSequence(sequence uint64, connected bool, subscribed bool, err error) {
+	if c.statusSequence.Load() != sequence {
 		return
 	}
-	c.reportRuntimeStatus(true, true, nil)
+	c.reportRuntimeStatus(connected, subscribed, err)
+}
+
+func (c *Client) reportConnectionLostStatus(client connectionStateClient, err error) {
+	if client != nil && client.IsConnectionOpen() {
+		return
+	}
+	sequence := c.nextStatusSequence()
+	c.reportRuntimeStatusForSequence(sequence, false, false, normalizeConnectionLostError(err))
+}
+
+func (c *Client) reportReconnectStatus(ctx context.Context, client reconnectClient) {
+	sequence := c.nextStatusSequence()
+	c.reportReconnectStatusWithTimeoutForSequence(ctx, client, reconnectSubscribeTimeout, sequence)
+}
+
+func (c *Client) reportReconnectStatusWithTimeout(ctx context.Context, client reconnectClient, timeout time.Duration) {
+	sequence := c.nextStatusSequence()
+	c.reportReconnectStatusWithTimeoutForSequence(ctx, client, timeout, sequence)
+}
+
+func (c *Client) reportReconnectStatusWithTimeoutForSequence(ctx context.Context, client reconnectClient, timeout time.Duration, sequence uint64) {
+	replayCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	err := c.replaySubscriptions(replayCtx, client)
+	if c.statusSequence.Load() != sequence {
+		return
+	}
+	if !client.IsConnectionOpen() {
+		if err == nil {
+			err = errors.New("mqttclient: connection lost during resubscribe")
+		}
+		c.reportRuntimeStatusForSequence(sequence, false, false, err)
+		return
+	}
+	if err != nil {
+		c.reportRuntimeStatusForSequence(sequence, true, false, err)
+		return
+	}
+	c.reportRuntimeStatusForSequence(sequence, true, true, nil)
 }
 
 func (c *Client) replaySubscriptions(ctx context.Context, client subscriptionClient) error {
 	for topic, handler := range c.subscriptionSnapshot() {
-		if err := waitToken(ctx, client.Subscribe(topic, subscribeQoS, handler)); err != nil {
+		if err := waitSubscribeToken(ctx, topic, client.Subscribe(topic, subscribeQoS, handler)); err != nil {
 			return fmt.Errorf("mqttclient: resubscribe %q: %w", topic, err)
 		}
 	}
@@ -278,6 +325,31 @@ func waitToken(ctx context.Context, token paho.Token) error {
 	case <-token.Done():
 		return token.Error() //nolint:wrapcheck // paho token error; callers add context
 	}
+}
+
+func waitSubscribeToken(ctx context.Context, topic string, token paho.Token) error {
+	if err := waitToken(ctx, token); err != nil {
+		return err
+	}
+	return validateSubscribeResult(topic, token)
+}
+
+func validateSubscribeResult(topic string, token paho.Token) error {
+	resultToken, ok := token.(interface{ Result() map[string]byte })
+	if !ok {
+		return nil
+	}
+	qos, ok := resultToken.Result()[topic]
+	if !ok {
+		return errors.New("SUBACK missing topic result")
+	}
+	if qos == subscribeFailureCode {
+		return fmt.Errorf("SUBACK rejected subscription with code 0x%02x", qos)
+	}
+	if qos > 2 {
+		return fmt.Errorf("SUBACK returned invalid QoS %d", qos)
+	}
+	return nil
 }
 
 func clientID(identity string) string {

--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -29,6 +29,7 @@ const (
 // Client adapts Eclipse Paho to the curtailment MQTT ingest interface.
 type Client struct {
 	mu             sync.Mutex
+	statusMu       sync.Mutex
 	client         paho.Client
 	subscriptions  map[string]paho.MessageHandler
 	statusReporter func(connected bool, subscribed bool, err error)
@@ -162,6 +163,12 @@ func (c *Client) Subscribe(ctx context.Context, topic string, handler func(paylo
 }
 
 func (c *Client) reportRuntimeStatus(connected bool, subscribed bool, err error) {
+	c.statusMu.Lock()
+	defer c.statusMu.Unlock()
+	c.reportRuntimeStatusLocked(connected, subscribed, err)
+}
+
+func (c *Client) reportRuntimeStatusLocked(connected bool, subscribed bool, err error) {
 	c.mu.Lock()
 	reporter := c.statusReporter
 	c.mu.Unlock()
@@ -171,14 +178,18 @@ func (c *Client) reportRuntimeStatus(connected bool, subscribed bool, err error)
 }
 
 func (c *Client) nextStatusSequence() uint64 {
+	c.statusMu.Lock()
+	defer c.statusMu.Unlock()
 	return c.statusSequence.Add(1)
 }
 
 func (c *Client) reportRuntimeStatusForSequence(sequence uint64, connected bool, subscribed bool, err error) {
+	c.statusMu.Lock()
+	defer c.statusMu.Unlock()
 	if c.statusSequence.Load() != sequence {
 		return
 	}
-	c.reportRuntimeStatus(connected, subscribed, err)
+	c.reportRuntimeStatusLocked(connected, subscribed, err)
 }
 
 func (c *Client) reportConnectionLostStatus(client connectionStateClient, err error) {
@@ -198,9 +209,6 @@ func (c *Client) reportReconnectStatus(ctx context.Context, client reconnectClie
 
 func (c *Client) reportReconnectStatusForSequence(ctx context.Context, client reconnectClient, sequence uint64) {
 	err := c.replaySubscriptions(ctx, client)
-	if c.statusSequence.Load() != sequence {
-		return
-	}
 	if !client.IsConnectionOpen() {
 		if err == nil {
 			err = errors.New("mqttclient: connection lost during resubscribe")

--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -18,6 +18,7 @@ import (
 
 const subscribeQoS byte = 1
 const maxPayloadBytes = 1024
+const reconnectSubscribeTimeout = 10 * time.Second
 
 const (
 	transportTCP = "tcp"
@@ -159,7 +160,13 @@ func (c *Client) reportRuntimeStatus(connected bool, subscribed bool, err error)
 }
 
 func (c *Client) reportReconnectStatus(ctx context.Context, client subscriptionClient) {
-	if err := c.replaySubscriptions(ctx, client); err != nil {
+	c.reportReconnectStatusWithTimeout(ctx, client, reconnectSubscribeTimeout)
+}
+
+func (c *Client) reportReconnectStatusWithTimeout(ctx context.Context, client subscriptionClient, timeout time.Duration) {
+	replayCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := c.replaySubscriptions(replayCtx, client); err != nil {
 		c.reportRuntimeStatus(true, false, err)
 		return
 	}

--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -26,9 +26,10 @@ const (
 
 // Client adapts Eclipse Paho to the curtailment MQTT ingest interface.
 type Client struct {
-	mu            sync.Mutex
-	client        paho.Client
-	subscriptions map[string]paho.MessageHandler
+	mu             sync.Mutex
+	client         paho.Client
+	subscriptions  map[string]paho.MessageHandler
+	statusReporter func(connected bool, subscribed bool, err error)
 }
 
 type subscriptionClient interface {
@@ -43,6 +44,10 @@ var _ interface {
 	Connect(ctx context.Context, host string, port int32, transport string, username, password, clientIdentity string) error
 	Subscribe(ctx context.Context, topic string, handler func(payload []byte, receivedAt time.Time)) error
 	Disconnect(shutdownDeadline time.Duration)
+} = (*Client)(nil)
+
+var _ interface {
+	SetRuntimeStatusReporter(reporter func(connected bool, subscribed bool, err error))
 } = (*Client)(nil)
 
 func New() *Client {
@@ -61,10 +66,17 @@ func (c *Client) Connect(ctx context.Context, host string, port int32, transport
 		return err
 	}
 	initialConnectComplete := &atomic.Bool{}
+	initialOnConnectObserved := &atomic.Bool{}
 	opts := clientOptions(brokerURL, tlsConfig, username, password, clientIdentity, func(client paho.Client) {
+		if initialOnConnectObserved.CompareAndSwap(false, true) {
+			return
+		}
 		if initialConnectComplete.Load() {
 			c.resubscribe(client)
+			c.reportRuntimeStatus(true, true, nil)
 		}
+	}, func(_ paho.Client, err error) {
+		c.reportRuntimeStatus(false, false, normalizeConnectionLostError(err))
 	})
 
 	client := paho.NewClient(opts)
@@ -90,6 +102,12 @@ func (c *Client) Connect(ctx context.Context, host string, port int32, transport
 	}
 	initialConnectComplete.Store(true)
 	return nil
+}
+
+func (c *Client) SetRuntimeStatusReporter(reporter func(connected bool, subscribed bool, err error)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.statusReporter = reporter
 }
 
 func (c *Client) Subscribe(ctx context.Context, topic string, handler func(payload []byte, receivedAt time.Time)) error {
@@ -130,6 +148,15 @@ func (c *Client) Subscribe(ctx context.Context, topic string, handler func(paylo
 		return fmt.Errorf("mqttclient: subscribe %q: %w", topic, err)
 	}
 	return nil
+}
+
+func (c *Client) reportRuntimeStatus(connected bool, subscribed bool, err error) {
+	c.mu.Lock()
+	reporter := c.statusReporter
+	c.mu.Unlock()
+	if reporter != nil {
+		reporter(connected, subscribed, err)
+	}
 }
 
 func (c *Client) resubscribe(client paho.Client) {
@@ -187,6 +214,7 @@ func clientOptions(
 	password string,
 	clientIdentity string,
 	onConnect paho.OnConnectHandler,
+	onConnectionLost paho.ConnectionLostHandler,
 ) *paho.ClientOptions {
 	opts := paho.NewClientOptions().
 		AddBroker(brokerURL).
@@ -199,10 +227,20 @@ func clientOptions(
 		SetOnConnectHandler(onConnect).
 		SetOrderMatters(true).
 		SetProtocolVersion(4)
+	if onConnectionLost != nil {
+		opts.SetConnectionLostHandler(onConnectionLost)
+	}
 	if tlsConfig != nil {
 		opts.SetTLSConfig(tlsConfig)
 	}
 	return opts
+}
+
+func normalizeConnectionLostError(err error) error {
+	if err != nil {
+		return err
+	}
+	return errors.New("mqttclient: connection lost")
 }
 
 func (c *Client) Disconnect(shutdownDeadline time.Duration) {

--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -72,8 +72,7 @@ func (c *Client) Connect(ctx context.Context, host string, port int32, transport
 			return
 		}
 		if initialConnectComplete.Load() {
-			c.resubscribe(client)
-			c.reportRuntimeStatus(true, true, nil)
+			c.reportReconnectStatus(ctx, client)
 		}
 	}, func(_ paho.Client, err error) {
 		c.reportRuntimeStatus(false, false, normalizeConnectionLostError(err))
@@ -159,14 +158,21 @@ func (c *Client) reportRuntimeStatus(connected bool, subscribed bool, err error)
 	}
 }
 
-func (c *Client) resubscribe(client paho.Client) {
-	c.replaySubscriptions(client)
+func (c *Client) reportReconnectStatus(ctx context.Context, client subscriptionClient) {
+	if err := c.replaySubscriptions(ctx, client); err != nil {
+		c.reportRuntimeStatus(true, false, err)
+		return
+	}
+	c.reportRuntimeStatus(true, true, nil)
 }
 
-func (c *Client) replaySubscriptions(client subscriptionClient) {
+func (c *Client) replaySubscriptions(ctx context.Context, client subscriptionClient) error {
 	for topic, handler := range c.subscriptionSnapshot() {
-		client.Subscribe(topic, subscribeQoS, handler)
+		if err := waitToken(ctx, client.Subscribe(topic, subscribeQoS, handler)); err != nil {
+			return fmt.Errorf("mqttclient: resubscribe %q: %w", topic, err)
+		}
 	}
+	return nil
 }
 
 func (c *Client) addRoutes(client routeClient) {

--- a/server/internal/infrastructure/mqttclient/client_test.go
+++ b/server/internal/infrastructure/mqttclient/client_test.go
@@ -312,30 +312,49 @@ func TestClientOptions_RuntimeStatusCallbacks(t *testing.T) {
 	}
 }
 
+type runtimeStatusCapture struct {
+	reports    int
+	connected  bool
+	subscribed bool
+	err        error
+}
+
+func captureRuntimeStatus(client *Client) *runtimeStatusCapture {
+	capture := &runtimeStatusCapture{}
+	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
+		capture.reports++
+		capture.connected = connected
+		capture.subscribed = subscribed
+		capture.err = err
+	})
+	return capture
+}
+
+func reportReconnectStatusWithTestTimeout(t *testing.T, client *Client, replay reconnectClient, timeout time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
+	defer cancel()
+	sequence := client.nextStatusSequence()
+	client.reportReconnectStatusForSequence(ctx, replay, sequence)
+}
+
 func TestClientRuntimeStatusReporter(t *testing.T) {
 	t.Parallel()
 
 	client := New()
-	var gotConnected bool
-	var gotSubscribed bool
-	var gotErr error
-	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
-		gotConnected = connected
-		gotSubscribed = subscribed
-		gotErr = err
-	})
+	status := captureRuntimeStatus(client)
 
 	wantErr := errors.New("connection lost")
 	client.reportRuntimeStatus(false, false, wantErr)
 
-	if gotConnected {
+	if status.connected {
 		t.Fatal("connected = true, want false")
 	}
-	if gotSubscribed {
+	if status.subscribed {
 		t.Fatal("subscribed = true, want false")
 	}
-	if !errors.Is(gotErr, wantErr) {
-		t.Fatalf("err = %v, want %v", gotErr, wantErr)
+	if !errors.Is(status.err, wantErr) {
+		t.Fatalf("err = %v, want %v", status.err, wantErr)
 	}
 }
 
@@ -343,17 +362,14 @@ func TestReportConnectionLostStatusSkipsAlreadyOpenClient(t *testing.T) {
 	t.Parallel()
 
 	client := New()
-	calls := 0
-	client.SetRuntimeStatusReporter(func(bool, bool, error) {
-		calls++
-	})
+	status := captureRuntimeStatus(client)
 
 	openClient := &replayClient{}
 	openClient.setConnectionOpen(true)
 	client.reportConnectionLostStatus(openClient, errors.New("stale connection loss"))
 
-	if calls != 0 {
-		t.Fatalf("runtime status reports = %d, want 0", calls)
+	if status.reports != 0 {
+		t.Fatalf("runtime status reports = %d, want 0", status.reports)
 	}
 }
 
@@ -362,26 +378,18 @@ func TestReportReconnectStatusReportsSubscribedAfterReplaySuccess(t *testing.T) 
 
 	client := New()
 	client.subscriptions["curtailment/source"] = func(_ paho.Client, _ paho.Message) {}
-
-	var gotConnected bool
-	var gotSubscribed bool
-	var gotErr error
-	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
-		gotConnected = connected
-		gotSubscribed = subscribed
-		gotErr = err
-	})
+	status := captureRuntimeStatus(client)
 
 	client.reportReconnectStatus(t.Context(), &replayClient{})
 
-	if !gotConnected {
+	if !status.connected {
 		t.Fatal("connected = false, want true")
 	}
-	if !gotSubscribed {
+	if !status.subscribed {
 		t.Fatal("subscribed = false, want true")
 	}
-	if gotErr != nil {
-		t.Fatalf("err = %v, want nil", gotErr)
+	if status.err != nil {
+		t.Fatalf("err = %v, want nil", status.err)
 	}
 }
 
@@ -390,35 +398,26 @@ func TestReportReconnectStatusSuppressesStaleReplayReport(t *testing.T) {
 
 	client := New()
 	client.subscriptions["curtailment/source"] = func(_ paho.Client, _ paho.Message) {}
-	reports := 0
-	var gotConnected bool
-	var gotSubscribed bool
-	var gotErr error
-	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
-		reports++
-		gotConnected = connected
-		gotSubscribed = subscribed
-		gotErr = err
-	})
+	status := captureRuntimeStatus(client)
 
 	staleSequence := client.nextStatusSequence()
 	closedClient := &replayClient{}
 	closedClient.setConnectionOpen(false)
 	wantErr := errors.New("broker lost")
 	client.reportConnectionLostStatus(closedClient, wantErr)
-	if reports != 1 {
-		t.Fatalf("runtime status reports = %d, want 1", reports)
+	if status.reports != 1 {
+		t.Fatalf("runtime status reports = %d, want 1", status.reports)
 	}
-	if gotConnected || gotSubscribed {
-		t.Fatalf("connected=%v subscribed=%v, want both false", gotConnected, gotSubscribed)
+	if status.connected || status.subscribed {
+		t.Fatalf("connected=%v subscribed=%v, want both false", status.connected, status.subscribed)
 	}
-	if !errors.Is(gotErr, wantErr) {
-		t.Fatalf("err = %v, want %v", gotErr, wantErr)
+	if !errors.Is(status.err, wantErr) {
+		t.Fatalf("err = %v, want %v", status.err, wantErr)
 	}
 
-	client.reportReconnectStatusWithTimeoutForSequence(t.Context(), &replayClient{}, time.Millisecond, staleSequence)
-	if reports != 1 {
-		t.Fatalf("stale replay report was not suppressed; reports = %d, want 1", reports)
+	client.reportReconnectStatusForSequence(t.Context(), &replayClient{}, staleSequence)
+	if status.reports != 1 {
+		t.Fatalf("stale replay report was not suppressed; reports = %d, want 1", status.reports)
 	}
 }
 
@@ -430,25 +429,18 @@ func TestReportReconnectStatusReportsSubscribeReplayFailure(t *testing.T) {
 
 	wantErr := errors.New("subscription rejected")
 	replay := &replayClient{tokenErr: wantErr}
-	var gotConnected bool
-	var gotSubscribed bool
-	var gotErr error
-	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
-		gotConnected = connected
-		gotSubscribed = subscribed
-		gotErr = err
-	})
+	status := captureRuntimeStatus(client)
 
 	client.reportReconnectStatus(t.Context(), replay)
 
-	if !gotConnected {
+	if !status.connected {
 		t.Fatal("connected = false, want true")
 	}
-	if gotSubscribed {
+	if status.subscribed {
 		t.Fatal("subscribed = true, want false")
 	}
-	if !errors.Is(gotErr, wantErr) {
-		t.Fatalf("err = %v, want %v", gotErr, wantErr)
+	if !errors.Is(status.err, wantErr) {
+		t.Fatalf("err = %v, want %v", status.err, wantErr)
 	}
 }
 
@@ -460,25 +452,18 @@ func TestReportReconnectStatusReportsDisconnectedWhenReplayTimeoutFindsClosedCli
 
 	replay := &replayClient{token: newPendingToken()}
 	replay.setConnectionOpen(false)
-	var gotConnected bool
-	var gotSubscribed bool
-	var gotErr error
-	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
-		gotConnected = connected
-		gotSubscribed = subscribed
-		gotErr = err
-	})
+	status := captureRuntimeStatus(client)
 
-	client.reportReconnectStatusWithTimeout(t.Context(), replay, time.Millisecond)
+	reportReconnectStatusWithTestTimeout(t, client, replay, time.Millisecond)
 
-	if gotConnected {
+	if status.connected {
 		t.Fatal("connected = true, want false")
 	}
-	if gotSubscribed {
+	if status.subscribed {
 		t.Fatal("subscribed = true, want false")
 	}
-	if !errors.Is(gotErr, context.DeadlineExceeded) {
-		t.Fatalf("err = %v, want context deadline exceeded", gotErr)
+	if !errors.Is(status.err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context deadline exceeded", status.err)
 	}
 }
 
@@ -489,25 +474,18 @@ func TestReportReconnectStatusReportsSubscribeReplayTimeout(t *testing.T) {
 	client.subscriptions["curtailment/source"] = func(_ paho.Client, _ paho.Message) {}
 
 	replay := &replayClient{token: newPendingToken()}
-	var gotConnected bool
-	var gotSubscribed bool
-	var gotErr error
-	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
-		gotConnected = connected
-		gotSubscribed = subscribed
-		gotErr = err
-	})
+	status := captureRuntimeStatus(client)
 
-	client.reportReconnectStatusWithTimeout(t.Context(), replay, time.Millisecond)
+	reportReconnectStatusWithTestTimeout(t, client, replay, time.Millisecond)
 
-	if !gotConnected {
+	if !status.connected {
 		t.Fatal("connected = false, want true")
 	}
-	if gotSubscribed {
+	if status.subscribed {
 		t.Fatal("subscribed = true, want false")
 	}
-	if !errors.Is(gotErr, context.DeadlineExceeded) {
-		t.Fatalf("err = %v, want context deadline exceeded", gotErr)
+	if !errors.Is(status.err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context deadline exceeded", status.err)
 	}
 }
 

--- a/server/internal/infrastructure/mqttclient/client_test.go
+++ b/server/internal/infrastructure/mqttclient/client_test.go
@@ -16,7 +16,8 @@ type subscribeCall struct {
 }
 
 type replayClient struct {
-	calls []subscribeCall
+	calls    []subscribeCall
+	tokenErr error
 }
 
 func (r *replayClient) Subscribe(topic string, qos byte, callback paho.MessageHandler) paho.Token {
@@ -25,7 +26,29 @@ func (r *replayClient) Subscribe(topic string, qos byte, callback paho.MessageHa
 		qos:      qos,
 		callback: callback,
 	})
-	return nil
+	return completedToken{err: r.tokenErr}
+}
+
+type completedToken struct {
+	err error
+}
+
+func (t completedToken) Wait() bool {
+	return true
+}
+
+func (t completedToken) WaitTimeout(time.Duration) bool {
+	return true
+}
+
+func (t completedToken) Done() <-chan struct{} {
+	done := make(chan struct{})
+	close(done)
+	return done
+}
+
+func (t completedToken) Error() error {
+	return t.err
 }
 
 type routeCall struct {
@@ -106,7 +129,9 @@ func TestReplaySubscriptionsResubscribesStoredTopics(t *testing.T) {
 	client.subscriptions["curtailment/source"] = handler
 
 	replay := &replayClient{}
-	client.replaySubscriptions(replay)
+	if err := client.replaySubscriptions(t.Context(), replay); err != nil {
+		t.Fatalf("replaySubscriptions returned error: %v", err)
+	}
 
 	if len(replay.calls) != 1 {
 		t.Fatalf("replayed %d subscriptions, want 1", len(replay.calls))
@@ -224,6 +249,64 @@ func TestClientRuntimeStatusReporter(t *testing.T) {
 
 	if gotConnected {
 		t.Fatal("connected = true, want false")
+	}
+	if gotSubscribed {
+		t.Fatal("subscribed = true, want false")
+	}
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("err = %v, want %v", gotErr, wantErr)
+	}
+}
+
+func TestReportReconnectStatusReportsSubscribedAfterReplaySuccess(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	client.subscriptions["curtailment/source"] = func(_ paho.Client, _ paho.Message) {}
+
+	var gotConnected bool
+	var gotSubscribed bool
+	var gotErr error
+	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
+		gotConnected = connected
+		gotSubscribed = subscribed
+		gotErr = err
+	})
+
+	client.reportReconnectStatus(t.Context(), &replayClient{})
+
+	if !gotConnected {
+		t.Fatal("connected = false, want true")
+	}
+	if !gotSubscribed {
+		t.Fatal("subscribed = false, want true")
+	}
+	if gotErr != nil {
+		t.Fatalf("err = %v, want nil", gotErr)
+	}
+}
+
+func TestReportReconnectStatusReportsSubscribeReplayFailure(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	client.subscriptions["curtailment/source"] = func(_ paho.Client, _ paho.Message) {}
+
+	wantErr := errors.New("subscription rejected")
+	replay := &replayClient{tokenErr: wantErr}
+	var gotConnected bool
+	var gotSubscribed bool
+	var gotErr error
+	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
+		gotConnected = connected
+		gotSubscribed = subscribed
+		gotErr = err
+	})
+
+	client.reportReconnectStatus(t.Context(), replay)
+
+	if !gotConnected {
+		t.Fatal("connected = false, want true")
 	}
 	if gotSubscribed {
 		t.Fatal("subscribed = true, want false")

--- a/server/internal/infrastructure/mqttclient/client_test.go
+++ b/server/internal/infrastructure/mqttclient/client_test.go
@@ -17,9 +17,11 @@ type subscribeCall struct {
 }
 
 type replayClient struct {
-	calls    []subscribeCall
-	token    paho.Token
-	tokenErr error
+	calls             []subscribeCall
+	token             paho.Token
+	tokenErr          error
+	connectionOpen    bool
+	connectionOpenSet bool
 }
 
 func (r *replayClient) Subscribe(topic string, qos byte, callback paho.MessageHandler) paho.Token {
@@ -32,6 +34,18 @@ func (r *replayClient) Subscribe(topic string, qos byte, callback paho.MessageHa
 		return r.token
 	}
 	return completedToken{err: r.tokenErr}
+}
+
+func (r *replayClient) IsConnectionOpen() bool {
+	if !r.connectionOpenSet {
+		return true
+	}
+	return r.connectionOpen
+}
+
+func (r *replayClient) setConnectionOpen(open bool) {
+	r.connectionOpen = open
+	r.connectionOpenSet = true
 }
 
 type completedToken struct {
@@ -54,6 +68,15 @@ func (t completedToken) Done() <-chan struct{} {
 
 func (t completedToken) Error() error {
 	return t.err
+}
+
+type completedSubscribeToken struct {
+	completedToken
+	result map[string]byte
+}
+
+func (t completedSubscribeToken) Result() map[string]byte {
+	return t.result
 }
 
 type pendingToken struct {
@@ -185,6 +208,27 @@ func TestReplaySubscriptionsResubscribesStoredTopics(t *testing.T) {
 	}
 }
 
+func TestReplaySubscriptionsReportsSubackFailure(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	client.subscriptions["curtailment/source"] = func(_ paho.Client, _ paho.Message) {}
+
+	replay := &replayClient{
+		token: completedSubscribeToken{
+			result: map[string]byte{"curtailment/source": subscribeFailureCode},
+		},
+	}
+	err := client.replaySubscriptions(t.Context(), replay)
+
+	if err == nil {
+		t.Fatal("replaySubscriptions returned nil, want SUBACK failure")
+	}
+	if !strings.Contains(err.Error(), "SUBACK rejected subscription") {
+		t.Fatalf("err = %v, want SUBACK rejected subscription", err)
+	}
+}
+
 func TestSubscribeBeforeConnectStagesRoute(t *testing.T) {
 	t.Parallel()
 
@@ -295,6 +339,24 @@ func TestClientRuntimeStatusReporter(t *testing.T) {
 	}
 }
 
+func TestReportConnectionLostStatusSkipsAlreadyOpenClient(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	calls := 0
+	client.SetRuntimeStatusReporter(func(bool, bool, error) {
+		calls++
+	})
+
+	openClient := &replayClient{}
+	openClient.setConnectionOpen(true)
+	client.reportConnectionLostStatus(openClient, errors.New("stale connection loss"))
+
+	if calls != 0 {
+		t.Fatalf("runtime status reports = %d, want 0", calls)
+	}
+}
+
 func TestReportReconnectStatusReportsSubscribedAfterReplaySuccess(t *testing.T) {
 	t.Parallel()
 
@@ -320,6 +382,43 @@ func TestReportReconnectStatusReportsSubscribedAfterReplaySuccess(t *testing.T) 
 	}
 	if gotErr != nil {
 		t.Fatalf("err = %v, want nil", gotErr)
+	}
+}
+
+func TestReportReconnectStatusSuppressesStaleReplayReport(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	client.subscriptions["curtailment/source"] = func(_ paho.Client, _ paho.Message) {}
+	reports := 0
+	var gotConnected bool
+	var gotSubscribed bool
+	var gotErr error
+	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
+		reports++
+		gotConnected = connected
+		gotSubscribed = subscribed
+		gotErr = err
+	})
+
+	staleSequence := client.nextStatusSequence()
+	closedClient := &replayClient{}
+	closedClient.setConnectionOpen(false)
+	wantErr := errors.New("broker lost")
+	client.reportConnectionLostStatus(closedClient, wantErr)
+	if reports != 1 {
+		t.Fatalf("runtime status reports = %d, want 1", reports)
+	}
+	if gotConnected || gotSubscribed {
+		t.Fatalf("connected=%v subscribed=%v, want both false", gotConnected, gotSubscribed)
+	}
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("err = %v, want %v", gotErr, wantErr)
+	}
+
+	client.reportReconnectStatusWithTimeoutForSequence(t.Context(), &replayClient{}, time.Millisecond, staleSequence)
+	if reports != 1 {
+		t.Fatalf("stale replay report was not suppressed; reports = %d, want 1", reports)
 	}
 }
 
@@ -350,6 +449,36 @@ func TestReportReconnectStatusReportsSubscribeReplayFailure(t *testing.T) {
 	}
 	if !errors.Is(gotErr, wantErr) {
 		t.Fatalf("err = %v, want %v", gotErr, wantErr)
+	}
+}
+
+func TestReportReconnectStatusReportsDisconnectedWhenReplayTimeoutFindsClosedClient(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	client.subscriptions["curtailment/source"] = func(_ paho.Client, _ paho.Message) {}
+
+	replay := &replayClient{token: newPendingToken()}
+	replay.setConnectionOpen(false)
+	var gotConnected bool
+	var gotSubscribed bool
+	var gotErr error
+	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
+		gotConnected = connected
+		gotSubscribed = subscribed
+		gotErr = err
+	})
+
+	client.reportReconnectStatusWithTimeout(t.Context(), replay, time.Millisecond)
+
+	if gotConnected {
+		t.Fatal("connected = true, want false")
+	}
+	if gotSubscribed {
+		t.Fatal("subscribed = true, want false")
+	}
+	if !errors.Is(gotErr, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context deadline exceeded", gotErr)
 	}
 }
 

--- a/server/internal/infrastructure/mqttclient/client_test.go
+++ b/server/internal/infrastructure/mqttclient/client_test.go
@@ -319,6 +319,12 @@ type runtimeStatusCapture struct {
 	err        error
 }
 
+type runtimeStatusReport struct {
+	connected  bool
+	subscribed bool
+	err        error
+}
+
 func captureRuntimeStatus(client *Client) *runtimeStatusCapture {
 	capture := &runtimeStatusCapture{}
 	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
@@ -418,6 +424,91 @@ func TestReportReconnectStatusSuppressesStaleReplayReport(t *testing.T) {
 	client.reportReconnectStatusForSequence(t.Context(), &replayClient{}, staleSequence)
 	if status.reports != 1 {
 		t.Fatalf("stale replay report was not suppressed; reports = %d, want 1", status.reports)
+	}
+}
+
+func TestReportRuntimeStatusForSequenceDoesNotOverwriteNewerDisconnect(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	healthyReportEntered := make(chan struct{})
+	allowHealthyReport := make(chan struct{})
+	disconnectedReported := make(chan struct{})
+	reports := make(chan runtimeStatusReport, 2)
+	wantErr := errors.New("broker lost")
+
+	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
+		if connected && subscribed {
+			close(healthyReportEntered)
+			<-allowHealthyReport
+		}
+		reports <- runtimeStatusReport{
+			connected:  connected,
+			subscribed: subscribed,
+			err:        err,
+		}
+		if !connected && !subscribed {
+			close(disconnectedReported)
+		}
+	})
+
+	healthyReleased := false
+	defer func() {
+		if !healthyReleased {
+			close(allowHealthyReport)
+		}
+	}()
+
+	sequence := client.nextStatusSequence()
+	healthyDone := make(chan struct{})
+	go func() {
+		defer close(healthyDone)
+		client.reportRuntimeStatusForSequence(sequence, true, true, nil)
+	}()
+
+	select {
+	case <-healthyReportEntered:
+	case <-time.After(time.Second):
+		t.Fatal("healthy report did not enter reporter")
+	}
+
+	closedClient := &replayClient{}
+	closedClient.setConnectionOpen(false)
+	disconnectDone := make(chan struct{})
+	go func() {
+		defer close(disconnectDone)
+		client.reportConnectionLostStatus(closedClient, wantErr)
+	}()
+
+	select {
+	case <-disconnectedReported:
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(allowHealthyReport)
+	healthyReleased = true
+
+	select {
+	case <-healthyDone:
+	case <-time.After(time.Second):
+		t.Fatal("healthy report did not complete")
+	}
+	select {
+	case <-disconnectDone:
+	case <-time.After(time.Second):
+		t.Fatal("disconnect report did not complete")
+	}
+	close(reports)
+
+	var last runtimeStatusReport
+	for report := range reports {
+		last = report
+	}
+	if last.connected || last.subscribed {
+		t.Fatalf("last report connected=%v subscribed=%v, want both false", last.connected, last.subscribed)
+	}
+	if !errors.Is(last.err, wantErr) {
+		t.Fatalf("last err = %v, want %v", last.err, wantErr)
 	}
 }
 

--- a/server/internal/infrastructure/mqttclient/client_test.go
+++ b/server/internal/infrastructure/mqttclient/client_test.go
@@ -1,6 +1,7 @@
 package mqttclient
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -148,7 +149,7 @@ func TestSubscribeBeforeConnectStagesRoute(t *testing.T) {
 func TestClientOptions_DurableOrderedSession(t *testing.T) {
 	t.Parallel()
 
-	opts := clientOptions("tcp://10.0.0.1:1883", nil, "user", "pass", "source|broker|topic", nil)
+	opts := clientOptions("tcp://10.0.0.1:1883", nil, "user", "pass", "source|broker|topic", nil, nil)
 
 	if opts.CleanSession {
 		t.Fatal("CleanSession must be false so broker QoS1 queues survive fleetd restarts")
@@ -164,6 +165,71 @@ func TestClientOptions_DurableOrderedSession(t *testing.T) {
 	}
 	if opts.ClientID != clientID("source|broker|topic") {
 		t.Fatalf("ClientID = %q, want deterministic clientID helper output", opts.ClientID)
+	}
+}
+
+func TestClientOptions_RuntimeStatusCallbacks(t *testing.T) {
+	t.Parallel()
+
+	var connected bool
+	var lostErr error
+	opts := clientOptions(
+		"tcp://10.0.0.1:1883",
+		nil,
+		"user",
+		"pass",
+		"source|broker|topic",
+		func(paho.Client) {
+			connected = true
+		},
+		func(_ paho.Client, err error) {
+			lostErr = err
+		},
+	)
+
+	if opts.OnConnect == nil {
+		t.Fatal("OnConnect handler was not installed")
+	}
+	if opts.OnConnectionLost == nil {
+		t.Fatal("OnConnectionLost handler was not installed")
+	}
+
+	opts.OnConnect(nil)
+	if !connected {
+		t.Fatal("OnConnect handler did not run")
+	}
+
+	wantErr := errors.New("broker lost")
+	opts.OnConnectionLost(nil, wantErr)
+	if !errors.Is(lostErr, wantErr) {
+		t.Fatalf("lostErr = %v, want %v", lostErr, wantErr)
+	}
+}
+
+func TestClientRuntimeStatusReporter(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	var gotConnected bool
+	var gotSubscribed bool
+	var gotErr error
+	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
+		gotConnected = connected
+		gotSubscribed = subscribed
+		gotErr = err
+	})
+
+	wantErr := errors.New("connection lost")
+	client.reportRuntimeStatus(false, false, wantErr)
+
+	if gotConnected {
+		t.Fatal("connected = true, want false")
+	}
+	if gotSubscribed {
+		t.Fatal("subscribed = true, want false")
+	}
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("err = %v, want %v", gotErr, wantErr)
 	}
 }
 

--- a/server/internal/infrastructure/mqttclient/client_test.go
+++ b/server/internal/infrastructure/mqttclient/client_test.go
@@ -1,6 +1,7 @@
 package mqttclient
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -17,6 +18,7 @@ type subscribeCall struct {
 
 type replayClient struct {
 	calls    []subscribeCall
+	token    paho.Token
 	tokenErr error
 }
 
@@ -26,6 +28,9 @@ func (r *replayClient) Subscribe(topic string, qos byte, callback paho.MessageHa
 		qos:      qos,
 		callback: callback,
 	})
+	if r.token != nil {
+		return r.token
+	}
 	return completedToken{err: r.tokenErr}
 }
 
@@ -49,6 +54,38 @@ func (t completedToken) Done() <-chan struct{} {
 
 func (t completedToken) Error() error {
 	return t.err
+}
+
+type pendingToken struct {
+	done chan struct{}
+}
+
+func newPendingToken() pendingToken {
+	return pendingToken{done: make(chan struct{})}
+}
+
+func (t pendingToken) Wait() bool {
+	<-t.done
+	return true
+}
+
+func (t pendingToken) WaitTimeout(timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-t.done:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func (t pendingToken) Done() <-chan struct{} {
+	return t.done
+}
+
+func (t pendingToken) Error() error {
+	return nil
 }
 
 type routeCall struct {
@@ -313,6 +350,35 @@ func TestReportReconnectStatusReportsSubscribeReplayFailure(t *testing.T) {
 	}
 	if !errors.Is(gotErr, wantErr) {
 		t.Fatalf("err = %v, want %v", gotErr, wantErr)
+	}
+}
+
+func TestReportReconnectStatusReportsSubscribeReplayTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	client.subscriptions["curtailment/source"] = func(_ paho.Client, _ paho.Message) {}
+
+	replay := &replayClient{token: newPendingToken()}
+	var gotConnected bool
+	var gotSubscribed bool
+	var gotErr error
+	client.SetRuntimeStatusReporter(func(connected bool, subscribed bool, err error) {
+		gotConnected = connected
+		gotSubscribed = subscribed
+		gotErr = err
+	})
+
+	client.reportReconnectStatusWithTimeout(t.Context(), replay, time.Millisecond)
+
+	if !gotConnected {
+		t.Fatal("connected = false, want true")
+	}
+	if gotSubscribed {
+		t.Fatal("subscribed = true, want false")
+	}
+	if !errors.Is(gotErr, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context deadline exceeded", gotErr)
 	}
 }
 


### PR DESCRIPTION
Reviewable diff: +165/-11 across 3 files (excludes generated, test, and story files).

## Summary
MQTT curtailment sources now report broker runtime health after the initial subscription, so settings no longer stay connected when configured brokers disappear. Reconnect handling waits for subscription replay acknowledgements before reporting a broker as subscribed, validates SUBACK results, bounds the replay wait per reconnect attempt, and prevents stale reconnect health from overwriting newer disconnects. The change stays server-side; durable source state, protobufs, and frontend health mapping remain unchanged.

Closes #565.

## How it works
The ingest worker installs an optional runtime status callback on MQTT clients that support it. The Paho adapter reports connection loss as disconnected/unsubscribed, then on reconnect replays stored subscriptions with a bounded per-attempt timeout before reporting `connected=true, subscribed=true`. Reconnect status is guarded by a monotonic sequence and a status mutex so an older reconnect callback cannot publish healthy status after a newer disconnect callback. If replay fails, times out, or receives a rejected/missing SUBACK, the adapter reports degraded status; the subscriber keeps connected and subscribed counts separate and surfaces `RuntimeStateError` when there are zero subscribed brokers with an error. Existing settings UI behavior maps that runtime error to offline.

## Diagrams
```mermaid
flowchart TD
  A["Paho broker connection"] --> B["mqttclient callbacks"]
  B --> C["Sequenced runtime status guard"]
  C --> D["Bounded reconnect subscription replay"]
  D --> E["sourceWorker RuntimeStatusUpdate"]
  E --> F["Subscriber broker status map"]
  F --> G["MQTT source runtime state"]
  G --> H["Settings UI health label"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/infrastructure/mqttclient` | Adds runtime status reporter support, Paho connection-lost/reconnect callbacks, reconnect subscription replay token checks, SUBACK validation, a per-attempt replay timeout, and serialized status sequence reporting. | This is where broker socket lifecycle and subscription replay success become visible to curtailment runtime state without blocking indefinitely or allowing stale reconnect callbacks to mask newer disconnects. |
| `server/internal/domain/curtailment/mqttingest` | Workers optionally install per-broker runtime reporters; subscriber aggregation now treats zero subscribed brokers with errors as runtime error. | This preserves connected/subscribed counts while ensuring source health reflects whether signals can actually be received. |
| `server/internal/domain/curtailment/mqttingest` tests | Adds broker loss/reconnect and connected-but-unsubscribed error coverage. | Verifies one-broker degradation, all-broker offline/error behavior, and replay-failure health handling. |
| `server/internal/infrastructure/mqttclient` tests | Adds callback installation, reporter, replay success/failure/timeout, SUBACK failure, stale sequence suppression, and stale reconnect overwrite coverage. | Verifies reconnect reports subscribed only after replay succeeds and reports degraded status instead of hanging or overwriting newer disconnect state. |

## Key technical decisions & trade-offs
| Decision | Alternative |
| --- | --- |
| Use an optional internal callback interface instead of expanding `MQTTClient`. | Avoids forcing every existing fake/client to implement runtime reporting. |
| Keep connected and subscribed counts separate. | Operators can still see socket reachability while health follows whether curtailment signals can be received. |
| Wait for reconnect subscription tokens and validate SUBACK results before reporting `subscribed=true`. | Avoids a false healthy state when a broker reconnects but rejects or omits the curtailment topic subscription. |
| Bound reconnect subscription replay with a per-attempt timeout. | Prevents stuck Paho callback goroutines when a broker reconnects but never returns SUBACK. |
| Serialize status sequence checks with reporter invocation. | Prevents an older reconnect callback from publishing healthy status after a newer disconnect callback. |
| Keep frontend/proto unchanged. | Existing runtime state already maps `ERROR` to offline once server status is accurate. |
| Preserve worker-owned initial success reporting. | Prevents double-counting initial connect while still reporting later reconnects. |

## Testing & validation
- `bin/go test -count=1 ./server/internal/domain/curtailment/mqttingest ./server/internal/infrastructure/mqttclient`
- `bin/go test -race -count=1 ./server/internal/infrastructure/mqttclient`
- Pre-push `server-lint`: `0 issues`.
