### PR TITLE
fix(dev): don't mark session cookie Secure in local dev stack

### DIFF
--- a/server/docker-compose.base.yaml
+++ b/server/docker-compose.base.yaml
@@ -8,10 +8,11 @@ services:
       DB_PASSWORD: "fleet"
       DB_SSL_MODE: "disable"
       HTTP_LISTEN_ADDRESS: "0.0.0.0:4000"
-      # Local dev is served over plain HTTP on a LAN IP (e.g. hitting the Vite
-      # dev server from a phone). A Secure cookie is silently dropped by the
-      # browser over http:// on a non-localhost origin, breaking login. HTTP
-      # deployments set this false too; production runs over HTTPS with it true.
+      # Base default for stacks that extend this file and serve over plain HTTP
+      # (local dev, the real-miners runner, etc.): browsers silently drop a
+      # Secure cookie over http:// on a non-localhost origin (e.g. a LAN IP),
+      # which breaks login. The production deployment compose overrides this to
+      # "${SESSION_COOKIE_SECURE:-true}" since it runs over HTTPS.
       SESSION_COOKIE_SECURE: "false"
       LOG_LEVEL: "INFO"
       FLEET_COMMAND_MAX_WORKERS: "500"

--- a/server/docker-compose.base.yaml
+++ b/server/docker-compose.base.yaml
@@ -8,6 +8,11 @@ services:
       DB_PASSWORD: "fleet"
       DB_SSL_MODE: "disable"
       HTTP_LISTEN_ADDRESS: "0.0.0.0:4000"
+      # Local dev is served over plain HTTP on a LAN IP (e.g. hitting the Vite
+      # dev server from a phone). A Secure cookie is silently dropped by the
+      # browser over http:// on a non-localhost origin, breaking login. HTTP
+      # deployments set this false too; production runs over HTTPS with it true.
+      SESSION_COOKIE_SECURE: "false"
       LOG_LEVEL: "INFO"
       FLEET_COMMAND_MAX_WORKERS: "500"
       FLEET_COMMAND_MASTER_POLLING_INTERVAL: "1s"


### PR DESCRIPTION
## Problem

Logging into the local dev app from a phone (or any other device on the LAN) shows the auth screen, accepts valid credentials, then silently bounces back to the auth screen with no visible error. Desktop login via `http://localhost` works fine.

## Root cause

Auth is session-cookie based: the login response sets an `HttpOnly` session cookie, and every subsequent request rides on it (`credentials: "include"`). The client only tracks session expiry in state — the cookie itself keeps you logged in.

The local `:4000` `fleet-api` container issues that cookie with `Secure: true` (the code default in `session/config.go`), and nothing overrides `SESSION_COOKIE_SECURE` for the dev stack.

- **Desktop works** — `http://localhost` is treated as a *secure context*, so browsers accept a `Secure` cookie over plain HTTP there.
- **Phone fails** — `http://<host-ip>:5173` is **not** a secure context, so the browser silently drops the `Secure` cookie. Login "succeeds" but nothing persists, and the next (unauthenticated) request bounces back to auth.

## Fix

Set `SESSION_COOKIE_SECURE: "false"` for the local dev stack in `docker-compose.base.yaml`. This only affects local `just dev`:

- HTTP deployments already flip this flag off (`deployment-files/run-fleet.sh`, Windows installer).
- Production runs over HTTPS with it `true` — unchanged.

## Testing

- Verified login now succeeds from an iPhone hitting the Vite dev server over the LAN after `docker compose up fleet-api -d --build --force-recreate`.
- Desktop login unaffected.