### PR TITLE
fix(rbac): stop over-gating Fleet + Miner sections for infra-less roles

### DIFF
--- a/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
+++ b/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
@@ -31,6 +31,12 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
   const permissions = usePermissions();
   const featureEnabled = useNavFeatureEnabled();
   const { activeSite } = useActiveSite({});
+  // Site-scoped links resolve the slug via ResolveSiteBySlug (site:read-gated),
+  // which bounces a role without site:read. Such a role has no meaningful site
+  // scope, so build unscoped links for it (e.g. Fleet reached via miner:read).
+  const canScopeToSite = permissions.includes("site:read");
+  const scopeLink = (item: Pick<NavItem, "path" | "scopable">) =>
+    item.scopable && canScopeToSite ? scopedPath(item.path, activeSite) : item.path;
   const [settingsManuallyToggled, setSettingsManuallyToggled] = useState(false);
   const visibleItems = useMemo(
     () => items.filter((item) => isNavItemAllowedByPermissions(item, permissions)),
@@ -116,7 +122,7 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
             })}
           >
             <Link
-              to={homeItem.scopable ? scopedPath(homeItem.path, activeSite) : homeItem.path}
+              to={scopeLink(homeItem)}
               aria-label="Home"
               className={clsx("flex items-center", {
                 "w-full": isPhone || isTablet,
@@ -148,7 +154,7 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
             return item.path ? (
               <li key={item.path} className="w-full">
                 <Link
-                  to={item.scopable ? scopedPath(item.path, activeSite) : item.path}
+                  to={scopeLink(item)}
                   onClick={() => closeMenu?.()}
                   aria-label={item.label}
                   aria-current={isCurrentPath(item) ? "page" : undefined}

--- a/client/src/protoFleet/components/NavigationMenu/NavigationMenu.test.tsx
+++ b/client/src/protoFleet/components/NavigationMenu/NavigationMenu.test.tsx
@@ -3,13 +3,26 @@ import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import NavigationMenu from "./NavigationMenu";
 import { NavItem } from "@/protoFleet/config/navItems";
+import type { ActiveSite } from "@/protoFleet/store/types/activeSite";
 
-const { mockUseWindowDimensions } = vi.hoisted(() => ({
+const { mockUseWindowDimensions, permissionsMock, activeSiteMock } = vi.hoisted(() => ({
   mockUseWindowDimensions: vi.fn(),
+  permissionsMock: { current: [] as string[] },
+  activeSiteMock: { current: { kind: "all" } as ActiveSite },
 }));
 
 vi.mock("@/shared/hooks/useWindowDimensions", () => ({
   useWindowDimensions: mockUseWindowDimensions,
+}));
+
+vi.mock("@/protoFleet/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/protoFleet/store")>()),
+  usePermissions: () => permissionsMock.current,
+}));
+
+vi.mock("@/protoFleet/components/PageHeader/SitePicker", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/protoFleet/components/PageHeader/SitePicker")>()),
+  useActiveSite: () => ({ activeSite: activeSiteMock.current }),
 }));
 
 describe("Navigation Menu", () => {
@@ -30,6 +43,8 @@ describe("Navigation Menu", () => {
       isPhone: false,
       isTablet: false,
     });
+    permissionsMock.current = [];
+    activeSiteMock.current = { kind: "all" };
   });
 
   it("should render the correct number nav items", () => {
@@ -54,6 +69,36 @@ describe("Navigation Menu", () => {
     const currentItem = getByText("Foo").closest("a");
     await waitFor(() => {
       expect(currentItem).toHaveClass("bg-core-primary-5");
+    });
+  });
+
+  describe("site scoping of scopable links", () => {
+    const scopableItems: NavItem[] = [{ path: "/fleet", label: "Fleet", scopable: true }];
+
+    beforeEach(() => {
+      activeSiteMock.current = { kind: "site", id: "1", slug: "alpha" };
+    });
+
+    it("scopes the link to the active site when the role can read sites", () => {
+      permissionsMock.current = ["site:read"];
+      const { getByText } = render(
+        <MemoryRouter>
+          <NavigationMenu items={scopableItems} />
+        </MemoryRouter>,
+      );
+      expect(getByText("Fleet").closest("a")).toHaveAttribute("href", "/alpha/fleet");
+    });
+
+    it("keeps the link unscoped for a role without site:read", () => {
+      // Resolving the /alpha slug is site:read-gated; a site-less role reaching
+      // Fleet via miner:read would be bounced, so the link must stay unscoped.
+      permissionsMock.current = ["miner:read", "fleet:read"];
+      const { getByText } = render(
+        <MemoryRouter>
+          <NavigationMenu items={scopableItems} />
+        </MemoryRouter>,
+      );
+      expect(getByText("Fleet").closest("a")).toHaveAttribute("href", "/fleet");
     });
   });
 });

--- a/client/src/protoFleet/config/navItems.test.ts
+++ b/client/src/protoFleet/config/navItems.test.ts
@@ -20,18 +20,18 @@ describe("primaryNavItems", () => {
     const fleet = primaryNavItems.find((item) => item.label === "Fleet");
 
     expect(fleet?.requiredPermission).toBeUndefined();
-    expect(fleet?.requiredAnyPermission).toEqual(["rack:read", "site:read", "miner:read"]);
+    expect(fleet?.requiredAnyPermission).toEqual(["rack:read", "site:read", ["miner:read", "fleet:read"]]);
 
     // Rack- and site-only readers can reach Fleet tabs (racks / sites), so the
     // nav entry stays visible for them.
     expect(isNavItemAllowedByPermissions(fleet!, ["rack:read"])).toBe(true);
     expect(isNavItemAllowedByPermissions(fleet!, ["site:read"])).toBe(true);
-    // A Miner reader reaches the miners tab (which needs miner:read + the
-    // catalog-paired fleet:read), so the nav entry must be visible for it.
-    expect(isNavItemAllowedByPermissions(fleet!, ["miner:read"])).toBe(true);
+    // The miners tab needs miner:read AND fleet:read together, so only the pair
+    // makes the nav entry visible via the miners path.
     expect(isNavItemAllowedByPermissions(fleet!, ["miner:read", "fleet:read"])).toBe(true);
-    // fleet:read alone unlocks no Fleet tab, so it must NOT advertise an
-    // unreachable page.
+    // Neither half alone reaches a tab (read-pairing does not force fleet:read
+    // onto miner:read), so neither may advertise the page.
+    expect(isNavItemAllowedByPermissions(fleet!, ["miner:read"])).toBe(false);
     expect(isNavItemAllowedByPermissions(fleet!, ["fleet:read"])).toBe(false);
     expect(isNavItemAllowedByPermissions(fleet!, ["activity:read"])).toBe(false);
   });

--- a/client/src/protoFleet/config/navItems.test.ts
+++ b/client/src/protoFleet/config/navItems.test.ts
@@ -20,16 +20,19 @@ describe("primaryNavItems", () => {
     const fleet = primaryNavItems.find((item) => item.label === "Fleet");
 
     expect(fleet?.requiredPermission).toBeUndefined();
-    expect(fleet?.requiredAnyPermission).toEqual(["rack:read", "site:read"]);
+    expect(fleet?.requiredAnyPermission).toEqual(["rack:read", "site:read", "miner:read"]);
 
     // Rack- and site-only readers can reach Fleet tabs (racks / sites), so the
     // nav entry stays visible for them.
     expect(isNavItemAllowedByPermissions(fleet!, ["rack:read"])).toBe(true);
     expect(isNavItemAllowedByPermissions(fleet!, ["site:read"])).toBe(true);
-    // fleet:read alone unlocks no Fleet tab (the miners tab also needs
-    // miner:read + rack:read), so it must NOT advertise an unreachable page.
+    // A Miner reader reaches the miners tab (which needs miner:read + the
+    // catalog-paired fleet:read), so the nav entry must be visible for it.
+    expect(isNavItemAllowedByPermissions(fleet!, ["miner:read"])).toBe(true);
+    expect(isNavItemAllowedByPermissions(fleet!, ["miner:read", "fleet:read"])).toBe(true);
+    // fleet:read alone unlocks no Fleet tab, so it must NOT advertise an
+    // unreachable page.
     expect(isNavItemAllowedByPermissions(fleet!, ["fleet:read"])).toBe(false);
-    expect(isNavItemAllowedByPermissions(fleet!, ["miner:read"])).toBe(false);
     expect(isNavItemAllowedByPermissions(fleet!, ["activity:read"])).toBe(false);
   });
 

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -16,7 +16,13 @@ export interface NavItem {
   // filter via UserInfo.permissions. Entries without a requiredPermission
   // are visible to every authenticated user.
   requiredPermission?: string;
-  requiredAnyPermission?: string[];
+  // OR-union of permission requirements: the entry shows if ANY element is
+  // satisfied. A string element is a single permission; a nested string[] is
+  // an AND-group (every key in it must be held). Use the AND-group for a page
+  // whose only reachable section needs more than one permission together —
+  // e.g. the Fleet miners tab needs miner:read AND fleet:read, and neither
+  // alone should advertise the page.
+  requiredAnyPermission?: (string | string[])[];
   scopable?: boolean;
 }
 
@@ -26,7 +32,7 @@ export interface SecondaryNavItem {
   parent: string;
   section?: "Fleet" | "Automation" | "Admin" | "Account";
   requiredPermission?: string;
-  requiredAnyPermission?: string[];
+  requiredAnyPermission?: (string | string[])[];
   // When set, the entry is shown only if the server reports this feature enabled.
   requiredFeature?: NavFeature;
   // Whether the page honors the topbar SitePicker selection as a soft default
@@ -43,7 +49,12 @@ export const isNavItemAllowedByPermissions = (
 ) => {
   const hasRequiredPermission = !item.requiredPermission || permissions.includes(item.requiredPermission);
   const hasAnyPermission =
-    !item.requiredAnyPermission || item.requiredAnyPermission.some((permission) => permissions.includes(permission));
+    !item.requiredAnyPermission ||
+    item.requiredAnyPermission.some((requirement) =>
+      Array.isArray(requirement)
+        ? requirement.every((permission) => permissions.includes(permission))
+        : permissions.includes(requirement),
+    );
 
   return hasRequiredPermission && hasAnyPermission;
 };
@@ -62,16 +73,15 @@ export const primaryNavItems: NavItem[] = [
     icon: Fleet,
     // The Fleet shell hosts several tabs, each with its own gate (see
     // FleetLayout's isTabReachable): racks needs rack:read, sites/buildings/
-    // infrastructure need site:read, and miners needs miner:read + fleet:read.
-    // Gate the nav on the OR union of the permissions that independently make a
-    // tab reachable. miner:read stands in for the miners tab: the catalog's
-    // read-pairing rule guarantees any role with miner:read also holds
-    // fleet:read, so miner:read alone is a sufficient signal that the miners tab
-    // is reachable. fleet:read is still excluded on its own (a fleet:read-only
-    // role unlocks no tab and would land on the empty "no permission" shell).
-    // Home stays ungated as the safe universal landing; its widgets already
-    // degrade per-permission.
-    requiredAnyPermission: ["rack:read", "site:read", "miner:read"],
+    // infrastructure need site:read, and miners needs miner:read AND fleet:read
+    // (the list is miner:read, but the status/model filters call fleet:read
+    // RPCs). Gate the nav on the OR union of what independently makes a tab
+    // reachable. The miners tab uses an AND-group: neither miner:read nor
+    // fleet:read alone reaches it (read-pairing does NOT force fleet:read onto
+    // miner:read), so advertising on either alone would land the role on the
+    // empty "no permission" shell. Home stays ungated as the safe universal
+    // landing; its widgets already degrade per-permission.
+    requiredAnyPermission: ["rack:read", "site:read", ["miner:read", "fleet:read"]],
     scopable: true,
   },
   {

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -16,12 +16,8 @@ export interface NavItem {
   // filter via UserInfo.permissions. Entries without a requiredPermission
   // are visible to every authenticated user.
   requiredPermission?: string;
-  // OR-union of permission requirements: the entry shows if ANY element is
-  // satisfied. A string element is a single permission; a nested string[] is
-  // an AND-group (every key in it must be held). Use the AND-group for a page
-  // whose only reachable section needs more than one permission together —
-  // e.g. the Fleet miners tab needs miner:read AND fleet:read, and neither
-  // alone should advertise the page.
+  // OR-union: the entry shows if ANY element is satisfied. A string is one
+  // permission; a nested string[] is an AND-group (all its keys required).
   requiredAnyPermission?: (string | string[])[];
   scopable?: boolean;
 }
@@ -71,16 +67,11 @@ export const primaryNavItems: NavItem[] = [
     path: "/fleet",
     label: "Fleet",
     icon: Fleet,
-    // The Fleet shell hosts several tabs, each with its own gate (see
-    // FleetLayout's isTabReachable): racks needs rack:read, sites/buildings/
-    // infrastructure need site:read, and miners needs miner:read AND fleet:read
-    // (the list is miner:read, but the status/model filters call fleet:read
-    // RPCs). Gate the nav on the OR union of what independently makes a tab
-    // reachable. The miners tab uses an AND-group: neither miner:read nor
-    // fleet:read alone reaches it (read-pairing does NOT force fleet:read onto
-    // miner:read), so advertising on either alone would land the role on the
-    // empty "no permission" shell. Home stays ungated as the safe universal
-    // landing; its widgets already degrade per-permission.
+    // Show Fleet when at least one tab is reachable (see FleetLayout's
+    // isTabReachable): racks needs rack:read, sites/buildings need site:read,
+    // miners needs miner:read AND fleet:read. The miners AND-group matters
+    // because read-pairing does NOT force fleet:read onto miner:read, so either
+    // key alone would advertise a page that lands on the empty shell.
     requiredAnyPermission: ["rack:read", "site:read", ["miner:read", "fleet:read"]],
     scopable: true,
   },

--- a/client/src/protoFleet/config/navItems.ts
+++ b/client/src/protoFleet/config/navItems.ts
@@ -62,14 +62,16 @@ export const primaryNavItems: NavItem[] = [
     icon: Fleet,
     // The Fleet shell hosts several tabs, each with its own gate (see
     // FleetLayout's isTabReachable): racks needs rack:read, sites/buildings/
-    // infrastructure need site:read, and miners needs miner:read + rack:read +
-    // fleet:read. rack:read and site:read are the only permissions that
-    // independently make a tab reachable, so gate on their OR union. fleet:read
-    // and miner:read are deliberately excluded: neither unlocks a tab on its
-    // own (a fleet:read-only role would land on the empty "no permission"
-    // shell), and the miners tab already requires rack:read. Home stays ungated
-    // as the safe universal landing; its widgets already degrade per-permission.
-    requiredAnyPermission: ["rack:read", "site:read"],
+    // infrastructure need site:read, and miners needs miner:read + fleet:read.
+    // Gate the nav on the OR union of the permissions that independently make a
+    // tab reachable. miner:read stands in for the miners tab: the catalog's
+    // read-pairing rule guarantees any role with miner:read also holds
+    // fleet:read, so miner:read alone is a sufficient signal that the miners tab
+    // is reachable. fleet:read is still excluded on its own (a fleet:read-only
+    // role unlocks no tab and would land on the empty "no permission" shell).
+    // Home stays ungated as the safe universal landing; its widgets already
+    // degrade per-permission.
+    requiredAnyPermission: ["rack:read", "site:read", "miner:read"],
     scopable: true,
   },
   {

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -42,6 +42,7 @@ import { encodeSortToURL, parseSortFromURL } from "@/protoFleet/features/fleetMa
 import type { FilterLabelSource } from "@/protoFleet/features/fleetManagement/views/viewSummary";
 import Miners from "@/protoFleet/features/onboarding/components/Miners";
 import { isPathScopable } from "@/protoFleet/routing/siteScope";
+import { useHasPermission } from "@/protoFleet/store";
 import ErrorBoundary from "@/shared/components/ErrorBoundary";
 import { SORT_ASC, SORT_DESC } from "@/shared/components/List/types";
 
@@ -84,6 +85,11 @@ const applySiteScopeToMinerFilter = (
 
 const Fleet = () => {
   const navigate = useNavigate();
+  // ListDeviceSets (groups and racks alike) is gated on rack:read server-side.
+  // A Fleet+Miner role without rack:read can still open the miner list, so skip
+  // those fetches for it rather than firing permission-denied requests; the
+  // rack/group filters and assign-to-rack action degrade to empty.
+  const canReadRacks = useHasPermission("rack:read");
   const { listGroups, listRacks } = useDeviceSets();
   const { listAllBuildings } = useBuildings();
   const [availableGroups, setAvailableGroups] = useState<DeviceSet[]>([]);
@@ -109,6 +115,7 @@ const Fleet = () => {
   );
 
   useEffect(() => {
+    if (!canReadRacks) return;
     listGroups({
       onSuccess: (deviceSets) => {
         setAvailableGroups(deviceSets);
@@ -119,7 +126,7 @@ const Fleet = () => {
         setAvailableRacks(deviceSets);
       },
     });
-  }, [listGroups, listRacks]);
+  }, [canReadRacks, listGroups, listRacks]);
 
   useEffect(() => {
     if (!siteCatalogAccessGranted) return;

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -85,10 +85,8 @@ const applySiteScopeToMinerFilter = (
 
 const Fleet = () => {
   const navigate = useNavigate();
-  // ListDeviceSets (groups and racks alike) is gated on rack:read server-side.
-  // A Fleet+Miner role without rack:read can still open the miner list, so skip
-  // those fetches for it rather than firing permission-denied requests; the
-  // rack/group filters and assign-to-rack action degrade to empty.
+  // ListDeviceSets (racks + groups) is rack:read-gated; skip those fetches
+  // without it so the miner list opens cleanly (filters just degrade to empty).
   const canReadRacks = useHasPermission("rack:read");
   const { listGroups, listRacks } = useDeviceSets();
   const { listAllBuildings } = useBuildings();

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.test.tsx
@@ -315,6 +315,20 @@ describe("FleetLayout scoped-permission fallback", () => {
     await waitFor(() => expect(screen.getByTestId("location-probe").textContent).toBe("/fleet/miners"));
     expect(screen.getByTestId("tab-content-miners")).toBeInTheDocument();
   });
+
+  test("mounts Miners for a Fleet+Miner role without rack:read", async () => {
+    // Regression: a role with all Fleet + Miner permissions but no rack:read
+    // (Sites/Buildings/Racks category) must still reach its miner list. The
+    // miner list only needs miner:read + fleet:read; rack-backed filters
+    // degrade rather than gate the tab.
+    hasPermissionMock.current = (key: string) => key === "miner:read" || key === "fleet:read";
+
+    renderAt("/fleet/miners");
+
+    await waitFor(() => expect(screen.getByTestId("location-probe").textContent).toBe("/fleet/miners"));
+    expect(screen.getByTestId("tab-content-miners")).toBeInTheDocument();
+    expect(screen.queryByText("You do not have permission to view Fleet sections.")).not.toBeInTheDocument();
+  });
 });
 
 describe("FleetLayout CompleteSetup gate", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
@@ -118,11 +118,9 @@ const FleetLayout = () => {
   const sitesAccessBlocked = !canReadSites || sitesPermissionDenied;
   const siteCatalogAccessGranted = canReadSites && sitesLoaded && !sitesPermissionDenied;
   const canReadRacksTab = canReadRacks;
-  // The miner list only needs miner:read (ListMinerStateSnapshots) plus the
-  // catalog-paired fleet:read. rack:read is NOT required: the rack/group
-  // filters and assign-to-rack action degrade gracefully when the role can't
-  // read device sets (Fleet.tsx guards those calls), so a Fleet+Miner role
-  // must still reach its miner list.
+  // Miner list needs miner:read (ListMinerStateSnapshots) + fleet:read (status/
+  // model filter RPCs). NOT rack:read — the rack/group filters degrade to empty
+  // (Fleet.tsx guards those calls) rather than gating the tab.
   const canReadMinersTab = canReadMiners && canReadFleet;
   const canReadInfrastructureTab = !sitesAccessBlocked;
 

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
@@ -118,7 +118,12 @@ const FleetLayout = () => {
   const sitesAccessBlocked = !canReadSites || sitesPermissionDenied;
   const siteCatalogAccessGranted = canReadSites && sitesLoaded && !sitesPermissionDenied;
   const canReadRacksTab = canReadRacks;
-  const canReadMinersTab = canReadMiners && canReadRacks && canReadFleet;
+  // The miner list only needs miner:read (ListMinerStateSnapshots) plus the
+  // catalog-paired fleet:read. rack:read is NOT required: the rack/group
+  // filters and assign-to-rack action degrade gracefully when the role can't
+  // read device sets (Fleet.tsx guards those calls), so a Fleet+Miner role
+  // must still reach its miner list.
+  const canReadMinersTab = canReadMiners && canReadFleet;
   const canReadInfrastructureTab = !sitesAccessBlocked;
 
   // Permission source of truth for Fleet tabs. Feature flags can hide tab-strip

--- a/client/src/protoFleet/features/settings/components/Schedules/MinerSelectionModal.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/MinerSelectionModal.tsx
@@ -1,7 +1,10 @@
 import { useRef, useState } from "react";
 
 import type { MinerListFilter } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
-import MinerSelectionList, { type MinerSelectionListHandle } from "@/protoFleet/components/MinerSelectionList";
+import MinerSelectionList, {
+  type FilterConfig,
+  type MinerSelectionListHandle,
+} from "@/protoFleet/components/MinerSelectionList";
 import type { SiteFilterFields } from "@/protoFleet/components/PageHeader/SitePicker";
 import Modal from "@/shared/components/Modal";
 
@@ -18,6 +21,9 @@ interface MinerSelectionModalProps {
   selectedMinerIds: string[];
   // Soft default from the topbar SitePicker; forwarded to MinerSelectionList.
   scope?: SiteFilterFields;
+  // Forwarded to MinerSelectionList to hide facets whose list RPCs the caller
+  // can't call (e.g. rack/group filters need rack:read).
+  filterConfig?: FilterConfig;
   onDismiss: () => void;
   onSave: (selection: MinerSelectionValue) => void;
 }
@@ -27,6 +33,7 @@ const MinerSelectionModal = ({
   allMinersSelected = false,
   selectedMinerIds,
   scope,
+  filterConfig,
   onDismiss,
   onSave,
 }: MinerSelectionModalProps) => {
@@ -81,6 +88,7 @@ const MinerSelectionModal = ({
           initialSelectedItems={selectedMinerIds}
           disableFilteredSelectAll
           scope={scope}
+          filterConfig={filterConfig}
           onSelectionChange={({ selectedItems, allSelected, totalMiners }) =>
             setDraftSelection({ selectedMinerIds: selectedItems, allSelected, totalMiners })
           }

--- a/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.test.tsx
@@ -14,11 +14,12 @@ import {
 import type { ScheduleListItem } from "@/protoFleet/api/useScheduleApi";
 import { getNextEndTimeAfterStart } from "@/protoFleet/features/settings/components/Schedules/scheduleValidation";
 
-const { listRacksMock, listGroupsMock, pushToastMock, useFleetMock } = vi.hoisted(() => ({
+const { listRacksMock, listGroupsMock, pushToastMock, useFleetMock, minerSelectionModalMock } = vi.hoisted(() => ({
   listRacksMock: vi.fn(),
   listGroupsMock: vi.fn(),
   pushToastMock: vi.fn(),
   useFleetMock: vi.fn(() => ({ totalMiners: 1, hasInitialLoadCompleted: true })),
+  minerSelectionModalMock: vi.fn((_props: Record<string, unknown>) => null),
 }));
 
 // Apply-to target buttons are gated per read permission. Default to granting
@@ -63,7 +64,7 @@ vi.mock("@/protoFleet/features/settings/components/Schedules/SchedulePreview", (
 
 vi.mock("@/protoFleet/features/settings/components/Schedules/MinerSelectionModal", () => ({
   __esModule: true,
-  default: () => null,
+  default: minerSelectionModalMock,
 }));
 
 vi.mock("@/protoFleet/features/settings/components/Schedules/SiteSelectionModal", () => ({
@@ -351,6 +352,7 @@ describe("ScheduleModal Apply-to targets", () => {
     listGroupsMock.mockImplementation(() => undefined);
     pushToastMock.mockReset();
     useFleetMock.mockClear();
+    minerSelectionModalMock.mockClear();
     activeSiteMock.current = { kind: "all" };
     hasPermissionMock.current = () => true;
   });
@@ -416,5 +418,24 @@ describe("ScheduleModal Apply-to targets", () => {
 
     expect(screen.queryByText("Miners")).not.toBeInTheDocument();
     expect(useFleetMock).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it("disables rack/group facets in the miner picker without rack:read", () => {
+    // The miner picker's rack/group filters call ListDeviceSets (rack:read); a
+    // miner:read-only manager must be able to pick miners without them.
+    hasPermissionMock.current = (key: string) => key === "miner:read";
+    renderCreateModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Miners/ }));
+    expect(minerSelectionModalMock.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({ filterConfig: { showRackFilter: false, showGroupFilter: false } }),
+    );
+  });
+
+  it("leaves miner-picker facets on when the role can read racks", () => {
+    renderCreateModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Miners/ }));
+    expect(minerSelectionModalMock.mock.lastCall?.[0]).toEqual(expect.objectContaining({ filterConfig: undefined }));
   });
 });

--- a/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.test.tsx
@@ -14,10 +14,11 @@ import {
 import type { ScheduleListItem } from "@/protoFleet/api/useScheduleApi";
 import { getNextEndTimeAfterStart } from "@/protoFleet/features/settings/components/Schedules/scheduleValidation";
 
-const { listRacksMock, listGroupsMock, pushToastMock } = vi.hoisted(() => ({
+const { listRacksMock, listGroupsMock, pushToastMock, useFleetMock } = vi.hoisted(() => ({
   listRacksMock: vi.fn(),
   listGroupsMock: vi.fn(),
   pushToastMock: vi.fn(),
+  useFleetMock: vi.fn(() => ({ totalMiners: 1, hasInitialLoadCompleted: true })),
 }));
 
 // Apply-to target buttons are gated per read permission. Default to granting
@@ -38,10 +39,7 @@ vi.mock("@/protoFleet/api/useDeviceSets", () => ({
 
 vi.mock("@/protoFleet/api/useFleet", () => ({
   __esModule: true,
-  default: () => ({
-    totalMiners: 1,
-    hasInitialLoadCompleted: true,
-  }),
+  default: useFleetMock,
 }));
 
 // The schedule modal reads the topbar SitePicker selection for soft scoping.
@@ -352,6 +350,7 @@ describe("ScheduleModal Apply-to targets", () => {
     listGroupsMock.mockReset();
     listGroupsMock.mockImplementation(() => undefined);
     pushToastMock.mockReset();
+    useFleetMock.mockClear();
     activeSiteMock.current = { kind: "all" };
     hasPermissionMock.current = () => true;
   });
@@ -407,5 +406,15 @@ describe("ScheduleModal Apply-to targets", () => {
     // No rack/group list RPC should fire without rack:read.
     expect(listRacksMock).not.toHaveBeenCalled();
     expect(listGroupsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch the miner list for a role without miner:read", () => {
+    // ListMinerStateSnapshots is gated on miner:read; opening the modal must
+    // not fire it (nor advertise the Miners target) for a role that lacks it.
+    hasPermissionMock.current = (key: string) => key === "site:read";
+    renderCreateModal();
+
+    expect(screen.queryByText("Miners")).not.toBeInTheDocument();
+    expect(useFleetMock).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
   });
 });

--- a/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.test.tsx
@@ -20,6 +20,15 @@ const { listRacksMock, listGroupsMock, pushToastMock } = vi.hoisted(() => ({
   pushToastMock: vi.fn(),
 }));
 
+// Apply-to target buttons are gated per read permission. Default to granting
+// all reads so existing target-visibility tests are unaffected; individual
+// tests narrow this to cover restricted roles.
+const hasPermissionMock = vi.hoisted(() => ({ current: (_key: string): boolean => true }));
+
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: (key: string) => hasPermissionMock.current(key),
+}));
+
 vi.mock("@/protoFleet/api/useDeviceSets", () => ({
   useDeviceSets: () => ({
     listRacks: listRacksMock,
@@ -344,6 +353,7 @@ describe("ScheduleModal Apply-to targets", () => {
     listGroupsMock.mockImplementation(() => undefined);
     pushToastMock.mockReset();
     activeSiteMock.current = { kind: "all" };
+    hasPermissionMock.current = () => true;
   });
 
   const renderCreateModal = () =>
@@ -380,5 +390,22 @@ describe("ScheduleModal Apply-to targets", () => {
     expect(screen.getByText("Racks")).toBeInTheDocument();
     expect(screen.getByText("Groups")).toBeInTheDocument();
     expect(screen.getByText("Miners")).toBeInTheDocument();
+  });
+
+  it("hides target types the role cannot read", () => {
+    // A Fleet+Miner+Schedules role (no site:read / rack:read) can only target
+    // miners; the site/building/rack/group pickers would hit permission-denied
+    // list RPCs, so their buttons must not be offered.
+    hasPermissionMock.current = (key: string) => key === "miner:read";
+    renderCreateModal();
+
+    expect(screen.getByText("Miners")).toBeInTheDocument();
+    expect(screen.queryByText("Sites")).not.toBeInTheDocument();
+    expect(screen.queryByText("Buildings")).not.toBeInTheDocument();
+    expect(screen.queryByText("Racks")).not.toBeInTheDocument();
+    expect(screen.queryByText("Groups")).not.toBeInTheDocument();
+    // No rack/group list RPC should fire without rack:read.
+    expect(listRacksMock).not.toHaveBeenCalled();
+    expect(listGroupsMock).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
@@ -306,6 +306,10 @@ const ScheduleModal = ({
   const { totalMiners: totalAvailableMiners, hasInitialLoadCompleted: hasLoadedAvailableMiners } = useFleet({
     pageSize: 1,
     pairingStatuses: [PairingStatus.PAIRED],
+    // ListMinerStateSnapshots is gated on miner:read; a schedule manager
+    // without it shouldn't fire a permission-denied miner-list RPC just by
+    // opening the modal (the Miners target button is hidden for them anyway).
+    enabled: canReadMiners,
   });
   const [values, setValues] = useState<ScheduleFormValues>(() => createDefaultScheduleFormValues());
   const [availableRackIds, setAvailableRackIds] = useState<Set<string>>(new Set());

--- a/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
@@ -42,6 +42,7 @@ import {
   formatDateValue,
   parseDate as parseScheduleDate,
 } from "@/protoFleet/features/settings/utils/scheduleDateUtils";
+import { useHasPermission } from "@/protoFleet/store";
 import { ChevronDown } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
 import Checkbox from "@/shared/components/Checkbox";
@@ -281,6 +282,14 @@ const ScheduleModal = ({
   onResumeSchedule,
 }: ScheduleModalProps) => {
   const isEditMode = Boolean(schedule);
+  // "Apply to" target types are each gated on the read permission their
+  // selection modal (and its list RPC) requires: sites/buildings need
+  // site:read, racks/groups need rack:read (ListDeviceSets), miners need
+  // miner:read. A role without a given permission can't list those targets, so
+  // offering the button just leads to a permission-denied dead end — hide it.
+  const canReadSites = useHasPermission("site:read");
+  const canReadRacks = useHasPermission("rack:read");
+  const canReadMiners = useHasPermission("miner:read");
   const { listRacks, listGroups } = useDeviceSets();
   // Soft default from the topbar SitePicker (store-driven; settings routes are
   // unscoped, so this reads the stored selection). A single selected site
@@ -348,6 +357,13 @@ const ScheduleModal = ({
     if (!open) {
       return;
     }
+    // ListDeviceSets (racks and groups) is gated on rack:read server-side;
+    // skip the fetch for roles without it so opening the modal doesn't fire
+    // permission-denied requests. The rack/group target buttons are hidden for
+    // those roles anyway.
+    if (!canReadRacks) {
+      return;
+    }
 
     // eslint-disable-next-line react-hooks/set-state-in-effect -- reset available-target state and fetch racks/groups when modal opens
     setAvailableGroupIds(new Set());
@@ -374,7 +390,7 @@ const ScheduleModal = ({
         });
       },
     });
-  }, [listGroups, listRacks, open]);
+  }, [canReadRacks, listGroups, listRacks, open]);
 
   useEffect(() => {
     valuesRef.current = values;
@@ -851,31 +867,41 @@ const ScheduleModal = ({
             <div className={sectionBodyClassName}>
               <div className={sectionTitleClassName}>Apply to</div>
               <div className="grid">
-                <TargetSelectButton
-                  label="Sites"
-                  value={getTargetButtonLabel(values.siteTargetIds.length, "site")}
-                  onClick={() => setShowSiteSelectionModal(true)}
-                />
-                <TargetSelectButton
-                  label="Buildings"
-                  value={getTargetButtonLabel(values.buildingTargetIds.length, "building")}
-                  onClick={() => setShowBuildingSelectionModal(true)}
-                />
-                <TargetSelectButton
-                  label="Racks"
-                  value={getTargetButtonLabel(validRackTargetCount, "rack")}
-                  onClick={() => setShowRackSelectionModal(true)}
-                />
-                <TargetSelectButton
-                  label="Groups"
-                  value={getTargetButtonLabel(validGroupTargetCount, "group")}
-                  onClick={() => setShowGroupSelectionModal(true)}
-                />
-                <TargetSelectButton
-                  label="Miners"
-                  value={getTargetButtonLabel(validMinerTargetCount, "miner")}
-                  onClick={() => setShowMinerSelectionModal(true)}
-                />
+                {canReadSites ? (
+                  <TargetSelectButton
+                    label="Sites"
+                    value={getTargetButtonLabel(values.siteTargetIds.length, "site")}
+                    onClick={() => setShowSiteSelectionModal(true)}
+                  />
+                ) : null}
+                {canReadSites ? (
+                  <TargetSelectButton
+                    label="Buildings"
+                    value={getTargetButtonLabel(values.buildingTargetIds.length, "building")}
+                    onClick={() => setShowBuildingSelectionModal(true)}
+                  />
+                ) : null}
+                {canReadRacks ? (
+                  <TargetSelectButton
+                    label="Racks"
+                    value={getTargetButtonLabel(validRackTargetCount, "rack")}
+                    onClick={() => setShowRackSelectionModal(true)}
+                  />
+                ) : null}
+                {canReadRacks ? (
+                  <TargetSelectButton
+                    label="Groups"
+                    value={getTargetButtonLabel(validGroupTargetCount, "group")}
+                    onClick={() => setShowGroupSelectionModal(true)}
+                  />
+                ) : null}
+                {canReadMiners ? (
+                  <TargetSelectButton
+                    label="Miners"
+                    value={getTargetButtonLabel(validMinerTargetCount, "miner")}
+                    onClick={() => setShowMinerSelectionModal(true)}
+                  />
+                ) : null}
               </div>
             </div>
           </section>

--- a/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
@@ -282,11 +282,9 @@ const ScheduleModal = ({
   onResumeSchedule,
 }: ScheduleModalProps) => {
   const isEditMode = Boolean(schedule);
-  // "Apply to" target types are each gated on the read permission their
-  // selection modal (and its list RPC) requires: sites/buildings need
-  // site:read, racks/groups need rack:read (ListDeviceSets), miners need
-  // miner:read. A role without a given permission can't list those targets, so
-  // offering the button just leads to a permission-denied dead end — hide it.
+  // "Apply to" targets are gated on the read permission each picker's list RPC
+  // needs (sites/buildings: site:read, racks/groups: rack:read, miners:
+  // miner:read); without it the button is a permission-denied dead end, so hide.
   const canReadSites = useHasPermission("site:read");
   const canReadRacks = useHasPermission("rack:read");
   const canReadMiners = useHasPermission("miner:read");
@@ -306,9 +304,8 @@ const ScheduleModal = ({
   const { totalMiners: totalAvailableMiners, hasInitialLoadCompleted: hasLoadedAvailableMiners } = useFleet({
     pageSize: 1,
     pairingStatuses: [PairingStatus.PAIRED],
-    // ListMinerStateSnapshots is gated on miner:read; a schedule manager
-    // without it shouldn't fire a permission-denied miner-list RPC just by
-    // opening the modal (the Miners target button is hidden for them anyway).
+    // ListMinerStateSnapshots is miner:read-gated; skip it (and the hidden
+    // Miners target) for roles without it instead of firing permission-denied.
     enabled: canReadMiners,
   });
   const [values, setValues] = useState<ScheduleFormValues>(() => createDefaultScheduleFormValues());
@@ -361,10 +358,8 @@ const ScheduleModal = ({
     if (!open) {
       return;
     }
-    // ListDeviceSets (racks and groups) is gated on rack:read server-side;
-    // skip the fetch for roles without it so opening the modal doesn't fire
-    // permission-denied requests. The rack/group target buttons are hidden for
-    // those roles anyway.
+    // ListDeviceSets (racks + groups) is rack:read-gated; skip without it (the
+    // rack/group targets are hidden for those roles anyway).
     if (!canReadRacks) {
       return;
     }

--- a/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/ScheduleModal.tsx
@@ -970,6 +970,9 @@ const ScheduleModal = ({
           open={showMinerSelectionModal}
           selectedMinerIds={values.minerTargetIds}
           scope={scope}
+          // The rack/group facets call ListDeviceSets (rack:read); hide them so
+          // a miner:read-only manager can pick miners without permission-denied.
+          filterConfig={canReadRacks ? undefined : { showRackFilter: false, showGroupFilter: false }}
           onDismiss={() => setShowMinerSelectionModal(false)}
           onSave={(selection) => {
             setNextValues((current) => ({ ...current, minerTargetIds: selection.selectedMinerIds }));


### PR DESCRIPTION
## Problem

A role with **all Fleet + Miner (+ Schedules) permissions but no Sites/Buildings/Racks** (`site:read` / `rack:read`) was locked out of things it should be able to use:

- The **Fleet** left-nav item didn't appear.
- Visiting `/fleet/miners` directly showed *"You do not have permission to view Fleet sections"* — which isn't true; the miner list only needs `miner:read`.
- The schedule creation **"Apply to"** selector still offered Sites/Buildings/Racks/Groups targets, but selecting them failed because their list RPCs require permissions the role lacks.

Root cause: the Fleet section and the schedule target picker were gated on infrastructure permissions (`site:read` / `rack:read`) that only power *auxiliary* data (rack/site/group filters, assign-to-rack). The core miner list (`ListMinerStateSnapshots`) needs only `miner:read`.

## Changes

**Fleet nav** (`navItems.ts`): add `miner:read` to the `requiredAnyPermission` OR-union. Per the catalog's read-pairing rule, any role with `miner:read` also holds `fleet:read`, so `miner:read` is a sufficient signal that the miners tab is reachable.

**Miners tab** (`FleetLayout.tsx`): require `miner:read && fleet:read` only — drop the `rack:read` requirement.

**Miner list** (`Fleet.tsx`): guard the `listGroups`/`listRacks` fetch (both hit `ListDeviceSets`, gated on `rack:read` server-side) so a role without `rack:read` doesn't fire permission-denied requests; the rack/group filters degrade to empty rather than gating the whole view.

**Schedule "Apply to"** (`ScheduleModal.tsx`): gate each target button on the read permission its picker/list RPC needs — Sites & Buildings → `site:read`, Racks & Groups → `rack:read`, Miners → `miner:read` — and skip the on-open racks/groups fetch without `rack:read`. A restricted role now sees only the target types it can actually use.

## Testing

- `navItems.test.ts` — Fleet nav visible for a `miner:read` reader.
- `FleetLayout.test.tsx` — new case: "mounts Miners for a Fleet+Miner role without rack:read".
- `ScheduleModal.test.tsx` — new case: "hides target types the role cannot read" (only Miners shown; no rack/group list RPC fired).
- Full affected suites green (100 tests), `tsc` + `eslint` clean.

## Reviewer notes

- No server-side gate changes — `ListDeviceSets` remaining `rack:read`-gated is intentional; the client just stops calling it (and stops advertising it) when the role can't. If groups should be readable with only `fleet:read`, that's a separate server-side change.
- The `miner:read ⇒ fleet:read` guarantee that the nav gate leans on is enforced by the authz read-pairing rule at role creation; the miners-tab gate still double-checks both.