### PR TITLE
refactor(ipscanner): isolate scanner activations (3/9)

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -462,9 +462,7 @@ func start(config *Config) error {
 	// Ensure IP scanner service cleanup on shutdown
 	defer func() {
 		slog.Info("Stopping IP scanner service")
-		if err := ipScannerService.Stop(); err != nil {
-			slog.Error("Failed to stop IP scanner service", "error", err)
-		}
+		stopStandaloneJob("IP scanner service", ipScannerService)
 	}()
 
 	dbMessageQueue := queue.NewDatabaseMessageQueue(&config.Queue, conn)

--- a/server/internal/domain/ipscanner/integration_test.go
+++ b/server/internal/domain/ipscanner/integration_test.go
@@ -115,7 +115,7 @@ func TestIPScannerService_RediscoverOfflineDeviceAtNewIP(t *testing.T) {
 	err := service.Start(testCtx)
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, service.Stop())
+		require.NoError(t, service.Stop(context.Background()))
 	}()
 
 	// Wait for the service to complete at least one scan cycle

--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -2,6 +2,8 @@ package ipscanner
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"sync"
@@ -10,7 +12,10 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/minerdiscovery"
 	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
+
+var errServiceStopping = errors.New("ip scanner service is still stopping")
 
 // Service orchestrates automatic IP address discovery for offline devices
 type Service struct {
@@ -22,12 +27,21 @@ type Service struct {
 	scanner               *NetworkScanner
 	logger                *slog.Logger
 
-	// Worker pool
-	tasks      chan SubnetScanTask
-	results    chan SubnetScanResult
-	cancelFunc context.CancelFunc
-	wg         sync.WaitGroup
-	mux        sync.Mutex // Prevents multiple instances of scanLoop from running
+	lifecycleMu sync.Mutex
+	run         *serviceRun
+}
+
+var _ runtimejobs.Lifecycle = (*Service)(nil)
+
+// serviceRun contains all state owned by a single activation. Keeping queues
+// here prevents stopped runs from leaking buffered work into a later Start.
+type serviceRun struct {
+	tasks    chan SubnetScanTask
+	results  chan SubnetScanResult
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	done     chan struct{}
+	stopping bool
 }
 
 // NewIPScannerService creates a new IP scanner service
@@ -47,8 +61,6 @@ func NewIPScannerService(
 		deviceIDCheckService:  deviceIDCheckService,
 		scanner:               NewNetworkScanner(discoverer, deviceIDCheckService, config.MaxConcurrentIPScansPerSubnet, logger),
 		logger:                logger.With("component", "ipscanner"),
-		tasks:                 make(chan SubnetScanTask, config.MaxConcurrentSubnetScans),
-		results:               make(chan SubnetScanResult, config.MaxConcurrentSubnetScans),
 	}
 }
 
@@ -59,21 +71,33 @@ func (s *Service) Start(ctx context.Context) error {
 		return nil
 	}
 
-	// Prevent multiple Start() calls from creating duplicate goroutines
-	if !s.mux.TryLock() {
-		s.logger.Warn("IP scanner service already started")
-		return nil
-	}
-	defer s.mux.Unlock()
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
 
-	// Check if already started by examining cancelFunc
-	if s.cancelFunc != nil {
-		s.logger.Warn("IP scanner service already running")
-		return nil
+	if s.run != nil {
+		select {
+		case <-s.run.done:
+			s.run = nil
+		default:
+			if s.run.stopping {
+				return errServiceStopping
+			}
+			s.logger.Warn("IP scanner service already running")
+			return nil
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("start ip scanner service: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	s.cancelFunc = cancel
+	run := &serviceRun{
+		tasks:   make(chan SubnetScanTask, s.config.MaxConcurrentSubnetScans),
+		results: make(chan SubnetScanResult, s.config.MaxConcurrentSubnetScans),
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+	s.run = run
 
 	s.logger.Info("Starting IP scanner service",
 		"scan_interval", s.config.ScanInterval,
@@ -83,55 +107,70 @@ func (s *Service) Start(ctx context.Context) error {
 
 	// Start worker pool
 	for i := range s.config.MaxConcurrentSubnetScans {
-		s.wg.Add(1)
-		go s.scanWorker(ctx, i)
+		run.wg.Go(func() { s.scanWorker(ctx, run, i) })
 	}
 
 	// Start result processor
-	s.wg.Add(1)
-	go s.resultProcessor(ctx)
+	run.wg.Go(func() { s.resultProcessor(ctx, run) })
 
 	// Start main scan loop
-	s.wg.Add(1)
-	go s.scanLoop(ctx)
+	run.wg.Go(func() { s.scanLoop(ctx, run) })
+
+	go func() {
+		run.wg.Wait()
+		close(run.done)
+	}()
 
 	return nil
 }
 
-// Stop gracefully stops the IP scanner service
-func (s *Service) Stop() error {
-	if s.cancelFunc != nil {
-		s.logger.Info("Stopping IP scanner service")
-		s.cancelFunc()
-		s.wg.Wait()
-		s.cancelFunc = nil // Reset to allow restart
-		s.logger.Info("IP scanner service stopped")
+// Stop gracefully stops the active scanner run, bounded by ctx.
+func (s *Service) Stop(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	run := s.run
+	if run == nil {
+		s.lifecycleMu.Unlock()
+		return nil
 	}
-	return nil
+	s.logger.Info("Stopping IP scanner service")
+	run.stopping = true
+	run.cancel()
+	s.lifecycleMu.Unlock()
+
+	select {
+	case <-run.done:
+		s.lifecycleMu.Lock()
+		if s.run == run {
+			s.run = nil
+		}
+		s.lifecycleMu.Unlock()
+		s.logger.Info("IP scanner service stopped")
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("stop ip scanner service: %w", ctx.Err())
+	}
 }
 
 // scanLoop periodically scans for offline devices
-func (s *Service) scanLoop(ctx context.Context) {
-	defer s.wg.Done()
-
+func (s *Service) scanLoop(ctx context.Context, run *serviceRun) {
 	ticker := time.NewTicker(s.config.ScanInterval)
 	defer ticker.Stop()
 
 	// Run immediately on start
-	s.scanOfflineDevices(ctx)
+	s.scanOfflineDevices(ctx, run.tasks)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.scanOfflineDevices(ctx)
+			s.scanOfflineDevices(ctx, run.tasks)
 		}
 	}
 }
 
 // scanOfflineDevices fetches offline devices and dispatches scan tasks grouped by subnet
-func (s *Service) scanOfflineDevices(ctx context.Context) {
+func (s *Service) scanOfflineDevices(ctx context.Context, tasks chan<- SubnetScanTask) {
 	s.logger.Debug("Scanning for offline devices")
 
 	// Fetch offline devices from the device store
@@ -242,7 +281,7 @@ func (s *Service) scanOfflineDevices(ctx context.Context) {
 
 		// Try to dispatch task with timeout (blocking)
 		select {
-		case s.tasks <- task:
+		case tasks <- task:
 			tasksDispatched++
 			s.logger.Debug("Dispatched subnet scan task",
 				"subnet", subnet,
@@ -274,9 +313,7 @@ func (s *Service) scanOfflineDevices(ctx context.Context) {
 }
 
 // scanWorker processes scan tasks from the queue
-func (s *Service) scanWorker(ctx context.Context, workerID int) {
-	defer s.wg.Done()
-
+func (s *Service) scanWorker(ctx context.Context, run *serviceRun, workerID int) {
 	logger := s.logger.With("worker_id", workerID)
 	logger.Debug("Starting scan worker")
 
@@ -284,12 +321,16 @@ func (s *Service) scanWorker(ctx context.Context, workerID int) {
 		select {
 		case <-ctx.Done():
 			return
-		case task, ok := <-s.tasks:
+		case task, ok := <-run.tasks:
 			if !ok {
 				return
 			}
 			result := s.processTask(ctx, task)
-			s.results <- result
+			select {
+			case run.results <- result:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }
@@ -330,14 +371,12 @@ func (s *Service) processTask(ctx context.Context, task SubnetScanTask) SubnetSc
 }
 
 // resultProcessor handles scan results
-func (s *Service) resultProcessor(ctx context.Context) {
-	defer s.wg.Done()
-
+func (s *Service) resultProcessor(ctx context.Context, run *serviceRun) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case result, ok := <-s.results:
+		case result, ok := <-run.results:
 			if !ok {
 				return
 			}

--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -90,7 +90,7 @@ func (s *Service) Start(ctx context.Context) error {
 		return fmt.Errorf("start ip scanner service: %w", err)
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	run := &serviceRun{
 		tasks:   make(chan SubnetScanTask, s.config.MaxConcurrentSubnetScans),
 		results: make(chan SubnetScanResult, s.config.MaxConcurrentSubnetScans),

--- a/server/internal/domain/ipscanner/service_test.go
+++ b/server/internal/domain/ipscanner/service_test.go
@@ -64,6 +64,50 @@ func TestIPScannerService_StartStopStart(t *testing.T) {
 	}
 }
 
+func TestIPScannerService_Start_CallerCancellationDoesNotStopRun(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	config := Config{
+		Enabled:                       true,
+		ScanInterval:                  10 * time.Millisecond,
+		MaxConcurrentSubnetScans:      1,
+		MaxConcurrentIPScansPerSubnet: 1,
+		ScanTimeout:                   time.Second,
+		SubnetMaskBits:                24,
+	}
+	deviceStore := storemocks.NewMockDeviceStore(ctrl)
+	scanned := make(chan struct{}, 2)
+	deviceStore.EXPECT().GetOfflineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, int) ([]stores.OfflineDeviceInfo, error) {
+			select {
+			case scanned <- struct{}{}:
+			default:
+			}
+			return nil, nil
+		},
+	).AnyTimes()
+	service := NewIPScannerService(
+		config,
+		deviceStore,
+		storemocks.NewMockDiscoveredDeviceStore(ctrl),
+		&noopDiscoverer{},
+		mocks.NewMockDeviceIdentityCheckService(ctrl),
+		slog.Default(),
+	)
+
+	startupCtx, cancelStartup := context.WithCancel(t.Context())
+	if err := service.Start(startupCtx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	waitForScannerSignal(t, scanned, "initial scan did not run")
+
+	cancelStartup()
+	waitForScannerSignal(t, scanned, "startup context cancellation stopped periodic scans")
+
+	if err := service.Stop(t.Context()); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+}
+
 func TestIPScannerService_Stop_CancelsWorkerBlockedOnFullResults(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	config := Config{

--- a/server/internal/domain/ipscanner/service_test.go
+++ b/server/internal/domain/ipscanner/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/block/proto-fleet/server/internal/domain/ipscanner/mocks"
 	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
+	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	storemocks "github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
 )
 
@@ -20,72 +21,135 @@ func (n *noopDiscoverer) Discover(ctx context.Context, ipAddress, port string) (
 	return nil, nil
 }
 
-func TestNewIPScannerService(t *testing.T) {
+func TestIPScannerService_StartStopStart(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	config := Config{
 		Enabled:                       true,
-		ScanInterval:                  5 * time.Minute,
-		MaxConcurrentSubnetScans:      5,
-		MaxConcurrentIPScansPerSubnet: 10,
-		ScanTimeout:                   30 * time.Second,
+		ScanInterval:                  time.Hour,
+		MaxConcurrentSubnetScans:      1,
+		MaxConcurrentIPScansPerSubnet: 1,
+		ScanTimeout:                   time.Second,
 		SubnetMaskBits:                24,
 	}
-
 	deviceStore := storemocks.NewMockDeviceStore(ctrl)
-	discoveredDeviceStore := storemocks.NewMockDiscoveredDeviceStore(ctrl)
-	discoverer := &noopDiscoverer{}
-	deviceIDCheckService := mocks.NewMockDeviceIdentityCheckService(ctrl)
-	logger := slog.Default()
+	scanned := make(chan struct{}, 2)
+	deviceStore.EXPECT().GetOfflineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, int) ([]stores.OfflineDeviceInfo, error) {
+			scanned <- struct{}{}
+			return nil, nil
+		},
+	).AnyTimes()
+	service := NewIPScannerService(
+		config,
+		deviceStore,
+		storemocks.NewMockDiscoveredDeviceStore(ctrl),
+		&noopDiscoverer{},
+		mocks.NewMockDeviceIdentityCheckService(ctrl),
+		slog.Default(),
+	)
 
-	service := NewIPScannerService(config, deviceStore, discoveredDeviceStore, discoverer, deviceIDCheckService, logger)
-
-	if service == nil {
-		t.Fatal("NewIPScannerService returned nil")
+	if err := service.Start(t.Context()); err != nil {
+		t.Fatalf("first Start failed: %v", err)
+	}
+	waitForScannerSignal(t, scanned, "first run did not scan")
+	if err := service.Stop(context.Background()); err != nil {
+		t.Fatalf("first Stop failed: %v", err)
+	}
+	if err := service.Start(t.Context()); err != nil {
+		t.Fatalf("second Start failed: %v", err)
+	}
+	waitForScannerSignal(t, scanned, "second run did not scan")
+	if err := service.Stop(context.Background()); err != nil {
+		t.Fatalf("second Stop failed: %v", err)
 	}
 }
 
-func TestIPScannerService_StartStop(t *testing.T) {
+func TestIPScannerService_Stop_CancelsWorkerBlockedOnFullResults(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	config := Config{
 		Enabled:                       true,
-		ScanInterval:                  100 * time.Millisecond,
-		MaxConcurrentSubnetScans:      2,
-		MaxConcurrentIPScansPerSubnet: 5,
-		ScanTimeout:                   1 * time.Second,
+		ScanInterval:                  time.Hour,
+		MaxConcurrentSubnetScans:      1,
+		MaxConcurrentIPScansPerSubnet: 1,
+		ScanTimeout:                   time.Second,
 		SubnetMaskBits:                24,
 	}
+	service := NewIPScannerService(
+		config,
+		storemocks.NewMockDeviceStore(ctrl),
+		storemocks.NewMockDiscoveredDeviceStore(ctrl),
+		&noopDiscoverer{},
+		mocks.NewMockDeviceIdentityCheckService(ctrl),
+		slog.Default(),
+	)
 
-	deviceStore := storemocks.NewMockDeviceStore(ctrl)
-	discoveredDeviceStore := storemocks.NewMockDiscoveredDeviceStore(ctrl)
-	discoverer := &noopDiscoverer{}
-	deviceIDCheckService := mocks.NewMockDeviceIdentityCheckService(ctrl)
-	logger := slog.Default()
+	ctx, cancel := context.WithCancel(t.Context())
+	run := &serviceRun{
+		tasks:   make(chan SubnetScanTask, 1),
+		results: make(chan SubnetScanResult, 1),
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+	service.run = run
+	run.results <- SubnetScanResult{}
+	run.tasks <- SubnetScanTask{Subnet: "invalid"}
+	run.wg.Go(func() { service.scanWorker(ctx, run, 0) })
+	go func() {
+		run.wg.Wait()
+		close(run.done)
+	}()
 
-	// Expect GetOfflineDevices to be called at least once
-	deviceStore.EXPECT().
-		GetOfflineDevices(gomock.Any(), gomock.Any()).
-		Return(nil, nil).
-		AnyTimes()
-
-	service := NewIPScannerService(config, deviceStore, discoveredDeviceStore, discoverer, deviceIDCheckService, logger)
-
-	ctx := t.Context()
-	err := service.Start(ctx)
-	if err != nil {
-		t.Fatalf("Failed to start service: %v", err)
+	deadline := time.Now().Add(time.Second)
+	for len(run.tasks) != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if len(run.tasks) != 0 {
+		t.Fatal("worker did not consume queued task")
+	}
+	select {
+	case <-run.done:
+		t.Fatal("worker unexpectedly exited while the result queue was full")
+	case <-time.After(10 * time.Millisecond):
 	}
 
-	// Give it a moment to start
-	time.Sleep(150 * time.Millisecond)
+	stopCtx, stopCancel := context.WithTimeout(t.Context(), time.Second)
+	defer stopCancel()
+	if err := service.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+}
 
-	// Stop the service
-	err = service.Stop()
-	if err != nil {
-		t.Fatalf("Failed to stop service: %v", err)
+func TestIPScannerService_Stop_ReturnsAtDeadline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	service := NewIPScannerService(
+		Config{Enabled: true, MaxConcurrentSubnetScans: 1, MaxConcurrentIPScansPerSubnet: 1},
+		storemocks.NewMockDeviceStore(ctrl),
+		storemocks.NewMockDiscoveredDeviceStore(ctrl),
+		&noopDiscoverer{},
+		mocks.NewMockDeviceIdentityCheckService(ctrl),
+		slog.Default(),
+	)
+	service.run = &serviceRun{
+		cancel: func() {},
+		done:   make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+	if err := service.Stop(ctx); err == nil {
+		t.Fatal("Stop returned nil after its deadline")
+	}
+	if err := service.Start(t.Context()); err == nil {
+		t.Fatal("Start succeeded while the prior run was still stopping")
+	}
+}
+
+func waitForScannerSignal(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal(message)
 	}
 }
 
@@ -172,7 +236,7 @@ func TestIPScannerService_PreventMultipleInstances(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Stop the service
-	err = service.Stop()
+	err = service.Stop(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to stop service: %v", err)
 	}


### PR DESCRIPTION
Reviewable diff: +90/-53 across 2 files (excludes generated, test, and story files).

## Summary

IP discovery now has activation-scoped queues and bounded shutdown, preventing one Fleet activation from leaking scan work or results into the next. Standalone scanning keeps its current startup behavior while gaining a clean `Start -> Stop -> Start` path.

**Stack:**

- Foundation: [#780](https://github.com/block/proto-fleet/pull/780) (merged)
- Parallel domain refactors: diagnostics [#781](https://github.com/block/proto-fleet/pull/781), IP scanning [#782](https://github.com/block/proto-fleet/pull/782), scheduling [#783](https://github.com/block/proto-fleet/pull/783), curtailment [#785](https://github.com/block/proto-fleet/pull/785), command execution [#787](https://github.com/block/proto-fleet/pull/787), and telemetry [#786](https://github.com/block/proto-fleet/pull/786)
- Orchestration: [#784](https://github.com/block/proto-fleet/pull/784)
- Catalog and `fleetd` cutover: [#788](https://github.com/block/proto-fleet/pull/788)

This PR is the **IP scanner lifecycle** slice and now targets `main`. Merged [#780](https://github.com/block/proto-fleet/pull/780) supplies the shared `runtimejobs.Lifecycle` contract; the remaining domain and orchestration refactors are independent sibling PRs and can merge in any order. #788 is temporarily based on the integration branch so its reviewable diff contains only catalog/cutover work; after the siblings merge it will be rebased and retargeted to `main`. Passive-mode coordinator wiring, epoch fencing, and request gating remain later HA work.

## How it works

Before this PR, the scanner's task queue, result queue, cancellation function, and goroutine tracking belonged to the long-lived service and assumed one activation for the lifetime of the process. Adding a lifecycle interface around that state would not make it safely restartable: buffered work could cross into a later activation, a worker blocked while publishing a result could prevent shutdown, and a timed-out stop could otherwise be followed by an overlapping start.

Each successful `Start` now creates fresh task and result channels plus service-owned cancellation, then launches the scanner workers for that activation. Worker sends select on cancellation, so a full result queue cannot trap shutdown. `Stop` cancels producers and consumers, waits for every activation-owned goroutine within the caller's deadline, and only then permits restart. The underlying discovery flow—selecting offline devices, grouping them by subnet, verifying identity, and persisting a corrected address—remains unchanged.

```mermaid
flowchart LR
    S["Start activation"] --> Q["Fresh task and result queues"]
    Q --> W["Scanner workers"]
    W --> C["Cancellation-aware result send"]
    X["Stop"] --> C
    X --> D["Drain activation goroutines"]
    D --> R["Fresh later activation"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/ipscanner/service.go` | Adds lifecycle state, per-run queues, cancellation-aware sends, and bounded drain | Prevents cross-activation results and shutdown hangs |
| `server/cmd/fleetd/main.go` | Routes scanner teardown through the bounded standalone helper | Preserves process shutdown limits |
| IP scanner tests | Add restart, blocked-send cancellation, and stop-deadline coverage | Exercises the concurrency edges introduced by activation switching |

## Key technical decisions & trade-offs

- Allocate queues per activation rather than draining shared queues after stop; ownership is clearer and stale results become unreachable.
- Keep a timed-out activation in `stopping` state so restart cannot overlap surviving scanner work.

## Related

Related: #740

## Testing & validation

- `go test -short -race -count=1 ./internal/domain/ipscanner ./cmd/fleetd`
- Covers duplicate start, restart, full result queue cancellation, and caller stop deadlines.

## Post-Deploy Monitoring & Validation

Watch IP scanner errors, scan completion rates, and shutdown drain logs through one normal scan interval. Roll back if scans stop being scheduled, discovered devices stop appearing, or scanner shutdown repeatedly exceeds its budget.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with_Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
