### PR TITLE
[codex] Add fleet saved views e2e coverage

### DIFF
--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -14,7 +14,7 @@ const ASSIGN_RACKS_TO_BUILDING = "AssignRacksToBuilding";
 const AUTOMATION_SITE_PREFIX = "automation_buildings_site";
 const AUTOMATION_BUILDING_PREFIX = "automation_buildings_building";
 const AUTOMATION_RACK_PREFIX = "automation_buildings_rack";
-const TEMP_ZONE = "AutomationBuildingsZone";
+export const AUTOMATION_BUILDINGS_ZONE = "AutomationBuildingsZone";
 const RACK_COLUMNS = 2;
 const RACK_ROWS = 2;
 type BuildingsCleanupFleetLocationsPage = Pick<
@@ -129,7 +129,7 @@ export async function createRackWithAssignedMiners(
   return await test.step("Create a rack with two miners assigned", async () => {
     await racksPage.navigateToRacksPage();
     await racksPage.clickAddRackButton();
-    await racksPage.inputZone(TEMP_ZONE);
+    await racksPage.inputZone(AUTOMATION_BUILDINGS_ZONE);
     await racksPage.inputRackLabel(rackLabel);
     await racksPage.enableCustomRackLayout();
     await racksPage.inputColumns(RACK_COLUMNS);
@@ -177,6 +177,20 @@ export async function assignRackToBuilding(
     test.expect(String(body.racks[0]?.rackId)).toBe(rackId.toString());
     test.expect(response.status()).toBe(200);
   });
+}
+
+export async function setupRackAssignedToBuilding(
+  page: Page,
+  fleetLocationsPage: FleetLocationsPage,
+  racksPage: RacksPage,
+  scenario: BuildingsScenarioData,
+) {
+  const buildingId = await createSiteAndBuilding(fleetLocationsPage, scenario);
+  const { rackId, selectedMinerIps } = await createRackWithAssignedMiners(racksPage, scenario.rackLabel);
+
+  await assignRackToBuilding(page, racksPage, scenario.rackLabel, rackId, scenario.buildingName, buildingId);
+
+  return { buildingId, rackId, selectedMinerIps };
 }
 
 export async function removeRackFromBuilding(

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from "@playwright/test";
+import { expect, type Locator, Page } from "@playwright/test";
 import { DEFAULT_TIMEOUT, testConfig } from "../config/test.config";
 
 const FLEET_TAB_ROUTE = /.*\/fleet\/(?:sites|buildings|racks|miners)(?:[/?#].*)?$/;
@@ -11,6 +11,141 @@ export class BasePage {
 
   async reloadPage() {
     await this.page.reload();
+  }
+
+  async validateActiveFilter(filterLabel: string) {
+    await expect(this.activeFilterEditButton(filterLabel)).toBeVisible();
+  }
+
+  async validateActiveFilterSummary(filterValue: string, expectedSummary: string) {
+    await expect(await this.visibleTestIdLocator(`active-filter-${filterValue}-edit`)).toHaveText(expectedSummary);
+  }
+
+  async validateActiveFilterNotVisible(filterLabel: string) {
+    await expect(this.activeFilterEditButton(filterLabel)).toHaveCount(0);
+  }
+
+  async clickClearAllFilters() {
+    await this.page.getByRole("button", { name: "Clear all filters", exact: true }).click();
+  }
+
+  async clearActiveFilter(filterValue: string) {
+    const clearButton = await this.visibleTestIdLocator(`active-filter-${filterValue}-clear`);
+    await clearButton.evaluate((element) => {
+      const target = element as HTMLElement;
+      target.scrollIntoView({ block: "center", inline: "center" });
+      target.click();
+    });
+  }
+
+  async clickNewSavedViewButton() {
+    const emptyState = this.viewsEmptyStateNewButton();
+    if (await emptyState.isVisible().catch(() => false)) {
+      await emptyState.click();
+      return;
+    }
+
+    await this.openViewsPopover();
+    await this.page.getByTestId("fleet-view-tabs-popover-new-view").click();
+  }
+
+  async clickClearActiveView() {
+    await this.openViewsPopover();
+    await this.page.getByTestId("fleet-view-tabs-popover-clear-view").click();
+  }
+
+  async validateViewModalOpened(title: "New view" | "Update view" | "Rename view") {
+    const modal = this.page.getByTestId("view-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(title);
+  }
+
+  async inputViewName(name: string) {
+    await this.page.locator("#view-name").fill(name);
+  }
+
+  async saveNewView() {
+    await this.page.getByTestId("view-modal").getByRole("button", { name: "Save", exact: true }).click();
+    await expect(this.page.getByTestId("view-modal")).toBeHidden();
+  }
+
+  async updateSavedView() {
+    await this.page.getByTestId("view-modal").getByRole("button", { name: "Update", exact: true }).click();
+    await expect(this.page.getByTestId("view-modal")).toBeHidden();
+  }
+
+  async confirmRenameView() {
+    await this.page.getByTestId("view-modal").getByRole("button", { name: "Rename", exact: true }).click();
+    await expect(this.page.getByTestId("view-modal")).toBeHidden();
+  }
+
+  async validateViewTabVisible(viewName: string) {
+    await this.openViewsPopover();
+    await expect(this.viewRow(viewName)).toBeVisible();
+    await this.fleetViewTabsTrigger().click();
+    await expect(this.viewsPopover()).toBeHidden();
+  }
+
+  async validateViewTabActive(viewName: string) {
+    await expect(this.fleetViewTabsTrigger()).toContainText(viewName);
+  }
+
+  async clickViewTab(viewName: string) {
+    await this.openViewsPopover();
+    await this.viewRow(viewName).click();
+  }
+
+  async clickResetViewAction(viewName: string) {
+    await this.validateViewTabActive(viewName);
+    await this.openKebabPopover();
+    await this.page.getByTestId("fleet-view-tabs-reset-action").click();
+  }
+
+  async clickUpdateViewAction(viewName: string) {
+    await this.validateViewTabActive(viewName);
+    await this.openKebabPopover();
+    await this.page.getByTestId("fleet-view-tabs-update-action").click();
+  }
+
+  async clickRenameViewAction(viewName: string) {
+    await this.validateViewTabActive(viewName);
+    await this.openKebabPopover();
+    await this.page.getByTestId("fleet-view-tabs-rename-action").click();
+  }
+
+  async clickDeleteViewAction(viewName: string) {
+    await this.validateViewTabActive(viewName);
+    await this.openKebabPopover();
+    await this.page.getByTestId("fleet-view-tabs-delete-action").click();
+  }
+
+  async validateViewTabNotVisible(viewName: string) {
+    const trigger = this.fleetViewTabsTrigger();
+    if (await trigger.isVisible().catch(() => false)) {
+      await expect(trigger).not.toContainText(viewName);
+      await trigger.click();
+      const popover = this.viewsPopover();
+      if (await popover.isVisible().catch(() => false)) {
+        await expect(this.viewRow(viewName)).toHaveCount(0);
+        await trigger.click();
+        await expect(popover).toBeHidden();
+      }
+      return;
+    }
+
+    await expect(this.viewsEmptyStateNewButton()).toBeVisible();
+  }
+
+  async validateDeleteViewDialogOpened(viewName: string) {
+    const dialog = this.page.getByTestId("fleet-view-tabs-delete-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(`Delete the view "${viewName}"? This can't be undone.`);
+  }
+
+  async confirmDeleteView() {
+    const dialog = this.page.getByTestId("fleet-view-tabs-delete-dialog");
+    await dialog.getByRole("button", { name: "Delete", exact: true }).click();
+    await expect(dialog).toBeHidden();
   }
 
   async validateLoggedIn(timeout: number = DEFAULT_TIMEOUT) {
@@ -313,5 +448,74 @@ export class BasePage {
     } finally {
       this.page.setDefaultTimeout(originalTimeout);
     }
+  }
+
+  private activeFilterEditButton(filterLabel: string): Locator {
+    return this.page
+      .locator('button[data-testid^="active-filter-"][data-testid$="-edit"]')
+      .filter({ hasText: filterLabel });
+  }
+
+  private fleetViewTabsContainer(): Locator {
+    return this.page.getByTestId(this.isMobile ? "fleet-view-tabs-mobile" : "fleet-view-tabs-desktop");
+  }
+
+  private fleetViewTabsTrigger(): Locator {
+    return this.fleetViewTabsContainer().getByTestId("fleet-view-tabs-trigger");
+  }
+
+  private viewsEmptyStateNewButton(): Locator {
+    return this.fleetViewTabsContainer().getByTestId("fleet-view-tabs-new-view-button");
+  }
+
+  private viewsPopover(): Locator {
+    return this.page.getByTestId("fleet-view-tabs-views-popover");
+  }
+
+  private kebabButton(): Locator {
+    return this.fleetViewTabsContainer().getByTestId("fleet-view-tabs-kebab");
+  }
+
+  private kebabPopover(): Locator {
+    return this.page.getByTestId("fleet-view-tabs-kebab-popover");
+  }
+
+  private viewRow(viewName: string): Locator {
+    return this.viewsPopover().locator('[data-testid^="fleet-view-row-"]').filter({ hasText: viewName });
+  }
+
+  private async openViewsPopover() {
+    await this.fleetViewTabsTrigger().click();
+    await expect(this.viewsPopover()).toBeVisible();
+  }
+
+  private async openKebabPopover() {
+    await this.kebabButton().click();
+    await expect(this.kebabPopover()).toBeVisible();
+  }
+
+  private async visibleTestIdLocator(testId: string): Promise<Locator> {
+    const matches = this.page.getByTestId(testId);
+    const count = await matches.count();
+    let visibleMatch: Locator | null = null;
+
+    for (let i = 0; i < count; i++) {
+      const candidate = matches.nth(i);
+      if (!(await candidate.isVisible().catch(() => false))) {
+        continue;
+      }
+
+      if (visibleMatch) {
+        throw new Error(`Expected a single visible ${testId} locator, but found multiple visible matches.`);
+      }
+
+      visibleMatch = candidate;
+    }
+
+    if (!visibleMatch) {
+      throw new Error(`Could not find a visible locator for test id "${testId}".`);
+    }
+
+    return visibleMatch;
   }
 }

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -30,12 +30,32 @@ export class BasePage {
   }
 
   async clearActiveFilter(filterValue: string) {
-    const clearButton = await this.visibleTestIdLocator(`active-filter-${filterValue}-clear`);
-    await clearButton.evaluate((element) => {
-      const target = element as HTMLElement;
-      target.scrollIntoView({ block: "center", inline: "center" });
-      target.click();
-    });
+    if (!this.isMobile) {
+      const clearButton = await this.visibleTestIdLocator(`active-filter-${filterValue}-clear`);
+      await clearButton.scrollIntoViewIfNeeded();
+      await clearButton.click();
+      return;
+    }
+
+    const editButton = await this.visibleTestIdLocator(`active-filter-${filterValue}-edit`);
+    await editButton.click();
+
+    const popover = this.page.getByTestId("dropdown-filter-popover");
+    await expect(popover).toBeVisible();
+
+    const options = popover.locator('[data-testid^="filter-option-"]');
+    const count = await options.count();
+
+    for (let i = 0; i < count; i++) {
+      const option = options.nth(i);
+      const checkbox = option.locator('input[type="checkbox"]');
+      if (await checkbox.isChecked().catch(() => false)) {
+        await option.click();
+      }
+    }
+
+    await this.page.mouse.click(1, 1);
+    await expect(popover).toBeHidden();
   }
 
   async clickNewSavedViewButton() {
@@ -496,26 +516,35 @@ export class BasePage {
 
   private async visibleTestIdLocator(testId: string): Promise<Locator> {
     const matches = this.page.getByTestId(testId);
-    const count = await matches.count();
-    let visibleMatch: Locator | null = null;
+    let visibleIndex = -1;
 
-    for (let i = 0; i < count; i++) {
-      const candidate = matches.nth(i);
-      if (!(await candidate.isVisible().catch(() => false))) {
-        continue;
-      }
+    await expect
+      .poll(
+        async () => {
+          const count = await matches.count();
+          const visibleIndexes: number[] = [];
 
-      if (visibleMatch) {
-        throw new Error(`Expected a single visible ${testId} locator, but found multiple visible matches.`);
-      }
+          for (let i = 0; i < count; i++) {
+            const candidate = matches.nth(i);
+            if (await candidate.isVisible().catch(() => false)) {
+              visibleIndexes.push(i);
+            }
+          }
 
-      visibleMatch = candidate;
-    }
+          if (visibleIndexes.length === 1) {
+            [visibleIndex] = visibleIndexes;
+            return `single:${visibleIndex}`;
+          }
 
-    if (!visibleMatch) {
-      throw new Error(`Could not find a visible locator for test id "${testId}".`);
-    }
+          return visibleIndexes.length === 0 ? "none" : `multiple:${visibleIndexes.join(",")}`;
+        },
+        {
+          timeout: DEFAULT_TIMEOUT,
+          message: `Expected a single visible locator for test id "${testId}".`,
+        },
+      )
+      .toMatch(/^single:\d+$/);
 
-    return visibleMatch;
+    return matches.nth(visibleIndex);
   }
 }

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -371,11 +371,41 @@ export class FleetLocationsPage extends BasePage {
     },
   ) {
     await this.navigateToBuildingsPage();
+    await this.validateCurrentBuildingRowCounts(buildingName, expected);
+  }
+
+  async validateCurrentBuildingRowCounts(
+    buildingName: string,
+    expected: {
+      siteName: string;
+      racks: number;
+      miners: number;
+    },
+  ) {
     const row = this.getListRowByName(buildingName);
     await expect(row).toBeVisible();
     await expect(row.getByTestId("site")).toHaveText(expected.siteName);
     await expect(row.getByTestId("racks")).toHaveText(String(expected.racks));
     await expect(row.getByTestId("miners")).toHaveText(String(expected.miners));
+  }
+
+  async openBuildingsForSite(siteName: string): Promise<bigint> {
+    await this.navigateToSitesPage();
+    const siteId = await this.getScopeIdFromRowName(siteName, "site");
+    await this.openRowActions(siteName);
+    await this.clickRowAction("View buildings");
+    await expect(this.page).toHaveURL(new RegExp(`/fleet/buildings\\?site=${siteId.toString()}(?:[&#].*)?$`));
+    await expect(this.page.getByTestId("fleet-buildings-page")).toBeVisible();
+    return siteId;
+  }
+
+  async openRacksForBuilding(buildingName: string): Promise<bigint> {
+    await this.navigateToBuildingsPage();
+    const buildingId = await this.getScopeIdFromRowName(buildingName, "building");
+    await this.openRowActions(buildingName);
+    await this.clickRowAction("View racks");
+    await expect(this.page).toHaveURL(new RegExp(`/fleet/racks\\?building=${buildingId.toString()}(?:[&#].*)?$`));
+    return buildingId;
   }
 
   private getListRowByName(name: string) {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -1132,35 +1132,6 @@ export class MinersPage extends BasePage {
     await this.validateTemperatureUnit("°C");
   }
 
-  async validateActiveFilter(filterLabel: string) {
-    // Match the chip's editable summary button only — the outer chip wrapper also carries
-    // an `active-filter-*` testid, which would otherwise resolve two elements with the
-    // same text and trip Playwright's strict mode.
-    const activeFilterButton = this.page.locator('button[data-testid^="active-filter-"][data-testid$="-edit"]', {
-      hasText: filterLabel,
-    });
-    await expect(activeFilterButton).toBeVisible();
-  }
-
-  async validateActiveFilterSummary(filterValue: string, expectedSummary: string) {
-    await expect(this.page.getByTestId(`active-filter-${filterValue}-edit`)).toHaveText(expectedSummary);
-  }
-
-  async validateActiveFilterNotVisible(filterLabel: string) {
-    const activeFilterButton = this.page.locator('button[data-testid^="active-filter-"][data-testid$="-edit"]', {
-      hasText: filterLabel,
-    });
-    await expect(activeFilterButton).toHaveCount(0);
-  }
-
-  async clickClearAllFilters() {
-    await this.page.getByRole("button", { name: "Clear all filters", exact: true }).click();
-  }
-
-  async clearActiveFilter(filterValue: string) {
-    await this.page.getByTestId(`active-filter-${filterValue}-clear`).click();
-  }
-
   async validateNoResultsEmptyState() {
     await this.page.getByText("No results", { exact: true }).waitFor();
     await expect(this.page.getByText("No results", { exact: true })).toBeVisible();
@@ -1246,29 +1217,6 @@ export class MinersPage extends BasePage {
     await this.clickButton("Get started");
   }
 
-  // FleetViewTabs is mounted twice (mobile and desktop layout slots); only one
-  // is interactive at a time. Filter to `:visible` so locators don't trip
-  // Playwright strict mode by matching both copies.
-  private viewsTrigger(): Locator {
-    return this.page.locator('[data-testid="fleet-view-tabs-trigger"]:visible');
-  }
-
-  private viewsEmptyStateNewButton(): Locator {
-    return this.page.locator('[data-testid="fleet-view-tabs-new-view-button"]:visible');
-  }
-
-  private viewsPopover(): Locator {
-    return this.page.getByTestId("fleet-view-tabs-views-popover");
-  }
-
-  private kebabButton(): Locator {
-    return this.page.locator('[data-testid="fleet-view-tabs-kebab"]:visible');
-  }
-
-  private kebabPopover(): Locator {
-    return this.page.getByTestId("fleet-view-tabs-kebab-popover");
-  }
-
   private bulkWorkerNameSaveButton(): Locator {
     return this.page.getByTestId(
       this.isMobile ? "bulk-worker-name-save-button-mobile" : "bulk-worker-name-save-button",
@@ -1277,136 +1225,6 @@ export class MinersPage extends BasePage {
 
   private bulkRenameSaveButton(): Locator {
     return this.page.getByTestId(this.isMobile ? "bulk-rename-save-button-mobile" : "bulk-rename-save-button");
-  }
-
-  private async openViewsPopover() {
-    const trigger = this.viewsTrigger();
-    await trigger.click();
-    await expect(this.viewsPopover()).toBeVisible();
-  }
-
-  private async openKebabPopover() {
-    await this.kebabButton().click();
-    await expect(this.kebabPopover()).toBeVisible();
-  }
-
-  async clickNewSavedViewButton() {
-    // Empty state (no saved views yet) renders the "+ New view" trigger
-    // directly; with views present it lives inside the dropdown popover.
-    const emptyState = this.viewsEmptyStateNewButton();
-    if (await emptyState.isVisible().catch(() => false)) {
-      await emptyState.click();
-      return;
-    }
-    await this.openViewsPopover();
-    await this.page.getByTestId("fleet-view-tabs-popover-new-view").click();
-  }
-
-  async clickClearActiveView() {
-    await this.openViewsPopover();
-    await this.page.getByTestId("fleet-view-tabs-popover-clear-view").click();
-  }
-
-  async validateViewModalOpened(title: "New view" | "Update view" | "Rename view") {
-    const modal = this.page.getByTestId("view-modal");
-    await expect(modal).toBeVisible();
-    await expect(modal).toContainText(title);
-  }
-
-  async inputViewName(name: string) {
-    await this.page.locator("#view-name").fill(name);
-  }
-
-  async saveNewView() {
-    await this.page.getByTestId("view-modal").getByRole("button", { name: "Save", exact: true }).click();
-    await expect(this.page.getByTestId("view-modal")).toBeHidden();
-  }
-
-  async updateSavedView() {
-    await this.page.getByTestId("view-modal").getByRole("button", { name: "Update", exact: true }).click();
-    await expect(this.page.getByTestId("view-modal")).toBeHidden();
-  }
-
-  async confirmRenameView() {
-    await this.page.getByTestId("view-modal").getByRole("button", { name: "Rename", exact: true }).click();
-    await expect(this.page.getByTestId("view-modal")).toBeHidden();
-  }
-
-  private viewRow(viewName: string): Locator {
-    return this.viewsPopover().locator('[data-testid^="fleet-view-row-"]').filter({ hasText: viewName });
-  }
-
-  async validateViewTabVisible(viewName: string) {
-    await this.openViewsPopover();
-    await expect(this.viewRow(viewName)).toBeVisible();
-    // Close the popover so subsequent helpers start from a clean state.
-    await this.viewsTrigger().click();
-    await expect(this.viewsPopover()).toBeHidden();
-  }
-
-  async validateViewTabActive(viewName: string) {
-    // When a view is active the trigger label is the view's name.
-    await expect(this.viewsTrigger()).toContainText(viewName);
-  }
-
-  async clickViewTab(viewName: string) {
-    await this.openViewsPopover();
-    await this.viewRow(viewName).click();
-  }
-
-  async clickResetViewAction(viewName: string) {
-    await this.validateViewTabActive(viewName);
-    await this.openKebabPopover();
-    await this.page.getByTestId("fleet-view-tabs-reset-action").click();
-  }
-
-  async clickUpdateViewAction(viewName: string) {
-    await this.validateViewTabActive(viewName);
-    await this.openKebabPopover();
-    await this.page.getByTestId("fleet-view-tabs-update-action").click();
-  }
-
-  async clickRenameViewAction(viewName: string) {
-    await this.validateViewTabActive(viewName);
-    await this.openKebabPopover();
-    await this.page.getByTestId("fleet-view-tabs-rename-action").click();
-  }
-
-  async clickDeleteViewAction(viewName: string) {
-    await this.validateViewTabActive(viewName);
-    await this.openKebabPopover();
-    await this.page.getByTestId("fleet-view-tabs-delete-action").click();
-  }
-
-  async validateViewTabNotVisible(viewName: string) {
-    // After deleting the last (or only) view, the trigger collapses to the
-    // empty-state "+ New view" button; otherwise the trigger remains but the
-    // popover no longer lists this view.
-    const trigger = this.viewsTrigger();
-    if (await trigger.isVisible().catch(() => false)) {
-      await expect(trigger).not.toContainText(viewName);
-      await trigger.click();
-      const popover = this.viewsPopover();
-      if (await popover.isVisible().catch(() => false)) {
-        await expect(this.viewRow(viewName)).toHaveCount(0);
-        await trigger.click();
-        await expect(popover).toBeHidden();
-      }
-      return;
-    }
-    await expect(this.viewsEmptyStateNewButton()).toBeVisible();
-  }
-
-  async validateDeleteViewDialogOpened(viewName: string) {
-    const dialog = this.page.getByTestId("fleet-view-tabs-delete-dialog");
-    await expect(dialog).toBeVisible();
-    await expect(dialog).toContainText(`Delete the view "${viewName}"? This can't be undone.`);
-  }
-
-  async confirmDeleteView() {
-    const dialog = this.page.getByTestId("fleet-view-tabs-delete-dialog");
-    await dialog.getByRole("button", { name: "Delete", exact: true }).click();
-    await expect(dialog).toBeHidden();
   }
 
   async clickMinerElementByTestId(ipAddress: string, testId: string) {

--- a/client/e2eTests/protoFleet/spec/fleetSavedViews.spec.ts
+++ b/client/e2eTests/protoFleet/spec/fleetSavedViews.spec.ts
@@ -1,0 +1,147 @@
+import { test } from "../fixtures/pageFixtures";
+import {
+  AUTOMATION_BUILDINGS_ZONE,
+  createBuildingsScenarioData,
+  setupRackAssignedToBuilding,
+  useBuildingsHooks,
+} from "../helpers/buildingsTestSetup";
+import { generateRandomText } from "../helpers/testDataHelper";
+
+test.describe("Proto Fleet - Fleet saved views", () => {
+  useBuildingsHooks();
+
+  test("Buildings saved view restores the site-filtered fleet view", async ({
+    page,
+    fleetLocationsPage,
+    racksPage,
+  }) => {
+    const scenario = createBuildingsScenarioData();
+    const viewName = generateRandomText("buildings_view");
+
+    await setupRackAssignedToBuilding(page, fleetLocationsPage, racksPage, scenario);
+
+    let siteId = 0n;
+
+    await test.step("Open the buildings tab from the site row and save the filtered view", async () => {
+      siteId = await fleetLocationsPage.openBuildingsForSite(scenario.siteName);
+
+      await fleetLocationsPage.validateCurrentBuildingRowCounts(scenario.buildingName, {
+        siteName: scenario.siteName,
+        racks: 1,
+        miners: 2,
+      });
+
+      let searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("site")).toEqual([siteId.toString()]);
+
+      await fleetLocationsPage.clickNewSavedViewButton();
+      await fleetLocationsPage.validateViewModalOpened("New view");
+      await fleetLocationsPage.inputViewName(viewName);
+      await fleetLocationsPage.saveNewView();
+      await fleetLocationsPage.validateViewTabActive(viewName);
+    });
+
+    await test.step("Clear the site filter so the saved view becomes dirty", async () => {
+      await fleetLocationsPage.clearActiveFilter("site");
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("site")).toEqual([]);
+      test.expect(searchParams.get("view")).not.toBeNull();
+    });
+
+    await test.step("Reset and then delete the saved view", async () => {
+      await fleetLocationsPage.clickResetViewAction(viewName);
+      await fleetLocationsPage.validateViewTabActive(viewName);
+      await fleetLocationsPage.validateCurrentBuildingRowCounts(scenario.buildingName, {
+        siteName: scenario.siteName,
+        racks: 1,
+        miners: 2,
+      });
+
+      let searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("site")).toEqual([siteId.toString()]);
+
+      await fleetLocationsPage.clickDeleteViewAction(viewName);
+      await fleetLocationsPage.validateDeleteViewDialogOpened(viewName);
+      await fleetLocationsPage.confirmDeleteView();
+      await fleetLocationsPage.validateViewTabNotVisible(viewName);
+
+      searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.get("view")).toBeNull();
+      test.expect(searchParams.getAll("site")).toEqual([siteId.toString()]);
+    });
+  });
+
+  test("Racks saved view restores the building filter and display mode", async ({
+    page,
+    fleetLocationsPage,
+    racksPage,
+  }) => {
+    const scenario = createBuildingsScenarioData();
+    const viewName = generateRandomText("racks_view");
+
+    const { buildingId } = await setupRackAssignedToBuilding(page, fleetLocationsPage, racksPage, scenario);
+
+    await test.step("Open the racks tab from the building row and save a grid view", async () => {
+      const openedBuildingId = await fleetLocationsPage.openRacksForBuilding(scenario.buildingName);
+      test.expect(openedBuildingId).toBe(buildingId);
+
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+      await racksPage.clickViewGrid();
+      await racksPage.validateRackCardVisible(scenario.rackLabel, AUTOMATION_BUILDINGS_ZONE);
+
+      let searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("building")).toEqual([buildingId.toString()]);
+      test.expect(searchParams.get("display")).toBe("grid");
+
+      await racksPage.clickNewSavedViewButton();
+      await racksPage.validateViewModalOpened("New view");
+      await racksPage.inputViewName(viewName);
+      await racksPage.saveNewView();
+      await racksPage.validateViewTabActive(viewName);
+    });
+
+    await test.step("Change to list view and clear the building filter", async () => {
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+      await racksPage.clearActiveFilter("building");
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+
+      await racksPage.validateRackPlacementRow(scenario.rackLabel, scenario.siteName, scenario.buildingName);
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("building")).toEqual([]);
+      test.expect(searchParams.get("display")).toBe("list");
+      test.expect(searchParams.get("view")).not.toBeNull();
+    });
+
+    await test.step("Reset the saved view back to the building-scoped grid state", async () => {
+      await racksPage.clickResetViewAction(viewName);
+      await racksPage.validateViewTabActive(viewName);
+      await racksPage.validateRackCardVisible(scenario.rackLabel, AUTOMATION_BUILDINGS_ZONE);
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("building")).toEqual([buildingId.toString()]);
+      test.expect(searchParams.get("display")).toBe("grid");
+    });
+
+    await test.step("Clear the active view, then reopen it from the saved views menu", async () => {
+      await racksPage.reloadPage();
+      await racksPage.validateRackCardVisible(scenario.rackLabel, AUTOMATION_BUILDINGS_ZONE);
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+      await racksPage.clearActiveFilter("building");
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+      await racksPage.clickClearActiveView();
+      await racksPage.clickViewTab(viewName);
+
+      await racksPage.validateViewTabActive(viewName);
+      await racksPage.validateRackCardVisible(scenario.rackLabel, AUTOMATION_BUILDINGS_ZONE);
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("building")).toEqual([buildingId.toString()]);
+      test.expect(searchParams.get("display")).toBe("grid");
+      test.expect(searchParams.get("view")).not.toBeNull();
+    });
+  });
+});

--- a/client/e2eTests/protoFleet/spec/fleetSavedViews.spec.ts
+++ b/client/e2eTests/protoFleet/spec/fleetSavedViews.spec.ts
@@ -143,5 +143,17 @@ test.describe("Proto Fleet - Fleet saved views", () => {
       test.expect(searchParams.get("display")).toBe("grid");
       test.expect(searchParams.get("view")).not.toBeNull();
     });
+
+    await test.step("Delete the saved view to leave the fleet state clean", async () => {
+      await racksPage.clickDeleteViewAction(viewName);
+      await racksPage.validateDeleteViewDialogOpened(viewName);
+      await racksPage.confirmDeleteView();
+      await racksPage.validateViewTabNotVisible(viewName);
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("building")).toEqual([buildingId.toString()]);
+      test.expect(searchParams.get("display")).toBe("grid");
+      test.expect(searchParams.get("view")).toBeNull();
+    });
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
@@ -296,7 +296,9 @@ const FleetLayout = () => {
       >
         <div className="flex items-baseline justify-between gap-4">
           <h1 className="text-heading-300 text-text-primary">Fleet</h1>
-          <div className="laptop:hidden">{viewTabs}</div>
+          <div className="laptop:hidden" data-testid="fleet-view-tabs-mobile">
+            {viewTabs}
+          </div>
         </div>
         {canReadMiners ? (
           <CompleteSetup
@@ -309,7 +311,11 @@ const FleetLayout = () => {
           activeId={currentTab}
           onSelect={onSelect}
           ariaLabel="Fleet sections"
-          trailing={<div className="hidden pb-2 laptop:block">{viewTabs}</div>}
+          trailing={
+            <div className="hidden pb-2 laptop:block" data-testid="fleet-view-tabs-desktop">
+              {viewTabs}
+            </div>
+          }
         >
           {visibleTabs.map((tab) => (
             <TabStripItem key={tab} id={tab} label={tabLabel[tab]} testId={`fleet-tab-${tab}`} />


### PR DESCRIPTION
Reviewable diff: +8/-2 across 1 files (excludes generated, test, and story files).

## Summary

Adds ProtoFleet E2E coverage for fleet saved views on the Buildings and Racks tabs, using the existing buildings setup flow to create deterministic fleet data and then verifying that saved views restore the expected scoped state.

The product change is intentionally small: Fleet view tabs now expose stable desktop and mobile wrapper test ids so the shared Playwright helpers can target the active control without relying on brittle visibility selectors.

## How it works

The new spec creates a site, building, rack, and assigned miners through the existing E2E setup helpers, then navigates into Buildings and Racks through row actions so the URL-scoped filters match a real user flow. From there, the test saves views, dirties them by changing filters or display mode, and verifies that reset and reopen actions restore the expected Fleet state.

To keep the scenario readable, the saved-view and active-filter interactions now live in `BasePage`, where they handle the Fleet view tabs UI for both desktop and mobile. The Fleet layout exposes stable wrapper test ids for the mobile and desktop view-tab slots, and the new page-object helpers scope actions to the visible slot before opening view menus, resetting views, or clearing active filters.

## Diagrams

```mermaid
flowchart TD
  A["Create site, building, rack, and miners"] --> B["Open Buildings or Racks from row actions"]
  B --> C["Save current filtered view"]
  C --> D["Dirty the view by changing filters or display mode"]
  D --> E["Reset or reopen the saved view"]
  E --> F["Assert URL params and Fleet content are restored"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/fleetSavedViews.spec.ts` | Adds Buildings and Racks saved-view scenarios | Main user-flow coverage and assertions |
| `client/e2eTests/protoFleet/pages/base.ts` | Centralizes saved-view and active-filter helpers | Shared selector strategy and mobile/desktop behavior |
| `client/e2eTests/protoFleet/pages/miners.ts` | Removes duplicated saved-view and filter helpers | Confirms the shared helpers replace existing one-off logic cleanly |
| `client/e2eTests/protoFleet/pages/fleetLocations.ts` | Adds helpers for opening scoped Buildings/Racks views and validating current rows | Keeps the spec readable and aligned with Fleet navigation flows |
| `client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts` | Exposes a reusable rack-assigned-to-building setup helper | Reuses existing scenario setup instead of duplicating it in the spec |
| `client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx` | Adds stable view-tab wrapper test ids | The only product change; enables deterministic selectors across responsive layouts |

## Key technical decisions & trade-offs

- Add wrapper `data-testid`s around the mobile and desktop Fleet view-tab mounts instead of relying on `.first()` or `:visible`, because the UI intentionally mounts both layouts and tests need a stable way to scope to the interactive one.
- Reuse the existing buildings setup flow and extract a small shared setup helper instead of embedding multi-step provisioning logic in the new spec, because the spec reads better when it focuses on the saved-view behavior.
- Validate restored URL params and user-visible Fleet content instead of over-asserting transient chip state, because the regression risk is whether the saved view restores the underlying scoped page state.

## Testing & validation

- `./node_modules/.bin/eslint e2eTests/protoFleet/helpers/buildingsTestSetup.ts e2eTests/protoFleet/pages/base.ts e2eTests/protoFleet/pages/fleetLocations.ts e2eTests/protoFleet/pages/miners.ts e2eTests/protoFleet/spec/fleetSavedViews.spec.ts src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx`
- `PW_UI_NO_DEPS=1 ../../node_modules/.bin/playwright test spec/fleetSavedViews.spec.ts --project=desktop`
- `PW_UI_NO_DEPS=1 ../../node_modules/.bin/playwright test spec/fleetSavedViews.spec.ts --project=mobile`

Not covered here: creating saved views on the Sites or Miners tabs, or more advanced filter combinations beyond the Buildings and Racks flows added in this PR.
