### PR TITLE
fix(curtailment): clarify active-curtailment command blocks

### DIFF
--- a/server/internal/domain/command/preflight_block_test.go
+++ b/server/internal/domain/command/preflight_block_test.go
@@ -194,6 +194,29 @@ func TestProcessCommand_ManualFullSkip_Blocks(t *testing.T) {
 	assert.Equal(t, []string{"miner-1", "miner-2"}, ev.Metadata["skipped_identifiers"])
 }
 
+func TestProcessCommand_ManualCurtailmentSkip_ExplainsActiveCurtailment(t *testing.T) {
+	filter := NewCurtailmentActiveFilter(&fakeCurtailmentActiveQuerier{
+		active: []string{"miner-1", "miner-2"},
+	})
+	svc, _ := newPreflightTestService(t, filter)
+	svc.resolveDeviceIDsOverride = func(_ context.Context, _ []string) ([]int64, error) {
+		return []int64{101, 102}, nil
+	}
+
+	_, err := svc.processCommand(manualSessionCtx(1), &Command{
+		commandType:    commandtype.SetPowerTarget,
+		deviceSelector: includeSelector("miner-1", "miner-2"),
+	})
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t,
+		"command blocked: 2 of 2 devices are part of an active curtailment event",
+		fleetErr.DebugMessage,
+	)
+}
+
 func TestProcessCommand_ManualFullSkipWithNoLiveDevices_ReturnsInvalidArgument(t *testing.T) {
 	svc, store := newPreflightTestService(t, newFakeFilter("test_block", "stale-miner"))
 	svc.resolveDeviceIDsOverride = func(_ context.Context, identifiers []string) ([]int64, error) {
@@ -351,4 +374,20 @@ func TestSkipMetadata_DeduplicatesFilterNames(t *testing.T) {
 	assert.Equal(t, []string{"a", "b", "c"}, md["skipped_identifiers"])
 	// filters deduplicated and sorted
 	assert.Equal(t, []string{"f1", "f2"}, md["filters"])
+}
+
+func TestPreflightBlockedMessage(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"command blocked: 1 of 1 device is part of an active curtailment event",
+		preflightBlockedMessage(1, []SkippedDevice{{FilterName: CurtailmentActiveFilterName}}),
+	)
+	assert.Equal(t,
+		"command blocked: 2 of 3 device(s) excluded by preflight filters",
+		preflightBlockedMessage(3, []SkippedDevice{
+			{FilterName: CurtailmentActiveFilterName},
+			{FilterName: ScheduleConflictFilterName},
+		}),
+	)
 }

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -305,6 +305,37 @@ func skipMetadata(eventType string, requestedCount int, skipped []SkippedDevice)
 	}
 }
 
+func preflightBlockedMessage(requestedCount int, skipped []SkippedDevice) string {
+	if skipsOnlyFromFilter(skipped, CurtailmentActiveFilterName) {
+		deviceNoun := "devices"
+		if requestedCount == 1 {
+			deviceNoun = "device"
+		}
+		verb := "are"
+		if len(skipped) == 1 {
+			verb = "is"
+		}
+		return fmt.Sprintf(
+			"command blocked: %d of %d %s %s part of an active curtailment event",
+			len(skipped), requestedCount, deviceNoun, verb)
+	}
+	return fmt.Sprintf(
+		"command blocked: %d of %d device(s) excluded by preflight filters",
+		len(skipped), requestedCount)
+}
+
+func skipsOnlyFromFilter(skipped []SkippedDevice, filterName string) bool {
+	if len(skipped) == 0 {
+		return false
+	}
+	for _, sk := range skipped {
+		if sk.FilterName != filterName {
+			return false
+		}
+	}
+	return true
+}
+
 // composeFinalizers chains onFinished callbacks so commands like DownloadLogs
 // can layer a bundle builder alongside the activity finalizer. Nil callbacks
 // are skipped; empty input returns nil. Best-effort: every callback runs even
@@ -853,9 +884,8 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 		if err := s.logPreflightBlockedStrict(ctx, command.commandType, identifiers, skipped); err != nil {
 			return nil, fleeterror.NewInternalErrorf("logging preflight block: %v", err)
 		}
-		return nil, fleeterror.NewFailedPreconditionErrorf(
-			"command blocked: %d of %d device(s) excluded by preflight filters",
-			len(skipped), len(identifiers))
+		return nil, fleeterror.NewFailedPreconditionError(
+			preflightBlockedMessage(len(identifiers), skipped))
 	}
 
 	if len(kept) == 0 && len(skipped) > 0 {


### PR DESCRIPTION
Reviewable diff: +33/-3 across 1 file (excludes generated, test, and story files).

## Summary
Manual miner commands blocked entirely by active curtailment now explain that condition instead of referring only to “preflight filters.” Operators receive the actionable reason through the existing command error toast without client-specific parsing. Mixed-filter blocks retain the generic message so the response does not misattribute the cause.

## How it works
The command service checks the filter identity already attached to each skipped device. A homogeneous `curtailment_active` result produces a count-aware active-curtailment message; every other combination follows the existing generic fallback.

```mermaid
flowchart LR
    A["Manual miner command"] --> B["Command preflight filters"]
    B --> C{"All skips caused by active curtailment?"}
    C -->|"Yes"| D["Return active-curtailment explanation"]
    C -->|"No"| E["Return generic preflight explanation"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/command/service.go` | Selects a curtailment-specific preflight error when all skipped devices share that filter | Confirms the public error stays accurate for homogeneous and mixed-filter outcomes |
| `server/internal/domain/command/preflight_block_test.go` | Covers plural and singular curtailment messages plus the mixed-filter fallback | Pins the operator-visible contract and existing fallback behavior |

## Key technical decisions & trade-offs
- Derive the message from command-domain filter metadata rather than parsing errors in the client, keeping all API consumers consistent.
- Special-case only homogeneous curtailment skips; mixed causes remain generic rather than overstating curtailment as the sole blocker.
- Preserve `FailedPrecondition` and the existing audit path; only the returned diagnostic text changes.

## Testing & validation
- `go test -short ./internal/domain/command -count=1`
- `golangci-lint run -c .golangci.yaml ./internal/domain/command/...`
- Pre-push `server-lint` hook
- Regression coverage exercises the real curtailment filter through `processCommand`; DB-backed integration tests were not required for this message-only path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
