### PR TITLE
fix(server): align telemetry chunk windows

### DIFF
--- a/server/migrations/000111_align_hot_telemetry_chunks.down.sql
+++ b/server/migrations/000111_align_hot_telemetry_chunks.down.sql
@@ -1,0 +1,10 @@
+SELECT set_chunk_time_interval('device_metrics', INTERVAL '1 day');
+SELECT set_chunk_time_interval('miner_state_snapshots', INTERVAL '1 day');
+
+SELECT remove_compression_policy('device_metrics', if_exists => true);
+SELECT add_compression_policy('device_metrics', INTERVAL '6 hours',
+    schedule_interval => INTERVAL '1 hour');
+
+SELECT remove_compression_policy('miner_state_snapshots', if_exists => true);
+SELECT add_compression_policy('miner_state_snapshots', INTERVAL '6 hours',
+    schedule_interval => INTERVAL '1 hour');

--- a/server/migrations/000111_align_hot_telemetry_chunks.up.sql
+++ b/server/migrations/000111_align_hot_telemetry_chunks.up.sql
@@ -1,0 +1,16 @@
+-- Bound the uncompressed hot set for high-cardinality telemetry ingest.
+--
+-- Timescale compression policies evaluate chunk end time, not row time. With a
+-- 1-day chunk and compress_after=6h, today's chunk is not eligible until roughly
+-- 30 hours after it starts. Smaller chunks let the existing 6h compression
+-- window take effect while preserving ingestion cadence and query semantics.
+SELECT set_chunk_time_interval('device_metrics', INTERVAL '1 hour');
+SELECT set_chunk_time_interval('miner_state_snapshots', INTERVAL '6 hours');
+
+SELECT remove_compression_policy('device_metrics', if_exists => true);
+SELECT add_compression_policy('device_metrics', INTERVAL '6 hours',
+    schedule_interval => INTERVAL '1 hour');
+
+SELECT remove_compression_policy('miner_state_snapshots', if_exists => true);
+SELECT add_compression_policy('miner_state_snapshots', INTERVAL '6 hours',
+    schedule_interval => INTERVAL '1 hour');


### PR DESCRIPTION
Reviewable diff: +26/-0 across 2 files (excludes generated, test, and story files).

## Summary
This PR keeps high-cardinality telemetry ingest from sitting in a full-day uncompressed Timescale chunk before compression can help. It aligns future chunk intervals with the existing six-hour compression policy so large virtual-miner or edge-device deployments can shed hot storage earlier without changing collection cadence, dashboard durations, or aggregate semantics. Existing oversized chunks are not rewritten by this migration; operational cleanup remains a separate recovery step.

## How it works
When the migration runs, future `device_metrics` chunks become one-hour chunks and future `miner_state_snapshots` chunks become six-hour chunks. The compression policies for both hypertables are reinstalled with the current `compress_after => 6 hours` and hourly schedule, so the behavioral change is the chunk boundary that determines when data first becomes eligible for compression. Rolling the migration back restores both hypertables to one-day chunks while keeping the same six-hour compression window.

## Diagrams
```mermaid
flowchart LR
    Writer["Telemetry and state snapshot writers"] --> Metrics["device_metrics future chunks: 1 hour"]
    Writer --> Snapshots["miner_state_snapshots future chunks: 6 hours"]
    Metrics --> Policy["Compression policy: chunk end + 6 hours"]
    Snapshots --> Policy
    Policy --> Storage["Smaller hot set before historical data compresses"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/migrations/000111_align_hot_telemetry_chunks.up.sql` | Adds the forward Timescale policy change for future chunk intervals and reasserts compression policy schedules. | Review the chosen hot-window trade-off: one-hour metric chunks, six-hour snapshot chunks, existing six-hour compression. |
| `server/migrations/000111_align_hot_telemetry_chunks.down.sql` | Restores both hypertables to one-day chunks and reinstalls the same compression policies. | Confirms rollback returns chunk sizing to latest-main behavior without dropping data or changing retention. |

## Key technical decisions & trade-offs
- `device_metrics` uses one-hour chunks rather than one-day chunks to bound the highest-volume heap/index hot set; the trade-off is more chunks and catalog metadata for raw 24h reads.
- `miner_state_snapshots` uses six-hour chunks rather than one-hour chunks because snapshots compressed well in the Pi investigation and do not need the same chunk count as raw metrics.
- Compression timing remains six hours instead of becoming more aggressive, giving hourly continuous aggregate refreshes room to run before chunks become compression candidates.
- The migration only affects future chunks; splitting or compressing already-created oversized chunks is an operational recovery action, not a schema migration side effect.

## Testing & validation
- Ran `just gen`; it completed after bootstrapping the repo-local `packages/proto-python-gen` venv, and no generated diff remained.
- Ran all migrations through `000111` on a throwaway Timescale database.
- Verified migration up produced `device_metrics` chunk interval `01:00:00`, `miner_state_snapshots` chunk interval `06:00:00`, and both compression jobs at `compress_after=06:00:00` with `schedule_interval=01:00:00`.
- Verified `migrate down 1` restored both chunk intervals to `1 day`.
