### PR TITLE
fix(monitoring): correct CPU/memory alert text to five minutes

### DIFF
--- a/server/monitoring/grafana/system-monitoring/proto-fleet-system-rules.yaml
+++ b/server/monitoring/grafana/system-monitoring/proto-fleet-system-rules.yaml
@@ -66,10 +66,10 @@ groups:
           rule_group: proto-fleet-system
           template: system-cpu
         annotations:
-          summary: "Host CPU usage has been above 90% for at least ten minutes."
+          summary: "Host CPU usage has been above 90% for at least five minutes."
           description: |
             CPU on the machine running Proto Fleet has been above 90% for at
-            least ten minutes. Telemetry polling, command dispatch, and the
+            least five minutes. Telemetry polling, command dispatch, and the
             database all compete for that CPU; check for runaway processes on
             the host.
 
@@ -118,10 +118,10 @@ groups:
           rule_group: proto-fleet-system
           template: system-memory
         annotations:
-          summary: "Host memory usage has been above 90% for at least ten minutes."
+          summary: "Host memory usage has been above 90% for at least five minutes."
           description: |
             RAM on the machine running Proto Fleet has been above 90% for at
-            least ten minutes. If it keeps climbing, the kernel OOM killer may
+            least five minutes. If it keeps climbing, the kernel OOM killer may
             take out fleet-api or TimescaleDB.
 
       # Two-tier disk alerting: this warning at 75% gives lead time to plan


### PR DESCRIPTION
## Summary

The `Host CPU High` and `Host Memory High` system-monitoring rules fire at `for: 5m`, but their `summary` and `description` still read "for at least ten minutes" — stale prose from before the window was shortened in #690. The alert was telling operators the wrong number (visible in the alerts list and in delivered notifications).

## Change

Update both annotations (summary + description) from "ten minutes" to "five minutes". No behavior change — the `for:` durations and thresholds are untouched; this is text-only.

## Verification

Audited every rule in `proto-fleet-system-rules.yaml`, comparing each `for:`/threshold to the minutes stated in its prose:

| Rule | for | prose | ok |
| --- | --- | --- | --- |
| Host CPU High | 5m | five minutes | fixed |
| Host Memory High | 5m | five minutes | fixed |
| Host Disk Space Warning | 15m | fifteen minutes | already correct |
| Host Disk Space Low | 15m | fifteen minutes | already correct |
| Host Disk Monitoring Stalled | 720s + 3m | fifteen minutes | already correct (total time-to-fire) |
| Fleet Heartbeat Stale | 120s + 3m | five minutes | already correct (total time-to-fire) |

The staleness rules deliberately state total time-to-fire (threshold + pending), so only the two gauge rules had drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)