### PR TITLE
refactor(server): orchestrate runtime job groups (8/9)

### DIFF
--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -90,7 +90,7 @@ func (s *Service) Start(ctx context.Context) error {
 		return fmt.Errorf("start ip scanner service: %w", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	ctx, cancel := context.WithCancel(ctx)
 	run := &serviceRun{
 		tasks:   make(chan SubnetScanTask, s.config.MaxConcurrentSubnetScans),
 		results: make(chan SubnetScanResult, s.config.MaxConcurrentSubnetScans),

--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -78,11 +78,14 @@ func (s *Service) Start(ctx context.Context) error {
 		select {
 		case <-s.run.done:
 			s.run = nil
-		case <-s.run.activationDone:
-			return errServiceStopping
 		default:
-			s.logger.Warn("IP scanner service already running")
-			return nil
+			select {
+			case <-s.run.activationDone:
+				return errServiceStopping
+			default:
+				s.logger.Warn("IP scanner service already running")
+				return nil
+			}
 		}
 	}
 	if err := ctx.Err(); err != nil {

--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -42,7 +42,6 @@ type serviceRun struct {
 	cancel         context.CancelFunc
 	wg             sync.WaitGroup
 	done           chan struct{}
-	stopping       bool
 }
 
 // NewIPScannerService creates a new IP scanner service
@@ -79,16 +78,9 @@ func (s *Service) Start(ctx context.Context) error {
 		select {
 		case <-s.run.done:
 			s.run = nil
+		case <-s.run.activationDone:
+			return errServiceStopping
 		default:
-			if s.run.stopping {
-				return errServiceStopping
-			}
-			select {
-			case <-s.run.activationDone:
-				s.run.stopping = true
-				return errServiceStopping
-			default:
-			}
 			s.logger.Warn("IP scanner service already running")
 			return nil
 		}
@@ -141,7 +133,6 @@ func (s *Service) Stop(ctx context.Context) error {
 		return nil
 	}
 	s.logger.Info("Stopping IP scanner service")
-	run.stopping = true
 	run.cancel()
 	s.lifecycleMu.Unlock()
 

--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -36,12 +36,13 @@ var _ runtimejobs.Lifecycle = (*Service)(nil)
 // serviceRun contains all state owned by a single activation. Keeping queues
 // here prevents stopped runs from leaking buffered work into a later Start.
 type serviceRun struct {
-	tasks    chan SubnetScanTask
-	results  chan SubnetScanResult
-	cancel   context.CancelFunc
-	wg       sync.WaitGroup
-	done     chan struct{}
-	stopping bool
+	tasks          chan SubnetScanTask
+	results        chan SubnetScanResult
+	activationDone <-chan struct{}
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+	done           chan struct{}
+	stopping       bool
 }
 
 // NewIPScannerService creates a new IP scanner service
@@ -82,6 +83,12 @@ func (s *Service) Start(ctx context.Context) error {
 			if s.run.stopping {
 				return errServiceStopping
 			}
+			select {
+			case <-s.run.activationDone:
+				s.run.stopping = true
+				return errServiceStopping
+			default:
+			}
 			s.logger.Warn("IP scanner service already running")
 			return nil
 		}
@@ -92,10 +99,11 @@ func (s *Service) Start(ctx context.Context) error {
 
 	ctx, cancel := context.WithCancel(ctx)
 	run := &serviceRun{
-		tasks:   make(chan SubnetScanTask, s.config.MaxConcurrentSubnetScans),
-		results: make(chan SubnetScanResult, s.config.MaxConcurrentSubnetScans),
-		cancel:  cancel,
-		done:    make(chan struct{}),
+		tasks:          make(chan SubnetScanTask, s.config.MaxConcurrentSubnetScans),
+		results:        make(chan SubnetScanResult, s.config.MaxConcurrentSubnetScans),
+		activationDone: ctx.Done(),
+		cancel:         cancel,
+		done:           make(chan struct{}),
 	}
 	s.run = run
 

--- a/server/internal/domain/ipscanner/service_test.go
+++ b/server/internal/domain/ipscanner/service_test.go
@@ -64,27 +64,24 @@ func TestIPScannerService_StartStopStart(t *testing.T) {
 	}
 }
 
-func TestIPScannerService_Start_CallerCancellationDoesNotStopRun(t *testing.T) {
+func TestIPScannerService_Start_ActivationCancellationStopsRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	config := Config{
 		Enabled:                       true,
-		ScanInterval:                  10 * time.Millisecond,
+		ScanInterval:                  time.Hour,
 		MaxConcurrentSubnetScans:      1,
 		MaxConcurrentIPScansPerSubnet: 1,
 		ScanTimeout:                   time.Second,
 		SubnetMaskBits:                24,
 	}
 	deviceStore := storemocks.NewMockDeviceStore(ctrl)
-	scanned := make(chan struct{}, 2)
+	scanned := make(chan struct{}, 1)
 	deviceStore.EXPECT().GetOfflineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(context.Context, int) ([]stores.OfflineDeviceInfo, error) {
-			select {
-			case scanned <- struct{}{}:
-			default:
-			}
+			scanned <- struct{}{}
 			return nil, nil
 		},
-	).AnyTimes()
+	)
 	service := NewIPScannerService(
 		config,
 		deviceStore,
@@ -94,14 +91,21 @@ func TestIPScannerService_Start_CallerCancellationDoesNotStopRun(t *testing.T) {
 		slog.Default(),
 	)
 
-	startupCtx, cancelStartup := context.WithCancel(t.Context())
-	if err := service.Start(startupCtx); err != nil {
+	activationCtx, cancelActivation := context.WithCancel(t.Context())
+	if err := service.Start(activationCtx); err != nil {
 		t.Fatalf("Start failed: %v", err)
 	}
 	waitForScannerSignal(t, scanned, "initial scan did not run")
 
-	cancelStartup()
-	waitForScannerSignal(t, scanned, "startup context cancellation stopped periodic scans")
+	service.lifecycleMu.Lock()
+	run := service.run
+	service.lifecycleMu.Unlock()
+	if run == nil {
+		t.Fatal("Start did not create an active scanner run")
+	}
+
+	cancelActivation()
+	waitForScannerSignal(t, run.done, "activation context cancellation did not stop scanner run")
 
 	if err := service.Stop(t.Context()); err != nil {
 		t.Fatalf("Stop failed: %v", err)

--- a/server/internal/domain/ipscanner/service_test.go
+++ b/server/internal/domain/ipscanner/service_test.go
@@ -66,7 +66,7 @@ func TestIPScannerService_StartStopStart(t *testing.T) {
 	}
 }
 
-func TestIPScannerService_Start_ActivationCancellationStopsRun(t *testing.T) {
+func TestIPScannerService_Start_ActivationCancellationAllowsRestartAfterDrain(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	config := Config{
 		Enabled:                       true,
@@ -83,7 +83,7 @@ func TestIPScannerService_Start_ActivationCancellationStopsRun(t *testing.T) {
 			scanned <- struct{}{}
 			return nil, nil
 		},
-	)
+	).Times(2)
 	service := NewIPScannerService(
 		config,
 		deviceStore,
@@ -109,6 +109,10 @@ func TestIPScannerService_Start_ActivationCancellationStopsRun(t *testing.T) {
 	cancelActivation()
 	waitForScannerSignal(t, run.done, "activation context cancellation did not stop scanner run")
 
+	if err := service.Start(t.Context()); err != nil {
+		t.Fatalf("Start after drain failed: %v", err)
+	}
+	waitForScannerSignal(t, scanned, "restarted run did not scan")
 	if err := service.Stop(t.Context()); err != nil {
 		t.Fatalf("Stop failed: %v", err)
 	}

--- a/server/internal/domain/ipscanner/service_test.go
+++ b/server/internal/domain/ipscanner/service_test.go
@@ -2,7 +2,9 @@ package ipscanner
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -109,6 +111,75 @@ func TestIPScannerService_Start_ActivationCancellationStopsRun(t *testing.T) {
 
 	if err := service.Stop(t.Context()); err != nil {
 		t.Fatalf("Stop failed: %v", err)
+	}
+}
+
+func TestIPScannerService_Start_RejectsCanceledRunUntilDrained(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	config := Config{
+		Enabled:                       true,
+		ScanInterval:                  time.Hour,
+		MaxConcurrentSubnetScans:      1,
+		MaxConcurrentIPScansPerSubnet: 1,
+		ScanTimeout:                   time.Second,
+		SubnetMaskBits:                24,
+	}
+	firstScanStarted := make(chan struct{})
+	releaseFirstScan := make(chan struct{})
+	release := sync.OnceFunc(func() { close(releaseFirstScan) })
+	t.Cleanup(release)
+	blockFirstScan := sync.OnceFunc(func() {
+		close(firstScanStarted)
+		<-releaseFirstScan
+	})
+	deviceStore := storemocks.NewMockDeviceStore(ctrl)
+	deviceStore.EXPECT().GetOfflineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, int) ([]stores.OfflineDeviceInfo, error) {
+			blockFirstScan()
+			return nil, nil
+		},
+	).AnyTimes()
+	service := NewIPScannerService(
+		config,
+		deviceStore,
+		storemocks.NewMockDiscoveredDeviceStore(ctrl),
+		&noopDiscoverer{},
+		mocks.NewMockDeviceIdentityCheckService(ctrl),
+		slog.Default(),
+	)
+
+	activationCtx, cancelActivation := context.WithCancel(t.Context())
+	if err := service.Start(activationCtx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	waitForScannerSignal(t, firstScanStarted, "initial scan did not start")
+
+	service.lifecycleMu.Lock()
+	run := service.run
+	service.lifecycleMu.Unlock()
+	if run == nil {
+		t.Fatal("Start did not create an active scanner run")
+	}
+
+	cancelActivation()
+	select {
+	case <-run.done:
+		t.Fatal("scanner run drained before restart check")
+	default:
+	}
+	if err := service.Start(t.Context()); !errors.Is(err, errServiceStopping) {
+		t.Fatalf("Start error = %v, want %v", err, errServiceStopping)
+	}
+
+	release()
+	if err := service.Stop(t.Context()); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+	if err := service.Start(t.Context()); err != nil {
+		t.Fatalf("Start after drain failed: %v", err)
+	}
+	if err := service.Stop(t.Context()); err != nil {
+		t.Fatalf("final Stop failed: %v", err)
 	}
 }
 

--- a/server/internal/domain/ipscanner/service_test.go
+++ b/server/internal/domain/ipscanner/service_test.go
@@ -248,9 +248,11 @@ func TestIPScannerService_Stop_ReturnsAtDeadline(t *testing.T) {
 		mocks.NewMockDeviceIdentityCheckService(ctrl),
 		slog.Default(),
 	)
+	activationCtx, cancelActivation := context.WithCancel(t.Context())
 	service.run = &serviceRun{
-		cancel: func() {},
-		done:   make(chan struct{}),
+		activationDone: activationCtx.Done(),
+		cancel:         cancelActivation,
+		done:           make(chan struct{}),
 	}
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -14,7 +14,8 @@ import (
 // Lifecycle operations are serialized. A group can restart after a clean stop,
 // but incomplete cleanup permanently prevents another activation.
 type Group struct {
-	mu sync.Mutex
+	terminalErrMu   sync.Mutex
+	operationPermit chan struct{}
 
 	cleanupTimeout time.Duration
 	jobs           []Job
@@ -41,25 +42,28 @@ func NewGroup(jobs []Job, cleanupTimeout time.Duration) (*Group, error) {
 	}
 
 	return &Group{
-		cleanupTimeout: cleanupTimeout,
-		jobs:           slices.Clone(jobs),
+		cleanupTimeout:  cleanupTimeout,
+		jobs:            slices.Clone(jobs),
+		operationPermit: make(chan struct{}, 1),
 	}, nil
 }
 
 // Err reports the terminal cleanup failure that prevents reactivation.
 func (g *Group) Err() error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	g.terminalErrMu.Lock()
+	defer g.terminalErrMu.Unlock()
 	return g.terminalErr
 }
 
 // Start starts every job in registration order.
 func (g *Group) Start(ctx context.Context) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	if err := g.acquireOperation(ctx); err != nil {
+		return err
+	}
+	defer g.releaseOperation()
 
-	if g.terminalErr != nil {
-		return fmt.Errorf("runtime job group cannot restart after incomplete cleanup: %w", g.terminalErr)
+	if terminalErr := g.Err(); terminalErr != nil {
+		return fmt.Errorf("runtime job group cannot restart after incomplete cleanup: %w", terminalErr)
 	}
 	if g.cancel != nil {
 		select {
@@ -96,17 +100,20 @@ func (g *Group) failStart(ctx context.Context, started int, startErr error) erro
 		return startErr
 	}
 
-	g.terminalErr = errors.Join(startErr, fmt.Errorf("rollback runtime jobs: %w", rollbackErr))
-	return g.terminalErr
+	terminalErr := errors.Join(startErr, fmt.Errorf("rollback runtime jobs: %w", rollbackErr))
+	g.setTerminalErr(terminalErr)
+	return terminalErr
 }
 
 // Stop broadcasts cancellation, then stops jobs in reverse registration order.
 func (g *Group) Stop(ctx context.Context) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	if err := g.acquireOperation(ctx); err != nil {
+		return err
+	}
+	defer g.releaseOperation()
 
-	if g.terminalErr != nil {
-		return g.terminalErr
+	if terminalErr := g.Err(); terminalErr != nil {
+		return terminalErr
 	}
 	if g.cancel == nil {
 		return nil
@@ -116,10 +123,41 @@ func (g *Group) Stop(ctx context.Context) error {
 	g.activationDone = nil
 	g.cancel = nil
 	if err := g.stopJobs(ctx, g.jobs); err != nil {
-		g.terminalErr = err
+		g.setTerminalErr(err)
 		return err
 	}
 	return nil
+}
+
+func (g *Group) acquireOperation(ctx context.Context) error {
+	// Context bounds waiting behind another lifecycle operation. If the permit
+	// is already free, Stop must still make its best-effort cleanup attempt.
+	select {
+	case g.operationPermit <- struct{}{}:
+		return nil
+	default:
+	}
+
+	select {
+	case g.operationPermit <- struct{}{}:
+		if err := ctx.Err(); err != nil {
+			g.releaseOperation()
+			return fmt.Errorf("acquire runtime job group operation: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("acquire runtime job group operation: %w", ctx.Err())
+	}
+}
+
+func (g *Group) releaseOperation() {
+	<-g.operationPermit
+}
+
+func (g *Group) setTerminalErr(err error) {
+	g.terminalErrMu.Lock()
+	defer g.terminalErrMu.Unlock()
+	g.terminalErr = err
 }
 
 func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
@@ -139,15 +177,24 @@ func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
 		// necessarily best effort; waiting for it could make shutdown unbounded.
 		<-stopGoroutineStarted
 
-		var err error
-		select {
-		case err = <-result:
-		case <-stopCtx.Done():
-			err = stopCtx.Err()
-		}
+		err := waitForStopResult(stopCtx, result)
 		if err != nil {
 			stopErrors = append(stopErrors, fmt.Errorf("stop runtime job %q: %w", job.Name(), err))
 		}
 	}
 	return errors.Join(stopErrors...)
+}
+
+func waitForStopResult(stopCtx context.Context, result <-chan error) error {
+	select {
+	case err := <-result:
+		return err
+	case <-stopCtx.Done():
+		select {
+		case err := <-result:
+			return err
+		default:
+			return fmt.Errorf("wait for runtime job stop: %w", stopCtx.Err())
+		}
+	}
 }

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -1,0 +1,141 @@
+package runtimejobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+)
+
+// Group owns at most one activation of an ordered set of jobs at a time.
+//
+// Lifecycle operations are serialized. A group can restart after a clean stop,
+// but incomplete cleanup permanently prevents another activation.
+type Group struct {
+	mu sync.Mutex
+
+	cleanupTimeout time.Duration
+	jobs           []Job
+	terminalErr    error
+	cancel         context.CancelFunc
+}
+
+// NewGroup validates jobs and creates a stopped group. cleanupTimeout is one
+// wall-clock budget shared by every job during a stop or startup rollback.
+func NewGroup(jobs []Job, cleanupTimeout time.Duration) (*Group, error) {
+	if cleanupTimeout <= 0 {
+		return nil, errors.New("runtime job cleanup timeout must be positive")
+	}
+	seen := make(map[string]struct{}, len(jobs))
+	for i, job := range jobs {
+		if err := job.validate(); err != nil {
+			return nil, fmt.Errorf("runtime job %d: %w", i, err)
+		}
+		if _, ok := seen[job.Name()]; ok {
+			return nil, fmt.Errorf("runtime job name %q appears more than once", job.Name())
+		}
+		seen[job.Name()] = struct{}{}
+	}
+
+	return &Group{
+		cleanupTimeout: cleanupTimeout,
+		jobs:           slices.Clone(jobs),
+	}, nil
+}
+
+// Err reports the terminal cleanup failure that prevents reactivation.
+func (g *Group) Err() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.terminalErr
+}
+
+// Start starts every job in registration order.
+func (g *Group) Start(ctx context.Context) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.terminalErr != nil {
+		return fmt.Errorf("runtime job group cannot restart after incomplete cleanup: %w", g.terminalErr)
+	}
+	if g.cancel != nil {
+		return nil
+	}
+
+	activationCtx, cancel := context.WithCancel(ctx)
+	g.cancel = cancel
+	started := 0
+	for _, job := range g.jobs {
+		if err := activationCtx.Err(); err != nil {
+			return g.failStart(ctx, started, fmt.Errorf("start runtime job %q: %w", job.Name(), err))
+		}
+		if err := job.Start(activationCtx); err != nil {
+			return g.failStart(ctx, started, fmt.Errorf("start runtime job %q: %w", job.Name(), err))
+		}
+		started++
+	}
+
+	return nil
+}
+
+func (g *Group) failStart(ctx context.Context, started int, startErr error) error {
+	g.cancel()
+	rollbackErr := g.stopJobs(ctx, g.jobs[:started])
+	g.cancel = nil
+	if rollbackErr == nil {
+		return startErr
+	}
+
+	g.terminalErr = errors.Join(startErr, fmt.Errorf("rollback runtime jobs: %w", rollbackErr))
+	return g.terminalErr
+}
+
+// Stop broadcasts cancellation, then stops jobs in reverse registration order.
+func (g *Group) Stop(ctx context.Context) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.terminalErr != nil {
+		return g.terminalErr
+	}
+	if g.cancel == nil {
+		return nil
+	}
+
+	g.cancel()
+	g.cancel = nil
+	if err := g.stopJobs(ctx, g.jobs); err != nil {
+		g.terminalErr = err
+		return err
+	}
+	return nil
+}
+
+func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
+	stopCtx, cancel := context.WithTimeout(parent, g.cleanupTimeout)
+	defer cancel()
+
+	var stopErrors []error
+	for _, job := range slices.Backward(jobs) {
+		result := make(chan error, 1)
+		stopGoroutineStarted := make(chan struct{})
+		go func() {
+			close(stopGoroutineStarted)
+			result <- job.Stop(stopCtx)
+		}()
+		<-stopGoroutineStarted
+
+		var err error
+		select {
+		case err = <-result:
+		case <-stopCtx.Done():
+			err = stopCtx.Err()
+		}
+		if err != nil {
+			stopErrors = append(stopErrors, fmt.Errorf("stop runtime job %q: %w", job.Name(), err))
+		}
+	}
+	return errors.Join(stopErrors...)
+}

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -20,6 +20,7 @@ type Group struct {
 	cleanupTimeout time.Duration
 	jobs           []Job
 	terminalErr    error
+	pendingCleanup []Job
 	activationDone <-chan struct{}
 	cancel         context.CancelFunc
 }
@@ -93,13 +94,14 @@ func (g *Group) Start(ctx context.Context) error {
 
 func (g *Group) failStart(ctx context.Context, started int, startErr error) error {
 	g.cancel()
-	rollbackErr := g.stopJobs(ctx, g.jobs[:started])
+	pendingCleanup, rollbackErr := g.stopJobs(ctx, g.jobs[:started])
 	g.activationDone = nil
 	g.cancel = nil
 	if rollbackErr == nil {
 		return startErr
 	}
 
+	g.pendingCleanup = pendingCleanup
 	terminalErr := errors.Join(startErr, fmt.Errorf("rollback runtime jobs: %w", rollbackErr))
 	g.setTerminalErr(terminalErr)
 	return terminalErr
@@ -112,8 +114,10 @@ func (g *Group) Stop(ctx context.Context) error {
 	}
 	defer g.releaseOperation()
 
-	if terminalErr := g.Err(); terminalErr != nil {
-		return terminalErr
+	if len(g.pendingCleanup) > 0 {
+		var err error
+		g.pendingCleanup, err = g.stopJobs(ctx, g.pendingCleanup)
+		return err
 	}
 	if g.cancel == nil {
 		return nil
@@ -122,7 +126,9 @@ func (g *Group) Stop(ctx context.Context) error {
 	g.cancel()
 	g.activationDone = nil
 	g.cancel = nil
-	if err := g.stopJobs(ctx, g.jobs); err != nil {
+	pendingCleanup, err := g.stopJobs(ctx, g.jobs)
+	if err != nil {
+		g.pendingCleanup = pendingCleanup
 		g.setTerminalErr(err)
 		return err
 	}
@@ -160,10 +166,11 @@ func (g *Group) setTerminalErr(err error) {
 	g.terminalErr = err
 }
 
-func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
+func (g *Group) stopJobs(parent context.Context, jobs []Job) ([]Job, error) {
 	stopCtx, cancel := context.WithTimeout(parent, g.cleanupTimeout)
 	defer cancel()
 
+	var pendingCleanup []Job
 	var stopErrors []error
 	for _, job := range slices.Backward(jobs) {
 		result := make(chan error, 1)
@@ -179,10 +186,12 @@ func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
 
 		err := waitForStopResult(stopCtx, result)
 		if err != nil {
+			pendingCleanup = append(pendingCleanup, job)
 			stopErrors = append(stopErrors, fmt.Errorf("stop runtime job %q: %w", job.Name(), err))
 		}
 	}
-	return errors.Join(stopErrors...)
+	slices.Reverse(pendingCleanup)
+	return pendingCleanup, errors.Join(stopErrors...)
 }
 
 func waitForStopResult(stopCtx context.Context, result <-chan error) error {

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -104,7 +104,13 @@ func (g *Group) Start(ctx context.Context) error {
 
 func (g *Group) failStart(ctx context.Context, started int, startErr error) error {
 	g.cancelActivation()
-	pendingCleanup, rollbackErr := g.stopJobs(ctx, g.jobs[:started])
+	rollbackCtx := context.WithoutCancel(ctx)
+	if deadline, ok := ctx.Deadline(); ok {
+		var cancel context.CancelFunc
+		rollbackCtx, cancel = context.WithDeadline(rollbackCtx, deadline)
+		defer cancel()
+	}
+	pendingCleanup, rollbackErr := g.stopJobs(rollbackCtx, g.jobs[:started])
 	g.clearActivation()
 	if rollbackErr == nil {
 		return startErr

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -19,7 +19,7 @@ type Group struct {
 	cleanupTimeout time.Duration
 	jobs           []Job
 	terminalErr    error
-	activationCtx  context.Context
+	activationDone <-chan struct{}
 	cancel         context.CancelFunc
 }
 
@@ -62,14 +62,16 @@ func (g *Group) Start(ctx context.Context) error {
 		return fmt.Errorf("runtime job group cannot restart after incomplete cleanup: %w", g.terminalErr)
 	}
 	if g.cancel != nil {
-		if err := g.activationCtx.Err(); err != nil {
-			return fmt.Errorf("runtime job group activation ended before stop: %w", err)
+		select {
+		case <-g.activationDone:
+			return errors.New("runtime job group activation ended before stop")
+		default:
 		}
 		return nil
 	}
 
 	activationCtx, cancel := context.WithCancel(ctx)
-	g.activationCtx = activationCtx
+	g.activationDone = activationCtx.Done()
 	g.cancel = cancel
 	started := 0
 	for _, job := range g.jobs {
@@ -88,7 +90,7 @@ func (g *Group) Start(ctx context.Context) error {
 func (g *Group) failStart(ctx context.Context, started int, startErr error) error {
 	g.cancel()
 	rollbackErr := g.stopJobs(ctx, g.jobs[:started])
-	g.activationCtx = nil
+	g.activationDone = nil
 	g.cancel = nil
 	if rollbackErr == nil {
 		return startErr
@@ -111,7 +113,7 @@ func (g *Group) Stop(ctx context.Context) error {
 	}
 
 	g.cancel()
-	g.activationCtx = nil
+	g.activationDone = nil
 	g.cancel = nil
 	if err := g.stopJobs(ctx, g.jobs); err != nil {
 		g.terminalErr = err

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -19,6 +19,7 @@ type Group struct {
 	cleanupTimeout time.Duration
 	jobs           []Job
 	terminalErr    error
+	activationCtx  context.Context
 	cancel         context.CancelFunc
 }
 
@@ -61,10 +62,14 @@ func (g *Group) Start(ctx context.Context) error {
 		return fmt.Errorf("runtime job group cannot restart after incomplete cleanup: %w", g.terminalErr)
 	}
 	if g.cancel != nil {
+		if err := g.activationCtx.Err(); err != nil {
+			return fmt.Errorf("runtime job group activation ended before stop: %w", err)
+		}
 		return nil
 	}
 
 	activationCtx, cancel := context.WithCancel(ctx)
+	g.activationCtx = activationCtx
 	g.cancel = cancel
 	started := 0
 	for _, job := range g.jobs {
@@ -83,6 +88,7 @@ func (g *Group) Start(ctx context.Context) error {
 func (g *Group) failStart(ctx context.Context, started int, startErr error) error {
 	g.cancel()
 	rollbackErr := g.stopJobs(ctx, g.jobs[:started])
+	g.activationCtx = nil
 	g.cancel = nil
 	if rollbackErr == nil {
 		return startErr
@@ -105,6 +111,7 @@ func (g *Group) Stop(ctx context.Context) error {
 	}
 
 	g.cancel()
+	g.activationCtx = nil
 	g.cancel = nil
 	if err := g.stopJobs(ctx, g.jobs); err != nil {
 		g.terminalErr = err
@@ -125,6 +132,9 @@ func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
 			close(stopGoroutineStarted)
 			result <- job.Stop(stopCtx)
 		}()
+		// Schedule every stop attempt before honoring an already-expired group
+		// deadline. Once the caller's budget is gone, entering Stop itself is
+		// necessarily best effort; waiting for it could make shutdown unbounded.
 		<-stopGoroutineStarted
 
 		var err error

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -14,15 +14,17 @@ import (
 // Lifecycle operations are serialized. A group can restart after a clean stop,
 // but incomplete cleanup permanently prevents another activation.
 type Group struct {
-	terminalErrMu   sync.Mutex
+	stateMu         sync.Mutex
 	operationPermit chan struct{}
 
 	cleanupTimeout time.Duration
 	jobs           []Job
 	terminalErr    error
 	pendingCleanup []Job
+	stopAttempts   map[string]<-chan error
 	activationDone <-chan struct{}
 	cancel         context.CancelFunc
+	stopGeneration uint64
 }
 
 // NewGroup validates jobs and creates a stopped group. cleanupTimeout is one
@@ -46,18 +48,23 @@ func NewGroup(jobs []Job, cleanupTimeout time.Duration) (*Group, error) {
 		cleanupTimeout:  cleanupTimeout,
 		jobs:            slices.Clone(jobs),
 		operationPermit: make(chan struct{}, 1),
+		stopAttempts:    make(map[string]<-chan error),
 	}, nil
 }
 
 // Err reports the terminal cleanup failure that prevents reactivation.
 func (g *Group) Err() error {
-	g.terminalErrMu.Lock()
-	defer g.terminalErrMu.Unlock()
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
 	return g.terminalErr
 }
 
 // Start starts every job in registration order.
 func (g *Group) Start(ctx context.Context) error {
+	// A Stop requested after this Start invocation must cancel this activation,
+	// including the narrow interval between acquiring the operation permit and
+	// publishing the activation cancel function.
+	stopGeneration := g.currentStopGeneration()
 	if err := g.acquireOperation(ctx); err != nil {
 		return err
 	}
@@ -66,9 +73,10 @@ func (g *Group) Start(ctx context.Context) error {
 	if terminalErr := g.Err(); terminalErr != nil {
 		return fmt.Errorf("runtime job group cannot restart after incomplete cleanup: %w", terminalErr)
 	}
-	if g.cancel != nil {
+	activationDone, cancel := g.activation()
+	if cancel != nil {
 		select {
-		case <-g.activationDone:
+		case <-activationDone:
 			return errors.New("runtime job group activation ended before stop")
 		default:
 		}
@@ -76,8 +84,7 @@ func (g *Group) Start(ctx context.Context) error {
 	}
 
 	activationCtx, cancel := context.WithCancel(ctx)
-	g.activationDone = activationCtx.Done()
-	g.cancel = cancel
+	g.setActivation(activationCtx.Done(), cancel, stopGeneration)
 	started := 0
 	for _, job := range g.jobs {
 		if err := activationCtx.Err(); err != nil {
@@ -88,15 +95,17 @@ func (g *Group) Start(ctx context.Context) error {
 		}
 		started++
 	}
+	if err := activationCtx.Err(); err != nil {
+		return g.failStart(ctx, started, fmt.Errorf("start runtime job group: %w", err))
+	}
 
 	return nil
 }
 
 func (g *Group) failStart(ctx context.Context, started int, startErr error) error {
-	g.cancel()
+	g.cancelActivation()
 	pendingCleanup, rollbackErr := g.stopJobs(ctx, g.jobs[:started])
-	g.activationDone = nil
-	g.cancel = nil
+	g.clearActivation()
 	if rollbackErr == nil {
 		return startErr
 	}
@@ -109,6 +118,9 @@ func (g *Group) failStart(ctx context.Context, started int, startErr error) erro
 
 // Stop broadcasts cancellation, then stops jobs in reverse registration order.
 func (g *Group) Stop(ctx context.Context) error {
+	// Cancellation is not a lifecycle operation: broadcast it before waiting so
+	// a Start blocked inside a job can return and release the operation slot.
+	g.requestStop()
 	if err := g.acquireOperation(ctx); err != nil {
 		return err
 	}
@@ -119,13 +131,13 @@ func (g *Group) Stop(ctx context.Context) error {
 		g.pendingCleanup, err = g.stopJobs(ctx, g.pendingCleanup)
 		return err
 	}
-	if g.cancel == nil {
+	_, cancel := g.activation()
+	if cancel == nil {
 		return nil
 	}
 
-	g.cancel()
-	g.activationDone = nil
-	g.cancel = nil
+	g.cancelActivation()
+	g.clearActivation()
 	pendingCleanup, err := g.stopJobs(ctx, g.jobs)
 	if err != nil {
 		g.pendingCleanup = pendingCleanup
@@ -161,9 +173,56 @@ func (g *Group) releaseOperation() {
 }
 
 func (g *Group) setTerminalErr(err error) {
-	g.terminalErrMu.Lock()
-	defer g.terminalErrMu.Unlock()
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
 	g.terminalErr = err
+}
+
+func (g *Group) activation() (<-chan struct{}, context.CancelFunc) {
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
+	return g.activationDone, g.cancel
+}
+
+func (g *Group) currentStopGeneration() uint64 {
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
+	return g.stopGeneration
+}
+
+func (g *Group) setActivation(done <-chan struct{}, cancel context.CancelFunc, stopGeneration uint64) {
+	g.stateMu.Lock()
+	g.activationDone = done
+	g.cancel = cancel
+	stopRequested := g.stopGeneration != stopGeneration
+	g.stateMu.Unlock()
+	if stopRequested {
+		cancel()
+	}
+}
+
+func (g *Group) requestStop() {
+	g.stateMu.Lock()
+	g.stopGeneration++
+	cancel := g.cancel
+	g.stateMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (g *Group) cancelActivation() {
+	_, cancel := g.activation()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (g *Group) clearActivation() {
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
+	g.activationDone = nil
+	g.cancel = nil
 }
 
 func (g *Group) stopJobs(parent context.Context, jobs []Job) ([]Job, error) {
@@ -173,18 +232,7 @@ func (g *Group) stopJobs(parent context.Context, jobs []Job) ([]Job, error) {
 	var pendingCleanup []Job
 	var stopErrors []error
 	for _, job := range slices.Backward(jobs) {
-		result := make(chan error, 1)
-		stopGoroutineStarted := make(chan struct{})
-		go func() {
-			close(stopGoroutineStarted)
-			result <- job.Stop(stopCtx)
-		}()
-		// Schedule every stop attempt before honoring an already-expired group
-		// deadline. Once the caller's budget is gone, entering Stop itself is
-		// necessarily best effort; waiting for it could make shutdown unbounded.
-		<-stopGoroutineStarted
-
-		err := waitForStopResult(stopCtx, result)
+		err := g.stopJob(stopCtx, job)
 		if err != nil {
 			pendingCleanup = append(pendingCleanup, job)
 			stopErrors = append(stopErrors, fmt.Errorf("stop runtime job %q: %w", job.Name(), err))
@@ -194,16 +242,50 @@ func (g *Group) stopJobs(parent context.Context, jobs []Job) ([]Job, error) {
 	return pendingCleanup, errors.Join(stopErrors...)
 }
 
-func waitForStopResult(stopCtx context.Context, result <-chan error) error {
+func (g *Group) stopJob(stopCtx context.Context, job Job) error {
+	if result, ok := g.stopAttempts[job.Name()]; ok {
+		err, completed := waitForStopResult(stopCtx, result)
+		if !completed {
+			return err
+		}
+		delete(g.stopAttempts, job.Name())
+		if err == nil {
+			return nil
+		}
+		// This invocation joined the previous attempt. Once that attempt has
+		// returned, one fresh attempt is safe; never retry an attempt started by
+		// this same invocation or an immediate error could loop forever.
+	}
+
+	result := make(chan error, 1)
+	stopGoroutineStarted := make(chan struct{})
+	g.stopAttempts[job.Name()] = result
+	go func() {
+		close(stopGoroutineStarted)
+		result <- job.Stop(stopCtx)
+	}()
+	// Schedule every stop attempt before honoring an already-expired group
+	// deadline. Once the caller's budget is gone, entering Stop itself is
+	// necessarily best effort; waiting for it could make shutdown unbounded.
+	<-stopGoroutineStarted
+
+	err, completed := waitForStopResult(stopCtx, result)
+	if completed {
+		delete(g.stopAttempts, job.Name())
+	}
+	return err
+}
+
+func waitForStopResult(stopCtx context.Context, result <-chan error) (error, bool) {
 	select {
 	case err := <-result:
-		return err
+		return err, true
 	case <-stopCtx.Done():
 		select {
 		case err := <-result:
-			return err
+			return err, true
 		default:
-			return fmt.Errorf("wait for runtime job stop: %w", stopCtx.Err())
+			return fmt.Errorf("wait for runtime job stop: %w", stopCtx.Err()), false
 		}
 	}
 }

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -27,16 +27,17 @@ type Group struct {
 	stopGeneration uint64
 }
 
-// NewGroup validates jobs and creates a stopped group. cleanupTimeout is one
-// wall-clock budget shared by every job during a stop or startup rollback.
+// NewGroup validates group configuration and creates a stopped group.
+// cleanupTimeout is one wall-clock budget shared by every job during a stop
+// or startup rollback.
 func NewGroup(jobs []Job, cleanupTimeout time.Duration) (*Group, error) {
 	if cleanupTimeout <= 0 {
 		return nil, errors.New("runtime job cleanup timeout must be positive")
 	}
 	seen := make(map[string]struct{}, len(jobs))
 	for i, job := range jobs {
-		if err := job.validate(); err != nil {
-			return nil, fmt.Errorf("runtime job %d: %w", i, err)
+		if job == nil {
+			return nil, fmt.Errorf("runtime job %d must not be nil", i)
 		}
 		if _, ok := seen[job.Name()]; ok {
 			return nil, fmt.Errorf("runtime job name %q appears more than once", job.Name())

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const groupCleanupTimeout = 10 * time.Second
+
 // Group owns at most one activation of an ordered set of jobs at a time.
 //
 // Lifecycle operations are serialized. A group can restart after a clean stop,
@@ -28,12 +30,13 @@ type Group struct {
 }
 
 // NewGroup validates group configuration and creates a stopped group.
-// cleanupTimeout is one wall-clock budget shared by every job during a stop
+// The group shares one ten-second cleanup budget across every job during a stop
 // or startup rollback.
-func NewGroup(jobs []Job, cleanupTimeout time.Duration) (*Group, error) {
-	if cleanupTimeout <= 0 {
-		return nil, errors.New("runtime job cleanup timeout must be positive")
-	}
+func NewGroup(jobs []Job) (*Group, error) {
+	return newGroup(jobs, groupCleanupTimeout)
+}
+
+func newGroup(jobs []Job, cleanupTimeout time.Duration) (*Group, error) {
 	seen := make(map[string]struct{}, len(jobs))
 	for i, job := range jobs {
 		if job == nil {

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -21,8 +21,6 @@ type Group struct {
 
 	jobs           []Job
 	terminalErr    error
-	pendingCleanup []Job
-	stopAttempts   map[string]<-chan error
 	activationDone <-chan struct{}
 	cancel         context.CancelFunc
 	stopGeneration uint64
@@ -46,7 +44,6 @@ func NewGroup(jobs []Job) (*Group, error) {
 	return &Group{
 		jobs:            slices.Clone(jobs),
 		operationPermit: make(chan struct{}, 1),
-		stopAttempts:    make(map[string]<-chan error),
 	}, nil
 }
 
@@ -108,19 +105,19 @@ func (g *Group) failStart(ctx context.Context, started int, startErr error) erro
 		rollbackCtx, cancel = context.WithDeadline(rollbackCtx, deadline)
 		defer cancel()
 	}
-	pendingCleanup, rollbackErr := g.stopJobs(rollbackCtx, g.jobs[:started])
+	rollbackErr := g.stopJobs(rollbackCtx, g.jobs[:started])
 	g.clearActivation()
 	if rollbackErr == nil {
 		return startErr
 	}
 
-	g.pendingCleanup = pendingCleanup
 	terminalErr := errors.Join(startErr, fmt.Errorf("rollback runtime jobs: %w", rollbackErr))
 	g.setTerminalErr(terminalErr)
 	return terminalErr
 }
 
 // Stop broadcasts cancellation, then stops jobs in reverse registration order.
+// A cleanup failure is terminal and is not retried.
 func (g *Group) Stop(ctx context.Context) error {
 	// Cancellation is not a lifecycle operation: broadcast it before waiting so
 	// a Start blocked inside a job can return and release the operation slot.
@@ -130,10 +127,8 @@ func (g *Group) Stop(ctx context.Context) error {
 	}
 	defer g.releaseOperation()
 
-	if len(g.pendingCleanup) > 0 {
-		var err error
-		g.pendingCleanup, err = g.stopJobs(ctx, g.pendingCleanup)
-		return err
+	if terminalErr := g.Err(); terminalErr != nil {
+		return terminalErr
 	}
 	_, cancel := g.activation()
 	if cancel == nil {
@@ -142,9 +137,8 @@ func (g *Group) Stop(ctx context.Context) error {
 
 	g.cancelActivation()
 	g.clearActivation()
-	pendingCleanup, err := g.stopJobs(ctx, g.jobs)
+	err := g.stopJobs(ctx, g.jobs)
 	if err != nil {
-		g.pendingCleanup = pendingCleanup
 		g.setTerminalErr(err)
 		return err
 	}
@@ -229,41 +223,23 @@ func (g *Group) clearActivation() {
 	g.cancel = nil
 }
 
-func (g *Group) stopJobs(parent context.Context, jobs []Job) ([]Job, error) {
+func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
 	stopCtx, cancel := context.WithTimeout(parent, groupCleanupTimeout)
 	defer cancel()
 
-	var pendingCleanup []Job
 	var stopErrors []error
 	for _, job := range slices.Backward(jobs) {
 		err := g.stopJob(stopCtx, job)
 		if err != nil {
-			pendingCleanup = append(pendingCleanup, job)
 			stopErrors = append(stopErrors, fmt.Errorf("stop runtime job %q: %w", job.Name(), err))
 		}
 	}
-	slices.Reverse(pendingCleanup)
-	return pendingCleanup, errors.Join(stopErrors...)
+	return errors.Join(stopErrors...)
 }
 
 func (g *Group) stopJob(stopCtx context.Context, job Job) error {
-	if result, ok := g.stopAttempts[job.Name()]; ok {
-		err, completed := waitForStopResult(stopCtx, result)
-		if !completed {
-			return err
-		}
-		delete(g.stopAttempts, job.Name())
-		if err == nil {
-			return nil
-		}
-		// This invocation joined the previous attempt. Once that attempt has
-		// returned, one fresh attempt is safe; never retry an attempt started by
-		// this same invocation or an immediate error could loop forever.
-	}
-
 	result := make(chan error, 1)
 	stopGoroutineStarted := make(chan struct{})
-	g.stopAttempts[job.Name()] = result
 	go func() {
 		close(stopGoroutineStarted)
 		result <- job.Stop(stopCtx)
@@ -273,23 +249,19 @@ func (g *Group) stopJob(stopCtx context.Context, job Job) error {
 	// necessarily best effort; waiting for it could make shutdown unbounded.
 	<-stopGoroutineStarted
 
-	err, completed := waitForStopResult(stopCtx, result)
-	if completed {
-		delete(g.stopAttempts, job.Name())
-	}
-	return err
+	return waitForStopResult(stopCtx, result)
 }
 
-func waitForStopResult(stopCtx context.Context, result <-chan error) (error, bool) {
+func waitForStopResult(stopCtx context.Context, result <-chan error) error {
 	select {
 	case err := <-result:
-		return err, true
+		return err
 	case <-stopCtx.Done():
 		select {
 		case err := <-result:
-			return err, true
+			return err
 		default:
-			return fmt.Errorf("wait for runtime job stop: %w", stopCtx.Err()), false
+			return fmt.Errorf("wait for runtime job stop: %w", stopCtx.Err())
 		}
 	}
 }

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -16,14 +16,13 @@ const groupCleanupTimeout = 10 * time.Second
 // Lifecycle operations are serialized. A group can restart after a clean stop,
 // but incomplete cleanup permanently prevents another activation.
 type Group struct {
-	stateMu         sync.Mutex
-	operationPermit chan struct{}
+	stateMu     sync.Mutex
+	operationMu sync.Mutex
 
 	jobs           []Job
 	terminalErr    error
 	activationDone <-chan struct{}
 	cancel         context.CancelFunc
-	stopGeneration uint64
 }
 
 // NewGroup validates group configuration and creates a stopped group.
@@ -41,10 +40,7 @@ func NewGroup(jobs []Job) (*Group, error) {
 		seen[job.Name()] = struct{}{}
 	}
 
-	return &Group{
-		jobs:            slices.Clone(jobs),
-		operationPermit: make(chan struct{}, 1),
-	}, nil
+	return &Group{jobs: slices.Clone(jobs)}, nil
 }
 
 // Err reports the terminal cleanup failure that prevents reactivation.
@@ -56,14 +52,8 @@ func (g *Group) Err() error {
 
 // Start starts every job in registration order.
 func (g *Group) Start(ctx context.Context) error {
-	// A Stop requested after this Start invocation must cancel this activation,
-	// including the narrow interval between acquiring the operation permit and
-	// publishing the activation cancel function.
-	stopGeneration := g.currentStopGeneration()
-	if err := g.acquireOperation(ctx); err != nil {
-		return err
-	}
-	defer g.releaseOperation()
+	g.operationMu.Lock()
+	defer g.operationMu.Unlock()
 
 	if terminalErr := g.Err(); terminalErr != nil {
 		return fmt.Errorf("runtime job group cannot restart after incomplete cleanup: %w", terminalErr)
@@ -79,7 +69,7 @@ func (g *Group) Start(ctx context.Context) error {
 	}
 
 	activationCtx, cancel := context.WithCancel(ctx)
-	g.setActivation(activationCtx.Done(), cancel, stopGeneration)
+	g.setActivation(activationCtx.Done(), cancel)
 	started := 0
 	for _, job := range g.jobs {
 		if err := activationCtx.Err(); err != nil {
@@ -119,13 +109,8 @@ func (g *Group) failStart(ctx context.Context, started int, startErr error) erro
 // Stop broadcasts cancellation, then stops jobs in reverse registration order.
 // A cleanup failure is terminal and is not retried.
 func (g *Group) Stop(ctx context.Context) error {
-	// Cancellation is not a lifecycle operation: broadcast it before waiting so
-	// a Start blocked inside a job can return and release the operation slot.
-	g.requestStop()
-	if err := g.acquireOperation(ctx); err != nil {
-		return err
-	}
-	defer g.releaseOperation()
+	g.operationMu.Lock()
+	defer g.operationMu.Unlock()
 
 	if terminalErr := g.Err(); terminalErr != nil {
 		return terminalErr
@@ -145,31 +130,6 @@ func (g *Group) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (g *Group) acquireOperation(ctx context.Context) error {
-	// Context bounds waiting behind another lifecycle operation. If the permit
-	// is already free, Stop must still make its best-effort cleanup attempt.
-	select {
-	case g.operationPermit <- struct{}{}:
-		return nil
-	default:
-	}
-
-	select {
-	case g.operationPermit <- struct{}{}:
-		if err := ctx.Err(); err != nil {
-			g.releaseOperation()
-			return fmt.Errorf("acquire runtime job group operation: %w", err)
-		}
-		return nil
-	case <-ctx.Done():
-		return fmt.Errorf("acquire runtime job group operation: %w", ctx.Err())
-	}
-}
-
-func (g *Group) releaseOperation() {
-	<-g.operationPermit
-}
-
 func (g *Group) setTerminalErr(err error) {
 	g.stateMu.Lock()
 	defer g.stateMu.Unlock()
@@ -182,31 +142,11 @@ func (g *Group) activation() (<-chan struct{}, context.CancelFunc) {
 	return g.activationDone, g.cancel
 }
 
-func (g *Group) currentStopGeneration() uint64 {
+func (g *Group) setActivation(done <-chan struct{}, cancel context.CancelFunc) {
 	g.stateMu.Lock()
 	defer g.stateMu.Unlock()
-	return g.stopGeneration
-}
-
-func (g *Group) setActivation(done <-chan struct{}, cancel context.CancelFunc, stopGeneration uint64) {
-	g.stateMu.Lock()
 	g.activationDone = done
 	g.cancel = cancel
-	stopRequested := g.stopGeneration != stopGeneration
-	g.stateMu.Unlock()
-	if stopRequested {
-		cancel()
-	}
-}
-
-func (g *Group) requestStop() {
-	g.stateMu.Lock()
-	g.stopGeneration++
-	cancel := g.cancel
-	g.stateMu.Unlock()
-	if cancel != nil {
-		cancel()
-	}
 }
 
 func (g *Group) cancelActivation() {

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -19,7 +19,6 @@ type Group struct {
 	stateMu         sync.Mutex
 	operationPermit chan struct{}
 
-	cleanupTimeout time.Duration
 	jobs           []Job
 	terminalErr    error
 	pendingCleanup []Job
@@ -33,10 +32,6 @@ type Group struct {
 // The group shares one ten-second cleanup budget across every job during a stop
 // or startup rollback.
 func NewGroup(jobs []Job) (*Group, error) {
-	return newGroup(jobs, groupCleanupTimeout)
-}
-
-func newGroup(jobs []Job, cleanupTimeout time.Duration) (*Group, error) {
 	seen := make(map[string]struct{}, len(jobs))
 	for i, job := range jobs {
 		if job == nil {
@@ -49,7 +44,6 @@ func newGroup(jobs []Job, cleanupTimeout time.Duration) (*Group, error) {
 	}
 
 	return &Group{
-		cleanupTimeout:  cleanupTimeout,
 		jobs:            slices.Clone(jobs),
 		operationPermit: make(chan struct{}, 1),
 		stopAttempts:    make(map[string]<-chan error),
@@ -236,7 +230,7 @@ func (g *Group) clearActivation() {
 }
 
 func (g *Group) stopJobs(parent context.Context, jobs []Job) ([]Job, error) {
-	stopCtx, cancel := context.WithTimeout(parent, g.cleanupTimeout)
+	stopCtx, cancel := context.WithTimeout(parent, groupCleanupTimeout)
 	defer cancel()
 
 	var pendingCleanup []Job

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -258,11 +258,14 @@ func TestGroupStopHonorsCallerCancellation(t *testing.T) {
 	err := group.Stop(stopCtx)
 	require.ErrorIs(t, err, context.Canceled)
 
-	select {
-	case <-stopEntered:
-	default:
-		t.Fatal("stop was not attempted")
-	}
+	require.Eventually(t, func() bool {
+		select {
+		case <-stopEntered:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond, "stop was not attempted")
 }
 
 func TestGroupStartAndStopAreIdempotent(t *testing.T) {
@@ -282,6 +285,23 @@ func TestGroupStartAndStopAreIdempotent(t *testing.T) {
 	require.NoError(t, group.Stop(context.Background()))
 	assert.Equal(t, int32(1), starts.Load())
 	assert.Equal(t, int32(1), stops.Load())
+}
+
+func TestGroupRequiresStopAfterActivationContextEnds(t *testing.T) {
+	t.Parallel()
+
+	group := newTestGroup(t, newTestJob("job", nil, nil))
+	activationCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, group.Start(activationCtx))
+	cancel()
+
+	err := group.Start(context.Background())
+	require.ErrorContains(t, err, "activation ended before stop")
+	assert.ErrorIs(t, err, context.Canceled)
+
+	require.NoError(t, group.Stop(context.Background()))
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
 }
 
 func TestGroupRestartUsesFreshActivationContext(t *testing.T) {

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -200,6 +200,63 @@ func TestGroupStopTimeoutIsGroupWideAndTerminal(t *testing.T) {
 	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
 }
 
+func TestGroupStopRetriesOnlyIncompleteCleanup(t *testing.T) {
+	t.Parallel()
+
+	var completedStops atomic.Int32
+	var retriedStops atomic.Int32
+	group, err := NewGroup([]Job{
+		newTestJob("retried", noopJob, func(ctx context.Context) error {
+			if retriedStops.Add(1) == 1 {
+				<-ctx.Done()
+				return ctx.Err()
+			}
+			return nil
+		}),
+		newTestJob("completed", noopJob, func(context.Context) error {
+			completedStops.Add(1)
+			return nil
+		}),
+	}, 20*time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, group.Start(context.Background()))
+
+	require.ErrorIs(t, group.Stop(context.Background()), context.DeadlineExceeded)
+	require.NoError(t, group.Stop(context.Background()))
+	assert.Equal(t, int32(1), completedStops.Load())
+	assert.Equal(t, int32(2), retriedStops.Load())
+	assert.ErrorIs(t, group.Err(), context.DeadlineExceeded)
+	require.ErrorContains(t, group.Start(context.Background()), "cannot restart after incomplete cleanup")
+}
+
+func TestGroupStopRetriesIncompleteStartupRollback(t *testing.T) {
+	t.Parallel()
+
+	rollbackErr := errors.New("rollback failed")
+	var completedStops atomic.Int32
+	var retriedStops atomic.Int32
+	group := newTestGroup(t,
+		newTestJob("retried", noopJob, func(context.Context) error {
+			if retriedStops.Add(1) == 1 {
+				return rollbackErr
+			}
+			return nil
+		}),
+		newTestJob("completed", noopJob, func(context.Context) error {
+			completedStops.Add(1)
+			return nil
+		}),
+		newTestJob("fails", func(context.Context) error { return errors.New("start failed") }, noopJob),
+	)
+
+	require.ErrorIs(t, group.Start(context.Background()), rollbackErr)
+	require.NoError(t, group.Stop(context.Background()))
+	assert.Equal(t, int32(1), completedStops.Load())
+	assert.Equal(t, int32(2), retriedStops.Load())
+	assert.ErrorIs(t, group.Err(), rollbackErr)
+	require.ErrorContains(t, group.Start(context.Background()), "cannot restart after incomplete cleanup")
+}
+
 func TestGroupStopSharesOneDeadlineAcrossJobs(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -334,53 +334,144 @@ func TestGroupStopReturnsReadyResultAfterContextCancellation(t *testing.T) {
 	stopCtx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	assert.ErrorIs(t, waitForStopResult(stopCtx, result), stopErr)
+	err, completed := waitForStopResult(stopCtx, result)
+	assert.ErrorIs(t, err, stopErr)
+	assert.True(t, completed)
 }
 
-func TestGroupStopCanExpireWhileStartIsBlocked(t *testing.T) {
+func TestGroupStopCancelsBlockedStartBeforeWaitingForOperation(t *testing.T) {
 	t.Parallel()
 
 	startEntered := make(chan struct{})
-	releaseStart := make(chan struct{})
-	group := newTestGroup(t, newTestJob(
-		"job",
-		func(context.Context) error {
-			close(startEntered)
-			<-releaseStart
+	startCanceled := make(chan struct{})
+	var stops atomic.Int32
+	group := newTestGroup(t,
+		newTestJob("started", noopJob, func(context.Context) error {
+			stops.Add(1)
 			return nil
-		},
-		noopJob,
-	))
+		}),
+		newTestJob("blocked", func(ctx context.Context) error {
+			close(startEntered)
+			<-ctx.Done()
+			close(startCanceled)
+			return ctx.Err()
+		}, noopJob),
+	)
 
 	startResult := make(chan error, 1)
 	go func() {
 		startResult <- group.Start(context.Background())
 	}()
 	<-startEntered
-	released := false
-	defer func() {
-		if !released {
-			close(releaseStart)
-		}
+
+	stopResult := make(chan error, 1)
+	go func() {
+		stopResult <- group.Stop(context.Background())
 	}()
+
+	select {
+	case <-startCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel the blocked Start")
+	}
+
+	require.ErrorIs(t, <-startResult, context.Canceled)
+	require.NoError(t, <-stopResult)
+	assert.Equal(t, int32(1), stops.Load(), "Stop must roll back only the successfully started prefix")
+}
+
+func TestGroupStopRequestCancelsStartWaitingToPublishActivation(t *testing.T) {
+	t.Parallel()
+
+	var starts atomic.Int32
+	group := newTestGroup(t, newTestJob("job", func(context.Context) error {
+		starts.Add(1)
+		return nil
+	}, noopJob))
+
+	// Occupy the operation slot so Start snapshots the current stop generation,
+	// then blocks before it can publish its activation cancel function.
+	group.operationPermit <- struct{}{}
+	startWaiting := make(chan struct{}, 1)
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- group.Start(doneObservedContext{
+			observed: startWaiting,
+		})
+	}()
+	<-startWaiting
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
-	stopResult := make(chan error, 1)
-	go func() {
-		stopResult <- group.Stop(stopCtx)
-	}()
-	select {
-	case err := <-stopResult:
-		assert.ErrorIs(t, err, context.DeadlineExceeded)
-	case <-time.After(time.Second):
-		t.Fatal("Stop did not honor its context while Start was blocked")
-	}
+	require.ErrorIs(t, group.Stop(stopCtx), context.DeadlineExceeded)
 
-	close(releaseStart)
-	released = true
-	require.NoError(t, <-startResult)
-	require.NoError(t, group.Stop(context.Background()))
+	group.releaseOperation()
+	require.ErrorIs(t, <-startResult, context.Canceled)
+	assert.Equal(t, int32(0), starts.Load(), "the pre-publication stop request must cancel before any job starts")
+}
+
+func TestGroupStopRetryJoinsInFlightAttemptBeforeRetrying(t *testing.T) {
+	t.Parallel()
+
+	firstStopEntered := make(chan struct{})
+	releaseFirstStop := make(chan struct{})
+	secondStopEntered := make(chan struct{})
+	firstStopErr := errors.New("first stop failed")
+	var stopCalls atomic.Int32
+	var activeStops atomic.Int32
+	var maxActiveStops atomic.Int32
+	group, err := NewGroup([]Job{newTestJob("job", noopJob, func(context.Context) error {
+		call := stopCalls.Add(1)
+		active := activeStops.Add(1)
+		defer activeStops.Add(-1)
+		for {
+			currentMax := maxActiveStops.Load()
+			if active <= currentMax || maxActiveStops.CompareAndSwap(currentMax, active) {
+				break
+			}
+		}
+		if call == 1 {
+			close(firstStopEntered)
+			<-releaseFirstStop
+			return firstStopErr
+		}
+		close(secondStopEntered)
+		return nil
+	})}, 20*time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, group.Start(context.Background()))
+
+	firstResult := make(chan error, 1)
+	go func() {
+		firstResult <- group.Stop(context.Background())
+	}()
+	<-firstStopEntered
+	require.ErrorIs(t, <-firstResult, context.DeadlineExceeded)
+
+	retryResult := make(chan error, 1)
+	go func() {
+		retryResult <- group.Stop(context.Background())
+	}()
+	require.Eventually(t, func() bool {
+		return len(group.operationPermit) == 1
+	}, time.Second, time.Millisecond, "retry did not acquire the serialized operation permit")
+	select {
+	case <-secondStopEntered:
+		t.Fatal("retry overlapped the in-flight job Stop")
+	default:
+	}
+	assert.Equal(t, int32(1), stopCalls.Load())
+
+	close(releaseFirstStop)
+	select {
+	case <-secondStopEntered:
+	case <-time.After(time.Second):
+		t.Fatal("retry did not make a fresh attempt after the joined attempt failed")
+	}
+	require.NoError(t, <-retryResult)
+	assert.Equal(t, int32(2), stopCalls.Load())
+	assert.Equal(t, int32(1), maxActiveStops.Load())
+	assert.ErrorIs(t, group.Err(), context.DeadlineExceeded)
 }
 
 func TestGroupStartAndStopAreIdempotent(t *testing.T) {
@@ -473,6 +564,23 @@ func newTestJob(name string, start, stop func(context.Context) error) Job {
 }
 
 func noopJob(context.Context) error { return nil }
+
+type doneObservedContext struct {
+	observed chan<- struct{}
+}
+
+func (doneObservedContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+
+func (c doneObservedContext) Done() <-chan struct{} {
+	select {
+	case c.observed <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (doneObservedContext) Err() error    { return nil }
+func (doneObservedContext) Value(any) any { return nil }
 
 type testLifecycle struct {
 	start func(context.Context) error

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -268,6 +268,64 @@ func TestGroupStopHonorsCallerCancellation(t *testing.T) {
 	}, time.Second, time.Millisecond, "stop was not attempted")
 }
 
+func TestGroupStopReturnsReadyResultAfterContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	stopErr := errors.New("stop failed")
+	result := make(chan error, 1)
+	result <- stopErr
+	stopCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.ErrorIs(t, waitForStopResult(stopCtx, result), stopErr)
+}
+
+func TestGroupStopCanExpireWhileStartIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	startEntered := make(chan struct{})
+	releaseStart := make(chan struct{})
+	group := newTestGroup(t, newTestJob(
+		"job",
+		func(context.Context) error {
+			close(startEntered)
+			<-releaseStart
+			return nil
+		},
+		noopJob,
+	))
+
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- group.Start(context.Background())
+	}()
+	<-startEntered
+	released := false
+	defer func() {
+		if !released {
+			close(releaseStart)
+		}
+	}()
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	stopResult := make(chan error, 1)
+	go func() {
+		stopResult <- group.Stop(stopCtx)
+	}()
+	select {
+	case err := <-stopResult:
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not honor its context while Start was blocked")
+	}
+
+	close(releaseStart)
+	released = true
+	require.NoError(t, <-startResult)
+	require.NoError(t, group.Stop(context.Background()))
+}
+
 func TestGroupStartAndStopAreIdempotent(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -1,0 +1,361 @@
+package runtimejobs
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewJobValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewJob("", testLifecycle{start: noopJob, stop: noopJob})
+	require.EqualError(t, err, "name must not be empty")
+
+	_, err = NewJob("job", nil)
+	require.EqualError(t, err, "lifecycle must not be nil")
+}
+
+func TestNewGroupValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewGroup([]Job{{name: "job"}}, time.Second)
+	require.ErrorContains(t, err, "runtime job 0: lifecycle must not be nil")
+
+	job := newTestJob("job", nil, nil)
+	_, err = NewGroup([]Job{job, job}, time.Second)
+	require.ErrorContains(t, err, "appears more than once")
+
+	_, err = NewGroup(nil, 0)
+	require.ErrorContains(t, err, "cleanup timeout must be positive")
+}
+
+func TestGroupStartsInOrderAndStopsInReverseAfterBroadcastingCancellation(t *testing.T) {
+	t.Parallel()
+
+	var events eventLog
+	makeJob := func(name string) Job {
+		var activationDone <-chan struct{}
+		return newTestJob(
+			name,
+			func(ctx context.Context) error {
+				activationDone = ctx.Done()
+				events.add("start:" + name)
+				return nil
+			},
+			func(context.Context) error {
+				select {
+				case <-activationDone:
+				default:
+					return errors.New("activation context was not canceled before stop")
+				}
+				events.add("stop:" + name)
+				return nil
+			},
+		)
+	}
+
+	group := newTestGroup(t, makeJob("a"), makeJob("b"), makeJob("c"))
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+
+	assert.Equal(t, []string{
+		"start:a", "start:b", "start:c",
+		"stop:c", "stop:b", "stop:a",
+	}, events.snapshot())
+}
+
+func TestGroupRollsBackCleanlyAndCanRetry(t *testing.T) {
+	t.Parallel()
+
+	var events eventLog
+	var failingStarts atomic.Int32
+	makeJob := func(name string) Job {
+		return newTestJob(
+			name,
+			func(context.Context) error {
+				events.add("start:" + name)
+				if name == "c" && failingStarts.Add(1) == 1 {
+					return errors.New("start c")
+				}
+				return nil
+			},
+			func(context.Context) error {
+				events.add("stop:" + name)
+				return nil
+			},
+		)
+	}
+	group := newTestGroup(t, makeJob("a"), makeJob("b"), makeJob("c"))
+
+	err := group.Start(context.Background())
+	require.ErrorContains(t, err, "start c")
+	assert.Equal(t, []string{"start:a", "start:b", "start:c", "stop:b", "stop:a"}, events.snapshot())
+
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+}
+
+func TestGroupRollbackUsesStartDeadline(t *testing.T) {
+	t.Parallel()
+
+	rollbackDeadline := make(chan time.Time, 1)
+	group := newTestGroup(t,
+		newTestJob("started", nil, func(ctx context.Context) error {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return errors.New("rollback context has no deadline")
+			}
+			rollbackDeadline <- deadline
+			return nil
+		}),
+		newTestJob("fails", func(context.Context) error { return errors.New("start failed") }, nil),
+	)
+
+	startCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	wantDeadline, ok := startCtx.Deadline()
+	require.True(t, ok)
+
+	require.ErrorContains(t, group.Start(startCtx), "start failed")
+	assert.True(t, wantDeadline.Equal(<-rollbackDeadline), "rollback must retain the Start caller's deadline")
+}
+
+func TestGroupRollbackFailureIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	rollbackErr := errors.New("rollback failed")
+	group := newTestGroup(t,
+		newTestJob("a", nil, func(context.Context) error { return rollbackErr }),
+		newTestJob("b", func(context.Context) error { return errors.New("start failed") }, nil),
+	)
+
+	err := group.Start(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rollbackErr)
+
+	err = group.Start(context.Background())
+	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
+	assert.ErrorIs(t, err, rollbackErr)
+	assert.ErrorIs(t, group.Err(), rollbackErr)
+}
+
+func TestGroupStopAggregatesErrorsAndBecomesTerminal(t *testing.T) {
+	t.Parallel()
+
+	errA := errors.New("stop a")
+	errB := errors.New("stop b")
+	group := newTestGroup(t,
+		newTestJob("a", nil, func(context.Context) error { return errA }),
+		newTestJob("b", nil, func(context.Context) error { return errB }),
+	)
+	require.NoError(t, group.Start(context.Background()))
+
+	err := group.Stop(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errA)
+	assert.ErrorIs(t, err, errB)
+
+	err = group.Start(context.Background())
+	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
+	assert.ErrorIs(t, err, errA)
+	assert.ErrorIs(t, group.Err(), errA)
+}
+
+func TestGroupStopTimeoutIsGroupWideAndTerminal(t *testing.T) {
+	t.Parallel()
+
+	stopEntered := make(chan struct{})
+	allowStop := make(chan struct{})
+	defer close(allowStop)
+	group, err := NewGroup([]Job{newTestJob(
+		"stuck",
+		noopJob,
+		func(context.Context) error {
+			close(stopEntered)
+			<-allowStop
+			return nil
+		},
+	)}, 20*time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, group.Start(context.Background()))
+
+	started := time.Now()
+	err = group.Stop(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	select {
+	case <-stopEntered:
+	default:
+		t.Fatal("stop was not attempted")
+	}
+
+	err = group.Start(context.Background())
+	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
+}
+
+func TestGroupStopSharesOneDeadlineAcrossJobs(t *testing.T) {
+	t.Parallel()
+
+	deadlines := make(chan time.Time, 2)
+	makeJob := func(name string, waitForDeadline bool) Job {
+		return newTestJob(
+			name,
+			noopJob,
+			func(ctx context.Context) error {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					return errors.New("stop context has no deadline")
+				}
+				deadlines <- deadline
+				if waitForDeadline {
+					<-ctx.Done()
+					return ctx.Err()
+				}
+				time.Sleep(10 * time.Millisecond)
+				return nil
+			},
+		)
+	}
+	group, err := NewGroup([]Job{
+		makeJob("waits-for-deadline", true),
+		makeJob("uses-part-of-budget", false),
+	}, 30*time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, group.Start(context.Background()))
+	require.ErrorIs(t, group.Stop(context.Background()), context.DeadlineExceeded)
+
+	first := <-deadlines
+	second := <-deadlines
+	assert.True(t, first.Equal(second), "every job must receive the same group-wide deadline")
+}
+
+func TestGroupStopHonorsCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	stopEntered := make(chan struct{})
+	releaseStop := make(chan struct{})
+	defer close(releaseStop)
+	group := newTestGroup(t, newTestJob(
+		"job",
+		nil,
+		func(context.Context) error {
+			close(stopEntered)
+			<-releaseStop
+			return nil
+		},
+	))
+	require.NoError(t, group.Start(context.Background()))
+
+	stopCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := group.Stop(stopCtx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	select {
+	case <-stopEntered:
+	default:
+		t.Fatal("stop was not attempted")
+	}
+}
+
+func TestGroupStartAndStopAreIdempotent(t *testing.T) {
+	t.Parallel()
+
+	var starts atomic.Int32
+	var stops atomic.Int32
+	group := newTestGroup(t, newTestJob(
+		"job",
+		func(context.Context) error { starts.Add(1); return nil },
+		func(context.Context) error { stops.Add(1); return nil },
+	))
+
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+	assert.Equal(t, int32(1), starts.Load())
+	assert.Equal(t, int32(1), stops.Load())
+}
+
+func TestGroupRestartUsesFreshActivationContext(t *testing.T) {
+	t.Parallel()
+
+	var contexts []context.Context
+	group := newTestGroup(t, newTestJob(
+		"job",
+		func(ctx context.Context) error {
+			contexts = append(contexts, ctx)
+			return nil
+		},
+		noopJob,
+	))
+
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+	require.NoError(t, group.Start(context.Background()))
+
+	require.Len(t, contexts, 2)
+	first := contexts[0]
+	second := contexts[1]
+	select {
+	case <-first.Done():
+	default:
+		t.Fatal("first activation context was not canceled")
+	}
+	select {
+	case <-second.Done():
+		t.Fatal("second activation context should still be active")
+	default:
+	}
+	require.NoError(t, group.Stop(context.Background()))
+}
+
+func newTestGroup(t *testing.T, jobs ...Job) *Group {
+	t.Helper()
+	group, err := NewGroup(jobs, time.Second)
+	require.NoError(t, err)
+	return group
+}
+
+func newTestJob(name string, start, stop func(context.Context) error) Job {
+	if start == nil {
+		start = noopJob
+	}
+	if stop == nil {
+		stop = noopJob
+	}
+	job, err := NewJob(name, testLifecycle{start: start, stop: stop})
+	if err != nil {
+		panic(err)
+	}
+	return job
+}
+
+func noopJob(context.Context) error { return nil }
+
+type testLifecycle struct {
+	start func(context.Context) error
+	stop  func(context.Context) error
+}
+
+func (l testLifecycle) Start(ctx context.Context) error { return l.start(ctx) }
+func (l testLifecycle) Stop(ctx context.Context) error  { return l.stop(ctx) }
+
+type eventLog struct {
+	events []string
+}
+
+func (l *eventLog) add(event string) {
+	l.events = append(l.events, event)
+}
+
+func (l *eventLog) snapshot() []string {
+	return append([]string(nil), l.events...)
+}

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -126,6 +126,28 @@ func TestGroupRollbackUsesStartDeadline(t *testing.T) {
 	assert.True(t, wantDeadline.Equal(<-rollbackDeadline), "rollback must retain the Start caller's deadline")
 }
 
+func TestGroupRollbackDetachesManualStartCancellation(t *testing.T) {
+	t.Parallel()
+
+	startCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rollbackResult := make(chan error, 1)
+	group := newTestGroup(t,
+		newTestJob("started", nil, func(ctx context.Context) error {
+			rollbackResult <- ctx.Err()
+			return ctx.Err()
+		}),
+		newTestJob("fails", func(context.Context) error {
+			cancel()
+			return errors.New("start failed")
+		}, nil),
+	)
+
+	require.ErrorContains(t, group.Start(startCtx), "start failed")
+	require.NoError(t, <-rollbackResult, "rollback must not inherit manual Start cancellation")
+	require.NoError(t, group.Err())
+}
+
 func TestGroupRollbackFailureIsTerminal(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -297,7 +297,6 @@ func TestGroupRequiresStopAfterActivationContextEnds(t *testing.T) {
 
 	err := group.Start(context.Background())
 	require.ErrorContains(t, err, "activation ended before stop")
-	assert.ErrorIs(t, err, context.Canceled)
 
 	require.NoError(t, group.Stop(context.Background()))
 	require.NoError(t, group.Start(context.Background()))

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -328,77 +328,6 @@ func TestGroupStopReturnsReadyResultAfterContextCancellation(t *testing.T) {
 	assert.ErrorIs(t, err, stopErr)
 }
 
-func TestGroupStopCancelsBlockedStartBeforeWaitingForOperation(t *testing.T) {
-	t.Parallel()
-
-	startEntered := make(chan struct{})
-	startCanceled := make(chan struct{})
-	var stops atomic.Int32
-	group := newTestGroup(t,
-		newTestJob("started", noopJob, func(context.Context) error {
-			stops.Add(1)
-			return nil
-		}),
-		newTestJob("blocked", func(ctx context.Context) error {
-			close(startEntered)
-			<-ctx.Done()
-			close(startCanceled)
-			return ctx.Err()
-		}, noopJob),
-	)
-
-	startResult := make(chan error, 1)
-	go func() {
-		startResult <- group.Start(context.Background())
-	}()
-	<-startEntered
-
-	stopResult := make(chan error, 1)
-	go func() {
-		stopResult <- group.Stop(context.Background())
-	}()
-
-	select {
-	case <-startCanceled:
-	case <-time.After(time.Second):
-		t.Fatal("Stop did not cancel the blocked Start")
-	}
-
-	require.ErrorIs(t, <-startResult, context.Canceled)
-	require.NoError(t, <-stopResult)
-	assert.Equal(t, int32(1), stops.Load(), "Stop must roll back only the successfully started prefix")
-}
-
-func TestGroupStopRequestCancelsStartWaitingToPublishActivation(t *testing.T) {
-	t.Parallel()
-
-	var starts atomic.Int32
-	group := newTestGroup(t, newTestJob("job", func(context.Context) error {
-		starts.Add(1)
-		return nil
-	}, noopJob))
-
-	// Occupy the operation slot so Start snapshots the current stop generation,
-	// then blocks before it can publish its activation cancel function.
-	group.operationPermit <- struct{}{}
-	startWaiting := make(chan struct{}, 1)
-	startResult := make(chan error, 1)
-	go func() {
-		startResult <- group.Start(doneObservedContext{
-			observed: startWaiting,
-		})
-	}()
-	<-startWaiting
-
-	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	require.ErrorIs(t, group.Stop(stopCtx), context.DeadlineExceeded)
-
-	group.releaseOperation()
-	require.ErrorIs(t, <-startResult, context.Canceled)
-	assert.Equal(t, int32(0), starts.Load(), "the pre-publication stop request must cancel before any job starts")
-}
-
 func TestGroupStartAndStopAreIdempotent(t *testing.T) {
 	t.Parallel()
 
@@ -456,23 +385,6 @@ func newTestJob(name string, start, stop func(context.Context) error) Job {
 }
 
 func noopJob(context.Context) error { return nil }
-
-type doneObservedContext struct {
-	observed chan<- struct{}
-}
-
-func (doneObservedContext) Deadline() (time.Time, bool) { return time.Time{}, false }
-
-func (c doneObservedContext) Done() <-chan struct{} {
-	select {
-	case c.observed <- struct{}{}:
-	default:
-	}
-	return nil
-}
-
-func (doneObservedContext) Err() error    { return nil }
-func (doneObservedContext) Value(any) any { return nil }
 
 type testLifecycle struct {
 	start func(context.Context) error

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -24,8 +24,8 @@ func TestNewJobValidation(t *testing.T) {
 func TestNewGroupValidation(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewGroup([]Job{{name: "job"}}, time.Second)
-	require.ErrorContains(t, err, "runtime job 0: lifecycle must not be nil")
+	_, err := NewGroup([]Job{nil}, time.Second)
+	require.ErrorContains(t, err, "runtime job 0 must not be nil")
 
 	job := newTestJob("job", nil, nil)
 	_, err = NewGroup([]Job{job, job}, time.Second)

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -531,39 +531,6 @@ func TestGroupRequiresStopAfterActivationContextEnds(t *testing.T) {
 	require.NoError(t, group.Stop(context.Background()))
 }
 
-func TestGroupRestartUsesFreshActivationContext(t *testing.T) {
-	t.Parallel()
-
-	var contexts []context.Context
-	group := newTestGroup(t, newTestJob(
-		"job",
-		func(ctx context.Context) error {
-			contexts = append(contexts, ctx)
-			return nil
-		},
-		noopJob,
-	))
-
-	require.NoError(t, group.Start(context.Background()))
-	require.NoError(t, group.Stop(context.Background()))
-	require.NoError(t, group.Start(context.Background()))
-
-	require.Len(t, contexts, 2)
-	first := contexts[0]
-	second := contexts[1]
-	select {
-	case <-first.Done():
-	default:
-		t.Fatal("first activation context was not canceled")
-	}
-	select {
-	case <-second.Done():
-		t.Fatal("second activation context should still be active")
-	default:
-	}
-	require.NoError(t, group.Stop(context.Background()))
-}
-
 func newTestGroup(t *testing.T, jobs ...Job) *Group {
 	t.Helper()
 	group, err := NewGroup(jobs, time.Second)

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -192,7 +192,7 @@ func TestGroupStopTimeoutIsGroupWideAndTerminal(t *testing.T) {
 	stopEntered := make(chan struct{})
 	allowStop := make(chan struct{})
 	defer close(allowStop)
-	group, err := newGroup([]Job{newTestJob(
+	group, err := NewGroup([]Job{newTestJob(
 		"stuck",
 		noopJob,
 		func(context.Context) error {
@@ -200,12 +200,14 @@ func TestGroupStopTimeoutIsGroupWideAndTerminal(t *testing.T) {
 			<-allowStop
 			return nil
 		},
-	)}, 20*time.Millisecond)
+	)})
 	require.NoError(t, err)
 	require.NoError(t, group.Start(context.Background()))
 
+	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
 	started := time.Now()
-	err = group.Stop(context.Background())
+	err = group.Stop(stopCtx)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Less(t, time.Since(started), 500*time.Millisecond)
@@ -224,7 +226,7 @@ func TestGroupStopRetriesOnlyIncompleteCleanup(t *testing.T) {
 
 	var completedStops atomic.Int32
 	var retriedStops atomic.Int32
-	group, err := newGroup([]Job{
+	group, err := NewGroup([]Job{
 		newTestJob("retried", noopJob, func(ctx context.Context) error {
 			if retriedStops.Add(1) == 1 {
 				<-ctx.Done()
@@ -236,11 +238,13 @@ func TestGroupStopRetriesOnlyIncompleteCleanup(t *testing.T) {
 			completedStops.Add(1)
 			return nil
 		}),
-	}, 20*time.Millisecond)
+	})
 	require.NoError(t, err)
 	require.NoError(t, group.Start(context.Background()))
 
-	require.ErrorIs(t, group.Stop(context.Background()), context.DeadlineExceeded)
+	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, group.Stop(stopCtx), context.DeadlineExceeded)
 	require.NoError(t, group.Stop(context.Background()))
 	assert.Equal(t, int32(1), completedStops.Load())
 	assert.Equal(t, int32(2), retriedStops.Load())
@@ -299,13 +303,15 @@ func TestGroupStopSharesOneDeadlineAcrossJobs(t *testing.T) {
 			},
 		)
 	}
-	group, err := newGroup([]Job{
+	group, err := NewGroup([]Job{
 		makeJob("waits-for-deadline", true),
 		makeJob("uses-part-of-budget", false),
-	}, 30*time.Millisecond)
+	})
 	require.NoError(t, err)
 	require.NoError(t, group.Start(context.Background()))
-	require.ErrorIs(t, group.Stop(context.Background()), context.DeadlineExceeded)
+	stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, group.Stop(stopCtx), context.DeadlineExceeded)
 
 	first := <-deadlines
 	second := <-deadlines
@@ -439,7 +445,7 @@ func TestGroupStopRetryJoinsInFlightAttemptBeforeRetrying(t *testing.T) {
 	var stopCalls atomic.Int32
 	var activeStops atomic.Int32
 	var maxActiveStops atomic.Int32
-	group, err := newGroup([]Job{newTestJob("job", noopJob, func(context.Context) error {
+	group, err := NewGroup([]Job{newTestJob("job", noopJob, func(context.Context) error {
 		call := stopCalls.Add(1)
 		active := activeStops.Add(1)
 		defer activeStops.Add(-1)
@@ -456,13 +462,15 @@ func TestGroupStopRetryJoinsInFlightAttemptBeforeRetrying(t *testing.T) {
 		}
 		close(secondStopEntered)
 		return nil
-	})}, 20*time.Millisecond)
+	})})
 	require.NoError(t, err)
 	require.NoError(t, group.Start(context.Background()))
 
 	firstResult := make(chan error, 1)
 	go func() {
-		firstResult <- group.Stop(context.Background())
+		stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		firstResult <- group.Stop(stopCtx)
 	}()
 	<-firstStopEntered
 	require.ErrorIs(t, <-firstResult, context.DeadlineExceeded)
@@ -530,7 +538,7 @@ func TestGroupRequiresStopAfterActivationContextEnds(t *testing.T) {
 
 func newTestGroup(t *testing.T, jobs ...Job) *Group {
 	t.Helper()
-	group, err := newGroup(jobs, time.Second)
+	group, err := NewGroup(jobs)
 	require.NoError(t, err)
 	return group
 }

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -149,14 +149,21 @@ func TestGroupRollbackFailureIsTerminal(t *testing.T) {
 	t.Parallel()
 
 	rollbackErr := errors.New("rollback failed")
+	var stopCalls atomic.Int32
 	group := newTestGroup(t,
-		newTestJob("a", nil, func(context.Context) error { return rollbackErr }),
+		newTestJob("a", nil, func(context.Context) error {
+			stopCalls.Add(1)
+			return rollbackErr
+		}),
 		newTestJob("b", func(context.Context) error { return errors.New("start failed") }, nil),
 	)
 
 	err := group.Start(context.Background())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, rollbackErr)
+
+	assert.ErrorIs(t, group.Stop(context.Background()), rollbackErr)
+	assert.Equal(t, int32(1), stopCalls.Load())
 
 	err = group.Start(context.Background())
 	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
@@ -169,9 +176,16 @@ func TestGroupStopAggregatesErrorsAndBecomesTerminal(t *testing.T) {
 
 	errA := errors.New("stop a")
 	errB := errors.New("stop b")
+	var stopCalls atomic.Int32
 	group := newTestGroup(t,
-		newTestJob("a", nil, func(context.Context) error { return errA }),
-		newTestJob("b", nil, func(context.Context) error { return errB }),
+		newTestJob("a", nil, func(context.Context) error {
+			stopCalls.Add(1)
+			return errA
+		}),
+		newTestJob("b", nil, func(context.Context) error {
+			stopCalls.Add(1)
+			return errB
+		}),
 	)
 	require.NoError(t, group.Start(context.Background()))
 
@@ -179,6 +193,11 @@ func TestGroupStopAggregatesErrorsAndBecomesTerminal(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errA)
 	assert.ErrorIs(t, err, errB)
+
+	err = group.Stop(context.Background())
+	assert.ErrorIs(t, err, errA)
+	assert.ErrorIs(t, err, errB)
+	assert.Equal(t, int32(2), stopCalls.Load())
 
 	err = group.Start(context.Background())
 	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
@@ -192,10 +211,12 @@ func TestGroupStopTimeoutIsGroupWideAndTerminal(t *testing.T) {
 	stopEntered := make(chan struct{})
 	allowStop := make(chan struct{})
 	defer close(allowStop)
+	var stopCalls atomic.Int32
 	group, err := NewGroup([]Job{newTestJob(
 		"stuck",
 		noopJob,
 		func(context.Context) error {
+			stopCalls.Add(1)
 			close(stopEntered)
 			<-allowStop
 			return nil
@@ -217,67 +238,11 @@ func TestGroupStopTimeoutIsGroupWideAndTerminal(t *testing.T) {
 		t.Fatal("stop was not attempted")
 	}
 
+	require.ErrorIs(t, group.Stop(context.Background()), context.DeadlineExceeded)
+	assert.Equal(t, int32(1), stopCalls.Load())
+
 	err = group.Start(context.Background())
 	require.ErrorContains(t, err, "cannot restart after incomplete cleanup")
-}
-
-func TestGroupStopRetriesOnlyIncompleteCleanup(t *testing.T) {
-	t.Parallel()
-
-	var completedStops atomic.Int32
-	var retriedStops atomic.Int32
-	group, err := NewGroup([]Job{
-		newTestJob("retried", noopJob, func(ctx context.Context) error {
-			if retriedStops.Add(1) == 1 {
-				<-ctx.Done()
-				return ctx.Err()
-			}
-			return nil
-		}),
-		newTestJob("completed", noopJob, func(context.Context) error {
-			completedStops.Add(1)
-			return nil
-		}),
-	})
-	require.NoError(t, err)
-	require.NoError(t, group.Start(context.Background()))
-
-	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	require.ErrorIs(t, group.Stop(stopCtx), context.DeadlineExceeded)
-	require.NoError(t, group.Stop(context.Background()))
-	assert.Equal(t, int32(1), completedStops.Load())
-	assert.Equal(t, int32(2), retriedStops.Load())
-	assert.ErrorIs(t, group.Err(), context.DeadlineExceeded)
-	require.ErrorContains(t, group.Start(context.Background()), "cannot restart after incomplete cleanup")
-}
-
-func TestGroupStopRetriesIncompleteStartupRollback(t *testing.T) {
-	t.Parallel()
-
-	rollbackErr := errors.New("rollback failed")
-	var completedStops atomic.Int32
-	var retriedStops atomic.Int32
-	group := newTestGroup(t,
-		newTestJob("retried", noopJob, func(context.Context) error {
-			if retriedStops.Add(1) == 1 {
-				return rollbackErr
-			}
-			return nil
-		}),
-		newTestJob("completed", noopJob, func(context.Context) error {
-			completedStops.Add(1)
-			return nil
-		}),
-		newTestJob("fails", func(context.Context) error { return errors.New("start failed") }, noopJob),
-	)
-
-	require.ErrorIs(t, group.Start(context.Background()), rollbackErr)
-	require.NoError(t, group.Stop(context.Background()))
-	assert.Equal(t, int32(1), completedStops.Load())
-	assert.Equal(t, int32(2), retriedStops.Load())
-	assert.ErrorIs(t, group.Err(), rollbackErr)
-	require.ErrorContains(t, group.Start(context.Background()), "cannot restart after incomplete cleanup")
 }
 
 func TestGroupStopSharesOneDeadlineAcrossJobs(t *testing.T) {
@@ -359,9 +324,8 @@ func TestGroupStopReturnsReadyResultAfterContextCancellation(t *testing.T) {
 	stopCtx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err, completed := waitForStopResult(stopCtx, result)
+	err := waitForStopResult(stopCtx, result)
 	assert.ErrorIs(t, err, stopErr)
-	assert.True(t, completed)
 }
 
 func TestGroupStopCancelsBlockedStartBeforeWaitingForOperation(t *testing.T) {
@@ -433,72 +397,6 @@ func TestGroupStopRequestCancelsStartWaitingToPublishActivation(t *testing.T) {
 	group.releaseOperation()
 	require.ErrorIs(t, <-startResult, context.Canceled)
 	assert.Equal(t, int32(0), starts.Load(), "the pre-publication stop request must cancel before any job starts")
-}
-
-func TestGroupStopRetryJoinsInFlightAttemptBeforeRetrying(t *testing.T) {
-	t.Parallel()
-
-	firstStopEntered := make(chan struct{})
-	releaseFirstStop := make(chan struct{})
-	secondStopEntered := make(chan struct{})
-	firstStopErr := errors.New("first stop failed")
-	var stopCalls atomic.Int32
-	var activeStops atomic.Int32
-	var maxActiveStops atomic.Int32
-	group, err := NewGroup([]Job{newTestJob("job", noopJob, func(context.Context) error {
-		call := stopCalls.Add(1)
-		active := activeStops.Add(1)
-		defer activeStops.Add(-1)
-		for {
-			currentMax := maxActiveStops.Load()
-			if active <= currentMax || maxActiveStops.CompareAndSwap(currentMax, active) {
-				break
-			}
-		}
-		if call == 1 {
-			close(firstStopEntered)
-			<-releaseFirstStop
-			return firstStopErr
-		}
-		close(secondStopEntered)
-		return nil
-	})})
-	require.NoError(t, err)
-	require.NoError(t, group.Start(context.Background()))
-
-	firstResult := make(chan error, 1)
-	go func() {
-		stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-		defer cancel()
-		firstResult <- group.Stop(stopCtx)
-	}()
-	<-firstStopEntered
-	require.ErrorIs(t, <-firstResult, context.DeadlineExceeded)
-
-	retryResult := make(chan error, 1)
-	go func() {
-		retryResult <- group.Stop(context.Background())
-	}()
-	require.Eventually(t, func() bool {
-		return len(group.operationPermit) == 1
-	}, time.Second, time.Millisecond, "retry did not acquire the serialized operation permit")
-	select {
-	case <-secondStopEntered:
-		t.Fatal("retry overlapped the in-flight job Stop")
-	default:
-	}
-	assert.Equal(t, int32(1), stopCalls.Load())
-
-	close(releaseFirstStop)
-	select {
-	case <-secondStopEntered:
-	case <-time.After(time.Second):
-		t.Fatal("retry did not make a fresh attempt after the joined attempt failed")
-	}
-	require.NoError(t, <-retryResult)
-	assert.Equal(t, int32(2), stopCalls.Load())
-	assert.Equal(t, int32(1), maxActiveStops.Load())
-	assert.ErrorIs(t, group.Err(), context.DeadlineExceeded)
 }
 
 func TestGroupStartAndStopAreIdempotent(t *testing.T) {

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -24,15 +24,12 @@ func TestNewJobValidation(t *testing.T) {
 func TestNewGroupValidation(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewGroup([]Job{nil}, time.Second)
+	_, err := NewGroup([]Job{nil})
 	require.ErrorContains(t, err, "runtime job 0 must not be nil")
 
 	job := newTestJob("job", nil, nil)
-	_, err = NewGroup([]Job{job, job}, time.Second)
+	_, err = NewGroup([]Job{job, job})
 	require.ErrorContains(t, err, "appears more than once")
-
-	_, err = NewGroup(nil, 0)
-	require.ErrorContains(t, err, "cleanup timeout must be positive")
 }
 
 func TestGroupStartsInOrderAndStopsInReverseAfterBroadcastingCancellation(t *testing.T) {
@@ -195,7 +192,7 @@ func TestGroupStopTimeoutIsGroupWideAndTerminal(t *testing.T) {
 	stopEntered := make(chan struct{})
 	allowStop := make(chan struct{})
 	defer close(allowStop)
-	group, err := NewGroup([]Job{newTestJob(
+	group, err := newGroup([]Job{newTestJob(
 		"stuck",
 		noopJob,
 		func(context.Context) error {
@@ -227,7 +224,7 @@ func TestGroupStopRetriesOnlyIncompleteCleanup(t *testing.T) {
 
 	var completedStops atomic.Int32
 	var retriedStops atomic.Int32
-	group, err := NewGroup([]Job{
+	group, err := newGroup([]Job{
 		newTestJob("retried", noopJob, func(ctx context.Context) error {
 			if retriedStops.Add(1) == 1 {
 				<-ctx.Done()
@@ -302,7 +299,7 @@ func TestGroupStopSharesOneDeadlineAcrossJobs(t *testing.T) {
 			},
 		)
 	}
-	group, err := NewGroup([]Job{
+	group, err := newGroup([]Job{
 		makeJob("waits-for-deadline", true),
 		makeJob("uses-part-of-budget", false),
 	}, 30*time.Millisecond)
@@ -442,7 +439,7 @@ func TestGroupStopRetryJoinsInFlightAttemptBeforeRetrying(t *testing.T) {
 	var stopCalls atomic.Int32
 	var activeStops atomic.Int32
 	var maxActiveStops atomic.Int32
-	group, err := NewGroup([]Job{newTestJob("job", noopJob, func(context.Context) error {
+	group, err := newGroup([]Job{newTestJob("job", noopJob, func(context.Context) error {
 		call := stopCalls.Add(1)
 		active := activeStops.Add(1)
 		defer activeStops.Add(-1)
@@ -533,7 +530,7 @@ func TestGroupRequiresStopAfterActivationContextEnds(t *testing.T) {
 
 func newTestGroup(t *testing.T, jobs ...Job) *Group {
 	t.Helper()
-	group, err := NewGroup(jobs, time.Second)
+	group, err := newGroup(jobs, time.Second)
 	require.NoError(t, err)
 	return group
 }

--- a/server/internal/runtimejobs/job.go
+++ b/server/internal/runtimejobs/job.go
@@ -1,0 +1,48 @@
+package runtimejobs
+
+import (
+	"context"
+	"errors"
+)
+
+// Job is a validated, named Lifecycle managed by a Group.
+type Job struct {
+	name      string
+	lifecycle Lifecycle
+}
+
+var _ Lifecycle = Job{}
+
+// NewJob validates and names a lifecycle for runtime orchestration.
+func NewJob(name string, lifecycle Lifecycle) (Job, error) {
+	job := Job{name: name, lifecycle: lifecycle}
+	if err := job.validate(); err != nil {
+		return Job{}, err
+	}
+	return job, nil
+}
+
+// Name identifies the job within its group.
+func (j Job) Name() string {
+	return j.name
+}
+
+// Start delegates activation to the job's lifecycle.
+func (j Job) Start(ctx context.Context) error {
+	return j.lifecycle.Start(ctx)
+}
+
+// Stop delegates cleanup to the job's lifecycle.
+func (j Job) Stop(ctx context.Context) error {
+	return j.lifecycle.Stop(ctx)
+}
+
+func (j Job) validate() error {
+	if j.name == "" {
+		return errors.New("name must not be empty")
+	}
+	if j.lifecycle == nil {
+		return errors.New("lifecycle must not be nil")
+	}
+	return nil
+}

--- a/server/internal/runtimejobs/job.go
+++ b/server/internal/runtimejobs/job.go
@@ -6,43 +6,44 @@ import (
 )
 
 // Job is a validated, named Lifecycle managed by a Group.
-type Job struct {
+// Implementations are created by NewJob.
+type Job interface {
+	Lifecycle
+	Name() string
+	isJob()
+}
+
+type job struct {
 	name      string
 	lifecycle Lifecycle
 }
 
-var _ Lifecycle = Job{}
+var _ Job = job{}
 
 // NewJob validates and names a lifecycle for runtime orchestration.
 func NewJob(name string, lifecycle Lifecycle) (Job, error) {
-	job := Job{name: name, lifecycle: lifecycle}
-	if err := job.validate(); err != nil {
-		return Job{}, err
+	if name == "" {
+		return nil, errors.New("name must not be empty")
 	}
-	return job, nil
+	if lifecycle == nil {
+		return nil, errors.New("lifecycle must not be nil")
+	}
+	return job{name: name, lifecycle: lifecycle}, nil
 }
 
 // Name identifies the job within its group.
-func (j Job) Name() string {
+func (j job) Name() string {
 	return j.name
 }
 
 // Start delegates activation to the job's lifecycle.
-func (j Job) Start(ctx context.Context) error {
+func (j job) Start(ctx context.Context) error {
 	return j.lifecycle.Start(ctx)
 }
 
 // Stop delegates cleanup to the job's lifecycle.
-func (j Job) Stop(ctx context.Context) error {
+func (j job) Stop(ctx context.Context) error {
 	return j.lifecycle.Stop(ctx)
 }
 
-func (j Job) validate() error {
-	if j.name == "" {
-		return errors.New("name must not be empty")
-	}
-	if j.lifecycle == nil {
-		return errors.New("lifecycle must not be nil")
-	}
-	return nil
-}
+func (job) isJob() {}

--- a/server/internal/runtimejobs/lifecycle.go
+++ b/server/internal/runtimejobs/lifecycle.go
@@ -5,10 +5,12 @@ import "context"
 
 // Lifecycle is implemented by independently activatable background work.
 //
-// Start must return only after startup has succeeded or failed. A failed Start
-// must leave the lifecycle stopped and safe to start again. Stop must honor its
-// context, fully drain the activation before returning nil, and allow a later
-// Start.
+// The context passed to Start defines the activation lifetime, not only the
+// startup operation. Implementations must stop activation-owned work when that
+// context is canceled. Callers must still invoke Stop, which requests the same
+// cancellation when necessary, honors its own context while waiting, fully
+// drains before returning nil, and allows a later Start. A failed Start must
+// leave the lifecycle stopped and safe to start again.
 type Lifecycle interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error

--- a/server/internal/runtimejobs/lifecycle.go
+++ b/server/internal/runtimejobs/lifecycle.go
@@ -5,10 +5,11 @@ import "context"
 
 // Lifecycle is implemented by independently activatable background work.
 //
-// The context passed to Start defines the activation lifetime, not only the
-// startup operation. Implementations must stop activation-owned work when that
-// context is canceled. Callers must still invoke Stop, which requests the same
-// cancellation when necessary, honors its own context while waiting, fully
+// The context passed to Start defines the activation's admission lifetime, not
+// only the startup operation. When it is canceled, implementations must stop
+// admitting new work and begin shutdown; already-admitted work may drain until
+// Stop's context expires. Callers must still invoke Stop, which requests the
+// same cancellation when necessary, honors its own context while waiting, fully
 // drains before returning nil, and allows a later Start. A failed Start must
 // leave the lifecycle stopped and safe to start again.
 type Lifecycle interface {


### PR DESCRIPTION
Reviewable diff: +346/-5 across 4 files (excludes generated, test, and story files).

## Summary

Fleet gains a small runtime orchestration layer that names jobs, validates the catalog boundary, and activates or drains a set as one unit. It gives the HA supervisor a deterministic start/rollback/stop contract without coupling orchestration to domain services or deployment policy.

**Stack:**

1. Lifecycle foundation [#780](https://github.com/block/proto-fleet/pull/780) — merged
2. Diagnostics [#781](https://github.com/block/proto-fleet/pull/781) — merged
3. IP scanning [#782](https://github.com/block/proto-fleet/pull/782) — merged
4. Scheduling [#783](https://github.com/block/proto-fleet/pull/783) — merged
5. Curtailment [#785](https://github.com/block/proto-fleet/pull/785) — merged
6. Command execution [#787](https://github.com/block/proto-fleet/pull/787) — merged
7. Telemetry [#786](https://github.com/block/proto-fleet/pull/786) — merged
8. **Runtime orchestration [#784](https://github.com/block/proto-fleet/pull/784) — this PR**
9. Catalog and `fleetd` cutover [#788](https://github.com/block/proto-fleet/pull/788) — open, stacked directly on this PR

This PR targets `main` and builds on the shared `runtimejobs.Lifecycle` contract merged in #780. #788 uses the `Job` and `Group` contracts introduced here and is now based directly on this branch; after #784 merges, #788 will be rebased and retargeted to `main`. Passive-mode coordinator wiring, epoch fencing, and active request gating remain later HA work.

## How it works

A `Job` owns a validated unique name and delegates the shared lifecycle contract. A `Group` creates one activation context and starts jobs in registration order with that context. The context remains the lifetime of the activation, so cancellation reaches every job; the lifecycle owner must still call `Stop` to complete the bounded drain.

If startup fails partway through, the group cancels the activation and rolls back only the started prefix in reverse order. Normal stop broadcasts the same cancellation first, then stops every job in reverse order under one group-wide cleanup deadline capped by the caller's context.

A clean stop returns the group to a restartable state. Any incomplete rollback or shutdown becomes terminal: later starts are rejected, and `Err` exposes the cleanup failure so a supervisor can treat the activation as unsafe instead of retrying while old work may still exist.

```mermaid
flowchart LR
    J["Validated named Jobs"] --> S["Start in order"]
    S --> A["Active group"]
    S --> F["Partial start failure"]
    F --> R["Cancel and rollback in reverse"]
    A --> X["Activation canceled or Stop called"]
    X --> D["Stop in reverse under one deadline"]
    D --> C["Clean and restartable"]
    D --> T["Terminal cleanup failure exposed by Err"]
```

```mermaid
stateDiagram-v2
    [*] --> Stopped
    Stopped --> Running: Start succeeds
    Stopped --> Stopped: Start fails and rollback succeeds
    Stopped --> Failed: rollback incomplete
    Running --> Stopped: Stop drains cleanly
    Running --> Failed: Stop incomplete
    Failed --> Failed: later Start rejected
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/runtimejobs/job.go` | Adds named lifecycle delegation and validation | Keeps catalog identity outside domain services |
| `server/internal/runtimejobs/group.go` | Adds ordered activation, rollback, reverse stop, shared cleanup budget, retry serialization, and terminal state | Defines the safety boundary consumed by HA supervision |
| `server/internal/runtimejobs/lifecycle.go` | Documents the activation-context and stop contract | Makes the contract shared by orchestration and domain jobs explicit |
| `server/internal/domain/ipscanner/service.go` | Honors activation cancellation before launching scanner work | Aligns an existing lifecycle implementation with the group contract |
| Focused tests | Exercise ordering, cancellation, deadlines, restart, retries, and failure state | Verify the concurrency and cleanup guarantees |

## Key technical decisions & trade-offs

- `Job` itself implements `Lifecycle`; there is no separate spec or named-job abstraction.
- The `Start` context defines the activation lifetime; `Stop` remains the explicit bounded drain boundary.
- The group owns lifecycle only; construction, enablement, scope, and catalog policy stay outside.
- One cleanup deadline covers the full group rather than resetting a timeout per job and allowing shutdown time to grow with catalog size.
- Incomplete cleanup permanently blocks reactivation rather than risking two owners of the same work.
- Cleanup retries are serialized so concurrent callers cannot stop the same jobs twice.

## Related

Related: #740

## Testing & validation

- `go test -short -race -count=1 ./internal/runtimejobs ./internal/domain/ipscanner ./cmd/fleetd`
- Covers ordered start/reverse stop, activation cancellation before `Stop`, partial-start rollback, caller cancellation/deadlines, shared timeout, retry serialization, terminal failure surfacing, and fresh restart contexts.
- `git range-diff` confirmed all eight commits remained patch-equivalent after rebasing onto current `main`.
- `git diff --check origin/main...HEAD`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this PR adds an orchestration library that `fleetd` does not consume until #788.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
