### PR TITLE
feat(curtailment): show live active-curtailment status

### DIFF
--- a/client/src/protoFleet/api/activeCurtailmentData.test.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.test.ts
@@ -359,6 +359,57 @@ describe("activeCurtailmentData", () => {
     ]);
   });
 
+  it("keeps a fresh active-list rollup over stale current detail when active detail hydration fails", async () => {
+    const staleDetail = curtailmentEvent("active-a", CurtailmentEventState.ACTIVE, {
+      reason: "Current Detail A",
+      decisionSnapshot: {
+        estimated_reduction_kw: 5,
+        selected_count: 10,
+      },
+      targetRollup: create(CurtailmentTargetRollupSchema, { confirmed: 10, total: 10 }),
+      targets: [create(CurtailmentTargetSchema, { deviceIdentifier: "miner-1" })],
+    });
+    const refreshedSummary = curtailmentEvent("active-a", CurtailmentEventState.ACTIVE, {
+      reason: "Summary A",
+      targetRollup: create(CurtailmentTargetRollupSchema, { confirmed: 4000, pending: 1000, total: 5000 }),
+    });
+    applyActiveCurtailmentEvent(staleDetail, { mergeActiveEvents: true });
+    mockListActiveCurtailments.mockResolvedValueOnce({ events: [refreshedSummary] });
+    mockGetCurtailmentEvent.mockRejectedValueOnce(new Error("detail unavailable"));
+
+    await refreshActiveCurtailmentData();
+
+    const snapshot = getActiveCurtailmentSnapshot();
+    expect(snapshot.event?.targetRollup).toEqual(
+      create(CurtailmentTargetRollupSchema, { confirmed: 4000, pending: 1000, total: 5000 }),
+    );
+    // Detail-only fields the list row never provides are retained.
+    expect(snapshot.event?.decisionSnapshot).toEqual({
+      estimated_reduction_kw: 5,
+      selected_count: 10,
+    });
+    expect(snapshot.event?.targets.map((target) => target.deviceIdentifier)).toEqual(["miner-1"]);
+  });
+
+  it("retains the current detail rollup when a rollup-less active-list row arrives and hydration fails", async () => {
+    const staleDetail = curtailmentEvent("active-a", CurtailmentEventState.ACTIVE, {
+      reason: "Current Detail A",
+      targetRollup: create(CurtailmentTargetRollupSchema, { confirmed: 10, total: 10 }),
+    });
+    const rollupLessSummary = curtailmentEvent("active-a", CurtailmentEventState.ACTIVE, {
+      reason: "Summary A",
+    });
+    applyActiveCurtailmentEvent(staleDetail, { mergeActiveEvents: true });
+    mockListActiveCurtailments.mockResolvedValueOnce({ events: [rollupLessSummary] });
+    mockGetCurtailmentEvent.mockRejectedValueOnce(new Error("detail unavailable"));
+
+    await refreshActiveCurtailmentData();
+
+    expect(getActiveCurtailmentSnapshot().event?.targetRollup).toEqual(
+      create(CurtailmentTargetRollupSchema, { confirmed: 10, total: 10 }),
+    );
+  });
+
   it("does not select an unhydrated active summary when active detail hydration fails", async () => {
     const activeSummary = curtailmentEvent("active-a", CurtailmentEventState.ACTIVE, { reason: "Summary A" });
     const otherSummary = curtailmentEvent("active-b", CurtailmentEventState.ACTIVE, { reason: "Summary B" });
@@ -370,6 +421,31 @@ describe("activeCurtailmentData", () => {
     const snapshot = getActiveCurtailmentSnapshot();
     expect(snapshot.event).toBeUndefined();
     expect(snapshot.events.map((event) => event.reason)).toEqual(["Summary A", "Summary B"]);
+  });
+
+  it("does not auto-select a rollup-only active summary after dismissal", () => {
+    // Active-list rows now always carry a live rollup; a rollup alone is not
+    // hydrated detail, so dismissal must not promote a summary-only row into
+    // the active card (its kW estimate would render as a fabricated zero).
+    const detailedEvent = curtailmentEvent("active-detailed", CurtailmentEventState.ACTIVE, {
+      decisionSnapshot: {
+        estimated_reduction_kw: 5,
+        selected_count: 2,
+      },
+      targetRollup: create(CurtailmentTargetRollupSchema, { confirmed: 2, total: 2 }),
+    });
+    const summaryOnlyEvent = curtailmentEvent("active-summary", CurtailmentEventState.ACTIVE, {
+      targetRollup: create(CurtailmentTargetRollupSchema, { confirmed: 4000, pending: 1000, total: 5000 }),
+    });
+
+    applyActiveCurtailmentEvent(detailedEvent, { mergeActiveEvents: true });
+    applyActiveCurtailmentEvent(summaryOnlyEvent, { mergeActiveEvents: true });
+    applyActiveCurtailmentEvent(detailedEvent, { mergeActiveEvents: true });
+
+    const snapshot = dismissActiveCurtailmentEvent(detailedEvent.eventUuid);
+
+    expect(snapshot.event).toBeUndefined();
+    expect(snapshot.events.map((event) => event.eventUuid)).toEqual(["active-summary"]);
   });
 
   it("surfaces auth failures from selected active detail hydration", async () => {

--- a/client/src/protoFleet/api/activeCurtailmentData.ts
+++ b/client/src/protoFleet/api/activeCurtailmentData.ts
@@ -160,9 +160,12 @@ function hasSnapshotNumber(event: ProtoCurtailmentEvent, keys: readonly string[]
   return keys.some((key) => typeof event.decisionSnapshot?.[key] === "number");
 }
 
+// Live rollups now ride on every active-list row, so rollup presence no
+// longer distinguishes hydrated detail from a summary row; auto-selection
+// still requires snapshot numbers or target rows so the active card never
+// renders a fabricated 0.0 kW estimate from a summary-only event.
 function hasActiveCurtailmentDetail(event: ProtoCurtailmentEvent): boolean {
   return (
-    Boolean(event.targetRollup) ||
     event.targets.length > 0 ||
     hasSnapshotNumber(event, detailReductionSnapshotKeys) ||
     hasSnapshotNumber(event, detailSelectedCountSnapshotKeys)
@@ -407,10 +410,14 @@ function getSelectedActiveCurtailmentWithCurrentDetail(
     return undefined;
   }
 
+  // The active-list row is fresher than the current detail, so its live
+  // target rollup wins; current detail only backfills fields the list row
+  // never provides (decision snapshot, targets) or lacks (older servers'
+  // rollup-less list rows).
   return createMessage(CurtailmentEventSchema, {
     ...selectedEvent,
     decisionSnapshot: currentEvent.decisionSnapshot,
-    targetRollup: currentEvent.targetRollup,
+    targetRollup: selectedEvent.targetRollup ?? currentEvent.targetRollup,
     targets: currentEvent.targets,
   });
 }

--- a/client/src/protoFleet/api/curtailmentMappers.ts
+++ b/client/src/protoFleet/api/curtailmentMappers.ts
@@ -324,7 +324,12 @@ export function mapActiveCurtailmentEvent(
     targetKw: getFixedKwTarget(event),
     observedReductionKw: observedPowerSummary.observedReductionKw,
     remainingPowerKw: observedPowerSummary.remainingPowerKw,
-    restoreBatchSize: event.effectiveBatchSize || event.restoreBatchSize,
+    // Restore displays follow the configured restore_batch_size, which is
+    // what the reconciler's restore claims obey (0 = up to the safety limit
+    // per wave). effective_batch_size is a start-time stamp of the selected
+    // count; all-paired and closed-loop growth leaves it stale, so it must
+    // not masquerade as the restore wave size.
+    restoreBatchSize: event.restoreBatchSize,
     restoreBatchIntervalSec: event.restoreBatchIntervalSec,
     rollups: getCurtailmentTargetRollups(event),
   };

--- a/client/src/protoFleet/api/curtailmentMappers.ts
+++ b/client/src/protoFleet/api/curtailmentMappers.ts
@@ -276,9 +276,14 @@ export function hasCurtailmentTargetMetrics(event: ProtoCurtailmentEvent): boole
 
 // A live rollup proves target counts but not estimated kW: active-list rows
 // carry rollups while their decision snapshot stays scrubbed, so kW estimates
-// need a snapshot number or hydrated target baselines.
+// need a snapshot number or hydrated target baselines. Target rows alone are
+// not enough — baseline_power_w is optional (telemetry gaps at selection), so
+// baseline-less targets would sum to a fabricated 0.0 kW estimate.
 export function hasCurtailmentEstimatedReductionKw(event: ProtoCurtailmentEvent): boolean {
-  return hasSnapshotNumber(event, estimatedReductionKwSnapshotKeys) || event.targets.length > 0;
+  return (
+    hasSnapshotNumber(event, estimatedReductionKwSnapshotKeys) ||
+    event.targets.some((target) => target.baselinePowerW !== undefined)
+  );
 }
 
 function getObservedPowerSummary(event: ProtoCurtailmentEvent, estimatedReductionKw: number): ObservedPowerSummary {

--- a/client/src/protoFleet/api/curtailmentMappers.ts
+++ b/client/src/protoFleet/api/curtailmentMappers.ts
@@ -13,6 +13,7 @@ import type {
 import {
   getActiveCurtailmentDisplayState,
   getCurtailmentEventEstimatedReductionKw,
+  getCurtailmentEventLiveTargetCount,
   getCurtailmentEventObservedReductionKw,
   getCurtailmentEventScopeLabel,
   getCurtailmentEventSelectedMinerCount,
@@ -273,6 +274,13 @@ export function hasCurtailmentTargetMetrics(event: ProtoCurtailmentEvent): boole
   );
 }
 
+// A live rollup proves target counts but not estimated kW: active-list rows
+// carry rollups while their decision snapshot stays scrubbed, so kW estimates
+// need a snapshot number or hydrated target baselines.
+export function hasCurtailmentEstimatedReductionKw(event: ProtoCurtailmentEvent): boolean {
+  return hasSnapshotNumber(event, estimatedReductionKwSnapshotKeys) || event.targets.length > 0;
+}
+
 function getObservedPowerSummary(event: ProtoCurtailmentEvent, estimatedReductionKw: number): ObservedPowerSummary {
   let observedPowerTotalW = 0;
   let hasObservedPower = false;
@@ -306,7 +314,7 @@ export function mapActiveCurtailmentEvent(
     isAutomationOwned: isAutomationExternalSource(externalSource),
     targetSiteCoverage: mapTargetSiteCoverage(event),
     endedAt: timestampToIsoString(event.endedAt),
-    selectedMiners: getCurtailmentEventSelectedMinerCount(event),
+    selectedMiners: getCurtailmentEventLiveTargetCount(event),
     estimatedReductionKw,
     targetKw: getFixedKwTarget(event),
     observedReductionKw: observedPowerSummary.observedReductionKw,
@@ -332,6 +340,7 @@ export function mapCurtailmentHistoryEvent(
     selectedMiners: getCurtailmentEventSelectedMinerCount(event),
     estimatedReductionKw: getCurtailmentEventEstimatedReductionKw(event),
     targetMetricsAvailable: hasCurtailmentTargetMetrics(event),
+    estimatedReductionAvailable: hasCurtailmentEstimatedReductionKw(event),
     targetKw: getFixedKwTarget(event),
     sourceLabel: getSourceLabel(externalSource),
     startedAt: timestampToIsoString(event.startedAt),
@@ -351,9 +360,13 @@ export function mapActiveCurtailmentHistoryEvent(
     return historyEvent;
   }
 
+  // Injected active rows represent live events, so they share the active
+  // card's live target count instead of the snapshot count.
+  const activeEvent = mapActiveCurtailmentEvent(event, options);
   return {
     ...historyEvent,
-    displayState: getActiveCurtailmentDisplayState(mapActiveCurtailmentEvent(event, options), {
+    selectedMiners: activeEvent.selectedMiners,
+    displayState: getActiveCurtailmentDisplayState(activeEvent, {
       dispatchStartedAsCurtailing: true,
     }),
   };

--- a/client/src/protoFleet/api/generated/curtailment/v1/curtailment_pb.ts
+++ b/client/src/protoFleet/api/generated/curtailment/v1/curtailment_pb.ts
@@ -1369,6 +1369,10 @@ export const StopCurtailmentResponseSchema: GenMessage<StopCurtailmentResponse> 
  * omits per-device targets and the decision snapshot; use GetCurtailmentEvent
  * for full per-target detail and event-start snapshot context.
  *
+ * Whole-org events omit `target_rollup` when the caller's curtailment:read
+ * grant is narrowed at any site: the rollup aggregates target counts across
+ * every site, so it requires unnarrowed org-wide read.
+ *
  * @generated from message curtailment.v1.ListActiveCurtailmentsRequest
  */
 export type ListActiveCurtailmentsRequest = Message<"curtailment.v1.ListActiveCurtailmentsRequest"> & {};

--- a/client/src/protoFleet/api/generated/curtailment/v1/curtailment_pb.ts
+++ b/client/src/protoFleet/api/generated/curtailment/v1/curtailment_pb.ts
@@ -1363,9 +1363,11 @@ export const StopCurtailmentResponseSchema: GenMessage<StopCurtailmentResponse> 
 /**
  * ListActiveCurtailments returns every non-terminal event for the caller's
  * org. Multiple can be active when they target disjoint device scopes (e.g.
- * one per site). Each event carries its metadata, scope, and mode params but
+ * one per site). Each event carries its metadata, scope, mode params,
+ * target-site coverage, and a live `target_rollup` (per-state counts of the
+ * event's current target set, the operational truth for active displays) but
  * omits per-device targets and the decision snapshot; use GetCurtailmentEvent
- * for full per-target detail.
+ * for full per-target detail and event-start snapshot context.
  *
  * @generated from message curtailment.v1.ListActiveCurtailmentsRequest
  */

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -227,6 +227,201 @@ describe("useCurtailmentApi", () => {
     );
   });
 
+  it("prefers the live rollup total over the snapshot count for active events", async () => {
+    // Closed-loop claims / all-paired policy changes can grow the live target
+    // set far past the event-start snapshot; active surfaces show the live
+    // rollup as the operational truth.
+    const activeEvent = curtailmentEvent({
+      decisionSnapshot: {
+        estimated_reduction_kw: 6.2,
+        selected_count: 10,
+      },
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 4000,
+        pending: 1000,
+        total: 5000,
+      }),
+      targets: [],
+    });
+    mockListActiveCurtailments.mockResolvedValueOnce({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent?.selectedMiners).toBe(5000);
+    // The estimate-derived observed reduction scales by the live total
+    // (6.2 * 4000/5000), not the stale snapshot count (6.2 * 4000/10).
+    expect(result.current.activeEvent?.observedReductionKw).toBeCloseTo(4.96);
+    // The injected active history row is a live surface too.
+    expect(result.current.activeEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-1",
+        selectedMiners: 5000,
+        displayState: "curtailing",
+      }),
+    );
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-1",
+        selectedMiners: 5000,
+      }),
+    );
+  });
+
+  it("keeps live counts while marking summary-only active rows as missing a kW estimate", async () => {
+    // Non-selected active-list rows carry a live rollup but a scrubbed
+    // decision snapshot and no targets; the injected history row must not
+    // fabricate a 0.0 kW estimate from that shape.
+    const selectedEvent = curtailmentEvent();
+    const summaryOnlyEvent = curtailmentEvent({
+      eventUuid: "curt-summary-only",
+      decisionSnapshot: undefined,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 4000,
+        pending: 1000,
+        total: 5000,
+      }),
+      targets: [],
+    });
+    mockListActiveCurtailments.mockResolvedValueOnce({ events: [selectedEvent, summaryOnlyEvent] });
+    mockGetCurtailmentEvent.mockResolvedValueOnce({ event: selectedEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvents[1]).toEqual(
+      expect.objectContaining({
+        id: "curt-summary-only",
+        selectedMiners: 5000,
+        targetMetricsAvailable: true,
+        estimatedReductionAvailable: false,
+        estimatedReductionKw: 0,
+      }),
+    );
+  });
+
+  it("backfills the kW estimate for summary-only active rows from matching history", async () => {
+    const selectedEvent = curtailmentEvent();
+    const summaryOnlyEvent = curtailmentEvent({
+      eventUuid: "curt-summary-backfill",
+      decisionSnapshot: undefined,
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 4000,
+        pending: 1000,
+        total: 5000,
+      }),
+      targets: [],
+    });
+    const historyEvent = curtailmentEvent({
+      eventUuid: "curt-summary-backfill",
+      decisionSnapshot: {
+        estimated_reduction_kw: 8.4,
+        selected_count: 10,
+      },
+      targetRollup: undefined,
+      targets: [],
+    });
+    mockListActiveCurtailments.mockResolvedValueOnce({ events: [selectedEvent, summaryOnlyEvent] });
+    mockGetCurtailmentEvent.mockResolvedValueOnce({ event: selectedEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [historyEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvents[1]).toEqual(
+      expect.objectContaining({
+        id: "curt-summary-backfill",
+        selectedMiners: 5000,
+        estimatedReductionKw: 8.4,
+        estimatedReductionAvailable: true,
+      }),
+    );
+  });
+
+  it("keeps the snapshot count as audit context for completed history events", async () => {
+    const completedEvent = curtailmentEvent({
+      eventUuid: "curt-history-audit",
+      state: CurtailmentEventState.COMPLETED,
+      endedAt: timestamp("2026-05-01T13:00:00Z"),
+      decisionSnapshot: {
+        estimated_reduction_kw: 6.2,
+        selected_count: 10,
+      },
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        resolved: 5000,
+        total: 5000,
+      }),
+      targets: [],
+    });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [completedEvent], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-history-audit",
+        selectedMiners: 10,
+      }),
+    );
+  });
+
+  it("updates active target counts from active polling", async () => {
+    const initialEvent = curtailmentEvent({
+      decisionSnapshot: {
+        estimated_reduction_kw: 6.2,
+        selected_count: 10,
+      },
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        pending: 10,
+        total: 10,
+      }),
+      targets: [],
+    });
+    const grownEvent = curtailmentEvent({
+      decisionSnapshot: {
+        estimated_reduction_kw: 6.2,
+        selected_count: 10,
+      },
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 4000,
+        pending: 1000,
+        total: 5000,
+      }),
+      targets: [],
+    });
+    mockListActiveCurtailments.mockResolvedValueOnce({ event: initialEvent });
+    mockListCurtailmentEvents.mockResolvedValue({ events: [], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+    expect(result.current.activeEvent?.selectedMiners).toBe(10);
+
+    mockListActiveCurtailments.mockResolvedValueOnce({ event: grownEvent });
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent?.selectedMiners).toBe(5000);
+  });
+
   it("maps MQTT automation ownership onto active and history events", async () => {
     const activeEvent = curtailmentEvent({
       externalSource: "curtailment_automation",
@@ -812,6 +1007,39 @@ describe("useCurtailmentApi", () => {
       expect.objectContaining({
         reason: "Pending active event",
         state: "pending",
+      }),
+    );
+  });
+
+  it("uses live rollup totals for injected active rows in filtered history", async () => {
+    const activeEvent = curtailmentEvent({
+      eventUuid: "curt-live-injected",
+      state: CurtailmentEventState.ACTIVE,
+      decisionSnapshot: {
+        estimated_reduction_kw: 6.2,
+        selected_count: 10,
+      },
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 4990,
+        dispatched: 10,
+        total: 5000,
+      }),
+      targets: [],
+    });
+    mockListActiveCurtailments.mockResolvedValue({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValue({ events: [], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.setHistoryStatusFilters(["active"]);
+    });
+
+    expect(result.current.historyEvents[0]).toEqual(
+      expect.objectContaining({
+        id: "curt-live-injected",
+        state: "active",
+        selectedMiners: 5000,
       }),
     );
   });

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -21,6 +21,7 @@ import {
   CurtailmentTargetSchema,
   CurtailmentTargetState,
   FixedKwParamsSchema,
+  FullFleetParamsSchema,
   ScopeDeviceListSchema,
   ScopeSiteSchema,
   ScopeWholeOrgSchema,
@@ -686,7 +687,10 @@ describe("useCurtailmentApi", () => {
     expect(result.current.activeEvent?.observedReductionKw).toBeCloseTo(2.07);
   });
 
-  it("shows the effective restore batch size while preserving the configured form value", async () => {
+  it("shows the configured restore batch size, not the stale start-time stamp", async () => {
+    // effective_batch_size snapshots the selected count at Start; all-paired
+    // and closed-loop growth leaves it stale, and the reconciler's restore
+    // claims follow restore_batch_size anyway.
     const activeEvent = curtailmentEvent({
       effectiveBatchSize: 10,
       restoreBatchSize: 1,
@@ -700,8 +704,44 @@ describe("useCurtailmentApi", () => {
       await result.current.refreshCurtailment();
     });
 
-    expect(result.current.activeEvent?.restoreBatchSize).toBe(10);
+    expect(result.current.activeEvent?.restoreBatchSize).toBe(1);
     expect(result.current.activeEventFormValues?.restoreBatchSize).toBe("1");
+  });
+
+  it("keeps safety-limit restore semantics when the target set outgrows the start stamp", async () => {
+    // Full-shutdown all-paired repro: restore_batch_size=0 stamps
+    // effective_batch_size with the paired count at Start (3). Miners paired
+    // after the start grow the live target set (50); the restore display must
+    // keep the configured "up to safety limit" semantics instead of showing
+    // the stale 3-miner stamp as the restore wave size.
+    const activeEvent = curtailmentEvent({
+      mode: CurtailmentMode.FULL_FLEET,
+      forceIncludeAllPairedMiners: true,
+      modeParams: { case: "fullFleet", value: create(FullFleetParamsSchema, {}) },
+      restoreBatchSize: 0,
+      effectiveBatchSize: 3,
+      decisionSnapshot: {
+        selected_count: 3,
+      },
+      targetRollup: create(CurtailmentTargetRollupSchema, {
+        confirmed: 45,
+        pending: 5,
+        total: 50,
+      }),
+      targets: [],
+    });
+    mockListActiveCurtailments.mockResolvedValueOnce({ event: activeEvent });
+    mockListCurtailmentEvents.mockResolvedValueOnce({ events: [], nextPageToken: "" });
+
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.refreshCurtailment();
+    });
+
+    expect(result.current.activeEvent?.selectedMiners).toBe(50);
+    expect(result.current.activeEvent?.restoreBatchSize).toBe(0);
+    expect(result.current.activeEventFormValues?.restoreBatchSize).toBe("");
   });
 
   it("maps configured curtail batch controls into active event form values", async () => {

--- a/client/src/protoFleet/api/useCurtailmentApi.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.ts
@@ -300,6 +300,23 @@ function getActiveHistoryEvent(
       estimatedReductionKw: matchingHistoryEvent.estimatedReductionKw,
       targetKw: matchingHistoryEvent.targetKw,
       targetMetricsAvailable: true,
+      estimatedReductionAvailable: matchingHistoryEvent.estimatedReductionAvailable,
+      sourceLabel: matchingHistoryEvent.sourceLabel,
+    };
+  }
+
+  // Summary-only active rows prove live counts but not a kW estimate; keep
+  // the live count and backfill the estimate from the server history row's
+  // audit snapshot when it has one.
+  if (
+    mappedActiveEvent.estimatedReductionAvailable === false &&
+    matchingHistoryEvent.targetMetricsAvailable &&
+    matchingHistoryEvent.estimatedReductionAvailable !== false
+  ) {
+    return {
+      ...mappedActiveEvent,
+      estimatedReductionKw: matchingHistoryEvent.estimatedReductionKw,
+      estimatedReductionAvailable: true,
       sourceLabel: matchingHistoryEvent.sourceLabel,
     };
   }

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.test.tsx
@@ -100,6 +100,23 @@ describe("CurtailmentPill", () => {
     expect(screen.queryByText(getPlannedReductionText(0, 0))).not.toBeInTheDocument();
   });
 
+  it("shows the live miner count without a fabricated estimate when only counts are available", () => {
+    renderCurtailmentPill({
+      event: {
+        ...activeCurtailmentEvent,
+        selectedMiners: 5000,
+        estimatedReductionKw: 0,
+        targetMetricsAvailable: true,
+        estimatedReductionAvailable: false,
+      },
+    });
+
+    openCurtailmentPopover();
+
+    expect(screen.getByText("5,000 selected miners")).toBeInTheDocument();
+    expect(screen.queryByText(getPlannedReductionText(5000, 0))).not.toBeInTheDocument();
+  });
+
   it("does not render the details link without a details path", () => {
     renderCurtailmentPill();
 

--- a/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/CurtailmentPill.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { Link } from "react-router-dom";
 
-import type { CurtailmentPillProps, CurtailmentPillState } from "./curtailmentPillTypes";
+import type { CurtailmentPillEvent, CurtailmentPillProps, CurtailmentPillState } from "./curtailmentPillTypes";
 import PageHeaderPopoverPill from "./PageHeaderPopoverPill";
 import {
   activeCurtailmentDisplayStateConfigs,
@@ -26,14 +26,25 @@ function getLegacyCurtailmentPillHeaderState(state: CurtailmentPillState): Curta
   }
 }
 
+function getPlannedReductionDetail(event: CurtailmentPillEvent): string {
+  if (!event.targetMetricsAvailable) {
+    return unavailableTargetMetricsLabel;
+  }
+
+  const minerCountLabel = formatCurtailmentSelectedMinerCount(event.selectedMiners);
+  // Summary-only rows carry a live count but no kW estimate; showing
+  // "0.0 kW planned" would fabricate a zero estimate.
+  if (event.estimatedReductionAvailable === false) {
+    return minerCountLabel;
+  }
+
+  return `${minerCountLabel} - ${formatCurtailmentKw(event.estimatedReductionKw)} planned`;
+}
+
 function CurtailmentPill({ event, detailsPath }: CurtailmentPillProps): ReactElement {
   const stateConfig = activeCurtailmentDisplayStateConfigs[event.state];
   const headerStateConfig = curtailmentEventStateConfigs[getLegacyCurtailmentPillHeaderState(event.state)];
-  const plannedReductionDetail = event.targetMetricsAvailable
-    ? `${formatCurtailmentSelectedMinerCount(event.selectedMiners)} - ${formatCurtailmentKw(
-        event.estimatedReductionKw,
-      )} planned`
-    : unavailableTargetMetricsLabel;
+  const plannedReductionDetail = getPlannedReductionDetail(event);
   const detailRows = [
     { id: "state", value: stateConfig.label },
     { id: "scope", value: event.scopeLabel },

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
@@ -6,6 +6,8 @@ import {
   CurtailmentEventSchema,
   CurtailmentEventState,
   CurtailmentTargetRollupSchema,
+  CurtailmentTargetSchema,
+  CurtailmentTargetState,
   FixedKwParamsSchema,
   ScopeWholeOrgSchema,
 } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
@@ -48,6 +50,108 @@ describe("mapCurtailmentPillEvent", () => {
       expect.objectContaining({
         state,
         targetMetricsAvailable: true,
+      }),
+    );
+  });
+
+  it("prefers the live rollup total over the snapshot count", () => {
+    expect(
+      mapCurtailmentPillEvent(
+        curtailmentEvent({
+          state: CurtailmentEventState.ACTIVE,
+          decisionSnapshot: {
+            estimated_reduction_kw: 23.4,
+            selected_count: 10,
+          },
+          targetRollup: targetRollup({ confirmed: 4000, pending: 1000, total: 5000 }),
+        }),
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        selectedMiners: 5000,
+        estimatedReductionAvailable: true,
+      }),
+    );
+  });
+
+  it("treats a zeroed live rollup as zero targets even when a snapshot count exists", () => {
+    expect(
+      mapCurtailmentPillEvent(
+        curtailmentEvent({
+          state: CurtailmentEventState.ACTIVE,
+          decisionSnapshot: {
+            estimated_reduction_kw: 23.4,
+            selected_count: 10,
+          },
+          targetRollup: create(CurtailmentTargetRollupSchema, {}),
+        }),
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        selectedMiners: 0,
+        targetMetricsAvailable: true,
+      }),
+    );
+  });
+
+  it("falls back to hydrated targets, then the snapshot count, when no rollup exists", () => {
+    expect(
+      mapCurtailmentPillEvent(
+        curtailmentEvent({
+          state: CurtailmentEventState.ACTIVE,
+          decisionSnapshot: {
+            estimated_reduction_kw: 23.4,
+            selected_count: 10,
+          },
+          targetRollup: undefined,
+          targets: [
+            create(CurtailmentTargetSchema, { deviceIdentifier: "miner-1", state: CurtailmentTargetState.CONFIRMED }),
+            create(CurtailmentTargetSchema, { deviceIdentifier: "miner-2", state: CurtailmentTargetState.CONFIRMED }),
+            create(CurtailmentTargetSchema, { deviceIdentifier: "miner-3", state: CurtailmentTargetState.PENDING }),
+          ],
+        }),
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        selectedMiners: 3,
+      }),
+    );
+
+    expect(
+      mapCurtailmentPillEvent(
+        curtailmentEvent({
+          state: CurtailmentEventState.ACTIVE,
+          decisionSnapshot: {
+            estimated_reduction_kw: 23.4,
+            selected_count: 10,
+          },
+          targetRollup: undefined,
+          targets: [],
+        }),
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        selectedMiners: 10,
+      }),
+    );
+  });
+
+  it("marks rollup-only summary rows as counts-only so no zero estimate renders", () => {
+    expect(
+      mapCurtailmentPillEvent(
+        curtailmentEvent({
+          state: CurtailmentEventState.ACTIVE,
+          decisionSnapshot: {},
+          targetRollup: targetRollup({ confirmed: 4000, pending: 1000, total: 5000 }),
+          targets: [],
+        }),
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        selectedMiners: 5000,
+        targetMetricsAvailable: true,
+        estimatedReductionAvailable: false,
+        estimatedReductionKw: 0,
       }),
     );
   });

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.test.ts
@@ -136,6 +136,54 @@ describe("mapCurtailmentPillEvent", () => {
     );
   });
 
+  it("does not treat baseline-less targets as proof of a kW estimate", () => {
+    // baseline_power_w is optional (telemetry gap at selection); without a
+    // snapshot estimate, baseline-less targets would sum to a fabricated
+    // 0.0 kW, so the estimate must report unavailable.
+    const baselessTargets = [
+      create(CurtailmentTargetSchema, { deviceIdentifier: "miner-1", state: CurtailmentTargetState.CONFIRMED }),
+      create(CurtailmentTargetSchema, { deviceIdentifier: "miner-2", state: CurtailmentTargetState.PENDING }),
+    ];
+    expect(
+      mapCurtailmentPillEvent(
+        curtailmentEvent({
+          state: CurtailmentEventState.ACTIVE,
+          decisionSnapshot: {},
+          targetRollup: undefined,
+          targets: baselessTargets,
+        }),
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        selectedMiners: 2,
+        estimatedReductionAvailable: false,
+      }),
+    );
+
+    expect(
+      mapCurtailmentPillEvent(
+        curtailmentEvent({
+          state: CurtailmentEventState.ACTIVE,
+          decisionSnapshot: {},
+          targetRollup: undefined,
+          targets: [
+            ...baselessTargets,
+            create(CurtailmentTargetSchema, {
+              deviceIdentifier: "miner-3",
+              state: CurtailmentTargetState.CONFIRMED,
+              baselinePowerW: 3000,
+            }),
+          ],
+        }),
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        selectedMiners: 3,
+        estimatedReductionAvailable: true,
+      }),
+    );
+  });
+
   it("marks rollup-only summary rows as counts-only so no zero estimate renders", () => {
     expect(
       mapCurtailmentPillEvent(

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillMapper.ts
@@ -1,12 +1,16 @@
 import { type CurtailmentPillEvent, isCurtailmentPillState } from "./curtailmentPillTypes";
-import { getFixedKwTarget, hasCurtailmentTargetMetrics } from "@/protoFleet/api/curtailmentMappers";
+import {
+  getFixedKwTarget,
+  hasCurtailmentEstimatedReductionKw,
+  hasCurtailmentTargetMetrics,
+} from "@/protoFleet/api/curtailmentMappers";
 import type { CurtailmentEvent as ProtoCurtailmentEvent } from "@/protoFleet/api/generated/curtailment/v1/curtailment_pb";
 import {
   getActiveCurtailmentDisplayState,
   getCurtailmentEventEstimatedReductionKw,
+  getCurtailmentEventLiveTargetCount,
   getCurtailmentEventObservedReductionKw,
   getCurtailmentEventScopeLabel,
-  getCurtailmentEventSelectedMinerCount,
   getCurtailmentTargetRollups,
   isActiveCurtailmentEventState,
   mapCurtailmentEventState,
@@ -22,7 +26,8 @@ export function mapCurtailmentPillEvent(event?: ProtoCurtailmentEvent): Curtailm
     return null;
   }
 
-  const selectedMiners = getCurtailmentEventSelectedMinerCount(event);
+  // The pill only renders for active states, so it shows the live target set.
+  const selectedMiners = getCurtailmentEventLiveTargetCount(event);
   const estimatedReductionKw = getCurtailmentEventEstimatedReductionKw(event);
   const displayState = getActiveCurtailmentDisplayState(
     {
@@ -47,5 +52,6 @@ export function mapCurtailmentPillEvent(event?: ProtoCurtailmentEvent): Curtailm
     selectedMiners,
     estimatedReductionKw,
     targetMetricsAvailable: hasCurtailmentTargetMetrics(event),
+    estimatedReductionAvailable: hasCurtailmentEstimatedReductionKw(event),
   };
 }

--- a/client/src/protoFleet/components/PageHeader/curtailmentPillTypes.ts
+++ b/client/src/protoFleet/components/PageHeader/curtailmentPillTypes.ts
@@ -22,6 +22,9 @@ export interface CurtailmentPillEvent {
   selectedMiners: number;
   estimatedReductionKw: number;
   targetMetricsAvailable: boolean;
+  // Live rollups prove counts without proving a kW estimate; summary-only
+  // rows show the miner count alone instead of a fabricated 0.0 kW.
+  estimatedReductionAvailable?: boolean;
 }
 
 export interface CurtailmentPillProps {

--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -29,6 +29,8 @@ export interface ActiveCurtailmentEvent {
   targetKw?: number;
   observedReductionKw: number;
   remainingPowerKw?: number;
+  // Configured restore wave size; 0 means "up to the safety limit" per wave,
+  // matching the reconciler's restore claim sizing.
   restoreBatchSize: number;
   restoreBatchIntervalSec: number;
   rollups: CurtailmentTargetRollup[];

--- a/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentHistory.tsx
@@ -32,6 +32,10 @@ export interface CurtailmentHistoryEvent {
   selectedMiners: number;
   estimatedReductionKw: number;
   targetMetricsAvailable: boolean;
+  // Distinct from targetMetricsAvailable: live rollups prove counts without
+  // proving a kW estimate (active-list rows scrub the decision snapshot).
+  // Optional so fixture-driven surfaces default to the count signal.
+  estimatedReductionAvailable?: boolean;
   targetKw?: number;
   sourceLabel: string;
   startedAt?: string;
@@ -176,7 +180,17 @@ function formatHistoryMinerCount(event: CurtailmentHistoryEvent): string {
 }
 
 function formatHistoryTargetVsActual(event: CurtailmentHistoryEvent): string {
-  return event.targetMetricsAvailable ? formatTargetVsActual(event) : unavailableTargetMetricsLabel;
+  if (!event.targetMetricsAvailable) {
+    return unavailableTargetMetricsLabel;
+  }
+
+  // Summary-only active rows carry live counts but no kW estimate; showing
+  // "target / 0.0 kW" would fabricate a zero estimate.
+  if (event.estimatedReductionAvailable === false) {
+    return unavailableTargetMetricsLabel;
+  }
+
+  return formatTargetVsActual(event);
 }
 
 function getDateTime(value?: string): Date | undefined {

--- a/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
+++ b/client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts
@@ -260,9 +260,27 @@ export function getCurtailmentTargetRollups(event: ProtoCurtailmentEvent): Curta
   return rollups.filter((targetRollup) => targetRollup.count > 0);
 }
 
+// Audit-context count: prefers the event-start decision snapshot, so
+// history rows keep describing the original selection. Active surfaces
+// should use getCurtailmentEventLiveTargetCount instead.
 export function getCurtailmentEventSelectedMinerCount(event: ProtoCurtailmentEvent): number {
   const snapshotSelectedCount = getSnapshotNumber(event, selectedCountSnapshotKeys);
   return snapshotSelectedCount ?? event.targetRollup?.total ?? event.targets.length;
+}
+
+// Live operational count for active surfaces: the target rollup describes the
+// event's current target set, which closed-loop claims and all-paired policy
+// changes can grow far past the event-start snapshot count. When no rollup is
+// available the legacy fallbacks apply: hydrated target rows, then the
+// event-start snapshot count.
+export function getCurtailmentEventLiveTargetCount(event: ProtoCurtailmentEvent): number {
+  if (event.targetRollup) {
+    return event.targetRollup.total;
+  }
+  if (event.targets.length > 0) {
+    return event.targets.length;
+  }
+  return getSnapshotNumber(event, selectedCountSnapshotKeys) ?? 0;
 }
 
 export function getCurtailmentEventEstimatedReductionKw(event: ProtoCurtailmentEvent): number {
@@ -284,7 +302,10 @@ function getConfirmedTargetCount(event: ProtoCurtailmentEvent): number {
 }
 
 function getEstimatedObservedReductionKw(event: ProtoCurtailmentEvent, estimatedReductionKw: number): number {
-  const selectedCount = getCurtailmentEventSelectedMinerCount(event);
+  // The confirmed numerator is rollup-derived, so pair it with the live
+  // rollup total; a stale snapshot denominator would push progress past 100%
+  // once the live target set outgrows the event-start selection.
+  const selectedCount = getCurtailmentEventLiveTargetCount(event);
   if (selectedCount <= 0) {
     return 0;
   }

--- a/docs/plans/2026-07-03-live-active-curtailment-status-plan.md
+++ b/docs/plans/2026-07-03-live-active-curtailment-status-plan.md
@@ -1,0 +1,151 @@
+---
+title: "Live active-curtailment status"
+date: 2026-07-03
+status: implementing
+type: plan
+---
+
+# Live active-curtailment status
+
+## Summary
+
+Active curtailment status should describe the event as it exists now, not only
+the event-start decision snapshot. Operators should be able to glance at the
+Energy active-curtailment card, header/status surfaces, and injected active
+history rows and see the current targeted miner count and phase breakdown:
+pending, dispatched, confirmed, drifted, unavailable, released, resolved, and
+restore failed.
+
+This is especially important after all-paired durable targeting. An event can
+start with a small or stale `selected_count` snapshot and later own a much
+larger set of targets as closed-loop admission, unavailable targets, or
+all-paired policy rows change. The UI should present the live `target_rollup`
+as the operational truth while keeping the decision snapshot as audit context.
+
+No new schema or new user-facing workflow is expected. The existing active
+curtailment UI should become more accurate using the `target_rollup` field that
+already exists on `CurtailmentEvent`.
+
+## Target UI/UX Shape
+
+- The active curtailment card's "Applies to" count should use the current live
+  target total when `target_rollup` is available.
+- Active progress and restore calculations should continue to use phase counts,
+  including `unavailable` targets introduced by all-paired curtailment.
+- Multiple active events should each show live counts without requiring the user
+  to select or hydrate every event detail row.
+- Active events injected into the history list should use live target metrics
+  when available, so filtered active/history views do not show stale selected
+  counts.
+- Completed/history rows should still be allowed to show event-start snapshot
+  context where that is the intended audit view.
+- `ListActiveCurtailments` should remain lightweight: no per-target rows and no
+  full decision snapshot payload.
+- If live rollup data is missing, the UI should keep today's fallback behavior
+  rather than blanking active status.
+
+The main acceptance case from the incident log is:
+
+> An active event with `decision_snapshot.selected_count = 10` and
+> `target_rollup.total = 5000` displays 5,000 as the live targeted count.
+
+## Current Readiness
+
+- PR #631 has landed, so all-paired curtailment target states and rollup fields
+  are on `main`.
+- `CurtailmentEvent` already has `target_rollup`, and
+  `CurtailmentTargetRollup` already includes `unavailable`.
+- Event detail, start, stop, force-release, and all-paired count-only responses
+  already know how to populate rollups.
+- The existing frontend mappers already convert `target_rollup` into display
+  phase counts.
+
+The remaining gap is active-list wiring. Today, `ListActiveCurtailments` returns
+metadata-only events. It does not include `target_rollup`, and the active UI
+still has paths that prefer `decision_snapshot.selected_count` over live totals.
+
+## Implementation Approach
+
+The implementation can be approached in a few equivalent ways. The important
+contract is that active summaries carry live rollup counts without expanding
+per-target payloads.
+
+One low-risk backend shape is:
+
+- Extend the active-event list query to aggregate target counts alongside the
+  current event metadata.
+- Keep the current "no decision snapshot" behavior for active polling.
+- Map aggregate columns into `models.Event.TargetRollup` when converting active
+  event rows.
+- Populate `target_rollup` in `toListActiveCurtailmentsResponse`.
+- Update comments in `proto/curtailment/v1/curtailment.proto` and server
+  translator comments so the active-list shape is documented as metadata,
+  scope, mode params, target-site coverage, and live target rollup.
+
+An alternate backend shape is to have the service attach rollups after
+`ListActiveEvents`. That is simpler mechanically but risks an N+1 query pattern
+on a route that polls frequently. If that approach is chosen, it should batch
+rollups or otherwise keep active polling cheap.
+
+On the client side, the key behavior is to separate active/live display from
+historical/audit display:
+
+- Active-event mapping should prefer `targetRollup.total` over snapshot
+  `selected_count` when calculating `selectedMiners`.
+- Historical mapping can continue to use snapshot values first where that is
+  the desired audit context.
+- Active-history injection should use the same live-count behavior as the
+  active card, because those rows represent active events.
+- The active refresh fallback path should not let stale selected-event detail
+  overwrite a fresher `targetRollup` from `ListActiveCurtailments`. If detail
+  hydration fails, prefer the active-list row's rollup and state while retaining
+  current detail-only fields only when the list row does not provide them.
+- Existing fallback behavior should remain for old responses or partial data:
+  if no `targetRollup` exists, derive counts from targets when present, then
+  fall back to snapshot/empty values as today.
+
+The UI can stay visually close to the current design. The goal is accuracy, not
+new decoration. The active card should continue using the existing stats and
+progress presentation; the displayed numbers should simply come from live
+rollups when those are available.
+
+## Test Plan
+
+Backend tests:
+
+- `ListActiveCurtailments` returns `target_rollup` for each active event.
+- Active-list responses still omit per-target rows.
+- Active-list responses still omit decision snapshots and scrub replay metadata.
+- Rollups include all active target states, including `unavailable`.
+- Events with no target rows return a zeroed rollup rather than failing.
+- If the rollup is implemented in SQL, add or extend a DB-backed store test to
+  verify aggregate counts across pending, dispatching/dispatched, confirmed,
+  drifted, unavailable, resolved, released, and restore-failed rows.
+
+Client tests:
+
+- An active event with snapshot selected count `10` and live rollup total
+  `5000` maps/displays as 5,000 targeted miners.
+- A completed/history event can still use snapshot selected count as audit
+  context.
+- Active polling updates target counts from `ListActiveCurtailments`.
+- If selected-event detail hydration fails, a fresh active-list rollup is kept
+  instead of overwritten by stale current detail.
+- Injected active rows in filtered history use live rollup totals and phase
+  counts.
+- Existing restore progress tests continue to pass with rollup-based totals.
+
+Suggested targeted validation after implementation:
+
+```sh
+go test ./server/internal/handlers/curtailment ./server/internal/domain/stores/sqlstores
+npm test -- activeCurtailmentData.test.ts useCurtailmentApi.test.ts ActiveCurtailmentStatus.test.tsx
+```
+
+## Notes And Boundaries
+
+- This does not change target ownership semantics.
+- This does not change all-paired selection or reconciliation behavior.
+- This does not require returning target rows from active polling.
+- This does not need to expose decision snapshots from `ListActiveCurtailments`.
+- Structured command-preflight diagnostics remain a separate incident follow-up.

--- a/proto/curtailment/v1/curtailment.proto
+++ b/proto/curtailment/v1/curtailment.proto
@@ -716,9 +716,11 @@ message StopCurtailmentResponse {
 
 // ListActiveCurtailments returns every non-terminal event for the caller's
 // org. Multiple can be active when they target disjoint device scopes (e.g.
-// one per site). Each event carries its metadata, scope, and mode params but
+// one per site). Each event carries its metadata, scope, mode params,
+// target-site coverage, and a live `target_rollup` (per-state counts of the
+// event's current target set, the operational truth for active displays) but
 // omits per-device targets and the decision snapshot; use GetCurtailmentEvent
-// for full per-target detail.
+// for full per-target detail and event-start snapshot context.
 message ListActiveCurtailmentsRequest {}
 
 message ListActiveCurtailmentsResponse {

--- a/proto/curtailment/v1/curtailment.proto
+++ b/proto/curtailment/v1/curtailment.proto
@@ -721,6 +721,10 @@ message StopCurtailmentResponse {
 // event's current target set, the operational truth for active displays) but
 // omits per-device targets and the decision snapshot; use GetCurtailmentEvent
 // for full per-target detail and event-start snapshot context.
+//
+// Whole-org events omit `target_rollup` when the caller's curtailment:read
+// grant is narrowed at any site: the rollup aggregates target counts across
+// every site, so it requires unnarrowed org-wide read.
 message ListActiveCurtailmentsRequest {}
 
 message ListActiveCurtailmentsResponse {

--- a/server/generated/grpc/curtailment/v1/curtailment.pb.go
+++ b/server/generated/grpc/curtailment/v1/curtailment.pb.go
@@ -3142,6 +3142,10 @@ func (x *StopCurtailmentResponse) GetEvent() *CurtailmentEvent {
 // event's current target set, the operational truth for active displays) but
 // omits per-device targets and the decision snapshot; use GetCurtailmentEvent
 // for full per-target detail and event-start snapshot context.
+//
+// Whole-org events omit `target_rollup` when the caller's curtailment:read
+// grant is narrowed at any site: the rollup aggregates target counts across
+// every site, so it requires unnarrowed org-wide read.
 type ListActiveCurtailmentsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields

--- a/server/generated/grpc/curtailment/v1/curtailment.pb.go
+++ b/server/generated/grpc/curtailment/v1/curtailment.pb.go
@@ -3137,9 +3137,11 @@ func (x *StopCurtailmentResponse) GetEvent() *CurtailmentEvent {
 
 // ListActiveCurtailments returns every non-terminal event for the caller's
 // org. Multiple can be active when they target disjoint device scopes (e.g.
-// one per site). Each event carries its metadata, scope, and mode params but
+// one per site). Each event carries its metadata, scope, mode params,
+// target-site coverage, and a live `target_rollup` (per-state counts of the
+// event's current target set, the operational truth for active displays) but
 // omits per-device targets and the decision snapshot; use GetCurtailmentEvent
-// for full per-target detail.
+// for full per-target detail and event-start snapshot context.
 type ListActiveCurtailmentsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -1193,15 +1193,15 @@ func (q *Queries) GetCurtailmentReconcilerHeartbeat(ctx context.Context) (Curtai
 
 const getCurtailmentTargetRollupByEvent = `-- name: GetCurtailmentTargetRollupByEvent :one
 SELECT
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'pending')::BIGINT AS pending,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state IN ('dispatching', 'dispatched'))::BIGINT AS dispatched,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'confirmed')::BIGINT AS confirmed,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'drifted')::BIGINT AS drifted,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'resolved')::BIGINT AS resolved,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'released')::BIGINT AS released,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'restore_failed')::BIGINT AS restore_failed,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'unavailable')::BIGINT AS unavailable,
-    COUNT(ct.device_identifier)::BIGINT AS total
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'pending')::BIGINT AS pending,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state IN ('dispatching', 'dispatched'))::BIGINT AS dispatched,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'confirmed')::BIGINT AS confirmed,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'drifted')::BIGINT AS drifted,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'resolved')::BIGINT AS resolved,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'released')::BIGINT AS released,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'restore_failed')::BIGINT AS restore_failed,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'unavailable')::BIGINT AS unavailable,
+    COUNT(ct.curtailment_event_id)::BIGINT AS total
 FROM curtailment_event ce
 LEFT JOIN curtailment_target ct ON ct.curtailment_event_id = ce.id
 WHERE ce.org_id = $1
@@ -1228,6 +1228,12 @@ type GetCurtailmentTargetRollupByEventRow struct {
 
 // Org-scoped aggregate for paginated event detail. Target pages can be
 // partial, but the rollup must describe the whole event.
+//
+// Counts ct.curtailment_event_id (NULL exactly on the LEFT JOIN's no-target
+// row, like any ct column) so the aggregate only touches index columns of
+// idx_curtailment_target_event_state and stays index-only-scannable. State
+// buckets mirror the ListActiveCurtailmentEvents lateral rollup above; keep
+// the bucketing rules in sync (dispatching/dispatched conflate).
 func (q *Queries) GetCurtailmentTargetRollupByEvent(ctx context.Context, arg GetCurtailmentTargetRollupByEventParams) (GetCurtailmentTargetRollupByEventRow, error) {
 	row := q.queryRow(ctx, q.getCurtailmentTargetRollupByEventStmt, getCurtailmentTargetRollupByEvent, arg.OrgID, arg.EventUuid)
 	var i GetCurtailmentTargetRollupByEventRow
@@ -1512,21 +1518,46 @@ func (q *Queries) ListActiveCurtailedDevicesByOrg(ctx context.Context, orgID int
 
 const listActiveCurtailmentEvents = `-- name: ListActiveCurtailmentEvents :many
 SELECT
-    id, event_uuid, org_id, state, mode, strategy, level, priority,
-    loop_type, scope_type, scope_jsonb, mode_params_jsonb,
-    curtail_batch_size, curtail_batch_interval_sec,
-    restore_batch_size, restore_batch_interval_sec, effective_batch_size,
-    min_curtailed_duration_sec, max_duration_seconds, allow_unbounded,
-    include_maintenance, force_include_maintenance, force_include_all_paired_miners,
+    ce.id, ce.event_uuid, ce.org_id, ce.state, ce.mode, ce.strategy, ce.level, ce.priority,
+    ce.loop_type, ce.scope_type, ce.scope_jsonb, ce.mode_params_jsonb,
+    ce.curtail_batch_size, ce.curtail_batch_interval_sec,
+    ce.restore_batch_size, ce.restore_batch_interval_sec, ce.effective_batch_size,
+    ce.min_curtailed_duration_sec, ce.max_duration_seconds, ce.allow_unbounded,
+    ce.include_maintenance, ce.force_include_maintenance, ce.force_include_all_paired_miners,
     '{}'::JSONB AS decision_snapshot_jsonb,
-    source_actor_type, source_actor_id,
-    external_source, external_reference, idempotency_key,
-    supersedes_event_id, reason, scheduled_start_at, started_at, ended_at,
-    created_at, updated_at, created_by_user_id
-FROM curtailment_event
-WHERE org_id = $1
-    AND state IN ('pending', 'active', 'restoring')
-ORDER BY COALESCE(started_at, created_at) DESC, id DESC
+    ce.source_actor_type, ce.source_actor_id,
+    ce.external_source, ce.external_reference, ce.idempotency_key,
+    ce.supersedes_event_id, ce.reason, ce.scheduled_start_at, ce.started_at, ce.ended_at,
+    ce.created_at, ce.updated_at, ce.created_by_user_id,
+    COALESCE(rollup.pending, 0)::BIGINT AS rollup_pending,
+    COALESCE(rollup.dispatched, 0)::BIGINT AS rollup_dispatched,
+    COALESCE(rollup.confirmed, 0)::BIGINT AS rollup_confirmed,
+    COALESCE(rollup.drifted, 0)::BIGINT AS rollup_drifted,
+    COALESCE(rollup.resolved, 0)::BIGINT AS rollup_resolved,
+    COALESCE(rollup.released, 0)::BIGINT AS rollup_released,
+    COALESCE(rollup.restore_failed, 0)::BIGINT AS rollup_restore_failed,
+    COALESCE(rollup.unavailable, 0)::BIGINT AS rollup_unavailable,
+    COALESCE(rollup.total, 0)::BIGINT AS rollup_total
+FROM curtailment_event ce
+LEFT JOIN LATERAL (
+    -- State buckets mirror GetCurtailmentTargetRollupByEvent below; keep the
+    -- two aggregates' bucketing rules in sync (dispatching/dispatched conflate).
+    SELECT
+        COUNT(*) FILTER (WHERE ct.state = 'pending') AS pending,
+        COUNT(*) FILTER (WHERE ct.state IN ('dispatching', 'dispatched')) AS dispatched,
+        COUNT(*) FILTER (WHERE ct.state = 'confirmed') AS confirmed,
+        COUNT(*) FILTER (WHERE ct.state = 'drifted') AS drifted,
+        COUNT(*) FILTER (WHERE ct.state = 'resolved') AS resolved,
+        COUNT(*) FILTER (WHERE ct.state = 'released') AS released,
+        COUNT(*) FILTER (WHERE ct.state = 'restore_failed') AS restore_failed,
+        COUNT(*) FILTER (WHERE ct.state = 'unavailable') AS unavailable,
+        COUNT(*) AS total
+    FROM curtailment_target ct
+    WHERE ct.curtailment_event_id = ce.id
+) rollup ON true
+WHERE ce.org_id = $1
+    AND ce.state IN ('pending', 'active', 'restoring')
+ORDER BY COALESCE(ce.started_at, ce.created_at) DESC, ce.id DESC
 `
 
 type ListActiveCurtailmentEventsRow struct {
@@ -1567,6 +1598,15 @@ type ListActiveCurtailmentEventsRow struct {
 	CreatedAt                   time.Time
 	UpdatedAt                   time.Time
 	CreatedByUserID             int64
+	RollupPending               int64
+	RollupDispatched            int64
+	RollupConfirmed             int64
+	RollupDrifted               int64
+	RollupResolved              int64
+	RollupReleased              int64
+	RollupRestoreFailed         int64
+	RollupUnavailable           int64
+	RollupTotal                 int64
 }
 
 // Org-scoped list of every non-terminal event. Multiple can be active when
@@ -1576,6 +1616,11 @@ type ListActiveCurtailmentEventsRow struct {
 // Active summaries intentionally omit the persisted decision snapshot. Polling
 // runs frequently and the response shape never exposes the snapshot; detail
 // callers use GetCurtailmentEventDetailByUUID instead.
+//
+// Each row carries a live per-state target rollup so active polling reflects
+// the event's current target set (closed-loop claims and all-paired policy
+// changes grow it past the event-start snapshot) without hydrating per-target
+// rows. Events with no target rows aggregate to a zeroed rollup.
 func (q *Queries) ListActiveCurtailmentEvents(ctx context.Context, orgID int64) ([]ListActiveCurtailmentEventsRow, error) {
 	rows, err := q.query(ctx, q.listActiveCurtailmentEventsStmt, listActiveCurtailmentEvents, orgID)
 	if err != nil {
@@ -1623,6 +1668,15 @@ func (q *Queries) ListActiveCurtailmentEvents(ctx context.Context, orgID int64) 
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.CreatedByUserID,
+			&i.RollupPending,
+			&i.RollupDispatched,
+			&i.RollupConfirmed,
+			&i.RollupDrifted,
+			&i.RollupResolved,
+			&i.RollupReleased,
+			&i.RollupRestoreFailed,
+			&i.RollupUnavailable,
+			&i.RollupTotal,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -2111,7 +2111,7 @@ func convertEventListRow(row sqlc.ListCurtailmentEventsForOrgRow) *models.Event 
 }
 
 func convertActiveEventRow(row sqlc.ListActiveCurtailmentEventsRow) *models.Event {
-	return convertEventFields(
+	event := convertEventFields(
 		row.ID,
 		row.EventUuid,
 		row.OrgID,
@@ -2150,6 +2150,21 @@ func convertActiveEventRow(row sqlc.ListActiveCurtailmentEventsRow) *models.Even
 		row.CreatedAt,
 		row.UpdatedAt,
 	)
+	// The active-list query aggregates target counts per row; events with no
+	// target rows carry a zeroed (non-nil) rollup so active displays can trust
+	// it as the live target set.
+	event.TargetRollup = &models.TargetRollup{
+		Pending:       row.RollupPending,
+		Dispatched:    row.RollupDispatched,
+		Confirmed:     row.RollupConfirmed,
+		Drifted:       row.RollupDrifted,
+		Resolved:      row.RollupResolved,
+		Released:      row.RollupReleased,
+		RestoreFailed: row.RollupRestoreFailed,
+		Unavailable:   row.RollupUnavailable,
+		Total:         row.RollupTotal,
+	}
+	return event
 }
 
 func convertEventFields(

--- a/server/internal/domain/stores/sqlstores/curtailment_active_rollup_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_active_rollup_integration_test.go
@@ -1,0 +1,83 @@
+package sqlstores_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	"github.com/block/proto-fleet/server/internal/testutil"
+)
+
+// Pins the live per-event rollup on the active-events list: aggregate counts
+// cover every target state (dispatching/dispatched conflated, unavailable
+// included), and target-less events aggregate to a zeroed non-nil rollup
+// instead of failing or returning nil.
+func TestSQLCurtailmentStore_ListActiveEvents_ReturnsLiveTargetRollups(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	store := sqlstores.NewSQLCurtailmentStore(testContext.DatabaseService.DB)
+
+	targetedUUID := uuid.New()
+	_, err := store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreTestEvent(user.OrganizationID, user.DatabaseID, targetedUUID, models.EventStateActive, "active-rollup-targeted"),
+		[]models.InsertTargetParams{
+			curtailmentStoreTestTarget("rollup-pending", models.TargetStatePending, models.DesiredStateCurtailed),
+			curtailmentStoreTestTarget("rollup-dispatching", models.TargetStateDispatching, models.DesiredStateCurtailed),
+			curtailmentStoreTestTarget("rollup-dispatched", models.TargetStateDispatched, models.DesiredStateCurtailed),
+			curtailmentStoreTestTarget("rollup-confirmed-a", models.TargetStateConfirmed, models.DesiredStateCurtailed),
+			curtailmentStoreTestTarget("rollup-confirmed-b", models.TargetStateConfirmed, models.DesiredStateCurtailed),
+			curtailmentStoreTestTarget("rollup-drifted", models.TargetStateDrifted, models.DesiredStateCurtailed),
+			curtailmentStoreTestTarget("rollup-unavailable", models.TargetStateUnavailable, models.DesiredStateCurtailed),
+			curtailmentStoreTestTarget("rollup-resolved", models.TargetStateResolved, models.DesiredStateActive),
+			curtailmentStoreTestTarget("rollup-released", models.TargetStateReleased, models.DesiredStateActive),
+			curtailmentStoreTestTarget("rollup-restore-failed", models.TargetStateRestoreFailed, models.DesiredStateActive),
+		},
+	)
+	require.NoError(t, err)
+
+	targetlessUUID := uuid.New()
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreClosedLoopFullFleetEvent(user.OrganizationID, user.DatabaseID, targetlessUUID, models.ScopeTypeWholeOrg, 0, "active-rollup-targetless"),
+		nil,
+	)
+	require.NoError(t, err)
+
+	events, err := store.ListActiveEvents(ctx, user.OrganizationID)
+	require.NoError(t, err)
+
+	byUUID := make(map[uuid.UUID]*models.Event, len(events))
+	for _, event := range events {
+		byUUID[event.EventUUID] = event
+	}
+
+	targeted := byUUID[targetedUUID]
+	require.NotNil(t, targeted)
+	require.NotNil(t, targeted.TargetRollup)
+	assert.Equal(t, &models.TargetRollup{
+		Pending:       1,
+		Dispatched:    2, // dispatching + dispatched conflate in operator rollups
+		Confirmed:     2,
+		Drifted:       1,
+		Resolved:      1,
+		Released:      1,
+		RestoreFailed: 1,
+		Unavailable:   1,
+		Total:         10,
+	}, targeted.TargetRollup)
+
+	targetless := byUUID[targetlessUUID]
+	require.NotNil(t, targetless)
+	require.NotNil(t, targetless.TargetRollup, "target-less events must carry a zeroed rollup, not nil")
+	assert.Equal(t, &models.TargetRollup{}, targetless.TargetRollup)
+}

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -247,7 +247,29 @@ func (h *Handler) ListActiveCurtailments(ctx context.Context, _ *connect.Request
 	if err != nil {
 		return nil, err
 	}
-	return connect.NewResponse(toListActiveCurtailmentsResponse(events)), nil
+	// Whole-org events stay visible on the plain org grant so narrowed
+	// operators still learn their sites are curtailed, but their live rollup
+	// aggregates target counts across every site — including narrowed ones —
+	// so it requires the same unnarrowed org-wide read that whole-org writes
+	// and incomplete-coverage reads already demand.
+	orgWideRead, err := hasOrgWidePermission(ctx, authz.PermCurtailmentRead)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(toListActiveCurtailmentsResponse(events, orgWideRead)), nil
+}
+
+// hasOrgWidePermission reports whether the caller holds permission at org
+// scope without site narrowing; Forbidden maps to false rather than failing
+// the request.
+func hasOrgWidePermission(ctx context.Context, permission string) (bool, error) {
+	if _, err := middleware.RequireOrgWidePermission(ctx, permission); err != nil {
+		if fleeterror.IsForbiddenError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (h *Handler) ListCurtailmentEvents(ctx context.Context, req *connect.Request[pb.ListCurtailmentEventsRequest]) (*connect.Response[pb.ListCurtailmentEventsResponse], error) {

--- a/server/internal/handlers/curtailment/handler_list_test.go
+++ b/server/internal/handlers/curtailment/handler_list_test.go
@@ -398,6 +398,93 @@ func TestHandler_ListActiveCurtailments_ReturnsActiveEvents(t *testing.T) {
 	assert.Empty(t, resp.Msg.Events[0].IdempotencyKey)
 }
 
+// TestHandler_ListActiveCurtailments_OmitsWholeOrgRollupForNarrowedRead: a
+// whole-org event stays visible on the plain org grant, but its live rollup
+// aggregates target counts across every site — including sites the caller's
+// read grant is narrowed away from — so the rollup requires unnarrowed
+// org-wide read. Site-scoped events at permitted sites keep their rollups.
+func TestHandler_ListActiveCurtailments_OmitsWholeOrgRollupForNarrowedRead(t *testing.T) {
+	t.Parallel()
+	const (
+		orgID       = int64(42)
+		allowedSite = int64(7)
+		narrowSite  = int64(8)
+	)
+	wholeOrgUUID := uuid.New()
+	allowedSiteUUID := uuid.New()
+	store := &listStubStore{
+		activeEvents: []*models.Event{
+			{
+				ID:                      1,
+				EventUUID:               wholeOrgUUID,
+				OrgID:                   orgID,
+				State:                   models.EventStateActive,
+				Mode:                    models.ModeFullFleet,
+				Strategy:                models.StrategyLeastEfficientFirst,
+				Level:                   models.LevelFull,
+				Priority:                models.PriorityNormal,
+				RestoreBatchSize:        10,
+				RestoreBatchIntervalSec: 120,
+				Reason:                  "whole-org",
+				ScopeType:               models.ScopeTypeWholeOrg,
+				TargetRollup:            &models.TargetRollup{Confirmed: 4990, Pending: 10, Total: 5000},
+			},
+			{
+				ID:                      2,
+				EventUUID:               allowedSiteUUID,
+				OrgID:                   orgID,
+				State:                   models.EventStateActive,
+				Mode:                    models.ModeFixedKw,
+				Strategy:                models.StrategyLeastEfficientFirst,
+				Level:                   models.LevelFull,
+				Priority:                models.PriorityNormal,
+				RestoreBatchSize:        10,
+				RestoreBatchIntervalSec: 120,
+				Reason:                  "allowed-site",
+				ScopeType:               models.ScopeTypeSite,
+				ScopeJSON:               siteScopeJSON(t, allowedSite),
+				TargetRollup:            &models.TargetRollup{Confirmed: 3, Total: 3},
+			},
+		},
+	}
+	h := NewHandler(domainCurtailment.NewService(store))
+	narrowedCtx := testSessionCtxWithAssignments(t, &session.Info{
+		AuthMethod:     session.AuthMethodSession,
+		OrganizationID: orgID,
+		UserID:         9,
+		Role:           "OPERATOR",
+	}, testOrgAssignment(authz.PermCurtailmentRead),
+		testSiteAssignment(allowedSite, authz.PermCurtailmentRead),
+		testSiteAssignment(narrowSite))
+
+	resp, err := h.ListActiveCurtailments(narrowedCtx, connect.NewRequest(&pb.ListActiveCurtailmentsRequest{}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Events, 2)
+	assert.Equal(t, wholeOrgUUID.String(), resp.Msg.Events[0].EventUuid,
+		"whole-org events stay visible so narrowed operators learn their sites are curtailed")
+	assert.Nil(t, resp.Msg.Events[0].TargetRollup,
+		"whole-org rollup aggregates narrowed sites; it must not ship without org-wide read")
+	require.NotNil(t, resp.Msg.Events[1].TargetRollup,
+		"site-scoped rollups at permitted sites are unaffected by narrowing elsewhere")
+	assert.Equal(t, int32(3), resp.Msg.Events[1].TargetRollup.Total)
+
+	orgWideCtx := testSessionCtxWithAssignments(t, &session.Info{
+		AuthMethod:     session.AuthMethodSession,
+		OrganizationID: orgID,
+		UserID:         9,
+		Role:           "OPERATOR",
+	}, testOrgAssignment(authz.PermCurtailmentRead),
+		testSiteAssignment(allowedSite, authz.PermCurtailmentRead),
+		testSiteAssignment(narrowSite, authz.PermCurtailmentRead))
+
+	resp, err = h.ListActiveCurtailments(orgWideCtx, connect.NewRequest(&pb.ListActiveCurtailmentsRequest{}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Events, 2)
+	require.NotNil(t, resp.Msg.Events[0].TargetRollup,
+		"matching narrowed grants keep org read effective everywhere, so the rollup ships")
+	assert.Equal(t, int32(5000), resp.Msg.Events[0].TargetRollup.Total)
+}
+
 func TestHandler_ListActiveCurtailments_FiltersSiteScopedEvents(t *testing.T) {
 	t.Parallel()
 	const (

--- a/server/internal/handlers/curtailment/handler_list_test.go
+++ b/server/internal/handlers/curtailment/handler_list_test.go
@@ -322,8 +322,9 @@ func TestHandler_ListCurtailmentEvents_HappyPath(t *testing.T) {
 }
 
 // TestHandler_ListActiveCurtailments_ReturnsActiveEvents: multiple concurrent
-// non-terminal events round-trip through the handler, and the per-target heavy
-// payload is intentionally absent (use GetCurtailmentEvent for detail).
+// non-terminal events round-trip through the handler with their live target
+// rollups, and the per-target heavy payload and decision snapshot are
+// intentionally absent (use GetCurtailmentEvent for detail).
 func TestHandler_ListActiveCurtailments_ReturnsActiveEvents(t *testing.T) {
 	t.Parallel()
 	source, reference, key := "opensearch", "alert-1", "retry-key"
@@ -344,6 +345,18 @@ func TestHandler_ListActiveCurtailments_ReturnsActiveEvents(t *testing.T) {
 				ExternalSource:          &source,
 				ExternalReference:       &reference,
 				IdempotencyKey:          &key,
+				DecisionSnapshotJSON:    []byte(`{"selected_count":10}`),
+				TargetRollup: &models.TargetRollup{
+					Pending:       1,
+					Dispatched:    2,
+					Confirmed:     4990,
+					Drifted:       1,
+					Resolved:      2,
+					Released:      1,
+					RestoreFailed: 1,
+					Unavailable:   2,
+					Total:         5000,
+				},
 			},
 			{
 				ID:                      2,
@@ -357,6 +370,7 @@ func TestHandler_ListActiveCurtailments_ReturnsActiveEvents(t *testing.T) {
 				RestoreBatchSize:        10,
 				RestoreBatchIntervalSec: 120,
 				Reason:                  "site-b",
+				TargetRollup:            &models.TargetRollup{},
 			},
 		},
 	}
@@ -368,6 +382,16 @@ func TestHandler_ListActiveCurtailments_ReturnsActiveEvents(t *testing.T) {
 	assert.Equal(t, store.activeEvents[0].EventUUID.String(), resp.Msg.Events[0].EventUuid)
 	assert.Equal(t, store.activeEvents[1].EventUUID.String(), resp.Msg.Events[1].EventUuid)
 	assert.Empty(t, resp.Msg.Events[0].Targets, "list-active response must not include per-target rows")
+	assert.Nil(t, resp.Msg.Events[0].DecisionSnapshot, "list-active response must not include the decision snapshot")
+	// Live rollups ride along so active displays can show the event's current
+	// target set instead of the event-start snapshot count.
+	require.NotNil(t, resp.Msg.Events[0].TargetRollup)
+	assert.Equal(t, int32(5000), resp.Msg.Events[0].TargetRollup.Total)
+	assert.Equal(t, int32(4990), resp.Msg.Events[0].TargetRollup.Confirmed)
+	assert.Equal(t, int32(2), resp.Msg.Events[0].TargetRollup.Unavailable)
+	assert.Equal(t, int32(1), resp.Msg.Events[0].TargetRollup.RestoreFailed)
+	require.NotNil(t, resp.Msg.Events[1].TargetRollup, "target-less events carry a zeroed rollup")
+	assert.Equal(t, int32(0), resp.Msg.Events[1].TargetRollup.Total)
 	// Replay handles are scrubbed from the list view, like the history list.
 	assert.Empty(t, resp.Msg.Events[0].ExternalSource)
 	assert.Empty(t, resp.Msg.Events[0].ExternalReference)

--- a/server/internal/handlers/curtailment/translate.go
+++ b/server/internal/handlers/curtailment/translate.go
@@ -847,10 +847,12 @@ func toListEventsResponse(events []*models.Event, nextPageToken string) *pb.List
 // metadata + scope + mode params + target-site coverage + live target rollup,
 // no per-device targets or decision snapshot (use GetCurtailmentEvent for
 // detail). The rollup describes the event's current target set so active
-// polling reflects closed-loop claims and all-paired policy changes. Replay
-// handles are scrubbed as in the history list — a list view doesn't expose
-// webhook trigger metadata.
-func toListActiveCurtailmentsResponse(events []*models.Event) *pb.ListActiveCurtailmentsResponse {
+// polling reflects closed-loop claims and all-paired policy changes; on
+// whole-org events it aggregates across every site, so it is omitted unless
+// the caller's read permission is org-wide (unnarrowed). Replay handles are
+// scrubbed as in the history list — a list view doesn't expose webhook
+// trigger metadata.
+func toListActiveCurtailmentsResponse(events []*models.Event, orgWideRead bool) *pb.ListActiveCurtailmentsResponse {
 	out := &pb.ListActiveCurtailmentsResponse{
 		Events: make([]*pb.CurtailmentEvent, len(events)),
 	}
@@ -858,12 +860,21 @@ func toListActiveCurtailmentsResponse(events []*models.Event) *pb.ListActiveCurt
 		e := toEventProto(ev)
 		populateEventScope(e, ev)
 		populateEventModeParams(e, ev)
-		populateEventTargetRollup(e, ev)
+		if orgWideRead || !isWholeOrgScopedEvent(ev) {
+			populateEventTargetRollup(e, ev)
+		}
 		populateEventTargetSiteCoverage(e, ev)
 		scrubListSensitiveFields(e)
 		out.Events[i] = e
 	}
 	return out
+}
+
+// isWholeOrgScopedEvent mirrors populateEventScope's whole-org handling: an
+// empty scope type renders as whole-org on the wire, so it is treated as
+// whole-org for rollup exposure too.
+func isWholeOrgScopedEvent(event *models.Event) bool {
+	return event.ScopeType == models.ScopeTypeWholeOrg || event.ScopeType == ""
 }
 
 // toEventProtoListItem populates the list-view shape (no targets).

--- a/server/internal/handlers/curtailment/translate.go
+++ b/server/internal/handlers/curtailment/translate.go
@@ -844,9 +844,12 @@ func toListEventsResponse(events []*models.Event, nextPageToken string) *pb.List
 }
 
 // toListActiveCurtailmentsResponse builds the active-events response: event
-// metadata + scope, no per-device targets or decision snapshot (use
-// GetCurtailmentEvent for detail). Replay handles are scrubbed as in the
-// history list — a list view doesn't expose webhook trigger metadata.
+// metadata + scope + mode params + target-site coverage + live target rollup,
+// no per-device targets or decision snapshot (use GetCurtailmentEvent for
+// detail). The rollup describes the event's current target set so active
+// polling reflects closed-loop claims and all-paired policy changes. Replay
+// handles are scrubbed as in the history list — a list view doesn't expose
+// webhook trigger metadata.
 func toListActiveCurtailmentsResponse(events []*models.Event) *pb.ListActiveCurtailmentsResponse {
 	out := &pb.ListActiveCurtailmentsResponse{
 		Events: make([]*pb.CurtailmentEvent, len(events)),
@@ -855,6 +858,7 @@ func toListActiveCurtailmentsResponse(events []*models.Event) *pb.ListActiveCurt
 		e := toEventProto(ev)
 		populateEventScope(e, ev)
 		populateEventModeParams(e, ev)
+		populateEventTargetRollup(e, ev)
 		populateEventTargetSiteCoverage(e, ev)
 		scrubListSensitiveFields(e)
 		out.Events[i] = e

--- a/server/migrations/000110_add_curtailment_target_event_state_index.down.sql
+++ b/server/migrations/000110_add_curtailment_target_event_state_index.down.sql
@@ -1,0 +1,3 @@
+-- Online drop; see the up migration's CONCURRENTLY note. Must be the sole
+-- statement in the file (no implicit transaction).
+DROP INDEX CONCURRENTLY IF EXISTS idx_curtailment_target_event_state;

--- a/server/migrations/000110_add_curtailment_target_event_state_index.up.sql
+++ b/server/migrations/000110_add_curtailment_target_event_state_index.up.sql
@@ -1,0 +1,16 @@
+-- Covering index for the live target rollup on the active-events poll path
+-- (ListActiveCurtailmentEvents): the per-event COUNT(*) FILTER (WHERE state
+-- ...) lateral touches only (curtailment_event_id, state), so between write
+-- bursts it can run as an index-only scan instead of a heap fetch across
+-- fleet-sized target sets. Unfiltered because the rollup counts every state,
+-- including terminal rows.
+--
+-- Uses CONCURRENTLY so the build does not block writes on high-row-count
+-- deploys. golang-migrate v4's postgres driver runs each statement directly
+-- via conn.ExecContext — no implicit transaction wraps the migration body —
+-- so CREATE INDEX CONCURRENTLY is safe here (sole statement in the file).
+-- If a partial build fails it leaves schema_migrations.dirty=true at version
+-- 110 and may leave an INVALID index in pg_indexes; operator recovery is to
+-- DROP the INVALID index and `migrate force 109` before re-deploying.
+CREATE INDEX CONCURRENTLY idx_curtailment_target_event_state
+    ON curtailment_target (curtailment_event_id, state);

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -516,22 +516,52 @@ LIMIT sqlc.arg('row_limit')::BIGINT;
 -- Active summaries intentionally omit the persisted decision snapshot. Polling
 -- runs frequently and the response shape never exposes the snapshot; detail
 -- callers use GetCurtailmentEventDetailByUUID instead.
+--
+-- Each row carries a live per-state target rollup so active polling reflects
+-- the event's current target set (closed-loop claims and all-paired policy
+-- changes grow it past the event-start snapshot) without hydrating per-target
+-- rows. Events with no target rows aggregate to a zeroed rollup.
 SELECT
-    id, event_uuid, org_id, state, mode, strategy, level, priority,
-    loop_type, scope_type, scope_jsonb, mode_params_jsonb,
-    curtail_batch_size, curtail_batch_interval_sec,
-    restore_batch_size, restore_batch_interval_sec, effective_batch_size,
-    min_curtailed_duration_sec, max_duration_seconds, allow_unbounded,
-    include_maintenance, force_include_maintenance, force_include_all_paired_miners,
+    ce.id, ce.event_uuid, ce.org_id, ce.state, ce.mode, ce.strategy, ce.level, ce.priority,
+    ce.loop_type, ce.scope_type, ce.scope_jsonb, ce.mode_params_jsonb,
+    ce.curtail_batch_size, ce.curtail_batch_interval_sec,
+    ce.restore_batch_size, ce.restore_batch_interval_sec, ce.effective_batch_size,
+    ce.min_curtailed_duration_sec, ce.max_duration_seconds, ce.allow_unbounded,
+    ce.include_maintenance, ce.force_include_maintenance, ce.force_include_all_paired_miners,
     '{}'::JSONB AS decision_snapshot_jsonb,
-    source_actor_type, source_actor_id,
-    external_source, external_reference, idempotency_key,
-    supersedes_event_id, reason, scheduled_start_at, started_at, ended_at,
-    created_at, updated_at, created_by_user_id
-FROM curtailment_event
-WHERE org_id = sqlc.arg('org_id')
-    AND state IN ('pending', 'active', 'restoring')
-ORDER BY COALESCE(started_at, created_at) DESC, id DESC;
+    ce.source_actor_type, ce.source_actor_id,
+    ce.external_source, ce.external_reference, ce.idempotency_key,
+    ce.supersedes_event_id, ce.reason, ce.scheduled_start_at, ce.started_at, ce.ended_at,
+    ce.created_at, ce.updated_at, ce.created_by_user_id,
+    COALESCE(rollup.pending, 0)::BIGINT AS rollup_pending,
+    COALESCE(rollup.dispatched, 0)::BIGINT AS rollup_dispatched,
+    COALESCE(rollup.confirmed, 0)::BIGINT AS rollup_confirmed,
+    COALESCE(rollup.drifted, 0)::BIGINT AS rollup_drifted,
+    COALESCE(rollup.resolved, 0)::BIGINT AS rollup_resolved,
+    COALESCE(rollup.released, 0)::BIGINT AS rollup_released,
+    COALESCE(rollup.restore_failed, 0)::BIGINT AS rollup_restore_failed,
+    COALESCE(rollup.unavailable, 0)::BIGINT AS rollup_unavailable,
+    COALESCE(rollup.total, 0)::BIGINT AS rollup_total
+FROM curtailment_event ce
+LEFT JOIN LATERAL (
+    -- State buckets mirror GetCurtailmentTargetRollupByEvent below; keep the
+    -- two aggregates' bucketing rules in sync (dispatching/dispatched conflate).
+    SELECT
+        COUNT(*) FILTER (WHERE ct.state = 'pending') AS pending,
+        COUNT(*) FILTER (WHERE ct.state IN ('dispatching', 'dispatched')) AS dispatched,
+        COUNT(*) FILTER (WHERE ct.state = 'confirmed') AS confirmed,
+        COUNT(*) FILTER (WHERE ct.state = 'drifted') AS drifted,
+        COUNT(*) FILTER (WHERE ct.state = 'resolved') AS resolved,
+        COUNT(*) FILTER (WHERE ct.state = 'released') AS released,
+        COUNT(*) FILTER (WHERE ct.state = 'restore_failed') AS restore_failed,
+        COUNT(*) FILTER (WHERE ct.state = 'unavailable') AS unavailable,
+        COUNT(*) AS total
+    FROM curtailment_target ct
+    WHERE ct.curtailment_event_id = ce.id
+) rollup ON true
+WHERE ce.org_id = sqlc.arg('org_id')
+    AND ce.state IN ('pending', 'active', 'restoring')
+ORDER BY COALESCE(ce.started_at, ce.created_at) DESC, ce.id DESC;
 
 -- name: ListCurtailmentTargetSiteCoverageByEvent :many
 -- Coverage for explicit-device event authorization. target_count is every
@@ -980,16 +1010,22 @@ LIMIT sqlc.arg('row_limit')::BIGINT;
 -- name: GetCurtailmentTargetRollupByEvent :one
 -- Org-scoped aggregate for paginated event detail. Target pages can be
 -- partial, but the rollup must describe the whole event.
+--
+-- Counts ct.curtailment_event_id (NULL exactly on the LEFT JOIN's no-target
+-- row, like any ct column) so the aggregate only touches index columns of
+-- idx_curtailment_target_event_state and stays index-only-scannable. State
+-- buckets mirror the ListActiveCurtailmentEvents lateral rollup above; keep
+-- the bucketing rules in sync (dispatching/dispatched conflate).
 SELECT
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'pending')::BIGINT AS pending,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state IN ('dispatching', 'dispatched'))::BIGINT AS dispatched,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'confirmed')::BIGINT AS confirmed,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'drifted')::BIGINT AS drifted,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'resolved')::BIGINT AS resolved,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'released')::BIGINT AS released,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'restore_failed')::BIGINT AS restore_failed,
-    COUNT(ct.device_identifier) FILTER (WHERE ct.state = 'unavailable')::BIGINT AS unavailable,
-    COUNT(ct.device_identifier)::BIGINT AS total
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'pending')::BIGINT AS pending,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state IN ('dispatching', 'dispatched'))::BIGINT AS dispatched,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'confirmed')::BIGINT AS confirmed,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'drifted')::BIGINT AS drifted,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'resolved')::BIGINT AS resolved,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'released')::BIGINT AS released,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'restore_failed')::BIGINT AS restore_failed,
+    COUNT(ct.curtailment_event_id) FILTER (WHERE ct.state = 'unavailable')::BIGINT AS unavailable,
+    COUNT(ct.curtailment_event_id)::BIGINT AS total
 FROM curtailment_event ce
 LEFT JOIN curtailment_target ct ON ct.curtailment_event_id = ce.id
 WHERE ce.org_id = sqlc.arg('org_id')


### PR DESCRIPTION
Reviewable diff: +415/-47 across 17 files (excludes generated, test, and story files).

Fixes #656. Implementation plan: `docs/plans/2026-07-03-live-active-curtailment-status-plan.md`.

## Summary

Active curtailment surfaces could show the event-start `decision_snapshot.selected_count` instead of the event's current target set, which is misleading for closed-loop and all-paired events whose target ownership grows long after the start decision (snapshot says 10, event owns 5,000). `ListActiveCurtailments` now returns a live per-state `target_rollup` for every event, and the active card, header pill, and injected active-history rows display that live total as the operational truth while history rows keep snapshot counts as audit context. Active-list responses stay lightweight (no per-target rows, no decision snapshots), and — per the Codex security review — whole-org events omit the rollup unless the caller's `curtailment:read` is org-wide (unnarrowed), since that aggregate spans every site.

## How it works

The active-events SQL query aggregates target counts per event in a `LEFT JOIN LATERAL` (one round trip, no N+1 on the poll path), so every listed event carries pending/dispatched/confirmed/drifted/unavailable/resolved/released/restore-failed counts plus a total. Events with no target rows get a zeroed (non-nil) rollup rather than an absent one. The store maps the aggregate columns into `models.Event.TargetRollup`, and the handler populates `target_rollup` on each wire event with the same scrubbing rules as before. A new migration adds a covering index on `curtailment_target (curtailment_event_id, state)` so the aggregate can run as an index-only scan on fleet-sized target sets.

Rollup exposure follows the existing permission model: site-scoped events at denied sites were already filtered out, and whole-org events remain visible on the plain org grant so narrowed operators still learn their sites are curtailed — but their rollup aggregates counts across every site, so the handler omits it unless the caller passes `RequireOrgWidePermission`, the same gate whole-org writes and incomplete-coverage reads already use.

On the client, a new `getCurtailmentEventLiveTargetCount` prefers `targetRollup.total`, then hydrated target rows, then the snapshot count — the reverse of the audit-context helper history rows keep using. Active mapping (card, pill, injected history rows) uses the live count, and the estimate-derived observed-reduction ratio now uses the same live denominator so progress can no longer exceed 100% when the target set outgrows the snapshot. When per-event detail hydration fails during a poll, the fresh active-list rollup wins over the stale cached detail; the cached decision snapshot and target rows are retained only because list rows never carry them.

Because list rows now prove counts without proving a kW estimate (their decision snapshot stays scrubbed), a new `estimatedReductionAvailable` signal keeps count-only rows from rendering a fabricated "0.0 kW": the pill and history table show the live miner count alone, and injected history rows backfill the estimate from a matching server history row when one exists. An estimate counts as available only with a snapshot number or at least one baseline-bearing target row — `baseline_power_w` is optional, so baseline-less targets alone would also sum to a fake zero.

The active card's Restore stat now follows the configured `restore_batch_size` instead of substituting `effective_batch_size` (the selected count stamped at Start). For safety-limit restores (`restore_batch_size=0`) on all-paired or closed-loop events the stamp goes stale as the target set grows, while the reconciler's restore claims ignore it and wave up to the safety limit — so a full-shutdown event now reads "Up to safety limit every Ns" rather than presenting the start-time miner count as the restore wave size, and the restore-time estimate matches the actual single-wave behavior.

## Diagrams

```mermaid
flowchart LR
    A["Client poll (3s)"] --> B["ListActiveCurtailments"]
    B --> C["ListActiveCurtailmentEvents SQL<br/>LEFT JOIN LATERAL rollup"]
    C --> D["models.Event.TargetRollup"]
    D --> K{"whole-org event and<br/>read narrowed at a site?"}
    K -- "yes: omit rollup" --> E["wire event<br/>(no targets, no snapshot)"]
    K -- "no" --> L["target_rollup on wire event"]
    L --> E
    E --> F["getCurtailmentEventLiveTargetCount"]
    F --> G["Active card"]
    F --> H["Header pill"]
    F --> I["Injected active history rows"]
    E -. "unchanged: snapshot-first" .-> J["History rows (audit context)"]
```

```mermaid
sequenceDiagram
    participant UI as Active poll
    participant API as ListActiveCurtailments
    participant Detail as GetCurtailmentEvent
    UI->>API: poll
    API-->>UI: events with live target_rollup
    UI->>Detail: hydrate selected event
    alt hydration succeeds
        Detail-->>UI: fresh detail (snapshot + rollup)
    else hydration fails
        UI->>UI: keep list-row rollup, retain cached snapshot/targets only
    end
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/sqlc/queries/curtailment.sql` | Active-list query gains a lateral per-event rollup; detail rollup query counts an index column | Bucketing rules must stay in sync between the two aggregates |
| `server/migrations/000110_*` | New covering index on `curtailment_target (curtailment_event_id, state)`, `CONCURRENTLY`, up+down | Poll-path cost; dirty-state recovery documented in the file header |
| `server/internal/domain/stores/sqlstores/curtailment.go` | `convertActiveEventRow` maps aggregate columns into a non-nil `TargetRollup` | Zeroed rollup is deliberate for target-less events |
| `server/internal/handlers/curtailment/handler.go` | `ListActiveCurtailments` computes org-wide read once per request | Security boundary: whole-org rollups require unnarrowed read |
| `server/internal/handlers/curtailment/translate.go` | `toListActiveCurtailmentsResponse` populates `target_rollup`, skipping whole-org events for narrowed callers | Response still omits targets/snapshots and scrubs replay metadata |
| `proto/curtailment/v1/curtailment.proto` | Comment-only: documents the active-list shape and the org-wide rollup gate | No wire-shape change |
| `client/src/protoFleet/features/energy/curtailmentDisplayUtils.ts` | New live-count helper; observed-reduction denominator uses it | The live-vs-audit split lives here |
| `client/src/protoFleet/api/curtailmentMappers.ts` | Active card + injected history rows use live counts; new `hasCurtailmentEstimatedReductionKw` (snapshot number or baseline-bearing target); Restore stat follows configured `restore_batch_size`, not the start-time `effective_batch_size` stamp | Counts, kW estimates, and restore-profile display each track their real source |
| `client/src/protoFleet/api/activeCurtailmentData.ts` | Fresh list rollup survives failed detail hydration; rollup no longer counts as hydrated detail | Prevents stale-detail overwrite and summary-row auto-selection |
| `client/src/protoFleet/api/useCurtailmentApi.ts` | Injected rows backfill kW estimate from matching history | Live count + audit estimate coexist on one row |
| `client/src/protoFleet/components/PageHeader/*` | Pill shows live count; count-only rows drop the kW suffix | User-visible copy path |
| `server/generated/**`, `client/src/protoFleet/api/generated/**` | Regenerated via `just gen` | Generated — skip |

## Key technical decisions & trade-offs

- **Rollup aggregated in the list SQL (lateral join)** over attaching rollups per event in the service: one query on a 3s poll path instead of N+1 round trips.
- **Zeroed non-nil rollup for target-less events** over omitting it: active displays can trust the rollup as the live truth; a pending closed-loop event correctly shows 0 targets rather than a stale snapshot count.
- **Whole-org rollups gated on org-wide (unnarrowed) read, but whole-org events stay visible** over dropping the events or computing per-caller site-limited rollups: narrowed operators must still see that their sites are curtailed, while the cross-site aggregate follows the same `RequireOrgWidePermission` gate as whole-org writes. Per-caller rollups would put a per-session aggregate on a shared poll path.
- **Live-count preference only on active surfaces**; history keeps snapshot-first as audit context, preserving the existing meaning of completed rows.
- **Fallback chain preserved** (`rollup → targets → snapshot`) so old servers / partial data render exactly as today.
- **Separate `estimatedReductionAvailable` signal** over reusing `targetMetricsAvailable`: rollups and baseline-less target rows prove counts but not estimates; without the split, such rows would render a false "0.0 kW planned".
- **Unfiltered covering index** over widening the existing partial index: the rollup counts every state including terminal rows; the existing partial predicate is stale (missing `dispatching`/`unavailable`). Follow-up may drop the partial if it stops winning plans.

## Testing & validation

- Server: handler tests assert rollups ride on active-list responses while targets/snapshots stay absent, and a regression test (`TestHandler_ListActiveCurtailments_OmitsWholeOrgRollupForNarrowedRead`) pins the security gate: a whole-org active event with an org read grant narrowed by a site assignment omits the rollup, while matching narrowed grants and site-scoped events keep theirs. A new DB-backed store test pins all eight rollup state buckets, the dispatching/dispatched conflation, and the zeroed rollup for target-less events.
- Client: the curtailment suites pass, including cases for the 10-vs-5000 acceptance scenario, the full-shutdown repro (grown all-paired event shows the live count with safety-limit restore semantics instead of the stale stamp), live-count polling updates, hydration-failure rollup preference (both directions of the `??`), zeroed-rollup sentinel, fallback tiers, the observed-reduction denominator divergence, snapshot-first history audit context, count-only summary-row rendering, and baseline-less targets reporting the estimate as unavailable.
- `tsc --noEmit`, ESLint, `go vet`, `golangci-lint`, and `buf lint` are clean.
- **Not covered locally:** the DB-backed store test and migration 000110 could not be executed on the dev machine (local Docker daemon fails to start); they compile and run in CI's `protofleet-server-checks` job, which brings up TimescaleDB. No E2E coverage was added for the live-count surfaces.

## Review feedback addressed

- **Codex security review (MEDIUM)** — whole-org active rollups could leak cross-site target counts to callers with narrowed org read. Fixed in `fe0b5ad2b` by gating whole-org rollups on `RequireOrgWidePermission` (recommendation option 2), with the regression test above.
- **Copilot** — `hasCurtailmentEstimatedReductionKw` treated any target rows as proof of an estimate, but `baseline_power_w` is optional, so baseline-less targets rendered a fabricated "0.0 kW planned". Fixed in `c10d374a4`; estimates now require a snapshot number or a baseline-bearing target.
- **Manual testing (full-shutdown profile)** — "Applies to" tracked newly paired miners but "Restore" still showed the start-time count. Fixed in `f3d44067b`: the Restore stat displayed `effective_batch_size` (a Start-time stamp of the selected count) as the wave size, which goes stale under all-paired/closed-loop growth and which the reconciler's restore claims ignore for `restore_batch_size=0`. The display now follows the configured restore profile.

## Known Residuals

Accepted from code review (advisory severity, recorded per review policy):

- P2 (authz, pre-existing on `main`): `GetCurtailmentEvent` grants whole-org event detail — full rollup, decision snapshot, and per-device target rows — on the plain org-scope read check; `requireEventPermission` produces no site contexts for whole-org events, so narrowing is never consulted. This is a larger exposure than the list aggregate gated in this PR, but tightening it would break active-card detail hydration for narrowed operators, so aligning whole-org read semantics across Get/List needs a deliberate authz decision in a follow-up.
- P3 (performance): index-only scans degrade to heap fetches while the reconciler churns target pages during dispatch/restore waves; bounded and buffer-resident, monitor rather than pre-optimize.
- P3 (performance, pre-existing): the per-poll detail call fetches and discards a 1000-row target page for multi-page events; the new list rollup makes skipping that hydration possible as a follow-up.
- P3 (schema): `curtailment_target` now has six secondary indexes; if `idx_curtailment_target_pending_work` stops winning plans after this lands, drop it in a follow-up migration.

## Post-Deploy Monitoring & Validation

- Log queries: server error logs filtered for `failed to list active curtailment events` (store-level failures of the rewritten query).
- Metrics: latency of `ListActiveCurtailments` RPC before/after deploy; `pg_stat_statements` mean_exec_time for `ListActiveCurtailmentEvents` during a large active event.
- Index health: `SELECT indisvalid FROM pg_index JOIN pg_class ON indexrelid = oid WHERE relname = 'idx_curtailment_target_event_state'` must return true post-migration; if a deploy interruption leaves the migration dirty at version 110, drop the INVALID index and `migrate force 109` (documented in the migration header).
- Healthy signal: active curtailment card / header pill counts move with closed-loop claims within one poll interval (~3s) during an active event; users with unnarrowed org read see whole-org rollup counts, narrowed users see the event without live counts (pre-PR display).
- Failure signal / rollback: active card shows 0 or stale counts while an event owns targets, or active-list latency regresses materially — revert the client preference (history-safe) or the server commit independently; the index is purely additive and can stay.
- Validation window: first large curtailment event after deploy; owner: @rongxin-liu.

