### PR TITLE
refactor(curtailment): make control loops restartable (5/9)

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -565,9 +565,7 @@ func start(config *Config) error {
 		return fmt.Errorf("failed to start curtailment reconciler: %w", err)
 	}
 	defer func() {
-		if err := curtailmentRec.Stop(); err != nil {
-			slog.Error("failed to stop curtailment reconciler", "error", err)
-		}
+		stopStandaloneJob("curtailment reconciler", curtailmentRec)
 	}()
 
 	mqttQueries, err := db.NewPreparedQuerier(context.Background(), conn)
@@ -604,7 +602,13 @@ func start(config *Config) error {
 	if err := mqttSubscriber.Start(context.Background()); err != nil {
 		return fmt.Errorf("failed to start curtailment mqtt subscriber: %w", err)
 	}
-	defer mqttSubscriber.Stop()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := mqttSubscriber.Stop(shutdownCtx); err != nil {
+			slog.Error("failed to stop curtailment mqtt subscriber", "error", err)
+		}
+	}()
 	mqttConnectionTester, err := mqttingest.NewMQTTConnectionTester(mqttingest.ConnectionTesterConfig{
 		NewClient: func() mqttingest.MQTTClient { return mqttclient.New() },
 	})
@@ -636,7 +640,9 @@ func start(config *Config) error {
 		if err := curtailmentAlertMetrics.Start(context.Background()); err != nil {
 			return fmt.Errorf("failed to start curtailment alert metrics loop: %w", err)
 		}
-		defer curtailmentAlertMetrics.Stop()
+		defer func() {
+			stopStandaloneJob("curtailment alert metrics loop", curtailmentAlertMetrics)
+		}()
 	}
 
 	deviceResolver := deviceresolver.New(deviceStore)

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -603,11 +603,7 @@ func start(config *Config) error {
 		return fmt.Errorf("failed to start curtailment mqtt subscriber: %w", err)
 	}
 	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		defer cancel()
-		if err := mqttSubscriber.Stop(shutdownCtx); err != nil {
-			slog.Error("failed to stop curtailment mqtt subscriber", "error", err)
-		}
+		stopStandaloneJob("curtailment mqtt subscriber", mqttSubscriber)
 	}()
 	mqttConnectionTester, err := mqttingest.NewMQTTConnectionTester(mqttingest.ConnectionTesterConfig{
 		NewClient: func() mqttingest.MQTTClient { return mqttclient.New() },

--- a/server/internal/domain/curtailment/alert_metrics.go
+++ b/server/internal/domain/curtailment/alert_metrics.go
@@ -62,12 +62,12 @@ type AlertMetricsConfig struct {
 type AlertMetricsLoop struct {
 	cfg AlertMetricsConfig
 
-	cancel  context.CancelFunc
-	runDone <-chan struct{}
+	cancel      context.CancelFunc
+	runCanceled <-chan struct{}
+	runDone     <-chan struct{}
 
 	lifecycleMu sync.Mutex
 	mu          sync.Mutex
-	stopping    bool
 
 	// prevConnected / prevActive remember the labels each gauge was emitted
 	// with last tick (touched only by the tick goroutine), so a renamed or
@@ -109,15 +109,16 @@ func (l *AlertMetricsLoop) Start(ctx context.Context) error {
 	defer l.lifecycleMu.Unlock()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.stopping {
-		return errors.New("curtailment alert metrics: previous activation is still stopping")
-	}
 	if l.cancel != nil {
+		if channelClosed(l.runCanceled) {
+			return errors.New("curtailment alert metrics: previous activation is still stopping")
+		}
 		return nil
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 	runDone := make(chan struct{})
 	l.cancel = cancel
+	l.runCanceled = runCtx.Done()
 	l.runDone = runDone
 	go l.tickLoop(runCtx, runDone)
 	l.cfg.Logger.Info("curtailment alert metrics loop started", "interval", l.cfg.Interval)
@@ -135,7 +136,6 @@ func (l *AlertMetricsLoop) Stop(ctx context.Context) error {
 		l.mu.Unlock()
 		return nil
 	}
-	l.stopping = true
 	cancel := l.cancel
 	runDone := l.runDone
 	l.mu.Unlock()
@@ -153,8 +153,20 @@ func (l *AlertMetricsLoop) finishActivation() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.cancel = nil
+	l.runCanceled = nil
 	l.runDone = nil
-	l.stopping = false
+}
+
+func channelClosed(done <-chan struct{}) bool {
+	if done == nil {
+		return false
+	}
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
 }
 
 func (l *AlertMetricsLoop) tickLoop(ctx context.Context, runDone chan<- struct{}) {

--- a/server/internal/domain/curtailment/alert_metrics.go
+++ b/server/internal/domain/curtailment/alert_metrics.go
@@ -7,6 +7,7 @@ package curtailment
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/mqttingest"
 	"github.com/block/proto-fleet/server/internal/infrastructure/metrics"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 // 10s keeps alert latency close to the source signal: curtailment engages
@@ -60,11 +62,12 @@ type AlertMetricsConfig struct {
 type AlertMetricsLoop struct {
 	cfg AlertMetricsConfig
 
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	cancel  context.CancelFunc
+	runDone <-chan struct{}
 
-	mu      sync.Mutex
-	running bool
+	lifecycleMu sync.Mutex
+	mu          sync.Mutex
+	stopping    bool
 
 	// prevConnected / prevActive remember the labels each gauge was emitted
 	// with last tick (touched only by the tick goroutine), so a renamed or
@@ -73,6 +76,8 @@ type AlertMetricsLoop struct {
 	prevConnected map[int64]metrics.MQTTSourceLabels
 	prevActive    map[int64]metrics.MQTTSourceLabels
 }
+
+var _ runtimejobs.Lifecycle = (*AlertMetricsLoop)(nil)
 
 // NewAlertMetricsLoop validates dependencies and applies defaults.
 func NewAlertMetricsLoop(cfg AlertMetricsConfig) (*AlertMetricsLoop, error) {
@@ -99,39 +104,62 @@ func NewAlertMetricsLoop(cfg AlertMetricsConfig) (*AlertMetricsLoop, error) {
 
 // Start launches the tick loop; a second Start while running is a no-op.
 // The loop runs until Stop.
-func (l *AlertMetricsLoop) Start(_ context.Context) error {
+func (l *AlertMetricsLoop) Start(ctx context.Context) error {
+	l.lifecycleMu.Lock()
+	defer l.lifecycleMu.Unlock()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.running {
+	if l.stopping {
+		return errors.New("curtailment alert metrics: previous activation is still stopping")
+	}
+	if l.cancel != nil {
 		return nil
 	}
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(ctx)
+	runDone := make(chan struct{})
 	l.cancel = cancel
-	l.running = true
-	l.wg.Add(1)
-	go l.tickLoop(runCtx)
+	l.runDone = runDone
+	go l.tickLoop(runCtx, runDone)
 	l.cfg.Logger.Info("curtailment alert metrics loop started", "interval", l.cfg.Interval)
 	return nil
 }
 
-// Stop cancels the loop and waits for the in-flight tick to drain. The wait
-// holds the mutex so a concurrent Start cannot reuse the WaitGroup mid-Wait;
-// the tick goroutine never takes the mutex, so this cannot deadlock.
-func (l *AlertMetricsLoop) Stop() {
+// Stop cancels the loop and waits for the in-flight tick within ctx.
+// A timed-out activation remains owned, preventing a replacement loop from
+// overlapping work that ignored cancellation.
+func (l *AlertMetricsLoop) Stop(ctx context.Context) error {
+	l.lifecycleMu.Lock()
+	defer l.lifecycleMu.Unlock()
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	if l.cancel == nil {
-		return
+		l.mu.Unlock()
+		return nil
 	}
-	l.cancel()
-	l.cancel = nil
-	l.running = false
-	l.wg.Wait()
-	l.cfg.Logger.Info("curtailment alert metrics loop stopped")
+	l.stopping = true
+	cancel := l.cancel
+	runDone := l.runDone
+	l.mu.Unlock()
+	cancel()
+	select {
+	case <-runDone:
+		l.cfg.Logger.Info("curtailment alert metrics loop stopped")
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("curtailment alert metrics: stop: %w", ctx.Err())
+	}
 }
 
-func (l *AlertMetricsLoop) tickLoop(ctx context.Context) {
-	defer l.wg.Done()
+func (l *AlertMetricsLoop) finishActivation() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.cancel = nil
+	l.runDone = nil
+	l.stopping = false
+}
+
+func (l *AlertMetricsLoop) tickLoop(ctx context.Context, runDone chan<- struct{}) {
+	defer close(runDone)
+	defer l.finishActivation()
 	ticker := time.NewTicker(l.cfg.Interval)
 	defer ticker.Stop()
 	l.tick(ctx)

--- a/server/internal/domain/curtailment/alert_metrics.go
+++ b/server/internal/domain/curtailment/alert_metrics.go
@@ -102,8 +102,8 @@ func NewAlertMetricsLoop(cfg AlertMetricsConfig) (*AlertMetricsLoop, error) {
 	return &AlertMetricsLoop{cfg: cfg}, nil
 }
 
-// Start launches the tick loop; a second Start while running is a no-op.
-// The loop runs until Stop.
+// Start launches the tick loop for the lifetime of ctx; a second Start while
+// running is a no-op.
 func (l *AlertMetricsLoop) Start(ctx context.Context) error {
 	l.lifecycleMu.Lock()
 	defer l.lifecycleMu.Unlock()

--- a/server/internal/domain/curtailment/alert_metrics_test.go
+++ b/server/internal/domain/curtailment/alert_metrics_test.go
@@ -32,6 +32,21 @@ func (blockingSourcesLister) ListEnabledSources(ctx context.Context) ([]mqttinge
 	return nil, fmt.Errorf("list enabled sources: %w", ctx.Err())
 }
 
+type uninterruptibleSourcesLister struct {
+	started chan struct{}
+	release <-chan struct{}
+}
+
+func (l *uninterruptibleSourcesLister) ListEnabledSources(context.Context) ([]mqttingest.SourceConfig, error) {
+	select {
+	case <-l.started:
+	default:
+		close(l.started)
+	}
+	<-l.release
+	return nil, nil
+}
+
 type fakeRuntime struct {
 	statuses map[int64]mqttingest.RuntimeStatus
 }
@@ -378,12 +393,55 @@ func TestAlertMetricsLoopStartStop(t *testing.T) {
 
 	require.NoError(t, loop.Start(context.Background()))
 	require.NoError(t, loop.Start(context.Background()), "second Start must be a no-op")
-	loop.Stop()
-	loop.Stop() // second Stop must be a no-op
+	require.NoError(t, loop.Stop(context.Background()))
+	require.NoError(t, loop.Stop(context.Background())) // second Stop must be a no-op
 
 	// The first tick runs synchronously before the ticker wait, so Stop
 	// after Start guarantees at least one emission.
 	require.NotEmpty(t, emitter.connected)
+}
+
+func TestAlertMetricsLoopActivationContextCancellationAllowsRestart(t *testing.T) {
+	loop := newTestAlertMetricsLoop(t, AlertMetricsConfig{
+		Sources:           &fakeSourcesLister{},
+		Runtime:           &fakeRuntime{},
+		ActiveCurtailment: &fakeActiveLister{},
+		Emitter:           &recordingEmitter{},
+	})
+	runCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, loop.Start(runCtx))
+	cancel()
+	require.Eventually(t, func() bool {
+		loop.mu.Lock()
+		defer loop.mu.Unlock()
+		return loop.cancel == nil
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, loop.Start(context.Background()))
+	require.NoError(t, loop.Stop(context.Background()))
+}
+
+func TestAlertMetricsLoopStopPreventsOverlapAfterTimeout(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	loop := newTestAlertMetricsLoop(t, AlertMetricsConfig{
+		Sources:           &uninterruptibleSourcesLister{started: started, release: release},
+		Runtime:           &fakeRuntime{},
+		ActiveCurtailment: &fakeActiveLister{},
+		Emitter:           &recordingEmitter{},
+	})
+	require.NoError(t, loop.Start(context.Background()))
+	<-started
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer stopCancel()
+	require.ErrorIs(t, loop.Stop(stopCtx), context.DeadlineExceeded)
+	require.Error(t, loop.Start(context.Background()), "timed-out tick must retain the activation")
+
+	close(release)
+	require.NoError(t, loop.Stop(context.Background()))
+	require.NoError(t, loop.Start(context.Background()))
+	require.NoError(t, loop.Stop(context.Background()))
 }
 
 func TestNewAlertMetricsLoopValidatesDependencies(t *testing.T) {

--- a/server/internal/domain/curtailment/alert_metrics_test.go
+++ b/server/internal/domain/curtailment/alert_metrics_test.go
@@ -421,6 +421,28 @@ func TestAlertMetricsLoopActivationContextCancellationAllowsRestart(t *testing.T
 	require.NoError(t, loop.Stop(context.Background()))
 }
 
+func TestAlertMetricsLoopActivationContextCancellationPreventsOverlapWhileDraining(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	loop := newTestAlertMetricsLoop(t, AlertMetricsConfig{
+		Sources:           &uninterruptibleSourcesLister{started: started, release: release},
+		Runtime:           &fakeRuntime{},
+		ActiveCurtailment: &fakeActiveLister{},
+		Emitter:           &recordingEmitter{},
+	})
+	runCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, loop.Start(runCtx))
+	<-started
+
+	cancel()
+	require.ErrorContains(t, loop.Start(context.Background()), "previous activation is still stopping")
+
+	close(release)
+	require.NoError(t, loop.Stop(context.Background()))
+	require.NoError(t, loop.Start(context.Background()))
+	require.NoError(t, loop.Stop(context.Background()))
+}
+
 func TestAlertMetricsLoopStopPreventsOverlapAfterTimeout(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -79,17 +79,21 @@ type brokerRuntimeStatus struct {
 	lastError  string
 }
 
+type subscriberActivation struct {
+	runCanceled <-chan struct{}
+	cancel      context.CancelFunc
+	done        chan struct{}
+	workerWG    sync.WaitGroup
+	cleanupOnce sync.Once
+}
+
 // Subscriber owns per-source workers.
 type Subscriber struct {
 	cfg            Config
-	runCanceled    <-chan struct{}
 	workers        map[int64]*sourceWorkerHandle
 	statuses       map[int64]RuntimeStatus
 	brokerStatuses map[int64]map[string]brokerRuntimeStatus
-	runCancel      context.CancelFunc
-	stopping       bool
-	drainDone      <-chan struct{}
-	workerWG       sync.WaitGroup
+	activation     *subscriberActivation
 	lifecycleMu    sync.Mutex
 	mu             sync.Mutex
 	reconcileMu    sync.Mutex
@@ -147,27 +151,29 @@ func (s *Subscriber) Start(ctx context.Context) error {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()
 	s.mu.Lock()
-	if s.stopping {
+	if s.activation != nil {
+		stopping := channelClosed(s.activation.runCanceled)
 		s.mu.Unlock()
-		return errors.New("mqttingest: previous subscriber activation is still stopping")
-	}
-	if s.runCancel != nil {
-		s.mu.Unlock()
+		if stopping {
+			return errors.New("mqttingest: previous subscriber activation is still stopping")
+		}
 		return errors.New("mqttingest: subscriber already started")
 	}
 	runCtx, cancel := context.WithCancel(ctx)
-	s.runCanceled = runCtx.Done()
-	s.runCancel = cancel
+	activation := &subscriberActivation{
+		runCanceled: runCtx.Done(),
+		cancel:      cancel,
+		done:        make(chan struct{}),
+	}
+	s.activation = activation
 	s.workers = make(map[int64]*sourceWorkerHandle)
 	s.mu.Unlock()
+	go s.cleanupActivationWhenCanceled(activation)
 
 	if _, _, err := s.reconcile(runCtx, true); err != nil {
 		cancel()
-		s.mu.Lock()
-		s.runCanceled = nil
-		s.runCancel = nil
-		s.workers = make(map[int64]*sourceWorkerHandle)
-		s.mu.Unlock()
+		s.startActivationCleanup(activation)
+		<-activation.done
 		return err
 	}
 	return nil
@@ -179,72 +185,80 @@ func (s *Subscriber) Reconcile(ctx context.Context) error {
 	return err
 }
 
-// Stop cancels all workers and waits for them within ctx. When the
-// budget expires, the canceled activation remains installed until a later
-// successful Stop observes that every worker has drained. This avoids
-// reusing the WaitGroup or starting replacement workers alongside stragglers.
+// Stop cancels all workers and waits for them within ctx. Cleanup continues
+// after the caller's budget expires, and the activation remains installed
+// until every worker has drained so a replacement activation cannot overlap it.
 func (s *Subscriber) Stop(ctx context.Context) error {
 	s.lifecycleMu.Lock()
-	defer s.lifecycleMu.Unlock()
 	s.mu.Lock()
-	cancel := s.runCancel
-	if cancel == nil {
+	activation := s.activation
+	if activation == nil {
 		s.mu.Unlock()
+		s.lifecycleMu.Unlock()
 		return nil
 	}
-	if !s.stopping {
-		s.stopping = true
-		cancel()
-	}
+	cancel := activation.cancel
+	done := activation.done
 	s.mu.Unlock()
+	s.lifecycleMu.Unlock()
 
-	// Wait for an in-progress reconcile to finish adding any workers before
-	// waiting on the shared WaitGroup. The stopping flag prevents subsequent
-	// reconciles from adding more work even if this call exhausts its budget.
-	if err := s.lockReconcile(ctx); err != nil {
-		return fmt.Errorf("mqttingest: stop subscriber: %w", err)
+	cancel()
+	s.startActivationCleanup(activation)
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("mqttingest: stop subscriber: %w", ctx.Err())
 	}
-	defer s.reconcileMu.Unlock()
+}
 
+func (s *Subscriber) cleanupActivationWhenCanceled(activation *subscriberActivation) {
+	<-activation.runCanceled
+	s.startActivationCleanup(activation)
+}
+
+func (s *Subscriber) startActivationCleanup(activation *subscriberActivation) {
+	activation.cleanupOnce.Do(func() {
+		go s.cleanupActivation(activation)
+	})
+}
+
+func (s *Subscriber) cleanupActivation(activation *subscriberActivation) {
+	// Exclude Add calls before waiting on this activation's WaitGroup. Once the
+	// activation context is canceled, later reconciles fail before adding work.
+	s.reconcileMu.Lock()
 	s.mu.Lock()
+	if s.activation != activation {
+		close(activation.done)
+		s.mu.Unlock()
+		s.reconcileMu.Unlock()
+		return
+	}
 	handles := make([]*sourceWorkerHandle, 0, len(s.workers))
 	for _, handle := range s.workers {
 		handles = append(handles, handle)
-	}
-	drainDone := s.drainDone
-	if drainDone == nil {
-		done := make(chan struct{})
-		drainDone = done
-		s.drainDone = done
-		go func() {
-			s.workerWG.Wait()
-			close(done)
-		}()
 	}
 	s.mu.Unlock()
 	for _, handle := range handles {
 		handle.cancel()
 	}
+	s.reconcileMu.Unlock()
+
 	s.cfg.Logger.Info("mqttingest subscriber draining workers")
-	select {
-	case <-drainDone:
-		s.cfg.Logger.Info("mqttingest subscriber stopped cleanly")
-	case <-ctx.Done():
-		return fmt.Errorf("mqttingest: stop subscriber: %w", ctx.Err())
-	}
+	activation.workerWG.Wait()
 
 	s.mu.Lock()
-	for sourceID := range s.workers {
-		s.setSourceStatusLocked(sourceID, RuntimeStateStopped, "")
+	if s.activation == activation {
+		for sourceID := range s.workers {
+			s.setSourceStatusLocked(sourceID, RuntimeStateStopped, "")
+		}
+		s.workers = make(map[int64]*sourceWorkerHandle)
+		s.brokerStatuses = make(map[int64]map[string]brokerRuntimeStatus)
+		s.activation = nil
 	}
-	s.workers = make(map[int64]*sourceWorkerHandle)
-	s.brokerStatuses = make(map[int64]map[string]brokerRuntimeStatus)
-	s.runCanceled = nil
-	s.runCancel = nil
-	s.stopping = false
-	s.drainDone = nil
+	close(activation.done)
 	s.mu.Unlock()
-	return nil
+	s.cfg.Logger.Info("mqttingest subscriber stopped cleanly")
 }
 
 func (s *Subscriber) SourceRuntimeStatus(sourceID int64) RuntimeStatus {
@@ -261,12 +275,13 @@ func (s *Subscriber) QuiesceSource(ctx context.Context, sourceID int64) error {
 	defer s.reconcileMu.Unlock()
 
 	s.mu.Lock()
-	runCanceled := s.runCanceled
+	activation := s.activation
 	handle := s.workers[sourceID]
 	s.mu.Unlock()
-	if runCanceled == nil || handle == nil {
+	if activation == nil || handle == nil {
 		return nil
 	}
+	runCanceled := activation.runCanceled
 	handle.cancel()
 	if err := s.waitForHandleStopped(ctx, handle); err != nil {
 		s.recordSourceError(handle.worker.source.ID, err.Error())
@@ -290,16 +305,16 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 	defer s.reconcileMu.Unlock()
 
 	s.mu.Lock()
-	runCanceled := s.runCanceled
-	isStopping := s.stopping
+	activation := s.activation
 	existing := make(map[int64]*sourceWorkerHandle, len(s.workers))
 	for id, handle := range s.workers {
 		existing[id] = handle
 	}
 	s.mu.Unlock()
-	if runCanceled == nil || isStopping || channelClosed(runCanceled) {
+	if activation == nil || channelClosed(activation.runCanceled) {
 		return 0, 0, errors.New("mqttingest: subscriber is not started")
 	}
+	runCanceled := activation.runCanceled
 
 	sources, err := s.cfg.Store.ListEnabledSources(ctx)
 	if err != nil {
@@ -360,7 +375,7 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 		s.mu.Unlock()
 
 		workerCtx, workerCancel := contextWithDone(runCanceled)
-		w, done, err := s.startWorker(ctx, workerCtx, src, &s.workerWG)
+		w, done, err := s.startWorker(ctx, workerCtx, src, &activation.workerWG)
 		if err != nil {
 			workerCancel()
 			if firstStartErr == nil {
@@ -380,7 +395,7 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 			fingerprint: fingerprint,
 		}
 		s.mu.Lock()
-		if s.runCanceled != runCanceled {
+		if s.activation != activation {
 			s.mu.Unlock()
 			workerCancel()
 			continue

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -85,6 +85,7 @@ type subscriberActivation struct {
 	runCanceled <-chan struct{}
 	cancel      context.CancelFunc
 	done        chan struct{}
+	sourceIDs   map[int64]struct{}
 	workerWG    sync.WaitGroup
 	cleanupOnce sync.Once
 }
@@ -167,6 +168,7 @@ func (s *Subscriber) Start(ctx context.Context) error {
 		runCanceled: runCtx.Done(),
 		cancel:      cancel,
 		done:        make(chan struct{}),
+		sourceIDs:   make(map[int64]struct{}),
 	}
 	s.activation = activation
 	s.workers = make(map[int64]*sourceWorkerHandle)
@@ -258,7 +260,7 @@ func (s *Subscriber) cleanupActivation(activation *subscriberActivation) {
 
 	s.mu.Lock()
 	if s.activation == activation {
-		for sourceID := range s.workers {
+		for sourceID := range activation.sourceIDs {
 			s.setSourceStatusLocked(sourceID, RuntimeStateStopped, "")
 		}
 		s.workers = make(map[int64]*sourceWorkerHandle)
@@ -386,6 +388,7 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 			continue
 		}
 		s.setSourceStatusLocked(src.ID, RuntimeStateStarting, "")
+		activation.sourceIDs[src.ID] = struct{}{}
 		s.brokerStatuses[src.ID] = make(map[string]brokerRuntimeStatus)
 		s.mu.Unlock()
 

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -150,11 +150,11 @@ func NewSubscriber(cfg Config) (*Subscriber, error) {
 // source reconciliation.
 func (s *Subscriber) Start(ctx context.Context) error {
 	s.lifecycleMu.Lock()
-	defer s.lifecycleMu.Unlock()
 	s.mu.Lock()
 	if s.activation != nil {
 		stopping := channelClosed(s.activation.runCanceled)
 		s.mu.Unlock()
+		s.lifecycleMu.Unlock()
 		if stopping {
 			return errors.New("mqttingest: previous subscriber activation is still stopping")
 		}
@@ -169,6 +169,7 @@ func (s *Subscriber) Start(ctx context.Context) error {
 	s.activation = activation
 	s.workers = make(map[int64]*sourceWorkerHandle)
 	s.mu.Unlock()
+	s.lifecycleMu.Unlock()
 	go s.cleanupActivationWhenCanceled(activation)
 
 	if _, _, err := s.reconcile(runCtx, true); err != nil {
@@ -176,6 +177,11 @@ func (s *Subscriber) Start(ctx context.Context) error {
 		s.startActivationCleanup(activation)
 		<-activation.done
 		return err
+	}
+	if err := runCtx.Err(); err != nil {
+		s.startActivationCleanup(activation)
+		<-activation.done
+		return fmt.Errorf("mqttingest: start subscriber: %w", err)
 	}
 	return nil
 }

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -50,6 +50,8 @@ const (
 const workerRestartBackoffMax = 30 * time.Second
 const reconcileRetryTimeout = 30 * time.Second
 
+var errSubscriberNotStarted = errors.New("mqttingest: subscriber is not started")
+
 // Config bundles the subscriber's runtime dependencies and tunables.
 type Config struct {
 	Store             Store
@@ -319,13 +321,16 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 	}
 	s.mu.Unlock()
 	if activation == nil || channelClosed(activation.runCanceled) {
-		return 0, 0, errors.New("mqttingest: subscriber is not started")
+		return 0, 0, errSubscriberNotStarted
 	}
 	runCanceled := activation.runCanceled
 
 	sources, err := s.cfg.Store.ListEnabledSources(ctx)
 	if err != nil {
 		return 0, 0, fmt.Errorf("mqttingest: list enabled sources: %w", err)
+	}
+	if channelClosed(runCanceled) {
+		return 0, len(sources), errSubscriberNotStarted
 	}
 	s.cfg.Logger.Info("mqttingest subscriber reconciling", slog.Int("source_count", len(sources)))
 
@@ -370,6 +375,9 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 	started := 0
 	var firstStartErr error
 	for _, src := range sources {
+		if channelClosed(runCanceled) {
+			return started, len(sources), errSubscriberNotStarted
+		}
 		fingerprint := sourceConfigFingerprint(src)
 		s.mu.Lock()
 		current, ok := s.workers[src.ID]
@@ -382,6 +390,10 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 		s.mu.Unlock()
 
 		workerCtx, workerCancel := contextWithDone(runCanceled)
+		if channelClosed(runCanceled) {
+			workerCancel()
+			return started, len(sources), errSubscriberNotStarted
+		}
 		w, done, err := s.startWorker(ctx, workerCtx, src, &activation.workerWG)
 		if err != nil {
 			workerCancel()
@@ -402,10 +414,10 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 			fingerprint: fingerprint,
 		}
 		s.mu.Lock()
-		if s.activation != activation {
+		if s.activation != activation || channelClosed(runCanceled) {
 			s.mu.Unlock()
 			workerCancel()
-			continue
+			return started, len(sources), errSubscriberNotStarted
 		}
 		if previous, ok := s.workers[src.ID]; ok {
 			previous.cancel()

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -146,7 +146,8 @@ func NewSubscriber(cfg Config) (*Subscriber, error) {
 	return s, nil
 }
 
-// Start starts the runtime and performs the initial source reconciliation.
+// Start runs the subscriber for the lifetime of ctx and performs the initial
+// source reconciliation.
 func (s *Subscriber) Start(ctx context.Context) error {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 // MQTTClient is one broker connection for one source.
@@ -80,15 +82,20 @@ type brokerRuntimeStatus struct {
 // Subscriber owns per-source workers.
 type Subscriber struct {
 	cfg            Config
-	runDone        <-chan struct{}
+	runCanceled    <-chan struct{}
 	workers        map[int64]*sourceWorkerHandle
 	statuses       map[int64]RuntimeStatus
 	brokerStatuses map[int64]map[string]brokerRuntimeStatus
-	cancel         context.CancelFunc
-	wg             sync.WaitGroup
+	runCancel      context.CancelFunc
+	stopping       bool
+	drainDone      <-chan struct{}
+	workerWG       sync.WaitGroup
+	lifecycleMu    sync.Mutex
 	mu             sync.Mutex
 	reconcileMu    sync.Mutex
 }
+
+var _ runtimejobs.Lifecycle = (*Subscriber)(nil)
 
 // NewSubscriber validates dependencies and applies runtime defaults.
 func NewSubscriber(cfg Config) (*Subscriber, error) {
@@ -137,22 +144,28 @@ func NewSubscriber(cfg Config) (*Subscriber, error) {
 
 // Start starts the runtime and performs the initial source reconciliation.
 func (s *Subscriber) Start(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
 	s.mu.Lock()
-	if s.cancel != nil {
+	if s.stopping {
+		s.mu.Unlock()
+		return errors.New("mqttingest: previous subscriber activation is still stopping")
+	}
+	if s.runCancel != nil {
 		s.mu.Unlock()
 		return errors.New("mqttingest: subscriber already started")
 	}
 	runCtx, cancel := context.WithCancel(ctx)
-	s.runDone = runCtx.Done()
-	s.cancel = cancel
+	s.runCanceled = runCtx.Done()
+	s.runCancel = cancel
 	s.workers = make(map[int64]*sourceWorkerHandle)
 	s.mu.Unlock()
 
 	if _, _, err := s.reconcile(runCtx, true); err != nil {
 		cancel()
 		s.mu.Lock()
-		s.runDone = nil
-		s.cancel = nil
+		s.runCanceled = nil
+		s.runCancel = nil
 		s.workers = make(map[int64]*sourceWorkerHandle)
 		s.mu.Unlock()
 		return err
@@ -166,41 +179,58 @@ func (s *Subscriber) Reconcile(ctx context.Context) error {
 	return err
 }
 
-// Stop cancels all workers and waits up to ShutdownDeadline for them to drain.
-func (s *Subscriber) Stop() {
-	s.reconcileMu.Lock()
+// Stop cancels all workers and waits for them within ctx. When the
+// budget expires, the canceled activation remains installed until a later
+// successful Stop observes that every worker has drained. This avoids
+// reusing the WaitGroup or starting replacement workers alongside stragglers.
+func (s *Subscriber) Stop(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	s.mu.Lock()
+	cancel := s.runCancel
+	if cancel == nil {
+		s.mu.Unlock()
+		return nil
+	}
+	if !s.stopping {
+		s.stopping = true
+		cancel()
+	}
+	s.mu.Unlock()
+
+	// Wait for an in-progress reconcile to finish adding any workers before
+	// waiting on the shared WaitGroup. The stopping flag prevents subsequent
+	// reconciles from adding more work even if this call exhausts its budget.
+	if err := s.lockReconcile(ctx); err != nil {
+		return fmt.Errorf("mqttingest: stop subscriber: %w", err)
+	}
 	defer s.reconcileMu.Unlock()
 
 	s.mu.Lock()
-	cancel := s.cancel
-	if cancel == nil {
-		s.mu.Unlock()
-		return
-	}
 	handles := make([]*sourceWorkerHandle, 0, len(s.workers))
 	for _, handle := range s.workers {
 		handles = append(handles, handle)
 	}
-	s.runDone = nil
-	s.cancel = nil
+	drainDone := s.drainDone
+	if drainDone == nil {
+		done := make(chan struct{})
+		drainDone = done
+		s.drainDone = done
+		go func() {
+			s.workerWG.Wait()
+			close(done)
+		}()
+	}
 	s.mu.Unlock()
-
 	for _, handle := range handles {
 		handle.cancel()
 	}
-	cancel()
-	s.cfg.Logger.Info("mqttingest subscriber draining workers",
-		slog.Duration("deadline", s.cfg.ShutdownDeadline))
-	done := make(chan struct{})
-	go func() {
-		s.wg.Wait()
-		close(done)
-	}()
+	s.cfg.Logger.Info("mqttingest subscriber draining workers")
 	select {
-	case <-done:
+	case <-drainDone:
 		s.cfg.Logger.Info("mqttingest subscriber stopped cleanly")
-	case <-time.After(s.cfg.ShutdownDeadline):
-		s.cfg.Logger.Warn("mqttingest subscriber shutdown deadline exceeded")
+	case <-ctx.Done():
+		return fmt.Errorf("mqttingest: stop subscriber: %w", ctx.Err())
 	}
 
 	s.mu.Lock()
@@ -209,16 +239,11 @@ func (s *Subscriber) Stop() {
 	}
 	s.workers = make(map[int64]*sourceWorkerHandle)
 	s.brokerStatuses = make(map[int64]map[string]brokerRuntimeStatus)
+	s.runCanceled = nil
+	s.runCancel = nil
+	s.stopping = false
+	s.drainDone = nil
 	s.mu.Unlock()
-}
-
-// Run starts enabled sources once and blocks until ctx is canceled.
-func (s *Subscriber) Run(ctx context.Context) error {
-	if err := s.Start(ctx); err != nil {
-		return err
-	}
-	<-ctx.Done()
-	s.Stop()
 	return nil
 }
 
@@ -236,16 +261,16 @@ func (s *Subscriber) QuiesceSource(ctx context.Context, sourceID int64) error {
 	defer s.reconcileMu.Unlock()
 
 	s.mu.Lock()
-	runDone := s.runDone
+	runCanceled := s.runCanceled
 	handle := s.workers[sourceID]
 	s.mu.Unlock()
-	if runDone == nil || handle == nil {
+	if runCanceled == nil || handle == nil {
 		return nil
 	}
 	handle.cancel()
 	if err := s.waitForHandleStopped(ctx, handle); err != nil {
 		s.recordSourceError(handle.worker.source.ID, err.Error())
-		s.reconcileWhenHandleStops(runDone, handle)
+		s.reconcileWhenHandleStops(runCanceled, handle)
 		return err
 	}
 	s.mu.Lock()
@@ -265,13 +290,14 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 	defer s.reconcileMu.Unlock()
 
 	s.mu.Lock()
-	runDone := s.runDone
+	runCanceled := s.runCanceled
+	isStopping := s.stopping
 	existing := make(map[int64]*sourceWorkerHandle, len(s.workers))
 	for id, handle := range s.workers {
 		existing[id] = handle
 	}
 	s.mu.Unlock()
-	if runDone == nil {
+	if runCanceled == nil || isStopping || channelClosed(runCanceled) {
 		return 0, 0, errors.New("mqttingest: subscriber is not started")
 	}
 
@@ -307,7 +333,7 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 	for _, handle := range stopping {
 		if err := s.waitForHandleStopped(ctx, handle); err != nil {
 			s.recordSourceError(handle.worker.source.ID, err.Error())
-			s.reconcileWhenHandleStops(runDone, handle)
+			s.reconcileWhenHandleStops(runCanceled, handle)
 			return 0, len(sources), err
 		}
 		s.mu.Lock()
@@ -333,8 +359,8 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 		s.brokerStatuses[src.ID] = make(map[string]brokerRuntimeStatus)
 		s.mu.Unlock()
 
-		workerCtx, workerCancel := contextWithDone(runDone)
-		w, done, err := s.startWorker(ctx, workerCtx, src, &s.wg)
+		workerCtx, workerCancel := contextWithDone(runCanceled)
+		w, done, err := s.startWorker(ctx, workerCtx, src, &s.workerWG)
 		if err != nil {
 			workerCancel()
 			if firstStartErr == nil {
@@ -354,7 +380,7 @@ func (s *Subscriber) reconcile(ctx context.Context, failIfNoneStarted bool) (int
 			fingerprint: fingerprint,
 		}
 		s.mu.Lock()
-		if s.runDone != runDone {
+		if s.runCanceled != runCanceled {
 			s.mu.Unlock()
 			workerCancel()
 			continue
@@ -411,30 +437,30 @@ func handleStopped(handle *sourceWorkerHandle) bool {
 	}
 }
 
-func (s *Subscriber) reconcileWhenHandleStops(runDone <-chan struct{}, handle *sourceWorkerHandle) {
+func (s *Subscriber) reconcileWhenHandleStops(runCanceled <-chan struct{}, handle *sourceWorkerHandle) {
 	if handle == nil || handle.done == nil {
 		return
 	}
 	handle.retryOnce.Do(func() {
-		go s.reconcileAfterHandleStops(runDone, handle)
+		go s.reconcileAfterHandleStops(runCanceled, handle)
 	})
 }
 
-func (s *Subscriber) reconcileAfterHandleStops(runDone <-chan struct{}, handle *sourceWorkerHandle) {
-	if runDone == nil {
+func (s *Subscriber) reconcileAfterHandleStops(runCanceled <-chan struct{}, handle *sourceWorkerHandle) {
+	if runCanceled == nil {
 		return
 	}
 	select {
-	case <-runDone:
+	case <-runCanceled:
 		return
 	case <-handle.done:
 	}
 	select {
-	case <-runDone:
+	case <-runCanceled:
 		return
 	default:
 	}
-	runCtx, runCancel := contextWithDone(runDone)
+	runCtx, runCancel := contextWithDone(runCanceled)
 	defer runCancel()
 	reconcileCtx, timeoutCancel := context.WithTimeout(runCtx, s.cfg.ReconcileTimeout)
 	defer timeoutCancel()
@@ -455,6 +481,18 @@ func contextWithDone(done <-chan struct{}) (context.Context, context.CancelFunc)
 		}
 	}()
 	return ctx, cancel
+}
+
+func channelClosed(done <-chan struct{}) bool {
+	if done == nil {
+		return false
+	}
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Subscriber) waitForHandleStopped(ctx context.Context, handle *sourceWorkerHandle) error {

--- a/server/internal/domain/curtailment/mqttingest/subscriber_test.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber_test.go
@@ -67,10 +67,10 @@ type blockingListStore struct {
 	release     <-chan struct{}
 }
 
-func (s *blockingListStore) ListEnabledSources(context.Context) ([]SourceConfig, error) {
+func (s *blockingListStore) ListEnabledSources(ctx context.Context) ([]SourceConfig, error) {
 	s.startedOnce.Do(func() { close(s.started) })
 	<-s.release
-	return nil, nil
+	return s.Store.ListEnabledSources(ctx)
 }
 
 func (c *blockingDisconnectClient) Connect(context.Context, string, int32, string, string, string, string) error {
@@ -295,10 +295,50 @@ func TestSubscriber_StopCanCancelBlockedInitialReconcile(t *testing.T) {
 	require.ErrorContains(t, s.Start(context.Background()), "previous subscriber activation is still stopping")
 
 	close(release)
-	require.ErrorIs(t, <-startDone, context.Canceled)
+	require.ErrorContains(t, <-startDone, "subscriber is not started")
 	require.NoError(t, s.Stop(context.Background()))
 	require.NoError(t, s.Start(context.Background()))
 	require.NoError(t, s.Stop(context.Background()))
+}
+
+func TestSubscriber_ReconcileDoesNotStartWorkersAfterStop(t *testing.T) {
+	store := newFakeSourceStore()
+	reg := &clientRegistry{}
+	s := newReconcileTestSubscriber(t, store, reg)
+	require.NoError(t, s.Start(context.Background()))
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	store.setSources(reconcileTestSource(1, "maestro"))
+	s.cfg.Store = &blockingListStore{
+		Store:   store,
+		started: started,
+		release: release,
+	}
+
+	reconcileDone := make(chan error, 1)
+	go func() {
+		reconcileDone <- s.Reconcile(context.Background())
+	}()
+	<-started
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- s.Stop(context.Background())
+	}()
+	require.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.activation != nil && channelClosed(s.activation.runCanceled)
+	}, time.Second, 10*time.Millisecond)
+
+	close(release)
+	require.ErrorContains(t, <-reconcileDone, "subscriber is not started")
+	require.NoError(t, <-stopDone)
+	active, maxActive, connects := reg.snapshot()
+	assert.Zero(t, active)
+	assert.Zero(t, maxActive)
+	assert.Zero(t, connects)
 }
 
 func TestSubscriber_StopTimeoutAllowsRestartAfterWorkersEventuallyDrain(t *testing.T) {

--- a/server/internal/domain/curtailment/mqttingest/subscriber_test.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber_test.go
@@ -237,7 +237,30 @@ func TestSubscriber_ReconcileStartsAndStopsWorkers(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "broker sessions should drain after the source is removed")
 }
 
-func TestSubscriber_StopKeepsTimedOutActivationOwnedUntilWorkersDrain(t *testing.T) {
+func TestSubscriber_StartContextCancellationAllowsRestartAfterWorkersDrain(t *testing.T) {
+	t.Parallel()
+
+	src := reconcileTestSource(1, "maestro")
+	store := newFakeSourceStore(src)
+	reg := &clientRegistry{}
+	s := newReconcileTestSubscriber(t, store, reg)
+	runCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, s.Start(runCtx))
+	requireRunningBrokers(t, s, src.ID, 2)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		return s.Start(context.Background()) == nil
+	}, 2*time.Second, 10*time.Millisecond, "subscriber should restart after its canceled activation drains")
+	requireRunningBrokers(t, s, src.ID, 2)
+
+	_, maxActive, connects := reg.snapshot()
+	assert.LessOrEqual(t, maxActive, 2, "replacement activation must not overlap canceled workers")
+	assert.Equal(t, 4, connects)
+	require.NoError(t, s.Stop(context.Background()))
+}
+
+func TestSubscriber_StopTimeoutAllowsRestartAfterWorkersEventuallyDrain(t *testing.T) {
 	src := reconcileTestSource(1, "maestro")
 	store := newFakeSourceStore(src)
 	reg := &clientRegistry{}
@@ -261,8 +284,12 @@ func TestSubscriber_StopKeepsTimedOutActivationOwnedUntilWorkersDrain(t *testing
 	require.Error(t, s.Reconcile(context.Background()), "a stopping activation must reject new workers")
 
 	close(release)
-	require.NoError(t, s.Stop(context.Background()))
-	require.NoError(t, s.Start(context.Background()))
+	require.Eventually(t, func() bool {
+		return s.Start(context.Background()) == nil
+	}, 2*time.Second, 10*time.Millisecond, "subscriber should restart after timed-out workers eventually drain")
+	requireRunningBrokers(t, s, src.ID, 2)
+	_, maxActive, _ := reg.snapshot()
+	assert.LessOrEqual(t, maxActive, 2, "replacement activation must not overlap timed-out workers")
 	require.NoError(t, s.Stop(context.Background()))
 }
 

--- a/server/internal/domain/curtailment/mqttingest/subscriber_test.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber_test.go
@@ -341,6 +341,28 @@ func TestSubscriber_ReconcileDoesNotStartWorkersAfterStop(t *testing.T) {
 	assert.Zero(t, connects)
 }
 
+func TestSubscriber_CleanupStopsStatusesForUninstalledWorkers(t *testing.T) {
+	s := newReconcileTestSubscriber(t, newFakeSourceStore(), &clientRegistry{})
+	runCtx, cancel := context.WithCancel(t.Context())
+	activation := &subscriberActivation{
+		runCanceled: runCtx.Done(),
+		cancel:      cancel,
+		done:        make(chan struct{}),
+		sourceIDs:   map[int64]struct{}{1: {}},
+	}
+	s.activation = activation
+	s.statuses[1] = RuntimeStatus{State: RuntimeStateRunning}
+
+	cancel()
+	s.startActivationCleanup(activation)
+	select {
+	case <-activation.done:
+	case <-time.After(time.Second):
+		t.Fatal("subscriber activation did not finish cleanup")
+	}
+	assert.Equal(t, RuntimeStateStopped, s.SourceRuntimeStatus(1).State)
+}
+
 func TestSubscriber_StopTimeoutAllowsRestartAfterWorkersEventuallyDrain(t *testing.T) {
 	src := reconcileTestSource(1, "maestro")
 	store := newFakeSourceStore(src)

--- a/server/internal/domain/curtailment/mqttingest/subscriber_test.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber_test.go
@@ -60,6 +60,19 @@ type blockingDisconnectClient struct {
 	release <-chan struct{}
 }
 
+type blockingListStore struct {
+	Store
+	started     chan struct{}
+	startedOnce sync.Once
+	release     <-chan struct{}
+}
+
+func (s *blockingListStore) ListEnabledSources(context.Context) ([]SourceConfig, error) {
+	s.startedOnce.Do(func() { close(s.started) })
+	<-s.release
+	return nil, nil
+}
+
 func (c *blockingDisconnectClient) Connect(context.Context, string, int32, string, string, string, string) error {
 	c.reg.onConnect()
 	return nil
@@ -257,6 +270,34 @@ func TestSubscriber_StartContextCancellationAllowsRestartAfterWorkersDrain(t *te
 	_, maxActive, connects := reg.snapshot()
 	assert.LessOrEqual(t, maxActive, 2, "replacement activation must not overlap canceled workers")
 	assert.Equal(t, 4, connects)
+	require.NoError(t, s.Stop(context.Background()))
+}
+
+func TestSubscriber_StopCanCancelBlockedInitialReconcile(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	store := &blockingListStore{
+		Store:   newFakeSourceStore(),
+		started: started,
+		release: release,
+	}
+	s := newReconcileTestSubscriber(t, store, &clientRegistry{})
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- s.Start(context.Background())
+	}()
+	<-started
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer stopCancel()
+	require.ErrorIs(t, s.Stop(stopCtx), context.DeadlineExceeded)
+	require.ErrorContains(t, s.Start(context.Background()), "previous subscriber activation is still stopping")
+
+	close(release)
+	require.ErrorIs(t, <-startDone, context.Canceled)
+	require.NoError(t, s.Stop(context.Background()))
+	require.NoError(t, s.Start(context.Background()))
 	require.NoError(t, s.Stop(context.Background()))
 }
 

--- a/server/internal/domain/curtailment/mqttingest/subscriber_test.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber_test.go
@@ -55,6 +55,25 @@ type countingClient struct {
 	connected bool
 }
 
+type blockingDisconnectClient struct {
+	reg     *clientRegistry
+	release <-chan struct{}
+}
+
+func (c *blockingDisconnectClient) Connect(context.Context, string, int32, string, string, string, string) error {
+	c.reg.onConnect()
+	return nil
+}
+
+func (c *blockingDisconnectClient) Subscribe(context.Context, string, func([]byte, time.Time)) error {
+	return nil
+}
+
+func (c *blockingDisconnectClient) Disconnect(time.Duration) {
+	<-c.release
+	c.reg.onDisconnect()
+}
+
 func (c *countingClient) Connect(context.Context, string, int32, string, string, string, string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -199,7 +218,7 @@ func TestSubscriber_ReconcileStartsAndStopsWorkers(t *testing.T) {
 	reg := &clientRegistry{}
 	s := newReconcileTestSubscriber(t, store, reg)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRunningBrokers(t, s, src.ID, 2)
 
@@ -218,6 +237,35 @@ func TestSubscriber_ReconcileStartsAndStopsWorkers(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "broker sessions should drain after the source is removed")
 }
 
+func TestSubscriber_StopKeepsTimedOutActivationOwnedUntilWorkersDrain(t *testing.T) {
+	src := reconcileTestSource(1, "maestro")
+	store := newFakeSourceStore(src)
+	reg := &clientRegistry{}
+	release := make(chan struct{})
+	s, err := NewSubscriber(Config{
+		Store:             store,
+		NewClient:         func() MQTTClient { return &blockingDisconnectClient{reg: reg, release: release} },
+		Decryptor:         passthroughDecryptor{},
+		Logger:            slog.New(slog.DiscardHandler),
+		ShutdownDeadline:  time.Second,
+		WatchdogTickEvery: time.Millisecond,
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.Start(context.Background()))
+	requireRunningBrokers(t, s, src.ID, 2)
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer stopCancel()
+	require.ErrorIs(t, s.Stop(stopCtx), context.DeadlineExceeded)
+	require.Error(t, s.Start(context.Background()), "timed-out workers must keep ownership of the activation")
+	require.Error(t, s.Reconcile(context.Background()), "a stopping activation must reject new workers")
+
+	close(release)
+	require.NoError(t, s.Stop(context.Background()))
+	require.NoError(t, s.Start(context.Background()))
+	require.NoError(t, s.Stop(context.Background()))
+}
+
 func TestSubscriber_ReconcileRestartsChangedSourceWithoutOverlap(t *testing.T) {
 	t.Parallel()
 
@@ -226,7 +274,7 @@ func TestSubscriber_ReconcileRestartsChangedSourceWithoutOverlap(t *testing.T) {
 	reg := &clientRegistry{}
 	s := newReconcileTestSubscriber(t, store, reg)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRunningBrokers(t, s, src.ID, 2)
 
@@ -253,7 +301,7 @@ func TestSubscriber_ReconcileSkipsUnchangedSource(t *testing.T) {
 	reg := &clientRegistry{}
 	s := newReconcileTestSubscriber(t, store, reg)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRunningBrokers(t, s, src.ID, 2)
 
@@ -274,7 +322,7 @@ func TestSubscriber_QuiesceSourceStopsOnlyTargetSource(t *testing.T) {
 	reg := &clientRegistry{}
 	s := newReconcileTestSubscriber(t, store, reg)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRunningBrokers(t, s, first.ID, 2)
 	requireRunningBrokers(t, s, second.ID, 2)
@@ -305,7 +353,7 @@ func TestSubscriber_RuntimeStatusTracksBrokerDisconnectAndReconnect(t *testing.T
 	})
 	require.NoError(t, err)
 	require.NoError(t, s.Start(context.Background()))
-	defer s.Stop()
+	defer func() { require.NoError(t, s.Stop(context.Background())) }()
 
 	requireRuntimeStatus(t, s, src.ID, RuntimeStateRunning, 2, 2)
 

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/infrastructure/driver"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 	sdk "github.com/block/proto-fleet/server/sdk/v1"
 )
 
@@ -33,7 +34,6 @@ const (
 	reconcilerActorName = "curtailment-reconciler"
 
 	defaultTickInterval            = 30 * time.Second
-	defaultShutdownDeadline        = 10 * time.Second
 	defaultMaxRetries        int32 = 10
 	defaultCurtailMaxRetries int32 = 50
 
@@ -60,7 +60,6 @@ type CommandDispatcher interface {
 // Config carries runtime tunables. Zero-valued fields use defaults.
 type Config struct {
 	TickInterval         time.Duration `help:"Interval between curtailment reconciler ticks. Zero uses the default; values below 1s are rejected." default:"0s" env:"TICK_INTERVAL"`
-	ShutdownDeadline     time.Duration
 	MaxRetries           int32
 	CurtailMaxRetries    int32
 	DriftThresholdFactor float64
@@ -75,9 +74,6 @@ type Config struct {
 func (c Config) withDefaults() Config {
 	if c.TickInterval <= 0 {
 		c.TickInterval = defaultTickInterval
-	}
-	if c.ShutdownDeadline <= 0 {
-		c.ShutdownDeadline = defaultShutdownDeadline
 	}
 	if c.MaxRetries <= 0 {
 		c.MaxRetries = defaultMaxRetries
@@ -112,11 +108,14 @@ type Reconciler struct {
 
 	stopCancel context.CancelFunc
 	workCancel context.CancelFunc
-	wg         sync.WaitGroup
+	runDone    <-chan struct{}
 
-	mu      sync.Mutex
-	running bool
+	lifecycleMu sync.Mutex
+	mu          sync.Mutex
+	stopping    bool
 }
+
+var _ runtimejobs.Lifecycle = (*Reconciler)(nil)
 
 // Option configures a Reconciler at construction time.
 type Option func(*Reconciler)
@@ -167,7 +166,7 @@ func New(cfg Config, store interfaces.CurtailmentStore, cmd CommandDispatcher, o
 
 // Start spins up the tick loop. Repeat Starts without an intervening Stop
 // are no-ops so misbehaving wiring cannot fork two reconcilers.
-func (r *Reconciler) Start(_ context.Context) error {
+func (r *Reconciler) Start(ctx context.Context) error {
 	if r.store == nil {
 		return fmt.Errorf("curtailment reconciler: store is required")
 	}
@@ -181,58 +180,75 @@ func (r *Reconciler) Start(_ context.Context) error {
 		return fmt.Errorf("curtailment reconciler: curtail_dispatch_timeout_sec must be at least 1, got %d", r.cfg.CurtailDispatchTimeoutSec)
 	}
 
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
 	r.mu.Lock()
-	if r.running {
+	if r.stopping {
+		r.mu.Unlock()
+		return errors.New("curtailment reconciler: previous activation is still stopping")
+	}
+	if r.runDone != nil {
 		r.mu.Unlock()
 		return nil
 	}
-	r.running = true
-	stopCtx, stopCancel := context.WithCancel(context.Background())
-	workCtx, workCancel := context.WithCancel(context.Background())
+	stopCtx, stopCancel := context.WithCancel(ctx)
+	// Stopping the activation prevents new ticks immediately but gives the
+	// current tick a chance to finish. Stop cancels this detached work
+	// context if its caller's shutdown budget expires.
+	workCtx, workCancel := context.WithCancel(context.WithoutCancel(ctx))
+	runDone := make(chan struct{})
 	r.stopCancel = stopCancel
 	r.workCancel = workCancel
+	r.runDone = runDone
 	r.mu.Unlock()
 
-	r.wg.Add(1)
-	go r.tickLoop(stopCtx, workCtx)
+	go r.tickLoop(stopCtx, workCtx, workCancel, runDone)
 	slog.Info("curtailment reconciler started", "tick_interval", r.cfg.TickInterval)
 	return nil
 }
 
-// Stop signals the tick loop and waits up to ShutdownDeadline for the
-// in-flight tick to drain. Concurrent second Stop is a no-op. Adding a
-// Start-after-Stop restart path needs a `stopping` guard to prevent
-// stacking goroutines on the same WaitGroup.
-func (r *Reconciler) Stop() error {
+// Stop prevents new ticks, waits for the current tick to drain within
+// ctx, and force-cancels its work when the budget expires. A timed-out
+// activation retains ownership until its goroutine actually exits, so Start
+// can never overlap it.
+func (r *Reconciler) Stop(ctx context.Context) error {
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+
 	r.mu.Lock()
-	if !r.running {
+	if r.runDone == nil {
 		r.mu.Unlock()
 		return nil
 	}
-	r.running = false
+	r.stopping = true
 	stopCancel := r.stopCancel
 	workCancel := r.workCancel
-	r.stopCancel = nil
-	r.workCancel = nil
+	runDone := r.runDone
 	r.mu.Unlock()
 
-	if workCancel != nil {
-		watchdog := time.AfterFunc(r.cfg.ShutdownDeadline, workCancel)
-		defer watchdog.Stop()
-	}
 	if stopCancel != nil {
 		stopCancel()
 	}
-	r.wg.Wait()
-	if workCancel != nil {
-		workCancel()
+	select {
+	case <-runDone:
+		slog.Info("curtailment reconciler stopped")
+		return nil
+	case <-ctx.Done():
+		if workCancel != nil {
+			workCancel()
+		}
+		return fmt.Errorf("curtailment reconciler: stop: %w", ctx.Err())
 	}
-	slog.Info("curtailment reconciler stopped")
-	return nil
 }
 
-func (r *Reconciler) tickLoop(stopCtx, workCtx context.Context) {
-	defer r.wg.Done()
+func (r *Reconciler) tickLoop(
+	stopCtx context.Context,
+	workCtx context.Context,
+	workCancel context.CancelFunc,
+	runDone chan<- struct{},
+) {
+	defer close(runDone)
+	defer r.finishActivation(workCancel)
 	ticker := time.NewTicker(r.cfg.TickInterval)
 	defer ticker.Stop()
 	for {
@@ -243,6 +259,16 @@ func (r *Reconciler) tickLoop(stopCtx, workCtx context.Context) {
 			r.safeTick(workCtx)
 		}
 	}
+}
+
+func (r *Reconciler) finishActivation(workCancel context.CancelFunc) {
+	workCancel()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stopping = false
+	r.stopCancel = nil
+	r.workCancel = nil
+	r.runDone = nil
 }
 
 // safeTick recovers panics in tick-level infra so the goroutine survives;

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -252,6 +252,9 @@ func (r *Reconciler) tickLoop(loopCtx, workCtx context.Context, runDone chan<- s
 			return
 		case <-ticker.C:
 			r.safeTick(workCtx)
+			if loopCtx.Err() != nil {
+				return
+			}
 		}
 	}
 }

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -106,7 +106,8 @@ type Reconciler struct {
 	fanAlert FacilityFanAlertEmitter
 	now      func() time.Time
 
-	runCancel   context.CancelFunc
+	loopCancel  context.CancelFunc
+	workCancel  context.CancelFunc
 	runCanceled <-chan struct{}
 	runDone     <-chan struct{}
 
@@ -191,14 +192,16 @@ func (r *Reconciler) Start(ctx context.Context) error {
 		}
 		return nil
 	}
-	runCtx, runCancel := context.WithCancel(ctx)
+	workCtx, workCancel := context.WithCancel(ctx)
+	loopCtx, loopCancel := context.WithCancel(workCtx)
 	runDone := make(chan struct{})
-	r.runCancel = runCancel
-	r.runCanceled = runCtx.Done()
+	r.loopCancel = loopCancel
+	r.workCancel = workCancel
+	r.runCanceled = loopCtx.Done()
 	r.runDone = runDone
 	r.mu.Unlock()
 
-	go r.tickLoop(runCtx, runDone)
+	go r.tickLoop(loopCtx, workCtx, runDone)
 	slog.Info("curtailment reconciler started", "tick_interval", r.cfg.TickInterval)
 	return nil
 }
@@ -215,33 +218,40 @@ func (r *Reconciler) Stop(ctx context.Context) error {
 		r.mu.Unlock()
 		return nil
 	}
-	runCancel := r.runCancel
+	loopCancel := r.loopCancel
+	workCancel := r.workCancel
 	runDone := r.runDone
 	r.mu.Unlock()
 
-	if runCancel != nil {
-		runCancel()
+	if loopCancel != nil {
+		loopCancel()
 	}
 	select {
 	case <-runDone:
+		if workCancel != nil {
+			workCancel()
+		}
 		slog.Info("curtailment reconciler stopped")
 		return nil
 	case <-ctx.Done():
+		if workCancel != nil {
+			workCancel()
+		}
 		return fmt.Errorf("curtailment reconciler: stop: %w", ctx.Err())
 	}
 }
 
-func (r *Reconciler) tickLoop(ctx context.Context, runDone chan<- struct{}) {
+func (r *Reconciler) tickLoop(loopCtx, workCtx context.Context, runDone chan<- struct{}) {
 	defer close(runDone)
 	defer r.finishActivation()
 	ticker := time.NewTicker(r.cfg.TickInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-ctx.Done():
+		case <-loopCtx.Done():
 			return
 		case <-ticker.C:
-			r.safeTick(ctx)
+			r.safeTick(workCtx)
 		}
 	}
 }
@@ -249,7 +259,8 @@ func (r *Reconciler) tickLoop(ctx context.Context, runDone chan<- struct{}) {
 func (r *Reconciler) finishActivation() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.runCancel = nil
+	r.loopCancel = nil
+	r.workCancel = nil
 	r.runCanceled = nil
 	r.runDone = nil
 }

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -106,12 +106,12 @@ type Reconciler struct {
 	fanAlert FacilityFanAlertEmitter
 	now      func() time.Time
 
-	runCancel context.CancelFunc
-	runDone   <-chan struct{}
+	runCancel   context.CancelFunc
+	runCanceled <-chan struct{}
+	runDone     <-chan struct{}
 
 	lifecycleMu sync.Mutex
 	mu          sync.Mutex
-	stopping    bool
 }
 
 var _ runtimejobs.Lifecycle = (*Reconciler)(nil)
@@ -183,17 +183,18 @@ func (r *Reconciler) Start(ctx context.Context) error {
 	r.lifecycleMu.Lock()
 	defer r.lifecycleMu.Unlock()
 	r.mu.Lock()
-	if r.stopping {
-		r.mu.Unlock()
-		return errors.New("curtailment reconciler: previous activation is still stopping")
-	}
 	if r.runDone != nil {
+		stopping := channelClosed(r.runCanceled)
 		r.mu.Unlock()
+		if stopping {
+			return errors.New("curtailment reconciler: previous activation is still stopping")
+		}
 		return nil
 	}
 	runCtx, runCancel := context.WithCancel(ctx)
 	runDone := make(chan struct{})
 	r.runCancel = runCancel
+	r.runCanceled = runCtx.Done()
 	r.runDone = runDone
 	r.mu.Unlock()
 
@@ -214,7 +215,6 @@ func (r *Reconciler) Stop(ctx context.Context) error {
 		r.mu.Unlock()
 		return nil
 	}
-	r.stopping = true
 	runCancel := r.runCancel
 	runDone := r.runDone
 	r.mu.Unlock()
@@ -249,9 +249,21 @@ func (r *Reconciler) tickLoop(ctx context.Context, runDone chan<- struct{}) {
 func (r *Reconciler) finishActivation() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.stopping = false
 	r.runCancel = nil
+	r.runCanceled = nil
 	r.runDone = nil
+}
+
+func channelClosed(done <-chan struct{}) bool {
+	if done == nil {
+		return false
+	}
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
 }
 
 // safeTick recovers panics in tick-level infra so the goroutine survives;

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -192,8 +192,8 @@ func (r *Reconciler) Start(ctx context.Context) error {
 		}
 		return nil
 	}
-	workCtx, workCancel := context.WithCancel(ctx)
-	loopCtx, loopCancel := context.WithCancel(workCtx)
+	workCtx, workCancel := context.WithCancel(context.WithoutCancel(ctx))
+	loopCtx, loopCancel := context.WithCancel(ctx)
 	runDone := make(chan struct{})
 	r.loopCancel = loopCancel
 	r.workCancel = workCancel

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -106,9 +106,8 @@ type Reconciler struct {
 	fanAlert FacilityFanAlertEmitter
 	now      func() time.Time
 
-	stopCancel context.CancelFunc
-	workCancel context.CancelFunc
-	runDone    <-chan struct{}
+	runCancel context.CancelFunc
+	runDone   <-chan struct{}
 
 	lifecycleMu sync.Mutex
 	mu          sync.Mutex
@@ -164,8 +163,9 @@ func New(cfg Config, store interfaces.CurtailmentStore, cmd CommandDispatcher, o
 	return r
 }
 
-// Start spins up the tick loop. Repeat Starts without an intervening Stop
-// are no-ops so misbehaving wiring cannot fork two reconcilers.
+// Start spins up the tick loop for the lifetime of ctx. Repeat Starts without
+// an intervening Stop are no-ops so misbehaving wiring cannot fork two
+// reconcilers.
 func (r *Reconciler) Start(ctx context.Context) error {
 	if r.store == nil {
 		return fmt.Errorf("curtailment reconciler: store is required")
@@ -191,26 +191,20 @@ func (r *Reconciler) Start(ctx context.Context) error {
 		r.mu.Unlock()
 		return nil
 	}
-	stopCtx, stopCancel := context.WithCancel(ctx)
-	// Stopping the activation prevents new ticks immediately but gives the
-	// current tick a chance to finish. Stop cancels this detached work
-	// context if its caller's shutdown budget expires.
-	workCtx, workCancel := context.WithCancel(context.WithoutCancel(ctx))
+	runCtx, runCancel := context.WithCancel(ctx)
 	runDone := make(chan struct{})
-	r.stopCancel = stopCancel
-	r.workCancel = workCancel
+	r.runCancel = runCancel
 	r.runDone = runDone
 	r.mu.Unlock()
 
-	go r.tickLoop(stopCtx, workCtx, workCancel, runDone)
+	go r.tickLoop(runCtx, runDone)
 	slog.Info("curtailment reconciler started", "tick_interval", r.cfg.TickInterval)
 	return nil
 }
 
-// Stop prevents new ticks, waits for the current tick to drain within
-// ctx, and force-cancels its work when the budget expires. A timed-out
-// activation retains ownership until its goroutine actually exits, so Start
-// can never overlap it.
+// Stop cancels the activation and waits for it to drain within ctx. A timed-out
+// activation retains ownership until its goroutine actually exits, so Start can
+// never overlap it.
 func (r *Reconciler) Stop(ctx context.Context) error {
 	r.lifecycleMu.Lock()
 	defer r.lifecycleMu.Unlock()
@@ -221,53 +215,42 @@ func (r *Reconciler) Stop(ctx context.Context) error {
 		return nil
 	}
 	r.stopping = true
-	stopCancel := r.stopCancel
-	workCancel := r.workCancel
+	runCancel := r.runCancel
 	runDone := r.runDone
 	r.mu.Unlock()
 
-	if stopCancel != nil {
-		stopCancel()
+	if runCancel != nil {
+		runCancel()
 	}
 	select {
 	case <-runDone:
 		slog.Info("curtailment reconciler stopped")
 		return nil
 	case <-ctx.Done():
-		if workCancel != nil {
-			workCancel()
-		}
 		return fmt.Errorf("curtailment reconciler: stop: %w", ctx.Err())
 	}
 }
 
-func (r *Reconciler) tickLoop(
-	stopCtx context.Context,
-	workCtx context.Context,
-	workCancel context.CancelFunc,
-	runDone chan<- struct{},
-) {
+func (r *Reconciler) tickLoop(ctx context.Context, runDone chan<- struct{}) {
 	defer close(runDone)
-	defer r.finishActivation(workCancel)
+	defer r.finishActivation()
 	ticker := time.NewTicker(r.cfg.TickInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-stopCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			r.safeTick(workCtx)
+			r.safeTick(ctx)
 		}
 	}
 }
 
-func (r *Reconciler) finishActivation(workCancel context.CancelFunc) {
-	workCancel()
+func (r *Reconciler) finishActivation() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.stopping = false
-	r.stopCancel = nil
-	r.workCancel = nil
+	r.runCancel = nil
 	r.runDone = nil
 }
 

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -4322,6 +4322,75 @@ func TestReconciler_ActivationContextCancellationPreventsOverlapWhileDraining(t 
 	require.NoError(t, r.Stop(context.Background()))
 }
 
+func TestReconciler_StopLetsInFlightWorkDrain(t *testing.T) {
+	r := New(Config{TickInterval: time.Hour}, newFakeStore(), &fakeDispatcher{})
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	workCtx, workCancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	r.loopCancel = loopCancel
+	r.workCancel = workCancel
+	r.runCanceled = loopCtx.Done()
+	r.runDone = runDone
+
+	loopStopped := make(chan struct{})
+	releaseWork := make(chan struct{})
+	go func() {
+		<-loopCtx.Done()
+		close(loopStopped)
+		select {
+		case <-workCtx.Done():
+			t.Error("Stop canceled in-flight work before its drain budget expired")
+		case <-releaseWork:
+		}
+		r.finishActivation()
+		close(runDone)
+	}()
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- r.Stop(context.Background()) }()
+	<-loopStopped
+	select {
+	case <-workCtx.Done():
+		t.Fatal("in-flight work was canceled during graceful drain")
+	default:
+	}
+	close(releaseWork)
+	require.NoError(t, <-stopDone)
+}
+
+func TestReconciler_StopDeadlineCancelsInFlightWork(t *testing.T) {
+	r := New(Config{TickInterval: time.Hour}, newFakeStore(), &fakeDispatcher{})
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	workCtx, workCancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	r.loopCancel = loopCancel
+	r.workCancel = workCancel
+	r.runCanceled = loopCtx.Done()
+	r.runDone = runDone
+
+	workCanceled := make(chan struct{})
+	releaseWork := make(chan struct{})
+	go func() {
+		<-loopCtx.Done()
+		<-workCtx.Done()
+		close(workCanceled)
+		<-releaseWork
+		r.finishActivation()
+		close(runDone)
+	}()
+
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelStop()
+	require.ErrorIs(t, r.Stop(stopCtx), context.DeadlineExceeded)
+	select {
+	case <-workCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("Stop deadline did not cancel in-flight work")
+	}
+	close(releaseWork)
+	require.NoError(t, r.Stop(context.Background()))
+}
+
 func TestReconciler_StopCancellationPreventsOverlappingRestart(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
@@ -4329,7 +4398,8 @@ func TestReconciler_StopCancellationPreventsOverlappingRestart(t *testing.T) {
 
 	runCtx, runCancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})
-	r.runCancel = runCancel
+	r.loopCancel = runCancel
+	r.workCancel = runCancel
 	r.runCanceled = runCtx.Done()
 	r.runDone = runDone
 

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -4332,6 +4332,31 @@ func TestReconciler_ActivationContextCancellationPreventsOverlapWhileDraining(t 
 	require.NoError(t, r.Stop(context.Background()))
 }
 
+func TestReconciler_ActivationCancellationDoesNotAdmitQueuedTick(t *testing.T) {
+	store := newFakeStore()
+	firstTickStarted := make(chan struct{})
+	releaseFirstTick := make(chan struct{})
+	store.listEventsHook = func(context.Context) {
+		if store.listEventsCalls == 1 {
+			close(firstTickStarted)
+			<-releaseFirstTick
+		}
+	}
+	r := New(Config{}, store, &fakeDispatcher{})
+	r.cfg.TickInterval = time.Millisecond
+	loopCtx, cancelLoop := context.WithCancel(t.Context())
+	runDone := make(chan struct{})
+	go r.tickLoop(loopCtx, context.Background(), runDone)
+
+	<-firstTickStarted
+	time.Sleep(5 * time.Millisecond)
+	cancelLoop()
+	close(releaseFirstTick)
+	<-runDone
+
+	require.Equal(t, 1, store.listEventsCalls)
+}
+
 func TestReconciler_StopLetsInFlightWorkDrain(t *testing.T) {
 	r := New(Config{TickInterval: time.Hour}, newFakeStore(), &fakeDispatcher{})
 	loopCtx, loopCancel := context.WithCancel(context.Background())

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -4301,19 +4301,18 @@ func TestReconciler_StopCancellationPreventsOverlappingRestart(t *testing.T) {
 	disp := &fakeDispatcher{}
 	r := New(Config{TickInterval: time.Hour}, store, disp)
 
-	workCtx, workCancel := context.WithCancel(context.Background())
+	runCtx, runCancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})
-	r.stopCancel = func() {}
-	r.workCancel = workCancel
+	r.runCancel = runCancel
 	r.runDone = runDone
 
 	workCanceled := make(chan struct{})
 	releaseWork := make(chan struct{})
 	go func() {
-		<-workCtx.Done()
+		<-runCtx.Done()
 		close(workCanceled)
 		<-releaseWork
-		r.finishActivation(workCancel)
+		r.finishActivation()
 		close(runDone)
 	}()
 

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -4304,9 +4304,14 @@ func TestReconciler_ActivationContextCancellationPreventsOverlapWhileDraining(t 
 	store := newFakeStore()
 	started := make(chan struct{})
 	release := make(chan struct{})
-	store.listEventsHook = func(context.Context) {
+	workCanceled := make(chan struct{})
+	store.listEventsHook = func(ctx context.Context) {
 		close(started)
-		<-release
+		select {
+		case <-ctx.Done():
+			close(workCanceled)
+		case <-release:
+		}
 	}
 	r := New(Config{TickInterval: time.Second}, store, &fakeDispatcher{})
 	runCtx, cancel := context.WithCancel(context.Background())
@@ -4315,6 +4320,11 @@ func TestReconciler_ActivationContextCancellationPreventsOverlapWhileDraining(t 
 
 	cancel()
 	require.ErrorContains(t, r.Start(context.Background()), "previous activation is still stopping")
+	select {
+	case <-workCanceled:
+		t.Fatal("activation cancellation canceled admitted reconciliation work")
+	default:
+	}
 
 	close(release)
 	require.NoError(t, r.Stop(context.Background()))

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -818,7 +818,6 @@ func identifiersFromSelector(selector *pb.DeviceSelector) []string {
 func newReconcilerForTest(store *fakeStore, disp *fakeDispatcher) *Reconciler {
 	r := New(Config{
 		TickInterval:         time.Hour, // tests drive runTick directly
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		CurtailMaxRetries:    3,
 		DriftThresholdFactor: 0.5,
@@ -830,7 +829,6 @@ func newReconcilerForTest(store *fakeStore, disp *fakeDispatcher) *Reconciler {
 func newReconcilerWithFansForTest(store *fakeStore, disp *fakeDispatcher, fans *fakeFanController) *Reconciler {
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		CurtailMaxRetries:    3,
 		DriftThresholdFactor: 0.5,
@@ -847,7 +845,6 @@ func newReconcilerWithFanAlertForTest(
 ) *Reconciler {
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		CurtailMaxRetries:    3,
 		DriftThresholdFactor: 0.5,
@@ -3126,7 +3123,6 @@ func TestReconciler_ListEventsErrorAdvancesHeartbeatAndIncrementsFailure(t *test
 
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		DriftThresholdFactor: 0.5,
 	}, store, disp, WithMetrics(metrics))
@@ -4171,7 +4167,6 @@ func TestReconciler_ObserveTickDurationFiresOnHappyPath(t *testing.T) {
 
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		DriftThresholdFactor: 0.5,
 	}, store, disp, WithMetrics(metrics))
@@ -4196,7 +4191,6 @@ func TestReconciler_TickFailureFiresOnTickInfraPanic(t *testing.T) {
 	store.listEventsPanicErr = "synthetic db panic"
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		DriftThresholdFactor: 0.5,
 	}, store, disp, WithMetrics(metrics))
@@ -4230,7 +4224,6 @@ func TestReconciler_TickFailureFiresOnPerEventPanic(t *testing.T) {
 	first := true
 	r := New(Config{
 		TickInterval:         time.Hour,
-		ShutdownDeadline:     time.Second,
 		MaxRetries:           3,
 		DriftThresholdFactor: 0.5,
 	}, store, disp, WithMetrics(metrics))
@@ -4276,19 +4269,77 @@ func TestReconciler_PanicInListEventsRecovers(t *testing.T) {
 func TestReconciler_StartIdempotency(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
-	r := New(Config{TickInterval: time.Hour, ShutdownDeadline: time.Second}, store, disp)
+	r := New(Config{TickInterval: time.Hour}, store, disp)
 
 	require.NoError(t, r.Start(context.Background()))
 	require.NoError(t, r.Start(context.Background()), "second Start is a no-op")
-	require.NoError(t, r.Stop())
+	require.NoError(t, r.Stop(context.Background()))
 	// Second Stop is a no-op too; verify no panic / goroutine deadlock.
-	require.NoError(t, r.Stop())
+	require.NoError(t, r.Stop(context.Background()))
+}
+
+func TestReconciler_ActivationContextCancellationAllowsRestart(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+	r := New(Config{TickInterval: time.Hour}, store, disp)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, r.Start(runCtx))
+	cancel()
+	require.Eventually(t, func() bool {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		return r.runDone == nil
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, r.Start(context.Background()))
+	require.NoError(t, r.Stop(context.Background()))
+}
+
+func TestReconciler_StopCancellationPreventsOverlappingRestart(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+	r := New(Config{TickInterval: time.Hour}, store, disp)
+
+	workCtx, workCancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	r.stopCancel = func() {}
+	r.workCancel = workCancel
+	r.runDone = runDone
+
+	workCanceled := make(chan struct{})
+	releaseWork := make(chan struct{})
+	go func() {
+		<-workCtx.Done()
+		close(workCanceled)
+		<-releaseWork
+		r.finishActivation(workCancel)
+		close(runDone)
+	}()
+
+	stopCtx, cancelStop := context.WithCancel(context.Background())
+	cancelStop()
+	require.ErrorIs(t, r.Stop(stopCtx), context.Canceled)
+	require.Eventually(t, func() bool {
+		select {
+		case <-workCanceled:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.ErrorContains(t, r.Start(context.Background()), "previous activation is still stopping")
+
+	close(releaseWork)
+	require.NoError(t, r.Stop(context.Background()))
+	require.NoError(t, r.Start(context.Background()))
+	require.NoError(t, r.Stop(context.Background()))
 }
 
 func TestReconciler_StartRejectsSubSecondTickInterval(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
-	r := New(Config{TickInterval: 500 * time.Millisecond, ShutdownDeadline: time.Second}, store, disp)
+	r := New(Config{TickInterval: 500 * time.Millisecond}, store, disp)
 
 	err := r.Start(context.Background())
 	require.Error(t, err)
@@ -4300,7 +4351,6 @@ func TestReconciler_StartRejectsInvalidCurtailDispatchTimeout(t *testing.T) {
 	disp := &fakeDispatcher{}
 	r := New(Config{
 		TickInterval:              time.Hour,
-		ShutdownDeadline:          time.Second,
 		CurtailDispatchTimeoutSec: -1,
 	}, store, disp)
 
@@ -4312,7 +4362,7 @@ func TestReconciler_StartRejectsInvalidCurtailDispatchTimeout(t *testing.T) {
 func TestReconciler_ConfigDefaultsDispatchTimeouts(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
-	r := New(Config{TickInterval: time.Hour, ShutdownDeadline: time.Second}, store, disp)
+	r := New(Config{TickInterval: time.Hour}, store, disp)
 
 	assert.Equal(t, int32(10), r.cfg.MaxRetries)
 	assert.Equal(t, int32(50), r.cfg.CurtailMaxRetries)

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -40,6 +40,7 @@ type fakeStore struct {
 	listEventsErr      error
 	listEventsCalls    int
 	listEventsPanicErr string
+	listEventsHook     func(context.Context)
 	listTargetsHook    func(context.Context, uuid.UUID)
 	listTargetsCtxErr  map[uuid.UUID]error
 
@@ -383,8 +384,11 @@ func (f *fakeStore) GetEventByExternalReference(context.Context, int64, string, 
 	panic("GetEventByExternalReference not exercised by reconciler tests")
 }
 
-func (f *fakeStore) ListNonTerminalEvents(context.Context) ([]*models.Event, error) {
+func (f *fakeStore) ListNonTerminalEvents(ctx context.Context) ([]*models.Event, error) {
 	f.listEventsCalls++
+	if f.listEventsHook != nil {
+		f.listEventsHook(ctx)
+	}
 	if f.listEventsPanicErr != "" {
 		panic(f.listEventsPanicErr)
 	}
@@ -4296,6 +4300,28 @@ func TestReconciler_ActivationContextCancellationAllowsRestart(t *testing.T) {
 	require.NoError(t, r.Stop(context.Background()))
 }
 
+func TestReconciler_ActivationContextCancellationPreventsOverlapWhileDraining(t *testing.T) {
+	store := newFakeStore()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	store.listEventsHook = func(context.Context) {
+		close(started)
+		<-release
+	}
+	r := New(Config{TickInterval: time.Second}, store, &fakeDispatcher{})
+	runCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, r.Start(runCtx))
+	<-started
+
+	cancel()
+	require.ErrorContains(t, r.Start(context.Background()), "previous activation is still stopping")
+
+	close(release)
+	require.NoError(t, r.Stop(context.Background()))
+	require.NoError(t, r.Start(context.Background()))
+	require.NoError(t, r.Stop(context.Background()))
+}
+
 func TestReconciler_StopCancellationPreventsOverlappingRestart(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}
@@ -4304,6 +4330,7 @@ func TestReconciler_StopCancellationPreventsOverlappingRestart(t *testing.T) {
 	runCtx, runCancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})
 	r.runCancel = runCancel
+	r.runCanceled = runCtx.Done()
 	r.runDone = runDone
 
 	workCanceled := make(chan struct{})


### PR DESCRIPTION
Reviewable diff: +238/-141 across 4 files (excludes generated, test, and story files).

## Summary

Curtailment reconciliation, MQTT ingest, and curtailment alert metrics now share the same restartable lifecycle contract. A passive Fleet can keep these control-input loops stopped, while a clean demotion drains the current activation before a later owner starts them again.

**Stack:**

- Foundation: [#780](https://github.com/block/proto-fleet/pull/780) (merged)
- Parallel domain refactors: diagnostics [#781](https://github.com/block/proto-fleet/pull/781), IP scanning [#782](https://github.com/block/proto-fleet/pull/782), scheduling [#783](https://github.com/block/proto-fleet/pull/783), curtailment [#785](https://github.com/block/proto-fleet/pull/785), command execution [#787](https://github.com/block/proto-fleet/pull/787), and telemetry [#786](https://github.com/block/proto-fleet/pull/786)
- Orchestration: [#784](https://github.com/block/proto-fleet/pull/784)
- Catalog and `fleetd` cutover: [#788](https://github.com/block/proto-fleet/pull/788)

This PR is the **curtailment lifecycles** slice and now targets `main`. Merged [#780](https://github.com/block/proto-fleet/pull/780) supplies the shared `runtimejobs.Lifecycle` contract; the remaining domain and orchestration refactors are independent sibling PRs and can merge in any order. #788 is temporarily based on the integration branch so its reviewable diff contains only catalog/cutover work; after the siblings merge it will be rebased and retargeted to `main`. Passive-mode coordinator wiring, epoch fencing, and request gating remain later HA work.

## How it works

Each concrete loop owns one activation context and drain state. Cancellation of the `Start` context and an explicit `Stop` request the same cancellation; `Stop` then waits within the caller's deadline. The reconciler passes that context into tick database and control work, so activation cancellation also reaches already-admitted work instead of leaving it detached. MQTT gives each activation its own worker accounting and completion signal, and a timed-out stop continues cleanup asynchronously before permitting restart. The alert metrics loop likewise retains ownership until any in-flight tick exits.

```mermaid
flowchart LR
    A["Activation"] --> R["Curtailment reconciler"]
    A --> M["MQTT subscriber"]
    A --> X["Alert metrics loop"]
    D["Activation cancellation or Stop"] --> C["Cancel activation work"]
    C --> R
    C --> M
    C --> X
    R --> Z["Drain before restart"]
    M --> Z
    X --> Z
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `curtailment/reconciler/` | Uses one activation context for the loop and admitted tick work | Prevents duplicate control actions across owners |
| `curtailment/mqttingest/` | Serializes lifecycle and waits for subscriber workers | Prevents overlapping source subscriptions |
| `curtailment/alert_metrics.go` | Adds restartable loop and in-flight tick ownership | Avoids old-activation metric writes after restart |
| `server/cmd/fleetd/main.go` | Uses bounded stop contexts for all three loops | Preserves standalone behavior and finite shutdown |

## Key technical decisions & trade-offs

- Keep three domain lifecycles separate because they have different dependencies and enablement, while grouping them in one reviewable curtailment PR.
- Preserve conditional alert-metrics construction when metrics are disabled.
- Use one run context per lifecycle so cancellation and explicit stop have identical reach.
- Block restart after a timed-out drain until surviving work actually exits.

## Related

Related: #740

## Testing & validation

- `go test -short -race -count=1 ./internal/domain/curtailment ./internal/domain/curtailment/mqttingest ./internal/domain/curtailment/reconciler ./cmd/fleetd`
- Covers activation cancellation, timeout, eventual restart, and no overlap; focused cancellation/restart tests were repeated 25 times under the race detector.

## Post-Deploy Monitoring & Validation

Watch reconciler errors/control-action counts, MQTT connection and subscription state, alert metric freshness, and shutdown drain logs through at least one reconcile interval. Roll back on duplicate control actions, overlapping MQTT clients, stale alert metrics, or repeated stop-budget failures.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)