### PR TITLE
fix(ui): scope rack manage-miners modals to active site (+ unassigned)

### DIFF
--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -101,6 +101,20 @@ describe("MinerSelectionList site scope", () => {
     expect(listRacksMock).toHaveBeenCalledWith(expect.objectContaining({ siteIds: [7n], includeUnassigned: false }));
   });
 
+  it("includes site-unassigned miners in the list but keeps rack facet options within the site", async () => {
+    // A specific scoped site with includeUnassigned: the miner list should also
+    // surface site-unassigned miners, but the rack/building facet options must
+    // stay strictly within the site (no unassigned racks in the dropdown).
+    render(<MinerSelectionList scope={{ siteIds: [7n], includeUnassigned: true }} />);
+
+    const filter = lastFleetFilter();
+    expect(filter.siteIds).toEqual([7n]);
+    expect(filter.includeUnassigned).toBe(true);
+
+    await waitFor(() => expect(listRacksMock).toHaveBeenCalled());
+    expect(listRacksMock).toHaveBeenCalledWith(expect.objectContaining({ siteIds: [7n], includeUnassigned: false }));
+  });
+
   it("re-applies the filter when the active site changes mid-modal", () => {
     const { rerender } = render(<MinerSelectionList scope={{ siteIds: [7n], includeUnassigned: false }} />);
     expect(lastFleetFilter().siteIds).toEqual([7n]);

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -281,6 +281,15 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
 
     const scopeSiteIds = useMemo(() => scope?.siteIds ?? [], [scope]);
     const scopeIncludeUnassigned = scope?.includeUnassigned ?? false;
+    // Facet-option scope is decoupled from the miner-list scope. The list may
+    // surface site-unassigned miners (scope.includeUnassigned), but the
+    // Building/Rack *dropdown options* must stay strictly within the scoped
+    // site — otherwise a scoped site would list unassigned buildings/racks,
+    // offering facet choices outside the site (and, in assignable-only mode,
+    // ones that immediately conflict → empty state). Only when no site is
+    // scoped (e.g. the "unassigned" SitePicker mode) do the option fetches
+    // honor includeUnassigned.
+    const facetIncludeUnassigned = scopeSiteIds.length > 0 ? false : scopeIncludeUnassigned;
     // Serialized key so effects/callbacks only re-fire when the selection
     // actually changes (siteIds is a fresh bigint[] each render otherwise).
     const scopeKey = `${scopeSiteIds.map(String).join(",")}|${scopeIncludeUnassigned}`;
@@ -633,13 +642,13 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
     }, [scrollToTop, goToPrevPage]);
 
     // Fetch filter options only for enabled filters. Rack/building facet options
-    // scope to the active site so the dropdowns list only the site's members;
-    // group and site options stay org-wide until ListGroups gains site filtering
-    // (issue #520).
+    // scope to the active site so the dropdowns list only the site's members
+    // (facetIncludeUnassigned, not the list's includeUnassigned); group and site
+    // options stay org-wide until ListGroups gains site filtering (issue #520).
     useEffect(() => {
       if (showGroupFilter) listGroups({ onSuccess: setAvailableGroups });
       if (showRackFilter)
-        listRacks({ siteIds: scopeSiteIds, includeUnassigned: scopeIncludeUnassigned, onSuccess: setAvailableRacks });
+        listRacks({ siteIds: scopeSiteIds, includeUnassigned: facetIncludeUnassigned, onSuccess: setAvailableRacks });
       if (showSiteFilter)
         listSites({
           onSuccess: (sites) =>
@@ -650,7 +659,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       if (showBuildingFilter)
         listBuildings({
           siteIds: scopeSiteIds,
-          includeUnassigned: scopeIncludeUnassigned,
+          includeUnassigned: facetIncludeUnassigned,
           onSuccess: (buildings) =>
             setAvailableBuildings(
               buildings

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
@@ -79,11 +79,17 @@ describe("ManageMinersModal", () => {
     expect(latestProps.current.filterConfig).toEqual({
       showTypeFilter: true,
       showSubnetFilter: true,
-      showSiteFilter: true,
+      showSiteFilter: false,
       showBuildingFilter: true,
       showRackFilter: true,
       showGroupFilter: true,
     });
+  });
+
+  it("forwards the header site scope to the selection list", () => {
+    const scope = { siteIds: [7n], includeUnassigned: false };
+    render(<ManageMinersModal {...defaultProps} scope={scope} />);
+    expect(latestProps.current.scope).toEqual(scope);
   });
 
   it("passes currentRackMiners as initialSelectedItems", () => {
@@ -158,6 +164,6 @@ describe("ManageMinersModal", () => {
 
     // No save (which would otherwise resolve/commit a hidden selection).
     expect(onConfirm).not.toHaveBeenCalled();
-    expect(screen.getByText(/Clear the Site, Building, or Rack filter/i)).toBeInTheDocument();
+    expect(screen.getByText(/Clear the Building or Rack filter/i)).toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
@@ -72,10 +72,12 @@ describe("ManageMinersModal", () => {
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
   });
 
-  it("renders MinerSelectionList with correct filter config", () => {
-    render(<ManageMinersModal {...defaultProps} />);
+  it("hides the Site facet and forwards the header site scope when scope is provided", () => {
+    const scope = { siteIds: [7n], includeUnassigned: true };
+    render(<ManageMinersModal {...defaultProps} scope={scope} />);
 
     expect(screen.getByTestId("miner-selection-list")).toBeInTheDocument();
+    expect(latestProps.current.scope).toEqual(scope);
     expect(latestProps.current.filterConfig).toEqual({
       showTypeFilter: true,
       showSubnetFilter: true,
@@ -86,10 +88,9 @@ describe("ManageMinersModal", () => {
     });
   });
 
-  it("forwards the header site scope to the selection list", () => {
-    const scope = { siteIds: [7n], includeUnassigned: false };
-    render(<ManageMinersModal {...defaultProps} scope={scope} />);
-    expect(latestProps.current.scope).toEqual(scope);
+  it("keeps the Site facet when no scope is provided (avoids stranding on the full org)", () => {
+    render(<ManageMinersModal {...defaultProps} />);
+    expect(latestProps.current.filterConfig.showSiteFilter).toBe(true);
   });
 
   it("passes currentRackMiners as initialSelectedItems", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
@@ -112,10 +112,11 @@ export default function ManageMinersModal({
           filterConfig={{
             showTypeFilter: true,
             showSubnetFilter: true,
-            // Site facet omitted — the header SitePicker scope (passed as
-            // `scope`) already governs the site, so a per-modal Site filter is
-            // redundant.
-            showSiteFilter: false,
+            // Site facet is redundant when the header SitePicker scope governs
+            // the site, so hide it whenever a `scope` is supplied. If a caller
+            // omits scope, keep the facet so the picker can still narrow by
+            // site (rather than stranding the operator on the full org list).
+            showSiteFilter: !scope,
             showBuildingFilter: true,
             showRackFilter: true,
             showGroupFilter: true,

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
@@ -5,6 +5,7 @@ import MinerSelectionList, {
   type MinerEligibility,
   type MinerSelectionListHandle,
 } from "@/protoFleet/components/MinerSelectionList";
+import type { SiteFilterFields } from "@/protoFleet/components/PageHeader/SitePicker";
 
 import { Alert } from "@/shared/assets/icons";
 import Callout from "@/shared/components/Callout";
@@ -19,6 +20,10 @@ interface ManageMinersModalProps {
   /** Target rack label, shown in the assignment-conflict dialog. */
   targetRackLabel: string;
   maxSlots: number;
+  /** Header SitePicker scope. Limits the list (and its Building/Rack facets) to
+   *  the active site so the modal never shows the full org when a site is
+   *  scoped; "all sites" passes the empty filter and shows everything. */
+  scope?: SiteFilterFields;
   onDismiss: () => void;
   /** `reassignedItems` is the subset of the explicit selection that is currently
    *  assigned elsewhere, so the caller can confirm the reparent (empty when
@@ -40,6 +45,7 @@ export default function ManageMinersModal({
   eligibility,
   targetRackLabel,
   maxSlots,
+  scope,
   onDismiss,
   onConfirm,
 }: ManageMinersModalProps) {
@@ -57,7 +63,7 @@ export default function ManageMinersModal({
     // save a selection the operator can't see (or wipe membership). Prompt them
     // to clear the filter first instead.
     if (blockedByFilter) {
-      setOverflowError("Clear the Site, Building, or Rack filter to continue — it doesn't match this rack.");
+      setOverflowError("Clear the Building or Rack filter to continue — it doesn't match this rack.");
       return;
     }
 
@@ -106,11 +112,15 @@ export default function ManageMinersModal({
           filterConfig={{
             showTypeFilter: true,
             showSubnetFilter: true,
-            showSiteFilter: true,
+            // Site facet omitted — the header SitePicker scope (passed as
+            // `scope`) already governs the site, so a per-modal Site filter is
+            // redundant.
+            showSiteFilter: false,
             showBuildingFilter: true,
             showRackFilter: true,
             showGroupFilter: true,
           }}
+          scope={scope}
           initialSelectedItems={currentRackMiners}
           eligibility={eligibility}
           targetRackLabel={targetRackLabel}

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -7,6 +7,7 @@ import ReparentWarningDialog from "./ReparentWarningDialog";
 import ScanMinerQrModal from "./ScanMinerQrModal";
 import SearchMinersModal from "./SearchMinersModal";
 import { type AssignmentMode, orderIndexToOrigin, originLabel, type RackFormData, type SelectedSlot } from "./types";
+import { useRackMinerScope } from "./useRackMinerScope";
 import { fetchAllMinerSnapshots } from "@/protoFleet/api/fetchAllMinerSnapshots";
 import { type DeviceSet, type RackSlot } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import {
@@ -19,7 +20,6 @@ import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import useFleet from "@/protoFleet/api/useFleet";
 import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
 import type { MinerEligibility } from "@/protoFleet/components/MinerSelectionList";
-import { siteFilterFromActive, useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
 import { isMinerSnapshotIneligible } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import { slotNumberToRowCol } from "@/protoFleet/features/fleetManagement/utils/slotNumbering";
@@ -96,20 +96,8 @@ export default function ManageRackModal({
 }: ManageRackModalProps) {
   const { saveRack, getRackSlots, listGroupMembers } = useDeviceSets();
 
-  // Header SitePicker scope. Forwarded to the miner-selection sub-modals so they
-  // list only the scoped site's miners (matching the rest of the page) instead
-  // of the full org; "all sites" resolves to the empty filter (no regression).
-  //
-  // For a specific scoped site we also surface site-unassigned miners: the
-  // common way to get a miner into a site is to assign it to a rack there, so it
-  // starts out unassigned and would otherwise be invisible in this modal. The
-  // "all" (already everything) and "unassigned" (already includeUnassigned)
-  // cases need no adjustment.
-  const { activeSite } = useActiveSite({});
-  const scope = useMemo(() => {
-    const base = siteFilterFromActive(activeSite);
-    return activeSite.kind === "site" ? { ...base, includeUnassigned: true } : base;
-  }, [activeSite]);
+  // Header SitePicker scope, forwarded to the miner-selection sub-modals.
+  const scope = useRackMinerScope();
 
   // Fetch all miners for display data (name, IP, model, etc.)
   const { miners: minersMap } = useFleet({ pageSize: 1000 });

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -19,6 +19,7 @@ import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import useFleet from "@/protoFleet/api/useFleet";
 import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
 import type { MinerEligibility } from "@/protoFleet/components/MinerSelectionList";
+import { siteFilterFromActive, useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
 import { isMinerSnapshotIneligible } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import { slotNumberToRowCol } from "@/protoFleet/features/fleetManagement/utils/slotNumbering";
@@ -94,6 +95,21 @@ export default function ManageRackModal({
   onDelete,
 }: ManageRackModalProps) {
   const { saveRack, getRackSlots, listGroupMembers } = useDeviceSets();
+
+  // Header SitePicker scope. Forwarded to the miner-selection sub-modals so they
+  // list only the scoped site's miners (matching the rest of the page) instead
+  // of the full org; "all sites" resolves to the empty filter (no regression).
+  //
+  // For a specific scoped site we also surface site-unassigned miners: the
+  // common way to get a miner into a site is to assign it to a rack there, so it
+  // starts out unassigned and would otherwise be invisible in this modal. The
+  // "all" (already everything) and "unassigned" (already includeUnassigned)
+  // cases need no adjustment.
+  const { activeSite } = useActiveSite({});
+  const scope = useMemo(() => {
+    const base = siteFilterFromActive(activeSite);
+    return activeSite.kind === "site" ? { ...base, includeUnassigned: true } : base;
+  }, [activeSite]);
 
   // Fetch all miners for display data (name, IP, model, etc.)
   const { miners: minersMap } = useFleet({ pageSize: 1000 });
@@ -656,6 +672,7 @@ export default function ManageRackModal({
           eligibility={eligibility}
           targetRackLabel={rackSettings.label}
           maxSlots={totalSlots}
+          scope={scope}
           onDismiss={() => setShowManageMiners(false)}
           onConfirm={handleManageMinersConfirm}
         />
@@ -666,6 +683,7 @@ export default function ManageRackModal({
           show={showSearchMiners}
           eligibility={eligibility}
           targetRackLabel={rackSettings.label}
+          scope={scope}
           onDismiss={() => {
             setShowSearchMiners(false);
             setSelectedSlot(null);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from "react";
 
 import type { MinerEligibility, MinerSelectionListHandle } from "@/protoFleet/components/MinerSelectionList";
 import MinerSelectionList from "@/protoFleet/components/MinerSelectionList";
+import type { SiteFilterFields } from "@/protoFleet/components/PageHeader/SitePicker";
 
 import Modal from "@/shared/components/Modal";
 
@@ -13,6 +14,10 @@ interface SearchMinersModalProps {
   eligibility: MinerEligibility;
   /** Target rack label, shown in the assignment-conflict dialog. */
   targetRackLabel: string;
+  /** Header SitePicker scope. Limits the list (and its Building/Rack facets) to
+   *  the active site so the modal never shows the full org when a site is
+   *  scoped; "all sites" passes the empty filter and shows everything. */
+  scope?: SiteFilterFields;
   onDismiss: () => void;
   /** `isReassignment` is true when the picked miner is currently assigned to a
    *  different rack/building/site, so the caller can confirm the reparent. */
@@ -23,6 +28,7 @@ export default function SearchMinersModal({
   show,
   eligibility,
   targetRackLabel,
+  scope,
   onDismiss,
   onConfirm,
 }: SearchMinersModalProps) {
@@ -62,11 +68,15 @@ export default function SearchMinersModal({
         filterConfig={{
           showTypeFilter: true,
           showSubnetFilter: true,
-          showSiteFilter: true,
+          // Site facet omitted — the header SitePicker scope (passed as
+          // `scope`) already governs the site, so a per-modal Site filter is
+          // redundant.
+          showSiteFilter: false,
           showBuildingFilter: true,
           showRackFilter: true,
           showGroupFilter: true,
         }}
+        scope={scope}
         eligibility={eligibility}
         targetRackLabel={targetRackLabel}
         singleSelect

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
@@ -68,10 +68,11 @@ export default function SearchMinersModal({
         filterConfig={{
           showTypeFilter: true,
           showSubnetFilter: true,
-          // Site facet omitted — the header SitePicker scope (passed as
-          // `scope`) already governs the site, so a per-modal Site filter is
-          // redundant.
-          showSiteFilter: false,
+          // Site facet is redundant when the header SitePicker scope governs
+          // the site, so hide it whenever a `scope` is supplied. If a caller
+          // omits scope, keep the facet so the picker can still narrow by
+          // site (rather than stranding the operator on the full org list).
+          showSiteFilter: !scope,
           showBuildingFilter: true,
           showRackFilter: true,
           showGroupFilter: true,

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/useRackMinerScope.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/useRackMinerScope.ts
@@ -1,0 +1,26 @@
+import { useMemo } from "react";
+
+import {
+  type SiteFilterFields,
+  siteFilterFromActive,
+  useActiveSite,
+} from "@/protoFleet/components/PageHeader/SitePicker";
+
+/** Header SitePicker scope for the rack miner-selection pickers (Manage Miners /
+ *  Search Miners). Forwarded as `scope` so the pickers list only the scoped
+ *  site's miners instead of the full org; "all sites" resolves to the empty
+ *  filter (no regression).
+ *
+ *  For a specific scoped site we also surface site-unassigned miners: the common
+ *  way to get a miner into a site is to assign it to a rack there, so it starts
+ *  out unassigned and would otherwise be invisible in these pickers. The "all"
+ *  (already everything) and "unassigned" (already includeUnassigned) cases need
+ *  no adjustment. Shared between ManageRackModal and the rack-detail slot-search
+ *  flow so the includeUnassigned decision lives in one place. */
+export function useRackMinerScope(): SiteFilterFields {
+  const { activeSite } = useActiveSite({});
+  return useMemo(() => {
+    const base = siteFilterFromActive(activeSite);
+    return activeSite.kind === "site" ? { ...base, includeUnassigned: true } : base;
+  }, [activeSite]);
+}

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -22,6 +22,7 @@ import { ManageRackModal, type RackFormData } from "@/protoFleet/features/fleetM
 import ReparentWarningDialog from "@/protoFleet/features/fleetManagement/components/ManageRackModal/ReparentWarningDialog";
 import SearchMinersModal from "@/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal";
 import { orderIndexToOrigin } from "@/protoFleet/features/fleetManagement/components/ManageRackModal/types";
+import { useRackMinerScope } from "@/protoFleet/features/fleetManagement/components/ManageRackModal/useRackMinerScope";
 import type { SlotHealthState } from "@/protoFleet/features/fleetManagement/components/RackDetailGrid/types";
 import { RackHealthModule } from "@/protoFleet/features/fleetManagement/components/RackHealthModule";
 import { SLOT_STATUS_MAP } from "@/protoFleet/features/fleetManagement/utils/rackCardMapper";
@@ -77,6 +78,10 @@ const RackOverviewPage = () => {
   // label the rack's parent site in breadcrumbs), so this page no longer fires
   // its own ListSites.
   const { sites } = useSitesContext();
+
+  // Header SitePicker scope for the slot-search miner picker (this page renders
+  // SearchMinersModal directly, not via ManageRackModal).
+  const searchMinerScope = useRackMinerScope();
 
   // Request versioning to guard against stale resolution callbacks
   const resolveVersionRef = useRef(0);
@@ -561,6 +566,7 @@ const RackOverviewPage = () => {
             buildingId: rack.placement?.building?.id || undefined,
           }}
           targetRackLabel={rack.label}
+          scope={searchMinerScope}
           onDismiss={() => setSearchMinerSlot(null)}
           onConfirm={(minerId, isReassignment) => {
             const slot = searchMinerSlot;


### PR DESCRIPTION
Reviewable diff: +41/-3 across 3 files (excludes generated, test, and story files).

## Summary

Scopes the **Manage Miners** and **Search Miners** pickers (opened from the Edit/Manage Rack modal) to the site selected in the page-header SitePicker, instead of always showing the full org list of miners. When a specific site is scoped, the pickers show that site's miners **plus miners not assigned to any site** — the common path for getting miners into a site is assigning them to a rack there, so they start out unassigned and must be reachable. The redundant per-modal **Site** filter facet is removed now that the header scope governs the site.

## How it works

The header SitePicker selection lives in a Zustand UI slice and is read via `useActiveSite`. `ManageRackModal` reads it once and converts it to the additive `{ siteIds, includeUnassigned }` filter pair used across the app (via `siteFilterFromActive`), then forwards it as a `scope` prop to both sub-modals, which pass it straight through to the shared `MinerSelectionList`.

`MinerSelectionList` already knew how to fold a `scope` into its server-side `MinerListFilter` (AND-ed with the user's model/rack/group facets, so applying a facet never drops the site constraint). The fix is simply that the two rack pickers now supply that scope — previously they passed none, so the list queried every paired miner in the org.

Scope resolution by SitePicker state:

- **All sites** → `{ siteIds: [], includeUnassigned: false }` → the empty filter, server returns everything (unchanged behavior, no regression).
- **A specific site** → `{ siteIds: [<id>], includeUnassigned: true }` → miners in that site **OR** miners with no site. The `includeUnassigned: true` is the deliberate addition here.
- **Unassigned** → `{ siteIds: [], includeUnassigned: true }` → already only unassigned miners (unchanged).

Because `siteIds`/`includeUnassigned` are additive (OR) on the server, a specific site resolves to "this site's miners or unassigned miners." This scope only overrides the list when the modal isn't already constraining by the target rack's own placement:

- **New / unplaced rack** (create flow): no rack placement to key off, so the header scope now bounds the list to the scoped site + unassigned.
- **"Show assigned miners" toggle ON**: rack-eligibility filtering is dropped, so the header scope is what keeps the list to the scoped site + unassigned rather than the whole org.
- **Default assignable view for an already-placed rack**: unchanged — the list already pinned to the rack's site with `includeUnassigned: true`, so all three modes now behave consistently.

```mermaid
flowchart TD
    SP["Page-header SitePicker (Zustand UI slice)"] --> UAS["useActiveSite()"]
    UAS --> MRM["ManageRackModal: siteFilterFromActive + includeUnassigned for a specific site"]
    MRM -->|"scope prop"| MMM["ManageMinersModal (Site facet removed)"]
    MRM -->|"scope prop"| SMM["SearchMinersModal (Site facet removed)"]
    MMM --> MSL["MinerSelectionList"]
    SMM --> MSL
    MSL -->|"scope AND user facets AND rack eligibility"| API["ListMinerStateSnapshots (server-side MinerListFilter)"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `ManageRackModal.tsx` | Reads `useActiveSite`, derives `scope` (adds `includeUnassigned` for a specific site), forwards it to both sub-modals | Core of the change — where the header scope enters the rack flow and where the unassigned-miners decision lives |
| `ManageMinersModal.tsx` | Accepts `scope`, forwards to `MinerSelectionList`, sets `showSiteFilter: false`; conflict copy drops "Site" | Multi-select picker; verify facet removal + copy |
| `SearchMinersModal.tsx` | Accepts `scope`, forwards to `MinerSelectionList`, sets `showSiteFilter: false` | Single-select picker; same treatment |
| `ManageMinersModal.test.tsx` | Updated `filterConfig` and conflict-copy assertions; added a scope-forwarding test | Test-only |

## Key technical decisions & trade-offs

- **Compute scope in `ManageRackModal`, not per call site.** `ManageRackModal` is rendered from four places (RacksPage ×2, RackOverviewPage, FleetCreateFlow); reading `useActiveSite` once inside it covers all of them uniformly. Chosen over threading a `scope` prop through every call site. Mirrors the existing `ScheduleModal → MinerSelectionModal` precedent.
- **`includeUnassigned: true` is scoped locally**, not baked into `siteFilterFromActive`. That shared helper is used by the racks list, activity, fleet, and schedules, all of which want strict site-only semantics — so the "+ unassigned" behavior is applied only in this rack-assignment context.
- **Site facet removed from the two pickers** rather than left as a redundant override. With the header scope now governing the site, an in-modal Site dropdown would be confusing and could fight the scope. The Building/Rack facets stay (and remain scoped to the active site); the Site *column* still renders since its label rides on the miner snapshot.

## Testing & validation

- `ManageMinersModal.test.tsx` + `MinerSelectionList.test.tsx`: 25 passing (updated `filterConfig`/conflict-copy assertions, added a `scope`-forwarding test).
- `RackOverviewPage.test.tsx`: 5 passing — confirms the new `useActiveSite` hook doesn't break modal-hosting pages.
- `tsc --noEmit`, ESLint, and Prettier: clean on all changed files.
- Not covered: no dedicated `ManageRackModal` test file exists, so the exact `scope` value it derives (including the `includeUnassigned` toggle per SitePicker state) is not asserted by an automated test; verified by reasoning against `MinerSelectionList`'s filter logic. The QR-scan picker is intentionally untouched (it resolves a scanned serial rather than listing miners).
