### PR TITLE
perf(server): collapse identical combined-metrics requests

### DIFF
--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -73,12 +73,18 @@ package telemetry
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 
 	fm "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
@@ -139,6 +145,20 @@ const (
 
 	// Page size for combined metrics query
 	defaultCombinedMetricsPageSize = 100
+
+	// combinedMetricsQuantum aligns combined-metrics time bounds before
+	// singleflight keying: EndTime rounds down to this quantum and StartTime
+	// shifts by the same delta. Clients stamp bounds from Date.now(), so raw
+	// bounds never collide across viewers; quantized ones do. Worst case a
+	// follower sees data under 15s stale, invisible at dashboard granularity.
+	combinedMetricsQuantum = 15 * time.Second
+
+	// combinedMetricsFlightTimeout bounds the shared singleflight query, which
+	// runs detached from any individual caller's context. The store already
+	// caps each query at its QueryTimeout (60s default) but that config is not
+	// visible at this layer, so mirror it plus headroom; this exists only to
+	// avoid leaking the flight goroutine if a connection wedges.
+	combinedMetricsFlightTimeout = 65 * time.Second
 )
 
 //go:generate go run go.uber.org/mock/mockgen -source=service.go -destination=mocks/mock_service.go -package=mock UpdateScheduler,TelemetryDataStore,MinerGetter,CachedMinerGetter
@@ -323,6 +343,9 @@ type TelemetryService struct {
 	// statusPollingRoutine skips devices in this map to avoid double-processing the same
 	// device simultaneously in both the full-telemetry and status-only paths.
 	inFlight sync.Map // map[DeviceIdentifier]struct{}
+	// combinedMetricsSingle collapses identical concurrent GetCombinedMetrics
+	// calls (N dashboard viewers polling the same org) into one execution.
+	combinedMetricsSingle singleflight.Group
 }
 
 func NewTelemetryService(config Config, telemetryDataStore TelemetryDataStore, minerManager CachedMinerGetter, scheduler UpdateScheduler, deviceStore stores.DeviceStore, errorPoller ErrorPoller) *TelemetryService {
@@ -1482,7 +1505,44 @@ func (s *TelemetryService) StreamDeviceStatusUpdates(ctx context.Context, query 
 	return updateChan, nil
 }
 
+// GetCombinedMetrics collapses identical concurrent queries into a single
+// execution via singleflight: N dashboard viewers polling the same org would
+// otherwise each run the same heavy aggregation every refresh.
+//
+// The shared query runs on a context detached from any individual caller
+// (context.WithoutCancel + a fixed timeout) so that a cancellation of
+// whichever caller raced into singleflight first does not poison the result
+// for siblings whose own contexts are still valid. Each caller then selects
+// between the shared result and its own ctx independently.
 func (s *TelemetryService) GetCombinedMetrics(ctx context.Context, query models.CombinedMetricsQuery) (models.CombinedMetric, error) {
+	query = quantizeCombinedMetricsWindow(query)
+
+	ch := s.combinedMetricsSingle.DoChan(combinedMetricsFlightKey(query), func() (any, error) {
+		flightCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), combinedMetricsFlightTimeout)
+		defer cancel()
+		return s.fetchCombinedMetrics(flightCtx, query)
+	})
+
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			// Errors come from fetchCombinedMetrics, which returns store and
+			// domain errors unchanged. Pass through as before.
+			return models.CombinedMetric{}, res.Err //nolint:wrapcheck
+		}
+		result, ok := res.Val.(models.CombinedMetric)
+		if !ok {
+			return models.CombinedMetric{}, fleeterror.NewInternalErrorf("unexpected type from combined metrics singleflight: %T", res.Val)
+		}
+		return result, nil
+	case <-ctx.Done():
+		// This caller gave up; the detached query keeps running so siblings
+		// still in the flight get their result.
+		return models.CombinedMetric{}, ctx.Err() //nolint:wrapcheck
+	}
+}
+
+func (s *TelemetryService) fetchCombinedMetrics(ctx context.Context, query models.CombinedMetricsQuery) (models.CombinedMetric, error) {
 	// Site scope is applied by resolving the in-scope device identifiers and
 	// feeding the existing device-list paths: the telemetry continuous
 	// aggregates have no site_id column, so we cannot filter them directly.
@@ -1577,6 +1637,101 @@ func intersectDeviceIDs(selected, inScope []models.DeviceIdentifier) []models.De
 		}
 	}
 	return result
+}
+
+// quantizeCombinedMetricsWindow rounds EndTime down to combinedMetricsQuantum
+// and shifts StartTime by the same delta, preserving duration. Applied before
+// keying and before executing so every follower's key matches the query the
+// leader actually ran. Nil bounds pass through untouched; the store resolves
+// their defaults.
+func quantizeCombinedMetricsWindow(query models.CombinedMetricsQuery) models.CombinedMetricsQuery {
+	if query.TimeRange.EndTime == nil {
+		return query
+	}
+	end := query.TimeRange.EndTime.Truncate(combinedMetricsQuantum)
+	delta := query.TimeRange.EndTime.Sub(end)
+	query.TimeRange.EndTime = &end
+	if query.TimeRange.StartTime != nil {
+		start := query.TimeRange.StartTime.Add(-delta)
+		query.TimeRange.StartTime = &start
+	}
+	return query
+}
+
+// combinedMetricsFlightKey builds the singleflight key for a quantized query.
+// Every field of models.CombinedMetricsQuery that changes the result
+// participates. Slices are sorted on copies so set-equal queries collapse
+// regardless of caller ordering.
+func combinedMetricsFlightKey(query models.CombinedMetricsQuery) string {
+	var b strings.Builder
+	b.WriteString(strconv.FormatInt(query.OrganizationID, 10))
+	b.WriteByte('|')
+	writeKeyTime(&b, query.TimeRange.StartTime)
+	b.WriteByte('|')
+	writeKeyTime(&b, query.TimeRange.EndTime)
+	b.WriteByte('|')
+	writeKeyDuration(&b, query.WindowDuration)
+	b.WriteByte('|')
+	writeKeyDuration(&b, query.SlideInterval)
+	b.WriteByte('|')
+	writeSortedInts(&b, query.MeasurementTypes)
+	b.WriteByte('|')
+	writeSortedInts(&b, query.AggregationTypes)
+	b.WriteByte('|')
+	b.WriteString(deviceIDsKeyHash(query.DeviceIDs))
+	b.WriteByte('|')
+	writeSortedInts(&b, query.SiteIDs)
+	b.WriteByte('|')
+	b.WriteString(strconv.FormatBool(query.IncludeUnassigned))
+	b.WriteByte('|')
+	b.WriteString(strconv.Itoa(query.PageSize))
+	b.WriteByte('|')
+	b.WriteString(query.PaginationToken)
+	return b.String()
+}
+
+func writeKeyTime(b *strings.Builder, t *time.Time) {
+	if t == nil {
+		b.WriteString("nil")
+		return
+	}
+	b.WriteString(strconv.FormatInt(t.UnixNano(), 10))
+}
+
+func writeKeyDuration(b *strings.Builder, d *time.Duration) {
+	if d == nil {
+		b.WriteString("nil")
+		return
+	}
+	b.WriteString(strconv.FormatInt(int64(*d), 10))
+}
+
+func writeSortedInts[T ~int | ~int64](b *strings.Builder, vals []T) {
+	sorted := slices.Clone(vals)
+	slices.Sort(sorted)
+	for i, v := range sorted {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.FormatInt(int64(v), 10))
+	}
+}
+
+// deviceIDsKeyHash hashes the sorted device list so keys stay bounded for
+// multi-thousand-device selections. A NUL separator keeps the hash injective
+// over the ID sequence.
+func deviceIDsKeyHash(ids []models.DeviceIdentifier) string {
+	if len(ids) == 0 {
+		return "all"
+	}
+	sorted := slices.Clone(ids)
+	slices.Sort(sorted)
+	h := sha256.New()
+	for _, id := range sorted {
+		h.Write([]byte(id))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func minerFilterForDeviceIDs(deviceIDs []models.DeviceIdentifier) *stores.MinerFilter {

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -153,6 +153,13 @@ const (
 	// follower sees data under 15s stale, invisible at dashboard granularity.
 	combinedMetricsQuantum = 15 * time.Second
 
+	// combinedMetricsQuantizeMinInterval gates quantization: only queries whose
+	// SlideInterval (bucket size) is at least this get coarsened, keeping the
+	// sub-quantum shift confined to partial edge buckets. Finer queries keep
+	// their exact bounds and coalesce only when identical. The dashboard's
+	// smallest granularity is 90s, so its queries always quantize.
+	combinedMetricsQuantizeMinInterval = time.Minute
+
 	// combinedMetricsFlightTimeout bounds the shared singleflight query, which
 	// runs detached from any individual caller's context. The store already
 	// caps each query at its QueryTimeout (60s default) but that config is not
@@ -346,24 +353,30 @@ type TelemetryService struct {
 	// combinedMetricsSingle collapses identical concurrent GetCombinedMetrics
 	// calls (N dashboard viewers polling the same org) into one execution.
 	combinedMetricsSingle singleflight.Group
+	// combinedMetricsFlights counts the callers waiting on each singleflight
+	// key so the detached shared query is cancelled as soon as the last
+	// waiter gives up, instead of running against the DB until its timeout.
+	combinedMetricsFlightsMu sync.Mutex
+	combinedMetricsFlights   map[string]*combinedMetricsFlight
 }
 
 func NewTelemetryService(config Config, telemetryDataStore TelemetryDataStore, minerManager CachedMinerGetter, scheduler UpdateScheduler, deviceStore stores.DeviceStore, errorPoller ErrorPoller) *TelemetryService {
 	return &TelemetryService{
-		config:               config,
-		telemetryDataStore:   telemetryDataStore,
-		minerManager:         minerManager,
-		updateScheduler:      scheduler,
-		deviceStore:          deviceStore,
-		errorPoller:          errorPoller,
-		tasks:                make(chan models.Device, config.ConcurrencyLimit),
-		statusTasks:          make(chan models.Device, config.ConcurrencyLimit),
-		statusResults:        make(chan statusResult, resultsChannelBuffer),
-		statusFlushRequests:  make(chan statusFlushRequest),
-		metricsResults:       make(chan metricsResult, resultsChannelBuffer),
-		metricsFlushRequests: make(chan metricsFlushRequest),
-		lookBackDuration:     -1 * (config.StalenessThreshold - config.FetchInterval),
-		metricsObserver:      newMetricsObserver(NoMetrics()),
+		config:                 config,
+		telemetryDataStore:     telemetryDataStore,
+		minerManager:           minerManager,
+		updateScheduler:        scheduler,
+		deviceStore:            deviceStore,
+		errorPoller:            errorPoller,
+		tasks:                  make(chan models.Device, config.ConcurrencyLimit),
+		statusTasks:            make(chan models.Device, config.ConcurrencyLimit),
+		statusResults:          make(chan statusResult, resultsChannelBuffer),
+		statusFlushRequests:    make(chan statusFlushRequest),
+		metricsResults:         make(chan metricsResult, resultsChannelBuffer),
+		metricsFlushRequests:   make(chan metricsFlushRequest),
+		lookBackDuration:       -1 * (config.StalenessThreshold - config.FetchInterval),
+		metricsObserver:        newMetricsObserver(NoMetrics()),
+		combinedMetricsFlights: make(map[string]*combinedMetricsFlight),
 	}
 }
 
@@ -1513,13 +1526,27 @@ func (s *TelemetryService) StreamDeviceStatusUpdates(ctx context.Context, query 
 // (context.WithoutCancel + a fixed timeout) so that a cancellation of
 // whichever caller raced into singleflight first does not poison the result
 // for siblings whose own contexts are still valid. Each caller then selects
-// between the shared result and its own ctx independently.
+// between the shared result and its own ctx independently. Waiters are
+// counted per flight; when the last one gives up the shared query is
+// cancelled rather than left burning the DB until its timeout.
 func (s *TelemetryService) GetCombinedMetrics(ctx context.Context, query models.CombinedMetricsQuery) (models.CombinedMetric, error) {
-	query = quantizeCombinedMetricsWindow(query)
+	// The store resolves nil bounds against time.Now() at execution, so two
+	// concurrent nil-bound queries are not interchangeable: a follower could
+	// receive a window anchored to the leader's execution time. Run them
+	// without singleflight on the caller's own context.
+	if query.TimeRange.StartTime == nil || query.TimeRange.EndTime == nil {
+		return s.fetchCombinedMetrics(ctx, query)
+	}
 
-	ch := s.combinedMetricsSingle.DoChan(combinedMetricsFlightKey(query), func() (any, error) {
+	query = quantizeCombinedMetricsWindow(query)
+	key := combinedMetricsFlightKey(query)
+	flight := s.joinCombinedMetricsFlight(key)
+	defer s.leaveCombinedMetricsFlight(key, flight)
+
+	ch := s.combinedMetricsSingle.DoChan(key, func() (any, error) {
 		flightCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), combinedMetricsFlightTimeout)
 		defer cancel()
+		s.armCombinedMetricsFlight(flight, cancel)
 		return s.fetchCombinedMetrics(flightCtx, query)
 	})
 
@@ -1536,9 +1563,59 @@ func (s *TelemetryService) GetCombinedMetrics(ctx context.Context, query models.
 		}
 		return result, nil
 	case <-ctx.Done():
-		// This caller gave up; the detached query keeps running so siblings
-		// still in the flight get their result.
+		// This caller gave up. The deferred leave decrements the waiter count;
+		// siblings still in the flight keep the detached query alive, and the
+		// last one out cancels it.
 		return models.CombinedMetric{}, ctx.Err() //nolint:wrapcheck
+	}
+}
+
+// combinedMetricsFlight tracks how many callers are waiting on one
+// singleflight execution, plus the cancel func of the running flight.
+type combinedMetricsFlight struct {
+	waiters int
+	cancel  context.CancelFunc
+}
+
+func (s *TelemetryService) joinCombinedMetricsFlight(key string) *combinedMetricsFlight {
+	s.combinedMetricsFlightsMu.Lock()
+	defer s.combinedMetricsFlightsMu.Unlock()
+	flight := s.combinedMetricsFlights[key]
+	if flight == nil {
+		flight = &combinedMetricsFlight{}
+		s.combinedMetricsFlights[key] = flight
+	}
+	flight.waiters++
+	return flight
+}
+
+// leaveCombinedMetricsFlight is called once per caller on every exit path.
+// The last waiter out cancels the shared query and forgets the key so later
+// callers start a fresh flight instead of joining a cancelled one.
+func (s *TelemetryService) leaveCombinedMetricsFlight(key string, flight *combinedMetricsFlight) {
+	s.combinedMetricsFlightsMu.Lock()
+	defer s.combinedMetricsFlightsMu.Unlock()
+	flight.waiters--
+	if flight.waiters > 0 {
+		return
+	}
+	if flight.cancel != nil {
+		flight.cancel()
+	}
+	delete(s.combinedMetricsFlights, key)
+	s.combinedMetricsSingle.Forget(key)
+}
+
+// armCombinedMetricsFlight registers the running flight's cancel func so the
+// last departing waiter can stop it. If every waiter already left before the
+// flight got scheduled, cancel immediately.
+func (s *TelemetryService) armCombinedMetricsFlight(flight *combinedMetricsFlight, cancel context.CancelFunc) {
+	s.combinedMetricsFlightsMu.Lock()
+	flight.cancel = cancel
+	abandoned := flight.waiters == 0
+	s.combinedMetricsFlightsMu.Unlock()
+	if abandoned {
+		cancel()
 	}
 }
 
@@ -1642,10 +1719,16 @@ func intersectDeviceIDs(selected, inScope []models.DeviceIdentifier) []models.De
 // quantizeCombinedMetricsWindow rounds EndTime down to combinedMetricsQuantum
 // and shifts StartTime by the same delta, preserving duration. Applied before
 // keying and before executing so every follower's key matches the query the
-// leader actually ran. Nil bounds pass through untouched; the store resolves
-// their defaults.
+// leader actually ran. Queries requesting resolution finer than
+// combinedMetricsQuantizeMinInterval pass through untouched: the shift would
+// be visible at their bucket size, so they keep exact bounds and only
+// coalesce with identical queries. Nil bounds never get here;
+// GetCombinedMetrics runs them outside singleflight.
 func quantizeCombinedMetricsWindow(query models.CombinedMetricsQuery) models.CombinedMetricsQuery {
 	if query.TimeRange.EndTime == nil {
+		return query
+	}
+	if query.SlideInterval == nil || *query.SlideInterval < combinedMetricsQuantizeMinInterval {
 		return query
 	}
 	end := query.TimeRange.EndTime.Truncate(combinedMetricsQuantum)
@@ -1660,8 +1743,13 @@ func quantizeCombinedMetricsWindow(query models.CombinedMetricsQuery) models.Com
 
 // combinedMetricsFlightKey builds the singleflight key for a quantized query.
 // Every field of models.CombinedMetricsQuery that changes the result
-// participates. Slices are sorted on copies so set-equal queries collapse
-// regardless of caller ordering.
+// participates. MeasurementTypes and AggregationTypes keep caller order
+// because the store emits metrics and aggregated values in request slice
+// order, so only identically ordered requests may share a response. DeviceIDs
+// and SiteIDs are pure filters; they are sorted on copies so set-equal
+// selections collapse. PageSize and PaginationToken are excluded because the
+// combined-metrics path ignores them; add them back if pagination is ever
+// implemented.
 func combinedMetricsFlightKey(query models.CombinedMetricsQuery) string {
 	var b strings.Builder
 	b.WriteString(strconv.FormatInt(query.OrganizationID, 10))
@@ -1674,19 +1762,15 @@ func combinedMetricsFlightKey(query models.CombinedMetricsQuery) string {
 	b.WriteByte('|')
 	writeKeyDuration(&b, query.SlideInterval)
 	b.WriteByte('|')
-	writeSortedInts(&b, query.MeasurementTypes)
+	writeInts(&b, query.MeasurementTypes)
 	b.WriteByte('|')
-	writeSortedInts(&b, query.AggregationTypes)
+	writeInts(&b, query.AggregationTypes)
 	b.WriteByte('|')
 	b.WriteString(deviceIDsKeyHash(query.DeviceIDs))
 	b.WriteByte('|')
 	writeSortedInts(&b, query.SiteIDs)
 	b.WriteByte('|')
 	b.WriteString(strconv.FormatBool(query.IncludeUnassigned))
-	b.WriteByte('|')
-	b.WriteString(strconv.Itoa(query.PageSize))
-	b.WriteByte('|')
-	b.WriteString(query.PaginationToken)
 	return b.String()
 }
 
@@ -1706,15 +1790,19 @@ func writeKeyDuration(b *strings.Builder, d *time.Duration) {
 	b.WriteString(strconv.FormatInt(int64(*d), 10))
 }
 
-func writeSortedInts[T ~int | ~int64](b *strings.Builder, vals []T) {
-	sorted := slices.Clone(vals)
-	slices.Sort(sorted)
-	for i, v := range sorted {
+func writeInts[T ~int | ~int64](b *strings.Builder, vals []T) {
+	for i, v := range vals {
 		if i > 0 {
 			b.WriteByte(',')
 		}
 		b.WriteString(strconv.FormatInt(int64(v), 10))
 	}
+}
+
+func writeSortedInts[T ~int | ~int64](b *strings.Builder, vals []T) {
+	sorted := slices.Clone(vals)
+	slices.Sort(sorted)
+	writeInts(b, sorted)
 }
 
 // deviceIDsKeyHash hashes the sorted device list so keys stay bounded for

--- a/server/internal/domain/telemetry/service_test.go
+++ b/server/internal/domain/telemetry/service_test.go
@@ -4113,3 +4113,190 @@ func TestWriteFleetStateSnapshot(t *testing.T) {
 		service.writeFleetStateSnapshot(t.Context(), tickTime)
 	})
 }
+
+// combinedMetricsQueryAt builds a query whose end time lands endOffset past a
+// fixed quantum-aligned base, with a 24h duration. Offsets within the same
+// 15s quantum must quantize (and therefore key) identically.
+func combinedMetricsQueryAt(org int64, endOffset time.Duration) models.CombinedMetricsQuery {
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	end := base.Add(endOffset)
+	start := end.Add(-24 * time.Hour)
+	return models.CombinedMetricsQuery{
+		OrganizationID:   org,
+		MeasurementTypes: []models.MeasurementType{models.MeasurementTypeHashrate},
+		TimeRange:        models.TimeRange{StartTime: &start, EndTime: &end},
+	}
+}
+
+func newCombinedMetricsTestService(t *testing.T) (*TelemetryService, *mock.MockTelemetryDataStore) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	dataStore := mock.NewMockTelemetryDataStore(ctrl)
+	svc := NewTelemetryService(Config{
+		StalenessThreshold: time.Minute,
+		FetchInterval:      10 * time.Second,
+		ConcurrencyLimit:   5,
+	}, dataStore, nil, nil, storesMocks.NewMockDeviceStore(ctrl), mock.NewMockErrorPoller(ctrl))
+	return svc, dataStore
+}
+
+// TestGetCombinedMetrics_Singleflight verifies identical concurrent queries
+// collapse into one store execution, distinct queries do not, and a canceled
+// caller returns promptly without poisoning the shared flight.
+func TestGetCombinedMetrics_Singleflight(t *testing.T) {
+	quantumBase := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("identical concurrent queries share one store call", func(t *testing.T) {
+		// Arrange
+		svc, dataStore := newCombinedMetricsTestService(t)
+		started := make(chan struct{})
+		release := make(chan struct{})
+		want := models.CombinedMetric{Metrics: []models.Metric{{MeasurementType: models.MeasurementTypeHashrate}}}
+		dataStore.EXPECT().
+			GetCombinedMetrics(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, q models.CombinedMetricsQuery) (models.CombinedMetric, error) {
+				// The executed query must carry the quantized bounds so the
+				// shared result matches what followers keyed on.
+				assert.Equal(t, quantumBase, *q.TimeRange.EndTime)
+				assert.Equal(t, quantumBase.Add(-24*time.Hour), *q.TimeRange.StartTime)
+				close(started)
+				<-release
+				return want, nil
+			})
+
+		results := make(chan models.CombinedMetric, 2)
+		errs := make(chan error, 2)
+		run := func(q models.CombinedMetricsQuery) {
+			res, err := svc.GetCombinedMetrics(t.Context(), q)
+			results <- res
+			errs <- err
+		}
+
+		// Act: end times 3s and 7s past the quantum boundary collapse to the
+		// same key. The store blocks until released, guaranteeing overlap.
+		go run(combinedMetricsQueryAt(42, 3*time.Second))
+		<-started
+		go run(combinedMetricsQueryAt(42, 7*time.Second))
+		// Let the second caller join the pending flight before the leader is
+		// released; if it misses and re-queries, the mock fails on call count.
+		time.Sleep(50 * time.Millisecond)
+		close(release)
+
+		// Assert
+		for range 2 {
+			require.NoError(t, <-errs)
+			assert.Equal(t, want, <-results)
+		}
+	})
+
+	t.Run("distinct queries do not collapse", func(t *testing.T) {
+		differentMeasurements := combinedMetricsQueryAt(1, 3*time.Second)
+		differentMeasurements.MeasurementTypes = []models.MeasurementType{models.MeasurementTypePower}
+
+		tests := []struct {
+			name   string
+			queryA models.CombinedMetricsQuery
+			queryB models.CombinedMetricsQuery
+		}{
+			{"different orgs", combinedMetricsQueryAt(1, 3*time.Second), combinedMetricsQueryAt(2, 3*time.Second)},
+			{"different measurement sets", combinedMetricsQueryAt(1, 3*time.Second), differentMeasurements},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				// Arrange
+				svc, dataStore := newCombinedMetricsTestService(t)
+				started := make(chan struct{}, 2)
+				release := make(chan struct{})
+				dataStore.EXPECT().
+					GetCombinedMetrics(gomock.Any(), gomock.Any()).
+					Times(2).
+					DoAndReturn(func(_ context.Context, _ models.CombinedMetricsQuery) (models.CombinedMetric, error) {
+						started <- struct{}{}
+						<-release
+						return models.CombinedMetric{}, nil
+					})
+
+				errs := make(chan error, 2)
+
+				// Act
+				go func() {
+					_, err := svc.GetCombinedMetrics(t.Context(), tc.queryA)
+					errs <- err
+				}()
+				go func() {
+					_, err := svc.GetCombinedMetrics(t.Context(), tc.queryB)
+					errs <- err
+				}()
+
+				// Assert: both queries reach the store concurrently, proving
+				// they run as separate flights.
+				for range 2 {
+					select {
+					case <-started:
+					case <-time.After(5 * time.Second):
+						t.Fatal("expected two concurrent store calls")
+					}
+				}
+				close(release)
+				require.NoError(t, <-errs)
+				require.NoError(t, <-errs)
+			})
+		}
+	})
+
+	t.Run("canceled caller returns while sibling still gets the result", func(t *testing.T) {
+		// Arrange
+		svc, dataStore := newCombinedMetricsTestService(t)
+		started := make(chan struct{})
+		release := make(chan struct{})
+		want := models.CombinedMetric{Metrics: []models.Metric{{MeasurementType: models.MeasurementTypeHashrate}}}
+		dataStore.EXPECT().
+			GetCombinedMetrics(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ models.CombinedMetricsQuery) (models.CombinedMetric, error) {
+				close(started)
+				// The flight context must be detached from the leader: if the
+				// leader's cancellation propagated here, this would error and
+				// poison the follower's result below.
+				select {
+				case <-release:
+					return want, nil
+				case <-ctx.Done():
+					return models.CombinedMetric{}, ctx.Err()
+				}
+			})
+
+		leaderCtx, cancelLeader := context.WithCancel(t.Context())
+		leaderErrs := make(chan error, 1)
+		go func() {
+			_, err := svc.GetCombinedMetrics(leaderCtx, combinedMetricsQueryAt(42, 3*time.Second))
+			leaderErrs <- err
+		}()
+		<-started
+
+		followerResults := make(chan models.CombinedMetric, 1)
+		followerErrs := make(chan error, 1)
+		go func() {
+			res, err := svc.GetCombinedMetrics(t.Context(), combinedMetricsQueryAt(42, 7*time.Second))
+			followerResults <- res
+			followerErrs <- err
+		}()
+		time.Sleep(50 * time.Millisecond) // let the follower join the pending flight
+
+		// Act
+		cancelLeader()
+
+		// Assert: the canceled caller returns promptly even though the store
+		// call is still blocked.
+		select {
+		case err := <-leaderErrs:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(5 * time.Second):
+			t.Fatal("canceled caller did not return promptly")
+		}
+
+		close(release)
+		require.NoError(t, <-followerErrs)
+		assert.Equal(t, want, <-followerResults)
+	})
+}

--- a/server/internal/domain/telemetry/service_test.go
+++ b/server/internal/domain/telemetry/service_test.go
@@ -4114,17 +4114,20 @@ func TestWriteFleetStateSnapshot(t *testing.T) {
 	})
 }
 
-// combinedMetricsQueryAt builds a query whose end time lands endOffset past a
-// fixed quantum-aligned base, with a 24h duration. Offsets within the same
-// 15s quantum must quantize (and therefore key) identically.
+// combinedMetricsQueryAt builds a dashboard-like query (90s granularity)
+// whose end time lands endOffset past a fixed quantum-aligned base, with a
+// 24h duration. Offsets within the same 15s quantum must quantize (and
+// therefore key) identically.
 func combinedMetricsQueryAt(org int64, endOffset time.Duration) models.CombinedMetricsQuery {
 	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 	end := base.Add(endOffset)
 	start := end.Add(-24 * time.Hour)
+	slide := 90 * time.Second
 	return models.CombinedMetricsQuery{
 		OrganizationID:   org,
 		MeasurementTypes: []models.MeasurementType{models.MeasurementTypeHashrate},
 		TimeRange:        models.TimeRange{StartTime: &start, EndTime: &end},
+		SlideInterval:    &slide,
 	}
 }
 
@@ -4141,9 +4144,125 @@ func newCombinedMetricsTestService(t *testing.T) (*TelemetryService, *mock.MockT
 	return svc, dataStore
 }
 
+// TestQuantizeCombinedMetricsWindow verifies coarsening applies only when the
+// requested bucket interval makes a sub-quantum shift invisible; finer
+// queries keep their exact bounds.
+func TestQuantizeCombinedMetricsWindow(t *testing.T) {
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	coarse := 90 * time.Second
+	fine := 10 * time.Second
+	end := base.Add(7 * time.Second)
+	start := end.Add(-time.Hour)
+
+	tests := []struct {
+		name          string
+		slideInterval *time.Duration
+		wantStart     time.Time
+		wantEnd       time.Time
+	}{
+		{"coarse interval shifts window onto the quantum grid", &coarse, base.Add(-time.Hour), base},
+		{"fine interval keeps exact bounds", &fine, start, end},
+		{"nil interval keeps exact bounds", nil, start, end},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			query := models.CombinedMetricsQuery{
+				TimeRange:     models.TimeRange{StartTime: &start, EndTime: &end},
+				SlideInterval: tc.slideInterval,
+			}
+
+			// Act
+			got := quantizeCombinedMetricsWindow(query)
+
+			// Assert
+			assert.Equal(t, tc.wantStart, *got.TimeRange.StartTime)
+			assert.Equal(t, tc.wantEnd, *got.TimeRange.EndTime)
+		})
+	}
+}
+
+// TestCombinedMetricsFlightKey verifies which query variations may share a
+// flight: pure filter sets (DeviceIDs, SiteIDs) collapse regardless of
+// order, order-sensitive slices (MeasurementTypes, AggregationTypes) do not
+// because the store emits results in request slice order, and pagination
+// fields the combined-metrics path ignores never split a key.
+func TestCombinedMetricsFlightKey(t *testing.T) {
+	base := func() models.CombinedMetricsQuery {
+		q := combinedMetricsQueryAt(42, 3*time.Second)
+		q.MeasurementTypes = []models.MeasurementType{models.MeasurementTypeHashrate, models.MeasurementTypePower}
+		q.AggregationTypes = []models.AggregationType{models.AggregationTypeAverage, models.AggregationTypeMax}
+		q.DeviceIDs = []models.DeviceIdentifier{"device-a", "device-b"}
+		q.SiteIDs = []int64{1, 2}
+		return q
+	}
+
+	tests := []struct {
+		name     string
+		mutate   func(*models.CombinedMetricsQuery)
+		wantSame bool
+	}{
+		{
+			"pagination fields do not split the key",
+			func(q *models.CombinedMetricsQuery) {
+				q.PageSize = 500
+				q.PaginationToken = "token"
+			},
+			true,
+		},
+		{
+			"device ID order does not split the key",
+			func(q *models.CombinedMetricsQuery) {
+				q.DeviceIDs = []models.DeviceIdentifier{"device-b", "device-a"}
+			},
+			true,
+		},
+		{
+			"site ID order does not split the key",
+			func(q *models.CombinedMetricsQuery) {
+				q.SiteIDs = []int64{2, 1}
+			},
+			true,
+		},
+		{
+			"measurement type order splits the key",
+			func(q *models.CombinedMetricsQuery) {
+				q.MeasurementTypes = []models.MeasurementType{models.MeasurementTypePower, models.MeasurementTypeHashrate}
+			},
+			false,
+		},
+		{
+			"aggregation type order splits the key",
+			func(q *models.CombinedMetricsQuery) {
+				q.AggregationTypes = []models.AggregationType{models.AggregationTypeMax, models.AggregationTypeAverage}
+			},
+			false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			query := base()
+			tc.mutate(&query)
+
+			// Act
+			got := combinedMetricsFlightKey(query)
+
+			// Assert
+			if tc.wantSame {
+				assert.Equal(t, combinedMetricsFlightKey(base()), got)
+			} else {
+				assert.NotEqual(t, combinedMetricsFlightKey(base()), got)
+			}
+		})
+	}
+}
+
 // TestGetCombinedMetrics_Singleflight verifies identical concurrent queries
-// collapse into one store execution, distinct queries do not, and a canceled
-// caller returns promptly without poisoning the shared flight.
+// collapse into one store execution, non-collapsing queries (distinct fields,
+// fine granularity skew, nil bounds) do not, a canceled caller returns
+// promptly without poisoning the shared flight, and the shared query is
+// cancelled once no waiter remains.
 func TestGetCombinedMetrics_Singleflight(t *testing.T) {
 	quantumBase := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 
@@ -4190,9 +4309,22 @@ func TestGetCombinedMetrics_Singleflight(t *testing.T) {
 		}
 	})
 
-	t.Run("distinct queries do not collapse", func(t *testing.T) {
+	t.Run("non-collapsing queries do not share a flight", func(t *testing.T) {
 		differentMeasurements := combinedMetricsQueryAt(1, 3*time.Second)
 		differentMeasurements.MeasurementTypes = []models.MeasurementType{models.MeasurementTypePower}
+
+		fineSlide := 10 * time.Second
+		fineA := combinedMetricsQueryAt(1, 3*time.Second)
+		fineA.SlideInterval = &fineSlide
+		fineB := combinedMetricsQueryAt(1, 7*time.Second)
+		fineB.SlideInterval = &fineSlide
+
+		// Nil bounds resolve against time.Now() inside the store, so even
+		// byte-identical nil-bound queries must bypass singleflight.
+		nilBoundsA := combinedMetricsQueryAt(1, 3*time.Second)
+		nilBoundsA.TimeRange = models.TimeRange{}
+		nilBoundsB := combinedMetricsQueryAt(1, 3*time.Second)
+		nilBoundsB.TimeRange = models.TimeRange{}
 
 		tests := []struct {
 			name   string
@@ -4201,6 +4333,8 @@ func TestGetCombinedMetrics_Singleflight(t *testing.T) {
 		}{
 			{"different orgs", combinedMetricsQueryAt(1, 3*time.Second), combinedMetricsQueryAt(2, 3*time.Second)},
 			{"different measurement sets", combinedMetricsQueryAt(1, 3*time.Second), differentMeasurements},
+			{"fine granularity with skewed windows", fineA, fineB},
+			{"identical nil time bounds", nilBoundsA, nilBoundsB},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -4298,5 +4432,53 @@ func TestGetCombinedMetrics_Singleflight(t *testing.T) {
 		close(release)
 		require.NoError(t, <-followerErrs)
 		assert.Equal(t, want, <-followerResults)
+	})
+
+	t.Run("last waiter leaving cancels the shared query", func(t *testing.T) {
+		// Arrange
+		svc, dataStore := newCombinedMetricsTestService(t)
+		started := make(chan struct{})
+		storeCtxErr := make(chan error, 1)
+		want := models.CombinedMetric{Metrics: []models.Metric{{MeasurementType: models.MeasurementTypeHashrate}}}
+		gomock.InOrder(
+			dataStore.EXPECT().
+				GetCombinedMetrics(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, _ models.CombinedMetricsQuery) (models.CombinedMetric, error) {
+					close(started)
+					<-ctx.Done()
+					storeCtxErr <- ctx.Err()
+					return models.CombinedMetric{}, ctx.Err()
+				}),
+			dataStore.EXPECT().
+				GetCombinedMetrics(gomock.Any(), gomock.Any()).
+				Return(want, nil),
+		)
+
+		callerCtx, cancelCaller := context.WithCancel(t.Context())
+		errs := make(chan error, 1)
+		go func() {
+			_, err := svc.GetCombinedMetrics(callerCtx, combinedMetricsQueryAt(42, 3*time.Second))
+			errs <- err
+		}()
+		<-started
+
+		// Act
+		cancelCaller()
+
+		// Assert: the detached store query is cancelled once no waiter remains,
+		// instead of running out the flight timeout.
+		select {
+		case err := <-storeCtxErr:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(5 * time.Second):
+			t.Fatal("store query was not cancelled after the last waiter left")
+		}
+		require.ErrorIs(t, <-errs, context.Canceled)
+
+		// A later identical query starts a fresh flight rather than joining
+		// the cancelled one.
+		res, err := svc.GetCombinedMetrics(t.Context(), combinedMetricsQueryAt(42, 3*time.Second))
+		require.NoError(t, err)
+		assert.Equal(t, want, res)
 	})
 }


### PR DESCRIPTION
Reviewable diff: +155/-0 across 1 file (excludes generated and test files).

## Summary

Every dashboard viewer polls `GetCombinedMetrics` on a 15-second interval, and identical concurrent requests each execute the full query pipeline independently: N viewers of the same org cost N heavy database queries per poll window. This PR collapses identical concurrent requests into one execution, so a fleet dashboard's database cost is bounded by distinct view shapes, not viewer count. Complementary to #648, which bounds the cost of each individual query; the two merge in any order.

## How it works

`TelemetryService.GetCombinedMetrics` first quantizes the request window: the end time is truncated down to a 15-second grid (matching the client poll interval) and the start time shifts by the same delta, preserving duration. This matters because clients stamp both bounds from the current time, so two viewers' requests never carry byte-identical windows; without quantization no two requests would ever share a key. The staleness introduced is under 15 seconds, invisible at dashboard granularity.

The quantized query produces a flight key covering every result-affecting field: org, window bounds (nil bounds participate as nil markers and are resolved later by the store), slide interval, sorted measurement and aggregation types, a hash of the sorted device IDs, sorted site IDs, include-unassigned, and pagination fields. Concurrent calls with the same key join one singleflight: the leader executes the original method body, including site-scope resolution and the live uptime bar, so those queries are collapsed too. The leader runs on a context detached from its caller (with a 65s budget, the store's 60s query timeout plus headroom), so a canceled leader cannot poison waiting followers; each caller independently races the shared result against its own context.

The pattern, including the detached-context and error conventions, is copied from the existing `fleetmanagement.getCachedFleetOptions` singleflight. No TTL cache is added: collapsing concurrency is the observed pathology, and the quantized key already merges within-window sequential calls.

## Diagrams

```mermaid
flowchart TD
  A["Viewer 1 request (end=12:00:03)"] --> Q["Quantize window to 15s grid"]
  B["Viewer 2 request (end=12:00:11)"] --> Q
  Q --> K["Same flight key"]
  K --> L["Leader executes once (detached context, 65s budget)"]
  L --> R["Result shared with all callers"]
  R --> C1["Viewer 1 (or its ctx.Done)"]
  R --> C2["Viewer 2 (or its ctx.Done)"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/telemetry/service.go` | `GetCombinedMetrics` wraps the moved-to-private `fetchCombinedMetrics` in a quantize + singleflight layer; key builder and window quantization helpers. | Key completeness (every result-affecting field participates) and the detached-context lifetime are the two things to scrutinize. |

## Key technical decisions & trade-offs

- Service layer over handler or store: dedup sits before site-scope resolution (collapsing that query too) and below the API surface, so internal callers benefit; `StreamCombinedMetrics` is deliberately not wrapped.
- 15s quantum matching the client poll interval: bigger quanta increase staleness with no extra collapse; smaller quanta stop colliding.
- Singleflight without a TTL cache: concurrency collapse fixes the observed N-viewers pathology; a cache adds invalidation semantics for no demonstrated need (the fleetoptions precedent has one because its callers are sequential).
- Fixed 65s flight budget as a local constant: the store's `QueryTimeout` is not visible at the domain layer; the constant states this.

## Testing & validation

- Concurrency-gated unit tests with the gomock store: same-quantum concurrent calls hit the store exactly once and share the result (the store fake blocks until both callers are enlisted, and asserts the executed query carries quantized bounds); different orgs or measurement sets execute independently and concurrently; a canceled leader returns promptly while the follower still receives the result, proving the flight context is detached.
- Full `internal/domain/telemetry` suite green, including `-race -count=5` on the new tests; `go build` and `golangci-lint` clean.
- Not covered: no end-to-end multi-client measurement; the collapse ratio in production equals the number of concurrent same-view dashboards, observable via existing query logs once deployed.
