### PR TITLE
feat(curtailment): make full shutdown the default and first mode option

### DIFF
--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -43,6 +43,10 @@ export class EnergyPage extends BasePage {
     const modal = this.page.getByTestId("full-screen-two-pane-modal");
 
     await modal.locator("#curtailment-reason").fill(reason);
+    // Full shutdown is the default mode; switch to fixed-kW so the target
+    // input renders.
+    await modal.locator("#curtailment-mode").click();
+    await this.page.getByRole("option", { name: "Fixed kW reduction", exact: true }).click();
     await modal.locator("#curtailment-target-kw").fill(targetKw);
     await modal.locator("#curtailment-restore-batch-interval").fill(restoreBatchIntervalSec);
   }

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -134,6 +134,8 @@ vi.mock("@/protoFleet/features/settings/components/Schedules/MinerSelectionModal
 }));
 
 const configuredValues: Partial<CurtailmentFormValues> = {
+  // A configured fixed-kW plan; the modal itself defaults to full shutdown.
+  curtailmentMode: "fixedKwReduction",
   targetKw: "40",
   curtailBatchSize: "8",
   curtailBatchIntervalSec: "30",
@@ -280,10 +282,9 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByText("Fleet will automatically curtail the least efficient miners first.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Curtailment mode" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "About curtailment mode" })).toBeInTheDocument();
-    expect(screen.getByText("Fixed kW reduction")).toBeInTheDocument();
-    expect(screen.getByLabelText("Fixed target reduction (kW)")).toBeInTheDocument();
-    expect(screen.getByLabelText("Fixed target reduction (kW)")).toHaveAttribute("type", "text");
-    expect(screen.getByLabelText("Fixed target reduction (kW)")).toHaveAttribute("inputmode", "decimal");
+    // Full shutdown is the default mode, so no fixed-target input renders.
+    expect(screen.getByText("Full shutdown")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Fixed target reduction (kW)")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Miner selection strategy" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Min duration (sec)")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Max duration (sec)")).not.toBeInTheDocument();
@@ -1572,6 +1573,11 @@ describe("CurtailmentStartModal", () => {
   it("submits the current form values without dismissing the modal", async () => {
     const user = userEvent.setup();
     const { onDismiss, onSubmit } = renderModal();
+
+    // Full shutdown is the default; switch to fixed-kW mode first.
+    await user.click(screen.getByRole("button", { name: "Curtailment mode" }));
+    await user.click(await screen.findByText("Fixed kW reduction"));
+
     const targetInput = screen.getByLabelText("Fixed target reduction (kW)");
     const restoreBatchSizeInput = screen.getAllByLabelText("Batch size (miners)")[1];
     const restoreIntervalInput = screen.getAllByLabelText("Batch interval (sec)")[1];
@@ -1624,13 +1630,9 @@ describe("CurtailmentStartModal", () => {
     });
     const startButton = screen.getByRole("button", { name: "Run curtailment" });
 
-    expect(startButton).toBeEnabled();
-
-    await user.click(screen.getByRole("button", { name: "Curtailment mode" }));
-    const fullShutdownOption = await screen.findByText("Full shutdown");
-    expect(document.body.querySelectorAll('input[type="radio"]')).toHaveLength(0);
-    await user.click(fullShutdownOption);
-
+    // Full shutdown is the default mode — no mode switch needed, and no
+    // fixed-target input is required to start.
+    expect(screen.getByRole("button", { name: "Curtailment mode" })).toHaveTextContent("Full shutdown");
     expect(screen.queryByLabelText("Fixed target reduction (kW)")).not.toBeInTheDocument();
     expect(screen.getByText("Fleet will automatically curtail the least efficient miners first.")).toBeInTheDocument();
     expect(startButton).toBeEnabled();
@@ -2009,7 +2011,7 @@ describe("CurtailmentStartModal", () => {
         open
         onDismiss={onDismiss}
         onSubmit={onSubmit}
-        initialValues={{ targetKw: "10", reason: "Initial reason" }}
+        initialValues={{ curtailmentMode: "fixedKwReduction", targetKw: "10", reason: "Initial reason" }}
       />,
     );
 
@@ -2023,7 +2025,7 @@ describe("CurtailmentStartModal", () => {
         open={false}
         onDismiss={onDismiss}
         onSubmit={onSubmit}
-        initialValues={{ targetKw: "10", reason: "Initial reason" }}
+        initialValues={{ curtailmentMode: "fixedKwReduction", targetKw: "10", reason: "Initial reason" }}
       />,
     );
     rerender(
@@ -2031,7 +2033,7 @@ describe("CurtailmentStartModal", () => {
         open
         onDismiss={onDismiss}
         onSubmit={onSubmit}
-        initialValues={{ targetKw: "25", reason: "Updated reason" }}
+        initialValues={{ curtailmentMode: "fixedKwReduction", targetKw: "25", reason: "Updated reason" }}
       />,
     );
 
@@ -2060,6 +2062,11 @@ describe("CurtailmentStartModal", () => {
   it("shows required start-field validation when the CTA is clicked or fields are edited", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal();
+
+    // Full shutdown is the default; switch to fixed-kW mode so the
+    // target-reduction requirement applies.
+    await user.click(screen.getByRole("button", { name: "Curtailment mode" }));
+    await user.click(await screen.findByText("Fixed kW reduction"));
 
     const startButton = screen.getByRole("button", { name: "Run curtailment" });
     const targetInput = screen.getByLabelText("Fixed target reduction (kW)");

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -202,7 +202,9 @@ const defaultValues: CurtailmentFormValues = {
   deviceIdentifiers: [],
   minerSelectionMode: "subset",
   responseProfileId: customResponseProfileId,
-  curtailmentMode: "fixedKwReduction",
+  // Whole-fleet shutdown is the primary operator flow; fixed-kW sizing is
+  // the opt-in refinement (matches the response-profile form default).
+  curtailmentMode: "fullFleet",
   minerSelectionStrategy: "leastEfficientFirst",
   targetKw: "",
   toleranceKw: "",
@@ -222,9 +224,11 @@ const defaultValues: CurtailmentFormValues = {
   forceIncludeAllPairedMiners: false,
 };
 const editableCurtailmentFields: EditableCurtailmentField[] = ["reason", "restoreIntervalSec"];
+// Full shutdown leads: whole-fleet curtailment is the primary operator flow
+// (matches the response-profile default and DeviceSettingsModal ordering).
 const curtailmentModeOptions = [
-  { value: "fixedKwReduction", label: "Fixed kW reduction" },
   { value: "fullFleet", label: "Full shutdown" },
+  { value: "fixedKwReduction", label: "Fixed kW reduction" },
 ];
 const getSiteScopeRowId = (siteId: string) => `site:${siteId}`;
 


### PR DESCRIPTION
Reviewable diff: +7/-3 across 1 file (excludes generated, test, and story files).

## Summary

Whole-fleet curtailment ("Full shutdown") is now the first option in the curtailment-mode dropdown and the default mode when opening the run-curtailment modal, replacing "Fixed kW reduction" as the lead option. Full shutdown is the primary operator flow; fixed-kW sizing stays one click away.

## How it works

The run-curtailment modal and the response-profile create/edit modal share one component (`CurtailmentStartModal`), so a single change covers both surfaces the mode dropdown appears on:

- `curtailmentModeOptions` reordered to list `fullFleet` first.
- The modal's default form values now start in `fullFleet` mode (previously `fixedKwReduction`), so a fresh "New curtailment" opens ready to run a full shutdown with no target input required.

This aligns with the two places that already led with whole-fleet: the response-profile form's default action type (`fullFleet`) and the infra device-settings modal's mode ordering. Saved response profiles, edit mode, and explicit initial values are unaffected — the default only applies to a fresh custom plan.

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/energy/CurtailmentStartModal.tsx` | Option order + default `curtailmentMode` | The whole behavioral change |
| `client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx` | Tests updated to pin the new default; fixed-kW flows now switch mode explicitly | Test — verify the new default is pinned, not just accommodated |

## Key technical decisions & trade-offs

- Default changed along with ordering: a first option that isn't the default would be inconsistent for a dropdown; the empty-state test now pins full-shutdown-by-default (no target input on open).
- Fixed-kW-specific tests switch mode via the dropdown (mirroring how the old tests exercised full shutdown), keeping validation and submission coverage for both modes.

## Testing & validation

- `CurtailmentStartModal.test.tsx`: 58/58 pass, including reworked empty-state, submission, and required-field-validation tests.
- All curtailment-related client tests: 18 files, 444 tests pass. Typecheck clean.
- Not covered: E2E specs run in CI; any that assume the fixed-kW default will surface there.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — client-only display/default change; server request building is untouched (mode is explicit in every start request).