### PR TITLE
feat: pluggable client observability with Datadog RUM + API tracing

### DIFF
--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -444,6 +444,7 @@ jobs:
           cp deployment-files/client/Dockerfile deployment/client/
           cp deployment-files/client/nginx.http.conf deployment/client/
           cp deployment-files/client/nginx.https.conf deployment/client/
+          cp -r deployment-files/client/docker-entrypoint.d deployment/client/
           cp deployment-files/server/Dockerfile deployment/server/
           cp deployment-files/docker-compose.yaml deployment/
           cp deployment-files/docker-compose.alerts.yaml deployment/

--- a/client/README.md
+++ b/client/README.md
@@ -186,6 +186,12 @@ Datadog keys (all read via both mechanisms; runtime `DD_*` / build-time `VITE_DD
 Both `DD_APPLICATION_ID` and `DD_CLIENT_TOKEN` must be set to enable; otherwise the client
 runs unchanged with no SDK side effects.
 
+**Privacy:** RUM sends to the operator's own Datadog org. Session Replay is off by default
+(`DD_SESSION_REPLAY_SAMPLE_RATE=0`) and masks all text/inputs when enabled
+(`defaultPrivacyLevel: "mask"`). A `beforeSend` scrubber strips query strings from resource
+URLs before events leave the browser; extend it in `providers/datadog.ts` if the UI surfaces
+further sensitive strings (worker/pool/wallet labels, IPs) in action names or error metadata.
+
 **Adding a provider** (Sentry, PostHog): implement `ObservabilityProvider` under
 `src/shared/observability/providers/`, then add one `registerProvider(...)` call in
 `src/shared/observability/providers.ts`. The entry point, transport, and error boundary are

--- a/client/README.md
+++ b/client/README.md
@@ -155,6 +155,43 @@ npm run storybook
 
 **ProtoFleet** — gRPC-Web with Connect-RPC. Generated TypeScript code in `src/protoFleet/api/generated/` from Protobuf definitions. Supports server-to-client streaming for real-time telemetry. Custom hooks in `src/protoFleet/api/`.
 
+### Observability
+
+Client observability lives in `src/shared/observability/` as a vendor-neutral provider
+registry. Datadog RUM is the first provider; a provider is a complete no-op unless its
+required config is present. When enabled, Datadog RUM captures page/session data, forwards
+React render errors (via the shared `ErrorBoundary`), and injects distributed-tracing
+headers on same-origin `/api-proxy` calls so a slow RPC can be traced client→server.
+
+**Configuration** resolves runtime-first, then build-time:
+
+1. `window.__RUNTIME_CONFIG__[KEY]` — rendered into `config.js` by the deployment nginx
+   image at container start from `DD_*` environment variables. Operators enable Datadog on
+   a prebuilt image by setting these in their `.env` — no rebuild required.
+2. `import.meta.env.VITE_<KEY>` — build-time value for local dev and CI (set in `.env`).
+
+Datadog keys (all read via both mechanisms; runtime `DD_*` / build-time `VITE_DD_*`):
+
+| Key                             | Required                                     | Default                                |
+| ------------------------------- | -------------------------------------------- | -------------------------------------- |
+| `DD_APPLICATION_ID`             | yes                                          | —                                      |
+| `DD_CLIENT_TOKEN`               | yes (public RUM token, not a secret API key) | —                                      |
+| `DD_SITE`                       | no                                           | `datadoghq.com`                        |
+| `DD_SERVICE`                    | no                                           | `proto-fleet-client`                   |
+| `DD_ENV`                        | no                                           | build env (`production`/`development`) |
+| `DD_RUM_SAMPLE_RATE`            | no                                           | `100`                                  |
+| `DD_SESSION_REPLAY_SAMPLE_RATE` | no                                           | `0`                                    |
+| `DD_TRACE_SAMPLE_RATE`          | no                                           | `100`                                  |
+
+Both `DD_APPLICATION_ID` and `DD_CLIENT_TOKEN` must be set to enable; otherwise the client
+runs unchanged with no SDK side effects.
+
+**Adding a provider** (Sentry, PostHog): implement `ObservabilityProvider` under
+`src/shared/observability/providers/`, then add one `registerProvider(...)` call in
+`src/shared/observability/providers.ts`. The entry point, transport, and error boundary are
+provider-agnostic and do not change. End-to-end distributed traces also require the backend
+to accept/propagate the incoming trace headers.
+
 ### Import Rules
 
 Use the `@/` path alias for all absolute imports:

--- a/client/README.md
+++ b/client/README.md
@@ -161,7 +161,9 @@ Client observability lives in `src/shared/observability/` as a vendor-neutral pr
 registry. Datadog RUM is the first provider; a provider is a complete no-op unless its
 required config is present. When enabled, Datadog RUM captures page/session data, forwards
 React render errors (via the shared `ErrorBoundary`), and injects distributed-tracing
-headers on same-origin `/api-proxy` calls so a slow RPC can be traced client→server.
+headers on same-origin `/api-proxy` calls. This is future-ready client plumbing for
+client→server trace correlation; the bundled backend telemetry path does not currently export
+correlated server spans to Datadog.
 
 **Configuration** resolves runtime-first, then build-time:
 
@@ -186,17 +188,18 @@ Datadog keys (all read via both mechanisms; runtime `DD_*` / build-time `VITE_DD
 Both `DD_APPLICATION_ID` and `DD_CLIENT_TOKEN` must be set to enable; otherwise the client
 runs unchanged with no SDK side effects.
 
-**Privacy:** RUM sends to the operator's own Datadog org. Session Replay is off by default
+**Data minimization:** RUM sends to the operator's own Datadog org. Session Replay is off by default
 (`DD_SESSION_REPLAY_SAMPLE_RATE=0`) and masks all text/inputs when enabled
-(`defaultPrivacyLevel: "mask"`). A `beforeSend` scrubber strips query strings from resource
-URLs before events leave the browser; extend it in `providers/datadog.ts` if the UI surfaces
-further sensitive strings (worker/pool/wallet labels, IPs) in action names or error metadata.
+(`defaultPrivacyLevel: "mask"`). A `beforeSend` scrubber removes query strings that RUM does
+not need for route-level analysis; extend it in `providers/datadog.ts` if the UI later surfaces
+sensitive strings in action names or error metadata.
 
 **Adding a provider** (Sentry, PostHog): implement `ObservabilityProvider` under
 `src/shared/observability/providers/`, then add one `registerProvider(...)` call in
 `src/shared/observability/providers.ts`. The entry point, transport, and error boundary are
-provider-agnostic and do not change. End-to-end distributed traces also require the backend
-to accept/propagate the incoming trace headers.
+provider-agnostic and do not change. End-to-end distributed traces remain follow-up work: the
+backend must deliberately associate the incoming context and export server spans to the same
+observability backend.
 
 ### Import Rules
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@bufbuild/protobuf": "2.12.1",
         "@connectrpc/connect": "2.1.2",
         "@connectrpc/connect-web": "2.1.2",
+        "@datadog/browser-rum": "7.5.0",
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/sortable": "10.0.0",
         "barcode-detector": "3.2.0",
@@ -890,6 +891,50 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-7.5.0.tgz",
+      "integrity": "sha512-qvjv0Ox55+x/wxFT8cjIAse1voLVorJd3lg2Q53nJ0CREZ1bqqjo2gDz/Lm4t0fqQnqyqrOncc3X2pg4LxCFzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/js-core": "0.0.5"
+      }
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-7.5.0.tgz",
+      "integrity": "sha512-w7T0sAu9wx0zIdAmHM4avwdJW/gu+llCUCyeo5mQO5Qbf7VcA8K9Y+R4ZsNizRC14K5beAAkj5MqdaBC2x+yZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "7.5.0",
+        "@datadog/browser-rum-core": "7.5.0",
+        "@datadog/js-core": "0.0.5"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "7.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-7.5.0.tgz",
+      "integrity": "sha512-Okyq2+y3Dtw5AL4xpw/fT1Dkmyr/Q4na3Wa+D9FU+i1g5i3BGyr6HNUv6L7vCrF6CyDVfCi3Nv90lgdprRCkyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "7.5.0",
+        "@datadog/js-core": "0.0.5"
+      }
+    },
+    "node_modules/@datadog/js-core": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@datadog/js-core/-/js-core-0.0.5.tgz",
+      "integrity": "sha512-9cGazfbindLRCcHh7Pgle68SZrSKMr6ScIvtT7XwxTGp38RaskXA/CG4nUojb46nWnsmV+KyH3C8WymkXdgMJg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -31,6 +31,7 @@
     "@bufbuild/protobuf": "2.12.1",
     "@connectrpc/connect": "2.1.2",
     "@connectrpc/connect-web": "2.1.2",
+    "@datadog/browser-rum": "7.5.0",
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/sortable": "10.0.0",
     "barcode-detector": "3.2.0",

--- a/client/public/config.js
+++ b/client/public/config.js
@@ -1,0 +1,7 @@
+/* global window */
+// Runtime configuration placeholder, read by the client as window.__RUNTIME_CONFIG__.
+//
+// In deployed images this file is regenerated at container start from environment
+// variables (see deployment-files/client/docker-entrypoint.d). In local dev and CI
+// it stays empty, so configuration falls back to build-time VITE_* vars.
+window.__RUNTIME_CONFIG__ = window.__RUNTIME_CONFIG__ || {};

--- a/client/src/protoFleet/api/transport.ts
+++ b/client/src/protoFleet/api/transport.ts
@@ -1,10 +1,16 @@
 import { createConnectTransport } from "@connectrpc/connect-web";
 import { API_PROXY_BASE } from "@/protoFleet/api/constants";
+import { observabilityInterceptors } from "@/shared/observability";
+// Side effect: registers observability providers before interceptors are collected.
+import "@/shared/observability/providers";
 
 const transport = createConnectTransport({
   baseUrl: `${API_PROXY_BASE}/`,
   // Include cookies with all requests for session-based authentication
   fetch: (input, init) => fetch(input, { ...init, credentials: "include" }),
+  // Observability providers may contribute RPC instrumentation. Empty when none
+  // are configured, so transport behavior is unchanged in that case.
+  interceptors: observabilityInterceptors(),
 });
 
 export { transport };

--- a/client/src/protoFleet/components/App/App.tsx
+++ b/client/src/protoFleet/components/App/App.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, Suspense, useEffect, useMemo, useRef } from "react";
+import { type ErrorInfo, ReactNode, Suspense, useCallback, useEffect, useMemo, useRef } from "react";
 import { useMatches } from "react-router-dom";
 import clsx from "clsx";
 
@@ -103,6 +103,10 @@ const App = ({ children, fullscreen }: AppProps) => {
 
   const isActionBarVisible = useIsActionBarVisible();
 
+  const handleRenderError = useCallback((error: Error, errorInfo: ErrorInfo) => {
+    reportObservabilityError(error, { componentStack: errorInfo.componentStack });
+  }, []);
+
   // Show loading spinner ONLY if auth is required AND (loading OR access denied)
   const showLoading = requireAuth && (loading || hasAccess !== true);
 
@@ -121,9 +125,7 @@ const App = ({ children, fullscreen }: AppProps) => {
   // RENDER
   // ============================================================================
   return (
-    <ErrorBoundary
-      onError={(error, errorInfo) => reportObservabilityError(error, { componentStack: errorInfo.componentStack })}
-    >
+    <ErrorBoundary onError={handleRenderError}>
       {/* Toaster - Fixed position, renders above overlays (z-50) and dialogs (z-40) */}
       <div
         className={clsx(

--- a/client/src/protoFleet/components/App/App.tsx
+++ b/client/src/protoFleet/components/App/App.tsx
@@ -14,6 +14,7 @@ import ErrorBoundary from "@/shared/components/ErrorBoundary";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import { useApplyTheme } from "@/shared/features/preferences";
 import { Toaster } from "@/shared/features/toaster";
+import { reportObservabilityError } from "@/shared/observability";
 import { isBackendDownError } from "@/shared/utils/backendHealth";
 import { prefetchRoutes } from "@/shared/utils/prefetchRoutes";
 
@@ -120,7 +121,9 @@ const App = ({ children, fullscreen }: AppProps) => {
   // RENDER
   // ============================================================================
   return (
-    <ErrorBoundary>
+    <ErrorBoundary
+      onError={(error, errorInfo) => reportObservabilityError(error, { componentStack: errorInfo.componentStack })}
+    >
       {/* Toaster - Fixed position, renders above overlays (z-50) and dialogs (z-40) */}
       <div
         className={clsx(

--- a/client/src/protoFleet/components/App/App.tsx
+++ b/client/src/protoFleet/components/App/App.tsx
@@ -103,6 +103,8 @@ const App = ({ children, fullscreen }: AppProps) => {
 
   const isActionBarVisible = useIsActionBarVisible();
 
+  // reportObservabilityError is a stable module-level import, not a reactive
+  // value, so it is intentionally not a dependency (exhaustive-deps agrees).
   const handleRenderError = useCallback((error: Error, errorInfo: ErrorInfo) => {
     reportObservabilityError(error, { componentStack: errorInfo.componentStack });
   }, []);

--- a/client/src/protoFleet/index.html
+++ b/client/src/protoFleet/index.html
@@ -9,6 +9,9 @@
 
   <body class="font-body text-text-primary overscroll-none" data-theme="light">
     <div id="root"></div>
+    <!-- Runtime config (window.__RUNTIME_CONFIG__). Classic script so it runs before
+         the deferred module below. Empty in dev; regenerated from env in deployed images. -->
+    <script src="/config.js"></script>
     <script type="module" src="mainWrapper.tsx"></script>
   </body>
 </html>

--- a/client/src/protoFleet/mainWrapper.tsx
+++ b/client/src/protoFleet/mainWrapper.tsx
@@ -1,8 +1,19 @@
 import ReactDOM from "react-dom/client";
 
 import Main from "./main";
-import { logBuildVersion } from "@/shared/utils/version";
+import { API_PROXY_BASE } from "@/protoFleet/api/constants";
+import { getConfigValue, initObservability } from "@/shared/observability";
+// Side effect: registers observability providers before init runs.
+import "@/shared/observability/providers";
+import { buildVersionInfo, logBuildVersion } from "@/shared/utils/version";
 
 logBuildVersion();
+
+initObservability({
+  service: "proto-fleet-client",
+  version: buildVersionInfo.commit,
+  env: getConfigValue("DD_ENV") ?? (import.meta.env.PROD ? "production" : "development"),
+  apiTracingOrigin: API_PROXY_BASE,
+});
 
 ReactDOM.createRoot(document.getElementById("root")!).render(<Main />);

--- a/client/src/protoFleet/mainWrapper.tsx
+++ b/client/src/protoFleet/mainWrapper.tsx
@@ -2,18 +2,20 @@ import ReactDOM from "react-dom/client";
 
 import Main from "./main";
 import { API_PROXY_BASE } from "@/protoFleet/api/constants";
-import { getConfigValue, initObservability } from "@/shared/observability";
+import { initObservability } from "@/shared/observability";
 // Side effect: registers observability providers before init runs.
 import "@/shared/observability/providers";
 import { buildVersionInfo, logBuildVersion } from "@/shared/utils/version";
 
 logBuildVersion();
 
+// Provider-agnostic context: each provider layers its own config keys on top
+// (e.g. the Datadog provider prefers DD_ENV over this default).
 initObservability({
   service: "proto-fleet-client",
   version: buildVersionInfo.commit,
-  env: getConfigValue("DD_ENV") ?? (import.meta.env.PROD ? "production" : "development"),
-  apiTracingOrigin: API_PROXY_BASE,
+  env: import.meta.env.PROD ? "production" : "development",
+  apiTracingPathPrefix: API_PROXY_BASE,
 });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(<Main />);

--- a/client/src/shared/observability/index.ts
+++ b/client/src/shared/observability/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Pluggable client observability.
+ *
+ * To add a backend (e.g. Sentry, PostHog): create a module under `providers/`
+ * implementing `ObservabilityProvider`, then register it in `providers.ts`.
+ * Nothing else — entry point, transport, and error boundary are provider-agnostic.
+ */
+
+export type { ObservabilityProvider, ObservabilityInitContext, ObservabilityErrorMeta } from "./types";
+export { getConfigValue } from "./runtimeConfig";
+export { registerProvider, initObservability, reportObservabilityError, observabilityInterceptors } from "./registry";

--- a/client/src/shared/observability/index.ts
+++ b/client/src/shared/observability/index.ts
@@ -1,11 +1,4 @@
-/**
- * Pluggable client observability.
- *
- * To add a backend (e.g. Sentry, PostHog): create a module under `providers/`
- * implementing `ObservabilityProvider`, then register it in `providers.ts`.
- * Nothing else — entry point, transport, and error boundary are provider-agnostic.
- */
+/** Pluggable client observability. To add a backend, see `providers.ts`. */
 
 export type { ObservabilityProvider, ObservabilityInitContext, ObservabilityErrorMeta } from "./types";
-export { getConfigValue } from "./runtimeConfig";
 export { registerProvider, initObservability, reportObservabilityError, observabilityInterceptors } from "./registry";

--- a/client/src/shared/observability/providers.ts
+++ b/client/src/shared/observability/providers.ts
@@ -1,0 +1,14 @@
+import { datadogProvider } from "./providers/datadog";
+import { registerProvider } from "./registry";
+
+/**
+ * Registers the built-in observability providers as a side effect of import.
+ *
+ * Imported by both the app entry point (before `initObservability`) and the API
+ * transport (before it collects interceptors), so registration always precedes
+ * use regardless of module load order. Registration is idempotent by provider name.
+ *
+ * To add a provider (Sentry, PostHog): implement it under `providers/` and add a
+ * `registerProvider(...)` call here — no other file needs to change.
+ */
+registerProvider(datadogProvider);

--- a/client/src/shared/observability/providers/datadog.test.ts
+++ b/client/src/shared/observability/providers/datadog.test.ts
@@ -139,7 +139,6 @@ describe("datadogProvider.init", () => {
       resource?: { url: string };
     }) => boolean;
 
-    // Resource event: view URL, referrer, and resource URL are all scrubbed.
     const resourceEvent = {
       type: "resource",
       view: { url: `${origin}/fleet/miners?subnet=10.0.0.0/24&rackId=r1`, referrer: `${origin}/x?token=t` },
@@ -150,7 +149,6 @@ describe("datadogProvider.init", () => {
     expect(resourceEvent.view.referrer).toBe(`${origin}/x`);
     expect(resourceEvent.resource?.url).toBe(`${origin}/api-proxy/svc/Method`);
 
-    // Non-resource (view) event: the view URL is still scrubbed.
     const viewEvent = { type: "view", view: { url: `${origin}/fleet/miners?buildingId=b2` } };
     expect(beforeSend(viewEvent)).toBe(true);
     expect(viewEvent.view.url).toBe(`${origin}/fleet/miners`);

--- a/client/src/shared/observability/providers/datadog.test.ts
+++ b/client/src/shared/observability/providers/datadog.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { datadogRum } from "@datadog/browser-rum";
+import type { RumInitConfiguration } from "@datadog/browser-rum";
+
+import type { ObservabilityInitContext } from "../types";
+import { datadogProvider } from "./datadog";
+
+type MutableWindow = Window & { __RUNTIME_CONFIG__?: Record<string, string> };
+
+const ctx: ObservabilityInitContext = {
+  service: "proto-fleet-client",
+  version: "test-commit",
+  env: "test",
+  apiTracingOrigin: "/api-proxy",
+};
+
+const setRuntimeConfig = (config: Record<string, string>) => {
+  (window as MutableWindow).__RUNTIME_CONFIG__ = config;
+};
+
+const initMock = vi.mocked(datadogRum.init);
+const addErrorMock = vi.mocked(datadogRum.addError);
+
+const lastInitConfig = (): RumInitConfiguration => initMock.mock.calls[0][0];
+
+beforeEach(() => {
+  delete (window as MutableWindow).__RUNTIME_CONFIG__;
+  initMock.mockClear();
+  addErrorMock.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("datadogProvider.isConfigured", () => {
+  it("is false when either required key is missing", () => {
+    setRuntimeConfig({ DD_APPLICATION_ID: "app-id" });
+    expect(datadogProvider.isConfigured()).toBe(false);
+
+    setRuntimeConfig({ DD_CLIENT_TOKEN: "token" });
+    expect(datadogProvider.isConfigured()).toBe(false);
+  });
+
+  it("is true when both required keys are present", () => {
+    setRuntimeConfig({ DD_APPLICATION_ID: "app-id", DD_CLIENT_TOKEN: "token" });
+    expect(datadogProvider.isConfigured()).toBe(true);
+  });
+
+  it("reads from build-time VITE_ vars as a fallback", () => {
+    vi.stubEnv("VITE_DD_APPLICATION_ID", "app-id");
+    vi.stubEnv("VITE_DD_CLIENT_TOKEN", "token");
+    expect(datadogProvider.isConfigured()).toBe(true);
+  });
+});
+
+describe("datadogProvider.init", () => {
+  it("does not initialize RUM when required keys are missing", () => {
+    datadogProvider.init(ctx);
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  it("initializes RUM once with required config and version from the context", () => {
+    setRuntimeConfig({ DD_APPLICATION_ID: "app-id", DD_CLIENT_TOKEN: "token" });
+
+    datadogProvider.init(ctx);
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const config = lastInitConfig();
+    expect(config.applicationId).toBe("app-id");
+    expect(config.clientToken).toBe("token");
+    expect(config.version).toBe("test-commit");
+  });
+
+  it("applies defaults for optional keys and honors overrides", () => {
+    setRuntimeConfig({ DD_APPLICATION_ID: "app-id", DD_CLIENT_TOKEN: "token" });
+    datadogProvider.init(ctx);
+    let config = lastInitConfig();
+    expect(config.site).toBe("datadoghq.com");
+    expect(config.service).toBe("proto-fleet-client");
+    expect(config.sessionSampleRate).toBe(100);
+    expect(config.sessionReplaySampleRate).toBe(0);
+
+    initMock.mockClear();
+    setRuntimeConfig({
+      DD_APPLICATION_ID: "app-id",
+      DD_CLIENT_TOKEN: "token",
+      DD_SITE: "us3.datadoghq.com",
+      DD_SERVICE: "custom-service",
+      DD_RUM_SAMPLE_RATE: "25",
+      DD_SESSION_REPLAY_SAMPLE_RATE: "10",
+    });
+    datadogProvider.init(ctx);
+    config = lastInitConfig();
+    expect(config.site).toBe("us3.datadoghq.com");
+    expect(config.service).toBe("custom-service");
+    expect(config.sessionSampleRate).toBe(25);
+    expect(config.sessionReplaySampleRate).toBe(10);
+  });
+
+  it("falls back to defaults when a sample rate is non-numeric", () => {
+    setRuntimeConfig({
+      DD_APPLICATION_ID: "app-id",
+      DD_CLIENT_TOKEN: "token",
+      DD_RUM_SAMPLE_RATE: "not-a-number",
+    });
+    datadogProvider.init(ctx);
+    expect(lastInitConfig().sessionSampleRate).toBe(100);
+  });
+
+  it("scopes distributed tracing to same-origin API calls only", () => {
+    setRuntimeConfig({ DD_APPLICATION_ID: "app-id", DD_CLIENT_TOKEN: "token" });
+    datadogProvider.init(ctx);
+
+    const tracing = lastInitConfig().allowedTracingUrls ?? [];
+    const matcher = tracing[0] as (url: string) => boolean;
+    const origin = window.location.origin;
+
+    expect(matcher(`${origin}/api-proxy/telemetry.v1.TelemetryService/Get`)).toBe(true);
+    expect(matcher(`${origin}/other/path`)).toBe(false);
+    expect(matcher("https://third-party.example.com/api-proxy/x")).toBe(false);
+  });
+});
+
+describe("datadogProvider.reportError", () => {
+  it("forwards errors to datadogRum.addError", () => {
+    const error = new Error("render failed");
+    datadogProvider.reportError?.(error, { react: "info" });
+    expect(addErrorMock).toHaveBeenCalledWith(error, { react: "info" });
+  });
+});

--- a/client/src/shared/observability/providers/datadog.test.ts
+++ b/client/src/shared/observability/providers/datadog.test.ts
@@ -5,17 +5,15 @@ import type { RumInitConfiguration } from "@datadog/browser-rum";
 import type { ObservabilityInitContext } from "../types";
 import { datadogProvider } from "./datadog";
 
-type MutableWindow = Window & { __RUNTIME_CONFIG__?: Record<string, string> };
-
 const ctx: ObservabilityInitContext = {
   service: "proto-fleet-client",
   version: "test-commit",
   env: "test",
-  apiTracingOrigin: "/api-proxy",
+  apiTracingPathPrefix: "/api-proxy",
 };
 
 const setRuntimeConfig = (config: Record<string, string>) => {
-  (window as MutableWindow).__RUNTIME_CONFIG__ = config;
+  window.__RUNTIME_CONFIG__ = config;
 };
 
 const initMock = vi.mocked(datadogRum.init);
@@ -24,7 +22,7 @@ const addErrorMock = vi.mocked(datadogRum.addError);
 const lastInitConfig = (): RumInitConfiguration => initMock.mock.calls[0][0];
 
 beforeEach(() => {
-  delete (window as MutableWindow).__RUNTIME_CONFIG__;
+  delete window.__RUNTIME_CONFIG__;
   initMock.mockClear();
   addErrorMock.mockClear();
 });
@@ -78,8 +76,10 @@ describe("datadogProvider.init", () => {
     let config = lastInitConfig();
     expect(config.site).toBe("datadoghq.com");
     expect(config.service).toBe("proto-fleet-client");
+    expect(config.env).toBe("test"); // falls back to context.env
     expect(config.sessionSampleRate).toBe(100);
     expect(config.sessionReplaySampleRate).toBe(0);
+    expect(config.traceSampleRate).toBe(100);
 
     initMock.mockClear();
     setRuntimeConfig({
@@ -87,15 +87,19 @@ describe("datadogProvider.init", () => {
       DD_CLIENT_TOKEN: "token",
       DD_SITE: "us3.datadoghq.com",
       DD_SERVICE: "custom-service",
+      DD_ENV: "staging",
       DD_RUM_SAMPLE_RATE: "25",
       DD_SESSION_REPLAY_SAMPLE_RATE: "10",
+      DD_TRACE_SAMPLE_RATE: "50",
     });
     datadogProvider.init(ctx);
     config = lastInitConfig();
     expect(config.site).toBe("us3.datadoghq.com");
     expect(config.service).toBe("custom-service");
+    expect(config.env).toBe("staging"); // DD_ENV overrides context.env
     expect(config.sessionSampleRate).toBe(25);
     expect(config.sessionReplaySampleRate).toBe(10);
+    expect(config.traceSampleRate).toBe(50);
   });
 
   it("falls back to defaults when a sample rate is non-numeric", () => {
@@ -118,6 +122,7 @@ describe("datadogProvider.init", () => {
 
     expect(matcher(`${origin}/api-proxy/telemetry.v1.TelemetryService/Get`)).toBe(true);
     expect(matcher(`${origin}/other/path`)).toBe(false);
+    expect(matcher(`${origin}/api-proxy-internal/x`)).toBe(false); // sibling path not swept in
     expect(matcher("https://third-party.example.com/api-proxy/x")).toBe(false);
   });
 });

--- a/client/src/shared/observability/providers/datadog.test.ts
+++ b/client/src/shared/observability/providers/datadog.test.ts
@@ -125,21 +125,35 @@ describe("datadogProvider.init", () => {
     expect(config.traceSampleRate).toBe(0);
   });
 
-  it("masks replay content and scrubs resource URL query strings before sending", () => {
+  it("masks replay content and scrubs query strings from view and resource URLs", () => {
     setRuntimeConfig({ DD_APPLICATION_ID: "app-id", DD_CLIENT_TOKEN: "token" });
     datadogProvider.init(ctx);
     const config = lastInitConfig();
 
     expect(config.defaultPrivacyLevel).toBe("mask");
 
-    const beforeSend = config.beforeSend as (event: { type: string; resource?: { url: string } }) => boolean;
+    const origin = window.location.origin;
+    const beforeSend = config.beforeSend as (event: {
+      type: string;
+      view: { url: string; referrer?: string };
+      resource?: { url: string };
+    }) => boolean;
+
+    // Resource event: view URL, referrer, and resource URL are all scrubbed.
     const resourceEvent = {
       type: "resource",
-      resource: { url: `${window.location.origin}/api-proxy/svc/Method?minerId=abc123&token=secret` },
+      view: { url: `${origin}/fleet/miners?subnet=10.0.0.0/24&rackId=r1`, referrer: `${origin}/x?token=t` },
+      resource: { url: `${origin}/api-proxy/svc/Method?minerId=abc123&token=secret` },
     };
-    const kept = beforeSend(resourceEvent);
-    expect(kept).toBe(true);
-    expect(resourceEvent.resource?.url).toBe(`${window.location.origin}/api-proxy/svc/Method`);
+    expect(beforeSend(resourceEvent)).toBe(true);
+    expect(resourceEvent.view.url).toBe(`${origin}/fleet/miners`);
+    expect(resourceEvent.view.referrer).toBe(`${origin}/x`);
+    expect(resourceEvent.resource?.url).toBe(`${origin}/api-proxy/svc/Method`);
+
+    // Non-resource (view) event: the view URL is still scrubbed.
+    const viewEvent = { type: "view", view: { url: `${origin}/fleet/miners?buildingId=b2` } };
+    expect(beforeSend(viewEvent)).toBe(true);
+    expect(viewEvent.view.url).toBe(`${origin}/fleet/miners`);
   });
 
   it("scopes distributed tracing to same-origin API calls only", () => {

--- a/client/src/shared/observability/providers/datadog.test.ts
+++ b/client/src/shared/observability/providers/datadog.test.ts
@@ -112,6 +112,36 @@ describe("datadogProvider.init", () => {
     expect(lastInitConfig().sessionSampleRate).toBe(100);
   });
 
+  it("clamps out-of-range sample rates to 0-100", () => {
+    setRuntimeConfig({
+      DD_APPLICATION_ID: "app-id",
+      DD_CLIENT_TOKEN: "token",
+      DD_RUM_SAMPLE_RATE: "1000",
+      DD_TRACE_SAMPLE_RATE: "-5",
+    });
+    datadogProvider.init(ctx);
+    const config = lastInitConfig();
+    expect(config.sessionSampleRate).toBe(100);
+    expect(config.traceSampleRate).toBe(0);
+  });
+
+  it("masks replay content and scrubs resource URL query strings before sending", () => {
+    setRuntimeConfig({ DD_APPLICATION_ID: "app-id", DD_CLIENT_TOKEN: "token" });
+    datadogProvider.init(ctx);
+    const config = lastInitConfig();
+
+    expect(config.defaultPrivacyLevel).toBe("mask");
+
+    const beforeSend = config.beforeSend as (event: { type: string; resource?: { url: string } }) => boolean;
+    const resourceEvent = {
+      type: "resource",
+      resource: { url: `${window.location.origin}/api-proxy/svc/Method?minerId=abc123&token=secret` },
+    };
+    const kept = beforeSend(resourceEvent);
+    expect(kept).toBe(true);
+    expect(resourceEvent.resource?.url).toBe(`${window.location.origin}/api-proxy/svc/Method`);
+  });
+
   it("scopes distributed tracing to same-origin API calls only", () => {
     setRuntimeConfig({ DD_APPLICATION_ID: "app-id", DD_CLIENT_TOKEN: "token" });
     datadogProvider.init(ctx);

--- a/client/src/shared/observability/providers/datadog.ts
+++ b/client/src/shared/observability/providers/datadog.ts
@@ -1,0 +1,68 @@
+import { datadogRum } from "@datadog/browser-rum";
+import type { RumInitConfiguration } from "@datadog/browser-rum";
+
+import { getConfigValue } from "../runtimeConfig";
+import type { ObservabilityErrorMeta, ObservabilityInitContext, ObservabilityProvider } from "../types";
+
+/** Required config keys — the provider is a no-op unless both are present. */
+const REQUIRED_KEYS = ["DD_APPLICATION_ID", "DD_CLIENT_TOKEN"] as const;
+
+const parseSampleRate = (value: string | undefined, fallback: number): number => {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+/** Distributed tracing scope: same-origin requests under the API base path
+ * (e.g. `/api-proxy/...`). Datadog RUM injects trace headers on matching fetch
+ * calls, so ConnectRPC RPCs — which go through the global fetch — are traced. */
+const makeApiTracingMatcher =
+  (apiTracingOrigin: string) =>
+  (url: string): boolean => {
+    try {
+      const parsed = new URL(url, window.location.origin);
+      return parsed.origin === window.location.origin && parsed.pathname.startsWith(apiTracingOrigin);
+    } catch {
+      return false;
+    }
+  };
+
+export const datadogProvider: ObservabilityProvider = {
+  name: "datadog",
+
+  isConfigured(): boolean {
+    return REQUIRED_KEYS.every((key) => getConfigValue(key) !== undefined);
+  },
+
+  init(context: ObservabilityInitContext): void {
+    const applicationId = getConfigValue("DD_APPLICATION_ID");
+    const clientToken = getConfigValue("DD_CLIENT_TOKEN");
+    if (!applicationId || !clientToken) {
+      return;
+    }
+
+    const config: RumInitConfiguration = {
+      applicationId,
+      clientToken,
+      site: (getConfigValue("DD_SITE") ?? "datadoghq.com") as RumInitConfiguration["site"],
+      service: getConfigValue("DD_SERVICE") ?? context.service,
+      env: getConfigValue("DD_ENV") ?? context.env,
+      version: context.version,
+      sessionSampleRate: parseSampleRate(getConfigValue("DD_RUM_SAMPLE_RATE"), 100),
+      sessionReplaySampleRate: parseSampleRate(getConfigValue("DD_SESSION_REPLAY_SAMPLE_RATE"), 0),
+      traceSampleRate: parseSampleRate(getConfigValue("DD_TRACE_SAMPLE_RATE"), 100),
+      trackResources: true,
+      trackLongTasks: true,
+      trackUserInteractions: true,
+      allowedTracingUrls: [makeApiTracingMatcher(context.apiTracingOrigin)],
+    };
+
+    datadogRum.init(config);
+  },
+
+  reportError(error: unknown, meta?: ObservabilityErrorMeta): void {
+    datadogRum.addError(error, meta);
+  },
+};

--- a/client/src/shared/observability/providers/datadog.ts
+++ b/client/src/shared/observability/providers/datadog.ts
@@ -17,13 +17,18 @@ const parseSampleRate = (value: string | undefined, fallback: number): number =>
 
 /** Distributed tracing scope: same-origin requests under the API base path
  * (e.g. `/api-proxy/...`). Datadog RUM injects trace headers on matching fetch
- * calls, so ConnectRPC RPCs — which go through the global fetch — are traced. */
+ * calls, so ConnectRPC RPCs — which go through the global fetch — are traced.
+ * Matches the prefix on a path boundary so a sibling like `/api-proxy-internal`
+ * is not swept in. */
 const makeApiTracingMatcher =
-  (apiTracingOrigin: string) =>
+  (apiTracingPathPrefix: string) =>
   (url: string): boolean => {
     try {
       const parsed = new URL(url, window.location.origin);
-      return parsed.origin === window.location.origin && parsed.pathname.startsWith(apiTracingOrigin);
+      if (parsed.origin !== window.location.origin) {
+        return false;
+      }
+      return parsed.pathname === apiTracingPathPrefix || parsed.pathname.startsWith(`${apiTracingPathPrefix}/`);
     } catch {
       return false;
     }
@@ -56,7 +61,7 @@ export const datadogProvider: ObservabilityProvider = {
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-      allowedTracingUrls: [makeApiTracingMatcher(context.apiTracingOrigin)],
+      allowedTracingUrls: [makeApiTracingMatcher(context.apiTracingPathPrefix)],
     };
 
     datadogRum.init(config);

--- a/client/src/shared/observability/providers/datadog.ts
+++ b/client/src/shared/observability/providers/datadog.ts
@@ -3,6 +3,7 @@ import type { RumEvent, RumInitConfiguration } from "@datadog/browser-rum";
 
 import { getConfigValue } from "../runtimeConfig";
 import type { ObservabilityErrorMeta, ObservabilityInitContext, ObservabilityProvider } from "../types";
+import { clamp } from "@/shared/utils/math";
 
 /** Required config keys — the provider is a no-op unless both are present. */
 const REQUIRED_KEYS = ["DD_APPLICATION_ID", "DD_CLIENT_TOKEN"] as const;
@@ -17,7 +18,7 @@ const parseSampleRate = (value: string | undefined, fallback: number): number =>
   if (!Number.isFinite(parsed)) {
     return fallback;
   }
-  return Math.min(100, Math.max(0, parsed));
+  return clamp(parsed, 0, 100);
 };
 
 /** Drop the query string (and fragment) from a URL, keeping origin + path.
@@ -32,12 +33,10 @@ const stripUrlQuery = (url: string): string => {
   }
 };
 
-/** beforeSend scrubber: redact query strings from URL fields before events
- * leave the browser. Every event carries the active view URL, and ProtoFleet
- * stores fleet context (group/rack/building IDs, subnet filters) in the query
- * string, so the view URL/referrer are scrubbed on all event types, plus the
- * resource URL on resource events. Extension point for further redaction
- * (action names, error metadata) if the UI surfaces more sensitive strings. */
+/** beforeSend scrubber: strip query strings from URL fields as defense-in-depth
+ * data minimization. ProtoFleet keeps operational context (group/rack/building
+ * IDs, subnet filters) there, and RUM does not need it for route-level analysis.
+ * Extend here if the UI later surfaces sensitive strings in other fields. */
 const scrubEvent = (event: RumEvent): boolean => {
   event.view.url = stripUrlQuery(event.view.url);
   if (event.view.referrer) {

--- a/client/src/shared/observability/providers/datadog.ts
+++ b/client/src/shared/observability/providers/datadog.ts
@@ -1,5 +1,5 @@
 import { datadogRum } from "@datadog/browser-rum";
-import type { RumInitConfiguration } from "@datadog/browser-rum";
+import type { RumEvent, RumInitConfiguration } from "@datadog/browser-rum";
 
 import { getConfigValue } from "../runtimeConfig";
 import type { ObservabilityErrorMeta, ObservabilityInitContext, ObservabilityProvider } from "../types";
@@ -7,12 +7,39 @@ import type { ObservabilityErrorMeta, ObservabilityInitContext, ObservabilityPro
 /** Required config keys — the provider is a no-op unless both are present. */
 const REQUIRED_KEYS = ["DD_APPLICATION_ID", "DD_CLIENT_TOKEN"] as const;
 
+/** Parse a sample rate, clamped to the documented 0-100 range so a
+ * misconfigured value (e.g. 1000 or -1) can't produce unexpected sampling. */
 const parseSampleRate = (value: string | undefined, fallback: number): number => {
   if (value === undefined) {
     return fallback;
   }
   const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.min(100, Math.max(0, parsed));
+};
+
+/** Drop the query string (and fragment) from a URL, keeping origin + path.
+ * Query params on fleet API/resource URLs can carry identifiers or filters we
+ * don't want leaving the browser. Returns the input unchanged if unparseable. */
+const stripUrlQuery = (url: string): string => {
+  try {
+    const parsed = new URL(url, window.location.origin);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+};
+
+/** beforeSend scrubber: redact query strings from resource URLs before events
+ * leave the browser. This is the extension point for further redaction (action
+ * names, error metadata) if the fleet UI surfaces more sensitive strings. */
+const scrubEvent = (event: RumEvent): boolean => {
+  if (event.type === "resource" && event.resource.url) {
+    event.resource.url = stripUrlQuery(event.resource.url);
+  }
+  return true;
 };
 
 /** Distributed tracing scope: same-origin requests under the API base path
@@ -56,12 +83,16 @@ export const datadogProvider: ObservabilityProvider = {
       env: getConfigValue("DD_ENV") ?? context.env,
       version: context.version,
       sessionSampleRate: parseSampleRate(getConfigValue("DD_RUM_SAMPLE_RATE"), 100),
+      // Session Replay is off by default (rate 0); when an operator enables it,
+      // mask all text and inputs so rendered fleet data isn't recorded verbatim.
       sessionReplaySampleRate: parseSampleRate(getConfigValue("DD_SESSION_REPLAY_SAMPLE_RATE"), 0),
+      defaultPrivacyLevel: "mask",
       traceSampleRate: parseSampleRate(getConfigValue("DD_TRACE_SAMPLE_RATE"), 100),
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
       allowedTracingUrls: [makeApiTracingMatcher(context.apiTracingPathPrefix)],
+      beforeSend: scrubEvent,
     };
 
     datadogRum.init(config);

--- a/client/src/shared/observability/providers/datadog.ts
+++ b/client/src/shared/observability/providers/datadog.ts
@@ -32,10 +32,17 @@ const stripUrlQuery = (url: string): string => {
   }
 };
 
-/** beforeSend scrubber: redact query strings from resource URLs before events
- * leave the browser. This is the extension point for further redaction (action
- * names, error metadata) if the fleet UI surfaces more sensitive strings. */
+/** beforeSend scrubber: redact query strings from URL fields before events
+ * leave the browser. Every event carries the active view URL, and ProtoFleet
+ * stores fleet context (group/rack/building IDs, subnet filters) in the query
+ * string, so the view URL/referrer are scrubbed on all event types, plus the
+ * resource URL on resource events. Extension point for further redaction
+ * (action names, error metadata) if the UI surfaces more sensitive strings. */
 const scrubEvent = (event: RumEvent): boolean => {
+  event.view.url = stripUrlQuery(event.view.url);
+  if (event.view.referrer) {
+    event.view.referrer = stripUrlQuery(event.view.referrer);
+  }
   if (event.type === "resource" && event.resource.url) {
     event.resource.url = stripUrlQuery(event.resource.url);
   }

--- a/client/src/shared/observability/registry.test.ts
+++ b/client/src/shared/observability/registry.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetObservabilityForTests,
+  initObservability,
+  observabilityInterceptors,
+  registerProvider,
+  reportObservabilityError,
+} from "./registry";
+import type { ObservabilityInitContext, ObservabilityProvider } from "./types";
+
+const ctx: ObservabilityInitContext = {
+  service: "test-service",
+  version: "test-commit",
+  env: "test",
+  apiTracingOrigin: "/api-proxy",
+};
+
+beforeEach(() => {
+  __resetObservabilityForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("initObservability", () => {
+  it("initializes a configured provider once with the context", () => {
+    const init = vi.fn();
+    registerProvider({ name: "configured", isConfigured: () => true, init });
+
+    initObservability(ctx);
+
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(init).toHaveBeenCalledWith(ctx);
+  });
+
+  it("skips an unconfigured provider", () => {
+    const init = vi.fn();
+    registerProvider({ name: "unconfigured", isConfigured: () => false, init });
+
+    initObservability(ctx);
+
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it("isolates a provider init failure so other providers still initialize", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const goodInit = vi.fn();
+    registerProvider({
+      name: "throwing",
+      isConfigured: () => true,
+      init: () => {
+        throw new Error("boom");
+      },
+    });
+    registerProvider({ name: "good", isConfigured: () => true, init: goodInit });
+
+    expect(() => initObservability(ctx)).not.toThrow();
+    expect(goodInit).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it("is idempotent: a second call does not re-initialize providers", () => {
+    const init = vi.fn();
+    registerProvider({ name: "configured", isConfigured: () => true, init });
+
+    initObservability(ctx);
+    initObservability(ctx);
+
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("registerProvider", () => {
+  it("does not register the same provider name twice", () => {
+    const initA = vi.fn();
+    const initB = vi.fn();
+    registerProvider({ name: "dup", isConfigured: () => true, init: initA });
+    registerProvider({ name: "dup", isConfigured: () => true, init: initB });
+
+    initObservability(ctx);
+
+    expect(initA).toHaveBeenCalledTimes(1);
+    expect(initB).not.toHaveBeenCalled();
+  });
+});
+
+describe("reportObservabilityError", () => {
+  it("forwards only to configured providers that implement reportError", () => {
+    const configuredReport = vi.fn();
+    const unconfiguredReport = vi.fn();
+    registerProvider({
+      name: "configured",
+      isConfigured: () => true,
+      init: vi.fn(),
+      reportError: configuredReport,
+    });
+    registerProvider({
+      name: "unconfigured",
+      isConfigured: () => false,
+      init: vi.fn(),
+      reportError: unconfiguredReport,
+    });
+
+    const error = new Error("render failed");
+    reportObservabilityError(error, { react: "info" });
+
+    expect(configuredReport).toHaveBeenCalledWith(error, { react: "info" });
+    expect(unconfiguredReport).not.toHaveBeenCalled();
+  });
+
+  it("never throws when a provider's reportError throws", () => {
+    registerProvider({
+      name: "throwing",
+      isConfigured: () => true,
+      init: vi.fn(),
+      reportError: () => {
+        throw new Error("report boom");
+      },
+    });
+
+    expect(() => reportObservabilityError(new Error("x"))).not.toThrow();
+  });
+});
+
+describe("observabilityInterceptors", () => {
+  it("collects interceptors only from configured providers", () => {
+    const interceptor = ((next) => next) as ReturnType<
+      NonNullable<ObservabilityProvider["connectInterceptors"]>
+    >[number];
+    registerProvider({
+      name: "configured",
+      isConfigured: () => true,
+      init: vi.fn(),
+      connectInterceptors: () => [interceptor],
+    });
+    registerProvider({
+      name: "unconfigured",
+      isConfigured: () => false,
+      init: vi.fn(),
+      connectInterceptors: () => [interceptor],
+    });
+
+    expect(observabilityInterceptors()).toEqual([interceptor]);
+  });
+
+  it("returns an empty array when no provider contributes interceptors", () => {
+    registerProvider({ name: "plain", isConfigured: () => true, init: vi.fn() });
+    expect(observabilityInterceptors()).toEqual([]);
+  });
+});

--- a/client/src/shared/observability/registry.test.ts
+++ b/client/src/shared/observability/registry.test.ts
@@ -13,7 +13,7 @@ const ctx: ObservabilityInitContext = {
   service: "test-service",
   version: "test-commit",
   env: "test",
-  apiTracingOrigin: "/api-proxy",
+  apiTracingPathPrefix: "/api-proxy",
 };
 
 beforeEach(() => {
@@ -148,5 +148,15 @@ describe("observabilityInterceptors", () => {
   it("returns an empty array when no provider contributes interceptors", () => {
     registerProvider({ name: "plain", isConfigured: () => true, init: vi.fn() });
     expect(observabilityInterceptors()).toEqual([]);
+  });
+
+  it("concatenates interceptors from multiple configured providers in registration order", () => {
+    type Interceptor = ReturnType<NonNullable<ObservabilityProvider["connectInterceptors"]>>[number];
+    const first = ((next) => next) as Interceptor;
+    const second = ((next) => next) as Interceptor;
+    registerProvider({ name: "a", isConfigured: () => true, init: vi.fn(), connectInterceptors: () => [first] });
+    registerProvider({ name: "b", isConfigured: () => true, init: vi.fn(), connectInterceptors: () => [second] });
+
+    expect(observabilityInterceptors()).toEqual([first, second]);
   });
 });

--- a/client/src/shared/observability/registry.ts
+++ b/client/src/shared/observability/registry.ts
@@ -3,11 +3,8 @@ import type { Interceptor } from "@connectrpc/connect";
 import type { ObservabilityErrorMeta, ObservabilityInitContext, ObservabilityProvider } from "./types";
 
 /**
- * Vendor-neutral observability registry.
- *
- * Providers register themselves (see `providers.ts`, imported for its side effect
- * at app startup). Adding a new backend means writing one provider module and
- * registering it here — no changes to the entry point, transport, or error boundary.
+ * Vendor-neutral observability registry. Providers register themselves via
+ * `providers.ts`, imported for its side effect at app startup.
  */
 
 const providers: ObservabilityProvider[] = [];

--- a/client/src/shared/observability/registry.ts
+++ b/client/src/shared/observability/registry.ts
@@ -1,0 +1,72 @@
+import type { Interceptor } from "@connectrpc/connect";
+
+import type { ObservabilityErrorMeta, ObservabilityInitContext, ObservabilityProvider } from "./types";
+
+/**
+ * Vendor-neutral observability registry.
+ *
+ * Providers register themselves (see `providers.ts`, imported for its side effect
+ * at app startup). Adding a new backend means writing one provider module and
+ * registering it here — no changes to the entry point, transport, or error boundary.
+ */
+
+const providers: ObservabilityProvider[] = [];
+let initialized = false;
+
+/** Register a provider. Idempotent by `name`. */
+export const registerProvider = (provider: ObservabilityProvider): void => {
+  if (!providers.some((existing) => existing.name === provider.name)) {
+    providers.push(provider);
+  }
+};
+
+/** Initialize every configured provider exactly once. A provider failure is
+ * isolated so it can never block app startup. */
+export const initObservability = (context: ObservabilityInitContext): void => {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+
+  for (const provider of providers) {
+    if (!provider.isConfigured()) {
+      continue;
+    }
+    try {
+      provider.init(context);
+    } catch (error) {
+      console.error(`[observability] provider "${provider.name}" failed to initialize`, error);
+    }
+  }
+};
+
+/** Forward a captured error to every configured provider. Never throws. */
+export const reportObservabilityError = (error: unknown, meta?: ObservabilityErrorMeta): void => {
+  for (const provider of providers) {
+    if (!provider.isConfigured() || !provider.reportError) {
+      continue;
+    }
+    try {
+      provider.reportError(error, meta);
+    } catch {
+      // Error reporting must never surface its own failure.
+    }
+  }
+};
+
+/** Collect ConnectRPC interceptors contributed by configured providers. */
+export const observabilityInterceptors = (): Interceptor[] => {
+  const interceptors: Interceptor[] = [];
+  for (const provider of providers) {
+    if (provider.isConfigured() && provider.connectInterceptors) {
+      interceptors.push(...provider.connectInterceptors());
+    }
+  }
+  return interceptors;
+};
+
+/** Reset registry state. Test-only. */
+export const __resetObservabilityForTests = (): void => {
+  providers.length = 0;
+  initialized = false;
+};

--- a/client/src/shared/observability/runtimeConfig.test.ts
+++ b/client/src/shared/observability/runtimeConfig.test.ts
@@ -2,10 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getConfigValue } from "./runtimeConfig";
 
-type MutableWindow = Window & { __RUNTIME_CONFIG__?: Record<string, string> };
-
 const clearRuntimeConfig = () => {
-  delete (window as MutableWindow).__RUNTIME_CONFIG__;
+  delete window.__RUNTIME_CONFIG__;
 };
 
 describe("getConfigValue", () => {
@@ -17,7 +15,7 @@ describe("getConfigValue", () => {
   });
 
   it("returns the runtime value when present", () => {
-    (window as MutableWindow).__RUNTIME_CONFIG__ = { DD_CLIENT_TOKEN: "runtime-token" };
+    window.__RUNTIME_CONFIG__ = { DD_CLIENT_TOKEN: "runtime-token" };
     expect(getConfigValue("DD_CLIENT_TOKEN")).toBe("runtime-token");
   });
 
@@ -28,13 +26,13 @@ describe("getConfigValue", () => {
 
   it("prefers the runtime value over the build-time value", () => {
     vi.stubEnv("VITE_DD_CLIENT_TOKEN", "build-token");
-    (window as MutableWindow).__RUNTIME_CONFIG__ = { DD_CLIENT_TOKEN: "runtime-token" };
+    window.__RUNTIME_CONFIG__ = { DD_CLIENT_TOKEN: "runtime-token" };
     expect(getConfigValue("DD_CLIENT_TOKEN")).toBe("runtime-token");
   });
 
   it("treats an empty or whitespace runtime value as unset and falls back", () => {
     vi.stubEnv("VITE_DD_CLIENT_TOKEN", "build-token");
-    (window as MutableWindow).__RUNTIME_CONFIG__ = { DD_CLIENT_TOKEN: "   " };
+    window.__RUNTIME_CONFIG__ = { DD_CLIENT_TOKEN: "   " };
     expect(getConfigValue("DD_CLIENT_TOKEN")).toBe("build-token");
   });
 

--- a/client/src/shared/observability/runtimeConfig.test.ts
+++ b/client/src/shared/observability/runtimeConfig.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getConfigValue } from "./runtimeConfig";
+
+type MutableWindow = Window & { __RUNTIME_CONFIG__?: Record<string, string> };
+
+const clearRuntimeConfig = () => {
+  delete (window as MutableWindow).__RUNTIME_CONFIG__;
+};
+
+describe("getConfigValue", () => {
+  beforeEach(clearRuntimeConfig);
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearRuntimeConfig();
+  });
+
+  it("returns the runtime value when present", () => {
+    (window as MutableWindow).__RUNTIME_CONFIG__ = { DD_CLIENT_TOKEN: "runtime-token" };
+    expect(getConfigValue("DD_CLIENT_TOKEN")).toBe("runtime-token");
+  });
+
+  it("falls back to the build-time VITE_ value when there is no runtime value", () => {
+    vi.stubEnv("VITE_DD_CLIENT_TOKEN", "build-token");
+    expect(getConfigValue("DD_CLIENT_TOKEN")).toBe("build-token");
+  });
+
+  it("prefers the runtime value over the build-time value", () => {
+    vi.stubEnv("VITE_DD_CLIENT_TOKEN", "build-token");
+    (window as MutableWindow).__RUNTIME_CONFIG__ = { DD_CLIENT_TOKEN: "runtime-token" };
+    expect(getConfigValue("DD_CLIENT_TOKEN")).toBe("runtime-token");
+  });
+
+  it("treats an empty or whitespace runtime value as unset and falls back", () => {
+    vi.stubEnv("VITE_DD_CLIENT_TOKEN", "build-token");
+    (window as MutableWindow).__RUNTIME_CONFIG__ = { DD_CLIENT_TOKEN: "   " };
+    expect(getConfigValue("DD_CLIENT_TOKEN")).toBe("build-token");
+  });
+
+  it("returns undefined when neither source is set", () => {
+    expect(getConfigValue("DD_CLIENT_TOKEN")).toBeUndefined();
+  });
+});

--- a/client/src/shared/observability/runtimeConfig.ts
+++ b/client/src/shared/observability/runtimeConfig.ts
@@ -1,0 +1,38 @@
+/**
+ * Runtime-first configuration accessor for the observability layer.
+ *
+ * Resolution order for a key:
+ *   1. `window.__RUNTIME_CONFIG__[key]` — rendered by the deployment nginx image
+ *      at container start from operator-supplied environment variables. This lets
+ *      an operator enable a provider on a prebuilt client artifact without a rebuild.
+ *   2. `import.meta.env.VITE_<key>` — the build-time value used by local dev and CI.
+ *
+ * An empty (or whitespace-only) value is treated as unset so a rendered-but-blank
+ * runtime slot falls through to the build-time value (or `undefined`). Providers use
+ * this to stay a complete no-op when their required keys are absent.
+ */
+
+declare global {
+  interface Window {
+    __RUNTIME_CONFIG__?: Record<string, string>;
+  }
+}
+
+const normalize = (value: string | undefined): string | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+};
+
+export const getConfigValue = (key: string): string | undefined => {
+  const runtime = typeof window !== "undefined" ? window.__RUNTIME_CONFIG__?.[key] : undefined;
+  const runtimeValue = normalize(runtime);
+  if (runtimeValue !== undefined) {
+    return runtimeValue;
+  }
+
+  const env = import.meta.env as Record<string, string | undefined>;
+  return normalize(env[`VITE_${key}`]);
+};

--- a/client/src/shared/observability/types.ts
+++ b/client/src/shared/observability/types.ts
@@ -9,8 +9,8 @@ export interface ObservabilityInitContext {
   version: string;
   /** Deploy environment (e.g. "production", "staging", "dev"). */
   env: string;
-  /** Origin or path prefix of client→server API calls, used to scope distributed tracing. */
-  apiTracingOrigin: string;
+  /** Path prefix of same-origin client→server API calls, used to scope distributed tracing. */
+  apiTracingPathPrefix: string;
 }
 
 export type ObservabilityErrorMeta = Record<string, unknown>;

--- a/client/src/shared/observability/types.ts
+++ b/client/src/shared/observability/types.ts
@@ -1,0 +1,36 @@
+import type { Interceptor } from "@connectrpc/connect";
+
+/** Context passed to every provider at startup. App-specific values so `shared/`
+ * stays free of any dependency on a specific app (`protoFleet` / `protoOS`). */
+export interface ObservabilityInitContext {
+  /** Logical service name reported to the backend (e.g. "proto-fleet-client"). */
+  service: string;
+  /** Build identifier (commit or version) for correlating sessions to a release. */
+  version: string;
+  /** Deploy environment (e.g. "production", "staging", "dev"). */
+  env: string;
+  /** Origin or path prefix of client→server API calls, used to scope distributed tracing. */
+  apiTracingOrigin: string;
+}
+
+export type ObservabilityErrorMeta = Record<string, unknown>;
+
+/**
+ * A pluggable observability backend (Datadog, and later Sentry/PostHog).
+ *
+ * A provider is self-describing: it reads its own configuration and reports
+ * whether it `isConfigured()`. The registry only initializes configured providers,
+ * so an unconfigured provider is a complete no-op.
+ */
+export interface ObservabilityProvider {
+  /** Stable identifier, used in logs and to de-duplicate registration. */
+  readonly name: string;
+  /** True only when this provider's required configuration is present. */
+  isConfigured(): boolean;
+  /** Initialize the provider. Called at most once by the registry. */
+  init(context: ObservabilityInitContext): void;
+  /** Forward a captured error to the provider. Optional. */
+  reportError?(error: unknown, meta?: ObservabilityErrorMeta): void;
+  /** ConnectRPC interceptors this provider contributes for RPC instrumentation. Optional. */
+  connectInterceptors?(): Interceptor[];
+}

--- a/client/src/tests/setup.ts
+++ b/client/src/tests/setup.ts
@@ -4,6 +4,17 @@ import * as matchers from "@testing-library/jest-dom/matchers";
 
 expect.extend(matchers);
 
+// Datadog RUM SDK — mocked globally so tests never load the real SDK or hit the
+// network. Provider tests assert against these spies.
+vi.mock("@datadog/browser-rum", () => ({
+  datadogRum: {
+    init: vi.fn(),
+    addError: vi.fn(),
+    setUser: vi.fn(),
+    setGlobalContextProperty: vi.fn(),
+  },
+}));
+
 // eslint-disable-next-line no-undef
 global.ResizeObserver = class ResizeObserver {
   observe = vi.fn();

--- a/client/src/tests/setup.ts
+++ b/client/src/tests/setup.ts
@@ -10,8 +10,6 @@ vi.mock("@datadog/browser-rum", () => ({
   datadogRum: {
     init: vi.fn(),
     addError: vi.fn(),
-    setUser: vi.fn(),
-    setGlobalContextProperty: vi.fn(),
   },
 }));
 

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,1 +1,24 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Datadog RUM application ID. Required (with the client token) to enable RUM. */
+  readonly VITE_DD_APPLICATION_ID?: string;
+  /** Datadog RUM client token. Required (with the application ID) to enable RUM. */
+  readonly VITE_DD_CLIENT_TOKEN?: string;
+  /** Datadog site (e.g. "datadoghq.com", "us3.datadoghq.com"). Defaults to datadoghq.com. */
+  readonly VITE_DD_SITE?: string;
+  /** Service name reported to Datadog. Defaults to the app's init-context service. */
+  readonly VITE_DD_SERVICE?: string;
+  /** Deploy environment reported to Datadog. Defaults to the app's init-context env. */
+  readonly VITE_DD_ENV?: string;
+  /** RUM session sample rate, 0-100. Defaults to 100. */
+  readonly VITE_DD_RUM_SAMPLE_RATE?: string;
+  /** Session Replay sample rate, 0-100. Defaults to 0 (off). */
+  readonly VITE_DD_SESSION_REPLAY_SAMPLE_RATE?: string;
+  /** Distributed-tracing sample rate for API calls, 0-100. Defaults to 100. */
+  readonly VITE_DD_TRACE_SAMPLE_RATE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/deployment-files/client/Dockerfile
+++ b/deployment-files/client/Dockerfile
@@ -7,6 +7,12 @@ COPY protoFleet /usr/share/nginx/html
 # Copy custom nginx config for SSL and streams support
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
+# Render window.__RUNTIME_CONFIG__ into config.js from environment on container
+# start (nginx runs /docker-entrypoint.d/*.sh before starting). Lets an operator
+# enable observability via env vars without rebuilding the client.
+COPY docker-entrypoint.d/40-render-runtime-config.sh /docker-entrypoint.d/40-render-runtime-config.sh
+RUN chmod +x /docker-entrypoint.d/40-render-runtime-config.sh
+
 # Create directory for SSL certificates (mounted at runtime)
 RUN mkdir -p /etc/nginx/ssl
 

--- a/deployment-files/client/docker-entrypoint.d/40-render-runtime-config.sh
+++ b/deployment-files/client/docker-entrypoint.d/40-render-runtime-config.sh
@@ -14,10 +14,15 @@ emit_key() {
   key="$1"
   value="$2"
   [ -n "$value" ] || return 0
-  # Escape backslashes then double quotes for safe embedding in a JS string.
-  escaped=$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  # Strip CR/newlines (a raw newline would produce an unterminated JS string and
+  # brick config.js), then escape backslashes and double quotes for safe embedding.
+  escaped=$(printf '%s' "$value" | tr -d '\r\n' | sed 's/\\/\\\\/g; s/"/\\"/g')
   printf '  %s: "%s",\n' "$key" "$escaped" >> "$CONFIG_FILE"
 }
+
+# config.js is publicly served to browsers. Only emit public values (RUM
+# application ID / client token are public identifiers). Never add a secret
+# such as a Datadog API key (DD_API_KEY) to this list.
 
 emit_key "DD_APPLICATION_ID" "${DD_APPLICATION_ID:-}"
 emit_key "DD_CLIENT_TOKEN" "${DD_CLIENT_TOKEN:-}"

--- a/deployment-files/client/docker-entrypoint.d/40-render-runtime-config.sh
+++ b/deployment-files/client/docker-entrypoint.d/40-render-runtime-config.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Render runtime client configuration into config.js, read by the client as
+# window.__RUNTIME_CONFIG__. Only keys that are set are emitted, so an unset key
+# leaves the corresponding client provider a no-op. Runs on every container start
+# (nginx executes /docker-entrypoint.d/*.sh before starting); config.js is served
+# no-cache so operator changes take effect on restart without a rebuild.
+set -eu
+
+CONFIG_FILE="/usr/share/nginx/html/config.js"
+
+printf 'window.__RUNTIME_CONFIG__ = {\n' > "$CONFIG_FILE"
+
+emit_key() {
+  key="$1"
+  value="$2"
+  [ -n "$value" ] || return 0
+  # Escape backslashes then double quotes for safe embedding in a JS string.
+  escaped=$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  printf '  %s: "%s",\n' "$key" "$escaped" >> "$CONFIG_FILE"
+}
+
+emit_key "DD_APPLICATION_ID" "${DD_APPLICATION_ID:-}"
+emit_key "DD_CLIENT_TOKEN" "${DD_CLIENT_TOKEN:-}"
+emit_key "DD_SITE" "${DD_SITE:-}"
+emit_key "DD_SERVICE" "${DD_SERVICE:-}"
+emit_key "DD_ENV" "${DD_ENV:-}"
+emit_key "DD_RUM_SAMPLE_RATE" "${DD_RUM_SAMPLE_RATE:-}"
+emit_key "DD_SESSION_REPLAY_SAMPLE_RATE" "${DD_SESSION_REPLAY_SAMPLE_RATE:-}"
+emit_key "DD_TRACE_SAMPLE_RATE" "${DD_TRACE_SAMPLE_RATE:-}"
+
+printf '};\n' >> "$CONFIG_FILE"

--- a/deployment-files/client/nginx.http.conf
+++ b/deployment-files/client/nginx.http.conf
@@ -1,6 +1,14 @@
 server {
     listen 80;
 
+    # Runtime client config, regenerated from env at container start. Never cache
+    # so operator changes take effect on restart.
+    location = /config.js {
+        root /usr/share/nginx/html;
+        default_type application/javascript;
+        add_header Cache-Control "no-store" always;
+    }
+
     # React app root
     location / {
         root /usr/share/nginx/html;

--- a/deployment-files/client/nginx.https.conf
+++ b/deployment-files/client/nginx.https.conf
@@ -22,6 +22,14 @@ server {
     # HSTS - instruct browsers to always use HTTPS (1 hour for LAN/self-signed deployments)
     add_header Strict-Transport-Security "max-age=3600" always;
 
+    # Runtime client config, regenerated from env at container start. Never cache
+    # so operator changes take effect on restart.
+    location = /config.js {
+        root /usr/share/nginx/html;
+        default_type application/javascript;
+        add_header Cache-Control "no-store" always;
+    }
+
     # React app root
     location / {
         root /usr/share/nginx/html;

--- a/deployment-files/docker-compose.yaml
+++ b/deployment-files/docker-compose.yaml
@@ -56,6 +56,19 @@ services:
       - fleet-api
     restart: always
     network_mode: host
+    environment:
+      # Datadog RUM (client observability). All optional — unset keys leave RUM
+      # disabled (no-op). Set these in the operator .env to enable without a
+      # client rebuild; they are rendered into config.js at container start.
+      # DD_CLIENT_TOKEN is a public browser RUM client token, not a secret API key.
+      DD_APPLICATION_ID: "${DD_APPLICATION_ID:-}"
+      DD_CLIENT_TOKEN: "${DD_CLIENT_TOKEN:-}"
+      DD_SITE: "${DD_SITE:-}"
+      DD_SERVICE: "${DD_SERVICE:-}"
+      DD_ENV: "${DD_ENV:-}"
+      DD_RUM_SAMPLE_RATE: "${DD_RUM_SAMPLE_RATE:-}"
+      DD_SESSION_REPLAY_SAMPLE_RATE: "${DD_SESSION_REPLAY_SAMPLE_RATE:-}"
+      DD_TRACE_SAMPLE_RATE: "${DD_TRACE_SAMPLE_RATE:-}"
     volumes:
       - ./ssl:/etc/nginx/ssl:ro
     logging:

--- a/docs/plans/2026-07-11-001-feat-client-observability-datadog-rum-plan.md
+++ b/docs/plans/2026-07-11-001-feat-client-observability-datadog-rum-plan.md
@@ -1,0 +1,463 @@
+---
+title: "feat: Pluggable client observability with Datadog RUM + API tracing"
+date: 2026-07-11
+status: proposed
+type: feat
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+---
+
+# feat: Pluggable client observability with Datadog RUM + API tracing
+
+## Summary
+
+Add a vendor-neutral observability layer to the ProtoFleet web client. A small provider
+registry initializes any configured backend at startup; a Datadog RUM provider is the first
+implementation. When the required Datadog config keys are present the provider initializes
+RUM (page/session monitoring, error capture, and distributed tracing on client→server API
+calls); when they are absent it is a complete no-op. The abstraction is shaped so Sentry or
+PostHog can be added later by writing one more provider file — no changes to the entry point,
+transport, or error boundary.
+
+Config resolves **runtime-first with a build-time fallback**: deployed operators set OS env
+vars that nginx renders into a `window.__RUNTIME_CONFIG__` blob at container start (no
+rebuild), while local dev and CI builds continue to use Vite `VITE_*` vars. This matches the
+repo's existing "operator edits an env file, containers read it" deployment model.
+
+Distributed tracing links front-end RUM sessions to the existing backend OTEL pipeline so
+latency on specific RPCs can be traced end-to-end.
+
+**Product Contract preservation:** N/A — solo plan (`ce-plan-bootstrap`), no upstream
+brainstorm to preserve.
+
+---
+
+## Problem Frame
+
+Operators and developers currently have no visibility into client-side behavior: page load
+performance, JS errors reaching users, or where latency originates on a slow API call. There
+is no error/analytics/telemetry integration anywhere in `client/` today (confirmed: the only
+`useTelemetry*` code is miner-domain data, not app observability). When a user reports "the
+fleet page is slow," there is no signal to say whether the cost is client render, network, or
+server handling.
+
+We want:
+1. A way to turn on Datadog RUM by configuration, with a clean no-op when unconfigured.
+2. A bootstrapping pattern generic enough that Sentry/PostHog follow the same shape.
+3. Distributed traces on client→server API calls to troubleshoot latency.
+
+### Scope Boundaries
+
+**In scope**
+- Generic observability provider interface + registry + startup bootstrap (in `shared/`).
+- Datadog RUM provider (init, error capture, tracing config).
+- Runtime-config accessor with build-time (`VITE_*`) fallback.
+- Distributed tracing on ConnectRPC calls, correlated to the backend.
+- Wiring into the ProtoFleet entry point and error boundary.
+- Deployment plumbing so operators can enable via env vars without a rebuild.
+
+### Deferred to Follow-Up Work
+- Wiring the same bootstrap into the **protoOS** client (`client/src/protoOS/mainWrapper.tsx`).
+  The abstraction lives in `shared/` and is designed for it, but protoOS enablement is a
+  separate change.
+- Actual Sentry / PostHog providers (the pattern is proven by Datadog; no second provider is
+  built here).
+- Datadog Session Replay tuning beyond a sample-rate knob (default off).
+- Custom RUM actions / user identification beyond anonymous session + build metadata.
+- Server-side trace ingestion changes beyond confirming header acceptance (see Risks).
+
+### Non-goals
+- Replacing or changing the miner-telemetry domain features (`useTelemetryMetrics`, etc.).
+- Building an in-house metrics/telemetry backend — this integrates a vendor SDK.
+
+---
+
+## Requirements
+
+- **R1** — A provider is initialized only when its required config keys are present; otherwise
+  the app runs unchanged with zero SDK side effects (no network, no globals patched).
+- **R2** — Adding a new provider (Sentry/PostHog) requires writing one provider module and
+  registering it; no edits to the entry point, transport, or error boundary.
+- **R3** — Datadog RUM, when enabled, captures page/session data and forwards React
+  render-time errors caught by the shared `ErrorBoundary`.
+- **R4** — Client→server API calls (ConnectRPC) carry trace context that correlates with the
+  backend so a slow RPC can be traced end-to-end.
+- **R5** — Configuration is resolvable at deploy time by an operator (runtime injection) and
+  at dev/CI time via `VITE_*`, through one accessor with a documented precedence.
+- **R6** — A provider `init()` failure must not crash or block app startup.
+- **R7** — Datadog config keys are typed (no untyped `import.meta.env` access for new vars).
+
+---
+
+## Key Technical Decisions
+
+**KTD1 — Provider registry pattern, abstraction in `client/src/shared/observability/`.**
+A provider-agnostic interface + registry lives in `shared/` (mirroring how `version.ts` and
+`ErrorBoundary` are shared across both apps). Providers are self-describing: each reads its own
+config and reports whether it `isConfigured()`. The registry iterates registered providers and
+initializes the configured ones. Rationale: satisfies R2 and keeps app code vendor-free;
+`shared/` must not import `@/protoFleet` or `@/protoOS` (app-specific values are passed in as
+an init context).
+
+**KTD2 — Datadog distributed tracing via RUM `allowedTracingUrls`, not a bespoke interceptor.**
+`@datadog/browser-rum` instruments the global `fetch`; connect-web's transport calls global
+`fetch` (its custom wrapper delegates to it), so configuring `allowedTracingUrls` to match the
+`/api-proxy` origin makes RUM inject `traceparent` / `x-datadog-*` headers on every RPC and
+tie them to RUM resource timings + backend APM. This is the supported, RUM-correlated path and
+requires no change to how the ~25 clients are built (all share one transport). Rationale:
+directly serves R4 and "troubleshoot latency" with front-end↔back-end correlation.
+
+**KTD3 — Vendor-neutral interceptor seam kept, unused by Datadog.**
+The registry exposes an optional `observabilityInterceptors()` contribution that the transport
+composes into `createConnectTransport({ interceptors })`. Datadog returns none (it uses
+`allowedTracingUrls`), but the seam lets a future provider that does *not* auto-instrument
+fetch add explicit RPC instrumentation without touching transport code. Avoids double header
+injection today while keeping R2 true for tracing, not just init.
+
+**KTD4 — Runtime-config accessor with build-time fallback.**
+A single `getConfigValue(key)` reads `window.__RUNTIME_CONFIG__?.[key]` first, then falls back
+to `import.meta.env['VITE_' + key]`. Deployed nginx renders `window.__RUNTIME_CONFIG__` from
+container env at start; dev/CI use `VITE_*`. Rationale: satisfies R5 and the "operator
+configures → enabled" intent for prebuilt static artifacts, while preserving the established
+`VITE_*` dev ergonomics. Precedence (runtime > build-time) lets an operator override a baked
+default.
+
+**KTD5 — Enablement = both required Datadog keys present.**
+`DD_APPLICATION_ID` and `DD_CLIENT_TOKEN` are the required keys; all others have defaults. This
+is the single enable/no-op switch (R1).
+
+**KTD6 — Error forwarding through the existing `ErrorBoundary.onError` seam.**
+The shared `ErrorBoundary` already calls `props.onError?.(normalized, errorInfo)`. ProtoFleet's
+`App` passes an `onError` that fans out to `reportObservabilityError(...)`. No new error
+plumbing; unconfigured → the fan-out is a no-op (R3, R6).
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+  subgraph Startup
+    MW[mainWrapper.tsx] -->|initObservability ctx| REG[observability registry]
+    REG -->|isConfigured?| DD[Datadog provider]
+    DD -->|yes| RUMINIT[datadogRum.init + allowedTracingUrls]
+    DD -->|no| NOOP[no-op]
+  end
+  subgraph Config
+    RTC["getConfigValue(key)"] --> WIN["window.__RUNTIME_CONFIG__ (nginx-rendered)"]
+    RTC --> VITE["import.meta.env.VITE_* (dev/CI)"]
+    DD --> RTC
+  end
+  subgraph Runtime
+    APP[App.tsx ErrorBoundary onError] --> RE["reportObservabilityError()"] --> REG
+    TR[transport.ts createConnectTransport] -->|observabilityInterceptors| REG
+    FETCH[global fetch on /api-proxy] -->|RUM allowedTracingUrls| TRACE[traceparent / x-datadog-*]
+    TRACE --> BE[backend OTEL collector -> APM]
+  end
+```
+
+Config precedence for every key: `window.__RUNTIME_CONFIG__[KEY]` → `import.meta.env.VITE_KEY`
+→ provider default.
+
+---
+
+## Output Structure
+
+```
+client/src/shared/observability/
+├── index.ts                     # barrel: initObservability, reportObservabilityError, observabilityInterceptors
+├── types.ts                     # ObservabilityProvider, ObservabilityInitContext
+├── registry.ts                  # provider list + iterate/guard/init logic
+├── runtimeConfig.ts             # getConfigValue(key) runtime-first accessor + window typing
+├── registry.test.ts
+├── runtimeConfig.test.ts
+└── providers/
+    ├── datadog.ts               # Datadog RUM provider
+    └── datadog.test.ts
+```
+
+---
+
+## Implementation Units
+
+### U1. Add Datadog SDK dependency and typed env vars
+
+**Goal:** Make `@datadog/browser-rum` available and type the new config vars.
+**Requirements:** R7.
+**Dependencies:** none.
+**Files:**
+- `client/package.json` (add `@datadog/browser-rum`, exact-pinned per repo convention)
+- `client/package-lock.json` (regenerated)
+- `client/src/vite-env.d.ts` (augment `ImportMetaEnv` with `VITE_DD_*` keys)
+**Approach:** Install with `--save-exact` against the public npm registry (`client/.npmrc`
+points at npmjs, not Artifactory — so no registry override needed for the client). Add an
+`ImportMetaEnv` interface listing `VITE_DD_APPLICATION_ID`, `VITE_DD_CLIENT_TOKEN`,
+`VITE_DD_SITE`, `VITE_DD_SERVICE`, `VITE_DD_ENV`, `VITE_DD_RUM_SAMPLE_RATE`,
+`VITE_DD_SESSION_REPLAY_SAMPLE_RATE`, `VITE_DD_TRACE_SAMPLE_RATE` (all optional strings).
+**Patterns to follow:** existing exact-pin style in `client/package.json`; `vite-env.d.ts`.
+**Test scenarios:** `Test expectation: none -- dependency + type declarations, no runtime behavior.`
+**Verification:** `npm ci` resolves; `npm run typecheck` passes with the new typings.
+
+### U2. Runtime-config accessor with build-time fallback
+
+**Goal:** One accessor that resolves config runtime-first, then `VITE_*`, used by all providers.
+**Requirements:** R5.
+**Dependencies:** none.
+**Files:**
+- `client/src/shared/observability/runtimeConfig.ts`
+- `client/src/shared/observability/runtimeConfig.test.ts`
+**Approach:** Export `getConfigValue(key: string): string | undefined` returning
+`window.__RUNTIME_CONFIG__?.[key] ?? readViteEnv('VITE_' + key)`. Declare a `Window`
+augmentation for `__RUNTIME_CONFIG__?: Record<string, string>`. Treat empty string as unset.
+Keep it framework-free and side-effect-free so `shared/` boundary rules hold.
+**Patterns to follow:** `client/src/shared/utils/version.ts` (module-level env reads, fallbacks).
+**Test scenarios:**
+- Happy path: runtime value present → returns runtime value (input `window.__RUNTIME_CONFIG__ = {DD_CLIENT_TOKEN: "rt"}`, `getConfigValue("DD_CLIENT_TOKEN")` → `"rt"`).
+- Fallback: no runtime value, `VITE_DD_CLIENT_TOKEN` set → returns the Vite value.
+- Precedence: both set → runtime wins.
+- Empty/edge: runtime value is `""` → treated as unset, falls back; neither set → `undefined`.
+**Verification:** unit tests pass; no `console.log` introduced.
+
+### U3. Provider interface, registry, and error/interceptor fan-out
+
+**Goal:** Vendor-neutral core: types, registry, `initObservability`, `reportObservabilityError`,
+`observabilityInterceptors`.
+**Requirements:** R1, R2, R6.
+**Dependencies:** U2.
+**Files:**
+- `client/src/shared/observability/types.ts`
+- `client/src/shared/observability/registry.ts`
+- `client/src/shared/observability/index.ts`
+- `client/src/shared/observability/registry.test.ts`
+**Approach:** Define `ObservabilityProvider { name; isConfigured(): boolean;
+init(ctx: ObservabilityInitContext): void; reportError?(error, meta?): void;
+connectInterceptors?(): Interceptor[]; }` and `ObservabilityInitContext { service; version;
+env; apiTracingOrigin; }` (`Interceptor` from `@connectrpc/connect`). Registry holds the
+provider array (Datadog registered in U4 or via a `providers.ts` list). `initObservability(ctx)`
+iterates: skip unconfigured; wrap each `init()` in try/catch that logs via `console.error` (the
+sanctioned level) so one failure never blocks startup (R6). `reportObservabilityError` fans out
+to configured providers' `reportError`. `observabilityInterceptors()` concatenates
+`connectInterceptors()` from configured providers.
+**Patterns to follow:** sanctioned `console.error` usage (`router.tsx`); barrel-export style.
+**Test scenarios:**
+- Configured provider → `init` called once with the context.
+- Unconfigured provider → `init` not called.
+- `init` throws → error swallowed/logged, `initObservability` still returns, other providers still init (integration: two providers, first throws, second still initialized).
+- `reportObservabilityError` → only configured providers' `reportError` invoked.
+- `observabilityInterceptors()` → returns interceptors only from configured providers (empty when none).
+- Idempotency: calling `initObservability` twice does not double-init a provider (guard flag).
+**Verification:** unit tests pass; `shared/` imports no app modules.
+
+### U4. Datadog RUM provider
+
+**Goal:** Implement the Datadog provider: enablement, init with tracing, error capture.
+**Requirements:** R1, R3, R4, R5.
+**Dependencies:** U1, U2, U3.
+**Files:**
+- `client/src/shared/observability/providers/datadog.ts`
+- `client/src/shared/observability/providers/datadog.test.ts`
+- register it in the registry (`registry.ts` or a `providers.ts` list from U3)
+**Approach:** `isConfigured()` → both `getConfigValue("DD_APPLICATION_ID")` and
+`getConfigValue("DD_CLIENT_TOKEN")` non-empty (KTD5). `init(ctx)` calls `datadogRum.init({
+applicationId, clientToken, site (default "datadoghq.com"), service (ctx.service default
+"proto-fleet-client"), env (DD_ENV || ctx.env), version (ctx.version), sessionSampleRate,
+sessionReplaySampleRate (default 0), trackResources: true, trackLongTasks: true,
+trackUserInteractions: true, allowedTracingUrls: [ match fn accepting ctx.apiTracingOrigin /
+`/api-proxy/` requests ], traceSampleRate })`. Numeric sample rates parsed from strings with
+safe defaults. `reportError(error, meta)` → `datadogRum.addError(error, meta)`.
+`connectInterceptors()` → `[]` (KTD2/KTD3). Read all config via `getConfigValue`; read
+`version` from `buildVersionInfo` in the init context (passed by caller, not imported here to
+keep `shared/` self-contained — `buildVersionInfo` is already in `shared/` so a direct import is
+also acceptable).
+**Patterns to follow:** `featureFlags.ts` (`=== "true"`/default parsing), `version.ts`.
+**Execution note:** implement `isConfigured` and the init-arg mapping test-first — the no-op
+guard (R1) and correct `allowedTracingUrls` shape (R4) are the load-bearing behaviors.
+**Test scenarios:**
+- `isConfigured` false when either required key missing → `init` maps to no `datadogRum.init` call.
+- `isConfigured` true when both present.
+- `init` calls `datadogRum.init` once with `applicationId`/`clientToken` from config and
+  `version` from the context.
+- `allowedTracingUrls` matches an `/api-proxy/...` URL and does **not** match an unrelated
+  third-party URL (assert via the provided match function).
+- Optional keys: defaults applied when unset (site, service, sample rates); overridden when set.
+- `reportError` forwards to `datadogRum.addError`.
+- Sample-rate parsing: non-numeric string → default; valid string → parsed number.
+**Verification:** unit tests pass with the Datadog SDK mocked (see U6 setup).
+
+### U5. Wire bootstrap, tracing interceptors, and error forwarding into ProtoFleet
+
+**Goal:** Activate the layer in the ProtoFleet app.
+**Requirements:** R2, R3, R4, R6.
+**Dependencies:** U3, U4.
+**Files:**
+- `client/src/protoFleet/mainWrapper.tsx` (call `initObservability(ctx)` beside `logBuildVersion()`)
+- `client/src/protoFleet/api/transport.ts` (spread `observabilityInterceptors()` into `interceptors`)
+- `client/src/protoFleet/components/App/App.tsx` (pass `onError` to `ErrorBoundary` → `reportObservabilityError`)
+**Approach:** Build the init context from `buildVersionInfo` (service `"proto-fleet-client"`,
+`version: buildVersionInfo.commit`, env from config/build) and the API origin derived from
+`API_PROXY_BASE`. Add `interceptors: observabilityInterceptors()` to `createConnectTransport`
+(empty array today → transport behavior unchanged when unconfigured, R2). Pass
+`onError={(err, info) => reportObservabilityError(err, { react: info })}` at the `ErrorBoundary`
+in `App.tsx`. All three seams are no-ops when nothing is configured.
+**Patterns to follow:** `mainWrapper.tsx` `logBuildVersion()` call site; `ErrorBoundary`
+`onError` prop already threaded.
+**Test scenarios:**
+- `Covers R6.` transport constructs successfully with empty interceptors (unconfigured) — existing API tests still pass.
+- `App` renders and, when a child throws, the `onError` prop invokes `reportObservabilityError` (mock the observability module; assert called with the error).
+- Smoke: `mainWrapper` module import triggers `initObservability` exactly once (mock registry).
+**Verification:** `npm run typecheck`, targeted vitest for `App` + transport, existing api tests green.
+
+### U6. Test setup mock for the Datadog SDK
+
+**Goal:** Prevent tests from touching the real SDK / network.
+**Requirements:** supports R1/R3/R4 test isolation.
+**Dependencies:** U1.
+**Files:**
+- `client/src/tests/setup.ts` (add `vi.mock('@datadog/browser-rum', ...)` with spies for `init`, `addError`)
+**Approach:** Provide a module mock exposing `datadogRum` with `vi.fn()` `init`/`addError`/etc.
+so provider tests assert call shape without side effects. Keep alongside the existing global
+stubs (`ResizeObserver`, observers).
+**Patterns to follow:** existing global stubs in `client/src/tests/setup.ts`.
+**Test scenarios:** `Test expectation: none -- test infrastructure; exercised by U4/U5 tests.`
+**Verification:** U4/U5 suites run without network; full `npm test` green.
+
+### U7. Deployment runtime-config injection (operator enablement without rebuild)
+
+**Goal:** Let a self-hosting operator enable Datadog via env vars on the prebuilt client image.
+**Requirements:** R5 (deploy-time half).
+**Dependencies:** U2.
+**Files:**
+- `deployment-files/client/Dockerfile` (add an entrypoint that renders runtime config, keep nginx CMD)
+- `deployment-files/client/docker-entrypoint.d/40-render-runtime-config.sh` (new; emits `window.__RUNTIME_CONFIG__`)
+- `deployment-files/client/nginx.http.conf`, `deployment-files/client/nginx.https.conf` (serve the generated `config.js` no-cache)
+- `deployment-files/docker-compose.yaml` (pass `DD_*` env into the `fleet-client` service)
+- `client/src/protoFleet/index.html` (load `<script src="/config.js"></script>` before the module bundle)
+- `deployment-files/run-fleet.sh` and `.env` example (surface `DD_*` keys to operators)
+**Approach:** The `nginx:alpine` base already runs `/docker-entrypoint.d/*.sh` before starting
+nginx — add a script that writes `/usr/share/nginx/html/config.js` containing
+`window.__RUNTIME_CONFIG__ = { DD_APPLICATION_ID: "$DD_APPLICATION_ID", ... }` from container
+env (only keys that are set; omit empties so `getConfigValue` treats them as unset → no-op when
+the operator configures nothing, R1). Serve `config.js` with `Cache-Control: no-store` so
+operator changes take effect on restart. `index.html` loads it before `mainWrapper.tsx` so
+`window.__RUNTIME_CONFIG__` exists at init. Dev is unaffected (no `config.js` served by Vite →
+falls back to `VITE_*`).
+**Execution note:** mostly packaging/config; prefer a container smoke check (start image with
+and without `DD_*` env, confirm `config.js` contents and that the app no-ops when unset) over
+unit tests.
+**Test scenarios:** `Test expectation: none behaviorally in JS.` Verify via runtime smoke:
+- With `DD_APPLICATION_ID`+`DD_CLIENT_TOKEN` set → `config.js` contains both keys; RUM initializes.
+- With no `DD_*` env → `config.js` omits them (or is empty) → app runs, no RUM, no errors.
+**Verification:** build the deployment client image; `curl` `config.js` in both env states;
+confirm `index.html` references the script and the app boots either way.
+
+### U8. Documentation
+
+**Goal:** Document the config keys, precedence, and how to add a new provider.
+**Requirements:** R2, R5 (discoverability).
+**Dependencies:** U1–U7.
+**Files:**
+- `client/README.md` (observability section: `VITE_DD_*` for dev, runtime `DD_*` for deploy, precedence)
+- `client/src/shared/observability/index.ts` (concise doc comment: how to add a provider)
+- deployment docs where env vars are listed (alongside `SESSION_COOKIE_SECURE`)
+**Approach:** Short, example-driven. Note that only `DD_APPLICATION_ID` + `DD_CLIENT_TOKEN`
+are required; everything else defaults; absent → no-op. Document the Sentry/PostHog "write one
+provider" path.
+**Test scenarios:** `Test expectation: none -- docs only.`
+**Verification:** docs render; keys match code.
+
+---
+
+## System-Wide Impact
+
+- **External contract surfaces:** new env vars consumed by CI build (`VITE_DD_*`) and by the
+  deployment client container (`DD_*`); a new `config.js` served by nginx; `index.html` gains a
+  script tag. These are additive and inert when unset.
+- **Transport:** all ~25 ConnectRPC clients share one transport; the interceptor array is empty
+  today, so behavior is unchanged until a provider contributes interceptors.
+- **Both apps:** the core lives in `shared/`; protoOS wiring is deferred but unblocked.
+
+---
+
+## Risks & Dependencies
+
+- **Server must accept/propagate trace headers for end-to-end traces (R4).** The backend
+  already runs an OTEL collector (`FLEET_TELEMETRY_ENDPOINT`, otel-collector service). If the
+  server does not propagate incoming `traceparent`/`x-datadog-*` context, front-end spans still
+  record client-side timing but won't stitch to backend spans. *Mitigation:* verify server
+  header handling; treat backend correlation as a follow-up if missing. Client value (RUM
+  resource timing, error capture) lands regardless.
+- **Datadog RUM patches global `fetch`.** connect-web's custom `fetch` wrapper delegates to
+  global `fetch`, so instrumentation applies — but confirm the wrapper isn't replaced by a
+  non-global fetch in future. *Mitigation:* a test asserting the transport uses global fetch;
+  the KTD3 interceptor seam is the fallback if auto-instrumentation ever breaks.
+- **Runtime `config.js` caching.** If cached, operator changes won't apply. *Mitigation:*
+  `Cache-Control: no-store` on `config.js`.
+- **Secret handling.** `DD_CLIENT_TOKEN` is a public RUM client token (safe for browser), not a
+  secret API key — document this so operators don't paste a privileged key.
+- **Bundle size.** `@datadog/browser-rum` adds to the bundle; it is only *initialized* when
+  configured, but the code is present. *Mitigation:* acceptable; revisit dynamic import if
+  bundle budget becomes a concern (noted, not done here).
+
+---
+
+## Alternative Approaches Considered
+
+- **Build-time-only `VITE_*` config.** Simplest and consistent with existing client config, but
+  a self-hosting operator with a prebuilt artifact could not enable Datadog without rebuilding —
+  fails the "operator configures → enabled" intent. Rejected as the sole mechanism; kept as the
+  dev/CI fallback layer (KTD4).
+- **Bespoke ConnectRPC tracing interceptor as the primary tracing mechanism.** Vendor-neutral,
+  but would duplicate/collide with RUM's own fetch instrumentation and lose automatic RUM↔APM
+  correlation. Rejected as primary; retained as an optional seam (KTD3).
+- **React context provider for observability.** Heavier than needed — init is a one-time
+  startup side effect, better placed in `mainWrapper.tsx` next to `logBuildVersion()`. Error
+  forwarding uses the existing `ErrorBoundary.onError` seam instead of new context.
+
+---
+
+## Definition of Done
+
+- Provider registry + Datadog provider implemented in `client/src/shared/observability/`, with
+  unit tests green (U2–U4, U6).
+- With no Datadog config: app builds, boots, and behaves exactly as today; no SDK init, no
+  network, transport interceptors empty (R1, R6).
+- With `DD_APPLICATION_ID` + `DD_CLIENT_TOKEN` set (dev via `VITE_*`, deploy via runtime
+  `config.js`): RUM initializes, captures errors via `ErrorBoundary.onError`, and API calls to
+  `/api-proxy` carry trace headers (R3, R4, R5).
+- Adding a hypothetical second provider requires only a new file under `providers/` + registry
+  entry (R2) — verified by the registry's provider-agnostic tests.
+- Deployment image renders `config.js` from env; documented in `client/README.md` and deploy
+  docs (U7, U8).
+- `npm run typecheck`, `npm test`, and lint pass; no new `console.log`.
+
+---
+
+## Verification Contract
+
+- **Unit:** `runtimeConfig.test.ts`, `registry.test.ts`, `providers/datadog.test.ts` cover
+  precedence, no-op gating, init-arg mapping, `allowedTracingUrls` matching, error fan-out,
+  init-failure isolation, idempotency.
+- **Integration:** `App` error → `reportObservabilityError`; transport constructs with empty +
+  non-empty interceptor arrays; existing api suites remain green.
+- **Runtime smoke (U7):** deployment client image serves correct `config.js` in
+  configured/unconfigured states; app boots and no-ops when unset.
+- **Gates:** `npm run typecheck`, `npm test`, client lint (no new `console.log`), and (for U7)
+  a container build + `curl config.js`.
+
+---
+
+## Sources & Research
+
+- Codebase map (this session): entry `client/src/protoFleet/mainWrapper.tsx`; env pattern
+  `client/src/shared/utils/version.ts`, `client/src/protoFleet/constants/featureFlags.ts`;
+  transport `client/src/protoFleet/api/transport.ts` (no interceptors today; single shared
+  transport for ~25 clients in `clients.ts`); error seam
+  `client/src/shared/components/ErrorBoundary/ErrorBoundary.tsx` (`onError`); test setup
+  `client/src/tests/setup.ts`; boundaries + `no-console` in `client/eslint.config.js`.
+- Deployment: `deployment-files/client/Dockerfile` (prebuilt static + nginx, no entrypoint
+  today), `deployment-files/docker-compose.yaml` `fleet-client` service, CI `VITE_*` injection
+  in `.github/workflows/proto-fleet-artifact-build.yml`.
+- External: `@datadog/browser-rum` RUM init + `allowedTracingUrls` distributed-tracing config
+  (Datadog Browser RUM docs) — to be confirmed against the installed SDK version during U4.

--- a/docs/plans/2026-07-11-001-feat-client-observability-datadog-rum-plan.md
+++ b/docs/plans/2026-07-11-001-feat-client-observability-datadog-rum-plan.md
@@ -16,7 +16,7 @@ product_contract_source: ce-plan-bootstrap
 Add a vendor-neutral observability layer to the ProtoFleet web client. A small provider
 registry initializes any configured backend at startup; a Datadog RUM provider is the first
 implementation. When the required Datadog config keys are present the provider initializes
-RUM (page/session monitoring, error capture, and distributed tracing on client→server API
+RUM (page/session monitoring, error capture, and trace-context injection on client→server API
 calls); when they are absent it is a complete no-op. The abstraction is shaped so Sentry or
 PostHog can be added later by writing one more provider file — no changes to the entry point,
 transport, or error boundary.
@@ -26,8 +26,8 @@ vars that nginx renders into a `window.__RUNTIME_CONFIG__` blob at container sta
 rebuild), while local dev and CI builds continue to use Vite `VITE_*` vars. This matches the
 repo's existing "operator edits an env file, containers read it" deployment model.
 
-Distributed tracing links front-end RUM sessions to the existing backend OTEL pipeline so
-latency on specific RPCs can be traced end-to-end.
+Trace-context injection provides the client half of future front-end↔back-end correlation.
+Associating and exporting backend spans to the same observability system is explicitly deferred.
 
 **Product Contract preservation:** N/A — solo plan (`ce-plan-bootstrap`), no upstream
 brainstorm to preserve.
@@ -46,7 +46,7 @@ server handling.
 We want:
 1. A way to turn on Datadog RUM by configuration, with a clean no-op when unconfigured.
 2. A bootstrapping pattern generic enough that Sentry/PostHog follow the same shape.
-3. Distributed traces on client→server API calls to troubleshoot latency.
+3. Future-ready trace-context injection on client→server API calls.
 
 ### Scope Boundaries
 
@@ -54,7 +54,7 @@ We want:
 - Generic observability provider interface + registry + startup bootstrap (in `shared/`).
 - Datadog RUM provider (init, error capture, tracing config).
 - Runtime-config accessor with build-time (`VITE_*`) fallback.
-- Distributed tracing on ConnectRPC calls, correlated to the backend.
+- Trace-context injection on ConnectRPC calls, ready for future backend correlation.
 - Wiring into the ProtoFleet entry point and error boundary.
 - Deployment plumbing so operators can enable via env vars without a rebuild.
 
@@ -66,7 +66,7 @@ We want:
   built here).
 - Datadog Session Replay tuning beyond a sample-rate knob (default off).
 - Custom RUM actions / user identification beyond anonymous session + build metadata.
-- Server-side trace ingestion changes beyond confirming header acceptance (see Risks).
+- Server-side trace parenting/linking and export to Datadog (see Risks).
 
 ### Non-goals
 - Replacing or changing the miner-telemetry domain features (`useTelemetryMetrics`, etc.).
@@ -82,8 +82,8 @@ We want:
   registering it; no edits to the entry point, transport, or error boundary.
 - **R3** — Datadog RUM, when enabled, captures page/session data and forwards React
   render-time errors caught by the shared `ErrorBoundary`.
-- **R4** — Client→server API calls (ConnectRPC) carry trace context that correlates with the
-  backend so a slow RPC can be traced end-to-end.
+- **R4** — Client→server API calls (ConnectRPC) carry trace context scoped to the same-origin
+  API path, providing the client half of future backend correlation.
 - **R5** — Configuration is resolvable at deploy time by an operator (runtime injection) and
   at dev/CI time via `VITE_*`, through one accessor with a documented precedence.
 - **R6** — A provider `init()` failure must not crash or block app startup.
@@ -105,9 +105,9 @@ an init context).
 `@datadog/browser-rum` instruments the global `fetch`; connect-web's transport calls global
 `fetch` (its custom wrapper delegates to it), so configuring `allowedTracingUrls` to match the
 `/api-proxy` origin makes RUM inject `traceparent` / `x-datadog-*` headers on every RPC and
-tie them to RUM resource timings + backend APM. This is the supported, RUM-correlated path and
+tie them to RUM resource timings. This provides the client half of a future RUM↔APM path and
 requires no change to how the ~25 clients are built (all share one transport). Rationale:
-directly serves R4 and "troubleshoot latency" with front-end↔back-end correlation.
+directly serves R4 without claiming backend correlation that this change does not configure.
 
 **KTD3 — Vendor-neutral interceptor seam kept, unused by Datadog.**
 The registry exposes an optional `observabilityInterceptors()` contribution that the transport
@@ -154,7 +154,7 @@ flowchart TD
     APP[App.tsx ErrorBoundary onError] --> RE["reportObservabilityError()"] --> REG
     TR[transport.ts createConnectTransport] -->|observabilityInterceptors| REG
     FETCH[global fetch on /api-proxy] -->|RUM allowedTracingUrls| TRACE[traceparent / x-datadog-*]
-    TRACE --> BE[backend OTEL collector -> APM]
+    TRACE --> FUTURE[future backend correlation and export]
   end
 ```
 
@@ -382,12 +382,11 @@ provider" path.
 
 ## Risks & Dependencies
 
-- **Server must accept/propagate trace headers for end-to-end traces (R4).** The backend
-  already runs an OTEL collector (`FLEET_TELEMETRY_ENDPOINT`, otel-collector service). If the
-  server does not propagate incoming `traceparent`/`x-datadog-*` context, front-end spans still
-  record client-side timing but won't stitch to backend spans. *Mitigation:* verify server
-  header handling; treat backend correlation as a follow-up if missing. Client value (RUM
-  resource timing, error capture) lands regardless.
+- **End-to-end trace correlation is deferred.** The backend currently treats incoming requests
+  as public endpoints and the bundled OTEL collector exports server traces to Jaeger, not the
+  operator's Datadog org. This change only injects scoped trace context and records client-side
+  resource timing. A follow-up must define the trust/association policy for browser-supplied
+  context and export server spans to the same backend before claiming end-to-end traces.
 - **Datadog RUM patches global `fetch`.** connect-web's custom `fetch` wrapper delegates to
   global `fetch`, so instrumentation applies — but confirm the wrapper isn't replaced by a
   non-global fetch in future. *Mitigation:* a test asserting the transport uses global fetch;
@@ -409,8 +408,8 @@ provider" path.
   fails the "operator configures → enabled" intent. Rejected as the sole mechanism; kept as the
   dev/CI fallback layer (KTD4).
 - **Bespoke ConnectRPC tracing interceptor as the primary tracing mechanism.** Vendor-neutral,
-  but would duplicate/collide with RUM's own fetch instrumentation and lose automatic RUM↔APM
-  correlation. Rejected as primary; retained as an optional seam (KTD3).
+  but would duplicate/collide with RUM's own fetch instrumentation. Rejected as primary;
+  retained as an optional seam for a future provider (KTD3).
 - **React context provider for observability.** Heavier than needed — init is a one-time
   startup side effect, better placed in `mainWrapper.tsx` next to `logBuildVersion()`. Error
   forwarding uses the existing `ErrorBoundary.onError` seam instead of new context.


### PR DESCRIPTION
## Summary

Adds a vendor-neutral observability layer to the ProtoFleet client. A small provider registry initializes any configured backend at startup; **Datadog RUM** is the first provider. When the required Datadog config is present the provider initializes RUM (page/session monitoring, error capture, and distributed tracing on client→server API calls); when it is absent the provider is a **complete no-op** — the app runs exactly as before, with no SDK init and no network.

The abstraction is shaped so Sentry or PostHog can be added later by writing one provider module and registering it — no changes to the entry point, transport, or error boundary.

Plan: `docs/plans/2026-07-11-001-feat-client-observability-datadog-rum-plan.md`

## Motivation

Today we have zero visibility into the client once it's deployed. When the UI breaks or crawls in the field, we find out through screenshots and secondhand reports — no error traces, no performance data, no way to correlate a frontend symptom with the backend request that caused it.

This PR adds real-user monitoring to the client, built around three principles:

1. **Off by default, zero cost when off.** The whole layer is a no-op unless an operator supplies Datadog credentials — no SDK init, no network calls, no behavior change. Crucially, operators can enable it on a *prebuilt* image: the nginx entrypoint renders runtime config from environment variables at container start, so no rebuild is needed to turn it on (or off).

2. **Privacy-safe by design.** Data goes to the operator's own Datadog org, not ours. Fleet context lives in our query strings (rack/building IDs, subnet filters), so a `beforeSend` scrubber strips query strings from every URL before events leave the browser. Session Replay is off by default and fully masked when enabled.

3. **Vendor-neutral core.** The app talks to a small provider registry, not to Datadog. Datadog RUM is just the first provider — adding Sentry or PostHog later is one new module and one registration line; the entry point, transport, and error boundary don't change.

What we get: client-side error reporting, performance/resource timing, and distributed traces that connect a user's click in the UI to the specific backend RPC it triggered.

## How it works

```mermaid
flowchart TD
  MW["mainWrapper.tsx<br/>initObservability(ctx)"] --> REG["registry"]
  REG -->|isConfigured?| DD["Datadog provider"]
  DD -->|yes| RUM["datadogRum.init + allowedTracingUrls"]
  DD -->|no| NOOP["no-op"]
  RTC["getConfigValue(key)"] --> WIN["window.__RUNTIME_CONFIG__<br/>(nginx-rendered config.js)"]
  RTC --> VITE["import.meta.env.VITE_*<br/>(dev/CI)"]
  DD --> RTC
  APP["App ErrorBoundary onError"] --> RE["reportObservabilityError()"] --> REG
  FETCH["global fetch on /api-proxy"] -->|RUM allowedTracingUrls| TRACE["traceparent / x-datadog-*"] --> BE["backend OTEL"]
```

**Config resolves runtime-first, then build-time**, through one accessor (`getConfigValue`):
1. `window.__RUNTIME_CONFIG__[KEY]` — rendered into `config.js` by the deployment nginx image at container start from `DD_*` env. Operators enable Datadog on a prebuilt image by setting env in their `.env` — **no rebuild**.
2. `import.meta.env.VITE_<KEY>` — build-time value for local dev / CI.

Enablement gate: both `DD_APPLICATION_ID` and `DD_CLIENT_TOKEN` must be set (the latter is a public browser RUM token, not a secret API key). All other keys default.

**Distributed tracing:** RUM's `allowedTracingUrls` is scoped to same-origin `/api-proxy` requests (matched on a path boundary), so ConnectRPC RPCs — which flow through the global `fetch` — get trace headers correlating front-end sessions to the backend OTEL pipeline. Same-origin-only; no cross-origin header leak (verified by test).

## Code areas

- `client/src/shared/observability/` — provider interface, registry, runtime-config accessor, Datadog provider (all vendor-neutral; `shared/` imports no app).
- `client/src/protoFleet/{mainWrapper,api/transport,components/App}` — startup init, transport interceptor seam, error forwarding via the existing `ErrorBoundary.onError`.
- `deployment-files/client/` — nginx entrypoint renders `config.js` from env (served no-store); compose passes `DD_*` from the operator `.env`.

## Testing

- 24 unit tests across `runtimeConfig`, `registry`, and the Datadog provider: precedence/empty-as-unset, no-op gating, init-arg mapping, `env`/sample-rate parsing, same-origin + path-boundary tracing scope, error/interceptor fan-out, init-failure isolation, idempotency.
- SDK mocked globally in test setup; existing 305 App/api tests remain green.
- `build:protoFleet` emits `config.js` + the script tag and bundles the SDK; deploy entrypoint smoke-tested (configured/unconfigured/control-char values).
- **Not run here:** container smoke of the nginx image (base-image pull is network-restricted in this environment) and a live browser session (no visible surface when unconfigured; needs the Docker backend).

## Deferred (follow-up)

- Wiring the same bootstrap into the **protoOS** client (abstraction is ready for it).
- Actual Sentry / PostHog providers.
- Backend acceptance/propagation of the trace headers for full end-to-end stitching (client value — RUM timing + error capture — lands regardless).

## Residual Review Findings

Multi-agent review (correctness, security, maintainability/standards, testing) found no P0/P1. All actionable findings were applied except:

- **P2 (testing) — `client/src/protoFleet/components/App/App.tsx`: `onError` → `reportObservabilityError` forwarding is not unit-tested.** The `App.test.tsx` suite is `describe.skip` in this repo (App isn't unit-tested due to routing/provider complexity), so a full-render test would be brittle. The one-line mapping is covered indirectly (`ErrorBoundary.test.tsx` proves `onError` fires; `reportObservabilityError` fan-out is unit-tested). Left as a known gap rather than fighting the skipped suite.
