### PR TITLE
fix(ci): allow security review PR comments

### DIFF
--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -47,6 +47,16 @@ class ReviewPolicyTest(unittest.TestCase):
             "python3 .github/scripts/evaluate_review_policy_test.py",
         )
 
+    def test_codex_security_review_can_write_pr_comments(self):
+        workflow = load_workflow("codex-security-review.yml")
+        post_review = workflow["jobs"]["post-review"]
+        script = post_review["steps"][1]["with"]["script"]
+
+        self.assertEqual(post_review["permissions"]["issues"], "write")
+        self.assertEqual(post_review["permissions"]["pull-requests"], "write")
+        self.assertIn("github.rest.issues.createComment", script)
+        self.assertIn("github.rest.issues.updateComment", script)
+
     def test_workflow_ignored_events_do_not_cancel_active_evaluations(self):
         workflow = load_workflow("review-policy.yml")
         group_expression = workflow["concurrency"]["group"]

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -47,16 +47,6 @@ class ReviewPolicyTest(unittest.TestCase):
             "python3 .github/scripts/evaluate_review_policy_test.py",
         )
 
-    def test_codex_security_review_can_write_pr_comments(self):
-        workflow = load_workflow("codex-security-review.yml")
-        post_review = workflow["jobs"]["post-review"]
-        script = post_review["steps"][1]["with"]["script"]
-
-        self.assertEqual(post_review["permissions"]["issues"], "write")
-        self.assertEqual(post_review["permissions"]["pull-requests"], "write")
-        self.assertIn("github.rest.issues.createComment", script)
-        self.assertIn("github.rest.issues.updateComment", script)
-
     def test_workflow_ignored_events_do_not_cancel_active_evaluations(self):
         workflow = load_workflow("review-policy.yml")
         group_expression = workflow["concurrency"]["group"]

--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -240,7 +240,7 @@ jobs:
     permissions:
       actions: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     env:
       CODEX_MODEL: gpt-5.5
       REVIEW_COMMIT_RANGE: ${{ format('{0}...{1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) }}


### PR DESCRIPTION
Reviewable diff: +1/-1 across 1 files (excludes generated, test, and story files).

## Summary

The automated security review can now post its PR summary comment on same-repository pull requests. The post-review job already had issue-comment write permission, but GitHub rejected the PR issue-comment create call, so this grants the Pull Requests write permission that GitHub also accepts for that endpoint.

## How it works

The security review job still generates and uploads the review artifacts as before. The post-review job downloads the markdown artifact, checks that the PR head still matches the reviewed SHA, then creates or updates the marker comment on the PR. This change only expands that posting job's token from `pull-requests: read` to `pull-requests: write`; it does not change the review scope, artifact generation, or fork guard.

## Diagrams

```mermaid
flowchart TD
  A["Security review finishes"] --> B["Upload review markdown"]
  B --> C["Post-review job downloads markdown"]
  C --> D["Verify PR head SHA still matches"]
  D --> E["Create or update marker PR comment"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/codex-security-review.yml` | Grants `pull-requests: write` to the post-review job. | Lets the workflow create/update PR issue comments when GitHub rejects the endpoint with only Issues write. |

## Key technical decisions & trade-offs

- Add `pull-requests: write` instead of replacing `issues: write`, because GitHub documents either permission set for issue comments and the workflow uses issue-comment list/update/create APIs.
- Keep the permission scoped to the post-review job rather than the whole workflow.

## Testing & validation

- Existing workflow regression suite passed locally.
- YAML parse check passed for the affected workflow set.
- `git diff --check`

Not covered: the next GitHub Actions run must verify that GitHub now allows the PR comment create/update call.
