### PR TITLE
refactor(command): make execution restartable (6/9)

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -471,9 +471,6 @@ func start(config *Config) error {
 
 	dbMessageQueue := queue.NewDatabaseMessageQueue(&config.Queue, conn)
 
-	executionServiceCtx, executionServiceCancel := context.WithCancel(context.Background())
-	defer executionServiceCancel()
-
 	// Ensure plugin cleanup on shutdown
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(),
@@ -484,11 +481,15 @@ func start(config *Config) error {
 		}
 	}()
 
-	executionService := commandDomain.NewExecutionService(executionServiceCtx, &config.Command, conn, dbMessageQueue, encryptSvc, tokenSvc, minerService, deviceStore, telemetryService, filesService)
+	executionService := commandDomain.NewExecutionService(&config.Command, conn, dbMessageQueue, encryptSvc, tokenSvc, minerService, deviceStore, telemetryService, filesService)
 	executionService.WithMetricsEmitter(metricsProvider)
-	err = executionService.Start(executionServiceCtx)
+	err = executionService.Start(context.Background())
 	if err != nil {
 		slog.Error("failed to start command execution service", "error", err)
+	} else {
+		defer func() {
+			stopStandaloneJob("command execution service", executionService)
+		}()
 	}
 
 	statusService := commandDomain.NewStatusService(conn, dbMessageQueue)

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -73,9 +73,9 @@ type ExecutionService struct {
 	lifecycleMu           sync.Mutex
 	queueProcessorRunning bool
 	runCancel             context.CancelFunc
+	runCtxDone            <-chan struct{}
 	runWG                 sync.WaitGroup
 	runDone               <-chan struct{}
-	stopping              bool
 }
 
 var _ runtimejobs.Lifecycle = (*ExecutionService)(nil)
@@ -121,11 +121,13 @@ func (es *ExecutionService) WithMetricsEmitter(emitter MetricsEmitter) *Executio
 // active.
 func (es *ExecutionService) Start(ctx context.Context) error {
 	es.lifecycleMu.Lock()
-	if es.stopping {
-		es.lifecycleMu.Unlock()
-		return fmt.Errorf("command execution service is still stopping")
-	}
 	if es.runCancel != nil {
+		select {
+		case <-es.runCtxDone:
+			es.lifecycleMu.Unlock()
+			return fmt.Errorf("command execution service activation is still draining")
+		default:
+		}
 		es.lifecycleMu.Unlock()
 		return nil
 	}
@@ -133,6 +135,7 @@ func (es *ExecutionService) Start(ctx context.Context) error {
 	runCtx, runCancel := context.WithCancel(ctx)
 	runDone := make(chan struct{})
 	es.runCancel = runCancel
+	es.runCtxDone = runCtx.Done()
 	es.runDone = runDone
 	es.queueProcessorRunning = true
 
@@ -164,8 +167,8 @@ func (es *ExecutionService) finishRun(done chan struct{}) {
 	es.lifecycleMu.Lock()
 	if es.runDone == (<-chan struct{})(done) {
 		es.runCancel = nil
+		es.runCtxDone = nil
 		es.runDone = nil
-		es.stopping = false
 		es.queueProcessorRunning = false
 	}
 	es.lifecycleMu.Unlock()
@@ -180,10 +183,7 @@ func (es *ExecutionService) Stop(ctx context.Context) error {
 		es.lifecycleMu.Unlock()
 		return nil
 	}
-	if !es.stopping {
-		es.stopping = true
-		es.runCancel()
-	}
+	es.runCancel()
 	done := es.runDone
 	es.lifecycleMu.Unlock()
 

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -117,7 +117,8 @@ func (es *ExecutionService) WithMetricsEmitter(emitter MetricsEmitter) *Executio
 	return es
 }
 
-// Start starts the queue processor thread if it is not already running.
+// Start runs command execution for the lifetime of ctx if it is not already
+// active.
 func (es *ExecutionService) Start(ctx context.Context) error {
 	es.lifecycleMu.Lock()
 	if es.stopping {

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -70,15 +70,36 @@ type ExecutionService struct {
 
 	workerSemaphore chan struct{}
 
-	lifecycleMu           sync.Mutex
-	queueProcessorRunning bool
-	runCancel             context.CancelFunc
-	runCtxDone            <-chan struct{}
-	runWG                 sync.WaitGroup
-	runDone               <-chan struct{}
+	lifecycleMu sync.Mutex
+	run         *executionRun
+}
+
+type executionRun struct {
+	admissionCtx    context.Context //nolint:containedctx // scoped to this activation's admission phase
+	cancelAdmission context.CancelFunc
+	workCtx         context.Context //nolint:containedctx // scoped to this activation's drain phase
+	cancelWork      context.CancelFunc
+	accepting       bool
+	wg              sync.WaitGroup
+	done            chan struct{}
 }
 
 var _ runtimejobs.Lifecycle = (*ExecutionService)(nil)
+
+var errExecutionNotAccepting = errors.New("command execution service is not accepting work")
+
+func newExecutionRun(ctx context.Context) *executionRun {
+	admissionCtx, cancelAdmission := context.WithCancel(ctx)
+	workCtx, cancelWork := context.WithCancel(context.WithoutCancel(ctx))
+	return &executionRun{
+		admissionCtx:    admissionCtx,
+		cancelAdmission: cancelAdmission,
+		workCtx:         workCtx,
+		cancelWork:      cancelWork,
+		accepting:       true,
+		done:            make(chan struct{}),
+	}
+}
 
 func NewExecutionService(config *Config, conn *sql.DB, messageQueue queue.MessageQueue, encryptService *encrypt.Service, tokenService *tokenDomain.Service, minerService CachedMinerGetter, deviceStore stores.DeviceStore, telemetryListener TelemetryListener, filesService *files.Service) *ExecutionService {
 	if config.StuckMessageTimeout <= 0 {
@@ -94,18 +115,17 @@ func NewExecutionService(config *Config, conn *sql.DB, messageQueue queue.Messag
 		config.FirmwareUpdateStuckTimeout = 20 * time.Minute
 	}
 	return &ExecutionService{
-		config:                config,
-		conn:                  conn,
-		messageQueue:          messageQueue,
-		encryptService:        encryptService,
-		tokenService:          tokenService,
-		minerService:          minerService,
-		deviceStore:           deviceStore,
-		telemetryListener:     telemetryListener,
-		filesService:          filesService,
-		metricsEmitter:        NoCommandMetrics(),
-		workerSemaphore:       make(chan struct{}, config.MaxWorkers),
-		queueProcessorRunning: false,
+		config:            config,
+		conn:              conn,
+		messageQueue:      messageQueue,
+		encryptService:    encryptService,
+		tokenService:      tokenService,
+		minerService:      minerService,
+		deviceStore:       deviceStore,
+		telemetryListener: telemetryListener,
+		filesService:      filesService,
+		metricsEmitter:    NoCommandMetrics(),
+		workerSemaphore:   make(chan struct{}, config.MaxWorkers),
 	}
 }
 
@@ -125,77 +145,78 @@ func (es *ExecutionService) Start(ctx context.Context) error {
 	}
 
 	es.lifecycleMu.Lock()
-	if es.runCancel != nil {
-		select {
-		case <-es.runCtxDone:
+	if es.run != nil {
+		if !es.run.accepting || es.run.admissionCtx.Err() != nil {
 			es.lifecycleMu.Unlock()
 			return fmt.Errorf("command execution service activation is still draining")
-		default:
 		}
 		es.lifecycleMu.Unlock()
 		return nil
 	}
 
-	runCtx, runCancel := context.WithCancel(ctx)
-	runDone := make(chan struct{})
-	es.runCancel = runCancel
-	es.runCtxDone = runCtx.Done()
-	es.runDone = runDone
-	es.queueProcessorRunning = true
+	run := newExecutionRun(ctx)
+	es.run = run
 
-	es.runWG.Go(func() {
-		es.startStuckMessageReaper(runCtx)
+	run.wg.Go(func() {
+		es.startStuckMessageReaper(run.admissionCtx)
 	})
 
 	// Start the queue processor thread
-	es.runWG.Go(func() {
-		err := es.startQueueProcessorThread(runCtx)
-		runCancel()
-		es.lifecycleMu.Lock()
-		es.queueProcessorRunning = false
-		es.lifecycleMu.Unlock()
+	run.wg.Go(func() {
+		err := es.startQueueProcessorThread(run)
+		es.beginStop(run)
 
 		if err != nil && !errors.Is(err, context.Canceled) {
 			slog.Error("message processing stopped with error", "error", err)
 		}
 	})
-	go es.finishRun(runDone)
+	context.AfterFunc(run.admissionCtx, func() {
+		es.beginStop(run)
+	})
+	go es.finishRun(run)
 	es.lifecycleMu.Unlock()
 
 	return nil
 }
 
-func (es *ExecutionService) finishRun(done chan struct{}) {
-	es.runWG.Wait()
-
+func (es *ExecutionService) beginStop(run *executionRun) {
 	es.lifecycleMu.Lock()
-	if es.runDone == (<-chan struct{})(done) {
-		es.runCancel = nil
-		es.runCtxDone = nil
-		es.runDone = nil
-		es.queueProcessorRunning = false
+	if es.run == run {
+		run.accepting = false
 	}
 	es.lifecycleMu.Unlock()
-	close(done)
+	run.cancelAdmission()
 }
 
-// Stop cancels the active queue processor, reaper, and workers and waits for
-// all execution-owned goroutines to drain.
+func (es *ExecutionService) finishRun(run *executionRun) {
+	run.wg.Wait()
+	run.cancelWork()
+	es.lifecycleMu.Lock()
+	if es.run == run {
+		es.run = nil
+	}
+	es.lifecycleMu.Unlock()
+	close(run.done)
+}
+
+// Stop closes admission and waits for admitted work to drain. If ctx expires,
+// it cancels that work before returning.
 func (es *ExecutionService) Stop(ctx context.Context) error {
 	es.lifecycleMu.Lock()
-	if es.runCancel == nil {
+	run := es.run
+	if run == nil {
 		es.lifecycleMu.Unlock()
 		return nil
 	}
-	es.queueProcessorRunning = false
-	es.runCancel()
-	done := es.runDone
+	run.accepting = false
 	es.lifecycleMu.Unlock()
+	run.cancelAdmission()
 
 	select {
-	case <-done:
+	case <-run.done:
 		return nil
 	case <-ctx.Done():
+		run.cancelWork()
 		return fmt.Errorf("stop command execution service: %w", ctx.Err())
 	}
 }
@@ -204,7 +225,34 @@ func (es *ExecutionService) IsRunning() bool {
 	es.lifecycleMu.Lock()
 	defer es.lifecycleMu.Unlock()
 
-	return es.queueProcessorRunning
+	return es.run != nil && es.run.accepting && es.run.admissionCtx.Err() == nil
+}
+
+// withAdmission makes accepting an enqueue atomic with stopping. Once
+// admitted, the operation may drain after Stop begins and is canceled only if
+// the stop context expires.
+func (es *ExecutionService) withAdmission(ctx context.Context, fn func(context.Context) error) error {
+	es.lifecycleMu.Lock()
+	run := es.run
+	if run == nil || !run.accepting || run.admissionCtx.Err() != nil {
+		es.lifecycleMu.Unlock()
+		return errExecutionNotAccepting
+	}
+	run.wg.Add(1)
+	es.lifecycleMu.Unlock()
+	defer run.wg.Done()
+
+	workCtx, cancel := context.WithCancel(ctx)
+	stopCancel := context.AfterFunc(run.workCtx, cancel)
+	defer func() {
+		stopCancel()
+		cancel()
+	}()
+	if run.workCtx.Err() != nil {
+		cancel()
+	}
+
+	return fn(workCtx)
 }
 
 func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {
@@ -354,7 +402,8 @@ func (es *ExecutionService) dequeueWithRetry(ctx context.Context, limit int32) (
 	return nil, err
 }
 
-func (es *ExecutionService) startQueueProcessorThread(ctx context.Context) error {
+func (es *ExecutionService) startQueueProcessorThread(run *executionRun) error {
+	ctx := run.admissionCtx
 	for {
 		reservedSlots, err := es.reserveWorkerSlots(ctx)
 		if err != nil {
@@ -394,16 +443,16 @@ func (es *ExecutionService) startQueueProcessorThread(ctx context.Context) error
 		}
 
 		for _, message := range messages {
-			// The processor remains in runWG while it adds workers, so Wait
+			// The processor remains in the run wait group while it adds workers, so Wait
 			// cannot finish before all worker registrations are complete.
-			es.runWG.Go(func() {
+			run.wg.Go(func() {
 				defer func() { <-es.workerSemaphore }()
 
 				timeout := es.config.WorkerExecutionTimeout
 				if message.CommandType == commandtype.FirmwareUpdate {
 					timeout = es.config.FirmwareUpdateTimeout
 				}
-				workerCtx, cancel := context.WithTimeout(ctx, timeout)
+				workerCtx, cancel := context.WithTimeout(run.workCtx, timeout)
 				defer cancel()
 
 				es.workerProcessCommand(workerCtx, message)

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -183,6 +183,7 @@ func (es *ExecutionService) Stop(ctx context.Context) error {
 		es.lifecycleMu.Unlock()
 		return nil
 	}
+	es.queueProcessorRunning = false
 	es.runCancel()
 	done := es.runDone
 	es.lifecycleMu.Unlock()

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/infrastructure/encrypt"
 	"github.com/block/proto-fleet/server/internal/infrastructure/files"
 	"github.com/block/proto-fleet/server/internal/infrastructure/queue"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 const (
@@ -69,12 +70,17 @@ type ExecutionService struct {
 
 	workerSemaphore chan struct{}
 
-	queueProcessorMu      sync.Mutex
+	lifecycleMu           sync.Mutex
 	queueProcessorRunning bool
-	reaperCancel          context.CancelFunc
+	runCancel             context.CancelFunc
+	runWG                 sync.WaitGroup
+	runDone               <-chan struct{}
+	stopping              bool
 }
 
-func NewExecutionService(ctx context.Context, config *Config, conn *sql.DB, messageQueue queue.MessageQueue, encryptService *encrypt.Service, tokenService *tokenDomain.Service, minerService CachedMinerGetter, deviceStore stores.DeviceStore, telemetryListener TelemetryListener, filesService *files.Service) *ExecutionService {
+var _ runtimejobs.Lifecycle = (*ExecutionService)(nil)
+
+func NewExecutionService(config *Config, conn *sql.DB, messageQueue queue.MessageQueue, encryptService *encrypt.Service, tokenService *tokenDomain.Service, minerService CachedMinerGetter, deviceStore stores.DeviceStore, telemetryListener TelemetryListener, filesService *files.Service) *ExecutionService {
 	if config.StuckMessageTimeout <= 0 {
 		config.StuckMessageTimeout = 5 * time.Minute
 	}
@@ -113,42 +119,84 @@ func (es *ExecutionService) WithMetricsEmitter(emitter MetricsEmitter) *Executio
 
 // Start starts the queue processor thread if it is not already running.
 func (es *ExecutionService) Start(ctx context.Context) error {
-	es.queueProcessorMu.Lock()
-	defer es.queueProcessorMu.Unlock()
-
-	if es.queueProcessorRunning {
+	es.lifecycleMu.Lock()
+	if es.stopping {
+		es.lifecycleMu.Unlock()
+		return fmt.Errorf("command execution service is still stopping")
+	}
+	if es.runCancel != nil {
+		es.lifecycleMu.Unlock()
 		return nil
 	}
 
+	runCtx, runCancel := context.WithCancel(ctx)
+	runDone := make(chan struct{})
+	es.runCancel = runCancel
+	es.runDone = runDone
 	es.queueProcessorRunning = true
 
-	if es.reaperCancel != nil {
-		es.reaperCancel()
-	}
-	reaperCtx, reaperCancel := context.WithCancel(ctx)
-	es.reaperCancel = reaperCancel
-
-	go es.startStuckMessageReaper(reaperCtx)
+	es.runWG.Go(func() {
+		es.startStuckMessageReaper(runCtx)
+	})
 
 	// Start the queue processor thread
-	go func() {
-		err := es.startQueueProcessorThread(ctx)
-		reaperCancel()
-		es.queueProcessorMu.Lock()
+	es.runWG.Go(func() {
+		err := es.startQueueProcessorThread(runCtx)
+		runCancel()
+		es.lifecycleMu.Lock()
 		es.queueProcessorRunning = false
-		es.queueProcessorMu.Unlock()
+		es.lifecycleMu.Unlock()
 
 		if err != nil && !errors.Is(err, context.Canceled) {
 			slog.Error("message processing stopped with error", "error", err)
 		}
-	}()
+	})
+	go es.finishRun(runDone)
+	es.lifecycleMu.Unlock()
 
 	return nil
 }
 
+func (es *ExecutionService) finishRun(done chan struct{}) {
+	es.runWG.Wait()
+
+	es.lifecycleMu.Lock()
+	if es.runDone == (<-chan struct{})(done) {
+		es.runCancel = nil
+		es.runDone = nil
+		es.stopping = false
+		es.queueProcessorRunning = false
+	}
+	es.lifecycleMu.Unlock()
+	close(done)
+}
+
+// Stop cancels the active queue processor, reaper, and workers and waits for
+// all execution-owned goroutines to drain.
+func (es *ExecutionService) Stop(ctx context.Context) error {
+	es.lifecycleMu.Lock()
+	if es.runCancel == nil {
+		es.lifecycleMu.Unlock()
+		return nil
+	}
+	if !es.stopping {
+		es.stopping = true
+		es.runCancel()
+	}
+	done := es.runDone
+	es.lifecycleMu.Unlock()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("stop command execution service: %w", ctx.Err())
+	}
+}
+
 func (es *ExecutionService) IsRunning() bool {
-	es.queueProcessorMu.Lock()
-	defer es.queueProcessorMu.Unlock()
+	es.lifecycleMu.Lock()
+	defer es.lifecycleMu.Unlock()
 
 	return es.queueProcessorRunning
 }
@@ -264,8 +312,8 @@ func (es *ExecutionService) emitReapedCommandMetrics(ctx context.Context, reaped
 	}
 }
 
-func (es *ExecutionService) dequeueWithRetry(ctx context.Context) ([]queue.Message, error) {
-	messages, err := es.messageQueue.Dequeue(ctx)
+func (es *ExecutionService) dequeueWithRetry(ctx context.Context, limit int32) ([]queue.Message, error) {
+	messages, err := es.messageQueue.Dequeue(ctx, limit)
 	if err == nil {
 		return messages, nil
 	}
@@ -288,7 +336,7 @@ func (es *ExecutionService) dequeueWithRetry(ctx context.Context) ([]queue.Messa
 		// simple backoff for next attempt
 		delay *= 2
 
-		messages, err = es.messageQueue.Dequeue(ctx)
+		messages, err = es.messageQueue.Dequeue(ctx, limit)
 		if err == nil {
 			return messages, nil
 		}
@@ -297,47 +345,89 @@ func (es *ExecutionService) dequeueWithRetry(ctx context.Context) ([]queue.Messa
 		}
 	}
 
-	slog.Error("dequeue failed after retries", "error", err)
 	return nil, err
 }
 
 func (es *ExecutionService) startQueueProcessorThread(ctx context.Context) error {
 	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("queue processor context canceled: %w", ctx.Err())
-		default:
-			messages, err := es.dequeueWithRetry(ctx)
-
-			if err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return err
-				}
-				return fleeterror.NewInternalErrorf("error dequeueing messages: %v", err)
+		reservedSlots, err := es.reserveWorkerSlots(ctx)
+		if err != nil {
+			return err
+		}
+		messages, err := es.dequeueWithRetry(ctx, reservedSlots)
+		if err != nil {
+			es.releaseWorkerSlots(int(reservedSlots))
+			if ctx.Err() != nil {
+				return fmt.Errorf("queue processor context canceled while dequeuing: %w", ctx.Err())
 			}
-
-			if len(messages) == 0 {
-				time.Sleep(es.config.MasterPollingInterval)
+			slog.Error("dequeue failed after retries; command execution service remains active", "error", err)
+			timer := time.NewTimer(es.config.MasterPollingInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return fmt.Errorf("queue processor context canceled after dequeue failure: %w", ctx.Err())
+			case <-timer.C:
 				continue
 			}
+		}
+		if len(messages) > int(reservedSlots) {
+			es.releaseWorkerSlots(int(reservedSlots))
+			return fleeterror.NewInternalErrorf("dequeue returned %d messages for %d reserved worker slots", len(messages), reservedSlots)
+		}
+		es.releaseWorkerSlots(int(reservedSlots) - len(messages))
 
-			for _, message := range messages {
-				es.workerSemaphore <- struct{}{}
-
-				go func(msg queue.Message) {
-					defer func() { <-es.workerSemaphore }()
-
-					timeout := es.config.WorkerExecutionTimeout
-					if msg.CommandType == commandtype.FirmwareUpdate {
-						timeout = es.config.FirmwareUpdateTimeout
-					}
-					workerCtx, cancel := context.WithTimeout(ctx, timeout)
-					defer cancel()
-
-					es.workerProcessCommand(workerCtx, msg)
-				}(message)
+		if len(messages) == 0 {
+			timer := time.NewTimer(es.config.MasterPollingInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return fmt.Errorf("queue processor context canceled while idle: %w", ctx.Err())
+			case <-timer.C:
+				continue
 			}
 		}
+
+		for _, message := range messages {
+			// The processor remains in runWG while it adds workers, so Wait
+			// cannot finish before all worker registrations are complete.
+			es.runWG.Go(func() {
+				defer func() { <-es.workerSemaphore }()
+
+				timeout := es.config.WorkerExecutionTimeout
+				if message.CommandType == commandtype.FirmwareUpdate {
+					timeout = es.config.FirmwareUpdateTimeout
+				}
+				workerCtx, cancel := context.WithTimeout(ctx, timeout)
+				defer cancel()
+
+				es.workerProcessCommand(workerCtx, message)
+			})
+		}
+	}
+}
+
+func (es *ExecutionService) reserveWorkerSlots(ctx context.Context) (int32, error) {
+	select {
+	case es.workerSemaphore <- struct{}{}:
+	case <-ctx.Done():
+		return 0, fmt.Errorf("queue processor context canceled waiting for worker slot: %w", ctx.Err())
+	}
+
+	reserved := int32(1)
+	for int(reserved) < cap(es.workerSemaphore) {
+		select {
+		case es.workerSemaphore <- struct{}{}:
+			reserved++
+		default:
+			return reserved, nil
+		}
+	}
+	return reserved, nil
+}
+
+func (es *ExecutionService) releaseWorkerSlots(count int) {
+	for range count {
+		<-es.workerSemaphore
 	}
 }
 

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -86,7 +86,7 @@ type executionRun struct {
 
 var _ runtimejobs.Lifecycle = (*ExecutionService)(nil)
 
-var errExecutionNotAccepting = errors.New("command execution service is not accepting work")
+var errExecutionStoppedBeforeEnqueue = errors.New("command execution service stopped before enqueue")
 
 func newExecutionRun(ctx context.Context) *executionRun {
 	admissionCtx, cancelAdmission := context.WithCancel(ctx)
@@ -236,23 +236,29 @@ func (es *ExecutionService) withAdmission(ctx context.Context, fn func(context.C
 	run := es.run
 	if run == nil || !run.accepting || run.admissionCtx.Err() != nil {
 		es.lifecycleMu.Unlock()
-		return errExecutionNotAccepting
+		return errExecutionStoppedBeforeEnqueue
 	}
 	run.wg.Add(1)
 	es.lifecycleMu.Unlock()
 	defer run.wg.Done()
 
-	workCtx, cancel := context.WithCancel(ctx)
-	stopCancel := context.AfterFunc(run.workCtx, cancel)
+	workCtx, cancel := context.WithCancelCause(ctx)
+	stopCancel := context.AfterFunc(run.workCtx, func() {
+		cancel(errExecutionStoppedBeforeEnqueue)
+	})
 	defer func() {
 		stopCancel()
-		cancel()
+		cancel(context.Canceled)
 	}()
 	if run.workCtx.Err() != nil {
-		cancel()
+		cancel(errExecutionStoppedBeforeEnqueue)
 	}
 
-	return fn(workCtx)
+	err := fn(workCtx)
+	if err != nil && errors.Is(context.Cause(workCtx), errExecutionStoppedBeforeEnqueue) {
+		return errExecutionStoppedBeforeEnqueue
+	}
+	return err
 }
 
 func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -120,6 +120,10 @@ func (es *ExecutionService) WithMetricsEmitter(emitter MetricsEmitter) *Executio
 // Start runs command execution for the lifetime of ctx if it is not already
 // active.
 func (es *ExecutionService) Start(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("start command execution service: %w", err)
+	}
+
 	es.lifecycleMu.Lock()
 	if es.runCancel != nil {
 		select {

--- a/server/internal/domain/command/execution_service_credentials_test.go
+++ b/server/internal/domain/command/execution_service_credentials_test.go
@@ -409,7 +409,7 @@ func setupPasswordCommandDeviceWithStatus(t *testing.T, driverName string, withC
 		require.NoError(t, err)
 	}
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers: 1,
 	}, conn, nil, encryptSvc, nil, nil, nil, nil, nil)
 	return svc, conn, encryptSvc, dbDeviceID, deviceIdentifier

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -73,6 +73,20 @@ func TestExecutionService_Start(t *testing.T) {
 		require.NoError(t, svc.Stop(context.Background()))
 	})
 
+	t.Run("rejects restart while a canceled activation is draining", func(t *testing.T) {
+		runCtx, runCancel := context.WithCancel(t.Context())
+		svc := &ExecutionService{
+			runCancel:  runCancel,
+			runCtxDone: runCtx.Done(),
+			runDone:    make(chan struct{}),
+		}
+		runCancel()
+
+		err := svc.Start(t.Context())
+
+		require.EqualError(t, err, "command execution service activation is still draining")
+	})
+
 	t.Run("activation cancellation stops promptly and allows restart", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
@@ -125,9 +139,10 @@ func TestExecutionService_StopTimeoutRetainsActivationUntilWorkerDrains(t *testi
 		MasterPollingInterval: time.Hour,
 	}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
 
-	_, runCancel := context.WithCancel(context.Background())
+	runCtx, runCancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})
 	svc.runCancel = runCancel
+	svc.runCtxDone = runCtx.Done()
 	svc.runDone = runDone
 	svc.queueProcessorRunning = true
 	workerStarted := make(chan struct{})

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -241,7 +241,7 @@ func TestExecutionService_StopWaitsForAdmittedEnqueue(t *testing.T) {
 	require.Eventually(t, func() bool { return !svc.IsRunning() }, 100*time.Millisecond, time.Millisecond)
 	require.ErrorIs(t, svc.withAdmission(t.Context(), func(context.Context) error {
 		return nil
-	}), errExecutionNotAccepting)
+	}), errExecutionStoppedBeforeEnqueue)
 
 	select {
 	case err := <-stopDone:
@@ -252,6 +252,47 @@ func TestExecutionService_StopWaitsForAdmittedEnqueue(t *testing.T) {
 	close(releaseEnqueue)
 	require.NoError(t, <-enqueueDone)
 	require.NoError(t, <-stopDone)
+}
+
+func TestExecutionService_ForceCanceledEnqueueIsClassifiedAsStopped(t *testing.T) {
+	svc := &ExecutionService{}
+	run := newExecutionRun(t.Context())
+	svc.run = run
+
+	enqueueStarted := make(chan struct{})
+	enqueueDone := make(chan error, 1)
+	go func() {
+		enqueueDone <- svc.withAdmission(t.Context(), func(ctx context.Context) error {
+			close(enqueueStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+	<-enqueueStarted
+	go svc.finishRun(run)
+
+	stopCtx, cancelStop := context.WithCancel(context.Background())
+	cancelStop()
+	require.ErrorIs(t, svc.Stop(stopCtx), context.Canceled)
+
+	require.ErrorIs(t, <-enqueueDone, errExecutionStoppedBeforeEnqueue)
+	require.NoError(t, svc.Stop(context.Background()))
+}
+
+func TestExecutionService_CallerCanceledEnqueueRemainsCallerCancellation(t *testing.T) {
+	svc := &ExecutionService{}
+	run := newExecutionRun(t.Context())
+	svc.run = run
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := svc.withAdmission(ctx, func(ctx context.Context) error {
+		return ctx.Err()
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, errExecutionStoppedBeforeEnqueue)
 }
 
 func TestExecutionService_DequeueIsLimitedToAvailableWorkers(t *testing.T) {

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -162,9 +162,10 @@ func TestExecutionService_StopTimeoutRetainsActivationUntilWorkerDrains(t *testi
 	require.NoError(t, svc.Stop(context.Background()))
 }
 
-func TestExecutionService_StopDrainsAdmittedWorker(t *testing.T) {
+func TestExecutionService_ActivationCancellationThenStopDrainsAdmittedWorker(t *testing.T) {
 	svc := NewExecutionService(&Config{MaxWorkers: 1}, nil, nil, nil, nil, nil, nil, nil, nil)
-	run := newExecutionRun(t.Context())
+	activationCtx, cancelActivation := context.WithCancel(t.Context())
+	run := newExecutionRun(activationCtx)
 	svc.run = run
 
 	workerStarted := make(chan struct{})
@@ -178,18 +179,25 @@ func TestExecutionService_StopDrainsAdmittedWorker(t *testing.T) {
 		case <-releaseWorker:
 		}
 	})
+	context.AfterFunc(run.admissionCtx, func() {
+		svc.beginStop(run)
+	})
 	go svc.finishRun(run)
 	<-workerStarted
 
+	cancelActivation()
+	require.Eventually(t, func() bool { return !svc.IsRunning() }, 100*time.Millisecond, time.Millisecond)
+
 	stopDone := make(chan error, 1)
 	go func() {
-		stopDone <- svc.Stop(context.Background())
+		stopCtx, cancelStop := context.WithTimeout(context.Background(), time.Second)
+		defer cancelStop()
+		stopDone <- svc.Stop(stopCtx)
 	}()
-	require.Eventually(t, func() bool { return !svc.IsRunning() }, 100*time.Millisecond, time.Millisecond)
 
 	select {
 	case <-workerCanceled:
-		t.Fatal("normal Stop canceled admitted worker")
+		t.Fatal("activation cancellation prematurely canceled admitted worker")
 	default:
 	}
 	select {

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -39,51 +40,19 @@ type firmwareStatusMiner struct {
 }
 
 func TestExecutionService_Start(t *testing.T) {
-	t.Run("starts when not running and returns true", func(t *testing.T) {
+	t.Run("is idempotent while running", func(t *testing.T) {
 		// Arrange
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		started := false
+		var started atomic.Bool
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
-		mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
-			started = true
+		mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
+			started.Store(true)
 			return nil, nil
 		}).AnyTimes()
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-
-		svc := NewExecutionService(t.Context(), &Config{
-			MaxWorkers:            5,
-			MasterPollingInterval: 10 * time.Millisecond,
-		}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
-
-		// Act
-		err := svc.Start(t.Context())
-
-		// Assert
-		require.NoError(t, err)
-
-		// Verify the processor started
-		assert.Eventually(t, func() bool {
-			return started
-		}, 100*time.Millisecond, 5*time.Millisecond, "Processor should start")
-
-		assert.True(t, svc.IsRunning())
-	})
-
-	t.Run("returns false when already running", func(t *testing.T) {
-		// Arrange
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		started := false
-		mockQueue := mocks.NewMockMessageQueue(ctrl)
-		mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
-			started = true
-			return nil, nil
-		}).AnyTimes()
-		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 10 * time.Millisecond,
 		}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
@@ -93,9 +62,7 @@ func TestExecutionService_Start(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify the processor started
-		assert.Eventually(t, func() bool {
-			return started
-		}, 100*time.Millisecond, 5*time.Millisecond, "Processor should start")
+		assert.Eventually(t, started.Load, 100*time.Millisecond, 5*time.Millisecond, "Processor should start")
 
 		// Act - try to start again
 		err = svc.Start(t.Context())
@@ -103,40 +70,101 @@ func TestExecutionService_Start(t *testing.T) {
 		// Assert
 		require.NoError(t, err)
 		assert.True(t, svc.IsRunning())
+		require.NoError(t, svc.Stop(context.Background()))
+	})
+
+	t.Run("stops promptly while idle and can restart", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockQueue := mocks.NewMockMessageQueue(ctrl)
+		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
+
+		var dequeues atomic.Int32
+		mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, int32) ([]queue.Message, error) {
+			dequeues.Add(1)
+			return nil, nil
+		}).AnyTimes()
+
+		svc := NewExecutionService(&Config{
+			MaxWorkers:            1,
+			MasterPollingInterval: time.Hour,
+		}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
+
+		require.NoError(t, svc.Start(t.Context()))
+		require.Eventually(t, func() bool { return dequeues.Load() >= 1 }, 100*time.Millisecond, time.Millisecond)
+		stop := func() {
+			stopCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			require.NoError(t, svc.Stop(stopCtx))
+		}
+		stop()
+		require.False(t, svc.IsRunning())
+
+		require.NoError(t, svc.Start(t.Context()))
+		require.Eventually(t, func() bool { return dequeues.Load() >= 2 }, 100*time.Millisecond, time.Millisecond)
+		stop()
 	})
 }
 
-func TestStuckMessageReaper(t *testing.T) {
-	t.Run("reaper goroutine runs alongside processor", func(t *testing.T) {
-		// Arrange
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+func TestExecutionService_StopTimeoutRetainsActivationUntilWorkerDrains(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockQueue := mocks.NewMockMessageQueue(ctrl)
+	mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
+	mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}).AnyTimes()
 
-		mockQueue := mocks.NewMockMessageQueue(ctrl)
-		mockQueue.EXPECT().Dequeue(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
-			<-ctx.Done()
-			return nil, ctx.Err()
-		}).AnyTimes()
-		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
+	svc := NewExecutionService(&Config{
+		MaxWorkers:            1,
+		MasterPollingInterval: time.Hour,
+	}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
 
-		// conn=nil makes reapStuckMessages skip the DB call, so we just test
-		// that the goroutine starts and the processor runs alongside it.
-		svc := NewExecutionService(t.Context(), &Config{
-			MaxWorkers:            5,
-			MasterPollingInterval: 10 * time.Millisecond,
-			StuckMessageTimeout:   5 * time.Minute,
-			ReaperInterval:        10 * time.Millisecond,
-		}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
-
-		// Act
-		err := svc.Start(t.Context())
-
-		// Assert
-		require.NoError(t, err)
-		assert.Eventually(t, func() bool {
-			return svc.IsRunning()
-		}, 100*time.Millisecond, 5*time.Millisecond)
+	_, runCancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	svc.runCancel = runCancel
+	svc.runDone = runDone
+	svc.queueProcessorRunning = true
+	workerStarted := make(chan struct{})
+	releaseWorker := make(chan struct{})
+	svc.runWG.Go(func() {
+		close(workerStarted)
+		<-releaseWorker
 	})
+	go svc.finishRun(runDone)
+	<-workerStarted
+
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	require.ErrorIs(t, svc.Stop(stopCtx), context.DeadlineExceeded)
+	cancelStop()
+	require.Error(t, svc.Start(t.Context()))
+
+	close(releaseWorker)
+	require.NoError(t, svc.Stop(context.Background()))
+	require.NoError(t, svc.Start(t.Context()))
+	require.NoError(t, svc.Stop(context.Background()))
+}
+
+func TestExecutionService_DequeueIsLimitedToAvailableWorkers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockQueue := mocks.NewMockMessageQueue(ctrl)
+	mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
+	dequeued := make(chan struct{})
+	mockQueue.EXPECT().Dequeue(gomock.Any(), int32(1)).DoAndReturn(func(context.Context, int32) ([]queue.Message, error) {
+		close(dequeued)
+		return nil, nil
+	})
+
+	svc := NewExecutionService(&Config{
+		MaxWorkers:            1,
+		MasterPollingInterval: time.Hour,
+	}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- svc.startQueueProcessorThread(ctx) }()
+	<-dequeued
+	cancel()
+
+	require.ErrorIs(t, <-done, context.Canceled)
 }
 
 func TestQueueProcessorRetries(t *testing.T) {
@@ -148,14 +176,14 @@ func TestQueueProcessorRetries(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
-			DoAndReturn(func(context.Context) ([]queue.Message, error) {
+			Dequeue(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ int32) ([]queue.Message, error) {
 				cancel()
 				return nil, fleeterror.NewInternalError("error opening tx: context canceled")
 			})
 
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-		svc := NewExecutionService(ctx, &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: time.Millisecond,
 			DequeueRetries:        0,
@@ -175,48 +203,43 @@ func TestQueueProcessorRetries(t *testing.T) {
 
 		testError := errors.New("temporary error")
 
-		retryComplete := make(chan struct{})
-
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
 
 		// Track successful retry completion
-		retrySucceeded := false
+		var retrySucceeded atomic.Bool
 
 		// First call - returns error
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
+			Dequeue(gomock.Any(), gomock.Any()).
 			Return(nil, testError).
 			Times(1)
 
 		// Second call - returns error
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
+			Dequeue(gomock.Any(), gomock.Any()).
 			Return(nil, testError).
 			Times(1)
 
 		// Third call - returns success and signals completion
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
-			DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
-				// Signal that retry sequence completed successfully
-				retrySucceeded = true
-				close(retryComplete)
-
+			Dequeue(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
+				retrySucceeded.Store(true)
 				return []queue.Message{}, nil
 			}).
 			Times(1)
 
 		// Subsequent calls just block
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
-			DoAndReturn(func(ctx context.Context) ([]queue.Message, error) {
+			Dequeue(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
 				<-ctx.Done()
 				return nil, ctx.Err()
 			}).
 			AnyTimes()
 
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: time.Millisecond,
 			DequeueRetries:        3,
@@ -227,14 +250,13 @@ func TestQueueProcessorRetries(t *testing.T) {
 		require.NoError(t, err)
 
 		// Assert
-		assert.Eventually(t, func() bool {
-			return retrySucceeded
-		}, 200*time.Millisecond, 10*time.Millisecond, "Service should retry and eventually succeed")
+		assert.Eventually(t, retrySucceeded.Load, 200*time.Millisecond, 10*time.Millisecond, "Service should retry and eventually succeed")
 
 		assert.True(t, svc.IsRunning())
+		require.NoError(t, svc.Stop(context.Background()))
 	})
 
-	t.Run("stops running after max retries exhausted", func(t *testing.T) {
+	t.Run("keeps running after max retries exhausted", func(t *testing.T) {
 		// Arrange
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -245,12 +267,20 @@ func TestQueueProcessorRetries(t *testing.T) {
 
 		// First three calls fail (initial + 2 retries)
 		mockQueue.EXPECT().
-			Dequeue(gomock.Any()).
+			Dequeue(gomock.Any(), gomock.Any()).
 			Return(nil, testError).
 			Times(3)
+		retrying := make(chan struct{})
+		mockQueue.EXPECT().
+			Dequeue(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
+				close(retrying)
+				<-ctx.Done()
+				return nil, ctx.Err()
+			})
 
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: time.Millisecond,
 			DequeueRetries:        2, // Only 2 retries allowed
@@ -260,10 +290,13 @@ func TestQueueProcessorRetries(t *testing.T) {
 		err := svc.Start(t.Context())
 		require.NoError(t, err)
 
-		// Assert - wait for the service to stop running with timeout
-		assert.Eventually(t, func() bool {
-			return !svc.IsRunning()
-		}, 500*time.Millisecond, 10*time.Millisecond, "Service should stop running after max retries are exhausted")
+		select {
+		case <-retrying:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("service did not resume dequeuing after exhausting retries")
+		}
+		assert.True(t, svc.IsRunning())
+		require.NoError(t, svc.Stop(context.Background()))
 	})
 }
 
@@ -295,7 +328,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Reboot(gomock.Any()).
 			Return(fleeterror.NewUnimplementedError("reboot not supported"))
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -335,7 +368,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Reboot(gomock.Any()).
 			Return(fleeterror.NewInternalErrorf("temporary failure"))
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -375,7 +408,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Reboot(gomock.Any()).
 			Return(nil)
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -408,7 +441,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			GetMiner(gomock.Any(), int64(45)).
 			Return(nil, errors.New("device not found"))
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -448,7 +481,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Curtail(gomock.Any(), sdk.CurtailRequest{Level: sdk.CurtailLevelFull}).
 			Return(nil)
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -478,7 +511,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 		mockMinerGetter.EXPECT().GetMiner(gomock.Any(), int64(51)).Return(mockMiner, nil)
 		// Curtail must NOT be called when payload unmarshal fails.
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -516,7 +549,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			mockMinerGetter.EXPECT().GetMiner(gomock.Any(), int64(53)).Return(mockMiner, nil)
 			// No mockMiner.EXPECT().Curtail(...) — bounds check must short-circuit.
 
-			svc := NewExecutionService(t.Context(), &Config{
+			svc := NewExecutionService(&Config{
 				MaxWorkers:             5,
 				MasterPollingInterval:  10 * time.Millisecond,
 				WorkerExecutionTimeout: 5 * time.Second,
@@ -550,7 +583,7 @@ func TestExecuteCommandOnDevice(t *testing.T) {
 			Uncurtail(gomock.Any(), sdk.UncurtailRequest{}).
 			Return(nil)
 
-		svc := NewExecutionService(t.Context(), &Config{
+		svc := NewExecutionService(&Config{
 			MaxWorkers:             5,
 			MasterPollingInterval:  10 * time.Millisecond,
 			WorkerExecutionTimeout: 5 * time.Second,
@@ -715,7 +748,7 @@ func TestExecuteCommandOnDevice_FirmwareUpdatePassesFileMetadata(t *testing.T) {
 		GetDeviceStatusForDeviceIdentifiers(gomock.Any(), []tmodels.DeviceIdentifier{"device-123"}).
 		Return(map[tmodels.DeviceIdentifier]models.MinerStatus{}, nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -793,7 +826,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_UsesStoredWorkerName(t *testin
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -866,7 +899,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_UsesStoredWorkerNameAfterLooku
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -937,7 +970,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_PrefersCurrentPrimaryPoolWorke
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1000,7 +1033,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_FallsBackToStoredMacAddress(t 
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1068,7 +1101,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_LeavesUsernameUnchangedWhenWor
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1115,7 +1148,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_LeavesRawPoolUsernamesUnchange
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1164,7 +1197,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_PreservesLegacyDottedFleetUser
 			return nil
 		})
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1225,7 +1258,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReappliesCurrentPoolsWithStore
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1280,7 +1313,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyUsesDesiredWorkerNameFr
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-payload"), "payload-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1336,7 +1369,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyAppendsStoredWorkerName
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-append"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1391,7 +1424,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyReplacesEntireDottedWor
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-dotted-worker"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1452,7 +1485,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyNormalizesAllPoolsToSto
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-normalize-all"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1497,7 +1530,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_PersistsWorkerNameWhenNoCurren
 		UpdateWorkerName(gomock.Any(), models.DeviceIdentifier("device-reapply-empty"), "new-worker").
 		Return(nil)
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1538,7 +1571,7 @@ func TestExecuteCommandOnDevice_UpdateMiningPools_ReapplyPreservesGetPoolsErrorC
 		GetMiningPools(gomock.Any()).
 		Return(nil, fleeterror.NewUnimplementedErrorf("get pools not supported"))
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,
@@ -1634,7 +1667,7 @@ func TestExecuteCommand_UpdateMinerPassword_PersistFailureFailsCommand(t *testin
 	mockMiner.EXPECT().UpdateMinerPassword(gomock.Any(), gomock.Any()).Return(nil)
 	mockMinerGetter.EXPECT().InvalidateMiner(models.DeviceIdentifier("dev-50"))
 
-	svc := NewExecutionService(t.Context(), &Config{
+	svc := NewExecutionService(&Config{
 		MaxWorkers:             5,
 		MasterPollingInterval:  10 * time.Millisecond,
 		WorkerExecutionTimeout: 5 * time.Second,

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -83,17 +83,14 @@ func TestExecutionService_Start(t *testing.T) {
 	})
 
 	t.Run("rejects restart while a canceled activation is draining", func(t *testing.T) {
-		runCtx, runCancel := context.WithCancel(t.Context())
-		svc := &ExecutionService{
-			runCancel:  runCancel,
-			runCtxDone: runCtx.Done(),
-			runDone:    make(chan struct{}),
-		}
-		runCancel()
+		run := newExecutionRun(t.Context())
+		svc := &ExecutionService{run: run}
+		svc.beginStop(run)
 
 		err := svc.Start(t.Context())
 
 		require.EqualError(t, err, "command execution service activation is still draining")
+		run.cancelWork()
 	})
 
 	t.Run("activation cancellation stops promptly and allows restart", func(t *testing.T) {
@@ -119,7 +116,7 @@ func TestExecutionService_Start(t *testing.T) {
 		require.Eventually(t, func() bool {
 			svc.lifecycleMu.Lock()
 			defer svc.lifecycleMu.Unlock()
-			return svc.runCancel == nil
+			return svc.run == nil
 		}, 100*time.Millisecond, time.Millisecond)
 		require.False(t, svc.IsRunning())
 
@@ -135,44 +132,118 @@ func TestExecutionService_Start(t *testing.T) {
 }
 
 func TestExecutionService_StopTimeoutRetainsActivationUntilWorkerDrains(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockQueue := mocks.NewMockMessageQueue(ctrl)
-	mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
-	mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ int32) ([]queue.Message, error) {
-		<-ctx.Done()
-		return nil, ctx.Err()
-	}).AnyTimes()
-
 	svc := NewExecutionService(&Config{
 		MaxWorkers:            1,
 		MasterPollingInterval: time.Hour,
-	}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
+	}, nil, nil, nil, nil, nil, nil, nil, nil)
 
-	runCtx, runCancel := context.WithCancel(context.Background())
-	runDone := make(chan struct{})
-	svc.runCancel = runCancel
-	svc.runCtxDone = runCtx.Done()
-	svc.runDone = runDone
-	svc.queueProcessorRunning = true
+	run := newExecutionRun(context.Background())
+	svc.run = run
 	workerStarted := make(chan struct{})
+	workerCanceled := make(chan struct{})
 	releaseWorker := make(chan struct{})
-	svc.runWG.Go(func() {
+	run.wg.Go(func() {
 		close(workerStarted)
+		<-run.workCtx.Done()
+		close(workerCanceled)
 		<-releaseWorker
 	})
-	go svc.finishRun(runDone)
+	go svc.finishRun(run)
 	<-workerStarted
 
 	stopCtx, cancelStop := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	require.ErrorIs(t, svc.Stop(stopCtx), context.DeadlineExceeded)
 	require.False(t, svc.IsRunning())
+	<-workerCanceled
 	cancelStop()
 	require.Error(t, svc.Start(t.Context()))
 
 	close(releaseWorker)
 	require.NoError(t, svc.Stop(context.Background()))
-	require.NoError(t, svc.Start(t.Context()))
-	require.NoError(t, svc.Stop(context.Background()))
+}
+
+func TestExecutionService_StopDrainsAdmittedWorker(t *testing.T) {
+	svc := NewExecutionService(&Config{MaxWorkers: 1}, nil, nil, nil, nil, nil, nil, nil, nil)
+	run := newExecutionRun(t.Context())
+	svc.run = run
+
+	workerStarted := make(chan struct{})
+	releaseWorker := make(chan struct{})
+	workerCanceled := make(chan struct{})
+	run.wg.Go(func() {
+		close(workerStarted)
+		select {
+		case <-run.workCtx.Done():
+			close(workerCanceled)
+		case <-releaseWorker:
+		}
+	})
+	go svc.finishRun(run)
+	<-workerStarted
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- svc.Stop(context.Background())
+	}()
+	require.Eventually(t, func() bool { return !svc.IsRunning() }, 100*time.Millisecond, time.Millisecond)
+
+	select {
+	case <-workerCanceled:
+		t.Fatal("normal Stop canceled admitted worker")
+	default:
+	}
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Stop returned before admitted worker drained: %v", err)
+	default:
+	}
+
+	close(releaseWorker)
+	require.NoError(t, <-stopDone)
+}
+
+func TestExecutionService_StopWaitsForAdmittedEnqueue(t *testing.T) {
+	svc := NewExecutionService(&Config{MaxWorkers: 1}, nil, nil, nil, nil, nil, nil, nil, nil)
+	run := newExecutionRun(t.Context())
+	svc.run = run
+	run.wg.Add(1) // Matches the processor's lifetime while admission is open.
+	go svc.finishRun(run)
+
+	enqueueStarted := make(chan struct{})
+	releaseEnqueue := make(chan struct{})
+	enqueueDone := make(chan error, 1)
+	go func() {
+		enqueueDone <- svc.withAdmission(t.Context(), func(ctx context.Context) error {
+			close(enqueueStarted)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-releaseEnqueue:
+				return nil
+			}
+		})
+	}()
+	<-enqueueStarted
+	run.wg.Done()
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- svc.Stop(context.Background())
+	}()
+	require.Eventually(t, func() bool { return !svc.IsRunning() }, 100*time.Millisecond, time.Millisecond)
+	require.ErrorIs(t, svc.withAdmission(t.Context(), func(context.Context) error {
+		return nil
+	}), errExecutionNotAccepting)
+
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Stop returned before admitted enqueue drained: %v", err)
+	default:
+	}
+
+	close(releaseEnqueue)
+	require.NoError(t, <-enqueueDone)
+	require.NoError(t, <-stopDone)
 }
 
 func TestExecutionService_DequeueIsLimitedToAvailableWorkers(t *testing.T) {
@@ -190,8 +261,10 @@ func TestExecutionService_DequeueIsLimitedToAvailableWorkers(t *testing.T) {
 		MasterPollingInterval: time.Hour,
 	}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
 	ctx, cancel := context.WithCancel(t.Context())
+	run := newExecutionRun(ctx)
+	defer run.cancelWork()
 	done := make(chan error, 1)
-	go func() { done <- svc.startQueueProcessorThread(ctx) }()
+	go func() { done <- svc.startQueueProcessorThread(run) }()
 	<-dequeued
 	cancel()
 
@@ -221,7 +294,9 @@ func TestQueueProcessorRetries(t *testing.T) {
 		}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
 
 		// Act
-		err := svc.startQueueProcessorThread(ctx)
+		run := newExecutionRun(ctx)
+		defer run.cancelWork()
+		err := svc.startQueueProcessorThread(run)
 
 		// Assert
 		require.ErrorIs(t, err, context.Canceled)

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -156,6 +156,7 @@ func TestExecutionService_StopTimeoutRetainsActivationUntilWorkerDrains(t *testi
 
 	stopCtx, cancelStop := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	require.ErrorIs(t, svc.Stop(stopCtx), context.DeadlineExceeded)
+	require.False(t, svc.IsRunning())
 	cancelStop()
 	require.Error(t, svc.Start(t.Context()))
 

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -73,7 +73,7 @@ func TestExecutionService_Start(t *testing.T) {
 		require.NoError(t, svc.Stop(context.Background()))
 	})
 
-	t.Run("stops promptly while idle and can restart", func(t *testing.T) {
+	t.Run("activation cancellation stops promptly and allows restart", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockQueue := mocks.NewMockMessageQueue(ctrl)
 		mockMinerGetter := minerMocks.NewMockCachedMinerGetter(ctrl)
@@ -89,16 +89,22 @@ func TestExecutionService_Start(t *testing.T) {
 			MasterPollingInterval: time.Hour,
 		}, nil, mockQueue, nil, nil, mockMinerGetter, nil, nil, nil)
 
-		require.NoError(t, svc.Start(t.Context()))
+		activationCtx, cancelActivation := context.WithCancel(t.Context())
+		require.NoError(t, svc.Start(activationCtx))
 		require.Eventually(t, func() bool { return dequeues.Load() >= 1 }, 100*time.Millisecond, time.Millisecond)
+		cancelActivation()
+		require.Eventually(t, func() bool {
+			svc.lifecycleMu.Lock()
+			defer svc.lifecycleMu.Unlock()
+			return svc.runCancel == nil
+		}, 100*time.Millisecond, time.Millisecond)
+		require.False(t, svc.IsRunning())
+
 		stop := func() {
 			stopCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			require.NoError(t, svc.Stop(stopCtx))
 		}
-		stop()
-		require.False(t, svc.IsRunning())
-
 		require.NoError(t, svc.Start(t.Context()))
 		require.Eventually(t, func() bool { return dequeues.Load() >= 2 }, 100*time.Millisecond, time.Millisecond)
 		stop()

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -40,6 +40,15 @@ type firmwareStatusMiner struct {
 }
 
 func TestExecutionService_Start(t *testing.T) {
+	t.Run("rejects a canceled activation", func(t *testing.T) {
+		svc := &ExecutionService{}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		require.ErrorIs(t, svc.Start(ctx), context.Canceled)
+		require.False(t, svc.IsRunning())
+	})
+
 	t.Run("is idempotent while running", func(t *testing.T) {
 		// Arrange
 		ctrl := gomock.NewController(t)

--- a/server/internal/domain/command/preflight_block_test.go
+++ b/server/internal/domain/command/preflight_block_test.go
@@ -66,7 +66,7 @@ func newPreflightTestService(t *testing.T, filter CommandFilter) (*Service, *rec
 	store := &recordingActivityStore{}
 	svc := &Service{
 		config:           &Config{},
-		executionService: &ExecutionService{queueProcessorRunning: true},
+		executionService: &ExecutionService{run: newExecutionRun(context.Background())},
 		activitySvc:      activity.NewService(store),
 		filters:          []CommandFilter{filter},
 	}

--- a/server/internal/domain/command/reaper_integration_test.go
+++ b/server/internal/domain/command/reaper_integration_test.go
@@ -122,7 +122,7 @@ func (n *noopMessageQueue) Enqueue(_ context.Context, _ string, _ commandtype.Ty
 func (n *noopMessageQueue) EnqueueMany(_ context.Context, _ string, _ commandtype.Type, _ []queue.EnqueueMessage) error {
 	return nil
 }
-func (n *noopMessageQueue) Dequeue(ctx context.Context) ([]queue.Message, error) {
+func (n *noopMessageQueue) Dequeue(ctx context.Context, _ int32) ([]queue.Message, error) {
 	<-ctx.Done()
 	return nil, fmt.Errorf("dequeue cancelled: %w", ctx.Err())
 }
@@ -153,7 +153,7 @@ func TestReaperIntegration(t *testing.T) {
 		createBatchLog(t, conn, batchUUID, user.DatabaseID, 1)
 		createStuckMessage(t, conn, batchUUID, device.DatabaseID, 10*time.Minute)
 
-		svc := command.NewExecutionService(t.Context(), &command.Config{
+		svc := command.NewExecutionService(&command.Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 100 * time.Millisecond,
 			StuckMessageTimeout:   5 * time.Minute,
@@ -190,7 +190,7 @@ func TestReaperIntegration(t *testing.T) {
 		createBatchLog(t, conn, batchUUID, user.DatabaseID, 1)
 		createStuckMessage(t, conn, batchUUID, device.DatabaseID, 1*time.Minute)
 
-		svc := command.NewExecutionService(t.Context(), &command.Config{
+		svc := command.NewExecutionService(&command.Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 100 * time.Millisecond,
 			StuckMessageTimeout:   5 * time.Minute,
@@ -239,7 +239,7 @@ func TestReaperIntegration(t *testing.T) {
 		_, err = conn.ExecContext(ctx, "ALTER TABLE queue_message ENABLE TRIGGER update_queue_message_updated_at")
 		require.NoError(t, err)
 
-		svc := command.NewExecutionService(t.Context(), &command.Config{
+		svc := command.NewExecutionService(&command.Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 100 * time.Millisecond,
 			StuckMessageTimeout:   5 * time.Minute,
@@ -267,7 +267,7 @@ func TestReaperIntegration(t *testing.T) {
 		createStuckMessage(t, conn, batchUUID, device1.DatabaseID, 10*time.Minute)
 		createStuckMessage(t, conn, batchUUID, device2.DatabaseID, 10*time.Minute)
 
-		svc := command.NewExecutionService(t.Context(), &command.Config{
+		svc := command.NewExecutionService(&command.Config{
 			MaxWorkers:            5,
 			MasterPollingInterval: 100 * time.Millisecond,
 			StuckMessageTimeout:   5 * time.Minute,

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -487,6 +487,15 @@ func (s *Service) getMarkFinishedBatchFunction(processingMarkedInDB bool) func(c
 	}
 }
 
+func (s *Service) finishUnenqueuedCommandBatch(ctx context.Context, commandBatchLogUUID string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dbWriteTimeout)
+	defer cancel()
+	if err := s.getMarkFinishedBatchFunction(false)(cleanupCtx, commandBatchLogUUID); err != nil {
+		return fleeterror.NewInternalErrorf("command execution stopped before enqueue; failed to finish command batch: %v", err)
+	}
+	return fleeterror.NewInternalError("command execution service stopped before enqueue")
+}
+
 func (s *Service) statusUpdateIsFinishedBranch(ctx context.Context, commandBatchLogUUID string) (bool, error) {
 	isFinished, err := s.messageQueue.IsBatchFinished(ctx, commandBatchLogUUID)
 	if err != nil {
@@ -907,7 +916,7 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 	}
 
 	if !s.executionService.IsRunning() {
-		return nil, fleeterror.NewInternalError("command execution service stopped before enqueue")
+		return nil, s.finishUnenqueuedCommandBatch(ctx, batchLogIdentifier)
 	}
 	if len(queuePayloads) == 0 {
 		err = s.messageQueue.Enqueue(ctx, batchLogIdentifier, command.commandType, deviceIDs, command.payload)
@@ -1398,7 +1407,7 @@ func (s *Service) ReapplyCurrentPoolsWithWorkerNames(
 	}
 
 	if !s.executionService.IsRunning() {
-		return "", fleeterror.NewInternalError("command execution service stopped before enqueue")
+		return "", s.finishUnenqueuedCommandBatch(ctx, commandBatchLogUUID)
 	}
 	if err := s.enqueueWorkerNameReapplyMessages(ctx, commandBatchLogUUID, deviceIdentifiers, deviceIDsByIdentifier, desiredWorkerNamesByDeviceIdentifier); err != nil {
 		return "", err

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -921,7 +921,7 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 		}
 		return s.messageQueue.EnqueueMany(workCtx, batchLogIdentifier, command.commandType, queuePayloads)
 	})
-	if errors.Is(err, errExecutionNotAccepting) {
+	if errors.Is(err, errExecutionStoppedBeforeEnqueue) {
 		return nil, s.finishUnenqueuedCommandBatch(ctx, batchLogIdentifier)
 	}
 	if err != nil {
@@ -1410,7 +1410,7 @@ func (s *Service) ReapplyCurrentPoolsWithWorkerNames(
 	err = s.executionService.withAdmission(ctx, func(workCtx context.Context) error {
 		return s.enqueueWorkerNameReapplyMessages(workCtx, commandBatchLogUUID, deviceIdentifiers, deviceIDsByIdentifier, desiredWorkerNamesByDeviceIdentifier)
 	})
-	if errors.Is(err, errExecutionNotAccepting) {
+	if errors.Is(err, errExecutionStoppedBeforeEnqueue) {
 		return "", s.finishUnenqueuedCommandBatch(ctx, commandBatchLogUUID)
 	}
 	if err != nil {

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -915,19 +915,20 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 		return nil, fleeterror.NewInternalErrorf("error saving command batch log to db: %v", err)
 	}
 
-	if !s.executionService.IsRunning() {
+	err = s.executionService.withAdmission(ctx, func(workCtx context.Context) error {
+		if len(queuePayloads) == 0 {
+			return s.messageQueue.Enqueue(workCtx, batchLogIdentifier, command.commandType, deviceIDs, command.payload)
+		}
+		return s.messageQueue.EnqueueMany(workCtx, batchLogIdentifier, command.commandType, queuePayloads)
+	})
+	if errors.Is(err, errExecutionNotAccepting) {
 		return nil, s.finishUnenqueuedCommandBatch(ctx, batchLogIdentifier)
 	}
-	if len(queuePayloads) == 0 {
-		err = s.messageQueue.Enqueue(ctx, batchLogIdentifier, command.commandType, deviceIDs, command.payload)
-		if err != nil {
+	if err != nil {
+		if len(queuePayloads) == 0 {
 			return nil, fleeterror.NewInternalErrorf("error enqueuing a batch of commands: %v", err)
 		}
-	} else {
-		err = s.messageQueue.EnqueueMany(ctx, batchLogIdentifier, command.commandType, queuePayloads)
-		if err != nil {
-			return nil, fleeterror.NewInternalErrorf("error enqueuing per-device command payloads: %v", err)
-		}
+		return nil, fleeterror.NewInternalErrorf("error enqueuing per-device command payloads: %v", err)
 	}
 
 	return &CommandResult{
@@ -1406,10 +1407,13 @@ func (s *Service) ReapplyCurrentPoolsWithWorkerNames(
 		return "", err
 	}
 
-	if !s.executionService.IsRunning() {
+	err = s.executionService.withAdmission(ctx, func(workCtx context.Context) error {
+		return s.enqueueWorkerNameReapplyMessages(workCtx, commandBatchLogUUID, deviceIdentifiers, deviceIDsByIdentifier, desiredWorkerNamesByDeviceIdentifier)
+	})
+	if errors.Is(err, errExecutionNotAccepting) {
 		return "", s.finishUnenqueuedCommandBatch(ctx, commandBatchLogUUID)
 	}
-	if err := s.enqueueWorkerNameReapplyMessages(ctx, commandBatchLogUUID, deviceIdentifiers, deviceIDsByIdentifier, desiredWorkerNamesByDeviceIdentifier); err != nil {
+	if err != nil {
 		return "", err
 	}
 

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -906,6 +906,9 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 		return nil, fleeterror.NewInternalErrorf("error saving command batch log to db: %v", err)
 	}
 
+	if !s.executionService.IsRunning() {
+		return nil, fleeterror.NewInternalError("command execution service stopped before enqueue")
+	}
 	if len(queuePayloads) == 0 {
 		err = s.messageQueue.Enqueue(ctx, batchLogIdentifier, command.commandType, deviceIDs, command.payload)
 		if err != nil {
@@ -1394,6 +1397,9 @@ func (s *Service) ReapplyCurrentPoolsWithWorkerNames(
 		return "", err
 	}
 
+	if !s.executionService.IsRunning() {
+		return "", fleeterror.NewInternalError("command execution service stopped before enqueue")
+	}
 	if err := s.enqueueWorkerNameReapplyMessages(ctx, commandBatchLogUUID, deviceIdentifiers, deviceIDsByIdentifier, desiredWorkerNamesByDeviceIdentifier); err != nil {
 		return "", err
 	}

--- a/server/internal/domain/command/service_curtail_test.go
+++ b/server/internal/domain/command/service_curtail_test.go
@@ -49,7 +49,7 @@ func (f *fakeMessageQueue) EnqueueMany(_ context.Context, batchUUID string, ct c
 	return f.enqueueReturnError
 }
 
-func (f *fakeMessageQueue) Dequeue(context.Context) ([]queue.Message, error) {
+func (f *fakeMessageQueue) Dequeue(context.Context, int32) ([]queue.Message, error) {
 	panic("Dequeue not used")
 }
 func (f *fakeMessageQueue) MarkSuccess(context.Context, int64) error {

--- a/server/internal/domain/command/service_curtail_test.go
+++ b/server/internal/domain/command/service_curtail_test.go
@@ -82,7 +82,7 @@ func newCurtailDispatchServiceWithActivityStore(t *testing.T) (*Service, *fakeMe
 	store := &recordingActivityStore{}
 	svc := &Service{
 		config:           &Config{},
-		executionService: &ExecutionService{queueProcessorRunning: true},
+		executionService: &ExecutionService{run: newExecutionRun(context.Background())},
 		messageQueue:     q,
 		activitySvc:      activity.NewService(store),
 	}

--- a/server/internal/domain/command/session_org_validation_test.go
+++ b/server/internal/domain/command/session_org_validation_test.go
@@ -35,9 +35,9 @@ func sessionCtxWithOrg(orgID int64) context.Context {
 func TestProcessCommand_RejectsMissingOrgID(t *testing.T) {
 	// Constructing a Service struct directly (same-package test) so we never
 	// reach the DB layer -- validation must short-circuit before then. The
-	// executionService is pre-marked running so the IsRunning() check passes
+	// executionService is pre-marked running so startup does not reach the queue
 	// and control reaches the validation we care about.
-	es := &ExecutionService{queueProcessorRunning: true}
+	es := &ExecutionService{run: newExecutionRun(context.Background())}
 	svc := &Service{config: &Config{}, executionService: es}
 
 	cases := []struct {
@@ -63,7 +63,7 @@ func TestProcessCommand_RejectsMissingOrgID(t *testing.T) {
 }
 
 func TestReapplyCurrentPoolsWithWorkerNames_RejectsMissingOrgID(t *testing.T) {
-	es := &ExecutionService{queueProcessorRunning: true}
+	es := &ExecutionService{run: newExecutionRun(context.Background())}
 	svc := &Service{config: &Config{}, executionService: es}
 
 	ctx := sessionCtxWithOrg(0)

--- a/server/internal/domain/command/zero_target_integration_test.go
+++ b/server/internal/domain/command/zero_target_integration_test.go
@@ -42,7 +42,6 @@ func newZeroTargetDispatchTestService(t *testing.T, conn *sql.DB) *command.Servi
 	t.Cleanup(cancel)
 
 	executionService := command.NewExecutionService(
-		executionCtx,
 		commandConfig,
 		conn,
 		messageQueue,

--- a/server/internal/infrastructure/queue/interface.go
+++ b/server/internal/infrastructure/queue/interface.go
@@ -34,8 +34,8 @@ type MessageQueue interface {
 	// EnqueueMany adds commands with per-device payloads in one atomic operation.
 	EnqueueMany(ctx context.Context, commandBatchLogUUID string, commandType commandtype.Type, messages []EnqueueMessage) error
 
-	// Dequeue retrieves and locks batch of commands for processing
-	Dequeue(ctx context.Context) ([]Message, error)
+	// Dequeue retrieves and locks at most limit commands for processing.
+	Dequeue(ctx context.Context, limit int32) ([]Message, error)
 
 	// MarkSuccess updates a command as successfully processed.
 	// Returns ErrStale if the message is no longer PROCESSING.

--- a/server/internal/infrastructure/queue/mocks/mock_message_queue.go
+++ b/server/internal/infrastructure/queue/mocks/mock_message_queue.go
@@ -43,18 +43,18 @@ func (m *MockMessageQueue) EXPECT() *MockMessageQueueMockRecorder {
 }
 
 // Dequeue mocks base method.
-func (m *MockMessageQueue) Dequeue(ctx context.Context) ([]queue.Message, error) {
+func (m *MockMessageQueue) Dequeue(ctx context.Context, limit int32) ([]queue.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dequeue", ctx)
+	ret := m.ctrl.Call(m, "Dequeue", ctx, limit)
 	ret0, _ := ret[0].([]queue.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Dequeue indicates an expected call of Dequeue.
-func (mr *MockMessageQueueMockRecorder) Dequeue(ctx any) *gomock.Call {
+func (mr *MockMessageQueueMockRecorder) Dequeue(ctx, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dequeue", reflect.TypeOf((*MockMessageQueue)(nil).Dequeue), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dequeue", reflect.TypeOf((*MockMessageQueue)(nil).Dequeue), ctx, limit)
 }
 
 // Enqueue mocks base method.

--- a/server/internal/infrastructure/queue/service.go
+++ b/server/internal/infrastructure/queue/service.go
@@ -76,11 +76,17 @@ func (d DatabaseMessageQueue) enqueueEncoded(ctx context.Context, commandBatchLo
 	})
 }
 
-func (d DatabaseMessageQueue) Dequeue(ctx context.Context) ([]Message, error) {
+func (d DatabaseMessageQueue) Dequeue(ctx context.Context, limit int32) ([]Message, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	if d.config.DequeLimit > 0 {
+		limit = min(limit, d.config.DequeLimit)
+	}
 	messages, err := db.WithTransaction(ctx, d.conn, func(q *sqlc.Queries) ([]Message, error) {
 		dbMessages, err := q.GetMessagesToProcess(ctx, sqlc.GetMessagesToProcessParams{
 			RetryCount: d.config.MaxFailureRetries,
-			Limit:      d.config.DequeLimit,
+			Limit:      limit,
 		})
 		if err != nil {
 			return nil, fleeterror.NewInternalErrorf("failed to get messages to process: %v", err)

--- a/server/internal/testutil/infrastructure_provider.go
+++ b/server/internal/testutil/infrastructure_provider.go
@@ -27,7 +27,6 @@ import (
 )
 
 type InfrastructureProvider struct {
-	serviceProvider  *ServiceProvider
 	AuthClient       authv1connect.AuthServiceClient
 	ApiKeyClient     apikeyv1connect.ApiKeyServiceClient
 	PairingClient    pairingv1connect.PairingServiceClient
@@ -80,7 +79,6 @@ func NewInfrastructureProvider(t *testing.T, serviceProvider *ServiceProvider, a
 	commandClient := minercommandv1connect.NewMinerCommandServiceClient(http.DefaultClient, testServer.URL)
 
 	provider := InfrastructureProvider{
-		serviceProvider:  serviceProvider,
 		AuthClient:       authClient,
 		ApiKeyClient:     apiKeyClient,
 		PairingClient:    pairingClient,
@@ -91,10 +89,7 @@ func NewInfrastructureProvider(t *testing.T, serviceProvider *ServiceProvider, a
 		testServer:       testServer,
 	}
 
-	t.Cleanup(func() {
-		provider.testServer.Close()
-		provider.serviceProvider.ExecutionServiceCancel()
-	})
+	t.Cleanup(provider.testServer.Close)
 
 	return &provider
 }

--- a/server/internal/testutil/service_provider.go
+++ b/server/internal/testutil/service_provider.go
@@ -149,7 +149,7 @@ func NewServiceProvider(t *testing.T, db *sql.DB, config *Config) *ServiceProvid
 
 	executionServiceCtx, executionServiceCancel := context.WithCancel(t.Context())
 
-	executionService := command.NewExecutionService(executionServiceCtx, commandConfig, db, dbMessageQueue, encryptService, tokenService, minerService, deviceStore, nil, filesService)
+	executionService := command.NewExecutionService(commandConfig, db, dbMessageQueue, encryptService, tokenService, minerService, deviceStore, nil, filesService)
 	err = executionService.Start(executionServiceCtx)
 	assert.NoError(t, err)
 

--- a/server/internal/testutil/service_provider.go
+++ b/server/internal/testutil/service_provider.go
@@ -36,6 +36,7 @@ const (
 	testWorkerExecutionTimeout      = 30 * time.Second
 	testMasterPollingInterval       = time.Second
 	testBatchStatusUpdateInterval   = time.Second
+	testExecutionShutdownTimeout    = 10 * time.Second
 	testDequeueLimit                = 500
 	testMaxFailureRetries           = 5
 	testSessionDuration             = 5 * time.Minute
@@ -53,7 +54,6 @@ type ServiceProvider struct {
 	PairingService         *pairing.Service
 	OnboardingService      *onboarding.Service
 	CommandService         *command.Service
-	ExecutionServiceCancel context.CancelFunc
 	EncryptService         *encrypt.Service
 	FleetManagementService *fleetmanagement.Service
 	DeviceStore            *sqlstores.SQLDeviceStore
@@ -152,6 +152,12 @@ func NewServiceProvider(t *testing.T, db *sql.DB, config *Config) *ServiceProvid
 	executionService := command.NewExecutionService(commandConfig, db, dbMessageQueue, encryptService, tokenService, minerService, deviceStore, nil, filesService)
 	err = executionService.Start(executionServiceCtx)
 	assert.NoError(t, err)
+	t.Cleanup(func() {
+		executionServiceCancel()
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), testExecutionShutdownTimeout)
+		defer stopCancel()
+		assert.NoError(t, executionService.Stop(stopCtx))
+	})
 
 	statusService := command.NewStatusService(db, dbMessageQueue)
 	commandService := command.NewService(commandConfig, db, executionService, dbMessageQueue, statusService, encryptService, filesService, deviceStore, userStore, authService, nil, pluginService, activitySvc)
@@ -175,7 +181,6 @@ func NewServiceProvider(t *testing.T, db *sql.DB, config *Config) *ServiceProvid
 		PairingService:         pairingService,
 		OnboardingService:      onboardingService,
 		CommandService:         commandService,
-		ExecutionServiceCancel: executionServiceCancel,
 		EncryptService:         encryptService,
 		FleetManagementService: fleetManagementService,
 		DeviceStore:            deviceStore,


### PR DESCRIPTION
Reviewable diff: +277/-100 across 7 files (excludes generated, test, and story files).

## Summary

Command execution now supports repeatable activation and shutdown without overlapping processors or canceling commands that have already reached a miner. Shutdown closes admission immediately, drains admitted queue writes and command workers within the caller's budget, and only force-cancels that work when the budget expires.

**Stack:**

- Foundation: [#780](https://github.com/block/proto-fleet/pull/780) (merged)
- Parallel domain refactors: diagnostics [#781](https://github.com/block/proto-fleet/pull/781), IP scanning [#782](https://github.com/block/proto-fleet/pull/782), scheduling [#783](https://github.com/block/proto-fleet/pull/783), curtailment [#785](https://github.com/block/proto-fleet/pull/785), **command execution [#787](https://github.com/block/proto-fleet/pull/787)**, and telemetry [#786](https://github.com/block/proto-fleet/pull/786)
- Orchestration: [#784](https://github.com/block/proto-fleet/pull/784)
- Catalog and `fleetd` cutover: [#788](https://github.com/block/proto-fleet/pull/788)

This PR targets `main` and builds on the `runtimejobs.Lifecycle` contract from #780. The sibling domain refactors are independent; #788 contains the later catalog and `fleetd` cutover. Passive-mode coordination, epoch fencing, and request gating remain later HA work.

## How it works

`Start` creates one activation with two contexts. The admission context owns the queue processor and stuck-message reaper; canceling it stops new dequeues and closes the enqueue gate. The work context belongs to operations already admitted by that activation, including queue writes and command workers.

Command requests hold the activation gate through `Enqueue`, `EnqueueMany`, or worker-name reapply, making enqueue ordering atomic with shutdown. `Stop` closes that gate and cancels admission, then waits for the activation's wait group. A clean drain preserves an in-flight command’s normal result bookkeeping; if the caller’s stop deadline expires, `Stop` force-cancels the work context and returns the deadline error while the activation remains unavailable until its goroutines actually exit. If that forced cancellation interrupts a queue transaction, the admission wrapper classifies it as stopped before enqueue so the saved batch is marked finished instead of remaining `PENDING`; request cancellation remains distinguishable and follows the normal error path.

Callers that cancel the activation context still pair that cancellation with bounded `Stop` so admitted work cannot outlive its dependencies. The shared test service provider owns this teardown for both direct service tests and the HTTP infrastructure harness.

The queue processor reserves currently available worker slots before dequeueing and passes that limit to the database queue. Operational dequeue failures exhaust the configured retries, back off for one polling interval, and retry while the activation remains open.

```mermaid
flowchart LR
    S["Start activation"] --> A["Admission context"]
    S --> W["Work context"]
    A --> P["Queue processor"]
    A --> R["Stuck-message reaper"]
    P --> C["Reserve worker capacity"]
    C --> Q["Dequeue up to capacity"]
    Q --> X["Admitted command workers"]
    G["Command request"] --> L["Activation admission gate"]
    L --> E["Enqueue or worker-name reapply"]
    E --> W
    X --> W
    T["Stop or activation cancellation"] --> K["Close admission"]
    K --> D["Bounded drain of admitted work"]
    D --> N["Safe later activation"]
```

```mermaid
sequenceDiagram
    participant Request
    participant Activation
    participant Queue
    participant Worker
    participant Stop
    Request->>Activation: Acquire admission
    Activation->>Queue: Persist pending command
    Queue-->>Activation: Commit
    Activation-->>Request: Release admission
    Activation->>Worker: Run admitted command
    Stop->>Activation: Close admission and stop dequeue
    Activation-->>Stop: Wait for admitted work
    Worker-->>Activation: Finish command and bookkeeping
    Activation-->>Stop: Drain complete
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/command/execution_service.go` | Adds activation-owned admission/work contexts, cause-aware forced cancellation, bounded drain, capacity reservation, and persistent dequeue retry | Defines the no-overlap and no-premature-cancellation lifecycle guarantees |
| `server/internal/domain/command/service.go` | Holds activation admission through all queue-write paths and finishes batches whose enqueue is force-canceled | Removes the enqueue-versus-Stop TOCTOU window and prevents orphaned `PENDING` batches |
| `server/internal/infrastructure/queue/` | Adds and enforces an explicit dequeue limit | Prevents claiming more work than the activation can run |
| `server/cmd/fleetd/main.go` | Uses context-free construction and bounded standalone stop | Preserves standalone startup while making shutdown explicit |
| `server/internal/testutil/` | Replaces cancel-only cleanup with a bounded execution-service stop | Keeps admitted workers from outliving test DB/plugin dependencies |
| Command tests | Cover cancellation, restart, drain, timeout, admission ordering, and retry behavior | Exercises the lifecycle boundaries under the race detector |
| `server/internal/infrastructure/queue/mocks/` | Generated mock signature update | Generated — skip |

## Key technical decisions & trade-offs

- Separate admission cancellation from admitted-work cancellation instead of sharing one context that can turn a successfully delivered miner command into a retry.
- Require lifecycle owners to pair activation cancellation with bounded `Stop` rather than reattaching admitted work to an unbounded cancellation source.
- Use one private activation gate across all enqueue paths instead of exposing a reusable lease abstraction before another consumer needs it.
- Keep an activation published until every admitted goroutine exits, even after a stop timeout, rather than allowing a replacement processor to overlap it.
- Claim only currently reserved worker capacity rather than caching unclaimed queue candidates whose ownership could become stale across multiple consumers.
- Retry operational dequeue failures inside the activation rather than adding a second asynchronous health interface to every lifecycle.

## Related

Related: #740

## Testing & validation

- `go test -short -race -count=1 ./internal/domain/command ./internal/infrastructure/queue ./cmd/fleetd`
- `go test -short -run '^$' ./...` from `server/`
- Targeted lifecycle race tests cover activation cancellation followed by bounded drain, forced cancellation at the stop deadline, cleanup of shutdown-canceled enqueue attempts, rejection of new admission, and deterministic enqueue-versus-Stop ordering.
- Targeted `golangci-lint` reports zero issues; `git diff --check` passes.
- Database-backed integration tests were not run locally.

## Post-Deploy Monitoring & Validation

Watch dequeue failure/retry logs, queue depth and processing age, active worker counts, stuck-message reaping, and shutdown drain errors. Roll back if commands stop leaving the queue, worker concurrency exceeds configuration, duplicate dispatch appears, or drain deadlines recur.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
