### PR TITLE
refactor(schedule): make processor restartable (4/9)

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -548,9 +548,7 @@ func start(config *Config) error {
 		return fmt.Errorf("failed to start schedule processor: %w", err)
 	}
 	defer func() {
-		if err := scheduleProcessor.Stop(); err != nil {
-			slog.Error("failed to stop schedule processor", "error", err)
-		}
+		stopStandaloneJob("schedule processor", scheduleProcessor)
 	}()
 
 	curtailmentRec := curtailmentReconciler.New(

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -2,6 +2,7 @@ package schedule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	scheduletargets "github.com/block/proto-fleet/server/internal/domain/schedule/targets"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 const (
@@ -28,14 +30,9 @@ const (
 	revertPerformanceMode = commandpb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY
 	schedulerActorName    = "scheduler"
 	oneTimeRetryDelay     = time.Second
-	// shutdownDeadline bounds Stop(): drain-before-cancel is the graceful
-	// path, the watchdog cancels workCtx if a DB/dispatch call wedges.
-	// Sized within the fleetd-wide shutdownTimeout (10s).
-	shutdownDeadline = 10 * time.Second
 )
 
-// shutdownDeadlineFn lets tests shrink the watchdog without affecting prod.
-var shutdownDeadlineFn = func() time.Duration { return shutdownDeadline }
+var errProcessorStopping = errors.New("schedule processor is still stopping")
 
 // CommandDispatcher is the subset of command.Service the processor needs.
 // CommandResult carries preflight skips for schedule-level audit.
@@ -64,14 +61,19 @@ type Processor struct {
 	activitySvc     *activity.Service
 	now             func() time.Time
 
-	stopCancel context.CancelFunc
-	workCancel context.CancelFunc
-	wg         sync.WaitGroup
-	timerWG    sync.WaitGroup
-	mu         sync.Mutex
-	jobs       map[int64]jobEntry
-	nextGen    uint64
+	stopCancel  context.CancelFunc
+	workCancel  context.CancelFunc
+	wg          sync.WaitGroup
+	timerWG     sync.WaitGroup
+	lifecycleMu sync.Mutex
+	running     bool
+	stopDone    chan struct{}
+	mu          sync.Mutex
+	jobs        map[int64]jobEntry
+	nextGen     uint64
 }
+
+var _ runtimejobs.Lifecycle = (*Processor)(nil)
 
 func NewProcessor(
 	procStore interfaces.ScheduleProcessorStore,
@@ -114,22 +116,40 @@ func scheduleFingerprint(sched *pb.Schedule) string {
 	return strings.Join(parts, "|")
 }
 
-func (p *Processor) Start(_ context.Context) error {
-	stopCtx, stopCancel := context.WithCancel(context.Background())
-	workCtx, workCancel := context.WithCancel(context.Background())
+func (p *Processor) Start(ctx context.Context) error {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+
+	if p.running {
+		return nil
+	}
+	if p.stopDone != nil {
+		return errProcessorStopping
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("schedule processor startup: %w", err)
+	}
+
+	// stopCtx follows the activation context so periodic producers stop as
+	// soon as ownership is withdrawn. workCtx keeps the caller's values but is
+	// cancelled by Stop after in-flight callbacks have had a chance to drain.
+	stopCtx, stopCancel := context.WithCancel(ctx)
+	workCtx, workCancel := context.WithCancel(context.WithoutCancel(ctx))
 	p.stopCancel = stopCancel
 	p.workCancel = workCancel
 
 	p.cron = cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)))
+	p.mu.Lock()
+	p.jobs = make(map[int64]jobEntry)
+	p.nextGen = 0
+	p.mu.Unlock()
 
-	if err := p.recoverStaleRunning(workCtx); err != nil {
-		stopCancel()
-		workCancel()
+	if err := p.recoverStaleRunning(stopCtx); err != nil {
+		p.resetFailedStart()
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
-	if err := p.syncSchedules(workCtx); err != nil {
-		stopCancel()
-		workCancel()
+	if err := p.syncSchedulesForRun(stopCtx, stopCtx, workCtx); err != nil {
+		p.resetFailedStart()
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
 
@@ -138,53 +158,113 @@ func (p *Processor) Start(_ context.Context) error {
 	p.wg.Add(2)
 	go p.reconcileLoop(stopCtx, workCtx)
 	go p.endOfWindowLoop(stopCtx, workCtx)
+	p.running = true
 
 	slog.Info("schedule processor started")
 	return nil
 }
 
-func (p *Processor) Stop() error {
-	// Watchdog bounds total shutdown: workCancel is idempotent, so an early
-	// fire just unblocks wedged in-flight calls; the drain sequence below
-	// still runs to completion.
-	if p.workCancel != nil {
-		watchdog := time.AfterFunc(shutdownDeadlineFn(), p.workCancel)
-		defer watchdog.Stop()
+// Stop gracefully stops the processor, bounded by ctx. A deadline
+// cancels in-flight work and returns to the caller; the processor remains in
+// the stopping state until its goroutines have actually drained, preventing a
+// later Start from overlapping the old activation.
+func (p *Processor) Stop(ctx context.Context) error {
+	done, workCancel := p.beginStop()
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		workCancel()
+		return fmt.Errorf("stop schedule processor: %w", ctx.Err())
+	}
+}
+
+func (p *Processor) beginStop() (<-chan struct{}, context.CancelFunc) {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+
+	workCancel := p.workCancel
+	if workCancel == nil {
+		workCancel = func() {}
+	}
+	if p.stopDone != nil {
+		return p.stopDone, workCancel
+	}
+	if !p.running && p.stopCancel == nil && p.workCancel == nil && p.cron == nil {
+		return nil, func() {}
 	}
 
-	if p.stopCancel != nil {
-		p.stopCancel()
+	p.running = false
+	p.stopDone = make(chan struct{})
+	done := p.stopDone
+	stopCancel := p.stopCancel
+	cronRunner := p.cron
+
+	if stopCancel != nil {
+		stopCancel()
+	}
+	var cronCtx context.Context
+	if cronRunner != nil {
+		cronCtx = cronRunner.Stop()
 	}
 
-	// Stop cron before waiting on the loops so no new cron callbacks fire
-	// during shutdown. In-flight callbacks complete with workCtx still live;
-	// cron.Stop() returns a context that's done once they finish. AddFunc on
-	// a stopped cron appends to entries without firing, so a late
-	// registration from the reconcile loop's last iteration is harmless.
-	if p.cron != nil {
-		cronCtx := p.cron.Stop()
+	go p.finishStop(done, cronCtx, workCancel)
+	return done, workCancel
+}
+
+func (p *Processor) finishStop(done chan struct{}, cronCtx context.Context, workCancel context.CancelFunc) {
+	if cronCtx != nil {
 		<-cronCtx.Done()
 	}
-
 	p.wg.Wait()
 
 	p.mu.Lock()
 	for _, entry := range p.jobs {
-		if entry.isOneTime && entry.timer != nil {
-			if entry.timer.Stop() {
-				p.timerWG.Done()
-			}
+		if entry.isOneTime && entry.timer != nil && entry.timer.Stop() {
+			p.timerWG.Done()
 		}
 	}
 	p.mu.Unlock()
-
 	p.timerWG.Wait()
+	workCancel()
 
+	p.lifecycleMu.Lock()
+	p.mu.Lock()
+	p.jobs = make(map[int64]jobEntry)
+	p.nextGen = 0
+	p.mu.Unlock()
+	p.stopCancel = nil
+	p.workCancel = nil
+	p.cron = nil
+	p.stopDone = nil
+	close(done)
+	p.lifecycleMu.Unlock()
+	slog.Info("schedule processor stopped")
+}
+
+func (p *Processor) resetFailedStart() {
+	if p.stopCancel != nil {
+		p.stopCancel()
+	}
 	if p.workCancel != nil {
 		p.workCancel()
 	}
-	slog.Info("schedule processor stopped")
-	return nil
+	p.mu.Lock()
+	for _, entry := range p.jobs {
+		if entry.isOneTime && entry.timer != nil && entry.timer.Stop() {
+			p.timerWG.Done()
+		}
+	}
+	p.jobs = make(map[int64]jobEntry)
+	p.nextGen = 0
+	p.mu.Unlock()
+	p.timerWG.Wait()
+	p.stopCancel = nil
+	p.workCancel = nil
+	p.cron = nil
 }
 
 func (p *Processor) reconcileLoop(stopCtx, workCtx context.Context) {
@@ -196,7 +276,10 @@ func (p *Processor) reconcileLoop(stopCtx, workCtx context.Context) {
 		case <-stopCtx.Done():
 			return
 		case <-ticker.C:
-			if err := p.syncSchedules(workCtx); err != nil {
+			if stopCtx.Err() != nil {
+				return
+			}
+			if err := p.syncSchedulesForRun(stopCtx, workCtx, workCtx); err != nil {
 				slog.Error("reconciliation failed, will retry next cycle", "error", err)
 			}
 		}
@@ -212,6 +295,9 @@ func (p *Processor) endOfWindowLoop(stopCtx, workCtx context.Context) {
 		case <-stopCtx.Done():
 			return
 		case <-ticker.C:
+			if stopCtx.Err() != nil {
+				return
+			}
 			p.checkEndOfWindow(workCtx)
 		}
 	}
@@ -245,7 +331,11 @@ func (p *Processor) recoverStaleRunning(ctx context.Context) error {
 // syncSchedules loads active/running schedules from the DB, diffs against
 // registered jobs, and adds/removes/updates as needed.
 func (p *Processor) syncSchedules(ctx context.Context) error {
-	schedules, err := p.procStore.GetActiveSchedules(ctx)
+	return p.syncSchedulesForRun(ctx, ctx, ctx)
+}
+
+func (p *Processor) syncSchedulesForRun(stopCtx, queryCtx, workCtx context.Context) error {
+	schedules, err := p.procStore.GetActiveSchedules(queryCtx)
 	if err != nil {
 		return fmt.Errorf("failed to load active schedules: %w", err)
 	}
@@ -265,7 +355,7 @@ func (p *Processor) syncSchedules(ctx context.Context) error {
 			p.removeJobLocked(sw.Schedule.Id)
 		}
 
-		if err := p.registerJob(ctx, sw.Schedule); err != nil {
+		if err := p.registerJob(stopCtx, workCtx, sw.Schedule); err != nil {
 			slog.Error("failed to register job", "schedule_id", sw.Schedule.Id, "error", err)
 		}
 	}
@@ -278,7 +368,7 @@ func (p *Processor) syncSchedules(ctx context.Context) error {
 	return nil
 }
 
-func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
+func (p *Processor) registerJob(stopCtx, workCtx context.Context, sched *pb.Schedule) error {
 	scheduleID := sched.Id
 	generation := p.nextJobGenerationLocked()
 
@@ -294,7 +384,12 @@ func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 		p.timerWG.Add(1)
 		timer := time.AfterFunc(delay, func() {
 			defer p.timerWG.Done()
-			p.executeSchedule(ctx, scheduleID)
+			select {
+			case <-stopCtx.Done():
+				return
+			default:
+				p.executeSchedule(workCtx, scheduleID)
+			}
 		})
 		p.jobs[scheduleID] = jobEntry{timer: timer, isOneTime: true, fingerprint: scheduleFingerprint(sched), generation: generation}
 		return nil
@@ -309,7 +404,14 @@ func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 		return fmt.Errorf("failed to build cron expression: %w", err)
 	}
 
-	entryID, err := p.cron.AddFunc(cronExpr, func() { p.executeSchedule(ctx, scheduleID) })
+	entryID, err := p.cron.AddFunc(cronExpr, func() {
+		select {
+		case <-stopCtx.Done():
+			return
+		default:
+			p.executeSchedule(workCtx, scheduleID)
+		}
+	})
 	if err != nil {
 		return fmt.Errorf("failed to register cron job: %w", err)
 	}

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -61,15 +61,16 @@ type Processor struct {
 	activitySvc     *activity.Service
 	now             func() time.Time
 
-	stopCancel  context.CancelFunc
-	workCancel  context.CancelFunc
-	wg          sync.WaitGroup
-	timerWG     sync.WaitGroup
-	lifecycleMu sync.Mutex
-	stopDone    chan struct{}
-	mu          sync.Mutex
-	jobs        map[int64]jobEntry
-	nextGen     uint64
+	stopCancel     context.CancelFunc
+	workCancel     context.CancelFunc
+	activationDone <-chan struct{}
+	wg             sync.WaitGroup
+	timerWG        sync.WaitGroup
+	lifecycleMu    sync.Mutex
+	stopDone       chan struct{}
+	mu             sync.Mutex
+	jobs           map[int64]jobEntry
+	nextGen        uint64
 }
 
 var _ runtimejobs.Lifecycle = (*Processor)(nil)
@@ -123,7 +124,12 @@ func (p *Processor) Start(ctx context.Context) error {
 		return errProcessorStopping
 	}
 	if p.stopCancel != nil {
-		return nil
+		select {
+		case <-p.activationDone:
+			return errProcessorStopping
+		default:
+			return nil
+		}
 	}
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("schedule processor startup: %w", err)
@@ -136,6 +142,7 @@ func (p *Processor) Start(ctx context.Context) error {
 	workCtx, workCancel := context.WithCancel(context.WithoutCancel(ctx))
 	p.stopCancel = stopCancel
 	p.workCancel = workCancel
+	p.activationDone = stopCtx.Done()
 
 	p.cron = cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)))
 	p.mu.Lock()
@@ -157,15 +164,15 @@ func (p *Processor) Start(ctx context.Context) error {
 	p.wg.Add(2)
 	go p.reconcileLoop(stopCtx, workCtx)
 	go p.endOfWindowLoop(stopCtx, workCtx)
-	go p.stopOnActivationCancellation(stopCtx)
+	go p.stopOnActivationCancellation(p.activationDone)
 
 	slog.Info("schedule processor started")
 	return nil
 }
 
-func (p *Processor) stopOnActivationCancellation(stopCtx context.Context) {
-	<-stopCtx.Done()
-	p.beginStop()
+func (p *Processor) stopOnActivationCancellation(activationDone <-chan struct{}) {
+	<-activationDone
+	p.beginStop(activationDone)
 }
 
 // Stop gracefully stops the processor, bounded by ctx. A deadline
@@ -173,7 +180,7 @@ func (p *Processor) stopOnActivationCancellation(stopCtx context.Context) {
 // the stopping state until its goroutines have actually drained, preventing a
 // later Start from overlapping the old activation.
 func (p *Processor) Stop(ctx context.Context) error {
-	done, workCancel := p.beginStop()
+	done, workCancel := p.beginStop(nil)
 	if done == nil {
 		return nil
 	}
@@ -186,9 +193,12 @@ func (p *Processor) Stop(ctx context.Context) error {
 	}
 }
 
-func (p *Processor) beginStop() (<-chan struct{}, context.CancelFunc) {
+func (p *Processor) beginStop(activationDone <-chan struct{}) (<-chan struct{}, context.CancelFunc) {
 	p.lifecycleMu.Lock()
 	defer p.lifecycleMu.Unlock()
+	if activationDone != nil && p.activationDone != activationDone {
+		return nil, func() {}
+	}
 
 	workCancel := p.workCancel
 	if workCancel == nil {
@@ -241,6 +251,7 @@ func (p *Processor) finishStop(done chan struct{}, cronCtx context.Context, work
 	p.mu.Unlock()
 	p.stopCancel = nil
 	p.workCancel = nil
+	p.activationDone = nil
 	p.cron = nil
 	p.stopDone = nil
 	close(done)
@@ -253,6 +264,7 @@ func (p *Processor) resetFailedStart() {
 	p.workCancel()
 	p.stopCancel = nil
 	p.workCancel = nil
+	p.activationDone = nil
 	p.cron = nil
 }
 

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -62,6 +62,7 @@ type processorActivation struct {
 	cancelWork      context.CancelFunc
 	cron            *cron.Cron
 	startupDone     chan struct{}
+	startupErr      error
 	stopDone        chan struct{}
 	stopOnce        sync.Once
 	wg              sync.WaitGroup
@@ -80,6 +81,16 @@ func newProcessorActivation(ctx context.Context) *processorActivation {
 		startupDone:     make(chan struct{}),
 		stopDone:        make(chan struct{}),
 	}
+}
+
+func (a *processorActivation) startupResult() error {
+	if a.startupErr != nil {
+		return a.startupErr
+	}
+	if a.admissionCtx.Err() != nil {
+		return errProcessorStopping
+	}
+	return nil
 }
 
 type Processor struct {
@@ -150,10 +161,20 @@ func (p *Processor) Start(ctx context.Context) error {
 	p.lifecycleMu.Lock()
 	if active := p.activation; active != nil {
 		p.lifecycleMu.Unlock()
-		if active.admissionCtx.Err() != nil {
-			return errProcessorStopping
+		select {
+		case <-active.startupDone:
+			return active.startupResult()
+		case <-active.admissionCtx.Done():
+			// Startup failures publish their result before canceling admission.
+			select {
+			case <-active.startupDone:
+				return active.startupResult()
+			default:
+				return errProcessorStopping
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("schedule processor startup: %w", ctx.Err())
 		}
-		return nil
 	}
 	run := newProcessorActivation(ctx)
 	p.activation = run
@@ -182,10 +203,11 @@ func (p *Processor) Start(ctx context.Context) error {
 }
 
 func (p *Processor) failStart(run *processorActivation, err error) error {
+	run.startupErr = fmt.Errorf("schedule processor startup: %w", err)
 	close(run.startupDone)
 	p.beginStop(run)
 	<-run.stopDone
-	return fmt.Errorf("schedule processor startup: %w", err)
+	return run.startupErr
 }
 
 // Stop cancels the activation and waits for it to drain, bounded by ctx. The

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -30,6 +30,7 @@ const (
 	revertPerformanceMode = commandpb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY
 	schedulerActorName    = "scheduler"
 	oneTimeRetryDelay     = time.Second
+	scheduleStateTimeout  = 10 * time.Second
 )
 
 var errProcessorStopping = errors.New("schedule processor is still stopping")
@@ -416,7 +417,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 	sw, err := p.procStore.GetScheduleByID(ctx, scheduleID)
 	if err != nil {
 		slog.Error("failed to re-read schedule after status transition", "schedule_id", scheduleID, "error", err)
-		if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
+		if rerr := p.revertScheduleAfterClaim(ctx, scheduleID); rerr != nil {
 			slog.Error("failed to revert schedule after read failure", "schedule_id", scheduleID, "error", rerr)
 			return
 		}
@@ -433,7 +434,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 		startDate, err := parseDateInLocation(sched.StartDate, sched.Timezone)
 		if err == nil && now.Before(startDate) {
 			slog.Info("schedule start_date not reached, skipping execution", "schedule_id", scheduleID)
-			if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
+			if rerr := p.revertScheduleAfterClaim(ctx, scheduleID); rerr != nil {
 				slog.Error("failed to revert schedule before start_date", "schedule_id", scheduleID, "error", rerr)
 			}
 			return
@@ -451,7 +452,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 	deviceIdentifiers, err := p.resolveTargets(ctx, sched, orgID)
 	if err != nil {
 		slog.Error("failed to resolve targets", "schedule_id", scheduleID, "error", err)
-		if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
+		if rerr := p.revertScheduleAfterClaim(ctx, scheduleID); rerr != nil {
 			slog.Error("failed to revert schedule after target resolution failure", "schedule_id", scheduleID, "error", rerr)
 			return
 		}
@@ -479,7 +480,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 	result, err := p.dispatch(cmdCtx, sched, selector)
 	if err != nil {
 		slog.Error("failed to dispatch command", "schedule_id", scheduleID, "action", sched.Action, "error", err)
-		if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
+		if rerr := p.revertScheduleAfterClaim(ctx, scheduleID); rerr != nil {
 			slog.Error("failed to revert schedule after dispatch failure", "schedule_id", scheduleID, "error", rerr)
 			return
 		}
@@ -554,6 +555,20 @@ func (p *Processor) removeJobForRetry(scheduleID int64, gen uint64, hasGen bool)
 	p.removeJobIfCurrent(scheduleID, gen, hasGen)
 }
 
+// State writes after a schedule is claimed must outlive activation
+// cancellation so the row is not left running, but remain bounded.
+func (p *Processor) updateScheduleAfterClaim(ctx context.Context, scheduleID int64, lastRunAt, nextRunAt *int64, status string) error {
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scheduleStateTimeout)
+	defer cancel()
+	return p.procStore.UpdateScheduleAfterRun(writeCtx, scheduleID, lastRunAt, nextRunAt, status)
+}
+
+func (p *Processor) revertScheduleAfterClaim(ctx context.Context, scheduleID int64) error {
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scheduleStateTimeout)
+	defer cancel()
+	return p.procStore.RevertScheduleToActive(writeCtx, scheduleID)
+}
+
 func (p *Processor) dispatch(ctx context.Context, sched *pb.Schedule, selector *commandpb.DeviceSelector) (*command.CommandResult, error) {
 	switch sched.Action {
 	case pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET:
@@ -609,7 +624,7 @@ func (p *Processor) updateAfterRunWithGeneration(ctx context.Context, sched *pb.
 	nextRun, err := ComputeNextRun(sched, now)
 	if err != nil {
 		slog.Error("failed to compute next run, keeping active", "schedule_id", sched.Id, "error", err)
-		if uerr := p.procStore.UpdateScheduleAfterRun(ctx, sched.Id, &lastRun, nil, statusActive); uerr != nil {
+		if uerr := p.updateScheduleAfterClaim(ctx, sched.Id, &lastRun, nil, statusActive); uerr != nil {
 			slog.Error("failed to update schedule after run", "schedule_id", sched.Id, "error", uerr)
 		}
 		return
@@ -634,9 +649,9 @@ func (p *Processor) updateAfterRunWithGeneration(ctx context.Context, sched *pb.
 		nextRunPtr = &nru
 	}
 
-	if err := p.procStore.UpdateScheduleAfterRun(ctx, sched.Id, &lastRun, nextRunPtr, status); err != nil {
+	if err := p.updateScheduleAfterClaim(ctx, sched.Id, &lastRun, nextRunPtr, status); err != nil {
 		slog.Error("failed to update schedule after run, reverting to active", "schedule_id", sched.Id, "error", err)
-		if rerr := p.procStore.RevertScheduleToActive(ctx, sched.Id); rerr != nil {
+		if rerr := p.revertScheduleAfterClaim(ctx, sched.Id); rerr != nil {
 			slog.Error("failed to revert schedule after update failure", "schedule_id", sched.Id, "error", rerr)
 			return
 		}
@@ -657,9 +672,9 @@ func (p *Processor) transitionToCompleted(ctx context.Context, sched *pb.Schedul
 
 func (p *Processor) transitionToCompletedWithGeneration(ctx context.Context, sched *pb.Schedule, orgID int64, now time.Time, gen uint64, hasGen bool) {
 	lastRun := now.Unix()
-	if err := p.procStore.UpdateScheduleAfterRun(ctx, sched.Id, &lastRun, nil, statusCompleted); err != nil {
+	if err := p.updateScheduleAfterClaim(ctx, sched.Id, &lastRun, nil, statusCompleted); err != nil {
 		slog.Error("failed to transition schedule to completed, reverting to active", "schedule_id", sched.Id, "error", err)
-		if rerr := p.procStore.RevertScheduleToActive(ctx, sched.Id); rerr != nil {
+		if rerr := p.revertScheduleAfterClaim(ctx, sched.Id); rerr != nil {
 			slog.Error("failed to revert schedule after completion failure", "schedule_id", sched.Id, "error", rerr)
 			return
 		}

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -61,8 +61,7 @@ type Processor struct {
 	activitySvc     *activity.Service
 	now             func() time.Time
 
-	stopCancel     context.CancelFunc
-	workCancel     context.CancelFunc
+	runCancel      context.CancelFunc
 	activationDone <-chan struct{}
 	wg             sync.WaitGroup
 	timerWG        sync.WaitGroup
@@ -116,6 +115,7 @@ func scheduleFingerprint(sched *pb.Schedule) string {
 	return strings.Join(parts, "|")
 }
 
+// Start activates schedule processing for the lifetime of ctx.
 func (p *Processor) Start(ctx context.Context) error {
 	p.lifecycleMu.Lock()
 	defer p.lifecycleMu.Unlock()
@@ -123,7 +123,7 @@ func (p *Processor) Start(ctx context.Context) error {
 	if p.stopDone != nil {
 		return errProcessorStopping
 	}
-	if p.stopCancel != nil {
+	if p.runCancel != nil {
 		select {
 		case <-p.activationDone:
 			return errProcessorStopping
@@ -135,52 +135,44 @@ func (p *Processor) Start(ctx context.Context) error {
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
 
-	// stopCtx follows the activation context so periodic producers stop as
-	// soon as ownership is withdrawn. workCtx keeps the caller's values but is
-	// cancelled by Stop after in-flight callbacks have had a chance to drain.
-	stopCtx, stopCancel := context.WithCancel(ctx)
-	workCtx, workCancel := context.WithCancel(context.WithoutCancel(ctx))
-	p.stopCancel = stopCancel
-	p.workCancel = workCancel
-	p.activationDone = stopCtx.Done()
+	runCtx, runCancel := context.WithCancel(ctx)
+	activationDone := runCtx.Done()
+	p.runCancel = runCancel
+	p.activationDone = activationDone
 
 	p.cron = cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)))
-	p.mu.Lock()
-	p.jobs = make(map[int64]jobEntry)
-	p.nextGen = 0
-	p.mu.Unlock()
 
-	if err := p.recoverStaleRunning(stopCtx); err != nil {
+	if err := p.recoverStaleRunning(runCtx); err != nil {
 		p.resetFailedStart()
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
-	if err := p.syncSchedulesForRun(stopCtx, stopCtx, workCtx); err != nil {
+	if err := p.syncSchedules(runCtx); err != nil {
 		p.resetFailedStart()
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
 
 	p.cron.Start()
 
-	p.wg.Add(2)
-	go p.reconcileLoop(stopCtx, workCtx)
-	go p.endOfWindowLoop(stopCtx, workCtx)
-	go p.stopOnActivationCancellation(p.activationDone)
+	p.wg.Add(3)
+	go p.reconcileLoop(runCtx)
+	go p.endOfWindowLoop(runCtx)
+	go p.stopOnActivationCancellation(activationDone)
 
 	slog.Info("schedule processor started")
 	return nil
 }
 
 func (p *Processor) stopOnActivationCancellation(activationDone <-chan struct{}) {
+	defer p.wg.Done()
 	<-activationDone
-	p.beginStop(activationDone)
+	p.beginStop()
 }
 
-// Stop gracefully stops the processor, bounded by ctx. A deadline
-// cancels in-flight work and returns to the caller; the processor remains in
-// the stopping state until its goroutines have actually drained, preventing a
-// later Start from overlapping the old activation.
+// Stop cancels the activation and waits for it to drain, bounded by ctx. The
+// processor remains in the stopping state until its goroutines have actually
+// drained, preventing a later Start from overlapping the old activation.
 func (p *Processor) Stop(ctx context.Context) error {
-	done, workCancel := p.beginStop(nil)
+	done := p.beginStop()
 	if done == nil {
 		return nil
 	}
@@ -188,47 +180,39 @@ func (p *Processor) Stop(ctx context.Context) error {
 	case <-done:
 		return nil
 	case <-ctx.Done():
-		workCancel()
 		return fmt.Errorf("stop schedule processor: %w", ctx.Err())
 	}
 }
 
-func (p *Processor) beginStop(activationDone <-chan struct{}) (<-chan struct{}, context.CancelFunc) {
+func (p *Processor) beginStop() <-chan struct{} {
 	p.lifecycleMu.Lock()
 	defer p.lifecycleMu.Unlock()
-	if activationDone != nil && p.activationDone != activationDone {
-		return nil, func() {}
-	}
 
-	workCancel := p.workCancel
-	if workCancel == nil {
-		workCancel = func() {}
-	}
 	if p.stopDone != nil {
-		return p.stopDone, workCancel
+		return p.stopDone
 	}
-	if p.stopCancel == nil && p.workCancel == nil && p.cron == nil {
-		return nil, func() {}
+	if p.runCancel == nil && p.cron == nil {
+		return nil
 	}
 
 	p.stopDone = make(chan struct{})
 	done := p.stopDone
-	stopCancel := p.stopCancel
+	runCancel := p.runCancel
 	cronRunner := p.cron
 
-	if stopCancel != nil {
-		stopCancel()
+	if runCancel != nil {
+		runCancel()
 	}
 	var cronCtx context.Context
 	if cronRunner != nil {
 		cronCtx = cronRunner.Stop()
 	}
 
-	go p.finishStop(done, cronCtx, workCancel)
-	return done, workCancel
+	go p.finishStop(done, cronCtx)
+	return done
 }
 
-func (p *Processor) finishStop(done chan struct{}, cronCtx context.Context, workCancel context.CancelFunc) {
+func (p *Processor) finishStop(done chan struct{}, cronCtx context.Context) {
 	if cronCtx != nil {
 		<-cronCtx.Done()
 	}
@@ -242,15 +226,13 @@ func (p *Processor) finishStop(done chan struct{}, cronCtx context.Context, work
 	}
 	p.mu.Unlock()
 	p.timerWG.Wait()
-	workCancel()
 
 	p.lifecycleMu.Lock()
 	p.mu.Lock()
 	p.jobs = make(map[int64]jobEntry)
 	p.nextGen = 0
 	p.mu.Unlock()
-	p.stopCancel = nil
-	p.workCancel = nil
+	p.runCancel = nil
 	p.activationDone = nil
 	p.cron = nil
 	p.stopDone = nil
@@ -260,46 +242,44 @@ func (p *Processor) finishStop(done chan struct{}, cronCtx context.Context, work
 }
 
 func (p *Processor) resetFailedStart() {
-	p.stopCancel()
-	p.workCancel()
-	p.stopCancel = nil
-	p.workCancel = nil
+	p.runCancel()
+	p.runCancel = nil
 	p.activationDone = nil
 	p.cron = nil
 }
 
-func (p *Processor) reconcileLoop(stopCtx, workCtx context.Context) {
+func (p *Processor) reconcileLoop(ctx context.Context) {
 	defer p.wg.Done()
 	ticker := time.NewTicker(reconcileInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-stopCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if stopCtx.Err() != nil {
+			if ctx.Err() != nil {
 				return
 			}
-			if err := p.syncSchedulesForRun(stopCtx, workCtx, workCtx); err != nil {
+			if err := p.syncSchedules(ctx); err != nil {
 				slog.Error("reconciliation failed, will retry next cycle", "error", err)
 			}
 		}
 	}
 }
 
-func (p *Processor) endOfWindowLoop(stopCtx, workCtx context.Context) {
+func (p *Processor) endOfWindowLoop(ctx context.Context) {
 	defer p.wg.Done()
 	ticker := time.NewTicker(endOfWindowInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-stopCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if stopCtx.Err() != nil {
+			if ctx.Err() != nil {
 				return
 			}
-			p.checkEndOfWindow(workCtx)
+			p.checkEndOfWindow(ctx)
 		}
 	}
 }
@@ -332,11 +312,7 @@ func (p *Processor) recoverStaleRunning(ctx context.Context) error {
 // syncSchedules loads active/running schedules from the DB, diffs against
 // registered jobs, and adds/removes/updates as needed.
 func (p *Processor) syncSchedules(ctx context.Context) error {
-	return p.syncSchedulesForRun(ctx, ctx, ctx)
-}
-
-func (p *Processor) syncSchedulesForRun(stopCtx, queryCtx, workCtx context.Context) error {
-	schedules, err := p.procStore.GetActiveSchedules(queryCtx)
+	schedules, err := p.procStore.GetActiveSchedules(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to load active schedules: %w", err)
 	}
@@ -356,7 +332,7 @@ func (p *Processor) syncSchedulesForRun(stopCtx, queryCtx, workCtx context.Conte
 			p.removeJobLocked(sw.Schedule.Id)
 		}
 
-		if err := p.registerJob(stopCtx, workCtx, sw.Schedule); err != nil {
+		if err := p.registerJob(ctx, sw.Schedule); err != nil {
 			slog.Error("failed to register job", "schedule_id", sw.Schedule.Id, "error", err)
 		}
 	}
@@ -369,9 +345,17 @@ func (p *Processor) syncSchedulesForRun(stopCtx, queryCtx, workCtx context.Conte
 	return nil
 }
 
-func (p *Processor) registerJob(stopCtx, workCtx context.Context, sched *pb.Schedule) error {
+func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 	scheduleID := sched.Id
 	generation := p.nextJobGenerationLocked()
+	executeIfActive := func() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			p.executeSchedule(ctx, scheduleID)
+		}
+	}
 
 	if sched.ScheduleType == pb.ScheduleType_SCHEDULE_TYPE_ONE_TIME {
 		t, err := ParseScheduleTime(sched.StartDate, sched.StartTime, sched.Timezone)
@@ -385,12 +369,7 @@ func (p *Processor) registerJob(stopCtx, workCtx context.Context, sched *pb.Sche
 		p.timerWG.Add(1)
 		timer := time.AfterFunc(delay, func() {
 			defer p.timerWG.Done()
-			select {
-			case <-stopCtx.Done():
-				return
-			default:
-				p.executeSchedule(workCtx, scheduleID)
-			}
+			executeIfActive()
 		})
 		p.jobs[scheduleID] = jobEntry{timer: timer, isOneTime: true, fingerprint: scheduleFingerprint(sched), generation: generation}
 		return nil
@@ -405,14 +384,7 @@ func (p *Processor) registerJob(stopCtx, workCtx context.Context, sched *pb.Sche
 		return fmt.Errorf("failed to build cron expression: %w", err)
 	}
 
-	entryID, err := p.cron.AddFunc(cronExpr, func() {
-		select {
-		case <-stopCtx.Done():
-			return
-		default:
-			p.executeSchedule(workCtx, scheduleID)
-		}
-	})
+	entryID, err := p.cron.AddFunc(cronExpr, executeIfActive)
 	if err != nil {
 		return fmt.Errorf("failed to register cron job: %w", err)
 	}

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -159,9 +159,15 @@ func (p *Processor) Start(ctx context.Context) error {
 	go p.reconcileLoop(stopCtx, workCtx)
 	go p.endOfWindowLoop(stopCtx, workCtx)
 	p.running = true
+	go p.stopOnActivationCancellation(stopCtx)
 
 	slog.Info("schedule processor started")
 	return nil
+}
+
+func (p *Processor) stopOnActivationCancellation(stopCtx context.Context) {
+	<-stopCtx.Done()
+	p.beginStop()
 }
 
 // Stop gracefully stops the processor, bounded by ctx. A deadline

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -66,7 +66,6 @@ type Processor struct {
 	wg          sync.WaitGroup
 	timerWG     sync.WaitGroup
 	lifecycleMu sync.Mutex
-	running     bool
 	stopDone    chan struct{}
 	mu          sync.Mutex
 	jobs        map[int64]jobEntry
@@ -120,11 +119,11 @@ func (p *Processor) Start(ctx context.Context) error {
 	p.lifecycleMu.Lock()
 	defer p.lifecycleMu.Unlock()
 
-	if p.running {
-		return nil
-	}
 	if p.stopDone != nil {
 		return errProcessorStopping
+	}
+	if p.stopCancel != nil {
+		return nil
 	}
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("schedule processor startup: %w", err)
@@ -158,7 +157,6 @@ func (p *Processor) Start(ctx context.Context) error {
 	p.wg.Add(2)
 	go p.reconcileLoop(stopCtx, workCtx)
 	go p.endOfWindowLoop(stopCtx, workCtx)
-	p.running = true
 	go p.stopOnActivationCancellation(stopCtx)
 
 	slog.Info("schedule processor started")
@@ -199,11 +197,10 @@ func (p *Processor) beginStop() (<-chan struct{}, context.CancelFunc) {
 	if p.stopDone != nil {
 		return p.stopDone, workCancel
 	}
-	if !p.running && p.stopCancel == nil && p.workCancel == nil && p.cron == nil {
+	if p.stopCancel == nil && p.workCancel == nil && p.cron == nil {
 		return nil, func() {}
 	}
 
-	p.running = false
 	p.stopDone = make(chan struct{})
 	done := p.stopDone
 	stopCancel := p.stopCancel
@@ -252,22 +249,8 @@ func (p *Processor) finishStop(done chan struct{}, cronCtx context.Context, work
 }
 
 func (p *Processor) resetFailedStart() {
-	if p.stopCancel != nil {
-		p.stopCancel()
-	}
-	if p.workCancel != nil {
-		p.workCancel()
-	}
-	p.mu.Lock()
-	for _, entry := range p.jobs {
-		if entry.isOneTime && entry.timer != nil && entry.timer.Stop() {
-			p.timerWG.Done()
-		}
-	}
-	p.jobs = make(map[int64]jobEntry)
-	p.nextGen = 0
-	p.mu.Unlock()
-	p.timerWG.Wait()
+	p.stopCancel()
+	p.workCancel()
 	p.stopCancel = nil
 	p.workCancel = nil
 	p.cron = nil

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -30,7 +30,6 @@ const (
 	revertPerformanceMode = commandpb.PerformanceMode_PERFORMANCE_MODE_EFFICIENCY
 	schedulerActorName    = "scheduler"
 	oneTimeRetryDelay     = time.Second
-	scheduleStateTimeout  = 10 * time.Second
 )
 
 var errProcessorStopping = errors.New("schedule processor is still stopping")
@@ -47,13 +46,43 @@ type CommandDispatcher interface {
 type jobEntry struct {
 	entryID     cron.EntryID
 	timer       *time.Timer
+	activation  *processorActivation
 	isOneTime   bool
 	fingerprint string
 	generation  uint64
 }
 
-type Processor struct {
+// processorActivation separates stopping new work from canceling work that was
+// already admitted. Activation cancellation closes admission immediately;
+// admitted work is only force-canceled when Stop exhausts its deadline.
+type processorActivation struct {
+	admissionCtx    context.Context //nolint:containedctx // scoped to this activation's admission phase
+	cancelAdmission context.CancelFunc
+	workCtx         context.Context //nolint:containedctx // scoped to this activation's drain phase
+	cancelWork      context.CancelFunc
 	cron            *cron.Cron
+	startupDone     chan struct{}
+	stopDone        chan struct{}
+	stopOnce        sync.Once
+	wg              sync.WaitGroup
+	timerWG         sync.WaitGroup
+}
+
+func newProcessorActivation(ctx context.Context) *processorActivation {
+	admissionCtx, cancelAdmission := context.WithCancel(ctx)
+	workCtx, cancelWork := context.WithCancel(context.WithoutCancel(ctx))
+	return &processorActivation{
+		admissionCtx:    admissionCtx,
+		cancelAdmission: cancelAdmission,
+		workCtx:         workCtx,
+		cancelWork:      cancelWork,
+		cron:            cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger))),
+		startupDone:     make(chan struct{}),
+		stopDone:        make(chan struct{}),
+	}
+}
+
+type Processor struct {
 	procStore       interfaces.ScheduleProcessorStore
 	targetStore     interfaces.ScheduleTargetStore
 	collectionStore interfaces.CollectionStore
@@ -62,15 +91,11 @@ type Processor struct {
 	activitySvc     *activity.Service
 	now             func() time.Time
 
-	runCancel      context.CancelFunc
-	activationDone <-chan struct{}
-	wg             sync.WaitGroup
-	timerWG        sync.WaitGroup
-	lifecycleMu    sync.Mutex
-	stopDone       chan struct{}
-	mu             sync.Mutex
-	jobs           map[int64]jobEntry
-	nextGen        uint64
+	lifecycleMu sync.Mutex
+	activation  *processorActivation
+	mu          sync.Mutex
+	jobs        map[int64]jobEntry
+	nextGen     uint64
 }
 
 var _ runtimejobs.Lifecycle = (*Processor)(nil)
@@ -118,169 +143,138 @@ func scheduleFingerprint(sched *pb.Schedule) string {
 
 // Start activates schedule processing for the lifetime of ctx.
 func (p *Processor) Start(ctx context.Context) error {
-	p.lifecycleMu.Lock()
-	defer p.lifecycleMu.Unlock()
-
-	if p.stopDone != nil {
-		return errProcessorStopping
-	}
-	if p.runCancel != nil {
-		select {
-		case <-p.activationDone:
-			return errProcessorStopping
-		default:
-			return nil
-		}
-	}
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("schedule processor startup: %w", err)
 	}
 
-	runCtx, runCancel := context.WithCancel(ctx)
-	activationDone := runCtx.Done()
-	p.runCancel = runCancel
-	p.activationDone = activationDone
-
-	p.cron = cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger)))
-
-	if err := p.recoverStaleRunning(runCtx); err != nil {
-		p.resetFailedStart()
-		return fmt.Errorf("schedule processor startup: %w", err)
+	p.lifecycleMu.Lock()
+	if active := p.activation; active != nil {
+		p.lifecycleMu.Unlock()
+		if active.admissionCtx.Err() != nil {
+			return errProcessorStopping
+		}
+		return nil
 	}
-	if err := p.syncSchedules(runCtx); err != nil {
-		p.resetFailedStart()
-		return fmt.Errorf("schedule processor startup: %w", err)
+	run := newProcessorActivation(ctx)
+	p.activation = run
+	p.lifecycleMu.Unlock()
+
+	context.AfterFunc(run.admissionCtx, func() { p.beginStop(run) })
+
+	if err := p.recoverStaleRunning(run.admissionCtx); err != nil {
+		return p.failStart(run, err)
+	}
+	if err := p.syncSchedules(run.admissionCtx, run); err != nil {
+		return p.failStart(run, err)
+	}
+	if err := run.admissionCtx.Err(); err != nil {
+		return p.failStart(run, err)
 	}
 
-	p.cron.Start()
-
-	p.wg.Add(3)
-	go p.reconcileLoop(runCtx)
-	go p.endOfWindowLoop(runCtx)
-	go p.stopOnActivationCancellation(activationDone)
+	run.cron.Start()
+	run.wg.Add(2)
+	go p.reconcileLoop(run)
+	go p.endOfWindowLoop(run)
+	close(run.startupDone)
 
 	slog.Info("schedule processor started")
 	return nil
 }
 
-func (p *Processor) stopOnActivationCancellation(activationDone <-chan struct{}) {
-	defer p.wg.Done()
-	<-activationDone
-	p.beginStop()
+func (p *Processor) failStart(run *processorActivation, err error) error {
+	close(run.startupDone)
+	p.beginStop(run)
+	<-run.stopDone
+	return fmt.Errorf("schedule processor startup: %w", err)
 }
 
 // Stop cancels the activation and waits for it to drain, bounded by ctx. The
 // processor remains in the stopping state until its goroutines have actually
 // drained, preventing a later Start from overlapping the old activation.
 func (p *Processor) Stop(ctx context.Context) error {
-	done := p.beginStop()
-	if done == nil {
+	p.lifecycleMu.Lock()
+	run := p.activation
+	p.lifecycleMu.Unlock()
+	if run == nil {
 		return nil
 	}
+	p.beginStop(run)
 	select {
-	case <-done:
+	case <-run.stopDone:
 		return nil
 	case <-ctx.Done():
+		run.cancelWork()
 		return fmt.Errorf("stop schedule processor: %w", ctx.Err())
 	}
 }
 
-func (p *Processor) beginStop() <-chan struct{} {
-	p.lifecycleMu.Lock()
-	defer p.lifecycleMu.Unlock()
-
-	if p.stopDone != nil {
-		return p.stopDone
-	}
-	if p.runCancel == nil && p.cron == nil {
-		return nil
-	}
-
-	p.stopDone = make(chan struct{})
-	done := p.stopDone
-	runCancel := p.runCancel
-	cronRunner := p.cron
-
-	if runCancel != nil {
-		runCancel()
-	}
-	var cronCtx context.Context
-	if cronRunner != nil {
-		cronCtx = cronRunner.Stop()
-	}
-
-	go p.finishStop(done, cronCtx)
-	return done
+func (p *Processor) beginStop(run *processorActivation) {
+	run.stopOnce.Do(func() {
+		run.cancelAdmission()
+		go p.finishStop(run)
+	})
 }
 
-func (p *Processor) finishStop(done chan struct{}, cronCtx context.Context) {
-	if cronCtx != nil {
-		<-cronCtx.Done()
-	}
-	p.wg.Wait()
+func (p *Processor) finishStop(run *processorActivation) {
+	<-run.startupDone
+	<-run.cron.Stop().Done()
+	run.wg.Wait()
 
 	p.mu.Lock()
 	for _, entry := range p.jobs {
-		if entry.isOneTime && entry.timer != nil && entry.timer.Stop() {
-			p.timerWG.Done()
+		if entry.activation == run && entry.isOneTime && entry.timer != nil && entry.timer.Stop() {
+			run.timerWG.Done()
 		}
 	}
 	p.mu.Unlock()
-	p.timerWG.Wait()
+	run.timerWG.Wait()
+	run.cancelWork()
 
 	p.lifecycleMu.Lock()
 	p.mu.Lock()
 	p.jobs = make(map[int64]jobEntry)
 	p.nextGen = 0
 	p.mu.Unlock()
-	p.runCancel = nil
-	p.activationDone = nil
-	p.cron = nil
-	p.stopDone = nil
-	close(done)
+	if p.activation == run {
+		p.activation = nil
+	}
+	close(run.stopDone)
 	p.lifecycleMu.Unlock()
 	slog.Info("schedule processor stopped")
 }
 
-func (p *Processor) resetFailedStart() {
-	p.runCancel()
-	p.runCancel = nil
-	p.activationDone = nil
-	p.cron = nil
-}
-
-func (p *Processor) reconcileLoop(ctx context.Context) {
-	defer p.wg.Done()
+func (p *Processor) reconcileLoop(run *processorActivation) {
+	defer run.wg.Done()
 	ticker := time.NewTicker(reconcileInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-ctx.Done():
+		case <-run.admissionCtx.Done():
 			return
 		case <-ticker.C:
-			if ctx.Err() != nil {
+			if run.admissionCtx.Err() != nil {
 				return
 			}
-			if err := p.syncSchedules(ctx); err != nil {
+			if err := p.syncSchedules(run.workCtx, run); err != nil {
 				slog.Error("reconciliation failed, will retry next cycle", "error", err)
 			}
 		}
 	}
 }
 
-func (p *Processor) endOfWindowLoop(ctx context.Context) {
-	defer p.wg.Done()
+func (p *Processor) endOfWindowLoop(run *processorActivation) {
+	defer run.wg.Done()
 	ticker := time.NewTicker(endOfWindowInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-ctx.Done():
+		case <-run.admissionCtx.Done():
 			return
 		case <-ticker.C:
-			if ctx.Err() != nil {
+			if run.admissionCtx.Err() != nil {
 				return
 			}
-			p.checkEndOfWindow(ctx)
+			p.checkEndOfWindow(run.workCtx)
 		}
 	}
 }
@@ -312,7 +306,7 @@ func (p *Processor) recoverStaleRunning(ctx context.Context) error {
 
 // syncSchedules loads active/running schedules from the DB, diffs against
 // registered jobs, and adds/removes/updates as needed.
-func (p *Processor) syncSchedules(ctx context.Context) error {
+func (p *Processor) syncSchedules(ctx context.Context, run *processorActivation) error {
 	schedules, err := p.procStore.GetActiveSchedules(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to load active schedules: %w", err)
@@ -333,7 +327,7 @@ func (p *Processor) syncSchedules(ctx context.Context) error {
 			p.removeJobLocked(sw.Schedule.Id)
 		}
 
-		if err := p.registerJob(ctx, sw.Schedule); err != nil {
+		if err := p.registerJob(run, sw.Schedule); err != nil {
 			slog.Error("failed to register job", "schedule_id", sw.Schedule.Id, "error", err)
 		}
 	}
@@ -346,15 +340,15 @@ func (p *Processor) syncSchedules(ctx context.Context) error {
 	return nil
 }
 
-func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
+func (p *Processor) registerJob(run *processorActivation, sched *pb.Schedule) error {
 	scheduleID := sched.Id
 	generation := p.nextJobGenerationLocked()
 	executeIfActive := func() {
 		select {
-		case <-ctx.Done():
+		case <-run.admissionCtx.Done():
 			return
 		default:
-			p.executeSchedule(ctx, scheduleID)
+			p.executeSchedule(run.workCtx, scheduleID)
 		}
 	}
 
@@ -367,12 +361,12 @@ func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 		if delay < oneTimeRetryDelay {
 			delay = oneTimeRetryDelay
 		}
-		p.timerWG.Add(1)
+		run.timerWG.Add(1)
 		timer := time.AfterFunc(delay, func() {
-			defer p.timerWG.Done()
+			defer run.timerWG.Done()
 			executeIfActive()
 		})
-		p.jobs[scheduleID] = jobEntry{timer: timer, isOneTime: true, fingerprint: scheduleFingerprint(sched), generation: generation}
+		p.jobs[scheduleID] = jobEntry{timer: timer, activation: run, isOneTime: true, fingerprint: scheduleFingerprint(sched), generation: generation}
 		return nil
 	}
 
@@ -385,12 +379,12 @@ func (p *Processor) registerJob(ctx context.Context, sched *pb.Schedule) error {
 		return fmt.Errorf("failed to build cron expression: %w", err)
 	}
 
-	entryID, err := p.cron.AddFunc(cronExpr, executeIfActive)
+	entryID, err := run.cron.AddFunc(cronExpr, executeIfActive)
 	if err != nil {
 		return fmt.Errorf("failed to register cron job: %w", err)
 	}
 
-	p.jobs[scheduleID] = jobEntry{entryID: entryID, fingerprint: scheduleFingerprint(sched), generation: generation}
+	p.jobs[scheduleID] = jobEntry{entryID: entryID, activation: run, fingerprint: scheduleFingerprint(sched), generation: generation}
 	return nil
 }
 
@@ -417,7 +411,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 	sw, err := p.procStore.GetScheduleByID(ctx, scheduleID)
 	if err != nil {
 		slog.Error("failed to re-read schedule after status transition", "schedule_id", scheduleID, "error", err)
-		if rerr := p.revertScheduleAfterClaim(ctx, scheduleID); rerr != nil {
+		if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
 			slog.Error("failed to revert schedule after read failure", "schedule_id", scheduleID, "error", rerr)
 			return
 		}
@@ -434,7 +428,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 		startDate, err := parseDateInLocation(sched.StartDate, sched.Timezone)
 		if err == nil && now.Before(startDate) {
 			slog.Info("schedule start_date not reached, skipping execution", "schedule_id", scheduleID)
-			if rerr := p.revertScheduleAfterClaim(ctx, scheduleID); rerr != nil {
+			if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
 				slog.Error("failed to revert schedule before start_date", "schedule_id", scheduleID, "error", rerr)
 			}
 			return
@@ -452,7 +446,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 	deviceIdentifiers, err := p.resolveTargets(ctx, sched, orgID)
 	if err != nil {
 		slog.Error("failed to resolve targets", "schedule_id", scheduleID, "error", err)
-		if rerr := p.revertScheduleAfterClaim(ctx, scheduleID); rerr != nil {
+		if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
 			slog.Error("failed to revert schedule after target resolution failure", "schedule_id", scheduleID, "error", rerr)
 			return
 		}
@@ -480,7 +474,7 @@ func (p *Processor) executeSchedule(ctx context.Context, scheduleID int64) {
 	result, err := p.dispatch(cmdCtx, sched, selector)
 	if err != nil {
 		slog.Error("failed to dispatch command", "schedule_id", scheduleID, "action", sched.Action, "error", err)
-		if rerr := p.revertScheduleAfterClaim(ctx, scheduleID); rerr != nil {
+		if rerr := p.procStore.RevertScheduleToActive(ctx, scheduleID); rerr != nil {
 			slog.Error("failed to revert schedule after dispatch failure", "schedule_id", scheduleID, "error", rerr)
 			return
 		}
@@ -555,20 +549,6 @@ func (p *Processor) removeJobForRetry(scheduleID int64, gen uint64, hasGen bool)
 	p.removeJobIfCurrent(scheduleID, gen, hasGen)
 }
 
-// State writes after a schedule is claimed must outlive activation
-// cancellation so the row is not left running, but remain bounded.
-func (p *Processor) updateScheduleAfterClaim(ctx context.Context, scheduleID int64, lastRunAt, nextRunAt *int64, status string) error {
-	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scheduleStateTimeout)
-	defer cancel()
-	return p.procStore.UpdateScheduleAfterRun(writeCtx, scheduleID, lastRunAt, nextRunAt, status)
-}
-
-func (p *Processor) revertScheduleAfterClaim(ctx context.Context, scheduleID int64) error {
-	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scheduleStateTimeout)
-	defer cancel()
-	return p.procStore.RevertScheduleToActive(writeCtx, scheduleID)
-}
-
 func (p *Processor) dispatch(ctx context.Context, sched *pb.Schedule, selector *commandpb.DeviceSelector) (*command.CommandResult, error) {
 	switch sched.Action {
 	case pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET:
@@ -624,7 +604,7 @@ func (p *Processor) updateAfterRunWithGeneration(ctx context.Context, sched *pb.
 	nextRun, err := ComputeNextRun(sched, now)
 	if err != nil {
 		slog.Error("failed to compute next run, keeping active", "schedule_id", sched.Id, "error", err)
-		if uerr := p.updateScheduleAfterClaim(ctx, sched.Id, &lastRun, nil, statusActive); uerr != nil {
+		if uerr := p.procStore.UpdateScheduleAfterRun(ctx, sched.Id, &lastRun, nil, statusActive); uerr != nil {
 			slog.Error("failed to update schedule after run", "schedule_id", sched.Id, "error", uerr)
 		}
 		return
@@ -649,9 +629,9 @@ func (p *Processor) updateAfterRunWithGeneration(ctx context.Context, sched *pb.
 		nextRunPtr = &nru
 	}
 
-	if err := p.updateScheduleAfterClaim(ctx, sched.Id, &lastRun, nextRunPtr, status); err != nil {
+	if err := p.procStore.UpdateScheduleAfterRun(ctx, sched.Id, &lastRun, nextRunPtr, status); err != nil {
 		slog.Error("failed to update schedule after run, reverting to active", "schedule_id", sched.Id, "error", err)
-		if rerr := p.revertScheduleAfterClaim(ctx, sched.Id); rerr != nil {
+		if rerr := p.procStore.RevertScheduleToActive(ctx, sched.Id); rerr != nil {
 			slog.Error("failed to revert schedule after update failure", "schedule_id", sched.Id, "error", rerr)
 			return
 		}
@@ -672,9 +652,9 @@ func (p *Processor) transitionToCompleted(ctx context.Context, sched *pb.Schedul
 
 func (p *Processor) transitionToCompletedWithGeneration(ctx context.Context, sched *pb.Schedule, orgID int64, now time.Time, gen uint64, hasGen bool) {
 	lastRun := now.Unix()
-	if err := p.updateScheduleAfterClaim(ctx, sched.Id, &lastRun, nil, statusCompleted); err != nil {
+	if err := p.procStore.UpdateScheduleAfterRun(ctx, sched.Id, &lastRun, nil, statusCompleted); err != nil {
 		slog.Error("failed to transition schedule to completed, reverting to active", "schedule_id", sched.Id, "error", err)
-		if rerr := p.revertScheduleAfterClaim(ctx, sched.Id); rerr != nil {
+		if rerr := p.procStore.RevertScheduleToActive(ctx, sched.Id); rerr != nil {
 			slog.Error("failed to revert schedule after completion failure", "schedule_id", sched.Id, "error", rerr)
 			return
 		}
@@ -825,10 +805,10 @@ func (p *Processor) removeJobLocked(scheduleID int64) {
 	if entry, ok := p.jobs[scheduleID]; ok {
 		if entry.isOneTime {
 			if entry.timer != nil && entry.timer.Stop() {
-				p.timerWG.Done()
+				entry.activation.timerWG.Done()
 			}
 		} else {
-			p.cron.Remove(entry.entryID)
+			entry.activation.cron.Remove(entry.entryID)
 		}
 		delete(p.jobs, scheduleID)
 	}

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/assert/v2"
-	"github.com/robfig/cron/v3"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -86,170 +85,7 @@ func waitForSignal(t *testing.T, ch <-chan struct{}, msg string) {
 	}
 }
 
-func assertNoSignal(t *testing.T, ch <-chan struct{}, d time.Duration, msg string) {
-	t.Helper()
-	select {
-	case <-ch:
-		t.Fatal(msg)
-	case <-time.After(d):
-	}
-}
-
 // --- lifecycle shutdown ---
-
-func TestStop_WaitsForInFlightTimerCallback(t *testing.T) {
-	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	runCtx, runCancel := context.WithCancel(context.Background())
-	p.runCancel = runCancel
-
-	started := make(chan struct{})
-	release := make(chan struct{})
-	stopped := make(chan struct{})
-
-	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
-		func(ctx context.Context, scheduleID int64) (int64, error) {
-			close(started)
-			<-release
-			assert.True(t, errors.Is(ctx.Err(), context.Canceled))
-			return int64(0), nil
-		},
-	)
-
-	p.timerWG.Add(1)
-	timer := time.AfterFunc(time.Hour, func() {
-		defer p.timerWG.Done()
-		p.executeSchedule(runCtx, 1)
-	})
-	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
-	timer.Reset(0)
-
-	waitForSignal(t, started, "timer callback did not start")
-
-	go func() {
-		assert.NoError(t, p.Stop(context.Background()))
-		close(stopped)
-	}()
-
-	assertNoSignal(t, stopped, 50*time.Millisecond, "Stop returned before timer callback finished")
-	close(release)
-	waitForSignal(t, stopped, "Stop did not return after timer callback finished")
-}
-
-func TestStop_DoesNotWaitForFutureStoppedTimer(t *testing.T) {
-	p, _, _, _, _ := newTestProcessor(t, time.Now())
-	_, runCancel := context.WithCancel(context.Background())
-	p.runCancel = runCancel
-
-	fired := make(chan struct{})
-	stopped := make(chan struct{})
-
-	p.timerWG.Add(1)
-	timer := time.AfterFunc(time.Hour, func() {
-		defer p.timerWG.Done()
-		close(fired)
-	})
-	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
-
-	go func() {
-		assert.NoError(t, p.Stop(context.Background()))
-		close(stopped)
-	}()
-
-	waitForSignal(t, stopped, "Stop waited for a future timer instead of stopping it")
-	assertNoSignal(t, fired, 10*time.Millisecond, "stopped timer fired")
-}
-
-func TestStop_DrainsTimersRegisteredByStoppingLoop(t *testing.T) {
-	p, _, _, _, _ := newTestProcessor(t, time.Now())
-	runCtx, runCancel := context.WithCancel(context.Background())
-	p.runCancel = runCancel
-
-	registered := make(chan struct{})
-	fired := make(chan struct{})
-	stopped := make(chan struct{})
-
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		<-runCtx.Done()
-
-		p.mu.Lock()
-		defer p.mu.Unlock()
-		p.timerWG.Add(1)
-		timer := time.AfterFunc(time.Hour, func() {
-			defer p.timerWG.Done()
-			close(fired)
-		})
-		p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
-		close(registered)
-	}()
-
-	go func() {
-		assert.NoError(t, p.Stop(context.Background()))
-		close(stopped)
-	}()
-
-	waitForSignal(t, stopped, "Stop did not drain timer registered while stopping loops")
-	waitForSignal(t, registered, "stopping loop did not register timer before drain")
-	assertNoSignal(t, fired, 10*time.Millisecond, "timer registered during shutdown fired")
-}
-
-func TestStop_CancelsCronJobContext(t *testing.T) {
-	p, _, _, _, _ := newTestProcessor(t, time.Now())
-	runCtx, runCancel := context.WithCancel(context.Background())
-	p.runCancel = runCancel
-	p.cron = cron.New(cron.WithSeconds())
-
-	started := make(chan struct{})
-	stopped := make(chan struct{})
-
-	_, err := p.cron.AddFunc("@every 1s", func() {
-		close(started)
-		<-runCtx.Done()
-	})
-	assert.NoError(t, err)
-	p.cron.Start()
-
-	waitForSignal(t, started, "cron callback did not start")
-
-	go func() {
-		assert.NoError(t, p.Stop(context.Background()))
-		close(stopped)
-	}()
-
-	waitForSignal(t, stopped, "Stop did not cancel the cron callback context")
-}
-
-func TestStop_CancelsInFlightWork(t *testing.T) {
-	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	runCtx, runCancel := context.WithCancel(context.Background())
-	p.runCancel = runCancel
-
-	started := make(chan struct{})
-	cancelled := make(chan struct{})
-
-	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
-		func(ctx context.Context, _ int64) (int64, error) {
-			close(started)
-			<-ctx.Done()
-			close(cancelled)
-			return int64(0), ctx.Err()
-		},
-	)
-
-	p.timerWG.Add(1)
-	timer := time.AfterFunc(time.Hour, func() {
-		defer p.timerWG.Done()
-		p.executeSchedule(runCtx, 1)
-	})
-	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
-	timer.Reset(0)
-
-	waitForSignal(t, started, "hung callback did not start")
-
-	assert.NoError(t, p.Stop(context.Background()))
-	waitForSignal(t, cancelled, "Stop did not cancel in-flight work")
-}
 
 func TestProcessor_StartStopStart_ReRegistersUnchangedSchedules(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
@@ -266,96 +102,153 @@ func TestProcessor_StartStopStart_ReRegistersUnchangedSchedules(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(schedules, nil).Times(4)
 
 	assert.NoError(t, p.Start(t.Context()))
-	assert.Equal(t, 1, len(p.cron.Entries()))
+	assert.Equal(t, 1, len(p.activation.cron.Entries()))
 	assert.NoError(t, p.Stop(context.Background()))
 
 	assert.NoError(t, p.Start(t.Context()))
-	assert.Equal(t, 1, len(p.cron.Entries()))
+	assert.Equal(t, 1, len(p.activation.cron.Entries()))
 	assert.NoError(t, p.Stop(context.Background()))
 }
 
-func TestProcessor_StartHonorsActivationCancellation(t *testing.T) {
+func TestProcessor_StopDeadlineDoesNotBlockOnStartup(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
 	queryStarted := make(chan struct{})
+	releaseQuery := make(chan struct{})
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) ([]interfaces.ScheduleWithOrg, error) {
+		func(context.Context) ([]interfaces.ScheduleWithOrg, error) {
 			close(queryStarted)
-			<-ctx.Done()
-			return nil, ctx.Err()
+			<-releaseQuery
+			return nil, nil
 		},
 	)
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]interfaces.ScheduleWithOrg, error) { return nil, ctx.Err() },
+	)
 
-	ctx, cancel := context.WithCancel(context.Background())
 	startDone := make(chan error, 1)
-	go func() { startDone <- p.Start(ctx) }()
+	go func() { startDone <- p.Start(context.Background()) }()
 	waitForSignal(t, queryStarted, "startup query did not begin")
-	cancel()
 
-	select {
-	case err := <-startDone:
-		assert.Error(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("Start did not return after its activation context was canceled")
-	}
-}
-
-func TestProcessor_ActivationCancellationRejectsRestartUntilDrain(t *testing.T) {
-	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(4)
-
-	activationCtx, cancelActivation := context.WithCancel(context.Background())
-	assert.NoError(t, p.Start(activationCtx))
-
-	callbackStarted := make(chan struct{})
-	releaseCallback := make(chan struct{})
-	p.timerWG.Add(1)
-	timer := time.AfterFunc(0, func() {
-		defer p.timerWG.Done()
-		close(callbackStarted)
-		<-releaseCallback
-	})
-	p.mu.Lock()
-	p.jobs[1] = jobEntry{timer: timer, isOneTime: true}
-	p.mu.Unlock()
-	waitForSignal(t, callbackStarted, "timer callback did not start")
-
-	cancelActivation()
-
+	stopCtx, cancelStop := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancelStop()
+	assert.Error(t, p.Stop(stopCtx))
 	assert.True(t, errors.Is(p.Start(context.Background()), errProcessorStopping))
-	close(releaseCallback)
+
+	close(releaseQuery)
+	assert.Error(t, <-startDone)
 	assert.NoError(t, p.Stop(context.Background()))
+
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(2)
 	assert.NoError(t, p.Start(context.Background()))
 	assert.NoError(t, p.Stop(context.Background()))
 }
 
-func TestProcessor_Stop_PreventsRestartUntilDrainCompletes(t *testing.T) {
-	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	runCtx, runCancel := context.WithCancel(context.Background())
-	p.runCancel = runCancel
-
-	started := make(chan struct{})
-	release := make(chan struct{})
-	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
-		func(context.Context, int64) (int64, error) {
-			close(started)
-			<-release
-			return 0, nil
+func TestProcessor_ActivationCancellationDrainsAdmittedSchedule(t *testing.T) {
+	p, procStore, targetStore, _, _ := newTestProcessor(t, time.Now())
+	runStarted := make(chan struct{})
+	releaseRun := make(chan struct{})
+	sched := &pb.Schedule{Id: 1, Action: pb.ScheduleAction_SCHEDULE_ACTION_REBOOT, ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_ONE_TIME, StartDate: "2026-04-01", StartTime: "10:00", Timezone: "UTC"}
+	withOrg := []interfaces.ScheduleWithOrg{{Schedule: sched, OrgID: 1}}
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(withOrg, nil).Times(2)
+	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).Return(int64(1), nil)
+	procStore.EXPECT().GetScheduleByID(gomock.Any(), int64(1)).Return(&interfaces.ScheduleWithOrg{Schedule: sched, OrgID: 1}, nil)
+	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return(nil, nil)
+	// No targets still requires final state persistence.
+	procStore.EXPECT().UpdateScheduleAfterRun(gomock.Any(), int64(1), gomock.Any(), gomock.Nil(), statusCompleted).DoAndReturn(
+		func(ctx context.Context, _ int64, _ *int64, _ *int64, _ string) error {
+			close(runStarted)
+			<-releaseRun
+			assert.NoError(t, ctx.Err())
+			return nil
 		},
 	)
 
-	p.timerWG.Add(1)
-	timer := time.AfterFunc(time.Hour, func() {
-		defer p.timerWG.Done()
-		p.executeSchedule(runCtx, 1)
-	})
-	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
-	timer.Reset(0)
+	activationCtx, cancelActivation := context.WithCancel(context.Background())
+	assert.NoError(t, p.Start(activationCtx))
+	p.jobs[1].timer.Reset(0)
+	waitForSignal(t, runStarted, "schedule did not reach final state persistence")
+
+	cancelActivation()
+	assert.True(t, errors.Is(p.Start(context.Background()), errProcessorStopping))
+	close(releaseRun)
+	assert.NoError(t, p.Stop(context.Background()))
+}
+
+func TestProcessor_ActivationCancellationDrainsAdmittedWindowRevert(t *testing.T) {
+	now := time.Date(2026, 4, 1, 17, 30, 0, 0, time.UTC)
+	p, procStore, targetStore, _, cmdSvc := newTestProcessor(t, now)
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(2)
+
+	activationCtx, cancelActivation := context.WithCancel(context.Background())
+	assert.NoError(t, p.Start(activationCtx))
+	run := p.activation
+
+	lastRun := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	sched := &pb.Schedule{
+		Id:           1,
+		Action:       pb.ScheduleAction_SCHEDULE_ACTION_SET_POWER_TARGET,
+		Status:       pb.ScheduleStatus_SCHEDULE_STATUS_RUNNING,
+		StartDate:    "2026-04-01",
+		StartTime:    "09:00",
+		EndTime:      "17:00",
+		Timezone:     "UTC",
+		LastRunAt:    timestamppb.New(lastRun),
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_RECURRING,
+		Recurrence:   &pb.ScheduleRecurrence{Frequency: pb.RecurrenceFrequency_RECURRENCE_FREQUENCY_DAILY, Interval: 1},
+	}
+	dispatchStarted := make(chan struct{})
+	releaseDispatch := make(chan struct{})
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return([]interfaces.ScheduleWithOrg{{Schedule: sched, OrgID: 1}}, nil)
+	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"}}, nil)
+	cmdSvc.EXPECT().SetPowerTarget(gomock.Any(), gomock.Any(), revertPerformanceMode).DoAndReturn(
+		func(ctx context.Context, _ *commandpb.DeviceSelector, _ commandpb.PerformanceMode) (*commanddomain.CommandResult, error) {
+			close(dispatchStarted)
+			<-releaseDispatch
+			assert.NoError(t, ctx.Err())
+			return nil, nil
+		},
+	)
+	procStore.EXPECT().UpdateScheduleAfterRun(gomock.Any(), int64(1), gomock.Nil(), gomock.Not(gomock.Nil()), statusActive).DoAndReturn(
+		func(ctx context.Context, _ int64, _ *int64, _ *int64, _ string) error {
+			assert.NoError(t, ctx.Err())
+			return nil
+		},
+	)
+
+	run.wg.Add(1)
+	go func() {
+		defer run.wg.Done()
+		p.checkEndOfWindow(run.workCtx)
+	}()
+	waitForSignal(t, dispatchStarted, "window revert was not dispatched")
+	cancelActivation()
+	close(releaseDispatch)
+	assert.NoError(t, p.Stop(context.Background()))
+}
+
+func TestProcessor_StopDeadlineForceCancelsAdmittedWork(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(2)
+	assert.NoError(t, p.Start(context.Background()))
+	run := p.activation
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	release := make(chan struct{})
+	run.wg.Add(1)
+	go func() {
+		defer run.wg.Done()
+		close(started)
+		<-run.workCtx.Done()
+		close(cancelled)
+		<-release
+	}()
 	waitForSignal(t, started, "timer callback did not start")
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
 	assert.Error(t, p.Stop(ctx))
-	assert.Error(t, p.Start(t.Context()))
+	waitForSignal(t, cancelled, "Stop deadline did not cancel admitted work")
+	assert.True(t, errors.Is(p.Start(t.Context()), errProcessorStopping))
 
 	close(release)
 	assert.NoError(t, p.Stop(context.Background()))
@@ -363,8 +256,7 @@ func TestProcessor_Stop_PreventsRestartUntilDrainCompletes(t *testing.T) {
 
 func TestProcessor_ActivationCancellationPreventsNewTimerWork(t *testing.T) {
 	p, _, _, _, _ := newTestProcessor(t, time.Now())
-	p.cron = cron.New()
-	runCtx, cancelRun := context.WithCancel(t.Context())
+	run := newProcessorActivation(t.Context())
 
 	sched := &pb.Schedule{
 		Id:           1,
@@ -374,13 +266,13 @@ func TestProcessor_ActivationCancellationPreventsNewTimerWork(t *testing.T) {
 		Timezone:     "UTC",
 	}
 	p.mu.Lock()
-	assert.NoError(t, p.registerJob(runCtx, sched))
+	assert.NoError(t, p.registerJob(run, sched))
 	timer := p.jobs[1].timer
 	p.mu.Unlock()
 
-	cancelRun()
+	run.cancelAdmission()
 	timer.Reset(0)
-	p.timerWG.Wait()
+	run.timerWG.Wait()
 }
 
 // --- recoverStaleRunning ---
@@ -439,9 +331,9 @@ func TestRecoverStaleRunning_ResetsWindowWithNilLastRunAt(t *testing.T) {
 
 func TestSyncSchedules_RegistersNewJobs(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	p.cron = cron.New()
-	p.cron.Start()
-	defer p.cron.Stop()
+	run := newProcessorActivation(context.Background())
+	run.cron.Start()
+	defer run.cron.Stop()
 
 	sched := &pb.Schedule{
 		Id:           1,
@@ -457,7 +349,7 @@ func TestSyncSchedules_RegistersNewJobs(t *testing.T) {
 		{Schedule: sched, OrgID: 1},
 	}, nil)
 
-	assert.NoError(t, p.syncSchedules(context.Background()))
+	assert.NoError(t, p.syncSchedules(context.Background(), run))
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -468,17 +360,17 @@ func TestSyncSchedules_RegistersNewJobs(t *testing.T) {
 
 func TestSyncSchedules_RemovesStaleJobs(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	p.cron = cron.New()
-	p.cron.Start()
-	defer p.cron.Stop()
+	run := newProcessorActivation(context.Background())
+	run.cron.Start()
+	defer run.cron.Stop()
 
 	// Pre-populate a job that won't appear in the DB query.
-	entryID, _ := p.cron.AddFunc("0 9 * * *", func() {})
-	p.jobs[99] = jobEntry{entryID: entryID, fingerprint: "old"}
+	entryID, _ := run.cron.AddFunc("0 9 * * *", func() {})
+	p.jobs[99] = jobEntry{entryID: entryID, activation: run, fingerprint: "old"}
 
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil)
 
-	assert.NoError(t, p.syncSchedules(context.Background()))
+	assert.NoError(t, p.syncSchedules(context.Background(), run))
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -487,13 +379,13 @@ func TestSyncSchedules_RemovesStaleJobs(t *testing.T) {
 
 func TestSyncSchedules_ReRegistersOnFingerprintChange(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	p.cron = cron.New()
-	p.cron.Start()
-	defer p.cron.Stop()
+	run := newProcessorActivation(context.Background())
+	run.cron.Start()
+	defer run.cron.Stop()
 
 	// Pre-populate with old fingerprint.
-	entryID, _ := p.cron.AddFunc("0 9 * * *", func() {})
-	p.jobs[1] = jobEntry{entryID: entryID, fingerprint: "old-fingerprint"}
+	entryID, _ := run.cron.AddFunc("0 9 * * *", func() {})
+	p.jobs[1] = jobEntry{entryID: entryID, activation: run, fingerprint: "old-fingerprint"}
 
 	sched := &pb.Schedule{
 		Id:           1,
@@ -509,7 +401,7 @@ func TestSyncSchedules_ReRegistersOnFingerprintChange(t *testing.T) {
 		{Schedule: sched, OrgID: 1},
 	}, nil)
 
-	assert.NoError(t, p.syncSchedules(context.Background()))
+	assert.NoError(t, p.syncSchedules(context.Background(), run))
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -773,44 +665,6 @@ func TestExecuteSchedule_Success(t *testing.T) {
 	p.executeSchedule(context.Background(), 1)
 }
 
-func TestExecuteSchedule_ActivationCancellationDoesNotCancelFinalization(t *testing.T) {
-	now := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
-	p, procStore, targetStore, _, cmdSvc := newTestProcessor(t, now)
-	ctx, cancel := context.WithCancel(context.Background())
-
-	sched := &pb.Schedule{
-		Id:           1,
-		Action:       pb.ScheduleAction_SCHEDULE_ACTION_REBOOT,
-		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_ONE_TIME,
-		StartDate:    "2026-04-01",
-		StartTime:    "10:00",
-		Timezone:     "UTC",
-	}
-
-	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).Return(int64(1), nil)
-	procStore.EXPECT().GetScheduleByID(gomock.Any(), int64(1)).Return(&interfaces.ScheduleWithOrg{Schedule: sched, OrgID: 1}, nil)
-	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
-		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
-	}, nil)
-	cmdSvc.EXPECT().Reboot(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(context.Context, *commandpb.DeviceSelector) (*commanddomain.CommandResult, error) {
-			cancel()
-			return nil, nil
-		},
-	)
-	procStore.EXPECT().UpdateScheduleAfterRun(gomock.Any(), int64(1), gomock.Any(), gomock.Nil(), statusCompleted).DoAndReturn(
-		func(writeCtx context.Context, _ int64, _ *int64, _ *int64, _ string) error {
-			assert.NoError(t, writeCtx.Err())
-			_, bounded := writeCtx.Deadline()
-			assert.True(t, bounded, "finalization context should be bounded")
-			return nil
-		},
-	)
-
-	p.executeSchedule(ctx, 1)
-	assert.Error(t, ctx.Err())
-}
-
 func TestExecuteSchedule_SkipsWhenNotActive(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
 
@@ -850,13 +704,13 @@ func TestExecuteSchedule_DispatchFailureReverts(t *testing.T) {
 func TestExecuteSchedule_DispatchFailureRevertFails_KeepsJob(t *testing.T) {
 	now := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
 	p, procStore, targetStore, _, cmdSvc := newTestProcessor(t, now)
-	p.cron = cron.New()
-	p.cron.Start()
-	defer p.cron.Stop()
+	run := newProcessorActivation(context.Background())
+	run.cron.Start()
+	defer run.cron.Stop()
 
 	// Pre-register a job so we can verify it is NOT removed.
-	entryID, _ := p.cron.AddFunc("0 10 * * *", func() {})
-	p.jobs[1] = jobEntry{entryID: entryID, fingerprint: "test"}
+	entryID, _ := run.cron.AddFunc("0 10 * * *", func() {})
+	p.jobs[1] = jobEntry{entryID: entryID, activation: run, fingerprint: "test"}
 
 	sched := &pb.Schedule{
 		Id:           1,
@@ -1052,12 +906,12 @@ func TestUpdateAfterRun_PowerTargetWindowStaysRunning(t *testing.T) {
 func TestUpdateAfterRun_UpdateFailsRevertFails_KeepsJob(t *testing.T) {
 	now := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
 	p, procStore, _, _, _ := newTestProcessor(t, now)
-	p.cron = cron.New()
-	p.cron.Start()
-	defer p.cron.Stop()
+	run := newProcessorActivation(context.Background())
+	run.cron.Start()
+	defer run.cron.Stop()
 
-	entryID, _ := p.cron.AddFunc("0 10 * * *", func() {})
-	p.jobs[1] = jobEntry{entryID: entryID, fingerprint: "test"}
+	entryID, _ := run.cron.AddFunc("0 10 * * *", func() {})
+	p.jobs[1] = jobEntry{entryID: entryID, activation: run, fingerprint: "test"}
 
 	sched := &pb.Schedule{
 		Id:           1,
@@ -1118,12 +972,12 @@ func TestUpdateAfterRun_UpdateFails_DoesNotRemoveReregisteredJob(t *testing.T) {
 func TestTransitionToCompleted_UpdateFailsRevertFails_KeepsJob(t *testing.T) {
 	now := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
 	p, procStore, _, _, _ := newTestProcessor(t, now)
-	p.cron = cron.New()
-	p.cron.Start()
-	defer p.cron.Stop()
+	run := newProcessorActivation(context.Background())
+	run.cron.Start()
+	defer run.cron.Stop()
 
-	entryID, _ := p.cron.AddFunc("0 10 * * *", func() {})
-	p.jobs[1] = jobEntry{entryID: entryID, fingerprint: "test"}
+	entryID, _ := run.cron.AddFunc("0 10 * * *", func() {})
+	p.jobs[1] = jobEntry{entryID: entryID, activation: run, fingerprint: "test"}
 
 	sched := &pb.Schedule{
 		Id:           1,

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -99,8 +99,8 @@ func assertNoSignal(t *testing.T, ch <-chan struct{}, d time.Duration, msg strin
 
 func TestStop_WaitsForInFlightTimerCallback(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	workCtx, workCancel := context.WithCancel(context.Background())
-	p.workCancel = workCancel
+	runCtx, runCancel := context.WithCancel(context.Background())
+	p.runCancel = runCancel
 
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -110,7 +110,7 @@ func TestStop_WaitsForInFlightTimerCallback(t *testing.T) {
 		func(ctx context.Context, scheduleID int64) (int64, error) {
 			close(started)
 			<-release
-			assert.NoError(t, ctx.Err())
+			assert.True(t, errors.Is(ctx.Err(), context.Canceled))
 			return int64(0), nil
 		},
 	)
@@ -118,7 +118,7 @@ func TestStop_WaitsForInFlightTimerCallback(t *testing.T) {
 	p.timerWG.Add(1)
 	timer := time.AfterFunc(time.Hour, func() {
 		defer p.timerWG.Done()
-		p.executeSchedule(workCtx, 1)
+		p.executeSchedule(runCtx, 1)
 	})
 	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
 	timer.Reset(0)
@@ -137,8 +137,8 @@ func TestStop_WaitsForInFlightTimerCallback(t *testing.T) {
 
 func TestStop_DoesNotWaitForFutureStoppedTimer(t *testing.T) {
 	p, _, _, _, _ := newTestProcessor(t, time.Now())
-	_, workCancel := context.WithCancel(context.Background())
-	p.workCancel = workCancel
+	_, runCancel := context.WithCancel(context.Background())
+	p.runCancel = runCancel
 
 	fired := make(chan struct{})
 	stopped := make(chan struct{})
@@ -161,10 +161,8 @@ func TestStop_DoesNotWaitForFutureStoppedTimer(t *testing.T) {
 
 func TestStop_DrainsTimersRegisteredByStoppingLoop(t *testing.T) {
 	p, _, _, _, _ := newTestProcessor(t, time.Now())
-	stopCtx, stopCancel := context.WithCancel(context.Background())
-	_, workCancel := context.WithCancel(context.Background())
-	p.stopCancel = stopCancel
-	p.workCancel = workCancel
+	runCtx, runCancel := context.WithCancel(context.Background())
+	p.runCancel = runCancel
 
 	registered := make(chan struct{})
 	fired := make(chan struct{})
@@ -173,7 +171,7 @@ func TestStop_DrainsTimersRegisteredByStoppingLoop(t *testing.T) {
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
-		<-stopCtx.Done()
+		<-runCtx.Done()
 
 		p.mu.Lock()
 		defer p.mu.Unlock()
@@ -196,20 +194,18 @@ func TestStop_DrainsTimersRegisteredByStoppingLoop(t *testing.T) {
 	assertNoSignal(t, fired, 10*time.Millisecond, "timer registered during shutdown fired")
 }
 
-func TestStop_CronJobsFinishWithLiveContext(t *testing.T) {
+func TestStop_CancelsCronJobContext(t *testing.T) {
 	p, _, _, _, _ := newTestProcessor(t, time.Now())
-	workCtx, workCancel := context.WithCancel(context.Background())
-	p.workCancel = workCancel
+	runCtx, runCancel := context.WithCancel(context.Background())
+	p.runCancel = runCancel
 	p.cron = cron.New(cron.WithSeconds())
 
 	started := make(chan struct{})
-	release := make(chan struct{})
 	stopped := make(chan struct{})
 
 	_, err := p.cron.AddFunc("@every 1s", func() {
 		close(started)
-		<-release
-		assert.NoError(t, workCtx.Err())
+		<-runCtx.Done()
 	})
 	assert.NoError(t, err)
 	p.cron.Start()
@@ -221,20 +217,16 @@ func TestStop_CronJobsFinishWithLiveContext(t *testing.T) {
 		close(stopped)
 	}()
 
-	assertNoSignal(t, stopped, 50*time.Millisecond, "Stop returned before cron callback finished")
-	close(release)
-	waitForSignal(t, stopped, "Stop did not return after cron callback finished")
+	waitForSignal(t, stopped, "Stop did not cancel the cron callback context")
 }
 
-// A caller deadline cancels work that failed to drain and bounds Stop.
-func TestStop_DeadlineCancelsHungWork(t *testing.T) {
+func TestStop_CancelsInFlightWork(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	workCtx, workCancel := context.WithCancel(context.Background())
-	p.workCancel = workCancel
+	runCtx, runCancel := context.WithCancel(context.Background())
+	p.runCancel = runCancel
 
 	started := make(chan struct{})
 	cancelled := make(chan struct{})
-	stopped := make(chan error, 1)
 
 	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
 		func(ctx context.Context, _ int64) (int64, error) {
@@ -248,27 +240,15 @@ func TestStop_DeadlineCancelsHungWork(t *testing.T) {
 	p.timerWG.Add(1)
 	timer := time.AfterFunc(time.Hour, func() {
 		defer p.timerWG.Done()
-		p.executeSchedule(workCtx, 1)
+		p.executeSchedule(runCtx, 1)
 	})
 	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
 	timer.Reset(0)
 
 	waitForSignal(t, started, "hung callback did not start")
 
-	begin := time.Now()
-	stopCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
-	defer cancel()
-	go func() {
-		stopped <- p.Stop(stopCtx)
-	}()
-
-	waitForSignal(t, cancelled, "deadline did not cancel hung work via workCancel")
-	assert.True(t, errors.Is(<-stopped, context.DeadlineExceeded))
 	assert.NoError(t, p.Stop(context.Background()))
-
-	if elapsed := time.Since(begin); elapsed > time.Second {
-		t.Fatalf("Stop took %v; caller deadline should have bounded shutdown well below this", elapsed)
-	}
+	waitForSignal(t, cancelled, "Stop did not cancel in-flight work")
 }
 
 func TestProcessor_StartStopStart_ReRegistersUnchangedSchedules(t *testing.T) {
@@ -319,38 +299,9 @@ func TestProcessor_StartHonorsActivationCancellation(t *testing.T) {
 	}
 }
 
-func TestProcessor_ActivationCancellationAllowsRestartAfterDrain(t *testing.T) {
-	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	getActiveSchedulesCalls := 0
-	procStore.EXPECT().GetActiveSchedules(gomock.Any()).DoAndReturn(
-		func(context.Context) ([]interfaces.ScheduleWithOrg, error) {
-			getActiveSchedulesCalls++
-			return nil, nil
-		},
-	).Times(4)
-
-	activationCtx, cancelActivation := context.WithCancel(context.Background())
-	assert.NoError(t, p.Start(activationCtx))
-	cancelActivation()
-
-	deadline := time.Now().Add(2 * time.Second)
-	for getActiveSchedulesCalls < 4 {
-		err := p.Start(context.Background())
-		if err != nil && !errors.Is(err, errProcessorStopping) {
-			t.Fatalf("restart after activation cancellation: %v", err)
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("processor did not become restartable after activation cancellation")
-		}
-		time.Sleep(time.Millisecond)
-	}
-
-	assert.NoError(t, p.Stop(context.Background()))
-}
-
 func TestProcessor_ActivationCancellationRejectsRestartUntilDrain(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(2)
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(4)
 
 	activationCtx, cancelActivation := context.WithCancel(context.Background())
 	assert.NoError(t, p.Start(activationCtx))
@@ -373,34 +324,14 @@ func TestProcessor_ActivationCancellationRejectsRestartUntilDrain(t *testing.T) 
 	assert.True(t, errors.Is(p.Start(context.Background()), errProcessorStopping))
 	close(releaseCallback)
 	assert.NoError(t, p.Stop(context.Background()))
-}
-
-func TestProcessor_StaleCancellationWatcherCannotStopNewActivation(t *testing.T) {
-	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(4)
-
 	assert.NoError(t, p.Start(context.Background()))
-	oldActivationDone := p.activationDone
-	assert.NoError(t, p.Stop(context.Background()))
-
-	assert.NoError(t, p.Start(context.Background()))
-	newActivationDone := p.activationDone
-
-	watcherReturned := make(chan struct{})
-	go func() {
-		p.stopOnActivationCancellation(oldActivationDone)
-		close(watcherReturned)
-	}()
-	waitForSignal(t, watcherReturned, "stale cancellation watcher did not return")
-	assertNoSignal(t, newActivationDone, 10*time.Millisecond, "stale cancellation watcher stopped the new activation")
-
 	assert.NoError(t, p.Stop(context.Background()))
 }
 
 func TestProcessor_Stop_PreventsRestartUntilDrainCompletes(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
-	workCtx, workCancel := context.WithCancel(context.Background())
-	p.workCancel = workCancel
+	runCtx, runCancel := context.WithCancel(context.Background())
+	p.runCancel = runCancel
 
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -415,7 +346,7 @@ func TestProcessor_Stop_PreventsRestartUntilDrainCompletes(t *testing.T) {
 	p.timerWG.Add(1)
 	timer := time.AfterFunc(time.Hour, func() {
 		defer p.timerWG.Done()
-		p.executeSchedule(workCtx, 1)
+		p.executeSchedule(runCtx, 1)
 	})
 	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
 	timer.Reset(0)
@@ -433,9 +364,7 @@ func TestProcessor_Stop_PreventsRestartUntilDrainCompletes(t *testing.T) {
 func TestProcessor_ActivationCancellationPreventsNewTimerWork(t *testing.T) {
 	p, _, _, _, _ := newTestProcessor(t, time.Now())
 	p.cron = cron.New()
-	stopCtx, stop := context.WithCancel(t.Context())
-	workCtx, cancelWork := context.WithCancel(context.WithoutCancel(t.Context()))
-	defer cancelWork()
+	runCtx, cancelRun := context.WithCancel(t.Context())
 
 	sched := &pb.Schedule{
 		Id:           1,
@@ -445,11 +374,11 @@ func TestProcessor_ActivationCancellationPreventsNewTimerWork(t *testing.T) {
 		Timezone:     "UTC",
 	}
 	p.mu.Lock()
-	assert.NoError(t, p.registerJob(stopCtx, workCtx, sched))
+	assert.NoError(t, p.registerJob(runCtx, sched))
 	timer := p.jobs[1].timer
 	p.mu.Unlock()
 
-	stop()
+	cancelRun()
 	timer.Reset(0)
 	p.timerWG.Wait()
 }

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -348,6 +348,55 @@ func TestProcessor_ActivationCancellationAllowsRestartAfterDrain(t *testing.T) {
 	assert.NoError(t, p.Stop(context.Background()))
 }
 
+func TestProcessor_ActivationCancellationRejectsRestartUntilDrain(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(2)
+
+	activationCtx, cancelActivation := context.WithCancel(context.Background())
+	assert.NoError(t, p.Start(activationCtx))
+
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	p.timerWG.Add(1)
+	timer := time.AfterFunc(0, func() {
+		defer p.timerWG.Done()
+		close(callbackStarted)
+		<-releaseCallback
+	})
+	p.mu.Lock()
+	p.jobs[1] = jobEntry{timer: timer, isOneTime: true}
+	p.mu.Unlock()
+	waitForSignal(t, callbackStarted, "timer callback did not start")
+
+	cancelActivation()
+
+	assert.True(t, errors.Is(p.Start(context.Background()), errProcessorStopping))
+	close(releaseCallback)
+	assert.NoError(t, p.Stop(context.Background()))
+}
+
+func TestProcessor_StaleCancellationWatcherCannotStopNewActivation(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(4)
+
+	assert.NoError(t, p.Start(context.Background()))
+	oldActivationDone := p.activationDone
+	assert.NoError(t, p.Stop(context.Background()))
+
+	assert.NoError(t, p.Start(context.Background()))
+	newActivationDone := p.activationDone
+
+	watcherReturned := make(chan struct{})
+	go func() {
+		p.stopOnActivationCancellation(oldActivationDone)
+		close(watcherReturned)
+	}()
+	waitForSignal(t, watcherReturned, "stale cancellation watcher did not return")
+	assertNoSignal(t, newActivationDone, 10*time.Millisecond, "stale cancellation watcher stopped the new activation")
+
+	assert.NoError(t, p.Stop(context.Background()))
+}
+
 func TestProcessor_Stop_PreventsRestartUntilDrainCompletes(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
 	workCtx, workCancel := context.WithCancel(context.Background())

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -773,6 +773,44 @@ func TestExecuteSchedule_Success(t *testing.T) {
 	p.executeSchedule(context.Background(), 1)
 }
 
+func TestExecuteSchedule_ActivationCancellationDoesNotCancelFinalization(t *testing.T) {
+	now := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	p, procStore, targetStore, _, cmdSvc := newTestProcessor(t, now)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sched := &pb.Schedule{
+		Id:           1,
+		Action:       pb.ScheduleAction_SCHEDULE_ACTION_REBOOT,
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_ONE_TIME,
+		StartDate:    "2026-04-01",
+		StartTime:    "10:00",
+		Timezone:     "UTC",
+	}
+
+	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).Return(int64(1), nil)
+	procStore.EXPECT().GetScheduleByID(gomock.Any(), int64(1)).Return(&interfaces.ScheduleWithOrg{Schedule: sched, OrgID: 1}, nil)
+	targetStore.EXPECT().GetScheduleTargets(gomock.Any(), int64(1), int64(1)).Return([]*pb.ScheduleTarget{
+		{TargetType: pb.ScheduleTargetType_SCHEDULE_TARGET_TYPE_MINER, TargetId: "miner-1"},
+	}, nil)
+	cmdSvc.EXPECT().Reboot(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *commandpb.DeviceSelector) (*commanddomain.CommandResult, error) {
+			cancel()
+			return nil, nil
+		},
+	)
+	procStore.EXPECT().UpdateScheduleAfterRun(gomock.Any(), int64(1), gomock.Any(), gomock.Nil(), statusCompleted).DoAndReturn(
+		func(writeCtx context.Context, _ int64, _ *int64, _ *int64, _ string) error {
+			assert.NoError(t, writeCtx.Err())
+			_, bounded := writeCtx.Deadline()
+			assert.True(t, bounded, "finalization context should be bounded")
+			return nil
+		},
+	)
+
+	p.executeSchedule(ctx, 1)
+	assert.Error(t, ctx.Err())
+}
+
 func TestExecuteSchedule_SkipsWhenNotActive(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
 

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -126,7 +126,7 @@ func TestStop_WaitsForInFlightTimerCallback(t *testing.T) {
 	waitForSignal(t, started, "timer callback did not start")
 
 	go func() {
-		assert.NoError(t, p.Stop())
+		assert.NoError(t, p.Stop(context.Background()))
 		close(stopped)
 	}()
 
@@ -151,7 +151,7 @@ func TestStop_DoesNotWaitForFutureStoppedTimer(t *testing.T) {
 	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
 
 	go func() {
-		assert.NoError(t, p.Stop())
+		assert.NoError(t, p.Stop(context.Background()))
 		close(stopped)
 	}()
 
@@ -187,7 +187,7 @@ func TestStop_DrainsTimersRegisteredByStoppingLoop(t *testing.T) {
 	}()
 
 	go func() {
-		assert.NoError(t, p.Stop())
+		assert.NoError(t, p.Stop(context.Background()))
 		close(stopped)
 	}()
 
@@ -217,7 +217,7 @@ func TestStop_CronJobsFinishWithLiveContext(t *testing.T) {
 	waitForSignal(t, started, "cron callback did not start")
 
 	go func() {
-		assert.NoError(t, p.Stop())
+		assert.NoError(t, p.Stop(context.Background()))
 		close(stopped)
 	}()
 
@@ -226,20 +226,15 @@ func TestStop_CronJobsFinishWithLiveContext(t *testing.T) {
 	waitForSignal(t, stopped, "Stop did not return after cron callback finished")
 }
 
-// Drain must still be bounded: if work wedges, the watchdog cancels workCtx
-// so the in-flight call returns and the wg waits release.
-func TestStop_WatchdogCancelsHungWork(t *testing.T) {
-	prev := shutdownDeadlineFn
-	shutdownDeadlineFn = func() time.Duration { return 50 * time.Millisecond }
-	t.Cleanup(func() { shutdownDeadlineFn = prev })
-
+// A caller deadline cancels work that failed to drain and bounds Stop.
+func TestStop_DeadlineCancelsHungWork(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
 	workCtx, workCancel := context.WithCancel(context.Background())
 	p.workCancel = workCancel
 
 	started := make(chan struct{})
 	cancelled := make(chan struct{})
-	stopped := make(chan struct{})
+	stopped := make(chan error, 1)
 
 	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
 		func(ctx context.Context, _ int64) (int64, error) {
@@ -261,17 +256,124 @@ func TestStop_WatchdogCancelsHungWork(t *testing.T) {
 	waitForSignal(t, started, "hung callback did not start")
 
 	begin := time.Now()
+	stopCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
 	go func() {
-		assert.NoError(t, p.Stop())
-		close(stopped)
+		stopped <- p.Stop(stopCtx)
 	}()
 
-	waitForSignal(t, cancelled, "watchdog did not cancel hung work via workCancel")
-	waitForSignal(t, stopped, "Stop did not return after watchdog fired")
+	waitForSignal(t, cancelled, "deadline did not cancel hung work via workCancel")
+	assert.True(t, errors.Is(<-stopped, context.DeadlineExceeded))
+	assert.NoError(t, p.Stop(context.Background()))
 
 	if elapsed := time.Since(begin); elapsed > time.Second {
-		t.Fatalf("Stop took %v; watchdog should have bounded shutdown well below this", elapsed)
+		t.Fatalf("Stop took %v; caller deadline should have bounded shutdown well below this", elapsed)
 	}
+}
+
+func TestProcessor_StartStopStart_ReRegistersUnchangedSchedules(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	sched := &pb.Schedule{
+		Id:           1,
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_RECURRING,
+		StartDate:    "2026-04-01",
+		StartTime:    "09:00",
+		Timezone:     "UTC",
+		Status:       pb.ScheduleStatus_SCHEDULE_STATUS_ACTIVE,
+		Recurrence:   &pb.ScheduleRecurrence{Frequency: pb.RecurrenceFrequency_RECURRENCE_FREQUENCY_DAILY, Interval: 1},
+	}
+	schedules := []interfaces.ScheduleWithOrg{{Schedule: sched, OrgID: 1}}
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(schedules, nil).Times(4)
+
+	assert.NoError(t, p.Start(t.Context()))
+	assert.Equal(t, 1, len(p.cron.Entries()))
+	assert.NoError(t, p.Stop(context.Background()))
+
+	assert.NoError(t, p.Start(t.Context()))
+	assert.Equal(t, 1, len(p.cron.Entries()))
+	assert.NoError(t, p.Stop(context.Background()))
+}
+
+func TestProcessor_StartHonorsActivationCancellation(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	queryStarted := make(chan struct{})
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]interfaces.ScheduleWithOrg, error) {
+			close(queryStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startDone := make(chan error, 1)
+	go func() { startDone <- p.Start(ctx) }()
+	waitForSignal(t, queryStarted, "startup query did not begin")
+	cancel()
+
+	select {
+	case err := <-startDone:
+		assert.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return after its activation context was canceled")
+	}
+}
+
+func TestProcessor_Stop_PreventsRestartUntilDrainCompletes(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	workCtx, workCancel := context.WithCancel(context.Background())
+	p.workCancel = workCancel
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	procStore.EXPECT().SetScheduleRunning(gomock.Any(), int64(1)).DoAndReturn(
+		func(context.Context, int64) (int64, error) {
+			close(started)
+			<-release
+			return 0, nil
+		},
+	)
+
+	p.timerWG.Add(1)
+	timer := time.AfterFunc(time.Hour, func() {
+		defer p.timerWG.Done()
+		p.executeSchedule(workCtx, 1)
+	})
+	p.jobs[1] = jobEntry{timer: timer, isOneTime: true, generation: 1}
+	timer.Reset(0)
+	waitForSignal(t, started, "timer callback did not start")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+	assert.Error(t, p.Stop(ctx))
+	assert.Error(t, p.Start(t.Context()))
+
+	close(release)
+	assert.NoError(t, p.Stop(context.Background()))
+}
+
+func TestProcessor_ActivationCancellationPreventsNewTimerWork(t *testing.T) {
+	p, _, _, _, _ := newTestProcessor(t, time.Now())
+	p.cron = cron.New()
+	stopCtx, stop := context.WithCancel(t.Context())
+	workCtx, cancelWork := context.WithCancel(context.WithoutCancel(t.Context()))
+	defer cancelWork()
+
+	sched := &pb.Schedule{
+		Id:           1,
+		ScheduleType: pb.ScheduleType_SCHEDULE_TYPE_ONE_TIME,
+		StartDate:    "2026-04-01",
+		StartTime:    "09:00",
+		Timezone:     "UTC",
+	}
+	p.mu.Lock()
+	assert.NoError(t, p.registerJob(stopCtx, workCtx, sched))
+	timer := p.jobs[1].timer
+	p.mu.Unlock()
+
+	stop()
+	timer.Reset(0)
+	p.timerWG.Wait()
 }
 
 // --- recoverStaleRunning ---

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -319,6 +319,35 @@ func TestProcessor_StartHonorsActivationCancellation(t *testing.T) {
 	}
 }
 
+func TestProcessor_ActivationCancellationAllowsRestartAfterDrain(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	getActiveSchedulesCalls := 0
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).DoAndReturn(
+		func(context.Context) ([]interfaces.ScheduleWithOrg, error) {
+			getActiveSchedulesCalls++
+			return nil, nil
+		},
+	).Times(4)
+
+	activationCtx, cancelActivation := context.WithCancel(context.Background())
+	assert.NoError(t, p.Start(activationCtx))
+	cancelActivation()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for getActiveSchedulesCalls < 4 {
+		err := p.Start(context.Background())
+		if err != nil && !errors.Is(err, errProcessorStopping) {
+			t.Fatalf("restart after activation cancellation: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("processor did not become restartable after activation cancellation")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	assert.NoError(t, p.Stop(context.Background()))
+}
+
 func TestProcessor_Stop_PreventsRestartUntilDrainCompletes(t *testing.T) {
 	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
 	workCtx, workCancel := context.WithCancel(context.Background())

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -3,6 +3,7 @@ package schedule
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -85,6 +86,21 @@ func waitForSignal(t *testing.T, ch <-chan struct{}, msg string) {
 	}
 }
 
+type doneObservedContext struct {
+	doneObserved chan struct{}
+	once         sync.Once
+}
+
+func (*doneObservedContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.doneObserved) })
+	return nil
+}
+
+func (*doneObservedContext) Err() error    { return nil }
+func (*doneObservedContext) Value(any) any { return nil }
+
 // --- lifecycle shutdown ---
 
 func TestProcessor_StartStopStart_ReRegistersUnchangedSchedules(t *testing.T) {
@@ -141,6 +157,32 @@ func TestProcessor_StopDeadlineDoesNotBlockOnStartup(t *testing.T) {
 	procStore.EXPECT().GetActiveSchedules(gomock.Any()).Return(nil, nil).Times(2)
 	assert.NoError(t, p.Start(context.Background()))
 	assert.NoError(t, p.Stop(context.Background()))
+}
+
+func TestProcessor_ConcurrentStartPropagatesStartupFailure(t *testing.T) {
+	p, procStore, _, _, _ := newTestProcessor(t, time.Now())
+	queryStarted := make(chan struct{})
+	joinObserved := make(chan struct{})
+	startupErr := errors.New("startup query failed")
+	procStore.EXPECT().GetActiveSchedules(gomock.Any()).DoAndReturn(
+		func(context.Context) ([]interfaces.ScheduleWithOrg, error) {
+			close(queryStarted)
+			<-joinObserved
+			return nil, startupErr
+		},
+	)
+
+	firstStart := make(chan error, 1)
+	go func() { firstStart <- p.Start(context.Background()) }()
+	waitForSignal(t, queryStarted, "startup query did not begin")
+
+	joinCtx := &doneObservedContext{
+		doneObserved: joinObserved,
+	}
+	secondErr := p.Start(joinCtx)
+	firstErr := <-firstStart
+	assert.True(t, errors.Is(firstErr, startupErr))
+	assert.True(t, errors.Is(secondErr, startupErr))
 }
 
 func TestProcessor_ActivationCancellationDrainsAdmittedSchedule(t *testing.T) {


### PR DESCRIPTION
Reviewable diff: +152/-84 across 2 files (excludes generated, test, and story files).

## Summary

Schedule processing can now be stopped, fully drained, and started again without rebuilding `fleetd`. This prepares scheduled command recovery, cron callbacks, and end-of-window reverts for active/passive demotion and promotion while preserving standalone behavior.

**Stack:**

- Foundation: [#780](https://github.com/block/proto-fleet/pull/780) (merged)
- Parallel domain refactors: diagnostics [#781](https://github.com/block/proto-fleet/pull/781), IP scanning [#782](https://github.com/block/proto-fleet/pull/782), **scheduling [#783](https://github.com/block/proto-fleet/pull/783)**, curtailment [#785](https://github.com/block/proto-fleet/pull/785), telemetry [#786](https://github.com/block/proto-fleet/pull/786), and command execution [#787](https://github.com/block/proto-fleet/pull/787)
- Orchestration: [#784](https://github.com/block/proto-fleet/pull/784)
- Catalog and `fleetd` cutover: [#788](https://github.com/block/proto-fleet/pull/788)

This PR targets `main` and builds on the `runtimejobs.Lifecycle` contract merged in #780. The sibling domain refactors can merge independently; #788 performs the final catalog/cutover integration. Passive-mode coordinator wiring, epoch fencing, and request gating remain later HA work.

## How it works

Each `Start` creates one schedule activation with two phases. Its admission context is canceled immediately when ownership is withdrawn or `Stop` begins, preventing loops, timers, and cron from starting new work. Work already admitted keeps a separate activation-owned context through target resolution, command dispatch, and final database state persistence, so a demotion cannot strand a schedule halfway through its workflow.

`Stop(ctx)` waits for admitted work to drain. If the caller's shutdown deadline expires, it cancels that work context and returns the deadline error; the processor remains unavailable for restart until the old activation has actually exited. Startup database work runs outside the lifecycle lock, allowing `Stop` to honor its own deadline even when startup is blocked.

```mermaid
flowchart LR
    S["Start activation"] --> R["Recover and register schedules"]
    R --> A["Admit timer, cron, and reconciliation work"]
    A --> W["Run schedule workflow"]
    W --> D["Dispatch command"]
    D --> P["Persist final schedule state"]
    X["Activation canceled or Stop called"] --> C["Close admission"]
    C --> G["Drain admitted work"]
    G --> N["Allow next activation"]
    T["Stop deadline expires"] --> F["Force-cancel admitted work"]
    F --> N
```

```mermaid
stateDiagram-v2
    [*] --> Starting
    Starting --> Running: recovery succeeds
    Starting --> Draining: startup fails or is canceled
    Running --> Draining: activation canceled or Stop called
    Draining --> Stopped: callbacks and timers exit
    Draining --> Draining: Stop deadline force-cancels work
    Stopped --> Starting: next Start
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/schedule/processor.go` | Adds activation-owned admission and work contexts, restart-safe lifecycle state, and bounded Stop behavior | Defines the ownership handoff and guarantees that admitted schedule workflows drain as one unit |
| `server/cmd/fleetd/main.go` | Stops the processor through the shared standalone lifecycle helper | Preserves the process-wide shutdown budget |
| Schedule processor tests | Cover startup/stop races, admitted schedule and window-revert draining, deadline cancellation, timer admission, and restart | Exercises lifecycle ordering under the race detector |

## Key technical decisions & trade-offs

- Model shutdown once at the activation boundary instead of giving individual database writes special cancellation exceptions.
- Cancel admission immediately, but preserve one context for the full already-admitted workflow so dispatch and persisted state cannot diverge.
- Let the caller's `Stop` deadline decide when graceful draining becomes forced cancellation rather than embedding another processor-specific timeout.
- Reject restart until the previous activation has actually drained, avoiding overlapping owners after a timed-out stop.

## Related

Related: #740

## Testing & validation

- `go test -short -race -count=1 ./internal/domain/schedule ./cmd/fleetd`
- Focused lifecycle tests repeated 100 times under the race detector.
- `golangci-lint` passed for `./internal/domain/schedule/...` and `./cmd/fleetd/...`.
- Covers activation cancellation during a schedule and end-of-window revert, forced cancellation at the Stop deadline, blocked startup, timer admission, drain completion, and restart.
- Does not cover future HA coordinator or epoch-fencing behavior; those are outside this PR.

## Post-Deploy Monitoring & Validation

Watch schedule recovery/start errors, command creation from due schedules, end-of-window reverts, and shutdown drain logs through at least one schedule interval. Roll back if schedules are duplicated, due work stops dispatching, reverts are missed, or processor drains repeatedly exceed the shutdown budget.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
