### PR TITLE
chore(client): add opt-in HTTPS for local Vite dev server

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -12,6 +12,9 @@ dist-ssr
 *.local
 .env
 
+# Local HTTPS dev certificates (generated via mkcert)
+certs
+
 # build directories
 dist
 

--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,8 @@
     "upload": "scp -Crp dist/* admin@$npm_config_host:/home/admin/",
     "format": "prettier --list-different --write \"./**/*.{js,jsx,ts,tsx,css,md}\"",
     "format:check": "prettier --check \"./**/*.{js,jsx,ts,tsx,css,md}\"",
-    "bootstrap": "npx tsx ./scripts/auth_discover_pair.ts"
+    "bootstrap": "npx tsx ./scripts/auth_discover_pair.ts",
+    "setup:https": "node ./scripts/generate-dev-certs.mjs"
   },
   "dependencies": {
     "@bufbuild/protobuf": "2.12.0",

--- a/client/scripts/generate-dev-certs.mjs
+++ b/client/scripts/generate-dev-certs.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Generate locally-trusted TLS certs for the Vite dev server's opt-in HTTPS mode
+// (`VITE_HTTPS=true`). Writes client/certs/{localhost,localhost-key}.pem.
+//
+// Run once (or whenever your hostname changes) with: npm run setup:https
+//
+// The cert covers loopback (localhost / 127.0.0.1 / ::1) plus this machine's
+// hostname(s), so it also works when the server is exposed with `vite --host`
+// and reached by hostname. LAN IPs are intentionally omitted: they rotate with
+// DHCP, which would silently invalidate the cert. Reach the machine by hostname
+// instead, or re-run this script if you must pin a new address.
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import os from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const clientDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const certsDir = resolve(clientDir, "certs");
+
+// mkcert must be installed and its local CA trusted (`mkcert -install`).
+const version = spawnSync("mkcert", ["-version"], { encoding: "utf8" });
+if (version.error) {
+  console.error(
+    "mkcert is not installed or not on PATH.\n" +
+      "  macOS:  brew install mkcert nss   (nss adds Firefox trust)\n" +
+      "  then:   mkcert -install           (one-time, trusts the local CA)\n" +
+      "See https://github.com/FiloSottile/mkcert for other platforms.",
+  );
+  process.exit(1);
+}
+
+// Loopback always; hostname(s) so `--host` access by name works. No LAN IPs.
+const hosts = new Set(["localhost", "127.0.0.1", "::1"]);
+if (os.hostname()) hosts.add(os.hostname());
+
+// macOS advertises an mDNS/Bonjour name that often differs from os.hostname().
+if (process.platform === "darwin") {
+  const localName = spawnSync("scutil", ["--get", "LocalHostName"], { encoding: "utf8" });
+  if (localName.status === 0 && localName.stdout.trim()) {
+    hosts.add(`${localName.stdout.trim()}.local`);
+  }
+}
+
+mkdirSync(certsDir, { recursive: true });
+
+const hostList = [...hosts];
+console.log(`Generating dev certs for: ${hostList.join(", ")}`);
+const result = spawnSync(
+  "mkcert",
+  ["-key-file", "certs/localhost-key.pem", "-cert-file", "certs/localhost.pem", ...hostList],
+  { cwd: clientDir, stdio: "inherit" },
+);
+
+if (result.status !== 0) process.exit(result.status ?? 1);
+console.log(
+  "\nDone. Start the dev server over HTTPS with:\n  VITE_HTTPS=true npm run dev:protoFleet   # or: VITE_HTTPS=true npm run dev",
+);

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -109,6 +109,19 @@ export default defineConfig(({ mode, command }) => {
   }
 
   const env = loadEnv(mode, process.cwd(), "");
+
+  // Opt-in HTTPS for local dev. Defaults to HTTP so CI, E2E, and other devs are
+  // unaffected. Generate locally-trusted certs with:
+  //   mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1
+  // then run: VITE_HTTPS=true npm run dev:protoFleet  (or npm run dev for protoOS)
+  const useHttps = env.VITE_HTTPS === "true" || process.env.VITE_HTTPS === "true";
+  const httpsConfig = useHttps
+    ? {
+        key: fs.readFileSync(resolve(_dirname, "certs/localhost-key.pem")),
+        cert: fs.readFileSync(resolve(_dirname, "certs/localhost.pem")),
+      }
+    : undefined;
+
   let proxies;
   if (mode === "protoFleet") {
     const proxyUrl = env.FLEET_PROXY_URL || process.env.FLEET_PROXY_URL || "http://localhost:4000";
@@ -171,6 +184,7 @@ export default defineConfig(({ mode, command }) => {
     server: {
       proxy: proxies,
       historyApiFallback: true,
+      https: httpsConfig,
     },
     preview: {
       proxy: proxies,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -110,15 +110,29 @@ export default defineConfig(({ mode, command }) => {
 
   const env = loadEnv(mode, process.cwd(), "");
 
-  // Opt-in HTTPS for local dev. Defaults to HTTP so CI, E2E, and other devs are
-  // unaffected. Generate locally-trusted certs with:
+  // Opt-in HTTPS for the local dev server. Defaults to HTTP so CI, E2E, and
+  // other devs are unaffected. Generate locally-trusted certs with:
   //   mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1
   // then run: VITE_HTTPS=true npm run dev:protoFleet  (or npm run dev for protoOS)
-  const useHttps = env.VITE_HTTPS === "true" || process.env.VITE_HTTPS === "true";
+  //
+  // Only honored for `vite serve` — `server.https` is irrelevant to `vite build`,
+  // and reading certs there would fail builds for no reason.
+  const useHttps = command === "serve" && (env.VITE_HTTPS === "true" || process.env.VITE_HTTPS === "true");
+  const readCert = (file: string) => {
+    const certPath = resolve(_dirname, "certs", file);
+    try {
+      return fs.readFileSync(certPath);
+    } catch {
+      throw new Error(
+        `VITE_HTTPS=true but ${certPath} is missing. Generate locally-trusted certs with:\n` +
+          `  cd client && mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1`,
+      );
+    }
+  };
   const httpsConfig = useHttps
     ? {
-        key: fs.readFileSync(resolve(_dirname, "certs/localhost-key.pem")),
-        cert: fs.readFileSync(resolve(_dirname, "certs/localhost.pem")),
+        key: readCert("localhost-key.pem"),
+        cert: readCert("localhost.pem"),
       }
     : undefined;
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -111,8 +111,8 @@ export default defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), "");
 
   // Opt-in HTTPS for the local dev server. Defaults to HTTP so CI, E2E, and
-  // other devs are unaffected. Generate locally-trusted certs with:
-  //   mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1
+  // other devs are unaffected. Generate locally-trusted certs once with:
+  //   npm run setup:https
   // then run: VITE_HTTPS=true npm run dev:protoFleet  (or npm run dev for protoOS)
   //
   // Only honored for `vite serve` — `server.https` is irrelevant to `vite build`,
@@ -124,8 +124,7 @@ export default defineConfig(({ mode, command }) => {
       return fs.readFileSync(certPath);
     } catch {
       throw new Error(
-        `VITE_HTTPS=true but ${certPath} is missing. Generate locally-trusted certs with:\n` +
-          `  cd client && mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1`,
+        `VITE_HTTPS=true but ${certPath} is missing. Generate locally-trusted certs with:\n  npm run setup:https`,
       );
     }
   };


### PR DESCRIPTION
Reviewable diff: +90/-1 across 4 files (excludes generated, test, and story files).

## Summary

Adds an **opt-in HTTPS mode** for the local Vite dev server so developers can run ProtoOS/ProtoFleet over `https://localhost` (or `https://<hostname>` when exposed via `vite --host`) when they need a secure context. HTTPS is gated behind `VITE_HTTPS=true`; the default remains plain HTTP, so CI, E2E, and everyone else are unaffected. A one-shot `npm run setup:https` generates the locally-trusted certs.

## How it works

Vite 8 removed the `--https` CLI flag, so enabling TLS now requires feeding cert files into `server.https`. This PR wires that up behind an env flag, plus a helper script to produce the certs:

1. `npm run setup:https` (→ `scripts/generate-dev-certs.mjs`) shells out to `mkcert` to write `client/certs/{localhost,localhost-key}.pem`. The cert's SANs cover loopback (`localhost` / `127.0.0.1` / `::1`) **plus this machine's hostname(s)** — including the macOS mDNS `.local` name — so TLS also validates when the server is reached by hostname over `--host`. LAN IPs are intentionally omitted (they rotate with DHCP and would silently invalidate the cert).
2. When `VITE_HTTPS=true` **and** the command is `vite serve`, `vite.config.ts` reads those cert files and populates `server.https`; otherwise `server.https` stays `undefined` (Vite's default HTTP). Gating on `serve` means `vite build` never touches certs.
3. If certs are missing, cert loading throws an explicit error pointing at `npm run setup:https` rather than a raw `ENOENT`.
4. The env var flows through the existing npm scripts unchanged (`dev:protoFleet`, and the `dev-protoOS.ts` spawn wrapper, which inherits `process.env`).
5. Vite terminates TLS locally and forwards to the existing HTTP proxy targets (`FLEET_PROXY_URL` / `PROXY_URL`) unchanged — those proxies already set `secure: false`.

Run it with:

```bash
cd client
npm run setup:https                      # one-time (re-run if your hostname changes)
VITE_HTTPS=true npm run dev:protoFleet    # or: VITE_HTTPS=true npm run dev  (protoOS)
```

## Diagram

```mermaid
flowchart LR
    S["npm run setup:https"] --> M["mkcert - certs cover loopback + hostname(s)"]
    M --> C1["client/certs/*.pem (git-ignored)"]
    A["npm run dev (VITE_HTTPS=true)"] --> B["vite.config.ts"]
    B --> C{"command === serve AND VITE_HTTPS === true?"}
    C -->|"no (build, or unset)"| D["server.https = undefined - HTTP"]
    C -->|"yes"| E["readCert() from client/certs"]
    E -->|"missing"| ERR["throw - run npm run setup:https"]
    E -->|"present"| F["server.https = key + cert - HTTPS"]
    C1 -.-> E
    F --> G["https://localhost or https://hostname"]
    G --> H["proxy to HTTP backend (secure:false)"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/scripts/generate-dev-certs.mjs` | New one-shot cert generator; SANs = loopback + hostname(s), no LAN IPs; errors if `mkcert` absent | Determines which hosts the cert is valid for; the `--host`-by-hostname support lives here |
| `client/package.json` | Adds `setup:https` script | Single entry point; deliberately **not** `prepare` (see trade-offs) |
| `client/vite.config.ts` | `VITE_HTTPS`- and `serve`-gated `server.https`; explicit missing-cert error | Only runtime behavioral change; verify the default (`undefined`) path preserves HTTP and that `build` never reads certs |
| `client/.gitignore` | Adds `certs` so private keys are never committed | Security: keeps per-dev cert/key material out of git |

## Key technical decisions & trade-offs

- **Opt-in via env var, not default.** So CI/E2E/other devs are untouched and no certs are required to run normally.
- **`serve`-only cert loading.** `vite.config.ts` also runs for `vite build`, where `server.https` is meaningless; gating on `command === "serve"` keeps builds from reading (and failing on) certs.
- **`setup:https` script, not a `prepare` hook.** `npm ci` runs `prepare` (verified), so wiring mkcert there would fire on every CI build and every install — including machines without mkcert and devs who don't want HTTPS. A dedicated script keeps it strictly opt-in.
- **Hostname in SANs, LAN IP excluded.** Hostnames are stable; DHCP-assigned IPs are not, so pinning an IP would silently break the cert. Reaching the box by hostname over `--host` works; re-run the script if a specific address must be pinned.
- **mkcert (locally-trusted) over `@vitejs/plugin-basic-ssl` (self-signed).** No browser warnings, proper secure-context support, no new npm dependency. Trade-off: each dev generates their own certs (and other devices need the mkcert root CA trusted).

## Testing & validation

- `npm run setup:https` produces a cert whose SANs are `localhost, <hostname>.local, <mDNS>.local, 127.0.0.1, ::1` (verified via `openssl x509 -ext subjectAltName`).
- `VITE_HTTPS=true vite serve` → `https://localhost` returns **200 with TLS verified against the local mkcert CA**; with `--host`, `https://<hostname>.local` also returns **200 verified** (previously failed with a SAN mismatch).
- `VITE_HTTPS=true vite build` completes cleanly with `certs/` removed — build never reads certs.
- `VITE_HTTPS=true vite serve` with missing certs throws the explicit `npm run setup:https` guidance.
- Default (no env var) still serves HTTP; `git check-ignore` confirms `client/certs/` is ignored.
- ESLint + Prettier clean; lefthook pre-commit (`client-format`) and pre-push (`client-typecheck`) passed.
- **Not covered:** no automated test for the HTTPS path (local-dev-only config); other devices reaching the `--host` server must trust the mkcert root CA, and Firefox needs `nss` + `mkcert -install`.
