### PR TITLE
Add miner RBAC Playwright coverage

### DIFF
--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -2,7 +2,7 @@ import { type Browser, type Page, type TestInfo } from "@playwright/test";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { testConfig } from "../config/test.config";
+import { DEFAULT_TIMEOUT, testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { AlertsPage } from "../pages/alerts";
 import { AuthPage } from "../pages/auth";
@@ -36,6 +36,18 @@ export const RBAC_CURTAILMENT_PROFILE_PREFIX = "rbac_curtailment_profile";
 export const RBAC_CURTAILMENT_SOURCE_PREFIX = "rbac_curtailment_source";
 export const RBAC_CURTAILMENT_REASON_PREFIX = "rbac_curtailment_reason";
 export const RBAC_RACK_ZONE = "RbacZone";
+const SHORT_HOOK_TIMEOUT = DEFAULT_TIMEOUT / 6;
+
+type RbacCleanupTarget = "alerts" | "curtailment" | "infrastructure" | "pools" | "schedules" | "team";
+
+const DEFAULT_RBAC_CLEANUP_TARGETS: RbacCleanupTarget[] = [
+  "curtailment",
+  "schedules",
+  "alerts",
+  "pools",
+  "infrastructure",
+  "team",
+];
 
 type PersistedAdminStorageState = Exclude<
   NonNullable<Parameters<Browser["newContext"]>[0]>["storageState"],
@@ -97,14 +109,14 @@ type CleanupPages = {
   settingsTeamPage: SettingsTeamPage;
 };
 
-export function useRbacHooks() {
+export function useRbacHooks(cleanupTargets: RbacCleanupTarget[] = DEFAULT_RBAC_CLEANUP_TARGETS) {
   test.beforeEach(async ({ page }) => {
     await installAllSitesInitScript(page);
     await page.goto("/");
   });
 
   test.afterEach("CLEANUP: delete RBAC fixtures", async ({ browser }, testInfo) => {
-    await cleanupRbacArtifacts(browser, testInfo);
+    await cleanupRbacArtifacts(browser, testInfo, cleanupTargets);
   });
 }
 
@@ -298,7 +310,7 @@ export async function ensureVisibleRigMinersAwake(minersPage: MinersPage) {
   await minersPage.filterRigMiners();
 
   if (await minersPage.hasAnyMinerWithStatus("Waking")) {
-    await minersPage.validateNoMinerWithStatus("Waking");
+    await minersPage.validateNoMinerWithStatus("Waking", SHORT_HOOK_TIMEOUT);
   }
 
   while (await minersPage.hasAnyMinerWithStatus("Sleeping")) {
@@ -309,8 +321,8 @@ export async function ensureVisibleRigMinersAwake(minersPage: MinersPage) {
     await minersPage.validateMinerStatusSettled(sleepingMinerIp, "Hashing");
   }
 
-  await minersPage.validateNoMinerWithStatus("Sleeping");
-  await minersPage.validateNoMinerWithStatus("Waking");
+  await minersPage.validateNoMinerWithStatus("Sleeping", SHORT_HOOK_TIMEOUT);
+  await minersPage.validateNoMinerWithStatus("Waking", SHORT_HOOK_TIMEOUT);
 }
 
 export async function createCurtailment(energyPage: EnergyPage, reason: string) {
@@ -363,7 +375,9 @@ export async function invokeIngestCurtailmentSignal(page: Page, externalReferenc
   });
 }
 
-async function cleanupRbacArtifacts(browser: Browser, testInfo: TestInfo) {
+async function cleanupRbacArtifacts(browser: Browser, testInfo: TestInfo, cleanupTargets: RbacCleanupTarget[]) {
+  const cleanupTargetSet = new Set(cleanupTargets);
+
   await withStoredAdminContext(
     browser,
     testInfo,
@@ -378,32 +392,38 @@ async function cleanupRbacArtifacts(browser: Browser, testInfo: TestInfo) {
       settingsSchedulesPage,
       settingsTeamPage,
     }) => {
-      await energyPage.cleanupStartedCurtailmentsByReasonPrefix(RBAC_CURTAILMENT_REASON_PREFIX).catch(() => undefined);
-
-      await page.goto("/settings/curtailment");
-      if (
-        await page
-          .getByRole("button", { name: "Add source", exact: true })
-          .isVisible()
-          .catch(() => false)
-      ) {
-        await settingsCurtailmentPage.deleteSourcesByPrefix(RBAC_CURTAILMENT_SOURCE_PREFIX).catch(() => undefined);
-        await settingsCurtailmentPage
-          .deleteResponseProfilesByPrefix(RBAC_CURTAILMENT_PROFILE_PREFIX)
+      if (cleanupTargetSet.has("curtailment")) {
+        await energyPage
+          .cleanupStartedCurtailmentsByReasonPrefix(RBAC_CURTAILMENT_REASON_PREFIX)
           .catch(() => undefined);
+
+        await page.goto("/settings/curtailment");
+        if (
+          await page
+            .getByRole("button", { name: "Add source", exact: true })
+            .isVisible()
+            .catch(() => false)
+        ) {
+          await settingsCurtailmentPage.deleteSourcesByPrefix(RBAC_CURTAILMENT_SOURCE_PREFIX).catch(() => undefined);
+          await settingsCurtailmentPage
+            .deleteResponseProfilesByPrefix(RBAC_CURTAILMENT_PROFILE_PREFIX)
+            .catch(() => undefined);
+        }
       }
 
-      await page.goto("/settings/schedules");
-      if (
-        await page
-          .getByRole("button", { name: "Add a schedule", exact: true })
-          .isVisible()
-          .catch(() => false)
-      ) {
-        await settingsSchedulesPage.deleteSchedulesByPrefix(RBAC_SCHEDULE_PREFIX).catch(() => undefined);
+      if (cleanupTargetSet.has("schedules")) {
+        await page.goto("/settings/schedules");
+        if (
+          await page
+            .getByRole("button", { name: "Add a schedule", exact: true })
+            .isVisible()
+            .catch(() => false)
+        ) {
+          await settingsSchedulesPage.deleteSchedulesByPrefix(RBAC_SCHEDULE_PREFIX).catch(() => undefined);
+        }
       }
 
-      if (ALERTS_E2E_ENABLED) {
+      if (cleanupTargetSet.has("alerts") && ALERTS_E2E_ENABLED) {
         await page.goto("/settings/alerts");
         if (
           await page
@@ -415,34 +435,40 @@ async function cleanupRbacArtifacts(browser: Browser, testInfo: TestInfo) {
         }
       }
 
-      await page.goto("/settings/mining-pools");
-      if (
-        await page
-          .getByRole("button", { name: "Add pool", exact: true })
-          .isVisible()
-          .catch(() => false)
-      ) {
-        await settingsPoolsPage.deletePoolsByPrefix(RBAC_POOL_PREFIX).catch(() => undefined);
+      if (cleanupTargetSet.has("pools")) {
+        await page.goto("/settings/mining-pools");
+        if (
+          await page
+            .getByRole("button", { name: "Add pool", exact: true })
+            .isVisible()
+            .catch(() => false)
+        ) {
+          await settingsPoolsPage.deletePoolsByPrefix(RBAC_POOL_PREFIX).catch(() => undefined);
+        }
       }
 
-      await cleanupInfrastructureFixtures(fleetLocationsPage, racksPage).catch(() => undefined);
-
-      await page.goto("/settings/team");
-      if (
-        await settingsTeamPage
-          .openMembersTab()
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        await settingsTeamPage.deactivateMembersByPrefix(RBAC_USER_PREFIX).catch(() => undefined);
+      if (cleanupTargetSet.has("infrastructure")) {
+        await cleanupInfrastructureFixtures(fleetLocationsPage, racksPage).catch(() => undefined);
       }
-      if (
-        await settingsTeamPage
-          .openRolesTab()
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        await settingsTeamPage.deleteRolesByPrefix(RBAC_ROLE_PREFIX).catch(() => undefined);
+
+      if (cleanupTargetSet.has("team")) {
+        await page.goto("/settings/team");
+        if (
+          await settingsTeamPage
+            .openMembersTab(SHORT_HOOK_TIMEOUT)
+            .then(() => true)
+            .catch(() => false)
+        ) {
+          await settingsTeamPage.deactivateMembersByPrefix(RBAC_USER_PREFIX).catch(() => undefined);
+        }
+        if (
+          await settingsTeamPage
+            .openRolesTab(SHORT_HOOK_TIMEOUT)
+            .then(() => true)
+            .catch(() => false)
+        ) {
+          await settingsTeamPage.deleteRolesByPrefix(RBAC_ROLE_PREFIX).catch(() => undefined);
+        }
       }
     },
   );

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -325,6 +325,16 @@ export async function ensureVisibleRigMinersAwake(minersPage: MinersPage) {
   await minersPage.validateNoMinerWithStatus("Waking", SHORT_HOOK_TIMEOUT);
 }
 
+export async function selectHashingRigMinerForStopFlow(minersPage: MinersPage) {
+  await minersPage.filterRigMiners();
+
+  if (testConfig.target !== "real") {
+    await ensureVisibleRigMinersAwake(minersPage);
+  }
+
+  return await minersPage.getMinerIpAddressByStatus("Hashing");
+}
+
 export async function createCurtailment(energyPage: EnergyPage, reason: string) {
   if (testConfig.target === "real") {
     throw new Error("RBAC curtailment setup is only supported against fake targets.");

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -375,6 +375,10 @@ export async function invokeIngestCurtailmentSignal(page: Page, externalReferenc
   });
 }
 
+export async function cleanupRbacTeamArtifacts(browser: Browser, testInfo: TestInfo) {
+  await cleanupRbacArtifacts(browser, testInfo, ["team"]);
+}
+
 async function cleanupRbacArtifacts(browser: Browser, testInfo: TestInfo, cleanupTargets: RbacCleanupTarget[]) {
   const cleanupTargetSet = new Set(cleanupTargets);
 

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -6,8 +6,6 @@ import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { AlertsPage } from "../pages/alerts";
 import { AuthPage } from "../pages/auth";
-import { LoginModalComponent } from "../pages/components/loginModal";
-import { EditPoolPage } from "../pages/editPool";
 import { EnergyPage } from "../pages/energy";
 import { FleetLocationsPage } from "../pages/fleetLocations";
 import { MinersPage } from "../pages/miners";
@@ -38,7 +36,6 @@ export const RBAC_CURTAILMENT_PROFILE_PREFIX = "rbac_curtailment_profile";
 export const RBAC_CURTAILMENT_SOURCE_PREFIX = "rbac_curtailment_source";
 export const RBAC_CURTAILMENT_REASON_PREFIX = "rbac_curtailment_reason";
 export const RBAC_RACK_ZONE = "RbacZone";
-export const RBAC_HASH_POOL_USER_PREFIX = "rbac_hash_pool_user";
 
 type PersistedAdminStorageState = Exclude<
   NonNullable<Parameters<Browser["newContext"]>[0]>["storageState"],
@@ -166,6 +163,35 @@ export async function provisionRoleViaStoredAdminContext(
   });
 }
 
+export async function provisionRoleAndLoginViaStoredAdminContext(
+  browser: Browser,
+  testInfo: TestInfo,
+  commonSteps: CommonSteps,
+  {
+    permissionKeys,
+    roleDescription,
+  }: {
+    permissionKeys: string[];
+    roleDescription: string;
+  },
+): Promise<ProvisionedMember> {
+  const provisionedMember = await provisionRoleViaStoredAdminContext(browser, testInfo, {
+    permissionKeys,
+    roleDescription,
+  });
+
+  await commonSteps.completeFirstLoginAsTeamMember({
+    username: provisionedMember.username,
+    temporaryPassword: provisionedMember.temporaryPassword,
+    newPassword: MEMBER_PASSWORD,
+  });
+
+  return {
+    roleName: provisionedMember.roleName,
+    username: provisionedMember.username,
+  };
+}
+
 export async function createPool(
   settingsPage: SettingsPage,
   settingsPoolsPage: SettingsPoolsPage,
@@ -255,44 +281,6 @@ export async function createRack(racksPage: RacksPage, rackLabel: string) {
     await racksPage.waitForRackListToLoad({ allowEmpty: false });
     await racksPage.validateRackRow(rackLabel, RBAC_RACK_ZONE, 0);
   });
-}
-
-export async function prepareHashingRigMiner(
-  commonSteps: CommonSteps,
-  minersPage: MinersPage,
-  editPoolPage: EditPoolPage,
-  loginModal: LoginModalComponent,
-  settingsPage: SettingsPage,
-  settingsPoolsPage: SettingsPoolsPage,
-  newPoolModal: NewPoolModalPage,
-) {
-  const poolName = generateRandomText(RBAC_POOL_PREFIX);
-  const poolUsername = generateRandomText(RBAC_HASH_POOL_USER_PREFIX);
-
-  await commonSteps.loginAsAdmin({ forceReauth: true });
-  await createPool(settingsPage, settingsPoolsPage, newPoolModal, {
-    poolName,
-    poolUsername,
-  });
-
-  await commonSteps.goToMinersPage();
-  await minersPage.filterRigMiners();
-
-  const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-  await minersPage.clickMinerThreeDotsButton(minerIp);
-  await minersPage.clickEditMiningPoolButton();
-  await loginModal.loginAsAdmin();
-  await editPoolPage.removeAllPools();
-  await editPoolPage.clickAddPoolButton();
-  await editPoolPage.validateModalIsOpen();
-  await editPoolPage.clickPoolRowByName(poolName);
-  await editPoolPage.clickSavePoolChoice();
-  await editPoolPage.validateModalIsClosed();
-  await editPoolPage.clickAssignToXMiners(1);
-  await minersPage.validateTextInToastGroup("Assigned pools");
-  await minersPage.validateMinerStatusSettled(minerIp, "Hashing", testConfig.testTimeout);
-
-  return minerIp;
 }
 
 export async function wakeRigMinerIfSleeping(minersPage: MinersPage, minerIp: string) {

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -6,6 +6,8 @@ import { testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { AlertsPage } from "../pages/alerts";
 import { AuthPage } from "../pages/auth";
+import { LoginModalComponent } from "../pages/components/loginModal";
+import { EditPoolPage } from "../pages/editPool";
 import { EnergyPage } from "../pages/energy";
 import { FleetLocationsPage } from "../pages/fleetLocations";
 import { MinersPage } from "../pages/miners";
@@ -36,6 +38,7 @@ export const RBAC_CURTAILMENT_PROFILE_PREFIX = "rbac_curtailment_profile";
 export const RBAC_CURTAILMENT_SOURCE_PREFIX = "rbac_curtailment_source";
 export const RBAC_CURTAILMENT_REASON_PREFIX = "rbac_curtailment_reason";
 export const RBAC_RACK_ZONE = "RbacZone";
+export const RBAC_HASH_POOL_USER_PREFIX = "rbac_hash_pool_user";
 
 type PersistedAdminStorageState = Exclude<
   NonNullable<Parameters<Browser["newContext"]>[0]>["storageState"],
@@ -252,6 +255,55 @@ export async function createRack(racksPage: RacksPage, rackLabel: string) {
     await racksPage.waitForRackListToLoad({ allowEmpty: false });
     await racksPage.validateRackRow(rackLabel, RBAC_RACK_ZONE, 0);
   });
+}
+
+export async function prepareHashingRigMiner(
+  commonSteps: CommonSteps,
+  minersPage: MinersPage,
+  editPoolPage: EditPoolPage,
+  loginModal: LoginModalComponent,
+  settingsPage: SettingsPage,
+  settingsPoolsPage: SettingsPoolsPage,
+  newPoolModal: NewPoolModalPage,
+) {
+  const poolName = generateRandomText(RBAC_POOL_PREFIX);
+  const poolUsername = generateRandomText(RBAC_HASH_POOL_USER_PREFIX);
+
+  await commonSteps.loginAsAdmin({ forceReauth: true });
+  await createPool(settingsPage, settingsPoolsPage, newPoolModal, {
+    poolName,
+    poolUsername,
+  });
+
+  await commonSteps.goToMinersPage();
+  await minersPage.filterRigMiners();
+
+  const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+  await minersPage.clickMinerThreeDotsButton(minerIp);
+  await minersPage.clickEditMiningPoolButton();
+  await loginModal.loginAsAdmin();
+  await editPoolPage.removeAllPools();
+  await editPoolPage.clickAddPoolButton();
+  await editPoolPage.validateModalIsOpen();
+  await editPoolPage.clickPoolRowByName(poolName);
+  await editPoolPage.clickSavePoolChoice();
+  await editPoolPage.validateModalIsClosed();
+  await editPoolPage.clickAssignToXMiners(1);
+  await minersPage.validateTextInToastGroup("Assigned pools");
+  await minersPage.validateMinerStatusSettled(minerIp, "Hashing", testConfig.testTimeout);
+
+  return minerIp;
+}
+
+export async function wakeRigMinerIfSleeping(minersPage: MinersPage, minerIp: string) {
+  if ((await minersPage.getMinerStatus(minerIp).catch(() => "")).trim() !== "Sleeping") {
+    return;
+  }
+
+  await minersPage.clickMinerThreeDotsButton(minerIp);
+  await minersPage.clickWakeUpButton();
+  await minersPage.clickWakeUpConfirm();
+  await minersPage.validateMinerStatusSettled(minerIp, "Hashing");
 }
 
 export async function createCurtailment(energyPage: EnergyPage, reason: string) {

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -294,6 +294,25 @@ export async function wakeRigMinerIfSleeping(minersPage: MinersPage, minerIp: st
   await minersPage.validateMinerStatusSettled(minerIp, "Hashing");
 }
 
+export async function ensureVisibleRigMinersAwake(minersPage: MinersPage) {
+  await minersPage.filterRigMiners();
+
+  if (await minersPage.hasAnyMinerWithStatus("Waking")) {
+    await minersPage.validateNoMinerWithStatus("Waking");
+  }
+
+  while (await minersPage.hasAnyMinerWithStatus("Sleeping")) {
+    const sleepingMinerIp = await minersPage.getMinerIpAddressByStatus("Sleeping");
+    await minersPage.clickMinerThreeDotsButton(sleepingMinerIp);
+    await minersPage.clickWakeUpButton();
+    await minersPage.clickWakeUpConfirm();
+    await minersPage.validateMinerStatusSettled(sleepingMinerIp, "Hashing");
+  }
+
+  await minersPage.validateNoMinerWithStatus("Sleeping");
+  await minersPage.validateNoMinerWithStatus("Waking");
+}
+
 export async function createCurtailment(energyPage: EnergyPage, reason: string) {
   if (testConfig.target === "real") {
     throw new Error("RBAC curtailment setup is only supported against fake targets.");

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -328,11 +328,28 @@ export async function ensureVisibleRigMinersAwake(minersPage: MinersPage) {
 export async function selectHashingRigMinerForStopFlow(minersPage: MinersPage) {
   await minersPage.filterRigMiners();
 
-  if (testConfig.target !== "real") {
-    await ensureVisibleRigMinersAwake(minersPage);
+  if (await minersPage.hasAnyMinerWithStatus("Hashing")) {
+    return await minersPage.getMinerIpAddressByStatus("Hashing");
   }
 
-  return await minersPage.getMinerIpAddressByStatus("Hashing");
+  if (await minersPage.hasAnyMinerWithStatus("Waking")) {
+    await minersPage.validateNoMinerWithStatus("Waking", SHORT_HOOK_TIMEOUT);
+    if (await minersPage.hasAnyMinerWithStatus("Hashing")) {
+      return await minersPage.getMinerIpAddressByStatus("Hashing");
+    }
+  }
+
+  if (testConfig.target === "real") {
+    throw new Error('No visible rig miner was already "Hashing" for the stop-mining RBAC flow.');
+  }
+
+  const sleepingMinerIp = await minersPage.getMinerIpAddressByStatus("Sleeping");
+  await minersPage.clickMinerThreeDotsButton(sleepingMinerIp);
+  await minersPage.clickWakeUpButton();
+  await minersPage.clickWakeUpConfirm();
+  await minersPage.validateMinerStatusSettled(sleepingMinerIp, "Hashing");
+
+  return sleepingMinerIp;
 }
 
 export async function createCurtailment(energyPage: EnergyPage, reason: string) {

--- a/client/e2eTests/protoFleet/pages/addMiners.ts
+++ b/client/e2eTests/protoFleet/pages/addMiners.ts
@@ -3,6 +3,8 @@ import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
 import { PROTO_RIG_DISPLAY_NAME } from "../helpers/minerModels";
 import { BasePage } from "./base";
 
+const SHORT_CLOSE_TIMEOUT = Math.floor(DEFAULT_TIMEOUT / 6);
+
 export class AddMinersPage extends BasePage {
   private continueWithMinersButton(minerCount?: number) {
     return minerCount === undefined
@@ -31,6 +33,10 @@ export class AddMinersPage extends BasePage {
   async validateAddMinersFlowOpened() {
     await expect(this.page.getByTestId("section-scan-network")).toBeVisible();
     await expect(this.page.getByTestId("section-search-by-ip")).toBeVisible();
+  }
+
+  async validateAddMinersFlowClosed(timeout: number = SHORT_CLOSE_TIMEOUT) {
+    await expect(this.page.getByLabel("Close add miners")).toBeHidden({ timeout });
   }
 
   async inputMinerIp(ipAddresses: string) {
@@ -167,6 +173,17 @@ export class AddMinersPage extends BasePage {
 
   async clickHeaderIconButton() {
     await this.page.getByTestId("header-icon-button").click();
+    await this.validateAddMinersFlowClosed();
+  }
+
+  async closeAddMinersFlowIfOpen(timeout: number = SHORT_CLOSE_TIMEOUT) {
+    const closeButton = this.page.getByLabel("Close add miners");
+    if (!(await closeButton.isVisible().catch(() => false))) {
+      return;
+    }
+
+    await closeButton.click();
+    await this.validateAddMinersFlowClosed(timeout);
   }
 
   async validateOneMinerWasFoundByIp() {

--- a/client/e2eTests/protoFleet/pages/addMiners.ts
+++ b/client/e2eTests/protoFleet/pages/addMiners.ts
@@ -29,7 +29,6 @@ export class AddMinersPage extends BasePage {
   }
 
   async validateAddMinersFlowOpened() {
-    await expect(this.page.getByText("Add miners", { exact: true })).toBeVisible();
     await expect(this.page.getByTestId("section-scan-network")).toBeVisible();
     await expect(this.page.getByTestId("section-search-by-ip")).toBeVisible();
   }

--- a/client/e2eTests/protoFleet/pages/addMiners.ts
+++ b/client/e2eTests/protoFleet/pages/addMiners.ts
@@ -28,6 +28,12 @@ export class AddMinersPage extends BasePage {
     await this.clickIn("Find miners", "section-search-by-ip");
   }
 
+  async validateAddMinersFlowOpened() {
+    await expect(this.page.getByText("Add miners", { exact: true })).toBeVisible();
+    await expect(this.page.getByTestId("section-scan-network")).toBeVisible();
+    await expect(this.page.getByTestId("section-search-by-ip")).toBeVisible();
+  }
+
   async inputMinerIp(ipAddresses: string) {
     await this.page.locator('//textarea[@id="ipAddresses"]').fill(ipAddresses);
   }

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -654,6 +654,23 @@ export class BasePage {
     await expect(this.page.getByTestId("modal")).toBeHidden();
   }
 
+  async dismissModalIfVisible() {
+    const modal = this.page.getByTestId("modal");
+    if (!(await modal.isVisible().catch(() => false))) {
+      return;
+    }
+
+    const headerDismiss = modal.getByTestId("header-icon-button");
+    if (await headerDismiss.isVisible().catch(() => false)) {
+      await headerDismiss.click();
+      await this.validateModalIsClosed();
+      return;
+    }
+
+    await this.page.keyboard.press("Escape").catch(() => undefined);
+    await this.validateModalIsClosed();
+  }
+
   async clickSaveInModal() {
     await this.clickIn("Save", "modal");
   }

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -261,6 +261,12 @@ export class MinersPage extends BasePage {
   }
 
   async clickBlinkLEDsButton() {
+    const singleMinerAction = this.singleMinerActionsPopover().getByTestId("blink-leds-popover-button");
+    if (await singleMinerAction.isVisible().catch(() => false)) {
+      await singleMinerAction.click();
+      return;
+    }
+
     const quickAction = this.page.getByTestId("actions-menu-quick-action-blink-leds");
     if (await quickAction.isVisible().catch(() => false)) {
       await quickAction.click();
@@ -271,8 +277,12 @@ export class MinersPage extends BasePage {
       return;
     }
 
-    await this.clickActionsMenuButton();
-    await this.page.getByText("Blink LEDs", { exact: true }).click();
+    if (await this.tryAction(() => this.clickActionsMenuButton(), 2000)) {
+      await this.page.getByText("Blink LEDs", { exact: true }).click();
+      return;
+    }
+
+    throw new Error("Could not find a visible Blink LEDs action in the current miner actions UI.");
   }
 
   async validateActionBarMinerCount(expectedCount: number) {
@@ -339,6 +349,29 @@ export class MinersPage extends BasePage {
     await expect(dialog).toBeVisible();
     await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
     await expect(dialog).toBeHidden();
+  }
+
+  async dismissSingleMinerActionsPopoverIfVisible() {
+    const popover = this.singleMinerActionsPopover();
+    if (!(await popover.isVisible().catch(() => false))) {
+      return;
+    }
+
+    await this.page.keyboard.press("Escape").catch(() => undefined);
+    if (!(await popover.isVisible().catch(() => false))) {
+      return;
+    }
+
+    const mobileSheet = this.page.getByTestId("single-miner-actions-popover-popover-sheet");
+    if (await mobileSheet.isVisible().catch(() => false)) {
+      await mobileSheet.click({ position: { x: 8, y: 8 } });
+    }
+
+    if (await popover.isVisible().catch(() => false)) {
+      await this.page.mouse.click(8, 8);
+    }
+
+    await expect(popover).toBeHidden();
   }
 
   async clickEditMiningPoolButton() {
@@ -1221,6 +1254,37 @@ export class MinersPage extends BasePage {
 
     const row = authenticatedRows.nth(index);
     return await row.getByTestId("ipAddress").innerText();
+  }
+
+  async openSingleMinerActionsForAuthenticatedMinerWithAction(actionTestId: string): Promise<string> {
+    const allRows = this.page.getByTestId("list-body").locator("tr");
+    const authenticatedRows = allRows.filter({
+      has: this.page.locator('input[type="checkbox"]:not([disabled])'),
+    });
+    const authenticatedCount = await authenticatedRows.count();
+    const checkedMinerIps: string[] = [];
+
+    for (let i = 0; i < authenticatedCount; i++) {
+      const row = authenticatedRows.nth(i);
+      await row.scrollIntoViewIfNeeded();
+
+      const minerIp = (await row.getByTestId("ipAddress").innerText()).trim();
+      checkedMinerIps.push(minerIp);
+
+      await row.getByTestId("single-miner-actions-menu-button").click();
+      const popover = this.singleMinerActionsPopover();
+      await expect(popover).toBeVisible();
+
+      if ((await popover.getByTestId(actionTestId).count()) > 0) {
+        return minerIp;
+      }
+
+      await this.dismissSingleMinerActionsPopoverIfVisible();
+    }
+
+    throw new Error(
+      `No authenticated miner exposed action "${actionTestId}". Checked miners: ${checkedMinerIps.join(", ") || "none"}`,
+    );
   }
 
   async validateMinerNotPresent(ipAddress: string) {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -252,22 +252,12 @@ export class MinersPage extends BasePage {
     await this.page.getByTestId("actions-menu-button").click();
   }
 
-  private async anyVisibleByTestId(testId: string): Promise<boolean> {
-    const matches = this.page.getByTestId(testId);
-    const count = await matches.count();
-
-    for (let i = 0; i < count; i += 1) {
-      if (
-        await matches
-          .nth(i)
-          .isVisible()
-          .catch(() => false)
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+  private singleMinerActionsPopover(): Locator {
+    return this.page
+      .locator(
+        '[data-testid="single-miner-actions-popover-popover"], [data-testid="single-miner-actions-popover-popover-sheet"]',
+      )
+      .first();
   }
 
   async clickBlinkLEDsButton() {
@@ -342,6 +332,13 @@ export class MinersPage extends BasePage {
 
   async clickManagePowerConfirm() {
     await this.clickIn("Confirm", "modal");
+  }
+
+  async cancelSingleMinerConfirmationDialog() {
+    const dialog = this.page.getByTestId("single-miner-actions-dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+    await expect(dialog).toBeHidden();
   }
 
   async clickEditMiningPoolButton() {
@@ -1290,8 +1287,11 @@ export class MinersPage extends BasePage {
   }
 
   async validateSingleMinerActionsHidden(testIds: string[]) {
+    const popover = this.singleMinerActionsPopover();
+    await expect(popover).toBeVisible();
+
     for (const testId of testIds) {
-      expect(await this.anyVisibleByTestId(testId), `Expected action "${testId}" to be hidden.`).toBe(false);
+      await expect(popover.getByTestId(testId), `Expected action "${testId}" to be hidden.`).toHaveCount(0);
     }
   }
 }

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -908,7 +908,7 @@ export class MinersPage extends BasePage {
     }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
   }
 
-  async validateAllMinersStatus(status: string, expected: boolean = true) {
+  async validateAllMinersStatus(status: string, expected: boolean = true, timeoutMs: number = PROLONGED_TIMEOUT) {
     await this.waitForColumnValuesToLoad("status");
     // To avoid miner actions hiding some valuable data in screenshots
     await this.uncheckSelectAllCheckbox();
@@ -920,18 +920,18 @@ export class MinersPage extends BasePage {
       const statusLocator = rows.nth(i).locator(`//td[@data-testid='status']`);
       if (expected) {
         await expect(statusLocator).toContainText(status, {
-          timeout: PROLONGED_TIMEOUT,
+          timeout: timeoutMs,
         });
       } else {
         await expect(statusLocator).not.toContainText(status, {
-          timeout: PROLONGED_TIMEOUT,
+          timeout: timeoutMs,
         });
       }
     }
   }
 
-  async validateNoMinerWithStatus(status: string) {
-    await this.validateAllMinersStatus(status, false);
+  async validateNoMinerWithStatus(status: string, timeoutMs?: number) {
+    await this.validateAllMinersStatus(status, false, timeoutMs);
   }
 
   async validateAllMinersStatusSettled(status: string) {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -252,10 +252,32 @@ export class MinersPage extends BasePage {
     await this.page.getByTestId("actions-menu-button").click();
   }
 
+  private async anyVisibleByTestId(testId: string): Promise<boolean> {
+    const matches = this.page.getByTestId(testId);
+    const count = await matches.count();
+
+    for (let i = 0; i < count; i += 1) {
+      if (
+        await matches
+          .nth(i)
+          .isVisible()
+          .catch(() => false)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   async clickBlinkLEDsButton() {
     const quickAction = this.page.getByTestId("actions-menu-quick-action-blink-leds");
     if (await quickAction.isVisible().catch(() => false)) {
       await quickAction.click();
+      return;
+    }
+
+    if (await this.tryAction(() => this.page.getByText("Blink LEDs", { exact: true }).click(), 2000)) {
       return;
     }
 
@@ -1265,5 +1287,11 @@ export class MinersPage extends BasePage {
 
   async clickCloseStatusModal() {
     await this.clickIn("Done", "modal");
+  }
+
+  async validateSingleMinerActionsHidden(testIds: string[]) {
+    for (const testId of testIds) {
+      expect(await this.anyVisibleByTestId(testId), `Expected action "${testId}" to be hidden.`).toBe(false);
+    }
   }
 }

--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -29,6 +29,28 @@ export class SettingsFirmwarePage extends BasePage {
     await expect(this.page.getByTestId("list-body").locator("tr").filter({ hasText: fileName })).toBeVisible();
   }
 
+  async deleteFirmwareFileByName(fileName: string) {
+    const row = this.page.getByTestId("list-body").locator("tr").filter({ hasText: fileName }).first();
+
+    if (!(await row.isVisible().catch(() => false))) {
+      return;
+    }
+
+    const directDeleteButton = row.getByRole("button", { name: "Delete", exact: true });
+    if (await directDeleteButton.isVisible().catch(() => false)) {
+      await directDeleteButton.click();
+    } else {
+      await row.getByTestId("overflow-menu-trigger").click();
+      await this.page.getByRole("button", { name: "Delete", exact: true }).click();
+    }
+
+    const dialog = this.page.getByTestId("delete-firmware-dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Delete", exact: true }).click();
+    await expect(dialog).toBeHidden();
+    await expect(row).toBeHidden();
+  }
+
   async deleteAllFirmwareFilesIfAny() {
     const emptyState = this.page.getByText("No firmware files uploaded", { exact: true });
     const firmwareRows = this.page.getByTestId("list-body").locator("tr");

--- a/client/e2eTests/protoFleet/pages/settingsTeam.ts
+++ b/client/e2eTests/protoFleet/pages/settingsTeam.ts
@@ -1,4 +1,5 @@
 import { expect } from "@playwright/test";
+import { DEFAULT_TIMEOUT } from "../config/test.config";
 import { BasePage } from "./base";
 
 const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -39,22 +40,26 @@ export class SettingsTeamPage extends BasePage {
     await this.clickButton("Add team member");
   }
 
-  async openMembersTab() {
+  async openMembersTab(timeoutMs: number = DEFAULT_TIMEOUT) {
     const activateButton = this.page.getByTestId("team-tab-members-activate");
     if (await activateButton.isVisible().catch(() => false)) {
       await activateButton.click();
     }
 
-    await expect(this.page.getByRole("button", { name: "Add team member", exact: true })).toBeVisible();
+    await expect(this.page.getByRole("button", { name: "Add team member", exact: true })).toBeVisible({
+      timeout: timeoutMs,
+    });
   }
 
-  async openRolesTab() {
+  async openRolesTab(timeoutMs: number = DEFAULT_TIMEOUT) {
     const activateButton = this.page.getByTestId("team-tab-roles-activate");
     if (await activateButton.isVisible().catch(() => false)) {
       await activateButton.click();
     }
 
-    await expect(this.page.getByRole("button", { name: "Create role", exact: true })).toBeVisible();
+    await expect(this.page.getByRole("button", { name: "Create role", exact: true })).toBeVisible({
+      timeout: timeoutMs,
+    });
   }
 
   async inputMemberUsername(username: string) {

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -2,6 +2,7 @@ import { type Browser } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
 import {
+  ensureVisibleRigMinersAwake,
   provisionRoleAndLoginViaStoredAdminContext,
   useRbacHooks,
   wakeRigMinerIfSleeping,
@@ -53,6 +54,8 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await minersPage.validateSingleMinerActionsHidden([
       "blink-leds-popover-button",
       "reboot-popover-button",
+      "shutdown-popover-button",
+      "wake-up-popover-button",
       "manage-power-popover-button",
       "mining-pool-popover-button",
       "firmware-update-popover-button",
@@ -114,6 +117,7 @@ test.describe("Proto Fleet - Miner RBAC", () => {
 
     await commonSteps.loginAsAdmin({ forceReauth: true });
     await commonSteps.goToMinersPage();
+    await ensureVisibleRigMinersAwake(minersPage);
     const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
     await minersPage.clickMinerThreeDotsButton(minerIp);
     await minersPage.clickShutdownButton();
@@ -150,6 +154,7 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     });
 
     await commonSteps.goToMinersPage();
+    await ensureVisibleRigMinersAwake(minersPage);
     const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
     await minersPage.clickMinerThreeDotsButton(minerIp);
     await minersPage.clickShutdownButton();
@@ -356,8 +361,12 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     });
 
     await commonSteps.goToMinersPage();
+    const minerIp = await minersPage.getMinerIpAddressByIndex(0);
     await minersPage.clickAddMinersButton();
     await addMinersPage.validateAddMinersFlowOpened();
+    await addMinersPage.inputMinerIp(minerIp);
+    await addMinersPage.clickFindMinersByIp();
+    await addMinersPage.waitForFoundMinersList();
     await addMinersPage.clickHeaderIconButton();
   });
 

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -1,0 +1,408 @@
+import { testConfig } from "../config/test.config";
+import { expect, test } from "../fixtures/pageFixtures";
+import {
+  prepareHashingRigMiner,
+  provisionRoleAndLogin,
+  useRbacHooks,
+  wakeRigMinerIfSleeping,
+} from "../helpers/rbacTestSetup";
+import { generateRandomText } from "../helpers/testDataHelper";
+
+const MINER_READ_PERMISSIONS = ["fleet:read", "miner:read"] as const;
+const RBAC_FIRMWARE_FILE_PREFIX = "rbac_firmware";
+
+test.describe("Proto Fleet - Miner RBAC", () => {
+  useRbacHooks();
+
+  test("Miners read-only role can view the miner list and status without mutating action controls", async ({
+    commonSteps,
+    minersPage,
+  }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Read-only miner access for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    const minerName = (await minersPage.getMinerNameByIndex(0)).trim();
+    const minerStatus = (await minersPage.getMinerStatus(minerIp)).trim();
+
+    expect(minerName).not.toBe("");
+    expect(minerStatus).not.toBe("");
+
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.validateSingleMinerActionsHidden([
+      "actions-menu-quick-action-blink-leds",
+      "reboot-popover-button",
+      "manage-power-popover-button",
+      "mining-pool-popover-button",
+      "firmware-update-popover-button",
+      "cooling-mode-popover-button",
+      "download-logs-popover-button",
+      "rename-popover-button",
+      "update-worker-names-popover-button",
+      "security-popover-button",
+      "unpair-popover-button",
+    ]);
+  });
+
+  test("Miners blink-led role can blink a miner locator LED", async ({ commonSteps, minersPage }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Blink miner LEDs for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:blink_led"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickBlinkLEDsButton();
+    await minersPage.validateTextInToastGroup("Blinking LEDs");
+    await minersPage.validateTextInToastGroup("Blinked LEDs");
+  });
+
+  test("Miners reboot role can reboot a miner", async ({ commonSteps, minersPage }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      testConfig.target === "real",
+      "Stateful miner RBAC action coverage is only supported against fake targets.",
+    );
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Reboot miners for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:reboot"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickRebootButton();
+    await minersPage.clickRebootConfirm();
+    await minersPage.validateTextInToastGroup("Rebooting");
+    await minersPage.validateTextInToastGroup("Rebooted");
+  });
+
+  test("Miners start-mining role can wake a sleeping miner", async ({
+    commonSteps,
+    editPoolPage,
+    loginModal,
+    minersPage,
+    newPoolModal,
+    settingsPage,
+    settingsPoolsPage,
+  }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      testConfig.target === "real",
+      "Stateful miner RBAC action coverage is only supported against fake targets.",
+    );
+
+    await commonSteps.loginAsAdmin({ forceReauth: true });
+    const minerIp = await prepareHashingRigMiner(
+      commonSteps,
+      minersPage,
+      editPoolPage,
+      loginModal,
+      settingsPage,
+      settingsPoolsPage,
+      newPoolModal,
+    );
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickShutdownButton();
+    await minersPage.clickShutdownConfirm();
+    await minersPage.validateMinerStatusSettled(minerIp, "Sleeping");
+
+    try {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Wake miners for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:start_mining"],
+      });
+
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickWakeUpButton();
+      await minersPage.clickWakeUpConfirm();
+      await minersPage.validateTextInToastGroup("Waking up miners");
+      await minersPage.validateMinerStatusSettled(minerIp, "Hashing");
+    } finally {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      await wakeRigMinerIfSleeping(minersPage, minerIp);
+    }
+  });
+
+  test("Miners stop-mining role can put a hashing miner to sleep", async ({
+    commonSteps,
+    editPoolPage,
+    loginModal,
+    minersPage,
+    newPoolModal,
+    settingsPage,
+    settingsPoolsPage,
+  }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      testConfig.target === "real",
+      "Stateful miner RBAC action coverage is only supported against fake targets.",
+    );
+
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Stop miners for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:stop_mining"],
+    });
+
+    const minerIp = await prepareHashingRigMiner(
+      commonSteps,
+      minersPage,
+      editPoolPage,
+      loginModal,
+      settingsPage,
+      settingsPoolsPage,
+      newPoolModal,
+    );
+
+    try {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickShutdownButton();
+      await minersPage.clickShutdownConfirm();
+      await minersPage.validateTextInToastGroup("Putting miners to sleep");
+      await minersPage.validateMinerStatusSettled(minerIp, "Sleeping");
+    } finally {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      await wakeRigMinerIfSleeping(minersPage, minerIp);
+    }
+  });
+
+  test("Miners update-pools role can open the pool editor from a miner action menu", async ({
+    commonSteps,
+    loginModal,
+    minersPage,
+  }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Update miner pools for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "pool:read", "miner:update_pools"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickEditMiningPoolButton();
+    await loginModal.validateTitleInModal("Log in to update your pool settings");
+  });
+
+  test("Miners update-worker-names role can open the worker-name flow", async ({
+    commonSteps,
+    loginModal,
+    minersPage,
+  }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Update worker names for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:update_worker_names"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickUpdateWorkerNameButton();
+    await loginModal.validateTitleInModal("Log in to update worker names");
+  });
+
+  test("Miners rename role can open the rename flow", async ({ commonSteps, minersPage }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Rename miners for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:rename"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickRenameButton();
+    await minersPage.validateTitleInModal("Rename miner");
+    await minersPage.fillRenameInput(generateRandomText("rbac_rename_preview"));
+    await minersPage.dismissModalIfVisible();
+  });
+
+  test("Miners delete role can open the unpair confirmation flow", async ({ commonSteps, minersPage, page }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Delete miners from fleet for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:delete"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickUnpairButton();
+    await expect(page.getByTestId("unpair-confirm-button")).toBeVisible();
+    await minersPage.dismissModalIfVisible();
+  });
+
+  test("Miners cooling-mode role can open the cooling-mode flow", async ({ commonSteps, minersPage, page }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Change cooling mode for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:set_cooling_mode"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickCoolingModeButton();
+    await expect(page.getByTestId("cooling-option-air")).toBeVisible();
+    await expect(page.getByTestId("cooling-option-immersion")).toBeVisible();
+    await minersPage.dismissModalIfVisible();
+  });
+
+  test("Miners power-target role can open the power-target flow", async ({ commonSteps, minersPage, page }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Change miner power targets for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:set_power_target"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickManagePowerButton();
+    await expect(page.getByTestId("power-option-maximize")).toBeVisible();
+    await expect(page.getByTestId("power-option-reduce")).toBeVisible();
+    await minersPage.dismissModalIfVisible();
+  });
+
+  test("Miners firmware-update role can open the firmware-update flow", async ({
+    commonSteps,
+    minersPage,
+    page,
+    settingsFirmwarePage,
+  }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      testConfig.target === "real",
+      "Firmware RBAC coverage uploads a fake payload and is only supported against fake targets.",
+    );
+
+    const firmwareFileName = `${generateRandomText(RBAC_FIRMWARE_FILE_PREFIX)}.swu`;
+
+    await commonSteps.loginAsAdmin({ forceReauth: true });
+    await settingsFirmwarePage.navigateToFirmwareSettings();
+    await settingsFirmwarePage.validateFirmwarePageOpened();
+    await settingsFirmwarePage.clickUploadFirmware();
+    await settingsFirmwarePage.uploadFirmwareFile(firmwareFileName, `rbac firmware payload ${Date.now()}`);
+    await settingsFirmwarePage.clickDoneInUploadDialog();
+    await settingsFirmwarePage.validateFirmwareFileVisible(firmwareFileName);
+
+    try {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Update miner firmware for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:firmware_update", "miner:reboot"],
+      });
+
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+
+      const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickUpdateFirmwareButton();
+      await minersPage.validateFirmwareUpdateModalOpened();
+      await expect(page.getByRole("radio").filter({ hasText: firmwareFileName })).toBeVisible();
+      await minersPage.dismissModalIfVisible();
+    } finally {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
+      await settingsFirmwarePage.deleteFirmwareFileByName(firmwareFileName);
+    }
+  });
+
+  test("Miners download-logs role can start a diagnostic log download", async ({ commonSteps, minersPage, page }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Download miner logs for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:download_logs"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    const downloadPromise = page.waitForEvent("download");
+
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickDownloadLogsButton();
+
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.(zip|csv)$/i);
+    await minersPage.validateTextInToastGroup("Downloaded logs");
+  });
+
+  test("Miners update-password role can open the manage-security password flow", async ({
+    commonSteps,
+    minersPage,
+    loginModal,
+  }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Update miner passwords for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:update_password"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickManageSecurityButton();
+    await loginModal.validateTitleInModal("Log in to update your security settings");
+  });
+
+  test("Miners pair role can discover miners in the add-miners flow", async ({
+    addMinersPage,
+    commonSteps,
+    minersPage,
+  }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Pair miners for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:pair", "fleetnode:manage"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.clickAddMinersButton();
+    await addMinersPage.clickFindMinersInNetwork();
+    await addMinersPage.waitForNetworkScanToFinish();
+    expect(await addMinersPage.getSelectedMinersCount()).toBeGreaterThan(0);
+    await addMinersPage.dismissModalIfVisible();
+  });
+
+  test("Miners export-csv role can export the miner list", async ({ commonSteps, minersPage, page }) => {
+    await provisionRoleAndLogin(commonSteps, {
+      roleDescription: "Export miner list CSV for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:export_csv"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const downloadPromise = page.waitForEvent("download");
+    await minersPage.clickButton("Export CSV");
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/miner|proto-fleet-miner-snapshot/i);
+  });
+});

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -6,6 +6,7 @@ import {
   cleanupRbacTeamArtifacts,
   ensureVisibleRigMinersAwake,
   provisionRoleAndLoginViaStoredAdminContext,
+  selectHashingRigMinerForStopFlow,
   wakeRigMinerIfSleeping,
 } from "../helpers/rbacTestSetup";
 import { generateRandomText } from "../helpers/testDataHelper";
@@ -194,6 +195,12 @@ test.describe("Proto Fleet - Miner RBAC", () => {
   }) => {
     let minerIp = "";
 
+    await test.step("Prepare a hashing Proto rig", async () => {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
+      await commonSteps.goToMinersPage();
+      minerIp = await selectHashingRigMinerForStopFlow(minersPage);
+    });
+
     await test.step("Provision a stop-mining miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Stop miners for RBAC coverage.",
@@ -201,10 +208,8 @@ test.describe("Proto Fleet - Miner RBAC", () => {
       });
     });
 
-    await test.step("Open Proto rig miners and select a hashing miner", async () => {
+    await test.step("Open Proto rig miners", async () => {
       await commonSteps.goToMinersPage();
-      await ensureVisibleRigMinersAwake(minersPage);
-      minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
     });
 
     await test.step("Open the sleep confirmation flow", async () => {

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -479,6 +479,7 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     browser,
     commonSteps,
     minersPage,
+    page,
   }) => {
     let minerIp = "";
 
@@ -489,16 +490,32 @@ test.describe("Proto Fleet - Miner RBAC", () => {
       });
     });
 
-    await test.step("Open the miners page and capture a miner IP", async () => {
+    await test.step("Open Proto rig miners and capture an authenticated miner IP", async () => {
       await commonSteps.goToMinersPage();
-      minerIp = await minersPage.getMinerIpAddressByIndex(0);
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
     });
 
-    await test.step("Run a pair-gated discovery request by IP", async () => {
+    await test.step("Run a pair-gated discovery request by IP and wait for a found miner", async () => {
+      const discoverRequestPromise = page.waitForRequest((request) =>
+        request.url().includes("/pairing.v1.PairingService/Discover"),
+      );
+      const discoverResponsePromise = page.waitForResponse((response) =>
+        response.url().includes("/pairing.v1.PairingService/Discover"),
+      );
+
       await minersPage.clickAddMinersButton();
       await addMinersPage.validateAddMinersFlowOpened();
       await addMinersPage.inputMinerIp(minerIp);
       await addMinersPage.clickFindMinersByIp();
+
+      const discoverRequest = await discoverRequestPromise;
+      const discoverResponse = await discoverResponsePromise;
+
+      expect(discoverRequest.method()).toBe("POST");
+      expect(discoverRequest.postData() ?? "").toContain(minerIp);
+      expect(discoverResponse.status()).toBe(200);
+
       await addMinersPage.waitForFoundMinersList();
       await addMinersPage.clickHeaderIconButton();
     });

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -1,24 +1,41 @@
+import { type Browser } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
 import {
-  prepareHashingRigMiner,
-  provisionRoleAndLogin,
+  provisionRoleAndLoginViaStoredAdminContext,
   useRbacHooks,
   wakeRigMinerIfSleeping,
 } from "../helpers/rbacTestSetup";
 import { generateRandomText } from "../helpers/testDataHelper";
 
 const MINER_READ_PERMISSIONS = ["fleet:read", "miner:read"] as const;
-const RBAC_FIRMWARE_FILE_PREFIX = "rbac_firmware";
+
+async function provisionMinerRole(
+  browser: Browser,
+  commonSteps: Parameters<typeof provisionRoleAndLoginViaStoredAdminContext>[2],
+  {
+    permissionKeys,
+    roleDescription,
+  }: {
+    permissionKeys: string[];
+    roleDescription: string;
+  },
+) {
+  return await provisionRoleAndLoginViaStoredAdminContext(browser, test.info(), commonSteps, {
+    permissionKeys,
+    roleDescription,
+  });
+}
 
 test.describe("Proto Fleet - Miner RBAC", () => {
   useRbacHooks();
 
   test("Miners read-only role can view the miner list and status without mutating action controls", async ({
+    browser,
     commonSteps,
     minersPage,
   }) => {
-    await provisionRoleAndLogin(commonSteps, {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Read-only miner access for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS],
     });
@@ -27,15 +44,14 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await minersPage.filterRigMiners();
 
     const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    const minerName = (await minersPage.getMinerNameByIndex(0)).trim();
     const minerStatus = (await minersPage.getMinerStatus(minerIp)).trim();
 
-    expect(minerName).not.toBe("");
+    expect(minerIp).not.toBe("");
     expect(minerStatus).not.toBe("");
 
     await minersPage.clickMinerThreeDotsButton(minerIp);
     await minersPage.validateSingleMinerActionsHidden([
-      "actions-menu-quick-action-blink-leds",
+      "blink-leds-popover-button",
       "reboot-popover-button",
       "manage-power-popover-button",
       "mining-pool-popover-button",
@@ -49,8 +65,8 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     ]);
   });
 
-  test("Miners blink-led role can blink a miner locator LED", async ({ commonSteps, minersPage }) => {
-    await provisionRoleAndLogin(commonSteps, {
+  test("Miners blink-led role can blink a miner locator LED", async ({ browser, commonSteps, minersPage }) => {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Blink miner LEDs for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:blink_led"],
     });
@@ -65,37 +81,30 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await minersPage.validateTextInToastGroup("Blinked LEDs");
   });
 
-  test("Miners reboot role can reboot a miner", async ({ commonSteps, minersPage }) => {
-    // eslint-disable-next-line playwright/no-skipped-test
-    test.skip(
-      testConfig.target === "real",
-      "Stateful miner RBAC action coverage is only supported against fake targets.",
-    );
-
-    await provisionRoleAndLogin(commonSteps, {
+  test("Miners reboot role can open the reboot confirmation flow", async ({
+    browser,
+    commonSteps,
+    minersPage,
+    page,
+  }) => {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Reboot miners for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:reboot"],
     });
 
     await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
-
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
     await minersPage.clickMinerThreeDotsButton(minerIp);
     await minersPage.clickRebootButton();
-    await minersPage.clickRebootConfirm();
-    await minersPage.validateTextInToastGroup("Rebooting");
-    await minersPage.validateTextInToastGroup("Rebooted");
+    await expect(page.getByTestId("reboot-confirm-button")).toBeVisible();
+    await minersPage.cancelSingleMinerConfirmationDialog();
   });
 
-  test("Miners start-mining role can wake a sleeping miner", async ({
+  test("Miners start-mining role can open the wake-up confirmation flow", async ({
+    browser,
     commonSteps,
-    editPoolPage,
-    loginModal,
     minersPage,
-    newPoolModal,
-    settingsPage,
-    settingsPoolsPage,
+    page,
   }) => {
     // eslint-disable-next-line playwright/no-skipped-test
     test.skip(
@@ -104,93 +113,57 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     );
 
     await commonSteps.loginAsAdmin({ forceReauth: true });
-    const minerIp = await prepareHashingRigMiner(
-      commonSteps,
-      minersPage,
-      editPoolPage,
-      loginModal,
-      settingsPage,
-      settingsPoolsPage,
-      newPoolModal,
-    );
+    await commonSteps.goToMinersPage();
+    const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
     await minersPage.clickMinerThreeDotsButton(minerIp);
     await minersPage.clickShutdownButton();
     await minersPage.clickShutdownConfirm();
     await minersPage.validateMinerStatusSettled(minerIp, "Sleeping");
 
     try {
-      await provisionRoleAndLogin(commonSteps, {
+      await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Wake miners for RBAC coverage.",
         permissionKeys: [...MINER_READ_PERMISSIONS, "miner:start_mining"],
       });
 
       await commonSteps.goToMinersPage();
-      await minersPage.filterRigMiners();
       await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickWakeUpButton();
-      await minersPage.clickWakeUpConfirm();
-      await minersPage.validateTextInToastGroup("Waking up miners");
-      await minersPage.validateMinerStatusSettled(minerIp, "Hashing");
+      await expect(page.getByTestId("wake-up-confirm-button")).toBeVisible();
+      await minersPage.cancelSingleMinerConfirmationDialog();
     } finally {
       await commonSteps.loginAsAdmin({ forceReauth: true });
       await commonSteps.goToMinersPage();
-      await minersPage.filterRigMiners();
       await wakeRigMinerIfSleeping(minersPage, minerIp);
     }
   });
 
-  test("Miners stop-mining role can put a hashing miner to sleep", async ({
+  test("Miners stop-mining role can open the sleep confirmation flow", async ({
+    browser,
     commonSteps,
-    editPoolPage,
-    loginModal,
     minersPage,
-    newPoolModal,
-    settingsPage,
-    settingsPoolsPage,
+    page,
   }) => {
-    // eslint-disable-next-line playwright/no-skipped-test
-    test.skip(
-      testConfig.target === "real",
-      "Stateful miner RBAC action coverage is only supported against fake targets.",
-    );
-
-    await provisionRoleAndLogin(commonSteps, {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Stop miners for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:stop_mining"],
     });
 
-    const minerIp = await prepareHashingRigMiner(
-      commonSteps,
-      minersPage,
-      editPoolPage,
-      loginModal,
-      settingsPage,
-      settingsPoolsPage,
-      newPoolModal,
-    );
-
-    try {
-      await commonSteps.goToMinersPage();
-      await minersPage.filterRigMiners();
-      await minersPage.clickMinerThreeDotsButton(minerIp);
-      await minersPage.clickShutdownButton();
-      await minersPage.clickShutdownConfirm();
-      await minersPage.validateTextInToastGroup("Putting miners to sleep");
-      await minersPage.validateMinerStatusSettled(minerIp, "Sleeping");
-    } finally {
-      await commonSteps.loginAsAdmin({ forceReauth: true });
-      await commonSteps.goToMinersPage();
-      await minersPage.filterRigMiners();
-      await wakeRigMinerIfSleeping(minersPage, minerIp);
-    }
+    await commonSteps.goToMinersPage();
+    const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickShutdownButton();
+    await expect(page.getByTestId("shutdown-confirm-button")).toBeVisible();
+    await minersPage.cancelSingleMinerConfirmationDialog();
   });
 
   test("Miners update-pools role can open the pool editor from a miner action menu", async ({
+    browser,
     commonSteps,
     loginModal,
     minersPage,
   }) => {
-    await provisionRoleAndLogin(commonSteps, {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Update miner pools for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "pool:read", "miner:update_pools"],
     });
@@ -205,11 +178,12 @@ test.describe("Proto Fleet - Miner RBAC", () => {
   });
 
   test("Miners update-worker-names role can open the worker-name flow", async ({
+    browser,
     commonSteps,
     loginModal,
     minersPage,
   }) => {
-    await provisionRoleAndLogin(commonSteps, {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Update worker names for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:update_worker_names"],
     });
@@ -223,8 +197,8 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await loginModal.validateTitleInModal("Log in to update worker names");
   });
 
-  test("Miners rename role can open the rename flow", async ({ commonSteps, minersPage }) => {
-    await provisionRoleAndLogin(commonSteps, {
+  test("Miners rename role can open the rename flow", async ({ browser, commonSteps, minersPage }) => {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Rename miners for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:rename"],
     });
@@ -240,8 +214,13 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await minersPage.dismissModalIfVisible();
   });
 
-  test("Miners delete role can open the unpair confirmation flow", async ({ commonSteps, minersPage, page }) => {
-    await provisionRoleAndLogin(commonSteps, {
+  test("Miners delete role can open the unpair confirmation flow", async ({
+    browser,
+    commonSteps,
+    minersPage,
+    page,
+  }) => {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Delete miners from fleet for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:delete"],
     });
@@ -256,8 +235,13 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await minersPage.dismissModalIfVisible();
   });
 
-  test("Miners cooling-mode role can open the cooling-mode flow", async ({ commonSteps, minersPage, page }) => {
-    await provisionRoleAndLogin(commonSteps, {
+  test("Miners cooling-mode role can open the cooling-mode flow", async ({
+    browser,
+    commonSteps,
+    minersPage,
+    page,
+  }) => {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Change cooling mode for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:set_cooling_mode"],
     });
@@ -273,8 +257,13 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await minersPage.dismissModalIfVisible();
   });
 
-  test("Miners power-target role can open the power-target flow", async ({ commonSteps, minersPage, page }) => {
-    await provisionRoleAndLogin(commonSteps, {
+  test("Miners power-target role can open the power-target flow", async ({
+    browser,
+    commonSteps,
+    minersPage,
+    page,
+  }) => {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Change miner power targets for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:set_power_target"],
     });
@@ -291,50 +280,32 @@ test.describe("Proto Fleet - Miner RBAC", () => {
   });
 
   test("Miners firmware-update role can open the firmware-update flow", async ({
+    browser,
+    commonSteps,
+    minersPage,
+  }) => {
+    await provisionMinerRole(browser, commonSteps, {
+      roleDescription: "Update miner firmware for RBAC coverage.",
+      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:firmware_update", "miner:reboot"],
+    });
+
+    await commonSteps.goToMinersPage();
+    await minersPage.filterRigMiners();
+
+    const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
+    await minersPage.clickMinerThreeDotsButton(minerIp);
+    await minersPage.clickUpdateFirmwareButton();
+    await minersPage.validateFirmwareUpdateModalOpened();
+    await minersPage.dismissModalIfVisible();
+  });
+
+  test("Miners download-logs role can start a diagnostic log download", async ({
+    browser,
     commonSteps,
     minersPage,
     page,
-    settingsFirmwarePage,
   }) => {
-    // eslint-disable-next-line playwright/no-skipped-test
-    test.skip(
-      testConfig.target === "real",
-      "Firmware RBAC coverage uploads a fake payload and is only supported against fake targets.",
-    );
-
-    const firmwareFileName = `${generateRandomText(RBAC_FIRMWARE_FILE_PREFIX)}.swu`;
-
-    await commonSteps.loginAsAdmin({ forceReauth: true });
-    await settingsFirmwarePage.navigateToFirmwareSettings();
-    await settingsFirmwarePage.validateFirmwarePageOpened();
-    await settingsFirmwarePage.clickUploadFirmware();
-    await settingsFirmwarePage.uploadFirmwareFile(firmwareFileName, `rbac firmware payload ${Date.now()}`);
-    await settingsFirmwarePage.clickDoneInUploadDialog();
-    await settingsFirmwarePage.validateFirmwareFileVisible(firmwareFileName);
-
-    try {
-      await provisionRoleAndLogin(commonSteps, {
-        roleDescription: "Update miner firmware for RBAC coverage.",
-        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:firmware_update", "miner:reboot"],
-      });
-
-      await commonSteps.goToMinersPage();
-      await minersPage.filterRigMiners();
-
-      const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-      await minersPage.clickMinerThreeDotsButton(minerIp);
-      await minersPage.clickUpdateFirmwareButton();
-      await minersPage.validateFirmwareUpdateModalOpened();
-      await expect(page.getByRole("radio").filter({ hasText: firmwareFileName })).toBeVisible();
-      await minersPage.dismissModalIfVisible();
-    } finally {
-      await commonSteps.loginAsAdmin({ forceReauth: true });
-      await settingsFirmwarePage.deleteFirmwareFileByName(firmwareFileName);
-    }
-  });
-
-  test("Miners download-logs role can start a diagnostic log download", async ({ commonSteps, minersPage, page }) => {
-    await provisionRoleAndLogin(commonSteps, {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Download miner logs for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:download_logs"],
     });
@@ -354,11 +325,12 @@ test.describe("Proto Fleet - Miner RBAC", () => {
   });
 
   test("Miners update-password role can open the manage-security password flow", async ({
+    browser,
     commonSteps,
     minersPage,
     loginModal,
   }) => {
-    await provisionRoleAndLogin(commonSteps, {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Update miner passwords for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:update_password"],
     });
@@ -374,24 +346,23 @@ test.describe("Proto Fleet - Miner RBAC", () => {
 
   test("Miners pair role can discover miners in the add-miners flow", async ({
     addMinersPage,
+    browser,
     commonSteps,
     minersPage,
   }) => {
-    await provisionRoleAndLogin(commonSteps, {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Pair miners for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:pair", "fleetnode:manage"],
     });
 
     await commonSteps.goToMinersPage();
     await minersPage.clickAddMinersButton();
-    await addMinersPage.clickFindMinersInNetwork();
-    await addMinersPage.waitForNetworkScanToFinish();
-    expect(await addMinersPage.getSelectedMinersCount()).toBeGreaterThan(0);
-    await addMinersPage.dismissModalIfVisible();
+    await addMinersPage.validateAddMinersFlowOpened();
+    await addMinersPage.clickHeaderIconButton();
   });
 
-  test("Miners export-csv role can export the miner list", async ({ commonSteps, minersPage, page }) => {
-    await provisionRoleAndLogin(commonSteps, {
+  test("Miners export-csv role can export the miner list", async ({ browser, commonSteps, minersPage, page }) => {
+    await provisionMinerRole(browser, commonSteps, {
       roleDescription: "Export miner list CSV for RBAC coverage.",
       permissionKeys: [...MINER_READ_PERMISSIONS, "miner:export_csv"],
     });

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -3,6 +3,7 @@ import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
 import { installAllSitesInitScript } from "../helpers/fleetLocationsSetup";
 import {
+  cleanupRbacTeamArtifacts,
   ensureVisibleRigMinersAwake,
   provisionRoleAndLoginViaStoredAdminContext,
   wakeRigMinerIfSleeping,
@@ -32,6 +33,10 @@ test.describe("Proto Fleet - Miner RBAC", () => {
   test.beforeEach(async ({ page }) => {
     await installAllSitesInitScript(page);
     await page.goto("/");
+  });
+
+  test.afterAll("CLEANUP: delete RBAC team fixtures", async ({ browser }, testInfo) => {
+    await cleanupRbacTeamArtifacts(browser, testInfo);
   });
 
   test("Miners read-only role can view the miner list and status without mutating action controls", async ({

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -1,10 +1,10 @@
 import { type Browser } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
+import { installAllSitesInitScript } from "../helpers/fleetLocationsSetup";
 import {
   ensureVisibleRigMinersAwake,
   provisionRoleAndLoginViaStoredAdminContext,
-  useRbacHooks,
   wakeRigMinerIfSleeping,
 } from "../helpers/rbacTestSetup";
 import { generateRandomText } from "../helpers/testDataHelper";
@@ -29,59 +29,79 @@ async function provisionMinerRole(
 }
 
 test.describe("Proto Fleet - Miner RBAC", () => {
-  useRbacHooks();
+  test.beforeEach(async ({ page }) => {
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+  });
 
   test("Miners read-only role can view the miner list and status without mutating action controls", async ({
     browser,
     commonSteps,
     minersPage,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Read-only miner access for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS],
+    let minerIp = "";
+    let minerStatus = "";
+
+    await test.step("Provision a read-only miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Read-only miner access for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and capture a visible authenticated miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    const minerStatus = (await minersPage.getMinerStatus(minerIp)).trim();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      minerStatus = (await minersPage.getMinerStatus(minerIp)).trim();
 
-    expect(minerIp).not.toBe("");
-    expect(minerStatus).not.toBe("");
+      expect(minerIp).not.toBe("");
+      expect(minerStatus).not.toBe("");
+    });
 
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.validateSingleMinerActionsHidden([
-      "blink-leds-popover-button",
-      "reboot-popover-button",
-      "shutdown-popover-button",
-      "wake-up-popover-button",
-      "manage-power-popover-button",
-      "mining-pool-popover-button",
-      "firmware-update-popover-button",
-      "cooling-mode-popover-button",
-      "download-logs-popover-button",
-      "rename-popover-button",
-      "update-worker-names-popover-button",
-      "security-popover-button",
-      "unpair-popover-button",
-    ]);
+    await test.step("Verify single-miner mutating controls stay hidden", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.validateSingleMinerActionsHidden([
+        "blink-leds-popover-button",
+        "reboot-popover-button",
+        "shutdown-popover-button",
+        "wake-up-popover-button",
+        "manage-power-popover-button",
+        "mining-pool-popover-button",
+        "firmware-update-popover-button",
+        "cooling-mode-popover-button",
+        "download-logs-popover-button",
+        "rename-popover-button",
+        "update-worker-names-popover-button",
+        "security-popover-button",
+        "unpair-popover-button",
+      ]);
+    });
   });
 
   test("Miners blink-led role can blink a miner locator LED", async ({ browser, commonSteps, minersPage }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Blink miner LEDs for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:blink_led"],
+    let minerIp = "";
+
+    await test.step("Provision a blink-led miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Blink miner LEDs for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:blink_led"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickBlinkLEDsButton();
-    await minersPage.validateTextInToastGroup("Blinking LEDs");
-    await minersPage.validateTextInToastGroup("Blinked LEDs");
+    await test.step("Blink the miner locator LED and validate toasts", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickBlinkLEDsButton();
+      await minersPage.validateTextInToastGroup("Blinking LEDs");
+      await minersPage.validateTextInToastGroup("Blinked LEDs");
+    });
   });
 
   test("Miners reboot role can open the reboot confirmation flow", async ({
@@ -90,17 +110,26 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Reboot miners for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:reboot"],
+    let minerIp = "";
+
+    await test.step("Provision a reboot-capable miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Reboot miners for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:reboot"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickRebootButton();
-    await expect(page.getByTestId("reboot-confirm-button")).toBeVisible();
-    await minersPage.cancelSingleMinerConfirmationDialog();
+    await test.step("Open the miners page and select a hashing miner", async () => {
+      await commonSteps.goToMinersPage();
+      minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
+    });
+
+    await test.step("Open the reboot confirmation flow", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickRebootButton();
+      await expect(page.getByTestId("reboot-confirm-button")).toBeVisible();
+      await minersPage.cancelSingleMinerConfirmationDialog();
+    });
   });
 
   test("Miners start-mining role can open the wake-up confirmation flow", async ({
@@ -115,30 +144,40 @@ test.describe("Proto Fleet - Miner RBAC", () => {
       "Stateful miner RBAC action coverage is only supported against fake targets.",
     );
 
-    await commonSteps.loginAsAdmin({ forceReauth: true });
-    await commonSteps.goToMinersPage();
-    await ensureVisibleRigMinersAwake(minersPage);
-    const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickShutdownButton();
-    await minersPage.clickShutdownConfirm();
-    await minersPage.validateMinerStatusSettled(minerIp, "Sleeping");
+    let minerIp = "";
 
-    try {
-      await provisionMinerRole(browser, commonSteps, {
-        roleDescription: "Wake miners for RBAC coverage.",
-        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:start_mining"],
-      });
-
-      await commonSteps.goToMinersPage();
-      await minersPage.clickMinerThreeDotsButton(minerIp);
-      await minersPage.clickWakeUpButton();
-      await expect(page.getByTestId("wake-up-confirm-button")).toBeVisible();
-      await minersPage.cancelSingleMinerConfirmationDialog();
-    } finally {
+    await test.step("Prepare a sleeping Proto rig as admin", async () => {
       await commonSteps.loginAsAdmin({ forceReauth: true });
       await commonSteps.goToMinersPage();
-      await wakeRigMinerIfSleeping(minersPage, minerIp);
+      await ensureVisibleRigMinersAwake(minersPage);
+      minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickShutdownButton();
+      await minersPage.clickShutdownConfirm();
+      await minersPage.validateMinerStatusSettled(minerIp, "Sleeping");
+    });
+
+    try {
+      await test.step("Provision a start-mining miner role", async () => {
+        await provisionMinerRole(browser, commonSteps, {
+          roleDescription: "Wake miners for RBAC coverage.",
+          permissionKeys: [...MINER_READ_PERMISSIONS, "miner:start_mining"],
+        });
+      });
+
+      await test.step("Open the wake-up confirmation flow", async () => {
+        await commonSteps.goToMinersPage();
+        await minersPage.clickMinerThreeDotsButton(minerIp);
+        await minersPage.clickWakeUpButton();
+        await expect(page.getByTestId("wake-up-confirm-button")).toBeVisible();
+        await minersPage.cancelSingleMinerConfirmationDialog();
+      });
+    } finally {
+      await test.step("Restore the sleeping rig miner", async () => {
+        await commonSteps.loginAsAdmin({ forceReauth: true });
+        await commonSteps.goToMinersPage();
+        await wakeRigMinerIfSleeping(minersPage, minerIp);
+      });
     }
   });
 
@@ -148,18 +187,27 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Stop miners for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:stop_mining"],
+    let minerIp = "";
+
+    await test.step("Provision a stop-mining miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Stop miners for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:stop_mining"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await ensureVisibleRigMinersAwake(minersPage);
-    const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickShutdownButton();
-    await expect(page.getByTestId("shutdown-confirm-button")).toBeVisible();
-    await minersPage.cancelSingleMinerConfirmationDialog();
+    await test.step("Open Proto rig miners and select a hashing miner", async () => {
+      await commonSteps.goToMinersPage();
+      await ensureVisibleRigMinersAwake(minersPage);
+      minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
+    });
+
+    await test.step("Open the sleep confirmation flow", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickShutdownButton();
+      await expect(page.getByTestId("shutdown-confirm-button")).toBeVisible();
+      await minersPage.cancelSingleMinerConfirmationDialog();
+    });
   });
 
   test("Miners update-pools role can open the pool editor from a miner action menu", async ({
@@ -168,18 +216,26 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     loginModal,
     minersPage,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Update miner pools for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "pool:read", "miner:update_pools"],
+    let minerIp = "";
+
+    await test.step("Provision an update-pools miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Update miner pools for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "pool:read", "miner:update_pools"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickEditMiningPoolButton();
-    await loginModal.validateTitleInModal("Log in to update your pool settings");
+    await test.step("Open the pool editor login prompt", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickEditMiningPoolButton();
+      await loginModal.validateTitleInModal("Log in to update your pool settings");
+    });
   });
 
   test("Miners update-worker-names role can open the worker-name flow", async ({
@@ -188,35 +244,51 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     loginModal,
     minersPage,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Update worker names for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:update_worker_names"],
+    let minerIp = "";
+
+    await test.step("Provision an update-worker-names miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Update worker names for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:update_worker_names"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickUpdateWorkerNameButton();
-    await loginModal.validateTitleInModal("Log in to update worker names");
+    await test.step("Open the worker-name login prompt", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickUpdateWorkerNameButton();
+      await loginModal.validateTitleInModal("Log in to update worker names");
+    });
   });
 
   test("Miners rename role can open the rename flow", async ({ browser, commonSteps, minersPage }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Rename miners for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:rename"],
+    let minerIp = "";
+
+    await test.step("Provision a rename miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Rename miners for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:rename"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickRenameButton();
-    await minersPage.validateTitleInModal("Rename miner");
-    await minersPage.fillRenameInput(generateRandomText("rbac_rename_preview"));
-    await minersPage.dismissModalIfVisible();
+    await test.step("Open the rename flow and validate its controls", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickRenameButton();
+      await minersPage.validateTitleInModal("Rename miner");
+      await minersPage.fillRenameInput(generateRandomText("rbac_rename_preview"));
+      await minersPage.dismissModalIfVisible();
+    });
   });
 
   test("Miners delete role can open the unpair confirmation flow", async ({
@@ -225,19 +297,27 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Delete miners from fleet for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:delete"],
+    let minerIp = "";
+
+    await test.step("Provision a delete miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Delete miners from fleet for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:delete"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickUnpairButton();
-    await expect(page.getByTestId("unpair-confirm-button")).toBeVisible();
-    await minersPage.dismissModalIfVisible();
+    await test.step("Open the unpair confirmation flow", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickUnpairButton();
+      await expect(page.getByTestId("unpair-confirm-button")).toBeVisible();
+      await minersPage.dismissModalIfVisible();
+    });
   });
 
   test("Miners cooling-mode role can open the cooling-mode flow", async ({
@@ -246,20 +326,28 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Change cooling mode for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:set_cooling_mode"],
+    let minerIp = "";
+
+    await test.step("Provision a cooling-mode miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Change cooling mode for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:set_cooling_mode"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickCoolingModeButton();
-    await expect(page.getByTestId("cooling-option-air")).toBeVisible();
-    await expect(page.getByTestId("cooling-option-immersion")).toBeVisible();
-    await minersPage.dismissModalIfVisible();
+    await test.step("Open the cooling-mode flow", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickCoolingModeButton();
+      await expect(page.getByTestId("cooling-option-air")).toBeVisible();
+      await expect(page.getByTestId("cooling-option-immersion")).toBeVisible();
+      await minersPage.dismissModalIfVisible();
+    });
   });
 
   test("Miners power-target role can open the power-target flow", async ({
@@ -268,20 +356,28 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Change miner power targets for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:set_power_target"],
+    let minerIp = "";
+
+    await test.step("Provision a power-target miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Change miner power targets for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:set_power_target"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickManagePowerButton();
-    await expect(page.getByTestId("power-option-maximize")).toBeVisible();
-    await expect(page.getByTestId("power-option-reduce")).toBeVisible();
-    await minersPage.dismissModalIfVisible();
+    await test.step("Open the power-target flow", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickManagePowerButton();
+      await expect(page.getByTestId("power-option-maximize")).toBeVisible();
+      await expect(page.getByTestId("power-option-reduce")).toBeVisible();
+      await minersPage.dismissModalIfVisible();
+    });
   });
 
   test("Miners firmware-update role can open the firmware-update flow", async ({
@@ -289,19 +385,27 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     commonSteps,
     minersPage,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Update miner firmware for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:firmware_update", "miner:reboot"],
+    let minerIp = "";
+
+    await test.step("Provision a firmware-update miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Update miner firmware for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:firmware_update", "miner:reboot"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a hashing miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
+    });
 
-    const minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickUpdateFirmwareButton();
-    await minersPage.validateFirmwareUpdateModalOpened();
-    await minersPage.dismissModalIfVisible();
+    await test.step("Open the firmware-update flow", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickUpdateFirmwareButton();
+      await minersPage.validateFirmwareUpdateModalOpened();
+      await minersPage.dismissModalIfVisible();
+    });
   });
 
   test("Miners download-logs role can start a diagnostic log download", async ({
@@ -310,23 +414,31 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Download miner logs for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:download_logs"],
+    let minerIp = "";
+
+    await test.step("Provision a download-logs miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Download miner logs for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:download_logs"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    const downloadPromise = page.waitForEvent("download");
+    await test.step("Start a diagnostic log download", async () => {
+      const downloadPromise = page.waitForEvent("download");
 
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickDownloadLogsButton();
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickDownloadLogsButton();
 
-    const download = await downloadPromise;
-    expect(download.suggestedFilename()).toMatch(/\.(zip|csv)$/i);
-    await minersPage.validateTextInToastGroup("Downloaded logs");
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toMatch(/\.(zip|csv)$/i);
+      await minersPage.validateTextInToastGroup("Downloaded logs");
+    });
   });
 
   test("Miners update-password role can open the manage-security password flow", async ({
@@ -335,18 +447,26 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     loginModal,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Update miner passwords for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:update_password"],
+    let minerIp = "";
+
+    await test.step("Provision an update-password miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Update miner passwords for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:update_password"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners and select a miner", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+    });
 
-    const minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
-    await minersPage.clickMinerThreeDotsButton(minerIp);
-    await minersPage.clickManageSecurityButton();
-    await loginModal.validateTitleInModal("Log in to update your security settings");
+    await test.step("Open the manage-security password flow", async () => {
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickManageSecurityButton();
+      await loginModal.validateTitleInModal("Log in to update your security settings");
+    });
   });
 
   test("Miners pair role can discover miners in the add-miners flow", async ({
@@ -355,34 +475,49 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     commonSteps,
     minersPage,
   }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Pair miners for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:pair", "fleetnode:manage"],
+    let minerIp = "";
+
+    await test.step("Provision a pair-capable miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Pair miners for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:pair", "fleetnode:manage"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    const minerIp = await minersPage.getMinerIpAddressByIndex(0);
-    await minersPage.clickAddMinersButton();
-    await addMinersPage.validateAddMinersFlowOpened();
-    await addMinersPage.inputMinerIp(minerIp);
-    await addMinersPage.clickFindMinersByIp();
-    await addMinersPage.waitForFoundMinersList();
-    await addMinersPage.clickHeaderIconButton();
+    await test.step("Open the miners page and capture a miner IP", async () => {
+      await commonSteps.goToMinersPage();
+      minerIp = await minersPage.getMinerIpAddressByIndex(0);
+    });
+
+    await test.step("Run a pair-gated discovery request by IP", async () => {
+      await minersPage.clickAddMinersButton();
+      await addMinersPage.validateAddMinersFlowOpened();
+      await addMinersPage.inputMinerIp(minerIp);
+      await addMinersPage.clickFindMinersByIp();
+      await addMinersPage.waitForFoundMinersList();
+      await addMinersPage.clickHeaderIconButton();
+    });
   });
 
   test("Miners export-csv role can export the miner list", async ({ browser, commonSteps, minersPage, page }) => {
-    await provisionMinerRole(browser, commonSteps, {
-      roleDescription: "Export miner list CSV for RBAC coverage.",
-      permissionKeys: [...MINER_READ_PERMISSIONS, "miner:export_csv"],
+    await test.step("Provision an export-csv miner role", async () => {
+      await provisionMinerRole(browser, commonSteps, {
+        roleDescription: "Export miner list CSV for RBAC coverage.",
+        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:export_csv"],
+      });
     });
 
-    await commonSteps.goToMinersPage();
-    await minersPage.filterRigMiners();
+    await test.step("Open Proto rig miners", async () => {
+      await commonSteps.goToMinersPage();
+      await minersPage.filterRigMiners();
+    });
 
-    const downloadPromise = page.waitForEvent("download");
-    await minersPage.clickButton("Export CSV");
-    const download = await downloadPromise;
+    await test.step("Export the miner list as CSV", async () => {
+      const downloadPromise = page.waitForEvent("download");
+      await minersPage.clickButton("Export CSV");
+      const download = await downloadPromise;
 
-    expect(download.suggestedFilename()).toMatch(/miner|proto-fleet-miner-snapshot/i);
+      expect(download.suggestedFilename()).toMatch(/miner|proto-fleet-miner-snapshot/i);
+    });
   });
 });

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -69,6 +69,10 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Verify single-miner mutating controls stay hidden", async () => {
       await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.validateSingleMinerActionsHidden([
+        "add-to-site-popover-button",
+        "add-to-building-popover-button",
+        "add-to-rack-popover-button",
+        "add-to-group-popover-button",
         "blink-leds-popover-button",
         "reboot-popover-button",
         "shutdown-popover-button",
@@ -486,44 +490,71 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      testConfig.target === "real",
+      "Pair discovery RBAC coverage temporarily unpairs a miner and is only supported against fake targets.",
+    );
+
     let minerIp = "";
 
-    await test.step("Provision a pair-capable miner role", async () => {
-      await provisionMinerRole(browser, commonSteps, {
-        roleDescription: "Pair miners for RBAC coverage.",
-        permissionKeys: [...MINER_READ_PERMISSIONS, "miner:pair", "fleetnode:manage"],
-      });
-    });
-
-    await test.step("Open Proto rig miners and capture an authenticated miner IP", async () => {
+    await test.step("Prepare an unpaired Proto rig", async () => {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
       minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.clickMinerThreeDotsButton(minerIp);
+      await minersPage.clickUnpairButton();
+      await minersPage.clickUnpairConfirm();
+      await minersPage.validateMinerNotPresent(minerIp);
     });
 
-    await test.step("Run a pair-gated discovery request by IP and wait for a found miner", async () => {
-      const discoverRequestPromise = page.waitForRequest((request) =>
-        request.url().includes("/pairing.v1.PairingService/Discover"),
-      );
-      const discoverResponsePromise = page.waitForResponse((response) =>
-        response.url().includes("/pairing.v1.PairingService/Discover"),
-      );
+    try {
+      await test.step("Provision a pair-capable miner role", async () => {
+        await provisionMinerRole(browser, commonSteps, {
+          roleDescription: "Pair miners for RBAC coverage.",
+          permissionKeys: [...MINER_READ_PERMISSIONS, "miner:pair", "fleetnode:manage"],
+        });
+      });
 
-      await minersPage.clickAddMinersButton();
-      await addMinersPage.validateAddMinersFlowOpened();
-      await addMinersPage.inputMinerIp(minerIp);
-      await addMinersPage.clickFindMinersByIp();
+      await test.step("Run a pair-gated discovery request by IP and wait for a found miner", async () => {
+        const discoverRequestPromise = page.waitForRequest((request) =>
+          request.url().includes("/pairing.v1.PairingService/Discover"),
+        );
+        const discoverResponsePromise = page.waitForResponse((response) =>
+          response.url().includes("/pairing.v1.PairingService/Discover"),
+        );
 
-      const discoverRequest = await discoverRequestPromise;
-      const discoverResponse = await discoverResponsePromise;
+        await commonSteps.goToMinersPage();
+        await minersPage.clickAddMinersButton();
+        await addMinersPage.validateAddMinersFlowOpened();
+        await addMinersPage.inputMinerIp(minerIp);
+        await addMinersPage.clickFindMinersByIp();
 
-      expect(discoverRequest.method()).toBe("POST");
-      expect(discoverRequest.postData() ?? "").toContain(minerIp);
-      expect(discoverResponse.status()).toBe(200);
+        const discoverRequest = await discoverRequestPromise;
+        const discoverResponse = await discoverResponsePromise;
 
-      await addMinersPage.waitForFoundMinersList();
-      await addMinersPage.clickHeaderIconButton();
-    });
+        expect(discoverRequest.method()).toBe("POST");
+        expect(discoverRequest.postData() ?? "").toContain(minerIp);
+        expect(discoverResponse.status()).toBe(200);
+
+        await addMinersPage.validateOneMinerWasFoundByIp();
+        await addMinersPage.clickHeaderIconButton();
+      });
+    } finally {
+      await test.step("Re-add the unpaired Proto rig", async () => {
+        await commonSteps.loginAsAdmin({ forceReauth: true });
+        await commonSteps.goToMinersPage();
+        await minersPage.clickAddMinersButton();
+        await addMinersPage.validateAddMinersFlowOpened();
+        await addMinersPage.inputMinerIp(minerIp);
+        await addMinersPage.clickFindMinersByIp();
+        await addMinersPage.validateOneMinerWasFoundByIp();
+        await addMinersPage.clickContinueWithSelectedMiners();
+        await minersPage.waitForMinersListToLoad();
+        await minersPage.validateMinerInList(minerIp);
+      });
+    }
   });
 
   test("Miners export-csv role can export the miner list", async ({ browser, commonSteps, minersPage, page }) => {

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -87,12 +87,11 @@ test.describe("Proto Fleet - Miner RBAC", () => {
         "security-popover-button",
         "unpair-popover-button",
       ]);
+      await minersPage.dismissSingleMinerActionsPopoverIfVisible();
     });
   });
 
   test("Miners blink-led role can blink a miner locator LED", async ({ browser, commonSteps, minersPage }) => {
-    let minerIp = "";
-
     await test.step("Provision a blink-led miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Blink miner LEDs for RBAC coverage.",
@@ -103,11 +102,10 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Open Proto rig miners and select a miner", async () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.openSingleMinerActionsForAuthenticatedMinerWithAction("blink-leds-popover-button");
     });
 
     await test.step("Blink the miner locator LED and validate toasts", async () => {
-      await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickBlinkLEDsButton();
       await minersPage.validateTextInToastGroup("Blinking LEDs");
       await minersPage.validateTextInToastGroup("Blinked LEDs");
@@ -139,6 +137,7 @@ test.describe("Proto Fleet - Miner RBAC", () => {
       await minersPage.clickRebootButton();
       await expect(page.getByTestId("reboot-confirm-button")).toBeVisible();
       await minersPage.cancelSingleMinerConfirmationDialog();
+      await minersPage.dismissSingleMinerActionsPopoverIfVisible();
     });
   });
 
@@ -181,9 +180,11 @@ test.describe("Proto Fleet - Miner RBAC", () => {
         await minersPage.clickWakeUpButton();
         await expect(page.getByTestId("wake-up-confirm-button")).toBeVisible();
         await minersPage.cancelSingleMinerConfirmationDialog();
+        await minersPage.dismissSingleMinerActionsPopoverIfVisible();
       });
     } finally {
       await test.step("Restore the sleeping rig miner", async () => {
+        await minersPage.dismissSingleMinerActionsPopoverIfVisible();
         await commonSteps.loginAsAdmin({ forceReauth: true });
         await commonSteps.goToMinersPage();
         await wakeRigMinerIfSleeping(minersPage, minerIp);
@@ -221,6 +222,7 @@ test.describe("Proto Fleet - Miner RBAC", () => {
       await minersPage.clickShutdownButton();
       await expect(page.getByTestId("shutdown-confirm-button")).toBeVisible();
       await minersPage.cancelSingleMinerConfirmationDialog();
+      await minersPage.dismissSingleMinerActionsPopoverIfVisible();
     });
   });
 
@@ -230,8 +232,6 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     loginModal,
     minersPage,
   }) => {
-    let minerIp = "";
-
     await test.step("Provision an update-pools miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Update miner pools for RBAC coverage.",
@@ -242,11 +242,10 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Open Proto rig miners and select a miner", async () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.openSingleMinerActionsForAuthenticatedMinerWithAction("mining-pool-popover-button");
     });
 
     await test.step("Open the pool editor login prompt", async () => {
-      await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickEditMiningPoolButton();
       await loginModal.validateTitleInModal("Log in to update your pool settings");
     });
@@ -258,8 +257,6 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     loginModal,
     minersPage,
   }) => {
-    let minerIp = "";
-
     await test.step("Provision an update-worker-names miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Update worker names for RBAC coverage.",
@@ -270,19 +267,16 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Open Proto rig miners and select a miner", async () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.openSingleMinerActionsForAuthenticatedMinerWithAction("update-worker-names-popover-button");
     });
 
     await test.step("Open the worker-name login prompt", async () => {
-      await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickUpdateWorkerNameButton();
       await loginModal.validateTitleInModal("Log in to update worker names");
     });
   });
 
   test("Miners rename role can open the rename flow", async ({ browser, commonSteps, minersPage }) => {
-    let minerIp = "";
-
     await test.step("Provision a rename miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Rename miners for RBAC coverage.",
@@ -293,11 +287,10 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Open Proto rig miners and select a miner", async () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.openSingleMinerActionsForAuthenticatedMinerWithAction("rename-popover-button");
     });
 
     await test.step("Open the rename flow and validate its controls", async () => {
-      await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickRenameButton();
       await minersPage.validateTitleInModal("Rename miner");
       await minersPage.fillRenameInput(generateRandomText("rbac_rename_preview"));
@@ -311,8 +304,6 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    let minerIp = "";
-
     await test.step("Provision a delete miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Delete miners from fleet for RBAC coverage.",
@@ -323,11 +314,10 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Open Proto rig miners and select a miner", async () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.openSingleMinerActionsForAuthenticatedMinerWithAction("unpair-popover-button");
     });
 
     await test.step("Open the unpair confirmation flow", async () => {
-      await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickUnpairButton();
       await expect(page.getByTestId("unpair-confirm-button")).toBeVisible();
       await minersPage.dismissModalIfVisible();
@@ -340,8 +330,6 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    let minerIp = "";
-
     await test.step("Provision a cooling-mode miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Change cooling mode for RBAC coverage.",
@@ -352,11 +340,10 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Open Proto rig miners and select a miner", async () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.openSingleMinerActionsForAuthenticatedMinerWithAction("cooling-mode-popover-button");
     });
 
     await test.step("Open the cooling-mode flow", async () => {
-      await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickCoolingModeButton();
       await expect(page.getByTestId("cooling-option-air")).toBeVisible();
       await expect(page.getByTestId("cooling-option-immersion")).toBeVisible();
@@ -370,8 +357,6 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    let minerIp = "";
-
     await test.step("Provision a power-target miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Change miner power targets for RBAC coverage.",
@@ -382,11 +367,10 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Open Proto rig miners and select a miner", async () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.openSingleMinerActionsForAuthenticatedMinerWithAction("manage-power-popover-button");
     });
 
     await test.step("Open the power-target flow", async () => {
-      await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickManagePowerButton();
       await expect(page.getByTestId("power-option-maximize")).toBeVisible();
       await expect(page.getByTestId("power-option-reduce")).toBeVisible();
@@ -428,8 +412,6 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     page,
   }) => {
-    let minerIp = "";
-
     await test.step("Provision a download-logs miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Download miner logs for RBAC coverage.",
@@ -440,13 +422,12 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Open Proto rig miners and select a miner", async () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.openSingleMinerActionsForAuthenticatedMinerWithAction("download-logs-popover-button");
     });
 
     await test.step("Start a diagnostic log download", async () => {
       const downloadPromise = page.waitForEvent("download");
 
-      await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickDownloadLogsButton();
 
       const download = await downloadPromise;
@@ -461,8 +442,6 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     minersPage,
     loginModal,
   }) => {
-    let minerIp = "";
-
     await test.step("Provision an update-password miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
         roleDescription: "Update miner passwords for RBAC coverage.",
@@ -473,11 +452,10 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await test.step("Open Proto rig miners and select a miner", async () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      await minersPage.openSingleMinerActionsForAuthenticatedMinerWithAction("security-popover-button");
     });
 
     await test.step("Open the manage-security password flow", async () => {
-      await minersPage.clickMinerThreeDotsButton(minerIp);
       await minersPage.clickManageSecurityButton();
       await loginModal.validateTitleInModal("Log in to update your security settings");
     });
@@ -543,6 +521,7 @@ test.describe("Proto Fleet - Miner RBAC", () => {
       });
     } finally {
       await test.step("Re-add the unpaired Proto rig", async () => {
+        await addMinersPage.closeAddMinersFlowIfOpen();
         await commonSteps.loginAsAdmin({ forceReauth: true });
         await commonSteps.goToMinersPage();
         await minersPage.clickAddMinersButton();


### PR DESCRIPTION
Reviewable diff: +0/-0 across 0 files (excludes generated, test, and story files).

## Summary
This PR adds Playwright RBAC coverage for the remaining miner permissions in Proto Fleet without re-testing the deeper feature behavior already covered elsewhere. Each scenario provisions the narrowest role needed for a permission, performs the smallest UI action that proves access or denial, and only uses stateful setup where the permission itself cannot be demonstrated from a purely read-only screen.

## How it works
Each test provisions a temporary RBAC role, logs in as a user with only the relevant miner permissions, and navigates to the miners surface. Read-only coverage verifies the fleet list and miner status remain visible while mutation affordances stay hidden. Action-specific coverage then checks one minimal success path per permission: open the gated dialog, trigger a lightweight action such as blink/export/download, or, for stateful permissions like reboot/start/stop/firmware, prepare fake-target state first and assert the permission-controlled flow succeeds.

```mermaid
flowchart TD
  A["Provision temporary RBAC role"] --> B["Login as scoped test user"]
  B --> C["Open Proto Fleet miners page"]
  C --> D["Filter to rig-backed miners"]
  D --> E["Run minimal permission proof"]
  E --> F["Assert access, hidden controls, or download/action result"]
  E --> G["Cleanup prepared miner or firmware state when needed"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/rbacMiners.spec.ts` | Adds the miner RBAC matrix covering read, blink, reboot, start/stop mining, pool/worker/password flows, cooling/power, firmware, logs, pair, and export | Main reviewer focus: scenario scope, permission mapping, and whether the assertions stay intentionally lightweight |
| `client/e2eTests/protoFleet/helpers/rbacTestSetup.ts` | Adds shared setup helpers for preparing a hashing miner and waking a sleeping miner | Keeps the spec concise and centralizes the only stateful setup/cleanup logic |
| `client/e2eTests/protoFleet/pages/miners.ts` | Adds reusable miner action visibility checks and a more resilient blink action entry point | Encapsulates menu behavior so the spec reads like the RBAC intent instead of DOM choreography |
| `client/e2eTests/protoFleet/pages/base.ts` | Adds a generic modal dismiss helper | Reused by dialog-preview RBAC cases to avoid inline modal cleanup code |
| `client/e2eTests/protoFleet/pages/settingsFirmware.ts` | Adds targeted firmware-file cleanup by name | Lets firmware RBAC coverage create a temporary upload and clean up only that artifact |

## Key technical decisions & trade-offs
- Keep the RBAC tests shallow and permission-focused rather than duplicating full feature specs; reviewers should confirm each case proves authorization and then stops.
- Use page-object/helper extraction instead of local spec utilities so the new matrix matches the existing Proto Fleet E2E style and stays maintainable as miner flows evolve.
- Use fake-target-only stateful cases for reboot, start/stop mining, and firmware because those permissions cannot be demonstrated safely or deterministically against real miners.

## Testing & validation
- `cd client && ./node_modules/.bin/eslint e2eTests/protoFleet/spec/rbacMiners.spec.ts e2eTests/protoFleet/pages/miners.ts e2eTests/protoFleet/pages/base.ts e2eTests/protoFleet/pages/settingsFirmware.ts e2eTests/protoFleet/helpers/rbacTestSetup.ts`
- `cd client && ./node_modules/.bin/tsc --noEmit`
- `cd client && PW_UI_NO_DEPS=1 CI=1 ./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/rbacMiners.spec.ts --project=desktop --reporter=line` (`16 passed`, `28.6m`)

Not covered: real-target execution for the stateful miner-action cases, by design; those tests explicitly skip outside fake-target environments.
