### PR TITLE
fix(client): refresh setup card after unpair

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx
@@ -10,6 +10,7 @@ const {
   mockRefetchErrors,
   mockListAllBuildings,
   mockUseHasPermission,
+  mockNotifyMinersChanged,
   mockFleetOutletContext,
 } = vi.hoisted(() => ({
   mockMinerList: vi.fn(() => <div data-testid="miner-list">MinerList</div>),
@@ -17,6 +18,7 @@ const {
   mockRefetchErrors: vi.fn(),
   mockListAllBuildings: vi.fn(),
   mockUseHasPermission: vi.fn((_permission: string) => true),
+  mockNotifyMinersChanged: vi.fn(),
   mockFleetOutletContext: {
     sites: [],
     sitesError: null,
@@ -24,6 +26,7 @@ const {
     siteCatalogAccessGranted: true,
     refetchSites: vi.fn(),
     notifyPairingCompleted: vi.fn(),
+    notifyMinersChanged: vi.fn(),
     minersChangedAt: 0,
     publishViewFilterContext: vi.fn(),
   },
@@ -147,6 +150,7 @@ describe("Fleet - Polling", () => {
       sitesError: null,
       sitesLoaded: true,
       siteCatalogAccessGranted: true,
+      notifyMinersChanged: mockNotifyMinersChanged,
       minersChangedAt: 0,
     });
 
@@ -312,6 +316,28 @@ describe("Fleet - Component Integration", () => {
     expect(mockRefreshCurrentPage).toHaveBeenCalledTimes(1);
     expect(mockRefetchErrors).toHaveBeenCalledTimes(1);
     expect(mockRefetchAuthNeededMiners).toHaveBeenCalledTimes(1);
+    expect(mockRefetch).not.toHaveBeenCalled();
+  });
+
+  it("passes a miner refresh callback that pulses FleetLayout miner changes", async () => {
+    const useFleetModule = await import("@/protoFleet/api/useFleet");
+    const mockRefetch = vi.fn();
+
+    vi.mocked(useFleetModule.default).mockReturnValue(
+      createFleetMock({
+        minerIds: ["miner-1"],
+        totalMiners: 1,
+        refetch: mockRefetch,
+      }),
+    );
+
+    renderFleet();
+
+    const minerListCalls = mockMinerList.mock.calls as unknown as Array<[{ onRefetchMiners: () => void }]>;
+    const latestMinerListProps = minerListCalls[minerListCalls.length - 1][0];
+    latestMinerListProps.onRefetchMiners();
+
+    expect(mockNotifyMinersChanged).toHaveBeenCalledTimes(1);
     expect(mockRefetch).not.toHaveBeenCalled();
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx
@@ -92,8 +92,14 @@ const Fleet = () => {
   const { listAllBuildings } = useBuildings();
   const [availableGroups, setAvailableGroups] = useState<DeviceSet[]>([]);
   const [availableRacks, setAvailableRacks] = useState<DeviceSet[]>([]);
-  const { sites, siteCatalogAccessGranted, notifyPairingCompleted, minersChangedAt, publishViewFilterContext } =
-    useFleetOutletContext();
+  const {
+    sites,
+    siteCatalogAccessGranted,
+    notifyPairingCompleted,
+    notifyMinersChanged,
+    minersChangedAt,
+    publishViewFilterContext,
+  } = useFleetOutletContext();
   // Validate scope against catalog *access* (authoritative now), not
   // sitesLoaded — a mid-session PermissionDenied clears `sites` to [] while
   // sitesLoaded stays true, which would otherwise strip a reachable scoped
@@ -398,7 +404,7 @@ const Fleet = () => {
           currentSortConfig={currentSortConfig}
           onExportCsv={siteScopeMatchesNoRows ? () => undefined : exportCsv}
           exportCsvLoading={siteScopeMatchesNoRows ? false : isExportingCsv}
-          onRefetchMiners={refetchAll}
+          onRefetchMiners={notifyMinersChanged}
           onRefreshMinersComplete={refreshVisibleRows}
           onWorkerNameUpdated={updateMinerWorkerName}
           onMergeMiners={mergeMiners}

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/FleetLayout.tsx
@@ -226,6 +226,7 @@ const FleetLayout = () => {
       siteCatalogAccessGranted,
       refetchSites,
       notifyPairingCompleted,
+      notifyMinersChanged,
       minersChangedAt,
       publishViewFilterContext,
     }),
@@ -236,6 +237,7 @@ const FleetLayout = () => {
       siteCatalogAccessGranted,
       refetchSites,
       notifyPairingCompleted,
+      notifyMinersChanged,
       minersChangedAt,
       publishViewFilterContext,
     ],
@@ -281,6 +283,7 @@ const FleetLayout = () => {
         {canReadMiners ? (
           <CompleteSetup
             lastPairingCompletedAt={lastPairingCompletedAt}
+            minersChangedAt={minersChangedAt}
             onPairingCompleted={notifyPairingCompleted}
             onRefetchMiners={notifyMinersChanged}
           />

--- a/client/src/protoFleet/features/fleetManagement/components/FleetLayout/outletContext.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetLayout/outletContext.ts
@@ -16,13 +16,12 @@ export interface FleetOutletContext {
   // server-side authz changes that still deny the catalog RPC after UI gating.
   siteCatalogAccessGranted: boolean;
   refetchSites: () => void;
-  // Pairing coordination between the Miners tab and the chrome-level
-  // CompleteSetup banner. Miners → CompleteSetup: call `notifyPairingCompleted`
-  // when pairing finishes so the banner's pool/auth probes refresh. Bumps
-  // `minersChangedAt`: CompleteSetup → Miners signal for when an in-banner
-  // flow (e.g. pool assignment) wants the miner list to refetch immediately
-  // instead of waiting for the next poll tick.
+  // Coordination between the Miners tab and the chrome-level CompleteSetup
+  // banner. `notifyPairingCompleted` starts CompleteSetup's post-pairing poll.
+  // `notifyMinersChanged` bumps `minersChangedAt` so every consumer with its
+  // own fleet probes can refetch immediately after membership/status changes.
   notifyPairingCompleted: () => void;
+  notifyMinersChanged: () => void;
   minersChangedAt: number;
   /**
    * Child tabs publish their filter metadata up to FleetLayout so the

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.test.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.test.tsx
@@ -100,11 +100,14 @@ beforeEach(async () => {
 });
 
 describe("CompleteSetup", () => {
-  const renderCompleteSetup = (props: { lastPairingCompletedAt?: number; onRefetchMiners?: () => void } = {}) => {
+  const renderCompleteSetup = (
+    props: { lastPairingCompletedAt?: number; minersChangedAt?: number; onRefetchMiners?: () => void } = {},
+  ) => {
     return render(
       <MemoryRouter>
         <CompleteSetup
           lastPairingCompletedAt={props.lastPairingCompletedAt}
+          minersChangedAt={props.minersChangedAt}
           onRefetchMiners={props.onRefetchMiners ?? mockRefetchMiners}
         />
       </MemoryRouter>,
@@ -577,6 +580,26 @@ describe("CompleteSetup", () => {
       renderCompleteSetup();
 
       expect(screen.queryByText("Authenticate miners")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Miner change refresh", () => {
+    it("refetches setup counts when fleet miners change", async () => {
+      const { rerender } = renderCompleteSetup({ minersChangedAt: 0 });
+
+      mockRefetchAuthNeededMiners.mockClear();
+      mockRefetchPoolNeededCount.mockClear();
+
+      rerender(
+        <MemoryRouter>
+          <CompleteSetup minersChangedAt={123} onRefetchMiners={mockRefetchMiners} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(mockRefetchAuthNeededMiners).toHaveBeenCalledTimes(1);
+        expect(mockRefetchPoolNeededCount).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.test.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.test.tsx
@@ -601,6 +601,30 @@ describe("CompleteSetup", () => {
         expect(mockRefetchPoolNeededCount).toHaveBeenCalledTimes(1);
       });
     });
+
+    it("does not refetch setup counts when complete setup is dismissed", async () => {
+      const { useReactiveLocalStorage } = await import("@/shared/hooks/useReactiveLocalStorage");
+      vi.mocked(useReactiveLocalStorage).mockImplementation((key: string) => {
+        if (key === "completeSetupDismissed") {
+          return [true, vi.fn()];
+        }
+        return [false, vi.fn()];
+      });
+
+      const { rerender } = renderCompleteSetup({ minersChangedAt: 0 });
+
+      mockRefetchAuthNeededMiners.mockClear();
+      mockRefetchPoolNeededCount.mockClear();
+
+      rerender(
+        <MemoryRouter>
+          <CompleteSetup minersChangedAt={123} onRefetchMiners={mockRefetchMiners} />
+        </MemoryRouter>,
+      );
+
+      expect(mockRefetchAuthNeededMiners).not.toHaveBeenCalled();
+      expect(mockRefetchPoolNeededCount).not.toHaveBeenCalled();
+    });
   });
 
   describe("Polling after pairing completion", () => {

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.test.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.test.tsx
@@ -625,6 +625,42 @@ describe("CompleteSetup", () => {
       expect(mockRefetchAuthNeededMiners).not.toHaveBeenCalled();
       expect(mockRefetchPoolNeededCount).not.toHaveBeenCalled();
     });
+
+    it("waits to handle miner changes while pool count is loading", async () => {
+      let isLoadingPoolNeeded = true;
+      vi.mocked(usePoolNeededCount).mockImplementation(() => ({
+        poolNeededCount: 0,
+        isLoading: isLoadingPoolNeeded,
+        hasInitialLoadCompleted: !isLoadingPoolNeeded,
+        refetch: mockRefetchPoolNeededCount,
+      }));
+
+      const { rerender } = renderCompleteSetup({ minersChangedAt: 0 });
+
+      mockRefetchAuthNeededMiners.mockClear();
+      mockRefetchPoolNeededCount.mockClear();
+
+      rerender(
+        <MemoryRouter>
+          <CompleteSetup minersChangedAt={123} onRefetchMiners={mockRefetchMiners} />
+        </MemoryRouter>,
+      );
+
+      expect(mockRefetchAuthNeededMiners).not.toHaveBeenCalled();
+      expect(mockRefetchPoolNeededCount).not.toHaveBeenCalled();
+
+      isLoadingPoolNeeded = false;
+      rerender(
+        <MemoryRouter>
+          <CompleteSetup minersChangedAt={123} onRefetchMiners={mockRefetchMiners} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(mockRefetchAuthNeededMiners).toHaveBeenCalledTimes(1);
+        expect(mockRefetchPoolNeededCount).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe("Polling after pairing completion", () => {

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
@@ -166,12 +166,14 @@ const CompleteSetup = ({
 
   const lastHandledMinersChangedAtRef = useRef(0);
   useEffect(() => {
-    if (minersChangedAt <= 0 || minersChangedAt === lastHandledMinersChangedAtRef.current) return;
+    if (completSetupDismissed || minersChangedAt <= 0 || minersChangedAt === lastHandledMinersChangedAtRef.current) {
+      return;
+    }
 
     lastHandledMinersChangedAtRef.current = minersChangedAt;
     refetchAuthNeededMiners();
     refetchPoolNeededCount();
-  }, [minersChangedAt, refetchAuthNeededMiners, refetchPoolNeededCount]);
+  }, [completSetupDismissed, minersChangedAt, refetchAuthNeededMiners, refetchPoolNeededCount]);
 
   // Get streaming command batch updates
   const { streamCommandBatchUpdates } = useMinerCommand();

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
@@ -130,6 +130,7 @@ const ConfigurePoolCard = ({
 type CompleteSetupProps = {
   className?: string;
   lastPairingCompletedAt?: number;
+  minersChangedAt?: number;
   onRefetchMiners?: () => void;
   onPairingCompleted?: () => void;
 };
@@ -137,6 +138,7 @@ type CompleteSetupProps = {
 const CompleteSetup = ({
   className = "",
   lastPairingCompletedAt: externalPairingTimestamp = 0,
+  minersChangedAt = 0,
   onRefetchMiners,
   onPairingCompleted: externalOnPairingCompleted,
 }: CompleteSetupProps) => {
@@ -161,6 +163,15 @@ const CompleteSetup = ({
 
   // Fetch count of miners needing pool configuration
   const { poolNeededCount, isLoading: isLoadingPoolNeeded, refetch: refetchPoolNeededCount } = usePoolNeededCount();
+
+  const lastHandledMinersChangedAtRef = useRef(0);
+  useEffect(() => {
+    if (minersChangedAt <= 0 || minersChangedAt === lastHandledMinersChangedAtRef.current) return;
+
+    lastHandledMinersChangedAtRef.current = minersChangedAt;
+    refetchAuthNeededMiners();
+    refetchPoolNeededCount();
+  }, [minersChangedAt, refetchAuthNeededMiners, refetchPoolNeededCount]);
 
   // Get streaming command batch updates
   const { streamCommandBatchUpdates } = useMinerCommand();

--- a/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
+++ b/client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx
@@ -166,14 +166,19 @@ const CompleteSetup = ({
 
   const lastHandledMinersChangedAtRef = useRef(0);
   useEffect(() => {
-    if (completSetupDismissed || minersChangedAt <= 0 || minersChangedAt === lastHandledMinersChangedAtRef.current) {
+    if (
+      completSetupDismissed ||
+      isLoadingPoolNeeded ||
+      minersChangedAt <= 0 ||
+      minersChangedAt === lastHandledMinersChangedAtRef.current
+    ) {
       return;
     }
 
     lastHandledMinersChangedAtRef.current = minersChangedAt;
     refetchAuthNeededMiners();
     refetchPoolNeededCount();
-  }, [completSetupDismissed, minersChangedAt, refetchAuthNeededMiners, refetchPoolNeededCount]);
+  }, [completSetupDismissed, isLoadingPoolNeeded, minersChangedAt, refetchAuthNeededMiners, refetchPoolNeededCount]);
 
   // Get streaming command batch updates
   const { streamCommandBatchUpdates } = useMinerCommand();


### PR DESCRIPTION
Reviewable diff: +28/-9 across 4 files (excludes generated, test, and story files).

## Summary
After all miners are unpaired, the Fleet complete-setup banner now refreshes the same way the miner table does, so stale “Authenticate miners” or pool setup tasks clear instead of lingering. The fix reuses FleetLayout’s existing refresh coordination so membership changes notify both the Miners tab and the chrome-level CompleteSetup probes. Fixes #514.

## How it works
Unpair actions still call the MinerList refresh callback after the server-side change completes. Fleet now routes that callback through FleetLayout’s miner-change pulse instead of directly refetching only the table. Fleet continues to observe that pulse for table refreshes, while CompleteSetup now also observes it and refetches its auth-needed and pool-needed counts immediately.

## Diagrams
```mermaid
flowchart LR
  A["Unpair miner action"] --> B["MinerList refresh callback"]
  B --> C["FleetLayout miner-change pulse"]
  C --> D["Fleet table refetch"]
  C --> E["CompleteSetup auth probe refetch"]
  C --> F["CompleteSetup pool probe refetch"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/fleetManagement/components/FleetLayout/` | Exposes `notifyMinersChanged` through outlet context and passes `minersChangedAt` to CompleteSetup. | Makes the layout-owned refresh pulse available to both the tab content and banner. |
| `client/src/protoFleet/features/fleetManagement/components/Fleet/Fleet.tsx` | Sends MinerList refresh requests through the shared miner-change pulse. | Keeps table refresh behavior while letting other fleet probes react to the same membership change. |
| `client/src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.tsx` | Refetches auth-needed miners and pool-needed count when `minersChangedAt` changes. | Clears stale setup cards after unpair and other miner membership/status changes. |
| `client/src/protoFleet/features/**/*.test.tsx` | Adds focused coverage for the Fleet pulse and CompleteSetup probe refresh. | Verifies the issue path without broad UI or API mocking changes. |

## Key technical decisions & trade-offs
- Reused the existing FleetLayout timestamp pulse instead of adding a new event bus or wiring CompleteSetup into MinerList internals.
- Kept Fleet’s table refetch indirect through `minersChangedAt`, so one callback now refreshes every consumer that owns fleet-derived probes.
- Scoped CompleteSetup refreshes to miner-change pulses only; no backend API, persistence, or generated-code changes are involved.

## Testing & validation
- `npm exec -- vitest run src/protoFleet/features/onboarding/components/CompleteSetup/CompleteSetup.test.tsx src/protoFleet/features/fleetManagement/components/Fleet/Fleet.test.tsx`
- `git diff --check`
- `source ./bin/activate-hermit && just lint`
