### PR TITLE
[codex] Add fleet filters e2e coverage

### DIFF
--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -182,6 +182,7 @@ export class BasePage {
 
     const [targetLabel] = targetLabels;
     const activeEditButton = await this.findVisibleTestIdLocator(`active-filter-${categoryKey}-edit`);
+    let clearedExistingSelection = false;
     if (activeEditButton) {
       const currentSummary = ((await activeEditButton.textContent()) ?? "").replace(/\s+/g, " ").trim();
       if (currentSummary === targetLabel) {
@@ -189,11 +190,16 @@ export class BasePage {
       }
 
       await this.clearActiveFilter(categoryKey);
+      await this.waitForActiveFilterToClear(categoryKey);
+      clearedExistingSelection = true;
     }
 
     const addFilterPopover = await this.openVisibleAddFilter();
     const submenu = await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
     await this.waitForCheckboxFilterOptions(submenu, categoryKey, targetLabels);
+    if (clearedExistingSelection) {
+      await this.waitForCheckboxFilterSelectionState(submenu, categoryKey, []);
+    }
     const targetOption = (await this.readCheckboxFilterOptionStates(submenu)).find(
       ({ label }) => label === targetLabel,
     );
@@ -265,6 +271,27 @@ export class BasePage {
         },
       )
       .toEqual([]);
+  }
+
+  private async waitForCheckboxFilterSelectionState(
+    container: Locator,
+    categoryKey: string,
+    expectedCheckedLabels: string[],
+  ) {
+    const expected = [...expectedCheckedLabels].sort();
+    await expect
+      .poll(
+        async () =>
+          (await this.readCheckboxFilterOptionStates(container))
+            .filter(({ checked }) => checked)
+            .map(({ label }) => label)
+            .sort(),
+        {
+          timeout: DEFAULT_TIMEOUT,
+          message: `Expected the visible "${categoryKey}" filter selection to be ${expected.join(", ") || "empty"}.`,
+        },
+      )
+      .toEqual(expected);
   }
 
   private async readCheckboxFilterOptionStates(container: Locator) {
@@ -708,6 +735,18 @@ export class BasePage {
     const trigger = await this.getVisibleAddFilterTrigger();
     await trigger.click();
     await expect(popover).toBeHidden();
+  }
+
+  private async waitForActiveFilterToClear(categoryKey: string) {
+    await expect
+      .poll(
+        async () => ((await this.findVisibleTestIdLocator(`active-filter-${categoryKey}-edit`)) ? "visible" : "hidden"),
+        {
+          timeout: DEFAULT_TIMEOUT,
+          message: `Expected active "${categoryKey}" filter chip to clear.`,
+        },
+      )
+      .toBe("hidden");
   }
 
   private async findVisibleTestIdLocator(testId: string): Promise<Locator | null> {

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -192,97 +192,109 @@ export class BasePage {
     }
 
     const addFilterPopover = await this.openVisibleAddFilter();
-    await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
-    const targetOption = (await this.readVisibleCheckboxFilterOptionStates()).find(
+    const submenu = await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
+    await this.waitForCheckboxFilterOptions(submenu, categoryKey, targetLabels);
+    const targetOption = (await this.readCheckboxFilterOptionStates(submenu)).find(
       ({ label }) => label === targetLabel,
     );
     if (!targetOption) {
       throw new Error(`Could not find "${targetLabel}" in the visible "${categoryKey}" filter options.`);
     }
 
-    await (await this.visibleTestIdLocator(`filter-option-${targetOption.id}`)).click();
-
-    const popover = this.page.getByTestId("nested-dropdown-filter-popover");
-    if (await popover.isVisible().catch(() => false)) {
-      await this.dismissNestedAddFilterPopover();
-    }
+    await (await this.visibleContainerTestIdLocator(submenu, `filter-option-${targetOption.id}`)).click();
+    await this.dismissNestedAddFilterPopover();
   }
 
   protected async toggleAllNestedCheckboxFilterOptions(categoryKey: string) {
     const activeEditButton = await this.findVisibleTestIdLocator(`active-filter-${categoryKey}-edit`);
     if (activeEditButton) {
-      const popover = await this.openActiveFilterPopover(categoryKey);
-      await this.toggleVisibleCheckboxFilterOptions();
-      await activeEditButton.click();
-      await expect(popover).toBeHidden();
+      await this.clearActiveFilter(categoryKey);
       return;
     }
 
     const addFilterPopover = await this.openVisibleAddFilter();
-    await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
-    await this.toggleVisibleCheckboxFilterOptions();
+    const submenu = await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
+    await this.toggleVisibleCheckboxFilterOptions(submenu);
     await this.dismissNestedAddFilterPopover();
   }
 
-  private async toggleVisibleCheckboxFilterOptions() {
-    const initialOptions = await this.readVisibleCheckboxFilterOptionStates();
-    if (initialOptions.length === 0) {
+  private async toggleVisibleCheckboxFilterOptions(container: Locator) {
+    const options = container.locator('[data-testid^="filter-option-"]');
+    const count = await options.count();
+    if (count === 0) {
       return;
     }
 
-    const anyChecked = initialOptions.some(({ checked }) => checked);
-
-    while (true) {
-      const visibleOptions = await this.readVisibleCheckboxFilterOptionStates();
-      if (visibleOptions.length === 0) {
-        return;
+    let anyChecked = false;
+    for (let i = 0; i < count; i++) {
+      if (
+        await options
+          .nth(i)
+          .locator('input[type="checkbox"]')
+          .isChecked()
+          .catch(() => false)
+      ) {
+        anyChecked = true;
+        break;
       }
+    }
 
-      const nextOption = visibleOptions.find(({ checked }) => checked === anyChecked);
-      if (!nextOption) {
-        return;
+    for (let i = 0; i < count; i++) {
+      const option = options.nth(i);
+      const isChecked = await option
+        .locator('input[type="checkbox"]')
+        .isChecked()
+        .catch(() => false);
+      if (isChecked === anyChecked) {
+        await option.click();
       }
-
-      await (await this.visibleTestIdLocator(`filter-option-${nextOption.id}`)).click();
     }
   }
 
-  private async readVisibleCheckboxFilterOptionStates() {
-    return await this.page.locator('[data-testid^="filter-option-"]').evaluateAll((elements) =>
-      elements.flatMap((element) => {
-        const option = element as HTMLElement;
-        const rect = option.getBoundingClientRect();
-        const style = window.getComputedStyle(option);
-        const checkVisibility = (
-          option as HTMLElement & {
-            checkVisibility?: (options?: { checkOpacity?: boolean; checkVisibilityCSS?: boolean }) => boolean;
-          }
-        ).checkVisibility;
-        const visible =
-          (typeof checkVisibility === "function"
-            ? checkVisibility.call(option, { checkOpacity: true, checkVisibilityCSS: true })
-            : true) &&
-          rect.width > 0 &&
-          rect.height > 0 &&
-          style.visibility !== "hidden" &&
-          style.display !== "none" &&
-          option.offsetParent !== null &&
-          option.getAttribute("aria-hidden") !== "true";
+  private async waitForCheckboxFilterOptions(container: Locator, categoryKey: string, targetLabels: string[]) {
+    await expect
+      .poll(
+        async () => {
+          const visibleOptions = await this.readCheckboxFilterOptionStates(container);
+          const visibleLabels = new Set(visibleOptions.map(({ label }) => label));
+          return targetLabels.filter((label) => !visibleLabels.has(label));
+        },
+        {
+          timeout: DEFAULT_TIMEOUT,
+          message: `Expected the visible "${categoryKey}" filter options to include: ${targetLabels.join(", ")}.`,
+        },
+      )
+      .toEqual([]);
+  }
 
-        if (!visible) {
-          return [];
-        }
+  private async readCheckboxFilterOptionStates(container: Locator) {
+    const options = container.locator('[data-testid^="filter-option-"]');
+    const count = await options.count();
+    const visibleOptions = new Map<string, { id: string; label: string; checked: boolean }>();
 
-        const checkbox = option.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
-        return [
-          {
-            id: (option.dataset.testid ?? "").replace(/^filter-option-/, ""),
-            label: (option.textContent ?? "").replace(/\s+/g, " ").trim(),
-            checked: checkbox?.checked ?? false,
-          },
-        ];
-      }),
-    );
+    for (let i = 0; i < count; i++) {
+      const option = options.nth(i);
+      if (!(await option.isVisible().catch(() => false))) {
+        continue;
+      }
+
+      const testId = await option.getAttribute("data-testid");
+      if (!testId) {
+        continue;
+      }
+
+      const id = testId.replace(/^filter-option-/, "");
+      visibleOptions.set(id, {
+        id,
+        label: ((await option.textContent()) ?? "").replace(/\s+/g, " ").trim(),
+        checked: await option
+          .locator('input[type="checkbox"]')
+          .isChecked()
+          .catch(() => false),
+      });
+    }
+
+    return [...visibleOptions.values()];
   }
 
   async validateLoggedIn(timeout: number = DEFAULT_TIMEOUT) {
@@ -668,14 +680,6 @@ export class BasePage {
     return popover;
   }
 
-  private async openActiveFilterPopover(categoryKey: string) {
-    const editButton = await this.visibleTestIdLocator(`active-filter-${categoryKey}-edit`);
-    await editButton.click();
-    const popover = this.page.getByTestId("dropdown-filter-popover");
-    await expect(popover).toBeVisible();
-    return popover;
-  }
-
   private async openNestedFilterSubmenu(popover: Locator, categoryKey: string) {
     await popover.getByTestId(`nested-dropdown-filter-row-${categoryKey}`).click();
     const desktopSubmenu = this.page.getByTestId(`nested-dropdown-filter-submenu-${categoryKey}`);
@@ -743,5 +747,24 @@ export class BasePage {
     }
 
     return match;
+  }
+
+  private async visibleContainerTestIdLocator(container: Locator, testId: string): Promise<Locator> {
+    const matches = container.getByTestId(testId);
+    const count = await matches.count();
+    const visibleIndexes: number[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const candidate = matches.nth(i);
+      if (await candidate.isVisible().catch(() => false)) {
+        visibleIndexes.push(i);
+      }
+    }
+
+    if (visibleIndexes.length !== 1) {
+      throw new Error(`Expected a single visible locator for test id "${testId}" within the current filter container.`);
+    }
+
+    return matches.nth(visibleIndexes[0]);
   }
 }

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -25,6 +25,11 @@ export class BasePage {
     await expect(this.activeFilterEditButton(filterLabel)).toHaveCount(0);
   }
 
+  async validateNoResultsEmptyState() {
+    await expect(this.page.getByText("No results", { exact: true })).toBeVisible();
+    await expect(this.page.getByRole("button", { name: "Clear all filters", exact: true })).toBeVisible();
+  }
+
   async clickClearAllFilters() {
     await this.page.getByRole("button", { name: "Clear all filters", exact: true }).click();
   }
@@ -166,6 +171,118 @@ export class BasePage {
     const dialog = this.page.getByTestId("fleet-view-tabs-delete-dialog");
     await dialog.getByRole("button", { name: "Delete", exact: true }).click();
     await expect(dialog).toBeHidden();
+  }
+
+  protected async setNestedCheckboxFilterSelection(categoryKey: string, targetLabels: string[]) {
+    if (targetLabels.length !== 1) {
+      throw new Error(
+        `Expected exactly one target label for "${categoryKey}" filter, received ${targetLabels.length}.`,
+      );
+    }
+
+    const [targetLabel] = targetLabels;
+    const activeEditButton = await this.findVisibleTestIdLocator(`active-filter-${categoryKey}-edit`);
+    if (activeEditButton) {
+      const currentSummary = ((await activeEditButton.textContent()) ?? "").replace(/\s+/g, " ").trim();
+      if (currentSummary === targetLabel) {
+        return;
+      }
+
+      await this.clearActiveFilter(categoryKey);
+    }
+
+    const addFilterPopover = await this.openVisibleAddFilter();
+    await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
+    const targetOption = (await this.readVisibleCheckboxFilterOptionStates()).find(
+      ({ label }) => label === targetLabel,
+    );
+    if (!targetOption) {
+      throw new Error(`Could not find "${targetLabel}" in the visible "${categoryKey}" filter options.`);
+    }
+
+    await (await this.visibleTestIdLocator(`filter-option-${targetOption.id}`)).click();
+
+    const popover = this.page.getByTestId("nested-dropdown-filter-popover");
+    if (await popover.isVisible().catch(() => false)) {
+      await this.dismissAddFilterPopover();
+    }
+  }
+
+  protected async toggleAllNestedCheckboxFilterOptions(categoryKey: string) {
+    const activeEditButton = await this.findVisibleTestIdLocator(`active-filter-${categoryKey}-edit`);
+    if (activeEditButton) {
+      const popover = await this.openActiveFilterPopover(categoryKey);
+      await this.toggleVisibleCheckboxFilterOptions();
+      await activeEditButton.click();
+      await expect(popover).toBeHidden();
+      return;
+    }
+
+    const addFilterPopover = await this.openVisibleAddFilter();
+    await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
+    await this.toggleVisibleCheckboxFilterOptions();
+    await this.dismissAddFilterPopover();
+  }
+
+  private async toggleVisibleCheckboxFilterOptions() {
+    const initialOptions = await this.readVisibleCheckboxFilterOptionStates();
+    if (initialOptions.length === 0) {
+      return;
+    }
+
+    const anyChecked = initialOptions.some(({ checked }) => checked);
+
+    while (true) {
+      const visibleOptions = await this.readVisibleCheckboxFilterOptionStates();
+      if (visibleOptions.length === 0) {
+        return;
+      }
+
+      const nextOption = visibleOptions.find(({ checked }) => checked === anyChecked);
+      if (!nextOption) {
+        return;
+      }
+
+      await (await this.visibleTestIdLocator(`filter-option-${nextOption.id}`)).click();
+    }
+  }
+
+  private async readVisibleCheckboxFilterOptionStates() {
+    return await this.page.locator('[data-testid^="filter-option-"]').evaluateAll((elements) =>
+      elements.flatMap((element) => {
+        const option = element as HTMLElement;
+        const rect = option.getBoundingClientRect();
+        const style = window.getComputedStyle(option);
+        const checkVisibility = (
+          option as HTMLElement & {
+            checkVisibility?: (options?: { checkOpacity?: boolean; checkVisibilityCSS?: boolean }) => boolean;
+          }
+        ).checkVisibility;
+        const visible =
+          (typeof checkVisibility === "function"
+            ? checkVisibility.call(option, { checkOpacity: true, checkVisibilityCSS: true })
+            : true) &&
+          rect.width > 0 &&
+          rect.height > 0 &&
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          option.offsetParent !== null &&
+          option.getAttribute("aria-hidden") !== "true";
+
+        if (!visible) {
+          return [];
+        }
+
+        const checkbox = option.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+        return [
+          {
+            id: (option.dataset.testid ?? "").replace(/^filter-option-/, ""),
+            label: (option.textContent ?? "").replace(/\s+/g, " ").trim(),
+            checked: checkbox?.checked ?? false,
+          },
+        ];
+      }),
+    );
   }
 
   async validateLoggedIn(timeout: number = DEFAULT_TIMEOUT) {
@@ -514,37 +631,117 @@ export class BasePage {
     await expect(this.kebabPopover()).toBeVisible();
   }
 
-  private async visibleTestIdLocator(testId: string): Promise<Locator> {
-    const matches = this.page.getByTestId(testId);
+  private async getVisibleAddFilterTrigger(): Promise<Locator> {
+    const triggers = this.page.getByTestId("filter-nested-add-filter");
     let visibleIndex = -1;
 
     await expect
       .poll(
         async () => {
-          const count = await matches.count();
-          const visibleIndexes: number[] = [];
+          const count = await triggers.count();
 
           for (let i = 0; i < count; i++) {
-            const candidate = matches.nth(i);
-            if (await candidate.isVisible().catch(() => false)) {
-              visibleIndexes.push(i);
+            const trigger = triggers.nth(i);
+            if (await trigger.isVisible().catch(() => false)) {
+              visibleIndex = i;
+              return "visible";
             }
           }
 
-          if (visibleIndexes.length === 1) {
-            [visibleIndex] = visibleIndexes;
-            return `single:${visibleIndex}`;
-          }
-
-          return visibleIndexes.length === 0 ? "none" : `multiple:${visibleIndexes.join(",")}`;
+          return "hidden";
         },
         {
           timeout: DEFAULT_TIMEOUT,
-          message: `Expected a single visible locator for test id "${testId}".`,
+          message: "Expected a visible Add Filter trigger.",
         },
       )
-      .toMatch(/^single:\d+$/);
+      .toBe("visible");
 
-    return matches.nth(visibleIndex);
+    return triggers.nth(visibleIndex);
+  }
+
+  private async openVisibleAddFilter() {
+    const trigger = await this.getVisibleAddFilterTrigger();
+    await trigger.click();
+    const popover = this.page.getByTestId("nested-dropdown-filter-popover");
+    await expect(popover).toBeVisible();
+    return popover;
+  }
+
+  private async openActiveFilterPopover(categoryKey: string) {
+    const editButton = await this.visibleTestIdLocator(`active-filter-${categoryKey}-edit`);
+    await editButton.click();
+    const popover = this.page.getByTestId("dropdown-filter-popover");
+    await expect(popover).toBeVisible();
+    return popover;
+  }
+
+  private async openNestedFilterSubmenu(popover: Locator, categoryKey: string) {
+    await popover.getByTestId(`nested-dropdown-filter-row-${categoryKey}`).click();
+    const desktopSubmenu = this.page.getByTestId(`nested-dropdown-filter-submenu-${categoryKey}`);
+    const mobileBack = popover.getByTestId("nested-dropdown-filter-back");
+    await expect(desktopSubmenu.or(mobileBack)).toBeVisible();
+
+    if (await desktopSubmenu.isVisible().catch(() => false)) {
+      return desktopSubmenu;
+    }
+
+    return popover;
+  }
+
+  private async dismissAddFilterPopover() {
+    const popover = this.page.getByTestId("nested-dropdown-filter-popover");
+    if (!(await popover.isVisible().catch(() => false))) {
+      return;
+    }
+
+    if (this.isMobile) {
+      await this.page.mouse.click(1, 1);
+      await expect(popover).toBeHidden();
+      return;
+    }
+
+    const trigger = await this.getVisibleAddFilterTrigger();
+    await trigger.click();
+    await expect(popover).toBeHidden();
+  }
+
+  private async findVisibleTestIdLocator(testId: string): Promise<Locator | null> {
+    const matches = this.page.getByTestId(testId);
+    const count = await matches.count();
+    const visibleIndexes: number[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const candidate = matches.nth(i);
+      if (await candidate.isVisible().catch(() => false)) {
+        visibleIndexes.push(i);
+      }
+    }
+
+    if (visibleIndexes.length === 0) {
+      return null;
+    }
+
+    if (visibleIndexes.length > 1) {
+      throw new Error(`Expected a single visible locator for test id "${testId}", found ${visibleIndexes.length}.`);
+    }
+
+    return matches.nth(visibleIndexes[0]);
+  }
+
+  private async visibleTestIdLocator(testId: string): Promise<Locator> {
+    await expect
+      .poll(async () => ((await this.findVisibleTestIdLocator(testId)) ? "single" : "none"), {
+        timeout: DEFAULT_TIMEOUT,
+        message: `Expected a single visible locator for test id "${testId}".`,
+      })
+      .toBe("single");
+
+    const match = await this.findVisibleTestIdLocator(testId);
+    if (!match) {
+      throw new Error(`Expected a visible locator for test id "${testId}".`);
+    }
+
+    return match;
   }
 }

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -204,7 +204,7 @@ export class BasePage {
 
     const popover = this.page.getByTestId("nested-dropdown-filter-popover");
     if (await popover.isVisible().catch(() => false)) {
-      await this.dismissAddFilterPopover();
+      await this.dismissNestedAddFilterPopover();
     }
   }
 
@@ -221,7 +221,7 @@ export class BasePage {
     const addFilterPopover = await this.openVisibleAddFilter();
     await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
     await this.toggleVisibleCheckboxFilterOptions();
-    await this.dismissAddFilterPopover();
+    await this.dismissNestedAddFilterPopover();
   }
 
   private async toggleVisibleCheckboxFilterOptions() {
@@ -689,7 +689,7 @@ export class BasePage {
     return popover;
   }
 
-  private async dismissAddFilterPopover() {
+  private async dismissNestedAddFilterPopover() {
     const popover = this.page.getByTestId("nested-dropdown-filter-popover");
     if (!(await popover.isVisible().catch(() => false))) {
       return;

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -261,6 +261,28 @@ export class FleetLocationsPage extends BasePage {
     await expect(this.getListRowByName(name)).toHaveCount(0);
   }
 
+  async getSiteIdByName(name: string): Promise<bigint> {
+    await this.navigateToSitesPage();
+    return await this.getScopeIdFromRowName(name, "site");
+  }
+
+  async getBuildingIdByName(name: string): Promise<bigint> {
+    await this.navigateToBuildingsPage();
+    return await this.getScopeIdFromRowName(name, "building");
+  }
+
+  async applySiteFilter(siteNames: string[]) {
+    await this.setNestedCheckboxFilterSelection("site", siteNames);
+  }
+
+  async validateCurrentBuildingVisible(name: string) {
+    await expect(this.getListRowByName(name)).toBeVisible();
+  }
+
+  async validateCurrentBuildingNotVisible(name: string) {
+    await expect(this.getListRowByName(name)).toHaveCount(0);
+  }
+
   async deleteSite(name: string) {
     await this.navigateToSitesPage();
     await this.openRowActions(name);

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -45,12 +45,7 @@ export class FleetLocationsPage extends BasePage {
     await this.page.getByTestId("building-settings-modal-save").click();
 
     await expect(this.page.getByTestId("building-settings-modal")).toHaveCount(0);
-
-    const fullScreenModal = this.page.getByTestId("full-screen-two-pane-modal");
-    if (await fullScreenModal.isVisible().catch(() => false)) {
-      await fullScreenModal.getByTestId("header-icon-button").click();
-      await expect(fullScreenModal).toHaveCount(0);
-    }
+    await this.closeFullScreenModalIfVisible();
 
     const row = this.getListRowByName(buildingName);
     await expect(row).toBeVisible();
@@ -547,7 +542,7 @@ export class FleetLocationsPage extends BasePage {
       return;
     }
 
-    await fullScreenModal.getByTestId("header-icon-button").click();
+    await this.tryAction(() => fullScreenModal.getByTestId("header-icon-button").click());
     await expect(fullScreenModal).toHaveCount(0);
   }
 

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -319,105 +319,20 @@ export class RacksPage extends BasePage {
     await this.clickButton("View grid");
   }
 
-  private async getVisibleAddFilterTrigger(): Promise<Locator> {
-    const triggers = this.page.getByTestId("filter-nested-add-filter");
-    const count = await triggers.count();
-    for (let i = 0; i < count; i++) {
-      const trigger = triggers.nth(i);
-      if (await trigger.isVisible().catch(() => false)) return trigger;
-    }
-    throw new Error("No visible Add Filter trigger found");
-  }
-
-  private async openVisibleAddFilter() {
-    const trigger = await this.getVisibleAddFilterTrigger();
-    await trigger.click();
-    const popover = this.page.getByTestId("nested-dropdown-filter-popover");
-    await expect(popover).toBeVisible();
-    return popover;
-  }
-
-  private async openZoneSubmenu(popover: Locator) {
-    await popover.getByTestId("nested-dropdown-filter-row-zone").click();
-    // Desktop renders a portaled side submenu; phone/tablet collapses options into the
-    // parent popover with a "back" header. Either way the option rows for the chosen
-    // category become visible — return whichever container holds them.
-    const desktopSubmenu = this.page.getByTestId("nested-dropdown-filter-submenu-zone");
-    const mobileBack = popover.getByTestId("nested-dropdown-filter-back");
-    await expect(desktopSubmenu.or(mobileBack)).toBeVisible();
-    if (await desktopSubmenu.isVisible().catch(() => false)) return desktopSubmenu;
-    return popover;
-  }
-
-  private async dismissAddFilterPopover() {
-    // Toggle the trigger to close — the trigger is never covered by its own popover, so
-    // this is more reliable than clicking page chrome that may not exist or may be
-    // intercepted by the portal-fixed popover.
-    const trigger = await this.getVisibleAddFilterTrigger();
-    await trigger.click();
-    await expect(this.page.getByTestId("nested-dropdown-filter-popover")).toBeHidden();
-  }
-
-  private async setZoneSelection(target: string[]) {
-    // Open Add Filter, drill into Zone, and toggle each option to match the desired set.
-    // Reading the live submenu (which reflects current selection) avoids the race in
-    // editing an existing chip's popover while resetAndFetch is in flight.
-    const popover = await this.openVisibleAddFilter();
-    const submenu = await this.openZoneSubmenu(popover);
-    const options = submenu.locator('[data-testid^="filter-option-"]');
-    const count = await options.count();
-    const wanted = new Set(target);
-    for (let i = 0; i < count; i++) {
-      const opt = options.nth(i);
-      const testId = await opt.getAttribute("data-testid");
-      if (!testId) continue;
-      const optionId = testId.replace(/^filter-option-/, "");
-      const isChecked = await opt
-        .locator('input[type="checkbox"]')
-        .isChecked()
-        .catch(() => false);
-      if (isChecked !== wanted.has(optionId)) {
-        await opt.click();
-      }
-    }
-    await this.dismissAddFilterPopover();
-  }
-
   async applyZoneFilter(zoneNames: string[]) {
-    await this.setZoneSelection(zoneNames);
+    await this.setNestedCheckboxFilterSelection("zone", zoneNames);
+  }
+
+  async applySiteFilter(siteNames: string[]) {
+    await this.setNestedCheckboxFilterSelection("site", siteNames);
+  }
+
+  async applyBuildingFilter(buildingNames: string[]) {
+    await this.setNestedCheckboxFilterSelection("building", buildingNames);
   }
 
   async toggleAllZoneFilters() {
-    // Toggle: if any zone is currently selected, clear; otherwise select all.
-    const popover = await this.openVisibleAddFilter();
-    const submenu = await this.openZoneSubmenu(popover);
-    const options = submenu.locator('[data-testid^="filter-option-"]');
-    const count = await options.count();
-    let anyChecked = false;
-    for (let i = 0; i < count; i++) {
-      if (
-        await options
-          .nth(i)
-          .locator('input[type="checkbox"]')
-          .isChecked()
-          .catch(() => false)
-      ) {
-        anyChecked = true;
-        break;
-      }
-    }
-    for (let i = 0; i < count; i++) {
-      const opt = options.nth(i);
-      const isChecked = await opt
-        .locator('input[type="checkbox"]')
-        .isChecked()
-        .catch(() => false);
-      if (isChecked === anyChecked) {
-        // anyChecked => clear all (uncheck checked); !anyChecked => select all (check unchecked).
-        await opt.click();
-      }
-    }
-    await this.dismissAddFilterPopover();
+    await this.toggleAllNestedCheckboxFilterOptions("zone");
   }
 
   async selectGridSort(sortLabel: string) {
@@ -492,6 +407,10 @@ export class RacksPage extends BasePage {
     await expect(row).toBeVisible();
     await expect(row.getByTestId("site")).toHaveText(siteName);
     await expect(row.getByTestId("building")).toHaveText(buildingName);
+  }
+
+  async validateRackNotVisible(label: string) {
+    await expect(this.getRackListRow(label)).toHaveCount(0);
   }
 
   async openRackFromList(label: string) {

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -528,13 +528,28 @@ export class RacksPage extends BasePage {
   }
 
   private async clickDropdownFilterOption(popover: Locator, optionName: string) {
-    const optionByTestId = popover.getByTestId(`filter-option-${optionName}`).first();
-    if (await optionByTestId.isVisible().catch(() => false)) {
-      await optionByTestId.click();
-      return;
+    const optionByTestId = popover.getByTestId(`filter-option-${optionName}`);
+    const optionByTestIdCount = await optionByTestId.count();
+    for (let i = 0; i < optionByTestIdCount; i++) {
+      const option = optionByTestId.nth(i);
+      if (await option.isVisible().catch(() => false)) {
+        await option.click();
+        return;
+      }
     }
 
-    await popover.getByText(optionName, { exact: true }).first().click();
+    const optionRows = popover.locator('[data-testid^="filter-option-"]').filter({ hasText: optionName });
+    const optionRowCount = await optionRows.count();
+    for (let i = 0; i < optionRowCount; i++) {
+      const option = optionRows.nth(i);
+      const label = ((await option.textContent()) ?? "").replace(/\s+/g, " ").trim();
+      if (label === optionName && (await option.isVisible().catch(() => false))) {
+        await option.click();
+        return;
+      }
+    }
+
+    throw new Error(`Could not find a visible dropdown filter option named "${optionName}".`);
   }
 
   private async clickVisibleFilterDropdown(title: string) {

--- a/client/e2eTests/protoFleet/spec/fleetFilters.spec.ts
+++ b/client/e2eTests/protoFleet/spec/fleetFilters.spec.ts
@@ -1,0 +1,121 @@
+import { test } from "../fixtures/pageFixtures";
+import {
+  createBuildingsScenarioData,
+  createSiteAndBuilding,
+  setupRackAssignedToBuilding,
+  useBuildingsHooks,
+} from "../helpers/buildingsTestSetup";
+
+test.describe("Proto Fleet - Fleet filters", () => {
+  useBuildingsHooks();
+
+  test("Buildings site filter scopes the list and clears cleanly", async ({ page, fleetLocationsPage }) => {
+    const primary = createBuildingsScenarioData();
+    const secondary = createBuildingsScenarioData();
+
+    await createSiteAndBuilding(fleetLocationsPage, primary);
+    await createSiteAndBuilding(fleetLocationsPage, secondary);
+
+    const primarySiteId = await fleetLocationsPage.getSiteIdByName(primary.siteName);
+    const secondarySiteId = await fleetLocationsPage.getSiteIdByName(secondary.siteName);
+
+    await test.step("Apply the first site filter from the buildings tab", async () => {
+      await fleetLocationsPage.navigateToBuildingsPage();
+      await fleetLocationsPage.applySiteFilter([primary.siteName]);
+
+      await fleetLocationsPage.validateActiveFilterSummary("site", primary.siteName);
+      await fleetLocationsPage.validateCurrentBuildingRowCounts(primary.buildingName, {
+        siteName: primary.siteName,
+        racks: 0,
+        miners: 0,
+      });
+      await fleetLocationsPage.validateCurrentBuildingNotVisible(secondary.buildingName);
+
+      test.expect(new URL(page.url()).searchParams.getAll("site")).toEqual([primarySiteId.toString()]);
+    });
+
+    await test.step("Switch the filter to the second site", async () => {
+      await fleetLocationsPage.applySiteFilter([secondary.siteName]);
+
+      await fleetLocationsPage.validateActiveFilterSummary("site", secondary.siteName);
+      await fleetLocationsPage.validateCurrentBuildingRowCounts(secondary.buildingName, {
+        siteName: secondary.siteName,
+        racks: 0,
+        miners: 0,
+      });
+      await fleetLocationsPage.validateCurrentBuildingNotVisible(primary.buildingName);
+
+      test.expect(new URL(page.url()).searchParams.getAll("site")).toEqual([secondarySiteId.toString()]);
+    });
+
+    await test.step("Clear the site filter and show both buildings again", async () => {
+      await fleetLocationsPage.clearActiveFilter("site");
+
+      await fleetLocationsPage.validateActiveFilterNotVisible("Sites");
+      await fleetLocationsPage.validateCurrentBuildingVisible(primary.buildingName);
+      await fleetLocationsPage.validateCurrentBuildingVisible(secondary.buildingName);
+
+      test.expect(new URL(page.url()).searchParams.getAll("site")).toEqual([]);
+    });
+  });
+
+  test("Racks site and building filters can reach no results and then clear cleanly", async ({
+    page,
+    fleetLocationsPage,
+    racksPage,
+  }) => {
+    const primary = createBuildingsScenarioData();
+    const secondary = createBuildingsScenarioData();
+
+    await setupRackAssignedToBuilding(page, fleetLocationsPage, racksPage, primary);
+    const { buildingId: secondaryBuildingId } = await setupRackAssignedToBuilding(
+      page,
+      fleetLocationsPage,
+      racksPage,
+      secondary,
+    );
+
+    const primarySiteId = await fleetLocationsPage.getSiteIdByName(primary.siteName);
+
+    await test.step("Apply a site filter and confirm only the matching rack remains", async () => {
+      await racksPage.navigateToRacksPage();
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+
+      await racksPage.applySiteFilter([primary.siteName]);
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+
+      await racksPage.validateActiveFilterSummary("site", primary.siteName);
+      await racksPage.validateRackPlacementRow(primary.rackLabel, primary.siteName, primary.buildingName);
+      await racksPage.validateRackNotVisible(secondary.rackLabel);
+
+      test.expect(new URL(page.url()).searchParams.getAll("site")).toEqual([primarySiteId.toString()]);
+    });
+
+    await test.step("Add a mismatched building filter to force the no-results state", async () => {
+      await racksPage.applyBuildingFilter([secondary.buildingName]);
+      await racksPage.waitForRackListToLoad();
+
+      await racksPage.validateActiveFilterSummary("building", secondary.buildingName);
+      await racksPage.validateNoResultsEmptyState();
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("site")).toEqual([primarySiteId.toString()]);
+      test.expect(searchParams.getAll("building")).toEqual([secondaryBuildingId.toString()]);
+    });
+
+    await test.step("Clear all filters and restore the full rack list", async () => {
+      await racksPage.clickClearAllFilters();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false });
+
+      await racksPage.validateActiveFilterNotVisible("Sites");
+      await racksPage.validateActiveFilterNotVisible("Buildings");
+      await racksPage.validateRackPlacementRow(primary.rackLabel, primary.siteName, primary.buildingName);
+      await racksPage.validateRackPlacementRow(secondary.rackLabel, secondary.siteName, secondary.buildingName);
+
+      const searchParams = new URL(page.url()).searchParams;
+      test.expect(searchParams.getAll("site")).toEqual([]);
+      test.expect(searchParams.getAll("building")).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Reviewable diff: +246/-108 across 3 files (excludes generated, test, and story files).

## Summary
This PR adds Proto Fleet E2E coverage for fleet filters on the Buildings and Racks tabs. It covers filtering a buildings list by site, combining rack site and building filters to reach a no-results state, and clearing filters back to the full dataset while asserting both table contents and URL query params. It also consolidates the nested Add Filter interaction into shared page-object helpers so future filter specs can stay scenario-focused instead of reimplementing desktop/mobile popover behavior.

## How it works
The new spec creates two isolated location setups so each filter assertion has a clear control and comparison row. In the Buildings flow, the test creates two site/building pairs, filters the Buildings tab by one site, switches to the other, and then clears the active filter while verifying the visible rows and `site` query param updates.

In the Racks flow, the test creates two site/building/rack/miner setups, applies a site filter from the Racks list, adds a mismatched building filter to intentionally produce the empty state, and then uses Clear all filters to restore the full rack list. Assertions verify the active filter summaries, the rack placement columns, the no-results empty state, and the `site` / `building` URL params.

To keep the spec readable, the filter mechanics moved into shared helpers on `BasePage`. Those helpers now:
- wait for the visible `+ Add Filter` trigger rather than assuming immediate availability
- handle the active-chip vs add-filter paths separately
- use mobile-specific dismissal for nested popovers
- support the existing zone toggle-all rack flow through the same shared nested checkbox primitives

## Diagrams
```mermaid
flowchart LR
  A["fleetFilters.spec.ts"] --> B["Create scenario data"]
  B --> C["Page object filter helper"]
  C --> D["Open Add Filter or active chip"]
  D --> E["Select visible filter option"]
  E --> F["Fleet page refetches scoped rows"]
  F --> G["Assert row contents + URL params"]
```

```mermaid
flowchart TD
  A["Racks filter scenario"] --> B["Apply site filter"]
  B --> C["Only matching rack remains"]
  C --> D["Apply mismatched building filter"]
  D --> E["No results empty state"]
  E --> F["Clear all filters"]
  F --> G["Both racks visible again"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/fleetFilters.spec.ts` | Adds the new Buildings and Racks filter scenarios. | This is the user-facing coverage being introduced. |
| `client/e2eTests/protoFleet/pages/base.ts` | Adds reusable nested filter helpers, no-results validation, and desktop/mobile popover handling. | Most of the behavioral complexity lives here, and it affects future filter interactions beyond this spec. |
| `client/e2eTests/protoFleet/pages/fleetLocations.ts` | Adds site-id lookup, site-filter application, and current-row visibility helpers for Buildings assertions. | Keeps the Buildings scenario readable and centralizes Buildings-tab selectors. |
| `client/e2eTests/protoFleet/pages/racks.ts` | Reuses the shared nested filter helpers for site/building/zone interactions and adds rack invisibility assertions. | Verifies the refactor still supports existing rack filter usage patterns. |

## Key technical decisions & trade-offs
- Reused a shared nested-filter helper in `BasePage` instead of duplicating site/building/zone logic in each page object, trading a slightly richer base helper for cleaner specs.
- Kept filter selection scoped to the current E2E usage of single-option site/building selection, instead of building a broader multi-select abstraction that the current scenarios do not need.
- Preserved the existing rack zone toggle-all flow by routing it through the shared helper, rather than leaving two parallel implementations of nested filter behavior.

## Testing & validation
- `./node_modules/.bin/eslint e2eTests/protoFleet/pages/base.ts e2eTests/protoFleet/pages/fleetLocations.ts e2eTests/protoFleet/pages/racks.ts e2eTests/protoFleet/spec/fleetFilters.spec.ts`
- `PW_UI_NO_DEPS=1 ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/fleetFilters.spec.ts --project=desktop`
- `PW_UI_NO_DEPS=1 ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/fleetFilters.spec.ts --project=mobile`

Not covered here: broader multi-select filter behavior on these chips, since the added scenarios only exercise the single-selection flows currently used by the fleet pages.
