### PR TITLE
fix(db): require shared transaction helpers

### DIFF
--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -18,7 +18,6 @@ linters:
     - errname
     - errorlint
     - exhaustruct
-    - forbidigo
     - funcorder
     - funlen
     - gochecknoglobals
@@ -66,7 +65,8 @@ linters:
       threshold: 100
     forbidigo:
       forbid:
-        - pattern: fmt\.Errorf
+        - pattern: \.(Begin|BeginTx)$
+          msg: use db.WithTransaction or db.WithTransactionNoResult
     goconst:
       min-len: 8
       min-occurrences: 3
@@ -83,6 +83,7 @@ linters:
     generated: lax
     rules:
       - linters:
+          - forbidigo
           - goconst
           - scopelint
         path: _test\.go

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -1796,6 +1796,7 @@ func (s *SQLDeviceStore) UpdateDeviceCustomNames(ctx context.Context, orgID int6
 		customNames = append(customNames, name)
 	}
 
+	//nolint:forbidigo // This legacy path executes raw SQL and cannot use the sqlc transaction helper yet.
 	tx, err := s.conn.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to begin rename transaction: %v", err)

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -1796,7 +1796,7 @@ func (s *SQLDeviceStore) UpdateDeviceCustomNames(ctx context.Context, orgID int6
 		customNames = append(customNames, name)
 	}
 
-	//nolint:forbidigo // This legacy path executes raw SQL and cannot use the sqlc transaction helper yet.
+	//nolint:forbidigo // This legacy path uses raw array SQL; moving it requires a separately validated sqlc query.
 	tx, err := s.conn.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to begin rename transaction: %v", err)

--- a/server/internal/domain/stores/sqlstores/notification_history.go
+++ b/server/internal/domain/stores/sqlstores/notification_history.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/block/proto-fleet/server/generated/sqlc"
 	"github.com/block/proto-fleet/server/internal/domain/notificationhistory"
+	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 )
 
 // > Grafana repeat_interval (1h, notification-policies.yaml) with margin for one missed re-notify; keep in sync.
@@ -54,33 +55,24 @@ func (s *SQLNotificationHistoryStore) InsertBatch(ctx context.Context, notifs []
 	if len(notifs) == 0 {
 		return nil
 	}
-	tx, err := s.conn.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin notification batch tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }() // no-op once committed
-
-	q := sqlc.New(tx)
-	for start := 0; start < len(notifs); start += maxBatchRows {
-		end := min(start+maxBatchRows, len(notifs))
-		chunk := notifs[start:end]
-		payload, err := marshalBulkNotificationRows(chunk)
-		if err != nil {
-			return fmt.Errorf("marshal notification batch chunk: %w", err)
+	return db.WithTransactionNoResult(ctx, s.conn.DB, func(q *sqlc.Queries) error {
+		for start := 0; start < len(notifs); start += maxBatchRows {
+			end := min(start+maxBatchRows, len(notifs))
+			chunk := notifs[start:end]
+			payload, err := marshalBulkNotificationRows(chunk)
+			if err != nil {
+				return fmt.Errorf("marshal notification batch chunk: %w", err)
+			}
+			inserted, err := q.BulkInsertNotificationHistory(ctx, payload)
+			if err != nil {
+				return fmt.Errorf("insert notification batch chunk: %w", err)
+			}
+			if inserted != int64(len(chunk)) {
+				return fmt.Errorf("insert notification batch chunk: inserted %d of %d rows", inserted, len(chunk))
+			}
 		}
-		inserted, err := q.BulkInsertNotificationHistory(ctx, payload)
-		if err != nil {
-			return fmt.Errorf("insert notification batch chunk: %w", err)
-		}
-		if inserted != int64(len(chunk)) {
-			return fmt.Errorf("insert notification batch chunk: inserted %d of %d rows", inserted, len(chunk))
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit notification batch: %w", err)
-	}
-	return nil
+		return nil
+	})
 }
 
 // bulkNotificationRow is the per-row JSON shape for BulkInsertNotificationHistory's jsonb_to_recordset; tags match its column names.

--- a/server/internal/infrastructure/db/with_transaction.go
+++ b/server/internal/infrastructure/db/with_transaction.go
@@ -20,15 +20,17 @@ func WithTransaction[T any](ctx context.Context, db *sql.DB, action func(q *sqlc
 func withTransactionWithRetry[T any](ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) (T, error), config RetryConfig, txOpts *sql.TxOptions) (T, error) {
 	var zero T
 	var lastErr error
+	attempts := 0
 	currentBackoff := config.InitialBackoff
 
 	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
 		select {
 		case <-ctx.Done():
-			return zero, fleeterror.NewInternalErrorf("context aborted: %v", ctx.Err())
+			return zero, fleeterror.NewInternalErrorf("context aborted: %w", ctx.Err())
 		default:
 		}
 
+		attempts = attempt
 		result, err := executeTransaction(ctx, db, action, txOpts)
 		if err == nil {
 			return result, nil
@@ -47,19 +49,20 @@ func withTransactionWithRetry[T any](ctx context.Context, db *sql.DB, action fun
 
 		select {
 		case <-ctx.Done():
-			return zero, fleeterror.NewInternalErrorf("context aborted: %v", ctx.Err())
+			return zero, fleeterror.NewInternalErrorf("context aborted: %w", ctx.Err())
 		case <-time.After(sleepDuration):
 		}
 
 		currentBackoff = time.Duration(float64(currentBackoff) * config.BackoffMultiplier)
 	}
 
-	// Preserve FleetError if the original error was already a business error
+	// Preserve non-retryable FleetError values so business error codes survive
+	// the transaction boundary unchanged.
 	var fleetErr fleeterror.FleetError
-	if errors.As(lastErr, &fleetErr) {
+	if !IsRetryablePostgresError(lastErr) && errors.As(lastErr, &fleetErr) {
 		return zero, fleetErr
 	}
-	return zero, fleeterror.NewInternalErrorf("transaction failed after %d attempts: %v", config.MaxAttempts, lastErr)
+	return zero, fleeterror.NewInternalErrorf("transaction failed after %d attempts: %w", attempts, lastErr)
 }
 
 func executeTransaction[T any](ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) (T, error), txOpts *sql.TxOptions) (T, error) {
@@ -68,7 +71,7 @@ func executeTransaction[T any](ctx context.Context, db *sql.DB, action func(q *s
 	//nolint:forbidigo // This helper is the canonical boundary for opening SQL transactions.
 	tx, err := db.BeginTx(ctx, txOpts)
 	if err != nil {
-		return zero, fleeterror.NewInternalErrorf("error opening tx: %v", err)
+		return zero, fleeterror.NewInternalErrorf("error opening tx: %w", err)
 	}
 
 	//goland:noinspection GoUnhandledErrorResult
@@ -82,7 +85,7 @@ func executeTransaction[T any](ctx context.Context, db *sql.DB, action func(q *s
 
 	err = tx.Commit()
 	if err != nil {
-		return zero, fleeterror.NewInternalErrorf("error committing tx: %v", err)
+		return zero, fleeterror.NewInternalErrorf("error committing tx: %w", err)
 	}
 
 	return result, nil

--- a/server/internal/infrastructure/db/with_transaction.go
+++ b/server/internal/infrastructure/db/with_transaction.go
@@ -10,6 +10,9 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 )
 
+// WithTransaction runs action in a transaction and retries the entire action for
+// retryable PostgreSQL errors. The action must be safe to replay and should not
+// perform side effects outside the transaction.
 func WithTransaction[T any](ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) (T, error), opts ...*sql.TxOptions) (T, error) {
 	return withTransactionWithRetry(ctx, db, action, DefaultRetryConfig, firstTxOpts(opts))
 }
@@ -62,6 +65,7 @@ func withTransactionWithRetry[T any](ctx context.Context, db *sql.DB, action fun
 func executeTransaction[T any](ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) (T, error), txOpts *sql.TxOptions) (T, error) {
 	var zero T
 
+	//nolint:forbidigo // This helper is the canonical boundary for opening SQL transactions.
 	tx, err := db.BeginTx(ctx, txOpts)
 	if err != nil {
 		return zero, fleeterror.NewInternalErrorf("error opening tx: %v", err)
@@ -84,6 +88,9 @@ func executeTransaction[T any](ctx context.Context, db *sql.DB, action func(q *s
 	return result, nil
 }
 
+// WithTransactionNoResult runs action in a transaction and retries the entire
+// action for retryable PostgreSQL errors. The action must be safe to replay and
+// should not perform side effects outside the transaction.
 func WithTransactionNoResult(ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) error, opts ...*sql.TxOptions) error {
 	return withTransactionNoResultWithRetry(ctx, db, action, DefaultRetryConfig, firstTxOpts(opts))
 }

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -370,6 +370,7 @@ func (s *TimescaleTelemetryStore) StoreDeviceMetrics(ctx context.Context, data .
 	ctx, cancel := context.WithTimeout(ctx, s.config.WriteTimeout)
 	defer cancel()
 
+	//nolint:forbidigo // This legacy telemetry transaction predates the shared transaction helper.
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -1840,6 +1841,7 @@ func (s *TimescaleTelemetryStore) UpsertFleetMetricRollups(ctx context.Context, 
 	ctx, cancel := context.WithTimeout(ctx, s.config.WriteTimeout)
 	defer cancel()
 
+	//nolint:forbidigo // This legacy telemetry transaction predates the shared transaction helper.
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin fleet metric rollup tx: %w", err)

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -371,48 +371,63 @@ func (s *TimescaleTelemetryStore) StoreDeviceMetrics(ctx context.Context, data .
 	ctx, cancel := context.WithTimeout(ctx, s.config.WriteTimeout)
 	defer cancel()
 
-	return db.WithTransactionNoResult(ctx, s.db, func(q *sqlc.Queries) error {
-		if s.config.AsyncMetricCommit {
-			if err := q.DisableSyncCommit(ctx); err != nil {
-				return fmt.Errorf("failed to set async commit: %w", err)
-			}
+	//nolint:forbidigo // The caller falls back per row; helper retries would amplify transient failures across the batch.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			s.logger.Warn("failed to rollback transaction", "error", err)
+		}
+	}()
+
+	qtx := s.queries.WithTx(tx)
+
+	if s.config.AsyncMetricCommit {
+		if err := qtx.DisableSyncCommit(ctx); err != nil {
+			return fmt.Errorf("failed to set async commit: %w", err)
+		}
+	}
+
+	for _, metrics := range data {
+		params := sqlc.InsertDeviceMetricsParams{
+			Time:             metrics.Timestamp,
+			DeviceIdentifier: metrics.DeviceIdentifier,
+			Health:           toNullString(metrics.Health.String()),
 		}
 
-		for _, metrics := range data {
-			params := sqlc.InsertDeviceMetricsParams{
-				Time:             metrics.Timestamp,
-				DeviceIdentifier: metrics.DeviceIdentifier,
-				Health:           toNullString(metrics.Health.String()),
-			}
-
-			if metrics.HashrateHS != nil {
-				params.HashRateHs = sql.NullFloat64{Float64: metrics.HashrateHS.Value, Valid: true}
-				params.HashRateHsKind = toNullString(metrics.HashrateHS.Kind.String())
-			}
-			if metrics.TempC != nil {
-				params.TempC = sql.NullFloat64{Float64: metrics.TempC.Value, Valid: true}
-				params.TempCKind = toNullString(metrics.TempC.Kind.String())
-			}
-			if metrics.FanRPM != nil {
-				params.FanRpm = sql.NullFloat64{Float64: metrics.FanRPM.Value, Valid: true}
-				params.FanRpmKind = toNullString(metrics.FanRPM.Kind.String())
-			}
-			if metrics.PowerW != nil {
-				params.PowerW = sql.NullFloat64{Float64: metrics.PowerW.Value, Valid: true}
-				params.PowerWKind = toNullString(metrics.PowerW.Kind.String())
-			}
-			if metrics.EfficiencyJH != nil {
-				params.EfficiencyJh = sql.NullFloat64{Float64: metrics.EfficiencyJH.Value, Valid: true}
-				params.EfficiencyJhKind = toNullString(metrics.EfficiencyJH.Kind.String())
-			}
-
-			if err := q.InsertDeviceMetrics(ctx, params); err != nil {
-				return fmt.Errorf("failed to insert metrics for device %s: %w", metrics.DeviceIdentifier, err)
-			}
+		if metrics.HashrateHS != nil {
+			params.HashRateHs = sql.NullFloat64{Float64: metrics.HashrateHS.Value, Valid: true}
+			params.HashRateHsKind = toNullString(metrics.HashrateHS.Kind.String())
+		}
+		if metrics.TempC != nil {
+			params.TempC = sql.NullFloat64{Float64: metrics.TempC.Value, Valid: true}
+			params.TempCKind = toNullString(metrics.TempC.Kind.String())
+		}
+		if metrics.FanRPM != nil {
+			params.FanRpm = sql.NullFloat64{Float64: metrics.FanRPM.Value, Valid: true}
+			params.FanRpmKind = toNullString(metrics.FanRPM.Kind.String())
+		}
+		if metrics.PowerW != nil {
+			params.PowerW = sql.NullFloat64{Float64: metrics.PowerW.Value, Valid: true}
+			params.PowerWKind = toNullString(metrics.PowerW.Kind.String())
+		}
+		if metrics.EfficiencyJH != nil {
+			params.EfficiencyJh = sql.NullFloat64{Float64: metrics.EfficiencyJH.Value, Valid: true}
+			params.EfficiencyJhKind = toNullString(metrics.EfficiencyJH.Kind.String())
 		}
 
-		return nil
-	})
+		if err := qtx.InsertDeviceMetrics(ctx, params); err != nil {
+			return fmt.Errorf("failed to insert metrics for device %s: %w", metrics.DeviceIdentifier, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
 }
 
 // GetLatestDeviceMetricsBatch retrieves the latest metrics for multiple devices.

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/telemetry"
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
 	modelsV2 "github.com/block/proto-fleet/server/internal/domain/telemetry/models/v2"
+	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 )
 
 const (
@@ -370,63 +371,48 @@ func (s *TimescaleTelemetryStore) StoreDeviceMetrics(ctx context.Context, data .
 	ctx, cancel := context.WithTimeout(ctx, s.config.WriteTimeout)
 	defer cancel()
 
-	//nolint:forbidigo // This legacy telemetry transaction predates the shared transaction helper.
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
-			s.logger.Warn("failed to rollback transaction", "error", err)
-		}
-	}()
-
-	qtx := s.queries.WithTx(tx)
-
-	if s.config.AsyncMetricCommit {
-		if err := qtx.DisableSyncCommit(ctx); err != nil {
-			return fmt.Errorf("failed to set async commit: %w", err)
-		}
-	}
-
-	for _, metrics := range data {
-		params := sqlc.InsertDeviceMetricsParams{
-			Time:             metrics.Timestamp,
-			DeviceIdentifier: metrics.DeviceIdentifier,
-			Health:           toNullString(metrics.Health.String()),
+	return db.WithTransactionNoResult(ctx, s.db, func(q *sqlc.Queries) error {
+		if s.config.AsyncMetricCommit {
+			if err := q.DisableSyncCommit(ctx); err != nil {
+				return fmt.Errorf("failed to set async commit: %w", err)
+			}
 		}
 
-		if metrics.HashrateHS != nil {
-			params.HashRateHs = sql.NullFloat64{Float64: metrics.HashrateHS.Value, Valid: true}
-			params.HashRateHsKind = toNullString(metrics.HashrateHS.Kind.String())
-		}
-		if metrics.TempC != nil {
-			params.TempC = sql.NullFloat64{Float64: metrics.TempC.Value, Valid: true}
-			params.TempCKind = toNullString(metrics.TempC.Kind.String())
-		}
-		if metrics.FanRPM != nil {
-			params.FanRpm = sql.NullFloat64{Float64: metrics.FanRPM.Value, Valid: true}
-			params.FanRpmKind = toNullString(metrics.FanRPM.Kind.String())
-		}
-		if metrics.PowerW != nil {
-			params.PowerW = sql.NullFloat64{Float64: metrics.PowerW.Value, Valid: true}
-			params.PowerWKind = toNullString(metrics.PowerW.Kind.String())
-		}
-		if metrics.EfficiencyJH != nil {
-			params.EfficiencyJh = sql.NullFloat64{Float64: metrics.EfficiencyJH.Value, Valid: true}
-			params.EfficiencyJhKind = toNullString(metrics.EfficiencyJH.Kind.String())
+		for _, metrics := range data {
+			params := sqlc.InsertDeviceMetricsParams{
+				Time:             metrics.Timestamp,
+				DeviceIdentifier: metrics.DeviceIdentifier,
+				Health:           toNullString(metrics.Health.String()),
+			}
+
+			if metrics.HashrateHS != nil {
+				params.HashRateHs = sql.NullFloat64{Float64: metrics.HashrateHS.Value, Valid: true}
+				params.HashRateHsKind = toNullString(metrics.HashrateHS.Kind.String())
+			}
+			if metrics.TempC != nil {
+				params.TempC = sql.NullFloat64{Float64: metrics.TempC.Value, Valid: true}
+				params.TempCKind = toNullString(metrics.TempC.Kind.String())
+			}
+			if metrics.FanRPM != nil {
+				params.FanRpm = sql.NullFloat64{Float64: metrics.FanRPM.Value, Valid: true}
+				params.FanRpmKind = toNullString(metrics.FanRPM.Kind.String())
+			}
+			if metrics.PowerW != nil {
+				params.PowerW = sql.NullFloat64{Float64: metrics.PowerW.Value, Valid: true}
+				params.PowerWKind = toNullString(metrics.PowerW.Kind.String())
+			}
+			if metrics.EfficiencyJH != nil {
+				params.EfficiencyJh = sql.NullFloat64{Float64: metrics.EfficiencyJH.Value, Valid: true}
+				params.EfficiencyJhKind = toNullString(metrics.EfficiencyJH.Kind.String())
+			}
+
+			if err := q.InsertDeviceMetrics(ctx, params); err != nil {
+				return fmt.Errorf("failed to insert metrics for device %s: %w", metrics.DeviceIdentifier, err)
+			}
 		}
 
-		if err := qtx.InsertDeviceMetrics(ctx, params); err != nil {
-			return fmt.Errorf("failed to insert metrics for device %s: %w", metrics.DeviceIdentifier, err)
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // GetLatestDeviceMetricsBatch retrieves the latest metrics for multiple devices.
@@ -1841,40 +1827,27 @@ func (s *TimescaleTelemetryStore) UpsertFleetMetricRollups(ctx context.Context, 
 	ctx, cancel := context.WithTimeout(ctx, s.config.WriteTimeout)
 	defer cancel()
 
-	//nolint:forbidigo // This legacy telemetry transaction predates the shared transaction helper.
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin fleet metric rollup tx: %w", err)
-	}
-	defer func() {
-		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
-			s.logger.Warn("failed to rollback fleet metric rollup tx", "error", err)
+	return db.WithTransactionNoResult(ctx, s.db, func(q *sqlc.Queries) error {
+		if err := q.DeleteFleetMetricRollupsForWindow(ctx, sqlc.DeleteFleetMetricRollupsForWindowParams{
+			StartTime: startTime,
+			EndTime:   endTime,
+		}); err != nil {
+			return fmt.Errorf("delete fleet metric rollups for window: %w", err)
 		}
-	}()
-
-	qtx := s.queries.WithTx(tx)
-	if err := qtx.DeleteFleetMetricRollupsForWindow(ctx, sqlc.DeleteFleetMetricRollupsForWindowParams{
-		StartTime: startTime,
-		EndTime:   endTime,
-	}); err != nil {
-		return fmt.Errorf("delete fleet metric rollups for window: %w", err)
-	}
-	if err := qtx.UpsertFleetMetricRollups(ctx, sqlc.UpsertFleetMetricRollupsParams{
-		StartTime: startTime,
-		EndTime:   endTime,
-	}); err != nil {
-		return fmt.Errorf("upsert fleet metric rollups: %w", err)
-	}
-	if err := qtx.AdvanceFleetMetricRollupProgress(ctx, sqlc.AdvanceFleetMetricRollupProgressParams{
-		EarliestBucket: models.TruncateToFleetRollupBucket(startTime),
-		LatestBucket:   models.TruncateToFleetRollupBucket(endTime.Add(-time.Nanosecond)),
-	}); err != nil {
-		return fmt.Errorf("advance fleet metric rollup progress: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit fleet metric rollup tx: %w", err)
-	}
-	return nil
+		if err := q.UpsertFleetMetricRollups(ctx, sqlc.UpsertFleetMetricRollupsParams{
+			StartTime: startTime,
+			EndTime:   endTime,
+		}); err != nil {
+			return fmt.Errorf("upsert fleet metric rollups: %w", err)
+		}
+		if err := q.AdvanceFleetMetricRollupProgress(ctx, sqlc.AdvanceFleetMetricRollupProgressParams{
+			EarliestBucket: models.TruncateToFleetRollupBucket(startTime),
+			LatestBucket:   models.TruncateToFleetRollupBucket(endTime.Add(-time.Nanosecond)),
+		}); err != nil {
+			return fmt.Errorf("advance fleet metric rollup progress: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *TimescaleTelemetryStore) GetLatestFleetMetricRollupBucket(ctx context.Context) (time.Time, error) {


### PR DESCRIPTION
Reviewable diff: +61/-67 across 5 files (excludes generated, test, and story files).

## Summary

Server contributors now get a lint failure when production code opens a `database/sql` transaction directly instead of using the shared sqlc transaction helpers. Alertmanager notification batches and fleet metric rollups now use that boundary, while transaction paths with materially different retry semantics remain explicit, reviewable exceptions.

**Stack:** **[#768](https://github.com/block/proto-fleet/pull/768) this PR** -> [#759](https://github.com/block/proto-fleet/pull/759) `feat(db): support explicit Postgres DSNs`. PR #759 builds on this transaction boundary to add explicit DSN support and HA pool-reset behavior; those HA changes are intentionally out of scope here.

## How it works

The server lint configuration rejects calls whose selector is `Begin` or `BeginTx`. Test files remain exempt so integration fixtures can control transactions directly. The canonical helper and two higher-risk legacy paths use line-level, documented suppressions so every production exception stays visible in review.

Alertmanager notification chunks and each fleet-rollup delete/upsert/progress sequence pass their complete unit of work to `db.WithTransactionNoResult`. The helper binds sqlc queries to one transaction, rolls back on any failure, and replays the callback for retryable PostgreSQL errors. It preserves wrapped cancellation and PostgreSQL causes for `errors.Is`/`errors.As`, and terminal errors report the number of attempts actually made.

Telemetry metric batches keep their existing single-attempt transaction because their caller already falls back to one write per metric after a batch failure. Applying the retrying helper there could turn one transient 500-row failure into 1,503 transaction attempts. The raw paired-array device rename also remains on its legacy path until it can be moved to a separately validated sqlc query.

```mermaid
flowchart LR
    A["Alertmanager webhook"] --> C["Shared transaction retry boundary"]
    B["Fleet rollup routine"] --> C
    C --> D["sqlc queries bound to one transaction"]
    D --> E["Commit the complete unit of work"]
    F["Telemetry metric batch"] --> G["Documented single-attempt exception"]
    G --> H["Existing per-row fallback on batch failure"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/.golangci.yaml` | Enabled `forbidigo` for production code and prohibited direct `Begin`/`BeginTx` calls | Defines the enforcement boundary and test-only exemption |
| `server/internal/domain/stores/sqlstores/notification_history.go` | Routed notification batch persistence through `WithTransactionNoResult` | Keeps all webhook rows atomic under the shared retry policy |
| `server/internal/infrastructure/timescaledb/telemetry_store.go` | Routed fleet rollups through the helper and documented why metric batches retain their transaction path | Applies retries only where they do not multiply an outer fallback |
| `server/internal/infrastructure/db/with_transaction.go` | Documented replay safety, preserved wrapped causes, and corrected attempt reporting | Makes the supported transaction boundary observable and retry-correct |
| `server/internal/domain/stores/sqlstores/device.go` | Retained one line-level exception for the raw paired-array rename query | Keeps the higher-risk sqlc migration explicit without weakening the repository-wide rule |

## Key technical decisions & trade-offs

- Use the existing `forbidigo` linter instead of adding a custom analyzer; selector-name matching is lightweight but may require a justified suppression for an unrelated `Begin` method.
- Exempt test files because database-backed fixtures intentionally open transactions directly; production code remains covered.
- Migrate transaction paths whose complete callbacks are safe to replay; retain telemetry metric batches because their per-row fallback would amplify transient failures.
- Preserve non-retryable `FleetError` values unchanged, while wrapping retryable and terminal causes with `%w` so PostgreSQL and context classification still works.
- Retain the raw-array device rename until its paired `unnest` query can be moved to sqlc and validated separately.

## Testing & validation

- `source ./bin/activate-hermit && just _lint-server`
- `go test ./internal/infrastructure/db`
- `go test ./internal/domain/telemetry`
- `go test -short ./internal/infrastructure/timescaledb`
- `go test -run '^$' ./internal/domain/stores/sqlstores`
- No new tests or dependencies were added; existing unit coverage was used for this localized review fix.
- Database-backed sqlstores integration tests were not run locally; CI remains responsible for that coverage.
- No fault-injection test currently forces a retryable `BeginTx` or `Commit` error.

## Post-deploy monitoring & validation

- During the first 24 hours, watch `alertmanager webhook: failed to persist alert batch` and `fleet metric rollup routine: upsert failed` for a sustained increase.
- Healthy signals are stable webhook 2xx rates and fleet rollup progress continuing to advance.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
