### PR TITLE
chore(ci): update GitHub Actions to latest pinned versions

### DIFF
--- a/.github/actions/go-cache-setup/action.yml
+++ b/.github/actions/go-cache-setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure Go cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cache/go-build
@@ -16,7 +16,7 @@ runs:
           ${{ runner.os }}-${{ runner.arch }}-go-
 
     - name: Configure golangci-lint cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/golangci-lint
         key: ${{ runner.os }}-${{ runner.arch }}-golangci-${{ hashFiles('**/.golangci.yaml', '**/go.sum') }}

--- a/.github/client-e2e-tests.yml
+++ b/.github/client-e2e-tests.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*

--- a/.github/workflows/asicrs-plugin-checks.yml
+++ b/.github/workflows/asicrs-plugin-checks.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: plugin/asicrs
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
         run: |
@@ -40,7 +40,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Cargo registry & build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -65,7 +65,7 @@ jobs:
         working-directory: plugin/asicrs
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
         run: |
@@ -78,7 +78,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Cargo registry & build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -27,7 +27,7 @@ jobs:
       REVIEW_DIFF_FILE: .git/codex-review.diff
     steps:
       - name: Checkout PR head commit
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -53,7 +53,7 @@ jobs:
       - name: Run Codex Security Review
         id: run_codex
         if: ${{ env.OPENAI_API_KEY != '' }}
-        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1.8
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           openai-api-key: ${{ env.OPENAI_API_KEY }}
           model: ${{ env.CODEX_MODEL }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Checkout code
         if: ${{ !github.event.repository.private }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Dependency Review
         if: ${{ !github.event.repository.private }}

--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Validate host profiles and compose interpolation
         run: ./deployment-files/tests/test-profiles.sh

--- a/.github/workflows/generated-code-check.yml
+++ b/.github/workflows/generated-code-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/mdk-api-docs.yml
+++ b/.github/workflows/mdk-api-docs.yml
@@ -30,7 +30,7 @@ jobs:
     name: Build Redoc site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20

--- a/.github/workflows/migration-hygiene.yml
+++ b/.github/workflows/migration-hygiene.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - name: Checkout PR merge result
         if: ${{ github.event.pull_request != null }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Checkout current ref
         if: ${{ github.event.pull_request == null }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -105,7 +105,7 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download deployment bundle artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/powershell-lint.yml
+++ b/.github/workflows/powershell-lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install PSScriptAnalyzer
         shell: powershell

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -37,11 +37,11 @@ jobs:
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Detect changed areas
         id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: .github/path-filters.yml
 

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -89,10 +89,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET SDK from global.json
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: deployment-files/windows/global.json
 
@@ -156,7 +156,7 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -186,7 +186,7 @@ jobs:
           chmod +x server/proto-plugin-* server/antminer-plugin-* server/virtual-plugin-*
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build asicrs plugin binary
         run: |
@@ -228,7 +228,7 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -279,7 +279,7 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -346,10 +346,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build TimescaleDB image
         run: |
@@ -385,7 +385,7 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Create deployment directory structure
         run: |

--- a/.github/workflows/protofleet-antminer-plugin-checks.yml
+++ b/.github/workflows/protofleet-antminer-plugin-checks.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: plugin/antminer
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-client-checks.yml
+++ b/.github/workflows/protofleet-client-checks.yml
@@ -23,13 +23,13 @@ jobs:
         working-directory: client
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
 
       - name: Cache npm dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('client/package-lock.json') }}
@@ -56,13 +56,13 @@ jobs:
         working-directory: client
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
 
       - name: Cache npm dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('client/package-lock.json') }}
@@ -84,13 +84,13 @@ jobs:
         working-directory: client
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
 
       - name: Cache npm dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('client/package-lock.json') }}

--- a/.github/workflows/protofleet-contract-checks.yml
+++ b/.github/workflows/protofleet-contract-checks.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/go-cache-setup
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # buildx's type=gha cache backend reads ACTIONS_RUNTIME_TOKEN and
       # ACTIONS_CACHE_URL (aka ACTIONS_RESULTS_URL) from the environment. These

--- a/.github/workflows/protofleet-e2e-real-miners-manual.yml
+++ b/.github/workflows/protofleet-e2e-real-miners-manual.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Activate hermit
         uses: cashapp/activate-hermit@12a728b03ad41eace0f9abaf98a035e7e8ea2318 # v1.1.4

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
       specs: ${{ steps.detect.outputs.specs }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -37,7 +37,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -52,7 +52,7 @@ jobs:
       # Rolldown's Linux binding), so we always run a clean `npm ci` and just
       # keep its downloads warm. This is also the pattern Client Checks uses.
       - name: Cache npm dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('client/package-lock.json') }}
@@ -70,7 +70,7 @@ jobs:
           npm run build:protoFleet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # Docker cache is computed before the plugin build so the gitignored
       # `server/plugins/*` binaries (not a Docker build input) don't enter
@@ -82,7 +82,7 @@ jobs:
       - name: Restore Docker image cache
         id: docker-image-cache
         if: github.event_name != 'schedule'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/docker-images
           # `server/**` because the Dockerfile does `COPY server/ ./`
@@ -114,7 +114,7 @@ jobs:
 
       - name: Save Docker image cache
         if: github.event_name != 'schedule' && steps.docker-image-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/docker-images
           key: ${{ runner.os }}-protofleet-e2e-docker-${{ hashFiles('server/**') }}
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -186,7 +186,7 @@ jobs:
       # See the build job: cache ~/.npm and run a clean `npm ci` rather than
       # caching a built node_modules.
       - name: Cache npm dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('client/package-lock.json') }}
@@ -195,7 +195,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('client/package-lock.json') }}
@@ -348,7 +348,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -359,7 +359,7 @@ jobs:
 
       # See the build job: cache ~/.npm and run a clean `npm ci`.
       - name: Cache npm dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('client/package-lock.json') }}

--- a/.github/workflows/protofleet-example-python-plugin-checks.yml
+++ b/.github/workflows/protofleet-example-python-plugin-checks.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: plugin/example-python
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-proto-checks.yml
+++ b/.github/workflows/protofleet-proto-checks.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-proto-plugin-checks.yml
+++ b/.github/workflows/protofleet-proto-plugin-checks.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: plugin/proto
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-server-checks.yml
+++ b/.github/workflows/protofleet-server-checks.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: server
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -53,7 +53,7 @@ jobs:
         working-directory: server
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -69,7 +69,7 @@ jobs:
       # the step). Cache the built image (same approach as the E2E build job)
       # and load it first so `docker compose up` finds it and skips the build.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # Rotate the cache weekly (ISO year-week) so a cache hit still rebuilds
       # against fresh upstream base images and packages (ubuntu, PostgreSQL,
@@ -81,7 +81,7 @@ jobs:
 
       - name: Restore TimescaleDB image cache
         id: tsdb-image-cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/docker-images
           key: ${{ runner.os }}-server-timescaledb-${{ steps.cache-week.outputs.week }}-${{ hashFiles('server/timescaledb/**') }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: Save TimescaleDB image cache
         if: steps.tsdb-image-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/docker-images
           key: ${{ runner.os }}-server-timescaledb-${{ steps.cache-week.outputs.week }}-${{ hashFiles('server/timescaledb/**') }}

--- a/.github/workflows/protofleet-virtual-plugin-checks.yml
+++ b/.github/workflows/protofleet-virtual-plugin-checks.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: plugin/virtual
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protoos-e2e-tests.yml
+++ b/.github/workflows/protoos-e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -40,7 +40,7 @@ jobs:
             fake-proto-rig
 
       - name: Cache Node modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             client/node_modules

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: packages/proto-python-gen
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -49,7 +49,7 @@ jobs:
         working-directory: server/sdk/v1/python
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -92,7 +92,7 @@ jobs:
         working-directory: packages/proto-python-gen
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     needs: [build-artifacts]
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download deployment bundle artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/rust-sdk-checks.yml
+++ b/.github/workflows/rust-sdk-checks.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: sdk/rust/proto-fleet-plugin
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
         run: |
@@ -39,7 +39,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Cargo registry & build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -67,7 +67,7 @@ jobs:
         working-directory: sdk/rust/proto-fleet-plugin
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
         run: |
@@ -80,7 +80,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Cargo registry & build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/windows-csharp-checks.yml
+++ b/.github/workflows/windows-csharp-checks.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET SDK from global.json
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: deployment-files/windows/global.json
 


### PR DESCRIPTION
Reviewable diff: +71/-71 across 28 files (excludes generated, test, and story files).

## Summary

Bumps every third-party GitHub Action used in this repo's workflows and composite actions to its latest released version, keeping the existing pin-to-commit-SHA convention (`owner/action@<full-sha> # <version>`). No workflow logic changes — only the `uses:` refs and their version comments.

## How it works

Each `uses:` line across `.github/workflows/`, `.github/actions/`, and `.github/client-e2e-tests.yml` was inventoried, the latest release tag for each action was resolved via the GitHub API, and the tag was dereferenced to its commit SHA. Actions already at their latest version were left untouched.

## Version changes

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v6.0.3 (and one v6.0.2) | v7.0.0 |
| `actions/cache` (incl. `cache/restore`, `cache/save`) | v5.0.5 | v6.1.0 |
| `docker/setup-buildx-action` | v4.1.0 | v4.2.0 |
| `actions/setup-dotnet` | v5.3.0 | v5.4.0 |
| `dorny/paths-filter` | v4.0.1 | v4.0.2 |
| `openai/codex-action` | v1.8 | v1.11 |

## Already at latest (unchanged)

`actions/download-artifact` v8.0.1, `actions/upload-artifact` v7.0.1, `actions/setup-node` v6.4.0, `actions/github-script` v9.0.0, `arduino/setup-protoc` v3.0.0, `crazy-max/ghaction-github-runtime` v4.0.0, `actions/labeler` v6.1.0, `actions/dependency-review-action` v5.0.0, `actions/upload-pages-artifact` v5.0.0, `actions/deploy-pages` v5.0.0, `cashapp/activate-hermit` v1.1.4.

## Key technical decisions & trade-offs

- **Major bumps included** (`checkout` v6→v7, `cache` v5→v6): both are routine runtime/Node updates from GitHub with no breaking input changes for the usage patterns in this repo. The `cache` v6 bump invalidates existing cache entries only if the key format changed (it did not); worst case is a cold cache on first run.
- **Kept full-SHA pinning** rather than floating tags, matching the repo's existing supply-chain posture.
- `openai/codex-action` has no GitHub releases, so the latest tag (v1.11) was resolved from the tags API directly.

## Testing & validation

- Verified no stale SHAs remain anywhere under `.github/` via grep.
- Each new SHA was resolved from the GitHub API (release tag → dereferenced tag object → commit SHA), not hand-copied.
- CI on this PR is the real validation: the pr-gate workflow exercises checkout, cache, buildx, and the setup actions directly.