### PR TITLE
fix(ui): refine fleet surfaces and detail spacing

### DIFF
--- a/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
+++ b/client/src/protoFleet/components/NavigationMenu/Navigation.tsx
@@ -6,7 +6,6 @@ import { useLogoutAction } from "@/protoFleet/api/useLogout";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import { isNavItemAllowedByPermissions, NavItem, secondaryNavItems } from "@/protoFleet/config/navItems";
 import { useNavFeatureEnabled } from "@/protoFleet/hooks/useNavFeatureEnabled";
-import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
 import { scopedPath, unscopedScopablePath } from "@/protoFleet/routing/siteScope";
 import { usePermissions } from "@/protoFleet/store";
 import { Logo, LogoAlt } from "@/shared/assets/icons";
@@ -27,7 +26,6 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
   const { pathname } = useLocation();
   const { isPhone, isTablet } = useWindowDimensions();
   const logout = useLogoutAction();
-  const { bg } = usePageBackground();
   const permissions = usePermissions();
   const featureEnabled = useNavFeatureEnabled();
   const { activeSite } = useActiveSite({});
@@ -108,9 +106,9 @@ const Navigation = ({ items, className, closeMenu }: NavigationProps) => {
       className={clsx(
         "group/nav absolute top-0 left-0 z-30 flex min-h-screen w-60 flex-col justify-between bg-surface-base text-text-primary-70",
         "laptop:absolute laptop:top-0 laptop:left-0 laptop:z-50 laptop:w-16 laptop:overflow-hidden laptop:hover:w-50 laptop:hover:border-r laptop:hover:border-core-primary-10 laptop:hover:bg-surface-base laptop:hover:shadow-lg",
-        bg === "surface-5" ? "laptop:bg-surface-5 laptop:dark:bg-surface-base" : "laptop:bg-surface-base",
+        "laptop:bg-surface-base",
         "desktop:w-50 desktop:overflow-hidden desktop:border-r desktop:border-core-primary-10",
-        bg === "surface-5" ? "desktop:bg-surface-5 desktop:dark:bg-surface-base" : "desktop:bg-surface-base",
+        "desktop:bg-surface-base",
         className,
       )}
     >

--- a/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
+++ b/client/src/protoFleet/components/PageHeader/SitePicker/SitePicker.tsx
@@ -138,7 +138,7 @@ const SitePicker = ({ sites, error, onRetry, triggerClassName = "text-300" }: Si
       <button
         type="button"
         className={clsx(
-          "hover:bg-surface-base-hover flex max-w-full min-w-0 items-center gap-1 rounded-md px-2 py-1 text-text-primary focus-visible:underline",
+          "flex max-w-full min-w-0 items-center gap-1 rounded-md px-2 py-1 text-text-primary hover:bg-surface-base-hover focus-visible:underline",
           triggerClassName,
         )}
         aria-haspopup="dialog"
@@ -218,7 +218,7 @@ const SitePickerOption = ({ label, selected, onClick, testId }: SitePickerOption
     aria-checked={selected}
     onClick={onClick}
     data-testid={testId}
-    className="hover:bg-surface-base-hover focus-visible:bg-surface-base-hover flex w-full items-center gap-3 rounded-md px-2 py-2.5 text-left text-300 text-text-primary"
+    className="flex w-full items-center gap-3 rounded-md px-2 py-2.5 text-left text-300 text-text-primary hover:bg-surface-base-hover focus-visible:bg-surface-base-hover"
   >
     <Radio selected={selected} />
     <span>{label}</span>

--- a/client/src/protoFleet/features/alerts/components/ActiveAlertsCard.tsx
+++ b/client/src/protoFleet/features/alerts/components/ActiveAlertsCard.tsx
@@ -127,7 +127,7 @@ const ActiveAlertsCard = () => {
   const isEmpty = groups.length === 0 && fleetWideAlerts.length === 0;
 
   return (
-    <section className="flex flex-col gap-4 rounded-xl bg-surface-base p-6 dark:bg-core-primary-5">
+    <section className="flex flex-col gap-4 rounded-xl bg-surface-elevated-base p-6 shadow-100">
       <h3 className="text-heading-200">Active alerts</h3>
 
       {error ? <Callout intent="danger" prefixIcon={<Alert />} title={error} /> : null}

--- a/client/src/protoFleet/features/buildings/components/BuildingMetricsRow.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingMetricsRow.tsx
@@ -10,6 +10,7 @@ interface BuildingMetricsRowProps {
   // `undefined` while stats are still loading; the Metric primitive renders
   // skeletons. `null` on any cell is the no-data em dash.
   stats: GetBuildingStatsResponse | undefined;
+  variant?: "default" | "compact";
   testId?: string;
 }
 
@@ -21,7 +22,7 @@ const formatMinersOnline = (hashing: number, total: number): string => {
 // Four-metric header for /buildings/:id. Mirrors the rack-overview top
 // strip (hashrate / power / efficiency / online) but power adds a capacity
 // denominator from the building's power_kw config field.
-const BuildingMetricsRow = ({ powerCapacityKw, stats, testId }: BuildingMetricsRowProps) => {
+const BuildingMetricsRow = ({ powerCapacityKw, stats, variant = "default", testId }: BuildingMetricsRowProps) => {
   // Per-field reporting counts so a device that reported state but not
   // efficiency doesn't pull the building average toward a misleading
   // partial number — render the dash instead.
@@ -38,10 +39,10 @@ const BuildingMetricsRow = ({ powerCapacityKw, stats, testId }: BuildingMetricsR
 
   return (
     <div className="grid grid-cols-2 gap-6 tablet:grid-cols-4" data-testid={testId ?? "building-metrics-row"}>
-      <Metric label="Hashrate" value={hashrate} testId="building-metric-hashrate" />
-      <Metric label="Power" value={power} testId="building-metric-power" />
-      <Metric label="Efficiency" value={efficiency} testId="building-metric-efficiency" />
-      <Metric label="Miners online" value={onlineDisplay} testId="building-metric-online" />
+      <Metric label="Hashrate" value={hashrate} variant={variant} testId="building-metric-hashrate" />
+      <Metric label="Power" value={power} variant={variant} testId="building-metric-power" />
+      <Metric label="Efficiency" value={efficiency} variant={variant} testId="building-metric-efficiency" />
+      <Metric label="Miners online" value={onlineDisplay} variant={variant} testId="building-metric-online" />
     </div>
   );
 };

--- a/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingPageHeader.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 import Breadcrumb, { type BreadcrumbSibling } from "@/shared/components/Breadcrumb";
-import Button, { variants } from "@/shared/components/Button";
+import Button, { sizes, variants } from "@/shared/components/Button";
 import Header from "@/shared/components/Header";
 
 interface BuildingPageHeaderProps {
@@ -49,6 +49,7 @@ const BuildingPageHeader = ({
         <div className="ml-3 flex items-center gap-3">
           <Button
             variant={variants.secondary}
+            size={sizes.compact}
             onClick={() => navigate(scopedPath(`/fleet/racks?building=${buildingId}`, activeSite))}
             testId="building-page-view-racks"
           >
@@ -56,6 +57,7 @@ const BuildingPageHeader = ({
           </Button>
           <Button
             variant={variants.secondary}
+            size={sizes.compact}
             onClick={() => navigate(scopedPath(`/fleet/miners?building=${buildingId}`, activeSite))}
             testId="building-page-view-miners"
           >
@@ -63,6 +65,7 @@ const BuildingPageHeader = ({
           </Button>
           <Button
             variant={variants.secondary}
+            size={sizes.compact}
             onClick={onEditBuilding ?? (() => undefined)}
             disabled={!onEditBuilding}
             testId="building-page-edit"

--- a/client/src/protoFleet/features/buildings/components/BuildingRackGrid/BuildingRackGrid.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingRackGrid/BuildingRackGrid.tsx
@@ -183,7 +183,7 @@ const BuildingRackGrid = ({
   return (
     <div
       ref={containerRef}
-      className="flex flex-col gap-4 rounded-2xl border border-border-5 bg-surface-base p-10 shadow-100 phone:p-6"
+      className="flex flex-col gap-4 rounded-xl bg-surface-elevated-base p-10 shadow-100 phone:p-6"
       data-testid={testId}
     >
       {/* Sort control */}
@@ -247,7 +247,7 @@ const BuildingRackGrid = ({
             {unplacedRacks.map((rack) => (
               <div
                 key={rack.rackId}
-                className="cursor-pointer rounded-lg border border-border-5 p-3 transition-colors hover:bg-surface-5"
+                className="cursor-pointer rounded-xl bg-surface-overlay p-4 transition-opacity duration-[120ms] hover:opacity-[0.82]"
                 onClick={() => navigate(`/racks/${rack.rackId}`)}
                 data-testid={`${testId}-unplaced-${rack.rackLabel}`}
               >

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -22,6 +22,7 @@ import { useTelemetryMetrics } from "@/protoFleet/api/useTelemetryMetrics";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
+import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -161,6 +162,7 @@ const BuildingPage = () => {
   const duration = useDuration();
   const setDuration = useSetDuration();
   const { refs } = useStickyState();
+  const { bgClass } = usePageBackground();
 
   // Component errors scoped to the building's devices. While stats are
   // still loading (memberDeviceIds === null) we pass enabled=false so the
@@ -299,26 +301,26 @@ const BuildingPage = () => {
             metrics row, diagnostics, and performance section don't sit
             indefinitely in skeleton state with no recovery affordance. */}
         {statsError && !statsHasLoaded ? (
-          <div className="px-6 pt-6 laptop:px-10 laptop:pt-10">
+          <div className="px-6 pt-6 laptop:px-10">
             <div
               className="flex items-center justify-between gap-3 rounded-xl border border-intent-critical-20 bg-intent-critical-10 px-4 py-3 text-200 text-intent-critical-text"
               data-testid="building-page-stats-error"
             >
               <span>Couldn&apos;t load building metrics: {statsError}</span>
-              <button
-                type="button"
+              <Button
+                variant={variants.secondary}
+                size={sizes.compact}
+                text="Retry"
                 onClick={() => refetchStats()}
-                className="shrink-0 underline hover:opacity-80"
-                data-testid="building-page-stats-retry"
-              >
-                Retry
-              </button>
+                className="shrink-0"
+                testId="building-page-stats-retry"
+              />
             </div>
           </div>
         ) : null}
 
         {/* Metrics row */}
-        <section className="px-6 pt-6 laptop:px-10 laptop:pt-10">
+        <section className="px-6 pt-6 laptop:px-10">
           <BuildingMetricsRow powerCapacityKw={effectiveBuilding.powerKw} stats={stats} />
         </section>
 
@@ -351,7 +353,7 @@ const BuildingPage = () => {
         {/* Performance section — identical wiring to RackOverviewPage */}
         <section className="pb-6">
           <div ref={refs.vertical.start} />
-          <div className="sticky top-0 z-2 bg-surface-5 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10 dark:bg-surface-base">
+          <div className={`${bgClass} sticky top-0 z-2 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10`}>
             <div className="flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between">
               <div className="text-heading-200 text-text-primary">Performance</div>
               <div className="flex items-center gap-6 text-200 text-core-primary-50">
@@ -408,7 +410,7 @@ const BuildingPage = () => {
             </div>
           </div>
 
-          <div className="px-6 laptop:px-10">
+          <div className="px-6 pt-4 laptop:px-10">
             <DeviceSetPerformanceSection duration={duration} metrics={metrics} />
           </div>
           {/* eslint-disable-next-line react-hooks/refs -- ref object from useStickyState is passed to <div ref>; React writes .current during commit, not read during render */}

--- a/client/src/protoFleet/features/dashboard/components/ChartWidget/ChartWidget.test.tsx
+++ b/client/src/protoFleet/features/dashboard/components/ChartWidget/ChartWidget.test.tsx
@@ -71,7 +71,8 @@ describe("ChartWidget", () => {
     const widget = container.firstChild as HTMLElement;
     expect(widget).toHaveClass("custom-class");
     expect(widget).toHaveClass("rounded-xl");
-    expect(widget).toHaveClass("bg-surface-base");
+    expect(widget).toHaveClass("bg-surface-elevated-base");
+    expect(widget).toHaveClass("shadow-100");
     expect(widget).toHaveClass("p-10");
   });
 

--- a/client/src/protoFleet/features/dashboard/components/ChartWidget/ChartWidget.tsx
+++ b/client/src/protoFleet/features/dashboard/components/ChartWidget/ChartWidget.tsx
@@ -28,7 +28,7 @@ const ChartWidget = ({
   const statsArray = stats ? (Array.isArray(stats) ? stats : [stats]) : [];
 
   return (
-    <div className={clsx("rounded-xl bg-surface-base p-10 dark:bg-core-primary-5 phone:p-6", className)}>
+    <div className={clsx("rounded-xl bg-surface-elevated-base p-10 shadow-100 phone:p-6", className)}>
       <div className={statsPadding}>
         {statsArray.length > 0 ? (
           <Stats

--- a/client/src/protoFleet/features/dashboard/components/FleetHealthSection/FleetHealthSection.tsx
+++ b/client/src/protoFleet/features/dashboard/components/FleetHealthSection/FleetHealthSection.tsx
@@ -110,7 +110,7 @@ const FleetHealthSection = ({
         </p>
       ) : null}
 
-      <div className="mt-6 rounded-xl bg-surface-base p-10 dark:bg-core-primary-5 phone:p-6">
+      <div className="mt-6 rounded-xl bg-surface-elevated-base p-10 shadow-100 phone:p-6">
         <FleetHealthMetrics
           fleetSize={fleetSize}
           healthyMiners={healthyMiners}

--- a/client/src/protoFleet/features/dashboard/components/FleetHealthSection/SiteResourcePanel.tsx
+++ b/client/src/protoFleet/features/dashboard/components/FleetHealthSection/SiteResourcePanel.tsx
@@ -240,11 +240,11 @@ const SiteResourcePanel = ({ siteId, activeSite }: SiteResourcePanelProps) => {
           // The measured viewport stays at content width (mx = card padding),
           // so the slide clamps with the last card flush to the content edge —
           // not the card edge — leaving the gutter clear at the end.
-          <div className="-mx-10 overflow-hidden phone:-mx-6" data-testid="site-resource-gallery">
+          <div className="-mx-10 -my-4 overflow-hidden py-4 phone:-mx-6" data-testid="site-resource-gallery">
             <div ref={carousel.viewportRef} className="mx-10 phone:mx-6">
               <div
                 ref={carousel.trackRef}
-                className="flex items-stretch gap-1 transition-transform duration-300 ease-out"
+                className="flex items-stretch gap-4 transition-transform duration-300 ease-out"
                 style={{ transform: `translateX(-${carousel.translatePx}px)` }}
               >
                 {renderGallery()}

--- a/client/src/protoFleet/features/dashboard/components/SegmentedMetricPanel/SegmentedMetricPanel.tsx
+++ b/client/src/protoFleet/features/dashboard/components/SegmentedMetricPanel/SegmentedMetricPanel.tsx
@@ -130,10 +130,10 @@ export const SegmentedMetricPanel = ({
 
   return (
     <div
-      className={`flex w-full flex-col gap-6 overflow-hidden rounded-xl bg-surface-base laptop:flex-row laptop:gap-0 dark:bg-core-primary-5 ${className || ""}`}
+      className={`flex w-full flex-col gap-6 overflow-hidden rounded-xl bg-surface-elevated-base shadow-100 laptop:flex-row laptop:gap-0 ${className || ""}`}
     >
       {/* Left Panel: ChartWidget with SegmentedBarChart(s) */}
-      <ChartWidget stats={stat} className="w-full rounded-none! bg-transparent laptop:w-1/2 dark:bg-transparent">
+      <ChartWidget stats={stat} className="w-full rounded-none! bg-transparent! shadow-none! laptop:w-1/2">
         <div className={`w-full ${isMultiDay ? "flex flex-row" : ""}`}>
           {processedChartData.map((dayData, index) => {
             // Use pre-calculated width for this chart

--- a/client/src/protoFleet/features/dashboard/components/SitesSection/SiteCard.tsx
+++ b/client/src/protoFleet/features/dashboard/components/SitesSection/SiteCard.tsx
@@ -86,7 +86,7 @@ const SiteCard = ({ site, className }: SiteCardProps) => {
   return (
     <div
       ref={cardRef}
-      className={clsx("flex h-full flex-col gap-5 rounded-xl bg-surface-base p-10 dark:bg-core-primary-5", className)}
+      className={clsx("flex h-full flex-col gap-5 rounded-xl bg-surface-elevated-base p-10 shadow-100", className)}
       data-testid={`dashboard-site-card-${idText}`}
     >
       <div className="flex items-start justify-between gap-2">

--- a/client/src/protoFleet/features/dashboard/components/SitesSection/SitesSection.test.tsx
+++ b/client/src/protoFleet/features/dashboard/components/SitesSection/SitesSection.test.tsx
@@ -58,7 +58,7 @@ describe("SitesSection", () => {
     setBreakpoint("desktop");
     const { rerender } = renderWithRouter([makeSite(1, "Alpha")]);
     expect(screen.getByTestId("dashboard-sites-track").style.getPropertyValue("--site-card-w")).toBe(
-      "calc((100% - 8px) / 3)",
+      "calc((100% - 32px) / 3)",
     );
 
     const withWin = (sites: SiteWithCounts[]) => (
@@ -70,7 +70,7 @@ describe("SitesSection", () => {
     setBreakpoint("laptop");
     rerender(withWin([makeSite(1, "Alpha")]));
     expect(screen.getByTestId("dashboard-sites-track").style.getPropertyValue("--site-card-w")).toBe(
-      "calc((100% - 4px) / 2)",
+      "calc((100% - 16px) / 2)",
     );
 
     setBreakpoint("phone");

--- a/client/src/protoFleet/features/dashboard/components/SitesSection/SitesSection.tsx
+++ b/client/src/protoFleet/features/dashboard/components/SitesSection/SitesSection.tsx
@@ -7,9 +7,9 @@ import Button, { sizes, variants } from "@/shared/components/Button";
 import SkeletonBar from "@/shared/components/SkeletonBar";
 import { useWindowDimensions } from "@/shared/hooks/useWindowDimensions";
 
-// Track gap between cards (Tailwind gap-1 = 4px). Drives both the card width
+// Track gap between cards (Tailwind gap-4 = 16px). Drives both the card width
 // and the per-step translate so they can't drift.
-const GAP_PX = 4;
+const GAP_PX = 16;
 
 interface SitesSectionProps {
   // `undefined` while ListSites is still loading; `[]` once loaded with no
@@ -86,9 +86,9 @@ const SitesSection = ({ sites }: SitesSectionProps) => {
           stays at content width (mx matches the page padding) so the cards
           overflow into the right gutter instead of being cut at the content
           boundary, while the clamp still right-aligns the last card. */}
-      <div className="mt-6 overflow-hidden">
+      <div className="-mx-4 mt-2 overflow-hidden px-4 py-4">
         <div
-          className="mx-6 flex gap-1 transition-transform duration-300 ease-out laptop:mx-10"
+          className="mx-6 flex gap-4 transition-transform duration-300 ease-out laptop:mx-10"
           style={trackStyle}
           data-testid="dashboard-sites-track"
         >

--- a/client/src/protoFleet/features/dashboard/components/TemperaturePanel/TemperaturePanel.tsx
+++ b/client/src/protoFleet/features/dashboard/components/TemperaturePanel/TemperaturePanel.tsx
@@ -56,11 +56,11 @@ export function TemperaturePanel({ duration, temperatureStatusCounts }: Temperat
     };
 
     return (
-      <div className="flex w-full flex-row overflow-hidden rounded-xl bg-surface-base dark:bg-core-primary-5 phone:flex-col phone:gap-6">
-        <ChartWidget stats={stat} className="w-1/2 rounded-none! bg-transparent dark:bg-transparent phone:w-full">
+      <div className="flex w-full flex-row overflow-hidden rounded-xl bg-surface-elevated-base shadow-100 phone:flex-col phone:gap-6">
+        <ChartWidget stats={stat} className="w-1/2 rounded-none! bg-transparent! shadow-none! phone:w-full">
           <SkeletonBar className="h-60 w-full" />
         </ChartWidget>
-        <div className="flex w-1/2 flex-col justify-between space-y-3 rounded-xl bg-transparent p-10 dark:bg-transparent phone:w-full phone:gap-4 phone:p-6 phone:pt-0">
+        <div className="flex w-1/2 flex-col justify-between space-y-3 rounded-xl bg-transparent p-10 phone:w-full phone:gap-4 phone:p-6 phone:pt-0">
           <SkeletonBar className="h-20 w-full" />
           <SkeletonBar className="h-20 w-full" />
           <SkeletonBar className="h-20 w-full" />

--- a/client/src/protoFleet/features/dashboard/components/UptimePanel/UptimePanel.tsx
+++ b/client/src/protoFleet/features/dashboard/components/UptimePanel/UptimePanel.tsx
@@ -76,11 +76,11 @@ export function UptimePanel({ duration, uptimeStatusCounts }: UptimePanelProps) 
     };
 
     return (
-      <div className="flex w-full flex-row overflow-hidden rounded-xl bg-surface-base dark:bg-core-primary-5 phone:flex-col phone:gap-6">
-        <ChartWidget stats={stat} className="w-1/2 rounded-none! bg-transparent dark:bg-transparent phone:w-full">
+      <div className="flex w-full flex-row overflow-hidden rounded-xl bg-surface-elevated-base shadow-100 phone:flex-col phone:gap-6">
+        <ChartWidget stats={stat} className="w-1/2 rounded-none! bg-transparent! shadow-none! phone:w-full">
           <SkeletonBar className="h-60 w-full" />
         </ChartWidget>
-        <div className="flex w-1/2 flex-col justify-center gap-16 space-y-3 rounded-xl bg-transparent p-10 dark:bg-transparent phone:w-full phone:gap-4 phone:p-6 phone:pt-0">
+        <div className="flex w-1/2 flex-col justify-center gap-16 space-y-3 rounded-xl bg-transparent p-10 phone:w-full phone:gap-4 phone:p-6 phone:pt-0">
           <SkeletonBar className="h-20 w-full" />
           <SkeletonBar className="h-20 w-full" />
         </div>

--- a/client/src/protoFleet/features/dashboard/pages/Dashboard.tsx
+++ b/client/src/protoFleet/features/dashboard/pages/Dashboard.tsx
@@ -20,6 +20,7 @@ import { TemperaturePanel } from "@/protoFleet/features/dashboard/components/Tem
 import { UptimePanel } from "@/protoFleet/features/dashboard/components/UptimePanel";
 import { MinersPage } from "@/protoFleet/features/onboarding";
 import { CompleteSetup } from "@/protoFleet/features/onboarding/components/CompleteSetup";
+import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
 import { useRouteSiteScope } from "@/protoFleet/routing/siteScope";
 import { useDuration, useHasPermission, useSetDuration } from "@/protoFleet/store";
 import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
@@ -54,6 +55,7 @@ const Dashboard = () => {
   const canViewAlerts = hasAlertRead && alertsEnabled;
   const currentYear = new Date().getFullYear();
   const { refs } = useStickyState();
+  const { bgClass } = usePageBackground();
 
   // The org's site catalog is owned by the shell-level SitesProvider (one
   // shared fetch). useActiveSite uses it to validate the route scope: a
@@ -193,7 +195,7 @@ const Dashboard = () => {
               )}
             </div>
             {canViewAlerts ? (
-              <div className="mt-6 flex flex-col gap-1">
+              <div className="mt-6 flex flex-col gap-4">
                 <ActiveAlertsCard />
               </div>
             ) : null}
@@ -205,18 +207,18 @@ const Dashboard = () => {
           {/* Performance Section */}
           <section className="pb-6">
             <div ref={refs.vertical.start} />
-            <div className="sticky top-0 z-2 bg-surface-5 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10 dark:bg-surface-base">
+            <div className={`${bgClass} sticky top-0 z-2 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10`}>
               <SectionHeading heading="Performance">
                 <DurationSelector duration={duration} durations={fleetDurations} onSelect={setDuration} />
               </SectionHeading>
             </div>
 
-            <div className="flex flex-col gap-1 px-6 laptop:px-10">
+            <div className="flex flex-col gap-4 px-6 pt-4 laptop:px-10">
               <HashratePanel duration={duration} metrics={hashrateMetrics} />
               <UptimePanel duration={duration} uptimeStatusCounts={uptimeStatusCounts} />
               <TemperaturePanel duration={duration} temperatureStatusCounts={temperatureStatusCounts} />
 
-              <div className="grid grid-cols-1 gap-1 laptop:grid-cols-2">
+              <div className="grid grid-cols-1 gap-4 laptop:grid-cols-2">
                 <PowerPanel duration={duration} metrics={powerMetrics} totalMiners={totalMiners} />
                 <EfficiencyPanel duration={duration} metrics={efficiencyMetrics} totalMiners={totalMiners} />
               </div>

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -762,7 +762,7 @@ function SiteScopeOption({
       className={`flex w-full items-center gap-3 rounded-md px-2 py-2.5 text-left text-300 ${
         disabled
           ? "cursor-not-allowed text-text-primary-50"
-          : "hover:bg-surface-base-hover focus-visible:bg-surface-base-hover text-text-primary"
+          : "text-text-primary hover:bg-surface-base-hover focus-visible:bg-surface-base-hover"
       }`}
       data-testid={testId}
     >

--- a/client/src/protoFleet/features/fleetManagement/components/RackHealthModule/RackHealthModule.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackHealthModule/RackHealthModule.tsx
@@ -130,7 +130,7 @@ export const RackHealthModule = ({
   }, [hashingCount, sleepingCount, needsAttentionCount, offlineCount, rackFilterParam, activeSite, navigate]);
 
   return (
-    <div className="flex w-full flex-col overflow-hidden rounded-xl bg-surface-base laptop:flex-row dark:bg-core-primary-5">
+    <div className="flex w-full flex-col overflow-hidden rounded-xl bg-surface-elevated-base shadow-100 laptop:flex-row">
       {/* Left Panel: Rack Grid */}
       <div className="flex w-full items-center justify-center p-6 laptop:w-1/2 laptop:p-10">
         <RackDetailGrid

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -28,11 +28,12 @@ import { SLOT_STATUS_MAP } from "@/protoFleet/features/fleetManagement/utils/rac
 import DeviceSetActionsMenu from "@/protoFleet/features/groupManagement/components/DeviceSetActionsMenu";
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
+import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 import Breadcrumb, { type BreadcrumbSegment, type BreadcrumbSibling } from "@/shared/components/Breadcrumb";
-import Button, { variants } from "@/shared/components/Button";
+import Button, { sizes, variants } from "@/shared/components/Button";
 import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
 import Header from "@/shared/components/Header";
 import ProgressCircular from "@/shared/components/ProgressCircular";
@@ -259,6 +260,7 @@ const RackOverviewPage = () => {
   const duration = useDuration();
   const setDuration = useSetDuration();
   const { refs } = useStickyState();
+  const { bgClass } = usePageBackground();
 
   // Component errors scoped to rack's devices
   const componentErrorsOptions = useMemo(
@@ -375,55 +377,58 @@ const RackOverviewPage = () => {
       <div className="flex flex-col">
         {/* Header */}
         <div className="p-6 pb-0 laptop:p-10 laptop:pb-0">
-          <Breadcrumb segments={rackBreadcrumbSegments} testId="rack-page-breadcrumb" />
-          <Header
-            title={rack?.label ?? ""}
-            titleSize="text-heading-300"
-            subtitle={rackInfo?.zone || undefined}
-            subtitleSize="text-300"
-            subtitleClassName="text-text-primary"
-            inline
-            className="mt-3"
-          >
-            <div className="ml-3 flex items-center gap-3">
-              <Button
-                variant={variants.secondary}
-                onClick={() => navigate(scopedPath(`/fleet/miners?rack=${rack?.id}`, activeSite))}
-              >
-                View miners
-              </Button>
-              <Button
-                variant={variants.secondary}
-                onClick={() => sleepActionRef.current?.()}
-                disabled={!memberDeviceIds || memberDeviceIds.length === 0}
-              >
-                Sleep all miners
-              </Button>
-              <Button variant={variants.secondary} onClick={() => setShowEditModal(true)}>
-                Edit rack
-              </Button>
-              <DeviceSetActionsMenu
-                memberDeviceIds={memberDeviceIds ?? []}
-                deviceSetId={rack?.id}
-                deviceSetType="rack"
-                onEdit={() => setShowEditModal(true)}
-                editLabel="Edit rack"
-                onActionComplete={() => {
-                  if (rack) {
-                    resolveRack(rack.id);
-                    void refetchStats();
-                  }
-                }}
-                sleepActionRef={sleepActionRef}
-                actionActiveRef={actionActiveRef}
-              />
-            </div>
-          </Header>
+          <div className="flex flex-col gap-3">
+            <Breadcrumb segments={rackBreadcrumbSegments} testId="rack-page-breadcrumb" />
+            <Header
+              title={rack?.label ?? ""}
+              titleSize="text-heading-300"
+              subtitle={rackInfo?.zone || undefined}
+              subtitleSize="text-300"
+              subtitleClassName="text-text-primary"
+              inline
+            >
+              <div className="ml-3 flex items-center gap-3">
+                <Button
+                  variant={variants.secondary}
+                  size={sizes.compact}
+                  onClick={() => navigate(scopedPath(`/fleet/miners?rack=${rack?.id}`, activeSite))}
+                >
+                  View miners
+                </Button>
+                <Button
+                  variant={variants.secondary}
+                  size={sizes.compact}
+                  onClick={() => sleepActionRef.current?.()}
+                  disabled={!memberDeviceIds || memberDeviceIds.length === 0}
+                >
+                  Sleep all miners
+                </Button>
+                <Button variant={variants.secondary} size={sizes.compact} onClick={() => setShowEditModal(true)}>
+                  Edit rack
+                </Button>
+                <DeviceSetActionsMenu
+                  memberDeviceIds={memberDeviceIds ?? []}
+                  deviceSetId={rack?.id}
+                  deviceSetType="rack"
+                  onEdit={() => setShowEditModal(true)}
+                  editLabel="Edit rack"
+                  onActionComplete={() => {
+                    if (rack) {
+                      resolveRack(rack.id);
+                      void refetchStats();
+                    }
+                  }}
+                  sleepActionRef={sleepActionRef}
+                  actionActiveRef={actionActiveRef}
+                />
+              </div>
+            </Header>
+          </div>
         </div>
 
         {/* Health Overview Section */}
-        <section className="p-6 laptop:p-10">
-          <div className="flex flex-col gap-1">
+        <section className="px-6 pt-6 pb-6 laptop:px-10 laptop:pt-6 laptop:pb-10">
+          <div className="flex flex-col gap-4">
             <RackHealthModule
               rows={rows}
               cols={cols}
@@ -451,7 +456,7 @@ const RackOverviewPage = () => {
         {/* Performance Section */}
         <section className="pb-6">
           <div ref={refs.vertical.start} />
-          <div className="sticky top-0 z-2 bg-surface-5 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10 dark:bg-surface-base">
+          <div className={`${bgClass} sticky top-0 z-2 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10`}>
             <div className="flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between">
               <div className="text-heading-200 text-text-primary">Performance</div>
               <div className="flex items-center gap-6 text-200 text-core-primary-50">
@@ -508,7 +513,7 @@ const RackOverviewPage = () => {
             </div>
           </div>
 
-          <div className="px-6 laptop:px-10">
+          <div className="px-6 pt-4 laptop:px-10">
             <DeviceSetPerformanceSection duration={duration} metrics={metrics} />
           </div>
           {/* eslint-disable-next-line react-hooks/refs -- ref object from useStickyState is passed to <div ref>; React writes .current during commit, not read during render */}

--- a/client/src/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection.tsx
+++ b/client/src/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection.tsx
@@ -312,7 +312,7 @@ export function DeviceSetPerformanceSection({ duration, metrics: allMetrics }: D
   );
 
   return (
-    <div className="grid grid-cols-2 gap-1 phone:grid-cols-1">
+    <div className="grid grid-cols-2 gap-4 phone:grid-cols-1">
       <ChartPanel
         label="Hashrate"
         metrics={hashrateMetrics}

--- a/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
+++ b/client/src/protoFleet/features/groupManagement/pages/GroupOverviewPage.tsx
@@ -13,6 +13,7 @@ import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManageme
 import FleetHealth from "@/protoFleet/features/groupManagement/components/FleetHealth";
 import GroupModal from "@/protoFleet/features/groupManagement/components/GroupModal";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
+import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -122,6 +123,7 @@ const GroupOverviewPage = () => {
   const duration = useDuration();
   const setDuration = useSetDuration();
   const { refs } = useStickyState();
+  const { bgClass } = usePageBackground();
 
   // Component errors scoped to group's devices
   // Pass undefined when no members yet (loading); pass empty array for truly empty groups
@@ -232,7 +234,7 @@ const GroupOverviewPage = () => {
 
         {/* Overview Section */}
         <section className="p-6 laptop:p-10">
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-4">
             <FleetHealth
               title="Miners"
               fleetSize={stateCounts ? totalMiners : memberDeviceIds ? groupSize : undefined}
@@ -258,7 +260,7 @@ const GroupOverviewPage = () => {
         {/* Performance Section */}
         <section className="pb-6">
           <div ref={refs.vertical.start} />
-          <div className="sticky top-0 z-2 bg-surface-5 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10 dark:bg-surface-base">
+          <div className={`${bgClass} sticky top-0 z-2 px-6 pt-6 pb-6 laptop:px-10 laptop:pt-10`}>
             <div className="flex flex-col gap-4 tablet:flex-row tablet:items-center tablet:justify-between">
               <div className="text-heading-200 text-text-primary">Performance</div>
               <div className="flex items-center gap-6 text-200 text-core-primary-50">
@@ -315,7 +317,7 @@ const GroupOverviewPage = () => {
             </div>
           </div>
 
-          <div className="px-6 laptop:px-10">
+          <div className="px-6 pt-4 laptop:px-10">
             <DeviceSetPerformanceSection duration={duration} metrics={metrics} />
           </div>
           {/* eslint-disable-next-line react-hooks/refs -- ref object from useStickyState is passed to <div ref>; React writes .current during commit, not read during render */}

--- a/client/src/protoFleet/features/kpis/components/ComponentErrors/ComponentErrors.tsx
+++ b/client/src/protoFleet/features/kpis/components/ComponentErrors/ComponentErrors.tsx
@@ -50,9 +50,8 @@ const ComponentErrors = ({ icon, heading, errorCount, href, className }: Compone
   const isClickable = href && errorCount && errorCount > 0;
 
   const baseClassName = clsx(
-    // Contrasting card surface, matching the rack grid cards.
-    "flex items-center gap-3 rounded-xl bg-surface-overlay p-4",
-    isClickable && "hover:bg-core-primary-10",
+    "flex items-center gap-3 rounded-xl bg-surface-elevated-base p-4 shadow-100",
+    isClickable && "hover:bg-surface-base-hover",
     className,
   );
 

--- a/client/src/protoFleet/features/kpis/components/FleetErrors/FleetErrors.tsx
+++ b/client/src/protoFleet/features/kpis/components/FleetErrors/FleetErrors.tsx
@@ -29,7 +29,7 @@ const FleetErrors = ({
   const minerIssuesHref = (issue: string) => scopedPath(`/fleet/miners?issues=${issue}${suffix}`, activeSite);
   return (
     <div className={className}>
-      <div className="grid grid-cols-1 gap-1 tablet:grid-cols-2 laptop:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 tablet:grid-cols-2 laptop:grid-cols-4">
         <ComponentErrors
           icon={<ControlBoard />}
           heading="Control Boards"

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.stories.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.stories.tsx
@@ -25,7 +25,7 @@ const TaskCard = ({
   isLoading = false,
 }: TaskCardProps) => {
   return (
-    <div className="flex flex-col justify-between gap-4 rounded-2xl bg-surface-base p-6">
+    <div className="flex flex-col justify-between gap-4 rounded-2xl bg-surface-overlay p-6">
       <div className="flex flex-col gap-4">
         <div className="flex size-8 items-center justify-center rounded-lg bg-surface-5">{icon}</div>
         <div className="flex flex-col">

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
@@ -36,7 +36,7 @@ const TaskCard = ({
   isLoading = false,
 }: TaskCardProps) => {
   return (
-    <div className="flex flex-col justify-between gap-4 rounded-2xl bg-surface-base p-6">
+    <div className="flex flex-col justify-between gap-4 rounded-2xl bg-surface-overlay p-6">
       <div className="flex flex-col gap-4">
         <div className="flex size-8 items-center justify-center rounded-lg bg-surface-5">{icon}</div>
         <div className="flex flex-col">
@@ -402,7 +402,7 @@ const CompleteSetup = ({
     <>
       {shouldShow ? (
         <div className={className}>
-          <div className="@container rounded-3xl bg-core-primary-5 p-6">
+          <div className="@container rounded-xl bg-surface-elevated-base p-6 shadow-100">
             <div className="mb-6 flex items-center justify-between gap-x-10">
               <div className="text-heading-300">Complete setup</div>
               <Button

--- a/client/src/protoFleet/features/sites/components/SiteMetricsRow.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteMetricsRow.tsx
@@ -25,8 +25,7 @@ interface SiteMetricsRowProps {
   buildingCount: number;
   // `undefined` while metrics are still loading; the children render skeletons.
   metrics: SiteMetricsRowMetrics | undefined;
-  // Tile size. Defaults to the large `default` Metric scale used on the Sites
-  // list; the site detail page passes `compact` for its tighter header strip.
+  // Tile size. Defaults to the large `default` Metric scale used by top metric rows.
   variant?: "default" | "compact";
   testId?: string;
 }

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -244,24 +244,27 @@ const SiteDetailPage = () => {
             testId="site-detail-inline-error"
           />
         ) : null}
-        <Breadcrumb
-          segments={[
-            { label: "Sites", to: "/fleet/sites" },
-            { label: site.site.name, siblings: siteSiblings.length > 1 ? siteSiblings : undefined },
-          ]}
-          testId="site-detail-breadcrumb"
-        />
-        <div className="flex items-start justify-between gap-4">
-          <Header title={site.site.name} titleSize="text-heading-300" testId="site-detail-title" />
-          {canManageSites ? (
-            <Button
-              variant={variants.primary}
-              size={sizes.compact}
-              text="Edit site"
-              onClick={() => modals.openManageEdit(site.site!)}
-              testId="site-detail-edit"
-            />
-          ) : null}
+        <div className="flex flex-col gap-3">
+          <Breadcrumb
+            segments={[
+              { label: "Sites", to: "/fleet/sites" },
+              { label: site.site.name, siblings: siteSiblings.length > 1 ? siteSiblings : undefined },
+            ]}
+            testId="site-detail-breadcrumb"
+          />
+          <Header title={site.site.name} titleSize="text-heading-300" inline testId="site-detail-title">
+            {canManageSites ? (
+              <div className="ml-3 flex items-center gap-3">
+                <Button
+                  variant={variants.primary}
+                  size={sizes.compact}
+                  text="Edit site"
+                  onClick={() => modals.openManageEdit(site.site!)}
+                  testId="site-detail-edit"
+                />
+              </div>
+            ) : null}
+          </Header>
         </div>
         <div className="flex flex-col gap-4">
           {siteStatsError ? (
@@ -281,7 +284,6 @@ const SiteDetailPage = () => {
             powerCapacityMw={site.site.powerCapacityMw}
             buildingCount={detailBuildingCount}
             metrics={siteStats}
-            variant="compact"
             testId="site-detail-metrics-row"
           />
         </div>
@@ -311,7 +313,7 @@ const SiteDetailPage = () => {
               testId="site-detail-buildings-error"
             />
           ) : null}
-          <div className="rounded-xl bg-surface-base p-10 dark:bg-core-primary-5 phone:p-6">
+          <div className="rounded-xl bg-surface-elevated-base p-10 shadow-100 phone:p-6">
             {visibleBuildings === undefined ? (
               <div className="text-200 text-text-primary-50">Loading buildings…</div>
             ) : visibleBuildings.length === 0 ? (

--- a/client/src/protoFleet/hooks/usePageBackground.ts
+++ b/client/src/protoFleet/hooks/usePageBackground.ts
@@ -1,24 +1,3 @@
-import { useContext } from "react";
-import { UNSAFE_DataRouterContext, UNSAFE_DataRouterStateContext } from "react-router";
-
-export type PageBackground = "surface-5" | "surface-base";
-
-const bgClassMap: Record<PageBackground, string> = {
-  "surface-5": "bg-surface-5 dark:bg-surface-base",
-  "surface-base": "bg-surface-base",
-};
-
 export const usePageBackground = () => {
-  // Read the data router state directly via context instead of useMatches(),
-  // so we can safely fall back when rendered under a plain <MemoryRouter> (tests/storybook).
-  const dataRouterContext = useContext(UNSAFE_DataRouterContext);
-  const state = useContext(UNSAFE_DataRouterStateContext);
-
-  let bg: PageBackground = "surface-base";
-  if (dataRouterContext && state) {
-    const matches = state.matches;
-    bg = (matches[matches.length - 1]?.route?.handle as { bg?: PageBackground } | undefined)?.bg ?? "surface-base";
-  }
-
-  return { bg, bgClass: bgClassMap[bg] };
+  return { bgClass: "bg-surface-base" };
 };

--- a/client/src/protoFleet/router.tsx
+++ b/client/src/protoFleet/router.tsx
@@ -4,7 +4,6 @@ import { createBrowserRouter, LoaderFunction, LoaderFunctionArgs, Navigate, Outl
 
 import App from "./components/App";
 import SingleMinerWrapper from "./components/SingleMinerWrapper";
-import type { PageBackground } from "./hooks/usePageBackground";
 import {
   importActivityPage,
   importAuth,
@@ -176,14 +175,12 @@ const scopedGroupDetailRedirectLoader = async ({ params, request }: LoaderFuncti
 interface CreateRouteOptions {
   fullscreen?: boolean;
   loader?: LoaderFunction;
-  bg?: PageBackground;
 }
 
 const createRoute = (path: string, children: ReactNode, options: CreateRouteOptions = {}) => ({
   path,
   element: <App fullscreen={options.fullscreen}>{children}</App>,
   ...(options.loader && { loader: options.loader }),
-  ...(options.bg && { handle: { bg: options.bg } }),
 });
 
 const createFleetChildren = () => [
@@ -209,7 +206,7 @@ const createFleetRoute = (path: string) => ({
 
 const createScopableRoutes = (absolute: boolean) => [
   ...(absolute ? [] : [{ index: true, element: <Navigate to="dashboard" replace /> }]),
-  createRoute(absolute ? "/dashboard" : "dashboard", <Dashboard />, { bg: "surface-5" }),
+  createRoute(absolute ? "/dashboard" : "dashboard", <Dashboard />),
   createFleetRoute(absolute ? "/fleet" : "fleet"),
   createRoute(absolute ? "/groups" : "groups", <GroupsPage />),
   createRoute(absolute ? "/energy" : "energy", <EnergyPage />),
@@ -242,13 +239,13 @@ const router = createBrowserRouter([
   { path: "/miners", loader: minersRedirectLoader },
   { path: "/racks", loader: racksRedirectLoader },
 
-  createRoute("/racks/:rackId", <RackOverviewPage />, { bg: "surface-5" }),
-  createRoute("/groups/:groupLabel", <GroupOverviewPage />, { bg: "surface-5" }),
+  createRoute("/racks/:rackId", <RackOverviewPage />),
+  createRoute("/groups/:groupLabel", <GroupOverviewPage />),
 
   // /sites redirects into /fleet/sites.
   { path: "/sites", loader: sitesRedirectLoader },
-  createRoute("/sites/:id", <SiteDetailPage />, { bg: "surface-5" }),
-  createRoute("/buildings/:id", <BuildingPage />, { bg: "surface-5" }),
+  createRoute("/sites/:id", <SiteDetailPage />),
+  createRoute("/buildings/:id", <BuildingPage />),
 
   // Single miner (fullscreen - protoOS routes handle layout). SingleMinerWrapper
   // wraps the parent Outlet so it stays mounted across tab navigations — the

--- a/client/src/shared/styles/theme.css
+++ b/client/src/shared/styles/theme.css
@@ -91,6 +91,7 @@ theme below. Phone and tablet-only cover exact-range layouts. */
   --color-surface-20: rgb(var(--base_gray_20));
   --color-surface-default: rgb(var(--base_white_100) / 2%);
   --color-surface-base: rgb(var(--base_white_100));
+  --color-surface-base-hover: rgb(var(--base_black_100) / 5%);
   --color-surface-elevated-base: rgb(var(--base_white_100));
   --color-surface-overlay: rgb(var(--base_black_100) / 5%);
   --color-border-5: rgb(var(--base_black_100) / 5%);
@@ -331,6 +332,7 @@ theme below. Phone and tablet-only cover exact-range layouts. */
     --color-surface-10: rgb(var(--base_gray_70));
     --color-surface-20: rgb(var(--base_gray_80));
     --color-surface-base: rgb(var(--base_gray_90));
+    --color-surface-base-hover: rgb(var(--base_white_100) / 5%);
     --color-surface-elevated-base: rgb(var(--base_gray_80));
     --color-surface-overlay: rgb(var(--base_white_100) / 5%);
     --color-border-5: rgb(var(--base_white_100) / 5%);


### PR DESCRIPTION
## Summary
- align fleet base pages to white backgrounds while using elevated card surfaces with the shared shadow treatment
- add overflow/spacing buffers around dashboard and detail content so elevated shadows are not clipped
- normalize site, building, and rack detail headers: breadcrumb/title/action spacing, larger top metrics, and compact action buttons

## Tests
- ./node_modules/.bin/tsc --noEmit --pretty false
- NODE_OPTIONS=--localstorage-file=/tmp/proto-fleet-vitest-localstorage ./node_modules/.bin/vitest run src/protoFleet/features/dashboard/components/SitesSection/SitesSection.test.tsx src/protoFleet/features/dashboard/components/ChartWidget/ChartWidget.test.tsx src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx src/protoFleet/features/buildings/pages/BuildingPage.test.tsx src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
- git diff --check origin/main...HEAD