### PR TITLE
fix(protoos): keep KPI tab navigation inside embedded miner view

### DIFF
--- a/client/src/protoOS/features/kpis/components/TabMenu/TabMenuWrapper.test.tsx
+++ b/client/src/protoOS/features/kpis/components/TabMenu/TabMenuWrapper.test.tsx
@@ -1,0 +1,56 @@
+import { useNavigate } from "react-router-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import TabMenuWrapper from "./TabMenuWrapper";
+import { useMinerHosting } from "@/protoOS/contexts/MinerHostingContext";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+    useLocation: vi.fn(() => ({ pathname: "/", search: "", hash: "", state: null, key: "default" })),
+  };
+});
+
+vi.mock("@/protoOS/contexts/MinerHostingContext", () => ({
+  useMinerHosting: vi.fn(),
+}));
+
+vi.mock("@/protoOS/store", () => ({
+  useMiner: vi.fn(() => undefined),
+  useTemperatureUnit: vi.fn(() => "F"),
+  convertAndFormatMeasurement: vi.fn(() => "--"),
+  convertValueUnits: vi.fn(() => ({ value: null })),
+}));
+
+describe("TabMenuWrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useNavigate as Mock).mockReturnValue(mockNavigate);
+  });
+
+  it("navigates to absolute KPI paths in standalone protoOS (empty minerRoot)", () => {
+    (useMinerHosting as Mock).mockReturnValue({ minerRoot: "" });
+
+    render(<TabMenuWrapper />);
+    fireEvent.click(screen.getByText("Hashrate").closest("button") as HTMLButtonElement);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/hashrate");
+  });
+
+  it("prefixes minerRoot so KPI tabs stay inside the embedded fleet miner view", () => {
+    (useMinerHosting as Mock).mockReturnValue({ minerRoot: "/miners/miner-1" });
+
+    render(<TabMenuWrapper />);
+    fireEvent.click(screen.getByText("Efficiency").closest("button") as HTMLButtonElement);
+
+    // Without the minerRoot prefix this would navigate to "/efficiency", which
+    // ProtoFleet's "/:siteScope" route treats as an unknown site and redirects
+    // back to the dashboard.
+    expect(mockNavigate).toHaveBeenCalledWith("/miners/miner-1/efficiency");
+  });
+});

--- a/client/src/protoOS/features/kpis/components/TabMenu/TabMenuWrapper.tsx
+++ b/client/src/protoOS/features/kpis/components/TabMenu/TabMenuWrapper.tsx
@@ -1,15 +1,18 @@
 import { memo, useMemo } from "react";
+import { useMinerHosting } from "@/protoOS/contexts/MinerHostingContext";
 import { convertAndFormatMeasurement, convertValueUnits, useMiner, useTemperatureUnit } from "@/protoOS/store";
 import TabMenu from "@/shared/components/TabMenu";
 import { getDisplayValue } from "@/shared/utils/stringUtils";
 
-type TabMenuWrapperProps = {
-  basePath?: string; // Optional base path for navigation
-};
-
-const TabMenuWrapper = memo(({ basePath }: TabMenuWrapperProps) => {
+const TabMenuWrapper = memo(() => {
   const temperatureUnit = useTemperatureUnit();
   const miner = useMiner();
+  // Prefix minerRoot so KPI tab navigation stays inside the embedded miner view
+  // when fleet-hosted (minerRoot is "" in standalone protoOS). Without it the
+  // absolute paths (e.g. "/hashrate") escape the embed and ProtoFleet's
+  // "/:siteScope" route treats the tab segment as an unknown site, redirecting
+  // back to the dashboard.
+  const { minerRoot } = useMinerHosting();
 
   const tabItems = useMemo(
     () => ({
@@ -52,7 +55,7 @@ const TabMenuWrapper = memo(({ basePath }: TabMenuWrapperProps) => {
     [miner, temperatureUnit],
   );
 
-  return <TabMenu items={tabItems} basePath={basePath} />;
+  return <TabMenu items={tabItems} basePath={minerRoot} />;
 });
 
 TabMenuWrapper.displayName = "TabMenuWrapper";

--- a/docs/solutions/logic-errors/kpi-tab-navigation-needs-minerroot-prefix-2026-07-02.md
+++ b/docs/solutions/logic-errors/kpi-tab-navigation-needs-minerroot-prefix-2026-07-02.md
@@ -1,0 +1,107 @@
+---
+title: KPI tab navigation must prefix minerRoot to stay inside the embedded miner view
+date: 2026-07-02
+category: docs/solutions/logic-errors
+module: client/src/protoOS/features/kpis
+problem_type: logic_error
+component: navigation
+symptoms:
+  - "Clicking Hashrate/Efficiency/Power Usage/Temperature in the single-miner view jumps back to the fleet dashboard"
+  - "KPI tab strip never shows an active tab when fleet-hosted"
+  - "Absolute navigation like /hashrate escapes the /miners/:id/* embed"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - client/src/shared/components/TabMenu
+  - client/src/protoOS/contexts/MinerHostingContext
+  - client/src/protoFleet/routing/siteScope
+tags: [navigation, single-miner, embedded-view, fleet-hosted, minerRoot, base-path, protoOS, protoFleet]
+---
+
+# KPI tab navigation must prefix minerRoot to stay inside the embedded miner view
+
+## Problem
+
+ProtoOS runs two ways: standalone (routes at `/hashrate`, `/efficiency`, …) and
+embedded inside ProtoFleet's single-miner view at `/miners/:id/*`. In-view
+navigation therefore cannot use absolute paths — the correct target depends on
+which shell is hosting.
+
+The KPI tab strip (the Hashrate / Efficiency / Power Usage / Temperature stat
+cards on the miner Home page) navigated to absolute paths. `KpiLayout` rendered
+`<TabMenu />` with no `basePath`, so the shared `TabMenu` defaulted it to `""`
+and called `navigate("/hashrate")`.
+
+- **Standalone ProtoOS:** `/hashrate` is a real route → worked.
+- **Fleet-embedded:** the target should be `/miners/:id/hashrate`, but it
+  navigated to `/hashrate`. ProtoFleet's router matches that against its
+  `/:siteScope` route (treating `"hashrate"` as a site slug), fails to resolve
+  it, and `SiteScopeLayout` renders `<Navigate to="/" replace />` →
+  `appEntryLoader` → the **dashboard**.
+
+A second, quieter symptom: the active-tab check
+(`basePath + items[key].path === location.pathname`) never matched in fleet
+mode, so no KPI tab ever appeared selected.
+
+## Symptoms
+
+- Clicking any KPI stat card in `/miners/:id/*` redirects to the fleet dashboard.
+- No KPI tab is highlighted as active when fleet-hosted.
+
+## Solution
+
+Derive the base path from `minerRoot` (provided by `MinerHostingContext`) instead
+of leaving it empty. `TabMenuWrapper` already had a dead `basePath` prop that was
+never passed; wire it to the hosting context:
+
+```tsx
+const TabMenuWrapper = memo(() => {
+  const temperatureUnit = useTemperatureUnit();
+  const miner = useMiner();
+  // Prefix minerRoot so KPI tab navigation stays inside the embedded miner view
+  // when fleet-hosted (minerRoot is "" in standalone protoOS). Without it the
+  // absolute paths (e.g. "/hashrate") escape the embed and ProtoFleet's
+  // "/:siteScope" route treats the tab segment as an unknown site, redirecting
+  // back to the dashboard.
+  const { minerRoot } = useMinerHosting();
+  // ...tabItems...
+  return <TabMenu items={tabItems} basePath={minerRoot} />;
+});
+```
+
+`minerRoot` is `/miners/:id` when fleet-hosted and `""` in standalone ProtoOS —
+both apps wrap the tree in `MinerHostingProvider` — so standalone behavior is
+unchanged. Coverage: `TabMenuWrapper.test.tsx` asserts `/hashrate` in standalone
+and `/miners/miner-1/efficiency` when hosted.
+
+## Why This Works
+
+`minerRoot` is the single source of truth for "where does this ProtoOS instance
+live in the URL tree." Prefixing it makes every navigation relative to the host
+shell without the component needing to know which shell that is. Sibling
+in-view navigations already followed this idiom:
+
+- `NavigationMenu/Navigation.tsx` — `navigate(`${minerRoot}/${navigationItem}`)`
+- `NoPoolsCallout/NoPoolsCallout.tsx` — `navigate(`${minerRoot}/${navigationItems.miningPools}`)`
+- `PageHeader/PoolStatus/PoolStatusWrapper.tsx` — same pattern
+
+The KPI tab strip was the one place that missed it.
+
+## Prevention
+
+- **Any navigation inside ProtoOS must be relative to `minerRoot`.** Never call
+  `navigate("/some-route")` or build a `<Link to="/some-route">` with a leading
+  slash in ProtoOS code — prefix `minerRoot` from `useMinerHosting()`.
+- The shared `TabMenu` defaulting `basePath` to `""` (i.e. absolute navigation)
+  is the trap. When adding a new embedded consumer of `TabMenu`, always pass an
+  explicit `basePath`; treat an unset `basePath` as a bug in fleet-hosted code.
+- When a route "silently redirects to the dashboard," suspect an absolute path
+  escaping the embed and being swallowed by ProtoFleet's `/:siteScope`
+  catch-all. That route treats any unknown top-level segment as a site slug.
+
+## Related
+
+Introduced by the embedded single-miner view: PR #581
+(`feat(fleet): single-miner view with embedded ProtoOS proxy`). The
+`minerRoot` prefixing convention comes from `MinerHostingContext`.


### PR DESCRIPTION
Reviewable diff: +116/-6 across 2 files (excludes generated, test, and story files). The load-bearing code change is +9/-6 in a single file (`TabMenuWrapper.tsx`); the remaining +107 is a `docs/solutions/` note.

## Summary

Clicking the **Hashrate / Efficiency / Power Usage / Temperature** stat cards in the embedded single-miner view (`/miners/:id/*`) kicked the user back to the fleet dashboard instead of switching KPI tabs. The KPI tab strip navigated with absolute paths (`/hashrate`), which escape the embed. This wires the tab strip's base path to `minerRoot` so navigation stays inside the hosted miner view. Standalone ProtoOS is unaffected (`minerRoot` is `""` there).

## How it works

ProtoOS runs in two shells: standalone (routes live at `/hashrate`, `/efficiency`, …) and embedded inside ProtoFleet's single-miner view at `/miners/:id/*`. In-view navigation must be relative to whichever shell is hosting, so `MinerHostingContext` exposes `minerRoot` — `/miners/:id` when fleet-hosted, `""` when standalone.

The KPI tab strip (`TabMenuWrapper` → shared `TabMenu`) was the one navigation that didn't prefix `minerRoot`: `KpiLayout` rendered `<TabMenu />` with no `basePath`, so the shared component defaulted it to `""` and called `navigate("/hashrate")`.

- **Standalone:** `/hashrate` is a real route → fine.
- **Fleet-embedded:** the target should be `/miners/:id/hashrate`, but it navigated to `/hashrate`. ProtoFleet's router matches that against its `/:siteScope` route (treating `"hashrate"` as a site slug), fails to resolve it, and `SiteScopeLayout` renders `<Navigate to="/" replace />` → `appEntryLoader` → the dashboard. A quieter side effect: the active-tab check (`basePath + path === pathname`) never matched, so no tab appeared selected in fleet mode.

The fix reads `minerRoot` from `useMinerHosting()` and passes it as `basePath`, matching the idiom already used by `Navigation`, `NoPoolsCallout`, and `PoolStatusWrapper`. The dead `basePath` prop on `TabMenuWrapper` (declared, never passed) is removed.

## Diagrams

```mermaid
flowchart TD
    Click["Click KPI card in /miners/:id/*"] --> Wrapper["TabMenuWrapper"]
    Wrapper --> Root{"basePath source"}
    Root -->|"before: none, defaults to empty"| Abs["navigate('/hashrate')"]
    Root -->|"after: minerRoot"| Scoped["navigate('/miners/:id/hashrate')"]
    Abs --> SiteScope["ProtoFleet '/:siteScope' route treats 'hashrate' as a site"]
    SiteScope --> Redirect["Unknown site -> Navigate to '/' -> dashboard"]
    Scoped --> Stay["Hashrate tab renders inside embedded view"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoOS/features/kpis/components/TabMenu/TabMenuWrapper.tsx` | Read `minerRoot` from `useMinerHosting()`, pass as `basePath`; drop unused `basePath` prop | The whole fix. Confirm `minerRoot` is the right base-path source and standalone (`""`) is preserved |
| `client/src/protoOS/features/kpis/components/TabMenu/TabMenuWrapper.test.tsx` | New test | Covers standalone (`/hashrate`) and fleet-hosted (`/miners/miner-1/efficiency`) navigation |
| `docs/solutions/logic-errors/kpi-tab-navigation-needs-minerroot-prefix-2026-07-02.md` | New solution note | Documents the "ProtoOS navigation must prefix `minerRoot`" convention so the next embedded consumer doesn't repeat it |

## Key technical decisions & trade-offs

- **Fix in `TabMenuWrapper`, not shared `TabMenu`.** `TabMenuWrapper` is the ProtoOS-specific wrapper that already has access to `useMinerHosting()`; the shared `TabMenu` stays presentational and shell-agnostic. Alternative — defaulting `basePath` inside shared `TabMenu` — was rejected because `shared/` cannot import from `protoOS/` (component-boundary rule) and shouldn't know about hosting.
- **Reuse `minerRoot` rather than a new prop drill.** Matches the three existing sibling navigations, so there's one convention to reason about.

## Testing & validation

- New `TabMenuWrapper.test.tsx`: asserts `/hashrate` in standalone and `/miners/miner-1/efficiency` when fleet-hosted. Both pass.
- Existing shared `TabMenu` tests still pass.
- `tsc --noEmit` clean; `eslint` clean on changed files; lefthook pre-commit (format) and pre-push (typecheck) passed.
- Not covered: no E2E added; verified via unit tests and reasoning about the ProtoFleet `/:siteScope` redirect path rather than a live click-through.
