### PR TITLE
feat(buildings): server-side rack pagination + Building/Site facets (4/4, #765)

### DIFF
--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.test.tsx
@@ -13,6 +13,7 @@ import { DeviceSetSchema, RackInfoSchema } from "@/protoFleet/api/generated/devi
 // member-only AssignRacksToBuilding. These tests drive that flow end to end.
 const mockApi = vi.hoisted(() => ({
   listBuildingsBySite: vi.fn(),
+  listBuildings: vi.fn(),
   listBuildingRacks: vi.fn(),
   assignRacksToBuilding: vi.fn(),
 }));
@@ -67,12 +68,14 @@ const openPickerAndPickBeta = async () => {
 describe("ManageBuildingModal reparent commit-on-Continue", () => {
   beforeEach(() => {
     mockApi.listBuildingsBySite.mockReset();
+    mockApi.listBuildings.mockReset();
     mockApi.listBuildingRacks.mockReset();
     mockApi.assignRacksToBuilding.mockReset();
     mockListRacks.mockReset();
     // Building opens with no racks placed yet.
     mockApi.listBuildingRacks.mockImplementation(({ onSuccess }) => onSuccess?.([]));
     mockApi.listBuildingsBySite.mockImplementation(({ onSuccess }) => onSuccess?.([]));
+    mockApi.listBuildings.mockImplementation(({ onSuccess }) => onSuccess?.([]));
     mockApi.assignRacksToBuilding.mockImplementation(({ onSuccess }) => onSuccess?.(0n));
     mockListRacks.mockImplementation(({ onSuccess }) =>
       onSuccess?.([createRack(1n, "Alpha", 20n, 7n), createRack(2n, "Beta", 9n, 7n, 5)]),

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
@@ -734,6 +734,7 @@ const ManageBuildingModal = ({
           currentBuildingId={building.id}
           scope={rackScope}
           assignedScope={assignedScope}
+          allSites={activeSite.kind === "all"}
           buildingName={building.name}
           initialSelectedRackIds={currentRackIds}
           onDismiss={() => setShowManageRacks(false)}

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -613,6 +613,88 @@ describe("ManageRacksModal review fixes (#789)", () => {
     expect(onConfirm.mock.calls[0][0].added).toEqual([]);
   });
 
+  it("disables pagination while a page is loading (no stale-token double advance)", async () => {
+    // The current page's rows + nextPageToken stay live during a slow page
+    // fetch; without the loading gate the Next button would remain enabled with
+    // the previous page's token, so a double-click stores a stale token at the
+    // advanced index and fetches the wrong range.
+    const many = Array.from({ length: 60 }, (_, i) =>
+      createRack(BigInt(i + 1), `Rack ${String(i).padStart(2, "0")}`, 7n, 42n),
+    );
+    let resolvePage2: (() => void) | undefined;
+    mockListRacks.mockImplementation((req: FetchReq & { onSuccess?: Function; onFinally?: Function }) => {
+      const matched = many.filter((r) => matchesReq(r, req));
+      if (!req.pageSize) {
+        req.onSuccess?.(matched, "", matched.length);
+        req.onFinally?.();
+        return;
+      }
+      const offset = req.pageToken ? Number(req.pageToken) : 0;
+      const page = matched.slice(offset, offset + req.pageSize);
+      const nextOffset = offset + req.pageSize;
+      const nextToken = nextOffset < matched.length ? String(nextOffset) : "";
+      const resolve = () => {
+        req.onSuccess?.(page, nextToken, matched.length);
+        req.onFinally?.();
+      };
+      // Page 1 resolves immediately; page 2 defers so we can assert the gate.
+      if (offset === 0) resolve();
+      else resolvePage2 = resolve;
+    });
+    renderModal();
+    await waitFor(() => expect(screen.getByText("Showing 1–50 of 60 racks")).toBeInTheDocument());
+
+    const nextBtn = screen.getByRole("button", { name: "Next page" });
+    await userEvent.click(nextBtn);
+    // Page 2 is in flight: both pagination buttons are disabled.
+    expect(nextBtn).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Previous page" })).toBeDisabled();
+    const pageFetchesBefore = reqsMatching((r) => r.pageSize !== undefined).length;
+    await userEvent.click(nextBtn); // no-op while disabled — no extra fetch
+    expect(reqsMatching((r) => r.pageSize !== undefined).length).toBe(pageFetchesBefore);
+
+    resolvePage2!();
+    await waitFor(() => expect(screen.getByText("Showing 51–60 of 60 racks")).toBeInTheDocument());
+    // Exactly the correct page-2 token was used (not a stale re-fetch of page 1).
+    expect(lastRackReq().pageToken).toBe("50");
+  });
+
+  it("ignores a superseded Select all finalizer (Continue stays disabled until the latest resolves)", async () => {
+    // Two footer Select alls in flight: the slower (superseded) one finishing
+    // first must not re-enable Continue while the newer bulk fetch is pending —
+    // otherwise Continue could commit the stale selection.
+    const many = [createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Bravo", 7n, 42n)];
+    const pendingAll: Array<() => void> = [];
+    mockListRacks.mockImplementation((req: FetchReq & { onSuccess?: Function; onFinally?: Function }) => {
+      const matched = many.filter((r) => matchesReq(r, req));
+      if (!req.pageSize) {
+        pendingAll.push(() => {
+          req.onSuccess?.(matched, "", matched.length);
+          req.onFinally?.();
+        });
+        return;
+      }
+      req.onSuccess?.(matched.slice(0, req.pageSize), "", matched.length);
+      req.onFinally?.();
+    });
+    renderModal();
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    const selectAll = screen.getByRole("button", { name: "Select all" });
+    await userEvent.click(selectAll); // fetch #1
+    await userEvent.click(selectAll); // fetch #2 supersedes #1
+    const confirm = screen.getByTestId("manage-racks-modal-confirm");
+    expect(confirm).toBeDisabled();
+
+    // The superseded fetch #1 finalizes first: Continue must stay disabled.
+    pendingAll[0]();
+    expect(confirm).toBeDisabled();
+
+    // The latest fetch #2 finalizes: Continue is now usable.
+    pendingAll[1]();
+    await waitFor(() => expect(confirm).not.toBeDisabled());
+  });
+
   it("renders a filter chip when facing the current building (chip state is controlled by facets)", async () => {
     // Bug: filtering by the building being edited produced no chip because the
     // List remounts on every refetch (displayItems → undefined), wiping the

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -387,3 +387,76 @@ describe("ManageRacksModal server-side pagination", () => {
     expect(onConfirm.mock.calls[0][0].added).toHaveLength(60);
   });
 });
+
+// Regression tests for the automated PR-review findings on #789.
+describe("ManageRacksModal review fixes (#789)", () => {
+  it("removes an explicitly deselected seed even when it is absent from the fetch", async () => {
+    // Seed 3 is off-page / pinned out of the assignable fetch (only Alpha=1 is
+    // returned). Clicking "Select none" is an explicit clear, so both seeds must
+    // be reported removed — the accumulator is placeholder-seeded so the absent
+    // seed is still actionable. (Contrast the untouched-seed test above, which
+    // preserves it.)
+    const onConfirm = vi.fn();
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n)]);
+    renderModal({ initialSelectedRackIds: [1n, 3n], onConfirm });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "Select none" }));
+    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
+
+    const delta = onConfirm.mock.calls[0][0];
+    expect(delta.removed).toEqual(expect.arrayContaining([1n, 3n]));
+    expect(delta.added).toEqual([]);
+  });
+
+  it("footer 'Select all' honors an active Building facet (excludes no-building racks)", async () => {
+    // Building 7 has Alpha; there is also a no-building rack (Floating). With a
+    // Building facet pinned to this building the visible set drops Floating, and
+    // footer Select all must fetch the same effective request — not the raw
+    // scope that would sweep Floating back in.
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Floating", 0n, 42n)]);
+    mockListBuildings.mockImplementation(({ onSuccess }) => onSuccess?.([{ building: { id: 7n, name: "North" } }]));
+    const onConfirm = vi.fn();
+    renderModal({ onConfirm });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    // No facet: building 7 + no-building → both visible.
+    expect(screen.getByText("Floating")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    await userEvent.click(screen.getByTestId("nested-dropdown-filter-row-building"));
+    await userEvent.click(screen.getByTestId("filter-option-7"));
+    await waitFor(() => expect(screen.queryByText("Floating")).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }));
+    await waitFor(() => expect(screen.getByText("1 rack selected")).toBeInTheDocument());
+
+    const fetchAll = reqsMatching((r) => r.pageSize === undefined);
+    expect(fetchAll[fetchAll.length - 1]).toEqual(
+      expect.objectContaining({ buildingIds: [7n], includeNoBuilding: false }),
+    );
+
+    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
+    expect(onConfirm.mock.calls[0][0].added.map((a: { rackId: bigint }) => a.rackId)).toEqual([1n]);
+  });
+
+  it("treats a foreign Site facet as an empty assignable view and hides Select all (toggle off)", async () => {
+    // all-sites; a cross-site no-building rack (Faraway, site 99) exists. Picking
+    // a Site facet for a different site is unsatisfiable for the assignable set,
+    // so the view goes empty rather than surfacing Faraway as a disabled
+    // reassignment row — and footer Select all is hidden.
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Faraway", 0n, 99n)]);
+    mockListSites.mockImplementation(({ onSuccess }) =>
+      onSuccess?.([{ site: { id: 42n, name: "HQ" } }, { site: { id: 99n, name: "Remote" } }]),
+    );
+    renderModal({ allSites: true });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    await userEvent.click(screen.getByTestId("nested-dropdown-filter-row-site"));
+    await userEvent.click(screen.getByTestId("filter-option-99"));
+
+    await waitFor(() => expect(screen.queryByText("Alpha")).not.toBeInTheDocument());
+    expect(screen.queryByText("Faraway")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Select all" })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -78,18 +78,22 @@ const matchesReq = (rack: DeviceSet, req: FetchReq): boolean => {
 // pageToken (token = numeric offset as a string). No pageSize → return all
 // matches (the fetch-all path used by footer select-all).
 const setupListRacks = (all: DeviceSet[]) => {
-  mockListRacks.mockImplementation((req: FetchReq & { onSuccess?: Function; onError?: Function }) => {
-    const matched = all.filter((r) => matchesReq(r, req));
-    if (!req.pageSize) {
-      req.onSuccess?.(matched, "", matched.length);
-      return;
-    }
-    const offset = req.pageToken ? Number(req.pageToken) : 0;
-    const page = matched.slice(offset, offset + req.pageSize);
-    const nextOffset = offset + req.pageSize;
-    const nextToken = nextOffset < matched.length ? String(nextOffset) : "";
-    req.onSuccess?.(page, nextToken, matched.length);
-  });
+  mockListRacks.mockImplementation(
+    (req: FetchReq & { onSuccess?: Function; onError?: Function; onFinally?: Function }) => {
+      const matched = all.filter((r) => matchesReq(r, req));
+      if (!req.pageSize) {
+        req.onSuccess?.(matched, "", matched.length);
+        req.onFinally?.();
+        return;
+      }
+      const offset = req.pageToken ? Number(req.pageToken) : 0;
+      const page = matched.slice(offset, offset + req.pageSize);
+      const nextOffset = offset + req.pageSize;
+      const nextToken = nextOffset < matched.length ? String(nextOffset) : "";
+      req.onSuccess?.(page, nextToken, matched.length);
+      req.onFinally?.();
+    },
+  );
 };
 
 const SCOPE: SiteFilterFields = { siteIds: [42n], includeUnassigned: true };
@@ -471,5 +475,59 @@ describe("ManageRacksModal review fixes (#789)", () => {
     const call = mockListBuildings.mock.calls[mockListBuildings.mock.calls.length - 1][0];
     expect(call.siteIds).toEqual([]);
     expect(call.includeUnassigned).toBe(true);
+  });
+
+  it("clamps a multi-site Site facet to this building's site in assignable mode", async () => {
+    // Site facet = [thisSite 42, otherSite 99] with the toggle off. The request
+    // must intersect to [42] (not OR both), so a cross-site no-building rack
+    // (Faraway, site 99) never leaks into the assignable view.
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Faraway", 0n, 99n)]);
+    mockListSites.mockImplementation(({ onSuccess }) =>
+      onSuccess?.([{ site: { id: 42n, name: "HQ" } }, { site: { id: 99n, name: "Remote" } }]),
+    );
+    renderModal({ allSites: true });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    await userEvent.click(screen.getByTestId("nested-dropdown-filter-row-site"));
+    await userEvent.click(screen.getByTestId("filter-option-42"));
+    await userEvent.click(screen.getByTestId("filter-option-99"));
+
+    await waitFor(() => expect(lastRackReq().siteIds).toEqual([42n]));
+    expect(screen.queryByText("Faraway")).not.toBeInTheDocument();
+  });
+
+  it("disables Continue while a footer 'Select all' fetch is in flight", async () => {
+    const many = [createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Bravo", 7n, 42n)];
+    let resolveAll: (() => void) | undefined;
+    mockListRacks.mockImplementation((req: FetchReq & { onSuccess?: Function; onFinally?: Function }) => {
+      const matched = many.filter((r) => matchesReq(r, req));
+      if (!req.pageSize) {
+        // Defer the unpaginated select-all fetch so it stays in flight.
+        resolveAll = () => {
+          req.onSuccess?.(matched, "", matched.length);
+          req.onFinally?.();
+        };
+        return;
+      }
+      req.onSuccess?.(matched.slice(0, req.pageSize), "", matched.length);
+      req.onFinally?.();
+    });
+    const onConfirm = vi.fn();
+    renderModal({ onConfirm });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }));
+    const confirm = screen.getByTestId("manage-racks-modal-confirm");
+    expect(confirm).toBeDisabled();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    resolveAll!();
+    await waitFor(() => expect(screen.getByText("2 racks selected")).toBeInTheDocument());
+    expect(confirm).not.toBeDisabled();
+
+    await userEvent.click(confirm);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0].added).toHaveLength(2);
   });
 });

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -5,26 +5,38 @@ import userEvent from "@testing-library/user-event";
 
 import ManageRacksModal from "./ManageRacksModal";
 import { type RackSelectionDelta } from "./rackSelectionDelta";
-import { DeviceSetSchema, RackInfoSchema } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import {
+  type DeviceSet,
+  DeviceSetSchema,
+  RackInfoSchema,
+} from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import { type SiteFilterFields } from "@/protoFleet/components/PageHeader/SitePicker";
 
-// Assert the picker forwards its scope into the listRacks fetch (site scoping,
-// #758) and drives the "Show assigned racks" toggle (#766): default-off hides
-// already-placed racks, toggling on surfaces them and broadens the fetch to
-// `assignedScope`.
-// vi.hoisted so the handles exist when the hoisted vi.mock factories below run.
+// Part C (#765): ManageRacksModal fetches server-side — the toggle-off request
+// is pinned to the assignable set (this building + no-building racks), the
+// toggle-on request broadens to `assignedScope`, and Building/Site facets travel
+// on the request. There is NO client-side filtering of a fetched page, so these
+// tests drive a realistic mock that filters + paginates exactly like the server.
 const mockListRacks = vi.hoisted(() => vi.fn());
 const mockListBuildingsBySite = vi.hoisted(() => vi.fn());
+const mockListBuildings = vi.hoisted(() => vi.fn());
+const mockListSites = vi.hoisted(() => vi.fn());
 
 vi.mock("@/protoFleet/api/useDeviceSets", () => ({
   useDeviceSets: () => ({ listRacks: mockListRacks }),
 }));
 vi.mock("@/protoFleet/api/buildings", () => ({
-  useBuildings: () => ({ listBuildingsBySite: mockListBuildingsBySite }),
+  useBuildings: () => ({ listBuildingsBySite: mockListBuildingsBySite, listBuildings: mockListBuildings }),
+}));
+vi.mock("@/protoFleet/api/sites", () => ({
+  useSites: () => ({ listSites: mockListSites }),
+}));
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: () => true,
 }));
 
 // buildingId 7n is "this building"; a rack under building 9n (same site 42n) is
-// a reparent candidate ("In another building").
+// a reparent candidate ("In another building"). building 0n = no building.
 const createRack = (id: bigint, label: string, buildingId: bigint, siteId?: bigint, deviceCount = 0) =>
   create(DeviceSetSchema, {
     id,
@@ -36,12 +48,57 @@ const createRack = (id: bigint, label: string, buildingId: bigint, siteId?: bigi
     },
   });
 
+interface FetchReq {
+  siteIds: bigint[];
+  includeUnassigned: boolean;
+  buildingIds: bigint[];
+  includeNoBuilding: boolean;
+  pageSize?: number;
+  pageToken?: string;
+}
+
+// Server-equivalent match: site scope AND building scope, each null-permissive
+// via the include flags. Empty ids + false flag on a dimension = no filter on it.
+const matchesReq = (rack: DeviceSet, req: FetchReq): boolean => {
+  if (rack.typeDetails.case !== "rackInfo") return false;
+  const b = rack.typeDetails.value.buildingId ?? 0n;
+  const s = rack.typeDetails.value.siteId ?? 0n;
+  const siteOk =
+    req.siteIds.length === 0 && !req.includeUnassigned
+      ? true
+      : req.siteIds.includes(s) || (req.includeUnassigned && s === 0n);
+  const buildingOk =
+    req.buildingIds.length === 0 && !req.includeNoBuilding
+      ? true
+      : req.buildingIds.includes(b) || (req.includeNoBuilding && b === 0n);
+  return siteOk && buildingOk;
+};
+
+// Install a mock that filters `all` by the request and paginates by pageSize/
+// pageToken (token = numeric offset as a string). No pageSize → return all
+// matches (the fetch-all path used by footer select-all).
+const setupListRacks = (all: DeviceSet[]) => {
+  mockListRacks.mockImplementation((req: FetchReq & { onSuccess?: Function; onError?: Function }) => {
+    const matched = all.filter((r) => matchesReq(r, req));
+    if (!req.pageSize) {
+      req.onSuccess?.(matched, "", matched.length);
+      return;
+    }
+    const offset = req.pageToken ? Number(req.pageToken) : 0;
+    const page = matched.slice(offset, offset + req.pageSize);
+    const nextOffset = offset + req.pageSize;
+    const nextToken = nextOffset < matched.length ? String(nextOffset) : "";
+    req.onSuccess?.(page, nextToken, matched.length);
+  });
+};
+
 const SCOPE: SiteFilterFields = { siteIds: [42n], includeUnassigned: true };
 const ALL_SITES_ASSIGNED_SCOPE: SiteFilterFields = { siteIds: [], includeUnassigned: false };
 
 const renderModal = (overrides?: {
   scope?: SiteFilterFields;
   assignedScope?: SiteFilterFields;
+  allSites?: boolean;
   initialSelectedRackIds?: bigint[];
   onConfirm?: (delta: RackSelectionDelta) => void;
 }) =>
@@ -52,6 +109,7 @@ const renderModal = (overrides?: {
       currentBuildingId={7n}
       scope={overrides?.scope ?? SCOPE}
       assignedScope={overrides?.assignedScope ?? SCOPE}
+      allSites={overrides?.allSites ?? false}
       buildingName="North"
       initialSelectedRackIds={overrides?.initialSelectedRackIds ?? []}
       onDismiss={vi.fn()}
@@ -59,79 +117,81 @@ const renderModal = (overrides?: {
     />,
   );
 
-describe("ManageRacksModal fetch scoping", () => {
-  beforeEach(() => {
-    mockListRacks.mockReset();
-    mockListBuildingsBySite.mockReset();
-    // Resolve the building-label lookup with no rows so the effect settles.
-    mockListBuildingsBySite.mockImplementation(({ onSuccess }) => onSuccess?.([]));
-    mockListRacks.mockImplementation(({ onSuccess }) => onSuccess?.([]));
-  });
+const lastRackReq = (): FetchReq => mockListRacks.mock.calls[mockListRacks.mock.calls.length - 1][0];
+const reqsMatching = (pred: (r: FetchReq) => boolean): FetchReq[] =>
+  mockListRacks.mock.calls.map((c) => c[0]).filter(pred);
 
-  it("passes the scope's siteIds/includeUnassigned into listRacks", async () => {
+beforeEach(() => {
+  mockListRacks.mockReset();
+  mockListBuildingsBySite.mockReset();
+  mockListBuildings.mockReset();
+  mockListSites.mockReset();
+  mockListBuildingsBySite.mockImplementation(({ onSuccess }) => onSuccess?.([]));
+  mockListBuildings.mockImplementation(({ onSuccess }) => onSuccess?.([]));
+  mockListSites.mockImplementation(({ onSuccess }) => onSuccess?.([]));
+  setupListRacks([]);
+});
+
+describe("ManageRacksModal fetch scoping (server-side)", () => {
+  it("pins the toggle-off request to the assignable set (site scope + this building + no-building)", async () => {
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n)]);
     renderModal();
-    await waitFor(() => expect(mockListRacks).toHaveBeenCalled());
-    expect(mockListRacks).toHaveBeenCalledWith(expect.objectContaining({ siteIds: [42n], includeUnassigned: true }));
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    const req = lastRackReq();
+    expect(req.siteIds).toEqual([42n]);
+    expect(req.includeUnassigned).toBe(true);
+    expect(req.buildingIds).toEqual([7n]);
+    expect(req.includeNoBuilding).toBe(true);
+    expect(req.pageSize).toBe(50);
   });
 
   it("forwards a site-unassigned scope unchanged (no whole-org fallback)", async () => {
     renderModal({ scope: { siteIds: [], includeUnassigned: true } });
     await waitFor(() => expect(mockListRacks).toHaveBeenCalled());
-    const arg = mockListRacks.mock.calls[0][0];
-    expect(arg.siteIds).toEqual([]);
-    expect(arg.includeUnassigned).toBe(true);
+    const req = lastRackReq();
+    expect(req.siteIds).toEqual([]);
+    expect(req.includeUnassigned).toBe(true);
+    // Still pinned to this building so other-building racks never leak.
+    expect(req.buildingIds).toEqual([7n]);
   });
 });
 
-describe("ManageRacksModal show-assigned toggle", () => {
+describe("ManageRacksModal show-assigned toggle (server-side)", () => {
   beforeEach(() => {
-    mockListRacks.mockReset();
-    mockListBuildingsBySite.mockReset();
-    mockListBuildingsBySite.mockImplementation(({ onSuccess }) => onSuccess?.([]));
-    // Both an eligible rack (this building) and a reparent candidate (another
-    // building, same site) come back on every fetch; the toggle governs which
-    // are shown, not the fetch.
-    mockListRacks.mockImplementation(({ onSuccess }) =>
-      onSuccess?.([createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Beta", 9n, 42n, 5)]),
-    );
+    // Alpha is eligible (this building); Beta is a reparent candidate (another
+    // building, same site). The server (mock) decides which are returned.
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Beta", 9n, 42n, 5)]);
   });
 
-  it("hides already-placed racks by default and surfaces them when toggled on", async () => {
+  it("excludes already-placed racks from the toggle-off fetch and surfaces them when toggled on", async () => {
     renderModal();
     await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
-    // Default off: the reparent candidate is hidden.
+    // Default off: Beta was excluded server-side (building 9 ∉ {7, none}).
     expect(screen.queryByText("Beta")).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByLabelText("Show assigned racks"));
-    // Toggled on: it surfaces.
     await waitFor(() => expect(screen.getByText("Beta")).toBeInTheDocument());
     expect(screen.getByText("Alpha")).toBeInTheDocument();
   });
 
-  it("broadens the fetch to assignedScope when toggled on (all-sites → global)", async () => {
+  it("drops the building pin and broadens to assignedScope when toggled on (all-sites → global)", async () => {
     renderModal({ scope: SCOPE, assignedScope: ALL_SITES_ASSIGNED_SCOPE });
-    await waitFor(() => expect(mockListRacks).toHaveBeenCalled());
-    // Default fetch uses the site scope.
-    expect(mockListRacks.mock.calls[0][0]).toEqual(
-      expect.objectContaining({ siteIds: [42n], includeUnassigned: true }),
-    );
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    expect(lastRackReq()).toEqual(expect.objectContaining({ siteIds: [42n], buildingIds: [7n] }));
 
     await userEvent.click(screen.getByLabelText("Show assigned racks"));
-    // Toggle-on fetch broadens to the global assignedScope.
-    await waitFor(() =>
-      expect(mockListRacks).toHaveBeenCalledWith(expect.objectContaining({ siteIds: [], includeUnassigned: false })),
-    );
+    await waitFor(() => expect(screen.getByText("Beta")).toBeInTheDocument());
+    const req = lastRackReq();
+    expect(req.siteIds).toEqual([]);
+    expect(req.includeUnassigned).toBe(false);
+    expect(req.buildingIds).toEqual([]);
+    expect(req.includeNoBuilding).toBe(false);
   });
 
-  // Rows sort alphabetically, so body checkbox 0 = Alpha (eligible), 1 = Beta
-  // (reparent candidate).
   const rowCheckbox = (index: number) =>
     screen.getByTestId("list-body").querySelectorAll<HTMLInputElement>("input[type='checkbox']")[index];
 
   it("header select-all selects the whole page including reparent rows and reports them in reassigned", async () => {
-    // The in-table header "select all" selects every row on the page, reparent
-    // candidates included — matches MinerSelectionList. Reparenting is gated by
-    // the confirm the host shows on Continue, not by excluding the row here.
     const onConfirm = vi.fn();
     renderModal({ onConfirm });
     await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
@@ -147,31 +207,7 @@ describe("ManageRacksModal show-assigned toggle", () => {
     expect(delta.reassigned).toEqual([{ rackId: 2n, label: "Beta", minerCount: 5 }]);
   });
 
-  it("header deselect clears the whole page including reparent picks", async () => {
-    // Pick the reparent row and the eligible row so the header reads "checked",
-    // then click it to clear the page. Both picks clear — nothing is stranded.
-    const onConfirm = vi.fn();
-    renderModal({ onConfirm });
-    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
-    await userEvent.click(screen.getByLabelText("Show assigned racks"));
-    await waitFor(() => expect(screen.getByText("Beta")).toBeInTheDocument());
-
-    await userEvent.click(rowCheckbox(1)); // reparent pick (Beta)
-    await userEvent.click(rowCheckbox(0)); // eligible pick (Alpha) → header now checked
-    const selectAll = screen.getByTestId("select-all-checkbox").querySelector("input")!;
-    await userEvent.click(selectAll); // header checked → this clears the page
-    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
-
-    const delta = onConfirm.mock.calls[0][0];
-    expect(delta.reassigned).toEqual([]);
-    expect(delta.added).toEqual([]);
-  });
-
   it("hides the footer 'Select all' while assigned racks are shown, and restores it when hidden", async () => {
-    // The footer "Select all" (all pages) must not sweep reparent rows, so it is
-    // dropped while the toggle surfaces them — matches MinerSelectionList. The
-    // in-table header checkbox remains the only page-level bulk gesture, and its
-    // reparent picks are gated by the Continue confirm.
     renderModal();
     await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: "Select all" })).toBeInTheDocument();
@@ -192,42 +228,13 @@ describe("ManageRacksModal show-assigned toggle", () => {
     await userEvent.click(screen.getByLabelText("Show assigned racks"));
     await waitFor(() => expect(screen.getByText("Beta")).toBeInTheDocument());
 
-    // Explicit per-row pick of the reparent candidate is allowed...
-    await userEvent.click(rowCheckbox(1));
-    // ...but toggling off hides it and must not leave it silently selected.
-    await userEvent.click(screen.getByLabelText("Show assigned racks"));
+    await userEvent.click(rowCheckbox(1)); // reparent pick (Beta)
+    await userEvent.click(screen.getByLabelText("Show assigned racks")); // toggle off
     await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
 
     const delta = onConfirm.mock.calls[0][0];
     expect(delta.reassigned).toEqual([]);
     expect(delta.added.map((a: { rackId: bigint }) => a.rackId)).not.toContain(2n);
-  });
-
-  it("recovers when the broadened (toggle-on) fetch fails", async () => {
-    // The eligible scoped fetch succeeds; toggling on broadens to a global scope
-    // whose fetch fails. The failure must not strand the operator behind a full-
-    // modal error that hides the Switch — the toggle reverts, the already-loaded
-    // eligible racks stay, and the picker remains usable.
-    mockListRacks.mockReset();
-    mockListRacks.mockImplementation(({ siteIds, onSuccess, onError }) => {
-      if (siteIds.length === 0) {
-        onError?.("network down");
-      } else {
-        onSuccess?.([createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Beta", 9n, 42n, 5)]);
-      }
-    });
-
-    renderModal({ scope: SCOPE, assignedScope: ALL_SITES_ASSIGNED_SCOPE });
-    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
-
-    await userEvent.click(screen.getByLabelText("Show assigned racks"));
-
-    // No blocking error state, the Switch survives, and the toggle is back off.
-    await waitFor(() => expect(screen.getByLabelText("Show assigned racks")).not.toBeChecked());
-    expect(screen.queryByTestId("manage-racks-modal-error")).not.toBeInTheDocument();
-    expect(screen.getByText("Alpha")).toBeInTheDocument();
-    // The ineligible rack never surfaced (broadened fetch failed).
-    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
   });
 
   it("allows an explicit single per-row reparent pick through the delta", async () => {
@@ -244,28 +251,139 @@ describe("ManageRacksModal show-assigned toggle", () => {
     expect(delta.reassigned).toEqual([{ rackId: 2n, label: "Beta", minerCount: 5 }]);
   });
 
-  it("treats a seeded reparent as in-this-building and never drops it on toggle-off", async () => {
-    // Reopen after staging a reparent: Beta is in the working set (seeded) but
-    // its server row still reports building 9n. It must render "In this building"
-    // (visible with the toggle OFF, no warning) and survive a toggle on→off — the
-    // path that strips reassignment picks — without being reported as removed.
-    const onConfirm = vi.fn();
-    renderModal({ initialSelectedRackIds: [2n], onConfirm });
-    await waitFor(() => expect(screen.getByText("Beta")).toBeInTheDocument());
-    // Default toggle-off view shows Beta (not hidden as a reassignment row);
-    // both Alpha and the seeded Beta now read "In this building", and nothing
-    // reads "In another building".
-    expect(screen.getAllByText("In this building")).toHaveLength(2);
-    expect(screen.queryByText("In another building")).not.toBeInTheDocument();
+  it("recovers when the broadened (toggle-on) fetch fails", async () => {
+    // The scoped fetch succeeds; the broadened all-sites fetch (siteIds empty)
+    // fails. The failure must revert the toggle, keep the picker usable, and not
+    // strand the operator behind the blocking error state.
+    mockListRacks.mockImplementation((req: FetchReq & { onSuccess?: Function; onError?: Function }) => {
+      if (req.siteIds.length === 0) {
+        req.onError?.("network down");
+        return;
+      }
+      req.onSuccess?.([createRack(1n, "Alpha", 7n, 42n)], "", 1);
+    });
 
-    // Toggle on then off — the reassignment-stripping path — must not drop it.
+    renderModal({ scope: SCOPE, assignedScope: ALL_SITES_ASSIGNED_SCOPE });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
     await userEvent.click(screen.getByLabelText("Show assigned racks"));
-    await userEvent.click(screen.getByLabelText("Show assigned racks"));
+
+    await waitFor(() => expect(screen.getByLabelText("Show assigned racks")).not.toBeChecked());
+    expect(screen.queryByTestId("manage-racks-modal-error")).not.toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
+  });
+
+  it("never reports a seeded rack absent from the fetch as removed", async () => {
+    // A seeded rack (id 3) that the eligibility-pinned fetch doesn't return
+    // (paging gap / soft-delete window) must be left alone, not unassigned.
+    const onConfirm = vi.fn();
+    renderModal({ initialSelectedRackIds: [1n, 3n], onConfirm });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
     await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
 
     const delta = onConfirm.mock.calls[0][0];
     expect(delta.removed).toEqual([]);
-    expect(delta.reassigned).toEqual([]);
     expect(delta.added).toEqual([]);
+  });
+});
+
+describe("ManageRacksModal facets → request (server-side)", () => {
+  it("translates a Building facet into buildingIds on the request", async () => {
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Beta", 9n, 42n, 5)]);
+    mockListBuildings.mockImplementation(({ onSuccess }) =>
+      onSuccess?.([{ building: { id: 7n, name: "North" } }, { building: { id: 9n, name: "South" } }]),
+    );
+    renderModal();
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    // Show assigned so the Building facet narrows a cross-building set.
+    await userEvent.click(screen.getByLabelText("Show assigned racks"));
+    await waitFor(() => expect(screen.getByText("Beta")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    await userEvent.click(screen.getByTestId("nested-dropdown-filter-row-building"));
+    await userEvent.click(screen.getByTestId("filter-option-9")); // building 9 = "South"
+
+    await waitFor(() => {
+      const req = lastRackReq();
+      expect(req.buildingIds).toEqual([9n]);
+    });
+  });
+
+  it("offers the Site facet only when the header is all-sites", async () => {
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n)]);
+    const { unmount } = renderModal({ allSites: false });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    expect(screen.getByTestId("nested-dropdown-filter-row-building")).toBeInTheDocument();
+    expect(screen.queryByTestId("nested-dropdown-filter-row-site")).not.toBeInTheDocument();
+    unmount();
+
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n)]);
+    renderModal({ allSites: true });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    expect(screen.getByTestId("nested-dropdown-filter-row-site")).toBeInTheDocument();
+  });
+
+  it("translates a Site facet into siteIds on the request", async () => {
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n), createRack(3n, "Gamma", 5n, 99n)]);
+    mockListSites.mockImplementation(({ onSuccess }) =>
+      onSuccess?.([{ site: { id: 42n, name: "HQ" } }, { site: { id: 99n, name: "Remote" } }]),
+    );
+    renderModal({ allSites: true, assignedScope: ALL_SITES_ASSIGNED_SCOPE });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    await userEvent.click(screen.getByLabelText("Show assigned racks"));
+
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    await userEvent.click(screen.getByTestId("nested-dropdown-filter-row-site"));
+    await userEvent.click(screen.getByTestId("filter-option-99")); // site 99 = "Remote"
+
+    await waitFor(() => expect(lastRackReq().siteIds).toEqual([99n]));
+  });
+});
+
+describe("ManageRacksModal server-side pagination", () => {
+  it("pages through results, carrying the scope across pages, with a server total", async () => {
+    // 60 eligible racks (this building) → two pages of 50 + 10.
+    const many = Array.from({ length: 60 }, (_, i) =>
+      createRack(BigInt(i + 1), `Rack ${String(i).padStart(2, "0")}`, 7n, 42n),
+    );
+    setupListRacks(many);
+    renderModal();
+    await waitFor(() => expect(screen.getByText("Showing 1–50 of 60 racks")).toBeInTheDocument());
+    expect(lastRackReq().pageToken ?? "").toBe("");
+
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await waitFor(() => expect(screen.getByText("Showing 51–60 of 60 racks")).toBeInTheDocument());
+    // Page 2 carried the same scope (facet correctness across pages).
+    const page2 = lastRackReq();
+    expect(page2.pageToken).toBe("50");
+    expect(page2.siteIds).toEqual([42n]);
+    expect(page2.buildingIds).toEqual([7n]);
+
+    await userEvent.click(screen.getByRole("button", { name: "Previous page" }));
+    await waitFor(() => expect(screen.getByText("Showing 1–50 of 60 racks")).toBeInTheDocument());
+  });
+
+  it("footer 'Select all' fetches every eligible rack across pages, not just the current page", async () => {
+    const many = Array.from({ length: 60 }, (_, i) =>
+      createRack(BigInt(i + 1), `Rack ${String(i).padStart(2, "0")}`, 7n, 42n),
+    );
+    setupListRacks(many);
+    const onConfirm = vi.fn();
+    renderModal({ onConfirm });
+    await waitFor(() => expect(screen.getByText("Showing 1–50 of 60 racks")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }));
+    await waitFor(() => expect(screen.getByText("60 racks selected")).toBeInTheDocument());
+
+    // The select-all fetch is unpaginated (no pageSize) over the eligible filter.
+    const fetchAll = reqsMatching((r) => r.pageSize === undefined);
+    expect(fetchAll.length).toBeGreaterThan(0);
+    expect(fetchAll[fetchAll.length - 1].buildingIds).toEqual([7n]);
+
+    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
+    expect(onConfirm.mock.calls[0][0].added).toHaveLength(60);
   });
 });

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -459,4 +459,17 @@ describe("ManageRacksModal review fixes (#789)", () => {
     expect(screen.queryByText("Faraway")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Select all" })).not.toBeInTheDocument();
   });
+
+  it("scopes Building facet options to the rack scope (no org-wide leak for a site-unassigned building)", async () => {
+    // scope.siteIds empty + includeUnassigned true (a site-unassigned building).
+    // The options fetch must carry includeUnassigned, not fall through to the
+    // org-wide list (empty siteIds + false) that would offer every site's
+    // buildings.
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n)]);
+    renderModal({ scope: { siteIds: [], includeUnassigned: true }, allSites: false });
+    await waitFor(() => expect(mockListBuildings).toHaveBeenCalled());
+    const call = mockListBuildings.mock.calls[mockListBuildings.mock.calls.length - 1][0];
+    expect(call.siteIds).toEqual([]);
+    expect(call.includeUnassigned).toBe(true);
+  });
 });

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -612,4 +612,47 @@ describe("ManageRacksModal review fixes (#789)", () => {
     await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
     expect(onConfirm.mock.calls[0][0].added).toEqual([]);
   });
+
+  it("renders a filter chip when facing the current building (chip state is controlled by facets)", async () => {
+    // Bug: filtering by the building being edited produced no chip because the
+    // List remounts on every refetch (displayItems → undefined), wiping the
+    // Filters-internal chip state. The chip is now driven by facet state.
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n)]);
+    mockListBuildings.mockImplementation(({ onSuccess }) => onSuccess?.([{ building: { id: 7n, name: "North" } }]));
+    renderModal();
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    await userEvent.click(screen.getByTestId("nested-dropdown-filter-row-building"));
+    await userEvent.click(screen.getByTestId("filter-option-7")); // building 7 = this building
+
+    await waitFor(() => expect(screen.getByTestId("active-filter-building")).toBeInTheDocument());
+    expect(lastRackReq().buildingIds).toEqual([7n]);
+  });
+
+  it("keeps the Building filter chip (and its effect) across the Show assigned toggle", async () => {
+    // Bug: a foreign-building chip (building 9, current 7) was cleared when
+    // toggling Show assigned, and re-applying the facet did nothing. The chip
+    // must survive the toggle and keep narrowing the (now assignable) fetch.
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Beta", 9n, 42n, 5)]);
+    mockListBuildings.mockImplementation(({ onSuccess }) =>
+      onSuccess?.([{ building: { id: 7n, name: "North" } }, { building: { id: 9n, name: "South" } }]),
+    );
+    renderModal();
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    // Facet a foreign building while the toggle is off: view is a placement
+    // conflict (empty) but the chip must still render.
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    await userEvent.click(screen.getByTestId("nested-dropdown-filter-row-building"));
+    await userEvent.click(screen.getByTestId("filter-option-9"));
+    await waitFor(() => expect(screen.getByTestId("active-filter-building")).toBeInTheDocument());
+
+    // Toggling Show assigned must NOT clear the chip, and the facet must keep
+    // constraining the request to building 9.
+    await userEvent.click(screen.getByLabelText("Show assigned racks"));
+    await waitFor(() => expect(screen.getByText("Beta")).toBeInTheDocument());
+    expect(screen.getByTestId("active-filter-building")).toBeInTheDocument();
+    expect(lastRackReq().buildingIds).toEqual([9n]);
+  });
 });

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -580,4 +580,36 @@ describe("ManageRacksModal review fixes (#789)", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(onConfirm.mock.calls[0][0].removed).toEqual([1n]);
   });
+
+  it("ignores a stale footer 'Select all' completion after Select none", async () => {
+    // Select all is slow; the operator clicks Select none before it resolves.
+    // The late completion must not silently re-select the bulk result.
+    const many = [createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Bravo", 7n, 42n)];
+    let resolveAll: (() => void) | undefined;
+    mockListRacks.mockImplementation((req: FetchReq & { onSuccess?: Function; onFinally?: Function }) => {
+      const matched = many.filter((r) => matchesReq(r, req));
+      if (!req.pageSize) {
+        resolveAll = () => {
+          req.onSuccess?.(matched, "", matched.length);
+          req.onFinally?.();
+        };
+        return;
+      }
+      req.onSuccess?.(matched.slice(0, req.pageSize), "", matched.length);
+      req.onFinally?.();
+    });
+    const onConfirm = vi.fn();
+    renderModal({ onConfirm });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }));
+    await userEvent.click(screen.getByRole("button", { name: "Select none" }));
+    // Stale bulk-select completion resolves now.
+    resolveAll!();
+    await waitFor(() => expect(screen.getByTestId("manage-racks-modal-confirm")).not.toBeDisabled());
+    expect(screen.getByText("0 racks selected")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
+    expect(onConfirm.mock.calls[0][0].added).toEqual([]);
+  });
 });

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -530,4 +530,54 @@ describe("ManageRacksModal review fixes (#789)", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(onConfirm.mock.calls[0][0].added).toHaveLength(2);
   });
+
+  it("keeps a selected rack's addition across a request reset that hides it", async () => {
+    // Check a non-seeded rack, then apply a Building facet that filters it out.
+    // selectedItems retains the id; its addition must still be reported on
+    // Continue (not silently dropped because the reset rebuilt the accumulator).
+    const rowCheckbox = (index: number) =>
+      screen.getByTestId("list-body").querySelectorAll<HTMLInputElement>("input[type='checkbox']")[index];
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Floating", 0n, 42n)]);
+    mockListBuildings.mockImplementation(({ onSuccess }) => onSuccess?.([{ building: { id: 7n, name: "North" } }]));
+    const onConfirm = vi.fn();
+    renderModal({ onConfirm });
+    await waitFor(() => expect(screen.getByText("Floating")).toBeInTheDocument());
+
+    // Select the no-building rack, then filter to building 7 (hides it).
+    await userEvent.click(rowCheckbox(1));
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    await userEvent.click(screen.getByTestId("nested-dropdown-filter-row-building"));
+    await userEvent.click(screen.getByTestId("filter-option-7"));
+    await waitFor(() => expect(screen.queryByText("Floating")).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
+    const delta = onConfirm.mock.calls[0][0];
+    expect(delta.added.map((a: { rackId: bigint; label: string }) => a.rackId)).toContain(2n);
+    expect(delta.added.find((a: { rackId: bigint; label: string }) => a.rackId === 2n).label).toBe("Floating");
+  });
+
+  it("lets Continue proceed (Select none → remove) under a placement-facet conflict", async () => {
+    // Under a conflicting Building facet the view is empty and no fetch runs
+    // (pageItems stays undefined). Continue must still work so the operator can
+    // Select none and remove the seeded racks.
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n)]);
+    mockListBuildings.mockImplementation(({ onSuccess }) =>
+      onSuccess?.([{ building: { id: 7n, name: "North" } }, { building: { id: 9n, name: "South" } }]),
+    );
+    const onConfirm = vi.fn();
+    renderModal({ initialSelectedRackIds: [1n], onConfirm });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    // Conflict: facet a different building than this one.
+    await userEvent.click(screen.getByTestId("filter-nested-filters-meta"));
+    await userEvent.click(screen.getByTestId("nested-dropdown-filter-row-building"));
+    await userEvent.click(screen.getByTestId("filter-option-9"));
+    await waitFor(() => expect(screen.queryByText("Alpha")).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "Select none" }));
+    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0].removed).toEqual([1n]);
+  });
 });

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -520,11 +520,14 @@ describe("ManageRacksModal review fixes (#789)", () => {
     await userEvent.click(screen.getByRole("button", { name: "Select all" }));
     const confirm = screen.getByTestId("manage-racks-modal-confirm");
     expect(confirm).toBeDisabled();
+    // Select all is disabled while its fetch is in flight (no duplicate clicks).
+    expect(screen.getByRole("button", { name: "Select all" })).toBeDisabled();
     expect(onConfirm).not.toHaveBeenCalled();
 
     resolveAll!();
     await waitFor(() => expect(screen.getByText("2 racks selected")).toBeInTheDocument());
     expect(confirm).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Select all" })).not.toBeDisabled();
 
     await userEvent.click(confirm);
     expect(onConfirm).toHaveBeenCalledTimes(1);
@@ -659,10 +662,11 @@ describe("ManageRacksModal review fixes (#789)", () => {
     expect(lastRackReq().pageToken).toBe("50");
   });
 
-  it("ignores a superseded Select all finalizer (Continue stays disabled until the latest resolves)", async () => {
-    // Two footer Select alls in flight: the slower (superseded) one finishing
-    // first must not re-enable Continue while the newer bulk fetch is pending —
-    // otherwise Continue could commit the stale selection.
+  it("a superseded Select all (cancel → restart) doesn't re-enable Continue until the latest resolves", async () => {
+    // Select all is disabled while running, but a cancel (row toggle) re-enables
+    // it — so a cancel-then-restart can still put two bulk fetches in flight. The
+    // slower (superseded) one finishing first must not re-enable Continue while
+    // the newer fetch is pending, or Continue could commit the stale selection.
     const many = [createRack(1n, "Alpha", 7n, 42n), createRack(2n, "Bravo", 7n, 42n)];
     const pendingAll: Array<() => void> = [];
     mockListRacks.mockImplementation((req: FetchReq & { onSuccess?: Function; onFinally?: Function }) => {
@@ -680,10 +684,20 @@ describe("ManageRacksModal review fixes (#789)", () => {
     renderModal();
     await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
 
-    const selectAll = screen.getByRole("button", { name: "Select all" });
-    await userEvent.click(selectAll); // fetch #1
-    await userEvent.click(selectAll); // fetch #2 supersedes #1
     const confirm = screen.getByTestId("manage-racks-modal-confirm");
+    const rowCheckbox = (i: number) =>
+      screen.getByTestId("list-body").querySelectorAll<HTMLInputElement>("input[type='checkbox']")[i];
+
+    // Fetch #1 in flight; Select all is disabled while it runs.
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }));
+    expect(screen.getByRole("button", { name: "Select all" })).toBeDisabled();
+
+    // A row toggle cancels it — Select all re-enables and Continue is usable.
+    await userEvent.click(rowCheckbox(0));
+    expect(screen.getByRole("button", { name: "Select all" })).not.toBeDisabled();
+
+    // Restart: fetch #2 in flight, Continue disabled again.
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }));
     expect(confirm).toBeDisabled();
 
     // The superseded fetch #1 finalizes first: Continue must stay disabled.

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -225,6 +225,8 @@ const ManageRacksModal = ({
   showAssignedRef.current = showAssigned;
   const buildingMapRef = useRef(buildingMap);
   buildingMapRef.current = buildingMap;
+  const selectedItemsRef = useRef(selectedItems);
+  selectedItemsRef.current = selectedItems;
 
   // Building-label lookup for the Building column (this building's site).
   useEffect(() => {
@@ -314,10 +316,23 @@ const ManageRacksModal = ({
   // report a removal).
   useEffect(() => {
     pageTokensRef.current = [""];
+    const prev = accumulatorRef.current;
     const acc = new Map<string, RackPickerItem>();
+    // Carry over the resolved item for every still-selected rack, so a selection
+    // the new request hides (e.g. check a rack, then apply a facet that filters
+    // it out) keeps its metadata. selectedItems retains the id via
+    // preserveOffPageSelection, so without this its addition would be silently
+    // dropped from the delta (absent from the accumulator) while the footer still
+    // shows it selected.
+    for (const id of selectedItemsRef.current) {
+      const existing = prev.get(id);
+      if (existing) acc.set(id, existing);
+    }
     for (const id of initialSelectedRackIds) {
-      acc.set(id.toString(), {
-        id: id.toString(),
+      const key = id.toString();
+      if (acc.has(key)) continue;
+      acc.set(key, {
+        id: key,
         label: "",
         buildingLabel: "—",
         statusLabel: "",
@@ -503,13 +518,17 @@ const ManageRacksModal = ({
   }, [showAssigned]);
 
   const handleConfirm = useCallback(() => {
-    // Guard against confirming mid-load: while the initial page hasn't arrived
-    // (undefined) or a footer "Select all" fetch is still in flight, the
-    // selection/accumulator aren't final, so committing would drop the pending
-    // additions. The Continue button is also disabled in these states.
-    if (pageItems === undefined || selectingAll) return;
+    // Guard against confirming mid-load: while a footer "Select all" fetch is in
+    // flight the selection/accumulator aren't final, so committing would drop the
+    // pending additions (Continue is also disabled then). A placement-facet
+    // conflict is a *loaded* empty view (no fetch runs, so pageItems stays
+    // undefined) — Continue must still work there so Select-none-then-Continue
+    // can clear the current racks; the accumulator holds the seeds + preserved
+    // selections needed for the delta.
+    if (selectingAll) return;
+    if (pageItems === undefined && !placementFacetConflict) return;
     onConfirm(computeRackSelectionDelta([...accumulatorRef.current.values()], initialSelectedRackIds, selectedItems));
-  }, [pageItems, selectingAll, selectedItems, initialSelectedRackIds, onConfirm]);
+  }, [pageItems, placementFacetConflict, selectingAll, selectedItems, initialSelectedRackIds, onConfirm]);
 
   // Footer "Select all" (offered only with the toggle off — see below) selects
   // every ELIGIBLE rack across all pages, not just the visible page. Server

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -235,16 +235,12 @@ const ManageRacksModal = ({
   const selectedItemsRef = useRef(selectedItems);
   selectedItemsRef.current = selectedItems;
   // Monotonic epoch that invalidates an in-flight footer "Select all": bumped by
-  // any newer selection or request change, so a slow bulk-select completion that
-  // lands after the operator has moved on (Select none, a row toggle, a filter)
-  // is ignored instead of silently re-selecting the stale result.
+  // any newer selection or request change, which also clears `selectingAll` (see
+  // the cancellation paths below). Both the result handler and the finalizer are
+  // gated on it, so a slow bulk-select completion that lands after the operator
+  // has moved on (Select none, a row toggle, a filter) neither re-selects the
+  // stale result nor re-enables Continue while a newer fetch is still pending.
   const selectAllEpochRef = useRef(0);
-  // Distinct from the epoch above: identifies a specific footer "Select all"
-  // *fetch* so its finalizer clears `selectingAll` only when it is still the
-  // latest bulk fetch. The epoch is bumped by any selection change (a row
-  // toggle, Select none), which must NOT strand `selectingAll` true — so the
-  // finalizer keys off this fetch id, not the epoch.
-  const selectAllFetchIdRef = useRef(0);
 
   // Building-label lookup for the Building column (this building's site).
   useEffect(() => {
@@ -371,6 +367,10 @@ const ManageRacksModal = ({
     setNextPageToken("");
     setTotalCount(0);
     setPageLoading(false);
+    // A request change cancels an in-flight select-all (epoch bumped above), so
+    // drop its loading state too — else Continue would stay disabled against the
+    // new, unrelated request.
+    setSelectingAll(false);
     /* eslint-enable react-hooks/set-state-in-effect */
   }, [requestKey, initialSelectedRackIds]);
 
@@ -586,7 +586,6 @@ const ManageRacksModal = ({
   const handleSelectAll = useCallback(() => {
     const req = requestRef.current;
     const epoch = (selectAllEpochRef.current += 1);
-    const fetchId = (selectAllFetchIdRef.current += 1);
     setSelectingAll(true);
     void listRacks({
       siteIds: req.siteIds,
@@ -612,25 +611,30 @@ const ManageRacksModal = ({
         pushToast({ message: `Couldn't select all racks: ${msg}`, status: STATUSES.error });
       },
       onFinally: () => {
-        // Clear the loading state only if this is still the latest bulk fetch.
-        // A superseded (slower) Select all finishing after a newer one must not
-        // re-enable Continue while the newer bulk result is still pending — that
-        // would let Continue commit the stale selection.
-        if (selectAllFetchIdRef.current !== fetchId) return;
+        // Only the latest bulk fetch clears the loading state. A cancellation
+        // (row toggle / Select none / filter) already cleared `selectingAll` and
+        // bumped the epoch, and a superseded fetch (cancel → restart) fails this
+        // check too — so a slower earlier fetch can't re-enable Continue while a
+        // newer one is still pending.
+        if (selectAllEpochRef.current !== epoch) return;
         setSelectingAll(false);
       },
     });
   }, [listRacks, currentBuildingId, siteId, seededRackIds]);
 
   // Wraps the List's selection setter so any manual selection change (row
-  // toggle, page header checkbox) invalidates an in-flight footer select-all.
+  // toggle, page header checkbox) cancels an in-flight footer select-all: bump
+  // the epoch (its result/finalizer are then ignored) and drop the loading state
+  // so the operator's manual selection takes over immediately.
   const handleSelectionChange = useCallback((value: string[] | ((prev: string[]) => string[])) => {
     selectAllEpochRef.current += 1;
+    setSelectingAll(false);
     setSelectedItems(value);
   }, []);
 
   const handleSelectNone = useCallback(() => {
     selectAllEpochRef.current += 1;
+    setSelectingAll(false);
     setSelectedItems([]);
   }, []);
 
@@ -755,6 +759,9 @@ const ManageRacksModal = ({
                 // gated by the reparent confirm on Continue.
                 onSelectAll={showAssigned || placementFacetConflict ? undefined : handleSelectAll}
                 onSelectNone={handleSelectNone}
+                // Prevent duplicate/overlapping bulk fetches while one is in
+                // flight. Select none stays live and doubles as cancel.
+                selectAllDisabled={selectingAll}
               />
             </div>
           </>

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -3,12 +3,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { buildRackPickerItem, describeRackReassignment, type RackPickerItem } from "../rackPickerItem";
 import { computeRackSelectionDelta, type RackSelectionDelta } from "./rackSelectionDelta";
 import { useBuildings } from "@/protoFleet/api/buildings";
+import { useSites } from "@/protoFleet/api/sites";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import { type SiteFilterFields } from "@/protoFleet/components/PageHeader/SitePicker";
-import { Alert, ChevronDown, Info } from "@/shared/assets/icons";
+import { useHasPermission } from "@/protoFleet/store";
+import { Alert, ChevronDown, Info, Plus } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Dialog from "@/shared/components/Dialog";
 import List from "@/shared/components/List";
+import type { ActiveFilters, FilterItem, NestedFilterChildItem } from "@/shared/components/List/Filters/types";
 import type { ColConfig, ColTitles } from "@/shared/components/List/types";
 import Modal, { ModalSelectAllFooter } from "@/shared/components/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular";
@@ -22,37 +25,34 @@ interface ManageRacksModalProps {
   // Parent building context drives the eligibility split.
   siteId: bigint;
   currentBuildingId: bigint;
-  // Rack-fetch scope, derived from the building's own site (see
-  // buildingRackScope) — NOT the header SitePicker. Governs which racks are
-  // *fetched*: the building's site + site-unassigned. There is no "all sites"
-  // fallback; the fetch is always scoped. Per-row eligibility is still
-  // computed against `siteId`.
+  // Assignable-only fetch scope, derived from the building's own site (see
+  // buildingRackScope) — NOT the header SitePicker. Used while "Show assigned
+  // racks" is OFF: the building's site + site-unassigned. Per-row eligibility is
+  // still computed against `siteId`.
   scope: SiteFilterFields;
   // Broadened fetch scope used while "Show assigned racks" is ON, so
   // already-placed (ineligible) racks surface for reparenting. All-sites header
-  // → global fetch (cross-site racks); scoped header → same as `scope` (the
-  // site scope already covers other-building same-site racks — the toggle just
-  // stops hiding them). See assignedRackScope.
+  // → global fetch (cross-site racks); scoped header → same as `scope`. See
+  // assignedRackScope.
   assignedScope: SiteFilterFields;
+  // True when the header SitePicker is on "all sites". Gates the Site facet
+  // (offered only when the fetch can span sites), mirroring the miner picker's
+  // `showSiteFilter: !scope`.
+  allSites: boolean;
   buildingName: string;
   // Rack IDs currently in the building's working set. The modal seeds its
   // selection with these so the operator sees the current state and can
   // add / remove in one flow.
   initialSelectedRackIds: bigint[];
   onDismiss: () => void;
-  // Returns the delta against initialSelectedRackIds: `added` is the
-  // newly-checked racks (rackId + label so the caller can render
-  // without a separate lookup); `removed` is the seeded ids the
-  // operator unchecked. Racks the operator did not touch are not in
-  // either list — the caller leaves them as-is. Delta-shape avoids
-  // accidentally unassigning a seeded rack that didn't make it into
-  // the listRacks response (race, paging gap, soft-delete window).
-  // `delta.reassigned` reports the added racks that are being reparented so the
-  // host can gate the reparent confirm before committing.
+  // Returns the delta against initialSelectedRackIds. `delta.reassigned` reports
+  // the added racks that are being reparented so the host can gate the reparent
+  // confirm before committing. Computed against the items-by-id accumulator
+  // (every rack seen across pages / select-all), NOT just the current page.
   onConfirm: (delta: RackSelectionDelta) => void;
 }
 
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 50;
 
 const colTitles: ColTitles<RackPickerColumn> = {
   name: "Name",
@@ -83,60 +83,129 @@ const ManageRacksModal = ({
   currentBuildingId,
   scope,
   assignedScope,
+  allSites,
   buildingName,
   initialSelectedRackIds,
   onDismiss,
   onConfirm,
 }: ManageRacksModalProps) => {
   const { listRacks } = useDeviceSets();
-  const { listBuildingsBySite } = useBuildings();
-  const [items, setItems] = useState<RackPickerItem[] | undefined>(undefined);
+  const { listBuildingsBySite, listBuildings } = useBuildings();
+  const { listSites } = useSites();
+  const canReadSiteCatalog = useHasPermission("site:read");
+
+  const [pageItems, setPageItems] = useState<RackPickerItem[] | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const [selectedItems, setSelectedItems] = useState<string[]>(() => initialSelectedRackIds.map((id) => id.toString()));
-  const [page, setPage] = useState(0);
   // "Show assigned racks" — default off, so the list starts with only the
   // assignable set (this building's site + unassigned, eligible rows). Turning
-  // it on surfaces racks already placed in another building/site; they become
-  // selectable (reparenting moves them, behind a confirm) and are flagged with
-  // a warning icon.
+  // it on broadens the fetch and surfaces racks already placed elsewhere; they
+  // become selectable (reparenting moves them, behind a confirm) and are flagged
+  // with a warning icon.
   const [showAssigned, setShowAssigned] = useState(false);
   const [showAssignedInfo, setShowAssignedInfo] = useState(false);
   // The reassignment row whose conflict dialog is open, or null.
   const [conflictInfoItem, setConflictInfoItem] = useState<RackPickerItem | null>(null);
-  // Active fetch scope: broadened to `assignedScope` while the toggle is on so
-  // ineligible racks are actually fetched (cross-site when all-sites).
-  const activeScope = showAssigned ? assignedScope : scope;
-  // Self-fetched building id → display label map for the Building
-  // column. Falls back to "—" via the buildItem helper when an id is
-  // missing (cross-site rack, or fetch in flight).
+  // User facet selections. Building narrows within the fetched set; Site
+  // (offered only under all-sites) narrows the site scope.
+  const [facetBuildingIds, setFacetBuildingIds] = useState<bigint[]>([]);
+  const [facetSiteIds, setFacetSiteIds] = useState<bigint[]>([]);
+  const [availableBuildings, setAvailableBuildings] = useState<{ id: string; label: string }[]>([]);
+  const [availableSites, setAvailableSites] = useState<{ id: string; label: string }[]>([]);
+  // Self-fetched building id → display label map for the Building column. Falls
+  // back to "—" via buildRackPickerItem when an id is missing.
   const [buildingMap, setBuildingMap] = useState<Record<string, string>>({});
+
+  // --- Pagination state ---
+  // Server-side pagination. `pageTokensRef[i]` is the page token to fetch page
+  // `i` (index 0 → ""); grown as the operator pages forward so Previous can
+  // return without re-deriving tokens. Kept in a ref so mutating it never
+  // retriggers the fetch effect.
+  const [pageIndex, setPageIndex] = useState(0);
+  const [nextPageToken, setNextPageToken] = useState("");
+  const [totalCount, setTotalCount] = useState(0);
+  const pageTokensRef = useRef<string[]>([""]);
+  // Every rack seen this session (across pages + select-all), keyed by id.
+  // computeRackSelectionDelta needs the FULL set, not just the current page —
+  // server pagination only hands us one page at a time. Reset when the request
+  // shape changes (the set it describes changed).
+  const accumulatorRef = useRef<Map<string, RackPickerItem>>(new Map());
 
   // Racks already in the working set. Passed to buildRackPickerItem so a seeded
   // rack — including a reparent staged earlier this session but not yet Saved —
-  // classifies as "in this building" instead of being re-derived as a
-  // reassignment row from its stale server placement. Stable per open (the host
-  // only mutates entries on this picker's own confirm, which unmounts it).
+  // classifies as "in this building" instead of a reassignment row derived from
+  // its stale server placement.
   const seededRackIds = useMemo(
     () => new Set(initialSelectedRackIds.map((id) => id.toString())),
     [initialSelectedRackIds],
   );
 
-  // Ids of the ineligible (reassignment) racks currently loaded. Used to drop
-  // them from the selection when the toggle goes off — either explicitly, or as
-  // part of recovering from a failed broadened fetch below.
-  const reassignmentIdSet = useMemo(
-    () => new Set((items ?? []).filter((r) => r.reassignment).map((r) => r.id)),
-    [items],
+  // The effective server request. Everything that narrows the result set lives
+  // here so pagination stays correct — there is no client-side filtering of a
+  // fetched page (that would empty pages after the fact and break page counts /
+  // select-all). Toggle OFF pins the fetch to the assignable set (this building
+  // + no-building racks, within the site scope); toggle ON broadens to
+  // assignedScope and lets facets narrow freely. Mirrors MinerSelectionList's
+  // derived filter.
+  const request = useMemo(() => {
+    const base = showAssigned ? assignedScope : scope;
+    let siteIds = base.siteIds;
+    let includeUnassigned = base.includeUnassigned;
+    // Site facet (offered only under all-sites) narrows the site scope.
+    if (facetSiteIds.length > 0) {
+      siteIds = facetSiteIds;
+      includeUnassigned = false;
+    }
+    let buildingIds: bigint[];
+    let includeNoBuilding: boolean;
+    if (!showAssigned) {
+      // Assignable-only: return only this building's racks + no-building racks.
+      // A Building facet on another building yields an empty intersection,
+      // surfaced as placementFacetConflict below rather than a broadened fetch.
+      if (facetBuildingIds.length > 0) {
+        buildingIds = facetBuildingIds.filter((id) => id === currentBuildingId);
+        includeNoBuilding = false;
+      } else {
+        buildingIds = [currentBuildingId];
+        includeNoBuilding = true;
+      }
+    } else {
+      buildingIds = facetBuildingIds;
+      includeNoBuilding = false;
+    }
+    return { siteIds, includeUnassigned, buildingIds, includeNoBuilding };
+  }, [showAssigned, scope, assignedScope, facetSiteIds, facetBuildingIds, currentBuildingId]);
+
+  // Assignable-only + a Building facet that excludes this building = provably no
+  // assignable matches. Show empty rather than fetch (an empty building_ids with
+  // include_no_building=false drops the building predicate and would leak the
+  // whole site). Self-correcting once the facet is cleared. Mirrors
+  // MinerSelectionList's placementFacetConflict.
+  const placementFacetConflict =
+    !showAssigned && facetBuildingIds.length > 0 && !facetBuildingIds.includes(currentBuildingId);
+
+  const requestKey = useMemo(
+    () =>
+      JSON.stringify({
+        s: request.siteIds.map(String),
+        u: request.includeUnassigned,
+        b: request.buildingIds.map(String),
+        nb: request.includeNoBuilding,
+        conflict: placementFacetConflict,
+      }),
+    [request, placementFacetConflict],
   );
-  // Mirrors of the toggle + reassignment set for the fetch effect's async error
-  // handler. Read via refs so the effect need not list them as deps —
-  // `reassignmentIdSet` gets a fresh identity on every `items` change, which in
-  // the deps array would trigger an endless refetch loop.
+
+  // Live mirrors read by the fetch effect / callbacks so they aren't listed as
+  // effect deps (which would churn identity every render).
+  const requestRef = useRef(request);
+  requestRef.current = request;
   const showAssignedRef = useRef(showAssigned);
   showAssignedRef.current = showAssigned;
-  const reassignmentIdSetRef = useRef(reassignmentIdSet);
-  reassignmentIdSetRef.current = reassignmentIdSet;
+  const buildingMapRef = useRef(buildingMap);
+  buildingMapRef.current = buildingMap;
 
+  // Building-label lookup for the Building column (this building's site).
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
@@ -151,8 +220,6 @@ const ManageRacksModal = ({
         }
         setBuildingMap(out);
       },
-      // Silent on error — the Building column degrades to "—" but the
-      // picker still functions.
       onError: () => {
         if (!cancelled) setBuildingMap({});
       },
@@ -162,46 +229,113 @@ const ManageRacksModal = ({
     };
   }, [open, siteId, listBuildingsBySite]);
 
-  // Fetch the full rack list and build picker items. Cross-site / cross-
-  // building eligibility is computed per-row in buildItem so the operator
-  // sees the full org-wide list with ineligible racks rendered disabled
-  // (ineligible-but-visible — matches the SearchMinersModal pattern).
-  // Conditional mount guarantees fresh state per open.
+  // Facet dropdown options. Building options scope to the active site(s) (the
+  // building's site, or org-wide under all-sites). Site options only fetched
+  // (and only offered) under all-sites, gated by site:read like the miner picker.
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
+    const optionSiteIds = allSites ? [] : scope.siteIds;
+    void listBuildings({
+      siteIds: optionSiteIds,
+      onSuccess: (rows) => {
+        if (cancelled) return;
+        setAvailableBuildings(
+          rows
+            .filter((b) => b.building !== undefined)
+            .map((b) => ({ id: String(b.building!.id), label: b.building!.name })),
+        );
+      },
+      onError: () => {
+        if (!cancelled) setAvailableBuildings([]);
+      },
+    });
+    if (allSites && canReadSiteCatalog) {
+      void listSites({
+        onSuccess: (rows) => {
+          if (cancelled) return;
+          setAvailableSites(
+            rows.filter((s) => s.site !== undefined).map((s) => ({ id: String(s.site!.id), label: s.site!.name })),
+          );
+        },
+        onError: () => {
+          if (!cancelled) setAvailableSites([]);
+        },
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [open, allSites, scope.siteIds, canReadSiteCatalog, listBuildings, listSites]);
+
+  // Reset pagination whenever the request shape changes — the described set is
+  // different, so tokens and the accumulator no longer apply. Done during render
+  // (React's "adjust state when a prop changes" pattern) rather than in an effect
+  // so the reset lands before the fetch effect reads pageIndex, and to avoid the
+  // cascading extra render a setState-in-effect would cause.
+  const prevRequestKeyRef = useRef(requestKey);
+  if (prevRequestKeyRef.current !== requestKey) {
+    prevRequestKeyRef.current = requestKey;
+    pageTokensRef.current = [""];
+    accumulatorRef.current = new Map();
+    setPageIndex(0);
+    setError(null);
+  }
+
+  // Fetch the current page. Builds picker items and folds them into the
+  // accumulator. Ineligible racks are excluded server-side while the toggle is
+  // off, so no client-side filtering happens here.
+  useEffect(() => {
+    if (!open) return;
+    // A placement-facet conflict has no assignable matches — skip the fetch and
+    // let the derived display values below render the empty state.
+    if (placementFacetConflict) return;
+    // After a reset, pageTokensRef holds only index 0; a stale pageIndex > 0
+    // reads undefined and waits for the reset's setPageIndex(0) to land.
+    const token = pageTokensRef.current[pageIndex];
+    if (token === undefined) return;
+    let cancelled = false;
+    const req = requestRef.current;
     void listRacks({
-      siteIds: activeScope.siteIds,
-      includeUnassigned: activeScope.includeUnassigned,
-      onSuccess: (racks) => {
+      siteIds: req.siteIds,
+      includeUnassigned: req.includeUnassigned,
+      buildingIds: req.buildingIds,
+      includeNoBuilding: req.includeNoBuilding,
+      pageSize: PAGE_SIZE,
+      pageToken: token,
+      onSuccess: (racks, next, total) => {
         if (cancelled) return;
         const out: RackPickerItem[] = [];
         for (const rack of racks) {
-          const item = buildRackPickerItem(rack, siteId, currentBuildingId, buildingMap, seededRackIds);
-          if (item) out.push(item);
+          const item = buildRackPickerItem(rack, siteId, currentBuildingId, buildingMapRef.current, seededRackIds);
+          if (item) {
+            out.push(item);
+            accumulatorRef.current.set(item.id, item);
+          }
         }
         out.sort((a, b) => a.label.localeCompare(b.label));
-        setItems(out);
+        pageTokensRef.current[pageIndex + 1] = next;
+        setPageItems(out);
+        setNextPageToken(next);
+        setTotalCount(total);
+        setError(null);
       },
       onError: (msg) => {
         if (cancelled) return;
-        // A failed *broadened* (toggle-on) fetch must not strand the operator:
-        // the full-modal error branch below hides the Switch, so they could
-        // never toggle back off. Instead keep the already-loaded eligible racks,
-        // revert the toggle, and surface the failure as a toast — the picker
-        // stays usable with the scoped set. Only the initial scoped fetch (which
-        // has nothing to fall back to) shows the blocking error state.
+        // A failed *broadened* (toggle-on) fetch must not strand the operator
+        // behind the blocking error state (which hides the Switch). Revert the
+        // toggle — that changes the request and refetches the scoped set — drop
+        // any reparent picks, and surface the failure as a toast.
         if (showAssignedRef.current) {
           pushToast({ message: `Couldn't load assigned racks: ${msg}`, status: STATUSES.error });
-          const ineligible = reassignmentIdSetRef.current;
-          setShowAssigned(false);
-          setPage(0);
-          setSelectedItems((sel) => sel.filter((id) => !ineligible.has(id)));
+          const acc = accumulatorRef.current;
+          setSelectedItems((sel) => sel.filter((id) => !acc.get(id)?.reassignment));
           setConflictInfoItem(null);
+          setShowAssigned(false);
           return;
         }
         setError(msg);
-        setItems([]);
+        setPageItems([]);
       },
     });
     return () => {
@@ -209,50 +343,83 @@ const ManageRacksModal = ({
     };
   }, [
     open,
+    requestKey,
+    pageIndex,
+    buildingMap,
     siteId,
     currentBuildingId,
-    buildingMap,
-    listRacks,
-    activeScope.siteIds,
-    activeScope.includeUnassigned,
     seededRackIds,
+    placementFacetConflict,
+    listRacks,
   ]);
 
-  // Toggle-off hides the ineligible (reassignment) rows entirely — the picker
-  // shows only the assignable set. Toggle-on keeps them, selectable and flagged.
-  const visibleItems = useMemo(() => {
-    if (!items) return undefined;
-    return showAssigned ? items : items.filter((r) => !r.reassignment);
-  }, [items, showAssigned]);
+  const goToNextPage = useCallback(() => {
+    if (!nextPageToken) return;
+    pageTokensRef.current[pageIndex + 1] = nextPageToken;
+    setPageIndex((i) => i + 1);
+  }, [nextPageToken, pageIndex]);
+
+  const goToPrevPage = useCallback(() => setPageIndex((i) => Math.max(0, i - 1)), []);
 
   // With the toggle on, reassignment rows are intentionally selectable (behind
   // the reparent confirm at commit); nothing else is ever disabled.
   const isRowDisabled = useCallback((item: RackPickerItem) => item.disabled && !showAssigned, [showAssigned]);
 
-  // Flip the toggle and reset to the first page in one go — the visible set
-  // changes shape, so an out-of-range page would otherwise show empty. Turning
-  // the toggle OFF also drops any selected reassignment racks (they are now
-  // hidden, so leaving them selected would silently reparent them on Continue)
-  // and closes any open conflict dialog. A reparent accepted earlier in the
-  // session isn't a reassignment row anymore — it is seeded into this building's
-  // working set, so buildRackPickerItem classifies it in-this-building — so
-  // nothing seeded is at risk here. Matches Switch's setChecked signature
-  // (accepts a value or updater).
-  const handleToggleShowAssigned = useCallback(
-    (value: boolean | ((prev: boolean) => boolean)) => {
-      const next = typeof value === "function" ? value(showAssigned) : value;
-      setShowAssigned(next);
-      setPage(0);
-      if (!next) {
-        setSelectedItems((sel) => sel.filter((id) => !reassignmentIdSet.has(id)));
-        setConflictInfoItem(null);
-      }
-    },
-    [showAssigned, reassignmentIdSet],
-  );
+  // Flip the toggle. Turning it OFF drops any selected reassignment racks (now
+  // excluded from the fetch, so leaving them selected would silently reparent
+  // them on Continue) and closes the conflict dialog. Seeded racks classify
+  // in-this-building, so nothing seeded is at risk. The request change resets
+  // pagination via the effect above. Matches Switch's setChecked signature.
+  const handleToggleShowAssigned = useCallback((value: boolean | ((prev: boolean) => boolean)) => {
+    const next = typeof value === "function" ? value(showAssignedRef.current) : value;
+    if (!next) {
+      const acc = accumulatorRef.current;
+      setSelectedItems((sel) => sel.filter((id) => !acc.get(id)?.reassignment));
+      setConflictInfoItem(null);
+    }
+    setShowAssigned(next);
+  }, []);
+
+  const handleServerFilter = useCallback(async (active: ActiveFilters) => {
+    const buildingFilters = active.dropdownFilters.building;
+    setFacetBuildingIds(buildingFilters && buildingFilters.length > 0 ? buildingFilters.map((id) => BigInt(id)) : []);
+    const siteFilters = active.dropdownFilters.site;
+    setFacetSiteIds(siteFilters && siteFilters.length > 0 ? siteFilters.map((id) => BigInt(id)) : []);
+  }, []);
+
+  // "Add filter" popover: Building always, Site only under all-sites (site:read).
+  const filters = useMemo((): FilterItem[] => {
+    const children: NestedFilterChildItem[] = [
+      {
+        type: "dropdown",
+        title: "Building",
+        value: "building",
+        options: availableBuildings,
+        defaultOptionIds: [],
+      },
+    ];
+    if (allSites && canReadSiteCatalog) {
+      children.push({
+        type: "dropdown",
+        title: "Site",
+        value: "site",
+        options: availableSites,
+        defaultOptionIds: [],
+      });
+    }
+    return [
+      {
+        type: "nestedFilterDropdown",
+        title: "Add filter",
+        value: "filters-meta",
+        prefixIcon: <Plus width="w-3" />,
+        children,
+      },
+    ];
+  }, [availableBuildings, availableSites, allSites, canReadSiteCatalog]);
 
   // Name column renders a warning icon on reassignment rows while the toggle is
-  // on; tapping it opens the per-row conflict dialog. Other columns unchanged.
+  // on; tapping it opens the per-row conflict dialog.
   const listColConfig = useMemo<ColConfig<RackPickerItem, string, RackPickerColumn>>(() => {
     if (!showAssigned) return colConfig;
     return {
@@ -280,35 +447,50 @@ const ManageRacksModal = ({
     };
   }, [showAssigned]);
 
-  // Client-side pagination. List doesn't paginate on its own — it consumes
-  // a flat items array — so we slice here and feed a per-page view.
-  const pageItems = useMemo(() => {
-    if (!visibleItems) return [];
-    const start = page * PAGE_SIZE;
-    return visibleItems.slice(start, start + PAGE_SIZE);
-  }, [visibleItems, page]);
-  const totalItems = visibleItems?.length ?? 0;
-  const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
-  const hasPreviousPage = page > 0;
-  const hasNextPage = page < totalPages - 1;
-
   const handleConfirm = useCallback(() => {
-    if (!items) return;
-    onConfirm(computeRackSelectionDelta(items, initialSelectedRackIds, selectedItems));
-  }, [items, selectedItems, initialSelectedRackIds, onConfirm]);
+    if (pageItems === undefined) return;
+    onConfirm(computeRackSelectionDelta([...accumulatorRef.current.values()], initialSelectedRackIds, selectedItems));
+  }, [pageItems, selectedItems, initialSelectedRackIds, onConfirm]);
 
+  // Footer "Select all" (offered only with the toggle off — see below) selects
+  // every ELIGIBLE rack across all pages, not just the visible page. Server
+  // pagination hands us one page at a time, so we fetch the full assignable set
+  // (the toggle-off request, unpaginated) and select those ids, folding them
+  // into the accumulator so Continue can build the delta. Mirrors the miner
+  // picker's fetchAllSelectableMinerIds.
   const handleSelectAll = useCallback(() => {
-    if (!items) return;
-    // Footer "Select all" selects every eligible rack across all pages. It is
-    // only offered while the "Show assigned racks" toggle is off (see the footer
-    // wiring below), so no reassignment rows are on screen; the `!r.reassignment`
-    // filter still guards the same-site reassignment rows the fetch loads but
-    // keeps hidden. Bulk-selecting reparent rows stays possible only via the
-    // in-table header checkbox, which routes them through the reparent confirm.
-    setSelectedItems(items.filter((r) => !r.reassignment).map((r) => r.id));
-  }, [items]);
+    void listRacks({
+      siteIds: scope.siteIds,
+      includeUnassigned: scope.includeUnassigned,
+      buildingIds: [currentBuildingId],
+      includeNoBuilding: true,
+      onSuccess: (racks) => {
+        const ids: string[] = [];
+        for (const rack of racks) {
+          const item = buildRackPickerItem(rack, siteId, currentBuildingId, buildingMapRef.current, seededRackIds);
+          if (item) {
+            accumulatorRef.current.set(item.id, item);
+            ids.push(item.id);
+          }
+        }
+        setSelectedItems(ids);
+      },
+      onError: (msg) => {
+        pushToast({ message: `Couldn't select all racks: ${msg}`, status: STATUSES.error });
+      },
+    });
+  }, [listRacks, scope.siteIds, scope.includeUnassigned, currentBuildingId, siteId, seededRackIds]);
 
   const handleSelectNone = useCallback(() => setSelectedItems([]), []);
+
+  // A placement-facet conflict is provably empty; present it as such even though
+  // the last successful fetch may still be held in pageItems/totalCount.
+  const displayItems = placementFacetConflict ? [] : pageItems;
+  const displayTotal = placementFacetConflict ? 0 : totalCount;
+  const displayNextToken = placementFacetConflict ? "" : nextPageToken;
+
+  const pageStart = pageIndex * PAGE_SIZE;
+  const showFooterPagination = displayTotal > PAGE_SIZE;
 
   return (
     <Modal
@@ -335,7 +517,7 @@ const ManageRacksModal = ({
           <div className="py-6 text-300 text-intent-critical-fill" data-testid="manage-racks-modal-error">
             {error}
           </div>
-        ) : items === undefined ? (
+        ) : displayItems === undefined ? (
           <div className="flex flex-1 items-center justify-center py-12">
             <ProgressCircular indeterminate />
           </div>
@@ -346,6 +528,8 @@ const ManageRacksModal = ({
                 activeCols={activeCols}
                 colTitles={colTitles}
                 colConfig={listColConfig}
+                filters={filters}
+                onServerFilter={handleServerFilter}
                 headerControls={
                   <div className="flex items-center gap-1 px-1">
                     <Button
@@ -363,7 +547,7 @@ const ManageRacksModal = ({
                     />
                   </div>
                 }
-                items={pageItems}
+                items={displayItems}
                 itemKey="id"
                 itemSelectable
                 selectionType="checkbox"
@@ -378,10 +562,10 @@ const ManageRacksModal = ({
                 overflowContainer
                 stickyBgColor="bg-surface-elevated-base"
                 footerContent={
-                  totalItems > PAGE_SIZE ? (
+                  showFooterPagination ? (
                     <div className="flex flex-col items-center gap-4 py-6">
                       <span className="text-300 text-text-primary">
-                        Showing {page * PAGE_SIZE + 1}–{page * PAGE_SIZE + pageItems.length} of {totalItems} racks
+                        Showing {pageStart + 1}–{pageStart + displayItems.length} of {displayTotal} racks
                       </span>
                       <div className="flex gap-3">
                         <Button
@@ -389,16 +573,16 @@ const ManageRacksModal = ({
                           size={sizes.compact}
                           ariaLabel="Previous page"
                           prefixIcon={<ChevronDown className="rotate-90" />}
-                          onClick={() => setPage((p) => Math.max(0, p - 1))}
-                          disabled={!hasPreviousPage}
+                          onClick={goToPrevPage}
+                          disabled={pageIndex === 0}
                         />
                         <Button
                           variant={variants.secondary}
                           size={sizes.compact}
                           ariaLabel="Next page"
                           prefixIcon={<ChevronDown className="rotate-270" />}
-                          onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-                          disabled={!hasNextPage}
+                          onClick={goToNextPage}
+                          disabled={!displayNextToken}
                         />
                       </div>
                     </div>
@@ -409,12 +593,11 @@ const ManageRacksModal = ({
             <div className="shrink-0">
               <ModalSelectAllFooter
                 label={`${selectedItems.length} ${selectedItems.length === 1 ? "rack" : "racks"} selected`}
-                // Hide "Select all" while ineligible (reassignment) racks are on
-                // screen — a bulk select-all can't sweep them into a reparent.
-                // Matches MinerSelectionList, which drops select-all when its
-                // "Show assigned" toggle is on. The in-table header checkbox
-                // still selects the whole page (reparent rows included), gated by
-                // the reparent confirm on Continue.
+                // Hide "Select all" while ineligible (reassignment) racks are in
+                // the fetch — a bulk select-all can't sweep them into a reparent.
+                // Matches MinerSelectionList. The in-table header checkbox still
+                // selects the whole page (reparent rows included), gated by the
+                // reparent confirm on Continue.
                 onSelectAll={showAssigned ? undefined : handleSelectAll}
                 onSelectNone={handleSelectNone}
               />

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -227,6 +227,11 @@ const ManageRacksModal = ({
   buildingMapRef.current = buildingMap;
   const selectedItemsRef = useRef(selectedItems);
   selectedItemsRef.current = selectedItems;
+  // Monotonic epoch that invalidates an in-flight footer "Select all": bumped by
+  // any newer selection or request change, so a slow bulk-select completion that
+  // lands after the operator has moved on (Select none, a row toggle, a filter)
+  // is ignored instead of silently re-selecting the stale result.
+  const selectAllEpochRef = useRef(0);
 
   // Building-label lookup for the Building column (this building's site).
   useEffect(() => {
@@ -315,6 +320,9 @@ const ManageRacksModal = ({
   // the id; real rows overwrite it as pages load (the delta needs only the id to
   // report a removal).
   useEffect(() => {
+    // A request change (filter / toggle / site) invalidates any in-flight
+    // footer select-all — its result described the previous request.
+    selectAllEpochRef.current += 1;
     pageTokensRef.current = [""];
     const prev = accumulatorRef.current;
     const acc = new Map<string, RackPickerItem>();
@@ -540,6 +548,7 @@ const ManageRacksModal = ({
   // fetchAllSelectableMinerIds.
   const handleSelectAll = useCallback(() => {
     const req = requestRef.current;
+    const epoch = (selectAllEpochRef.current += 1);
     setSelectingAll(true);
     void listRacks({
       siteIds: req.siteIds,
@@ -547,6 +556,10 @@ const ManageRacksModal = ({
       buildingIds: req.buildingIds,
       includeNoBuilding: req.includeNoBuilding,
       onSuccess: (racks) => {
+        // Drop a stale completion: the operator changed the selection/filter
+        // while this fetch was in flight, so applying its result would clobber
+        // the newer state.
+        if (selectAllEpochRef.current !== epoch) return;
         const ids: string[] = [];
         for (const rack of racks) {
           const item = buildRackPickerItem(rack, siteId, currentBuildingId, buildingMapRef.current, seededRackIds);
@@ -564,7 +577,17 @@ const ManageRacksModal = ({
     });
   }, [listRacks, currentBuildingId, siteId, seededRackIds]);
 
-  const handleSelectNone = useCallback(() => setSelectedItems([]), []);
+  // Wraps the List's selection setter so any manual selection change (row
+  // toggle, page header checkbox) invalidates an in-flight footer select-all.
+  const handleSelectionChange = useCallback((value: string[] | ((prev: string[]) => string[])) => {
+    selectAllEpochRef.current += 1;
+    setSelectedItems(value);
+  }, []);
+
+  const handleSelectNone = useCallback(() => {
+    selectAllEpochRef.current += 1;
+    setSelectedItems([]);
+  }, []);
 
   // A placement-facet conflict is provably empty; present it as such even though
   // the last successful fetch may still be held in pageItems/totalCount.
@@ -636,7 +659,7 @@ const ManageRacksModal = ({
                 itemSelectable
                 selectionType="checkbox"
                 customSelectedItems={selectedItems}
-                customSetSelectedItems={setSelectedItems}
+                customSetSelectedItems={handleSelectionChange}
                 preserveOffPageSelection
                 isRowDisabled={isRowDisabled}
                 itemName={{ singular: "rack", plural: "racks" }}

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -233,15 +233,18 @@ const ManageRacksModal = ({
     };
   }, [open, siteId, listBuildingsBySite]);
 
-  // Facet dropdown options. Building options scope to the active site(s) (the
-  // building's site, or org-wide under all-sites). Site options only fetched
-  // (and only offered) under all-sites, gated by site:read like the miner picker.
+  // Facet dropdown options. Building options mirror the rack scope: org-wide
+  // under all-sites, otherwise the building's own site scope — including its
+  // include-unassigned flag, so a site-unassigned building doesn't fall through
+  // to an org-wide list (empty siteIds + false = no filter) that would offer
+  // buildings from every site. Site options only fetched (and only offered)
+  // under all-sites, gated by site:read like the miner picker.
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    const optionSiteIds = allSites ? [] : scope.siteIds;
     void listBuildings({
-      siteIds: optionSiteIds,
+      siteIds: allSites ? [] : scope.siteIds,
+      includeUnassigned: allSites ? false : scope.includeUnassigned,
       onSuccess: (rows) => {
         if (cancelled) return;
         setAvailableBuildings(
@@ -270,37 +273,34 @@ const ManageRacksModal = ({
     return () => {
       cancelled = true;
     };
-  }, [open, allSites, scope.siteIds, canReadSiteCatalog, listBuildings, listSites]);
+  }, [open, allSites, scope.siteIds, scope.includeUnassigned, canReadSiteCatalog, listBuildings, listSites]);
 
-  // Reset pagination whenever the request shape changes — the described set is
-  // different, so tokens and the accumulator no longer apply. Done during render
-  // (React's "adjust state when a prop changes" pattern) rather than in an effect
-  // so the reset lands before the fetch effect reads pageIndex, and to avoid the
-  // cascading extra render a setState-in-effect would cause.
-  const prevRequestKeyRef = useRef(requestKey);
-  if (prevRequestKeyRef.current !== requestKey) {
-    prevRequestKeyRef.current = requestKey;
+  // Reset pagination when the request shape changes — the described set is
+  // different, so tokens, accumulator, and the visible page no longer apply.
+  // View state (pageItems/nextPageToken/totalCount) is reset alongside the
+  // refs so the list returns to a loading baseline instead of briefly showing
+  // the previous request's rows (with Next still enabled); resetting pageItems
+  // to undefined also makes handleConfirm a no-op until the refetch repopulates
+  // the accumulator, closing the "Continue mid-refetch" delta race. This is a
+  // deliberate "resync on changed input" effect: the set-state-in-effect rule's
+  // cascading-render caveat is exactly the intended behavior (we must re-render
+  // to the new set's first page), so it is suppressed for the resets below.
+  //
+  // The accumulator is then seeded with a placeholder for every initially-
+  // selected rack, so computeRackSelectionDelta can act on a seed even before
+  // its page loads. Without it, a seed the current request never returns — an
+  // off-page member (building > one page) or a staged reparent pinned out of the
+  // assignable fetch — is "absent from items", and the delta's conservative
+  // "absent → preserve" rule silently keeps it, making an explicit "Select none"
+  // (or single deselect) of that rack a no-op on Continue. The seed carries only
+  // the id; real rows overwrite it as pages load (the delta needs only the id to
+  // report a removal).
+  useEffect(() => {
     pageTokensRef.current = [""];
-    accumulatorRef.current = new Map();
-    setPageIndex(0);
-    setError(null);
-  }
-
-  // Seed the accumulator with a placeholder for every initially-selected rack
-  // that isn't already resolved, so computeRackSelectionDelta can act on it even
-  // before its page loads. Without this, a seed that the current request never
-  // returns — an off-page member (building > one page) or a staged reparent
-  // pinned out of the assignable fetch — is "absent from items", and the delta's
-  // conservative "absent → preserve" rule silently keeps it. That makes an
-  // explicit "Select none" (or single deselect) of such a rack a no-op on
-  // Continue. The seed only carries the id; real rows overwrite it as pages load
-  // (and the delta only needs the id to report a removal). Runs after the reset
-  // above so it re-seeds a freshly cleared accumulator. Idempotent per id.
-  for (const id of initialSelectedRackIds) {
-    const key = id.toString();
-    if (!accumulatorRef.current.has(key)) {
-      accumulatorRef.current.set(key, {
-        id: key,
+    const acc = new Map<string, RackPickerItem>();
+    for (const id of initialSelectedRackIds) {
+      acc.set(id.toString(), {
+        id: id.toString(),
         label: "",
         buildingLabel: "—",
         statusLabel: "",
@@ -310,7 +310,15 @@ const ManageRacksModal = ({
         minerCount: 0,
       });
     }
-  }
+    accumulatorRef.current = acc;
+    /* eslint-disable react-hooks/set-state-in-effect -- intentional resync-on-input reset */
+    setPageIndex(0);
+    setError(null);
+    setPageItems(undefined);
+    setNextPageToken("");
+    setTotalCount(0);
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [requestKey, initialSelectedRackIds]);
 
   // Fetch the current page. Builds picker items and folds them into the
   // accumulator. Ineligible racks are excluded server-side while the toggle is

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -104,6 +104,9 @@ const ManageRacksModal = ({
   // with a warning icon.
   const [showAssigned, setShowAssigned] = useState(false);
   const [showAssignedInfo, setShowAssignedInfo] = useState(false);
+  // True while a footer "Select all" fetch is in flight — the selection isn't
+  // final yet, so Continue is disabled/guarded until it resolves.
+  const [selectingAll, setSelectingAll] = useState(false);
   // The reassignment row whose conflict dialog is open, or null.
   const [conflictInfoItem, setConflictInfoItem] = useState<RackPickerItem | null>(null);
   // User facet selections. Building narrows within the fetched set; Site
@@ -149,19 +152,25 @@ const ManageRacksModal = ({
   // derived filter.
   const request = useMemo(() => {
     const base = showAssigned ? assignedScope : scope;
-    let siteIds = base.siteIds;
-    let includeUnassigned = base.includeUnassigned;
-    // Site facet (offered only under all-sites) narrows the site scope.
-    if (facetSiteIds.length > 0) {
-      siteIds = facetSiteIds;
-      includeUnassigned = false;
-    }
+    let siteIds: bigint[];
+    let includeUnassigned: boolean;
     let buildingIds: bigint[];
     let includeNoBuilding: boolean;
     if (!showAssigned) {
-      // Assignable-only: return only this building's racks + no-building racks.
-      // A Building facet on another building yields an empty intersection,
-      // surfaced as placementFacetConflict below rather than a broadened fetch.
+      // Assignable-only: clamp BOTH dimensions to this building's own placement
+      // (its site + itself/no-building). A facet on another building/site is an
+      // empty intersection — surfaced as placementFacetConflict below rather than
+      // a broadened fetch. Clamping (not replacing) the Site facet is what stops a
+      // multi-select like [thisSite, otherSite] from OR-ing in cross-site
+      // no-building racks that would otherwise appear as disabled reassignment
+      // rows and get swept into a footer Select all.
+      if (facetSiteIds.length > 0) {
+        siteIds = facetSiteIds.filter((id) => id === siteId);
+        includeUnassigned = false;
+      } else {
+        siteIds = base.siteIds;
+        includeUnassigned = base.includeUnassigned;
+      }
       if (facetBuildingIds.length > 0) {
         buildingIds = facetBuildingIds.filter((id) => id === currentBuildingId);
         includeNoBuilding = false;
@@ -170,11 +179,19 @@ const ManageRacksModal = ({
         includeNoBuilding = true;
       }
     } else {
+      // Broadened: facets narrow freely (Site offered only under all-sites).
+      if (facetSiteIds.length > 0) {
+        siteIds = facetSiteIds;
+        includeUnassigned = false;
+      } else {
+        siteIds = base.siteIds;
+        includeUnassigned = base.includeUnassigned;
+      }
       buildingIds = facetBuildingIds;
       includeNoBuilding = false;
     }
     return { siteIds, includeUnassigned, buildingIds, includeNoBuilding };
-  }, [showAssigned, scope, assignedScope, facetSiteIds, facetBuildingIds, currentBuildingId]);
+  }, [showAssigned, scope, assignedScope, facetSiteIds, facetBuildingIds, currentBuildingId, siteId]);
 
   // Assignable-only + a placement facet that excludes this building's own
   // building/site = provably no assignable matches. Show empty rather than fetch
@@ -486,9 +503,13 @@ const ManageRacksModal = ({
   }, [showAssigned]);
 
   const handleConfirm = useCallback(() => {
-    if (pageItems === undefined) return;
+    // Guard against confirming mid-load: while the initial page hasn't arrived
+    // (undefined) or a footer "Select all" fetch is still in flight, the
+    // selection/accumulator aren't final, so committing would drop the pending
+    // additions. The Continue button is also disabled in these states.
+    if (pageItems === undefined || selectingAll) return;
     onConfirm(computeRackSelectionDelta([...accumulatorRef.current.values()], initialSelectedRackIds, selectedItems));
-  }, [pageItems, selectedItems, initialSelectedRackIds, onConfirm]);
+  }, [pageItems, selectingAll, selectedItems, initialSelectedRackIds, onConfirm]);
 
   // Footer "Select all" (offered only with the toggle off — see below) selects
   // every ELIGIBLE rack across all pages, not just the visible page. Server
@@ -500,6 +521,7 @@ const ManageRacksModal = ({
   // fetchAllSelectableMinerIds.
   const handleSelectAll = useCallback(() => {
     const req = requestRef.current;
+    setSelectingAll(true);
     void listRacks({
       siteIds: req.siteIds,
       includeUnassigned: req.includeUnassigned,
@@ -519,6 +541,7 @@ const ManageRacksModal = ({
       onError: (msg) => {
         pushToast({ message: `Couldn't select all racks: ${msg}`, status: STATUSES.error });
       },
+      onFinally: () => setSelectingAll(false),
     });
   }, [listRacks, currentBuildingId, siteId, seededRackIds]);
 
@@ -548,6 +571,7 @@ const ManageRacksModal = ({
           text: "Continue",
           variant: "primary",
           onClick: handleConfirm,
+          disabled: selectingAll,
           dismissModalOnClick: false,
           testId: "manage-racks-modal-confirm",
         },

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -127,6 +127,13 @@ const ManageRacksModal = ({
   const [pageIndex, setPageIndex] = useState(0);
   const [nextPageToken, setNextPageToken] = useState("");
   const [totalCount, setTotalCount] = useState(0);
+  // True from a Next/Previous click until that page's fetch resolves. The
+  // current page's rows and `nextPageToken` stay live during the request (no
+  // spinner flash), so without this the pagination buttons would remain enabled
+  // with the *previous* page's token — a double-click then stores a stale token
+  // at the advanced index, fetching the wrong range. Disabling them while a page
+  // is in flight closes that race.
+  const [pageLoading, setPageLoading] = useState(false);
   const pageTokensRef = useRef<string[]>([""]);
   // Every rack seen this session (across pages + select-all), keyed by id.
   // computeRackSelectionDelta needs the FULL set, not just the current page —
@@ -232,6 +239,12 @@ const ManageRacksModal = ({
   // lands after the operator has moved on (Select none, a row toggle, a filter)
   // is ignored instead of silently re-selecting the stale result.
   const selectAllEpochRef = useRef(0);
+  // Distinct from the epoch above: identifies a specific footer "Select all"
+  // *fetch* so its finalizer clears `selectingAll` only when it is still the
+  // latest bulk fetch. The epoch is bumped by any selection change (a row
+  // toggle, Select none), which must NOT strand `selectingAll` true — so the
+  // finalizer keys off this fetch id, not the epoch.
+  const selectAllFetchIdRef = useRef(0);
 
   // Building-label lookup for the Building column (this building's site).
   useEffect(() => {
@@ -357,6 +370,7 @@ const ManageRacksModal = ({
     setPageItems(undefined);
     setNextPageToken("");
     setTotalCount(0);
+    setPageLoading(false);
     /* eslint-enable react-hooks/set-state-in-effect */
   }, [requestKey, initialSelectedRackIds]);
 
@@ -383,6 +397,7 @@ const ManageRacksModal = ({
       pageToken: token,
       onSuccess: (racks, next, total) => {
         if (cancelled) return;
+        setPageLoading(false);
         const out: RackPickerItem[] = [];
         for (const rack of racks) {
           const item = buildRackPickerItem(rack, siteId, currentBuildingId, buildingMapRef.current, seededRackIds);
@@ -400,6 +415,7 @@ const ManageRacksModal = ({
       },
       onError: (msg) => {
         if (cancelled) return;
+        setPageLoading(false);
         // A failed *broadened* (toggle-on) fetch must not strand the operator
         // behind the blocking error state (which hides the Switch). Revert the
         // toggle — that changes the request and refetches the scoped set — drop
@@ -432,12 +448,20 @@ const ManageRacksModal = ({
   ]);
 
   const goToNextPage = useCallback(() => {
-    if (!nextPageToken) return;
+    // Ignore clicks while the current page is still loading — `nextPageToken`
+    // then belongs to the page being left, so advancing would store a stale
+    // token at the next index and fetch the wrong range.
+    if (!nextPageToken || pageLoading) return;
     pageTokensRef.current[pageIndex + 1] = nextPageToken;
+    setPageLoading(true);
     setPageIndex((i) => i + 1);
-  }, [nextPageToken, pageIndex]);
+  }, [nextPageToken, pageIndex, pageLoading]);
 
-  const goToPrevPage = useCallback(() => setPageIndex((i) => Math.max(0, i - 1)), []);
+  const goToPrevPage = useCallback(() => {
+    if (pageLoading || pageIndex === 0) return;
+    setPageLoading(true);
+    setPageIndex((i) => i - 1);
+  }, [pageLoading, pageIndex]);
 
   // With the toggle on, reassignment rows are intentionally selectable (behind
   // the reparent confirm at commit); nothing else is ever disabled.
@@ -562,6 +586,7 @@ const ManageRacksModal = ({
   const handleSelectAll = useCallback(() => {
     const req = requestRef.current;
     const epoch = (selectAllEpochRef.current += 1);
+    const fetchId = (selectAllFetchIdRef.current += 1);
     setSelectingAll(true);
     void listRacks({
       siteIds: req.siteIds,
@@ -586,7 +611,14 @@ const ManageRacksModal = ({
       onError: (msg) => {
         pushToast({ message: `Couldn't select all racks: ${msg}`, status: STATUSES.error });
       },
-      onFinally: () => setSelectingAll(false),
+      onFinally: () => {
+        // Clear the loading state only if this is still the latest bulk fetch.
+        // A superseded (slower) Select all finishing after a newer one must not
+        // re-enable Continue while the newer bulk result is still pending — that
+        // would let Continue commit the stale selection.
+        if (selectAllFetchIdRef.current !== fetchId) return;
+        setSelectingAll(false);
+      },
     });
   }, [listRacks, currentBuildingId, siteId, seededRackIds]);
 
@@ -695,7 +727,7 @@ const ManageRacksModal = ({
                           ariaLabel="Previous page"
                           prefixIcon={<ChevronDown className="rotate-90" />}
                           onClick={goToPrevPage}
-                          disabled={pageIndex === 0}
+                          disabled={pageIndex === 0 || pageLoading}
                         />
                         <Button
                           variant={variants.secondary}
@@ -703,7 +735,7 @@ const ManageRacksModal = ({
                           ariaLabel="Next page"
                           prefixIcon={<ChevronDown className="rotate-270" />}
                           onClick={goToNextPage}
-                          disabled={!displayNextToken}
+                          disabled={!displayNextToken || pageLoading}
                         />
                       </div>
                     </div>

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -496,6 +496,19 @@ const ManageRacksModal = ({
     ];
   }, [availableBuildings, availableSites, allSites, canReadSiteCatalog]);
 
+  // Drive the List's filter chips from our own facet state (controlled). The
+  // List/Filters chip state is otherwise internal, and the loading path below
+  // unmounts the List on every request change — which would wipe the chips and
+  // desync them from facetBuildingIds/facetSiteIds (reapplying the same facet
+  // then no-ops). Seeding initialActiveFilters keeps the chips correct across
+  // remounts and toggles.
+  const activeFilters = useMemo((): ActiveFilters => {
+    const dropdownFilters: Record<string, string[]> = {};
+    if (facetBuildingIds.length > 0) dropdownFilters.building = facetBuildingIds.map(String);
+    if (facetSiteIds.length > 0) dropdownFilters.site = facetSiteIds.map(String);
+    return { buttonFilters: [], dropdownFilters, numericFilters: {}, textareaListFilters: {} };
+  }, [facetBuildingIds, facetSiteIds]);
+
   // Name column renders a warning icon on reassignment rows while the toggle is
   // on; tapping it opens the per-row conflict dialog.
   const listColConfig = useMemo<ColConfig<RackPickerItem, string, RackPickerColumn>>(() => {
@@ -636,6 +649,7 @@ const ManageRacksModal = ({
                 colTitles={colTitles}
                 colConfig={listColConfig}
                 filters={filters}
+                initialActiveFilters={activeFilters}
                 onServerFilter={handleServerFilter}
                 headerControls={
                   <div className="flex items-center gap-1 px-1">

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -176,13 +176,17 @@ const ManageRacksModal = ({
     return { siteIds, includeUnassigned, buildingIds, includeNoBuilding };
   }, [showAssigned, scope, assignedScope, facetSiteIds, facetBuildingIds, currentBuildingId]);
 
-  // Assignable-only + a Building facet that excludes this building = provably no
-  // assignable matches. Show empty rather than fetch (an empty building_ids with
-  // include_no_building=false drops the building predicate and would leak the
-  // whole site). Self-correcting once the facet is cleared. Mirrors
-  // MinerSelectionList's placementFacetConflict.
+  // Assignable-only + a placement facet that excludes this building's own
+  // building/site = provably no assignable matches. Show empty rather than fetch
+  // (an empty building_ids with include_no_building=false drops the building
+  // predicate and would leak the whole site; a foreign Site facet replaces the
+  // scope and surfaces cross-site no-building racks as disabled reassignment
+  // rows that distort counts/paging). Self-correcting once the facet is cleared.
+  // Mirrors MinerSelectionList's placementFacetConflict.
   const placementFacetConflict =
-    !showAssigned && facetBuildingIds.length > 0 && !facetBuildingIds.includes(currentBuildingId);
+    !showAssigned &&
+    ((facetBuildingIds.length > 0 && !facetBuildingIds.includes(currentBuildingId)) ||
+      (facetSiteIds.length > 0 && !facetSiteIds.includes(siteId)));
 
   const requestKey = useMemo(
     () =>
@@ -280,6 +284,32 @@ const ManageRacksModal = ({
     accumulatorRef.current = new Map();
     setPageIndex(0);
     setError(null);
+  }
+
+  // Seed the accumulator with a placeholder for every initially-selected rack
+  // that isn't already resolved, so computeRackSelectionDelta can act on it even
+  // before its page loads. Without this, a seed that the current request never
+  // returns — an off-page member (building > one page) or a staged reparent
+  // pinned out of the assignable fetch — is "absent from items", and the delta's
+  // conservative "absent → preserve" rule silently keeps it. That makes an
+  // explicit "Select none" (or single deselect) of such a rack a no-op on
+  // Continue. The seed only carries the id; real rows overwrite it as pages load
+  // (and the delta only needs the id to report a removal). Runs after the reset
+  // above so it re-seeds a freshly cleared accumulator. Idempotent per id.
+  for (const id of initialSelectedRackIds) {
+    const key = id.toString();
+    if (!accumulatorRef.current.has(key)) {
+      accumulatorRef.current.set(key, {
+        id: key,
+        label: "",
+        buildingLabel: "—",
+        statusLabel: "",
+        disabled: false,
+        reassignment: false,
+        crossSite: false,
+        minerCount: 0,
+      });
+    }
   }
 
   // Fetch the current page. Builds picker items and folds them into the
@@ -454,16 +484,19 @@ const ManageRacksModal = ({
 
   // Footer "Select all" (offered only with the toggle off — see below) selects
   // every ELIGIBLE rack across all pages, not just the visible page. Server
-  // pagination hands us one page at a time, so we fetch the full assignable set
-  // (the toggle-off request, unpaginated) and select those ids, folding them
-  // into the accumulator so Continue can build the delta. Mirrors the miner
-  // picker's fetchAllSelectableMinerIds.
+  // pagination hands us one page at a time, so we fetch the current effective
+  // request (the same filter the table shows — scope + any facets), unpaginated,
+  // and select those ids, folding them into the accumulator so Continue can build
+  // the delta. Using the effective request (not the raw scope) keeps bulk-select
+  // consistent with the filtered view. Mirrors the miner picker's
+  // fetchAllSelectableMinerIds.
   const handleSelectAll = useCallback(() => {
+    const req = requestRef.current;
     void listRacks({
-      siteIds: scope.siteIds,
-      includeUnassigned: scope.includeUnassigned,
-      buildingIds: [currentBuildingId],
-      includeNoBuilding: true,
+      siteIds: req.siteIds,
+      includeUnassigned: req.includeUnassigned,
+      buildingIds: req.buildingIds,
+      includeNoBuilding: req.includeNoBuilding,
       onSuccess: (racks) => {
         const ids: string[] = [];
         for (const rack of racks) {
@@ -479,7 +512,7 @@ const ManageRacksModal = ({
         pushToast({ message: `Couldn't select all racks: ${msg}`, status: STATUSES.error });
       },
     });
-  }, [listRacks, scope.siteIds, scope.includeUnassigned, currentBuildingId, siteId, seededRackIds]);
+  }, [listRacks, currentBuildingId, siteId, seededRackIds]);
 
   const handleSelectNone = useCallback(() => setSelectedItems([]), []);
 
@@ -595,10 +628,12 @@ const ManageRacksModal = ({
                 label={`${selectedItems.length} ${selectedItems.length === 1 ? "rack" : "racks"} selected`}
                 // Hide "Select all" while ineligible (reassignment) racks are in
                 // the fetch — a bulk select-all can't sweep them into a reparent.
-                // Matches MinerSelectionList. The in-table header checkbox still
-                // selects the whole page (reparent rows included), gated by the
-                // reparent confirm on Continue.
-                onSelectAll={showAssigned ? undefined : handleSelectAll}
+                // Also hide it under a placement-facet conflict, where the
+                // effective request is provably empty and a bulk select would be
+                // meaningless. Matches MinerSelectionList. The in-table header
+                // checkbox still selects the whole page (reparent rows included),
+                // gated by the reparent confirm on Continue.
+                onSelectAll={showAssigned || placementFacetConflict ? undefined : handleSelectAll}
                 onSelectNone={handleSelectNone}
               />
             </div>

--- a/client/src/shared/components/Modal/ModalSelectAllFooter.tsx
+++ b/client/src/shared/components/Modal/ModalSelectAllFooter.tsx
@@ -4,9 +4,13 @@ interface ModalSelectAllFooterProps {
   label?: string;
   onSelectAll?: () => void;
   onSelectNone?: () => void;
+  // Disables just the "Select all" button — e.g. while a bulk select-all fetch
+  // is in flight, to prevent duplicate/overlapping requests. "Select none"
+  // stays live so it can double as a cancel.
+  selectAllDisabled?: boolean;
 }
 
-const ModalSelectAllFooter = ({ label, onSelectAll, onSelectNone }: ModalSelectAllFooterProps) => {
+const ModalSelectAllFooter = ({ label, onSelectAll, onSelectNone, selectAllDisabled }: ModalSelectAllFooterProps) => {
   return (
     <div className="-mx-6 -mb-6 shrink-0 border-t border-border-5 bg-surface-elevated-base px-6 pt-5 pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
       <div className="flex min-w-0 items-center justify-between gap-3">
@@ -20,6 +24,7 @@ const ModalSelectAllFooter = ({ label, onSelectAll, onSelectNone }: ModalSelectA
               textColor="text-core-accent-fill"
               textOnlyUnderlineOnHover={false}
               onClick={onSelectAll}
+              disabled={selectAllDisabled}
             >
               Select all
             </Button>

--- a/docs/plans/2026-07-16-758-rack-picker-parity-plan.md
+++ b/docs/plans/2026-07-16-758-rack-picker-parity-plan.md
@@ -177,23 +177,51 @@ reaches `listRacks` (guards against reverting to a whole-org fetch).
 
 - Add a rack `filterConfig` facet set — adapt, don't copy the miner facets.
   Keep only:
-  - **Building** — `buildingIds` / `includeNoBuilding`.
-  - **Zone** — `zones`.
-  - **Drop the Site facet.** Part A now pins the fetch to the building's own
-    site (see PR 1 design note), so a Site facet would be a no-op / could only
-    contradict the fixed scope. (This supersedes #728's "hide Site facet when
-    scope governs it" — here the scope *always* governs it.)
-  - Drop **Model / Subnet / Group** — no rack analog.
+  - **Building** — `buildingIds` / `includeNoBuilding`. Always shown.
+  - **Site** — `siteIds`. **Shown only when the header is all-sites**, and
+    `site:read`-gated. This mirrors the miner picker exactly
+    (`SearchMinersModal.tsx:75` / `ManageMinersModal.tsx:119`:
+    `showSiteFilter: !scope`): hide Site when a scope already pins one site
+    (the facet would be a no-op), show it when the fetch actually spans sites.
+    The only multi-site fetch is the "Show assigned racks" + all-sites global
+    broadening from Part B; scope-sync (#764) guarantees a scoped header equals
+    the building's site. We accept the harmless no-op in the toggle-off
+    all-sites view for strict parity with the miner picker (which keeps the
+    facet visible in both toggle states and leans on the empty state), rather
+    than adding a rack-only special case. (This *refines* the earlier "drop the
+    Site facet" decision, which was written under Part A when the fetch was
+    always single-site; Part B's all-sites broadening made Site meaningful.)
+  - **Drop the Zone facet — deferred.** Zone labels are unique only *within* a
+    building (`ZoneKey { building_id, zone }`; `proto/common/v1/zone.proto`),
+    so a label-only zone filter collides across buildings ("Room 2" matches
+    every building's "Room 2"). The client still forwards the **deprecated**
+    flat `zones: string[]` wildcard path (`listRacks` sends `zones`, not
+    `zoneKeys`; `listRackZones` returns `string[]`, no building context), so a
+    correct zone facet needs the `zoneKeys`/`ZoneRef` FE migration that the 229
+    plan (`docs/plans/2026-05-14-229-...`) explicitly defers to Phase 2. The
+    miner picker has **no** zone facet either, so deferring keeps parity. The
+    Building facet already provides building-level narrowing. Zone lands as a
+    follow-up alongside the `zoneKeys` migration (composite `Building — Zone`
+    labels + precise `zoneKeys`, per 229's "richer labels, no cascade" path).
+  - Drop **Model / Subnet / Group / Rack** — no rack analog.
 - Migrate **`ManageRacksModal`** from client-side slicing to **server-side
   pagination** (`pageSize`/`pageToken`, `PAGE_SIZE=50`) so scope + facets are
   correct across pages. `ManageRacksModal` has no name box (none today).
+  - Part B (#766, now merged) hides ineligible rows with a **client-side**
+    `items.filter(r => !r.reassignment)` before slicing. That filter does not
+    survive server-side pagination and becomes unnecessary — the toggle already
+    switches `scope → assignedScope`, so scope governs which rows return.
+    **Delete the client-side filter** rather than paginate around it.
 - **`SearchRacksModal` stays on fetch-all + client-side name filter** —
   single-select, list is small after site scoping. This is what defers name
   search with zero backend work and no regression.
 - Facets compose (AND) with the building-site scope.
 
-**Tests:** facet → request translation; scope + facets correct across
-`ManageRacksModal` pages.
+**Tests:** facet → request translation (Building maps to
+`buildingIds`/`includeNoBuilding`; Site maps to `siteIds` and is only offered
+under an all-sites header); scope + facets correct across `ManageRacksModal`
+pages; toggle-on/off breadth still correct after removing the client-side
+reassignment filter.
 
 ### PR 3 — Part B: "Show assigned racks" toggle + reparent — [#766](https://github.com/block/proto-fleet/issues/766)
 
@@ -245,8 +273,10 @@ header always agrees with the building (or is all-sites).
 - [ ] Selecting an already-placed rack prompts a reparent confirm before
       commit; `reassignedItems` reported to the host modal; dialog states
       miners move with the rack.
-- [ ] Building / Zone facets filter server-side and compose (AND) with the
-      building-site scope; Site facet dropped (scope always governs it).
+- [ ] Building facet filters server-side and composes (AND) with the
+      building-site scope. Site facet shown only under an all-sites header
+      (`site:read`-gated), mirroring the miner picker's `showSiteFilter: !scope`.
+      Zone facet deferred (see PR 2 note).
 - [ ] `ManageRacksModal` paginates server-side; scope + facets correct
       across pages.
 - [ ] Name search unchanged — `SearchRacksModal` client-side filter still
@@ -257,7 +287,11 @@ header always agrees with the building (or is all-sites).
 
 ## Out of scope
 
-- Model / Subnet / Group facets (no rack analog).
+- Model / Subnet / Group / Rack facets (no rack analog).
+- **Zone facet — deferred to a follow-up.** Needs the `zoneKeys`/`ZoneRef` FE
+  migration (229 plan, Phase 2) to avoid the cross-building label collision;
+  the client currently only wires the deprecated flat `zones` wildcard. Miner
+  picker has no zone facet either, so deferring holds parity.
 - Telemetry-range / error-component facets (possible follow-up).
 - Server-side name search / `nameQuery` proto field.
 


### PR DESCRIPTION
Reviewable diff: +370/-152 across 3 files (excludes generated, test, and story files).

## Summary

Migrates the building rack picker (`ManageRacksModal`) from fetch-all + client-side slicing to **true server-side pagination** with **server-side eligibility pinning and filter facets**. Operators now page through large rack sets against a real server total, filter by Building (and by Site under the all-sites header), and the eligible/reassignment distinction is enforced by the query rather than by filtering an already-fetched page — which is what kept page counts and select-all correct.

**Stack** — Part C (final) of the rack-picker parity effort (#758, plan: `docs/plans/2026-07-16-758-rack-picker-parity-plan.md`):

- Part A — site scoping — #760 ✅ merged
- Scope-sync — #764 / #769 ✅ merged
- Part B — "Show assigned racks" toggle + reparent confirm — #766 / #772 ✅ merged
- **Part C — server-side pagination + facets — this PR** ← targets `main`

This PR builds on Part B's contract: `ManageRacksModal` reports a `RackSelectionDelta { added, removed, reassigned }` and `ManageBuildingModal` commits reparents on continue. The `scope` / `assignedScope` props (site pinning + assignable set) come from Parts A/B. Reassignment stays a **display-only** flag — it never filters.

**Deviations from the issue text** (agreed during planning):
- The **Site facet is kept** but offered *only* under the all-sites header and gated on `site:read`, mirroring the miner picker — rather than dropped. Under a pinned site it would be a no-op, so it's simply not shown there.
- The **Zone facet is deferred** pending the `zoneKeys` migration (#229) — zone labels are unique only within a building, so a correct zone facet needs the cascading building→zone picker that #229 Phase 2 introduces.
- `SearchRacksModal` is untouched — it stays fetch-all + client-side name filter (single-select, small list), as scoped.

## How it works

The picker no longer holds the full rack list. All narrowing is expressed as a single server request; the UI only ever holds one page.

1. **Request derivation.** UI state (toggle, facets, scope) is folded into one `ListDeviceSetsRequest` filter:
   - **Toggle OFF (default, assignable-only):** the fetch is *pinned* to `buildingIds:[thisBuilding] + includeNoBuilding:true` within the site scope — only racks that can be assigned here. This replaces the old client-side `!reassignment` filter.
   - **Toggle ON:** the pin drops, the request broadens to `assignedScope`, and racks already placed elsewhere surface as selectable **reassignment** rows (flagged, moved behind a confirm at commit).
   - **Facets** compose (AND) on top: Building intersects the pin; Site (all-sites only) overrides the site scope.
2. **Pagination.** A page-token stack (`pageTokensRef`) drives forward/back; each page is fetched with `pageSize:50` + the stored token. The server returns the page, the next token, and a real total.
3. **The accumulator.** Because `computeRackSelectionDelta` needs to resolve every checked/unchecked id back to a rack item, but only one page is in memory, every fetched rack is folded into an id→item Map (`accumulatorRef`). At commit, the delta is computed against the *union of all seen racks*, not just the visible page. Ids absent from the accumulator are conservatively left alone (the seeded-rack-preservation invariant).
4. **Empty-by-construction.** Toggle-off + a Building facet that excludes this building can't match anything (`placementFacetConflict`); the picker renders empty instead of fetching (an empty `buildingIds` would drop the predicate and leak the whole site).
5. **Failure handling.** A failed *broadened* (toggle-on) fetch reverts the toggle, drops any reparent picks, and toasts — rather than stranding the operator behind the blocking error state (which hides the toggle). A scoped-fetch failure shows the blocking error.
6. **Select-all** sweeps the entire eligible set via a separate unpaginated fetch of the toggle-off request, folding results into the accumulator so the delta is complete.

```mermaid
flowchart TD
    Toggle["Show assigned toggle"] --> Req
    Facets["Building / Site facets"] --> Req
    Scope["scope / assignedScope (Parts A/B)"] --> Req
    Req["request (derived filter)"] --> Key["requestKey change -> reset tokens + accumulator"]
    Key --> Fetch["fetch effect: listRacks(pageSize, pageToken)"]
    Fetch --> Page["page items -> displayed"]
    Fetch --> Acc["fold every rack into accumulatorRef (id -> item)"]
    Page --> Confirm["Continue"]
    Acc --> Confirm
    Confirm --> Delta["computeRackSelectionDelta(all seen items) -> RackSelectionDelta"]
```

```mermaid
stateDiagram-v2
    [*] --> AssignableOnly
    AssignableOnly --> Broadened: toggle ON (broaden to assignedScope)
    Broadened --> AssignableOnly: toggle OFF (re-pin, drop reparent picks)
    Broadened --> AssignableOnly: broadened fetch fails (revert + toast)
    AssignableOnly --> ConflictEmpty: Building facet excludes this building
    ConflictEmpty --> AssignableOnly: facet cleared
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/.../ManageRacksModal/ManageRacksModal.tsx` | Core rewrite: server request derivation, page-token pagination, accumulator, facets, conflict/failure handling, select-all | The whole change — focus here |
| `client/.../ManageBuildingModal/ManageBuildingModal.tsx` | Passes `allSites={activeSite.kind === "all"}` into the picker | One line; gates the Site facet |
| `client/.../ManageRacksModal/ManageRacksModal.test.tsx` | Rewritten: server-equivalent mock (filter + paginate), facet→request, pagination, failure recovery, select-all | Test-only |
| `client/.../ManageBuildingModal/ManageBuildingModal.test.tsx` | Adds `listBuildings` to the mocked `useBuildings` (picker now calls it) | Test-only |
| `docs/plans/2026-07-16-758-rack-picker-parity-plan.md` | Part C section updated: facet set, Zone deferred, delete client filter | Doc only |

## Key technical decisions & trade-offs

- **Full server-side pagination over client-side slicing** — client filtering would empty pages after the fact and break page counts / select-all against the real total. Chosen over the simpler "fetch-all, slice locally" that Parts A/B used.
- **Server-side eligibility pinning** (not client `!reassignment` filter) — mirrors `MinerSelectionList`; the query returns only assignable racks so pagination is correct. The deleted client filter is why the pin is needed.
- **id→item accumulator** to satisfy `computeRackSelectionDelta`'s full-set contract despite only one page being resident — the alternative (pass the visible page) silently drops off-page selections.
- **Render-phase reset** (`prevRequestKeyRef`) instead of a reset effect — lands before the fetch effect reads `pageIndex` and avoids a cascading extra render / `set-state-in-effect` lint.
- **`placementFacetConflict` renders empty rather than fetching** — an empty `buildingIds` with `includeNoBuilding:false` would drop the building predicate and leak the whole site.
- **Conditional Site facet + deferred Zone** — see deviations above; keeps parity with the miner picker without pulling in the `zoneKeys` migration.

## Testing & validation

- `ManageRacksModal.test.tsx` — 15 tests: request pinning (toggle off/on), facet→`buildingIds`/`siteIds` translation, Site facet only under all-sites, pagination across pages with server total, select-all fetch-all, broadened-fetch failure recovery, reparent drop-on-toggle-off, seeded-absent-not-removed.
- Full buildings suite: **121/121 pass**. `tsc --noEmit` clean, `eslint` clean on all changed files, `just format` no diffs.
- **Not covered:** the Zone facet (deferred, #229); `SearchRacksModal` (unchanged).
