### PR TITLE
Remove stale multi-site feature flag

### DIFF
--- a/client/src/protoFleet/constants/featureFlags.ts
+++ b/client/src/protoFleet/constants/featureFlags.ts
@@ -9,13 +9,6 @@
  */
 
 /**
- * Multi-site navigation and scoping affordances. The routes and APIs remain
- * available for QA/dogfood direct access while the operator-facing entry
- * points stay hidden by default. Override with `VITE_MULTI_SITE_ENABLED=true`.
- */
-export const MULTI_SITE_ENABLED = import.meta.env.VITE_MULTI_SITE_ENABLED === "true";
-
-/**
  * Infrastructure devices tab. When on, `/fleet/infrastructure` is
  * discoverable from the Fleet tab strip. The route stays registered so QA
  * and dogfood can still deep-link while the feature is in development.


### PR DESCRIPTION
Reviewable diff: +0/-7 across 1 file (excludes generated, test, and story files).

## Summary
This PR removes the stale `MULTI_SITE_ENABLED` export from ProtoFleet's build-time feature flag constants. The multi-site UI gates were removed earlier, and the symbol has no remaining client references, so keeping `VITE_MULTI_SITE_ENABLED` in the central registry makes the supported flag surface misleading.

## How it works
ProtoFleet continues to parse build-time feature flags from `client/src/protoFleet/constants/featureFlags.ts`. This change deletes only the unused multi-site flag block, leaving the infrastructure devices and alerts flags unchanged. Routes, APIs, and multi-site runtime behavior are not changed.

## Diagrams

```mermaid
flowchart TD
  A["Vite build env"] --> B["featureFlags.ts"]
  B --> C["INFRASTRUCTURE_DEVICES_ENABLED"]
  B --> D["ALERTS_ENABLED"]
  E["Stale VITE_MULTI_SITE_ENABLED entry"] --> F["Removed from exported flag surface"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/constants/featureFlags.ts` | Removed the unused `MULTI_SITE_ENABLED` export and its comment block. | Confirms the public client flag registry no longer advertises a retired multi-site gate. |

## Key technical decisions & trade-offs

- Remove only the live source export instead of editing historical planning docs, so archived context stays intact.
- Leave current multi-site routes, APIs, and state untouched because this is a stale flag cleanup, not a behavior change.

## Testing & validation

- Ran `/Users/negar/Development/proto-fleet/bin/npx eslint src/protoFleet/constants/featureFlags.ts --max-warnings 0`.
- Ran `/Users/negar/Development/proto-fleet/bin/npx prettier --check src/protoFleet/constants/featureFlags.ts`.
- Ran `/Users/negar/Development/proto-fleet/bin/npx tsc --noEmit`.
