### PR TITLE
refactor(diagnostics): make error closer restartable (2/9)

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -390,11 +390,15 @@ func start(config *Config) error {
 		WithCommandSender(fleetNodeControlRegistry)
 
 	// Create diagnostics service for error polling and auto-closing stale errors
-	diagnosticsCtx, diagnosticsCancel := context.WithCancel(context.Background())
-	defer diagnosticsCancel()
 	errorStore := sqlstores.NewSQLErrorStore(conn, transactor)
-	diagnosticsService := diagnostics.NewService(diagnosticsCtx, config.Diagnostics, errorStore, transactor).
+	diagnosticsService := diagnostics.NewService(config.Diagnostics, errorStore, transactor).
 		WithDeviceScopeResolver(deviceStore)
+	if err := diagnosticsService.Start(context.Background()); err != nil {
+		return fmt.Errorf("start diagnostics error closer: %w", err)
+	}
+	defer func() {
+		stopStandaloneJob("diagnostics error closer", diagnosticsService)
+	}()
 
 	// Shared per-org cache for ListMinerStateSnapshots option arrays
 	// (models, firmware versions). The TTL is the primary freshness

--- a/server/internal/domain/diagnostics/closer_test.go
+++ b/server/internal/domain/diagnostics/closer_test.go
@@ -2,10 +2,12 @@ package diagnostics
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	storeMocks "github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
@@ -15,68 +17,18 @@ import (
 // runCloser Tests
 // ============================================================================
 
-func TestCloser_WithValidConfig_ShouldCallCloseStaleErrors(t *testing.T) {
+func TestNewService_DoesNotStartCloser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	mockStore.EXPECT().
-		CloseStaleErrors(gomock.Any(), 2*time.Minute).
-		Return(int64(5), nil).
-		MinTimes(1)
+	_ = NewService(Config{
+		CloserPollInterval: time.Millisecond,
+	}, mockStore, mockTransactor)
 
-	ctx, cancel := context.WithCancel(t.Context())
-	config := Config{
-		CloserPollInterval:       10 * time.Millisecond,
-		CloserStalenessThreshold: 2 * time.Minute,
-	}
-
-	_ = NewService(ctx, config, mockStore, mockTransactor)
-
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-}
-
-func TestCloser_WithZeroConfig_ShouldUseDefaults(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockStore := storeMocks.NewMockErrorStore(ctrl)
-	mockTransactor := storeMocks.NewMockTransactor(ctrl)
-
-	mockStore.EXPECT().
-		CloseStaleErrors(gomock.Any(), defaultCloserStalenessThreshold).
-		Return(int64(0), nil).
-		AnyTimes()
-
-	ctx, cancel := context.WithCancel(t.Context())
-	config := Config{}
-
-	_ = NewService(ctx, config, mockStore, mockTransactor)
-
+	// Construction must remain side-effect free so fleetd can decide which
+	// process-owned jobs to start for the current runtime mode.
 	time.Sleep(10 * time.Millisecond)
-	cancel()
-}
-
-func TestCloser_WhenContextCancelled_ShouldStop(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockStore := storeMocks.NewMockErrorStore(ctrl)
-	mockTransactor := storeMocks.NewMockTransactor(ctrl)
-
-	mockStore.EXPECT().
-		CloseStaleErrors(gomock.Any(), gomock.Any()).
-		Return(int64(0), nil).
-		AnyTimes()
-
-	ctx, cancel := context.WithCancel(t.Context())
-	config := Config{
-		CloserPollInterval:       10 * time.Millisecond,
-		CloserStalenessThreshold: 2 * time.Minute,
-	}
-
-	_ = NewService(ctx, config, mockStore, mockTransactor)
-
-	cancel()
-
-	time.Sleep(50 * time.Millisecond)
 }
 
 func TestCloser_WhenCloseStaleErrorsFails_ShouldContinuePolling(t *testing.T) {
@@ -84,14 +36,17 @@ func TestCloser_WhenCloseStaleErrorsFails_ShouldContinuePolling(t *testing.T) {
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
+	retried := make(chan struct{})
 	gomock.InOrder(
 		mockStore.EXPECT().
 			CloseStaleErrors(gomock.Any(), 2*time.Minute).
 			Return(int64(0), assert.AnError),
 		mockStore.EXPECT().
 			CloseStaleErrors(gomock.Any(), 2*time.Minute).
-			Return(int64(3), nil).
-			AnyTimes(),
+			DoAndReturn(func(context.Context, time.Duration) (int64, error) {
+				close(retried)
+				return 3, nil
+			}),
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -100,32 +55,48 @@ func TestCloser_WhenCloseStaleErrorsFails_ShouldContinuePolling(t *testing.T) {
 		CloserStalenessThreshold: 2 * time.Minute,
 	}
 
-	_ = NewService(ctx, config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
+	require.NoError(t, svc.Start(ctx))
 
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-retried:
+	case <-time.After(time.Second):
+		t.Fatal("closer did not poll again after an error")
+	}
 	cancel()
 }
 
-func TestCloser_WithNegativeConfig_ShouldUseDefaults(t *testing.T) {
+func TestCloser_CanRestartAfterStop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
+	var calls atomic.Int32
 	mockStore.EXPECT().
-		CloseStaleErrors(gomock.Any(), defaultCloserStalenessThreshold).
-		Return(int64(0), nil).
+		CloseStaleErrors(gomock.Any(), 2*time.Minute).
+		DoAndReturn(func(context.Context, time.Duration) (int64, error) {
+			calls.Add(1)
+			return 0, nil
+		}).
 		AnyTimes()
 
-	ctx, cancel := context.WithCancel(t.Context())
-	config := Config{
-		CloserPollInterval:       -10 * time.Second,
-		CloserStalenessThreshold: -2 * time.Minute,
-	}
+	svc := NewService(Config{
+		CloserPollInterval:       time.Millisecond,
+		CloserStalenessThreshold: 2 * time.Minute,
+	}, mockStore, mockTransactor)
 
-	_ = NewService(ctx, config, mockStore, mockTransactor)
+	require.NoError(t, svc.Start(t.Context()))
+	require.Eventually(t, func() bool {
+		return calls.Load() > 0
+	}, 100*time.Millisecond, time.Millisecond)
+	require.NoError(t, svc.Stop(t.Context()))
 
-	time.Sleep(10 * time.Millisecond)
-	cancel()
+	firstRunCalls := calls.Load()
+	require.NoError(t, svc.Start(t.Context()))
+	require.Eventually(t, func() bool {
+		return calls.Load() > firstRunCalls
+	}, 100*time.Millisecond, time.Millisecond)
+	require.NoError(t, svc.Stop(t.Context()))
 }
 
 // ============================================================================

--- a/server/internal/domain/diagnostics/closer_test.go
+++ b/server/internal/domain/diagnostics/closer_test.go
@@ -47,6 +47,10 @@ func TestCloser_WhenCloseStaleErrorsFails_ShouldContinuePolling(t *testing.T) {
 				close(retried)
 				return 3, nil
 			}),
+		mockStore.EXPECT().
+			CloseStaleErrors(gomock.Any(), 2*time.Minute).
+			Return(int64(0), nil).
+			AnyTimes(),
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -64,6 +68,7 @@ func TestCloser_WhenCloseStaleErrorsFails_ShouldContinuePolling(t *testing.T) {
 		t.Fatal("closer did not poll again after an error")
 	}
 	cancel()
+	require.NoError(t, svc.Stop(t.Context()))
 }
 
 func TestCloser_CanRestartAfterStop(t *testing.T) {
@@ -90,6 +95,108 @@ func TestCloser_CanRestartAfterStop(t *testing.T) {
 		return calls.Load() > 0
 	}, 100*time.Millisecond, time.Millisecond)
 	require.NoError(t, svc.Stop(t.Context()))
+
+	firstRunCalls := calls.Load()
+	require.NoError(t, svc.Start(t.Context()))
+	require.Eventually(t, func() bool {
+		return calls.Load() > firstRunCalls
+	}, 100*time.Millisecond, time.Millisecond)
+	require.NoError(t, svc.Stop(t.Context()))
+}
+
+func TestCloser_CanRestartAfterStartContextCancellation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockErrorStore(ctrl)
+	mockTransactor := storeMocks.NewMockTransactor(ctrl)
+
+	var calls atomic.Int32
+	mockStore.EXPECT().
+		CloseStaleErrors(gomock.Any(), 2*time.Minute).
+		DoAndReturn(func(context.Context, time.Duration) (int64, error) {
+			calls.Add(1)
+			return 0, nil
+		}).
+		AnyTimes()
+
+	svc := NewService(Config{
+		CloserPollInterval:       time.Millisecond,
+		CloserStalenessThreshold: 2 * time.Minute,
+	}, mockStore, mockTransactor)
+
+	runCtx, cancel := context.WithCancel(t.Context())
+	require.NoError(t, svc.Start(runCtx))
+	require.Eventually(t, func() bool {
+		return calls.Load() > 0
+	}, 100*time.Millisecond, time.Millisecond)
+
+	svc.closerMu.Lock()
+	done := svc.closerDone
+	svc.closerMu.Unlock()
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, time.Millisecond)
+
+	firstRunCalls := calls.Load()
+	require.NoError(t, svc.Start(t.Context()))
+	require.Eventually(t, func() bool {
+		return calls.Load() > firstRunCalls
+	}, 100*time.Millisecond, time.Millisecond)
+	require.NoError(t, svc.Stop(t.Context()))
+}
+
+func TestCloser_StopTimeoutAllowsRestartAfterRunExits(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockErrorStore(ctrl)
+	mockTransactor := storeMocks.NewMockTransactor(ctrl)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	mockStore.EXPECT().
+		CloseStaleErrors(gomock.Any(), 2*time.Minute).
+		DoAndReturn(func(context.Context, time.Duration) (int64, error) {
+			if calls.Add(1) == 1 {
+				close(entered)
+				<-release
+			}
+			return 0, nil
+		}).
+		AnyTimes()
+
+	svc := NewService(Config{
+		CloserPollInterval:       time.Millisecond,
+		CloserStalenessThreshold: 2 * time.Minute,
+	}, mockStore, mockTransactor)
+
+	require.NoError(t, svc.Start(t.Context()))
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("closer did not begin polling")
+	}
+
+	svc.closerMu.Lock()
+	done := svc.closerDone
+	svc.closerMu.Unlock()
+	stopCtx, cancelStop := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancelStop()
+	require.ErrorIs(t, svc.Stop(stopCtx), context.DeadlineExceeded)
+
+	close(release)
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, time.Millisecond)
 
 	firstRunCalls := calls.Load()
 	require.NoError(t, svc.Start(t.Context()))

--- a/server/internal/domain/diagnostics/service.go
+++ b/server/internal/domain/diagnostics/service.go
@@ -2,7 +2,9 @@ package diagnostics
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	fm "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
@@ -11,6 +13,7 @@ import (
 	minerInterfaces "github.com/block/proto-fleet/server/internal/domain/miner/interfaces"
 	minerModels "github.com/block/proto-fleet/server/internal/domain/miner/models"
 	storeInterfaces "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 // PollResult contains the outcome of a PollErrors operation.
@@ -38,20 +41,67 @@ type Service struct {
 	errorStore  storeInterfaces.ErrorStore
 	transactor  storeInterfaces.Transactor
 	deviceScope DeviceScopeResolver
+
+	closerMu       sync.Mutex
+	closerCancel   context.CancelFunc
+	closerDone     chan struct{}
+	closerStopping bool
 }
 
-// NewService creates a new diagnostics service and starts the error closer goroutine.
-// The closer runs until the provided context is cancelled.
-func NewService(ctx context.Context, config Config, errorStore storeInterfaces.ErrorStore, transactor storeInterfaces.Transactor) *Service {
-	s := &Service{
+var _ runtimejobs.Lifecycle = (*Service)(nil)
+
+// NewService creates a diagnostics service without starting background work.
+func NewService(config Config, errorStore storeInterfaces.ErrorStore, transactor storeInterfaces.Transactor) *Service {
+	return &Service{
 		config:     config,
 		errorStore: errorStore,
 		transactor: transactor,
 	}
+}
 
-	go s.runCloser(ctx)
+// Start starts the stale-error closer. Repeated starts are idempotent.
+func (s *Service) Start(ctx context.Context) error {
+	s.closerMu.Lock()
+	defer s.closerMu.Unlock()
 
-	return s
+	if s.closerStopping {
+		return fmt.Errorf("diagnostics error closer is still stopping")
+	}
+	if s.closerCancel != nil {
+		return nil
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	s.closerCancel = cancel
+	s.closerDone = done
+	go func() {
+		defer close(done)
+		s.runCloser(runCtx)
+	}()
+	return nil
+}
+
+// Stop cancels the stale-error closer and waits for it to drain.
+func (s *Service) Stop(ctx context.Context) error {
+	s.closerMu.Lock()
+	defer s.closerMu.Unlock()
+
+	if s.closerCancel == nil {
+		return nil
+	}
+
+	s.closerStopping = true
+	s.closerCancel()
+	select {
+	case <-s.closerDone:
+		s.closerCancel = nil
+		s.closerDone = nil
+		s.closerStopping = false
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("stop diagnostics error closer: %w", ctx.Err())
+	}
 }
 
 // WithDeviceScopeResolver wires the resolver used to translate a site scope

--- a/server/internal/domain/diagnostics/service.go
+++ b/server/internal/domain/diagnostics/service.go
@@ -62,12 +62,12 @@ func NewService(config Config, errorStore storeInterfaces.ErrorStore, transactor
 // Start starts the stale-error closer. Repeated starts are idempotent.
 func (s *Service) Start(ctx context.Context) error {
 	s.closerMu.Lock()
-	defer s.closerMu.Unlock()
-
 	if s.closerStopping {
+		s.closerMu.Unlock()
 		return fmt.Errorf("diagnostics error closer is still stopping")
 	}
 	if s.closerCancel != nil {
+		s.closerMu.Unlock()
 		return nil
 	}
 
@@ -75,8 +75,11 @@ func (s *Service) Start(ctx context.Context) error {
 	done := make(chan struct{})
 	s.closerCancel = cancel
 	s.closerDone = done
+	s.closerMu.Unlock()
+
 	go func() {
 		defer close(done)
+		defer s.clearCloserState(done)
 		s.runCloser(runCtx)
 	}()
 	return nil
@@ -85,23 +88,38 @@ func (s *Service) Start(ctx context.Context) error {
 // Stop cancels the stale-error closer and waits for it to drain.
 func (s *Service) Stop(ctx context.Context) error {
 	s.closerMu.Lock()
-	defer s.closerMu.Unlock()
-
 	if s.closerCancel == nil {
+		s.closerMu.Unlock()
 		return nil
 	}
 
 	s.closerStopping = true
-	s.closerCancel()
+	cancel := s.closerCancel
+	done := s.closerDone
+	s.closerMu.Unlock()
+
+	cancel()
 	select {
-	case <-s.closerDone:
-		s.closerCancel = nil
-		s.closerDone = nil
-		s.closerStopping = false
+	case <-done:
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("stop diagnostics error closer: %w", ctx.Err())
 	}
+}
+
+// clearCloserState releases lifecycle state for this specific run. The
+// identity check prevents an exiting goroutine from clearing a newer run.
+func (s *Service) clearCloserState(done chan struct{}) {
+	s.closerMu.Lock()
+	defer s.closerMu.Unlock()
+
+	if s.closerDone != done {
+		return
+	}
+
+	s.closerCancel = nil
+	s.closerDone = nil
+	s.closerStopping = false
 }
 
 // WithDeviceScopeResolver wires the resolver used to translate a site scope

--- a/server/internal/domain/diagnostics/service_test.go
+++ b/server/internal/domain/diagnostics/service_test.go
@@ -38,7 +38,7 @@ func newTestService(ctrl *gomock.Controller, mockErrorStore *storeMocks.MockErro
 			return fn(ctx)
 		},
 	).AnyTimes()
-	return NewService(context.Background(), Config{}, mockErrorStore, mockTransactor)
+	return NewService(Config{}, mockErrorStore, mockTransactor)
 }
 
 func TestPollErrors_WithNoMiners_ShouldReturnEmptyResult(t *testing.T) {

--- a/server/internal/domain/diagnostics/watcher_test.go
+++ b/server/internal/domain/diagnostics/watcher_test.go
@@ -27,7 +27,7 @@ func TestNewWatcher_WithValidConfig_ShouldUseConfigValues(t *testing.T) {
 		WatchPollInterval:  30 * time.Second,
 		WatchChannelBuffer: 20,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	w := newWatcher(svc, 1, nil, config)
 
@@ -46,7 +46,7 @@ func TestNewWatcher_WithZeroConfig_ShouldUseFallbackDefaults(t *testing.T) {
 		WatchPollInterval:  0, // Zero - should use default
 		WatchChannelBuffer: 0, // Zero - should use default
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	w := newWatcher(svc, 1, nil, config)
 
@@ -63,7 +63,7 @@ func TestNewWatcher_WithNegativeConfig_ShouldUseFallbackDefaults(t *testing.T) {
 		WatchPollInterval:  -5 * time.Second,
 		WatchChannelBuffer: -10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	w := newWatcher(svc, 1, nil, config)
 
@@ -76,7 +76,7 @@ func TestNewWatcher_WithNilOpts_ShouldCreateEmptyOpts(t *testing.T) {
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 
 	w := newWatcher(svc, 1, nil, Config{})
 
@@ -88,7 +88,7 @@ func TestNewWatcher_WithOpts_ShouldPreserveOpts(t *testing.T) {
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 	opts := &WatchOptions{
 		Filter: &models.QueryFilter{
 			DeviceIdentifiers: []string{"device-1"},
@@ -110,7 +110,7 @@ func TestBuildFilterWithTimeFrom_WithNoOptsFilter_ShouldSetTimeFromAndIncludeClo
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, Config{})
 	w.lastPollTime = time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 
@@ -126,7 +126,7 @@ func TestBuildFilterWithTimeFrom_WithOptsFilter_ShouldMergeFilters(t *testing.T)
 	mockStore := storeMocks.NewMockErrorStore(ctrl)
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 	opts := &WatchOptions{
 		Filter: &models.QueryFilter{
 			DeviceIdentifiers: []string{"device-1", "device-2"},
@@ -159,7 +159,7 @@ func TestBuildFilterWithTimeFrom_WithOptsFilterHavingTimeTo_ShouldIgnoreUserTime
 
 	userTimeFrom := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	userTimeTo := time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC)
-	svc := NewService(context.Background(), Config{}, mockStore, mockTransactor)
+	svc := NewService(Config{}, mockStore, mockTransactor)
 	opts := &WatchOptions{
 		Filter: &models.QueryFilter{
 			TimeFrom:      &userTimeFrom, // Should be ignored
@@ -191,7 +191,7 @@ func TestSendEvent_WithSpaceInChannel_ShouldSendUpdate(t *testing.T) {
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
 	config := Config{WatchChannelBuffer: 5}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	ctx := context.Background()
@@ -216,7 +216,7 @@ func TestSendEvent_WithFullChannel_ShouldDropUpdate(t *testing.T) {
 	mockTransactor := storeMocks.NewMockTransactor(ctrl)
 
 	config := Config{WatchChannelBuffer: 1}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	ctx := context.Background()
@@ -248,7 +248,7 @@ func TestSendEvent_WithCancelledContextAndFullChannel_ShouldNotBlock(t *testing.
 
 	// Use buffer size 1 and fill it
 	config := Config{WatchChannelBuffer: 1}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	// Fill the channel
@@ -293,7 +293,7 @@ func TestPollAndSend_WithNewError_ShouldSendKindOpened(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -326,7 +326,7 @@ func TestPollAndSend_WithUpdatedError_ShouldSendKindUpdated(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -357,7 +357,7 @@ func TestPollAndSend_WithClosedError_ShouldSendKindClosed(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -394,7 +394,7 @@ func TestPollAndSend_WithMixedErrorStates_ShouldSendAllThreeKinds(t *testing.T) 
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -436,7 +436,7 @@ func TestPollAndSend_WithErrorAtExactPollTime_ShouldClassifyAsOpened(t *testing.
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(mockErrors, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = pollTime
 
@@ -460,7 +460,7 @@ func TestPollAndSend_WithNoErrors_ShouldNotSendAnyUpdates(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return([]models.ErrorMessage{}, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = time.Now()
 
@@ -483,7 +483,7 @@ func TestPollAndSend_WhenQueryFails_ShouldNotSendUpdates(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 	w.lastPollTime = time.Now()
 
@@ -506,7 +506,7 @@ func TestPollAndSend_ShouldUpdateLastPollTime(t *testing.T) {
 	mockStore.EXPECT().QueryErrors(gomock.Any(), gomock.Any()).Return([]models.ErrorMessage{}, nil)
 
 	config := Config{WatchChannelBuffer: 10}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	originalTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -535,7 +535,7 @@ func TestRun_WithImmediateCancellation_ShouldCloseChannel(t *testing.T) {
 		WatchPollInterval:  100 * time.Millisecond,
 		WatchChannelBuffer: 5,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -578,7 +578,7 @@ func TestRun_WithCancellationAfterInitialPoll_ShouldCloseChannel(t *testing.T) {
 		WatchPollInterval:  500 * time.Millisecond, // Long interval so we can control cancellation
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 	w := newWatcher(svc, 1, nil, config)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -629,7 +629,7 @@ func TestWatch_ShouldReturnChannel(t *testing.T) {
 		WatchPollInterval:  100 * time.Millisecond,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -659,7 +659,7 @@ func TestWatch_WithOpts_ShouldUseFilter(t *testing.T) {
 		WatchPollInterval:  100 * time.Millisecond,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -687,7 +687,7 @@ func TestWatcherPoll_AppliesSiteScopeEachPoll(t *testing.T) {
 		WatchPollInterval:  100 * time.Millisecond,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor).WithDeviceScopeResolver(mockDeviceStore)
+	svc := NewService(config, mockStore, mockTransactor).WithDeviceScopeResolver(mockDeviceStore)
 	opts := &WatchOptions{
 		Filter: &models.QueryFilter{
 			SiteIDs:           []int64{7},
@@ -746,7 +746,7 @@ func TestWatch_ChannelClosesOnContextCancel(t *testing.T) {
 		WatchPollInterval:  50 * time.Millisecond,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -788,7 +788,7 @@ func TestWatch_SendsCorrectKindBasedOnErrorState(t *testing.T) {
 		WatchPollInterval:  1 * time.Second,
 		WatchChannelBuffer: 10,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -825,7 +825,7 @@ func TestWatch_UsesServiceConfig(t *testing.T) {
 		WatchPollInterval:  50 * time.Millisecond, // Short poll interval
 		WatchChannelBuffer: 3,
 	}
-	svc := NewService(context.Background(), config, mockStore, mockTransactor)
+	svc := NewService(config, mockStore, mockTransactor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/server/internal/handlers/errorquery/handler_test.go
+++ b/server/internal/handlers/errorquery/handler_test.go
@@ -200,7 +200,7 @@ func TestHandler_GetError(t *testing.T) {
 			mockTransactor := storesMocks.NewMockTransactor(ctrl)
 			tt.setupMocks(mockErrorStore)
 
-			diagnosticsSvc := diagnostics.NewService(context.Background(), diagnostics.Config{}, mockErrorStore, mockTransactor)
+			diagnosticsSvc := diagnostics.NewService(diagnostics.Config{}, mockErrorStore, mockTransactor)
 			handler := NewHandler(diagnosticsSvc)
 
 			ctx := tt.setupContext()


### PR DESCRIPTION
Reviewable diff: +81/-9 across 2 files (excludes generated, test, and story files).

## Summary

Diagnostics error closing is now explicitly activatable and restartable, so a passive Fleet can construct diagnostics without silently starting background work. Standalone `fleetd` still starts the closer during boot and drains it during shutdown.

**Stack:**

- Foundation: [#780](https://github.com/block/proto-fleet/pull/780) (merged)
- Parallel domain refactors: diagnostics [#781](https://github.com/block/proto-fleet/pull/781), IP scanning [#782](https://github.com/block/proto-fleet/pull/782), scheduling [#783](https://github.com/block/proto-fleet/pull/783), curtailment [#785](https://github.com/block/proto-fleet/pull/785), command execution [#787](https://github.com/block/proto-fleet/pull/787), and telemetry [#786](https://github.com/block/proto-fleet/pull/786)
- Orchestration: [#784](https://github.com/block/proto-fleet/pull/784)
- Catalog and `fleetd` cutover: [#788](https://github.com/block/proto-fleet/pull/788)

This PR is the **diagnostics lifecycle** slice and now targets `main`. Merged [#780](https://github.com/block/proto-fleet/pull/780) supplies the shared `runtimejobs.Lifecycle` contract; the remaining domain and orchestration refactors are independent sibling PRs and can merge in any order. #788 is temporarily based on the integration branch so its reviewable diff contains only catalog/cutover work; after the siblings merge it will be rebased and retargeted to `main`. Passive-mode coordinator wiring, epoch fencing, and request gating remain later HA work.

## How it works

`NewService` only constructs dependencies. `fleetd` calls `Start` explicitly, which creates one activation context and closer loop. The run identity-safely clears its own state before signaling completion, whether it ends through `Stop` or independent activation-context cancellation. `Stop` snapshots the run under the mutex, waits unlocked, and may return at the caller deadline while cleanup continues; restart is admitted after the prior run actually exits.

```mermaid
flowchart LR
    C["Construct diagnostics service"] --> S["fleetd calls Start"]
    S --> L["Error closer loop"]
    X["Shutdown or demotion"] --> T["Stop with deadline"]
    T --> L
    T --> R["Safe to start again"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/diagnostics/service.go` | Removes constructor side effects and adds restartable lifecycle state | Passive construction must not start active work |
| `server/cmd/fleetd/main.go` | Explicitly starts and boundedly stops diagnostics | Preserves current standalone behavior with no between-PR gap |
| Diagnostics and error-query tests | Update construction and cover restart/error behavior | Verifies the lifecycle boundary without changing query behavior |

## Key technical decisions & trade-offs

- Start diagnostics explicitly in this PR rather than waiting for catalog cutover, avoiding a period where stale miner errors would stop auto-closing.
- Keep lifecycle ownership on the existing `Service`; no diagnostics-specific job wrapper is introduced.

## Related

Related: #740

## Testing & validation

- `go test -short -race -count=1 ./internal/domain/diagnostics ./internal/handlers/errorquery ./cmd/fleetd`
- Covers side-effect-free construction, retry after a closer error, activation-context cancellation, timed-out stop cleanup, and `Start -> Stop -> Start`.

## Post-Deploy Monitoring & Validation

Watch diagnostics closer errors and verify stale miner errors continue to transition closed. Roll back if the closer stops running after startup or shutdown logs report a diagnostics drain failure.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)