### PR TITLE
feat(firmware): persist upload target metadata

### DIFF
--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -13,7 +13,10 @@ export class SettingsFirmwarePage extends BasePage {
     await this.validateTitleInModal("Upload firmware");
   }
 
-  async uploadFirmwareFile(fileName: string, fileContents: string) {
+  async uploadFirmwareFile(fileName: string, fileContents: string, product = "Proto", model = "Rig") {
+    const modal = this.page.getByTestId("modal");
+    await modal.getByLabel("Product").fill(product);
+    await modal.getByLabel("Model").fill(model);
     await this.page.getByTestId("firmware-file-input").setInputFiles({
       name: fileName,
       mimeType: "application/octet-stream",

--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -13,10 +13,19 @@ export class SettingsFirmwarePage extends BasePage {
     await this.validateTitleInModal("Upload firmware");
   }
 
-  async uploadFirmwareFile(fileName: string, fileContents: string, product = "Proto", model = "Rig") {
+  async uploadFirmwareFile(
+    fileName: string,
+    fileContents: string,
+    manufacturer = "Proto",
+    model = "Rig",
+    firmwareVersion = "2.4.6",
+  ) {
     const modal = this.page.getByTestId("modal");
-    await modal.getByLabel("Product").fill(product);
-    await modal.getByLabel("Model").fill(model);
+    await modal.getByLabel("Manufacturer").click();
+    await this.page.getByRole("option", { name: manufacturer, exact: true }).click();
+    await modal.getByLabel("Model").click();
+    await this.page.getByRole("option", { name: model, exact: true }).click();
+    await modal.getByLabel("Firmware version").fill(firmwareVersion);
     await this.page.getByTestId("firmware-file-input").setInputFiles({
       name: fileName,
       mimeType: "application/octet-stream",

--- a/client/src/protoFleet/api/useFileUpload.ts
+++ b/client/src/protoFleet/api/useFileUpload.ts
@@ -13,6 +13,8 @@ export interface FileUploadOptions {
   onProgress?: (percent: number) => void;
   signal?: AbortSignal;
   fieldName?: string;
+  formFields?: Record<string, string>;
+  initiateFields?: Record<string, string | number | boolean>;
   chunked?: ChunkedUploadConfig;
 }
 
@@ -138,7 +140,7 @@ async function uploadChunked(
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ filename: file.name, file_size: file.size }),
+    body: JSON.stringify({ filename: file.name, file_size: file.size, ...options.initiateFields }),
     signal,
   });
 
@@ -250,6 +252,9 @@ function uploadDirect(
     });
 
     const formData = new FormData();
+    for (const [key, value] of Object.entries(options?.formFields ?? {})) {
+      formData.append(key, value);
+    }
     formData.append(options?.fieldName ?? "file", file);
     xhr.send(formData);
   });

--- a/client/src/protoFleet/api/useFirmwareApi.test.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.test.ts
@@ -4,6 +4,7 @@ import { _resetConfigCache, useFirmwareApi, validateFirmwareFile } from "./useFi
 
 const mockLogout = vi.fn();
 const mockUpload = vi.fn();
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21" };
 
 vi.mock("@/protoFleet/store", () => ({
   useLogout: () => mockLogout,
@@ -90,7 +91,7 @@ describe("useFirmwareApi", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       const { result } = renderHook(() => useFirmwareApi());
-      await result.current.checkFirmwareFile("abc123");
+      await result.current.checkFirmwareFile("abc123", firmwareTarget);
 
       expect(mockFetch).toHaveBeenCalledWith(
         "/api-proxy/api/v1/firmware/check",
@@ -98,7 +99,7 @@ describe("useFirmwareApi", () => {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sha256: "abc123" }),
+          body: JSON.stringify({ sha256: "abc123", target_manufacturer: "Proto", target_model: "S21" }),
         }),
       );
     });
@@ -114,7 +115,7 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      const data = await result.current.checkFirmwareFile("abc123");
+      const data = await result.current.checkFirmwareFile("abc123", firmwareTarget);
 
       expect(data).toEqual({ exists: true, firmwareFileId: "file-123" });
     });
@@ -130,7 +131,7 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      const data = await result.current.checkFirmwareFile("abc123");
+      const data = await result.current.checkFirmwareFile("abc123", firmwareTarget);
 
       expect(data).toEqual({ exists: false, firmwareFileId: undefined });
     });
@@ -146,7 +147,7 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      await expect(result.current.checkFirmwareFile("abc123")).rejects.toThrow("Session expired");
+      await expect(result.current.checkFirmwareFile("abc123", firmwareTarget)).rejects.toThrow("Session expired");
 
       expect(mockLogout).toHaveBeenCalledOnce();
     });
@@ -163,7 +164,9 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      await expect(result.current.checkFirmwareFile("abc123")).rejects.toThrow("Firmware check failed: 500");
+      await expect(result.current.checkFirmwareFile("abc123", firmwareTarget)).rejects.toThrow(
+        "Firmware check failed: 500",
+      );
 
       expect(mockLogout).not.toHaveBeenCalled();
     });
@@ -180,7 +183,9 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      await expect(result.current.checkFirmwareFile("bad")).rejects.toThrow("sha256 must be a 64-character hex string");
+      await expect(result.current.checkFirmwareFile("bad", firmwareTarget)).rejects.toThrow(
+        "sha256 must be a 64-character hex string",
+      );
     });
   });
 
@@ -201,7 +206,7 @@ describe("useFirmwareApi", () => {
 
       const file = new File(["data"], "firmware.swu");
       const { result } = renderHook(() => useFirmwareApi());
-      const id = await result.current.uploadFirmwareFile(file);
+      const id = await result.current.uploadFirmwareFile(file, firmwareTarget);
 
       expect(id).toBe("fw-abc");
       expect(mockUpload).toHaveBeenCalledWith(
@@ -210,6 +215,10 @@ describe("useFirmwareApi", () => {
         expect.objectContaining({
           onProgress: undefined,
           signal: undefined,
+          formFields: {
+            target_manufacturer: "Proto",
+            target_model: "S21",
+          },
         }),
       );
     });
@@ -230,7 +239,7 @@ describe("useFirmwareApi", () => {
       const file = new File(["a".repeat(10)], "firmware.swu");
       const onProgress = vi.fn();
       const { result } = renderHook(() => useFirmwareApi());
-      const id = await result.current.uploadFirmwareFile(file, { onProgress });
+      const id = await result.current.uploadFirmwareFile(file, { ...firmwareTarget, onProgress });
 
       expect(id).toBe("fw-chunked");
       expect(mockUpload).toHaveBeenCalledWith(
@@ -238,6 +247,10 @@ describe("useFirmwareApi", () => {
         file,
         expect.objectContaining({
           onProgress,
+          initiateFields: {
+            target_manufacturer: "Proto",
+            target_model: "S21",
+          },
           chunked: expect.objectContaining({
             enabled: true,
             chunkSize: 5,
@@ -265,7 +278,7 @@ describe("useFirmwareApi", () => {
       const file = new File(["data"], "firmware.swu");
       const { result } = renderHook(() => useFirmwareApi());
 
-      await expect(result.current.uploadFirmwareFile(file)).rejects.toThrow(
+      await expect(result.current.uploadFirmwareFile(file, firmwareTarget)).rejects.toThrow(
         "Server response missing firmware_file_id.",
       );
     });
@@ -290,7 +303,7 @@ describe("useFirmwareApi", () => {
       const file = new File(["data"], "firmware.swu");
       const { result } = renderHook(() => useFirmwareApi());
 
-      await result.current.uploadFirmwareFile(file, { signal: controller.signal });
+      await result.current.uploadFirmwareFile(file, { ...firmwareTarget, signal: controller.signal });
 
       expect(mockUpload).toHaveBeenCalledWith(
         expect.any(String),
@@ -302,7 +315,16 @@ describe("useFirmwareApi", () => {
 
   describe("listFirmwareFiles", () => {
     it("sends GET with credentials and returns file list", async () => {
-      const mockFiles = [{ id: "f1", filename: "fw.swu", size: 1024, uploaded_at: "2025-01-01T00:00:00Z" }];
+      const mockFiles = [
+        {
+          id: "f1",
+          filename: "fw.swu",
+          size: 1024,
+          uploaded_at: "2025-01-01T00:00:00Z",
+          target_manufacturer: "Proto",
+          target_model: "S21",
+        },
+      ];
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         status: 200,

--- a/client/src/protoFleet/api/useFirmwareApi.test.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.test.ts
@@ -4,7 +4,7 @@ import { _resetConfigCache, useFirmwareApi, validateFirmwareFile } from "./useFi
 
 const mockLogout = vi.fn();
 const mockUpload = vi.fn();
-const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21" };
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21", firmwareVersion: "v2.0.0" };
 
 vi.mock("@/protoFleet/store", () => ({
   useLogout: () => mockLogout,
@@ -99,7 +99,12 @@ describe("useFirmwareApi", () => {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sha256: "abc123", target_manufacturer: "Proto", target_model: "S21" }),
+          body: JSON.stringify({
+            sha256: "abc123",
+            target_manufacturer: "Proto",
+            target_model: "S21",
+            firmware_version: "v2.0.0",
+          }),
         }),
       );
     });
@@ -218,6 +223,7 @@ describe("useFirmwareApi", () => {
           formFields: {
             target_manufacturer: "Proto",
             target_model: "S21",
+            firmware_version: "v2.0.0",
           },
         }),
       );
@@ -250,6 +256,7 @@ describe("useFirmwareApi", () => {
           initiateFields: {
             target_manufacturer: "Proto",
             target_model: "S21",
+            firmware_version: "v2.0.0",
           },
           chunked: expect.objectContaining({
             enabled: true,
@@ -257,6 +264,54 @@ describe("useFirmwareApi", () => {
           }),
         }),
       );
+    });
+
+    it("requires metadata for swu upload", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              allowed_extensions: [".swu"],
+              max_file_size_bytes: 500 * 1024 * 1024,
+              chunk_size_bytes: 1 * 1024 * 1024,
+            }),
+        }),
+      );
+
+      const file = new File(["data"], "proto-rig.swu");
+      const { result } = renderHook(() => useFirmwareApi());
+
+      await expect(result.current.uploadFirmwareFile(file)).rejects.toThrow(
+        "Manufacturer, model, and firmware version are required.",
+      );
+      expect(mockUpload).not.toHaveBeenCalled();
+    });
+
+    it("requires metadata for non-swu upload", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              allowed_extensions: [".zip"],
+              max_file_size_bytes: 500 * 1024 * 1024,
+              chunk_size_bytes: 1 * 1024 * 1024,
+            }),
+        }),
+      );
+
+      const file = new File(["data"], "firmware.zip");
+      const { result } = renderHook(() => useFirmwareApi());
+
+      await expect(result.current.uploadFirmwareFile(file)).rejects.toThrow(
+        "Manufacturer, model, and firmware version are required.",
+      );
+      expect(mockUpload).not.toHaveBeenCalled();
     });
 
     it("throws when upload response is missing firmware_file_id", async () => {
@@ -323,6 +378,7 @@ describe("useFirmwareApi", () => {
           uploaded_at: "2025-01-01T00:00:00Z",
           target_manufacturer: "Proto",
           target_model: "S21",
+          firmware_version: "v2.0.0",
         },
       ];
       const mockFetch = vi.fn().mockResolvedValue({

--- a/client/src/protoFleet/api/useFirmwareApi.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.ts
@@ -66,6 +66,8 @@ async function fetchFirmwareConfig(logout: () => void): Promise<FirmwareConfig> 
 }
 
 export interface FirmwareUploadOptions {
+  targetManufacturer: string;
+  targetModel: string;
   onProgress?: (percent: number) => void;
   signal?: AbortSignal;
 }
@@ -96,6 +98,8 @@ export interface FirmwareFileInfo {
   filename: string;
   size: number;
   uploaded_at: string;
+  target_manufacturer: string;
+  target_model: string;
 }
 
 interface CheckFirmwareResponse {
@@ -112,12 +116,20 @@ export const useFirmwareApi = () => {
   }, [logout]);
 
   const checkFirmwareFile = useCallback(
-    async (sha256: string, signal?: AbortSignal): Promise<{ exists: boolean; firmwareFileId?: string }> => {
+    async (
+      sha256: string,
+      target: { targetManufacturer: string; targetModel: string },
+      signal?: AbortSignal,
+    ): Promise<{ exists: boolean; firmwareFileId?: string }> => {
       const response = await fetch(`${API_BASE}/check`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sha256 }),
+        body: JSON.stringify({
+          sha256,
+          target_manufacturer: target.targetManufacturer,
+          target_model: target.targetModel,
+        }),
         signal,
       });
 
@@ -146,6 +158,14 @@ export const useFirmwareApi = () => {
   const uploadFirmwareFile = useCallback(
     async (file: File, options?: FirmwareUploadOptions): Promise<string> => {
       const config = await fetchFirmwareConfig(logout);
+      const targetManufacturer = options?.targetManufacturer.trim();
+      const targetModel = options?.targetModel.trim();
+      if (!targetManufacturer) {
+        throw new Error("Product is required.");
+      }
+      if (!targetModel) {
+        throw new Error("Model is required.");
+      }
 
       let data: unknown;
       const useChunked = file.size > config.chunkSizeBytes;
@@ -153,6 +173,10 @@ export const useFirmwareApi = () => {
         data = await upload(`${API_BASE}/upload`, file, {
           onProgress: options?.onProgress,
           signal: options?.signal,
+          initiateFields: {
+            target_manufacturer: targetManufacturer,
+            target_model: targetModel,
+          },
           chunked: {
             enabled: true,
             chunkSize: config.chunkSizeBytes,
@@ -165,6 +189,10 @@ export const useFirmwareApi = () => {
         data = await upload(`${API_BASE}/upload`, file, {
           onProgress: options?.onProgress,
           signal: options?.signal,
+          formFields: {
+            target_manufacturer: targetManufacturer,
+            target_model: targetModel,
+          },
         });
       }
 

--- a/client/src/protoFleet/api/useFirmwareApi.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.ts
@@ -66,8 +66,9 @@ async function fetchFirmwareConfig(logout: () => void): Promise<FirmwareConfig> 
 }
 
 export interface FirmwareUploadOptions {
-  targetManufacturer: string;
-  targetModel: string;
+  targetManufacturer?: string;
+  targetModel?: string;
+  firmwareVersion?: string;
   onProgress?: (percent: number) => void;
   signal?: AbortSignal;
 }
@@ -100,11 +101,31 @@ export interface FirmwareFileInfo {
   uploaded_at: string;
   target_manufacturer: string;
   target_model: string;
+  firmware_version?: string;
 }
 
 interface CheckFirmwareResponse {
   exists: boolean;
   firmware_file_id?: string;
+}
+
+function hasCompleteFirmwareTarget(target: {
+  targetManufacturer?: string;
+  targetModel?: string;
+  firmwareVersion?: string;
+}): boolean {
+  return Boolean(target.targetManufacturer?.trim() && target.targetModel?.trim() && target.firmwareVersion?.trim());
+}
+
+function firmwareMetadataFields(options?: FirmwareUploadOptions): Record<string, string> {
+  const fields: Record<string, string> = {};
+  const targetManufacturer = options?.targetManufacturer?.trim();
+  const targetModel = options?.targetModel?.trim();
+  const firmwareVersion = options?.firmwareVersion?.trim();
+  if (targetManufacturer) fields.target_manufacturer = targetManufacturer;
+  if (targetModel) fields.target_model = targetModel;
+  if (firmwareVersion) fields.firmware_version = firmwareVersion;
+  return fields;
 }
 
 export const useFirmwareApi = () => {
@@ -118,7 +139,7 @@ export const useFirmwareApi = () => {
   const checkFirmwareFile = useCallback(
     async (
       sha256: string,
-      target: { targetManufacturer: string; targetModel: string },
+      target: { targetManufacturer: string; targetModel: string; firmwareVersion: string },
       signal?: AbortSignal,
     ): Promise<{ exists: boolean; firmwareFileId?: string }> => {
       const response = await fetch(`${API_BASE}/check`, {
@@ -129,6 +150,7 @@ export const useFirmwareApi = () => {
           sha256,
           target_manufacturer: target.targetManufacturer,
           target_model: target.targetModel,
+          firmware_version: target.firmwareVersion,
         }),
         signal,
       });
@@ -158,14 +180,10 @@ export const useFirmwareApi = () => {
   const uploadFirmwareFile = useCallback(
     async (file: File, options?: FirmwareUploadOptions): Promise<string> => {
       const config = await fetchFirmwareConfig(logout);
-      const targetManufacturer = options?.targetManufacturer.trim();
-      const targetModel = options?.targetModel.trim();
-      if (!targetManufacturer) {
-        throw new Error("Product is required.");
+      if (!hasCompleteFirmwareTarget(options ?? {})) {
+        throw new Error("Manufacturer, model, and firmware version are required.");
       }
-      if (!targetModel) {
-        throw new Error("Model is required.");
-      }
+      const metadataFields = firmwareMetadataFields(options);
 
       let data: unknown;
       const useChunked = file.size > config.chunkSizeBytes;
@@ -173,10 +191,7 @@ export const useFirmwareApi = () => {
         data = await upload(`${API_BASE}/upload`, file, {
           onProgress: options?.onProgress,
           signal: options?.signal,
-          initiateFields: {
-            target_manufacturer: targetManufacturer,
-            target_model: targetModel,
-          },
+          initiateFields: metadataFields,
           chunked: {
             enabled: true,
             chunkSize: config.chunkSizeBytes,
@@ -189,10 +204,7 @@ export const useFirmwareApi = () => {
         data = await upload(`${API_BASE}/upload`, file, {
           onProgress: options?.onProgress,
           signal: options?.signal,
-          formFields: {
-            target_manufacturer: targetManufacturer,
-            target_model: targetModel,
-          },
+          formFields: metadataFields,
         });
       }
 

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
@@ -16,6 +16,8 @@ vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
   validateFirmwareFile: vi.fn().mockReturnValue(null),
 }));
 
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21" };
+
 const defaultConfig = {
   allowedExtensions: [".swu", ".tar.gz", ".zip"],
   maxFileSizeBytes: 500 * 1024 * 1024,
@@ -106,7 +108,7 @@ describe("useFirmwareUpload", () => {
       const file = new File(["data"], "firmware.swu");
 
       act(() => {
-        result.current.processFile(file);
+        result.current.processFile(file, firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -129,7 +131,7 @@ describe("useFirmwareUpload", () => {
       const file = new File(["data"], "firmware.swu");
 
       act(() => {
-        result.current.processFile(file);
+        result.current.processFile(file, firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -148,7 +150,7 @@ describe("useFirmwareUpload", () => {
       expect(result.current.serverConfig).toBeNull();
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -168,7 +170,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -191,7 +193,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "first.swu"));
+        result.current.processFile(new File(["data"], "first.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -199,7 +201,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "second.swu"));
+        result.current.processFile(new File(["data"], "second.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -224,7 +226,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -244,7 +246,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.bin"));
+        result.current.processFile(new File(["data"], "firmware.bin"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -265,7 +267,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -298,7 +300,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
   validateFirmwareFile: vi.fn().mockReturnValue(null),
 }));
 
-const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21" };
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21", firmwareVersion: "v2.0.0" };
 
 const defaultConfig = {
   allowedExtensions: [".swu", ".tar.gz", ".zip"],
@@ -138,6 +138,27 @@ describe("useFirmwareUpload", () => {
         expect(result.current.state).toBe("ready");
       });
       expect(result.current.firmwareFileId).toBe("fw-existing");
+      expect(mockUploadFirmwareFile).not.toHaveBeenCalled();
+    });
+
+    it("sets error state when target metadata is incomplete", async () => {
+      const { result } = renderHook(() => useFirmwareUpload(true));
+
+      await vi.waitFor(() => {
+        expect(result.current.serverConfig).not.toBeNull();
+      });
+
+      const file = new File(["data"], "proto-rig.swu");
+
+      act(() => {
+        result.current.processFile(file, { targetManufacturer: "", targetModel: "", firmwareVersion: "" });
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.state).toBe("error");
+      });
+      expect(result.current.errorMessage).toBe("Manufacturer, model, and firmware version are required.");
+      expect(mockCheckFirmwareFile).not.toHaveBeenCalled();
       expect(mockUploadFirmwareFile).not.toHaveBeenCalled();
     });
 

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
@@ -19,6 +19,13 @@ export interface UseFirmwareUploadReturn {
 export interface FirmwareUploadTarget {
   targetManufacturer: string;
   targetModel: string;
+  firmwareVersion: string;
+}
+
+function hasCompleteFirmwareTarget(target: FirmwareUploadTarget): boolean {
+  return (
+    target.targetManufacturer.trim() !== "" && target.targetModel.trim() !== "" && target.firmwareVersion.trim() !== ""
+  );
 }
 
 export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
@@ -96,6 +103,11 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
           setState("error");
           return;
         }
+        if (!hasCompleteFirmwareTarget(target)) {
+          setErrorMessage("Manufacturer, model, and firmware version are required.");
+          setState("error");
+          return;
+        }
 
         setFile(selectedFile);
         setState("hashing");
@@ -117,6 +129,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         const newId = await uploadFirmwareFile(selectedFile, {
           targetManufacturer: target.targetManufacturer,
           targetModel: target.targetModel,
+          firmwareVersion: target.firmwareVersion,
           onProgress: setUploadProgress,
           signal: controller.signal,
         });

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
@@ -11,9 +11,14 @@ export interface UseFirmwareUploadReturn {
   uploadProgress: number;
   errorMessage: string | null;
   serverConfig: FirmwareConfig | null;
-  processFile: (file: File) => void;
+  processFile: (file: File, target: FirmwareUploadTarget) => void;
   reset: () => void;
   retry: () => void;
+}
+
+export interface FirmwareUploadTarget {
+  targetManufacturer: string;
+  targetModel: string;
 }
 
 export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
@@ -76,7 +81,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
   }, [reset]);
 
   const processFile = useCallback(
-    async (selectedFile: File) => {
+    async (selectedFile: File, target: FirmwareUploadTarget) => {
       abortControllerRef.current?.abort();
       const controller = new AbortController();
       abortControllerRef.current = controller;
@@ -98,7 +103,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         if (controller.signal.aborted) return;
 
         setState("checking");
-        const { exists, firmwareFileId: existingId } = await checkFirmwareFile(sha256, controller.signal);
+        const { exists, firmwareFileId: existingId } = await checkFirmwareFile(sha256, target, controller.signal);
         if (controller.signal.aborted) return;
 
         if (exists && existingId) {
@@ -110,6 +115,8 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         setState("uploading");
         setUploadProgress(0);
         const newId = await uploadFirmwareFile(selectedFile, {
+          targetManufacturer: target.targetManufacturer,
+          targetModel: target.targetModel,
           onProgress: setUploadProgress,
           signal: controller.signal,
         });
@@ -125,7 +132,10 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
     [checkFirmwareFile, uploadFirmwareFile, serverConfig, getConfig],
   );
 
-  const wrappedProcessFile = useCallback((f: File) => void processFile(f), [processFile]);
+  const wrappedProcessFile = useCallback(
+    (f: File, target: FirmwareUploadTarget) => void processFile(f, target),
+    [processFile],
+  );
 
   return {
     state,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
@@ -80,13 +80,53 @@ describe("FirmwareUpdateModal", () => {
 
   it("renders existing files immediately even while config is still loading", async () => {
     mockListFirmwareFiles.mockResolvedValue([
-      { id: "fw-1", filename: "alpha.swu", size: 1024, uploaded_at: "2025-01-01T00:00:00Z" },
+      {
+        id: "fw-1",
+        filename: "alpha.swu",
+        size: 1024,
+        uploaded_at: "2025-01-01T00:00:00Z",
+        target_manufacturer: "Proto",
+        target_model: "S21",
+      },
     ]);
 
     render(<FirmwareUpdateModal open onConfirm={vi.fn()} onDismiss={vi.fn()} />);
 
     expect(await screen.findByText("Select an existing firmware file")).toBeInTheDocument();
     expect(screen.getByText("alpha.swu")).toBeInTheDocument();
+  });
+
+  it("filters existing files to the selected miner target", async () => {
+    mockListFirmwareFiles.mockResolvedValue([
+      {
+        id: "fw-1",
+        filename: "alpha.swu",
+        size: 1024,
+        uploaded_at: "2025-01-01T00:00:00Z",
+        target_manufacturer: "Proto",
+        target_model: "Rig",
+      },
+      {
+        id: "fw-2",
+        filename: "beta.swu",
+        size: 1024,
+        uploaded_at: "2025-01-01T00:00:00Z",
+        target_manufacturer: "Bitmain",
+        target_model: "S21",
+      },
+    ]);
+
+    render(
+      <FirmwareUpdateModal
+        open
+        target={{ targetManufacturer: "Proto", targetModel: "Rig" }}
+        onConfirm={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("alpha.swu")).toBeInTheDocument();
+    expect(screen.queryByText("beta.swu")).not.toBeInTheDocument();
   });
 
   it("explains that miners reboot automatically after firmware installation", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import type { FirmwareFileInfo } from "@/protoFleet/api/useFirmwareApi";
 import { useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
@@ -11,6 +11,7 @@ import {
 } from "@/protoFleet/components/FirmwareUpload";
 import Button, { sizes as buttonSizes, variants } from "@/shared/components/Button";
 import { formatFileSize } from "@/shared/components/FileSizeValue";
+import Input from "@/shared/components/Input";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
@@ -18,11 +19,23 @@ import { formatTimestamp, isoToEpochSeconds } from "@/shared/utils/formatTimesta
 
 interface FirmwareUpdateModalProps {
   open?: boolean;
+  target?: {
+    targetManufacturer: string;
+    targetModel: string;
+  } | null;
   onConfirm: (firmwareFileId: string) => void;
   onDismiss: () => void;
 }
 
-const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModalProps) => {
+const fileMatchesTarget = (
+  file: FirmwareFileInfo,
+  target: { targetManufacturer: string; targetModel: string } | null | undefined,
+) => {
+  if (!target) return true;
+  return file.target_manufacturer === target.targetManufacturer && file.target_model === target.targetModel;
+};
+
+const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpdateModalProps) => {
   const {
     state: uploadState,
     file: uploadFile,
@@ -39,6 +52,16 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
   const [existingFiles, setExistingFiles] = useState<FirmwareFileInfo[] | null>(null);
   const [selectedExistingFileId, setSelectedExistingFileId] = useState<string | null>(null);
   const [showUploadZone, setShowUploadZone] = useState(false);
+  const [targetManufacturer, setTargetManufacturer] = useState("");
+  const [targetModel, setTargetModel] = useState("");
+
+  const effectiveTargetManufacturer = target?.targetManufacturer ?? targetManufacturer;
+  const effectiveTargetModel = target?.targetModel ?? targetModel;
+  const uploadTarget = useMemo(
+    () => ({ targetManufacturer: effectiveTargetManufacturer.trim(), targetModel: effectiveTargetModel.trim() }),
+    [effectiveTargetManufacturer, effectiveTargetModel],
+  );
+  const hasUploadTarget = uploadTarget.targetManufacturer !== "" && uploadTarget.targetModel !== "";
 
   useEffect(() => {
     if (open) {
@@ -74,13 +97,18 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
     (file: File) => {
       setSelectedExistingFileId(null);
       setShowUploadZone(true);
-      processFile(file);
+      processFile(file, uploadTarget);
     },
-    [processFile],
+    [processFile, uploadTarget],
   );
 
   const effectiveFirmwareFileId = selectedExistingFileId ?? uploadedFileId;
   const isReady = selectedExistingFileId != null || uploadState === "ready";
+  const compatibleExistingFiles = useMemo(
+    () => existingFiles?.filter((file) => fileMatchesTarget(file, target)) ?? null,
+    [existingFiles, target],
+  );
+  const visibleExistingFiles = compatibleExistingFiles ?? [];
 
   const handleConfirm = useCallback(() => {
     if (effectiveFirmwareFileId) {
@@ -89,6 +117,8 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
       setSelectedExistingFileId(null);
       setExistingFiles(null);
       setShowUploadZone(false);
+      setTargetManufacturer("");
+      setTargetModel("");
     }
   }, [effectiveFirmwareFileId, onConfirm, reset]);
 
@@ -97,12 +127,14 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
     setSelectedExistingFileId(null);
     setExistingFiles(null);
     setShowUploadZone(false);
+    setTargetManufacturer("");
+    setTargetModel("");
     onDismiss();
   }, [onDismiss, reset]);
 
   const isProcessing = uploadState === "hashing" || uploadState === "checking" || uploadState === "uploading";
   const configLoading = uploadState !== "error" && !serverConfig;
-  const hasExistingFiles = existingFiles != null && existingFiles.length > 0;
+  const hasExistingFiles = visibleExistingFiles.length > 0;
   const showLoadingSpinner = configLoading && !hasExistingFiles;
 
   const buttons = isReady ? [{ text: "Continue", variant: variants.primary, onClick: handleConfirm }] : undefined;
@@ -127,7 +159,7 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
               role="radiogroup"
               aria-label="Existing firmware files"
             >
-              {existingFiles.map((f) => (
+              {visibleExistingFiles.map((f) => (
                 <button
                   key={f.id}
                   type="button"
@@ -151,7 +183,8 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
                   <div className="flex min-w-0 flex-col">
                     <div className="truncate text-300 text-text-primary">{f.filename}</div>
                     <div className="text-200 text-text-primary-70">
-                      {formatFileSize(f.size)}, {formatTimestamp(isoToEpochSeconds(f.uploaded_at))}
+                      {f.target_manufacturer} {f.target_model} · {formatFileSize(f.size)} ·{" "}
+                      {formatTimestamp(isoToEpochSeconds(f.uploaded_at))}
                     </div>
                   </div>
                 </button>
@@ -176,7 +209,31 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
         {uploadState === "error" && errorMessage ? <FileErrorStatus message={errorMessage} onRetry={retry} /> : null}
 
         {uploadState === "idle" && serverConfig && (!hasExistingFiles || showUploadZone) ? (
-          <FileDropZone extensions={serverConfig.allowedExtensions} onFileSelect={handleUploadFileSelect} />
+          <>
+            <div className="grid gap-4 tablet:grid-cols-2">
+              <Input
+                id="firmware-update-target-manufacturer"
+                label="Product"
+                initValue={effectiveTargetManufacturer}
+                onChange={setTargetManufacturer}
+                disabled={!!target}
+                required
+              />
+              <Input
+                id="firmware-update-target-model"
+                label="Model"
+                initValue={effectiveTargetModel}
+                onChange={setTargetModel}
+                disabled={!!target}
+                required
+              />
+            </div>
+            <FileDropZone
+              extensions={serverConfig.allowedExtensions}
+              onFileSelect={handleUploadFileSelect}
+              disabled={!hasUploadTarget}
+            />
+          </>
         ) : null}
 
         {isProcessing && uploadFile ? (

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -54,14 +54,20 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
   const [showUploadZone, setShowUploadZone] = useState(false);
   const [targetManufacturer, setTargetManufacturer] = useState("");
   const [targetModel, setTargetModel] = useState("");
+  const [firmwareVersion, setFirmwareVersion] = useState("");
 
   const effectiveTargetManufacturer = target?.targetManufacturer ?? targetManufacturer;
   const effectiveTargetModel = target?.targetModel ?? targetModel;
   const uploadTarget = useMemo(
-    () => ({ targetManufacturer: effectiveTargetManufacturer.trim(), targetModel: effectiveTargetModel.trim() }),
-    [effectiveTargetManufacturer, effectiveTargetModel],
+    () => ({
+      targetManufacturer: effectiveTargetManufacturer.trim(),
+      targetModel: effectiveTargetModel.trim(),
+      firmwareVersion: firmwareVersion.trim(),
+    }),
+    [effectiveTargetManufacturer, effectiveTargetModel, firmwareVersion],
   );
-  const hasUploadTarget = uploadTarget.targetManufacturer !== "" && uploadTarget.targetModel !== "";
+  const hasUploadTarget =
+    uploadTarget.targetManufacturer !== "" && uploadTarget.targetModel !== "" && uploadTarget.firmwareVersion !== "";
 
   useEffect(() => {
     if (open) {
@@ -119,6 +125,7 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
       setShowUploadZone(false);
       setTargetManufacturer("");
       setTargetModel("");
+      setFirmwareVersion("");
     }
   }, [effectiveFirmwareFileId, onConfirm, reset]);
 
@@ -129,6 +136,7 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
     setShowUploadZone(false);
     setTargetManufacturer("");
     setTargetModel("");
+    setFirmwareVersion("");
     onDismiss();
   }, [onDismiss, reset]);
 
@@ -183,7 +191,8 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
                   <div className="flex min-w-0 flex-col">
                     <div className="truncate text-300 text-text-primary">{f.filename}</div>
                     <div className="text-200 text-text-primary-70">
-                      {f.target_manufacturer} {f.target_model} · {formatFileSize(f.size)} ·{" "}
+                      {f.target_manufacturer} {f.target_model}
+                      {f.firmware_version ? ` · ${f.firmware_version}` : ""} · {formatFileSize(f.size)} ·{" "}
                       {formatTimestamp(isoToEpochSeconds(f.uploaded_at))}
                     </div>
                   </div>
@@ -228,6 +237,13 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
                 required
               />
             </div>
+            <Input
+              id="firmware-update-version"
+              label="Firmware version"
+              initValue={firmwareVersion}
+              onChange={setFirmwareVersion}
+              required
+            />
             <FileDropZone
               extensions={serverConfig.allowedExtensions}
               onFileSelect={handleUploadFileSelect}

--- a/client/src/protoFleet/features/settings/components/Firmware.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.test.tsx
@@ -24,8 +24,22 @@ beforeEach(() => {
 });
 
 const sampleFiles = [
-  { id: "f1", filename: "alpha.swu", size: 1024, uploaded_at: "2025-06-01T12:00:00Z" },
-  { id: "f2", filename: "beta.tar.gz", size: 2048000, uploaded_at: "2025-06-02T14:30:00Z" },
+  {
+    id: "f1",
+    filename: "alpha.swu",
+    size: 1024,
+    uploaded_at: "2025-06-01T12:00:00Z",
+    target_manufacturer: "Proto",
+    target_model: "S21",
+  },
+  {
+    id: "f2",
+    filename: "beta.tar.gz",
+    size: 2048000,
+    uploaded_at: "2025-06-02T14:30:00Z",
+    target_manufacturer: "Bitmain",
+    target_model: "S19",
+  },
 ];
 
 describe("Firmware", () => {

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -16,14 +16,16 @@ import { formatTimestamp, isoToEpochSeconds } from "@/shared/utils/formatTimesta
 type FirmwareFileData = {
   id: string;
   filename: string;
+  target: string;
   size: number;
   uploadedAt: number;
 };
 
-type FirmwareColumns = "filename" | "uploadedAt" | "size";
+type FirmwareColumns = "filename" | "target" | "uploadedAt" | "size";
 
 const colTitles: ColTitles<FirmwareColumns> = {
   filename: "File name",
+  target: "Target",
   uploadedAt: "Uploaded",
   size: "Size",
 };
@@ -32,6 +34,10 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
   filename: {
     component: (file) => <span className="text-emphasis-300">{file.filename}</span>,
     width: "w-60",
+  },
+  target: {
+    component: (file) => <span>{file.target}</span>,
+    width: "w-48",
   },
   uploadedAt: {
     component: (file) => <span>{formatTimestamp(file.uploadedAt)}</span>,
@@ -43,13 +49,14 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
   },
 };
 
-const activeCols: FirmwareColumns[] = ["filename", "uploadedAt", "size"];
+const activeCols: FirmwareColumns[] = ["filename", "target", "uploadedAt", "size"];
 const FIRMWARE_PAGE_DESCRIPTION = "Upload and manage firmware files available to your fleet.";
 
 function toFileData(info: FirmwareFileInfo): FirmwareFileData {
   return {
     id: info.id,
     filename: info.filename,
+    target: `${info.target_manufacturer} ${info.target_model}`.trim(),
     size: info.size,
     uploadedAt: isoToEpochSeconds(info.uploaded_at),
   };

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -17,15 +17,17 @@ type FirmwareFileData = {
   id: string;
   filename: string;
   target: string;
+  firmwareVersion: string;
   size: number;
   uploadedAt: number;
 };
 
-type FirmwareColumns = "filename" | "target" | "uploadedAt" | "size";
+type FirmwareColumns = "filename" | "target" | "firmwareVersion" | "uploadedAt" | "size";
 
 const colTitles: ColTitles<FirmwareColumns> = {
   filename: "File name",
   target: "Target",
+  firmwareVersion: "Version",
   uploadedAt: "Uploaded",
   size: "Size",
 };
@@ -39,6 +41,10 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
     component: (file) => <span>{file.target}</span>,
     width: "w-48",
   },
+  firmwareVersion: {
+    component: (file) => <span>{file.firmwareVersion || "-"}</span>,
+    width: "w-36",
+  },
   uploadedAt: {
     component: (file) => <span>{formatTimestamp(file.uploadedAt)}</span>,
     width: "w-48",
@@ -49,7 +55,7 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
   },
 };
 
-const activeCols: FirmwareColumns[] = ["filename", "target", "uploadedAt", "size"];
+const activeCols: FirmwareColumns[] = ["filename", "target", "firmwareVersion", "uploadedAt", "size"];
 const FIRMWARE_PAGE_DESCRIPTION = "Upload and manage firmware files available to your fleet.";
 
 function toFileData(info: FirmwareFileInfo): FirmwareFileData {
@@ -57,6 +63,7 @@ function toFileData(info: FirmwareFileInfo): FirmwareFileData {
     id: info.id,
     filename: info.filename,
     target: `${info.target_manufacturer} ${info.target_model}`.trim(),
+    firmwareVersion: info.firmware_version ?? "",
     size: info.size,
     uploadedAt: isoToEpochSeconds(info.uploaded_at),
   };

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -13,6 +13,7 @@ import { variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
+import Input from "@/shared/components/Input";
 import Select from "@/shared/components/Select";
 
 interface FirmwareUploadDialogProps {
@@ -27,6 +28,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
   const { getMinerModelGroups } = useMinerModelGroups();
   const [targetManufacturer, setTargetManufacturer] = useState("");
   const [targetModel, setTargetModel] = useState("");
+  const [firmwareVersion, setFirmwareVersion] = useState("");
   const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
   const [modelsError, setModelsError] = useState<string | null>(null);
 
@@ -84,16 +86,20 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
 
   const selectedTargetModel = modelOptions.some((option) => option.value === targetModel) ? targetModel : "";
   const target = useMemo(
-    () => ({ targetManufacturer: targetManufacturer.trim(), targetModel: selectedTargetModel.trim() }),
-    [targetManufacturer, selectedTargetModel],
+    () => ({
+      targetManufacturer: targetManufacturer.trim(),
+      targetModel: selectedTargetModel.trim(),
+      firmwareVersion: firmwareVersion.trim(),
+    }),
+    [firmwareVersion, targetManufacturer, selectedTargetModel],
   );
-  const hasTarget = target.targetManufacturer !== "" && target.targetModel !== "";
 
   const handleDismiss = useCallback(() => {
     const uploaded = state === "ready";
     reset();
     setTargetManufacturer("");
     setTargetModel("");
+    setFirmwareVersion("");
     setModelGroups(null);
     setModelsError(null);
     if (uploaded) {
@@ -107,6 +113,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
     reset();
     setTargetManufacturer("");
     setTargetModel("");
+    setFirmwareVersion("");
     setModelGroups(null);
     setModelsError(null);
     onSuccess();
@@ -153,10 +160,15 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
                 forceBelow
               />
             </div>
+            <Input
+              id="firmware-version"
+              label="Firmware version"
+              initValue={firmwareVersion}
+              onChange={setFirmwareVersion}
+            />
             <FileDropZone
               extensions={serverConfig.allowedExtensions}
               onFileSelect={(selectedFile) => processFile(selectedFile, target)}
-              disabled={!hasTarget}
             />
           </>
         ) : null}

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -1,4 +1,6 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { MinerModelGroup } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
 import {
   FileDropZone,
   FileErrorStatus,
@@ -6,9 +8,12 @@ import {
   FileReadyStatus,
   useFirmwareUpload,
 } from "@/protoFleet/components/FirmwareUpload";
+import { Alert } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
+import Callout from "@/shared/components/Callout";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
+import Select from "@/shared/components/Select";
 
 interface FirmwareUploadDialogProps {
   open?: boolean;
@@ -19,18 +24,78 @@ interface FirmwareUploadDialogProps {
 const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDialogProps) => {
   const { state, file, uploadProgress, errorMessage, serverConfig, processFile, reset, retry } =
     useFirmwareUpload(!!open);
+  const { getMinerModelGroups } = useMinerModelGroups();
+  const [targetManufacturer, setTargetManufacturer] = useState("");
+  const [targetModel, setTargetModel] = useState("");
+  const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
+  const [modelsError, setModelsError] = useState<string | null>(null);
 
   const configLoaded = serverConfig !== null;
+  const modelsLoading = open && modelGroups === null && modelsError === null;
+  const modelsLoaded = !modelsLoading && modelsError === null;
   const isProcessing = state === "hashing" || state === "checking" || state === "uploading";
-  const showLoadingSpinner = state === "idle" && !configLoaded;
-  const showDropZone = state === "idle" && configLoaded;
+  const showLoadingSpinner = state === "idle" && (!configLoaded || modelsLoading);
+  const showDropZone = state === "idle" && configLoaded && modelsLoaded;
   const showProcessingStatus = isProcessing && file != null;
   const showReadyStatus = state === "ready" && file != null;
   const showError = state === "error" && errorMessage != null;
 
+  useEffect(() => {
+    if (!open || modelGroups !== null || modelsError !== null) return;
+
+    let cancelled = false;
+    void getMinerModelGroups(null)
+      .then((groups) => {
+        if (!cancelled) setModelGroups(groups);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setModelGroups([]);
+          setModelsError("Couldn't load fleet miner models.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getMinerModelGroups, modelGroups, modelsError, open]);
+
+  const manufacturerOptions = useMemo(() => {
+    const manufacturers = [
+      ...new Set((modelGroups ?? []).map((group) => group.manufacturer.trim()).filter(Boolean)),
+    ].sort();
+    return [
+      { value: "", label: "Select manufacturer" },
+      ...manufacturers.map((manufacturer) => ({ value: manufacturer, label: manufacturer })),
+    ];
+  }, [modelGroups]);
+
+  const modelOptions = useMemo(() => {
+    const models = (modelGroups ?? [])
+      .filter((group) => group.manufacturer === targetManufacturer)
+      .map((group) => group.model.trim())
+      .filter(Boolean)
+      .sort();
+    return [
+      { value: "", label: "Select model" },
+      ...models.map((modelName) => ({ value: modelName, label: modelName })),
+    ];
+  }, [modelGroups, targetManufacturer]);
+
+  const selectedTargetModel = modelOptions.some((option) => option.value === targetModel) ? targetModel : "";
+  const target = useMemo(
+    () => ({ targetManufacturer: targetManufacturer.trim(), targetModel: selectedTargetModel.trim() }),
+    [targetManufacturer, selectedTargetModel],
+  );
+  const hasTarget = target.targetManufacturer !== "" && target.targetModel !== "";
+
   const handleDismiss = useCallback(() => {
     const uploaded = state === "ready";
     reset();
+    setTargetManufacturer("");
+    setTargetModel("");
+    setModelGroups(null);
+    setModelsError(null);
     if (uploaded) {
       onSuccess();
     } else {
@@ -40,6 +105,10 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
 
   const handleDone = useCallback(() => {
     reset();
+    setTargetManufacturer("");
+    setTargetModel("");
+    setModelGroups(null);
+    setModelsError(null);
     onSuccess();
   }, [onSuccess, reset]);
 
@@ -60,7 +129,39 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
           </div>
         ) : null}
 
-        {showDropZone ? <FileDropZone extensions={serverConfig.allowedExtensions} onFileSelect={processFile} /> : null}
+        {showDropZone ? (
+          <>
+            <div className="grid gap-4 tablet:grid-cols-2">
+              <Select
+                id="firmware-target-manufacturer"
+                label="Manufacturer"
+                options={manufacturerOptions}
+                value={targetManufacturer}
+                onChange={(value) => {
+                  setTargetManufacturer(value);
+                  setTargetModel("");
+                }}
+                forceBelow
+              />
+              <Select
+                id="firmware-target-model"
+                label="Model"
+                options={modelOptions}
+                value={selectedTargetModel}
+                onChange={setTargetModel}
+                disabled={!targetManufacturer}
+                forceBelow
+              />
+            </div>
+            <FileDropZone
+              extensions={serverConfig.allowedExtensions}
+              onFileSelect={(selectedFile) => processFile(selectedFile, target)}
+              disabled={!hasTarget}
+            />
+          </>
+        ) : null}
+
+        {modelsError ? <Callout intent="danger" prefixIcon={<Alert />} title={modelsError} /> : null}
 
         {showProcessingStatus ? (
           <FileProcessingStatus

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -11,9 +11,9 @@ import {
 import { Alert } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
+import Input from "@/shared/components/Input";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
-import Input from "@/shared/components/Input";
 import Select from "@/shared/components/Select";
 
 interface FirmwareUploadDialogProps {
@@ -165,6 +165,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
               label="Firmware version"
               initValue={firmwareVersion}
               onChange={setFirmwareVersion}
+              required
             />
             <FileDropZone
               extensions={serverConfig.allowedExtensions}

--- a/server/cmd/fleetcli/firmware.go
+++ b/server/cmd/fleetcli/firmware.go
@@ -105,6 +105,10 @@ func firmwareUploadCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
+			target, err := firmwareTargetFromCommandStrict(cmd)
+			if err != nil {
+				return err
+			}
 
 			client, err := openClient(ctx, cmd)
 			if err != nil {
@@ -115,10 +119,6 @@ func firmwareUploadCommand() *cli.Command {
 			var progress io.Writer
 			if !cmd.Bool("quiet") {
 				progress = os.Stderr
-			}
-			target := firmwareTargetFromCommand(cmd)
-			if err := validateFirmwareUploadTarget(path, target); err != nil {
-				return err
 			}
 			result, reused, err := runFirmwareUpload(ctx, client, path, target, cmd.Bool("force"), progress)
 			if err != nil {
@@ -341,15 +341,6 @@ func (t firmwareTarget) validate() error {
 		return fmt.Errorf("--firmware-version is required")
 	}
 	return nil
-}
-
-// validateFirmwareUploadTarget requires full target metadata for non-.swu
-// uploads; .swu images carry their target inside the file itself.
-func validateFirmwareUploadTarget(path string, target firmwareTarget) error {
-	if strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".swu") {
-		return nil
-	}
-	return target.validate()
 }
 
 // runFirmwareUpload drives the full upload flow: fetch config, validate the

--- a/server/cmd/fleetcli/firmware.go
+++ b/server/cmd/fleetcli/firmware.go
@@ -61,8 +61,13 @@ func firmwareCheckCommand() *cli.Command {
 		Name:      "check",
 		Usage:     "Check whether a firmware file with the same SHA-256 already exists on the server",
 		ArgsUsage: "<path>",
+		Flags:     firmwareTargetFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			path, err := singleArg(cmd, "<path>")
+			if err != nil {
+				return err
+			}
+			target, err := firmwareTargetFromCommand(cmd)
 			if err != nil {
 				return err
 			}
@@ -77,7 +82,7 @@ func firmwareCheckCommand() *cli.Command {
 			}
 			defer func() { _ = client.Close() }()
 
-			resp, err := client.FirmwareCheck(ctx, digest)
+			resp, err := client.FirmwareCheck(ctx, digest, target)
 			if err != nil {
 				return err
 			}
@@ -92,6 +97,8 @@ func firmwareUploadCommand() *cli.Command {
 		Usage:     "Upload a firmware file, reusing the server copy when checksums match",
 		ArgsUsage: "<path>",
 		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "target-manufacturer", Usage: "Firmware target manufacturer/product"},
+			&cli.StringFlag{Name: "target-model", Usage: "Firmware target miner model"},
 			&cli.BoolFlag{Name: "force", Usage: "Upload even when a file with the same checksum already exists on the server"},
 			&cli.BoolFlag{Name: "quiet", Usage: "Suppress progress output on stderr"},
 		},
@@ -111,7 +118,11 @@ func firmwareUploadCommand() *cli.Command {
 			if !cmd.Bool("quiet") {
 				progress = os.Stderr
 			}
-			result, reused, err := runFirmwareUpload(ctx, client, path, cmd.Bool("force"), progress)
+			target, err := firmwareTargetFromCommand(cmd)
+			if err != nil {
+				return err
+			}
+			result, reused, err := runFirmwareUpload(ctx, client, path, target, cmd.Bool("force"), progress)
 			if err != nil {
 				return err
 			}
@@ -285,11 +296,37 @@ type firmwareUploadResult struct {
 	FirmwareFileID string `json:"firmware_file_id"`
 }
 
+type firmwareTarget struct {
+	Manufacturer string
+	Model        string
+}
+
+func firmwareTargetFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{Name: "target-manufacturer", Usage: "Firmware target manufacturer/product"},
+		&cli.StringFlag{Name: "target-model", Usage: "Firmware target miner model"},
+	}
+}
+
+func firmwareTargetFromCommand(cmd *cli.Command) (firmwareTarget, error) {
+	target := firmwareTarget{
+		Manufacturer: strings.TrimSpace(cmd.String("target-manufacturer")),
+		Model:        strings.TrimSpace(cmd.String("target-model")),
+	}
+	if target.Manufacturer == "" {
+		return firmwareTarget{}, fmt.Errorf("--target-manufacturer is required")
+	}
+	if target.Model == "" {
+		return firmwareTarget{}, fmt.Errorf("--target-model is required")
+	}
+	return target, nil
+}
+
 // runFirmwareUpload drives the full upload flow: fetch config, validate the
 // local file, hash it, reuse the server copy on a checksum hit (unless force),
 // and otherwise stream a direct or chunked upload depending on size. A nil
 // progress writer suppresses all progress output.
-func runFirmwareUpload(ctx context.Context, client *Client, path string, force bool, progress io.Writer) (firmwareUploadResult, bool, error) {
+func runFirmwareUpload(ctx context.Context, client *Client, path string, target firmwareTarget, force bool, progress io.Writer) (firmwareUploadResult, bool, error) {
 	var result firmwareUploadResult
 
 	f, err := os.Open(path)
@@ -327,7 +364,7 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, force b
 		return result, false, fmt.Errorf("rewind %s: %w", path, err)
 	}
 
-	check, err := client.FirmwareCheck(ctx, digest)
+	check, err := client.FirmwareCheck(ctx, digest, target)
 	if err != nil {
 		return result, false, err
 	}
@@ -339,9 +376,9 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, force b
 	reporter := newProgressPrinter(progress, size)
 	var fileID string
 	if size <= cfg.ChunkSizeBytes {
-		fileID, err = client.FirmwareUploadDirect(ctx, filename, f, reporter)
+		fileID, err = client.FirmwareUploadDirect(ctx, filename, f, target, reporter)
 	} else {
-		fileID, err = client.FirmwareUploadChunked(ctx, filename, f, size, cfg.ChunkSizeBytes, reporter)
+		fileID, err = client.FirmwareUploadChunked(ctx, filename, f, size, cfg.ChunkSizeBytes, target, reporter)
 	}
 	if reporter != nil {
 		_, _ = fmt.Fprintln(progress)

--- a/server/cmd/fleetcli/firmware.go
+++ b/server/cmd/fleetcli/firmware.go
@@ -67,7 +67,7 @@ func firmwareCheckCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			target, err := firmwareTargetFromCommand(cmd)
+			target, err := firmwareTargetFromCommandStrict(cmd)
 			if err != nil {
 				return err
 			}
@@ -96,12 +96,10 @@ func firmwareUploadCommand() *cli.Command {
 		Name:      "upload",
 		Usage:     "Upload a firmware file, reusing the server copy when checksums match",
 		ArgsUsage: "<path>",
-		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "target-manufacturer", Usage: "Firmware target manufacturer/product"},
-			&cli.StringFlag{Name: "target-model", Usage: "Firmware target miner model"},
+		Flags: append(firmwareTargetFlags(),
 			&cli.BoolFlag{Name: "force", Usage: "Upload even when a file with the same checksum already exists on the server"},
 			&cli.BoolFlag{Name: "quiet", Usage: "Suppress progress output on stderr"},
-		},
+		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			path, err := singleArg(cmd, "<path>")
 			if err != nil {
@@ -118,8 +116,8 @@ func firmwareUploadCommand() *cli.Command {
 			if !cmd.Bool("quiet") {
 				progress = os.Stderr
 			}
-			target, err := firmwareTargetFromCommand(cmd)
-			if err != nil {
+			target := firmwareTargetFromCommand(cmd)
+			if err := validateFirmwareUploadTarget(path, target); err != nil {
 				return err
 			}
 			result, reused, err := runFirmwareUpload(ctx, client, path, target, cmd.Bool("force"), progress)
@@ -294,32 +292,64 @@ func buildFirmwareDeployRequest(ctx context.Context, cmd *cli.Command, client *C
 
 type firmwareUploadResult struct {
 	FirmwareFileID string `json:"firmware_file_id"`
+	Reused         bool   `json:"reused,omitempty"`
 }
 
 type firmwareTarget struct {
 	Manufacturer string
 	Model        string
+	Version      string
 }
 
 func firmwareTargetFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{Name: "target-manufacturer", Usage: "Firmware target manufacturer/product"},
 		&cli.StringFlag{Name: "target-model", Usage: "Firmware target miner model"},
+		&cli.StringFlag{Name: "firmware-version", Usage: "Firmware version reported after a successful install"},
 	}
 }
 
-func firmwareTargetFromCommand(cmd *cli.Command) (firmwareTarget, error) {
-	target := firmwareTarget{
-		Manufacturer: strings.TrimSpace(cmd.String("target-manufacturer")),
-		Model:        strings.TrimSpace(cmd.String("target-model")),
-	}
-	if target.Manufacturer == "" {
-		return firmwareTarget{}, fmt.Errorf("--target-manufacturer is required")
-	}
-	if target.Model == "" {
-		return firmwareTarget{}, fmt.Errorf("--target-model is required")
+func firmwareTargetFromCommandStrict(cmd *cli.Command) (firmwareTarget, error) {
+	target := firmwareTargetFromCommand(cmd)
+	if err := target.validate(); err != nil {
+		return firmwareTarget{}, err
 	}
 	return target, nil
+}
+
+func firmwareTargetFromCommand(cmd *cli.Command) firmwareTarget {
+	return firmwareTarget{
+		Manufacturer: strings.TrimSpace(cmd.String("target-manufacturer")),
+		Model:        strings.TrimSpace(cmd.String("target-model")),
+		Version:      strings.TrimSpace(cmd.String("firmware-version")),
+	}
+}
+
+func (t firmwareTarget) complete() bool {
+	return t.Manufacturer != "" && t.Model != "" && t.Version != ""
+}
+
+// validate reports the first missing required firmware target field.
+func (t firmwareTarget) validate() error {
+	if t.Manufacturer == "" {
+		return fmt.Errorf("--target-manufacturer is required")
+	}
+	if t.Model == "" {
+		return fmt.Errorf("--target-model is required")
+	}
+	if t.Version == "" {
+		return fmt.Errorf("--firmware-version is required")
+	}
+	return nil
+}
+
+// validateFirmwareUploadTarget requires full target metadata for non-.swu
+// uploads; .swu images carry their target inside the file itself.
+func validateFirmwareUploadTarget(path string, target firmwareTarget) error {
+	if strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".swu") {
+		return nil
+	}
+	return target.validate()
 }
 
 // runFirmwareUpload drives the full upload flow: fetch config, validate the
@@ -364,21 +394,24 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, target 
 		return result, false, fmt.Errorf("rewind %s: %w", path, err)
 	}
 
-	check, err := client.FirmwareCheck(ctx, digest, target)
-	if err != nil {
-		return result, false, err
-	}
-	if check.Exists && check.FirmwareFileID != "" && !force {
-		result.FirmwareFileID = check.FirmwareFileID
-		return result, true, nil
+	if target.complete() {
+		check, err := client.FirmwareCheck(ctx, digest, target)
+		if err != nil {
+			return result, false, err
+		}
+		if check.Exists && check.FirmwareFileID != "" && !force {
+			result.FirmwareFileID = check.FirmwareFileID
+			result.Reused = true
+			return result, true, nil
+		}
 	}
 
 	reporter := newProgressPrinter(progress, size)
-	var fileID string
+	var uploadResp *firmwareUploadResponse
 	if size <= cfg.ChunkSizeBytes {
-		fileID, err = client.FirmwareUploadDirect(ctx, filename, f, target, reporter)
+		uploadResp, err = client.FirmwareUploadDirect(ctx, filename, f, target, force, reporter)
 	} else {
-		fileID, err = client.FirmwareUploadChunked(ctx, filename, f, size, cfg.ChunkSizeBytes, target, reporter)
+		uploadResp, err = client.FirmwareUploadChunked(ctx, filename, f, size, cfg.ChunkSizeBytes, target, force, reporter)
 	}
 	if reporter != nil {
 		_, _ = fmt.Fprintln(progress)
@@ -386,8 +419,9 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, target 
 	if err != nil {
 		return result, false, err
 	}
-	result.FirmwareFileID = fileID
-	return result, false, nil
+	result.FirmwareFileID = uploadResp.FirmwareFileID
+	result.Reused = uploadResp.Reused
+	return result, uploadResp.Reused, nil
 }
 
 // validateFirmwareFile applies the same local checks as the web client before

--- a/server/cmd/fleetcli/firmware_client.go
+++ b/server/cmd/fleetcli/firmware_client.go
@@ -38,6 +38,7 @@ type firmwareCheckRequest struct {
 	SHA256             string `json:"sha256"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
 }
 
 type firmwareCheckResponse struct {
@@ -52,6 +53,7 @@ type firmwareFileInfo struct {
 	UploadedAt         string `json:"uploaded_at"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version,omitempty"`
 }
 
 type firmwareListResponse struct {
@@ -67,6 +69,8 @@ type firmwareInitiateRequest struct {
 	FileSize           int64  `json:"file_size"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
+	Force              bool   `json:"force,omitempty"`
 }
 
 type firmwareInitiateResponse struct {
@@ -75,6 +79,7 @@ type firmwareInitiateResponse struct {
 
 type firmwareUploadResponse struct {
 	FirmwareFileID string `json:"firmware_file_id"`
+	Reused         bool   `json:"reused,omitempty"`
 }
 
 // firmwareURL builds an endpoint URL under the firmware HTTP API. Firmware
@@ -211,6 +216,7 @@ func (c *Client) FirmwareCheck(ctx context.Context, sha256Hex string, target fir
 		SHA256:             sha256Hex,
 		TargetManufacturer: target.Manufacturer,
 		TargetModel:        target.Model,
+		FirmwareVersion:    target.Version,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal firmware check request: %w", err)
@@ -262,17 +268,29 @@ func (c *Client) FirmwareDeleteAll(ctx context.Context) (*firmwareDeleteAllRespo
 // FirmwareUploadDirect streams the file as a single multipart request. The
 // body is piped so the file is never buffered in memory, which means the
 // request goes out with chunked transfer encoding instead of a Content-Length.
-func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file io.Reader, target firmwareTarget, progress progressFunc) (string, error) {
+func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file io.Reader, target firmwareTarget, force bool, progress progressFunc) (*firmwareUploadResponse, error) {
 	pr, pw := io.Pipe()
 	mw := multipart.NewWriter(pw)
 	go func() {
-		if err := mw.WriteField("target_manufacturer", target.Manufacturer); err != nil {
-			_ = pw.CloseWithError(err)
-			return
+		fields := map[string]string{
+			"target_manufacturer": target.Manufacturer,
+			"target_model":        target.Model,
+			"firmware_version":    target.Version,
 		}
-		if err := mw.WriteField("target_model", target.Model); err != nil {
-			_ = pw.CloseWithError(err)
-			return
+		for name, value := range fields {
+			if value == "" {
+				continue
+			}
+			if err := mw.WriteField(name, value); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+		}
+		if force {
+			if err := mw.WriteField("force", "true"); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
 		}
 		part, err := mw.CreateFormFile("file", filename)
 		if err != nil {
@@ -295,23 +313,25 @@ func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file
 		transfer:    true,
 		out:         resp,
 	}); err != nil {
-		return "", err
+		return nil, err
 	}
-	return resp.FirmwareFileID, nil
+	return resp, nil
 }
 
 // FirmwareUploadChunked uploads the file through the initiate/chunk/complete
 // flow. Chunks are sent sequentially because the server rejects out-of-order
 // ranges.
-func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, file io.ReaderAt, size, chunkSize int64, target firmwareTarget, progress progressFunc) (string, error) {
+func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, file io.ReaderAt, size, chunkSize int64, target firmwareTarget, force bool, progress progressFunc) (*firmwareUploadResponse, error) {
 	body, err := json.Marshal(firmwareInitiateRequest{
 		Filename:           filename,
 		FileSize:           size,
 		TargetManufacturer: target.Manufacturer,
 		TargetModel:        target.Model,
+		FirmwareVersion:    target.Version,
+		Force:              force,
 	})
 	if err != nil {
-		return "", fmt.Errorf("marshal chunked upload initiate request: %w", err)
+		return nil, fmt.Errorf("marshal chunked upload initiate request: %w", err)
 	}
 	initiate := &firmwareInitiateResponse{}
 	if err := c.doFirmware(ctx, firmwareRequest{
@@ -321,10 +341,10 @@ func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, fil
 		contentType: contentTypeJSON,
 		out:         initiate,
 	}); err != nil {
-		return "", err
+		return nil, err
 	}
 	if initiate.UploadID == "" {
-		return "", fmt.Errorf("chunked upload initiate did not return an upload id")
+		return nil, fmt.Errorf("chunked upload initiate did not return an upload id")
 	}
 
 	for start := int64(0); start < size; start += chunkSize {
@@ -339,7 +359,7 @@ func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, fil
 			contentRange:  fmt.Sprintf("bytes %d-%d/%d", start, end-1, size),
 			transfer:      true,
 		}); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
@@ -350,7 +370,7 @@ func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, fil
 		transfer: true,
 		out:      resp,
 	}); err != nil {
-		return "", err
+		return nil, err
 	}
-	return resp.FirmwareFileID, nil
+	return resp, nil
 }

--- a/server/cmd/fleetcli/firmware_client.go
+++ b/server/cmd/fleetcli/firmware_client.go
@@ -35,7 +35,9 @@ type firmwareConfig struct {
 }
 
 type firmwareCheckRequest struct {
-	SHA256 string `json:"sha256"`
+	SHA256             string `json:"sha256"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type firmwareCheckResponse struct {
@@ -44,10 +46,12 @@ type firmwareCheckResponse struct {
 }
 
 type firmwareFileInfo struct {
-	ID         string `json:"id"`
-	Filename   string `json:"filename"`
-	Size       int64  `json:"size"`
-	UploadedAt string `json:"uploaded_at"`
+	ID                 string `json:"id"`
+	Filename           string `json:"filename"`
+	Size               int64  `json:"size"`
+	UploadedAt         string `json:"uploaded_at"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type firmwareListResponse struct {
@@ -59,8 +63,10 @@ type firmwareDeleteAllResponse struct {
 }
 
 type firmwareInitiateRequest struct {
-	Filename string `json:"filename"`
-	FileSize int64  `json:"file_size"`
+	Filename           string `json:"filename"`
+	FileSize           int64  `json:"file_size"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type firmwareInitiateResponse struct {
@@ -200,8 +206,12 @@ func (c *Client) FirmwareConfig(ctx context.Context) (*firmwareConfig, error) {
 
 // FirmwareCheck asks the server whether a firmware file with the given
 // SHA-256 hex digest already exists.
-func (c *Client) FirmwareCheck(ctx context.Context, sha256Hex string) (*firmwareCheckResponse, error) {
-	body, err := json.Marshal(firmwareCheckRequest{SHA256: sha256Hex})
+func (c *Client) FirmwareCheck(ctx context.Context, sha256Hex string, target firmwareTarget) (*firmwareCheckResponse, error) {
+	body, err := json.Marshal(firmwareCheckRequest{
+		SHA256:             sha256Hex,
+		TargetManufacturer: target.Manufacturer,
+		TargetModel:        target.Model,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal firmware check request: %w", err)
 	}
@@ -252,10 +262,18 @@ func (c *Client) FirmwareDeleteAll(ctx context.Context) (*firmwareDeleteAllRespo
 // FirmwareUploadDirect streams the file as a single multipart request. The
 // body is piped so the file is never buffered in memory, which means the
 // request goes out with chunked transfer encoding instead of a Content-Length.
-func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file io.Reader, progress progressFunc) (string, error) {
+func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file io.Reader, target firmwareTarget, progress progressFunc) (string, error) {
 	pr, pw := io.Pipe()
 	mw := multipart.NewWriter(pw)
 	go func() {
+		if err := mw.WriteField("target_manufacturer", target.Manufacturer); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if err := mw.WriteField("target_model", target.Model); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
 		part, err := mw.CreateFormFile("file", filename)
 		if err != nil {
 			_ = pw.CloseWithError(err)
@@ -285,8 +303,13 @@ func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file
 // FirmwareUploadChunked uploads the file through the initiate/chunk/complete
 // flow. Chunks are sent sequentially because the server rejects out-of-order
 // ranges.
-func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, file io.ReaderAt, size, chunkSize int64, progress progressFunc) (string, error) {
-	body, err := json.Marshal(firmwareInitiateRequest{Filename: filename, FileSize: size})
+func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, file io.ReaderAt, size, chunkSize int64, target firmwareTarget, progress progressFunc) (string, error) {
+	body, err := json.Marshal(firmwareInitiateRequest{
+		Filename:           filename,
+		FileSize:           size,
+		TargetManufacturer: target.Manufacturer,
+		TargetModel:        target.Model,
+	})
 	if err != nil {
 		return "", fmt.Errorf("marshal chunked upload initiate request: %w", err)
 	}

--- a/server/cmd/fleetcli/firmware_test.go
+++ b/server/cmd/fleetcli/firmware_test.go
@@ -437,42 +437,24 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	}
 }
 
-func TestFirmwareUploadSWUWithoutMetadataSkipsPrecheck(t *testing.T) {
-	path := writeTempFirmwareFile(t, "proto-rig.swu", []byte("firmware"))
-
-	mux := http.NewServeMux()
-	serveFirmwareConfig(t, mux, firmwareConfig{AllowedExtensions: []string{".swu"}, MaxFileSizeBytes: 1 << 20, ChunkSizeBytes: 1024})
-	forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/check")
-	mux.HandleFunc("POST /api/v1/firmware/upload", func(w http.ResponseWriter, r *http.Request) {
-		if got := r.FormValue("target_manufacturer"); got != "" {
-			t.Errorf("target_manufacturer = %q, want empty", got)
-		}
-		if got := r.FormValue("target_model"); got != "" {
-			t.Errorf("target_model = %q, want empty", got)
-		}
-		if got := r.FormValue("firmware_version"); got != "" {
-			t.Errorf("firmware_version = %q, want empty", got)
-		}
-		writeFirmwareJSON(t, w, firmwareUploadResponse{FirmwareFileID: "parsed-id", Reused: true})
-	})
-	client := newFirmwareTestServer(t, mux)
-
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, firmwareTarget{}, false, nil)
-	if err != nil {
-		t.Fatalf("runFirmwareUpload() error = %v", err)
+func TestFirmwareTargetValidateRequiresAllMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  firmwareTarget
+		wantErr string
+	}{
+		{name: "manufacturer", target: firmwareTarget{}, wantErr: "--target-manufacturer is required"},
+		{name: "model", target: firmwareTarget{Manufacturer: "Proto"}, wantErr: "--target-model is required"},
+		{name: "version", target: firmwareTarget{Manufacturer: "Proto", Model: "S21"}, wantErr: "--firmware-version is required"},
 	}
-	if !reused || !result.Reused {
-		t.Fatalf("reused = %v result.Reused = %v, want true/true", reused, result.Reused)
-	}
-	if result.FirmwareFileID != "parsed-id" {
-		t.Errorf("FirmwareFileID = %q, want parsed-id", result.FirmwareFileID)
-	}
-}
 
-func TestValidateFirmwareUploadTargetRequiresMetadataForNonSWU(t *testing.T) {
-	err := validateFirmwareUploadTarget("firmware.zip", firmwareTarget{})
-	if err == nil || !strings.Contains(err.Error(), "--target-manufacturer is required") {
-		t.Fatalf("validateFirmwareUploadTarget() error = %v, want target-manufacturer requirement", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.target.validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validate() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/server/cmd/fleetcli/firmware_test.go
+++ b/server/cmd/fleetcli/firmware_test.go
@@ -90,7 +90,7 @@ func writeTempFirmwareFile(t *testing.T, name string, content []byte) string {
 }
 
 func testFirmwareTarget() firmwareTarget {
-	return firmwareTarget{Manufacturer: "Proto", Model: "S21"}
+	return firmwareTarget{Manufacturer: "Proto", Model: "S21", Version: "v2.0.0"}
 }
 
 func TestFileSHA256(t *testing.T) {
@@ -199,7 +199,7 @@ func TestFirmwareCheckSendsSHA256(t *testing.T) {
 	if gotContentType != contentTypeJSON {
 		t.Errorf("check Content-Type = %q, want %q", gotContentType, contentTypeJSON)
 	}
-	wantBody := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21"}`, digest)
+	wantBody := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`, digest)
 	if string(gotBody) != wantBody {
 		t.Errorf("check body = %s, want %s", gotBody, wantBody)
 	}
@@ -256,6 +256,9 @@ func TestFirmwareUploadReusesExistingFile(t *testing.T) {
 	}
 	if result.FirmwareFileID != "existing-id" {
 		t.Errorf("FirmwareFileID = %q, want %q", result.FirmwareFileID, "existing-id")
+	}
+	if !result.Reused {
+		t.Error("result.Reused = false, want true")
 	}
 }
 
@@ -324,6 +327,12 @@ func TestFirmwareUploadDirectUsesMultipart(t *testing.T) {
 				}
 				if got := r.FormValue("target_model"); got != "S21" {
 					t.Errorf("target_model = %q, want S21", got)
+				}
+				if got := r.FormValue("firmware_version"); got != "v2.0.0" {
+					t.Errorf("firmware_version = %q, want v2.0.0", got)
+				}
+				if got := r.FormValue("force"); got != "" {
+					t.Errorf("force = %q, want empty", got)
 				}
 				gotBytes, err = io.ReadAll(file)
 				if err != nil {
@@ -408,6 +417,9 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	if initiateBody.TargetManufacturer != "Proto" || initiateBody.TargetModel != "S21" {
 		t.Errorf("initiate target = %s %s, want Proto S21", initiateBody.TargetManufacturer, initiateBody.TargetModel)
 	}
+	if initiateBody.Force {
+		t.Error("initiate force = true, want false")
+	}
 	wantRanges := []string{"bytes 0-7/20", "bytes 8-15/20", "bytes 16-19/20"}
 	if len(gotRanges) != len(wantRanges) {
 		t.Fatalf("chunk count = %d (%v), want %d", len(gotRanges), gotRanges, len(wantRanges))
@@ -422,6 +434,45 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	}
 	if !bytes.Equal(reassembled, content) {
 		t.Errorf("reassembled chunks do not match the source file (got %q, want %q)", reassembled, content)
+	}
+}
+
+func TestFirmwareUploadSWUWithoutMetadataSkipsPrecheck(t *testing.T) {
+	path := writeTempFirmwareFile(t, "proto-rig.swu", []byte("firmware"))
+
+	mux := http.NewServeMux()
+	serveFirmwareConfig(t, mux, firmwareConfig{AllowedExtensions: []string{".swu"}, MaxFileSizeBytes: 1 << 20, ChunkSizeBytes: 1024})
+	forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/check")
+	mux.HandleFunc("POST /api/v1/firmware/upload", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.FormValue("target_manufacturer"); got != "" {
+			t.Errorf("target_manufacturer = %q, want empty", got)
+		}
+		if got := r.FormValue("target_model"); got != "" {
+			t.Errorf("target_model = %q, want empty", got)
+		}
+		if got := r.FormValue("firmware_version"); got != "" {
+			t.Errorf("firmware_version = %q, want empty", got)
+		}
+		writeFirmwareJSON(t, w, firmwareUploadResponse{FirmwareFileID: "parsed-id", Reused: true})
+	})
+	client := newFirmwareTestServer(t, mux)
+
+	result, reused, err := runFirmwareUpload(context.Background(), client, path, firmwareTarget{}, false, nil)
+	if err != nil {
+		t.Fatalf("runFirmwareUpload() error = %v", err)
+	}
+	if !reused || !result.Reused {
+		t.Fatalf("reused = %v result.Reused = %v, want true/true", reused, result.Reused)
+	}
+	if result.FirmwareFileID != "parsed-id" {
+		t.Errorf("FirmwareFileID = %q, want parsed-id", result.FirmwareFileID)
+	}
+}
+
+func TestValidateFirmwareUploadTargetRequiresMetadataForNonSWU(t *testing.T) {
+	err := validateFirmwareUploadTarget("firmware.zip", firmwareTarget{})
+	if err == nil || !strings.Contains(err.Error(), "--target-manufacturer is required") {
+		t.Fatalf("validateFirmwareUploadTarget() error = %v, want target-manufacturer requirement", err)
 	}
 }
 

--- a/server/cmd/fleetcli/firmware_test.go
+++ b/server/cmd/fleetcli/firmware_test.go
@@ -89,6 +89,10 @@ func writeTempFirmwareFile(t *testing.T, name string, content []byte) string {
 	return path
 }
 
+func testFirmwareTarget() firmwareTarget {
+	return firmwareTarget{Manufacturer: "Proto", Model: "S21"}
+}
+
 func TestFileSHA256(t *testing.T) {
 	content := []byte("fleet firmware payload")
 	path := writeTempFirmwareFile(t, "fw.swu", content)
@@ -187,7 +191,7 @@ func TestFirmwareCheckSendsSHA256(t *testing.T) {
 	client := newFirmwareTestServer(t, mux)
 
 	digest := strings.Repeat("ab", 32)
-	resp, err := client.FirmwareCheck(context.Background(), digest)
+	resp, err := client.FirmwareCheck(context.Background(), digest, testFirmwareTarget())
 	if err != nil {
 		t.Fatalf("FirmwareCheck() error = %v", err)
 	}
@@ -195,7 +199,7 @@ func TestFirmwareCheckSendsSHA256(t *testing.T) {
 	if gotContentType != contentTypeJSON {
 		t.Errorf("check Content-Type = %q, want %q", gotContentType, contentTypeJSON)
 	}
-	wantBody := fmt.Sprintf(`{"sha256":%q}`, digest)
+	wantBody := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21"}`, digest)
 	if string(gotBody) != wantBody {
 		t.Errorf("check body = %s, want %s", gotBody, wantBody)
 	}
@@ -243,7 +247,7 @@ func TestFirmwareUploadReusesExistingFile(t *testing.T) {
 	forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/upload/chunked")
 	client := newFirmwareTestServer(t, mux)
 
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, false, nil)
+	result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
 	if err != nil {
 		t.Fatalf("runFirmwareUpload() error = %v", err)
 	}
@@ -268,7 +272,7 @@ func TestFirmwareUploadForceUploadsDespiteCheckHit(t *testing.T) {
 	})
 	client := newFirmwareTestServer(t, mux)
 
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, true, nil)
+	result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), true, nil)
 	if err != nil {
 		t.Fatalf("runFirmwareUpload() error = %v", err)
 	}
@@ -315,6 +319,12 @@ func TestFirmwareUploadDirectUsesMultipart(t *testing.T) {
 				}
 				defer func() { _ = file.Close() }()
 				gotFilename = header.Filename
+				if got := r.FormValue("target_manufacturer"); got != "Proto" {
+					t.Errorf("target_manufacturer = %q, want Proto", got)
+				}
+				if got := r.FormValue("target_model"); got != "S21" {
+					t.Errorf("target_model = %q, want S21", got)
+				}
 				gotBytes, err = io.ReadAll(file)
 				if err != nil {
 					t.Errorf("read multipart file: %v", err)
@@ -323,7 +333,7 @@ func TestFirmwareUploadDirectUsesMultipart(t *testing.T) {
 			})
 			client := newFirmwareTestServer(t, mux)
 
-			result, reused, err := runFirmwareUpload(context.Background(), client, path, false, nil)
+			result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
 			if err != nil {
 				t.Fatalf("runFirmwareUpload() error = %v", err)
 			}
@@ -382,7 +392,7 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	})
 	client := newFirmwareTestServer(t, mux)
 
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, false, nil)
+	result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
 	if err != nil {
 		t.Fatalf("runFirmwareUpload() error = %v", err)
 	}
@@ -394,6 +404,9 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	}
 	if initiateBody.Filename != "big-firmware.swu" || initiateBody.FileSize != int64(len(content)) {
 		t.Errorf("initiate body = %+v, want filename big-firmware.swu and file_size %d", initiateBody, len(content))
+	}
+	if initiateBody.TargetManufacturer != "Proto" || initiateBody.TargetModel != "S21" {
+		t.Errorf("initiate target = %s %s, want Proto S21", initiateBody.TargetManufacturer, initiateBody.TargetModel)
 	}
 	wantRanges := []string{"bytes 0-7/20", "bytes 8-15/20", "bytes 16-19/20"}
 	if len(gotRanges) != len(wantRanges) {
@@ -448,7 +461,7 @@ func TestFirmwareUploadValidationRejectsLocally(t *testing.T) {
 			forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/upload/chunked")
 			client := newFirmwareTestServer(t, mux)
 
-			_, _, err := runFirmwareUpload(context.Background(), client, tt.path(t), false, nil)
+			_, _, err := runFirmwareUpload(context.Background(), client, tt.path(t), testFirmwareTarget(), false, nil)
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("runFirmwareUpload() error = %v, want containing %q", err, tt.wantErr)
 			}

--- a/server/e2e/fleetcli_firmware_e2e_test.go
+++ b/server/e2e/fleetcli_firmware_e2e_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	firmwareE2ETargetManufacturer = "Proto"
+	firmwareE2ETargetModel        = "Rig"
+)
+
 // TestFleetCLIFirmwareWorkflow drives the firmware file lifecycle through the
 // fleetcli binary: config -> check -> upload (direct and chunked) -> list ->
 // delete -> delete-all.
@@ -81,7 +86,7 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 	var smallFileID string
 
 	t.Run("UploadDirect", func(t *testing.T) {
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", smallPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, smallPath)
 		require.NoError(t, err, "direct upload should succeed")
 		smallFileID = decodeFirmwareFileID(t, output)
 		t.Logf("✓ Direct upload stored firmware file %s", smallFileID)
@@ -99,7 +104,7 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 	t.Run("UploadReusesExisting", func(t *testing.T) {
 		require.NotEmpty(t, smallFileID, "smallFileID must be set from the direct upload step")
 
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", smallPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, smallPath)
 		require.NoError(t, err, "re-upload should succeed")
 		assert.Equal(t, smallFileID, decodeFirmwareFileID(t, output),
 			"re-uploading identical content should return the existing file id")
@@ -117,7 +122,7 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 			"chunked test file must fit within the server's max file size")
 		chunkedPath := writeRandomFirmwareFile(t, workDir, "e2e-firmware-chunked.swu", chunkedSize)
 
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", chunkedPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, chunkedPath)
 		require.NoError(t, err, "chunked upload should succeed")
 		chunkedFileID = decodeFirmwareFileID(t, output)
 		assert.NotEqual(t, smallFileID, chunkedFileID, "chunked upload should store a distinct file")
@@ -184,9 +189,11 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 }
 
 type firmwareE2EFile struct {
-	ID       string `json:"id"`
-	Filename string `json:"filename"`
-	Size     int64  `json:"size"`
+	ID                 string `json:"id"`
+	Filename           string `json:"filename"`
+	Size               int64  `json:"size"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type firmwareE2ECheck struct {
@@ -211,7 +218,7 @@ func writeRandomFirmwareFile(t *testing.T, dir, name string, size int64) string 
 func checkFirmwareFile(t *testing.T, ctx context.Context, env []string, path string) firmwareE2ECheck {
 	t.Helper()
 
-	output, err := runFleetCLI(ctx, env, "firmware", "check", path)
+	output, err := runFleetCLI(ctx, env, "firmware", "check", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, path)
 	require.NoError(t, err, "firmware check should succeed")
 
 	var resp firmwareE2ECheck

--- a/server/e2e/fleetcli_firmware_e2e_test.go
+++ b/server/e2e/fleetcli_firmware_e2e_test.go
@@ -19,6 +19,7 @@ import (
 const (
 	firmwareE2ETargetManufacturer = "Proto"
 	firmwareE2ETargetModel        = "Rig"
+	firmwareE2EVersion            = "2.4.6"
 )
 
 // TestFleetCLIFirmwareWorkflow drives the firmware file lifecycle through the
@@ -86,7 +87,11 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 	var smallFileID string
 
 	t.Run("UploadDirect", func(t *testing.T) {
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, smallPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet",
+			"--target-manufacturer", firmwareE2ETargetManufacturer,
+			"--target-model", firmwareE2ETargetModel,
+			"--firmware-version", firmwareE2EVersion,
+			smallPath)
 		require.NoError(t, err, "direct upload should succeed")
 		smallFileID = decodeFirmwareFileID(t, output)
 		t.Logf("✓ Direct upload stored firmware file %s", smallFileID)
@@ -104,7 +109,11 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 	t.Run("UploadReusesExisting", func(t *testing.T) {
 		require.NotEmpty(t, smallFileID, "smallFileID must be set from the direct upload step")
 
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, smallPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet",
+			"--target-manufacturer", firmwareE2ETargetManufacturer,
+			"--target-model", firmwareE2ETargetModel,
+			"--firmware-version", firmwareE2EVersion,
+			smallPath)
 		require.NoError(t, err, "re-upload should succeed")
 		assert.Equal(t, smallFileID, decodeFirmwareFileID(t, output),
 			"re-uploading identical content should return the existing file id")
@@ -122,7 +131,11 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 			"chunked test file must fit within the server's max file size")
 		chunkedPath := writeRandomFirmwareFile(t, workDir, "e2e-firmware-chunked.swu", chunkedSize)
 
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, chunkedPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet",
+			"--target-manufacturer", firmwareE2ETargetManufacturer,
+			"--target-model", firmwareE2ETargetModel,
+			"--firmware-version", firmwareE2EVersion,
+			chunkedPath)
 		require.NoError(t, err, "chunked upload should succeed")
 		chunkedFileID = decodeFirmwareFileID(t, output)
 		assert.NotEqual(t, smallFileID, chunkedFileID, "chunked upload should store a distinct file")
@@ -146,11 +159,17 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 		require.NotNil(t, small, "list should include the direct upload")
 		assert.Equal(t, "e2e-firmware-small.swu", small.Filename)
 		assert.Equal(t, int64(64*1024), small.Size)
+		assert.Equal(t, firmwareE2ETargetManufacturer, small.TargetManufacturer)
+		assert.Equal(t, firmwareE2ETargetModel, small.TargetModel)
+		assert.Equal(t, firmwareE2EVersion, small.FirmwareVersion)
 
 		chunked := findFirmwareFile(files, chunkedFileID)
 		require.NotNil(t, chunked, "list should include the chunked upload")
 		assert.Equal(t, "e2e-firmware-chunked.swu", chunked.Filename)
 		assert.Equal(t, chunkedSize, chunked.Size, "stored size should match the full chunked file")
+		assert.Equal(t, firmwareE2ETargetManufacturer, chunked.TargetManufacturer)
+		assert.Equal(t, firmwareE2ETargetModel, chunked.TargetModel)
+		assert.Equal(t, firmwareE2EVersion, chunked.FirmwareVersion)
 		t.Logf("✓ List contains both uploads (%d file(s) total)", len(files))
 	})
 
@@ -194,6 +213,7 @@ type firmwareE2EFile struct {
 	Size               int64  `json:"size"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
 }
 
 type firmwareE2ECheck struct {
@@ -218,7 +238,11 @@ func writeRandomFirmwareFile(t *testing.T, dir, name string, size int64) string 
 func checkFirmwareFile(t *testing.T, ctx context.Context, env []string, path string) firmwareE2ECheck {
 	t.Helper()
 
-	output, err := runFleetCLI(ctx, env, "firmware", "check", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, path)
+	output, err := runFleetCLI(ctx, env, "firmware", "check",
+		"--target-manufacturer", firmwareE2ETargetManufacturer,
+		"--target-model", firmwareE2ETargetModel,
+		"--firmware-version", firmwareE2EVersion,
+		path)
 	require.NoError(t, err, "firmware check should succeed")
 
 	var resp firmwareE2ECheck

--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +21,8 @@ const (
 	minPasswordLength      = 8
 	maxLocateLEDOnTimeSecs = 300
 )
+
+var firmwareFilenameVersionRE = regexp.MustCompile(`(?:^|[^0-9.])v?([0-9]+\.[0-9]+\.[0-9]+)(?:$|[^0-9.]|\.[A-Za-z])`)
 
 // REST API JSON types matching the OpenAPI spec (MDK-API.json)
 
@@ -169,6 +172,21 @@ func nextFirmwareVersion(currentVersion string) string {
 	}
 
 	return fmt.Sprintf("%d.%d.%d", major, minor, patch+1)
+}
+
+func firmwareVersionFromFilename(filename string) (string, bool) {
+	matches := firmwareFilenameVersionRE.FindStringSubmatch(filename)
+	if len(matches) != 2 {
+		return "", false
+	}
+	return matches[1], true
+}
+
+func stagedFirmwareVersion(filename, currentVersion string) string {
+	if version, ok := firmwareVersionFromFilename(filename); ok {
+		return version
+	}
+	return nextFirmwareVersion(currentVersion)
 }
 
 func buildSystemUpdateStatus(status, currentVersion, previousVersion, newVersion string) UpdateStatus {
@@ -1785,24 +1803,29 @@ func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			h.writeJSON(w, http.StatusConflict, MessageResponse{Message: "System update is already in progress."})
 			return
 		}
+		h.state.mu.Unlock()
+
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Missing or invalid 'file' field in multipart form")
+			return
+		}
+		defer file.Close()
+
+		h.state.mu.Lock()
+		switch h.state.FWUpdateStatus {
+		case "downloading", "downloaded", "installing", "installed":
+			h.state.mu.Unlock()
+			h.writeJSON(w, http.StatusConflict, MessageResponse{Message: "System update is already in progress."})
+			return
+		}
 		currentVersion := h.state.FWCurrentVersion
 		if currentVersion == "" {
 			currentVersion = defaultFirmwareVersion
 		}
 		h.state.FWUpdateStatus = "downloading"
-		h.state.FWNewVersion = nextFirmwareVersion(currentVersion)
+		h.state.FWNewVersion = stagedFirmwareVersion(header.Filename, currentVersion)
 		h.state.mu.Unlock()
-
-		file, header, err := r.FormFile("file")
-		if err != nil {
-			h.state.mu.Lock()
-			h.state.FWUpdateStatus = ""
-			h.state.FWNewVersion = ""
-			h.state.mu.Unlock()
-			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Missing or invalid 'file' field in multipart form")
-			return
-		}
-		defer file.Close()
 
 		log.Printf("Firmware upload received: filename=%s, size=%d", header.Filename, header.Size)
 		h.startFirmwareOTALifecycle()

--- a/server/fake-proto-rig/rest_api_handler_test.go
+++ b/server/fake-proto-rig/rest_api_handler_test.go
@@ -2473,6 +2473,54 @@ func TestHandleSystem_SwUpdateStatusUsesSpecFieldNames(t *testing.T) {
 	}
 }
 
+func TestStagedFirmwareVersion_UsesFilenameVersionWhenPresent(t *testing.T) {
+	tests := []struct {
+		name           string
+		filename       string
+		currentVersion string
+		want           string
+	}{
+		{
+			name:           "plain semantic version",
+			filename:       "protoos-1.9.0.swu",
+			currentVersion: "1.8.0",
+			want:           "1.9.0",
+		},
+		{
+			name:           "v-prefixed semantic version",
+			filename:       "firmware-update-v2.0.2.swu",
+			currentVersion: "1.8.0",
+			want:           "2.0.2",
+		},
+		{
+			name:           "fallback when filename has no version",
+			filename:       "protoos-update.swu",
+			currentVersion: "1.8.0",
+			want:           defaultNextFirmwareVersion,
+		},
+		{
+			name:           "fallback increments non-default current version",
+			filename:       "protoos-update.swu",
+			currentVersion: "2.3.4",
+			want:           "2.3.5",
+		},
+		{
+			name:           "does not extract partial four-part version",
+			filename:       "protoos-1.2.3.4.swu",
+			currentVersion: "1.8.0",
+			want:           defaultNextFirmwareVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stagedFirmwareVersion(tt.filename, tt.currentVersion); got != tt.want {
+				t.Fatalf("expected staged version %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestHandleSystem_PreviousVersionSetAfterInstallReboot(t *testing.T) {
 	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
 	h := NewRESTApiHandler(state)
@@ -2622,10 +2670,11 @@ func TestHandleUpdate_PutWhileInstalled_RejectsAndPreservesStagedVersion(t *test
 func TestHandleUpdate_PutProgressesToInstalled(t *testing.T) {
 	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
 	h := NewRESTApiHandler(state)
+	const uploadedVersion = "2.4.6"
 
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
-	part, err := writer.CreateFormFile("file", "protoos-update.swu")
+	part, err := writer.CreateFormFile("file", "protoos-"+uploadedVersion+".swu")
 	if err != nil {
 		t.Fatalf("failed to create multipart file: %v", err)
 	}
@@ -2653,11 +2702,34 @@ func TestHandleUpdate_PutProgressesToInstalled(t *testing.T) {
 			t.Fatalf("expected sw_update_status object, got: %v", info["sw_update_status"])
 		}
 
-		if got := swUpdate["new_version"]; got != defaultNextFirmwareVersion {
-			t.Fatalf("expected new_version %q after upload, got %v", defaultNextFirmwareVersion, got)
+		if got := swUpdate["new_version"]; got != uploadedVersion {
+			t.Fatalf("expected new_version %q after upload, got %v", uploadedVersion, got)
 		}
 
 		if swUpdate["status"] == "installed" {
+			rebootRR := httptest.NewRecorder()
+			rebootReq := httptest.NewRequest(http.MethodPost, "/api/v1/system/reboot", nil)
+			h.handleReboot(rebootRR, rebootReq)
+
+			if rebootRR.Code != http.StatusAccepted {
+				t.Fatalf("expected %d from reboot, got %d; body=%s", http.StatusAccepted, rebootRR.Code, rebootRR.Body.String())
+			}
+
+			state.mu.Lock()
+			state.Rebooting = false
+			state.mu.Unlock()
+
+			info = getSystemInfo(t, h)
+			swUpdate, ok = info["sw_update_status"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected sw_update_status object after reboot, got: %v", info["sw_update_status"])
+			}
+			if got := swUpdate["current_version"]; got != uploadedVersion {
+				t.Fatalf("expected current_version %q after reboot, got %v", uploadedVersion, got)
+			}
+			if got := swUpdate["previous_version"]; got != defaultFirmwareVersion {
+				t.Fatalf("expected previous_version %q after reboot, got %v", defaultFirmwareVersion, got)
+			}
 			return
 		}
 

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -677,7 +677,10 @@ func TestExecuteCommandOnDevice_FirmwareUpdatePassesFileMetadata(t *testing.T) {
 	filesService, err := files.NewService(files.Config{})
 	require.NoError(t, err)
 	content := "firmware image"
-	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader(content))
+	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader(content), files.FirmwareMetadata{
+		TargetManufacturer: "Proto",
+		TargetModel:        "S21",
+	})
 	require.NoError(t, err)
 
 	mockQueue := mocks.NewMockMessageQueue(ctrl)

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -680,6 +680,7 @@ func TestExecuteCommandOnDevice_FirmwareUpdatePassesFileMetadata(t *testing.T) {
 	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader(content), files.FirmwareMetadata{
 		TargetManufacturer: "Proto",
 		TargetModel:        "S21",
+		FirmwareVersion:    "1.2.3",
 	})
 	require.NoError(t, err)
 

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -25,6 +25,7 @@ type uploadSession struct {
 	mu            sync.Mutex
 	uploadID      string
 	filename      string
+	metadata      files.FirmwareMetadata
 	expectedSize  int64
 	receivedBytes int64
 	tempFilePath  string
@@ -33,8 +34,10 @@ type uploadSession struct {
 }
 
 type initiateRequest struct {
-	Filename string `json:"filename"`
-	FileSize int64  `json:"file_size"`
+	Filename           string `json:"filename"`
+	FileSize           int64  `json:"file_size"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type initiateResponse struct {
@@ -137,6 +140,14 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	metadata := files.FirmwareMetadata{
+		TargetManufacturer: req.TargetManufacturer,
+		TargetModel:        req.TargetModel,
+	}
+	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	if req.FileSize <= 0 {
 		writeError(w, http.StatusBadRequest, "file_size must be greater than zero")
@@ -168,6 +179,7 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mgr.sessions[uploadID] = &uploadSession{
 		uploadID:     uploadID,
 		filename:     req.Filename,
+		metadata:     metadata,
 		expectedSize: req.FileSize,
 		tempFilePath: tempPath,
 		createdAt:    now,
@@ -326,7 +338,7 @@ func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, err := h.filesService.SaveFirmwareFileFromPath(sess.filename, sess.tempFilePath)
+	fileID, err := h.filesService.SaveFirmwareFileFromPath(sess.filename, sess.tempFilePath, sess.metadata)
 	if err != nil {
 		os.Remove(sess.tempFilePath)
 		if isClientError(err) {

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -29,6 +29,7 @@ type uploadSession struct {
 	expectedSize  int64
 	receivedBytes int64
 	tempFilePath  string
+	force         bool
 	createdAt     time.Time
 	lastActivity  time.Time
 }
@@ -38,6 +39,8 @@ type initiateRequest struct {
 	FileSize           int64  `json:"file_size"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
+	Force              bool   `json:"force,omitempty"`
 }
 
 type initiateResponse struct {
@@ -143,10 +146,7 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	metadata := files.FirmwareMetadata{
 		TargetManufacturer: req.TargetManufacturer,
 		TargetModel:        req.TargetModel,
-	}
-	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
+		FirmwareVersion:    req.FirmwareVersion,
 	}
 
 	if req.FileSize <= 0 {
@@ -182,6 +182,7 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		metadata:     metadata,
 		expectedSize: req.FileSize,
 		tempFilePath: tempPath,
+		force:        req.Force,
 		createdAt:    now,
 		lastActivity: now,
 	}
@@ -338,7 +339,7 @@ func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, err := h.filesService.SaveFirmwareFileFromPath(sess.filename, sess.tempFilePath, sess.metadata)
+	saveResult, err := h.filesService.SaveFirmwareUploadFromPath(sess.filename, sess.tempFilePath, sess.metadata, sess.force, "")
 	if err != nil {
 		os.Remove(sess.tempFilePath)
 		if isClientError(err) {
@@ -350,11 +351,11 @@ func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("chunked upload completed", "upload_id", uploadID, "firmware_file_id", fileID)
+	slog.Info("chunked upload completed", "upload_id", uploadID, "firmware_file_id", saveResult.FirmwareFileID, "reused", saveResult.Reused)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(uploadResponse{FirmwareFileID: fileID}); err != nil {
+	if err := json.NewEncoder(w).Encode(uploadResponse{FirmwareFileID: saveResult.FirmwareFileID, Reused: saveResult.Reused}); err != nil {
 		slog.Error("failed to encode chunked upload response", "error", err)
 	}
 }

--- a/server/internal/handlers/firmware/chunked_test.go
+++ b/server/internal/handlers/firmware/chunked_test.go
@@ -54,10 +54,14 @@ func TestParseContentRange(t *testing.T) {
 
 func chunkedInitiateBody(filename string, size int) string {
 	return fmt.Sprintf(
-		`{"filename":%q,"file_size":%d,"target_manufacturer":"Proto","target_model":"S21"}`,
+		`{"filename":%q,"file_size":%d,"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`,
 		filename,
 		size,
 	)
+}
+
+func chunkedInitiateBodyWithoutMetadata(filename string, size int) string {
+	return fmt.Sprintf(`{"filename":%q,"file_size":%d}`, filename, size)
 }
 
 func TestChunkedUpload_FullLifecycle(t *testing.T) {
@@ -136,18 +140,42 @@ func TestChunkedUpload_InitiateRejectsInvalidExtension(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "unsupported firmware file type")
 }
 
-func TestChunkedUpload_InitiateRejectsMissingTargetMetadata(t *testing.T) {
+func TestChunkedUpload_CompleteRejectsMissingTargetMetadata(t *testing.T) {
 	env := newTestEnv(t)
-	env.expectAuth()
 	mgr := NewChunkedUploadManager()
 
-	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":100}`))
+	initHandler := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	chunkH := &chunkHandler{mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	completeH := &completeHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	content := "missing metadata firmware"
+
+	env.expectAuth()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBodyWithoutMetadata("firmware.swu", len(content))))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
+	initHandler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
 
-	h.ServeHTTP(rr, req)
+	var initResp initiateResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &initResp))
+
+	env.expectAuth()
+	req = httptest.NewRequest(http.MethodPut, "/api/v1/firmware/upload/chunked/"+initResp.UploadID, strings.NewReader(content))
+	req.Header.Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", len(content)-1, len(content)))
+	req.AddCookie(validSessionCookie(env.sessionID))
+	req.SetPathValue("uploadId", initResp.UploadID)
+	rr = httptest.NewRecorder()
+	chunkH.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	env.expectAuth()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked/"+initResp.UploadID+"/complete", nil)
+	req.AddCookie(validSessionCookie(env.sessionID))
+	req.SetPathValue("uploadId", initResp.UploadID)
+	rr = httptest.NewRecorder()
+	completeH.ServeHTTP(rr, req)
+
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	assert.Contains(t, rr.Body.String(), "target_manufacturer")
 }

--- a/server/internal/handlers/firmware/chunked_test.go
+++ b/server/internal/handlers/firmware/chunked_test.go
@@ -52,6 +52,14 @@ func TestParseContentRange(t *testing.T) {
 	}
 }
 
+func chunkedInitiateBody(filename string, size int) string {
+	return fmt.Sprintf(
+		`{"filename":%q,"file_size":%d,"target_manufacturer":"Proto","target_model":"S21"}`,
+		filename,
+		size,
+	)
+}
+
 func TestChunkedUpload_FullLifecycle(t *testing.T) {
 	env := newTestEnv(t)
 	mgr := NewChunkedUploadManager()
@@ -64,7 +72,7 @@ func TestChunkedUpload_FullLifecycle(t *testing.T) {
 
 	// Initiate
 	env.expectAuth()
-	body := fmt.Sprintf(`{"filename":"firmware.swu","file_size":%d}`, len(content))
+	body := chunkedInitiateBody("firmware.swu", len(content))
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
@@ -118,7 +126,7 @@ func TestChunkedUpload_InitiateRejectsInvalidExtension(t *testing.T) {
 	mgr := NewChunkedUploadManager()
 
 	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"bad.bin","file_size":100}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("bad.bin", 100)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
@@ -128,6 +136,22 @@ func TestChunkedUpload_InitiateRejectsInvalidExtension(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "unsupported firmware file type")
 }
 
+func TestChunkedUpload_InitiateRejectsMissingTargetMetadata(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	mgr := NewChunkedUploadManager()
+
+	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":100}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "target_manufacturer")
+}
+
 func TestChunkedUpload_InitiateRejectsOversizedFile(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
@@ -135,7 +159,7 @@ func TestChunkedUpload_InitiateRejectsOversizedFile(t *testing.T) {
 	mgr := NewChunkedUploadManager()
 
 	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":200}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 200)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
@@ -150,7 +174,7 @@ func TestChunkedUpload_InitiateRejectsAuth(t *testing.T) {
 	mgr := NewChunkedUploadManager()
 
 	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":100}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 100)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
@@ -183,7 +207,7 @@ func TestChunkedUpload_ChunkRejectsOutOfOrder(t *testing.T) {
 
 	// Initiate
 	env.expectAuth()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":10}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 10)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
@@ -216,7 +240,7 @@ func TestChunkedUpload_CompleteRejectsSizeMismatch(t *testing.T) {
 
 	// Initiate with file_size=10
 	env.expectAuth()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":10}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 10)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
@@ -257,7 +281,7 @@ func TestChunkedUpload_DuplicateChunkRejected(t *testing.T) {
 
 	// Initiate
 	env.expectAuth()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":10}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 10)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -25,7 +25,9 @@ type uploadResponse struct {
 }
 
 type checkRequest struct {
-	SHA256 string `json:"sha256"`
+	SHA256             string `json:"sha256"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type checkResponse struct {
@@ -148,7 +150,16 @@ func (h *checkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, ok := h.filesService.FindFirmwareFileByChecksum(strings.ToLower(req.SHA256))
+	metadata := files.FirmwareMetadata{
+		TargetManufacturer: req.TargetManufacturer,
+		TargetModel:        req.TargetModel,
+	}
+	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	fileID, ok := h.filesService.FindFirmwareFileByChecksum(strings.ToLower(req.SHA256), metadata)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -195,7 +206,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	const multipartOverhead int64 = 1 * 1024 * 1024 // 1 MB
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxUploadBytes+multipartOverhead)
 
-	filename, fileReader, err := extractMultipartFile(r)
+	filename, fileReader, metadata, err := extractMultipartFile(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -207,7 +218,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, err := h.filesService.SaveFirmwareFile(filename, fileReader)
+	fileID, err := h.filesService.SaveFirmwareFile(filename, fileReader, metadata)
 	if err != nil {
 		if isClientError(err) {
 			writeError(w, http.StatusBadRequest, err.Error())
@@ -229,33 +240,57 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // extractMultipartFile streams the multipart body to find the "file" part
 // without buffering the entire body in memory or spilling to temp files.
-func extractMultipartFile(r *http.Request) (filename string, reader io.ReadCloser, err error) {
+func extractMultipartFile(r *http.Request) (filename string, reader io.ReadCloser, metadata files.FirmwareMetadata, err error) {
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
-		return "", nil, fmt.Errorf("expected multipart/form-data content type")
+		return "", nil, files.FirmwareMetadata{}, fmt.Errorf("expected multipart/form-data content type")
 	}
 
 	boundary := params["boundary"]
 	if boundary == "" {
-		return "", nil, fmt.Errorf("missing multipart boundary")
+		return "", nil, files.FirmwareMetadata{}, fmt.Errorf("missing multipart boundary")
 	}
 
 	mr := multipart.NewReader(r.Body, boundary)
+	var filePart io.ReadCloser
+	var fileName string
 	for {
 		part, err := mr.NextPart()
 		if err == io.EOF {
-			return "", nil, fmt.Errorf("missing 'file' field in multipart form")
+			break
 		}
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to read multipart form: %w", err)
+			return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read multipart form: %w", err)
 		}
 
-		if part.FormName() == "file" {
-			return part.FileName(), part, nil
+		switch part.FormName() {
+		case "file":
+			filePart = part
+			fileName = part.FileName()
+			if err := files.ValidateFirmwareMetadata(metadata); err != nil {
+				return "", nil, files.FirmwareMetadata{}, err
+			}
+			return fileName, filePart, metadata, nil
+		case "target_manufacturer":
+			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
+			part.Close()
+			if readErr != nil {
+				return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read target_manufacturer: %w", readErr)
+			}
+			metadata.TargetManufacturer = string(value)
+		case "target_model":
+			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
+			part.Close()
+			if readErr != nil {
+				return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read target_model: %w", readErr)
+			}
+			metadata.TargetModel = string(value)
+		default:
+			part.Close()
 		}
-		part.Close()
 	}
+	return "", nil, files.FirmwareMetadata{}, fmt.Errorf("missing 'file' field in multipart form")
 }
 
 // authenticate extracts and validates the session cookie from the HTTP request,

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -22,12 +22,14 @@ import (
 
 type uploadResponse struct {
 	FirmwareFileID string `json:"firmware_file_id"`
+	Reused         bool   `json:"reused,omitempty"`
 }
 
 type checkRequest struct {
 	SHA256             string `json:"sha256"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
 }
 
 type checkResponse struct {
@@ -153,8 +155,9 @@ func (h *checkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	metadata := files.FirmwareMetadata{
 		TargetManufacturer: req.TargetManufacturer,
 		TargetModel:        req.TargetModel,
+		FirmwareVersion:    req.FirmwareVersion,
 	}
-	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
+	if err := files.ValidateFirmwareUploadMetadata(metadata); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -206,7 +209,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	const multipartOverhead int64 = 1 * 1024 * 1024 // 1 MB
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxUploadBytes+multipartOverhead)
 
-	filename, fileReader, metadata, err := extractMultipartFile(r)
+	filename, fileReader, metadata, force, err := extractMultipartFile(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -218,7 +221,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, err := h.filesService.SaveFirmwareFile(filename, fileReader, metadata)
+	saveResult, err := h.filesService.SaveFirmwareUpload(filename, fileReader, metadata, force)
 	if err != nil {
 		if isClientError(err) {
 			writeError(w, http.StatusBadRequest, err.Error())
@@ -229,27 +232,27 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("firmware file uploaded successfully", "file_id", fileID, "filename", filename)
+	slog.Info("firmware file uploaded successfully", "file_id", saveResult.FirmwareFileID, "filename", filename, "reused", saveResult.Reused)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(uploadResponse{FirmwareFileID: fileID}); err != nil {
+	if err := json.NewEncoder(w).Encode(uploadResponse{FirmwareFileID: saveResult.FirmwareFileID, Reused: saveResult.Reused}); err != nil {
 		slog.Error("failed to encode upload response", "error", err)
 	}
 }
 
 // extractMultipartFile streams the multipart body to find the "file" part
 // without buffering the entire body in memory or spilling to temp files.
-func extractMultipartFile(r *http.Request) (filename string, reader io.ReadCloser, metadata files.FirmwareMetadata, err error) {
+func extractMultipartFile(r *http.Request) (filename string, reader io.ReadCloser, metadata files.FirmwareMetadata, force bool, err error) {
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
-		return "", nil, files.FirmwareMetadata{}, fmt.Errorf("expected multipart/form-data content type")
+		return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("expected multipart/form-data content type")
 	}
 
 	boundary := params["boundary"]
 	if boundary == "" {
-		return "", nil, files.FirmwareMetadata{}, fmt.Errorf("missing multipart boundary")
+		return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("missing multipart boundary")
 	}
 
 	mr := multipart.NewReader(r.Body, boundary)
@@ -261,36 +264,47 @@ func extractMultipartFile(r *http.Request) (filename string, reader io.ReadClose
 			break
 		}
 		if err != nil {
-			return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read multipart form: %w", err)
+			return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read multipart form: %w", err)
 		}
 
 		switch part.FormName() {
 		case "file":
 			filePart = part
 			fileName = part.FileName()
-			if err := files.ValidateFirmwareMetadata(metadata); err != nil {
-				return "", nil, files.FirmwareMetadata{}, err
-			}
-			return fileName, filePart, metadata, nil
+			return fileName, filePart, metadata, force, nil
 		case "target_manufacturer":
 			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
 			part.Close()
 			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read target_manufacturer: %w", readErr)
+				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read target_manufacturer: %w", readErr)
 			}
 			metadata.TargetManufacturer = string(value)
 		case "target_model":
 			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
 			part.Close()
 			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read target_model: %w", readErr)
+				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read target_model: %w", readErr)
 			}
 			metadata.TargetModel = string(value)
+		case "firmware_version":
+			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
+			part.Close()
+			if readErr != nil {
+				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read firmware_version: %w", readErr)
+			}
+			metadata.FirmwareVersion = string(value)
+		case "force":
+			value, readErr := io.ReadAll(io.LimitReader(part, 16))
+			part.Close()
+			if readErr != nil {
+				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read force: %w", readErr)
+			}
+			force = strings.EqualFold(strings.TrimSpace(string(value)), "true") || strings.TrimSpace(string(value)) == "1"
 		default:
 			part.Close()
 		}
 	}
-	return "", nil, files.FirmwareMetadata{}, fmt.Errorf("missing 'file' field in multipart form")
+	return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("missing 'file' field in multipart form")
 }
 
 // authenticate extracts and validates the session cookie from the HTTP request,

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -149,6 +149,8 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
+	require.NoError(t, writer.WriteField("target_manufacturer", "Proto"))
+	require.NoError(t, writer.WriteField("target_model", "S21"))
 	part, err := writer.CreateFormFile("file", filename)
 	require.NoError(t, err)
 	_, err = part.Write(content)
@@ -161,6 +163,33 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 		req.AddCookie(cookie)
 	}
 	return req
+}
+
+func createMultipartRequestWithoutMetadata(t *testing.T, filename string, content []byte, cookie *http.Cookie) *http.Request {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", filename)
+	require.NoError(t, err)
+	_, err = part.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	return req
+}
+
+func testFirmwareMetadata() files.FirmwareMetadata {
+	return files.FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21"}
+}
+
+func firmwareCheckBody(checksum string) string {
+	return fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21"}`, checksum)
 }
 
 func createCheckRequest(t *testing.T, body string, cookie *http.Cookie) *http.Request {
@@ -240,6 +269,18 @@ func TestUploadHandler_RejectsInvalidExtension(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	assert.Contains(t, rr.Body.String(), "unsupported firmware file type")
+}
+
+func TestUploadHandler_RejectsMissingTargetMetadata(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	req := createMultipartRequestWithoutMetadata(t, "firmware.swu", []byte("data"), validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.uploadHandler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "target_manufacturer")
 }
 
 func TestUploadHandler_RejectsMissingFileField(t *testing.T) {
@@ -349,7 +390,7 @@ func TestCheckHandler_RejectsNonHexChecksum(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 	nonHex := strings.Repeat("zz", 32) // 64 chars but not valid hex
-	req := createCheckRequest(t, `{"sha256":"`+nonHex+`"}`, validSessionCookie(env.sessionID))
+	req := createCheckRequest(t, firmwareCheckBody(nonHex), validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 
 	env.checkHandler().ServeHTTP(rr, req)
@@ -362,7 +403,7 @@ func TestCheckHandler_ReturnsFalseForUnknownChecksum(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 	checksum := strings.Repeat("a", 64)
-	req := createCheckRequest(t, `{"sha256":"`+checksum+`"}`, validSessionCookie(env.sessionID))
+	req := createCheckRequest(t, firmwareCheckBody(checksum), validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 
 	env.checkHandler().ServeHTTP(rr, req)
@@ -372,16 +413,35 @@ func TestCheckHandler_ReturnsFalseForUnknownChecksum(t *testing.T) {
 	assert.NotContains(t, rr.Body.String(), "firmware_file_id")
 }
 
+func TestCheckHandler_RequiresMatchingTargetMetadata(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+
+	content := "firmware content for target mismatch"
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	body := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S19"}`, sha256Hex(content))
+	req := createCheckRequest(t, body, validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.checkHandler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"exists":false`)
+	assert.NotContains(t, rr.Body.String(), fileID)
+}
+
 func TestCheckHandler_ReturnsTrueForKnownChecksum(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 
 	content := "firmware content for check test"
-	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	checksum := sha256Hex(content)
-	req := createCheckRequest(t, `{"sha256":"`+checksum+`"}`, validSessionCookie(env.sessionID))
+	req := createCheckRequest(t, firmwareCheckBody(checksum), validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 
 	env.checkHandler().ServeHTTP(rr, req)
@@ -396,11 +456,11 @@ func TestCheckHandler_AcceptsUppercaseChecksum(t *testing.T) {
 	env.expectAuth()
 
 	content := "firmware for uppercase check"
-	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	checksum := strings.ToUpper(sha256Hex(content))
-	req := createCheckRequest(t, `{"sha256":"`+checksum+`"}`, validSessionCookie(env.sessionID))
+	req := createCheckRequest(t, firmwareCheckBody(checksum), validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 
 	env.checkHandler().ServeHTTP(rr, req)
@@ -552,9 +612,9 @@ func TestListFilesHandler_ReturnsSavedFiles(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 
-	_, err := env.fileSvc.SaveFirmwareFile("alpha.swu", strings.NewReader("alpha"))
+	_, err := env.fileSvc.SaveFirmwareFile("alpha.swu", strings.NewReader("alpha"), testFirmwareMetadata())
 	require.NoError(t, err)
-	_, err = env.fileSvc.SaveFirmwareFile("beta.tar.gz", strings.NewReader("beta content"))
+	_, err = env.fileSvc.SaveFirmwareFile("beta.tar.gz", strings.NewReader("beta content"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/firmware/files", nil)
@@ -569,6 +629,10 @@ func TestListFilesHandler_ReturnsSavedFiles(t *testing.T) {
 	err = json.Unmarshal(rr.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	assert.Len(t, resp.Files, 2)
+	for _, file := range resp.Files {
+		assert.Equal(t, "Proto", file.TargetManufacturer)
+		assert.Equal(t, "S21", file.TargetModel)
+	}
 }
 
 // --- Delete file handler tests ---
@@ -587,7 +651,7 @@ func TestDeleteFileHandler_DeletesExistingFile(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 
-	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"))
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/firmware/files/"+fileID, nil)
@@ -650,9 +714,9 @@ func TestDeleteAllFilesHandler_DeletesAllFiles(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 
-	_, err := env.fileSvc.SaveFirmwareFile("one.swu", strings.NewReader("one"))
+	_, err := env.fileSvc.SaveFirmwareFile("one.swu", strings.NewReader("one"), testFirmwareMetadata())
 	require.NoError(t, err)
-	_, err = env.fileSvc.SaveFirmwareFile("two.swu", strings.NewReader("two"))
+	_, err = env.fileSvc.SaveFirmwareFile("two.swu", strings.NewReader("two"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/firmware/files", nil)

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -151,6 +151,7 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 	writer := multipart.NewWriter(&buf)
 	require.NoError(t, writer.WriteField("target_manufacturer", "Proto"))
 	require.NoError(t, writer.WriteField("target_model", "S21"))
+	require.NoError(t, writer.WriteField("firmware_version", "v2.0.0"))
 	part, err := writer.CreateFormFile("file", filename)
 	require.NoError(t, err)
 	_, err = part.Write(content)
@@ -185,11 +186,11 @@ func createMultipartRequestWithoutMetadata(t *testing.T, filename string, conten
 }
 
 func testFirmwareMetadata() files.FirmwareMetadata {
-	return files.FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21"}
+	return files.FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21", FirmwareVersion: "v2.0.0"}
 }
 
 func firmwareCheckBody(checksum string) string {
-	return fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21"}`, checksum)
+	return fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`, checksum)
 }
 
 func createCheckRequest(t *testing.T, body string, cookie *http.Cookie) *http.Request {
@@ -421,7 +422,7 @@ func TestCheckHandler_RequiresMatchingTargetMetadata(t *testing.T) {
 	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	body := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S19"}`, sha256Hex(content))
+	body := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S19","firmware_version":"v2.0.0"}`, sha256Hex(content))
 	req := createCheckRequest(t, body, validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 

--- a/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
@@ -240,7 +240,10 @@ func TestCommandArtifactUploadAndDownloadRequireInFlightExpectation(t *testing.T
 func TestDownloadCommandArtifactServesFirmwarePayload(t *testing.T) {
 	h, client := newArtifactTestClient(t)
 	payload := []byte("firmware image bytes")
-	fileID, err := h.files.SaveFirmwareFile("update.swu", bytes.NewReader(payload))
+	fileID, err := h.files.SaveFirmwareFile("update.swu", bytes.NewReader(payload), files.FirmwareMetadata{
+		TargetManufacturer: "Proto",
+		TargetModel:        "S21",
+	})
 	require.NoError(t, err)
 	_, info, err := h.files.OpenFirmwareFileWithInfo(fileID)
 	require.NoError(t, err)

--- a/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
@@ -243,6 +243,7 @@ func TestDownloadCommandArtifactServesFirmwarePayload(t *testing.T) {
 	fileID, err := h.files.SaveFirmwareFile("update.swu", bytes.NewReader(payload), files.FirmwareMetadata{
 		TargetManufacturer: "Proto",
 		TargetModel:        "S21",
+		FirmwareVersion:    "1.2.3",
 	})
 	require.NoError(t, err)
 	_, info, err := h.files.OpenFirmwareFileWithInfo(fileID)

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -3,6 +3,7 @@ package files
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,16 +19,25 @@ import (
 
 // FirmwareFileInfo holds metadata about a stored firmware file.
 type FirmwareFileInfo struct {
-	ID         string    `json:"id"`
-	Filename   string    `json:"filename"`
-	Size       int64     `json:"size"`
-	SHA256     string    `json:"sha256,omitempty"`
-	FilePath   string    `json:"-"`
-	UploadedAt time.Time `json:"uploaded_at"`
+	ID                 string    `json:"id"`
+	Filename           string    `json:"filename"`
+	Size               int64     `json:"size"`
+	SHA256             string    `json:"sha256,omitempty"`
+	FilePath           string    `json:"-"`
+	UploadedAt         time.Time `json:"uploaded_at"`
+	TargetManufacturer string    `json:"target_manufacturer"`
+	TargetModel        string    `json:"target_model"`
+}
+
+// FirmwareMetadata describes the single miner type a firmware file targets.
+type FirmwareMetadata struct {
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 const firmwareDir = "firmware"
 const firmwareStagingDir = "firmware/staging"
+const firmwareMetadataFilename = "metadata.json"
 
 const defaultMaxFirmwareFileSize int64 = 500 * 1024 * 1024 // 500 MB
 
@@ -45,6 +55,36 @@ func AllowedFirmwareExtensions() []string {
 
 func getFirmwareDirPath(fileID string) string {
 	return filepath.Join(firmwareDir, fileID)
+}
+
+type firmwareChecksumEntry struct {
+	fileID   string
+	metadata FirmwareMetadata
+}
+
+func (m FirmwareMetadata) normalized() FirmwareMetadata {
+	return FirmwareMetadata{
+		TargetManufacturer: strings.TrimSpace(m.TargetManufacturer),
+		TargetModel:        strings.TrimSpace(m.TargetModel),
+	}
+}
+
+func (m FirmwareMetadata) matches(other FirmwareMetadata) bool {
+	m = m.normalized()
+	other = other.normalized()
+	return m.TargetManufacturer == other.TargetManufacturer && m.TargetModel == other.TargetModel
+}
+
+// ValidateFirmwareMetadata checks that target metadata is complete.
+func ValidateFirmwareMetadata(metadata FirmwareMetadata) error {
+	metadata = metadata.normalized()
+	if metadata.TargetManufacturer == "" {
+		return fleeterror.NewInvalidArgumentError("target_manufacturer is required")
+	}
+	if metadata.TargetModel == "" {
+		return fleeterror.NewInvalidArgumentError("target_model is required")
+	}
+	return nil
 }
 
 // canonicalizeFirmwareFileID validates and normalizes a firmware file ID.
@@ -136,7 +176,12 @@ func (s *Service) ValidateFirmwareFile(filename string, size int64) error {
 //
 // Callers should call ValidateFirmwareFile or ValidateFirmwareFilename before
 // saving to ensure the filename extension is acceptable.
-func (s *Service) SaveFirmwareFile(filename string, reader io.Reader) (string, error) {
+func (s *Service) SaveFirmwareFile(filename string, reader io.Reader, metadata FirmwareMetadata) (string, error) {
+	metadata = metadata.normalized()
+	if err := ValidateFirmwareMetadata(metadata); err != nil {
+		return "", err
+	}
+
 	fileID := id.GenerateID()
 	dir := getFirmwareDirPath(fileID)
 
@@ -182,9 +227,14 @@ func (s *Service) SaveFirmwareFile(filename string, reader io.Reader) (string, e
 		return "", fleeterror.NewInternalErrorf("failed to sync firmware file to disk: %v", err)
 	}
 
+	if err := writeFirmwareMetadata(dir, metadata); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+
 	checksum := hex.EncodeToString(hasher.Sum(nil))
 
-	s.rememberFirmwareChecksum(checksum, fileID)
+	s.rememberFirmwareChecksum(checksum, fileID, metadata)
 
 	slog.Info("firmware file saved", "file_id", fileID, "filename", sanitized, "checksum", checksum)
 	return fileID, nil
@@ -194,7 +244,12 @@ func (s *Service) SaveFirmwareFile(filename string, reader io.Reader) (string, e
 // into the standard firmware directory, computes its SHA-256 checksum, and registers
 // it in the checksum index. Uses os.Rename for efficiency — both paths must be on
 // the same filesystem. Used by the chunked upload complete handler.
-func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string) (string, error) {
+func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string, metadata FirmwareMetadata) (string, error) {
+	metadata = metadata.normalized()
+	if err := ValidateFirmwareMetadata(metadata); err != nil {
+		return "", err
+	}
+
 	fileID := id.GenerateID()
 	dir := getFirmwareDirPath(fileID)
 
@@ -226,7 +281,12 @@ func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string) (str
 		return "", fleeterror.NewInvalidArgumentError("firmware file is empty")
 	}
 
-	s.rememberFirmwareChecksum(checksum, fileID)
+	if err := writeFirmwareMetadata(dir, metadata); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+
+	s.rememberFirmwareChecksum(checksum, fileID, metadata)
 
 	slog.Info("firmware file saved from path", "file_id", fileID, "filename", sanitized, "checksum", checksum)
 	return fileID, nil
@@ -242,9 +302,29 @@ func (s *Service) GetFirmwareFilePath(fileID string) (string, error) {
 	return getFirmwareFilePathForCanonicalID(canonical)
 }
 
+// GetFirmwareMetadata returns the target metadata for a stored firmware file.
+func (s *Service) GetFirmwareMetadata(fileID string) (FirmwareMetadata, error) {
+	canonical, err := canonicalizeFirmwareFileID(fileID)
+	if err != nil {
+		return FirmwareMetadata{}, err
+	}
+	dir := getFirmwareDirPath(canonical)
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return FirmwareMetadata{}, fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
+		}
+		return FirmwareMetadata{}, fleeterror.NewInternalErrorf("failed to stat firmware dir %s: %v", canonical, err)
+	}
+	metadata, err := readFirmwareMetadata(dir)
+	if err != nil {
+		return FirmwareMetadata{}, fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+	}
+	return metadata, nil
+}
+
 func getFirmwareFilePathForCanonicalID(canonical string) (string, error) {
 	dir := getFirmwareDirPath(canonical)
-	path, err := findSingleFileInDir(dir)
+	path, err := findSingleFirmwarePayloadInDir(dir)
 	if err != nil {
 		return "", fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
 	}
@@ -288,13 +368,20 @@ func (s *Service) OpenFirmwareFileWithInfo(fileID string) (io.ReadCloser, Firmwa
 		file.Close()
 		return nil, FirmwareFileInfo{}, err
 	}
+	metadata, err := readFirmwareMetadata(getFirmwareDirPath(canonical))
+	if err != nil {
+		file.Close()
+		return nil, FirmwareFileInfo{}, fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+	}
 
 	return file, FirmwareFileInfo{
-		ID:       canonical,
-		Filename: filepath.Base(filePath),
-		Size:     info.Size(),
-		SHA256:   checksum,
-		FilePath: filePath,
+		ID:                 canonical,
+		Filename:           filepath.Base(filePath),
+		Size:               info.Size(),
+		SHA256:             checksum,
+		FilePath:           filePath,
+		TargetManufacturer: metadata.TargetManufacturer,
+		TargetModel:        metadata.TargetModel,
 	}, nil
 }
 
@@ -306,7 +393,11 @@ func (s *Service) firmwareChecksum(canonicalID, filePath string) (string, error)
 	if err != nil {
 		return "", fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
 	}
-	s.rememberFirmwareChecksum(checksum, canonicalID)
+	metadata, err := readFirmwareMetadata(getFirmwareDirPath(canonicalID))
+	if err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+	}
+	s.rememberFirmwareChecksum(checksum, canonicalID, metadata)
 	return checksum, nil
 }
 
@@ -317,29 +408,47 @@ func (s *Service) lookupFirmwareChecksum(canonicalID string) (string, bool) {
 	return checksum, ok
 }
 
-func (s *Service) rememberFirmwareChecksum(checksum, canonicalID string) {
+func (s *Service) rememberFirmwareChecksum(checksum, canonicalID string, metadata FirmwareMetadata) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.firmwareChecksumByID[canonicalID] = checksum
-	for _, id := range s.checksumIndex[checksum] {
-		if id == canonicalID {
+	metadata = metadata.normalized()
+	for i, entry := range s.checksumIndex[checksum] {
+		if entry.fileID == canonicalID {
+			s.checksumIndex[checksum][i].metadata = metadata
 			return
 		}
 	}
-	s.checksumIndex[checksum] = append(s.checksumIndex[checksum], canonicalID)
+	s.checksumIndex[checksum] = append(s.checksumIndex[checksum], firmwareChecksumEntry{
+		fileID:   canonicalID,
+		metadata: metadata,
+	})
 }
 
 // FindFirmwareFileByChecksum looks up a firmware file by its SHA-256 hex digest.
 // Returns the file ID and true if found, or empty string and false otherwise.
 // Used by the pre-upload check endpoint to let clients skip redundant uploads.
-func (s *Service) FindFirmwareFileByChecksum(sha256Hex string) (string, bool) {
+func (s *Service) FindFirmwareFileByChecksum(sha256Hex string, metadata FirmwareMetadata) (string, bool) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	ids := s.checksumIndex[sha256Hex]
-	if len(ids) == 0 {
-		return "", false
+	entries := append([]firmwareChecksumEntry(nil), s.checksumIndex[sha256Hex]...)
+	s.mu.Unlock()
+
+	metadata = metadata.normalized()
+	for _, entry := range entries {
+		storedMetadata, err := readFirmwareMetadata(getFirmwareDirPath(entry.fileID))
+		if err != nil {
+			slog.Warn("deleting invalid firmware dir during checksum lookup", "file_id", entry.fileID, "error", err)
+			_ = os.RemoveAll(getFirmwareDirPath(entry.fileID))
+			s.mu.Lock()
+			s.removeFirmwareChecksumLocked(sha256Hex, entry.fileID)
+			s.mu.Unlock()
+			continue
+		}
+		if storedMetadata.matches(metadata) {
+			return entry.fileID, true
+		}
 	}
-	return ids[0], true
+	return "", false
 }
 
 // DeleteFirmwareFile removes a firmware file from disk and the checksum index.
@@ -378,8 +487,8 @@ func (s *Service) DeleteFirmwareFile(fileID string) error {
 func (s *Service) removeFirmwareChecksumLocked(checksum, canonicalID string) {
 	delete(s.firmwareChecksumByID, canonicalID)
 	ids := s.checksumIndex[checksum]
-	for i, id := range ids {
-		if id != canonicalID {
+	for i, entry := range ids {
+		if entry.fileID != canonicalID {
 			continue
 		}
 		ids = append(ids[:i], ids[i+1:]...)
@@ -394,8 +503,8 @@ func (s *Service) removeFirmwareChecksumLocked(checksum, canonicalID string) {
 
 func (s *Service) removeFirmwareChecksumByScanLocked(canonicalID string) {
 	for checksum, ids := range s.checksumIndex {
-		for i, id := range ids {
-			if id != canonicalID {
+		for i, entry := range ids {
+			if entry.fileID != canonicalID {
 				continue
 			}
 			ids = append(ids[:i], ids[i+1:]...)
@@ -428,7 +537,17 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 		}
 
 		dir := getFirmwareDirPath(fileID)
-		filePath, err := findSingleFileInDir(dir)
+		metadata, err := readFirmwareMetadata(dir)
+		if err != nil {
+			slog.Warn("deleting invalid firmware dir during list", "file_id", fileID, "error", err)
+			_ = os.RemoveAll(dir)
+			s.mu.Lock()
+			s.removeFirmwareChecksumByScanLocked(fileID)
+			s.mu.Unlock()
+			continue
+		}
+
+		filePath, err := findSingleFirmwarePayloadInDir(dir)
 		if err != nil {
 			slog.Warn("skipping firmware dir during list", "file_id", fileID, "error", err)
 			continue
@@ -447,10 +566,12 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 		}
 
 		result = append(result, FirmwareFileInfo{
-			ID:         fileID,
-			Filename:   filepath.Base(filePath),
-			Size:       fileInfo.Size(),
-			UploadedAt: dirInfo.ModTime(),
+			ID:                 fileID,
+			Filename:           filepath.Base(filePath),
+			Size:               fileInfo.Size(),
+			UploadedAt:         dirInfo.ModTime(),
+			TargetManufacturer: metadata.TargetManufacturer,
+			TargetModel:        metadata.TargetModel,
 		})
 	}
 
@@ -514,7 +635,13 @@ func (s *Service) initChecksumIndex() error {
 			continue
 		}
 		dir := getFirmwareDirPath(fileID)
-		filePath, err := findSingleFileInDir(dir)
+		metadata, err := readFirmwareMetadata(dir)
+		if err != nil {
+			slog.Warn("deleting invalid firmware dir during checksum rebuild", "file_id", fileID, "error", err)
+			_ = os.RemoveAll(dir)
+			continue
+		}
+		filePath, err := findSingleFirmwarePayloadInDir(dir)
 		if err != nil {
 			continue
 		}
@@ -524,7 +651,7 @@ func (s *Service) initChecksumIndex() error {
 			continue
 		}
 
-		s.rememberFirmwareChecksum(checksum, fileID)
+		s.rememberFirmwareChecksum(checksum, fileID, metadata)
 	}
 
 	count := 0
@@ -549,6 +676,67 @@ func computeFileChecksum(filePath string) (string, error) {
 		return "", fmt.Errorf("failed to compute checksum: %w", err)
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
+	file, err := os.OpenFile(filepath.Join(dir, firmwareMetadataFilename), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fleeterror.NewInternalErrorf("failed to create firmware metadata: %v", err)
+	}
+	defer file.Close()
+
+	if err := json.NewEncoder(file).Encode(metadata.normalized()); err != nil {
+		return fleeterror.NewInternalErrorf("failed to write firmware metadata: %v", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fleeterror.NewInternalErrorf("failed to sync firmware metadata to disk: %v", err)
+	}
+	return nil
+}
+
+func readFirmwareMetadata(dir string) (FirmwareMetadata, error) {
+	file, err := os.Open(filepath.Join(dir, firmwareMetadataFilename))
+	if err != nil {
+		return FirmwareMetadata{}, err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	var metadata FirmwareMetadata
+	if err := decoder.Decode(&metadata); err != nil {
+		return FirmwareMetadata{}, err
+	}
+	metadata = metadata.normalized()
+	if err := ValidateFirmwareMetadata(metadata); err != nil {
+		return FirmwareMetadata{}, err
+	}
+	return metadata, nil
+}
+
+// findSingleFirmwarePayloadInDir returns the path to the single non-directory
+// payload entry inside a directory. metadata.json is ignored.
+func findSingleFirmwarePayloadInDir(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read firmware dir %s: %w", dir, err)
+	}
+	var foundPath string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if e.Name() == firmwareMetadataFilename {
+			continue
+		}
+		if foundPath != "" {
+			return "", fmt.Errorf("multiple files found in %s", dir)
+		}
+		foundPath = filepath.Join(dir, e.Name())
+	}
+	if foundPath == "" {
+		return "", fmt.Errorf("no file found in %s", dir)
+	}
+	return foundPath, nil
 }
 
 func hasAllowedFirmwareExtension(filename string) bool {

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -820,14 +820,14 @@ func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
 func readFirmwareMetadata(dir string) (FirmwareMetadata, error) {
 	file, err := os.Open(filepath.Join(dir, firmwareMetadataFilename))
 	if err != nil {
-		return FirmwareMetadata{}, err
+		return FirmwareMetadata{}, fmt.Errorf("open firmware metadata: %w", err)
 	}
 	defer file.Close()
 
 	decoder := json.NewDecoder(file)
 	var metadata FirmwareMetadata
 	if err := decoder.Decode(&metadata); err != nil {
-		return FirmwareMetadata{}, err
+		return FirmwareMetadata{}, fmt.Errorf("decode firmware metadata: %w", err)
 	}
 	metadata = metadata.normalized()
 	if err := ValidateFirmwareMetadata(metadata); err != nil {

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -27,12 +27,22 @@ type FirmwareFileInfo struct {
 	UploadedAt         time.Time `json:"uploaded_at"`
 	TargetManufacturer string    `json:"target_manufacturer"`
 	TargetModel        string    `json:"target_model"`
+	FirmwareVersion    string    `json:"firmware_version,omitempty"`
 }
 
 // FirmwareMetadata describes the single miner type a firmware file targets.
 type FirmwareMetadata struct {
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version,omitempty"`
+}
+
+// FirmwareUploadSaveResult describes the stored or reused firmware file after
+// upload metadata has been resolved.
+type FirmwareUploadSaveResult struct {
+	FirmwareFileID string
+	Reused         bool
+	Metadata       FirmwareMetadata
 }
 
 const firmwareDir = "firmware"
@@ -66,13 +76,16 @@ func (m FirmwareMetadata) normalized() FirmwareMetadata {
 	return FirmwareMetadata{
 		TargetManufacturer: strings.TrimSpace(m.TargetManufacturer),
 		TargetModel:        strings.TrimSpace(m.TargetModel),
+		FirmwareVersion:    strings.TrimSpace(m.FirmwareVersion),
 	}
 }
 
 func (m FirmwareMetadata) matches(other FirmwareMetadata) bool {
 	m = m.normalized()
 	other = other.normalized()
-	return m.TargetManufacturer == other.TargetManufacturer && m.TargetModel == other.TargetModel
+	return m.TargetManufacturer == other.TargetManufacturer &&
+		m.TargetModel == other.TargetModel &&
+		m.FirmwareVersion == other.FirmwareVersion
 }
 
 // ValidateFirmwareMetadata checks that target metadata is complete.
@@ -83,6 +96,19 @@ func ValidateFirmwareMetadata(metadata FirmwareMetadata) error {
 	}
 	if metadata.TargetModel == "" {
 		return fleeterror.NewInvalidArgumentError("target_model is required")
+	}
+	return nil
+}
+
+// ValidateFirmwareUploadMetadata checks metadata required for new uploads and
+// checksum reuse. Existing files may predate firmware_version metadata.
+func ValidateFirmwareUploadMetadata(metadata FirmwareMetadata) error {
+	metadata = metadata.normalized()
+	if err := ValidateFirmwareMetadata(metadata); err != nil {
+		return err
+	}
+	if metadata.FirmwareVersion == "" {
+		return fleeterror.NewInvalidArgumentError("firmware_version is required")
 	}
 	return nil
 }
@@ -178,7 +204,7 @@ func (s *Service) ValidateFirmwareFile(filename string, size int64) error {
 // saving to ensure the filename extension is acceptable.
 func (s *Service) SaveFirmwareFile(filename string, reader io.Reader, metadata FirmwareMetadata) (string, error) {
 	metadata = metadata.normalized()
-	if err := ValidateFirmwareMetadata(metadata); err != nil {
+	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
 		return "", err
 	}
 
@@ -240,16 +266,117 @@ func (s *Service) SaveFirmwareFile(filename string, reader io.Reader, metadata F
 	return fileID, nil
 }
 
+// SaveFirmwareUpload stages a streamed upload and reuses an existing file with
+// the same checksum plus metadata unless force is true.
+func (s *Service) SaveFirmwareUpload(filename string, reader io.Reader, manualMetadata FirmwareMetadata, force bool) (FirmwareUploadSaveResult, error) {
+	var result FirmwareUploadSaveResult
+
+	tempFile, err := os.CreateTemp(firmwareStagingDir, "direct-*")
+	if err != nil {
+		return result, fleeterror.NewInternalErrorf("failed to create firmware staging file: %v", err)
+	}
+	tempPath := tempFile.Name()
+	removeTemp := true
+	defer func() {
+		_ = tempFile.Close()
+		if removeTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	maxSize := s.maxFirmwareFileSize
+	if maxSize <= 0 {
+		maxSize = defaultMaxFirmwareFileSize
+	}
+	limitedReader := io.LimitReader(reader, maxSize+1)
+	hasher := sha256.New()
+	written, err := io.Copy(tempFile, io.TeeReader(limitedReader, hasher))
+	if err != nil {
+		return result, fleeterror.NewInternalErrorf("failed to write firmware staging file: %v", err)
+	}
+	if written > maxSize {
+		return result, fleeterror.NewInvalidArgumentErrorf("firmware file too large: exceeded %d byte limit during upload", maxSize)
+	}
+	if written == 0 {
+		return result, fleeterror.NewInvalidArgumentError("firmware file is empty")
+	}
+	if err := tempFile.Sync(); err != nil {
+		return result, fleeterror.NewInternalErrorf("failed to sync firmware staging file: %v", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return result, fleeterror.NewInternalErrorf("failed to close firmware staging file: %v", err)
+	}
+
+	checksum := hex.EncodeToString(hasher.Sum(nil))
+	result, err = s.SaveFirmwareUploadFromPath(filename, tempPath, manualMetadata, force, checksum)
+	if err != nil {
+		return FirmwareUploadSaveResult{}, err
+	}
+	removeTemp = false
+	return result, nil
+}
+
+// SaveFirmwareUploadFromPath consumes a staged upload path. On success it either
+// removes the staged file and returns an existing matching firmware_file_id, or
+// moves the staged file into permanent firmware storage.
+func (s *Service) SaveFirmwareUploadFromPath(filename string, srcPath string, manualMetadata FirmwareMetadata, force bool, checksum string) (FirmwareUploadSaveResult, error) {
+	var result FirmwareUploadSaveResult
+
+	metadata := manualMetadata.normalized()
+	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
+		return result, err
+	}
+
+	if checksum == "" {
+		var err error
+		checksum, err = computeFileChecksum(srcPath)
+		if err != nil {
+			return result, fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
+		}
+	}
+
+	if !force {
+		if existingID, ok := s.FindFirmwareFileByChecksum(checksum, metadata); ok {
+			if err := os.Remove(srcPath); err != nil && !os.IsNotExist(err) {
+				return result, fleeterror.NewInternalErrorf("failed to remove reused firmware staging file: %v", err)
+			}
+			return FirmwareUploadSaveResult{
+				FirmwareFileID: existingID,
+				Reused:         true,
+				Metadata:       metadata,
+			}, nil
+		}
+	}
+
+	fileID, err := s.saveFirmwareFileFromPathWithChecksum(filename, srcPath, metadata, checksum)
+	if err != nil {
+		return result, err
+	}
+	return FirmwareUploadSaveResult{
+		FirmwareFileID: fileID,
+		Metadata:       metadata,
+	}, nil
+}
+
 // SaveFirmwareFileFromPath moves an existing file (e.g. from the staging directory)
 // into the standard firmware directory, computes its SHA-256 checksum, and registers
 // it in the checksum index. Uses os.Rename for efficiency — both paths must be on
 // the same filesystem. Used by the chunked upload complete handler.
 func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string, metadata FirmwareMetadata) (string, error) {
 	metadata = metadata.normalized()
-	if err := ValidateFirmwareMetadata(metadata); err != nil {
+	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
 		return "", err
 	}
 
+	checksum, err := computeFileChecksum(srcPath)
+	if err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to compute checksum before move: %v", err)
+	}
+
+	return s.saveFirmwareFileFromPathWithChecksum(filename, srcPath, metadata, checksum)
+}
+
+func (s *Service) saveFirmwareFileFromPathWithChecksum(filename string, srcPath string, metadata FirmwareMetadata, checksum string) (string, error) {
 	fileID := id.GenerateID()
 	dir := getFirmwareDirPath(fileID)
 
@@ -263,12 +390,6 @@ func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string, meta
 	if err := os.Rename(srcPath, destPath); err != nil {
 		_ = os.RemoveAll(dir)
 		return "", fleeterror.NewInternalErrorf("failed to move firmware file: %v", err)
-	}
-
-	checksum, err := computeFileChecksum(destPath)
-	if err != nil {
-		_ = os.RemoveAll(dir)
-		return "", fleeterror.NewInternalErrorf("failed to compute checksum after move: %v", err)
 	}
 
 	info, err := os.Stat(destPath)
@@ -382,6 +503,7 @@ func (s *Service) OpenFirmwareFileWithInfo(fileID string) (io.ReadCloser, Firmwa
 		FilePath:           filePath,
 		TargetManufacturer: metadata.TargetManufacturer,
 		TargetModel:        metadata.TargetModel,
+		FirmwareVersion:    metadata.FirmwareVersion,
 	}, nil
 }
 
@@ -572,6 +694,7 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 			UploadedAt:         dirInfo.ModTime(),
 			TargetManufacturer: metadata.TargetManufacturer,
 			TargetModel:        metadata.TargetModel,
+			FirmwareVersion:    metadata.FirmwareVersion,
 		})
 	}
 

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -19,6 +19,10 @@ func checksumOf(content string) string {
 	return hex.EncodeToString(h[:])
 }
 
+func testFirmwareMetadata() FirmwareMetadata {
+	return FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21"}
+}
+
 func storageDirEntries(t *testing.T, dir string) []os.DirEntry {
 	t.Helper()
 	entries, err := os.ReadDir(dir)
@@ -39,6 +43,7 @@ func storageDirEntriesExcept(t *testing.T, dir, ignoredName string) []os.DirEntr
 }
 
 func firmwareFileEntries(t *testing.T) []os.DirEntry {
+	t.Helper()
 	return storageDirEntriesExcept(t, firmwareDir, "staging")
 }
 
@@ -110,7 +115,7 @@ func TestSaveFirmwareFile_StreamsToDisk(t *testing.T) {
 	content := "fake firmware content"
 	reader := strings.NewReader(content)
 
-	fileID, err := svc.SaveFirmwareFile("firmware-v2.0.swu", reader)
+	fileID, err := svc.SaveFirmwareFile("firmware-v2.0.swu", reader, testFirmwareMetadata())
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, fileID)
@@ -124,10 +129,37 @@ func TestSaveFirmwareFile_StreamsToDisk(t *testing.T) {
 	assert.Equal(t, "firmware-v2.0.swu", filepath.Base(filePath))
 }
 
+func TestSaveFirmwareFile_WritesTargetMetadata(t *testing.T) {
+	svc := setupService(t)
+
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	metadata, err := svc.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	assert.Equal(t, testFirmwareMetadata(), metadata)
+
+	files, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "Proto", files[0].TargetManufacturer)
+	assert.Equal(t, "S21", files[0].TargetModel)
+}
+
+func TestSaveFirmwareFile_RejectsMissingTargetMetadata(t *testing.T) {
+	svc := setupService(t)
+
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), FirmwareMetadata{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target_manufacturer")
+	assert.Empty(t, firmwareFileEntries(t), "invalid upload should not leave files behind")
+}
+
 func TestSaveFirmwareFile_SanitizesFilename(t *testing.T) {
 	svc := setupService(t)
 
-	fileID, err := svc.SaveFirmwareFile("../../etc/passwd", strings.NewReader("data"))
+	fileID, err := svc.SaveFirmwareFile("../../etc/passwd", strings.NewReader("data"), testFirmwareMetadata())
 
 	require.NoError(t, err)
 
@@ -141,7 +173,7 @@ func TestSaveFirmwareFile_RejectsOversizedStream(t *testing.T) {
 	svc.maxFirmwareFileSize = 10
 
 	oversizedData := strings.Repeat("x", 20)
-	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(oversizedData))
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(oversizedData), testFirmwareMetadata())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too large")
@@ -153,10 +185,10 @@ func TestSaveFirmwareFile_IdenticalContentGetsDifferentIDs(t *testing.T) {
 	svc := setupService(t)
 
 	content := "identical firmware content"
-	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	assert.NotEqual(t, id1, id2, "each save should produce a unique fileID even for identical content")
@@ -165,10 +197,10 @@ func TestSaveFirmwareFile_IdenticalContentGetsDifferentIDs(t *testing.T) {
 func TestSaveFirmwareFile_DifferentContentGetsDifferentID(t *testing.T) {
 	svc := setupService(t)
 
-	id1, err := svc.SaveFirmwareFile("firmware-a.swu", strings.NewReader("content A"))
+	id1, err := svc.SaveFirmwareFile("firmware-a.swu", strings.NewReader("content A"), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("firmware-b.swu", strings.NewReader("content B"))
+	id2, err := svc.SaveFirmwareFile("firmware-b.swu", strings.NewReader("content B"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	assert.NotEqual(t, id1, id2, "different content should produce different fileIDs")
@@ -178,10 +210,10 @@ func TestSaveFirmwareFile_EachSaveCreatesOwnDirectory(t *testing.T) {
 	svc := setupService(t)
 
 	content := "same content twice"
-	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	_, err = svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	_, err = svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	assert.Len(t, firmwareFileEntries(t), 2, "each save should create its own directory on disk")
@@ -216,7 +248,7 @@ func TestOpenFirmwareFile_ReturnsReaderAndMetadata(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware binary data here"
-	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	reader, filename, size, err := svc.OpenFirmwareFile(fileID)
@@ -231,44 +263,22 @@ func TestOpenFirmwareFile_ReturnsReaderAndMetadata(t *testing.T) {
 	assert.Equal(t, content, string(data))
 }
 
-func TestOpenFirmwareFileWithInfo_ReturnsReaderAndChecksum(t *testing.T) {
+func TestOpenFirmwareFile_IgnoresMetadataSidecar(t *testing.T) {
 	svc := setupService(t)
 
-	content := "firmware binary data here"
-	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content))
+	content := "firmware payload"
+	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	reader, info, err := svc.OpenFirmwareFileWithInfo(fileID)
+	reader, filename, size, err := svc.OpenFirmwareFile(fileID)
 	require.NoError(t, err)
 	defer reader.Close()
-
-	assert.Equal(t, fileID, info.ID)
-	assert.Equal(t, "update.swu", info.Filename)
-	assert.Equal(t, int64(len(content)), info.Size)
-	assert.Equal(t, checksumOf(content), info.SHA256)
-	assert.Equal(t, filepath.Join(firmwareDir, fileID, "update.swu"), info.FilePath)
 
 	data, err := io.ReadAll(reader)
 	require.NoError(t, err)
+	assert.Equal(t, "update.swu", filename)
+	assert.Equal(t, int64(len(content)), size)
 	assert.Equal(t, content, string(data))
-}
-
-func TestOpenFirmwareFileWithInfo_RebuildsMissingChecksumIndexEntry(t *testing.T) {
-	svc := setupService(t)
-
-	content := "firmware binary data here"
-	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content))
-	require.NoError(t, err)
-	svc.checksumIndex = make(map[string][]string)
-	svc.firmwareChecksumByID = make(map[string]string)
-
-	reader, info, err := svc.OpenFirmwareFileWithInfo(fileID)
-	require.NoError(t, err)
-	defer reader.Close()
-
-	assert.Equal(t, checksumOf(content), info.SHA256)
-	assert.Equal(t, []string{fileID}, svc.checksumIndex[checksumOf(content)])
-	assert.Equal(t, checksumOf(content), svc.firmwareChecksumByID[fileID])
 }
 
 func TestOpenFirmwareFile_ReturnsErrorForMissing(t *testing.T) {
@@ -288,26 +298,14 @@ func TestOpenFirmwareFile_RejectsPathTraversal(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid firmware file ID")
 }
 
-func TestOpenFirmwareFileWithInfo_RejectsInvalidOrMissingID(t *testing.T) {
-	svc := setupService(t)
-
-	_, _, err := svc.OpenFirmwareFileWithInfo("../logs/tmp")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid firmware file ID")
-
-	_, _, err = svc.OpenFirmwareFileWithInfo("00000000-0000-0000-0000-000000000000")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "firmware file not found")
-}
-
 func TestFindFirmwareFileByChecksum_ReturnsTrueForExistingFile(t *testing.T) {
 	svc := setupService(t)
 
 	content := "findable firmware content"
-	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.True(t, ok)
 	assert.Equal(t, fileID, foundID)
 }
@@ -315,29 +313,60 @@ func TestFindFirmwareFileByChecksum_ReturnsTrueForExistingFile(t *testing.T) {
 func TestFindFirmwareFileByChecksum_ReturnsFalseForUnknownChecksum(t *testing.T) {
 	svc := setupService(t)
 
-	foundID, ok := svc.FindFirmwareFileByChecksum("0000000000000000000000000000000000000000000000000000000000000000")
+	foundID, ok := svc.FindFirmwareFileByChecksum("0000000000000000000000000000000000000000000000000000000000000000", testFirmwareMetadata())
 	assert.False(t, ok)
 	assert.Empty(t, foundID)
+}
+
+func TestFindFirmwareFileByChecksum_RequiresMatchingTargetMetadata(t *testing.T) {
+	svc := setupService(t)
+
+	content := "same firmware content"
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S19"})
+	assert.False(t, ok)
+	assert.Empty(t, foundID)
+
+	foundID, ok = svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
+	assert.True(t, ok)
+	assert.Equal(t, fileID, foundID)
+}
+
+func TestFindFirmwareFileByChecksum_DeletesInvalidMetadataDirectory(t *testing.T) {
+	svc := setupService(t)
+
+	content := "firmware with corrupted metadata"
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(getFirmwareDirPath(fileID), firmwareMetadataFilename), []byte(`not json`), 0600))
+
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
+
+	assert.False(t, ok)
+	assert.Empty(t, foundID)
+	assert.NoDirExists(t, getFirmwareDirPath(fileID))
 }
 
 func TestFindFirmwareFileByChecksum_ReturnsFalseAfterDelete(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware to find then delete"
-	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	err = svc.DeleteFirmwareFile(fileID)
 	require.NoError(t, err)
 
-	_, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	_, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.False(t, ok)
 }
 
 func TestDeleteFirmwareFile_RemovesDirectory(t *testing.T) {
 	svc := setupService(t)
 
-	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"))
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	dir := getFirmwareDirPath(fileID)
@@ -353,16 +382,15 @@ func TestDeleteFirmwareFile_RemovesFromChecksumIndex(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware to delete and re-upload"
-	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	err = svc.DeleteFirmwareFile(fileID)
 	require.NoError(t, err)
 
 	assert.Empty(t, svc.checksumIndex, "checksumIndex should be empty after delete")
-	assert.Empty(t, svc.firmwareChecksumByID, "firmwareChecksumByID should be empty after delete")
 
-	newID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	newID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 	assert.NotEqual(t, fileID, newID, "re-upload after delete should get a new fileID")
 }
@@ -413,7 +441,7 @@ func TestNewService_PreservesExistingFirmwareFilesAcrossRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	content := "persisted firmware data"
-	fileID, err := svc.SaveFirmwareFile("persisted.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("persisted.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	restartedSvc, err := NewService(Config{})
@@ -431,6 +459,32 @@ func TestNewService_PreservesExistingFirmwareFilesAcrossRestart(t *testing.T) {
 	assert.Equal(t, content, string(data))
 }
 
+func TestNewService_DeletesLegacyFirmwareDirectoriesWithoutMetadata(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111"), 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111", "legacy.swu"), []byte("legacy"), 0600))
+
+	_, err := NewService(Config{})
+	require.NoError(t, err)
+
+	assert.NoDirExists(t, filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111"))
+}
+
+func TestListFirmwareFiles_DeletesInvalidMetadataDirectories(t *testing.T) {
+	svc := setupService(t)
+
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(getFirmwareDirPath(fileID), firmwareMetadataFilename), []byte(`{"target_manufacturer":"","target_model":"S21"}`), 0600))
+
+	files, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	assert.Empty(t, files)
+	assert.NoDirExists(t, getFirmwareDirPath(fileID))
+}
+
 func TestInitChecksumIndex_RebuildsOnRestart(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)
@@ -439,13 +493,13 @@ func TestInitChecksumIndex_RebuildsOnRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	content := "firmware for restart test"
-	fileID, err := svc1.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := svc1.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	svc2, err := NewService(Config{})
 	require.NoError(t, err)
 
-	foundID, ok := svc2.FindFirmwareFileByChecksum(checksumOf(content))
+	foundID, ok := svc2.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.True(t, ok, "after restart, checksum index should contain the existing file")
 	assert.Equal(t, fileID, foundID)
 }
@@ -453,7 +507,7 @@ func TestInitChecksumIndex_RebuildsOnRestart(t *testing.T) {
 func TestSaveFirmwareFile_RejectsEmptyStream(t *testing.T) {
 	svc := setupService(t)
 
-	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(""))
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(""), testFirmwareMetadata())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty")
@@ -465,10 +519,10 @@ func TestSaveFirmwareFile_IndependentDeletion(t *testing.T) {
 	svc := setupService(t)
 
 	content := "shared firmware content"
-	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	err = svc.DeleteFirmwareFile(id1)
@@ -486,16 +540,16 @@ func TestFindFirmwareFileByChecksum_SurvivesPartialDeletion(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware uploaded by two batches"
-	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	err = svc.DeleteFirmwareFile(id2)
 	require.NoError(t, err)
 
-	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.True(t, ok, "checksum lookup should still succeed after deleting one of two identical uploads")
 	assert.Equal(t, id1, foundID)
 }
@@ -551,7 +605,7 @@ func TestSaveFirmwareFileFromPath_MovesAndRegistersChecksum(t *testing.T) {
 	srcPath := filepath.Join(firmwareStagingDir, "test-upload")
 	require.NoError(t, os.WriteFile(srcPath, []byte(content), 0600))
 
-	fileID, err := svc.SaveFirmwareFileFromPath("chunked.swu", srcPath)
+	fileID, err := svc.SaveFirmwareFileFromPath("chunked.swu", srcPath, testFirmwareMetadata())
 	require.NoError(t, err)
 	assert.NotEmpty(t, fileID)
 
@@ -563,7 +617,7 @@ func TestSaveFirmwareFileFromPath_MovesAndRegistersChecksum(t *testing.T) {
 	assert.Equal(t, content, string(data))
 	assert.Equal(t, "chunked.swu", filepath.Base(filePath))
 
-	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.True(t, ok, "checksum index should contain the file after SaveFirmwareFileFromPath")
 	assert.Equal(t, fileID, foundID)
 
@@ -577,7 +631,7 @@ func TestSaveFirmwareFileFromPath_RejectsEmptyFile(t *testing.T) {
 	srcPath := filepath.Join(firmwareStagingDir, "empty-upload")
 	require.NoError(t, os.WriteFile(srcPath, []byte{}, 0600))
 
-	_, err := svc.SaveFirmwareFileFromPath("empty.swu", srcPath)
+	_, err := svc.SaveFirmwareFileFromPath("empty.swu", srcPath, testFirmwareMetadata())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty")
 }
@@ -594,10 +648,10 @@ func TestListFirmwareFiles_EmptyReturnsEmptySlice(t *testing.T) {
 func TestListFirmwareFiles_ReturnsSavedFiles(t *testing.T) {
 	svc := setupService(t)
 
-	id1, err := svc.SaveFirmwareFile("alpha.swu", strings.NewReader("alpha content"))
+	id1, err := svc.SaveFirmwareFile("alpha.swu", strings.NewReader("alpha content"), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("beta.tar.gz", strings.NewReader("beta content here"))
+	id2, err := svc.SaveFirmwareFile("beta.tar.gz", strings.NewReader("beta content here"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	files, err := svc.ListFirmwareFiles()
@@ -626,7 +680,7 @@ func TestListFirmwareFiles_SkipsStagingDir(t *testing.T) {
 	// Place a file in the staging dir
 	require.NoError(t, os.WriteFile(filepath.Join(firmwareStagingDir, "orphan"), []byte("data"), 0600))
 
-	_, err := svc.SaveFirmwareFile("real.swu", strings.NewReader("real content"))
+	_, err := svc.SaveFirmwareFile("real.swu", strings.NewReader("real content"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	files, err := svc.ListFirmwareFiles()
@@ -638,10 +692,10 @@ func TestListFirmwareFiles_SkipsStagingDir(t *testing.T) {
 func TestListFirmwareFiles_SortedByUploadTimeDescending(t *testing.T) {
 	svc := setupService(t)
 
-	_, err := svc.SaveFirmwareFile("first.swu", strings.NewReader("first"))
+	_, err := svc.SaveFirmwareFile("first.swu", strings.NewReader("first"), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	_, err = svc.SaveFirmwareFile("second.swu", strings.NewReader("second"))
+	_, err = svc.SaveFirmwareFile("second.swu", strings.NewReader("second"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	files, err := svc.ListFirmwareFiles()
@@ -654,9 +708,9 @@ func TestListFirmwareFiles_SortedByUploadTimeDescending(t *testing.T) {
 func TestDeleteAllFirmwareFiles_RemovesAllFiles(t *testing.T) {
 	svc := setupService(t)
 
-	_, err := svc.SaveFirmwareFile("one.swu", strings.NewReader("one"))
+	_, err := svc.SaveFirmwareFile("one.swu", strings.NewReader("one"), testFirmwareMetadata())
 	require.NoError(t, err)
-	_, err = svc.SaveFirmwareFile("two.swu", strings.NewReader("two"))
+	_, err = svc.SaveFirmwareFile("two.swu", strings.NewReader("two"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	deleted, err := svc.DeleteAllFirmwareFiles()
@@ -680,15 +734,15 @@ func TestDeleteAllFirmwareFiles_CleansChecksumIndex(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware for checksum cleanup test"
-	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	_, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	_, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	require.True(t, ok, "checksum should be found before delete-all")
 
 	_, err = svc.DeleteAllFirmwareFiles()
 	require.NoError(t, err)
 
-	_, ok = svc.FindFirmwareFileByChecksum(checksumOf(content))
+	_, ok = svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.False(t, ok, "checksum should not be found after delete-all")
 }

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -20,7 +20,7 @@ func checksumOf(content string) string {
 }
 
 func testFirmwareMetadata() FirmwareMetadata {
-	return FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21"}
+	return FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21", FirmwareVersion: "v2.0.0"}
 }
 
 func storageDirEntries(t *testing.T, dir string) []os.DirEntry {
@@ -623,6 +623,60 @@ func TestSaveFirmwareFileFromPath_MovesAndRegistersChecksum(t *testing.T) {
 
 	_, statErr := os.Stat(srcPath)
 	assert.True(t, os.IsNotExist(statErr), "source file should be removed after rename")
+}
+
+func TestSaveFirmwareUpload_UsesManualMetadata(t *testing.T) {
+	svc := setupService(t)
+	content := "firmware content"
+
+	result, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), false)
+
+	require.NoError(t, err)
+	assert.False(t, result.Reused)
+	assert.Equal(t, testFirmwareMetadata(), result.Metadata)
+
+	metadata, err := svc.GetFirmwareMetadata(result.FirmwareFileID)
+	require.NoError(t, err)
+	assert.Equal(t, result.Metadata, metadata)
+}
+
+func TestSaveFirmwareUpload_RejectsMissingMetadata(t *testing.T) {
+	svc := setupService(t)
+
+	_, err := svc.SaveFirmwareUpload("vendor.swu", strings.NewReader("firmware content"), FirmwareMetadata{}, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target_manufacturer")
+}
+
+func TestSaveFirmwareUpload_ReusesExistingWithSameMetadata(t *testing.T) {
+	svc := setupService(t)
+	content := "firmware content"
+
+	first, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), false)
+	require.NoError(t, err)
+
+	second, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), false)
+	require.NoError(t, err)
+
+	assert.True(t, second.Reused)
+	assert.Equal(t, first.FirmwareFileID, second.FirmwareFileID)
+	assert.Len(t, firmwareFileEntries(t), 1)
+}
+
+func TestSaveFirmwareUpload_ForceBypassesDedupe(t *testing.T) {
+	svc := setupService(t)
+	content := "firmware content"
+
+	first, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), false)
+	require.NoError(t, err)
+
+	second, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), true)
+	require.NoError(t, err)
+
+	assert.False(t, second.Reused)
+	assert.NotEqual(t, first.FirmwareFileID, second.FirmwareFileID)
+	assert.Len(t, firmwareFileEntries(t), 2)
 }
 
 func TestSaveFirmwareFileFromPath_RejectsEmptyFile(t *testing.T) {

--- a/server/internal/infrastructure/files/service.go
+++ b/server/internal/infrastructure/files/service.go
@@ -83,8 +83,8 @@ type Service struct {
 	commandArtifactCleanupInterval time.Duration
 
 	mu                   sync.Mutex
-	checksumIndex        map[string][]string // SHA-256 hex -> fileIDs
-	firmwareChecksumByID map[string]string   // fileID -> SHA-256 hex
+	checksumIndex        map[string][]firmwareChecksumEntry // SHA-256 hex -> matching file metadata
+	firmwareChecksumByID map[string]string                  // fileID -> SHA-256 hex
 }
 
 // MaxFirmwareFileSize returns the configured maximum firmware file size in bytes.
@@ -155,7 +155,7 @@ func NewService(cfg Config) (*Service, error) {
 		maxCommandArtifactSize:         maxArtifactSize,
 		commandArtifactRetentionTTL:    retentionTTL,
 		commandArtifactCleanupInterval: cleanupInterval,
-		checksumIndex:                  make(map[string][]string),
+		checksumIndex:                  make(map[string][]firmwareChecksumEntry),
 		firmwareChecksumByID:           make(map[string]string),
 	}
 


### PR DESCRIPTION
Reviewable diff: +904/-134 across 13 files (excludes generated, test, and story files).

## Summary

Firmware uploads now carry a target manufacturer, model, and firmware version from ProtoFleet or the Fleet CLI through storage, listing, reuse checks, and miner updates. The metadata lets operators distinguish identical payloads intended for different devices or versions, while preserving read compatibility for metadata sidecars created before firmware versions were tracked. This is a standalone vertical slice with no protobuf, database migration, generated-code, or cohort changes.

## How it works

1. ProtoFleet chooses a manufacturer/model from discovered fleet model groups and requires a firmware version; Fleet CLI `check` and `upload` require the equivalent three flags.
2. Direct and chunked handlers validate the complete target, stream or assemble the payload, and pass normalized metadata into the firmware file service.
3. Each firmware directory stores one payload plus `metadata.json`. The service indexes SHA-256 with normalized metadata, so only an exact payload-and-target match is reused; `force` always creates a new stored copy.
4. List and artifact reads return the metadata. ProtoFleet displays it and filters existing firmware choices to the selected miner target, while command execution preserves the firmware version for downstream artifact handling.
5. The fake Proto Rig extracts a semantic version from the uploaded filename when present so E2E firmware activation reports the requested version.

```mermaid
flowchart LR
    U["ProtoFleet upload or Fleet CLI"] --> H["Direct, check, and chunked HTTP handlers"]
    H --> S["Firmware file service"]
    S --> D["Firmware directory: payload plus metadata.json"]
    S --> I["SHA-256 plus normalized metadata index"]
    D --> L["List and artifact reads"]
    I --> R["Exact-match reuse unless force is set"]
    L --> P["ProtoFleet list and compatible update picker"]
    L --> C["Command and FleetNode artifact flow"]
    C --> M["Miner or fake Proto Rig"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/infrastructure/files/` | Persists and reads `metadata.json`, rebuilds metadata-aware checksum indexes, removes legacy directories without valid sidecars, and supports forced or reused saves | Core durability, compatibility, normalization, and deduplication behavior |
| `server/internal/handlers/firmware/` | Requires metadata for checksum checks plus direct and chunked uploads; returns reuse and metadata fields | HTTP validation boundary and parity across upload modes |
| `server/cmd/fleetcli/` | Adds required manufacturer, model, and version flags to checks/uploads and carries them through direct/chunked clients | CLI contract and `.swu` behavior |
| `client/src/protoFleet/api/` and `components/FirmwareUpload/` | Adds metadata to client types, check requests, multipart/chunk initiation, and upload state | Web-to-server field propagation and pre-upload reuse |
| `client/src/protoFleet/features/settings/` | Adds model-aware upload inputs and metadata columns | Operator upload and inventory experience |
| `client/src/protoFleet/features/fleetManagement/` | Filters saved firmware by miner target and supplies metadata for new uploads | Prevents incompatible firmware choices during miner updates |
| `server/internal/domain/command/` and `server/internal/handlers/fleetnode/gateway/` | Updates artifact fixtures to include firmware versions | Verifies command artifact metadata reaches FleetNode paths |
| `server/fake-proto-rig/` | Derives the staged firmware version from filenames when available | Makes simulated activation reflect the uploaded target version |
| Test and E2E files | Cover storage compatibility, deduplication, handlers, CLI flags, UI uploads, and fake-rig activation | Regression coverage; review alongside the corresponding production area |

## Key technical decisions & trade-offs

- Store metadata beside the payload in `metadata.json` instead of adding a database or protobuf schema; firmware remains filesystem-owned, but sidecar integrity becomes part of index validity.
- Require manufacturer, model, and version for every new check/upload while allowing existing sidecars without a version to remain readable; this preserves the intended compatibility window without accepting incomplete new data.
- Deduplicate on normalized SHA-256 plus all metadata instead of SHA-256 alone; identical bytes can represent distinct device/version targets at the cost of additional stored copies.
- Treat missing or malformed sidecars as invalid during index rebuild/listing and remove those directories; legacy payload-only entries cannot be safely targeted.
- Keep fake-rig filename-version behavior and exclude the separate multipart-streaming refactor, keeping this PR scoped to firmware metadata.

## Testing & validation

- `go test ./internal/infrastructure/files ./internal/handlers/firmware ./cmd/fleetcli`
- `go test ./internal/domain/command -run '^TestExecuteCommandOnDevice_FirmwareUpdatePassesFileMetadata$'`
- `go test ./internal/handlers/fleetnode/gateway -run '^TestDownloadCommandArtifactServesFirmwarePayload$'`
- `GOWORK=off go -C server/fake-proto-rig test ./...`
- Targeted Vitest run: firmware API, upload hook, update modal, and settings firmware components — 63 tests passed
- `npm run build:protoFleet`
- `just lint`
- `git diff --check`
- Isolated Fleet CLI E2E: `go test -v -tags=e2e ./e2e -run '^TestFleetCLIFirmwareWorkflow$'`
- Isolated ProtoFleet Playwright setup plus `spec/firmware.spec.ts --project=desktop` — firmware upload/update lifecycle passed

The package-wide command and FleetNode gateway suites were also invoked together, but unrelated long-running tests did not complete within five minutes; the directly affected cases above passed. The final diff contains no cohort, migration, protobuf, or generated paths.
