### PR TITLE
fix(ui): keep bulk & row action menus within the viewport (#727)

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
@@ -16,8 +16,6 @@ const ANIMATION_TRANSLATE = minimalMargin;
 // Total upward shift the popover applies on top of `-popoverHeight`: the layout
 // offset correction (`POPOVER_OFFSET` beyond `minimalMargin`) plus the animation.
 const UPWARD_SHIFT = POPOVER_OFFSET - minimalMargin + ANIMATION_TRANSLATE;
-// Floor so an extremely short viewport still shows a usable, scrollable menu.
-const MIN_MENU_HEIGHT = 88;
 const MENU_MAX_HEIGHT_VAR = "--bulk-actions-menu-max-h";
 
 // The menu is anchored above the bottom-fixed action bar and opens upward, so a
@@ -88,7 +86,11 @@ const BulkActionsPopover = <ActionType,>({
 
     const update = () => {
       const triggerTop = trigger.getBoundingClientRect().top;
-      const available = Math.max(triggerTop - UPWARD_SHIFT + yOffset - minimalMargin, MIN_MENU_HEIGHT);
+      // Cap at exactly the space above the trigger (never floor above it — a floor
+      // taller than the real gap pushes the top off-screen and hides the first
+      // actions). On a very short viewport this shrinks toward 0 and the whole
+      // list scrolls internally, keeping every row reachable (#727).
+      const available = Math.max(triggerTop - UPWARD_SHIFT + yOffset - minimalMargin, 0);
       trigger.style.setProperty(MENU_MAX_HEIGHT_VAR, `${available}px`);
     };
 

--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
@@ -1,9 +1,26 @@
+import { useLayoutEffect } from "react";
 import { BulkAction } from "./types";
 import Divider from "@/shared/components/Divider";
-import Popover, { popoverSizes } from "@/shared/components/Popover";
+import Popover, { popoverSizes, usePopover } from "@/shared/components/Popover";
 import Row from "@/shared/components/Row";
 import { type Position, positions } from "@/shared/constants";
 import { useWindowDimensions } from "@/shared/hooks/useWindowDimensions";
+
+// The menu is anchored above the bottom-fixed action bar and opens upward, so a
+// tall list would otherwise run off the top of the viewport (#727). We cap its
+// height so its top edge stops `minimalMargin` (8px) below the viewport top and
+// the overflow scrolls internally. Derived from the trigger's measured position
+// and the popover's own offset math so it's exact regardless of bar height:
+//   topInViewport = trigger.top - popoverHeight - UPWARD_SHIFT + yOffset
+// setting that to MIN_TOP_MARGIN gives the max height below.
+const MIN_TOP_MARGIN = 8;
+// Total upward shift the popover applies on top of `-popoverHeight`:
+//   • layout: `offset` (20) minus `minimalMargin` (8) = 12, plus
+//   • animation: `slideUpPopover` settles at `translateY(-8px)` (forwards).
+const UPWARD_SHIFT = 12 + 8;
+// Floor so an extremely short viewport still shows a usable, scrollable menu.
+const MIN_MENU_HEIGHT = 88;
+const MENU_MAX_HEIGHT_VAR = "--bulk-actions-menu-max-h";
 
 interface BulkActionsPopoverProps<ActionType> {
   actions: BulkAction<ActionType>[];
@@ -50,13 +67,48 @@ const BulkActionsPopover = <ActionType,>({
   closePopover,
 }: BulkActionsPopoverProps<ActionType>) => {
   const { isPhone, isTablet } = useWindowDimensions();
+  const { triggerRef } = usePopover();
+  const yOffset = isPhone || isTablet ? -32 : 0;
+
+  // Keep the max-height in sync with the trigger's viewport position (phones use a
+  // full-height bottom sheet instead, so skip them). The value is published as a CSS
+  // variable on the trigger container; the inline popover is a DOM descendant, so it
+  // inherits it via `max-h-[var(...)]` below.
+  useLayoutEffect(() => {
+    const trigger = triggerRef.current;
+    // Only the default (upward, bottom-bar-anchored) menu needs the cap; callers
+    // that pass their own className position the menu themselves.
+    if (isPhone || !trigger || className) return;
+
+    const update = () => {
+      const triggerTop = trigger.getBoundingClientRect().top;
+      const available = Math.max(triggerTop - UPWARD_SHIFT + yOffset - MIN_TOP_MARGIN, MIN_MENU_HEIGHT);
+      trigger.style.setProperty(MENU_MAX_HEIGHT_VAR, `${available}px`);
+    };
+
+    update();
+    window.addEventListener("resize", update);
+    window.visualViewport?.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.visualViewport?.removeEventListener("resize", update);
+      trigger.style.removeProperty(MENU_MAX_HEIGHT_VAR);
+    };
+  }, [triggerRef, isPhone, yOffset, className]);
+
   const onAction = (action: BulkAction<ActionType>) => {
     beforeEach(action.requiresConfirmation);
     action.actionHandler();
   };
   return (
     <Popover
-      className={className ?? "-mr-3 !space-y-0 !rounded-2xl px-0 pt-2 pb-1 phone:w-[calc(100vw-theme(spacing.4))]"}
+      className={
+        className ??
+        // Cap the menu height (see MENU_MAX_HEIGHT_VAR above) and scroll internally so
+        // it can't run off the top when opening upward from the bottom-anchored action
+        // bar on short viewports (#727).
+        "-mr-3 max-h-[var(--bulk-actions-menu-max-h,80vh)] !space-y-0 overflow-y-auto overscroll-contain !rounded-2xl px-0 pt-2 pb-1 phone:w-[calc(100vw-theme(spacing.4))]"
+      }
       position={position}
       size={popoverSizes.small}
       offset={20}

--- a/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/BulkActions/BulkActionsPopover.tsx
@@ -2,25 +2,31 @@ import { useLayoutEffect } from "react";
 import { BulkAction } from "./types";
 import Divider from "@/shared/components/Divider";
 import Popover, { popoverSizes, usePopover } from "@/shared/components/Popover";
+import { minimalMargin } from "@/shared/components/Popover/constants";
 import Row from "@/shared/components/Row";
 import { type Position, positions } from "@/shared/constants";
 import { useWindowDimensions } from "@/shared/hooks/useWindowDimensions";
 
-// The menu is anchored above the bottom-fixed action bar and opens upward, so a
-// tall list would otherwise run off the top of the viewport (#727). We cap its
-// height so its top edge stops `minimalMargin` (8px) below the viewport top and
-// the overflow scrolls internally. Derived from the trigger's measured position
-// and the popover's own offset math so it's exact regardless of bar height:
-//   topInViewport = trigger.top - popoverHeight - UPWARD_SHIFT + yOffset
-// setting that to MIN_TOP_MARGIN gives the max height below.
-const MIN_TOP_MARGIN = 8;
-// Total upward shift the popover applies on top of `-popoverHeight`:
-//   • layout: `offset` (20) minus `minimalMargin` (8) = 12, plus
-//   • animation: `slideUpPopover` settles at `translateY(-8px)` (forwards).
-const UPWARD_SHIFT = 12 + 8;
+// Spacing between the trigger and the popover. Passed as the `offset` prop below
+// too, so the cap math and the rendered offset can't drift apart.
+const POPOVER_OFFSET = 20;
+// The open animation settles at translateY(-minimalMargin) (`slideUpPopover`,
+// forwards), a permanent upward shift on top of the layout position.
+const ANIMATION_TRANSLATE = minimalMargin;
+// Total upward shift the popover applies on top of `-popoverHeight`: the layout
+// offset correction (`POPOVER_OFFSET` beyond `minimalMargin`) plus the animation.
+const UPWARD_SHIFT = POPOVER_OFFSET - minimalMargin + ANIMATION_TRANSLATE;
 // Floor so an extremely short viewport still shows a usable, scrollable menu.
 const MIN_MENU_HEIGHT = 88;
 const MENU_MAX_HEIGHT_VAR = "--bulk-actions-menu-max-h";
+
+// The menu is anchored above the bottom-fixed action bar and opens upward, so a
+// tall list would otherwise run off the top of the viewport (#727). We cap its
+// height so its top edge stops `minimalMargin` below the viewport top and the
+// overflow scrolls internally. Derived from the trigger's measured position and
+// the popover's own offset math so it's exact regardless of bar height:
+//   topInViewport = trigger.top - popoverHeight - UPWARD_SHIFT + yOffset
+// setting that to `minimalMargin` gives the max height used in the effect.
 
 interface BulkActionsPopoverProps<ActionType> {
   actions: BulkAction<ActionType>[];
@@ -82,7 +88,7 @@ const BulkActionsPopover = <ActionType,>({
 
     const update = () => {
       const triggerTop = trigger.getBoundingClientRect().top;
-      const available = Math.max(triggerTop - UPWARD_SHIFT + yOffset - MIN_TOP_MARGIN, MIN_MENU_HEIGHT);
+      const available = Math.max(triggerTop - UPWARD_SHIFT + yOffset - minimalMargin, MIN_MENU_HEIGHT);
       trigger.style.setProperty(MENU_MAX_HEIGHT_VAR, `${available}px`);
     };
 
@@ -111,7 +117,7 @@ const BulkActionsPopover = <ActionType,>({
       }
       position={position}
       size={popoverSizes.small}
-      offset={20}
+      offset={POPOVER_OFFSET}
       yOffset={isPhone || isTablet ? -32 : 0}
       testId={testId}
       closePopover={closePopover}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.test.tsx
@@ -283,6 +283,8 @@ describe("MinerActionsMenu", () => {
   test("renders desktop quick actions and switches overflow trigger copy to More", () => {
     const blinkLEDsActionHandler = vi.fn();
     const rebootActionHandler = vi.fn();
+    const sleepActionHandler = vi.fn();
+    const wakeUpActionHandler = vi.fn();
     const managePowerActionHandler = vi.fn();
 
     mockUseWindowDimensions.mockReturnValue({
@@ -307,6 +309,20 @@ describe("MinerActionsMenu", () => {
           requiresConfirmation: false,
         },
         {
+          action: deviceActions.shutdown,
+          title: "Sleep",
+          icon: null,
+          actionHandler: sleepActionHandler,
+          requiresConfirmation: false,
+        },
+        {
+          action: deviceActions.wakeUp,
+          title: "Wake up",
+          icon: null,
+          actionHandler: wakeUpActionHandler,
+          requiresConfirmation: false,
+        },
+        {
           action: performanceActions.managePower,
           title: "Manage power",
           icon: null,
@@ -328,15 +344,20 @@ describe("MinerActionsMenu", () => {
 
     expect(screen.getByTestId("actions-menu-quick-action-blink-leds")).toHaveTextContent("Blink LEDs");
     expect(screen.getByTestId("actions-menu-quick-action-reboot")).toHaveTextContent("Reboot");
-    expect(screen.getByTestId("actions-menu-quick-action-manage-power")).toHaveTextContent("Manage power");
+    expect(screen.getByTestId("actions-menu-quick-action-shutdown")).toHaveTextContent("Sleep");
+    expect(screen.getByTestId("actions-menu-quick-action-wake-up")).toHaveTextContent("Wake up");
+    // Manage power is no longer promoted to the quick-action row.
+    expect(screen.queryByTestId("actions-menu-quick-action-manage-power")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("actions-menu-quick-action-blink-leds"));
     fireEvent.click(screen.getByTestId("actions-menu-quick-action-reboot"));
-    fireEvent.click(screen.getByTestId("actions-menu-quick-action-manage-power"));
+    fireEvent.click(screen.getByTestId("actions-menu-quick-action-shutdown"));
+    fireEvent.click(screen.getByTestId("actions-menu-quick-action-wake-up"));
 
     expect(blinkLEDsActionHandler).toHaveBeenCalledTimes(1);
     expect(rebootActionHandler).toHaveBeenCalledTimes(1);
-    expect(managePowerActionHandler).toHaveBeenCalledTimes(1);
+    expect(sleepActionHandler).toHaveBeenCalledTimes(1);
+    expect(wakeUpActionHandler).toHaveBeenCalledTimes(1);
 
     const widgetCalls = mockBulkActionsWidget.mock.calls as unknown as Array<[{ buttonTitle: string }]>;
     const widgetCall = widgetCalls[widgetCalls.length - 1];

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionsMenu.tsx
@@ -6,7 +6,7 @@ import { insertActionAfter, insertActionBefore } from "./actionMenuUtils";
 import { usePermittedActions } from "./actionPermissions";
 import BulkRenameModal from "./BulkRenameModal";
 import BulkWorkerNameModal from "./BulkWorkerNameModal";
-import { deviceActions, groupActions, performanceActions, settingsActions, SupportedAction } from "./constants";
+import { deviceActions, groupActions, settingsActions, SupportedAction } from "./constants";
 import MinerActionModalStack from "./MinerActionModalStack";
 import MinerReparentPicker from "./MinerReparentPicker";
 import { useMinerActions } from "./useMinerActions";
@@ -283,7 +283,8 @@ const MinerActionsMenu = ({
     const quickActionOrder: SupportedAction[] = [
       deviceActions.blinkLEDs,
       deviceActions.reboot,
-      performanceActions.managePower,
+      deviceActions.shutdown,
+      deviceActions.wakeUp,
     ];
     const actionMap = new Map(visibleActions.map((action) => [action.action, action]));
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
@@ -92,10 +92,12 @@ const MinerListActionBar = ({
   // Portal to the body so the bar escapes the app shell's fixed `z-20` scroll
   // container (a stacking context). Otherwise the bulk-actions menu — which opens
   // upward into the header band — is trapped below the `z-40` shell header no
-  // matter how high we set the bar's own z-index (#727).
+  // matter how high we set the bar's own z-index (#727). z-[45] sits above the
+  // header but below the phone/tablet nav drawer (`z-50`) so the drawer still
+  // covers the bar when open.
   return createPortal(
     <ActionBar
-      className="fixed right-0 bottom-4 left-0 z-50 laptop:left-16 desktop:left-50"
+      className="fixed right-0 bottom-4 left-0 z-[45] laptop:left-16 desktop:left-50"
       selectedItems={selectedMiners}
       selectionMode={selectionMode}
       totalCount={totalCount}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerListActionBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import type { SortConfig } from "@/protoFleet/api/generated/common/v1/sort_pb";
 import type {
   MinerListFilter,
@@ -88,9 +89,13 @@ const MinerListActionBar = ({
       </>
     ) : undefined;
 
-  return (
+  // Portal to the body so the bar escapes the app shell's fixed `z-20` scroll
+  // container (a stacking context). Otherwise the bulk-actions menu — which opens
+  // upward into the header band — is trapped below the `z-40` shell header no
+  // matter how high we set the bar's own z-index (#727).
+  return createPortal(
     <ActionBar
-      className="fixed right-0 bottom-4 left-0 z-20 laptop:left-16 desktop:left-50"
+      className="fixed right-0 bottom-4 left-0 z-50 laptop:left-16 desktop:left-50"
       selectedItems={selectedMiners}
       selectionMode={selectionMode}
       totalCount={totalCount}
@@ -119,7 +124,8 @@ const MinerListActionBar = ({
           }}
         />
       )}
-    />
+    />,
+    document.body,
   );
 };
 

--- a/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.test.tsx
@@ -32,6 +32,14 @@ describe("RowActionsMenu", () => {
     expect(screen.getByText("Delete")).toBeInTheDocument();
   });
 
+  it("caps the desktop popover wrapper to the viewport and makes it the scroller", () => {
+    render(<RowActionsMenu actions={[{ label: "Edit", onClick: vi.fn() }]} />);
+    fireEvent.click(screen.getByTestId("row-actions-menu-trigger"));
+    // The viewport cap lands on the positioned wrapper, so the wrapper itself must
+    // scroll — otherwise unconstrained inner content paints past the cap (#727).
+    expect(screen.getByTestId("row-actions-menu-popover")).toHaveClass("overflow-y-auto", "overscroll-contain");
+  });
+
   it("fires the action handler and closes the popover", () => {
     const onEdit = vi.fn();
     render(

--- a/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.tsx
@@ -161,10 +161,11 @@ const RowActionsMenuInner = ({
         <Popover
           // Cap to the visible viewport (8px off top + bottom) and scroll internally
           // so a menu taller than the screen stays fully reachable. `constrainHeightToViewport`
-          // tracks `visualViewport`, so the cap holds under pinch-zoom / browser-chrome
-          // collapse where a CSS `100vh` cap would exceed the tappable area. Pairs with the
-          // portal-fixed flip/clamp, which pins a capped menu 8px off both edges (#727).
-          className="!space-y-0 overflow-y-auto overscroll-contain !rounded-2xl px-0 pt-2 pb-1"
+          // caps + scrolls the popover wrapper and tracks `visualViewport`, so the cap holds
+          // under pinch-zoom / browser-chrome collapse where a CSS `100vh` cap would exceed
+          // the tappable area. Pairs with the portal-fixed flip/clamp, which pins a capped
+          // menu 8px off both edges (#727).
+          className="!space-y-0 !rounded-2xl px-0 pt-2 pb-1"
           constrainHeightToViewport
           closeIgnoreSelectors={[`[data-testid="${resolvedTriggerTestId}"]`]}
           closePopover={() => setMenuOpen(false)}

--- a/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.tsx
@@ -159,7 +159,10 @@ const RowActionsMenuInner = ({
       ) : null}
       {open && !isPhone ? (
         <Popover
-          className="!space-y-0 !rounded-2xl px-0 pt-2 pb-1"
+          // Cap at viewport height minus 8px top + 8px bottom and scroll internally
+          // so a menu taller than the screen stays fully reachable. Pairs with the
+          // portal-fixed flip/clamp, which pins a capped menu 8px off both edges (#727).
+          className="max-h-[calc(100vh-theme(spacing.4))] !space-y-0 overflow-y-auto overscroll-contain !rounded-2xl px-0 pt-2 pb-1"
           closeIgnoreSelectors={[`[data-testid="${resolvedTriggerTestId}"]`]}
           closePopover={() => setMenuOpen(false)}
           position={positions["bottom right"]}

--- a/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RowActionsMenu/RowActionsMenu.tsx
@@ -159,10 +159,13 @@ const RowActionsMenuInner = ({
       ) : null}
       {open && !isPhone ? (
         <Popover
-          // Cap at viewport height minus 8px top + 8px bottom and scroll internally
-          // so a menu taller than the screen stays fully reachable. Pairs with the
+          // Cap to the visible viewport (8px off top + bottom) and scroll internally
+          // so a menu taller than the screen stays fully reachable. `constrainHeightToViewport`
+          // tracks `visualViewport`, so the cap holds under pinch-zoom / browser-chrome
+          // collapse where a CSS `100vh` cap would exceed the tappable area. Pairs with the
           // portal-fixed flip/clamp, which pins a capped menu 8px off both edges (#727).
-          className="max-h-[calc(100vh-theme(spacing.4))] !space-y-0 overflow-y-auto overscroll-contain !rounded-2xl px-0 pt-2 pb-1"
+          className="!space-y-0 overflow-y-auto overscroll-contain !rounded-2xl px-0 pt-2 pb-1"
+          constrainHeightToViewport
           closeIgnoreSelectors={[`[data-testid="${resolvedTriggerTestId}"]`]}
           closePopover={() => setMenuOpen(false)}
           position={positions["bottom right"]}

--- a/client/src/shared/components/Popover/Popover.tsx
+++ b/client/src/shared/components/Popover/Popover.tsx
@@ -152,6 +152,10 @@ const Popover = ({
       className={clsx(
         "z-50 rounded-3xl backdrop-blur-[7px]",
         renderMode === "portal-fixed" ? "fixed" : "absolute",
+        // The viewport cap (`maxHeight`) is applied to this positioned wrapper via
+        // `popoverStyle`, so the wrapper must also be the scroller — otherwise the
+        // unconstrained inner content paints past the cap and clips off-screen.
+        constrainHeightToViewport && "overflow-y-auto overscroll-contain",
         popoverAnimation,
       )}
       style={popoverStyle}

--- a/client/src/shared/components/Popover/Popover.tsx
+++ b/client/src/shared/components/Popover/Popover.tsx
@@ -30,6 +30,14 @@ type PopoverProps = PopoverContentProps & {
    * override that decision.
    */
   disableAutoFlip?: boolean;
+  /**
+   * Cap the popover's height to the visible viewport (portal-fixed only) so a
+   * menu taller than the screen scrolls internally instead of overflowing the
+   * tappable area. Tracks `visualViewport`, so it holds under pinch-zoom and
+   * mobile browser-chrome collapse where a CSS `100vh` cap would not. Pair with
+   * `overflow-y-auto` on the popover's className to make the overflow scroll.
+   */
+  constrainHeightToViewport?: boolean;
 };
 
 /**
@@ -77,6 +85,7 @@ const Popover = ({
   closeIgnoreSelectors = [],
   freezePosition = false,
   disableAutoFlip = false,
+  constrainHeightToViewport = false,
 }: PopoverProps) => {
   const { triggerRef, renderMode: contextRenderMode } = usePopover();
   const { isPhone } = useWindowDimensions();
@@ -93,6 +102,7 @@ const Popover = ({
     position,
     freezePosition,
     disableAutoFlip,
+    constrainHeightToViewport,
   );
 
   const content = (contentClassName?: string, contentTestId?: string) => (

--- a/client/src/shared/components/Popover/usePopoverPosition.ts
+++ b/client/src/shared/components/Popover/usePopoverPosition.ts
@@ -292,9 +292,18 @@ const usePopoverPosition = (
         top = triggerRect.top + top;
         left = triggerRect.left + left;
 
+        // The open animation settles at a residual transform: slide-up ends at
+        // translateY(-minimalMargin), slide-down at translateY(0). Clamp against the
+        // post-animation (visual) position so a pinned popover keeps its margin off the
+        // viewport edge instead of the transform eating it (flush-to-edge).
+        const animationTranslateY = finalPosition?.includes("bottom") ? 0 : -minimalMargin;
         // If both top and bottom would overflow, keep the popover pinned within viewport bounds.
         // This prevents action rows from being rendered outside the tappable area on small screens.
-        top = clampPosition(top, minimalMargin, visibleViewport.height - popoverRect.height - minimalMargin);
+        top = clampPosition(
+          top,
+          minimalMargin - animationTranslateY,
+          visibleViewport.height - popoverRect.height - minimalMargin - animationTranslateY,
+        );
         left = clampPosition(left, minimalMargin, visibleViewport.width - popoverRect.width - minimalMargin);
 
         style = {

--- a/client/src/shared/components/Popover/usePopoverPosition.ts
+++ b/client/src/shared/components/Popover/usePopoverPosition.ts
@@ -98,6 +98,12 @@ const usePopoverPosition = (
   // forceBelow + available space) and a viewport-overflow-driven flip would
   // override the caller's intent.
   disableAutoFlip?: boolean,
+  // When set (portal-fixed only), caps the popover's height to the visible
+  // viewport so a menu taller than the screen scrolls internally instead of
+  // overflowing the tappable area. Unlike a CSS `100vh` cap this tracks
+  // `visualViewport` (recomputed on its resize below), so it also holds under
+  // pinch-zoom and mobile browser-chrome collapse (#727).
+  constrainHeightToViewport?: boolean,
 ) => {
   const { width: viewportWidth, height: viewportHeight } = useWindowDimensions();
 
@@ -311,6 +317,11 @@ const usePopoverPosition = (
           left: `${left}px`,
           visibility: "visible",
         };
+        if (constrainHeightToViewport) {
+          // Leave `minimalMargin` above and below; pairs with the top clamp so a
+          // capped menu stays fully on-screen and scrolls its own overflow.
+          style.maxHeight = `${Math.max(visibleViewport.height - 2 * minimalMargin, 0)}px`;
+        }
       } else if (renderMode === "portal-scrolling") {
         // Portal with scrolling: use document coordinates (with page offset)
         top = triggerRect.top + top + initialPageOffset;
@@ -353,6 +364,7 @@ const usePopoverPosition = (
     initialPageOffset,
     visibleViewport,
     disableAutoFlip,
+    constrainHeightToViewport,
   ]);
 
   return { popoverAnimation, popoverStyle, popoverRef };


### PR DESCRIPTION
Reviewable diff: +80/-9 across 5 files (excludes generated, test, and story files).

## Summary

The bulk-actions menu (opened from the fleet/miner list's bottom action bar) was clipped on short viewports — it opens upward, so its top ran off-screen, and it also rendered *underneath* the app's page header. The single-miner row menu ("⋯") could likewise overflow the viewport with no way to reach clipped items. This PR keeps both menus fully within the viewport and reachable, and reshuffles the bulk quick-action row.

Behavior after this change:
- **Bulk menu** renders above the page header and grows upward only until 8px below the top of the viewport, then scrolls internally.
- **Row menu** keeps its "open below the trigger, flip above when it doesn't fit" behavior, but when the list is taller than the screen it pins 8px off both the top and bottom edges and scrolls internally.
- **Quick actions** in the bulk bar are now Blink LEDs · Reboot · Sleep · Wake; Manage power moves into the "More" overflow menu.

## How it works

**Escaping the header (stacking context).** The action bar renders inside the app shell's scroll container, which is `position: fixed` with `z-20`. A fixed element always creates a stacking context, so nothing inside it — regardless of its own z-index — can paint above the shell header at `z-40`. The bulk menu, expanding upward into the header band, was therefore trapped beneath it. The fix renders `MinerListActionBar` through a React portal into `document.body`, lifting it out of that trapped layer; its `z-50` now sits above the header. Because no layout ancestor uses `transform`/`filter`, the fixed bar's on-screen position is identical before and after portaling — only its stacking layer changes. The menu remains a DOM descendant of its trigger, so click-outside handling and the height variable below still work.

**Capping the bulk menu height.** The bulk popover renders inline and opens upward from the trigger. Its final on-screen top edge is `trigger.top − popoverHeight − 20px` (a 12px positioning offset plus an 8px residual from the open animation). To make that land 8px below the viewport top, the component measures the trigger's position and publishes a max-height as a CSS variable on the trigger container; the inline popover inherits it and scrolls internally past that height. The value recomputes on viewport resize. Phones are unaffected — they use a full-height bottom sheet.

**Capping the row menu height.** The row menu already renders in "portal-fixed" mode, where the shared positioning hook flips the menu above the trigger when it won't fit below and clamps it inside the viewport. The missing piece was a height cap, so a taller-than-screen menu overflowed with no scroll. It now caps at `100vh − 16px` (8px top + 8px bottom) with internal scroll. Separately, the shared clamp was pinning the menu's *pre-animation* coordinate at 8px; the slide animation's residual `translateY(-8px)` then ate that margin, leaving it flush to the edge. The clamp now compensates for the animation's residual translate, so a pinned menu keeps a real 8px inset off both edges. This clamp fix applies to all `portal-fixed` popovers (row menus, selects), improving only the near-edge/overflow cases; menus that already fit are unchanged.

## Diagrams

```mermaid
flowchart TD
    Root["AppLayout root (no stacking context)"] --> Header["Shell header — fixed z-40"]
    Root --> Scroll["Scroll container — fixed z-20 (stacking context)"]
    Scroll --> Page["Miner list page"]
    Page -. "before: bar trapped under header" .-> BarOld["Action bar z-20 — clipped by header"]
    Root --> Body["document.body (portal target)"]
    Body --> BarNew["after: Action bar portal z-50 — above header"]
    BarNew --> Menu["Bulk menu — capped 8px below viewport top, scrolls"]
```

```mermaid
flowchart TD
    Open["Row menu opened"] --> Fit{"Fits below trigger?"}
    Fit -- "yes" --> Below["Open below trigger"]
    Fit -- "no" --> Flip["Flip above / pin to viewport"]
    Below --> Tall{"Taller than viewport?"}
    Flip --> Tall
    Tall -- "no" --> Done["Render as-is"]
    Tall -- "yes" --> Cap["Cap at 100vh-16px, scroll internally"]
    Cap --> Clamp["Clamp pins 8px off top & bottom (animation-compensated)"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `MinerList/MinerListActionBar.tsx` | Portal the action bar to `document.body`; bar `z-20`→`z-50` | Confirms the bar escapes the shell's `z-20` stacking context and that portaling doesn't shift its fixed position |
| `BulkActions/BulkActionsPopover.tsx` | Measure trigger, publish a max-height CSS var on the trigger; cap + internal scroll on the menu | The offset math (12px + 8px animation) that lands the top edge 8px below the viewport top |
| `MinerActionsMenu/MinerActionsMenu.tsx` | Quick-action row: +Sleep, +Wake, −Manage power | Small, surface-level change to which actions are promoted |
| `RowActionsMenu/RowActionsMenu.tsx` | Cap menu at `100vh−16px` with internal scroll | Shared row menu — verify short menus are unaffected |
| `shared/components/Popover/usePopoverPosition.ts` | Compensate the portal-fixed clamp for the animation's residual translate | Shared positioning logic — the highest-blast-radius change; confirm down-opening popovers are untouched |

## Key technical decisions & trade-offs

- **Portal the whole action bar vs. only the popover.** Portaling the bar keeps the menu inline (preserving the trigger-relative positioning and the max-height cascade) and makes its `z-50` effective, rather than re-plumbing the popover into portal-fixed mode. Safe because no layout ancestor establishes a containing block for fixed elements.
- **Dynamic CSS-variable max-height vs. a static rem buffer** for the bulk menu. The measured value lands the top edge at exactly 8px regardless of bar height (e.g. when the quick-action row wraps), which a fixed buffer can't do.
- **Fix the clamp at the source vs. per-caller.** The animation-translate compensation lives in the shared `usePopoverPosition` because that's the root cause; it's narrowly scoped to the `portal-fixed` branch and only alters near-edge/overflow positioning.
- **Reuse `minimalMargin` (8px)** for all insets so menu margins match the rest of the popover system.

## Testing & validation

- Unit tests updated/passing across Popover, RowActionsMenu, BulkActions, MinerListActionBar, and both action menus (57 passing, 1 pre-existing skip). The quick-actions test now asserts Sleep/Wake render and fire and that Manage power is no longer in the quick row.
- `tsc`, ESLint, and Prettier clean on all changed files.
- Verified in isolation that the Tailwind v4 arbitrary values used here (`max-h-[var(--…,80vh)]`, `max-h-[calc(100vh-theme(spacing.4))]`) compile to real CSS.
- **Not yet covered:** live browser verification at a short viewport. Layout-dependent behavior (the exact 8px landing, header layering, internal scroll) can't be exercised in jsdom and should be spot-checked manually.
