### PR TITLE
feat(rack): site/building placement in rack modal; fix assignable-only leaks (#702)

### DIFF
--- a/client/src/protoFleet/api/generated/collection/v1/collection_pb.ts
+++ b/client/src/protoFleet/api/generated/collection/v1/collection_pb.ts
@@ -149,8 +149,8 @@ export type RackInfo = Message<"collection.v1.RackInfo"> & {
   columns: number;
 
   /**
-   * Sub-building zone label (e.g. "Room 2", "East Wall"). Required when
-   * building_id is set; cleared (empty) automatically when the rack
+   * Sub-building zone label (e.g. "Room 2", "East Wall"). Optional, even
+   * when building_id is set. Cleared (empty) automatically when the rack
    * crosses a building boundary or moves to direct-under-site placement.
    *
    * @generated from field: string zone = 3;

--- a/client/src/protoFleet/api/generated/device_set/v1/device_set_pb.ts
+++ b/client/src/protoFleet/api/generated/device_set/v1/device_set_pb.ts
@@ -153,8 +153,8 @@ export type RackInfo = Message<"device_set.v1.RackInfo"> & {
   columns: number;
 
   /**
-   * Sub-building zone label (e.g. "Room 2", "East Wall"). Required when
-   * building_id is set; cleared (empty) automatically when the rack
+   * Sub-building zone label (e.g. "Room 2", "East Wall"). Optional, even
+   * when building_id is set. Cleared (empty) automatically when the rack
    * crosses a building boundary or moves to direct-under-site placement.
    *
    * @generated from field: string zone = 3;

--- a/client/src/protoFleet/api/useDeviceSets.test.ts
+++ b/client/src/protoFleet/api/useDeviceSets.test.ts
@@ -4,11 +4,13 @@ import { Code, ConnectError } from "@connectrpc/connect";
 
 const mockListDeviceSetMembers = vi.fn();
 const mockSaveRack = vi.fn();
+const mockUpdateDeviceSet = vi.fn();
 
 vi.mock("./clients", () => ({
   deviceSetClient: {
     listDeviceSetMembers: (...args: unknown[]) => mockListDeviceSetMembers(...args),
     saveRack: (...args: unknown[]) => mockSaveRack(...args),
+    updateDeviceSet: (...args: unknown[]) => mockUpdateDeviceSet(...args),
   },
 }));
 
@@ -213,5 +215,56 @@ describe("useDeviceSets — saveRack placement encoding", () => {
     const rackInfo = await runSaveRack({});
     expect(rackInfo.siteId).toBeUndefined();
     expect(rackInfo.buildingId).toBeUndefined();
+  });
+});
+
+describe("useDeviceSets — updateRack placement encoding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateDeviceSet.mockResolvedValue({ deviceSet: { id: 1n } });
+  });
+
+  const runUpdateRack = async (placement: { siteId?: bigint; buildingId?: bigint }) => {
+    const { result } = renderHook(() => useDeviceSets());
+    await act(async () => {
+      await result.current.updateRack({
+        deviceSetId: 1n,
+        label: "Rack A",
+        zone: "",
+        rows: 2,
+        columns: 2,
+        orderIndex: 0,
+        coolingType: 0,
+        ...placement,
+      });
+    });
+    return mockUpdateDeviceSet.mock.calls[0][0].typeDetails?.value;
+  };
+
+  it("sends only building_id when a building is chosen (server derives site_id)", async () => {
+    const rackInfo = await runUpdateRack({ siteId: 2n, buildingId: 3n });
+    expect(rackInfo.buildingId).toBe(3n);
+    expect(rackInfo.siteId).toBeUndefined();
+  });
+
+  it("sends site_id and an explicit building_id 0 when only a site is chosen", async () => {
+    const rackInfo = await runUpdateRack({ siteId: 2n, buildingId: 0n });
+    expect(rackInfo.siteId).toBe(2n);
+    expect(rackInfo.buildingId).toBe(0n);
+  });
+
+  it("sends explicit 0/0 to unassign when neither site nor building is chosen", async () => {
+    const rackInfo = await runUpdateRack({ siteId: 0n, buildingId: 0n });
+    expect(rackInfo.siteId).toBe(0n);
+    expect(rackInfo.buildingId).toBe(0n);
+  });
+
+  it("omits placement (rack:manage settings save) but still carries zone/dims", async () => {
+    const rackInfo = await runUpdateRack({});
+    expect(rackInfo.siteId).toBeUndefined();
+    expect(rackInfo.buildingId).toBeUndefined();
+    // rack_info is still sent so the server persists the zone/dimension edit.
+    expect(rackInfo.rows).toBe(2);
+    expect(rackInfo.columns).toBe(2);
   });
 });

--- a/client/src/protoFleet/api/useDeviceSets.test.ts
+++ b/client/src/protoFleet/api/useDeviceSets.test.ts
@@ -3,10 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Code, ConnectError } from "@connectrpc/connect";
 
 const mockListDeviceSetMembers = vi.fn();
+const mockSaveRack = vi.fn();
 
 vi.mock("./clients", () => ({
   deviceSetClient: {
     listDeviceSetMembers: (...args: unknown[]) => mockListDeviceSetMembers(...args),
+    saveRack: (...args: unknown[]) => mockSaveRack(...args),
   },
 }));
 
@@ -162,5 +164,54 @@ describe("useDeviceSets — listGroupMembers", () => {
 
     expect(mockHandleAuthErrors).toHaveBeenCalledTimes(1);
     expect(onFinally).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useDeviceSets — saveRack placement encoding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSaveRack.mockResolvedValue({ deviceSet: { id: 1n }, assignedCount: 0 });
+  });
+
+  const runSaveRack = async (placement: { siteId?: bigint; buildingId?: bigint }) => {
+    const { result } = renderHook(() => useDeviceSets());
+    await act(async () => {
+      await result.current.saveRack({
+        label: "Rack A",
+        zone: "",
+        rows: 2,
+        columns: 2,
+        orderIndex: 0,
+        coolingType: 0,
+        deviceIdentifiers: [],
+        slotAssignments: [],
+        ...placement,
+      });
+    });
+    return mockSaveRack.mock.calls[0][0].rackInfo;
+  };
+
+  it("sends only building_id when a building is chosen (server derives site_id)", async () => {
+    const rackInfo = await runSaveRack({ siteId: 2n, buildingId: 3n });
+    expect(rackInfo.buildingId).toBe(3n);
+    expect(rackInfo.siteId).toBeUndefined();
+  });
+
+  it("sends site_id and an explicit building_id 0 when only a site is chosen", async () => {
+    const rackInfo = await runSaveRack({ siteId: 2n, buildingId: 0n });
+    expect(rackInfo.siteId).toBe(2n);
+    expect(rackInfo.buildingId).toBe(0n);
+  });
+
+  it("sends explicit 0/0 to unassign when neither site nor building is chosen", async () => {
+    const rackInfo = await runSaveRack({ siteId: 0n, buildingId: 0n });
+    expect(rackInfo.siteId).toBe(0n);
+    expect(rackInfo.buildingId).toBe(0n);
+  });
+
+  it("omits placement entirely when both are undefined (preserves current placement)", async () => {
+    const rackInfo = await runSaveRack({});
+    expect(rackInfo.siteId).toBeUndefined();
+    expect(rackInfo.buildingId).toBeUndefined();
   });
 });

--- a/client/src/protoFleet/api/useDeviceSets.ts
+++ b/client/src/protoFleet/api/useDeviceSets.ts
@@ -150,6 +150,13 @@ interface UpdateRackProps {
   columns?: number;
   orderIndex?: RackOrderIndex;
   coolingType?: RackCoolingType;
+  // Placement (site:manage). Encoded like saveRack: a building fully
+  // determines placement (site derived server-side); an explicit 0n unassigns
+  // that level; undefined omits placement entirely (server preserves the
+  // rack's current site/building). Omit both for a rack:manage-only settings
+  // save that must not move the rack.
+  siteId?: bigint;
+  buildingId?: bigint;
   onSuccess?: (deviceSet: DeviceSet) => void;
   onError?: (message: string) => void;
   onFinally?: () => void;
@@ -819,12 +826,27 @@ const useDeviceSets = () => {
       columns,
       orderIndex,
       coolingType,
+      siteId,
+      buildingId,
       onSuccess,
       onError,
       onFinally,
     }: UpdateRackProps) => {
       try {
+        // Placement encoding mirrors saveRack: a building fully determines
+        // placement (send only building_id), otherwise send whichever of
+        // site_id / building_id was specified (0n unassigns, undefined omits).
+        const placement: { siteId?: bigint; buildingId?: bigint } = {};
+        if (buildingId !== undefined && buildingId > 0n) {
+          placement.buildingId = buildingId;
+        } else {
+          if (siteId !== undefined) placement.siteId = siteId;
+          if (buildingId !== undefined) placement.buildingId = buildingId;
+        }
+        const hasPlacement = placement.siteId !== undefined || placement.buildingId !== undefined;
+
         const rackInfo =
+          hasPlacement ||
           zone !== undefined ||
           rows !== undefined ||
           columns !== undefined ||
@@ -836,6 +858,7 @@ const useDeviceSets = () => {
                 ...(columns !== undefined && { columns }),
                 ...(orderIndex !== undefined && { orderIndex }),
                 ...(coolingType !== undefined && { coolingType }),
+                ...placement,
               })
             : undefined;
 

--- a/client/src/protoFleet/api/useDeviceSets.ts
+++ b/client/src/protoFleet/api/useDeviceSets.ts
@@ -209,6 +209,13 @@ interface SaveRackProps {
   deviceIdentifiers: string[];
   allDevices?: boolean;
   slotAssignments: { deviceIdentifier: string; row: number; column: number }[];
+  // Rack placement. Encoded onto RackInfo per its proto contract: when
+  // buildingId is set we send only building_id and let the server derive
+  // site_id; otherwise we send explicit site_id + building_id (0 = unassign)
+  // so an edit that clears placement takes effect. Leave both undefined to
+  // preserve the current placement on an update.
+  siteId?: bigint;
+  buildingId?: bigint;
   onSuccess?: (deviceSet: DeviceSet, assignedCount: number) => void;
   onError?: (message: string) => void;
   onFinally?: () => void;
@@ -947,17 +954,33 @@ const useDeviceSets = () => {
       deviceIdentifiers,
       allDevices,
       slotAssignments,
+      siteId,
+      buildingId,
       onSuccess,
       onError,
       onFinally,
     }: SaveRackProps) => {
       try {
+        // Placement encoding (see RackInfo proto): a building fully determines
+        // placement, so send only building_id and let the server derive
+        // site_id. Otherwise send whichever of site_id / building_id the
+        // caller specified — an explicit 0 unassigns that level, undefined
+        // leaves it untouched (preserved on update).
+        const placement: { siteId?: bigint; buildingId?: bigint } = {};
+        if (buildingId !== undefined && buildingId > 0n) {
+          placement.buildingId = buildingId;
+        } else {
+          if (siteId !== undefined) placement.siteId = siteId;
+          if (buildingId !== undefined) placement.buildingId = buildingId;
+        }
+
         const rackInfo = create(RackInfoSchema, {
           rows,
           columns,
           zone,
           orderIndex,
           coolingType,
+          ...placement,
         });
 
         const deviceSelector = buildDeviceSelector(deviceIdentifiers, allDevices);

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -213,14 +213,33 @@ describe("MinerSelectionList eligibility", () => {
     expect(filter.siteIds).toEqual([2n]);
   });
 
-  it("excludes all racked miners for a new rack (no rack id) but adds no rack/site/building ids", () => {
+  it("pins building to unplaced-only when the target rack has a site but no building", () => {
+    render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n }} />);
+
+    // Rack lives directly under a site: the site pins to that site, but the
+    // building dimension must pin to "no building" so a miner directly placed
+    // in some building (same site) doesn't leak into the assignable list.
+    const filter = lastFleetFilter();
+    expect(filter.siteIds).toEqual([2n]);
+    expect(filter.includeUnassigned).toBe(true);
+    expect(filter.buildingIds).toEqual([]);
+    expect(filter.includeNoBuilding).toBe(true);
+  });
+
+  it("pins every dimension to unplaced-only for a new/unplaced rack (no eligibility)", () => {
     render(<MinerSelectionList eligibility={{}} />);
 
+    // A rack that isn't placed at a level strips a miner's placement there on
+    // assign, so only miners unplaced at every level are assignable without a
+    // reparent. Each dimension pins to "no id + include unassigned" — leaving
+    // a dimension unconstrained would leak directly-placed miners into the
+    // default assignable list (see #702).
     const filter = lastFleetFilter();
     expect(filter.includeNoRack).toBe(true);
     expect(filter.rackIds).toEqual([]);
+    expect(filter.includeNoBuilding).toBe(true);
     expect(filter.buildingIds).toEqual([]);
-    expect(filter.includeNoBuilding).toBe(false);
+    expect(filter.includeUnassigned).toBe(true);
     expect(filter.siteIds).toEqual([]);
   });
 

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -213,34 +213,34 @@ describe("MinerSelectionList eligibility", () => {
     expect(filter.siteIds).toEqual([2n]);
   });
 
-  it("pins site to unassigned-only when the target rack has a site but no building", () => {
+  it("pins site + no-building when the target rack has a site but no building", () => {
     render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n }} />);
 
-    // Rack lives directly under a site: the site pins to that site. The
-    // building dimension is deliberately NOT pinned via includeNoBuilding —
-    // server-side that means "the miner's rack has no building", which would
-    // pull in miners already sitting in another building-less rack.
+    // Direct-under-site rack: site pins to that site, and building pins to "no
+    // building" (includeNoBuilding). Server-side that admits the rack's own
+    // members and excludes rackless miners directly placed in a building.
+    // rackId is set (existing rack), so the server keeps the rack-derived
+    // no-building branch that surfaces the current members.
     const filter = lastFleetFilter();
     expect(filter.siteIds).toEqual([2n]);
     expect(filter.includeUnassigned).toBe(true);
     expect(filter.buildingIds).toEqual([]);
-    expect(filter.includeNoBuilding).toBe(false);
+    expect(filter.includeNoBuilding).toBe(true);
   });
 
-  it("pins rack + site to unplaced-only for a new/unplaced rack (no eligibility)", () => {
+  it("pins every dimension to unplaced-only for a new/unplaced rack (no eligibility)", () => {
     render(<MinerSelectionList eligibility={{}} />);
 
     // A new/unplaced rack: assignable-without-reparent = fully-unplaced miners.
-    // "No rack" (includeNoRack) plus "no site" (includeUnassigned) is
-    // sufficient — a building requires a site, so site IS NULL already
-    // excludes any building-placed miner. includeNoBuilding is intentionally
-    // NOT set (it would match miners in other building-less racks).
+    // Every dimension pins to "no id + include unassigned/no-building". With no
+    // rackId, the server drops includeNoBuilding's rack-derived branch and
+    // reads this as "no rack AND no direct building AND no site".
     const filter = lastFleetFilter();
     expect(filter.includeNoRack).toBe(true);
     expect(filter.rackIds).toEqual([]);
     expect(filter.includeUnassigned).toBe(true);
     expect(filter.siteIds).toEqual([]);
-    expect(filter.includeNoBuilding).toBe(false);
+    expect(filter.includeNoBuilding).toBe(true);
     expect(filter.buildingIds).toEqual([]);
   });
 

--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -213,34 +213,35 @@ describe("MinerSelectionList eligibility", () => {
     expect(filter.siteIds).toEqual([2n]);
   });
 
-  it("pins building to unplaced-only when the target rack has a site but no building", () => {
+  it("pins site to unassigned-only when the target rack has a site but no building", () => {
     render(<MinerSelectionList eligibility={{ rackId: 1n, siteId: 2n }} />);
 
-    // Rack lives directly under a site: the site pins to that site, but the
-    // building dimension must pin to "no building" so a miner directly placed
-    // in some building (same site) doesn't leak into the assignable list.
+    // Rack lives directly under a site: the site pins to that site. The
+    // building dimension is deliberately NOT pinned via includeNoBuilding —
+    // server-side that means "the miner's rack has no building", which would
+    // pull in miners already sitting in another building-less rack.
     const filter = lastFleetFilter();
     expect(filter.siteIds).toEqual([2n]);
     expect(filter.includeUnassigned).toBe(true);
     expect(filter.buildingIds).toEqual([]);
-    expect(filter.includeNoBuilding).toBe(true);
+    expect(filter.includeNoBuilding).toBe(false);
   });
 
-  it("pins every dimension to unplaced-only for a new/unplaced rack (no eligibility)", () => {
+  it("pins rack + site to unplaced-only for a new/unplaced rack (no eligibility)", () => {
     render(<MinerSelectionList eligibility={{}} />);
 
-    // A rack that isn't placed at a level strips a miner's placement there on
-    // assign, so only miners unplaced at every level are assignable without a
-    // reparent. Each dimension pins to "no id + include unassigned" — leaving
-    // a dimension unconstrained would leak directly-placed miners into the
-    // default assignable list (see #702).
+    // A new/unplaced rack: assignable-without-reparent = fully-unplaced miners.
+    // "No rack" (includeNoRack) plus "no site" (includeUnassigned) is
+    // sufficient — a building requires a site, so site IS NULL already
+    // excludes any building-placed miner. includeNoBuilding is intentionally
+    // NOT set (it would match miners in other building-less racks).
     const filter = lastFleetFilter();
     expect(filter.includeNoRack).toBe(true);
     expect(filter.rackIds).toEqual([]);
-    expect(filter.includeNoBuilding).toBe(true);
-    expect(filter.buildingIds).toEqual([]);
     expect(filter.includeUnassigned).toBe(true);
     expect(filter.siteIds).toEqual([]);
+    expect(filter.includeNoBuilding).toBe(false);
+    expect(filter.buildingIds).toEqual([]);
   });
 
   it("respects a Rack facet that includes the target rack, dropping unracked, in assignable-only mode", async () => {

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -382,17 +382,13 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         } else if (eligBuildingId !== undefined) {
           merged.buildingIds = [eligBuildingId];
           merged.includeNoBuilding = true;
-        } else {
-          // The target rack isn't placed in a building (unplaced or
-          // directly-under-site): assigning a miner here strips its building,
-          // so only building-unplaced miners are assignable without a
-          // reparent. Pin to "no building" rather than leaving it
-          // unconstrained — otherwise a miner directly placed in some
-          // building leaks into the default assignable list (mirror of #702
-          // for the undefined-eligibility case).
-          merged.buildingIds = [];
-          merged.includeNoBuilding = true;
         }
+        // When the target rack has no building we deliberately do NOT pin
+        // includeNoBuilding: server-side that flag means "the miner's RACK has
+        // no building", which matches miners already sitting in another
+        // building-less rack and would leak them into a new rack's assignable
+        // list. The site pin below is sufficient — a building requires a site,
+        // so "site IS NULL" already excludes any building-placed miner.
 
         if (userFilter.siteIds.length > 0) {
           merged.siteIds = eligSiteId !== undefined ? userFilter.siteIds.filter((id) => id === eligSiteId) : [];

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -382,6 +382,16 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         } else if (eligBuildingId !== undefined) {
           merged.buildingIds = [eligBuildingId];
           merged.includeNoBuilding = true;
+        } else {
+          // The target rack isn't placed in a building (unplaced or
+          // directly-under-site): assigning a miner here strips its building,
+          // so only building-unplaced miners are assignable without a
+          // reparent. Pin to "no building" rather than leaving it
+          // unconstrained — otherwise a miner directly placed in some
+          // building leaks into the default assignable list (mirror of #702
+          // for the undefined-eligibility case).
+          merged.buildingIds = [];
+          merged.includeNoBuilding = true;
         }
 
         if (userFilter.siteIds.length > 0) {
@@ -389,6 +399,12 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
           merged.includeUnassigned = false;
         } else if (eligSiteId !== undefined) {
           merged.siteIds = [eligSiteId];
+          merged.includeUnassigned = true;
+        } else {
+          // Target rack isn't placed in a site: only site-unplaced miners are
+          // assignable without a reparent. Pin to "unassigned" so a
+          // directly-site-assigned miner doesn't leak into the default list.
+          merged.siteIds = [];
           merged.includeUnassigned = true;
         }
       }

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -382,13 +382,19 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
         } else if (eligBuildingId !== undefined) {
           merged.buildingIds = [eligBuildingId];
           merged.includeNoBuilding = true;
+        } else {
+          // Target rack has no building: assigning a miner clears its building,
+          // so only building-unplaced miners are assignable without a reparent.
+          // Pin includeNoBuilding. Server-side this admits the target rack's own
+          // members (their building-less rack matches) AND, via the no-rack
+          // branch, rackless miners with no direct building — while excluding a
+          // rackless miner directly placed in a building. For a NEW rack (no
+          // rack-id in the filter) the server drops the "rack has no building"
+          // sub-clause, since there are no members to preserve and it would
+          // otherwise pull in other building-less racks' members.
+          merged.buildingIds = [];
+          merged.includeNoBuilding = true;
         }
-        // When the target rack has no building we deliberately do NOT pin
-        // includeNoBuilding: server-side that flag means "the miner's RACK has
-        // no building", which matches miners already sitting in another
-        // building-less rack and would leak them into a new rack's assignable
-        // list. The site pin below is sufficient — a building requires a site,
-        // so "site IS NULL" already excludes any building-placed miner.
 
         if (userFilter.siteIds.length > 0) {
           merged.siteIds = eligSiteId !== undefined ? userFilter.siteIds.filter((id) => id === eligSiteId) : [];

--- a/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/BuildingSettingsModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/BuildingSettingsModal.tsx
@@ -24,9 +24,9 @@ interface BuildingSettingsModalCommonProps {
 }
 
 // Create mode owns site selection: when initialSiteId is supplied the
-// dropdown locks to that site (entry from /sites/:id or a site-scoped
-// row); otherwise it's editable and Save stays disabled until a site
-// is chosen.
+// dropdown locks to that site (entry from /sites/:id, a site-scoped row, or a
+// page-header site scope — the building belongs to that site); otherwise it's
+// editable and Save stays disabled until a site is chosen.
 interface BuildingSettingsModalCreateExtras {
   sites: SiteWithCounts[];
   initialSiteId?: bigint;

--- a/client/src/protoFleet/features/buildings/hooks/useBuildingModals.ts
+++ b/client/src/protoFleet/features/buildings/hooks/useBuildingModals.ts
@@ -23,10 +23,10 @@ import { pushToast, STATUSES } from "@/shared/features/toaster";
 // — matching the SiteModals pattern.
 export type BuildingModalState =
   | { kind: "none" }
-  // siteId undefined when opened from the global Buildings-tab CTA — the
-  // modal renders a Site dropdown for the operator to pick. When set
-  // (entry from /sites/:id or a site-scoped row), the dropdown locks to
-  // that site so the parent context is unambiguous.
+  // siteId undefined when opened from the global Buildings-tab CTA with no
+  // scope — the modal renders an empty Site dropdown for the operator to pick.
+  // When set (entry from /sites/:id, a site-scoped row, or a page-header site
+  // scope), the dropdown locks to that site.
   | { kind: "detailsCreate"; siteId?: bigint; siteName?: string; draft: BuildingFormValues }
   | { kind: "detailsEdit"; row: BuildingWithCounts; siteName?: string; draft: BuildingFormValues }
   | { kind: "manage"; row: BuildingWithCounts; siteName?: string }

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -105,6 +105,11 @@ const FleetCreateFlowProvider = ({
     bumpSitesRevision();
   }, [refetchSites, bumpEntities, bumpSitesRevision]);
 
+  // Prepopulate the new-rack Site dropdown from the page-header scope when a
+  // single site is selected (undefined for "All sites" / "Unassigned").
+  const activeSite = useFleetStore((state) => state.ui.activeSite);
+  const scopedSiteId = useMemo(() => (activeSite.kind === "site" ? BigInt(activeSite.id) : undefined), [activeSite]);
+
   // Rack create flow. rackSettings drives RackSettingsModal; once the
   // operator continues, rackFormData opens ManageRackModal seeded with the
   // selected miners. rackSeed survives the settings step so the miners reach
@@ -429,6 +434,7 @@ const FleetCreateFlowProvider = ({
         <RackSettingsModal
           show={rackSettingsOpen}
           existingRacks={[]}
+          defaultSiteId={scopedSiteId}
           onDismiss={closeRackFlow}
           onContinue={handleRackSettingsContinue}
         />
@@ -439,6 +445,7 @@ const FleetCreateFlowProvider = ({
           rackSettings={rackFormData}
           existingRacks={[]}
           seededMinerIds={rackSeed?.minerIds}
+          scopedSiteId={scopedSiteId}
           onDismiss={closeRackFlow}
           onSave={handleRackSaved}
         />
@@ -461,6 +468,8 @@ const FleetCreateFlowProvider = ({
           mode="create"
           initialValues={emptyBuildingFormValues()}
           sites={sites}
+          // Pre-fill (and lock to) the page-header site scope.
+          initialSiteId={scopedSiteId}
           onSave={handleBuildingCreate}
           onDismiss={closeBuildingSettings}
           saving={creatingBuilding || buildingModals.saving}

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -7,7 +7,6 @@ import ReparentWarningDialog from "./ReparentWarningDialog";
 import ScanMinerQrModal from "./ScanMinerQrModal";
 import SearchMinersModal from "./SearchMinersModal";
 import { type AssignmentMode, orderIndexToOrigin, originLabel, type RackFormData, type SelectedSlot } from "./types";
-import { useBuildings } from "@/protoFleet/api/buildings";
 import { fetchAllMinerSnapshots } from "@/protoFleet/api/fetchAllMinerSnapshots";
 import { type DeviceSet, type RackSlot } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import {
@@ -16,7 +15,6 @@ import {
   PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
-import { useSites } from "@/protoFleet/api/sites";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import useFleet from "@/protoFleet/api/useFleet";
 import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
@@ -101,16 +99,12 @@ export default function ManageRackModal({
   onSave,
   onDelete,
 }: ManageRackModalProps) {
-  const { saveRack, getRackSlots, listGroupMembers } = useDeviceSets();
-  // Placement moves for an in-session Rack Settings change go through the
-  // dedicated assign RPCs, which cascade the rack's CURRENT server-side members
-  // — never the modal's draft membership (see handleRackSettingsUpdate).
-  const { assignRacksToSite } = useSites();
-  const { assignRacksToBuilding } = useBuildings();
+  const { saveRack, updateRack, getRackSlots, listGroupMembers } = useDeviceSets();
   // Rack placement (site/building) is a site:manage action, enforced server-
-  // side on SaveRack. A rack:manage-only operator edits rack contents without
-  // touching placement, so we omit placement from the request (preserving the
-  // rack's current site/building) rather than sending an explicit change.
+  // side on SaveRack and UpdateDeviceSet. A rack:manage-only operator edits
+  // rack contents and metadata (label/zone/dims) without touching placement,
+  // so we omit placement from the request (preserving the rack's current
+  // site/building) rather than sending an explicit change.
   const canManagePlacement = useHasPermission("site:manage");
 
   // Fetch all miners for display data (name, IP, model, etc.)
@@ -500,51 +494,46 @@ export default function ManageRackModal({
     [eligibility, totalSlots, promptReparent],
   );
 
-  // RackSettingsModal edit handler. For an existing rack, a Site/Building
-  // change is persisted right here (not deferred to the final Save) so the
-  // rack — and its server-cascaded members — are already at the new placement
-  // before the operator opens Manage Miners; otherwise the assignable-only
-  // list would judge miners against a placement that isn't live yet. Only a
-  // real placement change triggers this; label/zone/dimension edits stay in
-  // memory until Save. Requires site:manage.
+  // RackSettingsModal "Continue" handler. For an EXISTING rack, Continue is
+  // the settings save: it persists label/zone/dimensions AND placement in a
+  // single atomic UpdateDeviceSet, then cascades the rack's CURRENT server
+  // members to the new placement — all server-side, in one transaction. This
+  // is why the eligibility filter above can trust rackSettings as the rack's
+  // live placement: by the time the operator opens Manage Miners, the rack and
+  // its members are already there. Membership is untouched here — "Continue
+  // saves settings, Save saves miners" — so the modal's draft rackMiners can't
+  // leak into a settings-only change.
   //
-  // Uses the dedicated placement RPCs (AssignRacksToBuilding / ToSite), NOT
-  // SaveRack: they move the rack and cascade its CURRENT persisted members,
-  // and must not touch membership — SaveRack would overwrite it with the
-  // modal's draft `rackMiners` (empty if members haven't loaded, or carrying
-  // unsaved add/removes), committing miner changes the operator never saved.
+  // A NEW rack doesn't exist yet, so there's nothing to persist; its settings
+  // (including placement) ride on the create in handleSave.
   const handleRackSettingsUpdate = useCallback(
     async (formData: RackFormData) => {
       const rackId = existingRackId;
-      const placementChanged =
-        rackId !== undefined &&
-        canManagePlacement &&
-        (formData.siteId !== rackSettings.siteId || formData.buildingId !== rackSettings.buildingId);
-
-      if (placementChanged) {
+      if (rackId !== undefined) {
         try {
           await new Promise<void>((resolve, reject) => {
-            const onError = (msg: string) => reject(new Error(msg));
-            if (formData.buildingId !== undefined) {
-              assignRacksToBuilding({
-                racks: [{ rackId }],
-                targetBuildingId: formData.buildingId,
-                onSuccess: () => resolve(),
-                onError,
-              });
-            } else {
-              // Direct-under-site (siteId set) or fully unassigned (undefined).
-              assignRacksToSite({
-                rackIds: [rackId],
-                targetSiteId: formData.siteId,
-                onSuccess: () => resolve(),
-                onError,
-              });
-            }
+            updateRack({
+              deviceSetId: rackId,
+              label: formData.label,
+              zone: formData.zone,
+              rows: formData.rows,
+              columns: formData.columns,
+              orderIndex: formData.orderIndex,
+              coolingType: formData.coolingType,
+              // site:manage sends explicit placement (an unset level -> 0n
+              // unassign) so the zone is authoritative and the rack + its
+              // members move now. A rack:manage-only operator omits placement,
+              // which preserves the current site/building; their zone edits
+              // (including a clear) still persist server-side.
+              siteId: canManagePlacement ? (formData.siteId ?? 0n) : undefined,
+              buildingId: canManagePlacement ? (formData.buildingId ?? 0n) : undefined,
+              onSuccess: () => resolve(),
+              onError: (msg) => reject(new Error(msg)),
+            });
           });
         } catch (err) {
           pushToast({
-            message: getErrorMessage(err, "Failed to update rack placement. Please try again."),
+            message: getErrorMessage(err, "Failed to update rack settings. Please try again."),
             status: STATUSES.error,
           });
           // Keep Rack Settings open (don't apply) so the operator can retry.
@@ -555,7 +544,7 @@ export default function ManageRackModal({
       setRackSettings(formData);
       setShowRackSettings(false);
     },
-    [existingRackId, canManagePlacement, rackSettings, assignRacksToSite, assignRacksToBuilding],
+    [existingRackId, canManagePlacement, updateRack],
   );
 
   // Save handler — single atomic RPC
@@ -581,15 +570,12 @@ export default function ManageRackModal({
         return { deviceIdentifier: deviceId, row, column: col };
       });
 
-      // Placement rides on CREATE (choose it) and on the one edit case where
-      // omitting it would lose the change: clearing an in-building rack's zone
-      // (the server's omitted-placement path restores the old zone). Every
-      // other existing-rack save omits placement — it's persisted on the Rack
-      // Settings Continue, so omitting keeps a concurrent move from being
-      // clobbered.
-      const clearingInBuildingZone =
-        existingRackId !== undefined && rackSettings.buildingId !== undefined && rackSettings.zone.trim() === "";
-      const sendPlacement = canManagePlacement && (existingRackId === undefined || clearingInBuildingZone);
+      // Placement rides on CREATE only. An existing rack's Site/Building (and
+      // zone/dimensions) are already persisted on the Rack Settings "Continue"
+      // — Continue saves settings, Save saves miners — so an edit Save omits
+      // placement: it preserves the rack's current server placement and can't
+      // clobber a move made by another session while this modal was open.
+      const sendPlacement = canManagePlacement && existingRackId === undefined;
 
       await new Promise<void>((resolve, reject) => {
         saveRack({
@@ -602,17 +588,8 @@ export default function ManageRackModal({
           coolingType: rackSettings.coolingType,
           deviceIdentifiers: rackMiners,
           slotAssignments: slotAssignmentsList,
-          // Placement is only sent on CREATE. An existing rack's Site/Building
-          // change is already persisted on the Rack Settings "Continue", so a
-          // (possibly miners-only) Save omits placement — this preserves the
-          // rack's current server placement and, crucially, can't clobber a
-          // move made by another session while this modal was open. Gated on
-          // site:manage; create sends its chosen placement (unset → NULL).
-          //
-          // Exception: clearing an in-building rack's zone. With placement
-          // omitted the server's legacy path restores the zone from the
-          // current placement, so the blank is silently ignored. Send the
-          // rack's current placement explicitly to mark it a real clear.
+          // Create sends its chosen placement (unset level → NULL), gated on
+          // site:manage. Edit omits placement (persisted on Continue).
           siteId: sendPlacement ? (rackSettings.siteId ?? 0n) : undefined,
           buildingId: sendPlacement ? (rackSettings.buildingId ?? 0n) : undefined,
           onSuccess: () => resolve(),

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -527,6 +527,7 @@ export default function ManageRackModal({
         const placementChanged =
           canManagePlacement &&
           (formData.siteId !== rackSettings.siteId || formData.buildingId !== rackSettings.buildingId);
+        let updated: DeviceSet | undefined;
         try {
           await new Promise<void>((resolve, reject) => {
             updateRack({
@@ -540,7 +541,10 @@ export default function ManageRackModal({
               // Unset level -> 0n unassign when the operator did change placement.
               siteId: placementChanged ? (formData.siteId ?? 0n) : undefined,
               buildingId: placementChanged ? (formData.buildingId ?? 0n) : undefined,
-              onSuccess: () => resolve(),
+              onSuccess: (ds) => {
+                updated = ds;
+                resolve();
+              },
               onError: (msg) => reject(new Error(msg)),
             });
           });
@@ -552,10 +556,28 @@ export default function ManageRackModal({
           // Keep Rack Settings open (don't apply) so the operator can retry.
           return;
         }
+        // Adopt the server's AUTHORITATIVE placement from the response, not the
+        // submitted formData: when placement was omitted (metadata-only edit)
+        // the server kept whatever the rack's current site/building is — which
+        // may differ from the stale formData values if another session moved it.
+        // The eligibility filter reads rackSettings placement, so trusting the
+        // response keeps the miner list scoped to where the rack really is.
+        const serverRackInfo = updated?.typeDetails.case === "rackInfo" ? updated.typeDetails.value : undefined;
+        const applied: RackFormData = serverRackInfo
+          ? {
+              ...formData,
+              siteId: serverRackInfo.siteId,
+              buildingId: serverRackInfo.buildingId,
+              zone: serverRackInfo.zone,
+            }
+          : formData;
         // Settings are now live on the server. Let the parent refetch so its
         // rack list/overview reflects the new label/placement even if the
         // operator dismisses without pressing the final miner Save.
         onSettingsPersisted?.();
+        setRackSettings(applied);
+        setShowRackSettings(false);
+        return;
       }
 
       setRackSettings(formData);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -22,6 +22,7 @@ import type { MinerEligibility } from "@/protoFleet/components/MinerSelectionLis
 import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
 import { isMinerSnapshotIneligible } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import { slotNumberToRowCol } from "@/protoFleet/features/fleetManagement/utils/slotNumbering";
+import { useHasPermission } from "@/protoFleet/store";
 
 import { DismissCircle } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
@@ -99,6 +100,11 @@ export default function ManageRackModal({
   onDelete,
 }: ManageRackModalProps) {
   const { saveRack, getRackSlots, listGroupMembers } = useDeviceSets();
+  // Rack placement (site/building) is a site:manage action, enforced server-
+  // side on SaveRack. A rack:manage-only operator edits rack contents without
+  // touching placement, so we omit placement from the request (preserving the
+  // rack's current site/building) rather than sending an explicit change.
+  const canManagePlacement = useHasPermission("site:manage");
 
   // Fetch all miners for display data (name, IP, model, etc.)
   const { miners: minersMap } = useFleet({ pageSize: 1000 });
@@ -525,12 +531,22 @@ export default function ManageRackModal({
           coolingType: rackSettings.coolingType,
           deviceIdentifiers: rackMiners,
           slotAssignments: slotAssignmentsList,
-          // Placement from the dropdowns. On edit, send an explicit 0 for an
-          // Unassigned selection so it actually clears (omitting would
-          // preserve the rack's current placement). On create there's nothing
-          // to preserve, so leave unfilled levels undefined → omitted → NULL.
-          siteId: existingRackId !== undefined ? (rackSettings.siteId ?? 0n) : rackSettings.siteId,
-          buildingId: existingRackId !== undefined ? (rackSettings.buildingId ?? 0n) : rackSettings.buildingId,
+          // Placement from the dropdowns, only when the operator can manage
+          // site placement — otherwise omit it (preserve current / create
+          // unplaced) so a rack:manage-only edit isn't rejected server-side.
+          // On edit, send an explicit 0 for an Unassigned selection so it
+          // actually clears (omitting would preserve). On create there's
+          // nothing to preserve, so unfilled levels are undefined → NULL.
+          siteId: canManagePlacement
+            ? existingRackId !== undefined
+              ? (rackSettings.siteId ?? 0n)
+              : rackSettings.siteId
+            : undefined,
+          buildingId: canManagePlacement
+            ? existingRackId !== undefined
+              ? (rackSettings.buildingId ?? 0n)
+              : rackSettings.buildingId
+            : undefined,
           onSuccess: () => resolve(),
           onError: (msg) => reject(new Error(msg)),
         });
@@ -546,7 +562,7 @@ export default function ManageRackModal({
     } finally {
       setIsSaving(false);
     }
-  }, [existingRackId, rackSettings, rackMiners, totalSlots, activeAssignments, saveRack, onSave]);
+  }, [existingRackId, rackSettings, rackMiners, totalSlots, activeAssignments, canManagePlacement, saveRack, onSave]);
 
   if (!show) return null;
 

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -85,6 +85,12 @@ interface ManageRackModalProps {
   scopedSiteId?: bigint;
   onDismiss: () => void;
   onSave: () => void;
+  // Fired after the Rack Settings "Continue" persists an EXISTING rack's
+  // settings (label/placement/zone/dims) — which happens before the final
+  // miner Save. Parents should refetch in the background so the rack list /
+  // overview stays consistent even if the operator dismisses the modal
+  // without pressing Save. No-op for a new rack (nothing is persisted yet).
+  onSettingsPersisted?: () => void;
   onDelete?: () => Promise<void> | void;
 }
 
@@ -97,6 +103,7 @@ export default function ManageRackModal({
   scopedSiteId,
   onDismiss,
   onSave,
+  onSettingsPersisted,
   onDelete,
 }: ManageRackModalProps) {
   const { saveRack, updateRack, getRackSlots, listGroupMembers } = useDeviceSets();
@@ -539,12 +546,16 @@ export default function ManageRackModal({
           // Keep Rack Settings open (don't apply) so the operator can retry.
           return;
         }
+        // Settings are now live on the server. Let the parent refetch so its
+        // rack list/overview reflects the new label/placement even if the
+        // operator dismisses without pressing the final miner Save.
+        onSettingsPersisted?.();
       }
 
       setRackSettings(formData);
       setShowRackSettings(false);
     },
-    [existingRackId, canManagePlacement, updateRack],
+    [existingRackId, canManagePlacement, updateRack, onSettingsPersisted],
   );
 
   // Save handler — single atomic RPC

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -580,22 +580,14 @@ export default function ManageRackModal({
           coolingType: rackSettings.coolingType,
           deviceIdentifiers: rackMiners,
           slotAssignments: slotAssignmentsList,
-          // Placement from the dropdowns, only when the operator can manage
-          // site placement — otherwise omit it (preserve current / create
-          // unplaced) so a rack:manage-only edit isn't rejected server-side.
-          // On edit, send an explicit 0 for an Unassigned selection so it
-          // actually clears (omitting would preserve). On create there's
-          // nothing to preserve, so unfilled levels are undefined → NULL.
-          siteId: canManagePlacement
-            ? existingRackId !== undefined
-              ? (rackSettings.siteId ?? 0n)
-              : rackSettings.siteId
-            : undefined,
-          buildingId: canManagePlacement
-            ? existingRackId !== undefined
-              ? (rackSettings.buildingId ?? 0n)
-              : rackSettings.buildingId
-            : undefined,
+          // Placement is only sent on CREATE. An existing rack's Site/Building
+          // change is already persisted on the Rack Settings "Continue", so a
+          // (possibly miners-only) Save omits placement — this preserves the
+          // rack's current server placement and, crucially, can't clobber a
+          // move made by another session while this modal was open. Gated on
+          // site:manage; create sends its chosen placement (unset → NULL).
+          siteId: canManagePlacement && existingRackId === undefined ? rackSettings.siteId : undefined,
+          buildingId: canManagePlacement && existingRackId === undefined ? rackSettings.buildingId : undefined,
           onSuccess: () => resolve(),
           onError: (msg) => reject(new Error(msg)),
         });

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -78,6 +78,10 @@ interface ManageRackModalProps {
   // New rack" flow) so the selected miners land in the left pane ready
   // for slot assignment. Ignored in edit mode (existingRackId set).
   seededMinerIds?: string[];
+  // Page-header site scope (single-site only). Forwarded to the embedded
+  // RackSettingsModal so a new rack created within a site scope keeps its Site
+  // field locked to that scope. Ignored for an existing rack (edit).
+  scopedSiteId?: bigint;
   onDismiss: () => void;
   onSave: () => void;
   onDelete?: () => Promise<void> | void;
@@ -89,6 +93,7 @@ export default function ManageRackModal({
   existingRackId,
   existingRacks,
   seededMinerIds,
+  scopedSiteId,
   onDismiss,
   onSave,
   onDelete,
@@ -104,21 +109,19 @@ export default function ManageRackModal({
   const totalSlots = rackSettings.rows * rackSettings.columns;
   const numberingOrigin = orderIndexToOrigin(rackSettings.orderIndex);
 
-  // Target-rack placement for the selection modals' eligibility filter. Read
-  // from the rack's own DeviceSet (id-based; site derives from building). A new
-  // rack has no id/placement yet, so eligibility only excludes already-racked
-  // miners. `|| undefined` collapses the proto default (0) to unassigned.
-  const currentRack = useMemo(
-    () => (existingRackId !== undefined ? existingRacks.find((r) => r.id === existingRackId) : undefined),
-    [existingRackId, existingRacks],
-  );
+  // Target-rack placement for the selection modals' eligibility filter. Tracks
+  // the placement chosen in RackSettingsModal (rackSettings) so the assignable
+  // list reflects the site/building the rack will actually land in — including
+  // edits made in-session and a not-yet-saved new rack. `rackId` still keys off
+  // the persisted id (a new rack has none, so only rack membership is excluded
+  // until it's saved).
   const eligibility = useMemo<MinerEligibility>(
     () => ({
       rackId: existingRackId,
-      siteId: currentRack?.placement?.site?.id || undefined,
-      buildingId: currentRack?.placement?.building?.id || undefined,
+      siteId: rackSettings.siteId,
+      buildingId: rackSettings.buildingId,
     }),
-    [existingRackId, currentRack],
+    [existingRackId, rackSettings.siteId, rackSettings.buildingId],
   );
 
   // Core assignment state. A new rack (no existingRackId) can be seeded
@@ -522,6 +525,12 @@ export default function ManageRackModal({
           coolingType: rackSettings.coolingType,
           deviceIdentifiers: rackMiners,
           slotAssignments: slotAssignmentsList,
+          // Placement from the dropdowns. On edit, send an explicit 0 for an
+          // Unassigned selection so it actually clears (omitting would
+          // preserve the rack's current placement). On create there's nothing
+          // to preserve, so leave unfilled levels undefined → omitted → NULL.
+          siteId: existingRackId !== undefined ? (rackSettings.siteId ?? 0n) : rackSettings.siteId,
+          buildingId: existingRackId !== undefined ? (rackSettings.buildingId ?? 0n) : rackSettings.buildingId,
           onSuccess: () => resolve(),
           onError: (msg) => reject(new Error(msg)),
         });
@@ -644,6 +653,8 @@ export default function ManageRackModal({
           show={showRackSettings}
           existingRacks={existingRacks}
           initialFormData={rackSettings}
+          existingRack={existingRackId !== undefined}
+          defaultSiteId={scopedSiteId}
           onDismiss={() => setShowRackSettings(false)}
           onContinue={handleRackSettingsUpdate}
         />

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -115,19 +115,27 @@ export default function ManageRackModal({
   const totalSlots = rackSettings.rows * rackSettings.columns;
   const numberingOrigin = orderIndexToOrigin(rackSettings.orderIndex);
 
-  // Target-rack placement for the selection modals' eligibility filter. Tracks
-  // the placement chosen in RackSettingsModal (rackSettings) so the assignable
-  // list reflects the site/building the rack will actually land in — including
-  // edits made in-session and a not-yet-saved new rack. `rackId` still keys off
-  // the persisted id (a new rack has none, so only rack membership is excluded
-  // until it's saved).
+  // Target-rack placement for the selection modals' eligibility filter. For an
+  // existing rack, pin to its CURRENT (persisted) placement — not a pending
+  // Site/Building edit in Rack Settings. A move is applied on save and cascades
+  // the rack's members with it, so the members are still at the old placement
+  // here; using the pending placement would flag them ineligible and let
+  // "Select all" drop them. A new rack has no persisted placement, so the live
+  // selection is the intended placement. `rackId` keys off the persisted id (a
+  // new rack has none, so only rack membership is excluded until it's saved).
   const eligibility = useMemo<MinerEligibility>(
     () => ({
       rackId: existingRackId,
-      siteId: rackSettings.siteId,
-      buildingId: rackSettings.buildingId,
+      siteId: existingRackId !== undefined ? initialRackSettings.siteId : rackSettings.siteId,
+      buildingId: existingRackId !== undefined ? initialRackSettings.buildingId : rackSettings.buildingId,
     }),
-    [existingRackId, rackSettings.siteId, rackSettings.buildingId],
+    [
+      existingRackId,
+      initialRackSettings.siteId,
+      initialRackSettings.buildingId,
+      rackSettings.siteId,
+      rackSettings.buildingId,
+    ],
   );
 
   // Core assignment state. A new rack (no existingRackId) can be seeded

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -569,6 +569,16 @@ export default function ManageRackModal({
         return { deviceIdentifier: deviceId, row, column: col };
       });
 
+      // Placement rides on CREATE (choose it) and on the one edit case where
+      // omitting it would lose the change: clearing an in-building rack's zone
+      // (the server's omitted-placement path restores the old zone). Every
+      // other existing-rack save omits placement — it's persisted on the Rack
+      // Settings Continue, so omitting keeps a concurrent move from being
+      // clobbered.
+      const clearingInBuildingZone =
+        existingRackId !== undefined && rackSettings.buildingId !== undefined && rackSettings.zone.trim() === "";
+      const sendPlacement = canManagePlacement && (existingRackId === undefined || clearingInBuildingZone);
+
       await new Promise<void>((resolve, reject) => {
         saveRack({
           deviceSetId: existingRackId,
@@ -586,8 +596,13 @@ export default function ManageRackModal({
           // rack's current server placement and, crucially, can't clobber a
           // move made by another session while this modal was open. Gated on
           // site:manage; create sends its chosen placement (unset → NULL).
-          siteId: canManagePlacement && existingRackId === undefined ? rackSettings.siteId : undefined,
-          buildingId: canManagePlacement && existingRackId === undefined ? rackSettings.buildingId : undefined,
+          //
+          // Exception: clearing an in-building rack's zone. With placement
+          // omitted the server's legacy path restores the zone from the
+          // current placement, so the blank is silently ignored. Send the
+          // rack's current placement explicitly to mark it a real clear.
+          siteId: sendPlacement ? (rackSettings.siteId ?? 0n) : undefined,
+          buildingId: sendPlacement ? (rackSettings.buildingId ?? 0n) : undefined,
           onSuccess: () => resolve(),
           onError: (msg) => reject(new Error(msg)),
         });

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -115,27 +115,21 @@ export default function ManageRackModal({
   const totalSlots = rackSettings.rows * rackSettings.columns;
   const numberingOrigin = orderIndexToOrigin(rackSettings.orderIndex);
 
-  // Target-rack placement for the selection modals' eligibility filter. For an
-  // existing rack, pin to its CURRENT (persisted) placement — not a pending
-  // Site/Building edit in Rack Settings. A move is applied on save and cascades
-  // the rack's members with it, so the members are still at the old placement
-  // here; using the pending placement would flag them ineligible and let
-  // "Select all" drop them. A new rack has no persisted placement, so the live
-  // selection is the intended placement. `rackId` keys off the persisted id (a
-  // new rack has none, so only rack membership is excluded until it's saved).
+  // Target-rack placement for the selection modals' eligibility filter.
+  // rackSettings always reflects the rack's LIVE persisted placement: a
+  // Site/Building change in Rack Settings is persisted immediately on Continue
+  // (handleRackSettingsUpdate), which also cascades the rack's members to the
+  // new placement. So by the time this filter runs, the rack and its members
+  // are already at the placement in rackSettings — no current-vs-pending split,
+  // and a miner already at the new destination reads as assignable. A new rack
+  // has no persisted placement, so rackSettings is the intended placement.
   const eligibility = useMemo<MinerEligibility>(
     () => ({
       rackId: existingRackId,
-      siteId: existingRackId !== undefined ? initialRackSettings.siteId : rackSettings.siteId,
-      buildingId: existingRackId !== undefined ? initialRackSettings.buildingId : rackSettings.buildingId,
+      siteId: rackSettings.siteId,
+      buildingId: rackSettings.buildingId,
     }),
-    [
-      existingRackId,
-      initialRackSettings.siteId,
-      initialRackSettings.buildingId,
-      rackSettings.siteId,
-      rackSettings.buildingId,
-    ],
+    [existingRackId, rackSettings.siteId, rackSettings.buildingId],
   );
 
   // Core assignment state. A new rack (no existingRackId) can be seeded
@@ -499,11 +493,58 @@ export default function ManageRackModal({
     [eligibility, totalSlots, promptReparent],
   );
 
-  // RackSettingsModal edit handler
-  const handleRackSettingsUpdate = useCallback((formData: RackFormData) => {
-    setRackSettings(formData);
-    setShowRackSettings(false);
-  }, []);
+  // RackSettingsModal edit handler. For an existing rack, a Site/Building
+  // change is persisted right here (not deferred to the final Save) so the
+  // rack — and its server-cascaded members — are already at the new placement
+  // before the operator opens Manage Miners; otherwise the assignable-only
+  // list would judge miners against a placement that isn't live yet. Only a
+  // real placement change triggers this; label/zone/dimension edits stay in
+  // memory until Save. Requires site:manage (already enforced on SaveRack).
+  const handleRackSettingsUpdate = useCallback(
+    async (formData: RackFormData) => {
+      const placementChanged =
+        existingRackId !== undefined &&
+        canManagePlacement &&
+        (formData.siteId !== rackSettings.siteId || formData.buildingId !== rackSettings.buildingId);
+
+      if (placementChanged) {
+        const slotAssignmentsList = Object.entries(activeAssignments).map(([key, deviceId]) => {
+          const [row, col] = key.split("-").map(Number);
+          return { deviceIdentifier: deviceId, row, column: col };
+        });
+        try {
+          await new Promise<void>((resolve, reject) => {
+            saveRack({
+              deviceSetId: existingRackId,
+              label: formData.label,
+              zone: formData.zone,
+              rows: formData.rows,
+              columns: formData.columns,
+              orderIndex: formData.orderIndex,
+              coolingType: formData.coolingType,
+              deviceIdentifiers: rackMiners,
+              slotAssignments: slotAssignmentsList,
+              siteId: formData.siteId ?? 0n,
+              buildingId: formData.buildingId ?? 0n,
+              onSuccess: () => resolve(),
+              onError: (msg) => reject(new Error(msg)),
+            });
+          });
+        } catch (err) {
+          pushToast({
+            message: getErrorMessage(err, "Failed to update rack placement. Please try again."),
+            status: STATUSES.error,
+          });
+          // Keep Rack Settings open (don't apply) so the operator can retry.
+          return;
+        }
+      }
+
+      setRackSettings(formData);
+      setShowRackSettings(false);
+    },
+    [existingRackId, canManagePlacement, rackSettings, rackMiners, activeAssignments, saveRack],
+  );
 
   // Save handler — single atomic RPC
   const handleSave = useCallback(async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -7,6 +7,7 @@ import ReparentWarningDialog from "./ReparentWarningDialog";
 import ScanMinerQrModal from "./ScanMinerQrModal";
 import SearchMinersModal from "./SearchMinersModal";
 import { type AssignmentMode, orderIndexToOrigin, originLabel, type RackFormData, type SelectedSlot } from "./types";
+import { useBuildings } from "@/protoFleet/api/buildings";
 import { fetchAllMinerSnapshots } from "@/protoFleet/api/fetchAllMinerSnapshots";
 import { type DeviceSet, type RackSlot } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import {
@@ -15,6 +16,7 @@ import {
   PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
+import { useSites } from "@/protoFleet/api/sites";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import useFleet from "@/protoFleet/api/useFleet";
 import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
@@ -100,6 +102,11 @@ export default function ManageRackModal({
   onDelete,
 }: ManageRackModalProps) {
   const { saveRack, getRackSlots, listGroupMembers } = useDeviceSets();
+  // Placement moves for an in-session Rack Settings change go through the
+  // dedicated assign RPCs, which cascade the rack's CURRENT server-side members
+  // — never the modal's draft membership (see handleRackSettingsUpdate).
+  const { assignRacksToSite } = useSites();
+  const { assignRacksToBuilding } = useBuildings();
   // Rack placement (site/building) is a site:manage action, enforced server-
   // side on SaveRack. A rack:manage-only operator edits rack contents without
   // touching placement, so we omit placement from the request (preserving the
@@ -499,36 +506,41 @@ export default function ManageRackModal({
   // before the operator opens Manage Miners; otherwise the assignable-only
   // list would judge miners against a placement that isn't live yet. Only a
   // real placement change triggers this; label/zone/dimension edits stay in
-  // memory until Save. Requires site:manage (already enforced on SaveRack).
+  // memory until Save. Requires site:manage.
+  //
+  // Uses the dedicated placement RPCs (AssignRacksToBuilding / ToSite), NOT
+  // SaveRack: they move the rack and cascade its CURRENT persisted members,
+  // and must not touch membership — SaveRack would overwrite it with the
+  // modal's draft `rackMiners` (empty if members haven't loaded, or carrying
+  // unsaved add/removes), committing miner changes the operator never saved.
   const handleRackSettingsUpdate = useCallback(
     async (formData: RackFormData) => {
+      const rackId = existingRackId;
       const placementChanged =
-        existingRackId !== undefined &&
+        rackId !== undefined &&
         canManagePlacement &&
         (formData.siteId !== rackSettings.siteId || formData.buildingId !== rackSettings.buildingId);
 
       if (placementChanged) {
-        const slotAssignmentsList = Object.entries(activeAssignments).map(([key, deviceId]) => {
-          const [row, col] = key.split("-").map(Number);
-          return { deviceIdentifier: deviceId, row, column: col };
-        });
         try {
           await new Promise<void>((resolve, reject) => {
-            saveRack({
-              deviceSetId: existingRackId,
-              label: formData.label,
-              zone: formData.zone,
-              rows: formData.rows,
-              columns: formData.columns,
-              orderIndex: formData.orderIndex,
-              coolingType: formData.coolingType,
-              deviceIdentifiers: rackMiners,
-              slotAssignments: slotAssignmentsList,
-              siteId: formData.siteId ?? 0n,
-              buildingId: formData.buildingId ?? 0n,
-              onSuccess: () => resolve(),
-              onError: (msg) => reject(new Error(msg)),
-            });
+            const onError = (msg: string) => reject(new Error(msg));
+            if (formData.buildingId !== undefined) {
+              assignRacksToBuilding({
+                racks: [{ rackId }],
+                targetBuildingId: formData.buildingId,
+                onSuccess: () => resolve(),
+                onError,
+              });
+            } else {
+              // Direct-under-site (siteId set) or fully unassigned (undefined).
+              assignRacksToSite({
+                rackIds: [rackId],
+                targetSiteId: formData.siteId,
+                onSuccess: () => resolve(),
+                onError,
+              });
+            }
           });
         } catch (err) {
           pushToast({
@@ -543,7 +555,7 @@ export default function ManageRackModal({
       setRackSettings(formData);
       setShowRackSettings(false);
     },
-    [existingRackId, canManagePlacement, rackSettings, rackMiners, activeAssignments, saveRack],
+    [existingRackId, canManagePlacement, rackSettings, assignRacksToSite, assignRacksToBuilding],
   );
 
   // Save handler — single atomic RPC

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -106,7 +106,7 @@ export default function ManageRackModal({
   onSettingsPersisted,
   onDelete,
 }: ManageRackModalProps) {
-  const { saveRack, updateRack, getRackSlots, listGroupMembers } = useDeviceSets();
+  const { saveRack, updateRack, getDeviceSet, getRackSlots, listGroupMembers } = useDeviceSets();
   // Rack placement (site/building) is a site:manage action, enforced server-
   // side on SaveRack and UpdateDeviceSet. A rack:manage-only operator edits
   // rack contents and metadata (label/zone/dims) without touching placement,
@@ -517,6 +517,16 @@ export default function ManageRackModal({
     async (formData: RackFormData) => {
       const rackId = existingRackId;
       if (rackId !== undefined) {
+        // Only send placement when the operator actually changed site/building
+        // this edit (compared to what the form was seeded with). A metadata-only
+        // edit (label/zone/dims) omits placement, so UpdateDeviceSet preserves
+        // the rack's CURRENT server placement — a stale cached value can't
+        // re-parent a rack that another session moved while this modal was open.
+        // Zone stays authoritative even with placement omitted (the settings
+        // path treats an empty zone as an explicit clear).
+        const placementChanged =
+          canManagePlacement &&
+          (formData.siteId !== rackSettings.siteId || formData.buildingId !== rackSettings.buildingId);
         try {
           await new Promise<void>((resolve, reject) => {
             updateRack({
@@ -527,13 +537,9 @@ export default function ManageRackModal({
               columns: formData.columns,
               orderIndex: formData.orderIndex,
               coolingType: formData.coolingType,
-              // site:manage sends explicit placement (an unset level -> 0n
-              // unassign) so the zone is authoritative and the rack + its
-              // members move now. A rack:manage-only operator omits placement,
-              // which preserves the current site/building; their zone edits
-              // (including a clear) still persist server-side.
-              siteId: canManagePlacement ? (formData.siteId ?? 0n) : undefined,
-              buildingId: canManagePlacement ? (formData.buildingId ?? 0n) : undefined,
+              // Unset level -> 0n unassign when the operator did change placement.
+              siteId: placementChanged ? (formData.siteId ?? 0n) : undefined,
+              buildingId: placementChanged ? (formData.buildingId ?? 0n) : undefined,
               onSuccess: () => resolve(),
               onError: (msg) => reject(new Error(msg)),
             });
@@ -555,7 +561,7 @@ export default function ManageRackModal({
       setRackSettings(formData);
       setShowRackSettings(false);
     },
-    [existingRackId, canManagePlacement, updateRack, onSettingsPersisted],
+    [existingRackId, canManagePlacement, rackSettings, updateRack, onSettingsPersisted],
   );
 
   // Save handler — single atomic RPC
@@ -588,15 +594,53 @@ export default function ManageRackModal({
       // clobber a move made by another session while this modal was open.
       const sendPlacement = canManagePlacement && existingRackId === undefined;
 
+      // Existing-rack Save is miners-only, but SaveRack always rewrites
+      // rack_info, so re-send the rack's CURRENT server metadata rather than the
+      // modal's cached copy — otherwise a concurrent zone/dimension edit from
+      // another session would be reverted (and stale dims could mis-validate the
+      // new slots). Best-effort: fall back to the cached values on a fetch miss
+      // so a transient error can't block the miner save.
+      let meta = {
+        label: rackSettings.label,
+        zone: rackSettings.zone,
+        rows: rackSettings.rows,
+        columns: rackSettings.columns,
+        orderIndex: rackSettings.orderIndex,
+        coolingType: rackSettings.coolingType,
+      };
+      if (existingRackId !== undefined) {
+        await new Promise<void>((resolve) => {
+          getDeviceSet({
+            deviceSetId: existingRackId,
+            onSuccess: (ds) => {
+              if (ds.typeDetails.case === "rackInfo") {
+                const ri = ds.typeDetails.value;
+                meta = {
+                  label: ds.label,
+                  zone: ri.zone,
+                  rows: ri.rows,
+                  columns: ri.columns,
+                  orderIndex: ri.orderIndex,
+                  coolingType: ri.coolingType,
+                };
+              }
+              resolve();
+            },
+            onNotFound: () => resolve(),
+            onError: () => resolve(),
+          });
+        });
+      }
+
       await new Promise<void>((resolve, reject) => {
         saveRack({
           deviceSetId: existingRackId,
-          label: rackSettings.label,
-          zone: rackSettings.zone,
-          rows: rackSettings.rows,
-          columns: rackSettings.columns,
-          orderIndex: rackSettings.orderIndex,
-          coolingType: rackSettings.coolingType,
+          label: meta.label,
+          zone: meta.zone,
+          rows: meta.rows,
+          columns: meta.columns,
+          orderIndex: meta.orderIndex,
+          coolingType: meta.coolingType,
           deviceIdentifiers: rackMiners,
           slotAssignments: slotAssignmentsList,
           // Create sends its chosen placement (unset level → NULL), gated on
@@ -609,7 +653,7 @@ export default function ManageRackModal({
       });
 
       pushToast({
-        message: existingRackId ? `Rack "${rackSettings.label}" updated` : `Rack "${rackSettings.label}" created`,
+        message: existingRackId ? `Rack "${meta.label}" updated` : `Rack "${meta.label}" created`,
         status: STATUSES.success,
       });
       onSave();
@@ -618,7 +662,17 @@ export default function ManageRackModal({
     } finally {
       setIsSaving(false);
     }
-  }, [existingRackId, rackSettings, rackMiners, totalSlots, activeAssignments, canManagePlacement, saveRack, onSave]);
+  }, [
+    existingRackId,
+    rackSettings,
+    rackMiners,
+    totalSlots,
+    activeAssignments,
+    canManagePlacement,
+    getDeviceSet,
+    saveRack,
+    onSave,
+  ]);
 
   if (!show) return null;
 

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/types.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/types.ts
@@ -10,6 +10,13 @@ export interface RackFormData {
   columns: number;
   orderIndex: RackOrderIndex;
   coolingType: RackCoolingType;
+  // Rack placement chosen in RackSettingsModal. Both optional; undefined =
+  // unassigned at that level. siteId is retained even when buildingId is set
+  // (it's the selected building's site) so the miner-selection eligibility
+  // filter can pin the site — saveRack omits it from the wire RackInfo and
+  // lets the server derive site from the building.
+  siteId?: bigint;
+  buildingId?: bigint;
 }
 
 export interface SelectedSlot {

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -40,7 +40,10 @@ interface RackSettingsModalProps {
   // own (it always runs in onContinue mode), so the caller passes it.
   existingRack?: boolean;
   onDismiss: () => void;
-  onContinue?: (formData: RackFormData) => void;
+  // May be async: for an existing rack the parent persists the settings (label/
+  // zone/dims + placement) on Continue, so we await it and keep the button busy
+  // until it resolves — a rejection leaves the modal open for a retry.
+  onContinue?: (formData: RackFormData) => void | Promise<void>;
   onSuccess?: () => void;
 }
 
@@ -348,7 +351,7 @@ const RackSettingsModal = ({
     [rackTypes],
   );
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = useCallback(async () => {
     setLabelError(undefined);
     setColumnsError(undefined);
     setRowsError(undefined);
@@ -386,7 +389,15 @@ const RackSettingsModal = ({
     };
 
     if (!isEditMode) {
-      onContinue?.(formData);
+      // Continue may persist settings (existing rack) or just advance (new
+      // rack). Await either way and keep the button busy so a slow save can't
+      // be double-submitted; the parent reopens/leaves this modal on failure.
+      setIsSubmitting(true);
+      try {
+        await onContinue?.(formData);
+      } finally {
+        setIsSubmitting(false);
+      }
       return;
     }
 

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -450,11 +450,14 @@ const RackSettingsModal = ({
       open={show}
       title="Rack settings"
       phoneSheet
-      onDismiss={onDismiss}
+      // Block dismiss (X / backdrop) while a settings save is in flight — the
+      // updateRack call persists regardless, so closing mid-request would be a
+      // surprise. Re-enabled once it resolves (or fails, leaving the form open).
+      onDismiss={isSubmitting ? () => {} : onDismiss}
       divider={false}
       buttons={[
         {
-          text: isEditMode ? (isSubmitting ? "Saving..." : "Save") : "Continue",
+          text: isSubmitting ? "Saving..." : isEditMode ? "Save" : "Continue",
           variant: "primary",
           disabled: isSubmitting || isInitialLoading,
           loading: isSubmitting,

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -129,8 +129,14 @@ const RackSettingsModal = ({
 
   const [label, setLabel] = useState(initialFormData?.label ?? rack?.label ?? "");
   const [zone, setZone] = useState(() => {
+    // Editing an existing rack: its stored zone is authoritative, INCLUDING an
+    // intentional "" — a blank zone is now a valid state. Use presence, not
+    // truthiness, and never fall through to the last-rack default, which would
+    // resurrect a just-cleared zone and re-persist it on Continue.
+    if (isExistingRack) return initialFormData?.zone ?? rackInfo?.zone ?? "";
+    // Create: seed from the form if it carries a zone, otherwise default to the
+    // most recently created rack's zone as a convenience.
     if (initialFormData?.zone) return initialFormData.zone;
-    if (rackInfo?.zone) return rackInfo.zone;
     if (existingRacks.length > 0) {
       const sorted = [...existingRacks].sort((a, b) => {
         const aTime = a.createdAt?.seconds ?? BigInt(0);

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -1,12 +1,15 @@
 import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
 
+import { useBuildings } from "@/protoFleet/api/buildings";
+import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import {
   type DeviceSet,
   RackCoolingType,
   RackOrderIndex,
   type RackType,
 } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { useSitesContext } from "@/protoFleet/api/SitesContext";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import { type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal/types";
 
@@ -25,10 +28,25 @@ interface RackSettingsModalProps {
   existingRacks: DeviceSet[];
   rack?: DeviceSet;
   initialFormData?: RackFormData;
+  // Prepopulates the Site dropdown when creating a rack with no prior
+  // placement (e.g. the page-header site scope). Ignored when
+  // initialFormData already carries a siteId.
+  defaultSiteId?: bigint;
+  // True when editing an existing rack (which has a real, possibly-NULL
+  // placement). Drives the "Unassigned" placement option — see
+  // showUnassignedOption. The embedded modal inside ManageRackModal can't tell
+  // create from edit on its own (it always runs in onContinue mode), so the
+  // caller passes it.
+  existingRack?: boolean;
   onDismiss: () => void;
   onContinue?: (formData: RackFormData) => void;
   onSuccess?: () => void;
 }
+
+// Explicit "Unassigned" entry for the placement dropdowns. The shared Select
+// has no clear affordance, so without this a user who picks a site/building
+// could never revert to unassigned.
+const UNASSIGNED_OPTION: SelectOption = { value: "", label: "Unassigned" };
 
 const orderIndexOptions: SelectOption[] = [
   { value: String(RackOrderIndex.BOTTOM_LEFT), label: "Bottom left" },
@@ -47,6 +65,8 @@ const RackSettingsModal = ({
   existingRacks,
   rack,
   initialFormData,
+  defaultSiteId,
+  existingRack,
   onDismiss,
   onContinue,
   onSuccess,
@@ -55,6 +75,36 @@ const RackSettingsModal = ({
   const rackInfo = rack?.typeDetails.case === "rackInfo" ? rack.typeDetails.value : undefined;
 
   const { updateRack, listRackZones, listRackTypes } = useDeviceSets();
+  const { sites } = useSitesContext();
+  const { listBuildingsBySite } = useBuildings();
+
+  // Editing an already-persisted rack surfaces an explicit "Unassigned" option
+  // seeded to the rack's real placement (a rack genuinely has a site/building
+  // or NULL). Creating a rack treats placement as an optional, unfilled field
+  // — no "Unassigned" entry, empty by default — so an empty select reads as
+  // "not chosen" (→ NULL) rather than a deliberate-looking default.
+  const showUnassignedOption = existingRack || isEditMode;
+
+  // Creating within a page-header site scope: the rack belongs to that site,
+  // so lock the field to it (defaultSiteId is only set for a single-site
+  // scope). An unscoped create leaves Site editable/optional; edit is never
+  // locked.
+  const siteLocked = !showUnassignedOption && defaultSiteId !== undefined;
+
+  // Placement. Site is retained even when a building is chosen (it's the
+  // building's site) so downstream eligibility filtering can pin the site;
+  // saveRack drops it from the wire RackInfo. Empty string = Unassigned.
+  const [siteIdText, setSiteIdText] = useState<string>(() => {
+    if (initialFormData?.siteId !== undefined) return initialFormData.siteId.toString();
+    // Create-only prefill — edit seeds solely from the rack's real placement,
+    // so an unplaced rack reads as Unassigned rather than the page scope.
+    if (!showUnassignedOption && defaultSiteId !== undefined) return defaultSiteId.toString();
+    return "";
+  });
+  const [buildingIdText, setBuildingIdText] = useState<string>(
+    initialFormData?.buildingId !== undefined ? initialFormData.buildingId.toString() : "",
+  );
+  const [buildings, setBuildings] = useState<BuildingWithCounts[]>([]);
 
   const [label, setLabel] = useState(initialFormData?.label ?? rack?.label ?? "");
   const [zone, setZone] = useState(() => {
@@ -120,6 +170,51 @@ const RackSettingsModal = ({
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount; initialFormData and rackInfo are initial values
   }, [listRackZones, listRackTypes]);
+
+  // Load the selected site's buildings so the Building dropdown can scope its
+  // options. Runs on mount (edit: shows the rack's current building) and on
+  // every site change. Aborts in-flight fetches so a fast site switch can't
+  // land stale options. When no site is selected there's nothing to fetch —
+  // buildingOptions falls back to Unassigned-only.
+  useEffect(() => {
+    if (siteIdText === "") return;
+    const controller = new AbortController();
+    listBuildingsBySite({
+      siteId: BigInt(siteIdText),
+      signal: controller.signal,
+      onSuccess: setBuildings,
+    });
+    return () => controller.abort();
+  }, [siteIdText, listBuildingsBySite]);
+
+  // Changing the site clears the building selection (the old building lives in
+  // a different site) and drops its now-stale options until the new site's
+  // buildings load.
+  const handleSiteChange = useCallback((value: string) => {
+    setSiteIdText(value);
+    setBuildingIdText("");
+    setBuildings([]);
+  }, []);
+
+  const siteOptions = useMemo<SelectOption[]>(() => {
+    const real = (sites ?? [])
+      .filter((s) => s.site !== undefined)
+      .map((s) => ({ value: s.site!.id.toString(), label: s.site!.name }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+    return showUnassignedOption ? [UNASSIGNED_OPTION, ...real] : real;
+  }, [sites, showUnassignedOption]);
+
+  const buildingOptions = useMemo<SelectOption[]>(() => {
+    // No site selected → nothing to scope to. Edit still offers Unassigned so
+    // the current NULL building reads clearly; create shows an empty
+    // placeholder.
+    if (siteIdText === "") return showUnassignedOption ? [UNASSIGNED_OPTION] : [];
+    const real = buildings
+      .filter((b) => b.building !== undefined)
+      .map((b) => ({ value: b.building!.id.toString(), label: b.building!.name }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+    return showUnassignedOption ? [UNASSIGNED_OPTION, ...real] : real;
+  }, [siteIdText, buildings, showUnassignedOption]);
 
   const filteredSuggestions = useMemo(() => {
     if (!zone.trim()) return zoneSuggestions;
@@ -230,6 +325,8 @@ const RackSettingsModal = ({
       columns: colsNum,
       orderIndex,
       coolingType,
+      siteId: siteIdText !== "" ? BigInt(siteIdText) : undefined,
+      buildingId: buildingIdText !== "" ? BigInt(buildingIdText) : undefined,
     };
 
     if (!isEditMode) {
@@ -269,6 +366,8 @@ const RackSettingsModal = ({
     columns,
     orderIndex,
     coolingType,
+    siteIdText,
+    buildingIdText,
     isEditMode,
     rack,
     updateRack,
@@ -311,6 +410,30 @@ const RackSettingsModal = ({
             initValue={label}
             onChange={(value) => setLabel(value)}
             error={labelError}
+          />
+
+          <Select
+            id="rack-site-select"
+            label={siteLocked ? "Site" : "Site (optional)"}
+            options={siteOptions}
+            value={siteIdText}
+            onChange={handleSiteChange}
+            disabled={siteLocked}
+            forceBelow
+            testId="rack-site-select"
+          />
+
+          <Select
+            id="rack-building-select"
+            label="Building (optional)"
+            options={buildingOptions}
+            value={buildingIdText}
+            onChange={setBuildingIdText}
+            // A building can't be chosen without a site — it scopes the
+            // options and supplies the derived site_id.
+            disabled={siteIdText === ""}
+            forceBelow
+            testId="rack-building-select"
           />
 
           <div className="relative">

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -12,6 +12,7 @@ import {
 import { useSitesContext } from "@/protoFleet/api/SitesContext";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import { type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal/types";
+import { useHasPermission } from "@/protoFleet/store";
 
 import { Alert } from "@/shared/assets/icons";
 import Callout from "@/shared/components/Callout";
@@ -85,6 +86,11 @@ const RackSettingsModal = ({
   const { updateRack, listRackZones, listRackTypes } = useDeviceSets();
   const { sites } = useSitesContext();
   const { listBuildingsBySite } = useBuildings();
+  // Placing a rack under a site/building is a site:manage action (the server
+  // enforces the same on SaveRack). A rack:manage-only operator can still edit
+  // rack contents, so the placement selects are hidden and no placement change
+  // is submitted (ManageRackModal omits it).
+  const canManagePlacement = useHasPermission("site:manage");
 
   // An already-persisted rack has a real placement (a site/building or NULL),
   // so an unplaced rack seeds the explicit "Unassigned" value. Creating a rack
@@ -97,15 +103,17 @@ const RackSettingsModal = ({
   // so lock the field to it (defaultSiteId is only set for a single-site
   // scope). An unscoped create leaves Site editable/optional; edit is never
   // locked.
-  const siteLocked = !isExistingRack && defaultSiteId !== undefined;
+  const siteLocked = !isExistingRack && canManagePlacement && defaultSiteId !== undefined;
 
   // Placement. Site is retained even when a building is chosen (it's the
   // building's site) so downstream eligibility filtering can pin the site;
   // saveRack drops it from the wire RackInfo.
   const [siteIdText, setSiteIdText] = useState<string>(() => {
     if (initialFormData?.siteId !== undefined) return initialFormData.siteId.toString();
-    // Create + page-header scope: prefill (and lock to) the scoped site.
-    if (!isExistingRack && defaultSiteId !== undefined) return defaultSiteId.toString();
+    // Create + page-header scope: prefill (and lock to) the scoped site. Only
+    // when the operator can manage placement — otherwise the rack is created
+    // unplaced.
+    if (!isExistingRack && canManagePlacement && defaultSiteId !== undefined) return defaultSiteId.toString();
     // Edit of an unplaced rack shows "Unassigned"; unscoped create shows the
     // empty placeholder.
     return isExistingRack ? UNASSIGNED_VALUE : "";
@@ -423,29 +431,33 @@ const RackSettingsModal = ({
             error={labelError}
           />
 
-          <Select
-            id="rack-site-select"
-            label={siteLocked ? "Site" : "Site (optional)"}
-            options={siteOptions}
-            value={siteIdText}
-            onChange={handleSiteChange}
-            disabled={siteLocked}
-            forceBelow
-            testId="rack-site-select"
-          />
+          {canManagePlacement ? (
+            <>
+              <Select
+                id="rack-site-select"
+                label={siteLocked ? "Site" : "Site (optional)"}
+                options={siteOptions}
+                value={siteIdText}
+                onChange={handleSiteChange}
+                disabled={siteLocked}
+                forceBelow
+                testId="rack-site-select"
+              />
 
-          <Select
-            id="rack-building-select"
-            label="Building (optional)"
-            options={buildingOptions}
-            value={buildingIdText}
-            onChange={setBuildingIdText}
-            // A building can't be chosen without a real site — it scopes the
-            // options and supplies the derived site_id.
-            disabled={!siteSelected}
-            forceBelow
-            testId="rack-building-select"
-          />
+              <Select
+                id="rack-building-select"
+                label="Building (optional)"
+                options={buildingOptions}
+                value={buildingIdText}
+                onChange={setBuildingIdText}
+                // A building can't be chosen without a real site — it scopes the
+                // options and supplies the derived site_id.
+                disabled={!siteSelected}
+                forceBelow
+                testId="rack-building-select"
+              />
+            </>
+          ) : null}
 
           <div className="relative">
             <Input

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -204,14 +204,44 @@ const RackSettingsModal = ({
     return () => controller.abort();
   }, [siteIdText, listBuildingsBySite]);
 
+  // Zone is sub-building, so it belongs to the rack's original building. When
+  // the form moves to a different building the zone is cleared; returning to
+  // the original building before saving restores it. Mirrors the server's
+  // clear-on-building-change so the field shows what will actually persist.
+  const originalBuildingText = initialFormData?.buildingId !== undefined ? initialFormData.buildingId.toString() : "";
+  const originalZone = initialFormData?.zone ?? "";
+  const reconcileZoneForBuilding = useCallback(
+    (nextBuildingText: string) => {
+      // Only an existing rack has a persisted building to cross. On create the
+      // server stores whatever zone is submitted, so leave the typed/seeded
+      // zone alone as the operator picks a building.
+      if (!isExistingRack) return;
+      const selected = isRealId(nextBuildingText) ? nextBuildingText : "";
+      setZone(selected !== "" && selected === originalBuildingText ? originalZone : "");
+    },
+    [isExistingRack, originalBuildingText, originalZone],
+  );
+
   // Changing the site clears the building selection (the old building lives in
   // a different site) and drops its now-stale options until the new site's
-  // buildings load.
-  const handleSiteChange = useCallback((value: string) => {
-    setSiteIdText(value);
-    setBuildingIdText("");
-    setBuildings([]);
-  }, []);
+  // buildings load. The building — and therefore the zone — resets too.
+  const handleSiteChange = useCallback(
+    (value: string) => {
+      setSiteIdText(value);
+      setBuildingIdText("");
+      setBuildings([]);
+      reconcileZoneForBuilding("");
+    },
+    [reconcileZoneForBuilding],
+  );
+
+  const handleBuildingChange = useCallback(
+    (value: string) => {
+      setBuildingIdText(value);
+      reconcileZoneForBuilding(value);
+    },
+    [reconcileZoneForBuilding],
+  );
 
   const siteSelected = isRealId(siteIdText);
 
@@ -449,7 +479,7 @@ const RackSettingsModal = ({
                 label="Building (optional)"
                 options={buildingOptions}
                 value={buildingIdText}
-                onChange={setBuildingIdText}
+                onChange={handleBuildingChange}
                 // A building can't be chosen without a real site — it scopes the
                 // options and supplies the derived site_id.
                 disabled={!siteSelected}

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -224,23 +224,30 @@ const RackSettingsModal = ({
 
   // Changing the site clears the building selection (the old building lives in
   // a different site) and drops its now-stale options until the new site's
-  // buildings load. The building — and therefore the zone — resets too.
+  // buildings load. The building — and therefore the zone — resets too. The
+  // shared Select fires onChange on every option click, so no-op when the same
+  // site is reselected — otherwise a confirm of the current site would clear
+  // the building/zone and re-encode the rack as direct-under-site on save.
   const handleSiteChange = useCallback(
     (value: string) => {
+      if (value === siteIdText) return;
       setSiteIdText(value);
       setBuildingIdText("");
       setBuildings([]);
       reconcileZoneForBuilding("");
     },
-    [reconcileZoneForBuilding],
+    [siteIdText, reconcileZoneForBuilding],
   );
 
   const handleBuildingChange = useCallback(
     (value: string) => {
+      // Same no-op guard as the site select: reselecting the current building
+      // must not reset the zone.
+      if (value === buildingIdText) return;
       setBuildingIdText(value);
       reconcileZoneForBuilding(value);
     },
-    [reconcileZoneForBuilding],
+    [buildingIdText, reconcileZoneForBuilding],
   );
 
   const siteSelected = isRealId(siteIdText);

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -33,10 +33,10 @@ interface RackSettingsModalProps {
   // initialFormData already carries a siteId.
   defaultSiteId?: bigint;
   // True when editing an existing rack (which has a real, possibly-NULL
-  // placement). Drives the "Unassigned" placement option — see
-  // showUnassignedOption. The embedded modal inside ManageRackModal can't tell
-  // create from edit on its own (it always runs in onContinue mode), so the
-  // caller passes it.
+  // placement). Seeds the placement selects to "Unassigned" when the rack is
+  // unplaced (vs. the empty placeholder on create) — see isExistingRack. The
+  // embedded modal inside ManageRackModal can't tell create from edit on its
+  // own (it always runs in onContinue mode), so the caller passes it.
   existingRack?: boolean;
   onDismiss: () => void;
   onContinue?: (formData: RackFormData) => void;
@@ -45,8 +45,16 @@ interface RackSettingsModalProps {
 
 // Explicit "Unassigned" entry for the placement dropdowns. The shared Select
 // has no clear affordance, so without this a user who picks a site/building
-// could never revert to unassigned.
-const UNASSIGNED_OPTION: SelectOption = { value: "", label: "Unassigned" };
+// could never revert to unassigned. A sentinel value (not "") is used so that
+// an empty string still renders as the unselected placeholder — "Unassigned"
+// only shows once the operator deliberately picks it or an existing rack seeds
+// it. On submit the sentinel maps to undefined, same as an empty selection.
+const UNASSIGNED_VALUE = "unassigned";
+const UNASSIGNED_OPTION: SelectOption = { value: UNASSIGNED_VALUE, label: "Unassigned" };
+// A real site/building id is selected (not the placeholder or the Unassigned
+// sentinel) — gates building fetch, the building select's enabled state, and
+// how the value is encoded onto RackFormData.
+const isRealId = (value: string): boolean => value !== "" && value !== UNASSIGNED_VALUE;
 
 const orderIndexOptions: SelectOption[] = [
   { value: String(RackOrderIndex.BOTTOM_LEFT), label: "Bottom left" },
@@ -78,32 +86,34 @@ const RackSettingsModal = ({
   const { sites } = useSitesContext();
   const { listBuildingsBySite } = useBuildings();
 
-  // Editing an already-persisted rack surfaces an explicit "Unassigned" option
-  // seeded to the rack's real placement (a rack genuinely has a site/building
-  // or NULL). Creating a rack treats placement as an optional, unfilled field
-  // — no "Unassigned" entry, empty by default — so an empty select reads as
-  // "not chosen" (→ NULL) rather than a deliberate-looking default.
-  const showUnassignedOption = existingRack || isEditMode;
+  // An already-persisted rack has a real placement (a site/building or NULL),
+  // so an unplaced rack seeds the explicit "Unassigned" value. Creating a rack
+  // treats placement as an optional, unfilled field: the default is the empty
+  // placeholder (reads as "not chosen"), though "Unassigned" is still pickable
+  // so a chosen site/building can be reverted.
+  const isExistingRack = existingRack || isEditMode;
 
   // Creating within a page-header site scope: the rack belongs to that site,
   // so lock the field to it (defaultSiteId is only set for a single-site
   // scope). An unscoped create leaves Site editable/optional; edit is never
   // locked.
-  const siteLocked = !showUnassignedOption && defaultSiteId !== undefined;
+  const siteLocked = !isExistingRack && defaultSiteId !== undefined;
 
   // Placement. Site is retained even when a building is chosen (it's the
   // building's site) so downstream eligibility filtering can pin the site;
-  // saveRack drops it from the wire RackInfo. Empty string = Unassigned.
+  // saveRack drops it from the wire RackInfo.
   const [siteIdText, setSiteIdText] = useState<string>(() => {
     if (initialFormData?.siteId !== undefined) return initialFormData.siteId.toString();
-    // Create-only prefill — edit seeds solely from the rack's real placement,
-    // so an unplaced rack reads as Unassigned rather than the page scope.
-    if (!showUnassignedOption && defaultSiteId !== undefined) return defaultSiteId.toString();
-    return "";
+    // Create + page-header scope: prefill (and lock to) the scoped site.
+    if (!isExistingRack && defaultSiteId !== undefined) return defaultSiteId.toString();
+    // Edit of an unplaced rack shows "Unassigned"; unscoped create shows the
+    // empty placeholder.
+    return isExistingRack ? UNASSIGNED_VALUE : "";
   });
-  const [buildingIdText, setBuildingIdText] = useState<string>(
-    initialFormData?.buildingId !== undefined ? initialFormData.buildingId.toString() : "",
-  );
+  const [buildingIdText, setBuildingIdText] = useState<string>(() => {
+    if (initialFormData?.buildingId !== undefined) return initialFormData.buildingId.toString();
+    return isExistingRack ? UNASSIGNED_VALUE : "";
+  });
   const [buildings, setBuildings] = useState<BuildingWithCounts[]>([]);
 
   const [label, setLabel] = useState(initialFormData?.label ?? rack?.label ?? "");
@@ -174,10 +184,9 @@ const RackSettingsModal = ({
   // Load the selected site's buildings so the Building dropdown can scope its
   // options. Runs on mount (edit: shows the rack's current building) and on
   // every site change. Aborts in-flight fetches so a fast site switch can't
-  // land stale options. When no site is selected there's nothing to fetch —
-  // buildingOptions falls back to Unassigned-only.
+  // land stale options. With no real site selected there's nothing to fetch.
   useEffect(() => {
-    if (siteIdText === "") return;
+    if (!isRealId(siteIdText)) return;
     const controller = new AbortController();
     listBuildingsBySite({
       siteId: BigInt(siteIdText),
@@ -196,25 +205,26 @@ const RackSettingsModal = ({
     setBuildings([]);
   }, []);
 
+  const siteSelected = isRealId(siteIdText);
+
   const siteOptions = useMemo<SelectOption[]>(() => {
     const real = (sites ?? [])
       .filter((s) => s.site !== undefined)
       .map((s) => ({ value: s.site!.id.toString(), label: s.site!.name }))
       .sort((a, b) => a.label.localeCompare(b.label));
-    return showUnassignedOption ? [UNASSIGNED_OPTION, ...real] : real;
-  }, [sites, showUnassignedOption]);
+    // Unassigned is always offered so a chosen site can be reverted; the empty
+    // placeholder (no option with value "") remains the unselected default.
+    return [UNASSIGNED_OPTION, ...real];
+  }, [sites]);
 
   const buildingOptions = useMemo<SelectOption[]>(() => {
-    // No site selected → nothing to scope to. Edit still offers Unassigned so
-    // the current NULL building reads clearly; create shows an empty
-    // placeholder.
-    if (siteIdText === "") return showUnassignedOption ? [UNASSIGNED_OPTION] : [];
+    if (!siteSelected) return [UNASSIGNED_OPTION];
     const real = buildings
       .filter((b) => b.building !== undefined)
       .map((b) => ({ value: b.building!.id.toString(), label: b.building!.name }))
       .sort((a, b) => a.label.localeCompare(b.label));
-    return showUnassignedOption ? [UNASSIGNED_OPTION, ...real] : real;
-  }, [siteIdText, buildings, showUnassignedOption]);
+    return [UNASSIGNED_OPTION, ...real];
+  }, [siteSelected, buildings]);
 
   const filteredSuggestions = useMemo(() => {
     if (!zone.trim()) return zoneSuggestions;
@@ -325,8 +335,9 @@ const RackSettingsModal = ({
       columns: colsNum,
       orderIndex,
       coolingType,
-      siteId: siteIdText !== "" ? BigInt(siteIdText) : undefined,
-      buildingId: buildingIdText !== "" ? BigInt(buildingIdText) : undefined,
+      // Placeholder ("") and the Unassigned sentinel both encode as undefined.
+      siteId: isRealId(siteIdText) ? BigInt(siteIdText) : undefined,
+      buildingId: isRealId(buildingIdText) ? BigInt(buildingIdText) : undefined,
     };
 
     if (!isEditMode) {
@@ -429,9 +440,9 @@ const RackSettingsModal = ({
             options={buildingOptions}
             value={buildingIdText}
             onChange={setBuildingIdText}
-            // A building can't be chosen without a site — it scopes the
+            // A building can't be chosen without a real site — it scopes the
             // options and supplies the derived site_id.
-            disabled={siteIdText === ""}
+            disabled={!siteSelected}
             forceBelow
             testId="rack-building-select"
           />

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -295,8 +295,12 @@ const FleetBuildingsPage = () => {
       createFlow.launchCreateBuilding({ rackIds: [], minerIds: [], conflictCount: 0 });
       return;
     }
-    buildingModals.openDetailsCreate();
-  }, [createFlow, buildingModals]);
+    // Pre-fill (and lock to) the page-header site scope so a new building
+    // belongs to the site the operator is viewing. Unscoped → editable, and
+    // the operator must pick a site.
+    const scopedSiteId = activeSite.kind === "site" ? BigInt(activeSite.id) : undefined;
+    buildingModals.openDetailsCreate(scopedSiteId);
+  }, [createFlow, buildingModals, activeSite]);
 
   const hasSites = (sites?.filter((s) => s.site !== undefined).length ?? 0) > 0;
   // CreateBuilding requires site:manage server-side.

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -300,6 +300,10 @@ const RackOverviewPage = () => {
       columns: rackInfo.columns ?? 1,
       orderIndex: rackInfo.orderIndex as RackOrderIndex,
       coolingType: rackInfo.coolingType as RackCoolingType,
+      // Seed current placement (0 → undefined) so the settings dropdowns and
+      // miner eligibility reflect where the rack lives.
+      siteId: rack.placement?.site?.id || undefined,
+      buildingId: rack.placement?.building?.id || undefined,
     };
   }, [showEditModal, rack, rackInfo]);
 

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -537,6 +537,13 @@ const RackOverviewPage = () => {
             resolveRack(rack.id);
             void refetchStats();
           }}
+          // Settings "Continue" persists before the final Save; refresh the
+          // overview in the background (modal stays open) so a later dismiss
+          // can't leave stale label/placement on screen.
+          onSettingsPersisted={() => {
+            resolveRack(rack.id);
+            void refetchStats();
+          }}
           onDelete={() =>
             new Promise<void>((resolve, reject) => {
               deleteGroup({

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -891,6 +891,13 @@ const RacksPage = () => {
     resetAndFetch();
     fetchZones();
   }, [resetAndFetch, fetchZones]);
+  // Rack Settings "Continue" persists an existing rack's settings before the
+  // final miner Save, so refresh the list in the background (without closing
+  // the modal) to keep it consistent if the operator then dismisses.
+  const handleRackSettingsPersisted = useCallback(() => {
+    resetAndFetch();
+    fetchZones();
+  }, [resetAndFetch, fetchZones]);
 
   const handleDeleteRack = useCallback(() => {
     if (!manageRackId) return Promise.resolve();
@@ -1139,6 +1146,7 @@ const RacksPage = () => {
             scopedSiteId={scopedSiteId}
             onDismiss={handleManageRackDismiss}
             onSave={handleManageRackSave}
+            onSettingsPersisted={handleRackSettingsPersisted}
             onDelete={manageRackId ? handleDeleteRack : undefined}
           />
         ) : null}
@@ -1463,6 +1471,7 @@ const RacksPage = () => {
           scopedSiteId={scopedSiteId}
           onDismiss={handleManageRackDismiss}
           onSave={handleManageRackSave}
+          onSettingsPersisted={handleRackSettingsPersisted}
         />
       ) : null}
       {reparentTarget ? (

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -188,6 +188,9 @@ const RacksPage = () => {
   const knownSiteIds = useMemo(() => (allSites ? new Set(allSites.map((s) => s.id)) : undefined), [allSites]);
   const { activeSite } = useActiveSite({ knownSiteIds });
   const activeSiteFilter = useMemo(() => siteFilterFromActive(activeSite), [activeSite]);
+  // Prepopulate the new-rack Site dropdown when a single site is scoped in the
+  // page header (undefined for "All sites" / "Unassigned").
+  const scopedSiteId = useMemo(() => (activeSite.kind === "site" ? BigInt(activeSite.id) : undefined), [activeSite]);
 
   const selectedSiteFilter = useMemo(() => parseIdFilterValuesFromURL(searchParams, "site"), [searchParams]);
   const selectedSiteValues = selectedSiteFilter.values;
@@ -923,6 +926,11 @@ const RacksPage = () => {
       columns: rackInfo.columns,
       orderIndex: rackInfo.orderIndex,
       coolingType: rackInfo.coolingType,
+      // Seed the rack's current placement (`|| undefined` collapses the proto
+      // default 0 to unassigned) so the settings dropdowns and the miner
+      // eligibility filter reflect where the rack lives.
+      siteId: rack.placement?.site?.id || undefined,
+      buildingId: rack.placement?.building?.id || undefined,
     });
     setManageRackId(rack.id);
   }, []);
@@ -1117,6 +1125,7 @@ const RacksPage = () => {
           <RackSettingsModal
             show={showRackSettingsModal}
             existingRacks={racks}
+            defaultSiteId={scopedSiteId}
             onDismiss={() => setShowRackSettingsModal(false)}
             onContinue={handleRackSettingsContinue}
           />
@@ -1127,6 +1136,7 @@ const RacksPage = () => {
             rackSettings={manageRackFormData}
             existingRackId={manageRackId}
             existingRacks={racks}
+            scopedSiteId={scopedSiteId}
             onDismiss={handleManageRackDismiss}
             onSave={handleManageRackSave}
             onDelete={manageRackId ? handleDeleteRack : undefined}
@@ -1439,6 +1449,7 @@ const RacksPage = () => {
         <RackSettingsModal
           show={showRackSettingsModal}
           existingRacks={racks}
+          defaultSiteId={scopedSiteId}
           onDismiss={() => setShowRackSettingsModal(false)}
           onContinue={handleRackSettingsContinue}
         />
@@ -1449,6 +1460,7 @@ const RacksPage = () => {
           rackSettings={manageRackFormData}
           existingRackId={manageRackId}
           existingRacks={racks}
+          scopedSiteId={scopedSiteId}
           onDismiss={handleManageRackDismiss}
           onSave={handleManageRackSave}
         />

--- a/proto/collection/v1/collection.proto
+++ b/proto/collection/v1/collection.proto
@@ -123,8 +123,8 @@ message RackInfo {
     int32 rows = 1 [(buf.validate.field).int32.gt = 0];
     // Number of columns in the rack grid
     int32 columns = 2 [(buf.validate.field).int32.gt = 0];
-    // Sub-building zone label (e.g. "Room 2", "East Wall"). Required when
-    // building_id is set; cleared (empty) automatically when the rack
+    // Sub-building zone label (e.g. "Room 2", "East Wall"). Optional, even
+    // when building_id is set. Cleared (empty) automatically when the rack
     // crosses a building boundary or moves to direct-under-site placement.
     string zone = 3 [(buf.validate.field).string.max_len = 100];
     // Order index defining where numbering starts

--- a/proto/device_set/v1/device_set.proto
+++ b/proto/device_set/v1/device_set.proto
@@ -159,8 +159,8 @@ message RackInfo {
     int32 rows = 1 [(buf.validate.field).int32.gt = 0];
     // Number of columns in the rack grid
     int32 columns = 2 [(buf.validate.field).int32.gt = 0];
-    // Sub-building zone label (e.g. "Room 2", "East Wall"). Required when
-    // building_id is set; cleared (empty) automatically when the rack
+    // Sub-building zone label (e.g. "Room 2", "East Wall"). Optional, even
+    // when building_id is set. Cleared (empty) automatically when the rack
     // crosses a building boundary or moves to direct-under-site placement.
     string zone = 3 [(buf.validate.field).string.max_len = 100];
     // Order index defining where numbering starts

--- a/server/generated/grpc/collection/v1/collection.pb.go
+++ b/server/generated/grpc/collection/v1/collection.pb.go
@@ -409,8 +409,8 @@ type RackInfo struct {
 	Rows int32 `protobuf:"varint,1,opt,name=rows,proto3" json:"rows,omitempty"`
 	// Number of columns in the rack grid
 	Columns int32 `protobuf:"varint,2,opt,name=columns,proto3" json:"columns,omitempty"`
-	// Sub-building zone label (e.g. "Room 2", "East Wall"). Required when
-	// building_id is set; cleared (empty) automatically when the rack
+	// Sub-building zone label (e.g. "Room 2", "East Wall"). Optional, even
+	// when building_id is set. Cleared (empty) automatically when the rack
 	// crosses a building boundary or moves to direct-under-site placement.
 	Zone string `protobuf:"bytes,3,opt,name=zone,proto3" json:"zone,omitempty"`
 	// Order index defining where numbering starts

--- a/server/generated/grpc/device_set/v1/device_set.pb.go
+++ b/server/generated/grpc/device_set/v1/device_set.pb.go
@@ -459,8 +459,8 @@ type RackInfo struct {
 	Rows int32 `protobuf:"varint,1,opt,name=rows,proto3" json:"rows,omitempty"`
 	// Number of columns in the rack grid
 	Columns int32 `protobuf:"varint,2,opt,name=columns,proto3" json:"columns,omitempty"`
-	// Sub-building zone label (e.g. "Room 2", "East Wall"). Required when
-	// building_id is set; cleared (empty) automatically when the rack
+	// Sub-building zone label (e.g. "Room 2", "East Wall"). Optional, even
+	// when building_id is set. Cleared (empty) automatically when the rack
 	// crosses a building boundary or moves to direct-under-site placement.
 	Zone string `protobuf:"bytes,3,opt,name=zone,proto3" json:"zone,omitempty"`
 	// Order index defining where numbering starts

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -2158,17 +2158,21 @@ func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *p
 		}
 	}
 
-	// Zone is building-scoped: clear it when leaving or crossing buildings,
-	// and preserve the current zone when the caller omitted it but the rack
-	// stays in a building (legacy clients don't send zone — validation only
-	// requires it when the request itself sets a non-zero building_id).
+	// Zone is building-scoped: clear it when the rack leaves or crosses
+	// buildings. Otherwise the submitted zone is authoritative — a client that
+	// manages placement (sends an explicit site/building, including 0 to
+	// unassign) seeds the current zone into its edit form, so an unedited save
+	// keeps it and an explicit blank clears it (zone is optional). Only a
+	// caller that OMITS placement entirely (legacy: no site_id/building_id)
+	// keeps the preserve-on-empty behavior, so a metadata-only update can't
+	// silently wipe the zone of a rack that stays in its building.
 	finalZone := rackInfo.GetZone()
 	leavingBuilding := current.BuildingID != nil && newBuildingID == nil
 	crossingBuildings := current.BuildingID != nil && newBuildingID != nil && !int64PtrEqual(current.BuildingID, newBuildingID)
 	switch {
 	case leavingBuilding || crossingBuildings:
 		finalZone = ""
-	case finalZone == "" && newBuildingID != nil:
+	case rackPlacementOmitted(rackInfo) && finalZone == "" && newBuildingID != nil:
 		finalZone = current.Zone
 	}
 

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -1948,17 +1948,12 @@ func (s *Service) SaveRack(ctx context.Context, req *pb.SaveRackRequest) (*pb.Sa
 }
 
 // validateSaveRackRequest enforces SaveRack input contract: rack_info
-// shape, slot bounds, and zone-required-when-building-set.
+// shape and slot bounds. Zone is an optional free-text sub-building label
+// (nullable column, no placement dependency), so it is never required —
+// including for a rack that belongs to a building.
 func validateSaveRackRequest(req *pb.SaveRackRequest, rackInfo *pb.RackInfo) error {
 	if rackInfo == nil {
 		return fleeterror.NewInvalidArgumentError("rack_info is required")
-	}
-	// Building_id=0 means "no building" (zero-as-unassign convention).
-	// Don't mutate rackInfo.BuildingId — nil-vs-&0 distinguishes
-	// "preserve placement" from "explicit unassign" downstream.
-	buildingPresent := rackInfo.BuildingId != nil && *rackInfo.BuildingId != 0
-	if buildingPresent && rackInfo.GetZone() == "" {
-		return fleeterror.NewInvalidArgumentError("zone is required when the rack belongs to a building")
 	}
 	if rackInfo.Rows < 1 || rackInfo.Rows > maxRackDimension {
 		return fleeterror.NewInvalidArgumentErrorf("rows must be between 1 and %d", maxRackDimension)

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -531,16 +531,24 @@ func (s *Service) UpdateCollection(ctx context.Context, req *pb.UpdateCollection
 			rackBuildingID   *int64
 		)
 		if isRack && rackInfo != nil {
-			// A settings save persists dimensions without replacing membership,
-			// so reject a shrink that no longer fits the rack's current members
-			// or their slot positions — otherwise Continue would leave the DB
-			// with a grid too small for the miners it holds (#718). Runs as the
-			// afterLock hook (under the rack row lock) so a concurrent SaveRack
-			// can't add members/slots between the check and the resize. Skipped
-			// when this call also replaces membership; the new set governs
-			// capacity then (and SaveRack owns that path).
+			// A rack can never hold more miners than its grid has slots (#718).
+			// Two shapes:
+			//   - membership replaced this call (device_selector present): the
+			//     NEW set governs capacity — validate len(deviceIdentifiers)
+			//     against the submitted dims, mirroring SaveRack. Pure
+			//     request-data check, no lock needed.
+			//   - settings-only (no device_selector): the rack's CURRENT members
+			//     govern — recheck under the rack row lock (afterLock) so a
+			//     concurrent SaveRack can't add members between the read and the
+			//     resize.
 			var afterLock func(context.Context) error
-			if !hasDeviceSelector {
+			if hasDeviceSelector {
+				if capacity := int(rackInfo.Rows) * int(rackInfo.Columns); len(deviceIdentifiers) > capacity {
+					return nil, fleeterror.NewInvalidArgumentErrorf(
+						"cannot assign %d miners to a rack with %d slot(s) (%d×%d)",
+						len(deviceIdentifiers), capacity, rackInfo.Rows, rackInfo.Columns)
+				}
+			} else {
 				afterLock = func(ctx context.Context) error {
 					return s.enforceRackDimensionsFitCurrentMembers(ctx, info.OrganizationID, req.CollectionId, rackInfo.Rows, rackInfo.Columns)
 				}

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -534,18 +534,21 @@ func (s *Service) UpdateCollection(ctx context.Context, req *pb.UpdateCollection
 			// A settings save persists dimensions without replacing membership,
 			// so reject a shrink that no longer fits the rack's current members
 			// or their slot positions — otherwise Continue would leave the DB
-			// with a grid too small for the miners it holds (#718). Skipped when
-			// this call also replaces membership; the new set governs capacity
-			// then (and SaveRack owns that path).
+			// with a grid too small for the miners it holds (#718). Runs as the
+			// afterLock hook (under the rack row lock) so a concurrent SaveRack
+			// can't add members/slots between the check and the resize. Skipped
+			// when this call also replaces membership; the new set governs
+			// capacity then (and SaveRack owns that path).
+			var afterLock func(context.Context) error
 			if !hasDeviceSelector {
-				if err := s.enforceRackDimensionsFitCurrentMembers(ctx, info.OrganizationID, req.CollectionId, rackInfo.Rows, rackInfo.Columns); err != nil {
-					return nil, err
+				afterLock = func(ctx context.Context) error {
+					return s.enforceRackDimensionsFitCurrentMembers(ctx, info.OrganizationID, req.CollectionId, rackInfo.Rows, rackInfo.Columns)
 				}
 			}
 			// preserveZoneOnEmpty=false: this settings save's form always
 			// submits the rack's current zone, so an empty zone is an explicit
 			// clear — even for a rack:manage operator who omits placement.
-			res, err := s.resolveAndApplyRackPlacement(ctx, info, req.CollectionId, rackInfo, deviceIdentifiers, false /* preserveZoneOnEmpty */)
+			res, err := s.resolveAndApplyRackPlacement(ctx, info, req.CollectionId, rackInfo, deviceIdentifiers, false /* preserveZoneOnEmpty */, afterLock)
 			if err != nil {
 				return nil, err
 			}
@@ -2173,7 +2176,7 @@ func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *p
 	// AND may carry an empty zone without meaning to clear it, so preserve the
 	// current zone on empty (see resolveAndApplyRackPlacement + the
 	// omitted-placement contract in service_test.go).
-	res, err := s.resolveAndApplyRackPlacement(ctx, info, collectionID, rackInfo, deviceIdentifiers, true /* preserveZoneOnEmpty */)
+	res, err := s.resolveAndApplyRackPlacement(ctx, info, collectionID, rackInfo, deviceIdentifiers, true /* preserveZoneOnEmpty */, nil /* afterLock */)
 	if err != nil {
 		return nil, err
 	}
@@ -2234,7 +2237,12 @@ func (s *Service) enforceRackDimensionsFitCurrentMembers(ctx context.Context, or
 // metadata/miners-only re-save can't silently wipe a zone it never edited;
 // the UpdateCollection settings save passes false because its form always
 // submits the current zone, so an empty value is an explicit clear.
-func (s *Service) resolveAndApplyRackPlacement(ctx context.Context, info *session.Info, collectionID int64, rackInfo *pb.RackInfo, deviceIdentifiers []string, preserveZoneOnEmpty bool) (*saveRackUpdatePathResult, error) {
+//
+// afterLock, when non-nil, runs AFTER the rack row lock is held but BEFORE any
+// write. It lets a caller re-validate under the lock (e.g. the dimension guard)
+// so a concurrent SaveRack can't mutate membership/slots between the caller's
+// pre-read and this resize. nil for callers with nothing to recheck.
+func (s *Service) resolveAndApplyRackPlacement(ctx context.Context, info *session.Info, collectionID int64, rackInfo *pb.RackInfo, deviceIdentifiers []string, preserveZoneOnEmpty bool, afterLock func(context.Context) error) (*saveRackUpdatePathResult, error) {
 	var (
 		current       interfaces.RackPlacement
 		newSiteID     *int64
@@ -2268,6 +2276,15 @@ func (s *Service) resolveAndApplyRackPlacement(ctx context.Context, info *sessio
 		}
 		current, err = s.collectionStore.LockRackPlacementForWrite(ctx, collectionID, info.OrganizationID)
 		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Re-validate under the rack lock before any write. A concurrent SaveRack
+	// touching membership/slots holds this same row lock, so it either
+	// committed before us (this recheck sees it) or waits until we commit.
+	if afterLock != nil {
+		if err := afterLock(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -531,6 +531,17 @@ func (s *Service) UpdateCollection(ctx context.Context, req *pb.UpdateCollection
 			rackBuildingID   *int64
 		)
 		if isRack && rackInfo != nil {
+			// A settings save persists dimensions without replacing membership,
+			// so reject a shrink that no longer fits the rack's current members
+			// or their slot positions — otherwise Continue would leave the DB
+			// with a grid too small for the miners it holds (#718). Skipped when
+			// this call also replaces membership; the new set governs capacity
+			// then (and SaveRack owns that path).
+			if !hasDeviceSelector {
+				if err := s.enforceRackDimensionsFitCurrentMembers(ctx, info.OrganizationID, req.CollectionId, rackInfo.Rows, rackInfo.Columns); err != nil {
+					return nil, err
+				}
+			}
 			// preserveZoneOnEmpty=false: this settings save's form always
 			// submits the rack's current zone, so an empty zone is an explicit
 			// clear — even for a rack:manage operator who omits placement.
@@ -2173,6 +2184,40 @@ func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *p
 		return nil, err
 	}
 	return res, nil
+}
+
+// enforceRackDimensionsFitCurrentMembers rejects a settings save that shrinks
+// the grid below the rack's current membership or below an occupied slot
+// position. UpdateCollection persists dimensions without touching membership,
+// so without this guard an operator could leave the DB holding more miners
+// than the new layout has slots (or slots addressed outside it). Uses plain
+// reads (no row locks) so it does not perturb the site->building->rack lock
+// order taken by resolveAndApplyRackPlacement.
+func (s *Service) enforceRackDimensionsFitCurrentMembers(ctx context.Context, orgID, collectionID int64, rows, columns int32) error {
+	slots, err := s.collectionStore.GetRackSlots(ctx, collectionID, orgID)
+	if err != nil {
+		return err
+	}
+	for _, slot := range slots {
+		if slot.Position == nil {
+			continue
+		}
+		if slot.Position.Row >= rows || slot.Position.Column >= columns {
+			return fleeterror.NewInvalidArgumentErrorf(
+				"cannot resize rack to %d×%d: an assigned miner's slot falls outside the smaller grid; remove miners or choose a larger size",
+				rows, columns)
+		}
+	}
+	coll, err := s.collectionStore.GetCollection(ctx, orgID, collectionID)
+	if err != nil {
+		return err
+	}
+	if capacity := int64(rows) * int64(columns); int64(coll.DeviceCount) > capacity {
+		return fleeterror.NewInvalidArgumentErrorf(
+			"cannot resize rack to %d slot(s): %d miner(s) are currently assigned; remove miners or choose a larger size",
+			capacity, coll.DeviceCount)
+	}
+	return nil
 }
 
 // resolveAndApplyRackPlacement locks site/building/rack in canonical order,

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -294,10 +294,10 @@ func (s *Service) CreateCollection(ctx context.Context, req *pb.CreateCollection
 	if req.Type == pb.CollectionType_COLLECTION_TYPE_RACK && rackInfo == nil {
 		return nil, fleeterror.NewInvalidArgumentError("rack_info is required for rack collections")
 	}
-	// TODO(#226): align with SaveRack's conditional zone rule once site/building UI lands.
-	if req.Type == pb.CollectionType_COLLECTION_TYPE_RACK && rackInfo != nil && rackInfo.GetZone() == "" {
-		return nil, fleeterror.NewInvalidArgumentError("zone is required for rack collections")
-	}
+	// Zone is an optional free-text sub-building label (nullable column, no
+	// placement dependency), so it is never required — matching SaveRack and
+	// UpdateCollection. A rack may be created unassigned or in a building with
+	// no zone.
 	if req.Type == pb.CollectionType_COLLECTION_TYPE_RACK && rackInfo != nil {
 		if rackInfo.Rows < 1 || rackInfo.Rows > maxRackDimension {
 			return nil, fleeterror.NewInvalidArgumentErrorf("rows must be between 1 and %d", maxRackDimension)
@@ -493,6 +493,18 @@ func (s *Service) UpdateCollection(ctx context.Context, req *pb.UpdateCollection
 		}
 	}
 
+	// rack_info carries a rack's settings (placement + dimensions). When
+	// present, we persist it here in the same transaction as the label —
+	// "Continue saves settings, Save saves miners" — so a settings change is
+	// atomic and never leaves the rack half-updated. Validate its shape up
+	// front; the rack-vs-group check happens in-tx.
+	rackInfo := req.GetRackInfo()
+	if rackInfo != nil {
+		if err := validateRackInfoShape(rackInfo); err != nil {
+			return nil, err
+		}
+	}
+
 	result, err := s.transactor.RunInTxWithResult(ctx, func(ctx context.Context) (any, error) {
 		var label, description *string
 		if req.Label != nil {
@@ -502,22 +514,43 @@ func (s *Service) UpdateCollection(ctx context.Context, req *pb.UpdateCollection
 			description = req.Description
 		}
 
-		err := s.collectionStore.UpdateCollection(ctx, info.OrganizationID, req.CollectionId, label, description)
+		collType, err := s.collectionStore.GetCollectionType(ctx, info.OrganizationID, req.CollectionId)
 		if err != nil {
+			return nil, err
+		}
+		isRack := collType == pb.CollectionType_COLLECTION_TYPE_RACK
+
+		// Persist rack settings (placement + dimensions) BEFORE the label so
+		// the canonical site -> building -> rack lock order is taken first;
+		// the label write then re-touches the already-locked rack row. This
+		// shares saveRackUpdate's helper so placement/zone are derived
+		// identically, and it never touches membership.
+		var (
+			placementApplied bool
+			rackSiteID       *int64
+			rackBuildingID   *int64
+		)
+		if isRack && rackInfo != nil {
+			// preserveZoneOnEmpty=false: this settings save's form always
+			// submits the rack's current zone, so an empty zone is an explicit
+			// clear — even for a rack:manage operator who omits placement.
+			res, err := s.resolveAndApplyRackPlacement(ctx, info, req.CollectionId, rackInfo, deviceIdentifiers, false /* preserveZoneOnEmpty */)
+			if err != nil {
+				return nil, err
+			}
+			placementApplied = true
+			rackSiteID = res.finalSiteID
+			rackBuildingID = res.finalBuildingID
+		}
+
+		if err := s.collectionStore.UpdateCollection(ctx, info.OrganizationID, req.CollectionId, label, description); err != nil {
 			return nil, err
 		}
 
 		if hasDeviceSelector {
-			collType, err := s.collectionStore.GetCollectionType(ctx, info.OrganizationID, req.CollectionId)
-			if err != nil {
-				return nil, err
-			}
-			var (
-				rackSiteID     *int64
-				rackBuildingID *int64
-			)
-			isRack := collType == pb.CollectionType_COLLECTION_TYPE_RACK
-			if isRack {
+			// When settings weren't touched this call, read the current
+			// placement so the cascade below stamps members correctly.
+			if isRack && !placementApplied {
 				placement, err := s.collectionStore.LockRackPlacementForWrite(ctx, req.CollectionId, info.OrganizationID)
 				if err != nil {
 					return nil, err
@@ -532,16 +565,18 @@ func (s *Service) UpdateCollection(ctx context.Context, req *pb.UpdateCollection
 				if _, err := s.collectionStore.AddDevicesToCollection(ctx, info.OrganizationID, req.CollectionId, deviceIdentifiers); err != nil {
 					return nil, err
 				}
-				// A rack ALWAYS dictates its members' placement, including a
-				// fully-unassigned rack (site + building NULL) — members
-				// can't keep a direct site/building the rack lacks, or the
-				// membership tree diverges. nil placement strips members;
-				// IS DISTINCT FROM no-ops members that already match.
-				if isRack {
-					if _, err := s.cascadeRackMembersToPlacement(ctx, info.OrganizationID, req.CollectionId, rackSiteID, rackBuildingID); err != nil {
-						return nil, err
-					}
-				}
+			}
+		}
+
+		// A rack ALWAYS dictates its members' placement, including a
+		// fully-unassigned rack (site + building NULL) — members can't keep a
+		// direct site/building the rack lacks, or the membership tree diverges.
+		// Cascade the FINAL member set whenever placement moved (settings save)
+		// or membership was replaced (miners save). nil placement strips
+		// members; IS DISTINCT FROM no-ops members that already match.
+		if isRack && (placementApplied || hasDeviceSelector) {
+			if _, err := s.cascadeRackMembersToPlacement(ctx, info.OrganizationID, req.CollectionId, rackSiteID, rackBuildingID); err != nil {
+				return nil, err
 			}
 		}
 
@@ -1947,11 +1982,12 @@ func (s *Service) SaveRack(ctx context.Context, req *pb.SaveRackRequest) (*pb.Sa
 	}, nil
 }
 
-// validateSaveRackRequest enforces SaveRack input contract: rack_info
-// shape and slot bounds. Zone is an optional free-text sub-building label
-// (nullable column, no placement dependency), so it is never required —
-// including for a rack that belongs to a building.
-func validateSaveRackRequest(req *pb.SaveRackRequest, rackInfo *pb.RackInfo) error {
+// validateRackInfoShape enforces the rack_info dimension/order/cooling
+// contract shared by every path that persists rack metadata (SaveRack and
+// UpdateCollection's rack-settings branch). Zone is an optional free-text
+// sub-building label (nullable column, no placement dependency), so it is
+// never required — including for a rack that belongs to a building.
+func validateRackInfoShape(rackInfo *pb.RackInfo) error {
 	if rackInfo == nil {
 		return fleeterror.NewInvalidArgumentError("rack_info is required")
 	}
@@ -1972,6 +2008,17 @@ func validateSaveRackRequest(req *pb.SaveRackRequest, rackInfo *pb.RackInfo) err
 	}
 	if _, ok := pb.RackCoolingType_name[int32(rackInfo.CoolingType)]; !ok {
 		return fleeterror.NewInvalidArgumentError("invalid cooling_type value")
+	}
+	return nil
+}
+
+// validateSaveRackRequest enforces SaveRack input contract: rack_info
+// shape and slot bounds. Zone is an optional free-text sub-building label
+// (nullable column, no placement dependency), so it is never required —
+// including for a rack that belongs to a building.
+func validateSaveRackRequest(req *pb.SaveRackRequest, rackInfo *pb.RackInfo) error {
+	if err := validateRackInfoShape(rackInfo); err != nil {
+		return err
 	}
 	for _, slot := range req.SlotAssignments {
 		if slot.Position == nil {
@@ -2111,10 +2158,43 @@ func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *p
 		return nil, fleeterror.NewInvalidArgumentErrorf("collection %d is not a rack", collectionID)
 	}
 
+	// SaveRack is a legacy-shaped save: a miners-only re-save omits placement
+	// AND may carry an empty zone without meaning to clear it, so preserve the
+	// current zone on empty (see resolveAndApplyRackPlacement + the
+	// omitted-placement contract in service_test.go).
+	res, err := s.resolveAndApplyRackPlacement(ctx, info, collectionID, rackInfo, deviceIdentifiers, true /* preserveZoneOnEmpty */)
+	if err != nil {
+		return nil, err
+	}
+	// The label write lands AFTER the placement helper has locked the rack
+	// row (via the canonical site -> building -> rack order), so it cannot
+	// invert lock ordering against a concurrent placement move.
+	if err := s.collectionStore.UpdateCollection(ctx, info.OrganizationID, collectionID, &req.Label, nil); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// resolveAndApplyRackPlacement locks site/building/rack in canonical order,
+// derives the building-scoped zone, and persists rack_info (dimensions) plus
+// placement. It deliberately touches neither the collection label nor
+// membership, so both the SaveRack update branch and UpdateCollection's
+// rack-settings path can persist placement + dims identically without one
+// path stepping on the other's concern. The caller is responsible for having
+// verified the collection is a rack owned by the org, and for cascading the
+// final member set to the returned placement.
+//
+// preserveZoneOnEmpty controls the empty-zone rule when placement is omitted
+// and the rack stays in a building: SaveRack (legacy save) passes true so a
+// metadata/miners-only re-save can't silently wipe a zone it never edited;
+// the UpdateCollection settings save passes false because its form always
+// submits the current zone, so an empty value is an explicit clear.
+func (s *Service) resolveAndApplyRackPlacement(ctx context.Context, info *session.Info, collectionID int64, rackInfo *pb.RackInfo, deviceIdentifiers []string, preserveZoneOnEmpty bool) (*saveRackUpdatePathResult, error) {
 	var (
 		current       interfaces.RackPlacement
 		newSiteID     *int64
 		newBuildingID *int64
+		err           error
 	)
 	if rackPlacementOmitted(rackInfo) {
 		// Preserve current placement; skip site/building locks since the
@@ -2172,20 +2252,14 @@ func (s *Service) saveRackUpdate(ctx context.Context, info *session.Info, req *p
 	switch {
 	case leavingBuilding || crossingBuildings:
 		finalZone = ""
-	case rackPlacementOmitted(rackInfo) && finalZone == "" && newBuildingID != nil:
+	case preserveZoneOnEmpty && rackPlacementOmitted(rackInfo) && finalZone == "" && newBuildingID != nil:
 		finalZone = current.Zone
 	}
 
-	err = s.collectionStore.UpdateCollection(ctx, info.OrganizationID, collectionID, &req.Label, nil)
-	if err != nil {
+	if err = s.collectionStore.UpdateRackInfo(ctx, collectionID, finalZone, rackInfo.Rows, rackInfo.Columns, int32(rackInfo.OrderIndex), int32(rackInfo.CoolingType), info.OrganizationID); err != nil {
 		return nil, err
 	}
-	err = s.collectionStore.UpdateRackInfo(ctx, collectionID, finalZone, rackInfo.Rows, rackInfo.Columns, int32(rackInfo.OrderIndex), int32(rackInfo.CoolingType), info.OrganizationID)
-	if err != nil {
-		return nil, err
-	}
-	err = s.collectionStore.UpdateRackPlacement(ctx, collectionID, info.OrganizationID, newSiteID, newBuildingID, finalZone)
-	if err != nil {
+	if err = s.collectionStore.UpdateRackPlacement(ctx, collectionID, info.OrganizationID, newSiteID, newBuildingID, finalZone); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -2053,8 +2053,10 @@ func TestService_UpdateCollection_RackSettingsClearsZoneOmittedPlacement(t *test
 	// Settings save cascades current members onto the (unchanged) placement.
 	mockStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), collectionID, testOrgID, gomock.Eq(&existingSite)).Return(int64(0), nil)
 	mockStore.EXPECT().CascadeRackDeviceBuildings(gomock.Any(), collectionID, testOrgID, gomock.Eq(&existingBuilding)).Return(int64(0), nil)
+	// Dimension guard reads the current slots + member count; empty rack fits.
+	mockStore.EXPECT().GetRackSlots(gomock.Any(), collectionID, testOrgID).Return(nil, nil)
 	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, collectionID).
-		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack", Type: pb.CollectionType_COLLECTION_TYPE_RACK}, nil)
+		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack", Type: pb.CollectionType_COLLECTION_TYPE_RACK}, nil).Times(2)
 	mockStore.EXPECT().GetRackInfo(gomock.Any(), collectionID, testOrgID).
 		Return(&pb.RackInfo{Rows: 4, Columns: 8, Zone: "", OrderIndex: pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT, CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR}, nil)
 
@@ -2105,8 +2107,10 @@ func TestService_UpdateCollection_RackSettingsPersistsPlacementAndCascades(t *te
 	mockStore.EXPECT().UpdateCollection(gomock.Any(), testOrgID, collectionID, gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), collectionID, testOrgID, gomock.Eq(&site)).Return(int64(2), nil)
 	mockStore.EXPECT().CascadeRackDeviceBuildings(gomock.Any(), collectionID, testOrgID, gomock.Eq(&building)).Return(int64(2), nil)
+	// Dimension guard reads the current slots + member count; empty rack fits.
+	mockStore.EXPECT().GetRackSlots(gomock.Any(), collectionID, testOrgID).Return(nil, nil)
 	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, collectionID).
-		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack", Type: pb.CollectionType_COLLECTION_TYPE_RACK}, nil)
+		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack", Type: pb.CollectionType_COLLECTION_TYPE_RACK}, nil).Times(2)
 	mockStore.EXPECT().GetRackInfo(gomock.Any(), collectionID, testOrgID).
 		Return(&pb.RackInfo{Rows: 4, Columns: 8, Zone: "Floor 2", SiteId: &site, BuildingId: &building, OrderIndex: pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT, CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR}, nil)
 
@@ -2128,6 +2132,43 @@ func TestService_UpdateCollection_RackSettingsPersistsPlacementAndCascades(t *te
 	require.NoError(t, err)
 	assert.Equal(t, "Floor 2", resp.Collection.GetRackInfo().Zone)
 	assert.Equal(t, building, *resp.Collection.GetRackInfo().BuildingId)
+	_ = mockSiteStore
+}
+
+// TestService_UpdateCollection_RackSettingsRejectsShrinkBelowMembers guards the
+// #718 regression: Continue persists dimensions without touching membership, so
+// a settings save that shrinks the grid below the current member count must be
+// rejected before any write, leaving the rack untouched.
+func TestService_UpdateCollection_RackSettingsRejectsShrinkBelowMembers(t *testing.T) {
+	svc, mockStore, mockSiteStore := newTestServiceWithSites(t, func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return nil, nil
+	})
+	ctx := testCtx(t)
+
+	collectionID := int64(43)
+
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, collectionID).Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
+	// Guard runs first: no out-of-bounds slots, but 5 members exceed the new
+	// 2×2 = 4 capacity → reject. No UpdateRackInfo / placement writes follow.
+	mockStore.EXPECT().GetRackSlots(gomock.Any(), collectionID, testOrgID).Return(nil, nil)
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, collectionID).
+		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack", Type: pb.CollectionType_COLLECTION_TYPE_RACK, DeviceCount: 5}, nil)
+
+	label := "Rack"
+	_, err := svc.UpdateCollection(ctx, &pb.UpdateCollectionRequest{
+		CollectionId: collectionID,
+		Label:        &label,
+		TypeDetails: &pb.UpdateCollectionRequest_RackInfo{
+			RackInfo: &pb.RackInfo{
+				Rows:        2,
+				Columns:     2,
+				OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+				CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot resize rack")
 	_ = mockSiteStore
 }
 

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -585,6 +585,10 @@ func TestService_UpdateCollection_WithoutDeviceSelectorLeavesMembers(t *testing.
 	ctx := testCtx(t)
 
 	newLabel := "Renamed Group"
+	// UpdateCollection now reads the collection type up front (to route a rack's
+	// settings save); a group with no device selector still only rewrites its
+	// label and re-reads the collection.
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, testCollectionID).Return(pb.CollectionType_COLLECTION_TYPE_GROUP, nil)
 	mockStore.EXPECT().UpdateCollection(gomock.Any(), testOrgID, testCollectionID, &newLabel, (*string)(nil)).Return(nil)
 	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
 		Return(&pb.DeviceCollection{Id: testCollectionID, Label: newLabel, DeviceCount: 3}, nil)
@@ -2018,6 +2022,112 @@ func TestService_SaveRack_ExplicitSameBuildingClearsZone(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", resp.Collection.GetRackInfo().Zone, "zone cleared for explicit same-building update with empty zone")
 
+	_ = mockSiteStore
+}
+
+// TestService_UpdateCollection_RackSettingsClearsZoneOmittedPlacement covers a
+// rack:manage-only settings save (the Rack Settings "Continue"): placement is
+// omitted (preserved), but an explicitly emptied zone is a real clear. Unlike
+// SaveRack's legacy path, the UpdateCollection settings path uses
+// preserveZoneOnEmpty=false, so it persists "" instead of restoring the current
+// zone. Regression guard for the rack:manage lost-zone-clear defect.
+func TestService_UpdateCollection_RackSettingsClearsZoneOmittedPlacement(t *testing.T) {
+	svc, mockStore, mockSiteStore := newTestServiceWithSites(t, func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return nil, nil
+	})
+	ctx := testCtx(t)
+
+	collectionID := int64(43)
+	existingSite := int64(7)
+	existingBuilding := int64(70)
+
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, collectionID).Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
+	// Omitted placement: no site/building locks, just the rack lock; the rack
+	// currently carries zone "Floor 1".
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), collectionID, testOrgID).
+		Return(interfaces.RackPlacement{SiteID: &existingSite, BuildingID: &existingBuilding, Zone: "Floor 1"}, nil)
+	// Zone honored as an explicit clear ("") — NOT restored from current.
+	mockStore.EXPECT().UpdateRackInfo(gomock.Any(), collectionID, "", int32(4), int32(8), int32(pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT), int32(pb.RackCoolingType_RACK_COOLING_TYPE_AIR), testOrgID).Return(nil)
+	mockStore.EXPECT().UpdateRackPlacement(gomock.Any(), collectionID, testOrgID, gomock.Eq(&existingSite), gomock.Eq(&existingBuilding), "").Return(nil)
+	mockStore.EXPECT().UpdateCollection(gomock.Any(), testOrgID, collectionID, gomock.Any(), gomock.Any()).Return(nil)
+	// Settings save cascades current members onto the (unchanged) placement.
+	mockStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), collectionID, testOrgID, gomock.Eq(&existingSite)).Return(int64(0), nil)
+	mockStore.EXPECT().CascadeRackDeviceBuildings(gomock.Any(), collectionID, testOrgID, gomock.Eq(&existingBuilding)).Return(int64(0), nil)
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, collectionID).
+		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack", Type: pb.CollectionType_COLLECTION_TYPE_RACK}, nil)
+	mockStore.EXPECT().GetRackInfo(gomock.Any(), collectionID, testOrgID).
+		Return(&pb.RackInfo{Rows: 4, Columns: 8, Zone: "", OrderIndex: pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT, CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR}, nil)
+
+	label := "Rack"
+	resp, err := svc.UpdateCollection(ctx, &pb.UpdateCollectionRequest{
+		CollectionId: collectionID,
+		Label:        &label,
+		// No SiteId/BuildingId → omitted placement (rack:manage settings save).
+		TypeDetails: &pb.UpdateCollectionRequest_RackInfo{
+			RackInfo: &pb.RackInfo{
+				Rows:        4,
+				Columns:     8,
+				Zone:        "",
+				OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+				CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "", resp.Collection.GetRackInfo().Zone, "empty zone is an explicit clear on the settings-save path")
+	_ = mockSiteStore
+}
+
+// TestService_UpdateCollection_RackSettingsPersistsPlacementAndCascades covers a
+// site:manage settings save (Continue): explicit placement is resolved,
+// persisted, and the rack's current members are cascaded to it — atomically and
+// without touching membership (no device selector). This is the single call
+// that replaces the former two-call updateRack + AssignRacksTo... sequence.
+func TestService_UpdateCollection_RackSettingsPersistsPlacementAndCascades(t *testing.T) {
+	svc, mockStore, mockSiteStore := newTestServiceWithSites(t, func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return nil, nil
+	})
+	ctx := testCtx(t)
+
+	collectionID := int64(43)
+	site := int64(7)
+	building := int64(70)
+
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, collectionID).Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
+	// Explicit building placement resolves + locks site/building (peek + re-read).
+	mockStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, building).Return(&site, nil).Times(2)
+	mockSiteStore.EXPECT().LockSiteForWrite(gomock.Any(), testOrgID, site).Return(nil)
+	mockSiteStore.EXPECT().LockBuildingForWrite(gomock.Any(), testOrgID, building).Return(nil)
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), collectionID, testOrgID).
+		Return(interfaces.RackPlacement{SiteID: &site, BuildingID: &building, Zone: "Floor 1"}, nil)
+	mockStore.EXPECT().UpdateRackInfo(gomock.Any(), collectionID, "Floor 2", int32(4), int32(8), int32(pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT), int32(pb.RackCoolingType_RACK_COOLING_TYPE_AIR), testOrgID).Return(nil)
+	mockStore.EXPECT().UpdateRackPlacement(gomock.Any(), collectionID, testOrgID, gomock.Eq(&site), gomock.Eq(&building), "Floor 2").Return(nil)
+	mockStore.EXPECT().UpdateCollection(gomock.Any(), testOrgID, collectionID, gomock.Any(), gomock.Any()).Return(nil)
+	mockStore.EXPECT().CascadeRackDeviceSites(gomock.Any(), collectionID, testOrgID, gomock.Eq(&site)).Return(int64(2), nil)
+	mockStore.EXPECT().CascadeRackDeviceBuildings(gomock.Any(), collectionID, testOrgID, gomock.Eq(&building)).Return(int64(2), nil)
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, collectionID).
+		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack", Type: pb.CollectionType_COLLECTION_TYPE_RACK}, nil)
+	mockStore.EXPECT().GetRackInfo(gomock.Any(), collectionID, testOrgID).
+		Return(&pb.RackInfo{Rows: 4, Columns: 8, Zone: "Floor 2", SiteId: &site, BuildingId: &building, OrderIndex: pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT, CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR}, nil)
+
+	label := "Rack"
+	resp, err := svc.UpdateCollection(ctx, &pb.UpdateCollectionRequest{
+		CollectionId: collectionID,
+		Label:        &label,
+		TypeDetails: &pb.UpdateCollectionRequest_RackInfo{
+			RackInfo: &pb.RackInfo{
+				Rows:        4,
+				Columns:     8,
+				Zone:        "Floor 2",
+				OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+				CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+				BuildingId:  &building,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Floor 2", resp.Collection.GetRackInfo().Zone)
+	assert.Equal(t, building, *resp.Collection.GetRackInfo().BuildingId)
 	_ = mockSiteStore
 }
 

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -1148,16 +1148,6 @@ func TestService_SaveRack_ValidationErrors(t *testing.T) {
 			want: "rack_info is required",
 		},
 		{
-			// Zone is now only required when the rack belongs to a building;
-			// direct-under-site racks (building_id nil) may have empty zone.
-			name: "missing zone with building set",
-			req: &pb.SaveRackRequest{
-				Label:    "Rack",
-				RackInfo: &pb.RackInfo{Rows: 4, Columns: 8, OrderIndex: pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT, CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR, BuildingId: int64Ptr(7)},
-			},
-			want: "zone is required when the rack belongs to a building",
-		},
-		{
 			name: "rows too large",
 			req: &pb.SaveRackRequest{
 				Label:    "Rack",
@@ -1231,6 +1221,24 @@ func TestService_SaveRack_ValidationErrors(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.want)
 		})
 	}
+}
+
+// Zone is an optional free-text sub-building label with no placement
+// dependency (nullable column), so a rack in a building may have an empty
+// zone. Guards against re-adding the old zone-required-when-building rule.
+func TestValidateSaveRackRequest_ZoneOptionalInBuilding(t *testing.T) {
+	err := validateSaveRackRequest(
+		&pb.SaveRackRequest{Label: "Rack"},
+		&pb.RackInfo{
+			Rows:        4,
+			Columns:     8,
+			OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+			CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+			BuildingId:  int64Ptr(7),
+			// Zone intentionally omitted.
+		},
+	)
+	require.NoError(t, err)
 }
 
 // Capacity guard: more resolved members than rows×columns is rejected

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -1963,6 +1963,64 @@ func TestService_SaveRack_OmittedPlacementPreservesZone(t *testing.T) {
 	_ = mockSiteStore
 }
 
+// TestService_SaveRack_ExplicitSameBuildingClearsZone is the counterpart to
+// the omitted-placement preserve above: a client that manages placement
+// (sends an explicit building) can clear the zone of a rack that stays in the
+// same building. The empty zone is honored, not restored from the current
+// placement.
+func TestService_SaveRack_ExplicitSameBuildingClearsZone(t *testing.T) {
+	resolver := func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return nil, nil
+	}
+	svc, mockStore, mockSiteStore := newTestServiceWithSites(t, resolver)
+	ctx := testCtx(t)
+
+	collectionID := int64(43)
+	site := int64(7)
+	building := int64(70)
+
+	mockStore.EXPECT().CollectionBelongsToOrg(gomock.Any(), collectionID, testOrgID).Return(true, nil)
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, collectionID).Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
+	// Explicit building placement resolves + locks site/building.
+	mockStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, building).Return(&site, nil).Times(2)
+	mockSiteStore.EXPECT().LockSiteForWrite(gomock.Any(), testOrgID, site).Return(nil)
+	mockSiteStore.EXPECT().LockBuildingForWrite(gomock.Any(), testOrgID, building).Return(nil)
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), collectionID, testOrgID).
+		Return(interfaces.RackPlacement{SiteID: &site, BuildingID: &building, Zone: "Floor 1"}, nil)
+
+	mockStore.EXPECT().UpdateCollection(gomock.Any(), testOrgID, collectionID, gomock.Any(), (*string)(nil)).Return(nil)
+	// Zone cleared: explicit placement, same building, empty zone submitted.
+	mockStore.EXPECT().UpdateRackInfo(gomock.Any(), collectionID, "", int32(4), int32(8), int32(pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT), int32(pb.RackCoolingType_RACK_COOLING_TYPE_AIR), testOrgID).Return(nil)
+	mockStore.EXPECT().UpdateRackPlacement(gomock.Any(), collectionID, testOrgID, gomock.Eq(&site), gomock.Eq(&building), "").Return(nil)
+
+	mockStore.EXPECT().RemoveAllDevicesFromCollection(gomock.Any(), testOrgID, collectionID).Return(int64(0), nil)
+	mockStore.EXPECT().GetRackSlots(gomock.Any(), collectionID, testOrgID).Return(nil, nil)
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, collectionID).
+		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack", Type: pb.CollectionType_COLLECTION_TYPE_RACK}, nil)
+
+	resp, err := svc.SaveRack(ctx, &pb.SaveRackRequest{
+		CollectionId: &collectionID,
+		Label:        "Rack",
+		RackInfo: &pb.RackInfo{
+			Rows:        4,
+			Columns:     8,
+			Zone:        "",
+			OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+			CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+			BuildingId:  &building,
+		},
+		DeviceSelector: &commonpb.DeviceSelector{
+			SelectionType: &commonpb.DeviceSelector_DeviceList{
+				DeviceList: &commonpb.DeviceIdentifierList{DeviceIdentifiers: []string{}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "", resp.Collection.GetRackInfo().Zone, "zone cleared for explicit same-building update with empty zone")
+
+	_ = mockSiteStore
+}
+
 // TestService_AddDevicesToGroup_HappyPath covers the group add flow:
 // groups are org-scoped (cross-site allowed) so there is no rack lock,
 // no LockSiteForWrite, and no cascade — just the membership insert

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -2148,8 +2148,12 @@ func TestService_UpdateCollection_RackSettingsRejectsShrinkBelowMembers(t *testi
 	collectionID := int64(43)
 
 	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, collectionID).Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
-	// Guard runs first: no out-of-bounds slots, but 5 members exceed the new
-	// 2×2 = 4 capacity → reject. No UpdateRackInfo / placement writes follow.
+	// Omitted placement → the rack row is locked first; the guard then runs
+	// UNDER that lock (afterLock hook). No out-of-bounds slots, but 5 members
+	// exceed the new 2×2 = 4 capacity → reject before any UpdateRackInfo /
+	// placement write.
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), collectionID, testOrgID).
+		Return(interfaces.RackPlacement{}, nil)
 	mockStore.EXPECT().GetRackSlots(gomock.Any(), collectionID, testOrgID).Return(nil, nil)
 	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, collectionID).
 		Return(&pb.DeviceCollection{Id: collectionID, Label: "Rack", Type: pb.CollectionType_COLLECTION_TYPE_RACK, DeviceCount: 5}, nil)

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -2176,6 +2176,46 @@ func TestService_UpdateCollection_RackSettingsRejectsShrinkBelowMembers(t *testi
 	_ = mockSiteStore
 }
 
+// TestService_UpdateCollection_RackSettingsRejectsMembershipOverCapacity guards
+// the combined shape: rack_info (dims) + device_selector (new membership) in one
+// call. The new set governs capacity, so replacing membership with more miners
+// than the submitted grid holds is rejected before any write — mirroring
+// SaveRack — rather than silently committing an over-capacity rack.
+func TestService_UpdateCollection_RackSettingsRejectsMembershipOverCapacity(t *testing.T) {
+	svc, mockStore, mockSiteStore := newTestServiceWithSites(t, func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return []string{"d1", "d2"}, nil // two miners
+	})
+	ctx := testCtx(t)
+
+	collectionID := int64(43)
+
+	// Only the type read happens before the capacity check rejects (2 miners
+	// into a 1×1 = 1-slot grid); no lock/placement/membership writes follow.
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, collectionID).Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
+
+	label := "Rack"
+	_, err := svc.UpdateCollection(ctx, &pb.UpdateCollectionRequest{
+		CollectionId: collectionID,
+		Label:        &label,
+		DeviceSelector: &commonpb.DeviceSelector{
+			SelectionType: &commonpb.DeviceSelector_DeviceList{
+				DeviceList: &commonpb.DeviceIdentifierList{DeviceIdentifiers: []string{"d1", "d2"}},
+			},
+		},
+		TypeDetails: &pb.UpdateCollectionRequest_RackInfo{
+			RackInfo: &pb.RackInfo{
+				Rows:        1,
+				Columns:     1,
+				OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+				CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot assign 2 miners")
+	_ = mockSiteStore
+}
+
 // TestService_AddDevicesToGroup_HappyPath covers the group add flow:
 // groups are org-scoped (cross-site allowed) so there is no rack lock,
 // no LockSiteForWrite, and no cascade — just the membership insert

--- a/server/internal/domain/stores/sqlstores/device_filters.go
+++ b/server/internal/domain/stores/sqlstores/device_filters.go
@@ -473,7 +473,16 @@ func appendFilterSQL(sb *strings.Builder, args []any, argNum int, orgID int64, f
 			argNum += 2
 			first = false
 		}
-		if fp.includeNoBuilding {
+		// include_no_building matches miners whose RACK has no building. That
+		// keeps a target rack's own members visible in the assignable-only
+		// filter (their building-less rack matches). But the assignable-only
+		// filter for a NEW rack carries no rack_ids and sets include_no_rack —
+		// there are no members to preserve, and this branch would instead pull
+		// in the members of OTHER building-less racks. So drop it for that
+		// shape (include_no_rack with no explicit rack filter); the no-rack
+		// branch below still admits rackless miners with no direct building.
+		emitNoBuildingRackBranch := fp.includeNoBuilding && !(fp.includeNoRack && !fp.rackIDsFilter.Valid)
+		if emitNoBuildingRackBranch {
 			if !first {
 				sb.WriteString(" OR ")
 			}

--- a/server/internal/domain/stores/sqlstores/device_filters.go
+++ b/server/internal/domain/stores/sqlstores/device_filters.go
@@ -332,19 +332,32 @@ func appendFilterSQL(sb *strings.Builder, args []any, argNum int, orgID int64, f
 		argNum += 2
 	}
 
-	if fp.rackIDsFilter.Valid {
+	// Rack membership predicate. rack_ids match an explicit rack; include_no_rack
+	// admits devices with no rack membership. Emitting this as a top-level AND
+	// whenever include_no_rack is set (even with no rack_ids) is what keeps the
+	// assignable-only filter for a NEW rack from leaking miners that sit in
+	// ANOTHER rack in the same building — their direct/rack-derived building
+	// still matches the building predicate below, so "no rack" has to be
+	// enforced here rather than only OR'd inside the building group.
+	if fp.rackIDsFilter.Valid || fp.includeNoRack {
 		sb.WriteString(" AND (")
-		fmt.Fprintf(sb,
-			"EXISTS (SELECT 1 FROM device_set_membership dcm"+
-				" WHERE dcm.device_id = device.id"+
-				" AND dcm.org_id = $%d"+
-				" AND dcm.device_set_type = 'rack'"+
-				" AND dcm.device_set_id = ANY($%d::bigint[]))",
-			argNum, argNum+1)
-		args = append(args, orgID, pq.Array(fp.rackIDValues))
-		argNum += 2
+		rackFirst := true
+		if fp.rackIDsFilter.Valid {
+			fmt.Fprintf(sb,
+				"EXISTS (SELECT 1 FROM device_set_membership dcm"+
+					" WHERE dcm.device_id = device.id"+
+					" AND dcm.org_id = $%d"+
+					" AND dcm.device_set_type = 'rack'"+
+					" AND dcm.device_set_id = ANY($%d::bigint[]))",
+				argNum, argNum+1)
+			args = append(args, orgID, pq.Array(fp.rackIDValues))
+			argNum += 2
+			rackFirst = false
+		}
 		if fp.includeNoRack {
-			sb.WriteString(" OR ")
+			if !rackFirst {
+				sb.WriteString(" OR ")
+			}
 			fmt.Fprintf(sb,
 				"NOT EXISTS (SELECT 1 FROM device_set_membership dcm"+
 					" JOIN device_set ds ON ds.id = dcm.device_set_id"+

--- a/server/internal/domain/stores/sqlstores/device_filters.go
+++ b/server/internal/domain/stores/sqlstores/device_filters.go
@@ -495,6 +495,24 @@ func appendFilterSQL(sb *strings.Builder, args []any, argNum int, orgID int64, f
 			if !first {
 				sb.WriteString(" OR ")
 			}
+			// The no-rack branch keeps genuinely-unplaced miners in the
+			// building group (they own no device_set_rack row, so the
+			// building_ids / include_no_building branches above can never
+			// match them). When the caller also constrains building
+			// (explicit IDs or include_no_building — e.g. the assignable-only
+			// miner-selection filter), a rackless miner should only pass if
+			// it is ALSO unplaced at the building level: a rackless miner
+			// with a direct device.building_id in another building is
+			// placed elsewhere, not assignable. Without this, that miner
+			// leaks into the default assignable-only list (issue #702).
+			// When no building predicate is present (e.g. the fleet
+			// "Unassigned" rack bucket with no building facet), this branch
+			// is the sole no-rack predicate and must stay unqualified so
+			// rackless-but-building-placed miners still surface.
+			buildingConstrained := fp.buildingIDsFilter.Valid || fp.includeNoBuilding
+			if buildingConstrained {
+				sb.WriteString("(device.building_id IS NULL AND ")
+			}
 			fmt.Fprintf(sb,
 				"NOT EXISTS (SELECT 1 FROM device_set_membership dcm"+
 					" JOIN device_set ds ON ds.id = dcm.device_set_id"+
@@ -503,6 +521,9 @@ func appendFilterSQL(sb *strings.Builder, args []any, argNum int, orgID int64, f
 					" AND dcm.device_set_type = 'rack'"+
 					" AND ds.deleted_at IS NULL)",
 				argNum)
+			if buildingConstrained {
+				sb.WriteString(")")
+			}
 			args = append(args, orgID)
 			argNum++
 		}

--- a/server/internal/domain/stores/sqlstores/device_filters_test.go
+++ b/server/internal/domain/stores/sqlstores/device_filters_test.go
@@ -831,10 +831,14 @@ func TestAppendFilterSQL_IncludeNoRack_Alone(t *testing.T) {
 func TestAppendFilterSQL_BuildingFiltersORTogether(t *testing.T) {
 	// building_ids + include_no_building + include_no_rack should be OR'd
 	// inside one outer AND so devices in any of the three populations match.
+	// An explicit rack filter keeps the "rack has no building" branch (it's
+	// only dropped for the rack-less new-rack shape).
 	var sb strings.Builder
 	fp := minerFilterParams{
 		buildingIDsFilter: validNullString(),
 		buildingIDValues:  []int64{7},
+		rackIDsFilter:     validNullString(),
+		rackIDValues:      []int64{5},
 		includeNoBuilding: true,
 		includeNoRack:     true,
 	}
@@ -847,6 +851,28 @@ func TestAppendFilterSQL_BuildingFiltersORTogether(t *testing.T) {
 	assert.Contains(t, sql, "dsr.building_id IS NULL")
 	assert.Contains(t, sql, "NOT EXISTS")
 	assert.GreaterOrEqual(t, strings.Count(sql, " OR "), 2)
+}
+
+// The assignable-only filter for a NEW rack sends include_no_rack with no
+// rack_ids and no building. Its "no building" pin must NOT emit the "rack has
+// no building" branch — there are no target members to keep, and that branch
+// would otherwise match miners in OTHER building-less racks. The no-rack
+// branch (device.building_id IS NULL AND NOT EXISTS rack) still admits
+// rackless miners with no direct building.
+func TestAppendFilterSQL_NewRackShape_DropsNoBuildingRackBranch(t *testing.T) {
+	var sb strings.Builder
+	fp := minerFilterParams{
+		includeNoBuilding: true,
+		includeNoRack:     true,
+		includeUnassigned: true,
+	}
+
+	appendFilterSQL(&sb, []any{"initial"}, 2, 42, fp)
+
+	sql := sb.String()
+	assert.Contains(t, sql, "device.site_id IS NULL")
+	assert.Contains(t, sql, "(device.building_id IS NULL AND NOT EXISTS")
+	assert.NotContains(t, sql, "dsr.building_id IS NULL")
 }
 
 // TestAppendFilterSQL_ZoneKeys_OrgIDDefenseInDepth guards against the

--- a/server/internal/domain/stores/sqlstores/device_filters_test.go
+++ b/server/internal/domain/stores/sqlstores/device_filters_test.go
@@ -400,6 +400,51 @@ func TestAppendFilterSQL_RackAndBuildingUnassigned_IncludeNoRackWideningPreserve
 	assert.Contains(t, sql, "device_set_id = ANY")
 	assert.Contains(t, sql, "dsr.building_id IS NULL")
 	assert.Equal(t, 2, strings.Count(sql, "NOT EXISTS"))
+	// #702: with a building predicate present (include_no_building), the
+	// no-rack branch is intersected with "no direct building" so a rackless
+	// miner directly placed in another building can't leak through.
+	assert.Contains(t, sql, "(device.building_id IS NULL AND NOT EXISTS")
+}
+
+// The assignable-only miner-selection filter (issue #702) sends the target
+// rack (rack_ids + include_no_rack) AND its building (building_ids +
+// include_no_building). The no-rack branch must be gated on
+// device.building_id IS NULL so a rackless miner with a direct building_id in
+// a different building stays out of the default assignable list.
+func TestAppendFilterSQL_AssignableOnlyShape_NoRackBranchGatedOnNoBuilding(t *testing.T) {
+	var sb strings.Builder
+	fp := minerFilterParams{
+		rackIDsFilter:     validNullString(),
+		rackIDValues:      []int64{5},
+		buildingIDsFilter: validNullString(),
+		buildingIDValues:  []int64{7},
+		includeNoBuilding: true,
+		includeNoRack:     true,
+	}
+
+	appendFilterSQL(&sb, []any{"initial"}, 2, 42, fp)
+
+	sql := sb.String()
+	assert.Contains(t, sql, "device.building_id = ANY")                   // branch A: direct/rack-derived building
+	assert.Contains(t, sql, "dsr.building_id IS NULL")                    // branch B: rack with no building
+	assert.Contains(t, sql, "(device.building_id IS NULL AND NOT EXISTS") // branch C: gated no-rack
+}
+
+// The fleet "Unassigned" rack bucket sends include_no_rack with no building
+// predicate at all. Here the no-rack branch is the SOLE building-group
+// predicate and must stay unqualified — otherwise a rackless miner directly
+// placed in a building would vanish from the Unassigned view.
+func TestAppendFilterSQL_UnassignedRackBucket_NoRackBranchNotGated(t *testing.T) {
+	var sb strings.Builder
+	fp := minerFilterParams{
+		includeNoRack: true,
+	}
+
+	appendFilterSQL(&sb, []any{"initial"}, 2, 42, fp)
+
+	sql := sb.String()
+	assert.Contains(t, sql, "NOT EXISTS")
+	assert.NotContains(t, sql, "device.building_id IS NULL")
 }
 
 // TestBuildMinerFilterParams_SiteFilter exercises the four allowed combos

--- a/server/internal/domain/stores/sqlstores/device_filters_test.go
+++ b/server/internal/domain/stores/sqlstores/device_filters_test.go
@@ -875,6 +875,32 @@ func TestAppendFilterSQL_NewRackShape_DropsNoBuildingRackBranch(t *testing.T) {
 	assert.NotContains(t, sql, "dsr.building_id IS NULL")
 }
 
+// A NEW rack placed in a building sends building_ids + include_no_building +
+// include_no_rack with NO rack_ids. "No rack" must be enforced as its own
+// top-level AND clause — otherwise a miner in ANOTHER rack in that building
+// (whose direct/rack-derived building_id still matches the building predicate)
+// leaks into the assignable-only list.
+func TestAppendFilterSQL_NewRackInBuilding_EnforcesNoRackTopLevel(t *testing.T) {
+	var sb strings.Builder
+	fp := minerFilterParams{
+		buildingIDsFilter: validNullString(),
+		buildingIDValues:  []int64{7},
+		includeNoBuilding: true,
+		includeNoRack:     true,
+		siteIDsFilter:     validNullString(),
+		siteIDValues:      []int64{3},
+		includeUnassigned: true,
+	}
+
+	appendFilterSQL(&sb, []any{"initial"}, 2, 42, fp)
+
+	sql := sb.String()
+	// Rack membership is its own AND clause enforcing "no rack".
+	assert.Contains(t, sql, " AND (NOT EXISTS (SELECT 1 FROM device_set_membership dcm JOIN device_set ds")
+	// The building predicate still admits directly-building-placed rackless miners.
+	assert.Contains(t, sql, "device.building_id = ANY")
+}
+
 // TestAppendFilterSQL_ZoneKeys_OrgIDDefenseInDepth guards against the
 // regression mode flagged by finding 2: a refactor that drops the
 // dcm.org_id clause from the wildcard branch would silently expose

--- a/server/internal/handlers/collection/handler.go
+++ b/server/internal/handlers/collection/handler.go
@@ -186,6 +186,16 @@ func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[pb.SaveRackRe
 	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
+	// Placement (site/building) is a site-management action, matching the
+	// dedicated AssignRacksToSite/Building RPCs. Require site:manage when the
+	// request carries placement intent; omitted placement preserves the
+	// current site/building and stays rack:manage. Mirrors the device_set.v1
+	// SaveRack handler.
+	if ri := r.Msg.RackInfo; ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+			return nil, err
+		}
+	}
 	result, err := h.collectionSvc.SaveRack(ctx, r.Msg)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/collection/handler.go
+++ b/server/internal/handlers/collection/handler.go
@@ -30,6 +30,15 @@ func (h *Handler) CreateCollection(ctx context.Context, r *connect.Request[pb.Cr
 	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
+	// Creating a rack under a site/building persists that placement, so mirror
+	// the Update/SaveRack gate: require site:manage when rack_info carries
+	// explicit placement (site_id/building_id). Otherwise a rack:manage-only
+	// caller could place a rack via the create path, bypassing the boundary.
+	if ri := r.Msg.GetRackInfo(); ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+			return nil, err
+		}
+	}
 	result, err := h.collectionSvc.CreateCollection(ctx, r.Msg)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/collection/handler.go
+++ b/server/internal/handlers/collection/handler.go
@@ -54,6 +54,16 @@ func (h *Handler) UpdateCollection(ctx context.Context, r *connect.Request[pb.Up
 	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
+	// UpdateCollection now persists a rack's placement (site/building) when
+	// rack_info carries it — the same reparent + cascade the DeviceSet handler
+	// exposes — so mirror its gate: require site:manage when placement intent is
+	// present (explicit site_id/building_id, incl. 0 to unassign). Metadata-only
+	// edits (label/zone/dims, membership) stay rack:manage.
+	if ri := r.Msg.GetRackInfo(); ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+			return nil, err
+		}
+	}
 	result, err := h.collectionSvc.UpdateCollection(ctx, r.Msg)
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -350,6 +350,17 @@ func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[dspb.SaveRack
 	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
+	// Placing a rack under a site/building is a site-management action —
+	// matching the dedicated AssignRacksToSite/Building RPCs (site:manage).
+	// A rack:manage-only caller may edit rack contents but not place the rack,
+	// so require site:manage when the request carries placement intent (an
+	// explicit site_id/building_id, including 0 to unassign). Omitted placement
+	// preserves the rack's current site/building and stays rack:manage.
+	if ri := r.Msg.RackInfo; ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+			return nil, err
+		}
+	}
 	req := toCollectionSaveRackReq(r.Msg)
 	result, err := h.svc.SaveRack(ctx, req)
 	if err != nil {

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -34,6 +34,15 @@ func (h *Handler) CreateDeviceSet(ctx context.Context, r *connect.Request[dspb.C
 	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
+	// Creating a rack under a site/building persists that placement (and can
+	// cascade added devices to it), so mirror the UpdateDeviceSet/SaveRack gate:
+	// require site:manage when rack_info carries explicit placement. Without
+	// this, a rack:manage-only caller could place a rack via the create path.
+	if ri, ok := r.Msg.TypeDetails.(*dspb.CreateDeviceSetRequest_RackInfo); ok && ri.RackInfo != nil && (ri.RackInfo.SiteId != nil || ri.RackInfo.BuildingId != nil) {
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+			return nil, err
+		}
+	}
 	req := toCollectionCreateReq(r.Msg)
 	result, err := h.svc.CreateCollection(ctx, req)
 	if err != nil {

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -64,6 +64,17 @@ func (h *Handler) UpdateDeviceSet(ctx context.Context, r *connect.Request[dspb.U
 	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
 		return nil, err
 	}
+	// A rack's placement is now persisted here too (zone/dims + site/building
+	// in one settings save). Placing a rack under a site/building is a
+	// site-management action, so — mirroring SaveRack — require site:manage
+	// when the request carries explicit placement intent (site_id/building_id,
+	// including 0 to unassign). Metadata-only edits (label/zone/dims, or a
+	// membership change) stay rack:manage.
+	if ri, ok := r.Msg.TypeDetails.(*dspb.UpdateDeviceSetRequest_RackInfo); ok && ri.RackInfo != nil && (ri.RackInfo.SiteId != nil || ri.RackInfo.BuildingId != nil) {
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+			return nil, err
+		}
+	}
 	req := toCollectionUpdateReq(r.Msg)
 	result, err := h.svc.UpdateCollection(ctx, req)
 	if err != nil {

--- a/server/internal/handlers/deviceset/handler_test.go
+++ b/server/internal/handlers/deviceset/handler_test.go
@@ -813,6 +813,30 @@ func TestSaveRack_PlacementRequiresSiteManage(t *testing.T) {
 	assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
 }
 
+// TestCreateDeviceSet_PlacementRequiresSiteManage confirms the create path
+// enforces the same boundary as SaveRack/UpdateDeviceSet: creating a rack under
+// a site/building persists that placement, so a rack:manage-only caller that
+// sends explicit placement is rejected before any store write. (Codex security
+// review, HIGH — the create path previously bypassed the gate.)
+func TestCreateDeviceSet_PlacementRequiresSiteManage(t *testing.T) {
+	h := newTestHandler(t)
+
+	// Has rack:manage but NOT site:manage.
+	ctx := ctxWithPerms(authz.PermRackManage)
+	req := connect.NewRequest(&dspb.CreateDeviceSetRequest{
+		Label: "Rack",
+		TypeDetails: &dspb.CreateDeviceSetRequest_RackInfo{
+			RackInfo: &dspb.RackInfo{BuildingId: ptrInt64Local(7)},
+		},
+	})
+
+	_, err := h.handler.CreateDeviceSet(ctx, req)
+	require.Error(t, err)
+	var fe fleeterror.FleetError
+	require.ErrorAs(t, err, &fe, "expected FleetError, got %T", err)
+	assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
+}
+
 // TestAssignDevicesToRack_HappyPathAssigns covers the assign branch:
 // target_rack_id set, devices flow through the lock → label-read →
 // remove → add → cascade chain, and the handler round-trips the

--- a/server/internal/handlers/deviceset/handler_test.go
+++ b/server/internal/handlers/deviceset/handler_test.go
@@ -790,6 +790,29 @@ func TestAssignDevicesToRack_PermissionRequired(t *testing.T) {
 	assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
 }
 
+// TestSaveRack_PlacementRequiresSiteManage confirms that placing a rack under
+// a site/building requires site:manage, even though SaveRack's base gate is
+// only rack:manage. A rack:manage-only caller that sends placement intent
+// (an explicit site_id/building_id) is rejected before any store write —
+// matching the dedicated AssignRacksToSite/Building RPCs.
+func TestSaveRack_PlacementRequiresSiteManage(t *testing.T) {
+	h := newTestHandler(t)
+
+	// Has rack:manage but NOT site:manage.
+	ctx := ctxWithPerms(authz.PermRackManage)
+	req := connect.NewRequest(&dspb.SaveRackRequest{
+		Label:          "Rack",
+		RackInfo:       &dspb.RackInfo{BuildingId: ptrInt64Local(7)},
+		DeviceSelector: deviceListSelector(),
+	})
+
+	_, err := h.handler.SaveRack(ctx, req)
+	require.Error(t, err)
+	var fe fleeterror.FleetError
+	require.ErrorAs(t, err, &fe, "expected FleetError, got %T", err)
+	assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
+}
+
 // TestAssignDevicesToRack_HappyPathAssigns covers the assign branch:
 // target_rack_id set, devices flow through the lock → label-read →
 // remove → add → cascade chain, and the handler round-trips the


### PR DESCRIPTION
Reviewable diff: ~+1169/−115 across 26 files (server, client, proto; excludes generated files).

## Summary

Fixes #702: miners that would actually be *reassigned* were showing up in the rack modal's default **"assignable only"** miner list (they rendered orange and triggered a reparent confirmation, but shouldn't have appeared at all). This closes two variants of that leak and, in the same area, gives the rack create/edit modals first-class **Site** and **Building** placement controls so operators set placement explicitly instead of it being inferred behind the scenes.

To make the assignable list trustworthy, a rack's **settings — placement, zone, and dimensions — now persist when you click *Continue* in Rack Settings**, so the list always judges miners against the rack's *live* placement rather than a pending one. The mental model is **"Continue saves settings, Save saves miners."**

Two things were leaking non-assignable miners into the default list:
1. A rackless miner with a direct `building_id` in a *different* building (same site) passed the server-side filter.
2. When the target rack isn't placed at a level (unplaced/new rack, or placed under a site with no building), that level was left unconstrained, so directly-placed miners leaked.

## How it works

**The assignable-only filter (server + client).** When "Show assigned miners" is off, `MinerSelectionList` folds the target rack's placement into a server `MinerListFilter` (rack/building/site, each "match-or-none"). The server (`device_filters.go`) turns that into SQL.

- *Server fix:* the building predicate OR's in a "no rack membership" branch so genuinely-unplaced miners stay assignable (they own no rack row to match the other branches). That branch was too broad — it admitted *any* rackless miner regardless of its direct `building_id`. It's now intersected with `device.building_id IS NULL` whenever a building constraint is present, so a rackless miner placed directly in another building is excluded. The standalone "Unassigned" rack bucket (no building constraint) is left unqualified, so that view still shows rackless-but-building-placed miners.
- *Client fix:* when the target rack has no value at a level (`eligBuildingId`/`eligSiteId` undefined), that dimension previously went unconstrained. It now pins to "unplaced only" (`includeNoBuilding`/`includeUnassigned` with empty ids), because assigning into a rack that lacks that level would strip the miner's placement there — so only miners already unplaced at that level are assignable without a reparent.

**Rack settings persist on *Continue*.** Editing a rack, *Continue* calls `updateRack` → `UpdateDeviceSet`, which now persists **placement + zone + dimensions in a single transaction and cascades the rack's current members** to the new placement — *without* touching membership. The final **Save** (`SaveRack`) then handles **miners only** and omits placement, preserving what Continue set. `SaveRack` and the settings path share one `resolveAndApplyRackPlacement` helper so placement/zone are derived identically. A new rack has nothing to persist yet, so its placement rides on the create `SaveRack`.

This replaces the original "everything rides on `SaveRack`" design: because the assignable list judges miners against the rack's placement, deferring placement to the final Save meant judging against a *pending* placement (miners in the destination read as reassignments). Persisting on Continue makes the list reflect reality; doing it through `UpdateDeviceSet` (which already carries `rack_info`, so no proto change) keeps it a single atomic call instead of an interim `updateRack` + `AssignRacksTo…` pair with a partial-failure window.

**Zone is optional.** The `CreateCollection` "zone required" rejection is removed — zone is a free-text sub-building label with no placement dependency. A `preserveZoneOnEmpty` flag distinguishes the two save paths: the settings-save (Continue) treats an empty zone as an explicit clear (the form always submits the current value, even for a `rack:manage`-only editor), while legacy `SaveRack` preserves it so a miners-only re-save can't wipe a zone it never edited.

**Permissions & safety.** Placing a rack under a site/building is a `site:manage` action, so `UpdateDeviceSet` and the deprecated `collection.v1.UpdateCollection` now require it when `rack_info` carries `site_id`/`building_id` (metadata/miners-only edits stay `rack:manage`). A settings-save that would shrink a rack below its current member count or an occupied slot position is rejected — and the check is re-run under the rack row lock so a concurrent `SaveRack` can't add members between the read and the resize. Continue shows a **"Saving…"** busy state and blocks dismiss while the request is in flight.

**Placement is scope-aware.** `0` is never stored — the server maps wire-`0` to SQL `NULL`, so "unassigned" is `NULL`. On **create**, placement is an optional, unfilled field (no "Unassigned" entry, empty by default); if the page header is scoped to a single site, the Site field is pre-filled **and locked** to it. On **edit**, an explicit "Unassigned" option is shown, seeded to the rack's real current placement. Building selection is disabled until a site is chosen and re-scopes to the selected site. The building create modal follows the same rule: pre-fill + lock to the page-header scope.

## Diagrams

```mermaid
flowchart TD
    U["Operator opens rack modal (Show assigned OFF)"] --> MSL["MinerSelectionList: fold target rack placement into filter"]
    MSL --> ELIG{"Target placed at level?"}
    ELIG -->|"has value"| PIN["Pin to that id OR unplaced"]
    ELIG -->|"undefined"| UNPL["Pin to unplaced-only (client fix)"]
    PIN --> REQ["MinerListFilter -> ListDevices RPC"]
    UNPL --> REQ
    REQ --> SQL["device_filters.go builds predicate"]
    SQL --> NR{"no-rack branch + building constraint?"}
    NR -->|"yes"| INT["require building_id IS NULL (server fix)"]
    NR -->|"no (Unassigned bucket)"| RAW["plain no-rack"]
    INT --> LIST["Assignable-only list"]
    RAW --> LIST
```

```mermaid
flowchart TD
    subgraph Continue["Rack Settings: Continue = save settings"]
        RSM["Site + Building + Zone + dims"] --> UR["updateRack -> UpdateDeviceSet"]
        UR --> GATE["site:manage gated if placement present"]
        GATE --> GUARD["resize guard under rack lock"]
        GUARD --> RAP["resolveAndApplyRackPlacement"]
        RAP --> W["persist placement + zone + dims; cascade members (0 -> NULL)"]
    end
    subgraph Save["Manage Rack: Save = save miners"]
        MRM["ManageRackModal.handleSave"] --> SR["SaveRack: membership + slots"]
        SR --> OMIT["existing rack -> omit placement (preserved); new rack -> create with placement"]
    end
    W -.->|"settings already live"| MRM
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
|---|---|---|
| `server/.../sqlstores/device_filters.go` | No-rack building branch intersected with `building_id IS NULL` when a building constraint is present; standalone Unassigned bucket unchanged | Core #702 filter fix |
| `server/.../collection/service.go` | `UpdateCollection` now persists rack placement + zone + dims and cascades members via the shared `resolveAndApplyRackPlacement`; `preserveZoneOnEmpty` split; `CreateCollection` zone rejection removed; `enforceRackDimensionsFitCurrentMembers` (under-lock resize guard) | Largest server change; the "Continue saves settings" engine |
| `server/.../handlers/deviceset/handler.go` | `UpdateDeviceSet` requires `site:manage` when `rack_info` carries placement | Auth parity with `SaveRack` |
| `server/.../handlers/collection/handler.go` | Same `site:manage` gate on the deprecated `collection.v1.UpdateCollection` | Closes the reparent bypass on the legacy endpoint |
| `client/.../components/MinerSelectionList.tsx` | Undefined site/building eligibility pins to unplaced-only instead of unconstrained | Second leak variant; assignable-only path only |
| `client/.../RackSettingsModal.tsx` | New Site/Building selects; create-lock vs edit-Unassigned; Continue awaits the settings save with a "Saving…" busy state + dismiss lock | Placement UX + busy affordance |
| `client/.../ManageRackModal/ManageRackModal.tsx` | Continue persists settings via `updateRack` (one atomic call); Save omits placement for existing racks; eligibility derives from live placement | Save/Continue split; core behavior |
| `client/.../api/useDeviceSets.ts` | `updateRack` now encodes placement onto `RackInfo` (mirrors `saveRack`) | Wire encoding of the proto contract |
| `client/.../ManageRackModal/types.ts` | `RackFormData` gains `siteId?`/`buildingId?` | Small contract change |
| `client/.../pages/*`, `FleetCreateFlow`, buildings modal/hooks | Seed current placement into edit; thread page-header `scopedSiteId`; building create pre-fill + lock | Call-site wiring |

## Key technical decisions & trade-offs

- **Settings persist on *Continue* via `UpdateDeviceSet`, not on the final `SaveRack`.** The assignable list must judge miners against the rack's live placement; deferring placement to Save judged against a pending one. Extending `UpdateDeviceSet` to persist settings + placement (no proto change — it already carries `rack_info`) makes Continue a single atomic call and removes the interim two-call (`updateRack` + `AssignRacksTo…`) partial-failure surface. `SaveRack` becomes miners-only.
- **Zone optional + `preserveZoneOnEmpty`** — one flag lets the settings-save honor an explicit clear while the legacy miners-only save can't accidentally wipe an untouched zone.
- **`site:manage` mirrored across every placement-bearing RPC**, including the deprecated `collection.v1.UpdateCollection`, so no endpoint can reparent a rack with only `rack:manage`.
- **Resize guard re-runs under the rack row lock** — a plain pre-read could be defeated by a concurrent `SaveRack`; the lock serializes them.
- **Create locks Site to the page-header scope; edit shows an explicit "Unassigned."** Consequence: you can't create an unassigned rack from within a single-site scope (use the "All sites" view). Building *site-editing on the update path* is deferred to **#715** (its `UpdateBuilding` excludes `site_id`, so an in-modal edit would need a second RPC / partial-failure surface).

## Testing & validation

- **Server:** `device_filters_test.go` covers the assignable-only shapes (no-rack branch gated on `building_id IS NULL`, the Unassigned-bucket case, the widening case). New `service.go` coverage for the settings-save path: placement + cascade, `rack:manage` zone-clear on omitted placement, and resize-reject-below-capacity (under lock). `handler_test.go` covers the `site:manage` gate. `go test` / `go vet` / `gofmt` clean.
- **Client:** `useDeviceSets.test.ts` covers the placement wire encodings for **both** `saveRack` and `updateRack` (building-only, site+0, explicit 0/0 unassign, undefined omit). `MinerSelectionList.test.tsx` covers the undefined-eligibility pins. tsc / ESLint / Prettier clean.
- **Not covered:** no dedicated `RackSettingsModal.test.tsx` for the dropdown option/lock logic (presentational; covered indirectly by the wire + eligibility tests). Building site-editing on the update path is out of scope (#715).
