### PR TITLE
fix(logging): reduce fleet log noise

### DIFF
--- a/deployment-files/tests/test-profiles.sh
+++ b/deployment-files/tests/test-profiles.sh
@@ -246,7 +246,7 @@ assert_rendered "no-profile render keeps defaults" "$out" \
     "shared_buffers=256MB" "max_worker_processes=19" "wal_compression=off" \
     "shared_preload_libraries=timescaledb,pg_stat_statements" \
     "pg_stat_statements.track_utility=off" \
-    "track_io_timing=on" "log_min_duration_statement=1000" \
+    "track_io_timing=on" "log_min_duration_statement=5000" \
     "log_parameter_max_length=0" "log_parameter_max_length_on_error=0" \
     'shm_size: "268435456"'
 

--- a/plugin/virtual/internal/driver/driver.go
+++ b/plugin/virtual/internal/driver/driver.go
@@ -160,7 +160,7 @@ func (d *Driver) DiscoverDevice(ctx context.Context, ipAddress, port string) (sd
 		return sdk.DeviceInfo{}, err
 	}
 
-	slog.Info("Discovered virtual miner", "serial", minerCfg.SerialNumber, "ip", ipAddress)
+	slog.Debug("Discovered virtual miner", "serial", minerCfg.SerialNumber, "ip", ipAddress)
 
 	return sdk.DeviceInfo{
 		Host:            ipAddress,
@@ -221,7 +221,7 @@ func (d *Driver) NewDevice(_ context.Context, deviceID string, deviceInfo sdk.De
 	d.devices[deviceID] = dev
 	d.mutex.Unlock()
 
-	slog.Info("Created virtual device instance", "device_id", deviceID, "serial", deviceInfo.SerialNumber)
+	slog.Debug("Created virtual device instance", "device_id", deviceID, "serial", deviceInfo.SerialNumber)
 
 	return sdk.NewDeviceResult{Device: dev}, nil
 }

--- a/server/docker-compose.base.yaml
+++ b/server/docker-compose.base.yaml
@@ -99,7 +99,7 @@ services:
       - "-c"
       - "track_io_timing=${PG_TRACK_IO_TIMING:-on}"
       - "-c"
-      - "log_min_duration_statement=${PG_LOG_MIN_DURATION_STATEMENT:-1000}"
+      - "log_min_duration_statement=${PG_LOG_MIN_DURATION_STATEMENT:-5000}"
       # Never log bind parameter values with slow statements: fleet-api binds
       # session tokens, password hashes, and credential ciphertext
       - "-c"

--- a/server/internal/domain/plugins/discoverer.go
+++ b/server/internal/domain/plugins/discoverer.go
@@ -141,7 +141,7 @@ func discoverWithPlugin(ctx context.Context, plugin *LoadedPlugin, pluginName, i
 		LastSeen:        time.Now(),
 	}
 
-	slog.Info("Plugin discovered device successfully",
+	slog.Debug("Plugin discovered device successfully",
 		"plugin", pluginName,
 		"device", deviceInfo.SerialNumber,
 		"model", deviceInfo.Model,

--- a/server/internal/domain/telemetry/scheduler/scheduler.go
+++ b/server/internal/domain/telemetry/scheduler/scheduler.go
@@ -36,10 +36,11 @@ func NewScheduler(config Config) *scheduler {
 
 // AddNewDevices adds new devices to the scheduler.
 func (s *scheduler) AddNewDevices(ctx context.Context, deviceID ...models.DeviceIdentifier) error {
+	var alreadyManaged []models.DeviceIdentifier
 
 	for _, id := range deviceID {
 		if _, exists := s.managedDevices.LoadOrStore(id, true); exists {
-			slog.Warn("Device already managed", "device_id", id)
+			alreadyManaged = append(alreadyManaged, id)
 			continue
 		}
 		s.mu.Lock()
@@ -49,6 +50,7 @@ func (s *scheduler) AddNewDevices(ctx context.Context, deviceID ...models.Device
 		// TODO(Briano-block): do we want to fetch historical telemetry data for the new device?
 		// where does our responsibility for telemetry data start and end? at pairing?
 	}
+	logDuplicateSchedulerDevices("scheduler skipped already managed devices", alreadyManaged)
 	return nil
 }
 
@@ -70,9 +72,7 @@ func (s *scheduler) addDevices(ctx context.Context, devices ...models.Device) er
 		inQueue, exists := s.managedDevices.Load(device.ID)
 		if !exists {
 			s.mu.Unlock()
-			for _, id := range alreadyScheduled {
-				slog.Warn("Device already scheduled", "device_id", id)
-			}
+			logDuplicateSchedulerDevices("scheduler skipped already scheduled devices", alreadyScheduled)
 			return DeviceNotManagedErr{DeviceID: device.ID}
 		}
 		if value, ok := inQueue.(bool); ok && value {
@@ -84,10 +84,28 @@ func (s *scheduler) addDevices(ctx context.Context, devices ...models.Device) er
 	}
 	s.mu.Unlock()
 
-	for _, id := range alreadyScheduled {
-		slog.Warn("Device already scheduled", "device_id", id)
-	}
+	logDuplicateSchedulerDevices("scheduler skipped already scheduled devices", alreadyScheduled)
 	return nil
+}
+
+func logDuplicateSchedulerDevices(message string, deviceIDs []models.DeviceIdentifier) {
+	if len(deviceIDs) == 0 {
+		return
+	}
+
+	attrs := []any{"count", len(deviceIDs)}
+	sampleSize := min(len(deviceIDs), 5)
+	samples := make([]string, 0, sampleSize)
+	for _, id := range deviceIDs[:sampleSize] {
+		samples = append(samples, id.String())
+	}
+	attrs = append(attrs, "sample_device_ids", samples)
+
+	if len(deviceIDs) == 1 {
+		slog.Debug(message, attrs...)
+		return
+	}
+	slog.Info(message, attrs...)
 }
 
 func (s *scheduler) AddFailedDevices(ctx context.Context, devices ...models.Device) error {

--- a/server/internal/domain/telemetry/scheduler/scheduler_test.go
+++ b/server/internal/domain/telemetry/scheduler/scheduler_test.go
@@ -50,6 +50,27 @@ func (h *captureLogHandler) findRecord(message string) (slog.Record, bool) {
 	return slog.Record{}, false
 }
 
+func (h *captureLogHandler) recordsForMessage(message string) []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	records := make([]slog.Record, 0)
+	for _, record := range h.records {
+		if record.Message == message {
+			records = append(records, record.Clone())
+		}
+	}
+	return records
+}
+
+func attrsFromRecord(record slog.Record) map[string]any {
+	attrs := map[string]any{}
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs[attr.Key] = attr.Value.Any()
+		return true
+	})
+	return attrs
+}
+
 func TestNewScheduler(t *testing.T) {
 	t.Run("creates a new scheduler instance", func(t *testing.T) {
 		config := Config{
@@ -159,13 +180,43 @@ func TestScheduler_DuplicateDeviceLogsAreAggregated(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, slog.LevelInfo, record.Level)
 
-	attrs := map[string]any{}
-	record.Attrs(func(attr slog.Attr) bool {
-		attrs[attr.Key] = attr.Value.Any()
-		return true
-	})
+	attrs := attrsFromRecord(record)
 	assert.Equal(t, int64(3), attrs["count"])
 	assert.Equal(t, []string{"123", "456", "789"}, attrs["sample_device_ids"])
+}
+
+func TestScheduler_AlreadyScheduledDeviceLogsAreAggregated(t *testing.T) {
+	oldLogger := slog.Default()
+	handler := &captureLogHandler{}
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(oldLogger) })
+
+	s := NewScheduler(Config{MaxConsecutiveFailures: 10})
+	ctx := t.Context()
+
+	require.NoError(t, s.AddNewDevices(ctx, "123"))
+	require.NoError(t, s.AddDevices(ctx, models.Device{ID: "123", LastUpdatedAt: time.Now()}))
+
+	deviceIDs := []models.DeviceIdentifier{"456", "789", "abc"}
+	require.NoError(t, s.AddNewDevices(ctx, deviceIDs...))
+	devices := make([]models.Device, 0, len(deviceIDs))
+	for _, id := range deviceIDs {
+		devices = append(devices, models.Device{ID: id, LastUpdatedAt: time.Now()})
+	}
+	require.NoError(t, s.AddDevices(ctx, devices...))
+
+	records := handler.recordsForMessage("scheduler skipped already scheduled devices")
+	require.Len(t, records, 2)
+
+	singleAttrs := attrsFromRecord(records[0])
+	assert.Equal(t, slog.LevelDebug, records[0].Level)
+	assert.Equal(t, int64(1), singleAttrs["count"])
+	assert.Equal(t, []string{"123"}, singleAttrs["sample_device_ids"])
+
+	multipleAttrs := attrsFromRecord(records[1])
+	assert.Equal(t, slog.LevelInfo, records[1].Level)
+	assert.Equal(t, int64(3), multipleAttrs["count"])
+	assert.Equal(t, []string{"456", "789", "abc"}, multipleAttrs["sample_device_ids"])
 }
 
 func TestScheduler_AddDevices(t *testing.T) {

--- a/server/internal/domain/telemetry/scheduler/scheduler_test.go
+++ b/server/internal/domain/telemetry/scheduler/scheduler_test.go
@@ -1,8 +1,11 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,6 +14,41 @@ import (
 
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
 )
+
+type captureLogHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureLogHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *captureLogHandler) Handle(_ context.Context, record slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, record.Clone())
+	return nil
+}
+
+func (h *captureLogHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *captureLogHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
+func (h *captureLogHandler) findRecord(message string) (slog.Record, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, record := range h.records {
+		if record.Message == message {
+			return record, true
+		}
+	}
+	return slog.Record{}, false
+}
 
 func TestNewScheduler(t *testing.T) {
 	t.Run("creates a new scheduler instance", func(t *testing.T) {
@@ -102,6 +140,32 @@ func TestScheduler_AddNewDevices(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, s.GetDeviceCount()) // Should still be 1
 	})
+}
+
+func TestScheduler_DuplicateDeviceLogsAreAggregated(t *testing.T) {
+	oldLogger := slog.Default()
+	handler := &captureLogHandler{}
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(oldLogger) })
+
+	s := NewScheduler(Config{MaxConsecutiveFailures: 10})
+	ctx := t.Context()
+	deviceIDs := []models.DeviceIdentifier{"123", "456", "789"}
+
+	require.NoError(t, s.AddNewDevices(ctx, deviceIDs...))
+	require.NoError(t, s.AddNewDevices(ctx, deviceIDs...))
+
+	record, ok := handler.findRecord("scheduler skipped already managed devices")
+	require.True(t, ok)
+	assert.Equal(t, slog.LevelInfo, record.Level)
+
+	attrs := map[string]any{}
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs[attr.Key] = attr.Value.Any()
+		return true
+	})
+	assert.Equal(t, int64(3), attrs["count"])
+	assert.Equal(t, []string{"123", "456", "789"}, attrs["sample_device_ids"])
 }
 
 func TestScheduler_AddDevices(t *testing.T) {

--- a/server/monitoring/grafana/grafana.ini
+++ b/server/monitoring/grafana/grafana.ini
@@ -30,4 +30,4 @@ enabled = false
 
 [log]
 mode = console
-level = info
+level = warn


### PR DESCRIPTION
Reviewable diff: +30/-12 across 5 files (excludes generated, test, and story files).

## Summary
Scale-test discovery and scheduler bookkeeping now keep the default logs readable at 5,000 virtual devices. High-cardinality per-device discovery success and virtual-device creation logs move out of INFO, while duplicate scheduler bookkeeping becomes a compact count-and-sample event instead of one WARN per device. Deployment defaults also quiet known auxiliary noise from Grafana and Postgres slow-query output without removing the operator override knobs.

## How it works
Per-device virtual discovery, virtual device construction, and generic plugin discovery success still emit the same identifying fields, but at DEBUG so an operator can opt into them during plugin debugging without flooding normal logs.

When the telemetry scheduler is asked to add devices that are already managed or already scheduled, it now batches those duplicates for the current call. A single duplicate logs at DEBUG; multiple duplicates log once at INFO with the duplicate count and up to five sample device IDs. This preserves the useful signal that repeated enqueue attempts are happening while removing the steady-state WARN storm from large fleets.

The Compose defaults now treat Postgres slow statements as slow at 5s instead of 1s, while preserving `PG_LOG_MIN_DURATION_STATEMENT` for lower-threshold debugging. Grafana console output defaults to WARN so stale alert evaluator chatter does not dominate the deployment logs.

```mermaid
flowchart TB
    A["Discovery and pairing loop"] --> B["Plugin discovery succeeds"]
    B --> C["Per-device success logs at DEBUG"]
    A --> D["Telemetry scheduler receives device IDs"]
    D --> E["New devices enter the queue"]
    D --> F["Duplicate device IDs are collected per call"]
    F --> G["One summary log with count and sample IDs"]
    H["Compose deployment defaults"] --> I["Postgres logs statements at 5s unless overridden"]
    H --> J["Grafana emits WARN and higher"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `plugin/virtual/internal/driver/driver.go` | Demoted virtual discovery and virtual device creation success logs to DEBUG. | These were the largest per-device log families in the 5,000-device run. |
| `server/internal/domain/plugins/discoverer.go` | Demoted generic plugin discovery success to DEBUG. | Keeps plugin-level success details available without duplicating every discovered device at INFO. |
| `server/internal/domain/telemetry/scheduler/scheduler.go` | Aggregates duplicate managed/scheduled devices into one summary log with count and sampled IDs. | Converts expected steady-state duplicate scheduling from WARN-per-device to bounded operational signal. |
| `server/docker-compose.base.yaml` | Raises the default Postgres slow-statement threshold from 1s to 5s while keeping the env override. | Reduces SQL continuation noise from dashboard-scale queries without removing slow-query diagnostics. |
| `server/monitoring/grafana/grafana.ini` | Sets Grafana console logging to WARN. | Suppresses low-value alert evaluator info logs in the local deployment stack. |
| `server/internal/domain/telemetry/scheduler/scheduler_test.go` | Adds coverage for aggregated duplicate scheduler logging. | Pins the count, level, and sampled device IDs for the new bounded log format. |
| `deployment-files/tests/test-profiles.sh` | Updates the compose render expectation for the new slow-query default. | Keeps the host-profile guard aligned with the deployment default change. |

## Key technical decisions & trade-offs
- Demote discovery success logs instead of deleting them outright, so plugin debugging can still recover per-device details with DEBUG logging.
- Treat duplicate scheduler adds as expected steady-state, not warnings; batched duplicates stay visible at INFO only when there is a multi-device pattern to investigate.
- Preserve deployment override knobs for Postgres slow-query logging rather than hard-coding a quieter threshold.
- Quiet Grafana at the component level instead of filtering its messages downstream, so log volume is reduced at the source.

## Testing & validation
- `./deployment-files/tests/test-profiles.sh`
- `source ./bin/activate-hermit && cd server && go test ./internal/domain/telemetry/scheduler ./internal/domain/plugins`
- `source ./bin/activate-hermit && cd plugin/virtual && go test ./internal/driver`
- `source ./bin/activate-hermit && just _lint-server`
- `source ./bin/activate-hermit && just _lint-plugins`
- `source ./bin/activate-hermit && cd plugin/virtual && golangci-lint run`
- `git diff --check`

Not covered: full `just lint`; `_lint-client` stops in this clean worktree because `eslint` is not installed (`sh: eslint: command not found`).
