### PR TITLE
Fix uptime rollup test flake: dead 55P03 retry and missing policy disables

### DIFF
--- a/server/internal/infrastructure/timescaledb/telemetry_store_uptime_rollup_test.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store_uptime_rollup_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
 	"github.com/block/proto-fleet/server/internal/testutil"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,7 @@ func TestTelemetryStore_UptimeCountsUseCurrentMembershipDeviceRollups(t *testing
 
 	user := dbSvc.CreateSuperAdminUser()
 	orgID := user.OrganizationID
+	disableUptimeRollupPolicies(t, db)
 	siteA := createUptimeTestSite(t, db, orgID, "rollup-site-a")
 	siteB := createUptimeTestSite(t, db, orgID, "rollup-site-b")
 
@@ -66,6 +68,7 @@ func TestTelemetryStore_UptimeCountsUseHourlyAndDailyDeviceRollups(t *testing.T)
 
 	user := dbSvc.CreateSuperAdminUser()
 	orgID := user.OrganizationID
+	disableUptimeRollupPolicies(t, db)
 
 	tests := []struct {
 		name           string
@@ -224,6 +227,7 @@ func TestTelemetryStore_UptimeRollup1mMatchesRawBucketingForNinetySecondBuckets(
 
 	user := dbSvc.CreateSuperAdminUser()
 	orgID := user.OrganizationID
+	disableUptimeRollupPolicies(t, db)
 	deviceIdentifier := fmt.Sprintf("rollup-90s-device-%d", time.Now().UnixNano())
 	at := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Minute).Add(50 * time.Second)
 	start := at.Add(-time.Minute)
@@ -256,6 +260,7 @@ func TestTelemetryStore_UptimeRollup1mPicksLatestStateWhenBucketSpansMinutes(t *
 
 	user := dbSvc.CreateSuperAdminUser()
 	orgID := user.OrganizationID
+	disableUptimeRollupPolicies(t, db)
 	deviceIdentifier := fmt.Sprintf("rollup-latest-state-device-%d", time.Now().UnixNano())
 
 	// Two snapshots one minute apart inside a single 90s bucket: the bucket
@@ -537,8 +542,10 @@ func refreshUptimeDeviceRollup(t *testing.T, db *sql.DB, view string, start, end
 		if err == nil {
 			return
 		}
-		var pqErr *pq.Error
-		if !errors.As(err, &pqErr) || pqErr.Code != "55P03" || attempt == maxAttempts {
+		// The test DB connects via the pgx driver (db.ConnectToDatabase), so
+		// lock-contention errors surface as *pgconn.PgError, not *pq.Error.
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "55P03" || attempt == maxAttempts {
 			require.NoError(t, err)
 		}
 		time.Sleep(time.Duration(attempt) * 100 * time.Millisecond)


### PR DESCRIPTION
Reviewable diff: +0/-0 across 0 files (excludes generated, test, and story files) — this PR is test-only: +9/-2 in one test file.

## Summary

Fixes the flake that failed the post-merge Server Checks run on `main` after #689 (`TestTelemetryStore_UptimeRollup1mPicksLatestStateWhenBucketSpansMinutes`, `SQLSTATE 55P03` "concurrent refresh"). The retry logic that was supposed to absorb exactly this error has been dead code since it was written, and four tests in the file were missing the policy-disable guard their siblings have. Pre-existing latent flake — unrelated to the dependency bump; a rerun passed.

## How it works

Two compounding causes, both in `server/internal/infrastructure/timescaledb/telemetry_store_uptime_rollup_test.go`:

1. **Dead retry.** `refreshUptimeDeviceRollup` retries on TimescaleDB lock contention (SQLSTATE `55P03`) by matching the error with `errors.As(err, &pqErr)` against `*pq.Error`. But the test database connects through `db.ConnectToDatabase`, which uses the **pgx** driver, so the error is a `*pgconn.PgError` and the match never succeeds — the first concurrent-refresh error fails the test instead of retrying. (The `SQLSTATE 55P03` suffix in the CI failure message is pgx's error formatting, which is how this was diagnosed.) The fix matches `*pgconn.PgError`.
2. **Missing policy disables.** The file's `disableUptimeRollupPolicies` helper unschedules the continuous-aggregate background refresh jobs so they cannot race the tests' explicit `refresh_continuous_aggregate` calls. Four of the eight tests that refresh rollups never called it — including the one that flaked. The fix adds the call to those four; with the policies unscheduled, the 55P03 contention should not occur at all, making the (now working) retry a second line of defense.

```mermaid
flowchart LR
  A["scheduled policy job<br/>policy_refresh_continuous_aggregate"] -- "races" --> C["refresh_continuous_aggregate()<br/>in test"]
  C -- "55P03 lock error<br/>(pgx: *pgconn.PgError)" --> D["retry loop matched<br/>*pq.Error → never fired"]
  D --> E["test fails immediately"]
  F["fix 1: disable policy jobs<br/>in all rollup tests"] -.-> A
  G["fix 2: match *pgconn.PgError"] -.-> D
```

## Areas of the code involved

| Area | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/infrastructure/timescaledb/telemetry_store_uptime_rollup_test.go` | Retry helper matches `*pgconn.PgError`; `disableUptimeRollupPolicies` added to 4 tests | Test-only; no production code touched |

## Key technical decisions & trade-offs

- **Fix both causes, not just one**: disabling the policies removes the race; fixing the error match makes the retry meaningful if contention appears through another path (e.g. two refreshes in parallel packages). Either alone would likely have been enough; both together match the intent documented in the helper's own comment.
- **Kept the `lib/pq` import**: `deleteMinerStateSnapshotRows` still uses `pq.Array`, so only the error-matching switched to `pgconn`.

## Testing & validation

- Ran the full `Uptime` test set in the package twice (`-count=2`) against local TimescaleDB — all pass.
- `golangci-lint` clean on the package.
- The race itself is wall-clock dependent (a policy job must fire mid-test), so the original failure mode is not deterministically reproducible locally; validation is by inspection of the error type (`pgx` vs `lib/pq`) plus the passing suite.