### PR TITLE
fix(ci): require releases and -rc. tags to be on main (allow test builds off branches)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,20 +17,14 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          # General shape: vX.Y.Z with an optional prerelease suffix
-          # (e.g. v1.2.3, v1.2.3-rc.1, v1.2.3-alpha.4, v1.2.3-<label>.1).
+          # vX.Y.Z with an optional prerelease suffix (e.g. v1.2.3-alpha.4).
           if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
             echo "::error::Tag '$TAG_NAME' does not match expected format (e.g., v1.2.3, v1.2.3-rc.1, or v1.2.3-<label>.1)"
             exit 1
           fi
-          # Reserve release-candidate naming: any tag that looks like an RC must be
-          # exactly vX.Y.Z-rc.N. This covers both a leading "rc" token (a typo like
-          # v1.2.3-rc1 or v1.2.3-RC.1) and an "-rc." appearing anywhere in the tag
-          # (e.g. v1.2.3-hostmon-rc.1). The on-main gate below keys on the literal
-          # "-rc." (matched case-insensitively by contains()), so both layers must
-          # agree on what counts as an RC — otherwise such a tag would pass here and
-          # then fail confusingly at the gate. Rejecting now keeps "-rc." fully
-          # reserved for canonical RCs.
+          # Reserve RC naming: any RC-looking tag must be canonical vX.Y.Z-rc.N.
+          # Matches the on-main gate below (which keys on "-rc." anywhere,
+          # case-insensitively) so a near-miss can't slip past it as a test build.
           if [[ "$TAG_NAME" == *-* ]]; then
             prerelease="${TAG_NAME#*-}"
             first_token="${prerelease%%[.-]*}"
@@ -44,21 +38,16 @@ jobs:
           fi
           echo "Tag '$TAG_NAME' is valid"
 
-      # Versioned releases (vX.Y.Z) and release candidates (vX.Y.Z-rc.N) must be
-      # cut from main so the release line can't silently diverge. Other
-      # prerelease suffixes (e.g. -alpha.N, -beta.N, -<label>) are intentionally
-      # left unrestricted so the team can cut throwaway test builds off feature
-      # branches — just not under the -rc. name, which is reserved for mainline
-      # release candidates.
+      # Releases and RCs must come from main; other prerelease suffixes stay
+      # unrestricted so test builds can be cut off feature branches.
       - name: Require releases and release candidates to be on main
         if: ${{ !contains(github.ref_name, '-') || contains(github.ref_name, '-rc.') }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           AHEAD_BY=$(gh api "repos/${{ github.repository }}/compare/main...${{ github.sha }}" --jq '.ahead_by')
-          # String compare, not -ne: a non-numeric ahead_by (e.g. "null" from a
-          # failed/unexpected API response) would coerce to 0 and silently pass.
-          # This is the enforcement point, so fail closed on anything but "0".
+          # String compare (not -ne): a non-numeric ahead_by like "null" would
+          # coerce to 0 and pass. Fail closed on anything but "0".
           if [[ "$AHEAD_BY" != "0" ]]; then
             echo "::error::Versioned releases and -rc. tags must be cut from main. Tag '${{ github.ref_name }}' points to a commit not on main (compare ahead_by=${AHEAD_BY:-unknown}). For branch/test builds, use a different prerelease suffix (e.g. v1.2.3-<label>.1)."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,22 @@ jobs:
             echo "::error::Tag '$TAG_NAME' does not match expected format (e.g., v1.2.3, v1.2.3-rc.1, or v1.2.3-<label>.1)"
             exit 1
           fi
-          # Reserve release-candidate naming: any tag whose prerelease starts with
-          # "rc" (any case) must be exactly vX.Y.Z-rc.N. This stops a typo like
-          # v1.2.3-rc1 or v1.2.3-RC.1 from slipping past the on-main gate (which
-          # keys on the literal "-rc.") and being treated as an unrestricted test build.
+          # Reserve release-candidate naming: any tag that looks like an RC must be
+          # exactly vX.Y.Z-rc.N. This covers both a leading "rc" token (a typo like
+          # v1.2.3-rc1 or v1.2.3-RC.1) and an "-rc." appearing anywhere in the tag
+          # (e.g. v1.2.3-hostmon-rc.1). The on-main gate below keys on the literal
+          # "-rc." (matched case-insensitively by contains()), so both layers must
+          # agree on what counts as an RC — otherwise such a tag would pass here and
+          # then fail confusingly at the gate. Rejecting now keeps "-rc." fully
+          # reserved for canonical RCs.
           if [[ "$TAG_NAME" == *-* ]]; then
             prerelease="${TAG_NAME#*-}"
             first_token="${prerelease%%[.-]*}"
             first_token_lc=$(printf '%s' "$first_token" | tr 'A-Z' 'a-z')
-            if [[ "$first_token_lc" == rc* ]] && [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
-              echo "::error::Tag '$TAG_NAME' looks like a release candidate but is malformed. RC tags must be exactly vX.Y.Z-rc.N (lowercase 'rc', dot before the number), e.g. v1.2.3-rc.1"
+            tag_lc=$(printf '%s' "$TAG_NAME" | tr 'A-Z' 'a-z')
+            if { [[ "$first_token_lc" == rc* ]] || [[ "$tag_lc" == *-rc.* ]]; } && \
+               [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+              echo "::error::Tag '$TAG_NAME' looks like a release candidate but is malformed. RC tags must be exactly vX.Y.Z-rc.N (lowercase 'rc', dot before the number), e.g. v1.2.3-rc.1. For branch/test builds, use a suffix without 'rc' (e.g. v1.2.3-<label>.1)."
               exit 1
             fi
           fi
@@ -50,8 +56,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           AHEAD_BY=$(gh api "repos/${{ github.repository }}/compare/main...${{ github.sha }}" --jq '.ahead_by')
-          if [[ "$AHEAD_BY" -ne 0 ]]; then
-            echo "::error::Versioned releases and -rc. tags must be cut from main. Tag '${{ github.ref_name }}' points to a commit not on main. For branch/test builds, use a different prerelease suffix (e.g. v1.2.3-<label>.1)."
+          # String compare, not -ne: a non-numeric ahead_by (e.g. "null" from a
+          # failed/unexpected API response) would coerce to 0 and silently pass.
+          # This is the enforcement point, so fail closed on anything but "0".
+          if [[ "$AHEAD_BY" != "0" ]]; then
+            echo "::error::Versioned releases and -rc. tags must be cut from main. Tag '${{ github.ref_name }}' points to a commit not on main (compare ahead_by=${AHEAD_BY:-unknown}). For branch/test builds, use a different prerelease suffix (e.g. v1.2.3-<label>.1)."
             exit 1
           fi
           echo "Release/RC tag is on main — OK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,17 +23,16 @@ jobs:
           fi
           echo "Tag '$TAG_NAME' is valid"
 
-      - name: Require full releases to be on main
-        if: ${{ !contains(github.ref_name, '-') }}
+      - name: Require tags to be on main
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           AHEAD_BY=$(gh api "repos/${{ github.repository }}/compare/main...${{ github.sha }}" --jq '.ahead_by')
           if [[ "$AHEAD_BY" -ne 0 ]]; then
-            echo "::error::Full releases are only allowed from commits on the main branch. Tag '${{ github.ref_name }}' points to a commit not on main."
+            echo "::error::Release tags are only allowed from commits on the main branch. Tag '${{ github.ref_name }}' points to a commit not on main."
             exit 1
           fi
-          echo "Full release tag is on main — OK"
+          echo "Release tag is on main — OK"
 
   build-artifacts:
     name: Build release artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,24 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
+          # General shape: vX.Y.Z with an optional prerelease suffix
+          # (e.g. v1.2.3, v1.2.3-rc.1, v1.2.3-alpha.4, v1.2.3-<label>.1).
           if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
-            echo "::error::Tag '$TAG_NAME' does not match expected format (e.g., v1.2.3 or v1.2.3-rc.1)"
+            echo "::error::Tag '$TAG_NAME' does not match expected format (e.g., v1.2.3, v1.2.3-rc.1, or v1.2.3-<label>.1)"
             exit 1
+          fi
+          # Reserve release-candidate naming: any tag whose prerelease starts with
+          # "rc" (any case) must be exactly vX.Y.Z-rc.N. This stops a typo like
+          # v1.2.3-rc1 or v1.2.3-RC.1 from slipping past the on-main gate (which
+          # keys on the literal "-rc.") and being treated as an unrestricted test build.
+          if [[ "$TAG_NAME" == *-* ]]; then
+            prerelease="${TAG_NAME#*-}"
+            first_token="${prerelease%%[.-]*}"
+            first_token_lc=$(printf '%s' "$first_token" | tr 'A-Z' 'a-z')
+            if [[ "$first_token_lc" == rc* ]] && [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+              echo "::error::Tag '$TAG_NAME' looks like a release candidate but is malformed. RC tags must be exactly vX.Y.Z-rc.N (lowercase 'rc', dot before the number), e.g. v1.2.3-rc.1"
+              exit 1
+            fi
           fi
           echo "Tag '$TAG_NAME' is valid"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,23 @@ jobs:
           fi
           echo "Tag '$TAG_NAME' is valid"
 
-      - name: Require tags to be on main
+      # Versioned releases (vX.Y.Z) and release candidates (vX.Y.Z-rc.N) must be
+      # cut from main so the release line can't silently diverge. Other
+      # prerelease suffixes (e.g. -alpha.N, -beta.N, -<label>) are intentionally
+      # left unrestricted so the team can cut throwaway test builds off feature
+      # branches — just not under the -rc. name, which is reserved for mainline
+      # release candidates.
+      - name: Require releases and release candidates to be on main
+        if: ${{ !contains(github.ref_name, '-') || contains(github.ref_name, '-rc.') }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           AHEAD_BY=$(gh api "repos/${{ github.repository }}/compare/main...${{ github.sha }}" --jq '.ahead_by')
           if [[ "$AHEAD_BY" -ne 0 ]]; then
-            echo "::error::Release tags are only allowed from commits on the main branch. Tag '${{ github.ref_name }}' points to a commit not on main."
+            echo "::error::Versioned releases and -rc. tags must be cut from main. Tag '${{ github.ref_name }}' points to a commit not on main. For branch/test builds, use a different prerelease suffix (e.g. v1.2.3-<label>.1)."
             exit 1
           fi
-          echo "Release tag is on main — OK"
+          echo "Release/RC tag is on main — OK"
 
   build-artifacts:
     name: Build release artifacts


### PR DESCRIPTION
## Problem

RC tags could be cut from non-mainline commits without the release workflow complaining. This happened in practice: `v0.2.9-rc.2` was tagged on an unmerged host-monitoring feature branch, 8 commits ahead of `main`, so the versioned RC line silently diverged from mainline.

## Root cause

The release workflow's on-main ancestry guard was gated behind a condition that only matched full releases:

```yaml
- name: Require full releases to be on main
  if: ${{ !contains(github.ref_name, '-') }}
```

Every prerelease tag contains a `-` (e.g. `v0.2.9-rc.2`), so `!contains(..., '-')` is false and the check was skipped for all of them — including versioned release candidates.

## Fix

**1. Gate the ancestry check by tag name**, not by whether it's a prerelease:

```yaml
if: \${{ !contains(github.ref_name, '-') || contains(github.ref_name, '-rc.') }}
```

- **Full releases** (`vX.Y.Z`) and **release candidates** (`vX.Y.Z-rc.N`) must be cut from `main`.
- **All other prerelease suffixes** (`-alpha.N`, `-beta.N`, `-<label>`) stay unrestricted, so the team can still cut throwaway test/branch builds off feature branches. They just can't use the `-rc.` name, which is reserved for mainline release candidates.

**2. Reserve `-rc.` naming to the canonical form.** The on-main gate keys on the literal `-rc.`, so a malformed RC (`v1.2.3-rc1`, `v1.2.3-RC.1`) would miss the gate and be treated as an unrestricted test build. The format-validation step now requires any tag whose prerelease starts with `rc` (any case) to be exactly `vX.Y.Z-rc.N`:

| Tag | Result |
|-----|--------|
| `v1.2.3`, `v1.2.3-rc.1`, `v1.2.3-rc.24` | accepted |
| `v1.2.3-rc1`, `v1.2.3-RC.1`, `v1.2.3-rc.1.2`, `v1.2.3-rc-1` | rejected (malformed RC) |
| `v1.2.3-alpha.4`, `v1.2.3-beta-2`, `v1.2.3-search.1` | accepted (not an RC) |

Together these keep the intended workflow — test releases off branches are fine — while preventing versioned RCs from being conflated with, or cut from, non-mainline work.

## Caveat (not addressed here)

This gate runs on tag *push*, so it fails the release **build** rather than preventing the tag from being created. It stops artifacts/releases from being produced off a non-main commit, but a stray tag would still need manual cleanup. Truly blocking the push would require tag protection rules / a server-side hook, which is out of scope.