### PR TITLE
fix(client): avoid Web Crypto for unpair batch ids

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -1323,9 +1323,14 @@ describe("useMinerActions", () => {
       );
     });
 
-    it("should fall back to a client batch identifier when crypto.randomUUID is unavailable", async () => {
+    it("should use a local client batch identifier instead of crypto.randomUUID", async () => {
       const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
-      Object.defineProperty(globalThis, "crypto", { value: {}, writable: true, configurable: true });
+      const randomUUID = vi.fn(() => "crypto-generated-id");
+      Object.defineProperty(globalThis, "crypto", {
+        value: { randomUUID },
+        writable: true,
+        configurable: true,
+      });
       mockDeleteMiners.mockImplementation(({ onSuccess }: any) => {
         onSuccess({ deletedCount: 1 });
       });
@@ -1357,6 +1362,7 @@ describe("useMinerActions", () => {
             deviceIdentifiers: ["device-1"],
           }),
         );
+        expect(randomUUID).not.toHaveBeenCalled();
         expect(mockDeleteMiners).toHaveBeenCalled();
         expect(mockCompleteBatchOperation).toHaveBeenCalledWith(batch.batchIdentifier);
       } finally {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -1323,6 +1323,49 @@ describe("useMinerActions", () => {
       );
     });
 
+    it("should fall back to a client batch identifier when crypto.randomUUID is unavailable", async () => {
+      const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+      Object.defineProperty(globalThis, "crypto", { value: {}, writable: true, configurable: true });
+      mockDeleteMiners.mockImplementation(({ onSuccess }: any) => {
+        onSuccess({ deletedCount: 1 });
+      });
+
+      try {
+        const { result } = renderHook(() =>
+          useMinerActions({
+            ...batchOpsParams(),
+            selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
+            selectionMode: "subset",
+          }),
+        );
+
+        const deleteAction = result.current.popoverActions.find((a) => a.action === deviceActions.unpair);
+
+        act(() => {
+          deleteAction?.actionHandler();
+        });
+
+        await act(async () => {
+          await result.current.handleConfirmation();
+        });
+
+        const batch = mockStartBatchOperation.mock.calls[0][0];
+        expect(batch).toEqual(
+          expect.objectContaining({
+            batchIdentifier: expect.stringMatching(/^unpair-/),
+            action: deviceActions.unpair,
+            deviceIdentifiers: ["device-1"],
+          }),
+        );
+        expect(mockDeleteMiners).toHaveBeenCalled();
+        expect(mockCompleteBatchOperation).toHaveBeenCalledWith(batch.batchIdentifier);
+      } finally {
+        if (originalCryptoDescriptor) {
+          Object.defineProperty(globalThis, "crypto", originalCryptoDescriptor);
+        }
+      }
+    });
+
     it("should complete batch operation on deleteMiners error", async () => {
       mockDeleteMiners.mockImplementation(({ onError }: any) => {
         onError("delete failed");

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -1304,6 +1304,7 @@ describe("useMinerActions", () => {
 
       expect(mockStartBatchOperation).toHaveBeenCalledWith(
         expect.objectContaining({
+          batchIdentifier: expect.stringMatching(/^unpair-/),
           action: deviceActions.unpair,
           deviceIdentifiers: ["device-1"],
         }),
@@ -1321,55 +1322,6 @@ describe("useMinerActions", () => {
           status: "success",
         }),
       );
-    });
-
-    it("should use a local client batch identifier instead of crypto.randomUUID", async () => {
-      const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
-      const randomUUID = vi.fn(() => "crypto-generated-id");
-      Object.defineProperty(globalThis, "crypto", {
-        value: { randomUUID },
-        writable: true,
-        configurable: true,
-      });
-      mockDeleteMiners.mockImplementation(({ onSuccess }: any) => {
-        onSuccess({ deletedCount: 1 });
-      });
-
-      try {
-        const { result } = renderHook(() =>
-          useMinerActions({
-            ...batchOpsParams(),
-            selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
-            selectionMode: "subset",
-          }),
-        );
-
-        const deleteAction = result.current.popoverActions.find((a) => a.action === deviceActions.unpair);
-
-        act(() => {
-          deleteAction?.actionHandler();
-        });
-
-        await act(async () => {
-          await result.current.handleConfirmation();
-        });
-
-        const batch = mockStartBatchOperation.mock.calls[0][0];
-        expect(batch).toEqual(
-          expect.objectContaining({
-            batchIdentifier: expect.stringMatching(/^unpair-/),
-            action: deviceActions.unpair,
-            deviceIdentifiers: ["device-1"],
-          }),
-        );
-        expect(randomUUID).not.toHaveBeenCalled();
-        expect(mockDeleteMiners).toHaveBeenCalled();
-        expect(mockCompleteBatchOperation).toHaveBeenCalledWith(batch.batchIdentifier);
-      } finally {
-        if (originalCryptoDescriptor) {
-          Object.defineProperty(globalThis, "crypto", originalCryptoDescriptor);
-        }
-      }
     });
 
     it("should complete batch operation on deleteMiners error", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -135,6 +135,13 @@ const actionCapabilityMetadata: Partial<Record<SupportedAction, { description: s
   [deviceActions.firmwareUpdate]: { description: "Firmware updates", commandType: CommandType.FIRMWARE_UPDATE },
 };
 
+const generateUnpairBatchIdentifier = (): string => {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `unpair-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+};
+
 function getUniqueModels(
   deviceIds: string[],
   miners: Record<string, MinerStateSnapshot>,
@@ -1147,7 +1154,7 @@ export const useMinerActions = ({
             longRunning: true,
             onClose: () => onActionComplete?.(),
           });
-          const unpairBatchId = crypto.randomUUID();
+          const unpairBatchId = generateUnpairBatchIdentifier();
           startBatchOperation({
             batchIdentifier: unpairBatchId,
             action: deviceActions.unpair,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -136,9 +136,6 @@ const actionCapabilityMetadata: Partial<Record<SupportedAction, { description: s
 };
 
 const generateUnpairBatchIdentifier = (): string => {
-  if (typeof globalThis.crypto?.randomUUID === "function") {
-    return globalThis.crypto.randomUUID();
-  }
   return `unpair-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
 };
 


### PR DESCRIPTION
Reviewable diff: +5/-1 across 1 file (excludes generated, test, and story files).

## Summary
Unpairing miners no longer depends on Web Crypto browser APIs. Operators using Proto Fleet from LAN HTTP, older browser contexts, or embedded WebViews can still confirm unpair actions, and the client keeps the same batch-tracking lifecycle for the toast and table update.

Fixes #296.

## How it works
When a user confirms Unpair, the action menu creates a client-only batch identifier before calling `DeleteMiners`. The identifier is always generated locally with a prefixed `Math.random()` and `Date.now()` string; it does not call `crypto.randomUUID()`. The ID only scopes local optimistic batch UI, so the server delete request and persisted data are unchanged.

## Diagrams
```mermaid
flowchart TD
    A["User confirms Unpair"] --> B["Generate local unpair-* batch id"]
    B --> C["Start optimistic batch state"]
    C --> D["Call DeleteMiners RPC"]
    D --> E["Complete local batch and refresh miners"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx` | Adds a local `unpair-*` batch-id helper and uses it for Unpair. | This is the production behavior change that avoids the browser TypeError class entirely. |
| `client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx` | Extends the existing Unpair success test to assert the local `unpair-*` batch id shape. | Keeps coverage on the affected flow without duplicating the delete/toast assertions. |

## Key technical decisions & trade-offs
- Use `Math.random()` plus `Date.now()` rather than Web Crypto because this value is a local UI correlation token, not a security token or persisted identifier.
- Keep the helper local to Unpair rather than introducing a shared UUID abstraction because no other client flow needs this exact behavior in this PR.

## Testing & validation
- `cd client && npx vitest run protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx`
- `git diff --check`
