### PR TITLE
Improve Proto Fleet E2E reporting and cleanup hooks

### DIFF
--- a/client/e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts
@@ -1,5 +1,5 @@
 import { type Browser, type Page, type TestInfo } from "@playwright/test";
-import { testConfig } from "../config/test.config";
+import { DEFAULT_TIMEOUT, testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { AuthPage } from "../pages/auth";
 import { FleetLocationsPage } from "../pages/fleetLocations";
@@ -17,6 +17,7 @@ import { generateRandomText } from "./testDataHelper";
 const AUTOMATION_SITE_BASE_PREFIX = "automation_building_detail_site";
 const AUTOMATION_BUILDING_BASE_PREFIX = "automation_building_detail_building";
 const AUTOMATION_RACK_BASE_PREFIX = "automation_building_detail_rack";
+const SHORT_CLEANUP_TIMEOUT = DEFAULT_TIMEOUT / 6;
 
 type BuildingDetailRunPrefixes = {
   sitePrefix: string;
@@ -88,10 +89,19 @@ async function cleanupAutomationFixtures(
   prefixes: BuildingDetailRunPrefixes,
 ) {
   await racksPage.navigateToRacksPage();
-  await racksPage.tryAction(() => racksPage.clickViewList());
-  await racksPage.waitForRackListToLoad();
+  await racksPage.tryAction(() => racksPage.clickViewList(SHORT_CLEANUP_TIMEOUT), SHORT_CLEANUP_TIMEOUT);
+  if (
+    !(await racksPage.tryAction(
+      () => racksPage.waitForRackListToLoad({ timeout: SHORT_CLEANUP_TIMEOUT }),
+      SHORT_CLEANUP_TIMEOUT,
+    ))
+  ) {
+    return;
+  }
 
-  const rackNames = (await racksPage.listRackNames()).filter((name) => name.startsWith(prefixes.rackPrefix));
+  const rackNames = (await racksPage.listRackNames(SHORT_CLEANUP_TIMEOUT)).filter((name) =>
+    name.startsWith(prefixes.rackPrefix),
+  );
   for (const rackName of rackNames) {
     await racksPage.deleteRackByLabelIfVisible(rackName);
   }

--- a/client/e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts
@@ -103,7 +103,7 @@ async function cleanupAutomationFixtures(
     name.startsWith(prefixes.rackPrefix),
   );
   for (const rackName of rackNames) {
-    await racksPage.deleteRackByLabelIfVisible(rackName);
+    await racksPage.deleteRackByLabelIfVisible(rackName, SHORT_CLEANUP_TIMEOUT);
   }
 
   const buildingNames = (await fleetLocationsPage.listBuildingNames()).filter((name) =>

--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -1,5 +1,5 @@
 import { type Browser, type Page, type TestInfo } from "@playwright/test";
-import { testConfig } from "../config/test.config";
+import { DEFAULT_TIMEOUT, testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { AuthPage } from "../pages/auth";
 import { FleetLocationsPage } from "../pages/fleetLocations";
@@ -15,6 +15,7 @@ const AUTOMATION_SITE_PREFIX = "automation_buildings_site";
 const AUTOMATION_BUILDING_PREFIX = "automation_buildings_building";
 const AUTOMATION_RACK_PREFIX = "automation_buildings_rack";
 export const AUTOMATION_BUILDINGS_ZONE = "AutomationBuildingsZone";
+const SHORT_CLEANUP_TIMEOUT = DEFAULT_TIMEOUT / 6;
 const RACK_COLUMNS = 2;
 const RACK_ROWS = 2;
 type BuildingsCleanupFleetLocationsPage = Pick<
@@ -51,10 +52,19 @@ async function cleanupAutomationFixtures(
   racksPage: BuildingsCleanupRacksPage,
 ) {
   await racksPage.navigateToRacksPage();
-  await racksPage.tryAction(() => racksPage.clickViewList());
-  await racksPage.waitForRackListToLoad();
+  await racksPage.tryAction(() => racksPage.clickViewList(SHORT_CLEANUP_TIMEOUT), SHORT_CLEANUP_TIMEOUT);
+  if (
+    !(await racksPage.tryAction(
+      () => racksPage.waitForRackListToLoad({ timeout: SHORT_CLEANUP_TIMEOUT }),
+      SHORT_CLEANUP_TIMEOUT,
+    ))
+  ) {
+    return;
+  }
 
-  const rackNames = (await racksPage.listRackNames()).filter((name) => name.startsWith(AUTOMATION_RACK_PREFIX));
+  const rackNames = (await racksPage.listRackNames(SHORT_CLEANUP_TIMEOUT)).filter((name) =>
+    name.startsWith(AUTOMATION_RACK_PREFIX),
+  );
   for (const rackName of rackNames) {
     await racksPage.deleteRackByLabelIfVisible(rackName);
   }

--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -66,7 +66,7 @@ async function cleanupAutomationFixtures(
     name.startsWith(AUTOMATION_RACK_PREFIX),
   );
   for (const rackName of rackNames) {
-    await racksPage.deleteRackByLabelIfVisible(rackName);
+    await racksPage.deleteRackByLabelIfVisible(rackName, SHORT_CLEANUP_TIMEOUT);
   }
 
   const buildingNames = (await fleetLocationsPage.listBuildingNames()).filter((name) =>

--- a/client/e2eTests/protoFleet/helpers/commonSteps.ts
+++ b/client/e2eTests/protoFleet/helpers/commonSteps.ts
@@ -40,15 +40,19 @@ export class CommonSteps {
   async loginAsAdmin({ forceReauth = false }: { forceReauth?: boolean } = {}) {
     await test.step("Login as admin", async () => {
       // eslint-disable-next-line playwright/no-conditional-in-test
-      if (forceReauth && (await this.authPage.isAlreadyLoggedIn())) {
-        await this.authPage.logout();
-        await this.authPage.validateRedirectedToAuth();
+      if (forceReauth) {
+        // eslint-disable-next-line playwright/no-conditional-in-test
+        if (await this.authPage.isAlreadyLoggedIn()) {
+          await this.authPage.logout();
+        }
+        await this.authPage.gotoAuthPage();
+      } else {
+        // eslint-disable-next-line playwright/no-conditional-in-test
+        if (await this.authPage.isAlreadyLoggedIn()) {
+          return;
+        }
       }
 
-      // eslint-disable-next-line playwright/no-conditional-in-test
-      if (await this.authPage.isAlreadyLoggedIn()) {
-        return;
-      }
       await this.authPage.inputUsername(testConfig.users.admin.username);
       await this.authPage.inputPassword(testConfig.users.admin.password);
       await this.authPage.clickLogin();
@@ -80,8 +84,8 @@ export class CommonSteps {
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (await this.authPage.isAlreadyLoggedIn()) {
         await this.authPage.logout();
-        await this.authPage.validateRedirectedToAuth();
       }
+      await this.authPage.gotoAuthPage();
       await this.authPage.inputUsername(username);
       await this.authPage.inputPassword(temporaryPassword);
       await this.authPage.clickLogin();

--- a/client/e2eTests/protoFleet/helpers/racksTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/racksTestSetup.ts
@@ -66,22 +66,7 @@ async function cleanupAllRacks(racksPage: RacksPage) {
   let rackNames = await racksPage.listRackNames(SHORT_CLEANUP_TIMEOUT);
 
   while (rackNames.length > 0) {
-    await racksPage.openRackFromList(rackNames[0]);
-    await racksPage.clickEditRack();
-    await racksPage.clickDeleteRack();
-    await racksPage.clickDeleteConfirm();
-    await racksPage.tryAction(() => racksPage.validateRackDeletedToast(SHORT_CLEANUP_TIMEOUT), SHORT_CLEANUP_TIMEOUT);
-
-    await racksPage.navigateToRacksPage();
-    await racksPage.tryAction(() => racksPage.clickViewList(SHORT_CLEANUP_TIMEOUT), SHORT_CLEANUP_TIMEOUT);
-    if (
-      !(await racksPage.tryAction(
-        () => racksPage.waitForRackListToLoad({ timeout: SHORT_CLEANUP_TIMEOUT }),
-        SHORT_CLEANUP_TIMEOUT,
-      ))
-    ) {
-      return;
-    }
+    await racksPage.deleteRackByLabelIfVisible(rackNames[0], SHORT_CLEANUP_TIMEOUT);
     rackNames = await racksPage.listRackNames(SHORT_CLEANUP_TIMEOUT);
   }
 }

--- a/client/e2eTests/protoFleet/helpers/racksTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/racksTestSetup.ts
@@ -1,5 +1,5 @@
 import { type Page } from "@playwright/test";
-import { testConfig } from "../config/test.config";
+import { DEFAULT_TIMEOUT, testConfig } from "../config/test.config";
 import { test } from "../fixtures/pageFixtures";
 import { AuthPage } from "../pages/auth";
 import { MinersPage } from "../pages/miners";
@@ -24,6 +24,7 @@ export const LARGE_RACK_COLUMNS = 3;
 export const LARGE_RACK_ROWS = 3;
 export const OVERVIEW_RACK_COLUMNS = 8;
 export const OVERVIEW_RACK_ROWS = 2;
+const SHORT_CLEANUP_TIMEOUT = DEFAULT_TIMEOUT / 6;
 export const ORDER_INDEX_SCENARIOS = [
   { label: "Bottom left", expectedNumbers: [3, 4, 1, 2] },
   { label: "Top left", expectedNumbers: [1, 2, 3, 4] },
@@ -52,22 +53,36 @@ export async function cleanupPoolIfPageOpen(
 
 async function cleanupAllRacks(racksPage: RacksPage) {
   await racksPage.navigateToRacksPage();
-  await racksPage.tryAction(() => racksPage.clickViewList());
-  await racksPage.waitForRackListToLoad();
+  await racksPage.tryAction(() => racksPage.clickViewList(SHORT_CLEANUP_TIMEOUT), SHORT_CLEANUP_TIMEOUT);
+  if (
+    !(await racksPage.tryAction(
+      () => racksPage.waitForRackListToLoad({ timeout: SHORT_CLEANUP_TIMEOUT }),
+      SHORT_CLEANUP_TIMEOUT,
+    ))
+  ) {
+    return;
+  }
 
-  let rackNames = await racksPage.listRackNames();
+  let rackNames = await racksPage.listRackNames(SHORT_CLEANUP_TIMEOUT);
 
   while (rackNames.length > 0) {
     await racksPage.openRackFromList(rackNames[0]);
     await racksPage.clickEditRack();
     await racksPage.clickDeleteRack();
     await racksPage.clickDeleteConfirm();
-    await racksPage.tryAction(() => racksPage.validateRackDeletedToast());
+    await racksPage.tryAction(() => racksPage.validateRackDeletedToast(SHORT_CLEANUP_TIMEOUT), SHORT_CLEANUP_TIMEOUT);
 
     await racksPage.navigateToRacksPage();
-    await racksPage.tryAction(() => racksPage.clickViewList());
-    await racksPage.waitForRackListToLoad();
-    rackNames = await racksPage.listRackNames();
+    await racksPage.tryAction(() => racksPage.clickViewList(SHORT_CLEANUP_TIMEOUT), SHORT_CLEANUP_TIMEOUT);
+    if (
+      !(await racksPage.tryAction(
+        () => racksPage.waitForRackListToLoad({ timeout: SHORT_CLEANUP_TIMEOUT }),
+        SHORT_CLEANUP_TIMEOUT,
+      ))
+    ) {
+      return;
+    }
+    rackNames = await racksPage.listRackNames(SHORT_CLEANUP_TIMEOUT);
   }
 }
 

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -37,17 +37,11 @@ export const RBAC_CURTAILMENT_SOURCE_PREFIX = "rbac_curtailment_source";
 export const RBAC_CURTAILMENT_REASON_PREFIX = "rbac_curtailment_reason";
 export const RBAC_RACK_ZONE = "RbacZone";
 const SHORT_HOOK_TIMEOUT = DEFAULT_TIMEOUT / 6;
+const RBAC_CLEANUP_TARGETS_ANNOTATION = "rbac-cleanup-targets";
 
 type RbacCleanupTarget = "alerts" | "curtailment" | "infrastructure" | "pools" | "schedules" | "team";
 
-const DEFAULT_RBAC_CLEANUP_TARGETS: RbacCleanupTarget[] = [
-  "curtailment",
-  "schedules",
-  "alerts",
-  "pools",
-  "infrastructure",
-  "team",
-];
+const DEFAULT_RBAC_CLEANUP_TARGETS: RbacCleanupTarget[] = ["team"];
 
 type PersistedAdminStorageState = Exclude<
   NonNullable<Parameters<Browser["newContext"]>[0]>["storageState"],
@@ -116,7 +110,14 @@ export function useRbacHooks(cleanupTargets: RbacCleanupTarget[] = DEFAULT_RBAC_
   });
 
   test.afterEach("CLEANUP: delete RBAC fixtures", async ({ browser }, testInfo) => {
-    await cleanupRbacArtifacts(browser, testInfo, cleanupTargets);
+    await cleanupRbacArtifacts(browser, testInfo, getCleanupTargetsForTest(testInfo, cleanupTargets));
+  });
+}
+
+export function markRbacCleanupTargets(testInfo: TestInfo, cleanupTargets: RbacCleanupTarget[]) {
+  testInfo.annotations.push({
+    type: RBAC_CLEANUP_TARGETS_ANNOTATION,
+    description: cleanupTargets.join(","),
   });
 }
 
@@ -503,6 +504,28 @@ async function cleanupRbacArtifacts(browser: Browser, testInfo: TestInfo, cleanu
       }
     },
   );
+}
+
+function getCleanupTargetsForTest(testInfo: TestInfo, defaultTargets: RbacCleanupTarget[]): RbacCleanupTarget[] {
+  const cleanupTargets = new Set<RbacCleanupTarget>(defaultTargets);
+
+  for (const annotation of testInfo.annotations) {
+    if (annotation.type !== RBAC_CLEANUP_TARGETS_ANNOTATION || !annotation.description) {
+      continue;
+    }
+
+    for (const cleanupTarget of annotation.description.split(",")) {
+      if (isRbacCleanupTarget(cleanupTarget)) {
+        cleanupTargets.add(cleanupTarget);
+      }
+    }
+  }
+
+  return [...cleanupTargets];
+}
+
+function isRbacCleanupTarget(value: string): value is RbacCleanupTarget {
+  return ["alerts", "curtailment", "infrastructure", "pools", "schedules", "team"].includes(value);
 }
 
 async function cleanupInfrastructureFixtures(fleetLocationsPage: FleetLocationsPage, racksPage: RacksPage) {

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -530,10 +530,19 @@ function isRbacCleanupTarget(value: string): value is RbacCleanupTarget {
 
 async function cleanupInfrastructureFixtures(fleetLocationsPage: FleetLocationsPage, racksPage: RacksPage) {
   await racksPage.navigateToRacksPage();
-  await racksPage.tryAction(() => racksPage.clickViewList());
-  await racksPage.waitForRackListToLoad();
+  await racksPage.tryAction(() => racksPage.clickViewList(SHORT_HOOK_TIMEOUT), SHORT_HOOK_TIMEOUT);
+  if (
+    !(await racksPage.tryAction(
+      () => racksPage.waitForRackListToLoad({ timeout: SHORT_HOOK_TIMEOUT }),
+      SHORT_HOOK_TIMEOUT,
+    ))
+  ) {
+    return;
+  }
 
-  const rackNames = (await racksPage.listRackNames()).filter((name) => name.startsWith(RBAC_RACK_PREFIX));
+  const rackNames = (await racksPage.listRackNames(SHORT_HOOK_TIMEOUT)).filter((name) =>
+    name.startsWith(RBAC_RACK_PREFIX),
+  );
   for (const rackName of rackNames) {
     await racksPage.deleteRackByLabelIfVisible(rackName);
   }

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -544,7 +544,7 @@ async function cleanupInfrastructureFixtures(fleetLocationsPage: FleetLocationsP
     name.startsWith(RBAC_RACK_PREFIX),
   );
   for (const rackName of rackNames) {
-    await racksPage.deleteRackByLabelIfVisible(rackName);
+    await racksPage.deleteRackByLabelIfVisible(rackName, SHORT_HOOK_TIMEOUT);
   }
 
   const buildingNames = (await fleetLocationsPage.listBuildingNames()).filter((name) =>

--- a/client/e2eTests/protoFleet/pages/auth.ts
+++ b/client/e2eTests/protoFleet/pages/auth.ts
@@ -44,6 +44,24 @@ export class AuthPage extends BasePage {
     await expect(this.page).toHaveURL(/.*\/auth/);
   }
 
+  async ensureAuthPage(timeoutMs = 5000) {
+    const loginForm = this.page.locator(`//input[@id='username']`);
+
+    try {
+      await expect
+        .poll(
+          async () => /\/auth(?:[/?#].*)?$/.test(this.page.url()) || (await loginForm.isVisible().catch(() => false)),
+          { timeout: timeoutMs },
+        )
+        .toBe(true);
+    } catch {
+      await this.page.goto("/auth");
+    }
+
+    await expect(this.page).toHaveURL(/.*\/auth/);
+    await expect(loginForm).toBeVisible();
+  }
+
   async inputNewPassword(password: string) {
     await this.page.locator(`//input[@id='newPassword']`).fill(password);
   }

--- a/client/e2eTests/protoFleet/pages/auth.ts
+++ b/client/e2eTests/protoFleet/pages/auth.ts
@@ -44,20 +44,9 @@ export class AuthPage extends BasePage {
     await expect(this.page).toHaveURL(/.*\/auth/);
   }
 
-  async ensureAuthPage(timeoutMs = 5000) {
+  async gotoAuthPage() {
     const loginForm = this.page.locator(`//input[@id='username']`);
-
-    try {
-      await expect
-        .poll(
-          async () => /\/auth(?:[/?#].*)?$/.test(this.page.url()) || (await loginForm.isVisible().catch(() => false)),
-          { timeout: timeoutMs },
-        )
-        .toBe(true);
-    } catch {
-      await this.page.goto("/auth");
-    }
-
+    await this.page.goto("/auth");
     await expect(this.page).toHaveURL(/.*\/auth/);
     await expect(loginForm).toBeVisible();
   }

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -346,23 +346,12 @@ export class BasePage {
 
   async logout() {
     const logoutButton = this.page.getByTestId("logout-button");
-    const navigationMenuButton = this.page.getByTestId("navigation-menu-button");
 
-    // The current session can be invalidated server-side at any moment
-    // (e.g. cleanup deactivated the member this page is logged in as),
-    // making the app redirect to /auth on its own mid-logout. Treat
-    // either outcome — a successful logout click or the app's own
-    // redirect — as logged out instead of timing out on a button that
-    // no longer exists.
-    await expect(async () => {
-      if (this.page.url().includes("/auth")) {
-        return;
-      }
-      if (this.isMobile && !(await logoutButton.isVisible().catch(() => false))) {
-        await navigationMenuButton.click({ timeout: 2_000 });
-      }
-      await logoutButton.click({ timeout: 2_000 });
-    }).toPass({ timeout: DEFAULT_TIMEOUT });
+    if (!(await logoutButton.isVisible().catch(() => false))) {
+      await this.clickNavigationMenuIfMobile();
+    }
+
+    await logoutButton.click();
   }
 
   async validateTitle(expectedTitle: string) {

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -2,7 +2,7 @@ import { expect, type Locator, Page } from "@playwright/test";
 import { DEFAULT_TIMEOUT, testConfig } from "../config/test.config";
 
 const FLEET_TAB_ROUTE = /.*\/fleet\/(?:sites|buildings|racks|miners)(?:[/?#].*)?$/;
-const TOAST_DISMISS_TIMEOUT = DEFAULT_TIMEOUT / 6;
+const OVERLAY_DISMISS_TIMEOUT = DEFAULT_TIMEOUT / 6;
 
 export class BasePage {
   constructor(
@@ -39,11 +39,16 @@ export class BasePage {
   }
 
   async clearActiveFilter(filterValue: string) {
-    if (!this.isMobile) {
-      const clearButton = await this.visibleTestIdLocator(`active-filter-${filterValue}-clear`);
+    const clearButton = await this.findVisibleTestIdLocator(`active-filter-${filterValue}-clear`);
+    if (clearButton) {
       await clearButton.scrollIntoViewIfNeeded();
       await clearButton.click();
+      await this.waitForActiveFilterToClear(filterValue);
       return;
+    }
+
+    if (!this.isMobile) {
+      throw new Error(`Expected a visible clear button for the active "${filterValue}" filter chip.`);
     }
 
     const editButton = await this.visibleTestIdLocator(`active-filter-${filterValue}-edit`);
@@ -63,8 +68,19 @@ export class BasePage {
       }
     }
 
-    await this.dismissMobilePopoverSheet("dropdown-filter-popover");
-    await expect(popover).toBeHidden();
+    if (await popover.isVisible().catch(() => false)) {
+      await editButton.click();
+    }
+
+    if (await popover.isVisible().catch(() => false)) {
+      await this.dismissMobilePopoverSheet("dropdown-filter-popover");
+    }
+    await expect
+      .poll(async () => await popover.isVisible().catch(() => false), {
+        timeout: OVERLAY_DISMISS_TIMEOUT,
+        message: "Expected the dropdown filter popover to close on mobile.",
+      })
+      .toBe(false);
   }
 
   async clickNewSavedViewButton() {
@@ -194,7 +210,6 @@ export class BasePage {
 
     const [targetLabel] = targetLabels;
     const activeEditButton = await this.findVisibleTestIdLocator(`active-filter-${categoryKey}-edit`);
-    let clearedExistingSelection = false;
     if (activeEditButton) {
       const currentSummary = ((await activeEditButton.textContent()) ?? "").replace(/\s+/g, " ").trim();
       if (currentSummary === targetLabel) {
@@ -202,16 +217,11 @@ export class BasePage {
       }
 
       await this.clearActiveFilter(categoryKey);
-      await this.waitForActiveFilterToClear(categoryKey);
-      clearedExistingSelection = true;
     }
 
     const addFilterPopover = await this.openVisibleAddFilter();
     const submenu = await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
     await this.waitForCheckboxFilterOptions(submenu, categoryKey, targetLabels);
-    if (clearedExistingSelection) {
-      await this.waitForCheckboxFilterSelectionState(submenu, categoryKey, []);
-    }
     const targetOption = (await this.readCheckboxFilterOptionStates(submenu)).find(
       ({ label }) => label === targetLabel,
     );
@@ -404,12 +414,33 @@ export class BasePage {
   }
 
   async dismissToast() {
-    const toast = this.page.getByTestId("toaster-container");
-    const dismissButton = this.page.getByRole("button", { name: "Dismiss" });
-    if (!(await dismissButton.isVisible())) {
-      await toast.click();
+    const toastContainer = this.page.getByTestId("toaster-container");
+    const groupedDismissButton = toastContainer.getByRole("button", { name: "Dismiss", exact: true });
+    const inlineDismissButton = toastContainer.getByTestId("toast").locator("button").first();
+
+    if (await groupedDismissButton.isVisible().catch(() => false)) {
+      await groupedDismissButton.click();
+      return;
     }
-    await toast.getByRole("button", { name: "Dismiss" }).click();
+
+    if (await inlineDismissButton.isVisible().catch(() => false)) {
+      await inlineDismissButton.click();
+      return;
+    }
+
+    await toastContainer.click({ position: { x: 8, y: 8 } });
+
+    if (await groupedDismissButton.isVisible().catch(() => false)) {
+      await groupedDismissButton.click();
+      return;
+    }
+
+    if (await inlineDismissButton.isVisible().catch(() => false)) {
+      await inlineDismissButton.click();
+      return;
+    }
+
+    throw new Error("Expected a visible toast dismiss control.");
   }
 
   async validateTextInModal(text: string) {
@@ -452,10 +483,14 @@ export class BasePage {
       return;
     }
 
-    await this.dismissToast().catch(async () => {
-      await toastContainer.waitFor({ state: "hidden", timeout: TOAST_DISMISS_TIMEOUT }).catch(() => undefined);
-    });
-    await toastContainer.waitFor({ state: "hidden", timeout: TOAST_DISMISS_TIMEOUT }).catch(() => undefined);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await this.dismissToast().catch(() => undefined);
+      await toastContainer.waitFor({ state: "hidden", timeout: OVERLAY_DISMISS_TIMEOUT }).catch(() => undefined);
+
+      if (!(await toastContainer.isVisible().catch(() => false))) {
+        return;
+      }
+    }
   }
 
   async validateButtonIsVisible(text: string) {
@@ -761,6 +796,15 @@ export class BasePage {
   }
 
   private async getVisibleAddFilterTrigger(): Promise<Locator> {
+    const namedButtons = this.page.getByRole("button", { name: "Add Filter", exact: true });
+    const namedButtonCount = await namedButtons.count();
+    for (let i = 0; i < namedButtonCount; i++) {
+      const button = namedButtons.nth(i);
+      if (await button.isVisible().catch(() => false)) {
+        return button;
+      }
+    }
+
     const triggers = this.page.getByTestId("filter-nested-add-filter");
     let visibleIndex = -1;
 
@@ -828,9 +872,13 @@ export class BasePage {
   }
 
   protected async dismissMobilePopoverSheet(popoverTestId: string) {
+    const popover = this.page.getByTestId(popoverTestId);
     const sheet = this.page.getByTestId(`${popoverTestId}-sheet`);
 
-    if (!(await sheet.isVisible().catch(() => false))) {
+    const isClosed = async () =>
+      !(await sheet.isVisible().catch(() => false)) && !(await popover.isVisible().catch(() => false));
+
+    if (await isClosed()) {
       return;
     }
 
@@ -844,10 +892,20 @@ export class BasePage {
       await this.page.mouse.click(1, 1).catch(() => undefined);
     }
 
+    if (await isClosed()) {
+      return;
+    }
+
     if (await sheet.isVisible().catch(() => false)) {
       await this.page.keyboard.press("Escape").catch(() => undefined);
-      await expect(sheet).toBeHidden();
     }
+
+    await expect
+      .poll(isClosed, {
+        timeout: OVERLAY_DISMISS_TIMEOUT,
+        message: `Expected the ${popoverTestId} mobile sheet to close.`,
+      })
+      .toBe(true);
   }
 
   protected async clickOverflowAction(text: string) {

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -334,6 +334,10 @@ export class BasePage {
   }
 
   async logout() {
+    if (this.page.url().includes("/auth")) {
+      return;
+    }
+
     const logoutButton = this.page.getByTestId("logout-button");
 
     if (!(await logoutButton.isVisible().catch(() => false))) {

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -210,6 +210,7 @@ export class BasePage {
 
     const [targetLabel] = targetLabels;
     const activeEditButton = await this.findVisibleTestIdLocator(`active-filter-${categoryKey}-edit`);
+    const hadActiveFilter = Boolean(activeEditButton);
     if (activeEditButton) {
       const currentSummary = ((await activeEditButton.textContent()) ?? "").replace(/\s+/g, " ").trim();
       if (currentSummary === targetLabel) {
@@ -217,11 +218,15 @@ export class BasePage {
       }
 
       await this.clearActiveFilter(categoryKey);
+      await this.waitForActiveFilterToClear(categoryKey);
     }
 
     const addFilterPopover = await this.openVisibleAddFilter();
     const submenu = await this.openNestedFilterSubmenu(addFilterPopover, categoryKey);
     await this.waitForCheckboxFilterOptions(submenu, categoryKey, targetLabels);
+    if (hadActiveFilter) {
+      await this.waitForCheckboxFilterSelectionState(submenu, categoryKey, []);
+    }
     const targetOption = (await this.readCheckboxFilterOptionStates(submenu)).find(
       ({ label }) => label === targetLabel,
     );
@@ -293,6 +298,27 @@ export class BasePage {
         },
       )
       .toEqual([]);
+  }
+
+  private async waitForCheckboxFilterSelectionState(
+    container: Locator,
+    categoryKey: string,
+    expectedCheckedLabels: string[],
+  ) {
+    const expected = [...expectedCheckedLabels].sort();
+    await expect
+      .poll(
+        async () =>
+          (await this.readCheckboxFilterOptionStates(container))
+            .filter(({ checked }) => checked)
+            .map(({ label }) => label)
+            .sort(),
+        {
+          timeout: DEFAULT_TIMEOUT,
+          message: `Expected the visible "${categoryKey}" filter selection to be ${expected.join(", ") || "empty"}.`,
+        },
+      )
+      .toEqual(expected);
   }
 
   private async readCheckboxFilterOptionStates(container: Locator) {

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -389,9 +389,9 @@ export class BasePage {
     await expect(this.page.getByText(text)).toBeVisible();
   }
 
-  async validateTextInToast(text: string) {
+  async validateTextInToast(text: string, timeout: number = DEFAULT_TIMEOUT) {
     const toast = this.page.getByTestId("toast").getByText(text);
-    await expect(toast).toBeVisible();
+    await expect(toast).toBeVisible({ timeout });
   }
 
   async validateTextInToastGroup(text: string) {

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -334,7 +334,9 @@ export class BasePage {
   }
 
   async logout() {
-    if (this.page.url().includes("/auth")) {
+    const loginForm = this.page.locator("#username");
+
+    if (this.page.url().includes("/auth") || (await loginForm.isVisible().catch(() => false))) {
       return;
     }
 
@@ -342,6 +344,16 @@ export class BasePage {
 
     if (!(await logoutButton.isVisible().catch(() => false))) {
       await this.clickNavigationMenuIfMobile();
+    }
+
+    if (this.page.url().includes("/auth") || (await loginForm.isVisible().catch(() => false))) {
+      return;
+    }
+
+    if (!(await logoutButton.isVisible().catch(() => false))) {
+      await this.page.goto("/auth");
+      await expect(loginForm).toBeVisible();
+      return;
     }
 
     await logoutButton.click();

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -2,6 +2,7 @@ import { expect, type Locator, Page } from "@playwright/test";
 import { DEFAULT_TIMEOUT, testConfig } from "../config/test.config";
 
 const FLEET_TAB_ROUTE = /.*\/fleet\/(?:sites|buildings|racks|miners)(?:[/?#].*)?$/;
+const TOAST_DISMISS_TIMEOUT = DEFAULT_TIMEOUT / 6;
 
 export class BasePage {
   constructor(
@@ -31,7 +32,10 @@ export class BasePage {
   }
 
   async clickClearAllFilters() {
-    await this.page.getByRole("button", { name: "Clear all filters", exact: true }).click();
+    await this.dismissVisibleToastIfPresent();
+    const clearAllFiltersButton = this.page.getByRole("button", { name: "Clear all filters", exact: true });
+    await clearAllFiltersButton.scrollIntoViewIfNeeded();
+    await clearAllFiltersButton.click();
   }
 
   async clearActiveFilter(filterValue: string) {
@@ -451,6 +455,18 @@ export class BasePage {
       }
     }
     return false;
+  }
+
+  private async dismissVisibleToastIfPresent() {
+    const toastContainer = this.page.getByTestId("toaster-container");
+    if (!(await toastContainer.isVisible().catch(() => false))) {
+      return;
+    }
+
+    await this.dismissToast().catch(async () => {
+      await toastContainer.waitFor({ state: "hidden", timeout: TOAST_DISMISS_TIMEOUT }).catch(() => undefined);
+    });
+    await toastContainer.waitFor({ state: "hidden", timeout: TOAST_DISMISS_TIMEOUT }).catch(() => undefined);
   }
 
   async validateButtonIsVisible(text: string) {

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -295,27 +295,6 @@ export class BasePage {
       .toEqual([]);
   }
 
-  private async waitForCheckboxFilterSelectionState(
-    container: Locator,
-    categoryKey: string,
-    expectedCheckedLabels: string[],
-  ) {
-    const expected = [...expectedCheckedLabels].sort();
-    await expect
-      .poll(
-        async () =>
-          (await this.readCheckboxFilterOptionStates(container))
-            .filter(({ checked }) => checked)
-            .map(({ label }) => label)
-            .sort(),
-        {
-          timeout: DEFAULT_TIMEOUT,
-          message: `Expected the visible "${categoryKey}" filter selection to be ${expected.join(", ") || "empty"}.`,
-        },
-      )
-      .toEqual(expected);
-  }
-
   private async readCheckboxFilterOptionStates(container: Locator) {
     const options = container.locator('[data-testid^="filter-option-"]');
     const count = await options.count();

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -303,11 +303,14 @@ export class FleetLocationsPage extends BasePage {
     await this.clickRowAction("Edit site");
     await this.clickManageSiteDelete();
 
+    const deleteDialog = this.page.getByTestId("site-delete-dialog");
     const confirmDeleteButton = this.page.getByTestId("site-delete-dialog-confirm");
     await expect(confirmDeleteButton).toBeVisible();
     await confirmDeleteButton.click({ trial: true });
     await confirmDeleteButton.click();
     await expect(this.getListRowByName(name)).toHaveCount(0);
+    await expect(deleteDialog).toHaveCount(0);
+    await expect(this.page.getByTestId("full-screen-two-pane-modal")).toHaveCount(0);
   }
 
   async deleteBuilding(name: string) {
@@ -315,11 +318,14 @@ export class FleetLocationsPage extends BasePage {
     await this.openManageBuildingFromList(name);
     await this.clickManageBuildingDelete();
 
+    const deleteDialog = this.page.getByTestId("building-delete-dialog");
     const confirmDeleteButton = this.page.getByTestId("building-delete-dialog-confirm");
     await expect(confirmDeleteButton).toBeVisible();
     await confirmDeleteButton.click({ trial: true });
     await confirmDeleteButton.click();
     await expect(this.getListRowByName(name)).toHaveCount(0);
+    await expect(deleteDialog).toHaveCount(0);
+    await expect(this.page.getByTestId("full-screen-two-pane-modal")).toHaveCount(0);
   }
 
   async renameBuilding(currentName: string, nextName: string) {

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -354,15 +354,15 @@ export class RacksPage extends BasePage {
     await this.getRackCard(label, zone).click();
   }
 
-  async clickViewList() {
-    await this.clickRackViewMode("View list");
+  async clickViewList(timeout: number = DEFAULT_TIMEOUT) {
+    await this.clickRackViewMode("View list", timeout);
   }
 
-  async clickViewGrid() {
-    await this.clickRackViewMode("View grid");
+  async clickViewGrid(timeout: number = DEFAULT_TIMEOUT) {
+    await this.clickRackViewMode("View grid", timeout);
   }
 
-  private async clickRackViewMode(label: "View grid" | "View list") {
+  private async clickRackViewMode(label: "View grid" | "View list", timeout: number) {
     const controls = this.page.getByTestId("segmented-control");
     let visibleControlIndex = -1;
 
@@ -384,7 +384,7 @@ export class RacksPage extends BasePage {
           return "hidden";
         },
         {
-          timeout: DEFAULT_TIMEOUT,
+          timeout,
           intervals: [DEFAULT_INTERVAL],
           message: `Expected the ${label} segmented control button to be visible.`,
         },
@@ -430,12 +430,14 @@ export class RacksPage extends BasePage {
   async waitForRackListToLoad({
     allowEmpty = true,
     requireManageAccess = true,
+    timeout = DEFAULT_TIMEOUT,
   }: {
     allowEmpty?: boolean;
     requireManageAccess?: boolean;
+    timeout?: number;
   } = {}) {
     if (requireManageAccess) {
-      await expect(this.page.getByRole("button", { name: "Add rack" }).first()).toBeVisible();
+      await expect(this.page.getByRole("button", { name: "Add rack" }).first()).toBeVisible({ timeout });
     }
 
     const rows = this.page.getByTestId("list-row");
@@ -456,11 +458,11 @@ export class RacksPage extends BasePage {
       const rowCountAfterDelay = await rows.count();
       // eslint-disable-next-line playwright/prefer-to-have-count -- intentionally non-retrying: verifies count has stabilized
       expect(rowCountAfterDelay).toBe(rowCount);
-    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
+    }).toPass({ timeout, intervals: [DEFAULT_INTERVAL] });
   }
 
-  async listRackNames(): Promise<string[]> {
-    await this.waitForRackListToLoad();
+  async listRackNames(timeout: number = DEFAULT_TIMEOUT): Promise<string[]> {
+    await this.waitForRackListToLoad({ timeout });
 
     const nameCells = this.page.getByTestId("list-row").getByTestId("name");
     const count = await nameCells.count();
@@ -581,8 +583,8 @@ export class RacksPage extends BasePage {
     await this.clickButton("Delete");
   }
 
-  async validateRackDeletedToast() {
-    await this.validateTextInToast("Rack deleted");
+  async validateRackDeletedToast(timeout: number = DEFAULT_TIMEOUT) {
+    await this.validateTextInToast("Rack deleted", timeout);
   }
 
   async validateRackOverviewAssignedSlots(slotNumbers: readonly number[]) {

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -504,9 +504,9 @@ export class RacksPage extends BasePage {
     await expect(this.getRackListRow(label)).toHaveCount(0);
   }
 
-  async openRackFromList(label: string) {
+  async openRackFromList(label: string, timeout: number = DEFAULT_TIMEOUT) {
     const row = this.getRackListRow(label);
-    await expect(row).toBeVisible();
+    await expect(row).toBeVisible({ timeout });
     await row.getByTestId("name").getByRole("button", { name: label, exact: true }).click();
   }
 
@@ -535,17 +535,17 @@ export class RacksPage extends BasePage {
     await this.selectParentPickerTarget(buildingName);
   }
 
-  async deleteRackByLabelIfVisible(label: string) {
+  async deleteRackByLabelIfVisible(label: string, timeout: number = DEFAULT_TIMEOUT) {
     await this.navigateToRacksPage();
-    await this.tryAction(() => this.clickViewList());
-    if (!(await this.tryAction(() => this.openRackFromList(label)))) {
+    await this.tryAction(() => this.clickViewList(timeout), timeout);
+    if (!(await this.tryAction(() => this.openRackFromList(label, timeout), timeout))) {
       return;
     }
 
     await this.clickEditRack();
     await this.clickDeleteRack();
     await this.clickDeleteConfirm();
-    await this.tryAction(() => this.validateRackDeletedToast());
+    await this.tryAction(() => this.validateRackDeletedToast(timeout), timeout);
   }
 
   async clickEditRack() {

--- a/client/e2eTests/protoFleet/spec/activity.spec.ts
+++ b/client/e2eTests/protoFleet/spec/activity.spec.ts
@@ -9,11 +9,18 @@ import { SettingsSchedulesPage } from "../pages/settingsSchedules";
 const SCHEDULE_PREFIX = "activity_schedule_e2e";
 
 test.describe("Proto Fleet - Activity", () => {
+  let shouldCleanupSchedules = false;
+
   test.beforeEach(async ({ page }) => {
+    shouldCleanupSchedules = false;
     await page.goto("/");
   });
 
   test.afterEach("CLEANUP: Delete schedules created during activity tests", async ({ browser }, testInfo) => {
+    if (!shouldCleanupSchedules) {
+      return;
+    }
+
     const isMobile = testInfo.project.use?.isMobile ?? false;
     const viewport = testInfo.project.use?.viewport;
     const context = await browser.newContext({ baseURL: testConfig.baseUrl, viewport });
@@ -205,6 +212,7 @@ test.describe("Proto Fleet - Activity", () => {
     });
 
     await test.step("Create a uniquely named schedule", async () => {
+      shouldCleanupSchedules = true;
       await settingsSchedulesPage.clickAddSchedule();
       await settingsSchedulesPage.inputScheduleName(scheduleName);
       await settingsSchedulesPage.selectStartDate(1);

--- a/client/e2eTests/protoFleet/spec/alerts.spec.ts
+++ b/client/e2eTests/protoFleet/spec/alerts.spec.ts
@@ -23,6 +23,8 @@ const ALERTS_E2E_ENABLED = process.env.E2E_ALERTS_ENABLED === "true";
 const REACHABLE_WEBHOOK_URL = "http://otel-collector:13133/healthz";
 
 test.describe("Proto Fleet - Alerts", () => {
+  let shouldCleanupChannels = false;
+
   // eslint-disable-next-line playwright/no-skipped-test
   test.skip(
     !ALERTS_E2E_ENABLED,
@@ -30,10 +32,15 @@ test.describe("Proto Fleet - Alerts", () => {
   );
 
   test.beforeEach(async ({ page }) => {
+    shouldCleanupChannels = false;
     await page.goto("/");
   });
 
   test.afterEach("CLEANUP: delete channels created during tests", async ({ browser }, testInfo) => {
+    if (!shouldCleanupChannels) {
+      return;
+    }
+
     const isMobile = testInfo.project.use?.isMobile ?? false;
     const viewport = testInfo.project.use?.viewport;
     const context = await browser.newContext({ baseURL: testConfig.baseUrl, viewport });
@@ -76,6 +83,7 @@ test.describe("Proto Fleet - Alerts", () => {
     });
 
     await test.step("Save the channel", async () => {
+      shouldCleanupChannels = true;
       await alertsPage.saveChannel();
       await alertsPage.validateChannelListed(channelName);
       await alertsPage.validateChannelStatus(channelName, "Not tested");
@@ -90,6 +98,7 @@ test.describe("Proto Fleet - Alerts", () => {
 
     await test.step("Delete the channel", async () => {
       await alertsPage.deleteChannel(channelName);
+      shouldCleanupChannels = false;
     });
   });
 });

--- a/client/e2eTests/protoFleet/spec/apiKeysSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/apiKeysSettings.spec.ts
@@ -9,11 +9,18 @@ import { SettingsApiKeysPage } from "../pages/settingsApiKeys";
 const API_KEY_PREFIX = "e2e_api_key";
 
 test.describe("Proto Fleet - Integrations", () => {
+  let shouldCleanupApiKeys = false;
+
   test.beforeEach(async ({ page }) => {
+    shouldCleanupApiKeys = false;
     await page.goto("/");
   });
 
   test.afterEach("CLEANUP: Revoke any API keys created during tests", async ({ browser }, testInfo) => {
+    if (!shouldCleanupApiKeys) {
+      return;
+    }
+
     const isMobile = testInfo.project.use?.isMobile ?? false;
     const viewport = testInfo.project.use?.viewport;
     const context = await browser.newContext({ baseURL: testConfig.baseUrl, viewport });
@@ -48,6 +55,7 @@ test.describe("Proto Fleet - Integrations", () => {
     });
 
     await test.step("Create a new API key without expiration", async () => {
+      shouldCleanupApiKeys = true;
       await settingsApiKeysPage.clickCreateApiKey();
       await settingsApiKeysPage.inputApiKeyName(apiKeyName);
       await settingsApiKeysPage.clickCreateInModal();
@@ -64,6 +72,7 @@ test.describe("Proto Fleet - Integrations", () => {
       await settingsApiKeysPage.clickRevokeApiKey(apiKeyName);
       await settingsApiKeysPage.confirmRevokeApiKey();
       await settingsApiKeysPage.validateApiKeyNotVisible(apiKeyName);
+      shouldCleanupApiKeys = false;
     });
   });
 
@@ -94,6 +103,7 @@ test.describe("Proto Fleet - Integrations", () => {
     });
 
     await test.step("Create a new API key with a future expiration date", async () => {
+      shouldCleanupApiKeys = true;
       await settingsApiKeysPage.selectExpirationDate(futureDate);
       await settingsApiKeysPage.inputApiKeyName(apiKeyName);
       await settingsApiKeysPage.clickCreateInModal();

--- a/client/e2eTests/protoFleet/spec/minersAddRemove.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersAddRemove.spec.ts
@@ -16,6 +16,10 @@ test.describe("Miners UNPAIR - ADD actions", () => {
       return;
     }
 
+    if (testInfo.status === testInfo.expectedStatus) {
+      return;
+    }
+
     const isMobile = testInfo.project.use?.isMobile ?? false;
     const context = await browser.newContext({ baseURL: testConfig.baseUrl });
     try {

--- a/client/e2eTests/protoFleet/spec/minersAddRemove.spec.ts
+++ b/client/e2eTests/protoFleet/spec/minersAddRemove.spec.ts
@@ -16,10 +16,6 @@ test.describe("Miners UNPAIR - ADD actions", () => {
       return;
     }
 
-    if (testInfo.status === testInfo.expectedStatus) {
-      return;
-    }
-
     const isMobile = testInfo.project.use?.isMobile ?? false;
     const context = await browser.newContext({ baseURL: testConfig.baseUrl });
     try {

--- a/client/e2eTests/protoFleet/spec/rbac.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbac.spec.ts
@@ -10,6 +10,7 @@ import {
   createRack,
   createSchedule,
   invokeIngestCurtailmentSignal,
+  markRbacCleanupTargets,
   MEMBER_PASSWORD,
   provisionRoleAndLogin,
   provisionRoleViaStoredAdminContext,
@@ -74,14 +75,18 @@ test.describe("Proto Fleet - RBAC", () => {
     commonSteps,
     settingsPoolsPage,
   }) => {
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Read-only mining pool access for RBAC coverage.",
-      permissionKeys: ["pool:read"],
+    await test.step("Provision a read-only pools role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Read-only mining pool access for RBAC coverage.",
+        permissionKeys: ["pool:read"],
+      });
     });
 
-    await validateManageOnlySettingsRouteHidden(page, {
-      route: "/settings/mining-pools",
-      validateSubmenuHidden: () => settingsPoolsPage.validateMiningPoolsSubmenuHidden(),
+    await test.step("Validate the Pools settings surface stays inaccessible", async () => {
+      await validateManageOnlySettingsRouteHidden(page, {
+        route: "/settings/mining-pools",
+        validateSubmenuHidden: () => settingsPoolsPage.validateMiningPoolsSubmenuHidden(),
+      });
     });
   });
 
@@ -93,22 +98,31 @@ test.describe("Proto Fleet - RBAC", () => {
   }) => {
     const poolName = generateRandomText(RBAC_POOL_PREFIX);
     const poolUsername = generateRandomText("rbac_pool_user");
+    markRbacCleanupTargets(test.info(), ["pools"]);
 
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Manage mining pools for RBAC coverage.",
-      permissionKeys: ["pool:read", "pool:manage"],
+    await test.step("Provision a manage-capable pools role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Manage mining pools for RBAC coverage.",
+        permissionKeys: ["pool:read", "pool:manage"],
+      });
     });
 
-    await settingsPage.navigateToMiningPoolsSettings();
-    await settingsPoolsPage.validateMiningPoolsPageOpened();
-
-    await createPool(settingsPage, settingsPoolsPage, newPoolModal, {
-      poolName,
-      poolUsername,
+    await test.step("Open mining pool settings", async () => {
+      await settingsPage.navigateToMiningPoolsSettings();
+      await settingsPoolsPage.validateMiningPoolsPageOpened();
     });
 
-    await settingsPoolsPage.deletePoolByNameIfVisible(poolName);
-    await settingsPoolsPage.validateTextInToast("Pool deleted");
+    await test.step("Create a pool with the RBAC manage role", async () => {
+      await createPool(settingsPage, settingsPoolsPage, newPoolModal, {
+        poolName,
+        poolUsername,
+      });
+    });
+
+    await test.step("Delete the pool again", async () => {
+      await settingsPoolsPage.deletePoolByNameIfVisible(poolName);
+      await settingsPoolsPage.validateTextInToast("Pool deleted");
+    });
   });
 
   test("Alerts read-only role can view alerts without channel management", async ({ alertsPage, commonSteps }) => {
@@ -119,19 +133,26 @@ test.describe("Proto Fleet - RBAC", () => {
     );
 
     const channelName = generateRandomText(RBAC_ALERT_CHANNEL_PREFIX);
+    markRbacCleanupTargets(test.info(), ["alerts"]);
 
-    await commonSteps.loginAsAdmin({ forceReauth: true });
-    await createAlertChannelAsAdmin(alertsPage, channelName);
-
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Read-only alerts access for RBAC coverage.",
-      permissionKeys: ["alert:read"],
+    await test.step("Create an alert channel as admin", async () => {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
+      await createAlertChannelAsAdmin(alertsPage, channelName);
     });
 
-    await alertsPage.navigateToAlertsSettings();
-    await alertsPage.validateAlertsPageOpened();
-    await alertsPage.validateChannelListed(channelName);
-    await alertsPage.validateAddChannelHidden();
+    await test.step("Provision a read-only alerts role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Read-only alerts access for RBAC coverage.",
+        permissionKeys: ["alert:read"],
+      });
+    });
+
+    await test.step("Validate the channel is visible but channel management stays hidden", async () => {
+      await alertsPage.navigateToAlertsSettings();
+      await alertsPage.validateAlertsPageOpened();
+      await alertsPage.validateChannelListed(channelName);
+      await alertsPage.validateAddChannelHidden();
+    });
   });
 
   test("Alerts manage role can create and delete channels", async ({ alertsPage, commonSteps }) => {
@@ -142,19 +163,27 @@ test.describe("Proto Fleet - RBAC", () => {
     );
 
     const channelName = generateRandomText(RBAC_ALERT_CHANNEL_PREFIX);
+    markRbacCleanupTargets(test.info(), ["alerts"]);
 
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Manage alerts for RBAC coverage.",
-      permissionKeys: ["alert:read", "alert:manage", "miner:read"],
+    await test.step("Provision a manage-capable alerts role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Manage alerts for RBAC coverage.",
+        permissionKeys: ["alert:read", "alert:manage", "miner:read"],
+      });
     });
 
-    await alertsPage.navigateToAlertsSettings();
-    await alertsPage.validateAlertsPageOpened();
-    await alertsPage.openAddChannelModal();
-    await alertsPage.fillWebhookChannel(channelName, REACHABLE_WEBHOOK_URL);
-    await alertsPage.saveChannel();
-    await alertsPage.validateChannelListed(channelName);
-    await alertsPage.deleteChannel(channelName);
+    await test.step("Create a channel from Alerts settings", async () => {
+      await alertsPage.navigateToAlertsSettings();
+      await alertsPage.validateAlertsPageOpened();
+      await alertsPage.openAddChannelModal();
+      await alertsPage.fillWebhookChannel(channelName, REACHABLE_WEBHOOK_URL);
+      await alertsPage.saveChannel();
+      await alertsPage.validateChannelListed(channelName);
+    });
+
+    await test.step("Delete the created channel", async () => {
+      await alertsPage.deleteChannel(channelName);
+    });
   });
 
   test("Schedules read-only role cannot access the Schedules settings surface", async ({
@@ -162,27 +191,39 @@ test.describe("Proto Fleet - RBAC", () => {
     commonSteps,
     settingsSchedulesPage,
   }) => {
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Read-only schedules access for RBAC coverage.",
-      permissionKeys: ["schedule:read"],
+    await test.step("Provision a read-only schedules role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Read-only schedules access for RBAC coverage.",
+        permissionKeys: ["schedule:read"],
+      });
     });
 
-    await validateManageOnlySettingsRouteHidden(page, {
-      route: "/settings/schedules",
-      validateSubmenuHidden: () => settingsSchedulesPage.validateSchedulesSubmenuHidden(),
+    await test.step("Validate the Schedules settings surface stays inaccessible", async () => {
+      await validateManageOnlySettingsRouteHidden(page, {
+        route: "/settings/schedules",
+        validateSubmenuHidden: () => settingsSchedulesPage.validateSchedulesSubmenuHidden(),
+      });
     });
   });
 
   test("Schedules manage role can create and delete schedules", async ({ commonSteps, settingsSchedulesPage }) => {
     const scheduleName = generateRandomText(RBAC_SCHEDULE_PREFIX);
+    markRbacCleanupTargets(test.info(), ["schedules"]);
 
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Manage schedules for RBAC coverage.",
-      permissionKeys: ["schedule:manage", "miner:set_power_target"],
+    await test.step("Provision a manage-capable schedules role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Manage schedules for RBAC coverage.",
+        permissionKeys: ["schedule:manage", "miner:set_power_target"],
+      });
     });
 
-    await createSchedule(settingsSchedulesPage, scheduleName);
-    await settingsSchedulesPage.deleteSchedule(scheduleName);
+    await test.step("Create a schedule", async () => {
+      await createSchedule(settingsSchedulesPage, scheduleName);
+    });
+
+    await test.step("Delete the created schedule", async () => {
+      await settingsSchedulesPage.deleteSchedule(scheduleName);
+    });
   });
 
   test("Curtailment read-only role can view the Energy page without manage controls", async ({
@@ -196,20 +237,27 @@ test.describe("Proto Fleet - RBAC", () => {
     );
 
     const reason = generateRandomText(RBAC_CURTAILMENT_REASON_PREFIX);
+    markRbacCleanupTargets(test.info(), ["curtailment"]);
 
-    await commonSteps.loginAsAdmin({ forceReauth: true });
-    await createCurtailment(energyPage, reason);
-
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Read-only curtailment access for RBAC coverage.",
-      permissionKeys: ["curtailment:read"],
+    await test.step("Create an active curtailment as admin", async () => {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
+      await createCurtailment(energyPage, reason);
     });
 
-    await energyPage.navigateToEnergyPage();
-    await energyPage.validateEnergyPageOpened();
-    await energyPage.validateRunCurtailmentButtonHidden();
-    await energyPage.validateActiveCurtailment(reason);
-    await energyPage.validateActiveCurtailmentManageActionsHidden(reason);
+    await test.step("Provision a read-only curtailment role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Read-only curtailment access for RBAC coverage.",
+        permissionKeys: ["curtailment:read"],
+      });
+    });
+
+    await test.step("Validate the active curtailment is visible without manage controls", async () => {
+      await energyPage.navigateToEnergyPage();
+      await energyPage.validateEnergyPageOpened();
+      await energyPage.validateRunCurtailmentButtonHidden();
+      await energyPage.validateActiveCurtailment(reason);
+      await energyPage.validateActiveCurtailmentManageActionsHidden(reason);
+    });
   });
 
   test("Curtailment manage role can preview, start, and stop a curtailment", async ({ commonSteps, energyPage }) => {
@@ -220,15 +268,23 @@ test.describe("Proto Fleet - RBAC", () => {
     );
 
     const reason = generateRandomText(RBAC_CURTAILMENT_REASON_PREFIX);
+    markRbacCleanupTargets(test.info(), ["curtailment"]);
 
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Manage curtailment for RBAC coverage.",
-      permissionKeys: ["curtailment:manage"],
+    await test.step("Provision a manage-capable curtailment role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Manage curtailment for RBAC coverage.",
+        permissionKeys: ["curtailment:manage"],
+      });
     });
 
-    await createCurtailment(energyPage, reason);
-    await energyPage.stopCurtailment({ reason });
-    await energyPage.waitForCurtailmentToRestore({ reason });
+    await test.step("Create a curtailment", async () => {
+      await createCurtailment(energyPage, reason);
+    });
+
+    await test.step("Stop the curtailment again", async () => {
+      await energyPage.stopCurtailment({ reason });
+      await energyPage.waitForCurtailmentToRestore({ reason });
+    });
   });
 
   test("Curtailment ingest permission reaches the ingest RPC while manage-only is denied", async ({
@@ -240,29 +296,39 @@ test.describe("Proto Fleet - RBAC", () => {
     const deniedReference = generateRandomText("rbac_ingest_denied");
     const allowedReference = generateRandomText("rbac_ingest_allowed");
 
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Manage-only curtailment role for ingest denial coverage.",
-      permissionKeys: ["curtailment:manage"],
+    await test.step("Provision a manage-only curtailment role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Manage-only curtailment role for ingest denial coverage.",
+        permissionKeys: ["curtailment:manage"],
+      });
     });
 
-    const deniedResult = await invokeIngestCurtailmentSignal(page, deniedReference);
-    expectConnectError(deniedResult, "permission_denied");
-
-    const ingestMember = await provisionRoleViaStoredAdminContext(browser, testInfo, {
-      roleDescription: "Ingest-only curtailment role for RPC coverage.",
-      permissionKeys: ["curtailment:ingest"],
+    await test.step("Validate the ingest RPC is denied without curtailment:ingest", async () => {
+      const deniedResult = await invokeIngestCurtailmentSignal(page, deniedReference);
+      expectConnectError(deniedResult, "permission_denied");
     });
 
-    await authPage.logout();
-    await authPage.validateRedirectedToAuth();
-    await commonSteps.completeFirstLoginAsTeamMember({
-      username: ingestMember.username,
-      temporaryPassword: ingestMember.temporaryPassword,
-      newPassword: MEMBER_PASSWORD,
+    const ingestMember = await test.step("Provision an ingest-only curtailment role", async () => {
+      return await provisionRoleViaStoredAdminContext(browser, testInfo, {
+        roleDescription: "Ingest-only curtailment role for RPC coverage.",
+        permissionKeys: ["curtailment:ingest"],
+      });
     });
 
-    const allowedResult = await invokeIngestCurtailmentSignal(page, allowedReference);
-    expectConnectSuccessfulOrUnimplemented(allowedResult);
+    await test.step("Log in as the ingest-only member", async () => {
+      await authPage.logout();
+      await authPage.validateRedirectedToAuth();
+      await commonSteps.completeFirstLoginAsTeamMember({
+        username: ingestMember.username,
+        temporaryPassword: ingestMember.temporaryPassword,
+        newPassword: MEMBER_PASSWORD,
+      });
+    });
+
+    await test.step("Validate the ingest RPC no longer returns a permission error", async () => {
+      const allowedResult = await invokeIngestCurtailmentSignal(page, allowedReference);
+      expectConnectSuccessfulOrUnimplemented(allowedResult);
+    });
   });
 
   test("Sites, buildings, and racks read-only role can view infrastructure without create actions", async ({
@@ -273,37 +339,44 @@ test.describe("Proto Fleet - RBAC", () => {
     const siteName = generateRandomText(RBAC_SITE_PREFIX);
     const buildingName = generateRandomText(RBAC_BUILDING_PREFIX);
     const rackLabel = generateRandomText(RBAC_RACK_PREFIX);
+    markRbacCleanupTargets(test.info(), ["infrastructure"]);
 
-    await commonSteps.loginAsAdmin({ forceReauth: true });
-    await createInfrastructureFixturesAsAdmin(fleetLocationsPage, racksPage, {
-      siteName,
-      buildingName,
-      rackLabel,
-    });
-
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Read-only infrastructure access for RBAC coverage.",
-      permissionKeys: ["site:read", "rack:read"],
+    await test.step("Create infrastructure fixtures as admin", async () => {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
+      await createInfrastructureFixturesAsAdmin(fleetLocationsPage, racksPage, {
+        siteName,
+        buildingName,
+        rackLabel,
+      });
     });
 
-    await fleetLocationsPage.validateSiteRowCounts(siteName, {
-      buildings: 1,
-      racks: 0,
-      miners: 0,
+    await test.step("Provision a read-only infrastructure role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Read-only infrastructure access for RBAC coverage.",
+        permissionKeys: ["site:read", "rack:read"],
+      });
     });
-    await fleetLocationsPage.validateBuildingRowCounts(buildingName, {
-      siteName,
-      racks: 0,
-      miners: 0,
+
+    await test.step("Validate the infrastructure is visible without create controls", async () => {
+      await fleetLocationsPage.validateSiteRowCounts(siteName, {
+        buildings: 1,
+        racks: 0,
+        miners: 0,
+      });
+      await fleetLocationsPage.validateBuildingRowCounts(buildingName, {
+        siteName,
+        racks: 0,
+        miners: 0,
+      });
+      await racksPage.navigateToRacksPage();
+      await racksPage.clickViewList();
+      await racksPage.waitForRackListToLoad({ allowEmpty: false, requireManageAccess: false });
+      await racksPage.validateRackRow(rackLabel, RBAC_RACK_ZONE, 0);
+      await fleetLocationsPage.validateAddSiteButtonHidden();
+      await fleetLocationsPage.validateAddBuildingButtonHidden();
+      await racksPage.navigateToRacksPage();
+      await racksPage.validateAddRackButtonHidden();
     });
-    await racksPage.navigateToRacksPage();
-    await racksPage.clickViewList();
-    await racksPage.waitForRackListToLoad({ allowEmpty: false, requireManageAccess: false });
-    await racksPage.validateRackRow(rackLabel, RBAC_RACK_ZONE, 0);
-    await fleetLocationsPage.validateAddSiteButtonHidden();
-    await fleetLocationsPage.validateAddBuildingButtonHidden();
-    await racksPage.navigateToRacksPage();
-    await racksPage.validateAddRackButtonHidden();
   });
 
   test("Sites, buildings, and racks manage role can create infrastructure", async ({
@@ -314,25 +387,32 @@ test.describe("Proto Fleet - RBAC", () => {
     const siteName = generateRandomText(RBAC_SITE_PREFIX);
     const buildingName = generateRandomText(RBAC_BUILDING_PREFIX);
     const rackLabel = generateRandomText(RBAC_RACK_PREFIX);
+    markRbacCleanupTargets(test.info(), ["infrastructure"]);
 
-    await provisionRoleAndLogin(commonSteps, {
-      roleDescription: "Manage infrastructure for RBAC coverage.",
-      permissionKeys: ["site:read", "site:manage", "rack:read", "rack:manage"],
+    await test.step("Provision a manage-capable infrastructure role", async () => {
+      await provisionRoleAndLogin(commonSteps, {
+        roleDescription: "Manage infrastructure for RBAC coverage.",
+        permissionKeys: ["site:read", "site:manage", "rack:read", "rack:manage"],
+      });
     });
 
-    await fleetLocationsPage.createSite(siteName);
-    await fleetLocationsPage.createBuilding(siteName, buildingName);
-    await createRack(racksPage, rackLabel);
-
-    await fleetLocationsPage.validateSiteRowCounts(siteName, {
-      buildings: 1,
-      racks: 0,
-      miners: 0,
+    await test.step("Create a site, building, and rack", async () => {
+      await fleetLocationsPage.createSite(siteName);
+      await fleetLocationsPage.createBuilding(siteName, buildingName);
+      await createRack(racksPage, rackLabel);
     });
-    await fleetLocationsPage.validateBuildingRowCounts(buildingName, {
-      siteName,
-      racks: 0,
-      miners: 0,
+
+    await test.step("Validate the infrastructure rows were created", async () => {
+      await fleetLocationsPage.validateSiteRowCounts(siteName, {
+        buildings: 1,
+        racks: 0,
+        miners: 0,
+      });
+      await fleetLocationsPage.validateBuildingRowCounts(buildingName, {
+        siteName,
+        racks: 0,
+        miners: 0,
+      });
     });
   });
 });

--- a/client/e2eTests/protoFleet/spec/rbac.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbac.spec.ts
@@ -10,7 +10,6 @@ import {
   createRack,
   createSchedule,
   invokeIngestCurtailmentSignal,
-  markRbacCleanupTargets,
   MEMBER_PASSWORD,
   provisionRoleAndLogin,
   provisionRoleViaStoredAdminContext,
@@ -23,7 +22,6 @@ import {
   RBAC_SCHEDULE_PREFIX,
   RBAC_SITE_PREFIX,
   REACHABLE_WEBHOOK_URL,
-  useRbacHooks,
 } from "../helpers/rbacTestSetup";
 import { generateRandomText } from "../helpers/testDataHelper";
 
@@ -68,7 +66,9 @@ function expectConnectSuccessfulOrUnimplemented(result: { body: string; ok: bool
 }
 
 test.describe("Proto Fleet - RBAC", () => {
-  useRbacHooks();
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
 
   test("Pools read-only role cannot access the Pools settings surface", async ({
     page,
@@ -98,7 +98,6 @@ test.describe("Proto Fleet - RBAC", () => {
   }) => {
     const poolName = generateRandomText(RBAC_POOL_PREFIX);
     const poolUsername = generateRandomText("rbac_pool_user");
-    markRbacCleanupTargets(test.info(), ["pools"]);
 
     await test.step("Provision a manage-capable pools role", async () => {
       await provisionRoleAndLogin(commonSteps, {
@@ -133,7 +132,6 @@ test.describe("Proto Fleet - RBAC", () => {
     );
 
     const channelName = generateRandomText(RBAC_ALERT_CHANNEL_PREFIX);
-    markRbacCleanupTargets(test.info(), ["alerts"]);
 
     await test.step("Create an alert channel as admin", async () => {
       await commonSteps.loginAsAdmin({ forceReauth: true });
@@ -163,7 +161,6 @@ test.describe("Proto Fleet - RBAC", () => {
     );
 
     const channelName = generateRandomText(RBAC_ALERT_CHANNEL_PREFIX);
-    markRbacCleanupTargets(test.info(), ["alerts"]);
 
     await test.step("Provision a manage-capable alerts role", async () => {
       await provisionRoleAndLogin(commonSteps, {
@@ -208,7 +205,6 @@ test.describe("Proto Fleet - RBAC", () => {
 
   test("Schedules manage role can create and delete schedules", async ({ commonSteps, settingsSchedulesPage }) => {
     const scheduleName = generateRandomText(RBAC_SCHEDULE_PREFIX);
-    markRbacCleanupTargets(test.info(), ["schedules"]);
 
     await test.step("Provision a manage-capable schedules role", async () => {
       await provisionRoleAndLogin(commonSteps, {
@@ -237,7 +233,6 @@ test.describe("Proto Fleet - RBAC", () => {
     );
 
     const reason = generateRandomText(RBAC_CURTAILMENT_REASON_PREFIX);
-    markRbacCleanupTargets(test.info(), ["curtailment"]);
 
     await test.step("Create an active curtailment as admin", async () => {
       await commonSteps.loginAsAdmin({ forceReauth: true });
@@ -268,7 +263,6 @@ test.describe("Proto Fleet - RBAC", () => {
     );
 
     const reason = generateRandomText(RBAC_CURTAILMENT_REASON_PREFIX);
-    markRbacCleanupTargets(test.info(), ["curtailment"]);
 
     await test.step("Provision a manage-capable curtailment role", async () => {
       await provisionRoleAndLogin(commonSteps, {
@@ -339,7 +333,6 @@ test.describe("Proto Fleet - RBAC", () => {
     const siteName = generateRandomText(RBAC_SITE_PREFIX);
     const buildingName = generateRandomText(RBAC_BUILDING_PREFIX);
     const rackLabel = generateRandomText(RBAC_RACK_PREFIX);
-    markRbacCleanupTargets(test.info(), ["infrastructure"]);
 
     await test.step("Create infrastructure fixtures as admin", async () => {
       await commonSteps.loginAsAdmin({ forceReauth: true });
@@ -387,7 +380,6 @@ test.describe("Proto Fleet - RBAC", () => {
     const siteName = generateRandomText(RBAC_SITE_PREFIX);
     const buildingName = generateRandomText(RBAC_BUILDING_PREFIX);
     const rackLabel = generateRandomText(RBAC_RACK_PREFIX);
-    markRbacCleanupTargets(test.info(), ["infrastructure"]);
 
     await test.step("Provision a manage-capable infrastructure role", async () => {
       await provisionRoleAndLogin(commonSteps, {

--- a/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacMiners.spec.ts
@@ -3,7 +3,6 @@ import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
 import { installAllSitesInitScript } from "../helpers/fleetLocationsSetup";
 import {
-  cleanupRbacTeamArtifacts,
   ensureVisibleRigMinersAwake,
   provisionRoleAndLoginViaStoredAdminContext,
   selectHashingRigMinerForStopFlow,
@@ -36,10 +35,6 @@ test.describe("Proto Fleet - Miner RBAC", () => {
     await page.goto("/");
   });
 
-  test.afterAll("CLEANUP: delete RBAC team fixtures", async ({ browser }, testInfo) => {
-    await cleanupRbacTeamArtifacts(browser, testInfo);
-  });
-
   test("Miners read-only role can view the miner list and status without mutating action controls", async ({
     browser,
     commonSteps,
@@ -47,6 +42,12 @@ test.describe("Proto Fleet - Miner RBAC", () => {
   }) => {
     let minerIp = "";
     let minerStatus = "";
+
+    await test.step("Prepare a visible hashing Proto rig as admin", async () => {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
+      await commonSteps.goToMinersPage();
+      await ensureVisibleRigMinersAwake(minersPage);
+    });
 
     await test.step("Provision a read-only miner role", async () => {
       await provisionMinerRole(browser, commonSteps, {
@@ -59,11 +60,11 @@ test.describe("Proto Fleet - Miner RBAC", () => {
       await commonSteps.goToMinersPage();
       await minersPage.filterRigMiners();
 
-      minerIp = await minersPage.getAuthenticatedMinerIpAddressByIndex(0);
+      minerIp = await minersPage.getMinerIpAddressByStatus("Hashing");
       minerStatus = (await minersPage.getMinerStatus(minerIp)).trim();
 
       expect(minerIp).not.toBe("");
-      expect(minerStatus).not.toBe("");
+      expect(minerStatus).toBe("Hashing");
     });
 
     await test.step("Verify single-miner mutating controls stay hidden", async () => {

--- a/client/e2eTests/protoFleet/spec/schedulesSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/schedulesSettings.spec.ts
@@ -9,11 +9,18 @@ import { SettingsSchedulesPage } from "../pages/settingsSchedules";
 const SCHEDULE_PREFIX = "schedule_e2e";
 
 test.describe("Proto Fleet - Schedules", () => {
+  let shouldCleanupSchedules = false;
+
   test.beforeEach(async ({ page }) => {
+    shouldCleanupSchedules = false;
     await page.goto("/");
   });
 
   test.afterEach("CLEANUP: Delete schedules created during tests", async ({ browser }, testInfo) => {
+    if (!shouldCleanupSchedules) {
+      return;
+    }
+
     const isMobile = testInfo.project.use?.isMobile ?? false;
     const viewport = testInfo.project.use?.viewport;
     const context = await browser.newContext({ baseURL: testConfig.baseUrl, viewport });
@@ -49,6 +56,7 @@ test.describe("Proto Fleet - Schedules", () => {
     });
 
     await test.step("Create a one-time schedule for one miner", async () => {
+      shouldCleanupSchedules = true;
       await settingsSchedulesPage.clickAddSchedule();
       await settingsSchedulesPage.inputScheduleName(scheduleName);
       await settingsSchedulesPage.selectStartDate(1);
@@ -84,6 +92,7 @@ test.describe("Proto Fleet - Schedules", () => {
 
     await test.step("Delete the schedule", async () => {
       await settingsSchedulesPage.deleteSchedule(updatedScheduleName);
+      shouldCleanupSchedules = false;
     });
   });
 
@@ -100,6 +109,7 @@ test.describe("Proto Fleet - Schedules", () => {
     });
 
     await test.step("Switch to a recurring weekly schedule and validate days are required", async () => {
+      shouldCleanupSchedules = true;
       await settingsSchedulesPage.clickAddSchedule();
       await settingsSchedulesPage.inputScheduleName(scheduleName);
       await settingsSchedulesPage.selectScheduleType("Recurring");

--- a/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
@@ -106,7 +106,7 @@ test.describe("Proto Fleet - Security Settings", () => {
 
     await test.step("Log out", async () => {
       await authPage.logout();
-      await authPage.validateRedirectedToAuth();
+      await authPage.ensureAuthPage();
     });
 
     await test.step("Log in with new username", async () => {
@@ -132,7 +132,7 @@ test.describe("Proto Fleet - Security Settings", () => {
 
     await test.step("Log out", async () => {
       await authPage.logout();
-      await authPage.validateRedirectedToAuth();
+      await authPage.ensureAuthPage();
     });
 
     await test.step("Log in with new password", async () => {

--- a/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/securitySettings.spec.ts
@@ -106,7 +106,7 @@ test.describe("Proto Fleet - Security Settings", () => {
 
     await test.step("Log out", async () => {
       await authPage.logout();
-      await authPage.ensureAuthPage();
+      await authPage.gotoAuthPage();
     });
 
     await test.step("Log in with new username", async () => {
@@ -132,7 +132,7 @@ test.describe("Proto Fleet - Security Settings", () => {
 
     await test.step("Log out", async () => {
       await authPage.logout();
-      await authPage.ensureAuthPage();
+      await authPage.gotoAuthPage();
     });
 
     await test.step("Log in with new password", async () => {


### PR DESCRIPTION
Reviewable diff: +0/-0 across 0 files (all changes are in Playwright test files).

## Summary
This PR makes existing Proto Fleet Playwright coverage easier to read in reports and less expensive to clean up between tests on the same worker. It adds explicit user-flow `test.step(...)` structure to the RBAC coverage and narrows several cleanup hooks so they only run when a test could actually leave persistent state behind.

## How it works
RBAC cleanup now defaults to team-fixture teardown only, and individual RBAC tests opt into extra cleanup targets such as pools, alerts, schedules, curtailment, or infrastructure only when that test creates that kind of fixture. A few standalone specs now track whether they really created an alert channel, schedule, or API key before opening a fresh admin context in `afterEach`, and the miners add/remove recovery hook now only runs after failures, which is the only time later tests on that worker need it.

## Diagrams
```mermaid
flowchart TD
  A["Spec starts"] --> B["Test creates fixture or mutates worker state"]
  B --> C["Spec marks the cleanup target it can leak"]
  C --> D["afterEach reads marked cleanup targets"]
  D --> E["Only relevant cleanup helpers run"]
  E --> F["Next test starts with less hook overhead"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/rbac.spec.ts` | Added explicit `test.step(...)` structure and per-test cleanup target marking. | Main report-readability improvement and the primary consumer of the shared cleanup changes. |
| `client/e2eTests/protoFleet/helpers/rbacTestSetup.ts` | Changed shared RBAC hooks from broad always-run cleanup to per-test target-driven cleanup. | Main CI/runtime improvement; reviewers should confirm we still clean leaked state without over-cleaning. |
| `client/e2eTests/protoFleet/spec/alerts.spec.ts` | Cleanup now runs only if the test saved a channel. | Avoids unnecessary admin cleanup work on clean runs. |
| `client/e2eTests/protoFleet/spec/schedulesSettings.spec.ts` | Cleanup now runs only if the test created a schedule that could persist. | Same pattern as alerts, for a spec that used to always pay hook cost. |
| `client/e2eTests/protoFleet/spec/apiKeysSettings.spec.ts` | Cleanup now runs only if the test created an API key. | Same pattern as alerts/schedules. |
| `client/e2eTests/protoFleet/spec/minersAddRemove.spec.ts` | Recovery hook now runs only after failures. | Keeps the expensive recovery flow for the case that actually threatens later tests. |

## Key technical decisions & trade-offs
- RBAC teardown is now opt-in per resource class instead of unconditional, which cuts hook time but makes the tests responsible for declaring what they can leak.
- The single-spec cleanup hooks still use fresh admin contexts when needed, rather than in-test cleanup everywhere, because that keeps failure recovery reliable while avoiding needless work on passing runs.
- This PR improves report structure only where the current report was especially dense, rather than refactoring every existing spec in one pass.

## Testing & validation
- `eslint` passed on all touched E2E files.
- `client-typecheck` passed during `git push`.
- Playwright runtime verification was attempted on the touched specs, but the local env was serving the Fleet availability page (`"Fleet will be right back"`) instead of the auth form, so full E2E verification is still blocked on env health.
