### PR TITLE
ci: split ProtoFleet E2E into 16 shards and slim the merge-reports job

### DIFF
--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -370,7 +370,11 @@ jobs:
         run: |
           # Pin the merge CLI to the lockfile's @playwright/test version so it can
           # read the shards' blob format without a full `npm ci` on the critical path.
-          PW_VERSION=$(jq -r '.packages["node_modules/@playwright/test"].version' ../../package-lock.json)
+          PW_VERSION=$(jq -r '.packages["node_modules/@playwright/test"].version // empty' ../../package-lock.json)
+          if [ -z "${PW_VERSION}" ]; then
+            echo "::error::Could not resolve @playwright/test version from client/package-lock.json"
+            exit 1
+          fi
           PLAYWRIGHT="npx --yes --package=@playwright/test@${PW_VERSION} playwright"
 
           echo "Merging blob reports with @playwright/test@${PW_VERSION}..."

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -164,12 +164,12 @@ jobs:
       contents: read
     env:
       # Total shard count. Keep in sync with the length of matrix.shard below.
-      SHARD_TOTAL: "8"
+      SHARD_TOTAL: "16"
     strategy:
       fail-fast: false
       matrix:
         # 0-indexed to match the round-robin modulo in the run step below.
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
         project: [desktop, mobile]
 
     steps:
@@ -357,19 +357,6 @@ jobs:
         with:
           preinstall: "false"
 
-      # See the build job: cache ~/.npm and run a clean `npm ci`.
-      - name: Cache npm dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('client/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
-
-      - name: Install client dependencies
-        working-directory: client
-        run: npm ci --include=optional
-
       - name: Download all blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -381,7 +368,12 @@ jobs:
         id: merge
         working-directory: client/e2eTests/protoFleet
         run: |
-          echo "Merging blob reports..."
+          # Pin the merge CLI to the lockfile's @playwright/test version so it can
+          # read the shards' blob format without a full `npm ci` on the critical path.
+          PW_VERSION=$(jq -r '.packages["node_modules/@playwright/test"].version' ../../package-lock.json)
+          PLAYWRIGHT="npx --yes --package=@playwright/test@${PW_VERSION} playwright"
+
+          echo "Merging blob reports with @playwright/test@${PW_VERSION}..."
           mkdir -p merged-reports
 
           # Organize blob reports by project
@@ -407,7 +399,7 @@ jobs:
             mkdir -p merged-reports/desktop/test-results
             PLAYWRIGHT_HTML_OUTPUT_DIR=merged-reports/desktop/playwright-report \
             PLAYWRIGHT_JUNIT_OUTPUT_FILE=merged-reports/desktop/test-results/results.xml \
-            npx playwright merge-reports --reporter=html,junit /tmp/desktop-blobs
+            $PLAYWRIGHT merge-reports --reporter=html,junit /tmp/desktop-blobs
             echo "desktop-report-path=client/e2eTests/protoFleet/merged-reports/desktop" >> $GITHUB_OUTPUT
           else
             echo "No desktop blob reports found"
@@ -419,7 +411,7 @@ jobs:
             mkdir -p merged-reports/mobile/test-results
             PLAYWRIGHT_HTML_OUTPUT_DIR=merged-reports/mobile/playwright-report \
             PLAYWRIGHT_JUNIT_OUTPUT_FILE=merged-reports/mobile/test-results/results.xml \
-            npx playwright merge-reports --reporter=html,junit /tmp/mobile-blobs
+            $PLAYWRIGHT merge-reports --reporter=html,junit /tmp/mobile-blobs
             echo "mobile-report-path=client/e2eTests/protoFleet/merged-reports/mobile" >> $GITHUB_OUTPUT
           else
             echo "No mobile blob reports found"


### PR DESCRIPTION
## Summary

PR CI wall-clock is dominated by the ProtoFleet E2E matrix. Analysis of the past week of PR CI (801 PR-triggered runs, ~12,200 jobs via the Actions API) shows a median PR Gate wall-clock of 16.1 min (p95 38.5 min) with this critical path: a ~6 min build, then the slowest of 8 E2E shards (9 to 13 min median), then a Merge Test Reports job that pays a full `npm ci` before merging blob reports. The E2E fan-in finished last in more gated runs than any other job.

This PR makes the two cheapest cuts to that path:

1. **16 E2E shards per project instead of 8** (desktop and mobile, so 32 matrix jobs instead of 16). Per-shard spec load halves from 4-5 spec files to 2-3.
2. **Slims merge-reports**: replaces the npm cache restore plus full `npm ci` with a single `npx --package=@playwright/test@<lockfile version>` invocation.

Expected: median PR Gate wall-clock drops to roughly 12-13 min. Trade-off: E2E runner-minutes roughly double. Queue times were ~0 across all 801 runs last week, so the added concurrency should not introduce queuing.

## How it works

- Spec files are assigned to shards round-robin by list index (`i % SHARD_TOTAL`) inside the run step. Shard count lives in exactly two places, the `SHARD_TOTAL` env var and the `matrix.shard` list, and both move from 8 to 16. With 38 spec files today every shard gets 2 or 3 specs; shards with zero specs already exit 0, so future spec-count changes stay safe.
- merge-reports only needs the Playwright CLI. It now resolves the exact `@playwright/test` version from `client/package-lock.json` with jq and runs `npx --yes --package=@playwright/test@<version> playwright merge-reports`, so the merge CLI always matches the blob-report format the shards produced without installing the whole client workspace.
- Nothing downstream depends on shard count: merge-reports downloads artifacts by the `blob-report-*` pattern, and the PR Gate `gate` job aggregates workflow-call results rather than per-shard job names, so required checks are unaffected.

## Diagrams

```mermaid
flowchart LR
    B["Build client and plugins<br/>~6 min"] --> S["e2e-tests matrix<br/>16 shards x 2 projects (was 8 x 2)<br/>slowest shard 9-13 min, expected 5-8 min"]
    S --> M["Merge Test Reports<br/>npm ci removed, pinned npx merge"]
```

## Areas of the code involved

- `.github/workflows/protofleet-e2e-tests.yml`
  - `e2e-tests` job: `SHARD_TOTAL` env and `matrix.shard` list
  - `merge-reports` job: removed the npm cache and client install steps; the merge step now pins the Playwright CLI to the client lockfile version via `npx --package`

## Key technical decisions & trade-offs

- **16 shards, not more.** Each shard pays 2-3 min of fixed setup (npm ci, browser install, docker image load, compose up), so wall-clock gains diminish quickly once shards hold 2-3 specs, while job count keeps doubling.
- **Playwright version resolved from the lockfile at runtime, not hardcoded.** The merge CLI must read the blob format the shards produced; deriving it from `client/package-lock.json` keeps the two in lockstep with zero maintenance.
- **Playwright `workers: 1` stays.** Tests within a shard share one docker-compose backend, so intra-shard parallelism would require test isolation work. Sharding provides the same parallelism with a dedicated backend per runner.
- **Known limit:** sharding cannot split a single spec file. A pathologically slow spec (like `rbac.spec.ts` at 20+ min on Jul 13-15 before #744 fixed its hooks) still sets the tail; file-level splits remain the fix for that class of problem.

## Testing & validation

- Workflow YAML parses cleanly.
- `jq -r '.packages["node_modules/@playwright/test"].version' client/package-lock.json` resolves to `1.61.1`, the value the merge step will pin.
- `just _lint-protos _lint-server _lint-plugins`: 0 issues. Client `tsc --noEmit`: pass.
- Real proof lands on this PR's own PR Gate run: expect 32 `e2e-tests` jobs and the merge step logging `Merging blob reports with @playwright/test@1.61.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)