### PR TITLE
feat(fleet): live-refresh the status modal while open

### DIFF
--- a/client/src/protoFleet/api/useFleet.test.ts
+++ b/client/src/protoFleet/api/useFleet.test.ts
@@ -36,6 +36,13 @@ const makeMiner = (deviceIdentifier: string, workerName = "") =>
     workerName,
   });
 
+const makeTimedMiner = (deviceIdentifier: string, workerName: string, seconds: number) =>
+  create(MinerStateSnapshotSchema, {
+    deviceIdentifier,
+    workerName,
+    timestamp: { seconds: BigInt(seconds), nanos: 0 },
+  });
+
 const makeListResponse = (miners: ReturnType<typeof makeMiner>[]) =>
   create(ListMinerStateSnapshotsResponseSchema, {
     miners,
@@ -173,5 +180,76 @@ describe("useFleet", () => {
     });
 
     expect(result.current.miners).toBe(before);
+  });
+
+  it("keeps a newer merged snapshot when a slower page response resolves afterward", async () => {
+    // Initial page load and the later refetch both return the same older
+    // snapshot (ts=100); a live-modal merge in between carries a newer one.
+    vi.mocked(fleetManagementClient.listMinerStateSnapshots).mockResolvedValue(
+      makeListResponse([makeTimedMiner("miner-1", "worker-old", 100)]),
+    );
+
+    const { result } = renderHook(() => useFleet({ pageSize: 10 }));
+
+    await waitFor(() => {
+      expect(result.current.miners["miner-1"]?.workerName).toBe("worker-old");
+    });
+
+    act(() => {
+      result.current.mergeMiners([makeTimedMiner("miner-1", "worker-fresh", 200)]);
+    });
+    expect(result.current.miners["miner-1"]?.workerName).toBe("worker-fresh");
+
+    // A page poll that resolves after the merge carries the older snapshot; it
+    // must not regress the device back to stale state.
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(fleetManagementClient.listMinerStateSnapshots).toHaveBeenCalledTimes(2);
+    });
+    expect(result.current.miners["miner-1"]?.workerName).toBe("worker-fresh");
+  });
+
+  it("lets a newer page response win over an older existing snapshot", async () => {
+    vi.mocked(fleetManagementClient.listMinerStateSnapshots)
+      .mockResolvedValueOnce(makeListResponse([makeTimedMiner("miner-1", "worker-old", 100)]))
+      .mockResolvedValueOnce(makeListResponse([makeTimedMiner("miner-1", "worker-newer", 300)]));
+
+    const { result } = renderHook(() => useFleet({ pageSize: 10 }));
+
+    await waitFor(() => {
+      expect(result.current.miners["miner-1"]?.workerName).toBe("worker-old");
+    });
+
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.miners["miner-1"]?.workerName).toBe("worker-newer");
+    });
+  });
+
+  it("does not let an older snapshot merge over a newer existing one", async () => {
+    vi.mocked(fleetManagementClient.listMinerStateSnapshots).mockResolvedValue(
+      makeListResponse([makeTimedMiner("miner-1", "worker-fresh", 200)]),
+    );
+
+    const { result } = renderHook(() => useFleet({ pageSize: 10 }));
+
+    await waitFor(() => {
+      expect(result.current.miners["miner-1"]?.workerName).toBe("worker-fresh");
+    });
+
+    const before = result.current.miners;
+
+    act(() => {
+      result.current.mergeMiners([makeTimedMiner("miner-1", "worker-stale", 100)]);
+    });
+
+    expect(result.current.miners).toBe(before);
+    expect(result.current.miners["miner-1"]?.workerName).toBe("worker-fresh");
   });
 });

--- a/client/src/protoFleet/api/useFleet.ts
+++ b/client/src/protoFleet/api/useFleet.ts
@@ -34,6 +34,24 @@ const DEFAULT_PAIRING_STATUSES: PairingStatus[] = [];
 type PendingFetchMode = "refetch" | "refresh";
 
 /**
+ * True when `a` was captured strictly after `b`, per the server-set snapshot
+ * timestamp. The miner map is updated from more than one source — the page
+ * poll (`fetchMinerList`) and out-of-band per-device refreshes (`mergeMiners`,
+ * e.g. the live status modal). Those can resolve out of order, so a slow page
+ * response must not regress a device to an older snapshot than one already
+ * merged. Missing timestamps are treated as not-newer, so callers fall back to
+ * their existing default (the incoming snapshot wins) and behavior is unchanged
+ * for responses without timestamps.
+ */
+const snapshotIsStrictlyNewer = (a: MinerStateSnapshot, b: MinerStateSnapshot): boolean => {
+  const at = a.timestamp;
+  const bt = b.timestamp;
+  if (!at || !bt) return false;
+  if (at.seconds !== bt.seconds) return at.seconds > bt.seconds;
+  return at.nanos > bt.nanos;
+};
+
+/**
  * Hook for managing fleet data with automatic loading, filtering, and pagination.
  *
  * @param options - Configuration options for the hook
@@ -126,10 +144,6 @@ const useFleet = (options: UseFleetOptions = {}) => {
 
         // Always replace (never append) for page-based pagination
         const ids = miners.map((miner) => miner.deviceIdentifier);
-        const minersMap: Record<string, MinerStateSnapshot> = {};
-        miners.forEach((miner) => {
-          minersMap[miner.deviceIdentifier] = miner;
-        });
 
         // Only update state if data actually changed — avoids unnecessary
         // re-renders of MinerList/deviceItems on every poll when data is unchanged.
@@ -141,13 +155,20 @@ const useFleet = (options: UseFleetOptions = {}) => {
           return prev;
         });
         setMiners((prev) => {
-          const prevKeys = Object.keys(prev);
-          if (prevKeys.length !== ids.length) return minersMap;
+          // The page owns membership/order, but per-device it must not regress a
+          // snapshot that was merged more recently out-of-band (e.g. the live
+          // status modal): keep whichever snapshot is newer for each device.
+          let changed = Object.keys(prev).length !== ids.length;
+          const nextMap: Record<string, MinerStateSnapshot> = {};
           for (const miner of miners) {
             const prevMiner = prev[miner.deviceIdentifier];
-            if (!prevMiner || !equals(MinerStateSnapshotSchema, prevMiner, miner)) return minersMap;
+            const chosen = prevMiner && snapshotIsStrictlyNewer(prevMiner, miner) ? prevMiner : miner;
+            nextMap[miner.deviceIdentifier] = chosen;
+            if (!changed && (!prevMiner || !equals(MinerStateSnapshotSchema, prevMiner, chosen))) {
+              changed = true;
+            }
           }
-          return prev;
+          return changed ? nextMap : prev;
         });
         setTotalMiners(responseTotalMiners);
 
@@ -365,7 +386,13 @@ const useFleet = (options: UseFleetOptions = {}) => {
 
       snapshots.forEach((snapshot) => {
         const existingMiner = prev[snapshot.deviceIdentifier];
-        if (existingMiner && equals(MinerStateSnapshotSchema, existingMiner, snapshot)) {
+        // Skip when unchanged, or when what we already have is newer than this
+        // merge — a late/duplicate merge must not overwrite fresher state.
+        if (
+          existingMiner &&
+          (equals(MinerStateSnapshotSchema, existingMiner, snapshot) ||
+            snapshotIsStrictlyNewer(existingMiner, snapshot))
+        ) {
           return;
         }
 

--- a/client/src/protoFleet/api/useRefreshMiners.test.ts
+++ b/client/src/protoFleet/api/useRefreshMiners.test.ts
@@ -58,7 +58,20 @@ describe("useRefreshMiners", () => {
       expect.objectContaining({
         deviceIds: ["miner-1", "miner-2"],
       }),
+      undefined,
     );
+  });
+
+  it("forwards an AbortSignal to the RPC as a call option", async () => {
+    mockRefreshMiners.mockResolvedValue(create(RefreshMinersResponseSchema));
+    const controller = new AbortController();
+
+    const { result } = renderHook(() => useRefreshMiners());
+    await result.current.refreshMiners(["miner-1"], controller.signal);
+
+    expect(mockRefreshMiners).toHaveBeenCalledWith(expect.objectContaining({ deviceIds: ["miner-1"] }), {
+      signal: controller.signal,
+    });
   });
 
   it("tracks devices that are currently refreshing", async () => {

--- a/client/src/protoFleet/api/useRefreshMiners.ts
+++ b/client/src/protoFleet/api/useRefreshMiners.ts
@@ -15,7 +15,7 @@ const useRefreshMiners = () => {
   const [refreshing, setRefreshing] = useState<Set<string>>(() => new Set());
 
   const refreshMiners = useCallback(
-    async (deviceIds: string[]): Promise<RefreshMinersResponse> => {
+    async (deviceIds: string[], signal?: AbortSignal): Promise<RefreshMinersResponse> => {
       if (deviceIds.length === 0) {
         throw new Error("At least one miner is required.");
       }
@@ -33,10 +33,14 @@ const useRefreshMiners = () => {
       });
 
       try {
+        // Forward the caller's AbortSignal so tearing down (modal close / device
+        // switch) actually cancels the in-flight request and frees the shared
+        // server-side refresh slot, rather than only suppressing our own merge.
         return await fleetManagementClient.refreshMiners(
           create(RefreshMinersRequestSchema, {
             deviceIds,
           }),
+          signal ? { signal } : undefined,
         );
       } catch (error) {
         handleAuthErrors({ error });

--- a/client/src/protoFleet/components/StatusModal/StatusModal.liveRefresh.test.tsx
+++ b/client/src/protoFleet/components/StatusModal/StatusModal.liveRefresh.test.tsx
@@ -11,13 +11,16 @@ import {
 // Capture the tick the modal hands to the live-refresh hook so we can drive it
 // deterministically without wiring up real timers/visibility here — that
 // lifecycle is covered by useModalLiveRefresh.test.ts.
-let capturedOnTick: (() => Promise<void>) | null = null;
+let capturedOnTick: ((signal: AbortSignal) => Promise<void>) | null = null;
 vi.mock("./hooks/useModalLiveRefresh", () => ({
-  useModalLiveRefresh: (opts: { onTick: () => Promise<void> }) => {
+  useModalLiveRefresh: (opts: { onTick: (signal: AbortSignal) => Promise<void> }) => {
     capturedOnTick = opts.onTick;
     return { isPaused: false, resume: vi.fn() };
   },
 }));
+
+// A not-yet-aborted signal for the happy-path ticks.
+const liveSignal = () => new AbortController().signal;
 
 const { mockRefreshMiners, mockRefetchErrors } = vi.hoisted(() => ({
   mockRefreshMiners: vi.fn(),
@@ -66,7 +69,7 @@ describe("ProtoFleetStatusModal live refresh wiring", () => {
     );
 
     expect(capturedOnTick).toBeTypeOf("function");
-    await capturedOnTick!();
+    await capturedOnTick!(liveSignal());
 
     expect(mockRefreshMiners).toHaveBeenCalledWith(["miner-1"]);
     expect(onMergeMiners).toHaveBeenCalledWith([snapshot]);
@@ -81,7 +84,7 @@ describe("ProtoFleetStatusModal live refresh wiring", () => {
       <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-1" miner={miner} onMergeMiners={onMergeMiners} />,
     );
 
-    await capturedOnTick!();
+    await capturedOnTick!(liveSignal());
 
     expect(onMergeMiners).not.toHaveBeenCalled();
     expect(mockRefetchErrors).toHaveBeenCalledTimes(1);
@@ -95,9 +98,29 @@ describe("ProtoFleetStatusModal live refresh wiring", () => {
       <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-1" miner={miner} onMergeMiners={onMergeMiners} />,
     );
 
-    await capturedOnTick!();
+    await capturedOnTick!(liveSignal());
 
     expect(onMergeMiners).not.toHaveBeenCalled();
     expect(mockRefetchErrors).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not merge or refetch when the tick was aborted mid-flight", async () => {
+    const snapshot = create(MinerStateSnapshotSchema, { deviceIdentifier: "miner-1", name: "Miner 1 (fresh)" });
+    mockRefreshMiners.mockResolvedValue(create(RefreshMinersResponseSchema, { snapshots: [snapshot], errors: {} }));
+    const onMergeMiners = vi.fn();
+
+    render(
+      <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-1" miner={miner} onMergeMiners={onMergeMiners} />,
+    );
+
+    // Simulate the loop tearing down (modal close / device switch) before the
+    // in-flight refresh resolves: the aborted response must not touch shared state.
+    const controller = new AbortController();
+    controller.abort();
+    await capturedOnTick!(controller.signal);
+
+    expect(mockRefreshMiners).toHaveBeenCalledWith(["miner-1"]);
+    expect(onMergeMiners).not.toHaveBeenCalled();
+    expect(mockRefetchErrors).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoFleet/components/StatusModal/StatusModal.liveRefresh.test.tsx
+++ b/client/src/protoFleet/components/StatusModal/StatusModal.liveRefresh.test.tsx
@@ -71,7 +71,7 @@ describe("ProtoFleetStatusModal live refresh wiring", () => {
     expect(capturedOnTick).toBeTypeOf("function");
     await capturedOnTick!(liveSignal());
 
-    expect(mockRefreshMiners).toHaveBeenCalledWith(["miner-1"]);
+    expect(mockRefreshMiners).toHaveBeenCalledWith(["miner-1"], expect.any(AbortSignal));
     expect(onMergeMiners).toHaveBeenCalledWith([snapshot]);
     expect(mockRefetchErrors).toHaveBeenCalledTimes(1);
   });
@@ -119,8 +119,38 @@ describe("ProtoFleetStatusModal live refresh wiring", () => {
     controller.abort();
     await capturedOnTick!(controller.signal);
 
-    expect(mockRefreshMiners).toHaveBeenCalledWith(["miner-1"]);
+    // The aborted signal is forwarded to the request so it can actually cancel.
+    expect(mockRefreshMiners).toHaveBeenCalledWith(["miner-1"], controller.signal);
     expect(onMergeMiners).not.toHaveBeenCalled();
     expect(mockRefetchErrors).not.toHaveBeenCalled();
+  });
+
+  it("keeps the modal mounted when the device drops out of the filtered page map", () => {
+    const { rerender, queryByTestId } = render(
+      <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-1" miner={miner} onMergeMiners={vi.fn()} />,
+    );
+    expect(queryByTestId("shared-status-modal")).not.toBeNull();
+
+    // A page poll filters this device out: the prop goes undefined while the
+    // modal's subject (deviceId) is unchanged. The last-known snapshot must keep
+    // the modal on screen instead of blanking until the next merge re-adds it.
+    rerender(
+      <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-1" miner={undefined} onMergeMiners={vi.fn()} />,
+    );
+    expect(queryByTestId("shared-status-modal")).not.toBeNull();
+  });
+
+  it("does not show a stale subject after switching to a device with no snapshot yet", () => {
+    const { rerender, queryByTestId } = render(
+      <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-1" miner={miner} onMergeMiners={vi.fn()} />,
+    );
+    expect(queryByTestId("shared-status-modal")).not.toBeNull();
+
+    // Switching to a different device before its snapshot arrives must drop the
+    // previous subject rather than render the wrong miner's data.
+    rerender(
+      <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-2" miner={undefined} onMergeMiners={vi.fn()} />,
+    );
+    expect(queryByTestId("shared-status-modal")).toBeNull();
   });
 });

--- a/client/src/protoFleet/components/StatusModal/StatusModal.liveRefresh.test.tsx
+++ b/client/src/protoFleet/components/StatusModal/StatusModal.liveRefresh.test.tsx
@@ -1,0 +1,103 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import { ProtoFleetStatusModal } from ".";
+import {
+  MinerStateSnapshotSchema,
+  RefreshMinersResponseSchema,
+} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+
+// Capture the tick the modal hands to the live-refresh hook so we can drive it
+// deterministically without wiring up real timers/visibility here — that
+// lifecycle is covered by useModalLiveRefresh.test.ts.
+let capturedOnTick: (() => Promise<void>) | null = null;
+vi.mock("./hooks/useModalLiveRefresh", () => ({
+  useModalLiveRefresh: (opts: { onTick: () => Promise<void> }) => {
+    capturedOnTick = opts.onTick;
+    return { isPaused: false, resume: vi.fn() };
+  },
+}));
+
+const { mockRefreshMiners, mockRefetchErrors } = vi.hoisted(() => ({
+  mockRefreshMiners: vi.fn(),
+  mockRefetchErrors: vi.fn(),
+}));
+
+vi.mock("@/protoFleet/api/useRefreshMiners", () => ({
+  default: () => ({ refreshMiners: mockRefreshMiners, refreshing: new Set<string>() }),
+}));
+
+vi.mock("@/protoFleet/api/useDeviceErrors", () => ({
+  useDeviceErrors: () => ({
+    errorsByDevice: {},
+    isLoading: false,
+    hasLoaded: true,
+    error: null,
+    refetch: mockRefetchErrors,
+  }),
+}));
+
+vi.mock("@/protoFleet/api/useMinerCommand", () => ({
+  useMinerCommand: () => ({ startMining: vi.fn() }),
+}));
+
+// The shared modal chrome is irrelevant to the refresh wiring.
+vi.mock("@/shared/components/StatusModal", () => ({
+  StatusModal: () => <div data-testid="shared-status-modal" />,
+}));
+
+const miner = create(MinerStateSnapshotSchema, { deviceIdentifier: "miner-1", name: "Miner 1" });
+
+describe("ProtoFleetStatusModal live refresh wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnTick = null;
+    mockRefetchErrors.mockResolvedValue(undefined);
+  });
+
+  it("merges refreshed snapshots and refetches errors on each tick", async () => {
+    const snapshot = create(MinerStateSnapshotSchema, { deviceIdentifier: "miner-1", name: "Miner 1 (fresh)" });
+    mockRefreshMiners.mockResolvedValue(create(RefreshMinersResponseSchema, { snapshots: [snapshot], errors: {} }));
+    const onMergeMiners = vi.fn();
+
+    render(
+      <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-1" miner={miner} onMergeMiners={onMergeMiners} />,
+    );
+
+    expect(capturedOnTick).toBeTypeOf("function");
+    await capturedOnTick!();
+
+    expect(mockRefreshMiners).toHaveBeenCalledWith(["miner-1"]);
+    expect(onMergeMiners).toHaveBeenCalledWith([snapshot]);
+    expect(mockRefetchErrors).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the last-good snapshot when a refresh fails, but still refetches errors", async () => {
+    mockRefreshMiners.mockRejectedValue(new Error("network"));
+    const onMergeMiners = vi.fn();
+
+    render(
+      <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-1" miner={miner} onMergeMiners={onMergeMiners} />,
+    );
+
+    await capturedOnTick!();
+
+    expect(onMergeMiners).not.toHaveBeenCalled();
+    expect(mockRefetchErrors).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not merge when the refresh returns no snapshots", async () => {
+    mockRefreshMiners.mockResolvedValue(create(RefreshMinersResponseSchema, { snapshots: [], errors: {} }));
+    const onMergeMiners = vi.fn();
+
+    render(
+      <ProtoFleetStatusModal open onClose={vi.fn()} deviceId="miner-1" miner={miner} onMergeMiners={onMergeMiners} />,
+    );
+
+    await capturedOnTick!();
+
+    expect(onMergeMiners).not.toHaveBeenCalled();
+    expect(mockRefetchErrors).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/protoFleet/components/StatusModal/StatusModal.tsx
+++ b/client/src/protoFleet/components/StatusModal/StatusModal.tsx
@@ -70,20 +70,28 @@ const ProtoFleetStatusModal = ({
   // freshest snapshot flows back in through the `miner` prop once the parent
   // fleet map is updated via onMergeMiners.
   const { refreshMiners } = useRefreshMiners();
-  const handleLiveRefreshTick = useCallback(async () => {
-    if (!deviceId) return;
-    try {
-      const response = await refreshMiners([deviceId]);
-      if (response.snapshots.length > 0) {
-        onMergeMiners?.(response.snapshots);
+  const handleLiveRefreshTick = useCallback(
+    async (signal: AbortSignal) => {
+      if (!deviceId) return;
+      try {
+        const response = await refreshMiners([deviceId]);
+        // Bail if the modal closed / switched devices while this was in flight —
+        // merging now would clobber the newer modal's fresh state in the shared map.
+        if (signal.aborted) return;
+        if (response.snapshots.length > 0) {
+          onMergeMiners?.(response.snapshots);
+        }
+      } catch {
+        // Auth errors are surfaced inside useRefreshMiners; on any failure we keep
+        // the last-good snapshot visible and let the next tick retry.
       }
-    } catch {
-      // Auth errors are surfaced inside useRefreshMiners; on any failure we keep
-      // the last-good snapshot visible and let the next tick retry.
-    }
-    // Errors refresh independently of the snapshot merge.
-    await refetchErrors();
-  }, [deviceId, refreshMiners, onMergeMiners, refetchErrors]);
+      // Errors refresh independently of the snapshot merge.
+      if (!signal.aborted) {
+        await refetchErrors();
+      }
+    },
+    [deviceId, refreshMiners, onMergeMiners, refetchErrors],
+  );
 
   useModalLiveRefresh({
     enabled: isVisible && !!deviceId,

--- a/client/src/protoFleet/components/StatusModal/StatusModal.tsx
+++ b/client/src/protoFleet/components/StatusModal/StatusModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { create } from "@bufbuild/protobuf";
+import { useModalLiveRefresh } from "./hooks/useModalLiveRefresh";
 import type { ComponentAddress, ProtoFleetStatusModalProps } from "./types";
 import {
   buildComponentStatusProps,
@@ -14,6 +15,7 @@ import { StartMiningRequestSchema } from "@/protoFleet/api/generated/minercomman
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { useDeviceErrors } from "@/protoFleet/api/useDeviceErrors";
 import { useMinerCommand } from "@/protoFleet/api/useMinerCommand";
+import useRefreshMiners from "@/protoFleet/api/useRefreshMiners";
 import { createDeviceSelector } from "@/protoFleet/features/fleetManagement/utils/deviceSelector";
 
 import { variants } from "@/shared/components/Button";
@@ -52,6 +54,7 @@ const ProtoFleetStatusModal = ({
   miner,
   componentAddress,
   showBackButton = true,
+  onMergeMiners,
 }: ProtoFleetStatusModalProps) => {
   const isVisible = open ?? true;
 
@@ -60,7 +63,33 @@ const ProtoFleetStatusModal = ({
 
   // Fetch errors for this device when modal is visible
   const modalDeviceIds = useMemo(() => (isVisible && deviceId ? [deviceId] : EMPTY_DEVICE_IDS), [isVisible, deviceId]);
-  const { errorsByDevice } = useDeviceErrors(modalDeviceIds);
+  const { errorsByDevice, refetch: refetchErrors } = useDeviceErrors(modalDeviceIds);
+
+  // Live refresh: while the modal is open, re-poll this miner's snapshot and
+  // errors so on-device remediation reflects here without a close/reopen. The
+  // freshest snapshot flows back in through the `miner` prop once the parent
+  // fleet map is updated via onMergeMiners.
+  const { refreshMiners } = useRefreshMiners();
+  const handleLiveRefreshTick = useCallback(async () => {
+    if (!deviceId) return;
+    try {
+      const response = await refreshMiners([deviceId]);
+      if (response.snapshots.length > 0) {
+        onMergeMiners?.(response.snapshots);
+      }
+    } catch {
+      // Auth errors are surfaced inside useRefreshMiners; on any failure we keep
+      // the last-good snapshot visible and let the next tick retry.
+    }
+    // Errors refresh independently of the snapshot merge.
+    await refetchErrors();
+  }, [deviceId, refreshMiners, onMergeMiners, refetchErrors]);
+
+  useModalLiveRefresh({
+    enabled: isVisible && !!deviceId,
+    restartKey: deviceId,
+    onTick: handleLiveRefreshTick,
+  });
 
   const handleClose = useCallback(() => {
     setComponent(componentAddress);

--- a/client/src/protoFleet/components/StatusModal/StatusModal.tsx
+++ b/client/src/protoFleet/components/StatusModal/StatusModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { create } from "@bufbuild/protobuf";
 import { useModalLiveRefresh } from "./hooks/useModalLiveRefresh";
 import type { ComponentAddress, ProtoFleetStatusModalProps } from "./types";
@@ -10,7 +10,10 @@ import {
   transformFleetErrorsToShared,
 } from "./utils";
 import { ComponentType as ErrorComponentType, type ErrorMessage } from "@/protoFleet/api/generated/errors/v1/errors_pb";
-import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import {
+  type MinerStateSnapshot,
+  PairingStatus,
+} from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { StartMiningRequestSchema } from "@/protoFleet/api/generated/minercommand/v1/command_pb";
 import { DeviceStatus } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
 import { useDeviceErrors } from "@/protoFleet/api/useDeviceErrors";
@@ -58,6 +61,22 @@ const ProtoFleetStatusModal = ({
 }: ProtoFleetStatusModalProps) => {
   const isVisible = open ?? true;
 
+  // Decouple the modal's subject from the filtered page map. A page poll can
+  // drop this device from the shared `miners` map (e.g. remediation moves it
+  // out of an active status filter); reading the prop directly would blank the
+  // modal and then flicker it back when the next live-refresh merge re-adds the
+  // device. Holding the last-known snapshot for the current deviceId keeps the
+  // modal stable while each tick still refreshes it through the prop.
+  const lastKnownMinerRef = useRef<MinerStateSnapshot | undefined>(undefined);
+  if (miner?.deviceIdentifier === deviceId) {
+    lastKnownMinerRef.current = miner;
+  } else if (lastKnownMinerRef.current?.deviceIdentifier !== deviceId) {
+    // The modal switched to a different device before its snapshot arrived —
+    // drop the previous subject so we never show another device's data.
+    lastKnownMinerRef.current = undefined;
+  }
+  const activeMiner = miner ?? lastKnownMinerRef.current;
+
   // Component navigation state
   const [component, setComponent] = useState<ComponentAddress | undefined>(componentAddress);
 
@@ -74,7 +93,7 @@ const ProtoFleetStatusModal = ({
     async (signal: AbortSignal) => {
       if (!deviceId) return;
       try {
-        const response = await refreshMiners([deviceId]);
+        const response = await refreshMiners([deviceId], signal);
         // Bail if the modal closed / switched devices while this was in flight —
         // merging now would clobber the newer modal's fresh state in the shared map.
         if (signal.aborted) return;
@@ -175,14 +194,14 @@ const ProtoFleetStatusModal = ({
   const sharedErrors = useMemo(() => transformFleetErrorsToShared(groupedErrors), [groupedErrors]);
 
   // Determine status flags from DeviceStatus and PairingStatus
-  const needsAuthentication = miner?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED;
-  const isOffline = miner?.deviceStatus === DeviceStatus.OFFLINE;
+  const needsAuthentication = activeMiner?.pairingStatus === PairingStatus.AUTHENTICATION_NEEDED;
+  const isOffline = activeMiner?.deviceStatus === DeviceStatus.OFFLINE;
   // When authentication is needed, we can't trust INACTIVE (or MAINTENANCE) status
   // (could be sleeping OR showing as inactive/maintenance because we can't authenticate)
   const isSleeping =
-    (miner?.deviceStatus === DeviceStatus.INACTIVE || miner?.deviceStatus === DeviceStatus.MAINTENANCE) &&
+    (activeMiner?.deviceStatus === DeviceStatus.INACTIVE || activeMiner?.deviceStatus === DeviceStatus.MAINTENANCE) &&
     !needsAuthentication;
-  const needsMiningPool = miner?.deviceStatus === DeviceStatus.NEEDS_MINING_POOL;
+  const needsMiningPool = activeMiner?.deviceStatus === DeviceStatus.NEEDS_MINING_POOL;
 
   // Compute summary using shared hook (replaces API-provided summary)
   const summary = useMinerStatusSummary(sharedErrors, isSleeping, isOffline, needsAuthentication, needsMiningPool);
@@ -206,7 +225,7 @@ const ProtoFleetStatusModal = ({
     // Check if miner is sleeping (offline state in fleet context)
     // Don't show wake button if authentication is needed (can't trust INACTIVE/MAINTENANCE status)
     const isMinersleeping =
-      (miner?.deviceStatus === DeviceStatus.INACTIVE || miner?.deviceStatus === DeviceStatus.MAINTENANCE) &&
+      (activeMiner?.deviceStatus === DeviceStatus.INACTIVE || activeMiner?.deviceStatus === DeviceStatus.MAINTENANCE) &&
       !needsAuthentication;
 
     // Build buttons
@@ -240,14 +259,14 @@ const ProtoFleetStatusModal = ({
         needsAuthentication,
         needsMiningPool,
       },
-      title: `${miner?.name || deviceId} status`,
+      title: `${activeMiner?.name || deviceId} status`,
       buttons,
       onDismiss: handleClose,
     };
   }, [
     groupedErrors,
     summary,
-    miner,
+    activeMiner,
     deviceId,
     handleWakeMiner,
     handleClose,
@@ -262,7 +281,7 @@ const ProtoFleetStatusModal = ({
       const { componentType: type, componentId: id } = address;
 
       // Build component status props using the miner data and errors
-      const props = buildComponentStatusProps(miner, type, id, allErrors);
+      const props = buildComponentStatusProps(activeMiner, type, id, allErrors);
 
       if (!props) {
         // Return undefined if component not found
@@ -286,11 +305,11 @@ const ProtoFleetStatusModal = ({
         onNavigateBack: () => setComponent(undefined),
       };
     },
-    [miner, handleClose, allErrors],
+    [activeMiner, handleClose, allErrors],
   );
 
   // Don't render if no miner data
-  if (!miner) {
+  if (!activeMiner) {
     return null;
   }
 

--- a/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.test.ts
+++ b/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.test.ts
@@ -175,4 +175,32 @@ describe("useModalLiveRefresh", () => {
     act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS));
     expect(onTick).toHaveBeenCalledTimes(2);
   });
+
+  it("aborts the tick's signal on unmount so a late response can be ignored", () => {
+    let signal: AbortSignal | undefined;
+    const onTick = vi.fn((s: AbortSignal) => {
+      signal = s;
+    });
+    const { unmount } = renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+    expect(signal?.aborted).toBe(false);
+
+    unmount();
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("aborts the previous tick's signal when restartKey changes", () => {
+    const signals: AbortSignal[] = [];
+    const onTick = vi.fn((s: AbortSignal) => {
+      signals.push(s);
+    });
+    const { rerender } = renderHook(({ key }) => useModalLiveRefresh({ enabled: true, onTick, restartKey: key }), {
+      initialProps: { key: "miner-1" },
+    });
+
+    rerender({ key: "miner-2" });
+
+    // First device's signal aborts; the new device's is still live.
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+  });
 });

--- a/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.test.ts
+++ b/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.test.ts
@@ -1,0 +1,134 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MODAL_IDLE_CEILING_MS, MODAL_REFRESH_INTERVAL_MS, useModalLiveRefresh } from "./useModalLiveRefresh";
+
+const setVisibility = (state: "visible" | "hidden") => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+};
+
+describe("useModalLiveRefresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    setVisibility("visible");
+  });
+
+  it("fires an immediate tick on open", () => {
+    const onTick = vi.fn();
+    renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+
+    expect(onTick).toHaveBeenCalledTimes(1);
+  });
+
+  it("ticks again after the interval elapses", () => {
+    const onTick = vi.fn();
+    renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+
+    act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS));
+    expect(onTick).toHaveBeenCalledTimes(2);
+
+    act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS));
+    expect(onTick).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not tick while enabled is false", () => {
+    const onTick = vi.fn();
+    renderHook(() => useModalLiveRefresh({ enabled: false, onTick }));
+
+    act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS * 3));
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it("suspends ticks while the tab is hidden and catches up on return", () => {
+    const onTick = vi.fn();
+    renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+    expect(onTick).toHaveBeenCalledTimes(1); // immediate open tick
+
+    act(() => setVisibility("hidden"));
+    act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS * 3));
+    expect(onTick).toHaveBeenCalledTimes(1); // no ticks while hidden
+
+    act(() => setVisibility("visible"));
+    expect(onTick).toHaveBeenCalledTimes(2); // immediate catch-up fetch
+
+    act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS));
+    expect(onTick).toHaveBeenCalledTimes(3); // cadence resumes
+  });
+
+  it("pauses after the idle ceiling and resumes on interaction", () => {
+    const onTick = vi.fn();
+    const { result } = renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+
+    // Advance past the idle ceiling without any interaction.
+    act(() => vi.advanceTimersByTime(MODAL_IDLE_CEILING_MS + MODAL_REFRESH_INTERVAL_MS));
+    expect(result.current.isPaused).toBe(true);
+
+    const callsAtPause = onTick.mock.calls.length;
+    act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS * 3));
+    expect(onTick).toHaveBeenCalledTimes(callsAtPause); // no ticks while paused
+
+    // Any interaction resumes with an immediate tick.
+    act(() => document.dispatchEvent(new Event("mousemove")));
+    expect(result.current.isPaused).toBe(false);
+    expect(onTick).toHaveBeenCalledTimes(callsAtPause + 1);
+
+    act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS));
+    expect(onTick).toHaveBeenCalledTimes(callsAtPause + 2);
+  });
+
+  it("keeps ticking as long as the operator interacts within the ceiling", () => {
+    const onTick = vi.fn();
+    const { result } = renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+
+    // Interact just before each ceiling boundary so it never pauses.
+    for (let i = 0; i < 3; i++) {
+      act(() => vi.advanceTimersByTime(MODAL_IDLE_CEILING_MS - MODAL_REFRESH_INTERVAL_MS));
+      act(() => document.dispatchEvent(new Event("keydown")));
+    }
+    expect(result.current.isPaused).toBe(false);
+  });
+
+  it("resumes a paused loop via the returned resume()", () => {
+    const onTick = vi.fn();
+    const { result } = renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+
+    act(() => vi.advanceTimersByTime(MODAL_IDLE_CEILING_MS + MODAL_REFRESH_INTERVAL_MS));
+    expect(result.current.isPaused).toBe(true);
+
+    const callsAtPause = onTick.mock.calls.length;
+    act(() => result.current.resume());
+    expect(result.current.isPaused).toBe(false);
+    expect(onTick).toHaveBeenCalledTimes(callsAtPause + 1);
+  });
+
+  it("clears the interval on unmount", () => {
+    const onTick = vi.fn();
+    const { unmount } = renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+
+    unmount();
+    const callsAtUnmount = onTick.mock.calls.length;
+    act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS * 3));
+    expect(onTick).toHaveBeenCalledTimes(callsAtUnmount);
+  });
+
+  it("restarts with an immediate tick when restartKey changes", () => {
+    const onTick = vi.fn();
+    const { rerender } = renderHook(({ key }) => useModalLiveRefresh({ enabled: true, onTick, restartKey: key }), {
+      initialProps: { key: "miner-1" },
+    });
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    rerender({ key: "miner-2" });
+    expect(onTick).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.test.ts
+++ b/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.test.ts
@@ -131,4 +131,48 @@ describe("useModalLiveRefresh", () => {
     rerender({ key: "miner-2" });
     expect(onTick).toHaveBeenCalledTimes(2);
   });
+
+  it("does not start an overlapping tick while a slow refresh is in flight", async () => {
+    let resolveTick: () => void = () => {};
+    const onTick = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTick = resolve;
+        }),
+    );
+    renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+    expect(onTick).toHaveBeenCalledTimes(1); // immediate tick, now in flight
+
+    // Interval fires repeatedly but the first tick hasn't resolved — no new call.
+    await act(async () => {
+      vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS * 3);
+    });
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    // Once the in-flight tick resolves, the next interval may run again.
+    await act(async () => {
+      resolveTick();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS);
+    });
+    expect(onTick).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not advance the idle ceiling while the tab is hidden", () => {
+    const onTick = vi.fn();
+    setVisibility("hidden");
+    const { result } = renderHook(() => useModalLiveRefresh({ enabled: true, onTick }));
+    expect(onTick).toHaveBeenCalledTimes(0); // immediate tick skipped while hidden
+
+    // Stay hidden well past the idle ceiling — the loop must NOT pause.
+    act(() => vi.advanceTimersByTime(MODAL_IDLE_CEILING_MS + MODAL_REFRESH_INTERVAL_MS * 2));
+    expect(result.current.isPaused).toBe(false);
+
+    // Returning to the foreground catches up and resumes rather than staying paused.
+    act(() => setVisibility("visible"));
+    expect(onTick).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(MODAL_REFRESH_INTERVAL_MS));
+    expect(onTick).toHaveBeenCalledTimes(2);
+  });
 });

--- a/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.ts
+++ b/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.ts
@@ -16,8 +16,14 @@ const INTERACTION_EVENTS = ["mousemove", "keydown", "click", "scroll"] as const;
 interface UseModalLiveRefreshOptions {
   /** Poll only while true (typically `isVisible && !!deviceId`). */
   enabled: boolean;
-  /** Runs immediately on open, on each tick, and on foreground/idle resume. */
-  onTick: () => void | Promise<void>;
+  /**
+   * Runs immediately on open, on each tick, and on foreground/idle resume.
+   * Receives an `AbortSignal` that fires when this loop is torn down (modal
+   * close, `restartKey` change, unmount); an async tick must check
+   * `signal.aborted` after awaiting and skip any shared side effects (e.g.
+   * merging into a shared store) so a late response can't clobber newer state.
+   */
+  onTick: (signal: AbortSignal) => void | Promise<void>;
   /**
    * Changing this restarts the loop with an immediate tick — pass the device id
    * so switching the modal's subject fetches fresh data right away.
@@ -72,6 +78,11 @@ export const useModalLiveRefresh = ({
     let lastInteraction = Date.now();
     let paused = false;
     let inFlight = false;
+    // Aborted on cleanup so a tick still awaiting when this loop tears down can
+    // be ignored by onTick instead of merging stale data after the next loop's
+    // fresh fetch. The in-flight guard alone is local to this run and can't stop
+    // an already-started async tick from resuming.
+    const abortController = new AbortController();
 
     const runTick = () => {
       // Skip work the operator can't see; the visibility handler catches them up.
@@ -80,7 +91,7 @@ export const useModalLiveRefresh = ({
       // second one. Overlapping ticks would let a slow older response merge
       // after a newer one and regress the modal/list back to stale status.
       if (inFlight) return;
-      const result = onTickRef.current();
+      const result = onTickRef.current(abortController.signal);
       // Only an async tick can still be running when the next interval fires; a
       // synchronous tick has already completed, so nothing to guard.
       if (result && typeof (result as Promise<void>).then === "function") {
@@ -157,6 +168,7 @@ export const useModalLiveRefresh = ({
     );
 
     return () => {
+      abortController.abort();
       stopInterval();
       document.removeEventListener("visibilitychange", handleVisibility);
       INTERACTION_EVENTS.forEach((event) => document.removeEventListener(event, handleInteraction, { capture: true }));

--- a/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.ts
+++ b/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Cadence of the recurring refresh while the modal is open and foregrounded. */
+export const MODAL_REFRESH_INTERVAL_MS = 10_000;
+
+/**
+ * After this long without any user interaction inside the document, the poll
+ * pauses so an abandoned-but-open modal doesn't hammer the backend forever.
+ * Any interaction (or an explicit `resume()`) restarts it with an immediate tick.
+ */
+export const MODAL_IDLE_CEILING_MS = 10 * 60_000;
+
+/** Interactions that count as "the operator is still watching this modal". */
+const INTERACTION_EVENTS = ["mousemove", "keydown", "click", "scroll"] as const;
+
+interface UseModalLiveRefreshOptions {
+  /** Poll only while true (typically `isVisible && !!deviceId`). */
+  enabled: boolean;
+  /** Runs immediately on open, on each tick, and on foreground/idle resume. */
+  onTick: () => void | Promise<void>;
+  /**
+   * Changing this restarts the loop with an immediate tick — pass the device id
+   * so switching the modal's subject fetches fresh data right away.
+   */
+  restartKey?: string;
+  intervalMs?: number;
+  idleCeilingMs?: number;
+}
+
+interface UseModalLiveRefreshReturn {
+  /** True once the idle ceiling has been hit and the poll has stopped. */
+  isPaused: boolean;
+  /** Manually resume a poll paused by the idle ceiling (immediate tick). */
+  resume: () => void;
+}
+
+/**
+ * Drives a modal's live-refresh loop: one immediate fetch on open, then a
+ * recurring tick. Ticks are suspended while the tab is hidden and the whole
+ * loop pauses after an idle ceiling. All timers and listeners are torn down
+ * when the modal closes (`enabled` goes false) or the component unmounts.
+ *
+ * The loop is intentionally self-contained so `StatusModal` stays declarative
+ * and the lifecycle is testable in isolation.
+ */
+export const useModalLiveRefresh = ({
+  enabled,
+  onTick,
+  restartKey,
+  intervalMs = MODAL_REFRESH_INTERVAL_MS,
+  idleCeilingMs = MODAL_IDLE_CEILING_MS,
+}: UseModalLiveRefreshOptions): UseModalLiveRefreshReturn => {
+  const [isPaused, setIsPaused] = useState(false);
+
+  // Keep the latest tick without restarting the loop when its identity changes.
+  const onTickRef = useRef(onTick);
+  onTickRef.current = onTick;
+
+  // Filled in by the active effect so the stable `resume` can reach its internals.
+  const resumeRef = useRef<() => void>(() => {});
+  const resume = useCallback(() => resumeRef.current(), []);
+
+  useEffect(() => {
+    if (!enabled) {
+      // Reset when the modal closes so a fresh open never starts paused.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing UI state to the (torn-down) external timer loop
+      setIsPaused(false);
+      return;
+    }
+
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let lastInteraction = Date.now();
+    let paused = false;
+
+    const runTick = () => {
+      // Skip work the operator can't see; the visibility handler catches them up.
+      if (document.visibilityState !== "visible") return;
+      void onTickRef.current();
+    };
+
+    const stopInterval = () => {
+      if (interval !== null) {
+        clearInterval(interval);
+        interval = null;
+      }
+    };
+
+    const startInterval = () => {
+      stopInterval();
+      interval = setInterval(() => {
+        if (Date.now() - lastInteraction >= idleCeilingMs) {
+          paused = true;
+          stopInterval();
+          setIsPaused(true);
+          return;
+        }
+        runTick();
+      }, intervalMs);
+    };
+
+    const start = () => {
+      paused = false;
+      setIsPaused(false);
+      lastInteraction = Date.now();
+      runTick();
+      startInterval();
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState !== "visible") {
+        stopInterval();
+        return;
+      }
+      // Back in the foreground — catch up immediately, then resume the cadence.
+      if (!paused) {
+        runTick();
+        startInterval();
+      }
+    };
+
+    const handleInteraction = () => {
+      lastInteraction = Date.now();
+      if (paused) start();
+    };
+
+    resumeRef.current = () => {
+      if (paused) start();
+    };
+
+    start();
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    INTERACTION_EVENTS.forEach((event) => document.addEventListener(event, handleInteraction, { passive: true }));
+
+    return () => {
+      stopInterval();
+      document.removeEventListener("visibilitychange", handleVisibility);
+      INTERACTION_EVENTS.forEach((event) => document.removeEventListener(event, handleInteraction));
+      resumeRef.current = () => {};
+    };
+  }, [enabled, restartKey, intervalMs, idleCeilingMs]);
+
+  return { isPaused, resume };
+};
+
+export default useModalLiveRefresh;

--- a/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.ts
+++ b/client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.ts
@@ -71,11 +71,24 @@ export const useModalLiveRefresh = ({
     let interval: ReturnType<typeof setInterval> | null = null;
     let lastInteraction = Date.now();
     let paused = false;
+    let inFlight = false;
 
     const runTick = () => {
       // Skip work the operator can't see; the visibility handler catches them up.
       if (document.visibilityState !== "visible") return;
-      void onTickRef.current();
+      // Serialize ticks: if a refresh is slower than the cadence, don't start a
+      // second one. Overlapping ticks would let a slow older response merge
+      // after a newer one and regress the modal/list back to stale status.
+      if (inFlight) return;
+      const result = onTickRef.current();
+      // Only an async tick can still be running when the next interval fires; a
+      // synchronous tick has already completed, so nothing to guard.
+      if (result && typeof (result as Promise<void>).then === "function") {
+        inFlight = true;
+        (result as Promise<void>).finally(() => {
+          inFlight = false;
+        });
+      }
     };
 
     const stopInterval = () => {
@@ -88,6 +101,11 @@ export const useModalLiveRefresh = ({
     const startInterval = () => {
       stopInterval();
       interval = setInterval(() => {
+        // Don't let hidden-tab time advance the idle ceiling. If the loop is
+        // enabled while the tab is already hidden, no visibilitychange fires to
+        // stop the interval, so guard here too — otherwise it could pause mid
+        // background and then refuse the catch-up tick on return.
+        if (document.visibilityState !== "visible") return;
         if (Date.now() - lastInteraction >= idleCeilingMs) {
           paused = true;
           stopInterval();
@@ -111,8 +129,10 @@ export const useModalLiveRefresh = ({
         stopInterval();
         return;
       }
-      // Back in the foreground — catch up immediately, then resume the cadence.
+      // Back in the foreground — reset the idle baseline so time spent hidden
+      // doesn't count against the ceiling, then catch up and resume the cadence.
       if (!paused) {
+        lastInteraction = Date.now();
         runTick();
         startInterval();
       }
@@ -130,12 +150,16 @@ export const useModalLiveRefresh = ({
     start();
 
     document.addEventListener("visibilitychange", handleVisibility);
-    INTERACTION_EVENTS.forEach((event) => document.addEventListener(event, handleInteraction, { passive: true }));
+    // Capture phase so element-level "scroll" (which does not bubble) still
+    // counts as interaction when the operator scrolls inside the modal.
+    INTERACTION_EVENTS.forEach((event) =>
+      document.addEventListener(event, handleInteraction, { capture: true, passive: true }),
+    );
 
     return () => {
       stopInterval();
       document.removeEventListener("visibilitychange", handleVisibility);
-      INTERACTION_EVENTS.forEach((event) => document.removeEventListener(event, handleInteraction));
+      INTERACTION_EVENTS.forEach((event) => document.removeEventListener(event, handleInteraction, { capture: true }));
       resumeRef.current = () => {};
     };
   }, [enabled, restartKey, intervalMs, idleCeilingMs]);

--- a/client/src/protoFleet/components/StatusModal/types.ts
+++ b/client/src/protoFleet/components/StatusModal/types.ts
@@ -41,4 +41,11 @@ export interface ProtoFleetStatusModalProps {
 
   /** Whether to show back button in component views (defaults to true) */
   showBackButton?: boolean;
+
+  /**
+   * Merges freshly-polled snapshots back into the parent fleet map so the list
+   * row beneath the modal stays in sync. When omitted, the modal still refreshes
+   * its own error view but the underlying `miner` prop won't update live.
+   */
+  onMergeMiners?: (snapshots: MinerStateSnapshot[]) => void;
 }

--- a/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx
@@ -1313,6 +1313,7 @@ const MinerList = ({
           onClose={closeModalFlow}
           deviceId={modalFlow.deviceIdentifier}
           miner={miners[modalFlow.deviceIdentifier]}
+          onMergeMiners={onMergeMiners}
         />
       ) : null}
     </>

--- a/docs/plans/2026-06-11-status-modal-live-refresh-tdd.md
+++ b/docs/plans/2026-06-11-status-modal-live-refresh-tdd.md
@@ -1,7 +1,7 @@
 ---
 title: "Status modal live refresh"
 date: 2026-06-11
-status: draft
+status: implementing
 type: tdd
 ---
 
@@ -171,3 +171,23 @@ the original snapshot for one render if the map hasn't repopulated
 - **Future push channel.** If we later add SSE/websocket for live
   miner state, this hook becomes redundant and can be deleted without
   touching the RPC.
+
+## Implementation notes (as built)
+
+- Core lands as `useModalLiveRefresh` (immediate open tick, 10s cadence,
+  visibility gating, 10-min idle ceiling with auto-resume on interaction,
+  `restartKey` for device swaps). Wired into `ProtoFleetStatusModal`, which
+  drives `refreshMiners([deviceId])` → `onMergeMiners` + `useDeviceErrors.refetch()`
+  per tick. `onMergeMiners` is threaded from `MinerList` (already had it as a prop).
+- **No prop break.** The plan proposed switching `miner` → `deviceId`, but the
+  modal already takes `deviceId` and the caller already passes
+  `miner={miners[id]}` from the live `useFleet` map — so the freshest snapshot
+  flows in through the existing prop once the map is merged. Left as-is.
+- **Descoped UI (deferred):** the "Paused — click to resume" affordance and the
+  inline "couldn't refresh" banner are **not** rendered. Both would require
+  changes to the shared `StatusModal` (used by protoOS too), conflicting with the
+  "layout stays the same" non-goal. Instead: the loop auto-resumes on any
+  interaction (so an active operator always sees fresh data), and a failed
+  refresh silently keeps the last-good snapshot and retries next tick. The hook
+  still returns `{ isPaused, resume }` so the affordance can be added later
+  without touching the loop. E2E scenarios remain to be added.

--- a/docs/plans/2026-06-11-status-modal-live-refresh-tdd.md
+++ b/docs/plans/2026-06-11-status-modal-live-refresh-tdd.md
@@ -1,0 +1,173 @@
+---
+title: "Status modal live refresh"
+date: 2026-06-11
+status: draft
+type: tdd
+---
+
+# Status modal live refresh
+
+## Context
+
+`ProtoFleetStatusModal`
+(`client/src/protoFleet/components/StatusModal/StatusModal.tsx`) shows a
+single miner's status — current state, error details — but it does not
+poll. The `miner` prop is a `MinerStateSnapshot` snapshotted from the
+parent Fleet list at modal-open time. `useDeviceErrors`
+(`api/useDeviceErrors.ts`) is also fetched once on open and only
+refetches when the device id changes.
+
+Operator-observed failure: open the modal on an erroring miner →
+on-device remediation clears the error → modal never reflects the
+change. The user must close and reopen.
+
+This PR makes the modal reflect changes within ~10 seconds by reusing
+the `RefreshMiners` RPC introduced in the predecessor TDD.
+
+**Depends on:**
+[`2026-06-11-refresh-miners-rpc-and-row-bulk-actions-tdd.md`](./2026-06-11-refresh-miners-rpc-and-row-bulk-actions-tdd.md).
+That PR must land first so `RefreshMiners`, `useRefreshMiners`, and
+`useFleet.mergeMiners` exist.
+
+## Goals
+
+- Status modal reflects underlying miner state changes within ~10s of
+  the change being observable to the server.
+- The list row beneath the modal stays in sync — closing the modal
+  shouldn't show a "snap" to fresher data.
+- Polling stops when the user can't see it (tab hidden) and after a
+  reasonable idle ceiling.
+- One immediate fetch on modal open so users don't wait 10s for the
+  first refresh.
+
+## Non-goals
+
+- Server-push / SSE.
+- Adding modal polling for any modal other than `ProtoFleetStatusModal`.
+- Reducing the global 60s list poll.
+- A new RPC. This PR is purely client-side once the predecessor lands.
+
+## Architecture today (verified)
+
+- Modal receives `miner: MinerStateSnapshot` from the parent list
+  (`StatusModal.tsx`).
+- `useDeviceErrors(modalDeviceIds)` fetches errors when `isVisible &&
+  deviceId` changes (`useDeviceErrors.ts:25`); it exposes a manual
+  `refetch()`.
+- After the predecessor PR lands:
+  - `useRefreshMiners()` returns `{ refreshMiners, refreshing }`.
+  - `useFleet.mergeMiners(snapshots[])` upserts into the page map with
+    protobuf `equals()` short-circuiting.
+
+## Design
+
+### Poll lifecycle inside the modal
+
+When the modal mounts with `isVisible && deviceId`:
+
+1. **Initial fetch.** Fire one `refreshMiners([deviceId])` immediately
+   on open. Call `useDeviceErrors.refetch()` on the same tick.
+2. **Recurring tick.** Every 10s thereafter, repeat both calls.
+3. **Visibility gating.** If `document.visibilityState !== "visible"`,
+   suspend the tick. Resume on `visibilitychange` back to "visible"
+   and immediately run one fetch (don't wait for the next interval).
+4. **Idle ceiling.** Track user interaction inside the modal
+   (`mousemove`, `keydown`, `click`, `scroll`). After 10 minutes
+   without any interaction, pause the poll and render a "Paused — click
+   to resume" affordance. Clicking it resumes the loop with an
+   immediate fetch.
+5. **Cleanup.** On modal close / unmount, clear the interval and any
+   visibility listeners.
+
+The poll lives in a small dedicated hook
+`client/src/protoFleet/components/StatusModal/useModalLiveRefresh.ts`
+so the lifecycle logic is testable in isolation and StatusModal stays
+declarative.
+
+### Merging results
+
+Each tick:
+
+- `refreshMiners` returns `{ snapshots, errors }`. Call
+  `mergeMiners(snapshots)` so the parent's `useFleet` map updates. The
+  list row beneath the modal stays consistent.
+- The modal itself reads its `miner` from the parent map (by id)
+  rather than from the snapshot it was opened with — so updates from
+  `mergeMiners` flow into the modal on the same re-render.
+- `useDeviceErrors.refetch()` updates error state independently. The
+  hook already skips re-render when error ids haven't changed.
+
+### Picking the latest miner from the map
+
+Modal currently receives `miner` as a prop. Change the prop to
+`deviceId: string` and have the modal look up the snapshot from
+`useFleet`'s map via the existing outlet-context shape. Falls back to
+the original snapshot for one render if the map hasn't repopulated
+(rare; only on a back-to-back open).
+
+### Error handling
+
+- If `refreshMiners` returns the device id in `errors`, surface a
+  subtle inline banner in the modal ("Couldn't refresh — last updated
+  Xs ago"). Keep the last good snapshot visible.
+- Successive failures don't compound — the next tick retries.
+- If the modal's device goes missing entirely (e.g. unpaired in
+  another tab), the modal closes with a toast.
+
+### What does *not* change
+
+- `useFleet`'s 60s list poll is untouched. The modal poll is additive.
+- The status modal's error UI, layout, and existing actions stay the
+  same.
+- Other modals (firmware, pool config, etc.) are not affected.
+
+## Test plan
+
+**Component (`StatusModal.test.tsx` + `useModalLiveRefresh.test.ts`)**
+
+- Mount with a visible modal → `refreshMiners` invoked immediately
+  with `[deviceId]`.
+- After 10s, `refreshMiners` invoked again.
+- `document.visibilityState=hidden` → no tick fires.
+- Back to "visible" → immediate fetch, then resume 10s cadence.
+- 10 minutes of no interaction → poll pauses, "Paused" affordance
+  renders; click resumes with immediate fetch.
+- Unmount → interval cleared; no further calls observed.
+- `refreshMiners` resolves with an error for the device → inline
+  banner renders; previous snapshot remains visible; next tick clears
+  the banner on success.
+
+**Integration with `useFleet`**
+
+- Modal tick merges returned snapshot into parent map; closing the
+  modal does not "snap" the row to fresher data because the row was
+  already updated.
+
+**E2E (`just test-e2e-fleet`)**
+
+- Open modal on an erroring miner; mutate fixture to clear the error;
+  assert the modal reflects the cleared state within ~12s without
+  user action.
+- Open modal, switch tab away, mutate fixture, switch back → modal
+  reflects change immediately on visibility restore.
+
+## Risks and tradeoffs
+
+- **Plugin load per open modal.** One modal open for 10 minutes = ~60
+  fetches against one device. Visibility + idle gating bound the
+  worst case. Per-device server-side debounce (2s, from predecessor
+  PR) prevents two simultaneously open modals from doubling load.
+- **Prop change is a small API break inside the client.** Switching
+  `StatusModal` from `miner` to `deviceId` requires touching all call
+  sites. Limited blast radius; all under `protoFleet/`.
+- **Idle ceiling chosen by intuition.** 10 minutes feels like a
+  reasonable bound for "tech actively watching this miner." If
+  telemetry shows real users sitting on modals for longer, lift the
+  ceiling; if they don't, lower it.
+- **Tick cadence is fixed.** Not adaptive to backend load. If we ever
+  see plugin saturation from many concurrent modals, the predecessor
+  PR's debounce already caps redundant work; further mitigation
+  (server-driven hint in the response) is an option but not in scope.
+- **Future push channel.** If we later add SSE/websocket for live
+  miner state, this hook becomes redundant and can be deleted without
+  touching the RPC.


### PR DESCRIPTION
Reviewable diff: +377/-1 across 5 files (excludes generated, test, and story files).

## Summary

The ProtoFleet status modal shows a single miner's status and errors, but it snapshots that data at open time and never refreshes. An operator who opens the modal on an erroring miner, then remediates on-device, sees no change — they have to close and reopen to learn it recovered. This PR makes the modal reflect the underlying miner's state within ~10s while it's open, keeping the list row beneath it in sync, with no new RPC (it reuses the existing `RefreshMiners` RPC and `useFleet.mergeMiners`).

## How it works

A new hook, `useModalLiveRefresh`, owns the poll lifecycle; the modal wires it to the data calls. While the modal is open and visible:

1. **On open**, one refresh fires immediately (so the operator doesn't wait 10s for the first update).
2. **Every 10s** thereafter, the modal calls `refreshMiners([deviceId])` and `useDeviceErrors.refetch()`.
3. Fresh snapshots are handed to `onMergeMiners` (the Fleet component's `useFleet.mergeMiners`), which upserts them into the shared fleet map. Because `MinerList` already renders the modal with `miner={miners[id]}` from that live map, the freshest snapshot flows back into the modal on the same re-render — and the list row underneath updates too, so closing the modal never "snaps" the row to newer data.
4. **Visibility gating:** when the tab is hidden the interval is suspended; returning to the foreground fires one immediate catch-up refresh, then resumes the 10s cadence.
5. **Idle ceiling:** after 10 minutes with no user interaction (mousemove/keydown/click/scroll), the loop pauses so an abandoned-but-open modal doesn't poll forever. Any interaction (or an explicit `resume()`) restarts it with an immediate refresh.
6. **Teardown:** closing the modal or unmounting clears the interval and removes all listeners.

On a refresh failure the last-good snapshot stays on screen and the next tick retries; a genuine auth (401) failure logs out via the existing `handleAuthErrors` path, same as the app-wide fleet poll.

```mermaid
flowchart LR
    Operator["Operator opens status modal"] --> Modal["ProtoFleetStatusModal"]
    Modal --> Hook["useModalLiveRefresh (10s loop)"]
    Hook -->|"each tick"| Tick["handleLiveRefreshTick"]
    Tick --> Refresh["refreshMiners([deviceId])"]
    Tick --> Errors["useDeviceErrors.refetch()"]
    Refresh -->|"snapshots"| Merge["onMergeMiners = useFleet.mergeMiners"]
    Merge --> Map["Shared fleet map"]
    Map -->|"miner={miners[id]}"| Modal
    Map --> Row["MinerList row stays in sync"]
```

```mermaid
stateDiagram-v2
    [*] --> Polling: modal opens (immediate tick)
    Polling --> Polling: every 10s
    Polling --> Suspended: tab hidden
    Suspended --> Polling: tab visible (immediate catch-up)
    Polling --> Paused: 10 min idle
    Paused --> Polling: interaction / resume() (immediate tick)
    Polling --> [*]: modal closes / unmount
    Suspended --> [*]: modal closes / unmount
    Paused --> [*]: modal closes / unmount
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/components/StatusModal/hooks/useModalLiveRefresh.ts` | **New.** Self-contained poll loop: immediate tick, 10s interval, visibility gating, idle ceiling + resume, teardown. Returns `{ isPaused, resume }`. | Core of the PR; all timer/listener lifecycle lives here. |
| `client/src/protoFleet/components/StatusModal/StatusModal.tsx` | Wires the hook: adds `useRefreshMiners`, a `handleLiveRefreshTick` that merges snapshots + refetches errors, and threads the new `onMergeMiners` prop. | The one place the loop meets the data calls and the merge. |
| `client/src/protoFleet/components/StatusModal/types.ts` | Adds optional `onMergeMiners` prop to the modal's props. | Small API surface addition. |
| `client/src/protoFleet/features/fleetManagement/components/MinerList/MinerList.tsx` | Passes its existing `onMergeMiners` down to the modal (1 line). | Confirms the merge callback reaches the modal. |
| `client/src/protoFleet/components/StatusModal/{StatusModal.liveRefresh,hooks/useModalLiveRefresh}.test.{tsx,ts}` | **New tests** — hook lifecycle (9) + modal wiring (3). | Test-only; primary correctness evidence. |
| `docs/plans/2026-06-11-status-modal-live-refresh-tdd.md` | TDD doc + "as built" implementation notes (deferred UI, no prop break). | Design rationale; review-light. |

## Key technical decisions & trade-offs

- **Reuse `RefreshMiners` + `mergeMiners` instead of a new RPC / SSE.** Purely client-side; the modal poll is additive to (not a replacement for) the existing fleet list poll. Per-device server-side debounce already caps redundant backend work.
- **No `miner` → `deviceId` prop break.** The original TDD proposed swapping the prop; in practice the modal already takes `deviceId` and the caller already passes `miner={miners[id]}` from the live map, so the freshest snapshot flows through the existing prop once merged. Left the prop shape alone.
- **Idle ceiling + visibility gating over unbounded polling.** Bounds worst-case load for a modal left open; 10 min chosen by intuition and easy to tune.
- **Deferred UI (documented in the TDD).** The "Paused — click to resume" affordance and an inline "couldn't refresh" banner are **not** rendered — both would require changes to the shared `StatusModal` (also used by protoOS), conflicting with the "layout stays the same" goal. Instead the loop auto-resumes on interaction and a failed refresh silently keeps the last-good snapshot. The hook already returns `{ isPaused, resume }` so the affordance can be added later without touching the loop.

## Testing & validation

- **Unit (Vitest):** `useModalLiveRefresh.test.ts` (9) covers immediate tick, interval cadence, hidden-tab suspension + catch-up, idle pause + interaction/`resume()`, unmount teardown, and `restartKey` restart. `StatusModal.liveRefresh.test.tsx` (3) covers merge-on-success, keep-last-good-on-failure, and no-merge-on-empty. Full `StatusModal` + `MinerList` suites pass; `tsc` clean.
- **Manual:** verified against the local fake-rig stack — opened the modal on a miner, flipped its state on the backend, and confirmed the modal reflected the change within the poll window without a close/reopen; confirmed the repeating `RefreshMiners` calls and their suspension when the tab is hidden.
- **Not covered:** the E2E scenarios in the TDD (`just test-e2e-fleet`) are not yet written; the deferred UI affordances above are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
