### PR TITLE
feat(fleet): move site/building/rack/groups to end of miner table

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/minerTableColumnPreferences.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/minerTableColumnPreferences.test.ts
@@ -46,15 +46,15 @@ describe("minerTableColumnPreferences", () => {
       normalizeMinerTableColumnPreferences({
         columns: configurableMinerColumns.map((columnId) => ({ id: columnId, visible: true })),
       }),
-      minerCols.workerName,
       minerCols.groups,
+      minerCols.model,
     );
 
     expect(buildActiveMinerColumns(reordered).slice(0, 4)).toEqual([
       minerCols.name,
-      minerCols.workerName,
       minerCols.groups,
-      minerCols.site,
+      minerCols.model,
+      minerCols.macAddress,
     ]);
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/minerTableColumnPreferences.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/minerTableColumnPreferences.ts
@@ -1,10 +1,6 @@
 import { minerCols, type MinerColumn } from "./constants";
 
 export const configurableMinerColumns = [
-  minerCols.groups,
-  minerCols.site,
-  minerCols.building,
-  minerCols.rack,
   minerCols.model,
   minerCols.macAddress,
   minerCols.ipAddress,
@@ -16,6 +12,10 @@ export const configurableMinerColumns = [
   minerCols.temperature,
   minerCols.firmware,
   minerCols.workerName,
+  minerCols.site,
+  minerCols.building,
+  minerCols.rack,
+  minerCols.groups,
 ] as const;
 
 export type ConfigurableMinerColumn = (typeof configurableMinerColumns)[number];


### PR DESCRIPTION
## Summary

Reorders the **default** column layout of the fleet miner list so a miner's own attributes (model, MAC, IP, status, health metrics, firmware, worker name) lead the table, and its physical/organizational location — site, building, rack, groups — trails at the end.

## How it works

The miner table's column order is driven by a single source of truth, `configurableMinerColumns`, in `minerTableColumnPreferences.ts`. This array defines both the canonical ordering and (via the default-preferences factory) the initial visibility. Moving the four location/grouping columns to the tail of that array is all that's needed — the reorder, visibility, normalization, and localStorage-persistence machinery all derive from it. The always-first `name` column is prepended separately and is unaffected.

The one reorder unit test that hard-coded the previous ordering was updated to exercise a still-meaningful move (a now-trailing column dragged to the front) while continuing to assert that `name` stays pinned first.

## Areas involved

- `client/.../MinerList/minerTableColumnPreferences.ts` — the column-order source of truth
- `client/.../MinerList/minerTableColumnPreferences.test.ts` — updated expectation

## Non-goals / deferred

- This changes the **default** only. Users who have already reordered/toggled columns keep their saved layout — the normalization step preserves stored ordering for known columns, so existing preferences are intentionally not migrated or reset.
- No change to which columns exist, their visibility defaults, the fixed `name` column, or the drag-to-reorder behavior.

## Testing

- Prettier + ESLint: clean on both files
- `vitest` MinerList suite: 13 files, 121 passed / 1 skipped