### PR TITLE
[codex] Add site detail E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/helpers/sitesDetailTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/sitesDetailTestSetup.ts
@@ -1,0 +1,169 @@
+import { type Browser, type Page, type TestInfo } from "@playwright/test";
+import { testConfig } from "../config/test.config";
+import { test } from "../fixtures/pageFixtures";
+import { AuthPage } from "../pages/auth";
+import { FleetLocationsPage } from "../pages/fleetLocations";
+import { MinersPage } from "../pages/miners";
+import { CommonSteps } from "./commonSteps";
+import { generateRandomText } from "./testDataHelper";
+
+const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
+const AUTOMATION_SITE_BASE_PREFIX = "automation_site_detail_site";
+const AUTOMATION_BUILDING_BASE_PREFIX = "automation_site_detail_building";
+
+type SiteDetailRunPrefixes = {
+  sitePrefix: string;
+  buildingPrefix: string;
+};
+
+const testRunPrefixes = new Map<string, SiteDetailRunPrefixes>();
+
+type SitesDetailCleanupFleetLocationsPage = Pick<
+  FleetLocationsPage,
+  "deleteBuildingByNameIfVisible" | "deleteSiteByNameIfVisible" | "listBuildingNames" | "listSiteNames"
+>;
+
+export type SiteDetailScenarioData = {
+  siteName: string;
+  renamedSiteName: string;
+  siblingSiteName: string;
+  buildingName: string;
+  city: string;
+  powerCapacityMw: string;
+};
+
+function getTestRunKey(testInfo: TestInfo): string {
+  return [testInfo.project.name, testInfo.testId, testInfo.workerIndex, testInfo.retry, testInfo.repeatEachIndex].join(
+    ":",
+  );
+}
+
+function getSafeProjectName(testInfo: TestInfo): string {
+  return (
+    testInfo.project.name
+      .replace(/[^a-zA-Z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .toLowerCase() || "project"
+  );
+}
+
+function createRunPrefixes(testInfo: TestInfo): SiteDetailRunPrefixes {
+  const runPrefix = `${getSafeProjectName(testInfo)}_${testInfo.workerIndex}_${testInfo.retry}`;
+
+  return {
+    sitePrefix: generateRandomText(`${AUTOMATION_SITE_BASE_PREFIX}_${runPrefix}`),
+    buildingPrefix: generateRandomText(`${AUTOMATION_BUILDING_BASE_PREFIX}_${runPrefix}`),
+  };
+}
+
+function getRunPrefixes(testInfo: TestInfo): SiteDetailRunPrefixes {
+  const prefixes = testRunPrefixes.get(getTestRunKey(testInfo));
+  if (!prefixes) {
+    throw new Error("Site detail E2E run prefixes were not initialized.");
+  }
+
+  return prefixes;
+}
+
+export function createSiteDetailScenarioData(testInfo: TestInfo): SiteDetailScenarioData {
+  const prefixes = getRunPrefixes(testInfo);
+
+  return {
+    siteName: generateRandomText(`${prefixes.sitePrefix}_primary`),
+    renamedSiteName: generateRandomText(`${prefixes.sitePrefix}_renamed`),
+    siblingSiteName: generateRandomText(`${prefixes.sitePrefix}_sibling`),
+    buildingName: generateRandomText(`${prefixes.buildingPrefix}_primary`),
+    city: "Chicago",
+    powerCapacityMw: "12.5",
+  };
+}
+
+async function installAllSitesInitScript(page: Page) {
+  await page.addInitScript(
+    ({ storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          state: {
+            ui: {
+              activeSite: { kind: "all" },
+            },
+          },
+          version: 0,
+        }),
+      );
+    },
+    { storageKey: ACTIVE_SITE_STORAGE_KEY },
+  );
+}
+
+async function cleanupAutomationFixtures(
+  fleetLocationsPage: SitesDetailCleanupFleetLocationsPage,
+  prefixes: SiteDetailRunPrefixes,
+) {
+  const buildingNames = (await fleetLocationsPage.listBuildingNames()).filter((name) =>
+    name.startsWith(prefixes.buildingPrefix),
+  );
+  for (const buildingName of buildingNames) {
+    await fleetLocationsPage.deleteBuildingByNameIfVisible(buildingName);
+  }
+
+  const siteNames = (await fleetLocationsPage.listSiteNames()).filter((name) => name.startsWith(prefixes.sitePrefix));
+  for (const siteName of siteNames) {
+    await fleetLocationsPage.deleteSiteByNameIfVisible(siteName);
+  }
+}
+
+async function cleanupAutomationSites(browser: Browser, testInfo: TestInfo) {
+  const prefixes = getRunPrefixes(testInfo);
+  const isMobile = testInfo.project.use?.isMobile ?? false;
+  const context = await browser.newContext({
+    baseURL: testConfig.baseUrl,
+    viewport: testInfo.project.use?.viewport,
+  });
+
+  try {
+    const page = await context.newPage();
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+
+    const authPage = new AuthPage(page, isMobile);
+    const minersPage = new MinersPage(page, isMobile);
+    const fleetLocationsPage = new FleetLocationsPage(page, isMobile);
+    const commonSteps = new CommonSteps(authPage, minersPage);
+
+    await commonSteps.loginAsAdmin();
+    await cleanupAutomationFixtures(fleetLocationsPage, prefixes);
+  } finally {
+    await context.close();
+  }
+}
+
+export function useSiteDetailHooks() {
+  test.beforeEach(async ({ page, commonSteps, fleetLocationsPage }, testInfo) => {
+    testRunPrefixes.set(getTestRunKey(testInfo), createRunPrefixes(testInfo));
+
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+    await commonSteps.loginAsAdmin();
+    await cleanupAutomationFixtures(fleetLocationsPage, getRunPrefixes(testInfo));
+  });
+
+  test.afterEach("CLEANUP: Delete automation site detail fixtures", async ({ browser }, testInfo) => {
+    try {
+      await cleanupAutomationSites(browser, testInfo);
+    } finally {
+      testRunPrefixes.delete(getTestRunKey(testInfo));
+    }
+  });
+}
+
+export async function createSiteDetailSites(
+  fleetLocationsPage: FleetLocationsPage,
+  scenario: Pick<SiteDetailScenarioData, "siteName" | "siblingSiteName">,
+) {
+  await test.step("Create the sites used by the detail scenarios", async () => {
+    await fleetLocationsPage.createSite(scenario.siteName);
+    await fleetLocationsPage.createSite(scenario.siblingSiteName);
+  });
+}

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -115,8 +115,24 @@ export class BasePage {
   }
 
   async navigateToFleetPage() {
+    if (
+      FLEET_TAB_ROUTE.test(this.page.url()) &&
+      (await this.page
+        .getByTestId("fleet-layout")
+        .isVisible()
+        .catch(() => false))
+    ) {
+      return;
+    }
+
+    const fleetLink = this.page.getByTestId("navigation-menu").locator('a[href="/fleet"]');
+
     await this.clickNavigationMenuIfMobile();
-    await this.page.getByTestId("navigation-menu").locator('a[href="/fleet"]').click();
+    if (await fleetLink.isVisible().catch(() => false)) {
+      await fleetLink.click();
+    } else {
+      await this.page.goto("/fleet/sites");
+    }
     await expect(this.page.getByTestId("fleet-layout")).toBeVisible();
     await expect(this.page).toHaveURL(FLEET_TAB_ROUTE);
   }

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -7,10 +7,7 @@ export class FleetLocationsPage extends BasePage {
   async navigateToSitesPage() {
     await this.navigateToFleetPage();
     await this.page.getByTestId("fleet-tab-sites-activate").click();
-    await expect(this.page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
-    await expect(this.page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
-    await expect(this.page.getByTestId("fleet-sites-page")).toBeVisible();
-    await this.selectAllSitesIfNeeded();
+    await this.validateSitesPageOpened();
   }
 
   async navigateToBuildingsPage() {
@@ -58,6 +55,113 @@ export class FleetLocationsPage extends BasePage {
     const row = this.getListRowByName(buildingName);
     await expect(row).toBeVisible();
     return await this.getScopeIdFromRowName(buildingName, "building");
+  }
+
+  async openSiteDetail(name: string): Promise<bigint> {
+    await this.navigateToSitesPage();
+    const siteId = await this.getScopeIdFromRowName(name, "site");
+    const row = this.getListRowByName(name);
+    await expect(row).toBeVisible();
+    await row.getByTestId("name").click();
+    await expect(this.page).toHaveURL(new RegExp(`/sites/${siteId.toString()}(?:[?#].*)?$`));
+    await expect(this.page.getByTestId("site-detail-page")).toBeVisible();
+    return siteId;
+  }
+
+  async validateSitesPageOpened() {
+    await expect(this.page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
+    await this.validateSitesListVisible();
+  }
+
+  async validateSitesListVisible() {
+    await expect(this.page.getByTestId("fleet-sites-redirecting")).toHaveCount(0);
+    await expect(this.page.getByTestId("fleet-sites-page")).toBeVisible();
+    await this.selectAllSitesIfNeeded();
+  }
+
+  async validateSiteDetailOpened(siteName: string) {
+    await expect(this.page.getByTestId("site-detail-page")).toBeVisible();
+    await expect(this.page.getByTestId("site-detail-title")).toHaveText(siteName);
+  }
+
+  async validateSiteDetailMetrics(expected: { location?: string; buildings?: number }) {
+    const metricsRow = this.page.getByTestId("site-detail-metrics-row");
+    await expect(metricsRow).toBeVisible();
+
+    if (expected.location !== undefined) {
+      await expect(metricsRow.getByTestId("site-metric-location-value")).toHaveText(expected.location);
+    }
+
+    if (expected.buildings !== undefined) {
+      await expect(metricsRow.getByTestId("site-metric-buildings-value")).toHaveText(String(expected.buildings));
+    }
+  }
+
+  async editSiteDetailsFromDetail(updates: { name?: string; city?: string; powerCapacityMw?: string }) {
+    await expect(this.page.getByTestId("site-detail-edit")).toBeVisible();
+    await this.page.getByTestId("site-detail-edit").click();
+    const fullScreenModal = this.page.getByTestId("full-screen-two-pane-modal");
+    await expect(fullScreenModal).toBeVisible();
+    await this.clickManageSiteEditDetails(fullScreenModal);
+
+    const settingsModal = this.page.getByTestId("site-settings-modal");
+    await expect(settingsModal).toBeVisible();
+
+    if (updates.name !== undefined) {
+      await settingsModal.getByTestId("site-settings-name-input").fill(updates.name);
+    }
+
+    if (updates.city !== undefined) {
+      await settingsModal.getByTestId("site-settings-city-input").fill(updates.city);
+    }
+
+    if (updates.powerCapacityMw !== undefined) {
+      await settingsModal.getByTestId("site-settings-capacity-input").fill(updates.powerCapacityMw);
+    }
+
+    await settingsModal.getByTestId("site-settings-modal-save").click();
+    await this.waitForModalToClose("site-settings-modal");
+    await this.closeFullScreenModalIfVisible();
+  }
+
+  async addBuildingFromSiteDetail(buildingName: string) {
+    await expect(this.page.getByTestId("site-detail-add-building")).toBeVisible();
+    await this.page.getByTestId("site-detail-add-building").click();
+
+    const settingsModal = this.page.getByTestId("building-settings-modal");
+    await expect(settingsModal).toBeVisible();
+    await settingsModal.getByTestId("building-settings-name-input").fill(buildingName);
+    await settingsModal.getByTestId("building-settings-modal-save").click();
+    await this.waitForModalToClose("building-settings-modal");
+  }
+
+  async validateSiteDetailBuildingVisible(buildingName: string) {
+    await expect(this.page.getByTestId("site-detail-page").getByText(buildingName, { exact: true })).toBeVisible();
+  }
+
+  async switchSiteDetailBreadcrumbTo(siteName: string) {
+    const switcher = this.page.getByTestId("site-detail-breadcrumb-switcher");
+    await expect(switcher).toBeVisible();
+    await switcher.click();
+    await this.page.getByTestId(`site-detail-breadcrumb-menu-item-${siteName}`).click();
+    await expect(this.page.getByTestId("site-detail-breadcrumb-switcher")).toContainText(siteName);
+    await expect(this.page.getByTestId("site-detail-title")).toHaveText(siteName);
+  }
+
+  async deleteSiteFromDetail() {
+    await expect(this.page.getByTestId("site-detail-edit")).toBeVisible();
+    await this.page.getByTestId("site-detail-edit").click();
+    await this.clickManageSiteDelete();
+
+    const confirmDeleteButton = this.page.getByTestId("site-delete-dialog-confirm");
+    await expect(confirmDeleteButton).toBeVisible();
+    await confirmDeleteButton.click({ trial: true });
+    await confirmDeleteButton.click();
+  }
+
+  async validateSiteNotVisible(name: string) {
+    await this.navigateToSitesPage();
+    await expect(this.getListRowByName(name)).toHaveCount(0);
   }
 
   async deleteSite(name: string) {
@@ -247,6 +351,16 @@ export class FleetLocationsPage extends BasePage {
 
     const overflowMenu = await this.openFullScreenOverflowMenu();
     await overflowMenu.getByTestId("manage-site-modal-delete-overflow-item").click();
+  }
+
+  private async clickManageSiteEditDetails(scope = this.page.getByTestId("full-screen-two-pane-modal")) {
+    if (!this.isMobile) {
+      await scope.getByTestId("manage-site-modal-edit-details").click();
+      return;
+    }
+
+    const overflowMenu = await this.openFullScreenOverflowMenu();
+    await overflowMenu.getByTestId("manage-site-modal-edit-details-overflow-item").click();
   }
 
   private async clickManageBuildingDelete() {

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -153,10 +153,13 @@ export class FleetLocationsPage extends BasePage {
     await this.page.getByTestId("site-detail-edit").click();
     await this.clickManageSiteDelete();
 
+    const deleteDialog = this.page.getByTestId("site-delete-dialog");
     const confirmDeleteButton = this.page.getByTestId("site-delete-dialog-confirm");
     await expect(confirmDeleteButton).toBeVisible();
     await confirmDeleteButton.click({ trial: true });
     await confirmDeleteButton.click();
+    await expect(deleteDialog).toHaveCount(0);
+    await expect(this.page.getByTestId("full-screen-two-pane-modal")).toHaveCount(0);
   }
 
   async validateSiteNotVisible(name: string) {

--- a/client/e2eTests/protoFleet/spec/sitesDetail.spec.ts
+++ b/client/e2eTests/protoFleet/spec/sitesDetail.spec.ts
@@ -1,0 +1,59 @@
+import { test } from "../fixtures/pageFixtures";
+import {
+  createSiteDetailScenarioData,
+  createSiteDetailSites,
+  useSiteDetailHooks,
+} from "../helpers/sitesDetailTestSetup";
+
+test.describe("Sites - detail", () => {
+  useSiteDetailHooks();
+
+  test("Site detail supports editing details, adding a building, and switching to a sibling site", async ({
+    fleetLocationsPage,
+  }, testInfo) => {
+    const scenario = createSiteDetailScenarioData(testInfo);
+
+    await createSiteDetailSites(fleetLocationsPage, scenario);
+    await fleetLocationsPage.openSiteDetail(scenario.siteName);
+    await fleetLocationsPage.validateSiteDetailOpened(scenario.siteName);
+    await fleetLocationsPage.validateSiteDetailMetrics({ location: "—", buildings: 0 });
+
+    await fleetLocationsPage.editSiteDetailsFromDetail({
+      name: scenario.renamedSiteName,
+      city: scenario.city,
+      powerCapacityMw: scenario.powerCapacityMw,
+    });
+
+    await fleetLocationsPage.validateSiteDetailOpened(scenario.renamedSiteName);
+    await fleetLocationsPage.validateSiteDetailMetrics({ location: scenario.city, buildings: 0 });
+
+    await fleetLocationsPage.addBuildingFromSiteDetail(scenario.buildingName);
+
+    await fleetLocationsPage.validateSiteDetailMetrics({ location: scenario.city, buildings: 1 });
+    await fleetLocationsPage.validateSiteDetailBuildingVisible(scenario.buildingName);
+    await fleetLocationsPage.switchSiteDetailBreadcrumbTo(scenario.siblingSiteName);
+    await fleetLocationsPage.validateSiteDetailOpened(scenario.siblingSiteName);
+    await fleetLocationsPage.validateSiteDetailMetrics({ location: "—", buildings: 0 });
+
+    await fleetLocationsPage.validateSiteRowCounts(scenario.renamedSiteName, {
+      buildings: 1,
+      racks: 0,
+      miners: 0,
+    });
+    await fleetLocationsPage.validateBuildingRowCounts(scenario.buildingName, {
+      siteName: scenario.renamedSiteName,
+      racks: 0,
+      miners: 0,
+    });
+  });
+
+  test("Deleting a site from the detail page removes it", async ({ fleetLocationsPage }, testInfo) => {
+    const scenario = createSiteDetailScenarioData(testInfo);
+
+    await fleetLocationsPage.createSite(scenario.siteName);
+    await fleetLocationsPage.openSiteDetail(scenario.siteName);
+
+    await fleetLocationsPage.deleteSiteFromDetail();
+    await fleetLocationsPage.validateSiteNotVisible(scenario.siteName);
+  });
+});

--- a/client/src/protoFleet/features/buildings/hooks/useBuildingModals.test.ts
+++ b/client/src/protoFleet/features/buildings/hooks/useBuildingModals.test.ts
@@ -163,6 +163,21 @@ describe("useBuildingModals", () => {
     }
   });
 
+  it("detailsSaveEdit invokes onMutationSuccess on update success", async () => {
+    vi.mocked(buildingsClient.updateBuilding).mockResolvedValue(makeUpdateResp(11n, "Renamed"));
+    const initial = makeBuildingRow(11n, "Old");
+    const onMutationSuccess = vi.fn();
+    const { result } = renderHook(() => useBuildingModals({ onMutationSuccess }));
+    act(() => result.current.openManage(initial, "North DC"));
+    act(() => result.current.manageEditDetails());
+
+    await act(async () => {
+      await result.current.detailsSaveEdit({ ...emptyBuildingFormValues(), name: "Renamed" });
+    });
+
+    expect(onMutationSuccess).toHaveBeenCalled();
+  });
+
   it("requestDeleteCurrent from detailsEdit sets deleteTarget and closes everything to none", () => {
     const row = makeBuildingRow(11n, "Target", 2n);
     const { result } = renderHook(() => useBuildingModals());

--- a/client/src/protoFleet/features/buildings/hooks/useBuildingModals.test.ts
+++ b/client/src/protoFleet/features/buildings/hooks/useBuildingModals.test.ts
@@ -105,7 +105,8 @@ describe("useBuildingModals", () => {
   it("detailsCreate calls CreateBuilding and closes on success", async () => {
     vi.mocked(buildingsClient.createBuilding).mockResolvedValue(makeCreateResp(11n, "Main"));
     const refetch = vi.fn();
-    const { result } = renderHook(() => useBuildingModals({ refetchBuildings: refetch }));
+    const onMutationSuccess = vi.fn();
+    const { result } = renderHook(() => useBuildingModals({ refetchBuildings: refetch, onMutationSuccess }));
     act(() => result.current.openDetailsCreate(7n, "North DC"));
 
     await act(async () => {
@@ -116,6 +117,7 @@ describe("useBuildingModals", () => {
       expect(buildingsClient.createBuilding).toHaveBeenCalledTimes(1);
     });
     expect(refetch).toHaveBeenCalled();
+    expect(onMutationSuccess).toHaveBeenCalled();
     expect(result.current.state.kind).toBe("none");
   });
 
@@ -186,7 +188,8 @@ describe("useBuildingModals", () => {
     vi.mocked(buildingsClient.deleteBuilding).mockResolvedValue(makeDeleteResp());
     const row = makeBuildingRow(11n, "Target");
     const onDeleteFromManage = vi.fn();
-    const { result } = renderHook(() => useBuildingModals({ onDeleteFromManage }));
+    const onMutationSuccess = vi.fn();
+    const { result } = renderHook(() => useBuildingModals({ onDeleteFromManage, onMutationSuccess }));
     act(() => result.current.openManage(row, "North DC"));
     act(() => result.current.manageEditDetails());
     act(() => result.current.requestDeleteCurrent());
@@ -197,6 +200,7 @@ describe("useBuildingModals", () => {
 
     expect(buildingsClient.deleteBuilding).toHaveBeenCalledWith({ id: 11n }, { signal: undefined });
     expect(onDeleteFromManage).toHaveBeenCalledWith(11n);
+    expect(onMutationSuccess).toHaveBeenCalled();
     expect(result.current.deleteTarget).toBeNull();
     expect(result.current.state.kind).toBe("none");
   });

--- a/client/src/protoFleet/features/buildings/hooks/useBuildingModals.ts
+++ b/client/src/protoFleet/features/buildings/hooks/useBuildingModals.ts
@@ -37,6 +37,9 @@ interface UseBuildingModalsOptions {
   // mutation so ManageSiteModal stays in sync without the
   // host wiring its own refetch into every callback.
   refetchBuildings?: () => void;
+  // Optional host-level follow-up when a successful building mutation also
+  // needs to refresh adjacent page state, like parent-site summary counts.
+  onMutationSuccess?: () => void;
   // Fires when a delete originating from ManageBuildingModal succeeds. The
   // manage modal's anchor is the now-deleted building, so the host page
   // (typically /buildings/:id) needs to navigate elsewhere — this hook
@@ -95,6 +98,7 @@ export interface BuildingModalsApi {
 
 const useBuildingModals = ({
   refetchBuildings,
+  onMutationSuccess,
   onDeleteFromManage,
 }: UseBuildingModalsOptions = {}): BuildingModalsApi => {
   const [state, setState] = useState<BuildingModalState>({ kind: "none" });
@@ -170,6 +174,7 @@ const useBuildingModals = ({
           onSuccess: (building) => {
             pushToast({ message: `Building "${building.name}" created`, status: STATUSES.success });
             refetchBuildings?.();
+            onMutationSuccess?.();
             // Functional setState so a mid-flight dismiss can't be overwritten
             // by this success closure.
             setState((prev) => (prev.kind === "detailsCreate" ? { kind: "none" } : prev));
@@ -186,7 +191,7 @@ const useBuildingModals = ({
         });
       });
     },
-    [state, createBuilding, refetchBuildings],
+    [state, createBuilding, refetchBuildings, onMutationSuccess],
   );
 
   const detailsSaveEdit = useCallback(
@@ -208,6 +213,7 @@ const useBuildingModals = ({
           onSuccess: (building) => {
             pushToast({ message: `Building "${building.name}" saved`, status: STATUSES.success });
             refetchBuildings?.();
+            onMutationSuccess?.();
             setState((prev) => {
               if (prev.kind === "detailsEdit") return { kind: "none" };
               if (prev.kind === "manageEditingDetails") {
@@ -231,7 +237,7 @@ const useBuildingModals = ({
         });
       });
     },
-    [state, updateBuilding, refetchBuildings],
+    [state, updateBuilding, refetchBuildings, onMutationSuccess],
   );
 
   const requestDeleteCurrent = useCallback(() => {
@@ -277,6 +283,7 @@ const useBuildingModals = ({
         onSuccess: () => {
           pushToast({ message: `Building "${name}" deleted`, status: STATUSES.success });
           refetchBuildings?.();
+          onMutationSuccess?.();
           setDeleteTarget(null);
           deleteFromManageRef.current = false;
           setState({ kind: "none" });
@@ -298,7 +305,7 @@ const useBuildingModals = ({
         onFinally: () => setDeleting(false),
       });
     });
-  }, [deleteTarget, deleteBuilding, refetchBuildings, onDeleteFromManage]);
+  }, [deleteTarget, deleteBuilding, refetchBuildings, onMutationSuccess, onDeleteFromManage]);
 
   const refreshBuildings = useCallback(() => {
     refetchBuildings?.();

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -143,7 +143,6 @@ const SiteDetailPage = () => {
   // Membership saves in ManageSiteModal also affect building rows, so share
   // the same refresh signal used for direct building mutations.
   const modals = useSiteModals({ refetchSites, refetchBuildings });
-  const buildingModals = useBuildingModals({ refetchBuildings, onMutationSuccess: refetchSites });
 
   const siteId = site?.site?.id;
   const siteIdText = siteId?.toString();
@@ -163,6 +162,11 @@ const SiteDetailPage = () => {
     error: siteStatsError,
     refetch: refetchSiteStats,
   } = useSiteStats({ siteId: siteId ?? 0n, enabled: siteId !== undefined, pollIntervalMs: POLL_INTERVAL_MS });
+  const handleBuildingMutationSuccess = useCallback(() => {
+    refetchSites();
+    refetchSiteStats();
+  }, [refetchSites, refetchSiteStats]);
+  const buildingModals = useBuildingModals({ refetchBuildings, onMutationSuccess: handleBuildingMutationSuccess });
 
   // Performance charts — mirrors the group/rack/building overview pages, but
   // scopes telemetry by site rather than by explicit device-set membership.
@@ -227,9 +231,8 @@ const SiteDetailPage = () => {
   }
 
   const hasLoadedVisibleBuildings = visibleBuildings !== undefined && visibleBuildingsError === null;
-  const detailBuildingCount = hasLoadedVisibleBuildings
-    ? visibleBuildings.length
-    : (siteStats?.buildingCount ?? Number(site.buildingCount));
+  const detailBuildingCount =
+    siteStats?.buildingCount ?? (hasLoadedVisibleBuildings ? visibleBuildings.length : Number(site.buildingCount));
 
   const siteSiblings = sites
     .filter((row) => row.site !== undefined)

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -94,12 +94,15 @@ const SiteDetailPage = () => {
     [listBuildingsBySite],
   );
 
-  // Bump retryCounter to re-run the effect so the cleanup AbortController
-  // stays owned by useEffect and isn't leaked by an imperative call.
+  // Bump retryCounter / sitesRefreshKey to re-run the effect so the cleanup
+  // AbortController stays owned by useEffect and isn't leaked by an
+  // imperative callback.
   const [retryCounter, setRetryCounter] = useState(0);
+  const [sitesRefreshKey, setSitesRefreshKey] = useState(0);
   const handleRetry = useCallback(() => setRetryCounter((n) => n + 1), []);
+  const refetchSites = useCallback(() => setSitesRefreshKey((n) => n + 1), []);
 
-  useEffect(() => fetchSites(), [fetchSites, retryCounter]);
+  useEffect(() => fetchSites(), [fetchSites, retryCounter, sitesRefreshKey]);
 
   // Bounce to /fleet when SitePicker switches to a different specific
   // site — "All sites" / "Unassigned" don't conflict with this view.
@@ -139,8 +142,8 @@ const SiteDetailPage = () => {
   const refetchBuildings = useCallback(() => setBuildingsRefreshKey((n) => n + 1), []);
   // Membership saves in ManageSiteModal also affect building rows, so share
   // the same refresh signal used for direct building mutations.
-  const modals = useSiteModals({ refetchSites: fetchSites, refetchBuildings });
-  const buildingModals = useBuildingModals({ refetchBuildings, onMutationSuccess: fetchSites });
+  const modals = useSiteModals({ refetchSites, refetchBuildings });
+  const buildingModals = useBuildingModals({ refetchBuildings, onMutationSuccess: refetchSites });
 
   const siteId = site?.site?.id;
   const siteIdText = siteId?.toString();
@@ -223,8 +226,10 @@ const SiteDetailPage = () => {
     );
   }
 
-  const detailBuildingCount =
-    visibleBuildings !== undefined ? visibleBuildings.length : (siteStats?.buildingCount ?? Number(site.buildingCount));
+  const hasLoadedVisibleBuildings = visibleBuildings !== undefined && visibleBuildingsError === null;
+  const detailBuildingCount = hasLoadedVisibleBuildings
+    ? visibleBuildings.length
+    : (siteStats?.buildingCount ?? Number(site.buildingCount));
 
   const siteSiblings = sites
     .filter((row) => row.site !== undefined)

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -140,7 +140,7 @@ const SiteDetailPage = () => {
   // Membership saves in ManageSiteModal also affect building rows, so share
   // the same refresh signal used for direct building mutations.
   const modals = useSiteModals({ refetchSites: fetchSites, refetchBuildings });
-  const buildingModals = useBuildingModals({ refetchBuildings });
+  const buildingModals = useBuildingModals({ refetchBuildings, onMutationSuccess: fetchSites });
 
   const siteId = site?.site?.id;
   const siteIdText = siteId?.toString();
@@ -223,6 +223,9 @@ const SiteDetailPage = () => {
     );
   }
 
+  const detailBuildingCount =
+    visibleBuildings !== undefined ? visibleBuildings.length : (siteStats?.buildingCount ?? Number(site.buildingCount));
+
   const siteSiblings = sites
     .filter((row) => row.site !== undefined)
     .map((row) => {
@@ -263,7 +266,7 @@ const SiteDetailPage = () => {
           testId="site-detail-breadcrumb"
         />
         <div className="flex items-start justify-between gap-4">
-          <Header title={site.site.name} titleSize="text-heading-300" />
+          <Header title={site.site.name} titleSize="text-heading-300" testId="site-detail-title" />
           {canManageSites ? (
             <Button
               variant={variants.primary}
@@ -290,7 +293,7 @@ const SiteDetailPage = () => {
             locationCity={site.site.locationCity}
             locationState={site.site.locationState}
             powerCapacityMw={site.site.powerCapacityMw}
-            buildingCount={siteStats?.buildingCount ?? Number(site.buildingCount)}
+            buildingCount={detailBuildingCount}
             metrics={siteStats}
             variant="compact"
             testId="site-detail-metrics-row"

--- a/client/src/shared/components/Metric/Metric.tsx
+++ b/client/src/shared/components/Metric/Metric.tsx
@@ -28,8 +28,13 @@ const Metric = ({ label, value, valueSize, variant = "default", testId, classNam
 
   return (
     <div className={clsx("flex flex-col", compact ? "gap-0.5" : "gap-1", className)} data-testid={testId}>
-      <div className="text-300 text-text-primary-50">{label}</div>
-      <div className={clsx(resolvedValueSize, "text-text-primary")}>
+      <div className="text-300 text-text-primary-50" data-testid={testId ? `${testId}-label` : undefined}>
+        {label}
+      </div>
+      <div
+        className={clsx(resolvedValueSize, "text-text-primary")}
+        data-testid={testId ? `${testId}-value` : undefined}
+      >
         {value === undefined ? (
           <SkeletonBar className={clsx("w-24", compact ? "h-4" : "h-7")} />
         ) : value === null ? (


### PR DESCRIPTION
🤖 Reviewable diff: +23/-8 across 3 files (excludes generated, test, and story files).

## Summary
This PR adds ProtoFleet E2E coverage for the new site detail workflow: opening a site from the Fleet Sites tab, editing its details, creating a building from the detail page, switching to a sibling site from the breadcrumb, and deleting a site from detail. To keep that scenario stable and readable, it also adds a few small product-side testability and refresh fixes so the detail header stays in sync with building mutations and exposes stable hooks for metric assertions.

## How it works
The new `sitesDetail.spec.ts` drives the site detail page end to end through the existing Fleet page objects. A dedicated setup helper creates per-run site/building prefixes, forces the topbar site picker into `All sites`, and cleans up only the fixtures created by the current run so desktop and mobile workers do not delete each other's data.

On the product side, the site detail header now exposes a stable title test id and metric value hooks. Building mutations triggered from site detail flow through `useBuildingModals`, which can now notify the host page after successful create/update/delete operations; the site detail page uses that callback to refresh its site row state and derives the displayed building count from the currently loaded building cards when available, so the header and buildings section stay aligned immediately after an in-page create.

## Diagrams
```mermaid
flowchart TD
  A["Fleet Sites tab"] --> B["Open /sites/:id detail view"]
  B --> C["Edit site details"]
  C --> D["Create building from detail"]
  D --> E["Refresh site/building state"]
  E --> F["Assert detail metrics and building cards"]
  F --> G["Switch to sibling site via breadcrumb"]
  G --> H["Assert sibling detail state"]
```

```mermaid
sequenceDiagram
  participant E2E as E2E spec
  participant Detail as SiteDetailPage
  participant Modals as useBuildingModals
  participant Sites as listSites
  participant Buildings as listBuildingsBySite

  E2E->>Detail: Add building
  Detail->>Modals: openDetailsCreate(siteId)
  Modals->>Buildings: createBuilding(...)
  Modals-->>Detail: onMutationSuccess()
  Detail->>Sites: refetch site rows
  Detail->>Buildings: refetch building cards
  Detail-->>E2E: header + cards reflect new building count
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/sitesDetail.spec.ts` | Adds the site-detail scenario coverage | Main user-facing workflow under test |
| `client/e2eTests/protoFleet/helpers/sitesDetailTestSetup.ts` | Adds isolated per-run fixture setup and cleanup | Prevents desktop/mobile runs from deleting each other's sites |
| `client/e2eTests/protoFleet/pages/base.ts` and `client/e2eTests/protoFleet/pages/fleetLocations.ts` | Adds site-detail page object helpers and more resilient Fleet navigation | Keeps the spec readable and avoids shell-navigation flakiness |
| `client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx` | Refreshes detail state after building mutations and adds a stable title hook | Ensures the header count matches the in-page building list immediately after create |
| `client/src/protoFleet/features/buildings/hooks/useBuildingModals.ts` | Adds an optional host-level mutation success callback | Lets site detail refresh adjacent site data without changing other callers |
| `client/src/shared/components/Metric/Metric.tsx` | Exposes stable `-label` / `-value` test ids | Lets E2E assert metric values without scraping combined label text |
| `client/src/protoFleet/features/buildings/hooks/useBuildingModals.test.ts` | Extends hook coverage for the new callback path | Verifies the new refresh hook fires on mutation success |

## Key technical decisions & trade-offs
- Detail-page building count now prefers the loaded building-card list over `siteStats.buildingCount` when cards are present, instead of waiting for a separate stats refresh, so the operator sees immediate consistency after creating a building in-page.
- Building-mutation refresh is routed through an optional `onMutationSuccess` callback on `useBuildingModals`, instead of hard-coding site-detail behavior into the shared hook, so existing building pages keep their current behavior.
- Site-detail fixture cleanup is scoped with a per-run randomized prefix, instead of a single shared automation prefix, so parallel desktop/mobile runs and local reruns cannot race each other’s teardown.

## Testing & validation
- `./node_modules/.bin/eslint e2eTests/protoFleet/pages/base.ts e2eTests/protoFleet/pages/fleetLocations.ts e2eTests/protoFleet/helpers/sitesDetailTestSetup.ts e2eTests/protoFleet/spec/sitesDetail.spec.ts src/protoFleet/features/sites/pages/SiteDetailPage.tsx src/shared/components/Metric/Metric.tsx src/protoFleet/features/buildings/hooks/useBuildingModals.ts src/protoFleet/features/buildings/hooks/useBuildingModals.test.ts`
- `npx vitest run src/protoFleet/features/buildings/hooks/useBuildingModals.test.ts src/protoFleet/features/sites/components/SiteMetricsRow.test.ts`
- `./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/sitesDetail.spec.ts --project=desktop`
- `./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/sitesDetail.spec.ts --project=mobile`
