### PR TITLE
fix(fleet): keep bulk placement scoped to visible miners

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import MinerReparentPicker from "./MinerReparentPicker";
 import { PerDeviceBuildingConflictReason } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
 // Building-reparent flow only. The two-step force-clear confirm is the
 // part with branching logic: the server enumerates per-device conflicts,
@@ -13,15 +14,19 @@ import { PerDeviceBuildingConflictReason } from "@/protoFleet/api/generated/buil
 // open the dialog or retry.
 
 const {
+  mockAssignDevicesToSite,
   mockAssignDevicesToBuilding,
   mockAssignDevicesToRack,
   mockGetDeviceSet,
+  mockListRacks,
   mockListMinerStateSnapshots,
   mockPushToast,
 } = vi.hoisted(() => ({
+  mockAssignDevicesToSite: vi.fn(),
   mockAssignDevicesToBuilding: vi.fn(),
   mockAssignDevicesToRack: vi.fn(),
   mockGetDeviceSet: vi.fn(),
+  mockListRacks: vi.fn(),
   mockListMinerStateSnapshots: vi.fn(),
   mockPushToast: vi.fn(() => 1),
 }));
@@ -30,13 +35,13 @@ vi.mock("@/protoFleet/api/buildings", () => ({
   useBuildings: () => ({ assignDevicesToBuilding: mockAssignDevicesToBuilding }),
 }));
 vi.mock("@/protoFleet/api/sites", () => ({
-  useSites: () => ({ assignDevicesToSite: vi.fn() }),
+  useSites: () => ({ assignDevicesToSite: mockAssignDevicesToSite }),
 }));
 vi.mock("@/protoFleet/api/useDeviceSets", () => ({
   useDeviceSets: () => ({
     assignDevicesToRack: mockAssignDevicesToRack,
     getDeviceSet: mockGetDeviceSet,
-    listRacks: vi.fn(),
+    listRacks: mockListRacks,
   }),
 }));
 vi.mock("@/protoFleet/api/clients", () => ({
@@ -88,6 +93,58 @@ const renderPicker = () =>
   );
 
 const DIALOG_TITLE = "Move miners between buildings?";
+
+const renderAllSitePicker = () =>
+  render(
+    <MinerReparentPicker
+      kind="site"
+      deviceIdentifiers={[]}
+      selectionMode="all"
+      totalCount={2}
+      sourceLabel="All miners"
+      successMessage={(count) => `Moved ${count} miner(s).`}
+      onClose={vi.fn()}
+    />,
+  );
+
+describe("MinerReparentPicker — all-mode placement selection", () => {
+  beforeEach(() => {
+    mockAssignDevicesToSite.mockReset();
+    mockListRacks.mockReset();
+    mockListMinerStateSnapshots.mockReset();
+    mockPushToast.mockReset();
+    mockPushToast.mockReturnValue(1);
+  });
+
+  it("resolves all selected miners with the same visible pairing-status scope as the miner table", async () => {
+    mockListRacks.mockImplementation(({ onSuccess }) => onSuccess([]));
+    mockListMinerStateSnapshots
+      .mockResolvedValueOnce({
+        miners: [{ deviceIdentifier: "d1", pairingStatus: PairingStatus.PAIRED }],
+        cursor: "next",
+      })
+      .mockResolvedValueOnce({
+        miners: [{ deviceIdentifier: "d2", pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }],
+        cursor: "",
+      });
+    mockAssignDevicesToSite.mockImplementationOnce(({ onSuccess }) => {
+      onSuccess(2n);
+    });
+
+    renderAllSitePicker();
+    fireEvent.click(screen.getByText("pick-target"));
+
+    await waitFor(() => expect(mockAssignDevicesToSite).toHaveBeenCalledTimes(1));
+
+    expect(mockListMinerStateSnapshots.mock.calls[0][0].filter.pairingStatuses).toEqual([
+      PairingStatus.PAIRED,
+      PairingStatus.AUTHENTICATION_NEEDED,
+      PairingStatus.DEFAULT_PASSWORD,
+    ]);
+    expect(mockListMinerStateSnapshots.mock.calls[1][0].cursor).toBe("next");
+    expect(mockAssignDevicesToSite.mock.calls[0][0].deviceIdentifiers).toEqual(["d1", "d2"]);
+  });
+});
 
 describe("MinerReparentPicker — building force-clear flow", () => {
   beforeEach(() => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx
@@ -14,6 +14,7 @@ import { useSites } from "@/protoFleet/api/sites";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
 import { useFleetCreateFlow } from "@/protoFleet/features/fleetManagement/components/FleetCreateFlow/context";
+import { applyFleetVisiblePairingStatuses } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 import {
   getMinerBuildingLabel,
   getMinerRackLabel,
@@ -620,7 +621,7 @@ const MinerReparentPicker = ({
     snapshots: Record<string, MinerStateSnapshot> | undefined;
   } | null> => {
     if (selectionMode === "all") {
-      const effectiveFilter = currentFilter ?? create(MinerListFilterSchema);
+      const effectiveFilter = applyFleetVisiblePairingStatuses(currentFilter);
       const loadingToast = pushToast({
         message: "Loading selected miners…",
         status: STATUSES.loading,
@@ -748,8 +749,9 @@ const MinerReparentPicker = ({
           let ids: string[];
           let snapshots: Record<string, MinerStateSnapshot> | undefined;
           if (selectionMode === "all") {
-            // Undefined filter = no URL filter params = full fleet.
-            const effectiveFilter = currentFilter ?? create(MinerListFilterSchema);
+            // Mirror the miner table's default pairing-status scope so
+            // "select all" stays aligned with the visible fleet rows.
+            const effectiveFilter = applyFleetVisiblePairingStatuses(currentFilter);
             const loadingToast = pushToast({
               message: "Loading selected miners…",
               status: STATUSES.loading,


### PR DESCRIPTION
Reviewable diff: +5/-3 across 1 file (excludes generated, test, and story files).

## Summary
Bulk placement now keeps “select all” aligned with the miners the operator can see, so hidden unpaired discoveries no longer cause site/building/rack placement to reject after a parent is created. This fixes the empty-site failure mode where creating a site from all visible paired miners sent discovered-only identifiers into the follow-up assignment RPC.

## How it works
The miner table already loads rows through `FLEET_VISIBLE_PAIRING_STATUSES`. The all-mode placement resolver now applies the same pairing-status scope before paginating `ListMinerStateSnapshots`, so the IDs handed to site/building/rack assignment match the visible fleet rows. Server-side all-or-nothing conflict handling remains unchanged; the client simply stops expanding the selected set to hidden unpaired discoveries.

## Diagrams
```mermaid
flowchart LR
    A["Operator selects all visible miners"] --> B["MinerReparentPicker resolves selected IDs"]
    B --> C["Apply fleet-visible pairing-status scope"]
    C --> D["ListMinerStateSnapshots pages"]
    D --> E["AssignDevicesToSite / Building / Rack"]
    E --> F["Placement succeeds without hidden unpaired IDs"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.tsx` | All-mode placement resolution applies the fleet-visible pairing-status filter. | This is the behavior change that prevents hidden unpaired rows from entering placement RPCs. |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.test.tsx` | Adds a regression test for all-mode site placement resolution. | Verifies the resolver sends the same visible pairing-status scope as the miner table and assigns only resolved IDs. |

## Key technical decisions & trade-offs
| Decision | Trade-off |
| --- | --- |
| Reuse `applyFleetVisiblePairingStatuses` instead of introducing a placement-specific status list. | Keeps placement selection consistent with the miner table; if visible fleet statuses change, all-mode placement follows that contract. |
| Preserve server all-or-nothing conflict semantics instead of ignoring `DEVICE_NOT_FOUND`. | The server still rejects stale or invalid identifiers; the client avoids sending hidden discovered-only IDs in the first place. |

## Testing & validation
- `npm test -- --run src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerReparentPicker.test.tsx`
- `npm run lint`
- Live Pi recovery validation: assigning the 4,999 paired miners with the paired-only resolver shape returned `reassignedCount: 4999`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
