### PR TITLE
fix(ui): allow scrolling back through Server Logs and Miner Logs

### DIFF
--- a/client/src/protoFleet/features/serverLogs/pages/ServerLogsPage.tsx
+++ b/client/src/protoFleet/features/serverLogs/pages/ServerLogsPage.tsx
@@ -126,7 +126,7 @@ const ServerLogsPage = () => {
           testId="server-logs-export-error"
         />
       ) : null}
-      <Logs logsData={logsData} fetchMaxLogs={fetchMaxLogs} downloadFilename="server-logs" />
+      <Logs logsData={logsData} fetchMaxLogs={fetchMaxLogs} downloadFilename="server-logs" scrollMode="container" />
     </>
   );
 };

--- a/client/src/shared/components/Logs/Logs.tsx
+++ b/client/src/shared/components/Logs/Logs.tsx
@@ -46,6 +46,12 @@ interface LogsProps {
   logsData?: LogsData;
   fetchMaxLogs: () => Promise<LogsData | undefined>;
   downloadFilename?: string;
+  /**
+   * "document": the pane grows with its content and the page scrolls (Miner Logs).
+   * "container": the pane is a fixed-height box that scrolls itself, for layouts
+   * where the page itself never scrolls (Server Logs).
+   */
+  scrollMode?: "document" | "container";
 }
 
 const LEVEL_TO_LOG_TYPE: Record<StructuredLogEntry["level"], logType> = {
@@ -63,7 +69,7 @@ const entryToLogInfo = (entry: StructuredLogEntry): LogInfo => ({
 
 const isStructured = (data: LogsData): data is Extract<LogsData, { kind: "structured" }> => data.kind === "structured";
 
-const Logs = ({ logsData, fetchMaxLogs, downloadFilename = "miner-logs" }: LogsProps) => {
+const Logs = ({ logsData, fetchMaxLogs, downloadFilename = "miner-logs", scrollMode = "document" }: LogsProps) => {
   const [isExporting, setIsExporting] = useState(false);
   const [initPage, setInitPage] = useState(false);
   const [storedLogs, setStoredLogs] = useState<string[]>([]);
@@ -247,11 +253,10 @@ const Logs = ({ logsData, fetchMaxLogs, downloadFilename = "miner-logs" }: LogsP
   }, [searchValue, filterByLogType]);
 
   const handleScroll = useCallback(() => {
-    // The log pane scrolls itself when a fixed-height layout constrains it
-    // (Server Logs); otherwise the document scrolls (Miner Logs).
-    const container = scrollContainerRef.current;
     let distanceFromBottom: number;
-    if (container && container.scrollHeight > container.clientHeight) {
+    if (scrollMode === "container") {
+      const container = scrollContainerRef.current;
+      if (!container) return;
       distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
     } else {
       const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
@@ -259,23 +264,21 @@ const Logs = ({ logsData, fetchMaxLogs, downloadFilename = "miner-logs" }: LogsP
     }
     // consider within 5px as "at bottom"
     setIsPinnedToBottom(distanceFromBottom < 5);
-  }, []);
+  }, [scrollMode]);
 
   // The log pane only mounts once logs exist, so re-attach when they appear.
   const hasLogs = logs.length > 0;
   useEffect(() => {
     if (!hasLogs) return;
-    const container = scrollContainerRef.current;
-    window.addEventListener("scroll", handleScroll);
-    container?.addEventListener("scroll", handleScroll);
+    const target = scrollMode === "container" ? scrollContainerRef.current : window;
+    target?.addEventListener("scroll", handleScroll);
     // eslint-disable-next-line react-hooks/set-state-in-effect -- initialize isPinnedToBottom from current scroll position on mount
     handleScroll();
 
     return () => {
-      window.removeEventListener("scroll", handleScroll);
-      container?.removeEventListener("scroll", handleScroll);
+      target?.removeEventListener("scroll", handleScroll);
     };
-  }, [handleScroll, hasLogs]);
+  }, [handleScroll, hasLogs, scrollMode]);
 
   return (
     <>
@@ -354,7 +357,10 @@ const Logs = ({ logsData, fetchMaxLogs, downloadFilename = "miner-logs" }: LogsP
               </div>
             </div>
           </div>
-          <div ref={scrollContainerRef} className="h-[calc(100%-60px-58px)] overflow-y-auto">
+          <div
+            ref={scrollContainerRef}
+            className={scrollMode === "container" ? "h-[calc(100%-60px-58px)] overflow-y-auto" : undefined}
+          >
             <div className="p-4 font-mono text-mono-text-50 font-light text-text-primary">
               {filteredLogs.length ? (
                 filteredLogs.map((log, index) => {

--- a/client/src/shared/components/Logs/Logs.tsx
+++ b/client/src/shared/components/Logs/Logs.tsx
@@ -76,6 +76,7 @@ const Logs = ({ logsData, fetchMaxLogs, downloadFilename = "miner-logs" }: LogsP
 
   const [searchValue, setSearchValue] = useState<string>("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const searchBarRef = useRef<HTMLDivElement>(null);
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
 
@@ -246,23 +247,35 @@ const Logs = ({ logsData, fetchMaxLogs, downloadFilename = "miner-logs" }: LogsP
   }, [searchValue, filterByLogType]);
 
   const handleScroll = useCallback(() => {
-    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-    const scrollHeight = document.documentElement.scrollHeight;
-    const clientHeight = document.documentElement.clientHeight;
-    const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+    // The log pane scrolls itself when a fixed-height layout constrains it
+    // (Server Logs); otherwise the document scrolls (Miner Logs).
+    const container = scrollContainerRef.current;
+    let distanceFromBottom: number;
+    if (container && container.scrollHeight > container.clientHeight) {
+      distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+    } else {
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      distanceFromBottom = document.documentElement.scrollHeight - scrollTop - document.documentElement.clientHeight;
+    }
     // consider within 5px as "at bottom"
     setIsPinnedToBottom(distanceFromBottom < 5);
   }, []);
 
+  // The log pane only mounts once logs exist, so re-attach when they appear.
+  const hasLogs = logs.length > 0;
   useEffect(() => {
+    if (!hasLogs) return;
+    const container = scrollContainerRef.current;
     window.addEventListener("scroll", handleScroll);
+    container?.addEventListener("scroll", handleScroll);
     // eslint-disable-next-line react-hooks/set-state-in-effect -- initialize isPinnedToBottom from current scroll position on mount
     handleScroll();
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
+      container?.removeEventListener("scroll", handleScroll);
     };
-  }, [handleScroll]);
+  }, [handleScroll, hasLogs]);
 
   return (
     <>
@@ -341,7 +354,7 @@ const Logs = ({ logsData, fetchMaxLogs, downloadFilename = "miner-logs" }: LogsP
               </div>
             </div>
           </div>
-          <div className="h-[calc(100%-60px-58px)] overflow-y-hidden">
+          <div ref={scrollContainerRef} className="h-[calc(100%-60px-58px)] overflow-y-auto">
             <div className="p-4 font-mono text-mono-text-50 font-light text-text-primary">
               {filteredLogs.length ? (
                 filteredLogs.map((log, index) => {


### PR DESCRIPTION
## Problem

Logs in the Server Logs UI had no scrollback — you could only ever see the tail of the log. The shared `Logs` component (originally built for Miner Logs) rendered the log list in a fixed-height container with `overflow-y-hidden`, which `scrollIntoView` can still scroll programmatically (so auto-follow worked) but blocks user wheel/trackpad scrolling entirely.

On top of that, the pin-to-bottom detection listened only to `window` scroll. That matched the Miner Logs layout (protoOS scrolls the document), but the fleet app scrolls an inner `overflow-auto` container, so on Server Logs the component always believed it was pinned to the bottom.

## Fix

`Logs` now takes an explicit `scrollMode` prop declared by the call site:

- `"document"` (default, Miner Logs): the pane grows with its content and the page scrolls, as before.
- `"container"` (Server Logs): the pane is a fixed-height box that scrolls itself (`overflow-y-auto`).

Scroll listening and pin-to-bottom detection follow the declared mode — the pane in `"container"` mode, the document in `"document"` mode.

## Verification

- `tsc`, `eslint`, and the existing vitest suite are clean.
- Drove both pages in the local dev app with Playwright (API mocked): initial load pins to the bottom; wheel-up scrolls back to the first log line; new poll entries do not yank the view down while scrolled up; auto-follow resumes after returning to the bottom. Verified on both `/settings/server-logs` and `/miners/:id/logs`, re-run after the `scrollMode` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)