### PR TITLE
[codex] Add building detail E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts
@@ -1,0 +1,259 @@
+import { type Browser, type Page, type TestInfo } from "@playwright/test";
+import { testConfig } from "../config/test.config";
+import { test } from "../fixtures/pageFixtures";
+import { AuthPage } from "../pages/auth";
+import { FleetLocationsPage } from "../pages/fleetLocations";
+import { MinersPage } from "../pages/miners";
+import { RacksPage } from "../pages/racks";
+import {
+  assignRackToBuilding,
+  createRackWithAssignedMiners,
+  validateRackAndMinerPlacementAcrossTabs,
+  validateSiteAndBuildingCounts,
+} from "./buildingsTestSetup";
+import { CommonSteps } from "./commonSteps";
+import { getSafeProjectName, getTestRunKey, installAllSitesInitScript } from "./fleetLocationsSetup";
+import { generateRandomText } from "./testDataHelper";
+const AUTOMATION_SITE_BASE_PREFIX = "automation_building_detail_site";
+const AUTOMATION_BUILDING_BASE_PREFIX = "automation_building_detail_building";
+const AUTOMATION_RACK_BASE_PREFIX = "automation_building_detail_rack";
+
+type BuildingDetailRunPrefixes = {
+  sitePrefix: string;
+  buildingPrefix: string;
+  rackPrefix: string;
+};
+
+const testRunPrefixes = new Map<string, BuildingDetailRunPrefixes>();
+
+type BuildingDetailCleanupFleetLocationsPage = Pick<
+  FleetLocationsPage,
+  "deleteBuildingByNameIfVisible" | "deleteSiteByNameIfVisible" | "listBuildingNames" | "listSiteNames"
+>;
+
+type BuildingDetailCleanupRacksPage = Pick<
+  RacksPage,
+  | "clickViewList"
+  | "deleteRackByLabelIfVisible"
+  | "listRackNames"
+  | "navigateToRacksPage"
+  | "tryAction"
+  | "waitForRackListToLoad"
+>;
+
+export type BuildingDetailScenarioData = {
+  siteName: string;
+  buildingName: string;
+  renamedBuildingName: string;
+  siblingBuildingName: string;
+  rackLabel: string;
+  powerCapacityMw: string;
+};
+
+function createRunPrefixes(testInfo: TestInfo): BuildingDetailRunPrefixes {
+  const runPrefix = `${getSafeProjectName(testInfo)}_${testInfo.workerIndex}_${testInfo.retry}`;
+
+  return {
+    sitePrefix: generateRandomText(`${AUTOMATION_SITE_BASE_PREFIX}_${runPrefix}`),
+    buildingPrefix: generateRandomText(`${AUTOMATION_BUILDING_BASE_PREFIX}_${runPrefix}`),
+    rackPrefix: generateRandomText(`${AUTOMATION_RACK_BASE_PREFIX}_${runPrefix}`),
+  };
+}
+
+function getRunPrefixes(testInfo: TestInfo): BuildingDetailRunPrefixes {
+  const prefixes = testRunPrefixes.get(getTestRunKey(testInfo));
+  if (!prefixes) {
+    throw new Error("Building detail E2E run prefixes were not initialized.");
+  }
+
+  return prefixes;
+}
+
+export function createBuildingDetailScenarioData(testInfo: TestInfo): BuildingDetailScenarioData {
+  const prefixes = getRunPrefixes(testInfo);
+
+  return {
+    siteName: generateRandomText(`${prefixes.sitePrefix}_primary`),
+    buildingName: generateRandomText(`${prefixes.buildingPrefix}_primary`),
+    renamedBuildingName: generateRandomText(`${prefixes.buildingPrefix}_renamed`),
+    siblingBuildingName: generateRandomText(`${prefixes.buildingPrefix}_sibling`),
+    rackLabel: generateRandomText(`${prefixes.rackPrefix}_primary`),
+    powerCapacityMw: "4.2",
+  };
+}
+
+async function cleanupAutomationFixtures(
+  fleetLocationsPage: BuildingDetailCleanupFleetLocationsPage,
+  racksPage: BuildingDetailCleanupRacksPage,
+  prefixes: BuildingDetailRunPrefixes,
+) {
+  await racksPage.navigateToRacksPage();
+  await racksPage.tryAction(() => racksPage.clickViewList());
+  await racksPage.waitForRackListToLoad();
+
+  const rackNames = (await racksPage.listRackNames()).filter((name) => name.startsWith(prefixes.rackPrefix));
+  for (const rackName of rackNames) {
+    await racksPage.deleteRackByLabelIfVisible(rackName);
+  }
+
+  const buildingNames = (await fleetLocationsPage.listBuildingNames()).filter((name) =>
+    name.startsWith(prefixes.buildingPrefix),
+  );
+  for (const buildingName of buildingNames) {
+    await fleetLocationsPage.deleteBuildingByNameIfVisible(buildingName);
+  }
+
+  const siteNames = (await fleetLocationsPage.listSiteNames()).filter((name) => name.startsWith(prefixes.sitePrefix));
+  for (const siteName of siteNames) {
+    await fleetLocationsPage.deleteSiteByNameIfVisible(siteName);
+  }
+}
+
+async function cleanupAutomationBuildingDetail(browser: Browser, testInfo: TestInfo) {
+  const prefixes = getRunPrefixes(testInfo);
+  const isMobile = testInfo.project.use?.isMobile ?? false;
+  const context = await browser.newContext({
+    baseURL: testConfig.baseUrl,
+    viewport: testInfo.project.use?.viewport,
+  });
+
+  try {
+    const page = await context.newPage();
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+
+    const authPage = new AuthPage(page, isMobile);
+    const minersPage = new MinersPage(page, isMobile);
+    const racksPage = new RacksPage(page, isMobile);
+    const fleetLocationsPage = new FleetLocationsPage(page, isMobile);
+    const commonSteps = new CommonSteps(authPage, minersPage);
+
+    await commonSteps.loginAsAdmin();
+    await cleanupAutomationFixtures(fleetLocationsPage, racksPage, prefixes);
+  } finally {
+    await context.close();
+  }
+}
+
+export function useBuildingDetailHooks() {
+  test.beforeEach(async ({ page, commonSteps, fleetLocationsPage, racksPage }, testInfo) => {
+    testRunPrefixes.set(getTestRunKey(testInfo), createRunPrefixes(testInfo));
+
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+    await commonSteps.loginAsAdmin();
+    await cleanupAutomationFixtures(fleetLocationsPage, racksPage, getRunPrefixes(testInfo));
+  });
+
+  test.afterEach("CLEANUP: Delete automation building detail fixtures", async ({ browser }, testInfo) => {
+    try {
+      await cleanupAutomationBuildingDetail(browser, testInfo);
+    } finally {
+      testRunPrefixes.delete(getTestRunKey(testInfo));
+    }
+  });
+}
+
+export async function setupBuildingDetailScenario(
+  page: Page,
+  fleetLocationsPage: FleetLocationsPage,
+  racksPage: RacksPage,
+  scenario: BuildingDetailScenarioData,
+) {
+  return await test.step("Create a site, two buildings, and an assigned rack for building detail coverage", async () => {
+    await fleetLocationsPage.createSite(scenario.siteName);
+    const buildingId = await fleetLocationsPage.createBuilding(scenario.siteName, scenario.buildingName);
+    await fleetLocationsPage.createBuilding(scenario.siteName, scenario.siblingBuildingName);
+
+    const { rackId, selectedMinerIps } = await createRackWithAssignedMiners(racksPage, scenario.rackLabel);
+    await assignRackToBuilding(page, racksPage, scenario.rackLabel, rackId, scenario.buildingName, buildingId);
+
+    return { buildingId, rackId, selectedMinerIps };
+  });
+}
+
+export async function setupBuildingDetailDeletionScenario(
+  page: Page,
+  fleetLocationsPage: FleetLocationsPage,
+  racksPage: RacksPage,
+  scenario: BuildingDetailScenarioData,
+) {
+  return await test.step("Create a site, one building, and an assigned rack for the delete scenario", async () => {
+    await fleetLocationsPage.createSite(scenario.siteName);
+    const buildingId = await fleetLocationsPage.createBuilding(scenario.siteName, scenario.buildingName);
+
+    const { rackId, selectedMinerIps } = await createRackWithAssignedMiners(racksPage, scenario.rackLabel);
+    await assignRackToBuilding(page, racksPage, scenario.rackLabel, rackId, scenario.buildingName, buildingId);
+
+    return { buildingId, rackId, selectedMinerIps };
+  });
+}
+
+export async function validateBuildingDetailScenarioAcrossTabs({
+  page,
+  fleetLocationsPage,
+  minersPage,
+  racksPage,
+  scenario,
+  selectedMinerIps,
+}: {
+  page: Page;
+  fleetLocationsPage: FleetLocationsPage;
+  minersPage: MinersPage;
+  racksPage: RacksPage;
+  scenario: {
+    siteName: string;
+    buildingName: string;
+    siblingBuildingName: string;
+    rackLabel: string;
+  };
+  selectedMinerIps: string[];
+}) {
+  await test.step("Validate the renamed building and sibling counts across the Fleet tabs", async () => {
+    await validateSiteAndBuildingCounts(fleetLocationsPage, {
+      siteName: scenario.siteName,
+      siteCounts: {
+        buildings: 2,
+        racks: 1,
+        miners: 2,
+      },
+      buildings: [
+        { buildingName: scenario.buildingName, racks: 1, miners: 2 },
+        { buildingName: scenario.siblingBuildingName, racks: 0, miners: 0 },
+      ],
+    });
+  });
+
+  await test.step("Validate the building detail View racks button opens the scoped racks list", async () => {
+    await fleetLocationsPage.openBuildingDetail(scenario.buildingName);
+    await fleetLocationsPage.openRacksFromBuildingDetail();
+    await racksPage.clickViewList();
+    await racksPage.waitForRackListToLoad({ allowEmpty: false });
+    await racksPage.validateRackPlacementRow(scenario.rackLabel, scenario.siteName, scenario.buildingName);
+  });
+
+  await test.step("Validate the building detail View miners button opens the scoped miners list", async () => {
+    await fleetLocationsPage.openBuildingDetail(scenario.buildingName);
+    await fleetLocationsPage.openMinersFromBuildingDetail();
+    await minersPage.waitForMinersTitle();
+    await minersPage.waitForMinersListToLoad();
+
+    for (const ipAddress of selectedMinerIps) {
+      await test.expect.poll(() => minersPage.getMinerColumnText(ipAddress, "site")).toBe(scenario.siteName);
+      await test.expect.poll(() => minersPage.getMinerColumnText(ipAddress, "building")).toBe(scenario.buildingName);
+      await test.expect.poll(() => minersPage.getMinerColumnText(ipAddress, "rack")).toBe(scenario.rackLabel);
+    }
+  });
+
+  await test.step("Validate the racks and miners tabs still show the renamed building placement", async () => {
+    await validateRackAndMinerPlacementAcrossTabs({
+      page,
+      minersPage,
+      racksPage,
+      siteName: scenario.siteName,
+      buildingName: scenario.buildingName,
+      rackLabel: scenario.rackLabel,
+      selectedMinerIps,
+    });
+  });
+}

--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -6,6 +6,7 @@ import { FleetLocationsPage } from "../pages/fleetLocations";
 import { MinersPage } from "../pages/miners";
 import { RacksPage } from "../pages/racks";
 import { CommonSteps } from "./commonSteps";
+import { installAllSitesInitScript } from "./fleetLocationsSetup";
 import { addSelectableMinersToSlots } from "./racksHelpers";
 import { generateRandomText } from "./testDataHelper";
 
@@ -16,8 +17,6 @@ const AUTOMATION_RACK_PREFIX = "automation_buildings_rack";
 const TEMP_ZONE = "AutomationBuildingsZone";
 const RACK_COLUMNS = 2;
 const RACK_ROWS = 2;
-const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
-
 type BuildingsCleanupFleetLocationsPage = Pick<
   FleetLocationsPage,
   "deleteBuildingByNameIfVisible" | "deleteSiteByNameIfVisible" | "listBuildingNames" | "listSiteNames"
@@ -45,25 +44,6 @@ export function createBuildingsScenarioData(): BuildingsScenarioData {
     buildingName: generateRandomText(AUTOMATION_BUILDING_PREFIX),
     rackLabel: generateRandomText(AUTOMATION_RACK_PREFIX),
   };
-}
-
-async function installAllSitesInitScript(page: Page) {
-  await page.addInitScript(
-    ({ storageKey }) => {
-      localStorage.setItem(
-        storageKey,
-        JSON.stringify({
-          state: {
-            ui: {
-              activeSite: { kind: "all" },
-            },
-          },
-          version: 0,
-        }),
-      );
-    },
-    { storageKey: ACTIVE_SITE_STORAGE_KEY },
-  );
 }
 
 async function cleanupAutomationFixtures(

--- a/client/e2eTests/protoFleet/helpers/fleetLocationsSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/fleetLocationsSetup.ts
@@ -1,0 +1,37 @@
+import { type Page, type TestInfo } from "@playwright/test";
+
+const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
+
+export function getTestRunKey(testInfo: TestInfo): string {
+  return [testInfo.project.name, testInfo.testId, testInfo.workerIndex, testInfo.retry, testInfo.repeatEachIndex].join(
+    ":",
+  );
+}
+
+export function getSafeProjectName(testInfo: TestInfo): string {
+  return (
+    testInfo.project.name
+      .replace(/[^a-zA-Z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .toLowerCase() || "project"
+  );
+}
+
+export async function installAllSitesInitScript(page: Page) {
+  await page.addInitScript(
+    ({ storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          state: {
+            ui: {
+              activeSite: { kind: "all" },
+            },
+          },
+          version: 0,
+        }),
+      );
+    },
+    { storageKey: ACTIVE_SITE_STORAGE_KEY },
+  );
+}

--- a/client/e2eTests/protoFleet/helpers/sitesDetailTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/sitesDetailTestSetup.ts
@@ -1,13 +1,12 @@
-import { type Browser, type Page, type TestInfo } from "@playwright/test";
+import { type Browser, type TestInfo } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { AuthPage } from "../pages/auth";
 import { FleetLocationsPage } from "../pages/fleetLocations";
 import { MinersPage } from "../pages/miners";
 import { CommonSteps } from "./commonSteps";
+import { getSafeProjectName, getTestRunKey, installAllSitesInitScript } from "./fleetLocationsSetup";
 import { generateRandomText } from "./testDataHelper";
-
-const ACTIVE_SITE_STORAGE_KEY = "proto-fleet-multi-site";
 const AUTOMATION_SITE_BASE_PREFIX = "automation_site_detail_site";
 const AUTOMATION_BUILDING_BASE_PREFIX = "automation_site_detail_building";
 
@@ -31,21 +30,6 @@ export type SiteDetailScenarioData = {
   city: string;
   powerCapacityMw: string;
 };
-
-function getTestRunKey(testInfo: TestInfo): string {
-  return [testInfo.project.name, testInfo.testId, testInfo.workerIndex, testInfo.retry, testInfo.repeatEachIndex].join(
-    ":",
-  );
-}
-
-function getSafeProjectName(testInfo: TestInfo): string {
-  return (
-    testInfo.project.name
-      .replace(/[^a-zA-Z0-9]+/g, "_")
-      .replace(/^_+|_+$/g, "")
-      .toLowerCase() || "project"
-  );
-}
 
 function createRunPrefixes(testInfo: TestInfo): SiteDetailRunPrefixes {
   const runPrefix = `${getSafeProjectName(testInfo)}_${testInfo.workerIndex}_${testInfo.retry}`;
@@ -76,25 +60,6 @@ export function createSiteDetailScenarioData(testInfo: TestInfo): SiteDetailScen
     city: "Chicago",
     powerCapacityMw: "12.5",
   };
-}
-
-async function installAllSitesInitScript(page: Page) {
-  await page.addInitScript(
-    ({ storageKey }) => {
-      localStorage.setItem(
-        storageKey,
-        JSON.stringify({
-          state: {
-            ui: {
-              activeSite: { kind: "all" },
-            },
-          },
-          version: 0,
-        }),
-      );
-    },
-    { storageKey: ACTIVE_SITE_STORAGE_KEY },
-  );
 }
 
 async function cleanupAutomationFixtures(

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -68,6 +68,17 @@ export class FleetLocationsPage extends BasePage {
     return siteId;
   }
 
+  async openBuildingDetail(name: string): Promise<bigint> {
+    await this.navigateToBuildingsPage();
+    const buildingId = await this.getScopeIdFromRowName(name, "building");
+    const row = this.getListRowByName(name);
+    await expect(row).toBeVisible();
+    await row.getByTestId("name").click();
+    await expect(this.page).toHaveURL(new RegExp(`/buildings/${buildingId.toString()}(?:[?#].*)?$`));
+    await expect(this.page.getByTestId("building-page")).toBeVisible();
+    return buildingId;
+  }
+
   async validateSitesPageOpened() {
     await expect(this.page).toHaveURL(/\/fleet\/sites(?:[?#].*)?$/);
     await this.validateSitesListVisible();
@@ -84,6 +95,11 @@ export class FleetLocationsPage extends BasePage {
     await expect(this.page.getByTestId("site-detail-title")).toHaveText(siteName);
   }
 
+  async validateBuildingDetailOpened(buildingName: string) {
+    await expect(this.page.getByTestId("building-page")).toBeVisible();
+    await expect(this.page.getByTestId("building-page-title")).toHaveText(buildingName);
+  }
+
   async validateSiteDetailMetrics(expected: { location?: string; buildings?: number }) {
     const metricsRow = this.page.getByTestId("site-detail-metrics-row");
     await expect(metricsRow).toBeVisible();
@@ -94,6 +110,21 @@ export class FleetLocationsPage extends BasePage {
 
     if (expected.buildings !== undefined) {
       await expect(metricsRow.getByTestId("site-metric-buildings-value")).toHaveText(String(expected.buildings));
+    }
+  }
+
+  async validateBuildingDetailMetrics(expected: { minersOnline?: string; totalMiners?: number }) {
+    const metricsRow = this.page.getByTestId("building-metrics-row");
+    await expect(metricsRow).toBeVisible();
+
+    if (expected.minersOnline !== undefined) {
+      await expect(metricsRow.getByTestId("building-metric-online-value")).toHaveText(expected.minersOnline);
+    }
+
+    if (expected.totalMiners !== undefined) {
+      await expect(metricsRow.getByTestId("building-metric-online-value")).toHaveText(
+        new RegExp(`^\\d+\\s/\\s${expected.totalMiners}$`),
+      );
     }
   }
 
@@ -124,6 +155,29 @@ export class FleetLocationsPage extends BasePage {
     await this.closeFullScreenModalIfVisible();
   }
 
+  async editBuildingDetailsFromDetail(updates: { name?: string; powerCapacityMw?: string }) {
+    await expect(this.page.getByTestId("building-page-edit")).toBeVisible();
+    await this.page.getByTestId("building-page-edit").click();
+    const fullScreenModal = this.page.getByTestId("full-screen-two-pane-modal");
+    await expect(fullScreenModal).toBeVisible();
+    await this.clickManageBuildingEditDetails(fullScreenModal);
+
+    const settingsModal = this.page.getByTestId("building-settings-modal");
+    await expect(settingsModal).toBeVisible();
+
+    if (updates.name !== undefined) {
+      await settingsModal.getByTestId("building-settings-name-input").fill(updates.name);
+    }
+
+    if (updates.powerCapacityMw !== undefined) {
+      await settingsModal.getByTestId("building-settings-power-input").fill(updates.powerCapacityMw);
+    }
+
+    await settingsModal.getByTestId("building-settings-modal-save").click();
+    await this.waitForModalToClose("building-settings-modal");
+    await this.closeFullScreenModalIfVisible();
+  }
+
   async addBuildingFromSiteDetail(buildingName: string) {
     await expect(this.page.getByTestId("site-detail-add-building")).toBeVisible();
     await this.page.getByTestId("site-detail-add-building").click();
@@ -148,6 +202,15 @@ export class FleetLocationsPage extends BasePage {
     await expect(this.page.getByTestId("site-detail-title")).toHaveText(siteName);
   }
 
+  async switchBuildingDetailBreadcrumbTo(buildingName: string) {
+    const switcher = this.page.getByTestId("building-page-breadcrumb-switcher");
+    await expect(switcher).toBeVisible();
+    await switcher.click();
+    await this.page.getByTestId(`building-page-breadcrumb-menu-item-${buildingName}`).click();
+    await expect(this.page.getByTestId("building-page-breadcrumb-switcher")).toContainText(buildingName);
+    await expect(this.page.getByTestId("building-page-title")).toHaveText(buildingName);
+  }
+
   async deleteSiteFromDetail() {
     await expect(this.page.getByTestId("site-detail-edit")).toBeVisible();
     await this.page.getByTestId("site-detail-edit").click();
@@ -162,8 +225,38 @@ export class FleetLocationsPage extends BasePage {
     await expect(this.page.getByTestId("full-screen-two-pane-modal")).toHaveCount(0);
   }
 
+  async openRacksFromBuildingDetail() {
+    await expect(this.page.getByTestId("building-page-view-racks")).toBeVisible();
+    await this.page.getByTestId("building-page-view-racks").click();
+    await expect(this.page).toHaveURL(/\/fleet\/racks\?building=\d+/);
+  }
+
+  async openMinersFromBuildingDetail() {
+    await expect(this.page.getByTestId("building-page-view-miners")).toBeVisible();
+    await this.page.getByTestId("building-page-view-miners").click();
+    await expect(this.page).toHaveURL(/\/fleet\/miners\?building=\d+/);
+  }
+
+  async deleteBuildingFromDetail() {
+    await expect(this.page.getByTestId("building-page-edit")).toBeVisible();
+    await this.page.getByTestId("building-page-edit").click();
+    await this.clickManageBuildingDelete();
+
+    const confirmDeleteButton = this.page.getByTestId("building-delete-dialog-confirm");
+    await expect(confirmDeleteButton).toBeVisible();
+    await confirmDeleteButton.click({ trial: true });
+    await confirmDeleteButton.click();
+    await expect(this.page.getByTestId("building-delete-dialog")).toHaveCount(0);
+    await this.validateSitesPageOpened();
+  }
+
   async validateSiteNotVisible(name: string) {
     await this.navigateToSitesPage();
+    await expect(this.getListRowByName(name)).toHaveCount(0);
+  }
+
+  async validateBuildingNotVisible(name: string) {
+    await this.navigateToBuildingsPage();
     await expect(this.getListRowByName(name)).toHaveCount(0);
   }
 

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -122,8 +122,9 @@ export class FleetLocationsPage extends BasePage {
     }
 
     if (expected.totalMiners !== undefined) {
+      const formattedTotal = expected.totalMiners.toLocaleString();
       await expect(metricsRow.getByTestId("building-metric-online-value")).toHaveText(
-        new RegExp(`^\\d+\\s/\\s${expected.totalMiners}$`),
+        new RegExp(`^[\\d,]+\\s/\\s${formattedTotal}$`),
       );
     }
   }

--- a/client/e2eTests/protoFleet/spec/buildingDetail.spec.ts
+++ b/client/e2eTests/protoFleet/spec/buildingDetail.spec.ts
@@ -1,0 +1,92 @@
+import { test } from "../fixtures/pageFixtures";
+import {
+  createBuildingDetailScenarioData,
+  setupBuildingDetailDeletionScenario,
+  setupBuildingDetailScenario,
+  useBuildingDetailHooks,
+  validateBuildingDetailScenarioAcrossTabs,
+} from "../helpers/buildingDetailTestSetup";
+import { validateRackAndMinerPlacementAcrossTabs, validateSiteAndBuildingCounts } from "../helpers/buildingsTestSetup";
+
+test.describe("Buildings - detail", () => {
+  useBuildingDetailHooks();
+
+  test("Building detail supports editing details, opening scoped racks and miners, and switching to a sibling building", async ({
+    page,
+    fleetLocationsPage,
+    minersPage,
+    racksPage,
+  }, testInfo) => {
+    const scenario = createBuildingDetailScenarioData(testInfo);
+    const { selectedMinerIps } = await setupBuildingDetailScenario(page, fleetLocationsPage, racksPage, scenario);
+
+    await fleetLocationsPage.openBuildingDetail(scenario.buildingName);
+    await fleetLocationsPage.validateBuildingDetailOpened(scenario.buildingName);
+    await fleetLocationsPage.validateBuildingDetailMetrics({ totalMiners: 2 });
+
+    await fleetLocationsPage.editBuildingDetailsFromDetail({
+      name: scenario.renamedBuildingName,
+      powerCapacityMw: scenario.powerCapacityMw,
+    });
+
+    await fleetLocationsPage.validateBuildingDetailOpened(scenario.renamedBuildingName);
+    await fleetLocationsPage.validateBuildingDetailMetrics({ totalMiners: 2 });
+
+    await validateBuildingDetailScenarioAcrossTabs({
+      page,
+      fleetLocationsPage,
+      minersPage,
+      racksPage,
+      scenario: {
+        siteName: scenario.siteName,
+        buildingName: scenario.renamedBuildingName,
+        siblingBuildingName: scenario.siblingBuildingName,
+        rackLabel: scenario.rackLabel,
+      },
+      selectedMinerIps,
+    });
+
+    await fleetLocationsPage.openBuildingDetail(scenario.renamedBuildingName);
+    await fleetLocationsPage.switchBuildingDetailBreadcrumbTo(scenario.siblingBuildingName);
+    await fleetLocationsPage.validateBuildingDetailOpened(scenario.siblingBuildingName);
+    await fleetLocationsPage.validateBuildingDetailMetrics({ minersOnline: "0 / 0" });
+  });
+
+  test("Deleting a building from the detail page keeps the rack on the site", async ({
+    page,
+    fleetLocationsPage,
+    minersPage,
+    racksPage,
+  }, testInfo) => {
+    const scenario = createBuildingDetailScenarioData(testInfo);
+    const { selectedMinerIps } = await setupBuildingDetailDeletionScenario(
+      page,
+      fleetLocationsPage,
+      racksPage,
+      scenario,
+    );
+
+    await fleetLocationsPage.openBuildingDetail(scenario.buildingName);
+    await fleetLocationsPage.validateBuildingDetailOpened(scenario.buildingName);
+    await fleetLocationsPage.deleteBuildingFromDetail();
+
+    await fleetLocationsPage.validateBuildingNotVisible(scenario.buildingName);
+    await validateSiteAndBuildingCounts(fleetLocationsPage, {
+      siteName: scenario.siteName,
+      siteCounts: {
+        buildings: 0,
+        racks: 1,
+        miners: 2,
+      },
+      buildings: [],
+    });
+    await validateRackAndMinerPlacementAcrossTabs({
+      page,
+      minersPage,
+      racksPage,
+      siteName: scenario.siteName,
+      rackLabel: scenario.rackLabel,
+      selectedMinerIps,
+    });
+  });
+});

--- a/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
@@ -45,7 +45,7 @@ const BuildingPageHeader = ({
   return (
     <div className="flex flex-col gap-3">
       <Breadcrumb segments={breadcrumbSegments} testId="building-page-breadcrumb" />
-      <Header title={label} titleSize="text-heading-300" inline>
+      <Header title={label} titleSize="text-heading-300" inline testId="building-page-title">
         <div className="ml-3 flex items-center gap-3">
           <Button
             variant={variants.secondary}


### PR DESCRIPTION
Reviewable diff: +393/-59 across 6 files (excludes generated, test, and story files).

## Summary

This PR adds dedicated ProtoFleet E2E coverage for the standalone building detail route at `/buildings/:id`, which was still uncovered even after the broader Buildings tab flows and Site detail flows were in place. It verifies that building-detail actions stay consistent with the surrounding Fleet tabs, and it pulls the repeated all-sites E2E bootstrap logic into a shared helper so the new coverage does not add another copy of the same setup code.

## How it works

The new `buildingDetail.spec.ts` creates a site, buildings, a rack, and assigned miners using the existing building/rack helper flows, then opens the standalone building detail page from the Buildings tab. From there it exercises the building-detail-only controls: editing the building from detail, using the detail-page breadcrumb sibling switcher, following the detail-page `View racks` and `View miners` buttons into filtered Fleet lists, and deleting the building from detail while confirming that the rack stays on the site and becomes unassigned.

To keep the spec itself readable, the page-object work for building detail lives in `fleetLocations.ts`, and the setup/cleanup logic lives in `buildingDetailTestSetup.ts`. The shared E2E bootstrap that forces the Fleet UI into the `All sites` scope and provides stable per-run keys is now centralized in `fleetLocationsSetup.ts`, and the existing site-detail/buildings helpers now reuse that same helper instead of carrying local copies.

## Diagrams

```mermaid
flowchart TD
  A["Create site + buildings"] --> B["Create rack + assign miners"]
  B --> C["Assign rack to building from Racks tab"]
  C --> D["Open /buildings/:id from Buildings tab"]
  D --> E["Edit building from detail page"]
  E --> F["Open filtered Racks and Miners views"]
  F --> G["Switch to sibling building from breadcrumb"]
```

```mermaid
sequenceDiagram
  participant T as Test
  participant B as Buildings tab
  participant D as Building detail
  participant R as Racks tab
  participant M as Miners tab

  T->>B: Open building row
  B->>D: Navigate to /buildings/:id
  T->>D: Edit building name
  T->>D: Click "View racks"
  D->>R: Navigate with ?building=<id>
  T->>D: Reopen building detail
  T->>D: Click "View miners"
  D->>M: Navigate with ?building=<id>
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/buildingDetail.spec.ts` | Adds the new building-detail scenarios | Main user-flow coverage added by this PR |
| `client/e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts` | Encapsulates scenario setup, cleanup, and cross-tab assertions | Keeps the spec readable and defines the cleanup strategy |
| `client/e2eTests/protoFleet/pages/fleetLocations.ts` | Adds building-detail page-object actions and assertions | Core selector and interaction layer for the new coverage |
| `client/e2eTests/protoFleet/helpers/fleetLocationsSetup.ts` | Centralizes the all-sites bootstrap and run-key helpers | Removes duplicated E2E setup logic and reduces drift risk |
| `client/e2eTests/protoFleet/helpers/sitesDetailTestSetup.ts` | Reuses the shared setup helper | Shows the dedupe is applied consistently, not only for the new test |
| `client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts` | Reuses the shared setup helper | Keeps the existing Buildings flows aligned with the shared bootstrap |
| `client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx` | Adds a stable title test id on the building detail page | Small product-side testability hook needed for deterministic assertions |

## Key technical decisions & trade-offs

- Reused the existing building/rack setup helpers instead of inventing a new data-construction path, so the new coverage stays aligned with the already-tested Buildings workflows.
- Added building-detail actions to the existing `FleetLocationsPage` page object instead of creating a separate page object, because the detail route is still part of the Fleet locations surface and shares the same navigation context.
- Centralized the all-sites bootstrap into a shared helper rather than leaving a third near-copy in the new setup file, trading a small helper extraction for less future drift.
- Asserted the stable denominator of the `Miners online` metric on populated buildings instead of exact online numerators, because the environment does not guarantee that every assigned miner is actively hashing at assertion time.

## Testing & validation

- `./node_modules/.bin/eslint e2eTests/protoFleet/helpers/fleetLocationsSetup.ts e2eTests/protoFleet/helpers/sitesDetailTestSetup.ts e2eTests/protoFleet/helpers/buildingsTestSetup.ts e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts e2eTests/protoFleet/spec/buildingDetail.spec.ts e2eTests/protoFleet/pages/fleetLocations.ts src/protoFleet/features/buildings/components/BuildingPageHeader.tsx`
- `npx vitest run src/protoFleet/features/buildings/pages/BuildingPage.test.tsx`
- `PW_UI_NO_DEPS=1 ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/buildingDetail.spec.ts --project=desktop`
- `PW_UI_NO_DEPS=1 ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/buildingDetail.spec.ts --project=mobile`

Not covered here:
- infrastructure-tab behavior, which remains feature-flagged off in the current Fleet UI
- synthetic error-state coverage for `/buildings/:id` load failures or not-found flows in Playwright
