### PR TITLE
Add admin RBAC Playwright coverage

### DIFF
--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -20,6 +20,7 @@ import { SettingsPage } from "../pages/settings";
 import { SettingsApiKeysPage } from "../pages/settingsApiKeys";
 import { SettingsCurtailmentPage } from "../pages/settingsCurtailment";
 import { SettingsFirmwarePage } from "../pages/settingsFirmware";
+import { SettingsNodesPage } from "../pages/settingsNodes";
 import { SettingsPoolsPage } from "../pages/settingsPools";
 import { SettingsSchedulesPage } from "../pages/settingsSchedules";
 import { SettingsSecurityPage } from "../pages/settingsSecurity";
@@ -38,6 +39,7 @@ type PageFixtures = {
   settingsFirmwarePage: SettingsFirmwarePage;
   settingsCurtailmentPage: SettingsCurtailmentPage;
   settingsApiKeysPage: SettingsApiKeysPage;
+  settingsNodesPage: SettingsNodesPage;
   settingsSchedulesPage: SettingsSchedulesPage;
   settingsSecurityPage: SettingsSecurityPage;
   settingsTeamPage: SettingsTeamPage;
@@ -87,6 +89,9 @@ export const test = base.extend<PageFixtures>({
   },
   settingsApiKeysPage: async ({ page, isMobile }, use) => {
     await use(new SettingsApiKeysPage(page, isMobile));
+  },
+  settingsNodesPage: async ({ page, isMobile }, use) => {
+    await use(new SettingsNodesPage(page, isMobile));
   },
   settingsSchedulesPage: async ({ page, isMobile }, use) => {
     await use(new SettingsSchedulesPage(page, isMobile));

--- a/client/e2eTests/protoFleet/helpers/rbacAdminTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacAdminTestSetup.ts
@@ -1,0 +1,215 @@
+import { create, toJsonString } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
+import { type Browser, type Page, type Route, type TestInfo } from "@playwright/test";
+import { testConfig } from "../config/test.config";
+import { AuthPage } from "../pages/auth";
+import { MinersPage } from "../pages/miners";
+import { SettingsPage } from "../pages/settings";
+import { SettingsApiKeysPage } from "../pages/settingsApiKeys";
+import { SettingsTeamPage } from "../pages/settingsTeam";
+import { CommonSteps } from "./commonSteps";
+import { provisionRoleAndLoginViaStoredAdminContext } from "./rbacTestSetup";
+import { createServerLogEntry, fulfillServerLogs } from "./serverLogsMocks";
+import {
+  CreateEnrollmentCodeResponseSchema,
+  FleetNodeEnrollmentStatus,
+  FleetNodeSummarySchema,
+  ListFleetNodesResponseSchema,
+} from "@/protoFleet/api/generated/fleetnodeadmin/v1/fleetnodeadmin_pb";
+import { LogLevel } from "@/protoFleet/api/generated/serverlog/v1/serverlog_pb";
+
+export const ADMIN_RBAC_API_KEY_PREFIX = "rbac_admin_api_key";
+
+const NODES_RPC_PATTERN = /FleetNodeAdminService\/ListFleetNodes/;
+const CREATE_ENROLLMENT_CODE_RPC_PATTERN = /FleetNodeAdminService\/CreateEnrollmentCode/;
+const SERVER_LOGS_RPC_PATTERN = /ServerLogService\/ListServerLogs/;
+
+type NodesMockController = {
+  showAwaitingNode: () => void;
+};
+
+export async function provisionAdminRole(
+  browser: Browser,
+  testInfo: TestInfo,
+  commonSteps: Parameters<typeof provisionRoleAndLoginViaStoredAdminContext>[2],
+  {
+    permissionKeys,
+    roleDescription,
+  }: {
+    permissionKeys: string[];
+    roleDescription: string;
+  },
+) {
+  return await provisionRoleAndLoginViaStoredAdminContext(browser, testInfo, commonSteps, {
+    permissionKeys,
+    roleDescription,
+  });
+}
+
+export async function cleanupAdminApiKeys(
+  browser: Browser,
+  isMobile: boolean,
+  viewport: { height: number; width: number } | null,
+) {
+  const context = await browser.newContext({
+    baseURL: testConfig.baseUrl,
+    viewport: viewport ?? undefined,
+  });
+
+  try {
+    const page = await context.newPage();
+    await page.goto("/");
+
+    const authPage = new AuthPage(page, isMobile);
+    const minersPage = new MinersPage(page, isMobile);
+    const settingsPage = new SettingsPage(page, isMobile);
+    const settingsTeamPage = new SettingsTeamPage(page, isMobile);
+    const settingsApiKeysPage = new SettingsApiKeysPage(page, isMobile);
+    const commonSteps = new CommonSteps(authPage, minersPage, settingsPage, settingsTeamPage);
+
+    await commonSteps.loginAsAdmin({ forceReauth: true });
+    await settingsApiKeysPage.navigateToApiKeysSettings();
+    await settingsApiKeysPage.deleteApiKeysByPrefix(ADMIN_RBAC_API_KEY_PREFIX);
+  } finally {
+    await context.close();
+  }
+}
+
+export async function mockAdminServerLogs(page: Page) {
+  await page.route(SERVER_LOGS_RPC_PATTERN, async (route) => {
+    return await fulfillServerLogs(
+      route,
+      [
+        createServerLogEntry({
+          id: 1n,
+          level: LogLevel.INFO,
+          message: "server booted",
+          source: "fleetd",
+          time: new Date("2026-07-17T09:00:00Z"),
+        }),
+        createServerLogEntry({
+          id: 2n,
+          level: LogLevel.WARN,
+          message: "node disconnected",
+          source: "scheduler",
+          time: new Date("2026-07-17T09:00:05Z"),
+        }),
+      ],
+      2n,
+    );
+  });
+}
+
+export async function mockReadOnlyNodes(page: Page) {
+  await page.route(NODES_RPC_PATTERN, async (route) => {
+    return await fulfillFleetNodes(route, [
+      createNodeSummary({
+        fleetNodeId: 7n,
+        name: "node-01",
+        enrollmentStatus: FleetNodeEnrollmentStatus.CONFIRMED,
+        identityFingerprint: "SHA256:rbac-node-01",
+        createdAt: new Date("2026-07-17T08:00:00Z"),
+        lastSeenAt: new Date("2026-07-17T09:00:00Z"),
+      }),
+    ]);
+  });
+}
+
+export async function mockManageableNodes(page: Page): Promise<NodesMockController> {
+  let showAwaitingNode = false;
+
+  await page.route(NODES_RPC_PATTERN, async (route) => {
+    return await fulfillFleetNodes(
+      route,
+      showAwaitingNode
+        ? [
+            createNodeSummary({
+              fleetNodeId: 11n,
+              pendingEnrollmentId: 11n,
+              name: "node-pending",
+              enrollmentStatus: FleetNodeEnrollmentStatus.AWAITING_CONFIRMATION,
+              identityFingerprint: "SHA256:rbac-pending-node",
+              lastSeenAt: new Date("2026-07-17T09:05:00Z"),
+            }),
+          ]
+        : [
+            createNodeSummary({
+              fleetNodeId: 7n,
+              name: "node-01",
+              enrollmentStatus: FleetNodeEnrollmentStatus.CONFIRMED,
+              identityFingerprint: "SHA256:rbac-node-01",
+              createdAt: new Date("2026-07-17T08:00:00Z"),
+              lastSeenAt: new Date("2026-07-17T09:00:00Z"),
+            }),
+          ],
+    );
+  });
+  await page.route(CREATE_ENROLLMENT_CODE_RPC_PATTERN, async (route) => {
+    return await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: toJsonString(
+        CreateEnrollmentCodeResponseSchema,
+        create(CreateEnrollmentCodeResponseSchema, {
+          code: "rbac-enrollment-code-1234",
+          pendingEnrollmentId: 11n,
+          expiresAt: createTimestamp(new Date("2026-07-17T10:00:00Z")),
+        }),
+      ),
+    });
+  });
+
+  return {
+    showAwaitingNode() {
+      showAwaitingNode = true;
+    },
+  };
+}
+
+function createTimestamp(date: Date) {
+  return create(TimestampSchema, {
+    seconds: BigInt(Math.floor(date.getTime() / 1000)),
+    nanos: 0,
+  });
+}
+
+function createNodeSummary({
+  fleetNodeId,
+  pendingEnrollmentId,
+  name,
+  enrollmentStatus,
+  createdAt,
+  lastSeenAt,
+  identityFingerprint,
+}: {
+  fleetNodeId: bigint;
+  pendingEnrollmentId?: bigint;
+  name: string;
+  enrollmentStatus: FleetNodeEnrollmentStatus;
+  createdAt?: Date;
+  lastSeenAt?: Date;
+  identityFingerprint: string;
+}) {
+  return create(FleetNodeSummarySchema, {
+    fleetNodeId,
+    pendingEnrollmentId,
+    name,
+    enrollmentStatus,
+    createdAt: createdAt ? createTimestamp(createdAt) : undefined,
+    lastSeenAt: lastSeenAt ? createTimestamp(lastSeenAt) : undefined,
+    identityFingerprint,
+  });
+}
+
+function fulfillFleetNodes(route: Route, nodes: ReturnType<typeof createNodeSummary>[]) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: toJsonString(
+      ListFleetNodesResponseSchema,
+      create(ListFleetNodesResponseSchema, {
+        fleetNodes: nodes,
+      }),
+    ),
+  });
+}

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -649,6 +649,14 @@ export class BasePage {
     await expect(this.page).toHaveURL(/.*\/settings\/firmware/);
   }
 
+  async navigateToNodesSettings() {
+    await this.clickNavigationMenuIfMobile();
+    await this.clickExpandSettingsIfMobile();
+    await this.navigateSettingsIfDesktop();
+    await this.page.getByTestId("secondary-nav").locator('a[href="/settings/nodes"]').click();
+    await expect(this.page).toHaveURL(/.*\/settings\/nodes/);
+  }
+
   async navigateToApiKeysSettings() {
     await this.clickNavigationMenuIfMobile();
     await this.clickExpandSettingsIfMobile();

--- a/client/e2eTests/protoFleet/pages/settingsNodes.ts
+++ b/client/e2eTests/protoFleet/pages/settingsNodes.ts
@@ -1,0 +1,93 @@
+import { expect } from "@playwright/test";
+import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
+import { BasePage } from "./base";
+
+export class SettingsNodesPage extends BasePage {
+  private nodeRow(nodeName: string) {
+    return this.page
+      .getByTestId("list-body")
+      .getByTestId("list-row")
+      .filter({
+        has: this.page.getByTestId("name").getByText(nodeName, { exact: true }),
+      });
+  }
+
+  async validateNodesPageOpened() {
+    await expect(this.page).toHaveURL(/.*\/settings\/nodes/);
+    await this.validateTitle("Nodes");
+  }
+
+  async waitForNodesListToLoad() {
+    await this.validateNodesPageOpened();
+    const rows = this.page.getByTestId("list-body").getByTestId("list-row");
+    const emptyState = this.page.getByText("No nodes yet", { exact: true });
+
+    await expect(this.page.getByText("Loading nodes...")).toBeHidden();
+
+    await expect(async () => {
+      if (await emptyState.isVisible().catch(() => false)) {
+        return;
+      }
+
+      const rowCount = await rows.count();
+      // eslint-disable-next-line playwright/prefer-to-have-count -- intentionally non-retrying: verifies the mocked/live row count has settled above zero
+      expect(rowCount).toBeGreaterThan(0);
+      await new Promise((resolve) => setTimeout(resolve, DEFAULT_INTERVAL));
+
+      if (await emptyState.isVisible().catch(() => false)) {
+        return;
+      }
+
+      const rowCountAfterDelay = await rows.count();
+      // eslint-disable-next-line playwright/prefer-to-have-count -- intentionally compares two sampled counts to confirm the list has stabilized
+      expect(rowCountAfterDelay).toBe(rowCount);
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [DEFAULT_INTERVAL] });
+  }
+
+  async validateNodeVisible(nodeName: string) {
+    await expect(this.nodeRow(nodeName)).toBeVisible();
+  }
+
+  async validateEnrollNodeVisible() {
+    await expect(this.page.getByRole("button", { name: "Enroll node", exact: true })).toBeVisible();
+  }
+
+  async validateEnrollNodeHidden() {
+    await expect(this.page.getByRole("button", { name: "Enroll node", exact: true })).toHaveCount(0);
+  }
+
+  async clickEnrollNode() {
+    await this.clickButton("Enroll node");
+  }
+
+  async clickNodeActionsMenu(nodeName: string) {
+    await this.nodeRow(nodeName).getByTestId("list-actions-trigger").click();
+  }
+
+  async clickNodeAction(actionName: "Confirm enrollment" | "Revoke") {
+    await this.clickButton(actionName);
+  }
+
+  async validateNodeActionVisible(actionName: "Confirm enrollment" | "Revoke") {
+    await expect(this.page.getByRole("button", { name: actionName, exact: true })).toBeVisible();
+  }
+
+  async validateNodeActionHidden(actionName: "Confirm enrollment" | "Revoke") {
+    await expect(this.page.getByRole("button", { name: actionName, exact: true })).toHaveCount(0);
+  }
+
+  async validateEnrollNodeModalOpened() {
+    const modal = this.page.getByTestId("modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText("Enroll a node");
+    await expect(modal).toContainText("1. On the host you want to enroll, run:");
+  }
+
+  async validateConfirmNodeModalOpened(nodeName: string) {
+    const modal = this.page.getByTestId("modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText("Confirm the node");
+    await expect(modal).toContainText(nodeName);
+    await expect(modal.getByRole("button", { name: "Confirm node", exact: true })).toBeVisible();
+  }
+}

--- a/client/e2eTests/protoFleet/pages/settingsTeam.ts
+++ b/client/e2eTests/protoFleet/pages/settingsTeam.ts
@@ -36,6 +36,10 @@ export class SettingsTeamPage extends BasePage {
     await expect(this.page.getByRole("button", { name: "Add team member" })).toBeVisible();
   }
 
+  async validateAddTeamMemberHidden() {
+    await expect(this.page.getByRole("button", { name: "Add team member", exact: true })).toHaveCount(0);
+  }
+
   async clickAddTeamMember() {
     await this.clickButton("Add team member");
   }
@@ -132,6 +136,10 @@ export class SettingsTeamPage extends BasePage {
     await expect(this.page.getByTestId("secondary-nav").locator('a[href="/settings/team"]')).toBeHidden();
   }
 
+  async validateRolesTabHidden() {
+    await expect(this.page.getByTestId("team-tab-roles")).toHaveCount(0);
+  }
+
   async clickCreateRole() {
     await this.clickButton("Create role");
   }
@@ -177,6 +185,14 @@ export class SettingsTeamPage extends BasePage {
 
   async validateRoleVisible(roleName: string) {
     await expect(this.roleRow(roleName)).toBeVisible();
+  }
+
+  async validateRoleNotVisible(roleName: string) {
+    await expect(this.roleRow(roleName)).toHaveCount(0);
+  }
+
+  async validateSystemRoleLockVisible() {
+    await expect(this.page.getByTestId("system-role-lock").first()).toBeVisible();
   }
 
   async deactivateMembersByPrefix(usernamePrefix: string) {
@@ -232,6 +248,10 @@ export class SettingsTeamPage extends BasePage {
     await this.memberRow(username).getByTestId("list-actions-trigger").click();
   }
 
+  async validateMemberActionsHidden(username: string) {
+    await expect(this.memberRow(username).getByTestId("list-actions-trigger")).toHaveCount(0);
+  }
+
   async clickResetPassword() {
     await this.clickButton("Reset Password");
   }
@@ -246,6 +266,26 @@ export class SettingsTeamPage extends BasePage {
 
   async clickSaveEditedRole() {
     await this.clickButton("Save");
+  }
+
+  async clickRoleActionsMenu(roleName: string) {
+    await this.roleRow(roleName).getByTestId("list-actions-trigger").click();
+  }
+
+  async clickEditRoleAction() {
+    await this.clickButton("Edit");
+  }
+
+  async clickDeleteRoleAction() {
+    await this.clickButton("Delete");
+  }
+
+  async clickSaveRoleChanges() {
+    await this.clickButton("Save changes");
+  }
+
+  async clickDeleteRoleConfirm() {
+    await this.clickButton("Delete role");
   }
 
   async clickResetMemberPasswordConfirm() {

--- a/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
@@ -17,16 +17,16 @@ test.describe("Proto Fleet - Admin RBAC", () => {
   });
 
   test.afterAll("CLEANUP: delete admin RBAC fixtures", async ({ browser }, testInfo) => {
-    await test.step("Clean up RBAC team fixtures", async () => {
-      await cleanupRbacTeamArtifacts(browser, testInfo);
-    });
-
     await test.step("Clean up RBAC admin API keys", async () => {
       await cleanupAdminApiKeys(
         browser,
         testInfo.project.use?.isMobile ?? false,
         testInfo.project.use?.viewport ?? null,
       );
+    });
+
+    await test.step("Clean up RBAC team fixtures", async () => {
+      await cleanupRbacTeamArtifacts(browser, testInfo);
     });
   });
 

--- a/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
@@ -1,0 +1,505 @@
+import { create, toJsonString } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
+import { type Browser, type Route } from "@playwright/test";
+import { testConfig } from "../config/test.config";
+import { expect, test } from "../fixtures/pageFixtures";
+import { CommonSteps } from "../helpers/commonSteps";
+import {
+  cleanupRbacTeamArtifacts,
+  provisionRoleAndLoginViaStoredAdminContext,
+  RBAC_ROLE_PREFIX,
+} from "../helpers/rbacTestSetup";
+import { generateRandomText } from "../helpers/testDataHelper";
+import { AuthPage } from "../pages/auth";
+import { MinersPage } from "../pages/miners";
+import { SettingsPage } from "../pages/settings";
+import { SettingsApiKeysPage } from "../pages/settingsApiKeys";
+import { SettingsTeamPage } from "../pages/settingsTeam";
+import {
+  CreateEnrollmentCodeResponseSchema,
+  FleetNodeEnrollmentStatus,
+  FleetNodeSummarySchema,
+  ListFleetNodesResponseSchema,
+} from "@/protoFleet/api/generated/fleetnodeadmin/v1/fleetnodeadmin_pb";
+import {
+  ListServerLogsResponseSchema,
+  LogEntrySchema,
+  LogLevel,
+} from "@/protoFleet/api/generated/serverlog/v1/serverlog_pb";
+
+const ADMIN_RBAC_API_KEY_PREFIX = "rbac_admin_api_key";
+const NODES_RPC_PATTERN = /FleetNodeAdminService\/ListFleetNodes/;
+const CREATE_ENROLLMENT_CODE_RPC_PATTERN = /FleetNodeAdminService\/CreateEnrollmentCode/;
+const SERVER_LOGS_RPC_PATTERN = /ServerLogService\/ListServerLogs/;
+
+async function provisionAdminRole(
+  browser: Browser,
+  commonSteps: Parameters<typeof provisionRoleAndLoginViaStoredAdminContext>[2],
+  {
+    permissionKeys,
+    roleDescription,
+  }: {
+    permissionKeys: string[];
+    roleDescription: string;
+  },
+) {
+  return await provisionRoleAndLoginViaStoredAdminContext(browser, test.info(), commonSteps, {
+    permissionKeys,
+    roleDescription,
+  });
+}
+
+function createTimestamp(date: Date) {
+  return create(TimestampSchema, {
+    seconds: BigInt(Math.floor(date.getTime() / 1000)),
+    nanos: 0,
+  });
+}
+
+function createNodeSummary({
+  fleetNodeId,
+  pendingEnrollmentId,
+  name,
+  enrollmentStatus,
+  createdAt,
+  lastSeenAt,
+  identityFingerprint,
+}: {
+  fleetNodeId: bigint;
+  pendingEnrollmentId?: bigint;
+  name: string;
+  enrollmentStatus: FleetNodeEnrollmentStatus;
+  createdAt?: Date;
+  lastSeenAt?: Date;
+  identityFingerprint: string;
+}) {
+  return create(FleetNodeSummarySchema, {
+    fleetNodeId,
+    pendingEnrollmentId,
+    name,
+    enrollmentStatus,
+    createdAt: createdAt ? createTimestamp(createdAt) : undefined,
+    lastSeenAt: lastSeenAt ? createTimestamp(lastSeenAt) : undefined,
+    identityFingerprint,
+  });
+}
+
+function fulfillFleetNodes(route: Route, nodes: ReturnType<typeof createNodeSummary>[]) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: toJsonString(
+      ListFleetNodesResponseSchema,
+      create(ListFleetNodesResponseSchema, {
+        fleetNodes: nodes,
+      }),
+    ),
+  });
+}
+
+function fulfillEnrollmentCode(route: Route) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: toJsonString(
+      CreateEnrollmentCodeResponseSchema,
+      create(CreateEnrollmentCodeResponseSchema, {
+        code: "rbac-enrollment-code-1234",
+        pendingEnrollmentId: 11n,
+        expiresAt: createTimestamp(new Date("2026-07-17T10:00:00Z")),
+      }),
+    ),
+  });
+}
+
+function createServerLogEntry({
+  id,
+  level,
+  message,
+  source,
+  time,
+}: {
+  id: bigint;
+  level: LogLevel;
+  message: string;
+  source: string;
+  time: Date;
+}) {
+  return create(LogEntrySchema, {
+    id,
+    level,
+    message,
+    source,
+    time: createTimestamp(time),
+  });
+}
+
+async function cleanupAdminApiKeys(
+  browser: Browser,
+  isMobile: boolean,
+  viewport: { height: number; width: number } | null,
+) {
+  const context = await browser.newContext({
+    baseURL: testConfig.baseUrl,
+    viewport: viewport ?? undefined,
+  });
+
+  try {
+    const page = await context.newPage();
+    await page.goto("/");
+
+    const authPage = new AuthPage(page, isMobile);
+    const minersPage = new MinersPage(page, isMobile);
+    const settingsPage = new SettingsPage(page, isMobile);
+    const settingsTeamPage = new SettingsTeamPage(page, isMobile);
+    const settingsApiKeysPage = new SettingsApiKeysPage(page, isMobile);
+    const commonSteps = new CommonSteps(authPage, minersPage, settingsPage, settingsTeamPage);
+
+    await commonSteps.loginAsAdmin({ forceReauth: true });
+    await settingsApiKeysPage.navigateToApiKeysSettings();
+    await settingsApiKeysPage.deleteApiKeysByPrefix(ADMIN_RBAC_API_KEY_PREFIX);
+  } finally {
+    await context.close();
+  }
+}
+
+test.describe("Proto Fleet - Admin RBAC", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test.afterAll("CLEANUP: delete admin RBAC fixtures", async ({ browser }, testInfo) => {
+    await cleanupRbacTeamArtifacts(browser, testInfo);
+    await cleanupAdminApiKeys(browser, testInfo.project.use?.isMobile ?? false, testInfo.project.use?.viewport ?? null);
+  });
+
+  test("Activity read role can view the activity log and export CSV", async ({
+    activityPage,
+    browser,
+    commonSteps,
+  }) => {
+    await test.step("Provision an activity-read role", async () => {
+      await provisionAdminRole(browser, commonSteps, {
+        roleDescription: "Read the organization activity log for RBAC coverage.",
+        permissionKeys: ["activity:read"],
+      });
+    });
+
+    await test.step("Open Activity and validate the feed loads", async () => {
+      await activityPage.navigateToActivityPage();
+      await activityPage.waitForActivityListToLoad();
+    });
+
+    await test.step("Export the activity feed as CSV", async () => {
+      const download = await activityPage.exportCsv();
+      expect(download.suggestedFilename()).toMatch(/activity-export.*\.csv$/i);
+    });
+  });
+
+  test("Server-log read role can access recent server logs", async ({ browser, commonSteps, page, serverLogsPage }) => {
+    await page.route(SERVER_LOGS_RPC_PATTERN, async (route) => {
+      return await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: toJsonString(
+          ListServerLogsResponseSchema,
+          create(ListServerLogsResponseSchema, {
+            entries: [
+              createServerLogEntry({
+                id: 1n,
+                level: LogLevel.INFO,
+                message: "server booted",
+                source: "fleetd",
+                time: new Date("2026-07-17T09:00:00Z"),
+              }),
+              createServerLogEntry({
+                id: 2n,
+                level: LogLevel.WARN,
+                message: "node disconnected",
+                source: "scheduler",
+                time: new Date("2026-07-17T09:00:05Z"),
+              }),
+            ],
+            latestId: 2n,
+            bufferSize: 2,
+            truncated: false,
+          }),
+        ),
+      });
+    });
+
+    await test.step("Provision a server-log-read role", async () => {
+      await provisionAdminRole(browser, commonSteps, {
+        roleDescription: "Read server logs for RBAC coverage.",
+        permissionKeys: ["serverlog:read"],
+      });
+    });
+
+    await test.step("Open Server Logs and validate the mocked feed", async () => {
+      await serverLogsPage.navigateToServerLogsSettings();
+      await serverLogsPage.validateServerLogsPageOpened();
+      await serverLogsPage.waitForLogRowCount(2);
+      await serverLogsPage.validateLogRowVisible("fleetd server booted");
+      await serverLogsPage.validateLogRowVisible("scheduler node disconnected");
+    });
+  });
+
+  test("Fleet-node read role can view nodes without enrollment controls", async ({
+    browser,
+    commonSteps,
+    page,
+    settingsNodesPage,
+  }) => {
+    await page.route(NODES_RPC_PATTERN, async (route) => {
+      return await fulfillFleetNodes(route, [
+        createNodeSummary({
+          fleetNodeId: 7n,
+          name: "node-01",
+          enrollmentStatus: FleetNodeEnrollmentStatus.CONFIRMED,
+          identityFingerprint: "SHA256:rbac-node-01",
+          createdAt: new Date("2026-07-17T08:00:00Z"),
+          lastSeenAt: new Date("2026-07-17T09:00:00Z"),
+        }),
+      ]);
+    });
+
+    await test.step("Provision a fleet-node-read role", async () => {
+      await provisionAdminRole(browser, commonSteps, {
+        roleDescription: "View nodes without enrollment controls for RBAC coverage.",
+        permissionKeys: ["fleetnode:read"],
+      });
+    });
+
+    await test.step("Open Nodes and validate management controls stay hidden", async () => {
+      await settingsNodesPage.navigateToNodesSettings();
+      await settingsNodesPage.waitForNodesListToLoad();
+      await settingsNodesPage.validateNodeVisible("node-01");
+      await settingsNodesPage.validateEnrollNodeHidden();
+      await settingsNodesPage.validateNodeActionHidden("Confirm enrollment");
+      await settingsNodesPage.validateNodeActionHidden("Revoke");
+    });
+  });
+
+  test("Fleet-node manage role can open enrollment and confirmation controls", async ({
+    browser,
+    commonSteps,
+    page,
+    settingsNodesPage,
+  }) => {
+    let showAwaitingNode = false;
+
+    await page.route(NODES_RPC_PATTERN, async (route) => {
+      return await fulfillFleetNodes(
+        route,
+        showAwaitingNode
+          ? [
+              createNodeSummary({
+                fleetNodeId: 11n,
+                pendingEnrollmentId: 11n,
+                name: "node-pending",
+                enrollmentStatus: FleetNodeEnrollmentStatus.AWAITING_CONFIRMATION,
+                identityFingerprint: "SHA256:rbac-pending-node",
+                lastSeenAt: new Date("2026-07-17T09:05:00Z"),
+              }),
+            ]
+          : [
+              createNodeSummary({
+                fleetNodeId: 7n,
+                name: "node-01",
+                enrollmentStatus: FleetNodeEnrollmentStatus.CONFIRMED,
+                identityFingerprint: "SHA256:rbac-node-01",
+                createdAt: new Date("2026-07-17T08:00:00Z"),
+                lastSeenAt: new Date("2026-07-17T09:00:00Z"),
+              }),
+            ],
+      );
+    });
+    await page.route(CREATE_ENROLLMENT_CODE_RPC_PATTERN, async (route) => {
+      return await fulfillEnrollmentCode(route);
+    });
+
+    await test.step("Provision a fleet-node-manage role", async () => {
+      await provisionAdminRole(browser, commonSteps, {
+        roleDescription: "Manage nodes for RBAC coverage.",
+        permissionKeys: ["fleetnode:read", "fleetnode:manage"],
+      });
+    });
+
+    await test.step("Open Nodes and start a new enrollment", async () => {
+      await settingsNodesPage.navigateToNodesSettings();
+      await settingsNodesPage.waitForNodesListToLoad();
+      await settingsNodesPage.validateEnrollNodeVisible();
+      await settingsNodesPage.clickEnrollNode();
+      await settingsNodesPage.validateEnrollNodeModalOpened();
+      await page.keyboard.press("Escape");
+      showAwaitingNode = true;
+    });
+
+    await test.step("Open the pending-node confirmation controls", async () => {
+      await settingsNodesPage.reloadPage();
+      await settingsNodesPage.waitForNodesListToLoad();
+      await settingsNodesPage.clickNodeActionsMenu("node-pending");
+      await settingsNodesPage.validateNodeActionVisible("Confirm enrollment");
+      await settingsNodesPage.validateNodeActionVisible("Revoke");
+      await settingsNodesPage.clickNodeAction("Confirm enrollment");
+      await settingsNodesPage.validateConfirmNodeModalOpened("node-pending");
+    });
+  });
+
+  test("API-key manage role can create and revoke API keys", async ({ browser, commonSteps, settingsApiKeysPage }) => {
+    const apiKeyName = generateRandomText(ADMIN_RBAC_API_KEY_PREFIX);
+
+    await test.step("Provision an API-key-manage role", async () => {
+      await provisionAdminRole(browser, commonSteps, {
+        roleDescription: "Manage API keys for RBAC coverage.",
+        permissionKeys: ["apikey:manage"],
+      });
+    });
+
+    await test.step("Open Integrations and create an API key", async () => {
+      await settingsApiKeysPage.navigateToApiKeysSettings();
+      await settingsApiKeysPage.validateApiKeysPageOpened();
+      await settingsApiKeysPage.clickCreateApiKey();
+      await settingsApiKeysPage.inputApiKeyName(apiKeyName);
+      await settingsApiKeysPage.clickCreateInModal();
+      await settingsApiKeysPage.validateApiKeyCreated();
+      await settingsApiKeysPage.clickDone();
+      await settingsApiKeysPage.validateApiKeyVisible(apiKeyName);
+    });
+
+    await test.step("Revoke the API key", async () => {
+      await settingsApiKeysPage.clickRevokeApiKey(apiKeyName);
+      await settingsApiKeysPage.confirmRevokeApiKey();
+      await settingsApiKeysPage.validateApiKeyNotVisible(apiKeyName);
+    });
+  });
+
+  test("User-read role can list users without management controls", async ({
+    browser,
+    commonSteps,
+    settingsPage,
+    settingsTeamPage,
+  }) => {
+    await test.step("Provision a user-read role", async () => {
+      await provisionAdminRole(browser, commonSteps, {
+        roleDescription: "Read team members without management controls for RBAC coverage.",
+        permissionKeys: ["user:read"],
+      });
+    });
+
+    await test.step("Open Team and validate the members list is read-only", async () => {
+      await settingsPage.navigateToTeamSettings();
+      await settingsTeamPage.validateTeamSettingsPageOpened();
+      await settingsTeamPage.validateMemberVisible(testConfig.users.admin.username);
+      await settingsTeamPage.validateAddTeamMemberHidden();
+      await settingsTeamPage.validateMemberActionsHidden(testConfig.users.admin.username);
+      await settingsTeamPage.validateRolesTabHidden();
+    });
+  });
+
+  test("User-manage role can create, reset, reassign, and deactivate users", async ({
+    browser,
+    commonSteps,
+    settingsPage,
+    settingsTeamPage,
+  }) => {
+    const createdUsername = generateRandomText("rbac_user_manage_member");
+    const baseMemberRole = generateRandomText(RBAC_ROLE_PREFIX);
+    const editedMemberRole = generateRandomText(RBAC_ROLE_PREFIX);
+
+    await test.step("Create assignable member roles as admin", async () => {
+      await commonSteps.loginAsAdmin({ forceReauth: true });
+      await settingsPage.navigateToTeamSettings();
+      await settingsTeamPage.validateTeamSettingsPageOpened();
+      await settingsTeamPage.openRolesTab();
+      await settingsTeamPage.createCustomRole(baseMemberRole, "Base assignable RBAC member role.", ["activity:read"]);
+      await settingsTeamPage.createCustomRole(editedMemberRole, "Edited assignable RBAC member role.", [
+        "activity:read",
+        "user:read",
+      ]);
+    });
+
+    await test.step("Provision a user-manage role", async () => {
+      await provisionAdminRole(browser, commonSteps, {
+        roleDescription: "Manage users for RBAC coverage.",
+        permissionKeys: ["activity:read", "user:read", "user:manage"],
+      });
+    });
+
+    await test.step("Create a team member with an assignable custom role", async () => {
+      await settingsPage.navigateToTeamSettings();
+      await settingsTeamPage.validateTeamSettingsPageOpened();
+      await settingsTeamPage.openMembersTab();
+      await settingsTeamPage.createTeamMemberAndGetTemporaryPassword(createdUsername, baseMemberRole);
+      await settingsTeamPage.validateMemberRole(createdUsername, baseMemberRole);
+    });
+
+    await test.step("Reset the member password", async () => {
+      await settingsTeamPage.clickMemberActionsMenu(createdUsername);
+      await settingsTeamPage.clickResetPassword();
+      await settingsTeamPage.clickResetMemberPasswordConfirm();
+      await settingsTeamPage.validatePasswordReset();
+      await settingsTeamPage.clickDone();
+    });
+
+    await test.step("Reassign the member role", async () => {
+      await settingsTeamPage.clickMemberActionsMenu(createdUsername);
+      await settingsTeamPage.clickEditRole();
+      await settingsTeamPage.selectEditedRole(editedMemberRole);
+      await settingsTeamPage.clickSaveEditedRole();
+      await settingsTeamPage.validateMemberRole(createdUsername, editedMemberRole);
+    });
+
+    await test.step("Deactivate the member", async () => {
+      await settingsTeamPage.clickMemberActionsMenu(createdUsername);
+      await settingsTeamPage.clickDeactivate();
+      await settingsTeamPage.clickConfirmDeactivation();
+      await settingsTeamPage.validateMemberNotInList(createdUsername);
+    });
+  });
+
+  test("Role-manage role can create, edit, and delete custom roles while built-in roles stay immutable", async ({
+    browser,
+    commonSteps,
+    settingsPage,
+    settingsTeamPage,
+  }) => {
+    const roleName = generateRandomText(RBAC_ROLE_PREFIX);
+    const updatedRoleName = generateRandomText(RBAC_ROLE_PREFIX);
+
+    await test.step("Provision a role-manage role", async () => {
+      await provisionAdminRole(browser, commonSteps, {
+        roleDescription: "Manage roles for RBAC coverage.",
+        permissionKeys: ["activity:read", "role:manage"],
+      });
+    });
+
+    await test.step("Open Team roles and validate built-in roles are immutable", async () => {
+      await settingsPage.navigateToTeamSettings();
+      await settingsTeamPage.validateTeamSettingsPageOpened();
+      await settingsTeamPage.openRolesTab();
+      await settingsTeamPage.validateSystemRoleLockVisible();
+    });
+
+    await test.step("Create a custom role", async () => {
+      await settingsTeamPage.createCustomRole(roleName, "Custom RBAC role under test.", ["activity:read"]);
+    });
+
+    await test.step("Edit the custom role", async () => {
+      await settingsTeamPage.clickRoleActionsMenu(roleName);
+      await settingsTeamPage.clickEditRoleAction();
+      await settingsTeamPage.inputRoleName(updatedRoleName);
+      await settingsTeamPage.inputRoleDescription("Updated RBAC role description.");
+      await settingsTeamPage.clickSaveRoleChanges();
+      await settingsTeamPage.validateRoleVisible(updatedRoleName);
+      await settingsTeamPage.validateRoleNotVisible(roleName);
+    });
+
+    await test.step("Delete the custom role", async () => {
+      await settingsTeamPage.clickRoleActionsMenu(updatedRoleName);
+      await settingsTeamPage.clickDeleteRoleAction();
+      await settingsTeamPage.clickDeleteRoleConfirm();
+      await settingsTeamPage.validateRoleNotVisible(updatedRoleName);
+    });
+  });
+});

--- a/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
@@ -1,167 +1,15 @@
-import { create, toJsonString } from "@bufbuild/protobuf";
-import { TimestampSchema } from "@bufbuild/protobuf/wkt";
-import { type Browser, type Route } from "@playwright/test";
 import { testConfig } from "../config/test.config";
 import { expect, test } from "../fixtures/pageFixtures";
-import { CommonSteps } from "../helpers/commonSteps";
 import {
-  cleanupRbacTeamArtifacts,
-  provisionRoleAndLoginViaStoredAdminContext,
-  RBAC_ROLE_PREFIX,
-} from "../helpers/rbacTestSetup";
+  ADMIN_RBAC_API_KEY_PREFIX,
+  cleanupAdminApiKeys,
+  mockAdminServerLogs,
+  mockManageableNodes,
+  mockReadOnlyNodes,
+  provisionAdminRole,
+} from "../helpers/rbacAdminTestSetup";
+import { cleanupRbacTeamArtifacts, RBAC_ROLE_PREFIX } from "../helpers/rbacTestSetup";
 import { generateRandomText } from "../helpers/testDataHelper";
-import { AuthPage } from "../pages/auth";
-import { MinersPage } from "../pages/miners";
-import { SettingsPage } from "../pages/settings";
-import { SettingsApiKeysPage } from "../pages/settingsApiKeys";
-import { SettingsTeamPage } from "../pages/settingsTeam";
-import {
-  CreateEnrollmentCodeResponseSchema,
-  FleetNodeEnrollmentStatus,
-  FleetNodeSummarySchema,
-  ListFleetNodesResponseSchema,
-} from "@/protoFleet/api/generated/fleetnodeadmin/v1/fleetnodeadmin_pb";
-import {
-  ListServerLogsResponseSchema,
-  LogEntrySchema,
-  LogLevel,
-} from "@/protoFleet/api/generated/serverlog/v1/serverlog_pb";
-
-const ADMIN_RBAC_API_KEY_PREFIX = "rbac_admin_api_key";
-const NODES_RPC_PATTERN = /FleetNodeAdminService\/ListFleetNodes/;
-const CREATE_ENROLLMENT_CODE_RPC_PATTERN = /FleetNodeAdminService\/CreateEnrollmentCode/;
-const SERVER_LOGS_RPC_PATTERN = /ServerLogService\/ListServerLogs/;
-
-async function provisionAdminRole(
-  browser: Browser,
-  commonSteps: Parameters<typeof provisionRoleAndLoginViaStoredAdminContext>[2],
-  {
-    permissionKeys,
-    roleDescription,
-  }: {
-    permissionKeys: string[];
-    roleDescription: string;
-  },
-) {
-  return await provisionRoleAndLoginViaStoredAdminContext(browser, test.info(), commonSteps, {
-    permissionKeys,
-    roleDescription,
-  });
-}
-
-function createTimestamp(date: Date) {
-  return create(TimestampSchema, {
-    seconds: BigInt(Math.floor(date.getTime() / 1000)),
-    nanos: 0,
-  });
-}
-
-function createNodeSummary({
-  fleetNodeId,
-  pendingEnrollmentId,
-  name,
-  enrollmentStatus,
-  createdAt,
-  lastSeenAt,
-  identityFingerprint,
-}: {
-  fleetNodeId: bigint;
-  pendingEnrollmentId?: bigint;
-  name: string;
-  enrollmentStatus: FleetNodeEnrollmentStatus;
-  createdAt?: Date;
-  lastSeenAt?: Date;
-  identityFingerprint: string;
-}) {
-  return create(FleetNodeSummarySchema, {
-    fleetNodeId,
-    pendingEnrollmentId,
-    name,
-    enrollmentStatus,
-    createdAt: createdAt ? createTimestamp(createdAt) : undefined,
-    lastSeenAt: lastSeenAt ? createTimestamp(lastSeenAt) : undefined,
-    identityFingerprint,
-  });
-}
-
-function fulfillFleetNodes(route: Route, nodes: ReturnType<typeof createNodeSummary>[]) {
-  return route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    body: toJsonString(
-      ListFleetNodesResponseSchema,
-      create(ListFleetNodesResponseSchema, {
-        fleetNodes: nodes,
-      }),
-    ),
-  });
-}
-
-function fulfillEnrollmentCode(route: Route) {
-  return route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    body: toJsonString(
-      CreateEnrollmentCodeResponseSchema,
-      create(CreateEnrollmentCodeResponseSchema, {
-        code: "rbac-enrollment-code-1234",
-        pendingEnrollmentId: 11n,
-        expiresAt: createTimestamp(new Date("2026-07-17T10:00:00Z")),
-      }),
-    ),
-  });
-}
-
-function createServerLogEntry({
-  id,
-  level,
-  message,
-  source,
-  time,
-}: {
-  id: bigint;
-  level: LogLevel;
-  message: string;
-  source: string;
-  time: Date;
-}) {
-  return create(LogEntrySchema, {
-    id,
-    level,
-    message,
-    source,
-    time: createTimestamp(time),
-  });
-}
-
-async function cleanupAdminApiKeys(
-  browser: Browser,
-  isMobile: boolean,
-  viewport: { height: number; width: number } | null,
-) {
-  const context = await browser.newContext({
-    baseURL: testConfig.baseUrl,
-    viewport: viewport ?? undefined,
-  });
-
-  try {
-    const page = await context.newPage();
-    await page.goto("/");
-
-    const authPage = new AuthPage(page, isMobile);
-    const minersPage = new MinersPage(page, isMobile);
-    const settingsPage = new SettingsPage(page, isMobile);
-    const settingsTeamPage = new SettingsTeamPage(page, isMobile);
-    const settingsApiKeysPage = new SettingsApiKeysPage(page, isMobile);
-    const commonSteps = new CommonSteps(authPage, minersPage, settingsPage, settingsTeamPage);
-
-    await commonSteps.loginAsAdmin({ forceReauth: true });
-    await settingsApiKeysPage.navigateToApiKeysSettings();
-    await settingsApiKeysPage.deleteApiKeysByPrefix(ADMIN_RBAC_API_KEY_PREFIX);
-  } finally {
-    await context.close();
-  }
-}
 
 test.describe("Proto Fleet - Admin RBAC", () => {
   test.beforeEach(async ({ page }) => {
@@ -169,8 +17,17 @@ test.describe("Proto Fleet - Admin RBAC", () => {
   });
 
   test.afterAll("CLEANUP: delete admin RBAC fixtures", async ({ browser }, testInfo) => {
-    await cleanupRbacTeamArtifacts(browser, testInfo);
-    await cleanupAdminApiKeys(browser, testInfo.project.use?.isMobile ?? false, testInfo.project.use?.viewport ?? null);
+    await test.step("Clean up RBAC team fixtures", async () => {
+      await cleanupRbacTeamArtifacts(browser, testInfo);
+    });
+
+    await test.step("Clean up RBAC admin API keys", async () => {
+      await cleanupAdminApiKeys(
+        browser,
+        testInfo.project.use?.isMobile ?? false,
+        testInfo.project.use?.viewport ?? null,
+      );
+    });
   });
 
   test("Activity read role can view the activity log and export CSV", async ({
@@ -179,7 +36,7 @@ test.describe("Proto Fleet - Admin RBAC", () => {
     commonSteps,
   }) => {
     await test.step("Provision an activity-read role", async () => {
-      await provisionAdminRole(browser, commonSteps, {
+      await provisionAdminRole(browser, test.info(), commonSteps, {
         roleDescription: "Read the organization activity log for RBAC coverage.",
         permissionKeys: ["activity:read"],
       });
@@ -197,39 +54,12 @@ test.describe("Proto Fleet - Admin RBAC", () => {
   });
 
   test("Server-log read role can access recent server logs", async ({ browser, commonSteps, page, serverLogsPage }) => {
-    await page.route(SERVER_LOGS_RPC_PATTERN, async (route) => {
-      return await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: toJsonString(
-          ListServerLogsResponseSchema,
-          create(ListServerLogsResponseSchema, {
-            entries: [
-              createServerLogEntry({
-                id: 1n,
-                level: LogLevel.INFO,
-                message: "server booted",
-                source: "fleetd",
-                time: new Date("2026-07-17T09:00:00Z"),
-              }),
-              createServerLogEntry({
-                id: 2n,
-                level: LogLevel.WARN,
-                message: "node disconnected",
-                source: "scheduler",
-                time: new Date("2026-07-17T09:00:05Z"),
-              }),
-            ],
-            latestId: 2n,
-            bufferSize: 2,
-            truncated: false,
-          }),
-        ),
-      });
+    await test.step("Mock the Server Logs backend data", async () => {
+      await mockAdminServerLogs(page);
     });
 
     await test.step("Provision a server-log-read role", async () => {
-      await provisionAdminRole(browser, commonSteps, {
+      await provisionAdminRole(browser, test.info(), commonSteps, {
         roleDescription: "Read server logs for RBAC coverage.",
         permissionKeys: ["serverlog:read"],
       });
@@ -250,21 +80,12 @@ test.describe("Proto Fleet - Admin RBAC", () => {
     page,
     settingsNodesPage,
   }) => {
-    await page.route(NODES_RPC_PATTERN, async (route) => {
-      return await fulfillFleetNodes(route, [
-        createNodeSummary({
-          fleetNodeId: 7n,
-          name: "node-01",
-          enrollmentStatus: FleetNodeEnrollmentStatus.CONFIRMED,
-          identityFingerprint: "SHA256:rbac-node-01",
-          createdAt: new Date("2026-07-17T08:00:00Z"),
-          lastSeenAt: new Date("2026-07-17T09:00:00Z"),
-        }),
-      ]);
+    await test.step("Mock the Nodes backend data", async () => {
+      await mockReadOnlyNodes(page);
     });
 
     await test.step("Provision a fleet-node-read role", async () => {
-      await provisionAdminRole(browser, commonSteps, {
+      await provisionAdminRole(browser, test.info(), commonSteps, {
         roleDescription: "View nodes without enrollment controls for RBAC coverage.",
         permissionKeys: ["fleetnode:read"],
       });
@@ -286,40 +107,12 @@ test.describe("Proto Fleet - Admin RBAC", () => {
     page,
     settingsNodesPage,
   }) => {
-    let showAwaitingNode = false;
-
-    await page.route(NODES_RPC_PATTERN, async (route) => {
-      return await fulfillFleetNodes(
-        route,
-        showAwaitingNode
-          ? [
-              createNodeSummary({
-                fleetNodeId: 11n,
-                pendingEnrollmentId: 11n,
-                name: "node-pending",
-                enrollmentStatus: FleetNodeEnrollmentStatus.AWAITING_CONFIRMATION,
-                identityFingerprint: "SHA256:rbac-pending-node",
-                lastSeenAt: new Date("2026-07-17T09:05:00Z"),
-              }),
-            ]
-          : [
-              createNodeSummary({
-                fleetNodeId: 7n,
-                name: "node-01",
-                enrollmentStatus: FleetNodeEnrollmentStatus.CONFIRMED,
-                identityFingerprint: "SHA256:rbac-node-01",
-                createdAt: new Date("2026-07-17T08:00:00Z"),
-                lastSeenAt: new Date("2026-07-17T09:00:00Z"),
-              }),
-            ],
-      );
-    });
-    await page.route(CREATE_ENROLLMENT_CODE_RPC_PATTERN, async (route) => {
-      return await fulfillEnrollmentCode(route);
+    const nodesMock = await test.step("Mock the Nodes backend data and enrollment flow", async () => {
+      return await mockManageableNodes(page);
     });
 
     await test.step("Provision a fleet-node-manage role", async () => {
-      await provisionAdminRole(browser, commonSteps, {
+      await provisionAdminRole(browser, test.info(), commonSteps, {
         roleDescription: "Manage nodes for RBAC coverage.",
         permissionKeys: ["fleetnode:read", "fleetnode:manage"],
       });
@@ -332,7 +125,7 @@ test.describe("Proto Fleet - Admin RBAC", () => {
       await settingsNodesPage.clickEnrollNode();
       await settingsNodesPage.validateEnrollNodeModalOpened();
       await page.keyboard.press("Escape");
-      showAwaitingNode = true;
+      nodesMock.showAwaitingNode();
     });
 
     await test.step("Open the pending-node confirmation controls", async () => {
@@ -350,7 +143,7 @@ test.describe("Proto Fleet - Admin RBAC", () => {
     const apiKeyName = generateRandomText(ADMIN_RBAC_API_KEY_PREFIX);
 
     await test.step("Provision an API-key-manage role", async () => {
-      await provisionAdminRole(browser, commonSteps, {
+      await provisionAdminRole(browser, test.info(), commonSteps, {
         roleDescription: "Manage API keys for RBAC coverage.",
         permissionKeys: ["apikey:manage"],
       });
@@ -381,7 +174,7 @@ test.describe("Proto Fleet - Admin RBAC", () => {
     settingsTeamPage,
   }) => {
     await test.step("Provision a user-read role", async () => {
-      await provisionAdminRole(browser, commonSteps, {
+      await provisionAdminRole(browser, test.info(), commonSteps, {
         roleDescription: "Read team members without management controls for RBAC coverage.",
         permissionKeys: ["user:read"],
       });
@@ -420,7 +213,7 @@ test.describe("Proto Fleet - Admin RBAC", () => {
     });
 
     await test.step("Provision a user-manage role", async () => {
-      await provisionAdminRole(browser, commonSteps, {
+      await provisionAdminRole(browser, test.info(), commonSteps, {
         roleDescription: "Manage users for RBAC coverage.",
         permissionKeys: ["activity:read", "user:read", "user:manage"],
       });
@@ -468,7 +261,7 @@ test.describe("Proto Fleet - Admin RBAC", () => {
     const updatedRoleName = generateRandomText(RBAC_ROLE_PREFIX);
 
     await test.step("Provision a role-manage role", async () => {
-      await provisionAdminRole(browser, commonSteps, {
+      await provisionAdminRole(browser, test.info(), commonSteps, {
         roleDescription: "Manage roles for RBAC coverage.",
         permissionKeys: ["activity:read", "role:manage"],
       });


### PR DESCRIPTION
Reviewable diff: +0/-0 across 0 files (excludes generated, test, and story files).

## Summary

This PR adds Playwright RBAC coverage for the remaining administration permissions in Proto Fleet. It verifies that permission-scoped users can reach the admin surfaces they should see, are blocked from controls they should not have, and can complete one minimal management round-trip where the permission is explicitly mutating.

The new coverage focuses on organization activity, server logs, fleet nodes, API keys, team members, and custom roles. It keeps the checks compact and deterministic so these permission tests validate access boundaries without re-testing the deeper feature behavior already covered elsewhere.

## How it works

The new `rbacAdmin.spec.ts` provisions custom roles through the stored-admin RBAC helper flow, logs in as the scoped user, and then exercises one narrow admin scenario per permission area. Read-only cases validate surface visibility and hidden controls, while manage cases perform the smallest meaningful action such as creating and revoking an API key or creating, editing, and deleting a custom role.

For surfaces where live backend data would otherwise make the test noisy or fragile, the spec mocks the underlying RPC responses at the browser boundary. Server logs and fleet-node list/enrollment states are therefore deterministic while still validating the client-side permission gating, route access, and visible actions that a real user experiences.

Cleanup stays concentrated at the spec level instead of after every test. Team/role fixtures are removed through the existing stored-admin RBAC cleanup helper, and API keys created by the spec are revoked once at the end so the test run stays fast while leaving the backend reusable for later local runs.

## Diagrams

```mermaid
flowchart TD
  A["Stored admin auth state"] --> B["Provision custom RBAC role + member"]
  B --> C["Log in as scoped user"]
  C --> D["Open admin surface"]
  D --> E["Validate allowed view or hidden control"]
  E --> F["Run one minimal manage action when applicable"]
  F --> G["Spec-level cleanup of RBAC fixtures"]
```

```mermaid
flowchart TD
  A["RBAC admin spec"] --> B["Live backend flow"]
  A --> C["Mocked browser RPC flow"]
  B --> D["Activity export"]
  B --> E["API key create/revoke"]
  B --> F["User + role management"]
  C --> G["Server logs feed"]
  C --> H["Fleet nodes list + enrollment modal states"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts` | Added the new admin RBAC scenarios and spec-level cleanup | Main behavior under review; shows exactly which permissions are covered and how |
| `client/e2eTests/protoFleet/pages/settingsNodes.ts` | Added a Nodes settings page object for list, modal, and action assertions | New helper surface that keeps the spec readable and reusable |
| `client/e2eTests/protoFleet/pages/settingsTeam.ts` | Added RBAC-oriented role/member assertions and role-action helpers | Extends existing team helpers to support read-only and role-manage checks |
| `client/e2eTests/protoFleet/pages/base.ts` | Added Nodes settings navigation helper | Needed so the new spec uses the same navigation pattern as other settings specs |
| `client/e2eTests/protoFleet/fixtures/pageFixtures.ts` | Registered the new Nodes page fixture | Wires the new page object into the shared Playwright fixture model |

## Key technical decisions & trade-offs

- Mocked server logs and fleet-node RPCs in the RBAC spec instead of relying on ambient backend data so permission checks stay deterministic and minimal.
- Reused the stored-admin RBAC provisioning path instead of building new setup flows so the new coverage matches the existing RBAC test model.
- Kept cleanup at `afterAll` scope for the spec instead of per-test hooks to reduce repeated waits while still removing created users, roles, and API keys.
- Used `user:read + user:manage` for the mutating team-member scenario because that reflects the actual usable Team UI path after the members/roles merge.

## Testing & validation

- `./node_modules/.bin/eslint e2eTests/protoFleet/pages/base.ts e2eTests/protoFleet/pages/settingsNodes.ts e2eTests/protoFleet/pages/settingsTeam.ts e2eTests/protoFleet/fixtures/pageFixtures.ts e2eTests/protoFleet/spec/rbacAdmin.spec.ts`
- `./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/rbacAdmin.spec.ts --project=desktop --no-deps --reporter=line`
- `./node_modules/.bin/playwright test -c e2eTests/protoFleet/playwright.config.ts e2eTests/protoFleet/spec/rbacAdmin.spec.ts --project=mobile --no-deps --reporter=line`

Not covered here:
- Full fleet-node enrollment completion against a real daemon host; the RBAC spec only validates access to the enrollment and confirmation UI states.
- Deep behavior of activity export, server-log export, or role/member workflows beyond the narrow permission boundary checks already covered by their dedicated specs.
