### PR TITLE
fix(ci): prevent stale review policy publishes

### DIFF
--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -11,29 +11,24 @@ import evaluate_review_policy as policy
 
 
 class ReviewPolicyTest(unittest.TestCase):
-    def test_workflow_publishes_only_completed_policy_decisions(self):
+    def test_workflow_skips_cancelled_publish_side_effects(self):
         workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn(
-            "publishable: ${{ steps.evaluate_policy.outputs.publishable || "
-            "steps.fallback_policy.outputs.publishable || 'false' }}",
-            workflow,
-        )
-        self.assertEqual(workflow.count("needs.evaluate.outputs.publishable == 'true'"), 2)
         self.assertEqual(workflow.count("needs.evaluate.result != 'cancelled'"), 2)
+        self.assertNotIn("needs.evaluate.outputs.publishable", workflow)
+        self.assertNotIn("publishable:", workflow)
+        self.assertNotIn('echo "publishable=true"', workflow)
 
-    def test_workflow_publishes_unsupported_base_decisions(self):
+    def test_workflow_keeps_fail_closed_non_cancelled_failures(self):
         workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn('echo "unsupported_base=true" >> "$GITHUB_OUTPUT"', workflow)
-        self.assertIn("id: fallback_policy", workflow)
-        self.assertIn('if [ "$UNSUPPORTED_BASE" = "true" ]; then', workflow)
-        self.assertIn("enforced=true", workflow)
-        self.assertIn('echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn('exit 1', workflow)
+        self.assertIn("got base ref ${BASE_REF}.", workflow)
+        self.assertIn("ENFORCED: ${{ needs.evaluate.outputs.enforced || 'true' }}", workflow)
 
     def test_workflow_serializes_and_authorizes_label_sync(self):
         workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -18,11 +18,23 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertIn(
             "publishable: ${{ steps.evaluate_policy.outputs.publishable || "
+            "steps.unsupported_base_policy.outputs.publishable || "
             "steps.bootstrap_policy.outputs.publishable || 'false' }}",
             workflow,
         )
         self.assertEqual(workflow.count("needs.evaluate.outputs.publishable == 'true'"), 2)
         self.assertEqual(workflow.count("needs.evaluate.result != 'cancelled'"), 2)
+
+    def test_workflow_publishes_unsupported_base_decisions(self):
+        workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('echo "unsupported_base=true" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn("id: unsupported_base_policy", workflow)
+        self.assertIn("steps.unsupported_base_policy.outputs.enforced", workflow)
+        self.assertIn('echo "enforced=true" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn("steps.policy_source.outputs.unsupported_base != 'true'", workflow)
 
     def test_workflow_serializes_and_authorizes_label_sync(self):
         workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -49,8 +49,11 @@ class ReviewPolicyTest(unittest.TestCase):
 
     def test_workflow_ignored_events_do_not_cancel_active_evaluations(self):
         workflow = load_workflow("review-policy.yml")
+        group_expression = workflow["concurrency"]["group"]
         cancel_expression = workflow["concurrency"]["cancel-in-progress"]
 
+        self.assertIn("format('ignored-{0}', github.run_id)", group_expression)
+        self.assertIn("github.event.pull_request.head.sha || github.event.workflow_run.head_sha", group_expression)
         self.assertIn("github.event.check_run.app.slug == 'github-actions'", cancel_expression)
         self.assertIn("github.event.action == 'rerequested'", cancel_expression)
         self.assertIn("github.event.check_suite.app.slug == 'github-actions'", cancel_expression)

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -18,8 +18,7 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertIn(
             "publishable: ${{ steps.evaluate_policy.outputs.publishable || "
-            "steps.unsupported_base_policy.outputs.publishable || "
-            "steps.bootstrap_policy.outputs.publishable || 'false' }}",
+            "steps.fallback_policy.outputs.publishable || 'false' }}",
             workflow,
         )
         self.assertEqual(workflow.count("needs.evaluate.outputs.publishable == 'true'"), 2)
@@ -31,10 +30,10 @@ class ReviewPolicyTest(unittest.TestCase):
         )
 
         self.assertIn('echo "unsupported_base=true" >> "$GITHUB_OUTPUT"', workflow)
-        self.assertIn("id: unsupported_base_policy", workflow)
-        self.assertIn("steps.unsupported_base_policy.outputs.enforced", workflow)
-        self.assertIn('echo "enforced=true" >> "$GITHUB_OUTPUT"', workflow)
-        self.assertIn("steps.policy_source.outputs.unsupported_base != 'true'", workflow)
+        self.assertIn("id: fallback_policy", workflow)
+        self.assertIn('if [ "$UNSUPPORTED_BASE" = "true" ]; then', workflow)
+        self.assertIn("enforced=true", workflow)
+        self.assertIn('echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"', workflow)
 
     def test_workflow_serializes_and_authorizes_label_sync(self):
         workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import subprocess
 import unittest
 import tempfile
 import zipfile
@@ -10,38 +11,102 @@ from pathlib import Path
 import evaluate_review_policy as policy
 
 
+WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / "workflows"
+
+
+def read_workflow(name):
+    return (WORKFLOWS_DIR / name).read_text(encoding="utf-8")
+
+
+def load_workflow(name):
+    result = subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "puts JSON.generate(YAML.load_file(ARGV.fetch(0)))",
+            str(WORKFLOWS_DIR / name),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
 class ReviewPolicyTest(unittest.TestCase):
-    def test_workflow_skips_cancelled_publish_side_effects(self):
-        workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(
-            encoding="utf-8"
+    def test_pr_gate_runs_review_policy_tests(self):
+        workflow = load_workflow("pr-gate.yml")
+        jobs = workflow["jobs"]
+
+        self.assertIn("review-policy-tests", jobs)
+        self.assertIn("review-policy-tests", jobs["gate"]["needs"])
+        self.assertEqual(
+            jobs["review-policy-tests"]["steps"][1]["run"],
+            "python3 .github/scripts/evaluate_review_policy_test.py",
         )
 
-        self.assertEqual(workflow.count("needs.evaluate.result != 'cancelled'"), 2)
-        self.assertNotIn("needs.evaluate.outputs.publishable", workflow)
-        self.assertNotIn("publishable:", workflow)
-        self.assertNotIn('echo "publishable=true"', workflow)
+    def test_workflow_ignored_events_do_not_cancel_active_evaluations(self):
+        workflow = load_workflow("review-policy.yml")
+        cancel_expression = workflow["concurrency"]["cancel-in-progress"]
 
-    def test_workflow_keeps_fail_closed_non_cancelled_failures(self):
-        workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(
-            encoding="utf-8"
+        self.assertIn("github.event.check_run.app.slug == 'github-actions'", cancel_expression)
+        self.assertIn("github.event.action == 'rerequested'", cancel_expression)
+        self.assertIn("github.event.check_suite.app.slug == 'github-actions'", cancel_expression)
+        self.assertIn("github.event.context == 'Review Policy'", cancel_expression)
+        self.assertIn("github.event.context == 'Review Policy Advisory'", cancel_expression)
+        self.assertIn("github.event.review.state == 'commented'", cancel_expression)
+
+    def test_workflow_publishes_pending_status_for_cancelled_evaluation(self):
+        workflow = load_workflow("review-policy.yml")
+        publish_job = workflow["jobs"]["publish-status"]
+        publish_step = publish_job["steps"][0]
+        script = publish_step["with"]["script"]
+
+        self.assertEqual(publish_job["if"], "always() && needs.evaluate.outputs.found == 'true'")
+        self.assertEqual(
+            publish_job["concurrency"]["group"],
+            "review-policy-publish-${{ needs.evaluate.outputs.head_sha }}",
         )
-
-        self.assertIn('exit 1', workflow)
-        self.assertIn("got base ref ${BASE_REF}.", workflow)
-        self.assertIn("ENFORCED: ${{ needs.evaluate.outputs.enforced || 'true' }}", workflow)
+        self.assertEqual(publish_step["env"]["EVALUATE_RESULT"], "${{ needs.evaluate.result }}")
+        self.assertIn("existingRunId > currentRunId", script)
+        self.assertIn("evaluationCancelled ? 'pending'", script)
+        self.assertIn(
+            "Review policy evaluation was cancelled; waiting for a fresh decision.",
+            script,
+        )
 
     def test_workflow_serializes_and_authorizes_label_sync(self):
-        workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(
-            encoding="utf-8"
+        workflow = load_workflow("review-policy.yml")
+        label_job = workflow["jobs"]["sync-label"]
+
+        self.assertEqual(
+            label_job["if"],
+            "always() && needs.evaluate.outputs.found == 'true' && needs.evaluate.result != 'cancelled'",
+        )
+        self.assertEqual(
+            label_job["concurrency"]["group"],
+            "review-policy-label-${{ needs.evaluate.outputs.head_sha }}",
+        )
+        self.assertEqual(label_job["permissions"], {"issues": "write", "pull-requests": "write"})
+
+    def test_workflow_keeps_fail_closed_non_cancelled_failures(self):
+        workflow_text = read_workflow("review-policy.yml")
+        workflow = load_workflow("review-policy.yml")
+        publish_env = workflow["jobs"]["publish-status"]["steps"][0]["env"]
+        classifier_step = next(
+            step
+            for step in workflow["jobs"]["evaluate"]["steps"]
+            if step.get("id") == "ai_classifier"
         )
 
-        self.assertIn("group: review-policy-label-${{ needs.evaluate.outputs.head_sha }}", workflow)
-        self.assertIn(
-            "    permissions:\n"
-            "      issues: write\n"
-            "      pull-requests: write\n",
-            workflow,
-        )
+        self.assertIn('exit 1', workflow_text)
+        self.assertIn("got base ref ${BASE_REF}.", workflow_text)
+        self.assertEqual(publish_env["DECISION"], "${{ needs.evaluate.outputs.decision || 'needs-human-review' }}")
+        self.assertEqual(publish_env["PASSED"], "${{ needs.evaluate.outputs.passed || 'false' }}")
+        self.assertEqual(publish_env["ENFORCED"], "${{ needs.evaluate.outputs.enforced || 'true' }}")
+        self.assertEqual(classifier_step["timeout-minutes"], 10)
 
     def test_path_matches_double_star_root_file(self):
         self.assertTrue(policy.path_matches("package.json", "**/package.json"))

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -11,6 +11,32 @@ import evaluate_review_policy as policy
 
 
 class ReviewPolicyTest(unittest.TestCase):
+    def test_workflow_publishes_only_completed_policy_decisions(self):
+        workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            "publishable: ${{ steps.evaluate_policy.outputs.publishable || "
+            "steps.bootstrap_policy.outputs.publishable || 'false' }}",
+            workflow,
+        )
+        self.assertEqual(workflow.count("needs.evaluate.outputs.publishable == 'true'"), 2)
+        self.assertEqual(workflow.count("needs.evaluate.result != 'cancelled'"), 2)
+
+    def test_workflow_serializes_and_authorizes_label_sync(self):
+        workflow = (Path(__file__).resolve().parents[1] / "workflows" / "review-policy.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("group: review-policy-label-${{ needs.evaluate.outputs.head_sha }}", workflow)
+        self.assertIn(
+            "    permissions:\n"
+            "      issues: write\n"
+            "      pull-requests: write\n",
+            workflow,
+        )
+
     def test_path_matches_double_star_root_file(self):
         self.assertTrue(policy.path_matches("package.json", "**/package.json"))
         self.assertTrue(policy.path_matches("client/package.json", "**/package.json"))

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -176,6 +176,17 @@ jobs:
     uses: ./.github/workflows/protoos-e2e-tests.yml
     secrets: inherit
 
+  review-policy-tests:
+    name: Review Policy Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run review policy tests
+        run: python3 .github/scripts/evaluate_review_policy_test.py
+
   gate:
     name: Gate
     runs-on: ubuntu-latest
@@ -201,6 +212,7 @@ jobs:
       - powershell-lint
       - protofleet-e2e-tests
       - protoos-e2e-tests
+      - review-policy-tests
     steps:
       - name: Evaluate gate
         env:

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -45,6 +45,7 @@ jobs:
       decision: ${{ steps.evaluate_policy.outputs.decision || steps.bootstrap_policy.outputs.decision || 'needs-human-review' }}
       passed: ${{ steps.evaluate_policy.outputs.passed || steps.bootstrap_policy.outputs.passed || 'false' }}
       enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}
+      publishable: ${{ steps.evaluate_policy.outputs.publishable || steps.bootstrap_policy.outputs.publishable || 'false' }}
     env:
       CODEX_MODEL: gpt-5.5
       CODEX_REASONING_EFFORT: high
@@ -190,6 +191,7 @@ jobs:
           echo "decision=needs-human-review" >> "$GITHUB_OUTPUT"
           echo "passed=false" >> "$GITHUB_OUTPUT"
           echo "enforced=false" >> "$GITHUB_OUTPUT"
+          echo "publishable=true" >> "$GITHUB_OUTPUT"
           {
             echo "## Review Policy"
             echo
@@ -410,6 +412,7 @@ jobs:
           echo "decision=${decision}" >> "$GITHUB_OUTPUT"
           echo "passed=${passed}" >> "$GITHUB_OUTPUT"
           echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"
+          echo "publishable=true" >> "$GITHUB_OUTPUT"
           exit "$status"
 
       - name: Skip non-PR event
@@ -419,7 +422,11 @@ jobs:
   publish-status:
     name: Publish Review Policy Status
     needs: evaluate
-    if: always() && needs.evaluate.outputs.found == 'true'
+    if: >-
+      always() &&
+      needs.evaluate.outputs.found == 'true' &&
+      needs.evaluate.outputs.publishable == 'true' &&
+      needs.evaluate.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -506,12 +513,19 @@ jobs:
   sync-label:
     name: Sync Label
     needs: evaluate
-    if: always() && needs.evaluate.outputs.found == 'true'
+    if: >-
+      always() &&
+      needs.evaluate.outputs.found == 'true' &&
+      needs.evaluate.outputs.publishable == 'true' &&
+      needs.evaluate.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: review-policy-label-${{ needs.evaluate.outputs.head_sha }}
+      cancel-in-progress: true
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Sync review policy label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -615,7 +629,7 @@ jobs:
               }
             } catch (error) {
               if (error.status === 403) {
-                core.info(`Unable to sync review policy label with this event token: ${error.message}`);
+                core.warning(`Unable to sync review policy label with this event token: ${error.message}`);
               } else {
                 core.warning(`Unable to sync review policy label: ${error.message}`);
               }

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -42,10 +42,9 @@ jobs:
       number: ${{ steps.pr.outputs.number }}
       base_sha: ${{ steps.pr.outputs.base_sha }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
-      decision: ${{ steps.evaluate_policy.outputs.decision || steps.fallback_policy.outputs.decision || 'needs-human-review' }}
-      passed: ${{ steps.evaluate_policy.outputs.passed || steps.fallback_policy.outputs.passed || 'false' }}
-      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.fallback_policy.outputs.enforced || 'true' }}
-      publishable: ${{ steps.evaluate_policy.outputs.publishable || steps.fallback_policy.outputs.publishable || 'false' }}
+      decision: ${{ steps.evaluate_policy.outputs.decision || steps.bootstrap_policy.outputs.decision || 'needs-human-review' }}
+      passed: ${{ steps.evaluate_policy.outputs.passed || steps.bootstrap_policy.outputs.passed || 'false' }}
+      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}
     env:
       CODEX_MODEL: gpt-5.5
       CODEX_REASONING_EFFORT: high
@@ -171,10 +170,8 @@ jobs:
           TRUSTED_BASE: ${{ steps.pr.outputs.trusted_base }}
         run: |
           if [ "$TRUSTED_BASE" != "true" ]; then
-            echo "Review policy only evaluates PRs based on the repository default branch; got base ref ${BASE_REF}."
-            echo "unsupported_base=true" >> "$GITHUB_OUTPUT"
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "Review policy only evaluates PRs based on the repository default branch; got base ref ${BASE_REF}." >&2
+            exit 1
           fi
           if [ ! -f .github/scripts/evaluate_review_policy.py ] || [ ! -f .github/review-policy.json ]; then
             echo "Trusted base commit does not contain review policy code and config; publishing a fail-closed bootstrap decision without executing PR-head policy code."
@@ -186,35 +183,21 @@ jobs:
           echo "path=$(pwd)" >> "$GITHUB_OUTPUT"
           echo "Using review policy code from the trusted base commit."
 
-      - name: Use fallback decision
-        id: fallback_policy
+      - name: Use bootstrap fallback decision
+        id: bootstrap_policy
         if: steps.pr.outputs.found == 'true' && steps.policy_source.outputs.available != 'true'
-        env:
-          BASE_REF: ${{ steps.pr.outputs.base_ref }}
-          UNSUPPORTED_BASE: ${{ steps.policy_source.outputs.unsupported_base }}
         run: |
-          if [ "$UNSUPPORTED_BASE" = "true" ]; then
-            enforced=true
-            mode=enforced
-            detail="Review Policy only evaluates PRs based on the repository default branch; got base ref \`${BASE_REF}\`."
-          else
-            enforced=false
-            mode=advisory
-            detail="Trusted base policy code is not available yet, so this bootstrap run did not execute PR-controlled policy code."
-          fi
-
           echo "decision=needs-human-review" >> "$GITHUB_OUTPUT"
           echo "passed=false" >> "$GITHUB_OUTPUT"
-          echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"
-          echo "publishable=true" >> "$GITHUB_OUTPUT"
+          echo "enforced=false" >> "$GITHUB_OUTPUT"
           {
             echo "## Review Policy"
             echo
             echo "**Decision:** \`needs-human-review\`"
             echo "**Status:** fail"
-            echo "**Mode:** ${mode}"
+            echo "**Mode:** advisory"
             echo
-            echo "${detail}"
+            echo "Trusted base policy code is not available yet, so this bootstrap run did not execute PR-controlled policy code."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run deterministic low-risk preflight
@@ -427,7 +410,6 @@ jobs:
           echo "decision=${decision}" >> "$GITHUB_OUTPUT"
           echo "passed=${passed}" >> "$GITHUB_OUTPUT"
           echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"
-          echo "publishable=true" >> "$GITHUB_OUTPUT"
           exit "$status"
 
       - name: Skip non-PR event
@@ -440,7 +422,6 @@ jobs:
     if: >-
       always() &&
       needs.evaluate.outputs.found == 'true' &&
-      needs.evaluate.outputs.publishable == 'true' &&
       needs.evaluate.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -531,7 +512,6 @@ jobs:
     if: >-
       always() &&
       needs.evaluate.outputs.found == 'true' &&
-      needs.evaluate.outputs.publishable == 'true' &&
       needs.evaluate.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -42,10 +42,10 @@ jobs:
       number: ${{ steps.pr.outputs.number }}
       base_sha: ${{ steps.pr.outputs.base_sha }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
-      decision: ${{ steps.evaluate_policy.outputs.decision || steps.bootstrap_policy.outputs.decision || 'needs-human-review' }}
-      passed: ${{ steps.evaluate_policy.outputs.passed || steps.bootstrap_policy.outputs.passed || 'false' }}
-      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}
-      publishable: ${{ steps.evaluate_policy.outputs.publishable || steps.bootstrap_policy.outputs.publishable || 'false' }}
+      decision: ${{ steps.evaluate_policy.outputs.decision || steps.unsupported_base_policy.outputs.decision || steps.bootstrap_policy.outputs.decision || 'needs-human-review' }}
+      passed: ${{ steps.evaluate_policy.outputs.passed || steps.unsupported_base_policy.outputs.passed || steps.bootstrap_policy.outputs.passed || 'false' }}
+      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.unsupported_base_policy.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}
+      publishable: ${{ steps.evaluate_policy.outputs.publishable || steps.unsupported_base_policy.outputs.publishable || steps.bootstrap_policy.outputs.publishable || 'false' }}
     env:
       CODEX_MODEL: gpt-5.5
       CODEX_REASONING_EFFORT: high
@@ -171,8 +171,10 @@ jobs:
           TRUSTED_BASE: ${{ steps.pr.outputs.trusted_base }}
         run: |
           if [ "$TRUSTED_BASE" != "true" ]; then
-            echo "Review policy only evaluates PRs based on the repository default branch; got base ref ${BASE_REF}." >&2
-            exit 1
+            echo "Review policy only evaluates PRs based on the repository default branch; got base ref ${BASE_REF}."
+            echo "unsupported_base=true" >> "$GITHUB_OUTPUT"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           if [ ! -f .github/scripts/evaluate_review_policy.py ] || [ ! -f .github/review-policy.json ]; then
             echo "Trusted base commit does not contain review policy code and config; publishing a fail-closed bootstrap decision without executing PR-head policy code."
@@ -184,9 +186,32 @@ jobs:
           echo "path=$(pwd)" >> "$GITHUB_OUTPUT"
           echo "Using review policy code from the trusted base commit."
 
+      - name: Use unsupported base decision
+        id: unsupported_base_policy
+        if: steps.pr.outputs.found == 'true' && steps.policy_source.outputs.unsupported_base == 'true'
+        env:
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        run: |
+          echo "decision=needs-human-review" >> "$GITHUB_OUTPUT"
+          echo "passed=false" >> "$GITHUB_OUTPUT"
+          echo "enforced=true" >> "$GITHUB_OUTPUT"
+          echo "publishable=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Review Policy"
+            echo
+            echo "**Decision:** \`needs-human-review\`"
+            echo "**Status:** fail"
+            echo "**Mode:** enforced"
+            echo
+            echo "Review Policy only evaluates PRs based on the repository default branch; got base ref \`${BASE_REF}\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Use bootstrap fallback decision
         id: bootstrap_policy
-        if: steps.pr.outputs.found == 'true' && steps.policy_source.outputs.available != 'true'
+        if: >-
+          steps.pr.outputs.found == 'true' &&
+          steps.policy_source.outputs.available != 'true' &&
+          steps.policy_source.outputs.unsupported_base != 'true'
         run: |
           echo "decision=needs-human-review" >> "$GITHUB_OUTPUT"
           echo "passed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -42,10 +42,10 @@ jobs:
       number: ${{ steps.pr.outputs.number }}
       base_sha: ${{ steps.pr.outputs.base_sha }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
-      decision: ${{ steps.evaluate_policy.outputs.decision || steps.unsupported_base_policy.outputs.decision || steps.bootstrap_policy.outputs.decision || 'needs-human-review' }}
-      passed: ${{ steps.evaluate_policy.outputs.passed || steps.unsupported_base_policy.outputs.passed || steps.bootstrap_policy.outputs.passed || 'false' }}
-      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.unsupported_base_policy.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}
-      publishable: ${{ steps.evaluate_policy.outputs.publishable || steps.unsupported_base_policy.outputs.publishable || steps.bootstrap_policy.outputs.publishable || 'false' }}
+      decision: ${{ steps.evaluate_policy.outputs.decision || steps.fallback_policy.outputs.decision || 'needs-human-review' }}
+      passed: ${{ steps.evaluate_policy.outputs.passed || steps.fallback_policy.outputs.passed || 'false' }}
+      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.fallback_policy.outputs.enforced || 'true' }}
+      publishable: ${{ steps.evaluate_policy.outputs.publishable || steps.fallback_policy.outputs.publishable || 'false' }}
     env:
       CODEX_MODEL: gpt-5.5
       CODEX_REASONING_EFFORT: high
@@ -186,45 +186,35 @@ jobs:
           echo "path=$(pwd)" >> "$GITHUB_OUTPUT"
           echo "Using review policy code from the trusted base commit."
 
-      - name: Use unsupported base decision
-        id: unsupported_base_policy
-        if: steps.pr.outputs.found == 'true' && steps.policy_source.outputs.unsupported_base == 'true'
+      - name: Use fallback decision
+        id: fallback_policy
+        if: steps.pr.outputs.found == 'true' && steps.policy_source.outputs.available != 'true'
         env:
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          UNSUPPORTED_BASE: ${{ steps.policy_source.outputs.unsupported_base }}
         run: |
-          echo "decision=needs-human-review" >> "$GITHUB_OUTPUT"
-          echo "passed=false" >> "$GITHUB_OUTPUT"
-          echo "enforced=true" >> "$GITHUB_OUTPUT"
-          echo "publishable=true" >> "$GITHUB_OUTPUT"
-          {
-            echo "## Review Policy"
-            echo
-            echo "**Decision:** \`needs-human-review\`"
-            echo "**Status:** fail"
-            echo "**Mode:** enforced"
-            echo
-            echo "Review Policy only evaluates PRs based on the repository default branch; got base ref \`${BASE_REF}\`."
-          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$UNSUPPORTED_BASE" = "true" ]; then
+            enforced=true
+            mode=enforced
+            detail="Review Policy only evaluates PRs based on the repository default branch; got base ref \`${BASE_REF}\`."
+          else
+            enforced=false
+            mode=advisory
+            detail="Trusted base policy code is not available yet, so this bootstrap run did not execute PR-controlled policy code."
+          fi
 
-      - name: Use bootstrap fallback decision
-        id: bootstrap_policy
-        if: >-
-          steps.pr.outputs.found == 'true' &&
-          steps.policy_source.outputs.available != 'true' &&
-          steps.policy_source.outputs.unsupported_base != 'true'
-        run: |
           echo "decision=needs-human-review" >> "$GITHUB_OUTPUT"
           echo "passed=false" >> "$GITHUB_OUTPUT"
-          echo "enforced=false" >> "$GITHUB_OUTPUT"
+          echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"
           echo "publishable=true" >> "$GITHUB_OUTPUT"
           {
             echo "## Review Policy"
             echo
             echo "**Decision:** \`needs-human-review\`"
             echo "**Status:** fail"
-            echo "**Mode:** advisory"
+            echo "**Mode:** ${mode}"
             echo
-            echo "Trusted base policy code is not available yet, so this bootstrap run did not execute PR-controlled policy code."
+            echo "${detail}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run deterministic low-risk preflight

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -16,7 +16,17 @@ on: # zizmor: ignore[dangerous-triggers] review policy runs from trusted workflo
 
 concurrency:
   group: review-policy-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.event.check_run.head_sha || github.event.check_suite.head_sha || github.event.sha || github.sha || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: >-
+    ${{
+      !(
+        (github.event_name == 'check_run' && github.event.check_run.app.slug == 'github-actions') ||
+        (github.event_name == 'check_run' && github.event.action == 'rerequested') ||
+        (github.event_name == 'check_suite' && github.event.check_suite.app.slug == 'github-actions') ||
+        (github.event_name == 'check_suite' && github.event.action == 'rerequested') ||
+        (github.event_name == 'status' && (github.event.context == 'Review Policy' || github.event.context == 'Review Policy Advisory')) ||
+        (github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.state == 'commented')
+      )
+    }}
 
 permissions:
   actions: read
@@ -273,6 +283,7 @@ jobs:
           steps.pr.outputs.same_repo == 'true' &&
           steps.preflight.outputs.eligible == 'true'
         continue-on-error: true
+        timeout-minutes: 10
         uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1.8
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -421,8 +432,7 @@ jobs:
     needs: evaluate
     if: >-
       always() &&
-      needs.evaluate.outputs.found == 'true' &&
-      needs.evaluate.result != 'cancelled'
+      needs.evaluate.outputs.found == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -441,12 +451,14 @@ jobs:
           DECISION: ${{ needs.evaluate.outputs.decision || 'needs-human-review' }}
           PASSED: ${{ needs.evaluate.outputs.passed || 'false' }}
           ENFORCED: ${{ needs.evaluate.outputs.enforced || 'true' }}
+          EVALUATE_RESULT: ${{ needs.evaluate.result }}
           TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
             const decision = process.env.DECISION || 'needs-human-review';
             const passed = process.env.PASSED === 'true';
             const enforced = process.env.ENFORCED !== 'false';
+            const evaluationCancelled = process.env.EVALUATE_RESULT === 'cancelled';
             const issue_number = Number(process.env.PR_NUMBER);
             const baseSha = process.env.BASE_SHA;
             const headSha = process.env.HEAD_SHA;
@@ -456,6 +468,9 @@ jobs:
               'human-approved': 'Current authorized human approval satisfies policy.',
               'needs-human-review': 'Human review is required before merge.',
             };
+            const description = evaluationCancelled
+              ? 'Review policy evaluation was cancelled; waiting for a fresh decision.'
+              : (descriptions[decision] || `Review policy decision: ${decision}`);
             if (!Number.isInteger(issue_number) || issue_number <= 0) {
               core.setFailed(`Invalid pull request number for review policy status: ${process.env.PR_NUMBER}`);
               return;
@@ -500,9 +515,9 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: headSha,
-              state: passed || !enforced ? 'success' : 'failure',
+              state: evaluationCancelled ? 'pending' : (passed || !enforced ? 'success' : 'failure'),
               context: statusContext,
-              description: descriptions[decision] || `Review policy decision: ${decision}`,
+              description,
               target_url: process.env.TARGET_URL,
             });
 

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -15,7 +15,19 @@ on: # zizmor: ignore[dangerous-triggers] review policy runs from trusted workflo
   status:
 
 concurrency:
-  group: review-policy-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.event.check_run.head_sha || github.event.check_suite.head_sha || github.event.sha || github.sha || github.run_id }}
+  group: >-
+    review-policy-${{
+      (
+        (github.event_name == 'check_run' && github.event.check_run.app.slug == 'github-actions') ||
+        (github.event_name == 'check_run' && github.event.action == 'rerequested') ||
+        (github.event_name == 'check_suite' && github.event.check_suite.app.slug == 'github-actions') ||
+        (github.event_name == 'check_suite' && github.event.action == 'rerequested') ||
+        (github.event_name == 'status' && (github.event.context == 'Review Policy' || github.event.context == 'Review Policy Advisory')) ||
+        (github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.state == 'commented')
+      ) &&
+      format('ignored-{0}', github.run_id) ||
+      (github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.event.check_run.head_sha || github.event.check_suite.head_sha || github.event.sha || github.sha || github.run_id)
+    }}
   cancel-in-progress: >-
     ${{
       !(


### PR DESCRIPTION
Reviewable diff: +56/-8 across 2 files (excludes generated, test, and story files).

## Summary

Review Policy now avoids stale or misleading side effects without reopening the stale-green hole. Ignored/no-op events use their own per-run concurrency group, so they cannot cancel or replace queued meaningful evaluations for the same head SHA; real policy evaluations still serialize by head SHA. Cancelled evaluations publish a pending Review Policy status instead of a red fallback failure, non-cancelled evaluation failures still fail closed, PR label sync remains serialized per head SHA with the permission GitHub requires, and the workflow regression tests now run in PR Gate.

## How it works

The workflow distinguishes meaningful policy events from ignored/no-op triggers at the workflow concurrency layer. Meaningful events such as review dismissals, PR edits, workflow completions, and external status/check completions continue to use the PR head SHA as their concurrency group. Ignored events, such as GitHub Actions check events, managed Review Policy status events, rerequested check events, and comment-only review submissions, use `github.run_id` in a per-run group so they cannot replace a pending meaningful evaluation under GitHub's default single-pending-run concurrency behavior.

When an evaluation resolves a PR but is cancelled, the status publisher still runs behind the stale-head and newer-run guards and writes `Review Policy` as `pending`. That blocks a future required status check without showing a false policy failure. Normal evaluator failures keep the existing fail-closed defaults: `needs-human-review`, `passed=false`, and `enforced=true`.

The AI classifier step has its own timeout, so a hung classifier becomes a normal `continue-on-error` failure that flows through the existing fail-closed fallback instead of cancelling the whole evaluate job. Label sync still skips cancelled evaluations, serializes by head SHA, and keeps exactly one managed Review Policy label.

## Diagrams

```mermaid
flowchart TD
  A["Review Policy event"] --> B{"Ignored/no-op event"}
  B --> C["Use per-run concurrency group"]
  B --> D["Use head-SHA concurrency group"]
  C --> E["Skip evaluation without replacing queued policy runs"]
  D --> F["Resolve PR and head SHA"]
  F --> G{"Evaluate cancelled"}
  G --> H["Publish pending Review Policy status"]
  G --> I["Use evaluator outputs or fail-closed defaults"]
  I --> J["Publish success or failure for current head"]
  J --> K["Sync one managed PR label"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/review-policy.yml` | Routes ignored/no-op events to a per-run concurrency group, keeps real evaluations serialized by head SHA, bounds the AI classifier step, publishes pending status for cancelled evaluations, and keeps label sync skipped on cancellation. | This is the production workflow behavior that prevents stale green statuses and confusing red failures while preserving fail-closed behavior for real evaluation failures. |
| `.github/workflows/pr-gate.yml` | Adds a Review Policy Tests job and includes it in the Gate dependency list. | Ensures workflow regression guards run in CI instead of only locally. |
| `.github/scripts/evaluate_review_policy_test.py` | Adds structural workflow assertions for PR Gate wiring, ignored-event concurrency behavior, publish/label job conditions, permissions, and classifier timeout. | Test file — protects the YAML guardrails that caused the observed #716/#717 confusion and later stale-status review feedback. |

## Key technical decisions & trade-offs

- Give ignored events unique per-run concurrency groups instead of `queue: max`, preserving stale-run cancellation for real same-head policy evaluations.
- Publish `pending` for cancelled evaluations instead of skipping status publishing entirely, so required checks block without showing a false policy failure.
- Keep label sync skipped for cancelled evaluations, since labels are advisory PR metadata and should only reflect completed decisions.
- Add a step-level classifier timeout so hung AI calls fail closed through the normal fallback path.
- Parse workflow YAML in tests with Ruby stdlib YAML from Python, avoiding a new PyYAML dependency while making assertions structural instead of string-count based.

## Testing & validation

- `python3 .github/scripts/evaluate_review_policy_test.py`
- `ruby -ryaml -e 'data=YAML.load_file(%q(.github/workflows/review-policy.yml)); puts data.fetch(%q(concurrency)).fetch(%q(group)); puts data.fetch(%q(concurrency)).fetch(%q(cancel-in-progress))'`
- `ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path); puts "parsed #{path}" }' .github/workflows/review-policy.yml .github/workflows/pr-gate.yml`
- `git diff --check`

Not covered: the updated PR Gate job and Review Policy workflow still need to complete in GitHub Actions on this pushed commit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
