### PR TITLE
test(e2e): add some more straight forward ProtoFleet RBAC coverage

### DIFF
--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -118,8 +118,8 @@ export const test = base.extend<PageFixtures>({
   loginModal: async ({ page, isMobile }, use) => {
     await use(new LoginModalComponent(page, isMobile));
   },
-  commonSteps: async ({ authPage, minersPage }, use) => {
-    await use(new CommonSteps(authPage, minersPage));
+  commonSteps: async ({ authPage, minersPage, settingsPage, settingsTeamPage }, use) => {
+    await use(new CommonSteps(authPage, minersPage, settingsPage, settingsTeamPage));
   },
 });
 

--- a/client/e2eTests/protoFleet/helpers/commonSteps.ts
+++ b/client/e2eTests/protoFleet/helpers/commonSteps.ts
@@ -37,8 +37,14 @@ export class CommonSteps {
     };
   }
 
-  async loginAsAdmin() {
+  async loginAsAdmin({ forceReauth = false }: { forceReauth?: boolean } = {}) {
     await test.step("Login as admin", async () => {
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      if (forceReauth && (await this.authPage.isAlreadyLoggedIn())) {
+        await this.authPage.logout();
+        await this.authPage.validateRedirectedToAuth();
+      }
+
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (await this.authPage.isAlreadyLoggedIn()) {
         return;
@@ -59,7 +65,7 @@ export class CommonSteps {
     const { settingsPage, settingsTeamPage } = this.requireTeamHelpers();
 
     return await test.step("Create a custom role and team member as admin", async () => {
-      await this.loginAsAdmin();
+      await this.loginAsAdmin({ forceReauth: true });
       await settingsPage.navigateToTeamSettings();
       await settingsTeamPage.validateTeamSettingsPageOpened();
       await settingsTeamPage.openRolesTab();

--- a/client/e2eTests/protoFleet/helpers/commonSteps.ts
+++ b/client/e2eTests/protoFleet/helpers/commonSteps.ts
@@ -2,12 +2,40 @@ import { test } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { AuthPage } from "../pages/auth";
 import { MinersPage } from "../pages/miners";
+import { SettingsPage } from "../pages/settings";
+import { SettingsTeamPage } from "../pages/settingsTeam";
+
+type CreateRoleAndMemberOptions = {
+  roleName: string;
+  roleDescription: string;
+  permissionKeys: string[];
+  username: string;
+};
+
+type FirstLoginOptions = {
+  username: string;
+  temporaryPassword: string;
+  newPassword: string;
+};
 
 export class CommonSteps {
   constructor(
     private authPage: AuthPage,
     private minersPage: MinersPage,
+    private settingsPage?: SettingsPage,
+    private settingsTeamPage?: SettingsTeamPage,
   ) {}
+
+  private requireTeamHelpers() {
+    if (!this.settingsPage || !this.settingsTeamPage) {
+      throw new Error("Settings helpers are required for team and role setup flows.");
+    }
+
+    return {
+      settingsPage: this.settingsPage,
+      settingsTeamPage: this.settingsTeamPage,
+    };
+  }
 
   async loginAsAdmin() {
     await test.step("Login as admin", async () => {
@@ -18,6 +46,44 @@ export class CommonSteps {
       await this.authPage.inputUsername(testConfig.users.admin.username);
       await this.authPage.inputPassword(testConfig.users.admin.password);
       await this.authPage.clickLogin();
+      await this.authPage.validateLoggedIn();
+    });
+  }
+
+  async createRoleAndTeamMember({
+    roleName,
+    roleDescription,
+    permissionKeys,
+    username,
+  }: CreateRoleAndMemberOptions): Promise<string> {
+    const { settingsPage, settingsTeamPage } = this.requireTeamHelpers();
+
+    return await test.step("Create a custom role and team member as admin", async () => {
+      await this.loginAsAdmin();
+      await settingsPage.navigateToTeamSettings();
+      await settingsTeamPage.validateTeamSettingsPageOpened();
+      await settingsTeamPage.openRolesTab();
+      await settingsTeamPage.createCustomRole(roleName, roleDescription, permissionKeys);
+      await settingsTeamPage.openMembersTab();
+      return await settingsTeamPage.createTeamMemberAndGetTemporaryPassword(username, roleName);
+    });
+  }
+
+  async completeFirstLoginAsTeamMember({ username, temporaryPassword, newPassword }: FirstLoginOptions) {
+    await test.step("Log in as the new team member and set a permanent password", async () => {
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      if (await this.authPage.isAlreadyLoggedIn()) {
+        await this.authPage.logout();
+        await this.authPage.validateRedirectedToAuth();
+      }
+      await this.authPage.inputUsername(username);
+      await this.authPage.inputPassword(temporaryPassword);
+      await this.authPage.clickLogin();
+      await this.authPage.validateUpdatePasswordTitle();
+      await this.authPage.inputNewPassword(newPassword);
+      await this.authPage.inputConfirmPassword(newPassword);
+      await this.authPage.clickContinue();
+      await this.authPage.clickLoginButton();
       await this.authPage.validateLoggedIn();
     });
   }

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -37,14 +37,18 @@ export const RBAC_CURTAILMENT_SOURCE_PREFIX = "rbac_curtailment_source";
 export const RBAC_CURTAILMENT_REASON_PREFIX = "rbac_curtailment_reason";
 export const RBAC_RACK_ZONE = "RbacZone";
 
+type PersistedAdminStorageState = Exclude<
+  NonNullable<Parameters<Browser["newContext"]>[0]>["storageState"],
+  string | undefined
+>;
+
+type AdminStorageState = {
+  cookies: PersistedAdminStorageState["cookies"];
+  origins: PersistedAdminStorageState["origins"];
+};
+
 const helpersDir = path.dirname(fileURLToPath(import.meta.url));
 const adminStorageStatePath = path.join(helpersDir, "..", "playwright", ".auth", "admin.json");
-type AdminStorageState = {
-  cookies?: Array<unknown>;
-  origins?: Array<{
-    localStorage?: Array<{ name: string; value: string }>;
-  }>;
-};
 
 function loadAdminStorageState(): {
   localStorageEntries: Array<{ name: string; value: string }>;
@@ -58,8 +62,10 @@ function loadAdminStorageState(): {
     };
   } catch (error) {
     if ((error as { code?: string }).code === "ENOENT") {
-      throw new Error(
-        `Missing admin auth state at ${adminStorageStatePath}. Run 02-saveAuthState.spec.ts or the auth setup dependency before RBAC tests that need stored admin context.`,
+      throw Object.assign(
+        new Error(
+          `Missing admin auth state at ${adminStorageStatePath}. Run 02-saveAuthState.spec.ts or the auth setup dependency before RBAC tests that need stored admin context.`,
+        ),
         { cause: error },
       );
     }

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -441,6 +441,8 @@ async function withStoredAdminContext<T>(
     const energyPage = new EnergyPage(page, isMobile);
     const commonSteps = new CommonSteps(authPage, minersPage, settingsPage, settingsTeamPage);
 
+    await commonSteps.loginAsAdmin();
+
     return await callback({
       alertsPage,
       commonSteps,

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -1,0 +1,427 @@
+import { type Browser, type Page, type TestInfo } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { testConfig } from "../config/test.config";
+import { test } from "../fixtures/pageFixtures";
+import { AlertsPage } from "../pages/alerts";
+import { AuthPage } from "../pages/auth";
+import { EnergyPage } from "../pages/energy";
+import { FleetLocationsPage } from "../pages/fleetLocations";
+import { MinersPage } from "../pages/miners";
+import { NewPoolModalPage } from "../pages/newPoolModal";
+import { RacksPage } from "../pages/racks";
+import { SettingsPage } from "../pages/settings";
+import { SettingsCurtailmentPage } from "../pages/settingsCurtailment";
+import { SettingsPoolsPage } from "../pages/settingsPools";
+import { SettingsSchedulesPage } from "../pages/settingsSchedules";
+import { SettingsTeamPage } from "../pages/settingsTeam";
+import { CommonSteps } from "./commonSteps";
+import { installAllSitesInitScript } from "./fleetLocationsSetup";
+import { generateRandomText } from "./testDataHelper";
+
+export const ALERTS_E2E_ENABLED = process.env.E2E_ALERTS_ENABLED === "true";
+export const MEMBER_PASSWORD = "Password123!";
+export const VALID_POOL_URL = "stratum+tcp://mine.ocean.xyz:3334";
+export const REACHABLE_WEBHOOK_URL = "http://otel-collector:13133/healthz";
+export const RBAC_ROLE_PREFIX = "rbac_role";
+export const RBAC_USER_PREFIX = "rbac_user";
+export const RBAC_POOL_PREFIX = "rbac_pool";
+export const RBAC_ALERT_CHANNEL_PREFIX = "rbac_alert_channel";
+export const RBAC_SCHEDULE_PREFIX = "rbac_schedule";
+export const RBAC_SITE_PREFIX = "rbac_site";
+export const RBAC_BUILDING_PREFIX = "rbac_building";
+export const RBAC_RACK_PREFIX = "rbac_rack";
+export const RBAC_CURTAILMENT_PROFILE_PREFIX = "rbac_curtailment_profile";
+export const RBAC_CURTAILMENT_SOURCE_PREFIX = "rbac_curtailment_source";
+export const RBAC_CURTAILMENT_REASON_PREFIX = "rbac_curtailment_reason";
+export const RBAC_RACK_ZONE = "RbacZone";
+
+const helpersDir = path.dirname(fileURLToPath(import.meta.url));
+const adminStorageStatePath = path.join(helpersDir, "..", "playwright", ".auth", "admin.json");
+const adminStorageState = JSON.parse(fs.readFileSync(adminStorageStatePath, "utf8")) as {
+  origins?: Array<{
+    localStorage?: Array<{ name: string; value: string }>;
+  }>;
+};
+const adminLocalStorageEntries = adminStorageState.origins?.flatMap((origin) => origin.localStorage ?? []) ?? [];
+
+type ProvisionedMember = {
+  roleName: string;
+  username: string;
+};
+
+type ProvisionedMemberWithTemporaryPassword = ProvisionedMember & {
+  temporaryPassword: string;
+};
+
+type CleanupPages = {
+  alertsPage: AlertsPage;
+  commonSteps: CommonSteps;
+  energyPage: EnergyPage;
+  fleetLocationsPage: FleetLocationsPage;
+  page: Page;
+  racksPage: RacksPage;
+  settingsPage: SettingsPage;
+  settingsCurtailmentPage: SettingsCurtailmentPage;
+  settingsPoolsPage: SettingsPoolsPage;
+  settingsSchedulesPage: SettingsSchedulesPage;
+  settingsTeamPage: SettingsTeamPage;
+};
+
+export function useRbacHooks() {
+  test.beforeEach(async ({ page }) => {
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+  });
+
+  test.afterEach("CLEANUP: delete RBAC fixtures", async ({ browser }, testInfo) => {
+    await cleanupRbacArtifacts(browser, testInfo).catch(() => undefined);
+  });
+}
+
+export async function provisionRoleAndLogin(
+  commonSteps: CommonSteps,
+  {
+    permissionKeys,
+    roleDescription,
+  }: {
+    permissionKeys: string[];
+    roleDescription: string;
+  },
+): Promise<ProvisionedMember> {
+  const roleName = generateRandomText(RBAC_ROLE_PREFIX);
+  const username = generateRandomText(RBAC_USER_PREFIX);
+
+  const temporaryPassword = await commonSteps.createRoleAndTeamMember({
+    roleName,
+    roleDescription,
+    permissionKeys,
+    username,
+  });
+
+  await commonSteps.completeFirstLoginAsTeamMember({
+    username,
+    temporaryPassword,
+    newPassword: MEMBER_PASSWORD,
+  });
+
+  return { roleName, username };
+}
+
+export async function provisionRoleViaStoredAdminContext(
+  browser: Browser,
+  testInfo: TestInfo,
+  {
+    permissionKeys,
+    roleDescription,
+  }: {
+    permissionKeys: string[];
+    roleDescription: string;
+  },
+): Promise<ProvisionedMemberWithTemporaryPassword> {
+  return await withStoredAdminContext(browser, testInfo, async ({ commonSteps }) => {
+    const roleName = generateRandomText(RBAC_ROLE_PREFIX);
+    const username = generateRandomText(RBAC_USER_PREFIX);
+
+    const temporaryPassword = await commonSteps.createRoleAndTeamMember({
+      roleName,
+      roleDescription,
+      permissionKeys,
+      username,
+    });
+
+    return { roleName, temporaryPassword, username };
+  });
+}
+
+export async function createPool(
+  settingsPage: SettingsPage,
+  settingsPoolsPage: SettingsPoolsPage,
+  newPoolModal: NewPoolModalPage,
+  {
+    poolName,
+    poolUsername,
+  }: {
+    poolName: string;
+    poolUsername: string;
+  },
+) {
+  await test.step(`Create pool "${poolName}"`, async () => {
+    await settingsPage.navigateToMiningPoolsSettings();
+    await settingsPoolsPage.validateMiningPoolsPageOpened();
+    await settingsPoolsPage.clickAddPool();
+    await newPoolModal.validatePoolModalOpened();
+    await newPoolModal.inputPoolName(poolName);
+    await newPoolModal.inputPoolUrl(VALID_POOL_URL);
+    await newPoolModal.inputPoolUsername(poolUsername);
+    await newPoolModal.clickSaveNewPool();
+    await settingsPoolsPage.validateTextInToast("Pool added");
+    await settingsPoolsPage.validatePoolEntryByUniqueName(poolName, VALID_POOL_URL, poolUsername);
+  });
+}
+
+export async function createAlertChannelAsAdmin(alertsPage: AlertsPage, channelName: string) {
+  await test.step(`Create alerts channel "${channelName}" as admin`, async () => {
+    await alertsPage.navigateToAlertsSettings();
+    await alertsPage.validateAlertsPageOpened();
+    await alertsPage.openAddChannelModal();
+    await alertsPage.fillWebhookChannel(channelName, REACHABLE_WEBHOOK_URL);
+    await alertsPage.saveChannel();
+    await alertsPage.validateChannelListed(channelName);
+  });
+}
+
+export async function createSchedule(settingsSchedulesPage: SettingsSchedulesPage, scheduleName: string) {
+  await test.step(`Create schedule "${scheduleName}"`, async () => {
+    await settingsSchedulesPage.navigateToSchedulesSettings();
+    await settingsSchedulesPage.validateSchedulesPageOpened();
+    await settingsSchedulesPage.clickAddSchedule();
+    await settingsSchedulesPage.inputScheduleName(scheduleName);
+    await settingsSchedulesPage.selectStartDate(1);
+    await settingsSchedulesPage.openMinersTargetSelector();
+    await settingsSchedulesPage.waitForMinerSelectionModalToLoad();
+    await settingsSchedulesPage.selectFirstMiners(1);
+    await settingsSchedulesPage.confirmMinerSelection();
+    await settingsSchedulesPage.clickSaveSchedule();
+    await settingsSchedulesPage.validateScheduleVisible(scheduleName);
+  });
+}
+
+export async function createInfrastructureFixturesAsAdmin(
+  fleetLocationsPage: FleetLocationsPage,
+  racksPage: RacksPage,
+  {
+    siteName,
+    buildingName,
+    rackLabel,
+  }: {
+    siteName: string;
+    buildingName: string;
+    rackLabel: string;
+  },
+) {
+  await test.step("Create site, building, and rack as admin", async () => {
+    await fleetLocationsPage.createSite(siteName);
+    await fleetLocationsPage.createBuilding(siteName, buildingName);
+    await createRack(racksPage, rackLabel);
+  });
+}
+
+export async function createRack(racksPage: RacksPage, rackLabel: string) {
+  await test.step(`Create rack "${rackLabel}"`, async () => {
+    await racksPage.navigateToRacksPage();
+    await racksPage.clickAddRackButton();
+    await racksPage.inputZone(RBAC_RACK_ZONE);
+    await racksPage.inputRackLabel(rackLabel);
+    await racksPage.enableCustomRackLayout();
+    await racksPage.inputColumns(2);
+    await racksPage.inputRows(2);
+    await racksPage.clickContinueFromRackSettings();
+    await racksPage.clickSaveRack();
+    await racksPage.validateRackToast(rackLabel);
+    await racksPage.clickViewList();
+    await racksPage.waitForRackListToLoad({ allowEmpty: false });
+    await racksPage.validateRackRow(rackLabel, RBAC_RACK_ZONE, 0);
+  });
+}
+
+export async function createCurtailment(energyPage: EnergyPage, reason: string) {
+  await test.step(`Create curtailment "${reason}"`, async () => {
+    await energyPage.navigateToEnergyPage();
+    await energyPage.validateEnergyPageOpened();
+    await energyPage.openCurtailmentPlanner();
+    await energyPage.fillCurtailmentPlan({
+      reason,
+      targetKw: "1",
+      restoreBatchIntervalSec: "60",
+    });
+    await energyPage.waitForPreview("1");
+    await energyPage.startCurtailment();
+    await energyPage.validateActiveCurtailment(reason);
+  });
+}
+
+export async function invokeIngestCurtailmentSignal(page: Page, externalReference: string) {
+  return await test.step("Call IngestCurtailmentSignal with the current logged-in user", async () => {
+    return await page.evaluate(
+      async ({ externalReference }) => {
+        const response = await fetch("/api-proxy/curtailment.v1.CurtailmentService/IngestCurtailmentSignal", {
+          method: "POST",
+          headers: {
+            "Connect-Protocol-Version": "1",
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify({
+            externalSource: "rbac-e2e",
+            externalReference,
+            signalPayload: btoa(JSON.stringify({ dispatch_id: externalReference })),
+            reason: "rbac ingest test",
+          }),
+        });
+
+        return {
+          body: await response.text(),
+          ok: response.ok,
+          status: response.status,
+        };
+      },
+      { externalReference },
+    );
+  });
+}
+
+async function cleanupRbacArtifacts(browser: Browser, testInfo: TestInfo) {
+  await withStoredAdminContext(
+    browser,
+    testInfo,
+    async ({
+      alertsPage,
+      energyPage,
+      fleetLocationsPage,
+      page,
+      racksPage,
+      settingsCurtailmentPage,
+      settingsPoolsPage,
+      settingsSchedulesPage,
+      settingsTeamPage,
+    }) => {
+      await energyPage.cleanupStartedCurtailmentsByReasonPrefix(RBAC_CURTAILMENT_REASON_PREFIX).catch(() => undefined);
+
+      await page.goto("/settings/curtailment");
+      if (
+        await page
+          .getByRole("button", { name: "Add source", exact: true })
+          .isVisible()
+          .catch(() => false)
+      ) {
+        await settingsCurtailmentPage.deleteSourcesByPrefix(RBAC_CURTAILMENT_SOURCE_PREFIX).catch(() => undefined);
+        await settingsCurtailmentPage
+          .deleteResponseProfilesByPrefix(RBAC_CURTAILMENT_PROFILE_PREFIX)
+          .catch(() => undefined);
+      }
+
+      await page.goto("/settings/schedules");
+      if (
+        await page
+          .getByRole("button", { name: "Add a schedule", exact: true })
+          .isVisible()
+          .catch(() => false)
+      ) {
+        await settingsSchedulesPage.deleteSchedulesByPrefix(RBAC_SCHEDULE_PREFIX).catch(() => undefined);
+      }
+
+      if (ALERTS_E2E_ENABLED) {
+        await page.goto("/settings/alerts");
+        if (
+          await page
+            .getByRole("button", { name: "Add channel", exact: true })
+            .isVisible()
+            .catch(() => false)
+        ) {
+          await alertsPage.deleteChannelsByPrefix(RBAC_ALERT_CHANNEL_PREFIX).catch(() => undefined);
+        }
+      }
+
+      await page.goto("/settings/mining-pools");
+      if (
+        await page
+          .getByRole("button", { name: "Add pool", exact: true })
+          .isVisible()
+          .catch(() => false)
+      ) {
+        await settingsPoolsPage.deletePoolsByPrefix(RBAC_POOL_PREFIX).catch(() => undefined);
+      }
+
+      await cleanupInfrastructureFixtures(fleetLocationsPage, racksPage).catch(() => undefined);
+
+      await page.goto("/settings/team");
+      if (
+        await page
+          .getByRole("button", { name: "Create role", exact: true })
+          .isVisible()
+          .catch(() => false)
+      ) {
+        await settingsTeamPage.deactivateMembersByPrefix(RBAC_USER_PREFIX).catch(() => undefined);
+        await settingsTeamPage.deleteRolesByPrefix(RBAC_ROLE_PREFIX).catch(() => undefined);
+      }
+    },
+  );
+}
+
+async function cleanupInfrastructureFixtures(fleetLocationsPage: FleetLocationsPage, racksPage: RacksPage) {
+  await racksPage.navigateToRacksPage();
+  await racksPage.tryAction(() => racksPage.clickViewList());
+  await racksPage.waitForRackListToLoad();
+
+  const rackNames = (await racksPage.listRackNames()).filter((name) => name.startsWith(RBAC_RACK_PREFIX));
+  for (const rackName of rackNames) {
+    await racksPage.deleteRackByLabelIfVisible(rackName);
+  }
+
+  const buildingNames = (await fleetLocationsPage.listBuildingNames()).filter((name) =>
+    name.startsWith(RBAC_BUILDING_PREFIX),
+  );
+  for (const buildingName of buildingNames) {
+    await fleetLocationsPage.deleteBuildingByNameIfVisible(buildingName);
+  }
+
+  const siteNames = (await fleetLocationsPage.listSiteNames()).filter((name) => name.startsWith(RBAC_SITE_PREFIX));
+  for (const siteName of siteNames) {
+    await fleetLocationsPage.deleteSiteByNameIfVisible(siteName);
+  }
+}
+
+async function withStoredAdminContext<T>(
+  browser: Browser,
+  testInfo: TestInfo,
+  callback: (pages: CleanupPages) => Promise<T>,
+): Promise<T> {
+  const isMobile = testInfo.project.use?.isMobile ?? false;
+  const context = await browser.newContext({
+    baseURL: testConfig.baseUrl,
+    storageState: adminStorageStatePath,
+    viewport: testInfo.project.use?.viewport,
+  });
+
+  try {
+    const page = await context.newPage();
+    await page.addInitScript((entries: Array<{ name: string; value: string }>) => {
+      for (const entry of entries) {
+        localStorage.setItem(entry.name, entry.value);
+      }
+    }, adminLocalStorageEntries);
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+
+    const authPage = new AuthPage(page, isMobile);
+    const minersPage = new MinersPage(page, isMobile);
+    const settingsPage = new SettingsPage(page, isMobile);
+    const settingsTeamPage = new SettingsTeamPage(page, isMobile);
+    const settingsPoolsPage = new SettingsPoolsPage(page, isMobile);
+    const settingsSchedulesPage = new SettingsSchedulesPage(page, isMobile);
+    const settingsCurtailmentPage = new SettingsCurtailmentPage(page, isMobile);
+    const alertsPage = new AlertsPage(page, isMobile);
+    const fleetLocationsPage = new FleetLocationsPage(page, isMobile);
+    const racksPage = new RacksPage(page, isMobile);
+    const energyPage = new EnergyPage(page, isMobile);
+    const commonSteps = new CommonSteps(authPage, minersPage, settingsPage, settingsTeamPage);
+
+    return await callback({
+      alertsPage,
+      commonSteps,
+      energyPage,
+      fleetLocationsPage,
+      page,
+      racksPage,
+      settingsCurtailmentPage,
+      settingsPage,
+      settingsPoolsPage,
+      settingsSchedulesPage,
+      settingsTeamPage,
+    });
+  } finally {
+    await context.close();
+  }
+}

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -39,12 +39,34 @@ export const RBAC_RACK_ZONE = "RbacZone";
 
 const helpersDir = path.dirname(fileURLToPath(import.meta.url));
 const adminStorageStatePath = path.join(helpersDir, "..", "playwright", ".auth", "admin.json");
-const adminStorageState = JSON.parse(fs.readFileSync(adminStorageStatePath, "utf8")) as {
+type AdminStorageState = {
+  cookies?: Array<unknown>;
   origins?: Array<{
     localStorage?: Array<{ name: string; value: string }>;
   }>;
 };
-const adminLocalStorageEntries = adminStorageState.origins?.flatMap((origin) => origin.localStorage ?? []) ?? [];
+
+function loadAdminStorageState(): {
+  localStorageEntries: Array<{ name: string; value: string }>;
+  storageState: AdminStorageState;
+} {
+  try {
+    const storageState = JSON.parse(fs.readFileSync(adminStorageStatePath, "utf8")) as AdminStorageState;
+    return {
+      localStorageEntries: storageState.origins?.flatMap((origin) => origin.localStorage ?? []) ?? [],
+      storageState,
+    };
+  } catch (error) {
+    if ((error as { code?: string }).code === "ENOENT") {
+      throw new Error(
+        `Missing admin auth state at ${adminStorageStatePath}. Run 02-saveAuthState.spec.ts or the auth setup dependency before RBAC tests that need stored admin context.`,
+        { cause: error },
+      );
+    }
+
+    throw error;
+  }
+}
 
 type ProvisionedMember = {
   roleName: string;
@@ -76,7 +98,7 @@ export function useRbacHooks() {
   });
 
   test.afterEach("CLEANUP: delete RBAC fixtures", async ({ browser }, testInfo) => {
-    await cleanupRbacArtifacts(browser, testInfo).catch(() => undefined);
+    await cleanupRbacArtifacts(browser, testInfo);
   });
 }
 
@@ -227,6 +249,10 @@ export async function createRack(racksPage: RacksPage, rackLabel: string) {
 }
 
 export async function createCurtailment(energyPage: EnergyPage, reason: string) {
+  if (testConfig.target === "real") {
+    throw new Error("RBAC curtailment setup is only supported against fake targets.");
+  }
+
   await test.step(`Create curtailment "${reason}"`, async () => {
     await energyPage.navigateToEnergyPage();
     await energyPage.validateEnergyPageOpened();
@@ -379,9 +405,10 @@ async function withStoredAdminContext<T>(
   callback: (pages: CleanupPages) => Promise<T>,
 ): Promise<T> {
   const isMobile = testInfo.project.use?.isMobile ?? false;
+  const { localStorageEntries, storageState } = loadAdminStorageState();
   const context = await browser.newContext({
     baseURL: testConfig.baseUrl,
-    storageState: adminStorageStatePath,
+    storageState,
     viewport: testInfo.project.use?.viewport,
   });
 
@@ -391,7 +418,7 @@ async function withStoredAdminContext<T>(
       for (const entry of entries) {
         localStorage.setItem(entry.name, entry.value);
       }
-    }, adminLocalStorageEntries);
+    }, localStorageEntries);
     await installAllSitesInitScript(page);
     await page.goto("/");
 

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -370,12 +370,19 @@ async function cleanupRbacArtifacts(browser: Browser, testInfo: TestInfo) {
 
       await page.goto("/settings/team");
       if (
-        await page
-          .getByRole("button", { name: "Create role", exact: true })
-          .isVisible()
+        await settingsTeamPage
+          .openMembersTab()
+          .then(() => true)
           .catch(() => false)
       ) {
         await settingsTeamPage.deactivateMembersByPrefix(RBAC_USER_PREFIX).catch(() => undefined);
+      }
+      if (
+        await settingsTeamPage
+          .openRolesTab()
+          .then(() => true)
+          .catch(() => false)
+      ) {
         await settingsTeamPage.deleteRolesByPrefix(RBAC_ROLE_PREFIX).catch(() => undefined);
       }
     },

--- a/client/e2eTests/protoFleet/pages/alerts.ts
+++ b/client/e2eTests/protoFleet/pages/alerts.ts
@@ -13,6 +13,15 @@ export class AlertsPage extends BasePage {
     super(page, isMobile);
   }
 
+  async validateAlertsPageOpened() {
+    await expect(this.page).toHaveURL(/.*\/settings\/alerts/);
+    await this.validateTitle("Alerts");
+  }
+
+  async validateAddChannelHidden() {
+    await expect(this.page.getByRole("button", { name: "Add channel", exact: true })).toHaveCount(0);
+  }
+
   async openAddChannelModal() {
     await this.page.getByRole("button", { name: "Add channel" }).click();
     await this.validateModalIsOpen();

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -333,8 +333,11 @@ export class BasePage {
   }
 
   async logout() {
-    await this.clickNavigationMenuIfMobile();
-    await this.page.getByTestId("logout-button").click();
+    const logoutButton = this.page.getByTestId("logout-button");
+    if (!(await logoutButton.isVisible().catch(() => false))) {
+      await this.clickNavigationMenuIfMobile();
+    }
+    await logoutButton.click();
   }
 
   async validateTitle(expectedTitle: string) {

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -4,6 +4,7 @@ import { BasePage } from "./base";
 
 const stopRequestPattern = /StopCurtailment/;
 const restoreReconciliationTimeout = DEFAULT_TIMEOUT * 4;
+const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 export interface CurtailmentCleanupTarget {
   reason: string;
@@ -200,6 +201,7 @@ export class EnergyPage extends BasePage {
     await expect(this.page).toHaveURL(/.*\/energy/);
 
     const reasons = new Set<string>();
+    const activeReasonPattern = new RegExp(`(${escapeRegex(prefix)}.*?)(?=\\s+\\(Applies to )`);
 
     const activeCurtailmentSections = this.page
       .getByTestId("active-curtailment-primary-lockup")
@@ -207,11 +209,9 @@ export class EnergyPage extends BasePage {
 
     for (const activeCurtailmentSection of await activeCurtailmentSections.all()) {
       const text = (await activeCurtailmentSection.textContent()) ?? "";
-      for (const line of text.split("\n")) {
-        const trimmed = line.trim();
-        if (trimmed.startsWith(prefix) && trimmed.includes(" (Applies to ")) {
-          reasons.add(trimmed.replace(/\s+\(Applies to .*$/, ""));
-        }
+      const activeReasonMatch = text.match(activeReasonPattern);
+      if (activeReasonMatch?.[1]) {
+        reasons.add(activeReasonMatch[1].trim());
       }
     }
 

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -201,12 +201,16 @@ export class EnergyPage extends BasePage {
 
     const reasons = new Set<string>();
 
-    for (const activeLockup of await this.page.getByTestId("active-curtailment-primary-lockup").all()) {
-      const text = (await activeLockup.textContent()) ?? "";
+    const activeCurtailmentSections = this.page
+      .getByTestId("active-curtailment-primary-lockup")
+      .locator("xpath=ancestor::section[1]");
+
+    for (const activeCurtailmentSection of await activeCurtailmentSections.all()) {
+      const text = (await activeCurtailmentSection.textContent()) ?? "";
       for (const line of text.split("\n")) {
         const trimmed = line.trim();
-        if (trimmed.startsWith(prefix)) {
-          reasons.add(trimmed);
+        if (trimmed.startsWith(prefix) && trimmed.includes(" (Applies to ")) {
+          reasons.add(trimmed.replace(/\s+\(Applies to .*$/, ""));
         }
       }
     }

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -199,21 +199,31 @@ export class EnergyPage extends BasePage {
     await this.page.goto("/energy");
     await expect(this.page).toHaveURL(/.*\/energy/);
 
-    const reasons = await this.page
-      .locator('[data-testid="active-curtailment-primary-lockup"], [data-testid^="curtailment-history-row-"]')
-      .evaluateAll((elements, expectedPrefix) => {
-        const matches = new Set<string>();
-        for (const element of elements) {
-          const text = element.textContent ?? "";
-          for (const line of text.split("\n")) {
-            const trimmed = line.trim();
-            if (trimmed.startsWith(expectedPrefix)) {
-              matches.add(trimmed);
-            }
-          }
+    const reasons = new Set<string>();
+
+    for (const activeLockup of await this.page.getByTestId("active-curtailment-primary-lockup").all()) {
+      const text = (await activeLockup.textContent()) ?? "";
+      for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith(prefix)) {
+          reasons.add(trimmed);
         }
-        return [...matches];
-      }, prefix);
+      }
+    }
+
+    const stoppableHistoryRows = this.page
+      .locator('[data-testid^="curtailment-history-row-"]')
+      .filter({ has: this.page.getByRole("button", { name: /^Stop / }) });
+
+    for (const historyRow of await stoppableHistoryRows.all()) {
+      const text = (await historyRow.textContent()) ?? "";
+      for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith(prefix)) {
+          reasons.add(trimmed);
+        }
+      }
+    }
 
     for (const reason of reasons) {
       await this.cleanupStartedCurtailment({ reason });

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -26,6 +26,10 @@ export class EnergyPage extends BasePage {
     await this.validateTitle("Curtailment history");
   }
 
+  async validateRunCurtailmentButtonHidden() {
+    await expect(this.page.getByRole("button", { name: "Run curtailment", exact: true })).toHaveCount(0);
+  }
+
   async openCurtailmentPlanner() {
     await this.clickButton("Run curtailment");
     await expect(this.page.getByTestId("full-screen-two-pane-modal").getByText("New curtailment")).toBeVisible();
@@ -95,6 +99,15 @@ export class EnergyPage extends BasePage {
     await expect(activeCurtailmentSection.getByTestId("active-curtailment-primary-lockup")).toContainText(
       /Pending|Curtailing|Curtailed/,
     );
+  }
+
+  async validateActiveCurtailmentManageActionsHidden(reason: string) {
+    const activeCurtailmentSection = this.activeCurtailmentSection(reason);
+    await expect(activeCurtailmentSection).toBeVisible();
+    await expect(activeCurtailmentSection.getByRole("button", { name: "Edit", exact: true })).toHaveCount(0);
+    await expect(activeCurtailmentSection.getByRole("button", { name: "Stop", exact: true })).toHaveCount(0);
+    await expect(activeCurtailmentSection.getByRole("button", { name: "Restore", exact: true })).toHaveCount(0);
+    await expect(activeCurtailmentSection.getByRole("button", { name: "Restore now", exact: true })).toHaveCount(0);
   }
 
   async validateCurtailmentHistoryRow(reason: string) {
@@ -179,6 +192,31 @@ export class EnergyPage extends BasePage {
 
     if (await this.hasMatchingActiveCurtailment(target.reason)) {
       await this.waitForCurtailmentToRestore(target);
+    }
+  }
+
+  async cleanupStartedCurtailmentsByReasonPrefix(prefix: string) {
+    await this.page.goto("/energy");
+    await expect(this.page).toHaveURL(/.*\/energy/);
+
+    const reasons = await this.page
+      .locator('[data-testid="active-curtailment-primary-lockup"], [data-testid^="curtailment-history-row-"]')
+      .evaluateAll((elements, expectedPrefix) => {
+        const matches = new Set<string>();
+        for (const element of elements) {
+          const text = element.textContent ?? "";
+          for (const line of text.split("\n")) {
+            const trimmed = line.trim();
+            if (trimmed.startsWith(expectedPrefix)) {
+              matches.add(trimmed);
+            }
+          }
+        }
+        return [...matches];
+      }, prefix);
+
+    for (const reason of reasons) {
+      await this.cleanupStartedCurtailment({ reason });
     }
   }
 

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -278,6 +278,18 @@ export class FleetLocationsPage extends BasePage {
     await expect(this.getListRowByName(name)).toHaveCount(0);
   }
 
+  async validateAddSiteButtonHidden() {
+    await this.navigateToSitesPage();
+    await expect(this.page.getByTestId("fleet-sites-add")).toHaveCount(0);
+    await expect(this.page.getByRole("button", { name: "Add a site", exact: true })).toHaveCount(0);
+  }
+
+  async validateAddBuildingButtonHidden() {
+    await this.navigateToBuildingsPage();
+    await expect(this.page.getByTestId("fleet-buildings-add")).toHaveCount(0);
+    await expect(this.page.getByRole("button", { name: "Add building", exact: true })).toHaveCount(0);
+  }
+
   async deleteSite(name: string) {
     await this.navigateToSitesPage();
     await this.openRowActions(name);

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -17,6 +17,10 @@ export class RacksPage extends BasePage {
     await this.validateTitle("Fleet");
   }
 
+  async validateAddRackButtonHidden() {
+    await expect(this.page.getByRole("button", { name: "Add rack", exact: true })).toHaveCount(0);
+  }
+
   async clickAddRackButton() {
     await this.clickButton("Add rack");
     await this.validateTitleInModal("Rack settings");

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -367,8 +367,16 @@ export class RacksPage extends BasePage {
     await expect(popover).toBeHidden();
   }
 
-  async waitForRackListToLoad({ allowEmpty = true }: { allowEmpty?: boolean } = {}) {
-    await expect(this.page.getByRole("button", { name: "Add rack" }).first()).toBeVisible();
+  async waitForRackListToLoad({
+    allowEmpty = true,
+    requireManageAccess = true,
+  }: {
+    allowEmpty?: boolean;
+    requireManageAccess?: boolean;
+  } = {}) {
+    if (requireManageAccess) {
+      await expect(this.page.getByRole("button", { name: "Add rack" }).first()).toBeVisible();
+    }
 
     const rows = this.page.getByTestId("list-row");
     const noRowsText = this.page.getByText("You haven't set up any racks");

--- a/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
+++ b/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
@@ -21,6 +21,10 @@ export type CurtailmentSourceFormInput = {
 };
 
 export class SettingsCurtailmentPage extends BasePage {
+  async validateCurtailmentSubmenuHidden() {
+    await expect(this.page.getByTestId("secondary-nav").locator('a[href="/settings/curtailment"]')).toBeHidden();
+  }
+
   async validateCurtailmentPageOpened() {
     await expect(this.page).toHaveURL(/.*\/settings\/curtailment/);
     await expect(this.page.getByTestId("settings-curtailment-page")).toBeVisible();

--- a/client/e2eTests/protoFleet/pages/settingsPools.ts
+++ b/client/e2eTests/protoFleet/pages/settingsPools.ts
@@ -9,6 +9,10 @@ export class SettingsPoolsPage extends BasePage {
       .first();
   }
 
+  async validateMiningPoolsSubmenuHidden() {
+    await expect(this.page.getByTestId("secondary-nav").locator('a[href="/settings/mining-pools"]')).toBeHidden();
+  }
+
   async validateMiningPoolsPageOpened() {
     await expect(this.page).toHaveURL(/.*\/mining-pools/);
     await this.validateButtonIsVisible("Add pool");
@@ -47,5 +51,21 @@ export class SettingsPoolsPage extends BasePage {
       await expect(poolRows).toHaveCount(poolCount - 1 - i);
     }
     await expect(poolRows).toHaveCount(0);
+  }
+
+  async deletePoolsByPrefix(prefix: string) {
+    const poolRows = await this.page.getByTestId("pool-row").all();
+    const poolNamesToDelete: string[] = [];
+
+    for (const row of poolRows) {
+      const poolName = (await row.getByTestId("pool-name").textContent())?.trim();
+      if (poolName?.startsWith(prefix)) {
+        poolNamesToDelete.push(poolName);
+      }
+    }
+
+    for (const poolName of poolNamesToDelete) {
+      await this.deletePoolByNameIfVisible(poolName);
+    }
   }
 }

--- a/client/e2eTests/protoFleet/pages/settingsSchedules.ts
+++ b/client/e2eTests/protoFleet/pages/settingsSchedules.ts
@@ -6,6 +6,10 @@ import { ModalMinerSelectionList } from "./components/modalMinerSelectionList";
 export class SettingsSchedulesPage extends BasePage {
   private readonly modalMinerList = new ModalMinerSelectionList(this.page.getByTestId("modal"));
 
+  async validateSchedulesSubmenuHidden() {
+    await expect(this.page.getByTestId("secondary-nav").locator('a[href="/settings/schedules"]')).toBeHidden();
+  }
+
   async validateSchedulesPageOpened() {
     await expect(this.page).toHaveURL(/.*\/settings\/schedules/);
     await this.validateTitle("Schedules");

--- a/client/e2eTests/protoFleet/pages/settingsTeam.ts
+++ b/client/e2eTests/protoFleet/pages/settingsTeam.ts
@@ -2,6 +2,28 @@ import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
 export class SettingsTeamPage extends BasePage {
+  private memberRow(username: string) {
+    return this.page
+      .getByTestId("list-body")
+      .locator("tr")
+      .filter({
+        has: this.page.getByTestId("username").getByText(username, { exact: true }),
+      });
+  }
+
+  private roleRow(roleName: string) {
+    return this.page
+      .getByTestId("list-body")
+      .locator("tr")
+      .filter({
+        has: this.page.getByTestId("name").getByText(roleName, { exact: true }),
+      });
+  }
+
+  private sanitizePermissionKey(permissionKey: string) {
+    return permissionKey.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+  }
+
   async validateTeamSettingsPageOpened() {
     await expect(this.page).toHaveURL(/.*\/team/);
     await this.validateTitle("Team");
@@ -13,6 +35,24 @@ export class SettingsTeamPage extends BasePage {
 
   async clickAddTeamMember() {
     await this.clickButton("Add team member");
+  }
+
+  async openMembersTab() {
+    const activateButton = this.page.getByTestId("team-tab-members-activate");
+    if (await activateButton.isVisible().catch(() => false)) {
+      await activateButton.click();
+    }
+
+    await expect(this.page.getByRole("button", { name: "Add team member", exact: true })).toBeVisible();
+  }
+
+  async openRolesTab() {
+    const activateButton = this.page.getByTestId("team-tab-roles-activate");
+    if (await activateButton.isVisible().catch(() => false)) {
+      await activateButton.click();
+    }
+
+    await expect(this.page.getByRole("button", { name: "Create role", exact: true })).toBeVisible();
   }
 
   async inputMemberUsername(username: string) {
@@ -32,6 +72,19 @@ export class SettingsTeamPage extends BasePage {
     await this.pickRoleFromOpenModal(roleLabel);
   }
 
+  async createTeamMemberAndGetTemporaryPassword(username: string, roleLabel: string) {
+    await this.clickAddTeamMember();
+    await this.inputMemberUsername(username);
+    await this.selectMemberRole(roleLabel);
+    await this.clickSaveTeamMember();
+    await this.validateMemberAdded();
+
+    const temporaryPassword = await this.getTemporaryPassword();
+    await this.clickDone();
+    await this.validateMemberVisible(username);
+    return temporaryPassword;
+  }
+
   async clickSaveTeamMember() {
     await this.clickButton("Save");
   }
@@ -49,23 +102,11 @@ export class SettingsTeamPage extends BasePage {
   }
 
   async validateMemberRole(username: string, role: string) {
-    const memberRow = this.page
-      .getByTestId("list-body")
-      .locator("tr")
-      .filter({
-        has: this.page.locator(`//td[@data-testid='username']//*[text()='${username}']`),
-      });
-    await expect(memberRow.locator(`//td[@data-testid='role']`)).toHaveText(role);
+    await expect(this.memberRow(username).getByTestId("role")).toHaveText(role);
   }
 
   async validateMemberLastLogin(username: string, lastLogin: string) {
-    const memberRow = this.page
-      .getByTestId("list-body")
-      .locator("tr")
-      .filter({
-        has: this.page.locator(`//td[@data-testid='username']//*[text()='${username}']`),
-      });
-    await expect(memberRow.locator(`//td[@data-testid='lastLoginAt']`)).toHaveText(lastLogin);
+    await expect(this.memberRow(username).getByTestId("lastLoginAt")).toHaveText(lastLogin);
   }
 
   async getTemporaryPassword(): Promise<string> {
@@ -73,7 +114,7 @@ export class SettingsTeamPage extends BasePage {
   }
 
   async validateMemberVisible(username: string) {
-    await expect(this.page.locator(`//td[@data-testid='username']//*[text()='${username}']`)).toBeVisible();
+    await expect(this.memberRow(username)).toBeVisible();
   }
 
   // FIELD_TECH (and any role without user:read) doesn't see the Team
@@ -84,14 +125,104 @@ export class SettingsTeamPage extends BasePage {
     await expect(this.page.getByTestId("secondary-nav").locator('a[href="/settings/team"]')).toBeHidden();
   }
 
+  async clickCreateRole() {
+    await this.clickButton("Create role");
+  }
+
+  async inputRoleName(roleName: string) {
+    await this.page.locator("#role-name").fill(roleName);
+  }
+
+  async inputRoleDescription(description: string) {
+    await this.page.locator("#role-description").fill(description);
+  }
+
+  async selectRolePermission(permissionKey: string) {
+    await this.page.getByTestId("role-permission-search").fill(permissionKey);
+
+    const permissionRow = this.page.getByTestId(`role-permission-${this.sanitizePermissionKey(permissionKey)}`);
+    await expect(permissionRow).toBeVisible();
+
+    const checkbox = permissionRow.getByRole("checkbox");
+    if (!(await checkbox.isChecked())) {
+      await permissionRow.click();
+    }
+  }
+
+  async clickCreateRoleConfirm() {
+    await this.page.getByTestId("modal").getByRole("button", { name: "Create role", exact: true }).click();
+  }
+
+  async createCustomRole(roleName: string, description: string, permissionKeys: string[]) {
+    await this.clickCreateRole();
+    await this.inputRoleName(roleName);
+    await this.inputRoleDescription(description);
+
+    for (const permissionKey of permissionKeys) {
+      await this.selectRolePermission(permissionKey);
+    }
+
+    await this.page.getByTestId("role-permission-search").clear();
+    await this.clickCreateRoleConfirm();
+    await expect(this.page.getByTestId("modal")).toBeHidden();
+    await this.validateRoleVisible(roleName);
+  }
+
+  async validateRoleVisible(roleName: string) {
+    await expect(this.roleRow(roleName)).toBeVisible();
+  }
+
+  async deactivateMembersByPrefix(usernamePrefix: string) {
+    await this.openMembersTab();
+    const memberRows = await this.page.getByTestId("list-row").all();
+    const usernamesToDeactivate: string[] = [];
+
+    for (const row of memberRows) {
+      const usernameElement = row.getByTestId("username").locator("span");
+      const username = (await usernameElement.textContent())?.trim();
+      if (username?.startsWith(usernamePrefix)) {
+        usernamesToDeactivate.push(username);
+      }
+    }
+
+    for (const username of usernamesToDeactivate) {
+      await this.clickMemberActionsMenu(username);
+      await this.clickDeactivate();
+      await this.clickConfirmDeactivation();
+      await this.validateMemberNotInList(username);
+    }
+  }
+
+  async deleteRolesByPrefix(rolePrefix: string) {
+    await this.openRolesTab();
+    const roleRows = await this.page.getByTestId("list-row").all();
+    const roleNamesToDelete: string[] = [];
+
+    for (const row of roleRows) {
+      const roleName = (
+        await row
+          .getByTestId("name")
+          .getByText(new RegExp(`^${rolePrefix}`))
+          .textContent()
+          .catch(() => null)
+      )?.trim();
+      if (roleName?.startsWith(rolePrefix)) {
+        roleNamesToDelete.push(roleName);
+      }
+    }
+
+    for (const roleName of roleNamesToDelete) {
+      const row = this.roleRow(roleName);
+      await expect(row).toBeVisible();
+      await row.getByTestId("list-actions-trigger").click();
+      await this.clickButton("Delete");
+      await this.clickButton("Delete role");
+      await expect(this.roleRow(roleName)).toBeHidden();
+    }
+  }
+
   async clickMemberActionsMenu(username: string) {
-    const memberRow = this.page
-      .getByTestId("list-body")
-      .locator("tr")
-      .filter({
-        has: this.page.locator(`//td[@data-testid='username']//*[text()='${username}']`),
-      });
-    await memberRow.getByTestId("list-actions-trigger").click();
+    await this.memberRow(username).getByTestId("list-actions-trigger").click();
   }
 
   async clickResetPassword() {
@@ -134,6 +265,6 @@ export class SettingsTeamPage extends BasePage {
   }
 
   async validateMemberNotInList(username: string) {
-    await expect(this.page.locator(`//td[@data-testid='username']//*[text()='${username}']`)).toBeHidden();
+    await expect(this.memberRow(username)).toBeHidden();
   }
 }

--- a/client/e2eTests/protoFleet/pages/settingsTeam.ts
+++ b/client/e2eTests/protoFleet/pages/settingsTeam.ts
@@ -1,6 +1,8 @@
 import { expect } from "@playwright/test";
 import { BasePage } from "./base";
 
+const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 export class SettingsTeamPage extends BasePage {
   private memberRow(username: string) {
     return this.page
@@ -202,7 +204,7 @@ export class SettingsTeamPage extends BasePage {
       const roleName = (
         await row
           .getByTestId("name")
-          .getByText(new RegExp(`^${rolePrefix}`))
+          .getByText(new RegExp(`^${escapeRegex(rolePrefix)}`))
           .textContent()
           .catch(() => null)
       )?.trim();

--- a/client/e2eTests/protoFleet/spec/rbac.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbac.spec.ts
@@ -57,12 +57,13 @@ function expectConnectError(result: { body: string; status: number }, code: "per
   expect(result.status === 501 || normalizedBody.includes(code), summary).toBeTruthy();
 }
 
-function expectConnectNotPermissionDenied(result: { body: string; status: number }) {
+function expectConnectSuccessfulOrUnimplemented(result: { body: string; ok: boolean; status: number }) {
   const normalizedBody = result.body.toLowerCase();
   const summary = JSON.stringify(result);
 
-  expect(result.status).not.toBe(403);
   expect(normalizedBody.includes("permission_denied"), summary).toBeFalsy();
+  expect(normalizedBody.includes("unauthenticated"), summary).toBeFalsy();
+  expect(result.ok || result.status === 501 || normalizedBody.includes("unimplemented"), summary).toBeTruthy();
 }
 
 test.describe("Proto Fleet - RBAC", () => {
@@ -261,7 +262,7 @@ test.describe("Proto Fleet - RBAC", () => {
     });
 
     const allowedResult = await invokeIngestCurtailmentSignal(page, allowedReference);
-    expectConnectNotPermissionDenied(allowedResult);
+    expectConnectSuccessfulOrUnimplemented(allowedResult);
   });
 
   test("Sites, buildings, and racks read-only role can view infrastructure without create actions", async ({

--- a/client/e2eTests/protoFleet/spec/rbac.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbac.spec.ts
@@ -1,0 +1,315 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/pageFixtures";
+import {
+  ALERTS_E2E_ENABLED,
+  createAlertChannelAsAdmin,
+  createCurtailment,
+  createInfrastructureFixturesAsAdmin,
+  createPool,
+  createRack,
+  createSchedule,
+  invokeIngestCurtailmentSignal,
+  MEMBER_PASSWORD,
+  provisionRoleAndLogin,
+  provisionRoleViaStoredAdminContext,
+  RBAC_ALERT_CHANNEL_PREFIX,
+  RBAC_BUILDING_PREFIX,
+  RBAC_CURTAILMENT_REASON_PREFIX,
+  RBAC_POOL_PREFIX,
+  RBAC_RACK_PREFIX,
+  RBAC_RACK_ZONE,
+  RBAC_SCHEDULE_PREFIX,
+  RBAC_SITE_PREFIX,
+  REACHABLE_WEBHOOK_URL,
+  useRbacHooks,
+} from "../helpers/rbacTestSetup";
+import { generateRandomText } from "../helpers/testDataHelper";
+
+async function validateManageOnlySettingsRouteHidden(
+  page: Page,
+  {
+    route,
+    validateSubmenuHidden,
+  }: {
+    route: string;
+    validateSubmenuHidden: () => Promise<void>;
+  },
+) {
+  await page.goto("/settings/preferences");
+  await expect(page).toHaveURL(/.*\/settings\/preferences/);
+  await validateSubmenuHidden();
+
+  await page.goto(route);
+  await expect(page).toHaveURL(/.*\/settings\/preferences/);
+  await validateSubmenuHidden();
+}
+
+function expectConnectError(result: { body: string; status: number }, code: "permission_denied" | "unimplemented") {
+  const normalizedBody = result.body.toLowerCase();
+  const summary = JSON.stringify(result);
+
+  if (code === "permission_denied") {
+    expect(result.status === 403 || normalizedBody.includes(code), summary).toBeTruthy();
+    return;
+  }
+
+  expect(result.status === 501 || normalizedBody.includes(code), summary).toBeTruthy();
+}
+
+test.describe("Proto Fleet - RBAC", () => {
+  useRbacHooks();
+
+  test("Pools read-only role cannot access the Pools settings surface", async ({
+    page,
+    commonSteps,
+    settingsPoolsPage,
+  }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Read-only mining pool access for RBAC coverage.",
+      permissionKeys: ["pool:read"],
+    });
+
+    await validateManageOnlySettingsRouteHidden(page, {
+      route: "/settings/mining-pools",
+      validateSubmenuHidden: () => settingsPoolsPage.validateMiningPoolsSubmenuHidden(),
+    });
+  });
+
+  test("Pools manage role can create and delete mining pools", async ({
+    commonSteps,
+    newPoolModal,
+    settingsPage,
+    settingsPoolsPage,
+  }) => {
+    const poolName = generateRandomText(RBAC_POOL_PREFIX);
+    const poolUsername = generateRandomText("rbac_pool_user");
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Manage mining pools for RBAC coverage.",
+      permissionKeys: ["pool:read", "pool:manage"],
+    });
+
+    await settingsPage.navigateToMiningPoolsSettings();
+    await settingsPoolsPage.validateMiningPoolsPageOpened();
+
+    await createPool(settingsPage, settingsPoolsPage, newPoolModal, {
+      poolName,
+      poolUsername,
+    });
+
+    await settingsPoolsPage.deletePoolByNameIfVisible(poolName);
+    await settingsPoolsPage.validateTextInToast("Pool deleted");
+  });
+
+  test("Alerts read-only role can view alerts without channel management", async ({ alertsPage, commonSteps }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      !ALERTS_E2E_ENABLED,
+      "Requires the alerts sidecar + VITE_ALERTS_ENABLED; set E2E_ALERTS_ENABLED=true to run.",
+    );
+
+    const channelName = generateRandomText(RBAC_ALERT_CHANNEL_PREFIX);
+
+    await commonSteps.loginAsAdmin();
+    await createAlertChannelAsAdmin(alertsPage, channelName);
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Read-only alerts access for RBAC coverage.",
+      permissionKeys: ["alert:read"],
+    });
+
+    await alertsPage.navigateToAlertsSettings();
+    await alertsPage.validateAlertsPageOpened();
+    await alertsPage.validateChannelListed(channelName);
+    await alertsPage.validateAddChannelHidden();
+  });
+
+  test("Alerts manage role can create and delete channels", async ({ alertsPage, commonSteps }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      !ALERTS_E2E_ENABLED,
+      "Requires the alerts sidecar + VITE_ALERTS_ENABLED; set E2E_ALERTS_ENABLED=true to run.",
+    );
+
+    const channelName = generateRandomText(RBAC_ALERT_CHANNEL_PREFIX);
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Manage alerts for RBAC coverage.",
+      permissionKeys: ["alert:read", "alert:manage"],
+    });
+
+    await alertsPage.navigateToAlertsSettings();
+    await alertsPage.validateAlertsPageOpened();
+    await alertsPage.openAddChannelModal();
+    await alertsPage.fillWebhookChannel(channelName, REACHABLE_WEBHOOK_URL);
+    await alertsPage.saveChannel();
+    await alertsPage.validateChannelListed(channelName);
+    await alertsPage.deleteChannel(channelName);
+  });
+
+  test("Schedules read-only role cannot access the Schedules settings surface", async ({
+    page,
+    commonSteps,
+    settingsSchedulesPage,
+  }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Read-only schedules access for RBAC coverage.",
+      permissionKeys: ["schedule:read"],
+    });
+
+    await validateManageOnlySettingsRouteHidden(page, {
+      route: "/settings/schedules",
+      validateSubmenuHidden: () => settingsSchedulesPage.validateSchedulesSubmenuHidden(),
+    });
+  });
+
+  test("Schedules manage role can create and delete schedules", async ({ commonSteps, settingsSchedulesPage }) => {
+    const scheduleName = generateRandomText(RBAC_SCHEDULE_PREFIX);
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Manage schedules for RBAC coverage.",
+      permissionKeys: ["schedule:manage", "miner:set_power_target"],
+    });
+
+    await createSchedule(settingsSchedulesPage, scheduleName);
+    await settingsSchedulesPage.deleteSchedule(scheduleName);
+  });
+
+  test("Curtailment read-only role can view the Energy page without manage controls", async ({
+    commonSteps,
+    energyPage,
+  }) => {
+    const reason = generateRandomText(RBAC_CURTAILMENT_REASON_PREFIX);
+
+    await commonSteps.loginAsAdmin();
+    await createCurtailment(energyPage, reason);
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Read-only curtailment access for RBAC coverage.",
+      permissionKeys: ["curtailment:read"],
+    });
+
+    await energyPage.navigateToEnergyPage();
+    await energyPage.validateEnergyPageOpened();
+    await energyPage.validateRunCurtailmentButtonHidden();
+    await energyPage.validateActiveCurtailment(reason);
+    await energyPage.validateActiveCurtailmentManageActionsHidden(reason);
+  });
+
+  test("Curtailment manage role can preview, start, and stop a curtailment", async ({ commonSteps, energyPage }) => {
+    const reason = generateRandomText(RBAC_CURTAILMENT_REASON_PREFIX);
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Manage curtailment for RBAC coverage.",
+      permissionKeys: ["curtailment:manage"],
+    });
+
+    await createCurtailment(energyPage, reason);
+    await energyPage.stopCurtailment({ reason });
+    await energyPage.waitForCurtailmentToRestore({ reason });
+  });
+
+  test("Curtailment ingest permission reaches the ingest RPC while manage-only is denied", async ({
+    authPage,
+    browser,
+    commonSteps,
+    page,
+  }, testInfo) => {
+    const deniedReference = generateRandomText("rbac_ingest_denied");
+    const allowedReference = generateRandomText("rbac_ingest_allowed");
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Manage-only curtailment role for ingest denial coverage.",
+      permissionKeys: ["curtailment:manage"],
+    });
+
+    const deniedResult = await invokeIngestCurtailmentSignal(page, deniedReference);
+    expectConnectError(deniedResult, "permission_denied");
+
+    const ingestMember = await provisionRoleViaStoredAdminContext(browser, testInfo, {
+      roleDescription: "Ingest-only curtailment role for RPC coverage.",
+      permissionKeys: ["curtailment:ingest"],
+    });
+
+    await authPage.logout();
+    await authPage.validateRedirectedToAuth();
+    await commonSteps.completeFirstLoginAsTeamMember({
+      username: ingestMember.username,
+      temporaryPassword: ingestMember.temporaryPassword,
+      newPassword: MEMBER_PASSWORD,
+    });
+
+    const allowedResult = await invokeIngestCurtailmentSignal(page, allowedReference);
+    expectConnectError(allowedResult, "unimplemented");
+  });
+
+  test("Sites, buildings, and racks read-only role can view infrastructure without create actions", async ({
+    commonSteps,
+    fleetLocationsPage,
+    racksPage,
+  }) => {
+    const siteName = generateRandomText(RBAC_SITE_PREFIX);
+    const buildingName = generateRandomText(RBAC_BUILDING_PREFIX);
+    const rackLabel = generateRandomText(RBAC_RACK_PREFIX);
+
+    await commonSteps.loginAsAdmin();
+    await createInfrastructureFixturesAsAdmin(fleetLocationsPage, racksPage, {
+      siteName,
+      buildingName,
+      rackLabel,
+    });
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Read-only infrastructure access for RBAC coverage.",
+      permissionKeys: ["site:read", "rack:read"],
+    });
+
+    await fleetLocationsPage.validateSiteRowCounts(siteName, {
+      buildings: 1,
+      racks: 0,
+      miners: 0,
+    });
+    await fleetLocationsPage.validateBuildingRowCounts(buildingName, {
+      siteName,
+      racks: 0,
+      miners: 0,
+    });
+    await racksPage.navigateToRacksPage();
+    await racksPage.clickViewList();
+    await racksPage.waitForRackListToLoad({ allowEmpty: false });
+    await racksPage.validateRackRow(rackLabel, RBAC_RACK_ZONE, 0);
+    await fleetLocationsPage.validateAddSiteButtonHidden();
+    await fleetLocationsPage.validateAddBuildingButtonHidden();
+    await racksPage.validateAddRackButtonHidden();
+  });
+
+  test("Sites, buildings, and racks manage role can create infrastructure", async ({
+    commonSteps,
+    fleetLocationsPage,
+    racksPage,
+  }) => {
+    const siteName = generateRandomText(RBAC_SITE_PREFIX);
+    const buildingName = generateRandomText(RBAC_BUILDING_PREFIX);
+    const rackLabel = generateRandomText(RBAC_RACK_PREFIX);
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Manage infrastructure for RBAC coverage.",
+      permissionKeys: ["site:read", "site:manage", "rack:read", "rack:manage"],
+    });
+
+    await fleetLocationsPage.createSite(siteName);
+    await fleetLocationsPage.createBuilding(siteName, buildingName);
+    await createRack(racksPage, rackLabel);
+
+    await fleetLocationsPage.validateSiteRowCounts(siteName, {
+      buildings: 1,
+      racks: 0,
+      miners: 0,
+    });
+    await fleetLocationsPage.validateBuildingRowCounts(buildingName, {
+      siteName,
+      racks: 0,
+      miners: 0,
+    });
+  });
+});

--- a/client/e2eTests/protoFleet/spec/rbac.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbac.spec.ts
@@ -135,7 +135,7 @@ test.describe("Proto Fleet - RBAC", () => {
 
     await provisionRoleAndLogin(commonSteps, {
       roleDescription: "Manage alerts for RBAC coverage.",
-      permissionKeys: ["alert:read", "alert:manage"],
+      permissionKeys: ["alert:read", "alert:manage", "miner:read"],
     });
 
     await alertsPage.navigateToAlertsSettings();

--- a/client/e2eTests/protoFleet/spec/rbac.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbac.spec.ts
@@ -119,7 +119,7 @@ test.describe("Proto Fleet - RBAC", () => {
 
     const channelName = generateRandomText(RBAC_ALERT_CHANNEL_PREFIX);
 
-    await commonSteps.loginAsAdmin();
+    await commonSteps.loginAsAdmin({ forceReauth: true });
     await createAlertChannelAsAdmin(alertsPage, channelName);
 
     await provisionRoleAndLogin(commonSteps, {
@@ -196,7 +196,7 @@ test.describe("Proto Fleet - RBAC", () => {
 
     const reason = generateRandomText(RBAC_CURTAILMENT_REASON_PREFIX);
 
-    await commonSteps.loginAsAdmin();
+    await commonSteps.loginAsAdmin({ forceReauth: true });
     await createCurtailment(energyPage, reason);
 
     await provisionRoleAndLogin(commonSteps, {
@@ -273,7 +273,7 @@ test.describe("Proto Fleet - RBAC", () => {
     const buildingName = generateRandomText(RBAC_BUILDING_PREFIX);
     const rackLabel = generateRandomText(RBAC_RACK_PREFIX);
 
-    await commonSteps.loginAsAdmin();
+    await commonSteps.loginAsAdmin({ forceReauth: true });
     await createInfrastructureFixturesAsAdmin(fleetLocationsPage, racksPage, {
       siteName,
       buildingName,
@@ -301,6 +301,7 @@ test.describe("Proto Fleet - RBAC", () => {
     await racksPage.validateRackRow(rackLabel, RBAC_RACK_ZONE, 0);
     await fleetLocationsPage.validateAddSiteButtonHidden();
     await fleetLocationsPage.validateAddBuildingButtonHidden();
+    await racksPage.navigateToRacksPage();
     await racksPage.validateAddRackButtonHidden();
   });
 

--- a/client/e2eTests/protoFleet/spec/rbac.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbac.spec.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
 import {
   ALERTS_E2E_ENABLED,
@@ -54,6 +55,14 @@ function expectConnectError(result: { body: string; status: number }, code: "per
   }
 
   expect(result.status === 501 || normalizedBody.includes(code), summary).toBeTruthy();
+}
+
+function expectConnectNotPermissionDenied(result: { body: string; status: number }) {
+  const normalizedBody = result.body.toLowerCase();
+  const summary = JSON.stringify(result);
+
+  expect(result.status).not.toBe(403);
+  expect(normalizedBody.includes("permission_denied"), summary).toBeFalsy();
 }
 
 test.describe("Proto Fleet - RBAC", () => {
@@ -179,6 +188,12 @@ test.describe("Proto Fleet - RBAC", () => {
     commonSteps,
     energyPage,
   }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      testConfig.target === "real",
+      "Curtailment RBAC E2E creates whole-fleet curtailments and is only supported against fake targets.",
+    );
+
     const reason = generateRandomText(RBAC_CURTAILMENT_REASON_PREFIX);
 
     await commonSteps.loginAsAdmin();
@@ -197,6 +212,12 @@ test.describe("Proto Fleet - RBAC", () => {
   });
 
   test("Curtailment manage role can preview, start, and stop a curtailment", async ({ commonSteps, energyPage }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      testConfig.target === "real",
+      "Curtailment RBAC E2E creates whole-fleet curtailments and is only supported against fake targets.",
+    );
+
     const reason = generateRandomText(RBAC_CURTAILMENT_REASON_PREFIX);
 
     await provisionRoleAndLogin(commonSteps, {
@@ -240,7 +261,7 @@ test.describe("Proto Fleet - RBAC", () => {
     });
 
     const allowedResult = await invokeIngestCurtailmentSignal(page, allowedReference);
-    expectConnectError(allowedResult, "unimplemented");
+    expectConnectNotPermissionDenied(allowedResult);
   });
 
   test("Sites, buildings, and racks read-only role can view infrastructure without create actions", async ({
@@ -276,7 +297,7 @@ test.describe("Proto Fleet - RBAC", () => {
     });
     await racksPage.navigateToRacksPage();
     await racksPage.clickViewList();
-    await racksPage.waitForRackListToLoad({ allowEmpty: false });
+    await racksPage.waitForRackListToLoad({ allowEmpty: false, requireManageAccess: false });
     await racksPage.validateRackRow(rackLabel, RBAC_RACK_ZONE, 0);
     await fleetLocationsPage.validateAddSiteButtonHidden();
     await fleetLocationsPage.validateAddBuildingButtonHidden();

--- a/client/src/protoFleet/features/settings/components/CreateEditRoleModal.tsx
+++ b/client/src/protoFleet/features/settings/components/CreateEditRoleModal.tsx
@@ -37,6 +37,8 @@ const collapsedFor = (permissions: string[], groups: PermissionGroup[]): Set<str
   return collapsed;
 };
 
+const permissionTestId = (key: string) => `role-permission-${key.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`;
+
 const CreateEditRoleModal = ({ open, role, onDismiss, onSuccess }: CreateEditRoleModalProps) => {
   const isVisible = open ?? true;
   const isEdit = !!role;
@@ -315,6 +317,7 @@ const CreateEditRoleModalForm = ({
           initValue={query}
           onChange={(value) => setQuery(value)}
           dismiss
+          testId="role-permission-search"
         />
       </div>
 
@@ -394,6 +397,7 @@ const CreateEditRoleModalForm = ({
                       return (
                         <label
                           key={entry.key}
+                          data-testid={permissionTestId(entry.key)}
                           className={clsx(
                             "flex items-center gap-3 py-2 pl-6 hover:bg-core-primary-2",
                             isLocked ? "cursor-not-allowed" : "cursor-pointer",


### PR DESCRIPTION
🤖 AI-updated PR description.

Reviewable diff: +4/-0 across 1 non-test file, with the full PR touching 13 files that are otherwise E2E specs, helpers, and page objects.

## Summary
This PR adds a dedicated ProtoFleet RBAC E2E “simple surface” matrix for pools, alerts, schedules, curtailment, ingest, and infrastructure. Each scenario proves one allow/deny boundary or one create/delete round-trip so we cover authorization behavior without repeating deeper feature-level assertions already exercised elsewhere.

To support deterministic setup, the role editor now exposes stable selectors for permission search and permission rows. The follow-up fixes on this PR also defer loading the generated admin auth state until runtime, avoid requiring `rack:manage` in the read-only infrastructure wait path, and make the ingest-permission assertion tolerate the RPC being implemented later.

## How it works
The new `rbac.spec.ts` provisions a fresh custom role and team member per scenario, completes first-login for that member, and then performs the minimum UI flow needed to prove access or denial. Shared provisioning and cleanup live in `rbacTestSetup.ts` and `CommonSteps`, while page-object updates absorb feature-specific selectors and repeated interaction details for alerts, schedules, curtailment, pools, racks, and team settings. The role modal test IDs let setup pick exact grants without brittle text traversal.

## Diagrams
```mermaid
flowchart LR
  A["RBAC spec scenario"] --> B["Provision role with selected permissions"]
  B --> C["Create team member for that role"]
  C --> D["Complete first login as member"]
  D --> E["Navigate to target ProtoFleet surface"]
  E --> F["Assert denial or run one allowed action"]
  F --> G["Cleanup created RBAC fixtures"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/rbac.spec.ts` | Adds the simple RBAC scenario matrix across settings, alerts, curtailment, ingest, and infrastructure | Main reviewer entrypoint for scenario scope, assertions, and permission combinations |
| `client/e2eTests/protoFleet/helpers/rbacTestSetup.ts` | Adds shared role provisioning, stored-admin helpers, and RBAC cleanup | Centralizes the stateful setup/teardown that makes the spec repeatable |
| `client/e2eTests/protoFleet/helpers/commonSteps.ts` | Adds reusable role and team-member setup primitives used by the RBAC flow | Defines how roles and first-login setup are created in the UI |
| `client/e2eTests/protoFleet/pages/*.ts` | Extends page objects for pools, alerts, schedules, curtailment, fleet locations, racks, and team settings | Keeps the spec readable and contains UI-specific selectors and waits |
| `client/src/protoFleet/features/settings/components/CreateEditRoleModal.tsx` | Adds stable test IDs for permission search and permission rows | Lets the setup flow pick exact permissions without brittle DOM matching |

## Key technical decisions & trade-offs
- Keep RBAC checks in a dedicated spec instead of folding them into feature specs: reviewers get a single authorization-focused matrix and avoid duplicating feature-level assertions.
- Verify the minimum meaningful action per permission surface instead of full workflows: coverage stays fast and maintainable while still proving allow/deny boundaries.
- Treat alerts channel creation as `alert:manage` plus `miner:read`: this matches the live RPC permission contract rather than a flatter UI assumption.
- Skip the curtailment create/manage RBAC scenarios on real targets: these flows create whole-fleet curtailments and should stay limited to fake/local targets.
- Assert ingest access as “not permission denied” rather than hard-coding today’s `unimplemented` response: the test stays valid once the backend implements the RPC.

## Testing & validation
- `./node_modules/.bin/eslint e2eTests/protoFleet/helpers/rbacTestSetup.ts e2eTests/protoFleet/pages/racks.ts e2eTests/protoFleet/pages/settingsTeam.ts e2eTests/protoFleet/spec/rbac.spec.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npx playwright test --project=desktop spec/rbac.spec.ts --list`
- `PW_UI_NO_DEPS=1 npx playwright test --project=desktop spec/rbac.spec.ts --grep "Curtailment read-only role can view the Energy page without manage controls|Curtailment manage role can preview, start, and stop a curtailment|Curtailment ingest permission reaches the ingest RPC while manage-only is denied|Sites, buildings, and racks read-only role can view infrastructure without create actions"`
- Earlier full local alerts-enabled verification on this branch: `PW_UI_NO_DEPS=1 E2E_ALERTS_ENABLED=true npx playwright test --project=desktop spec/rbac.spec.ts` → `11 passed`

Not covered:
- The onboarding/setup specs were not rerun during this follow-up because verification used an already-bootstrapped local env and targeted the RBAC regression surface directly.
