### PR TITLE
fix(curtailment): support MQTT shared-subscription filters

### DIFF
--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -234,8 +235,24 @@ func (c *Client) replaySubscriptions(ctx context.Context, client subscriptionCli
 
 func (c *Client) addRoutes(client routeClient) {
 	for topic, handler := range c.subscriptionSnapshot() {
-		client.AddRoute(topic, handler)
+		client.AddRoute(normalizeTopicFilter(topic), handler)
 	}
+}
+
+// normalizeTopicFilter strips shared-subscription prefixes the same way paho
+// v1.5.1 does in Subscribe. Staged routes must use the normalized form:
+// paho's router only strips $share (never $queue) when matching, and a route
+// staged under the original filter would duplicate the normalized route paho
+// adds on Subscribe, delivering each message twice.
+func normalizeTopicFilter(topic string) string {
+	if strings.HasPrefix(topic, "$share/") {
+		parts := strings.SplitN(topic, "/", 3)
+		if len(parts) == 3 {
+			return parts[2]
+		}
+		return topic
+	}
+	return strings.TrimPrefix(topic, "$queue/")
 }
 
 func (c *Client) subscriptionSnapshot() map[string]paho.MessageHandler {

--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -254,7 +254,7 @@ func normalizeTopicFilter(topic string) string {
 		}
 		return topic
 	}
-	if rest := strings.TrimPrefix(topic, "$queue/"); rest != "" {
+	if rest, ok := strings.CutPrefix(topic, "$queue/"); ok && rest != "" {
 		return rest
 	}
 	return topic

--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -243,16 +243,21 @@ func (c *Client) addRoutes(client routeClient) {
 // v1.5.1 does in Subscribe. Staged routes must use the normalized form:
 // paho's router only strips $share (never $queue) when matching, and a route
 // staged under the original filter would duplicate the normalized route paho
-// adds on Subscribe, delivering each message twice.
+// adds on Subscribe, delivering each message twice. Degenerate filters with
+// an empty remainder ("$queue/", "$share/<group>/") are kept as-is rather
+// than registering an empty-topic route; Subscribe fails them normally.
 func normalizeTopicFilter(topic string) string {
 	if strings.HasPrefix(topic, "$share/") {
 		parts := strings.SplitN(topic, "/", 3)
-		if len(parts) == 3 {
+		if len(parts) == 3 && parts[2] != "" {
 			return parts[2]
 		}
 		return topic
 	}
-	return strings.TrimPrefix(topic, "$queue/")
+	if rest := strings.TrimPrefix(topic, "$queue/"); rest != "" {
+		return rest
+	}
+	return topic
 }
 
 func (c *Client) subscriptionSnapshot() map[string]paho.MessageHandler {

--- a/server/internal/infrastructure/mqttclient/client.go
+++ b/server/internal/infrastructure/mqttclient/client.go
@@ -342,9 +342,19 @@ func validateSubscribeResult(topic string, token paho.Token) error {
 	if !ok {
 		return nil
 	}
-	qos, ok := resultToken.Result()[topic]
+	result := resultToken.Result()
+	qos, ok := result[topic]
 	if !ok {
-		return errors.New("SUBACK missing topic result")
+		// Paho v1.5.1 keys single-topic SUBACK results by the normalized
+		// filter ($share/<group>/ and $queue/ prefixes stripped), not the
+		// original one. The wrapper subscribes one topic at a time, so a
+		// sole result entry is that subscription's outcome.
+		if len(result) != 1 {
+			return errors.New("SUBACK missing topic result")
+		}
+		for _, soleQoS := range result {
+			qos = soleQoS
+		}
 	}
 	if qos == subscribeFailureCode {
 		return fmt.Errorf("SUBACK rejected subscription with code 0x%02x", qos)

--- a/server/internal/infrastructure/mqttclient/client_test.go
+++ b/server/internal/infrastructure/mqttclient/client_test.go
@@ -229,6 +229,87 @@ func TestReplaySubscriptionsReportsSubackFailure(t *testing.T) {
 	}
 }
 
+func TestValidateSubscribeResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		topic   string
+		result  map[string]byte
+		wantErr string
+	}{
+		{
+			name:   "exact topic result succeeds",
+			topic:  "maestro/target",
+			result: map[string]byte{"maestro/target": 1},
+		},
+		{
+			name:   "shared group filter succeeds with paho-normalized result key",
+			topic:  "$share/group/maestro/target",
+			result: map[string]byte{"maestro/target": 1},
+		},
+		{
+			name:   "queue filter succeeds with paho-normalized result key",
+			topic:  "$queue/maestro/target",
+			result: map[string]byte{"maestro/target": 1},
+		},
+		{
+			name:    "rejected SUBACK code fails",
+			topic:   "maestro/target",
+			result:  map[string]byte{"maestro/target": subscribeFailureCode},
+			wantErr: "SUBACK rejected subscription",
+		},
+		{
+			name:    "rejected SUBACK code fails via sole-entry fallback",
+			topic:   "$share/group/maestro/target",
+			result:  map[string]byte{"maestro/target": subscribeFailureCode},
+			wantErr: "SUBACK rejected subscription",
+		},
+		{
+			name:    "invalid QoS fails",
+			topic:   "maestro/target",
+			result:  map[string]byte{"maestro/target": 3},
+			wantErr: "SUBACK returned invalid QoS",
+		},
+		{
+			name:    "empty result map fails",
+			topic:   "maestro/target",
+			result:  map[string]byte{},
+			wantErr: "SUBACK missing topic result",
+		},
+		{
+			name:  "multi-result map missing exact topic fails",
+			topic: "maestro/target",
+			result: map[string]byte{
+				"other/topic":   1,
+				"another/topic": 1,
+			},
+			wantErr: "SUBACK missing topic result",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateSubscribeResult(tt.topic, completedSubscribeToken{result: tt.result})
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateSubscribeResult returned error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateSubscribeResult returned nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestSubscribeBeforeConnectStagesRoute(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/infrastructure/mqttclient/client_test.go
+++ b/server/internal/infrastructure/mqttclient/client_test.go
@@ -272,6 +272,20 @@ func TestValidateSubscribeResult(t *testing.T) {
 			wantErr: "SUBACK returned invalid QoS",
 		},
 		{
+			name:    "invalid QoS fails via sole-entry fallback",
+			topic:   "$share/group/maestro/target",
+			result:  map[string]byte{"maestro/target": 3},
+			wantErr: "SUBACK returned invalid QoS",
+		},
+		{
+			// Pins the deliberate leniency: the wrapper subscribes one topic
+			// at a time, so a sole result entry is trusted even when its key
+			// does not textually match the subscribed filter.
+			name:   "sole entry accepted for non-shared topic mismatch",
+			topic:  "maestro/target",
+			result: map[string]byte{"other/topic": 1},
+		},
+		{
 			name:    "empty result map fails",
 			topic:   "maestro/target",
 			result:  map[string]byte{},
@@ -310,6 +324,14 @@ func TestValidateSubscribeResult(t *testing.T) {
 	}
 }
 
+func TestValidateSubscribeResultIgnoresTokenWithoutResult(t *testing.T) {
+	t.Parallel()
+
+	if err := validateSubscribeResult("maestro/target", completedToken{}); err != nil {
+		t.Fatalf("validateSubscribeResult returned error for plain token: %v", err)
+	}
+}
+
 func TestSubscribeBeforeConnectStagesRoute(t *testing.T) {
 	t.Parallel()
 
@@ -330,6 +352,41 @@ func TestSubscribeBeforeConnectStagesRoute(t *testing.T) {
 	}
 	if recorder.calls[0].callback == nil {
 		t.Fatal("callback was not staged")
+	}
+}
+
+func TestAddRoutesNormalizesSharedSubscriptionFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		topic string
+		want  string
+	}{
+		{name: "share prefix stripped", topic: "$share/group/maestro/target", want: "maestro/target"},
+		{name: "queue prefix stripped", topic: "$queue/maestro/target", want: "maestro/target"},
+		{name: "plain topic unchanged", topic: "maestro/target", want: "maestro/target"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := New()
+			if err := client.Subscribe(t.Context(), tt.topic, func(_ []byte, _ time.Time) {}); err != nil {
+				t.Fatalf("Subscribe returned error: %v", err)
+			}
+
+			recorder := &routeRecorder{}
+			client.addRoutes(recorder)
+
+			if len(recorder.calls) != 1 {
+				t.Fatalf("routes added = %d, want 1", len(recorder.calls))
+			}
+			if recorder.calls[0].topic != tt.want {
+				t.Fatalf("route topic = %q, want %q", recorder.calls[0].topic, tt.want)
+			}
+		})
 	}
 }
 

--- a/server/internal/infrastructure/mqttclient/client_test.go
+++ b/server/internal/infrastructure/mqttclient/client_test.go
@@ -366,6 +366,9 @@ func TestAddRoutesNormalizesSharedSubscriptionFilters(t *testing.T) {
 		{name: "share prefix stripped", topic: "$share/group/maestro/target", want: "maestro/target"},
 		{name: "queue prefix stripped", topic: "$queue/maestro/target", want: "maestro/target"},
 		{name: "plain topic unchanged", topic: "maestro/target", want: "maestro/target"},
+		{name: "queue prefix with empty remainder unchanged", topic: "$queue/", want: "$queue/"},
+		{name: "share prefix with empty remainder unchanged", topic: "$share/group/", want: "$share/group/"},
+		{name: "share prefix missing topic segment unchanged", topic: "$share/group", want: "$share/group"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Reviewable diff: +30/-3 across 1 file (excludes generated, test, and story files).

Fixes #629.

## Summary

Operators using valid MQTT shared-subscription filters (`$share/<group>/...`, `$queue/...`) for curtailment sources could not test, start, or reconnect them: SUBACK validation rejected the subscription even when the broker accepted it. This PR makes the wrapper's SUBACK validation and staged message routes agree with how Paho v1.5.1 actually normalizes shared-subscription filters, so shared filters connect, validate, and deliver messages correctly.

## How it works

Paho v1.5.1 strips `$share/<group>/` and `$queue/` prefixes from a single-topic `Subscribe` before recording the token topic, so the SUBACK result map is keyed by the normalized filter while our `validateSubscribeResult` looked up the original one and returned `SUBACK missing topic result`. Since the wrapper subscribes one topic at a time, the fix keeps the exact-key lookup as the primary path and, when the exact key is absent and the result map has exactly one entry, validates that sole entry's QoS. Empty maps and multi-entry maps without the exact key remain errors; `0x80` rejection and invalid-QoS checks are preserved, including through the fallback.

Fixing SUBACK validation made shared filters newly reachable end to end, which exposed a second normalization gap in staged routes. `Subscribe` before `Connect` stages the handler and `Connect` registers it via `AddRoute` using the original filter. Paho's router strips `$share` when matching (so those routes duplicated the normalized route Paho adds on `Subscribe`, delivering each message twice) but never strips `$queue` (so those staged routes matched nothing, silently dropping messages queued by the broker in the CONNACK-to-SUBACK window). `addRoutes` now registers staged routes under the same normalized form Paho uses, so the later `Subscribe` replaces the route in place instead of duplicating it.

```mermaid
flowchart LR
    A["Curtailment source config<br/>topic: $share/g/maestro/target"] --> B["mqttclient.Connect"]
    B --> C["addRoutes<br/>(normalized filter)"]
    B --> D["client.Subscribe<br/>(original filter)"]
    D --> E["Broker SUBACK"]
    E --> F["validateSubscribeResult<br/>exact key, else sole-entry fallback"]
    F -->|"QoS 0-2"| G["Source healthy, messages flow"]
    F -->|"0x80 or invalid QoS"| H["Subscribe error surfaced"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/infrastructure/mqttclient/client.go` | `validateSubscribeResult` gains a sole-entry fallback; `addRoutes` registers staged routes via new `normalizeTopicFilter` | The whole change; both paths must mirror Paho v1.5.1's normalization exactly |
| `server/internal/infrastructure/mqttclient/client_test.go` | Table-driven `TestValidateSubscribeResult` (10 cases), `TestValidateSubscribeResultIgnoresTokenWithoutResult`, `TestAddRoutesNormalizesSharedSubscriptionFilters` | Pins the seven scenarios from #629 plus fallback rejection paths and deliberate sole-entry leniency |

## Key technical decisions & trade-offs

- **Sole-entry fallback over replicating Paho's normalization in validation.** Duplicating the prefix-stripping would couple us to Paho internals twice; trusting the sole entry of a single-topic subscribe is simpler and the wrapper never batch-subscribes. Trade-off: a broker returning a result keyed by an unrelated topic is accepted — acceptable because SUBACK carries only return codes (no topics), so the keys always come from Paho's own recorded subscription, not the broker.
- **Normalizing staged routes rather than teaching the router about `$queue`.** The router is Paho's; registering routes in the form Paho itself uses makes `Subscribe` replace (not duplicate) the staged route and fixes `$queue` matching with no behavioral change for plain topics.

## Testing & validation

- `go test ./internal/infrastructure/mqttclient/` — all pass; new tests observed red before each fix.
- `golangci-lint run ./internal/infrastructure/mqttclient/...` — 0 issues.
- Downstream consumer suite `go test ./internal/domain/curtailment/mqttingest/` — pass.
- Not covered: no live broker integration test with a real shared-subscription-capable broker (e.g. EMQX/HiveMQ); validation is unit-level against Paho v1.5.1's recorded behavior.

## Post-Deploy Monitoring & Validation

- **Logs:** search fleetd logs for `SUBACK missing topic result` — should no longer appear for sources configured with `$share`/`$queue` filters; `SUBACK rejected subscription` still indicates genuine broker rejection (e.g. broker without shared-subscription support on MQTT 3.1.1).
- **Healthy signal:** curtailment MQTT sources with shared filters show connected+subscribed runtime status after test/start/reconnect.
- **Failure signal / rollback trigger:** duplicate curtailment signal processing (double handling of one publish) or sources stuck disconnected after this deploys — revert the PR; no schema or config migration involved.
- **Window / owner:** first 24h after deploy, owner @rongxin-liu.