### PR TITLE
refactor(fleetd): start jobs from runtime catalog (9/9)

### DIFF
--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -760,7 +760,7 @@ func start(config *Config) error {
 		return fmt.Errorf("create runtime job group: %w", err)
 	}
 	defer func() {
-		stopRuntimeJobGroup(runtimeJobGroup, shutdownTimeout)
+		stopRuntimeJobGroup(runtimeJobGroup, executionService, shutdownTimeout)
 	}()
 	if err := runtimeJobGroup.Start(context.Background()); err != nil {
 		return fmt.Errorf("start runtime jobs: %w", err)

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -759,12 +759,12 @@ func start(config *Config) error {
 	if err != nil {
 		return fmt.Errorf("create runtime job group: %w", err)
 	}
-	if err := runtimeJobGroup.Start(context.Background()); err != nil {
-		return fmt.Errorf("start runtime jobs: %w", err)
-	}
 	defer func() {
 		stopRuntimeJobGroup(runtimeJobGroup, shutdownTimeout)
 	}()
+	if err := runtimeJobGroup.Start(context.Background()); err != nil {
+		return fmt.Errorf("start runtime jobs: %w", err)
+	}
 
 	listener, err := net.Listen("tcp", config.HTTP.Address)
 	if err != nil {

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -276,36 +276,33 @@ func start(config *Config) error {
 	// userStore implements both UserStore and UserManagementStore interfaces
 	authSvc := authDomain.NewService(userStore, userStore, transactor, tokenSvc, sessionSvc, encryptSvc, activitySvc, permissionResolver)
 
-	// Start session cleanup goroutine
-	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
-	go func() {
+	identityStateCleanup := newBackgroundLoop(func(ctx context.Context) {
 		ticker := time.NewTicker(sessionSvc.CleanupInterval())
 		defer ticker.Stop()
 
 		for {
 			select {
 			case <-ticker.C:
-				if deleted, err := sessionSvc.CleanupExpired(cleanupCtx); err != nil {
+				if deleted, err := sessionSvc.CleanupExpired(ctx); err != nil {
 					slog.Error("failed to cleanup expired sessions", "error", err)
 				} else if deleted > 0 {
 					slog.Debug("cleaned up expired sessions", "count", deleted)
 				}
-				if swept, err := fleetNodeEnrollmentSvc.SweepExpired(cleanupCtx); err != nil {
+				if swept, err := fleetNodeEnrollmentSvc.SweepExpired(ctx); err != nil {
 					slog.Error("failed to sweep expired fleet node enrollments", "error", err)
 				} else if swept > 0 {
 					slog.Debug("swept expired fleet node enrollments", "count", swept)
 				}
-				if challenges, sessions, err := fleetNodeAuthSvc.SweepExpired(cleanupCtx); err != nil {
+				if challenges, sessions, err := fleetNodeAuthSvc.SweepExpired(ctx); err != nil {
 					slog.Error("failed to sweep expired fleet node auth state", "error", err)
 				} else if challenges > 0 || sessions > 0 {
 					slog.Debug("swept expired fleet node auth state", "challenges", challenges, "sessions", sessions)
 				}
-			case <-cleanupCtx.Done():
+			case <-ctx.Done():
 				return
 			}
 		}
-	}()
-	defer cleanupCancel()
+	})
 
 	if err := config.Plugins.Validate(); err != nil {
 		return fmt.Errorf("invalid plugin configuration: %w", err)
@@ -360,7 +357,6 @@ func start(config *Config) error {
 	if err != nil {
 		return err
 	}
-	commandArtifactCleanupCtx, commandArtifactCleanupCancel := context.WithCancel(context.Background())
 	runCommandArtifactSweep := func() {
 		deleted, sweepErr := filesService.SweepExpiredCommandArtifacts(time.Now().UTC(), filesService.CommandArtifactRetentionTTL())
 		if sweepErr != nil {
@@ -371,7 +367,7 @@ func start(config *Config) error {
 			slog.Debug("swept expired command artifacts", "count", deleted)
 		}
 	}
-	go func() {
+	commandArtifactCleanup := newBackgroundLoop(func(ctx context.Context) {
 		ticker := time.NewTicker(filesService.CommandArtifactCleanupInterval())
 		defer ticker.Stop()
 		runCommandArtifactSweep()
@@ -380,12 +376,11 @@ func start(config *Config) error {
 			select {
 			case <-ticker.C:
 				runCommandArtifactSweep()
-			case <-commandArtifactCleanupCtx.Done():
+			case <-ctx.Done():
 				return
 			}
 		}
-	}()
-	defer commandArtifactCleanupCancel()
+	})
 	minerService := miner.NewMinerService(conn, userStore, encryptSvc, filesService, pluginManager).
 		WithCommandSender(fleetNodeControlRegistry)
 
@@ -393,12 +388,6 @@ func start(config *Config) error {
 	errorStore := sqlstores.NewSQLErrorStore(conn, transactor)
 	diagnosticsService := diagnostics.NewService(config.Diagnostics, errorStore, transactor).
 		WithDeviceScopeResolver(deviceStore)
-	if err := diagnosticsService.Start(context.Background()); err != nil {
-		return fmt.Errorf("start diagnostics error closer: %w", err)
-	}
-	defer func() {
-		stopStandaloneJob("diagnostics error closer", diagnosticsService)
-	}()
 
 	// Shared per-org cache for ListMinerStateSnapshots option arrays
 	// (models, firmware versions). The TTL is the primary freshness
@@ -416,10 +405,6 @@ func start(config *Config) error {
 	)
 	telemetryService.WithMetricsEmitter(metricsProvider)
 	fleetNodePairingSvc.WithTelemetryScheduler(telemetryService)
-	if err := telemetryService.Start(context.Background()); err != nil {
-		slog.Error("failed to start telemetry service", "error", err)
-		return fmt.Errorf("failed to start telemetry service: %w", err)
-	}
 
 	// Ensure telemetry service cleanup on shutdown.
 	defer func() {
@@ -453,17 +438,6 @@ func start(config *Config) error {
 		slog.Default(),
 	)
 
-	if err := ipScannerService.Start(context.Background()); err != nil {
-		slog.Error("failed to start IP scanner service", "error", err)
-		return fmt.Errorf("failed to start IP scanner service: %w", err)
-	}
-
-	// Ensure IP scanner service cleanup on shutdown
-	defer func() {
-		slog.Info("Stopping IP scanner service")
-		stopStandaloneJob("IP scanner service", ipScannerService)
-	}()
-
 	dbMessageQueue := queue.NewDatabaseMessageQueue(&config.Queue, conn)
 
 	// Ensure plugin cleanup on shutdown
@@ -478,14 +452,6 @@ func start(config *Config) error {
 
 	executionService := commandDomain.NewExecutionService(&config.Command, conn, dbMessageQueue, encryptSvc, tokenSvc, minerService, deviceStore, telemetryService, filesService)
 	executionService.WithMetricsEmitter(metricsProvider)
-	err = executionService.Start(context.Background())
-	if err != nil {
-		slog.Error("failed to start command execution service", "error", err)
-	} else {
-		defer func() {
-			stopStandaloneJob("command execution service", executionService)
-		}()
-	}
 
 	statusService := commandDomain.NewStatusService(conn, dbMessageQueue)
 	commandSvc := commandDomain.NewService(&config.Command, conn, executionService, dbMessageQueue, statusService, encryptSvc, filesService, deviceStore, userStore, authSvc, telemetryService, pluginService, activitySvc)
@@ -542,12 +508,6 @@ func start(config *Config) error {
 	commandSvc.RegisterFilter(commandDomain.NewCurtailmentActiveFilter(curtailmentStore))
 
 	scheduleProcessor := scheduleDomain.NewProcessor(scheduleStore, scheduleStore, collectionStore, deviceStore, commandSvc, activitySvc)
-	if err := scheduleProcessor.Start(context.Background()); err != nil {
-		return fmt.Errorf("failed to start schedule processor: %w", err)
-	}
-	defer func() {
-		stopStandaloneJob("schedule processor", scheduleProcessor)
-	}()
 
 	curtailmentRec := curtailmentReconciler.New(
 		config.Curtailment,
@@ -557,12 +517,6 @@ func start(config *Config) error {
 		curtailmentReconciler.WithFacilityFanController(facilityFanController),
 		curtailmentReconciler.WithFacilityFanAlertEmitter(metricsProvider),
 	)
-	if err := curtailmentRec.Start(context.Background()); err != nil {
-		return fmt.Errorf("failed to start curtailment reconciler: %w", err)
-	}
-	defer func() {
-		stopStandaloneJob("curtailment reconciler", curtailmentRec)
-	}()
 
 	mqttQueries, err := db.NewPreparedQuerier(context.Background(), conn)
 	if err != nil {
@@ -595,12 +549,6 @@ func start(config *Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize curtailment mqtt subscriber: %w", err)
 	}
-	if err := mqttSubscriber.Start(context.Background()); err != nil {
-		return fmt.Errorf("failed to start curtailment mqtt subscriber: %w", err)
-	}
-	defer func() {
-		stopStandaloneJob("curtailment mqtt subscriber", mqttSubscriber)
-	}()
 	mqttConnectionTester, err := mqttingest.NewMQTTConnectionTester(mqttingest.ConnectionTesterConfig{
 		NewClient: func() mqttingest.MQTTClient { return mqttclient.New() },
 	})
@@ -619,8 +567,9 @@ func start(config *Config) error {
 
 	// Feeds the MQTT curtailment default alert rules; skipped when the
 	// metrics pipeline is off so its periodic queries aren't wasted work.
+	var curtailmentAlertMetrics runtimejobs.Lifecycle
 	if metricsProvider.Enabled() {
-		curtailmentAlertMetrics, err := curtailmentDomain.NewAlertMetricsLoop(curtailmentDomain.AlertMetricsConfig{
+		alertMetricsLoop, err := curtailmentDomain.NewAlertMetricsLoop(curtailmentDomain.AlertMetricsConfig{
 			Sources:           mqttingest.NewSQLCStore(mqttQueries),
 			Runtime:           mqttSubscriber,
 			ActiveCurtailment: curtailmentStore,
@@ -629,12 +578,7 @@ func start(config *Config) error {
 		if err != nil {
 			return fmt.Errorf("failed to initialize curtailment alert metrics loop: %w", err)
 		}
-		if err := curtailmentAlertMetrics.Start(context.Background()); err != nil {
-			return fmt.Errorf("failed to start curtailment alert metrics loop: %w", err)
-		}
-		defer func() {
-			stopStandaloneJob("curtailment alert metrics loop", curtailmentAlertMetrics)
-		}()
+		curtailmentAlertMetrics = alertMetricsLoop
 	}
 
 	deviceResolver := deviceresolver.New(deviceStore)
@@ -689,9 +633,9 @@ func start(config *Config) error {
 	mux.Handle("DELETE /api/v1/firmware/files", firmwareHandler.NewDeleteAllFilesHandler(filesService, sessionSvc, userStore))
 	mux.Handle("/miners/{deviceIdentifier}/api/v1/{rest...}", minerProxyHandler.NewHandler(conn, sessionSvc, userStore, permissionResolver, encryptSvc))
 
-	chunkedCleanupCtx, chunkedCleanupCancel := context.WithCancel(context.Background())
-	go chunkedMgr.StartCleanup(chunkedCleanupCtx, config.Files.ChunkedUploadSessionTTL)
-	defer chunkedCleanupCancel()
+	chunkedUploadCleanup := newBackgroundLoop(func(ctx context.Context) {
+		chunkedMgr.StartCleanup(ctx, config.Files.ChunkedUploadSessionTTL)
+	})
 
 	if len(reflectEnabledServices) != 0 {
 		slog.Debug("enabling reflection", "services", reflectEnabledServices)
@@ -781,48 +725,59 @@ func start(config *Config) error {
 	if err != nil {
 		return fmt.Errorf("listen on %s: %w", config.HTTP.Address, err)
 	}
+	defer func() {
+		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			slog.Error("failed to close HTTP listener", "error", err)
+		}
+	}()
 
-	// Started only once the listener is accepting: the first heartbeat is what
-	// clears the Fleet Heartbeat Stale alert, so a crash-looping boot must not
-	// keep refreshing it and mask a down fleet-api.
+	// Start only after binding the listener: the first heartbeat clears the Fleet
+	// Heartbeat Stale alert, so a crash-looping boot must not keep refreshing it
+	// and mask a down fleet-api. The kernel may briefly queue connections before
+	// Serve starts while the runtime jobs activate.
+	var systemMonitoring runtimejobs.Lifecycle
 	if config.SystemMonitoring.Enabled {
-		sysmonCtx, sysmonCancel := context.WithCancel(context.Background())
-		defer sysmonCancel()
-		go sysmon.New(config.SystemMonitoring, metricsProvider).Run(sysmonCtx)
+		collector := sysmon.New(config.SystemMonitoring, metricsProvider)
+		systemMonitoring = newBackgroundLoop(collector.Run)
 	}
+
+	jobs, err := newRuntimeJobs(runtimeJobLifecycles{
+		identityStateCleanup:      identityStateCleanup,
+		commandArtifactCleanup:    commandArtifactCleanup,
+		diagnosticsErrorCloser:    diagnosticsService,
+		telemetry:                 telemetryService,
+		ipScanner:                 ipScannerService,
+		commandExecution:          executionService,
+		scheduleProcessor:         scheduleProcessor,
+		curtailmentReconciler:     curtailmentRec,
+		curtailmentMQTTSubscriber: mqttSubscriber,
+		curtailmentAlertMetrics:   curtailmentAlertMetrics,
+		chunkedUploadCleanup:      chunkedUploadCleanup,
+		systemMonitoring:          systemMonitoring,
+	})
+	if err != nil {
+		return err
+	}
+	runtimeJobGroup, err := runtimejobs.NewGroup(jobs, shutdownTimeout)
+	if err != nil {
+		return fmt.Errorf("create runtime job group: %w", err)
+	}
+	if err := runtimeJobGroup.Start(context.Background()); err != nil {
+		return fmt.Errorf("start runtime jobs: %w", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := runtimeJobGroup.Stop(shutdownCtx); err != nil {
+			slog.Error("failed to stop runtime jobs", "error", err)
+		}
+	}()
 
 	err = httpServer.Serve(listener)
 	if err != nil {
 		return fmt.Errorf("server shutting down: %+v", err)
 	}
 	return nil
-}
-
-// stopStandaloneJob gives work one graceful-shutdown budget, then one final
-// bounded drain budget. Stop is synchronous, so both budgets rely on the
-// implementation honoring the supplied contexts.
-func stopStandaloneJob(name string, job runtimejobs.Lifecycle) {
-	stopStandaloneJobWithTimeout(name, job, shutdownTimeout)
-}
-
-func stopStandaloneJobWithTimeout(name string, job runtimejobs.Lifecycle, timeout time.Duration) {
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
-	err := job.Stop(shutdownCtx)
-	shutdownErr := shutdownCtx.Err()
-	cancel()
-	if err == nil {
-		return
-	}
-	if !errors.Is(shutdownErr, context.DeadlineExceeded) {
-		slog.Error("failed to stop runtime job", "job", name, "error", err)
-		return
-	}
-	slog.Error("runtime job exceeded shutdown timeout", "job", name, "error", err)
-	drainCtx, drainCancel := context.WithTimeout(context.Background(), timeout)
-	defer drainCancel()
-	if err := job.Stop(drainCtx); err != nil {
-		slog.Error("failed to drain runtime job", "job", name, "error", err)
-	}
 }
 
 func newHTTP2Server(config HTTPConfig) *http2.Server {

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -721,24 +721,21 @@ func start(config *Config) error {
 		Handler:           handler,
 		ReadHeaderTimeout: config.HTTP.ReadHeaderTimeout,
 	}
-	listener, err := net.Listen("tcp", config.HTTP.Address)
-	if err != nil {
-		return fmt.Errorf("listen on %s: %w", config.HTTP.Address, err)
-	}
-	defer func() {
-		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-			slog.Error("failed to close HTTP listener", "error", err)
-		}
-	}()
 
-	// Start only after binding the listener: the first heartbeat clears the Fleet
-	// Heartbeat Stale alert, so a crash-looping boot must not keep refreshing it
-	// and mask a down fleet-api. The kernel may briefly queue connections before
-	// Serve starts while the runtime jobs activate.
+	// The first heartbeat clears the Fleet Heartbeat Stale alert, so keep it
+	// gated until the HTTP listener is bound. Other jobs may perform synchronous
+	// startup work and must finish before the public port can accept connections.
+	listenerBound := make(chan struct{})
 	var systemMonitoring runtimejobs.Lifecycle
 	if config.SystemMonitoring.Enabled {
 		collector := sysmon.New(config.SystemMonitoring, metricsProvider)
-		systemMonitoring = newBackgroundLoop(collector.Run)
+		systemMonitoring = newBackgroundLoop(func(ctx context.Context) {
+			select {
+			case <-listenerBound:
+				collector.Run(ctx)
+			case <-ctx.Done():
+			}
+		})
 	}
 
 	jobs, err := newRuntimeJobs(runtimeJobLifecycles{
@@ -766,10 +763,17 @@ func start(config *Config) error {
 		return fmt.Errorf("start runtime jobs: %w", err)
 	}
 	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		defer cancel()
-		if err := runtimeJobGroup.Stop(shutdownCtx); err != nil {
-			slog.Error("failed to stop runtime jobs", "error", err)
+		stopRuntimeJobGroup(runtimeJobGroup, shutdownTimeout)
+	}()
+
+	listener, err := net.Listen("tcp", config.HTTP.Address)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", config.HTTP.Address, err)
+	}
+	close(listenerBound)
+	defer func() {
+		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			slog.Error("failed to close HTTP listener", "error", err)
 		}
 	}()
 

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -406,11 +406,6 @@ func start(config *Config) error {
 	telemetryService.WithMetricsEmitter(metricsProvider)
 	fleetNodePairingSvc.WithTelemetryScheduler(telemetryService)
 
-	// Ensure telemetry service cleanup on shutdown.
-	defer func() {
-		stopStandaloneJob("telemetry service", telemetryService)
-	}()
-
 	pluginPairer := plugins.NewPairer(pluginManager, transactor, discoveredDeviceStore, deviceStore, encryptSvc)
 
 	pairingSvc := pairingDomain.NewService(

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -750,7 +750,7 @@ func start(config *Config) error {
 	if err != nil {
 		return err
 	}
-	runtimeJobGroup, err := runtimejobs.NewGroup(jobs, shutdownTimeout)
+	runtimeJobGroup, err := runtimejobs.NewGroup(jobs)
 	if err != nil {
 		return fmt.Errorf("create runtime job group: %w", err)
 	}

--- a/server/cmd/fleetd/main_test.go
+++ b/server/cmd/fleetd/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"net"
 	"net/http"
@@ -18,68 +17,6 @@ import (
 	kongyaml "github.com/alecthomas/kong-yaml"
 	"github.com/stretchr/testify/require"
 )
-
-type scriptedLifecycle struct {
-	stopErrors   []error
-	stopFuncs    []func(context.Context) error
-	stopContexts []context.Context
-}
-
-func (s *scriptedLifecycle) Start(context.Context) error { return nil }
-
-func (s *scriptedLifecycle) Stop(ctx context.Context) error {
-	s.stopContexts = append(s.stopContexts, ctx)
-	if len(s.stopFuncs) > 0 {
-		stop := s.stopFuncs[0]
-		s.stopFuncs = s.stopFuncs[1:]
-		return stop(ctx)
-	}
-	if len(s.stopErrors) == 0 {
-		return nil
-	}
-	err := s.stopErrors[0]
-	s.stopErrors = s.stopErrors[1:]
-	return err
-}
-
-func TestStopStandaloneJobDoesNotRetryEarlyDeadlineExceeded(t *testing.T) {
-	var contextErr error
-	job := &scriptedLifecycle{stopFuncs: []func(context.Context) error{
-		func(ctx context.Context) error {
-			contextErr = ctx.Err()
-			return context.DeadlineExceeded
-		},
-	}}
-	stopStandaloneJobWithTimeout("internal timeout", job, time.Second)
-
-	require.Len(t, job.stopContexts, 1)
-	require.NoError(t, contextErr)
-}
-
-func TestStopStandaloneJobRetriesAfterShutdownTimeout(t *testing.T) {
-	job := &scriptedLifecycle{stopFuncs: []func(context.Context) error{
-		func(ctx context.Context) error {
-			<-ctx.Done()
-			return ctx.Err()
-		},
-		func(context.Context) error { return nil },
-	}}
-	stopStandaloneJobWithTimeout("shutdown timeout", job, 5*time.Millisecond)
-
-	require.Len(t, job.stopContexts, 2)
-	require.ErrorIs(t, job.stopContexts[0].Err(), context.DeadlineExceeded)
-	_, hasDeadline := job.stopContexts[1].Deadline()
-	require.True(t, hasDeadline)
-}
-
-func TestStopStandaloneJobDoesNotRetryOrdinaryFailure(t *testing.T) {
-	job := &scriptedLifecycle{stopErrors: []error{errors.New("stop failed")}}
-	stopStandaloneJob("ordinary failure", job)
-
-	require.Len(t, job.stopContexts, 1)
-	_, hasDeadline := job.stopContexts[0].Deadline()
-	require.True(t, hasDeadline)
-}
 
 func TestFleetdLoadsConfigFromYAML(t *testing.T) {
 	t.Parallel()

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -103,20 +103,27 @@ type runtimeJobGroupStopper interface {
 }
 
 // stopRuntimeJobGroup gives the group one graceful-shutdown budget, then one
-// fresh bounded budget to retry only the jobs whose first stop did not finish.
-func stopRuntimeJobGroup(group runtimeJobGroupStopper, timeout time.Duration) {
+// fresh bounded retry. Command execution receives a final independent budget
+// after producer retries because its activation is detached from group
+// cancellation to preserve shutdown ordering.
+func stopRuntimeJobGroup(group runtimeJobGroupStopper, commandExecution runtimejobs.Lifecycle, timeout time.Duration) {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	err := group.Stop(shutdownCtx)
 	cancel()
-	if err == nil {
-		return
+	if err != nil {
+		slog.Error("failed to stop runtime jobs", "error", err)
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), timeout)
+		if err := group.Stop(drainCtx); err != nil {
+			slog.Error("failed to drain runtime jobs", "error", err)
+		}
+		drainCancel()
 	}
 
-	slog.Error("failed to stop runtime jobs", "error", err)
-	drainCtx, drainCancel := context.WithTimeout(context.Background(), timeout)
-	defer drainCancel()
-	if err := group.Stop(drainCtx); err != nil {
-		slog.Error("failed to drain runtime jobs", "error", err)
+	commandCtx, commandCancel := context.WithTimeout(context.Background(), timeout)
+	err = commandExecution.Stop(commandCtx)
+	commandCancel()
+	if err != nil {
+		slog.Error("failed to stop command execution after runtime jobs", "error", err)
 	}
 }
 

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
@@ -73,6 +75,28 @@ func (l *backgroundLoop) Stop(ctx context.Context) error {
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("stop background loop: %w", ctx.Err())
+	}
+}
+
+type runtimeJobGroupStopper interface {
+	Stop(ctx context.Context) error
+}
+
+// stopRuntimeJobGroup gives the group one graceful-shutdown budget, then one
+// fresh bounded budget to retry only the jobs whose first stop did not finish.
+func stopRuntimeJobGroup(group runtimeJobGroupStopper, timeout time.Duration) {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	err := group.Stop(shutdownCtx)
+	cancel()
+	if err == nil {
+		return
+	}
+
+	slog.Error("failed to stop runtime jobs", "error", err)
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), timeout)
+	defer drainCancel()
+	if err := group.Stop(drainCtx); err != nil {
+		slog.Error("failed to drain runtime jobs", "error", err)
 	}
 }
 

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -35,6 +35,9 @@ func (l stopOrderedLifecycle) Start(ctx context.Context) error {
 }
 
 func (l stopOrderedLifecycle) Stop(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("stop ordered lifecycle: %w", err)
+	}
 	return l.lifecycle.Stop(ctx)
 }
 

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -46,9 +46,19 @@ func (l *backgroundLoop) Start(ctx context.Context) error {
 	l.done = done
 	go func() {
 		defer close(done)
+		defer l.finishRun(done)
 		l.run(runCtx)
 	}()
 	return nil
+}
+
+func (l *backgroundLoop) finishRun(done chan struct{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.done == done {
+		l.cancel = nil
+		l.done = nil
+	}
 }
 
 func (l *backgroundLoop) Stop(ctx context.Context) error {
@@ -64,12 +74,6 @@ func (l *backgroundLoop) Stop(ctx context.Context) error {
 	cancel()
 	select {
 	case <-done:
-		l.mu.Lock()
-		if l.done == done {
-			l.cancel = nil
-			l.done = nil
-		}
-		l.mu.Unlock()
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("stop background loop: %w", ctx.Err())

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
+)
+
+// backgroundLoop adapts a context-driven loop to the runtime job lifecycle.
+type backgroundLoop struct {
+	mu sync.Mutex
+
+	run    func(context.Context)
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+var _ runtimejobs.Lifecycle = (*backgroundLoop)(nil)
+
+func newBackgroundLoop(run func(context.Context)) *backgroundLoop {
+	return &backgroundLoop{run: run}
+}
+
+func (l *backgroundLoop) Start(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("start background loop: %w", err)
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.cancel != nil {
+		select {
+		case <-l.done:
+			return fmt.Errorf("background loop activation ended before stop")
+		default:
+			return nil
+		}
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	l.cancel = cancel
+	l.done = done
+	go func() {
+		defer close(done)
+		l.run(runCtx)
+	}()
+	return nil
+}
+
+func (l *backgroundLoop) Stop(ctx context.Context) error {
+	l.mu.Lock()
+	if l.cancel == nil {
+		l.mu.Unlock()
+		return nil
+	}
+	cancel := l.cancel
+	done := l.done
+	l.mu.Unlock()
+
+	cancel()
+	select {
+	case <-done:
+		l.mu.Lock()
+		if l.done == done {
+			l.cancel = nil
+			l.done = nil
+		}
+		l.mu.Unlock()
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("stop background loop: %w", ctx.Err())
+	}
+}
+
+type runtimeJobLifecycles struct {
+	identityStateCleanup      runtimejobs.Lifecycle
+	commandArtifactCleanup    runtimejobs.Lifecycle
+	diagnosticsErrorCloser    runtimejobs.Lifecycle
+	telemetry                 runtimejobs.Lifecycle
+	ipScanner                 runtimejobs.Lifecycle
+	commandExecution          runtimejobs.Lifecycle
+	scheduleProcessor         runtimejobs.Lifecycle
+	curtailmentReconciler     runtimejobs.Lifecycle
+	curtailmentMQTTSubscriber runtimejobs.Lifecycle
+	curtailmentAlertMetrics   runtimejobs.Lifecycle
+	chunkedUploadCleanup      runtimejobs.Lifecycle
+	systemMonitoring          runtimejobs.Lifecycle
+}
+
+func newRuntimeJobs(lifecycles runtimeJobLifecycles) ([]runtimejobs.Job, error) {
+	jobs := make([]runtimejobs.Job, 0, 12)
+	add := func(name string, lifecycle runtimejobs.Lifecycle) error {
+		job, err := runtimejobs.NewJob(name, lifecycle)
+		if err != nil {
+			return fmt.Errorf("create runtime job %q: %w", name, err)
+		}
+		jobs = append(jobs, job)
+		return nil
+	}
+
+	required := []struct {
+		name      string
+		lifecycle runtimejobs.Lifecycle
+	}{
+		{name: "identity-state-cleanup", lifecycle: lifecycles.identityStateCleanup},
+		{name: "command-artifact-cleanup", lifecycle: lifecycles.commandArtifactCleanup},
+		{name: "diagnostics-error-closer", lifecycle: lifecycles.diagnosticsErrorCloser},
+		{name: "telemetry", lifecycle: lifecycles.telemetry},
+		{name: "ip-scanner", lifecycle: lifecycles.ipScanner},
+		{name: "command-execution", lifecycle: lifecycles.commandExecution},
+		{name: "schedule-processor", lifecycle: lifecycles.scheduleProcessor},
+		{name: "curtailment-reconciler", lifecycle: lifecycles.curtailmentReconciler},
+		{name: "curtailment-mqtt-subscriber", lifecycle: lifecycles.curtailmentMQTTSubscriber},
+	}
+	for _, job := range required {
+		if err := add(job.name, job.lifecycle); err != nil {
+			return nil, err
+		}
+	}
+	if lifecycles.curtailmentAlertMetrics != nil {
+		if err := add("curtailment-alert-metrics", lifecycles.curtailmentAlertMetrics); err != nil {
+			return nil, err
+		}
+	}
+	if err := add("chunked-upload-cleanup", lifecycles.chunkedUploadCleanup); err != nil {
+		return nil, err
+	}
+	if lifecycles.systemMonitoring != nil {
+		if err := add("system-monitoring", lifecycles.systemMonitoring); err != nil {
+			return nil, err
+		}
+	}
+
+	return jobs, nil
+}

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -21,6 +21,23 @@ type backgroundLoop struct {
 
 var _ runtimejobs.Lifecycle = (*backgroundLoop)(nil)
 
+// stopOrderedLifecycle keeps a shared dependency active until the group reaches
+// it in reverse stop order. This lets jobs registered after it finish draining
+// without losing the dependency to the group's broadcast cancellation.
+type stopOrderedLifecycle struct {
+	lifecycle runtimejobs.Lifecycle
+}
+
+var _ runtimejobs.Lifecycle = stopOrderedLifecycle{}
+
+func (l stopOrderedLifecycle) Start(ctx context.Context) error {
+	return l.lifecycle.Start(context.WithoutCancel(ctx))
+}
+
+func (l stopOrderedLifecycle) Stop(ctx context.Context) error {
+	return l.lifecycle.Stop(ctx)
+}
+
 func newBackgroundLoop(run func(context.Context)) *backgroundLoop {
 	return &backgroundLoop{run: run}
 }
@@ -125,6 +142,10 @@ func newRuntimeJobs(lifecycles runtimeJobLifecycles) ([]runtimejobs.Job, error) 
 		jobs = append(jobs, job)
 		return nil
 	}
+	commandExecution := lifecycles.commandExecution
+	if commandExecution != nil {
+		commandExecution = stopOrderedLifecycle{lifecycle: commandExecution}
+	}
 
 	required := []struct {
 		name      string
@@ -135,7 +156,7 @@ func newRuntimeJobs(lifecycles runtimeJobLifecycles) ([]runtimejobs.Job, error) 
 		{name: "diagnostics-error-closer", lifecycle: lifecycles.diagnosticsErrorCloser},
 		{name: "telemetry", lifecycle: lifecycles.telemetry},
 		{name: "ip-scanner", lifecycle: lifecycles.ipScanner},
-		{name: "command-execution", lifecycle: lifecycles.commandExecution},
+		{name: "command-execution", lifecycle: commandExecution},
 		{name: "schedule-processor", lifecycle: lifecycles.scheduleProcessor},
 		{name: "curtailment-reconciler", lifecycle: lifecycles.curtailmentReconciler},
 		{name: "curtailment-mqtt-subscriber", lifecycle: lifecycles.curtailmentMQTTSubscriber},

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -46,19 +46,9 @@ func (l *backgroundLoop) Start(ctx context.Context) error {
 	l.done = done
 	go func() {
 		defer close(done)
-		defer l.finishRun(done)
 		l.run(runCtx)
 	}()
 	return nil
-}
-
-func (l *backgroundLoop) finishRun(done chan struct{}) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if l.done == done {
-		l.cancel = nil
-		l.done = nil
-	}
 }
 
 func (l *backgroundLoop) Stop(ctx context.Context) error {
@@ -74,6 +64,12 @@ func (l *backgroundLoop) Stop(ctx context.Context) error {
 	cancel()
 	select {
 	case <-done:
+		l.mu.Lock()
+		if l.done == done {
+			l.cancel = nil
+			l.done = nil
+		}
+		l.mu.Unlock()
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("stop background loop: %w", ctx.Err())

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -137,7 +137,7 @@ type runtimeJobLifecycles struct {
 }
 
 func newRuntimeJobs(lifecycles runtimeJobLifecycles) ([]runtimejobs.Job, error) {
-	jobs := make([]runtimejobs.Job, 0, 12)
+	var jobs []runtimejobs.Job
 	add := func(name string, lifecycle runtimejobs.Lifecycle) error {
 		job, err := runtimejobs.NewJob(name, lifecycle)
 		if err != nil {

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -102,21 +102,15 @@ type runtimeJobGroupStopper interface {
 	Stop(ctx context.Context) error
 }
 
-// stopRuntimeJobGroup gives the group one graceful-shutdown budget, then one
-// fresh bounded retry. Command execution receives a final independent budget
-// after producer retries because its activation is detached from group
-// cancellation to preserve shutdown ordering.
+// stopRuntimeJobGroup gives the group one graceful-shutdown budget. Command
+// execution receives a final independent budget because its activation is
+// detached from group cancellation to preserve shutdown ordering.
 func stopRuntimeJobGroup(group runtimeJobGroupStopper, commandExecution runtimejobs.Lifecycle, timeout time.Duration) {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	err := group.Stop(shutdownCtx)
 	cancel()
 	if err != nil {
 		slog.Error("failed to stop runtime jobs", "error", err)
-		drainCtx, drainCancel := context.WithTimeout(context.Background(), timeout)
-		if err := group.Stop(drainCtx); err != nil {
-			slog.Error("failed to drain runtime jobs", "error", err)
-		}
-		drainCancel()
 	}
 
 	commandCtx, commandCancel := context.WithTimeout(context.Background(), timeout)

--- a/server/cmd/fleetd/runtime_jobs_test.go
+++ b/server/cmd/fleetd/runtime_jobs_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -13,6 +14,18 @@ type noopLifecycle struct{}
 
 func (noopLifecycle) Start(context.Context) error { return nil }
 func (noopLifecycle) Stop(context.Context) error  { return nil }
+
+type scriptedRuntimeJobGroupStopper struct {
+	stops    []func(context.Context) error
+	contexts []context.Context
+}
+
+func (s *scriptedRuntimeJobGroupStopper) Stop(ctx context.Context) error {
+	s.contexts = append(s.contexts, ctx)
+	stop := s.stops[0]
+	s.stops = s.stops[1:]
+	return stop(ctx)
+}
 
 func TestNewRuntimeJobs(t *testing.T) {
 	all := runtimeJobLifecycles{
@@ -120,6 +133,51 @@ func TestBackgroundLoopStopCanBeRetriedAfterTimeout(t *testing.T) {
 
 	close(release)
 	require.NoError(t, loop.Stop(context.Background()))
+}
+
+func TestStopRuntimeJobGroupDoesNotRetrySuccessfulStop(t *testing.T) {
+	group := &scriptedRuntimeJobGroupStopper{stops: []func(context.Context) error{
+		func(context.Context) error { return nil },
+	}}
+
+	stopRuntimeJobGroup(group, time.Second)
+
+	require.Len(t, group.contexts, 1)
+	_, hasDeadline := group.contexts[0].Deadline()
+	require.True(t, hasDeadline)
+}
+
+func TestStopRuntimeJobGroupRetriesFailureWithFreshDeadline(t *testing.T) {
+	group := &scriptedRuntimeJobGroupStopper{stops: []func(context.Context) error{
+		func(context.Context) error { return errors.New("first stop failed") },
+		func(context.Context) error { return nil },
+	}}
+
+	stopRuntimeJobGroup(group, time.Second)
+
+	require.Len(t, group.contexts, 2)
+	firstDeadline, firstHasDeadline := group.contexts[0].Deadline()
+	secondDeadline, secondHasDeadline := group.contexts[1].Deadline()
+	require.True(t, firstHasDeadline)
+	require.True(t, secondHasDeadline)
+	require.True(t, secondDeadline.After(firstDeadline))
+}
+
+func TestStopRuntimeJobGroupBoundsDrainRetry(t *testing.T) {
+	group := &scriptedRuntimeJobGroupStopper{stops: []func(context.Context) error{
+		func(context.Context) error { return errors.New("first stop failed") },
+		func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}}
+
+	started := time.Now()
+	stopRuntimeJobGroup(group, 5*time.Millisecond)
+
+	require.Len(t, group.contexts, 2)
+	require.ErrorIs(t, group.contexts[1].Err(), context.DeadlineExceeded)
+	require.Less(t, time.Since(started), time.Second)
 }
 
 func jobNames(jobs []runtimejobs.Job) []string {

--- a/server/cmd/fleetd/runtime_jobs_test.go
+++ b/server/cmd/fleetd/runtime_jobs_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -85,7 +84,7 @@ func TestBackgroundLoopCanRestartAfterDraining(t *testing.T) {
 	}
 }
 
-func TestBackgroundLoopActivationCancellationAllowsRestart(t *testing.T) {
+func TestBackgroundLoopActivationCancellationRequiresStopBeforeRestart(t *testing.T) {
 	started := make(chan struct{}, 2)
 	loop := newBackgroundLoop(func(ctx context.Context) {
 		started <- struct{}{}
@@ -97,23 +96,20 @@ func TestBackgroundLoopActivationCancellationAllowsRestart(t *testing.T) {
 	requireReceive(t, started)
 	cancelFirst()
 	require.Eventually(t, func() bool {
-		return loop.Start(context.Background()) == nil
+		return loop.Start(context.Background()) != nil
 	}, time.Second, time.Millisecond)
+	require.NoError(t, loop.Stop(context.Background()))
+	require.NoError(t, loop.Start(context.Background()))
 	requireReceive(t, started)
 	require.NoError(t, loop.Stop(context.Background()))
 }
 
-func TestBackgroundLoopStopTimeoutEventuallyAllowsRestart(t *testing.T) {
-	started := make(chan struct{}, 2)
+func TestBackgroundLoopStopCanBeRetriedAfterTimeout(t *testing.T) {
+	started := make(chan struct{}, 1)
 	release := make(chan struct{})
-	var runs atomic.Int32
-	loop := newBackgroundLoop(func(ctx context.Context) {
+	loop := newBackgroundLoop(func(context.Context) {
 		started <- struct{}{}
-		if runs.Add(1) == 1 {
-			<-release
-			return
-		}
-		<-ctx.Done()
+		<-release
 	})
 
 	require.NoError(t, loop.Start(context.Background()))
@@ -123,10 +119,6 @@ func TestBackgroundLoopStopTimeoutEventuallyAllowsRestart(t *testing.T) {
 	require.ErrorIs(t, loop.Stop(stopCtx), context.DeadlineExceeded)
 
 	close(release)
-	require.Eventually(t, func() bool {
-		return loop.Start(context.Background()) == nil
-	}, time.Second, time.Millisecond)
-	requireReceive(t, started)
 	require.NoError(t, loop.Stop(context.Background()))
 }
 

--- a/server/cmd/fleetd/runtime_jobs_test.go
+++ b/server/cmd/fleetd/runtime_jobs_test.go
@@ -243,7 +243,7 @@ func TestStopRuntimeJobGroupDoesNotRetrySuccessfulStop(t *testing.T) {
 		func(context.Context) error { return nil },
 	}}
 
-	stopRuntimeJobGroup(group, time.Second)
+	stopRuntimeJobGroup(group, noopLifecycle{}, time.Second)
 
 	require.Len(t, group.contexts, 1)
 	_, hasDeadline := group.contexts[0].Deadline()
@@ -256,7 +256,7 @@ func TestStopRuntimeJobGroupRetriesFailureWithFreshDeadline(t *testing.T) {
 		func(context.Context) error { return nil },
 	}}
 
-	stopRuntimeJobGroup(group, time.Second)
+	stopRuntimeJobGroup(group, noopLifecycle{}, time.Second)
 
 	require.Len(t, group.contexts, 2)
 	firstDeadline, firstHasDeadline := group.contexts[0].Deadline()
@@ -274,12 +274,19 @@ func TestStopRuntimeJobGroupBoundsDrainRetry(t *testing.T) {
 			return ctx.Err()
 		},
 	}}
+	commandStopped := make(chan bool, 1)
+	commandExecution := funcLifecycle{stop: func(ctx context.Context) error {
+		_, hasDeadline := ctx.Deadline()
+		commandStopped <- hasDeadline && ctx.Err() == nil
+		return nil
+	}}
 
 	started := time.Now()
-	stopRuntimeJobGroup(group, 5*time.Millisecond)
+	stopRuntimeJobGroup(group, commandExecution, 5*time.Millisecond)
 
 	require.Len(t, group.contexts, 2)
 	require.ErrorIs(t, group.contexts[1].Err(), context.DeadlineExceeded)
+	require.True(t, <-commandStopped)
 	require.Less(t, time.Since(started), time.Second)
 }
 

--- a/server/cmd/fleetd/runtime_jobs_test.go
+++ b/server/cmd/fleetd/runtime_jobs_test.go
@@ -15,6 +15,25 @@ type noopLifecycle struct{}
 func (noopLifecycle) Start(context.Context) error { return nil }
 func (noopLifecycle) Stop(context.Context) error  { return nil }
 
+type funcLifecycle struct {
+	start func(context.Context) error
+	stop  func(context.Context) error
+}
+
+func (l funcLifecycle) Start(ctx context.Context) error {
+	if l.start == nil {
+		return nil
+	}
+	return l.start(ctx)
+}
+
+func (l funcLifecycle) Stop(ctx context.Context) error {
+	if l.stop == nil {
+		return nil
+	}
+	return l.stop(ctx)
+}
+
 type scriptedRuntimeJobGroupStopper struct {
 	stops    []func(context.Context) error
 	contexts []context.Context
@@ -81,6 +100,57 @@ func TestNewRuntimeJobs(t *testing.T) {
 func TestNewRuntimeJobsRejectsMissingRequiredLifecycle(t *testing.T) {
 	_, err := newRuntimeJobs(runtimeJobLifecycles{})
 	require.ErrorContains(t, err, `create runtime job "identity-state-cleanup"`)
+}
+
+func TestRuntimeJobGroupKeepsCommandExecutionAliveWhileProducersDrain(t *testing.T) {
+	var commandDone <-chan struct{}
+	commandStopped := make(chan struct{})
+	commandExecution := funcLifecycle{
+		start: func(ctx context.Context) error {
+			commandDone = ctx.Done()
+			return nil
+		},
+		stop: func(context.Context) error {
+			close(commandStopped)
+			return nil
+		},
+	}
+	producer := funcLifecycle{stop: func(context.Context) error {
+		select {
+		case <-commandDone:
+			return errors.New("command execution canceled before producer drained")
+		default:
+		}
+		select {
+		case <-commandStopped:
+			return errors.New("command execution stopped before producer drained")
+		default:
+			return nil
+		}
+	}}
+
+	jobs, err := newRuntimeJobs(runtimeJobLifecycles{
+		identityStateCleanup:      noopLifecycle{},
+		commandArtifactCleanup:    noopLifecycle{},
+		diagnosticsErrorCloser:    noopLifecycle{},
+		telemetry:                 noopLifecycle{},
+		ipScanner:                 noopLifecycle{},
+		commandExecution:          commandExecution,
+		scheduleProcessor:         producer,
+		curtailmentReconciler:     noopLifecycle{},
+		curtailmentMQTTSubscriber: noopLifecycle{},
+		chunkedUploadCleanup:      noopLifecycle{},
+	})
+	require.NoError(t, err)
+	group, err := runtimejobs.NewGroup(jobs, time.Second)
+	require.NoError(t, err)
+	require.NoError(t, group.Start(t.Context()))
+	require.NoError(t, group.Stop(t.Context()))
+	select {
+	case <-commandStopped:
+	default:
+		t.Fatal("command execution was not stopped")
+	}
 }
 
 func TestBackgroundLoopCanRestartAfterDraining(t *testing.T) {

--- a/server/cmd/fleetd/runtime_jobs_test.go
+++ b/server/cmd/fleetd/runtime_jobs_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -84,22 +85,35 @@ func TestBackgroundLoopCanRestartAfterDraining(t *testing.T) {
 	}
 }
 
-func TestBackgroundLoopCannotRestartEndedActivationBeforeStop(t *testing.T) {
-	done := make(chan struct{})
-	loop := newBackgroundLoop(func(context.Context) { close(done) })
+func TestBackgroundLoopActivationCancellationAllowsRestart(t *testing.T) {
+	started := make(chan struct{}, 2)
+	loop := newBackgroundLoop(func(ctx context.Context) {
+		started <- struct{}{}
+		<-ctx.Done()
+	})
 
-	require.NoError(t, loop.Start(context.Background()))
-	requireReceive(t, done)
-	require.ErrorContains(t, loop.Start(context.Background()), "activation ended before stop")
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	require.NoError(t, loop.Start(firstCtx))
+	requireReceive(t, started)
+	cancelFirst()
+	require.Eventually(t, func() bool {
+		return loop.Start(context.Background()) == nil
+	}, time.Second, time.Millisecond)
+	requireReceive(t, started)
 	require.NoError(t, loop.Stop(context.Background()))
 }
 
-func TestBackgroundLoopStopHonorsDeadlineAndCanFinishDraining(t *testing.T) {
-	started := make(chan struct{}, 1)
+func TestBackgroundLoopStopTimeoutEventuallyAllowsRestart(t *testing.T) {
+	started := make(chan struct{}, 2)
 	release := make(chan struct{})
-	loop := newBackgroundLoop(func(context.Context) {
+	var runs atomic.Int32
+	loop := newBackgroundLoop(func(ctx context.Context) {
 		started <- struct{}{}
-		<-release
+		if runs.Add(1) == 1 {
+			<-release
+			return
+		}
+		<-ctx.Done()
 	})
 
 	require.NoError(t, loop.Start(context.Background()))
@@ -109,8 +123,11 @@ func TestBackgroundLoopStopHonorsDeadlineAndCanFinishDraining(t *testing.T) {
 	require.ErrorIs(t, loop.Stop(stopCtx), context.DeadlineExceeded)
 
 	close(release)
+	require.Eventually(t, func() bool {
+		return loop.Start(context.Background()) == nil
+	}, time.Second, time.Millisecond)
+	requireReceive(t, started)
 	require.NoError(t, loop.Stop(context.Background()))
-	require.NoError(t, loop.Start(context.Background()))
 }
 
 func jobNames(jobs []runtimejobs.Job) []string {

--- a/server/cmd/fleetd/runtime_jobs_test.go
+++ b/server/cmd/fleetd/runtime_jobs_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
+	"github.com/stretchr/testify/require"
+)
+
+type noopLifecycle struct{}
+
+func (noopLifecycle) Start(context.Context) error { return nil }
+func (noopLifecycle) Stop(context.Context) error  { return nil }
+
+func TestNewRuntimeJobs(t *testing.T) {
+	all := runtimeJobLifecycles{
+		identityStateCleanup:      noopLifecycle{},
+		commandArtifactCleanup:    noopLifecycle{},
+		diagnosticsErrorCloser:    noopLifecycle{},
+		telemetry:                 noopLifecycle{},
+		ipScanner:                 noopLifecycle{},
+		commandExecution:          noopLifecycle{},
+		scheduleProcessor:         noopLifecycle{},
+		curtailmentReconciler:     noopLifecycle{},
+		curtailmentMQTTSubscriber: noopLifecycle{},
+		curtailmentAlertMetrics:   noopLifecycle{},
+		chunkedUploadCleanup:      noopLifecycle{},
+		systemMonitoring:          noopLifecycle{},
+	}
+
+	jobs, err := newRuntimeJobs(all)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"identity-state-cleanup",
+		"command-artifact-cleanup",
+		"diagnostics-error-closer",
+		"telemetry",
+		"ip-scanner",
+		"command-execution",
+		"schedule-processor",
+		"curtailment-reconciler",
+		"curtailment-mqtt-subscriber",
+		"curtailment-alert-metrics",
+		"chunked-upload-cleanup",
+		"system-monitoring",
+	}, jobNames(jobs))
+
+	all.curtailmentAlertMetrics = nil
+	all.systemMonitoring = nil
+	jobs, err = newRuntimeJobs(all)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"identity-state-cleanup",
+		"command-artifact-cleanup",
+		"diagnostics-error-closer",
+		"telemetry",
+		"ip-scanner",
+		"command-execution",
+		"schedule-processor",
+		"curtailment-reconciler",
+		"curtailment-mqtt-subscriber",
+		"chunked-upload-cleanup",
+	}, jobNames(jobs))
+}
+
+func TestNewRuntimeJobsRejectsMissingRequiredLifecycle(t *testing.T) {
+	_, err := newRuntimeJobs(runtimeJobLifecycles{})
+	require.ErrorContains(t, err, `create runtime job "identity-state-cleanup"`)
+}
+
+func TestBackgroundLoopCanRestartAfterDraining(t *testing.T) {
+	started := make(chan struct{}, 2)
+	loop := newBackgroundLoop(func(ctx context.Context) {
+		started <- struct{}{}
+		<-ctx.Done()
+	})
+
+	for range 2 {
+		require.NoError(t, loop.Start(context.Background()))
+		requireReceive(t, started)
+		require.NoError(t, loop.Stop(context.Background()))
+	}
+}
+
+func TestBackgroundLoopCannotRestartEndedActivationBeforeStop(t *testing.T) {
+	done := make(chan struct{})
+	loop := newBackgroundLoop(func(context.Context) { close(done) })
+
+	require.NoError(t, loop.Start(context.Background()))
+	requireReceive(t, done)
+	require.ErrorContains(t, loop.Start(context.Background()), "activation ended before stop")
+	require.NoError(t, loop.Stop(context.Background()))
+}
+
+func TestBackgroundLoopStopHonorsDeadlineAndCanFinishDraining(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	loop := newBackgroundLoop(func(context.Context) {
+		started <- struct{}{}
+		<-release
+	})
+
+	require.NoError(t, loop.Start(context.Background()))
+	requireReceive(t, started)
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, loop.Stop(stopCtx), context.DeadlineExceeded)
+
+	close(release)
+	require.NoError(t, loop.Stop(context.Background()))
+	require.NoError(t, loop.Start(context.Background()))
+}
+
+func jobNames(jobs []runtimejobs.Job) []string {
+	names := make([]string, 0, len(jobs))
+	for _, job := range jobs {
+		names = append(names, job.Name())
+	}
+	return names
+}
+
+func requireReceive(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for background loop")
+	}
+}

--- a/server/cmd/fleetd/runtime_jobs_test.go
+++ b/server/cmd/fleetd/runtime_jobs_test.go
@@ -153,6 +153,39 @@ func TestRuntimeJobGroupKeepsCommandExecutionAliveWhileProducersDrain(t *testing
 	}
 }
 
+func TestRuntimeJobGroupKeepsCommandExecutionAliveForDrainRetry(t *testing.T) {
+	commandStopCalls := 0
+	producerStopCalls := 0
+	command, err := runtimejobs.NewJob("command", stopOrderedLifecycle{lifecycle: funcLifecycle{
+		stop: func(context.Context) error {
+			commandStopCalls++
+			return nil
+		},
+	}})
+	require.NoError(t, err)
+	producer, err := runtimejobs.NewJob("producer", funcLifecycle{stop: func(ctx context.Context) error {
+		producerStopCalls++
+		if producerStopCalls == 1 {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		if commandStopCalls != 0 {
+			return errors.New("command execution stopped before producer retry")
+		}
+		return nil
+	}})
+	require.NoError(t, err)
+	group, err := runtimejobs.NewGroup([]runtimejobs.Job{command, producer}, time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, group.Start(t.Context()))
+
+	require.ErrorIs(t, group.Stop(context.Background()), context.DeadlineExceeded)
+	require.Zero(t, commandStopCalls)
+	require.NoError(t, group.Stop(context.Background()))
+	require.Equal(t, 2, producerStopCalls)
+	require.Equal(t, 1, commandStopCalls)
+}
+
 func TestBackgroundLoopCanRestartAfterDraining(t *testing.T) {
 	started := make(chan struct{}, 2)
 	loop := newBackgroundLoop(func(ctx context.Context) {

--- a/server/cmd/fleetd/runtime_jobs_test.go
+++ b/server/cmd/fleetd/runtime_jobs_test.go
@@ -35,15 +35,13 @@ func (l funcLifecycle) Stop(ctx context.Context) error {
 }
 
 type scriptedRuntimeJobGroupStopper struct {
-	stops    []func(context.Context) error
+	stop     func(context.Context) error
 	contexts []context.Context
 }
 
 func (s *scriptedRuntimeJobGroupStopper) Stop(ctx context.Context) error {
 	s.contexts = append(s.contexts, ctx)
-	stop := s.stops[0]
-	s.stops = s.stops[1:]
-	return stop(ctx)
+	return s.stop(ctx)
 }
 
 func TestNewRuntimeJobs(t *testing.T) {
@@ -142,7 +140,7 @@ func TestRuntimeJobGroupKeepsCommandExecutionAliveWhileProducersDrain(t *testing
 		chunkedUploadCleanup:      noopLifecycle{},
 	})
 	require.NoError(t, err)
-	group, err := runtimejobs.NewGroup(jobs, time.Second)
+	group, err := runtimejobs.NewGroup(jobs)
 	require.NoError(t, err)
 	require.NoError(t, group.Start(t.Context()))
 	require.NoError(t, group.Stop(t.Context()))
@@ -151,39 +149,6 @@ func TestRuntimeJobGroupKeepsCommandExecutionAliveWhileProducersDrain(t *testing
 	default:
 		t.Fatal("command execution was not stopped")
 	}
-}
-
-func TestRuntimeJobGroupKeepsCommandExecutionAliveForDrainRetry(t *testing.T) {
-	commandStopCalls := 0
-	producerStopCalls := 0
-	command, err := runtimejobs.NewJob("command", stopOrderedLifecycle{lifecycle: funcLifecycle{
-		stop: func(context.Context) error {
-			commandStopCalls++
-			return nil
-		},
-	}})
-	require.NoError(t, err)
-	producer, err := runtimejobs.NewJob("producer", funcLifecycle{stop: func(ctx context.Context) error {
-		producerStopCalls++
-		if producerStopCalls == 1 {
-			<-ctx.Done()
-			return ctx.Err()
-		}
-		if commandStopCalls != 0 {
-			return errors.New("command execution stopped before producer retry")
-		}
-		return nil
-	}})
-	require.NoError(t, err)
-	group, err := runtimejobs.NewGroup([]runtimejobs.Job{command, producer}, time.Millisecond)
-	require.NoError(t, err)
-	require.NoError(t, group.Start(t.Context()))
-
-	require.ErrorIs(t, group.Stop(context.Background()), context.DeadlineExceeded)
-	require.Zero(t, commandStopCalls)
-	require.NoError(t, group.Stop(context.Background()))
-	require.Equal(t, 2, producerStopCalls)
-	require.Equal(t, 1, commandStopCalls)
 }
 
 func TestBackgroundLoopCanRestartAfterDraining(t *testing.T) {
@@ -239,9 +204,9 @@ func TestBackgroundLoopStopCanBeRetriedAfterTimeout(t *testing.T) {
 }
 
 func TestStopRuntimeJobGroupDoesNotRetrySuccessfulStop(t *testing.T) {
-	group := &scriptedRuntimeJobGroupStopper{stops: []func(context.Context) error{
-		func(context.Context) error { return nil },
-	}}
+	group := &scriptedRuntimeJobGroupStopper{
+		stop: func(context.Context) error { return nil },
+	}
 
 	stopRuntimeJobGroup(group, noopLifecycle{}, time.Second)
 
@@ -250,30 +215,28 @@ func TestStopRuntimeJobGroupDoesNotRetrySuccessfulStop(t *testing.T) {
 	require.True(t, hasDeadline)
 }
 
-func TestStopRuntimeJobGroupRetriesFailureWithFreshDeadline(t *testing.T) {
-	group := &scriptedRuntimeJobGroupStopper{stops: []func(context.Context) error{
-		func(context.Context) error { return errors.New("first stop failed") },
-		func(context.Context) error { return nil },
-	}}
+func TestStopRuntimeJobGroupStopsCommandAfterGroupFailure(t *testing.T) {
+	group := &scriptedRuntimeJobGroupStopper{
+		stop: func(context.Context) error { return errors.New("stop failed") },
+	}
+	commandStopped := false
 
-	stopRuntimeJobGroup(group, noopLifecycle{}, time.Second)
+	stopRuntimeJobGroup(group, funcLifecycle{stop: func(context.Context) error {
+		commandStopped = true
+		return nil
+	}}, time.Second)
 
-	require.Len(t, group.contexts, 2)
-	firstDeadline, firstHasDeadline := group.contexts[0].Deadline()
-	secondDeadline, secondHasDeadline := group.contexts[1].Deadline()
-	require.True(t, firstHasDeadline)
-	require.True(t, secondHasDeadline)
-	require.True(t, secondDeadline.After(firstDeadline))
+	require.Len(t, group.contexts, 1)
+	require.True(t, commandStopped)
 }
 
-func TestStopRuntimeJobGroupBoundsDrainRetry(t *testing.T) {
-	group := &scriptedRuntimeJobGroupStopper{stops: []func(context.Context) error{
-		func(context.Context) error { return errors.New("first stop failed") },
-		func(ctx context.Context) error {
+func TestStopRuntimeJobGroupBoundsGroupAndCommandStops(t *testing.T) {
+	group := &scriptedRuntimeJobGroupStopper{
+		stop: func(ctx context.Context) error {
 			<-ctx.Done()
 			return ctx.Err()
 		},
-	}}
+	}
 	commandStopped := make(chan bool, 1)
 	commandExecution := funcLifecycle{stop: func(ctx context.Context) error {
 		_, hasDeadline := ctx.Deadline()
@@ -284,8 +247,8 @@ func TestStopRuntimeJobGroupBoundsDrainRetry(t *testing.T) {
 	started := time.Now()
 	stopRuntimeJobGroup(group, commandExecution, 5*time.Millisecond)
 
-	require.Len(t, group.contexts, 2)
-	require.ErrorIs(t, group.contexts[1].Err(), context.DeadlineExceeded)
+	require.Len(t, group.contexts, 1)
+	require.ErrorIs(t, group.contexts[0].Err(), context.DeadlineExceeded)
 	require.True(t, <-commandStopped)
 	require.Less(t, time.Since(started), time.Second)
 }

--- a/server/internal/infrastructure/sysmon/sysmon.go
+++ b/server/internal/infrastructure/sysmon/sysmon.go
@@ -6,6 +6,7 @@ package sysmon
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -40,6 +41,7 @@ type Collector struct {
 	cpuBusy  atomic.Bool
 	memBusy  atomic.Bool
 	diskBusy atomic.Bool
+	probes   sync.WaitGroup
 }
 
 // The Fleet Heartbeat Stale rule's staleness threshold is 120s, so the
@@ -71,6 +73,7 @@ func New(cfg Config, emitter Emitter) *Collector {
 func (c *Collector) Run(ctx context.Context) {
 	ticker := time.NewTicker(c.cfg.Interval)
 	defer ticker.Stop()
+	defer c.probes.Wait()
 	c.collectOnce(ctx)
 	for {
 		select {
@@ -113,10 +116,10 @@ func (c *Collector) launch(busy *atomic.Bool, probe string, work func()) {
 		slog.Warn("sysmon: previous read still in flight, skipping this tick", "probe", probe)
 		return
 	}
-	go func() {
+	c.probes.Go(func() {
 		defer busy.Store(false)
 		work()
-	}()
+	})
 }
 
 func readCPU(ctx context.Context) *float64 {

--- a/server/internal/infrastructure/sysmon/sysmon.go
+++ b/server/internal/infrastructure/sysmon/sysmon.go
@@ -6,7 +6,6 @@ package sysmon
 import (
 	"context"
 	"log/slog"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -41,7 +40,6 @@ type Collector struct {
 	cpuBusy  atomic.Bool
 	memBusy  atomic.Bool
 	diskBusy atomic.Bool
-	probes   sync.WaitGroup
 }
 
 // The Fleet Heartbeat Stale rule's staleness threshold is 120s, so the
@@ -73,7 +71,6 @@ func New(cfg Config, emitter Emitter) *Collector {
 func (c *Collector) Run(ctx context.Context) {
 	ticker := time.NewTicker(c.cfg.Interval)
 	defer ticker.Stop()
-	defer c.probes.Wait()
 	c.collectOnce(ctx)
 	for {
 		select {
@@ -116,10 +113,10 @@ func (c *Collector) launch(busy *atomic.Bool, probe string, work func()) {
 		slog.Warn("sysmon: previous read still in flight, skipping this tick", "probe", probe)
 		return
 	}
-	c.probes.Go(func() {
+	go func() {
 		defer busy.Store(false)
 		work()
-	})
+	}()
 }
 
 func readCPU(ctx context.Context) *float64 {

--- a/server/internal/infrastructure/sysmon/sysmon_test.go
+++ b/server/internal/infrastructure/sysmon/sysmon_test.go
@@ -123,6 +123,10 @@ func TestHungDiskReadBlocksOnlyTheDiskProbe(t *testing.T) {
 	// Act
 	collector.collectOnce(context.Background())
 	require.Eventually(t, func() bool { return diskReads.Load() == 1 }, time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool {
+		cpu, mem, _ := emitter.gauges()
+		return len(cpu) == 1 && len(mem) == 1 && !collector.cpuBusy.Load() && !collector.memBusy.Load()
+	}, time.Second, 5*time.Millisecond)
 	collector.collectOnce(context.Background())
 
 	// Assert
@@ -166,7 +170,7 @@ func TestRunEmitsImmediatelyAndStopsOnCancel(t *testing.T) {
 	}
 }
 
-func TestRunWaitsForInFlightProbes(t *testing.T) {
+func TestRunDoesNotWaitForInFlightProbes(t *testing.T) {
 	emitter := &fakeEmitter{}
 	collector := New(Config{Interval: time.Hour, DiskPath: "/"}, emitter)
 	probeStarted := make(chan struct{})
@@ -193,16 +197,10 @@ func TestRunWaitsForInFlightProbes(t *testing.T) {
 	cancel()
 	select {
 	case <-done:
-		t.Fatal("Run returned before its in-flight probe drained")
-	case <-time.After(10 * time.Millisecond):
-	}
-
-	close(releaseProbe)
-	select {
-	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("Run did not return after its in-flight probe drained")
+		t.Fatal("Run waited for an in-flight probe after cancellation")
 	}
+	close(releaseProbe)
 }
 
 func TestNewClampsIntervalToAllowedRange(t *testing.T) {

--- a/server/internal/infrastructure/sysmon/sysmon_test.go
+++ b/server/internal/infrastructure/sysmon/sysmon_test.go
@@ -166,6 +166,45 @@ func TestRunEmitsImmediatelyAndStopsOnCancel(t *testing.T) {
 	}
 }
 
+func TestRunWaitsForInFlightProbes(t *testing.T) {
+	emitter := &fakeEmitter{}
+	collector := New(Config{Interval: time.Hour, DiskPath: "/"}, emitter)
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	collector.readCPU = func(context.Context) *float64 { return nil }
+	collector.readMem = func(context.Context) *float64 { return nil }
+	collector.readDisk = func(context.Context, string) *float64 {
+		close(probeStarted)
+		<-releaseProbe
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		collector.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-probeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("disk probe did not start")
+	}
+	cancel()
+	select {
+	case <-done:
+		t.Fatal("Run returned before its in-flight probe drained")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(releaseProbe)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after its in-flight probe drained")
+	}
+}
+
 func TestNewClampsIntervalToAllowedRange(t *testing.T) {
 	// Act
 	short := New(Config{Interval: time.Millisecond}, &fakeEmitter{})


### PR DESCRIPTION
Reviewable diff: +254/-112 across 2 files (excludes generated, test, and story files).

## Summary

`fleetd` now activates its 12 background jobs from one explicit ordered catalog and drains them as one runtime group. Standalone deployments still run the same work, while the HA supervisor gains a single boundary it can later leave stopped on passive instances and toggle on ownership changes.

**Stack:**

1. Lifecycle foundation [#780](https://github.com/block/proto-fleet/pull/780) — merged
2. Diagnostics [#781](https://github.com/block/proto-fleet/pull/781) — merged
3. IP scanning [#782](https://github.com/block/proto-fleet/pull/782) — merged
4. Scheduling [#783](https://github.com/block/proto-fleet/pull/783) — merged
5. Curtailment [#785](https://github.com/block/proto-fleet/pull/785) — merged
6. Command execution [#787](https://github.com/block/proto-fleet/pull/787) — merged
7. Telemetry [#786](https://github.com/block/proto-fleet/pull/786) — merged
8. Runtime orchestration [#784](https://github.com/block/proto-fleet/pull/784) — merged
9. **Catalog and `fleetd` cutover [#788](https://github.com/block/proto-fleet/pull/788) — this PR**

This final PR now targets the latest `main`, which includes the runtime `Job`/`Group` implementation from #784. Its reviewable diff contains only the catalog and `fleetd` cutover.

Passive-mode coordinator wiring, epoch fencing, and active request gating remain HA follow-up work. This PR supplies the activation boundary; it does not choose when Fleet is active.

## How it works

Construction remains in dependency order, but no active loop starts during construction. `fleetd` builds the canonical catalog and starts one `runtimejobs.Group`; the group passes one activation context to every catalog entry. Four context-driven loops—identity cleanup, command-artifact cleanup, chunked-upload cleanup, and system monitoring—use a small `backgroundLoop` lifecycle adapter. The other eight entries are the restartable services introduced by the earlier stack.

Command execution is a drain dependency for later producers. A small stop-order wrapper keeps it alive when the group broadcasts activation cancellation, allowing schedule and telemetry producers to finish first. Group shutdown gets one bounded 10-second attempt; incomplete cleanup is terminal rather than retried. Command execution then receives its own fresh bounded stop budget so it is still stopped if an earlier producer consumed the group budget.

System monitoring waits on a listener-ready signal before it emits its first heartbeat. Other jobs complete synchronous startup before `fleetd` binds the HTTP listener; once binding succeeds, the signal releases system monitoring and the server begins accepting connections. Telemetry now has only the common `Start`/`Stop` lifecycle, so group shutdown is its sole cleanup owner.

```mermaid
flowchart TB
    C["Construct services without starting jobs"] --> K["Build ordered 12-job catalog"]
    K --> G["Start runtime Group"]
    G --> F["Startup failure"]
    F --> R["Cancel and rollback started prefix"]
    G --> L["Bind HTTP listener"]
    L --> H["Release system-monitoring heartbeat"]
    H --> A["Standalone active runtime"]
    A --> S["Shutdown or future demotion"]
    S --> D["Cancel and reverse-stop under one bounded budget"]
    D --> X["Final command-execution stop"]
    X --> P["Process teardown"]
```

```mermaid
sequenceDiagram
    participant O as Runtime owner
    participant G as Job group
    participant P as Schedule and telemetry producers
    participant C as Command execution
    O->>G: Stop with 10-second budget
    G->>P: Cancel activation and drain in reverse order
    Note over C: Cancellation is detached to preserve the drain dependency
    G->>C: Stop if group budget remains
    O->>C: Final independent bounded Stop
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/cmd/fleetd/runtime_jobs.go` (new) | Defines the context-loop adapter, command drain ordering, bounded group shutdown, and canonical ordered catalog | Review exact job membership, order, optional omission, and shutdown dependency handling |
| `server/cmd/fleetd/main.go` | Separates construction from activation and cuts startup/shutdown over to `Group` | Review startup strictness, listener/heartbeat ordering, and single-owner shutdown |
| Focused tests | Pin catalog order and optionals, adapter restart/drain, command drain ordering, bounded final cleanup, and heartbeat cancellation behavior | Protect the HA-sensitive lifecycle edges |

## Key technical decisions & trade-offs

- Keep catalog policy in `fleetd`; domain services know lifecycle, not deployment names or enablement.
- Treat the group `Start` context as the shared activation lifetime and `Stop` as the explicit bounded drain.
- Use one local adapter for four existing context loops instead of introducing new service types or a general registry.
- Omit optional jobs with true nil interfaces; disabled alert metrics and system monitoring are not registered.
- Keep command execution alive until its producers drain, then stop it under its own final bounded budget.
- Treat incomplete group cleanup as terminal rather than retrying a potentially unsafe activation.
- Start the group before listener binding while gating the first system heartbeat on a successful bind.
- Treat any grouped startup failure as fatal and roll back instead of continuing with a partially active Fleet.

## Related

Related: #740

## Testing & validation

- `go test -short -race -count=1 ./cmd/fleetd ./internal/infrastructure/sysmon ./internal/runtimejobs ./internal/domain/telemetry`
- `go test -short -run '^$' ./...` from `server/`
- Repo-pinned `golangci-lint` 2.9.0 (`0 issues`)
- `git diff --check` against current `main`
- Database-backed integration tests were not run locally.

## Post-Deploy Monitoring & Validation

For one normal job interval after rollout, watch startup errors containing `start runtime jobs`, shutdown errors containing `failed to stop runtime jobs`, command queue depth/age, telemetry freshness, schedule dispatch, scanner completion, MQTT subscription state, curtailment actions, diagnostics closing, cleanup logs, and system heartbeat freshness. Roll back on missing job activity, duplicate side effects, stale telemetry/control inputs, or any group drain failure.
