### PR TITLE
fix(server): allow recreating soft-deleted users and pools

### DIFF
--- a/server/internal/domain/stores/sqlstores/pool.go
+++ b/server/internal/domain/stores/sqlstores/pool.go
@@ -77,7 +77,7 @@ func (s *SQLPoolStore) CreatePool(ctx context.Context, config *pb.PoolConfig, or
 		OrgID:       orgID,
 	})
 	if err != nil {
-		return 0, fleeterror.NewInternalErrorf("error creating pool: %v", err)
+		return 0, fleeterror.NewInternalErrorf("error creating pool: %w", err)
 	}
 
 	return poolID, nil

--- a/server/internal/domain/stores/sqlstores/soft_delete_uniqueness_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/soft_delete_uniqueness_integration_test.go
@@ -5,56 +5,68 @@ import (
 
 	poolspb "github.com/block/proto-fleet/server/generated/grpc/pools/v1"
 	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	"github.com/block/proto-fleet/server/internal/infrastructure/encrypt"
 	"github.com/block/proto-fleet/server/internal/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-func TestSQLPoolStore_AllowsPoolKeyReuseAfterSoftDelete(t *testing.T) {
+func TestSQLStores_AllowKeyReuseAfterSoftDelete(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping database integration test in short mode")
 	}
 
 	ctx := t.Context()
-	_, poolStore := setupTransactorTest(t)
-	config := &poolspb.PoolConfig{
-		PoolName: "Reusable Pool",
-		Url:      "stratum+tcp://reuse.pool.example.com:3333",
-		Username: "wallet",
-		Password: wrapperspb.String("secret"),
-	}
+	poolStore, userStore := setupSoftDeleteUniquenessStores(t)
 
-	firstID, err := poolStore.CreatePool(ctx, config, 1)
-	require.NoError(t, err)
+	t.Run("pool key", func(t *testing.T) {
+		config := &poolspb.PoolConfig{
+			PoolName: "Reusable Pool",
+			Url:      "stratum+tcp://reuse.pool.example.com:3333",
+			Username: "wallet",
+			Password: wrapperspb.String("secret"),
+		}
 
-	_, err = poolStore.CreatePool(ctx, config, 1)
-	require.Error(t, err, "duplicate live pool keys must still be rejected")
+		firstID, err := poolStore.CreatePool(ctx, config, 1)
+		require.NoError(t, err)
 
-	require.NoError(t, poolStore.SoftDeletePool(ctx, 1, firstID))
+		_, err = poolStore.CreatePool(ctx, config, 1)
+		require.Error(t, err, "duplicate live pool keys must still be rejected")
 
-	secondID, err := poolStore.CreatePool(ctx, config, 1)
-	require.NoError(t, err)
-	require.NotEqual(t, firstID, secondID)
+		require.NoError(t, poolStore.SoftDeletePool(ctx, 1, firstID))
+
+		secondID, err := poolStore.CreatePool(ctx, config, 1)
+		require.NoError(t, err)
+		require.NotEqual(t, firstID, secondID)
+	})
+
+	t.Run("username", func(t *testing.T) {
+		firstID, err := userStore.CreateUser(ctx, "external-user-1", "reuse@example.com", "hash", false)
+		require.NoError(t, err)
+
+		_, err = userStore.CreateUser(ctx, "external-user-2", "reuse@example.com", "hash", false)
+		require.Error(t, err, "duplicate live usernames must still be rejected")
+
+		require.NoError(t, userStore.SoftDeleteUser(ctx, firstID))
+
+		secondID, err := userStore.CreateUser(ctx, "external-user-2", "reuse@example.com", "hash", false)
+		require.NoError(t, err)
+		require.NotEqual(t, firstID, secondID)
+	})
 }
 
-func TestSQLUserStore_AllowsUsernameReuseAfterSoftDelete(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping database integration test in short mode")
-	}
+func setupSoftDeleteUniquenessStores(t *testing.T) (*sqlstores.SQLPoolStore, *sqlstores.SQLUserStore) {
+	t.Helper()
 
-	ctx := t.Context()
 	db := testutil.GetTestDB(t)
-	userStore := sqlstores.NewSQLUserStore(db)
-
-	firstID, err := userStore.CreateUser(ctx, "external-user-1", "reuse@example.com", "hash", false)
+	config, err := testutil.GetTestConfig()
 	require.NoError(t, err)
 
-	_, err = userStore.CreateUser(ctx, "external-user-2", "reuse@example.com", "hash", false)
-	require.Error(t, err, "duplicate live usernames must still be rejected")
-
-	require.NoError(t, userStore.SoftDeleteUser(ctx, firstID))
-
-	secondID, err := userStore.CreateUser(ctx, "external-user-2", "reuse@example.com", "hash", false)
+	encryptService, err := encrypt.NewService(&encrypt.Config{ServiceMasterKey: config.ServiceMasterKey})
 	require.NoError(t, err)
-	require.NotEqual(t, firstID, secondID)
+
+	_, err = db.Exec(`INSERT INTO organization (id, org_id, name) VALUES (1, 'test-org-1', 'Test Organization 1') ON CONFLICT DO NOTHING`)
+	require.NoError(t, err, "Failed to create test organization")
+
+	return sqlstores.NewSQLPoolStore(db, encryptService), sqlstores.NewSQLUserStore(db)
 }

--- a/server/internal/domain/stores/sqlstores/soft_delete_uniqueness_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/soft_delete_uniqueness_integration_test.go
@@ -1,0 +1,60 @@
+package sqlstores_test
+
+import (
+	"testing"
+
+	poolspb "github.com/block/proto-fleet/server/generated/grpc/pools/v1"
+	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	"github.com/block/proto-fleet/server/internal/testutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestSQLPoolStore_AllowsPoolKeyReuseAfterSoftDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	ctx := t.Context()
+	_, poolStore := setupTransactorTest(t)
+	config := &poolspb.PoolConfig{
+		PoolName: "Reusable Pool",
+		Url:      "stratum+tcp://reuse.pool.example.com:3333",
+		Username: "wallet",
+		Password: wrapperspb.String("secret"),
+	}
+
+	firstID, err := poolStore.CreatePool(ctx, config, 1)
+	require.NoError(t, err)
+
+	_, err = poolStore.CreatePool(ctx, config, 1)
+	require.Error(t, err, "duplicate live pool keys must still be rejected")
+
+	require.NoError(t, poolStore.SoftDeletePool(ctx, 1, firstID))
+
+	secondID, err := poolStore.CreatePool(ctx, config, 1)
+	require.NoError(t, err)
+	require.NotEqual(t, firstID, secondID)
+}
+
+func TestSQLUserStore_AllowsUsernameReuseAfterSoftDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	ctx := t.Context()
+	db := testutil.GetTestDB(t)
+	userStore := sqlstores.NewSQLUserStore(db)
+
+	firstID, err := userStore.CreateUser(ctx, "external-user-1", "reuse@example.com", "hash", false)
+	require.NoError(t, err)
+
+	_, err = userStore.CreateUser(ctx, "external-user-2", "reuse@example.com", "hash", false)
+	require.Error(t, err, "duplicate live usernames must still be rejected")
+
+	require.NoError(t, userStore.SoftDeleteUser(ctx, firstID))
+
+	secondID, err := userStore.CreateUser(ctx, "external-user-2", "reuse@example.com", "hash", false)
+	require.NoError(t, err)
+	require.NotEqual(t, firstID, secondID)
+}

--- a/server/internal/domain/stores/sqlstores/soft_delete_uniqueness_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/soft_delete_uniqueness_integration_test.go
@@ -5,8 +5,10 @@ import (
 
 	poolspb "github.com/block/proto-fleet/server/generated/grpc/pools/v1"
 	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 	"github.com/block/proto-fleet/server/internal/infrastructure/encrypt"
 	"github.com/block/proto-fleet/server/internal/testutil"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -31,7 +33,7 @@ func TestSQLStores_AllowKeyReuseAfterSoftDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = poolStore.CreatePool(ctx, config, 1)
-		require.Error(t, err, "duplicate live pool keys must still be rejected")
+		requireUniqueViolationOn(t, err, "uk_pool_org_url_username")
 
 		require.NoError(t, poolStore.SoftDeletePool(ctx, 1, firstID))
 
@@ -45,7 +47,7 @@ func TestSQLStores_AllowKeyReuseAfterSoftDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = userStore.CreateUser(ctx, "external-user-2", "reuse@example.com", "hash", false)
-		require.Error(t, err, "duplicate live usernames must still be rejected")
+		requireUniqueViolationOn(t, err, "uq_user_username")
 
 		require.NoError(t, userStore.SoftDeleteUser(ctx, firstID))
 
@@ -69,4 +71,13 @@ func setupSoftDeleteUniquenessStores(t *testing.T) (*sqlstores.SQLPoolStore, *sq
 	require.NoError(t, err, "Failed to create test organization")
 
 	return sqlstores.NewSQLPoolStore(db, encryptService), sqlstores.NewSQLUserStore(db)
+}
+
+func requireUniqueViolationOn(t *testing.T, err error, constraintName string) {
+	t.Helper()
+
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	require.Equal(t, db.PGUniqueViolation, pgErr.Code)
+	require.Equal(t, constraintName, pgErr.ConstraintName)
 }

--- a/server/migrations/000116_scope_soft_delete_uniqueness.down.sql
+++ b/server/migrations/000116_scope_soft_delete_uniqueness.down.sql
@@ -1,0 +1,20 @@
+-- Restore the original full-table uniqueness constraints.
+--
+-- This can fail after the up migration has admitted reused keys behind
+-- soft-deleted rows. Resolve those duplicate historical rows before migrating
+-- down.
+ALTER TABLE "user"
+    ADD CONSTRAINT uq_user_username_full UNIQUE (username);
+
+DROP INDEX uq_user_username;
+
+ALTER TABLE "user"
+    RENAME CONSTRAINT uq_user_username_full TO uq_user_username;
+
+ALTER TABLE pool
+    ADD CONSTRAINT uk_pool_org_url_username_full UNIQUE (org_id, url, username);
+
+DROP INDEX uk_pool_org_url_username;
+
+ALTER TABLE pool
+    RENAME CONSTRAINT uk_pool_org_url_username_full TO uk_pool_org_url_username;

--- a/server/migrations/000116_scope_soft_delete_uniqueness.down.sql
+++ b/server/migrations/000116_scope_soft_delete_uniqueness.down.sql
@@ -1,20 +1,4 @@
--- Restore the original full-table uniqueness constraints.
---
--- This can fail after the up migration has admitted reused keys behind
--- soft-deleted rows. Resolve those duplicate historical rows before migrating
--- down.
-ALTER TABLE "user"
-    ADD CONSTRAINT uq_user_username_full UNIQUE (username);
-
-DROP INDEX uq_user_username;
-
-ALTER TABLE "user"
-    RENAME CONSTRAINT uq_user_username_full TO uq_user_username;
-
-ALTER TABLE pool
-    ADD CONSTRAINT uk_pool_org_url_username_full UNIQUE (org_id, url, username);
-
-DROP INDEX uk_pool_org_url_username;
-
-ALTER TABLE pool
-    RENAME CONSTRAINT uk_pool_org_url_username_full TO uk_pool_org_url_username;
+-- Undo 000116 if the replacement user index was created but not swapped in by
+-- 000117. CONCURRENTLY must be the sole statement and cannot run in a
+-- transaction.
+DROP INDEX CONCURRENTLY IF EXISTS uq_user_username_live;

--- a/server/migrations/000116_scope_soft_delete_uniqueness.up.sql
+++ b/server/migrations/000116_scope_soft_delete_uniqueness.up.sql
@@ -3,6 +3,13 @@
 -- replacement index before 000117 swaps out the old full-table constraint.
 --
 -- CONCURRENTLY must be the sole statement and cannot run in a transaction.
+-- golang-migrate v4's postgres driver runs each statement directly via
+-- conn.ExecContext, no implicit transaction wraps the body, so
+-- CREATE UNIQUE INDEX CONCURRENTLY is safe here. If a partial build
+-- fails it leaves schema_migrations.dirty=true at version 116 and may
+-- leave an INVALID uq_user_username_live index in pg_indexes. Recovery
+-- is to DROP the INVALID index and `migrate force 115` before
+-- re-deploying.
 CREATE UNIQUE INDEX CONCURRENTLY uq_user_username_live
     ON "user" (username)
     WHERE deleted_at IS NULL;

--- a/server/migrations/000116_scope_soft_delete_uniqueness.up.sql
+++ b/server/migrations/000116_scope_soft_delete_uniqueness.up.sql
@@ -1,25 +1,8 @@
 -- Scope legacy uniqueness checks to live rows so soft-deleted pools and users
--- do not reserve their old keys forever.
+-- do not reserve their old keys forever. This first migration builds the user
+-- replacement index before 000117 swaps out the old full-table constraint.
 --
--- Build replacement indexes before dropping the old constraints so the schema
--- never has a uniqueness gap. The final index names match the old constraint
--- names to keep PostgreSQL unique-violation metadata stable for callers.
+-- CONCURRENTLY must be the sole statement and cannot run in a transaction.
 CREATE UNIQUE INDEX CONCURRENTLY uq_user_username_live
     ON "user" (username)
     WHERE deleted_at IS NULL;
-
-ALTER TABLE "user"
-    DROP CONSTRAINT uq_user_username;
-
-ALTER INDEX uq_user_username_live
-    RENAME TO uq_user_username;
-
-CREATE UNIQUE INDEX CONCURRENTLY uk_pool_org_url_username_live
-    ON pool (org_id, url, username)
-    WHERE deleted_at IS NULL;
-
-ALTER TABLE pool
-    DROP CONSTRAINT uk_pool_org_url_username;
-
-ALTER INDEX uk_pool_org_url_username_live
-    RENAME TO uk_pool_org_url_username;

--- a/server/migrations/000116_scope_soft_delete_uniqueness.up.sql
+++ b/server/migrations/000116_scope_soft_delete_uniqueness.up.sql
@@ -1,0 +1,25 @@
+-- Scope legacy uniqueness checks to live rows so soft-deleted pools and users
+-- do not reserve their old keys forever.
+--
+-- Build replacement indexes before dropping the old constraints so the schema
+-- never has a uniqueness gap. The final index names match the old constraint
+-- names to keep PostgreSQL unique-violation metadata stable for callers.
+CREATE UNIQUE INDEX uq_user_username_live
+    ON "user" (username)
+    WHERE deleted_at IS NULL;
+
+ALTER TABLE "user"
+    DROP CONSTRAINT uq_user_username;
+
+ALTER INDEX uq_user_username_live
+    RENAME TO uq_user_username;
+
+CREATE UNIQUE INDEX uk_pool_org_url_username_live
+    ON pool (org_id, url, username)
+    WHERE deleted_at IS NULL;
+
+ALTER TABLE pool
+    DROP CONSTRAINT uk_pool_org_url_username;
+
+ALTER INDEX uk_pool_org_url_username_live
+    RENAME TO uk_pool_org_url_username;

--- a/server/migrations/000116_scope_soft_delete_uniqueness.up.sql
+++ b/server/migrations/000116_scope_soft_delete_uniqueness.up.sql
@@ -4,7 +4,7 @@
 -- Build replacement indexes before dropping the old constraints so the schema
 -- never has a uniqueness gap. The final index names match the old constraint
 -- names to keep PostgreSQL unique-violation metadata stable for callers.
-CREATE UNIQUE INDEX uq_user_username_live
+CREATE UNIQUE INDEX CONCURRENTLY uq_user_username_live
     ON "user" (username)
     WHERE deleted_at IS NULL;
 
@@ -14,7 +14,7 @@ ALTER TABLE "user"
 ALTER INDEX uq_user_username_live
     RENAME TO uq_user_username;
 
-CREATE UNIQUE INDEX uk_pool_org_url_username_live
+CREATE UNIQUE INDEX CONCURRENTLY uk_pool_org_url_username_live
     ON pool (org_id, url, username)
     WHERE deleted_at IS NULL;
 

--- a/server/migrations/000117_swap_user_soft_delete_uniqueness.down.sql
+++ b/server/migrations/000117_swap_user_soft_delete_uniqueness.down.sql
@@ -1,0 +1,12 @@
+-- Restore the original full-table user.username uniqueness constraint.
+--
+-- This can fail after the up migration has admitted reused usernames behind
+-- soft-deleted rows. Resolve those duplicate historical rows before migrating
+-- down.
+ALTER TABLE "user"
+    ADD CONSTRAINT uq_user_username_full UNIQUE (username);
+
+DROP INDEX uq_user_username;
+
+ALTER TABLE "user"
+    RENAME CONSTRAINT uq_user_username_full TO uq_user_username;

--- a/server/migrations/000117_swap_user_soft_delete_uniqueness.up.sql
+++ b/server/migrations/000117_swap_user_soft_delete_uniqueness.up.sql
@@ -1,0 +1,8 @@
+-- Swap user.username from a full-table unique constraint to the live-row
+-- partial index built in 000116. The final index name matches the old
+-- constraint name to keep unique-violation metadata stable for callers.
+ALTER TABLE "user"
+    DROP CONSTRAINT uq_user_username;
+
+ALTER INDEX uq_user_username_live
+    RENAME TO uq_user_username;

--- a/server/migrations/000118_create_live_pool_key_index.down.sql
+++ b/server/migrations/000118_create_live_pool_key_index.down.sql
@@ -1,0 +1,4 @@
+-- Undo 000118 if the replacement pool key index was created but not swapped in
+-- by 000119. CONCURRENTLY must be the sole statement and cannot run in a
+-- transaction.
+DROP INDEX CONCURRENTLY IF EXISTS uk_pool_org_url_username_live;

--- a/server/migrations/000118_create_live_pool_key_index.up.sql
+++ b/server/migrations/000118_create_live_pool_key_index.up.sql
@@ -1,0 +1,7 @@
+-- Build the live-row pool key replacement index before 000119 swaps out the
+-- old full-table constraint.
+--
+-- CONCURRENTLY must be the sole statement and cannot run in a transaction.
+CREATE UNIQUE INDEX CONCURRENTLY uk_pool_org_url_username_live
+    ON pool (org_id, url, username)
+    WHERE deleted_at IS NULL;

--- a/server/migrations/000118_create_live_pool_key_index.up.sql
+++ b/server/migrations/000118_create_live_pool_key_index.up.sql
@@ -2,6 +2,13 @@
 -- old full-table constraint.
 --
 -- CONCURRENTLY must be the sole statement and cannot run in a transaction.
+-- golang-migrate v4's postgres driver runs each statement directly via
+-- conn.ExecContext, no implicit transaction wraps the body, so
+-- CREATE UNIQUE INDEX CONCURRENTLY is safe here. If a partial build
+-- fails it leaves schema_migrations.dirty=true at version 118 and may
+-- leave an INVALID uk_pool_org_url_username_live index in pg_indexes. Recovery
+-- is to DROP the INVALID index and `migrate force 117` before
+-- re-deploying.
 CREATE UNIQUE INDEX CONCURRENTLY uk_pool_org_url_username_live
     ON pool (org_id, url, username)
     WHERE deleted_at IS NULL;

--- a/server/migrations/000119_swap_pool_soft_delete_uniqueness.down.sql
+++ b/server/migrations/000119_swap_pool_soft_delete_uniqueness.down.sql
@@ -1,0 +1,12 @@
+-- Restore the original full-table pool key uniqueness constraint.
+--
+-- This can fail after the up migration has admitted reused pool keys behind
+-- soft-deleted rows. Resolve those duplicate historical rows before migrating
+-- down.
+ALTER TABLE pool
+    ADD CONSTRAINT uk_pool_org_url_username_full UNIQUE (org_id, url, username);
+
+DROP INDEX uk_pool_org_url_username;
+
+ALTER TABLE pool
+    RENAME CONSTRAINT uk_pool_org_url_username_full TO uk_pool_org_url_username;

--- a/server/migrations/000119_swap_pool_soft_delete_uniqueness.up.sql
+++ b/server/migrations/000119_swap_pool_soft_delete_uniqueness.up.sql
@@ -1,0 +1,8 @@
+-- Swap pool(org_id, url, username) from a full-table unique constraint to the
+-- live-row partial index built in 000118. The final index name matches the old
+-- constraint name to keep unique-violation metadata stable for callers.
+ALTER TABLE pool
+    DROP CONSTRAINT uk_pool_org_url_username;
+
+ALTER INDEX uk_pool_org_url_username_live
+    RENAME TO uk_pool_org_url_username;


### PR DESCRIPTION
Reviewable diff: +78/-1 across 9 files (excludes generated, test, and story files).

## Summary
Deleted users and deleted mining pools no longer reserve their old unique keys. Operators can recreate a pool with the same URL and username after deletion, and admins can recreate a username after deactivating the prior user, while live duplicates remain rejected.

The migration is split so every `CREATE UNIQUE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` operation is the only statement in its migration file. That matches the existing golang-migrate/Postgres pattern, documents the dirty-migration recovery path for each concurrent build, and avoids dirty migrations from concurrent index builds being submitted in a multi-command query.

Fixes #696.
Fixes #423.

## How it works
The database invariant moves from full-table unique constraints to partial unique indexes covering only rows where `deleted_at IS NULL`. New inserts still collide with other live rows, so active usernames and active pool keys remain unique. Once a row is soft-deleted, it leaves the live uniqueness set and the same key can be inserted again as a new row.

The migration runs in four ordered steps. First, it builds the live-row `user.username` index concurrently as a single-statement migration, then swaps the old user constraint for that index name in a regular transactional migration. It repeats the same pattern for `pool(org_id, url, username)`: build the live-row index concurrently, then drop the old constraint and rename the new index. Down migrations reverse the sequence, with rollback expected to fail if historical reused keys now exist.

Pool creation now wraps database insert failures with `%w`, so callers and tests can inspect the underlying Postgres error through `errors.As` while preserving the existing error message text. The regression test asserts both duplicate paths fail on the expected unique constraint/index names before proving soft-deleted rows can be replaced.

## Diagrams
```mermaid
flowchart TD
    A["Create live user or pool"] --> B["Live-row unique index enforces key"]
    B --> C["Soft delete sets deleted_at"]
    C --> D["Row leaves live uniqueness set"]
    D --> E["Create replacement with same key"]
    E --> F["Replacement becomes the only live row for that key"]
```

```mermaid
flowchart TD
    U1["000116: create user live index concurrently"] --> U2["000117: drop old user constraint and rename index"]
    U2 --> P1["000118: create pool live index concurrently"]
    P1 --> P2["000119: drop old pool constraint and rename index"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/migrations/000116_scope_soft_delete_uniqueness.*.sql` | Builds/drops the user live-row unique index concurrently as a single-statement migration, with recovery notes for dirty/INVALID-index deploy failures. | Keeps concurrent index operations outside multi-statement migration execution and documents operator recovery. |
| `server/migrations/000117_swap_user_soft_delete_uniqueness.*.sql` | Swaps the original `user.username` constraint for the partial live-row index name, and restores it on rollback. | This is where user uniqueness semantics change from all rows to live rows. |
| `server/migrations/000118_create_live_pool_key_index.*.sql` | Builds/drops the pool live-row unique index concurrently as a single-statement migration, with recovery notes for dirty/INVALID-index deploy failures. | Keeps the pool concurrent index operation isolated for safe migration execution and documents operator recovery. |
| `server/migrations/000119_swap_pool_soft_delete_uniqueness.*.sql` | Swaps the original pool key constraint for the partial live-row index name, and restores it on rollback. | This is where pool key uniqueness semantics change from all rows to live rows. |
| `server/internal/domain/stores/sqlstores/pool.go` | Wraps create-pool insert failures with `%w`. | Preserves access to the underlying Postgres error for constraint-aware callers/tests without changing the user-facing error text. |
| `server/internal/domain/stores/sqlstores/soft_delete_uniqueness_integration_test.go` | Adds DB-backed regression coverage for live duplicate rejection and post-delete reuse, sharing one migrated test database across the focused pool and user subtests. | Proves both flows match the intended soft-delete semantics and pins the expected unique constraint/index names. |

## Key technical decisions & trade-offs
- Use partial unique indexes instead of application-side duplicate filtering so all insert paths share one database invariant.
- Split concurrent index DDL into single-statement migration files instead of combining them with constraint swaps, matching existing migration safety patterns.
- Preserve the old index/constraint names for the live-row indexes so unique-violation metadata remains stable for callers.
- Wrap pool creation insert failures with `%w` instead of string-matching the error so constraint assertions use typed Postgres errors.
- Keep sqlc queries unchanged because inserts, soft deletes, and list filters already express the correct live-row semantics once the database invariant changes.

## Testing & validation
- `just lint`
- `DB_PASSWORD=fleet go test ./internal/domain/stores/sqlstores -run 'TestSQLStores_AllowKeyReuseAfterSoftDelete' -count=1` from `server/`
- Verified `000116` and `000118` concurrent migration up/down files each contain exactly one SQL statement.
- `git diff --check`
