### PR TITLE
fix(fleet): show non-paired rack members in miner selection (#777)

### DIFF
--- a/client/src/protoFleet/components/MinerSelectionList.test.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.test.tsx
@@ -3,6 +3,11 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import MinerSelectionList from "./MinerSelectionList";
+import { PairingStatus } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import {
+  FLEET_SELECTABLE_PAIRING_STATUSES,
+  FLEET_VISIBLE_PAIRING_STATUSES,
+} from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 
 const { fleetArgsSpy, listPropsSpy, listRacksMock, listGroupsMock, hasPermMock } = vi.hoisted(() => ({
   fleetArgsSpy: vi.fn(),
@@ -391,5 +396,31 @@ describe("MinerSelectionList eligibility", () => {
       <>{colConfig.name.component({ deviceIdentifier: "b", rackId: 9n, siteId: 2n, buildingId: 3n, ...base }, [])}</>,
     );
     expect(ineligible.container.querySelector(conflictButton)).not.toBeNull();
+  });
+});
+
+describe("MinerSelectionList pairing statuses", () => {
+  beforeEach(() => {
+    fleetArgsSpy.mockReset();
+    listRacksMock.mockReset();
+    listGroupsMock.mockReset();
+  });
+
+  const lastFleetPairingStatuses = () => {
+    const calls = fleetArgsSpy.mock.calls;
+    return calls[calls.length - 1]?.[0]?.pairingStatuses;
+  };
+
+  it("fetches PAIRED-only by default (other selection flows unchanged)", () => {
+    render(<MinerSelectionList />);
+    expect(lastFleetPairingStatuses()).toEqual(FLEET_SELECTABLE_PAIRING_STATUSES);
+    expect(lastFleetPairingStatuses()).toEqual([PairingStatus.PAIRED]);
+  });
+
+  it("forwards a widened pairing set so non-paired rack members render (#777)", () => {
+    render(<MinerSelectionList pairingStatuses={FLEET_VISIBLE_PAIRING_STATUSES} />);
+    expect(lastFleetPairingStatuses()).toEqual(FLEET_VISIBLE_PAIRING_STATUSES);
+    expect(lastFleetPairingStatuses()).toContain(PairingStatus.AUTHENTICATION_NEEDED);
+    expect(lastFleetPairingStatuses()).toContain(PairingStatus.DEFAULT_PASSWORD);
   });
 });

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -20,6 +20,7 @@ import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import useFleet from "@/protoFleet/api/useFleet";
 import type { SiteFilterFields } from "@/protoFleet/components/PageHeader/SitePicker";
 import { INACTIVE_PLACEHOLDER } from "@/protoFleet/features/fleetManagement/components/MinerList/constants";
+import { FLEET_SELECTABLE_PAIRING_STATUSES } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 import {
   getMinerBuildingId,
   getMinerBuildingLabel,
@@ -119,6 +120,8 @@ export interface MinerSelectionListProps {
   eligibility?: MinerEligibility;
   // Label of the target rack, shown in the assignment-conflict dialog.
   targetRackLabel?: string;
+  // Pairing statuses the list fetches; defaults to PAIRED-only. Rack flows pass the wider visible set so non-paired members render.
+  pairingStatuses?: PairingStatus[];
   onSelectionChange?: (state: {
     selectedItems: string[];
     allSelected: boolean;
@@ -264,6 +267,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       scope,
       eligibility,
       targetRackLabel,
+      pairingStatuses = FLEET_SELECTABLE_PAIRING_STATUSES,
       onSelectionChange,
     },
     ref,
@@ -446,7 +450,7 @@ const MinerSelectionList = forwardRef<MinerSelectionListHandle, MinerSelectionLi
       filter,
       sort: sortConfig,
       pageSize: PAGE_SIZE,
-      pairingStatuses: [PairingStatus.PAIRED],
+      pairingStatuses,
     });
 
     const currentPageItems = useMemo(() => {

--- a/client/src/protoFleet/components/MinerSelectionList.tsx
+++ b/client/src/protoFleet/components/MinerSelectionList.tsx
@@ -120,7 +120,8 @@ export interface MinerSelectionListProps {
   eligibility?: MinerEligibility;
   // Label of the target rack, shown in the assignment-conflict dialog.
   targetRackLabel?: string;
-  // Pairing statuses the list fetches; defaults to PAIRED-only. Rack flows pass the wider visible set so non-paired members render.
+  // Pairing statuses the list fetches; defaults to PAIRED-only. Rack flows pass
+  // the wider visible set so non-paired members render.
   pairingStatuses?: PairingStatus[];
   onSelectionChange?: (state: {
     selectedItems: string[];

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
@@ -6,6 +6,7 @@ import MinerSelectionList, {
   type MinerSelectionListHandle,
 } from "@/protoFleet/components/MinerSelectionList";
 import type { SiteFilterFields } from "@/protoFleet/components/PageHeader/SitePicker";
+import { FLEET_VISIBLE_PAIRING_STATUSES } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 
 import { Alert } from "@/shared/assets/icons";
 import Callout from "@/shared/components/Callout";
@@ -125,6 +126,7 @@ export default function ManageMinersModal({
           initialSelectedItems={currentRackMiners}
           eligibility={eligibility}
           targetRackLabel={targetRackLabel}
+          pairingStatuses={FLEET_VISIBLE_PAIRING_STATUSES}
         />
       </div>
     </Modal>

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { fetchAllSelectableMinerIds } from "./fetchAllSelectableMinerIds";
 import ManageMinersModal from "./ManageMinersModal";
 import MinersPane from "./MinersPane";
 import RackPane from "./RackPane";
@@ -8,12 +9,10 @@ import ScanMinerQrModal, { type ScanAssignmentResult } from "./ScanMinerQrModal"
 import SearchMinersModal from "./SearchMinersModal";
 import { type AssignmentMode, orderIndexToOrigin, originLabel, type RackFormData, type SelectedSlot } from "./types";
 import { useRackMinerScope } from "./useRackMinerScope";
-import { fetchAllMinerSnapshots } from "@/protoFleet/api/fetchAllMinerSnapshots";
 import { type DeviceSet, type RackSlot } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import {
   type MinerListFilter,
   type MinerStateSnapshot,
-  PairingStatus,
 } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
 import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
@@ -21,7 +20,6 @@ import useFleet from "@/protoFleet/api/useFleet";
 import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
 import type { MinerEligibility } from "@/protoFleet/components/MinerSelectionList";
 import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
-import { isMinerSnapshotIneligible } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import { slotNumberToRowCol } from "@/protoFleet/features/fleetManagement/utils/slotNumbering";
 import { useHasPermission } from "@/protoFleet/store";
 
@@ -31,24 +29,6 @@ import Callout from "@/shared/components/Callout";
 import Dialog from "@/shared/components/Dialog";
 import ProgressCircular from "@/shared/components/ProgressCircular";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
-
-/** Fetch all miner IDs eligible for a rack by paginating through the fleet API.
- *  Applies the same filter the user had active in MinerSelectionList so "select all"
- *  respects model/subnet filters. Miners in a different rack/building/site are
- *  excluded id-based (matches the list's eligibility predicate) so "select all"
- *  can't pull in ineligible miners even if the assignable-only toggle was off. */
-async function fetchAllSelectableMinerIds(
-  eligibility: MinerEligibility,
-  listFilter?: MinerListFilter,
-): Promise<string[]> {
-  const filter = listFilter
-    ? { ...listFilter, pairingStatuses: [PairingStatus.PAIRED] }
-    : { pairingStatuses: [PairingStatus.PAIRED] };
-  const snapshots = await fetchAllMinerSnapshots(filter);
-  return Object.values(snapshots)
-    .filter((m) => !isMinerSnapshotIneligible(m, eligibility))
-    .map((m) => m.deviceIdentifier);
-}
 
 /** Remove the first entry whose value matches `target` from a record, returning a shallow copy. */
 function removeAssignmentByValue(record: Record<string, string>, target: string): Record<string, string> {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
@@ -253,13 +253,16 @@ describe("ScanMinerQrModal", () => {
     expect(onConfirm).toHaveBeenCalledWith("dev-1", true);
   });
 
-  it("blocks assigning a miner that isn't fully paired", async () => {
+  it("assigns a not-fully-paired miner like any other (lookup only returns the visible set)", async () => {
+    // #777: auth-needed / default-password miners are assignable to racks — the
+    // scan lookup only ever resolves the visible pairing set, matching the list
+    // and search flows. No pairing gate blocks assignment.
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValueOnce({
       status: "found",
       snapshot: snapshot({ pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }),
     });
-    const onAssign = vi.fn();
+    const onAssign = vi.fn().mockReturnValue({ slotLabel: "Slot 1", hasNextSlot: true });
     const onConfirm = vi.fn();
 
     renderScanMinerQrModal({ onAssign, onConfirm });
@@ -268,16 +271,13 @@ describe("ScanMinerQrModal", () => {
       capturedOnDetected?.(["SN123"]);
     });
 
-    await waitFor(() => expect(screen.getByText(/isn't fully paired/i)).toBeInTheDocument());
-    expect(
-      screen.getByText("Only paired miners can be assigned to a rack. Finish pairing this miner, then scan it again."),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Assign to slot")).not.toBeInTheDocument();
-    expect(onAssign).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByText("Miner assigned")).toBeInTheDocument());
+    expect(screen.queryByText(/isn't fully paired/i)).not.toBeInTheDocument();
+    expect(onAssign).toHaveBeenCalledWith("dev-1");
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
-  it("prioritizes pairing guidance when an unpaired miner is already assigned elsewhere", async () => {
+  it("routes a not-fully-paired miner assigned elsewhere through the reassignment confirm", async () => {
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValueOnce({
       status: "found",
@@ -295,15 +295,13 @@ describe("ScanMinerQrModal", () => {
       capturedOnDetected?.(["SN123"]);
     });
 
-    await waitFor(() => expect(screen.getByText(/isn't fully paired/i)).toBeInTheDocument());
-    expect(
-      screen.getByText("Only paired miners can be assigned to a rack. Finish pairing this miner, then scan it again."),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Miner already assigned")).not.toBeInTheDocument();
-    expect(screen.queryByText("Assigning it here will move it from Rack B.")).not.toBeInTheDocument();
-    expect(screen.queryByText("Assign to slot")).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Miner already assigned")).toBeInTheDocument());
+    expect(screen.getByText("Assigning it here will move it from Rack B.")).toBeInTheDocument();
+    expect(screen.queryByText(/isn't fully paired/i)).not.toBeInTheDocument();
     expect(onAssign).not.toHaveBeenCalled();
-    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Assign to slot" }));
+    expect(onConfirm).toHaveBeenCalledWith("dev-1", true);
   });
 
   it("shows the target slot in the live scanner copy", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
@@ -8,7 +8,6 @@ import {
 import { lookupMinerByIdentifier } from "@/protoFleet/api/lookupMinerByIdentifier";
 import type { MinerEligibility } from "@/protoFleet/components/MinerSelectionList";
 import { canUseLiveCamera, useQrScanner } from "@/protoFleet/features/fleetManagement/hooks/useQrScanner";
-import { FLEET_SELECTABLE_PAIRING_STATUSES } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 import { isMinerSnapshotIneligible } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 import { parseScannedIdentifier } from "@/protoFleet/features/fleetManagement/utils/parseScannedIdentifier";
 
@@ -123,10 +122,13 @@ export default function ScanMinerQrModal({
 
       const snapshot = resolvedSnapshots[0];
       const isReassignment = isMinerSnapshotIneligible(snapshot, eligibility);
-      const notPairedForAssignment = !FLEET_SELECTABLE_PAIRING_STATUSES.includes(snapshot.pairingStatus);
       const requiresConfirmation = resolvedSnapshots.length > 1;
 
-      if (requiresConfirmation || isReassignment || notPairedForAssignment) {
+      // LookupMinerByIdentifier only resolves miners in the visible pairing set
+      // (PAIRED / auth-needed / default-password) — the same set the rack list
+      // and search flows allow — so a resolved miner is always assignable; no
+      // pairing gate here.
+      if (requiresConfirmation || isReassignment) {
         setPhase({ kind: "found", snapshot, isReassignment, requiresConfirmation });
         return;
       }

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.stories.tsx
@@ -146,17 +146,6 @@ export const FoundInAnotherRack: Story = {
   },
 };
 
-/** Resolved, but the miner still needs pairing work before assignment. */
-export const FoundNotFullyPaired: Story = {
-  args: {
-    phase: {
-      kind: "found",
-      snapshot: mockSnapshot({ pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }),
-      isReassignment: false,
-    },
-  },
-};
-
 /** The serial did not match any paired miner. */
 export const NotFound: Story = {
   args: { phase: { kind: "not-found", identifier: "9999999999999999" } },

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.tsx
@@ -2,7 +2,6 @@ import { type ReactNode, type RefObject } from "react";
 
 import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import { INACTIVE_PLACEHOLDER } from "@/protoFleet/features/fleetManagement/components/MinerList/constants";
-import { FLEET_SELECTABLE_PAIRING_STATUSES } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 import { getMinerRackLabel } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
 
 import { Alert, Dismiss, Success } from "@/shared/assets/icons";
@@ -82,13 +81,6 @@ export default function ScanMinerQrModalView({
     !!getMinerRackLabel(phase.snapshot) &&
     getMinerRackLabel(phase.snapshot) !== currentRackLabel;
 
-  // Enforce the same eligibility rule as the list/search assignment flows
-  // (FLEET_SELECTABLE_PAIRING_STATUSES = PAIRED only). LookupMinerByIdentifier
-  // also resolves AUTHENTICATION_NEEDED / DEFAULT_PASSWORD miners, so without
-  // this guard the scan flow would let operators rack not-fully-paired miners
-  // that the rest of the UI excludes.
-  const notPairedForAssignment =
-    phase.kind === "found" && !FLEET_SELECTABLE_PAIRING_STATUSES.includes(phase.snapshot.pairingStatus);
   const cameraUnavailable = phase.kind === "scanning" && !liveCamera;
   const cameraFailed = phase.kind === "scanning" && liveCamera && (cameraStatus === "error" || !!cameraError);
 
@@ -156,7 +148,6 @@ export default function ScanMinerQrModalView({
         isReassignment={phase.isReassignment}
         requiresConfirmation={!!phase.requiresConfirmation}
         otherRackLabel={getMinerRackLabel(phase.snapshot)}
-        notPaired={notPairedForAssignment}
         targetSlotLabel={targetSlotLabel}
         onDismiss={onDismiss}
         onConfirm={onConfirmFound}
@@ -364,7 +355,6 @@ function FoundMinerDialog({
   isReassignment,
   requiresConfirmation,
   otherRackLabel,
-  notPaired,
   targetSlotLabel,
   onDismiss,
   onConfirm,
@@ -376,31 +366,26 @@ function FoundMinerDialog({
   isReassignment: boolean;
   requiresConfirmation: boolean;
   otherRackLabel: string;
-  notPaired: boolean;
   targetSlotLabel: string;
   onDismiss: () => void;
   onConfirm: () => void;
   onRescan: () => void;
 }) {
-  const title = notPaired
-    ? "Miner isn't fully paired"
-    : requiresConfirmation
-      ? "Multiple miners found"
-      : inOtherRack
-        ? "Miner already assigned"
-        : isReassignment
-          ? "Confirm miner move"
-          : "Miner can't be assigned";
-  const subtitle = notPaired
-    ? "Only paired miners can be assigned to a rack. Finish pairing this miner, then scan it again."
-    : requiresConfirmation
-      ? `Multiple QR codes were detected. Confirm this is the miner for ${targetSlotLabel}.`
-      : inOtherRack
-        ? `Assigning it here will move it from ${otherRackLabel}.`
-        : isReassignment
-          ? `Assigning it here will move it to ${currentRackLabel}.`
-          : "Choose another miner for this rack slot.";
-  const canConfirmAssignment = (isReassignment || requiresConfirmation) && !notPaired;
+  const title = requiresConfirmation
+    ? "Multiple miners found"
+    : inOtherRack
+      ? "Miner already assigned"
+      : isReassignment
+        ? "Confirm miner move"
+        : "Miner can't be assigned";
+  const subtitle = requiresConfirmation
+    ? `Multiple QR codes were detected. Confirm this is the miner for ${targetSlotLabel}.`
+    : inOtherRack
+      ? `Assigning it here will move it from ${otherRackLabel}.`
+      : isReassignment
+        ? `Assigning it here will move it to ${currentRackLabel}.`
+        : "Choose another miner for this rack slot.";
+  const canConfirmAssignment = isReassignment || requiresConfirmation;
   const buttons: ButtonProps[] = [
     dismissButton(onDismiss),
     {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from "react";
 import type { MinerEligibility, MinerSelectionListHandle } from "@/protoFleet/components/MinerSelectionList";
 import MinerSelectionList from "@/protoFleet/components/MinerSelectionList";
 import type { SiteFilterFields } from "@/protoFleet/components/PageHeader/SitePicker";
+import { FLEET_VISIBLE_PAIRING_STATUSES } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
 
 import Modal from "@/shared/components/Modal";
 
@@ -80,6 +81,7 @@ export default function SearchMinersModal({
         scope={scope}
         eligibility={eligibility}
         targetRackLabel={targetRackLabel}
+        pairingStatuses={FLEET_VISIBLE_PAIRING_STATUSES}
         singleSelect
         onSelectionChange={({ selectedItems }) => setHasSelection(selectedItems.length > 0)}
       />

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/fetchAllSelectableMinerIds.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/fetchAllSelectableMinerIds.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchAllSelectableMinerIds } from "./fetchAllSelectableMinerIds";
+import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import { FLEET_VISIBLE_PAIRING_STATUSES } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
+
+const mockFetchAllMinerSnapshots = vi.fn();
+vi.mock("@/protoFleet/api/fetchAllMinerSnapshots", () => ({
+  fetchAllMinerSnapshots: (...args: unknown[]) => mockFetchAllMinerSnapshots(...args),
+}));
+
+// Unplaced snapshot: no rack/building/site, so eligible for any target.
+const snapshot = (deviceIdentifier: string): MinerStateSnapshot => ({ deviceIdentifier }) as MinerStateSnapshot;
+
+describe("fetchAllSelectableMinerIds", () => {
+  beforeEach(() => {
+    mockFetchAllMinerSnapshots.mockReset();
+  });
+
+  it("resolves select-all with the visible pairing set so non-paired members aren't dropped", async () => {
+    // Regression for #777: the rack list fetches the visible set, so the
+    // select-all resolver must too — otherwise Save would evict a rack's
+    // auth-needed / default-password members.
+    mockFetchAllMinerSnapshots.mockResolvedValue({
+      "paired-1": snapshot("paired-1"),
+      "auth-needed-1": snapshot("auth-needed-1"),
+    });
+
+    const ids = await fetchAllSelectableMinerIds({});
+
+    expect(mockFetchAllMinerSnapshots).toHaveBeenCalledWith(
+      expect.objectContaining({ pairingStatuses: FLEET_VISIBLE_PAIRING_STATUSES }),
+    );
+    expect(ids).toEqual(["paired-1", "auth-needed-1"]);
+  });
+
+  it("preserves the user's active list filter while overriding pairing statuses", async () => {
+    mockFetchAllMinerSnapshots.mockResolvedValue({});
+
+    await fetchAllSelectableMinerIds({}, { models: ["S21"] } as never);
+
+    expect(mockFetchAllMinerSnapshots).toHaveBeenCalledWith(
+      expect.objectContaining({ models: ["S21"], pairingStatuses: FLEET_VISIBLE_PAIRING_STATUSES }),
+    );
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/fetchAllSelectableMinerIds.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/fetchAllSelectableMinerIds.ts
@@ -1,0 +1,26 @@
+import { fetchAllMinerSnapshots } from "@/protoFleet/api/fetchAllMinerSnapshots";
+import type { MinerListFilter } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import type { MinerEligibility } from "@/protoFleet/components/MinerSelectionList";
+import { FLEET_VISIBLE_PAIRING_STATUSES } from "@/protoFleet/features/fleetManagement/utils/fleetVisiblePairingFilter";
+import { isMinerSnapshotIneligible } from "@/protoFleet/features/fleetManagement/utils/minerPlacement";
+
+/** Fetch all miner IDs eligible for a rack by paginating through the fleet API.
+ *  Applies the same filter the user had active in MinerSelectionList so "select all"
+ *  respects model/subnet filters. Miners in a different rack/building/site are
+ *  excluded id-based (matches the list's eligibility predicate) so "select all"
+ *  can't pull in ineligible miners even if the assignable-only toggle was off.
+ *  Uses the visible pairing set (not PAIRED-only) to stay aligned with the rack
+ *  list's fetch — otherwise "select all" would resolve to fewer ids than the
+ *  list shows and Save would silently drop a rack's non-paired members. */
+export async function fetchAllSelectableMinerIds(
+  eligibility: MinerEligibility,
+  listFilter?: MinerListFilter,
+): Promise<string[]> {
+  const filter = listFilter
+    ? { ...listFilter, pairingStatuses: FLEET_VISIBLE_PAIRING_STATUSES }
+    : { pairingStatuses: FLEET_VISIBLE_PAIRING_STATUSES };
+  const snapshots = await fetchAllMinerSnapshots(filter);
+  return Object.values(snapshots)
+    .filter((m) => !isMinerSnapshotIneligible(m, eligibility))
+    .map((m) => m.deviceIdentifier);
+}


### PR DESCRIPTION
Reviewable diff: +9/-1 across 3 files (excludes generated, test, and story files).

## Summary

Operators can now see and organize **every** miner in a rack from the "Select miners" modal, regardless of pairing status — including auth-needed and default-password miners that aren't yet fully paired. This restores parity with what CSV/Foreman import already allows: import legitimately places non-paired miners into racks to record physical topology before authentication, but the selection modal previously couldn't show them.

This fixes a footer count that ran off by N (#777): a rack with a non-paired member read "4 miners selected" while only 3 rows rendered, and stayed ≥1 after deselecting everything visible.

## How it works

The rack modal builds its initial selection from **full** rack membership (`listGroupMembers`, all pairing statuses) and seeds it into `MinerSelectionList`. The list itself, however, fetched its rows with a hardcoded `PAIRED`-only filter. Any rack member not in `PAIRED` state (auth-needed / default-password) was therefore counted in the seed — and in the footer's `selectedItems.length` — but never returned as a row. It had no checkbox, couldn't be deselected, and rode along on every selection.

The fix widens what the list fetches so the seed and the rows come from the same population:

1. `MinerSelectionList` gains a `pairingStatuses` prop, defaulting to `FLEET_SELECTABLE_PAIRING_STATUSES` (`[PAIRED]`). This is forwarded to `useFleet`, replacing the previously hardcoded value. Every existing caller that doesn't pass the prop (Schedules, Groups) keeps PAIRED-only behavior unchanged.
2. The two rack-assignment flows — `ManageMinersModal` (edit membership) and `SearchMinersModal` (add one) — pass `FLEET_VISIBLE_PAIRING_STATUSES` (`PAIRED` + `AUTHENTICATION_NEEDED` + `DEFAULT_PASSWORD`), the same "visible" set the import resolver uses.

With the wider fetch, non-paired members now render as normal rows: they appear selected, can be deselected, and `totalMiners` / the footer count reflect reality. Membership integrity on save is preserved — `saveRack` still replaces membership atomically from the selection, and a member is only dropped if the operator explicitly unchecks it.

```mermaid
flowchart TD
    A["ManageRackModal"] -->|"listGroupMembers: all statuses"| B["seed = full membership"]
    B --> C["MinerSelectionList: initialSelectedItems"]
    D["ManageMinersModal / SearchMinersModal"] -->|"pairingStatuses = VISIBLE set"| C
    C -->|"useFleet fetch"| E["list rows: PAIRED + auth-needed + default-password"]
    C --> F["footer count = selectedItems.length"]
    E --> G["seeded non-paired member now has a row -> deselectable, counted correctly"]
    F --> G
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/.../components/MinerSelectionList.tsx` | Added `pairingStatuses?` prop (default `FLEET_SELECTABLE_PAIRING_STATUSES`); forwarded to `useFleet` instead of a hardcoded `[PAIRED]`. | The one behavioral change. Confirm the default preserves PAIRED-only for all callers that don't opt in. |
| `client/.../ManageRackModal/ManageMinersModal.tsx` | Passes `FLEET_VISIBLE_PAIRING_STATUSES`. | Opt-in for the seeded edit-membership flow (#777 repro). |
| `client/.../ManageRackModal/SearchMinersModal.tsx` | Passes `FLEET_VISIBLE_PAIRING_STATUSES`. | Opt-in for the add-a-miner flow, so an auth-needed miner can be assigned via search. |
| `client/.../components/MinerSelectionList.test.tsx` | Added 2 cases (default PAIRED-only; widened set forwarded). | Test-only. |

Both pairing-status constants already exist in `fleetVisiblePairingFilter.ts`; no new sets were introduced.

## Key technical decisions & trade-offs

- **Frontend visibility fix, not a backend placement guard.** The alternative — rejecting non-paired miners at the rack/building/site write paths — was rejected because it would regress import: the Foreman/CSV resolver (`GetPairedDevicesByMACAddresses`, SQL matches `PAIRED, AUTHENTICATION_NEEDED, DEFAULT_PASSWORD`) intentionally places non-paired miners so topology is recorded before authentication, and rack stat rollups already include those statuses. This PR aligns the UI with that existing contract rather than fighting it.
- **Opt-in prop, default unchanged.** Widening is per-caller so unrelated selection flows (Schedules, Groups) stay PAIRED-only. Trade-off: two call sites must opt in, versus a global widen that would surface non-paired miners everywhere.
- **Seed is left intact.** The phantom id staying in `selectedItems` is protective — `saveRack` replaces membership atomically, so trimming the seed to "fix the count" would silently evict a real member. The fix makes the member visible instead.

## Testing & validation

- `MinerSelectionList.test.tsx`: added coverage that the default fetch is PAIRED-only and that a passed `pairingStatuses` (visible set) is forwarded to `useFleet`. Full file: 20/20 pass.
- `tsc --noEmit` clean; eslint clean on the four changed files; `just format` clean.
- **Not covered:** building/site assignment uses a separate list component (`buildings/.../ManageRacksModal`) and is untouched here — a follow-up if the same visibility is wanted there.
