### PR TITLE
fix(rbac): log role create/update/delete to the activity log

### DIFF
--- a/client/src/protoFleet/features/activity/utils/activityIcons.tsx
+++ b/client/src/protoFleet/features/activity/utils/activityIcons.tsx
@@ -33,6 +33,7 @@ const iconMap: Record<string, (props: IconProps) => ReactNode> = {
   deactivate_user: Trash,
   reset_password: Lock,
   create_admin_user: Lock,
+  update_user_role: Lock,
 
   stop_mining: Power,
   start_mining: Power,
@@ -61,6 +62,10 @@ const iconMap: Record<string, (props: IconProps) => ReactNode> = {
   create_pool: MiningPools,
   update_pool: MiningPools,
   delete_pool: Trash,
+
+  create_role: Lock,
+  update_role: Edit,
+  delete_role: Trash,
 };
 
 export function getActivityIcon(eventType: string): (props: IconProps) => ReactNode {

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -656,7 +656,7 @@ func start(config *Config) error {
 	mux.Handle(foremanimportv1connect.NewForemanImportServiceHandler(foremanImportHandler.NewHandler(foremanImportSvc), li))
 	mux.Handle(activityv1connect.NewActivityServiceHandler(activityHandler.NewHandler(activitySvc), li))
 	mux.Handle(apikeyv1connect.NewApiKeyServiceHandler(apikeyHandler.NewHandler(apiKeySvc), li))
-	mux.Handle(authzv1connect.NewAuthzServiceHandler(authzHandler.NewHandler(authz.NewService(conn)), li))
+	mux.Handle(authzv1connect.NewAuthzServiceHandler(authzHandler.NewHandler(authz.NewService(conn, activitySvc)), li))
 	mux.Handle(serverlogv1connect.NewServerLogServiceHandler(serverlogHandler.NewHandler(logging.DefaultBuffer()), li))
 
 	alertHandler := alertsHandler.NewHandler(alertsSvc, notificationHistoryStore)

--- a/server/internal/domain/authz/service.go
+++ b/server/internal/domain/authz/service.go
@@ -55,16 +55,28 @@ func NewService(conn *sql.DB, activitySvc *activity.Service) *Service {
 	return &Service{conn: conn, activitySvc: activitySvc}
 }
 
+// auditWriteTimeout bounds the detached audit-log insert (see
+// logActivity) so a stuck write can't leak a goroutine.
+const auditWriteTimeout = 5 * time.Second
+
 // logActivity records a role-management event, stamping the acting user
 // from the request's session so the activity feed attributes it to the
 // caller. Role CRUD sits in the auth category alongside update_user_role
 // (role assignment), so the whole RBAC surface reads from one bucket.
+//
+// Callers invoke this only after the role mutation has committed, so the
+// audit write is detached from the request context via WithoutCancel: a
+// client that cancels or times out the moment the change lands must not
+// suppress the audit row for a security-sensitive RBAC change. A bounded
+// timeout keeps the detached write from hanging.
 func (s *Service) logActivity(ctx context.Context, event activitymodels.Event) {
 	if s.activitySvc == nil {
 		return
 	}
 	activity.StampActor(ctx, &event)
-	s.activitySvc.Log(ctx, event)
+	logCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), auditWriteTimeout)
+	defer cancel()
+	s.activitySvc.Log(logCtx, event)
 }
 
 // RoleView is the domain-layer projection of a role row plus its

--- a/server/internal/domain/authz/service.go
+++ b/server/internal/domain/authz/service.go
@@ -56,7 +56,9 @@ func NewService(conn *sql.DB, activitySvc *activity.Service) *Service {
 }
 
 // auditWriteTimeout bounds the detached audit-log insert (see
-// logActivity) so a stuck write can't leak a goroutine.
+// logActivity). Because the insert runs synchronously on the request
+// path after WithoutCancel strips the caller's deadline, a hung DB write
+// would otherwise block the handler indefinitely; the timeout caps that.
 const auditWriteTimeout = 5 * time.Second
 
 // logActivity records a role-management event, stamping the acting user
@@ -68,7 +70,7 @@ const auditWriteTimeout = 5 * time.Second
 // audit write is detached from the request context via WithoutCancel: a
 // client that cancels or times out the moment the change lands must not
 // suppress the audit row for a security-sensitive RBAC change. A bounded
-// timeout keeps the detached write from hanging.
+// timeout keeps a hung insert from blocking the handler on that same path.
 func (s *Service) logActivity(ctx context.Context, event activitymodels.Event) {
 	if s.activitySvc == nil {
 		return

--- a/server/internal/domain/authz/service.go
+++ b/server/internal/domain/authz/service.go
@@ -13,6 +13,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/block/proto-fleet/server/generated/sqlc"
+	"github.com/block/proto-fleet/server/internal/domain/activity"
+	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 )
@@ -38,15 +40,31 @@ const (
 // same transaction as the write so a concurrent UnassignRole or role-
 // permission edit can't slip in between the check and the persist.
 type Service struct {
-	conn *sql.DB
+	conn        *sql.DB
+	activitySvc *activity.Service
 }
 
 // NewService wires a Service to the connection pool. The per-request
 // permission resolver lives in the middleware layer; this service
 // re-loads effective permissions inside its own transaction via
 // LoadEffectiveTx so the parity check is consistent with the write.
-func NewService(conn *sql.DB) *Service {
-	return &Service{conn: conn}
+//
+// activitySvc records role-management audit events; it may be nil (its
+// Log method is a no-op on a nil receiver), which tests rely on.
+func NewService(conn *sql.DB, activitySvc *activity.Service) *Service {
+	return &Service{conn: conn, activitySvc: activitySvc}
+}
+
+// logActivity records a role-management event, stamping the acting user
+// from the request's session so the activity feed attributes it to the
+// caller. Role CRUD sits in the auth category alongside update_user_role
+// (role assignment), so the whole RBAC surface reads from one bucket.
+func (s *Service) logActivity(ctx context.Context, event activitymodels.Event) {
+	if s.activitySvc == nil {
+		return
+	}
+	activity.StampActor(ctx, &event)
+	s.activitySvc.Log(ctx, event)
 }
 
 // RoleView is the domain-layer projection of a role row plus its
@@ -145,7 +163,7 @@ func (s *Service) CreateCustomRole(ctx context.Context, callerID, orgID int64, n
 		return RoleView{}, err
 	}
 	trimmedDescription := strings.TrimSpace(description)
-	return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (RoleView, error) {
+	view, err := db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (RoleView, error) {
 		if err := authorizeCallerCanGrant(ctx, q, callerID, orgID, normalized); err != nil {
 			return RoleView{}, err
 		}
@@ -162,6 +180,18 @@ func (s *Service) CreateCustomRole(ctx context.Context, callerID, orgID int64, n
 		}
 		return hydrateRole(ctx, q, role)
 	})
+	if err != nil {
+		return RoleView{}, err
+	}
+	// Logged after commit so a rolled-back attempt leaves no audit row.
+	s.logActivity(ctx, activitymodels.Event{
+		Category:       activitymodels.CategoryAuth,
+		Type:           "create_role",
+		Description:    fmt.Sprintf("Role created: %s", view.Name),
+		OrganizationID: &orgID,
+		Metadata:       map[string]any{"role_id": view.ID, "role_name": view.Name, "permission_keys": normalized},
+	})
+	return view, nil
 }
 
 // UpdateCustomRole replaces the name, description, and permission set
@@ -179,7 +209,7 @@ func (s *Service) UpdateCustomRole(ctx context.Context, callerID, orgID, roleID 
 		return RoleView{}, err
 	}
 	trimmedDescription := strings.TrimSpace(description)
-	return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (RoleView, error) {
+	view, err := db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (RoleView, error) {
 		existing, err := getRoleInOrg(ctx, q, orgID, roleID)
 		if err != nil {
 			return RoleView{}, err
@@ -217,6 +247,18 @@ func (s *Service) UpdateCustomRole(ctx context.Context, callerID, orgID, roleID 
 		}
 		return hydrateRole(ctx, q, updated)
 	})
+	if err != nil {
+		return RoleView{}, err
+	}
+	// Logged after commit so a rolled-back attempt leaves no audit row.
+	s.logActivity(ctx, activitymodels.Event{
+		Category:       activitymodels.CategoryAuth,
+		Type:           "update_role",
+		Description:    fmt.Sprintf("Role updated: %s", view.Name),
+		OrganizationID: &orgID,
+		Metadata:       map[string]any{"role_id": view.ID, "role_name": view.Name, "permission_keys": normalized},
+	})
+	return view, nil
 }
 
 // DeleteCustomRole soft-deletes a custom role. Refuses on any active
@@ -238,7 +280,8 @@ func (s *Service) UpdateCustomRole(ctx context.Context, callerID, orgID, roleID 
 // user_organization_role row) cannot slip an assignment in between the
 // count check and the soft delete.
 func (s *Service) DeleteCustomRole(ctx context.Context, callerID, orgID, roleID int64) error {
-	return db.WithTransactionNoResult(ctx, s.conn, func(q *sqlc.Queries) error {
+	var deletedName string
+	err := db.WithTransactionNoResult(ctx, s.conn, func(q *sqlc.Queries) error {
 		if err := authorizeCallerCanGrant(ctx, q, callerID, orgID, nil); err != nil {
 			return err
 		}
@@ -259,8 +302,21 @@ func (s *Service) DeleteCustomRole(ctx context.Context, callerID, orgID, roleID 
 		if err := q.SoftDeleteCustomRole(ctx, roleID); err != nil {
 			return fleeterror.NewInternalErrorf("authz: soft delete role: %w", err)
 		}
+		deletedName = existing.Name
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+	// Logged after commit so a rolled-back attempt leaves no audit row.
+	s.logActivity(ctx, activitymodels.Event{
+		Category:       activitymodels.CategoryAuth,
+		Type:           "delete_role",
+		Description:    fmt.Sprintf("Role deleted: %s", deletedName),
+		OrganizationID: &orgID,
+		Metadata:       map[string]any{"role_id": roleID, "role_name": deletedName},
+	})
+	return nil
 }
 
 // authorizeCallerCanGrant runs privilege-parity inside the active

--- a/server/internal/domain/authz/service_integration_test.go
+++ b/server/internal/domain/authz/service_integration_test.go
@@ -1,13 +1,18 @@
 package authz_test
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
+	"connectrpc.com/authn"
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/proto-fleet/server/generated/sqlc"
+	"github.com/block/proto-fleet/server/internal/domain/activity"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
@@ -37,7 +42,7 @@ func setupOrgWithSuperAdmin(t *testing.T, db *sql.DB) (int64, int64) {
 func TestService_CreateCustomRole_Succeeds(t *testing.T) {
 	db := testutil.GetTestDB(t)
 	orgID, userID := setupOrgWithSuperAdmin(t, db)
-	svc := authz.NewService(db)
+	svc := authz.NewService(db, nil)
 
 	view, err := svc.CreateCustomRole(t.Context(), userID, orgID,
 		"Floor Manager", "  trim me  ",
@@ -77,7 +82,7 @@ func TestService_CreateCustomRole_PrivilegeParityRejectsBeyondCaller(t *testing.
 	})
 	require.NoError(t, err)
 
-	svc := authz.NewService(db)
+	svc := authz.NewService(db, nil)
 	_, err = svc.CreateCustomRole(ctx, callerID, orgID,
 		"Reboot Plus", "",
 		[]string{authz.PermFleetRead, authz.PermMinerRead, authz.PermMinerReboot},
@@ -100,7 +105,7 @@ func TestService_CreateCustomRole_DeactivatedCallerCannotPersistGrants(t *testin
 	)
 	require.NoError(t, err)
 
-	svc := authz.NewService(db)
+	svc := authz.NewService(db, nil)
 	_, err = svc.CreateCustomRole(ctx, userID, orgID,
 		"Should Fail", "",
 		[]string{authz.PermFleetRead},
@@ -112,7 +117,7 @@ func TestService_CreateCustomRole_DeactivatedCallerCannotPersistGrants(t *testin
 func TestService_UpdateCustomRole_RejectsBuiltins(t *testing.T) {
 	db := testutil.GetTestDB(t)
 	orgID, userID := setupOrgWithSuperAdmin(t, db)
-	svc := authz.NewService(db)
+	svc := authz.NewService(db, nil)
 
 	for _, key := range []string{"SUPER_ADMIN", "ADMIN", "FIELD_TECH"} {
 		builtinRoleID := getBuiltinRoleID(t, db, orgID, key)
@@ -128,7 +133,7 @@ func TestService_UpdateCustomRole_RejectsBuiltins(t *testing.T) {
 func TestService_DeleteCustomRole_RejectsBuiltins(t *testing.T) {
 	db := testutil.GetTestDB(t)
 	orgID, callerID := setupOrgWithSuperAdmin(t, db)
-	svc := authz.NewService(db)
+	svc := authz.NewService(db, nil)
 
 	for _, key := range []string{"SUPER_ADMIN", "ADMIN", "FIELD_TECH"} {
 		builtinRoleID := getBuiltinRoleID(t, db, orgID, key)
@@ -142,7 +147,7 @@ func TestService_DeleteCustomRole_RejectsRoleWithActiveAssignments(t *testing.T)
 	db := testutil.GetTestDB(t)
 	ctx := t.Context()
 	orgID, callerID := setupOrgWithSuperAdmin(t, db)
-	svc := authz.NewService(db)
+	svc := authz.NewService(db, nil)
 
 	view, err := svc.CreateCustomRole(ctx, callerID, orgID,
 		"Operator", "",
@@ -175,7 +180,7 @@ func TestService_DeleteCustomRole_DeactivatedAssigneeDoesNotBlockDeletion(t *tes
 	db := testutil.GetTestDB(t)
 	ctx := t.Context()
 	orgID, callerID := setupOrgWithSuperAdmin(t, db)
-	svc := authz.NewService(db)
+	svc := authz.NewService(db, nil)
 
 	view, err := svc.CreateCustomRole(ctx, callerID, orgID,
 		"Old Operator", "",
@@ -211,7 +216,7 @@ func TestService_DeleteCustomRole_CrossOrgRoleIDMaskedAsInvalidArgument(t *testi
 	orgA, callerA := setupOrgWithSuperAdmin(t, db)
 	orgB, callerB := setupOrgWithSuperAdmin(t, db)
 
-	svc := authz.NewService(db)
+	svc := authz.NewService(db, nil)
 	roleInB, err := svc.CreateCustomRole(ctx, callerB, orgB,
 		"OrgB Role", "",
 		[]string{authz.PermFleetRead},
@@ -231,7 +236,7 @@ func TestService_ListRoles_BuiltinOrderAndCustomMemberCount(t *testing.T) {
 	ctx := t.Context()
 	orgID, callerID := setupOrgWithSuperAdmin(t, db)
 
-	svc := authz.NewService(db)
+	svc := authz.NewService(db, nil)
 	custom, err := svc.CreateCustomRole(ctx, callerID, orgID,
 		"Site Lead", "",
 		[]string{authz.PermFleetRead, authz.PermSiteRead},
@@ -268,6 +273,84 @@ func TestService_ListRoles_BuiltinOrderAndCustomMemberCount(t *testing.T) {
 		[]string{authz.PermFleetRead, authz.PermSiteRead},
 		roles[3].PermissionKeys,
 	)
+}
+
+// ctxWithSession attaches session info so activity.StampActor can
+// attribute logged events to the acting caller, mirroring what the
+// authn middleware does on a live request.
+func ctxWithSession(t *testing.T, externalUserID, username string, orgID int64) context.Context {
+	t.Helper()
+	return authn.SetInfo(t.Context(), &session.Info{
+		SessionID:      "test-session",
+		OrganizationID: orgID,
+		ExternalUserID: externalUserID,
+		Username:       username,
+	})
+}
+
+// countActivityEvents returns how many activity_log rows exist for the
+// given org and event_type.
+func countActivityEvents(t *testing.T, db *sql.DB, orgID int64, eventType string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM activity_log WHERE organization_id = $1 AND event_type = $2`,
+		orgID, eventType,
+	).Scan(&n))
+	return n
+}
+
+// TestService_RoleMutations_WriteActivityLog covers the audit-log gap
+// where role CRUD produced no activity rows even though role assignment
+// (update_user_role) did. Each mutation must emit exactly one event
+// attributed to the caller.
+func TestService_RoleMutations_WriteActivityLog(t *testing.T) {
+	db := testutil.GetTestDB(t)
+	orgID, callerID := setupOrgWithSuperAdmin(t, db)
+	activitySvc := activity.NewService(sqlstores.NewSQLActivityStore(db))
+	svc := authz.NewService(db, activitySvc)
+	ctx := ctxWithSession(t, "ext-caller", "caller", orgID)
+
+	view, err := svc.CreateCustomRole(ctx, callerID, orgID,
+		"Auditable Role", "",
+		[]string{authz.PermFleetRead, authz.PermMinerRead},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, countActivityEvents(t, db, orgID, "create_role"))
+
+	_, err = svc.UpdateCustomRole(ctx, callerID, orgID, view.ID,
+		"Auditable Role", "now with a description",
+		[]string{authz.PermFleetRead, authz.PermMinerRead},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, countActivityEvents(t, db, orgID, "update_role"))
+
+	require.NoError(t, svc.DeleteCustomRole(ctx, callerID, orgID, view.ID))
+	require.Equal(t, 1, countActivityEvents(t, db, orgID, "delete_role"))
+
+	// The event must be attributed to the acting caller via StampActor.
+	var username string
+	require.NoError(t, db.QueryRow(
+		`SELECT username FROM activity_log WHERE organization_id = $1 AND event_type = 'create_role'`,
+		orgID,
+	).Scan(&username))
+	require.Equal(t, "caller", username)
+}
+
+// TestService_RoleMutations_NoActivityLogWhenRejected ensures a failed
+// mutation leaves no audit row: the log call sits after the transaction
+// commits, so a rejected delete must not emit an event.
+func TestService_RoleMutations_NoActivityLogWhenRejected(t *testing.T) {
+	db := testutil.GetTestDB(t)
+	orgID, callerID := setupOrgWithSuperAdmin(t, db)
+	activitySvc := activity.NewService(sqlstores.NewSQLActivityStore(db))
+	svc := authz.NewService(db, activitySvc)
+	ctx := ctxWithSession(t, "ext-caller", "caller", orgID)
+
+	// Deleting a non-existent role id is rejected before any write.
+	err := svc.DeleteCustomRole(ctx, callerID, orgID, 999_999_999)
+	require.Error(t, err)
+	require.Equal(t, 0, countActivityEvents(t, db, orgID, "delete_role"))
 }
 
 // createCustomRoleWithPermissions inserts a custom role directly via

--- a/server/internal/handlers/authz/handler_integration_test.go
+++ b/server/internal/handlers/authz/handler_integration_test.go
@@ -42,7 +42,7 @@ func TestHandler_ListRoles_AcceptsUserManageOnlyCaller(t *testing.T) {
 		`SELECT id FROM organization WHERE org_id = $1`, "listroles-gate-org").Scan(&orgID))
 	require.NoError(t, authzDomain.Reconcile(ctx, db))
 
-	svc := authzDomain.NewService(db)
+	svc := authzDomain.NewService(db, nil)
 	handler := authz.NewHandler(svc)
 
 	resp, err := handler.ListRoles(
@@ -72,7 +72,7 @@ func TestHandler_ListRoles_DeniesWhenNeitherKeyHeld(t *testing.T) {
 		`SELECT id FROM organization WHERE org_id = $1`, "listroles-deny-org").Scan(&orgID))
 	require.NoError(t, authzDomain.Reconcile(ctx, db))
 
-	svc := authzDomain.NewService(db)
+	svc := authzDomain.NewService(db, nil)
 	handler := authz.NewHandler(svc)
 
 	_, err = handler.ListRoles(


### PR DESCRIPTION
## Problem

Actions on roles didn't appear in the activity log, even though **role assignment** changes did.

Root cause: role assignment (`update_user_role`) lives in the **auth** service, which is wired to the activity log. Role CRUD lives in the separate **authz** service, which had no activity dependency — so `CreateCustomRole` / `UpdateCustomRole` / `DeleteCustomRole` silently produced no audit rows.

## Change

- Give the authz `Service` an `*activity.Service` and a `logActivity` helper that stamps the acting caller from the request session (mirrors the auth service pattern).
- Emit `create_role` / `update_role` / `delete_role` events (under the `auth` category, next to `update_user_role`) **after the transaction commits**, so a rolled-back or rejected mutation leaves no audit row. Each event carries `role_id`, `role_name`, and (for create/update) `permission_keys` metadata.
- Wire the activity service into `authz.NewService` at bootstrap.
- Add activity-log icons for the three new events, plus the previously unmapped `update_user_role`, so they render with semantic icons instead of the generic fallback. (The displayed label already comes from the backend `description`, so no label mapping was needed.)

## Testing

- New integration tests: each of create/update/delete writes exactly one event attributed to the caller; a rejected delete writes nothing.
- `go build ./...`, `go vet`, `golangci-lint`, client `tsc --noEmit`, and `eslint` all clean.
- Full authz domain + handler suites pass.