### PR TITLE
fix(rbac): align role icons, surface permission dependencies, gate fleet nav

### DIFF
--- a/client/src/protoFleet/config/navItems.test.ts
+++ b/client/src/protoFleet/config/navItems.test.ts
@@ -15,6 +15,21 @@ describe("primaryNavItems", () => {
     });
     expect(labels.indexOf("Energy")).toBe(labels.indexOf("Activity") - 1);
   });
+
+  it("gates Fleet and Groups on fleet:read so inaccessible pages stay hidden", () => {
+    const fleet = primaryNavItems.find((item) => item.label === "Fleet");
+    const groups = primaryNavItems.find((item) => item.label === "Groups");
+
+    expect(fleet?.requiredPermission).toBe("fleet:read");
+    expect(groups?.requiredPermission).toBe("fleet:read");
+  });
+
+  it("leaves Home ungated as the universal landing", () => {
+    const home = primaryNavItems.find((item) => item.label === "Home");
+
+    expect(home?.requiredPermission).toBeUndefined();
+    expect(home?.requiredAnyPermission).toBeUndefined();
+  });
 });
 
 describe("secondaryNavItems", () => {

--- a/client/src/protoFleet/config/navItems.test.ts
+++ b/client/src/protoFleet/config/navItems.test.ts
@@ -16,12 +16,27 @@ describe("primaryNavItems", () => {
     expect(labels.indexOf("Energy")).toBe(labels.indexOf("Activity") - 1);
   });
 
-  it("gates Fleet and Groups on fleet:read so inaccessible pages stay hidden", () => {
+  it("gates Fleet on the union of its tab permissions so any reachable tab keeps a nav path", () => {
     const fleet = primaryNavItems.find((item) => item.label === "Fleet");
+
+    expect(fleet?.requiredPermission).toBeUndefined();
+    expect(fleet?.requiredAnyPermission).toEqual(["fleet:read", "rack:read", "site:read"]);
+
+    // Rack- and site-only readers can reach Fleet tabs by deep link, so the
+    // nav entry must stay visible for them.
+    expect(isNavItemAllowedByPermissions(fleet!, ["rack:read"])).toBe(true);
+    expect(isNavItemAllowedByPermissions(fleet!, ["site:read"])).toBe(true);
+    expect(isNavItemAllowedByPermissions(fleet!, ["fleet:read"])).toBe(true);
+    expect(isNavItemAllowedByPermissions(fleet!, ["activity:read"])).toBe(false);
+  });
+
+  it("gates Groups on rack:read to match the server-side device-set read gate", () => {
     const groups = primaryNavItems.find((item) => item.label === "Groups");
 
-    expect(fleet?.requiredPermission).toBe("fleet:read");
-    expect(groups?.requiredPermission).toBe("fleet:read");
+    expect(groups?.requiredPermission).toBe("rack:read");
+    expect(groups?.requiredAnyPermission).toBeUndefined();
+    expect(isNavItemAllowedByPermissions(groups!, ["rack:read"])).toBe(true);
+    expect(isNavItemAllowedByPermissions(groups!, ["fleet:read"])).toBe(false);
   });
 
   it("leaves Home ungated as the universal landing", () => {

--- a/client/src/protoFleet/config/navItems.test.ts
+++ b/client/src/protoFleet/config/navItems.test.ts
@@ -16,17 +16,20 @@ describe("primaryNavItems", () => {
     expect(labels.indexOf("Energy")).toBe(labels.indexOf("Activity") - 1);
   });
 
-  it("gates Fleet on the union of its tab permissions so any reachable tab keeps a nav path", () => {
+  it("gates Fleet on the permissions that actually make a tab reachable", () => {
     const fleet = primaryNavItems.find((item) => item.label === "Fleet");
 
     expect(fleet?.requiredPermission).toBeUndefined();
-    expect(fleet?.requiredAnyPermission).toEqual(["fleet:read", "rack:read", "site:read"]);
+    expect(fleet?.requiredAnyPermission).toEqual(["rack:read", "site:read"]);
 
-    // Rack- and site-only readers can reach Fleet tabs by deep link, so the
-    // nav entry must stay visible for them.
+    // Rack- and site-only readers can reach Fleet tabs (racks / sites), so the
+    // nav entry stays visible for them.
     expect(isNavItemAllowedByPermissions(fleet!, ["rack:read"])).toBe(true);
     expect(isNavItemAllowedByPermissions(fleet!, ["site:read"])).toBe(true);
-    expect(isNavItemAllowedByPermissions(fleet!, ["fleet:read"])).toBe(true);
+    // fleet:read alone unlocks no Fleet tab (the miners tab also needs
+    // miner:read + rack:read), so it must NOT advertise an unreachable page.
+    expect(isNavItemAllowedByPermissions(fleet!, ["fleet:read"])).toBe(false);
+    expect(isNavItemAllowedByPermissions(fleet!, ["miner:read"])).toBe(false);
     expect(isNavItemAllowedByPermissions(fleet!, ["activity:read"])).toBe(false);
   });
 

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -60,15 +60,16 @@ export const primaryNavItems: NavItem[] = [
     path: "/fleet",
     label: "Fleet",
     icon: Fleet,
-    // The Fleet shell hosts several tabs, each with its own server-side gate
-    // (see FleetLayout's isTabReachable): miners on fleet:read, racks on
-    // rack:read, and sites/buildings/infrastructure on site:read. Use the OR
-    // union of those gates so any role that can reach at least one tab keeps a
-    // nav path in; gating on fleet:read alone would strand rack- or site-only
-    // readers who can still deep-link to /fleet/racks or /fleet/sites. Home
-    // stays ungated as the safe universal landing; its widgets already degrade
-    // per-permission.
-    requiredAnyPermission: ["fleet:read", "rack:read", "site:read"],
+    // The Fleet shell hosts several tabs, each with its own gate (see
+    // FleetLayout's isTabReachable): racks needs rack:read, sites/buildings/
+    // infrastructure need site:read, and miners needs miner:read + rack:read +
+    // fleet:read. rack:read and site:read are the only permissions that
+    // independently make a tab reachable, so gate on their OR union. fleet:read
+    // and miner:read are deliberately excluded: neither unlocks a tab on its
+    // own (a fleet:read-only role would land on the empty "no permission"
+    // shell), and the miners tab already requires rack:read. Home stays ungated
+    // as the safe universal landing; its widgets already degrade per-permission.
+    requiredAnyPermission: ["rack:read", "site:read"],
     scopable: true,
   },
   {

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -60,18 +60,27 @@ export const primaryNavItems: NavItem[] = [
     path: "/fleet",
     label: "Fleet",
     icon: Fleet,
-    // Fleet (miner list + telemetry) and Groups (miners grouped by label) both
-    // surface fleet data the server gates on fleet:read, so a role without it
-    // would land on an empty, erroring page. Home stays ungated as the safe
-    // universal landing; its widgets already degrade per-permission.
-    requiredPermission: "fleet:read",
+    // The Fleet shell hosts several tabs, each with its own server-side gate
+    // (see FleetLayout's isTabReachable): miners on fleet:read, racks on
+    // rack:read, and sites/buildings/infrastructure on site:read. Use the OR
+    // union of those gates so any role that can reach at least one tab keeps a
+    // nav path in; gating on fleet:read alone would strand rack- or site-only
+    // readers who can still deep-link to /fleet/racks or /fleet/sites. Home
+    // stays ungated as the safe universal landing; its widgets already degrade
+    // per-permission.
+    requiredAnyPermission: ["fleet:read", "rack:read", "site:read"],
     scopable: true,
   },
   {
     path: "/groups",
     label: "Groups",
     icon: Groups,
-    requiredPermission: "fleet:read",
+    // The Groups page's list + stats flow (ListDeviceSets, GetDeviceSetStats)
+    // is gated server-side on rack:read (see deviceset handler's
+    // requireDeviceSetReadPermission), so gate the nav on rack:read to match.
+    // fleet:read would wrongly hide it from rack readers/managers who can use
+    // the page.
+    requiredPermission: "rack:read",
     scopable: true,
   },
   {

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -60,12 +60,18 @@ export const primaryNavItems: NavItem[] = [
     path: "/fleet",
     label: "Fleet",
     icon: Fleet,
+    // Fleet (miner list + telemetry) and Groups (miners grouped by label) both
+    // surface fleet data the server gates on fleet:read, so a role without it
+    // would land on an empty, erroring page. Home stays ungated as the safe
+    // universal landing; its widgets already degrade per-permission.
+    requiredPermission: "fleet:read",
     scopable: true,
   },
   {
     path: "/groups",
     label: "Groups",
     icon: Groups,
+    requiredPermission: "fleet:read",
     scopable: true,
   },
   {

--- a/client/src/protoFleet/features/settings/components/CreateEditRoleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/CreateEditRoleModal.tsx
@@ -2,7 +2,11 @@ import { useCallback, useMemo, useState } from "react";
 import clsx from "clsx";
 
 import { type RoleItem, useRoleManagement } from "@/protoFleet/api/useRoleManagement";
-import { type PermissionGroup, usePermissionCatalog } from "@/protoFleet/features/settings/utils/permissionCatalog";
+import {
+  type DependencyGaps,
+  type PermissionGroup,
+  usePermissionCatalog,
+} from "@/protoFleet/features/settings/utils/permissionCatalog";
 import { Alert, ChevronDown } from "@/shared/assets/icons";
 import Button, { variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
@@ -43,7 +47,7 @@ const CreateEditRoleModal = ({ open, role, onDismiss, onSuccess }: CreateEditRol
     permissionGroups,
     withRequiredReads,
     lockedReadKeys,
-    missingDependencies,
+    dependencyGaps,
     isLoading: catalogLoading,
     error: catalogError,
   } = usePermissionCatalog();
@@ -69,7 +73,7 @@ const CreateEditRoleModal = ({ open, role, onDismiss, onSuccess }: CreateEditRol
       permissionGroups={permissionGroups}
       withRequiredReads={withRequiredReads}
       lockedReadKeys={lockedReadKeys}
-      missingDependencies={missingDependencies}
+      dependencyGaps={dependencyGaps}
       createRole={createRole}
       updateRole={updateRole}
       onDismiss={onDismiss}
@@ -86,7 +90,7 @@ interface FormProps {
   permissionGroups: PermissionGroup[];
   withRequiredReads: (selected: Iterable<string>) => string[];
   lockedReadKeys: (selected: Iterable<string>) => Set<string>;
-  missingDependencies: (selected: Iterable<string>) => string[];
+  dependencyGaps: (selected: Iterable<string>) => DependencyGaps;
   createRole: ReturnType<typeof useRoleManagement>["createRole"];
   updateRole: ReturnType<typeof useRoleManagement>["updateRole"];
   onDismiss: () => void;
@@ -101,7 +105,7 @@ const CreateEditRoleModalForm = ({
   permissionGroups,
   withRequiredReads,
   lockedReadKeys,
-  missingDependencies,
+  dependencyGaps,
   createRole,
   updateRole,
   onDismiss,
@@ -231,17 +235,21 @@ const CreateEditRoleModalForm = ({
 
   // Permissions the current selection needs to be usable but doesn't grant
   // yet (e.g. Schedules can't run an action without the matching miner
-  // permission). Surfaced as a one-click suggestion rather than auto-added.
+  // permission). Hard requirements are offered as a one-click add; "choose at
+  // least one" sets are shown as guidance only, since granting every member
+  // would over-grant sensitive actions when just one is needed.
   const descriptionByKey = useMemo(() => {
     const map = new Map<string, string>();
     permissionGroups.forEach((group) => group.entries.forEach((entry) => map.set(entry.key, entry.description)));
     return map;
   }, [permissionGroups]);
-  const missingDeps = useMemo(() => missingDependencies(Array.from(selected)), [selected, missingDependencies]);
-  const addMissingDeps = useCallback(() => {
+  const describe = useCallback((key: string) => descriptionByKey.get(key) ?? key, [descriptionByKey]);
+  const gaps = useMemo(() => dependencyGaps(Array.from(selected)), [selected, dependencyGaps]);
+  const hasGaps = gaps.required.length > 0 || gaps.chooseOneOf.length > 0;
+  const addRequiredDeps = useCallback(() => {
     setErrorMsg("");
-    setExplicit((prev) => new Set([...prev, ...missingDeps]));
-  }, [missingDeps]);
+    setExplicit((prev) => new Set([...prev, ...gaps.required]));
+  }, [gaps.required]);
 
   return (
     <Modal
@@ -310,17 +318,26 @@ const CreateEditRoleModalForm = ({
         />
       </div>
 
-      {missingDeps.length > 0 ? (
+      {hasGaps ? (
         <Callout
           className="mb-3"
           intent="warning"
           prefixIcon={<Alert />}
           title="This role needs more access to be usable"
-          subtitle={`The permissions you selected also depend on: ${missingDeps
-            .map((key) => descriptionByKey.get(key) ?? key)
-            .join(", ")}`}
-          buttonText="Add required permissions"
-          buttonOnClick={addMissingDeps}
+          subtitle={
+            <div className="flex flex-col gap-1">
+              {gaps.required.length > 0 ? (
+                <span>The permissions you selected also require: {gaps.required.map(describe).join(", ")}</span>
+              ) : null}
+              {gaps.chooseOneOf.map((group) => (
+                <span key={group.join("|")}>
+                  Choose at least one action to schedule: {group.map(describe).join(", ")}
+                </span>
+              ))}
+            </div>
+          }
+          buttonText={gaps.required.length > 0 ? "Add required permissions" : undefined}
+          buttonOnClick={gaps.required.length > 0 ? addRequiredDeps : undefined}
         />
       ) : null}
 

--- a/client/src/protoFleet/features/settings/components/CreateEditRoleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/CreateEditRoleModal.tsx
@@ -43,6 +43,7 @@ const CreateEditRoleModal = ({ open, role, onDismiss, onSuccess }: CreateEditRol
     permissionGroups,
     withRequiredReads,
     lockedReadKeys,
+    missingDependencies,
     isLoading: catalogLoading,
     error: catalogError,
   } = usePermissionCatalog();
@@ -68,6 +69,7 @@ const CreateEditRoleModal = ({ open, role, onDismiss, onSuccess }: CreateEditRol
       permissionGroups={permissionGroups}
       withRequiredReads={withRequiredReads}
       lockedReadKeys={lockedReadKeys}
+      missingDependencies={missingDependencies}
       createRole={createRole}
       updateRole={updateRole}
       onDismiss={onDismiss}
@@ -84,6 +86,7 @@ interface FormProps {
   permissionGroups: PermissionGroup[];
   withRequiredReads: (selected: Iterable<string>) => string[];
   lockedReadKeys: (selected: Iterable<string>) => Set<string>;
+  missingDependencies: (selected: Iterable<string>) => string[];
   createRole: ReturnType<typeof useRoleManagement>["createRole"];
   updateRole: ReturnType<typeof useRoleManagement>["updateRole"];
   onDismiss: () => void;
@@ -98,6 +101,7 @@ const CreateEditRoleModalForm = ({
   permissionGroups,
   withRequiredReads,
   lockedReadKeys,
+  missingDependencies,
   createRole,
   updateRole,
   onDismiss,
@@ -225,6 +229,20 @@ const CreateEditRoleModalForm = ({
 
   const lockedReads = useMemo(() => lockedReadKeys(Array.from(selected)), [selected, lockedReadKeys]);
 
+  // Permissions the current selection needs to be usable but doesn't grant
+  // yet (e.g. Schedules can't run an action without the matching miner
+  // permission). Surfaced as a one-click suggestion rather than auto-added.
+  const descriptionByKey = useMemo(() => {
+    const map = new Map<string, string>();
+    permissionGroups.forEach((group) => group.entries.forEach((entry) => map.set(entry.key, entry.description)));
+    return map;
+  }, [permissionGroups]);
+  const missingDeps = useMemo(() => missingDependencies(Array.from(selected)), [selected, missingDependencies]);
+  const addMissingDeps = useCallback(() => {
+    setErrorMsg("");
+    setExplicit((prev) => new Set([...prev, ...missingDeps]));
+  }, [missingDeps]);
+
   return (
     <Modal
       open={isVisible}
@@ -292,6 +310,20 @@ const CreateEditRoleModalForm = ({
         />
       </div>
 
+      {missingDeps.length > 0 ? (
+        <Callout
+          className="mb-3"
+          intent="warning"
+          prefixIcon={<Alert />}
+          title="This role needs more access to be usable"
+          subtitle={`The permissions you selected also depend on: ${missingDeps
+            .map((key) => descriptionByKey.get(key) ?? key)
+            .join(", ")}`}
+          buttonText="Add required permissions"
+          buttonOnClick={addMissingDeps}
+        />
+      ) : null}
+
       {renderedGroups.length === 0 ? (
         <div className="py-10 text-center text-200 text-text-primary-50">No permissions match "{query.trim()}".</div>
       ) : (
@@ -307,6 +339,7 @@ const CreateEditRoleModalForm = ({
               <section key={group.resource}>
                 <div className="flex items-center gap-3 py-3">
                   <Checkbox
+                    className="shrink-0"
                     checked={allSelected}
                     partiallyChecked={someSelected}
                     onChange={(e) => toggleGroup(groupKeys, e.target.checked)}
@@ -351,6 +384,7 @@ const CreateEditRoleModalForm = ({
                           )}
                         >
                           <Checkbox
+                            className="shrink-0"
                             checked={checked}
                             disabled={isLocked}
                             onChange={(e) => toggleKey(entry.key, e.target.checked)}

--- a/client/src/protoFleet/features/settings/components/Roles.tsx
+++ b/client/src/protoFleet/features/settings/components/Roles.tsx
@@ -43,18 +43,18 @@ const SystemDefaultRoleLockContent = () => {
   return (
     <div
       ref={triggerRef}
-      className={`${systemDefaultRoleTriggerClassName} relative inline-flex justify-center text-text-primary-50`}
+      className={`${systemDefaultRoleTriggerClassName} relative flex w-full text-text-primary-50`}
       data-testid="system-role-lock"
     >
       <button
         type="button"
-        className="p-1 hover:cursor-pointer hover:text-text-primary"
+        className="flex h-8 w-8 items-center justify-center hover:cursor-pointer hover:text-text-primary"
         aria-label="System default role"
         aria-expanded={isOpen}
         aria-haspopup="dialog"
         onClick={() => setIsOpen((current) => !current)}
       >
-        <Lock width="w-5" />
+        <Lock />
       </button>
       {isOpen ? (
         <Popover

--- a/client/src/protoFleet/features/settings/utils/permissionCatalog.test.ts
+++ b/client/src/protoFleet/features/settings/utils/permissionCatalog.test.ts
@@ -16,10 +16,11 @@ const catalog: CatalogEntry[] = [
 ];
 
 describe("dependencyGaps", () => {
-  it("splits schedule:manage gaps into hard reads and a choose-one-of action set", () => {
+  it("gives schedule:manage no hard requirements, only a choose-one-of action set", () => {
     const gaps = dependencyGaps(["schedule:manage"], catalog);
-    // Reads are hard requirements, safe for the one-click add.
-    expect(gaps.required.sort()).toEqual(["fleet:read", "miner:read", "rack:read"].sort());
+    // No forced reads: the chosen action pulls its own read floor via
+    // withRequiredReads, and rack/miner reads are only for optional targeting.
+    expect(gaps.required).toEqual([]);
     // The miner actions are a "choose at least one" set, never auto-added.
     expect(gaps.chooseOneOf).toEqual([["miner:reboot", "miner:stop_mining", "miner:set_power_target"]]);
   });
@@ -33,10 +34,10 @@ describe("dependencyGaps", () => {
 
   it("stops suggesting the action set once one member is held (oneOf)", () => {
     const selected = withRequiredReads(["schedule:manage", "miner:reboot"], catalog);
-    // miner:reboot satisfies the "at least one action" set and pulls in
-    // miner:read + fleet:read via required reads, leaving only rack:read.
+    // miner:reboot satisfies the "at least one action" set and pulls in its own
+    // read floor, so nothing is left to flag.
     const gaps = dependencyGaps(selected, catalog);
-    expect(gaps.required).toEqual(["rack:read"]);
+    expect(gaps.required).toEqual([]);
     expect(gaps.chooseOneOf).toEqual([]);
   });
 

--- a/client/src/protoFleet/features/settings/utils/permissionCatalog.test.ts
+++ b/client/src/protoFleet/features/settings/utils/permissionCatalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { type CatalogEntry, missingDependencies, withRequiredReads } from "./permissionCatalog";
+import { type CatalogEntry, dependencyGaps, withRequiredReads } from "./permissionCatalog";
 
 // Minimal catalog covering the keys the dependency rules reference.
 const catalog: CatalogEntry[] = [
@@ -15,35 +15,59 @@ const catalog: CatalogEntry[] = [
   { key: "schedule:manage", description: "Create, edit, pause, resume, and delete schedules.", resource: "schedule" },
 ];
 
-describe("missingDependencies", () => {
-  it("flags the reads and at least one action schedule:manage needs", () => {
-    expect(missingDependencies(["schedule:manage"], catalog).sort()).toEqual(
-      ["fleet:read", "miner:read", "miner:reboot", "miner:set_power_target", "miner:stop_mining", "rack:read"].sort(),
-    );
+describe("dependencyGaps", () => {
+  it("splits schedule:manage gaps into hard reads and a choose-one-of action set", () => {
+    const gaps = dependencyGaps(["schedule:manage"], catalog);
+    // Reads are hard requirements, safe for the one-click add.
+    expect(gaps.required.sort()).toEqual(["fleet:read", "miner:read", "rack:read"].sort());
+    // The miner actions are a "choose at least one" set, never auto-added.
+    expect(gaps.chooseOneOf).toEqual([["miner:reboot", "miner:stop_mining", "miner:set_power_target"]]);
   });
 
-  it("stops suggesting the other actions once one is held (oneOf)", () => {
+  it("never lists oneOf members as hard-required", () => {
+    const gaps = dependencyGaps(["schedule:manage"], catalog);
+    expect(gaps.required).not.toContain("miner:reboot");
+    expect(gaps.required).not.toContain("miner:stop_mining");
+    expect(gaps.required).not.toContain("miner:set_power_target");
+  });
+
+  it("stops suggesting the action set once one member is held (oneOf)", () => {
     const selected = withRequiredReads(["schedule:manage", "miner:reboot"], catalog);
     // miner:reboot satisfies the "at least one action" set and pulls in
     // miner:read + fleet:read via required reads, leaving only rack:read.
-    expect(missingDependencies(selected, catalog)).toEqual(["rack:read"]);
+    const gaps = dependencyGaps(selected, catalog);
+    expect(gaps.required).toEqual(["rack:read"]);
+    expect(gaps.chooseOneOf).toEqual([]);
   });
 
-  it("flags reboot access for firmware updates", () => {
-    expect(missingDependencies(["miner:firmware_update"], catalog)).toEqual(["miner:reboot"]);
+  it("treats reboot access for firmware updates as a hard requirement", () => {
+    const gaps = dependencyGaps(["miner:firmware_update"], catalog);
+    expect(gaps.required).toEqual(["miner:reboot"]);
+    expect(gaps.chooseOneOf).toEqual([]);
   });
 
-  it("returns nothing once dependencies are satisfied", () => {
+  it("returns no gaps once dependencies are satisfied", () => {
     const selected = ["schedule:manage", "fleet:read", "miner:read", "rack:read", "miner:reboot"];
-    expect(missingDependencies(selected, catalog)).toEqual([]);
+    const gaps = dependencyGaps(selected, catalog);
+    expect(gaps.required).toEqual([]);
+    expect(gaps.chooseOneOf).toEqual([]);
   });
 
-  it("skips dependencies the catalog does not publish", () => {
+  it("skips choose-one-of members the catalog does not publish", () => {
     const trimmed = catalog.filter((entry) => entry.key !== "miner:set_power_target");
-    expect(missingDependencies(["schedule:manage"], trimmed)).not.toContain("miner:set_power_target");
+    const gaps = dependencyGaps(["schedule:manage"], trimmed);
+    expect(gaps.chooseOneOf).toEqual([["miner:reboot", "miner:stop_mining"]]);
   });
 
-  it("reports nothing for selections without functional dependencies", () => {
-    expect(missingDependencies(["miner:reboot", "miner:read", "fleet:read"], catalog)).toEqual([]);
+  it("omits a choose-one-of set entirely when the catalog publishes none of its members", () => {
+    const trimmed = catalog.filter((entry) => entry.resource !== "miner" || entry.key === "miner:read");
+    const gaps = dependencyGaps(["schedule:manage"], trimmed);
+    expect(gaps.chooseOneOf).toEqual([]);
+  });
+
+  it("reports no gaps for selections without functional dependencies", () => {
+    const gaps = dependencyGaps(["miner:reboot", "miner:read", "fleet:read"], catalog);
+    expect(gaps.required).toEqual([]);
+    expect(gaps.chooseOneOf).toEqual([]);
   });
 });

--- a/client/src/protoFleet/features/settings/utils/permissionCatalog.test.ts
+++ b/client/src/protoFleet/features/settings/utils/permissionCatalog.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { type CatalogEntry, missingDependencies, withRequiredReads } from "./permissionCatalog";
+
+// Minimal catalog covering the keys the dependency rules reference.
+const catalog: CatalogEntry[] = [
+  { key: "fleet:read", description: "View the dashboard, miner list, and live telemetry.", resource: "fleet" },
+  { key: "miner:read", description: "View a miner's details, status, and error history.", resource: "miner" },
+  { key: "miner:reboot", description: "Reboot a miner.", resource: "miner" },
+  { key: "miner:stop_mining", description: "Stop mining on a miner.", resource: "miner" },
+  { key: "miner:set_power_target", description: "Change a miner's power target.", resource: "miner" },
+  { key: "miner:firmware_update", description: "Install firmware updates on a miner.", resource: "miner" },
+  { key: "rack:read", description: "List racks at a site.", resource: "rack" },
+  { key: "schedule:read", description: "View scheduled miner actions.", resource: "schedule" },
+  { key: "schedule:manage", description: "Create, edit, pause, resume, and delete schedules.", resource: "schedule" },
+];
+
+describe("missingDependencies", () => {
+  it("flags the reads and at least one action schedule:manage needs", () => {
+    expect(missingDependencies(["schedule:manage"], catalog).sort()).toEqual(
+      ["fleet:read", "miner:read", "miner:reboot", "miner:set_power_target", "miner:stop_mining", "rack:read"].sort(),
+    );
+  });
+
+  it("stops suggesting the other actions once one is held (oneOf)", () => {
+    const selected = withRequiredReads(["schedule:manage", "miner:reboot"], catalog);
+    // miner:reboot satisfies the "at least one action" set and pulls in
+    // miner:read + fleet:read via required reads, leaving only rack:read.
+    expect(missingDependencies(selected, catalog)).toEqual(["rack:read"]);
+  });
+
+  it("flags reboot access for firmware updates", () => {
+    expect(missingDependencies(["miner:firmware_update"], catalog)).toEqual(["miner:reboot"]);
+  });
+
+  it("returns nothing once dependencies are satisfied", () => {
+    const selected = ["schedule:manage", "fleet:read", "miner:read", "rack:read", "miner:reboot"];
+    expect(missingDependencies(selected, catalog)).toEqual([]);
+  });
+
+  it("skips dependencies the catalog does not publish", () => {
+    const trimmed = catalog.filter((entry) => entry.key !== "miner:set_power_target");
+    expect(missingDependencies(["schedule:manage"], trimmed)).not.toContain("miner:set_power_target");
+  });
+
+  it("reports nothing for selections without functional dependencies", () => {
+    expect(missingDependencies(["miner:reboot", "miner:read", "fleet:read"], catalog)).toEqual([]);
+  });
+});

--- a/client/src/protoFleet/features/settings/utils/permissionCatalog.ts
+++ b/client/src/protoFleet/features/settings/utils/permissionCatalog.ts
@@ -123,6 +123,62 @@ export const lockedReadKeys = (selected: Iterable<string>, catalog: CatalogEntry
   return locked;
 };
 
+interface FunctionalDependency {
+  /** Companion keys always needed for the grant to be usable. */
+  requires?: string[];
+  /**
+   * Sets where at least one key must be held. Suggested only while none of
+   * the set is selected, so a deliberately narrow role (e.g. a reboot-only
+   * scheduler) isn't nagged to grant the other actions once it holds one.
+   */
+  oneOf?: string[][];
+}
+
+// Companion permissions a grant needs to be usable, beyond the same-resource
+// reads requiredReadsFor already resolves. These are surfaced as a one-click
+// suggestion rather than auto-added, so handing a role miner-action authority
+// stays a deliberate choice.
+const FUNCTIONAL_DEPENDENCIES: Record<string, FunctionalDependency> = {
+  // schedule:manage opens the Schedules surface, but the create form's target
+  // picker lists miners (fleet:read + miner:read) plus groups and racks
+  // (rack:read), and the server gates creating or resuming a schedule on the
+  // miner action it performs (reboot / sleep / set power).
+  "schedule:manage": {
+    requires: ["fleet:read", "miner:read", "rack:read"],
+    oneOf: [["miner:reboot", "miner:stop_mining", "miner:set_power_target"]],
+  },
+  // Installing firmware can reboot the device, so the server gates the
+  // firmware RPC on miner:reboot in addition to miner:firmware_update.
+  "miner:firmware_update": { requires: ["miner:reboot"] },
+};
+
+/**
+ * Companion permissions a selection functionally depends on but is missing.
+ * Only keys the catalog actually publishes are returned, so a dependency the
+ * server hasn't shipped is skipped rather than offered as an un-grantable row.
+ * For an unsatisfied "at least one" set, every member is suggested so the
+ * one-click add yields a fully usable role the admin can then trim down.
+ */
+export const missingDependencies = (selected: Iterable<string>, catalog: CatalogEntry[]): string[] => {
+  const selectedSet = new Set(selected);
+  const catalogKeys = new Set(catalog.map((entry) => entry.key));
+  const has = (key: string) => catalogKeys.has(key) && !selectedSet.has(key);
+  const missing = new Set<string>();
+  for (const key of selectedSet) {
+    const dep = FUNCTIONAL_DEPENDENCIES[key];
+    if (!dep) continue;
+    for (const required of dep.requires ?? []) {
+      if (has(required)) missing.add(required);
+    }
+    for (const group of dep.oneOf ?? []) {
+      if (!group.some((member) => selectedSet.has(member))) {
+        group.filter(has).forEach((member) => missing.add(member));
+      }
+    }
+  }
+  return [...missing];
+};
+
 export interface UsePermissionCatalogResult {
   catalog: CatalogEntry[];
   permissionGroups: PermissionGroup[];
@@ -131,6 +187,7 @@ export interface UsePermissionCatalogResult {
   requiredReadsFor: (key: string) => string[];
   withRequiredReads: (selected: Iterable<string>) => string[];
   lockedReadKeys: (selected: Iterable<string>) => Set<string>;
+  missingDependencies: (selected: Iterable<string>) => string[];
 }
 
 // Module-level cache so multiple hook instances share the single fetch.
@@ -197,6 +254,10 @@ export const usePermissionCatalog = (): UsePermissionCatalogResult => {
     [catalog],
   );
   const boundLockedReadKeys = useCallback((selected: Iterable<string>) => lockedReadKeys(selected, catalog), [catalog]);
+  const boundMissingDependencies = useCallback(
+    (selected: Iterable<string>) => missingDependencies(selected, catalog),
+    [catalog],
+  );
 
   return {
     catalog,
@@ -206,5 +267,6 @@ export const usePermissionCatalog = (): UsePermissionCatalogResult => {
     requiredReadsFor: boundRequiredReadsFor,
     withRequiredReads: boundWithRequiredReads,
     lockedReadKeys: boundLockedReadKeys,
+    missingDependencies: boundMissingDependencies,
   };
 };

--- a/client/src/protoFleet/features/settings/utils/permissionCatalog.ts
+++ b/client/src/protoFleet/features/settings/utils/permissionCatalog.ts
@@ -152,31 +152,48 @@ const FUNCTIONAL_DEPENDENCIES: Record<string, FunctionalDependency> = {
   "miner:firmware_update": { requires: ["miner:reboot"] },
 };
 
+export interface DependencyGaps {
+  /**
+   * Hard companion permissions the selection is missing. These are always
+   * required, so the one-click add can safely grant all of them at once.
+   */
+  required: string[];
+  /**
+   * Unsatisfied "at least one" sets — the admin must grant at least one
+   * member of each set, but the choice is theirs. Never auto-added, since
+   * granting every member would over-grant (e.g. handing a scheduling role
+   * every sensitive miner action when only one is needed).
+   */
+  chooseOneOf: string[][];
+}
+
 /**
- * Companion permissions a selection functionally depends on but is missing.
+ * Splits a selection's functional dependency gap into hard requirements (safe
+ * to one-click add) and "choose at least one" sets (display-only guidance).
  * Only keys the catalog actually publishes are returned, so a dependency the
  * server hasn't shipped is skipped rather than offered as an un-grantable row.
- * For an unsatisfied "at least one" set, every member is suggested so the
- * one-click add yields a fully usable role the admin can then trim down.
+ * An "at least one" set already satisfied by the selection is omitted, so a
+ * deliberately narrow role isn't nagged once it holds a member.
  */
-export const missingDependencies = (selected: Iterable<string>, catalog: CatalogEntry[]): string[] => {
+export const dependencyGaps = (selected: Iterable<string>, catalog: CatalogEntry[]): DependencyGaps => {
   const selectedSet = new Set(selected);
   const catalogKeys = new Set(catalog.map((entry) => entry.key));
   const has = (key: string) => catalogKeys.has(key) && !selectedSet.has(key);
-  const missing = new Set<string>();
+  const required = new Set<string>();
+  const chooseOneOf: string[][] = [];
   for (const key of selectedSet) {
     const dep = FUNCTIONAL_DEPENDENCIES[key];
     if (!dep) continue;
-    for (const required of dep.requires ?? []) {
-      if (has(required)) missing.add(required);
+    for (const requiredKey of dep.requires ?? []) {
+      if (has(requiredKey)) required.add(requiredKey);
     }
     for (const group of dep.oneOf ?? []) {
-      if (!group.some((member) => selectedSet.has(member))) {
-        group.filter(has).forEach((member) => missing.add(member));
-      }
+      if (group.some((member) => selectedSet.has(member))) continue;
+      const options = group.filter((member) => catalogKeys.has(member));
+      if (options.length > 0) chooseOneOf.push(options);
     }
   }
-  return [...missing];
+  return { required: [...required], chooseOneOf };
 };
 
 export interface UsePermissionCatalogResult {
@@ -187,7 +204,7 @@ export interface UsePermissionCatalogResult {
   requiredReadsFor: (key: string) => string[];
   withRequiredReads: (selected: Iterable<string>) => string[];
   lockedReadKeys: (selected: Iterable<string>) => Set<string>;
-  missingDependencies: (selected: Iterable<string>) => string[];
+  dependencyGaps: (selected: Iterable<string>) => DependencyGaps;
 }
 
 // Module-level cache so multiple hook instances share the single fetch.
@@ -254,10 +271,7 @@ export const usePermissionCatalog = (): UsePermissionCatalogResult => {
     [catalog],
   );
   const boundLockedReadKeys = useCallback((selected: Iterable<string>) => lockedReadKeys(selected, catalog), [catalog]);
-  const boundMissingDependencies = useCallback(
-    (selected: Iterable<string>) => missingDependencies(selected, catalog),
-    [catalog],
-  );
+  const boundDependencyGaps = useCallback((selected: Iterable<string>) => dependencyGaps(selected, catalog), [catalog]);
 
   return {
     catalog,
@@ -267,6 +281,6 @@ export const usePermissionCatalog = (): UsePermissionCatalogResult => {
     requiredReadsFor: boundRequiredReadsFor,
     withRequiredReads: boundWithRequiredReads,
     lockedReadKeys: boundLockedReadKeys,
-    missingDependencies: boundMissingDependencies,
+    dependencyGaps: boundDependencyGaps,
   };
 };

--- a/client/src/protoFleet/features/settings/utils/permissionCatalog.ts
+++ b/client/src/protoFleet/features/settings/utils/permissionCatalog.ts
@@ -139,12 +139,15 @@ interface FunctionalDependency {
 // suggestion rather than auto-added, so handing a role miner-action authority
 // stays a deliberate choice.
 const FUNCTIONAL_DEPENDENCIES: Record<string, FunctionalDependency> = {
-  // schedule:manage opens the Schedules surface, but the create form's target
-  // picker lists miners (fleet:read + miner:read) plus groups and racks
-  // (rack:read), and the server gates creating or resuming a schedule on the
-  // miner action it performs (reboot / sleep / set power).
+  // schedule:manage lets a role open the Schedules surface, but a schedule is
+  // inert until it can perform an action: the server gates create / update /
+  // resume on the underlying miner action (reboot / sleep / set power).
+  // Selecting one of those actions pulls in its own read floor (miner:read +
+  // fleet:read) via withRequiredReads, and an empty target list already means
+  // "all miners" — so no read is a hard requirement here. rack/miner reads are
+  // only needed for optional rack/group/miner targeting, which the admin can
+  // add if they want it rather than being forced into broader access.
   "schedule:manage": {
-    requires: ["fleet:read", "miner:read", "rack:read"],
     oneOf: [["miner:reboot", "miner:stop_mining", "miner:set_power_target"]],
   },
   // Installing firmware can reboot the device, so the server gates the

--- a/server/internal/domain/authz/catalog.go
+++ b/server/internal/domain/authz/catalog.go
@@ -124,9 +124,9 @@ type CatalogEntry struct {
 // catalog is the canonical list. Order is by resource group then by key,
 // chosen to match the order the admin UI renders.
 var catalog = []CatalogEntry{
-	{PermFleetRead, "View the dashboard, miner list, and live telemetry.", ResourceFleet},
+	{PermFleetRead, "View the dashboard, live telemetry, and fleet diagnostics.", ResourceFleet},
 
-	{PermMinerRead, "View a miner's details, status, and error history.", ResourceMiner},
+	{PermMinerRead, "View a miner's details, status, and the fleet-wide miner list. Required for every other miner action.", ResourceMiner},
 	{PermMinerBlinkLED, "Flash a miner's locator LED.", ResourceMiner},
 	{PermMinerReboot, "Reboot a miner.", ResourceMiner},
 	{PermMinerStartMining, "Start mining on a miner.", ResourceMiner},
@@ -134,48 +134,48 @@ var catalog = []CatalogEntry{
 	{PermMinerUpdatePools, "Change a miner's mining pool configuration.", ResourceMiner},
 	{PermMinerUpdateWorkerName, "Change a miner's worker names.", ResourceMiner},
 	{PermMinerRename, "Rename a miner.", ResourceMiner},
-	{PermMinerDelete, "Delete a miner.", ResourceMiner},
+	{PermMinerDelete, "Delete a miner from the fleet, unpairing the physical device.", ResourceMiner},
 	{PermMinerSetCoolingMode, "Change a miner's cooling mode.", ResourceMiner},
 	{PermMinerSetPowerTarget, "Change a miner's power target.", ResourceMiner},
-	{PermMinerFirmwareUpdate, "Install firmware updates on a miner. Installs can reboot the device, so this also needs reboot access.", ResourceMiner},
+	{PermMinerFirmwareUpdate, "Install firmware on a miner. Installs can reboot the device, so this also needs reboot access.", ResourceMiner},
 	{PermMinerDownloadLogs, "Download diagnostic logs from a miner.", ResourceMiner},
 	{PermMinerUpdatePassword, "Change a miner's local web interface password.", ResourceMiner},
 	{PermMinerUnpair, "Unpair a miner from the fleet.", ResourceMiner},
-	{PermMinerPair, "Pair a new miner into the fleet.", ResourceMiner},
-	{PermMinerExportCSV, "Export miner data as CSV.", ResourceMiner},
+	{PermMinerPair, "Discover, pair, and bulk-import miners into the fleet.", ResourceMiner},
+	{PermMinerExportCSV, "Export the miner list as CSV.", ResourceMiner},
 
-	{PermRackRead, "List racks at a site.", ResourceRack},
-	{PermRackManage, "Create, rename, delete racks and move miners between them.", ResourceRack},
+	{PermRackRead, "View racks and device groups, including their members and layout.", ResourceRack},
+	{PermRackManage, "Create, edit, and delete racks and device groups, and move miners between them.", ResourceRack},
 
 	{PermSiteRead, "View sites and buildings.", ResourceSite},
-	{PermSiteManage, "Create, edit, and delete sites and buildings.", ResourceSite},
+	{PermSiteManage, "Create, edit, and delete sites and buildings, and assign racks and miners to them.", ResourceSite},
 
 	{PermActivityRead, "View the organization-wide activity log and export it as CSV.", ResourceActivity},
 
-	{PermServerlogRead, "View server-side logs.", ResourceServerLog},
+	{PermServerlogRead, "View recent server logs across all organizations.", ResourceServerLog},
 
-	{PermCurtailmentRead, "View curtailment status, events, and policies.", ResourceCurtailment},
-	{PermCurtailmentManage, "Preview, start, stop, and manage curtailment policies.", ResourceCurtailment},
-	{PermCurtailmentIngest, "Accept curtailment dispatch signals from external providers.", ResourceCurtailment},
+	{PermCurtailmentRead, "View curtailment events and active status.", ResourceCurtailment},
+	{PermCurtailmentManage, "Preview, start, stop, and override curtailment events, and manage profiles, automation rules, and dispatch sources.", ResourceCurtailment},
+	{PermCurtailmentIngest, "Accept external curtailment dispatch signals. Not yet implemented.", ResourceCurtailment},
 
 	{PermPoolRead, "View saved mining pool configurations.", ResourcePool},
-	{PermPoolManage, "Create, edit, and delete saved mining pool configurations.", ResourcePool},
+	{PermPoolManage, "Create, edit, delete, and validate saved mining pool configurations. Validation makes the server connect to a supplied address.", ResourcePool},
 
 	{PermScheduleRead, "View scheduled miner actions.", ResourceSchedule},
-	{PermScheduleManage, "Create, edit, pause, resume, and delete scheduled miner actions. Scheduling an action also needs permission to perform that action.", ResourceSchedule},
+	{PermScheduleManage, "Create, edit, pause, resume, reorder, and delete scheduled miner actions. Scheduling an action also needs permission to perform it.", ResourceSchedule},
 
-	{PermFleetnodeRead, "View fleet-node state.", ResourceFleetNode},
-	{PermFleetnodeManage, "Perform fleet-node admin operations.", ResourceFleetNode},
+	{PermFleetnodeRead, "View fleet nodes, their paired miners, and discovered unpaired devices.", ResourceFleetNode},
+	{PermFleetnodeManage, "Enroll, confirm, and revoke fleet nodes, pair miners on them, and run network scans.", ResourceFleetNode},
 
-	{PermAlertRead, "View alert channels, alert rules, silences, and delivery history.", ResourceAlert},
-	{PermAlertManage, "Create, edit, test, and delete alert channels; pause and resume alert rules; create and lift silences.", ResourceAlert},
+	{PermAlertRead, "View alert channels, rules, maintenance windows, and alert history.", ResourceAlert},
+	{PermAlertManage, "Create, edit, test, and delete alert channels; pause and resume alert rules; create, edit, and delete maintenance windows.", ResourceAlert},
 
 	{PermAPIKeyManage, "List, create, and revoke API keys for the organization.", ResourceAPIKey},
 
 	{PermUserRead, "List users in the organization.", ResourceUser},
-	{PermUserManage, "Create, reset, and deactivate users in the organization.", ResourceUser},
+	{PermUserManage, "Create, deactivate, reset passwords, and reassign roles for users in the organization.", ResourceUser},
 
-	{PermRoleManage, "Create, edit, and delete custom roles. Built-in roles cannot be modified.", ResourceRole},
+	{PermRoleManage, "Create, edit, and delete custom roles, and view all roles and permissions. Built-in roles cannot be modified.", ResourceRole},
 }
 
 // AllPermissions returns the canonical permission keys in catalog order. The

--- a/server/internal/domain/authz/catalog.go
+++ b/server/internal/domain/authz/catalog.go
@@ -124,22 +124,22 @@ type CatalogEntry struct {
 // catalog is the canonical list. Order is by resource group then by key,
 // chosen to match the order the admin UI renders.
 var catalog = []CatalogEntry{
-	{PermFleetRead, "View dashboard, miner list, and telemetry. Required floor for any role with miner actions.", ResourceFleet},
+	{PermFleetRead, "View the dashboard, miner list, and live telemetry.", ResourceFleet},
 
-	{PermMinerRead, "View miner detail, status snapshot, and error history. Required floor for any miner action permission.", ResourceMiner},
-	{PermMinerBlinkLED, "Trigger the locator LED on a miner.", ResourceMiner},
+	{PermMinerRead, "View a miner's details, status, and error history.", ResourceMiner},
+	{PermMinerBlinkLED, "Flash a miner's locator LED.", ResourceMiner},
 	{PermMinerReboot, "Reboot a miner.", ResourceMiner},
 	{PermMinerStartMining, "Start mining on a miner.", ResourceMiner},
 	{PermMinerStopMining, "Stop mining on a miner.", ResourceMiner},
-	{PermMinerUpdatePools, "Update a miner's pool configuration.", ResourceMiner},
-	{PermMinerUpdateWorkerName, "Update worker names on a miner.", ResourceMiner},
+	{PermMinerUpdatePools, "Change a miner's mining pool configuration.", ResourceMiner},
+	{PermMinerUpdateWorkerName, "Change a miner's worker names.", ResourceMiner},
 	{PermMinerRename, "Rename a miner.", ResourceMiner},
 	{PermMinerDelete, "Delete a miner.", ResourceMiner},
 	{PermMinerSetCoolingMode, "Change a miner's cooling mode.", ResourceMiner},
 	{PermMinerSetPowerTarget, "Change a miner's power target.", ResourceMiner},
-	{PermMinerFirmwareUpdate, "Push a firmware update to a miner. Firmware dispatch also requires miner:reboot because successful installs may reboot automatically.", ResourceMiner},
+	{PermMinerFirmwareUpdate, "Install firmware updates on a miner. Installs can reboot the device, so this also needs reboot access.", ResourceMiner},
 	{PermMinerDownloadLogs, "Download diagnostic logs from a miner.", ResourceMiner},
-	{PermMinerUpdatePassword, "Change the miner's device-local web UI password.", ResourceMiner},
+	{PermMinerUpdatePassword, "Change a miner's local web interface password.", ResourceMiner},
 	{PermMinerUnpair, "Unpair a miner from the fleet.", ResourceMiner},
 	{PermMinerPair, "Pair a new miner into the fleet.", ResourceMiner},
 	{PermMinerExportCSV, "Export miner data as CSV.", ResourceMiner},
@@ -162,7 +162,7 @@ var catalog = []CatalogEntry{
 	{PermPoolManage, "Create, edit, and delete saved mining pool configurations.", ResourcePool},
 
 	{PermScheduleRead, "View scheduled miner actions.", ResourceSchedule},
-	{PermScheduleManage, "Create, edit, pause, resume, and delete scheduled miner actions. Requires the underlying miner action permission to schedule that action.", ResourceSchedule},
+	{PermScheduleManage, "Create, edit, pause, resume, and delete scheduled miner actions. Scheduling an action also needs permission to perform that action.", ResourceSchedule},
 
 	{PermFleetnodeRead, "View fleet-node state.", ResourceFleetNode},
 	{PermFleetnodeManage, "Perform fleet-node admin operations.", ResourceFleetNode},


### PR DESCRIPTION
## Summary

Fixes a cluster of subtle UX issues in the RBAC roles & permissions views:

1. **Icon alignment** — the built-in-role lock now lines up with the row action menu instead of sitting offset.
2. **Checkbox shrink** — long permission descriptions no longer squeeze the associated checkbox below its fixed size.
3. **Permission copy** — reworded permission descriptions that read like internal docs (dropped "Required floor…", raw permission-key references, "device-local web UI").
4. **Nav gating** — primary nav entries are hidden when the role can't actually reach the page behind them.
5. **Permission dependencies** — the role builder warns when a selection isn't usable on its own (e.g. a "Schedules" role can't create or resume a schedule without miner-action access) and offers to add the missing reads.

## How it works

- **Icon alignment:** the lock placeholder now occupies the same left-aligned `h-8 w-8` box as the ellipsis action trigger, so locks and menus share a baseline across rows.
- **Checkbox shrink:** `shrink-0` on the role-builder checkboxes stops flex from compressing the fixed-size control.
- **Permission copy:** edited the canonical descriptions in `authz/catalog.go`, which project into the `ListPermissions` RPC the role builder renders.
- **Nav gating:** each primary nav item is gated on the permission its page actually needs. `Fleet` → `requiredAnyPermission: ["rack:read", "site:read"]` — the union of `FleetLayout`'s per-tab gates; `fleet:read`/`miner:read` alone unlock no tab, so they would dead-end on the empty shell. `Groups` → `rack:read`, matching the server-side `ListDeviceSets` gate. `Home` stays ungated as the universal landing.
- **Permission dependencies:** a new `FUNCTIONAL_DEPENDENCIES` model in `permissionCatalog.ts`, surfaced via `dependencyGaps(selected)` returning `{ required, chooseOneOf }`. `required` are hard companion reads (`schedule:manage` → `fleet:read` + `miner:read` + `rack:read`; `miner:firmware_update` → `miner:reboot`) that the "Add required permissions" button grants in one click. `chooseOneOf` are "grant at least one" sets (`schedule:manage` → reboot / sleep / set-power) shown as guidance only and never auto-added, so a role isn't handed every sensitive miner action at once. The client model mirrors — but never replaces — the server gates; saving an under-powered role is still allowed.

## Diagram

```mermaid
flowchart TD
    A[Admin selects schedule:manage] --> B{Missing dependencies?}
    B -- hard reads missing --> C[Warning Callout lists them<br/>+ 'Add required permissions']
    C --> D[Click adds fleet:read +<br/>miner:read + rack:read only]
    B -- action set unsatisfied --> E[Callout: choose at least one<br/>reboot / sleep / set-power — no auto-add]
    B -- satisfied --> F[No warning]
    D --> F
```

## Areas of the code involved

- `client/.../settings/components/Roles.tsx` — lock icon alignment
- `client/.../settings/components/CreateEditRoleModal.tsx` — checkbox `shrink-0` + dependency warning Callout
- `client/.../settings/utils/permissionCatalog.ts` — `FUNCTIONAL_DEPENDENCIES` + `dependencyGaps()`
- `client/.../config/navItems.ts` — Fleet/Groups nav gates
- `server/internal/domain/authz/catalog.go` — permission description copy
- Tests: new `permissionCatalog.test.ts`; extended `navItems.test.ts`

## Key technical decisions & trade-offs

- **Highlight, don't auto-grant sensitive actions.** The one-click add only grants read companions; the miner actions a schedule performs stay a deliberate per-action choice, so a scheduling role never silently gains reboot/stop/power authority.
- **Gate nav on real reachability.** Fleet/Groups gates mirror the server and `FleetLayout` tab gates rather than a blanket `fleet:read`, so no role sees a nav entry that dead-ends on an empty shell, and rack/site readers keep their path in.
- **Home stays ungated** as the safe universal landing; its widgets already degrade per-permission.
- **Copy lives server-side** in `catalog.go` (the single source for `ListPermissions`); no migration needed since descriptions aren't persisted.

## Testing & validation

- `just lint` clean (buf, eslint, golangci-lint — 0 issues).
- Client: `permissionCatalog.test.ts` (`dependencyGaps`), `navItems.test.ts` (Fleet/Groups gating + Home ungated), and `Roles.test.tsx` — 18 tests green; `tsc --noEmit` clean; lefthook pre-commit/pre-push hooks passed.
- Server: `authz` catalog tests pass (`go test -run 'TestCatalog|…' -short`). The full `authz` package run times out locally on `TestReconcile_SuperAdminTamperingRepaired` (a DB-backed integration test needing the test database) — unrelated to this diff (the server change is description-only); runs in CI.
- Not run: E2E (docker-compose). **Manual follow-up:** verify the lock alignment and dependency Callout render correctly in-browser.