### PR TITLE
fix(fleet): stop empty states from overflowing narrow viewports

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import clsx from "clsx";
 
 import BuildingList from "../components/BuildingList";
 import FilterRow from "../components/FilterRow";
@@ -18,6 +19,7 @@ import {
   useActiveSite,
 } from "@/protoFleet/components/PageHeader/SitePicker";
 import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
+import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import BuildingModals from "@/protoFleet/features/buildings/components/BuildingModals";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
@@ -540,6 +542,7 @@ const FleetBuildingsPage = () => {
       <>
         {inlineErrors}
         <NullState
+          className={clsx("sticky left-0", PAGE_SCROLL_CHROME_WIDTH)}
           icon={<Building width="w-5" />}
           title="No buildings yet"
           description={

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetSitesPage.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import clsx from "clsx";
 
 import FilterRow from "../components/FilterRow";
 import FleetGroupListActionBar from "../components/FleetGroupActionsMenu/FleetGroupListActionBar";
@@ -10,6 +11,7 @@ import { issueOptions } from "@/protoFleet/components/DeviceSetList";
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
 import NullState from "@/protoFleet/components/NullState";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
+import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import {
   FILTER_URL_PARAM_KEYS,
@@ -340,6 +342,7 @@ const FleetSitesPage = () => {
       <>
         {inlineError}
         <NullState
+          className={clsx("sticky left-0", PAGE_SCROLL_CHROME_WIDTH)}
           icon={<Site width="w-5" />}
           title="No sites yet"
           description="Create your first site to organize miners by location."

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -1103,6 +1103,7 @@ const RacksPage = () => {
     return (
       <>
         <NullState
+          className={clsx("sticky left-0", PAGE_SCROLL_CHROME_WIDTH)}
           icon={<Racks width="w-5" />}
           title="You haven't set up any racks"
           description="Add a rack and assign miners to rack positions to get started."

--- a/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupsPage.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import clsx from "clsx";
 
 import type { DeviceSet } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
@@ -12,6 +13,7 @@ import {
 import NoFilterResultsEmptyState from "@/protoFleet/components/NoFilterResultsEmptyState";
 import NullState from "@/protoFleet/components/NullState";
 import { type SiteFilterFields, siteFilterFromActive } from "@/protoFleet/components/PageHeader/SitePicker";
+import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import { useOptionalFleetOutletContext } from "@/protoFleet/features/fleetManagement/components/FleetLayout/outletContext";
 import {
   FILTER_URL_PARAM_KEYS,
@@ -260,6 +262,7 @@ const GroupsPage = () => {
     <>
       {!hasGroups ? (
         <NullState
+          className={clsx("sticky left-0", PAGE_SCROLL_CHROME_WIDTH)}
           icon={<Groups width="w-5" />}
           title="Groups"
           description="Organize your miners into groups."


### PR DESCRIPTION
## Problem

On narrow (phone) viewports, the Fleet no-data screens (Sites, Buildings, Racks, Groups empty states) render wider than the viewport, causing horizontal page scroll — the whole page, including the header, pans sideways. It reads as "mobile-Safari-only" because that's the only place the app is browsed at ~375px; desktop is wide enough to hide it.

## Root cause

FleetLayout wraps its content in a `w-max min-w-full` subtree ([FleetLayout.tsx](../blob/main/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx)) so wide tables can scroll horizontally within the shell's single both-axes scroll container. Inside a `max-content` box, **text is measured unwrapped**, so a bare `NullState`'s description string plus its padding sized the subtree wider than a phone viewport.

Measured in an isolated repro at 375px: subtree = **387px → overflow**. Pinning the null state to the viewport width so its text wraps: subtree = **375px → no overflow**.

The codebase already solves this for the *filtered*-empty states via [`FilterRow`](../blob/main/client/src/protoFleet/features/fleetManagement/components/FilterRow/FilterRow.tsx) (`sticky left-0` + `PAGE_SCROLL_CHROME_WIDTH`). The bare "no data at all" `NullState` branches just never got that chrome.

## Fix

Pass the same chrome (`sticky left-0` + `PAGE_SCROLL_CHROME_WIDTH`) to the four bare `NullState` branches via the `className` prop it already forwards to its root element. No shared-component change, no double-padding, consistent with `FilterRow`.

- FleetSitesPage — "No sites yet"
- FleetBuildingsPage — "No buildings yet"
- RacksPage — "You haven't set up any racks"
- GroupsPage — "Groups"

## Out of scope (audited, safe as-is)

The unwrapped `NoFilterResultsEmptyState` uses in RacksPage/GroupsPage render *inside* the table via the `emptyStateRow` prop, are `w-full` with short text, and are width-constrained by the table — not a `max-content` leak.

## Testing

- `tsc --noEmit` ✅
- `eslint --max-warnings 0` on changed files ✅
- Mechanism + fix confirmed with an isolated 375px repro (387px → 375px)