### PR TITLE
fix(inputs): use 16px font on phones to stop iOS focus-zoom

### DIFF
--- a/client/src/shared/components/DatePicker/DatePickerInput.tsx
+++ b/client/src/shared/components/DatePicker/DatePickerInput.tsx
@@ -89,7 +89,12 @@ const DatePickerInput = ({
   );
 
   const inputClasses = clsx(
-    "w-full rounded-lg border border-border-5 bg-surface-base px-3 py-2 text-300 text-text-primary outline-hidden",
+    // pointer-coarse:text-400 = 16px on touch devices. iOS auto-zooms a focused field whose
+    // font is under 16px and never zooms back out, leaving later views zoomed/overflowing.
+    // It's a WebKit behavior affecting every iOS browser (Safari, Chrome, Brave, ...) at any
+    // width/orientation — so target the coarse pointer, not a width breakpoint (which would
+    // miss landscape phones and iPads); desktop keeps 14px.
+    "w-full rounded-lg border border-border-5 bg-surface-base px-3 py-2 text-300 pointer-coarse:text-400 text-text-primary outline-hidden",
     "transition duration-200 ease-in-out",
     "focus:border-border-20 focus:ring-4 focus:ring-surface-10",
     { "cursor-not-allowed bg-core-primary-5": disabled },

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -183,7 +183,12 @@ const Input = ({
           id={id}
           data-testid={testId}
           className={clsx(
-            "peer w-full rounded-lg text-300 text-text-primary outline-hidden",
+            // pointer-coarse:text-400 = 16px on touch devices. iOS auto-zooms a focused field
+            // whose font is under 16px and never zooms back out, leaving later views
+            // zoomed/overflowing. It's a WebKit behavior affecting every iOS browser (Safari,
+            // Chrome, Brave, ...) at any width/orientation — so target the coarse pointer, not a
+            // width breakpoint (which would miss landscape phones and iPads); desktop keeps 14px.
+            "peer w-full rounded-lg text-300 text-text-primary outline-hidden pointer-coarse:text-400",
             "transition duration-200 ease-in-out",
             { "bg-surface-base": !disabled },
             { "bg-core-primary-5": disabled },

--- a/client/src/shared/components/Textarea/Textarea.tsx
+++ b/client/src/shared/components/Textarea/Textarea.tsx
@@ -119,7 +119,12 @@ const Textarea = ({
           id={id}
           data-testid={testId}
           className={clsx(
-            "peer w-full rounded-lg text-300 text-text-primary outline-hidden",
+            // pointer-coarse:text-400 = 16px on touch devices. iOS auto-zooms a focused field
+            // whose font is under 16px and never zooms back out, leaving later views
+            // zoomed/overflowing. It's a WebKit behavior affecting every iOS browser (Safari,
+            // Chrome, Brave, ...) at any width/orientation — so target the coarse pointer, not a
+            // width breakpoint (which would miss landscape phones and iPads); desktop keeps 14px.
+            "peer w-full rounded-lg text-300 text-text-primary outline-hidden pointer-coarse:text-400",
             "transition duration-200 ease-in-out",
             { "bg-surface-base": !disabled },
             { "bg-core-primary-5": disabled },


### PR DESCRIPTION
## Problem

On mobile Safari, tapping a form field zooms the page in — and iOS never zooms back out — so every view *after* focusing an input is left zoomed and overflowing horizontally. This is the underlying cause behind several "content overflows on mobile Safari" reports (including the rack modals).

## Root cause

iOS auto-zooms when a focused `input`/`textarea`/`select` has a computed `font-size` **under 16px**, to make the small text readable. This is a **WebKit** behavior, and because every browser on iOS is required to use WebKit (App Store rule 2.5.6), it affects **all iOS browsers** — Safari, Chrome, Brave, Firefox, etc. — not Safari alone. It is *not* a Chromium/Blink behavior: Blink on Android and desktop does not focus-zoom.

Crucially, the zoom is driven by the input's font size, **not** the viewport width — so it fires on landscape phones and iPads too, at any width/orientation.

The shared text-entry primitives all rendered at `text-300` (0.875rem = 14px):

- `shared/components/Input/Input.tsx`
- `shared/components/Textarea/Textarea.tsx`
- `shared/components/DatePicker/DatePickerInput.tsx`

## Fix

Add `pointer-coarse:text-400` (16px) to those three inputs. `pointer-coarse` (`@media (pointer: coarse)`) targets **touch devices at any width/orientation** — covering landscape phones and iPads that a width breakpoint would miss — while desktop (fine pointer) keeps the denser 14px. The custom `Select` is div-based (no editable field) and doesn't trigger zoom, so it's unchanged.

16px is the documented threshold; disabling user zoom via the viewport meta (`maximum-scale=1`) is avoided as an accessibility regression.

## Testing

- Verified in Storybook that the variant compiles to `@media (pointer: coarse) { font-size: var(--text-400) }` (16px) on all three inputs; desktop (fine pointer) renders 14px.
- `tsc --noEmit` ✅, `eslint --max-warnings 0` ✅
- Confirmed on-device (iPhone) the zoom reproduces in both Safari and Brave — consistent with the WebKit explanation.

## Relationship to other PRs

Companion to the mobile-overflow fixes (#665 empty states, #667 rack-settings field row). This one addresses the *zoom-driven* overflow specifically and likely resolves the remaining fullscreen rack-modal clipping.