### PR TITLE
feat(fleet): show miner site/building/rack in embedded single-miner view

### DIFF
--- a/client/src/protoFleet/components/SingleMinerWrapper/SingleMinerWrapper.tsx
+++ b/client/src/protoFleet/components/SingleMinerWrapper/SingleMinerWrapper.tsx
@@ -56,6 +56,9 @@ const SingleMinerWrapper = ({ children }: { children: ReactNode }) => {
       ipAddress: cachedMetadata?.ipAddress,
       macAddress: cachedMetadata?.macAddress,
       firmwareVersion: cachedMetadata?.firmwareVersion,
+      site: cachedMetadata?.site,
+      building: cachedMetadata?.building,
+      rack: cachedMetadata?.rack,
     }),
     [cachedMetadata, displayId],
   );

--- a/client/src/protoFleet/components/SingleMinerWrapper/routeState.ts
+++ b/client/src/protoFleet/components/SingleMinerWrapper/routeState.ts
@@ -1,4 +1,9 @@
 import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import {
+  getMinerBuildingLabel,
+  getMinerRackLabel,
+  getMinerSiteLabel,
+} from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import type { MinerMetadata } from "@/shared/types/minerMetadata";
 
 export type SingleMinerMetadata = MinerMetadata;
@@ -19,6 +24,9 @@ export const buildSingleMinerMetadata = (miner: MinerStateSnapshot): SingleMiner
   ipAddress: nonEmpty(miner.ipAddress),
   macAddress: nonEmpty(miner.macAddress),
   firmwareVersion: nonEmpty(miner.firmwareVersion),
+  site: nonEmpty(getMinerSiteLabel(miner)),
+  building: nonEmpty(getMinerBuildingLabel(miner)),
+  rack: nonEmpty(getMinerRackLabel(miner)),
 });
 
 export const buildSingleMinerRouteState = (miner: MinerStateSnapshot): SingleMinerRouteState => ({

--- a/client/src/protoOS/components/AppLayout/AppLayout.test.tsx
+++ b/client/src/protoOS/components/AppLayout/AppLayout.test.tsx
@@ -68,6 +68,20 @@ describe("AppLayout", () => {
     expect(within(screen.getByTestId("location-info-item")).getByText("Rockdale")).toBeInTheDocument();
   });
 
+  it("hides the location row when fleet-hosted with no placement", () => {
+    render(
+      <MemoryRouter>
+        <MinerHostingProvider mode="fleet" metadata={{ minerName: "Antminer S21" }}>
+          <AppLayout title="Home" type={navigationMenuTypes.app} customHeaderButtons={<div />}>
+            <div>Content</div>
+          </AppLayout>
+        </MinerHostingProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("location-info-item")).not.toBeInTheDocument();
+  });
+
   it("hides the location row when not fleet-hosted", () => {
     render(
       <MemoryRouter>

--- a/client/src/protoOS/components/AppLayout/AppLayout.test.tsx
+++ b/client/src/protoOS/components/AppLayout/AppLayout.test.tsx
@@ -29,6 +29,9 @@ describe("AppLayout", () => {
             ipAddress: "10.0.0.42",
             firmwareVersion: "2026.1",
             macAddress: "AA:BB:CC:DD:EE:FF",
+            site: "Rockdale",
+            building: "Building A",
+            rack: "Rack 12",
           }}
         >
           <AppLayout title="Home" type={navigationMenuTypes.app} customHeaderButtons={<div />}>
@@ -43,6 +46,39 @@ describe("AppLayout", () => {
     expect(within(screen.getByTestId("version-info-item")).getByText("2026.1")).toBeInTheDocument();
     expect(within(screen.getByTestId("mac-address-info-item")).getByText("AA:BB:CC:DD:EE:FF")).toBeInTheDocument();
 
+    const locationItem = within(screen.getByTestId("location-info-item"));
+    expect(locationItem.getByText("Rockdale")).toBeInTheDocument();
+    expect(locationItem.getByText("Building A")).toBeInTheDocument();
+    expect(locationItem.getByText("Rack 12")).toBeInTheDocument();
+
     expect(within(screen.getByTestId("miner-name-info-item")).queryByText("Proto Rig")).not.toBeInTheDocument();
+  });
+
+  it("omits placement levels the miner is not assigned to", () => {
+    render(
+      <MemoryRouter>
+        <MinerHostingProvider mode="fleet" metadata={{ minerName: "Antminer S21", site: "Rockdale" }}>
+          <AppLayout title="Home" type={navigationMenuTypes.app} customHeaderButtons={<div />}>
+            <div>Content</div>
+          </AppLayout>
+        </MinerHostingProvider>
+      </MemoryRouter>,
+    );
+
+    expect(within(screen.getByTestId("location-info-item")).getByText("Rockdale")).toBeInTheDocument();
+  });
+
+  it("hides the location row when not fleet-hosted", () => {
+    render(
+      <MemoryRouter>
+        <MinerHostingProvider mode="direct" metadata={{ site: "Rockdale", building: "Building A", rack: "Rack 12" }}>
+          <AppLayout title="Home" type={navigationMenuTypes.app} customHeaderButtons={<div />}>
+            <div>Content</div>
+          </AppLayout>
+        </MinerHostingProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("location-info-item")).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoOS/components/AppLayout/AppLayout.tsx
+++ b/client/src/protoOS/components/AppLayout/AppLayout.tsx
@@ -45,6 +45,12 @@ const AppLayout = ({
   const ipAddress = useIpAddress();
   const pendingNetworkInfo = useNetworkInfoPending();
 
+  // Placement is a Fleet-only concept and rides in on the hosting metadata.
+  // Show a single "Location" row that stacks site / building / rack on their
+  // own lines, omitting any levels the miner isn't placed at.
+  const locationLines = [metadata.site, metadata.building, metadata.rack].filter(Boolean) as string[];
+  const locationInfo = isFleetHosted && locationLines.length ? { values: locationLines } : undefined;
+
   return (
     <div className="flex min-h-screen bg-surface-base">
       <div className="fixed top-0 left-0 z-40 h-screen grow overflow-hidden">
@@ -57,6 +63,7 @@ const AppLayout = ({
           }}
           isVisible={isMenuOpen}
           closeMenu={() => setIsMenuOpen(false)}
+          locationInfo={locationInfo}
           versionInfo={{
             value: isFleetHosted ? metadata.firmwareVersion || osVersion : osVersion,
             loading: isFleetHosted ? !metadata.firmwareVersion && pendingSystemInfo : pendingSystemInfo,

--- a/client/src/protoOS/components/NavigationMenu/FloatingNavigation.tsx
+++ b/client/src/protoOS/components/NavigationMenu/FloatingNavigation.tsx
@@ -2,6 +2,7 @@ import { useCallback, useLayoutEffect, useState } from "react";
 import clsx from "clsx";
 
 import type { IpAddressInfoProps } from "./InfoItem/IpAddressInfo";
+import type { LocationInfoProps } from "./InfoItem/LocationInfo";
 import type { MacAddressInfoProps } from "./InfoItem/MacAddressInfo";
 import type { MinerNameInfoProps } from "./InfoItem/MinerNameInfo";
 import type { VersionInfoProps } from "./InfoItem/VersionInfo";
@@ -12,6 +13,7 @@ import { usePreventScroll } from "@/shared/hooks/usePreventScroll";
 interface FloatingNavigationProps {
   closeMenu?: () => void;
   ipAddressInfo?: IpAddressInfoProps;
+  locationInfo?: LocationInfoProps;
   macInfo?: MacAddressInfoProps;
   minerNameInfo?: MinerNameInfoProps;
   type: NavigationMenuType;
@@ -21,6 +23,7 @@ interface FloatingNavigationProps {
 const FloatingNavigation = ({
   closeMenu,
   ipAddressInfo,
+  locationInfo,
   macInfo,
   minerNameInfo,
   type,
@@ -56,6 +59,7 @@ const FloatingNavigation = ({
       >
         <Navigation
           ipAddressInfo={ipAddressInfo}
+          locationInfo={locationInfo}
           macInfo={macInfo}
           minerNameInfo={minerNameInfo}
           onItemClick={handleCloseMenu}

--- a/client/src/protoOS/components/NavigationMenu/InfoItem/LocationInfo/LocationInfo.tsx
+++ b/client/src/protoOS/components/NavigationMenu/InfoItem/LocationInfo/LocationInfo.tsx
@@ -1,0 +1,30 @@
+import Row from "@/shared/components/Row";
+import SkeletonBar from "@/shared/components/SkeletonBar";
+
+export interface LocationInfoProps {
+  loading?: boolean;
+  // Placement levels (site, building, rack), already filtered to non-empty
+  // values by the caller. Rendered stacked under a single "Location" label.
+  values?: string[];
+}
+
+const LocationInfo = ({ loading, values = [] }: LocationInfoProps) => {
+  return (
+    <Row divider={false} compact className="flex items-center" testId="location-info-item">
+      <div className="grow">
+        <div className="relative text-200 text-text-primary-70">Location</div>
+        <div className="font-mono text-mono-text-50 leading-[16px] text-text-primary-30">
+          {loading ? (
+            <SkeletonBar className="h-[14px]! w-2/3" />
+          ) : values.length ? (
+            values.map((line, index) => <div key={`${index}-${line}`}>{line}</div>)
+          ) : (
+            "—"
+          )}
+        </div>
+      </div>
+    </Row>
+  );
+};
+
+export default LocationInfo;

--- a/client/src/protoOS/components/NavigationMenu/InfoItem/LocationInfo/index.ts
+++ b/client/src/protoOS/components/NavigationMenu/InfoItem/LocationInfo/index.ts
@@ -1,0 +1,4 @@
+import LocationInfo, { LocationInfoProps } from "./LocationInfo";
+
+export default LocationInfo;
+export type { LocationInfoProps };

--- a/client/src/protoOS/components/NavigationMenu/Navigation.tsx
+++ b/client/src/protoOS/components/NavigationMenu/Navigation.tsx
@@ -5,6 +5,8 @@ import clsx from "clsx";
 import { navigationItems, navigationMenuTypes } from "./constants";
 import IpAddressInfo from "./InfoItem/IpAddressInfo";
 import type { IpAddressInfoProps } from "./InfoItem/IpAddressInfo";
+import LocationInfo from "./InfoItem/LocationInfo";
+import type { LocationInfoProps } from "./InfoItem/LocationInfo";
 import MacAddressInfo from "./InfoItem/MacAddressInfo";
 import type { MacAddressInfoProps } from "./InfoItem/MacAddressInfo";
 import MinerNameInfo from "./InfoItem/MinerNameInfo";
@@ -19,6 +21,7 @@ import { useNavigate } from "@/shared/hooks/useNavigate";
 
 interface NavigationProps {
   ipAddressInfo?: IpAddressInfoProps;
+  locationInfo?: LocationInfoProps;
   macInfo?: MacAddressInfoProps;
   minerNameInfo?: MinerNameInfoProps;
   onItemClick?: () => void;
@@ -26,7 +29,15 @@ interface NavigationProps {
   type: NavigationMenuType;
 }
 
-const Navigation = ({ ipAddressInfo, macInfo, minerNameInfo, onItemClick, versionInfo, type }: NavigationProps) => {
+const Navigation = ({
+  ipAddressInfo,
+  locationInfo,
+  macInfo,
+  minerNameInfo,
+  onItemClick,
+  versionInfo,
+  type,
+}: NavigationProps) => {
   const isApp = useMemo(() => type === navigationMenuTypes.app, [type]);
 
   const { minerRoot, closeButton } = useMinerHosting();
@@ -79,6 +90,8 @@ const Navigation = ({ ipAddressInfo, macInfo, minerNameInfo, onItemClick, versio
 
       <div className="px-3 pb-3">
         <MinerNameInfo loading={minerNameInfo?.loading} value={minerNameInfo?.value} />
+
+        {locationInfo ? <LocationInfo loading={locationInfo.loading} values={locationInfo.values} /> : null}
 
         <IpAddressInfo loading={ipAddressInfo?.loading} value={ipAddressInfo?.value} />
 

--- a/client/src/protoOS/components/NavigationMenu/NavigationMenu.tsx
+++ b/client/src/protoOS/components/NavigationMenu/NavigationMenu.tsx
@@ -1,5 +1,6 @@
 import FloatingNavigation from "./FloatingNavigation";
 import type { IpAddressInfoProps } from "./InfoItem/IpAddressInfo";
+import type { LocationInfoProps } from "./InfoItem/LocationInfo";
 import type { MacAddressInfoProps } from "./InfoItem/MacAddressInfo";
 import type { MinerNameInfoProps } from "./InfoItem/MinerNameInfo";
 import type { VersionInfoProps } from "./InfoItem/VersionInfo";
@@ -10,6 +11,7 @@ import { useWindowDimensions } from "@/shared/hooks/useWindowDimensions";
 interface NavigationMenuProps {
   closeMenu?: () => void;
   ipAddressInfo?: IpAddressInfoProps;
+  locationInfo?: LocationInfoProps;
   macInfo?: MacAddressInfoProps;
   minerNameInfo?: MinerNameInfoProps;
   isVisible?: boolean;
@@ -20,6 +22,7 @@ interface NavigationMenuProps {
 const NavigationMenu = ({
   closeMenu,
   ipAddressInfo,
+  locationInfo,
   macInfo,
   minerNameInfo,
   isVisible,
@@ -33,6 +36,7 @@ const NavigationMenu = ({
       return (
         <FloatingNavigation
           ipAddressInfo={ipAddressInfo}
+          locationInfo={locationInfo}
           macInfo={macInfo}
           minerNameInfo={minerNameInfo}
           versionInfo={versionInfo}
@@ -47,6 +51,7 @@ const NavigationMenu = ({
   return (
     <Navigation
       ipAddressInfo={ipAddressInfo}
+      locationInfo={locationInfo}
       macInfo={macInfo}
       minerNameInfo={minerNameInfo}
       versionInfo={versionInfo}

--- a/client/src/shared/types/minerMetadata.ts
+++ b/client/src/shared/types/minerMetadata.ts
@@ -8,4 +8,9 @@ export type MinerMetadata = {
   ipAddress?: string;
   macAddress?: string;
   firmwareVersion?: string;
+  // Fleet placement labels (site / building / rack). Only populated when the
+  // miner is hosted inside the Fleet shell; standalone ProtoOS has no placement.
+  site?: string;
+  building?: string;
+  rack?: string;
 };


### PR DESCRIPTION
Reviewable diff: +80/-1 across 9 files (excludes generated, test, and story files).

## Summary

When you open a Proto Rig's single-miner view embedded inside the Fleet shell, the ProtoOS navigation sidebar now shows a **Location** block — the miner's Fleet placement as site / building / rack, each on its own line. Previously the embedded view exposed only device-local identity (name, IP, MAC, firmware) fetched from the miner itself; it had no idea where the miner physically sits in the fleet hierarchy. This closes that gap using data the Fleet shell already holds, with no server, proto, or database changes.

## How it works

The embedded single-miner experience is the real ProtoOS React app mounted inside the Fleet shell (not an iframe); its data hooks call the miner through the Fleet proxy. Placement (site/building/rack) is **Fleet-side** data the miner does not know about, so it can't come through that proxy. Instead it travels through the app-neutral `MinerMetadata` bridge that already carries name/IP/MAC/firmware from the Fleet shell into the ProtoOS hosting context:

1. **Source** — when a miner is opened from the list, the opener already holds its `MinerStateSnapshot`, which includes a `placement` object with site/building/rack labels. Existing `minerPlacement` helpers (`getMinerSiteLabel`, etc.) read those labels.
2. **Carry** — `buildSingleMinerMetadata` copies the three labels onto the `MinerMetadata` object (three new optional string fields). This object rides in via navigation state and the device-keyed metadata cache, exactly like the existing identity fields, and is handed to the `MinerHostingProvider`.
3. **Render** — `AppLayout` reads the labels off the hosting metadata, filters out empty levels, and — only when fleet-hosted — passes the surviving list to a new `LocationInfo` row in the navigation sidebar's info panel. The row stacks each level on its own line under a single "Location" label.

Gating: the row renders only in `mode="fleet"` and only when at least one level is present. A miner placed at a site but not a rack shows just the site; a fully unplaced miner shows no row. Standalone ProtoOS (direct mode) never shows it, since placement is a Fleet-only concept.

```mermaid
flowchart LR
    A["Miner list (MinerStateSnapshot.placement)"] --> B["buildSingleMinerMetadata()"]
    B --> C["MinerMetadata bridge (+site/building/rack)"]
    C --> D["MinerHostingProvider (mode=fleet)"]
    D --> E["AppLayout: filter empties, gate on fleet-hosted"]
    E --> F["LocationInfo row in nav sidebar"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/shared/types/minerMetadata.ts` | Added optional `site`/`building`/`rack` to the app-neutral `MinerMetadata` type | The contract bridging the two apps; kept as plain strings so no proto types leak into ProtoOS |
| `client/.../SingleMinerWrapper/routeState.ts` | `buildSingleMinerMetadata` populates the three labels via existing placement helpers | Where Fleet placement enters the metadata bridge |
| `client/.../SingleMinerWrapper/SingleMinerWrapper.tsx` | Passes the new fields through its metadata memo | Keeps memo identity stable for embedded consumers |
| `client/.../NavigationMenu/InfoItem/LocationInfo/` (new) | New info-panel row; takes a pre-filtered `values` array, stacks each on its own line | Primary new UI; mirrors sibling `InfoItem` styling |
| `client/.../NavigationMenu/Navigation.tsx`, `NavigationMenu.tsx`, `FloatingNavigation.tsx` | Thread a new `locationInfo` prop through desktop + mobile nav; render `LocationInfo` when present | Prop plumbing; render is conditional on the prop existing |
| `client/.../AppLayout/AppLayout.tsx` | Builds the filtered level list and gates on `isFleetHosted` | The decision point for what shows and when |
| `client/.../AppLayout/AppLayout.test.tsx` | Tests for breadcrumb render, partial placement, and direct-mode hiding | Coverage for the gating logic |

## Key technical decisions & trade-offs

- **Reuse the existing `MinerMetadata` bridge** rather than fetching placement inside ProtoOS. No new RPC/proxy surface, and placement stays out of ProtoOS's device-local model. Trade-off below.
- **Plain strings, not proto refs, on the bridge type** — keeps `shared/` app-neutral and prevents ProtoFleet proto types from leaking into ProtoOS.
- **Render gated on `isFleetHosted` + non-empty** — placement is meaningless in standalone ProtoOS, so it never appears there.
- **Known limitation (deferred):** metadata is delivered via navigation state + an in-memory cache, both of which reset on a full page reload. So after a hard refresh or deep-link, the Location row (and the snapshot-sourced name) is absent until re-navigated. IP/MAC/firmware survive because ProtoOS re-fetches them from the miner; placement has no such fallback. A durable fix would fetch the miner's snapshot by identifier (`lookupMinerByIdentifier`) when the cache is cold — not included here.

## Testing & validation

- `tsc --noEmit`, ESLint, and Prettier clean on all changed files.
- Unit tests (`AppLayout.test.tsx`): full breadcrumb renders each level; partial placement (site only) renders just that level; direct (non-fleet) mode hides the row entirely. NavigationMenu suite still green.
- **Not covered:** the refresh/deep-link cold-cache case described above (behaves as documented — row absent until re-navigation).
