### PR TITLE
fix(multi-site): sync active scope to entity on headerless detail routes (#764)

### DIFF
--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.test.tsx
@@ -265,6 +265,35 @@ describe("BuildingPage", () => {
     expect(screen.getByTestId("location-probe")).toHaveTextContent("/austin/fleet/racks?building=123");
   });
 
+  it("syncs a mismatched header scope to the building's own site on this headerless route (#764)", async () => {
+    // Deep-link to a building whose site differs from the persisted header scope.
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "99", slug: "elsewhere" };
+    });
+    sitesCtx.current = {
+      ...sitesCtx.current,
+      sites: [create(SiteWithCountsSchema, { site: create(SiteSchema, { id: 8n, name: "Austin", slug: "austin" }) })],
+    };
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "8", slug: "austin" }),
+    );
+  });
+
+  it("leaves an all-sites header scope untouched when viewing a building (#764)", async () => {
+    sitesCtx.current = {
+      ...sitesCtx.current,
+      sites: [create(SiteWithCountsSchema, { site: create(SiteSchema, { id: 8n, name: "Austin", slug: "austin" }) })],
+    };
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId("building-page-view-miners")).toBeVisible());
+    expect(useFleetStore.getState().ui.activeSite).toEqual(DEFAULT_ACTIVE_SITE);
+  });
+
   it("keeps edit building visible on mobile and moves peer actions into an action sheet", async () => {
     renderPage();
 

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -14,7 +14,7 @@ import {
   BuildingWithCountsSchema,
 } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { AggregationType, MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
-import { buildSiteSlugById, parseBigIntId } from "@/protoFleet/api/sites";
+import { parseBigIntId } from "@/protoFleet/api/sites";
 import { useSitesContext } from "@/protoFleet/api/SitesContext";
 import { useBuildingStats } from "@/protoFleet/api/useBuildingStats";
 import { useComponentErrors } from "@/protoFleet/api/useComponentErrors";
@@ -23,7 +23,7 @@ import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
 import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
-import { useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
+import { entityScopeTarget, useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -211,13 +211,13 @@ const BuildingPage = () => {
   );
 
   // On deep-link/bookmark, align the (headerless-route) scope with the opened
-  // building's own site so its modals' miner pickers scope correctly (#764).
-  const syncSiteId =
-    typeof effectiveOutcome === "object" && effectiveOutcome.status === "found"
-      ? effectiveOutcome.building.siteId?.toString()
-      : undefined;
-  const syncSiteSlug = syncSiteId && syncSiteId !== "0" ? buildSiteSlugById(sites)?.get(syncSiteId) : undefined;
-  useSyncScopeToEntity(syncSiteId === "0" ? undefined : syncSiteId, syncSiteSlug);
+  // building's own site (or the unassigned bucket when it has none) so its
+  // modals' miner pickers scope correctly (#764). Pass undefined while the
+  // building is still loading so an unassigned building isn't treated as such
+  // before it resolves.
+  const loadedBuilding =
+    typeof effectiveOutcome === "object" && effectiveOutcome.status === "found" ? effectiveOutcome.building : undefined;
+  useSyncScopeToEntity(loadedBuilding ? entityScopeTarget(loadedBuilding.siteId, sites) : undefined);
 
   if (effectiveOutcome === "loading") {
     return (

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -14,7 +14,7 @@ import {
   BuildingWithCountsSchema,
 } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { AggregationType, MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
-import { parseBigIntId } from "@/protoFleet/api/sites";
+import { buildSiteSlugById, parseBigIntId } from "@/protoFleet/api/sites";
 import { useSitesContext } from "@/protoFleet/api/SitesContext";
 import { useBuildingStats } from "@/protoFleet/api/useBuildingStats";
 import { useComponentErrors } from "@/protoFleet/api/useComponentErrors";
@@ -23,6 +23,7 @@ import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
 import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
+import { useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -208,6 +209,15 @@ const BuildingPage = () => {
       ),
     [sites],
   );
+
+  // On deep-link/bookmark, align the (headerless-route) scope with the opened
+  // building's own site so its modals' miner pickers scope correctly (#764).
+  const syncSiteId =
+    typeof effectiveOutcome === "object" && effectiveOutcome.status === "found"
+      ? effectiveOutcome.building.siteId?.toString()
+      : undefined;
+  const syncSiteSlug = syncSiteId && syncSiteId !== "0" ? buildSiteSlugById(sites)?.get(syncSiteId) : undefined;
+  useSyncScopeToEntity(syncSiteId === "0" ? undefined : syncSiteId, syncSiteSlug);
 
   if (effectiveOutcome === "loading") {
     return (

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
@@ -39,7 +39,8 @@ vi.mock("@/protoFleet/api/buildings", () => ({
   useBuildings: () => mockUseBuildings(),
 }));
 
-vi.mock("@/protoFleet/api/sites", () => ({
+vi.mock("@/protoFleet/api/sites", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/protoFleet/api/sites")>()),
   useSites: () => mockUseSites(),
 }));
 
@@ -352,6 +353,43 @@ describe("RackOverviewPage", () => {
     renderRackOverviewPage();
 
     expect(await screen.findByTestId("rack-page-breadcrumb-link-0")).toHaveAttribute("href", "/unassigned/fleet/racks");
+  });
+
+  it("syncs a mismatched header scope to the rack's own site on this headerless route (#764)", async () => {
+    // Deep-link to a rack whose site differs from the persisted header scope.
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "99", slug: "elsewhere" };
+    });
+    const rackInSite = create(DeviceSetSchema, {
+      id: 7n,
+      label: rackName,
+      typeDetails: { case: "rackInfo", value: { rows: 6, columns: 5, zone: rackZone, siteId: 22n } },
+    });
+    mockResolvedRackPageData(rackInSite, {
+      sites: [{ site: { id: 22n, name: "Denver", slug: "denver" } }],
+    });
+
+    renderRackOverviewPage();
+
+    await waitFor(() =>
+      expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "22", slug: "denver" }),
+    );
+  });
+
+  it("leaves an all-sites header scope untouched when viewing a rack (#764)", async () => {
+    const rackInSite = create(DeviceSetSchema, {
+      id: 7n,
+      label: rackName,
+      typeDetails: { case: "rackInfo", value: { rows: 6, columns: 5, zone: rackZone, siteId: 22n } },
+    });
+    mockResolvedRackPageData(rackInSite, {
+      sites: [{ site: { id: 22n, name: "Denver", slug: "denver" } }],
+    });
+
+    renderRackOverviewPage();
+
+    await waitFor(() => expect(screen.getAllByText(rackName).length).toBeGreaterThan(0));
+    expect(useFleetStore.getState().ui.activeSite).toEqual(DEFAULT_ACTIVE_SITE);
   });
 
   it("keeps rack detail header actions compact on mobile", async () => {

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
@@ -401,6 +401,20 @@ describe("RackOverviewPage", () => {
     );
   });
 
+  it("moves a specific-site header scope to unassigned for an unassigned rack (#764)", async () => {
+    // Unassigned rack (no placement site, no building) opened while a specific
+    // site is persisted — the header must drop to the unassigned bucket so the
+    // miner picker isn't filtered to the wrong site.
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "99", slug: "elsewhere" };
+    });
+    // Default rack (id 7) has no siteId, buildingId, or placement.
+
+    renderRackOverviewPage();
+
+    await waitFor(() => expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "unassigned" }));
+  });
+
   it("leaves an all-sites header scope untouched when viewing a rack (#764)", async () => {
     const rackInSite = create(DeviceSetSchema, {
       id: 7n,

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.test.tsx
@@ -376,6 +376,31 @@ describe("RackOverviewPage", () => {
     );
   });
 
+  it("syncs from rack placement site when the building catalog is unavailable (#764)", async () => {
+    // Rack is placed under a building (no rackInfo.siteId), and the auxiliary
+    // listAllBuildings request returns nothing — but the rack's own placement
+    // still carries its site, so the sync must fire off that.
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "99", slug: "elsewhere" };
+    });
+    const rackUnderBuilding = create(DeviceSetSchema, {
+      id: 7n,
+      label: rackName,
+      typeDetails: { case: "rackInfo", value: { rows: 6, columns: 5, zone: rackZone, buildingId: 11n } },
+      placement: { site: { id: 22n } },
+    });
+    mockResolvedRackPageData(rackUnderBuilding, {
+      allBuildings: [],
+      sites: [{ site: { id: 22n, name: "Denver", slug: "denver" } }],
+    });
+
+    renderRackOverviewPage();
+
+    await waitFor(() =>
+      expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "22", slug: "denver" }),
+    );
+  });
+
   it("leaves an all-sites header scope untouched when viewing a rack (#764)", async () => {
     const rackInSite = create(DeviceSetSchema, {
       id: 7n,

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -12,6 +12,7 @@ import {
   RackSlotPositionSchema,
 } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import { AggregationType, MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
+import { buildSiteSlugById } from "@/protoFleet/api/sites";
 import { useSitesContext } from "@/protoFleet/api/SitesContext";
 import { useComponentErrors } from "@/protoFleet/api/useComponentErrors";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
@@ -30,6 +31,7 @@ import DeviceSetActionsMenu from "@/protoFleet/features/groupManagement/componen
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
 import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
+import { useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -261,6 +263,11 @@ const RackOverviewPage = () => {
       cancelled = true;
     };
   }, [listRacks, rack, rackInfo, rackSiblingKey, rackSiteId]);
+
+  // On deep-link/bookmark, align the (headerless-route) scope with the opened
+  // rack's own site so ManageRackModal's miner picker scopes correctly (#764).
+  const syncSiteId = rackSiteId && rackSiteId !== "0" ? rackSiteId : undefined;
+  useSyncScopeToEntity(syncSiteId, syncSiteId ? buildSiteSlugById(sites)?.get(syncSiteId) : undefined);
 
   const duration = useDuration();
   const setDuration = useSetDuration();

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -12,7 +12,6 @@ import {
   RackSlotPositionSchema,
 } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import { AggregationType, MeasurementType } from "@/protoFleet/api/generated/telemetry/v1/telemetry_pb";
-import { buildSiteSlugById } from "@/protoFleet/api/sites";
 import { useSitesContext } from "@/protoFleet/api/SitesContext";
 import { useComponentErrors } from "@/protoFleet/api/useComponentErrors";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
@@ -31,7 +30,7 @@ import DeviceSetActionsMenu from "@/protoFleet/features/groupManagement/componen
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
 import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
 import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
-import { useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
+import { entityScopeTarget, useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
 import { useDuration, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -265,14 +264,15 @@ const RackOverviewPage = () => {
   }, [listRacks, rack, rackInfo, rackSiblingKey, rackSiteId]);
 
   // On deep-link/bookmark, align the (headerless-route) scope with the opened
-  // rack's own site so ManageRackModal's miner picker scopes correctly (#764).
-  // Prefer the rack's own placement site (carried on the DeviceSet itself) over
-  // the rackInfo→building-catalog derivation, so the sync still fires for a
+  // rack's own site (or the unassigned bucket when it has none) so
+  // ManageRackModal's miner picker scopes correctly (#764). Prefer the rack's
+  // own placement site (carried on the DeviceSet itself) over the
+  // rackInfo→building-catalog derivation, so the sync still fires for a
   // building-placed rack when the auxiliary listAllBuildings request fails.
-  const rackPlacementSiteId = rack?.placement?.site?.id?.toString();
-  const rawSyncSiteId = rackPlacementSiteId ?? rackSiteId;
-  const syncSiteId = rawSyncSiteId && rawSyncSiteId !== "0" ? rawSyncSiteId : undefined;
-  useSyncScopeToEntity(syncSiteId, syncSiteId ? buildSiteSlugById(sites)?.get(syncSiteId) : undefined);
+  // Pass undefined until the rack resolves so an unassigned rack isn't treated
+  // as such before it loads.
+  const rackScopeSiteId = rack?.placement?.site?.id ?? rackInfo?.siteId ?? rackBuilding?.siteId;
+  useSyncScopeToEntity(rack ? entityScopeTarget(rackScopeSiteId, sites) : undefined);
 
   const duration = useDuration();
   const setDuration = useSetDuration();

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -266,7 +266,12 @@ const RackOverviewPage = () => {
 
   // On deep-link/bookmark, align the (headerless-route) scope with the opened
   // rack's own site so ManageRackModal's miner picker scopes correctly (#764).
-  const syncSiteId = rackSiteId && rackSiteId !== "0" ? rackSiteId : undefined;
+  // Prefer the rack's own placement site (carried on the DeviceSet itself) over
+  // the rackInfo→building-catalog derivation, so the sync still fires for a
+  // building-placed rack when the auxiliary listAllBuildings request fails.
+  const rackPlacementSiteId = rack?.placement?.site?.id?.toString();
+  const rawSyncSiteId = rackPlacementSiteId ?? rackSiteId;
+  const syncSiteId = rawSyncSiteId && rawSyncSiteId !== "0" ? rawSyncSiteId : undefined;
   useSyncScopeToEntity(syncSiteId, syncSiteId ? buildSiteSlugById(sites)?.get(syncSiteId) : undefined);
 
   const duration = useDuration();

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
@@ -170,14 +170,42 @@ describe("SiteDetailPage", () => {
     );
   });
 
-  it("preserves the selected site when a site detail mismatch redirects back to Fleet", async () => {
+  it("syncs a mismatched persisted scope to the site being viewed instead of bouncing away", async () => {
+    // Deep-link to /sites/7 (Dallas) while the header scope points at another
+    // site (Austin). The headerless route must adopt the viewed site rather
+    // than redirect to /fleet (#764).
     useFleetStore.setState((state) => {
       state.ui.activeSite = { kind: "site", id: "8", slug: "austin" };
     });
 
     renderPage();
 
-    await waitFor(() => expect(screen.getByTestId("location-probe")).toHaveTextContent("/austin/fleet"));
+    expect(await screen.findByTestId("site-detail-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("location-probe")).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
+    );
+  });
+
+  it("adopts the viewed site when the persisted scope is 'unassigned'", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "unassigned" };
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId("site-detail-page")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
+    );
+  });
+
+  it("leaves an all-sites scope untouched when viewing a site", async () => {
+    // Viewing one entity shouldn't collapse an intentional org-wide view.
+    renderPage();
+
+    expect(await screen.findByTestId("site-detail-page")).toBeInTheDocument();
+    expect(useFleetStore.getState().ui.activeSite).toEqual(DEFAULT_ACTIVE_SITE);
   });
 
   it("renders the metrics row scoped to the resolved site", async () => {

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
 
 import SiteMetricsRow from "../components/SiteMetricsRow";
 import SiteModals from "../components/SiteModals";
@@ -17,7 +17,7 @@ import BuildingModals from "@/protoFleet/features/buildings/components/BuildingM
 import BuildingSummaryCard from "@/protoFleet/features/buildings/components/BuildingSummaryCard";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
-import { scopedPath } from "@/protoFleet/routing/siteScope";
+import { useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
 import { useDuration, useHasPermission, useSetDuration } from "@/protoFleet/store";
 import { Alert } from "@/shared/assets/icons";
 import Breadcrumb from "@/shared/components/Breadcrumb";
@@ -39,7 +39,6 @@ const ALL_MEASUREMENT_TYPES: MeasurementType[] = [
 const ALL_AGGREGATION_TYPES: AggregationType[] = [AggregationType.AVERAGE, AggregationType.MIN, AggregationType.MAX];
 
 const SiteDetailPage = () => {
-  const navigate = useNavigate();
   const { id: idParam } = useParams<{ id?: string }>();
   const targetId = idParam ?? "";
 
@@ -50,7 +49,6 @@ const SiteDetailPage = () => {
   const { sites, sitesError: error, siteCatalogAccessGranted, refetchSites } = useSitesContext();
   const [buildings, setBuildings] = useState<{ siteId: string; rows: BuildingWithCounts[] } | undefined>(undefined);
   const [buildingsError, setBuildingsError] = useState<{ siteId: string; message: string } | null>(null);
-  const breadcrumbSiteSelectionRef = useRef<string | null>(null);
 
   const fetchBuildings = useCallback(
     (siteId: bigint) => {
@@ -85,16 +83,9 @@ const SiteDetailPage = () => {
     () => (siteCatalogAccessGranted ? buildKnownSiteIds(sites) : undefined),
     [siteCatalogAccessGranted, sites],
   );
-  const { activeSite, setActiveSite } = useActiveSite({ knownSiteIds });
-  useEffect(() => {
-    if (activeSite.kind !== "site") return;
-    if (activeSite.id === targetId) {
-      breadcrumbSiteSelectionRef.current = null;
-      return;
-    }
-    if (breadcrumbSiteSelectionRef.current === activeSite.id) return;
-    navigate(scopedPath("/fleet", activeSite), { replace: true });
-  }, [activeSite, navigate, targetId]);
+  // Keep the deleted-site guard (resets a stored scope that points at a site
+  // the viewer lost access to); setActiveSite drives breadcrumb sibling nav.
+  const { setActiveSite } = useActiveSite({ knownSiteIds });
 
   const site = useMemo(() => {
     if (!sites) return undefined;
@@ -102,6 +93,11 @@ const SiteDetailPage = () => {
     if (parsed === null) return undefined;
     return sites.find((s) => s.site?.id === parsed);
   }, [sites, targetId]);
+
+  // This is a headerless route, so the persisted scope can point at an
+  // unrelated site on deep-link/bookmark. Align it with the site being viewed
+  // (leaving "all-sites" as-is) rather than bouncing away to /fleet (#764).
+  useSyncScopeToEntity(site ? targetId : undefined, site?.site?.slug);
 
   // UpdateSite + CreateBuilding require site:manage server-side.
   const canManageSites = useHasPermission("site:manage");
@@ -222,10 +218,7 @@ const SiteDetailPage = () => {
         to: `/sites/${siblingId}`,
         isActive: siblingSite.id === site.site!.id,
         onSelect: siblingSite.slug
-          ? () => {
-              breadcrumbSiteSelectionRef.current = siblingId;
-              setActiveSite({ kind: "site", id: siblingId, slug: siblingSite.slug });
-            }
+          ? () => setActiveSite({ kind: "site", id: siblingId, slug: siblingSite.slug })
           : undefined,
       };
     });

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -17,7 +17,7 @@ import BuildingModals from "@/protoFleet/features/buildings/components/BuildingM
 import BuildingSummaryCard from "@/protoFleet/features/buildings/components/BuildingSummaryCard";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
 import { DeviceSetPerformanceSection } from "@/protoFleet/features/groupManagement/components/DeviceSetPerformanceSection";
-import { useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
+import { entityScopeTarget, useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
 import { useDuration, useHasPermission, useSetDuration } from "@/protoFleet/store";
 import { Alert } from "@/shared/assets/icons";
 import Breadcrumb from "@/shared/components/Breadcrumb";
@@ -97,7 +97,7 @@ const SiteDetailPage = () => {
   // This is a headerless route, so the persisted scope can point at an
   // unrelated site on deep-link/bookmark. Align it with the site being viewed
   // (leaving "all-sites" as-is) rather than bouncing away to /fleet (#764).
-  useSyncScopeToEntity(site ? targetId : undefined, site?.site?.slug);
+  useSyncScopeToEntity(site ? entityScopeTarget(site.site?.id, sites) : undefined);
 
   // UpdateSite + CreateBuilding require site:manage server-side.
   const canManageSites = useHasPermission("site:manage");

--- a/client/src/protoFleet/hooks/useSyncScopeToEntity.test.tsx
+++ b/client/src/protoFleet/hooks/useSyncScopeToEntity.test.tsx
@@ -1,0 +1,88 @@
+import { type ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useSyncScopeToEntity } from "./useSyncScopeToEntity";
+import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
+
+// The detail routes this hook targets render outside SiteScopeLayout, so there
+// is no SiteScopeContext provider — useRouteSiteScope() returns null and the
+// store selection is the sole source of scope. A bare MemoryRouter reproduces
+// that (satisfies useNavigate/useLocation without adding a route scope).
+const wrapper = ({ children }: { children: ReactNode }) => <MemoryRouter>{children}</MemoryRouter>;
+
+const renderSync = (siteId: string | undefined, slug: string | undefined) =>
+  renderHook(({ id, s }: { id?: string; s?: string }) => useSyncScopeToEntity(id, s), {
+    wrapper,
+    initialProps: { id: siteId, s: slug },
+  });
+
+describe("useSyncScopeToEntity", () => {
+  beforeEach(() => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = DEFAULT_ACTIVE_SITE;
+    });
+  });
+
+  it("overwrites a mismatched scoped site with the entity's own site", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "8", slug: "austin" };
+    });
+
+    renderSync("7", "dallas");
+
+    await waitFor(() =>
+      expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
+    );
+  });
+
+  it("overwrites an 'unassigned' scope with the entity's own site", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "unassigned" };
+    });
+
+    renderSync("7", "dallas");
+
+    await waitFor(() =>
+      expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
+    );
+  });
+
+  it("leaves an all-sites scope untouched", async () => {
+    renderSync("7", "dallas");
+
+    // Give the effect a chance to (not) run.
+    await Promise.resolve();
+    expect(useFleetStore.getState().ui.activeSite).toEqual(DEFAULT_ACTIVE_SITE);
+  });
+
+  it("is a no-op when the scope already matches the entity's site", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "7", slug: "dallas" };
+    });
+
+    renderSync("7", "dallas");
+
+    await Promise.resolve();
+    expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" });
+  });
+
+  it("does nothing until the entity's site id and slug are both resolved", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "8", slug: "austin" };
+    });
+
+    // id known but slug still resolving.
+    const { rerender } = renderSync("7", undefined);
+    await Promise.resolve();
+    expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "8", slug: "austin" });
+
+    // slug arrives → sync fires.
+    rerender({ id: "7", s: "dallas" });
+    await waitFor(() =>
+      expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
+    );
+  });
+});

--- a/client/src/protoFleet/hooks/useSyncScopeToEntity.test.tsx
+++ b/client/src/protoFleet/hooks/useSyncScopeToEntity.test.tsx
@@ -69,6 +69,18 @@ describe("useSyncScopeToEntity", () => {
     expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" });
   });
 
+  it("refreshes a stale slug when the id matches (post-rename reconciliation)", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "7", slug: "old-dallas" };
+    });
+
+    renderSync("7", "dallas");
+
+    await waitFor(() =>
+      expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
+    );
+  });
+
   it("does nothing until the entity's site id and slug are both resolved", async () => {
     useFleetStore.setState((state) => {
       state.ui.activeSite = { kind: "site", id: "8", slug: "austin" };

--- a/client/src/protoFleet/hooks/useSyncScopeToEntity.test.tsx
+++ b/client/src/protoFleet/hooks/useSyncScopeToEntity.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { useSyncScopeToEntity } from "./useSyncScopeToEntity";
+import { type ScopeSyncTarget, useSyncScopeToEntity } from "./useSyncScopeToEntity";
 import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 
@@ -13,11 +13,13 @@ import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 // that (satisfies useNavigate/useLocation without adding a route scope).
 const wrapper = ({ children }: { children: ReactNode }) => <MemoryRouter>{children}</MemoryRouter>;
 
-const renderSync = (siteId: string | undefined, slug: string | undefined) =>
-  renderHook(({ id, s }: { id?: string; s?: string }) => useSyncScopeToEntity(id, s), {
+const renderSync = (target: ScopeSyncTarget | undefined) =>
+  renderHook(({ t }: { t?: ScopeSyncTarget }) => useSyncScopeToEntity(t), {
     wrapper,
-    initialProps: { id: siteId, s: slug },
+    initialProps: { t: target },
   });
+
+const site = (id: string, slug: string): ScopeSyncTarget => ({ kind: "site", id, slug });
 
 describe("useSyncScopeToEntity", () => {
   beforeEach(() => {
@@ -31,7 +33,7 @@ describe("useSyncScopeToEntity", () => {
       state.ui.activeSite = { kind: "site", id: "8", slug: "austin" };
     });
 
-    renderSync("7", "dallas");
+    renderSync(site("7", "dallas"));
 
     await waitFor(() =>
       expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
@@ -43,15 +45,15 @@ describe("useSyncScopeToEntity", () => {
       state.ui.activeSite = { kind: "unassigned" };
     });
 
-    renderSync("7", "dallas");
+    renderSync(site("7", "dallas"));
 
     await waitFor(() =>
       expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
     );
   });
 
-  it("leaves an all-sites scope untouched", async () => {
-    renderSync("7", "dallas");
+  it("leaves an all-sites scope untouched for a scoped-site entity", async () => {
+    renderSync(site("7", "dallas"));
 
     // Give the effect a chance to (not) run.
     await Promise.resolve();
@@ -63,7 +65,7 @@ describe("useSyncScopeToEntity", () => {
       state.ui.activeSite = { kind: "site", id: "7", slug: "dallas" };
     });
 
-    renderSync("7", "dallas");
+    renderSync(site("7", "dallas"));
 
     await Promise.resolve();
     expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" });
@@ -74,25 +76,42 @@ describe("useSyncScopeToEntity", () => {
       state.ui.activeSite = { kind: "site", id: "7", slug: "old-dallas" };
     });
 
-    renderSync("7", "dallas");
+    renderSync(site("7", "dallas"));
 
     await waitFor(() =>
       expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
     );
   });
 
-  it("does nothing until the entity's site id and slug are both resolved", async () => {
+  it("moves a specific-site scope to unassigned for an unassigned entity", async () => {
     useFleetStore.setState((state) => {
       state.ui.activeSite = { kind: "site", id: "8", slug: "austin" };
     });
 
-    // id known but slug still resolving.
-    const { rerender } = renderSync("7", undefined);
+    renderSync({ kind: "unassigned" });
+
+    await waitFor(() => expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "unassigned" }));
+  });
+
+  it("leaves an all-sites scope untouched for an unassigned entity", async () => {
+    renderSync({ kind: "unassigned" });
+
+    await Promise.resolve();
+    expect(useFleetStore.getState().ui.activeSite).toEqual(DEFAULT_ACTIVE_SITE);
+  });
+
+  it("does nothing until the target is resolved", async () => {
+    useFleetStore.setState((state) => {
+      state.ui.activeSite = { kind: "site", id: "8", slug: "austin" };
+    });
+
+    // Entity/slug still loading → undefined target.
+    const { rerender } = renderSync(undefined);
     await Promise.resolve();
     expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "8", slug: "austin" });
 
-    // slug arrives → sync fires.
-    rerender({ id: "7", s: "dallas" });
+    // Target arrives → sync fires.
+    rerender({ t: site("7", "dallas") });
     await waitFor(() =>
       expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "7", slug: "dallas" }),
     );

--- a/client/src/protoFleet/hooks/useSyncScopeToEntity.ts
+++ b/client/src/protoFleet/hooks/useSyncScopeToEntity.ts
@@ -1,6 +1,29 @@
 import { useEffect } from "react";
 
+import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { buildSiteSlugById } from "@/protoFleet/api/sites";
 import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
+
+// The scope an opened entity implies: either its own site (id + canonical slug)
+// or the unassigned bucket when it has no site. Never "all" — an entity always
+// lives somewhere specific, so viewing one can't imply an org-wide view.
+export type ScopeSyncTarget = { kind: "site"; id: string; slug: string } | { kind: "unassigned" };
+
+// Build the sync target for an entity that has finished loading. `siteId` is the
+// entity's own site (bigint); undefined or 0n means the entity is unassigned.
+// Returns `undefined` only while a scoped site's slug is still being resolved
+// from the catalog, so the caller keeps waiting rather than sync a dead slug.
+// Callers must pass `undefined` (not this) while the entity itself is still
+// loading, so an unassigned target isn't confused with "not resolved yet".
+export const entityScopeTarget = (
+  siteId: bigint | undefined,
+  sites: SiteWithCounts[] | undefined,
+): ScopeSyncTarget | undefined => {
+  const id = siteId?.toString();
+  if (!id || id === "0") return { kind: "unassigned" };
+  const slug = buildSiteSlugById(sites)?.get(id);
+  return slug ? { kind: "site", id, slug } : undefined;
+};
 
 // Sync the persisted header scope to the entity being viewed on the
 // **headerless** detail routes (`/buildings/:id`, `/racks/:rackId`,
@@ -15,35 +38,48 @@ import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 // (modals, facets, feeds) agreeing with the opened entity, so no per-modal
 // special-casing is needed.
 //
-// Behavior:
-//   - "all-sites"       → left untouched. Viewing one entity shouldn't collapse
-//                         an intentional org-wide view.
-//   - matching "site"   → no-op, unless the stored slug is stale (renamed): we
-//                         hold the entity's canonical slug here, so refresh it
-//                         in place rather than leave a dead slug that later
-//                         produces broken scoped paths.
-//   - different "site"  → overwritten to the entity's own site.
-//   - "unassigned"      → overwritten to the entity's own site.
+// `target` is undefined until the entity has loaded (and, for a scoped site,
+// its slug resolved), so callers pass undefined while loading rather than let
+// an unassigned entity look the same as "not resolved yet".
 //
-// Only fires once the entity's site id + slug are resolved (both required to
-// build a scoped ActiveSite). In-app navigation never mismatches, so this only
-// changes behavior on deep links/bookmarks — exactly when switching context to
-// the opened entity is desirable.
+// Behavior:
+//   - "all-sites"            → left untouched. Viewing one entity shouldn't
+//                              collapse an intentional org-wide view.
+//   - matching "site"        → no-op, unless the stored slug is stale (renamed):
+//                              we hold the entity's canonical slug here, so
+//                              refresh it in place rather than leave a dead slug
+//                              that later produces broken scoped paths.
+//   - different "site"       → overwritten to the entity's own site.
+//   - unassigned entity      → overwritten to the unassigned bucket when the
+//                              stored scope is a specific site (all-sites still
+//                              left untouched).
+//
+// In-app navigation never mismatches, so this only changes behavior on deep
+// links/bookmarks — exactly when switching context to the opened entity is
+// desirable.
 //
 // Safe against useActiveSite's reconciliation: these routes carry no route
 // scope, so the route-scope mirror effect early-returns and won't clobber this
 // write, and the deleted-site guard passes for a real (loaded) site.
-export const useSyncScopeToEntity = (siteId: string | undefined, slug: string | undefined): void => {
+export const useSyncScopeToEntity = (target: ScopeSyncTarget | undefined): void => {
   const { activeSite, setActiveSite } = useActiveSite({});
+  const kind = target?.kind;
+  const siteId = target?.kind === "site" ? target.id : undefined;
+  const slug = target?.kind === "site" ? target.slug : undefined;
 
   useEffect(() => {
-    if (!siteId || !slug) return;
+    if (!kind) return;
     // Never collapse an intentional org-wide view.
     if (activeSite.kind === "all") return;
-    // Already scoped to this entity's site with an up-to-date slug — nothing to
-    // do. A matching id but stale slug still falls through so the rename is
-    // reconciled from the entity's canonical slug.
+    if (kind === "unassigned") {
+      if (activeSite.kind === "unassigned") return;
+      setActiveSite({ kind: "unassigned" });
+      return;
+    }
+    // Scoped site. A matching id but stale slug still falls through so the
+    // rename is reconciled from the entity's canonical slug.
+    if (!siteId || !slug) return;
     if (activeSite.kind === "site" && activeSite.id === siteId && activeSite.slug === slug) return;
     setActiveSite({ kind: "site", id: siteId, slug });
-  }, [activeSite, siteId, slug, setActiveSite]);
+  }, [activeSite, kind, siteId, slug, setActiveSite]);
 };

--- a/client/src/protoFleet/hooks/useSyncScopeToEntity.ts
+++ b/client/src/protoFleet/hooks/useSyncScopeToEntity.ts
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+
+import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
+
+// Sync the persisted header scope to the entity being viewed on the
+// **headerless** detail routes (`/buildings/:id`, `/racks/:rackId`,
+// `/sites/:id`). Those routes render outside SiteScopeLayout, so `useActiveSite`
+// falls back to the last-persisted SitePicker selection, which can point at an
+// unrelated site when the page is reached via deep link or bookmark (e.g.
+// opening a North building while "South" is selected). That stale scope drives
+// MinerSelectionList's toggle-on breadth and the Building/Rack facet options,
+// producing the pre-existing miner picker bug (#764).
+//
+// Fixing it here — at the navigation layer — keeps every downstream consumer
+// (modals, facets, feeds) agreeing with the opened entity, so no per-modal
+// special-casing is needed.
+//
+// Behavior:
+//   - "all-sites"       → left untouched. Viewing one entity shouldn't collapse
+//                         an intentional org-wide view.
+//   - matching "site"   → no-op (header already agrees).
+//   - different "site"  → overwritten to the entity's own site.
+//   - "unassigned"      → overwritten to the entity's own site.
+//
+// Only fires once the entity's site id + slug are resolved (both required to
+// build a scoped ActiveSite). In-app navigation never mismatches, so this only
+// changes behavior on deep links/bookmarks — exactly when switching context to
+// the opened entity is desirable.
+//
+// Safe against useActiveSite's reconciliation: these routes carry no route
+// scope, so the route-scope mirror effect early-returns and won't clobber this
+// write, and the deleted-site guard passes for a real (loaded) site.
+export const useSyncScopeToEntity = (siteId: string | undefined, slug: string | undefined): void => {
+  const { activeSite, setActiveSite } = useActiveSite({});
+
+  useEffect(() => {
+    if (!siteId || !slug) return;
+    // Never collapse an intentional org-wide view.
+    if (activeSite.kind === "all") return;
+    // Already scoped to this entity's site — nothing to do.
+    if (activeSite.kind === "site" && activeSite.id === siteId) return;
+    setActiveSite({ kind: "site", id: siteId, slug });
+  }, [activeSite, siteId, slug, setActiveSite]);
+};

--- a/client/src/protoFleet/hooks/useSyncScopeToEntity.ts
+++ b/client/src/protoFleet/hooks/useSyncScopeToEntity.ts
@@ -18,7 +18,10 @@ import { useActiveSite } from "@/protoFleet/components/PageHeader/SitePicker";
 // Behavior:
 //   - "all-sites"       → left untouched. Viewing one entity shouldn't collapse
 //                         an intentional org-wide view.
-//   - matching "site"   → no-op (header already agrees).
+//   - matching "site"   → no-op, unless the stored slug is stale (renamed): we
+//                         hold the entity's canonical slug here, so refresh it
+//                         in place rather than leave a dead slug that later
+//                         produces broken scoped paths.
 //   - different "site"  → overwritten to the entity's own site.
 //   - "unassigned"      → overwritten to the entity's own site.
 //
@@ -37,8 +40,10 @@ export const useSyncScopeToEntity = (siteId: string | undefined, slug: string | 
     if (!siteId || !slug) return;
     // Never collapse an intentional org-wide view.
     if (activeSite.kind === "all") return;
-    // Already scoped to this entity's site — nothing to do.
-    if (activeSite.kind === "site" && activeSite.id === siteId) return;
+    // Already scoped to this entity's site with an up-to-date slug — nothing to
+    // do. A matching id but stale slug still falls through so the rename is
+    // reconciled from the entity's canonical slug.
+    if (activeSite.kind === "site" && activeSite.id === siteId && activeSite.slug === slug) return;
     setActiveSite({ kind: "site", id: siteId, slug });
   }, [activeSite, siteId, slug, setActiveSite]);
 };


### PR DESCRIPTION
Reviewable diff: +74/-20 across 4 files (excludes generated, test, and story files).

## Summary

The detail routes `/buildings/:id`, `/racks/:rackId`, and `/sites/:id` render **outside** `SiteScopeLayout`, so they have no route scope and the header falls back to the last-persisted `SitePicker` selection. On a deep link or bookmark that selection can point at an **unrelated** site (e.g. opening a North building while "South" is selected). That stale scope drove the rack/building miner picker's "Show assigned miners" breadth and its Site/Building facet options, producing a pre-existing miner-selection bug.

This PR fixes it at the navigation layer: on load, the page aligns the header scope with the entity being viewed (its own site), leaving an intentional "all-sites" view untouched. Once the header agrees with the entity, the miner picker scopes correctly with **no change to `MinerSelectionList`**.

Part of the rack-picker parity effort (`docs/plans/2026-07-16-758-rack-picker-parity-plan.md`) and unblocks #758 Part B, whose breadth model assumes the header agrees with the entity or is all-sites. This is a global-nav behavior change on deep links, so it wants a product nod before shipping.

## How it works

A new `useSyncScopeToEntity(siteId, slug)` hook is called by each of the three detail pages once the entity has resolved:

1. The page derives the entity's own site — building's `siteId`, the rack's `siteId` (falling back to its building's site), or the site page's own id — plus that site's **slug** (needed to build a scoped selection), resolved from the shell-level site catalog (`SitesContext` → `buildSiteSlugById`).
2. The hook reads the persisted scope and reconciles it against the entity's site:
   - **all-sites** → left untouched (viewing one entity shouldn't collapse an org-wide view).
   - **already this site** → no-op.
   - **a different site, or unassigned** → overwritten to the entity's own site.
3. It waits until *both* the site id and slug are known, so it never writes a partial/dead selection mid-load.

Because these routes carry no route scope, `useActiveSite`'s route-scope mirror effect early-returns and won't clobber the write, and its deleted-site guard passes for a real (loaded) site. In-app navigation already arrives with a matching scope, so this only changes behavior on deep links/bookmarks — exactly when adopting the opened entity's context is desirable.

`SiteDetailPage` previously handled the mismatch the opposite way — it **bounced to `/fleet`** for the persisted site. That effect (and its `breadcrumbSiteSelectionRef` bookkeeping) is replaced by the same sync hook, so the page now stays put and adopts the viewed site.

```mermaid
flowchart TD
    A["Deep link / bookmark to /buildings/:id, /racks/:rackId, /sites/:id"] --> B["Page resolves entity + its site id"]
    B --> C["Resolve site slug from SitesContext catalog"]
    C --> D{"useSyncScopeToEntity: persisted scope?"}
    D -->|"all-sites"| E["Leave untouched"]
    D -->|"same site"| F["No-op"]
    D -->|"different site / unassigned"| G["setActiveSite to entity's site"]
    E --> H["Header agrees with entity"]
    F --> H
    G --> H
    H --> I["Miner picker scopes correctly (no MinerSelectionList change)"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/hooks/useSyncScopeToEntity.ts` (new) | The reconciliation hook and its all-sites / match / mismatch rules | Core logic; the guard conditions are the correctness surface |
| `client/src/protoFleet/features/buildings/pages/BuildingPage.tsx` | Resolves building site id + slug and calls the hook | Confirms the hook fires only once the building has loaded |
| `client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx` | Resolves rack site id (rack → building fallback) + slug and calls the hook | Rack-modal reproduction path |
| `client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx` | Replaces the bounce-to-`/fleet` effect (and `breadcrumbSiteSelectionRef`, now-unused imports) with the sync hook | Behavior change: stays on page instead of redirecting |
| `*.test.tsx` (4 files) | Hook unit tests + per-page deep-link sync / all-sites-untouched tests; updated the old SiteDetailPage redirect test | test coverage — review-light |

## Key technical decisions & trade-offs

- **Fix at the nav layer, not per-modal.** One shared hook makes the header authoritative, so every downstream consumer (modals, facets, feeds) agrees — chosen over special-casing the mismatch inside each modal / `MinerSelectionList`.
- **Leave "all-sites" untouched.** Only scoped/unassigned selections are overwritten, preserving an intentional org-wide view; the alternative (always adopt the entity's site) would silently narrow that view.
- **Gate on id *and* slug.** The scoped `ActiveSite` needs a live slug; waiting for both avoids emitting a dead slug that `ResolveSiteBySlug` would treat as missing.
- **SiteDetailPage now adopts the site instead of redirecting to `/fleet`.** This is the visible behavior change and the reason a product nod is wanted.

## Testing & validation

- `tsc --noEmit`, `eslint --max-warnings 0`, and `prettier` all clean on the changed files.
- Vitest: **33 passing** across the four files.
  - New hook unit test — mismatch overwrite, unassigned overwrite, all-sites untouched, already-matching no-op, and waits-for-id+slug.
  - Building / Rack pages — deep-link mismatch syncs to the entity's site; all-sites left untouched.
  - SiteDetailPage — old "redirects to Fleet on mismatch" test updated to assert sync-to-entity (stays on page); added unassigned-adopts and all-sites-untouched cases.
- Not covered by automated tests: the end-to-end miner-picker toggle reproduction inside the live modals (acceptance criterion #2) — verified to be fixed by construction since the header now matches the entity, but not exercised via an integration test here.
