### PR TITLE
fix(rack): stop rack-settings field row from overflowing on phones

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -372,7 +372,7 @@ const RackSettingsModal = ({
             />
           ) : null}
 
-          <div className="flex gap-3">
+          <div className="grid grid-cols-2 gap-3 tablet:grid-cols-3">
             <div className="flex-1">
               <Input
                 id="rack-columns"


### PR DESCRIPTION
## Problem

On a phone, opening **Rack settings** (create/edit rack) renders the modal wider than the viewport — the sheet pans sideways, clipping the close button and title. Pre-existing on `main`; surfaced while testing on mobile Safari.

## Root cause

The Columns / Rows / Order index fields were laid out three-across with `flex gap-3`. On a phone-width sheet the three fields can't shrink to fit — WebKit in particular refuses to shrink flex items below their intrinsic size — so the row pushes the whole sheet wider than the viewport.

Reproduced in Storybook (Blink) at 320px: the field row overflowed its container by ~18px per column. On real mobile Safari it shows at normal phone widths (~390px) because WebKit's flex min-sizing is stricter than Blink's.

## Fix

`RackSettingsModal.tsx` — swap the 3-across `flex` row for a responsive grid:

```
grid grid-cols-2 gap-3 tablet:grid-cols-3
```

Columns|Rows paired with Order index below on phones; three-across from tablet up, where the modal is wide enough.

## Testing

- Reproduced + verified fix in Storybook (`RackSettingsModal/Create New`) at 375px and 320px → 0 horizontal scrollers, `documentElement.scrollWidth == viewport`.
- `tsc --noEmit` ✅, `eslint --max-warnings 0` ✅
- Visual check at 390px: clean bottom sheet, nothing clipped.

## Note

A second, separate mobile overflow (the fullscreen rack modal's header clipping the Save button — a WebKit-only issue likely in the shared `Header`) is still being confirmed and is **not** part of this PR.