### PR TITLE
feat(curtailment): target any reachable miner regardless of mining status

### DIFF
--- a/docs/plans/2026-07-07-663-curtailment-commandability-admission-plan.md
+++ b/docs/plans/2026-07-07-663-curtailment-commandability-admission-plan.md
@@ -1,0 +1,105 @@
+---
+title: "Curtailment: admit reachable pool-less miners (commandability admission)"
+date: 2026-07-07
+status: implementing
+type: plan
+tracker: https://github.com/block/proto-fleet/issues/663
+---
+
+# Curtailment: Admit Reachable Pool-less Miners
+
+## Problem
+
+Both curtailment admission classifiers exclude `NEEDS_MINING_POOL` miners even
+though they are reachable, authenticated, have a driver, and draw idle power —
+a sleep command would land. On a 14-miner all-paired full-shutdown dev-fleet
+event, 10 miners were held `unavailable`, several of them reachable pool-less
+proto miners whose idle draw persisted through the curtailment.
+
+Curtailment's job is to stop power draw; whether the miner is productively
+mining is irrelevant. Admission should converge on **commandability** (can we
+deliver a sleep command?), not mining status.
+
+## Scope
+
+- `NEEDS_MINING_POOL` becomes targetable in both classifiers:
+  - Normal selection (`classifyCandidates`): admitted, still behind the
+    existing telemetry-freshness gates. Fixed-kW's dual-signal filter still
+    excludes zero-hash miners, so kW-sized selection stays sound; the
+    practical admission change lands in full-fleet selection, plus more
+    accurate skip reasons in fixed-kW.
+  - All-paired policy (`AllPairedPolicyTargetState`): initial state `pending`,
+    dispatched normally instead of parked `unavailable`.
+- `INACTIVE` stays excluded **by design**: codebase-wide it means "sleeping"
+  (CSV export, dashboard sleeping counts). Admitting it would produce no-op
+  curtails and let restore wake miners an operator deliberately put to sleep.
+- `ERROR`/`UNKNOWN` stay parked in the all-paired path (that path has no
+  telemetry gates); documented in code comments.
+- Genuinely unreachable states unchanged: `OFFLINE`, `UPDATING`,
+  `REBOOT_REQUIRED`, missing status, missing driver, `AUTHENTICATION_NEEDED`.
+- Baseline persistence fixed for never-hashing miners (see below).
+- Server-only. No UI change: the skip-reason vocabulary is unchanged and the
+  live rollup already surfaces pending/confirmed transitions.
+
+## Key finding: baseline/restore gap for never-hashing miners
+
+`shouldPersistBaselinePowerW` rejects FullFleet baselines below
+`candidate_min_power_w` (default 1500 W). Pool-less idle draw is typically
+below that, so no baseline would be persisted and confirmation degrades to the
+hash-only fallback — which is provably broken for a never-hashing miner:
+
+- `isCurtailed` hash-only fallback confirms instantly (hash is already 0) —
+  a false positive before the sleep command takes effect.
+- `isRestored` hash-only fallback requires hash > 0, which never happens —
+  restore ages out to `restore_failed`.
+
+Fix: bypass the FullFleet baseline floor when the candidate is **not
+currently hashing** (hash missing or <= 0). The floor exists to keep garbage
+low-power readings from becoming baselines for hashing miners, where the
+hash-only fallback works; for non-hashing miners the fallback cannot work, so
+a real power baseline is strictly better. This also fixes the same latent bug
+for ERROR/UNKNOWN phantom loads admitted into full-fleet selection today.
+
+## Implementation units
+
+### U1. Admit NEEDS_MINING_POOL in normal selection
+
+`server/internal/domain/curtailment/service.go`: move `NEEDS_MINING_POOL` out
+of the skip arm into a fall-through arm (commandability admission); keep
+`INACTIVE` on `SkipNonActionableStatus` with an exclusion-by-design comment.
+Update `TestDeviceStatusClassifierMatrix` and
+`TestService_Preview_FiltersByPairingDeviceStatusAndStaleness`; add coverage
+for fresh-telemetry admission, stale-telemetry skip, and the dual-signal
+interaction in fixed-kW vs full-fleet modes.
+
+### U2. All-paired policy dispatches pool-less miners
+
+`server/internal/domain/curtailment/selector.go`: remove `NEEDS_MINING_POOL`
+from the unavailable arm of `AllPairedPolicyTargetState` so it falls through
+to `TargetStatePending`. Update both classifiers' sync comments. Update
+`BuildAllPairedPolicyPlan` tests (pool-less pending, idle power counted in the
+estimate) and add reconciler tests: pool-less target dispatches and confirms;
+a parked `unavailable` pool-less target on an in-flight event is promoted and
+dispatched on the next tick (existing events self-heal after deploy — no
+migration needed).
+
+### U3. Baseline persistence at idle draw
+
+Thread a hashing signal into baseline persistence:
+`SelectedDevice.HashRateHS`, `shouldPersistBaselinePowerW(..., hashing)`,
+`BuildInsertTargetParams`, `AllPairedPromotionBaselinePowerW`. Non-hashing
+candidates persist any positive finite power baseline. Tests: idle-baseline
+curtail confirm requires power to actually drop; restore confirms when power
+returns; hashing miners below the floor keep today's behavior.
+
+### U4. Docs and verification
+
+This plan doc; `just lint`; full curtailment package + reconciler test suites.
+
+## Risks
+
+- Low-baseline flap: if a miner's sleep draw exceeds half its idle draw,
+  drift/confirm could oscillate. Mitigated by the configurable
+  `DriftThresholdFactor` and the drift path's preserve-on-missing semantics.
+- The classifier matrix test intentionally breaks unless both switches move
+  together; U1/U2 land as one logical change.

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -1152,6 +1152,60 @@ func TestReconciler_AllPairedPolicyParkedPoolLessTargetPromotedAndDispatched(t *
 	assert.InDelta(t, 2000.0, *final.BaselinePowerW, 0.001)
 }
 
+// A never-hashing miner's idle draw is usually below candidate_min_power_w,
+// but its baseline must still be persisted: the hash-only fallback the floor
+// relies on cannot confirm curtail (hash is already 0 → instant false
+// positive) or restore (hash never rises → ages out to restore_failed) for a
+// miner that never hashes. The floor applies only to hashing miners.
+func TestReconciler_AllPairedPolicyPoolLessPromotionPersistsBelowFloorBaseline(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	nonActionableReason := "non_actionable_status"
+	store.events = []*models.Event{
+		{
+			ID:                          eventID,
+			EventUUID:                   eventUUID,
+			OrgID:                       1,
+			State:                       models.EventStateActive,
+			Mode:                        models.ModeFullFleet,
+			LoopType:                    models.LoopTypeClosed,
+			ScopeType:                   models.ScopeTypeWholeOrg,
+			ForceIncludeAllPairedMiners: true,
+			// Real events stamp the floor into the decision snapshot; the
+			// readiness-refresh path reads it back from here.
+			DecisionSnapshotJSON: []byte(`{"candidate_min_power_w":1500}`),
+			CreatedByUserID:      99,
+		},
+	}
+	store.targetsByEventID[eventID] = []*models.Target{
+		{
+			CurtailmentEventID: eventID,
+			DeviceIdentifier:   "pool-less",
+			State:              models.TargetStateUnavailable,
+			DesiredState:       models.DesiredStateCurtailed,
+			LastError:          &nonActionableReason,
+		},
+	}
+	driver := "antminer"
+	// 400 W idle draw: below the 1500 W candidate_min_power_w floor.
+	store.candidates = []*models.Candidate{
+		{DeviceIdentifier: "pool-less", DriverName: &driver, DeviceStatus: "NEEDS_MINING_POOL", PairingStatus: "PAIRED", LatestPowerW: ptrFloat64(400), LatestHashRateHS: ptrFloat64(0)},
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	require.Equal(t, 1, disp.curtailCalls)
+	final := store.targetsByEventID[eventID][0]
+	assert.Equal(t, models.TargetStateDispatched, final.State)
+	require.NotNil(t, final.BaselinePowerW,
+		"non-hashing miners must persist any positive baseline; the min-power floor only makes sense where the hash-only fallback works")
+	assert.InDelta(t, 400.0, *final.BaselinePowerW, 0.001)
+}
+
 // A readiness flip the bulk UPDATE skips (row advanced concurrently, so it is
 // absent from RETURNING) must not be mirrored in memory: an optimistic mirror
 // would feed the same-tick dispatch pass and re-issue a duplicate Curtail

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -1122,6 +1122,7 @@ func TestReconciler_AllPairedPolicyParkedPoolLessTargetPromotedAndDispatched(t *
 			LoopType:                    models.LoopTypeClosed,
 			ScopeType:                   models.ScopeTypeWholeOrg,
 			ForceIncludeAllPairedMiners: true,
+			DecisionSnapshotJSON:        []byte(`{"candidate_min_power_w":1500}`),
 			CreatedByUserID:             99,
 		},
 	}
@@ -3886,6 +3887,19 @@ func TestReconciler_ConfigDefaultsDispatchTimeouts(t *testing.T) {
 // --- isCurtailed unit tests ---
 // requirePositiveEvidence=false (drift): missing samples preserve
 // curtailed; =true (confirm): missing samples return false.
+
+// A pool-less miner's persisted idle baseline (#663) makes power-vs-baseline
+// the confirm signal; hash is 0 through the whole lifecycle so the hash-only
+// fallback would confirm vacuously.
+func TestIsCurtailed_ConfirmPath_IdleBaselinePoolLessMiner(t *testing.T) {
+	t.Parallel()
+	baseline := 400.0
+	// Sleep draw well under half the idle draw: confirmed.
+	assert.True(t, isCurtailed(ptrFloat64(30), &baseline, ptrFloat64(0), 0.5, true))
+	// Draw still above half the idle baseline: not confirmed — the sleep
+	// command has not (yet) taken effect.
+	assert.False(t, isCurtailed(ptrFloat64(210), &baseline, ptrFloat64(0), 0.5, true))
+}
 
 func TestIsCurtailed_DriftPath_BaselineRelativeThreshold(t *testing.T) {
 	baseline := 3000.0

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -1101,6 +1101,57 @@ func TestReconciler_AllPairedPolicyUnavailableTargetBecomesPendingAndDispatches(
 	assert.InDelta(t, 3000.0, *final.BaselinePowerW, 0.001)
 }
 
+// A pool-less miner parked unavailable by the pre-#663 classifier (or by a
+// transient non-actionable status) is promoted, baseline-backfilled, and
+// dispatched once the classifier sees NEEDS_MINING_POOL as commandable —
+// existing all-paired events self-heal without migration.
+func TestReconciler_AllPairedPolicyParkedPoolLessTargetPromotedAndDispatched(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	eventUUID := uuid.New()
+	nonActionableReason := "non_actionable_status"
+	store.events = []*models.Event{
+		{
+			ID:                          eventID,
+			EventUUID:                   eventUUID,
+			OrgID:                       1,
+			State:                       models.EventStateActive,
+			Mode:                        models.ModeFullFleet,
+			LoopType:                    models.LoopTypeClosed,
+			ScopeType:                   models.ScopeTypeWholeOrg,
+			ForceIncludeAllPairedMiners: true,
+			CreatedByUserID:             99,
+		},
+	}
+	store.targetsByEventID[eventID] = []*models.Target{
+		{
+			CurtailmentEventID: eventID,
+			DeviceIdentifier:   "pool-less",
+			State:              models.TargetStateUnavailable,
+			DesiredState:       models.DesiredStateCurtailed,
+			LastError:          &nonActionableReason,
+		},
+	}
+	driver := "antminer"
+	store.candidates = []*models.Candidate{
+		{DeviceIdentifier: "pool-less", DriverName: &driver, DeviceStatus: "NEEDS_MINING_POOL", PairingStatus: "PAIRED", LatestPowerW: ptrFloat64(2000), LatestHashRateHS: ptrFloat64(0)},
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	require.Equal(t, 1, disp.curtailCalls)
+	assert.ElementsMatch(t, []string{"pool-less"}, disp.curtailLastIDs)
+	final := store.targetsByEventID[eventID][0]
+	assert.Equal(t, models.TargetStateDispatched, final.State)
+	assert.Nil(t, final.LastError)
+	require.NotNil(t, final.BaselinePowerW,
+		"promotion must backfill the idle-draw baseline; hash-only fallback cannot confirm curtail/restore for a never-hashing miner")
+	assert.InDelta(t, 2000.0, *final.BaselinePowerW, 0.001)
+}
+
 // A readiness flip the bulk UPDATE skips (row advanced concurrently, so it is
 // absent from RETURNING) must not be mirrored in memory: an optimistic mirror
 // would feed the same-tick dispatch pass and re-issue a duplicate Curtail

--- a/server/internal/domain/curtailment/reconciler/restore_test.go
+++ b/server/internal/domain/curtailment/reconciler/restore_test.go
@@ -1052,6 +1052,10 @@ func TestIsRestored(t *testing.T) {
 		{"no_telemetry_not_restored", nil, ptrFloat64(3000), nil, 0.5, false},
 		{"baseline_zero_falls_back_to_hash", ptrFloat64(2000), ptrFloat64(0), ptrFloat64(100), 0.5, true},
 		{"power_present_baseline_nil_hash_nil_not_restored", ptrFloat64(2000), nil, nil, 0.5, false},
+		// Pool-less miner at an idle-draw baseline (#663): power is the only
+		// usable signal because hash stays 0 through the whole lifecycle.
+		{"idle_baseline_wake_draw_restored", ptrFloat64(400), ptrFloat64(400), ptrFloat64(0), 0.5, true},
+		{"idle_baseline_sleep_draw_not_restored", ptrFloat64(30), ptrFloat64(400), ptrFloat64(0), 0.5, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/domain/curtailment/selector.go
+++ b/server/internal/domain/curtailment/selector.go
@@ -109,9 +109,13 @@ type Plan struct {
 type SelectedDevice struct {
 	DeviceIdentifier string
 	PowerW           float64
-	EfficiencyJH     float64
-	TargetState      models.TargetState
-	LastError        string
+	// HashRateHS is the latest hash sample at selection time. Baseline
+	// persistence reads it: the min-power floor only applies to hashing
+	// miners, where the hash-only confirm/restore fallback works.
+	HashRateHS   float64
+	EfficiencyJH float64
+	TargetState  models.TargetState
+	LastError    string
 }
 
 // BuildPlan runs the selection pipeline (mode-specific eligibility filter, rank
@@ -215,11 +219,19 @@ func BuildPlan(
 		res.InsufficientDetail.ExcludedDeadMonitor += dualSignalCounts.deadMonitor
 	}
 
+	// modes.Candidate doesn't carry hash; recover it for the selected set so
+	// baseline persistence can tell hashing miners from idle ones.
+	hashByDevice := make(map[string]float64, len(inputs))
+	for _, c := range inputs {
+		hashByDevice[c.DeviceIdentifier] = c.HashRateHS
+	}
+
 	selected := make([]SelectedDevice, len(res.Selected))
 	for i, c := range res.Selected {
 		selected[i] = SelectedDevice{
 			DeviceIdentifier: c.DeviceIdentifier,
 			PowerW:           c.PowerW,
+			HashRateHS:       hashByDevice[c.DeviceIdentifier],
 			EfficiencyJH:     c.EfficiencyJH,
 		}
 	}
@@ -293,9 +305,14 @@ func BuildAllPairedPolicyPlan(
 		if state == models.TargetStateUnavailable {
 			unavailableCount++
 		}
+		hashRateHS := 0.0
+		if hasNonNegativeFiniteFloat(c.LatestHashRateHS) {
+			hashRateHS = *c.LatestHashRateHS
+		}
 		selected = append(selected, SelectedDevice{
 			DeviceIdentifier: c.DeviceIdentifier,
 			PowerW:           powerW,
+			HashRateHS:       hashRateHS,
 			EfficiencyJH:     derefFloat(avgEff),
 			TargetState:      state,
 			LastError:        reason,
@@ -374,7 +391,8 @@ func AllPairedPromotionBaselinePowerW(c *models.Candidate, minPowerW int32) *flo
 		return nil
 	}
 	power := *c.LatestPowerW
-	if !shouldPersistBaselinePowerW(models.ModeFullFleet, power, minPowerW) {
+	hashing := hasNonNegativeFiniteFloat(c.LatestHashRateHS) && *c.LatestHashRateHS > 0
+	if !shouldPersistBaselinePowerW(models.ModeFullFleet, power, minPowerW, hashing) {
 		return nil
 	}
 	return &power

--- a/server/internal/domain/curtailment/selector.go
+++ b/server/internal/domain/curtailment/selector.go
@@ -316,8 +316,12 @@ func BuildAllPairedPolicyPlan(
 // policy target state. It deliberately diverges from classifyCandidates
 // (service.go) on ERROR/UNKNOWN: normal selection admits them when telemetry
 // is fresh, while this policy dispatches without telemetry gates and so holds
-// every non-commandable status unavailable until it clears. When adding a
-// device status, update both switches and the pinned matrix in
+// every non-commandable status unavailable until it clears.
+// NEEDS_MINING_POOL is pending in both (#663): the miner is reachable and
+// draws idle power, so a sleep command lands regardless of mining status.
+// INACTIVE stays parked: it means the miner is already sleeping, and
+// restoring it would wake a miner someone deliberately put to sleep. When
+// adding a device status, update both switches and the pinned matrix in
 // TestDeviceStatusClassifierMatrix.
 func AllPairedPolicyTargetState(c *models.Candidate, includeMaintenance bool) (models.TargetState, string) {
 	if c == nil {
@@ -338,7 +342,7 @@ func AllPairedPolicyTargetState(c *models.Candidate, includeMaintenance bool) (m
 		return models.TargetStateUnavailable, allPairedUnavailableUpdating
 	case "REBOOT_REQUIRED":
 		return models.TargetStateUnavailable, allPairedUnavailableRebootRequired
-	case "INACTIVE", "NEEDS_MINING_POOL", "ERROR", "UNKNOWN":
+	case "INACTIVE", "ERROR", "UNKNOWN":
 		return models.TargetStateUnavailable, allPairedUnavailableNonActionableStatus
 	case "MAINTENANCE":
 		if !includeMaintenance {

--- a/server/internal/domain/curtailment/selector.go
+++ b/server/internal/domain/curtailment/selector.go
@@ -271,6 +271,11 @@ const (
 	allPairedUnavailableStaleTelemetry = "stale_telemetry"
 )
 
+// deviceStatusNeedsMiningPool is the device_status_enum value for a reachable
+// miner with no pool configured. Referenced by both admission classifiers and
+// the status-authoritative hash override below.
+const deviceStatusNeedsMiningPool = "NEEDS_MINING_POOL"
+
 // statusAuthoritativeHashRateHS returns the hash sample to use for selection
 // accounting and baseline-persistence decisions. Device status is
 // authoritative over the raw sample for NEEDS_MINING_POOL: a pool-less miner
@@ -278,7 +283,7 @@ const (
 // let it count as curtailable mining load in fixed-kW selection, nor mark it
 // "hashing" for the baseline min-power floor.
 func statusAuthoritativeHashRateHS(c *models.Candidate) float64 {
-	if c.DeviceStatus == "NEEDS_MINING_POOL" {
+	if c.DeviceStatus == deviceStatusNeedsMiningPool {
 		return 0
 	}
 	if hasNonNegativeFiniteFloat(c.LatestHashRateHS) {
@@ -387,7 +392,7 @@ func AllPairedPolicyTargetState(c *models.Candidate, includeMaintenance bool) (m
 		return models.TargetStateUnavailable, allPairedUnavailableRebootRequired
 	case "INACTIVE", "ERROR", "UNKNOWN":
 		return models.TargetStateUnavailable, allPairedUnavailableNonActionableStatus
-	case "NEEDS_MINING_POOL":
+	case deviceStatusNeedsMiningPool:
 		// Commandable (#663), but only dispatchable once a positive power
 		// sample exists: power-vs-baseline is the sole signal that can
 		// confirm curtail/restore for a never-hashing miner. Parked rows are

--- a/server/internal/domain/curtailment/selector.go
+++ b/server/internal/domain/curtailment/selector.go
@@ -262,7 +262,37 @@ const (
 	allPairedUnavailableRebootRequired       = "reboot_required"
 	allPairedUnavailableNonActionableStatus  = "non_actionable_status"
 	allPairedUnavailableMaintenance          = "maintenance"
+	// allPairedUnavailableStaleTelemetry parks a pool-less miner whose power
+	// telemetry is missing or zero. Power-vs-baseline is the only signal that
+	// can confirm curtail/restore for a never-hashing miner, so dispatching
+	// without a positive power sample would confirm curtail vacuously and
+	// never confirm restore. Reuses the stale_telemetry vocabulary the normal
+	// classifier emits for the same condition.
+	allPairedUnavailableStaleTelemetry = "stale_telemetry"
 )
+
+// statusAuthoritativeHashRateHS returns the hash sample to use for selection
+// accounting and baseline-persistence decisions. Device status is
+// authoritative over the raw sample for NEEDS_MINING_POOL: a pool-less miner
+// cannot be mining, so a stale-positive or inconsistent hash sample must not
+// let it count as curtailable mining load in fixed-kW selection, nor mark it
+// "hashing" for the baseline min-power floor.
+func statusAuthoritativeHashRateHS(c *models.Candidate) float64 {
+	if c.DeviceStatus == "NEEDS_MINING_POOL" {
+		return 0
+	}
+	if hasNonNegativeFiniteFloat(c.LatestHashRateHS) {
+		return *c.LatestHashRateHS
+	}
+	return 0
+}
+
+// hasPositivePowerSample reports whether the candidate carries a usable
+// positive power reading — the admission requirement for miners whose only
+// confirmable signal is power.
+func hasPositivePowerSample(c *models.Candidate) bool {
+	return hasNonNegativeFiniteFloat(c.LatestPowerW) && *c.LatestPowerW > 0
+}
 
 // BuildAllPairedPolicyPlan creates a durable FULL_FLEET target list from every
 // paired-like miner in scope. It separates ownership from dispatch readiness:
@@ -305,14 +335,10 @@ func BuildAllPairedPolicyPlan(
 		if state == models.TargetStateUnavailable {
 			unavailableCount++
 		}
-		hashRateHS := 0.0
-		if hasNonNegativeFiniteFloat(c.LatestHashRateHS) {
-			hashRateHS = *c.LatestHashRateHS
-		}
 		selected = append(selected, SelectedDevice{
 			DeviceIdentifier: c.DeviceIdentifier,
 			PowerW:           powerW,
-			HashRateHS:       hashRateHS,
+			HashRateHS:       statusAuthoritativeHashRateHS(c),
 			EfficiencyJH:     derefFloat(avgEff),
 			TargetState:      state,
 			LastError:        reason,
@@ -361,6 +387,16 @@ func AllPairedPolicyTargetState(c *models.Candidate, includeMaintenance bool) (m
 		return models.TargetStateUnavailable, allPairedUnavailableRebootRequired
 	case "INACTIVE", "ERROR", "UNKNOWN":
 		return models.TargetStateUnavailable, allPairedUnavailableNonActionableStatus
+	case "NEEDS_MINING_POOL":
+		// Commandable (#663), but only dispatchable once a positive power
+		// sample exists: power-vs-baseline is the sole signal that can
+		// confirm curtail/restore for a never-hashing miner. Parked rows are
+		// re-evaluated every reconciler tick and promote (with a baseline
+		// backfill) once telemetry lands.
+		if !hasPositivePowerSample(c) {
+			return models.TargetStateUnavailable, allPairedUnavailableStaleTelemetry
+		}
+		return models.TargetStatePending, ""
 	case "MAINTENANCE":
 		if !includeMaintenance {
 			return models.TargetStateUnavailable, allPairedUnavailableMaintenance
@@ -391,7 +427,7 @@ func AllPairedPromotionBaselinePowerW(c *models.Candidate, minPowerW int32) *flo
 		return nil
 	}
 	power := *c.LatestPowerW
-	hashing := hasNonNegativeFiniteFloat(c.LatestHashRateHS) && *c.LatestHashRateHS > 0
+	hashing := statusAuthoritativeHashRateHS(c) > 0
 	if !shouldPersistBaselinePowerW(models.ModeFullFleet, power, minPowerW, hashing) {
 		return nil
 	}

--- a/server/internal/domain/curtailment/selector_test.go
+++ b/server/internal/domain/curtailment/selector_test.go
@@ -286,6 +286,75 @@ func TestDeviceStatusClassifierMatrix(t *testing.T) {
 	}
 }
 
+// A pool-less miner is commandable but only dispatchable with a positive
+// power sample: power-vs-baseline is the sole signal that can confirm
+// curtail/restore when hash never rises, so nil/zero power parks the row
+// (promoted by the readiness refresh once telemetry lands).
+func TestAllPairedPolicyTargetState_PoolLessRequiresPositivePowerSample(t *testing.T) {
+	t.Parallel()
+
+	driver := "antminer"
+	poolLess := func(power *float64) *models.Candidate {
+		return &models.Candidate{
+			DeviceIdentifier: "pool-less",
+			DriverName:       &driver,
+			DeviceStatus:     "NEEDS_MINING_POOL",
+			PairingStatus:    "PAIRED",
+			LatestPowerW:     power,
+			LatestHashRateHS: eff(0),
+		}
+	}
+
+	state, reason := AllPairedPolicyTargetState(poolLess(nil), false)
+	assert.Equal(t, models.TargetStateUnavailable, state, "missing power sample must park the row")
+	assert.Equal(t, "stale_telemetry", reason)
+
+	state, reason = AllPairedPolicyTargetState(poolLess(eff(0)), false)
+	assert.Equal(t, models.TargetStateUnavailable, state, "zero power sample must park the row")
+	assert.Equal(t, "stale_telemetry", reason)
+
+	state, reason = AllPairedPolicyTargetState(poolLess(eff(400)), false)
+	assert.Equal(t, models.TargetStatePending, state)
+	assert.Empty(t, reason)
+}
+
+// Device status is authoritative over a stale-positive hash sample: a
+// pool-less miner cannot be mining, so selection accounting and the baseline
+// min-power floor must treat it as non-hashing even when the latest hash
+// sample reads positive.
+func TestPoolLessStalePositiveHashTreatedAsNonHashing(t *testing.T) {
+	t.Parallel()
+
+	driver := "antminer"
+	poolLess := &models.Candidate{
+		DeviceIdentifier: "pool-less",
+		DriverName:       &driver,
+		DeviceStatus:     "NEEDS_MINING_POOL",
+		PairingStatus:    "PAIRED",
+		LatestPowerW:     eff(400), // below the 1500 W floor
+		LatestHashRateHS: eff(100), // stale-positive: contradicts the status
+	}
+
+	assert.Zero(t, statusAuthoritativeHashRateHS(poolLess))
+
+	// Baseline promotion must persist the below-floor idle baseline: the
+	// stale-positive hash must not mark the miner "hashing" and drop it.
+	baseline := AllPairedPromotionBaselinePowerW(poolLess, 1500)
+	require.NotNil(t, baseline)
+	assert.InDelta(t, 400.0, *baseline, 0.001)
+
+	// All-paired plan rows carry the status-authoritative hash so insert-time
+	// baseline persistence sees non-hashing too.
+	plan := BuildAllPairedPolicyPlan([]*models.Candidate{poolLess}, nil, false, 1500)
+	require.Len(t, plan.Selected, 1)
+	assert.Equal(t, models.TargetStatePending, plan.Selected[0].TargetState)
+	assert.Zero(t, plan.Selected[0].HashRateHS)
+	targets := BuildInsertTargetParams(plan.Selected, models.ModeFullFleet, 1500)
+	require.Len(t, targets, 1)
+	require.NotNil(t, targets[0].BaselinePowerW)
+	assert.InDelta(t, 400.0, *targets[0].BaselinePowerW, 0.001)
+}
+
 func TestBuildAllPairedPolicyPlan_MaintenanceOverrideMakesMaintenancePending(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/domain/curtailment/selector_test.go
+++ b/server/internal/domain/curtailment/selector_test.go
@@ -196,8 +196,8 @@ func TestBuildAllPairedPolicyPlan_TargetsPairedLikeMinersByDispatchReadiness(t *
 
 	require.Len(t, plan.Selected, 9)
 	assert.Equal(t, 9, plan.PolicyTargetCount)
-	assert.Equal(t, 7, plan.UnavailableTargetCount)
-	assert.InDelta(t, 5.0, plan.EstimatedReductionKW, 0.001)
+	assert.Equal(t, 6, plan.UnavailableTargetCount)
+	assert.InDelta(t, 7.0, plan.EstimatedReductionKW, 0.001)
 	assert.Equal(t, models.TargetStatePending, plan.Selected[0].TargetState)
 	assert.Equal(t, models.TargetStatePending, plan.Selected[1].TargetState)
 	assert.Equal(t, models.TargetStateUnavailable, plan.Selected[2].TargetState)
@@ -206,8 +206,9 @@ func TestBuildAllPairedPolicyPlan_TargetsPairedLikeMinersByDispatchReadiness(t *
 	assert.Equal(t, "offline", plan.Selected[3].LastError)
 	assert.Equal(t, models.TargetStateUnavailable, plan.Selected[4].TargetState)
 	assert.Equal(t, "non_actionable_status", plan.Selected[4].LastError)
-	assert.Equal(t, models.TargetStateUnavailable, plan.Selected[5].TargetState)
-	assert.Equal(t, "non_actionable_status", plan.Selected[5].LastError)
+	// Pool-less miner is dispatchable (#663): pending, idle power counted.
+	assert.Equal(t, models.TargetStatePending, plan.Selected[5].TargetState)
+	assert.Empty(t, plan.Selected[5].LastError)
 	assert.Equal(t, models.TargetStateUnavailable, plan.Selected[6].TargetState)
 	assert.Equal(t, "maintenance", plan.Selected[6].LastError)
 	assert.Equal(t, models.TargetStateUnavailable, plan.Selected[7].TargetState)
@@ -223,7 +224,9 @@ func TestBuildAllPairedPolicyPlan_TargetsPairedLikeMinersByDispatchReadiness(t *
 // status added to one switch cannot silently diverge in the other. The
 // ERROR/UNKNOWN rows differ on purpose: normal selection trusts fresh
 // telemetry over the coarse status, while the all-paired policy dispatches
-// without telemetry gates and holds them unavailable.
+// without telemetry gates and holds them unavailable. NEEDS_MINING_POOL is
+// admitted by both (#663, commandability admission); INACTIVE stays excluded
+// because the miner is already sleeping.
 func TestDeviceStatusClassifierMatrix(t *testing.T) {
 	t.Parallel()
 
@@ -242,7 +245,7 @@ func TestDeviceStatusClassifierMatrix(t *testing.T) {
 		{"MAINTENANCE", false, SkipMaintenance, false, "maintenance"},
 		{"ERROR", true, "", false, "non_actionable_status"},   // intentional divergence
 		{"UNKNOWN", true, "", false, "non_actionable_status"}, // intentional divergence
-		{"NEEDS_MINING_POOL", false, SkipNonActionableStatus, false, "non_actionable_status"},
+		{"NEEDS_MINING_POOL", true, "", true, ""},             // commandability admission (#663)
 		{"UPDATING", false, SkipUpdating, false, "updating"},
 		{"REBOOT_REQUIRED", false, SkipRebootRequired, false, "reboot_required"},
 		{"", false, SkipStaleTelemetry, false, "missing_status"}, // no device_status row

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -1614,7 +1614,13 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 		}
 		// Missing, non-finite, or negative power/hash samples cannot prove the
 		// miner is observable after dispatch; treat them as stale telemetry.
-		if !hasNonNegativeFiniteFloat(c.LatestPowerW) || !hasNonNegativeFiniteFloat(c.LatestHashRateHS) {
+		// Pool-less miners are exempt from the hash-sample requirement: their
+		// hash is status-authoritatively 0 (a miner with no pool cannot be
+		// mining, and may never have reported a hash sample), and their
+		// positive-power requirement was already enforced above.
+		requiresHashSample := c.DeviceStatus != deviceStatusNeedsMiningPool
+		if !hasNonNegativeFiniteFloat(c.LatestPowerW) ||
+			(requiresHashSample && !hasNonNegativeFiniteFloat(c.LatestHashRateHS)) {
 			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipStaleTelemetry})
 			summary.ExcludedStale++
 			continue

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -1569,7 +1569,11 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipUnreachableResidualLoad})
 			summary.ExcludedOffline++
 			continue
-		case "INACTIVE", "NEEDS_MINING_POOL":
+		case "INACTIVE":
+			// Excluded by design: INACTIVE means the miner is sleeping
+			// (operator- or curtailment-initiated). Curtailing it is a no-op
+			// and restoring it would wake a miner someone deliberately put
+			// to sleep.
 			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipNonActionableStatus})
 			summary.ExcludedNonActionable++
 			continue
@@ -1586,6 +1590,12 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 			// The all-paired policy holds these unavailable instead because it
 			// dispatches without the freshness gates below
 			// (AllPairedPolicyTargetState in selector.go).
+		case "NEEDS_MINING_POOL":
+			// Commandability admission (#663): a pool-less miner is reachable,
+			// authenticated, and draws idle power — a sleep command lands.
+			// Subject to the same freshness gates below; fixed-kW's
+			// dual-signal filter still excludes it (zero hash), so kW-sized
+			// selection stays sound.
 		}
 		if c.LatestMetricsAt == nil {
 			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipStaleTelemetry})

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -1590,7 +1590,7 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 			// The all-paired policy holds these unavailable instead because it
 			// dispatches without the freshness gates below
 			// (AllPairedPolicyTargetState in selector.go).
-		case "NEEDS_MINING_POOL":
+		case deviceStatusNeedsMiningPool:
 			// Commandability admission (#663): a pool-less miner is reachable,
 			// authenticated, and draws idle power — a sleep command lands.
 			// Subject to the freshness gates below, plus a positive-power

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -1787,7 +1787,7 @@ func BuildInsertTargetParams(selected []SelectedDevice, mode models.Mode, minPow
 	targets := make([]models.InsertTargetParams, len(selected))
 	for i, sel := range selected {
 		var baseline *float64
-		if shouldPersistBaselinePowerW(mode, sel.PowerW, minPowerW) {
+		if shouldPersistBaselinePowerW(mode, sel.PowerW, minPowerW, sel.HashRateHS > 0) {
 			v := sel.PowerW
 			baseline = &v
 		}
@@ -1826,11 +1826,18 @@ func BuildFullFleetAdmissionTargets(
 	return BuildInsertTargetParams(plan.Selected, models.ModeFullFleet, minPowerW), plan.Skipped
 }
 
-func shouldPersistBaselinePowerW(mode models.Mode, powerW float64, minPowerW int32) bool {
+// shouldPersistBaselinePowerW gates baseline capture. Full-fleet selection
+// runs without the dual-signal filter, so a below-floor power reading from a
+// hashing miner is suspect (dead power monitor) and the hash-only
+// confirm/restore fallback is the better signal. For a non-hashing miner the
+// hash-only fallback is provably broken (hash is already 0: curtail confirms
+// instantly, restore never confirms), so any positive idle-draw baseline is
+// strictly better and the floor does not apply.
+func shouldPersistBaselinePowerW(mode models.Mode, powerW float64, minPowerW int32, hashing bool) bool {
 	if powerW <= 0 {
 		return false
 	}
-	if mode == models.ModeFullFleet && powerW < float64(minPowerW) {
+	if mode == models.ModeFullFleet && hashing && powerW < float64(minPowerW) {
 		return false
 	}
 	return true

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -1593,9 +1593,19 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 		case "NEEDS_MINING_POOL":
 			// Commandability admission (#663): a pool-less miner is reachable,
 			// authenticated, and draws idle power — a sleep command lands.
-			// Subject to the same freshness gates below; fixed-kW's
-			// dual-signal filter still excludes it (zero hash), so kW-sized
-			// selection stays sound.
+			// Subject to the freshness gates below, plus a positive-power
+			// requirement: power-vs-baseline is the only signal that can
+			// confirm curtail/restore for a never-hashing miner, so a
+			// zero-power sample is as good as stale. Its hash is forced to 0
+			// for selection (statusAuthoritativeHashRateHS): a pool-less
+			// miner cannot be mining, so a stale-positive hash sample must
+			// not let fixed-kW count it as curtailable mining load — the
+			// dual-signal filter excludes it there.
+			if !hasPositivePowerSample(c) {
+				skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipStaleTelemetry})
+				summary.ExcludedStale++
+				continue
+			}
 		}
 		if c.LatestMetricsAt == nil {
 			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipStaleTelemetry})
@@ -1622,7 +1632,7 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 		eligible = append(eligible, CandidateInput{
 			DeviceIdentifier: c.DeviceIdentifier,
 			PowerW:           derefFloat(c.LatestPowerW),
-			HashRateHS:       derefFloat(c.LatestHashRateHS),
+			HashRateHS:       statusAuthoritativeHashRateHS(c),
 			AvgEfficiencyJH:  avgEff,
 		})
 	}

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -1009,7 +1009,7 @@ func TestService_Preview_FiltersByPairingDeviceStatusAndStaleness(t *testing.T) 
 		miner("rebooting", "REBOOT_REQUIRED", "PAIRED", 3000, 100),
 		miner("offline", "OFFLINE", "PAIRED", 3000, 100),
 		miner("inactive", "INACTIVE", "PAIRED", 3000, 100),
-		miner("needs-pool", "NEEDS_MINING_POOL", "PAIRED", 3000, 100),
+		miner("needs-pool", "NEEDS_MINING_POOL", "PAIRED", 3000, 0),
 		miner("maintenance", "MAINTENANCE", "PAIRED", 3000, 100),
 		staleMiner("stale"),
 		minerWithEff("eligible", 3000, 100, 40),
@@ -1035,10 +1035,10 @@ func TestService_Preview_FiltersByPairingDeviceStatusAndStaleness(t *testing.T) 
 	assert.Equal(t, SkipRebootRequired, reasons["rebooting"])
 	assert.Equal(t, SkipUnreachableResidualLoad, reasons["offline"])
 	assert.Equal(t, SkipNonActionableStatus, reasons["inactive"])
-	// Pool-less miner passes status admission (#663) but is hashing here
-	// (100 H/s), so it competes as a normal candidate; with the 2.5 kW target
-	// already met by the eligible miner, it is simply not selected.
-	assert.NotContains(t, reasons, "needs-pool")
+	// Pool-less miner passes status admission (#663); in fixed-kW mode the
+	// dual-signal filter then skips it with the sharper diagnostic — idle
+	// draw with zero hash is phantom load for kW-sized selection.
+	assert.Equal(t, SkipPhantomLoadNoHash, reasons["needs-pool"])
 	assert.Equal(t, SkipMaintenance, reasons["maintenance"])
 	assert.Equal(t, SkipStaleTelemetry, reasons["stale"])
 }

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -1047,21 +1047,36 @@ func TestClassifyCandidates_PoolLessMinerAdmittedWhenTelemetryFresh(t *testing.T
 	t.Parallel()
 
 	// Commandability admission (#663): NEEDS_MINING_POOL passes status
-	// admission even with zero hash, but stays behind the freshness gates.
+	// admission even with zero hash, but stays behind the freshness gates
+	// plus a positive-power requirement (power is its only confirmable
+	// signal). A stale-positive hash sample is overridden by the status: the
+	// eligible candidate carries hash 0 so fixed-kW accounting and baseline
+	// persistence treat it as non-hashing.
 	fresh := miner("needs-pool-fresh", "NEEDS_MINING_POOL", "PAIRED", 2000, 0)
+	stalePositiveHash := miner("needs-pool-stale-hash", "NEEDS_MINING_POOL", "PAIRED", 2000, 100)
+	zeroPower := miner("needs-pool-zero-power", "NEEDS_MINING_POOL", "PAIRED", 0, 0)
 	stale := staleMiner("needs-pool-stale")
 	stale.DeviceStatus = "NEEDS_MINING_POOL"
 
 	eligible, skipped, _ := classifyCandidates(
-		[]*models.Candidate{fresh, stale},
+		[]*models.Candidate{fresh, stalePositiveHash, zeroPower, stale},
 		classifyOpts{CandidateMinPowerW: 1500},
 	)
 
-	require.Len(t, eligible, 1)
+	require.Len(t, eligible, 2)
 	assert.Equal(t, "needs-pool-fresh", eligible[0].DeviceIdentifier)
-	require.Len(t, skipped, 1)
-	assert.Equal(t, "needs-pool-stale", skipped[0].DeviceIdentifier)
-	assert.Equal(t, SkipStaleTelemetry, skipped[0].Reason)
+	assert.Equal(t, "needs-pool-stale-hash", eligible[1].DeviceIdentifier)
+	assert.Zero(t, eligible[1].HashRateHS,
+		"device status is authoritative: a pool-less miner cannot be mining, so a stale-positive hash sample must not count as mining load")
+
+	reasons := map[string]SkipReason{}
+	for _, s := range skipped {
+		reasons[s.DeviceIdentifier] = s.Reason
+	}
+	require.Len(t, skipped, 2)
+	assert.Equal(t, SkipStaleTelemetry, reasons["needs-pool-zero-power"],
+		"zero power is as good as stale for a miner whose only confirmable signal is power")
+	assert.Equal(t, SkipStaleTelemetry, reasons["needs-pool-stale"])
 }
 
 func TestService_Preview_PoolLessZeroHashMinerSkippedByDualSignalInFixedKw(t *testing.T) {

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -1035,9 +1035,62 @@ func TestService_Preview_FiltersByPairingDeviceStatusAndStaleness(t *testing.T) 
 	assert.Equal(t, SkipRebootRequired, reasons["rebooting"])
 	assert.Equal(t, SkipUnreachableResidualLoad, reasons["offline"])
 	assert.Equal(t, SkipNonActionableStatus, reasons["inactive"])
-	assert.Equal(t, SkipNonActionableStatus, reasons["needs-pool"])
+	// Pool-less miner passes status admission (#663) but is hashing here
+	// (100 H/s), so it competes as a normal candidate; with the 2.5 kW target
+	// already met by the eligible miner, it is simply not selected.
+	assert.NotContains(t, reasons, "needs-pool")
 	assert.Equal(t, SkipMaintenance, reasons["maintenance"])
 	assert.Equal(t, SkipStaleTelemetry, reasons["stale"])
+}
+
+func TestClassifyCandidates_PoolLessMinerAdmittedWhenTelemetryFresh(t *testing.T) {
+	t.Parallel()
+
+	// Commandability admission (#663): NEEDS_MINING_POOL passes status
+	// admission even with zero hash, but stays behind the freshness gates.
+	fresh := miner("needs-pool-fresh", "NEEDS_MINING_POOL", "PAIRED", 2000, 0)
+	stale := staleMiner("needs-pool-stale")
+	stale.DeviceStatus = "NEEDS_MINING_POOL"
+
+	eligible, skipped, _ := classifyCandidates(
+		[]*models.Candidate{fresh, stale},
+		classifyOpts{CandidateMinPowerW: 1500},
+	)
+
+	require.Len(t, eligible, 1)
+	assert.Equal(t, "needs-pool-fresh", eligible[0].DeviceIdentifier)
+	require.Len(t, skipped, 1)
+	assert.Equal(t, "needs-pool-stale", skipped[0].DeviceIdentifier)
+	assert.Equal(t, SkipStaleTelemetry, skipped[0].Reason)
+}
+
+func TestService_Preview_PoolLessZeroHashMinerSkippedByDualSignalInFixedKw(t *testing.T) {
+	t.Parallel()
+
+	// A pool-less miner passes status admission (#663) but fixed-kW's
+	// dual-signal filter still excludes it: idle draw with zero hash is
+	// phantom load for kW-sized selection.
+	const orgID = int64(1)
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.candidatesByOrg[orgID] = []*models.Candidate{
+		miner("needs-pool", "NEEDS_MINING_POOL", "PAIRED", 3000, 0),
+		minerWithEff("eligible", 3000, 100, 40),
+	}
+
+	svc := NewService(store)
+	req := validRequest(orgID)
+	req.TargetKW = 2.5
+	plan, err := svc.Preview(t.Context(), req)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Selected, 1)
+	assert.Equal(t, "eligible", plan.Selected[0].DeviceIdentifier)
+	reasons := map[string]SkipReason{}
+	for _, s := range plan.Skipped {
+		reasons[s.DeviceIdentifier] = s.Reason
+	}
+	assert.Equal(t, SkipPhantomLoadNoHash, reasons["needs-pool"])
 }
 
 func TestService_Preview_MaintenancePairAdmitsMiners(t *testing.T) {

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -1054,20 +1054,26 @@ func TestClassifyCandidates_PoolLessMinerAdmittedWhenTelemetryFresh(t *testing.T
 	// persistence treat it as non-hashing.
 	fresh := miner("needs-pool-fresh", "NEEDS_MINING_POOL", "PAIRED", 2000, 0)
 	stalePositiveHash := miner("needs-pool-stale-hash", "NEEDS_MINING_POOL", "PAIRED", 2000, 100)
+	// Power-only telemetry: a pool-less miner may never have reported a hash
+	// sample at all; the hash-sample freshness requirement must not apply.
+	noHashSample := miner("needs-pool-no-hash-sample", "NEEDS_MINING_POOL", "PAIRED", 2000, 0)
+	noHashSample.LatestHashRateHS = nil
 	zeroPower := miner("needs-pool-zero-power", "NEEDS_MINING_POOL", "PAIRED", 0, 0)
 	stale := staleMiner("needs-pool-stale")
 	stale.DeviceStatus = "NEEDS_MINING_POOL"
 
 	eligible, skipped, _ := classifyCandidates(
-		[]*models.Candidate{fresh, stalePositiveHash, zeroPower, stale},
+		[]*models.Candidate{fresh, stalePositiveHash, noHashSample, zeroPower, stale},
 		classifyOpts{CandidateMinPowerW: 1500},
 	)
 
-	require.Len(t, eligible, 2)
+	require.Len(t, eligible, 3)
 	assert.Equal(t, "needs-pool-fresh", eligible[0].DeviceIdentifier)
 	assert.Equal(t, "needs-pool-stale-hash", eligible[1].DeviceIdentifier)
 	assert.Zero(t, eligible[1].HashRateHS,
 		"device status is authoritative: a pool-less miner cannot be mining, so a stale-positive hash sample must not count as mining load")
+	assert.Equal(t, "needs-pool-no-hash-sample", eligible[2].DeviceIdentifier)
+	assert.Zero(t, eligible[2].HashRateHS)
 
 	reasons := map[string]SkipReason{}
 	for _, s := range skipped {

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -1093,6 +1093,29 @@ func TestService_Preview_PoolLessZeroHashMinerSkippedByDualSignalInFixedKw(t *te
 	assert.Equal(t, SkipPhantomLoadNoHash, reasons["needs-pool"])
 }
 
+func TestBuildInsertTargetParams_BaselineFloorAppliesOnlyToHashingMiners(t *testing.T) {
+	t.Parallel()
+
+	selected := []SelectedDevice{
+		// Hashing below the floor: suspect power reading (dead monitor);
+		// hash-only fallback works, so no baseline is persisted.
+		{DeviceIdentifier: "hashing-below-floor", PowerW: 400, HashRateHS: 100},
+		// Never-hashing below the floor: hash-only fallback is broken, so
+		// the idle-draw baseline must be persisted (#663).
+		{DeviceIdentifier: "idle-below-floor", PowerW: 400, HashRateHS: 0},
+		// Zero power never persists a baseline regardless of hash.
+		{DeviceIdentifier: "no-power", PowerW: 0, HashRateHS: 0},
+	}
+
+	targets := BuildInsertTargetParams(selected, models.ModeFullFleet, 1500)
+
+	require.Len(t, targets, 3)
+	assert.Nil(t, targets[0].BaselinePowerW)
+	require.NotNil(t, targets[1].BaselinePowerW)
+	assert.InDelta(t, 400.0, *targets[1].BaselinePowerW, 0.001)
+	assert.Nil(t, targets[2].BaselinePowerW)
+}
+
 func TestService_Preview_MaintenancePairAdmitsMiners(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Reviewable diff: +97/-12 across 2 files (excludes generated, test, and story files).

Closes #663

## Summary

Curtailment admission now converges on commandability: a reachable, authenticated `NEEDS_MINING_POOL` miner is targetable in both admission classifiers instead of being excluded for not mining. Its idle draw is real power that a sleep command can shed — on the dev fleet, a 14-miner all-paired full shutdown left several reachable pool-less miners drawing idle power for the whole event. This PR also fixes a latent confirmation bug the admission change would have amplified: never-hashing miners now persist an idle-draw power baseline so curtail confirm and restore confirm work at low baselines.

## How it works

Two classifiers gate curtailment admission. Normal (fixed-kW / manual / closed-loop full-fleet) selection classifies candidates in `classifyCandidates`; the all-paired policy classifies durable target rows in `AllPairedPolicyTargetState`. Both previously bucketed `NEEDS_MINING_POOL` with `INACTIVE` as non-actionable.

- **Normal selection**: `NEEDS_MINING_POOL` now falls through to the telemetry-freshness gates (same pattern as the existing `ERROR`/`UNKNOWN` admission). Fixed-kW's dual-signal filter still excludes zero-hash miners — a pool-less miner now surfaces with the sharper `phantom_load_no_hash` / `below_candidate_min_power_w` skip reason instead of `non_actionable_status`. The practical dispatch change lands in full-fleet selection, which runs without the dual-signal filter.
- **All-paired policy**: `NEEDS_MINING_POOL` maps to `pending` and dispatches normally. Existing in-flight events self-heal without migration: the reconciler's readiness refresh re-classifies parked `unavailable` rows every tick, so pool-less targets get promoted, baseline-backfilled, and dispatched on the next tick after deploy.
- **Baseline fix**: `shouldPersistBaselinePowerW` rejected full-fleet baselines below `candidate_min_power_w` (default 1500 W), assuming the hash-only confirm/restore fallback covers those rows. That fallback is provably broken for a never-hashing miner: curtail confirms instantly (hash already 0) and restore never confirms (hash never rises), aging out to `restore_failed`. The floor now applies only to hashing miners (where a below-floor power reading means a dead power monitor and hash is the better signal); non-hashing miners persist any positive idle-draw baseline, making power-vs-baseline the confirm signal for both directions. The hash signal is threaded via a new `SelectedDevice.HashRateHS` field.

`INACTIVE` stays excluded by design (it means "sleeping"; restore must not wake operator-slept miners), and `ERROR`/`UNKNOWN` stay parked in the all-paired path (no telemetry gates there) — both now documented in the classifier comments and the pinned matrix test.

## Diagrams

```mermaid
flowchart LR
    subgraph normal [Normal selection]
        NMP1["NEEDS_MINING_POOL"] -->|"falls through like ERROR/UNKNOWN"| fresh["freshness gates"]
        fresh --> dual["fixed-kW dual-signal filter"]
        dual -->|"zero hash: skipped"| skip["phantom_load_no_hash"]
        dual -->|"full-fleet: no filter"| sel["selected"]
    end
    subgraph allpaired [All-paired policy]
        NMP2["NEEDS_MINING_POOL"] --> pend["pending"]
        pend --> disp["dispatched, idle-draw baseline persisted"]
    end
    sel --> conf["isCurtailed / isRestored via power-vs-baseline"]
    disp --> conf
```

```mermaid
stateDiagram-v2
    [*] --> unavailable: parked pre-deploy
    unavailable --> pending: readiness refresh reclassifies NEEDS_MINING_POOL
    pending --> dispatched: sleep command, baseline backfilled
    dispatched --> confirmed: power drops below baseline x 0.5
    confirmed --> resolved: restore confirms when power returns above baseline x 0.5
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/curtailment/service.go` | `classifyCandidates` admits `NEEDS_MINING_POOL`; `shouldPersistBaselinePowerW` gains a hashing gate | The admission semantics and the floor-bypass rationale |
| `server/internal/domain/curtailment/selector.go` | `AllPairedPolicyTargetState` returns pending for pool-less; `SelectedDevice.HashRateHS` threaded through `BuildPlan` / `BuildAllPairedPolicyPlan`; `AllPairedPromotionBaselinePowerW` hashing-aware | The hash-signal threading; estimated reduction now counts pool-less idle draw |
| `server/internal/domain/curtailment/selector_test.go`, `service_test.go`, `reconciler/reconciler_test.go`, `reconciler/restore_test.go` | Pinned classifier matrix updated; new admission, promotion, baseline-floor, and idle-baseline confirm/restore tests | Test — verify scenarios match the acceptance criteria |
| `docs/plans/2026-07-07-663-curtailment-commandability-admission-plan.md` | Plan doc | Context only |

## Key technical decisions & trade-offs

- **Baseline floor bypass keyed on "not hashing", not on device status** — fixes the same latent confirm/restore bug for ERROR/UNKNOWN phantom loads in full-fleet, and avoids threading device status into baseline logic. Alternative rejected: status-based restore confirmation in the reconciler (larger semantic change).
- **Fixed-kW dual-signal filter untouched** — kW-sized selection still counts only measurable mining load; pool-less admission there changes the skip reason, not the outcome. `InsufficientLoadDetail` bucket counts shift accordingly (`non_actionable` → `phantom_load`/`below_threshold`).
- **All-paired estimated reduction now includes pool-less idle draw** — more accurate for grid-shed purposes; display-only consumers verified.
- **No skip-reason vocabulary change** — `non_actionable_status` still exists (INACTIVE); no client change needed.

## Testing & validation

- Pinned `TestDeviceStatusClassifierMatrix` updated for the new admission matrix; both classifier switches and the matrix moved together.
- New tests: classify-level pool-less admission (fresh vs stale telemetry), fixed-kW dual-signal skip, all-paired plan pending state + estimate, reconciler promotion of a parked pool-less target (self-heal path), below-floor baseline persistence at promotion (was red before the fix), `BuildInsertTargetParams` floor semantics, and `isCurtailed`/`isRestored` at idle-draw baselines.
- Full server suite green against the local TimescaleDB (including `sqlstores` curtailment integration tests); `golangci-lint` clean.
- Not covered: hardware-in-the-loop verification that a specific miner model's sleep draw sits below half its pool-less idle draw (see residuals).

## Known Residuals

Accepted from code review (recorded, not fixed here):

- ~~**major** `reconciler_allpaired.go` (promotion path) — pool-less target with missing/zero power dispatches with a nil baseline~~ **Fixed in c6697657**: pool-less admission now requires a positive power sample in both classifiers; rows without one stay parked (`stale_telemetry`) until telemetry lands.
- **major** `reconciler.go` (drift path) — if a miner's sleep draw exceeds `DriftThresholdFactor` x idle baseline, a confirmed target can flap Drifted → re-dispatch indefinitely (curtail-phase targets never terminalize). Impossible for mining baselines; plausible at idle baselines depending on hardware. Mitigation lever: per-org `DriftThresholdFactor`.
- **minor** `selector.go` — the all-paired hashing signal reads the raw latest hash sample with no freshness gate; a dead hash sensor on a hashing miner can persist a suspect below-floor baseline.
- **minor** `handlers/curtailment/translate.go` — the Start-response baseline echo (`PowerW > 0`) has never matched the persistence rule and now diverges in one more dimension (hashing gate). Display-only.

## Post-Deploy Monitoring & Validation

- **Logs**: `curtailment reconciler` entries for the first all-paired event after deploy — expect `claimed all-paired policy targets` / readiness-refresh promotions of previously-unavailable pool-less rows; watch for `curtail telemetry timeout aging initiated` and `restore telemetry timeout aging initiated` on pool-less devices (failure signal for the confirm-threshold risk above).
- **Metrics/rollup**: `target_rollup` on active all-paired events — `unavailable` count should drop by the number of reachable pool-less miners; they should progress pending → dispatched → confirmed.
- **Healthy signal**: dev-fleet all-paired full shutdown shows pool-less proto miners confirmed with observed power near sleep draw; restore completes without `restore_failed`.
- **Failure signal / rollback trigger**: sustained Drifted → re-dispatch loops or `restore_failed` clusters on pool-less devices; mitigate by raising the event's drift threshold factor or reverting the baseline-floor commit (`fix(curtailment): persist idle-draw baselines...`) independently of the admission commits.
- **Window/owner**: first curtailment event after deploy on the dev fleet; @rongxin-liu.
