### PR TITLE
feat(rack): scan 1D barcodes (not just QR) for miner slot assignment

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/RackPane.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/RackPane.tsx
@@ -107,7 +107,7 @@ function SlotPopover({
             onScanQr();
           }}
         >
-          Scan QR code
+          Scan barcode
         </button>
       </div>
     </>

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
@@ -79,16 +79,16 @@ describe("ScanMinerQrModal", () => {
 
     await waitFor(() => expect(screen.getByText("Miner One")).toBeInTheDocument());
     // The parsed (prefix-stripped) serial + detected type are sent to the lookup.
-    expect(mockLookup).toHaveBeenCalledWith("SN123", MinerIdentifierType.SERIAL_NUMBER);
+    expect(mockLookup).toHaveBeenCalledWith("SN123", MinerIdentifierType.SERIAL_NUMBER, expect.any(AbortSignal));
 
     fireEvent.click(screen.getByText("Assign to slot"));
     expect(onConfirm).toHaveBeenCalledWith("dev-1");
   });
 
-  it("tries every decoded barcode and resolves the one that matches", async () => {
+  it("tries every decoded barcode until one resolves", async () => {
     mockCanUseLiveCamera.mockReturnValue(true);
-    // A frame can decode multiple codes; the first (e.g. a model/asset code)
-    // doesn't resolve, the serial does. It must not stop at the first miss.
+    // Two same-typed candidates: the first misses, the second resolves — it
+    // must not stop at the first miss.
     mockLookup
       .mockResolvedValueOnce({ status: "notFound" })
       .mockResolvedValueOnce({ status: "found", snapshot: snapshot() });
@@ -96,11 +96,41 @@ describe("ScanMinerQrModal", () => {
     render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
 
     await act(async () => {
-      capturedOnDetected?.(["MODEL234T", "SN:SN123"]);
+      capturedOnDetected?.(["FIRSTMISS111", "SECONDHIT222"]);
     });
 
     await waitFor(() => expect(screen.getByText("Miner One")).toBeInTheDocument());
     expect(mockLookup).toHaveBeenCalledTimes(2);
+  });
+
+  it("tries an explicitly-typed candidate before an unspecified one", async () => {
+    mockCanUseLiveCamera.mockReturnValue(true);
+    mockLookup.mockResolvedValue({ status: "found", snapshot: snapshot() });
+
+    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
+
+    // Model/asset code listed first, SN:-prefixed serial second — the serial
+    // must be looked up first so a stray code can't out-race it.
+    await act(async () => {
+      capturedOnDetected?.(["MODEL234T", "SN:REALSN"]);
+    });
+
+    await waitFor(() => expect(screen.getByText("Miner One")).toBeInTheDocument());
+    expect(mockLookup.mock.calls[0][0]).toBe("REALSN");
+  });
+
+  it("de-dupes a value decoded more than once in the same frame", async () => {
+    mockCanUseLiveCamera.mockReturnValue(true);
+    mockLookup.mockResolvedValue({ status: "found", snapshot: snapshot() });
+
+    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
+
+    await act(async () => {
+      capturedOnDetected?.(["SN:DUP", "SN:DUP"]);
+    });
+
+    await waitFor(() => expect(screen.getByText("Miner One")).toBeInTheDocument());
+    expect(mockLookup).toHaveBeenCalledTimes(1);
   });
 
   it("shows a not-found message when the serial has no paired miner", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
@@ -141,7 +141,7 @@ describe("ScanMinerQrModal", () => {
 
     render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
 
-    expect(screen.getByText(/Take a photo of the QR code/i)).toBeInTheDocument();
+    expect(screen.getByText(/Take a photo of the code/i)).toBeInTheDocument();
     expect(screen.getByText("Open camera")).toBeInTheDocument();
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
@@ -7,11 +7,11 @@ import { MinerIdentifierType, PairingStatus } from "@/protoFleet/api/generated/f
 // --- Mock the scanner hook so tests never touch real camera/WASM APIs. ---
 const mockUseQrScanner = vi.fn();
 const mockCanUseLiveCamera = vi.fn();
-let capturedOnDetected: ((raw: string) => void) | undefined;
+let capturedOnDetected: ((raws: string[]) => void) | undefined;
 
 vi.mock("@/protoFleet/features/fleetManagement/hooks/useQrScanner", () => ({
   canUseLiveCamera: () => mockCanUseLiveCamera(),
-  useQrScanner: (opts: { onDetected: (raw: string) => void; active: boolean }) => {
+  useQrScanner: (opts: { onDetected: (raws: string[]) => void; active: boolean }) => {
     capturedOnDetected = opts.onDetected;
     return mockUseQrScanner(opts);
   },
@@ -74,7 +74,7 @@ describe("ScanMinerQrModal", () => {
 
     // Simulate the camera hook detecting a prefixed QR payload.
     await act(async () => {
-      capturedOnDetected?.("SN:SN123");
+      capturedOnDetected?.(["SN:SN123"]);
     });
 
     await waitFor(() => expect(screen.getByText("Miner One")).toBeInTheDocument());
@@ -85,6 +85,24 @@ describe("ScanMinerQrModal", () => {
     expect(onConfirm).toHaveBeenCalledWith("dev-1");
   });
 
+  it("tries every decoded barcode and resolves the one that matches", async () => {
+    mockCanUseLiveCamera.mockReturnValue(true);
+    // A frame can decode multiple codes; the first (e.g. a model/asset code)
+    // doesn't resolve, the serial does. It must not stop at the first miss.
+    mockLookup
+      .mockResolvedValueOnce({ status: "notFound" })
+      .mockResolvedValueOnce({ status: "found", snapshot: snapshot() });
+
+    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
+
+    await act(async () => {
+      capturedOnDetected?.(["MODEL234T", "SN:SN123"]);
+    });
+
+    await waitFor(() => expect(screen.getByText("Miner One")).toBeInTheDocument());
+    expect(mockLookup).toHaveBeenCalledTimes(2);
+  });
+
   it("shows a not-found message when the serial has no paired miner", async () => {
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValueOnce({ status: "notFound" });
@@ -92,7 +110,7 @@ describe("ScanMinerQrModal", () => {
     render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
 
     await act(async () => {
-      capturedOnDetected?.("SN:NOPE");
+      capturedOnDetected?.(["SN:NOPE"]);
     });
 
     await waitFor(() => expect(screen.getByText(/No paired miner found/i)).toBeInTheDocument());
@@ -109,7 +127,7 @@ describe("ScanMinerQrModal", () => {
     render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={onConfirm} />);
 
     await act(async () => {
-      capturedOnDetected?.("SN123");
+      capturedOnDetected?.(["SN123"]);
     });
 
     await waitFor(() => expect(screen.getByText(/Already assigned to rack "Rack B"/i)).toBeInTheDocument());
@@ -128,7 +146,7 @@ describe("ScanMinerQrModal", () => {
     render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={onConfirm} />);
 
     await act(async () => {
-      capturedOnDetected?.("SN123");
+      capturedOnDetected?.(["SN123"]);
     });
 
     await waitFor(() => expect(screen.getByText(/isn't fully paired/i)).toBeInTheDocument());
@@ -152,7 +170,7 @@ describe("ScanMinerQrModal", () => {
     render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
 
     await act(async () => {
-      capturedOnDetected?.("SN123");
+      capturedOnDetected?.(["SN123"]);
     });
 
     await waitFor(() => expect(screen.getByText("server exploded")).toBeInTheDocument());

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
@@ -29,27 +29,32 @@ export default function ScanMinerQrModal({ show, currentRackLabel, onDismiss, on
   // a result). Toggling this tears the stream down between scans.
   const cameraActive = show && liveCamera && phase.kind === "scanning";
 
-  const runLookup = useCallback(async (rawValue: string) => {
-    const { value, type } = parseScannedIdentifier(rawValue);
-    if (!value) {
-      setPhase({ kind: "not-found", identifier: rawValue.trim() });
+  // A single frame/photo can decode more than one barcode (e.g. a serial plus a
+  // model/asset code), and the detector's ordering isn't guaranteed — so try
+  // each decoded value against the lookup and only report not-found once none
+  // resolve, rather than committing to the first.
+  const runLookup = useCallback(async (rawValues: string[]) => {
+    const seq = ++lookupSeq.current;
+    const candidates = rawValues.map((raw) => ({ raw, ...parseScannedIdentifier(raw) })).filter((c) => c.value);
+    if (candidates.length === 0) {
+      setPhase({ kind: "not-found", identifier: rawValues[0]?.trim() ?? "" });
       return;
     }
-    const seq = ++lookupSeq.current;
-    setPhase({ kind: "looking-up", identifier: value });
-    const result = await lookupMinerByIdentifier(value, type);
-    if (seq !== lookupSeq.current) return; // superseded
-    switch (result.status) {
-      case "found":
+    setPhase({ kind: "looking-up", identifier: candidates[0].value });
+    let lastError: string | null = null;
+    for (const { value, type } of candidates) {
+      const result = await lookupMinerByIdentifier(value, type);
+      if (seq !== lookupSeq.current) return; // superseded by a newer scan / close
+      if (result.status === "found") {
         setPhase({ kind: "found", snapshot: result.snapshot });
-        break;
-      case "notFound":
-        setPhase({ kind: "not-found", identifier: value });
-        break;
-      case "error":
-        setPhase({ kind: "error", message: result.message });
-        break;
+        return;
+      }
+      if (result.status === "error") lastError = result.message;
+      // notFound → keep trying the remaining decoded values
     }
+    setPhase(
+      lastError ? { kind: "error", message: lastError } : { kind: "not-found", identifier: candidates[0].value },
+    );
   }, []);
 
   const { videoRef, status, errorMessage, detectFromBlob } = useQrScanner({
@@ -76,9 +81,9 @@ export default function ScanMinerQrModal({ show, currentRackLabel, onDismiss, on
       if (!file) return;
       setPhase({ kind: "looking-up", identifier: "" });
       try {
-        const rawValue = await detectFromBlob(file);
-        if (rawValue) {
-          await runLookup(rawValue);
+        const rawValues = await detectFromBlob(file);
+        if (rawValues.length) {
+          await runLookup(rawValues);
         } else {
           setPhase({ kind: "not-found", identifier: "" });
         }

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import ScanMinerQrModalView, { type ScanPhase } from "./ScanMinerQrModalView";
+import { MinerIdentifierType } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { lookupMinerByIdentifier } from "@/protoFleet/api/lookupMinerByIdentifier";
 import { canUseLiveCamera, useQrScanner } from "@/protoFleet/features/fleetManagement/hooks/useQrScanner";
 import { parseScannedIdentifier } from "@/protoFleet/features/fleetManagement/utils/parseScannedIdentifier";
@@ -24,6 +25,9 @@ export default function ScanMinerQrModal({ show, currentRackLabel, onDismiss, on
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   // Guards the async lookup against a modal close / rescan mid-flight.
   const lookupSeq = useRef(0);
+  // Aborts in-flight lookups (a multi-candidate loop issues several) on rescan
+  // or unmount, so a mid-scan dismiss doesn't keep hitting the server.
+  const abortRef = useRef<AbortController | null>(null);
 
   // Only run the live camera while we're actively scanning (not while showing
   // a result). Toggling this tears the stream down between scans.
@@ -35,26 +39,48 @@ export default function ScanMinerQrModal({ show, currentRackLabel, onDismiss, on
   // resolve, rather than committing to the first.
   const runLookup = useCallback(async (rawValues: string[]) => {
     const seq = ++lookupSeq.current;
-    const candidates = rawValues.map((raw) => ({ raw, ...parseScannedIdentifier(raw) })).filter((c) => c.value);
+    // Cancel any lookups still in flight from a previous scan.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    // Parse → drop empties → de-dupe by value (the same label can decode more
+    // than once in one frame) → try explicitly-typed (SN:/MAC:) candidates
+    // first so a stray model/asset code can't out-race the intended serial/MAC.
+    const seen = new Set<string>();
+    const candidates = rawValues
+      .map((raw) => parseScannedIdentifier(raw))
+      .filter((c) => {
+        if (!c.value || seen.has(c.value)) return false;
+        seen.add(c.value);
+        return true;
+      })
+      .sort(
+        (a, b) =>
+          Number(a.type === MinerIdentifierType.UNSPECIFIED) - Number(b.type === MinerIdentifierType.UNSPECIFIED),
+      );
+
     if (candidates.length === 0) {
       setPhase({ kind: "not-found", identifier: rawValues[0]?.trim() ?? "" });
       return;
     }
     setPhase({ kind: "looking-up", identifier: candidates[0].value });
-    let lastError: string | null = null;
     for (const { value, type } of candidates) {
-      const result = await lookupMinerByIdentifier(value, type);
-      if (seq !== lookupSeq.current) return; // superseded by a newer scan / close
+      const result = await lookupMinerByIdentifier(value, type, controller.signal);
+      if (seq !== lookupSeq.current || controller.signal.aborted) return; // superseded / aborted
       if (result.status === "found") {
         setPhase({ kind: "found", snapshot: result.snapshot });
         return;
       }
-      if (result.status === "error") lastError = result.message;
-      // notFound → keep trying the remaining decoded values
+      if (result.status === "error") {
+        // A transport/server failure will hit the remaining candidates too —
+        // surface it now instead of waiting through N sequential failures.
+        setPhase({ kind: "error", message: result.message });
+        return;
+      }
+      // notFound → try the next candidate
     }
-    setPhase(
-      lastError ? { kind: "error", message: lastError } : { kind: "not-found", identifier: candidates[0].value },
-    );
+    setPhase({ kind: "not-found", identifier: candidates[0].value });
   }, []);
 
   const { videoRef, status, errorMessage, detectFromBlob } = useQrScanner({
@@ -66,13 +92,18 @@ export default function ScanMinerQrModal({ show, currentRackLabel, onDismiss, on
   useEffect(() => {
     if (show) {
       lookupSeq.current++;
+      abortRef.current?.abort();
       // eslint-disable-next-line react-hooks/set-state-in-effect -- reset scan flow to its initial phase on each open
       setPhase({ kind: "scanning" });
     }
   }, [show]);
 
+  // Stop any in-flight lookup loop when the modal unmounts (dismissed mid-scan).
+  useEffect(() => () => abortRef.current?.abort(), []);
+
   const rescan = useCallback(() => {
     lookupSeq.current++;
+    abortRef.current?.abort();
     setPhase({ kind: "scanning" });
   }, []);
 
@@ -88,7 +119,7 @@ export default function ScanMinerQrModal({ show, currentRackLabel, onDismiss, on
           setPhase({ kind: "not-found", identifier: "" });
         }
       } catch {
-        setPhase({ kind: "error", message: "Could not read the photo. Try again with the QR code centered." });
+        setPhase({ kind: "error", message: "Could not read the photo. Try again with the code centered." });
       }
     },
     [detectFromBlob, runLookup],

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.tsx
@@ -77,7 +77,7 @@ export default function ScanMinerQrModalView({
   return (
     <Modal
       open={show}
-      title="Scan miner QR code"
+      title="Scan miner barcode"
       size="standard"
       phoneSheet
       onDismiss={onDismiss}
@@ -141,11 +141,11 @@ export default function ScanMinerQrModalView({
           <Callout
             intent="warning"
             prefixIcon={<Alert />}
-            title={phase.identifier ? `No paired miner found for "${phase.identifier}"` : "No QR code detected"}
+            title={phase.identifier ? `No paired miner found for "${phase.identifier}"` : "No code detected"}
             subtitle={
               phase.identifier
                 ? "Check that the miner is paired to this Fleet, or scan a different code."
-                : "Make sure the whole QR code is visible and try again."
+                : "Make sure the whole code is visible and try again."
             }
           />
         ) : null}
@@ -188,7 +188,9 @@ function LiveCameraView({
       {errorMessage ? (
         <Callout intent="danger" prefixIcon={<Alert />} title={errorMessage} />
       ) : (
-        <span className="text-center text-300 text-text-primary-50">Point the camera at the miner's QR label.</span>
+        <span className="text-center text-300 text-text-primary-50">
+          Point the camera at the QR code or barcode on the miner's label.
+        </span>
       )}
     </div>
   );
@@ -209,8 +211,8 @@ function PhotoCapturePrompt({
         <Callout
           intent="information"
           prefixIcon={<Info />}
-          title="Take a photo of the QR code"
-          subtitle="Live scanning needs a secure (HTTPS) connection. Tap below to capture the miner's QR label with your camera."
+          title="Take a photo of the code"
+          subtitle="Live scanning needs a secure (HTTPS) connection. Tap below to capture the code on the miner's label with your camera."
         />
       ) : null}
       <button

--- a/client/src/protoFleet/features/fleetManagement/hooks/useQrScanner.ts
+++ b/client/src/protoFleet/features/fleetManagement/hooks/useQrScanner.ts
@@ -58,6 +58,9 @@ export function useQrScanner({ onDetected, active }: UseQrScannerOptions): UseQr
   const streamRef = useRef<MediaStream | null>(null);
   const detectorRef = useRef<BarcodeDetector | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Offscreen canvas used to crop each frame to the visible preview square
+  // before decoding (see detectionFrame).
+  const cropCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const detectedRef = useRef(false);
   // Guards against overlapping decodes: detect() can take longer than
   // SCAN_INTERVAL_MS (notably the WASM fallback on mobile), and without this a
@@ -162,7 +165,7 @@ export function useQrScanner({ onDetected, active }: UseQrScannerOptions): UseQr
           if (!el || detectedRef.current || detectingRef.current || el.readyState < 2) return;
           detectingRef.current = true;
           try {
-            const results = await detector.detect(el);
+            const results = await detector.detect(detectionFrame(el, cropCanvasRef));
             // The effect may have torn down while detect() was in flight; don't
             // fire onDetected (a lookup + state update) after teardown.
             if (cancelled) return;
@@ -204,6 +207,39 @@ export function useQrScanner({ onDetected, active }: UseQrScannerOptions): UseQr
   }, [active, getDetector, stop]);
 
   return { videoRef, status, errorMessage, detectFromBlob };
+}
+
+/**
+ * The live preview shows an `aspect-square`, `object-cover` crop of the (often
+ * 16:9) camera stream, but `detect()` reads the full frame. Decode only the
+ * visible center square so a barcode sitting in the hidden side margins — an
+ * adjacent label in a dense rack row — can't be scanned and assigned while the
+ * operator is aiming at a different, visible label. Returns the video unchanged
+ * when there's nothing to crop (a square or not-yet-sized frame).
+ */
+function detectionFrame(
+  video: HTMLVideoElement,
+  canvasRef: RefObject<HTMLCanvasElement | null>,
+): HTMLVideoElement | HTMLCanvasElement {
+  const vw = video.videoWidth;
+  const vh = video.videoHeight;
+  if (!vw || !vh || vw === vh) return video;
+
+  const side = Math.min(vw, vh);
+  const sx = (vw - side) / 2;
+  const sy = (vh - side) / 2;
+
+  let canvas = canvasRef.current;
+  if (!canvas) {
+    canvas = document.createElement("canvas");
+    canvasRef.current = canvas;
+  }
+  canvas.width = side;
+  canvas.height = side;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return video;
+  ctx.drawImage(video, sx, sy, side, side, 0, 0, side, side);
+  return canvas;
 }
 
 /** Map a getUserMedia rejection to a short, actionable message. */

--- a/client/src/protoFleet/features/fleetManagement/hooks/useQrScanner.ts
+++ b/client/src/protoFleet/features/fleetManagement/hooks/useQrScanner.ts
@@ -79,7 +79,13 @@ export function useQrScanner({ onDetected, active }: UseQrScannerOptions): UseQr
   const getDetector = useCallback((): BarcodeDetector => {
     if (!detectorRef.current) {
       initBarcodeScanner();
-      detectorRef.current = new BarcodeDetector({ formats: ["qr_code"] });
+      // QR is the common case, but some vendors (e.g. Bitmain) print the serial
+      // on a 1D barcode, so accept the alphanumeric linear symbologies used on
+      // equipment labels alongside the 2D formats. The decoded value flows
+      // through parseScannedIdentifier the same way regardless of symbology.
+      detectorRef.current = new BarcodeDetector({
+        formats: ["qr_code", "data_matrix", "code_128", "code_39", "code_93"],
+      });
     }
     return detectorRef.current;
   }, []);

--- a/client/src/protoFleet/features/fleetManagement/hooks/useQrScanner.ts
+++ b/client/src/protoFleet/features/fleetManagement/hooks/useQrScanner.ts
@@ -128,7 +128,11 @@ export function useQrScanner({ onDetected, active }: UseQrScannerOptions): UseQr
     const start = async () => {
       try {
         const stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: { ideal: "environment" } },
+          // Request a high resolution: a dense 1D barcode (e.g. an Antminer
+          // serial in Code 128) needs enough horizontal pixels across its bars
+          // to decode, where a QR would survive a lower-res frame. `ideal` so
+          // devices without a 1080p camera gracefully fall back.
+          video: { facingMode: { ideal: "environment" }, width: { ideal: 1920 }, height: { ideal: 1080 } },
           audio: false,
         });
         if (cancelled) {

--- a/client/src/protoFleet/features/fleetManagement/hooks/useQrScanner.ts
+++ b/client/src/protoFleet/features/fleetManagement/hooks/useQrScanner.ts
@@ -19,8 +19,14 @@ export function canUseLiveCamera(): boolean {
 type ScanStatus = "idle" | "starting" | "scanning" | "error";
 
 interface UseQrScannerOptions {
-  /** Called with the raw decoded text when a code is found. */
-  onDetected: (rawValue: string) => void;
+  /**
+   * Called with every raw decoded value in the frame when at least one code is
+   * found. A single label or rack shot can carry more than one barcode (e.g. a
+   * serial and a model/asset code), and the detector's ordering isn't
+   * guaranteed — so the caller should try each value rather than assume the
+   * first is the one to resolve.
+   */
+  onDetected: (rawValues: string[]) => void;
   /** When false, the scanner stays torn down (e.g. modal closed). */
   active: boolean;
 }
@@ -30,8 +36,9 @@ interface UseQrScannerResult {
   status: ScanStatus;
   /** Populated when status === "error"; a user-facing message. */
   errorMessage: string;
-  /** Decode a still image (File/Blob) from the photo-capture fallback. */
-  detectFromBlob: (blob: Blob) => Promise<string | null>;
+  /** Decode a still image (File/Blob) from the photo-capture fallback; returns
+   *  every decoded value (see onDetected). */
+  detectFromBlob: (blob: Blob) => Promise<string[]>;
 }
 
 const SCAN_INTERVAL_MS = 250;
@@ -94,9 +101,9 @@ export function useQrScanner({ onDetected, active }: UseQrScannerOptions): UseQr
   }, []);
 
   const detectFromBlob = useCallback(
-    async (blob: Blob): Promise<string | null> => {
+    async (blob: Blob): Promise<string[]> => {
       const results = await getDetector().detect(blob);
-      return results[0]?.rawValue ?? null;
+      return results.map((r) => r.rawValue).filter(Boolean);
     },
     [getDetector],
   );
@@ -170,10 +177,10 @@ export function useQrScanner({ onDetected, active }: UseQrScannerOptions): UseQr
             // fire onDetected (a lookup + state update) after teardown.
             if (cancelled) return;
             decodeFailuresRef.current = 0;
-            const value = results[0]?.rawValue;
-            if (value && !detectedRef.current) {
+            const values = results.map((r) => r.rawValue).filter(Boolean);
+            if (values.length && !detectedRef.current) {
               detectedRef.current = true;
-              onDetectedRef.current(value);
+              onDetectedRef.current(values);
             }
           } catch {
             // A blurry frame resolves empty; a *throw* means the decoder itself


### PR DESCRIPTION
## What

Extends the scan-to-assign flow (added in #654) to read **1D barcodes** in addition to QR. Some vendors — notably Bitmain/Antminer — print the miner serial on a 1D barcode rather than a QR, so those labels couldn't be scanned before.

Closes #675 (follow-up raised by @b-rowan on #654).

## Changes

- **`useQrScanner`** — the `BarcodeDetector` now decodes `["qr_code", "data_matrix", "code_128", "code_39", "code_93"]` (was QR-only), for both the live-camera loop and the photo-capture `detectFromBlob`. Antminer serials are Code 128.
- **`useQrScanner`** — request an `ideal` 1920×1080 camera stream (was defaulting to ~640×480). A dense 1D barcode needs enough horizontal pixels across its bars to decode; QR survives a lower-res frame, 1D often doesn't. `ideal` degrades gracefully on lesser cameras.
- **Copy** (`ScanMinerQrModalView`, `RackPane` popover) — made format-agnostic: "Scan miner barcode", "QR code or barcode", "code" instead of "QR code".

No server change: a decoded serial flows through the existing `parseScannedIdentifier` → `LookupMinerByIdentifier` path unchanged, regardless of symbology.

## Testing

- Verified the engine + these formats decode a real Antminer S21 label end-to-end: ran the actual label photo through `zxing-wasm` (the lib `barcode-detector` wraps) with the app's exact format list → `Code128: "DGAHFKABDJGJD01G1"`. Also round-tripped the serial through Code 128/39/93.
- `ScanMinerQrModal` tests updated for the copy change; 6/6 passing.
- `tsc --noEmit` ✅, `eslint --max-warnings 0` ✅ (format literals validated as `BarcodeFormat`s).

## Notes

- The self-hosted ZXing reader WASM (`initBarcodeScanner`) already supports all these symbologies, so no asset change was needed.
- Symbology set chosen for alphanumeric equipment serials (Code 128/39/93) + 2D (QR/Data Matrix); easy to extend (e.g. `itf`/`codabar`) if a vendor label needs it.