### PR TITLE
refactor(server): make background jobs restartable (1/2)

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -129,6 +129,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 	"github.com/block/proto-fleet/server/internal/infrastructure/mqttclient"
 	"github.com/block/proto-fleet/server/internal/infrastructure/server"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 const shutdownTimeout = 10 * time.Second
@@ -386,11 +387,19 @@ func start(config *Config) error {
 		WithCommandSender(fleetNodeControlRegistry)
 
 	// Create diagnostics service for error polling and auto-closing stale errors
-	diagnosticsCtx, diagnosticsCancel := context.WithCancel(context.Background())
-	defer diagnosticsCancel()
 	errorStore := sqlstores.NewSQLErrorStore(conn, transactor)
-	diagnosticsService := diagnostics.NewService(diagnosticsCtx, config.Diagnostics, errorStore, transactor).
+	diagnosticsService := diagnostics.NewService(config.Diagnostics, errorStore, transactor).
 		WithDeviceScopeResolver(deviceStore)
+	if err := diagnosticsService.Start(context.Background()); err != nil {
+		return fmt.Errorf("start diagnostics error closer: %w", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := diagnosticsService.Stop(shutdownCtx); err != nil {
+			slog.Error("failed to stop diagnostics error closer", "error", err)
+		}
+	}()
 
 	// Shared per-org cache for ListMinerStateSnapshots option arrays
 	// (models, firmware versions). The TTL is the primary freshness
@@ -418,7 +427,7 @@ func start(config *Config) error {
 		slog.Info("Stopping telemetry service")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
-		if err := telemetryService.Stop(shutdownCtx); err != nil {
+		if err := telemetryService.Close(shutdownCtx); err != nil {
 			slog.Error("Failed to stop telemetry service", "error", err)
 		}
 	}()
@@ -458,15 +467,10 @@ func start(config *Config) error {
 	// Ensure IP scanner service cleanup on shutdown
 	defer func() {
 		slog.Info("Stopping IP scanner service")
-		if err := ipScannerService.Stop(); err != nil {
-			slog.Error("Failed to stop IP scanner service", "error", err)
-		}
+		stopStandaloneJob("IP scanner service", ipScannerService)
 	}()
 
 	dbMessageQueue := queue.NewDatabaseMessageQueue(&config.Queue, conn)
-
-	executionServiceCtx, executionServiceCancel := context.WithCancel(context.Background())
-	defer executionServiceCancel()
 
 	// Ensure plugin cleanup on shutdown
 	defer func() {
@@ -478,11 +482,15 @@ func start(config *Config) error {
 		}
 	}()
 
-	executionService := commandDomain.NewExecutionService(executionServiceCtx, &config.Command, conn, dbMessageQueue, encryptSvc, tokenSvc, minerService, deviceStore, telemetryService, filesService)
+	executionService := commandDomain.NewExecutionService(&config.Command, conn, dbMessageQueue, encryptSvc, tokenSvc, minerService, deviceStore, telemetryService, filesService)
 	executionService.WithMetricsEmitter(metricsProvider)
-	err = executionService.Start(executionServiceCtx)
+	err = executionService.Start(context.Background())
 	if err != nil {
 		slog.Error("failed to start command execution service", "error", err)
+	} else {
+		defer func() {
+			stopStandaloneJob("command execution service", executionService)
+		}()
 	}
 
 	statusService := commandDomain.NewStatusService(conn, dbMessageQueue)
@@ -544,9 +552,7 @@ func start(config *Config) error {
 		return fmt.Errorf("failed to start schedule processor: %w", err)
 	}
 	defer func() {
-		if err := scheduleProcessor.Stop(); err != nil {
-			slog.Error("failed to stop schedule processor", "error", err)
-		}
+		stopStandaloneJob("schedule processor", scheduleProcessor)
 	}()
 
 	curtailmentRec := curtailmentReconciler.New(
@@ -561,9 +567,7 @@ func start(config *Config) error {
 		return fmt.Errorf("failed to start curtailment reconciler: %w", err)
 	}
 	defer func() {
-		if err := curtailmentRec.Stop(); err != nil {
-			slog.Error("failed to stop curtailment reconciler", "error", err)
-		}
+		stopStandaloneJob("curtailment reconciler", curtailmentRec)
 	}()
 
 	mqttQueries, err := db.NewPreparedQuerier(context.Background(), conn)
@@ -600,7 +604,13 @@ func start(config *Config) error {
 	if err := mqttSubscriber.Start(context.Background()); err != nil {
 		return fmt.Errorf("failed to start curtailment mqtt subscriber: %w", err)
 	}
-	defer mqttSubscriber.Stop()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := mqttSubscriber.Stop(shutdownCtx); err != nil {
+			slog.Error("failed to stop curtailment mqtt subscriber", "error", err)
+		}
+	}()
 	mqttConnectionTester, err := mqttingest.NewMQTTConnectionTester(mqttingest.ConnectionTesterConfig{
 		NewClient: func() mqttingest.MQTTClient { return mqttclient.New() },
 	})
@@ -632,7 +642,9 @@ func start(config *Config) error {
 		if err := curtailmentAlertMetrics.Start(context.Background()); err != nil {
 			return fmt.Errorf("failed to start curtailment alert metrics loop: %w", err)
 		}
-		defer curtailmentAlertMetrics.Stop()
+		defer func() {
+			stopStandaloneJob("curtailment alert metrics loop", curtailmentAlertMetrics)
+		}()
 	}
 
 	deviceResolver := deviceresolver.New(deviceStore)
@@ -793,6 +805,28 @@ func start(config *Config) error {
 		return fmt.Errorf("server shutting down: %+v", err)
 	}
 	return nil
+}
+
+// stopStandaloneJob gives work one graceful-shutdown budget, then one final
+// bounded drain budget after forced cancellation. Later teardown always gets
+// a chance to run even if a dependency ignores cancellation.
+func stopStandaloneJob(name string, job runtimejobs.Lifecycle) {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	err := job.Stop(shutdownCtx)
+	cancel()
+	if err == nil {
+		return
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		slog.Error("failed to stop runtime job", "job", name, "error", err)
+		return
+	}
+	slog.Error("runtime job exceeded shutdown timeout", "job", name, "error", err)
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer drainCancel()
+	if err := job.Stop(drainCtx); err != nil {
+		slog.Error("failed to drain runtime job", "job", name, "error", err)
+	}
 }
 
 func newHTTP2Server(config HTTPConfig) *http2.Server {

--- a/server/cmd/fleetd/main_test.go
+++ b/server/cmd/fleetd/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net"
 	"net/http"
@@ -17,6 +18,47 @@ import (
 	kongyaml "github.com/alecthomas/kong-yaml"
 	"github.com/stretchr/testify/require"
 )
+
+type scriptedLifecycle struct {
+	stopErrors   []error
+	stopContexts []context.Context
+}
+
+func (s *scriptedLifecycle) Start(context.Context) error { return nil }
+
+func (s *scriptedLifecycle) Stop(ctx context.Context) error {
+	s.stopContexts = append(s.stopContexts, ctx)
+	if len(s.stopErrors) == 0 {
+		return nil
+	}
+	err := s.stopErrors[0]
+	s.stopErrors = s.stopErrors[1:]
+	return err
+}
+
+func TestStopStandaloneJobRetriesOnlyAfterTimeout(t *testing.T) {
+	tests := []struct {
+		name      string
+		stopErrs  []error
+		wantCalls int
+	}{
+		{name: "ordinary failure", stopErrs: []error{errors.New("stop failed")}, wantCalls: 1},
+		{name: "timeout", stopErrs: []error{context.DeadlineExceeded, nil}, wantCalls: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &scriptedLifecycle{stopErrors: tt.stopErrs}
+			stopStandaloneJob(tt.name, job)
+
+			require.Len(t, job.stopContexts, tt.wantCalls)
+			for _, ctx := range job.stopContexts {
+				_, hasDeadline := ctx.Deadline()
+				require.True(t, hasDeadline)
+			}
+		})
+	}
+}
 
 func TestFleetdLoadsConfigFromYAML(t *testing.T) {
 	t.Parallel()

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/infrastructure/encrypt"
 	"github.com/block/proto-fleet/server/internal/infrastructure/files"
 	"github.com/block/proto-fleet/server/internal/infrastructure/queue"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 const (
@@ -69,12 +70,17 @@ type ExecutionService struct {
 
 	workerSemaphore chan struct{}
 
-	queueProcessorMu      sync.Mutex
+	lifecycleMu           sync.Mutex
 	queueProcessorRunning bool
-	reaperCancel          context.CancelFunc
+	runCancel             context.CancelFunc
+	runWG                 sync.WaitGroup
+	runDone               <-chan struct{}
+	stopping              bool
 }
 
-func NewExecutionService(ctx context.Context, config *Config, conn *sql.DB, messageQueue queue.MessageQueue, encryptService *encrypt.Service, tokenService *tokenDomain.Service, minerService CachedMinerGetter, deviceStore stores.DeviceStore, telemetryListener TelemetryListener, filesService *files.Service) *ExecutionService {
+var _ runtimejobs.Lifecycle = (*ExecutionService)(nil)
+
+func NewExecutionService(config *Config, conn *sql.DB, messageQueue queue.MessageQueue, encryptService *encrypt.Service, tokenService *tokenDomain.Service, minerService CachedMinerGetter, deviceStore stores.DeviceStore, telemetryListener TelemetryListener, filesService *files.Service) *ExecutionService {
 	if config.StuckMessageTimeout <= 0 {
 		config.StuckMessageTimeout = 5 * time.Minute
 	}
@@ -113,42 +119,84 @@ func (es *ExecutionService) WithMetricsEmitter(emitter MetricsEmitter) *Executio
 
 // Start starts the queue processor thread if it is not already running.
 func (es *ExecutionService) Start(ctx context.Context) error {
-	es.queueProcessorMu.Lock()
-	defer es.queueProcessorMu.Unlock()
-
-	if es.queueProcessorRunning {
+	es.lifecycleMu.Lock()
+	if es.stopping {
+		es.lifecycleMu.Unlock()
+		return fmt.Errorf("command execution service is still stopping")
+	}
+	if es.runCancel != nil {
+		es.lifecycleMu.Unlock()
 		return nil
 	}
 
+	runCtx, runCancel := context.WithCancel(ctx)
+	runDone := make(chan struct{})
+	es.runCancel = runCancel
+	es.runDone = runDone
 	es.queueProcessorRunning = true
 
-	if es.reaperCancel != nil {
-		es.reaperCancel()
-	}
-	reaperCtx, reaperCancel := context.WithCancel(ctx)
-	es.reaperCancel = reaperCancel
-
-	go es.startStuckMessageReaper(reaperCtx)
+	es.runWG.Go(func() {
+		es.startStuckMessageReaper(runCtx)
+	})
 
 	// Start the queue processor thread
-	go func() {
-		err := es.startQueueProcessorThread(ctx)
-		reaperCancel()
-		es.queueProcessorMu.Lock()
+	es.runWG.Go(func() {
+		err := es.startQueueProcessorThread(runCtx)
+		runCancel()
+		es.lifecycleMu.Lock()
 		es.queueProcessorRunning = false
-		es.queueProcessorMu.Unlock()
+		es.lifecycleMu.Unlock()
 
 		if err != nil && !errors.Is(err, context.Canceled) {
 			slog.Error("message processing stopped with error", "error", err)
 		}
-	}()
+	})
+	go es.finishRun(runDone)
+	es.lifecycleMu.Unlock()
 
 	return nil
 }
 
+func (es *ExecutionService) finishRun(done chan struct{}) {
+	es.runWG.Wait()
+
+	es.lifecycleMu.Lock()
+	if es.runDone == (<-chan struct{})(done) {
+		es.runCancel = nil
+		es.runDone = nil
+		es.stopping = false
+		es.queueProcessorRunning = false
+	}
+	es.lifecycleMu.Unlock()
+	close(done)
+}
+
+// Stop cancels the active queue processor, reaper, and workers and waits for
+// all execution-owned goroutines to drain.
+func (es *ExecutionService) Stop(ctx context.Context) error {
+	es.lifecycleMu.Lock()
+	if es.runCancel == nil {
+		es.lifecycleMu.Unlock()
+		return nil
+	}
+	if !es.stopping {
+		es.stopping = true
+		es.runCancel()
+	}
+	done := es.runDone
+	es.lifecycleMu.Unlock()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("stop command execution service: %w", ctx.Err())
+	}
+}
+
 func (es *ExecutionService) IsRunning() bool {
-	es.queueProcessorMu.Lock()
-	defer es.queueProcessorMu.Unlock()
+	es.lifecycleMu.Lock()
+	defer es.lifecycleMu.Unlock()
 
 	return es.queueProcessorRunning
 }
@@ -317,25 +365,37 @@ func (es *ExecutionService) startQueueProcessorThread(ctx context.Context) error
 			}
 
 			if len(messages) == 0 {
-				time.Sleep(es.config.MasterPollingInterval)
-				continue
+				timer := time.NewTimer(es.config.MasterPollingInterval)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return fmt.Errorf("queue processor context canceled while idle: %w", ctx.Err())
+				case <-timer.C:
+					continue
+				}
 			}
 
 			for _, message := range messages {
-				es.workerSemaphore <- struct{}{}
+				select {
+				case es.workerSemaphore <- struct{}{}:
+				case <-ctx.Done():
+					return fmt.Errorf("queue processor context canceled waiting for worker slot: %w", ctx.Err())
+				}
 
-				go func(msg queue.Message) {
+				// The processor remains in runWG while it adds workers, so Wait
+				// cannot finish before all worker registrations are complete.
+				es.runWG.Go(func() {
 					defer func() { <-es.workerSemaphore }()
 
 					timeout := es.config.WorkerExecutionTimeout
-					if msg.CommandType == commandtype.FirmwareUpdate {
+					if message.CommandType == commandtype.FirmwareUpdate {
 						timeout = es.config.FirmwareUpdateTimeout
 					}
 					workerCtx, cancel := context.WithTimeout(ctx, timeout)
 					defer cancel()
 
-					es.workerProcessCommand(workerCtx, msg)
-				}(message)
+					es.workerProcessCommand(workerCtx, message)
+				})
 			}
 		}
 	}

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -312,8 +312,8 @@ func (es *ExecutionService) emitReapedCommandMetrics(ctx context.Context, reaped
 	}
 }
 
-func (es *ExecutionService) dequeueWithRetry(ctx context.Context) ([]queue.Message, error) {
-	messages, err := es.messageQueue.Dequeue(ctx)
+func (es *ExecutionService) dequeueWithRetry(ctx context.Context, limit int32) ([]queue.Message, error) {
+	messages, err := es.messageQueue.Dequeue(ctx, limit)
 	if err == nil {
 		return messages, nil
 	}
@@ -336,7 +336,7 @@ func (es *ExecutionService) dequeueWithRetry(ctx context.Context) ([]queue.Messa
 		// simple backoff for next attempt
 		delay *= 2
 
-		messages, err = es.messageQueue.Dequeue(ctx)
+		messages, err = es.messageQueue.Dequeue(ctx, limit)
 		if err == nil {
 			return messages, nil
 		}
@@ -351,53 +351,76 @@ func (es *ExecutionService) dequeueWithRetry(ctx context.Context) ([]queue.Messa
 
 func (es *ExecutionService) startQueueProcessorThread(ctx context.Context) error {
 	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("queue processor context canceled: %w", ctx.Err())
-		default:
-			messages, err := es.dequeueWithRetry(ctx)
-
-			if err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return err
-				}
-				return fleeterror.NewInternalErrorf("error dequeueing messages: %v", err)
+		reservedSlots, err := es.reserveWorkerSlots(ctx)
+		if err != nil {
+			return err
+		}
+		messages, err := es.dequeueWithRetry(ctx, reservedSlots)
+		if err != nil {
+			es.releaseWorkerSlots(int(reservedSlots))
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
 			}
+			return fleeterror.NewInternalErrorf("error dequeueing messages: %v", err)
+		}
+		if len(messages) > int(reservedSlots) {
+			es.releaseWorkerSlots(int(reservedSlots))
+			return fleeterror.NewInternalErrorf("dequeue returned %d messages for %d reserved worker slots", len(messages), reservedSlots)
+		}
+		es.releaseWorkerSlots(int(reservedSlots) - len(messages))
 
-			if len(messages) == 0 {
-				timer := time.NewTimer(es.config.MasterPollingInterval)
-				select {
-				case <-ctx.Done():
-					timer.Stop()
-					return fmt.Errorf("queue processor context canceled while idle: %w", ctx.Err())
-				case <-timer.C:
-					continue
-				}
-			}
-
-			for _, message := range messages {
-				select {
-				case es.workerSemaphore <- struct{}{}:
-				case <-ctx.Done():
-					return fmt.Errorf("queue processor context canceled waiting for worker slot: %w", ctx.Err())
-				}
-
-				// The processor remains in runWG while it adds workers, so Wait
-				// cannot finish before all worker registrations are complete.
-				es.runWG.Go(func() {
-					defer func() { <-es.workerSemaphore }()
-
-					timeout := es.config.WorkerExecutionTimeout
-					if message.CommandType == commandtype.FirmwareUpdate {
-						timeout = es.config.FirmwareUpdateTimeout
-					}
-					workerCtx, cancel := context.WithTimeout(ctx, timeout)
-					defer cancel()
-
-					es.workerProcessCommand(workerCtx, message)
-				})
+		if len(messages) == 0 {
+			timer := time.NewTimer(es.config.MasterPollingInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return fmt.Errorf("queue processor context canceled while idle: %w", ctx.Err())
+			case <-timer.C:
+				continue
 			}
 		}
+
+		for _, message := range messages {
+			// The processor remains in runWG while it adds workers, so Wait
+			// cannot finish before all worker registrations are complete.
+			es.runWG.Go(func() {
+				defer func() { <-es.workerSemaphore }()
+
+				timeout := es.config.WorkerExecutionTimeout
+				if message.CommandType == commandtype.FirmwareUpdate {
+					timeout = es.config.FirmwareUpdateTimeout
+				}
+				workerCtx, cancel := context.WithTimeout(ctx, timeout)
+				defer cancel()
+
+				es.workerProcessCommand(workerCtx, message)
+			})
+		}
+	}
+}
+
+func (es *ExecutionService) reserveWorkerSlots(ctx context.Context) (int32, error) {
+	select {
+	case es.workerSemaphore <- struct{}{}:
+	case <-ctx.Done():
+		return 0, fmt.Errorf("queue processor context canceled waiting for worker slot: %w", ctx.Err())
+	}
+
+	reserved := int32(1)
+	for int(reserved) < cap(es.workerSemaphore) {
+		select {
+		case es.workerSemaphore <- struct{}{}:
+			reserved++
+		default:
+			return reserved, nil
+		}
+	}
+	return reserved, nil
+}
+
+func (es *ExecutionService) releaseWorkerSlots(count int) {
+	for range count {
+		<-es.workerSemaphore
 	}
 }
 

--- a/server/internal/domain/command/execution_service_credentials_test.go
+++ b/server/internal/domain/command/execution_service_credentials_test.go
@@ -409,9 +409,10 @@ func setupPasswordCommandDeviceWithStatus(t *testing.T, driverName string, withC
 		require.NoError(t, err)
 	}
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers: 1,
 	}, conn, nil, encryptSvc, nil, nil, nil, nil, nil)
+
 	return svc, conn, encryptSvc, dbDeviceID, deviceIdentifier
 }
 

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -39,51 +40,19 @@ type firmwareStatusMiner struct {
 }
 
 func TestExecutionService_Start(t *testing.T) {
-	t.Run("starts when not running and returns true", func(t *testing.T) {
+	t.Run("is idempotent while running", func(t *testing.T) {
 		// Arrange
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		started := false
+		var started atomic.Bool
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
 		mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
-			started = true
+			started.Store(true)
 			return nil, nil
 		}).AnyTimes()
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-
-		svc := NewExecutionService(t.Context(), &Config{
-			MaxWorkers:            5,
-			MasterPollingInterval: 10 * time.Millisecond,
-		}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
-
-		// Act
-		err := svc.Start(t.Context())
-
-		// Assert
-		require.NoError(t, err)
-
-		// Verify the processor started
-		assert.Eventually(t, func() bool {
-			return started
-		}, 100*time.Millisecond, 5*time.Millisecond, "Processor should start")
-
-		assert.True(t, svc.IsRunning())
-	})
-
-	t.Run("returns false when already running", func(t *testing.T) {
-		// Arrange
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		started := false
-		mockQueue := mocks.NewMockMessageQueue(ctrl)
-		mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
-			started = true
-			return nil, nil
-		}).AnyTimes()
-		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 10 * time.Millisecond,
 		}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
@@ -93,9 +62,7 @@ func TestExecutionService_Start(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify the processor started
-		assert.Eventually(t, func() bool {
-			return started
-		}, 100*time.Millisecond, 5*time.Millisecond, "Processor should start")
+		assert.Eventually(t, started.Load, 100*time.Millisecond, 5*time.Millisecond, "Processor should start")
 
 		// Act - try to start again
 		err = svc.Start(t.Context())
@@ -104,39 +71,104 @@ func TestExecutionService_Start(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, svc.IsRunning())
 	})
-}
 
-func TestStuckMessageReaper(t *testing.T) {
-	t.Run("reaper goroutine runs alongside processor", func(t *testing.T) {
-		// Arrange
+	t.Run("stops promptly while idle and can restart", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
-		mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
-			<-ctx.Done()
-			return nil, ctx.Err()
-		}).AnyTimes()
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
 
-		// conn=nil makes reapStuckMessages skip the DB call, so we just test
-		// that the goroutine starts and the processor runs alongside it.
-		svc := NewExecutionService(t.Context(), &Config{
-			MaxWorkers:            5,
-			MasterPollingInterval: 10 * time.Millisecond,
-			StuckMessageTimeout:   5 * time.Minute,
-			ReaperInterval:        10 * time.Millisecond,
+		var dequeues atomic.Int32
+		mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(context.Context) ([]queue.Message, error) {
+			dequeues.Add(1)
+			return nil, nil
+		}).AnyTimes()
+
+		svc := NewExecutionService(&Config{
+			MaxWorkers:            1,
+			MasterPollingInterval: time.Hour,
 		}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
 
-		// Act
-		err := svc.Start(t.Context())
+		require.NoError(t, svc.Start(t.Context()))
+		require.Eventually(t, func() bool { return dequeues.Load() >= 1 }, 100*time.Millisecond, time.Millisecond)
+		stop := func() {
+			stopCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			require.NoError(t, svc.Stop(stopCtx))
+		}
+		stop()
+		require.False(t, svc.IsRunning())
 
-		// Assert
-		require.NoError(t, err)
-		assert.Eventually(t, func() bool {
-			return svc.IsRunning()
-		}, 100*time.Millisecond, 5*time.Millisecond)
+		require.NoError(t, svc.Start(t.Context()))
+		require.Eventually(t, func() bool { return dequeues.Load() >= 2 }, 100*time.Millisecond, time.Millisecond)
+		stop()
 	})
+}
+
+func TestExecutionService_StopTimeoutRetainsActivationUntilWorkerDrains(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockQueue := mocks.NewMockMessageQueue(ctrl)
+	mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
+	mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}).AnyTimes()
+
+	svc := NewExecutionService(&Config{
+		MaxWorkers:            1,
+		MasterPollingInterval: time.Hour,
+	}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
+
+	_, runCancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	svc.runCancel = runCancel
+	svc.runDone = runDone
+	svc.queueProcessorRunning = true
+	workerStarted := make(chan struct{})
+	releaseWorker := make(chan struct{})
+	svc.runWG.Go(func() {
+		close(workerStarted)
+		<-releaseWorker
+	})
+	go svc.finishRun(runDone)
+	<-workerStarted
+
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	require.ErrorIs(t, svc.Stop(stopCtx), context.DeadlineExceeded)
+	cancelStop()
+	require.Error(t, svc.Start(t.Context()))
+
+	close(releaseWorker)
+	require.NoError(t, svc.Stop(context.Background()))
+	require.NoError(t, svc.Start(t.Context()))
+	require.NoError(t, svc.Stop(context.Background()))
+}
+
+func TestExecutionService_CanRestartAfterProcessorFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockQueue := mocks.NewMockMessageQueue(ctrl)
+	mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
+	firstDequeue := mockQueue.EXPECT().Dequeue(gomock.Any()).Return(nil, errors.New("queue unavailable"))
+	mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}).AnyTimes().After(firstDequeue)
+
+	svc := NewExecutionService(&Config{
+		MaxWorkers:            1,
+		MasterPollingInterval: time.Hour,
+		DequeueRetries:        0,
+	}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
+
+	require.NoError(t, svc.Start(t.Context()))
+	require.Eventually(t, func() bool {
+		svc.lifecycleMu.Lock()
+		defer svc.lifecycleMu.Unlock()
+		return svc.runCancel == nil
+	}, time.Second, time.Millisecond)
+
+	require.NoError(t, svc.Start(t.Context()))
+	require.Eventually(t, svc.IsRunning, time.Second, time.Millisecond)
+	require.NoError(t, svc.Stop(context.Background()))
 }
 
 func TestQueueProcessorRetries(t *testing.T) {
@@ -155,7 +187,7 @@ func TestQueueProcessorRetries(t *testing.T) {
 			})
 
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-		svc := NewExecutionService(ctx, &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: time.Millisecond,
 			DequeueRetries:        0,
@@ -180,7 +212,7 @@ func TestQueueProcessorRetries(t *testing.T) {
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
 
 		// Track successful retry completion
-		retrySucceeded := false
+		var retrySucceeded atomic.Bool
 
 		// First call - returns error
 		mockQueue.EXPECT().
@@ -199,7 +231,7 @@ func TestQueueProcessorRetries(t *testing.T) {
 			Dequeue(gomock.Any()).
 			DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
 				// Signal that retry sequence completed successfully
-				retrySucceeded = true
+				retrySucceeded.Store(true)
 				close(retryComplete)
 
 				return []queue.Message{}, nil
@@ -216,7 +248,7 @@ func TestQueueProcessorRetries(t *testing.T) {
 			AnyTimes()
 
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: time.Millisecond,
 			DequeueRetries:        3,
@@ -227,9 +259,7 @@ func TestQueueProcessorRetries(t *testing.T) {
 		require.NoError(t, err)
 
 		// Assert
-		assert.Eventually(t, func() bool {
-			return retrySucceeded
-		}, 200*time.Millisecond, 10*time.Millisecond, "Service should retry and eventually succeed")
+		assert.Eventually(t, retrySucceeded.Load, 200*time.Millisecond, 10*time.Millisecond, "Service should retry and eventually succeed")
 
 		assert.True(t, svc.IsRunning())
 	})
@@ -250,7 +280,7 @@ func TestQueueProcessorRetries(t *testing.T) {
 			Times(3)
 
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: time.Millisecond,
 			DequeueRetries:        2, // Only 2 retries allowed
@@ -295,7 +325,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Reboot(gomock.Any()).
 			Return(fleeterror.NewUnimplementedError("reboot not supported"))
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -335,7 +365,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Reboot(gomock.Any()).
 			Return(fleeterror.NewInternalErrorf("temporary failure"))
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -375,7 +405,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Reboot(gomock.Any()).
 			Return(nil)
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -408,7 +438,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			GetMiner(gomock.Any(), int64(45)).
 			Return(nil, errors.New("device not found"))
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -448,7 +478,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Curtail(gomock.Any(), sdk.CurtailRequest{Level: sdk.CurtailLevelFull}).
 			Return(nil)
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -478,7 +508,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 		mockMinerGetter.EXPECT().GetMiner(gomock.Any(), int64(51)).Return(mockMiner, nil)
 		// Curtail must NOT be called when payload unmarshal fails.
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -516,7 +546,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			mockMinerGetter.EXPECT().GetMiner(gomock.Any(), int64(53)).Return(mockMiner, nil)
 			// No mockMiner.EXPECT().Curtail(...) — bounds check must short-circuit.
 
-			svc := NewExecutionService(t.Context(), &Config{
+			svc := NewExecutionService(&Config{
 				MaxWorkers:             5,
 				MasterPollingInterval:  10 * time.Millisecond,
 				WorkerExecutionTimeout: 5 * time.Second,
@@ -550,7 +580,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Uncurtail(gomock.Any(), sdk.UncurtailRequest{}).
 			Return(nil)
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -715,7 +745,7 @@ func TestExecuteCommandOnDevice_FirmwareUpdatePassesFileMetadata(t *testing.T) {
 		GetDeviceStatusForDeviceIdentifiers(gomock.Any(), []tmodels.DeviceIdentifier{"device-123"}).
 		Return(map[tmodels.DeviceIdentifier]models.MinerStatus{}, nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -793,7 +823,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_UsesStoredWorkerName(t *testin
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -866,7 +896,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_UsesStoredWorkerNameAfterLooku
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -937,7 +967,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_PrefersCurrentPrimaryPoolWorke
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1000,7 +1030,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_FallsBackToStoredMacAddress(t 
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1068,7 +1098,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_LeavesUsernameUnchangedWhenWor
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1115,7 +1145,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_LeavesRawPoolUsernamesUnchange
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1164,7 +1194,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_PreservesLegacyDottedFleetUser
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1225,7 +1255,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReappliesCurrentPoolsWithStore
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1280,7 +1310,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyUsesDesiredWorkerNameFr
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-payload"), "payload-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1336,7 +1366,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyAppendsStoredWorkerName
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-append"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1391,7 +1421,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyReplacesEntireDottedWor
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-dotted-worker"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1452,7 +1482,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyNormalizesAllPoolsToSto
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-normalize-all"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1497,7 +1527,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_PersistsWorkerNameWhenNoCurren
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-empty"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1538,7 +1568,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyPreservesGetPoolsErrorC
 		GetMiningPools(gomock.Any()).
 		Return(nil, fleeterror.NewUnimplementedErrorf("get pools not supported"))
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1634,7 +1664,7 @@ func TestExecuteCommand_UpdateMinerPassword_PersistFailureFailsCommand(t *testin
 	mockMiner.EXPECT().UpdateMinerPassword(gomock.Any(), gomock.Any()).Return(nil)
 	mockMinerGetter.EXPECT().InvalidateMiner(models.DeviceIdentifier("dev-50"))
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -47,7 +47,7 @@ func TestExecutionService_Start(t *testing.T) {
 
 		var started atomic.Bool
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
-		mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
+		mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
 			started.Store(true)
 			return nil, nil
 		}).AnyTimes()
@@ -78,7 +78,7 @@ func TestExecutionService_Start(t *testing.T) {
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
 
 		var dequeues atomic.Int32
-		mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(context.Context) ([]queue.Message, error) {
+		mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, int32) ([]queue.Message, error) {
 			dequeues.Add(1)
 			return nil, nil
 		}).AnyTimes()
@@ -108,7 +108,7 @@ func TestExecutionService_StopTimeoutRetainsActivationUntilWorkerDrains(t *testi
 	ctrl := gomock.NewController(t)
 	mockQueue := mocks.NewMockMessageQueue(ctrl)
 	mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-	mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
+	mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}).AnyTimes()
@@ -143,12 +143,35 @@ func TestExecutionService_StopTimeoutRetainsActivationUntilWorkerDrains(t *testi
 	require.NoError(t, svc.Stop(context.Background()))
 }
 
+func TestExecutionService_DequeueIsLimitedToAvailableWorkers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockQueue := mocks.NewMockMessageQueue(ctrl)
+	mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
+	dequeued := make(chan struct{})
+	mockQueue.EXPECT().Dequeue(gomock.Any(), int32(1)).DoAndReturn(func(context.Context, int32) ([]queue.Message, error) {
+		close(dequeued)
+		return nil, nil
+	})
+
+	svc := NewExecutionService(&Config{
+		MaxWorkers:            1,
+		MasterPollingInterval: time.Hour,
+	}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- svc.startQueueProcessorThread(ctx) }()
+	<-dequeued
+	cancel()
+
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
 func TestExecutionService_CanRestartAfterProcessorFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockQueue := mocks.NewMockMessageQueue(ctrl)
 	mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-	firstDequeue := mockQueue.EXPECT().Dequeue(gomock.Any()).Return(nil, errors.New("queue unavailable"))
-	mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
+	firstDequeue := mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).Return(nil, errors.New("queue unavailable"))
+	mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}).AnyTimes().After(firstDequeue)
@@ -180,8 +203,8 @@ func TestQueueProcessorRetries(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
-			DoAndReturn(func(context.Context) ([]queue.Message, error) {
+			Dequeue(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(context.Context, int32) ([]queue.Message, error) {
 				cancel()
 				return nil, fleeterror.NewInternalError("error opening tx: context canceled")
 			})
@@ -216,20 +239,20 @@ func TestQueueProcessorRetries(t *testing.T) {
 
 		// First call - returns error
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
+			Dequeue(gomock.Any(), gomock.Any()).
 			Return(nil, testError).
 			Times(1)
 
 		// Second call - returns error
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
+			Dequeue(gomock.Any(), gomock.Any()).
 			Return(nil, testError).
 			Times(1)
 
 		// Third call - returns success and signals completion
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
-			DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
+			Dequeue(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
 				// Signal that retry sequence completed successfully
 				retrySucceeded.Store(true)
 				close(retryComplete)
@@ -240,8 +263,8 @@ func TestQueueProcessorRetries(t *testing.T) {
 
 		// Subsequent calls just block
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
-			DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
+			Dequeue(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
 				<-ctx.Done()
 				return nil, ctx.Err()
 			}).
@@ -275,7 +298,7 @@ func TestQueueProcessorRetries(t *testing.T) {
 
 		// First three calls fail (initial + 2 retries)
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
+			Dequeue(gomock.Any(), gomock.Any()).
 			Return(nil, testError).
 			Times(3)
 

--- a/server/internal/domain/command/reaper_integration_test.go
+++ b/server/internal/domain/command/reaper_integration_test.go
@@ -153,7 +153,7 @@ func TestReaperIntegration(t *testing.T) {
 		createBatchLog(t, conn, batchUUID, user.DatabaseID, 1)
 		createStuckMessage(t, conn, batchUUID, device.DatabaseID, 10*time.Minute)
 
-		svc := command.NewExecutionService(t.Context(), &command.Config{
+		svc := command.NewExecutionService(&command.Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 100 * time.Millisecond,
 			StuckMessageTimeout:   5 * time.Minute,
@@ -190,7 +190,7 @@ func TestReaperIntegration(t *testing.T) {
 		createBatchLog(t, conn, batchUUID, user.DatabaseID, 1)
 		createStuckMessage(t, conn, batchUUID, device.DatabaseID, 1*time.Minute)
 
-		svc := command.NewExecutionService(t.Context(), &command.Config{
+		svc := command.NewExecutionService(&command.Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 100 * time.Millisecond,
 			StuckMessageTimeout:   5 * time.Minute,
@@ -239,7 +239,7 @@ func TestReaperIntegration(t *testing.T) {
 		_, err = conn.ExecContext(ctx, "ALTER TABLE queue_message ENABLE TRIGGER update_queue_message_updated_at")
 		require.NoError(t, err)
 
-		svc := command.NewExecutionService(t.Context(), &command.Config{
+		svc := command.NewExecutionService(&command.Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 100 * time.Millisecond,
 			StuckMessageTimeout:   5 * time.Minute,
@@ -267,7 +267,7 @@ func TestReaperIntegration(t *testing.T) {
 		createStuckMessage(t, conn, batchUUID, device1.DatabaseID, 10*time.Minute)
 		createStuckMessage(t, conn, batchUUID, device2.DatabaseID, 10*time.Minute)
 
-		svc := command.NewExecutionService(t.Context(), &command.Config{
+		svc := command.NewExecutionService(&command.Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 100 * time.Millisecond,
 			StuckMessageTimeout:   5 * time.Minute,

--- a/server/internal/domain/command/reaper_integration_test.go
+++ b/server/internal/domain/command/reaper_integration_test.go
@@ -122,7 +122,7 @@ func (n *noopMessageQueue) Enqueue(_ context.Context, _ string, _ commandtype.Ty
 func (n *noopMessageQueue) EnqueueMany(_ context.Context, _ string, _ commandtype.Type, _ []queue.EnqueueMessage) error {
 	return nil
 }
-func (n *noopMessageQueue) Dequeue(ctx context.Context) ([]queue.Message, error) {
+func (n *noopMessageQueue) Dequeue(ctx context.Context, _ int32) ([]queue.Message, error) {
 	<-ctx.Done()
 	return nil, fmt.Errorf("dequeue cancelled: %w", ctx.Err())
 }

--- a/server/internal/domain/command/service_curtail_test.go
+++ b/server/internal/domain/command/service_curtail_test.go
@@ -49,7 +49,7 @@ func (f *fakeMessageQueue) EnqueueMany(_ context.Context, batchUUID string, ct c
 	return f.enqueueReturnError
 }
 
-func (f *fakeMessageQueue) Dequeue(context.Context) ([]queue.Message, error) {
+func (f *fakeMessageQueue) Dequeue(context.Context, int32) ([]queue.Message, error) {
 	panic("Dequeue not used")
 }
 func (f *fakeMessageQueue) MarkSuccess(context.Context, int64) error {

--- a/server/internal/domain/command/zero_target_integration_test.go
+++ b/server/internal/domain/command/zero_target_integration_test.go
@@ -42,7 +42,6 @@ func newZeroTargetDispatchTestService(t *testing.T, conn *sql.DB) *command.Servi
 	t.Cleanup(cancel)
 
 	executionService := command.NewExecutionService(
-		executionCtx,
 		commandConfig,
 		conn,
 		messageQueue,
@@ -53,6 +52,7 @@ func newZeroTargetDispatchTestService(t *testing.T, conn *sql.DB) *command.Servi
 		nil,
 		nil,
 	)
+
 	require.NoError(t, executionService.Start(executionCtx))
 
 	return command.NewService(

--- a/server/internal/domain/curtailment/alert_metrics.go
+++ b/server/internal/domain/curtailment/alert_metrics.go
@@ -7,6 +7,7 @@ package curtailment
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/mqttingest"
 	"github.com/block/proto-fleet/server/internal/infrastructure/metrics"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 // 10s keeps alert latency close to the source signal: curtailment engages
@@ -60,11 +62,12 @@ type AlertMetricsConfig struct {
 type AlertMetricsLoop struct {
 	cfg AlertMetricsConfig
 
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	cancel  context.CancelFunc
+	runDone <-chan struct{}
 
-	mu      sync.Mutex
-	running bool
+	lifecycleMu sync.Mutex
+	mu          sync.Mutex
+	stopping    bool
 
 	// prevConnected / prevActive remember the labels each gauge was emitted
 	// with last tick (touched only by the tick goroutine), so a renamed or
@@ -73,6 +76,8 @@ type AlertMetricsLoop struct {
 	prevConnected map[int64]metrics.MQTTSourceLabels
 	prevActive    map[int64]metrics.MQTTSourceLabels
 }
+
+var _ runtimejobs.Lifecycle = (*AlertMetricsLoop)(nil)
 
 // NewAlertMetricsLoop validates dependencies and applies defaults.
 func NewAlertMetricsLoop(cfg AlertMetricsConfig) (*AlertMetricsLoop, error) {
@@ -99,39 +104,62 @@ func NewAlertMetricsLoop(cfg AlertMetricsConfig) (*AlertMetricsLoop, error) {
 
 // Start launches the tick loop; a second Start while running is a no-op.
 // The loop runs until Stop.
-func (l *AlertMetricsLoop) Start(_ context.Context) error {
+func (l *AlertMetricsLoop) Start(ctx context.Context) error {
+	l.lifecycleMu.Lock()
+	defer l.lifecycleMu.Unlock()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.running {
+	if l.stopping {
+		return errors.New("curtailment alert metrics: previous activation is still stopping")
+	}
+	if l.cancel != nil {
 		return nil
 	}
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(ctx)
+	runDone := make(chan struct{})
 	l.cancel = cancel
-	l.running = true
-	l.wg.Add(1)
-	go l.tickLoop(runCtx)
+	l.runDone = runDone
+	go l.tickLoop(runCtx, runDone)
 	l.cfg.Logger.Info("curtailment alert metrics loop started", "interval", l.cfg.Interval)
 	return nil
 }
 
-// Stop cancels the loop and waits for the in-flight tick to drain. The wait
-// holds the mutex so a concurrent Start cannot reuse the WaitGroup mid-Wait;
-// the tick goroutine never takes the mutex, so this cannot deadlock.
-func (l *AlertMetricsLoop) Stop() {
+// Stop cancels the loop and waits for the in-flight tick within ctx.
+// A timed-out activation remains owned, preventing a replacement loop from
+// overlapping work that ignored cancellation.
+func (l *AlertMetricsLoop) Stop(ctx context.Context) error {
+	l.lifecycleMu.Lock()
+	defer l.lifecycleMu.Unlock()
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	if l.cancel == nil {
-		return
+		l.mu.Unlock()
+		return nil
 	}
-	l.cancel()
-	l.cancel = nil
-	l.running = false
-	l.wg.Wait()
-	l.cfg.Logger.Info("curtailment alert metrics loop stopped")
+	l.stopping = true
+	cancel := l.cancel
+	runDone := l.runDone
+	l.mu.Unlock()
+	cancel()
+	select {
+	case <-runDone:
+		l.cfg.Logger.Info("curtailment alert metrics loop stopped")
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("curtailment alert metrics: stop: %w", ctx.Err())
+	}
 }
 
-func (l *AlertMetricsLoop) tickLoop(ctx context.Context) {
-	defer l.wg.Done()
+func (l *AlertMetricsLoop) finishActivation() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.cancel = nil
+	l.runDone = nil
+	l.stopping = false
+}
+
+func (l *AlertMetricsLoop) tickLoop(ctx context.Context, runDone chan<- struct{}) {
+	defer close(runDone)
+	defer l.finishActivation()
 	ticker := time.NewTicker(l.cfg.Interval)
 	defer ticker.Stop()
 	l.tick(ctx)

--- a/server/internal/domain/curtailment/alert_metrics_test.go
+++ b/server/internal/domain/curtailment/alert_metrics_test.go
@@ -32,6 +32,21 @@ func (blockingSourcesLister) ListEnabledSources(ctx context.Context) ([]mqttinge
 	return nil, fmt.Errorf("list enabled sources: %w", ctx.Err())
 }
 
+type uninterruptibleSourcesLister struct {
+	started chan struct{}
+	release <-chan struct{}
+}
+
+func (l *uninterruptibleSourcesLister) ListEnabledSources(context.Context) ([]mqttingest.SourceConfig, error) {
+	select {
+	case <-l.started:
+	default:
+		close(l.started)
+	}
+	<-l.release
+	return nil, nil
+}
+
 type fakeRuntime struct {
 	statuses map[int64]mqttingest.RuntimeStatus
 }
@@ -378,12 +393,55 @@ func TestAlertMetricsLoopStartStop(t *testing.T) {
 
 	require.NoError(t, loop.Start(context.Background()))
 	require.NoError(t, loop.Start(context.Background()), "second Start must be a no-op")
-	loop.Stop()
-	loop.Stop() // second Stop must be a no-op
+	require.NoError(t, loop.Stop(context.Background()))
+	require.NoError(t, loop.Stop(context.Background())) // second Stop must be a no-op
 
 	// The first tick runs synchronously before the ticker wait, so Stop
 	// after Start guarantees at least one emission.
 	require.NotEmpty(t, emitter.connected)
+}
+
+func TestAlertMetricsLoopActivationContextCancellationAllowsRestart(t *testing.T) {
+	loop := newTestAlertMetricsLoop(t, AlertMetricsConfig{
+		Sources:           &fakeSourcesLister{},
+		Runtime:           &fakeRuntime{},
+		ActiveCurtailment: &fakeActiveLister{},
+		Emitter:           &recordingEmitter{},
+	})
+	runCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, loop.Start(runCtx))
+	cancel()
+	require.Eventually(t, func() bool {
+		loop.mu.Lock()
+		defer loop.mu.Unlock()
+		return loop.cancel == nil
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, loop.Start(context.Background()))
+	require.NoError(t, loop.Stop(context.Background()))
+}
+
+func TestAlertMetricsLoopStopPreventsOverlapAfterTimeout(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	loop := newTestAlertMetricsLoop(t, AlertMetricsConfig{
+		Sources:           &uninterruptibleSourcesLister{started: started, release: release},
+		Runtime:           &fakeRuntime{},
+		ActiveCurtailment: &fakeActiveLister{},
+		Emitter:           &recordingEmitter{},
+	})
+	require.NoError(t, loop.Start(context.Background()))
+	<-started
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer stopCancel()
+	require.ErrorIs(t, loop.Stop(stopCtx), context.DeadlineExceeded)
+	require.Error(t, loop.Start(context.Background()), "timed-out tick must retain the activation")
+
+	close(release)
+	require.NoError(t, loop.Stop(context.Background()))
+	require.NoError(t, loop.Start(context.Background()))
+	require.NoError(t, loop.Stop(context.Background()))
 }
 
 func TestNewAlertMetricsLoopValidatesDependencies(t *testing.T) {

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 // MQTTClient is one broker connection for one source.
@@ -80,15 +82,20 @@ type brokerRuntimeStatus struct {
 // Subscriber owns per-source workers.
 type Subscriber struct {
 	cfg            Config
-	runDone        <-chan struct{}
+	runCanceled    <-chan struct{}
 	workers        map[int64]*sourceWorkerHandle
 	statuses       map[int64]RuntimeStatus
 	brokerStatuses map[int64]map[string]brokerRuntimeStatus
-	cancel         context.CancelFunc
-	wg             sync.WaitGroup
+	runCancel      context.CancelFunc
+	stopping       bool
+	drainDone      <-chan struct{}
+	workerWG       sync.WaitGroup
+	lifecycleMu    sync.Mutex
 	mu             sync.Mutex
 	reconcileMu    sync.Mutex
 }
+
+var _ runtimejobs.Lifecycle = (*Subscriber)(nil)
 
 // NewSubscriber validates dependencies and applies runtime defaults.
 func NewSubscriber(cfg Config) (*Subscriber, error) {
@@ -137,22 +144,28 @@ func NewSubscriber(cfg Config) (*Subscriber, error) {
 
 // Start starts the runtime and performs the initial source reconciliation.
 func (s *Subscriber) Start(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
 	s.mu.Lock()
-	if s.cancel != nil {
+	if s.stopping {
+		s.mu.Unlock()
+		return errors.New("mqttingest: previous subscriber activation is still stopping")
+	}
+	if s.runCancel != nil {
 		s.mu.Unlock()
 		return errors.New("mqttingest: subscriber already started")
 	}
 	runCtx, cancel := context.WithCancel(ctx)
-	s.runDone = runCtx.Done()
-	s.cancel = cancel
+	s.runCanceled = runCtx.Done()
+	s.runCancel = cancel
 	s.workers = make(map[int64]*sourceWorkerHandle)
 	s.mu.Unlock()
 
 	if _, _, err := s.reconcile(runCtx, true); err != nil {
 		cancel()
 		s.mu.Lock()
-		s.runDone = nil
-		s.cancel = nil
+		s.runCanceled = nil
+		s.runCancel = nil
 		s.workers = make(map[int64]*sourceWorkerHandle)
 		s.mu.Unlock()
 		return err
@@ -166,41 +179,58 @@ func (s *Subscriber) Reconcile(ctx context.Context) error {
 	return err
 }
 
-// Stop cancels all workers and waits up to ShutdownDeadline for them to drain.
-func (s *Subscriber) Stop() {
-	s.reconcileMu.Lock()
+// Stop cancels all workers and waits for them within ctx. When the
+// budget expires, the canceled activation remains installed until a later
+// successful Stop observes that every worker has drained. This avoids
+// reusing the WaitGroup or starting replacement workers alongside stragglers.
+func (s *Subscriber) Stop(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	s.mu.Lock()
+	cancel := s.runCancel
+	if cancel == nil {
+		s.mu.Unlock()
+		return nil
+	}
+	if !s.stopping {
+		s.stopping = true
+		cancel()
+	}
+	s.mu.Unlock()
+
+	// Wait for an in-progress reconcile to finish adding any workers before
+	// waiting on the shared WaitGroup. The stopping flag prevents subsequent
+	// reconciles from adding more work even if this call exhausts its budget.
+	if err := s.lockReconcile(ctx); err != nil {
+		return fmt.Errorf("mqttingest: stop subscriber: %w", err)
+	}
 	defer s.reconcileMu.Unlock()
 
 	s.mu.Lock()
-	cancel := s.cancel
-	if cancel == nil {
-		s.mu.Unlock()
-		return
-	}
 	handles := make([]*sourceWorkerHandle, 0, len(s.workers))
 	for _, handle := range s.workers {
 		handles = append(handles, handle)
 	}
-	s.runDone = nil
-	s.cancel = nil
+	drainDone := s.drainDone
+	if drainDone == nil {
+		done := make(chan struct{})
+		drainDone = done
+		s.drainDone = done
+		go func() {
+			s.workerWG.Wait()
+			close(done)
+		}()
+	}
 	s.mu.Unlock()
-
 	for _, handle := range handles {
 		handle.cancel()
 	}
-	cancel()
-	s.cfg.Logger.Info("mqttingest subscriber draining workers",
-		slog.Duration("deadline", s.cfg.ShutdownDeadline))
-	done := make(chan struct{})
-	go func() {
-		s.wg.Wait()
-		close(done)
-	}()
+	s.cfg.Logger.Info("mqttingest subscriber draining workers")
 	select {
-	case <-done:
+	case <-drainDone:
 		s.cfg.Logger.Info("mqttingest subscriber stopped cleanly")
-	case <-time.After(s.cfg.ShutdownDeadline):
-		s.cfg.Logger.Warn("mqttingest subscriber shutdown deadline exceeded")
+	case <-ctx.Done():
+		return fmt.Errorf("mqttingest: stop subscriber: %w", ctx.Err())
 	}
 
 	s.mu.Lock()
@@ -209,16 +239,11 @@ func (s *Subscriber) Stop() {
 	}
 	s.workers = make(map[int64]*sourceWorkerHandle)
 	s.brokerStatuses = make(map[int64]map[string]brokerRuntimeStatus)
+	s.runCanceled = nil
+	s.runCancel = nil
+	s.stopping = false
+	s.drainDone = nil
 	s.mu.Unlock()
-}
-
-// Run starts enabled sources once and blocks until ctx is canceled.
-func (s *Subscriber) Run(ctx context.Context) error {
-	if err := s.Start(ctx); err != nil {
-		return err
-	}
-	<-ctx.Done()
-	s.Stop()
 	return nil
 }
 
@@ -236,16 +261,16 @@ func (s *Subscriber) QuiesceSource(ctx context.Context, sourceID int64) error {
 	defer s.reconcileMu.Unlock()
 
 	s.mu.Lock()
-	runDone := s.runDone
+	runCanceled := s.runCanceled
 	handle := s.workers[sourceID]
 	s.mu.Unlock()
-	if runDone == nil || handle == nil {
+	if runCanceled == nil || handle == nil {
 		return nil
 	}
 	handle.cancel()
 	if err := s.waitForHandleStopped(ctx, handle); err != nil {
 		s.recordSourceError(handle.worker.source.ID, err.Error())
-		s.reconcileWhenHandleStops(runDone, handle)
+		s.reconcileWhenHandleStops(runCanceled, handle)
 		return err
 	}
 	s.mu.Lock()
@@ -265,13 +290,14 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 	defer s.reconcileMu.Unlock()
 
 	s.mu.Lock()
-	runDone := s.runDone
+	runCanceled := s.runCanceled
+	isStopping := s.stopping
 	existing := make(map[int64]*sourceWorkerHandle, len(s.workers))
 	for id, handle := range s.workers {
 		existing[id] = handle
 	}
 	s.mu.Unlock()
-	if runDone == nil {
+	if runCanceled == nil || isStopping || channelClosed(runCanceled) {
 		return 0, 0, errors.New("mqttingest: subscriber is not started")
 	}
 
@@ -307,7 +333,7 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 	for _, handle := range stopping {
 		if err := s.waitForHandleStopped(ctx, handle); err != nil {
 			s.recordSourceError(handle.worker.source.ID, err.Error())
-			s.reconcileWhenHandleStops(runDone, handle)
+			s.reconcileWhenHandleStops(runCanceled, handle)
 			return 0, len(sources), err
 		}
 		s.mu.Lock()
@@ -333,8 +359,8 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 		s.brokerStatuses[src.ID] = make(map[string]brokerRuntimeStatus)
 		s.mu.Unlock()
 
-		workerCtx, workerCancel := contextWithDone(runDone)
-		w, done, err := s.startWorker(ctx, workerCtx, src, &s.wg)
+		workerCtx, workerCancel := contextWithDone(runCanceled)
+		w, done, err := s.startWorker(ctx, workerCtx, src, &s.workerWG)
 		if err != nil {
 			workerCancel()
 			if firstStartErr == nil {
@@ -354,7 +380,7 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 			fingerprint: fingerprint,
 		}
 		s.mu.Lock()
-		if s.runDone != runDone {
+		if s.runCanceled != runCanceled {
 			s.mu.Unlock()
 			workerCancel()
 			continue
@@ -411,30 +437,30 @@ func handleStopped(handle *sourceWorkerHandle) bool {
 	}
 }
 
-func (s *Subscriber) reconcileWhenHandleStops(runDone <-chan struct{}, handle *sourceWorkerHandle) {
+func (s *Subscriber) reconcileWhenHandleStops(runCanceled <-chan struct{}, handle *sourceWorkerHandle) {
 	if handle == nil || handle.done == nil {
 		return
 	}
 	handle.retryOnce.Do(func() {
-		go s.reconcileAfterHandleStops(runDone, handle)
+		go s.reconcileAfterHandleStops(runCanceled, handle)
 	})
 }
 
-func (s *Subscriber) reconcileAfterHandleStops(runDone <-chan struct{}, handle *sourceWorkerHandle) {
-	if runDone == nil {
+func (s *Subscriber) reconcileAfterHandleStops(runCanceled <-chan struct{}, handle *sourceWorkerHandle) {
+	if runCanceled == nil {
 		return
 	}
 	select {
-	case <-runDone:
+	case <-runCanceled:
 		return
 	case <-handle.done:
 	}
 	select {
-	case <-runDone:
+	case <-runCanceled:
 		return
 	default:
 	}
-	runCtx, runCancel := contextWithDone(runDone)
+	runCtx, runCancel := contextWithDone(runCanceled)
 	defer runCancel()
 	reconcileCtx, timeoutCancel := context.WithTimeout(runCtx, s.cfg.ReconcileTimeout)
 	defer timeoutCancel()
@@ -455,6 +481,18 @@ func contextWithDone(done <-chan struct{}) (context.Context, context.CancelFunc)
 		}
 	}()
 	return ctx, cancel
+}
+
+func channelClosed(done <-chan struct{}) bool {
+	if done == nil {
+		return false
+	}
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Subscriber) waitForHandleStopped(ctx context.Context, handle *sourceWorkerHandle) error {

--- a/server/internal/domain/curtailment/mqttingest/subscriber_test.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber_test.go
@@ -55,6 +55,25 @@ type countingClient struct {
 	connected bool
 }
 
+type blockingDisconnectClient struct {
+	reg     *clientRegistry
+	release <-chan struct{}
+}
+
+func (c *blockingDisconnectClient) Connect(context.Context, string, int32, string, string, string, string) error {
+	c.reg.onConnect()
+	return nil
+}
+
+func (c *blockingDisconnectClient) Subscribe(context.Context, string, func([]byte, time.Time)) error {
+	return nil
+}
+
+func (c *blockingDisconnectClient) Disconnect(time.Duration) {
+	<-c.release
+	c.reg.onDisconnect()
+}
+
 func (c *countingClient) Connect(context.Context, string, int32, string, string, string, string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -199,7 +218,7 @@ func TestSubscriber_ReconcileStartsAndStopsWorkers(t *testing.T) {
 	reg := &clientRegistry{}
 	s := newReconcileTestSubscriber(t, store, reg)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRunningBrokers(t, s, src.ID, 2)
 
@@ -218,6 +237,35 @@ func TestSubscriber_ReconcileStartsAndStopsWorkers(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "broker sessions should drain after the source is removed")
 }
 
+func TestSubscriber_StopKeepsTimedOutActivationOwnedUntilWorkersDrain(t *testing.T) {
+	src := reconcileTestSource(1, "maestro")
+	store := newFakeSourceStore(src)
+	reg := &clientRegistry{}
+	release := make(chan struct{})
+	s, err := NewSubscriber(Config{
+		Store:             store,
+		NewClient:         func() MQTTClient { return &blockingDisconnectClient{reg: reg, release: release} },
+		Decryptor:         passthroughDecryptor{},
+		Logger:            slog.New(slog.DiscardHandler),
+		ShutdownDeadline:  time.Second,
+		WatchdogTickEvery: time.Millisecond,
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.Start(context.Background()))
+	requireRunningBrokers(t, s, src.ID, 2)
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer stopCancel()
+	require.ErrorIs(t, s.Stop(stopCtx), context.DeadlineExceeded)
+	require.Error(t, s.Start(context.Background()), "timed-out workers must keep ownership of the activation")
+	require.Error(t, s.Reconcile(context.Background()), "a stopping activation must reject new workers")
+
+	close(release)
+	require.NoError(t, s.Stop(context.Background()))
+	require.NoError(t, s.Start(context.Background()))
+	require.NoError(t, s.Stop(context.Background()))
+}
+
 func TestSubscriber_ReconcileRestartsChangedSourceWithoutOverlap(t *testing.T) {
 	t.Parallel()
 
@@ -226,7 +274,7 @@ func TestSubscriber_ReconcileRestartsChangedSourceWithoutOverlap(t *testing.T) {
 	reg := &clientRegistry{}
 	s := newReconcileTestSubscriber(t, store, reg)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRunningBrokers(t, s, src.ID, 2)
 
@@ -253,7 +301,7 @@ func TestSubscriber_ReconcileSkipsUnchangedSource(t *testing.T) {
 	reg := &clientRegistry{}
 	s := newReconcileTestSubscriber(t, store, reg)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRunningBrokers(t, s, src.ID, 2)
 
@@ -274,7 +322,7 @@ func TestSubscriber_QuiesceSourceStopsOnlyTargetSource(t *testing.T) {
 	reg := &clientRegistry{}
 	s := newReconcileTestSubscriber(t, store, reg)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRunningBrokers(t, s, first.ID, 2)
 	requireRunningBrokers(t, s, second.ID, 2)
@@ -305,7 +353,7 @@ func TestSubscriber_RuntimeStatusTracksBrokerDisconnectAndReconnect(t *testing.T
 	})
 	require.NoError(t, err)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRuntimeStatus(t, s, src.ID, RuntimeStateRunning, 2, 2)
 

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/infrastructure/driver"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 	sdk "github.com/block/proto-fleet/server/sdk/v1"
 )
 
@@ -33,7 +34,6 @@ const (
 	reconcilerActorName = "curtailment-reconciler"
 
 	defaultTickInterval            = 30 * time.Second
-	defaultShutdownDeadline        = 10 * time.Second
 	defaultMaxRetries        int32 = 10
 	defaultCurtailMaxRetries int32 = 50
 
@@ -55,7 +55,6 @@ type CommandDispatcher interface {
 // Config carries runtime tunables. Zero-valued fields use defaults.
 type Config struct {
 	TickInterval         time.Duration `help:"Interval between curtailment reconciler ticks. Zero uses the default; values below 1s are rejected." default:"0s" env:"TICK_INTERVAL"`
-	ShutdownDeadline     time.Duration
 	MaxRetries           int32
 	CurtailMaxRetries    int32
 	DriftThresholdFactor float64
@@ -70,9 +69,6 @@ type Config struct {
 func (c Config) withDefaults() Config {
 	if c.TickInterval <= 0 {
 		c.TickInterval = defaultTickInterval
-	}
-	if c.ShutdownDeadline <= 0 {
-		c.ShutdownDeadline = defaultShutdownDeadline
 	}
 	if c.MaxRetries <= 0 {
 		c.MaxRetries = defaultMaxRetries
@@ -107,11 +103,14 @@ type Reconciler struct {
 
 	stopCancel context.CancelFunc
 	workCancel context.CancelFunc
-	wg         sync.WaitGroup
+	runDone    <-chan struct{}
 
-	mu      sync.Mutex
-	running bool
+	lifecycleMu sync.Mutex
+	mu          sync.Mutex
+	stopping    bool
 }
+
+var _ runtimejobs.Lifecycle = (*Reconciler)(nil)
 
 // Option configures a Reconciler at construction time.
 type Option func(*Reconciler)
@@ -162,7 +161,7 @@ func New(cfg Config, store interfaces.CurtailmentStore, cmd CommandDispatcher, o
 
 // Start spins up the tick loop. Repeat Starts without an intervening Stop
 // are no-ops so misbehaving wiring cannot fork two reconcilers.
-func (r *Reconciler) Start(_ context.Context) error {
+func (r *Reconciler) Start(ctx context.Context) error {
 	if r.store == nil {
 		return fmt.Errorf("curtailment reconciler: store is required")
 	}
@@ -176,58 +175,75 @@ func (r *Reconciler) Start(_ context.Context) error {
 		return fmt.Errorf("curtailment reconciler: curtail_dispatch_timeout_sec must be at least 1, got %d", r.cfg.CurtailDispatchTimeoutSec)
 	}
 
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
 	r.mu.Lock()
-	if r.running {
+	if r.stopping {
+		r.mu.Unlock()
+		return errors.New("curtailment reconciler: previous activation is still stopping")
+	}
+	if r.runDone != nil {
 		r.mu.Unlock()
 		return nil
 	}
-	r.running = true
-	stopCtx, stopCancel := context.WithCancel(context.Background())
-	workCtx, workCancel := context.WithCancel(context.Background())
+	stopCtx, stopCancel := context.WithCancel(ctx)
+	// Stopping the activation prevents new ticks immediately but gives the
+	// current tick a chance to finish. Stop cancels this detached work
+	// context if its caller's shutdown budget expires.
+	workCtx, workCancel := context.WithCancel(context.WithoutCancel(ctx))
+	runDone := make(chan struct{})
 	r.stopCancel = stopCancel
 	r.workCancel = workCancel
+	r.runDone = runDone
 	r.mu.Unlock()
 
-	r.wg.Add(1)
-	go r.tickLoop(stopCtx, workCtx)
+	go r.tickLoop(stopCtx, workCtx, workCancel, runDone)
 	slog.Info("curtailment reconciler started", "tick_interval", r.cfg.TickInterval)
 	return nil
 }
 
-// Stop signals the tick loop and waits up to ShutdownDeadline for the
-// in-flight tick to drain. Concurrent second Stop is a no-op. Adding a
-// Start-after-Stop restart path needs a `stopping` guard to prevent
-// stacking goroutines on the same WaitGroup.
-func (r *Reconciler) Stop() error {
+// Stop prevents new ticks, waits for the current tick to drain within
+// ctx, and force-cancels its work when the budget expires. A timed-out
+// activation retains ownership until its goroutine actually exits, so Start
+// can never overlap it.
+func (r *Reconciler) Stop(ctx context.Context) error {
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+
 	r.mu.Lock()
-	if !r.running {
+	if r.runDone == nil {
 		r.mu.Unlock()
 		return nil
 	}
-	r.running = false
+	r.stopping = true
 	stopCancel := r.stopCancel
 	workCancel := r.workCancel
-	r.stopCancel = nil
-	r.workCancel = nil
+	runDone := r.runDone
 	r.mu.Unlock()
 
-	if workCancel != nil {
-		watchdog := time.AfterFunc(r.cfg.ShutdownDeadline, workCancel)
-		defer watchdog.Stop()
-	}
 	if stopCancel != nil {
 		stopCancel()
 	}
-	r.wg.Wait()
-	if workCancel != nil {
-		workCancel()
+	select {
+	case <-runDone:
+		slog.Info("curtailment reconciler stopped")
+		return nil
+	case <-ctx.Done():
+		if workCancel != nil {
+			workCancel()
+		}
+		return fmt.Errorf("curtailment reconciler: stop: %w", ctx.Err())
 	}
-	slog.Info("curtailment reconciler stopped")
-	return nil
 }
 
-func (r *Reconciler) tickLoop(stopCtx, workCtx context.Context) {
-	defer r.wg.Done()
+func (r *Reconciler) tickLoop(
+	stopCtx context.Context,
+	workCtx context.Context,
+	workCancel context.CancelFunc,
+	runDone chan<- struct{},
+) {
+	defer close(runDone)
+	defer r.finishActivation(workCancel)
 	ticker := time.NewTicker(r.cfg.TickInterval)
 	defer ticker.Stop()
 	for {
@@ -238,6 +254,16 @@ func (r *Reconciler) tickLoop(stopCtx, workCtx context.Context) {
 			r.safeTick(workCtx)
 		}
 	}
+}
+
+func (r *Reconciler) finishActivation(workCancel context.CancelFunc) {
+	workCancel()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stopping = false
+	r.stopCancel = nil
+	r.workCancel = nil
+	r.runDone = nil
 }
 
 // safeTick recovers panics in tick-level infra so the goroutine survives;

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -799,7 +799,6 @@ func identifiersFromSelector(selector *pb.DeviceSelector) []string {
 func newReconcilerForTest(store *fakeStore, disp *fakeDispatcher) *Reconciler {
 	r := New(Config{
 		TickInterval:         time.Hour, // tests drive runTick directly
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		CurtailMaxRetries:    3,
 		DriftThresholdFactor: 0.5,
@@ -811,7 +810,6 @@ func newReconcilerForTest(store *fakeStore, disp *fakeDispatcher) *Reconciler {
 func newReconcilerWithFansForTest(store *fakeStore, disp *fakeDispatcher, fans *fakeFanController) *Reconciler {
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		CurtailMaxRetries:    3,
 		DriftThresholdFactor: 0.5,
@@ -828,7 +826,6 @@ func newReconcilerWithFanAlertForTest(
 ) *Reconciler {
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		CurtailMaxRetries:    3,
 		DriftThresholdFactor: 0.5,
@@ -3105,7 +3102,6 @@ func TestReconciler_ListEventsErrorAdvancesHeartbeatAndIncrementsFailure(t *test
 
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		DriftThresholdFactor: 0.5,
 	}, store, disp, WithMetrics(metrics))
@@ -3845,7 +3841,6 @@ func TestReconciler_ObserveTickDurationFiresOnHappyPath(t *testing.T) {
 
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		DriftThresholdFactor: 0.5,
 	}, store, disp, WithMetrics(metrics))
@@ -3870,7 +3865,6 @@ func TestReconciler_TickFailureFiresOnTickInfraPanic(t *testing.T) {
 	store.listEventsPanicErr = "synthetic db panic"
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		DriftThresholdFactor: 0.5,
 	}, store, disp, WithMetrics(metrics))
@@ -3904,7 +3898,6 @@ func TestReconciler_TickFailureFiresOnPerEventPanic(t *testing.T) {
 	first := true
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		DriftThresholdFactor: 0.5,
 	}, store, disp, WithMetrics(metrics))
@@ -3950,19 +3943,77 @@ func TestReconciler_PanicInListEventsRecovers(t *testing.T) {
 func TestReconciler_StartIdempotency(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
-	r := New(Config{TickInterval: time.Hour, ShutdownDeadline: time.Second}, store, disp)
+	r := New(Config{TickInterval: time.Hour}, store, disp)
 
 	require.NoError(t, r.Start(context.Background()))
 	require.NoError(t, r.Start(context.Background()), "second Start is a no-op")
-	require.NoError(t, r.Stop())
+	require.NoError(t, r.Stop(context.Background()))
 	// Second Stop is a no-op too; verify no panic / goroutine deadlock.
-	require.NoError(t, r.Stop())
+	require.NoError(t, r.Stop(context.Background()))
+}
+
+func TestReconciler_ActivationContextCancellationAllowsRestart(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+	r := New(Config{TickInterval: time.Hour}, store, disp)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, r.Start(runCtx))
+	cancel()
+	require.Eventually(t, func() bool {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		return r.runDone == nil
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, r.Start(context.Background()))
+	require.NoError(t, r.Stop(context.Background()))
+}
+
+func TestReconciler_StopCancellationPreventsOverlappingRestart(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+	r := New(Config{TickInterval: time.Hour}, store, disp)
+
+	workCtx, workCancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	r.stopCancel = func() {}
+	r.workCancel = workCancel
+	r.runDone = runDone
+
+	workCanceled := make(chan struct{})
+	releaseWork := make(chan struct{})
+	go func() {
+		<-workCtx.Done()
+		close(workCanceled)
+		<-releaseWork
+		r.finishActivation(workCancel)
+		close(runDone)
+	}()
+
+	stopCtx, cancelStop := context.WithCancel(context.Background())
+	cancelStop()
+	require.ErrorIs(t, r.Stop(stopCtx), context.Canceled)
+	require.Eventually(t, func() bool {
+		select {
+		case <-workCanceled:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.ErrorContains(t, r.Start(context.Background()), "previous activation is still stopping")
+
+	close(releaseWork)
+	require.NoError(t, r.Stop(context.Background()))
+	require.NoError(t, r.Start(context.Background()))
+	require.NoError(t, r.Stop(context.Background()))
 }
 
 func TestReconciler_StartRejectsSubSecondTickInterval(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
-	r := New(Config{TickInterval: 500 * time.Millisecond, ShutdownDeadline: time.Second}, store, disp)
+	r := New(Config{TickInterval: 500 * time.Millisecond}, store, disp)
 
 	err := r.Start(context.Background())
 	require.Error(t, err)
@@ -3974,7 +4025,6 @@ func TestReconciler_StartRejectsInvalidCurtailDispatchTimeout(t *testing.T) {
 	disp := &fakeDispatcher{}
 	r := New(Config{
 		TickInterval:              time.Hour,
-		ShutdownDeadline:          time.Second,
 		CurtailDispatchTimeoutSec: -1,
 	}, store, disp)
 
@@ -3986,7 +4036,7 @@ func TestReconciler_StartRejectsInvalidCurtailDispatchTimeout(t *testing.T) {
 func TestReconciler_ConfigDefaultsDispatchTimeouts(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
-	r := New(Config{TickInterval: time.Hour, ShutdownDeadline: time.Second}, store, disp)
+	r := New(Config{TickInterval: time.Hour}, store, disp)
 
 	assert.Equal(t, int32(10), r.cfg.MaxRetries)
 	assert.Equal(t, int32(50), r.cfg.CurtailMaxRetries)

--- a/server/internal/domain/diagnostics/closer_test.go
+++ b/server/internal/domain/diagnostics/closer_test.go
@@ -2,10 +2,12 @@ package diagnostics
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	storeMocks "github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
@@ -15,68 +17,18 @@ import (
 // runCloser Tests
 // ============================================================================
 
-func TestCloser_WithValidConfig_ShouldCallCloseStaleErrors(t *testing.T) {
+func TestNewService_DoesNotStartCloser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	mockStore.EXPECT().
-		CloseStaleErrors(gomock.Any(), 2*time.Minute).
-		Return(int64(5), nil).
-		MinTimes(1)
+	_ = NewService(Config{
+		CloserPollInterval: time.Millisecond,
+	}, mockStore, mockTransactor)
 
-	ctx, cancel := context.WithCancel(t.Context())
-	config := Config{
-		CloserPollInterval:       10 * time.Millisecond,
-		CloserStalenessThreshold: 2 * time.Minute,
-	}
-
-	_ = NewService(ctx, config, mockStore, mockTransactor)
-
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-}
-
-func TestCloser_WithZeroConfig_ShouldUseDefaults(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockStore := storeMocks.NewMockErrorStore(ctrl)
-	mockTransactor := storeMocks.NewMockTransactor(ctrl)
-
-	mockStore.EXPECT().
-		CloseStaleErrors(gomock.Any(), defaultCloserStalenessThreshold).
-		Return(int64(0), nil).
-		AnyTimes()
-
-	ctx, cancel := context.WithCancel(t.Context())
-	config := Config{}
-
-	_ = NewService(ctx, config, mockStore, mockTransactor)
-
+	// Construction must remain side-effect free so fleetd can decide which
+	// process-owned jobs to start for the current runtime mode.
 	time.Sleep(10 * time.Millisecond)
-	cancel()
-}
-
-func TestCloser_WhenContextCancelled_ShouldStop(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockStore := storeMocks.NewMockErrorStore(ctrl)
-	mockTransactor := storeMocks.NewMockTransactor(ctrl)
-
-	mockStore.EXPECT().
-		CloseStaleErrors(gomock.Any(), gomock.Any()).
-		Return(int64(0), nil).
-		AnyTimes()
-
-	ctx, cancel := context.WithCancel(t.Context())
-	config := Config{
-		CloserPollInterval:       10 * time.Millisecond,
-		CloserStalenessThreshold: 2 * time.Minute,
-	}
-
-	_ = NewService(ctx, config, mockStore, mockTransactor)
-
-	cancel()
-
-	time.Sleep(50 * time.Millisecond)
 }
 
 func TestCloser_WhenCloseStaleErrorsFails_ShouldContinuePolling(t *testing.T) {
@@ -84,14 +36,17 @@ func TestCloser_WhenCloseStaleErrorsFails_ShouldContinuePolling(t *testing.T) {
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
+	retried := make(chan struct{})
 	gomock.InOrder(
 		mockStore.EXPECT().
 			CloseStaleErrors(gomock.Any(), 2*time.Minute).
 			Return(int64(0), assert.AnError),
 		mockStore.EXPECT().
 			CloseStaleErrors(gomock.Any(), 2*time.Minute).
-			Return(int64(3), nil).
-			AnyTimes(),
+			DoAndReturn(func(context.Context, time.Duration) (int64, error) {
+				close(retried)
+				return 3, nil
+			}),
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -100,32 +55,48 @@ func TestCloser_WhenCloseStaleErrorsFails_ShouldContinuePolling(t *testing.T) {
 		CloserStalenessThreshold: 2 * time.Minute,
 	}
 
-	_ = NewService(ctx, config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
+	require.NoError(t, svc.Start(ctx))
 
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-retried:
+	case <-time.After(time.Second):
+		t.Fatal("closer did not poll again after an error")
+	}
 	cancel()
 }
 
-func TestCloser_WithNegativeConfig_ShouldUseDefaults(t *testing.T) {
+func TestCloser_CanRestartAfterStop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
+	var calls atomic.Int32
 	mockStore.EXPECT().
-		CloseStaleErrors(gomock.Any(), defaultCloserStalenessThreshold).
-		Return(int64(0), nil).
+		CloseStaleErrors(gomock.Any(), 2*time.Minute).
+		DoAndReturn(func(context.Context, time.Duration) (int64, error) {
+			calls.Add(1)
+			return 0, nil
+		}).
 		AnyTimes()
 
-	ctx, cancel := context.WithCancel(t.Context())
-	config := Config{
-		CloserPollInterval:       -10 * time.Second,
-		CloserStalenessThreshold: -2 * time.Minute,
-	}
+	svc := NewService(Config{
+		CloserPollInterval:       time.Millisecond,
+		CloserStalenessThreshold: 2 * time.Minute,
+	}, mockStore, mockTransactor)
 
-	_ = NewService(ctx, config, mockStore, mockTransactor)
+	require.NoError(t, svc.Start(t.Context()))
+	require.Eventually(t, func() bool {
+		return calls.Load() > 0
+	}, 100*time.Millisecond, time.Millisecond)
+	require.NoError(t, svc.Stop(t.Context()))
 
-	time.Sleep(10 * time.Millisecond)
-	cancel()
+	firstRunCalls := calls.Load()
+	require.NoError(t, svc.Start(t.Context()))
+	require.Eventually(t, func() bool {
+		return calls.Load() > firstRunCalls
+	}, 100*time.Millisecond, time.Millisecond)
+	require.NoError(t, svc.Stop(t.Context()))
 }
 
 // ============================================================================

--- a/server/internal/domain/diagnostics/service.go
+++ b/server/internal/domain/diagnostics/service.go
@@ -2,7 +2,9 @@ package diagnostics
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	fm "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
@@ -11,6 +13,7 @@ import (
 	minerInterfaces "github.com/block/proto-fleet/server/internal/domain/miner/interfaces"
 	minerModels "github.com/block/proto-fleet/server/internal/domain/miner/models"
 	storeInterfaces "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 // PollResult contains the outcome of a PollErrors operation.
@@ -38,20 +41,67 @@ type Service struct {
 	errorStore  storeInterfaces.ErrorStore
 	transactor  storeInterfaces.Transactor
 	deviceScope DeviceScopeResolver
+
+	closerMu       sync.Mutex
+	closerCancel   context.CancelFunc
+	closerDone     chan struct{}
+	closerStopping bool
 }
 
-// NewService creates a new diagnostics service and starts the error closer goroutine.
-// The closer runs until the provided context is cancelled.
-func NewService(ctx context.Context, config Config, errorStore storeInterfaces.ErrorStore, transactor storeInterfaces.Transactor) *Service {
-	s := &Service{
+var _ runtimejobs.Lifecycle = (*Service)(nil)
+
+// NewService creates a diagnostics service without starting background work.
+func NewService(config Config, errorStore storeInterfaces.ErrorStore, transactor storeInterfaces.Transactor) *Service {
+	return &Service{
 		config:     config,
 		errorStore: errorStore,
 		transactor: transactor,
 	}
+}
 
-	go s.runCloser(ctx)
+// Start starts the stale-error closer. Repeated starts are idempotent.
+func (s *Service) Start(ctx context.Context) error {
+	s.closerMu.Lock()
+	defer s.closerMu.Unlock()
 
-	return s
+	if s.closerStopping {
+		return fmt.Errorf("diagnostics error closer is still stopping")
+	}
+	if s.closerCancel != nil {
+		return nil
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	s.closerCancel = cancel
+	s.closerDone = done
+	go func() {
+		defer close(done)
+		s.runCloser(runCtx)
+	}()
+	return nil
+}
+
+// Stop cancels the stale-error closer and waits for it to drain.
+func (s *Service) Stop(ctx context.Context) error {
+	s.closerMu.Lock()
+	defer s.closerMu.Unlock()
+
+	if s.closerCancel == nil {
+		return nil
+	}
+
+	s.closerStopping = true
+	s.closerCancel()
+	select {
+	case <-s.closerDone:
+		s.closerCancel = nil
+		s.closerDone = nil
+		s.closerStopping = false
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("stop diagnostics error closer: %w", ctx.Err())
+	}
 }
 
 // WithDeviceScopeResolver wires the resolver used to translate a site scope

--- a/server/internal/domain/diagnostics/service_test.go
+++ b/server/internal/domain/diagnostics/service_test.go
@@ -38,7 +38,7 @@ func newTestService(ctrl *gomock.Controller, mockErrorStore *storeMocks.MockErro
 			return fn(ctx)
 		},
 	).AnyTimes()
-	return NewService(context.Background(), Config{}, mockErrorStore, mockTransactor)
+	return NewService(Config{}, mockErrorStore, mockTransactor)
 }
 
 func TestPollErrors_WithNoMiners_ShouldReturnEmptyResult(t *testing.T) {

--- a/server/internal/domain/diagnostics/watcher_test.go
+++ b/server/internal/domain/diagnostics/watcher_test.go
@@ -27,7 +27,7 @@ func TestNewWatcher_WithValidConfig_ShouldUseConfigValues(t *testing.T) {
 		WatchPollInterval:  30 * time.Second,
 		WatchChannelBuffer: 20,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	w := newWatcher(svc, 1, nil, config)
 
@@ -46,7 +46,7 @@ func TestNewWatcher_WithZeroConfig_ShouldUseFallbackDefaults(t *testing.T) {
 		WatchPollInterval:  0, // Zero - should use default
 		WatchChannelBuffer: 0, // Zero - should use default
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	w := newWatcher(svc, 1, nil, config)
 
@@ -63,7 +63,7 @@ func TestNewWatcher_WithNegativeConfig_ShouldUseFallbackDefaults(t *testing.T) {
 		WatchPollInterval:  -5 * time.Second,
 		WatchChannelBuffer: -10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	w := newWatcher(svc, 1, nil, config)
 
@@ -76,7 +76,7 @@ func TestNewWatcher_WithNilOpts_ShouldCreateEmptyOpts(t *testing.T) {
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 
 	w := newWatcher(svc, 1, nil, Config{})
 
@@ -88,7 +88,7 @@ func TestNewWatcher_WithOpts_ShouldPreserveOpts(t *testing.T) {
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 	opts := &WatchOptions{
 		Filter: &models.QueryFilter{
 			DeviceIdentifiers: []string{"device-1"},
@@ -110,7 +110,7 @@ func TestBuildFilterWithTimeFrom_WithNoOptsFilter_ShouldSetTimeFromAndIncludeClo
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, Config{})
 	w.lastPollTime = time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 
@@ -126,7 +126,7 @@ func TestBuildFilterWithTimeFrom_WithOptsFilter_ShouldMergeFilters(t *testing.T)
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 	opts := &WatchOptions{
 		Filter: &models.QueryFilter{
 			DeviceIdentifiers: []string{"device-1", "device-2"},
@@ -159,7 +159,7 @@ func TestBuildFilterWithTimeFrom_WithOptsFilterHavingTimeTo_ShouldIgnoreUserTime
 
 	userTimeFrom := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	userTimeTo := time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC)
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 	opts := &WatchOptions{
 		Filter: &models.QueryFilter{
 			TimeFrom:      &userTimeFrom, // Should be ignored
@@ -191,7 +191,7 @@ func TestSendEvent_WithSpaceInChannel_ShouldSendUpdate(t *testing.T) {
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
 	config := Config{WatchChannelBuffer: 5}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	ctx := context.Background()
@@ -216,7 +216,7 @@ func TestSendEvent_WithFullChannel_ShouldDropUpdate(t *testing.T) {
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
 	config := Config{WatchChannelBuffer: 1}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	ctx := context.Background()
@@ -248,7 +248,7 @@ func TestSendEvent_WithCancelledContextAndFullChannel_ShouldNotBlock(t *testing.
 
 	// Use buffer size 1 and fill it
 	config := Config{WatchChannelBuffer: 1}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	// Fill the channel
@@ -293,7 +293,7 @@ func TestPollAndSend_WithNewError_ShouldSendKindOpened(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -326,7 +326,7 @@ func TestPollAndSend_WithUpdatedError_ShouldSendKindUpdated(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -357,7 +357,7 @@ func TestPollAndSend_WithClosedError_ShouldSendKindClosed(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -394,7 +394,7 @@ func TestPollAndSend_WithMixedErrorStates_ShouldSendAllThreeKinds(t *testing.T) 
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -436,7 +436,7 @@ func TestPollAndSend_WithErrorAtExactPollTime_ShouldClassifyAsOpened(t *testing.
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -460,7 +460,7 @@ func TestPollAndSend_WithNoErrors_ShouldNotSendAnyUpdates(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return([]models.ErrorMessage{}, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = time.Now()
 
@@ -483,7 +483,7 @@ func TestPollAndSend_WhenQueryFails_ShouldNotSendUpdates(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = time.Now()
 
@@ -506,7 +506,7 @@ func TestPollAndSend_ShouldUpdateLastPollTime(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return([]models.ErrorMessage{}, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	originalTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -535,7 +535,7 @@ func TestRun_WithImmediateCancellation_ShouldCloseChannel(t *testing.T) {
 		WatchPollInterval:  100 * time.Millisecond,
 		WatchChannelBuffer: 5,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -578,7 +578,7 @@ func TestRun_WithCancellationAfterInitialPoll_ShouldCloseChannel(t *testing.T) {
 		WatchPollInterval:  500 * time.Millisecond, // Long interval so we can control cancellation
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -629,7 +629,7 @@ func TestWatch_ShouldReturnChannel(t *testing.T) {
 		WatchPollInterval:  100 * time.Millisecond,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -659,7 +659,7 @@ func TestWatch_WithOpts_ShouldUseFilter(t *testing.T) {
 		WatchPollInterval:  100 * time.Millisecond,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -687,7 +687,7 @@ func TestWatcherPoll_AppliesSiteScopeEachPoll(t *testing.T) {
 		WatchPollInterval:  100 * time.Millisecond,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor).WithDeviceScopeResolver(mockDeviceStore)
+	svc := NewService(config, mockStore, mockTransactor).WithDeviceScopeResolver(mockDeviceStore)
 	opts := &WatchOptions{
 		Filter: &models.QueryFilter{
 			SiteIDs:           []int64{7},
@@ -746,7 +746,7 @@ func TestWatch_ChannelClosesOnContextCancel(t *testing.T) {
 		WatchPollInterval:  50 * time.Millisecond,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -788,7 +788,7 @@ func TestWatch_SendsCorrectKindBasedOnErrorState(t *testing.T) {
 		WatchPollInterval:  1 * time.Second,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -825,7 +825,7 @@ func TestWatch_UsesServiceConfig(t *testing.T) {
 		WatchPollInterval:  50 * time.Millisecond, // Short poll interval
 		WatchChannelBuffer: 3,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/server/internal/domain/ipscanner/integration_test.go
+++ b/server/internal/domain/ipscanner/integration_test.go
@@ -115,7 +115,7 @@ func TestIPScannerService_RediscoverOfflineDeviceAtNewIP(t *testing.T) {
 	err := service.Start(testCtx)
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, service.Stop())
+		require.NoError(t, service.Stop(context.Background()))
 	}()
 
 	// Wait for the service to complete at least one scan cycle

--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -2,6 +2,8 @@ package ipscanner
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"sync"
@@ -10,7 +12,10 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/minerdiscovery"
 	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
+
+var errServiceStopping = errors.New("ip scanner service is still stopping")
 
 // Service orchestrates automatic IP address discovery for offline devices
 type Service struct {
@@ -22,12 +27,21 @@ type Service struct {
 	scanner               *NetworkScanner
 	logger                *slog.Logger
 
-	// Worker pool
-	tasks      chan SubnetScanTask
-	results    chan SubnetScanResult
-	cancelFunc context.CancelFunc
-	wg         sync.WaitGroup
-	mux        sync.Mutex // Prevents multiple instances of scanLoop from running
+	lifecycleMu sync.Mutex
+	run         *serviceRun
+}
+
+var _ runtimejobs.Lifecycle = (*Service)(nil)
+
+// serviceRun contains all state owned by a single activation. Keeping queues
+// here prevents stopped runs from leaking buffered work into a later Start.
+type serviceRun struct {
+	tasks    chan SubnetScanTask
+	results  chan SubnetScanResult
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	done     chan struct{}
+	stopping bool
 }
 
 // NewIPScannerService creates a new IP scanner service
@@ -47,8 +61,6 @@ func NewIPScannerService(
 		deviceIDCheckService:  deviceIDCheckService,
 		scanner:               NewNetworkScanner(discoverer, deviceIDCheckService, config.MaxConcurrentIPScansPerSubnet, logger),
 		logger:                logger.With("component", "ipscanner"),
-		tasks:                 make(chan SubnetScanTask, config.MaxConcurrentSubnetScans),
-		results:               make(chan SubnetScanResult, config.MaxConcurrentSubnetScans),
 	}
 }
 
@@ -59,21 +71,33 @@ func (s *Service) Start(ctx context.Context) error {
 		return nil
 	}
 
-	// Prevent multiple Start() calls from creating duplicate goroutines
-	if !s.mux.TryLock() {
-		s.logger.Warn("IP scanner service already started")
-		return nil
-	}
-	defer s.mux.Unlock()
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
 
-	// Check if already started by examining cancelFunc
-	if s.cancelFunc != nil {
-		s.logger.Warn("IP scanner service already running")
-		return nil
+	if s.run != nil {
+		select {
+		case <-s.run.done:
+			s.run = nil
+		default:
+			if s.run.stopping {
+				return errServiceStopping
+			}
+			s.logger.Warn("IP scanner service already running")
+			return nil
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("start ip scanner service: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	s.cancelFunc = cancel
+	run := &serviceRun{
+		tasks:   make(chan SubnetScanTask, s.config.MaxConcurrentSubnetScans),
+		results: make(chan SubnetScanResult, s.config.MaxConcurrentSubnetScans),
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+	s.run = run
 
 	s.logger.Info("Starting IP scanner service",
 		"scan_interval", s.config.ScanInterval,
@@ -83,55 +107,70 @@ func (s *Service) Start(ctx context.Context) error {
 
 	// Start worker pool
 	for i := range s.config.MaxConcurrentSubnetScans {
-		s.wg.Add(1)
-		go s.scanWorker(ctx, i)
+		run.wg.Go(func() { s.scanWorker(ctx, run, i) })
 	}
 
 	// Start result processor
-	s.wg.Add(1)
-	go s.resultProcessor(ctx)
+	run.wg.Go(func() { s.resultProcessor(ctx, run) })
 
 	// Start main scan loop
-	s.wg.Add(1)
-	go s.scanLoop(ctx)
+	run.wg.Go(func() { s.scanLoop(ctx, run) })
+
+	go func() {
+		run.wg.Wait()
+		close(run.done)
+	}()
 
 	return nil
 }
 
-// Stop gracefully stops the IP scanner service
-func (s *Service) Stop() error {
-	if s.cancelFunc != nil {
-		s.logger.Info("Stopping IP scanner service")
-		s.cancelFunc()
-		s.wg.Wait()
-		s.cancelFunc = nil // Reset to allow restart
-		s.logger.Info("IP scanner service stopped")
+// Stop gracefully stops the active scanner run, bounded by ctx.
+func (s *Service) Stop(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	run := s.run
+	if run == nil {
+		s.lifecycleMu.Unlock()
+		return nil
 	}
-	return nil
+	s.logger.Info("Stopping IP scanner service")
+	run.stopping = true
+	run.cancel()
+	s.lifecycleMu.Unlock()
+
+	select {
+	case <-run.done:
+		s.lifecycleMu.Lock()
+		if s.run == run {
+			s.run = nil
+		}
+		s.lifecycleMu.Unlock()
+		s.logger.Info("IP scanner service stopped")
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("stop ip scanner service: %w", ctx.Err())
+	}
 }
 
 // scanLoop periodically scans for offline devices
-func (s *Service) scanLoop(ctx context.Context) {
-	defer s.wg.Done()
-
+func (s *Service) scanLoop(ctx context.Context, run *serviceRun) {
 	ticker := time.NewTicker(s.config.ScanInterval)
 	defer ticker.Stop()
 
 	// Run immediately on start
-	s.scanOfflineDevices(ctx)
+	s.scanOfflineDevices(ctx, run.tasks)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.scanOfflineDevices(ctx)
+			s.scanOfflineDevices(ctx, run.tasks)
 		}
 	}
 }
 
 // scanOfflineDevices fetches offline devices and dispatches scan tasks grouped by subnet
-func (s *Service) scanOfflineDevices(ctx context.Context) {
+func (s *Service) scanOfflineDevices(ctx context.Context, tasks chan<- SubnetScanTask) {
 	s.logger.Debug("Scanning for offline devices")
 
 	// Fetch offline devices from the device store
@@ -242,7 +281,7 @@ func (s *Service) scanOfflineDevices(ctx context.Context) {
 
 		// Try to dispatch task with timeout (blocking)
 		select {
-		case s.tasks <- task:
+		case tasks <- task:
 			tasksDispatched++
 			s.logger.Debug("Dispatched subnet scan task",
 				"subnet", subnet,
@@ -274,9 +313,7 @@ func (s *Service) scanOfflineDevices(ctx context.Context) {
 }
 
 // scanWorker processes scan tasks from the queue
-func (s *Service) scanWorker(ctx context.Context, workerID int) {
-	defer s.wg.Done()
-
+func (s *Service) scanWorker(ctx context.Context, run *serviceRun, workerID int) {
 	logger := s.logger.With("worker_id", workerID)
 	logger.Debug("Starting scan worker")
 
@@ -284,12 +321,16 @@ func (s *Service) scanWorker(ctx context.Context, workerID int) {
 		select {
 		case <-ctx.Done():
 			return
-		case task, ok := <-s.tasks:
+		case task, ok := <-run.tasks:
 			if !ok {
 				return
 			}
 			result := s.processTask(ctx, task)
-			s.results <- result
+			select {
+			case run.results <- result:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }
@@ -330,14 +371,12 @@ func (s *Service) processTask(ctx context.Context, task SubnetScanTask) SubnetSc
 }
 
 // resultProcessor handles scan results
-func (s *Service) resultProcessor(ctx context.Context) {
-	defer s.wg.Done()
-
+func (s *Service) resultProcessor(ctx context.Context, run *serviceRun) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case result, ok := <-s.results:
+		case result, ok := <-run.results:
 			if !ok {
 				return
 			}

--- a/server/internal/domain/ipscanner/service_test.go
+++ b/server/internal/domain/ipscanner/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/block/proto-fleet/server/internal/domain/ipscanner/mocks"
 	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
+	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	storemocks "github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
 )
 
@@ -20,72 +21,135 @@ func (n *noopDiscoverer) Discover(ctx context.Context, ipAddress, port string) (
 	return nil, nil
 }
 
-func TestNewIPScannerService(t *testing.T) {
+func TestIPScannerService_StartStopStart(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	config := Config{
 		Enabled:                       true,
-		ScanInterval:                  5 * time.Minute,
-		MaxConcurrentSubnetScans:      5,
-		MaxConcurrentIPScansPerSubnet: 10,
-		ScanTimeout:                   30 * time.Second,
+		ScanInterval:                  time.Hour,
+		MaxConcurrentSubnetScans:      1,
+		MaxConcurrentIPScansPerSubnet: 1,
+		ScanTimeout:                   time.Second,
 		SubnetMaskBits:                24,
 	}
-
 	deviceStore := storemocks.NewMockDeviceStore(ctrl)
-	discoveredDeviceStore := storemocks.NewMockDiscoveredDeviceStore(ctrl)
-	discoverer := &noopDiscoverer{}
-	deviceIDCheckService := mocks.NewMockDeviceIdentityCheckService(ctrl)
-	logger := slog.Default()
+	scanned := make(chan struct{}, 2)
+	deviceStore.EXPECT().GetOfflineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, int) ([]stores.OfflineDeviceInfo, error) {
+			scanned <- struct{}{}
+			return nil, nil
+		},
+	).AnyTimes()
+	service := NewIPScannerService(
+		config,
+		deviceStore,
+		storemocks.NewMockDiscoveredDeviceStore(ctrl),
+		&noopDiscoverer{},
+		mocks.NewMockDeviceIdentityCheckService(ctrl),
+		slog.Default(),
+	)
 
-	service := NewIPScannerService(config, deviceStore, discoveredDeviceStore, discoverer, deviceIDCheckService, logger)
-
-	if service == nil {
-		t.Fatal("NewIPScannerService returned nil")
+	if err := service.Start(t.Context()); err != nil {
+		t.Fatalf("first Start failed: %v", err)
+	}
+	waitForScannerSignal(t, scanned, "first run did not scan")
+	if err := service.Stop(context.Background()); err != nil {
+		t.Fatalf("first Stop failed: %v", err)
+	}
+	if err := service.Start(t.Context()); err != nil {
+		t.Fatalf("second Start failed: %v", err)
+	}
+	waitForScannerSignal(t, scanned, "second run did not scan")
+	if err := service.Stop(context.Background()); err != nil {
+		t.Fatalf("second Stop failed: %v", err)
 	}
 }
 
-func TestIPScannerService_StartStop(t *testing.T) {
+func TestIPScannerService_Stop_CancelsWorkerBlockedOnFullResults(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	config := Config{
 		Enabled:                       true,
-		ScanInterval:                  100 * time.Millisecond,
-		MaxConcurrentSubnetScans:      2,
-		MaxConcurrentIPScansPerSubnet: 5,
-		ScanTimeout:                   1 * time.Second,
+		ScanInterval:                  time.Hour,
+		MaxConcurrentSubnetScans:      1,
+		MaxConcurrentIPScansPerSubnet: 1,
+		ScanTimeout:                   time.Second,
 		SubnetMaskBits:                24,
 	}
+	service := NewIPScannerService(
+		config,
+		storemocks.NewMockDeviceStore(ctrl),
+		storemocks.NewMockDiscoveredDeviceStore(ctrl),
+		&noopDiscoverer{},
+		mocks.NewMockDeviceIdentityCheckService(ctrl),
+		slog.Default(),
+	)
 
-	deviceStore := storemocks.NewMockDeviceStore(ctrl)
-	discoveredDeviceStore := storemocks.NewMockDiscoveredDeviceStore(ctrl)
-	discoverer := &noopDiscoverer{}
-	deviceIDCheckService := mocks.NewMockDeviceIdentityCheckService(ctrl)
-	logger := slog.Default()
+	ctx, cancel := context.WithCancel(t.Context())
+	run := &serviceRun{
+		tasks:   make(chan SubnetScanTask, 1),
+		results: make(chan SubnetScanResult, 1),
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+	service.run = run
+	run.results <- SubnetScanResult{}
+	run.tasks <- SubnetScanTask{Subnet: "invalid"}
+	run.wg.Go(func() { service.scanWorker(ctx, run, 0) })
+	go func() {
+		run.wg.Wait()
+		close(run.done)
+	}()
 
-	// Expect GetOfflineDevices to be called at least once
-	deviceStore.EXPECT().
-		GetOfflineDevices(gomock.Any(), gomock.Any()).
-		Return(nil, nil).
-		AnyTimes()
-
-	service := NewIPScannerService(config, deviceStore, discoveredDeviceStore, discoverer, deviceIDCheckService, logger)
-
-	ctx := t.Context()
-	err := service.Start(ctx)
-	if err != nil {
-		t.Fatalf("Failed to start service: %v", err)
+	deadline := time.Now().Add(time.Second)
+	for len(run.tasks) != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if len(run.tasks) != 0 {
+		t.Fatal("worker did not consume queued task")
+	}
+	select {
+	case <-run.done:
+		t.Fatal("worker unexpectedly exited while the result queue was full")
+	case <-time.After(10 * time.Millisecond):
 	}
 
-	// Give it a moment to start
-	time.Sleep(150 * time.Millisecond)
+	stopCtx, stopCancel := context.WithTimeout(t.Context(), time.Second)
+	defer stopCancel()
+	if err := service.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+}
 
-	// Stop the service
-	err = service.Stop()
-	if err != nil {
-		t.Fatalf("Failed to stop service: %v", err)
+func TestIPScannerService_Stop_ReturnsAtDeadline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	service := NewIPScannerService(
+		Config{Enabled: true, MaxConcurrentSubnetScans: 1, MaxConcurrentIPScansPerSubnet: 1},
+		storemocks.NewMockDeviceStore(ctrl),
+		storemocks.NewMockDiscoveredDeviceStore(ctrl),
+		&noopDiscoverer{},
+		mocks.NewMockDeviceIdentityCheckService(ctrl),
+		slog.Default(),
+	)
+	service.run = &serviceRun{
+		cancel: func() {},
+		done:   make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+	if err := service.Stop(ctx); err == nil {
+		t.Fatal("Stop returned nil after its deadline")
+	}
+	if err := service.Start(t.Context()); err == nil {
+		t.Fatal("Start succeeded while the prior run was still stopping")
+	}
+}
+
+func waitForScannerSignal(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal(message)
 	}
 }
 
@@ -172,7 +236,7 @@ func TestIPScannerService_PreventMultipleInstances(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Stop the service
-	err = service.Stop()
+	err = service.Stop(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to stop service: %v", err)
 	}

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -2,6 +2,7 @@ package schedule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	scheduletargets "github.com/block/proto-fleet/server/internal/domain/schedule/targets"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 const (
@@ -28,14 +30,9 @@ const (
 	revertPerformanceMode = commandpb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY
 	schedulerActorName    = "scheduler"
 	oneTimeRetryDelay     = time.Second
-	// shutdownDeadline bounds Stop(): drain-before-cancel is the graceful
-	// path, the watchdog cancels workCtx if a DB/dispatch call wedges.
-	// Sized within the fleetd-wide shutdownTimeout (10s).
-	shutdownDeadline = 10 * time.Second
 )
 
-// shutdownDeadlineFn lets tests shrink the watchdog without affecting prod.
-var shutdownDeadlineFn = func() time.Duration { return shutdownDeadline }
+var errProcessorStopping = errors.New("schedule processor is still stopping")
 
 // CommandDispatcher is the subset of command.Service the processor needs.
 // CommandResult carries preflight skips for schedule-level audit.
@@ -64,14 +61,19 @@ type Processor struct {
 	activitySvc     *activity.Service
 	now             func() time.Time
 
-	stopCancel context.CancelFunc
-	workCancel context.CancelFunc
-	wg         sync.WaitGroup
-	timerWG    sync.WaitGroup
-	mu         sync.Mutex
-	jobs       map[int64]jobEntry
-	nextGen    uint64
+	stopCancel  context.CancelFunc
+	workCancel  context.CancelFunc
+	wg          sync.WaitGroup
+	timerWG     sync.WaitGroup
+	lifecycleMu sync.Mutex
+	running     bool
+	stopDone    chan struct{}
+	mu          sync.Mutex
+	jobs        map[int64]jobEntry
+	nextGen     uint64
 }
+
+var _ runtimejobs.Lifecycle = (*Processor)(nil)
 
 func NewProcessor(
 	procStore interfaces.ScheduleProcessorStore,
@@ -114,22 +116,40 @@ func scheduleFingerprint(sched *pb.Schedule) string {
 	return strings.Join(parts, "|")
 }
 
-func (p *Processor) Start(_ context.Context) error {
-	stopCtx, stopCancel := context.WithCancel(context.Background())
-	workCtx, workCancel := context.WithCancel(context.Background())
+func (p *Processor) Start(ctx context.Context) error {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+
+	if p.running {
+		return nil
+	}
+	if p.stopDone != nil {
+		return errProcessorStopping
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("schedule processor startup: %w", err)
+	}
+
+	// stopCtx follows the activation context so periodic producers stop as
+	// soon as ownership is withdrawn. workCtx keeps the caller's values but is
+	// cancelled by Stop after in-flight callbacks have had a chance to drain.
+	stopCtx, stopCancel := context.WithCancel(ctx)
+	workCtx, workCancel := context.WithCancel(context.WithoutCancel(ctx))
 	p.stopCancel = stopCancel
 	p.workCancel = workCancel
 
 	p.cron = cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)))
+	p.mu.Lock()
+	p.jobs = make(map[int64]jobEntry)
+	p.nextGen = 0
+	p.mu.Unlock()
 
-	if err := p.recoverStaleRunning(workCtx); err != nil {
-		stopCancel()
-		workCancel()
+	if err := p.recoverStaleRunning(stopCtx); err != nil {
+		p.resetFailedStart()
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
-	if err := p.syncSchedules(workCtx); err != nil {
-		stopCancel()
-		workCancel()
+	if err := p.syncSchedulesForRun(stopCtx, stopCtx, workCtx); err != nil {
+		p.resetFailedStart()
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
 
@@ -138,53 +158,113 @@ func (p *Processor) Start(_ context.Context) error {
 	p.wg.Add(2)
 	go p.reconcileLoop(stopCtx, workCtx)
 	go p.endOfWindowLoop(stopCtx, workCtx)
+	p.running = true
 
 	slog.Info("schedule processor started")
 	return nil
 }
 
-func (p *Processor) Stop() error {
-	// Watchdog bounds total shutdown: workCancel is idempotent, so an early
-	// fire just unblocks wedged in-flight calls; the drain sequence below
-	// still runs to completion.
-	if p.workCancel != nil {
-		watchdog := time.AfterFunc(shutdownDeadlineFn(), p.workCancel)
-		defer watchdog.Stop()
+// Stop gracefully stops the processor, bounded by ctx. A deadline
+// cancels in-flight work and returns to the caller; the processor remains in
+// the stopping state until its goroutines have actually drained, preventing a
+// later Start from overlapping the old activation.
+func (p *Processor) Stop(ctx context.Context) error {
+	done, workCancel := p.beginStop()
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		workCancel()
+		return fmt.Errorf("stop schedule processor: %w", ctx.Err())
+	}
+}
+
+func (p *Processor) beginStop() (<-chan struct{}, context.CancelFunc) {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+
+	workCancel := p.workCancel
+	if workCancel == nil {
+		workCancel = func() {}
+	}
+	if p.stopDone != nil {
+		return p.stopDone, workCancel
+	}
+	if !p.running && p.stopCancel == nil && p.workCancel == nil && p.cron == nil {
+		return nil, func() {}
 	}
 
-	if p.stopCancel != nil {
-		p.stopCancel()
+	p.running = false
+	p.stopDone = make(chan struct{})
+	done := p.stopDone
+	stopCancel := p.stopCancel
+	cronRunner := p.cron
+
+	if stopCancel != nil {
+		stopCancel()
+	}
+	var cronCtx context.Context
+	if cronRunner != nil {
+		cronCtx = cronRunner.Stop()
 	}
 
-	// Stop cron before waiting on the loops so no new cron callbacks fire
-	// during shutdown. In-flight callbacks complete with workCtx still live;
-	// cron.Stop() returns a context that's done once they finish. AddFunc on
-	// a stopped cron appends to entries without firing, so a late
-	// registration from the reconcile loop's last iteration is harmless.
-	if p.cron != nil {
-		cronCtx := p.cron.Stop()
+	go p.finishStop(done, cronCtx, workCancel)
+	return done, workCancel
+}
+
+func (p *Processor) finishStop(done chan struct{}, cronCtx context.Context, workCancel context.CancelFunc) {
+	if cronCtx != nil {
 		<-cronCtx.Done()
 	}
-
 	p.wg.Wait()
 
 	p.mu.Lock()
 	for _, entry := range p.jobs {
-		if entry.isOneTime && entry.timer != nil {
-			if entry.timer.Stop() {
-				p.timerWG.Done()
-			}
+		if entry.isOneTime && entry.timer != nil && entry.timer.Stop() {
+			p.timerWG.Done()
 		}
 	}
 	p.mu.Unlock()
-
 	p.timerWG.Wait()
+	workCancel()
 
+	p.lifecycleMu.Lock()
+	p.mu.Lock()
+	p.jobs = make(map[int64]jobEntry)
+	p.nextGen = 0
+	p.mu.Unlock()
+	p.stopCancel = nil
+	p.workCancel = nil
+	p.cron = nil
+	p.stopDone = nil
+	close(done)
+	p.lifecycleMu.Unlock()
+	slog.Info("schedule processor stopped")
+}
+
+func (p *Processor) resetFailedStart() {
+	if p.stopCancel != nil {
+		p.stopCancel()
+	}
 	if p.workCancel != nil {
 		p.workCancel()
 	}
-	slog.Info("schedule processor stopped")
-	return nil
+	p.mu.Lock()
+	for _, entry := range p.jobs {
+		if entry.isOneTime && entry.timer != nil && entry.timer.Stop() {
+			p.timerWG.Done()
+		}
+	}
+	p.jobs = make(map[int64]jobEntry)
+	p.nextGen = 0
+	p.mu.Unlock()
+	p.timerWG.Wait()
+	p.stopCancel = nil
+	p.workCancel = nil
+	p.cron = nil
 }
 
 func (p *Processor) reconcileLoop(stopCtx, workCtx context.Context) {
@@ -196,7 +276,10 @@ func (p *Processor) reconcileLoop(stopCtx, workCtx context.Context) {
 		case <-stopCtx.Done():
 			return
 		case <-ticker.C:
-			if err := p.syncSchedules(workCtx); err != nil {
+			if stopCtx.Err() != nil {
+				return
+			}
+			if err := p.syncSchedulesForRun(stopCtx, workCtx, workCtx); err != nil {
 				slog.Error("reconciliation failed, will retry next cycle", "error", err)
 			}
 		}
@@ -212,6 +295,9 @@ func (p *Processor) endOfWindowLoop(stopCtx, workCtx context.Context) {
 		case <-stopCtx.Done():
 			return
 		case <-ticker.C:
+			if stopCtx.Err() != nil {
+				return
+			}
 			p.checkEndOfWindow(workCtx)
 		}
 	}
@@ -245,7 +331,11 @@ func (p *Processor) recoverStaleRunning(ctx context.Context) error {
 // syncSchedules loads active/running schedules from the DB, diffs against
 // registered jobs, and adds/removes/updates as needed.
 func (p *Processor) syncSchedules(ctx context.Context) error {
-	schedules, err := p.procStore.GetActiveSchedules(ctx)
+	return p.syncSchedulesForRun(ctx, ctx, ctx)
+}
+
+func (p *Processor) syncSchedulesForRun(stopCtx, queryCtx, workCtx context.Context) error {
+	schedules, err := p.procStore.GetActiveSchedules(queryCtx)
 	if err != nil {
 		return fmt.Errorf("failed to load active schedules: %w", err)
 	}
@@ -265,7 +355,7 @@ func (p *Processor) syncSchedules(ctx context.Context) error {
 			p.removeJobLocked(sw.Schedule.Id)
 		}
 
-		if err := p.registerJob(ctx, sw.Schedule); err != nil {
+		if err := p.registerJob(stopCtx, workCtx, sw.Schedule); err != nil {
 			slog.Error("failed to register job", "schedule_id", sw.Schedule.Id, "error", err)
 		}
 	}
@@ -278,7 +368,7 @@ func (p *Processor) syncSchedules(ctx context.Context) error {
 	return nil
 }
 
-func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
+func (p *Processor) registerJob(stopCtx, workCtx context.Context, sched *pb.Schedule) error {
 	scheduleID := sched.Id
 	generation := p.nextJobGenerationLocked()
 
@@ -294,7 +384,12 @@ func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 		p.timerWG.Add(1)
 		timer := time.AfterFunc(delay, func() {
 			defer p.timerWG.Done()
-			p.executeSchedule(ctx, scheduleID)
+			select {
+			case <-stopCtx.Done():
+				return
+			default:
+				p.executeSchedule(workCtx, scheduleID)
+			}
 		})
 		p.jobs[scheduleID] = jobEntry{timer: timer, isOneTime: true, fingerprint: scheduleFingerprint(sched), generation: generation}
 		return nil
@@ -309,7 +404,14 @@ func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 		return fmt.Errorf("failed to build cron expression: %w", err)
 	}
 
-	entryID, err := p.cron.AddFunc(cronExpr, func() { p.executeSchedule(ctx, scheduleID) })
+	entryID, err := p.cron.AddFunc(cronExpr, func() {
+		select {
+		case <-stopCtx.Done():
+			return
+		default:
+			p.executeSchedule(workCtx, scheduleID)
+		}
+	})
 	if err != nil {
 		return fmt.Errorf("failed to register cron job: %w", err)
 	}

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -126,7 +126,7 @@ func TestStop_WaitsForInFlightTimerCallback(t *testing.T) {
 	waitForSignal(t, started, "timer callback did not start")
 
 	go func() {
-		assert.NoError(t, p.Stop())
+		assert.NoError(t, p.Stop(context.Background()))
 		close(stopped)
 	}()
 
@@ -151,7 +151,7 @@ func TestStop_DoesNotWaitForFutureStoppedTimer(t *testing.T) {
 	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
 
 	go func() {
-		assert.NoError(t, p.Stop())
+		assert.NoError(t, p.Stop(context.Background()))
 		close(stopped)
 	}()
 
@@ -187,7 +187,7 @@ func TestStop_DrainsTimersRegisteredByStoppingLoop(t *testing.T) {
 	}()
 
 	go func() {
-		assert.NoError(t, p.Stop())
+		assert.NoError(t, p.Stop(context.Background()))
 		close(stopped)
 	}()
 
@@ -217,7 +217,7 @@ func TestStop_CronJobsFinishWithLiveContext(t *testing.T) {
 	waitForSignal(t, started, "cron callback did not start")
 
 	go func() {
-		assert.NoError(t, p.Stop())
+		assert.NoError(t, p.Stop(context.Background()))
 		close(stopped)
 	}()
 
@@ -226,20 +226,15 @@ func TestStop_CronJobsFinishWithLiveContext(t *testing.T) {
 	waitForSignal(t, stopped, "Stop did not return after cron callback finished")
 }
 
-// Drain must still be bounded: if work wedges, the watchdog cancels workCtx
-// so the in-flight call returns and the wg waits release.
-func TestStop_WatchdogCancelsHungWork(t *testing.T) {
-	prev := shutdownDeadlineFn
-	shutdownDeadlineFn = func() time.Duration { return 50 * time.Millisecond }
-	t.Cleanup(func() { shutdownDeadlineFn = prev })
-
+// A caller deadline cancels work that failed to drain and bounds Stop.
+func TestStop_DeadlineCancelsHungWork(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
 	workCtx, workCancel := context.WithCancel(context.Background())
 	p.workCancel = workCancel
 
 	started := make(chan struct{})
 	cancelled := make(chan struct{})
-	stopped := make(chan struct{})
+	stopped := make(chan error, 1)
 
 	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
 		func(ctx context.Context, _ int64) (int64, error) {
@@ -261,17 +256,124 @@ func TestStop_WatchdogCancelsHungWork(t *testing.T) {
 	waitForSignal(t, started, "hung callback did not start")
 
 	begin := time.Now()
+	stopCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
 	go func() {
-		assert.NoError(t, p.Stop())
-		close(stopped)
+		stopped <- p.Stop(stopCtx)
 	}()
 
-	waitForSignal(t, cancelled, "watchdog did not cancel hung work via workCancel")
-	waitForSignal(t, stopped, "Stop did not return after watchdog fired")
+	waitForSignal(t, cancelled, "deadline did not cancel hung work via workCancel")
+	assert.True(t, errors.Is(<-stopped, context.DeadlineExceeded))
+	assert.NoError(t, p.Stop(context.Background()))
 
 	if elapsed := time.Since(begin); elapsed > time.Second {
-		t.Fatalf("Stop took %v; watchdog should have bounded shutdown well below this", elapsed)
+		t.Fatalf("Stop took %v; caller deadline should have bounded shutdown well below this", elapsed)
 	}
+}
+
+func TestProcessor_StartStopStart_ReRegistersUnchangedSchedules(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	sched := &pb.Schedule{
+		Id:           1,
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_RECURRING,
+		StartDate:    "2026-04-01",
+		StartTime:    "09:00",
+		Timezone:     "UTC",
+		Status:       pb.ScheduleStatus_SCHEDULE_STATUS_ACTIVE,
+		Recurrence:   &pb.ScheduleRecurrence{Frequency: pb.RecurrenceFrequency_RECURRENCE_FREQUENCY_DAILY, Interval: 1},
+	}
+	schedules := []interfaces.ScheduleWithOrg{{Schedule: sched, OrgID: 1}}
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(schedules, nil).Times(4)
+
+	assert.NoError(t, p.Start(t.Context()))
+	assert.Equal(t, 1, len(p.cron.Entries()))
+	assert.NoError(t, p.Stop(context.Background()))
+
+	assert.NoError(t, p.Start(t.Context()))
+	assert.Equal(t, 1, len(p.cron.Entries()))
+	assert.NoError(t, p.Stop(context.Background()))
+}
+
+func TestProcessor_StartHonorsActivationCancellation(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	queryStarted := make(chan struct{})
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]interfaces.ScheduleWithOrg, error) {
+			close(queryStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startDone := make(chan error, 1)
+	go func() { startDone <- p.Start(ctx) }()
+	waitForSignal(t, queryStarted, "startup query did not begin")
+	cancel()
+
+	select {
+	case err := <-startDone:
+		assert.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return after its activation context was canceled")
+	}
+}
+
+func TestProcessor_Stop_PreventsRestartUntilDrainCompletes(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	workCtx, workCancel := context.WithCancel(context.Background())
+	p.workCancel = workCancel
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
+		func(context.Context, int64) (int64, error) {
+			close(started)
+			<-release
+			return 0, nil
+		},
+	)
+
+	p.timerWG.Add(1)
+	timer := time.AfterFunc(time.Hour, func() {
+		defer p.timerWG.Done()
+		p.executeSchedule(workCtx, 1)
+	})
+	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
+	timer.Reset(0)
+	waitForSignal(t, started, "timer callback did not start")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+	assert.Error(t, p.Stop(ctx))
+	assert.Error(t, p.Start(t.Context()))
+
+	close(release)
+	assert.NoError(t, p.Stop(context.Background()))
+}
+
+func TestProcessor_ActivationCancellationPreventsNewTimerWork(t *testing.T) {
+	p, _, _, _, _ := newTestProcessor(t, time.Now())
+	p.cron = cron.New()
+	stopCtx, stop := context.WithCancel(t.Context())
+	workCtx, cancelWork := context.WithCancel(context.WithoutCancel(t.Context()))
+	defer cancelWork()
+
+	sched := &pb.Schedule{
+		Id:           1,
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_ONE_TIME,
+		StartDate:    "2026-04-01",
+		StartTime:    "09:00",
+		Timezone:     "UTC",
+	}
+	p.mu.Lock()
+	assert.NoError(t, p.registerJob(stopCtx, workCtx, sched))
+	timer := p.jobs[1].timer
+	p.mu.Unlock()
+
+	stop()
+	timer.Reset(0)
+	p.timerWG.Wait()
 }
 
 // --- recoverStaleRunning ---

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -94,6 +94,7 @@ import (
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
 	modelsV2 "github.com/block/proto-fleet/server/internal/domain/telemetry/models/v2"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 const (
@@ -319,7 +320,6 @@ type TelemetryService struct {
 	deviceStore        stores.DeviceStore
 	errorPoller        ErrorPoller
 	metricsObserver    *metricsObserver
-	mux                sync.Mutex
 	// tasks queues devices for full telemetry collection (metrics, telemetry, and status).
 	// Buffer sized to ConcurrencyLimit to ensure at least one queued task per worker.
 	tasks chan models.Device
@@ -338,8 +338,12 @@ type TelemetryService struct {
 	// metricsFlushRequests asks metricsWriterRoutine to flush pending metrics
 	// immediately and report the result to the caller.
 	metricsFlushRequests chan metricsFlushRequest
-	cancelFunc           context.CancelFunc
 	lookBackDuration     time.Duration
+	lifecycleMu          sync.Mutex
+	runCancel            context.CancelFunc
+	runWG                sync.WaitGroup
+	runDone              <-chan struct{}
+	stopping             bool
 	// devicesForStatusPolling tracks all paired devices that need periodic status checks.
 	// This ensures failed devices (removed from scheduler after MaxConsecutiveFailures)
 	// continue to be polled for status so they can recover when they come back online.
@@ -353,10 +357,10 @@ type TelemetryService struct {
 	// lastDefaultPwActive caches the last-seen default-password flag per device so
 	// the poll only checks for a pairing-status change on transitions, not every poll.
 	lastDefaultPwActive sync.Map // map[DeviceIdentifier]bool
-	// inFlight tracks devices currently being processed by a worker via the tasks channel.
+	// inFlight tracks devices currently being processed by workers or request-driven refreshes.
 	// statusPollingRoutine skips devices in this map to avoid double-processing the same
-	// device simultaneously in both the full-telemetry and status-only paths.
-	inFlight sync.Map // map[DeviceIdentifier]struct{}
+	// device simultaneously across the full-telemetry and status-only paths.
+	inFlight sync.Map // map[DeviceIdentifier]inFlightKind
 	// combinedMetricsSingle collapses identical concurrent GetCombinedMetrics
 	// calls (N dashboard viewers polling the same org) into one execution.
 	combinedMetricsSingle singleflight.Group
@@ -367,24 +371,27 @@ type TelemetryService struct {
 	combinedMetricsFlights   map[string]*combinedMetricsFlight
 }
 
+var _ runtimejobs.Lifecycle = (*TelemetryService)(nil)
+
 func NewTelemetryService(config Config, telemetryDataStore TelemetryDataStore, minerManager CachedMinerGetter, scheduler UpdateScheduler, deviceStore stores.DeviceStore, errorPoller ErrorPoller) *TelemetryService {
-	return &TelemetryService{
+	s := &TelemetryService{
 		config:                 config,
 		telemetryDataStore:     telemetryDataStore,
 		minerManager:           minerManager,
 		updateScheduler:        scheduler,
 		deviceStore:            deviceStore,
 		errorPoller:            errorPoller,
+		lookBackDuration:       -1 * (config.StalenessThreshold - config.FetchInterval),
+		metricsObserver:        newMetricsObserver(NoMetrics()),
+		combinedMetricsFlights: make(map[string]*combinedMetricsFlight),
 		tasks:                  make(chan models.Device, config.ConcurrencyLimit),
 		statusTasks:            make(chan models.Device, config.ConcurrencyLimit),
 		statusResults:          make(chan statusResult, resultsChannelBuffer),
 		statusFlushRequests:    make(chan statusFlushRequest),
 		metricsResults:         make(chan metricsResult, resultsChannelBuffer),
 		metricsFlushRequests:   make(chan metricsFlushRequest),
-		lookBackDuration:       -1 * (config.StalenessThreshold - config.FetchInterval),
-		metricsObserver:        newMetricsObserver(NoMetrics()),
-		combinedMetricsFlights: make(map[string]*combinedMetricsFlight),
 	}
+	return s
 }
 
 func (s *TelemetryService) WithMetricsEmitter(emitter MetricsEmitter) *TelemetryService {
@@ -535,30 +542,76 @@ func (s *TelemetryService) flushMetrics(ctx context.Context, deviceID *models.De
 }
 
 func (s *TelemetryService) Start(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	s.cancelFunc = cancel
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	if s.stopping {
+		return fmt.Errorf("telemetry service is still stopping")
+	}
+	if s.runCancel != nil {
+		return nil
+	}
 
-	go s.gatherMetricsRoutine(ctx)
-	go s.devicePollingRoutine(ctx)
-	go s.statusPollingRoutine(ctx)
-	go s.fleetStateSnapshotRoutine(ctx)
-	go s.fleetMetricRollupRoutine(ctx)
+	runCtx, cancel := context.WithCancel(ctx)
+	runDone := make(chan struct{})
+	s.runCancel = cancel
+	s.runDone = runDone
+	s.runWG.Go(func() { s.gatherMetricsRoutine(runCtx) })
+	s.runWG.Go(func() { s.devicePollingRoutine(runCtx) })
+	s.runWG.Go(func() { s.statusPollingRoutine(runCtx) })
+	s.runWG.Go(func() { s.fleetStateSnapshotRoutine(runCtx) })
+	s.runWG.Go(func() { s.fleetMetricRollupRoutine(runCtx) })
+	go s.finishRun(runDone)
 	return nil
 }
 
-func (s *TelemetryService) Stop(ctx context.Context) error {
-	s.cancelFunc()
-	defer close(s.tasks)
-	defer close(s.statusTasks)
-	defer close(s.statusResults)
+func (s *TelemetryService) finishRun(done chan struct{}) {
+	s.runWG.Wait()
 
-	s.broadcasters.Range(func(_, value any) bool {
+	s.lifecycleMu.Lock()
+	if s.runDone == (<-chan struct{})(done) {
+		s.runCancel = nil
+		s.runDone = nil
+		s.stopping = false
+	}
+	s.lifecycleMu.Unlock()
+	close(done)
+}
+
+func (s *TelemetryService) Stop(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	if s.runCancel == nil {
+		s.lifecycleMu.Unlock()
+		return nil
+	}
+	if !s.stopping {
+		s.stopping = true
+		s.runCancel()
+	}
+	done := s.runDone
+	s.lifecycleMu.Unlock()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("stop telemetry service: %w", ctx.Err())
+	}
+}
+
+// Close stops polling and closes per-organization broadcasters during process
+// teardown. Runtime demotion should call Stop so read-only streams can remain
+// independent of the active polling lifecycle.
+func (s *TelemetryService) Close(ctx context.Context) error {
+	if err := s.Stop(ctx); err != nil {
+		return err
+	}
+	s.broadcasters.Range(func(key, value any) bool {
 		if broadcaster, ok := value.(*TelemetryBroadcaster); ok {
 			broadcaster.Stop()
 		}
+		s.broadcasters.Delete(key)
 		return true
 	})
-
 	return nil
 }
 
@@ -597,19 +650,14 @@ func (s *TelemetryService) GetOrCreateBroadcaster(ctx context.Context, orgID int
 }
 
 func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context) {
-	if !s.mux.TryLock() {
-		return
-	}
-	defer s.mux.Unlock()
-
 	// Start workers that fetch telemetry/status from miners
 	for range s.config.ConcurrencyLimit {
-		go s.worker(ctx)
+		s.runWG.Go(func() { s.worker(ctx) })
 	}
 
 	// Start routines that collect results from workers and periodically write to DB
-	go s.statusWriterRoutine(ctx)
-	go s.metricsWriterRoutine(ctx)
+	s.runWG.Go(func() { s.statusWriterRoutine(ctx) })
+	s.runWG.Go(func() { s.metricsWriterRoutine(ctx) })
 
 	fetchInterval := s.config.FetchInterval
 	if fetchInterval <= 0 {
@@ -629,7 +677,11 @@ func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context) {
 				continue
 			}
 			for _, device := range devices {
-				s.tasks <- device
+				select {
+				case s.tasks <- device:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -312,6 +312,18 @@ type metricsResult struct {
 	metrics    modelsV2.DeviceMetrics
 }
 
+type telemetryResults struct {
+	status  chan statusResult
+	metrics chan metricsResult
+}
+
+func newTelemetryResults() telemetryResults {
+	return telemetryResults{
+		status:  make(chan statusResult, resultsChannelBuffer),
+		metrics: make(chan metricsResult, resultsChannelBuffer),
+	}
+}
+
 type TelemetryService struct {
 	config             Config
 	updateScheduler    UpdateScheduler
@@ -326,12 +338,14 @@ type TelemetryService struct {
 	// statusTasks queues devices for status-only checks (no telemetry fetch).
 	// Used by statusPollingRoutine to check failed devices for recovery.
 	statusTasks chan models.Device
-	// statusResults receives status updates from workers for batch DB writes.
+	// statusResults receives request-driven status updates. Background activations
+	// use per-run channels so stopped runs cannot leak results into a later run.
 	statusResults chan statusResult
 	// statusFlushRequests asks statusWriterRoutine to flush pending status
 	// updates immediately and report the result to the caller.
 	statusFlushRequests chan statusFlushRequest
-	// metricsResults receives device metrics from workers for batch DB writes.
+	// metricsResults receives request-driven device metrics. Background activations
+	// use per-run channels so stopped runs cannot leak results into a later run.
 	// Uses a blocking send so metrics are never dropped; backpressure slows workers
 	// if the DB falls behind rather than losing data.
 	metricsResults chan metricsResult
@@ -374,6 +388,7 @@ type TelemetryService struct {
 var _ runtimejobs.Lifecycle = (*TelemetryService)(nil)
 
 func NewTelemetryService(config Config, telemetryDataStore TelemetryDataStore, minerManager CachedMinerGetter, scheduler UpdateScheduler, deviceStore stores.DeviceStore, errorPoller ErrorPoller) *TelemetryService {
+	requestResults := newTelemetryResults()
 	s := &TelemetryService{
 		config:                 config,
 		telemetryDataStore:     telemetryDataStore,
@@ -386,12 +401,16 @@ func NewTelemetryService(config Config, telemetryDataStore TelemetryDataStore, m
 		combinedMetricsFlights: make(map[string]*combinedMetricsFlight),
 		tasks:                  make(chan models.Device, config.ConcurrencyLimit),
 		statusTasks:            make(chan models.Device, config.ConcurrencyLimit),
-		statusResults:          make(chan statusResult, resultsChannelBuffer),
+		statusResults:          requestResults.status,
 		statusFlushRequests:    make(chan statusFlushRequest),
-		metricsResults:         make(chan metricsResult, resultsChannelBuffer),
+		metricsResults:         requestResults.metrics,
 		metricsFlushRequests:   make(chan metricsFlushRequest),
 	}
 	return s
+}
+
+func (s *TelemetryService) requestResults() telemetryResults {
+	return telemetryResults{status: s.statusResults, metrics: s.metricsResults}
 }
 
 func (s *TelemetryService) WithMetricsEmitter(emitter MetricsEmitter) *TelemetryService {
@@ -553,9 +572,10 @@ func (s *TelemetryService) Start(ctx context.Context) error {
 
 	runCtx, cancel := context.WithCancel(ctx)
 	runDone := make(chan struct{})
+	runResults := newTelemetryResults()
 	s.runCancel = cancel
 	s.runDone = runDone
-	s.runWG.Go(func() { s.gatherMetricsRoutine(runCtx) })
+	s.runWG.Go(func() { s.gatherMetricsRoutine(runCtx, runResults) })
 	s.runWG.Go(func() { s.devicePollingRoutine(runCtx) })
 	s.runWG.Go(func() { s.statusPollingRoutine(runCtx) })
 	s.runWG.Go(func() { s.fleetStateSnapshotRoutine(runCtx) })
@@ -647,15 +667,15 @@ func (s *TelemetryService) GetOrCreateBroadcaster(ctx context.Context, orgID int
 	return broadcaster, nil
 }
 
-func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context) {
+func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context, results telemetryResults) {
 	// Start workers that fetch telemetry/status from miners
 	for range s.config.ConcurrencyLimit {
-		s.runWG.Go(func() { s.worker(ctx) })
+		s.runWG.Go(func() { s.workerForActivation(ctx, results) })
 	}
 
 	// Start routines that collect results from workers and periodically write to DB
-	s.runWG.Go(func() { s.statusWriterRoutine(ctx) })
-	s.runWG.Go(func() { s.metricsWriterRoutine(ctx) })
+	s.runWG.Go(func() { s.statusWriterRoutineForActivation(ctx, results.status) })
+	s.runWG.Go(func() { s.metricsWriterRoutineForActivation(ctx, results.metrics) })
 
 	fetchInterval := s.config.FetchInterval
 	if fetchInterval <= 0 {
@@ -871,6 +891,10 @@ func fleetMetricRollupWriteWindow(now, latest time.Time) (startTime, endTime tim
 // It fetches telemetry/status from miners and sends results to the statusResults channel
 // for periodic DB writes by statusWriterRoutine.
 func (s *TelemetryService) worker(ctx context.Context) {
+	s.workerForActivation(ctx, s.requestResults())
+}
+
+func (s *TelemetryService) workerForActivation(ctx context.Context, results telemetryResults) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -886,14 +910,14 @@ func (s *TelemetryService) worker(ctx context.Context) {
 				}
 				continue
 			}
-			_ = s.processDevice(ctx, device)
+			_ = s.processDeviceWithResults(ctx, device, results)
 			s.inFlight.Delete(device.ID)
 
 		case device, ok := <-s.statusTasks:
 			if !ok {
 				return
 			}
-			s.processStatusOnly(ctx, device)
+			s.processStatusOnlyWithResults(ctx, device, results.status)
 			s.inFlight.Delete(device.ID)
 		}
 	}
@@ -909,9 +933,13 @@ func (s *TelemetryService) worker(ctx context.Context) {
 // Connection errors during status fetch are converted to MinerStatusOffline (not errors),
 // so the flow continues. Only auth failures and other non-connection errors cause early return.
 func (s *TelemetryService) processDevice(ctx context.Context, device models.Device) error {
+	return s.processDeviceWithResults(ctx, device, s.requestResults())
+}
+
+func (s *TelemetryService) processDeviceWithResults(ctx context.Context, device models.Device, results telemetryResults) error {
 	// Telemetry failure doesn't block status/error polling - we still want to track online state.
 	// When metrics succeed, status is derived from the health field — no second RPC needed.
-	metricsStatus, hasMetricsStatus, orgID, driverName, siteID, pollSuccess, telemetryErr := s.GetTelemetryFromDevice(ctx, device)
+	metricsStatus, hasMetricsStatus, orgID, driverName, siteID, pollSuccess, telemetryErr := s.getTelemetryFromDevice(ctx, device, results.metrics)
 	var collectionErr error
 	s.metricsObserver.onPollResult(
 		ctx,
@@ -976,7 +1004,7 @@ func (s *TelemetryService) processDevice(ctx context.Context, device models.Devi
 
 	// Send status result to writer (non-blocking to prevent worker stalls)
 	select {
-	case s.statusResults <- statusResult{
+	case results.status <- statusResult{
 		deviceIdentifier: device.ID,
 		status:           status,
 		orgID:            orgID,
@@ -1017,6 +1045,10 @@ func (s *TelemetryService) processDevice(ctx context.Context, device models.Devi
 // This design ensures devices can automatically rejoin telemetry collection when they
 // come back online, without manual intervention.
 func (s *TelemetryService) processStatusOnly(ctx context.Context, device models.Device) {
+	s.processStatusOnlyWithResults(ctx, device, s.statusResults)
+}
+
+func (s *TelemetryService) processStatusOnlyWithResults(ctx context.Context, device models.Device, results chan<- statusResult) {
 	status, orgID, driverName, siteID, statusErr := s.fetchStatusFromMiner(ctx, device.ID)
 	if statusErr != nil {
 		// Non-connection errors (e.g., auth failures) - device stays in failed state.
@@ -1055,7 +1087,7 @@ func (s *TelemetryService) processStatusOnly(ctx context.Context, device models.
 
 	// Always send status to DB for UI visibility (even for offline devices)
 	select {
-	case s.statusResults <- statusResult{
+	case results <- statusResult{
 		deviceIdentifier: device.ID,
 		status:           status,
 		orgID:            orgID,
@@ -1072,6 +1104,10 @@ func (s *TelemetryService) processStatusOnly(ctx context.Context, device models.
 // statusWriterRoutine collects status results from workers and writes them to DB periodically.
 // This centralizes DB writes to reduce connection usage and improve throughput.
 func (s *TelemetryService) statusWriterRoutine(ctx context.Context) {
+	s.statusWriterRoutineForActivation(ctx, nil)
+}
+
+func (s *TelemetryService) statusWriterRoutineForActivation(ctx context.Context, activationResults <-chan statusResult) {
 	flushInterval := s.config.StatusFlushInterval
 	if flushInterval <= 0 {
 		flushInterval = defaultStatusFlushInterval
@@ -1101,6 +1137,11 @@ func (s *TelemetryService) statusWriterRoutine(ctx context.Context) {
 		var drainResult statusFlushResult
 		for {
 			select {
+			case result := <-activationResults:
+				addPendingUpdate(result)
+				if len(pendingUpdates) >= maxStatusBatchSize {
+					drainResult = mergeStatusFlushResults(drainResult, flush(flushCtx))
+				}
 			case result, ok := <-s.statusResults:
 				if !ok {
 					return drainResult
@@ -1209,6 +1250,12 @@ func (s *TelemetryService) statusWriterRoutine(ctx context.Context) {
 			_ = flush(shutdownCtx)
 			cancel()
 			return
+
+		case result := <-activationResults:
+			addPendingUpdate(result)
+			if len(pendingUpdates) >= maxStatusBatchSize {
+				_ = flush(ctx)
+			}
 
 		case result, ok := <-s.statusResults:
 			if !ok {
@@ -1458,6 +1505,10 @@ func (s *TelemetryService) resolveTrustedDeviceMetadata(ctx context.Context, dev
 // succeeded, and any error. The first bool is false when the health status is
 // ambiguous; see healthStatusToMinerStatus.
 func (s *TelemetryService) GetTelemetryFromDevice(ctx context.Context, device models.Device) (mm.MinerStatus, bool, int64, string, int64, bool, error) {
+	return s.getTelemetryFromDevice(ctx, device, s.metricsResults)
+}
+
+func (s *TelemetryService) getTelemetryFromDevice(ctx context.Context, device models.Device, results chan<- metricsResult) (mm.MinerStatus, bool, int64, string, int64, bool, error) {
 	fetchCtx, cancel := context.WithTimeout(ctx, s.config.MetricTimeout)
 	defer cancel()
 
@@ -1480,7 +1531,7 @@ func (s *TelemetryService) GetTelemetryFromDevice(ctx context.Context, device mo
 		// prevent enqueueing metrics we already fetched. Only give up if the service
 		// itself is shutting down (ctx cancelled by the root context).
 		select {
-		case s.metricsResults <- metricsResult{
+		case results <- metricsResult{
 			deviceID:   device.ID,
 			orgID:      result.orgID,
 			siteID:     result.siteID,
@@ -1504,6 +1555,10 @@ func (s *TelemetryService) GetTelemetryFromDevice(ctx context.Context, device mo
 	return result.status, result.hasStatus, result.orgID, result.driverName, result.siteID, pollSuccess, nil
 }
 func (s *TelemetryService) metricsWriterRoutine(ctx context.Context) {
+	s.metricsWriterRoutineForActivation(ctx, nil)
+}
+
+func (s *TelemetryService) metricsWriterRoutineForActivation(ctx context.Context, activationResults <-chan metricsResult) {
 	flushInterval := s.config.StatusFlushInterval
 	if flushInterval <= 0 {
 		flushInterval = defaultMetricsFlushInterval
@@ -1551,6 +1606,11 @@ func (s *TelemetryService) metricsWriterRoutine(ctx context.Context) {
 		var drainResult metricsFlushResult
 		for {
 			select {
+			case result := <-activationResults:
+				forwardMetrics(result)
+				if len(pending) >= maxMetricsBatchSize {
+					drainResult = mergeMetricsFlushResults(drainResult, flush(flushCtx))
+				}
 			case result, ok := <-s.metricsResults:
 				if !ok {
 					return drainResult
@@ -1574,6 +1634,11 @@ func (s *TelemetryService) metricsWriterRoutine(ctx context.Context) {
 			_ = flush(shutdownCtx)
 			cancel()
 			return
+		case result := <-activationResults:
+			forwardMetrics(result)
+			if len(pending) >= maxMetricsBatchSize {
+				_ = flush(ctx)
+			}
 		case result := <-s.metricsResults:
 			forwardMetrics(result)
 			if len(pending) >= maxMetricsBatchSize {

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -602,9 +602,7 @@ func (s *TelemetryService) Stop(ctx context.Context) error {
 // teardown. Runtime demotion should call Stop so read-only streams can remain
 // independent of the active polling lifecycle.
 func (s *TelemetryService) Close(ctx context.Context) error {
-	if err := s.Stop(ctx); err != nil {
-		return err
-	}
+	stopErr := s.Stop(ctx)
 	s.broadcasters.Range(func(key, value any) bool {
 		if broadcaster, ok := value.(*TelemetryBroadcaster); ok {
 			broadcaster.Stop()
@@ -612,7 +610,7 @@ func (s *TelemetryService) Close(ctx context.Context) error {
 		s.broadcasters.Delete(key)
 		return true
 	})
-	return nil
+	return stopErr
 }
 
 // GetOrCreateBroadcaster returns the broadcaster for an organization, creating it if needed

--- a/server/internal/domain/telemetry/service_test.go
+++ b/server/internal/domain/telemetry/service_test.go
@@ -335,6 +335,104 @@ func TestTelemetryService_StopStartPreservesRefreshDeviceClaim(t *testing.T) {
 	require.NoError(t, service.Stop(t.Context()))
 }
 
+func TestTelemetryWriters_DoNotConsumeResultsFromPreviousActivation(t *testing.T) {
+	t.Run("status", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockDataStore := mock.NewMockTelemetryDataStore(ctrl)
+		mockMinerGetter := mock.NewMockCachedMinerGetter(ctrl)
+		mockScheduler := mock.NewMockUpdateScheduler(ctrl)
+		mockDeviceStore := storesMocks.NewMockDeviceStore(ctrl)
+		deviceID := models.DeviceIdentifier("test-device")
+
+		mockDeviceStore.EXPECT().
+			GetDeviceStatusForDeviceIdentifiers(gomock.Any(), []models.DeviceIdentifier{deviceID}).
+			Return(nil, nil)
+		mockDeviceStore.EXPECT().
+			UpsertDeviceStatuses(gomock.Any(), []stores.DeviceStatusUpdate{{
+				DeviceIdentifier: deviceID,
+				Status:           mm.MinerStatusActive,
+			}}).
+			Return(nil)
+
+		service := NewTelemetryService(
+			Config{StalenessThreshold: time.Minute, FetchInterval: time.Hour, ConcurrencyLimit: 1, StatusFlushInterval: time.Hour},
+			mockDataStore,
+			mockMinerGetter,
+			mockScheduler,
+			mockDeviceStore,
+			mock.NewMockErrorPoller(ctrl),
+		)
+		stoppedActivationResults := make(chan statusResult, 1)
+		currentActivationResults := make(chan statusResult, 1)
+		stoppedActivationResults <- statusResult{deviceIdentifier: deviceID, status: mm.MinerStatusOffline}
+		currentActivationResults <- statusResult{deviceIdentifier: deviceID, status: mm.MinerStatusActive}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			service.statusWriterRoutineForActivation(ctx, currentActivationResults)
+			close(done)
+		}()
+
+		require.NoError(t, service.FlushStatusNow(ctx))
+		require.Len(t, stoppedActivationResults, 1)
+		cancel()
+		require.Eventually(t, func() bool {
+			select {
+			case <-done:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, time.Millisecond)
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockDataStore := mock.NewMockTelemetryDataStore(ctrl)
+		mockMinerGetter := mock.NewMockCachedMinerGetter(ctrl)
+		mockScheduler := mock.NewMockUpdateScheduler(ctrl)
+		mockDeviceStore := storesMocks.NewMockDeviceStore(ctrl)
+		currentMetric := modelsV2.DeviceMetrics{DeviceIdentifier: "current-device"}
+
+		mockDataStore.EXPECT().
+			StoreDeviceMetrics(gomock.Any(), currentMetric).
+			Return(nil)
+
+		service := NewTelemetryService(
+			Config{StalenessThreshold: time.Minute, FetchInterval: time.Hour, ConcurrencyLimit: 1, StatusFlushInterval: time.Hour},
+			mockDataStore,
+			mockMinerGetter,
+			mockScheduler,
+			mockDeviceStore,
+			mock.NewMockErrorPoller(ctrl),
+		)
+		stoppedActivationResults := make(chan metricsResult, 1)
+		currentActivationResults := make(chan metricsResult, 1)
+		stoppedActivationResults <- metricsResult{metrics: modelsV2.DeviceMetrics{DeviceIdentifier: "stale-device"}}
+		currentActivationResults <- metricsResult{metrics: currentMetric}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			service.metricsWriterRoutineForActivation(ctx, currentActivationResults)
+			close(done)
+		}()
+
+		require.NoError(t, service.FlushMetricsNow(ctx))
+		require.Len(t, stoppedActivationResults, 1)
+		cancel()
+		require.Eventually(t, func() bool {
+			select {
+			case <-done:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, time.Millisecond)
+	})
+}
+
 // FakeTelemetryData is no longer used - tests now use DeviceMetrics v2 model
 
 func TestTelemetryService_DataStoreInteraction(t *testing.T) {

--- a/server/internal/domain/telemetry/service_test.go
+++ b/server/internal/domain/telemetry/service_test.go
@@ -239,6 +239,27 @@ func TestTelemetryService_CanRestartAfterStop(t *testing.T) {
 	require.NoError(t, service.Stop(t.Context()))
 }
 
+func TestTelemetryService_CloseStopsBroadcastersAfterStopTimeout(t *testing.T) {
+	service := &TelemetryService{}
+	_, runCancel := context.WithCancel(t.Context())
+	service.runCancel = runCancel
+	service.runDone = make(chan struct{})
+
+	broadcaster := NewTelemetryBroadcaster(1, nil, time.Hour)
+	require.NoError(t, broadcaster.Start(t.Context()))
+	updates, _, err := broadcaster.Subscribe(t.Context(), SubscriptionConfig{})
+	require.NoError(t, err)
+	service.broadcasters.Store(int64(1), broadcaster)
+
+	stopCtx, cancelStop := context.WithCancel(t.Context())
+	cancelStop()
+	require.ErrorIs(t, service.Close(stopCtx), context.Canceled)
+	_, exists := service.broadcasters.Load(int64(1))
+	require.False(t, exists)
+	_, open := <-updates
+	require.False(t, open)
+}
+
 func TestTelemetryService_StopStartPreservesRefreshDeviceClaim(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockDataStore := mock.NewMockTelemetryDataStore(ctrl)

--- a/server/internal/domain/telemetry/service_test.go
+++ b/server/internal/domain/telemetry/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -206,110 +207,111 @@ func TestTelemetryService_RemoveDevices(t *testing.T) {
 	}
 }
 
-func TestTelemetryService_Start(t *testing.T) {
+func TestTelemetryService_CanRestartAfterStop(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mockDataStore := mock.NewMockTelemetryDataStore(ctrl)
 	mockMinerGetter := mock.NewMockCachedMinerGetter(ctrl)
 	mockScheduler := mock.NewMockUpdateScheduler(ctrl)
 	mockDeviceStore := storesMocks.NewMockDeviceStore(ctrl)
 
-	// Set up expectations for background processing
-	mockScheduler.EXPECT().
-		FetchDevices(gomock.Any(), gomock.Any()).
-		Return([]models.Device{}, nil).
-		AnyTimes()
+	mockScheduler.EXPECT().FetchDevices(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	var pairedDeviceLoads atomic.Int32
+	mockDeviceStore.EXPECT().GetAllPairedDeviceIdentifiers(gomock.Any()).DoAndReturn(
+		func(context.Context) ([]models.DeviceIdentifier, error) {
+			pairedDeviceLoads.Add(1)
+			return nil, nil
+		},
+	).AnyTimes()
+	mockDataStore.EXPECT().InsertMinerStateSnapshot(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	// Set up expectations for device polling
-	mockDeviceStore.EXPECT().
-		GetAllPairedDeviceIdentifiers(gomock.Any()).
-		Return([]models.DeviceIdentifier{}, nil).
-		AnyTimes()
+	service := NewTelemetryService(Config{
+		StalenessThreshold: time.Minute,
+		FetchInterval:      time.Hour,
+		ConcurrencyLimit:   1,
+		DevicePollInterval: time.Hour,
+	}, mockDataStore, mockMinerGetter, mockScheduler, mockDeviceStore, mock.NewMockErrorPoller(ctrl))
 
-	// Snapshot routine fires once on Start and then on the ticker.
-	mockDataStore.EXPECT().
-		InsertMinerStateSnapshot(gomock.Any(), gomock.Any()).
-		Return(nil).
-		AnyTimes()
-
-	config := Config{
-		StalenessThreshold: 1 * time.Minute,
-		FetchInterval:      100 * time.Millisecond, // Short interval for test
-		ConcurrencyLimit:   5,
-		DevicePollInterval: 100 * time.Millisecond, // Short interval for test
-	}
-
-	service := NewTelemetryService(config, mockDataStore, mockMinerGetter, mockScheduler, mockDeviceStore, mock.NewMockErrorPoller(ctrl))
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	err := service.Start(ctx)
-	require.NoError(t, err)
-
-	// Let it run briefly
-	time.Sleep(50 * time.Millisecond)
-
-	// Test that the service can be stopped after starting
-	err = service.Stop(ctx)
-	require.NoError(t, err)
-
-	// Give time for goroutines to clean up
-	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, service.Start(t.Context()))
+	require.Eventually(t, func() bool { return pairedDeviceLoads.Load() >= 1 }, time.Second, time.Millisecond)
+	require.NoError(t, service.Stop(t.Context()))
+	require.NoError(t, service.Start(t.Context()))
+	require.Eventually(t, func() bool { return pairedDeviceLoads.Load() >= 2 }, time.Second, time.Millisecond)
+	require.NoError(t, service.Stop(t.Context()))
 }
 
-func TestTelemetryService_Stop(t *testing.T) {
+func TestTelemetryService_StopStartPreservesRefreshDeviceClaim(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mockDataStore := mock.NewMockTelemetryDataStore(ctrl)
 	mockMinerGetter := mock.NewMockCachedMinerGetter(ctrl)
 	mockScheduler := mock.NewMockUpdateScheduler(ctrl)
 	mockDeviceStore := storesMocks.NewMockDeviceStore(ctrl)
+	mockMiner := minerMocks.NewMockMiner(ctrl)
+	mockErrorPoller := mock.NewMockErrorPoller(ctrl)
 
-	// Set up expectations for background processing
-	mockScheduler.EXPECT().
-		FetchDevices(gomock.Any(), gomock.Any()).
-		Return([]models.Device{}, nil).
-		AnyTimes()
+	deviceID := models.DeviceIdentifier("request-owned-refresh")
+	device := models.Device{ID: deviceID}
+	metric := modelsV2.DeviceMetrics{
+		DeviceIdentifier: string(deviceID),
+		Health:           modelsV2.HealthHealthyActive,
+	}
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
 
-	// Set up expectations for device polling
-	mockDeviceStore.EXPECT().
-		GetAllPairedDeviceIdentifiers(gomock.Any()).
-		Return([]models.DeviceIdentifier{}, nil).
-		AnyTimes()
+	mockScheduler.EXPECT().FetchDevices(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockScheduler.EXPECT().AddDevices(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	mockDeviceStore.EXPECT().GetAllPairedDeviceIdentifiers(gomock.Any()).Return(nil, nil).AnyTimes()
+	mockDeviceStore.EXPECT().GetDeviceStatusForDeviceIdentifiers(gomock.Any(), []models.DeviceIdentifier{deviceID}).Return(nil, nil).Times(1)
+	mockDeviceStore.EXPECT().UpsertDeviceStatuses(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	mockDataStore.EXPECT().InsertMinerStateSnapshot(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockDataStore.EXPECT().StoreDeviceMetrics(gomock.Any(), metric).Return(nil).Times(1)
+	mockMinerGetter.EXPECT().GetMinerFromDeviceIdentifier(gomock.Any(), deviceID).Return(mockMiner, nil).Times(2)
+	mockMiner.EXPECT().GetOrgID().Return(int64(0)).AnyTimes()
+	mockMiner.EXPECT().GetSiteID().Return(int64(0)).AnyTimes()
+	mockMiner.EXPECT().GetDriverName().Return("").AnyTimes()
+	mockMiner.EXPECT().GetDeviceMetrics(gomock.Any()).DoAndReturn(func(context.Context) (modelsV2.DeviceMetrics, error) {
+		close(refreshStarted)
+		<-releaseRefresh
+		return metric, nil
+	}).Times(1)
+	mockErrorPoller.EXPECT().PollErrors(gomock.Any(), mockMiner).Return(diagnostics.PollResult{}).Times(1)
 
-	mockDataStore.EXPECT().
-		InsertMinerStateSnapshot(gomock.Any(), gomock.Any()).
-		Return(nil).
-		AnyTimes()
+	service := NewTelemetryService(Config{
+		StalenessThreshold:  time.Minute,
+		FetchInterval:       time.Hour,
+		ConcurrencyLimit:    1,
+		DevicePollInterval:  time.Hour,
+		StatusFlushInterval: time.Hour,
+		MetricTimeout:       time.Second,
+	}, mockDataStore, mockMinerGetter, mockScheduler, mockDeviceStore, mockErrorPoller)
 
-	config := Config{
-		StalenessThreshold: 1 * time.Minute,
-		FetchInterval:      100 * time.Millisecond, // Short interval for test
-		ConcurrencyLimit:   5,
-		DevicePollInterval: 100 * time.Millisecond, // Short interval for test
+	require.NoError(t, service.Start(t.Context()))
+	refreshDone := make(chan error, 1)
+	go func() {
+		refreshDone <- service.RefreshDevice(t.Context(), device)
+	}()
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("RefreshDevice did not start")
 	}
 
-	service := NewTelemetryService(config, mockDataStore, mockMinerGetter, mockScheduler, mockDeviceStore, mock.NewMockErrorPoller(ctrl))
+	assertRefreshClaimed := func() {
+		claim, ok := service.inFlight.Load(deviceID)
+		require.True(t, ok)
+		assert.Equal(t, inFlightKindFullTelemetry, claim)
+	}
+	assertRefreshClaimed()
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	require.NoError(t, service.Stop(t.Context()))
+	assertRefreshClaimed()
+	require.NoError(t, service.Start(t.Context()))
+	assertRefreshClaimed()
 
-	// Start the service first
-	err := service.Start(ctx)
-	require.NoError(t, err)
-
-	// Let it run briefly
-	time.Sleep(50 * time.Millisecond)
-
-	// Test that Stop works without error
-	err = service.Stop(ctx)
-	require.NoError(t, err)
-
-	// Give time for goroutines to clean up
-	time.Sleep(100 * time.Millisecond)
+	close(releaseRefresh)
+	require.NoError(t, <-refreshDone)
+	_, claimed := service.inFlight.Load(deviceID)
+	assert.False(t, claimed)
+	require.NoError(t, service.Stop(t.Context()))
 }
 
 // FakeTelemetryData is no longer used - tests now use DeviceMetrics v2 model
@@ -2815,17 +2817,15 @@ func TestProcessStatusOnly_ConnectionError_SetsStatusOffline(t *testing.T) {
 	ctx := t.Context()
 	device := models.Device{ID: deviceID}
 
-	var receivedResult statusResult
-	go func() {
-		select {
-		case receivedResult = <-service.statusResults:
-		case <-time.After(1 * time.Second):
-		}
-	}()
-
 	// Act
 	service.processStatusOnly(ctx, device)
-	time.Sleep(50 * time.Millisecond)
+
+	var receivedResult statusResult
+	select {
+	case receivedResult = <-service.statusResults:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for status result")
+	}
 
 	// Assert - status is still written to DB for UI visibility
 	assert.Equal(t, deviceID, receivedResult.deviceIdentifier)
@@ -3073,17 +3073,15 @@ func TestProcessDevice_HealthHealthyActive_SkipsGetDeviceStatus(t *testing.T) {
 
 	ctx := t.Context()
 
-	var receivedResult statusResult
-	go func() {
-		select {
-		case receivedResult = <-service.statusResults:
-		case <-time.After(1 * time.Second):
-		}
-	}()
-
 	// Act
 	require.NoError(t, service.processDevice(ctx, device))
-	time.Sleep(50 * time.Millisecond)
+
+	var receivedResult statusResult
+	select {
+	case receivedResult = <-service.statusResults:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for status result")
+	}
 
 	// Assert — status was derived from metrics health, no GetDeviceStatus call.
 	assert.Equal(t, deviceID, receivedResult.deviceIdentifier)

--- a/server/internal/handlers/errorquery/handler_test.go
+++ b/server/internal/handlers/errorquery/handler_test.go
@@ -200,7 +200,7 @@ func TestHandler_GetError(t *testing.T) {
 			mockTransactor := storesMocks.NewMockTransactor(ctrl)
 			tt.setupMocks(mockErrorStore)
 
-			diagnosticsSvc := diagnostics.NewService(context.Background(), diagnostics.Config{}, mockErrorStore, mockTransactor)
+			diagnosticsSvc := diagnostics.NewService(diagnostics.Config{}, mockErrorStore, mockTransactor)
 			handler := NewHandler(diagnosticsSvc)
 
 			ctx := tt.setupContext()

--- a/server/internal/infrastructure/queue/interface.go
+++ b/server/internal/infrastructure/queue/interface.go
@@ -34,8 +34,8 @@ type MessageQueue interface {
 	// EnqueueMany adds commands with per-device payloads in one atomic operation.
 	EnqueueMany(ctx context.Context, commandBatchLogUUID string, commandType commandtype.Type, messages []EnqueueMessage) error
 
-	// Dequeue retrieves and locks batch of commands for processing
-	Dequeue(ctx context.Context) ([]Message, error)
+	// Dequeue retrieves and locks at most limit commands for processing.
+	Dequeue(ctx context.Context, limit int32) ([]Message, error)
 
 	// MarkSuccess updates a command as successfully processed.
 	// Returns ErrStale if the message is no longer PROCESSING.

--- a/server/internal/infrastructure/queue/mocks/mock_message_queue.go
+++ b/server/internal/infrastructure/queue/mocks/mock_message_queue.go
@@ -43,18 +43,18 @@ func (m *MockMessageQueue) EXPECT() *MockMessageQueueMockRecorder {
 }
 
 // Dequeue mocks base method.
-func (m *MockMessageQueue) Dequeue(ctx context.Context) ([]queue.Message, error) {
+func (m *MockMessageQueue) Dequeue(ctx context.Context, limit int32) ([]queue.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dequeue", ctx)
+	ret := m.ctrl.Call(m, "Dequeue", ctx, limit)
 	ret0, _ := ret[0].([]queue.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Dequeue indicates an expected call of Dequeue.
-func (mr *MockMessageQueueMockRecorder) Dequeue(ctx any) *gomock.Call {
+func (mr *MockMessageQueueMockRecorder) Dequeue(ctx, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dequeue", reflect.TypeOf((*MockMessageQueue)(nil).Dequeue), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dequeue", reflect.TypeOf((*MockMessageQueue)(nil).Dequeue), ctx, limit)
 }
 
 // Enqueue mocks base method.

--- a/server/internal/infrastructure/queue/service.go
+++ b/server/internal/infrastructure/queue/service.go
@@ -76,11 +76,17 @@ func (d DatabaseMessageQueue) enqueueEncoded(ctx context.Context, commandBatchLo
 	})
 }
 
-func (d DatabaseMessageQueue) Dequeue(ctx context.Context) ([]Message, error) {
+func (d DatabaseMessageQueue) Dequeue(ctx context.Context, limit int32) ([]Message, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	if d.config.DequeLimit > 0 {
+		limit = min(limit, d.config.DequeLimit)
+	}
 	messages, err := db.WithTransaction(ctx, d.conn, func(q *sqlc.Queries) ([]Message, error) {
 		dbMessages, err := q.GetMessagesToProcess(ctx, sqlc.GetMessagesToProcessParams{
 			RetryCount: d.config.MaxFailureRetries,
-			Limit:      d.config.DequeLimit,
+			Limit:      limit,
 		})
 		if err != nil {
 			return nil, fleeterror.NewInternalErrorf("failed to get messages to process: %v", err)

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -1,0 +1,188 @@
+// Package runtimejobs provides lifecycle management for Fleet background jobs.
+package runtimejobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+)
+
+// Lifecycle is implemented by independently activatable background work.
+//
+// Start must return only after startup has succeeded or failed. A failed Start
+// must leave the lifecycle stopped and safe to start again. Stop must honor its
+// context, fully drain the activation before returning nil, and allow a later
+// Start.
+type Lifecycle interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+}
+
+// Job is a validated, named Lifecycle managed by a Group.
+type Job struct {
+	name      string
+	lifecycle Lifecycle
+}
+
+var _ Lifecycle = Job{}
+
+// NewJob validates and names a lifecycle for runtime orchestration.
+func NewJob(name string, lifecycle Lifecycle) (Job, error) {
+	job := Job{name: name, lifecycle: lifecycle}
+	if err := job.validate(); err != nil {
+		return Job{}, err
+	}
+	return job, nil
+}
+
+// Name identifies the job within its group.
+func (j Job) Name() string {
+	return j.name
+}
+
+// Start delegates activation to the job's lifecycle.
+func (j Job) Start(ctx context.Context) error {
+	return j.lifecycle.Start(ctx)
+}
+
+// Stop delegates cleanup to the job's lifecycle.
+func (j Job) Stop(ctx context.Context) error {
+	return j.lifecycle.Stop(ctx)
+}
+
+func (j Job) validate() error {
+	if j.name == "" {
+		return errors.New("name must not be empty")
+	}
+	if j.lifecycle == nil {
+		return errors.New("lifecycle must not be nil")
+	}
+	return nil
+}
+
+// Group owns at most one activation of an ordered set of jobs at a time.
+//
+// Lifecycle operations are serialized. A group can restart after a clean stop,
+// but incomplete cleanup permanently prevents another activation.
+type Group struct {
+	mu sync.Mutex
+
+	cleanupTimeout time.Duration
+	jobs           []Job
+	terminalErr    error
+	cancel         context.CancelFunc
+}
+
+// NewGroup validates jobs and creates a stopped group. cleanupTimeout is one
+// wall-clock budget shared by every job during a stop or startup rollback.
+func NewGroup(jobs []Job, cleanupTimeout time.Duration) (*Group, error) {
+	if cleanupTimeout <= 0 {
+		return nil, errors.New("runtime job cleanup timeout must be positive")
+	}
+	seen := make(map[string]struct{}, len(jobs))
+	for i, job := range jobs {
+		if err := job.validate(); err != nil {
+			return nil, fmt.Errorf("runtime job %d: %w", i, err)
+		}
+		if _, ok := seen[job.Name()]; ok {
+			return nil, fmt.Errorf("runtime job name %q appears more than once", job.Name())
+		}
+		seen[job.Name()] = struct{}{}
+	}
+
+	return &Group{
+		cleanupTimeout: cleanupTimeout,
+		jobs:           slices.Clone(jobs),
+	}, nil
+}
+
+// Start starts every job in registration order.
+func (g *Group) Start(ctx context.Context) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.terminalErr != nil {
+		return fmt.Errorf("runtime job group cannot restart after incomplete cleanup: %w", g.terminalErr)
+	}
+	if g.cancel != nil {
+		return nil
+	}
+
+	activationCtx, cancel := context.WithCancel(ctx)
+	g.cancel = cancel
+	started := 0
+	for _, job := range g.jobs {
+		if err := activationCtx.Err(); err != nil {
+			return g.failStart(ctx, started, fmt.Errorf("start runtime job %q: %w", job.Name(), err))
+		}
+		if err := job.Start(activationCtx); err != nil {
+			return g.failStart(ctx, started, fmt.Errorf("start runtime job %q: %w", job.Name(), err))
+		}
+		started++
+	}
+
+	return nil
+}
+
+func (g *Group) failStart(ctx context.Context, started int, startErr error) error {
+	g.cancel()
+	rollbackErr := g.stopJobs(ctx, g.jobs[:started])
+	g.cancel = nil
+	if rollbackErr == nil {
+		return startErr
+	}
+
+	g.terminalErr = errors.Join(startErr, fmt.Errorf("rollback runtime jobs: %w", rollbackErr))
+	return g.terminalErr
+}
+
+// Stop broadcasts cancellation, then stops jobs in reverse registration order.
+func (g *Group) Stop(ctx context.Context) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.terminalErr != nil {
+		return g.terminalErr
+	}
+	if g.cancel == nil {
+		return nil
+	}
+
+	g.cancel()
+	g.cancel = nil
+	if err := g.stopJobs(ctx, g.jobs); err != nil {
+		g.terminalErr = err
+		return err
+	}
+	return nil
+}
+
+func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
+	stopCtx, cancel := context.WithTimeout(parent, g.cleanupTimeout)
+	defer cancel()
+
+	var stopErrors []error
+	for _, job := range slices.Backward(jobs) {
+		result := make(chan error, 1)
+		stopGoroutineStarted := make(chan struct{})
+		go func() {
+			close(stopGoroutineStarted)
+			result <- job.Stop(stopCtx)
+		}()
+		<-stopGoroutineStarted
+
+		var err error
+		select {
+		case err = <-result:
+		case <-stopCtx.Done():
+			err = stopCtx.Err()
+		}
+		if err != nil {
+			stopErrors = append(stopErrors, fmt.Errorf("stop runtime job %q: %w", job.Name(), err))
+		}
+	}
+	return errors.Join(stopErrors...)
+}

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -1,0 +1,359 @@
+package runtimejobs
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewJobValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewJob("", testLifecycle{start: noopJob, stop: noopJob})
+	require.EqualError(t, err, "name must not be empty")
+
+	_, err = NewJob("job", nil)
+	require.EqualError(t, err, "lifecycle must not be nil")
+}
+
+func TestNewGroupValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewGroup([]Job{{name: "job"}}, time.Second)
+	require.ErrorContains(t, err, "runtime job 0: lifecycle must not be nil")
+
+	job := newTestJob("job", nil, nil)
+	_, err = NewGroup([]Job{job, job}, time.Second)
+	require.ErrorContains(t, err, "appears more than once")
+
+	_, err = NewGroup(nil, 0)
+	require.ErrorContains(t, err, "cleanup timeout must be positive")
+}
+
+func TestGroupStartsInOrderAndStopsInReverseAfterBroadcastingCancellation(t *testing.T) {
+	t.Parallel()
+
+	var events eventLog
+	makeJob := func(name string) Job {
+		var activationDone <-chan struct{}
+		return newTestJob(
+			name,
+			func(ctx context.Context) error {
+				activationDone = ctx.Done()
+				events.add("start:" + name)
+				return nil
+			},
+			func(context.Context) error {
+				select {
+				case <-activationDone:
+				default:
+					return errors.New("activation context was not canceled before stop")
+				}
+				events.add("stop:" + name)
+				return nil
+			},
+		)
+	}
+
+	group := newTestGroup(t, makeJob("a"), makeJob("b"), makeJob("c"))
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+
+	assert.Equal(t, []string{
+		"start:a", "start:b", "start:c",
+		"stop:c", "stop:b", "stop:a",
+	}, events.snapshot())
+}
+
+func TestGroupRollsBackCleanlyAndCanRetry(t *testing.T) {
+	t.Parallel()
+
+	var events eventLog
+	var failingStarts atomic.Int32
+	makeJob := func(name string) Job {
+		return newTestJob(
+			name,
+			func(context.Context) error {
+				events.add("start:" + name)
+				if name == "c" && failingStarts.Add(1) == 1 {
+					return errors.New("start c")
+				}
+				return nil
+			},
+			func(context.Context) error {
+				events.add("stop:" + name)
+				return nil
+			},
+		)
+	}
+	group := newTestGroup(t, makeJob("a"), makeJob("b"), makeJob("c"))
+
+	err := group.Start(context.Background())
+	require.ErrorContains(t, err, "start c")
+	assert.Equal(t, []string{"start:a", "start:b", "start:c", "stop:b", "stop:a"}, events.snapshot())
+
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+}
+
+func TestGroupRollbackUsesStartDeadline(t *testing.T) {
+	t.Parallel()
+
+	rollbackDeadline := make(chan time.Time, 1)
+	group := newTestGroup(t,
+		newTestJob("started", nil, func(ctx context.Context) error {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return errors.New("rollback context has no deadline")
+			}
+			rollbackDeadline <- deadline
+			return nil
+		}),
+		newTestJob("fails", func(context.Context) error { return errors.New("start failed") }, nil),
+	)
+
+	startCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	wantDeadline, ok := startCtx.Deadline()
+	require.True(t, ok)
+
+	require.ErrorContains(t, group.Start(startCtx), "start failed")
+	assert.True(t, wantDeadline.Equal(<-rollbackDeadline), "rollback must retain the Start caller's deadline")
+}
+
+func TestGroupRollbackFailureIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	rollbackErr := errors.New("rollback failed")
+	group := newTestGroup(t,
+		newTestJob("a", nil, func(context.Context) error { return rollbackErr }),
+		newTestJob("b", func(context.Context) error { return errors.New("start failed") }, nil),
+	)
+
+	err := group.Start(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rollbackErr)
+
+	err = group.Start(context.Background())
+	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
+	assert.ErrorIs(t, err, rollbackErr)
+}
+
+func TestGroupStopAggregatesErrorsAndBecomesTerminal(t *testing.T) {
+	t.Parallel()
+
+	errA := errors.New("stop a")
+	errB := errors.New("stop b")
+	group := newTestGroup(t,
+		newTestJob("a", nil, func(context.Context) error { return errA }),
+		newTestJob("b", nil, func(context.Context) error { return errB }),
+	)
+	require.NoError(t, group.Start(context.Background()))
+
+	err := group.Stop(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errA)
+	assert.ErrorIs(t, err, errB)
+
+	err = group.Start(context.Background())
+	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
+	assert.ErrorIs(t, err, errA)
+}
+
+func TestGroupStopTimeoutIsGroupWideAndTerminal(t *testing.T) {
+	t.Parallel()
+
+	stopEntered := make(chan struct{})
+	allowStop := make(chan struct{})
+	defer close(allowStop)
+	group, err := NewGroup([]Job{newTestJob(
+		"stuck",
+		noopJob,
+		func(context.Context) error {
+			close(stopEntered)
+			<-allowStop
+			return nil
+		},
+	)}, 20*time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, group.Start(context.Background()))
+
+	started := time.Now()
+	err = group.Stop(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	select {
+	case <-stopEntered:
+	default:
+		t.Fatal("stop was not attempted")
+	}
+
+	err = group.Start(context.Background())
+	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
+}
+
+func TestGroupStopSharesOneDeadlineAcrossJobs(t *testing.T) {
+	t.Parallel()
+
+	deadlines := make(chan time.Time, 2)
+	makeJob := func(name string, waitForDeadline bool) Job {
+		return newTestJob(
+			name,
+			noopJob,
+			func(ctx context.Context) error {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					return errors.New("stop context has no deadline")
+				}
+				deadlines <- deadline
+				if waitForDeadline {
+					<-ctx.Done()
+					return ctx.Err()
+				}
+				time.Sleep(10 * time.Millisecond)
+				return nil
+			},
+		)
+	}
+	group, err := NewGroup([]Job{
+		makeJob("waits-for-deadline", true),
+		makeJob("uses-part-of-budget", false),
+	}, 30*time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, group.Start(context.Background()))
+	require.ErrorIs(t, group.Stop(context.Background()), context.DeadlineExceeded)
+
+	first := <-deadlines
+	second := <-deadlines
+	assert.True(t, first.Equal(second), "every job must receive the same group-wide deadline")
+}
+
+func TestGroupStopHonorsCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	stopEntered := make(chan struct{})
+	releaseStop := make(chan struct{})
+	defer close(releaseStop)
+	group := newTestGroup(t, newTestJob(
+		"job",
+		nil,
+		func(context.Context) error {
+			close(stopEntered)
+			<-releaseStop
+			return nil
+		},
+	))
+	require.NoError(t, group.Start(context.Background()))
+
+	stopCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := group.Stop(stopCtx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	select {
+	case <-stopEntered:
+	default:
+		t.Fatal("stop was not attempted")
+	}
+}
+
+func TestGroupStartAndStopAreIdempotent(t *testing.T) {
+	t.Parallel()
+
+	var starts atomic.Int32
+	var stops atomic.Int32
+	group := newTestGroup(t, newTestJob(
+		"job",
+		func(context.Context) error { starts.Add(1); return nil },
+		func(context.Context) error { stops.Add(1); return nil },
+	))
+
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+	assert.Equal(t, int32(1), starts.Load())
+	assert.Equal(t, int32(1), stops.Load())
+}
+
+func TestGroupRestartUsesFreshActivationContext(t *testing.T) {
+	t.Parallel()
+
+	var contexts []context.Context
+	group := newTestGroup(t, newTestJob(
+		"job",
+		func(ctx context.Context) error {
+			contexts = append(contexts, ctx)
+			return nil
+		},
+		noopJob,
+	))
+
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+	require.NoError(t, group.Start(context.Background()))
+
+	require.Len(t, contexts, 2)
+	first := contexts[0]
+	second := contexts[1]
+	select {
+	case <-first.Done():
+	default:
+		t.Fatal("first activation context was not canceled")
+	}
+	select {
+	case <-second.Done():
+		t.Fatal("second activation context should still be active")
+	default:
+	}
+	require.NoError(t, group.Stop(context.Background()))
+}
+
+func newTestGroup(t *testing.T, jobs ...Job) *Group {
+	t.Helper()
+	group, err := NewGroup(jobs, time.Second)
+	require.NoError(t, err)
+	return group
+}
+
+func newTestJob(name string, start, stop func(context.Context) error) Job {
+	if start == nil {
+		start = noopJob
+	}
+	if stop == nil {
+		stop = noopJob
+	}
+	job, err := NewJob(name, testLifecycle{start: start, stop: stop})
+	if err != nil {
+		panic(err)
+	}
+	return job
+}
+
+func noopJob(context.Context) error { return nil }
+
+type testLifecycle struct {
+	start func(context.Context) error
+	stop  func(context.Context) error
+}
+
+func (l testLifecycle) Start(ctx context.Context) error { return l.start(ctx) }
+func (l testLifecycle) Stop(ctx context.Context) error  { return l.stop(ctx) }
+
+type eventLog struct {
+	events []string
+}
+
+func (l *eventLog) add(event string) {
+	l.events = append(l.events, event)
+}
+
+func (l *eventLog) snapshot() []string {
+	return append([]string(nil), l.events...)
+}

--- a/server/internal/testutil/service_provider.go
+++ b/server/internal/testutil/service_provider.go
@@ -149,7 +149,7 @@ func NewServiceProvider(t *testing.T, db *sql.DB, config *Config) *ServiceProvid
 
 	executionServiceCtx, executionServiceCancel := context.WithCancel(t.Context())
 
-	executionService := command.NewExecutionService(executionServiceCtx, commandConfig, db, dbMessageQueue, encryptService, tokenService, minerService, deviceStore, nil, filesService)
+	executionService := command.NewExecutionService(commandConfig, db, dbMessageQueue, encryptService, tokenService, minerService, deviceStore, nil, filesService)
 	err = executionService.Start(executionServiceCtx)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Reviewable diff: +921/-300 across 11 files (excludes generated, test, and story files).

## Summary

Fleet's long-running server work now shares one restartable lifecycle contract. This gives the upcoming HA supervisor a safe boundary for stopping active work on demotion and starting it again on activation without rebuilding the process. Standalone `fleetd` behavior remains intact while the jobs are prepared for catalog-driven startup.

**Stack:**

1. **This PR (1/2): runtime lifecycle foundation and service hardening**
2. Follow-up PR B: declare the 12-job catalog and cut `fleetd` startup/shutdown over to the runtime group

Job selection, configuration filtering, passive-mode coordinator wiring, and epoch fencing are intentionally outside this PR. Catalog policy and construction land in PR B; coordinator behavior follows the catalog cutover.

## How it works

Restartable background work implements `Lifecycle`: `Start(context.Context) error` activates it, while `Stop(context.Context) error` cancels and drains that activation within the caller's budget. A `Job` adds the validated runtime name, delegates that lifecycle, and itself implements `Lifecycle`; services do not need a second "named job" abstraction.

The runtime group receives an ordered list of jobs, validates unique names, and starts them in order. If startup fails partway through, it cancels the activation and rolls back the successfully started prefix in reverse order. Normal shutdown follows the same cancel-then-reverse-stop path. Rollback and shutdown each use one group-wide cleanup deadline, capped by any earlier caller deadline; incomplete cleanup permanently blocks reactivation so a new owner cannot overlap surviving work.

Command execution, telemetry, scheduling, IP scanning, diagnostics, MQTT ingest, alert metrics, and curtailment reconciliation now expose the same lifecycle shape and keep fresh cancellation/drain state per activation. Their stop paths prevent new work, wait for admitted goroutines, honor cancellation, and permit `Start -> Stop -> Start` after a clean drain. The diagnostics constructor is side-effect free, but `fleetd` explicitly starts the closer in this PR so stale errors continue to close before PR B lands.

Standalone shutdown gives jobs the existing 10-second graceful budget followed, when needed, by one additional 10-second drain window after forced cancellation. Teardown continues if a dependency still does not drain, so one stuck job cannot block process shutdown indefinitely; MQTT and diagnostics retain their already-bounded teardown behavior.

```mermaid
flowchart TB
    C["Catalog and scope selection (PR B)"] --> J["Validated named Job"]
    L["Concrete Lifecycle"] --> J
    J --> G["Runtime Group"]
    G --> S["Start jobs in order"]
    S --> A["Activation-scoped workers"]
    A --> X["Cancel activation"]
    X --> R["Stop jobs in reverse order"]
    R --> D["One group-wide cleanup deadline"]
    D --> OK["Stopped and restartable"]
    D --> F["Cleanup failure blocks reactivation"]
```

```mermaid
stateDiagram-v2
    [*] --> Stopped
    Stopped --> Starting: Start
    Starting --> Running: all jobs started
    Starting --> Stopped: rollback completed
    Starting --> Failed: rollback incomplete
    Running --> Stopped: stop completed
    Running --> Failed: stop incomplete
    Failed --> Failed: Start rejected with cleanup cause
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/runtimejobs/` (new) | Shared `Lifecycle`, validated named `Job`, and ordered `Group` | Review lifecycle delegation, rollback, reverse stop, shared cleanup budget, and terminal failure behavior |
| `server/internal/domain/command/`, `server/internal/testutil/` | Construction is context-free; processor, reaper, and workers share activation cancellation and drain tracking | Prevents command work from overlapping a later activation |
| `server/internal/domain/telemetry/` | Pollers and writers restart cleanly while per-organization broadcasters remain process-owned | Separates activation shutdown from process teardown |
| `server/internal/domain/schedule/` | Cron state is rebuilt per activation and startup recovery honors cancellation | Ensures demotion can stop recovery and scheduled callbacks safely |
| `server/internal/domain/ipscanner/` | Per-run queues, cancellation-aware sends, and bounded worker drain | Prevents blocked scan results from hanging lifecycle transitions |
| `server/internal/domain/curtailment/` | Reconciler, MQTT ingest, and alert metrics implement the shared lifecycle | Makes control loops quiesce before another activation begins |
| `server/internal/domain/diagnostics/` | Constructor is side-effect free; the closer implements the shared lifecycle | Allows passive construction without silently starting work |
| `server/cmd/fleetd/main.go` | Explicit standalone lifecycle startup and shutdown | Preserves current operation until the catalog cutover |

## Key technical decisions & trade-offs

- `Job` owns its name and validation while implementing and delegating `Lifecycle`; concrete services remain unaware of runtime catalog naming.
- The group manages lifecycle only; construction, enablement, scope, and catalog state stay outside until PR B has a concrete consumer.
- One cleanup budget, capped by the caller's deadline, covers the whole group rather than resetting a timeout per job and making total shutdown grow with catalog size.
- Incomplete rollback or shutdown is terminal rather than risking two activations that own the same work.
- Telemetry broadcasters remain process-owned across activation stops and close only during process teardown.
- Standalone wiring keeps existing shutdown guarantees; the catalog and supervisor become the owner only in later PRs.

## Related

Related: #740

## Testing & validation

- `go test -short -race -count=1` across `runtimejobs`, every hardened domain package, and `cmd/fleetd`
- `go test -short -run '^$' ./...` from `server/` to compile every server package
- `just _lint-server` (`golangci-lint`: 0 issues)
- Coverage includes ordered start/reverse stop, cancellation-before-stop, partial-start rollback, caller cancellation and shorter deadlines, a shared cleanup deadline, terminal cleanup failure, stop timeout recovery, restart after clean drain, and concrete lifecycle conformance

Coordinator transitions, epoch fencing, passive request gating, and the final 12-job catalog are not exercised here; those remain PR B and HA follow-up work.

## Post-Deploy Monitoring & Validation

No migration or configuration change is required. After deployment, verify that command execution, telemetry, scheduling, scanning, diagnostics, MQTT ingest, and curtailment loops start normally and that shutdown logs contain no `runtime job exceeded shutdown timeout` or `failed to drain runtime job` errors. Rollback is the previous server artifact; this PR introduces no persisted state.
