### PR TITLE
Fix large-fleet uptime history timeouts

### DIFF
--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
@@ -12,6 +12,7 @@ import {
   BuildingWithCountsSchema,
 } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { SiteSchema, type SiteWithCounts, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 
@@ -19,6 +20,7 @@ const getBuildingMock = vi.hoisted(() => vi.fn());
 const listAllBuildingsMock = vi.hoisted(() => vi.fn());
 const listBuildingRacksMock = vi.hoisted(() => vi.fn());
 const listSitesMock = vi.hoisted(() => vi.fn());
+const mockUseTelemetryMetrics = vi.hoisted(() => vi.fn());
 
 vi.mock("@/protoFleet/api/buildings", () => ({
   useBuildings: () => ({
@@ -94,7 +96,7 @@ vi.mock("@/protoFleet/api/useComponentErrors", () => ({
 }));
 
 vi.mock("@/protoFleet/api/useTelemetryMetrics", () => ({
-  useTelemetryMetrics: () => ({ data: { metrics: [] } }),
+  useTelemetryMetrics: (options: unknown) => mockUseTelemetryMetrics(options),
 }));
 
 vi.mock("@/protoFleet/features/buildings/components/BuildingModals", () => ({
@@ -141,6 +143,7 @@ const renderPage = (initialEntry = "/buildings/123") =>
 describe("BuildingPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseTelemetryMetrics.mockReturnValue({ data: { metrics: [] } });
     useFleetStore.setState((state) => {
       state.ui.activeSite = DEFAULT_ACTIVE_SITE;
     });
@@ -223,5 +226,17 @@ describe("BuildingPage", () => {
     fireEvent.click(screen.getByTestId("building-page-view-miners"));
 
     expect(screen.getByTestId("location-probe")).toHaveTextContent("/fleet/miners?building=123");
+  });
+
+  it("does not request uptime telemetry for building performance charts", async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(mockUseTelemetryMetrics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          measurementTypes: expect.not.arrayContaining([MeasurementType.UPTIME]),
+        }),
+      ),
+    );
   });
 });

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -38,7 +38,6 @@ const ALL_MEASUREMENT_TYPES: MeasurementType[] = [
   MeasurementType.POWER,
   MeasurementType.TEMPERATURE,
   MeasurementType.EFFICIENCY,
-  MeasurementType.UPTIME,
 ];
 
 const ALL_AGGREGATION_TYPES: AggregationType[] = [AggregationType.AVERAGE, AggregationType.MIN, AggregationType.MAX];

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event";
 
 import RackOverviewPage from "./RackOverviewPage";
 import { DeviceSetSchema } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 
@@ -47,7 +48,7 @@ vi.mock("@/protoFleet/api/useDeviceSetStateCounts", () => ({
 }));
 
 vi.mock("@/protoFleet/api/useTelemetryMetrics", () => ({
-  useTelemetryMetrics: () => mockUseTelemetryMetrics(),
+  useTelemetryMetrics: (options: unknown) => mockUseTelemetryMetrics(options),
 }));
 
 vi.mock("@/protoFleet/api/useComponentErrors", () => ({
@@ -135,6 +136,7 @@ function mockResolvedRackPageData(
     allBuildings?: unknown[];
     sites?: unknown[];
     allRacks?: unknown[];
+    memberDeviceIds?: string[];
   } = {},
 ): void {
   mockUseParams.mockReturnValue({ rackId: "7" });
@@ -147,7 +149,8 @@ function mockResolvedRackPageData(
   });
   mockUseDeviceSets.mockReturnValue({
     getDeviceSet: ({ onSuccess }: { onSuccess: (resolvedDeviceSet: typeof rack) => void }) => onSuccess(deviceSet),
-    listGroupMembers: ({ onSuccess }: { onSuccess: (deviceIds: string[]) => void }) => onSuccess([]),
+    listGroupMembers: ({ onSuccess }: { onSuccess: (deviceIds: string[]) => void }) =>
+      onSuccess(options.memberDeviceIds ?? []),
     assignDevicesToRack: vi.fn(),
     listRacks: listRacksMock,
     setRackSlotPosition: vi.fn(),
@@ -303,5 +306,20 @@ describe("RackOverviewPage", () => {
     renderRackOverviewPage();
 
     expect(await screen.findByTestId("rack-page-breadcrumb-link-0")).toHaveAttribute("href", "/unassigned/fleet/racks");
+  });
+
+  it("does not request uptime telemetry for rack performance charts", async () => {
+    mockResolvedRackPageData(rack, { memberDeviceIds: ["miner-a"] });
+
+    renderRackOverviewPage();
+
+    await waitFor(() =>
+      expect(mockUseTelemetryMetrics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          measurementTypes: expect.not.arrayContaining([MeasurementType.UPTIME]),
+        }),
+      ),
+    );
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -45,7 +45,6 @@ const ALL_MEASUREMENT_TYPES: MeasurementType[] = [
   MeasurementType.POWER,
   MeasurementType.TEMPERATURE,
   MeasurementType.EFFICIENCY,
-  MeasurementType.UPTIME,
 ];
 
 const ALL_AGGREGATION_TYPES: AggregationType[] = [AggregationType.AVERAGE, AggregationType.MIN, AggregationType.MAX];

--- a/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.test.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.test.tsx
@@ -1,0 +1,154 @@
+import { MemoryRouter } from "react-router-dom";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import GroupOverviewPage from "./GroupOverviewPage";
+import { DeviceSetSchema, DeviceSetType } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
+import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
+
+const mockUseParams = vi.fn();
+const mockNavigate = vi.fn();
+const mockUseTelemetryMetrics = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+  };
+});
+
+vi.mock("@/protoFleet/api/useDeviceSets", () => ({
+  useDeviceSets: () => ({
+    listGroups: ({ onSuccess }: { onSuccess: (groups: unknown[]) => void }) =>
+      onSuccess([
+        create(DeviceSetSchema, {
+          id: 11n,
+          type: DeviceSetType.GROUP,
+          label: "Ops",
+        }),
+      ]),
+    listGroupMembers: ({ onSuccess }: { onSuccess: (deviceIds: string[]) => void }) => onSuccess(["miner-a"]),
+  }),
+}));
+
+vi.mock("@/protoFleet/api/useComponentErrors", () => ({
+  useComponentErrors: () => ({
+    controlBoardErrors: [],
+    fanErrors: [],
+    hashboardErrors: [],
+    psuErrors: [],
+  }),
+}));
+
+vi.mock("@/protoFleet/api/useDeviceSetStateCounts", () => ({
+  useDeviceSetStateCounts: () => ({
+    totalMiners: 1,
+    stateCounts: {
+      hashingCount: 1,
+      brokenCount: 0,
+      offlineCount: 0,
+      sleepingCount: 0,
+    },
+    hasLoaded: true,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/protoFleet/api/useTelemetryMetrics", () => ({
+  useTelemetryMetrics: (options: unknown) => mockUseTelemetryMetrics(options),
+}));
+
+vi.mock("@/protoFleet/features/groupManagement/components/DeviceSetActionsMenu", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+vi.mock("@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection", () => ({
+  DeviceSetPerformanceSection: () => <div>Performance section</div>,
+}));
+
+vi.mock("@/protoFleet/features/groupManagement/components/FleetHealth", () => ({
+  __esModule: true,
+  default: () => <div>Fleet health</div>,
+}));
+
+vi.mock("@/protoFleet/features/groupManagement/components/GroupModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/protoFleet/features/kpis/components/FleetErrors", () => ({
+  __esModule: true,
+  default: () => <div>Fleet errors</div>,
+}));
+
+vi.mock("@/protoFleet/store", () => ({
+  useDuration: () => "12h",
+  useSetDuration: () => vi.fn(),
+}));
+
+vi.mock("@/shared/assets/icons", () => ({
+  ChevronDown: ({ className }: { className?: string }) => <svg aria-hidden="true" className={className} />,
+}));
+
+vi.mock("@/shared/components/DurationSelector", () => ({
+  __esModule: true,
+  default: () => <div>Duration selector</div>,
+  fleetDurations: [],
+}));
+
+vi.mock("@/shared/components/ProgressCircular", () => ({
+  __esModule: true,
+  default: () => <div>Loading</div>,
+}));
+
+vi.mock("@/shared/hooks/useNavigate", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@/shared/hooks/useStickyState", () => ({
+  useStickyState: () => ({
+    refs: {
+      vertical: {
+        start: { current: null },
+        end: { current: null },
+      },
+    },
+  }),
+}));
+
+describe("GroupOverviewPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseParams.mockReturnValue({ groupLabel: "Ops" });
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = DEFAULT_ACTIVE_SITE;
+    });
+    mockUseTelemetryMetrics.mockReturnValue({
+      data: {
+        metrics: [],
+      },
+    });
+  });
+
+  it("does not request uptime telemetry for group performance charts", async () => {
+    render(
+      <MemoryRouter>
+        <GroupOverviewPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(mockUseTelemetryMetrics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          measurementTypes: expect.not.arrayContaining([MeasurementType.UPTIME]),
+        }),
+      ),
+    );
+  });
+});

--- a/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
@@ -29,7 +29,6 @@ const ALL_MEASUREMENT_TYPES: MeasurementType[] = [
   MeasurementType.POWER,
   MeasurementType.TEMPERATURE,
   MeasurementType.EFFICIENCY,
-  MeasurementType.UPTIME,
 ];
 
 const ALL_AGGREGATION_TYPES: AggregationType[] = [AggregationType.AVERAGE, AggregationType.MIN, AggregationType.MAX];

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -576,6 +576,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getMinerStateCountsByDeviceIDsStmt, err = db.PrepareContext(ctx, getMinerStateCountsByDeviceIDs); err != nil {
 		return nil, fmt.Errorf("error preparing query GetMinerStateCountsByDeviceIDs: %w", err)
 	}
+	if q.getMinerStateSnapshotCountsStmt, err = db.PrepareContext(ctx, getMinerStateSnapshotCounts); err != nil {
+		return nil, fmt.Errorf("error preparing query GetMinerStateSnapshotCounts: %w", err)
+	}
 	if q.getMinerStateSnapshotsStmt, err = db.PrepareContext(ctx, getMinerStateSnapshots); err != nil {
 		return nil, fmt.Errorf("error preparing query GetMinerStateSnapshots: %w", err)
 	}
@@ -2284,6 +2287,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getMinerStateCountsByDeviceIDsStmt: %w", cerr)
 		}
 	}
+	if q.getMinerStateSnapshotCountsStmt != nil {
+		if cerr := q.getMinerStateSnapshotCountsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getMinerStateSnapshotCountsStmt: %w", cerr)
+		}
+	}
 	if q.getMinerStateSnapshotsStmt != nil {
 		if cerr := q.getMinerStateSnapshotsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getMinerStateSnapshotsStmt: %w", cerr)
@@ -3812,6 +3820,7 @@ type Queries struct {
 	getMinerCredentialsByDeviceIDStmt                          *sql.Stmt
 	getMinerModelGroupsStmt                                    *sql.Stmt
 	getMinerStateCountsByDeviceIDsStmt                         *sql.Stmt
+	getMinerStateSnapshotCountsStmt                            *sql.Stmt
 	getMinerStateSnapshotsStmt                                 *sql.Stmt
 	getOfflineDevicesStmt                                      *sql.Stmt
 	getOpenErrorByDedupKeyStmt                                 *sql.Stmt
@@ -4263,6 +4272,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getMinerCredentialsByDeviceIDStmt:                          q.getMinerCredentialsByDeviceIDStmt,
 		getMinerModelGroupsStmt:                                    q.getMinerModelGroupsStmt,
 		getMinerStateCountsByDeviceIDsStmt:                         q.getMinerStateCountsByDeviceIDsStmt,
+		getMinerStateSnapshotCountsStmt:                            q.getMinerStateSnapshotCountsStmt,
 		getMinerStateSnapshotsStmt:                                 q.getMinerStateSnapshotsStmt,
 		getOfflineDevicesStmt:                                      q.getOfflineDevicesStmt,
 		getOpenErrorByDedupKeyStmt:                                 q.getOpenErrorByDedupKeyStmt,

--- a/server/generated/sqlc/miner_state_snapshots.sql.go
+++ b/server/generated/sqlc/miner_state_snapshots.sql.go
@@ -13,6 +13,99 @@ import (
 	"github.com/lib/pq"
 )
 
+const getMinerStateSnapshotCounts = `-- name: GetMinerStateSnapshotCounts :many
+WITH scoped_counts AS (
+    SELECT
+        snapshot_time,
+        SUM(hashing_count)::int AS hashing_count,
+        SUM(broken_count)::int AS broken_count,
+        SUM(offline_count)::int AS offline_count,
+        SUM(sleeping_count)::int AS sleeping_count
+    FROM miner_state_snapshot_counts_1m
+    WHERE org_id = $1
+      AND snapshot_time >= $2
+      AND snapshot_time <= $3
+      AND (
+          (cardinality(COALESCE($4::bigint[], '{}')) = 0
+           AND $5::boolean = false)
+          OR site_id = ANY(COALESCE($4::bigint[], '{}'))
+          OR ($5::boolean AND site_id IS NULL)
+      )
+    GROUP BY snapshot_time
+),
+latest_per_bucket AS (
+    SELECT DISTINCT ON (time_bucket($6::text::interval, scoped_counts.snapshot_time))
+        time_bucket($6::text::interval, scoped_counts.snapshot_time)::timestamptz AS bucket,
+        hashing_count,
+        broken_count,
+        offline_count,
+        sleeping_count
+    FROM scoped_counts
+    ORDER BY time_bucket($6::text::interval, scoped_counts.snapshot_time), scoped_counts.snapshot_time DESC
+)
+SELECT
+    bucket,
+    hashing_count,
+    broken_count,
+    offline_count,
+    sleeping_count
+FROM latest_per_bucket
+ORDER BY bucket ASC
+`
+
+type GetMinerStateSnapshotCountsParams struct {
+	OrgID             int64
+	StartTime         time.Time
+	EndTime           time.Time
+	SiteIds           []int64
+	IncludeUnassigned bool
+	BucketInterval    string
+}
+
+type GetMinerStateSnapshotCountsRow struct {
+	Bucket        time.Time
+	HashingCount  int32
+	BrokenCount   int32
+	OfflineCount  int32
+	SleepingCount int32
+}
+
+func (q *Queries) GetMinerStateSnapshotCounts(ctx context.Context, arg GetMinerStateSnapshotCountsParams) ([]GetMinerStateSnapshotCountsRow, error) {
+	rows, err := q.query(ctx, q.getMinerStateSnapshotCountsStmt, getMinerStateSnapshotCounts,
+		arg.OrgID,
+		arg.StartTime,
+		arg.EndTime,
+		pq.Array(arg.SiteIds),
+		arg.IncludeUnassigned,
+		arg.BucketInterval,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetMinerStateSnapshotCountsRow
+	for rows.Next() {
+		var i GetMinerStateSnapshotCountsRow
+		if err := rows.Scan(
+			&i.Bucket,
+			&i.HashingCount,
+			&i.BrokenCount,
+			&i.OfflineCount,
+			&i.SleepingCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getMinerStateSnapshots = `-- name: GetMinerStateSnapshots :many
 WITH per_device_bucket AS (
     SELECT DISTINCT ON (time_bucket($1::text::interval, time), device_identifier)
@@ -94,11 +187,12 @@ func (q *Queries) GetMinerStateSnapshots(ctx context.Context, arg GetMinerStateS
 }
 
 const insertMinerStateSnapshot = `-- name: InsertMinerStateSnapshot :exec
-INSERT INTO miner_state_snapshots (time, org_id, site_id, device_identifier, state)
+INSERT INTO miner_state_snapshots (time, org_id, site_id, building_id, device_identifier, state)
 SELECT
     $1::timestamptz,
     d.org_id,
     d.site_id,
+    d.building_id,
     d.device_identifier,
     CASE
         WHEN ds.status = 'OFFLINE'

--- a/server/generated/sqlc/models.go
+++ b/server/generated/sqlc/models.go
@@ -865,6 +865,19 @@ type MinerStateSnapshot struct {
 	DeviceIdentifier string
 	State            int16
 	SiteID           sql.NullInt64
+	BuildingID       sql.NullInt64
+}
+
+type MinerStateSnapshotCounts1m struct {
+	Bucket        time.Time
+	SnapshotTime  time.Time
+	OrgID         int64
+	SiteID        sql.NullInt64
+	BuildingID    sql.NullInt64
+	HashingCount  int32
+	BrokenCount   int32
+	OfflineCount  int32
+	SleepingCount int32
 }
 
 type NotificationActive struct {

--- a/server/internal/domain/telemetry/models/queries.go
+++ b/server/internal/domain/telemetry/models/queries.go
@@ -48,6 +48,21 @@ type CombinedMetricsQuery struct {
 	IncludeUnassigned bool `json:"include_unassigned,omitempty"`
 }
 
+// ShouldIncludeUptimeStatusCounts reports whether a CombinedMetrics response
+// should include uptime status counts. Empty measurement filters preserve the
+// historical default response shape.
+func ShouldIncludeUptimeStatusCounts(measurementTypes []MeasurementType) bool {
+	if len(measurementTypes) == 0 {
+		return true
+	}
+	for _, measurementType := range measurementTypes {
+		if measurementType == MeasurementTypeUptime {
+			return true
+		}
+	}
+	return false
+}
+
 type StreamCombinedMetricsQuery struct {
 	DeviceIDs        []DeviceIdentifier `json:"device_ids,omitempty"`
 	MeasurementTypes []MeasurementType  `json:"measurement_types,omitempty"`

--- a/server/internal/domain/telemetry/models/queries.go
+++ b/server/internal/domain/telemetry/models/queries.go
@@ -33,6 +33,11 @@ type CombinedMetricsQuery struct {
 	PageSize         int                `json:"page_size,omitempty"`
 	SlideInterval    *time.Duration     `json:"slide_interval,omitempty"`
 	OrganizationID   int64              `json:"organization_id,omitempty"`
+	// ExplicitDeviceIDs is true when DeviceIDs came from a caller-supplied
+	// DeviceList selector. It stays false when the service resolves a site
+	// scope into DeviceIDs for metric queries, allowing uptime history to use
+	// site-scoped aggregate rows instead of the raw arbitrary-selector path.
+	ExplicitDeviceIDs bool `json:"explicit_device_ids,omitempty"`
 	// SiteIDs scopes metrics to devices assigned to ANY of these sites (OR),
 	// AND'd with DeviceIDs. Empty + IncludeUnassigned=false applies no site
 	// restriction. Scope is by current site membership: the service resolves

--- a/server/internal/domain/telemetry/models/queries_test.go
+++ b/server/internal/domain/telemetry/models/queries_test.go
@@ -1,0 +1,41 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldIncludeUptimeStatusCounts(t *testing.T) {
+	tests := []struct {
+		name             string
+		measurementTypes []MeasurementType
+		expected         bool
+	}{
+		{
+			name:     "nil measurement list preserves default uptime counts",
+			expected: true,
+		},
+		{
+			name:             "empty measurement list preserves default uptime counts",
+			measurementTypes: []MeasurementType{},
+			expected:         true,
+		},
+		{
+			name:             "explicit non-uptime measurements skip uptime counts",
+			measurementTypes: []MeasurementType{MeasurementTypeHashrate, MeasurementTypePower},
+			expected:         false,
+		},
+		{
+			name:             "explicit uptime measurement includes uptime counts",
+			measurementTypes: []MeasurementType{MeasurementTypeHashrate, MeasurementTypeUptime},
+			expected:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ShouldIncludeUptimeStatusCounts(tt.measurementTypes))
+		})
+	}
+}

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -1483,11 +1483,15 @@ func (s *TelemetryService) StreamDeviceStatusUpdates(ctx context.Context, query 
 }
 
 func (s *TelemetryService) GetCombinedMetrics(ctx context.Context, query models.CombinedMetricsQuery) (models.CombinedMetric, error) {
+	explicitDeviceIDs := query.ExplicitDeviceIDs || len(query.DeviceIDs) > 0
+	query.ExplicitDeviceIDs = explicitDeviceIDs
+
 	// Site scope is applied by resolving the in-scope device identifiers and
-	// feeding the existing device-list paths: the telemetry continuous
-	// aggregates have no site_id column, so we cannot filter them directly.
-	// This scopes line metrics, status counts, and the live uptime bar
-	// uniformly to the site's current devices.
+	// feeding the existing device-list paths for line metrics/status counts.
+	// query.ExplicitDeviceIDs keeps track of whether DeviceIDs came from the
+	// caller or from this scope resolution; uptime history can use site-scoped
+	// aggregate rows for the latter but must keep exact raw selector semantics
+	// for the former.
 	if len(query.SiteIDs) > 0 || query.IncludeUnassigned {
 		identifiers, err := s.deviceStore.GetDeviceIdentifiersByOrgWithFilter(ctx, query.OrganizationID, &stores.MinerFilter{
 			SiteIDs:           query.SiteIDs,
@@ -1653,12 +1657,13 @@ func (s *TelemetryService) StreamCombinedMetrics(ctx context.Context, query mode
 
 func (s *TelemetryService) sendCombinedMetricUpdate(ctx context.Context, updateChan chan<- models.CombinedMetric, query models.StreamCombinedMetricsQuery, updateInterval time.Duration) error {
 	combinedQuery := models.CombinedMetricsQuery{
-		DeviceIDs:        query.DeviceIDs,
-		MeasurementTypes: query.MeasurementTypes,
-		AggregationTypes: query.AggregationTypes,
-		SlideInterval:    &query.Granularity,
-		PageSize:         defaultCombinedMetricsPageSize,
-		OrganizationID:   query.OrganizationID,
+		DeviceIDs:         query.DeviceIDs,
+		MeasurementTypes:  query.MeasurementTypes,
+		AggregationTypes:  query.AggregationTypes,
+		SlideInterval:     &query.Granularity,
+		PageSize:          defaultCombinedMetricsPageSize,
+		OrganizationID:    query.OrganizationID,
+		ExplicitDeviceIDs: len(query.DeviceIDs) > 0,
 	}
 
 	now := time.Now()

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -1522,7 +1522,9 @@ func (s *TelemetryService) GetCombinedMetrics(ctx context.Context, query models.
 	if err != nil {
 		return result, err
 	}
-	s.appendLiveUptimeBar(ctx, query.OrganizationID, query.DeviceIDs, &result)
+	if models.ShouldIncludeUptimeStatusCounts(query.MeasurementTypes) {
+		s.appendLiveUptimeBar(ctx, query.OrganizationID, query.DeviceIDs, &result)
+	}
 	return result, nil
 }
 
@@ -1706,7 +1708,9 @@ func (s *TelemetryService) sendCombinedMetricUpdate(ctx context.Context, updateC
 		}
 	}
 
-	s.appendLiveUptimeBar(ctx, query.OrganizationID, query.DeviceIDs, &combinedMetrics)
+	if models.ShouldIncludeUptimeStatusCounts(query.MeasurementTypes) {
+		s.appendLiveUptimeBar(ctx, query.OrganizationID, query.DeviceIDs, &combinedMetrics)
+	}
 
 	select {
 	case updateChan <- combinedMetrics:

--- a/server/internal/domain/telemetry/service_test.go
+++ b/server/internal/domain/telemetry/service_test.go
@@ -3254,6 +3254,69 @@ func TestService_GetCombinedMetrics_ReturnsRawValues(t *testing.T) {
 	}
 }
 
+func TestService_GetCombinedMetrics_GatesLiveUptimeBar(t *testing.T) {
+	t.Run("skips live state counts when uptime is not requested", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockDataStore := mock.NewMockTelemetryDataStore(ctrl)
+		mockDeviceStore := storesMocks.NewMockDeviceStore(ctrl)
+		service := NewTelemetryService(Config{}, mockDataStore, nil, nil, mockDeviceStore, mock.NewMockErrorPoller(ctrl))
+
+		mockDataStore.EXPECT().
+			GetCombinedMetrics(gomock.Any(), gomock.Any()).
+			Return(models.CombinedMetric{Metrics: []models.Metric{}}, nil)
+		mockDeviceStore.EXPECT().GetMinerStateCounts(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		result, err := service.GetCombinedMetrics(t.Context(), models.CombinedMetricsQuery{
+			OrganizationID:    42,
+			DeviceIDs:         []models.DeviceIdentifier{"device-a"},
+			MeasurementTypes:  []models.MeasurementType{models.MeasurementTypeHashrate},
+			AggregationTypes:  []models.AggregationType{models.AggregationTypeAverage},
+			ExplicitDeviceIDs: true,
+		})
+
+		require.NoError(t, err)
+		assert.Nil(t, result.MinerStateCounts)
+		assert.Empty(t, result.UptimeStatusCounts)
+	})
+
+	t.Run("appends live state counts when uptime is requested", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockDataStore := mock.NewMockTelemetryDataStore(ctrl)
+		mockDeviceStore := storesMocks.NewMockDeviceStore(ctrl)
+		service := NewTelemetryService(Config{}, mockDataStore, nil, nil, mockDeviceStore, mock.NewMockErrorPoller(ctrl))
+
+		deviceIDs := []models.DeviceIdentifier{"device-a"}
+		mockDataStore.EXPECT().
+			GetCombinedMetrics(gomock.Any(), gomock.Any()).
+			Return(models.CombinedMetric{Metrics: []models.Metric{}}, nil)
+		mockDeviceStore.EXPECT().
+			GetMinerStateCounts(gomock.Any(), int64(42), &stores.MinerFilter{DeviceIdentifiers: []string{"device-a"}}).
+			Return(&telemetryv1.MinerStateCounts{
+				HashingCount: 2,
+				OfflineCount: 1,
+			}, nil)
+
+		result, err := service.GetCombinedMetrics(t.Context(), models.CombinedMetricsQuery{
+			OrganizationID:    42,
+			DeviceIDs:         deviceIDs,
+			MeasurementTypes:  []models.MeasurementType{models.MeasurementTypeHashrate, models.MeasurementTypeUptime},
+			AggregationTypes:  []models.AggregationType{models.AggregationTypeAverage},
+			ExplicitDeviceIDs: true,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, result.MinerStateCounts)
+		assert.Equal(t, int32(2), result.MinerStateCounts.Hashing)
+		require.Len(t, result.UptimeStatusCounts, 1)
+		assert.Equal(t, int32(2), result.UptimeStatusCounts[0].HashingCount)
+		assert.Equal(t, int32(1), result.UptimeStatusCounts[0].NotHashingCount)
+	})
+}
+
 func TestPersistFirmwareVersionIfChanged(t *testing.T) {
 	const deviceID = models.DeviceIdentifier("device-1")
 	const firmwareV1 = "1.2.3"
@@ -3422,6 +3485,41 @@ func TestSendCombinedMetricUpdate_DeviceScopedMinerStateCounts(t *testing.T) {
 		assert.Equal(t, int32(2), result.MinerStateCounts.Broken)
 		assert.Equal(t, int32(1), result.MinerStateCounts.Offline)
 		assert.Equal(t, int32(3), result.MinerStateCounts.Sleeping)
+	})
+
+	t.Run("explicit non-uptime measurements skip MinerStateCounts", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockDataStore := mock.NewMockTelemetryDataStore(ctrl)
+		mockDeviceStore := storesMocks.NewMockDeviceStore(ctrl)
+
+		service := NewTelemetryService(Config{
+			StalenessThreshold: 1 * time.Minute,
+			FetchInterval:      10 * time.Second,
+			ConcurrencyLimit:   5,
+		}, mockDataStore, nil, nil, mockDeviceStore, nil)
+
+		query := models.StreamCombinedMetricsQuery{
+			DeviceIDs:        []models.DeviceIdentifier{"device-a"},
+			MeasurementTypes: []models.MeasurementType{models.MeasurementTypeHashrate},
+			Granularity:      5 * time.Minute,
+			UpdateInterval:   5 * time.Minute,
+			OrganizationID:   42,
+		}
+
+		mockDataStore.EXPECT().
+			GetCombinedMetrics(gomock.Any(), gomock.Any()).
+			Return(models.CombinedMetric{Metrics: []models.Metric{}}, nil)
+		mockDeviceStore.EXPECT().GetMinerStateCounts(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		updateChan := make(chan models.CombinedMetric, 1)
+		err := service.sendCombinedMetricUpdate(t.Context(), updateChan, query, 5*time.Minute)
+		require.NoError(t, err)
+
+		result := <-updateChan
+		assert.Nil(t, result.MinerStateCounts)
+		assert.Empty(t, result.UptimeStatusCounts)
 	})
 }
 

--- a/server/internal/domain/telemetry/site_scope_test.go
+++ b/server/internal/domain/telemetry/site_scope_test.go
@@ -45,6 +45,7 @@ func TestGetCombinedMetrics_SiteScope(t *testing.T) {
 			GetCombinedMetrics(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ any, q models.CombinedMetricsQuery) (models.CombinedMetric, error) {
 				assert.Equal(t, []models.DeviceIdentifier{"device-a", "device-b"}, q.DeviceIDs)
+				assert.False(t, q.ExplicitDeviceIDs)
 				return models.CombinedMetric{Metrics: []models.Metric{}}, nil
 			})
 
@@ -124,6 +125,7 @@ func TestGetCombinedMetrics_SiteScope(t *testing.T) {
 			GetCombinedMetrics(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ any, q models.CombinedMetricsQuery) (models.CombinedMetric, error) {
 				assert.Equal(t, []models.DeviceIdentifier{"device-a"}, q.DeviceIDs)
+				assert.True(t, q.ExplicitDeviceIDs)
 				return models.CombinedMetric{}, nil
 			})
 		deviceStore.EXPECT().

--- a/server/internal/handlers/telemetry/conversion.go
+++ b/server/internal/handlers/telemetry/conversion.go
@@ -81,12 +81,14 @@ var (
 
 func toCombinedMetricsQuery(req *telemetryv1.GetCombinedMetricsRequest) (models.CombinedMetricsQuery, error) {
 	var deviceIDs []models.DeviceIdentifier
+	var explicitDeviceIDs bool
 
 	if req.DeviceSelector != nil {
 		switch selector := req.DeviceSelector.SelectorValue.(type) {
 		case *telemetryv1.DeviceSelector_AllDevices:
 			deviceIDs = []models.DeviceIdentifier{}
 		case *telemetryv1.DeviceSelector_DeviceList:
+			explicitDeviceIDs = true
 			if selector.DeviceList != nil {
 				deviceIDs = models.ToDeviceIdentifiers(selector.DeviceList.DeviceIds)
 			}
@@ -135,6 +137,7 @@ func toCombinedMetricsQuery(req *telemetryv1.GetCombinedMetricsRequest) (models.
 		PageSize:          pageSize,
 		SiteIDs:           req.SiteIds,
 		IncludeUnassigned: req.IncludeUnassigned,
+		ExplicitDeviceIDs: explicitDeviceIDs,
 	}
 
 	return query, nil

--- a/server/internal/infrastructure/timescaledb/aggregation_test.go
+++ b/server/internal/infrastructure/timescaledb/aggregation_test.go
@@ -152,7 +152,7 @@ func TestAggregateMetrics_CumulativeVsNonCumulative(t *testing.T) {
 	}
 	aggTypes := []models.AggregationType{models.AggregationTypeAverage}
 
-	result := store.aggregateMetrics(data, measurementTypes, aggTypes, 10*time.Second)
+	result := store.aggregateMetrics(data, measurementTypes, aggTypes, 10*time.Second, true)
 
 	// Find hashrate and temperature metrics
 	var hashrateAvg, tempAvg float64
@@ -718,7 +718,7 @@ func TestCalculateTemperatureStatusCount_FallsBackToEarlierTempSample(t *testing
 }
 
 func TestLatestSamplesForStatusCounts_Empty(t *testing.T) {
-	uptime, temp := latestSamplesForStatusCounts(nil)
+	uptime, temp := latestSamplesForStatusCounts(nil, true)
 	assert.Nil(t, uptime)
 	assert.Nil(t, temp)
 }
@@ -734,7 +734,7 @@ func TestLatestSamplesForStatusCounts_DivergentLatest(t *testing.T) {
 		{DeviceIdentifier: "miner-a", Timestamp: now.Add(30 * time.Second), Health: modelsV2.HealthHealthyActive},
 	}
 
-	uptime, temp := latestSamplesForStatusCounts(data)
+	uptime, temp := latestSamplesForStatusCounts(data, true)
 
 	require.Len(t, uptime, 1)
 	assert.Equal(t, now.Add(30*time.Second), uptime[0].Timestamp, "uptime view uses absolute latest")
@@ -742,5 +742,19 @@ func TestLatestSamplesForStatusCounts_DivergentLatest(t *testing.T) {
 	require.Len(t, temp, 1)
 	require.NotNil(t, temp[0].TempC)
 	assert.Equal(t, 70.0, temp[0].TempC.Value, "temp view uses latest sample with TempC")
+	assert.Equal(t, now, temp[0].Timestamp)
+}
+
+func TestLatestSamplesForStatusCounts_SkipsUptimeWhenNotRequested(t *testing.T) {
+	now := time.Now()
+	data := []modelsV2.DeviceMetrics{
+		{DeviceIdentifier: "miner-a", Timestamp: now, Health: modelsV2.HealthHealthyActive, TempC: &modelsV2.MetricValue{Value: 70}},
+		{DeviceIdentifier: "miner-a", Timestamp: now.Add(30 * time.Second), Health: modelsV2.HealthWarning},
+	}
+
+	uptime, temp := latestSamplesForStatusCounts(data, false)
+
+	assert.Nil(t, uptime)
+	require.Len(t, temp, 1)
 	assert.Equal(t, now, temp[0].Timestamp)
 }

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -665,6 +665,12 @@ func (s *TimescaleTelemetryStore) uptimeCountsForQuery(ctx context.Context, quer
 	if query.OrganizationID == 0 {
 		return nil
 	}
+	if !query.ExplicitDeviceIDs {
+		if counts := s.getUptimeStatusCountsFromSnapshotCounts(ctx, query, startTime, endTime, bucketDuration); len(counts) > 0 {
+			return counts
+		}
+		return nil
+	}
 	return s.getUptimeStatusCountsFromSnapshots(ctx, query.OrganizationID, query.DeviceIDs, startTime, endTime, bucketDuration)
 }
 
@@ -1265,6 +1271,55 @@ func (s *TimescaleTelemetryStore) getUptimeStatusCountsFromSnapshots(
 		return nil
 	}
 
+	if len(rows) == 0 {
+		return nil
+	}
+
+	result := make([]models.UptimeStatusCount, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, models.UptimeStatusCount{
+			Timestamp:       row.Bucket,
+			HashingCount:    row.HashingCount,
+			BrokenCount:     row.BrokenCount,
+			NotHashingCount: row.OfflineCount + row.SleepingCount,
+		})
+	}
+	return result
+}
+
+func (s *TimescaleTelemetryStore) getUptimeStatusCountsFromSnapshotCounts(
+	ctx context.Context,
+	query models.CombinedMetricsQuery,
+	startTime, endTime time.Time,
+	bucketDuration time.Duration,
+) []models.UptimeStatusCount {
+	if query.OrganizationID == 0 {
+		return nil
+	}
+	// Snapshot cadence is ~60s, so finer buckets would yield empty slots.
+	if bucketDuration < time.Minute {
+		bucketDuration = time.Minute
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.config.QueryTimeout)
+	defer cancel()
+
+	rows, err := s.queries.GetMinerStateSnapshotCounts(ctx, sqlc.GetMinerStateSnapshotCountsParams{
+		BucketInterval:    fmt.Sprintf("%d seconds", int64(bucketDuration.Seconds())),
+		OrgID:             query.OrganizationID,
+		StartTime:         startTime,
+		EndTime:           endTime,
+		SiteIds:           query.SiteIDs,
+		IncludeUnassigned: query.IncludeUnassigned,
+	})
+	if err != nil {
+		s.logger.Error("failed to query miner state snapshot counts",
+			slog.Int64("org_id", query.OrganizationID),
+			slog.Int("site_count", len(query.SiteIDs)),
+			slog.Bool("include_unassigned", query.IncludeUnassigned),
+			slog.String("error", err.Error()))
+		return nil
+	}
 	if len(rows) == 0 {
 		return nil
 	}

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -553,9 +553,12 @@ func (s *TimescaleTelemetryStore) getCombinedMetricsFromRaw(ctx context.Context,
 		bucketDuration = *query.SlideInterval
 	}
 
-	result := s.aggregateMetrics(data, query.MeasurementTypes, query.AggregationTypes, bucketDuration)
+	includeUptimeCounts := shouldIncludeUptimeStatusCounts(query.MeasurementTypes)
+	result := s.aggregateMetrics(data, query.MeasurementTypes, query.AggregationTypes, bucketDuration, includeUptimeCounts)
 	startTime, endTime := s.getTimeRange(query.TimeRange)
-	result.UptimeStatusCounts = s.uptimeCountsForQuery(ctx, query, startTime, endTime, bucketDuration)
+	if includeUptimeCounts {
+		result.UptimeStatusCounts = s.uptimeCountsForQuery(ctx, query, startTime, endTime, bucketDuration)
+	}
 
 	return result, nil
 }
@@ -599,7 +602,10 @@ func (s *TimescaleTelemetryStore) getCombinedMetricsFromHourly(ctx context.Conte
 	metrics := s.aggregateHourlyRows(rows, query.MeasurementTypes, query.AggregationTypes)
 
 	tempCounts := s.getTemperatureCountsFromHourlyAggregates(ctx, query.DeviceIDs, startTime, endTime)
-	uptimeCounts := s.uptimeCountsForQuery(ctx, query, startTime, endTime, hourlyBucketDuration)
+	var uptimeCounts []models.UptimeStatusCount
+	if shouldIncludeUptimeStatusCounts(query.MeasurementTypes) {
+		uptimeCounts = s.uptimeCountsForQuery(ctx, query, startTime, endTime, hourlyBucketDuration)
+	}
 
 	return models.CombinedMetric{
 		Metrics:                 metrics,
@@ -647,7 +653,10 @@ func (s *TimescaleTelemetryStore) getCombinedMetricsFromDaily(ctx context.Contex
 	metrics := s.aggregateDailyRows(rows, query.MeasurementTypes, query.AggregationTypes)
 
 	tempCounts := s.getTemperatureCountsFromDailyAggregates(ctx, query.DeviceIDs, startTime, endTime)
-	uptimeCounts := s.uptimeCountsForQuery(ctx, query, startTime, endTime, dailyBucketDuration)
+	var uptimeCounts []models.UptimeStatusCount
+	if shouldIncludeUptimeStatusCounts(query.MeasurementTypes) {
+		uptimeCounts = s.uptimeCountsForQuery(ctx, query, startTime, endTime, dailyBucketDuration)
+	}
 
 	return models.CombinedMetric{
 		Metrics:                 metrics,
@@ -672,6 +681,18 @@ func (s *TimescaleTelemetryStore) uptimeCountsForQuery(ctx context.Context, quer
 		return nil
 	}
 	return s.getUptimeStatusCountsFromSnapshots(ctx, query.OrganizationID, query.DeviceIDs, startTime, endTime, bucketDuration)
+}
+
+func shouldIncludeUptimeStatusCounts(measurementTypes []models.MeasurementType) bool {
+	if len(measurementTypes) == 0 {
+		return true
+	}
+	for _, measurementType := range measurementTypes {
+		if measurementType == models.MeasurementTypeUptime {
+			return true
+		}
+	}
+	return false
 }
 
 // getTimeRange extracts start and end times from the query, using defaults if not set.
@@ -1125,6 +1146,7 @@ func (s *TimescaleTelemetryStore) aggregateMetrics(
 	measurementTypes []models.MeasurementType,
 	aggregationTypes []models.AggregationType,
 	windowDuration time.Duration,
+	includeUptimeCounts bool,
 ) models.CombinedMetric {
 	if len(data) == 0 {
 		return models.CombinedMetric{}
@@ -1158,21 +1180,25 @@ func (s *TimescaleTelemetryStore) aggregateMetrics(
 
 	allMetrics := make([]models.Metric, 0, len(buckets)*len(measurementTypes))
 	tempCounts := make([]models.TemperatureStatusCount, 0, len(buckets))
-	uptimeCounts := make([]models.UptimeStatusCount, 0, len(buckets))
+	var uptimeCounts []models.UptimeStatusCount
+	if includeUptimeCounts {
+		uptimeCounts = make([]models.UptimeStatusCount, 0, len(buckets))
+	}
 
 	for _, bucketTime := range bucketTimes {
 		bucketData := buckets[bucketTime]
 
-		// Dedupe once per bucket — both status-count functions need a
-		// per-device latest sample, with temperature using the latest
-		// sample that actually has TempC populated.
-		uptimeLatest, tempLatest := latestSamplesForStatusCounts(bucketData)
+		// Dedupe once per bucket for the requested status counts. Temperature
+		// always uses the latest sample that actually has TempC populated.
+		uptimeLatest, tempLatest := latestSamplesForStatusCounts(bucketData, includeUptimeCounts)
 
 		tempCount := temperatureStatusCountFromLatest(tempLatest, bucketTime)
 		tempCounts = append(tempCounts, tempCount)
 
-		uptimeCount := uptimeStatusCountFromLatest(uptimeLatest, bucketTime)
-		uptimeCounts = append(uptimeCounts, uptimeCount)
+		if includeUptimeCounts {
+			uptimeCount := uptimeStatusCountFromLatest(uptimeLatest, bucketTime)
+			uptimeCounts = append(uptimeCounts, uptimeCount)
+		}
 
 		for _, measurementType := range measurementTypes {
 			var aggregatedValues []models.AggregatedValue
@@ -1425,21 +1451,25 @@ func latestSamplePerDevice(data []modelsV2.DeviceMetrics) []modelsV2.DeviceMetri
 	return out
 }
 
-// latestSamplesForStatusCounts walks the bucket once and returns two deduped
-// views: the latest sample per device (for uptime), and the latest sample per
-// device that has a TempC reading (for temperature). The TempC-aware view
-// avoids dropping a device just because its very latest sample happens to be
-// missing a temperature — TempC reporting can be intermittent, while Health
-// is set on every sample.
-func latestSamplesForStatusCounts(data []modelsV2.DeviceMetrics) (uptime, temperature []modelsV2.DeviceMetrics) {
+// latestSamplesForStatusCounts walks the bucket once and returns requested
+// deduped views: the latest sample per device (for uptime), and the latest
+// sample per device that has a TempC reading (for temperature). The TempC-aware
+// view avoids dropping a device just because its very latest sample happens to
+// be missing a temperature; TempC reporting can be intermittent.
+func latestSamplesForStatusCounts(data []modelsV2.DeviceMetrics, includeUptime bool) (uptime, temperature []modelsV2.DeviceMetrics) {
 	if len(data) == 0 {
 		return nil, nil
 	}
-	allLatest := make(map[string]modelsV2.DeviceMetrics, len(data))
+	var allLatest map[string]modelsV2.DeviceMetrics
+	if includeUptime {
+		allLatest = make(map[string]modelsV2.DeviceMetrics, len(data))
+	}
 	tempLatest := make(map[string]modelsV2.DeviceMetrics, len(data))
 	for _, m := range data {
-		if existing, ok := allLatest[m.DeviceIdentifier]; !ok || m.Timestamp.After(existing.Timestamp) {
-			allLatest[m.DeviceIdentifier] = m
+		if includeUptime {
+			if existing, ok := allLatest[m.DeviceIdentifier]; !ok || m.Timestamp.After(existing.Timestamp) {
+				allLatest[m.DeviceIdentifier] = m
+			}
 		}
 		if m.TempC == nil {
 			continue
@@ -1448,9 +1478,11 @@ func latestSamplesForStatusCounts(data []modelsV2.DeviceMetrics) (uptime, temper
 			tempLatest[m.DeviceIdentifier] = m
 		}
 	}
-	uptime = make([]modelsV2.DeviceMetrics, 0, len(allLatest))
-	for _, m := range allLatest {
-		uptime = append(uptime, m)
+	if includeUptime {
+		uptime = make([]modelsV2.DeviceMetrics, 0, len(allLatest))
+		for _, m := range allLatest {
+			uptime = append(uptime, m)
+		}
 	}
 	temperature = make([]modelsV2.DeviceMetrics, 0, len(tempLatest))
 	for _, m := range tempLatest {
@@ -1464,7 +1496,7 @@ func latestSamplesForStatusCounts(data []modelsV2.DeviceMetrics) (uptime, temper
 // temperatureStatusCountFromLatest in hot loops where the caller has already
 // deduped.
 func calculateTemperatureStatusCount(data []modelsV2.DeviceMetrics, timestamp time.Time) models.TemperatureStatusCount {
-	_, temp := latestSamplesForStatusCounts(data)
+	_, temp := latestSamplesForStatusCounts(data, false)
 	return temperatureStatusCountFromLatest(temp, timestamp)
 }
 

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -553,7 +553,7 @@ func (s *TimescaleTelemetryStore) getCombinedMetricsFromRaw(ctx context.Context,
 		bucketDuration = *query.SlideInterval
 	}
 
-	includeUptimeCounts := shouldIncludeUptimeStatusCounts(query.MeasurementTypes)
+	includeUptimeCounts := models.ShouldIncludeUptimeStatusCounts(query.MeasurementTypes)
 	result := s.aggregateMetrics(data, query.MeasurementTypes, query.AggregationTypes, bucketDuration, includeUptimeCounts)
 	startTime, endTime := s.getTimeRange(query.TimeRange)
 	if includeUptimeCounts {
@@ -603,7 +603,7 @@ func (s *TimescaleTelemetryStore) getCombinedMetricsFromHourly(ctx context.Conte
 
 	tempCounts := s.getTemperatureCountsFromHourlyAggregates(ctx, query.DeviceIDs, startTime, endTime)
 	var uptimeCounts []models.UptimeStatusCount
-	if shouldIncludeUptimeStatusCounts(query.MeasurementTypes) {
+	if models.ShouldIncludeUptimeStatusCounts(query.MeasurementTypes) {
 		uptimeCounts = s.uptimeCountsForQuery(ctx, query, startTime, endTime, hourlyBucketDuration)
 	}
 
@@ -654,7 +654,7 @@ func (s *TimescaleTelemetryStore) getCombinedMetricsFromDaily(ctx context.Contex
 
 	tempCounts := s.getTemperatureCountsFromDailyAggregates(ctx, query.DeviceIDs, startTime, endTime)
 	var uptimeCounts []models.UptimeStatusCount
-	if shouldIncludeUptimeStatusCounts(query.MeasurementTypes) {
+	if models.ShouldIncludeUptimeStatusCounts(query.MeasurementTypes) {
 		uptimeCounts = s.uptimeCountsForQuery(ctx, query, startTime, endTime, dailyBucketDuration)
 	}
 
@@ -681,18 +681,6 @@ func (s *TimescaleTelemetryStore) uptimeCountsForQuery(ctx context.Context, quer
 		return nil
 	}
 	return s.getUptimeStatusCountsFromSnapshots(ctx, query.OrganizationID, query.DeviceIDs, startTime, endTime, bucketDuration)
-}
-
-func shouldIncludeUptimeStatusCounts(measurementTypes []models.MeasurementType) bool {
-	if len(measurementTypes) == 0 {
-		return true
-	}
-	for _, measurementType := range measurementTypes {
-		if measurementType == models.MeasurementTypeUptime {
-			return true
-		}
-	}
-	return false
 }
 
 // getTimeRange extracts start and end times from the query, using defaults if not set.

--- a/server/internal/infrastructure/timescaledb/telemetry_store_uptime_cagg_test.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store_uptime_cagg_test.go
@@ -85,6 +85,84 @@ func TestTelemetryStore_UptimeCountsExplicitDeviceIDsUseRawSnapshots(t *testing.
 	assert.Equal(t, int32(0), counts[0].NotHashingCount)
 }
 
+func TestTelemetryStore_GetCombinedMetricsSkipsUptimeCountsWhenNotRequested(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dbSvc := testutil.NewDatabaseService(t, nil)
+	db := dbSvc.DB
+	store, err := NewTelemetryStore(db, DefaultConfig())
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+	orgID := user.OrganizationID
+	deviceIdentifier := "skip-uptime-counts-device"
+	now := time.Now().UTC().Truncate(time.Minute)
+	insertDeviceMetricForUptimeRequest(t, db, now, deviceIdentifier)
+	insertMinerStateSnapshotRow(t, db, now, orgID, sql.NullInt64{}, sql.NullInt64{}, deviceIdentifier, 3)
+
+	start := now.Add(-time.Minute)
+	end := now.Add(time.Minute)
+	result, err := store.GetCombinedMetrics(ctx, models.CombinedMetricsQuery{
+		OrganizationID:    orgID,
+		DeviceIDs:         []models.DeviceIdentifier{models.DeviceIdentifier(deviceIdentifier)},
+		ExplicitDeviceIDs: true,
+		MeasurementTypes:  []models.MeasurementType{models.MeasurementTypeHashrate},
+		TimeRange: models.TimeRange{
+			StartTime: &start,
+			EndTime:   &end,
+		},
+		SlideInterval: ptrDuration(time.Minute),
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Metrics)
+	assert.Empty(t, result.UptimeStatusCounts)
+}
+
+func TestTelemetryStore_GetCombinedMetricsIncludesUptimeCountsWhenRequested(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dbSvc := testutil.NewDatabaseService(t, nil)
+	db := dbSvc.DB
+	store, err := NewTelemetryStore(db, DefaultConfig())
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+	orgID := user.OrganizationID
+	deviceIdentifier := "include-uptime-counts-device"
+	now := time.Now().UTC().Truncate(time.Minute)
+	insertDeviceMetricForUptimeRequest(t, db, now, deviceIdentifier)
+	insertMinerStateSnapshotRow(t, db, now, orgID, sql.NullInt64{}, sql.NullInt64{}, deviceIdentifier, 3)
+
+	start := now.Add(-time.Minute)
+	end := now.Add(time.Minute)
+	result, err := store.GetCombinedMetrics(ctx, models.CombinedMetricsQuery{
+		OrganizationID:    orgID,
+		DeviceIDs:         []models.DeviceIdentifier{models.DeviceIdentifier(deviceIdentifier)},
+		ExplicitDeviceIDs: true,
+		MeasurementTypes: []models.MeasurementType{
+			models.MeasurementTypeHashrate,
+			models.MeasurementTypeUptime,
+		},
+		TimeRange: models.TimeRange{
+			StartTime: &start,
+			EndTime:   &end,
+		},
+		SlideInterval: ptrDuration(time.Minute),
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Metrics)
+	require.Len(t, result.UptimeStatusCounts, 1)
+	assert.Equal(t, int32(1), result.UptimeStatusCounts[0].HashingCount)
+}
+
 func TestTelemetryStore_InsertMinerStateSnapshotStampsBuildingID(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -157,6 +235,21 @@ func insertMinerStateSnapshotRow(t *testing.T, db *sql.DB, at time.Time, orgID i
 			state = EXCLUDED.state
 	`, at, orgID, siteID, buildingID, deviceIdentifier, state)
 	require.NoError(t, err)
+}
+
+func insertDeviceMetricForUptimeRequest(t *testing.T, db *sql.DB, at time.Time, deviceIdentifier string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO device_metrics (time, device_identifier, hash_rate_hs)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (time, device_identifier) DO UPDATE SET
+			hash_rate_hs = EXCLUDED.hash_rate_hs
+	`, at, deviceIdentifier, 100_000_000.0)
+	require.NoError(t, err)
+}
+
+func ptrDuration(d time.Duration) *time.Duration {
+	return &d
 }
 
 func refreshUptimeSnapshotCounts(t *testing.T, db *sql.DB, start, end time.Time) {

--- a/server/internal/infrastructure/timescaledb/telemetry_store_uptime_cagg_test.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store_uptime_cagg_test.go
@@ -1,0 +1,199 @@
+package timescaledb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/block/proto-fleet/server/generated/sqlc"
+	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
+	"github.com/block/proto-fleet/server/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelemetryStore_UptimeCountsUseSnapshotCountsCAGG(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dbSvc := testutil.NewDatabaseService(t, nil)
+	db := dbSvc.DB
+	store, err := NewTelemetryStore(db, DefaultConfig())
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+	orgID := user.OrganizationID
+	siteA := createUptimeTestSite(t, db, orgID, "Uptime Site A")
+	siteB := createUptimeTestSite(t, db, orgID, "Uptime Site B")
+	buildingA := createUptimeTestBuilding(t, db, orgID, siteA, "Uptime Building A")
+	buildingB := createUptimeTestBuilding(t, db, orgID, siteB, "Uptime Building B")
+
+	start := time.Now().UTC().Add(-2 * time.Hour).Truncate(2 * time.Minute)
+	latest := start.Add(time.Minute)
+	insertMinerStateSnapshotRow(t, db, start, orgID, siteA, buildingA, "cagg-site-a-1", 3)
+	insertMinerStateSnapshotRow(t, db, start, orgID, siteB, buildingB, "cagg-site-b-1", 0)
+	insertMinerStateSnapshotRow(t, db, latest, orgID, siteA, buildingA, "cagg-site-a-1", 2)
+	insertMinerStateSnapshotRow(t, db, latest, orgID, siteB, buildingB, "cagg-site-b-1", 1)
+	refreshUptimeSnapshotCounts(t, db, start.Add(-time.Minute), latest.Add(time.Minute))
+
+	allCounts := store.uptimeCountsForQuery(ctx, models.CombinedMetricsQuery{
+		OrganizationID: orgID,
+	}, start.Add(-time.Second), latest.Add(time.Second), 2*time.Minute)
+	require.Len(t, allCounts, 1)
+	assert.Equal(t, int32(0), allCounts[0].HashingCount)
+	assert.Equal(t, int32(1), allCounts[0].BrokenCount)
+	assert.Equal(t, int32(1), allCounts[0].NotHashingCount)
+
+	siteCounts := store.uptimeCountsForQuery(ctx, models.CombinedMetricsQuery{
+		OrganizationID: orgID,
+		SiteIDs:        []int64{siteA.Int64},
+	}, start.Add(-time.Second), latest.Add(time.Second), 2*time.Minute)
+	require.Len(t, siteCounts, 1)
+	assert.Equal(t, int32(0), siteCounts[0].HashingCount)
+	assert.Equal(t, int32(1), siteCounts[0].BrokenCount)
+	assert.Equal(t, int32(0), siteCounts[0].NotHashingCount)
+}
+
+func TestTelemetryStore_UptimeCountsExplicitDeviceIDsUseRawSnapshots(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dbSvc := testutil.NewDatabaseService(t, nil)
+	db := dbSvc.DB
+	store, err := NewTelemetryStore(db, DefaultConfig())
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+	orgID := user.OrganizationID
+	at := time.Now().UTC().Add(-time.Hour).Truncate(time.Minute)
+	insertMinerStateSnapshotRow(t, db, at, orgID, sql.NullInt64{}, sql.NullInt64{}, "explicit-uptime-device", 3)
+
+	counts := store.uptimeCountsForQuery(ctx, models.CombinedMetricsQuery{
+		OrganizationID:    orgID,
+		DeviceIDs:         []models.DeviceIdentifier{"explicit-uptime-device", "explicit-uptime-device"},
+		ExplicitDeviceIDs: true,
+	}, at.Add(-time.Second), at.Add(time.Second), time.Minute)
+
+	require.Len(t, counts, 1)
+	assert.Equal(t, int32(1), counts[0].HashingCount)
+	assert.Equal(t, int32(0), counts[0].BrokenCount)
+	assert.Equal(t, int32(0), counts[0].NotHashingCount)
+}
+
+func TestTelemetryStore_InsertMinerStateSnapshotStampsBuildingID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dbSvc := testutil.NewDatabaseService(t, nil)
+	db := dbSvc.DB
+	store, err := NewTelemetryStore(db, DefaultConfig())
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	user := dbSvc.CreateSuperAdminUser()
+	orgID := user.OrganizationID
+	siteID := createUptimeTestSite(t, db, orgID, "Snapshot Stamp Site")
+	buildingID := createUptimeTestBuilding(t, db, orgID, siteID, "Snapshot Stamp Building")
+	device := dbSvc.CreateDevice(orgID, "proto")
+	pairDeviceForSnapshot(t, db, device.DatabaseID)
+	setDevicePlacementForSnapshot(t, db, device.DatabaseID, siteID, buildingID)
+	setDeviceStatusForSnapshot(t, db, device.DatabaseID, sqlc.DeviceStatusEnumACTIVE)
+
+	at := time.Now().UTC().Truncate(time.Millisecond)
+	require.NoError(t, store.InsertMinerStateSnapshot(ctx, at))
+
+	var gotSiteID, gotBuildingID sql.NullInt64
+	var gotState int16
+	err = db.QueryRowContext(ctx, `
+		SELECT site_id, building_id, state
+		FROM miner_state_snapshots
+		WHERE time = $1 AND device_identifier = $2
+	`, at, device.ID).Scan(&gotSiteID, &gotBuildingID, &gotState)
+	require.NoError(t, err)
+	require.True(t, gotSiteID.Valid)
+	require.True(t, gotBuildingID.Valid)
+	assert.Equal(t, siteID.Int64, gotSiteID.Int64)
+	assert.Equal(t, buildingID.Int64, gotBuildingID.Int64)
+	assert.Equal(t, int16(3), gotState)
+}
+
+func createUptimeTestSite(t *testing.T, db *sql.DB, orgID int64, name string) sql.NullInt64 {
+	t.Helper()
+	var id int64
+	err := db.QueryRowContext(context.Background(),
+		"INSERT INTO site (org_id, name, slug) VALUES ($1, $2, $3) RETURNING id",
+		orgID, name, name+"-slug",
+	).Scan(&id)
+	require.NoError(t, err)
+	return sql.NullInt64{Int64: id, Valid: true}
+}
+
+func createUptimeTestBuilding(t *testing.T, db *sql.DB, orgID int64, siteID sql.NullInt64, name string) sql.NullInt64 {
+	t.Helper()
+	var id int64
+	err := db.QueryRowContext(context.Background(),
+		"INSERT INTO building (org_id, site_id, name) VALUES ($1, $2, $3) RETURNING id",
+		orgID, siteID, name,
+	).Scan(&id)
+	require.NoError(t, err)
+	return sql.NullInt64{Int64: id, Valid: true}
+}
+
+func insertMinerStateSnapshotRow(t *testing.T, db *sql.DB, at time.Time, orgID int64, siteID, buildingID sql.NullInt64, deviceIdentifier string, state int16) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO miner_state_snapshots (time, org_id, site_id, building_id, device_identifier, state)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (time, device_identifier) DO UPDATE SET
+			org_id = EXCLUDED.org_id,
+			site_id = EXCLUDED.site_id,
+			building_id = EXCLUDED.building_id,
+			state = EXCLUDED.state
+	`, at, orgID, siteID, buildingID, deviceIdentifier, state)
+	require.NoError(t, err)
+}
+
+func refreshUptimeSnapshotCounts(t *testing.T, db *sql.DB, start, end time.Time) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(),
+		"CALL refresh_continuous_aggregate('miner_state_snapshot_counts_1m', $1::timestamptz, $2::timestamptz)",
+		start, end,
+	)
+	require.NoError(t, err)
+}
+
+func pairDeviceForSnapshot(t *testing.T, db *sql.DB, deviceID int64) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO device_pairing (device_id, pairing_status, paired_at)
+		VALUES ($1, 'PAIRED', CURRENT_TIMESTAMP)
+		ON CONFLICT (device_id) DO UPDATE SET pairing_status = 'PAIRED'
+	`, deviceID)
+	require.NoError(t, err)
+}
+
+func setDevicePlacementForSnapshot(t *testing.T, db *sql.DB, deviceID int64, siteID, buildingID sql.NullInt64) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		UPDATE device
+		SET site_id = $2, building_id = $3
+		WHERE id = $1
+	`, deviceID, siteID, buildingID)
+	require.NoError(t, err)
+}
+
+func setDeviceStatusForSnapshot(t *testing.T, db *sql.DB, deviceID int64, status sqlc.DeviceStatusEnum) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO device_status (device_id, status)
+		VALUES ($1, $2)
+		ON CONFLICT (device_id) DO UPDATE SET status = EXCLUDED.status
+	`, deviceID, status)
+	require.NoError(t, err)
+}

--- a/server/migrations/000106_add_uptime_snapshot_counts_cagg.down.sql
+++ b/server/migrations/000106_add_uptime_snapshot_counts_cagg.down.sql
@@ -1,0 +1,17 @@
+SELECT remove_continuous_aggregate_policy('miner_state_snapshot_counts_1m', if_exists => true);
+SELECT remove_retention_policy('miner_state_snapshot_counts_1m', if_exists => true);
+SELECT remove_compression_policy('miner_state_snapshot_counts_1m', if_exists => true);
+
+DROP INDEX IF EXISTS idx_miner_state_snapshot_counts_1m_org_building_bucket;
+DROP INDEX IF EXISTS idx_miner_state_snapshot_counts_1m_org_site_bucket;
+DROP INDEX IF EXISTS idx_miner_state_snapshot_counts_1m_org_bucket;
+DROP MATERIALIZED VIEW IF EXISTS miner_state_snapshot_counts_1m;
+
+DROP INDEX IF EXISTS idx_miner_state_snapshots_org_building_time;
+ALTER TABLE miner_state_snapshots
+    DROP COLUMN IF EXISTS building_id;
+
+SELECT remove_retention_policy('miner_state_snapshots', if_exists => true);
+SELECT add_retention_policy('miner_state_snapshots', INTERVAL '1 year');
+
+SELECT set_chunk_time_interval('miner_state_snapshots', INTERVAL '7 days');

--- a/server/migrations/000106_add_uptime_snapshot_counts_cagg.up.sql
+++ b/server/migrations/000106_add_uptime_snapshot_counts_cagg.up.sql
@@ -1,0 +1,56 @@
+ALTER TABLE miner_state_snapshots
+    ADD COLUMN building_id BIGINT NULL;
+
+CREATE INDEX idx_miner_state_snapshots_org_building_time
+    ON miner_state_snapshots(org_id, building_id, time DESC)
+    WHERE building_id IS NOT NULL;
+
+-- Large fleets write millions of raw per-device snapshots per day. Keep raw
+-- history short for debugging, and serve dashboard history from the compact
+-- aggregate below.
+SELECT remove_retention_policy('miner_state_snapshots', if_exists => true);
+SELECT add_retention_policy('miner_state_snapshots', INTERVAL '14 days',
+    schedule_interval => INTERVAL '1 hour');
+
+-- Future chunks should be small enough for retention/compression jobs to work
+-- in day-sized units. Existing chunks keep their current interval.
+SELECT set_chunk_time_interval('miner_state_snapshots', INTERVAL '1 day');
+
+CREATE MATERIALIZED VIEW miner_state_snapshot_counts_1m
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT
+    time_bucket(INTERVAL '1 minute', time) AS bucket,
+    time AS snapshot_time,
+    org_id,
+    site_id,
+    building_id,
+    COUNT(*) FILTER (WHERE state = 3)::int AS hashing_count,
+    COUNT(*) FILTER (WHERE state = 2)::int AS broken_count,
+    COUNT(*) FILTER (WHERE state = 0)::int AS offline_count,
+    COUNT(*) FILTER (WHERE state = 1)::int AS sleeping_count
+FROM miner_state_snapshots
+GROUP BY bucket, snapshot_time, org_id, site_id, building_id
+WITH NO DATA;
+
+CREATE INDEX idx_miner_state_snapshot_counts_1m_org_bucket
+    ON miner_state_snapshot_counts_1m(org_id, bucket DESC, snapshot_time DESC);
+CREATE INDEX idx_miner_state_snapshot_counts_1m_org_site_bucket
+    ON miner_state_snapshot_counts_1m(org_id, site_id, bucket DESC, snapshot_time DESC);
+CREATE INDEX idx_miner_state_snapshot_counts_1m_org_building_bucket
+    ON miner_state_snapshot_counts_1m(org_id, building_id, bucket DESC, snapshot_time DESC);
+
+SELECT add_continuous_aggregate_policy('miner_state_snapshot_counts_1m',
+    start_offset => INTERVAL '14 days',
+    end_offset => INTERVAL '2 minutes',
+    schedule_interval => INTERVAL '1 minute');
+
+ALTER MATERIALIZED VIEW miner_state_snapshot_counts_1m SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'org_id, site_id, building_id',
+    timescaledb.compress_orderby = 'bucket DESC, snapshot_time DESC'
+);
+
+SELECT add_compression_policy('miner_state_snapshot_counts_1m', INTERVAL '7 days',
+    schedule_interval => INTERVAL '1 hour');
+SELECT add_retention_policy('miner_state_snapshot_counts_1m', INTERVAL '1 year',
+    schedule_interval => INTERVAL '1 day');

--- a/server/sqlc.yaml
+++ b/server/sqlc.yaml
@@ -57,6 +57,10 @@ sql:
             go_type: "time.Time"
           - column: "device_status_daily.bucket"
             go_type: "time.Time"
+          - column: "miner_state_snapshot_counts_1m.bucket"
+            go_type: "time.Time"
+          - column: "miner_state_snapshot_counts_1m.snapshot_time"
+            go_type: "time.Time"
           # Schedule TIME columns are read back as strings by the current DB driver.
           - column: "schedule.start_time"
             go_type: "string"

--- a/server/sqlc/queries/miner_state_snapshots.sql
+++ b/server/sqlc/queries/miner_state_snapshots.sql
@@ -6,11 +6,12 @@
 -- enum values). The read query sums only 0..3, so unknown rows don't
 -- contribute to any chart bucket — matching CountMinersByState, which also
 -- excludes non-ACTIVE/non-bucketed statuses from every count.
-INSERT INTO miner_state_snapshots (time, org_id, site_id, device_identifier, state)
+INSERT INTO miner_state_snapshots (time, org_id, site_id, building_id, device_identifier, state)
 SELECT
     sqlc.arg('time')::timestamptz,
     d.org_id,
     d.site_id,
+    d.building_id,
     d.device_identifier,
     CASE
         WHEN ds.status = 'OFFLINE'
@@ -68,4 +69,43 @@ SELECT
     SUM(CASE WHEN state = 1 THEN 1 ELSE 0 END)::int AS sleeping_count
 FROM per_device_bucket
 GROUP BY bucket
+ORDER BY bucket ASC;
+
+-- name: GetMinerStateSnapshotCounts :many
+WITH scoped_counts AS (
+    SELECT
+        snapshot_time,
+        SUM(hashing_count)::int AS hashing_count,
+        SUM(broken_count)::int AS broken_count,
+        SUM(offline_count)::int AS offline_count,
+        SUM(sleeping_count)::int AS sleeping_count
+    FROM miner_state_snapshot_counts_1m
+    WHERE org_id = sqlc.arg('org_id')
+      AND snapshot_time >= sqlc.arg('start_time')
+      AND snapshot_time <= sqlc.arg('end_time')
+      AND (
+          (cardinality(COALESCE(sqlc.arg('site_ids')::bigint[], '{}')) = 0
+           AND sqlc.arg('include_unassigned')::boolean = false)
+          OR site_id = ANY(COALESCE(sqlc.arg('site_ids')::bigint[], '{}'))
+          OR (sqlc.arg('include_unassigned')::boolean AND site_id IS NULL)
+      )
+    GROUP BY snapshot_time
+),
+latest_per_bucket AS (
+    SELECT DISTINCT ON (time_bucket(sqlc.arg('bucket_interval')::text::interval, scoped_counts.snapshot_time))
+        time_bucket(sqlc.arg('bucket_interval')::text::interval, scoped_counts.snapshot_time)::timestamptz AS bucket,
+        hashing_count,
+        broken_count,
+        offline_count,
+        sleeping_count
+    FROM scoped_counts
+    ORDER BY time_bucket(sqlc.arg('bucket_interval')::text::interval, scoped_counts.snapshot_time), scoped_counts.snapshot_time DESC
+)
+SELECT
+    bucket,
+    hashing_count,
+    broken_count,
+    offline_count,
+    sleeping_count
+FROM latest_per_bucket
 ORDER BY bucket ASC;


### PR DESCRIPTION
Reviewable diff: +262/-41 across 11 files (excludes generated, test, and story files).

## Summary
Large-fleet uptime history now avoids repeated raw per-device snapshot scans on the dashboard/site paths and no longer computes uptime counts for pages that do not render uptime. This addresses the GetCombinedMetrics timeout path behind block/proto-fleet#575 and block/proto-fleet#571 while keeping explicit device-list uptime requests exact. Rack, building, and group performance pages now request only the metrics they display; dashboard and site pages still request uptime and use the optimized aggregate path plus the live uptime bar.

## How it works
Every miner-state snapshot insert now stamps the device's current `site_id` and `building_id`. A Timescale continuous aggregate stores one-minute count rows by source snapshot time, org, site, and building, with separate counts for hashing, broken, offline, and sleeping miners.

`GetCombinedMetrics` uses one shared measurement predicate in the service and store. If the request has an explicit measurement list without `MeasurementType.UPTIME`, the service skips the live `GetMinerStateCounts` append and the store skips raw in-memory uptime aggregation plus the CAGG/raw snapshot uptime query. If the request omits measurement types, the legacy default behavior is preserved and uptime counts are included.

When uptime is requested, org/site/unassigned history uses the continuous aggregate and picks the latest source snapshot inside each requested chart bucket. Explicit device-list requests stay on the existing raw snapshot query so arbitrary selectors keep exact semantics. The service appends the existing live uptime bar only for uptime requests, so the right edge remains fresh while the materialized aggregate refreshes behind it.

## Diagrams
```mermaid
flowchart TD
    A["Rack, building, group pages"] --> B["Request hashrate, power, temperature, efficiency"]
    B --> C["Service skips live state counts"]
    C --> D["Store skips historical uptime count work"]
    E["Dashboard or site page"] --> F["Request includes uptime"]
    F --> G["Read uptime history from CAGG"]
    H["Explicit device-list uptime request"] --> I["Read raw snapshots for exact selector semantics"]
    G --> J["Return historical uptime bars"]
    I --> J
    K["GetMinerStateCounts live read"] --> L["Append live bar"]
    J --> L
```

```mermaid
flowchart TD
    A["Snapshot job"] --> B["Insert miner_state_snapshots with site_id and building_id"]
    B --> C["miner_state_snapshot_counts_1m CAGG"]
    C --> D["Org, site, and future building scoped uptime history"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/{buildings,fleetManagement,groupManagement}/pages/*` | Removes `MeasurementType.UPTIME` from rack, building, and group performance requests | Prevents non-uptime pages from triggering backend uptime history work |
| `server/migrations/000106_*` | Adds `building_id`, creates the uptime CAGG, changes raw retention to 14 days, adds CAGG compression and one-year retention | Main data-model and operational behavior change |
| `server/sqlc/queries/miner_state_snapshots.sql`, `server/sqlc.yaml` | Stamps `building_id` and adds the aggregate count query | Query semantics determine correctness and performance |
| `server/internal/domain/telemetry/models/queries.go`, `server/internal/domain/telemetry/service.go` | Shares the uptime-request predicate and gates the live `GetMinerStateCounts` append | Ensures explicit non-uptime requests do not pay live uptime count cost or receive unexpected uptime data |
| `server/internal/infrastructure/timescaledb/telemetry_store.go` | Reuses the shared predicate and routes non-explicit uptime history to the CAGG | Runtime behavior for the timeout fix and historical count gate |
| `server/internal/domain/telemetry/*`, `server/internal/handlers/telemetry/conversion.go` | Tracks whether `DeviceIDs` came from an explicit selector or service-side site resolution | Prevents site-scoped optimization from changing explicit selector semantics |
| `server/internal/infrastructure/timescaledb/*_test.go`, `server/internal/domain/telemetry/*_test.go`, client page tests | Adds CAGG, duplicate selector, building stamp, request-gating, live-bar gating, and page request coverage | Guards the risky behavior changes |
| `server/generated/sqlc/*` | Generated sqlc output | Generated -- skip except to verify regeneration matches query changes |

## Key technical decisions & trade-offs
- Use a continuous aggregate for org/site uptime history instead of threshold-based raw scans; this makes common dashboard reads predictable at large fleet sizes but adds Timescale job/policy state.
- Gate uptime counts on `MeasurementType.UPTIME` instead of always filling `UptimeStatusCounts`; this removes hidden work for non-uptime views but means callers with explicit metric lists must include uptime when they need uptime bars.
- Keep omitted measurement types as the legacy default; this avoids surprising older callers but still computes uptime for broad/default requests.
- Keep explicit device-list uptime requests on raw snapshots instead of approximating them through aggregate rows; this preserves arbitrary selector semantics and avoids duplicate-ID inflation, at the cost of leaving very large custom lists on the slower exact path.
- Store `snapshot_time` in the CAGG and choose the latest source snapshot per requested bucket; this matches the existing latest-state-per-bucket behavior better than summing every one-minute aggregate row.
- Retain raw `miner_state_snapshots` for 14 days and aggregate counts for one year; this reduces storage and retention-job pressure, but raw device-level forensic history older than 14 days is no longer available after retention runs.
- Use `materialized_only` with a two-minute refresh lag; this keeps reads fast and stable, while the live bar covers the freshest point when uptime is requested.
- Include `site_id` and `building_id` in the aggregate now; this enables current site-scoped reads and future building-scoped reads, with some extra aggregate cardinality.

## Testing & validation
- `git diff --check`
- `PATH="/Users/ankitg/dev/repos/proto-fleet-b/bin:$PATH" DB_PASSWORD=fleet go test ./internal/domain/telemetry ./internal/domain/telemetry/models ./internal/infrastructure/timescaledb -count=1`
- `PATH="/Users/ankitg/dev/repos/proto-fleet-b/bin:$PATH" just lint` from `server/`
- `npm test -- --run src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx src/protoFleet/features/buildings/pages/BuildingPage.test.tsx src/protoFleet/features/groupManagement/pages/GroupOverviewPage.test.tsx`
- `npx eslint src/protoFleet/features/buildings/pages/BuildingPage.tsx src/protoFleet/features/buildings/pages/BuildingPage.test.tsx src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx src/protoFleet/features/groupManagement/pages/GroupOverviewPage.test.tsx --max-warnings 0`
- `npx prettier --check src/protoFleet/features/buildings/pages/BuildingPage.tsx src/protoFleet/features/buildings/pages/BuildingPage.test.tsx src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx src/protoFleet/features/groupManagement/pages/GroupOverviewPage.test.tsx`

Earlier validation on this branch:
- `PATH="/Users/ankitg/dev/repos/proto-fleet-b/bin:$PATH" DB_PASSWORD=fleet go test ./internal/domain/telemetry ./internal/handlers/telemetry -count=1`
- `PATH="/Users/ankitg/dev/repos/proto-fleet-b/bin:$PATH" just gen-db-queries` from `server/`
- Migration up/down on a temporary database through version 106.
- Deploy-like migration check against an existing compressed `miner_state_snapshots` chunk: migrated through 105, compressed a snapshot chunk, applied 106, and verified `building_id` was present.

Not run: full monorepo `just lint`; full client build.

## Post-Deploy Monitoring & Validation
| Signal | What to watch | Healthy | Rollback / mitigation trigger |
| --- | --- | --- | --- |
| API behavior | `GetCombinedMetrics` 5xx/504s and latency for dashboard/site/rack/building/group loads | Large fleet requests complete below gateway timeout | Sustained 504s or DB saturation after deploy |
| Fleet API logs | Search for `failed to query miner state snapshot counts` and migration/job errors mentioning `miner_state_snapshot_counts_1m` | No recurring CAGG query or policy errors | Repeated query failures or failed migration |
| Timescale jobs | `timescaledb_information.jobs` and `timescaledb_information.job_stats` for CAGG refresh, compression, and retention policies | Refresh runs every minute with recent `last_successful_finish` | Refresh lag grows or jobs repeatedly fail |
| Data sanity | Compare historical uptime bars against live `MinerStateCounts` on a known large fleet/site | Historical bars track expected fleet/site counts; live bar remains current | Large count drift outside expected snapshot timing |

Validation window: first 24 hours after deployment, owned by the deployer/operator testing this PR. Rollback caveat: once the 14-day raw retention job deletes old rows, those raw per-device rows cannot be recovered from the database; aggregate counts remain available for the configured one-year window.
