### PR TITLE
feat(rack): miner selection ux improvements in rack modal

### DIFF
--- a/client/e2eTests/protoFleet/pages/groups.ts
+++ b/client/e2eTests/protoFleet/pages/groups.ts
@@ -174,27 +174,34 @@ export class GroupsPage extends BasePage {
     }
   }
 
-  async filterModalType(type: string) {
-    await this.clickLocator(this.page.getByTestId("modal").getByTestId("filter-dropdown-Model"));
-    const popover = this.page.getByTestId("dropdown-filter-popover");
+  // The modal's filters live in a nested "Add filter" popover (matching the
+  // fleet miner list). The trigger is scoped to the modal; the popover/submenu
+  // are portaled to the body.
+  private async openModalFilterSubmenu(categoryKey: string) {
+    const trigger = this.page.getByTestId("modal").getByTestId("filter-nested-filters-meta");
+    await this.clickLocator(trigger);
+    const popover = this.page.getByTestId("nested-dropdown-filter-popover");
     await expect(popover).toBeVisible();
-    await expect(popover).toHaveCSS("opacity", "1");
-    await this.clickDropdownFilterOption(popover, [type]);
-    await this.clickLocator(popover.getByRole("button", { name: "Apply" }));
+
+    await popover.getByTestId(`nested-dropdown-filter-row-${categoryKey}`).click();
+    const desktopSubmenu = this.page.getByTestId(`nested-dropdown-filter-submenu-${categoryKey}`);
+    const mobileBack = popover.getByTestId("nested-dropdown-filter-back");
+    await expect(desktopSubmenu.or(mobileBack)).toBeVisible();
+    const submenu = (await desktopSubmenu.isVisible().catch(() => false)) ? desktopSubmenu : popover;
+    return { trigger, popover, submenu };
+  }
+
+  async filterModalType(type: string) {
+    const { trigger, popover, submenu } = await this.openModalFilterSubmenu("model");
+    await this.clickDropdownFilterOption(submenu, [type]);
+    await this.clickLocator(trigger);
     await expect(popover).toBeHidden();
   }
 
   async filterModalGroup(groupName: string) {
-    await this.page.getByTestId("modal").getByTestId("filter-dropdown-Group").click();
-    const popover = this.page.getByTestId("dropdown-filter-popover");
-    await expect(popover).toBeVisible();
-    await expect(popover).toHaveCSS("opacity", "1");
-
-    const resetButton = popover.getByRole("button", { name: "Reset" });
-    await resetButton.click();
-
-    await popover.getByText(groupName, { exact: true }).click();
-    await popover.getByRole("button", { name: "Apply" }).click();
+    const { trigger, popover, submenu } = await this.openModalFilterSubmenu("group");
+    await this.clickDropdownFilterOption(submenu, [groupName]);
+    await this.clickLocator(trigger);
     await expect(popover).toBeHidden();
   }
 

--- a/client/e2eTests/protoFleet/pages/groups.ts
+++ b/client/e2eTests/protoFleet/pages/groups.ts
@@ -177,11 +177,24 @@ export class GroupsPage extends BasePage {
   // The modal's filters live in a nested "Add filter" popover (matching the
   // fleet miner list). The trigger is scoped to the modal; the popover/submenu
   // are portaled to the body.
-  private async openModalFilterSubmenu(categoryKey: string) {
+  private async openModalFilterSubmenu(categoryKey: string, clearFirst = false) {
     const trigger = this.page.getByTestId("modal").getByTestId("filter-nested-filters-meta");
     await this.clickLocator(trigger);
     const popover = this.page.getByTestId("nested-dropdown-filter-popover");
     await expect(popover).toBeVisible();
+
+    if (clearFirst) {
+      // Checkbox facets accumulate, so callers that expect one selection to
+      // replace the last must clear first. "Clear all" only renders when
+      // something is selected, and clicking it closes the popover.
+      const clearAll = popover.getByRole("button", { name: "Clear all" });
+      if (await clearAll.isVisible().catch(() => false)) {
+        await clearAll.click();
+        await expect(popover).toBeHidden();
+        await this.clickLocator(trigger);
+        await expect(popover).toBeVisible();
+      }
+    }
 
     await popover.getByTestId(`nested-dropdown-filter-row-${categoryKey}`).click();
     const desktopSubmenu = this.page.getByTestId(`nested-dropdown-filter-submenu-${categoryKey}`);
@@ -199,7 +212,9 @@ export class GroupsPage extends BasePage {
   }
 
   async filterModalGroup(groupName: string) {
-    const { trigger, popover, submenu } = await this.openModalFilterSubmenu("group");
+    // Each call replaces the previously-filtered group (see the group-filter
+    // validation spec), so clear the prior selection first.
+    const { trigger, popover, submenu } = await this.openModalFilterSubmenu("group", true);
     await this.clickDropdownFilterOption(submenu, [groupName]);
     await this.clickLocator(trigger);
     await expect(popover).toBeHidden();

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -90,11 +90,28 @@ export class RacksPage extends BasePage {
   }
 
   async filterModalType(type: string) {
-    await this.page.getByTestId("modal").getByTestId("filter-dropdown-Model").click();
-    const popover = this.page.getByTestId("dropdown-filter-popover");
+    // The modal's filters live in a nested "Add filter" popover (matching the
+    // fleet miner list). Scope the trigger to the modal so we don't hit the
+    // rack-overview page's own filter behind it; the popover/submenu are
+    // portaled to the body, so query them page-level.
+    const trigger = this.page.getByTestId("modal").getByTestId("filter-nested-filters-meta");
+    await trigger.click();
+    const popover = this.page.getByTestId("nested-dropdown-filter-popover");
     await expect(popover).toBeVisible();
-    await this.clickDropdownFilterOption(popover, type);
-    await popover.getByRole("button", { name: "Apply" }).click();
+
+    await popover.getByTestId("nested-dropdown-filter-row-model").click();
+    // Desktop portals a side submenu; phone/tablet collapses the options into the
+    // popover with a "back" header.
+    const desktopSubmenu = this.page.getByTestId("nested-dropdown-filter-submenu-model");
+    const mobileBack = popover.getByTestId("nested-dropdown-filter-back");
+    await expect(desktopSubmenu.or(mobileBack)).toBeVisible();
+    const submenu = (await desktopSubmenu.isVisible().catch(() => false)) ? desktopSubmenu : popover;
+
+    await this.clickDropdownFilterOption(submenu, type);
+
+    // Checkbox selection applies immediately; toggle the trigger to close the
+    // popover so it doesn't overlay the list.
+    await trigger.click();
     await expect(popover).toBeHidden();
   }
 

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -126,7 +126,7 @@ describe("MinerSelectionList site scope", () => {
     await act(async () => {
       await listProps.onServerFilter({
         buttonFilters: [],
-        dropdownFilters: { type: ["S21"] },
+        dropdownFilters: { model: ["S21"] },
         numericFilters: {},
         textareaListFilters: {},
       });
@@ -150,7 +150,7 @@ describe("MinerSelectionList site scope", () => {
     await act(async () => {
       await listProps.onServerFilter({
         buttonFilters: [],
-        dropdownFilters: { type: ["S21"] },
+        dropdownFilters: { model: ["S21"] },
         numericFilters: {},
         textareaListFilters: {},
       });

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -9,7 +9,7 @@ const { fleetArgsSpy, listPropsSpy, listRacksMock, listGroupsMock, hasPermMock }
   listPropsSpy: vi.fn(),
   listRacksMock: vi.fn(),
   listGroupsMock: vi.fn(),
-  hasPermMock: vi.fn(() => true),
+  hasPermMock: vi.fn((_perm: string) => true),
 }));
 
 vi.mock("@/protoFleet/api/useFleet", () => ({
@@ -234,7 +234,9 @@ describe("MinerSelectionList eligibility", () => {
 
   it("hides the Site/Building facets when the user lacks site:read", () => {
     hasPermMock.mockReturnValue(false);
-    render(<MinerSelectionList filterConfig={{ showTypeFilter: true, showSiteFilter: true, showBuildingFilter: true }} />);
+    render(
+      <MinerSelectionList filterConfig={{ showTypeFilter: true, showSiteFilter: true, showBuildingFilter: true }} />,
+    );
     const filters = lastListProps()?.filters as { children?: { title: string }[] }[] | undefined;
     const titles = filters?.[0]?.children?.map((c) => c.title) ?? [];
     expect(titles).toContain("Model");

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -199,7 +199,7 @@ describe("MinerSelectionList eligibility", () => {
     expect(filter.siteIds).toEqual([]);
   });
 
-  it("overrides a user-selected Rack facet with the target rack while assignable-only is on", async () => {
+  it("respects a Rack facet that includes the target rack, dropping unracked, in assignable-only mode", async () => {
     render(<MinerSelectionList eligibility={{ rackId: 1n }} filterConfig={{ showRackFilter: true }} />);
 
     const listProps = lastListProps() as {
@@ -210,18 +210,19 @@ describe("MinerSelectionList eligibility", () => {
         textareaListFilters: Record<string, string[]>;
       }) => Promise<void>;
     };
+    // Facet the target rack itself: the facet now defines the dimension, so the
+    // request pins to it and stops OR-ing in unracked miners.
     await act(async () => {
       await listProps.onServerFilter({
         buttonFilters: [],
-        dropdownFilters: { rack: ["9"] },
+        dropdownFilters: { rack: ["1"] },
         numericFilters: {},
         textareaListFilters: {},
       });
     });
 
-    // The other rack (9) is dropped; only the target rack + unracked are admitted.
     expect(lastFleetFilter().rackIds).toEqual([1n]);
-    expect(lastFleetFilter().includeNoRack).toBe(true);
+    expect(lastFleetFilter().includeNoRack).toBe(false);
   });
 
   it("shows an empty result when a placement facet conflicts with the target rack (assignable-only)", async () => {

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -303,7 +303,7 @@ describe("MinerSelectionList eligibility", () => {
     expect(lastListProps()?.isRowDisabled).toBeUndefined();
   });
 
-  it("flags reassignment rows with orange text via colConfig", () => {
+  it("adds a conflict icon-button to the name cell only for reassignment rows", () => {
     render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n, buildingId: 3n }} />);
     const colConfig = lastListProps()?.colConfig as Record<
       string,
@@ -318,17 +318,18 @@ describe("MinerSelectionList eligibility", () => {
       buildingLabel: "",
       groupLabels: [],
     };
+    const conflictButton = "button[aria-label*='Assignment conflict']";
 
-    // In the target rack — not a reassignment, no orange.
+    // In the target rack — not a reassignment, no conflict icon.
     const eligible = render(
       <>{colConfig.name.component({ deviceIdentifier: "a", rackId: 1n, siteId: 2n, buildingId: 3n, ...base }, [])}</>,
     );
-    expect(eligible.container.querySelector(".text-text-emphasis")).toBeNull();
+    expect(eligible.container.querySelector(conflictButton)).toBeNull();
 
-    // In another rack — reassignment, orange.
+    // In another rack — reassignment, conflict icon present.
     const ineligible = render(
       <>{colConfig.name.component({ deviceIdentifier: "b", rackId: 9n, siteId: 2n, buildingId: 3n, ...base }, [])}</>,
     );
-    expect(ineligible.container.querySelector(".text-text-emphasis")).not.toBeNull();
+    expect(ineligible.container.querySelector(conflictButton)).not.toBeNull();
   });
 });

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -218,6 +218,14 @@ describe("MinerSelectionList eligibility", () => {
     expect(lastFleetFilter().includeNoRack).toBe(true);
   });
 
+  it("hides Select all while 'Show assigned miners' is on (avoids silently dropping reparent picks)", () => {
+    render(<MinerSelectionList eligibility={{ rackId: 1n }} />);
+    expect(screen.getByText("Select all")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Show assigned miners"));
+    expect(screen.queryByText("Select all")).not.toBeInTheDocument();
+  });
+
   it("renders the assignable-only toggle only when eligibility is provided", () => {
     const { rerender } = render(<MinerSelectionList />);
     expect(lastListProps()?.headerControls).toBeFalsy();

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -4,11 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import MinerSelectionList from "./MinerSelectionList";
 
-const { fleetArgsSpy, listPropsSpy, listRacksMock, listGroupsMock } = vi.hoisted(() => ({
+const { fleetArgsSpy, listPropsSpy, listRacksMock, listGroupsMock, hasPermMock } = vi.hoisted(() => ({
   fleetArgsSpy: vi.fn(),
   listPropsSpy: vi.fn(),
   listRacksMock: vi.fn(),
   listGroupsMock: vi.fn(),
+  hasPermMock: vi.fn(() => true),
 }));
 
 vi.mock("@/protoFleet/api/useFleet", () => ({
@@ -50,6 +51,10 @@ vi.mock("@/protoFleet/api/sites", () => ({
 
 vi.mock("@/protoFleet/api/buildings", () => ({
   useBuildings: () => ({ listBuildings: vi.fn() }),
+}));
+
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: (perm: string) => hasPermMock(perm),
 }));
 
 vi.mock("@/shared/components/List", () => ({
@@ -161,6 +166,7 @@ describe("MinerSelectionList eligibility", () => {
     listPropsSpy.mockReset();
     listRacksMock.mockReset();
     listGroupsMock.mockReset();
+    hasPermMock.mockReturnValue(true);
   });
 
   const lastFleetFilter = () => {
@@ -224,6 +230,16 @@ describe("MinerSelectionList eligibility", () => {
 
     fireEvent.click(screen.getByLabelText("Show assigned miners"));
     expect(screen.queryByText("Select all")).not.toBeInTheDocument();
+  });
+
+  it("hides the Site/Building facets when the user lacks site:read", () => {
+    hasPermMock.mockReturnValue(false);
+    render(<MinerSelectionList filterConfig={{ showTypeFilter: true, showSiteFilter: true, showBuildingFilter: true }} />);
+    const filters = lastListProps()?.filters as { children?: { title: string }[] }[] | undefined;
+    const titles = filters?.[0]?.children?.map((c) => c.title) ?? [];
+    expect(titles).toContain("Model");
+    expect(titles).not.toContain("Site");
+    expect(titles).not.toContain("Building");
   });
 
   it("renders the assignable-only toggle only when eligibility is provided", () => {

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -224,6 +224,32 @@ describe("MinerSelectionList eligibility", () => {
     expect(lastFleetFilter().includeNoRack).toBe(true);
   });
 
+  it("shows an empty result when a placement facet conflicts with the target rack (assignable-only)", async () => {
+    render(
+      <MinerSelectionList eligibility={{ rackId: 1n, buildingId: 3n }} filterConfig={{ showBuildingFilter: true }} />,
+    );
+
+    const listProps = lastListProps() as {
+      onServerFilter: (filters: {
+        buttonFilters: string[];
+        dropdownFilters: Record<string, string[]>;
+        numericFilters: Record<string, unknown>;
+        textareaListFilters: Record<string, string[]>;
+      }) => Promise<void>;
+    };
+    // Filter to a building the target rack isn't in — nothing assignable matches.
+    await act(async () => {
+      await listProps.onServerFilter({
+        buttonFilters: [],
+        dropdownFilters: { building: ["9"] },
+        numericFilters: {},
+        textareaListFilters: {},
+      });
+    });
+
+    expect(lastListProps()?.items).toEqual([]);
+  });
+
   it("hides Select all while 'Show assigned miners' is on (avoids silently dropping reparent picks)", () => {
     render(<MinerSelectionList eligibility={{ rackId: 1n }} />);
     expect(screen.getByText("Select all")).toBeInTheDocument();

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import MinerSelectionList from "./MinerSelectionList";
@@ -43,11 +44,20 @@ vi.mock("@/protoFleet/api/useDeviceSets", () => ({
   }),
 }));
 
+vi.mock("@/protoFleet/api/sites", () => ({
+  useSites: () => ({ listSites: vi.fn() }),
+}));
+
+vi.mock("@/protoFleet/api/buildings", () => ({
+  useBuildings: () => ({ listBuildings: vi.fn() }),
+}));
+
 vi.mock("@/shared/components/List", () => ({
   __esModule: true,
-  default: (props: unknown) => {
+  default: (props: { headerControls?: ReactNode }) => {
     listPropsSpy(props);
-    return <div data-testid="list-stub" />;
+    // Render headerControls so the assignable-only toggle is interactive in tests.
+    return <div data-testid="list-stub">{props.headerControls}</div>;
   },
 }));
 
@@ -142,5 +152,83 @@ describe("MinerSelectionList site scope", () => {
     });
 
     expect(screen.getByText("Select all")).toBeInTheDocument();
+  });
+});
+
+describe("MinerSelectionList eligibility", () => {
+  beforeEach(() => {
+    fleetArgsSpy.mockReset();
+    listPropsSpy.mockReset();
+    listRacksMock.mockReset();
+    listGroupsMock.mockReset();
+  });
+
+  const lastFleetFilter = () => {
+    const calls = fleetArgsSpy.mock.calls;
+    return calls[calls.length - 1]?.[0]?.filter;
+  };
+
+  const lastListProps = () => listPropsSpy.mock.calls[listPropsSpy.mock.calls.length - 1]?.[0];
+
+  it("folds the target rack's rack/building/site into the filter when assignable-only is on (default)", () => {
+    render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n, buildingId: 3n }} />);
+
+    const filter = lastFleetFilter();
+    expect(filter.includeNoRack).toBe(true);
+    expect(filter.rackIds).toEqual([1n]);
+    expect(filter.includeNoBuilding).toBe(true);
+    expect(filter.buildingIds).toEqual([3n]);
+    expect(filter.includeUnassigned).toBe(true);
+    expect(filter.siteIds).toEqual([2n]);
+  });
+
+  it("excludes all racked miners for a new rack (no rack id) but adds no rack/site/building ids", () => {
+    render(<MinerSelectionList eligibility={{}} />);
+
+    const filter = lastFleetFilter();
+    expect(filter.includeNoRack).toBe(true);
+    expect(filter.rackIds).toEqual([]);
+    expect(filter.buildingIds).toEqual([]);
+    expect(filter.includeNoBuilding).toBe(false);
+    expect(filter.siteIds).toEqual([]);
+  });
+
+  it("renders the assignable-only toggle only when eligibility is provided", () => {
+    const { rerender } = render(<MinerSelectionList />);
+    expect(lastListProps()?.headerControls).toBeFalsy();
+
+    rerender(<MinerSelectionList eligibility={{ rackId: 1n }} />);
+    expect(lastListProps()?.headerControls).toBeTruthy();
+  });
+
+  it("re-requests server-side (drops the eligibility constraints) when the toggle is turned off", () => {
+    render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n, buildingId: 3n }} />);
+
+    // Default on: eligibility folded into the fetch.
+    expect(lastFleetFilter().includeNoRack).toBe(true);
+    expect(lastFleetFilter().rackIds).toEqual([1n]);
+
+    // Toggle off → a fresh fetch with the constraints removed (server request,
+    // not a client-side row filter).
+    fireEvent.click(screen.getByLabelText("Show assignable only"));
+
+    expect(lastFleetFilter().includeNoRack).toBe(false);
+    expect(lastFleetFilter().rackIds).toEqual([]);
+    expect(lastFleetFilter().buildingIds).toEqual([]);
+    expect(lastFleetFilter().siteIds).toEqual([]);
+  });
+
+  it("disables ineligible rows (id-based) via isRowDisabled", () => {
+    render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n, buildingId: 3n }} />);
+
+    const isRowDisabled = lastListProps()?.isRowDisabled as (item: unknown) => boolean;
+    // In the target rack — eligible.
+    expect(isRowDisabled({ deviceIdentifier: "a", rackId: 1n, siteId: 2n, buildingId: 3n })).toBe(false);
+    // In another rack — ineligible.
+    expect(isRowDisabled({ deviceIdentifier: "b", rackId: 9n, siteId: 2n, buildingId: 3n })).toBe(true);
+    // Different building — ineligible.
+    expect(isRowDisabled({ deviceIdentifier: "c", siteId: 2n, buildingId: 8n })).toBe(true);
+    // Unplaced — eligible.
+    expect(isRowDisabled({ deviceIdentifier: "d" })).toBe(false);
   });
 });

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -201,16 +201,17 @@ describe("MinerSelectionList eligibility", () => {
     expect(lastListProps()?.headerControls).toBeTruthy();
   });
 
-  it("re-requests server-side (drops the eligibility constraints) when the toggle is turned off", () => {
+  it("applies eligibility server-side by default and drops it when 'Show assigned miners' is on", () => {
     render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n, buildingId: 3n }} />);
 
-    // Default on: eligibility folded into the fetch.
+    // Default (toggle off): eligibility folded into the fetch so assigned-elsewhere
+    // miners are excluded server-side.
     expect(lastFleetFilter().includeNoRack).toBe(true);
     expect(lastFleetFilter().rackIds).toEqual([1n]);
 
-    // Toggle off → a fresh fetch with the constraints removed (server request,
-    // not a client-side row filter).
-    fireEvent.click(screen.getByLabelText("Show assignable only"));
+    // Turning "Show assigned miners" on → a fresh fetch with the constraints
+    // removed (server request, not a client-side row filter).
+    fireEvent.click(screen.getByLabelText("Show assigned miners"));
 
     expect(lastFleetFilter().includeNoRack).toBe(false);
     expect(lastFleetFilter().rackIds).toEqual([]);
@@ -218,17 +219,39 @@ describe("MinerSelectionList eligibility", () => {
     expect(lastFleetFilter().siteIds).toEqual([]);
   });
 
-  it("disables ineligible rows (id-based) via isRowDisabled", () => {
+  it("keeps ineligible rows selectable (does not disable them)", () => {
     render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n, buildingId: 3n }} />);
+    // Reassignment is allowed (with a confirm at continue), so eligibility no
+    // longer disables rows — no isRowDisabled predicate is passed.
+    expect(lastListProps()?.isRowDisabled).toBeUndefined();
+  });
 
-    const isRowDisabled = lastListProps()?.isRowDisabled as (item: unknown) => boolean;
-    // In the target rack — eligible.
-    expect(isRowDisabled({ deviceIdentifier: "a", rackId: 1n, siteId: 2n, buildingId: 3n })).toBe(false);
-    // In another rack — ineligible.
-    expect(isRowDisabled({ deviceIdentifier: "b", rackId: 9n, siteId: 2n, buildingId: 3n })).toBe(true);
-    // Different building — ineligible.
-    expect(isRowDisabled({ deviceIdentifier: "c", siteId: 2n, buildingId: 8n })).toBe(true);
-    // Unplaced — eligible.
-    expect(isRowDisabled({ deviceIdentifier: "d" })).toBe(false);
+  it("flags reassignment rows with orange text via colConfig", () => {
+    render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n, buildingId: 3n }} />);
+    const colConfig = lastListProps()?.colConfig as Record<
+      string,
+      { component: (item: Record<string, unknown>, selected: string[]) => ReactNode }
+    >;
+    const base = {
+      name: "n",
+      model: "m",
+      ipAddress: "",
+      rackLabel: "",
+      siteLabel: "",
+      buildingLabel: "",
+      groupLabels: [],
+    };
+
+    // In the target rack — not a reassignment, no orange.
+    const eligible = render(
+      <>{colConfig.name.component({ deviceIdentifier: "a", rackId: 1n, siteId: 2n, buildingId: 3n, ...base }, [])}</>,
+    );
+    expect(eligible.container.querySelector(".text-text-emphasis")).toBeNull();
+
+    // In another rack — reassignment, orange.
+    const ineligible = render(
+      <>{colConfig.name.component({ deviceIdentifier: "b", rackId: 9n, siteId: 2n, buildingId: 3n, ...base }, [])}</>,
+    );
+    expect(ineligible.container.querySelector(".text-text-emphasis")).not.toBeNull();
   });
 });

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -193,6 +193,31 @@ describe("MinerSelectionList eligibility", () => {
     expect(filter.siteIds).toEqual([]);
   });
 
+  it("overrides a user-selected Rack facet with the target rack while assignable-only is on", async () => {
+    render(<MinerSelectionList eligibility={{ rackId: 1n }} filterConfig={{ showRackFilter: true }} />);
+
+    const listProps = lastListProps() as {
+      onServerFilter: (filters: {
+        buttonFilters: string[];
+        dropdownFilters: Record<string, string[]>;
+        numericFilters: Record<string, unknown>;
+        textareaListFilters: Record<string, string[]>;
+      }) => Promise<void>;
+    };
+    await act(async () => {
+      await listProps.onServerFilter({
+        buttonFilters: [],
+        dropdownFilters: { rack: ["9"] },
+        numericFilters: {},
+        textareaListFilters: {},
+      });
+    });
+
+    // The other rack (9) is dropped; only the target rack + unracked are admitted.
+    expect(lastFleetFilter().rackIds).toEqual([1n]);
+    expect(lastFleetFilter().includeNoRack).toBe(true);
+  });
+
   it("renders the assignable-only toggle only when eligibility is provided", () => {
     const { rerender } = render(<MinerSelectionList />);
     expect(lastListProps()?.headerControls).toBeFalsy();

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -357,17 +357,35 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         merged.includeUnassigned = scopeIncludeUnassigned;
       }
       if (!showAssigned && eligibilityEnabled) {
-        // Rack: admit unracked miners plus the target rack's own members.
-        // Override (not append) any user-selected Rack facet — while
-        // assignable-only is enforced, filtering to a *different* rack would
-        // otherwise pull that rack's members back in.
-        merged.includeNoRack = true;
-        merged.rackIds = eligRackId !== undefined ? [eligRackId] : [];
-        if (eligBuildingId !== undefined) {
+        // Each placement dimension is pinned to the target rack's value AND admits
+        // miners unassigned at that level (the assignable set = this rack's
+        // members + unplaced miners). When the operator has an explicit facet on a
+        // dimension, that facet *defines* it: intersect with the eligible value
+        // and drop the "include no ..." flag (they asked for specific
+        // racks/buildings/sites, not "unassigned"). A facet that excludes the
+        // target yields an empty intersection, surfaced as the
+        // placementFacetConflict empty state — so it never broadens the request.
+        if (userFilter.rackIds.length > 0) {
+          merged.rackIds = eligRackId !== undefined ? userFilter.rackIds.filter((id) => id === eligRackId) : [];
+          merged.includeNoRack = false;
+        } else {
+          merged.rackIds = eligRackId !== undefined ? [eligRackId] : [];
+          merged.includeNoRack = true;
+        }
+
+        if (userFilter.buildingIds.length > 0) {
+          merged.buildingIds =
+            eligBuildingId !== undefined ? userFilter.buildingIds.filter((id) => id === eligBuildingId) : [];
+          merged.includeNoBuilding = false;
+        } else if (eligBuildingId !== undefined) {
           merged.buildingIds = [eligBuildingId];
           merged.includeNoBuilding = true;
         }
-        if (eligSiteId !== undefined) {
+
+        if (userFilter.siteIds.length > 0) {
+          merged.siteIds = eligSiteId !== undefined ? userFilter.siteIds.filter((id) => id === eligSiteId) : [];
+          merged.includeUnassigned = false;
+        } else if (eligSiteId !== undefined) {
           merged.siteIds = [eligSiteId];
           merged.includeUnassigned = true;
         }

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { clone, create } from "@bufbuild/protobuf";
 
+import { useBuildings } from "@/protoFleet/api/buildings";
 import {
   SortConfigSchema,
   SortDirection as SortDirectionProto,
@@ -13,19 +14,32 @@ import {
   MinerListFilterSchema,
   PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import { useSites } from "@/protoFleet/api/sites";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import useFleet from "@/protoFleet/api/useFleet";
 import type { SiteFilterFields } from "@/protoFleet/components/PageHeader/SitePicker";
 import { INACTIVE_PLACEHOLDER } from "@/protoFleet/features/fleetManagement/components/MinerList/constants";
-import { getMinerGroupLabels, getMinerRackLabel } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
+import {
+  getMinerBuildingId,
+  getMinerBuildingLabel,
+  getMinerGroupLabels,
+  getMinerRackId,
+  getMinerRackLabel,
+  getMinerSiteId,
+  getMinerSiteLabel,
+  isPlacementIneligible,
+  type MinerEligibility,
+} from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 
-import { ChevronDown } from "@/shared/assets/icons";
+import { ChevronDown, Plus } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import List from "@/shared/components/List";
-import type { ActiveFilters, FilterItem } from "@/shared/components/List/Filters/types";
+import type { ActiveFilters, FilterItem, NestedFilterChildItem } from "@/shared/components/List/Filters/types";
 import type { ColConfig, ColTitles, SortDirection } from "@/shared/components/List/types";
 import { ModalSelectAllFooter } from "@/shared/components/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular";
+import Switch from "@/shared/components/Switch";
+import { expandSubnetLineToCidrs, normalizeSubnetLine, validateSubnetLine } from "@/shared/utils/filterValidation";
 
 // --- Exported types ---
 
@@ -35,14 +49,27 @@ export type DeviceListItem = {
   model: string;
   ipAddress: string;
   rackLabel: string;
+  siteLabel: string;
+  buildingLabel: string;
   groupLabels: string[];
+  // Placement identity (id-based), undefined when the miner is unassigned at
+  // that level. Drives eligibility checks that can't rely on labels (a
+  // same-named rack in another building would otherwise slip past).
+  rackId?: bigint;
+  siteId?: bigint;
+  buildingId?: bigint;
 };
 
 export type FilterConfig = {
   showTypeFilter?: boolean;
   showRackFilter?: boolean;
   showGroupFilter?: boolean;
+  showSubnetFilter?: boolean;
+  showSiteFilter?: boolean;
+  showBuildingFilter?: boolean;
 };
+
+export type { MinerEligibility };
 
 export interface MinerSelectionListHandle {
   getSelection: () => {
@@ -69,6 +96,12 @@ export interface MinerSelectionListProps {
   // MinerListFilter (AND with the user's model/rack/group facets) so applying a
   // facet never drops the site scope.
   scope?: SiteFilterFields;
+  // Target rack placement. When set, renders a "Show assignable only" toggle
+  // (default on) that folds rack/building/site eligibility into the server
+  // filter so miners in another rack/building/site drop out of the list
+  // entirely. When the toggle is off, ineligible miners are shown but disabled
+  // (id-based), so a cross-site pick can't happen silently.
+  eligibility?: MinerEligibility;
   onSelectionChange?: (state: {
     selectedItems: string[];
     allSelected: boolean;
@@ -81,8 +114,10 @@ export interface MinerSelectionListProps {
 const modalCols = {
   name: "name",
   type: "type",
-  rack: "rack",
   ipAddress: "ipAddress",
+  site: "site",
+  building: "building",
+  rack: "rack",
   group: "group",
 } as const;
 
@@ -91,16 +126,20 @@ type ModalColumn = (typeof modalCols)[keyof typeof modalCols];
 const modalColTitles: ColTitles<ModalColumn> = {
   name: "Name",
   type: "Model",
-  rack: "Rack",
   ipAddress: "IP address",
+  site: "Site",
+  building: "Building",
+  rack: "Rack",
   group: "Group",
 };
 
 const activeCols: ModalColumn[] = [
   modalCols.name,
   modalCols.type,
-  modalCols.rack,
   modalCols.ipAddress,
+  modalCols.site,
+  modalCols.building,
+  modalCols.rack,
   modalCols.group,
 ];
 
@@ -113,13 +152,21 @@ const modalColConfig: ColConfig<DeviceListItem, string, ModalColumn> = {
     component: (device: DeviceListItem) => <span>{device.model || INACTIVE_PLACEHOLDER}</span>,
     width: "min-w-20",
   },
-  [modalCols.rack]: {
-    component: (device: DeviceListItem) => <span>{device.rackLabel || INACTIVE_PLACEHOLDER}</span>,
-    width: "min-w-28",
-  },
   [modalCols.ipAddress]: {
     component: (device: DeviceListItem) => <span>{device.ipAddress || INACTIVE_PLACEHOLDER}</span>,
     width: "min-w-24",
+  },
+  [modalCols.site]: {
+    component: (device: DeviceListItem) => <span>{device.siteLabel || INACTIVE_PLACEHOLDER}</span>,
+    width: "min-w-24",
+  },
+  [modalCols.building]: {
+    component: (device: DeviceListItem) => <span>{device.buildingLabel || INACTIVE_PLACEHOLDER}</span>,
+    width: "min-w-24",
+  },
+  [modalCols.rack]: {
+    component: (device: DeviceListItem) => <span>{device.rackLabel || INACTIVE_PLACEHOLDER}</span>,
+    width: "min-w-28",
   },
   [modalCols.group]: {
     component: (device: DeviceListItem) => {
@@ -146,6 +193,8 @@ const hasUnsupportedAllSelectionFilter = (filter: MinerListFilter): boolean =>
   filter.rackIds.length > 0 ||
   filter.groupIds.length > 0 ||
   filter.siteIds.length > 0 ||
+  filter.buildingIds.length > 0 ||
+  filter.ipCidrs.length > 0 ||
   filter.includeUnassigned;
 
 const toDeviceListItem = (miner: ProtoMinerStateSnapshot): DeviceListItem => ({
@@ -154,7 +203,12 @@ const toDeviceListItem = (miner: ProtoMinerStateSnapshot): DeviceListItem => ({
   model: miner.model,
   ipAddress: miner.ipAddress,
   rackLabel: getMinerRackLabel(miner),
+  siteLabel: getMinerSiteLabel(miner),
+  buildingLabel: getMinerBuildingLabel(miner),
   groupLabels: getMinerGroupLabels(miner),
+  rackId: getMinerRackId(miner),
+  siteId: getMinerSiteId(miner),
+  buildingId: getMinerBuildingId(miner),
 });
 
 // --- Component ---
@@ -171,11 +225,19 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       disableFilteredSelectAll = false,
       showSelectAllFooter = true,
       scope,
+      eligibility,
       onSelectionChange,
     },
     ref,
   ) => {
-    const { showTypeFilter = true, showRackFilter = true, showGroupFilter = true } = filterConfig ?? {};
+    const {
+      showTypeFilter = true,
+      showRackFilter = true,
+      showGroupFilter = true,
+      showSubnetFilter = false,
+      showSiteFilter = false,
+      showBuildingFilter = false,
+    } = filterConfig ?? {};
 
     const scopeSiteIds = useMemo(() => scope?.siteIds ?? [], [scope]);
     const scopeIncludeUnassigned = scope?.includeUnassigned ?? false;
@@ -183,14 +245,31 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
     // actually changes (siteIds is a fresh bigint[] each render otherwise).
     const scopeKey = `${scopeSiteIds.map(String).join(",")}|${scopeIncludeUnassigned}`;
 
+    // Eligibility ids destructured to primitives so the derived filter memo has
+    // stable deps (the object prop is a fresh reference each render). Presence of
+    // the prop — not whether any id is set — enables the toggle and the rack
+    // exclusion, so a not-yet-placed new rack still filters out already-racked
+    // miners.
+    const eligibilityEnabled = eligibility !== undefined;
+    const eligRackId = eligibility?.rackId;
+    const eligSiteId = eligibility?.siteId;
+    const eligBuildingId = eligibility?.buildingId;
+    // "Show assignable only" — default on when a target rack is provided.
+    const [assignableOnly, setAssignableOnly] = useState(true);
+
     const { listGroups, listRacks } = useDeviceSets();
-    const [filter, setFilter] = useState(() =>
-      create(MinerListFilterSchema, { siteIds: scopeSiteIds, includeUnassigned: scopeIncludeUnassigned }),
-    );
+    const { listSites } = useSites();
+    const { listBuildings } = useBuildings();
+    // The user's facet selections (model / subnet / site / building / rack /
+    // group). Site scope and eligibility are layered on top in the derived
+    // `filter` below so applying a facet never drops those constraints.
+    const [userFilter, setUserFilter] = useState(() => create(MinerListFilterSchema, {}));
     const [selectedItems, setSelectedItems] = useState<string[]>(initialSelectedItems ?? []);
     const [allSelected, setAllSelected] = useState(initialAllSelected && !singleSelect);
     const [availableGroups, setAvailableGroups] = useState<DeviceSet[]>([]);
     const [availableRacks, setAvailableRacks] = useState<DeviceSet[]>([]);
+    const [availableSites, setAvailableSites] = useState<{ id: string; label: string }[]>([]);
+    const [availableBuildings, setAvailableBuildings] = useState<{ id: string; label: string }[]>([]);
     const [hasInitialSynced, setHasInitialSynced] = useState(!initialSelectedItems || initialSelectedItems.length > 0);
     const [currentSort, setCurrentSort] = useState<{ field: ModalColumn; direction: SortDirection } | undefined>(
       undefined,
@@ -206,6 +285,49 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         direction: currentSort.direction === "asc" ? SortDirectionProto.ASC : SortDirectionProto.DESC,
       });
     }, [currentSort]);
+
+    // Effective server filter: the user's facets + the active site scope +,
+    // when "assignable only" is on, the target rack's eligibility. Each
+    // eligibility dimension is null-permissive (in-rack-or-none, in-building-or
+    // -none, in-site-or-none), so the result excludes miners in a *different*
+    // rack/building/site while keeping unplaced and current-rack miners.
+    // useFleet dedupes by protobuf value equality, so a fresh object per render
+    // only triggers a refetch when the contents actually change.
+    const filter = useMemo(() => {
+      const merged = clone(MinerListFilterSchema, userFilter);
+      // Site scope is the soft baseline; a user-selected Site facet
+      // (userFilter.siteIds) is more specific and takes precedence.
+      if (merged.siteIds.length === 0) {
+        merged.siteIds = scopeSiteIds;
+        merged.includeUnassigned = scopeIncludeUnassigned;
+      }
+      if (assignableOnly && eligibilityEnabled) {
+        // Rack: always admit unracked miners; also admit the target rack's own
+        // members when it exists. Excludes miners in any other rack.
+        merged.includeNoRack = true;
+        if (eligRackId !== undefined && !merged.rackIds.includes(eligRackId)) {
+          merged.rackIds.push(eligRackId);
+        }
+        if (eligBuildingId !== undefined) {
+          merged.buildingIds = [eligBuildingId];
+          merged.includeNoBuilding = true;
+        }
+        if (eligSiteId !== undefined) {
+          merged.siteIds = [eligSiteId];
+          merged.includeUnassigned = true;
+        }
+      }
+      return merged;
+    }, [
+      userFilter,
+      scopeSiteIds,
+      scopeIncludeUnassigned,
+      assignableOnly,
+      eligibilityEnabled,
+      eligRackId,
+      eligBuildingId,
+      eligSiteId,
+    ]);
 
     const {
       minerIds,
@@ -232,12 +354,25 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         .filter((snapshot): snapshot is ProtoMinerStateSnapshot => Boolean(snapshot))
         .map(toDeviceListItem);
     }, [minerIds, miners]);
+
+    // A caller-supplied predicate wins; otherwise, when a target rack is set,
+    // disable ineligible rows. With "assignable only" on they're already
+    // filtered out server-side; with it off they render disabled so a
+    // cross-rack/site pick can't happen silently.
+    const effectiveIsRowDisabled = useMemo(() => {
+      if (isRowDisabled) return isRowDisabled;
+      if (!eligibilityEnabled) return undefined;
+      const target: MinerEligibility = { rackId: eligRackId, siteId: eligSiteId, buildingId: eligBuildingId };
+      return (item: DeviceListItem) => isPlacementIneligible(item, target);
+    }, [isRowDisabled, eligibilityEnabled, eligRackId, eligSiteId, eligBuildingId]);
+
     const currentSelectableItemIds = useMemo(
       () =>
-        (isRowDisabled ? currentPageItems.filter((device) => !isRowDisabled(device)) : currentPageItems).map(
-          (device) => device.deviceIdentifier,
-        ),
-      [currentPageItems, isRowDisabled],
+        (effectiveIsRowDisabled
+          ? currentPageItems.filter((device) => !effectiveIsRowDisabled(device))
+          : currentPageItems
+        ).map((device) => device.deviceIdentifier),
+      [currentPageItems, effectiveIsRowDisabled],
     );
     const displayedSelectedItems = allSelected && !singleSelect ? currentSelectableItemIds : selectedItems;
     const canSelectAll = !singleSelect && (!disableFilteredSelectAll || !hasUnsupportedAllSelectionFilter(filter));
@@ -323,41 +458,52 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       goToPrevPage();
     }, [scrollToTop, goToPrevPage]);
 
-    // Keep the active site scope folded into the filter when the selection
-    // changes mid-modal. Preserves the user's model/rack/group facets and only
-    // swaps the site fields.
-    useEffect(() => {
-      setFilter((current) => {
-        if (
-          current.siteIds.map(String).join(",") === scopeSiteIds.map(String).join(",") &&
-          current.includeUnassigned === scopeIncludeUnassigned
-        ) {
-          return current;
-        }
-        // Clone to preserve the user's model/rack/group facets, swapping only
-        // the site fields.
-        const next = clone(MinerListFilterSchema, current);
-        next.siteIds = scopeSiteIds;
-        next.includeUnassigned = scopeIncludeUnassigned;
-        return next;
-      });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [scopeKey]);
-
-    // Fetch filter options only for enabled filters. Rack facet options scope
-    // to the active site so the dropdown lists only the site's racks; group
-    // options stay org-wide until ListGroups gains site filtering (issue #520).
+    // Fetch filter options only for enabled filters. Rack/building facet options
+    // scope to the active site so the dropdowns list only the site's members;
+    // group and site options stay org-wide until ListGroups gains site filtering
+    // (issue #520).
     useEffect(() => {
       if (showGroupFilter) listGroups({ onSuccess: setAvailableGroups });
       if (showRackFilter)
         listRacks({ siteIds: scopeSiteIds, includeUnassigned: scopeIncludeUnassigned, onSuccess: setAvailableRacks });
+      if (showSiteFilter)
+        listSites({
+          onSuccess: (sites) =>
+            setAvailableSites(
+              sites.filter((s) => s.site !== undefined).map((s) => ({ id: String(s.site!.id), label: s.site!.name })),
+            ),
+        });
+      if (showBuildingFilter)
+        listBuildings({
+          siteIds: scopeSiteIds,
+          includeUnassigned: scopeIncludeUnassigned,
+          onSuccess: (buildings) =>
+            setAvailableBuildings(
+              buildings
+                .filter((b) => b.building !== undefined)
+                .map((b) => ({ id: String(b.building!.id), label: b.building!.name })),
+            ),
+        });
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [showGroupFilter, showRackFilter, listGroups, listRacks, scopeKey]);
+    }, [
+      showGroupFilter,
+      showRackFilter,
+      showSiteFilter,
+      showBuildingFilter,
+      listGroups,
+      listRacks,
+      listSites,
+      listBuildings,
+      scopeKey,
+    ]);
 
+    // A single "Add filter" popover (matching the fleet miner list) whose
+    // children mirror the displayed columns: Model, Subnet (IP), Site, Building,
+    // Rack, Group. Only enabled facets are offered.
     const filters = useMemo((): FilterItem[] => {
-      const items: FilterItem[] = [];
+      const children: NestedFilterChildItem[] = [];
       if (showTypeFilter) {
-        items.push({
+        children.push({
           type: "dropdown",
           title: "Model",
           value: "type",
@@ -365,8 +511,39 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
           defaultOptionIds: [],
         });
       }
+      if (showSubnetFilter) {
+        children.push({
+          type: "textareaList",
+          title: "Subnet",
+          value: "subnet",
+          validate: validateSubnetLine,
+          normalize: normalizeSubnetLine,
+          // Mirrors the onboarding discovery input: CIDR, bare IP, or IP range
+          // (short or full form).
+          placeholder: "192.168.1.0/24\n10.0.0.10-10.0.0.20\n10.0.0.42",
+          noun: "subnet",
+        });
+      }
+      if (showSiteFilter) {
+        children.push({
+          type: "dropdown",
+          title: "Site",
+          value: "site",
+          options: availableSites,
+          defaultOptionIds: [],
+        });
+      }
+      if (showBuildingFilter) {
+        children.push({
+          type: "dropdown",
+          title: "Building",
+          value: "building",
+          options: availableBuildings,
+          defaultOptionIds: [],
+        });
+      }
       if (showRackFilter) {
-        items.push({
+        children.push({
           type: "dropdown",
           title: "Rack",
           value: "rack",
@@ -375,7 +552,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         });
       }
       if (showGroupFilter) {
-        items.push({
+        children.push({
           type: "dropdown",
           title: "Group",
           value: "group",
@@ -383,40 +560,82 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
           defaultOptionIds: [],
         });
       }
-      return items;
-    }, [showTypeFilter, showRackFilter, showGroupFilter, availableModels, availableRacks, availableGroups]);
+      if (children.length === 0) return [];
+      return [
+        {
+          type: "nestedFilterDropdown",
+          title: "Add filter",
+          value: "filters-meta",
+          prefixIcon: <Plus width="w-3" />,
+          children,
+        },
+      ];
+    }, [
+      showTypeFilter,
+      showSubnetFilter,
+      showSiteFilter,
+      showBuildingFilter,
+      showRackFilter,
+      showGroupFilter,
+      availableModels,
+      availableSites,
+      availableBuildings,
+      availableRacks,
+      availableGroups,
+    ]);
 
+    // Build the user's facet filter (model / rack / group / subnet). Site scope
+    // and eligibility are layered on in the derived `filter` memo, so they're
+    // deliberately omitted here.
     const handleServerFilter = useCallback(
       async (activeFilters: ActiveFilters) => {
-        const minerFilter = create(MinerListFilterSchema, {
-          errorComponentTypes: [],
-          siteIds: scopeSiteIds,
-          includeUnassigned: scopeIncludeUnassigned,
-        });
+        const next = create(MinerListFilterSchema, { errorComponentTypes: [] });
 
         const typeFilters = activeFilters.dropdownFilters.type;
         if (typeFilters && typeFilters.length > 0) {
-          minerFilter.models.push(...typeFilters);
+          next.models.push(...typeFilters);
         }
 
         if (showRackFilter) {
           const rackFilters = activeFilters.dropdownFilters.rack;
           if (rackFilters && rackFilters.length > 0) {
-            minerFilter.rackIds.push(...rackFilters.map((id) => BigInt(id)));
+            next.rackIds.push(...rackFilters.map((id) => BigInt(id)));
           }
         }
 
         if (showGroupFilter) {
           const groupFilters = activeFilters.dropdownFilters.group;
           if (groupFilters && groupFilters.length > 0) {
-            minerFilter.groupIds.push(...groupFilters.map((id) => BigInt(id)));
+            next.groupIds.push(...groupFilters.map((id) => BigInt(id)));
           }
         }
 
-        setFilter(minerFilter);
+        if (showSiteFilter) {
+          const siteFilters = activeFilters.dropdownFilters.site;
+          if (siteFilters && siteFilters.length > 0) {
+            next.siteIds.push(...siteFilters.map((id) => BigInt(id)));
+          }
+        }
+
+        if (showBuildingFilter) {
+          const buildingFilters = activeFilters.dropdownFilters.building;
+          if (buildingFilters && buildingFilters.length > 0) {
+            next.buildingIds.push(...buildingFilters.map((id) => BigInt(id)));
+          }
+        }
+
+        if (showSubnetFilter) {
+          const subnetFilters = activeFilters.textareaListFilters.subnet;
+          if (subnetFilters && subnetFilters.length > 0) {
+            // Ranges expand to their covering CIDRs; CIDRs/IPs pass through. The
+            // server ORs all ip_cidrs and matches by containment.
+            next.ipCidrs.push(...subnetFilters.flatMap(expandSubnetLineToCidrs));
+          }
+        }
+
+        setUserFilter(next);
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [showRackFilter, showGroupFilter, scopeSiteIds, scopeIncludeUnassigned],
+      [showRackFilter, showGroupFilter, showSiteFilter, showBuildingFilter, showSubnetFilter],
     );
 
     const showSpinner = (isLoading || isMembersLoading) && currentPageItems.length === 0;
@@ -438,6 +657,21 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
             colConfig={modalColConfig}
             filters={filters}
             onServerFilter={handleServerFilter}
+            headerControls={
+              eligibilityEnabled ? (
+                // px-1 gives the toggle's hover scale-up room so it doesn't
+                // paint past the filter row's right edge and trigger horizontal
+                // scroll in the modal.
+                <div className="px-1">
+                  <Switch
+                    label="Show assignable only"
+                    ariaLabel="Show assignable only"
+                    checked={assignableOnly}
+                    setChecked={setAssignableOnly}
+                  />
+                </div>
+              ) : undefined
+            }
             items={currentPageItems}
             itemKey="deviceIdentifier"
             itemSelectable
@@ -448,7 +682,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
             customSelectedItems={displayedSelectedItems}
             customSetSelectedItems={handleSetSelectedItems}
             preserveOffPageSelection
-            isRowDisabled={isRowDisabled}
+            isRowDisabled={effectiveIsRowDisabled}
             total={totalMiners}
             hideTotal
             itemName={{ singular: "miner", plural: "miners" }}
@@ -497,8 +731,8 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
                 canSelectAll
                   ? () => {
                       setAllSelected(true);
-                      const selectableItems = isRowDisabled
-                        ? currentPageItems.filter((d) => !isRowDisabled(d))
+                      const selectableItems = effectiveIsRowDisabled
+                        ? currentPageItems.filter((d) => !effectiveIsRowDisabled(d))
                         : currentPageItems;
                       setSelectedItems(selectableItems.map((d) => d.deviceIdentifier));
                     }

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -79,8 +79,9 @@ export interface MinerSelectionListHandle {
     totalMiners: number | undefined;
     filter: MinerListFilter;
     // Selected ids that are currently assigned to a different rack/building/site
-    // (reassigning them moves them). Computed from the loaded pages, so it's
-    // exact for single-select and current-page multi-select.
+    // (reassigning them moves them). Covers off-page selections — placement is
+    // tracked for every item seen across pages, and a miner can only be selected
+    // from a page it appeared on.
     reassignedItems: string[];
   };
 }
@@ -313,12 +314,12 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         merged.includeUnassigned = scopeIncludeUnassigned;
       }
       if (!showAssigned && eligibilityEnabled) {
-        // Rack: always admit unracked miners; also admit the target rack's own
-        // members when it exists. Excludes miners in any other rack.
+        // Rack: admit unracked miners plus the target rack's own members.
+        // Override (not append) any user-selected Rack facet — while
+        // assignable-only is enforced, filtering to a *different* rack would
+        // otherwise pull that rack's members back in.
         merged.includeNoRack = true;
-        if (eligRackId !== undefined && !merged.rackIds.includes(eligRackId)) {
-          merged.rackIds.push(eligRackId);
-        }
+        merged.rackIds = eligRackId !== undefined ? [eligRackId] : [];
         if (eligBuildingId !== undefined) {
           merged.buildingIds = [eligBuildingId];
           merged.includeNoBuilding = true;
@@ -420,8 +421,14 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
 
     const scrollRef = useRef<HTMLDivElement>(null);
     const currentPageItemsRef = useRef(currentPageItems);
+    // Accumulates every item seen across pages so reassignment detection covers
+    // off-page selections. A miner can only be selected from a page it appeared
+    // on, so this map holds placement for every selectable id — unlike the
+    // parent's first-page-only snapshot cache.
+    const seenItemsRef = useRef<Map<string, DeviceListItem>>(new Map());
     useEffect(() => {
       currentPageItemsRef.current = currentPageItems;
+      for (const item of currentPageItems) seenItemsRef.current.set(item.deviceIdentifier, item);
     }, [currentPageItems]);
 
     const scrollToTop = useCallback(() => {
@@ -458,15 +465,14 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       ref,
       () => ({
         getSelection: () => {
-          const byId = new Map(currentPageItems.map((item) => [item.deviceIdentifier, item]));
           const reassignedItems = selectedItems.filter((id) => {
-            const item = byId.get(id);
+            const item = seenItemsRef.current.get(id);
             return item !== undefined && isReassignment(item);
           });
           return { selectedItems, allSelected, totalMiners, filter, reassignedItems };
         },
       }),
-      [selectedItems, allSelected, totalMiners, filter, currentPageItems, isReassignment],
+      [selectedItems, allSelected, totalMiners, filter, isReassignment],
     );
 
     const handleSetSelectedItems = useCallback(

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -272,18 +272,15 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
     // to flag the existing placement.
     const [showAssigned, setShowAssigned] = useState(false);
 
-    // Placement facets (Site / Building / Rack) only make sense when browsing
-    // beyond the assignable set. In assignable-only mode (a target rack, toggle
-    // off) eligibility already pins those dimensions to the rack's, so offering
-    // the facets there would let a conflicting pick silently override eligibility
-    // — so they're offered only when there's no target rack or "Show assigned
-    // miners" is on. Site/Building additionally require site:read (their options
-    // come from ListSites/ListBuildings); the Site/Building *columns* still
-    // render, since their labels ride on the miner snapshot, not those RPCs.
-    const placementFacetsAllowed = !eligibilityEnabled || showAssigned;
-    const showRackFilter = showRackFilterProp && placementFacetsAllowed;
-    const showSiteFilter = showSiteFilterProp && canReadSiteCatalog && placementFacetsAllowed;
-    const showBuildingFilter = showBuildingFilterProp && canReadSiteCatalog && placementFacetsAllowed;
+    // Site/Building facet options come from ListSites/ListBuildings (guarded by
+    // site:read), so those two facets are hidden for rack-management roles
+    // without that permission; the Site/Building *columns* still render since
+    // their labels ride on the miner snapshot. The facets stay visible in both
+    // toggle states — a facet that conflicts with the target rack's placement is
+    // handled by the assignable-only empty state below, not by hiding.
+    const showRackFilter = showRackFilterProp;
+    const showSiteFilter = showSiteFilterProp && canReadSiteCatalog;
+    const showBuildingFilter = showBuildingFilterProp && canReadSiteCatalog;
 
     const { listGroups, listRacks } = useDeviceSets();
     const { listSites } = useSites();
@@ -383,6 +380,38 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         .map(toDeviceListItem);
     }, [minerIds, miners]);
 
+    // Assignable-only + a conflicting placement facet = provably no results.
+    //
+    // In assignable-only mode (a target rack, "Show assigned miners" off), the
+    // derived filter pins site/building/rack to the target rack's placement.
+    // A user-selected Site/Building/Rack facet targets the same dimension, but
+    // MinerListFilter carries one id-list per dimension with OR semantics, so it
+    // *can't* express "building = A (eligibility) AND building = B (facet)" — the
+    // request can only send one. Rather than silently override the facet (show
+    // the rack's building instead of the picked one) or drop eligibility (leak
+    // ineligible rows via the server's include_no_rack coupling — see #702), we
+    // recognize the case client-side: if a placement facet doesn't include the
+    // target's id — or the target is unplaced at that level (undefined), so any
+    // facet there is unsatisfiable — nothing assignable can match, and we render
+    // the empty state instead of the (misleading) pinned-dimension results the
+    // server would still return. The facets stay visible and clearable, so this
+    // is self-correcting once the operator changes or removes the facet.
+    const placementFacetConflict = useMemo(() => {
+      if (showAssigned || !eligibilityEnabled) return false;
+      const conflicts = (facetIds: bigint[], targetId: bigint | undefined) =>
+        facetIds.length > 0 && (targetId === undefined || !facetIds.includes(targetId));
+      return (
+        conflicts(userFilter.rackIds, eligRackId) ||
+        conflicts(userFilter.buildingIds, eligBuildingId) ||
+        conflicts(userFilter.siteIds, eligSiteId)
+      );
+    }, [showAssigned, eligibilityEnabled, userFilter, eligRackId, eligBuildingId, eligSiteId]);
+
+    // Rows shown to the operator. A placement-facet conflict has no assignable
+    // matches, so present it as empty even though the server (queried with the
+    // pinned dimension) may return the target rack's miners.
+    const displayItems = placementFacetConflict ? [] : currentPageItems;
+
     // Miners assigned to a different rack/building/site are still selectable
     // (reassigning moves them, behind a confirm), but are flagged in orange so
     // the operator sees the existing placement. Only meaningful when "Show
@@ -436,6 +465,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       totalMiners !== undefined &&
       totalMiners > 0 &&
       !singleSelect &&
+      !placementFacetConflict &&
       (canSelectAll || allSelected || selectedItems.length > 0);
 
     const handleSort = useCallback((field: ModalColumn, direction: SortDirection) => {
@@ -750,7 +780,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
                 </div>
               ) : undefined
             }
-            items={currentPageItems}
+            items={displayItems}
             itemKey="deviceIdentifier"
             itemSelectable
             selectionType={singleSelect ? "radio" : "checkbox"}
@@ -767,8 +797,11 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
             containerClassName="min-h-0"
             overflowContainer
             stickyBgColor="bg-surface-elevated-base"
+            emptyStateRow={
+              <div className="py-10 text-center text-300 text-text-primary-70">No miners match these filters.</div>
+            }
             footerContent={
-              !isLoading && totalMiners !== undefined && totalMiners > 0 ? (
+              !placementFacetConflict && !isLoading && totalMiners !== undefined && totalMiners > 0 ? (
                 <div className="flex flex-col items-center gap-4 py-6">
                   <span className="text-300 text-text-primary">
                     Showing {currentPage * PAGE_SIZE + 1}–{currentPage * PAGE_SIZE + currentPageItems.length} of{" "}

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -662,7 +662,9 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         children.push({
           type: "dropdown",
           title: "Model",
-          value: "type",
+          // Keyed "model" to match the fleet miner list's nested filter (shared
+          // testids / category key), not the legacy "type".
+          value: "model",
           options: availableModels.map((model) => ({ id: model, label: model })),
           defaultOptionIds: [],
           showGroupDivider: true,
@@ -749,7 +751,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       async (activeFilters: ActiveFilters) => {
         const next = create(MinerListFilterSchema, { errorComponentTypes: [] });
 
-        const typeFilters = activeFilters.dropdownFilters.type;
+        const typeFilters = activeFilters.dropdownFilters.model;
         if (typeFilters && typeFilters.length > 0) {
           next.models.push(...typeFilters);
         }

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -84,6 +84,12 @@ export interface MinerSelectionListHandle {
     // tracked for every item seen across pages, and a miner can only be selected
     // from a page it appeared on.
     reassignedItems: string[];
+    // True when a placement facet conflicts with the target rack, so the list is
+    // showing an empty "no results" state. The selection is preserved (clearing
+    // the facet restores it), but callers must not act on it — committing would
+    // save a selection the operator can't see. Restored to false once the facet
+    // is cleared or changed.
+    blockedByFilter: boolean;
   };
 }
 
@@ -537,10 +543,17 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       }
     }, [initialSelectedItems, hasInitialSynced]);
 
-    // Notify parent of selection changes
+    // Notify parent of selection changes. While a placement facet conflicts, the
+    // list shows no results, so report an empty selection — this keeps callers
+    // that gate on selection (e.g. Search's Assign button) consistent with the
+    // empty view without discarding the underlying selection state.
     useEffect(() => {
+      if (placementFacetConflict) {
+        onSelectionChange?.({ selectedItems: [], allSelected: false, totalMiners });
+        return;
+      }
       onSelectionChange?.({ selectedItems, allSelected, totalMiners });
-    }, [selectedItems, allSelected, totalMiners, onSelectionChange]);
+    }, [selectedItems, allSelected, totalMiners, onSelectionChange, placementFacetConflict]);
 
     useEffect(() => {
       if (!allSelected || canSelectAll) {
@@ -559,10 +572,17 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
             const item = seenItemsRef.current.get(id);
             return item !== undefined && isReassignment(item);
           });
-          return { selectedItems, allSelected, totalMiners, filter, reassignedItems };
+          return {
+            selectedItems,
+            allSelected,
+            totalMiners,
+            filter,
+            reassignedItems,
+            blockedByFilter: placementFacetConflict,
+          };
         },
       }),
-      [selectedItems, allSelected, totalMiners, filter, isReassignment],
+      [selectedItems, allSelected, totalMiners, filter, isReassignment, placementFacetConflict],
     );
 
     const handleSetSelectedItems = useCallback(

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -30,6 +30,7 @@ import {
   isPlacementIneligible,
   type MinerEligibility,
 } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
+import { useHasPermission } from "@/protoFleet/store";
 
 import { ChevronDown, Info, Plus } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -242,9 +243,19 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       showRackFilter = true,
       showGroupFilter = true,
       showSubnetFilter = false,
-      showSiteFilter = false,
-      showBuildingFilter = false,
+      showSiteFilter: showSiteFilterProp = false,
+      showBuildingFilter: showBuildingFilterProp = false,
     } = filterConfig ?? {};
+
+    // Site/Building facet options come from ListSites/ListBuildings, which are
+    // guarded by site:read. Roles that manage racks without it (e.g. FIELD_TECH)
+    // would otherwise fire permission-denied RPCs and get empty facets, so hide
+    // these facets when the site catalog isn't readable. The Site/Building
+    // columns still render — their labels come from the miner snapshot, not
+    // these RPCs.
+    const canReadSiteCatalog = useHasPermission("site:read");
+    const showSiteFilter = showSiteFilterProp && canReadSiteCatalog;
+    const showBuildingFilter = showBuildingFilterProp && canReadSiteCatalog;
 
     const scopeSiteIds = useMemo(() => scope?.siteIds ?? [], [scope]);
     const scopeIncludeUnassigned = scope?.includeUnassigned ?? false;

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -31,8 +31,9 @@ import {
   type MinerEligibility,
 } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 
-import { ChevronDown, Plus } from "@/shared/assets/icons";
+import { ChevronDown, Info, Plus } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
+import Dialog from "@/shared/components/Dialog";
 import List from "@/shared/components/List";
 import type { ActiveFilters, FilterItem, NestedFilterChildItem } from "@/shared/components/List/Filters/types";
 import type { ColConfig, ColTitles, SortDirection } from "@/shared/components/List/types";
@@ -77,6 +78,10 @@ export interface MinerSelectionListHandle {
     allSelected: boolean;
     totalMiners: number | undefined;
     filter: MinerListFilter;
+    // Selected ids that are currently assigned to a different rack/building/site
+    // (reassigning them moves them). Computed from the loaded pages, so it's
+    // exact for single-select and current-page multi-select.
+    reassignedItems: string[];
   };
 }
 
@@ -96,11 +101,12 @@ export interface MinerSelectionListProps {
   // MinerListFilter (AND with the user's model/rack/group facets) so applying a
   // facet never drops the site scope.
   scope?: SiteFilterFields;
-  // Target rack placement. When set, renders a "Show assignable only" toggle
-  // (default on) that folds rack/building/site eligibility into the server
-  // filter so miners in another rack/building/site drop out of the list
-  // entirely. When the toggle is off, ineligible miners are shown but disabled
-  // (id-based), so a cross-site pick can't happen silently.
+  // Target rack placement. When set, renders a "Show assigned miners" toggle
+  // (default off) that folds rack/building/site eligibility into the server
+  // filter, so miners already assigned to another rack/building/site drop out.
+  // Turning it on surfaces those miners — still selectable (reassigning moves
+  // them, behind a caller confirm) and flagged in orange to show the existing
+  // placement.
   eligibility?: MinerEligibility;
   onSelectionChange?: (state: {
     selectedItems: string[];
@@ -254,8 +260,13 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
     const eligRackId = eligibility?.rackId;
     const eligSiteId = eligibility?.siteId;
     const eligBuildingId = eligibility?.buildingId;
-    // "Show assignable only" — default on when a target rack is provided.
-    const [assignableOnly, setAssignableOnly] = useState(true);
+    const [showAssignedInfo, setShowAssignedInfo] = useState(false);
+    // "Show assigned miners" — default off, so the list starts with only
+    // assignable (unassigned + this-rack) miners. Turning it on also surfaces
+    // miners currently assigned to another rack/building/site; they stay
+    // selectable (reassigning moves them, behind a confirm) and render in orange
+    // to flag the existing placement.
+    const [showAssigned, setShowAssigned] = useState(false);
 
     const { listGroups, listRacks } = useDeviceSets();
     const { listSites } = useSites();
@@ -301,7 +312,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         merged.siteIds = scopeSiteIds;
         merged.includeUnassigned = scopeIncludeUnassigned;
       }
-      if (assignableOnly && eligibilityEnabled) {
+      if (!showAssigned && eligibilityEnabled) {
         // Rack: always admit unracked miners; also admit the target rack's own
         // members when it exists. Excludes miners in any other rack.
         merged.includeNoRack = true;
@@ -322,7 +333,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       userFilter,
       scopeSiteIds,
       scopeIncludeUnassigned,
-      assignableOnly,
+      showAssigned,
       eligibilityEnabled,
       eligRackId,
       eligBuildingId,
@@ -355,25 +366,45 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         .map(toDeviceListItem);
     }, [minerIds, miners]);
 
-    // A caller-supplied predicate wins; otherwise, when a target rack is set,
-    // disable ineligible rows. With "assignable only" on they're already
-    // filtered out server-side; with it off they render disabled so a
-    // cross-rack/site pick can't happen silently.
-    const effectiveIsRowDisabled = useMemo(() => {
-      if (isRowDisabled) return isRowDisabled;
-      if (!eligibilityEnabled) return undefined;
-      const target: MinerEligibility = { rackId: eligRackId, siteId: eligSiteId, buildingId: eligBuildingId };
-      return (item: DeviceListItem) => isPlacementIneligible(item, target);
-    }, [isRowDisabled, eligibilityEnabled, eligRackId, eligSiteId, eligBuildingId]);
+    // Miners assigned to a different rack/building/site are still selectable
+    // (reassigning moves them, behind a confirm), but are flagged in orange so
+    // the operator sees the existing placement. Only meaningful when "Show
+    // assigned miners" is on; otherwise they're filtered out server-side.
+    const isReassignment = useCallback(
+      (item: DeviceListItem) =>
+        eligibilityEnabled &&
+        isPlacementIneligible(item, { rackId: eligRackId, siteId: eligSiteId, buildingId: eligBuildingId }),
+      [eligibilityEnabled, eligRackId, eligSiteId, eligBuildingId],
+    );
 
     const currentSelectableItemIds = useMemo(
       () =>
-        (effectiveIsRowDisabled
-          ? currentPageItems.filter((device) => !effectiveIsRowDisabled(device))
-          : currentPageItems
-        ).map((device) => device.deviceIdentifier),
-      [currentPageItems, effectiveIsRowDisabled],
+        (isRowDisabled ? currentPageItems.filter((device) => !isRowDisabled(device)) : currentPageItems).map(
+          (device) => device.deviceIdentifier,
+        ),
+      [currentPageItems, isRowDisabled],
     );
+
+    // Wrap the base column renderers so a reassignment row's text is orange.
+    // Wrapping (rather than editing each cell) keeps the placement flag in one
+    // place and lets the inner cells inherit the color.
+    const colConfig = useMemo<ColConfig<DeviceListItem, string, ModalColumn>>(() => {
+      const wrapped: ColConfig<DeviceListItem, string, ModalColumn> = {};
+      (Object.keys(modalColConfig) as ModalColumn[]).forEach((col) => {
+        const base = modalColConfig[col];
+        if (!base) return;
+        const baseComponent = base.component;
+        wrapped[col] = {
+          ...base,
+          component: (device: DeviceListItem, selectedItems: string[]) => (
+            <span className={isReassignment(device) ? "text-text-emphasis" : undefined}>
+              {baseComponent ? baseComponent(device, selectedItems) : null}
+            </span>
+          ),
+        };
+      });
+      return wrapped;
+    }, [isReassignment]);
     const displayedSelectedItems = allSelected && !singleSelect ? currentSelectableItemIds : selectedItems;
     const canSelectAll = !singleSelect && (!disableFilteredSelectAll || !hasUnsupportedAllSelectionFilter(filter));
     const shouldShowSelectionFooter =
@@ -426,9 +457,16 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
     useImperativeHandle(
       ref,
       () => ({
-        getSelection: () => ({ selectedItems, allSelected, totalMiners, filter }),
+        getSelection: () => {
+          const byId = new Map(currentPageItems.map((item) => [item.deviceIdentifier, item]));
+          const reassignedItems = selectedItems.filter((id) => {
+            const item = byId.get(id);
+            return item !== undefined && isReassignment(item);
+          });
+          return { selectedItems, allSelected, totalMiners, filter, reassignedItems };
+        },
       }),
-      [selectedItems, allSelected, totalMiners, filter],
+      [selectedItems, allSelected, totalMiners, filter, currentPageItems, isReassignment],
     );
 
     const handleSetSelectedItems = useCallback(
@@ -500,6 +538,8 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
     // A single "Add filter" popover (matching the fleet miner list) whose
     // children mirror the displayed columns: Model, Subnet (IP), Site, Building,
     // Rack, Group. Only enabled facets are offered.
+    // Order and grouping mirror the fleet miner list:
+    // Model | Site, Building, Rack, Group | Subnet.
     const filters = useMemo((): FilterItem[] => {
       const children: NestedFilterChildItem[] = [];
       if (showTypeFilter) {
@@ -509,19 +549,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
           value: "type",
           options: availableModels.map((model) => ({ id: model, label: model })),
           defaultOptionIds: [],
-        });
-      }
-      if (showSubnetFilter) {
-        children.push({
-          type: "textareaList",
-          title: "Subnet",
-          value: "subnet",
-          validate: validateSubnetLine,
-          normalize: normalizeSubnetLine,
-          // Mirrors the onboarding discovery input: CIDR, bare IP, or IP range
-          // (short or full form).
-          placeholder: "192.168.1.0/24\n10.0.0.10-10.0.0.20\n10.0.0.42",
-          noun: "subnet",
+          showGroupDivider: true,
         });
       }
       if (showSiteFilter) {
@@ -558,6 +586,20 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
           value: "group",
           options: availableGroups.map((g) => ({ id: String(g.id), label: g.label })),
           defaultOptionIds: [],
+          showGroupDivider: true,
+        });
+      }
+      if (showSubnetFilter) {
+        children.push({
+          type: "textareaList",
+          title: "Subnet",
+          value: "subnet",
+          validate: validateSubnetLine,
+          normalize: normalizeSubnetLine,
+          // Mirrors the onboarding discovery input, one example per accepted
+          // form: explicit IP, IP range (short or full), and CIDR.
+          placeholder: "10.0.0.42\n10.0.0.10-10.0.0.20\n192.168.1.0/24",
+          noun: "subnet",
         });
       }
       if (children.length === 0) return [];
@@ -654,7 +696,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
           <List<DeviceListItem, string, ModalColumn>
             activeCols={activeCols}
             colTitles={modalColTitles}
-            colConfig={modalColConfig}
+            colConfig={colConfig}
             filters={filters}
             onServerFilter={handleServerFilter}
             headerControls={
@@ -662,12 +704,19 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
                 // px-1 gives the toggle's hover scale-up room so it doesn't
                 // paint past the filter row's right edge and trigger horizontal
                 // scroll in the modal.
-                <div className="px-1">
+                <div className="flex items-center gap-1 px-1">
+                  <Button
+                    variant={variants.textOnly}
+                    textOnlyUnderlineOnHover={false}
+                    ariaLabel="About “Show assigned miners”"
+                    prefixIcon={<Info className="text-text-primary-70" />}
+                    onClick={() => setShowAssignedInfo(true)}
+                  />
                   <Switch
-                    label="Show assignable only"
-                    ariaLabel="Show assignable only"
-                    checked={assignableOnly}
-                    setChecked={setAssignableOnly}
+                    label="Show assigned miners"
+                    ariaLabel="Show assigned miners"
+                    checked={showAssigned}
+                    setChecked={setShowAssigned}
                   />
                 </div>
               ) : undefined
@@ -682,7 +731,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
             customSelectedItems={displayedSelectedItems}
             customSetSelectedItems={handleSetSelectedItems}
             preserveOffPageSelection
-            isRowDisabled={effectiveIsRowDisabled}
+            isRowDisabled={isRowDisabled}
             total={totalMiners}
             hideTotal
             itemName={{ singular: "miner", plural: "miners" }}
@@ -731,8 +780,8 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
                 canSelectAll
                   ? () => {
                       setAllSelected(true);
-                      const selectableItems = effectiveIsRowDisabled
-                        ? currentPageItems.filter((d) => !effectiveIsRowDisabled(d))
+                      const selectableItems = isRowDisabled
+                        ? currentPageItems.filter((d) => !isRowDisabled(d))
                         : currentPageItems;
                       setSelectedItems(selectableItems.map((d) => d.deviceIdentifier));
                     }
@@ -748,6 +797,15 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
               }
             />
           </div>
+        ) : null}
+        {showAssignedInfo ? (
+          <Dialog
+            icon={<Info />}
+            title="Show assigned miners"
+            subtitle="Shows or hides miners that are already assigned to another rack, or to a building or site that this rack is not assigned to. Assigning these miners to this rack will unassign them from their current placement."
+            onDismiss={() => setShowAssignedInfo(false)}
+            buttons={[{ text: "Got it", variant: variants.primary, onClick: () => setShowAssignedInfo(false) }]}
+          />
         ) : null}
       </div>
     );

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import { useHasPermission } from "@/protoFleet/store";
 
-import { ChevronDown, Info, Plus } from "@/shared/assets/icons";
+import { Alert, ChevronDown, Info, Plus } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Dialog from "@/shared/components/Dialog";
 import List from "@/shared/components/List";
@@ -110,6 +110,8 @@ export interface MinerSelectionListProps {
   // them, behind a caller confirm) and flagged in orange to show the existing
   // placement.
   eligibility?: MinerEligibility;
+  // Label of the target rack, shown in the assignment-conflict dialog.
+  targetRackLabel?: string;
   onSelectionChange?: (state: {
     selectedItems: string[];
     allSelected: boolean;
@@ -219,6 +221,25 @@ const toDeviceListItem = (miner: ProtoMinerStateSnapshot): DeviceListItem => ({
   buildingId: getMinerBuildingId(miner),
 });
 
+/** Copy for the assignment-conflict dialog. Lists only the placement levels the
+ *  miner currently occupies, joined naturally, so it reads correctly whether it
+ *  has a site, a site + building, or a full site + building + rack placement. */
+const describeReassignment = (item: DeviceListItem, targetRackLabel?: string): string => {
+  const parts: string[] = [];
+  if (item.siteLabel) parts.push(`site ${item.siteLabel}`);
+  if (item.buildingLabel) parts.push(`building ${item.buildingLabel}`);
+  if (item.rackLabel) parts.push(`rack ${item.rackLabel}`);
+  const current =
+    parts.length === 0
+      ? "its current placement"
+      : parts.length === 1
+        ? parts[0]
+        : `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`;
+  const name = item.name || item.deviceIdentifier;
+  const target = targetRackLabel ? `"${targetRackLabel}"` : "this rack";
+  return `Assigning ${name} to ${target} will unassign it from ${current}.`;
+};
+
 // --- Component ---
 
 const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionListProps>(
@@ -234,6 +255,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       showSelectAllFooter = true,
       scope,
       eligibility,
+      targetRackLabel,
       onSelectionChange,
     },
     ref,
@@ -265,6 +287,8 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
     const eligSiteId = eligibility?.siteId;
     const eligBuildingId = eligibility?.buildingId;
     const [showAssignedInfo, setShowAssignedInfo] = useState(false);
+    // The reassignment row whose conflict dialog is open, or null.
+    const [conflictInfoItem, setConflictInfoItem] = useState<DeviceListItem | null>(null);
     // "Show assigned miners" — default off, so the list starts with only
     // assignable (unassigned + this-rack) miners. Turning it on also surfaces
     // miners currently assigned to another rack/building/site; they stay
@@ -434,23 +458,36 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
     // Wrap the base column renderers so a reassignment row's text is orange.
     // Wrapping (rather than editing each cell) keeps the placement flag in one
     // place and lets the inner cells inherit the color.
+    // Flag reassignment rows with a right-aligned orange warning icon in the
+    // Name cell (rows keep the normal text color); clicking it opens a dialog
+    // explaining the placement collision. Only the Name column is overridden —
+    // other columns render unchanged.
     const colConfig = useMemo<ColConfig<DeviceListItem, string, ModalColumn>>(() => {
-      const wrapped: ColConfig<DeviceListItem, string, ModalColumn> = {};
-      (Object.keys(modalColConfig) as ModalColumn[]).forEach((col) => {
-        const base = modalColConfig[col];
-        if (!base) return;
-        const baseComponent = base.component;
-        wrapped[col] = {
-          ...base,
-          component: (device: DeviceListItem, selectedItems: string[]) => (
-            <span className={isReassignment(device) ? "text-text-emphasis" : undefined}>
-              {baseComponent ? baseComponent(device, selectedItems) : null}
-            </span>
+      if (!eligibilityEnabled) return modalColConfig;
+      return {
+        ...modalColConfig,
+        [modalCols.name]: {
+          width: "min-w-28",
+          component: (device: DeviceListItem) => (
+            <div className="flex items-center justify-between gap-2">
+              <span>{device.name || device.deviceIdentifier}</span>
+              {isReassignment(device) ? (
+                <Button
+                  variant={variants.textOnly}
+                  textOnlyUnderlineOnHover={false}
+                  ariaLabel="Assignment conflict — view details"
+                  prefixIcon={<Alert className="text-text-emphasis" />}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setConflictInfoItem(device);
+                  }}
+                />
+              ) : null}
+            </div>
           ),
-        };
-      });
-      return wrapped;
-    }, [isReassignment]);
+        },
+      };
+    }, [eligibilityEnabled, isReassignment]);
     const displayedSelectedItems = allSelected && !singleSelect ? currentSelectableItemIds : selectedItems;
     // While "Show assigned miners" is on, the list mixes assignable and
     // assigned-elsewhere rows, so "select all" is ambiguous (and the assignable
@@ -867,6 +904,15 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
             subtitle="Shows or hides miners that are already assigned to another rack, or to a building or site that this rack is not assigned to. Assigning these miners to this rack will unassign them from their current placement."
             onDismiss={() => setShowAssignedInfo(false)}
             buttons={[{ text: "Got it", variant: variants.primary, onClick: () => setShowAssignedInfo(false) }]}
+          />
+        ) : null}
+        {conflictInfoItem ? (
+          <Dialog
+            icon={<Alert className="text-text-emphasis" />}
+            title="Assignment conflict"
+            subtitle={describeReassignment(conflictInfoItem, targetRackLabel)}
+            onDismiss={() => setConflictInfoItem(null)}
+            buttons={[{ text: "Got it", variant: variants.primary, onClick: () => setConflictInfoItem(null) }]}
           />
         ) : null}
       </div>

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -407,7 +407,14 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       return wrapped;
     }, [isReassignment]);
     const displayedSelectedItems = allSelected && !singleSelect ? currentSelectableItemIds : selectedItems;
-    const canSelectAll = !singleSelect && (!disableFilteredSelectAll || !hasUnsupportedAllSelectionFilter(filter));
+    // While "Show assigned miners" is on, the list mixes assignable and
+    // assigned-elsewhere rows, so "select all" is ambiguous (and the assignable
+    // resolver would silently drop the reassignment picks). Only offer it in the
+    // assignable-only view.
+    const canSelectAll =
+      !singleSelect &&
+      !(eligibilityEnabled && showAssigned) &&
+      (!disableFilteredSelectAll || !hasUnsupportedAllSelectionFilter(filter));
     const shouldShowSelectionFooter =
       showSelectAllFooter &&
       totalMiners !== undefined &&

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -240,22 +240,14 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
   ) => {
     const {
       showTypeFilter = true,
-      showRackFilter = true,
+      showRackFilter: showRackFilterProp = true,
       showGroupFilter = true,
       showSubnetFilter = false,
       showSiteFilter: showSiteFilterProp = false,
       showBuildingFilter: showBuildingFilterProp = false,
     } = filterConfig ?? {};
 
-    // Site/Building facet options come from ListSites/ListBuildings, which are
-    // guarded by site:read. Roles that manage racks without it (e.g. FIELD_TECH)
-    // would otherwise fire permission-denied RPCs and get empty facets, so hide
-    // these facets when the site catalog isn't readable. The Site/Building
-    // columns still render — their labels come from the miner snapshot, not
-    // these RPCs.
     const canReadSiteCatalog = useHasPermission("site:read");
-    const showSiteFilter = showSiteFilterProp && canReadSiteCatalog;
-    const showBuildingFilter = showBuildingFilterProp && canReadSiteCatalog;
 
     const scopeSiteIds = useMemo(() => scope?.siteIds ?? [], [scope]);
     const scopeIncludeUnassigned = scope?.includeUnassigned ?? false;
@@ -279,6 +271,19 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
     // selectable (reassigning moves them, behind a confirm) and render in orange
     // to flag the existing placement.
     const [showAssigned, setShowAssigned] = useState(false);
+
+    // Placement facets (Site / Building / Rack) only make sense when browsing
+    // beyond the assignable set. In assignable-only mode (a target rack, toggle
+    // off) eligibility already pins those dimensions to the rack's, so offering
+    // the facets there would let a conflicting pick silently override eligibility
+    // — so they're offered only when there's no target rack or "Show assigned
+    // miners" is on. Site/Building additionally require site:read (their options
+    // come from ListSites/ListBuildings); the Site/Building *columns* still
+    // render, since their labels ride on the miner snapshot, not those RPCs.
+    const placementFacetsAllowed = !eligibilityEnabled || showAssigned;
+    const showRackFilter = showRackFilterProp && placementFacetsAllowed;
+    const showSiteFilter = showSiteFilterProp && canReadSiteCatalog && placementFacetsAllowed;
+    const showBuildingFilter = showBuildingFilterProp && canReadSiteCatalog && placementFacetsAllowed;
 
     const { listGroups, listRacks } = useDeviceSets();
     const { listSites } = useSites();

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.stories.tsx
@@ -23,6 +23,7 @@ export const Default = () => {
         show={show}
         currentRackMiners={["miner-001", "miner-002"]}
         eligibility={{ rackId: 1n, siteId: 10n, buildingId: 100n }}
+        targetRackLabel="Rack 1"
         maxSlots={12}
         onDismiss={() => {
           action("onDismiss")();

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.stories.tsx
@@ -22,7 +22,7 @@ export const Default = () => {
       <ManageMinersModal
         show={show}
         currentRackMiners={["miner-001", "miner-002"]}
-        currentRackLabel="Rack A-01"
+        eligibility={{ rackId: 1n, siteId: 10n, buildingId: 100n }}
         maxSlots={12}
         onDismiss={() => {
           action("onDismiss")();

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.stories.tsx
@@ -29,9 +29,10 @@ export const Default = () => {
           action("onDismiss")();
           setShow(false);
         }}
-        onConfirm={(selectedIds, allSelected, filter) => {
-          action("onConfirm")({ selectedIds, allSelected, filter });
+        onConfirm={async (selectedIds, allSelected, filter, reassignedItems) => {
+          action("onConfirm")({ selectedIds, allSelected, filter, reassignedItems });
           setShow(false);
+          return undefined;
         }}
       />
     </>

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
@@ -54,6 +54,7 @@ const defaultProps = {
   show: true,
   currentRackMiners: [] as string[],
   eligibility: { rackId: 1n, siteId: 10n, buildingId: 100n },
+  targetRackLabel: "Rack 1",
   maxSlots: 25,
   onDismiss: vi.fn(),
   onConfirm: vi.fn(),

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
@@ -52,7 +52,7 @@ vi.mock("@/shared/assets/icons", () => ({
 const defaultProps = {
   show: true,
   currentRackMiners: [] as string[],
-  currentRackLabel: "Rack-01",
+  eligibility: { rackId: 1n, siteId: 10n, buildingId: 100n },
   maxSlots: 25,
   onDismiss: vi.fn(),
   onConfirm: vi.fn(),
@@ -75,8 +75,11 @@ describe("ManageMinersModal", () => {
     expect(screen.getByTestId("miner-selection-list")).toBeInTheDocument();
     expect(latestProps.current.filterConfig).toEqual({
       showTypeFilter: true,
-      showRackFilter: false,
-      showGroupFilter: false,
+      showSubnetFilter: true,
+      showSiteFilter: true,
+      showBuildingFilter: true,
+      showRackFilter: true,
+      showGroupFilter: true,
     });
   });
 
@@ -85,13 +88,9 @@ describe("ManageMinersModal", () => {
     expect(latestProps.current.initialSelectedItems).toEqual(["miner-1", "miner-2"]);
   });
 
-  it("disables miners in other racks via isRowDisabled", () => {
-    render(<ManageMinersModal {...defaultProps} currentRackLabel="Rack-01" />);
-
-    const isRowDisabled = latestProps.current.isRowDisabled;
-    expect(isRowDisabled({ rackLabel: "Other-Rack", deviceIdentifier: "m1" })).toBe(true);
-    expect(isRowDisabled({ rackLabel: "Rack-01", deviceIdentifier: "m2" })).toBe(false);
-    expect(isRowDisabled({ rackLabel: "", deviceIdentifier: "m3" })).toBe(false);
+  it("passes the target rack eligibility to the selection list", () => {
+    render(<ManageMinersModal {...defaultProps} eligibility={{ rackId: 5n, siteId: 2n, buildingId: 3n }} />);
+    expect(latestProps.current.eligibility).toEqual({ rackId: 5n, siteId: 2n, buildingId: 3n });
   });
 
   it("calls onConfirm with selected IDs on continue", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
@@ -10,6 +10,7 @@ const mockGetSelection = vi.fn(() => ({
   allSelected: false,
   totalMiners: 0,
   reassignedItems: [] as string[],
+  blockedByFilter: false,
 }));
 
 vi.mock("@/protoFleet/components/MinerSelectionList", () => ({
@@ -102,6 +103,7 @@ describe("ManageMinersModal", () => {
       allSelected: false,
       totalMiners: 10,
       reassignedItems: [],
+      blockedByFilter: false,
     });
 
     render(<ManageMinersModal {...defaultProps} onConfirm={onConfirm} />);
@@ -116,6 +118,7 @@ describe("ManageMinersModal", () => {
       allSelected: false,
       totalMiners: 10,
       reassignedItems: [],
+      blockedByFilter: false,
     });
 
     render(<ManageMinersModal {...defaultProps} maxSlots={2} />);
@@ -131,11 +134,30 @@ describe("ManageMinersModal", () => {
       allSelected: false,
       totalMiners: 10,
       reassignedItems: [],
+      blockedByFilter: false,
     });
 
     render(<ManageMinersModal {...defaultProps} maxSlots={2} onConfirm={onConfirm} />);
     fireEvent.click(screen.getByText(/Continue/));
 
     expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("blocks Continue and prompts to clear the filter when a placement facet conflicts", () => {
+    const onConfirm = vi.fn();
+    mockGetSelection.mockReturnValue({
+      selectedItems: ["m1", "m2"],
+      allSelected: true,
+      totalMiners: 10,
+      reassignedItems: [],
+      blockedByFilter: true,
+    });
+
+    render(<ManageMinersModal {...defaultProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText(/Continue/));
+
+    // No save (which would otherwise resolve/commit a hidden selection).
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.getByText(/Clear the Site, Building, or Rack filter/i)).toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
@@ -9,6 +9,7 @@ const mockGetSelection = vi.fn(() => ({
   selectedItems: [] as string[],
   allSelected: false,
   totalMiners: 0,
+  reassignedItems: [] as string[],
 }));
 
 vi.mock("@/protoFleet/components/MinerSelectionList", () => ({
@@ -99,12 +100,13 @@ describe("ManageMinersModal", () => {
       selectedItems: ["miner-1", "miner-2"],
       allSelected: false,
       totalMiners: 10,
+      reassignedItems: [],
     });
 
     render(<ManageMinersModal {...defaultProps} onConfirm={onConfirm} />);
     fireEvent.click(screen.getByText(/Continue/));
 
-    expect(onConfirm).toHaveBeenCalledWith(["miner-1", "miner-2"], false, undefined);
+    expect(onConfirm).toHaveBeenCalledWith(["miner-1", "miner-2"], false, undefined, []);
   });
 
   it("shows overflow error when selection exceeds maxSlots", () => {
@@ -112,6 +114,7 @@ describe("ManageMinersModal", () => {
       selectedItems: ["m1", "m2", "m3"],
       allSelected: false,
       totalMiners: 10,
+      reassignedItems: [],
     });
 
     render(<ManageMinersModal {...defaultProps} maxSlots={2} />);
@@ -126,6 +129,7 @@ describe("ManageMinersModal", () => {
       selectedItems: ["m1", "m2", "m3"],
       allSelected: false,
       totalMiners: 10,
+      reassignedItems: [],
     });
 
     render(<ManageMinersModal {...defaultProps} maxSlots={2} onConfirm={onConfirm} />);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
@@ -18,7 +18,15 @@ interface ManageMinersModalProps {
   eligibility: MinerEligibility;
   maxSlots: number;
   onDismiss: () => void;
-  onConfirm: (selectedIds: string[], allSelected: boolean, filter?: MinerListFilter) => void;
+  /** `reassignedItems` is the subset of the explicit selection that is currently
+   *  assigned elsewhere, so the caller can confirm the reparent (empty when
+   *  `allSelected`, since that path is pre-filtered to assignable miners). */
+  onConfirm: (
+    selectedIds: string[],
+    allSelected: boolean,
+    filter: MinerListFilter | undefined,
+    reassignedItems: string[],
+  ) => void;
 }
 
 export default function ManageMinersModal({
@@ -36,7 +44,7 @@ export default function ManageMinersModal({
     const selection = selectionRef.current?.getSelection();
     if (!selection) return;
 
-    const { selectedItems, allSelected, filter } = selection;
+    const { selectedItems, allSelected, filter, reassignedItems } = selection;
 
     // Only validate overflow for explicit selections. When allSelected is true,
     // the parent resolves the full selectable list via server pagination and
@@ -48,7 +56,7 @@ export default function ManageMinersModal({
       return;
     }
 
-    onConfirm(selectedItems, allSelected, allSelected ? filter : undefined);
+    onConfirm(selectedItems, allSelected, allSelected ? filter : undefined, reassignedItems);
   }, [maxSlots, onConfirm]);
 
   if (!show) return null;

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
@@ -22,13 +22,16 @@ interface ManageMinersModalProps {
   onDismiss: () => void;
   /** `reassignedItems` is the subset of the explicit selection that is currently
    *  assigned elsewhere, so the caller can confirm the reparent (empty when
-   *  `allSelected`, since that path is pre-filtered to assignable miners). */
+   *  `allSelected`, since that path is pre-filtered to assignable miners).
+   *  Resolves to an error string to surface inside this (still-open) modal —
+   *  e.g. select-all overflow, which the parent only knows after resolving the
+   *  full id set — or undefined on success. */
   onConfirm: (
     selectedIds: string[],
     allSelected: boolean,
     filter: MinerListFilter | undefined,
     reassignedItems: string[],
-  ) => void;
+  ) => Promise<string | undefined>;
 }
 
 export default function ManageMinersModal({
@@ -43,11 +46,12 @@ export default function ManageMinersModal({
   const selectionRef = useRef<MinerSelectionListHandle>(null);
   const [overflowError, setOverflowError] = useState("");
 
-  const handleContinue = useCallback(() => {
+  const handleContinue = useCallback(async () => {
     const selection = selectionRef.current?.getSelection();
     if (!selection) return;
 
     const { selectedItems, allSelected, filter, reassignedItems, blockedByFilter } = selection;
+    setOverflowError("");
 
     // A conflicting placement facet shows "no results"; committing here would
     // save a selection the operator can't see (or wipe membership). Prompt them
@@ -58,8 +62,9 @@ export default function ManageMinersModal({
     }
 
     // Only validate overflow for explicit selections. When allSelected is true,
-    // the parent resolves the full selectable list via server pagination and
-    // validates overflow after resolution.
+    // the parent resolves the full selectable list via server pagination, so it
+    // returns the overflow (or load) error for us to surface here — this modal
+    // is still mounted above the parent's callout.
     if (!allSelected && selectedItems.length > maxSlots) {
       setOverflowError(
         `Cannot add ${selectedItems.length} miners with only ${maxSlots} available slots. Deselect some miners or update your rack settings.`,
@@ -67,7 +72,8 @@ export default function ManageMinersModal({
       return;
     }
 
-    onConfirm(selectedItems, allSelected, allSelected ? filter : undefined, reassignedItems);
+    const error = await onConfirm(selectedItems, allSelected, allSelected ? filter : undefined, reassignedItems);
+    if (error) setOverflowError(error);
   }, [maxSlots, onConfirm]);
 
   if (!show) return null;

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef, useState } from "react";
 
 import { type MinerListFilter } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import MinerSelectionList, {
-  type DeviceListItem,
+  type MinerEligibility,
   type MinerSelectionListHandle,
 } from "@/protoFleet/components/MinerSelectionList";
 
@@ -13,7 +13,9 @@ import Modal from "@/shared/components/Modal";
 interface ManageMinersModalProps {
   show: boolean;
   currentRackMiners: string[];
-  currentRackLabel: string;
+  /** Target rack placement. Drives the "Show assignable only" toggle and the
+   *  id-based eligibility filter. */
+  eligibility: MinerEligibility;
   maxSlots: number;
   onDismiss: () => void;
   onConfirm: (selectedIds: string[], allSelected: boolean, filter?: MinerListFilter) => void;
@@ -22,18 +24,13 @@ interface ManageMinersModalProps {
 export default function ManageMinersModal({
   show,
   currentRackMiners,
-  currentRackLabel,
+  eligibility,
   maxSlots,
   onDismiss,
   onConfirm,
 }: ManageMinersModalProps) {
   const selectionRef = useRef<MinerSelectionListHandle>(null);
   const [overflowError, setOverflowError] = useState("");
-
-  const isRowDisabled = useCallback(
-    (item: DeviceListItem) => !!(item.rackLabel && item.rackLabel !== currentRackLabel),
-    [currentRackLabel],
-  );
 
   const handleContinue = useCallback(() => {
     const selection = selectionRef.current?.getSelection();
@@ -81,9 +78,16 @@ export default function ManageMinersModal({
 
         <MinerSelectionList
           ref={selectionRef}
-          filterConfig={{ showTypeFilter: true, showRackFilter: false, showGroupFilter: false }}
+          filterConfig={{
+            showTypeFilter: true,
+            showSubnetFilter: true,
+            showSiteFilter: true,
+            showBuildingFilter: true,
+            showRackFilter: true,
+            showGroupFilter: true,
+          }}
           initialSelectedItems={currentRackMiners}
-          isRowDisabled={isRowDisabled}
+          eligibility={eligibility}
         />
       </div>
     </Modal>

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
@@ -16,6 +16,8 @@ interface ManageMinersModalProps {
   /** Target rack placement. Drives the "Show assignable only" toggle and the
    *  id-based eligibility filter. */
   eligibility: MinerEligibility;
+  /** Target rack label, shown in the assignment-conflict dialog. */
+  targetRackLabel: string;
   maxSlots: number;
   onDismiss: () => void;
   /** `reassignedItems` is the subset of the explicit selection that is currently
@@ -33,6 +35,7 @@ export default function ManageMinersModal({
   show,
   currentRackMiners,
   eligibility,
+  targetRackLabel,
   maxSlots,
   onDismiss,
   onConfirm,
@@ -96,6 +99,7 @@ export default function ManageMinersModal({
           }}
           initialSelectedItems={currentRackMiners}
           eligibility={eligibility}
+          targetRackLabel={targetRackLabel}
         />
       </div>
     </Modal>

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
@@ -47,7 +47,15 @@ export default function ManageMinersModal({
     const selection = selectionRef.current?.getSelection();
     if (!selection) return;
 
-    const { selectedItems, allSelected, filter, reassignedItems } = selection;
+    const { selectedItems, allSelected, filter, reassignedItems, blockedByFilter } = selection;
+
+    // A conflicting placement facet shows "no results"; committing here would
+    // save a selection the operator can't see (or wipe membership). Prompt them
+    // to clear the filter first instead.
+    if (blockedByFilter) {
+      setOverflowError("Clear the Site, Building, or Rack filter to continue — it doesn't match this rack.");
+      return;
+    }
 
     // Only validate overflow for explicit selections. When allSelected is true,
     // the parent resolves the full selectable list via server pagination and

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import ManageMinersModal from "./ManageMinersModal";
 import MinersPane from "./MinersPane";
 import RackPane from "./RackPane";
+import ReparentWarningDialog from "./ReparentWarningDialog";
 import ScanMinerQrModal from "./ScanMinerQrModal";
 import SearchMinersModal from "./SearchMinersModal";
 import { type AssignmentMode, orderIndexToOrigin, originLabel, type RackFormData, type SelectedSlot } from "./types";
@@ -141,6 +142,11 @@ export default function ManageRackModal({
   const [showScanQr, setShowScanQr] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Pending reparent confirmation. Set when a confirm action would pull miners
+  // out of a rack/building/site they're currently assigned to; `onConfirm`
+  // runs the deferred action once the operator accepts the warning (#672).
+  const [reparentConfirm, setReparentConfirm] = useState<{ count: number; onConfirm: () => void } | null>(null);
 
   // Loading / error state
   const [isLoading, setIsLoading] = useState(!!existingRackId);
@@ -319,25 +325,51 @@ export default function ManageRackModal({
     setShowSlotPopover(false);
   }, []);
 
-  // SearchMinersModal confirm — add miner to rack and assign to selected slot
-  const handleSearchMinerConfirm = useCallback(
-    (minerId: string) => {
-      if (!selectedSlot) return;
+  // Show the reparent warning (#672) when `count` > 0, else run `proceed`
+  // directly. `proceed` runs once the operator accepts the warning.
+  const promptReparent = useCallback((count: number, proceed: () => void) => {
+    if (count === 0) {
+      proceed();
+      return;
+    }
+    setReparentConfirm({ count, onConfirm: proceed });
+  }, []);
 
-      // Add miner to rack if not already present
-      setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
-
-      // Remove any existing assignment for this miner, then assign to selected slot
-      setSlotAssignments((prev) => {
-        const next = removeAssignmentByValue(prev, minerId);
-        next[selectedSlot.key] = minerId;
-        return next;
-      });
-
-      setSelectedSlot(null);
-      setShowSearchMiners(false);
+  // Guard by looking up placement in the display snapshots. Used where the
+  // caller only has ids (bulk select, scan). Select-all is pre-filtered to
+  // eligible ids, so reparents only arise from explicit picks.
+  const guardReparent = useCallback(
+    (ids: string[], proceed: () => void) => {
+      const reassignedCount = ids.filter((id) => {
+        const miner = allMiners[id];
+        return miner !== undefined && isMinerSnapshotIneligible(miner, eligibility);
+      }).length;
+      promptReparent(reassignedCount, proceed);
     },
-    [selectedSlot],
+    [allMiners, eligibility, promptReparent],
+  );
+
+  // SearchMinersModal confirm — add miner to rack and assign to selected slot.
+  // The modal reports the reassignment flag from the row it selected (exact even
+  // for fleets larger than the display page).
+  const handleSearchMinerConfirm = useCallback(
+    (minerId: string, isReassignment: boolean) => {
+      if (!selectedSlot) return;
+      const slotKey = selectedSlot.key;
+      promptReparent(isReassignment ? 1 : 0, () => {
+        // Add miner to rack if not already present
+        setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
+        // Remove any existing assignment for this miner, then assign to selected slot
+        setSlotAssignments((prev) => {
+          const next = removeAssignmentByValue(prev, minerId);
+          next[slotKey] = minerId;
+          return next;
+        });
+        setSelectedSlot(null);
+        setShowSearchMiners(false);
+      });
+    },
+    [selectedSlot, promptReparent],
   );
 
   // ScanMinerQrModal confirm — identical placement to search, but keyed off
@@ -346,18 +378,19 @@ export default function ManageRackModal({
   const handleScanMinerConfirm = useCallback(
     (minerId: string) => {
       if (!selectedSlot) return;
-
-      setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
-      setSlotAssignments((prev) => {
-        const next = removeAssignmentByValue(prev, minerId);
-        next[selectedSlot.key] = minerId;
-        return next;
+      const slotKey = selectedSlot.key;
+      guardReparent([minerId], () => {
+        setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
+        setSlotAssignments((prev) => {
+          const next = removeAssignmentByValue(prev, minerId);
+          next[slotKey] = minerId;
+          return next;
+        });
+        setSelectedSlot(null);
+        setShowScanQr(false);
       });
-
-      setSelectedSlot(null);
-      setShowScanQr(false);
     },
-    [selectedSlot],
+    [selectedSlot, guardReparent],
   );
 
   // Miner selection handler — when a slot is awaiting, assign miner to it
@@ -436,15 +469,17 @@ export default function ManageRackModal({
         return;
       }
 
-      setRackMiners(finalIds);
-      setShowManageMiners(false);
+      guardReparent(finalIds, () => {
+        setRackMiners(finalIds);
+        setShowManageMiners(false);
 
-      // Remove assignments for miners no longer in rack
-      const keepSet = new Set(finalIds);
-      setSlotAssignments((prev) => filterAssignmentsByValues(prev, keepSet));
-      setManualAssignmentCache((prev) => filterAssignmentsByValues(prev, keepSet));
+        // Remove assignments for miners no longer in rack
+        const keepSet = new Set(finalIds);
+        setSlotAssignments((prev) => filterAssignmentsByValues(prev, keepSet));
+        setManualAssignmentCache((prev) => filterAssignmentsByValues(prev, keepSet));
+      });
     },
-    [eligibility, totalSlots],
+    [eligibility, totalSlots, guardReparent],
   );
 
   // RackSettingsModal edit handler
@@ -646,6 +681,19 @@ export default function ManageRackModal({
             setSelectedSlot(null);
           }}
           onConfirm={handleScanMinerConfirm}
+        />
+      ) : null}
+
+      {reparentConfirm ? (
+        <ReparentWarningDialog
+          count={reparentConfirm.count}
+          rackLabel={rackSettings.label}
+          onCancel={() => setReparentConfirm(null)}
+          onConfirm={() => {
+            const proceed = reparentConfirm.onConfirm;
+            setReparentConfirm(null);
+            proceed();
+          }}
         />
       ) : null}
 

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -17,8 +17,9 @@ import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import useFleet from "@/protoFleet/api/useFleet";
 import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
+import type { MinerEligibility } from "@/protoFleet/components/MinerSelectionList";
 import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
-import { getMinerRackLabel } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
+import { isMinerSnapshotIneligible } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import { slotNumberToRowCol } from "@/protoFleet/features/fleetManagement/utils/slotNumbering";
 
 import { DismissCircle } from "@/shared/assets/icons";
@@ -30,17 +31,19 @@ import { pushToast, STATUSES } from "@/shared/features/toaster";
 
 /** Fetch all miner IDs eligible for a rack by paginating through the fleet API.
  *  Applies the same filter the user had active in MinerSelectionList so "select all"
- *  respects model/type filters. Miners in other racks are excluded. */
-async function fetchAllSelectableMinerIds(rackLabel: string, listFilter?: MinerListFilter): Promise<string[]> {
+ *  respects model/subnet filters. Miners in a different rack/building/site are
+ *  excluded id-based (matches the list's eligibility predicate) so "select all"
+ *  can't pull in ineligible miners even if the assignable-only toggle was off. */
+async function fetchAllSelectableMinerIds(
+  eligibility: MinerEligibility,
+  listFilter?: MinerListFilter,
+): Promise<string[]> {
   const filter = listFilter
     ? { ...listFilter, pairingStatuses: [PairingStatus.PAIRED] }
     : { pairingStatuses: [PairingStatus.PAIRED] };
   const snapshots = await fetchAllMinerSnapshots(filter);
   return Object.values(snapshots)
-    .filter((m) => {
-      const currentRackLabel = getMinerRackLabel(m);
-      return !currentRackLabel || currentRackLabel === rackLabel;
-    })
+    .filter((m) => !isMinerSnapshotIneligible(m, eligibility))
     .map((m) => m.deviceIdentifier);
 }
 
@@ -99,6 +102,23 @@ export default function ManageRackModal({
   const [rackSettings, setRackSettings] = useState<RackFormData>(initialRackSettings);
   const totalSlots = rackSettings.rows * rackSettings.columns;
   const numberingOrigin = orderIndexToOrigin(rackSettings.orderIndex);
+
+  // Target-rack placement for the selection modals' eligibility filter. Read
+  // from the rack's own DeviceSet (id-based; site derives from building). A new
+  // rack has no id/placement yet, so eligibility only excludes already-racked
+  // miners. `|| undefined` collapses the proto default (0) to unassigned.
+  const currentRack = useMemo(
+    () => (existingRackId !== undefined ? existingRacks.find((r) => r.id === existingRackId) : undefined),
+    [existingRackId, existingRacks],
+  );
+  const eligibility = useMemo<MinerEligibility>(
+    () => ({
+      rackId: existingRackId,
+      siteId: currentRack?.placement?.site?.id || undefined,
+      buildingId: currentRack?.placement?.building?.id || undefined,
+    }),
+    [existingRackId, currentRack],
+  );
 
   // Core assignment state. A new rack (no existingRackId) can be seeded
   // with miners from a bulk "Add to rack → New rack" flow; edit mode
@@ -396,12 +416,11 @@ export default function ManageRackModal({
       if (allSelected) {
         // When "select all" is active, selectedIds only contains the current page.
         // Paginate through all miners server-side to get the complete list, applying
-        // the same filters the user had active (e.g. model/type) and excluding miners
-        // in other racks. Use initialRackSettings.label because fleet data still
-        // carries the original label even if the user edited it locally.
+        // the same filters the user had active (e.g. model/subnet) and excluding
+        // miners in a different rack/building/site (id-based).
         try {
           setIsLoading(true);
-          finalIds = await fetchAllSelectableMinerIds(initialRackSettings.label, listFilter);
+          finalIds = await fetchAllSelectableMinerIds(eligibility, listFilter);
         } catch {
           setErrorMsg("Failed to load all miners. Please try again.");
           return;
@@ -425,7 +444,7 @@ export default function ManageRackModal({
       setSlotAssignments((prev) => filterAssignmentsByValues(prev, keepSet));
       setManualAssignmentCache((prev) => filterAssignmentsByValues(prev, keepSet));
     },
-    [initialRackSettings.label, totalSlots],
+    [eligibility, totalSlots],
   );
 
   // RackSettingsModal edit handler
@@ -599,7 +618,7 @@ export default function ManageRackModal({
         <ManageMinersModal
           show={showManageMiners}
           currentRackMiners={rackMiners}
-          currentRackLabel={initialRackSettings.label}
+          eligibility={eligibility}
           maxSlots={totalSlots}
           onDismiss={() => setShowManageMiners(false)}
           onConfirm={handleManageMinersConfirm}
@@ -609,7 +628,7 @@ export default function ManageRackModal({
       {showSearchMiners ? (
         <SearchMinersModal
           show={showSearchMiners}
-          currentRackLabel={initialRackSettings.label}
+          eligibility={eligibility}
           onDismiss={() => {
             setShowSearchMiners(false);
             setSelectedSlot(null);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -326,7 +326,11 @@ export default function ManageRackModal({
   }, []);
 
   // Show the reparent warning (#672) when `count` > 0, else run `proceed`
-  // directly. `proceed` runs once the operator accepts the warning.
+  // directly. `proceed` runs once the operator accepts the warning. Callers pass
+  // the reassignment count from a reliable source (the selection list's
+  // per-row placement, or the scanned miner's snapshot) rather than the parent's
+  // first-page-only `allMiners` cache, so the warning isn't missed for miners
+  // outside that page.
   const promptReparent = useCallback((count: number, proceed: () => void) => {
     if (count === 0) {
       proceed();
@@ -334,20 +338,6 @@ export default function ManageRackModal({
     }
     setReparentConfirm({ count, onConfirm: proceed });
   }, []);
-
-  // Guard by looking up placement in the display snapshots. Used where the
-  // caller only has ids (bulk select, scan). Select-all is pre-filtered to
-  // eligible ids, so reparents only arise from explicit picks.
-  const guardReparent = useCallback(
-    (ids: string[], proceed: () => void) => {
-      const reassignedCount = ids.filter((id) => {
-        const miner = allMiners[id];
-        return miner !== undefined && isMinerSnapshotIneligible(miner, eligibility);
-      }).length;
-      promptReparent(reassignedCount, proceed);
-    },
-    [allMiners, eligibility, promptReparent],
-  );
 
   // SearchMinersModal confirm — add miner to rack and assign to selected slot.
   // The modal reports the reassignment flag from the row it selected (exact even
@@ -373,13 +363,13 @@ export default function ManageRackModal({
   );
 
   // ScanMinerQrModal confirm — identical placement to search, but keyed off
-  // the resolved device identifier from the scanned serial. Kept separate so
-  // it closes the scan modal (not the search modal).
+  // the resolved device identifier from the scanned serial. The scan modal
+  // computes the reassignment flag from the resolved snapshot's placement.
   const handleScanMinerConfirm = useCallback(
-    (minerId: string) => {
+    (minerId: string, isReassignment: boolean) => {
       if (!selectedSlot) return;
       const slotKey = selectedSlot.key;
-      guardReparent([minerId], () => {
+      promptReparent(isReassignment ? 1 : 0, () => {
         setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
         setSlotAssignments((prev) => {
           const next = removeAssignmentByValue(prev, minerId);
@@ -390,7 +380,7 @@ export default function ManageRackModal({
         setShowScanQr(false);
       });
     },
-    [selectedSlot, guardReparent],
+    [selectedSlot, promptReparent],
   );
 
   // Miner selection handler — when a slot is awaiting, assign miner to it
@@ -443,8 +433,18 @@ export default function ManageRackModal({
 
   // ManageMinersModal confirm handler
   const handleManageMinersConfirm = useCallback(
-    async (selectedIds: string[], allSelected: boolean, listFilter?: MinerListFilter) => {
+    async (
+      selectedIds: string[],
+      allSelected: boolean,
+      listFilter: MinerListFilter | undefined,
+      reassignedItems: string[],
+    ) => {
       let finalIds = selectedIds;
+      // "Select all" resolves to the assignable set server-side (ineligible
+      // miners already excluded), so it can never reparent. An explicit
+      // selection can, and `reassignedItems` reports exactly which picks are
+      // assigned elsewhere.
+      let reassignedCount = reassignedItems.length;
 
       if (allSelected) {
         // When "select all" is active, selectedIds only contains the current page.
@@ -460,6 +460,7 @@ export default function ManageRackModal({
         } finally {
           setIsLoading(false);
         }
+        reassignedCount = 0;
       }
 
       if (finalIds.length > totalSlots) {
@@ -469,7 +470,7 @@ export default function ManageRackModal({
         return;
       }
 
-      guardReparent(finalIds, () => {
+      promptReparent(reassignedCount, () => {
         setRackMiners(finalIds);
         setShowManageMiners(false);
 
@@ -479,7 +480,7 @@ export default function ManageRackModal({
         setManualAssignmentCache((prev) => filterAssignmentsByValues(prev, keepSet));
       });
     },
-    [eligibility, totalSlots, guardReparent],
+    [eligibility, totalSlots, promptReparent],
   );
 
   // RackSettingsModal edit handler
@@ -676,6 +677,7 @@ export default function ManageRackModal({
         <ScanMinerQrModal
           show={showScanQr}
           currentRackLabel={initialRackSettings.label}
+          eligibility={eligibility}
           onDismiss={() => {
             setShowScanQr(false);
             setSelectedSlot(null);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -431,14 +431,16 @@ export default function ManageRackModal({
     [selectedMinerId],
   );
 
-  // ManageMinersModal confirm handler
+  // ManageMinersModal confirm handler. Returns an error string for the still-open
+  // modal to surface (or undefined on success) — the parent's own callout sits
+  // behind the modal, so select-all overflow/load errors must go back up.
   const handleManageMinersConfirm = useCallback(
     async (
       selectedIds: string[],
       allSelected: boolean,
       listFilter: MinerListFilter | undefined,
       reassignedItems: string[],
-    ) => {
+    ): Promise<string | undefined> => {
       let finalIds = selectedIds;
       // "Select all" resolves to the assignable set server-side (ineligible
       // miners already excluded), so it can never reparent. An explicit
@@ -455,8 +457,7 @@ export default function ManageRackModal({
           setIsLoading(true);
           finalIds = await fetchAllSelectableMinerIds(eligibility, listFilter);
         } catch {
-          setErrorMsg("Failed to load all miners. Please try again.");
-          return;
+          return "Failed to load all miners. Please try again.";
         } finally {
           setIsLoading(false);
         }
@@ -464,10 +465,7 @@ export default function ManageRackModal({
       }
 
       if (finalIds.length > totalSlots) {
-        setErrorMsg(
-          `Cannot add ${finalIds.length} miners with only ${totalSlots} available slots. Deselect some miners or update your rack settings.`,
-        );
-        return;
+        return `Cannot add ${finalIds.length} miners with only ${totalSlots} available slots. Deselect some miners or update your rack settings.`;
       }
 
       promptReparent(reassignedCount, () => {
@@ -479,6 +477,7 @@ export default function ManageRackModal({
         setSlotAssignments((prev) => filterAssignmentsByValues(prev, keepSet));
         setManualAssignmentCache((prev) => filterAssignmentsByValues(prev, keepSet));
       });
+      return undefined;
     },
     [eligibility, totalSlots, promptReparent],
   );

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -655,6 +655,7 @@ export default function ManageRackModal({
           show={showManageMiners}
           currentRackMiners={rackMiners}
           eligibility={eligibility}
+          targetRackLabel={rackSettings.label}
           maxSlots={totalSlots}
           onDismiss={() => setShowManageMiners(false)}
           onConfirm={handleManageMinersConfirm}
@@ -665,6 +666,7 @@ export default function ManageRackModal({
         <SearchMinersModal
           show={showSearchMiners}
           eligibility={eligibility}
+          targetRackLabel={rackSettings.label}
           onDismiss={() => {
             setShowSearchMiners(false);
             setSelectedSlot(null);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ReparentWarningDialog.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ReparentWarningDialog.tsx
@@ -1,0 +1,36 @@
+import { variants } from "@/shared/components/Button";
+import Dialog from "@/shared/components/Dialog";
+
+interface ReparentWarningDialogProps {
+  /** How many of the miners being assigned are currently placed elsewhere. */
+  count: number;
+  /** Target rack label, shown in the message. */
+  rackLabel: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Confirmation shown before assigning miners that are already in another
+ * rack/building/site — assigning them here removes them from their current
+ * placement (#672). Shared by the rack edit modal and the rack overview
+ * quick-assign flow so the warning copy stays consistent.
+ */
+export default function ReparentWarningDialog({ count, rackLabel, onCancel, onConfirm }: ReparentWarningDialogProps) {
+  const single = count === 1;
+  return (
+    <Dialog
+      title={single ? "Reassign this miner?" : `Reassign ${count} miners?`}
+      subtitle={
+        single
+          ? `This miner is currently assigned to another rack, building, or site. Assigning it to "${rackLabel}" will remove it from its current placement.`
+          : `${count} of these miners are currently assigned to another rack, building, or site. Assigning them to "${rackLabel}" will remove them from their current placement.`
+      }
+      onDismiss={onCancel}
+      buttons={[
+        { text: "Cancel", onClick: onCancel, variant: variants.secondary },
+        { text: "Reassign", onClick: onConfirm, variant: variants.primary },
+      ]}
+    />
+  );
+}

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
@@ -157,7 +157,7 @@ describe("ScanMinerQrModal", () => {
     await waitFor(() => expect(screen.getByText(/No paired miner found/i)).toBeInTheDocument());
   });
 
-  it("blocks assigning a miner already in a different rack", async () => {
+  it("allows reassigning a miner already in a different rack and reports it as a reassignment", async () => {
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValueOnce({
       status: "found",
@@ -173,9 +173,13 @@ describe("ScanMinerQrModal", () => {
       capturedOnDetected?.(["SN123"]);
     });
 
-    await waitFor(() => expect(screen.getByText(/Already assigned to rack "Rack B"/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/Currently assigned to rack "Rack B"/i)).toBeInTheDocument());
     const assignBtn = screen.getByText("Assign to slot") as HTMLButtonElement;
-    expect(assignBtn.disabled).toBe(true);
+    // Not blocked — the reparent is confirmed in ManageRackModal.
+    expect(assignBtn.disabled).toBe(false);
+
+    fireEvent.click(assignBtn);
+    expect(onConfirm).toHaveBeenCalledWith("dev-1", true);
   });
 
   it("blocks assigning a miner that isn't fully paired", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
@@ -70,7 +70,9 @@ describe("ScanMinerQrModal", () => {
     mockLookup.mockResolvedValueOnce({ status: "found", snapshot: snapshot() });
     const onConfirm = vi.fn();
 
-    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={onConfirm} />);
+    render(
+      <ScanMinerQrModal show currentRackLabel="Rack A" eligibility={{}} onDismiss={vi.fn()} onConfirm={onConfirm} />,
+    );
 
     // Simulate the camera hook detecting a prefixed QR payload.
     await act(async () => {
@@ -82,7 +84,8 @@ describe("ScanMinerQrModal", () => {
     expect(mockLookup).toHaveBeenCalledWith("SN123", MinerIdentifierType.SERIAL_NUMBER, expect.any(AbortSignal));
 
     fireEvent.click(screen.getByText("Assign to slot"));
-    expect(onConfirm).toHaveBeenCalledWith("dev-1");
+    // Empty eligibility + placement-less snapshot → not a reassignment.
+    expect(onConfirm).toHaveBeenCalledWith("dev-1", false);
   });
 
   it("tries every decoded barcode until one resolves", async () => {
@@ -93,7 +96,9 @@ describe("ScanMinerQrModal", () => {
       .mockResolvedValueOnce({ status: "notFound" })
       .mockResolvedValueOnce({ status: "found", snapshot: snapshot() });
 
-    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
+    render(
+      <ScanMinerQrModal show currentRackLabel="Rack A" eligibility={{}} onDismiss={vi.fn()} onConfirm={vi.fn()} />,
+    );
 
     await act(async () => {
       capturedOnDetected?.(["FIRSTMISS111", "SECONDHIT222"]);
@@ -107,7 +112,9 @@ describe("ScanMinerQrModal", () => {
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValue({ status: "found", snapshot: snapshot() });
 
-    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
+    render(
+      <ScanMinerQrModal show currentRackLabel="Rack A" eligibility={{}} onDismiss={vi.fn()} onConfirm={vi.fn()} />,
+    );
 
     // Model/asset code listed first, SN:-prefixed serial second — the serial
     // must be looked up first so a stray code can't out-race it.
@@ -123,7 +130,9 @@ describe("ScanMinerQrModal", () => {
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValue({ status: "found", snapshot: snapshot() });
 
-    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
+    render(
+      <ScanMinerQrModal show currentRackLabel="Rack A" eligibility={{}} onDismiss={vi.fn()} onConfirm={vi.fn()} />,
+    );
 
     await act(async () => {
       capturedOnDetected?.(["SN:DUP", "SN:DUP"]);
@@ -137,7 +146,9 @@ describe("ScanMinerQrModal", () => {
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValueOnce({ status: "notFound" });
 
-    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
+    render(
+      <ScanMinerQrModal show currentRackLabel="Rack A" eligibility={{}} onDismiss={vi.fn()} onConfirm={vi.fn()} />,
+    );
 
     await act(async () => {
       capturedOnDetected?.(["SN:NOPE"]);
@@ -154,7 +165,9 @@ describe("ScanMinerQrModal", () => {
     });
     const onConfirm = vi.fn();
 
-    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={onConfirm} />);
+    render(
+      <ScanMinerQrModal show currentRackLabel="Rack A" eligibility={{}} onDismiss={vi.fn()} onConfirm={onConfirm} />,
+    );
 
     await act(async () => {
       capturedOnDetected?.(["SN123"]);
@@ -173,7 +186,9 @@ describe("ScanMinerQrModal", () => {
     });
     const onConfirm = vi.fn();
 
-    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={onConfirm} />);
+    render(
+      <ScanMinerQrModal show currentRackLabel="Rack A" eligibility={{}} onDismiss={vi.fn()} onConfirm={onConfirm} />,
+    );
 
     await act(async () => {
       capturedOnDetected?.(["SN123"]);
@@ -187,7 +202,9 @@ describe("ScanMinerQrModal", () => {
   it("renders the photo-capture fallback when the live camera is unavailable (HTTP)", () => {
     mockCanUseLiveCamera.mockReturnValue(false);
 
-    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
+    render(
+      <ScanMinerQrModal show currentRackLabel="Rack A" eligibility={{}} onDismiss={vi.fn()} onConfirm={vi.fn()} />,
+    );
 
     expect(screen.getByText(/Take a photo of the code/i)).toBeInTheDocument();
     expect(screen.getByText("Open camera")).toBeInTheDocument();
@@ -197,7 +214,9 @@ describe("ScanMinerQrModal", () => {
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValueOnce({ status: "error", message: "server exploded" });
 
-    render(<ScanMinerQrModal show currentRackLabel="Rack A" onDismiss={vi.fn()} onConfirm={vi.fn()} />);
+    render(
+      <ScanMinerQrModal show currentRackLabel="Rack A" eligibility={{}} onDismiss={vi.fn()} onConfirm={vi.fn()} />,
+    );
 
     await act(async () => {
       capturedOnDetected?.(["SN123"]);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
@@ -3,15 +3,21 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import ScanMinerQrModalView, { type ScanPhase } from "./ScanMinerQrModalView";
 import { MinerIdentifierType } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { lookupMinerByIdentifier } from "@/protoFleet/api/lookupMinerByIdentifier";
+import type { MinerEligibility } from "@/protoFleet/components/MinerSelectionList";
 import { canUseLiveCamera, useQrScanner } from "@/protoFleet/features/fleetManagement/hooks/useQrScanner";
+import { isMinerSnapshotIneligible } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import { parseScannedIdentifier } from "@/protoFleet/features/fleetManagement/utils/parseScannedIdentifier";
 
 interface ScanMinerQrModalProps {
   show: boolean;
   /** Label of the rack being edited; a miner already in a *different* rack is blocked. */
   currentRackLabel: string;
+  /** Target rack placement, used to flag whether the scanned miner is a reparent. */
+  eligibility: MinerEligibility;
   onDismiss: () => void;
-  onConfirm: (deviceIdentifier: string) => void;
+  /** `isReassignment` is true when the scanned miner is currently assigned to a
+   *  different rack/building/site, so the caller can confirm the reparent. */
+  onConfirm: (deviceIdentifier: string, isReassignment: boolean) => void;
 }
 
 /**
@@ -19,7 +25,13 @@ interface ScanMinerQrModalProps {
  * decoding, and the identifier → miner lookup, driving the presentational
  * ScanMinerQrModalView through a `ScanPhase` state machine.
  */
-export default function ScanMinerQrModal({ show, currentRackLabel, onDismiss, onConfirm }: ScanMinerQrModalProps) {
+export default function ScanMinerQrModal({
+  show,
+  currentRackLabel,
+  eligibility,
+  onDismiss,
+  onConfirm,
+}: ScanMinerQrModalProps) {
   const [phase, setPhase] = useState<ScanPhase>({ kind: "scanning" });
   const liveCamera = canUseLiveCamera();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -126,8 +138,10 @@ export default function ScanMinerQrModal({ show, currentRackLabel, onDismiss, on
   );
 
   const handleConfirm = useCallback(() => {
-    if (phase.kind === "found") onConfirm(phase.snapshot.deviceIdentifier);
-  }, [phase, onConfirm]);
+    if (phase.kind === "found") {
+      onConfirm(phase.snapshot.deviceIdentifier, isMinerSnapshotIneligible(phase.snapshot, eligibility));
+    }
+  }, [phase, onConfirm, eligibility]);
 
   return (
     <ScanMinerQrModalView

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.tsx
@@ -60,7 +60,9 @@ export default function ScanMinerQrModalView({
 }: ScanMinerQrModalViewProps) {
   if (!show) return null;
 
-  // A miner already assigned to a *different* rack cannot be moved here via scan.
+  // A miner already in a *different* rack can still be assigned here — it's a
+  // reparent, confirmed via the warning in ManageRackModal — so this only drives
+  // an informational note, not a block.
   const foundInOtherRack =
     phase.kind === "found" &&
     !!getMinerRackLabel(phase.snapshot) &&
@@ -93,7 +95,7 @@ export default function ScanMinerQrModalView({
               {
                 text: "Assign to slot",
                 variant: variants.primary,
-                disabled: foundInOtherRack || notPairedForAssignment,
+                disabled: notPairedForAssignment,
                 onClick: onConfirm,
                 dismissModalOnClick: false,
               },
@@ -265,8 +267,8 @@ function FoundMiner({
         <Callout
           intent="warning"
           prefixIcon={<Alert />}
-          title={`Already assigned to rack "${otherRackLabel}"`}
-          subtitle="Remove it from that rack before assigning it here."
+          title={`Currently assigned to rack "${otherRackLabel}"`}
+          subtitle="Assigning it here will move it from that rack."
         />
       ) : notPaired ? (
         <Callout

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => {
       <SearchMinersModal
         show={show}
         eligibility={{ rackId: 1n, siteId: 10n, buildingId: 100n }}
+        targetRackLabel="Rack 1"
         onDismiss={() => {
           action("onDismiss")();
           setShow(false);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.stories.tsx
@@ -21,7 +21,7 @@ export const Default = () => {
       ) : null}
       <SearchMinersModal
         show={show}
-        currentRackLabel="Rack A-01"
+        eligibility={{ rackId: 1n, siteId: 10n, buildingId: 100n }}
         onDismiss={() => {
           action("onDismiss")();
           setShow(false);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
@@ -12,7 +12,9 @@ interface SearchMinersModalProps {
    *  or render disabled). */
   eligibility: MinerEligibility;
   onDismiss: () => void;
-  onConfirm: (selectedMinerId: string) => void;
+  /** `isReassignment` is true when the picked miner is currently assigned to a
+   *  different rack/building/site, so the caller can confirm the reparent. */
+  onConfirm: (selectedMinerId: string, isReassignment: boolean) => void;
 }
 
 export default function SearchMinersModal({ show, eligibility, onDismiss, onConfirm }: SearchMinersModalProps) {
@@ -22,7 +24,8 @@ export default function SearchMinersModal({ show, eligibility, onDismiss, onConf
   const handleConfirm = useCallback(() => {
     const selection = selectionRef.current?.getSelection();
     if (!selection || selection.selectedItems.length === 0) return;
-    onConfirm(selection.selectedItems[0]);
+    const minerId = selection.selectedItems[0];
+    onConfirm(minerId, selection.reassignedItems.includes(minerId));
   }, [onConfirm]);
 
   if (!show) return null;

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
@@ -31,7 +31,9 @@ export default function SearchMinersModal({
 
   const handleConfirm = useCallback(() => {
     const selection = selectionRef.current?.getSelection();
-    if (!selection || selection.selectedItems.length === 0) return;
+    // blockedByFilter: a conflicting placement facet is showing no results, so
+    // the (hidden) selection must not be acted on.
+    if (!selection || selection.blockedByFilter || selection.selectedItems.length === 0) return;
     const minerId = selection.selectedItems[0];
     onConfirm(minerId, selection.reassignedItems.includes(minerId));
   }, [onConfirm]);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
@@ -11,13 +11,21 @@ interface SearchMinersModalProps {
    *  id-based eligibility filter (miners in another rack/building/site drop out
    *  or render disabled). */
   eligibility: MinerEligibility;
+  /** Target rack label, shown in the assignment-conflict dialog. */
+  targetRackLabel: string;
   onDismiss: () => void;
   /** `isReassignment` is true when the picked miner is currently assigned to a
    *  different rack/building/site, so the caller can confirm the reparent. */
   onConfirm: (selectedMinerId: string, isReassignment: boolean) => void;
 }
 
-export default function SearchMinersModal({ show, eligibility, onDismiss, onConfirm }: SearchMinersModalProps) {
+export default function SearchMinersModal({
+  show,
+  eligibility,
+  targetRackLabel,
+  onDismiss,
+  onConfirm,
+}: SearchMinersModalProps) {
   const selectionRef = useRef<MinerSelectionListHandle>(null);
   const [hasSelection, setHasSelection] = useState(false);
 
@@ -58,6 +66,7 @@ export default function SearchMinersModal({ show, eligibility, onDismiss, onConf
           showGroupFilter: true,
         }}
         eligibility={eligibility}
+        targetRackLabel={targetRackLabel}
         singleSelect
         onSelectionChange={({ selectedItems }) => setHasSelection(selectedItems.length > 0)}
       />

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
@@ -1,25 +1,23 @@
 import { useCallback, useRef, useState } from "react";
 
-import type { DeviceListItem, MinerSelectionListHandle } from "@/protoFleet/components/MinerSelectionList";
+import type { MinerEligibility, MinerSelectionListHandle } from "@/protoFleet/components/MinerSelectionList";
 import MinerSelectionList from "@/protoFleet/components/MinerSelectionList";
 
 import Modal from "@/shared/components/Modal";
 
 interface SearchMinersModalProps {
   show: boolean;
-  currentRackLabel: string;
+  /** Target rack placement. Drives the "Show assignable only" toggle and the
+   *  id-based eligibility filter (miners in another rack/building/site drop out
+   *  or render disabled). */
+  eligibility: MinerEligibility;
   onDismiss: () => void;
   onConfirm: (selectedMinerId: string) => void;
 }
 
-export default function SearchMinersModal({ show, currentRackLabel, onDismiss, onConfirm }: SearchMinersModalProps) {
+export default function SearchMinersModal({ show, eligibility, onDismiss, onConfirm }: SearchMinersModalProps) {
   const selectionRef = useRef<MinerSelectionListHandle>(null);
   const [hasSelection, setHasSelection] = useState(false);
-
-  const isRowDisabled = useCallback(
-    (item: DeviceListItem) => !!(item.rackLabel && item.rackLabel !== currentRackLabel),
-    [currentRackLabel],
-  );
 
   const handleConfirm = useCallback(() => {
     const selection = selectionRef.current?.getSelection();
@@ -48,8 +46,15 @@ export default function SearchMinersModal({ show, currentRackLabel, onDismiss, o
     >
       <MinerSelectionList
         ref={selectionRef}
-        filterConfig={{ showTypeFilter: true, showRackFilter: false, showGroupFilter: false }}
-        isRowDisabled={isRowDisabled}
+        filterConfig={{
+          showTypeFilter: true,
+          showSubnetFilter: true,
+          showSiteFilter: true,
+          showBuildingFilter: true,
+          showRackFilter: true,
+          showGroupFilter: true,
+        }}
+        eligibility={eligibility}
         singleSelect
         onSelectionChange={({ selectedItems }) => setHasSelection(selectedItems.length > 0)}
       />

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -566,10 +566,15 @@ const RackOverviewPage = () => {
             // without resending the full rack state. On partial
             // success (assigned but slot failed), we still refresh so
             // the UI stays consistent.
-            const assign = () =>
+            // `force` clears a conflicting site when the target rack has no
+            // site of its own; without it the server returns conflicts and
+            // writes nothing. We force only after the operator has confirmed the
+            // reparent below.
+            const assign = (force: boolean) =>
               assignDevicesToRack({
                 targetRackId: rack.id,
                 deviceIdentifiers: [minerId],
+                forceClearConflictingSite: force,
                 onSuccess: () => {
                   setRackSlotPosition({
                     deviceSetId: rack.id,
@@ -590,16 +595,25 @@ const RackOverviewPage = () => {
                     },
                   });
                 },
+                // Defensive: a placement conflict without a preceding warning
+                // shouldn't be a silent no-op.
+                onConflicts: () => {
+                  pushToast({
+                    message: "This miner is assigned to another site. Confirm the move and try again.",
+                    status: STATUSES.error,
+                  });
+                },
                 onError: (msg) => {
                   pushToast({ message: msg, status: STATUSES.error });
                 },
               });
 
-            // Reparenting a miner from another rack/building/site warns first (#672).
+            // Reparenting a miner from another rack/building/site warns first (#672);
+            // confirming forces the site strip so a site-less target rack still writes.
             if (isReassignment) {
-              setReparentPrompt({ count: 1, onConfirm: assign });
+              setReparentPrompt({ count: 1, onConfirm: () => assign(true) });
             } else {
-              assign();
+              assign(false);
             }
           }}
         />

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -19,6 +19,7 @@ import { useDeviceSetStateCounts } from "@/protoFleet/api/useDeviceSetStateCount
 import { useTelemetryMetrics } from "@/protoFleet/api/useTelemetryMetrics";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import { ManageRackModal, type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal";
+import ReparentWarningDialog from "@/protoFleet/features/fleetManagement/components/ManageRackModal/ReparentWarningDialog";
 import SearchMinersModal from "@/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal";
 import { orderIndexToOrigin } from "@/protoFleet/features/fleetManagement/components/ManageRackModal/types";
 import type { SlotHealthState } from "@/protoFleet/features/fleetManagement/components/RackDetailGrid/types";
@@ -63,6 +64,8 @@ const RackOverviewPage = () => {
   const [resolveError, setResolveError] = useState<string | null>(null);
   const [showEditModal, setShowEditModal] = useState(false);
   const [searchMinerSlot, setSearchMinerSlot] = useState<{ row: number; col: number } | null>(null);
+  // Pending reparent confirmation for the quick slot-assign flow (#672).
+  const [reparentPrompt, setReparentPrompt] = useState<{ count: number; onConfirm: () => void } | null>(null);
   const sleepActionRef = useRef<(() => void) | null>(null);
   const actionActiveRef = useRef(false);
 
@@ -553,7 +556,7 @@ const RackOverviewPage = () => {
             buildingId: rack.placement?.building?.id || undefined,
           }}
           onDismiss={() => setSearchMinerSlot(null)}
-          onConfirm={(minerId) => {
+          onConfirm={(minerId, isReassignment) => {
             const slot = searchMinerSlot;
             setSearchMinerSlot(null);
 
@@ -563,33 +566,54 @@ const RackOverviewPage = () => {
             // without resending the full rack state. On partial
             // success (assigned but slot failed), we still refresh so
             // the UI stays consistent.
-            assignDevicesToRack({
-              targetRackId: rack.id,
-              deviceIdentifiers: [minerId],
-              onSuccess: () => {
-                setRackSlotPosition({
-                  deviceSetId: rack.id,
-                  deviceIdentifier: minerId,
-                  position: create(RackSlotPositionSchema, { row: slot.row, column: slot.col }),
-                  onSuccess: () => {
-                    pushToast({ message: "Miner assigned to slot", status: STATUSES.success });
-                    resolveRack(rack.id);
-                    void refetchStats();
-                  },
-                  onError: (msg) => {
-                    pushToast({
-                      message: `Miner added to rack but slot assignment failed: ${msg}`,
-                      status: STATUSES.error,
-                    });
-                    resolveRack(rack.id);
-                    void refetchStats();
-                  },
-                });
-              },
-              onError: (msg) => {
-                pushToast({ message: msg, status: STATUSES.error });
-              },
-            });
+            const assign = () =>
+              assignDevicesToRack({
+                targetRackId: rack.id,
+                deviceIdentifiers: [minerId],
+                onSuccess: () => {
+                  setRackSlotPosition({
+                    deviceSetId: rack.id,
+                    deviceIdentifier: minerId,
+                    position: create(RackSlotPositionSchema, { row: slot.row, column: slot.col }),
+                    onSuccess: () => {
+                      pushToast({ message: "Miner assigned to slot", status: STATUSES.success });
+                      resolveRack(rack.id);
+                      void refetchStats();
+                    },
+                    onError: (msg) => {
+                      pushToast({
+                        message: `Miner added to rack but slot assignment failed: ${msg}`,
+                        status: STATUSES.error,
+                      });
+                      resolveRack(rack.id);
+                      void refetchStats();
+                    },
+                  });
+                },
+                onError: (msg) => {
+                  pushToast({ message: msg, status: STATUSES.error });
+                },
+              });
+
+            // Reparenting a miner from another rack/building/site warns first (#672).
+            if (isReassignment) {
+              setReparentPrompt({ count: 1, onConfirm: assign });
+            } else {
+              assign();
+            }
+          }}
+        />
+      ) : null}
+
+      {reparentPrompt && rack ? (
+        <ReparentWarningDialog
+          count={reparentPrompt.count}
+          rackLabel={rack.label}
+          onCancel={() => setReparentPrompt(null)}
+          onConfirm={() => {
+            const proceed = reparentPrompt.onConfirm;
+            setReparentPrompt(null);
+            proceed();
           }}
         />
       ) : null}

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -555,6 +555,7 @@ const RackOverviewPage = () => {
             siteId: rack.placement?.site?.id || undefined,
             buildingId: rack.placement?.building?.id || undefined,
           }}
+          targetRackLabel={rack.label}
           onDismiss={() => setSearchMinerSlot(null)}
           onConfirm={(minerId, isReassignment) => {
             const slot = searchMinerSlot;

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -547,7 +547,11 @@ const RackOverviewPage = () => {
       {searchMinerSlot && rack ? (
         <SearchMinersModal
           show
-          currentRackLabel={rack.label}
+          eligibility={{
+            rackId: rack.id,
+            siteId: rack.placement?.site?.id || undefined,
+            buildingId: rack.placement?.building?.id || undefined,
+          }}
           onDismiss={() => setSearchMinerSlot(null)}
           onConfirm={(minerId) => {
             const slot = searchMinerSlot;

--- a/client/src/protoFleet/features/fleetManagement/utils/minerPlacement.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/minerPlacement.test.ts
@@ -44,9 +44,22 @@ describe("isPlacementIneligible", () => {
       expect(isPlacementIneligible({ rackId: 5n }, NEW_RACK)).toBe(true);
     });
 
-    it("keeps unracked miners regardless of building/site", () => {
-      expect(isPlacementIneligible({ buildingId: 7n, siteId: 8n }, NEW_RACK)).toBe(false);
+    it("flags an unracked-but-placed miner (an unplaced rack strips its building/site on assign)", () => {
+      expect(isPlacementIneligible({ buildingId: 7n }, NEW_RACK)).toBe(true);
+      expect(isPlacementIneligible({ siteId: 8n }, NEW_RACK)).toBe(true);
     });
+
+    it("keeps a fully unplaced miner", () => {
+      expect(isPlacementIneligible({}, NEW_RACK)).toBe(false);
+    });
+  });
+
+  it("flags a miner whose site the target lacks (rack placed under a site with no building)", () => {
+    // Target under site 10, no building. A miner directly in building 200 (same
+    // site) has its building stripped on assign, so it's a reassignment.
+    const SITE_ONLY: MinerEligibility = { rackId: 1n, siteId: 10n };
+    expect(isPlacementIneligible({ buildingId: 200n, siteId: 10n }, SITE_ONLY)).toBe(true);
+    expect(isPlacementIneligible({ siteId: 10n }, SITE_ONLY)).toBe(false);
   });
 });
 

--- a/client/src/protoFleet/features/fleetManagement/utils/minerPlacement.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/minerPlacement.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import {
+  isMinerSnapshotIneligible,
+  isPlacementIneligible,
+  type MinerEligibility,
+} from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
+
+// Target rack: id 1, in building 100 / site 10.
+const TARGET: MinerEligibility = { rackId: 1n, buildingId: 100n, siteId: 10n };
+
+describe("isPlacementIneligible", () => {
+  it("keeps a miner already in the target rack", () => {
+    expect(isPlacementIneligible({ rackId: 1n, buildingId: 100n, siteId: 10n }, TARGET)).toBe(false);
+  });
+
+  it("keeps a fully unplaced miner", () => {
+    expect(isPlacementIneligible({}, TARGET)).toBe(false);
+  });
+
+  it("excludes a miner in a different rack", () => {
+    expect(isPlacementIneligible({ rackId: 2n, buildingId: 100n, siteId: 10n }, TARGET)).toBe(true);
+  });
+
+  it("excludes a miner sitting directly in a different building (no rack)", () => {
+    expect(isPlacementIneligible({ buildingId: 200n, siteId: 10n }, TARGET)).toBe(true);
+  });
+
+  it("excludes a miner in a different site", () => {
+    expect(isPlacementIneligible({ siteId: 20n }, TARGET)).toBe(true);
+  });
+
+  it("does not confuse a same-id rack in the target with a different rack (id-based)", () => {
+    // Label-based checks would collide here; id-based keeps them distinct.
+    expect(isPlacementIneligible({ rackId: 1n }, TARGET)).toBe(false);
+    expect(isPlacementIneligible({ rackId: 99n }, TARGET)).toBe(true);
+  });
+
+  describe("new rack (no target ids)", () => {
+    const NEW_RACK: MinerEligibility = {};
+
+    it("excludes every already-racked miner", () => {
+      expect(isPlacementIneligible({ rackId: 5n }, NEW_RACK)).toBe(true);
+    });
+
+    it("keeps unracked miners regardless of building/site", () => {
+      expect(isPlacementIneligible({ buildingId: 7n, siteId: 8n }, NEW_RACK)).toBe(false);
+    });
+  });
+});
+
+describe("isMinerSnapshotIneligible", () => {
+  const snapshot = (placement: { rack?: bigint; building?: bigint; site?: bigint }): MinerStateSnapshot =>
+    ({
+      placement: {
+        rack: placement.rack !== undefined ? { id: placement.rack, label: "" } : undefined,
+        building: placement.building !== undefined ? { id: placement.building, label: "" } : undefined,
+        site: placement.site !== undefined ? { id: placement.site, label: "" } : undefined,
+        groups: [],
+      },
+    }) as unknown as MinerStateSnapshot;
+
+  it("reads placement refs off the snapshot", () => {
+    expect(isMinerSnapshotIneligible(snapshot({ rack: 1n, building: 100n, site: 10n }), TARGET)).toBe(false);
+    expect(isMinerSnapshotIneligible(snapshot({ rack: 2n }), TARGET)).toBe(true);
+    expect(isMinerSnapshotIneligible(snapshot({}), TARGET)).toBe(false);
+  });
+
+  it("treats a zero id (proto default) as unassigned", () => {
+    expect(isMinerSnapshotIneligible(snapshot({ rack: 0n }), TARGET)).toBe(false);
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/utils/minerPlacement.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/minerPlacement.ts
@@ -7,6 +7,45 @@ export const getMinerBuildingLabel = (miner: MinerStateSnapshot): string => mine
 
 export const getMinerRackLabel = (miner: MinerStateSnapshot): string => miner.placement?.rack?.label ?? "";
 
+/** Normalize a placement ResourceRef id to bigint, treating the proto default
+ *  (0 / absent ref) as "unassigned" (undefined) so id-based eligibility checks
+ *  don't confuse an unplaced miner with one placed at id 0. */
+const refId = (ref?: ResourceRef): bigint | undefined => (ref && ref.id !== 0n ? ref.id : undefined);
+
+export const getMinerSiteId = (miner: MinerStateSnapshot): bigint | undefined => refId(miner.placement?.site);
+
+export const getMinerBuildingId = (miner: MinerStateSnapshot): bigint | undefined => refId(miner.placement?.building);
+
+export const getMinerRackId = (miner: MinerStateSnapshot): bigint | undefined => refId(miner.placement?.rack);
+
+/** Placement of the rack a caller is assigning miners into. Miners in a
+ *  different rack, building, or site are "ineligible". Fields are undefined
+ *  when the target rack isn't placed at that level yet (e.g. a new rack). */
+export type MinerEligibility = {
+  rackId?: bigint;
+  siteId?: bigint;
+  buildingId?: bigint;
+};
+
+/** A placement is ineligible when it sits somewhere incompatible with the
+ *  target rack. Any miner in a *different* rack is ineligible — including every
+ *  racked miner when the target rack doesn't exist yet (rackId undefined), so a
+ *  new rack still only pulls from unracked miners. Building/site only gate when
+ *  the target rack is placed at that level. Unplaced miners stay eligible.
+ *  Id-based to avoid label collisions (a same-named rack in another building). */
+export const isPlacementIneligible = (placement: MinerEligibility, eligibility: MinerEligibility): boolean =>
+  (placement.rackId !== undefined && placement.rackId !== eligibility.rackId) ||
+  (eligibility.buildingId !== undefined &&
+    placement.buildingId !== undefined &&
+    placement.buildingId !== eligibility.buildingId) ||
+  (eligibility.siteId !== undefined && placement.siteId !== undefined && placement.siteId !== eligibility.siteId);
+
+export const isMinerSnapshotIneligible = (miner: MinerStateSnapshot, eligibility: MinerEligibility): boolean =>
+  isPlacementIneligible(
+    { rackId: getMinerRackId(miner), buildingId: getMinerBuildingId(miner), siteId: getMinerSiteId(miner) },
+    eligibility,
+  );
+
 export const getMinerGroupRefs = (miner: MinerStateSnapshot): ResourceRef[] => miner.placement?.groups ?? [];
 
 export const getMinerGroupLabels = (miner: MinerStateSnapshot): string[] =>

--- a/client/src/protoFleet/features/fleetManagement/utils/minerPlacement.ts
+++ b/client/src/protoFleet/features/fleetManagement/utils/minerPlacement.ts
@@ -27,18 +27,18 @@ export type MinerEligibility = {
   buildingId?: bigint;
 };
 
-/** A placement is ineligible when it sits somewhere incompatible with the
- *  target rack. Any miner in a *different* rack is ineligible — including every
- *  racked miner when the target rack doesn't exist yet (rackId undefined), so a
- *  new rack still only pulls from unracked miners. Building/site only gate when
- *  the target rack is placed at that level. Unplaced miners stay eligible.
+/** A placement is ineligible when it sits somewhere the target rack isn't, at
+ *  any level — assigning it there moves it. SaveRack aligns members to the
+ *  rack's placement, and an unplaced/partly-placed rack strips the mismatched
+ *  levels to NULL, so a miner placed at a level the target *lacks* (target id
+ *  undefined) is also a reassignment. This makes a new/unplaced rack warn before
+ *  clearing a miner's existing rack/building/site. A miner unplaced at a level
+ *  (its own id undefined) is never moved there, so it stays eligible.
  *  Id-based to avoid label collisions (a same-named rack in another building). */
 export const isPlacementIneligible = (placement: MinerEligibility, eligibility: MinerEligibility): boolean =>
   (placement.rackId !== undefined && placement.rackId !== eligibility.rackId) ||
-  (eligibility.buildingId !== undefined &&
-    placement.buildingId !== undefined &&
-    placement.buildingId !== eligibility.buildingId) ||
-  (eligibility.siteId !== undefined && placement.siteId !== undefined && placement.siteId !== eligibility.siteId);
+  (placement.buildingId !== undefined && placement.buildingId !== eligibility.buildingId) ||
+  (placement.siteId !== undefined && placement.siteId !== eligibility.siteId);
 
 export const isMinerSnapshotIneligible = (miner: MinerStateSnapshot, eligibility: MinerEligibility): boolean =>
   isPlacementIneligible(

--- a/client/src/shared/components/List/Filters/TextareaListModal.test.tsx
+++ b/client/src/shared/components/List/Filters/TextareaListModal.test.tsx
@@ -49,11 +49,39 @@ describe("TextareaListModal", () => {
     expect(onApply).toHaveBeenCalledWith(["ABC", "DEF"]);
   });
 
-  it("disables Apply when any line is invalid", () => {
+  it("validates on blur, not on keystroke", () => {
     renderModal();
-    fireEvent.change(screen.getByRole("textbox"), {
-      target: { value: "ok\nBAD\nok2" },
-    });
+    const textbox = screen.getByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "BAD" } });
+    // No error while typing.
+    expect(screen.queryByText(/rejected by stub/i)).not.toBeInTheDocument();
+    fireEvent.blur(textbox);
+    // Error surfaces on blur.
+    expect(screen.getByText(/rejected by stub/i)).toBeInTheDocument();
+  });
+
+  it("clears the error on focus and re-validates on the next blur", () => {
+    renderModal();
+    const textbox = screen.getByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "BAD" } });
+    fireEvent.blur(textbox);
+    expect(screen.getByText(/rejected by stub/i)).toBeInTheDocument();
+
+    // Focus clears the stale error.
+    fireEvent.focus(textbox);
+    expect(screen.queryByText(/rejected by stub/i)).not.toBeInTheDocument();
+
+    // Correcting the value and blurring again leaves no error.
+    fireEvent.change(textbox, { target: { value: "ok" } });
+    fireEvent.blur(textbox);
+    expect(screen.queryByText(/rejected by stub/i)).not.toBeInTheDocument();
+  });
+
+  it("disables Apply when any line is invalid (after blur)", () => {
+    renderModal();
+    const textbox = screen.getByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "ok\nBAD\nok2" } });
+    fireEvent.blur(textbox);
     expect(screen.getByText(/Line 2/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /apply/i })).toBeDisabled();
   });
@@ -70,9 +98,11 @@ describe("TextareaListModal", () => {
     const onApply = vi.fn();
     const lines = Array.from({ length: 5 }, (_, i) => `entry-${i}`);
     renderModal({ onApply, maxLines: 3 });
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: lines.join("\n") } });
+    const textbox = screen.getByRole("textbox");
+    fireEvent.change(textbox, { target: { value: lines.join("\n") } });
+    fireEvent.blur(textbox);
+    expect(screen.getByText(/Showing first 3/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /apply/i }));
     expect(onApply).toHaveBeenCalledWith(["entry-0", "entry-1", "entry-2"]);
-    expect(screen.getByText(/Showing first 3/i)).toBeInTheDocument();
   });
 });

--- a/client/src/shared/components/List/Filters/TextareaListModal.test.tsx
+++ b/client/src/shared/components/List/Filters/TextareaListModal.test.tsx
@@ -94,6 +94,18 @@ describe("TextareaListModal", () => {
     expect(onApply).toHaveBeenCalledWith([]);
   });
 
+  it("keeps the modal open and surfaces errors when Apply is clicked with an invalid draft", () => {
+    const onApply = vi.fn();
+    const onClose = vi.fn();
+    renderModal({ onApply, onClose });
+    // Type an invalid line but don't blur, so the Apply button isn't disabled yet.
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "BAD" } });
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(onApply).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText(/rejected by stub/i)).toBeInTheDocument();
+  });
+
   it("caps at maxLines with a 'Showing first N' notice", () => {
     const onApply = vi.fn();
     const lines = Array.from({ length: 5 }, (_, i) => `entry-${i}`);

--- a/client/src/shared/components/List/Filters/TextareaListModal.tsx
+++ b/client/src/shared/components/List/Filters/TextareaListModal.tsx
@@ -57,14 +57,30 @@ const TextareaListModalContent = ({
   onClose,
 }: TextareaListModalProps) => {
   const [draft, setDraft] = useState(initialValue.join("\n"));
+  // Validate on blur, not on every keystroke, so errors don't flash while a
+  // line is still being typed. `validated` is the text snapshot taken at the
+  // last blur; `null` means "no validation shown" (initial state, and after
+  // focus) so a fixed line's stale error clears until the field is blurred
+  // again. `draft` tracks live input.
+  const [validated, setValidated] = useState<string | null>(null);
 
-  const { parsed, truncated } = useMemo(() => parseLines(draft, validate, maxLines), [draft, validate, maxLines]);
+  const { parsed, truncated } = useMemo(
+    () => (validated === null ? { parsed: [], truncated: false } : parseLines(validated, validate, maxLines)),
+    [validated, validate, maxLines],
+  );
 
   const errorEntries = parsed.filter((p) => p.error !== null);
   const isValid = errorEntries.length === 0;
 
   const handleApply = () => {
-    const acceptedRaw = parsed
+    // Re-validate the live draft in case Apply is clicked without blurring the
+    // textarea first; surface any errors instead of silently dropping lines.
+    const result = parseLines(draft, validate, maxLines);
+    if (result.parsed.some((p) => p.error !== null)) {
+      setValidated(draft);
+      return;
+    }
+    const acceptedRaw = result.parsed
       .filter((p) => p.trimmed !== "" && p.error === null)
       .map((p) => (normalize ? normalize(p.trimmed) : p.trimmed));
     const seen = new Set<string>();
@@ -100,7 +116,7 @@ const TextareaListModalContent = ({
       <div className="mt-4 flex flex-col gap-3">
         {placeholder ? (
           <div className="text-200 text-text-primary-70" data-testid={`textarea-list-${categoryKey}-hint`}>
-            One per line. Example: <span className="font-mono">{placeholder.split("\n")[0]}</span>
+            One per line. Examples: <span className="font-mono">{placeholder.split("\n").join(", ")}</span>
           </div>
         ) : null}
         <Textarea
@@ -108,6 +124,8 @@ const TextareaListModalContent = ({
           label={label}
           initValue={draft}
           onChange={(value) => setDraft(value)}
+          onFocus={() => setValidated(null)}
+          onBlur={() => setValidated(draft)}
           rows={8}
           // Boolean error tints the border red; per-line messages render below
           // (they're easier to scan as a list than as one joined string).

--- a/client/src/shared/components/List/Filters/TextareaListModal.tsx
+++ b/client/src/shared/components/List/Filters/TextareaListModal.tsx
@@ -110,6 +110,10 @@ const TextareaListModalContent = ({
           onClick: handleApply,
           variant: variants.primary,
           disabled: !isValid,
+          // handleApply closes the modal itself on success; keep it open so an
+          // invalid draft (validated only on click) surfaces errors instead of
+          // dismissing and dropping the user's edits.
+          dismissModalOnClick: false,
         },
       ]}
     >

--- a/client/src/shared/components/List/Filters/types.ts
+++ b/client/src/shared/components/List/Filters/types.ts
@@ -92,11 +92,7 @@ export type NestedFilterChildItem = DropdownFilterItem | NumericRangeFilterItem 
 // textareaList renders as a trigger that opens the shared modal (the same
 // component the nestedFilterDropdown uses for its children).
 export type FilterItem =
-  | ButtonFilterItem
-  | DropdownFilterItem
-  | NestedFilterDropdownItem
-  | NumericRangeFilterItem
-  | TextareaListFilterItem;
+  ButtonFilterItem | DropdownFilterItem | NestedFilterDropdownItem | NumericRangeFilterItem | TextareaListFilterItem;
 
 /**
  * Submenu category passed into `NestedDropdownFilter`. Discriminated by

--- a/client/src/shared/components/List/Filters/types.ts
+++ b/client/src/shared/components/List/Filters/types.ts
@@ -88,7 +88,15 @@ export type NestedFilterDropdownItem = BaseFilterItem & {
 
 export type NestedFilterChildItem = DropdownFilterItem | NumericRangeFilterItem | TextareaListFilterItem;
 
-export type FilterItem = ButtonFilterItem | DropdownFilterItem | NestedFilterDropdownItem;
+// Standalone (top-level) filters. Dropdown/button render as inline controls;
+// textareaList renders as a trigger that opens the shared modal (the same
+// component the nestedFilterDropdown uses for its children).
+export type FilterItem =
+  | ButtonFilterItem
+  | DropdownFilterItem
+  | NestedFilterDropdownItem
+  | NumericRangeFilterItem
+  | TextareaListFilterItem;
 
 /**
  * Submenu category passed into `NestedDropdownFilter`. Discriminated by

--- a/client/src/shared/utils/filterValidation.test.ts
+++ b/client/src/shared/utils/filterValidation.test.ts
@@ -151,6 +151,11 @@ describe("validateSubnetLine", () => {
     expect(validateSubnetLine("10.0.0.10-999")).not.toBeNull();
   });
 
+  it("caps an IP range at 1024 addresses (stopgap for the client CIDR expansion)", () => {
+    expect(validateSubnetLine("10.0.0.0-10.0.3.255")).toBeNull(); // exactly 1024 addresses
+    expect(validateSubnetLine("10.0.0.0-10.0.4.0")).toBe("IP ranges are limited to 1024 addresses"); // 1025
+  });
+
   it("rejects hostnames with a targeted message (filter matches by IP, not name)", () => {
     expect(validateSubnetLine("miner01")).toBe("Hostnames aren't supported here — use an IP, CIDR, or range");
     expect(validateSubnetLine("rack3-unit.local")).toBe("Hostnames aren't supported here — use an IP, CIDR, or range");

--- a/client/src/shared/utils/filterValidation.test.ts
+++ b/client/src/shared/utils/filterValidation.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  expandSubnetLineToCidrs,
   normalizeCidrLine,
+  normalizeSubnetLine,
   type NumericRangeBounds,
   type NumericRangeValue,
   validateCidrLine,
   validateNumericRange,
+  validateSubnetLine,
 } from "./filterValidation";
 
 const bounds: NumericRangeBounds = { min: 0, max: 100, unit: "TH/s" };
@@ -128,5 +131,61 @@ describe("normalizeCidrLine", () => {
 
   it("preserves host == network for /32", () => {
     expect(normalizeCidrLine("192.168.1.5/32")).toBe("192.168.1.5/32");
+  });
+});
+
+describe("validateSubnetLine", () => {
+  it("accepts CIDRs and bare IPs like validateCidrLine", () => {
+    expect(validateSubnetLine("192.168.1.0/24")).toBeNull();
+    expect(validateSubnetLine("10.0.0.5")).toBeNull();
+  });
+
+  it("accepts short and full IPv4 ranges (discovery syntax)", () => {
+    expect(validateSubnetLine("10.0.0.10-20")).toBeNull();
+    expect(validateSubnetLine("10.0.0.10-10.0.0.20")).toBeNull();
+    expect(validateSubnetLine("10.0.0.10 - 10.0.0.20")).toBeNull();
+  });
+
+  it("rejects an inverted or malformed range", () => {
+    expect(validateSubnetLine("10.0.0.20-10")).not.toBeNull();
+    expect(validateSubnetLine("10.0.0.10-999")).not.toBeNull();
+  });
+
+  it("rejects hostnames with a targeted message (filter matches by IP, not name)", () => {
+    expect(validateSubnetLine("miner01")).toBe("Hostnames aren't supported here — use an IP, CIDR, or range");
+    expect(validateSubnetLine("rack3-unit.local")).toBe("Hostnames aren't supported here — use an IP, CIDR, or range");
+  });
+
+  it("gives the generic CIDR error (not the hostname hint) for an all-numeric malformed IP", () => {
+    const error = validateSubnetLine("999.1.1.1");
+    expect(error).not.toBeNull();
+    expect(error).not.toContain("Hostnames");
+  });
+});
+
+describe("normalizeSubnetLine", () => {
+  it("canonicalizes a short range to its full form so it dedups with the full form", () => {
+    expect(normalizeSubnetLine("10.0.0.10-20")).toBe("10.0.0.10-10.0.0.20");
+    expect(normalizeSubnetLine("10.0.0.10 - 10.0.0.20")).toBe("10.0.0.10-10.0.0.20");
+  });
+
+  it("defers to CIDR normalization for non-ranges", () => {
+    expect(normalizeSubnetLine("10.0.0.5")).toBe("10.0.0.5/32");
+  });
+});
+
+describe("expandSubnetLineToCidrs", () => {
+  it("expands a range into its covering CIDRs", () => {
+    expect(expandSubnetLineToCidrs("10.0.0.10-10.0.0.21")).toEqual([
+      "10.0.0.10/31",
+      "10.0.0.12/30",
+      "10.0.0.16/30",
+      "10.0.0.20/31",
+    ]);
+  });
+
+  it("passes a CIDR/IP through as a single normalized entry", () => {
+    expect(expandSubnetLineToCidrs("192.168.1.0/24")).toEqual(["192.168.1.0/24"]);
+    expect(expandSubnetLineToCidrs("10.0.0.5")).toEqual(["10.0.0.5/32"]);
   });
 });

--- a/client/src/shared/utils/filterValidation.test.ts
+++ b/client/src/shared/utils/filterValidation.test.ts
@@ -156,9 +156,9 @@ describe("validateSubnetLine", () => {
     expect(validateSubnetLine("rack3-unit.local")).toBe("Hostnames aren't supported here — use an IP, CIDR, or range");
   });
 
-  it("gives the generic CIDR error (not the hostname hint) for an all-numeric malformed IP", () => {
+  it("gives a generic error mentioning IP, range, and CIDR for an all-numeric malformed IP", () => {
     const error = validateSubnetLine("999.1.1.1");
-    expect(error).not.toBeNull();
+    expect(error).toBe("Not a valid IP address, range, or CIDR");
     expect(error).not.toContain("Hostnames");
   });
 });

--- a/client/src/shared/utils/filterValidation.ts
+++ b/client/src/shared/utils/filterValidation.ts
@@ -1,5 +1,6 @@
 import {
   ipv4RangeToCidrs,
+  ipv4ToInt,
   isValidCidr,
   isValidHostname,
   isValidIpv4,
@@ -7,6 +8,13 @@ import {
   looksLikeIpRange,
   parseIpRange,
 } from "./networkDiscovery";
+
+// A subnet range expands to a covering CIDR set client-side (the fleet filter
+// has no native range field). Cap a single range's span so one line can't blow
+// past the server's ip_cidrs limit and turn into a failed request with no inline
+// feedback. This is a stopgap bound per line — the complete guard lands when the
+// server accepts ranges natively (#682).
+const MAX_RANGE_ADDRESSES = 1024;
 
 export type NumericRangeValue = {
   min?: number;
@@ -143,7 +151,12 @@ export const validateSubnetLine = (line: string): string | null => {
   const trimmed = line.trim();
   if (trimmed === "") return "Empty value";
   if (looksLikeIpRange(trimmed)) {
-    return parseIpRange(trimmed) ? null : "Not a valid IP range (e.g. 10.0.0.10-10.0.0.20)";
+    const range = parseIpRange(trimmed);
+    if (!range) return "Not a valid IP range (e.g. 10.0.0.10-10.0.0.20)";
+    if (ipv4ToInt(range.endIp) - ipv4ToInt(range.startIp) + 1 > MAX_RANGE_ADDRESSES) {
+      return `IP ranges are limited to ${MAX_RANGE_ADDRESSES} addresses`;
+    }
+    return null;
   }
   if (trimmed.includes("/")) {
     return isValidCidr(trimmed) || isValidIpv6Cidr(trimmed)

--- a/client/src/shared/utils/filterValidation.ts
+++ b/client/src/shared/utils/filterValidation.ts
@@ -1,4 +1,12 @@
-import { isValidCidr, isValidIpv4, isValidIpv6 } from "./networkDiscovery";
+import {
+  ipv4RangeToCidrs,
+  isValidCidr,
+  isValidHostname,
+  isValidIpv4,
+  isValidIpv6,
+  looksLikeIpRange,
+  parseIpRange,
+} from "./networkDiscovery";
 
 export type NumericRangeValue = {
   min?: number;
@@ -122,4 +130,62 @@ export const normalizeCidrLine = (line: string): string => {
   const network = ipInt & maskInt;
   const networkOctets = [(network >>> 24) & 0xff, (network >>> 16) & 0xff, (network >>> 8) & 0xff, network & 0xff];
   return `${networkOctets.join(".")}/${mask}`;
+};
+
+/**
+ * Validates a subnet-filter line. Superset of {@link validateCidrLine}: also
+ * accepts an IPv4 range in the same syntax the onboarding discovery flow uses —
+ * short (`10.0.0.10-20`) or full (`10.0.0.10-10.0.0.20`), optional spaces around
+ * the dash. Hostnames are intentionally not accepted here (the fleet filter
+ * matches by IP, not name). Returns null when valid, else an error string.
+ */
+export const validateSubnetLine = (line: string): string | null => {
+  const trimmed = line.trim();
+  if (trimmed === "") return "Empty value";
+  if (looksLikeIpRange(trimmed)) {
+    return parseIpRange(trimmed) ? null : "Not a valid IP range (e.g. 10.0.0.10-10.0.0.20)";
+  }
+  const cidrError = validateCidrLine(trimmed);
+  if (cidrError === null) return null;
+  // Hostnames are valid discovery targets but can't be filtered on (the fleet
+  // list matches by IP, not name). Give a targeted hint instead of the generic
+  // CIDR error. Gate on an alphabetic char so an all-numeric malformed IP like
+  // "999.1.1.1" — which isValidHostname would also accept — still gets the CIDR
+  // error, not the hostname hint.
+  if (/[a-z]/i.test(trimmed) && isValidHostname(trimmed)) {
+    return "Hostnames aren't supported here — use an IP, CIDR, or range";
+  }
+  return cidrError;
+};
+
+/**
+ * Normalizes a subnet-filter line for display/dedup. Ranges canonicalize to
+ * their full `start-end` form (so short and full inputs dedup together);
+ * CIDRs/IPs defer to {@link normalizeCidrLine}. Assumes the line already passed
+ * {@link validateSubnetLine}.
+ */
+export const normalizeSubnetLine = (line: string): string => {
+  const trimmed = line.trim();
+  if (looksLikeIpRange(trimmed)) {
+    const range = parseIpRange(trimmed);
+    if (range) return `${range.startIp}-${range.endIp}`;
+  }
+  return normalizeCidrLine(trimmed);
+};
+
+/**
+ * Expands one subnet-filter line into the CIDR entries the server understands.
+ * A range decomposes to the minimal covering CIDR set; a CIDR/IP yields itself
+ * (normalized). The fleet filter (`ip_cidrs`) has no range field, so this is
+ * where ranges become server-expressible.
+ */
+export const expandSubnetLineToCidrs = (line: string): string[] => {
+  const trimmed = line.trim();
+  if (looksLikeIpRange(trimmed)) {
+    const range = parseIpRange(trimmed);
+    if (range) return ipv4RangeToCidrs(range.startIp, range.endIp);
+    return [];
+  }
+  const normalized = normalizeCidrLine(trimmed);
+  return normalized ? [normalized] : [];
 };

--- a/client/src/shared/utils/filterValidation.ts
+++ b/client/src/shared/utils/filterValidation.ts
@@ -145,17 +145,20 @@ export const validateSubnetLine = (line: string): string | null => {
   if (looksLikeIpRange(trimmed)) {
     return parseIpRange(trimmed) ? null : "Not a valid IP range (e.g. 10.0.0.10-10.0.0.20)";
   }
-  const cidrError = validateCidrLine(trimmed);
-  if (cidrError === null) return null;
+  if (trimmed.includes("/")) {
+    return isValidCidr(trimmed) || isValidIpv6Cidr(trimmed)
+      ? null
+      : "Not a valid CIDR (e.g. 255.255.255.0/24 or 2001:db8::/64)";
+  }
+  if (isValidIpv4(trimmed) || isValidIpv6(trimmed)) return null;
   // Hostnames are valid discovery targets but can't be filtered on (the fleet
-  // list matches by IP, not name). Give a targeted hint instead of the generic
-  // CIDR error. Gate on an alphabetic char so an all-numeric malformed IP like
-  // "999.1.1.1" — which isValidHostname would also accept — still gets the CIDR
-  // error, not the hostname hint.
+  // list matches by IP, not name). Give a targeted hint. Gate on an alphabetic
+  // char so an all-numeric malformed IP like "999.1.1.1" — which isValidHostname
+  // would also accept — still gets the generic error.
   if (/[a-z]/i.test(trimmed) && isValidHostname(trimmed)) {
     return "Hostnames aren't supported here — use an IP, CIDR, or range";
   }
-  return cidrError;
+  return "Not a valid IP address, range, or CIDR";
 };
 
 /**

--- a/client/src/shared/utils/networkDiscovery.test.ts
+++ b/client/src/shared/utils/networkDiscovery.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "vitest";
-import { isValidCidr, isValidIpv6, parseManualTargets } from "@/shared/utils/networkDiscovery";
+import {
+  intToIpv4,
+  ipv4RangeToCidrs,
+  isValidCidr,
+  isValidIpv6,
+  looksLikeIpRange,
+  parseManualTargets,
+} from "@/shared/utils/networkDiscovery";
 
 describe("parseManualTargets", () => {
   test("parses IPs, hostnames, CIDR subnets, and ranges", () => {
@@ -120,6 +127,70 @@ describe("isValidIpv6", () => {
     expect(isValidIpv6("fe80::1")).toBe(false); // link-local requires scope
     expect(isValidIpv6("febf::1234")).toBe(false); // full fe80::/10 range
     expect(isValidIpv6("fe80::1%eth0")).toBe(false); // scoped address
+  });
+});
+
+describe("looksLikeIpRange", () => {
+  test("matches short and full range syntax (with optional spaces)", () => {
+    expect(looksLikeIpRange("10.0.0.10-20")).toBe(true);
+    expect(looksLikeIpRange("10.0.0.10-10.0.0.20")).toBe(true);
+    expect(looksLikeIpRange("10.0.0.10 - 10.0.0.20")).toBe(true);
+  });
+
+  test("does not match CIDRs or bare IPs", () => {
+    expect(looksLikeIpRange("10.0.0.0/24")).toBe(false);
+    expect(looksLikeIpRange("10.0.0.10")).toBe(false);
+  });
+});
+
+describe("ipv4RangeToCidrs", () => {
+  test("aligned power-of-two range collapses to a single CIDR", () => {
+    expect(ipv4RangeToCidrs("192.168.1.0", "192.168.1.255")).toEqual(["192.168.1.0/24"]);
+    expect(ipv4RangeToCidrs("10.0.0.8", "10.0.0.15")).toEqual(["10.0.0.8/29"]);
+  });
+
+  test("arbitrary range decomposes into the minimal covering set", () => {
+    // The 8–12 miners case: 10.0.0.10 through 10.0.0.21 inclusive.
+    expect(ipv4RangeToCidrs("10.0.0.10", "10.0.0.21")).toEqual([
+      "10.0.0.10/31",
+      "10.0.0.12/30",
+      "10.0.0.16/30",
+      "10.0.0.20/31",
+    ]);
+  });
+
+  test("single address yields a /32", () => {
+    expect(ipv4RangeToCidrs("10.0.0.5", "10.0.0.5")).toEqual(["10.0.0.5/32"]);
+  });
+
+  test("covers the full IPv4 space without overflowing", () => {
+    expect(ipv4RangeToCidrs("0.0.0.0", "255.255.255.255")).toEqual(["0.0.0.0/0"]);
+  });
+
+  test("inverted range yields nothing", () => {
+    expect(ipv4RangeToCidrs("10.0.0.20", "10.0.0.10")).toEqual([]);
+  });
+
+  test("every address in the range is covered by exactly one emitted CIDR", () => {
+    const cidrs = ipv4RangeToCidrs("10.0.0.10", "10.0.0.21");
+    const contains = (cidr: string, ip: number) => {
+      const [net, bits] = cidr.split("/");
+      const netInt = net.split(".").reduce((a, p) => ((a << 8) + Number(p)) >>> 0, 0);
+      const mask = Number(bits) === 0 ? 0 : (0xffffffff << (32 - Number(bits))) >>> 0;
+      return (ip & mask) >>> 0 === netInt;
+    };
+    for (let octet = 10; octet <= 21; octet++) {
+      const ip = (10 << 24) + octet;
+      expect(cidrs.filter((c) => contains(c, ip >>> 0)).length).toBe(1);
+    }
+  });
+});
+
+describe("intToIpv4", () => {
+  test("round-trips with the documented octet packing", () => {
+    expect(intToIpv4(0)).toBe("0.0.0.0");
+    expect(intToIpv4(0xffffffff)).toBe("255.255.255.255");
+    expect(intToIpv4((192 << 24) | (168 << 16) | (1 << 8) | 42)).toBe("192.168.1.42");
   });
 });
 

--- a/client/src/shared/utils/networkDiscovery.ts
+++ b/client/src/shared/utils/networkDiscovery.ts
@@ -57,10 +57,51 @@ export const ipv4ToInt = (value: string) =>
     .map((part) => Number(part))
     .reduce((acc, part) => ((acc << 8) + part) >>> 0, 0);
 
+// Unpack a 32-bit unsigned integer back to a dotted IPv4 string.
+export const intToIpv4 = (value: number): string =>
+  [(value >>> 24) & 255, (value >>> 16) & 255, (value >>> 8) & 255, value & 255].join(".");
+
+const trailingZeroBits = (value: number): number => {
+  let count = 0;
+  let n = value >>> 0;
+  while ((n & 1) === 0 && count < 32) {
+    count++;
+    n >>>= 1;
+  }
+  return count;
+};
+
+// Decompose an inclusive IPv4 range into the minimal set of CIDR blocks that
+// exactly covers it. Lets a range be expressed as `ip_cidrs` filter entries,
+// since the fleet filter matches by CIDR containment and has no range field.
+export const ipv4RangeToCidrs = (startIp: string, endIp: string): string[] => {
+  let start = ipv4ToInt(startIp);
+  const end = ipv4ToInt(endIp);
+  if (end < start) return [];
+
+  const cidrs: string[] = [];
+  while (start <= end) {
+    // Largest aligned block anchored at `start`: bounded by its alignment (the
+    // number of trailing zero bits) and by how many addresses remain.
+    const maxByAlignment = start === 0 ? 32 : Math.min(32, trailingZeroBits(start));
+    const maxByCount = Math.floor(Math.log2(end - start + 1));
+    const hostBits = Math.min(maxByAlignment, maxByCount);
+    cidrs.push(`${intToIpv4(start)}/${32 - hostBits}`);
+    start += 2 ** hostBits;
+  }
+  return cidrs;
+};
+
 const SHORT_RANGE_REGEX = /^(\d{1,3}(?:\.\d{1,3}){3})\s*-\s*(\d{1,3})$/;
 const FULL_RANGE_REGEX = /^(\d{1,3}(?:\.\d{1,3}){3})\s*-\s*(\d{1,3}(?:\.\d{1,3}){3})$/;
 const CIDR_REGEX = /^(\d{1,3}(?:\.\d{1,3}){3})\/(\d{1,2})$/;
 const IPV4_LIKE_REGEX = /^\d{1,3}(?:\.\d{1,3}){3}\.?$/;
+
+// True when a token uses the discovery IP-range syntax (short `.10-21` or full
+// `.10-.20`), regardless of whether the endpoints are valid. Callers use this
+// to route a token to parseIpRange before other IP/CIDR checks.
+export const looksLikeIpRange = (value: string): boolean =>
+  SHORT_RANGE_REGEX.test(value) || FULL_RANGE_REGEX.test(value);
 
 export const parseIpRange = (value: string) => {
   const shortRangeMatch = value.match(SHORT_RANGE_REGEX);
@@ -102,8 +143,7 @@ export const parseManualTargets = (input: string) => {
   const categorizedInvalidEntries: CategorizedInvalidEntries = { ipAddresses: [], ipRanges: [], subnets: [] };
 
   entries.forEach((entry) => {
-    const looksLikeIpRange = SHORT_RANGE_REGEX.test(entry) || FULL_RANGE_REGEX.test(entry);
-    if (looksLikeIpRange) {
+    if (looksLikeIpRange(entry)) {
       const range = parseIpRange(entry);
       if (range) {
         targets.ipRanges.push(range);


### PR DESCRIPTION
Reviewable diff: +840/-181 across 13 files (excludes generated, test, and story files).

## Summary

Reworks the rack **miner-selection modals** (Manage / Search / Scan-QR, and the rack-overview quick-assign) so operators can actually find the miners they want when most of the fleet is already placed. The list gains fleet-style filters and sortable placement columns, and a miner already assigned elsewhere can now be pulled in directly — moved with a clear confirmation instead of being blocked.

## What operators get

- **Toggle for ineligible miners.** A "Show assigned miners" switch (default **off**) hides miners already assigned to another rack/building/site, so the list is just the ones you can add. Flip it **on** to reveal the rest — rendered in orange and still selectable. Assigning one prompts a confirmation that it will be unassigned from its current placement; an info button on the toggle explains the behavior.
- **Filters.** A nested "Add filter" popover matching the fleet miner list — **Model · Site · Building · Rack · Group · Subnet**. Subnet accepts explicit IPs, CIDRs, and IP ranges (same syntax as onboarding discovery).
- **New columns.** **Site, Building, Rack, and Group**, ordered Name · Model · IP · Site · Building · Rack · Group.
- **Sorting.** Sortable column headers (Name / Model / IP today).

## How it's supported under the hood

- **Placement identity.** Each miner snapshot carries `PlacementRefs` (site/building/rack as id + label); the list reads those ids into its row model. Columns render straight from the snapshot, and eligibility is compared by **id** (not label) so two racks sharing a name in different buildings can't be confused.
- **Eligibility is a server filter, not row-hiding.** The "assignable only" set is one `MinerListFilter` with null-permissive rack/building/site constraints, so paging, counts, and "select all" stay correct. The toggle flips whether those constraints are applied (default) or dropped (show everything).
- **Reparent confirmation.** On confirm, the host determines which picked miners are placed elsewhere and, if any, shows a shared `ReparentWarningDialog` before assigning. Detection uses per-row placement tracked across pages (bulk), the resolved snapshot (scan), or the selected row (search) — never a partial first-page cache — so it can't be missed for large fleets. The scan flow no longer blocks a cross-rack miner; it routes through the same confirmation.
- **Permission-aware facets.** The Site/Building facet options come from `ListSites`/`ListBuildings` (guarded by `site:read`), so those facets are hidden for rack-management roles without that permission. Columns still render (label data rides on the snapshot).
- **Subnet ranges.** Parsed with the onboarding discovery parser and expanded to CIDRs client-side (the fleet filter has no native range field); validated on blur.

```mermaid
flowchart TD
  Op["Operator"] --> Modal["Miner selection modal (Manage / Search / Scan)"]
  Modal --> List["MinerSelectionList"]
  List --> Toggle["Show assigned miners toggle"]
  List --> Facets["Add-filter popover + sortable columns"]
  Toggle --> Filter["Derived MinerListFilter"]
  Facets --> Filter
  Filter --> Fleet["useFleet (server-paginated)"]
  Fleet --> Rows["Rows (assigned-elsewhere flagged orange)"]
  Rows --> Confirm["Confirm / Assign"]
  Confirm --> Guard{"Any pick assigned elsewhere?"}
  Guard -->|"no"| Assign["Assign to rack + slot"]
  Guard -->|"yes"| Warn["ReparentWarningDialog"]
  Warn -->|"Reassign"| Assign
```

## Areas of the code involved

| Area / file | What changed |
| --- | --- |
| `protoFleet/components/MinerSelectionList.tsx` | Core list: placement columns, nested filters, derived server-side eligibility filter, "Show assigned miners" toggle + info dialog, orange styling, `site:read` facet gating, exact `reassignedItems` from `getSelection()` |
| `.../utils/minerPlacement.ts` | Placement-id getters + `isPlacementIneligible` / `isMinerSnapshotIneligible` predicate |
| `.../ManageRackModal/ManageRackModal.tsx` | Rack eligibility + reparent guard across Manage / Search / Scan confirm paths |
| `.../ManageRackModal/ReparentWarningDialog.tsx` (new) | Shared reparent confirmation |
| `.../ManageRackModal/ScanMinerQrModal{,View}.tsx` | Cross-rack scans reassign (via confirm) instead of being blocked |
| `.../ManageRackModal/{Search,Manage}MinersModal.tsx`, `pages/RackOverviewPage.tsx` | Pass eligibility, thread reassignment flags, quick-assign guard |
| `shared/utils/{filterValidation,networkDiscovery}.ts` | Subnet validation + range→CIDR expansion |
| `shared/components/List/Filters/{TextareaListModal,types}.ts(x)` | Validate-on-blur; standalone/nested filter typing |

## Key technical decisions

- **Server-side eligibility filter** over client row-hiding — keeps pagination/counts/"select all" honest.
- **Id-based placement** over label comparison — avoids same-name collisions across buildings.
- **Reparent via explicit confirm** over hard-blocking — enables intended moves while closing the silent cross-site path (#672).
- **Ranges decomposed to CIDRs client-side** over a proto range field — no backend change, behaviorally identical (native `ip_ranges` deferred to #682).

## Testing

Unit tests cover the toggle/eligibility filtering, reparent detection across all add paths (list, search, scan, bulk incl. off-page), the `site:read` facet gate, subnet validation + range expansion, and columns/sort wiring. CI green (lint, type-check, tests, generated-code check).

## Not in scope / follow-ups

- Sorting the Site / Building / Rack columns (needs server sort support) — **#687**.
- Fleet miner-list page range parity + native `ip_ranges` — **#682**.
- Assignable-only precision for rackless miners in another building — **#702**.
- Hostnames aren't filterable (the list matches by IP, not name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
